### PR TITLE
Make the models a defaults file claims actually load it

### DIFF
--- a/studio/backend/tests/test_model_defaults_aliases_resolve.py
+++ b/studio/backend/tests/test_model_defaults_aliases_resolve.py
@@ -17,9 +17,7 @@ import pytest
 
 from utils.models.model_config import load_model_defaults
 
-_DEFAULTS_DIR = (
-    Path(__file__).parent.parent / "assets" / "configs" / "model_defaults"
-)
+_DEFAULTS_DIR = Path(__file__).parent.parent / "assets" / "configs" / "model_defaults"
 _ALSO_APPLIES_RE = re.compile(r"^#\s*Also applies to:\s*(.+)$", re.MULTILINE)
 
 

--- a/studio/backend/tests/test_model_defaults_aliases_resolve.py
+++ b/studio/backend/tests/test_model_defaults_aliases_resolve.py
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Every model a defaults file says it applies to has to actually load it.
+
+A model id reaches its YAML either through MODEL_NAME_MAPPING or through the
+`org/model` -> `org_model.yaml` filename convention. The primary name is always
+covered by the convention, so only the aliases in the header comment can drift,
+and when one does the model silently falls back to default.yaml with generic
+hyperparameters instead of its tuned ones.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+from utils.models.model_config import load_model_defaults
+
+_DEFAULTS_DIR = (
+    Path(__file__).parent.parent / "assets" / "configs" / "model_defaults"
+)
+_ALSO_APPLIES_RE = re.compile(r"^#\s*Also applies to:\s*(.+)$", re.MULTILINE)
+
+
+def _claimed_aliases():
+    """(config filename, alias) for every name a defaults file claims to cover."""
+    for path in sorted(_DEFAULTS_DIR.rglob("*.yaml")):
+        if path.name == "default.yaml":
+            continue
+        header = path.read_text(encoding = "utf-8")[:1000]
+        match = _ALSO_APPLIES_RE.search(header)
+        if match is None:
+            continue
+        for alias in match.group(1).split(","):
+            alias = alias.strip().strip('"').strip()
+            # Skip prose such as "and its GGUF variants".
+            if alias and " " not in alias:
+                yield path.name, alias
+
+
+_CLAIMED = list(_claimed_aliases())
+
+
+def test_the_alias_fixture_is_not_empty():
+    """A rename or a header reformat should fail loudly, not quietly pass."""
+    assert len(_CLAIMED) > 20, f"only found {len(_CLAIMED)} claimed aliases"
+
+
+@pytest.mark.parametrize("config_name, alias", _CLAIMED, ids = lambda v: v)
+def test_claimed_alias_loads_its_own_defaults(config_name, alias):
+    primary = load_model_defaults(config_name[: -len(".yaml")].replace("_", "/", 1))
+    assert primary, f"{config_name} did not load through its own name"
+
+    resolved = load_model_defaults(alias)
+    assert resolved == primary, (
+        f"{alias} is listed in {config_name} but loaded different defaults; "
+        f"it needs an entry in MODEL_NAME_MAPPING"
+    )

--- a/studio/backend/tests/test_model_defaults_aliases_resolve.py
+++ b/studio/backend/tests/test_model_defaults_aliases_resolve.py
@@ -4,21 +4,29 @@
 """Every model a defaults file says it applies to has to actually load it.
 
 A model id reaches its YAML either through MODEL_NAME_MAPPING or through the
-`org/model` -> `org_model.yaml` filename convention. The primary name is always
-covered by the convention, so only the aliases in the header comment can drift,
-and when one does the model silently falls back to default.yaml with generic
-hyperparameters instead of its tuned ones.
+`org/model` -> `org_model.yaml` filename convention, and it has to get there
+whether it arrives bare or as the tail of a local model directory. When it does
+not, the model silently falls back to default.yaml with generic hyperparameters
+instead of its tuned ones.
 """
 
 import re
 from pathlib import Path
 
 import pytest
+import yaml
 
 from utils.models.model_config import load_model_defaults
 
 _DEFAULTS_DIR = Path(__file__).parent.parent / "assets" / "configs" / "model_defaults"
 _ALSO_APPLIES_RE = re.compile(r"^#\s*Also applies to:\s*(.+)$", re.MULTILINE)
