### PR TITLE
Tell npm permission failures apart from a blocked registry (#8725)

### DIFF
--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -1687,6 +1687,9 @@ function Invoke-SetupCommand {
     try {
         # Reset to avoid stale values from prior native commands.
         $global:LASTEXITCODE = 0
+        # Reset the captured-output slot: a stale value from a previous command
+        # must never be used to classify this one's failure.
+        $script:LastSetupCommandOutput = ""
         if ($script:UnslothVerbose -and -not $AlwaysQuiet) {
             # Merge stderr into stdout so progress/warning output stays visible
             # without flipping $? on successful native commands (PS 5.1 treats
@@ -1698,7 +1701,11 @@ function Invoke-SetupCommand {
         } else {
             $output = & $Command 2>&1 | Out-String
             if ($LASTEXITCODE -ne 0) {
-                Write-StudioLine (Redact-InstallOutput $output) -ForegroundColor Red
+                $redacted = Redact-InstallOutput $output
+                # Keep the failure text so callers can tell *why* it failed.
+                # Redacted, because whatever reads this may print it back.
+                $script:LastSetupCommandOutput = $redacted
+                Write-StudioLine $redacted -ForegroundColor Red
             }
         }
         return [int]$LASTEXITCODE
@@ -1808,11 +1815,69 @@ function substep {
     }
 }
 
+# Local, non-network reasons an npm install dies: a locked/denied file in the npm
+# cache (antivirus is the usual culprit on Windows), a read-only or full disk.
+# npm reports these with a POSIX-style errno and its own "rejected by your
+# operating system" wording. Checked BEFORE the network markers because npm's
+# FetchError line names registry.npmjs.org even when the failure is local --
+# that URL is what made the old hint fire on a permission error (issue #8725).
+$script:NpmLocalFailureRe = 'EACCES|EPERM|EBUSY|ENOSPC|ENFILE|EMFILE|operation was rejected by your operating system|EPERM: operation not permitted'
+
+# Markers that genuinely point at the registry being unreachable. Kept in sync
+# with the regex in studio/setup.sh's _suggest_npm_registry.
+$script:NpmNetworkFailureRe = '40[13]|ENOTFOUND|ECONNREFUSED|ECONNRESET|ETIMEDOUT|EAI_AGAIN|ConnectionRefused|failed to resolve|registry\.npmjs\.org|getaddrinfo|tunneling socket|network|proxy|self.?signed|unable to (get|verify)'
+
+function Show-NpmLocalFailureHint {
+    # An npm failure the network cannot explain: permissions, a lock, or disk.
+    # Telling this user to configure a mirror sends them after the wrong thing.
+    param([string]$FailureOutput = "")
+
+    $nodeVer = try { if (Get-Command node -ErrorAction SilentlyContinue) { (& node -v 2>$null | Out-String).Trim() } else { "" } } catch { "" }
+    $npmVer = try { if (Get-Command npm -ErrorAction SilentlyContinue) { (& npm -v 2>$null | Out-String).Trim() } else { "" } } catch { "" }
+
+    Write-StudioLine ""
+    step "frontend" "npm was blocked by the operating system, not by the network" "Yellow"
+    substep "npm reported a permission/lock error (EACCES/EPERM/EBUSY), so this is local."
+    if ($nodeVer -or $npmVer) {
+        substep "Runtime in use: node $nodeVer | npm $npmVer"
+    }
+    substep "Usual causes, in order:"
+    substep "  1. Antivirus or Windows Defender holding a file in the npm cache."
+    substep "  2. A previous install left an unwritable npm cache."
+    substep "  3. The install directory is read-only, or the disk is full."
+    substep "Things that usually clear it:"
+    substep "  npm cache clean --force"
+    substep "  Exclude the npm cache from your antivirus, then re-run the installer."
+    substep "  Or point npm at a writable cache: `$env:NPM_CONFIG_CACHE='C:\npm-cache'"
+    if ($FailureOutput -match 'EACCES|EPERM') {
+        substep "(Re-running as Administrator rarely helps here -- the file is locked, not privileged.)"
+    }
+}
+
 function Show-NpmRegistryHint {
     # Print actionable guidance when a frontend/OXC npm/bun install fails and the
     # registry lock is the likely cause (corporate firewall/proxy). No-op once the
     # user has opted in via UNSLOTH_NPM_REGISTRY. We never switch registries
     # automatically -- we only guide.
+    #
+    # $FailureOutput is the captured npm output (see Invoke-SetupCommand). It is
+    # what makes this hint conditional: without it every npm failure was reported
+    # as a blocked registry, including local permission errors (issue #8725).
+    # Empty output keeps the old unconditional behaviour, so a verbose-mode run
+    # -- where nothing is captured -- still gets the firewall guidance it had.
+    param([string]$FailureOutput = "")
+
+    if ($FailureOutput) {
+        if ($FailureOutput -imatch $script:NpmLocalFailureRe) {
+            Show-NpmLocalFailureHint -FailureOutput $FailureOutput
+            return
+        }
+        if ($FailureOutput -inotmatch $script:NpmNetworkFailureRe) {
+            # Nothing points at the registry. The raw npm error is already on
+            # screen and is more useful than a guess. Mirrors studio/setup.sh.
+            return
+        }
+    }
     if ($env:UNSLOTH_NPM_REGISTRY) { return }
     $mirror = $env:NPM_CONFIG_REGISTRY
     if (-not $mirror) {
@@ -3696,13 +3761,14 @@ if ($NeedFrontendBuild -and -not $IsPipInstall) {
     }
     if (-not $UseBun) {
         $npmExit = Invoke-SetupCommand { npm install @NpmRegistryArgs }
+        $npmFailureOutput = $script:LastSetupCommandOutput
         if ($npmExit -ne 0) {
             Pop-Location
             $ErrorActionPreference = $prevEAP_npm
             foreach ($gi in $HiddenGitignores) { Rename-Item -Path "$gi._twbuild" -NewName (Split-Path $gi -Leaf) -Force -ErrorAction SilentlyContinue }
             Write-StudioLine "[ERROR] npm install failed (exit code $npmExit)" -ForegroundColor Red
             Write-StudioLine "   Try running 'npm install' manually in frontend/ to see errors" -ForegroundColor Yellow
-            Show-NpmRegistryHint
+            Show-NpmRegistryHint -FailureOutput $npmFailureOutput
             Exit-SetupFailure "Frontend dependency installation failed (exit code $npmExit)"
         }
     }
@@ -3740,11 +3806,12 @@ if ((Test-Path $OxcValidatorDir) -and $NodeSource -ne "skip" -and (Get-Command n
     $ErrorActionPreference = "Continue"
     Push-Location $OxcValidatorDir
     $oxcInstallExit = Invoke-SetupCommand { npm install @NpmRegistryArgs }
+    $oxcFailureOutput = $script:LastSetupCommandOutput
     if ($oxcInstallExit -ne 0) {
         Pop-Location
         $ErrorActionPreference = $prevEAP_oxc
         Write-StudioLine "[ERROR] OXC validator npm install failed (exit code $oxcInstallExit)" -ForegroundColor Red
-        Show-NpmRegistryHint
+        Show-NpmRegistryHint -FailureOutput $oxcFailureOutput
         Exit-SetupFailure "OXC validator dependency installation failed (exit code $oxcInstallExit)"
     }
     Pop-Location

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -134,9 +134,46 @@ _CAPTURE_LOG=""
 # lock is the likely cause (corporate firewall/proxy). No-op once the user has opted in
 # via UNSLOTH_NPM_REGISTRY. We never switch registries automatically -- we only guide.
 # $1 = path to a captured install log (may be empty/missing).
-_suggest_npm_registry() {
-    [ -n "${UNSLOTH_NPM_REGISTRY:-}" ] && return 0
+# Local, non-network reasons an npm install dies: a locked or denied file in the
+# npm cache (antivirus, most often), a read-only tree, a full disk. npm reports
+# these with a POSIX errno and its own "rejected by your operating system"
+# wording. Checked BEFORE the network markers below, because npm's FetchError
+# line names registry.npmjs.org even when the cause is local -- that URL is what
+# made the registry hint fire on a plain permission error (issue #8725).
+_NPM_LOCAL_FAILURE_RE='EACCES|EPERM|EBUSY|ENOSPC|ENFILE|EMFILE|operation was rejected by your operating system'
+
+# Print guidance for an npm failure the network cannot explain. Not gated on
+# UNSLOTH_NPM_REGISTRY: a mirror does not make a locked cache writable.
+# $1 = path to a captured install log.
+_suggest_npm_local_failure() {
     local _log="${1:-}"
+    local _node _npm
+    _node="$( (node -v) 2>/dev/null || true )"
+    _npm="$( (npm -v) 2>/dev/null || true )"
+    printf '\n' >&2
+    step "frontend" "npm was blocked by the operating system, not by the network" "$C_WARN" >&2
+    substep "npm reported a permission/lock error (EACCES/EPERM/EBUSY), so this is local." >&2
+    [ -n "$_node$_npm" ] && substep "Runtime in use: node ${_node:-?} | npm ${_npm:-?}" >&2
+    substep "Usual causes, in order:" >&2
+    substep "  1. Antivirus or a file watcher holding a file in the npm cache." >&2
+    substep "  2. A previous install left an unwritable npm cache." >&2
+    substep "  3. The install directory is read-only, or the disk is full." >&2
+    substep "Things that usually clear it:" >&2
+    substep "  npm cache clean --force" >&2
+    substep "  Or point npm at a writable cache: NPM_CONFIG_CACHE=\"\$HOME/.npm-cache\"" >&2
+    return 0
+}
+
+_suggest_npm_registry() {
+    local _log="${1:-}"
+    # A local permission/disk failure is not a registry problem. Checked first,
+    # and before the UNSLOTH_NPM_REGISTRY opt-out, so the user still hears about
+    # it when they have already pointed us at a mirror.
+    if [ -n "$_log" ] && [ -s "$_log" ] && grep -Eqi "$_NPM_LOCAL_FAILURE_RE" "$_log"; then
+        _suggest_npm_local_failure "$_log"
+        return 0
+    fi
+    [ -n "${UNSLOTH_NPM_REGISTRY:-}" ] && return 0
     # If we captured output and it does NOT look like a registry/network problem, stay
     # quiet -- the raw error already shown is more useful than a misleading hint.
     if [ -n "$_log" ] && [ -s "$_log" ] \

--- a/tests/python/test_npm_failure_hint_parity.py
+++ b/tests/python/test_npm_failure_hint_parity.py
@@ -85,9 +85,7 @@ class TestPowerShellHintIsConditional:
         ]
         assert len(invocations) >= 2, f"expected the frontend and OXC call sites, got {invocations}"
         for call in invocations:
-            assert "-FailureOutput" in call, (
-                f"call site passes no failure output: {call.strip()!r}"
-            )
+            assert "-FailureOutput" in call, f"call site passes no failure output: {call.strip()!r}"
 
     def test_setup_command_publishes_its_captured_output(self):
         text = SETUP_PS1.read_text(encoding = "utf-8")
@@ -98,9 +96,9 @@ class TestPowerShellHintIsConditional:
         # The slot has to be cleared per call, or one command's failure text
         # would explain the next command's failure.
         body = _ps_function_body(text, "Invoke-SetupCommand")
-        assert re.search(r'\$script:LastSetupCommandOutput\s*=\s*""', body), (
-            "Invoke-SetupCommand must reset $script:LastSetupCommandOutput before running"
-        )
+        assert re.search(
+            r'\$script:LastSetupCommandOutput\s*=\s*""', body
+        ), "Invoke-SetupCommand must reset $script:LastSetupCommandOutput before running"
 
     def test_local_failures_are_classified_before_network_ones(self):
         """npm names registry.npmjs.org even in a permission error, so order matters."""
@@ -113,9 +111,9 @@ class TestPowerShellHintIsConditional:
         body = _ps_function_body(text, "Show-NpmRegistryHint")
         local_use = body.find("NpmLocalFailureRe")
         network_use = body.find("NpmNetworkFailureRe")
-        assert local_use != -1 and network_use != -1, (
-            "Show-NpmRegistryHint must consult both classifiers"
-        )
+        assert (
+            local_use != -1 and network_use != -1
+        ), "Show-NpmRegistryHint must consult both classifiers"
         assert local_use < network_use, (
             "the local-failure check must come first: npm's FetchError line names "
             "registry.npmjs.org even when the failure is a local permission error"

--- a/tests/python/test_npm_failure_hint_parity.py
+++ b/tests/python/test_npm_failure_hint_parity.py
@@ -1,0 +1,154 @@
+"""Parity tests for the npm-failure hint in setup.sh and setup.ps1 (issue #8725).
+
+A Windows user installing Studio with Node 24 on PATH hit this while the OXC
+validator runtime was being installed::
+
+    npm error code EACCES
+    npm error FetchError: request to https://registry.npmjs.org/oxlint/-/oxlint-1.65.0.tgz failed
+    npm error The operation was rejected by your operating system.
+
+That is a local failure -- a locked or unwritable npm cache -- but the installer
+answered "registry.npmjs.org looks blocked (corporate firewall/proxy?)", so the
+reporter went looking for a corporate proxy that did not exist. Re-running and
+running as Administrator changed nothing; only downgrading Node fixed it.
+
+Two separate defects produced that message:
+
+1. ``Show-NpmRegistryHint`` in studio/setup.ps1 took no arguments and printed the
+   registry hint on *every* non-zero npm exit -- it had no way to know why the
+   install failed, because ``Invoke-SetupCommand`` captured npm's output into a
+   local variable and dropped it.
+2. ``_suggest_npm_registry`` in studio/setup.sh *was* log-aware, but its
+   network regex includes the literal ``registry.npmjs.org``, and npm's
+   FetchError line names that host even when the cause is a permission error --
+   so the same log matched there too.
+
+The behavioural coverage lives next to each implementation
+(tests/sh/test_npm_failure_hint.sh, and the Pester suite for the PowerShell
+side). These tests run everywhere, including the Linux backend CI job, and pin
+the structure that keeps the two installers agreeing.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SETUP_SH = REPO_ROOT / "studio" / "setup.sh"
+SETUP_PS1 = REPO_ROOT / "studio" / "setup.ps1"
+
+# Errno markers npm uses for failures the network cannot explain.
+LOCAL_MARKERS = ["EACCES", "EPERM", "EBUSY", "ENOSPC"]
+
+
+def _ps_function_body(text: str, name: str) -> str:
+    """Return the body of a PowerShell function by brace counting.
+
+    Naive on purpose: these two functions contain no unbalanced braces inside
+    string literals. A regex with a fixed window silently truncates when the
+    function grows, which is worse than being simple.
+    """
+    match = re.search(rf"(?im)^\s*function\s+{re.escape(name)}\b", text)
+    assert match, f"{name} not found in the script under test"
+    start = text.index("{", match.end())
+    depth = 0
+    for i in range(start, len(text)):
+        if text[i] == "{":
+            depth += 1
+        elif text[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return text[start + 1 : i]
+    raise AssertionError(f"unbalanced braces while reading {name}")
+
+
+class TestPowerShellHintIsConditional:
+    """setup.ps1 must decide from the failure text, not print the hint blindly."""
+
+    def test_hint_accepts_the_failure_output(self):
+        text = SETUP_PS1.read_text(encoding = "utf-8")
+        body = _ps_function_body(text, "Show-NpmRegistryHint")
+        assert re.search(r"param\s*\(\s*\[string\]\s*\$FailureOutput", body), (
+            "Show-NpmRegistryHint must take the captured npm output; without it "
+            "every npm failure is reported as a blocked registry (issue #8725)."
+        )
+
+    def test_both_call_sites_pass_the_failure_output(self):
+        text = SETUP_PS1.read_text(encoding = "utf-8")
+        invocations = [
+            line.strip()
+            for line in text.splitlines()
+            if "Show-NpmRegistryHint" in line
+            and not line.lstrip().startswith("#")
+            and not re.match(r"\s*function\b", line)
+        ]
+        assert len(invocations) >= 2, f"expected the frontend and OXC call sites, got {invocations}"
+        for call in invocations:
+            assert "-FailureOutput" in call, (
+                f"call site passes no failure output: {call.strip()!r}"
+            )
+
+    def test_setup_command_publishes_its_captured_output(self):
+        text = SETUP_PS1.read_text(encoding = "utf-8")
+        assert "$script:LastSetupCommandOutput" in text, (
+            "Invoke-SetupCommand must publish the captured output so the hint can "
+            "classify the failure."
+        )
+        # The slot has to be cleared per call, or one command's failure text
+        # would explain the next command's failure.
+        body = _ps_function_body(text, "Invoke-SetupCommand")
+        assert re.search(r'\$script:LastSetupCommandOutput\s*=\s*""', body), (
+            "Invoke-SetupCommand must reset $script:LastSetupCommandOutput before running"
+        )
+
+    def test_local_failures_are_classified_before_network_ones(self):
+        """npm names registry.npmjs.org even in a permission error, so order matters."""
+        text = SETUP_PS1.read_text(encoding = "utf-8")
+        local_at = text.find("NpmLocalFailureRe")
+        network_at = text.find("NpmNetworkFailureRe")
+        assert local_at != -1, "no local-failure classifier in studio/setup.ps1"
+        assert network_at != -1, "no network-failure classifier in studio/setup.ps1"
+
+        body = _ps_function_body(text, "Show-NpmRegistryHint")
+        local_use = body.find("NpmLocalFailureRe")
+        network_use = body.find("NpmNetworkFailureRe")
+        assert local_use != -1 and network_use != -1, (
+            "Show-NpmRegistryHint must consult both classifiers"
+        )
+        assert local_use < network_use, (
+            "the local-failure check must come first: npm's FetchError line names "
+            "registry.npmjs.org even when the failure is a local permission error"
+        )
+
+
+class TestInstallersAgree:
+    """Both installers must recognise the same local-failure markers."""
+
+    def test_local_markers_present_in_both(self):
+        sh = SETUP_SH.read_text(encoding = "utf-8")
+        ps1 = SETUP_PS1.read_text(encoding = "utf-8")
+        for marker in LOCAL_MARKERS:
+            assert marker in sh, f"studio/setup.sh does not classify {marker}"
+            assert marker in ps1, f"studio/setup.ps1 does not classify {marker}"
+
+    def test_both_have_a_local_failure_hint(self):
+        sh = SETUP_SH.read_text(encoding = "utf-8")
+        ps1 = SETUP_PS1.read_text(encoding = "utf-8")
+        assert "_suggest_npm_local_failure" in sh
+        assert "Show-NpmLocalFailureHint" in ps1
+
+    def test_local_hint_is_not_gated_on_the_registry_opt_out(self):
+        """A mirror does not make a locked cache writable, so the hint must still print."""
+        sh = SETUP_SH.read_text(encoding = "utf-8")
+        match = re.search(r"_suggest_npm_registry\(\)\s*\{(.*?)\n\}", sh, re.DOTALL)
+        assert match, "_suggest_npm_registry not found in studio/setup.sh"
+        body = match.group(1)
+        local_at = body.find("_suggest_npm_local_failure")
+        optout_at = body.find('[ -n "${UNSLOTH_NPM_REGISTRY:-}" ]')
+        assert local_at != -1, "the local-failure branch is missing"
+        assert optout_at != -1, "the UNSLOTH_NPM_REGISTRY early-return is missing"
+        assert local_at < optout_at, (
+            "the local-failure branch must run before the UNSLOTH_NPM_REGISTRY "
+            "early return, or users with a mirror configured never hear about it"
+        )

--- a/tests/sh/test_npm_failure_hint.sh
+++ b/tests/sh/test_npm_failure_hint.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+# See /studio/LICENSE.AGPL-3.0
+#
+# Regression tests for the npm-failure hint in studio/setup.sh (issue #8725).
+#
+# A Windows user installing Studio hit this, with Node 24 on PATH:
+#
+#     npm error code EACCES
+#     npm error FetchError: request to https://registry.npmjs.org/oxlint/-/oxlint-1.65.0.tgz failed
+#     npm error The operation was rejected by your operating system.
+#
+# That is a local failure -- a locked or unwritable npm cache -- yet the
+# installer answered "registry.npmjs.org looks blocked (corporate
+# firewall/proxy?)" and sent them hunting for a corporate proxy that did not
+# exist. Re-running, and running as Administrator, changed nothing.
+#
+# The gate here was already log-aware, but its network regex includes the
+# literal registry.npmjs.org, and npm's FetchError line names that host even
+# when the cause is a permission error -- so this log matched and the wrong
+# hint printed. The fix classifies local errno failures (EACCES/EPERM/EBUSY/
+# ENOSPC) BEFORE the network markers.
+#
+# These tests extract the two functions and drive them with captured logs, so
+# nothing here touches npm or the network.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SETUP_SH="$SCRIPT_DIR/../../studio/setup.sh"
+PASS=0
+FAIL=0
+
+_FUNC_FILE=$(mktemp)
+{
+    sed -n '/^_NPM_LOCAL_FAILURE_RE=/p' "$SETUP_SH"
+    sed -n '/^_suggest_npm_local_failure()/,/^}/p' "$SETUP_SH"
+    sed -n '/^_suggest_npm_registry()/,/^}/p' "$SETUP_SH"
+} > "$_FUNC_FILE"
+
+for _needle in '_NPM_LOCAL_FAILURE_RE=' '_suggest_npm_local_failure()' '_suggest_npm_registry()'; do
+    if ! grep -q -- "$_needle" "$_FUNC_FILE"; then
+        echo "FAIL: could not extract $_needle from $SETUP_SH"
+        exit 1
+    fi
+done
+
+# Minimal stand-ins for the installer's output helpers; both write to stderr,
+# which is where the real ones send this guidance.
+step()    { printf '  %-15s%s\n' "$1" "$2" >&2; }
+substep() { printf '  %-15s%s\n' "" "$1" >&2; }
+C_WARN=""
+
+# shellcheck disable=SC1090
+. "$_FUNC_FILE"
+
+_log_file=$(mktemp)
+
+# The log from issue #8725, trimmed to the lines that matter. Note that it
+# mentions registry.npmjs.org: that is exactly what used to mislead the gate.
+_EACCES_LOG='npm error code EACCES
+npm error errno EACCES
+npm error FetchError: request to https://registry.npmjs.org/oxlint/-/oxlint-1.65.0.tgz failed, reason:
+npm error   code: '"'"'EACCES'"'"',
+npm error   type: '"'"'system'"'"'
+npm error The operation was rejected by your operating system.'
+
+_NETWORK_LOG='npm error code ENOTFOUND
+npm error network request to https://registry.npmjs.org/oxlint failed, reason: getaddrinfo ENOTFOUND registry.npmjs.org'
+
+_PROXY_LOG='npm error code E403
+npm error 403 Forbidden - GET https://registry.npmjs.org/oxlint
+npm error tunneling socket could not be established'
+
+_UNRELATED_LOG='npm error code ELIFECYCLE
+npm error errno 1
+npm error oxc-validator@1.0.0 postinstall script failed'
+
+check() {
+    # check <name> <log> <expect-local:yes|no> <expect-registry:yes|no>
+    local _name="$1" _log="$2" _want_local="$3" _want_registry="$4"
+    printf '%s\n' "$_log" > "$_log_file"
+
+    local _out
+    _out="$( _suggest_npm_registry "$_log_file" 2>&1 )"
+
+    local _got_local="no" _got_registry="no"
+    case "$_out" in *"blocked by the operating system"*) _got_local="yes" ;; esac
+    case "$_out" in *"looks blocked (corporate firewall/proxy?)"*) _got_registry="yes" ;; esac
+
+    if [ "$_got_local" = "$_want_local" ] && [ "$_got_registry" = "$_want_registry" ]; then
+        PASS=$((PASS + 1))
+        echo "ok   $_name"
+    else
+        FAIL=$((FAIL + 1))
+        echo "FAIL $_name"
+        echo "     expected local=$_want_local registry=$_want_registry"
+        echo "     got      local=$_got_local registry=$_got_registry"
+        echo "     output: $_out"
+    fi
+}
+
+# The bug: a permission error must not be reported as a blocked registry.
+check "EACCES log gets the local hint, not the registry one" "$_EACCES_LOG" yes no
+
+# Genuine network failures keep the behaviour the hint exists for.
+check "ENOTFOUND log still gets the registry hint" "$_NETWORK_LOG" no yes
+check "403/tunnelling log still gets the registry hint" "$_PROXY_LOG" no yes
+
+# Neither local nor network: stay quiet, the raw npm error is better than a guess.
+check "unrelated failure stays quiet" "$_UNRELATED_LOG" no no
+
+# A local failure is not about registries, so the mirror opt-out must not silence it.
+UNSLOTH_NPM_REGISTRY="https://mirror.example/api/npm/" \
+    check "local hint survives UNSLOTH_NPM_REGISTRY" "$_EACCES_LOG" yes no
+
+# EPERM is the other errno Windows reports for a locked file.
+check "EPERM log gets the local hint" \
+    'npm error code EPERM
+npm error syscall unlink
+npm error EPERM: operation not permitted, unlink '"'"'C:\Users\u\AppData\Local\npm-cache\_cacache\tmp\x'"'"'' \
+    yes no
+
+# No captured log at all: unchanged from before the fix -- the registry hint is
+# the only guidance available, so it still prints.
+: > "$_log_file"
+_out="$( _suggest_npm_registry "$_log_file" 2>&1 )"
+case "$_out" in
+    *"looks blocked (corporate firewall/proxy?)"*)
+        PASS=$((PASS + 1)); echo "ok   empty log keeps the old registry hint" ;;
+    *)
+        FAIL=$((FAIL + 1)); echo "FAIL empty log keeps the old registry hint"; echo "     output: $_out" ;;
+esac
+
+rm -f "$_FUNC_FILE" "$_log_file"
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] || exit 1

--- a/tests/studio_setup_ps1/Studio.Setup.NpmHint.Tests.ps1
+++ b/tests/studio_setup_ps1/Studio.Setup.NpmHint.Tests.ps1
@@ -1,0 +1,156 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+# See /studio/LICENSE.AGPL-3.0
+#
+# Regression tests for the npm-failure hint in studio/setup.ps1 (issue #8725).
+#
+# A Windows user installing Studio with Node 24 on PATH saw the OXC validator
+# step die with:
+#
+#     npm error code EACCES
+#     npm error FetchError: request to https://registry.npmjs.org/oxlint/-/oxlint-1.65.0.tgz failed
+#     npm error The operation was rejected by your operating system.
+#
+# and the installer answered "registry.npmjs.org looks blocked (corporate
+# firewall/proxy?)". That is a local failure -- a locked or unwritable npm cache
+# -- so the reporter spent the evening looking for a corporate proxy that did
+# not exist; re-running and running as Administrator changed nothing.
+#
+# Show-NpmRegistryHint used to take no arguments: it could not tell a blocked
+# registry from a denied file, because Invoke-SetupCommand captured npm's output
+# into a local variable and dropped it. It now receives that text and classifies
+# local errno failures BEFORE the network markers -- npm's FetchError line names
+# registry.npmjs.org even when the cause is local, which is exactly what made
+# the old hint fire.
+
+BeforeAll {
+    . (Join-Path $PSScriptRoot 'Get-FunctionSource.ps1')
+
+    $candidates = @(
+        $env:SETUP_PS1_PATH,
+        (Join-Path $PSScriptRoot '..\..\studio\setup.ps1')
+    ) | Where-Object { $_ }
+    $script:SetupPs1 = $candidates | Where-Object { Test-Path -LiteralPath $_ } | Select-Object -First 1
+    if (-not $script:SetupPs1) { throw "Could not locate studio/setup.ps1 (set SETUP_PS1_PATH)." }
+    Write-Host "setup.ps1 under test: $script:SetupPs1"
+
+    # The classifiers live at script scope, outside any function, so pull the
+    # real assignments out of the file rather than restating their values here.
+    $setupText = Get-Content -Raw -LiteralPath $script:SetupPs1
+    foreach ($varName in @('NpmLocalFailureRe', 'NpmNetworkFailureRe')) {
+        $m = [regex]::Match($setupText, "(?m)^\s*\`$script:$varName\s*=\s*'[^']*'")
+        if (-not $m.Success) { throw "Could not find `$script:$varName in $script:SetupPs1." }
+        . ([scriptblock]::Create($m.Value))
+    }
+
+    foreach ($fn in @('Get-StudioAnsi', 'Write-StudioLine', 'Write-StudioStdoutMirror', 'step', 'substep',
+                      'Show-NpmLocalFailureHint', 'Show-NpmRegistryHint')) {
+        $src = Get-FunctionSource -Path $script:SetupPs1 -Name $fn
+        if (-not $src) { throw "Function '$fn' not found in $script:SetupPs1 - cannot test the real code." }
+        . ([scriptblock]::Create($src))
+    }
+
+    # The log from the issue, trimmed. It names registry.npmjs.org: that is the
+    # line that used to send this failure down the firewall path.
+    $script:EaccesOutput = @'
+npm error code EACCES
+npm error errno EACCES
+npm error FetchError: request to https://registry.npmjs.org/oxlint/-/oxlint-1.65.0.tgz failed, reason:
+npm error   code: 'EACCES',
+npm error   type: 'system'
+npm error The operation was rejected by your operating system.
+'@
+
+    $script:NetworkOutput = @'
+npm error code ENOTFOUND
+npm error network request to https://registry.npmjs.org/oxlint failed, reason: getaddrinfo ENOTFOUND registry.npmjs.org
+'@
+
+    $script:UnrelatedOutput = @'
+npm error code ELIFECYCLE
+npm error errno 1
+npm error oxc-validator@1.0.0 postinstall script failed
+'@
+
+    function Invoke-CapturingHint {
+        param([string]$FailureOutput = "")
+        $prevOut = [Console]::Out
+        $writer = New-Object System.IO.StringWriter
+        try {
+            [Console]::SetOut($writer)
+            Show-NpmRegistryHint -FailureOutput $FailureOutput 6>&1 | Out-Null
+        } finally {
+            [Console]::SetOut($prevOut)
+        }
+        return $writer.ToString()
+    }
+}
+
+Describe 'Show-NpmRegistryHint classifies the failure before guessing' {
+    BeforeEach {
+        $script:StudioVtOk = $false
+        $script:StudioStdoutRedirected = $true
+        $env:NO_COLOR = $null
+        $env:UNSLOTH_NPM_REGISTRY = $null
+        $env:NPM_CONFIG_REGISTRY = $null
+    }
+
+    It 'reports a permission failure as local, not as a blocked registry' {
+        $out = Invoke-CapturingHint -FailureOutput $script:EaccesOutput
+        $out | Should -Match 'blocked by the operating system'
+        $out | Should -Not -Match 'looks blocked \(corporate firewall/proxy\?\)'
+    }
+
+    It 'still points at the registry when the failure really is the network' {
+        $out = Invoke-CapturingHint -FailureOutput $script:NetworkOutput
+        $out | Should -Match 'looks blocked \(corporate firewall/proxy\?\)'
+        $out | Should -Not -Match 'blocked by the operating system'
+    }
+
+    It 'stays quiet when nothing points at either cause' {
+        # The raw npm error is already on screen and beats a guess.
+        $out = Invoke-CapturingHint -FailureOutput $script:UnrelatedOutput
+        $out.Trim() | Should -BeNullOrEmpty
+    }
+
+    It 'keeps the old behaviour when no output was captured' {
+        # Verbose runs stream npm output straight through, so there is nothing to
+        # classify; the registry hint is then the only guidance available.
+        $out = Invoke-CapturingHint -FailureOutput ""
+        $out | Should -Match 'looks blocked \(corporate firewall/proxy\?\)'
+    }
+
+    It 'prints the local hint even when a mirror is already configured' {
+        # A mirror does not make a locked cache writable.
+        $env:UNSLOTH_NPM_REGISTRY = 'https://mirror.example/api/npm/'
+        try {
+            $out = Invoke-CapturingHint -FailureOutput $script:EaccesOutput
+            $out | Should -Match 'blocked by the operating system'
+        } finally {
+            $env:UNSLOTH_NPM_REGISTRY = $null
+        }
+    }
+}
+
+Describe 'Source contracts' {
+    It 'gives Show-NpmRegistryHint the captured output' {
+        $src = Get-FunctionSource -Path $script:SetupPs1 -Name 'Show-NpmRegistryHint'
+        $src | Should -Match '\[string\]\s*\$FailureOutput'
+    }
+
+    It 'checks local errno markers before network ones' {
+        $src = Get-FunctionSource -Path $script:SetupPs1 -Name 'Show-NpmRegistryHint'
+        $localAt = $src.IndexOf('NpmLocalFailureRe')
+        $networkAt = $src.IndexOf('NpmNetworkFailureRe')
+        $localAt | Should -BeGreaterThan -1
+        $networkAt | Should -BeGreaterThan -1
+        $localAt | Should -BeLessThan $networkAt
+    }
+
+    It 'passes the captured output at every call site' {
+        $text = Get-Content -Raw -LiteralPath $script:SetupPs1
+        $calls = ([regex]::Matches($text, '(?m)^\s*Show-NpmRegistryHint[^\r\n]*')) | ForEach-Object { $_.Value }
+        $calls.Count | Should -BeGreaterThan 1
+        foreach ($call in $calls) { $call | Should -Match '-FailureOutput' }
+    }
+}


### PR DESCRIPTION
Fixes #8725.

## The message that sent the reporter after the wrong thing

The OXC validator step died with a permission error and the installer answered with a firewall:

```
npm error code EACCES
npm error FetchError: request to https://registry.npmjs.org/oxlint/-/oxlint-1.65.0.tgz failed
npm error The operation was rejected by your operating system.
...
  frontend       registry.npmjs.org looks blocked (corporate firewall/proxy?)
```

`EACCES` is local — a locked or unwritable npm cache, usually antivirus on Windows. Nothing was blocked. Re-running and running as Administrator changed nothing, which fits: the file was locked, not privileged.

## Why it happened, in both installers

**`studio/setup.ps1`** — `Show-NpmRegistryHint` took no arguments and fired on *every* non-zero npm exit. It could not know why the install failed: `Invoke-SetupCommand` captured npm's output into a local variable and dropped it, so no signal reached the hint.

**`studio/setup.sh`** — already log-aware, but its network regex includes the literal `registry.npmjs.org`, and npm's `FetchError` line names that host even in a permission error. The same log matches there too. Worth stating plainly: **porting the sh gate to PowerShell would not have fixed this** — both sides needed the local case handled first.

## The change

- `Invoke-SetupCommand` publishes the redacted failure text as `$script:LastSetupCommandOutput`, reset per call so one command's failure can't explain the next one's.
- Both call sites (frontend npm, OXC) pass it to `Show-NpmRegistryHint -FailureOutput`.
- Local errno failures (`EACCES`/`EPERM`/`EBUSY`/`ENOSPC`/`ENFILE`/`EMFILE`, and npm's "rejected by your operating system") are classified **before** the network markers, and get their own hint: likely causes and the fixes that usually clear it (`npm cache clean --force`, an antivirus exclusion, `NPM_CONFIG_CACHE`), plus the node/npm in use — the reporter's own workaround was changing Node.
- `setup.sh` gets the same branch, placed ahead of its `UNSLOTH_NPM_REGISTRY` early return: a mirror does not make a locked cache writable, so that user should still hear about it.
- When neither pattern matches, both installers now stay quiet and let the raw npm error speak.

Deliberately unchanged: with **no** captured output — verbose runs stream npm straight through — the registry hint still prints exactly as before, so the corporate-proxy case it exists for is untouched.

## Tests

| suite | cases | runs |
| --- | --- | --- |
| `tests/sh/test_npm_failure_hint.sh` | 7 | Backend CI (ubuntu) + locally |
| `tests/python/test_npm_failure_hint_parity.py` | 7 | Backend CI (ubuntu) + locally |
| `tests/studio_setup_ps1/Studio.Setup.NpmHint.Tests.ps1` | 8 | Pester job (windows-latest) |

The shell and Python suites pass here, along with `tests/python/test_cross_platform_parity.py`, `tests/python/test_windows_setup_output_encoding.py` and `tests/studio/test_ci_shell_suite_coverage.py` (107 passed / 18 skipped), and `bash -n studio/setup.sh` is clean. The three pre-existing collection errors under `tests/python/` are missing `torch`/`jinja2` on my machine and are present without this change too.

I also checked the shell tests have teeth: neutering the new local branch makes them fail with the issue's exact wrong message, `registry.npmjs.org looks blocked (corporate firewall/proxy?)`, on the EACCES log.

**One caveat, stated up front:** I have no Windows machine and `pwsh` is not available on macOS, so the Pester file has not been executed — CI will be its first run. The PowerShell logic it covers is additionally pinned by the Python source-contract tests, which do run on the Linux job and pass here.
