### PR TITLE
Round the aggregate GPU VRAM total so it stops printing float residue

### DIFF
--- a/studio/frontend/src/hooks/gpu-vram.ts
+++ b/studio/frontend/src/hooks/gpu-vram.ts
@@ -9,11 +9,39 @@ export interface VramReportingDevice {
   vram_used_gb?: number;
 }
 
+export interface MemoryTotalDevice {
+  memory_total_gb?: number;
+  /** True when the reported GPU budget comes from shared system memory. */
+  shared_memory?: boolean;
+}
+
 export interface VramReportingGpu {
   devices?: VramReportingDevice[];
   /** Used VRAM across the visible GPUs when no single device's usage could be
    * attributed. Windows ROCm only; null everywhere else. See #7452. */
   vram_used_gb_aggregate?: number | null;
+}
+
+/** Sum dedicated VRAM while counting a shared host-memory pool only once.
+ *
+ * The backend rounds each device to 2dp before sending it, so adding the
+ * devices back up reintroduces binary floating point error: three B200s at
+ * 179.06 GiB each sum to 537.1800000000001. Not every caller rounds before
+ * printing the total, so the sum is returned at the precision the devices
+ * arrived with. */
+export function aggregateGpuMemoryTotalGb(
+  devices: MemoryTotalDevice[],
+): number {
+  const dedicated = devices
+    .filter((device) => !device.shared_memory)
+    .reduce((sum, device) => sum + (device.memory_total_gb ?? 0), 0);
+  const shared = Math.max(
+    0,
+    ...devices
+      .filter((device) => device.shared_memory)
+      .map((device) => device.memory_total_gb ?? 0),
+  );
+  return Math.round((dedicated + shared) * 100) / 100;
 }
 
 /** Whether every device reports its own usage, so each row and their sum are real. */

