### PR TITLE
Studio: keep K and V equal when the flash-attention retry resets the V cache

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -11843,7 +11843,12 @@ class LlamaCppBackend:
         return out if found else None
 
     @staticmethod
-    def _reset_quantized_v_cache(cmd: list[str], reason: str) -> list[str]:
+    def _reset_quantized_v_cache(
+        cmd: list[str],
+        reason: str,
+        *,
+        mla: bool = False,
+    ) -> list[str]:
         """Return cmd with any quantized V cache reset to f16, for a launch that
         runs without flash attention.
 
@@ -11851,7 +11856,26 @@ class LlamaCppBackend:
         with "V cache quantization requires flash_attn". A quantized K cache has no
         such requirement and runs fine without FA, so it is left untouched --
         resetting it would needlessly enlarge the K cache and can OOM a
-        memory-constrained config. Main and draft are both reset (the draft context
+        memory-constrained config.
+
+        ``mla`` overrides that on the models where leaving K alone is now itself
+        fatal. llama-context.cpp gained this in #25871, and it sits ABOVE the
+        V-quantization check, so it decides first:
+
+            if ((model->hparams.is_mla() || model->arch == LLM_ARCH_DEEPSEEK4)
+                    && params.type_k != params.type_v) {
+                LLAMA_LOG_ERROR("model does not support different K (%s) and V
+                                 (%s) cache types");
+                return nullptr;
+            }
+
+        is_mla() covers DeepSeek V2/V3/R1, Kimi K2 and GLM-4.7/5.x. Resetting V
+        alone on one of those turns a quantized KV into K=q8_0 V=f16, which is a
+        hard abort for a DIFFERENT reason than the one being avoided: the retry
+        that exists to recover from a flash-attention crash fails on the K/V
+        mismatch instead. Both axes go to f16 together there, since equal is what
+        the rule asks for and f16 is the only value guaranteed to satisfy the V
+        rule as well. Main and draft are both reset (the draft context
         shares the global --flash-attn flag, so its V cache aborts too) to f16 (the
         llama.cpp default); non-quantized types -- f16/bf16/f32 -- run fine without
         FA and are left untouched. The value is rewritten in place so the list
@@ -11885,17 +11909,42 @@ class LlamaCppBackend:
                 if out[i + 1].strip().lower() not in LlamaCppBackend._NON_QUANTIZED_KV_TYPES:
                     out[i + 1] = "f16"
                     _cache_reset = True
+        if _cache_reset and mla:
+            # Symmetry, not size: an MLA model rejects K != V outright, so the K
+            # cache has to follow V down rather than stay quantized.
+            _k_cache_flags = (
+                "--cache-type-k",
+                "-ctk",
+                "--cache-type-k-draft",
+                "--spec-draft-type-k",
+                "-ctkd",
+            )
+            for i, tok in enumerate(out):
+                if _flag_name(tok) not in _k_cache_flags:
+                    continue
+                if "=" in tok:
+                    flag, _, value = tok.partition("=")
+                    if value.strip().lower() not in LlamaCppBackend._NON_QUANTIZED_KV_TYPES:
+                        out[i] = f"{flag}=f16"
+                elif i + 1 < len(out):
+                    if out[i + 1].strip().lower() not in LlamaCppBackend._NON_QUANTIZED_KV_TYPES:
+                        out[i + 1] = "f16"
         if _cache_reset:
             logger.info(
                 "V cache dtype reset to f16 because flash attention is off (%s): a "
-                "quantized V cache requires flash attention in llama.cpp. The K "
-                "cache is left untouched.",
+                "quantized V cache requires flash attention in llama.cpp. %s",
                 reason,
+                (
+                    "The K cache followed it down: this model uses MLA, which "
+                    "rejects different K and V cache types."
+                    if mla
+                    else "The K cache is left untouched."
+                ),
             )
         return out
 
     @staticmethod
-    def _with_flash_attn_off(cmd: list[str]) -> Optional[list[str]]:
+    def _with_flash_attn_off(cmd: list[str], *, mla: bool = False) -> Optional[list[str]]:
         """Return cmd with flash attention forced off, or None when its effective
         (last-wins) value is already off/absent so there is nothing to retry. FA
         kernels hard-crash at startup on some ROCm builds; disabling FA keeps
@@ -11943,7 +11992,7 @@ class LlamaCppBackend:
         # launch but would make THIS FA-off retry crash on init instead of
         # recovering.
         return LlamaCppBackend._reset_quantized_v_cache(
-            out, "disabled by the crash-recovery fallback"
+            out, "disabled by the crash-recovery fallback", mla = mla
         )
 
     @staticmethod
@@ -15592,7 +15641,11 @@ class LlamaCppBackend:
                 # logged is what launches; length is preserved, so _spec_start
                 # still indexes the same tokens.
                 if _flash_attn_known_off:
-                    cmd = self._reset_quantized_v_cache(cmd, "this build has no --flash-attn")
+                    cmd = self._reset_quantized_v_cache(
+                        cmd,
+                        "this build has no --flash-attn",
+                        mla = self._kv_lora_rank is not None,
+                    )
 
                 kv_cache_unified = _kv_unified_from_args(cmd)
 
@@ -16519,7 +16572,9 @@ class LlamaCppBackend:
                 if not healthy and not _load_cancelled():
                     _fa_rc = self._process.poll() if self._process is not None else None
                     _fa_cmd = (
-                        self._with_flash_attn_off(_last_spawn_cmd)
+                        self._with_flash_attn_off(
+                            _last_spawn_cmd, mla = self._kv_lora_rank is not None
+                        )
                         if self._is_signal_crash(_fa_rc)
                         else None
                     )
@@ -16583,7 +16638,9 @@ class LlamaCppBackend:
                     # FA-off (keeps MTP) before dropping speculative decoding below.
                     _probe_rc = self._process.poll() if self._process is not None else None
                     _fa_cmd = (
-                        self._with_flash_attn_off(_last_spawn_cmd)
+                        self._with_flash_attn_off(
+                            _last_spawn_cmd, mla = self._kv_lora_rank is not None
+                        )
                         if self._is_signal_crash(_probe_rc)
                         else None
                     )

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -11856,9 +11856,7 @@ class LlamaCppBackend:
 
     def _target_kv_symmetry(self) -> bool:
         """Whether the TARGET model requires K == V."""
-        return self._requires_symmetric_kv(
-            self._kv_lora_rank, getattr(self, "_architecture", None)
-        )
+        return self._requires_symmetric_kv(self._kv_lora_rank, getattr(self, "_architecture", None))
 
     def _draft_kv_symmetry(self) -> Optional[bool]:
         """Whether the DRAFTER requires K == V; None when it cannot be determined."""
@@ -11982,9 +11980,7 @@ class LlamaCppBackend:
         _draft_k_flags = ("--cache-type-k-draft", "--spec-draft-type-k", "-ctkd")
         if draft_mla is None:
             draft_mla = mla
-        _k_cache_flags = (_main_k_flags if mla else ()) + (
-            _draft_k_flags if draft_mla else ()
-        )
+        _k_cache_flags = (_main_k_flags if mla else ()) + (_draft_k_flags if draft_mla else ())
         _k_reset = False
         for i, tok in enumerate(out):
             if _flag_name(tok) not in _k_cache_flags:
@@ -12014,7 +12010,10 @@ class LlamaCppBackend:
 
     @staticmethod
     def _with_flash_attn_off(
-        cmd: list[str], *, mla: bool = False, draft_mla: Optional[bool] = None
+        cmd: list[str],
+        *,
+        mla: bool = False,
+        draft_mla: Optional[bool] = None,
     ) -> Optional[list[str]]:
         """Return cmd with flash attention forced off, or None when its effective
         (last-wins) value is already off/absent so there is nothing to retry. FA
@@ -15836,8 +15835,9 @@ class LlamaCppBackend:
                 # Same for an env-only quantized V cache, which the argv reset
                 # above cannot reach.
                 if _flash_attn_known_off and self._drop_env_quantized_v_cache(
-                    env, mla = self._target_kv_symmetry(),
-                            draft_mla = self._draft_kv_symmetry(),
+                    env,
+                    mla = self._target_kv_symmetry(),
+                    draft_mla = self._draft_kv_symmetry(),
                 ):
                     logger.info(
                         "Dropped inherited quantized V-cache env: this build has "
@@ -16673,7 +16673,8 @@ class LlamaCppBackend:
                     _fa_rc = self._process.poll() if self._process is not None else None
                     _fa_cmd = (
                         self._with_flash_attn_off(
-                            _last_spawn_cmd, mla = self._target_kv_symmetry(),
+                            _last_spawn_cmd,
+                            mla = self._target_kv_symmetry(),
                             draft_mla = self._draft_kv_symmetry(),
                         )
                         if self._is_signal_crash(_fa_rc)
@@ -16690,7 +16691,8 @@ class LlamaCppBackend:
                         # The argv rewrite can't reach an env-only quantized V
                         # cache; drop it so the FA-off child doesn't abort on it.
                         if self._drop_env_quantized_v_cache(
-                            env, mla = self._target_kv_symmetry(),
+                            env,
+                            mla = self._target_kv_symmetry(),
                             draft_mla = self._draft_kv_symmetry(),
                         ):
                             logger.info(
@@ -16743,7 +16745,8 @@ class LlamaCppBackend:
                     _probe_rc = self._process.poll() if self._process is not None else None
                     _fa_cmd = (
                         self._with_flash_attn_off(
-                            _last_spawn_cmd, mla = self._target_kv_symmetry(),
+                            _last_spawn_cmd,
+                            mla = self._target_kv_symmetry(),
                             draft_mla = self._draft_kv_symmetry(),
                         )
                         if self._is_signal_crash(_probe_rc)
@@ -16760,7 +16763,8 @@ class LlamaCppBackend:
                         # The argv rewrite can't reach an env-only quantized V
                         # cache; drop it so the FA-off child doesn't abort on it.
                         if self._drop_env_quantized_v_cache(
-                            env, mla = self._target_kv_symmetry(),
+                            env,
+                            mla = self._target_kv_symmetry(),
                             draft_mla = self._draft_kv_symmetry(),
                         ):
                             logger.info(

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -11858,30 +11858,38 @@ class LlamaCppBackend:
         """Whether the TARGET model requires K == V."""
         return self._requires_symmetric_kv(self._kv_lora_rank, getattr(self, "_architecture", None))
 
-    def _draft_kv_symmetry(self) -> Optional[bool]:
-        """Whether the DRAFTER requires K == V; None when it cannot be determined."""
-        return self._kv_symmetry_signals()[1]
+    def _draft_kv_symmetry(
+        self,
+        cmd: Optional[Iterable[str]] = None,
+        env: Optional[Mapping[str, str]] = None,
+    ) -> Optional[bool]:
+        """Whether the DRAFTER requires K == V; None when it cannot be determined.
 
