### PR TITLE
Windows: stop compiling C# for colour on hosts that already render it

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -610,6 +610,16 @@ public static class UnslothStudioFinalPathV2
 
     function Enable-StudioVirtualTerminal {
         if ($env:NO_COLOR) { return $false }
+        # Windows Terminal always renders VT and sets WT_SESSION, so there is nothing to turn on
+        # and the Add-Type below can be skipped: it compiles C#, which spawns csc.exe and drops
+        # source in %TEMP% on every run. Both conjuncts are load-bearing. WT_SESSION is INHERITED,
+        # so the app's console-less spawn carries it while writing to a pipe; without the redirect
+        # check the Studio log panel would get raw escapes. And the capability property alone is
+        # what the HOST can render, not proof this buffer has ENABLE_VIRTUAL_TERMINAL_PROCESSING.
+        try {
+            if ($env:WT_SESSION -and -not $script:StudioStdoutRedirected `
+                -and $Host.UI.SupportsVirtualTerminal) { return $true }
+        } catch {}
         try {
             if (-not ("StudioVT.Native" -as [type])) {
                 Add-Type -Namespace StudioVT -Name Native -MemberDefinition @'

--- a/install.ps1
+++ b/install.ps1
@@ -610,16 +610,11 @@ public static class UnslothStudioFinalPathV2
 
     function Enable-StudioVirtualTerminal {
         if ($env:NO_COLOR) { return $false }
-        # Windows Terminal always renders VT and sets WT_SESSION, so there is nothing to turn on
-        # and the Add-Type below can be skipped: it compiles C#, which spawns csc.exe and drops
-        # source in %TEMP% on every run. Both conjuncts are load-bearing. WT_SESSION is INHERITED,
-        # so the app's console-less spawn carries it while writing to a pipe; without the redirect
-        # check the Studio log panel would get raw escapes. And the capability property alone is
-        # what the HOST can render, not proof this buffer has ENABLE_VIRTUAL_TERMINAL_PROCESSING.
-        try {
-            if ($env:WT_SESSION -and -not $script:StudioStdoutRedirected `
-                -and $Host.UI.SupportsVirtualTerminal) { return $true }
-        } catch {}
+        # A redirected stdout is not a console, GetConsoleMode fails on a non-console handle, and
+        # the block below can then only reach `return $false`. Answer that without the compiler:
+        # Add-Type runs csc.exe and drops source in %TEMP%. This is the desktop app's own path,
+        # where install.rs spawns us with a pipe, so it is where the compile actually happened.
+        if ($script:StudioStdoutRedirected) { return $false }
         try {
             if (-not ("StudioVT.Native" -as [type])) {
                 Add-Type -Namespace StudioVT -Name Native -MemberDefinition @'

--- a/install.ps1
+++ b/install.ps1
@@ -610,10 +610,10 @@ public static class UnslothStudioFinalPathV2
 
     function Enable-StudioVirtualTerminal {
         if ($env:NO_COLOR) { return $false }
-        # A redirected stdout is not a console, GetConsoleMode fails on a non-console handle, and
-        # the block below can then only reach `return $false`. Answer that without the compiler:
-        # Add-Type runs csc.exe and drops source in %TEMP%. This is the desktop app's own path,
-        # where install.rs spawns us with a pipe, so it is where the compile actually happened.
+        # A redirected stdout is not a console and GetConsoleMode fails on a non-console handle,
+        # so the block below could only return $false anyway. Answer without Add-Type, which runs
+        # csc.exe and drops source in %TEMP%. install.rs spawns us with a pipe, so this is the path
+        # the compile was on.
         if ($script:StudioStdoutRedirected) { return $false }
         try {
             if (-not ("StudioVT.Native" -as [type])) {

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -1615,6 +1615,16 @@ $Rule = [string]::new([char]0x2500, 52)
 
 function Enable-StudioVirtualTerminal {
     if ($env:NO_COLOR) { return $false }
+    # Windows Terminal always renders VT and sets WT_SESSION, so there is nothing to turn on and
+    # the Add-Type below can be skipped: it compiles C#, which spawns csc.exe and drops source in
+    # %TEMP% on every run. Both conjuncts are load-bearing. WT_SESSION is INHERITED, so the app's
+    # console-less spawn carries it while writing to a pipe; without the redirect check the Studio
+    # log panel would get raw escapes. And the capability property alone is what the HOST can
+    # render, not proof this buffer has ENABLE_VIRTUAL_TERMINAL_PROCESSING.
+    try {
+        if ($env:WT_SESSION -and -not $script:StudioStdoutRedirected `
+            -and $Host.UI.SupportsVirtualTerminal) { return $true }
+    } catch {}
     try {
         Add-Type -Namespace StudioVT -Name Native -MemberDefinition @'
 [DllImport("kernel32.dll")] public static extern IntPtr GetStdHandle(int nStdHandle);

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -1615,10 +1615,10 @@ $Rule = [string]::new([char]0x2500, 52)
 
 function Enable-StudioVirtualTerminal {
     if ($env:NO_COLOR) { return $false }
-    # A redirected stdout is not a console, GetConsoleMode fails on a non-console handle, and the
-    # block below can then only reach `return $false`. Answer that without the compiler: Add-Type
-    # runs csc.exe and drops source in %TEMP%. This is the path the CLI and the desktop app both
-    # take, where stdout is a pipe, so it is where the compile actually happened.
+    # A redirected stdout is not a console and GetConsoleMode fails on a non-console handle, so the
+    # block below could only return $false anyway. Answer without Add-Type, which runs csc.exe and
+    # drops source in %TEMP%. The CLI and the desktop app both pipe us, so this is the path the
+    # compile was on.
     if ($script:StudioStdoutRedirected) { return $false }
     try {
         Add-Type -Namespace StudioVT -Name Native -MemberDefinition @'

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -1615,16 +1615,11 @@ $Rule = [string]::new([char]0x2500, 52)
 
 function Enable-StudioVirtualTerminal {
     if ($env:NO_COLOR) { return $false }
-    # Windows Terminal always renders VT and sets WT_SESSION, so there is nothing to turn on and
-    # the Add-Type below can be skipped: it compiles C#, which spawns csc.exe and drops source in
-    # %TEMP% on every run. Both conjuncts are load-bearing. WT_SESSION is INHERITED, so the app's
-    # console-less spawn carries it while writing to a pipe; without the redirect check the Studio
-    # log panel would get raw escapes. And the capability property alone is what the HOST can
-    # render, not proof this buffer has ENABLE_VIRTUAL_TERMINAL_PROCESSING.
-    try {
-        if ($env:WT_SESSION -and -not $script:StudioStdoutRedirected `
-            -and $Host.UI.SupportsVirtualTerminal) { return $true }
-    } catch {}
+    # A redirected stdout is not a console, GetConsoleMode fails on a non-console handle, and the
+    # block below can then only reach `return $false`. Answer that without the compiler: Add-Type
+    # runs csc.exe and drops source in %TEMP%. This is the path the CLI and the desktop app both
+    # take, where stdout is a pipe, so it is where the compile actually happened.
+    if ($script:StudioStdoutRedirected) { return $false }
     try {
         Add-Type -Namespace StudioVT -Name Native -MemberDefinition @'
 [DllImport("kernel32.dll")] public static extern IntPtr GetStdHandle(int nStdHandle);

--- a/tests/python/test_windows_setup_output_encoding.py
+++ b/tests/python/test_windows_setup_output_encoding.py
@@ -736,9 +736,13 @@ def test_console_less_banner_keeps_its_glyphs(path: Path) -> None:
 
 # The fast path added so an install stops running the C# compiler for colour. Sliced back out
 # to reconstruct the function it replaced, so parity is measured against the real predecessor
-# rather than asserted about it.
+# rather than asserted about it. The comment block goes with the guard: leaving it behind would
+# still run correctly, since PowerShell comments do not execute, but the reconstruction would
+# not be the merge-base function and this test would be comparing against something it invented.
 _VT_FAST_PATH = re.compile(
-    r"(?m)^[ \t]*if \(\$script:StudioStdoutRedirected\) \{ return \$false \}\n"
+    r"(?m)^[ \t]*# A redirected stdout is not a console.*?\n"
+    r"(?:^[ \t]*#.*\n)*"
+    r"^[ \t]*if \(\$script:StudioStdoutRedirected\) \{ return \$false \}\n"
 )
 
 

--- a/tests/python/test_windows_setup_output_encoding.py
+++ b/tests/python/test_windows_setup_output_encoding.py
@@ -623,15 +623,11 @@ def _console_less_probe(path: Path) -> str:
 
 
 @lru_cache(maxsize = None)
-def _run_console_less(
-    path: Path,
-    source: str | None = None,
-    env: dict[str, str] | None = None,
-) -> tuple[int, bytes, str]:
+def _run_console_less(path: Path, source: str | None = None) -> tuple[int, bytes, str]:
     """Spawn the probe the way install.rs spawns the installer, and read bytes.
 
-    `source` and `env` are for the VT parity case, which runs this file's own function
-    beside the one it replaced under the same environment.
+    `source` is for the VT parity case, which runs this file's own function beside the one it
+    replaced. A str keeps the lru_cache above workable; a dict would not hash.
     """
     with tempfile.TemporaryDirectory() as workdir:
         # A file written here has no Zone.Identifier, so RemoteSigned admits it.
@@ -644,7 +640,6 @@ def _run_console_less(
             stderr = subprocess.PIPE,
             creationflags = CREATE_NO_WINDOW,
             timeout = 180,
-            env = env,
         )
     return proc.returncode, proc.stdout, proc.stderr.decode("utf-8", errors = "replace")
 
@@ -743,10 +738,7 @@ def test_console_less_banner_keeps_its_glyphs(path: Path) -> None:
 # to reconstruct the function it replaced, so parity is measured against the real predecessor
 # rather than asserted about it.
 _VT_FAST_PATH = re.compile(
-    r"(?m)^[ \t]*try \{\n"
-    r"[ \t]*if \(\$env:WT_SESSION -and -not \$script:StudioStdoutRedirected `\n"
-    r"[ \t]*-and \$Host\.UI\.SupportsVirtualTerminal\) \{ return \$true \}\n"
-    r"[ \t]*\} catch \{\}\n"
+    r"(?m)^[ \t]*if \(\$script:StudioStdoutRedirected\) \{ return \$false \}\n"
 )
 
 
@@ -770,33 +762,23 @@ def _vt_verdict(err: str) -> str:
 @windows_only
 @powershell_51_only
 @pytest.mark.parametrize("path", [SETUP_PS1, INSTALL_PS1], ids = ["setup.ps1", "install.ps1"])
-@pytest.mark.parametrize(
-    "wt_session", ["", "1a2b3c4d-0000-0000-0000-000000000000"], ids = ["no-WT_SESSION", "WT_SESSION"]
-)
-def test_vt_fast_path_decides_exactly_as_the_compile_did(path: Path, wt_session: str) -> None:
+def test_vt_fast_path_decides_exactly_as_the_compile_did(path: Path) -> None:
     """Skipping csc.exe must not change one byte the user sees.
 
-    WT_SESSION set is the case that matters: it is inherited, so install.rs's spawn carries it
-    into a pipe. The fast path has to decline there exactly as the SetConsoleMode call did,
-    or the Studio log panel fills with escape sequences.
+    This probe is the changed branch, not a bystander: install.rs spawns with a pipe, so
+    `$script:StudioStdoutRedirected` is true here and the early return is what runs. The
+    reconstructed predecessor reaches Add-Type instead, and has to land on the same verdict.
     """
-    env = dict(os.environ)
-    env.pop("NO_COLOR", None)
-    if wt_session:
-        env["WT_SESSION"] = wt_session
-    else:
-        env.pop("WT_SESSION", None)
-
-    new_code, new_raw, new_err = _run_console_less(path, env = env)
+    new_code, new_raw, new_err = _run_console_less(path)
     old_code, old_raw, old_err = _run_console_less(
-        path, source = _probe_without_the_vt_fast_path(path), env = env
+        path, source = _probe_without_the_vt_fast_path(path)
     )
     assert new_code == old_code == 0, (
         f"probe exit codes {new_code} (with the fast path) and {old_code} (without)"
         f"{_explain(path, new_code, new_raw, new_err)}"
     )
-    assert _vt_verdict(new_err) == _vt_verdict(old_err), (
-        f"WT_SESSION={wt_session!r}: the fast path returned "
+    assert _vt_verdict(new_err) == _vt_verdict(old_err) == "False", (
+        f"a redirected stream cannot render VT: the fast path returned "
         f"{_vt_verdict(new_err)} where the compile returned {_vt_verdict(old_err)}"
     )
     assert new_raw == old_raw, (

--- a/tests/python/test_windows_setup_output_encoding.py
+++ b/tests/python/test_windows_setup_output_encoding.py
@@ -623,18 +623,28 @@ def _console_less_probe(path: Path) -> str:
 
 
 @lru_cache(maxsize = None)
-def _run_console_less(path: Path) -> tuple[int, bytes, str]:
-    """Spawn the probe the way install.rs spawns the installer, and read bytes."""
+def _run_console_less(
+    path: Path,
+    source: str | None = None,
+    env: dict[str, str] | None = None,
+) -> tuple[int, bytes, str]:
+    """Spawn the probe the way install.rs spawns the installer, and read bytes.
+
+    `source` and `env` are for the VT parity case, which runs this file's own function
+    beside the one it replaced under the same environment.
+    """
     with tempfile.TemporaryDirectory() as workdir:
         # A file written here has no Zone.Identifier, so RemoteSigned admits it.
         probe = Path(workdir) / f"{path.stem}_console_less_probe.ps1"
-        probe.write_bytes(_console_less_probe(path).replace("\n", "\r\n").encode("ascii"))
+        text = _console_less_probe(path) if source is None else source
+        probe.write_bytes(text.replace("\n", "\r\n").encode("ascii"))
         proc = subprocess.run(
             [str(_WINDOWS_POWERSHELL), *TAURI_FLAGS, "-File", str(probe)],
             stdout = subprocess.PIPE,
             stderr = subprocess.PIPE,
             creationflags = CREATE_NO_WINDOW,
             timeout = 180,
+            env = env,
         )
     return proc.returncode, proc.stdout, proc.stderr.decode("utf-8", errors = "replace")
 
@@ -726,4 +736,69 @@ def test_console_less_banner_keeps_its_glyphs(path: Path) -> None:
     assert "??" not in text, "the sloth was transcoded to '?' by a non-UTF-8 code page" + detail
     assert text.count(RULE_CHAR * 52) == 1, (
         f"expected one 52-char U+2500 rule, found {text.count(RULE_CHAR * 52)}" + detail
+    )
+
+
+# The fast path added so an install stops running the C# compiler for colour. Sliced back out
+# to reconstruct the function it replaced, so parity is measured against the real predecessor
+# rather than asserted about it.
+_VT_FAST_PATH = re.compile(
+    r"(?m)^[ \t]*try \{\n"
+    r"[ \t]*if \(\$env:WT_SESSION -and -not \$script:StudioStdoutRedirected `\n"
+    r"[ \t]*-and \$Host\.UI\.SupportsVirtualTerminal\) \{ return \$true \}\n"
+    r"[ \t]*\} catch \{\}\n"
+)
+
+
+def _probe_without_the_vt_fast_path(path: Path) -> str:
+    probe = _console_less_probe(path)
+    stripped, count = _VT_FAST_PATH.subn("", probe, count = 1)
+    assert count == 1, (
+        f"{path.name}: the VT fast path is not in the sliced probe in the shape this test "
+        f"removes, so nothing was being compared. Update _VT_FAST_PATH."
+    )
+    return stripped
+
+
+def _vt_verdict(err: str) -> str:
+    for line in err.splitlines():
+        if line.startswith("studio_vt_ok="):
+            return line.split("=", 1)[1].strip()
+    raise AssertionError(f"the probe printed no studio_vt_ok line:\n{err}")
+
+
+@windows_only
+@powershell_51_only
+@pytest.mark.parametrize("path", [SETUP_PS1, INSTALL_PS1], ids = ["setup.ps1", "install.ps1"])
+@pytest.mark.parametrize("wt_session", ["", "1a2b3c4d-0000-0000-0000-000000000000"],
+                         ids = ["no-WT_SESSION", "WT_SESSION"])
+def test_vt_fast_path_decides_exactly_as_the_compile_did(path: Path, wt_session: str) -> None:
+    """Skipping csc.exe must not change one byte the user sees.
+
+    WT_SESSION set is the case that matters: it is inherited, so install.rs's spawn carries it
+    into a pipe. The fast path has to decline there exactly as the SetConsoleMode call did,
+    or the Studio log panel fills with escape sequences.
+    """
+    env = dict(os.environ)
+    env.pop("NO_COLOR", None)
+    if wt_session:
+        env["WT_SESSION"] = wt_session
+    else:
+        env.pop("WT_SESSION", None)
+
+    new_code, new_raw, new_err = _run_console_less(path, env = env)
+    old_code, old_raw, old_err = _run_console_less(
+        path, source = _probe_without_the_vt_fast_path(path), env = env
+    )
+    assert new_code == old_code == 0, (
+        f"probe exit codes {new_code} (with the fast path) and {old_code} (without)"
+        f"{_explain(path, new_code, new_raw, new_err)}"
+    )
+    assert _vt_verdict(new_err) == _vt_verdict(old_err), (
+        f"WT_SESSION={wt_session!r}: the fast path returned "
+        f"{_vt_verdict(new_err)} where the compile returned {_vt_verdict(old_err)}"
+    )
+    assert new_raw == old_raw, (
+        "the banner bytes moved. Same verdict in, same bytes out is the whole contract of "
+        "this change" + _explain(path, new_code, new_raw, new_err)
     )

--- a/tests/python/test_windows_setup_output_encoding.py
+++ b/tests/python/test_windows_setup_output_encoding.py
@@ -734,11 +734,9 @@ def test_console_less_banner_keeps_its_glyphs(path: Path) -> None:
     )
 
 
-# The fast path added so an install stops running the C# compiler for colour. Sliced back out
-# to reconstruct the function it replaced, so parity is measured against the real predecessor
-# rather than asserted about it. The comment block goes with the guard: leaving it behind would
-# still run correctly, since PowerShell comments do not execute, but the reconstruction would
-# not be the merge-base function and this test would be comparing against something it invented.
+# Sliced back out to rebuild the function this replaced, so parity is measured against the real
+# predecessor. The comments go with the guard: they do not execute, but leaving them behind
+# would make the reconstruction something this test invented rather than the merge-base function.
 _VT_FAST_PATH = re.compile(
     r"(?m)^[ \t]*# A redirected stdout is not a console.*?\n"
     r"(?:^[ \t]*#.*\n)*"

--- a/tests/python/test_windows_setup_output_encoding.py
+++ b/tests/python/test_windows_setup_output_encoding.py
@@ -770,8 +770,9 @@ def _vt_verdict(err: str) -> str:
 @windows_only
 @powershell_51_only
 @pytest.mark.parametrize("path", [SETUP_PS1, INSTALL_PS1], ids = ["setup.ps1", "install.ps1"])
-@pytest.mark.parametrize("wt_session", ["", "1a2b3c4d-0000-0000-0000-000000000000"],
-                         ids = ["no-WT_SESSION", "WT_SESSION"])
+@pytest.mark.parametrize(
+    "wt_session", ["", "1a2b3c4d-0000-0000-0000-000000000000"], ids = ["no-WT_SESSION", "WT_SESSION"]
+)
 def test_vt_fast_path_decides_exactly_as_the_compile_did(path: Path, wt_session: str) -> None:
     """Skipping csc.exe must not change one byte the user sees.
 

--- a/tests/studio/test_installer_av_shapes.py
+++ b/tests/studio/test_installer_av_shapes.py
@@ -111,13 +111,18 @@ def test_a_hidden_window_never_pairs_with_a_bypassed_policy(name: str) -> None:
 ALLOWED_PINVOKES = {
     # Canonicalising linked ancestors of security-relevant paths. No PS 5.1 equivalent:
     # ResolveLinkTarget is .NET 6+, and .Target misses a linked ancestor of a non-link leaf.
+    # Not skippable either: Get-StudioRuntimePathHash hashes this spelling byte for byte and
+    # Python derives the same mutex name from its own, so a GetFullPath fast path differing on
+    # case or an 8.3 name would let two installers each believe they hold the lock.
     "CreateFileW",
     "GetFinalPathNameByHandleW",
-    # ANSI colour on legacy conhost.
+    # ANSI colour on legacy conhost only: under Windows Terminal the compile is skipped, see
+    # test_virtual_terminal_asks_the_host_before_compiling.
     "GetStdHandle",
     "GetConsoleMode",
     "SetConsoleMode",
-    # Per-item Explorer icon refresh; the global broadcast alone does not recover a stale .lnk.
+    # Per-item Explorer icon refresh; the global broadcast alone does not recover a stale .lnk,
+    # so ie4uinit.exe -show, which is that broadcast, is not a substitute. Standalone path only.
     "SHChangeNotify",
     # PID -> image path for the venv-holder check. Win32_Process answers the same question,
     # but test_windows_installer_concurrency_guard.py bans it and $process.Path there: the
@@ -145,6 +150,34 @@ def test_no_new_native_imports(name: str) -> None:
         f"{name} imports {sorted(unexpected)} from native code. Prefer a PowerShell or .NET "
         f"equivalent; if there genuinely is none, add it to ALLOWED_PINVOKES with the reason."
     )
+
+
+@pytest.mark.parametrize("name", ("install.ps1", "studio/setup.ps1"))
+def test_virtual_terminal_asks_the_host_before_compiling(name: str) -> None:
+    """Add-Type runs the C# compiler, so the free answer has to be tried first.
+
+    All three conjuncts are required. WT_SESSION is INHERITED, so install.rs's console-less
+    spawn carries it while writing to a pipe: without the redirect check the Studio log panel
+    renders raw escape sequences. And the capability property reports what the HOST can render,
+    not whether this buffer has the mode set, so it cannot decide alone either.
+    """
+    text = _text(name)
+    start = text.index("function Enable-StudioVirtualTerminal")
+    # The call, not the comment above it that explains why the call is skippable.
+    call = re.compile(r"(?m)^[ \t]*Add-Type\b").search(text, start)
+    assert call, f"{name} no longer compiles the console thunk; update this guard"
+    compile_at = call.start()
+    fast_path = text.index("$env:WT_SESSION", start)
+    assert fast_path < compile_at, (
+        f"{name} compiles C# for colour before asking the host: move the WT_SESSION check above "
+        f"Add-Type, or every install spawns csc.exe again."
+    )
+    guard = text[fast_path:compile_at]
+    for conjunct in ("-not $script:StudioStdoutRedirected", "$Host.UI.SupportsVirtualTerminal"):
+        assert conjunct in guard, (
+            f"{name} skips the compile without requiring `{conjunct}`, so it can claim VT on a "
+            f"stream that cannot render it"
+        )
 
 
 @pytest.mark.parametrize("name", ALL_SCRIPTS)

--- a/tests/studio/test_installer_av_shapes.py
+++ b/tests/studio/test_installer_av_shapes.py
@@ -121,8 +121,8 @@ ALLOWED_PINVOKES = {
     "GetStdHandle",
     "GetConsoleMode",
     "SetConsoleMode",
-    # Per-item Explorer icon refresh; the global broadcast alone does not recover a stale .lnk,
-    # so ie4uinit.exe -show, which is that broadcast, is not a substitute. Standalone path only.
+    # Per-item Explorer icon refresh, standalone path only. ie4uinit.exe -show is the global
+    # broadcast, which alone does not recover a stale .lnk, so it is not a substitute.
     "SHChangeNotify",
     # PID -> image path for the venv-holder check. Win32_Process answers the same question,
     # but test_windows_installer_concurrency_guard.py bans it and $process.Path there: the
@@ -163,7 +163,7 @@ def test_virtual_terminal_answers_a_redirected_stream_without_compiling(name: st
     """
     text = _text(name)
     start = text.index("function Enable-StudioVirtualTerminal")
-    # The call, not the comment above it that explains why the call is skippable.
+    # The call, not the comment above it.
     call = re.compile(r"(?m)^[ \t]*Add-Type\b").search(text, start)
     assert call, f"{name} no longer compiles the console thunk; update this guard"
     compile_at = call.start()

--- a/tests/studio/test_installer_av_shapes.py
+++ b/tests/studio/test_installer_av_shapes.py
@@ -116,8 +116,8 @@ ALLOWED_PINVOKES = {
     # case or an 8.3 name would let two installers each believe they hold the lock.
     "CreateFileW",
     "GetFinalPathNameByHandleW",
-    # ANSI colour on legacy conhost only: under Windows Terminal the compile is skipped, see
-    # test_virtual_terminal_asks_the_host_before_compiling.
+    # ANSI colour on a real console. Skipped entirely when stdout is redirected, see
+    # test_virtual_terminal_answers_a_redirected_stream_without_compiling.
     "GetStdHandle",
     "GetConsoleMode",
     "SetConsoleMode",
@@ -153,13 +153,13 @@ def test_no_new_native_imports(name: str) -> None:
 
 
 @pytest.mark.parametrize("name", ("install.ps1", "studio/setup.ps1"))
-def test_virtual_terminal_asks_the_host_before_compiling(name: str) -> None:
-    """Add-Type runs the C# compiler, so the free answer has to be tried first.
+def test_virtual_terminal_answers_a_redirected_stream_without_compiling(name: str) -> None:
+    """Add-Type runs the C# compiler, so the answer we already know must come first.
 
-    All three conjuncts are required. WT_SESSION is INHERITED, so install.rs's console-less
-    spawn carries it while writing to a pipe: without the redirect check the Studio log panel
-    renders raw escape sequences. And the capability property reports what the HOST can render,
-    not whether this buffer has the mode set, so it cannot decide alone either.
+    Only the redirected case is decided early, and it is decided FALSE. A redirected stdout is
+    not a console, GetConsoleMode fails on a non-console handle, and the compiled path could
+    only have returned false too. Anything that claimed VT here would put raw escape sequences
+    in the Studio log panel, which is a pipe.
     """
     text = _text(name)
     start = text.index("function Enable-StudioVirtualTerminal")
@@ -167,17 +167,15 @@ def test_virtual_terminal_asks_the_host_before_compiling(name: str) -> None:
     call = re.compile(r"(?m)^[ \t]*Add-Type\b").search(text, start)
     assert call, f"{name} no longer compiles the console thunk; update this guard"
     compile_at = call.start()
-    fast_path = text.index("$env:WT_SESSION", start)
+    fast_path = text.index("if ($script:StudioStdoutRedirected) { return $false }", start)
     assert fast_path < compile_at, (
         f"{name} compiles C# for colour before asking the host: move the WT_SESSION check above "
         f"Add-Type, or every install spawns csc.exe again."
     )
-    guard = text[fast_path:compile_at]
-    for conjunct in ("-not $script:StudioStdoutRedirected", "$Host.UI.SupportsVirtualTerminal"):
-        assert conjunct in guard, (
-            f"{name} skips the compile without requiring `{conjunct}`, so it can claim VT on a "
-            f"stream that cannot render it"
-        )
+    assert "$true" not in text[fast_path:compile_at], (
+        f"{name} returns something other than $false before the compile. The early answer is "
+        f"only sound because a redirected stream can never render VT."
+    )
 
 
 @pytest.mark.parametrize("name", ALL_SCRIPTS)

--- a/tests/studio/test_installer_av_shapes.py
+++ b/tests/studio/test_installer_av_shapes.py
@@ -169,8 +169,8 @@ def test_virtual_terminal_answers_a_redirected_stream_without_compiling(name: st
     compile_at = call.start()
     fast_path = text.index("if ($script:StudioStdoutRedirected) { return $false }", start)
     assert fast_path < compile_at, (
-        f"{name} compiles C# for colour before asking the host: move the WT_SESSION check above "
-        f"Add-Type, or every install spawns csc.exe again."
+        f"{name} compiles C# for colour before checking the stream: move the redirect guard "
+        f"above Add-Type, or every install spawns csc.exe again."
     )
     assert "$true" not in text[fast_path:compile_at], (
         f"{name} returns something other than $false before the compile. The early answer is "


### PR DESCRIPTION
## Why

A user submitted the shipped `Unsloth-Desktop-0_1_701_beta-Windows.exe` to ANY.RUN, which is the first behavioural measurement we have of what an install looks like to a sandbox. Attributable to our own code it showed `csc.exe` processes and a "Suspicious source code drop". Every `Add-Type` in a PowerShell script compiles C# at runtime, which spawns the compiler and writes a `.cs` and a `.dll` into `%TEMP%`, and `Enable-StudioVirtualTerminal` is called unconditionally by both installers.

## What this does

One early return in front of the `Add-Type` block, in `install.ps1` and `studio/setup.ps1`:

```powershell
if ($script:StudioStdoutRedirected) { return $false }
```

A redirected stdout is not a console. `GetStdHandle(STD_OUTPUT_HANDLE)` returns the file or pipe handle, `GetConsoleMode` fails on a non-console handle, and the compiled block could then only reach `return $false`. So this is the same answer, not an approximation. .NET implements `IsOutputRedirected` as exactly that test, a non-character handle or a `GetConsoleMode` failure, so the two predicates are the same question asked twice.

This is also the path that was measured: `install.rs` spawns `install.ps1` with a pipe.

## Compiler accounting

The PR originally said two compiles, taking the sandbox's `csc.exe` count at face value. That was wrong, and independent audits corrected it. A successful install reaches up to four:

| | source |
|---|---|
| A | `UnslothStudioFinalPathV2`, `install.ps1:414`, reached by every install through the install mutex |
| B | `StudioVT.Native` in `install.ps1` |
| C | `StudioVT.Native` in the separate `studio/setup.ps1` process |
| D | `UnslothShell.IconRefresh`, only when a persistent shortcut is created, which is the standalone path |

| Path | before | after | removed |
|---|---:|---:|---|
| `--tauri`, redirected, which is the desktop app | 3 | 1 | **B and C** |
| `--tauri`, interactive console | 3 | 3 | none |
| standalone, redirected | 3 or 4 | 1 or 2 | **B and C** |
| standalone, interactive console | 3 or 4 | 3 or 4 | none |

So the desktop install drops from three compiles to one. An interactive console install is unchanged, because there VT genuinely has to be turned on and `GetConsoleMode` is the only way to do it.

## What this does not do

- A is not removable. It feeds `Get-StudioRuntimePathHash`, and Python derives the same mutex name from the same spelling byte for byte, so a managed fast path differing on case or on an 8.3 short name would let two installers each believe they hold the install lock.
- D stays: `ie4uinit.exe -show` is the global broadcast that the comment above it already records as insufficient for a stale per-item icon.
- The MALICIOUS "Changes powershell execution policy" signature in that report is untouched, and is worth recording accurately: it is **not** the Start Menu shortcut. `install.ps1` returns in `TauriMode` before `New-StudioShortcuts` is ever called, so the `.lnk` and `launch-studio.ps1` exist only on the standalone path. It comes from `install.rs` spawning `install.ps1`, and it fires on setting the policy at all, whatever the value.

## Parity

`$script:StudioVtOk` is the only value this function feeds, and it selects between the ANSI branch and the `-ForegroundColor` branch. Outside this one function both scripts are identical to `main` line for line, checked mechanically rather than argued. `Add-Type` writes nothing to stdout without `-PassThru`, so skipping a successful compile removes no bytes either.

One caveat found by audit and worth stating rather than hiding: `[Console]::IsOutputRedirected` is captured once near the top of each script, while the predecessor asked `GetStdHandle` at the moment of the call. A process that redirected stdout, then swapped `STD_OUTPUT_HANDLE` to `CONOUT$` or called `AllocConsole`, and then dot-sourced the installer into itself could see the two disagree. No shipped path does that, and the cached value already governs which sink every output line takes, so this change makes the VT verdict consistent with the routing the rest of the script has always used.

## Verification

- Windows staging leg green at this head: **78 passed, 0 skipped**, so the parity case ran on a real Windows PowerShell 5.1 host rather than skipping. `macos-14`, `macos-13`, `ubuntu-latest` and `ubuntu-22.04` green as the untouched controls.
- `tests/python/test_windows_setup_output_encoding.py` reconstructs the pre-change function by slicing the new early return back out, runs both under the console-less spawn, and asserts the same `studio_vt_ok` and the same banner bytes. The probe is redirected, so the early return is the branch under test rather than a bystander.
- `tests/studio/test_installer_av_shapes.py` fails if the compile moves ahead of the early return, or if the early return answers anything but `$false`. Both mutations were run and both fail it.
- Thirteen independent audits across two rounds covering output parity by host and stream shape, the update path from v0.1.701-beta, `unsloth studio update` and re-runs, idempotency, the process tree, shortcuts and login, macOS/Linux/WSL, the untouched subsystems, and whether the tests can pass while the product is broken.
- `test_uv_pinned_release.sh`, `test_tauri_retry_failure_context.sh`, `test_install_pipe_safety.sh` and `test_install_rollback_lifecycle.sh` all pass.

## History

The first revision tested `WT_SESSION` instead, to skip the compile under Windows Terminal. Review killed it, correctly: `WT_SESSION` is inherited, so an elevated install, which UAC gives a new console, carries it with stdout not redirected onto a buffer with no VT enabled, and the branch would have printed literal escape sequences. There is no sound way to learn a buffer's mode without `GetConsoleMode`. Deciding the redirected case instead is both provable and, as the table above shows, a bigger win, since the desktop path is the redirected one.
