### PR TITLE
Studio: share attached files across a project, remember params per model

### DIFF
--- a/studio/backend/routes/chat_history.py
+++ b/studio/backend/routes/chat_history.py
@@ -233,6 +233,10 @@ class ChatSettingsPayload(BaseModel):
     model_config = ConfigDict(extra = "forbid")
 
     inferenceParams: Optional[ChatInferenceSettings] = None
+    # Last-used params per checkpoint id. Deep-merged per key, so patching one
+    # model cannot drop another's.
+    inferenceParamsByModel: Optional[dict[str, ChatInferenceSettings]] = None
+    rememberParamsPerModel: Optional[bool] = None
     customPresets: Optional[list[ChatPreset]] = None
     activePreset: Optional[str] = None
     activePresetSource: Optional[Literal["builtin-default", "custom", "modified"]] = None

--- a/studio/backend/tests/test_chat_history_routes.py
+++ b/studio/backend/tests/test_chat_history_routes.py
@@ -295,6 +295,37 @@ def test_chat_settings_payload_accepts_fast_mode_presets():
     assert dumped["customPresets"][0]["params"]["fastMode"] is True
 
 
+def test_chat_settings_payload_carries_per_model_params():
+    """The payload is extra="forbid", so per-model memory only reaches the DB if the
+    schema names both keys. A patch also has to survive exclude_unset with just the
+    one model it touched, since that is what keeps other models' settings intact."""
+    payload = chat_history.ChatSettingsPayload.model_validate(
+        {
+            "rememberParamsPerModel": True,
+            "inferenceParamsByModel": {
+                "unsloth/Qwen3.5-9B-GGUF": {"temperature": 0.2, "maxTokens": 4096},
+            },
+        }
+    )
+
+    dumped = payload.model_dump(exclude_unset = True)
+    assert dumped["rememberParamsPerModel"] is True
+    assert dumped["inferenceParamsByModel"] == {
+        "unsloth/Qwen3.5-9B-GGUF": {"temperature": 0.2, "maxTokens": 4096},
+    }
+    # Nothing else is implied by the patch, so the merge cannot clobber it.
+    assert "inferenceParams" not in dumped
+
+
+def test_chat_settings_payload_rejects_junk_per_model_params():
+    """Provider-qualified ids are opaque keys, but the values are still real
+    inference settings -- an unknown field must 400 rather than reach the DB."""
+    with pytest.raises(ValidationError):
+        chat_history.ChatSettingsPayload.model_validate(
+            {"inferenceParamsByModel": {"openai:gpt-x": {"notAParam": 1}}}
+        )
+
+
 def test_chat_settings_payload_accepts_preset_load_config():
     payload = chat_history.ChatSettingsPayload.model_validate(
         {

--- a/studio/backend/tests/test_chat_history_storage.py
+++ b/studio/backend/tests/test_chat_history_storage.py
@@ -471,6 +471,29 @@ def test_settings_merge_preserves_nested_keys(tmp_path, monkeypatch):
     assert params == {"temperature": 0.9, "topP": 0.8}
 
 
+def test_settings_merge_keeps_each_model_s_remembered_params(tmp_path, monkeypatch):
+    """Per-model memory patches one model at a time, so the merge has to keep the
+    others. Without this, tuning a second model would wipe the first one's settings
+    and the switch back would land on whatever the last edit happened to be."""
+    _reset_studio_db(tmp_path, monkeypatch)
+    studio_db.upsert_chat_settings_merge(
+        {"inferenceParamsByModel": {"qwen": {"temperature": 0.2, "topP": 0.8}}}
+    )
+    studio_db.upsert_chat_settings_merge(
+        {"inferenceParamsByModel": {"llama": {"temperature": 0.9}}}
+    )
+    # A second edit to the first model merges into its own entry.
+    studio_db.upsert_chat_settings_merge(
+        {"inferenceParamsByModel": {"qwen": {"temperature": 0.4}}}
+    )
+
+    by_model = studio_db.list_chat_settings()["inferenceParamsByModel"]
+    assert by_model == {
+        "qwen": {"temperature": 0.4, "topP": 0.8},
+        "llama": {"temperature": 0.9},
+    }
+
+
 def test_settings_merge_quarantines_corrupt_json_and_rejects_partial_patch(tmp_path, monkeypatch):
     _reset_studio_db(tmp_path, monkeypatch)
     studio_db.upsert_chat_settings_merge({"inferenceParams": {"temperature": 0.5, "topP": 0.8}})

--- a/studio/backend/tests/test_chat_history_storage.py
+++ b/studio/backend/tests/test_chat_history_storage.py
@@ -483,15 +483,10 @@ def test_settings_merge_keeps_each_model_s_remembered_params(tmp_path, monkeypat
         {"inferenceParamsByModel": {"llama": {"temperature": 0.9}}}
     )
     # A second edit to the first model merges into its own entry.
-    studio_db.upsert_chat_settings_merge(
-        {"inferenceParamsByModel": {"qwen": {"temperature": 0.4}}}
-    )
+    studio_db.upsert_chat_settings_merge({"inferenceParamsByModel": {"qwen": {"temperature": 0.4}}})
 
     by_model = studio_db.list_chat_settings()["inferenceParamsByModel"]
-    assert by_model == {
-        "qwen": {"temperature": 0.4, "topP": 0.8},
-        "llama": {"temperature": 0.9},
-    }
+    assert by_model == {"qwen": {"temperature": 0.4, "topP": 0.8}, "llama": {"temperature": 0.9}}
 
 
 def test_settings_merge_quarantines_corrupt_json_and_rejects_partial_patch(tmp_path, monkeypatch):

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -138,6 +138,7 @@ import {
   getStoredChatThread,
   getStoredChatThreadReadResult,
   getStoredChatProject,
+  isThreadIncognito,
   listStoredChatThreads,
   listStoredChatMessages,
   saveStoredChatMessage,
@@ -1809,7 +1810,16 @@ async function resolveProjectId(
     const thread = await (
       readThreadRecord?.() ?? getStoredChatThread(threadId)
     ).catch(() => null);
-    return thread?.projectId ?? null;
+    if (thread) {
+      return thread.projectId ?? null;
+    }
+    // No row yet: initialize() does not await the write, so a fresh chat's first
+    // send can read ahead of its own row and drop the project's sources,
+    // instructions and sandbox. Fall back to the composer's project. An incognito
+    // thread is never persisted, so its missing row is the real answer.
+    if (isThreadIncognito(threadId)) {
+      return null;
+    }
   }
   const projectId = useChatRuntimeStore.getState().activeProjectId;
   if (!projectId) {

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -1807,9 +1807,14 @@ async function resolveProjectId(
   readThreadRecord?: ThreadRecordReader,
 ): Promise<string | null> {
   if (threadId) {
-    const thread = await (
-      readThreadRecord?.() ?? getStoredChatThread(threadId)
-    ).catch(() => null);
+    let thread: ThreadRecord | undefined;
+    try {
+      thread = await (readThreadRecord?.() ?? getStoredChatThread(threadId));
+    } catch {
+      // A failed lookup is not proof the row is missing, so it must not adopt
+      // whichever project the composer last had open.
+      return null;
+    }
     if (thread) {
       return thread.projectId ?? null;
     }

--- a/studio/frontend/src/features/chat/api/chat-settings-api.ts
+++ b/studio/frontend/src/features/chat/api/chat-settings-api.ts
@@ -18,6 +18,9 @@ export interface PersistedChatPreset {
 
 export interface PersistedChatSettings {
   inferenceParams?: PersistedInferenceParams;
+  /** Last-used params per checkpoint id, replayed on model switch. */
+  inferenceParamsByModel?: Record<string, PersistedInferenceParams>;
+  rememberParamsPerModel?: boolean;
   customPresets?: PersistedChatPreset[];
   activePreset?: string;
   activePresetSource?: ChatPresetSource;

--- a/studio/frontend/src/features/chat/index.ts
+++ b/studio/frontend/src/features/chat/index.ts
@@ -161,6 +161,7 @@ export {
 export {
   deleteStoredChatThreads,
   ensureStoredChatThread,
+  getStoredChatThread,
   isThreadIncognito,
   listStoredChatThreads,
   markThreadIncognito,

--- a/studio/frontend/src/features/chat/lib/per-model-params.ts
+++ b/studio/frontend/src/features/chat/lib/per-model-params.ts
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// Per-model parameter memory. Chat settings hold one set of sampling params, so
+// switching models used to hand the next model the previous one's temperature and
+// prompt. These keep a per-checkpoint record alongside the global set: an edit is
+// filed against the model it was made for, and a switch replays that model's own
+// settings. No store or network imports, so the rules stay unit-testable.
+
+import type { PersistedInferenceParams } from "../api/chat-settings-api";
+import type { InferenceParams } from "../types/runtime";
+
+export type PersistedInferenceParamKey = keyof PersistedInferenceParams;
+
+/** Params that persist across a reload. `checkpoint` names the model, so it is
+ * the key rather than one of the values. */
+export const PERSISTED_INFERENCE_PARAM_KEYS = [
+  "temperature",
+  "topP",
+  "topK",
+  "minP",
+  "repetitionPenalty",
+  "presencePenalty",
+  "maxSeqLength",
+  "maxTokens",
+  "systemPrompt",
+  "systemVariables",
+  "trustRemoteCode",
+  "fastMode",
+] as const satisfies readonly PersistedInferenceParamKey[];
+
+export function setInferenceParam(
+  params: InferenceParams,
+  key: PersistedInferenceParamKey,
+  value: PersistedInferenceParams[PersistedInferenceParamKey],
+): void {
+  (params as Record<PersistedInferenceParamKey, unknown>)[key] = value;
+}
+
+/** The persisted subset of a params object. No version-bumping side effect,
+ * unlike getChangedInferenceParams. */
+export function pickPersistedInferenceParams(
+  params: InferenceParams,
+): PersistedInferenceParams {
+  const picked: PersistedInferenceParams = {};
+  for (const key of PERSISTED_INFERENCE_PARAM_KEYS) {
+    const value = params[key];
+    if (value !== undefined) {
+      setInferenceParam(picked as InferenceParams, key, value);
+    }
+  }
+  return picked;
+}
+
+function hasKeys(value: object): boolean {
+  return Object.keys(value).length > 0;
+}
+
+/** The map after an edit, or null when there is nothing to record (off, no model,
+ * or no persisted param moved). Null leaves the map and its hydration version
+ * untouched. */
+export function getRememberedParamsPatch(
+  enabled: boolean,
+  paramsByModel: Record<string, PersistedInferenceParams>,
+  modelId: string | undefined,
+  changedParams: PersistedInferenceParams,
+): Record<string, PersistedInferenceParams> | null {
+  if (!(enabled && modelId && hasKeys(changedParams))) {
+    return null;
+  }
+  return {
+    ...paramsByModel,
+    // Merge, not replace: an edit reports only the params it moved.
+    [modelId]: { ...paramsByModel[modelId], ...changedParams },
+  };
+}
+
+/** The params a model switch should land on. A model with nothing remembered
+ * keeps what is on screen rather than snapping to defaults. Returns `current` by
+ * identity when nothing was replayed, so callers can tell the two apart. */
+export function getReplayedParams(
+  enabled: boolean,
+  paramsByModel: Record<string, PersistedInferenceParams>,
+  current: InferenceParams,
+  modelId: string,
+  checkpointChanged: boolean,
+): InferenceParams {
+  if (!(enabled && checkpointChanged)) {
+    return current;
+  }
+  const remembered = paramsByModel[modelId];
+  return remembered ? { ...current, ...remembered } : current;
+}

--- a/studio/frontend/src/features/chat/lib/per-model-params.ts
+++ b/studio/frontend/src/features/chat/lib/per-model-params.ts
@@ -64,15 +64,15 @@ export function getRememberedParamsPatch(
   paramsByModel: Record<string, PersistedInferenceParams>,
   modelId: string | undefined,
   changedParams: PersistedInferenceParams,
+  snapshot: PersistedInferenceParams,
 ): Record<string, PersistedInferenceParams> | null {
   if (!(enabled && modelId && hasKeys(changedParams))) {
     return null;
   }
-  return {
-    ...paramsByModel,
-    // Merge, not replace: an edit reports only the params it moved.
-    [modelId]: { ...paramsByModel[modelId], ...changedParams },
-  };
+  // The whole snapshot, not just what moved: replay overlays the entry onto the
+  // outgoing model's params, so a partial entry would leave the gaps filled by
+  // whichever model was on screen last.
+  return { ...paramsByModel, [modelId]: snapshot };
 }
 
 /** The params a model switch should land on. A model with nothing remembered

--- a/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
+++ b/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
@@ -1839,12 +1839,27 @@ export const useChatRuntimeStore = create<ChatRuntimeStore>((set, get) => ({
     set({ modelRequiresTrustRemoteCode }),
   setParams: (params, options) =>
     set((state) => {
+      // Mirror setCheckpoint: the local load path can mutate params.checkpoint
+      // via setParams() before setCheckpoint runs, leaving stale per-turn
+      // counters under the new checkpoint.
+      const checkpointChanged = state.params.checkpoint !== params.checkpoint;
+      // An interactive local load lands here with the destination checkpoint and
+      // the backend's recommended params, and only reaches setCheckpoint later,
+      // once params.checkpoint already matches. Replay here or that switch, the
+      // common one, never restores the model's own settings.
+      const nextParams = getReplayedParams(
+        state.rememberParamsPerModel,
+        state.paramsByModel,
+        params,
+        params.checkpoint,
+        checkpointChanged,
+      );
       // Bump version unconditionally so a late hydration response won't clobber
       // a pre-hydrate user edit; only the HTTP write is gated on settingsHydrated.
-      const changedParams = getChangedInferenceParams(params, state.params);
+      const changedParams = getChangedInferenceParams(nextParams, state.params);
       const queuedSettingsChanged = shouldAdvanceQueuedSettingsEpoch(
         state.params,
-        params,
+        nextParams,
         options?.trackQueuedSettings !== false,
       );
       // An edit belongs to the model the params now describe, so a call that moves
@@ -1853,19 +1868,16 @@ export const useChatRuntimeStore = create<ChatRuntimeStore>((set, get) => ({
         getRememberedParamsPatch(
           state.rememberParamsPerModel,
           state.paramsByModel,
-          params.checkpoint,
+          nextParams.checkpoint,
           changedParams,
+          pickPersistedInferenceParams(nextParams),
         ),
       );
       if (options?.persist !== false && state.settingsHydrated) {
-        persistParamEdit(changedParams, paramsByModel, params.checkpoint);
+        persistParamEdit(changedParams, paramsByModel, nextParams.checkpoint);
       }
-      // Mirror setCheckpoint: the local load path can mutate params.checkpoint
-      // via setParams() before setCheckpoint runs, leaving stale per-turn
-      // counters under the new checkpoint.
-      const checkpointChanged = state.params.checkpoint !== params.checkpoint;
       return {
-        params,
+        params: nextParams,
         ...(paramsByModel ? { paramsByModel } : {}),
         ...(queuedSettingsChanged
           ? { queuedSettingsEpoch: state.queuedSettingsEpoch + 1 }
@@ -2541,12 +2553,14 @@ export const useChatRuntimeStore = create<ChatRuntimeStore>((set, get) => ({
         state.rememberParamsPerModel,
       );
       // Turning it on adopts the settings on screen for the active model.
+      const snapshot = pickPersistedInferenceParams(state.params);
       const paramsByModel = trackParamsByModel(
         getRememberedParamsPatch(
           rememberParamsPerModel,
           state.paramsByModel,
           state.params.checkpoint,
-          pickPersistedInferenceParams(state.params),
+          snapshot,
+          snapshot,
         ),
       );
       if (paramsByModel && state.settingsHydrated && state.params.checkpoint) {

--- a/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
+++ b/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
@@ -29,6 +29,14 @@ import {
 import { normalizePresetLoadConfig } from "../presets/preset-load-config";
 import { getExternalMaxOutputTokens } from "../provider-capabilities";
 import {
+  PERSISTED_INFERENCE_PARAM_KEYS,
+  type PersistedInferenceParamKey,
+  getRememberedParamsPatch,
+  getReplayedParams,
+  pickPersistedInferenceParams,
+  setInferenceParam,
+} from "../lib/per-model-params";
+import {
   type ChatLoraSummary,
   type ChatModelSummary,
   DEFAULT_INFERENCE_PARAMS,
@@ -87,6 +95,8 @@ export type PermissionMode = "ask" | "auto" | "off" | "full";
 export const CHAT_WEB_FETCH_TOOLS_ENABLED_KEY =
   "unsloth_chat_web_fetch_tools_enabled";
 export const CHAT_RAG_SOURCE_KEY = "unsloth_chat_rag_source";
+export const CHAT_PROJECT_ATTACHMENT_TARGET_KEY =
+  "unsloth_chat_project_attachment_target";
 export const CHAT_RAG_MODE_KEY = "unsloth_chat_rag_mode";
 export const CHAT_RAG_TOP_K_KEY = "unsloth_chat_rag_top_k";
 export const CHAT_RAG_AUTOINJECT_KEY = "unsloth_chat_rag_autoinject";
@@ -105,9 +115,17 @@ const PERSISTED_SPEC_MODES = new Set(["auto", "ngram", "off"]);
 
 export type RagSource = { type: "thread" } | { type: "kb"; kbId: string };
 
+/** Where the composer files an attachment in a project chat. `project` indexes
+ * into the project's shared sources; `thread` keeps the file to the one chat.
+ * Ignored outside a project. */
+export type ProjectAttachmentTarget = "project" | "thread";
+
 export type RagMode = "hybrid" | "lexical" | "dense";
 
 export const DEFAULT_RAG_SOURCE: RagSource = { type: "thread" };
+// A project exists to share context, so its chats default to the whole project.
+export const DEFAULT_PROJECT_ATTACHMENT_TARGET: ProjectAttachmentTarget =
+  "project";
 export const DEFAULT_RAG_MODE: RagMode = "hybrid";
 export const DEFAULT_RAG_TOP_K = 5;
 // `auto` forces retrieval for smaller models (<=9B); `on`/`off` force it.
@@ -183,6 +201,14 @@ function saveRagSource(value: RagSource): void {
   } catch {
     // Ignore storage failures; the default RAG source still works for this session.
   }
+}
+
+function loadProjectAttachmentTarget(): ProjectAttachmentTarget {
+  const raw = loadString(
+    CHAT_PROJECT_ATTACHMENT_TARGET_KEY,
+    DEFAULT_PROJECT_ATTACHMENT_TARGET,
+  );
+  return raw === "thread" ? "thread" : DEFAULT_PROJECT_ATTACHMENT_TARGET;
 }
 
 function loadRagMode(): RagMode {
@@ -883,6 +909,9 @@ type ToolStatusEntry = {
 type ChatRuntimeStore = {
   settingsHydrated: boolean;
   params: InferenceParams;
+  /** Last-used sampling params per checkpoint id, replayed on model switch. */
+  paramsByModel: Record<string, PersistedInferenceParams>;
+  rememberParamsPerModel: boolean;
   customPresets: Preset[];
   activePreset: string;
   activePresetSource: ChatPresetSource;
@@ -985,6 +1014,8 @@ type ChatRuntimeStore = {
   mcpEnabledForChat: boolean;
   ragEnabled: boolean;
   ragSource: RagSource;
+  /** Composer attachment scope for chats inside a project. */
+  projectAttachmentTarget: ProjectAttachmentTarget;
   ragMode: RagMode;
   ragTopK: number;
   // autoInject = forced first-pass retrieval before answering.
@@ -1288,7 +1319,9 @@ type ChatRuntimeStore = {
   clearToolConfirmation: (toolCallId: string) => void;
   setWebFetchToolsEnabled: (enabled: boolean) => void;
   setRagEnabled: (enabled: boolean) => void;
+  setRememberParamsPerModel: (enabled: boolean) => void;
   setRagSource: (source: RagSource) => void;
+  setProjectAttachmentTarget: (target: ProjectAttachmentTarget) => void;
   setRagMode: (mode: RagMode) => void;
   setRagTopK: (topK: number) => void;
   setRagAutoInject: (value: RagAutoInject) => void;
@@ -1354,9 +1387,9 @@ type PersistedChatSettings = Awaited<
 type PersistedInferenceParams = NonNullable<
   PersistedChatSettings["inferenceParams"]
 >;
-type PersistedInferenceParamKey = keyof PersistedInferenceParams;
 type ScalarSettingKey =
   | "autoTitle"
+  | "rememberParamsPerModel"
   | "reasoningEffort"
   | "preserveThinking"
   | "collapseHtmlArtifacts"
@@ -1374,27 +1407,14 @@ type PresetHydrationVersions = {
 
 type SettingsHydrationVersions = {
   inferenceParams: Record<PersistedInferenceParamKey, number>;
+  paramsByModel: number;
   scalarSettings: Record<ScalarSettingKey, number>;
   presets: PresetHydrationVersions;
 };
 
-const PERSISTED_INFERENCE_PARAM_KEYS = [
-  "temperature",
-  "topP",
-  "topK",
-  "minP",
-  "repetitionPenalty",
-  "presencePenalty",
-  "maxSeqLength",
-  "maxTokens",
-  "systemPrompt",
-  "systemVariables",
-  "trustRemoteCode",
-  "fastMode",
-] as const satisfies readonly PersistedInferenceParamKey[];
-
 const SCALAR_SETTING_KEYS = [
   "autoTitle",
+  "rememberParamsPerModel",
   "reasoningEffort",
   "preserveThinking",
   "collapseHtmlArtifacts",
@@ -1405,6 +1425,7 @@ const SCALAR_SETTING_KEYS = [
   "toolCallTimeout",
 ] as const satisfies readonly ScalarSettingKey[];
 
+let paramsByModelMutationVersion = 0;
 const inferenceParamMutationVersions = Object.fromEntries(
   PERSISTED_INFERENCE_PARAM_KEYS.map((key) => [key, 0]),
 ) as Record<PersistedInferenceParamKey, number>;
@@ -1419,6 +1440,7 @@ function hasKeys(value: object): boolean {
 function getSettingsHydrationVersions(): SettingsHydrationVersions {
   return {
     inferenceParams: { ...inferenceParamMutationVersions },
+    paramsByModel: paramsByModelMutationVersion,
     scalarSettings: { ...scalarSettingMutationVersions },
     presets: {
       customPresets: customPresetsMutationVersion,
@@ -1426,14 +1448,6 @@ function getSettingsHydrationVersions(): SettingsHydrationVersions {
       activePresetSource: activePresetSourceMutationVersion,
     },
   };
-}
-
-function setInferenceParam(
-  params: InferenceParams,
-  key: PersistedInferenceParamKey,
-  value: PersistedInferenceParams[PersistedInferenceParamKey],
-): void {
-  (params as Record<PersistedInferenceParamKey, unknown>)[key] = value;
 }
 
 function getChangedInferenceParams(
@@ -1452,6 +1466,51 @@ function getChangedInferenceParams(
     }
   }
   return changedParams;
+}
+
+/** Bump the hydration versions for the replayed keys and mirror them into the
+ * global set, so a reload lands on this model's settings. */
+function persistReplayedParams(
+  state: ChatRuntimeStore,
+  nextParams: InferenceParams,
+  replayed: boolean,
+): void {
+  if (!replayed) {
+    return;
+  }
+  const changed = getChangedInferenceParams(nextParams, state.params);
+  if (state.settingsHydrated && hasKeys(changed)) {
+    saveSettingsPatch({ inferenceParams: changed });
+  }
+}
+
+/** Same contract as the inference-param versions: a local edit must not be
+ * clobbered by a hydration response already in flight. */
+function trackParamsByModel(
+  paramsByModel: Record<string, PersistedInferenceParams> | null,
+): Record<string, PersistedInferenceParams> | null {
+  if (paramsByModel) {
+    paramsByModelMutationVersion += 1;
+  }
+  return paramsByModel;
+}
+
+/** Write an edit to the global set, and to the model's own set when one is
+ * selected. Only the touched model is patched, so others are left alone. */
+function persistParamEdit(
+  changedParams: PersistedInferenceParams,
+  paramsByModel: Record<string, PersistedInferenceParams> | null,
+  modelId: string | undefined,
+): void {
+  if (!hasKeys(changedParams)) {
+    return;
+  }
+  saveSettingsPatch({
+    inferenceParams: changedParams,
+    ...(paramsByModel && modelId
+      ? { inferenceParamsByModel: { [modelId]: paramsByModel[modelId] } }
+      : {}),
+  });
 }
 
 function getHydratedCustomPresets(
@@ -1520,6 +1579,12 @@ function getHydratedSettingsState(
     }
   }
   nextState.params = params;
+  if (
+    settings.inferenceParamsByModel !== undefined &&
+    paramsByModelMutationVersion === versions.paramsByModel
+  ) {
+    nextState.paramsByModel = settings.inferenceParamsByModel;
+  }
   for (const key of SCALAR_SETTING_KEYS) {
     const value = settings[key];
     if (
@@ -1555,6 +1620,9 @@ export const useChatRuntimeStore = create<ChatRuntimeStore>((set, get) => ({
       ? { ...DEFAULT_INFERENCE_PARAMS, checkpoint: persistedExternal }
       : DEFAULT_INFERENCE_PARAMS;
   })(),
+  paramsByModel: {},
+  // On by default; a model with nothing remembered keeps the current settings.
+  rememberParamsPerModel: true,
   customPresets: [],
   activePreset: "Default",
   activePresetSource: getPresetSource("Default"),
@@ -1620,6 +1688,7 @@ export const useChatRuntimeStore = create<ChatRuntimeStore>((set, get) => ({
   // RAG is opt-in per session: always starts off, never restored from storage.
   ragEnabled: false,
   ragSource: loadRagSource(),
+  projectAttachmentTarget: loadProjectAttachmentTarget(),
   ragMode: loadRagMode(),
   ragTopK: loadRagTopK(),
   ragAutoInject: loadRagAutoInject(),
@@ -1778,12 +1847,18 @@ export const useChatRuntimeStore = create<ChatRuntimeStore>((set, get) => ({
         params,
         options?.trackQueuedSettings !== false,
       );
-      if (
-        options?.persist !== false &&
-        state.settingsHydrated &&
-        hasKeys(changedParams)
-      ) {
-        saveSettingsPatch({ inferenceParams: changedParams });
+      // An edit belongs to the model the params now describe, so a call that moves
+      // checkpoint and sliders at once files them under the destination.
+      const paramsByModel = trackParamsByModel(
+        getRememberedParamsPatch(
+          state.rememberParamsPerModel,
+          state.paramsByModel,
+          params.checkpoint,
+          changedParams,
+        ),
+      );
+      if (options?.persist !== false && state.settingsHydrated) {
+        persistParamEdit(changedParams, paramsByModel, params.checkpoint);
       }
       // Mirror setCheckpoint: the local load path can mutate params.checkpoint
       // via setParams() before setCheckpoint runs, leaving stale per-turn
@@ -1791,6 +1866,7 @@ export const useChatRuntimeStore = create<ChatRuntimeStore>((set, get) => ({
       const checkpointChanged = state.params.checkpoint !== params.checkpoint;
       return {
         params,
+        ...(paramsByModel ? { paramsByModel } : {}),
         ...(queuedSettingsChanged
           ? { queuedSettingsEpoch: state.queuedSettingsEpoch + 1 }
           : {}),
@@ -1968,10 +2044,17 @@ export const useChatRuntimeStore = create<ChatRuntimeStore>((set, get) => ({
       // Clear stale per-turn usage on model change; the relaxed external-provider
       // render gate would otherwise show old counters until the next completion.
       const checkpointChanged = state.params.checkpoint !== modelId;
+      const baseParams = getReplayedParams(
+        state.rememberParamsPerModel,
+        state.paramsByModel,
+        state.params,
+        modelId,
+        checkpointChanged,
+      );
       // Clamp maxTokens to the new model's cap when switching into an external
       // model so a value carried over from a local session doesn't exceed the
       // slider's max.
-      let nextMaxTokens = state.params.maxTokens;
+      let nextMaxTokens = baseParams.maxTokens;
       if (checkpointChanged && isExternalModelId(modelId)) {
         const parsed = parseExternalModelId(modelId);
         const provider = parsed
@@ -2013,12 +2096,14 @@ export const useChatRuntimeStore = create<ChatRuntimeStore>((set, get) => ({
         },
         options?.trackQueuedSettings !== false,
       );
+      const nextParams = {
+        ...baseParams,
+        checkpoint: modelId,
+        maxTokens: nextMaxTokens,
+      };
+      persistReplayedParams(state, nextParams, baseParams !== state.params);
       return {
-        params: {
-          ...state.params,
-          checkpoint: modelId,
-          maxTokens: nextMaxTokens,
-        },
+        params: nextParams,
         activeGgufVariant: nextGgufVariant,
         ...(queuedSettingsChanged
           ? { queuedSettingsEpoch: state.queuedSettingsEpoch + 1 }
@@ -2448,6 +2533,39 @@ export const useChatRuntimeStore = create<ChatRuntimeStore>((set, get) => ({
       ragEnabled,
       queuedSettingsEpoch: state.queuedSettingsEpoch + 1,
     })),
+  setRememberParamsPerModel: (rememberParamsPerModel) =>
+    set((state) => {
+      setScalarSettingVersion(
+        "rememberParamsPerModel",
+        rememberParamsPerModel,
+        state.rememberParamsPerModel,
+      );
+      // Turning it on adopts the settings on screen for the active model.
+      const paramsByModel = trackParamsByModel(
+        getRememberedParamsPatch(
+          rememberParamsPerModel,
+          state.paramsByModel,
+          state.params.checkpoint,
+          pickPersistedInferenceParams(state.params),
+        ),
+      );
+      if (paramsByModel && state.settingsHydrated && state.params.checkpoint) {
+        saveSettingsPatch({
+          inferenceParamsByModel: {
+            [state.params.checkpoint]: paramsByModel[state.params.checkpoint],
+          },
+        });
+      }
+      return {
+        rememberParamsPerModel,
+        ...(paramsByModel ? { paramsByModel } : {}),
+      };
+    }),
+  setProjectAttachmentTarget: (projectAttachmentTarget) =>
+    set(() => {
+      saveString(CHAT_PROJECT_ATTACHMENT_TARGET_KEY, projectAttachmentTarget);
+      return { projectAttachmentTarget };
+    }),
   setRagSource: (ragSource) =>
     set((state) => {
       saveRagSource(ragSource);

--- a/studio/frontend/src/features/chat/utils/chat-settings-storage.ts
+++ b/studio/frontend/src/features/chat/utils/chat-settings-storage.ts
@@ -152,6 +152,24 @@ function sanitizeInferenceParams(
   return hasKeys(params) ? params : undefined;
 }
 
+// The server merge never removes keys, so this load-time trim is what bounds the
+// map. Insertion order is preserved, so it drops the longest-known models first.
+const MAX_REMEMBERED_MODELS = 100;
+
+function sanitizeInferenceParamsByModel(
+  value: unknown,
+): Record<string, PersistedInferenceParams> | undefined {
+  if (!isRecord(value)) return undefined;
+  const byModel: Record<string, PersistedInferenceParams> = {};
+  const entries = Object.entries(value).slice(-MAX_REMEMBERED_MODELS);
+  for (const [modelId, params] of entries) {
+    if (!modelId) continue;
+    const sanitized = sanitizeInferenceParams(params);
+    if (sanitized) byModel[modelId] = sanitized;
+  }
+  return hasKeys(byModel) ? byModel : undefined;
+}
+
 function toFullPreset(preset: PersistedChatPreset): Preset {
   const loadConfig = normalizePresetLoadConfig(preset.loadConfig);
   return {
@@ -223,6 +241,10 @@ function sanitizeChatSettings(value: unknown): PersistedChatSettings {
 
   const settings: PersistedChatSettings = {};
   const inferenceParams = sanitizeInferenceParams(value.inferenceParams);
+  const inferenceParamsByModel = sanitizeInferenceParamsByModel(
+    value.inferenceParamsByModel,
+  );
+  const rememberParamsPerModel = sanitizeBool(value.rememberParamsPerModel);
   const customPresets = sanitizeCustomPresets(value.customPresets);
   const activePresetSource = sanitizePresetSource(value.activePresetSource);
   const reasoningEffort = sanitizeReasoningEffort(value.reasoningEffort);
@@ -238,6 +260,12 @@ function sanitizeChatSettings(value: unknown): PersistedChatSettings {
   const toolCallTimeout = sanitizeInt(value.toolCallTimeout, 1);
 
   if (inferenceParams) settings.inferenceParams = inferenceParams;
+  if (inferenceParamsByModel) {
+    settings.inferenceParamsByModel = inferenceParamsByModel;
+  }
+  if (rememberParamsPerModel !== undefined) {
+    settings.rememberParamsPerModel = rememberParamsPerModel;
+  }
   if (customPresets !== undefined) settings.customPresets = customPresets;
   if (typeof value.activePreset === "string" && value.activePreset.trim()) {
     settings.activePreset = value.activePreset.trim();
@@ -310,6 +338,8 @@ function loadLegacySystemPromptPresets(
 export function isEmptyChatSettings(settings: PersistedChatSettings): boolean {
   return (
     (!settings.inferenceParams || !hasKeys(settings.inferenceParams)) &&
+    settings.inferenceParamsByModel === undefined &&
+    settings.rememberParamsPerModel === undefined &&
     settings.customPresets === undefined &&
     settings.activePreset === undefined &&
     settings.activePresetSource === undefined &&

--- a/studio/frontend/src/features/rag/components/document-status-chip.tsx
+++ b/studio/frontend/src/features/rag/components/document-status-chip.tsx
@@ -4,7 +4,7 @@
 import { Badge } from "@/components/assistant-ui/badge";
 import { Spinner } from "@/components/ui/spinner";
 import { cn } from "@/lib/utils";
-import { File02Icon } from "@hugeicons/core-free-icons";
+import { File02Icon, Folder02Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { XIcon } from "lucide-react";
 import type { DocumentStatus } from "../types/rag";
@@ -15,27 +15,36 @@ export function DocumentStatusChip({
   progress,
   error,
   onRemove,
+  shared = false,
 }: {
   filename: string;
   status: DocumentStatus;
   progress?: number | null;
   error?: string | null;
   onRemove?: () => void;
+  /** Indexed for the whole project rather than this one chat: swap the file
+   * glyph for a folder so the two scopes are told apart at a glance. */
+  shared?: boolean;
 }) {
   const processing = status === "pending" || status === "running";
   return (
     <Badge
       variant="outline"
       size="sm"
-      title={error ?? filename}
+      title={
+        error ??
+        (shared
+          ? `${filename} — shared with every chat in this project`
+          : filename)
+      }
       className={cn(
         "rounded-full inline-flex items-center gap-1.5 max-w-[16rem]",
         status === "failed" && "border-destructive/40 text-destructive",
       )}
     >
-      {/* file */}
+      {/* file, or folder when the doc is a project-wide source */}
       <HugeiconsIcon
-        icon={File02Icon}
+        icon={shared ? Folder02Icon : File02Icon}
         strokeWidth={2}
         className="size-3 shrink-0"
       />

--- a/studio/frontend/src/features/rag/components/thread-documents-bar.tsx
+++ b/studio/frontend/src/features/rag/components/thread-documents-bar.tsx
@@ -3,10 +3,18 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { AttachmentIcon, FileDatabaseIcon } from "@hugeicons/core-free-icons";
+import {
+  AttachmentIcon,
+  FileDatabaseIcon,
+  Folder02Icon,
+} from "@hugeicons/core-free-icons";
+import { Tick02Icon } from "@/lib/tick-icon";
 import { useAui } from "@assistant-ui/react";
 import { cn } from "@/lib/utils";
-import { useChatRuntimeStore } from "@/features/chat/stores/chat-runtime-store";
+import {
+  type ProjectAttachmentTarget,
+  useChatRuntimeStore,
+} from "@/features/chat/stores/chat-runtime-store";
 import {
   chatHistoryClearBoundary,
   ChatThreadDeletedError,
@@ -18,8 +26,20 @@ import {
   useNativeIntentStore,
 } from "@/features/native-intents";
 import { toast } from "@/lib/toast";
-import { listKnowledgeBases, listThreadDocuments } from "../api/rag-api";
-import { RAG_UPLOAD_ACCEPT } from "../types/rag";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  invalidateProjectSources,
+  listKnowledgeBases,
+  listProjectDocuments,
+  listThreadDocuments,
+} from "../api/rag-api";
+import { RAG_UPLOAD_ACCEPT, isLinkedFolderManaged } from "../types/rag";
 import { DocumentStatusChip } from "./document-status-chip";
 import { useRagDocuments } from "./use-rag-documents";
 
@@ -80,6 +100,116 @@ async function requireStoredThread(threadId: string): Promise<void> {
   }
 }
 
+/** The composer's attach control. Wording and glyph follow the active target, so
+ * a project chat says up front where the file is going. */
+function AttachFilesButton({
+  disabled,
+  compact,
+  sharesWithProject,
+  onClick,
+}: {
+  disabled: boolean;
+  /** Icon-only once documents are attached, to leave the chips room. */
+  compact: boolean;
+  sharesWithProject: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      className={cn(
+        "composer-pill-btn shrink-0 -translate-y-px !text-foreground/80",
+        // Square button so the rounded-full hover reads as a circle.
+        compact && "size-8 justify-center px-0",
+      )}
+      aria-label={
+        sharesWithProject
+          ? "Attach documents to this project"
+          : "Attach documents to this thread"
+      }
+      title={
+        sharesWithProject
+          ? "Attach documents for retrieval, shared with every chat in this project"
+          : "Attach documents for retrieval in this chat"
+      }
+    >
+      <HugeiconsIcon
+        icon={sharesWithProject ? Folder02Icon : AttachmentIcon}
+        strokeWidth={2}
+        className="size-3.5"
+      />
+      {compact ? null : (
+        <span>
+          {sharesWithProject
+            ? "Add files for this project"
+            : "Add files to chat with"}
+        </span>
+      )}
+    </button>
+  );
+}
+
+/** Picks whether new attachments go to the project (shared with every chat in it)
+ * or to this chat alone. Only a project chat has the choice. */
+function AttachmentTargetMenu({
+  disabled,
+  sharesWithProject,
+  onSelect,
+}: {
+  disabled: boolean;
+  sharesWithProject: boolean;
+  onSelect: (target: ProjectAttachmentTarget) => void;
+}) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild={true}>
+        <button
+          type="button"
+          disabled={disabled}
+          aria-label="Choose where attached files go"
+          title="Choose where attached files go"
+          className="composer-pill-btn shrink-0 -translate-y-px !text-foreground/60 px-2"
+        >
+          <span className="text-ui-11">
+            {sharesWithProject ? "Project" : "This chat"}
+          </span>
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="unsloth-plus-menu w-64">
+        <DropdownMenuLabel>New files go to</DropdownMenuLabel>
+        <DropdownMenuItem onSelect={() => onSelect("project")}>
+          <HugeiconsIcon
+            icon={sharesWithProject ? Tick02Icon : Folder02Icon}
+            strokeWidth={1.75}
+            className="size-icon"
+          />
+          <span className="flex flex-col">
+            <span>The project</span>
+            <span className="text-ui-11 text-muted-foreground">
+              Every chat in this project can use them
+            </span>
+          </span>
+        </DropdownMenuItem>
+        <DropdownMenuItem onSelect={() => onSelect("thread")}>
+          <HugeiconsIcon
+            icon={sharesWithProject ? AttachmentIcon : Tick02Icon}
+            strokeWidth={1.75}
+            className="size-icon"
+          />
+          <span className="flex flex-col">
+            <span>This chat only</span>
+            <span className="text-ui-11 text-muted-foreground">
+              Other chats in the project won't see them
+            </span>
+          </span>
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
 export function ThreadDocumentsBar({
   threadId,
   onIndexingChange,
@@ -91,7 +221,20 @@ export function ThreadDocumentsBar({
   const ragSource = useChatRuntimeStore((s) => s.ragSource);
   const setRagSource = useChatRuntimeStore((s) => s.setRagSource);
   const setRagEnabled = useChatRuntimeStore((s) => s.setRagEnabled);
+  // activeProjectId is set by the chat page from the thread's own row, so it is
+  // null for every chat with no project.
+  const activeProjectId = useChatRuntimeStore((s) => s.activeProjectId);
+  const projectAttachmentTarget = useChatRuntimeStore(
+    (s) => s.projectAttachmentTarget,
+  );
+  const setProjectAttachmentTarget = useChatRuntimeStore(
+    (s) => s.setProjectAttachmentTarget,
+  );
   const aui = useAui();
+  // A KB-scoped chat uploads through the KB dialog, so neither scope applies there.
+  const projectId = ragSource.type === "kb" ? null : activeProjectId;
+  const sharesWithProject =
+    projectId !== null && projectAttachmentTarget === "project";
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   // A fresh chat has no thread id until the first message; materialize one on demand
@@ -124,10 +267,27 @@ export function ThreadDocumentsBar({
     lister,
   );
 
+  // The project's shared sources, listed alongside this chat's own so a file added
+  // from another chat is visible rather than silently in effect. Retrieval already
+  // combines both scopes (core/rag/tool.py).
+  const projectLister = useCallback(
+    () => (projectId ? listProjectDocuments(projectId) : Promise.resolve([])),
+    [projectId],
+  );
+  const {
+    documents: projectDocuments,
+    uploading: projectUploading,
+    upload: uploadToProject,
+    remove: removeFromProject,
+  } = useRagDocuments(
+    projectId && ragEnabled ? { type: "project", projectId } : null,
+    projectLister,
+  );
+
   // Tell the composer whether any doc is still indexing, so it can hold a queued
   // send until retrieval covers them (Composer.enqueueSend). For KB / RAG-off scope
-  // is null, so `documents` is empty and this reads false.
-  const hasIndexing = documents.some(
+  // is null, so both lists are empty and this reads false.
+  const hasIndexing = [...documents, ...projectDocuments].some(
     (d) => d.status === "pending" || d.status === "running",
   );
   useEffect(() => {
@@ -182,6 +342,29 @@ export function ThreadDocumentsBar({
     return pending;
   }, [aui, effectiveThreadId]);
 
+  // One entry point for the picker and desktop drops: project files go straight to
+  // the project, per-chat files materialize the thread first. The sources probe
+  // caches for 30s, so invalidate both sides of a project upload or a message sent
+  // mid-index keeps answering from a cached "no sources".
+  const attach = useCallback(
+    (items: Parameters<typeof upload>[0]) => {
+      if (sharesWithProject && projectId) {
+        invalidateProjectSources(projectId);
+        void uploadToProject(items).finally(() =>
+          invalidateProjectSources(projectId),
+        );
+        return;
+      }
+      // Pass the id as a promise so upload() flips its in-flight guard before
+      // materialization re-renders us; on the first click `scope` is still null.
+      const threadScope = ensureThreadId().then((id) =>
+        id ? ({ type: "thread", threadId: id } as const) : null,
+      );
+      void upload(items, threadScope);
+    },
+    [ensureThreadId, projectId, sharesWithProject, upload, uploadToProject],
+  );
+
   // Desktop drops land in the native-intent store because the drop listener lives on
   // the chat page; only the chat that received the OS drop may drain its batch.
   const nativeAttachmentTargetKey = useNativeAttachmentTargetKey();
@@ -213,7 +396,7 @@ export function ThreadDocumentsBar({
       setRagSource({ type: "thread" });
       setRagEnabled(true);
     }
-    void upload(
+    attach(
       intents.map((intent) => ({
         kind: "native" as const,
         token: intent.path.token,
@@ -221,15 +404,11 @@ export function ThreadDocumentsBar({
         sizeBytes: intent.path.sizeBytes,
         modifiedMs: intent.path.modifiedMs,
       })),
-      ensureThreadId().then((id) =>
-        id ? ({ type: "thread", threadId: id } as const) : null,
-      ),
     );
   }, [
     hasPendingAttachments,
     nativeAttachmentTargetKey,
-    upload,
-    ensureThreadId,
+    attach,
     ragEnabled,
     ragSource,
     setRagSource,
@@ -262,28 +441,25 @@ export function ThreadDocumentsBar({
     return <KnowledgeBaseSourceChip kbId={ragSource.kbId} />;
   }
 
+  const busy = uploading || projectUploading;
+  const chipCount = documents.length + projectDocuments.length;
+
   return (
     <div className="mb-2 flex w-full flex-row items-start gap-1.5 pl-0.5 pr-1.5 pt-0.5 pb-1">
-      <button
-        type="button"
+      <AttachFilesButton
+        disabled={busy}
+        compact={chipCount > 0}
+        sharesWithProject={sharesWithProject}
         onClick={handleAddDocs}
-        disabled={uploading}
-        className={cn(
-          "composer-pill-btn shrink-0 -translate-y-px !text-foreground/80",
-          // Square button so the rounded-full hover reads as a circle.
-          documents.length > 0 && "size-8 justify-center px-0",
-        )}
-        aria-label="Attach documents to this thread"
-        title="Attach documents for retrieval"
-      >
-        <HugeiconsIcon
-          icon={AttachmentIcon}
-          strokeWidth={2}
-          className="size-3.5"
+      />
+      {/* Only a project chat has two scopes to choose between. */}
+      {projectId ? (
+        <AttachmentTargetMenu
+          disabled={busy}
+          sharesWithProject={sharesWithProject}
+          onSelect={setProjectAttachmentTarget}
         />
-        {/* Icon-only once documents are attached. */}
-        {documents.length === 0 && <span>Add files to chat with</span>}
-      </button>
+      ) : null}
       <input
         ref={fileInputRef}
         type="file"
@@ -294,14 +470,7 @@ export function ThreadDocumentsBar({
           const files = Array.from(e.target.files ?? []);
           e.target.value = "";
           if (files.length === 0) return;
-          // Pass the id as a promise so upload() flips its in-flight guard before
-          // materialization re-renders us; on the first click `scope` is still null.
-          void upload(
-            files,
-            ensureThreadId().then((id) =>
-              id ? ({ type: "thread", threadId: id } as const) : null,
-            ),
-          );
+          attach(files);
         }}
       />
       {/* Cap height so a large set scrolls; fade the cut-off row. */}
@@ -313,6 +482,22 @@ export function ThreadDocumentsBar({
           chipsOverflow && "rag-docs-bottom-fade",
         )}
       >
+        {/* Project sources first: inherited context, and it outlives this chat. */}
+        {projectDocuments.map((doc) => (
+          <DocumentStatusChip
+            key={`project:${doc.id}`}
+            filename={doc.filename}
+            status={doc.status}
+            progress={doc.progress}
+            error={doc.error}
+            shared={true}
+            onRemove={
+              doc.id.startsWith("pending_") || isLinkedFolderManaged(doc)
+                ? undefined
+                : () => void removeFromProject(doc.id)
+            }
+          />
+        ))}
         {documents.map((doc) => (
           <DocumentStatusChip
             key={doc.id}

--- a/studio/frontend/src/features/rag/components/thread-documents-bar.tsx
+++ b/studio/frontend/src/features/rag/components/thread-documents-bar.tsx
@@ -19,6 +19,7 @@ import {
   chatHistoryClearBoundary,
   ChatThreadDeletedError,
   ensureStoredChatThread,
+  getStoredChatThread,
   isThreadIncognito,
 } from "@/features/chat";
 import {
@@ -39,7 +40,11 @@ import {
   listProjectDocuments,
   listThreadDocuments,
 } from "../api/rag-api";
-import { RAG_UPLOAD_ACCEPT, isLinkedFolderManaged } from "../types/rag";
+import {
+  type DocumentStatus,
+  RAG_UPLOAD_ACCEPT,
+  isLinkedFolderManaged,
+} from "../types/rag";
 import { DocumentStatusChip } from "./document-status-chip";
 import { useRagDocuments } from "./use-rag-documents";
 
@@ -98,6 +103,91 @@ async function requireStoredThread(threadId: string): Promise<void> {
   if (!stored) {
     throw new Error(`Thread ${threadId} was not persisted`);
   }
+}
+
+/** Read-only listing of the project's sources, shown when the Docs pill is off:
+ * they still reach the model, so they must not be invisible. */
+function InheritedProjectSources({
+  documents,
+}: {
+  documents: { id: string; filename: string; status: DocumentStatus }[];
+}) {
+  return (
+    <div className="mb-2 flex w-full flex-row items-center gap-1.5 pl-0.5 pr-1.5 pt-0.5 pb-1">
+      <span
+        className="composer-pill-btn shrink-0 cursor-default !text-foreground/60"
+        title="This chat retrieves from its project's sources. Manage them in the project's Sources tab."
+      >
+        <HugeiconsIcon icon={Folder02Icon} strokeWidth={2} className="size-3.5" />
+        <span>Project sources</span>
+      </span>
+      <div className="flex flex-1 flex-row flex-wrap items-center gap-1.5">
+        {documents.map((doc) => (
+          <DocumentStatusChip
+            key={`inherited:${doc.id}`}
+            filename={doc.filename}
+            status={doc.status}
+            shared={true}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * The project the displayed chat belongs to. Read from the chat's own row, not
+ * the global activeProjectId: the chat page updates that only after its own
+ * async lookup, so during a navigation it still names the project the user just
+ * left. Null while unresolved, which suppresses the project affordances rather
+ * than pointing them at the wrong project.
+ */
+function useThreadProjectId(threadId: string | null): string | null {
+  const activeProjectId = useChatRuntimeStore((s) => s.activeProjectId);
+  const [resolved, setResolved] = useState<{
+    threadId: string;
+    projectId: string | null;
+  } | null>(null);
+
+  useEffect(() => {
+    if (!threadId || isThreadIncognito(threadId)) {
+      return;
+    }
+    let cancelled = false;
+    getStoredChatThread(threadId).then(
+      (thread) => {
+        if (cancelled) {
+          return;
+        }
+        // No row yet: initialize() does not await the write, so the composer's
+        // project is the answer that row is about to record.
+        const projectId = thread
+          ? (thread.projectId ?? null)
+          : useChatRuntimeStore.getState().activeProjectId;
+        setResolved({ threadId, projectId });
+      },
+      // A failed lookup is not proof of no project, but it is no basis for
+      // filing a file into one either.
+      () => {
+        if (!cancelled) {
+          setResolved({ threadId, projectId: null });
+        }
+      },
+    );
+    return () => {
+      cancelled = true;
+    };
+  }, [threadId]);
+
+  // A chat with no id yet is the one being composed, so it belongs to whatever
+  // project the composer is in.
+  if (!threadId) {
+    return activeProjectId;
+  }
+  if (isThreadIncognito(threadId)) {
+    return null;
+  }
+  return resolved?.threadId === threadId ? resolved.projectId : null;
 }
 
 /** The composer's attach control. Wording and glyph follow the active target, so
@@ -221,9 +311,6 @@ export function ThreadDocumentsBar({
   const ragSource = useChatRuntimeStore((s) => s.ragSource);
   const setRagSource = useChatRuntimeStore((s) => s.setRagSource);
   const setRagEnabled = useChatRuntimeStore((s) => s.setRagEnabled);
-  // activeProjectId is set by the chat page from the thread's own row, so it is
-  // null for every chat with no project.
-  const activeProjectId = useChatRuntimeStore((s) => s.activeProjectId);
   const projectAttachmentTarget = useChatRuntimeStore(
     (s) => s.projectAttachmentTarget,
   );
@@ -231,10 +318,6 @@ export function ThreadDocumentsBar({
     (s) => s.setProjectAttachmentTarget,
   );
   const aui = useAui();
-  // A KB-scoped chat uploads through the KB dialog, so neither scope applies there.
-  const projectId = ragSource.type === "kb" ? null : activeProjectId;
-  const sharesWithProject =
-    projectId !== null && projectAttachmentTarget === "project";
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   // A fresh chat has no thread id until the first message; materialize one on demand
@@ -252,6 +335,14 @@ export function ThreadDocumentsBar({
       initPromiseRef.current = null;
     }
   }, [threadId]);
+
+  // Mirrors chat-adapter's rag_scope: an active KB replaces the project scope,
+  // but a KB preference left over while the pill is off does not.
+  const threadProjectId = useThreadProjectId(effectiveThreadId);
+  const projectId =
+    ragEnabled && ragSource.type === "kb" ? null : threadProjectId;
+  const sharesWithProject =
+    projectId !== null && projectAttachmentTarget === "project";
 
   const lister = useCallback(
     () =>
@@ -280,7 +371,7 @@ export function ThreadDocumentsBar({
     upload: uploadToProject,
     remove: removeFromProject,
   } = useRagDocuments(
-    projectId && ragEnabled ? { type: "project", projectId } : null,
+    projectId ? { type: "project", projectId } : null,
     projectLister,
   );
 
@@ -350,7 +441,9 @@ export function ThreadDocumentsBar({
     (items: Parameters<typeof upload>[0]) => {
       if (sharesWithProject && projectId) {
         invalidateProjectSources(projectId);
-        void uploadToProject(items).finally(() =>
+        // Explicit scope: a desktop drop enables RAG and attaches in the same
+        // tick, so the hook's own scope is still null on this render.
+        void uploadToProject(items, { type: "project", projectId }).finally(() =>
           invalidateProjectSources(projectId),
         );
         return;
@@ -433,12 +526,18 @@ export function ThreadDocumentsBar({
     fileInputRef.current?.click();
   }, []);
 
-  // Shown whenever the RAG pill is on: ingestion only needs the embedder, so
-  // files can index before a chat model loads.
-  if (!ragEnabled) return null;
   // A KB source uploads via the KB dialog, not here; show which KB is active.
-  if (ragSource.type === "kb") {
+  if (ragEnabled && ragSource.type === "kb") {
     return <KnowledgeBaseSourceChip kbId={ragSource.kbId} />;
+  }
+  // Project sources retrieve whenever the project has them, Docs pill or not
+  // (chat-adapter's projectRagEnabled), so keep them listed with the pill off
+  // rather than letting the model answer from files the user cannot see. The
+  // attach controls stay behind the pill: with it off, thread scope is inert.
+  if (!ragEnabled) {
+    return projectDocuments.length > 0 ? (
+      <InheritedProjectSources documents={projectDocuments} />
+    ) : null;
   }
 
   const busy = uploading || projectUploading;

--- a/studio/frontend/src/features/settings/settings-search.ts
+++ b/studio/frontend/src/features/settings/settings-search.ts
@@ -91,6 +91,8 @@ export const SETTINGS_SEARCH_INDEX: Record<SettingsTab, TranslationKey[]> = {
   chat: [
     "settings.general.chatDefaults",
     "settings.general.autoTitleNewChats",
+    "settings.chat.rememberParamsPerModel",
+    "settings.chat.projectAttachments",
     "settings.profile.greetingSloth",
     "settings.chat.thinking.collapseByDefault",
     "settings.chat.artifacts.title",

--- a/studio/frontend/src/features/settings/tabs/chat-tab.tsx
+++ b/studio/frontend/src/features/settings/tabs/chat-tab.tsx
@@ -124,6 +124,18 @@ export function ChatTab() {
   const togglePlusPin = usePlusMenuPrefsStore((state) => state.togglePin);
   const autoTitle = useChatRuntimeStore((state) => state.autoTitle);
   const setAutoTitle = useChatRuntimeStore((state) => state.setAutoTitle);
+  const rememberParamsPerModel = useChatRuntimeStore(
+    (state) => state.rememberParamsPerModel,
+  );
+  const setRememberParamsPerModel = useChatRuntimeStore(
+    (state) => state.setRememberParamsPerModel,
+  );
+  const projectAttachmentTarget = useChatRuntimeStore(
+    (state) => state.projectAttachmentTarget,
+  );
+  const setProjectAttachmentTarget = useChatRuntimeStore(
+    (state) => state.setProjectAttachmentTarget,
+  );
   const showGreetingSloth = useUserProfileStore((s) => s.showGreetingSloth);
   const setShowGreetingSloth = useUserProfileStore(
     (s) => s.setShowGreetingSloth,
@@ -274,6 +286,26 @@ export function ChatTab() {
           description={t("settings.general.autoTitleNewChatsDescription")}
         >
           <Switch checked={autoTitle} onCheckedChange={setAutoTitle} />
+        </SettingsRow>
+        <SettingsRow
+          label={t("settings.chat.rememberParamsPerModel")}
+          description={t("settings.chat.rememberParamsPerModelDescription")}
+        >
+          <Switch
+            checked={rememberParamsPerModel}
+            onCheckedChange={setRememberParamsPerModel}
+          />
+        </SettingsRow>
+        <SettingsRow
+          label={t("settings.chat.projectAttachments")}
+          description={t("settings.chat.projectAttachmentsDescription")}
+        >
+          <Switch
+            checked={projectAttachmentTarget === "project"}
+            onCheckedChange={(checked) =>
+              setProjectAttachmentTarget(checked ? "project" : "thread")
+            }
+          />
         </SettingsRow>
         <SettingsRow
           label={t("settings.profile.greetingSloth")}

--- a/studio/frontend/src/i18n/locales/en.ts
+++ b/studio/frontend/src/i18n/locales/en.ts
@@ -925,6 +925,12 @@ export const en = {
       modelDisclaimer: "Show model disclaimer",
       modelDisclaimerDescription:
         'Show "LLMs can make mistakes" under the chat box.',
+      rememberParamsPerModel: "Remember settings per model",
+      rememberParamsPerModelDescription:
+        "Switching models restores the temperature, prompt and other settings you last used with that model. Off keeps one set of settings for every model.",
+      projectAttachments: "Share files across a project",
+      projectAttachmentsDescription:
+        "Files attached in a chat that belongs to a project are indexed for the whole project, so every chat in it can use them. Change it per chat from the attach menu.",
       thinking: {
         collapseByDefault: "Collapse Thinking by default",
         collapseByDefaultDescription:

--- a/studio/frontend/tests/per-model-params.test.ts
+++ b/studio/frontend/tests/per-model-params.test.ts
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// Chat settings hold one set of sampling params, so switching models used to hand
+// the next model the previous one's temperature and system prompt. These pin the
+// rules the per-model memory follows, including the cases where it must NOT act:
+// a model with nothing remembered keeps what is on screen, and an edit that moved
+// nothing must not mark the map dirty.
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  PERSISTED_INFERENCE_PARAM_KEYS,
+  getRememberedParamsPatch,
+  getReplayedParams,
+  pickPersistedInferenceParams,
+} from "../src/features/chat/lib/per-model-params.ts";
+import type { InferenceParams } from "../src/features/chat/types/runtime.ts";
+
+const QWEN = "unsloth/Qwen3.5-9B-GGUF";
+const LLAMA = "unsloth/Llama-4-8B";
+
+function params(overrides: Partial<InferenceParams> = {}): InferenceParams {
+  return {
+    checkpoint: QWEN,
+    temperature: 0.7,
+    topP: 0.95,
+    topK: 40,
+    minP: 0.05,
+    repetitionPenalty: 1,
+    presencePenalty: 0,
+    maxSeqLength: 4096,
+    maxTokens: 2048,
+    systemPrompt: "",
+    systemVariables: "",
+    ...overrides,
+  } as InferenceParams;
+}
+
+test("an edit is filed against the model it was made for", () => {
+  const next = getRememberedParamsPatch(true, {}, QWEN, { temperature: 0.2 });
+  assert.deepEqual(next, { [QWEN]: { temperature: 0.2 } });
+});
+
+test("a later edit merges into the same model rather than replacing it", () => {
+  const first = getRememberedParamsPatch(true, {}, QWEN, { temperature: 0.2 });
+  assert.ok(first);
+  const second = getRememberedParamsPatch(true, first, QWEN, {
+    systemPrompt: "Be terse.",
+  });
+  assert.deepEqual(second, {
+    [QWEN]: { temperature: 0.2, systemPrompt: "Be terse." },
+  });
+});
+
+test("editing one model leaves every other model's memory alone", () => {
+  const before = { [LLAMA]: { temperature: 0.9 } };
+  const after = getRememberedParamsPatch(true, before, QWEN, {
+    temperature: 0.2,
+  });
+  assert.deepEqual(after, {
+    [LLAMA]: { temperature: 0.9 },
+    [QWEN]: { temperature: 0.2 },
+  });
+  // The input map is not mutated: the store compares by identity to decide
+  // whether anything has to be persisted.
+  assert.deepEqual(before, { [LLAMA]: { temperature: 0.9 } });
+});
+
+// Null is how the store leaves the map and its hydration version untouched.
+test("nothing is recorded when there is nothing to record", () => {
+  assert.equal(
+    getRememberedParamsPatch(false, {}, QWEN, { temperature: 0.2 }),
+    null,
+    "the feature being off records nothing",
+  );
+  assert.equal(
+    getRememberedParamsPatch(true, {}, undefined, { temperature: 0.2 }),
+    null,
+    "no model selected records nothing",
+  );
+  assert.equal(
+    getRememberedParamsPatch(true, {}, "", { temperature: 0.2 }),
+    null,
+    "an empty checkpoint is not a model id",
+  );
+  assert.equal(
+    getRememberedParamsPatch(true, {}, QWEN, {}),
+    null,
+    "an edit that moved no persisted param records nothing",
+  );
+});
+
+test("switching models replays that model's own settings", () => {
+  const current = params({ temperature: 0.7, systemPrompt: "" });
+  const replayed = getReplayedParams(
+    true,
+    { [LLAMA]: { temperature: 0.1, systemPrompt: "Be terse." } },
+    current,
+    LLAMA,
+    true,
+  );
+  assert.equal(replayed.temperature, 0.1);
+  assert.equal(replayed.systemPrompt, "Be terse.");
+  // Params the model never pinned carry over rather than snapping to defaults.
+  assert.equal(replayed.topP, current.topP);
+});
+
+test("a model with nothing remembered keeps the settings on screen", () => {
+  const current = params({ temperature: 0.33 });
+  const replayed = getReplayedParams(true, {}, current, LLAMA, true);
+  assert.equal(replayed, current, "returned by identity, so nothing persists");
+});
+
+test("re-selecting the same model does not replay over a live edit", () => {
+  const current = params({ temperature: 0.33 });
+  // checkpointChanged=false: the user just nudged a slider, and replaying the
+  // stored value here would undo the edit they are making.
+  const replayed = getReplayedParams(
+    true,
+    { [QWEN]: { temperature: 0.9 } },
+    current,
+    QWEN,
+    false,
+  );
+  assert.equal(replayed, current);
+});
+
+test("the feature being off leaves a model switch alone", () => {
+  const current = params({ temperature: 0.33 });
+  const replayed = getReplayedParams(
+    false,
+    { [LLAMA]: { temperature: 0.9 } },
+    current,
+    LLAMA,
+    true,
+  );
+  assert.equal(replayed, current);
+});
+
+// Turning the setting on adopts what is on screen for the active model, so the
+// first switch away and back returns to it rather than to nothing.
+test("the persisted snapshot covers every persisted key and excludes the checkpoint", () => {
+  const picked = pickPersistedInferenceParams(params());
+  assert.equal(
+    "checkpoint" in picked,
+    false,
+    "the checkpoint names the model, it is not one of the values",
+  );
+  for (const key of PERSISTED_INFERENCE_PARAM_KEYS) {
+    if (params()[key] !== undefined) {
+      assert.ok(key in picked, `${key} should be captured`);
+    }
+  }
+});
+
+test("the snapshot drops params the current model never set", () => {
+  const picked = pickPersistedInferenceParams(
+    params({ topK: undefined as unknown as number }),
+  );
+  assert.equal("topK" in picked, false);
+});

--- a/studio/frontend/tests/per-model-params.test.ts
+++ b/studio/frontend/tests/per-model-params.test.ts
@@ -38,55 +38,117 @@ function params(overrides: Partial<InferenceParams> = {}): InferenceParams {
   } as InferenceParams;
 }
 
+/** What the store passes: the edit that moved, plus the full resulting params. */
+function record(
+  paramsByModel: Record<string, Record<string, unknown>>,
+  modelId: string | undefined,
+  changed: Record<string, unknown>,
+  full: InferenceParams,
+) {
+  return getRememberedParamsPatch(
+    true,
+    paramsByModel as never,
+    modelId,
+    changed as never,
+    pickPersistedInferenceParams(full),
+  );
+}
+
 test("an edit is filed against the model it was made for", () => {
-  const next = getRememberedParamsPatch(true, {}, QWEN, { temperature: 0.2 });
-  assert.deepEqual(next, { [QWEN]: { temperature: 0.2 } });
+  const next = record({}, QWEN, { temperature: 0.2 }, params({ temperature: 0.2 }));
+  assert.equal(next?.[QWEN].temperature, 0.2);
 });
 
-test("a later edit merges into the same model rather than replacing it", () => {
-  const first = getRememberedParamsPatch(true, {}, QWEN, { temperature: 0.2 });
-  assert.ok(first);
-  const second = getRememberedParamsPatch(true, first, QWEN, {
-    systemPrompt: "Be terse.",
-  });
-  assert.deepEqual(second, {
-    [QWEN]: { temperature: 0.2, systemPrompt: "Be terse." },
-  });
+// The entry has to be the whole snapshot. Replay overlays it onto the outgoing
+// model's params, so anything missing would silently keep the other model's value.
+test("an entry records every param, not only the one that moved", () => {
+  const next = record(
+    {},
+    QWEN,
+    { temperature: 0.2 },
+    params({ temperature: 0.2, systemPrompt: "Be terse." }),
+  );
+  assert.equal(next?.[QWEN].systemPrompt, "Be terse.");
+  assert.equal(next?.[QWEN].topP, 0.95);
 });
 
 test("editing one model leaves every other model's memory alone", () => {
   const before = { [LLAMA]: { temperature: 0.9 } };
-  const after = getRememberedParamsPatch(true, before, QWEN, {
-    temperature: 0.2,
-  });
-  assert.deepEqual(after, {
-    [LLAMA]: { temperature: 0.9 },
-    [QWEN]: { temperature: 0.2 },
-  });
+  const after = record(before, QWEN, { temperature: 0.2 }, params({ temperature: 0.2 }));
+  assert.deepEqual(after?.[LLAMA], { temperature: 0.9 });
+  assert.equal(after?.[QWEN].temperature, 0.2);
   // The input map is not mutated: the store compares by identity to decide
   // whether anything has to be persisted.
   assert.deepEqual(before, { [LLAMA]: { temperature: 0.9 } });
 });
 
+// The reported failure: A remembered only its temperature, so switching back
+// overlaid it onto B's prompt and A ran under settings it was never given.
+test("a model returns to the prompt it was last used with", () => {
+  const aParams = params({ checkpoint: QWEN, temperature: 0.2, systemPrompt: "A" });
+  const memory = record({}, QWEN, { temperature: 0.2 }, aParams);
+  assert.ok(memory);
+
+  // Switch to B, which has no memory, then change only B's prompt.
+  const onB = getReplayedParams(true, memory, aParams, LLAMA, true);
+  const bParams = { ...onB, checkpoint: LLAMA, systemPrompt: "B" };
+  const afterB = record(memory, LLAMA, { systemPrompt: "B" }, bParams);
+  assert.ok(afterB);
+
+  const backOnA = getReplayedParams(true, afterB, bParams, QWEN, true);
+  assert.equal(backOnA.systemPrompt, "A");
+  assert.equal(backOnA.temperature, 0.2);
+});
+
+// The interactive local load never calls setCheckpoint first: it calls
+// setParams with the destination checkpoint and the backend's recommended
+// params. Replay has to happen on that call or the common switch restores
+// nothing. This walks that exact sequence through the two helpers setParams uses.
+test("a local model load replays memory over the backend's recommendation", () => {
+  let memory: Record<string, ReturnType<typeof pickPersistedInferenceParams>> = {};
+  let live = params({ checkpoint: QWEN });
+
+  function loadModel(modelId: string, recommended: Partial<InferenceParams>) {
+    const merged = { ...live, ...recommended, checkpoint: modelId };
+    const replayed = getReplayedParams(true, memory, merged, modelId, true);
+    memory = record(memory, modelId, { temperature: 1 }, replayed) ?? memory;
+    live = replayed;
+  }
+
+  function edit(overrides: Partial<InferenceParams>) {
+    live = { ...live, ...overrides };
+    memory = record(memory, live.checkpoint, overrides, live) ?? memory;
+  }
+
+  loadModel(QWEN, { temperature: 0.7 });
+  edit({ temperature: 0.2 });
+  loadModel(LLAMA, { temperature: 0.6 });
+  assert.equal(live.temperature, 0.6, "a model with no memory takes its recommendation");
+
+  loadModel(QWEN, { temperature: 0.7 });
+  assert.equal(live.temperature, 0.2, "the tuned value beats the recommendation");
+});
+
 // Null is how the store leaves the map and its hydration version untouched.
 test("nothing is recorded when there is nothing to record", () => {
+  const snapshot = pickPersistedInferenceParams(params());
   assert.equal(
-    getRememberedParamsPatch(false, {}, QWEN, { temperature: 0.2 }),
+    getRememberedParamsPatch(false, {}, QWEN, { temperature: 0.2 }, snapshot),
     null,
     "the feature being off records nothing",
   );
   assert.equal(
-    getRememberedParamsPatch(true, {}, undefined, { temperature: 0.2 }),
+    getRememberedParamsPatch(true, {}, undefined, { temperature: 0.2 }, snapshot),
     null,
     "no model selected records nothing",
   );
   assert.equal(
-    getRememberedParamsPatch(true, {}, "", { temperature: 0.2 }),
+    getRememberedParamsPatch(true, {}, "", { temperature: 0.2 }, snapshot),
     null,
     "an empty checkpoint is not a model id",
   );
   assert.equal(
-    getRememberedParamsPatch(true, {}, QWEN, {}),
+    getRememberedParamsPatch(true, {}, QWEN, {}, snapshot),
     null,
     "an edit that moved no persisted param records nothing",
   );


### PR DESCRIPTION
Fixes two pieces of feedback about Studio chat.

## 1. Files are not shared across a project

> I thought that if I added a new chat to an existing project, I'd be able to access the same files since they share the project, but it turns out I can't.

This is real. A file attached inside a chat that belongs to a project is indexed at **thread** scope, so no other chat in the project can see it:

```
thread_A docs: ['repro_notes.txt']
thread_B docs: []          # same project
project docs : []
```

The composer's Docs bar only ever had two scopes, `thread` and `kb`, so there was no way to attach a file *to the project* from a chat and no sign that the file you just dropped was chat-private. Project sources did exist, but only through the separate **Sources** tab on the project page.

**What changed:** in a project chat the Docs bar now files new attachments against the **project** by default, with a `Project / This chat` menu on the composer for per-chat overrides. It also lists the project's existing sources inline (folder glyph) beside the chat's own documents, so inherited context is visible instead of merely in effect.

Retrieval already combined project and thread scopes server side (`core/rag/tool.py`), so the mechanism works end to end once the upload lands in the right place:

```
chat-scope only (old behaviour):      []
project+chat scope (project chat):    ['shared_brief.txt']
```

There is also a related race in `resolveProjectId`. `initialize()` starts the thread row write without awaiting it, so the **first** message in a new project chat could read ahead of its own row, conclude the chat had no project, and silently drop the project's sources, instructions and sandbox from exactly the message the project was opened to ask. It now falls back to the composer's project, and never for incognito threads, which are deliberately unpersisted.

## 2. Chat parameters are global rather than per model

> The way chat parameters are handled is awkward; instead of being tied to specific models, there's basically just a single global setting that applies to the chat itself. There is a preset function, but that's designed for switching settings for the same model based on the use case, not for switching between different models.

Also real. `inferenceParams` is one flat blob and `setCheckpoint` carried every sampling value across a model switch, clamping only `maxTokens`. Presets were the only workaround and, as the report says, they are built for switching use case within one model.

**What changed:** sampling params are now remembered per checkpoint and replayed on switch, with a Settings toggle (on by default). A model with nothing remembered keeps whatever is on screen rather than snapping to defaults. Storage is a per-model map that the server deep merges per key, so tuning one model never clobbers another's:

```json
{
  "rememberParamsPerModel": true,
  "inferenceParamsByModel": {
    "unsloth/Qwen3.5-9B-GGUF": { "temperature": 0.2, "systemPrompt": "Be terse." },
    "unsloth/Llama-4-8B": { "temperature": 0.9 }
  }
}
```

The rules live in a new pure module, `features/chat/lib/per-model-params.ts`, free of store and network imports so they stay unit testable.

## Settings

Two new rows under Settings, both searchable:

- **Remember settings per model**, on by default
- **Share files across a project**, on by default, the same choice as the composer menu

## Testing

- Frontend: 2287 pass, including 10 new tests for the per-model rules
- Backend: new tests for the per-model settings merge and the payload schema
- Typecheck and the backend sweep match `main` exactly. The 5 pre-existing typecheck errors (speech dictation DOM types) and 16 pre-existing backend failures (macOS sandbox/env) are byte identical before and after
- Lint is at parity with `main`
- Locale parity passes; new strings are English only, which the parity check allows outside the `picker.` and `studio.` prefixes

One gap worth a reviewer's eyes: I verified the mechanism over HTTP and against the RAG scope resolver directly, but did not click through the new composer menu and chip rendering in a browser.
