### PR TITLE
Studio tests: do not dump core when a probe child is crashed on purpose

### DIFF
--- a/studio/backend/tests/test_rag_embeddings.py
+++ b/studio/backend/tests/test_rag_embeddings.py
@@ -16,6 +16,22 @@ import pytest
 from core.rag import config, embeddings
 
 
+# A child that dies of SIGSEGV is still handed to the host's core_pattern handler
+# (apport on Ubuntu), which reads the whole core before the child is reaped. Marking
+# the child non-dumpable first keeps the SIGSEGV this test needs and writes no core.
+# RLIMIT_CORE = 0 does NOT work here, because a piped core_pattern ignores it.
+# prctl is Linux-only, so the call is guarded and does nothing elsewhere.
+_CRASHING_UNLESS_CPU_SCRIPT = (
+    "import ctypes, sys\n"
+    "if sys.argv[1] != 'cpu':\n"
+    "    try:\n"
+    "        ctypes.CDLL(None).prctl(4, 0, 0, 0, 0)  # PR_SET_DUMPABLE = 0\n"
+    "    except Exception:\n"
+    "        pass\n"
+    "    ctypes.string_at(0)\n"
+)
+
+
 @pytest.fixture(autouse = True)
 def _pin_st_backend(monkeypatch):
     # Tests patch ST internals (_get), so force the ST backend.
@@ -501,7 +517,7 @@ def test_a_real_crashing_child_moves_the_load_to_cpu(monkeypatch):
     monkeypatch.setattr(
         torch_device_probe,
         "_PROBE_SCRIPT",
-        "import ctypes, sys\nif sys.argv[1] != 'cpu': ctypes.string_at(0)",
+        _CRASHING_UNLESS_CPU_SCRIPT,
     )
     torch_device_probe.device_can_allocate.cache_clear()
     monkeypatch.setattr(embeddings, "_device", lambda: "cuda")

--- a/studio/backend/tests/test_torch_device_probe.py
+++ b/studio/backend/tests/test_torch_device_probe.py
@@ -16,6 +16,23 @@ import pytest
 from utils import process_lifetime, torch_device_probe
 
 
+# A child that dies of SIGSEGV is still handed to the host's core_pattern handler
+# (apport on Ubuntu), which reads the whole core before the child is reaped: a
+# multi-MB write and roughly 4x the wall time per fault, on every run of this suite.
+# Marking the child non-dumpable first keeps the SIGSEGV the test needs and writes
+# no core. RLIMIT_CORE = 0 does NOT work here, because a piped core_pattern ignores
+# it; PR_SET_DUMPABLE is the only thing that suppresses the dump. prctl is
+# Linux-only, so the call is guarded and simply does nothing elsewhere.
+_SUPPRESS_CORE = (
+    "import ctypes\n"
+    "try:\n"
+    "    ctypes.CDLL(None).prctl(4, 0, 0, 0, 0)  # PR_SET_DUMPABLE = 0\n"
+    "except Exception:\n"
+    "    pass\n"
+)
+_CRASHING_SCRIPT = _SUPPRESS_CORE + "ctypes.string_at(0)\n"
+
+
 @pytest.fixture(autouse = True)
 def _fresh_probe(monkeypatch):
     monkeypatch.setenv(torch_device_probe.DISABLE_ENV_VAR, "0")
@@ -86,7 +103,7 @@ def test_probe_script_initializes_blas_and_synchronizes():
 
 
 def test_child_that_crashes_marks_the_device_unusable(monkeypatch):
-    _run_script(monkeypatch, "import ctypes; ctypes.string_at(0)")
+    _run_script(monkeypatch, _CRASHING_SCRIPT)
     assert torch_device_probe.device_can_allocate("cuda") is False
 
 

--- a/tests/test_deliberate_crashes_suppress_cores.py
+++ b/tests/test_deliberate_crashes_suppress_cores.py
@@ -37,29 +37,28 @@ considered, and comments cannot satisfy the suppression side either.
 from __future__ import annotations
 
 import ast
+from functools import lru_cache
 from pathlib import Path
-
-import pytest
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
-# Directories holding test suites. Anything under these is scanned.
-_TEST_ROOTS = (
-    REPO_ROOT / "tests",
-    REPO_ROOT / "studio" / "backend" / "tests",
-)
+_SKIP_DIRS = {".git", "node_modules", "__pycache__", ".venv", "venv", "temp", "build", "dist"}
 
-# Substrings that mean "this code, or this string handed to a child interpreter,
-# deliberately takes a fatal signal that dumps core".
+# Unconditional: these can only be a deliberate fatal fault.
 _CRASH_MARKERS = (
     "string_at(0)",  # ctypes.string_at(0) -> strlen(NULL) -> SIGSEGV
     "os.abort()",  # SIGABRT
-    "raise_signal(",  # signal.raise_signal(signal.SIGSEGV) and friends
     "_sigsegv(",  # faulthandler._sigsegv()
 )
 
-# A kill aimed at self only dumps core for these. SIGKILL and SIGTERM do not.
+# Conditional: these are only a deliberate crash when aimed at a core-dumping
+# signal. `signal.raise_signal(signum)` re-raising SIGINT after restoring the
+# default handler is the normal terminal-prompt idiom and must not be flagged.
+_SIGNAL_DIRECTED = ("raise_signal(", "os.kill(", ".kill(")
+
+# A signal aimed at self dumps core only for these. SIGKILL, SIGTERM and SIGINT
+# do not, which is why SIGKILL is the recommended way to make a child vanish.
 _FATAL_SIGNALS = ("SIGSEGV", "SIGABRT", "SIGBUS", "SIGILL", "SIGFPE", "SIGTRAP")
 
 # Either spelling counts as suppressing the dump.
@@ -68,12 +67,36 @@ _SUPPRESS_MARKERS = ("PR_SET_DUMPABLE", "prctl(4")
 _PRCTL_SET_DUMPABLE = 4
 
 
-def _iter_test_files():
-    for root in _TEST_ROOTS:
-        if not root.is_dir():
+def _test_roots():
+    """Every directory named `tests` in the repo, found rather than listed.
+
+    Hardcoding the roots means a suite added later is silently unguarded, which is
+    how this check would quietly stop being worth running.
+    """
+    roots = []
+    for path in REPO_ROOT.rglob("tests"):
+        if not path.is_dir():
             continue
