### PR TITLE
Studio tests: scan the model selector label wherever its classes live

### DIFF
--- a/tests/studio/test_studio_text_descender_clipping.py
+++ b/tests/studio/test_studio_text_descender_clipping.py
@@ -29,8 +29,11 @@ def _read(path: Path) -> str:
 
 def test_model_selector_trigger_label_uses_leading_tight():
     src = _read(MODEL_SELECTOR)
+    # Any quoted class list, not just a literal className attribute: the trigger label
+    # moved to className={cn("...", triggerLabelClassName)}, which a `<span className="`
+    # pattern stops seeing while the classes it guards are still right there.
     pattern = re.compile(
-        r'<span\s+className="[^"]*\bmin-w-0\b[^"]*\bflex-1\b[^"]*\btruncate\b[^"]*\bfont-heading\b[^"]*\btext-ui-16[^"]*"',
+        r'"[^"]*\bmin-w-0\b[^"]*\bflex-1\b[^"]*\btruncate\b[^"]*\bfont-heading\b[^"]*\btext-ui-16[^"]*"',
     )
     matches = pattern.findall(src)
     assert matches, "could not find ModelSelectorTrigger model-name span"


### PR DESCRIPTION
## Summary

`tests/studio/test_studio_text_descender_clipping.py::test_model_selector_trigger_label_uses_leading_tight` fails on `main`, so every PR's Repo tests (CPU) job is red:

```
FAILED tests/studio/test_studio_text_descender_clipping.py::test_model_selector_trigger_label_uses_leading_tight
  - AssertionError: could not find ModelSelectorTrigger model-name span
```

The label is fine. What moved is where its classes are written.

## What happened

The test looked for a literal attribute:

```python
r'<span\s+className="[^"]*\bmin-w-0\b[^"]*\bflex-1\b[^"]*\btruncate\b...'
```

The trigger label now composes its classes so a caller can extend them:

```tsx
<span
  className={cn(
    "min-w-0 flex flex-1 items-baseline truncate font-heading text-ui-16 font-medium leading-tight text-black dark:text-white",
    triggerLabelClassName,
  )}
>
```

`className={cn(` is not `className="`, so the pattern matched nothing and the test failed on its own "did I find anything" assertion. `leading-tight` was there the whole time.

## The fix

Match the quoted class list wherever it appears rather than only in an attribute. The five required tokens still have to be present, in order, in one string, and both assertions that follow are unchanged.

## Verified

- Fails before, passes after, on `main` at 1838e1084.
- Still catches what it exists to catch: swapping that `leading-tight` for `leading-none` fails the suite (2 failed), so the guard is not weakened.