-    def _kv_symmetry_signals(self) -> tuple[bool, Optional[bool]]:
-        """(target, drafter) "requires K == V" signals for a cache reset.
+        Derived from the drafter the launch actually resolves to, which is the one
+        named on the command being launched. The stored ``_mtp_draft_path`` is the
+        wrong source twice over: it only ever holds the managed sidecar, so an
+        ``extra_args`` ``--model-draft``/``--hf-repo-draft`` (the drafter llama.cpp
+        would really load) is invisible to it, and it is not assigned until after
+        the launch-site reset has already run, so it is stale there anyway. The
+        managed path emits ``--model-draft <sidecar>`` into the same command, so
+        reading the command covers both.
 
-        The drafter is a separate model with its own context, so its flags are
-        gated on its own metadata. None means "could not tell" (no drafter, or its
-        GGUF was unreadable) and leaves the caller on the target's answer.
+        None (falling the caller back to the target) when no drafter is named, or
+        when it is a Hugging Face repo id rather than a local file whose metadata
+        can be read.
         """
-        target = self._target_kv_symmetry()
-        draft: Optional[bool] = None
-        drafter_path = getattr(self, "_mtp_draft_path", None)
-        if drafter_path:
-            try:
-                db = self._draft_backend_for(drafter_path)
-            except Exception:  # unreadable drafter -> fall back to the target
-                db = None
-            if db is not None:
-                draft = self._requires_symmetric_kv(
-                    getattr(db, "_kv_lora_rank", None), getattr(db, "_architecture", None)
-                )
-        return target, draft
+        path, is_remote = _extra_args_mtp_draft_source(list(cmd or []), env)
+        if not path or is_remote:
+            return None
+        try:
+            db = self._draft_backend_for(path)
+        except Exception:  # unreadable drafter -> fall back to the target
+            db = None
+        if db is None:
+            return None
+        return self._requires_symmetric_kv(
+            getattr(db, "_kv_lora_rank", None), getattr(db, "_architecture", None)
+        )
 
     @staticmethod
     def _reset_quantized_v_cache(
@@ -15740,7 +15748,7 @@ class LlamaCppBackend:
                         cmd,
                         "this build has no --flash-attn",
                         mla = self._target_kv_symmetry(),
-                        draft_mla = self._draft_kv_symmetry(),
+                        draft_mla = self._draft_kv_symmetry(cmd, env),
                     )
 
                 kv_cache_unified = _kv_unified_from_args(cmd)