-        for path in sorted(root.rglob("test_*.py")):
-            yield path
+        if any(part in _SKIP_DIRS for part in path.relative_to(REPO_ROOT).parts):
+            continue
+        roots.append(path)
+    return sorted(roots)
+
+
+def _iter_test_files():
+    """Every Python file under a test root, not only `test_*.py`.
+
+    conftest.py, shared harnesses and the `_*_shim.py` files CI invokes directly can
+    all spawn children, so restricting this to `test_*.py` would leave a real hole.
+    """
+    seen = set()
+    for root in _test_roots():
+        for path in sorted(root.rglob("*.py")):
+            if any(part in _SKIP_DIRS for part in path.relative_to(REPO_ROOT).parts):
+                continue
+            if path.resolve() not in seen:
+                seen.add(path.resolve())
+                yield path
 
 
 def _docstring_nodes(tree):
@@ -102,16 +125,20 @@ def _code_strings(tree):
     ]
 
 
-def _self_kill_with_fatal_signal(tree) -> bool:
-    """os.kill(os.getpid(), signal.SIGSEGV) and similar, as real code."""
+def _directs_a_fatal_signal(tree) -> bool:
+    """A call that aims a core-dumping signal at a process, as real code.
+
+    Only fires when a fatal signal is named in the call. `raise_signal(signum)` with
+    a variable, the re-raise-after-restoring-the-default-handler idiom, is not a
+    deliberate crash and must not be flagged.
+    """
     for node in ast.walk(tree):
-        if not isinstance(node, ast.Call):
-            continue
-        func = ast.unparse(node.func) if node.args else ""
-        if not func.endswith("kill"):
+        if not isinstance(node, ast.Call) or not node.args:
             continue
         rendered = ast.unparse(node)
-        if "getpid()" in rendered and any(sig in rendered for sig in _FATAL_SIGNALS):
+        if not any(marker in rendered for marker in _SIGNAL_DIRECTED):
+            continue
+        if any(sig in rendered for sig in _FATAL_SIGNALS):
             return True
     return False
 
@@ -131,17 +158,36 @@ def _calls_prctl_set_dumpable(tree) -> bool:
     return False
 
 
+# Anything that could possibly make _classify say "crashes". Used as a raw-text
+# prefilter: the AST is a subset of the source, so a file whose text contains none of
+# these cannot match, and parsing it would be wasted work. This is what keeps the
+# check cheap. Without it, unparsing every Call node in ~1000 files costs ~9s; with
+# it, only a handful of files are ever parsed.
+_PREFILTER = _CRASH_MARKERS + _SIGNAL_DIRECTED
+
+
+@lru_cache(maxsize = None)
 def _classify(path):
-    """Return (crashes_on_purpose, suppresses_core) for one test file."""
-    tree = ast.parse(path.read_text(encoding = "utf-8", errors = "replace"), str(path))
+    """Return (crashes_on_purpose, suppresses_core) for one file."""
+    source = path.read_text(encoding = "utf-8", errors = "replace")
+    if not any(marker in source for marker in _PREFILTER):
+        return False, False
+
+    try:
+        tree = ast.parse(source, str(path))
+    except SyntaxError:
+        # Fixture files that are deliberately unparseable are not running anything.
+        return False, False
     strings = _code_strings(tree)
 
