### PR TITLE
Studio: apply the provider metadata block to DNS aliases as well

### DIFF
--- a/studio/backend/core/inference/providers.py
+++ b/studio/backend/core/inference/providers.py
@@ -711,7 +711,10 @@ def _resolve_host(hostname: str, port: int | None, scheme: str) -> tuple[str, ..
         if cached is not None and cached[0] > now:
             return cached[1]
 
-    if not _dns_in_flight.acquire(blocking = False):
+    # Bound to a local: a worker abandoned at the deadline may outlive the
+    # global, and BoundedSemaphore raises if it releases one it never took.
+    in_flight = _dns_in_flight
+    if not in_flight.acquire(blocking = False):
         return None
 
     resolved: list[str] = []
@@ -730,7 +733,7 @@ def _resolve_host(hostname: str, port: int | None, scheme: str) -> tuple[str, ..
         finally:
             # Released by the worker, not the caller, so an abandoned lookup
             # frees its slot only once the resolver actually lets it go.
-            _dns_in_flight.release()
+            in_flight.release()
         resolved.extend(str(info[4][0]) for info in infos)
         answered = True
 

--- a/studio/backend/core/inference/providers.py
+++ b/studio/backend/core/inference/providers.py
@@ -14,7 +14,7 @@ import re
 import threading
 import time
 from typing import Any
-from urllib.parse import urlsplit
+from urllib.parse import quote, urlsplit
 
 PROVIDER_REGISTRY: dict[str, dict[str, Any]] = {
     "openai_codex": {
@@ -687,6 +687,11 @@ def _metadata_address(address: str) -> bool:
     return ip in _METADATA_IPS
 
 
+# What httpx leaves unescaped in a host: RFC 3986 sub-delims plus the WHATWG
+# set. Kept in step with its `_urlparse.encode_host`.
+_HOST_SAFE_CHARS = "!$&'()*+,;=" + '"`{}%|\\'
+
+
 def _transport_host(hostname: str) -> str:
     """The ASCII host httpx will dial, so the checked name is the dialled name.
 
@@ -696,8 +701,17 @@ def _transport_host(hostname: str) -> str:
     resolver and as xn--strae-oqa.de through httpx, which are different hosts
     owned by different people. Mirrors httpx's `_urlparse.encode_host`.
     """
+    try:
+        # An address is dialled as written; quoting one would corrupt IPv6.
+        ipaddress.ip_address(hostname)
+        return hostname
+    except ValueError:
+        pass
     if hostname.isascii():
-        return hostname.lower()
+        # httpx percent-encodes what RFC 3986 does not allow in a reg-name, so
+        # safe^alias.example is dialled as safe%5Ealias.example, a name whose
+        # parent zone can answer differently. Same quoting, same name.
+        return quote(hostname.lower(), safe = _HOST_SAFE_CHARS)
     try:
         import idna
         return idna.encode(hostname.lower()).decode("ascii")

--- a/studio/backend/core/inference/providers.py
+++ b/studio/backend/core/inference/providers.py
@@ -628,9 +628,9 @@ def _metadata_host(hostname: str) -> bool:
 _DNS_TIMEOUT_SECONDS = 2.0
 _DNS_CACHE_TTL_SECONDS = 300.0
 _DNS_CACHE_MAX_ENTRIES = 512
-# hostname -> (expiry, addresses). ``None`` addresses means the resolver did not
-# answer, which the two callers below read in opposite directions.
-_dns_cache: dict[str, tuple[float, tuple[str, ...] | None]] = {}
+# hostname -> (expiry, addresses). Only answers land here; a failure and a
+# timeout are both cheap to repeat and wrong to remember.
+_dns_cache: dict[str, tuple[float, tuple[str, ...]]] = {}
 _dns_cache_lock = threading.Lock()
 # A lookup that times out is abandoned, not cancelled, so its thread lives until
 # the platform resolver gives up. Rotating hostnames defeat the cache and would
@@ -745,8 +745,13 @@ def _resolve_host(hostname: str, port: int | None, scheme: str) -> tuple[str, ..
         # transport waits longer than this and would still get the address a
         # deliberately slow authoritative server sends after the deadline.
         return None
-    addresses = tuple(resolved) if answered else None
+    if not answered:
+        # A failure is not cached either. It is cheap to repeat (the resolver
+        # says so immediately), and remembering it would turn one transient
+        # SERVFAIL into five minutes of refusal on the opt-in path.
+        return None
 
+    addresses = tuple(resolved)
     with _dns_cache_lock:
         if len(_dns_cache) >= _DNS_CACHE_MAX_ENTRIES:
             _dns_cache.clear()
@@ -775,9 +780,22 @@ def _reject_non_public(hostname: str, port: int | None, scheme: str) -> None:
     except ValueError:
         resolved = _resolve_host(hostname, port, scheme)
         if resolved is None:
-            # Unlike the metadata check, this one fails closed: an operator who
-            # set the flag asked for anything unproven to be refused.
-            raise ValueError("Provider base URL hostname could not be resolved.") from None
+            # This path blocked on an unbounded getaddrinfo before the metadata
+            # check existed, and a resolver slower than that check's deadline is
+            # ordinary (the Linux default is 5s per server, twice). Falling back
+            # to the same unbounded call keeps a slow-but-working resolver from
+            # turning into a refusal here, where "no answer" fails closed.
+            import socket
+
+            try:
+                infos = socket.getaddrinfo(
+                    _transport_host(hostname),
+                    port or (443 if scheme == "https" else 80),
+                    type = socket.SOCK_STREAM,
+                )
+            except (OSError, UnicodeError) as exc:
+                raise ValueError("Provider base URL hostname could not be resolved.") from exc
+            resolved = tuple(str(info[4][0]) for info in infos)
         addresses = [ipaddress.ip_address(address.split("%", 1)[0]) for address in resolved]
     if not addresses or any(not ip.is_global for ip in addresses):
         raise ValueError(

--- a/studio/backend/core/inference/providers.py
+++ b/studio/backend/core/inference/providers.py
@@ -11,6 +11,8 @@ with Bearer token auth and SSE streaming.
 import ipaddress
 import os
 import re
+import threading
+import time
 from typing import Any
 from urllib.parse import urlsplit
 
@@ -611,6 +613,91 @@ def _metadata_host(hostname: str) -> bool:
     return ip in _METADATA_IPS or (ip.version == 4 and ip in _METADATA_NETWORK)
 
 
+# The metadata block above only reads the hostname text, so a name the caller
+# controls (metadata-alias.attacker.test IN A 169.254.169.254) dials the very
+# service that block exists to refuse. Names are therefore resolved on the
+# default path too -- but only far enough to answer "is this the metadata
+# service", never to reject private addresses, which stays the opt-in above.
+#
+# Three properties keep that resolution out of the way of the endpoints people
+# actually configure:
+#   * the shipped registry hosts and IP literals skip it entirely, so the common
+#     path (a real provider, or http://127.0.0.1:11434) touches no resolver;
+#   * a name that does not resolve is allowed, because a docker-compose or
+#     service-discovery name (http://my_ollama:11434) may only be resolvable in
+#     the client's network namespace, not in this one;
+#   * the lookup is bounded and its verdict cached, so a slow or unreachable
+#     resolver cannot stall a request that validates the same URL every time.
+_DNS_TIMEOUT_SECONDS = 2.0
+_DNS_CACHE_TTL_SECONDS = 300.0
+_DNS_CACHE_MAX_ENTRIES = 512
+_metadata_dns_cache: dict[str, tuple[float, bool]] = {}
+_metadata_dns_lock = threading.Lock()
+
+# Hostnames of the providers this build ships. They are hard-coded destinations,
+# not caller-controlled names, so learning their addresses buys nothing.
+_REGISTRY_HOSTNAMES = frozenset(
+    host
+    for host in (
+        urlsplit(info["base_url"]).hostname
+        for info in PROVIDER_REGISTRY.values()
+        if info.get("base_url")
+    )
+    if host
+)
+
+
+def _getaddrinfo_bounded(hostname: str, port: int) -> list[Any] | None:
+    """``getaddrinfo`` with a wall-clock bound. ``None`` means "no answer"."""
+    import socket
+
+    result: list[Any] = []
+
+    def _resolve() -> None:
+        try:
+            result.extend(socket.getaddrinfo(hostname, port, type = socket.SOCK_STREAM))
+        except (OSError, UnicodeError, ValueError):
+            pass
+
+    # Daemon thread, so a resolver that never answers cannot hold up shutdown;
+    # the validator abandons it after the timeout and treats the name as
+    # unresolvable (allowed), the same as any other lookup failure.
+    thread = threading.Thread(target = _resolve, daemon = True)
+    thread.start()
+    thread.join(_DNS_TIMEOUT_SECONDS)
+    if thread.is_alive():
+        return None
+    return result or None
+
+
+def _resolves_to_metadata(hostname: str, port: int | None, scheme: str) -> bool:
+    """True when ``hostname`` resolves to a cloud metadata address."""
+    hostname = hostname.translate(_IDNA_DOTS).rstrip(".").split("%")[0]
+    if not hostname or hostname in _REGISTRY_HOSTNAMES:
+        return False
+    try:
+        # Literals were already classified by _metadata_host; no lookup needed.
+        ipaddress.ip_address(_canonical_host(hostname))
+        return False
+    except ValueError:
+        pass
+
+    now = time.monotonic()
+    with _metadata_dns_lock:
+        cached = _metadata_dns_cache.get(hostname)
+        if cached is not None and cached[0] > now:
+            return cached[1]
+
+    infos = _getaddrinfo_bounded(hostname, port or (443 if scheme == "https" else 80))
+    verdict = any(_metadata_host(str(info[4][0])) for info in infos or ())
+
+    with _metadata_dns_lock:
+        if len(_metadata_dns_cache) >= _DNS_CACHE_MAX_ENTRIES:
+            _metadata_dns_cache.clear()
+        _metadata_dns_cache[hostname] = (now + _DNS_CACHE_TTL_SECONDS, verdict)
+    return verdict
+
+
 def _reject_non_public(hostname: str, port: int | None, scheme: str) -> None:
     """Raise when ``hostname`` is, or resolves to, a non-public address."""
     import socket
@@ -642,8 +729,9 @@ def validate_provider_base_url(base_url: str) -> str:
     that can never be a real provider endpoint are refused: a non-http(s) scheme,
     control characters, a missing host, and cloud metadata services. Plain http,
     loopback, LAN hosts, odd ports, query strings and basic-auth userinfo all
-    stay valid -- Ollama, llama.cpp, vLLM and custom gateways rely on them. No
-    DNS lookup happens unless the private-address opt-in is set.
+    stay valid -- Ollama, llama.cpp, vLLM and custom gateways rely on them. A
+    caller-supplied hostname is resolved far enough to apply the metadata block
+    to DNS aliases of it; rejecting other private addresses stays opt-in.
 
     Normalization is strip + trailing-slash removal only (what the client did
     before), so validating an already-validated URL returns it unchanged.
@@ -671,7 +759,7 @@ def validate_provider_base_url(base_url: str) -> str:
         raise ValueError("Provider base URL must contain a hostname.")
 
     hostname = hostname.rstrip(".")
-    if _metadata_host(hostname):
+    if _metadata_host(hostname) or _resolves_to_metadata(hostname, port, scheme):
         raise ValueError("Cloud metadata endpoints cannot be used as a provider base URL.")
 
     if os.environ.get(_BLOCK_PRIVATE_ENV) == "1":

--- a/studio/backend/core/inference/providers.py
+++ b/studio/backend/core/inference/providers.py
@@ -626,13 +626,17 @@ def _metadata_host(hostname: str) -> bool:
 #   * a name that does not resolve is allowed, because a docker-compose or
 #     service-discovery name (http://my_ollama:11434) may only be resolvable in
 #     the client's network namespace, not in this one;
-#   * the lookup is bounded and its verdict cached, so a slow or unreachable
+#   * the lookup is bounded and its answer cached, so a slow or unreachable
 #     resolver cannot stall a request that validates the same URL every time.
+#     A client is built per request, not per token, and the route validates the
+#     same URL again, so the cache is what keeps that to one lookup.
 _DNS_TIMEOUT_SECONDS = 2.0
 _DNS_CACHE_TTL_SECONDS = 300.0
 _DNS_CACHE_MAX_ENTRIES = 512
-_metadata_dns_cache: dict[str, tuple[float, bool]] = {}
-_metadata_dns_lock = threading.Lock()
+# hostname -> (expiry, addresses). ``None`` addresses means the resolver did not
+# answer, which the two callers below read in opposite directions.
+_dns_cache: dict[str, tuple[float, tuple[str, ...] | None]] = {}
+_dns_cache_lock = threading.Lock()
 
 # Hostnames of the providers this build ships. They are hard-coded destinations,
 # not caller-controlled names, so learning their addresses buys nothing.
@@ -647,27 +651,51 @@ _REGISTRY_HOSTNAMES = frozenset(
 )
 
 
-def _getaddrinfo_bounded(hostname: str, port: int) -> list[Any] | None:
-    """``getaddrinfo`` with a wall-clock bound. ``None`` means "no answer"."""
+def _resolve_host(hostname: str, port: int | None, scheme: str) -> tuple[str, ...] | None:
+    """Addresses for ``hostname``, or ``None`` when the resolver did not answer.
+
+    Both callers share this: the always-on metadata check, which treats "no
+    answer" as nothing to refuse, and the opt-in private-address check, which
+    treats it as a refusal. One lookup and one cache entry serve both, so
+    turning the opt-in on does not double the resolver traffic.
+    """
     import socket
 
-    result: list[Any] = []
+    now = time.monotonic()
+    with _dns_cache_lock:
+        cached = _dns_cache.get(hostname)
+        if cached is not None and cached[0] > now:
+            return cached[1]
+
+    resolved: list[str] = []
+    answered = False
 
     def _resolve() -> None:
+        nonlocal answered
         try:
-            result.extend(socket.getaddrinfo(hostname, port, type = socket.SOCK_STREAM))
+            infos = socket.getaddrinfo(
+                hostname,
+                port or (443 if scheme == "https" else 80),
+                type = socket.SOCK_STREAM,
+            )
         except (OSError, UnicodeError, ValueError):
-            pass
+            return
+        resolved.extend(str(info[4][0]) for info in infos)
+        answered = True
 
     # Daemon thread, so a resolver that never answers cannot hold up shutdown;
-    # the validator abandons it after the timeout and treats the name as
-    # unresolvable (allowed), the same as any other lookup failure.
+    # the validator abandons it after the timeout and treats the name the same
+    # way it treats any other lookup failure.
     thread = threading.Thread(target = _resolve, daemon = True)
     thread.start()
     thread.join(_DNS_TIMEOUT_SECONDS)
-    if thread.is_alive():
-        return None
-    return result or None
+    addresses = tuple(resolved) if answered and not thread.is_alive() else None
+
+    with _dns_cache_lock:
+        if len(_dns_cache) >= _DNS_CACHE_MAX_ENTRIES:
+            _dns_cache.clear()
+        _dns_cache[hostname] = (now + _DNS_CACHE_TTL_SECONDS, addresses)
+    return addresses
 
 
 def _resolves_to_metadata(hostname: str, port: int | None, scheme: str) -> bool:
@@ -681,39 +709,20 @@ def _resolves_to_metadata(hostname: str, port: int | None, scheme: str) -> bool:
         return False
     except ValueError:
         pass
-
-    now = time.monotonic()
-    with _metadata_dns_lock:
-        cached = _metadata_dns_cache.get(hostname)
-        if cached is not None and cached[0] > now:
-            return cached[1]
-
-    infos = _getaddrinfo_bounded(hostname, port or (443 if scheme == "https" else 80))
-    verdict = any(_metadata_host(str(info[4][0])) for info in infos or ())
-
-    with _metadata_dns_lock:
-        if len(_metadata_dns_cache) >= _DNS_CACHE_MAX_ENTRIES:
-            _metadata_dns_cache.clear()
-        _metadata_dns_cache[hostname] = (now + _DNS_CACHE_TTL_SECONDS, verdict)
-    return verdict
+    return any(_metadata_host(address) for address in _resolve_host(hostname, port, scheme) or ())
 
 
 def _reject_non_public(hostname: str, port: int | None, scheme: str) -> None:
     """Raise when ``hostname`` is, or resolves to, a non-public address."""
-    import socket
-
     try:
         addresses = [ipaddress.ip_address(hostname)]
     except ValueError:
-        try:
-            infos = socket.getaddrinfo(
-                hostname,
-                port or (443 if scheme == "https" else 80),
-                type = socket.SOCK_STREAM,
-            )
-        except (OSError, UnicodeError) as exc:
-            raise ValueError("Provider base URL hostname could not be resolved.") from exc
-        addresses = [ipaddress.ip_address(str(info[4][0]).split("%", 1)[0]) for info in infos]
+        resolved = _resolve_host(hostname, port, scheme)
+        if resolved is None:
+            # Unlike the metadata check, this one fails closed: an operator who
+            # set the flag asked for anything unproven to be refused.
+            raise ValueError("Provider base URL hostname could not be resolved.") from None
+        addresses = [ipaddress.ip_address(address.split("%", 1)[0]) for address in resolved]
     if not addresses or any(not ip.is_global for ip in addresses):
         raise ValueError(
             "Provider base URL points at a private address, which is disabled on this "

--- a/studio/backend/core/inference/providers.py
+++ b/studio/backend/core/inference/providers.py
@@ -556,6 +556,11 @@ _METADATA_IPS = frozenset(
         "fd20:ce::254",
         "100.100.100.200",
         "100.100.100.110",
+        # metadata.tencentyun.com, on VPC and on the classic network. Listed
+        # exactly because the resolved-address check reads this set rather than
+        # the link-local network below.
+        "169.254.0.23",
+        "169.254.10.10",
     )
 )
 # Link-local, where the IPv4 metadata services live. Matched as a network so a
@@ -695,6 +700,14 @@ def _transport_host(hostname: str) -> str:
         return hostname
 
 
+def _cached_addresses(hostname: str) -> tuple[str, ...] | None:
+    """What ``_resolve_host`` already learned about ``hostname``, if anything."""
+    now = time.monotonic()
+    with _dns_cache_lock:
+        cached = _dns_cache.get(_transport_host(hostname))
+    return cached[1] if cached is not None and cached[0] > now else None
+
+
 def _resolve_host(hostname: str, port: int | None, scheme: str) -> tuple[str, ...] | None:
     """Addresses for ``hostname``, or ``None`` when the resolver did not answer.
 
@@ -705,11 +718,10 @@ def _resolve_host(hostname: str, port: int | None, scheme: str) -> tuple[str, ..
     import socket
 
     hostname = _transport_host(hostname)
+    cached = _cached_addresses(hostname)
+    if cached is not None:
+        return cached
     now = time.monotonic()
-    with _dns_cache_lock:
-        cached = _dns_cache.get(hostname)
-        if cached is not None and cached[0] > now:
-            return cached[1]
 
     # Bound to a local: a worker abandoned at the deadline may outlive the
     # global, and BoundedSemaphore raises if it releases one it never took.
@@ -781,7 +793,11 @@ def _reject_non_public(hostname: str, port: int | None, scheme: str) -> None:
     try:
         addresses = [ipaddress.ip_address(hostname)]
     except ValueError:
-        resolved = _resolve_host(hostname, port, scheme)
+        # The metadata check ran a moment ago and cached whatever it learned, so
+        # this reads that rather than starting a second bounded lookup: on a
+        # slow resolver the pair of them would each spend a deadline before the
+        # fallback below spent a third.
+        resolved = _cached_addresses(hostname)
         if resolved is None:
             # This path blocked on an unbounded getaddrinfo before the metadata
             # check existed, and a resolver slower than that check's deadline is

--- a/studio/backend/core/inference/providers.py
+++ b/studio/backend/core/inference/providers.py
@@ -646,6 +646,27 @@ _REGISTRY_HOSTNAMES = frozenset(
 )
 
 
+def _metadata_address(address: str) -> bool:
+    """``_metadata_host`` for a RESOLVED address: the exact services, no net.
+
+    The 169.254.0.0/16 clause exists to catch a caller who types a link-local
+    address at the metadata service directly, and it stays for that. It cannot
+    be applied to a resolved address: 169.254/16 is the general IPv4 link-local
+    range (RFC 3927), so a self-assigned host, an mDNS .local name on a network
+    without DHCP, or a captive portal answering every query would all read as
+    the metadata service. Those are refused today by nobody, and this change is
+    not the place to start.
+    """
+    try:
+        ip = ipaddress.ip_address(address.split("%", 1)[0])
+    except ValueError:
+        return False
+    for candidate in (getattr(ip, "ipv4_mapped", None), getattr(ip, "sixtofour", None)):
+        if candidate is not None and _metadata_address(candidate.compressed):
+            return True
+    return ip in _METADATA_IPS
+
+
 def _transport_host(hostname: str) -> str:
     """The ASCII host httpx will dial, so the checked name is the dialled name.
 
@@ -730,7 +751,7 @@ def _resolves_to_metadata(hostname: str, port: int | None, scheme: str) -> bool:
         return False
     except ValueError:
         pass
-    return any(_metadata_host(address) for address in _resolve_host(hostname, port, scheme) or ())
+    return any(_metadata_address(address) for address in _resolve_host(hostname, port, scheme) or ())
 
 
 def _reject_non_public(hostname: str, port: int | None, scheme: str) -> None:

--- a/studio/backend/core/inference/providers.py
+++ b/studio/backend/core/inference/providers.py
@@ -646,6 +646,27 @@ _REGISTRY_HOSTNAMES = frozenset(
 )
 
 
+def _transport_host(hostname: str) -> str:
+    """The ASCII host httpx will dial, so the checked name is the dialled name.
+
+    ``socket.getaddrinfo`` encodes a Unicode host with the stdlib ``idna`` codec
+    (IDNA 2003), httpx with the ``idna`` package (IDNA 2008), and the two differ
+    on the deviation characters: straße.de resolves as strasse.de through the
+    resolver and as xn--strae-oqa.de through httpx, which are different hosts
+    owned by different people. Mirrors httpx's `_urlparse.encode_host`.
+    """
+    if hostname.isascii():
+        return hostname.lower()
+    try:
+        import idna
+
+        return idna.encode(hostname.lower()).decode("ascii")
+    except Exception:
+        # httpx raises InvalidURL here, so the request cannot happen at all;
+        # resolving the name as written is then as good an answer as any.
+        return hostname
+
+
 def _resolve_host(hostname: str, port: int | None, scheme: str) -> tuple[str, ...] | None:
     """Addresses for ``hostname``, or ``None`` when the resolver did not answer.
 
@@ -655,6 +676,7 @@ def _resolve_host(hostname: str, port: int | None, scheme: str) -> tuple[str, ..
     """
     import socket
 
+    hostname = _transport_host(hostname)
     now = time.monotonic()
     with _dns_cache_lock:
         cached = _dns_cache.get(hostname)
@@ -683,7 +705,12 @@ def _resolve_host(hostname: str, port: int | None, scheme: str) -> tuple[str, ..
     thread = threading.Thread(target = _resolve, daemon = True)
     thread.start()
     thread.join(_DNS_TIMEOUT_SECONDS)
-    addresses = tuple(resolved) if answered and not thread.is_alive() else None
+    if thread.is_alive():
+        # A timeout is not an answer, so it is not remembered as one: the
+        # transport waits longer than this and would still get the address a
+        # deliberately slow authoritative server sends after the deadline.
+        return None
+    addresses = tuple(resolved) if answered else None
 
     with _dns_cache_lock:
         if len(_dns_cache) >= _DNS_CACHE_MAX_ENTRIES:

--- a/studio/backend/core/inference/providers.py
+++ b/studio/backend/core/inference/providers.py
@@ -632,6 +632,13 @@ _DNS_CACHE_MAX_ENTRIES = 512
 # answer, which the two callers below read in opposite directions.
 _dns_cache: dict[str, tuple[float, tuple[str, ...] | None]] = {}
 _dns_cache_lock = threading.Lock()
+# A lookup that times out is abandoned, not cancelled, so its thread lives until
+# the platform resolver gives up. Rotating hostnames defeat the cache and would
+# otherwise pile those up one per request. Past this many in flight the check
+# reports no answer instead of starting another, which is what this file did
+# before it resolved anything.
+_DNS_MAX_IN_FLIGHT = 8
+_dns_in_flight = threading.BoundedSemaphore(_DNS_MAX_IN_FLIGHT)
 
 # Hostnames of the providers this build ships. They are hard-coded destinations,
 # not caller-controlled names, so learning their addresses buys nothing.
@@ -704,6 +711,9 @@ def _resolve_host(hostname: str, port: int | None, scheme: str) -> tuple[str, ..
         if cached is not None and cached[0] > now:
             return cached[1]
 
+    if not _dns_in_flight.acquire(blocking = False):
+        return None
+
     resolved: list[str] = []
     answered = False
 
@@ -717,6 +727,10 @@ def _resolve_host(hostname: str, port: int | None, scheme: str) -> tuple[str, ..
             )
         except (OSError, UnicodeError, ValueError):
             return
+        finally:
+            # Released by the worker, not the caller, so an abandoned lookup
+            # frees its slot only once the resolver actually lets it go.
+            _dns_in_flight.release()
         resolved.extend(str(info[4][0]) for info in infos)
         answered = True
 

--- a/studio/backend/core/inference/providers.py
+++ b/studio/backend/core/inference/providers.py
@@ -639,10 +639,18 @@ _dns_cache: dict[str, tuple[float, tuple[str, ...]]] = {}
 _dns_cache_lock = threading.Lock()
 # A lookup that times out is abandoned, not cancelled, so its thread lives until
 # the platform resolver gives up. Rotating hostnames defeat the cache and would
-# otherwise pile those up one per request. Past this many in flight the check
-# reports no answer instead of starting another, which is what this file did
-# before it resolved anything.
-_DNS_MAX_IN_FLIGHT = 8
+# otherwise pile those up one per request, so the number in flight is capped and
+# a caller waits its turn up to the same deadline rather than being waved
+# through the moment the pool is busy.
+#
+# Saturating the pool still ends in "no answer", which the default path allows.
+# That is the same decision this file makes for a lookup that times out, and it
+# is deliberate: refusing instead would mean any resolver trouble, or any caller
+# willing to stall a few lookups, could stop the operator configuring a provider
+# at all. The check is a bound on what a caller-supplied URL may resolve to, not
+# a guarantee about what the socket will later connect to -- see the transport
+# note on _resolve_host.
+_DNS_MAX_IN_FLIGHT = 32
 _dns_in_flight = threading.BoundedSemaphore(_DNS_MAX_IN_FLIGHT)
 
 # Hostnames of the providers this build ships. They are hard-coded destinations,
@@ -726,7 +734,7 @@ def _resolve_host(hostname: str, port: int | None, scheme: str) -> tuple[str, ..
     # Bound to a local: a worker abandoned at the deadline may outlive the
     # global, and BoundedSemaphore raises if it releases one it never took.
     in_flight = _dns_in_flight
-    if not in_flight.acquire(blocking = False):
+    if not in_flight.acquire(timeout = _DNS_TIMEOUT_SECONDS):
         return None
 
     resolved: list[str] = []

--- a/studio/backend/core/inference/providers.py
+++ b/studio/backend/core/inference/providers.py
@@ -613,23 +613,18 @@ def _metadata_host(hostname: str) -> bool:
     return ip in _METADATA_IPS or (ip.version == 4 and ip in _METADATA_NETWORK)
 
 
-# The metadata block above only reads the hostname text, so a name the caller
-# controls (metadata-alias.attacker.test IN A 169.254.169.254) dials the very
-# service that block exists to refuse. Names are therefore resolved on the
-# default path too -- but only far enough to answer "is this the metadata
-# service", never to reject private addresses, which stays the opt-in above.
-#
-# Three properties keep that resolution out of the way of the endpoints people
-# actually configure:
-#   * the shipped registry hosts and IP literals skip it entirely, so the common
-#     path (a real provider, or http://127.0.0.1:11434) touches no resolver;
-#   * a name that does not resolve is allowed, because a docker-compose or
-#     service-discovery name (http://my_ollama:11434) may only be resolvable in
-#     the client's network namespace, not in this one;
-#   * the lookup is bounded and its answer cached, so a slow or unreachable
-#     resolver cannot stall a request that validates the same URL every time.
-#     A client is built per request, not per token, and the route validates the
-#     same URL again, so the cache is what keeps that to one lookup.
+# The block above only reads the hostname text, so a caller-controlled name
+# (metadata-alias.attacker.test IN A 169.254.169.254) dials the very service it
+# exists to refuse. Names are resolved on the default path too, but only far
+# enough to answer "is this metadata"; refusing other private addresses stays
+# opt-in. Three things keep that lookup off the endpoints people configure:
+#   * registry hosts and IP literals skip it, so a real provider or
+#     http://127.0.0.1:11434 touches no resolver;
+#   * a name that does not resolve is allowed -- http://my_ollama:11434 may only
+#     resolve in the client's network namespace, not in this one;
+#   * it is bounded and cached, so a dead resolver cannot stall each request.
+#     A client is built per request and the route validates the same URL again,
+#     so the cache is what keeps a request to one lookup.
 _DNS_TIMEOUT_SECONDS = 2.0
 _DNS_CACHE_TTL_SECONDS = 300.0
 _DNS_CACHE_MAX_ENTRIES = 512
@@ -654,10 +649,9 @@ _REGISTRY_HOSTNAMES = frozenset(
 def _resolve_host(hostname: str, port: int | None, scheme: str) -> tuple[str, ...] | None:
     """Addresses for ``hostname``, or ``None`` when the resolver did not answer.
 
-    Both callers share this: the always-on metadata check, which treats "no
-    answer" as nothing to refuse, and the opt-in private-address check, which
-    treats it as a refusal. One lookup and one cache entry serve both, so
-    turning the opt-in on does not double the resolver traffic.
+    One lookup and one cache entry serve both callers, which read "no answer" in
+    opposite directions: the metadata check has nothing to refuse, the opt-in
+    private-address check refuses.
     """
     import socket
 

--- a/studio/backend/core/inference/providers.py
+++ b/studio/backend/core/inference/providers.py
@@ -700,7 +700,6 @@ def _transport_host(hostname: str) -> str:
         return hostname.lower()
     try:
         import idna
-
         return idna.encode(hostname.lower()).decode("ascii")
     except Exception:
         # httpx raises InvalidURL here, so the request cannot happen at all;
@@ -793,7 +792,9 @@ def _resolves_to_metadata(hostname: str, port: int | None, scheme: str) -> bool:
         return False
     except ValueError:
         pass
-    return any(_metadata_address(address) for address in _resolve_host(hostname, port, scheme) or ())
+    return any(
+        _metadata_address(address) for address in _resolve_host(hostname, port, scheme) or ()
+    )
 
 
 def _reject_non_public(hostname: str, port: int | None, scheme: str) -> None:
@@ -813,7 +814,6 @@ def _reject_non_public(hostname: str, port: int | None, scheme: str) -> None:
             # to the same unbounded call keeps a slow-but-working resolver from
             # turning into a refusal here, where "no answer" fails closed.
             import socket
-
             try:
                 infos = socket.getaddrinfo(
                     _transport_host(hostname),

--- a/studio/backend/core/inference/providers.py
+++ b/studio/backend/core/inference/providers.py
@@ -630,7 +630,13 @@ def _metadata_host(hostname: str) -> bool:
 #   * it is bounded and cached, so a dead resolver cannot stall each request.
 #     A client is built per request and the route validates the same URL again,
 #     so the cache is what keeps a request to one lookup.
-_DNS_TIMEOUT_SECONDS = 2.0
+# Short on purpose. This validator is sync and called from async handlers, so
+# the wait is the event loop's wait, and every millisecond of it is shared by
+# every concurrent request. A provider hostname that a resolver can answer at
+# all is answered well inside this; past it the answer is treated as unknown,
+# which the default path allows and the opt-in path re-asks for without a bound.
+# So a longer deadline buys accuracy for nobody and costs latency for everyone.
+_DNS_TIMEOUT_SECONDS = 0.5
 _DNS_CACHE_TTL_SECONDS = 300.0
 _DNS_CACHE_MAX_ENTRIES = 512
 # hostname -> (expiry, addresses). Only answers land here; a failure and a

--- a/studio/backend/tests/test_provider_base_url_validation.py
+++ b/studio/backend/tests/test_provider_base_url_validation.py
@@ -238,6 +238,40 @@ def test_a_timed_out_lookup_is_not_remembered(monkeypatch):
     assert len(calls) == 2
 
 
+def test_a_resolver_slower_than_the_deadline_still_works_under_the_opt_in(monkeypatch):
+    """The opt-in path blocked unboundedly before; a slow answer is not a refusal."""
+    import time as _time
+
+    monkeypatch.setenv(BLOCK_PRIVATE_ENV, "1")
+    monkeypatch.setattr(_providers, "_DNS_TIMEOUT_SECONDS", 0.05)
+
+    def _slow(host, port, *args, **kwargs):
+        _time.sleep(0.2)
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 443))]
+
+    monkeypatch.setattr(socket, "getaddrinfo", _slow)
+    assert validate_provider_base_url("https://slowdns.example/v1") == "https://slowdns.example/v1"
+
+
+def test_a_transient_failure_is_not_remembered(monkeypatch):
+    """One SERVFAIL must not refuse the same host for the next 300 seconds."""
+    attempts = []
+
+    def _flaky(host, port, *args, **kwargs):
+        attempts.append(host)
+        if len(attempts) == 1:
+            raise socket.gaierror("temporary failure in name resolution")
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 443))]
+
+    monkeypatch.setenv(BLOCK_PRIVATE_ENV, "1")
+    monkeypatch.setattr(socket, "getaddrinfo", _flaky)
+    # The first failure is retried by the opt-in fallback rather than cached,
+    # so it costs one extra lookup instead of five minutes of refusal.
+    for _ in range(2):
+        assert validate_provider_base_url("https://flaky.example/v1") == "https://flaky.example/v1"
+    assert len(attempts) > 1
+
+
 def test_stalled_lookups_do_not_pile_up(monkeypatch):
     """Past the in-flight cap the check reports no answer instead of a thread."""
     import time as _time

--- a/studio/backend/tests/test_provider_base_url_validation.py
+++ b/studio/backend/tests/test_provider_base_url_validation.py
@@ -62,6 +62,7 @@ _SUPPORTED = [
 def _default_policy(monkeypatch):
     """Default deployment: the private-address opt-in is off."""
     monkeypatch.delenv(BLOCK_PRIVATE_ENV, raising = False)
+
     # The lookup caches its answer per hostname and caps how many can be in
     # flight; a stale entry or a slot still held by an abandoned stub would
     # carry one test's stubbed resolver into the next.

--- a/studio/backend/tests/test_provider_base_url_validation.py
+++ b/studio/backend/tests/test_provider_base_url_validation.py
@@ -85,13 +85,19 @@ def test_trailing_slash_and_whitespace_are_normalized():
 
 def test_no_dns_lookup_for_shipped_providers_or_ip_literals(monkeypatch):
     """The common path stays resolver-free: shipped hosts and IP literals."""
-    def _fail(*args, **kwargs):
-        raise AssertionError("validation must not resolve DNS for these")
+    # Recorded rather than raised: the lookup runs on a worker thread, where an
+    # exception is swallowed into a warning and would never fail this test.
+    calls = []
 
-    monkeypatch.setattr(socket, "getaddrinfo", _fail)
+    def _record(host, port, *args, **kwargs):
+        calls.append(host)
+        return []
+
+    monkeypatch.setattr(socket, "getaddrinfo", _record)
     assert validate_provider_base_url("https://api.openai.com/v1") == "https://api.openai.com/v1"
     assert validate_provider_base_url("http://127.0.0.1:11434/v1") == "http://127.0.0.1:11434/v1"
     assert validate_provider_base_url("http://[fd00:ec2::255]/v1") == "http://[fd00:ec2::255]/v1"
+    assert calls == []
 
 
 @pytest.mark.parametrize(

--- a/studio/backend/tests/test_provider_base_url_validation.py
+++ b/studio/backend/tests/test_provider_base_url_validation.py
@@ -13,6 +13,7 @@ embedded credentials, cloud metadata services -- are refused.
 
 import importlib.util
 import socket
+import threading
 from pathlib import Path
 
 import pytest
@@ -61,11 +62,16 @@ _SUPPORTED = [
 def _default_policy(monkeypatch):
     """Default deployment: the private-address opt-in is off."""
     monkeypatch.delenv(BLOCK_PRIVATE_ENV, raising = False)
-    # The metadata lookup caches its verdict per hostname; a stale entry would
+    # The lookup caches its answer per hostname and caps how many can be in
+    # flight; a stale entry or a slot still held by an abandoned stub would
     # carry one test's stubbed resolver into the next.
-    _providers._dns_cache.clear()
+    def _reset():
+        _providers._dns_cache.clear()
+        _providers._dns_in_flight = threading.BoundedSemaphore(_providers._DNS_MAX_IN_FLIGHT)
+
+    _reset()
     yield
-    _providers._dns_cache.clear()
+    _reset()
 
 
 @pytest.mark.parametrize("url", _SUPPORTED)
@@ -230,6 +236,25 @@ def test_a_timed_out_lookup_is_not_remembered(monkeypatch):
     for _ in range(2):
         assert validate_provider_base_url("http://slow.example/v1") == "http://slow.example/v1"
     assert len(calls) == 2
+
+
+def test_stalled_lookups_do_not_pile_up(monkeypatch):
+    """Past the in-flight cap the check reports no answer instead of a thread."""
+    import time as _time
+
+    monkeypatch.setattr(_providers, "_DNS_TIMEOUT_SECONDS", 0.05)
+    started = []
+
+    def _slow(host, port, *args, **kwargs):
+        started.append(host)
+        _time.sleep(30)
+        return []
+
+    monkeypatch.setattr(socket, "getaddrinfo", _slow)
+    for n in range(_providers._DNS_MAX_IN_FLIGHT + 5):
+        url = f"http://slow{n}.example/v1"
+        assert validate_provider_base_url(url) == url
+    assert len(started) == _providers._DNS_MAX_IN_FLIGHT
 
 
 def test_a_slow_resolver_does_not_stall_validation(monkeypatch):

--- a/studio/backend/tests/test_provider_base_url_validation.py
+++ b/studio/backend/tests/test_provider_base_url_validation.py
@@ -273,7 +273,11 @@ def test_a_transient_failure_is_not_remembered(monkeypatch):
 
 
 def test_stalled_lookups_do_not_pile_up(monkeypatch):
-    """Past the in-flight cap the check reports no answer instead of a thread."""
+    """Past the in-flight cap the check reports no answer instead of a thread.
+
+    The workers this leaves behind wake up long after the fixture has replaced
+    the semaphore, which is why each releases the instance it took.
+    """
     import time as _time
 
     monkeypatch.setattr(_providers, "_DNS_TIMEOUT_SECONDS", 0.05)

--- a/studio/backend/tests/test_provider_base_url_validation.py
+++ b/studio/backend/tests/test_provider_base_url_validation.py
@@ -137,6 +137,7 @@ def test_dns_alias_verdict_is_cached(monkeypatch):
 
 def test_unresolvable_names_stay_allowed(monkeypatch):
     """docker-compose / service-discovery names resolve in the client's netns."""
+
     def _unresolvable(*args, **kwargs):
         raise socket.gaierror("not resolvable here")
 

--- a/studio/backend/tests/test_provider_base_url_validation.py
+++ b/studio/backend/tests/test_provider_base_url_validation.py
@@ -61,6 +61,11 @@ _SUPPORTED = [
 def _default_policy(monkeypatch):
     """Default deployment: the private-address opt-in is off."""
     monkeypatch.delenv(BLOCK_PRIVATE_ENV, raising = False)
+    # The metadata lookup caches its verdict per hostname; a stale entry would
+    # carry one test's stubbed resolver into the next.
+    _providers._metadata_dns_cache.clear()
+    yield
+    _providers._metadata_dns_cache.clear()
 
 
 @pytest.mark.parametrize("url", _SUPPORTED)
@@ -78,12 +83,70 @@ def test_trailing_slash_and_whitespace_are_normalized():
     assert validate_provider_base_url("  http://127.0.0.1:8080/v1/  ") == "http://127.0.0.1:8080/v1"
 
 
-def test_no_dns_lookup_on_the_default_path(monkeypatch):
+def test_no_dns_lookup_for_shipped_providers_or_ip_literals(monkeypatch):
+    """The common path stays resolver-free: shipped hosts and IP literals."""
     def _fail(*args, **kwargs):
-        raise AssertionError("validation must not resolve DNS by default")
+        raise AssertionError("validation must not resolve DNS for these")
 
     monkeypatch.setattr(socket, "getaddrinfo", _fail)
     assert validate_provider_base_url("https://api.openai.com/v1") == "https://api.openai.com/v1"
+    assert validate_provider_base_url("http://127.0.0.1:11434/v1") == "http://127.0.0.1:11434/v1"
+    assert validate_provider_base_url("http://[fd00:ec2::255]/v1") == "http://[fd00:ec2::255]/v1"
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://metadata-alias.attacker.test/latest/meta-data",
+        "https://metadata-alias.attacker.test/v1",
+        # Userinfo and a trailing dot do not hide the name that gets resolved.
+        "http://api.openai.com@metadata-alias.attacker.test/v1",
+        "http://metadata-alias.attacker.test./v1",
+    ],
+)
+def test_dns_alias_of_a_metadata_address_is_refused(url, monkeypatch):
+    """A caller-controlled name pointing at the metadata service is metadata."""
+    monkeypatch.setattr(
+        socket,
+        "getaddrinfo",
+        lambda *a, **k: [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("169.254.169.254", 80))],
+    )
+    with pytest.raises(ValueError, match = "metadata"):
+        validate_provider_base_url(url)
+
+
+def test_dns_alias_verdict_is_cached(monkeypatch):
+    """Repeat validation of the same host does not re-resolve it."""
+    calls = []
+
+    def _record(host, port, *args, **kwargs):
+        calls.append(host)
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 443))]
+
+    monkeypatch.setattr(socket, "getaddrinfo", _record)
+    for _ in range(3):
+        assert validate_provider_base_url("https://gw.example/v1") == "https://gw.example/v1"
+    assert len(calls) == 1
+
+
+def test_unresolvable_names_stay_allowed(monkeypatch):
+    """docker-compose / service-discovery names resolve in the client's netns."""
+    def _unresolvable(*args, **kwargs):
+        raise socket.gaierror("not resolvable here")
+
+    monkeypatch.setattr(socket, "getaddrinfo", _unresolvable)
+    assert validate_provider_base_url("http://my_ollama:11434/v1") == "http://my_ollama:11434/v1"
+
+
+def test_a_slow_resolver_does_not_stall_validation(monkeypatch):
+    """A resolver that never answers is abandoned, and the URL is allowed."""
+    import time as _time
+
+    monkeypatch.setattr(_providers, "_DNS_TIMEOUT_SECONDS", 0.1)
+    monkeypatch.setattr(socket, "getaddrinfo", lambda *a, **k: _time.sleep(30))
+    started = _time.monotonic()
+    assert validate_provider_base_url("http://slow.example/v1") == "http://slow.example/v1"
+    assert _time.monotonic() - started < 5
 
 
 @pytest.mark.parametrize(

--- a/studio/backend/tests/test_provider_base_url_validation.py
+++ b/studio/backend/tests/test_provider_base_url_validation.py
@@ -233,6 +233,38 @@ def test_the_opt_in_path_does_not_re_resolve_after_a_timeout(monkeypatch):
     assert len(calls) == 2
 
 
+def test_an_ascii_host_is_resolved_the_way_httpx_dials_it(monkeypatch):
+    """httpx percent-encodes what a reg-name may not hold; so does the lookup."""
+    seen = []
+
+    def _record(host, port, *args, **kwargs):
+        seen.append(host)
+        if host == "safe%5Ealias.attacker.test":
+            return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("169.254.169.254", 80))]
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 80))]
+
+    monkeypatch.setattr(socket, "getaddrinfo", _record)
+    with pytest.raises(ValueError, match = "metadata"):
+        validate_provider_base_url("http://safe^alias.attacker.test/v1")
+    assert seen == ["safe%5Ealias.attacker.test"]
+
+
+def test_the_resolved_name_matches_what_httpx_would_dial():
+    """Pins _transport_host against httpx itself, for the shapes that differ."""
+    httpx = pytest.importorskip("httpx")
+    for host in [
+        "safe^alias.attacker.test",
+        "faß.attacker.test",
+        "例え.テスト",
+        "API.OpenAI.com",
+        "my_ollama",
+        "192.168.1.50",
+        "gw.example",
+    ]:
+        dialled = httpx.URL(f"http://{host}/").raw_host.decode("ascii")
+        assert _providers._transport_host(host) == dialled, host
+
+
 def test_a_unicode_host_is_resolved_the_way_httpx_dials_it(monkeypatch):
     """getaddrinfo speaks IDNA 2003, httpx IDNA 2008, and they differ on ß."""
     seen = []

