### PR TITLE
Studio: map Windows ROCm VRAM by HIP LUID

### DIFF
--- a/studio/backend/tests/test_rocm_windows_vram_7072.py
+++ b/studio/backend/tests/test_rocm_windows_vram_7072.py
@@ -317,6 +317,69 @@ def test_match_adapter_capacity_forced_matrix():
     assert m([40 * GB, 30 * GB, 3 * MiB], [48 * GB, 48 * GB]) == [None, None]
 
 
+def test_luid_join_sums_physical_nodes_and_clamps():
+    luid = "luid_0xffffffff_0x000147fe"
+    adapters = [
+        (f"{luid}_phys_0", 3.0 * GB),
+        (f"{luid.upper()}_phys_1", 4.0 * GB),
+        ("luid_0x00000000_0x00016b51_phys_0", 0.0),
+    ]
+    assert hw._rocm_windows_luid_used_by_device(adapters, [luid], [6 * GB]) == [6 * GB]
+
+
+def test_luid_join_rejects_duplicate_physical_sample():
+    luid = "luid_0x00000000_0x000147fe"
+    adapters = [(f"{luid}_phys_0", 2.0 * GB), (f"{luid}_phys_0", 2.0 * GB)]
+    assert hw._rocm_windows_luid_used_by_device(adapters, [luid], [16 * GB]) == [None]
+
+
+def test_single_gpu_uses_exact_hip_luid_with_basic_render_driver(win_rocm, monkeypatch):
+    """Regression from a RX 9070 XT host with a zero-use virtual adapter."""
+    gpu_luid = "luid_0x00000000_0x000147fe"
+    basic_luid = "luid_0x00000000_0x00016b51"
+    devices = [("AMD Radeon RX 9070 XT", 16 * GB)]
+    counters = [(f"{gpu_luid}_phys_0", 5.0 * GB), (f"{basic_luid}_phys_0", 0.0)]
+    monkeypatch.setenv("HIP_VISIBLE_DEVICES", "0")
+    monkeypatch.setitem(sys.modules, "torch", _fake_torch(devices, free_equals_total = True))
+    monkeypatch.setattr(
+        hw, "_rocm_windows_hip_device_luids", lambda count: [gpu_luid], raising = False
+    )
+    monkeypatch.setattr(
+        hw.subprocess, "run", _subprocess_run(adapter_output = _adapter_output(counters))
+    )
+
+    result = hw.get_visible_gpu_utilization()
+    assert result["devices"][0]["vram_used_gb"] == pytest.approx(5.0)
+    assert result["devices"][0]["vram_utilization_pct"] == pytest.approx(31.2)
+    _, aggregate = hw._rocm_windows_per_device_vram([0])
+    assert aggregate == pytest.approx(5.0)
+
+
+def test_available_hip_luid_with_missing_counter_does_not_use_capacity_fallback(
+    win_rocm, monkeypatch
+):
+    visible_luid = "luid_0x00000000_0x0000aaaa"
+    hidden_luid = "luid_0x00000000_0x0000bbbb"
+    devices = [("AMD Radeon", 8 * GB)]
+    counters = [(f"{hidden_luid}_phys_0", 6.0 * GB)]
+    monkeypatch.setenv("HIP_VISIBLE_DEVICES", "0")
+    monkeypatch.setitem(sys.modules, "torch", _fake_torch(devices, free_equals_total = True))
+    monkeypatch.setattr(hw, "_rocm_windows_hip_device_luids", lambda count: [visible_luid])
+    monkeypatch.setattr(
+        hw,
+        "_match_adapter_used_to_devices",
+        lambda *_: pytest.fail("capacity fallback must not run when HIP identity is available"),
+    )
+    monkeypatch.setattr(
+        hw.subprocess, "run", _subprocess_run(adapter_output = _adapter_output(counters))
+    )
+
+    result = hw.get_visible_gpu_utilization()
+    assert result["devices"][0]["vram_used_gb"] is None
+    _, aggregate = hw._rocm_windows_per_device_vram([0])
+    assert aggregate is None
+
+
 def test_perf_counter_parser_and_sentinel(monkeypatch):
     monkeypatch.setattr(hw.platform, "system", lambda: "Windows")
     monkeypatch.setattr(

--- a/studio/backend/utils/hardware/hardware.py
+++ b/studio/backend/utils/hardware/hardware.py
@@ -1811,9 +1811,7 @@ def _rocm_windows_perf_counter_vram_by_adapter() -> Optional[list[tuple[str, flo
         return None
 
 
-def _rocm_windows_hip_device_luids(
-    device_count: int,
-) -> Optional[list[Optional[str]]]:
+def _rocm_windows_hip_device_luids(device_count: int) -> Optional[list[Optional[str]]]:
     """Return the Windows LUID for each visible HIP ordinal.
 
     ``hipDeviceProp_tR0600`` exposes the same 8-byte LUID embedded in Windows
@@ -1882,16 +1880,12 @@ def _rocm_windows_hip_device_luids(
 
 
 def _rocm_windows_luid_used_by_device(
-    adapters: list[tuple[str, float]],
-    device_luids: list[Optional[str]],
-    device_totals: list[float],
+    adapters: list[tuple[str, float]], device_luids: list[Optional[str]], device_totals: list[float]
 ) -> list[Optional[float]]:
     """Join counter usage to visible HIP devices by exact LUID, failing closed."""
     samples: dict[tuple[str, int], float] = {}
     for instance, used in adapters:
-        match = re.fullmatch(
-            r"(luid_0x[0-9a-f]{8}_0x[0-9a-f]{8})_phys_(\d+)", instance.lower()
-        )
+        match = re.fullmatch(r"(luid_0x[0-9a-f]{8}_0x[0-9a-f]{8})_phys_(\d+)", instance.lower())
         if match is None:
             continue
         key = (match.group(1), int(match.group(2)))

--- a/studio/backend/utils/hardware/hardware.py
+++ b/studio/backend/utils/hardware/hardware.py
@@ -1811,15 +1811,118 @@ def _rocm_windows_perf_counter_vram_by_adapter() -> Optional[list[tuple[str, flo
         return None
 
 
+def _rocm_windows_hip_device_luids(
+    device_count: int,
+) -> Optional[list[Optional[str]]]:
+    """Return the Windows LUID for each visible HIP ordinal.
+
+    ``hipDeviceProp_tR0600`` exposes the same 8-byte LUID embedded in Windows
+    ``GPU Adapter Memory`` counter instance names. Querying HIP directly avoids
+    guessing from adapter order, name, or capacity. ``None`` means the runtime
+    API itself was unavailable; individual ``None`` entries mean that ordinal
+    could not be resolved and must remain unknown.
+    """
+    if platform.system() != "Windows":
+        return None
+    try:
+        import ctypes
+
+        torch = sys.modules.get("torch")
+        hip_version = str(getattr(getattr(torch, "version", None), "hip", ""))
+        major = hip_version.split(".", 1)[0]
+        dll_names = [
+            name
+            for name in (
+                f"amdhip64_{major}.dll" if major else None,
+                "amdhip64.dll",
+                "amdhip64_7.dll",
+                "amdhip64_6.dll",
+            )
+            if name
+        ]
+        win_dll = getattr(ctypes, "WinDLL")
+        kernel32 = win_dll("kernel32", use_last_error = True)
+        get_module_handle = kernel32.GetModuleHandleW
+        get_module_handle.argtypes = [ctypes.c_wchar_p]
+        get_module_handle.restype = ctypes.c_void_p
+        hip = None
+        for dll_name in dict.fromkeys(dll_names):
+            handle = get_module_handle(dll_name)
+            if handle:
+                hip = win_dll(dll_name, handle = handle)
+                break
+        if hip is None:
+            return None
+
+        get_properties = hip.hipGetDevicePropertiesR0600
+        get_properties.argtypes = [ctypes.c_void_p, ctypes.c_int]
+        get_properties.restype = ctypes.c_int
+
+        # The versioned R0600 ABI starts with name[256], UUID[16], then LUID[8].
+        # HIP writes the complete structure, so use a deliberately oversized buffer
+        # and read only this stable documented prefix.
+        buffer_size = 64 * 1024
+        luids: list[Optional[str]] = []
+        for ordinal in range(device_count):
+            raw = ctypes.create_string_buffer(buffer_size)
+            if get_properties(ctypes.byref(raw), ordinal) != 0:
+                luids.append(None)
+                continue
+            luid = bytes(raw[272:280])
+            if luid == b"\x00" * 8:
+                luids.append(None)
+                continue
+            low = int.from_bytes(luid[:4], "little", signed = False)
+            high = int.from_bytes(luid[4:], "little", signed = False)
+            luids.append(f"luid_0x{high:08x}_0x{low:08x}")
+        return luids
+    except Exception as e:
+        logger.debug("HIP device LUID probe unavailable: %s", e)
+        return None
+
+
+def _rocm_windows_luid_used_by_device(
+    adapters: list[tuple[str, float]],
+    device_luids: list[Optional[str]],
+    device_totals: list[float],
+) -> list[Optional[float]]:
+    """Join counter usage to visible HIP devices by exact LUID, failing closed."""
+    samples: dict[tuple[str, int], float] = {}
+    for instance, used in adapters:
+        match = re.fullmatch(
+            r"(luid_0x[0-9a-f]{8}_0x[0-9a-f]{8})_phys_(\d+)", instance.lower()
+        )
+        if match is None:
+            continue
+        key = (match.group(1), int(match.group(2)))
+        if key in samples:
+            # Repeated samples are not independent physical nodes; summing them
+            # would double-count. Invalidate identity attribution for this poll.
+            return [None] * len(device_luids)
+        samples[key] = used
+
+    used_by_luid: dict[str, float] = {}
+    for (luid, _phys_idx), used in samples.items():
+        used_by_luid[luid] = used_by_luid.get(luid, 0.0) + used
+
+    assigned: list[Optional[float]] = []
+    for position, luid in enumerate(device_luids):
+        normalized = luid.lower() if luid else None
+        used = used_by_luid.get(normalized) if normalized else None
+        total = device_totals[position] if position < len(device_totals) else 0.0
+        assigned.append(min(used, total) if used is not None and total > 0 else None)
+    return assigned
+
+
 def _match_adapter_used_to_devices(
     adapter_useds: list[float], device_totals: list[float]
 ) -> list[Optional[float]]:
     """Attribute per-adapter used bytes to torch devices by capacity ranking.
 
-    Windows shares no key between LUID counters and torch ordinals, so usages are
-    ranked against device totals and each is trusted only when capacity *forces* it
-    (it exceeds every smaller device); an ambiguous ranking reports unknown
-    (``None``) rather than fabricate a per-index free.
+    Windows exposes the LUID counter key through HIP device properties. When that
+    API is unavailable, usages are ranked against device totals and each is trusted
+    only when capacity *forces* it (it exceeds every smaller device); an ambiguous
+    ranking reports unknown (``None``) rather than fabricate a per-index free.
 
     Extra counters mean a hidden/display adapter, and the noise filter may have
     dropped a real reading, so values are emitted only when the supra-threshold
@@ -1965,8 +2068,21 @@ def _rocm_windows_per_device_vram(
     if adapters:
         adapter_useds = [used for _, used in adapters]
         totals = [d["total_bytes"] for d in dev_meta]
-        assigned = _match_adapter_used_to_devices(adapter_useds, totals)
-        aggregate_bytes = _rocm_windows_aggregate_used_bytes(adapter_useds, totals)
+        device_luids = _rocm_windows_hip_device_luids(len(dev_meta))
+        if device_luids is None:
+            # Preserve the existing conservative capacity fallback only when HIP's
+            # identity API itself is unavailable.
+            assigned = _match_adapter_used_to_devices(adapter_useds, totals)
+            aggregate_bytes = _rocm_windows_aggregate_used_bytes(adapter_useds, totals)
+        else:
+            # Once HIP identity is available, missing/ambiguous counters stay
+            # unknown instead of falling back to a heuristic that could contradict it.
+            assigned = _rocm_windows_luid_used_by_device(adapters, device_luids, totals)
+            aggregate_bytes = (
+                sum(used for used in assigned if used is not None)
+                if assigned and all(used is not None for used in assigned)
+                else None
+            )
         if aggregate_bytes is not None:
             aggregate_gb = round(aggregate_bytes / (1024**3), 2)
     else:


### PR DESCRIPTION
## Problem

Windows exposes Studio's per-adapter VRAM usage counters under instance names containing a DXGI LUID, while the current Windows ROCm path only has torch ordinals and device capacities. The existing capacity matcher deliberately returns `Unknown` when attribution is ambiguous.

That is correct for arbitrary adapters, but it leaves a common single-GPU setup unresolved when Windows reports both:

- the visible AMD GPU with a non-zero `Dedicated Usage` counter; and
- Microsoft Basic Render Driver / a virtual display adapter with a zero counter.

A local shortcut that treats exact-zero extras as inactive fixes that machine, but it is not safe generally: a zero counter can belong to a real hidden GPU.

## Approach

HIP already exposes the exact Windows LUID for each visible ordinal in `hipDeviceProp_tR0600`.

This change:

- obtains a handle to the HIP runtime already loaded by torch;
- calls the versioned `hipGetDevicePropertiesR0600` API and reads its documented `name[256]`, UUID[16], LUID[8] prefix;
- joins each visible HIP ordinal to `GPU Adapter Memory` samples by exact LUID;
- sums distinct `phys_N` nodes for the same LUID;
- fails closed on duplicate `(LUID, phys_N)` samples;
- clamps a direct reading to torch's device total;
- keeps per-device and aggregate usage unknown when HIP identity is available but a corresponding counter is missing; and
- preserves the existing conservative capacity fallback only when the HIP identity API itself is unavailable.

No fuzzy name/capacity matching is added. No new dependency is introduced, and the helper is Windows-only.

## Why this is separate from #8669

#8669 changes the `llama-server` sizing probe to prefer `amd-smi` and avoid a persistent HIP context. This PR changes the System tab / GPU utilization telemetry path in `utils/hardware/hardware.py`, where Windows `amd-smi` is intentionally unavailable and the per-LUID performance counters are already the data source.

## Verification

Regression bite against current `main`:

```text
assert None == 5.0 ± 5.0e-06
```

The same regression plus the existing Windows ROCm suites with this patch:

```text
31 passed
```

Additional checks:

```text
ruff check: passed
py_compile: passed
git diff --check: passed
```

Real Windows ROCm smoke test on an AMD Radeon RX 9070 XT:

```text
torch ordinal 0 -> luid_0x00000000_0x000147fe
matching perf counter -> non-zero Dedicated Usage
Basic Render Driver -> a different LUID with zero usage
```

The helper attributed the non-zero reading to ordinal 0 by identity. The test suite also covers full-width LUIDs, multiple `phys_N` nodes, duplicate samples, clamping, and a mapped device whose counter is absent.

## Compatibility / fallback

If the platform is not Windows, the loaded HIP DLL cannot be found, the versioned symbol is absent, an ordinal query fails, or HIP returns an all-zero LUID, the code reports unknown for the affected identity or uses the existing conservative matcher when the identity API is wholly unavailable. It does not guess a contradictory mapping.

Follow-up to the Windows ROCm telemetry work in #7072 / #7238 and #7452 / #8481.
