### PR TITLE
Let the uv signal handler exit without going through setup_fail

### DIFF
--- a/tests/sh/test_tauri_retry_failure_context.sh
+++ b/tests/sh/test_tauri_retry_failure_context.sh
@@ -219,13 +219,96 @@ if [ "$_setup_mode_count" -ne 2 ]; then
     exit 1
 fi
 
-_setup_exit_count=$(grep -Ec '^[[:space:]]*exit[[:space:]]+' "$SETUP_SH")
-if [ "$_setup_exit_count" -ne 1 ] ||
-    ! grep -q '^[[:space:]]*exit "\$exit_code"$' "$SETUP_SH"; then
+# setup.sh exits in exactly two places and both are accounted for here. setup_fail is the
+# one failure exit: every failure path goes through it so the desktop gets a [TAURI:ERROR]
+# line instead of a bare exit code. The pinned-uv signal handler is the other, and it is not
+# a failure: it re-raises the caller's own termination as 128+signal, the way install.sh's
+# _on_install_signal does, because install.rs cancels an install by SIGTERMing the process
+# group and a cancel must not be reported to the user as an installer failure. A third exit
+# anywhere, or a second exit inside either of these two, is an unrouted failure exit.
+# `|| true`: grep -c reports 0 with status 1, and under set -e a removed handler would
+# abort this file with no explanation instead of the failure below.
+_setup_fail_exits=$(sed -n '/^setup_fail()/,/^}/p' "$SETUP_SH" |
+    grep -Ec '^[[:space:]]*exit[[:space:]]+' || true)
+_setup_signal_exits=$(sed -n '/^_setup_uv_on_signal()/,/^}/p' "$SETUP_SH" |
+    grep -Ec '^[[:space:]]*exit[[:space:]]+' || true)
+_setup_exit_count=$(grep -Ec '^[[:space:]]*exit[[:space:]]+' "$SETUP_SH" || true)
+if [ "$_setup_fail_exits" -ne 1 ] ||
+    [ "$_setup_signal_exits" -ne 1 ] ||
+    [ "$_setup_exit_count" -ne $((_setup_fail_exits + _setup_signal_exits)) ] ||
+    ! grep -q '^[[:space:]]*exit "\$exit_code"$' "$SETUP_SH" ||
+    ! grep -q '^[[:space:]]*exit "\$1"$' "$SETUP_SH"; then
     echo "  FAIL: Unix setup has explicit exits outside setup_fail"
     exit 1
 fi
+# The signal handler stays reachable only from its own traps, at 128+signal. Called from
+# ordinary control flow it would be exactly the unrouted failure exit the count forbids.
+_setup_signal_refs=$(grep -c '_setup_uv_on_signal' "$SETUP_SH" || true)
+if [ "$_setup_signal_refs" -ne 4 ] ||
+    ! grep -qF "trap '_setup_uv_on_signal 129' HUP" "$SETUP_SH" ||
+    ! grep -qF "trap '_setup_uv_on_signal 130' INT" "$SETUP_SH" ||
+    ! grep -qF "trap '_setup_uv_on_signal 143' TERM" "$SETUP_SH"; then
+    echo "  FAIL: Unix setup signal handler is reachable outside its HUP/INT/TERM traps"
+    exit 1
+fi
 echo "  PASS: Unix setup routes explicit exits through setup_fail"