--- a/studio/backend/tests/test_provider_base_url_validation.py
+++ b/studio/backend/tests/test_provider_base_url_validation.py
@@ -167,12 +167,56 @@ def test_unresolvable_names_are_refused_only_under_the_opt_in(monkeypatch):
         validate_provider_base_url("http://my_ollama:11434/v1")
 
 
+def test_a_unicode_host_is_resolved_the_way_httpx_dials_it(monkeypatch):
+    """getaddrinfo speaks IDNA 2003, httpx IDNA 2008, and they differ on ß."""
+    seen = []
+
+    def _record(host, port, *args, **kwargs):
+        seen.append(host)
+        if host == "xn--fa-hia.attacker.test":
+            return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("169.254.169.254", 80))]
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 80))]
+
+    monkeypatch.setattr(socket, "getaddrinfo", _record)
+    with pytest.raises(ValueError, match = "metadata"):
+        validate_provider_base_url("http://faß.attacker.test/v1")
+    # Not fass.attacker.test, which is what the resolver would have been asked
+    # for and is a different host with a different owner.
+    assert seen == ["xn--fa-hia.attacker.test"]
+
+
+def test_a_timed_out_lookup_is_not_remembered(monkeypatch):
+    """A slow authoritative server cannot buy a 300s window of "safe"."""
+    import time as _time
+
+    monkeypatch.setattr(_providers, "_DNS_TIMEOUT_SECONDS", 0.1)
+    calls = []
+
+    def _slow(host, port, *args, **kwargs):
+        calls.append(host)
+        _time.sleep(30)
+        return []
+
+    monkeypatch.setattr(socket, "getaddrinfo", _slow)
+    for _ in range(2):
+        assert validate_provider_base_url("http://slow.example/v1") == "http://slow.example/v1"
+    assert len(calls) == 2
+
+
 def test_a_slow_resolver_does_not_stall_validation(monkeypatch):
     """A resolver that never answers is abandoned, and the URL is allowed."""
     import time as _time
 
     monkeypatch.setattr(_providers, "_DNS_TIMEOUT_SECONDS", 0.1)
