### PR TITLE
Raise the TRL cap to 1.10.0, and open the datasets hole it needs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,7 +139,7 @@ huggingfacenotorch = [
     "tyro",
     "protobuf",
     "sentencepiece>=0.2.0",
-    "datasets>=3.4.1,!=4.0.*,!=4.1.0,<4.4.0",
+    "datasets>=3.4.1,!=4.0.*,!=4.1.0,!=4.4.*,!=4.5.0,<5.0.0",
     "accelerate>=0.34.1",
     "peft>=0.18.0,!=0.11.0",
     "huggingface_hub>=0.34.0",
@@ -156,7 +156,7 @@ huggingfacenotorch = [
     "diffusers>=0.39.0 ; python_version >= '3.10'",
     "diffusers ; python_version < '3.10'",
     "transformers>=4.51.3,!=4.52.0,!=4.52.1,!=4.52.2,!=4.52.3,!=4.53.0,!=4.54.0,!=4.55.0,!=4.55.1,!=4.57.0,!=4.57.4,!=4.57.5,!=5.0.0,!=5.1.0,<=5.5.0",
-    "trl>=0.18.2,!=0.19.0,<=0.24.0",
+    "trl>=0.18.2,!=0.19.0,<=1.10.0",
     "sentence-transformers",
 ]
 # torchcodec backend for Gemma audio / datasets>=4 (#7225).
@@ -705,7 +705,7 @@ colab-new = [
     "packaging",
     "tyro",
     "transformers>=4.51.3,!=4.52.0,!=4.52.1,!=4.52.2,!=4.52.3,!=4.53.0,!=4.54.0,!=4.55.0,!=4.55.1,!=4.57.0,!=4.57.4,!=4.57.5,!=5.0.0,!=5.1.0,<=5.5.0",
-    "datasets>=3.4.1,!=4.0.*,!=4.1.0,<4.4.0",
+    "datasets>=3.4.1,!=4.0.*,!=4.1.0,!=4.4.*,!=4.5.0,<5.0.0",
     "sentencepiece>=0.2.0",
     "tqdm",
     "psutil",
@@ -720,7 +720,7 @@ colab-new = [
 ]
 colab-no-deps = [
     "accelerate>=0.34.1",
-    "trl>=0.18.2,!=0.19.0,<=0.24.0",
+    "trl>=0.18.2,!=0.19.0,<=1.10.0",
     "peft>=0.18.0",
     "xformers ; ('linux' in sys_platform or sys_platform == 'win32') and (platform_machine == 'AMD64' or platform_machine == 'x86_64')",
     "bitsandbytes>=0.45.5,!=0.46.0,!=0.48.0",


### PR DESCRIPTION
Split out of #8701, which now carries only the rollout fix and changes no resolved version for anyone.

This is the half that actually moves people onto TRL 1.x, so it is separated to be judged on its own. **Nothing needs it merged**: #8701's fix is inert below TRL 0.28.0 and only does something for someone who has already installed a newer TRL themselves.

## What changes

```
-    "trl>=0.18.2,!=0.19.0,<=0.24.0",
+    "trl>=0.18.2,!=0.19.0,<=1.10.0",
-    "datasets>=3.4.1,!=4.0.*,!=4.1.0,<4.4.0",
+    "datasets>=3.4.1,!=4.0.*,!=4.1.0,!=4.4.*,!=4.5.0,<5.0.0",
```

Both `[huggingfacenotorch]` and the `colab-*` extras, four lines.

## Why the two move together

Raising only the TRL cap ships a pin nobody exercises. TRL 1.10.0 requires `datasets>=4.7.0`, so with `datasets<4.4.0` still in place a resolver asked for `trl<=1.10.0` silently settles on `trl==0.29.1`.

The datasets change opens a hole rather than raising the floor. A `datasets>=4.7.0` floor would drop Python 3.9 and force 4.x on TRL 0.22.2 users who do not need it. The hole `!=4.4.*,!=4.5.0` is exactly what `patch_datasets` in `import_fixes.py:794-805` already refuses at runtime over the `_thread.RLock` recursion bug, so the metadata and the runtime guard agree rather than the metadata being the stricter of the two.

## Evidence carried over from #8701

`trl<=0.24.0` is metadata only. Nothing in unsloth or unsloth_zoo reads the TRL version and refuses 1.x at runtime; the only comparisons are floors at `trainer.py:725` and `:993`. With the trees on `PYTHONPATH` so no resolver sees the cap:

| suite | result |
|---|---|
| `tests/ -k grpo` | 991 passed |
| `tests/version_compat` | 1702 passed |
| 3-step GRPO, TRL 1.10.0 vs 0.22.2 | identical to all 16 digits |

The 5-test gap against 0.22.2 is this repo's own `TRL >= 1.7.0` gated assertions, which 0.22.2 skips and 1.10.0 runs and passes. Re-verified on datasets 4.8.5 with TRL 1.10.0: 991 / 1702 passed, GRPO smoke numbers identical to the datasets 3.6.0 run.

## Not covered

Multi-rank / TP and TRL server mode; vLLM builds other than 0.15.1; TRL versions between 0.22.2 and 1.10.0 at runtime; datasets 5.x; the 4.4-4.5 recursion failure itself; Mac, Windows and WSL; transformers 5.x.
