### PR TITLE
Studio: say when a model only partly fits on the GPU

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -16135,12 +16135,15 @@ class LlamaCppBackend:
                 self._gpu_offload_layers = parse_gpu_offload_counts(self._stdout_lines)
                 # Auto mode respects an inherited -ngl rather than stripping it (see
                 # _GPU_OFFLOAD_OVERRIDE_FLAGS), so the split can be the user's own
-                # choice even though the first-class mode still reads "auto". Set
-                # beside the counts, from the same extras this load launched with, so
-                # the two cannot disagree about which load they describe.
+                # choice even though the first-class mode still reads "auto". A
+                # --device naming no GPU is the same thing by a different route: it
+                # overrides the layer count outright, so llama.cpp reports 0/M for a
+                # placement that was asked for. Set beside the counts, from the same
+                # extras and env this load launched with, so the two cannot disagree
+                # about which load they describe.
                 self._offload_overridden = _extra_args_set_any_flag(
                     extra_args, _GPU_OFFLOAD_OVERRIDE_FLAGS
-                )
+                ) or _device_selection_is_cpu(extra_args, env)
                 if (
                     self._gpu_offload_layers is not None
                     and 0 < self._gpu_offload_layers[0] < self._gpu_offload_layers[1]

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -299,6 +299,32 @@ _GPU_DEVICE_PREFIXES = (
 )
 
 
+def parse_gpu_offload_counts(lines: "list[str]") -> "Optional[tuple[int, int]]":
+    """``(offloaded, total)`` layers from llama.cpp's own log, or None.
+
+    classify_gpu_offload_lines already reads this line and then collapses it to a
+    bool, so 12/60 and 60/60 both answer True. That is the right answer to "did the
+    GPU work at all", and it is why a half-offloaded model is indistinguishable from
+    a fully offloaded one everywhere downstream: the user gets a model running at a
+    fraction of the speed and is told only that it loaded.
+
+    Same largest-M rule as the classifier: a draft/MTP model logs its own much
+    smaller line, and the main model is the one worth reporting.
+    """
+    max_total = -1
+    offloaded_at_max = 0
+    for line in lines:
+        match = _OFFLOADED_LAYERS_RE.search(line)
+        if not match:
+            continue
+        offloaded, total = int(match.group(1)), int(match.group(2))
+        if total > max_total or (total == max_total and offloaded > offloaded_at_max):
+            max_total, offloaded_at_max = total, offloaded
+    if max_total <= 0:
+        return None
+    return offloaded_at_max, max_total
+
+
 def classify_gpu_offload_lines(lines: "list[str]") -> Optional[bool]:
     """True if the model landed on a GPU, False if it stayed on CPU despite GPU
     intent, None when the log has no usable signal."""
@@ -3568,6 +3594,8 @@ class LlamaCppBackend:
         self._stats_logger = None  # vLLM-style engine-stats poller, set on load
         # Set by _classify_gpu_offload after _wait_for_health.
         self._gpu_offload_active: Optional[bool] = None
+        # (offloaded, total) layers llama.cpp reported for this load, when it said.
+        self._gpu_offload_layers: Optional[tuple[int, int]] = None
         # Diffusion only: the split the running child was asked for.
         self._diffusion_requested_ngl: Optional[int] = None
         self._context_length: Optional[int] = None
@@ -3923,6 +3951,20 @@ class LlamaCppBackend:
         except (TypeError, ValueError):
             slots = 1
         return max(1, slots)
+
+    @property
+    def offloaded_layers(self) -> Optional[int]:
+        """Layers llama.cpp actually put on a GPU, when its log said so.
+
+        Reported because in Auto mode Studio does not choose the split: it decides
+        the model does not provably fit and hands placement to ``--fit on``. The
+        request (``gpu_layers``) is -1 in that mode, so without this the API cannot
+        distinguish a fully offloaded load from a mostly-CPU one."""
+        return self._gpu_offload_layers[0] if self._gpu_offload_layers else None
+
+    @property
+    def offload_total_layers(self) -> Optional[int]:
+        return self._gpu_offload_layers[1] if self._gpu_offload_layers else None
 
     @property
     def requested_parallel_slots(self) -> int:
@@ -16071,6 +16113,20 @@ class LlamaCppBackend:
                         gpu_indices is not None or use_fit or gpu_memory_mode == "manual",
                         _detected_gpus,
                     )
