### PR TITLE
Guard OAuth providers from legacy desktop clients

### DIFF
--- a/studio/backend/core/inference/providers.py
+++ b/studio/backend/core/inference/providers.py
@@ -680,7 +680,9 @@ def validate_provider_base_url(base_url: str) -> str:
     return raw.rstrip("/")
 
 
-def list_available_providers(include_hidden: bool = False) -> list[dict[str, Any]]:
+def list_available_providers(
+    include_hidden: bool = False, include_oauth: bool = False
+) -> list[dict[str, Any]]:
     """Return registered providers (for the /registry endpoint).
 
     Hidden entries exist only for backend lookups and are surfaced by the UI via
@@ -693,10 +695,16 @@ def list_available_providers(include_hidden: bool = False) -> list[dict[str, Any
     ``include_hidden`` is how a client that does know says so. The self-hosted
     presets are exactly the ones that run Studio's tools, so their capability
     has to reach a frontend that asks for it, and asking is opt-in.
+
+    OAuth providers are also opt-in because a legacy frontend renders every
+    visible registry row as an API-key form. An OAuth-aware frontend sends
+    ``include_oauth=true`` and handles the returned ``auth_kind`` contract.
     """
     result = []
     for provider_type, info in PROVIDER_REGISTRY.items():
         if info.get("hidden") and not include_hidden:
+            continue
+        if info.get("auth_kind") == "chatgpt_oauth" and not include_oauth:
             continue
         result.append(
             {

--- a/studio/backend/routes/providers.py
+++ b/studio/backend/routes/providers.py
@@ -152,7 +152,9 @@ async def get_public_key(current_subject: str = Depends(get_current_subject)):
 
 @router.get("/registry", response_model = list[ProviderRegistryEntry])
 async def list_registry(
-    include_hidden: bool = False, current_subject: str = Depends(get_current_subject)
+    include_hidden: bool = False,
+    include_oauth: bool = False,
+    current_subject: str = Depends(get_current_subject),
 ):
     """List all supported provider types with their default configurations.
 
@@ -161,8 +163,12 @@ async def list_registry(
     needs. It is opt-in so that a browser still running a pre-capability bundle,
     which does not know to filter on ``hidden``, keeps seeing exactly the list
     it saw before and cannot render them as duplicate dropdown options.
+
+    ``include_oauth=true`` declares that the client can render OAuth connection
+    flows. Without it, OAuth-only providers stay hidden from legacy bundles that
+    would incorrectly render an API-key form.
     """
-    return list_available_providers(include_hidden = include_hidden)
+    return list_available_providers(include_hidden = include_hidden, include_oauth = include_oauth)
 
 
 # ── Per-MTok pricing snapshot for client-side cost display ──────────

--- a/studio/backend/tests/test_external_tools_compat.py
+++ b/studio/backend/tests/test_external_tools_compat.py
@@ -135,6 +135,25 @@ def test_visible_rows_are_identical_with_and_without_include_hidden():
         assert row == widened[row["provider_type"]]
 
 
+def test_registry_default_hides_oauth_providers_from_legacy_clients():
+    """An old bundle must not render an OAuth provider as an API-key form."""
+    types = {entry["provider_type"] for entry in list_available_providers()}
+    assert "openai_codex" not in types
+
+
+def test_include_hidden_does_not_imply_oauth_client_support():
+    """Hidden-preset support and OAuth UI support are separate capabilities."""
+    types = {entry["provider_type"] for entry in list_available_providers(include_hidden = True)}
+    assert "openai_codex" not in types
+
+
+def test_oauth_aware_clients_can_request_oauth_providers():
+    entries = {
+        entry["provider_type"]: entry for entry in list_available_providers(include_oauth = True)
+    }
+    assert entries["openai_codex"]["auth_kind"] == "chatgpt_oauth"
+
+
 def test_registry_rows_keep_every_pre_change_key():
     """Additive only. A cached bundle reads these keys off every row."""
     for entry in list_available_providers(include_hidden = True):

--- a/studio/backend/tests/test_openai_codex_subscription.py
+++ b/studio/backend/tests/test_openai_codex_subscription.py
@@ -68,7 +68,9 @@ def test_protocol_constants_and_curated_provider_contract():
     ]
     assert OPENAI_CODEX_DEVICE_REDIRECT_URI == ("https://auth.openai.com/deviceauth/callback")
     row = next(
-        item for item in list_available_providers() if item["provider_type"] == "openai_codex"
+        item
+        for item in list_available_providers(include_oauth = True)
+        if item["provider_type"] == "openai_codex"
     )
     assert row["auth_kind"] == "chatgpt_oauth"
 

--- a/studio/frontend/src/features/chat/api/providers-api.ts
+++ b/studio/frontend/src/features/chat/api/providers-api.ts
@@ -139,7 +139,11 @@ export async function listProviderRegistry(): Promise<ProviderRegistryEntry[]> {
   // which carry the studio-tools capability the composer gates on. An older
   // backend ignores the parameter and returns the visible entries, so the
   // capability simply reads as unknown and the pills stay closed.
-  const response = await authFetch("/api/providers/registry?include_hidden=true");
+  // include_oauth declares that this bundle can render OAuth connection flows;
+  // without it, newer backends keep OAuth-only providers away from legacy UI.
+  const response = await authFetch(
+    "/api/providers/registry?include_hidden=true&include_oauth=true",
+  );
   return parseJsonOrThrow<ProviderRegistryEntry[]>(response);
 }
 

--- a/studio/frontend/tests/provider-registry-oauth-capability.test.ts
+++ b/studio/frontend/tests/provider-registry-oauth-capability.test.ts
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import { register } from "node:module";
+import test from "node:test";
+
+register("./helpers/settings-api-resolver.mjs", import.meta.url);
+
+const requests: string[] = [];
+globalThis.fetch = (async (input: RequestInfo | URL) => {
+  requests.push(String(input));
+  return new Response("[]", {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}) as typeof fetch;
+
+const { listProviderRegistry } = await import(
+  "../src/features/chat/api/providers-api.ts"
+);
+
+test("provider registry declares OAuth UI support", async () => {
+  requests.length = 0;
+
+  await listProviderRegistry();
+
+  assert.deepEqual(requests, [
+    "/api/providers/registry?include_hidden=true&include_oauth=true",
+  ]);
+});


### PR DESCRIPTION
## Summary

- keep OAuth-only providers out of the default provider registry response
- let OAuth-aware clients opt in with `include_oauth=true`
- make the current Studio frontend declare OAuth UI support when it loads the registry

## Root cause

The backend package can update independently from the desktop frontend. A newer backend exposed `openai_codex` to desktop `v0.1.701-beta`, whose provider dialog predates OAuth support and renders every provider as an API-key form. The backend then correctly rejects that API key, which creates the contradictory validation reported in #8722.

This change treats OAuth UI support as a client capability. Legacy clients keep the old default registry shape, while the OAuth-aware frontend opts in. The existing OAuth implementation remains unchanged.

Related: #8722

## Validation

- repository pre-commit hooks passed on all six changed files
- upstream-pinned Ruff `0.15.12` passed on the changed backend files
- 57 affected backend tests passed
- 2,278 frontend unit tests passed
- frontend typecheck passed
- frontend production build passed
- `git diff --check` passed

## Release note

This compatibility guard prevents older desktop bundles from showing an unusable OAuth provider. A desktop release that contains the OAuth frontend is still required before users on `v0.1.701-beta` can connect a ChatGPT subscription.

Fixes #8722
