### PR TITLE
Bump install.sh / install.ps1 pin to unsloth>=2026.8.18

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -4905,7 +4905,7 @@ exit 0
         if ($SkipTorch) {
             # No-torch: install unsloth + unsloth-zoo with --no-deps, then
             # runtime deps (typer, safetensors, transformers, etc.) with --no-deps.
-            $baseInstallExit = Invoke-InstallCommandRetry -Label "install unsloth (migrated no-torch)" { & $script:UvExe pip install --python $VenvPython --no-deps --reinstall-package unsloth --reinstall-package unsloth-zoo "unsloth>=2026.8.17" "unsloth-zoo>=2026.8.12" }
+            $baseInstallExit = Invoke-InstallCommandRetry -Label "install unsloth (migrated no-torch)" { & $script:UvExe pip install --python $VenvPython --no-deps --reinstall-package unsloth --reinstall-package unsloth-zoo "unsloth>=2026.8.18" "unsloth-zoo>=2026.8.12" }
             if ($baseInstallExit -eq 0) {
                 # Resolve pydantic WITH deps so pip pins pydantic-core
                 # to the matching version (no-torch-runtime.txt below
@@ -4919,7 +4919,7 @@ exit 0
                 }
             }
         } else {
-            $baseInstallExit = Invoke-InstallCommandRetry -Label "install unsloth (migrated)" { & $script:UvExe pip install --python $VenvPython --reinstall-package unsloth --reinstall-package unsloth-zoo "unsloth>=2026.8.17" "unsloth-zoo>=2026.8.12" }
+            $baseInstallExit = Invoke-InstallCommandRetry -Label "install unsloth (migrated)" { & $script:UvExe pip install --python $VenvPython --reinstall-package unsloth --reinstall-package unsloth-zoo "unsloth>=2026.8.18" "unsloth-zoo>=2026.8.12" }
         }
         if ($baseInstallExit -ne 0) {
             Write-StudioLine "[ERROR] Failed to install unsloth (exit code $baseInstallExit)" -ForegroundColor Red
@@ -5046,7 +5046,7 @@ exit 0
         if ($SkipTorch) {
             # No-torch: install unsloth + unsloth-zoo with --no-deps, then
             # runtime deps (typer, safetensors, transformers, etc.) with --no-deps.
-            $baseInstallExit = Invoke-InstallCommandRetry -Label "install unsloth (no-torch)" { & $script:UvExe pip install --python $VenvPython --no-deps --upgrade-package unsloth --upgrade-package unsloth-zoo "unsloth>=2026.8.17" "unsloth-zoo>=2026.8.12" }
+            $baseInstallExit = Invoke-InstallCommandRetry -Label "install unsloth (no-torch)" { & $script:UvExe pip install --python $VenvPython --no-deps --upgrade-package unsloth --upgrade-package unsloth-zoo "unsloth>=2026.8.18" "unsloth-zoo>=2026.8.12" }
             if ($baseInstallExit -eq 0) {
                 # Same pydantic-with-deps trick as the migrated branch.
                 $baseInstallExit = Invoke-InstallCommandRetry -Label "install pydantic" { & $script:UvExe pip install --python $VenvPython pydantic }
@@ -5058,7 +5058,7 @@ exit 0
                 }
             }
         } elseif ($StudioLocalInstall) {
-            $baseInstallExit = Invoke-InstallCommandRetry -Label "install unsloth (local)" { & $script:UvExe pip install --python $VenvPython --upgrade-package unsloth "unsloth>=2026.8.17" "unsloth-zoo>=2026.8.12" }
+            $baseInstallExit = Invoke-InstallCommandRetry -Label "install unsloth (local)" { & $script:UvExe pip install --python $VenvPython --upgrade-package unsloth "unsloth>=2026.8.18" "unsloth-zoo>=2026.8.12" }
         } else {
             $baseInstallExit = Invoke-InstallCommandRetry -Label "install unsloth" { & $script:UvExe pip install --python $VenvPython --upgrade-package unsloth -- "$PackageName" }
         }