+                # Kept alongside the boolean so a partial offload can be reported.
+                # In auto mode the placement is llama.cpp's (--fit on), so its log is
+                # the only account of what actually happened.
+                self._gpu_offload_layers = parse_gpu_offload_counts(self._stdout_lines)
+                if (
+                    self._gpu_offload_layers is not None
+                    and 0 < self._gpu_offload_layers[0] < self._gpu_offload_layers[1]
+                ):
+                    logger.warning(
+                        "llama-server offloaded %d of %d layers to GPU; the rest run on "
+                        "CPU, which is much slower for a dense model.",
+                        self._gpu_offload_layers[0],
+                        self._gpu_offload_layers[1],
+                    )
                 if self._gpu_offload_active is False and not _deliberate_cpu_only:
                     logger.warning(
                         "llama-server appears to have loaded the model entirely "
@@ -17043,6 +17099,7 @@ class LlamaCppBackend:
             # loading) server as VRAM-resident rather than reading the killed
             # server's stale zero-offload flag until the health probe reclassifies.
             self._gpu_offload_active = None
+            self._gpu_offload_layers = None
             # Drives _wait_for_vram_settle in the next load_model; set in finally
             # so both in-process and frontend Apply paths record the kill.
             self._last_kill_monotonic = time.monotonic()

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -309,7 +309,11 @@ def parse_gpu_offload_counts(lines: "list[str]") -> "Optional[tuple[int, int]]":
     fraction of the speed and is told only that it loaded.
 
     Same largest-M rule as the classifier: a draft/MTP model logs its own much
-    smaller line, and the main model is the one worth reporting.
+    smaller line, and the main model is the one worth reporting. On a tie the
+    first line wins, because llama.cpp loads the main model before its drafter and
+    nothing forces a drafter to have fewer layers than its target: taking the
+    larger N there would let a fully offloaded 32-layer drafter report 32/32 over
+    a main model that only got half its layers onto the GPU.
     """
     max_total = -1
     offloaded_at_max = 0
@@ -318,7 +322,7 @@ def parse_gpu_offload_counts(lines: "list[str]") -> "Optional[tuple[int, int]]":
         if not match:
             continue
         offloaded, total = int(match.group(1)), int(match.group(2))
-        if total > max_total or (total == max_total and offloaded > offloaded_at_max):
+        if total > max_total:
             max_total, offloaded_at_max = total, offloaded
     if max_total <= 0:
         return None
@@ -3596,6 +3600,8 @@ class LlamaCppBackend:
         self._gpu_offload_active: Optional[bool] = None
         # (offloaded, total) layers llama.cpp reported for this load, when it said.
         self._gpu_offload_layers: Optional[tuple[int, int]] = None
+        # Whether the user's own extras pinned the layer split for this load.
+        self._offload_overridden: bool = False
         # Diffusion only: the split the running child was asked for.
         self._diffusion_requested_ngl: Optional[int] = None
         self._context_length: Optional[int] = None
@@ -3965,6 +3971,16 @@ class LlamaCppBackend:
     @property
     def offload_total_layers(self) -> Optional[int]:
         return self._gpu_offload_layers[1] if self._gpu_offload_layers else None
+
+    @property
+    def offload_overridden(self) -> bool:
+        """Whether the user's own extras chose this split.
+
+        Auto mode strips neither -ngl nor --fit off from extras, so a deliberate
+        placement can arrive with gpu_memory_mode still reading "auto". Callers
+        that would otherwise suggest a smaller quantization need to know the
+        difference between a spill Studio allowed and a split the user asked for."""
+        return self._offload_overridden
 
     @property
     def requested_parallel_slots(self) -> int:
@@ -16117,6 +16133,14 @@ class LlamaCppBackend:
                 # In auto mode the placement is llama.cpp's (--fit on), so its log is
                 # the only account of what actually happened.
                 self._gpu_offload_layers = parse_gpu_offload_counts(self._stdout_lines)
+                # Auto mode respects an inherited -ngl rather than stripping it (see
+                # _GPU_OFFLOAD_OVERRIDE_FLAGS), so the split can be the user's own
+                # choice even though the first-class mode still reads "auto". Set
+                # beside the counts, from the same extras this load launched with, so
+                # the two cannot disagree about which load they describe.
+                self._offload_overridden = _extra_args_set_any_flag(
+                    extra_args, _GPU_OFFLOAD_OVERRIDE_FLAGS
+                )
                 if (
                     self._gpu_offload_layers is not None
                     and 0 < self._gpu_offload_layers[0] < self._gpu_offload_layers[1]
@@ -17100,6 +17124,7 @@ class LlamaCppBackend:
             # server's stale zero-offload flag until the health probe reclassifies.
             self._gpu_offload_active = None
             self._gpu_offload_layers = None
+            self._offload_overridden = False
             # Drives _wait_for_vram_settle in the next load_model; set in finally
             # so both in-process and frontend Apply paths record the kill.
             self._last_kill_monotonic = time.monotonic()

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -16132,17 +16132,33 @@ class LlamaCppBackend:
                 # Kept alongside the boolean so a partial offload can be reported.
                 # In auto mode the placement is llama.cpp's (--fit on), so its log is
                 # the only account of what actually happened.
-                self._gpu_offload_layers = parse_gpu_offload_counts(self._stdout_lines)
-                # Auto mode respects an inherited -ngl rather than stripping it (see
-                # _GPU_OFFLOAD_OVERRIDE_FLAGS), so the split can be the user's own
-                # choice even though the first-class mode still reads "auto". A
-                # --device naming no GPU is the same thing by a different route: it
-                # overrides the layer count outright, so llama.cpp reports 0/M for a
-                # placement that was asked for. Set beside the counts, from the same
-                # extras and env this load launched with, so the two cannot disagree
-                # about which load they describe.
+                #
+                # Gated on the same question the classifier asks, because llama.cpp
+                # logs "offloaded 0/N layers to GPU" on a plain CPU-only host too.
+                # Publishing that count would tell every user without a GPU that a
+                # smaller quantization would leave room on one they do not have.
+                if (
+                    _detected_gpus
+                    and not _arch_gate_forced_cpu
+                    and not _deliberate_cpu_only
+                    and (gpu_indices is not None or use_fit or gpu_memory_mode == "manual")
+                ):
+                    self._gpu_offload_layers = parse_gpu_offload_counts(self._stdout_lines)
+                else:
+                    self._gpu_offload_layers = None
+                # Auto mode respects an inherited -ngl rather than stripping it, so the
+                # split can be the user's own choice even though the first-class mode
+                # still reads "auto". A --device naming no GPU is the same thing by a
+                # different route: it overrides the layer count outright, so llama.cpp
+                # reports 0/M for a placement that was asked for.
+                #
+                # The layer flags only, not _GPU_OFFLOAD_OVERRIDE_FLAGS: that set also
+                # carries --fit, and --fit on is a request for llama.cpp to place the
+                # model, which is precisely the case worth reporting rather than
+                # suppressing. --fit off pins nothing by itself (it disables the fitter
+                # and leaves our own -ngl -1), so it cannot produce a split either.
                 self._offload_overridden = _extra_args_set_any_flag(
-                    extra_args, _GPU_OFFLOAD_OVERRIDE_FLAGS
+                    extra_args, _GPU_LAYER_FLAGS
                 ) or _device_selection_is_cpu(extra_args, env)
                 if (
                     self._gpu_offload_layers is not None

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -329,6 +329,38 @@ def parse_gpu_offload_counts(lines: "list[str]") -> "Optional[tuple[int, int]]":
     return offloaded_at_max, max_total
 
 
+def llama_saw_gpu_device(lines: "list[str]") -> Optional[bool]:
+    """Whether llama.cpp's own device table lists a GPU, or None if it has none.
+
+    Separate from where the model landed. llama.cpp prints device_info whenever a
+    GPU backend is visible to it, so an all-CPU table is the signal that the
+    backend did not load at all: the case the cudart64_X.dll remediation below is
+    written for. That matters for more than the log, because a load that put no
+    layers on the GPU reads identically to one that had no GPU backend to put
+    them on, and only one of the two is fixed by a smaller quantization.
+
+    Rows after the header only, so an unrelated line naming a backend cannot vote.
+    """
+    after_header = False
+    saw_device_row = False
+    saw_gpu_device = False
+    for line in lines:
+        if "device_info:" in line:
+            after_header = True
+            continue
+        if not after_header:
+            continue
+        match = _DEVICE_ROW_RE.search(line)
+        if not match:
+            continue
+        saw_device_row = True
+        if match.group(1).lower().startswith(_GPU_DEVICE_PREFIXES):
+            saw_gpu_device = True
+    if not saw_device_row:
+        return None
+    return saw_gpu_device
+
+
 def classify_gpu_offload_lines(lines: "list[str]") -> Optional[bool]:
     """True if the model landed on a GPU, False if it stayed on CPU despite GPU
     intent, None when the log has no usable signal."""
@@ -364,23 +396,8 @@ def classify_gpu_offload_lines(lines: "list[str]") -> Optional[bool]:
     # device_info: lists *available* devices (printed whenever a GPU backend is
     # visible), not where the model loaded, so it can only disconfirm: an
     # all-CPU table means no usable GPU. A visible GPU device is not proof the
-    # model used it, so it does not return True. Rows after the header only.
-    after_header = False
-    saw_device_row = False
-    saw_gpu_device = False
-    for line in lines:
-        if "device_info:" in line:
-            after_header = True
-            continue
-        if not after_header:
-            continue
-        match = _DEVICE_ROW_RE.search(line)
-        if not match:
-            continue
-        saw_device_row = True
-        if match.group(1).lower().startswith(_GPU_DEVICE_PREFIXES):
-            saw_gpu_device = True
-    if saw_device_row and not saw_gpu_device:
+    # model used it, so it does not return True.
+    if llama_saw_gpu_device(lines) is False:
         return False
     return None
 
@@ -3602,6 +3619,8 @@ class LlamaCppBackend:
         self._gpu_offload_layers: Optional[tuple[int, int]] = None
         # Whether the user's own extras pinned the layer split for this load.
         self._offload_overridden: bool = False
+        # Studio saw a GPU for this load but llama.cpp's device table did not.
+        self._gpu_backend_unavailable: bool = False
         # Diffusion only: the split the running child was asked for.
         self._diffusion_requested_ngl: Optional[int] = None
         self._context_length: Optional[int] = None
@@ -3971,6 +3990,15 @@ class LlamaCppBackend:
     @property
     def offload_total_layers(self) -> Optional[int]:
         return self._gpu_offload_layers[1] if self._gpu_offload_layers else None
+
+    @property
+    def gpu_backend_unavailable(self) -> bool:
+        """Studio found a GPU for this load but llama.cpp reported none.
+
+        Distinguishes a backend that failed to initialise from a fit that simply
+        placed no layers: both log ``offloaded 0/M``, and only the second is a
+        size problem, so only the second is answered by a smaller quantization."""
+        return self._gpu_backend_unavailable
 
     @property
     def offload_overridden(self) -> bool:
@@ -16146,6 +16174,15 @@ class LlamaCppBackend:
                     self._gpu_offload_layers = parse_gpu_offload_counts(self._stdout_lines)
                 else:
                     self._gpu_offload_layers = None
+                # A load that put no layers on the GPU reads identically to one that
+                # had no GPU backend to put them on, and only the first is helped by
+                # a smaller quantization. llama.cpp prints its device table whenever
+                # a GPU backend is visible to it, so an all-CPU table while Studio
+                # itself found a GPU is the second case: the DLL/backend failure the
+                # warning below is written for.
+                self._gpu_backend_unavailable = bool(_detected_gpus) and (
+                    llama_saw_gpu_device(self._stdout_lines) is False
+                )
                 # Auto mode respects an inherited -ngl rather than stripping it, so the
                 # split can be the user's own choice even though the first-class mode
                 # still reads "auto". A --device naming no GPU is the same thing by a
@@ -17144,6 +17181,7 @@ class LlamaCppBackend:
             self._gpu_offload_active = None
             self._gpu_offload_layers = None
             self._offload_overridden = False
+            self._gpu_backend_unavailable = False
             # Drives _wait_for_vram_settle in the next load_model; set in finally
             # so both in-process and frontend Apply paths record the kill.
             self._last_kill_monotonic = time.monotonic()

--- a/studio/backend/models/inference.py
+++ b/studio/backend/models/inference.py
@@ -715,6 +715,14 @@ class _InferenceRuntimeFields(BaseModel):
         None,
         description = "Total layers in the model, alongside offloaded_layers.",
     )
+    gpu_backend_unavailable: bool = Field(
+        False,
+        description = (
+            "Studio detected a GPU for this load but llama.cpp's own device table "
+            "reported none, meaning its GPU backend did not initialise. Separates a "
+            "backend failure from a fit that placed no layers; both log 0/M."
+        ),
+    )
     offload_overridden: bool = Field(
         False,
         description = (

--- a/studio/backend/models/inference.py
+++ b/studio/backend/models/inference.py
@@ -703,6 +703,18 @@ class _InferenceRuntimeFields(BaseModel):
         -1,
         description = "Manual mode: requested --gpu-layers value (-1 = Auto/--fit, or when not manual).",
     )
+    offloaded_layers: Optional[int] = Field(
+        None,
+        description = (
+            "Layers llama.cpp actually placed on a GPU, when it reported the count. "
+            "In Auto mode the placement is llama.cpp's own (--fit on), so this is the "
+            "only account of what happened; gpu_layers above is the REQUEST."
+        ),
+    )
+    offload_total_layers: Optional[int] = Field(
+        None,
+        description = "Total layers in the model, alongside offloaded_layers.",
+    )
     cpu_fallback_reason: Optional[Literal["vulkan_startup_crash"]] = Field(
         None,
         description = (

--- a/studio/backend/models/inference.py
+++ b/studio/backend/models/inference.py
@@ -715,6 +715,14 @@ class _InferenceRuntimeFields(BaseModel):
         None,
         description = "Total layers in the model, alongside offloaded_layers.",
     )
+    offload_overridden: bool = Field(
+        False,
+        description = (
+            "Whether the user's own llama-server extras pinned the layer split. "
+            "Auto mode respects an inherited -ngl instead of stripping it, so a "
+            "deliberate placement can arrive with gpu_memory_mode still 'auto'."
+        ),
+    )
     cpu_fallback_reason: Optional[Literal["vulkan_startup_crash"]] = Field(
         None,
         description = (

--- a/studio/backend/tests/test_llama_cpp_context_fit.py
+++ b/studio/backend/tests/test_llama_cpp_context_fit.py
@@ -72,6 +72,7 @@ from core.inference.llama_cpp import (
     _CTX_FIT_VRAM_FRACTION,
     LlamaCppBackend,
     classify_gpu_offload_lines,
+    parse_gpu_offload_counts,
 )
 from core.inference.llama_server_args import parse_ctx_override, resolve_requested_ctx
 
@@ -934,3 +935,39 @@ class TestAppleNoKvMetadataFloor:
             apple_budget_mib = 23_000,
         )
         assert plan["c_arg"] == 100_000  # explicit honored even without KV sizing
+
+
+class TestPartialOffloadIsReportable:
+    """The counts behind the boolean.
+
+    classify_gpu_offload_lines answers True for 12/60 and for 60/60 alike, which
+    is right for "did the GPU work at all" and is why a half-offloaded model was
+    indistinguishable from a fully offloaded one everywhere downstream.
+    """
+
+    def test_a_split_load_keeps_both_numbers(self):
+        assert parse_gpu_offload_counts(
+            ["load_tensors: offloaded 38/60 layers to GPU"]
+        ) == (38, 60)
+
+    def test_the_boolean_cannot_tell_these_apart(self):
+        split = ["load_tensors: offloaded 12/60 layers to GPU"]
+        whole = ["load_tensors: offloaded 60/60 layers to GPU"]
+        assert classify_gpu_offload_lines(split) is classify_gpu_offload_lines(whole) is True
+        assert parse_gpu_offload_counts(split) != parse_gpu_offload_counts(whole)
+
+    def test_the_main_model_wins_over_a_draft(self):
+        # A draft/MTP model logs its own much smaller line; reporting that one
+        # would tell the user about the wrong model. Same rule the classifier uses.
+        lines = [
+            "load_tensors: offloaded 3/3 layers to GPU",
+            "load_tensors: offloaded 12/60 layers to GPU",
+        ]
+        assert parse_gpu_offload_counts(lines) == (12, 60)
+
+    def test_no_counted_line_is_not_a_guess(self):
+        assert parse_gpu_offload_counts(["INFO starting server"]) is None
+        assert parse_gpu_offload_counts([]) is None
+
+    def test_a_zero_total_is_not_reportable(self):
+        assert parse_gpu_offload_counts(["offloaded 0/0 layers to GPU"]) is None

--- a/studio/backend/tests/test_llama_cpp_context_fit.py
+++ b/studio/backend/tests/test_llama_cpp_context_fit.py
@@ -995,6 +995,16 @@ class TestPartialOffloadIsReportable:
         assert not _extra_args_set_any_flag(["--threads", "8"], _GPU_OFFLOAD_OVERRIDE_FLAGS)
         assert not _extra_args_set_any_flag(None, _GPU_OFFLOAD_OVERRIDE_FLAGS)
 
+    def test_a_fit_on_in_extras_is_not_a_pinned_split(self):
+        # --fit on asks llama.cpp to choose the placement, which is the case
+        # worth reporting rather than suppressing, so the provenance check reads
+        # the layer flags alone and not the wider set that also carries --fit.
+        from core.inference.llama_cpp import _GPU_LAYER_FLAGS, _extra_args_set_any_flag
+
+        assert not _extra_args_set_any_flag(["--fit", "on"], _GPU_LAYER_FLAGS)
+        assert not _extra_args_set_any_flag(["--fit", "off"], _GPU_LAYER_FLAGS)
+        assert _extra_args_set_any_flag(["-ngl", "20"], _GPU_LAYER_FLAGS)
+
     def test_a_cpu_device_is_deliberate_placement_too(self):
         # --device cpu overrides the layer count outright, so llama.cpp reports
         # 0/M for a placement the user asked for. Recommending a smaller

--- a/studio/backend/tests/test_llama_cpp_context_fit.py
+++ b/studio/backend/tests/test_llama_cpp_context_fit.py
@@ -946,9 +946,7 @@ class TestPartialOffloadIsReportable:
     """
 
     def test_a_split_load_keeps_both_numbers(self):
-        assert parse_gpu_offload_counts(
-            ["load_tensors: offloaded 38/60 layers to GPU"]
-        ) == (38, 60)
+        assert parse_gpu_offload_counts(["load_tensors: offloaded 38/60 layers to GPU"]) == (38, 60)
 
     def test_the_boolean_cannot_tell_these_apart(self):
         split = ["load_tensors: offloaded 12/60 layers to GPU"]

--- a/studio/backend/tests/test_llama_cpp_context_fit.py
+++ b/studio/backend/tests/test_llama_cpp_context_fit.py
@@ -963,9 +963,34 @@ class TestPartialOffloadIsReportable:
         ]
         assert parse_gpu_offload_counts(lines) == (12, 60)
 