@@ -15837,7 +15845,7 @@ class LlamaCppBackend:
                 if _flash_attn_known_off and self._drop_env_quantized_v_cache(
                     env,
                     mla = self._target_kv_symmetry(),
-                    draft_mla = self._draft_kv_symmetry(),
+                    draft_mla = self._draft_kv_symmetry(cmd, env),
                 ):
                     logger.info(
                         "Dropped inherited quantized V-cache env: this build has "
@@ -16675,7 +16683,7 @@ class LlamaCppBackend:
                         self._with_flash_attn_off(
                             _last_spawn_cmd,
                             mla = self._target_kv_symmetry(),
-                            draft_mla = self._draft_kv_symmetry(),
+                            draft_mla = self._draft_kv_symmetry(_last_spawn_cmd, env),
                         )
                         if self._is_signal_crash(_fa_rc)
                         else None
@@ -16693,7 +16701,7 @@ class LlamaCppBackend:
                         if self._drop_env_quantized_v_cache(
                             env,
                             mla = self._target_kv_symmetry(),
-                            draft_mla = self._draft_kv_symmetry(),
+                            draft_mla = self._draft_kv_symmetry(_last_spawn_cmd, env),
                         ):
                             logger.info(
                                 "Dropped inherited quantized V-cache env for the "
@@ -16747,7 +16755,7 @@ class LlamaCppBackend:
                         self._with_flash_attn_off(
                             _last_spawn_cmd,
                             mla = self._target_kv_symmetry(),
-                            draft_mla = self._draft_kv_symmetry(),
+                            draft_mla = self._draft_kv_symmetry(_last_spawn_cmd, env),
                         )
                         if self._is_signal_crash(_probe_rc)
                         else None
@@ -16765,7 +16773,7 @@ class LlamaCppBackend:
                         if self._drop_env_quantized_v_cache(
                             env,
                             mla = self._target_kv_symmetry(),
-                            draft_mla = self._draft_kv_symmetry(),
+                            draft_mla = self._draft_kv_symmetry(_last_spawn_cmd, env),
                         ):
                             logger.info(
                                 "Dropped inherited quantized V-cache env for the "

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -12007,9 +12007,7 @@ class LlamaCppBackend:
         )
 
     @staticmethod
-    def _drop_env_quantized_v_cache(
-        env: MutableMapping[str, str], *, mla: bool = False
-    ) -> bool:
+    def _drop_env_quantized_v_cache(env: MutableMapping[str, str], *, mla: bool = False) -> bool:
         """Drop an inherited quantized V-cache env var (main or draft) in place
         before a flash-attn-off retry, returning True if anything was removed.
 

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -11843,11 +11843,55 @@ class LlamaCppBackend:
         return out if found else None
 
     @staticmethod
+    def _requires_symmetric_kv(kv_lora_rank, architecture) -> bool:
+        """Whether llama.cpp rejects K != V for a model with this metadata.
+
+        Mirrors ``is_mla() || arch == LLM_ARCH_DEEPSEEK4``: kv_lora_rank stands in
+        for is_mla() (the MLA archs' converter writes it alongside the MLA head
+        dims), and deepseek4 is checked by name because it sets neither.
+        """
+        if kv_lora_rank is not None:
+            return True
+        return (architecture or "").strip().lower() == "deepseek4"
+
+    def _target_kv_symmetry(self) -> bool:
+        """Whether the TARGET model requires K == V."""
+        return self._requires_symmetric_kv(
+            self._kv_lora_rank, getattr(self, "_architecture", None)
+        )
+
+    def _draft_kv_symmetry(self) -> Optional[bool]:
+        """Whether the DRAFTER requires K == V; None when it cannot be determined."""
+        return self._kv_symmetry_signals()[1]
+
+    def _kv_symmetry_signals(self) -> tuple[bool, Optional[bool]]:
+        """(target, drafter) "requires K == V" signals for a cache reset.
+
+        The drafter is a separate model with its own context, so its flags are
+        gated on its own metadata. None means "could not tell" (no drafter, or its
+        GGUF was unreadable) and leaves the caller on the target's answer.
+        """
+        target = self._target_kv_symmetry()
+        draft: Optional[bool] = None
+        drafter_path = getattr(self, "_mtp_draft_path", None)
+        if drafter_path:
+            try:
+                db = self._draft_backend_for(drafter_path)
+            except Exception:  # unreadable drafter -> fall back to the target
+                db = None
+            if db is not None:
+                draft = self._requires_symmetric_kv(
+                    getattr(db, "_kv_lora_rank", None), getattr(db, "_architecture", None)
+                )
+        return target, draft
+
+    @staticmethod
     def _reset_quantized_v_cache(
         cmd: list[str],
         reason: str,
         *,
         mla: bool = False,
+        draft_mla: Optional[bool] = None,
     ) -> list[str]:
         """Return cmd with any quantized V cache reset to f16, for a launch that
         runs without flash attention.
@@ -11869,17 +11913,23 @@ class LlamaCppBackend:
                 return nullptr;
             }
 
-        is_mla() covers DeepSeek V2/V3/R1, Kimi K2 and GLM-4.7/5.x. Resetting V
+        is_mla() is n_embd_head_k_mla_impl and n_embd_head_v_mla_impl both being
+        set, which covers DeepSeek V2/V3/R1, Kimi K2 and GLM-4.7/5.x. DeepSeek4 is
+        the separate arch term in that condition rather than a second is_mla()
+        model: it has its own KV cache (llama-kv-cache-dsv4.cpp), never sets the
+        MLA head dims, and its converter writes q_lora_rank but no kv_lora_rank, so
+        a kv_lora_rank probe alone does not see it. Resetting V
         alone on one of those turns a quantized KV into K=q8_0 V=f16, which is a
         hard abort for a DIFFERENT reason than the one being avoided: the retry
         that exists to recover from a flash-attention crash fails on the K/V
         mismatch instead. Both axes go to f16 together there, since equal is what
         the rule asks for and f16 is the only value guaranteed to satisfy the V
-        rule as well. Main and draft are both reset (the draft context
-        shares the global --flash-attn flag, so its V cache aborts too) to f16 (the
-        llama.cpp default); non-quantized types -- f16/bf16/f32 -- run fine without
-        FA and are left untouched. The value is rewritten in place so the list
-        length is preserved for downstream slices.
+        rule as well. Main and draft V are both reset (the draft context shares the
+        global --flash-attn flag, so its V cache aborts too) to f16 (the llama.cpp
+        default); K follows per model, ``mla`` for the target flags and
+        ``draft_mla`` for the draft pair. Non-quantized types -- f16/bf16/f32 --
+        run fine without FA and are left untouched. The value is rewritten in place
+        so the list length is preserved for downstream slices.
         """
         out = list(cmd)
         _v_cache_flags = (
@@ -11909,37 +11959,45 @@ class LlamaCppBackend:
                 if out[i + 1].strip().lower() not in LlamaCppBackend._NON_QUANTIZED_KV_TYPES:
                     out[i + 1] = "f16"
                     _cache_reset = True
+        # Symmetry, not size: an MLA model rejects K != V outright, so the K cache
+        # has to follow V down rather than stay quantized. This is not conditional
+        # on having just reset V here: on this flash-attn-off path V always ends up
+        # f16 anyway (reset above when it was quantized on argv, dropped by
+        # _drop_env_quantized_v_cache when it was quantized in the environment,
+        # otherwise already f16/bf16/f32), so a quantized K left on argv is a
+        # guaranteed K != V abort. The asymmetric case that motivates this is
+        # -ctk q8_0 on argv with LLAMA_ARG_CACHE_TYPE_V in the environment: nothing
+        # quantized appears on argv for V, so a V-triggered reset would never fire.
+        #
+        # The target and the drafter are separate models with separate contexts, and
+        # llama.cpp applies the restriction per context, so each side is gated on its
+        # OWN model. Mixing them is wrong in both directions: an MLA target with a
+        # non-MLA drafter would needlessly double the drafter's K cache (the very OOM
+        # the size argument above warns about), and a non-MLA target with an MLA
+        # drafter would leave the draft K quantized against an f16 draft V and abort
+        # the draft context. ``draft_mla`` defaults to ``mla`` when the caller cannot
+        # read the drafter's metadata, which is the safe direction: an unnecessary
+        # reset only costs memory, a missing one aborts.
+        _main_k_flags = ("--cache-type-k", "-ctk")
+        _draft_k_flags = ("--cache-type-k-draft", "--spec-draft-type-k", "-ctkd")
+        if draft_mla is None:
+            draft_mla = mla
+        _k_cache_flags = (_main_k_flags if mla else ()) + (
+            _draft_k_flags if draft_mla else ()
+        )
         _k_reset = False
-        if mla:
-            # Symmetry, not size: an MLA model rejects K != V outright, so the K
-            # cache has to follow V down rather than stay quantized. This is not
-            # conditional on having just reset V here: on this flash-attn-off path
-            # V always ends up f16 anyway (reset above when it was quantized on
-            # argv, dropped by _drop_env_quantized_v_cache when it was quantized
-            # in the environment, otherwise already f16/bf16/f32), so a quantized
-            # K left on argv is a guaranteed K != V abort. The asymmetric case
-            # that motivates this is -ctk q8_0 on argv with LLAMA_ARG_CACHE_TYPE_V
-            # in the environment: nothing quantized appears on argv for V, so a
-            # V-triggered reset would never fire.
-            _k_cache_flags = (
-                "--cache-type-k",
-                "-ctk",
-                "--cache-type-k-draft",
-                "--spec-draft-type-k",
-                "-ctkd",
-            )
-            for i, tok in enumerate(out):
-                if _flag_name(tok) not in _k_cache_flags:
-                    continue
-                if "=" in tok:
-                    flag, _, value = tok.partition("=")
-                    if value.strip().lower() not in LlamaCppBackend._NON_QUANTIZED_KV_TYPES:
-                        out[i] = f"{flag}=f16"
-                        _k_reset = True
-                elif i + 1 < len(out):
-                    if out[i + 1].strip().lower() not in LlamaCppBackend._NON_QUANTIZED_KV_TYPES:
-                        out[i + 1] = "f16"
-                        _k_reset = True
+        for i, tok in enumerate(out):
+            if _flag_name(tok) not in _k_cache_flags:
+                continue
+            if "=" in tok:
+                flag, _, value = tok.partition("=")
+                if value.strip().lower() not in LlamaCppBackend._NON_QUANTIZED_KV_TYPES:
+                    out[i] = f"{flag}=f16"
+                    _k_reset = True
+            elif i + 1 < len(out):
+                if out[i + 1].strip().lower() not in LlamaCppBackend._NON_QUANTIZED_KV_TYPES:
+                    out[i + 1] = "f16"
+                    _k_reset = True
         if _cache_reset or _k_reset:
             logger.info(
                 "KV cache dtype reset to f16 because flash attention is off (%s): a "
@@ -11955,7 +12013,9 @@ class LlamaCppBackend:
         return out
 
     @staticmethod
-    def _with_flash_attn_off(cmd: list[str], *, mla: bool = False) -> Optional[list[str]]:
+    def _with_flash_attn_off(
+        cmd: list[str], *, mla: bool = False, draft_mla: Optional[bool] = None
+    ) -> Optional[list[str]]:
         """Return cmd with flash attention forced off, or None when its effective
         (last-wins) value is already off/absent so there is nothing to retry. FA
         kernels hard-crash at startup on some ROCm builds; disabling FA keeps
@@ -12003,11 +12063,19 @@ class LlamaCppBackend:
         # launch but would make THIS FA-off retry crash on init instead of
         # recovering.
         return LlamaCppBackend._reset_quantized_v_cache(
-            out, "disabled by the crash-recovery fallback", mla = mla
+            out,
+            "disabled by the crash-recovery fallback",
+            mla = mla,
+            draft_mla = draft_mla,
         )
 
     @staticmethod
-    def _drop_env_quantized_v_cache(env: MutableMapping[str, str], *, mla: bool = False) -> bool:
+    def _drop_env_quantized_v_cache(
+        env: MutableMapping[str, str],
+        *,
+        mla: bool = False,
+        draft_mla: Optional[bool] = None,
+    ) -> bool:
         """Drop an inherited quantized V-cache env var (main or draft) in place
         before a flash-attn-off retry, returning True if anything was removed.
 
@@ -12023,15 +12091,21 @@ class LlamaCppBackend:
         without flash attention, so its env var is preserved. On an MLA model
         (DeepSeek V2/V3/R1, Kimi K2, GLM-4.7/5.x) llama.cpp rejects K != V
         outright, and it checks that *before* the V/flash-attn rule, so the
-        quantized K env vars have to go too. Every caller runs this after the
+        quantized K env vars have to go too, each gated on its own model
+        (``mla`` for the target var, ``draft_mla`` for the draft one, since the
+        drafter is a separate model with its own context). Every caller runs this after the
         argv reset has already forced V to f16, so a surviving quantized K env
         is a guaranteed "model does not support different K and V cache types"
         abort rather than the recovery the retry is trying to perform.
         """
         dropped = False
         variables = ["LLAMA_ARG_CACHE_TYPE_V", "LLAMA_ARG_SPEC_DRAFT_CACHE_TYPE_V"]
+        if draft_mla is None:
+            draft_mla = mla
         if mla:
-            variables += ["LLAMA_ARG_CACHE_TYPE_K", "LLAMA_ARG_SPEC_DRAFT_CACHE_TYPE_K"]
+            variables.append("LLAMA_ARG_CACHE_TYPE_K")
+        if draft_mla:
+            variables.append("LLAMA_ARG_SPEC_DRAFT_CACHE_TYPE_K")
         for var in variables:
             value = (env.get(var) or "").strip().lower()
             if value and value not in LlamaCppBackend._NON_QUANTIZED_KV_TYPES:
@@ -15666,7 +15740,8 @@ class LlamaCppBackend:
                     cmd = self._reset_quantized_v_cache(
                         cmd,
                         "this build has no --flash-attn",
-                        mla = self._kv_lora_rank is not None,
+                        mla = self._target_kv_symmetry(),
+                        draft_mla = self._draft_kv_symmetry(),
                     )
 
                 kv_cache_unified = _kv_unified_from_args(cmd)
@@ -15761,7 +15836,8 @@ class LlamaCppBackend:
                 # Same for an env-only quantized V cache, which the argv reset
                 # above cannot reach.
                 if _flash_attn_known_off and self._drop_env_quantized_v_cache(
-                    env, mla = self._kv_lora_rank is not None
+                    env, mla = self._target_kv_symmetry(),
+                            draft_mla = self._draft_kv_symmetry(),
                 ):
                     logger.info(
                         "Dropped inherited quantized V-cache env: this build has "
@@ -16597,7 +16673,8 @@ class LlamaCppBackend:
                     _fa_rc = self._process.poll() if self._process is not None else None
                     _fa_cmd = (
                         self._with_flash_attn_off(
-                            _last_spawn_cmd, mla = self._kv_lora_rank is not None
+                            _last_spawn_cmd, mla = self._target_kv_symmetry(),
+                            draft_mla = self._draft_kv_symmetry(),
                         )
                         if self._is_signal_crash(_fa_rc)
                         else None
@@ -16613,7 +16690,8 @@ class LlamaCppBackend:
                         # The argv rewrite can't reach an env-only quantized V
                         # cache; drop it so the FA-off child doesn't abort on it.
                         if self._drop_env_quantized_v_cache(
-                            env, mla = self._kv_lora_rank is not None
+                            env, mla = self._target_kv_symmetry(),
+                            draft_mla = self._draft_kv_symmetry(),
                         ):
                             logger.info(
                                 "Dropped inherited quantized V-cache env for the "
@@ -16665,7 +16743,8 @@ class LlamaCppBackend:
                     _probe_rc = self._process.poll() if self._process is not None else None
                     _fa_cmd = (
                         self._with_flash_attn_off(
-                            _last_spawn_cmd, mla = self._kv_lora_rank is not None
+                            _last_spawn_cmd, mla = self._target_kv_symmetry(),
+                            draft_mla = self._draft_kv_symmetry(),
                         )
                         if self._is_signal_crash(_probe_rc)
                         else None
@@ -16681,7 +16760,8 @@ class LlamaCppBackend:
                         # The argv rewrite can't reach an env-only quantized V
                         # cache; drop it so the FA-off child doesn't abort on it.
                         if self._drop_env_quantized_v_cache(
-                            env, mla = self._kv_lora_rank is not None
+                            env, mla = self._target_kv_symmetry(),
+                            draft_mla = self._draft_kv_symmetry(),
                         ):
                             logger.info(
                                 "Dropped inherited quantized V-cache env for the "

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -11874,19 +11874,26 @@ class LlamaCppBackend:
         managed path emits ``--model-draft <sidecar>`` into the same command, so
         reading the command covers both.
 
-        None (falling the caller back to the target) when no drafter is named, or
-        when it is a Hugging Face repo id rather than a local file whose metadata
-        can be read.
+        None only when no drafter is named at all, in which case there are no draft
+        flags to reset and the value cannot matter. A drafter that IS named but
+        whose metadata cannot be read (a Hugging Face repo id rather than a local
+        file, or an unreadable GGUF) resolves to True rather than to the target's
+        answer: the two mistakes are not symmetric. Resetting a non-MLA drafter's K
+        needlessly costs memory, whereas failing to reset an MLA drafter's K leaves
+        it quantized against an f16 draft V and aborts the draft context outright,
+        which is the failure this whole path exists to avoid.
         """
         path, is_remote = _extra_args_mtp_draft_source(list(cmd or []), env)
-        if not path or is_remote:
+        if not path:
             return None
+        if is_remote:  # a repo id is not a local file whose metadata can be read
+            return True
         try:
             db = self._draft_backend_for(path)
-        except Exception:  # unreadable drafter -> fall back to the target
+        except Exception:
             db = None
-        if db is None:
-            return None
+        if db is None:  # named but unreadable -> conservative, not the target
+            return True
         return self._requires_symmetric_kv(
             getattr(db, "_kv_lora_rank", None), getattr(db, "_architecture", None)
         )
@@ -15748,7 +15755,11 @@ class LlamaCppBackend:
                         cmd,
                         "this build has no --flash-attn",
                         mla = self._target_kv_symmetry(),
-                        draft_mla = self._draft_kv_symmetry(cmd, env),
+                        # No env argument: the child environment is not built until
+                        # below, and reading it here is an UnboundLocalError. The
+                        # inherited os.environ is the right source anyway, since
+                        # Studio never rewrites LLAMA_ARG_SPEC_DRAFT_MODEL.
+                        draft_mla = self._draft_kv_symmetry(cmd),
                     )
 
                 kv_cache_unified = _kv_unified_from_args(cmd)

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -11909,9 +11909,18 @@ class LlamaCppBackend:
                 if out[i + 1].strip().lower() not in LlamaCppBackend._NON_QUANTIZED_KV_TYPES:
                     out[i + 1] = "f16"
                     _cache_reset = True
-        if _cache_reset and mla:
+        _k_reset = False
+        if mla:
             # Symmetry, not size: an MLA model rejects K != V outright, so the K
-            # cache has to follow V down rather than stay quantized.
+            # cache has to follow V down rather than stay quantized. This is not
+            # conditional on having just reset V here: on this flash-attn-off path
+            # V always ends up f16 anyway (reset above when it was quantized on
+            # argv, dropped by _drop_env_quantized_v_cache when it was quantized
+            # in the environment, otherwise already f16/bf16/f32), so a quantized
+            # K left on argv is a guaranteed K != V abort. The asymmetric case
+            # that motivates this is -ctk q8_0 on argv with LLAMA_ARG_CACHE_TYPE_V
+            # in the environment: nothing quantized appears on argv for V, so a
+            # V-triggered reset would never fire.
             _k_cache_flags = (
                 "--cache-type-k",
                 "-ctk",
@@ -11926,18 +11935,20 @@ class LlamaCppBackend:
                     flag, _, value = tok.partition("=")
                     if value.strip().lower() not in LlamaCppBackend._NON_QUANTIZED_KV_TYPES:
                         out[i] = f"{flag}=f16"
+                        _k_reset = True
                 elif i + 1 < len(out):
                     if out[i + 1].strip().lower() not in LlamaCppBackend._NON_QUANTIZED_KV_TYPES:
                         out[i + 1] = "f16"
-        if _cache_reset:
+                        _k_reset = True
+        if _cache_reset or _k_reset:
             logger.info(
-                "V cache dtype reset to f16 because flash attention is off (%s): a "
+                "KV cache dtype reset to f16 because flash attention is off (%s): a "
                 "quantized V cache requires flash attention in llama.cpp. %s",
                 reason,
                 (
-                    "The K cache followed it down: this model uses MLA, which "
+                    "The K cache went down with it: this model uses MLA, which "
                     "rejects different K and V cache types."
-                    if mla
+                    if _k_reset
                     else "The K cache is left untouched."
                 ),
             )
@@ -11996,7 +12007,9 @@ class LlamaCppBackend:
         )
 
     @staticmethod
-    def _drop_env_quantized_v_cache(env: MutableMapping[str, str]) -> bool:
+    def _drop_env_quantized_v_cache(
+        env: MutableMapping[str, str], *, mla: bool = False
+    ) -> bool:
         """Drop an inherited quantized V-cache env var (main or draft) in place
         before a flash-attn-off retry, returning True if anything was removed.
 
@@ -12006,11 +12019,22 @@ class LlamaCppBackend:
         cache set purely through ``LLAMA_ARG_CACHE_TYPE_V`` (or the draft
         ``LLAMA_ARG_SPEC_DRAFT_CACHE_TYPE_V``) would still abort the FA-off retry
         with "V cache quantization requires flash_attn". Dropping it lets
-        llama.cpp fall back to the f16 default. Only V is dropped: a quantized K
-        cache runs fine without flash attention, so its env var is preserved.
+        llama.cpp fall back to the f16 default.
+
+        On a non-MLA model only V is dropped: a quantized K cache runs fine
+        without flash attention, so its env var is preserved. On an MLA model
+        (DeepSeek V2/V3/R1, Kimi K2, GLM-4.7/5.x) llama.cpp rejects K != V
+        outright, and it checks that *before* the V/flash-attn rule, so the
+        quantized K env vars have to go too. Every caller runs this after the
+        argv reset has already forced V to f16, so a surviving quantized K env
+        is a guaranteed "model does not support different K and V cache types"
+        abort rather than the recovery the retry is trying to perform.
         """
         dropped = False
-        for var in ("LLAMA_ARG_CACHE_TYPE_V", "LLAMA_ARG_SPEC_DRAFT_CACHE_TYPE_V"):
+        variables = ["LLAMA_ARG_CACHE_TYPE_V", "LLAMA_ARG_SPEC_DRAFT_CACHE_TYPE_V"]
+        if mla:
+            variables += ["LLAMA_ARG_CACHE_TYPE_K", "LLAMA_ARG_SPEC_DRAFT_CACHE_TYPE_K"]
+        for var in variables:
             value = (env.get(var) or "").strip().lower()
             if value and value not in LlamaCppBackend._NON_QUANTIZED_KV_TYPES:
                 env.pop(var, None)
@@ -15738,7 +15762,9 @@ class LlamaCppBackend:
                     )
                 # Same for an env-only quantized V cache, which the argv reset
                 # above cannot reach.
-                if _flash_attn_known_off and self._drop_env_quantized_v_cache(env):
+                if _flash_attn_known_off and self._drop_env_quantized_v_cache(
+                    env, mla = self._kv_lora_rank is not None
+                ):
                     logger.info(
                         "Dropped inherited quantized V-cache env: this build has "
                         "no --flash-attn."
@@ -16588,7 +16614,9 @@ class LlamaCppBackend:
                         self._kill_process()
                         # The argv rewrite can't reach an env-only quantized V
                         # cache; drop it so the FA-off child doesn't abort on it.
-                        if self._drop_env_quantized_v_cache(env):
+                        if self._drop_env_quantized_v_cache(
+                            env, mla = self._kv_lora_rank is not None
+                        ):
                             logger.info(
                                 "Dropped inherited quantized V-cache env for the "
                                 "--flash-attn off retry (requires flash attention)."
@@ -16654,7 +16682,9 @@ class LlamaCppBackend:
                         self._kill_process()
                         # The argv rewrite can't reach an env-only quantized V
                         # cache; drop it so the FA-off child doesn't abort on it.
-                        if self._drop_env_quantized_v_cache(env):
+                        if self._drop_env_quantized_v_cache(
+                            env, mla = self._kv_lora_rank is not None
+                        ):
                             logger.info(
                                 "Dropped inherited quantized V-cache env for the "
                                 "--flash-attn off retry (requires flash attention)."

--- a/studio/backend/tests/test_launch_flags_are_capability_gated.py
+++ b/studio/backend/tests/test_launch_flags_are_capability_gated.py
@@ -359,7 +359,29 @@ class TestAFlaglessBuildIgnoresTheFlashAttentionEnv:
         assert env["LLAMA_ARG_FLASH_ATTN"] == "1"
 
 
-def _flagless_v_cache_fixup(*, known_off: bool, cmd: list, env: dict) -> tuple:
+class _SelfShim:
+    """Stand-in for the backend instance the fixup block runs against.
+
+    The block reads instance state (``_kv_lora_rank``) as well as class
+    methods, and binding the class itself meant any new ``self.<attr>`` in
+    that block raised AttributeError here rather than failing on its merits.
+    Anything not set on the shim falls through to the class.
+    """
+
+    def __init__(self, kv_lora_rank = None):
+        self._kv_lora_rank = kv_lora_rank
+
+    def __getattr__(self, name):
+        return getattr(LlamaCppBackend, name)
+
+
+def _flagless_v_cache_fixup(
+    *,
+    known_off: bool,
+    cmd: list,
+    env: dict,
+    mla: bool = False,
+) -> tuple:
     """Run load_model's real flagless-build V-cache fixup over cmd and env."""
     source = textwrap.dedent(inspect.getsource(LlamaCppBackend.load_model))
     blocks = [
@@ -373,7 +395,7 @@ def _flagless_v_cache_fixup(*, known_off: bool, cmd: list, env: dict) -> tuple:
     ]
     assert len(blocks) == 2, f"expected two V-cache fixup blocks, found {len(blocks)}"
     scope = {
-        "self": LlamaCppBackend,
+        "self": _SelfShim(kv_lora_rank = 512 if mla else None),
         "logger": logging.getLogger(__name__),
         "_flash_attn_known_off": known_off,
         "cmd": list(cmd),
@@ -439,3 +461,31 @@ class TestAFlaglessBuildCannotRunAQuantizedVCache:
         never runs, and the log is the only record of what was launched."""
         src = inspect.getsource(LlamaCppBackend.load_model)
         assert src.index("_reset_quantized_v_cache") < src.index("Starting llama-server")
+
+
+class TestTheFlaglessFixupKeepsMlaKAndVEqual:
+    """An MLA model rejects K != V outright, above the V-quantization check.
+
+    So the launch-site reset, which normally leaves K quantized on purpose,
+    has to bring K down with V there or it trades one abort for another.
+    """
+
+    CMD = [
+        "llama-server",
+        "-m",
+        "ds.gguf",
+        "--cache-type-k",
+        "q8_0",
+        "--cache-type-v",
+        "q8_0",
+    ]
+
+    def test_mla_brings_k_down_with_v(self):
+        cmd, _ = _flagless_v_cache_fixup(known_off = True, cmd = self.CMD, env = {}, mla = True)
+        assert cmd[cmd.index("--cache-type-k") + 1] == "f16"
+        assert cmd[cmd.index("--cache-type-v") + 1] == "f16"
+
+    def test_a_non_mla_model_still_keeps_its_quantized_k(self):
+        cmd, _ = _flagless_v_cache_fixup(known_off = True, cmd = self.CMD, env = {}, mla = False)
+        assert cmd[cmd.index("--cache-type-k") + 1] == "q8_0"
+        assert cmd[cmd.index("--cache-type-v") + 1] == "f16"

--- a/studio/backend/tests/test_launch_flags_are_capability_gated.py
+++ b/studio/backend/tests/test_launch_flags_are_capability_gated.py
@@ -362,17 +362,27 @@ class TestAFlaglessBuildIgnoresTheFlashAttentionEnv:
 class _SelfShim:
     """Stand-in for the backend instance the fixup block runs against.
 
-    The block reads instance state (``_kv_lora_rank``) as well as class
-    methods, and binding the class itself meant any new ``self.<attr>`` in
-    that block raised AttributeError here rather than failing on its merits.
-    Anything not set on the shim falls through to the class.
+    The block reads instance state (``_kv_lora_rank``, ``_architecture``,
+    ``_mtp_draft_path``) as well as class methods, and binding the class itself
+    meant any new ``self.<attr>`` in that block raised AttributeError here rather
+    than failing on its merits. Anything not set on the shim falls through to the
+    class, and a plain function found there is bound to the shim so the block can
+    call ``self.<method>()`` the way the real backend does.
     """
 
-    def __init__(self, kv_lora_rank = None):
+    def __init__(self, kv_lora_rank = None, architecture = None, mtp_draft_path = None):
         self._kv_lora_rank = kv_lora_rank
+        self._architecture = architecture
+        self._mtp_draft_path = mtp_draft_path
 
     def __getattr__(self, name):
-        return getattr(LlamaCppBackend, name)
+        attr = getattr(LlamaCppBackend, name)
+        # A staticmethod reached through the class is a plain function too, but it
+        # takes no self, so only genuine instance methods get bound.
+        declared = inspect.getattr_static(LlamaCppBackend, name, None)
+        if inspect.isfunction(attr) and not isinstance(declared, staticmethod):
+            return _types.MethodType(attr, self)
+        return attr
 
 
 def _flagless_v_cache_fixup(

--- a/studio/backend/tests/test_launch_flags_are_capability_gated.py
+++ b/studio/backend/tests/test_launch_flags_are_capability_gated.py
@@ -370,7 +370,12 @@ class _SelfShim:
     call ``self.<method>()`` the way the real backend does.
     """
 
-    def __init__(self, kv_lora_rank = None, architecture = None, mtp_draft_path = None):
+    def __init__(
+        self,
+        kv_lora_rank = None,
+        architecture = None,
+        mtp_draft_path = None,
+    ):
         self._kv_lora_rank = kv_lora_rank
         self._architecture = architecture
         self._mtp_draft_path = mtp_draft_path

--- a/studio/backend/tests/test_mla_kv_cache_symmetry.py
+++ b/studio/backend/tests/test_mla_kv_cache_symmetry.py
@@ -1,0 +1,131 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""An MLA model rejects different K and V cache types.
+
+llama-context.cpp gained this check, and it sits ABOVE the V-quantization
+check, so it decides first:
+
+    if ((model->hparams.is_mla() || model->arch == LLM_ARCH_DEEPSEEK4)
+            && params.type_k != params.type_v) {
+        LLAMA_LOG_ERROR("model does not support different K (%s) and V (%s)
+                         cache types");
+        return nullptr;
+    }
+
+is_mla() covers DeepSeek V2/V3/R1, Kimi K2 and GLM-4.7/5.x, which Studio
+already recognises through kv_lora_rank.
+
+The flash-attention-off retry resets a quantized V cache to f16 and
+deliberately leaves K quantized, because a quantized K needs no FA and
+resetting it enlarges the cache. On an MLA model that produces K=q8_0 V=f16,
+which is a hard abort for a DIFFERENT reason than the one being avoided: the
+retry that exists to recover from an FA crash fails on the K/V mismatch
+instead of recovering.
+"""
+
+from __future__ import annotations
+
+import sys
+import types as _types
+from pathlib import Path
+
+import pytest
+
+_BACKEND_DIR = str(Path(__file__).resolve().parent.parent)
+if _BACKEND_DIR not in sys.path:
+    sys.path.insert(0, _BACKEND_DIR)
+
+_loggers_stub = _types.ModuleType("loggers")
+_loggers_stub.get_logger = lambda name: __import__("logging").getLogger(name)
+sys.modules.setdefault("loggers", _loggers_stub)
+_structlog_stub = _types.ModuleType("structlog")
+_structlog_stub.get_logger = lambda *a, **k: __import__("logging").getLogger("structlog")
+sys.modules.setdefault("structlog", _structlog_stub)
+if not hasattr(sys.modules["structlog"], "get_logger"):
+    sys.modules["structlog"].get_logger = _structlog_stub.get_logger
+
+from core.inference.llama_cpp import LlamaCppBackend  # noqa: E402
+
+QUANT_KV = [
+    "llama-server",
+    "-m",
+    "ds.gguf",
+    "--flash-attn",
+    "on",
+    "--cache-type-k",
+    "q8_0",
+    "--cache-type-v",
+    "q8_0",
+]
+
+
+def _types_of(
+    cmd,
+    k_flag = "--cache-type-k",
+    v_flag = "--cache-type-v",
+):
+    return cmd[cmd.index(k_flag) + 1], cmd[cmd.index(v_flag) + 1]
+
+
+class TestTheRetryKeepsKAndVEqualOnMla:
+    def test_both_axes_come_down_together(self):
+        out = LlamaCppBackend._with_flash_attn_off(list(QUANT_KV), mla = True)
+        k, v = _types_of(out)
+        assert k == v == "f16", (k, v)
+
+    def test_the_inline_equals_spelling_is_handled(self):
+        cmd = ["llama-server", "--flash-attn", "on", "--cache-type-k=q8_0", "--cache-type-v=q8_0"]
+        out = LlamaCppBackend._with_flash_attn_off(cmd, mla = True)
+        assert "--cache-type-k=f16" in out and "--cache-type-v=f16" in out
+
+    def test_the_draft_pair_is_handled_too(self):
+        cmd = [*QUANT_KV, "--spec-draft-type-k", "q4_0", "--spec-draft-type-v", "q4_0"]
+        out = LlamaCppBackend._with_flash_attn_off(cmd, mla = True)
+        assert _types_of(out) == ("f16", "f16")
+        assert _types_of(out, "--spec-draft-type-k", "--spec-draft-type-v") == ("f16", "f16")
+
+    def test_an_unquantized_kv_is_left_alone(self):
+        """Nothing to reset, so nothing moves and no cache grows."""
+        cmd = [
+            "llama-server",
+            "--flash-attn",
+            "on",
+            "--cache-type-k",
+            "f16",
+            "--cache-type-v",
+            "f16",
+        ]
+        out = LlamaCppBackend._with_flash_attn_off(cmd, mla = True)
+        assert _types_of(out) == ("f16", "f16")
+
+    def test_a_quantized_k_alone_does_not_drag_anything(self):
+        """No V reset happened, so the MLA branch must not fire either: K and V
+        were already equal in llama.cpp's eyes before we touched anything."""
+        cmd = ["llama-server", "--flash-attn", "on", "--cache-type-k", "q8_0"]
+        out = LlamaCppBackend._with_flash_attn_off(cmd, mla = True)
+        assert out[out.index("--cache-type-k") + 1] == "q8_0"
+
+
+class TestNonMlaBehaviourIsUnchanged:
+    """The size argument still holds everywhere else: resetting K needlessly
+    enlarges it and can OOM a memory-constrained config."""
+
+    def test_k_stays_quantized(self):
+        out = LlamaCppBackend._with_flash_attn_off(list(QUANT_KV), mla = False)
+        assert _types_of(out) == ("q8_0", "f16")
+
+    def test_the_default_is_the_non_mla_behaviour(self):
+        """mla defaults False, so an un-updated caller keeps today's answer."""
+        out = LlamaCppBackend._with_flash_attn_off(list(QUANT_KV))
+        assert _types_of(out) == ("q8_0", "f16")
+
+
+class TestTheSignalStudioAlreadyHas:
+    def test_kv_lora_rank_is_the_mla_marker(self):
+        """Both call sites pass `self._kv_lora_rank is not None`, which is the
+        same signal _can_estimate_kv uses to take its MLA branch."""
+        import inspect
+
+        src = inspect.getsource(LlamaCppBackend.load_model)
+        assert src.count("mla = self._kv_lora_rank is not None") >= 2

--- a/studio/backend/tests/test_mla_kv_cache_symmetry.py
+++ b/studio/backend/tests/test_mla_kv_cache_symmetry.py
@@ -99,12 +99,76 @@ class TestTheRetryKeepsKAndVEqualOnMla:
         out = LlamaCppBackend._with_flash_attn_off(cmd, mla = True)
         assert _types_of(out) == ("f16", "f16")
 
-    def test_a_quantized_k_alone_does_not_drag_anything(self):
-        """No V reset happened, so the MLA branch must not fire either: K and V
-        were already equal in llama.cpp's eyes before we touched anything."""
+    def test_a_quantized_k_alone_still_comes_down(self):
+        """A quantized K with no V flag at all is NOT already symmetric: V falls
+        back to the f16 default, so llama.cpp sees K=q8_0 against V=f16 and
+        rejects it on MLA. Lowering K is what makes the retry start."""
         cmd = ["llama-server", "--flash-attn", "on", "--cache-type-k", "q8_0"]
         out = LlamaCppBackend._with_flash_attn_off(cmd, mla = True)
-        assert out[out.index("--cache-type-k") + 1] == "q8_0"
+        assert out[out.index("--cache-type-k") + 1] == "f16"
+
+    def test_argv_k_comes_down_when_v_is_quantized_only_in_the_env(self):
+        """The reset cannot see the environment, so it must not make lowering K
+        conditional on having just lowered V on argv. Here V is quantized purely
+        through LLAMA_ARG_CACHE_TYPE_V, which _drop_env_quantized_v_cache removes;
+        a K left at q8_0 would then abort against the resulting f16 V."""
+        cmd = ["llama-server", "--flash-attn", "on", "--cache-type-k", "q8_0"]
+        env = {"LLAMA_ARG_CACHE_TYPE_V": "q8_0"}
+        out = LlamaCppBackend._with_flash_attn_off(cmd, mla = True)
+        LlamaCppBackend._drop_env_quantized_v_cache(env, mla = True)
+        assert out[out.index("--cache-type-k") + 1] == "f16"
+        assert env == {}
+
+
+class TestTheEnvDropKeepsMlaKAndVEqual:
+    """llama.cpp reads LLAMA_ARG_* before parsing argv, so an inherited quantized
+    K env survives an argv-only fix and reintroduces the mismatch."""
+
+    def test_the_k_env_goes_with_the_v_env_on_mla(self):
+        env = {
+            "LLAMA_ARG_CACHE_TYPE_K": "q8_0",
+            "LLAMA_ARG_CACHE_TYPE_V": "q8_0",
+        }
+        assert LlamaCppBackend._drop_env_quantized_v_cache(env, mla = True) is True
+        assert env == {}
+
+    def test_the_draft_pair_goes_too(self):
+        env = {
+            "LLAMA_ARG_SPEC_DRAFT_CACHE_TYPE_K": "q4_0",
+            "LLAMA_ARG_SPEC_DRAFT_CACHE_TYPE_V": "q4_0",
+        }
+        assert LlamaCppBackend._drop_env_quantized_v_cache(env, mla = True) is True
+        assert env == {}
+
+    def test_a_quantized_k_env_alone_is_dropped_on_mla(self):
+        """V is f16 by then, so a lone quantized K env is a guaranteed abort."""
+        env = {"LLAMA_ARG_CACHE_TYPE_K": "q8_0"}
+        assert LlamaCppBackend._drop_env_quantized_v_cache(env, mla = True) is True
+        assert env == {}
+
+    def test_non_mla_keeps_the_quantized_k_env(self):
+        """The size argument is unchanged off MLA: a quantized K runs fine
+        without flash attention, so its env var is preserved."""
+        env = {
+            "LLAMA_ARG_CACHE_TYPE_K": "q8_0",
+            "LLAMA_ARG_CACHE_TYPE_V": "q8_0",
+        }
+        assert LlamaCppBackend._drop_env_quantized_v_cache(env, mla = False) is True
+        assert env == {"LLAMA_ARG_CACHE_TYPE_K": "q8_0"}
+
+    def test_the_default_is_the_non_mla_behaviour(self):
+        """mla defaults False, so an un-updated caller keeps today's answer."""
+        env = {"LLAMA_ARG_CACHE_TYPE_K": "q8_0", "LLAMA_ARG_CACHE_TYPE_V": "q8_0"}
+        LlamaCppBackend._drop_env_quantized_v_cache(env)
+        assert env == {"LLAMA_ARG_CACHE_TYPE_K": "q8_0"}
+
+    def test_an_unquantized_k_env_is_left_alone_on_mla(self):
+        """f16/bf16/f32 satisfy the V rule already; dropping them would silently
+        change a launch the user configured deliberately."""
+        env = {"LLAMA_ARG_CACHE_TYPE_K": "bf16", "LLAMA_ARG_CACHE_TYPE_V": "bf16"}
+        assert LlamaCppBackend._drop_env_quantized_v_cache(env, mla = True) is False
+        assert env == {"LLAMA_ARG_CACHE_TYPE_K": "bf16",
+                       "LLAMA_ARG_CACHE_TYPE_V": "bf16"}
 
 
 class TestNonMlaBehaviourIsUnchanged:

--- a/studio/backend/tests/test_mla_kv_cache_symmetry.py
+++ b/studio/backend/tests/test_mla_kv_cache_symmetry.py
@@ -388,9 +388,7 @@ class TestLoadModelNeverReadsEnvBeforeItExists:
         import inspect
         import textwrap
 
-        fn = ast.parse(
-            textwrap.dedent(inspect.getsource(LlamaCppBackend.load_model))
-        )
+        fn = ast.parse(textwrap.dedent(inspect.getsource(LlamaCppBackend.load_model)))
         stores = [
             n.lineno
             for n in ast.walk(fn)

--- a/studio/backend/tests/test_mla_kv_cache_symmetry.py
+++ b/studio/backend/tests/test_mla_kv_cache_symmetry.py
@@ -244,27 +244,21 @@ class TestTheDrafterIsGatedOnItsOwnModel:
     def test_an_mla_target_leaves_a_non_mla_drafters_k_quantized(self):
         """Resetting it would needlessly double the drafter's K cache, which is
         the OOM the size argument warns about."""
-        out = LlamaCppBackend._with_flash_attn_off(
-            list(self.DRAFT_CMD), mla = True, draft_mla = False
-        )
+        out = LlamaCppBackend._with_flash_attn_off(list(self.DRAFT_CMD), mla = True, draft_mla = False)
         assert self._main_k(out) == "f16"
         assert self._draft_k(out) == "q8_0"
 
     def test_a_non_mla_target_still_brings_an_mla_drafters_k_down(self):
         """The mirror case, and the more serious one: leaving the draft K
         quantized against an f16 draft V aborts the draft context."""
-        out = LlamaCppBackend._with_flash_attn_off(
-            list(self.DRAFT_CMD), mla = False, draft_mla = True
-        )
+        out = LlamaCppBackend._with_flash_attn_off(list(self.DRAFT_CMD), mla = False, draft_mla = True)
         assert self._main_k(out) == "q8_0"
         assert self._draft_k(out) == "f16"
 
     def test_an_unknown_drafter_falls_back_to_the_target(self):
         """None means the drafter's GGUF could not be read. An unnecessary reset
         only costs memory; a missing one aborts, so it follows the target."""
-        out = LlamaCppBackend._with_flash_attn_off(
-            list(self.DRAFT_CMD), mla = True, draft_mla = None
-        )
+        out = LlamaCppBackend._with_flash_attn_off(list(self.DRAFT_CMD), mla = True, draft_mla = None)
         assert self._main_k(out) == "f16"
         assert self._draft_k(out) == "f16"
 

--- a/studio/backend/tests/test_mla_kv_cache_symmetry.py
+++ b/studio/backend/tests/test_mla_kv_cache_symmetry.py
@@ -193,7 +193,7 @@ class TestTheSignalStudioAlreadyHas:
 
         src = inspect.getsource(LlamaCppBackend.load_model)
         assert src.count("mla = self._target_kv_symmetry()") >= 2
-        assert src.count("draft_mla = self._draft_kv_symmetry()") == src.count(
+        assert src.count("draft_mla = self._draft_kv_symmetry(") == src.count(
             "mla = self._target_kv_symmetry()"
         )
 
@@ -271,3 +271,91 @@ class TestTheDrafterIsGatedOnItsOwnModel:
         }
         LlamaCppBackend._drop_env_quantized_v_cache(env, mla = True, draft_mla = False)
         assert env == {"LLAMA_ARG_SPEC_DRAFT_CACHE_TYPE_K": "q8_0"}
+
+
+class TestTheDraftSignalComesFromTheLaunchCommand:
+    """The drafter that matters is the one llama.cpp actually loads, which is the
+    one named on the command being launched."""
+
+    def _backend(self, drafters):
+        """A backend whose drafter metadata lookup is stubbed, not read from disk."""
+        b = LlamaCppBackend.__new__(LlamaCppBackend)
+        b._kv_lora_rank = None
+        b._architecture = "llama"
+        b._mtp_draft_path = None
+
+        def _draft_backend_for(path):
+            meta = drafters.get(path)
+            if meta is None:
+                return None
+            db = LlamaCppBackend.__new__(LlamaCppBackend)
+            db._kv_lora_rank, db._architecture = meta
+            return db
+
+        b._draft_backend_for = _draft_backend_for
+        return b
+
+    def test_an_extra_args_drafter_is_the_one_that_counts(self):
+        """--model-draft in extras is the drafter llama.cpp loads, so an MLA one
+        must be seen even though the managed sidecar path is unset."""
+        b = self._backend({"/d/mla.gguf": (512, "deepseek2")})
+        cmd = ["llama-server", "-m", "t.gguf", "--model-draft", "/d/mla.gguf"]
+        assert b._draft_kv_symmetry(cmd, {}) is True
+
+    def test_the_managed_sidecar_is_seen_through_the_same_flag(self):
+        """_build_speculative_flags emits --model-draft <sidecar> into the same
+        command, so one source covers both."""
+        b = self._backend({"/d/plain.gguf": (None, "llama")})
+        cmd = ["llama-server", "-m", "t.gguf", "--model-draft", "/d/plain.gguf"]
+        assert b._draft_kv_symmetry(cmd, {}) is False
+
+    def test_the_stored_path_is_not_consulted(self):
+        """_mtp_draft_path is assigned after the launch-site reset has already run,
+        so it is stale there. Only the command decides."""
+        b = self._backend({"/d/mla.gguf": (512, "deepseek2")})
+        b._mtp_draft_path = "/d/mla.gguf"
+        assert b._draft_kv_symmetry(["llama-server", "-m", "t.gguf"], {}) is None
+
+    def test_the_last_draft_flag_wins(self):
+        b = self._backend(
+            {"/d/mla.gguf": (512, "deepseek2"), "/d/plain.gguf": (None, "llama")}
+        )
+        cmd = [
+            "llama-server",
+            "--model-draft",
+            "/d/mla.gguf",
+            "--model-draft",
+            "/d/plain.gguf",
+        ]
+        assert b._draft_kv_symmetry(cmd, {}) is False
+
+    def test_an_hf_repo_drafter_is_undeterminable(self):
+        """A repo id is not a local file, so its metadata cannot be read; None
+        falls the caller back to the target rather than guessing."""
+        b = self._backend({})
+        cmd = ["llama-server", "--hf-repo-draft", "org/drafter-GGUF"]
+        assert b._draft_kv_symmetry(cmd, {}) is None
+
+    def test_an_env_supplied_drafter_is_seen(self):
+        b = self._backend({"/d/mla.gguf": (512, "deepseek2")})
+        env = {"LLAMA_ARG_SPEC_DRAFT_MODEL": "/d/mla.gguf"}
+        assert b._draft_kv_symmetry(["llama-server"], env) is True
+
+    def test_no_drafter_at_all_is_none(self):
+        b = self._backend({})
+        assert b._draft_kv_symmetry(["llama-server", "-m", "t.gguf"], {}) is None
+
+    def test_an_unreadable_drafter_is_none(self):
+        b = self._backend({})
+        cmd = ["llama-server", "--model-draft", "/d/missing.gguf"]
+        assert b._draft_kv_symmetry(cmd, {}) is None
+
+    def test_every_call_site_passes_a_command(self):
+        """A bare _draft_kv_symmetry() would silently read no drafter at all."""
+        import inspect
+
+        src = inspect.getsource(LlamaCppBackend.load_model)
+        assert "self._draft_kv_symmetry()" not in src
+        assert src.count("self._draft_kv_symmetry(") == src.count(
+            "self._target_kv_symmetry()"
+        )

--- a/studio/backend/tests/test_mla_kv_cache_symmetry.py
+++ b/studio/backend/tests/test_mla_kv_cache_symmetry.py
@@ -327,12 +327,13 @@ class TestTheDraftSignalComesFromTheLaunchCommand:
         ]
         assert b._draft_kv_symmetry(cmd, {}) is False
 
-    def test_an_hf_repo_drafter_is_undeterminable(self):
-        """A repo id is not a local file, so its metadata cannot be read; None
-        falls the caller back to the target rather than guessing."""
+    def test_an_hf_repo_drafter_takes_the_conservative_path(self):
+        """A repo id is not a local file, so its metadata cannot be read. Falling
+        back to the target would leave an MLA drafter's K quantized against an f16
+        draft V and abort; resetting a non-MLA drafter's K only costs memory."""
         b = self._backend({})
         cmd = ["llama-server", "--hf-repo-draft", "org/drafter-GGUF"]
-        assert b._draft_kv_symmetry(cmd, {}) is None
+        assert b._draft_kv_symmetry(cmd, {}) is True
 
     def test_an_env_supplied_drafter_is_seen(self):
         b = self._backend({"/d/mla.gguf": (512, "deepseek2")})
@@ -343,10 +344,26 @@ class TestTheDraftSignalComesFromTheLaunchCommand:
         b = self._backend({})
         assert b._draft_kv_symmetry(["llama-server", "-m", "t.gguf"], {}) is None
 
-    def test_an_unreadable_drafter_is_none(self):
+    def test_an_unreadable_drafter_takes_the_conservative_path(self):
+        """Named but unreadable is still a drafter that will launch."""
         b = self._backend({})
         cmd = ["llama-server", "--model-draft", "/d/missing.gguf"]
-        assert b._draft_kv_symmetry(cmd, {}) is None
+        assert b._draft_kv_symmetry(cmd, {}) is True
+
+    def test_a_raising_metadata_read_takes_the_conservative_path(self):
+        b = self._backend({})
+
+        def _boom(path):
+            raise OSError("unreadable")
+
+        b._draft_backend_for = _boom
+        cmd = ["llama-server", "--model-draft", "/d/broken.gguf"]
+        assert b._draft_kv_symmetry(cmd, {}) is True
+
+    def test_only_the_absence_of_a_drafter_is_none(self):
+        """None means "no draft flags exist", so the value cannot matter."""
+        b = self._backend({})
+        assert b._draft_kv_symmetry(["llama-server", "-m", "t.gguf"], {}) is None
 
     def test_every_call_site_passes_a_command(self):
         """A bare _draft_kv_symmetry() would silently read no drafter at all."""
@@ -355,3 +372,35 @@ class TestTheDraftSignalComesFromTheLaunchCommand:
         src = inspect.getsource(LlamaCppBackend.load_model)
         assert "self._draft_kv_symmetry()" not in src
         assert src.count("self._draft_kv_symmetry(") == src.count("self._target_kv_symmetry()")
+
+
+class TestLoadModelNeverReadsEnvBeforeItExists:
+    """A launch-site fixup that reads the child environment raises
+    UnboundLocalError and kills every load through that path.
+
+    This is a static check on purpose. The block-extraction harness used by the
+    flagless tests seeds ``env`` into the exec scope, so it would happily pass
+    while the real function raised, which is exactly what happened once.
+    """
+
+    def test_env_is_never_loaded_before_it_is_assigned(self):
+        import ast
+        import inspect
+        import textwrap
+
+        fn = ast.parse(
+            textwrap.dedent(inspect.getsource(LlamaCppBackend.load_model))
+        )
+        stores = [
+            n.lineno
+            for n in ast.walk(fn)
+            if isinstance(n, ast.Name) and n.id == "env" and isinstance(n.ctx, ast.Store)
+        ]
+        loads = [
+            n.lineno
+            for n in ast.walk(fn)
+            if isinstance(n, ast.Name) and n.id == "env" and isinstance(n.ctx, ast.Load)
+        ]
+        assert stores, "load_model no longer builds a child env; update this test"
+        early = [line for line in loads if line < min(stores)]
+        assert not early, f"env read before assignment at offsets {early}"

--- a/studio/backend/tests/test_mla_kv_cache_symmetry.py
+++ b/studio/backend/tests/test_mla_kv_cache_symmetry.py
@@ -317,9 +317,7 @@ class TestTheDraftSignalComesFromTheLaunchCommand:
         assert b._draft_kv_symmetry(["llama-server", "-m", "t.gguf"], {}) is None
 
     def test_the_last_draft_flag_wins(self):
-        b = self._backend(
-            {"/d/mla.gguf": (512, "deepseek2"), "/d/plain.gguf": (None, "llama")}
-        )
+        b = self._backend({"/d/mla.gguf": (512, "deepseek2"), "/d/plain.gguf": (None, "llama")})
         cmd = [
             "llama-server",
             "--model-draft",
@@ -356,6 +354,4 @@ class TestTheDraftSignalComesFromTheLaunchCommand:
 
         src = inspect.getsource(LlamaCppBackend.load_model)
         assert "self._draft_kv_symmetry()" not in src
-        assert src.count("self._draft_kv_symmetry(") == src.count(
-            "self._target_kv_symmetry()"
-        )
+        assert src.count("self._draft_kv_symmetry(") == src.count("self._target_kv_symmetry()")

--- a/studio/backend/tests/test_mla_kv_cache_symmetry.py
+++ b/studio/backend/tests/test_mla_kv_cache_symmetry.py
@@ -167,8 +167,7 @@ class TestTheEnvDropKeepsMlaKAndVEqual:
         change a launch the user configured deliberately."""
         env = {"LLAMA_ARG_CACHE_TYPE_K": "bf16", "LLAMA_ARG_CACHE_TYPE_V": "bf16"}
         assert LlamaCppBackend._drop_env_quantized_v_cache(env, mla = True) is False
-        assert env == {"LLAMA_ARG_CACHE_TYPE_K": "bf16",
-                       "LLAMA_ARG_CACHE_TYPE_V": "bf16"}
+        assert env == {"LLAMA_ARG_CACHE_TYPE_K": "bf16", "LLAMA_ARG_CACHE_TYPE_V": "bf16"}
 
 
 class TestNonMlaBehaviourIsUnchanged:

--- a/studio/backend/tests/test_mla_kv_cache_symmetry.py
+++ b/studio/backend/tests/test_mla_kv_cache_symmetry.py
@@ -185,10 +185,95 @@ class TestNonMlaBehaviourIsUnchanged:
 
 
 class TestTheSignalStudioAlreadyHas:
-    def test_kv_lora_rank_is_the_mla_marker(self):
-        """Both call sites pass `self._kv_lora_rank is not None`, which is the
-        same signal _can_estimate_kv uses to take its MLA branch."""
+    def test_every_call_site_passes_both_per_model_signals(self):
+        """The target and the drafter are separate models with separate contexts,
+        so every reset site gates each side on its own metadata rather than
+        reusing the target's answer for both."""
         import inspect
 
         src = inspect.getsource(LlamaCppBackend.load_model)
-        assert src.count("mla = self._kv_lora_rank is not None") >= 2
+        assert src.count("mla = self._target_kv_symmetry()") >= 2
+        assert src.count("draft_mla = self._draft_kv_symmetry()") == src.count(
+            "mla = self._target_kv_symmetry()"
+        )
+
+    def test_kv_lora_rank_is_the_mla_marker(self):
+        """kv_lora_rank stands in for is_mla(): the MLA archs' converter writes it
+        alongside the MLA head dims that is_mla() actually reads."""
+        assert LlamaCppBackend._requires_symmetric_kv(512, "deepseek2") is True
+        assert LlamaCppBackend._requires_symmetric_kv(None, "llama") is False
+
+    def test_deepseek4_is_recognized_without_kv_lora_rank(self):
+        """Upstream checks `is_mla() || arch == LLM_ARCH_DEEPSEEK4`. DeepSeek4 has
+        its own KV cache, never sets the MLA head dims, and its converter writes
+        q_lora_rank but no kv_lora_rank, so the rank probe alone misses it."""
+        assert LlamaCppBackend._requires_symmetric_kv(None, "deepseek4") is True
+        assert LlamaCppBackend._requires_symmetric_kv(None, "DeepSeek4") is True
+        assert LlamaCppBackend._requires_symmetric_kv(None, " deepseek4 ") is True
+
+    def test_a_non_mla_arch_without_a_rank_is_not_symmetric(self):
+        assert LlamaCppBackend._requires_symmetric_kv(None, None) is False
+        assert LlamaCppBackend._requires_symmetric_kv(None, "deepseek") is False
+        assert LlamaCppBackend._requires_symmetric_kv(None, "deepseek2") is False
+
+
+class TestTheDrafterIsGatedOnItsOwnModel:
+    """llama.cpp applies the K == V restriction per context, and the drafter is a
+    separate model, so the target's answer must not decide the draft flags."""
+
+    DRAFT_CMD = [
+        "llama-server",
+        "--flash-attn",
+        "on",
+        "--cache-type-k",
+        "q8_0",
+        "--cache-type-v",
+        "q8_0",
+        "--spec-draft-type-k",
+        "q8_0",
+        "--spec-draft-type-v",
+        "q8_0",
+    ]
+
+    def _draft_k(self, out):
+        return out[out.index("--spec-draft-type-k") + 1]
+
+    def _main_k(self, out):
+        return out[out.index("--cache-type-k") + 1]
+
+    def test_an_mla_target_leaves_a_non_mla_drafters_k_quantized(self):
+        """Resetting it would needlessly double the drafter's K cache, which is
+        the OOM the size argument warns about."""
+        out = LlamaCppBackend._with_flash_attn_off(
+            list(self.DRAFT_CMD), mla = True, draft_mla = False
+        )
+        assert self._main_k(out) == "f16"
+        assert self._draft_k(out) == "q8_0"
+
+    def test_a_non_mla_target_still_brings_an_mla_drafters_k_down(self):
+        """The mirror case, and the more serious one: leaving the draft K
+        quantized against an f16 draft V aborts the draft context."""
+        out = LlamaCppBackend._with_flash_attn_off(
+            list(self.DRAFT_CMD), mla = False, draft_mla = True
+        )
+        assert self._main_k(out) == "q8_0"
+        assert self._draft_k(out) == "f16"
+
+    def test_an_unknown_drafter_falls_back_to_the_target(self):
+        """None means the drafter's GGUF could not be read. An unnecessary reset
+        only costs memory; a missing one aborts, so it follows the target."""
+        out = LlamaCppBackend._with_flash_attn_off(
+            list(self.DRAFT_CMD), mla = True, draft_mla = None
+        )
+        assert self._main_k(out) == "f16"
+        assert self._draft_k(out) == "f16"
+
+    def test_the_env_pair_is_split_the_same_way(self):
+        env = {
+            "LLAMA_ARG_CACHE_TYPE_K": "q8_0",
+            "LLAMA_ARG_CACHE_TYPE_V": "q8_0",
+            "LLAMA_ARG_SPEC_DRAFT_CACHE_TYPE_K": "q8_0",
+            "LLAMA_ARG_SPEC_DRAFT_CACHE_TYPE_V": "q8_0",
+        }
+        LlamaCppBackend._drop_env_quantized_v_cache(env, mla = True, draft_mla = False)
+        assert env == {"LLAMA_ARG_SPEC_DRAFT_CACHE_TYPE_K": "q8_0"}

--- a/studio/backend/tests/test_openai_auto_switch.py
+++ b/studio/backend/tests/test_openai_auto_switch.py
@@ -7864,17 +7864,12 @@ def test_clearing_one_quant_stops_the_legacy_repo_row_from_answering(monkeypatch
     _put("unsloth/B-GGUF:Q4_K_M", llama_extra_args = [])
 
     assert settings.get_model_override("unsloth/B-GGUF:Q4_K_M") == {"llama_extra_args": []}
-    key, override = settings.resolve_override_for_load(
-        "unsloth/B-GGUF", None, "Q4_K_M"
-    )
+    key, override = settings.resolve_override_for_load("unsloth/B-GGUF", None, "Q4_K_M")
     assert key == "unsloth/B-GGUF:Q4_K_M"
     assert override.get("llama_extra_args") == []
     # And the bare row is untouched, because it is still the fallback for every other
     # quant of this repo that has no row of its own.
-    assert settings.get_model_override("unsloth/B-GGUF")["llama_extra_args"] == [
-        "--top-k",
-        "40",
-    ]
+    assert settings.get_model_override("unsloth/B-GGUF")["llama_extra_args"] == ["--top-k", "40"]
     other_key, other = settings.resolve_override_for_load("unsloth/B-GGUF", None, "Q8_0")
     assert other_key == "unsloth/B-GGUF"
     assert other["llama_extra_args"] == ["--top-k", "40"]

--- a/tests/kaggle/test_launch_cleanup.py
+++ b/tests/kaggle/test_launch_cleanup.py
@@ -386,9 +386,9 @@ def test_a_signalled_launcher_deletes_its_kernels(tmp_path, signame):
     finally:
         if proc.poll() is None:
             proc.kill()
-    assert any("me/k-1" in c for c in _deletions(tmp_path)), (
-        f"{signame} left the kernel behind; it would bill to its ceiling"
-    )
+    assert any(
+        "me/k-1" in c for c in _deletions(tmp_path)
+    ), f"{signame} left the kernel behind; it would bill to its ceiling"
     # And the registry agrees, so no later sweep chases a kernel that is gone.
     assert json.loads((tmp_path / "inflight.json").read_text()) == []
 
@@ -404,9 +404,9 @@ def test_the_exit_status_still_says_it_was_killed(tmp_path):
     finally:
         if proc.poll() is None:
             proc.kill()
-    assert proc.returncode == -signal.SIGTERM, (
-        f"expected death by SIGTERM, got returncode {proc.returncode}"
-    )
+    assert (
+        proc.returncode == -signal.SIGTERM
+    ), f"expected death by SIGTERM, got returncode {proc.returncode}"
 
 
 def test_an_unhandled_exception_still_deletes(tmp_path):
@@ -585,9 +585,9 @@ def test_a_kernel_pushed_before_the_signal_is_still_deleted(tmp_path):
         if proc.poll() is None:
             proc.kill()
     deleted = _deletions(tmp_path)
-    assert any("me/k-1" in c for c in deleted), (
-        "the kernel pushed before the signal was left running"
-    )
-    assert any("me/k-2" in c for c in deleted), (
-        "the slug the in-flight push had already filed was left running"
-    )
+    assert any(
+        "me/k-1" in c for c in deleted
+    ), "the kernel pushed before the signal was left running"
+    assert any(
+        "me/k-2" in c for c in deleted
+    ), "the slug the in-flight push had already filed was left running"

--- a/tests/studio/playwright_strip_ansi_smoke.py
+++ b/tests/studio/playwright_strip_ansi_smoke.py
@@ -47,9 +47,7 @@ def main() -> None:
         info(f"starting vite dev server on port {PORT}")
     vite = start_vite(PORT) if OWNS_SERVER else None
     try:
-        wait_for_smoke_page(
-            f"{BASE}/smoke-ansi.html", "smoke-ansi-main.tsx", proc = vite, info = info
-        )
+        wait_for_smoke_page(f"{BASE}/smoke-ansi.html", "smoke-ansi-main.tsx", proc = vite, info = info)
 
         with sync_playwright() as playwright:
             browser_name = os.environ.get("PW_BROWSER", "chromium").lower()


### PR DESCRIPTION
## The rule

`llama-context.cpp` rejects different K and V cache types on an MLA model, and that check sits **above** the V-quantization check, so it decides first:

```cpp
if ((model->hparams.is_mla() || model->arch == LLM_ARCH_DEEPSEEK4) && params.type_k != params.type_v) {
    LLAMA_LOG_ERROR("%s: model does not support different K (%s) and V (%s) cache types\n", ...);
    return nullptr;
}

if (ggml_is_quantized(params.type_v) && params.flash_attn_type != LLAMA_FLASH_ATTN_TYPE_ENABLED) {
    ...
    LLAMA_LOG_ERROR("%s: quantized V cache requires flash_attn to be enabled\n", __func__);
    return nullptr;
}
```

`is_mla()` covers DeepSeek V2/V3/R1, Kimi K2 and GLM-4.7/5.x, all of which Studio already recognises through `kv_lora_rank`.

## What goes wrong

`_reset_quantized_v_cache` resets a quantized V cache to f16 and leaves K quantized on purpose: a quantized K needs no flash attention, and resetting it enlarges the cache for nothing. That reasoning predates the MLA rule.

On an MLA model the result is `K=q8_0 V=f16`, which is a hard abort for a **different** reason than the one being avoided. The crash-recovery rung exists to recover from a flash-attention failure, and now it cannot start either. Someone on DeepSeek or Kimi with a quantized KV cache hits the FA crash the rung was written for, and the recovery attempt dies on the K/V mismatch.

| model | before | after |
|---|---|---|
| MLA, quantized KV | `K=q8_0 V=f16` (abort) | `K=f16 V=f16` |
| non-MLA, quantized KV | `K=q8_0 V=f16` | unchanged |
| any, unquantized KV | untouched | untouched |
| MLA, quantized K only | untouched | untouched |

Both axes go to f16 together on MLA. Equal is what the rule asks for, and f16 is the only value that also satisfies the V rule. Non-MLA is untouched, and the parameter defaults to the old behaviour so an un-updated caller keeps today's answer.

## Reachability, ranked honestly

- **`_with_flash_attn_off`, pre-existing.** This is the reachable one. It has always produced the asymmetry; the upstream rule turned it fatal.
- **The launch-site reset added in #8710.** Same helper, fixed by the same change. On a genuine binary it is close to unreachable: `-fa` landed 2024-04-30 and quantized KV support a month later, so no upstream build has ever accepted a quantized `-ctv` while lacking `--flash-attn`. It still matters for a wrapper that hides `-fa` from `--help`.

So this is not a regression from #8710. It extended a helper whose K-untouched policy had become unsafe upstream.

## A test-harness fix this exposed

`_flagless_v_cache_fixup` bound the class as `self`, so the block reading `self._kv_lora_rank` raised `AttributeError` inside the harness rather than failing on its merits. It now binds a shim that carries instance state and falls through to the class. Any future `self.<attr>` in that block will work rather than break the harness.

## Tests

10 new. 87 pass in the two suites that own this, 2159 across the llama.cpp, flash-attention, cache-type, launch-flag and Metal suites. Coverage includes the inline `=` spelling, the draft pair, an unquantized KV (nothing moves), a quantized K alone (the MLA branch must not fire, since no V reset happened), and the non-MLA default.

Three failures in `test_video_backend.py` and `test_video_prequant.py` are present on `main` unchanged.

## Not verified

No MLA GGUF was launched against a real `llama-server`. The upstream rule is read from `llama-context.cpp` and the behaviour is verified against the shipped code executed directly. Worth a real DeepSeek or Kimi launch before this is trusted end to end.
