### PR TITLE
Fix the Core sanity step collecting the zoo suite against this repo's tests package

### DIFF
--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -291,7 +291,11 @@ jobs:
             tests/utils/test_packing.py \
             tests/utils/test_trunc_normal_patch.py \
             tests/python/test_fast_language_model_text_only.py
-          python -m pytest --collect-only -q "$RUNNER_TEMP/unsloth-zoo/tests/"
+          # Collect from the zoo checkout, not from here: this repo ships a real
+          # tests/ package, so a zoo test doing "from tests.foo import bar" binds
+          # "tests" to OUR package and dies with ModuleNotFoundError. The later
+          # full zoo runs already set working-directory for the same reason.
+          (cd "$RUNNER_TEMP/unsloth-zoo" && python -m pytest --collect-only -q tests/)
 
       - name: import_fixes drift detectors (18 tests, HARD GATE)
         # One drift detector per fix_* / patch_* function in


### PR DESCRIPTION
### The failure

Every `Core (...)` matrix cell is red on every branch right now, including branches that touch nothing near the test suite. The step is **Sanity - collection only (both repos)**, exit code 2:

```
==================================== ERRORS ====================================
________ ERROR collecting tests/test_missing_parent_package_is_drift.py ________
../../_temp/unsloth-zoo/tests/test_missing_parent_package_is_drift.py:35: in <module>
    from tests.test_temporary_patches_exhaustive import (
E   ModuleNotFoundError: No module named 'tests.test_temporary_patches_exhaustive'
!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!
5148 tests collected, 1 error in 11.28s
```

The named module exists on `unsloth-zoo` main. Nothing is missing.

### Cause

The step collects the zoo suite by absolute path while the working directory is still this repo:

```yaml
python -m pytest --collect-only -q "$RUNNER_TEMP/unsloth-zoo/tests/"
```

This repo ships `tests/__init__.py`, so `tests` here is a real package. The zoo `tests/` directory has none, so `import tests.*` inside a zoo test resolves through the working directory and binds to **our** `tests` package, which has no `test_temporary_patches_exhaustive` submodule. Collection is interrupted and the whole cell fails.

The later full zoo runs in this same workflow already set `working-directory: ${{ runner.temp }}/unsloth-zoo`, which is why only this one step is affected.

### Fix

Run that one collection from the zoo checkout.

### Verification

Reproduced and fixed against a fresh `unsloth-zoo` clone locally, with a working directory holding a `tests/` package to match the runner:

| working directory | result |
| --- | --- |
| repo with a `tests/` package (current CI) | `5144 tests collected, 1 error` then `Interrupted` |
| zoo checkout (this PR) | `5163 tests collected` in 0.90s, 0 errors |

Also confirmed the same failure on two unrelated open branches (`fix/trl-1x-vllm-lora-and-pins`, `flags-editor`), so this is repo wide and not attributable to any one PR.