-    crashes = _self_kill_with_fatal_signal(tree) or any(
+    crashes = _directs_a_fatal_signal(tree) or any(
         marker in text for text in strings for marker in _CRASH_MARKERS
     )
-    # A self-kill written inside a child-script string counts too.
+    # The same, written inside a script string handed to a child interpreter.
     for text in strings:
-        if "getpid()" in text and any(sig in text for sig in _FATAL_SIGNALS):
+        if any(marker in text for marker in _SIGNAL_DIRECTED) and any(
+            sig in text for sig in _FATAL_SIGNALS
+        ):
             crashes = True
 
     suppresses = _calls_prctl_set_dumpable(tree) or any(
@@ -150,30 +196,42 @@ def _classify(path):
     return crashes, suppresses
 
 
+_FIX = """\
+Add this to the child before it faults:
+
+    ctypes.CDLL(None).prctl(4, 0, 0, 0, 0)   # PR_SET_DUMPABLE = 0
+
+The child still dies of the same signal, so nothing you assert changes.
+
+Two traps:
+  * prctl is Linux-only, so guard the call. It is a no-op elsewhere.
+  * RLIMIT_CORE = 0 looks like the fix and is NOT: a piped core_pattern ignores
+    it, measured at 117ms and still dumping.
+
+If you only need the child to vanish rather than to take a specific signal, use
+SIGKILL instead. SIGKILL never produces a core."""
+
+
 def test_the_scan_finds_the_files_it_is_meant_to_guard():
-    """A silent scan that matches nothing would pass forever and protect nothing."""
+    """A silent scan matching nothing would pass forever and protect nothing."""
     crashing = [p for p in _iter_test_files() if _classify(p)[0]]
-    assert crashing, "no deliberate-crash tests found; the scan or the markers are wrong"
+    assert crashing, (
+        "no deliberate-crash files matched, so this check is guarding an empty set. "
+        "Either the markers or the test roots are wrong."
+    )
 
 
-@pytest.mark.parametrize(
-    "path",
-    [pytest.param(p, id = str(p.relative_to(REPO_ROOT))) for p in _iter_test_files()],
-)
-def test_deliberate_crash_suppresses_its_core(path):
-    crashes, suppresses = _classify(path)
-    if not crashes:
-        return
-    assert suppresses, (
-        f"{path.relative_to(REPO_ROOT)} crashes a process on purpose but does not "
-        f"suppress the core dump.\n\n"
-        f"A fatal signal here is piped to the host core_pattern handler (apport on "
-        f"Ubuntu), which reads the whole core before the child is reaped: about 4x the "
-        f"wall time and a multi-MB write per fault, on every run of this suite.\n\n"
-        f"Add this to the child before it faults:\n"
-        f"    ctypes.CDLL(None).prctl(4, 0, 0, 0, 0)   # PR_SET_DUMPABLE = 0\n\n"
-        f"The child still dies of the same signal, so nothing you assert changes. Guard "
-        f"the call, since prctl is Linux-only. RLIMIT_CORE = 0 does NOT work: a piped "
-        f"core_pattern ignores it. If you only need the child to vanish rather than to "
-        f"take a specific signal, use SIGKILL, which never dumps core."
+def test_every_deliberate_crash_suppresses_its_core():
+    offenders = [
+        p.relative_to(REPO_ROOT)
+        for p in _iter_test_files()
+        if _classify(p) == (True, False)
+    ]
+    assert not offenders, (
+        "These files crash a process on purpose without suppressing the core dump:\n\n"
+        + "".join(f"    {p}\n" for p in offenders)
+        + "\nA fatal signal is piped to the host core_pattern handler (apport on "
+        "Ubuntu), which reads the WHOLE core before the child is reaped: about 4x the "
+        "wall time and a multi-MB write per fault, every run.\n\n"
+        + _FIX
     )

--- a/tests/test_deliberate_crashes_suppress_cores.py
+++ b/tests/test_deliberate_crashes_suppress_cores.py
@@ -223,15 +223,12 @@ def test_the_scan_finds_the_files_it_is_meant_to_guard():
 
 def test_every_deliberate_crash_suppresses_its_core():
     offenders = [
-        p.relative_to(REPO_ROOT)
-        for p in _iter_test_files()
-        if _classify(p) == (True, False)
+        p.relative_to(REPO_ROOT) for p in _iter_test_files() if _classify(p) == (True, False)
     ]
     assert not offenders, (
         "These files crash a process on purpose without suppressing the core dump:\n\n"
         + "".join(f"    {p}\n" for p in offenders)
         + "\nA fatal signal is piped to the host core_pattern handler (apport on "
         "Ubuntu), which reads the WHOLE core before the child is reaped: about 4x the "
-        "wall time and a multi-MB write per fault, every run.\n\n"
-        + _FIX
+        "wall time and a multi-MB write per fault, every run.\n\n" + _FIX
     )

--- a/tests/test_deliberate_crashes_suppress_cores.py
+++ b/tests/test_deliberate_crashes_suppress_cores.py
@@ -170,9 +170,7 @@ def _snippet_suppresses(snippet: str) -> bool:
 def _snippet_crashes(snippet: str) -> bool:
     if any(marker in snippet for marker in _CRASH_MARKERS):
         return True
-    return any(m in snippet for m in _SIGNAL_DIRECTED) and any(
-        s in snippet for s in _FATAL_SIGNALS
-    )
+    return any(m in snippet for m in _SIGNAL_DIRECTED) and any(s in snippet for s in _FATAL_SIGNALS)
 
 
 def _fold(node, env):
@@ -264,9 +262,9 @@ def _enclosing_scopes(tree):
 
     def walk(scope, node):
         for child in ast.iter_child_nodes(node):
-            next_scope = child if isinstance(
-                child, (ast.FunctionDef, ast.AsyncFunctionDef)
-            ) else scope
+            next_scope = (
+                child if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)) else scope
+            )
             owner[id(child)] = next_scope
             walk(next_scope, child)
 
@@ -344,9 +342,7 @@ SIGKILL instead. SIGKILL never produces a core."""
 # stays fixed. `want_violations` is whether the file should be reported.
 _FIXTURES = {
     "crash_written_as_real_code": (
-        "import ctypes\n"
-        "def child():\n"
-        "    ctypes.string_at(0)\n",
+        "import ctypes\ndef child():\n    ctypes.string_at(0)\n",
         True,  # not inside a script string, and still dumps a core
     ),
     "suppression_in_the_same_function": (
@@ -384,9 +380,7 @@ _FIXTURES = {
         True,  # prctl(4, 1) re-enables dumps, so this still dumps
     ),
     "signal_named_in_a_comment_only": (
-        "# this used to raise SIGSEGV, now it returns\n"
-        "def child():\n"
-        "    return -11\n",
+        "# this used to raise SIGSEGV, now it returns\ndef child():\n    return -11\n",
         False,
     ),
     "reraise_of_a_variable_signal": (
@@ -397,9 +391,7 @@ _FIXTURES = {
         False,  # the terminal-prompt idiom, no fatal signal named
     ),
     "unrelated_abort_methods": (
-        "def go(route, task):\n"
-        "    route.abort('failed')\n"
-        "    task.abort()\n",
+        "def go(route, task):\n    route.abort('failed')\n    task.abort()\n",
         False,  # Playwright and friends share the name and crash nothing
     ),
 }
@@ -411,9 +403,9 @@ def test_the_detector_is_not_fooled(tmp_path, name):
     path = tmp_path / f"{name}.py"
     path.write_text(source, encoding = "utf-8")
     crashes, violations = _analyze(path)
-    assert bool(violations) is want_violations, (
-        f"{name}: expected violations={want_violations}, got {violations or '()'}"
-    )
+    assert (
+        bool(violations) is want_violations
+    ), f"{name}: expected violations={want_violations}, got {violations or '()'}"
     if want_violations:
         assert crashes, f"{name}: a reported file must also count as crashing"
 
@@ -432,9 +424,7 @@ def test_the_scan_finds_the_files_it_is_meant_to_guard():
 
 def test_every_deliberate_crash_suppresses_its_core():
     offenders = {
-        p.relative_to(REPO_ROOT): _violations(p)
-        for p in _iter_test_files()
-        if _violations(p)
+        p.relative_to(REPO_ROOT): _violations(p) for p in _iter_test_files() if _violations(p)
     }
     report = "".join(
         f"    {path}\n" + "".join(f"        {why}\n" for why in whys)
@@ -445,6 +435,5 @@ def test_every_deliberate_crash_suppresses_its_core():
         + report
         + "\nA fatal signal is piped to the host core_pattern handler (apport on "
         "Ubuntu), which reads the WHOLE core before the child is reaped: about 4x the "
-        "wall time and a multi-MB write per fault, every run.\n\n"
-        + _FIX
+        "wall time and a multi-MB write per fault, every run.\n\n" + _FIX
     )

--- a/tests/test_deliberate_crashes_suppress_cores.py
+++ b/tests/test_deliberate_crashes_suppress_cores.py
@@ -27,11 +27,19 @@ piped core_pattern ignores it, measured at 117ms and still dumping. If the test 
 needs "the child vanished" rather than a specific signal, prefer SIGKILL, which never
 produces a core.
 
-Detection is AST-based on purpose. Roughly forty places in this suite mention SIGSEGV
-or SIGABRT in a comment, a docstring, or a return-code assertion such as
-`assert f(-11) is True`, and none of those crash anything. A textual scan would be
-almost entirely false positives, so only real calls and real child-script strings are
-considered, and comments cannot satisfy the suppression side either.
+Three things this deliberately gets right, each of which it got wrong first:
+
+  * Detection is AST-based. Roughly forty places in this suite mention SIGSEGV or
+    SIGABRT in a comment, a docstring, or a return-code assertion such as
+    `assert f(-11) is True`, and none of those crash anything. A textual scan would be
+    almost entirely false positives, and comments could satisfy the suppression side.
+  * A crash written as ordinary code counts, not only one inside a `-c` script string.
+    A `multiprocessing` target that calls `ctypes.string_at(0)` dumps exactly the same
+    core as a script string that does.
+  * Suppression is matched to the crash it is meant to cover, not to the file. A file
+    that defines a suppressed helper must not thereby bless a naked crash added to it
+    later, which is the most likely way this regresses given the files that now
+    contain such helpers.
 """
 
 from __future__ import annotations
@@ -40,39 +48,49 @@ import ast
 from functools import lru_cache
 from pathlib import Path
 
+import pytest
+
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+_SELF = Path(__file__).resolve()
 
 _SKIP_DIRS = {".git", "node_modules", "__pycache__", ".venv", "venv", "temp", "build", "dist"}
 
-# Unconditional: these can only be a deliberate fatal fault.
-_CRASH_MARKERS = (
-    "string_at(0)",  # ctypes.string_at(0) -> strlen(NULL) -> SIGSEGV
-    "os.abort()",  # SIGABRT
-    "_sigsegv(",  # faulthandler._sigsegv()
-)
+# Calls that can only be a deliberate fatal fault, keyed by the trailing attribute.
+# `arg0` is a required literal first argument, `owners` a set of acceptable receivers.
+# `abort` needs the receiver check: Playwright's `route.abort()` and a thread's
+# `.abort()` are ordinary calls that share the name and crash nothing.
+_CRASH_CALLS = {
+    "string_at": {"arg0": 0},  # ctypes.string_at(0) -> strlen(NULL) -> SIGSEGV
+    "abort": {"owners": ("os", "ctypes", "libc", "CDLL")},  # -> SIGABRT
+    "_sigsegv": {},  # faulthandler._sigsegv()
+}
 
-# Conditional: these are only a deliberate crash when aimed at a core-dumping
-# signal. `signal.raise_signal(signum)` re-raising SIGINT after restoring the
-# default handler is the normal terminal-prompt idiom and must not be flagged.
+# Textual form of the same, for snippets handed to a child interpreter.
+_CRASH_MARKERS = ("string_at(0)", "os.abort()", "_sigsegv(")
+
+# Only a deliberate crash when aimed at a core-dumping signal. `raise_signal(signum)`
+# re-raising SIGINT after restoring the default handler is the normal terminal-prompt
+# idiom and must not be flagged.
 _SIGNAL_DIRECTED = ("raise_signal(", "os.kill(", ".kill(")
+_DIRECTED_NAMES = {"raise_signal", "kill"}
 
-# A signal aimed at self dumps core only for these. SIGKILL, SIGTERM and SIGINT
-# do not, which is why SIGKILL is the recommended way to make a child vanish.
+# A signal aimed at self dumps core only for these. SIGKILL, SIGTERM and SIGINT do not,
+# which is why SIGKILL is the recommended way to make a child vanish.
 _FATAL_SIGNALS = ("SIGSEGV", "SIGABRT", "SIGBUS", "SIGILL", "SIGFPE", "SIGTRAP")
 
-# Either spelling counts as suppressing the dump.
-_SUPPRESS_MARKERS = ("PR_SET_DUMPABLE", "prctl(4")
+_PR_SET_DUMPABLE = 4
 
-_PRCTL_SET_DUMPABLE = 4
+# Raw-text prefilter, run before any parsing. The AST is a subset of the source, so a
+# file whose text holds none of these cannot match and parsing it is wasted work. This
+# is what keeps the check cheap: 32 of ~1050 files are actually parsed, 496ms rather
+# than 9s.
+_PREFILTER = _CRASH_MARKERS + _SIGNAL_DIRECTED + ("abort(",)
 
 
 def _test_roots():
-    """Every directory named `tests` in the repo, found rather than listed.
-
-    Hardcoding the roots means a suite added later is silently unguarded, which is
-    how this check would quietly stop being worth running.
-    """
+    """Every directory named `tests`, found rather than listed, so a suite added later
+    is guarded without anyone remembering to update a list here."""
     roots = []
     for path in REPO_ROOT.rglob("tests"):
         if not path.is_dir():
@@ -88,19 +106,119 @@ def _iter_test_files():
 
     conftest.py, shared harnesses and the `_*_shim.py` files CI invokes directly can
     all spawn children, so restricting this to `test_*.py` would leave a real hole.
+    This module is excluded: it necessarily contains every marker it looks for.
     """
     seen = set()
     for root in _test_roots():
         for path in sorted(root.rglob("*.py")):
+            resolved = path.resolve()
+            if resolved == _SELF or resolved in seen:
+                continue
             if any(part in _SKIP_DIRS for part in path.relative_to(REPO_ROOT).parts):
                 continue
-            if path.resolve() not in seen:
-                seen.add(path.resolve())
-                yield path
+            seen.add(resolved)
+            yield path
 
 
-def _docstring_nodes(tree):
-    """Constant nodes that are docstrings, which must not count as either signal."""
+def _called_name(node):
+    """Trailing attribute of a call, without unparsing it.
+
+    `ast.unparse` on every Call in the suite is what made an earlier version of this
+    check cost 9s. Almost every call is ruled out by its name alone, so unparse only
+    the handful that survive.
+    """
+    if not isinstance(node, ast.Call):
+        return None
+    func = node.func
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    if isinstance(func, ast.Name):
+        return func.id
+    return None
+
+
+def _prctl_clears_dumpable(node) -> bool:
+    """A prctl(PR_SET_DUMPABLE, 0, ...) call. The value argument matters: prctl(4, 1)
+    re-enables dumps, so treating any PR_SET_DUMPABLE call as suppression would bless a
+    crash that still dumps."""
+    if _called_name(node) != "prctl" or len(node.args) < 2:
+        return False
+    cmd, value = node.args[0], node.args[1]
+    cmd_ok = (isinstance(cmd, ast.Constant) and cmd.value == _PR_SET_DUMPABLE) or (
+        isinstance(cmd, ast.Name) and cmd.id.endswith("PR_SET_DUMPABLE")
+    )
+    return cmd_ok and isinstance(value, ast.Constant) and value.value == 0
+
+
+def _scope_suppresses(scope) -> bool:
+    """Whether this function (or module) clears the dumpable flag anywhere in it."""
+    return any(_prctl_clears_dumpable(n) for n in ast.walk(scope))
+
+
+def _snippet_suppresses(snippet: str) -> bool:
+    """Whether a child-script snippet clears the dumpable flag.
+
+    Snippets are Python source, so parse them and ask the same question. Fragments that
+    do not parse fall back to a textual check.
+    """
+    try:
+        return _scope_suppresses(ast.parse(snippet))
+    except SyntaxError:
+        return "prctl(4, 0" in snippet or "PR_SET_DUMPABLE, 0" in snippet
+
+
+def _snippet_crashes(snippet: str) -> bool:
+    if any(marker in snippet for marker in _CRASH_MARKERS):
+        return True
+    return any(m in snippet for m in _SIGNAL_DIRECTED) and any(
+        s in snippet for s in _FATAL_SIGNALS
+    )
+
+
+def _fold(node, env):
+    """Constant-fold a string expression. Returns (value, consumed literal ids).
+
+    Needed so `_SAFE = _SUPPRESS + "ctypes.string_at(0)"` is judged as the script it
+    actually becomes, rather than as a bare literal with no suppression next to it.
+    """
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value, {id(node)}
+    if isinstance(node, ast.Name):
+        return env.get(node.id), set()
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Add):
+        left, lids = _fold(node.left, env)
+        right, rids = _fold(node.right, env)
+        if left is not None and right is not None:
+            return left + right, lids | rids
+    return None, set()
+
+
+def _snippets(tree):
+    """Candidate child scripts: folded module constants, then unconsumed literals."""
+    env, consumed = {}, set()
+    for node in tree.body:
+        if not isinstance(node, ast.Assign) or len(node.targets) != 1:
+            continue
+        target = node.targets[0]
+        if not isinstance(target, ast.Name):
+            continue
+        value, ids = _fold(node.value, env)
+        if value is not None:
+            env[target.id] = value
+            consumed |= ids
+
+    docstrings = _docstring_ids(tree)
+    out = list(env.values())
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Constant) or not isinstance(node.value, str):
+            continue
+        if id(node) in consumed or id(node) in docstrings:
+            continue
+        out.append(node.value)
+    return out
+
+
+def _docstring_ids(tree):
     out = set()
     for node in ast.walk(tree):
         if isinstance(node, (ast.Module, ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
@@ -115,85 +233,94 @@ def _docstring_nodes(tree):
     return out
 
 
-def _code_strings(tree):
-    """Every string literal that is not a docstring."""
-    skip = _docstring_nodes(tree)
-    return [
-        node.value
-        for node in ast.walk(tree)
-        if isinstance(node, ast.Constant) and isinstance(node.value, str) and id(node) not in skip
-    ]
+def _is_crash_call(node) -> bool:
+    """A call that deliberately takes a core-dumping signal, written as code."""
+    if not isinstance(node, ast.Call):
+        return False
+    name = _called_name(node)
+    if name is None:
+        return False
+    if name in _CRASH_CALLS:
+        func = ast.unparse(node.func)
+        rule = _CRASH_CALLS[name]
+        if "arg0" in rule:
+            first = node.args[0] if node.args else None
+            if not (isinstance(first, ast.Constant) and first.value == rule["arg0"]):
+                return False
+        if "owners" in rule:
+            receiver = func[: -len(name)]
+            if not any(owner in receiver for owner in rule["owners"]):
+                return False
+        return True
+    if name not in _DIRECTED_NAMES:
+        return False
+    rendered = ast.unparse(node)
+    return any(s in rendered for s in _FATAL_SIGNALS)
 
 
-def _directs_a_fatal_signal(tree) -> bool:
-    """A call that aims a core-dumping signal at a process, as real code.
+def _enclosing_scopes(tree):
+    """Map each node id to the nearest enclosing function, else the module."""
+    owner = {}
 
-    Only fires when a fatal signal is named in the call. `raise_signal(signum)` with
-    a variable, the re-raise-after-restoring-the-default-handler idiom, is not a
-    deliberate crash and must not be flagged.
-    """
-    for node in ast.walk(tree):
-        if not isinstance(node, ast.Call) or not node.args:
-            continue
-        rendered = ast.unparse(node)
-        if not any(marker in rendered for marker in _SIGNAL_DIRECTED):
-            continue
-        if any(sig in rendered for sig in _FATAL_SIGNALS):
-            return True
-    return False
+    def walk(scope, node):
+        for child in ast.iter_child_nodes(node):
+            next_scope = child if isinstance(
+                child, (ast.FunctionDef, ast.AsyncFunctionDef)
+            ) else scope
+            owner[id(child)] = next_scope
+            walk(next_scope, child)
 
-
-def _calls_prctl_set_dumpable(tree) -> bool:
-    """A real prctl(PR_SET_DUMPABLE, 0, ...) call in this module's code."""
-    for node in ast.walk(tree):
-        if not isinstance(node, ast.Call) or not node.args:
-            continue
-        if not ast.unparse(node.func).endswith("prctl"):
-            continue
-        first = node.args[0]
-        if isinstance(first, ast.Constant) and first.value == _PRCTL_SET_DUMPABLE:
-            return True
-        if isinstance(first, ast.Name) and first.id.endswith("PR_SET_DUMPABLE"):
-            return True
-    return False
-
-
-# Anything that could possibly make _classify say "crashes". Used as a raw-text
-# prefilter: the AST is a subset of the source, so a file whose text contains none of
-# these cannot match, and parsing it would be wasted work. This is what keeps the
-# check cheap. Without it, unparsing every Call node in ~1000 files costs ~9s; with
-# it, only a handful of files are ever parsed.
-_PREFILTER = _CRASH_MARKERS + _SIGNAL_DIRECTED
+    walk(tree, tree)
+    return owner
 
 
 @lru_cache(maxsize = None)
-def _classify(path):
-    """Return (crashes_on_purpose, suppresses_core) for one file."""
+def _analyze(path):
+    """`(crashes_on_purpose, unsuppressed_reasons)` for one file.
+
+    One pass, cached, because both tests below ask about every file and parsing twice
+    doubles the cost of the check for nothing.
+    """
     source = path.read_text(encoding = "utf-8", errors = "replace")
     if not any(marker in source for marker in _PREFILTER):
-        return False, False
+        return False, ()
 
     try:
         tree = ast.parse(source, str(path))
     except SyntaxError:
-        # Fixture files that are deliberately unparseable are not running anything.
-        return False, False
-    strings = _code_strings(tree)
+        # A fixture that is deliberately unparseable is not running anything.
+        return False, ()
 
-    crashes = _directs_a_fatal_signal(tree) or any(
-        marker in text for text in strings for marker in _CRASH_MARKERS
-    )
-    # The same, written inside a script string handed to a child interpreter.
-    for text in strings:
-        if any(marker in text for marker in _SIGNAL_DIRECTED) and any(
-            sig in text for sig in _FATAL_SIGNALS
-        ):
-            crashes = True
+    crashes, out = False, []
+    for snippet in _snippets(tree):
+        if not _snippet_crashes(snippet):
+            continue
+        crashes = True
+        if not _snippet_suppresses(snippet):
+            out.append("a child script that crashes on purpose")
 
-    suppresses = _calls_prctl_set_dumpable(tree) or any(
-        marker in text for text in strings for marker in _SUPPRESS_MARKERS
-    )
-    return crashes, suppresses
+    owner = None
+    for node in ast.walk(tree):
+        if not _is_crash_call(node):
+            continue
+        crashes = True
+        if owner is None:
+            owner = _enclosing_scopes(tree)
+        scope = owner.get(id(node), tree)
+        if not _scope_suppresses(scope):
+            where = getattr(scope, "name", "module level")
+            out.append(f"{ast.unparse(node)} at line {node.lineno} (in {where})")
+    return crashes, tuple(dict.fromkeys(out))
+
+
+def _violations(path):
+    """Deliberate crashes in this file whose core dump is not suppressed."""
+    return _analyze(path)[1]
+
+
+def _crashes(path) -> bool:
+    """Whether this file crashes on purpose at all, suppressed or not."""
+    return _analyze(path)[0]
 
 
 _FIX = """\
@@ -203,8 +330,9 @@ Add this to the child before it faults:
 
 The child still dies of the same signal, so nothing you assert changes.
 
-Two traps:
+Three traps:
   * prctl is Linux-only, so guard the call. It is a no-op elsewhere.
+  * The value argument matters. prctl(4, 1) re-enables dumps.
   * RLIMIT_CORE = 0 looks like the fix and is NOT: a piped core_pattern ignores
     it, measured at 117ms and still dumping.
 
@@ -212,9 +340,90 @@ If you only need the child to vanish rather than to take a specific signal, use
 SIGKILL instead. SIGKILL never produces a core."""
 
 
+# Each of these is a way the detector was fooled before, kept as a fixture so the fix
+# stays fixed. `want_violations` is whether the file should be reported.
+_FIXTURES = {
+    "crash_written_as_real_code": (
+        "import ctypes\n"
+        "def child():\n"
+        "    ctypes.string_at(0)\n",
+        True,  # not inside a script string, and still dumps a core
+    ),
+    "suppression_in_the_same_function": (
+        "import ctypes\n"
+        "def child():\n"
+        "    ctypes.CDLL(None).prctl(4, 0, 0, 0, 0)\n"
+        "    ctypes.string_at(0)\n",
+        False,
+    ),
+    "suppression_in_a_different_function": (
+        "import ctypes\n"
+        "def suppressed():\n"
+        "    ctypes.CDLL(None).prctl(4, 0, 0, 0, 0)\n"
+        "    ctypes.string_at(0)\n"
+        "def naked():\n"
+        "    ctypes.string_at(0)\n",
+        True,  # the first function must not bless the second
+    ),
+    "helper_then_a_naked_script": (
+        'SUPPRESS = "ctypes.CDLL(None).prctl(4, 0, 0, 0, 0)\\n"\n'
+        'SAFE = SUPPRESS + "ctypes.string_at(0)\\n"\n'
+        'NAKED = "ctypes.string_at(0)\\n"\n',
+        True,  # SAFE is fine, NAKED is not, and the file must not pass on SAFE
+    ),
+    "concatenated_script_is_folded": (
+        'SUPPRESS = "ctypes.CDLL(None).prctl(4, 0, 0, 0, 0)\\n"\n'
+        'SAFE = SUPPRESS + "ctypes.string_at(0)\\n"\n',
+        False,  # judged as the script it becomes, not as a bare literal
+    ),
+    "dumpable_set_back_to_one": (
+        "import ctypes\n"
+        "def child():\n"
+        "    ctypes.CDLL(None).prctl(4, 1, 0, 0, 0)\n"
+        "    ctypes.string_at(0)\n",
+        True,  # prctl(4, 1) re-enables dumps, so this still dumps
+    ),
+    "signal_named_in_a_comment_only": (
+        "# this used to raise SIGSEGV, now it returns\n"
+        "def child():\n"
+        "    return -11\n",
+        False,
+    ),
+    "reraise_of_a_variable_signal": (
+        "import signal\n"
+        "def restore(signum):\n"
+        "    signal.signal(signum, signal.SIG_DFL)\n"
+        "    signal.raise_signal(signum)\n",
+        False,  # the terminal-prompt idiom, no fatal signal named
+    ),
+    "unrelated_abort_methods": (
+        "def go(route, task):\n"
+        "    route.abort('failed')\n"
+        "    task.abort()\n",
+        False,  # Playwright and friends share the name and crash nothing
+    ),
+}
+
+
+@pytest.mark.parametrize("name", sorted(_FIXTURES))
+def test_the_detector_is_not_fooled(tmp_path, name):
+    source, want_violations = _FIXTURES[name]
+    path = tmp_path / f"{name}.py"
+    path.write_text(source, encoding = "utf-8")
+    crashes, violations = _analyze(path)
+    assert bool(violations) is want_violations, (
+        f"{name}: expected violations={want_violations}, got {violations or '()'}"
+    )
+    if want_violations:
+        assert crashes, f"{name}: a reported file must also count as crashing"
+
+
 def test_the_scan_finds_the_files_it_is_meant_to_guard():
-    """A silent scan matching nothing would pass forever and protect nothing."""
-    crashing = [p for p in _iter_test_files() if _classify(p)[0]]
+    """A silent scan matching nothing would pass forever and protect nothing.
+
+    This module excludes itself, so the match has to come from a real test.
+    """
+    crashing = [p.relative_to(REPO_ROOT) for p in _iter_test_files() if _crashes(p)]
     assert crashing, (
         "no deliberate-crash files matched, so this check is guarding an empty set. "
         "Either the markers or the test roots are wrong."
@@ -222,13 +431,20 @@ def test_the_scan_finds_the_files_it_is_meant_to_guard():
 
 
 def test_every_deliberate_crash_suppresses_its_core():
-    offenders = [
-        p.relative_to(REPO_ROOT) for p in _iter_test_files() if _classify(p) == (True, False)
-    ]
+    offenders = {
+        p.relative_to(REPO_ROOT): _violations(p)
+        for p in _iter_test_files()
+        if _violations(p)
+    }
+    report = "".join(
+        f"    {path}\n" + "".join(f"        {why}\n" for why in whys)
+        for path, whys in offenders.items()
+    )
     assert not offenders, (
-        "These files crash a process on purpose without suppressing the core dump:\n\n"
-        + "".join(f"    {p}\n" for p in offenders)
+        "These crash a process on purpose without suppressing the core dump:\n\n"
+        + report
         + "\nA fatal signal is piped to the host core_pattern handler (apport on "
         "Ubuntu), which reads the WHOLE core before the child is reaped: about 4x the "
-        "wall time and a multi-MB write per fault, every run.\n\n" + _FIX
+        "wall time and a multi-MB write per fault, every run.\n\n"
+        + _FIX
     )

--- a/tests/test_deliberate_crashes_suppress_cores.py
+++ b/tests/test_deliberate_crashes_suppress_cores.py
@@ -53,10 +53,10 @@ _TEST_ROOTS = (
 # Substrings that mean "this code, or this string handed to a child interpreter,
 # deliberately takes a fatal signal that dumps core".
 _CRASH_MARKERS = (
-    "string_at(0)",          # ctypes.string_at(0) -> strlen(NULL) -> SIGSEGV
-    "os.abort()",            # SIGABRT
-    "raise_signal(",         # signal.raise_signal(signal.SIGSEGV) and friends
-    "_sigsegv(",             # faulthandler._sigsegv()
+    "string_at(0)",  # ctypes.string_at(0) -> strlen(NULL) -> SIGSEGV
+    "os.abort()",  # SIGABRT
+    "raise_signal(",  # signal.raise_signal(signal.SIGSEGV) and friends
+    "_sigsegv(",  # faulthandler._sigsegv()
 )
 
 # A kill aimed at self only dumps core for these. SIGKILL and SIGTERM do not.

--- a/tests/test_deliberate_crashes_suppress_cores.py
+++ b/tests/test_deliberate_crashes_suppress_cores.py
@@ -1,0 +1,179 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Every test that crashes a process on purpose must suppress its core dump.
+
+Some tests need a child that dies of a real fatal signal, usually to prove that a
+supervisor treats a hard fault differently from a clean non-zero exit. The signal is
+legitimate. The core dump that follows is not: `/proc/sys/kernel/core_pattern` on a
+stock Ubuntu box pipes it to apport, which reads the WHOLE core before the child is
+reaped. Measured locally that is 123ms and a multi-MB write per fault, against 30ms
+with the dump suppressed.
+
+At CI volume that is a slow suite. The reason it is worth a guard is that the idiom
+gets copied. The same `ctypes.string_at(0)` line, lifted into a local reproduction
+harness wrapped in `for _ in range(trials)`, produced roughly 240 deliberate faults in
+46 seconds on a shared build box and the resulting apport storm took down every tmux
+session for that user. The tests here are where people learn the pattern, so this is
+where the rule belongs.
+
+The fix is one call before the fault:
+
+    ctypes.CDLL(None).prctl(4, 0, 0, 0, 0)   # PR_SET_DUMPABLE = 0
+
+A non-dumpable process still dies of the same signal, so nothing a test asserts
+changes, and no core is written. Note that `RLIMIT_CORE = 0` is NOT a substitute: a
+piped core_pattern ignores it, measured at 117ms and still dumping. If the test only
+needs "the child vanished" rather than a specific signal, prefer SIGKILL, which never
+produces a core.
+
+Detection is AST-based on purpose. Roughly forty places in this suite mention SIGSEGV
+or SIGABRT in a comment, a docstring, or a return-code assertion such as
+`assert f(-11) is True`, and none of those crash anything. A textual scan would be
+almost entirely false positives, so only real calls and real child-script strings are
+considered, and comments cannot satisfy the suppression side either.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# Directories holding test suites. Anything under these is scanned.
+_TEST_ROOTS = (
+    REPO_ROOT / "tests",
+    REPO_ROOT / "studio" / "backend" / "tests",
+)
+
+# Substrings that mean "this code, or this string handed to a child interpreter,
+# deliberately takes a fatal signal that dumps core".
+_CRASH_MARKERS = (
+    "string_at(0)",          # ctypes.string_at(0) -> strlen(NULL) -> SIGSEGV
+    "os.abort()",            # SIGABRT
+    "raise_signal(",         # signal.raise_signal(signal.SIGSEGV) and friends
+    "_sigsegv(",             # faulthandler._sigsegv()
+)
+
+# A kill aimed at self only dumps core for these. SIGKILL and SIGTERM do not.
+_FATAL_SIGNALS = ("SIGSEGV", "SIGABRT", "SIGBUS", "SIGILL", "SIGFPE", "SIGTRAP")
+
+# Either spelling counts as suppressing the dump.
+_SUPPRESS_MARKERS = ("PR_SET_DUMPABLE", "prctl(4")
+
+_PRCTL_SET_DUMPABLE = 4
+
+
+def _iter_test_files():
+    for root in _TEST_ROOTS:
+        if not root.is_dir():
+            continue
+        for path in sorted(root.rglob("test_*.py")):
+            yield path
+
+
+def _docstring_nodes(tree):
+    """Constant nodes that are docstrings, which must not count as either signal."""
+    out = set()
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.Module, ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
+            body = getattr(node, "body", None)
+            if (
+                body
+                and isinstance(body[0], ast.Expr)
+                and isinstance(body[0].value, ast.Constant)
+                and isinstance(body[0].value.value, str)
+            ):
+                out.add(id(body[0].value))
+    return out
+
+
+def _code_strings(tree):
+    """Every string literal that is not a docstring."""
+    skip = _docstring_nodes(tree)
+    return [
+        node.value
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Constant) and isinstance(node.value, str) and id(node) not in skip
+    ]
+
+
+def _self_kill_with_fatal_signal(tree) -> bool:
+    """os.kill(os.getpid(), signal.SIGSEGV) and similar, as real code."""
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = ast.unparse(node.func) if node.args else ""
+        if not func.endswith("kill"):
+            continue
+        rendered = ast.unparse(node)
+        if "getpid()" in rendered and any(sig in rendered for sig in _FATAL_SIGNALS):
+            return True
+    return False
+
+
+def _calls_prctl_set_dumpable(tree) -> bool:
+    """A real prctl(PR_SET_DUMPABLE, 0, ...) call in this module's code."""
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or not node.args:
+            continue
+        if not ast.unparse(node.func).endswith("prctl"):
+            continue
+        first = node.args[0]
+        if isinstance(first, ast.Constant) and first.value == _PRCTL_SET_DUMPABLE:
+            return True
+        if isinstance(first, ast.Name) and first.id.endswith("PR_SET_DUMPABLE"):
+            return True
+    return False
+
+
+def _classify(path):
+    """Return (crashes_on_purpose, suppresses_core) for one test file."""
+    tree = ast.parse(path.read_text(encoding = "utf-8", errors = "replace"), str(path))
+    strings = _code_strings(tree)
+
+    crashes = _self_kill_with_fatal_signal(tree) or any(
+        marker in text for text in strings for marker in _CRASH_MARKERS
+    )
+    # A self-kill written inside a child-script string counts too.
+    for text in strings:
+        if "getpid()" in text and any(sig in text for sig in _FATAL_SIGNALS):
+            crashes = True
+
+    suppresses = _calls_prctl_set_dumpable(tree) or any(
+        marker in text for text in strings for marker in _SUPPRESS_MARKERS
+    )
+    return crashes, suppresses
+
+
+def test_the_scan_finds_the_files_it_is_meant_to_guard():
+    """A silent scan that matches nothing would pass forever and protect nothing."""
+    crashing = [p for p in _iter_test_files() if _classify(p)[0]]
+    assert crashing, "no deliberate-crash tests found; the scan or the markers are wrong"
+
+
+@pytest.mark.parametrize(
+    "path",
+    [pytest.param(p, id = str(p.relative_to(REPO_ROOT))) for p in _iter_test_files()],
+)
+def test_deliberate_crash_suppresses_its_core(path):
+    crashes, suppresses = _classify(path)
+    if not crashes:
+        return
+    assert suppresses, (
+        f"{path.relative_to(REPO_ROOT)} crashes a process on purpose but does not "
+        f"suppress the core dump.\n\n"
+        f"A fatal signal here is piped to the host core_pattern handler (apport on "
+        f"Ubuntu), which reads the whole core before the child is reaped: about 4x the "
+        f"wall time and a multi-MB write per fault, on every run of this suite.\n\n"
+        f"Add this to the child before it faults:\n"
+        f"    ctypes.CDLL(None).prctl(4, 0, 0, 0, 0)   # PR_SET_DUMPABLE = 0\n\n"
+        f"The child still dies of the same signal, so nothing you assert changes. Guard "
+        f"the call, since prctl is Linux-only. RLIMIT_CORE = 0 does NOT work: a piped "
+        f"core_pattern ignores it. If you only need the child to vanish rather than to "
+        f"take a specific signal, use SIGKILL, which never dumps core."
+    )


### PR DESCRIPTION
## Summary

Two backend tests crash a child on purpose with `ctypes.string_at(0)`, to check that the torch device probe treats a fatally-crashed child as an unusable device:

- `studio/backend/tests/test_torch_device_probe.py`
- `studio/backend/tests/test_rag_embeddings.py`

The SIGSEGV is the point of the test. The core dump that follows is not. `core_pattern` pipes it to the host handler (apport on Ubuntu), which reads the whole core before the child is reaped, so every run of this suite pays a multi-MB write and roughly 4x the wall time per fault.

This marks the child non-dumpable with `PR_SET_DUMPABLE` before it faults. The child still dies of SIGSEGV, so what the tests assert is unchanged, and no core is written.

## Measured

Three runs each, on this box, with apport as the `core_pattern` handler:

| | exit | mean |
|---|---|---|
| bare SIGSEGV | -11 | 123.3 ms |
| `PR_SET_DUMPABLE = 0`, then SIGSEGV | -11 | **30.1 ms** |
| `RLIMIT_CORE = 0`, then SIGSEGV | -11 | 117.2 ms |

`RLIMIT_CORE = 0` is the obvious thing to reach for and it does **not** work: a piped `core_pattern` ignores it, and the dump still happens. `PR_SET_DUMPABLE` is the only thing that suppresses it. Worth knowing, because the `RLIMIT_CORE` version looks correct and silently does nothing.

The non-crashing branch of the RAG script is unaffected:

```
rag script (argv=cuda)   rc=-11   30.9 ms
rag script (argv=cpu)    rc=  0   34.7 ms
```

## Portability

`prctl` is Linux-only, so the call is wrapped and does nothing on other platforms. There it is a no-op and the tests keep exactly their previous behaviour, including the core dump, which is what those platforms did before this change anyway.

## Why it is worth doing

The volume in CI is small, a handful of faults per suite run, so this is not urgent on its own. It matters because the pattern spreads. The same `ctypes.string_at(0)` idiom copied into a local reproduction harness with a `for _ in range(trials)` loop produced roughly 240 deliberate faults in 46 seconds on a shared build box, and the resulting apport storm was enough to take down every tmux session for that user. The tests here are the canonical example people copy, so it is the right place to establish that a deliberate crash suppresses its core.

## Tests

```
tests/test_torch_device_probe.py    53 passed
tests/test_rag_embeddings.py        25 passed
```