+    def test_a_drafter_of_equal_size_does_not_mask_the_main_model(self):
+        # Nothing forces a drafter to have fewer layers than its target. On a tie
+        # llama.cpp's load order decides: the main model is logged first, so the
+        # fully offloaded drafter behind it must not report 32/32 over a main
+        # model that only got half its layers onto the GPU.
+        lines = [
+            "load_tensors: offloaded 16/32 layers to GPU",
+            "load_tensors: offloaded 32/32 layers to GPU",
+        ]
+        assert parse_gpu_offload_counts(lines) == (16, 32)
+
     def test_no_counted_line_is_not_a_guess(self):
         assert parse_gpu_offload_counts(["INFO starting server"]) is None
         assert parse_gpu_offload_counts([]) is None
 
     def test_a_zero_total_is_not_reportable(self):
         assert parse_gpu_offload_counts(["offloaded 0/0 layers to GPU"]) is None
+
+    def test_an_extras_ngl_reads_as_the_users_own_placement(self):
+        # Auto mode respects an inherited -ngl instead of stripping it (manual
+        # mode is the one that strips), so gpu_memory_mode alone cannot tell a
+        # split Studio allowed from one the user asked for.
+        from core.inference.llama_cpp import (
+            _GPU_OFFLOAD_OVERRIDE_FLAGS,
+            _extra_args_set_any_flag,
+        )
+
+        assert _extra_args_set_any_flag(["-ngl", "20"], _GPU_OFFLOAD_OVERRIDE_FLAGS)
+        assert _extra_args_set_any_flag(["--gpu-layers=20"], _GPU_OFFLOAD_OVERRIDE_FLAGS)
+        assert not _extra_args_set_any_flag(["--threads", "8"], _GPU_OFFLOAD_OVERRIDE_FLAGS)
+        assert not _extra_args_set_any_flag(None, _GPU_OFFLOAD_OVERRIDE_FLAGS)

--- a/studio/backend/tests/test_llama_cpp_context_fit.py
+++ b/studio/backend/tests/test_llama_cpp_context_fit.py
@@ -995,6 +995,28 @@ class TestPartialOffloadIsReportable:
         assert not _extra_args_set_any_flag(["--threads", "8"], _GPU_OFFLOAD_OVERRIDE_FLAGS)
         assert not _extra_args_set_any_flag(None, _GPU_OFFLOAD_OVERRIDE_FLAGS)
 
+    def test_an_all_cpu_device_table_means_the_backend_did_not_load(self):
+        # llama.cpp prints its device table whenever a GPU backend is visible to
+        # it, so an all-CPU table is the DLL/backend failure rather than a fit
+        # that placed no layers. Both log the same 0/M line.
+        from core.inference.llama_cpp import llama_saw_gpu_device
+
+        cpu_only = [
+            "device_info: available devices",
+            "  - CPU: 12 cores",
+        ]
+        with_gpu = [
+            "device_info: available devices",
+            "  - CUDA0: NVIDIA GeForce RTX 4090",
+            "  - CPU: 12 cores",
+        ]
+        assert llama_saw_gpu_device(cpu_only) is False
+        assert llama_saw_gpu_device(with_gpu) is True
+        # No table at all is unknown, not a failure.
+        assert llama_saw_gpu_device(["INFO starting server"]) is None
+        # Rows before the header do not vote.
+        assert llama_saw_gpu_device(["  - CUDA0: something"]) is None
+
     def test_a_fit_on_in_extras_is_not_a_pinned_split(self):
         # --fit on asks llama.cpp to choose the placement, which is the case
         # worth reporting rather than suppressing, so the provenance check reads

--- a/studio/backend/tests/test_llama_cpp_context_fit.py
+++ b/studio/backend/tests/test_llama_cpp_context_fit.py
@@ -994,3 +994,16 @@ class TestPartialOffloadIsReportable:
         assert _extra_args_set_any_flag(["--gpu-layers=20"], _GPU_OFFLOAD_OVERRIDE_FLAGS)
         assert not _extra_args_set_any_flag(["--threads", "8"], _GPU_OFFLOAD_OVERRIDE_FLAGS)
         assert not _extra_args_set_any_flag(None, _GPU_OFFLOAD_OVERRIDE_FLAGS)
+
+    def test_a_cpu_device_is_deliberate_placement_too(self):
+        # --device cpu overrides the layer count outright, so llama.cpp reports
+        # 0/M for a placement the user asked for. Recommending a smaller
+        # quantization there would be advice against their own choice, the same
+        # as for an -ngl, so the provenance has to cover this route as well.
+        from core.inference.llama_cpp import _device_selection_is_cpu
+
+        assert _device_selection_is_cpu(["--device", "cpu"])
+        assert _device_selection_is_cpu(["-dev", "none"])
+        assert _device_selection_is_cpu(None, {"LLAMA_ARG_DEVICE": "cpu"})
+        assert not _device_selection_is_cpu(["--device", "CUDA0"])
+        assert not _device_selection_is_cpu(None)

--- a/studio/frontend/src/features/audio/audio-page.tsx
+++ b/studio/frontend/src/features/audio/audio-page.tsx
@@ -46,6 +46,8 @@ import {
   listGgufVariants,
   listLoras,
   loadModel,
+  offloadCountsFrom,
+  offloadWarning,
   unloadModel,
 } from "@/features/chat";
 import {
@@ -737,9 +739,18 @@ export function AudioPage({ active = true }: { active?: boolean }) {
         );
         if (!isCurrent()) return;
         if (res.is_audio && isTtsAudioType(res.audio_type)) {
-          toast.success(`Model loaded (${res.audio_type ?? "audio"})`, {
-            id: toastId,
-          });
+          // A TTS model is a GGUF like any other and can be split across the
+          // CPU by automatic fitting, so this cannot just claim success.
+          const offloadNotice = offloadWarning(offloadCountsFrom(res));
+          const showToast = offloadNotice ? toast.warning : toast.success;
+          showToast(
+            `Model loaded (${res.audio_type ?? "audio"})${offloadNotice?.titleSuffix ?? ""}`,
+            {
+              id: toastId,
+              description: offloadNotice?.description,
+              duration: offloadNotice ? 8000 : undefined,
+            },
+          );
         } else {
           toast.error(`${repoId} loaded but is not a supported TTS model.`, {
             id: toastId,

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -204,6 +204,11 @@ import {
   watchResearchRun,
 } from "../stores/research-run-store";
 import { cancelResearchRun, createResearchRun } from "./research-api";
+import {
+  type OffloadCounts,
+  isPartialOffload,
+  partialOffloadDescription,
+} from "../lib/partial-offload";
 
 // Small models (<=9B) answer from memory instead of calling search, so "auto"
 // forces retrieval for them and leaves it to larger ones.
@@ -2544,16 +2549,29 @@ async function autoLoadSmallestModel(options?: AutoLoadOptions): Promise<{
   const showAutoLoadSuccess = (
     message: string,
     cpuFallbackReason?: CpuFallbackReason | null,
+    offloadCounts?: OffloadCounts,
   ): void => {
+    // This is the path a new user hits first: a chat sent with no model loaded
+    // auto-loads the default, so an auto-fit split has to be reported here too or
+    // the case the warning exists for is the one case that stays silent.
+    const partialOffload =
+      !cpuFallbackReason && isPartialOffload(offloadCounts ?? {});
     const options = {
       description: cpuFallbackReason
         ? "The auto-selected Vulkan backend crashed during startup, so GPU acceleration is disabled for this model session."
-        : undefined,
+        : partialOffload
+          ? partialOffloadDescription(offloadCounts ?? {})
+          : undefined,
       duration: 5000,
       icon: undefined,
     };
-    const showToast = cpuFallbackReason ? toast.warning : toast.success;
-    const title = cpuFallbackReason ? `${message} on CPU` : message;
+    const showToast =
+      cpuFallbackReason || partialOffload ? toast.warning : toast.success;
+    const title = cpuFallbackReason
+      ? `${message} on CPU`
+      : partialOffload
+        ? `${message}, partly on CPU`
+        : message;
     if (autoLoadToastDismissed) {
       showToast(title, options);
       return;
@@ -2990,7 +3008,11 @@ async function autoLoadSmallestModel(options?: AutoLoadOptions): Promise<{
           ggufVariant: candidate.ggufVariant,
         });
       }
-      showAutoLoadSuccess(candidate.successLabel, loadResp.cpu_fallback_reason);
+      showAutoLoadSuccess(candidate.successLabel, loadResp.cpu_fallback_reason, {
+        offloaded: loadResp.offloaded_layers,
+        total: loadResp.offload_total_layers,
+        gpuMemoryMode: loadResp.gpu_memory_mode,
+      });
     });
     return true;
   }
@@ -3300,6 +3322,11 @@ async function autoLoadSmallestModel(options?: AutoLoadOptions): Promise<{
         showAutoLoadSuccess(
           `Loaded ${DEFAULT_CHAT_MODEL_LABEL} (${DEFAULT_CHAT_MODEL_VARIANT})`,
           loadResp.cpu_fallback_reason,
+          {
+            offloaded: loadResp.offloaded_layers,
+            total: loadResp.offload_total_layers,
+            gpuMemoryMode: loadResp.gpu_memory_mode,
+          },
         );
       });
       return { loaded: true, blockedByTrustRemoteCode: false };

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -206,8 +206,8 @@ import {
 import { cancelResearchRun, createResearchRun } from "./research-api";
 import {
   type OffloadCounts,
-  isPartialOffload,
-  partialOffloadDescription,
+  offloadCountsFrom,
+  offloadWarning,
 } from "../lib/partial-offload";
 
 // Small models (<=9B) answer from memory instead of calling search, so "auto"
@@ -2554,24 +2554,21 @@ async function autoLoadSmallestModel(options?: AutoLoadOptions): Promise<{
     // This is the path a new user hits first: a chat sent with no model loaded
     // auto-loads the default, so an auto-fit split has to be reported here too or
     // the case the warning exists for is the one case that stays silent.
-    const partialOffload =
-      !cpuFallbackReason && isPartialOffload(offloadCounts ?? {});
+    const offloadNotice = cpuFallbackReason
+      ? null
+      : offloadWarning(offloadCounts ?? {});
     const options = {
       description: cpuFallbackReason
         ? "The auto-selected Vulkan backend crashed during startup, so GPU acceleration is disabled for this model session."
-        : partialOffload
-          ? partialOffloadDescription(offloadCounts ?? {})
-          : undefined,
+        : offloadNotice?.description,
       duration: 5000,
       icon: undefined,
     };
     const showToast =
-      cpuFallbackReason || partialOffload ? toast.warning : toast.success;
+      cpuFallbackReason || offloadNotice ? toast.warning : toast.success;
     const title = cpuFallbackReason
       ? `${message} on CPU`
-      : partialOffload
-        ? `${message}, partly on CPU`
-        : message;
+      : `${message}${offloadNotice?.titleSuffix ?? ""}`;
     if (autoLoadToastDismissed) {
       showToast(title, options);
       return;
@@ -3008,11 +3005,11 @@ async function autoLoadSmallestModel(options?: AutoLoadOptions): Promise<{
           ggufVariant: candidate.ggufVariant,
         });
       }
-      showAutoLoadSuccess(candidate.successLabel, loadResp.cpu_fallback_reason, {
-        offloaded: loadResp.offloaded_layers,
-        total: loadResp.offload_total_layers,
-        gpuMemoryMode: loadResp.gpu_memory_mode,
-      });
+      showAutoLoadSuccess(
+        candidate.successLabel,
+        loadResp.cpu_fallback_reason,
+        offloadCountsFrom(loadResp),
+      );
     });
     return true;
   }
