### PR TITLE
Studio tests: match the model-name span in its cn() form

### DIFF
--- a/tests/studio/test_studio_text_descender_clipping.py
+++ b/tests/studio/test_studio_text_descender_clipping.py
@@ -27,12 +27,20 @@ def _read(path: Path) -> str:
     return path.read_text(encoding = "utf-8")
 
 
+# The classes that identify the trigger's model-name span. Matched as a set against every
+# string literal in the file rather than against a `className="..."` attribute: the span moved
+# to `className={cn("...", triggerLabelClassName)}` and the old attribute-shaped regex then
+# found nothing, so the guard passed vacuously while still reading as if it checked something.
+TRIGGER_LABEL_CLASSES = {"min-w-0", "flex-1", "truncate", "font-heading", "text-ui-16"}
+
+
 def test_model_selector_trigger_label_uses_leading_tight():
     src = _read(MODEL_SELECTOR)
-    pattern = re.compile(
-        r'<span\s+className="[^"]*\bmin-w-0\b[^"]*\bflex-1\b[^"]*\btruncate\b[^"]*\bfont-heading\b[^"]*\btext-ui-16[^"]*"',
-    )
-    matches = pattern.findall(src)
+    matches = [
+        literal
+        for literal in re.findall(r'"([^"\n]*)"', src)
+        if TRIGGER_LABEL_CLASSES <= set(literal.split())
+    ]
     assert matches, "could not find ModelSelectorTrigger model-name span"
     for cls in matches:
         assert "leading-tight" in cls, f"expected leading-tight, got: {cls}"

--- a/tests/studio/test_studio_text_descender_clipping.py
+++ b/tests/studio/test_studio_text_descender_clipping.py
@@ -27,10 +27,8 @@ def _read(path: Path) -> str:
     return path.read_text(encoding = "utf-8")
 
 
-# The classes that identify the trigger's model-name span. Matched as a set against every
-# string literal in the file rather than against a `className="..."` attribute: the span moved
-# to `className={cn("...", triggerLabelClassName)}` and the old attribute-shaped regex then
-# found nothing, so the guard passed vacuously while still reading as if it checked something.
+# Matched as a set against every string literal, not against a `className="..."` attribute:
+# the span moved to `className={cn("...", triggerLabelClassName)}`, which the old regex missed.
 TRIGGER_LABEL_CLASSES = {"min-w-0", "flex-1", "truncate", "font-heading", "text-ui-16"}
 
 


### PR DESCRIPTION
`Repo tests (CPU)` is red on main for every PR:

```
FAILED tests/studio/test_studio_text_descender_clipping.py::test_model_selector_trigger_label_uses_leading_tight
E       AssertionError: could not find ModelSelectorTrigger model-name span
E       assert []
```

The product is fine. The guard looked for a literal attribute:

```python
r'<span\s+className="[^"]*\bmin-w-0\b[^"]*\bflex-1\b[^"]*\btruncate\b...'
```

and `model-selector.tsx:275` now writes the label as

```tsx
<span
  className={cn(
    "min-w-0 flex flex-1 items-baseline truncate font-heading text-ui-16 font-medium leading-tight text-black dark:text-white",
    triggerLabelClassName,
  )}
>
```

so the regex matched nothing. `leading-tight` is present and correct; only the test broke.

## The change

Match the identifying class set against every string literal in the file instead of against an attribute. Order-insensitive, and it survives the next wrapper. Exactly one literal matches today, the right one.

## Why this is not a weaker test

The assertion it guards is unchanged: `leading-tight` present, `leading-none` never beside `truncate`. Mutating `leading-tight` to `leading-none` in `model-selector.tsx` fails both this test and `test_no_truncate_plus_leading_none_in_changed_files`. The `assert matches` line is what makes this safe: once the markup moved, the old form matched nothing and that assert turned it into the hard failure on main rather than a silent pass.

```
tests/studio/test_studio_text_descender_clipping.py  3 passed
with the mutation applied                            2 failed, 1 passed
```
