### PR TITLE
Studio tests: pin that pip_install_try clears the torch probe memo too

### DIFF
--- a/tests/studio/install/test_torch_probe_memoization.py
+++ b/tests/studio/install/test_torch_probe_memoization.py
@@ -216,3 +216,46 @@ class TestConsumersShareTheProbe:
         boom = subprocess.TimeoutExpired(cmd = "python", timeout = 90)
         with patch.object(stack_mod.subprocess, "run", side_effect = boom):
             assert stack_mod._probe_installed_torch_version() is None
+
+
+class TestEveryPipEntryPointInvalidates:
+    """pip_install_try installs torch too, so it must clear the memo.
+
+    studio/install_python_stack.py's Windows AMD path reinstalls the ROCm torch
+    trio through pip_install_try inside _ensure_rocm_torch. The repair paths run
+    at two points with the torchao version probe between them, so a memo that
+    survives that install pins torchao against the torch that was just replaced.
+    """
+
+    def _install_try(self):
+        with (
+            patch.object(stack_mod, "USE_UV", False),
+            patch.object(stack_mod, "CONSTRAINTS", Path("/nonexistent/constraints.txt")),
+            patch.object(
+                stack_mod.subprocess, "run", return_value = MagicMock(returncode = 0, stdout = b"")
+            ),
+        ):
+            return stack_mod.pip_install_try("torch repair", "torch")
+
+    def test_pip_install_try_invalidates_the_cache(self):
+        with patch.object(stack_mod.subprocess, "run", return_value = _probe_result()):
+            assert stack_mod._probe_torch_runtime()[2] == "2.9.1+cu128"
+
+        assert self._install_try() is True
+
+        out = _probe_result("2.10.0+rocm7.1|7.1.12345|")
+        with patch.object(stack_mod.subprocess, "run", return_value = out) as mock_run:
+            assert stack_mod._probe_torch_runtime()[2] == "2.10.0+rocm7.1"
+        assert mock_run.call_count == 1
+
+    def test_the_torchao_probe_sees_the_reinstalled_torch(self):
+        # The consumer that actually reads a stale answer: _select_torchao_spec runs
+        # between the two repair points.
+        with patch.object(stack_mod.subprocess, "run", return_value = _probe_result()):
+            assert stack_mod._probe_installed_torch_version() == "2.9.1+cu128"
+
+        self._install_try()
+
+        out = _probe_result("2.10.0+rocm7.1|7.1.12345|")
+        with patch.object(stack_mod.subprocess, "run", return_value = out):
+            assert stack_mod._probe_installed_torch_version() == "2.10.0+rocm7.1"


### PR DESCRIPTION
Follow-up to #8779. Tests only, no source change.

#8779 memoizes the torch classification and clears it on a pip operation. Both entry points do that now, but only `pip_install` has a test, so the `pip_install_try` half can be removed and nothing goes red.

### Why that half is the one worth pinning

`_ensure_rocm_torch` reinstalls the ROCm torch trio through `pip_install_try` (`studio/install_python_stack.py`, the Windows AMD path), and the repair paths run at two points with the torchao version probe between them:

| lines | what runs |
| --- | --- |
| 4481-4484 | `_ensure_cuda_torch` / `_ensure_rocm_torch` / `_ensure_xpu_torch` / `_ensure_cpu_torch` |
| 4566-4567 | `_probe_installed_torch_version()` then `_select_torchao_spec(...)` |
| 4695-4698 | the four repair paths again |

A memo that survives the reinstall pins torchao against the torch that was just replaced, and `_ensure_cpu_torch` reads the same stale answer two lines after the install.

### The tests

- `test_pip_install_try_invalidates_the_cache`: probe, reinstall through `pip_install_try`, probe again, and the second call both re-spawns and reports the new build
- `test_the_torchao_probe_sees_the_reinstalled_torch`: the same through `_probe_installed_torch_version`, which is the consumer that actually reads the stale value

Both fail with the `_invalidate_torch_runtime_probe()` call removed from `pip_install_try`, and pass with it.

### Not added

The strict-decode half is already covered by `test_undecodable_import_chatter_does_not_escape`, which drives the real subprocess rather than a mock. I wrote a second pair for it before noticing, and dropped them as redundant.

### Verification

- `tests/studio/install/` plus `tests/studio/test_xpu_triton_swap.py`: 2608 passed, 2 skipped
- `ruff check`: clean
