### PR TITLE
Fix the four Backend CI failures the collection error was hiding

### DIFF
--- a/studio/backend/tests/test_external_hosted_tool_passthrough.py
+++ b/studio/backend/tests/test_external_hosted_tool_passthrough.py
@@ -210,10 +210,14 @@ def test_a_self_hosted_provider_still_runs_studios_own_web_search(monkeypatch, p
 def test_a_local_only_selection_takes_the_loop_on_a_hosted_provider(monkeypatch, overrides):
     """Shape 3: one Studio-only name (or MCP) is unambiguous, so the feature
     works on hosted providers too."""
+    # ``routes.inference`` imports this inside ``_select_request_tools``, so it is never
+    # an attribute of the route module and patching it there set a name nobody reads.
+    # Patch it where the function-local import resolves it from, and leave ``raising`` at
+    # its default so a future move breaks this outright instead of silently letting the
+    # ``mcp_enabled`` case spawn stdio servers.
     monkeypatch.setattr(
-        "routes.inference.get_enabled_mcp_tools",
+        "core.inference.tools.get_enabled_mcp_tools",
         lambda: _noop_mcp(),
-        raising = False,
     )
     inf = _install(monkeypatch, "openai")
     with pytest.raises(LoopEntered):

--- a/studio/backend/tests/test_external_hosted_tool_passthrough.py
+++ b/studio/backend/tests/test_external_hosted_tool_passthrough.py
@@ -210,11 +210,10 @@ def test_a_self_hosted_provider_still_runs_studios_own_web_search(monkeypatch, p
 def test_a_local_only_selection_takes_the_loop_on_a_hosted_provider(monkeypatch, overrides):
     """Shape 3: one Studio-only name (or MCP) is unambiguous, so the feature
     works on hosted providers too."""
-    # ``routes.inference`` imports this inside ``_select_request_tools``, so it is never
-    # an attribute of the route module and patching it there set a name nobody reads.
-    # Patch it where the function-local import resolves it from, and leave ``raising`` at
-    # its default so a future move breaks this outright instead of silently letting the
-    # ``mcp_enabled`` case spawn stdio servers.
+    # ``_select_request_tools`` imports this from ``core.inference.tools`` inside the function
+    # body, so it is never an attribute of ``routes.inference``: patching the route set a dead
+    # name, and ``raising = False`` hid that while the real function spawned stdio MCP servers
+    # and wrote discovery cache and cool-off state. Default ``raising`` catches a future move.
     monkeypatch.setattr(
         "core.inference.tools.get_enabled_mcp_tools",
         lambda: _noop_mcp(),

--- a/studio/backend/tests/test_external_tool_stream_abuse.py
+++ b/studio/backend/tests/test_external_tool_stream_abuse.py
@@ -894,14 +894,11 @@ def test_no_asyncio_task_is_orphaned_when_the_loop_is_closed_mid_tool(executed, 
     cancel_event = threading.Event()
 
     async def _drive():
-        # Anything already running before the loop starts belongs to this harness, not to
-        # the tool loop, so the census is taken against it. On Python 3.10 and 3.11
-        # ``asyncio.wait_for`` wraps the coroutine it is handed in a second task
-        # (``asyncio/tasks.py``), so ``all_tasks()`` below also holds the ``wait_for()``
-        # task driving this one, and that task is by construction not done: it is awaiting
-        # the census. 3.12 reimplemented ``wait_for`` on ``asyncio.timeout`` and awaits the
-        # coroutine directly, which is the whole reason this read green there and red on the
-        # two older interpreters. Neither is an orphan either way.
+        # Tasks already running belong to this harness, not the tool loop, so the census is taken
+        # against them. On 3.10/3.11 ``asyncio.wait_for`` wraps its coroutine in a SECOND task, so
+        # ``all_tasks()`` below also returns the ``wait_for()`` task driving this one, never done
+        # because it is awaiting the census. 3.12 reimplemented ``wait_for`` on ``asyncio.timeout``
+        # and awaits directly, which is why this read green there and red on the older two.
         harness = asyncio.all_tasks()
         agen = stream_with_studio_tools(
             transport,
@@ -918,9 +915,8 @@ def test_no_asyncio_task_is_orphaned_when_the_loop_is_closed_mid_tool(executed, 
         await agen.aclose()
         # Give the drain a tick to join its worker before the task census.
         await asyncio.sleep(0)
-        # ``not task.done()`` is the contract: a task that has finished has been joined and
-        # is not a leak. What must not survive is a task still running with nobody left to
-        # await it.
+        # ``not task.done()``, not "no tasks exist": a finished task was joined and is no leak,
+        # what must not survive is one still running with nobody left to await it.
         return [
             task
             for task in asyncio.all_tasks()

--- a/studio/backend/tests/test_external_tool_stream_abuse.py
+++ b/studio/backend/tests/test_external_tool_stream_abuse.py
@@ -894,6 +894,15 @@ def test_no_asyncio_task_is_orphaned_when_the_loop_is_closed_mid_tool(executed, 
     cancel_event = threading.Event()
 
     async def _drive():
+        # Anything already running before the loop starts belongs to this harness, not to
+        # the tool loop, so the census is taken against it. On Python 3.10 and 3.11
+        # ``asyncio.wait_for`` wraps the coroutine it is handed in a second task
+        # (``asyncio/tasks.py``), so ``all_tasks()`` below also holds the ``wait_for()``
+        # task driving this one, and that task is by construction not done: it is awaiting
+        # the census. 3.12 reimplemented ``wait_for`` on ``asyncio.timeout`` and awaits the
+        # coroutine directly, which is the whole reason this read green there and red on the
+        # two older interpreters. Neither is an orphan either way.
+        harness = asyncio.all_tasks()
         agen = stream_with_studio_tools(
             transport,
             run = ToolLoopRun(messages = [{"role": "user", "content": "hi"}], session_id = "s1"),
@@ -909,10 +918,13 @@ def test_no_asyncio_task_is_orphaned_when_the_loop_is_closed_mid_tool(executed, 
         await agen.aclose()
         # Give the drain a tick to join its worker before the task census.
         await asyncio.sleep(0)
+        # ``not task.done()`` is the contract: a task that has finished has been joined and
+        # is not a leak. What must not survive is a task still running with nobody left to
+        # await it.
         return [
             task
             for task in asyncio.all_tasks()
-            if task is not asyncio.current_task() and not task.done()
+            if task not in harness and task is not asyncio.current_task() and not task.done()
         ]
 
     pending = asyncio.run(asyncio.wait_for(_drive(), timeout = 30.0))

--- a/studio/backend/tests/test_video_backend.py
+++ b/studio/backend/tests/test_video_backend.py
@@ -540,10 +540,9 @@ def _stub_apply_memory_plan(
 ) -> list:
     """Stand in for ``apply_memory_plan``, recording the placement kwargs of every call.
 
-    The keywords are spelled out rather than collected into ``**kwargs`` on purpose. A
-    double that swallows the signature keeps passing after the load starts handing over an
-    argument it never reads, which is exactly how ``placement_device`` (#8645) turned into a
-    TypeError on CI: the real function grew the keyword, the doubles here did not.
+    The keywords are spelled out rather than ``**kwargs`` on purpose: a double that swallows the
+    signature keeps passing once the load hands over an argument it never reads, which is how
+    ``placement_device`` (#8645) became a TypeError on CI.
     """
     calls = []
 
@@ -1850,10 +1849,10 @@ def test_dense_quant_skipped_under_offload(fake_runtime, monkeypatch):
 
 
 def test_the_video_load_places_on_the_selected_card_not_a_bare_device(fake_runtime, monkeypatch):
-    # The other half of #8645, at the video seam: apply_memory_plan hands `placement_device`
-    # to every diffusers placement call, and a bare device sends the CPU-offload hooks to
-    # ordinal 0 whatever was selected. So the load has to pass the INDEXED string while the
-    # policy argument stays bare, and the two must not be swapped.
+    # #8645 at the video seam: ``enable_model_cpu_offload`` reads the ordinal off the device and
+    # falls back to ``_offload_gpu_id = 0`` without one, so the load passes the INDEXED string as
+    # ``placement_device``; ``device`` stays bare because the memory/speed/attention policies
+    # compare it against "cuda". The two must not be swapped.
     import dataclasses
 
     import core.inference.video as video_mod

--- a/studio/backend/tests/test_video_backend.py
+++ b/studio/backend/tests/test_video_backend.py
@@ -531,6 +531,32 @@ def _load_gguf(backend, tmp_path):
     )
 
 
+def _stub_apply_memory_plan(monkeypatch, video_mod, *, policy = "model", vae_tiling = True) -> list:
+    """Stand in for ``apply_memory_plan``, recording the placement kwargs of every call.
+
+    The keywords are spelled out rather than collected into ``**kwargs`` on purpose. A
+    double that swallows the signature keeps passing after the load starts handing over an
+    argument it never reads, which is exactly how ``placement_device`` (#8645) turned into a
+    TypeError on CI: the real function grew the keyword, the doubles here did not.
+    """
+    calls = []
+
+    def _fake(pipe, plan, *, device = None, placement_device = None, logger = None):
+        calls.append({"device": device, "placement_device": placement_device})
+        return (policy, vae_tiling)
+
+    monkeypatch.setattr(video_mod, "apply_memory_plan", _fake)
+    return calls
+
+
+def _assert_placement_follows_the_target(calls, video_mod):
+    """Placement gets the INDEXED device off the resolved target, the policy string stays bare."""
+    target = video_mod.resolve_diffusion_device_target()
+    assert calls, "apply_memory_plan was never called"
+    assert calls[0]["placement_device"] == target.torch_device
+    assert calls[0]["device"] == target.device
+
+
 def test_resolve_kind():
     assert resolve_video_model_kind("x.gguf", None) == "gguf"
     assert resolve_video_model_kind("x.safetensors", None) == "single_file"
@@ -1790,11 +1816,7 @@ def test_dense_quant_skipped_under_offload(fake_runtime, monkeypatch):
         "plan_diffusion_memory",
         lambda **kwargs: dataclasses.replace(real_plan(**kwargs), offload_policy = "model"),
     )
-    monkeypatch.setattr(
-        video_mod,
-        "apply_memory_plan",
-        lambda pipe, plan, device = None, logger = None: ("model", True),
-    )
+    placements = _stub_apply_memory_plan(monkeypatch, video_mod)
 
     backend = VideoBackend()
     status = backend.load_pipeline(
@@ -1802,6 +1824,7 @@ def test_dense_quant_skipped_under_offload(fake_runtime, monkeypatch):
         model_kind = "pipeline",
         transformer_quant = "int8",
     )
+    _assert_placement_follows_the_target(placements, video_mod)
     assert status["offload_policy"] == "model"
     assert quantised == []
     assert status["transformer_quant"] is None
@@ -1811,6 +1834,36 @@ def test_dense_quant_skipped_under_offload(fake_runtime, monkeypatch):
     assert resolved["requested"] == "int8"
     assert resolved["value"] == "off"
     assert resolved["status"] == "fell_back"
+
+
+def test_the_video_load_places_on_the_selected_card_not_a_bare_device(fake_runtime, monkeypatch):
+    # The other half of #8645, at the video seam: apply_memory_plan hands `placement_device`
+    # to every diffusers placement call, and a bare device sends the CPU-offload hooks to
+    # ordinal 0 whatever was selected. So the load has to pass the INDEXED string while the
+    # policy argument stays bare, and the two must not be swapped.
+    import dataclasses
+
+    import core.inference.video as video_mod
+
+    real_target = VideoBackend._device_target
+
+    def _selected(self, ordinal = None):
+        return dataclasses.replace(real_target(self, ordinal), ordinal = 1)
+
+    monkeypatch.setattr(VideoBackend, "_device_target", _selected)
+    real_plan = video_mod.plan_diffusion_memory
+    monkeypatch.setattr(
+        video_mod,
+        "plan_diffusion_memory",
+        lambda **kwargs: dataclasses.replace(real_plan(**kwargs), offload_policy = "model"),
+    )
+    placements = _stub_apply_memory_plan(monkeypatch, video_mod)
+
+    VideoBackend().load_pipeline("Lightricks/LTX-2", model_kind = "pipeline")
+
+    assert placements, "apply_memory_plan was never called"
+    assert placements[0]["placement_device"] == "cpu:1"
+    assert placements[0]["device"] == "cpu"
 
 
 def test_explicit_dense_quant_refuses_under_offload(fake_runtime, monkeypatch):
@@ -6680,9 +6733,7 @@ def test_dense_quant_replan_uses_the_scaled_text_encoder(fake_runtime, monkeypat
         return dataclasses.replace(real(**kwargs), offload_policy = "model")
 
     monkeypatch.setattr(video_mod, "plan_diffusion_memory", _spy)
-    monkeypatch.setattr(
-        video_mod, "apply_memory_plan", lambda pipe, plan, device = None, logger = None: ("model", True)
-    )
+    placements = _stub_apply_memory_plan(monkeypatch, video_mod)
 
     VideoBackend().load_pipeline(
         "Lightricks/LTX-2",
@@ -6690,6 +6741,7 @@ def test_dense_quant_replan_uses_the_scaled_text_encoder(fake_runtime, monkeypat
         transformer_quant = "int8",
         text_encoder_quant = "fp8",
     )
+    _assert_placement_follows_the_target(placements, video_mod)
     assert len(calls) == 2, "the dense-quant re-plan did not run"
     assert calls[1]["model_dense_mib"] == int(
         (transformer_gb * _QUANT_STEADY_FACTOR["int8"] + text_encoder_gb * scale + vae_gb)

--- a/studio/backend/tests/test_video_backend.py
+++ b/studio/backend/tests/test_video_backend.py
@@ -531,7 +531,13 @@ def _load_gguf(backend, tmp_path):
     )
 
 
-def _stub_apply_memory_plan(monkeypatch, video_mod, *, policy = "model", vae_tiling = True) -> list:
+def _stub_apply_memory_plan(
+    monkeypatch,
+    video_mod,
+    *,
+    policy = "model",
+    vae_tiling = True,
+) -> list:
     """Stand in for ``apply_memory_plan``, recording the placement kwargs of every call.
 
     The keywords are spelled out rather than collected into ``**kwargs`` on purpose. A
@@ -541,7 +547,14 @@ def _stub_apply_memory_plan(monkeypatch, video_mod, *, policy = "model", vae_til
     """
     calls = []
 
-    def _fake(pipe, plan, *, device = None, placement_device = None, logger = None):
+    def _fake(
+        pipe,
+        plan,
+        *,
+        device = None,
+        placement_device = None,
+        logger = None,
+    ):
         calls.append({"device": device, "placement_device": placement_device})
         return (policy, vae_tiling)
 


### PR DESCRIPTION
## Why this sits on top of #8740

Based on `backendci-collect` (#8740), head `e95717a48`, and **#8740 has to merge first**.
Every `Backend CI` pytest leg used to exit 2 at collection, so none of these tests ran at
all. With that fixed the jobs finally run and four genuine pre-existing failures surface.
#8740 alone does not turn Backend CI green; this does the rest.

The four are from run
[31746755707](https://github.com/unslothai/unsloth/actions/runs/31746755707) on #8740's
head. Python 3.11: `4 failed, 24330 passed, 136 skipped, 36 deselected in 1590.36s`,
exit 1. Python 3.10 is the same four, 3.12 has three of them (see the asyncio one below).

Everything here is measured in a venv built from this workflow's own install list, with no
`unsloth_zoo` importable, run from `studio/backend` the way CI does. Nothing was installed
to make anything pass.

---

## 1. `test_refactor_guard.py::test_every_string_patch_target_still_resolves`

```
AssertionError: routes.inference.get_enabled_mcp_tools: missing attribute
'get_enabled_mcp_tools' (tests/test_external_hosted_tool_passthrough.py)
```

**Root cause.** `routes/inference.py` has never had `get_enabled_mcp_tools` as a module
attribute. `_select_request_tools` imports it from `core.inference.tools` inside the
function body, and so did every earlier revision:
`git show 9a907a8ac:.../routes/inference.py` (#5750, where the symbol was introduced),
`e6b448083` (#6490) and `0e158a8b7` (#8665) all show the import indented inside a
function. The test added in #8665 patched `"routes.inference.get_enabled_mcp_tools"` with
`raising = False`, which is what kept a name nothing reads from failing loudly.

**Which side.** The guard is right and is left alone; that is exactly the rot it exists to
catch. The patch target moves to `core.inference.tools.get_enabled_mcp_tools`, where the
function-local import resolves it from, and `raising` goes back to its default so a future
move breaks outright rather than going quiet again.

Not cosmetic: of the five parametrised cases only the `mcp_enabled` one reaches the call,
and with the dead patch that case ran the real `get_enabled_mcp_tools`, which spawns stdio
MCP servers and writes discovery cache and cool-off state. Swapping the stub for one that
raises gives `1 failed, 4 passed`, so it is load-bearing for that case and inert for the
other four.

**Before / after.** `tests/test_refactor_guard.py`: `1 failed, 11 passed`, exit 1 ->
`128 passed`, exit 0 across `test_refactor_guard.py`,
`test_external_hosted_tool_passthrough.py` and `test_mcp_servers.py`.

---

## 2 and 3. `test_video_backend.py::test_dense_quant_skipped_under_offload` and `::test_dense_quant_replan_uses_the_scaled_text_encoder`

```
TypeError: <locals>.<lambda>() got an unexpected keyword argument 'placement_device'
```

**Root cause.** `e7ea3cb97` (#8645) gave `apply_memory_plan` a `placement_device` keyword
and made both the diffusion and video loads pass `target.torch_device`, the indexed device
string. Production is right to pass it: `enable_model_cpu_offload` reads the index off the
device and, finding none, falls back to `_offload_gpu_id = 0` (diffusers 0.39
`pipeline_utils.py`), so a bare `"cuda"` pages the modules onto card 0 while generation
runs on the selected one. `device` stays bare because the memory, speed and attention
policies compare it against `"cuda"`. Two doubles in `test_video_backend.py` were written
`lambda pipe, plan, device = None, logger = None: ("model", True)` and so raised on the new
keyword.

**Which side.** Production keeps the argument; the doubles move. They are **not** widened
with `**kwargs`: swallowing the signature is how the next argument goes unnoticed the same
way, and it throws the value away. Both now go through `_stub_apply_memory_plan`, which
records the placement kwargs, and both assert the load handed the resolved target's
`torch_device` to placement and its bare `device` to the policy string.

On the CPU fake runtime those two strings coincide, so a third test pins the distinction
#8645 exists for: `_device_target` is patched to report `ordinal = 1`, and the load must
place on `"cpu:1"` while `device` stays `"cpu"`. Reverting `video.py` to
`placement_device = target.device` fails it with `assert 'cpu' == 'cpu:1'`, so it can fail.

**Before / after.** The two tests: `2 failed, 219 deselected`, exit 1 -> `312 passed` for
`test_video_backend.py` and `test_diffusion_memory.py`, exit 0.

---

## 4. `test_external_tool_stream_abuse.py::test_no_asyncio_task_is_orphaned_when_the_loop_is_closed_mid_tool`

```
AssertionError: assert [<Task finished name='Task-3591'
  coro=<wait_for() done, defined at .../asyncio/tasks.py:436> result=[...]>] == []
```

**Root cause: the test's own harness, not production.** The census runs inside a coroutine
that `asyncio.wait_for` drives, and on Python 3.10 and 3.11 `wait_for` wraps the coroutine
it is handed in a second task, so `all_tasks()` inside also returns the `wait_for()` task
driving the census. That task cannot be done: it is awaiting the census. 3.12 reimplemented
`wait_for` on `asyncio.timeout` and awaits the coroutine directly.

That is exactly the observed split in the run above: red on 3.10 and 3.11, green on 3.12,
and the leaked task is `coro=<wait_for() ... tasks.py:436>`, which is `wait_for` itself.
Five lines with no Studio code in them reproduce it:

```python
async def drive():
    return [t for t in asyncio.all_tasks()
            if t is not asyncio.current_task() and not t.done()]
print(asyncio.run(asyncio.wait_for(drive(), timeout = 5.0)))
```

```
3.11.14 -> [<Task finished name='Task-1' coro=<wait_for() ... tasks.py:436>>]
3.12.3  -> []
3.13.12 -> []
```

The loop itself does drain: the tool step runs under `asyncio.create_task` and
`_drain_step_task` joins it in a `finally`, which is why 3.12 and 3.13 see an empty census.

**Which side.** Nothing to fix in production. The census now subtracts the tasks that were
already running when the drive started, which belong to the harness by definition and
cannot be something the tool loop orphaned. `not task.done()` stays, and it is the right
contract: a finished task has been joined and is not a leak, while a task still running
with nobody to await it is. Asserting "no tasks exist at all" would pin something no caller
needs and would still trip over the same `wait_for` task.

It can still fail: adding `asyncio.create_task(asyncio.sleep(60))` inside the drive fails
it on both 3.11 and 3.13.

**Before / after.** On Python 3.11, `tests/test_external_tool_stream_abuse.py -k orphaned`:
`1 failed, 51 deselected`, exit 1 -> `52 passed`, exit 0 on both 3.11 and 3.13.

---

## Full suite

Python 3.11, workflow flags, no `unsloth_zoo`:

```
3 failed, 24347 passed, 122 skipped, 36 deselected, 78 warnings, 9 subtests passed in 1052.22s
exit 1
```

All four target failures are gone. The three left are `test_tool_output_streaming.py`
subprocess tests failing on this box for `bash: fork: Resource temporarily unavailable` /
`BlockingIOError: [Errno 11] Resource temporarily unavailable`, which is local process
contention, not a code failure. They are green on CI in the same run.

Tests only; no production file is touched.