--- a/studio/frontend/src/hooks/gpu-vram.ts
+++ b/studio/frontend/src/hooks/gpu-vram.ts
@@ -24,11 +24,9 @@ export interface VramReportingGpu {
 
 /** Sum dedicated VRAM while counting a shared host-memory pool only once.
  *
- * The backend rounds each device to 2dp before sending it, so adding the
- * devices back up reintroduces binary floating point error: three B200s at
- * 179.06 GiB each sum to 537.1800000000001. Not every caller rounds before
- * printing the total, so the sum is returned at the precision the devices
- * arrived with. */
+ * Devices arrive rounded to 2dp, so summing them reintroduces float error
+ * (three B200s at 179.06 give 537.1800000000001) and not every caller rounds
+ * again before printing. Round back to the precision they arrived with. */
 export function aggregateGpuMemoryTotalGb(
   devices: MemoryTotalDevice[],
 ): number {

--- a/studio/frontend/src/hooks/use-system.ts
+++ b/studio/frontend/src/hooks/use-system.ts
@@ -33,19 +33,9 @@ export interface SystemGpuInfo {
   devices: GpuDevice[];
 }
 
-/** Sum dedicated VRAM while counting a shared host-memory pool only once. */
-export function aggregateGpuMemoryTotalGb(devices: GpuDevice[]): number {
-  const dedicated = devices
-    .filter((device) => !device.shared_memory)
-    .reduce((sum, device) => sum + (device.memory_total_gb ?? 0), 0);
-  const shared = Math.max(
-    0,
-    ...devices
-      .filter((device) => device.shared_memory)
-      .map((device) => device.memory_total_gb ?? 0),
-  );
-  return dedicated + shared;
-}
+// Lives in gpu-vram.ts with the other VRAM rules, re-exported here for the
+// callers that already import it from this module.
+export { aggregateGpuMemoryTotalGb } from "./gpu-vram";
 
 export interface SystemInfoResponse {
   platform: string;

--- a/studio/frontend/tests/gpu-memory-aggregate.test.ts
+++ b/studio/frontend/tests/gpu-memory-aggregate.test.ts
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  type MemoryTotalDevice,
+  aggregateGpuMemoryTotalGb,
+} from "../src/hooks/gpu-vram.ts";
+
+// 183359 MiB rounded to 2dp by the backend, the per-device figure a B200 reports.
+const B200_GIB = 179.06;
+
+function dedicated(count: number, memory = B200_GIB): MemoryTotalDevice[] {
+  return Array.from({ length: count }, () => ({ memory_total_gb: memory }));
+}
+
+test("the total of several identical GPUs carries no float residue", () => {
+  // Summing three 179.06 values is 537.1800000000001 before rounding, and the
+  // run preview card prints the total without rounding it again.
+  const total = aggregateGpuMemoryTotalGb(dedicated(3));
+  assert.equal(total, 537.18);
+  assert.equal(String(total), "537.18");
+});
+
+test("no total keeps more than the 2dp the devices arrived with", () => {
+  for (let count = 1; count <= 8; count++) {
+    const total = aggregateGpuMemoryTotalGb(dedicated(count));
+    assert.equal(total, Math.round(total * 100) / 100, `${count} GPUs`);
+  }
+});
+
+test("a shared host-memory pool is still counted once", () => {
+  const devices: MemoryTotalDevice[] = [
+    ...dedicated(1, 8.5),
+    { memory_total_gb: 15.7, shared_memory: true },
+    { memory_total_gb: 15.7, shared_memory: true },
+  ];
+  assert.equal(aggregateGpuMemoryTotalGb(devices), 24.2);
+});
+
+test("devices without a reported total do not poison the sum", () => {
+  const devices: MemoryTotalDevice[] = [...dedicated(2), {}];
+  assert.equal(aggregateGpuMemoryTotalGb(devices), 358.12);
+});
+
+test("no devices means no VRAM", () => {
+  assert.equal(aggregateGpuMemoryTotalGb([]), 0);
+});


### PR DESCRIPTION
### The bug

With 3 GPUs the training page hardware row reads:

```
NVIDIA B200 · 537.1800000000001 GB
```

The residue is introduced by our own arithmetic, not by anything the driver reports.

### Why

The backend rounds each device to 2dp before sending it (`studio/backend/utils/hardware/nvidia.py:273`, `round(mem_total_mb / 1024, 2)`), so a B200's 183359 MiB arrives as `179.06`. `aggregateGpuMemoryTotalGb` then adds the devices back up and the sum is never re-rounded, and `179.06 * 3` is exactly `537.1800000000001` in IEEE-754 doubles.

Most call sites hide this because they round again on the way out (`hub-page.tsx:1266`, `model-config-page.tsx:732`, `about-tab.tsx:194`, and the two local `formatGiB` helpers). The training run preview card interpolates the total raw, so it shows the residue in full:

```tsx
// studio/frontend/src/features/studio/wizard/run-preview-card.tsx:515
? `${gpu.name} · ${gpu.memoryTotalGb} GB`
```

Two other sites carry the same raw total and would print it the same way: `model-selector/pickers.tsx:846,848` and `train-model-picker-lists.tsx:256-266`.

### The fix

Round the sum back to the 2dp the devices arrived with, in the aggregate itself rather than at each call site, so all four consumers are covered at once. The preview card now reads `NVIDIA B200 · 537.18 GB`.

The helper also moves from `use-system.ts` into `gpu-vram.ts`, which exists for exactly this ("split out of use-system.ts so the VRAM rules can be unit tested without pulling the auth and React graph in behind them"). It is typed structurally there, matching `VramReportingDevice` next to it. `use-system.ts` re-exports it, so every existing importer is untouched.

### Tests

New `studio/frontend/tests/gpu-memory-aggregate.test.ts`, 5 cases: the 3x B200 regression, no total keeping more than 2dp for 1 through 8 GPUs, the shared host-memory pool still counted once, devices missing a total not poisoning the sum, and the empty case.

- `npm test`: 2475 pass, 0 fail
- `npm run typecheck`: clean
- `npx biome check`: clean on the changed files

### Not in this PR

This line labels the value `GB` while the maths is GiB (`mem_total_mb / 1024`). `hub-page.tsx` labels the same number `GiB` and `model-config-page.tsx` labels it `GB`, so the wording is inconsistent across the app independently of this bug. Left alone here since changing what the unit says is a separate call from fixing the arithmetic.