@@ -5086,7 +5086,7 @@ exit 0
         Write-TauriLog "STEP" "Installing unsloth"
         substep "installing unsloth (this may take a few minutes)..."
         if ($StudioLocalInstall) {
-            $baseInstallExit = Invoke-InstallCommandRetry -Label "install unsloth (auto torch backend)" { & $script:UvExe pip install --python $VenvPython "unsloth-zoo>=2026.8.12" "unsloth>=2026.8.17" --torch-backend=auto }
+            $baseInstallExit = Invoke-InstallCommandRetry -Label "install unsloth (auto torch backend)" { & $script:UvExe pip install --python $VenvPython "unsloth-zoo>=2026.8.12" "unsloth>=2026.8.18" --torch-backend=auto }
             if ($baseInstallExit -ne 0) {
                 Write-StudioLine "[ERROR] Failed to install unsloth (exit code $baseInstallExit)" -ForegroundColor Red
                 return (Exit-InstallFailure "Failed to install unsloth (exit code $baseInstallExit)" $baseInstallExit)

--- a/install.sh
+++ b/install.sh
@@ -4952,7 +4952,7 @@ if [ "$_MIGRATED" = true ]; then
         # to prevent transitive torch resolution.
         run_install_cmd_retry "install unsloth (migrated no-torch)" uv pip install --python "$_VENV_PY" --no-deps \
             --reinstall-package unsloth --reinstall-package unsloth-zoo \
-            "unsloth>=2026.8.17" "unsloth-zoo>=2026.8.12"
+            "unsloth>=2026.8.18" "unsloth-zoo>=2026.8.12"
         # Resolve pydantic WITH deps so pip pins pydantic-core to the
         # matching version (no-torch-runtime.txt below is --no-deps).
         # All transitive deps are torch-free.
@@ -4967,7 +4967,7 @@ if [ "$_MIGRATED" = true ]; then
         run_install_cmd_retry "install unsloth (migrated)" uv pip install --python "$_VENV_PY" \
             ${_UNSLOTH_TORCH_OVERRIDES:+--overrides "$_UNSLOTH_TORCH_OVERRIDES"} \
             --reinstall-package unsloth --reinstall-package unsloth-zoo \
-            "unsloth>=2026.8.17" "unsloth-zoo>=2026.8.12"
+            "unsloth>=2026.8.18" "unsloth-zoo>=2026.8.12"
         [ -n "$_UNSLOTH_TORCH_OVERRIDES" ] && rm -f "$_UNSLOTH_TORCH_OVERRIDES"
         _UNSLOTH_TORCH_OVERRIDES=""
     fi
@@ -5201,7 +5201,7 @@ elif [ -n "$TORCH_INDEX_URL" ]; then
         # runtime deps (typer, safetensors, transformers, etc.) with --no-deps.
         run_install_cmd_retry "install unsloth (no-torch)" uv pip install --python "$_VENV_PY" --no-deps \
             --upgrade-package unsloth --upgrade-package unsloth-zoo \
-            "unsloth>=2026.8.17" "unsloth-zoo>=2026.8.12"
+            "unsloth>=2026.8.18" "unsloth-zoo>=2026.8.12"
         # Same pydantic-with-deps trick as the migrated branch.
         run_install_cmd_retry "install pydantic (with deps for compatible core)" \
             uv pip install --python "$_VENV_PY" pydantic
@@ -5220,7 +5220,7 @@ elif [ -n "$TORCH_INDEX_URL" ]; then
     elif [ "$STUDIO_LOCAL_INSTALL" = true ]; then
         run_install_cmd_retry "install unsloth (local)" uv pip install --python "$_VENV_PY" \
             ${_UNSLOTH_TORCH_OVERRIDES:+--overrides "$_UNSLOTH_TORCH_OVERRIDES"} \
-            --upgrade-package unsloth "unsloth>=2026.8.17" "unsloth-zoo>=2026.8.12"
+            --upgrade-package unsloth "unsloth>=2026.8.18" "unsloth-zoo>=2026.8.12"
         substep "overlaying local repo (editable)..."
         run_install_cmd "overlay local repo" uv pip install --python "$_VENV_PY" -e "$_REPO_ROOT" --no-deps
         substep "overlaying unsloth-zoo from git main..."
@@ -5249,7 +5249,7 @@ else
     tauri_log "STEP" "Installing Unsloth"
     substep "installing unsloth (this may take a few minutes)..."
     if [ "$STUDIO_LOCAL_INSTALL" = true ]; then
-        run_install_cmd_retry "install unsloth (auto torch backend)" uv pip install --python "$_VENV_PY" "unsloth-zoo>=2026.8.12" "unsloth>=2026.8.17" --torch-backend=auto
+        run_install_cmd_retry "install unsloth (auto torch backend)" uv pip install --python "$_VENV_PY" "unsloth-zoo>=2026.8.12" "unsloth>=2026.8.18" --torch-backend=auto
         substep "overlaying local repo (editable)..."
         run_install_cmd "overlay local repo" uv pip install --python "$_VENV_PY" -e "$_REPO_ROOT" --no-deps
         substep "overlaying unsloth-zoo from git main..."

--- a/studio/backend/tests/test_openai_auto_switch.py
+++ b/studio/backend/tests/test_openai_auto_switch.py
@@ -7864,17 +7864,12 @@ def test_clearing_one_quant_stops_the_legacy_repo_row_from_answering(monkeypatch
     _put("unsloth/B-GGUF:Q4_K_M", llama_extra_args = [])
 
     assert settings.get_model_override("unsloth/B-GGUF:Q4_K_M") == {"llama_extra_args": []}
-    key, override = settings.resolve_override_for_load(
-        "unsloth/B-GGUF", None, "Q4_K_M"
-    )
+    key, override = settings.resolve_override_for_load("unsloth/B-GGUF", None, "Q4_K_M")
     assert key == "unsloth/B-GGUF:Q4_K_M"
     assert override.get("llama_extra_args") == []
     # And the bare row is untouched, because it is still the fallback for every other
     # quant of this repo that has no row of its own.
-    assert settings.get_model_override("unsloth/B-GGUF")["llama_extra_args"] == [
-        "--top-k",
-        "40",
-    ]
+    assert settings.get_model_override("unsloth/B-GGUF")["llama_extra_args"] == ["--top-k", "40"]
     other_key, other = settings.resolve_override_for_load("unsloth/B-GGUF", None, "Q8_0")
     assert other_key == "unsloth/B-GGUF"
     assert other["llama_extra_args"] == ["--top-k", "40"]

--- a/tests/kaggle/test_launch_cleanup.py
+++ b/tests/kaggle/test_launch_cleanup.py
@@ -386,9 +386,9 @@ def test_a_signalled_launcher_deletes_its_kernels(tmp_path, signame):
     finally:
         if proc.poll() is None:
             proc.kill()
-    assert any("me/k-1" in c for c in _deletions(tmp_path)), (
-        f"{signame} left the kernel behind; it would bill to its ceiling"
-    )
+    assert any(
+        "me/k-1" in c for c in _deletions(tmp_path)
+    ), f"{signame} left the kernel behind; it would bill to its ceiling"
     # And the registry agrees, so no later sweep chases a kernel that is gone.
     assert json.loads((tmp_path / "inflight.json").read_text()) == []
 
@@ -404,9 +404,9 @@ def test_the_exit_status_still_says_it_was_killed(tmp_path):
     finally:
         if proc.poll() is None:
             proc.kill()
-    assert proc.returncode == -signal.SIGTERM, (
-        f"expected death by SIGTERM, got returncode {proc.returncode}"
-    )
+    assert (
+        proc.returncode == -signal.SIGTERM
+    ), f"expected death by SIGTERM, got returncode {proc.returncode}"
 
 
 def test_an_unhandled_exception_still_deletes(tmp_path):
@@ -585,9 +585,9 @@ def test_a_kernel_pushed_before_the_signal_is_still_deleted(tmp_path):
         if proc.poll() is None:
             proc.kill()
     deleted = _deletions(tmp_path)
-    assert any("me/k-1" in c for c in deleted), (
-        "the kernel pushed before the signal was left running"
-    )
-    assert any("me/k-2" in c for c in deleted), (
-        "the slug the in-flight push had already filed was left running"
-    )
+    assert any(
+        "me/k-1" in c for c in deleted
+    ), "the kernel pushed before the signal was left running"
+    assert any(
+        "me/k-2" in c for c in deleted
+    ), "the slug the in-flight push had already filed was left running"

--- a/tests/studio/playwright_strip_ansi_smoke.py
+++ b/tests/studio/playwright_strip_ansi_smoke.py
@@ -47,9 +47,7 @@ def main() -> None:
         info(f"starting vite dev server on port {PORT}")
     vite = start_vite(PORT) if OWNS_SERVER else None
     try:
-        wait_for_smoke_page(
-            f"{BASE}/smoke-ansi.html", "smoke-ansi-main.tsx", proc = vite, info = info
-        )
+        wait_for_smoke_page(f"{BASE}/smoke-ansi.html", "smoke-ansi-main.tsx", proc = vite, info = info)
 
         with sync_playwright() as playwright:
             browser_name = os.environ.get("PW_BROWSER", "chromium").lower()


### PR DESCRIPTION
## Summary

- PyPI release [unsloth 2026.8.18](https://pypi.org/project/unsloth/2026.8.18/) is now live.
- Bumps the pinned floor in `install.sh` and `install.ps1` from `unsloth>=2026.8.17` to `unsloth>=2026.8.18` so fresh installs resolve to the new wheel.
- Updates all 5 install commands in each of `install.sh` and `install.ps1` (migrated no-torch / migrated / no-torch / local / auto torch backend paths).
- `unsloth-zoo>=2026.8.12` is unchanged; it already matches the current unsloth-zoo release and the `unsloth_zoo>=2026.8.12` floor in `pyproject.toml`.
- This wheel carries the `v0.1.800-beta` Studio release stamp, which is what the desktop release verifies against.

Follows the same pattern as #5716 and #8831.

## Test plan

- [ ] Sanity-run `install.sh` on a clean Linux host
- [ ] Sanity-run `install.ps1` on a clean Windows host
- [ ] Confirm `uv pip install "unsloth>=2026.8.18"` resolves cleanly