### PR TITLE
Clarify tool approval copy

### DIFF
--- a/studio/frontend/src/features/chat/permission-mode-select.tsx
+++ b/studio/frontend/src/features/chat/permission-mode-select.tsx
@@ -46,7 +46,8 @@ export const PERMISSION_MODE_OPTIONS: readonly {
   {
     value: "ask",
     label: "Ask for approval",
-    description: "Always ask before tool calls edit files or use the internet",
+    description:
+      "Always ask before tool calls, editing files or using the internet",
     icon: Hand,
   },
   {


### PR DESCRIPTION
## Summary

- clarify the **Ask for approval** permission description
- use parallel grammar for tool calls, file edits, and internet access

## Why

The existing copy omitted punctuation and used inconsistent verb forms, making the three approval cases read as one ambiguous phrase.

## Screenshots

### Before

<!-- before-screenshot -->

### After

<!-- after-screenshot -->

## Validation

- Playwright: opened the real permission-mode dropdown and verified the updated text exactly
- ESLint: 0 errors (2 existing Fast Refresh warnings)
- `git diff --check`