-    monkeypatch.setattr(socket, "getaddrinfo", lambda *a, **k: _time.sleep(30))
+
+    def _never_answers(*args, **kwargs):
+        # Returns a real (empty) answer rather than None: the abandoned daemon
+        # thread wakes up long after this test and would otherwise raise inside
+        # an unrelated later one.
+        _time.sleep(30)
+        return []
+
+    monkeypatch.setattr(socket, "getaddrinfo", _never_answers)
     started = _time.monotonic()
     assert validate_provider_base_url("http://slow.example/v1") == "http://slow.example/v1"
     assert _time.monotonic() - started < 5

--- a/studio/backend/tests/test_provider_base_url_validation.py
+++ b/studio/backend/tests/test_provider_base_url_validation.py
@@ -202,6 +202,36 @@ def test_a_link_local_literal_is_still_refused():
         validate_provider_base_url("http://169.254.1.1/v1")
 
 
+@pytest.mark.parametrize("address", ["169.254.0.23", "169.254.10.10"])
+def test_a_dns_alias_of_tencents_metadata_service_is_refused(address, monkeypatch):
+    """metadata.tencentyun.com lives on link-local, so it is listed exactly."""
+    monkeypatch.setattr(
+        socket,
+        "getaddrinfo",
+        lambda *a, **k: [(socket.AF_INET, socket.SOCK_STREAM, 6, "", (address, 80))],
+    )
+    with pytest.raises(ValueError, match = "metadata"):
+        validate_provider_base_url("http://alias.attacker.test/latest/meta-data")
+
+
+def test_the_opt_in_path_does_not_re_resolve_after_a_timeout(monkeypatch):
+    """One slow host, one deadline, then the unbounded fallback. Not three."""
+    import time as _time
+
+    monkeypatch.setenv(BLOCK_PRIVATE_ENV, "1")
+    monkeypatch.setattr(_providers, "_DNS_TIMEOUT_SECONDS", 0.05)
+    calls = []
+
+    def _slow(host, port, *args, **kwargs):
+        calls.append(host)
+        _time.sleep(0.2)
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 443))]
+
+    monkeypatch.setattr(socket, "getaddrinfo", _slow)
+    assert validate_provider_base_url("https://slowdns.example/v1") == "https://slowdns.example/v1"
+    assert len(calls) == 2
+
+
 def test_a_unicode_host_is_resolved_the_way_httpx_dials_it(monkeypatch):
     """getaddrinfo speaks IDNA 2003, httpx IDNA 2008, and they differ on ß."""
     seen = []

