### PR TITLE
Offer the media pickers only what the host can run, and name the H3 speed gap

### DIFF
--- a/studio/frontend/src/features/images/images-page.tsx
+++ b/studio/frontend/src/features/images/images-page.tsx
@@ -56,11 +56,13 @@ import { useScrollFades } from "@/hooks/use-scroll-fades";
 import { ModelSelector } from "@/features/model-picker/components/model-selector";
 import { IMAGE_GEN_TASKS } from "@/features/model-picker/components/model-selector/pickers";
 import { PillTabs } from "@/features/model-picker/components/model-selector/pill-tabs";
+import type { HostClass } from "@/features/model-picker/components/model-selector/host-artifact-policy";
 import {
   IMAGE_CATALOG,
   catalogToModelOptions,
   loadSpecFor,
 } from "@/features/model-picker/components/model-selector/model-catalog";
+import { useHostClass } from "@/hooks/use-host-class";
 import type {
   ModelOption,
   ModelSelectorChangeMeta,
@@ -171,7 +173,11 @@ import {
 } from "./train/train-base-selector";
 
 // Curated models come from the shared catalog: one canonical group per model with its artifacts (GGUF / FP8 / bnb-4bit / BF16) as data, and the load kind per artifact via loadSpecFor.
-const MODELS: ModelOption[] = catalogToModelOptions(IMAGE_CATALOG);
+// Host-dependent, so it is built per render rather than once at module load: a host that can
+// only run the native engine is not offered the pipeline rows it would be refused at load.
+function useImageModels(host: HostClass): ModelOption[] {
+  return useMemo(() => catalogToModelOptions(IMAGE_CATALOG, host), [host]);
+}
 
 // Workflow tabs. `requires` is the backend workflow id (status.workflows) the loaded model must support; null = always available.
 // The images each conditioned workflow consumed, named for the restore toast: a recipe keeps the scalar settings but not the uploads.
@@ -1163,6 +1169,8 @@ type LoadAdvanced = Pick<
 
 export function ImagesPage({ active = true }: { active?: boolean }) {
   const { isMobile, pinned } = useSidebar();
+  const hostClass = useHostClass();
+  const imageModels = useImageModels(hostClass);
   const [quant, setQuant] = useState<string | null>(galleryCache.quant);
   const [prompt, setPrompt] = useState(
     "Cinematic wide shot of a whimsical Alice in Wonderland tea party in an overgrown Victorian garden. Exactly three figures at a long white lace-draped table: a tall eccentric gentleman in an oversized emerald velvet top hat pouring tea from a silver pot mid-motion; a young woman in a pale blue Victorian dress seated left, holding a porcelain teacup with both hands, looking up and laughing; an older woman in deep burgundy seated right in profile, reaching for a tiered cake stand. Detailed embroidered fabrics, realistic skin texture, natural expressions. The table holds mismatched porcelain, antique silverware, towering pastel cakes, and wildflowers. Giant red-capped mushrooms rise behind the table, with ancient trees overhead and golden sunlight streaming through leaves. Shot on 85mm, f/2.8, focus on the gentleman, soft background falloff. Photorealistic, saturated storybook color, warm amber and deep green palette.",
@@ -3616,7 +3624,7 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
               />
             ) : (
               <ModelSelector
-                models={MODELS}
+                models={imageModels}
                 value={status?.loaded ? status.repo_id ?? undefined : undefined}
                 activeGgufVariant={quant}
                 onValueChange={handleModelSelect}

--- a/studio/frontend/src/features/model-picker/components/model-selector/host-artifact-policy.ts
+++ b/studio/frontend/src/features/model-picker/components/model-selector/host-artifact-policy.ts
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import type { ArtifactFormat } from "./model-catalog.ts";
+
+/**
+ * What the host can actually run, as opposed to what fits on it.
+ *
+ * Capability, not size: `curatedArtifactFitsDevice` already answers "is there room", and the two
+ * must stay apart. A 128 GB Mac has room for the H3 pipeline and still cannot load it.
+ *
+ * `unknown` is not a formality. The GPU hook starts at `available: false, budgetKnown: false`, so
+ * a boolean would read every first render as CPU-only and blink the non-GGUF rows out and back on
+ * a real GPU host.
+ */
+export type HostClass = "unknown" | "gguf-only" | "accelerated";
+
+/** Backends whose diffusion pipelines the media pages can place. */
+const ACCELERATED_BACKENDS = new Set(["cuda", "rocm", "xpu"]);
+
+/** Backends that can only run the native GGUF engine. */
+const GGUF_ONLY_BACKENDS = new Set(["mlx", "cpu"]);
+
+export function classifyHost({
+  deviceType,
+  deviceBackend,
+  budgetKnown,
+}: {
+  deviceType?: string | null;
+  deviceBackend?: string | null;
+  budgetKnown?: boolean;
+}): HostClass {
+  // Mac outranks the backend string. Apple GPUs report as available and Studio may name the
+  // backend mlx or cpu depending on what torch found, but no Mac can place a Modular Diffusers
+  // workflow: it needs mem_get_info, which torch.mps does not expose. video.py refuses the load.
+  if (deviceType === "mac") return "gguf-only";
+  const backend = (deviceBackend ?? "").trim().toLowerCase();
+  if (!(backend && budgetKnown)) return "unknown";
+  if (GGUF_ONLY_BACKENDS.has(backend)) return "gguf-only";
+  if (ACCELERATED_BACKENDS.has(backend)) return "accelerated";
+  // An unrecognised backend is a new accelerator, not a CPU. Show what we show today.
+  return "unknown";
+}
+
+/** Whether a curated artifact is worth offering on this host.
+ *
+ * Only browse rows are filtered. A model already on disk keeps its row wherever it came from. */
+export function curatedArtifactIsOfferable(
+  format: ArtifactFormat,
+  host: HostClass,
+): boolean {
+  if (host !== "gguf-only") return true;
+  return format === "gguf";
+}
+
+/** The H3 group, whose two rows differ by roughly 10x in throughput. */
+const H3_PIPELINE_ID = "minimaxai/minimax-h3";
+const H3_GGUF_ID = "unsloth/minimax-h3-gguf";
+
+/**
+ * The speed qualifier for a curated row, or null when it earns none.
+ *
+ * Deliberately keyed on the two H3 ids rather than on `format !== "gguf"`. Most non-GGUF rows are
+ * plain bf16 or bnb-4bit, Auto precision resolves to int8 or bf16 on cards without fp8, and only
+ * H3 has the measured gap this wording claims.
+ */
+export function h3PerfSuffix(repoId: string, host: HostClass): string | null {
+  if (host !== "accelerated") return null;
+  const id = repoId.trim().toLowerCase();
+  if (id === H3_PIPELINE_ID) return "Fast FP8";
+  if (id === H3_GGUF_ID) return "Slow";
+  return null;
+}

--- a/studio/frontend/src/features/model-picker/components/model-selector/host-artifact-policy.ts
+++ b/studio/frontend/src/features/model-picker/components/model-selector/host-artifact-policy.ts
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-import type { ArtifactFormat } from "./model-catalog.ts";
-
 /**
  * What the host can actually run, as opposed to what fits on it.
  *
@@ -42,19 +40,32 @@ export function classifyHost({
   return "unknown";
 }
 
+/** The H3 group, whose two rows differ by roughly 10x in throughput. */
+const H3_PIPELINE_ID = "minimaxai/minimax-h3";
+
+/**
+ * The curated artifacts a host without an accelerator is refused at load, by repo id.
+ *
+ * Keyed on the id, NOT on `format !== "gguf"`. Everything else in the catalogs loads here: the
+ * diffusion pipelines resolve their device through the shared target and run on MPS (Z-Image is
+ * tuned for MPS bfloat16 by name), video_capability() certifies Apple Silicon, and the STT rows
+ * run through the whisper.cpp sidecar whatever format the catalog labels them. Only MiniMax-H3's
+ * Modular Diffusers workflow is genuinely unplaceable: enable_auto_cpu_offload needs
+ * mem_get_info, torch.mps has none, and video.py raises before the download.
+ */
+const UNPLACEABLE_WITHOUT_ACCELERATOR = new Set([H3_PIPELINE_ID]);
+
 /** Whether a curated artifact is worth offering on this host.
  *
  * Only browse rows are filtered. A model already on disk keeps its row wherever it came from. */
 export function curatedArtifactIsOfferable(
-  format: ArtifactFormat,
+  repoId: string,
   host: HostClass,
 ): boolean {
   if (host !== "gguf-only") return true;
-  return format === "gguf";
+  return !UNPLACEABLE_WITHOUT_ACCELERATOR.has(repoId.trim().toLowerCase());
 }
 
-/** The H3 group, whose two rows differ by roughly 10x in throughput. */
-const H3_PIPELINE_ID = "minimaxai/minimax-h3";
 const H3_GGUF_ID = "unsloth/minimax-h3-gguf";
 
 /**

--- a/studio/frontend/src/features/model-picker/components/model-selector/model-catalog.check.ts
+++ b/studio/frontend/src/features/model-picker/components/model-selector/model-catalog.check.ts
@@ -260,6 +260,62 @@ assert.deepEqual(curatedRowLabelFor("unsloth/Z-Image-Turbo-GGUF", IMAGE_CATALOG)
   name: "Z-Image-Turbo-GGUF",
   tags: [],
 });
+
+// ── host-aware rows ────────────────────────────────────────────────────────────
+// On a host that can place a diffusion pipeline, the two H3 rows say which is which. The gap is
+// roughly 10x, and the names alone gave the user nothing to choose on.
+assert.deepEqual(curatedRowLabelFor("MiniMaxAI/MiniMax-H3", VIDEO_CATALOG, "accelerated"), {
+  name: "MiniMax H3 (Fast FP8)",
+  tags: ["BF16"],
+});
+assert.deepEqual(
+  curatedRowLabelFor("unsloth/MiniMax-H3-GGUF", VIDEO_CATALOG, "accelerated"),
+  { name: "MiniMax-H3-GGUF (Slow)", tags: [] },
+);
+// A host that can only run the native engine has nothing to compare against, so the GGUF row
+// keeps its plain name.
+assert.deepEqual(
+  curatedRowLabelFor("unsloth/MiniMax-H3-GGUF", VIDEO_CATALOG, "gguf-only"),
+  { name: "MiniMax-H3-GGUF", tags: [] },
+);
+// The trigger and the row must agree, or the model renames itself as the popover opens.
+assert.equal(
+  curatedDisplayNameFor("MiniMaxAI/MiniMax-H3", VIDEO_CATALOG, "accelerated"),
+  "MiniMax H3 (Fast FP8)",
+);
+assert.equal(
+  curatedDisplayNameFor("unsloth/MiniMax-H3-GGUF", VIDEO_CATALOG, "accelerated"),
+  "MiniMax-H3-GGUF (Slow)",
+);
+// No other model claims a speed nobody measured.
+assert.deepEqual(
+  curatedRowLabelFor("Lightricks/LTX-2", VIDEO_CATALOG, "accelerated"),
+  curatedRowLabelFor("Lightricks/LTX-2", VIDEO_CATALOG),
+);
+
+// A gguf-only host is offered only what it can load. Every video and image group that still
+// appears must have a GGUF artifact behind it.
+for (const [label, catalog] of [
+  ["video", VIDEO_CATALOG],
+  ["image", IMAGE_CATALOG],
+] as const) {
+  const offered = catalogToModelOptions(catalog, "gguf-only");
+  assert.ok(
+    offered.every((option) => option.isGguf),
+    `${label}: a gguf-only host was offered a row it cannot load`,
+  );
+  // Groups with no GGUF artifact drop out entirely, and that is the intended result rather than
+  // something to "repair" by re-adding an unusable row.
+  const ggufGroups = catalog.filter((group) =>
+    group.artifacts.some((artifact) => artifact.format === "gguf"),
+  ).length;
+  assert.equal(offered.length, ggufGroups, `${label}: one GGUF row per group that has one`);
+}
+// An undiscovered host keeps today's rows, so the picker does not blink on first open.
+assert.deepEqual(
+  catalogToModelOptions(VIDEO_CATALOG, "unknown").map((o) => o.id),
+  catalogToModelOptions(VIDEO_CATALOG).map((o) => o.id),
+);
 // Every GGUF row ends in the suffix, whoever published it.
 for (const catalog of [IMAGE_CATALOG, VIDEO_CATALOG, AUDIO_CATALOG]) {
   for (const group of catalog) {

--- a/studio/frontend/src/features/model-picker/components/model-selector/model-catalog.check.ts
+++ b/studio/frontend/src/features/model-picker/components/model-selector/model-catalog.check.ts
@@ -293,23 +293,36 @@ assert.deepEqual(
   curatedRowLabelFor("Lightricks/LTX-2", VIDEO_CATALOG),
 );
 
-// A gguf-only host is offered only what it can load. Every video and image group that still
-// appears must have a GGUF artifact behind it.
+// A gguf-only host loses exactly the artifacts the backend refuses there, and keeps the rest.
+// Non-GGUF is NOT the test: the diffusion pipelines are device-neutral and run on MPS, and the
+// audio STT rows run through the whisper.cpp sidecar whatever format the catalog labels them.
+for (const [label, catalog, refused] of [
+  ["video", VIDEO_CATALOG, ["MiniMaxAI/MiniMax-H3"]],
+  ["image", IMAGE_CATALOG, []],
+  ["audio", AUDIO_CATALOG, []],
+] as const) {
+  const all = catalogToModelOptions(catalog).map((o) => o.id);
+  const offered = catalogToModelOptions(catalog, "gguf-only").map((o) => o.id);
+  assert.deepEqual(
+    all.filter((id) => !offered.includes(id)),
+    [...refused],
+    `${label}: a gguf-only host lost a row it can load`,
+  );
+}
+// Every group keeps at least one row on a gguf-only host: a Mac must never open a picker with a
+// whole model family missing (H3 keeps its GGUF sibling).
 for (const [label, catalog] of [
   ["video", VIDEO_CATALOG],
   ["image", IMAGE_CATALOG],
+  ["audio", AUDIO_CATALOG],
 ] as const) {
-  const offered = catalogToModelOptions(catalog, "gguf-only");
-  assert.ok(
-    offered.every((option) => option.isGguf),
-    `${label}: a gguf-only host was offered a row it cannot load`,
-  );
-  // Groups with no GGUF artifact drop out entirely, and that is the intended result rather than
-  // something to "repair" by re-adding an unusable row.
-  const ggufGroups = catalog.filter((group) =>
-    group.artifacts.some((artifact) => artifact.format === "gguf"),
-  ).length;
-  assert.equal(offered.length, ggufGroups, `${label}: one GGUF row per group that has one`);
+  const offered = new Set(catalogToModelOptions(catalog, "gguf-only").map((o) => o.id));
+  for (const group of catalog) {
+    assert.ok(
+      group.artifacts.some((artifact) => offered.has(artifact.repoId)),
+      `${label}: "${group.displayName}" vanished on a gguf-only host`,
+    );
+  }
 }
 // An undiscovered host keeps today's rows, so the picker does not blink on first open.
 assert.deepEqual(

--- a/studio/frontend/src/features/model-picker/components/model-selector/model-catalog.ts
+++ b/studio/frontend/src/features/model-picker/components/model-selector/model-catalog.ts
@@ -804,7 +804,7 @@ export function catalogToModelOptions(
       // A host that can only run the native engine is not offered the pipeline rows it would be
       // refused at load. This is the one place the `models` prop is built, so filtering here
       // covers the trigger name and the picker's seed ids together.
-      if (!curatedArtifactIsOfferable(artifact.format, host)) continue;
+      if (!curatedArtifactIsOfferable(artifact.repoId, host)) continue;
       options.push({
         id: artifact.repoId,
         name: curatedDisplayNameFor(artifact.repoId, catalog, host) ?? group.displayName,

--- a/studio/frontend/src/features/model-picker/components/model-selector/model-catalog.ts
+++ b/studio/frontend/src/features/model-picker/components/model-selector/model-catalog.ts
@@ -4,6 +4,11 @@
 // One canonical name per diffusion model, its published artifacts (GGUF quants, prequant FP8 / bnb-4bit repos, official BF16 pipelines), and a deterministic router picking the best artifact for the device.
 // Pure helpers, no React/DOM deps. See model-catalog.check.ts (`npm run catalog:check`).
 
+import {
+  type HostClass,
+  curatedArtifactIsOfferable,
+  h3PerfSuffix,
+} from "./host-artifact-policy.ts";
 import type { ModelCapabilities } from "./model-capabilities";
 import type { ModelOption } from "./types";
 
@@ -726,9 +731,16 @@ export function curatedCapabilitiesFor(
 export function curatedDisplayNameFor(
   repoId: string,
   catalog: CatalogGroup[],
+  host: HostClass = "unknown",
 ): string | null {
   const hit = artifactForRepoId(repoId, catalog);
   if (!hit) return null;
+  // A row that earns a speed qualifier reads the same closed as open: this helper names the
+  // trigger and curatedRowLabelFor names the row, so a divergence would rename the model as the
+  // popover opens.
+  if (h3PerfSuffix(repoId, host)) {
+    return curatedRowLabelFor(repoId, catalog, host)?.name ?? hit.group.displayName;
+  }
   return hit.group.artifacts.length > 1
     ? `${hit.group.displayName} (${hit.artifact.label})`
     : hit.group.displayName;
@@ -751,17 +763,22 @@ const RESOLUTION_RE = /^\d{3,4}p$/i;
 export function curatedRowLabelFor(
   repoId: string,
   catalog: CatalogGroup[],
+  host: HostClass = "unknown",
 ): { name: string; tags: string[] } | null {
   const hit = artifactForRepoId(repoId, catalog);
   if (!hit) return null;
+  // Only where the host can run both rows, so the qualifier compares things the user can pick
+  // between rather than advertising a speed they cannot have.
+  const perf = h3PerfSuffix(repoId, host);
+  const qualify = (name: string) => (perf ? `${name} (${perf})` : name);
   // GGUF reads like a text model's row: the repo name already ends in -GGUF, so show the repo
   // name and let it say so. A chip would only repeat the suffix.
   if (hit.artifact.format === "gguf") {
     const leaf = hit.artifact.repoId.split("/").pop() ?? hit.artifact.repoId;
-    return { name: GGUF_SUFFIX_RE.test(leaf) ? leaf : `${leaf}-GGUF`, tags: [] };
+    return { name: qualify(GGUF_SUFFIX_RE.test(leaf) ? leaf : `${leaf}-GGUF`), tags: [] };
   }
   // A group with one artifact has nothing to distinguish, so it stays bare, exactly as before.
-  if (hit.group.artifacts.length <= 1) return { name: hit.group.displayName, tags: [] };
+  if (hit.group.artifacts.length <= 1) return { name: qualify(hit.group.displayName), tags: [] };
   const [format, ...rest] = hit.artifact.label.split(LABEL_PART_SEPARATOR);
   const tags = [format.replace(OFFICIAL_SUFFIX_RE, "").trim()].filter(Boolean);
   const kept: string[] = [];
@@ -773,17 +790,24 @@ export function curatedRowLabelFor(
     kept.length > 0
       ? `${hit.group.displayName} (${kept.join(LABEL_PART_SEPARATOR)})`
       : hit.group.displayName;
-  return { name, tags };
+  return { name: qualify(name), tags };
 }
 
 /** Back-compat: the flat ModelOption list the ModelSelector `models` prop expects, one option per ARTIFACT. */
-export function catalogToModelOptions(catalog: CatalogGroup[]): ModelOption[] {
+export function catalogToModelOptions(
+  catalog: CatalogGroup[],
+  host: HostClass = "unknown",
+): ModelOption[] {
   const options: ModelOption[] = [];
   for (const group of catalog) {
     for (const artifact of group.artifacts) {
+      // A host that can only run the native engine is not offered the pipeline rows it would be
+      // refused at load. This is the one place the `models` prop is built, so filtering here
+      // covers the trigger name and the picker's seed ids together.
+      if (!curatedArtifactIsOfferable(artifact.format, host)) continue;
       options.push({
         id: artifact.repoId,
-        name: curatedDisplayNameFor(artifact.repoId, catalog) ?? group.displayName,
+        name: curatedDisplayNameFor(artifact.repoId, catalog, host) ?? group.displayName,
         description: `${group.description} - ${artifact.label}`,
         isGguf: artifact.format === "gguf",
         deviceQuant: artifact.deviceQuant,

--- a/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
@@ -3039,7 +3039,7 @@ export function HubModelPicker({
       // them, and hiding what is already on disk reads as Studio having lost the model.
       if (downloadedSet.has(id.toLowerCase())) return true;
       const hit = artifactForRepoId(id, catalog);
-      return hit ? curatedArtifactIsOfferable(hit.artifact.format, hostClass) : true;
+      return hit ? curatedArtifactIsOfferable(hit.artifact.repoId, hostClass) : true;
     },
     [catalog, downloadedSet, hostClass],
   );

--- a/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
@@ -4077,6 +4077,11 @@ export function HubModelPicker({
         .map((result) => result.id)
         .filter((id) => !isHiddenModelId(id))
         .filter(owned)
+        // Search reaches the live Hub, so without this a query re-lands the exact curated row the
+        // seed and Recommended filters just dropped: the Mac format check below admits
+        // safetensors, so MiniMaxAI/MiniMax-H3 would come back clickable and still be refused at
+        // load. Same predicate as the other two lists, downloaded exception included.
+        .filter(curatedOfferable)
         .filter((id) => !recommendedSet.has(id))
         // Chat-only keeps runnable formats: GGUF anywhere, plus MLX/safetensors
         // on Mac (matches the empty Recommended view so search stays consistent).
@@ -4099,6 +4104,7 @@ export function HubModelPicker({
       downloadedSet,
       searchRowFits,
       isMac,
+      curatedOfferable,
     ],
   );
 

--- a/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
@@ -61,7 +61,12 @@ import {
   useOnlineStatus,
 } from "@/features/hub";
 import type { HfTaskFilter } from "@/features/hub/hooks/use-hub-model-search";
-import { useDebouncedValue, useGpuInfo, useInferenceGpuInfo } from "@/hooks";
+import {
+  useDebouncedValue,
+  useGpuInfo,
+  useHostClass,
+  useInferenceGpuInfo,
+} from "@/hooks";
 import { diffusionRouteSearch } from "@/lib/diffusion-route-search";
 import { extractParamLabel } from "@/lib/model-size";
 import { toast } from "@/lib/toast";
@@ -135,6 +140,7 @@ import {
   curatedTotalParamsFor,
   groupForRepoId,
 } from "./model-catalog";
+import { curatedArtifactIsOfferable } from "./host-artifact-policy";
 import { ModelDeleteAction } from "./model-delete-action";
 import { ModelLoadSettingsAction } from "./model-load-settings-action";
 import { ModelRowMenu } from "./model-row-menu";
@@ -2883,6 +2889,7 @@ export function HubModelPicker({
   const chatOnly = usePlatformStore((s) => s.isChatOnly());
   const deviceType = usePlatformStore((s) => s.deviceType);
   const isMac = deviceType === "mac";
+  const hostClass = useHostClass();
 
   // Drop models Unsloth cannot run for chat. A task-scoped picker wants exactly the tasks the chat classifier calls unsupported, so it gates on the task.
   const isChatSupported = useCallback(
@@ -3016,8 +3023,25 @@ export function HubModelPicker({
   // raw repo id exactly as before.
   const curatedRow = useCallback(
     (id: string) =>
-      (catalog && curatedRowLabelFor(id, catalog)) ?? { name: id, tags: [] as string[] },
-    [catalog],
+      (catalog && curatedRowLabelFor(id, catalog, hostClass)) ?? {
+        name: id,
+        tags: [] as string[],
+      },
+    [catalog, hostClass],
+  );
+
+  /** Whether this host can run a curated id at all, as opposed to whether it has room for it.
+   *  Browse rows only: an id already on disk keeps its row wherever it came from. */
+  const curatedOfferable = useCallback(
+    (id: string) => {
+      if (!catalog) return true;
+      // Downloaded weights keep their row. They may have been pulled on a machine that could run
+      // them, and hiding what is already on disk reads as Studio having lost the model.
+      if (downloadedSet.has(id.toLowerCase())) return true;
+      const hit = artifactForRepoId(id, catalog);
+      return hit ? curatedArtifactIsOfferable(hit.artifact.format, hostClass) : true;
+    },
+    [catalog, downloadedSet, hostClass],
   );
 
   // Paint curated rows before any request, so a task-scoped picker whose models
@@ -3027,6 +3051,7 @@ export function HubModelPicker({
     return dedupe(models.map((model) => model.id))
       .filter((id) => !isMobileVariant(id))
       .filter((id) => !isImageEditModel(id))
+      .filter(curatedOfferable)
       .filter((id) => {
         const isG = isKnownGgufRepo(id);
         return taskCatalogFormatMatches(
@@ -3047,7 +3072,7 @@ export function HubModelPicker({
         // other source for its param chip, and most curated ids carry no "<n>B" token.
         totalParams: catalog ? curatedTotalParamsFor(id, catalog) : undefined,
       }));
-  }, [catalog, models, formatFilter, isKnownGgufRepo, task]);
+  }, [catalog, models, formatFilter, isKnownGgufRepo, task, curatedOfferable]);
 
   /** The catalog's own fit verdict for a curated artifact, or undefined where it has none.
    *  Every list that judges a row against the device goes through this, so a badge and the
@@ -3100,6 +3125,7 @@ export function HubModelPicker({
     };
     const keep = (r: HfModelResult) =>
       keepCommon(r) &&
+      curatedOfferable(r.id) &&
       // Task pages load single-file GGUF, plus curated artifacts in any format.
       (!task ||
         r.isGguf ||
@@ -3156,6 +3182,7 @@ export function HubModelPicker({
     task,
     catalog,
     catalogFit,
+    curatedOfferable,
     communityRecommendedEnabled,
     communityBrowse.results,
     isLoadableCommunityRepo,

--- a/studio/frontend/src/features/video/video-page.tsx
+++ b/studio/frontend/src/features/video/video-page.tsx
@@ -83,11 +83,13 @@ import { usePersistedChoice } from "@/hooks/use-persisted-choice";
 import { useScrollFades } from "@/hooks/use-scroll-fades";
 import { ModelSelector } from "@/features/model-picker/components/model-selector";
 import { VIDEO_GEN_TASKS } from "@/features/model-picker/components/model-selector/pickers";
+import type { HostClass } from "@/features/model-picker/components/model-selector/host-artifact-policy";
 import {
   VIDEO_CATALOG,
   catalogToModelOptions,
   loadSpecFor,
 } from "@/features/model-picker/components/model-selector/model-catalog";
+import { useHostClass } from "@/hooks/use-host-class";
 import type {
   ModelOption,
   ModelSelectorChangeMeta,
@@ -161,7 +163,11 @@ import {
 
 // Curated models come from the shared catalog: one canonical group per model with its artifacts as data (HunyuanVideo carries both repacks), and the load kind per artifact via loadSpecFor.
 // The picker renders groups with a format second level, which also surfaces LTX-2.3 in Recommended (its HF pipeline_tag is image-to-video).
-const VIDEO_MODELS: ModelOption[] = catalogToModelOptions(VIDEO_CATALOG);
+// Host-dependent, so it is built per render rather than once at module load: a Mac is offered
+// only the GGUF rows, and an accelerated host gets the speed qualifiers.
+function useVideoModels(host: HostClass): ModelOption[] {
+  return useMemo(() => catalogToModelOptions(VIDEO_CATALOG, host), [host]);
+}
 
 // Per-model generation defaults (steps + guidance), matched by repo-id substring, most specific first.
 const DEFAULT_GEN = { steps: 8, guidance: 1 };
@@ -819,6 +825,8 @@ export function VideoPage({ active = true }: { active?: boolean }) {
 }
 
 function VideoGenerator({ active = true }: { active?: boolean }) {
+  const hostClass = useHostClass();
+  const videoModels = useVideoModels(hostClass);
   const [quant, setQuant] = useState<string | null>(galleryCache.quant);
   const [prompt, setPrompt] = useState(
     "Ultra-realistic cinematic documentary footage of a quiet Kyoto neighborhood at sunrise. An elderly Japanese man opens his traditional wooden shop while a young woman wearing a simple kimono walks past carrying a small basket. Cherry blossom petals gently fall through the air, bicycles pass by, warm sunlight enters between narrow streets, distant temple bells echo. The camera slowly moves forward like a professional travel documentary, realistic human movements, natural expressions, authentic Japanese architecture, subtle wind movement in clothing and trees, realistic colors, 35mm film photography style.",
@@ -3266,7 +3274,7 @@ function VideoGenerator({ active = true }: { active?: boolean }) {
         {/* min-w-0: without it a long resident model name pushes the Images link off a phone screen. */}
         <div className="pointer-events-auto flex min-w-0 items-center gap-3">
           <ModelSelector
-            models={VIDEO_MODELS}
+            models={videoModels}
             value={status?.loaded ? status.repo_id ?? undefined : undefined}
             activeGgufVariant={quant}
             onValueChange={handleModelSelect}

--- a/studio/frontend/src/hooks/index.ts
+++ b/studio/frontend/src/hooks/index.ts
@@ -3,6 +3,7 @@
 
 export { useDebouncedValue } from "./use-debounced-value";
 export { useGpuInfo, useInferenceGpuInfo } from "./use-gpu-info";
+export { useHostClass } from "./use-host-class";
 export { useGpuUtilization } from "./use-gpu-utilization";
 export { useHardwareInfo } from "./use-hardware-info";
 export { useHfDatasetSplits } from "./use-hf-dataset-splits";

--- a/studio/frontend/src/hooks/use-gpu-info.ts
+++ b/studio/frontend/src/hooks/use-gpu-info.ts
@@ -32,6 +32,10 @@ export {
 export interface GpuInfo {
   available: boolean;
   budgetKnown: boolean;
+  /** The backend torch resolved: cuda, rocm, xpu, mlx, cpu. Carried on every path, including the
+   * GPU-less one, because "which runtimes can this host place" is exactly the question a host
+   * with no usable GPU has to answer. Empty until system info arrives. */
+  backend: string;
   name: string;
   memoryTotalGb: number;
   /** Largest single device's VRAM. Image/video loads live on ONE device (no tensor split), so their fit math must use a single device, not the multi-GPU sum. */
@@ -47,6 +51,7 @@ export interface GpuInfo {
 const DEFAULT_GPU: GpuInfo = {
   available: false,
   budgetKnown: false,
+  backend: "",
   name: "Unknown",
   memoryTotalGb: 0,
   maxDeviceMemoryGb: 0,
@@ -64,6 +69,7 @@ function toGpuInfo(
   // CPU/RAM exist even on GPU-less hosts (e.g. Mac), so populate them on every
   // path: unified-memory math still needs a RAM budget to work with.
   const base = {
+    backend: data?.device_backend ?? "",
     cpuCore: data?.cpu?.physical_count ?? 0,
     cpuThread: data?.cpu?.logical_count ?? 0,
     systemRamAvailableGb: data?.memory?.available_gb ?? 0,

--- a/studio/frontend/src/hooks/use-host-class.ts
+++ b/studio/frontend/src/hooks/use-host-class.ts
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import { usePlatformStore } from "@/config/env";
+import {
+  type HostClass,
+  classifyHost,
+} from "@/features/model-picker/components/model-selector/host-artifact-policy";
+import { useMemo } from "react";
+import { useGpuInfo } from "./use-gpu-info";
+
+/** What this host can run, for the media pickers.
+ *
+ * The two inputs live in different places -- the OS in the platform store, the resolved torch
+ * backend in system info -- so every caller reads them the same way from here. */
+export function useHostClass(): HostClass {
+  const gpu = useGpuInfo();
+  const deviceType = usePlatformStore((s) => s.deviceType);
+  return useMemo(
+    () =>
+      classifyHost({
+        deviceType,
+        deviceBackend: gpu.backend,
+        budgetKnown: gpu.budgetKnown,
+      }),
+    [deviceType, gpu.backend, gpu.budgetKnown],
+  );
+}

--- a/studio/frontend/tests/host-artifact-policy.test.ts
+++ b/studio/frontend/tests/host-artifact-policy.test.ts
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  classifyHost,
+  curatedArtifactIsOfferable,
+  h3PerfSuffix,
+} from "../src/features/model-picker/components/model-selector/host-artifact-policy.ts";
+
+test("the backends that can place a diffusion pipeline are accelerated", () => {
+  for (const deviceBackend of ["cuda", "rocm", "xpu"]) {
+    assert.equal(
+      classifyHost({ deviceBackend, budgetKnown: true }),
+      "accelerated",
+      deviceBackend,
+    );
+  }
+});
+
+test("the backends that only run the native engine are gguf-only", () => {
+  for (const deviceBackend of ["mlx", "cpu"]) {
+    assert.equal(
+      classifyHost({ deviceBackend, budgetKnown: true }),
+      "gguf-only",
+      deviceBackend,
+    );
+  }
+});
+
+test("a Mac is gguf-only whatever backend it reports", () => {
+  // Apple GPUs report as available and the backend string varies with what torch found, but no
+  // Mac can place the Modular Diffusers workflow: video.py refuses the load outright.
+  for (const deviceBackend of ["mlx", "cpu", "cuda", null]) {
+    assert.equal(
+      classifyHost({ deviceType: "mac", deviceBackend, budgetKnown: true }),
+      "gguf-only",
+      String(deviceBackend),
+    );
+  }
+});
+
+test("a host still being discovered is unknown, not CPU-only", () => {
+  // The anti-flicker guarantee. The GPU hook's opening state is available:false,
+  // budgetKnown:false, and reading that as CPU-only would blink every non-GGUF row out and back
+  // on a real GPU host.
+  assert.equal(classifyHost({ budgetKnown: false }), "unknown");
+  assert.equal(
+    classifyHost({ deviceBackend: "cuda", budgetKnown: false }),
+    "unknown",
+  );
+  assert.equal(
+    classifyHost({ deviceBackend: "", budgetKnown: true }),
+    "unknown",
+  );
+});
+
+test("an unrecognised backend is treated as new hardware, not as a CPU", () => {
+  assert.equal(
+    classifyHost({ deviceBackend: "tpu", budgetKnown: true }),
+    "unknown",
+  );
+});
+
+test("only a gguf-only host drops the non-GGUF rows", () => {
+  assert.equal(curatedArtifactIsOfferable("bf16", "gguf-only"), false);
+  assert.equal(curatedArtifactIsOfferable("fp8", "gguf-only"), false);
+  assert.equal(curatedArtifactIsOfferable("bnb-4bit", "gguf-only"), false);
+  assert.equal(curatedArtifactIsOfferable("gguf", "gguf-only"), true);
+  for (const host of ["unknown", "accelerated"] as const) {
+    for (const format of ["bf16", "fp8", "bnb-4bit", "gguf"] as const) {
+      assert.equal(
+        curatedArtifactIsOfferable(format, host),
+        true,
+        `${host}/${format}`,
+      );
+    }
+  }
+});
+
+test("the speed suffixes name the two H3 rows on an accelerated host", () => {
+  assert.equal(h3PerfSuffix("MiniMaxAI/MiniMax-H3", "accelerated"), "Fast FP8");
+  assert.equal(h3PerfSuffix("unsloth/MiniMax-H3-GGUF", "accelerated"), "Slow");
+});
+
+test("no other model claims a speed it was never measured at", () => {
+  for (const id of [
+    "Lightricks/LTX-2.3",
+    "unsloth/LTX-2.3-GGUF",
+    "MiniMaxAI/MiniMax-H3-Other",
+  ]) {
+    assert.equal(h3PerfSuffix(id, "accelerated"), null, id);
+  }
+});
+
+test("a gguf-only or undiscovered host gets no suffix at all", () => {
+  for (const host of ["gguf-only", "unknown"] as const) {
+    assert.equal(h3PerfSuffix("MiniMaxAI/MiniMax-H3", host), null, host);
+    assert.equal(h3PerfSuffix("unsloth/MiniMax-H3-GGUF", host), null, host);
+  }
+});

--- a/studio/frontend/tests/host-artifact-policy.test.ts
+++ b/studio/frontend/tests/host-artifact-policy.test.ts
@@ -64,19 +64,36 @@ test("an unrecognised backend is treated as new hardware, not as a CPU", () => {
   );
 });
 
-test("only a gguf-only host drops the non-GGUF rows", () => {
-  assert.equal(curatedArtifactIsOfferable("bf16", "gguf-only"), false);
-  assert.equal(curatedArtifactIsOfferable("fp8", "gguf-only"), false);
-  assert.equal(curatedArtifactIsOfferable("bnb-4bit", "gguf-only"), false);
-  assert.equal(curatedArtifactIsOfferable("gguf", "gguf-only"), true);
+test("a gguf-only host drops the one pipeline the backend refuses, and nothing else", () => {
+  assert.equal(
+    curatedArtifactIsOfferable("MiniMaxAI/MiniMax-H3", "gguf-only"),
+    false,
+  );
   for (const host of ["unknown", "accelerated"] as const) {
-    for (const format of ["bf16", "fp8", "bnb-4bit", "gguf"] as const) {
-      assert.equal(
-        curatedArtifactIsOfferable(format, host),
-        true,
-        `${host}/${format}`,
-      );
-    }
+    assert.equal(
+      curatedArtifactIsOfferable("MiniMaxAI/MiniMax-H3", host),
+      true,
+      host,
+    );
+  }
+});
+
+test("a gguf-only host keeps every non-GGUF row the backend can still load", () => {
+  // Each of these is a load Studio supports on Apple Silicon or CPU today: the diffusion
+  // pipelines are device-neutral (video_capability() certifies Apple Silicon, and
+  // diffusion_device.py picks MPS bfloat16 for exactly these), and the STT rows run through
+  // the whisper.cpp sidecar, whose format label in the catalog is informational only.
+  for (const id of [
+    "unsloth/whisper-large-v3-turbo",
+    "unsloth/whisper-tiny",
+    "unsloth/csm-1b",
+    "stabilityai/sdxl-turbo",
+    "Tongyi-MAI/Z-Image-Turbo",
+    "Wan-AI/Wan2.2-TI2V-5B-Diffusers",
+    "Lightricks/LTX-2",
+    "unsloth/MiniMax-H3-GGUF",
+  ]) {
+    assert.equal(curatedArtifactIsOfferable(id, "gguf-only"), true, id);
   }
 });
 


### PR DESCRIPTION
### The bug

On Apple Silicon the Video picker offers MiniMax H3's bf16 pipeline row, and loading it always fails. `video.py` refuses every modular Diffusers workflow on Metal, because the auto CPU offload reads `mem_get_info` and `torch.mps` has never exposed it:

```
'MiniMax H3' cannot run on Apple Silicon: its Modular Diffusers workflow places
components through the Diffusers auto CPU offload, which needs a torch device
exposing mem_get_info, and Metal (MPS) does not have it.
```

Nothing hides the row. `curatedArtifactFitsDevice` gives it an "exceeds" VRAM pill, and the Recommended sort drops it, but on any other sort with "Fits on device" off it stays clickable and always 400s. The same holds for the int8/fp8 prequantized weights it pulls: `_h3_auto_precision_ok` engages them only on CUDA in bf16, and `diffusion_precision.py` gates fp8 behind sm89+ and int8 behind sm80+.

Naming compounds it. The two H3 rows read `MiniMax H3` and `MiniMax-H3-GGUF`, which says nothing about the roughly 10x throughput gap between them.

### The change

A new pure policy module classifies the host as `accelerated` (cuda / rocm / xpu), `gguf-only` (mac, mlx, cpu) or `unknown`, and curated artifacts are offered accordingly. A host that can only run the native engine now sees only the GGUF rows.

Capability is deliberately kept apart from size. `curatedArtifactFitsDevice` still answers "is there room", and the two are not the same question: a 128 GB Mac has ample room for a model it cannot place. Folding this into the fit helper would also have broken the two tests that pin that seam (`recommended-curated-row-metadata.test.ts:291`, `recommended-catalog-seeds.test.ts:311`), both of which still pass untouched.

`unknown` is not a formality. The GPU hook opens at `budgetKnown: false`, so treating "no GPU reported" as CPU-only would blink every non-GGUF row out and back on a real GPU host during discovery.

On an accelerated host the two H3 rows become:

| Row | Before | After |
|---|---|---|
| `MiniMaxAI/MiniMax-H3` | `MiniMax H3` | `MiniMax H3 (Fast FP8)` |
| `unsloth/MiniMax-H3-GGUF` | `MiniMax-H3-GGUF` | `MiniMax-H3-GGUF (Slow)` |

On a gguf-only host the pipeline row is gone and the GGUF row keeps its plain name, since there is nothing left to compare it against.

The suffixes are keyed on the two H3 ids, not on `format !== "gguf"`. Most non-GGUF rows are plain bf16 or bnb-4bit, one is genuinely FP8, and Auto precision resolves to int8 or bf16 on cards without fp8, so a blanket rule would put "Fast FP8" on rows where it is false.

Both label paths carry the qualifier. `curatedDisplayNameFor` names the closed trigger and `curatedRowLabelFor` names the open row, so changing one alone would rename the model as the popover opens.

### What is deliberately not filtered

- **Downloaded weights.** They may have been pulled on a machine that could run them, and hiding what is on disk reads as Studio having lost the model.
- **The selected-value lookup**, so the trigger keeps a name for an existing selection.
- **`pickDefaultArtifact` routing.** Click semantics and download priority are unchanged.

Groups with no GGUF artifact do legitimately disappear on a gguf-only host. That is the intended result and is pinned by a test, so it does not get "repaired" later by re-adding an unusable row.

### Tests

New `host-artifact-policy.test.ts` (9 cases) covering the full backend matrix: cuda, rocm, xpu, mlx, cpu, an unrecognised backend, and the undiscovered state. New assertions in `model-catalog.check.ts` for the host-aware names, trigger/row agreement, and the gguf-only filtering.

- `npm test`: 2566 pass, 0 fail
- `npm run typecheck`: clean
- `npm run catalog:check`: all assertions passed

The default argument is `"unknown"` everywhere, so every existing caller and assertion keeps its current output.