+
+# Prove the exception behaves as claimed rather than only reading like it. A stubbed pinned-uv
+# install is interrupted for real, in Tauri mode, and has to report the signal as 128+signal,
+# leave none of the pinned path's temporaries behind (a ~40 MB unpacked archive plus staging
+# files inside a directory that is on PATH), and emit no failure context for a cancel.
+_signal_dir=$(mktemp -d)
+trap 'rm -f "$_stdout_file" "$_stderr_file"; rm -rf "$_signal_dir"' EXIT
+{
+    sed -n '/^_setup_uv_cleanup_temporaries()/,/^}/p' "$SETUP_SH"
+    sed -n '/^_setup_uv_on_signal()/,/^}/p' "$SETUP_SH"
+} > "$_signal_dir/uv_signal_fns.sh"
+cat > "$_signal_dir/interrupted_install.sh" <<'SIGNAL_STUB'
+# shellcheck disable=SC1090
+. "$1/uv_signal_fns.sh"
+_SIUP_WORK="$1/work"
+_SIUP_STAGE="$1/dest/.uv.stage"
+_SIUP_STAGE2="$1/dest/.uvx.stage"
+trap _setup_uv_cleanup_temporaries EXIT
+trap '_setup_uv_on_signal 129' HUP
+trap '_setup_uv_on_signal 130' INT
+trap '_setup_uv_on_signal 143' TERM
+: > "$1/ready"
+# Short sleeps, not one long one: a trap runs only once the foreground command returns.
+while :; do sleep 0.1; done
+SIGNAL_STUB
+mkdir -p "$_signal_dir/work/uv-x86_64-unknown-linux-gnu" "$_signal_dir/dest"
+: > "$_signal_dir/work/uv-x86_64-unknown-linux-gnu/uv"
+: > "$_signal_dir/dest/.uv.stage"
+: > "$_signal_dir/dest/.uvx.stage"
+set +e
+UNSLOTH_TAURI_MODE=1 bash "$_signal_dir/interrupted_install.sh" "$_signal_dir" \
+    >"$_stdout_file" 2>"$_stderr_file" &
+_signal_pid=$!
+_signal_waited=0
+while [ ! -e "$_signal_dir/ready" ] && [ "$_signal_waited" -lt 100 ]; do
+    command sleep 0.1
+    _signal_waited=$((_signal_waited + 1))
+done
+kill -TERM "$_signal_pid" 2>/dev/null
+wait "$_signal_pid"
+_exit_code=$?
+set -e
+if [ "$_exit_code" -ne 143 ]; then
+    echo "  FAIL: interrupted setup reported exit code $_exit_code instead of 143"
+    exit 1
+fi
+if [ -d "$_signal_dir/work" ] ||
+    [ -e "$_signal_dir/dest/.uv.stage" ] ||
+    [ -e "$_signal_dir/dest/.uvx.stage" ]; then
+    echo "  FAIL: interrupted setup left the pinned uv temporaries behind"
+    exit 1
+fi
+if grep -q '^\[TAURI:' "$_stdout_file" || grep -q '^\[TAURI:' "$_stderr_file"; then
+    echo "  FAIL: interrupted setup reported a cancel as an installer failure"
+    exit 1
+fi
+echo "  PASS: interrupted setup cleans up and re-raises the signal without failure context"
 
 _rollback_block=$(sed -n \
     '/^_restore_studio_venv_replacement()/,/^}/p' \

--- a/tests/sh/test_tauri_retry_failure_context.sh
+++ b/tests/sh/test_tauri_retry_failure_context.sh
@@ -219,15 +219,12 @@ if [ "$_setup_mode_count" -ne 2 ]; then
     exit 1
 fi
 
-# setup.sh exits in exactly two places and both are accounted for here. setup_fail is the
-# one failure exit: every failure path goes through it so the desktop gets a [TAURI:ERROR]
-# line instead of a bare exit code. The pinned-uv signal handler is the other, and it is not
-# a failure: it re-raises the caller's own termination as 128+signal, the way install.sh's
-# _on_install_signal does, because install.rs cancels an install by SIGTERMing the process
-# group and a cancel must not be reported to the user as an installer failure. A third exit
-# anywhere, or a second exit inside either of these two, is an unrouted failure exit.
-# `|| true`: grep -c reports 0 with status 1, and under set -e a removed handler would
-# abort this file with no explanation instead of the failure below.
+# setup.sh has exactly two exits. setup_fail is the only failure exit: every failure path goes
+# through it so the desktop gets a [TAURI:ERROR] line, not a bare exit code. The pinned-uv signal
+# handler is not a failure, it re-raises as 128+signal like install.sh's _on_install_signal,
+# because install.rs cancels an install by SIGTERMing the process group with intentional_stop and
+# a cancel must not raise a failure banner. A third exit, or a second inside either, is unrouted.
+# `|| true`: grep -c reports 0 with status 1, which under set -e would abort with no explanation.
 _setup_fail_exits=$(sed -n '/^setup_fail()/,/^}/p' "$SETUP_SH" |
     grep -Ec '^[[:space:]]*exit[[:space:]]+' || true)
 _setup_signal_exits=$(sed -n '/^_setup_uv_on_signal()/,/^}/p' "$SETUP_SH" |
@@ -241,8 +238,7 @@ if [ "$_setup_fail_exits" -ne 1 ] ||
     echo "  FAIL: Unix setup has explicit exits outside setup_fail"
     exit 1
 fi
-# The signal handler stays reachable only from its own traps, at 128+signal. Called from
-# ordinary control flow it would be exactly the unrouted failure exit the count forbids.
+# Trap-only: called from ordinary control flow the handler is the unrouted failure exit again.
 _setup_signal_refs=$(grep -c '_setup_uv_on_signal' "$SETUP_SH" || true)
 if [ "$_setup_signal_refs" -ne 4 ] ||
     ! grep -qF "trap '_setup_uv_on_signal 129' HUP" "$SETUP_SH" ||
@@ -253,10 +249,8 @@ if [ "$_setup_signal_refs" -ne 4 ] ||
 fi
 echo "  PASS: Unix setup routes explicit exits through setup_fail"
 
-# Prove the exception behaves as claimed rather than only reading like it. A stubbed pinned-uv
-# install is interrupted for real, in Tauri mode, and has to report the signal as 128+signal,
-# leave none of the pinned path's temporaries behind (a ~40 MB unpacked archive plus staging
-# files inside a directory that is on PATH), and emit no failure context for a cancel.
+# Prove the exception behaves as claimed: a stubbed pinned-uv install, interrupted for real in
+# Tauri mode, must report 128+signal, leave no temporaries behind, and print no cancel failure.
 _signal_dir=$(mktemp -d)
 trap 'rm -f "$_stdout_file" "$_stderr_file"; rm -rf "$_signal_dir"' EXIT
 {
@@ -274,7 +268,7 @@ trap '_setup_uv_on_signal 129' HUP
 trap '_setup_uv_on_signal 130' INT
 trap '_setup_uv_on_signal 143' TERM
 : > "$1/ready"
-# Short sleeps, not one long one: a trap runs only once the foreground command returns.
+# Short sleeps: a trap runs only once the foreground command returns.
 while :; do sleep 0.1; done
 SIGNAL_STUB
 mkdir -p "$_signal_dir/work/uv-x86_64-unknown-linux-gnu" "$_signal_dir/dest"


### PR DESCRIPTION
`Backend CI` / `Repo tests (CPU)` / `Shell installer tests` has been red on main since `5a5bf6413` ("Reduce antivirus false positives in the desktop installers", #8586). Every pytest step in that job passes; only the shell step fails, so it blocks the job on every open PR. Run [31716690017](https://github.com/unslothai/unsloth/actions/runs/31716690017) on main at `10f34dbf6` shows it:

```
  FAIL: Unix setup has explicit exits outside setup_fail
##[error]Process completed with exit code 1.
```

`tests/sh/test_tauri_retry_failure_context.sh` asserts that `studio/setup.sh` has exactly one top-level `exit` and that it is `setup_fail`'s. `5a5bf6413` added a second one, `exit "$1"` inside `_setup_uv_on_signal`, the HUP/INT/TERM handler that removes a partial pinned-uv install.

### Which side is wrong

The assertion (added in `01c856c6c`, #7529) protects one thing: no failure path may leave the desktop with a bare exit code instead of a `[TAURI:ERROR]` line, which `InstallFailureContext::observe_stdout` turns into the message the user is shown. A signal is not one of those paths:

- `stop_install` in `studio/src-tauri/src/install.rs` cancels an install by sending `SIGTERM` to the process group and setting `intentional_stop`. Routing that through `setup_fail` would set `explicit_error`, which the app promotes over everything else, so a user who pressed cancel would be shown an installer failure.
- `install.sh`'s own `_on_install_signal` already answers a signal by restoring the rollback, cleaning up temporaries and exiting 128+signal with no error context. The handler in `setup.sh` is the same shape for the same reason, and `setup.ps1` has no equivalent because PowerShell has no such handler, so its side of the assertion is untouched.

So the handler is right and the test changes. #8586's purpose is untouched: the pinned-release download that replaced the piped `install.sh` text is not modified, and neither is the cleanup it relies on.

### What the assertion is now

Not loosened to "one or more", split. `setup_fail` must hold exactly one `exit`, the signal handler exactly one, their sum must equal every `exit` in the file, and the two lines must still be `exit "$exit_code"` and `exit "$1"`. A third `exit` anywhere, or a second inside either, still fails. The handler must also stay reachable only from its three traps at 129/130/143: called from ordinary control flow it would be exactly the unrouted failure exit the count forbids.

The file also had no behavioural coverage of the interrupt, only text, so this adds it. A stubbed pinned-uv install is interrupted for real in Tauri mode and has to report 143, remove the work directory and both staging files, and print no `[TAURI:]` output.

### Verification

Shell suite run the way the workflow runs it (auto-discovery, same skip list): 47 files, exit code 0.

Each mutation applied to `studio/setup.sh` on top of main in a throwaway worktree, one at a time:

| mutation | result |
| --- | --- |
| extra top-level `exit 1` | `FAIL: Unix setup has explicit exits outside setup_fail` |
| `_setup_uv_on_signal` called from control flow | `FAIL: Unix setup signal handler is reachable outside its HUP/INT/TERM traps` |
| handler stops calling `_setup_uv_cleanup_temporaries` | `FAIL: interrupted setup left the pinned uv temporaries behind` |
| handler routed through `setup_fail` | `FAIL: Unix setup has explicit exits outside setup_fail` |
| handler emits `[TAURI:ERROR]` on cancel | `FAIL: interrupted setup reported a cancel as an installer failure` |

The new file also fails at `5a5bf6413^`, where the handler does not exist yet, so it is not passing vacuously.