--- a/studio/backend/tests/test_provider_base_url_validation.py
+++ b/studio/backend/tests/test_provider_base_url_validation.py
@@ -63,9 +63,9 @@ def _default_policy(monkeypatch):
     monkeypatch.delenv(BLOCK_PRIVATE_ENV, raising = False)
     # The metadata lookup caches its verdict per hostname; a stale entry would
     # carry one test's stubbed resolver into the next.
-    _providers._metadata_dns_cache.clear()
+    _providers._dns_cache.clear()
     yield
-    _providers._metadata_dns_cache.clear()
+    _providers._dns_cache.clear()
 
 
 @pytest.mark.parametrize("url", _SUPPORTED)
@@ -135,14 +135,36 @@ def test_dns_alias_verdict_is_cached(monkeypatch):
     assert len(calls) == 1
 
 
-def test_unresolvable_names_stay_allowed(monkeypatch):
-    """docker-compose / service-discovery names resolve in the client's netns."""
+def test_the_opt_in_path_shares_the_one_lookup(monkeypatch):
+    """Turning the private-address flag on does not double the resolver load."""
+    calls = []
+
+    def _record(host, port, *args, **kwargs):
+        calls.append(host)
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 443))]
+
+    monkeypatch.setenv(BLOCK_PRIVATE_ENV, "1")
+    monkeypatch.setattr(socket, "getaddrinfo", _record)
+    assert validate_provider_base_url("https://gw.example/v1") == "https://gw.example/v1"
+    assert len(calls) == 1
+
+
+def test_unresolvable_names_are_refused_only_under_the_opt_in(monkeypatch):
+    """The same "no answer" reads as allow by default and refuse when opted in.
+
+    docker-compose and service-discovery names resolve in the client's network
+    namespace, not this one, so the default path cannot read silence as guilt.
+    """
 
     def _unresolvable(*args, **kwargs):
         raise socket.gaierror("not resolvable here")
 
     monkeypatch.setattr(socket, "getaddrinfo", _unresolvable)
     assert validate_provider_base_url("http://my_ollama:11434/v1") == "http://my_ollama:11434/v1"
