### PR TITLE
Fix stale desktop download links

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,23 +31,23 @@ Download the native Unsloth Desktop app for your operating system:
   </tr>
   <tr>
     <td><b>Windows</b></td>
-    <td><a href='https://github.com/unslothai/unsloth/releases/download/v0.1.701-beta/Unsloth-Desktop-0_1_701_beta-Windows.exe'>Download</a></td>
+    <td><a href='https://unsloth.ai/download'>Download</a></td>
   </tr>
   <tr>
     <td><b>macOS</b></td>
-    <td><a href='https://github.com/unslothai/unsloth/releases/download/v0.1.701-beta/Unsloth-Desktop-0_1_701_beta-MacOS.dmg'>Download</a></td>
+    <td><a href='https://unsloth.ai/download'>Download</a></td>
   </tr>
   <tr>
     <td><b>Linux / Ubuntu (deb)</b></td>
-    <td><a href='https://github.com/unslothai/unsloth/releases/download/v0.1.701-beta/Unsloth-Desktop-0_1_701_beta-Ubuntu.deb'>Download</a></td>
+    <td><a href='https://unsloth.ai/download'>Download</a></td>
   </tr>
   <tr>
     <td><b>Linux (AppImage)</b></td>
-    <td><a href='https://github.com/unslothai/unsloth/releases/download/v0.1.701-beta/Unsloth-Desktop-0_1_701_beta-Linux.AppImage'>Download</a></td>
+    <td><a href='https://unsloth.ai/download'>Download</a></td>
   </tr>
   <tr>
     <td><b>Linux (Arm64)</b></td>
-    <td><a href='https://github.com/unslothai/unsloth/releases/download/v0.1.701-beta/Unsloth-Desktop-0_1_701_beta-ARM64.app.tar.gz'>Download</a></td>
+    <td><a href='https://unsloth.ai/download'>Download</a></td>
   </tr>
 </table>
 
@@ -130,23 +130,23 @@ The Tauri based desktop app is the easiest way to use Unsloth and needs no setup
   </tr>
   <tr>
     <td><b>Windows</b></td>
-    <td><a href='https://github.com/unslothai/unsloth/releases/download/v0.1.701-beta/Unsloth-Desktop-0_1_701_beta-Windows.exe'>Download</a></td>
+    <td><a href='https://unsloth.ai/download'>Download</a></td>
   </tr>
   <tr>
     <td><b>macOS</b></td>
-    <td><a href='https://github.com/unslothai/unsloth/releases/download/v0.1.701-beta/Unsloth-Desktop-0_1_701_beta-MacOS.dmg'>Download</a></td>
+    <td><a href='https://unsloth.ai/download'>Download</a></td>
   </tr>
   <tr>
     <td><b>Linux / Ubuntu (deb)</b></td>
-    <td><a href='https://github.com/unslothai/unsloth/releases/download/v0.1.701-beta/Unsloth-Desktop-0_1_701_beta-Linux.deb'>Download</a></td>
+    <td><a href='https://unsloth.ai/download'>Download</a></td>
   </tr>
   <tr>
     <td><b>Linux (AppImage)</b></td>
-    <td><a href='https://github.com/unslothai/unsloth/releases/download/v0.1.701-beta/Unsloth-Desktop-0_1_701_beta-Linux.AppImage'>Download</a></td>
+    <td><a href='https://unsloth.ai/download'>Download</a></td>
   </tr>
   <tr>
     <td><b>Linux (Arm64)</b></td>
-    <td><a href='https://github.com/unslothai/unsloth/releases/download/v0.1.701-beta/Unsloth-Desktop-0_1_701_beta-ARM64.app.tar.gz'>Download</a></td>
+    <td><a href='https://unsloth.ai/download'>Download</a></td>
   </tr>
 </table>
 


### PR DESCRIPTION
## Summary
- point both Desktop platform tables at the canonical download page
- avoid pinning README links to one release tag and versioned asset filenames
- fix the currently broken Linux `.deb` link and prevent the same regression on later releases

Closes #8688

## Tests
- Checked: `https://unsloth.ai/download` returns HTTP 200 after redirects
- Checked: all 10 platform links use the canonical download URL
- Ran: `git diff --check`