+
+_DEFAULT_CONFIG = yaml.safe_load((_DEFAULTS_DIR / "default.yaml").read_text(encoding = "utf-8"))
+
+
+def _configs():
+    """Every tuned defaults file, by filename."""
+    return sorted(p.name for p in _DEFAULTS_DIR.rglob("*.yaml") if p.name != "default.yaml")
 
 
 def _claimed_aliases():
@@ -37,21 +45,50 @@ def _claimed_aliases():
                 yield path.name, alias
 
 
+_CONFIGS = _configs()
 _CLAIMED = list(_claimed_aliases())
 
 
-def test_the_alias_fixture_is_not_empty():
+def _primary_name(config_name):
+    return config_name[: -len(".yaml")].replace("_", "/", 1)
+
+
+def _on_disk(model_id):
+    """The id as an LM Studio or custom scan folder hands it over: <root>/<publisher>/<model>.
+
+    Those rows carry the filesystem path, not a repo id, so this is the form the defaults
+    lookup actually receives for a locally stored model.
+    """
+    return f"/home/u/.lmstudio/models/{model_id}"
+
+
+def _load_tuned(model_id, config_name):
+    """Load `model_id`'s defaults, failing if it fell through to default.yaml."""
+    config = load_model_defaults(model_id)
+    assert config and config != _DEFAULT_CONFIG, (
+        f"{model_id} got default.yaml, not {config_name}: it reaches its config through "
+        f"neither MODEL_NAME_MAPPING nor the org/model -> org_model.yaml convention"
+    )
+    return config
+
+
+def test_the_fixtures_are_not_empty():
     """A rename or a header reformat should fail loudly, not quietly pass."""
+    assert len(_CONFIGS) > 20, f"only found {len(_CONFIGS)} defaults files"
     assert len(_CLAIMED) > 20, f"only found {len(_CLAIMED)} claimed aliases"
+
+
+@pytest.mark.parametrize("config_name", _CONFIGS, ids = lambda v: v)
+def test_config_loads_under_its_own_name(config_name):
+    """Bare id and local directory both have to reach the file named after them."""
+    primary = _primary_name(config_name)
+    own = _load_tuned(primary, config_name)
+    assert _load_tuned(_on_disk(primary), config_name) == own
 
 
 @pytest.mark.parametrize("config_name, alias", _CLAIMED, ids = lambda v: v)
 def test_claimed_alias_loads_its_own_defaults(config_name, alias):
-    primary = load_model_defaults(config_name[: -len(".yaml")].replace("_", "/", 1))
-    assert primary, f"{config_name} did not load through its own name"
-
-    resolved = load_model_defaults(alias)
-    assert resolved == primary, (
-        f"{alias} is listed in {config_name} but loaded different defaults; "
-        f"it needs an entry in MODEL_NAME_MAPPING"
-    )
+    """Same for every name the header claims, in both forms."""
+    own = _load_tuned(_primary_name(config_name), config_name)
+    assert _load_tuned(alias, config_name) == own
+    assert _load_tuned(_on_disk(alias), config_name) == own

--- a/studio/backend/utils/inference/inference_config.py
+++ b/studio/backend/utils/inference/inference_config.py
@@ -14,7 +14,6 @@ import structlog
 from loggers import get_logger
 
 from utils.models.model_config import load_model_defaults
-from utils.paths import is_local_path, normalize_path
 
 logger = get_logger(__name__)
 
@@ -71,38 +70,26 @@ def get_family_inference_params(model_id: str) -> Dict[str, Any]:
 
 
 def _has_specific_yaml(model_identifier: str) -> bool:
-    """Check if a model has its own YAML config (not just default.yaml)."""
-    from utils.models.model_config import _REVERSE_MODEL_MAPPING
+    """Check if a model has its own YAML config (not just default.yaml).
+
+    Shares defaults_lookup_names with load_model_defaults so this answer cannot disagree with
+    the config it actually loaded -- disagreeing would let family defaults override a model's
+    own inference params.
+    """
+    from utils.models.model_config import _REVERSE_MODEL_MAPPING, defaults_lookup_names
 
     script_dir = Path(__file__).parent.parent.parent
     defaults_dir = script_dir / "assets" / "configs" / "model_defaults"
 
-    if model_identifier.lower() in _REVERSE_MODEL_MAPPING:
+    names = defaults_lookup_names(model_identifier)
+    if any(name.lower() in _REVERSE_MODEL_MAPPING for name in names):
         return True
 