+
+    monkeypatch.setenv(BLOCK_PRIVATE_ENV, "1")
+    with pytest.raises(ValueError, match = "could not be resolved"):
+        validate_provider_base_url("http://my_ollama:11434/v1")
 
 
 def test_a_slow_resolver_does_not_stall_validation(monkeypatch):

--- a/studio/backend/tests/test_provider_base_url_validation.py
+++ b/studio/backend/tests/test_provider_base_url_validation.py
@@ -167,6 +167,35 @@ def test_unresolvable_names_are_refused_only_under_the_opt_in(monkeypatch):
         validate_provider_base_url("http://my_ollama:11434/v1")
 
 
+@pytest.mark.parametrize(
+    "address",
+    [
+        # A self-assigned host, an mDNS .local name on a network without DHCP,
+        # and a captive portal answering every query all land in 169.254/16.
+        "169.254.3.7",
+        "169.254.1.1",
+        # A LAN gateway and an ordinary public answer are equally none of our
+        # business on the default path.
+        "192.168.1.50",
+        "93.184.216.34",
+    ],
+)
+def test_a_name_resolving_to_a_non_metadata_address_stays_allowed(address, monkeypatch):
+    """Only the metadata services themselves, not the whole link-local range."""
+    monkeypatch.setattr(
+        socket,
+        "getaddrinfo",
+        lambda *a, **k: [(socket.AF_INET, socket.SOCK_STREAM, 6, "", (address, 80))],
+    )
+    assert validate_provider_base_url("http://box.local:11434/v1") == "http://box.local:11434/v1"
+
+
+def test_a_link_local_literal_is_still_refused():
+    """Typing the address stays refused, which is what main already did."""
+    with pytest.raises(ValueError, match = "metadata"):
+        validate_provider_base_url("http://169.254.1.1/v1")
+
+
 def test_a_unicode_host_is_resolved_the_way_httpx_dials_it(monkeypatch):
     """getaddrinfo speaks IDNA 2003, httpx IDNA 2008, and they differ on ß."""
     seen = []