@@ -3322,11 +3319,7 @@ async function autoLoadSmallestModel(options?: AutoLoadOptions): Promise<{
         showAutoLoadSuccess(
           `Loaded ${DEFAULT_CHAT_MODEL_LABEL} (${DEFAULT_CHAT_MODEL_VARIANT})`,
           loadResp.cpu_fallback_reason,
-          {
-            offloaded: loadResp.offloaded_layers,
-            total: loadResp.offload_total_layers,
-            gpuMemoryMode: loadResp.gpu_memory_mode,
-          },
+          offloadCountsFrom(loadResp),
         );
       });
       return { loaded: true, blockedByTrustRemoteCode: false };

--- a/studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts
+++ b/studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts
@@ -13,6 +13,7 @@ import {
 import { consumeNativePathToken } from "@/features/native-intents/api";
 // eslint-disable-next-line no-restricted-imports -- Avoid the hub barrel's React and download-manager exports.
 import { modelDisplayName } from "@/features/hub/lib/model-identity";
+import { type OffloadCounts, isPartialOffload } from "../lib/partial-offload";
 import { prepareHfTokenForUse } from "@/features/hf-auth";
 import {
   notifyNative,
@@ -826,6 +827,7 @@ export function useChatModelRuntime() {
       loadAbortRef.current = abortCtrl;
       const postLoadRefresh = { needed: false };
       let cpuFallbackReason: CpuFallbackReason | null = null;
+      let offloadCounts: OffloadCounts = {};
       try {
         async function performLoad(): Promise<void> {
           if (abortCtrl.signal.aborted) throw new Error("Cancelled");
@@ -1286,6 +1288,10 @@ export function useChatModelRuntime() {
               force_cancel_active: forceCancelActive,
             });
             cpuFallbackReason = loadResponse.cpu_fallback_reason ?? null;
+            offloadCounts = {
+              offloaded: loadResponse.offloaded_layers,
+              total: loadResponse.offload_total_layers,
+            };
 
             // If cancelled while loading, don't update UI to show
             // the model as active -- it's being unloaded.
@@ -1907,13 +1913,22 @@ export function useChatModelRuntime() {
           await performLoad();
           // User cancelled mid-refresh; cancelLoading handles teardown.
           if (abortCtrl.signal.aborted) return;
+          // A split load is a success the user still needs told about: the layers
+          // llama.cpp left on the CPU are on the critical path for every token.
+          const partialOffload =
+            !cpuFallbackReason && isPartialOffload(offloadCounts);
           const loadedTitle = cpuFallbackReason
             ? `${toastDisplayName} loaded on CPU`
-            : `${toastDisplayName} loaded`;
+            : partialOffload
+              ? `${toastDisplayName} loaded, partly on CPU`
+              : `${toastDisplayName} loaded`;
           const loadedDescription = cpuFallbackReason
             ? "The auto-selected Vulkan backend crashed during startup, so GPU acceleration is disabled for this model session."
-            : undefined;
-          const showLoadedToast = cpuFallbackReason ? toast.warning : toast.success;
+            : partialOffload
+              ? `${offloadCounts.offloaded} of ${offloadCounts.total} layers are on the GPU. The rest run on CPU, so generation will be slower. A smaller quantization would fit entirely on the GPU.`
+              : undefined;
+          const showLoadedToast =
+            cpuFallbackReason || partialOffload ? toast.warning : toast.success;
           if (loadToastDismissedRef.current) {
             showLoadedToast(loadedTitle, {
               description: loadedDescription,

--- a/studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts
+++ b/studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts
@@ -13,7 +13,11 @@ import {
 import { consumeNativePathToken } from "@/features/native-intents/api";
 // eslint-disable-next-line no-restricted-imports -- Avoid the hub barrel's React and download-manager exports.
 import { modelDisplayName } from "@/features/hub/lib/model-identity";
-import { type OffloadCounts, isPartialOffload } from "../lib/partial-offload";
+import {
+  type OffloadCounts,
+  isPartialOffload,
+  partialOffloadDescription,
+} from "../lib/partial-offload";
 import { prepareHfTokenForUse } from "@/features/hf-auth";
 import {
   notifyNative,
@@ -1291,6 +1295,7 @@ export function useChatModelRuntime() {
             offloadCounts = {
               offloaded: loadResponse.offloaded_layers,
               total: loadResponse.offload_total_layers,
+              gpuMemoryMode: loadResponse.gpu_memory_mode,
             };
 
             // If cancelled while loading, don't update UI to show
@@ -1925,7 +1930,7 @@ export function useChatModelRuntime() {
           const loadedDescription = cpuFallbackReason
             ? "The auto-selected Vulkan backend crashed during startup, so GPU acceleration is disabled for this model session."
             : partialOffload
-              ? `${offloadCounts.offloaded} of ${offloadCounts.total} layers are on the GPU. The rest run on CPU, so generation will be slower. A smaller quantization would fit entirely on the GPU.`
+              ? partialOffloadDescription(offloadCounts)
               : undefined;
           const showLoadedToast =
             cpuFallbackReason || partialOffload ? toast.warning : toast.success;

--- a/studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts
+++ b/studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts
@@ -15,8 +15,7 @@ import { consumeNativePathToken } from "@/features/native-intents/api";
 import { modelDisplayName } from "@/features/hub/lib/model-identity";
 import {
   type OffloadCounts,
-  isPartialOffload,
-  partialOffloadDescription,
+  offloadWarning,
 } from "../lib/partial-offload";
 import { prepareHfTokenForUse } from "@/features/hf-auth";
 import {
@@ -1296,6 +1295,7 @@ export function useChatModelRuntime() {
               offloaded: loadResponse.offloaded_layers,
               total: loadResponse.offload_total_layers,
               gpuMemoryMode: loadResponse.gpu_memory_mode,
+              offloadOverridden: loadResponse.offload_overridden,
             };
 
             // If cancelled while loading, don't update UI to show
@@ -1920,20 +1920,17 @@ export function useChatModelRuntime() {
           if (abortCtrl.signal.aborted) return;
           // A split load is a success the user still needs told about: the layers
           // llama.cpp left on the CPU are on the critical path for every token.
-          const partialOffload =
-            !cpuFallbackReason && isPartialOffload(offloadCounts);
+          const offloadNotice = cpuFallbackReason
+            ? null
+            : offloadWarning(offloadCounts);
           const loadedTitle = cpuFallbackReason
             ? `${toastDisplayName} loaded on CPU`
-            : partialOffload
-              ? `${toastDisplayName} loaded, partly on CPU`
-              : `${toastDisplayName} loaded`;
+            : `${toastDisplayName} loaded${offloadNotice?.titleSuffix ?? ""}`;
           const loadedDescription = cpuFallbackReason
             ? "The auto-selected Vulkan backend crashed during startup, so GPU acceleration is disabled for this model session."
-            : partialOffload
-              ? partialOffloadDescription(offloadCounts)
-              : undefined;
+            : offloadNotice?.description;
           const showLoadedToast =
-            cpuFallbackReason || partialOffload ? toast.warning : toast.success;
+            cpuFallbackReason || offloadNotice ? toast.warning : toast.success;
           if (loadToastDismissedRef.current) {
             showLoadedToast(loadedTitle, {
               description: loadedDescription,

--- a/studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts
+++ b/studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts
@@ -15,6 +15,7 @@ import { consumeNativePathToken } from "@/features/native-intents/api";
 import { modelDisplayName } from "@/features/hub/lib/model-identity";
 import {
   type OffloadCounts,
+  offloadCountsFrom,
   offloadWarning,
 } from "../lib/partial-offload";
 import { prepareHfTokenForUse } from "@/features/hf-auth";
@@ -1291,12 +1292,7 @@ export function useChatModelRuntime() {
               force_cancel_active: forceCancelActive,
             });
             cpuFallbackReason = loadResponse.cpu_fallback_reason ?? null;
-            offloadCounts = {
-              offloaded: loadResponse.offloaded_layers,
-              total: loadResponse.offload_total_layers,
-              gpuMemoryMode: loadResponse.gpu_memory_mode,
-              offloadOverridden: loadResponse.offload_overridden,
-            };
+            offloadCounts = offloadCountsFrom(loadResponse);
 
             // If cancelled while loading, don't update UI to show
             // the model as active -- it's being unloaded.

--- a/studio/frontend/src/features/chat/index.ts
+++ b/studio/frontend/src/features/chat/index.ts
@@ -61,6 +61,7 @@ export {
   GPU_LAYERS_AUTO,
 } from "./stores/chat-runtime-store";
 export { resolveStagedDiffusionClassification } from "./lib/gpu-placement";
+export { offloadCountsFrom, offloadWarning } from "./lib/partial-offload";
 export {
   preferFullToolOutput,
 

--- a/studio/frontend/src/features/chat/lib/partial-offload.ts
+++ b/studio/frontend/src/features/chat/lib/partial-offload.ts
@@ -4,29 +4,45 @@
 /** Whether a load landed only partly on the GPU, from llama.cpp's own count.
  *
  * Kept free of React so it can be tested: the runtime hook pulls in the router and
- * the whole chat store and cannot be imported under node:test.
+ * the whole chat store and cannot be imported under node:test. Shared, because the
+ * interactive load and the automatic one (a chat sent with no model loaded) are
+ * different code paths and the second is the one a new user hits first.
  *
- * Studio does not choose this split. In Auto mode it decides the model does not
- * provably fit and hands placement to llama.cpp's `--fit on`, which quietly puts
- * some layers on the CPU. Decode then runs at a fraction of the speed, and until
- * now the load reported success and nothing else, so the only way to find out was
- * to notice the model was slow.
+ * Studio only chooses this split in Manual mode. On Auto it decides the model does
+ * not provably fit and hands placement to llama.cpp's `--fit on`, which quietly
+ * puts some layers on the CPU. Decode then runs at a fraction of the speed, and the
+ * load reported success and nothing else, so the only way to find out was to notice
+ * the model was slow.
  */
 
 export interface OffloadCounts {
   offloaded?: number | null;
   total?: number | null;
+  /** "manual" means the user pinned the split themselves. */
+  gpuMemoryMode?: string | null;
 }
 
-/** `true` only for a genuine split: some layers on the GPU and some not.
+/** `true` only for a split nobody asked for.
  *
  * All-on-GPU is the normal case and needs no notice. None-on-GPU is a different
- * failure with its own reporting (the CPU-fallback path), so it is excluded here
- * rather than folded in.
+ * failure with its own reporting (the CPU-fallback path), so it is excluded rather
+ * than folded in. Manual mode is excluded because the user pinned that layer count
+ * deliberately: the model may well fit, and telling them to pick a smaller
+ * quantization would be advice against their own choice.
  */
 export function isPartialOffload(counts: OffloadCounts): boolean {
-  const { offloaded, total } = counts;
+  const { offloaded, total, gpuMemoryMode } = counts;
+  if (gpuMemoryMode === "manual") return false;
   if (typeof offloaded !== "number" || typeof total !== "number") return false;
   if (total <= 0) return false;
   return offloaded > 0 && offloaded < total;
+}
+
+/** The one wording, so the two load paths cannot drift apart. */
+export function partialOffloadDescription(counts: OffloadCounts): string {
+  return (
+    `${counts.offloaded} of ${counts.total} layers are on the GPU. The rest run on ` +
+    "CPU, so generation will be slower. A smaller quantization would fit entirely " +
+    "on the GPU."
+  );
 }

--- a/studio/frontend/src/features/chat/lib/partial-offload.ts
+++ b/studio/frontend/src/features/chat/lib/partial-offload.ts
@@ -26,6 +26,8 @@ export interface OffloadCounts {
   offloadOverridden?: boolean | null;
   /** Set when the backend already knows why the model is on the CPU. */
   cpuFallbackReason?: string | null;
+  /** Studio found a GPU for this load but llama.cpp reported none. */
+  gpuBackendUnavailable?: boolean | null;
 }
 
 /** The snake_case load response, narrowed to the fields this file reads. */
@@ -36,6 +38,7 @@ export interface OffloadCountsSource {
   gpu_layers?: number | null;
   offload_overridden?: boolean | null;
   cpu_fallback_reason?: string | null;
+  gpu_backend_unavailable?: boolean | null;
 }
 
 /** Pick the split out of a load response, so the load paths cannot drift. */
@@ -49,6 +52,7 @@ export function offloadCountsFrom(
     gpuLayers: response.gpu_layers,
     offloadOverridden: response.offload_overridden,
     cpuFallbackReason: response.cpu_fallback_reason,
+    gpuBackendUnavailable: response.gpu_backend_unavailable,
   };
 }
 
@@ -89,6 +93,7 @@ export function offloadWarning(counts: OffloadCounts): OffloadWarning | null {
     gpuLayers,
     offloadOverridden,
     cpuFallbackReason,
+    gpuBackendUnavailable,
   } = counts;
   if (cpuFallbackReason === "vulkan_startup_crash") {
     return {
@@ -108,6 +113,19 @@ export function offloadWarning(counts: OffloadCounts): OffloadWarning | null {
   if (typeof offloaded !== "number" || typeof total !== "number") return null;
   if (total <= 0 || offloaded >= total) return null;
   if (offloaded <= 0) {
+    // Nothing on the GPU has two causes that log the same 0/M line, and telling a
+    // user with a broken CUDA install to pick a smaller quantization sends them
+    // to re-download a model that was never the problem.
+    if (gpuBackendUnavailable) {
+      return {
+        titleSuffix: ", on CPU",
+        description:
+          "The GPU was found but llama.cpp could not use it, so the model runs " +
+          "entirely on CPU and generation will be slow. This is a backend " +
+          "problem rather than a size one, so a smaller quantization will not " +
+          "help. The llama-server log in Settings > Logs has the reason.",
+      };
+    }
     return {
       titleSuffix: ", on CPU",
       description:

--- a/studio/frontend/src/features/chat/lib/partial-offload.ts
+++ b/studio/frontend/src/features/chat/lib/partial-offload.ts
@@ -20,8 +20,12 @@ export interface OffloadCounts {
   total?: number | null;
   /** "manual" means the user picked the layer count in the load panel. */
   gpuMemoryMode?: string | null;
+  /** The requested count. -1 is Auto, which Manual mode also allows. */
+  gpuLayers?: number | null;
   /** The user's own `-ngl` in llama-server extras, which Auto mode respects. */
   offloadOverridden?: boolean | null;
+  /** Set when the backend already knows why the model is on the CPU. */
+  cpuFallbackReason?: string | null;
 }
 
 /** The snake_case load response, narrowed to the fields this file reads. */
@@ -29,10 +33,12 @@ export interface OffloadCountsSource {
   offloaded_layers?: number | null;
   offload_total_layers?: number | null;
   gpu_memory_mode?: string | null;
+  gpu_layers?: number | null;
   offload_overridden?: boolean | null;
+  cpu_fallback_reason?: string | null;
 }
 
-/** Pick the split out of a load response, so the four load paths cannot drift. */
+/** Pick the split out of a load response, so the load paths cannot drift. */
 export function offloadCountsFrom(
   response: OffloadCountsSource,
 ): OffloadCounts {
@@ -40,7 +46,9 @@ export function offloadCountsFrom(
     offloaded: response.offloaded_layers,
     total: response.offload_total_layers,
     gpuMemoryMode: response.gpu_memory_mode,
+    gpuLayers: response.gpu_layers,
     offloadOverridden: response.offload_overridden,
+    cpuFallbackReason: response.cpu_fallback_reason,
   };
 }
 
@@ -50,26 +58,53 @@ export interface OffloadWarning {
   description: string;
 }
 
-/** The warning a load's split deserves, or `null` when it deserves none.
+/** Why a loaded model is not fully on the GPU, or `null` when it is or nobody cares.
  *
- * `null` for a placement the user chose. Manual mode is the obvious one; the other
- * is an `-ngl` (or `--fit off`) they passed through llama-server extras, which Auto
- * mode deliberately respects rather than strips, so the reported mode alone cannot
- * tell a spill from a decision. In both cases "a smaller quantization would fit" is
- * advice against their own choice.
+ * A known reason wins over the counts. A recovered Vulkan startup crash leaves the
+ * model on the CPU with a `0/M` line behind it, and reading that as "nothing fit"
+ * would blame the model's size for a backend crash and recommend a quantization
+ * that changes nothing.
  *
- * `null` too when the counts are missing (an MLX or transformers load, or a
- * llama.cpp build whose log did not say) and when every layer made it onto the GPU,
- * which is the normal case and needs no notice.
+ * `null` for a placement the user chose. Manual mode with an explicit layer count is
+ * the obvious one, but Manual with GPU Layers left on Auto hands placement back to
+ * llama.cpp exactly like Auto mode does, so the mode alone is not the question: the
+ * requested count is. The other is an `-ngl` passed through llama-server extras,
+ * which Auto mode deliberately respects rather than strips. In both cases "a smaller
+ * quantization would fit" is advice against their own choice.
  *
- * Zero offloaded layers is a warning, not an exclusion. It is the worst version of
- * this problem and it has no other reporting: `cpu_fallback_reason` is only ever set
- * for the Vulkan startup-crash recovery, so an ordinary `--fit on` load that got
- * nothing onto the GPU announced plain success.
+ * `null` too when the counts are missing, which the backend also uses to say the
+ * split is not reportable: an MLX or transformers load, a llama.cpp build whose log
+ * did not say, or a host with no GPU at all, where llama.cpp still logs `0/N`.
+ * Every layer on the GPU is the normal case and needs no notice either.
+ *
+ * Zero offloaded layers is otherwise a warning, not an exclusion. It is the worst
+ * version of this problem and, absent a known reason, it had no reporting at all:
+ * an ordinary `--fit on` load that got nothing onto the GPU announced plain success.
  */
 export function offloadWarning(counts: OffloadCounts): OffloadWarning | null {
-  const { offloaded, total, gpuMemoryMode, offloadOverridden } = counts;
-  if (gpuMemoryMode === "manual" || offloadOverridden) return null;
+  const {
+    offloaded,
+    total,
+    gpuMemoryMode,
+    gpuLayers,
+    offloadOverridden,
+    cpuFallbackReason,
+  } = counts;
+  if (cpuFallbackReason === "vulkan_startup_crash") {
+    return {
+      titleSuffix: " on CPU",
+      description:
+        "The auto-selected Vulkan backend crashed during startup, so GPU " +
+        "acceleration is disabled for this model session.",
+    };
+  }
+  // An unrecognised reason is still a reason: say nothing rather than guess at it.
+  if (cpuFallbackReason) return null;
+  const manualPin =
+    gpuMemoryMode === "manual" &&
+    typeof gpuLayers === "number" &&
+    gpuLayers >= 0;
+  if (manualPin || offloadOverridden) return null;
   if (typeof offloaded !== "number" || typeof total !== "number") return null;
   if (total <= 0 || offloaded >= total) return null;
   if (offloaded <= 0) {

--- a/studio/frontend/src/features/chat/lib/partial-offload.ts
+++ b/studio/frontend/src/features/chat/lib/partial-offload.ts
@@ -1,48 +1,91 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-/** Whether a load landed only partly on the GPU, from llama.cpp's own count.
+/** What a load's layer split is worth telling the user, from llama.cpp's own count.
  *
  * Kept free of React so it can be tested: the runtime hook pulls in the router and
- * the whole chat store and cannot be imported under node:test. Shared, because the
- * interactive load and the automatic one (a chat sent with no model loaded) are
- * different code paths and the second is the one a new user hits first.
+ * the whole chat store and cannot be imported under node:test. Shared, because four
+ * separate flows load a model (the model picker, a chat sent with nothing loaded,
+ * compare mode, and a recipe run) and each used to announce success on its own.
  *
- * Studio only chooses this split in Manual mode. On Auto it decides the model does
- * not provably fit and hands placement to llama.cpp's `--fit on`, which quietly
- * puts some layers on the CPU. Decode then runs at a fraction of the speed, and the
- * load reported success and nothing else, so the only way to find out was to notice
- * the model was slow.
+ * Studio only chooses this split itself in Manual mode. On Auto it decides the model
+ * does not provably fit and hands placement to llama.cpp's `--fit on`, which quietly
+ * puts some or all layers on the CPU. Decode then runs at a fraction of the speed,
+ * and the load reported success and nothing else, so the only way to find out was to
+ * notice the model was slow.
  */
 
 export interface OffloadCounts {
   offloaded?: number | null;
   total?: number | null;
-  /** "manual" means the user pinned the split themselves. */
+  /** "manual" means the user picked the layer count in the load panel. */
   gpuMemoryMode?: string | null;
+  /** The user's own `-ngl` in llama-server extras, which Auto mode respects. */
+  offloadOverridden?: boolean | null;
 }
 
-/** `true` only for a split nobody asked for.
+/** The snake_case load response, narrowed to the fields this file reads. */
+export interface OffloadCountsSource {
+  offloaded_layers?: number | null;
+  offload_total_layers?: number | null;
+  gpu_memory_mode?: string | null;
+  offload_overridden?: boolean | null;
+}
+
+/** Pick the split out of a load response, so the four load paths cannot drift. */
+export function offloadCountsFrom(
+  response: OffloadCountsSource,
+): OffloadCounts {
+  return {
+    offloaded: response.offloaded_layers,
+    total: response.offload_total_layers,
+    gpuMemoryMode: response.gpu_memory_mode,
+    offloadOverridden: response.offload_overridden,
+  };
+}
+
+export interface OffloadWarning {
+  /** Appended to the loaded title, e.g. "Qwen3 loaded, partly on CPU". */
+  titleSuffix: string;
+  description: string;
+}
+
+/** The warning a load's split deserves, or `null` when it deserves none.
  *
- * All-on-GPU is the normal case and needs no notice. None-on-GPU is a different
- * failure with its own reporting (the CPU-fallback path), so it is excluded rather
- * than folded in. Manual mode is excluded because the user pinned that layer count
- * deliberately: the model may well fit, and telling them to pick a smaller
- * quantization would be advice against their own choice.
+ * `null` for a placement the user chose. Manual mode is the obvious one; the other
+ * is an `-ngl` (or `--fit off`) they passed through llama-server extras, which Auto
+ * mode deliberately respects rather than strips, so the reported mode alone cannot
+ * tell a spill from a decision. In both cases "a smaller quantization would fit" is
+ * advice against their own choice.
+ *
+ * `null` too when the counts are missing (an MLX or transformers load, or a
+ * llama.cpp build whose log did not say) and when every layer made it onto the GPU,
+ * which is the normal case and needs no notice.
+ *
+ * Zero offloaded layers is a warning, not an exclusion. It is the worst version of
+ * this problem and it has no other reporting: `cpu_fallback_reason` is only ever set
+ * for the Vulkan startup-crash recovery, so an ordinary `--fit on` load that got
+ * nothing onto the GPU announced plain success.
  */
-export function isPartialOffload(counts: OffloadCounts): boolean {
-  const { offloaded, total, gpuMemoryMode } = counts;
-  if (gpuMemoryMode === "manual") return false;
-  if (typeof offloaded !== "number" || typeof total !== "number") return false;
-  if (total <= 0) return false;
-  return offloaded > 0 && offloaded < total;
-}
-
-/** The one wording, so the two load paths cannot drift apart. */
-export function partialOffloadDescription(counts: OffloadCounts): string {
-  return (
-    `${counts.offloaded} of ${counts.total} layers are on the GPU. The rest run on ` +
-    "CPU, so generation will be slower. A smaller quantization would fit entirely " +
-    "on the GPU."
-  );
+export function offloadWarning(counts: OffloadCounts): OffloadWarning | null {
+  const { offloaded, total, gpuMemoryMode, offloadOverridden } = counts;
+  if (gpuMemoryMode === "manual" || offloadOverridden) return null;
+  if (typeof offloaded !== "number" || typeof total !== "number") return null;
+  if (total <= 0 || offloaded >= total) return null;
+  if (offloaded <= 0) {
+    return {
+      titleSuffix: ", on CPU",
+      description:
+        `None of the ${total} layers fit on the GPU, so the model runs entirely on ` +
+        "CPU and generation will be slow. A smaller quantization would leave room " +
+        "on the GPU.",
+    };
+  }
+  return {
+    titleSuffix: ", partly on CPU",
+    description:
+      `${offloaded} of ${total} layers are on the GPU. The rest run on CPU, so ` +
+      "generation will be slower. A smaller quantization would fit entirely on " +
+      "the GPU.",
+  };
 }

--- a/studio/frontend/src/features/chat/lib/partial-offload.ts
+++ b/studio/frontend/src/features/chat/lib/partial-offload.ts
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+/** Whether a load landed only partly on the GPU, from llama.cpp's own count.
+ *
+ * Kept free of React so it can be tested: the runtime hook pulls in the router and
+ * the whole chat store and cannot be imported under node:test.
+ *
+ * Studio does not choose this split. In Auto mode it decides the model does not
+ * provably fit and hands placement to llama.cpp's `--fit on`, which quietly puts
+ * some layers on the CPU. Decode then runs at a fraction of the speed, and until
+ * now the load reported success and nothing else, so the only way to find out was
+ * to notice the model was slow.
+ */
+
+export interface OffloadCounts {
+  offloaded?: number | null;
+  total?: number | null;
+}
+
+/** `true` only for a genuine split: some layers on the GPU and some not.
+ *
+ * All-on-GPU is the normal case and needs no notice. None-on-GPU is a different
+ * failure with its own reporting (the CPU-fallback path), so it is excluded here
+ * rather than folded in.
+ */
+export function isPartialOffload(counts: OffloadCounts): boolean {
+  const { offloaded, total } = counts;
+  if (typeof offloaded !== "number" || typeof total !== "number") return false;
+  if (total <= 0) return false;
+  return offloaded > 0 && offloaded < total;
+}

--- a/studio/frontend/src/features/chat/shared-composer.tsx
+++ b/studio/frontend/src/features/chat/shared-composer.tsx
@@ -1472,7 +1472,9 @@ export function SharedComposer({
         // Compare mode times two models against each other, so a pane that
         // quietly landed half on the CPU does not just run slow, it invalidates
         // the comparison being made. There is no per-pane success toast to
-        // correct here, so this warns or says nothing.
+        // correct here, so this warns or says nothing; the helper reads
+        // cpu_fallback_reason off the same response, so a recovered Vulkan crash
+        // names the crash instead of blaming the model's size.
         const compareOffload = offloadWarning(offloadCountsFrom(resp));
         if (compareOffload) {
           toast.warning(

--- a/studio/frontend/src/features/chat/shared-composer.tsx
+++ b/studio/frontend/src/features/chat/shared-composer.tsx
@@ -2,6 +2,7 @@
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
 import { mlxRuntimeStateFrom } from "./lib/mlx-runtime-state";
+import { offloadCountsFrom, offloadWarning } from "./lib/partial-offload";
 import { TooltipIconButton } from "@/components/assistant-ui/tooltip-icon-button";
 import {
   thinkEffortAriaLabel,
@@ -1468,6 +1469,17 @@ export function SharedComposer({
         // Persist the GPU Memory mode on a non-diffusion GGUF compare-load too,
         // so an applied manual choice survives a restart.
         persistGpuMemoryModeOnLoad(resp, effectiveGpuMemoryMode);
+        // Compare mode times two models against each other, so a pane that
+        // quietly landed half on the CPU does not just run slow, it invalidates
+        // the comparison being made. There is no per-pane success toast to
+        // correct here, so this warns or says nothing.
+        const compareOffload = offloadWarning(offloadCountsFrom(resp));
+        if (compareOffload) {
+          toast.warning(
+            `${compareModelDisplayName(sel.id)} loaded${compareOffload.titleSuffix}`,
+            { description: compareOffload.description, duration: 8000 },
+          );
+        }
         upgradeUnloadedActive = false;
         const store = useChatRuntimeStore.getState();
         store.setCheckpoint(

--- a/studio/frontend/src/features/chat/types/api.ts
+++ b/studio/frontend/src/features/chat/types/api.ts
@@ -238,6 +238,8 @@ export interface LoadModelResponse {
   gpu_memory_mode?: "auto" | "manual";
   gpu_layers?: number;
   /** Set when an automatic Vulkan startup crash was recovered by loading on CPU. */
+  offloaded_layers?: number | null;
+  offload_total_layers?: number | null;
   cpu_fallback_reason?: CpuFallbackReason | null;
   n_cpu_moe?: number;
   tensor_split?: number[] | null;
@@ -325,6 +327,8 @@ export interface InferenceStatusResponse {
   gpu_memory_mode?: "auto" | "manual";
   gpu_layers?: number;
   /** Set while the active model is a recovered CPU-only Vulkan load. */
+  offloaded_layers?: number | null;
+  offload_total_layers?: number | null;
   cpu_fallback_reason?: CpuFallbackReason | null;
   n_cpu_moe?: number;
   tensor_split?: number[] | null;

--- a/studio/frontend/src/features/chat/types/api.ts
+++ b/studio/frontend/src/features/chat/types/api.ts
@@ -240,6 +240,7 @@ export interface LoadModelResponse {
   /** Set when an automatic Vulkan startup crash was recovered by loading on CPU. */
   offloaded_layers?: number | null;
   offload_total_layers?: number | null;
+  offload_overridden?: boolean | null;
   cpu_fallback_reason?: CpuFallbackReason | null;
   n_cpu_moe?: number;
   tensor_split?: number[] | null;
@@ -329,6 +330,7 @@ export interface InferenceStatusResponse {
   /** Set while the active model is a recovered CPU-only Vulkan load. */
   offloaded_layers?: number | null;
   offload_total_layers?: number | null;
+  offload_overridden?: boolean | null;
   cpu_fallback_reason?: CpuFallbackReason | null;
   n_cpu_moe?: number;
   tensor_split?: number[] | null;

--- a/studio/frontend/src/features/chat/types/api.ts
+++ b/studio/frontend/src/features/chat/types/api.ts
@@ -241,6 +241,7 @@ export interface LoadModelResponse {
   offloaded_layers?: number | null;
   offload_total_layers?: number | null;
   offload_overridden?: boolean | null;
+  gpu_backend_unavailable?: boolean | null;
   cpu_fallback_reason?: CpuFallbackReason | null;
   n_cpu_moe?: number;
   tensor_split?: number[] | null;
@@ -331,6 +332,7 @@ export interface InferenceStatusResponse {
   offloaded_layers?: number | null;
   offload_total_layers?: number | null;
   offload_overridden?: boolean | null;
+  gpu_backend_unavailable?: boolean | null;
   cpu_fallback_reason?: CpuFallbackReason | null;
   n_cpu_moe?: number;
   tensor_split?: number[] | null;

--- a/studio/frontend/src/features/recipe-studio/hooks/use-recipe-executions.ts
+++ b/studio/frontend/src/features/recipe-studio/hooks/use-recipe-executions.ts
@@ -280,7 +280,9 @@ async function loadLocalModelSelection(
       tensor_parallel: false,
     });
     // A recipe run loads its model with no panel open, so a split load was
-    // announced here as a plain success and the run just came out slow.
+    // announced here as a plain success and the run just came out slow. The
+    // helper reads cpu_fallback_reason off the same response, so a recovered
+    // Vulkan crash reports the crash rather than blaming the model's size.
     const offloadNotice = offloadWarning(offloadCountsFrom(loadResp));
     const successOptions = {
       description: offloadNotice?.description,

--- a/studio/frontend/src/features/recipe-studio/hooks/use-recipe-executions.ts
+++ b/studio/frontend/src/features/recipe-studio/hooks/use-recipe-executions.ts
@@ -1,7 +1,12 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-import { getInferenceStatus, loadModel } from "@/features/chat";
+import {
+  getInferenceStatus,
+  loadModel,
+  offloadCountsFrom,
+  offloadWarning,
+} from "@/features/chat";
 import { createLoadingToastIcon, toast } from "@/lib/toast";
 import { toastError } from "@/shared/toast";
 import { useCallback, useEffect, useState } from "react";
@@ -250,7 +255,7 @@ async function loadLocalModelSelection(
   });
   try {
     const isGguf = GGUF_MODEL_PATTERN.test(target) || Boolean(ggufVariant);
-    await loadModel({
+    const loadResp = await loadModel({
       // biome-ignore lint/style/useNamingConvention: api schema
       model_path: target,
       // biome-ignore lint/style/useNamingConvention: api schema
@@ -274,15 +279,20 @@ async function loadLocalModelSelection(
       // biome-ignore lint/style/useNamingConvention: api schema
       tensor_parallel: false,
     });
+    // A recipe run loads its model with no panel open, so a split load was
+    // announced here as a plain success and the run just came out slow.
+    const offloadNotice = offloadWarning(offloadCountsFrom(loadResp));
     const successOptions = {
-      description: undefined,
-      duration: 2000,
+      description: offloadNotice?.description,
+      duration: offloadNotice ? 8000 : 2000,
       icon: undefined,
     };
+    const title = `Loaded ${modelLabel}${offloadNotice?.titleSuffix ?? ""}`;
+    const showToast = offloadNotice ? toast.warning : toast.success;
     if (loadToastDismissed) {
-      toast.success(`Loaded ${modelLabel}`, successOptions);
+      showToast(title, successOptions);
     } else {
-      toast.success(`Loaded ${modelLabel}`, { ...successOptions, id: toastId });
+      showToast(title, { ...successOptions, id: toastId });
     }
     return null;
   } catch (error) {

--- a/studio/frontend/tests/auto-load-cpu-fallback-toast.test.ts
+++ b/studio/frontend/tests/auto-load-cpu-fallback-toast.test.ts
@@ -23,7 +23,10 @@ test("an auto-load that fell back to CPU warns instead of claiming plain success
   // added alongside it, and pinning the whole expression made a widening of the
   // rule read as a break of it. What matters is that a CPU fallback still selects
   // the warning toast and still explains itself.
-  assert.match(helper, /cpuFallbackReason[^\n]*\? toast\.warning : toast\.success/);
+  assert.match(
+    helper,
+    /cpuFallbackReason[^\n]*\? toast\.warning : toast\.success/,
+  );
   assert.match(helper, /GPU acceleration is disabled for this model session/);
 });
 
@@ -33,19 +36,19 @@ test("an auto-load that only partly reached the GPU warns too", () => {
   // that stays silent.
   const start = source.indexOf("const showAutoLoadSuccess = (");
   const helper = source.slice(start, source.indexOf("\n  };", start));
-  assert.match(helper, /isPartialOffload/);
-  assert.match(helper, /partialOffloadDescription/);
+  assert.match(helper, /offloadWarning/);
+  assert.match(helper, /offloadNotice\?\.description/);
+  assert.match(helper, /offloadNotice\?\.titleSuffix/);
 });
 
 test("every auto-load path forwards the offload counts", () => {
   const calls = source.match(/\n\s*showAutoLoadSuccess\([\s\S]*?\);/g) ?? [];
   assert.ok(calls.length > 0, "no showAutoLoadSuccess call sites found");
   for (const call of calls) {
-    assert.match(call, /offloaded_layers/);
-    assert.match(call, /offload_total_layers/);
-    // Manual mode pins the split deliberately, so the mode has to travel with
-    // the counts or a user's own choice gets reported as a problem.
-    assert.match(call, /gpu_memory_mode/);
+    // Through the shared reader, so a field added to the split (the mode, and
+    // then whether extras overrode the placement) reaches every load path at
+    // once rather than the one whose call site got updated.
+    assert.match(call, /offloadCountsFrom\(loadResp\)/);
   }
 });
 

--- a/studio/frontend/tests/auto-load-cpu-fallback-toast.test.ts
+++ b/studio/frontend/tests/auto-load-cpu-fallback-toast.test.ts
@@ -19,8 +19,34 @@ test("an auto-load that fell back to CPU warns instead of claiming plain success
   const start = source.indexOf("const showAutoLoadSuccess = (");
   assert.ok(start >= 0, "showAutoLoadSuccess is no longer defined");
   const helper = source.slice(start, source.indexOf("\n  };", start));
-  assert.match(helper, /cpuFallbackReason \? toast\.warning : toast\.success/);
+  // Not the exact ternary: a second warning condition (a partial GPU offload) was
+  // added alongside it, and pinning the whole expression made a widening of the
+  // rule read as a break of it. What matters is that a CPU fallback still selects
+  // the warning toast and still explains itself.
+  assert.match(helper, /cpuFallbackReason[^\n]*\? toast\.warning : toast\.success/);
   assert.match(helper, /GPU acceleration is disabled for this model session/);
+});
+
+test("an auto-load that only partly reached the GPU warns too", () => {
+  // The path a new user hits first: a chat sent with no model loaded auto-loads
+  // the default, so without this the case the warning exists for is the one case
+  // that stays silent.
+  const start = source.indexOf("const showAutoLoadSuccess = (");
+  const helper = source.slice(start, source.indexOf("\n  };", start));
+  assert.match(helper, /isPartialOffload/);
+  assert.match(helper, /partialOffloadDescription/);
+});
+
+test("every auto-load path forwards the offload counts", () => {
+  const calls = source.match(/\n\s*showAutoLoadSuccess\([\s\S]*?\);/g) ?? [];
+  assert.ok(calls.length > 0, "no showAutoLoadSuccess call sites found");
+  for (const call of calls) {
+    assert.match(call, /offloaded_layers/);
+    assert.match(call, /offload_total_layers/);
+    // Manual mode pins the split deliberately, so the mode has to travel with
+    // the counts or a user's own choice gets reported as a problem.
+    assert.match(call, /gpu_memory_mode/);
+  }
 });
 
 test("every auto-load path forwards the load response's fallback reason", () => {

--- a/studio/frontend/tests/offload-warning-load-paths.test.ts
+++ b/studio/frontend/tests/offload-warning-load-paths.test.ts
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+// Four separate flows load a model, and each grew its own success toast. A
+// silent split announced as success in any one of them is the whole defect, so
+// the list is asserted rather than left to whoever touches a load path next.
+const LOAD_PATHS = [
+  "../src/features/chat/hooks/use-chat-model-runtime.ts",
+  "../src/features/chat/api/chat-adapter.ts",
+  "../src/features/chat/shared-composer.tsx",
+  "../src/features/recipe-studio/hooks/use-recipe-executions.ts",
+];
+
+test("every user-facing load path consults the offload warning", () => {
+  for (const path of LOAD_PATHS) {
+    const source = readFileSync(
+      fileURLToPath(new URL(path, import.meta.url)),
+      "utf8",
+    );
+    assert.match(source, /offloadWarning\(/, `${path} ignores the split`);
+  }
+});
+
+test("a recipe run no longer claims plain success unconditionally", () => {
+  // It loads with no panel open, so before this the run simply came out slow.
+  const source = readFileSync(
+    fileURLToPath(
+      new URL(
+        "../src/features/recipe-studio/hooks/use-recipe-executions.ts",
+        import.meta.url,
+      ),
+    ),
+    "utf8",
+  );
+  assert.match(source, /offloadNotice \? toast\.warning : toast\.success/);
+  assert.doesNotMatch(source, /toast\.success\(`Loaded \$\{modelLabel\}`/);
+});

--- a/studio/frontend/tests/offload-warning-load-paths.test.ts
+++ b/studio/frontend/tests/offload-warning-load-paths.test.ts
@@ -6,7 +6,7 @@ import { readFileSync } from "node:fs";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
 
-// Four separate flows load a model, and each grew its own success toast. A
+// Five separate flows load a model, and each grew its own success toast. A
 // silent split announced as success in any one of them is the whole defect, so
 // the list is asserted rather than left to whoever touches a load path next.
 const LOAD_PATHS = [
@@ -14,6 +14,8 @@ const LOAD_PATHS = [
   "../src/features/chat/api/chat-adapter.ts",
   "../src/features/chat/shared-composer.tsx",
   "../src/features/recipe-studio/hooks/use-recipe-executions.ts",
+  // The Audio page loads a GGUF TTS variant, which fits like any other GGUF.
+  "../src/features/audio/audio-page.tsx",
 ];
 
 test("every user-facing load path consults the offload warning", () => {

--- a/studio/frontend/tests/partial-offload.test.ts
+++ b/studio/frontend/tests/partial-offload.test.ts
@@ -4,54 +4,99 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
-  isPartialOffload,
-  partialOffloadDescription,
+  offloadCountsFrom,
+  offloadWarning,
 } from "../src/features/chat/lib/partial-offload.ts";
 
 test("a split load is reported", () => {
-  assert.equal(isPartialOffload({ offloaded: 38, total: 60 }), true);
-  assert.equal(isPartialOffload({ offloaded: 1, total: 60 }), true);
+  assert.match(
+    offloadWarning({ offloaded: 38, total: 60 })?.description ?? "",
+    /^38 of 60 layers are on the GPU\./,
+  );
+  assert.equal(
+    offloadWarning({ offloaded: 38, total: 60 })?.titleSuffix,
+    ", partly on CPU",
+  );
+  assert.notEqual(offloadWarning({ offloaded: 1, total: 60 }), null);
 });
 
 test("a full offload is the normal case and says nothing", () => {
-  assert.equal(isPartialOffload({ offloaded: 60, total: 60 }), false);
+  assert.equal(offloadWarning({ offloaded: 60, total: 60 }), null);
 });
 
-test("no layers on the GPU is the CPU-fallback path, not this one", () => {
-  // That case has its own reporting; folding it in here would double-warn.
-  assert.equal(isPartialOffload({ offloaded: 0, total: 60 }), false);
+test("no layers on the GPU is the worst case, not an excluded one", () => {
+  // cpu_fallback_reason is only ever set for the Vulkan startup-crash recovery,
+  // so an ordinary --fit on load that got nothing onto the GPU has no other
+  // reporting at all: it announced plain success and simply ran slowly.
+  const warning = offloadWarning({ offloaded: 0, total: 60 });
+  assert.equal(warning?.titleSuffix, ", on CPU");
+  assert.match(warning?.description ?? "", /^None of the 60 layers fit/);
 });
 
 test("a load that reported no counts says nothing", () => {
-  assert.equal(isPartialOffload({}), false);
-  assert.equal(isPartialOffload({ offloaded: null, total: null }), false);
-  assert.equal(isPartialOffload({ offloaded: 38, total: null }), false);
-  assert.equal(isPartialOffload({ offloaded: undefined, total: 60 }), false);
+  assert.equal(offloadWarning({}), null);
+  assert.equal(offloadWarning({ offloaded: null, total: null }), null);
+  assert.equal(offloadWarning({ offloaded: 38, total: null }), null);
+  assert.equal(offloadWarning({ offloaded: undefined, total: 60 }), null);
 });
 
 test("a nonsense total cannot produce a warning", () => {
-  assert.equal(isPartialOffload({ offloaded: 5, total: 0 }), false);
-  assert.equal(isPartialOffload({ offloaded: 5, total: -1 }), false);
+  assert.equal(offloadWarning({ offloaded: 5, total: 0 }), null);
+  assert.equal(offloadWarning({ offloaded: 5, total: -1 }), null);
+  assert.equal(offloadWarning({ offloaded: 61, total: 60 }), null);
 });
 
 test("a split the user pinned themselves is not warned about", () => {
   // Manual mode means the user chose that layer count. The model may well fit,
   // so "pick a smaller quantization" would be advice against their own decision.
   assert.equal(
-    isPartialOffload({ offloaded: 20, total: 60, gpuMemoryMode: "manual" }),
-    false,
+    offloadWarning({ offloaded: 20, total: 60, gpuMemoryMode: "manual" }),
+    null,
   );
-  assert.equal(
-    isPartialOffload({ offloaded: 20, total: 60, gpuMemoryMode: "auto" }),
-    true,
+  assert.notEqual(
+    offloadWarning({ offloaded: 20, total: 60, gpuMemoryMode: "auto" }),
+    null,
   );
   // Absent (an older backend) is treated as automatic, which is the default.
-  assert.equal(isPartialOffload({ offloaded: 20, total: 60 }), true);
+  assert.notEqual(offloadWarning({ offloaded: 20, total: 60 }), null);
 });
 
-test("both load paths share one wording", () => {
-  assert.match(
-    partialOffloadDescription({ offloaded: 38, total: 60 }),
-    /^38 of 60 layers are on the GPU\./,
+test("an -ngl passed through extras counts as the user's own choice", () => {
+  // Auto mode respects an inherited -ngl rather than stripping it, so the mode
+  // still reads "auto" for a split the user picked deliberately.
+  assert.equal(
+    offloadWarning({
+      offloaded: 20,
+      total: 60,
+      gpuMemoryMode: "auto",
+      offloadOverridden: true,
+    }),
+    null,
+  );
+  // Including the all-on-CPU case, which is a legitimate thing to ask for.
+  assert.equal(
+    offloadWarning({ offloaded: 0, total: 60, offloadOverridden: true }),
+    null,
+  );
+});
+
+test("every load path reads the response the same way", () => {
+  assert.deepEqual(
+    offloadCountsFrom({
+      // biome-ignore lint/style/useNamingConvention: api schema
+      offloaded_layers: 38,
+      // biome-ignore lint/style/useNamingConvention: api schema
+      offload_total_layers: 60,
+      // biome-ignore lint/style/useNamingConvention: api schema
+      gpu_memory_mode: "auto",
+      // biome-ignore lint/style/useNamingConvention: api schema
+      offload_overridden: false,
+    }),
+    {
+      offloaded: 38,
+      total: 60,
+      gpuMemoryMode: "auto",
+      offloadOverridden: false,
+    },
   );
 });

--- a/studio/frontend/tests/partial-offload.test.ts
+++ b/studio/frontend/tests/partial-offload.test.ts
@@ -47,10 +47,16 @@ test("a nonsense total cannot produce a warning", () => {
 });
 
 test("a split the user pinned themselves is not warned about", () => {
-  // Manual mode means the user chose that layer count. The model may well fit,
-  // so "pick a smaller quantization" would be advice against their own decision.
+  // Manual mode with an explicit layer count means the user chose that count.
+  // The model may well fit, so "pick a smaller quantization" would be advice
+  // against their own decision.
   assert.equal(
-    offloadWarning({ offloaded: 20, total: 60, gpuMemoryMode: "manual" }),
+    offloadWarning({
+      offloaded: 20,
+      total: 60,
+      gpuMemoryMode: "manual",
+      gpuLayers: 20,
+    }),
     null,
   );
   assert.notEqual(
@@ -90,13 +96,57 @@ test("every load path reads the response the same way", () => {
       // biome-ignore lint/style/useNamingConvention: api schema
       gpu_memory_mode: "auto",
       // biome-ignore lint/style/useNamingConvention: api schema
+      gpu_layers: -1,
+      // biome-ignore lint/style/useNamingConvention: api schema
       offload_overridden: false,
+      // biome-ignore lint/style/useNamingConvention: api schema
+      cpu_fallback_reason: null,
     }),
     {
       offloaded: 38,
       total: 60,
       gpuMemoryMode: "auto",
+      gpuLayers: -1,
       offloadOverridden: false,
+      cpuFallbackReason: null,
     },
+  );
+});
+
+test("Manual mode with GPU Layers on Auto is still an automatic spill", () => {
+  // Manual + Auto layers hands placement back to llama.cpp exactly like Auto
+  // mode does, and the response still reads "manual", so the mode alone is not
+  // the question: the requested count is.
+  assert.notEqual(
+    offloadWarning({
+      offloaded: 20,
+      total: 60,
+      gpuMemoryMode: "manual",
+      gpuLayers: -1,
+    }),
+    null,
+  );
+  assert.notEqual(
+    offloadWarning({ offloaded: 0, total: 60, gpuMemoryMode: "manual" }),
+    null,
+  );
+});
+
+test("a known reason for the CPU wins over the counts", () => {
+  // A recovered Vulkan startup crash leaves a 0/M line behind it. Reading that
+  // as "nothing fit" would blame the model's size for a backend crash and
+  // recommend a quantization that changes nothing.
+  const warning = offloadWarning({
+    offloaded: 0,
+    total: 60,
+    cpuFallbackReason: "vulkan_startup_crash",
+  });
+  assert.equal(warning?.titleSuffix, " on CPU");
+  assert.match(warning?.description ?? "", /Vulkan backend crashed/);
+  assert.doesNotMatch(warning?.description ?? "", /smaller quantization/);
+  // An unrecognised reason is still a reason: say nothing rather than guess.
+  assert.equal(
+    offloadWarning({ offloaded: 0, total: 60, cpuFallbackReason: "something" }),
+    null,
   );
 });

--- a/studio/frontend/tests/partial-offload.test.ts
+++ b/studio/frontend/tests/partial-offload.test.ts
@@ -3,7 +3,10 @@
 
 import assert from "node:assert/strict";
 import test from "node:test";
-import { isPartialOffload } from "../src/features/chat/lib/partial-offload.ts";
+import {
+  isPartialOffload,
+  partialOffloadDescription,
+} from "../src/features/chat/lib/partial-offload.ts";
 
 test("a split load is reported", () => {
   assert.equal(isPartialOffload({ offloaded: 38, total: 60 }), true);
@@ -29,4 +32,26 @@ test("a load that reported no counts says nothing", () => {
 test("a nonsense total cannot produce a warning", () => {
   assert.equal(isPartialOffload({ offloaded: 5, total: 0 }), false);
   assert.equal(isPartialOffload({ offloaded: 5, total: -1 }), false);
+});
+
+test("a split the user pinned themselves is not warned about", () => {
+  // Manual mode means the user chose that layer count. The model may well fit,
+  // so "pick a smaller quantization" would be advice against their own decision.
+  assert.equal(
+    isPartialOffload({ offloaded: 20, total: 60, gpuMemoryMode: "manual" }),
+    false,
+  );
+  assert.equal(
+    isPartialOffload({ offloaded: 20, total: 60, gpuMemoryMode: "auto" }),
+    true,
+  );
+  // Absent (an older backend) is treated as automatic, which is the default.
+  assert.equal(isPartialOffload({ offloaded: 20, total: 60 }), true);
+});
+
+test("both load paths share one wording", () => {
+  assert.match(
+    partialOffloadDescription({ offloaded: 38, total: 60 }),
+    /^38 of 60 layers are on the GPU\./,
+  );
 });

--- a/studio/frontend/tests/partial-offload.test.ts
+++ b/studio/frontend/tests/partial-offload.test.ts
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import { isPartialOffload } from "../src/features/chat/lib/partial-offload.ts";
+
+test("a split load is reported", () => {
+  assert.equal(isPartialOffload({ offloaded: 38, total: 60 }), true);
+  assert.equal(isPartialOffload({ offloaded: 1, total: 60 }), true);
+});
+
+test("a full offload is the normal case and says nothing", () => {
+  assert.equal(isPartialOffload({ offloaded: 60, total: 60 }), false);
+});
+
+test("no layers on the GPU is the CPU-fallback path, not this one", () => {
+  // That case has its own reporting; folding it in here would double-warn.
+  assert.equal(isPartialOffload({ offloaded: 0, total: 60 }), false);
+});
+
+test("a load that reported no counts says nothing", () => {
+  assert.equal(isPartialOffload({}), false);
+  assert.equal(isPartialOffload({ offloaded: null, total: null }), false);
+  assert.equal(isPartialOffload({ offloaded: 38, total: null }), false);
+  assert.equal(isPartialOffload({ offloaded: undefined, total: 60 }), false);
+});
+
+test("a nonsense total cannot produce a warning", () => {
+  assert.equal(isPartialOffload({ offloaded: 5, total: 0 }), false);
+  assert.equal(isPartialOffload({ offloaded: 5, total: -1 }), false);
+});

--- a/studio/frontend/tests/partial-offload.test.ts
+++ b/studio/frontend/tests/partial-offload.test.ts
@@ -101,6 +101,8 @@ test("every load path reads the response the same way", () => {
       offload_overridden: false,
       // biome-ignore lint/style/useNamingConvention: api schema
       cpu_fallback_reason: null,
+      // biome-ignore lint/style/useNamingConvention: api schema
+      gpu_backend_unavailable: false,
     }),
     {
       offloaded: 38,
@@ -109,6 +111,7 @@ test("every load path reads the response the same way", () => {
       gpuLayers: -1,
       offloadOverridden: false,
       cpuFallbackReason: null,
+      gpuBackendUnavailable: false,
     },
   );
 });
@@ -129,6 +132,30 @@ test("Manual mode with GPU Layers on Auto is still an automatic spill", () => {
   assert.notEqual(
     offloadWarning({ offloaded: 0, total: 60, gpuMemoryMode: "manual" }),
     null,
+  );
+});
+
+test("a GPU that llama.cpp could not use is not a size problem", () => {
+  // A failed CUDA/ROCm init logs the same 0/M line as a fit that placed no
+  // layers, and telling a user with a broken install to pick a smaller
+  // quantization sends them to re-download a model that was never the problem.
+  const broken = offloadWarning({
+    offloaded: 0,
+    total: 60,
+    gpuBackendUnavailable: true,
+  });
+  assert.match(broken?.description ?? "", /could not use it/);
+  assert.doesNotMatch(broken?.description ?? "", /smaller quantization would/);
+  // A genuine zero-layer fit still gets the size wording.
+  assert.match(
+    offloadWarning({ offloaded: 0, total: 60 })?.description ?? "",
+    /None of the 60 layers fit/,
+  );
+  // It only speaks to the all-CPU case; a split load is a split load.
+  assert.match(
+    offloadWarning({ offloaded: 20, total: 60, gpuBackendUnavailable: true })
+      ?.description ?? "",
+    /^20 of 60 layers/,
   );
 });
 


### PR DESCRIPTION
From the r/LocalLLaMA review:

> many novice users will get burned by ... dense models auto-spilling to RAM

The spill is the right behaviour and this PR does not change it. Refusing instead would break running a large model on a small card, which is exactly what people want partial offload for, and it would regress #7022 (a user with 16 GB VRAM and 112 GB RAM complaining that `--fit on` *blocks* a model). The problem is that it happens silently.

### What was already there

`_OFFLOADED_LAYERS_RE` matches llama.cpp's own `offloaded N/M layers to GPU`, and `classify_gpu_offload_lines` reduces it to `offloaded_at_max > 0`. That is the correct answer to "did the GPU work at all", and it is why `12/60` and `60/60` are indistinguishable everywhere downstream.

On the wire, `gpu_layers` is the **request**, so in Auto mode it is always `-1`. Studio does not pick the split: `_select_gpus` decides the model does not provably fit, returns `use_fit`, and llama.cpp's `--fit on` chooses the layer count. So a half-offloaded load was byte-identical to a fully offloaded one, and both got the same green "loaded" toast. The only way to discover it was to notice the model was slow.

The codebase already knows what it costs. `_fit_context_to_vram` shrinks context, and the serving-slot reducer says so directly: "Prefer fewer serving slots on GPU over --fit on offload: ... decode collapses ~3x (#6718)". It works hard to avoid the spill and then says nothing when it happens anyway.

### What changes

- `parse_gpu_offload_counts` keeps `(offloaded, total)` from the same line, using the same largest-M rule so a draft or MTP model's much smaller line cannot be reported instead of the main model
- recorded on the backend, published as `offloaded_layers` / `offload_total_layers`, cleared on unload
- a `logger.warning` server-side, and a warning toast: "38 of 60 layers are on the GPU. The rest run on CPU, so generation will be slower. A smaller quantization would fit entirely on the GPU."

Two cases are deliberately excluded. A full offload is the normal case and says nothing. **No** layers on the GPU is a different failure with its own reporting (the #5106 CPU-fallback path), so folding it in here would double-warn.

Placement is untouched: same flags, same decisions, only the reporting.

### Not in this PR

The same investigation found two larger gaps, both left alone as policy changes rather than transparency:

- Auto mode never emits `--n-cpu-moe`, so a MoE that overflows gets whole-layer spill instead of expert-only offload. Anchor is #7022
- `apply_model_memory_policy` emits `--load-mode mmap+mlock`, which keeps mmap on, so CPU-resident tensors stay in pageable memory. Studio's own `_LOAD_MODE_RESERVING_VALUES` already excludes that value

### Verification

- `parse_gpu_offload_counts` covered for a split load, the draft-versus-main rule, no counted line, and a zero total, plus a test asserting the boolean genuinely cannot tell `12/60` from `60/60`
- `isPartialOffload` covered for split, full, zero, missing and nonsense counts
- backend: `test_llama_cpp_context_fit.py`, `test_inference_status_route.py`, `test_inference_status_loaded_gguf.py`, `test_slot_offload_fit.py` -> 92 passed
- frontend: `npm test` 2394 pass / 0 fail, `npm run typecheck` clean
- `ruff check` clean, pre-push gate PASS

`test_mcp_server.py` and `test_rag_ocr_fallback.py` fail collection in my environment for missing optional dependencies, identically with and without this branch.