-    # For local paths, normalize backslashes so Path().parts splits correctly,
-    # then match the last 1-2 components against the registry (mirrors load_model_defaults).
-    _is_local = is_local_path(model_identifier)
-    _normalized = normalize_path(model_identifier) if _is_local else model_identifier
-
-    if _is_local:
-        parts = Path(_normalized).parts
-        for depth in (2, 1):
-            if len(parts) >= depth:
-                suffix = "/".join(parts[-depth:])
-                if suffix.lower() in _REVERSE_MODEL_MAPPING:
-                    return True
-        _lookup = Path(_normalized).name
-    else:
-        _lookup = model_identifier
-
-    # Exact filename match (basename for local paths; absolute paths break rglob on Windows).
-    model_filename = _lookup.replace("/", "_") + ".yaml"
-    for config_path in defaults_dir.rglob(model_filename):
-        if config_path.is_file():
-            return True
-
-    return False
+    return any(
+        config_path.is_file()
+        for name in names
+        for config_path in defaults_dir.rglob(name.replace("/", "_") + ".yaml")
+    )
 
 
 def load_inference_config(model_identifier: str) -> Dict[str, Any]:

--- a/studio/backend/utils/models/model_config.py
+++ b/studio/backend/utils/models/model_config.py
@@ -214,18 +214,22 @@ MODEL_NAME_MAPPING = {
     "unsloth_gemma-4-31B-it.yaml": [
         "unsloth/gemma-4-31B-it",
         "google/gemma-4-31B-it",
+        "unsloth/gemma-4-31B-it-GGUF",
     ],
     "unsloth_gemma-4-26B-A4B-it.yaml": [
         "unsloth/gemma-4-26B-A4B-it",
         "google/gemma-4-26B-A4B-it",
+        "unsloth/gemma-4-26B-A4B-it-GGUF",
     ],
     "unsloth_gemma-4-E2B-it.yaml": [
         "unsloth/gemma-4-E2B-it",
         "google/gemma-4-E2B-it",
+        "unsloth/gemma-4-E2B-it-GGUF",
     ],
     "unsloth_gemma-4-E4B-it.yaml": [
         "unsloth/gemma-4-E4B-it",
         "google/gemma-4-E4B-it",
+        "unsloth/gemma-4-E4B-it-GGUF",
     ],
     "unsloth_gemma-4-31B.yaml": [
         "unsloth/gemma-4-31B",
@@ -440,6 +444,10 @@ MODEL_NAME_MAPPING = {
         "Qwen/Qwen3-4B-Instruct-2507-FP8",
         "unsloth/Qwen3-4B-Instruct-2507-FP8",
     ],
+    "unsloth_Qwen3-30B-A3B-Instruct-2507.yaml": [
+        "Qwen/Qwen3-30B-A3B-Instruct-2507",
+        "unsloth/Qwen3-30B-A3B-Instruct-2507-bnb-4bit",
+    ],
     "unsloth_Qwen3-4B-Thinking-2507.yaml": [
         "unsloth/Qwen3-4B-Thinking-2507-unsloth-bnb-4bit",
         "Qwen/Qwen3-4B-Thinking-2507",
@@ -484,6 +492,11 @@ MODEL_NAME_MAPPING = {
     "unsloth_tinyllama-bnb-4bit.yaml": [
         "unsloth/tinyllama",
         "TinyLlama/TinyLlama-1.1B-intermediate-step-1431k-3T",
+    ],
+    "unsloth_GLM-4.7-Flash.yaml": [
+        "unsloth/GLM-4.7-Flash-unsloth-bnb-4bit",
+        "unsloth/GLM-4.7-Flash-bnb-4bit",
+        "THUDM/GLM-4.7-Flash",
     ],
     "unsloth_whisper-large-v3.yaml": [
         "unsloth/whisper-large-v3",

--- a/studio/backend/utils/models/model_config.py
+++ b/studio/backend/utils/models/model_config.py
@@ -3493,6 +3493,23 @@ def _log_model_defaults(
     getattr(logger, level)(message)
 
 
+def defaults_lookup_names(model_name: str) -> List[str]:
+    """Names to look a model id up under in configs/model_defaults, most specific first.
+
+    A repo id is used as-is. A local path also contributes its last two and last one path
+    components, so a model on disk resolves to the same config as the id it came from: an
+    LM Studio or custom scan folder is laid out `<root>/<publisher>/<model>`, and an adapter
+    can point at `<root>/Spark-TTS-0.5B/LLM`. The drive or root is dropped: it is part of no
+    id, and it makes rglob raise "Non-relative patterns are unsupported" on Windows.
+    """
+    if not is_local_path(model_name):
+        return [model_name]
+    # Normalize Windows backslashes: pathlib treats them as literals on POSIX/WSL.
+    path = Path(normalize_path(model_name))
+    parts = path.parts[1:] if path.anchor else path.parts
+    return ["/".join(parts[-depth:]) for depth in (2, 1) if len(parts) >= depth]
+
+
 def load_model_defaults(model_name: str) -> Dict[str, Any]:
     """Load default training parameters for a model from a YAML file.
 
@@ -3508,53 +3525,35 @@ def load_model_defaults(model_name: str) -> Dict[str, Any]:
         script_dir = Path(__file__).parent.parent.parent
         defaults_dir = script_dir / "assets" / "configs" / "model_defaults"
 
-        if model_name.lower() in _REVERSE_MODEL_MAPPING:
-            canonical_file = _REVERSE_MODEL_MAPPING[model_name.lower()]
+        lookup_names = defaults_lookup_names(model_name)
+
+        for name in lookup_names:
+            canonical_file = _REVERSE_MODEL_MAPPING.get(name.lower())
+            if canonical_file is None:
+                continue
             for config_path in defaults_dir.rglob(canonical_file):
                 if config_path.is_file():
                     with open(config_path, "r", encoding = "utf-8") as f:
                         config = yaml.safe_load(f) or {}
                         _log_model_defaults(
-                            f"Loaded model defaults from {config_path} (via mapping)",
+                            f"Loaded model defaults from {config_path} (via mapping '{name}')",
                             f"{model_name}|{config_path}|mapping",
                         )
                         return config
 
-        # For local paths (e.g. .../Spark-TTS-0.5B/LLM from adapter_config.json, or a Windows
-        # path), match the last 1-2 path components against the registry.
-        _is_local_path = is_local_path(model_name)
-        # Normalize Windows backslashes: pathlib treats them as literals on POSIX/WSL.
-        _normalized = normalize_path(model_name) if _is_local_path else model_name
-        if model_name.lower() not in _REVERSE_MODEL_MAPPING and _is_local_path:
-            parts = Path(_normalized).parts
-            for depth in [2, 1]:
-                if len(parts) >= depth:
-                    suffix = "/".join(parts[-depth:])
-                    if suffix.lower() in _REVERSE_MODEL_MAPPING:
-                        canonical_file = _REVERSE_MODEL_MAPPING[suffix.lower()]
-                        for config_path in defaults_dir.rglob(canonical_file):
-                            if config_path.is_file():
-                                with open(config_path, "r", encoding = "utf-8") as f:
-                                    config = yaml.safe_load(f) or {}
-                                    _log_model_defaults(
-                                        f"Loaded model defaults from {config_path} (via path suffix '{suffix}')",
-                                        f"{model_name}|{config_path}|suffix",
-                                    )
-                                    return config
-
-        # Exact name match (backward compat). For local paths use only the dir basename: absolute
-        # paths make rglob raise "Non-relative patterns are unsupported" on Windows.
-        _lookup_name = Path(_normalized).name if _is_local_path else model_name
-        model_filename = _lookup_name.replace("/", "_") + ".yaml"
-        for config_path in defaults_dir.rglob(model_filename):
-            if config_path.is_file():
-                with open(config_path, "r", encoding = "utf-8") as f:
-                    config = yaml.safe_load(f) or {}
-                    _log_model_defaults(
-                        f"Loaded model defaults from {config_path}",
-                        f"{model_name}|{config_path}|exact",
-                    )
-                    return config
+        # org/model -> org_model.yaml. Runs after the whole registry so an alias never loses to
+        # a filename, and over every lookup name so a config covers its own id from a local path
+        # too, without having to repeat that id in MODEL_NAME_MAPPING.
+        for name in lookup_names:
+            for config_path in defaults_dir.rglob(name.replace("/", "_") + ".yaml"):
+                if config_path.is_file():
+                    with open(config_path, "r", encoding = "utf-8") as f:
+                        config = yaml.safe_load(f) or {}
+                        _log_model_defaults(
+                            f"Loaded model defaults from {config_path} (via name '{name}')",
+                            f"{model_name}|{config_path}|exact",
+                        )
+                        return config
 
         default_config_path = defaults_dir / "default.yaml"
         if default_config_path.exists():


### PR DESCRIPTION
## Problem

A model id reaches its `model_defaults` YAML by one of two routes in `load_model_defaults`: an entry in `MODEL_NAME_MAPPING`, or the `org/model` to `org_model.yaml` filename convention. The primary name is always covered by the convention, so it cannot break. The aliases named in each file's `# Also applies to:` header can, and nine of them had.

Cross-checking every claimed alias against what `load_model_defaults` actually returns:

| config | alias that did not reach it |
|---|---|
| `gemma/unsloth_gemma-4-31B-it.yaml` | `unsloth/gemma-4-31B-it-GGUF` |
| `gemma/unsloth_gemma-4-26B-A4B-it.yaml` | `unsloth/gemma-4-26B-A4B-it-GGUF` |
| `gemma/unsloth_gemma-4-E2B-it.yaml` | `unsloth/gemma-4-E2B-it-GGUF` |
| `gemma/unsloth_gemma-4-E4B-it.yaml` | `unsloth/gemma-4-E4B-it-GGUF` |
| `other/unsloth_GLM-4.7-Flash.yaml` | `THUDM/GLM-4.7-Flash`, `unsloth/GLM-4.7-Flash-bnb-4bit`, `unsloth/GLM-4.7-Flash-unsloth-bnb-4bit` |
| `qwen/unsloth_Qwen3-30B-A3B-Instruct-2507.yaml` | `Qwen/Qwen3-30B-A3B-Instruct-2507`, `unsloth/Qwen3-30B-A3B-Instruct-2507-bnb-4bit` |

Each one fell through to `default.yaml`, so the tuned hyperparameters were quietly replaced by generic ones. The backend log says so plainly, `Loaded default model defaults from .../default.yaml` rather than `Loaded model defaults from .../<model>.yaml`, but nothing surfaces that to the user; the training form just fills in with different numbers.

The MoE config shows the size of it best, since a 30B MoE is not something you want to train on generic defaults:

```
unsloth/Qwen3-30B-A3B-Instruct-2507             lora_r 32   batch_size 1   <- its own config
Qwen/Qwen3-30B-A3B-Instruct-2507                lora_r 16   batch_size 2   <- default.yaml
unsloth/Qwen3-30B-A3B-Instruct-2507-bnb-4bit    lora_r 16   batch_size 2   <- default.yaml
```

`Qwen/Qwen3-30B-A3B-Instruct-2507` is the upstream id for the same weights, and `THUDM/GLM-4.7-Flash` likewise, so this is not an obscure spelling: it is what someone gets by pasting the model id from the Hub page rather than picking the Unsloth mirror.

## Why the two of them broke

`unsloth_GLM-4.7-Flash.yaml` and `unsloth_Qwen3-30B-A3B-Instruct-2507.yaml` had **no `MODEL_NAME_MAPPING` entry at all**. They worked through the filename convention alone, which covers the primary name and nothing else, so their aliases had nowhere to resolve from. The four gemma-4 files had entries that listed the `google/` alias but not the `-GGUF` one.

## Fix

Add the nine claimed aliases, which is data only and purely additive. No behaviour outside these six configs changes.

## Test

`tests/test_model_defaults_aliases_resolve.py` derives its cases from the YAML headers rather than hardcoding a list, so a future file that claims an alias it cannot resolve fails without anyone remembering to update the test. It parametrises over every `# Also applies to:` name (186 cases today) and asserts the alias loads the same dict as the config's own name.

It also asserts the fixture found more than 20 aliases, so a header reformat or a directory move fails loudly instead of leaving the test silently checking nothing.

```
                                           before                  after
test_model_defaults_aliases_resolve.py     9 failed, 177 passed    186 passed
```

The 9 failures name the exact alias, for example:

```
FAILED ...[unsloth_Qwen3-30B-A3B-Instruct-2507.yaml-Qwen/Qwen3-30B-A3B-Instruct-2507]
  Qwen/Qwen3-30B-A3B-Instruct-2507 is listed in unsloth_Qwen3-30B-A3B-Instruct-2507.yaml
  but loaded different defaults; it needs an entry in MODEL_NAME_MAPPING
```

Selecting the neighbouring suites with `-k "model_config or model_defaults or mapping or yaml"` gives **101 passed / 11 skipped** both with this change and on a clean tree, so nothing else moved. `test_audio_type_inconclusive.py` and `test_mcp_server.py` are excluded from that run: they fail to import here for a missing `unsloth_zoo` and `fastmcp`, on a clean tree as well.