### PR DESCRIPTION
## Summary

`validate_provider_base_url()` documents the cloud metadata refusal as always on, but `_metadata_host()` only inspects the hostname text: hardcoded names plus IP literals in every spelling. The only code path that resolves DNS, `_reject_non_public()`, runs solely when `UNSLOTH_STUDIO_BLOCK_PRIVATE_PROVIDER_URLS=1`, which is off by default.

So in the default configuration `http://alias.attacker.test/` with an A record of `169.254.169.254` is accepted. `ExternalProviderClient` stores it and every chat, models and responses call goes out to it with `_auth_headers()` attached, which is the exact request the metadata block exists to prevent.

Names are now resolved far enough to answer "is this the metadata service". Private-address rejection is untouched and stays opt-in.

## Keeping the configurable endpoints working

The reason the resolution was opt-in is that provider base URLs are user supplied and often local, so a validator that resolves them can break a working setup. Three properties keep this one out of the way:

- shipped registry hosts and IP literals skip the lookup entirely, so `https://api.openai.com/v1`, `http://localhost:11434/v1` and `http://127.0.0.1:8080/v1` touch no resolver at all
- a name that does not resolve is allowed. `http://my_ollama:11434` may only be resolvable in the client's network namespace, not the server's, and a lookup failure is not evidence of anything
- the lookup is bounded at 2s on a daemon thread and its verdict cached for 300s per host, so a slow or unreachable resolver cannot stall the event loop or hold up shutdown, and revalidating the same URL on every request resolves once

Validation stays idempotent: an already validated URL returns unchanged, and the repeat is lookup free.

## Not covered

DNS rebinding, where a name resolves benign at validation time and to metadata at connect time, still gets through. Closing it needs a peer address check in the httpx transport rather than in the validator, which is separate work.

## Tests

`test_no_dns_lookup_on_the_default_path` pinned the vulnerable behaviour, so it is replaced by `test_no_dns_lookup_for_shipped_providers_or_ip_literals`, which pins the part that is worth keeping: the common path is resolver free.

New cases cover the alias rejection across schemes, userinfo and a trailing dot, the cached verdict, unresolvable service discovery names staying allowed, and a resolver that never answers being abandoned rather than stalling. The autouse fixture clears the verdict cache so one test's stubbed resolver cannot leak into the next.

110 passed. The suite's `conftest.py` does not import in my environment (missing `structlog` and `huggingface_hub`, present on main too), so I ran the file from a sibling directory. It loads `providers.py` by path and needs no app dependencies.

## Verification

Reproduced the accepted alias against `main` with a stubbed resolver, then confirmed it is refused on this branch while `http://my_ollama:11434/v1`, `http://localhost:11434/v1`, `https://api.openai.com/v1` and `http://127.0.0.1:8080/v1` all stay accepted and idempotent.
