### PR TITLE
Studio: stop the chat UI falling behind a fast stream

### DIFF
--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -6137,9 +6137,8 @@ export function createOpenAIStreamAdapter(
               if (
                 reasoningDurationTracker.hasActiveGroup &&
                 !reasoningContentOpen &&
-                // The publishing chunk's flag only: a coalesced chunk never reaches
-                // here. Every finish re-measures from the group's start, so the
-                // final one still lands the right duration.
+                // The publishing chunk's flag only. Every finish re-measures from
+                // the group's start, so a coalesced chunk's dropped flag cannot skew it.
                 !structuredReasoningContinues &&
                 !hasUnclosedThinkTag(cumulativeText)
               ) {

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -5877,6 +5877,12 @@ export function createOpenAIStreamAdapter(
                     };
                   }
                 }
+                // Ungated and state-bearing, so it can be the first publish to
+                // expose a group the gate is holding: an external provider can
+                // synthesize a _toolEvent with no delta.tool_calls fragment
+                // before it.
+                reconcileReasoning(liveAssistantContent(), gateHeldSince);
+                gateHeldSince = undefined;
                 yield {
                   content: liveAssistantContent(),
                   metadata: {
@@ -6213,6 +6219,16 @@ export function createOpenAIStreamAdapter(
                   "",
                 );
               }
+              // Stamped before the close below can read it. Assigning it only
+              // in the skip branch meant a chunk carrying a COMPLETE
+              // <think>...</think> block stamped its start after its own end
+              // check had already run, so the end fell to the next arrival and
+              // any pause in between was charged to the reasoning. Cleared on
+              // every publish, so stamping a chunk that turns out to publish is
+              // harmless.
+              if (reasoning || delta.includes("<think>")) {
+                gateHeldSince ??= Date.now();
+              }
               // Closing a group reads only pre-gate state, so it runs on every
               // arrival: deferring it to the next publish let a pause after the
               // reasoning ended count as part of the reasoning. Only the START
@@ -6246,13 +6262,6 @@ export function createOpenAIStreamAdapter(
               // Coalesce text arriving before the next frame; cumulativeText
               // keeps it, and the cap publishes before a stop could drop it.
               if (!replayStateChanged && !canPublish(streamedChars)) {
-                // Only when the held chunk actually carries reasoning. Stamping
-                // on any held chunk backdated a group to a prose delta that
-                // arrived before reasoning began, which inflates the duration by
-                // the gap between them.
-                if (reasoning || delta.includes("<think>")) {
-                  gateHeldSince ??= Date.now();
-                }
                 continue;
               }
               const reasoningSeenAt = gateHeldSince;

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -4501,9 +4501,8 @@ export function createOpenAIStreamAdapter(
       // Seeded with the partial so the bubble reads as one response; the boundary lets
       // the finalizers re-derive the new output and repair a repeat/restart.
       let cumulativeText = continuation ? continuation.partial : "";
-      // What the publish gate bounds. Only ever grows, unlike cumulativeText, which
-      // the ${...} strip below can shorten, and it also counts the tool-argument
-      // deltas that never reach cumulativeText at all.
+      // What the gate bounds. Only grows, unlike cumulativeText, which the
+      // ${...} strip can shorten, and it counts tool-argument deltas too.
       let streamedChars = 0;
       const continuationPartial = continuation?.partial ?? "";
       // Local backends (and a self-hosted vLLM / llama-server, which get the flags)
@@ -4519,17 +4518,15 @@ export function createOpenAIStreamAdapter(
               text.slice(continuationPartial.length),
             )
           : text;
-      // The publish gate can hide a reasoning group entirely: if every chunk
-      // that revealed it was coalesced away, the tracker never started it and
-      // the persisted durations would have a hole where the rendered panel has
-      // a group. Both terminal publishes call this before reading metadata().
+      // A group whose every revealing chunk the gate coalesced away was never
+      // started, leaving a hole in the persisted durations where the panel
+      // renders a group. Both terminal publishes call this before metadata().
       const adoptGatedReasoningGroups = (
         content: readonly { type?: unknown; text?: unknown }[],
       ) => {
         const groups = countReasoningGroups(content);
         if (groups > reasoningDurationTracker.groupCount) {
-          // startGroup back-fills every index it skips, so one call fills the
-          // whole hole, not just the last group.
+          // startGroup back-fills the indexes it skips, so one call is enough.
           reasoningDurationTracker.startGroup(groups - 1);
         }
       };
@@ -5510,10 +5507,10 @@ export function createOpenAIStreamAdapter(
                         args: partial.args as ToolCallMessagePart["args"],
                         argsText: partial.argsText,
                       };
-                      // Gated like the text path: this preview repeats per argument
-                      // delta and tool_start replaces it with the authoritative
-                      // parse. The tool events themselves are rare and carry the
-                      // card's state, so they publish ungated.
+                      // Gated like the text path: this preview repeats per
+                      // argument delta and tool_start replaces it with the
+                      // authoritative parse. The tool events are rare and carry
+                      // the card's state, so those publish ungated.
                       if (canPublish(streamedChars)) {
                         yield {
                           content: liveAssistantContent(),
@@ -5972,11 +5969,10 @@ export function createOpenAIStreamAdapter(
                 rawDeltaToolCalls.length > 0
               ) {
                 closeReasoningContent();
-                // A fragment that only extends an existing call's arguments is
-                // the same per-delta preview as tool_args, so it is gated the
-                // same way. A fragment that introduces a call is not: that is
-                // the state an aborted turn would otherwise lose, so it always
-                // publishes.
+                // A fragment extending an existing call's arguments is the same
+                // per-delta preview as tool_args, so it is gated the same way.
+                // One that introduces a call always publishes: that is state an
+                // aborted turn would otherwise lose.
                 let addedToolCall = false;
                 for (const tc of rawDeltaToolCalls) {
                   if (!tc || typeof tc !== "object") continue;
@@ -6137,18 +6133,17 @@ export function createOpenAIStreamAdapter(
                   "",
                 );
               }
-              // A chunk the strip above emptied has nothing to show, and the
-              // yield below is skipped for it anyway. Asking the gate first
-              // would spend this cycle's publish on it and hold the next real
-              // chunk, so leave the gate untouched.
+              // A chunk the strip emptied has nothing to show and is skipped
+              // below anyway; asking the gate would spend this cycle's publish
+              // on it and hold the next real chunk.
               if (
                 mergeContinuation(cumulativeText).length === 0 &&
                 toolCallParts.length === 0
               ) {
                 continue;
               }
-              // Coalesce text received before the next frame; cumulativeText retains
-              // it. The gate publishes anyway once it holds more than a stop may drop.
+              // Coalesce text arriving before the next frame; cumulativeText
+              // keeps it, and the cap publishes before a stop could drop it.
               if (!canPublish(streamedChars)) {
                 continue;
               }
@@ -6178,8 +6173,8 @@ export function createOpenAIStreamAdapter(
               if (
                 reasoningDurationTracker.hasActiveGroup &&
                 !reasoningContentOpen &&
-                // The publishing chunk's flag only. Every finish re-measures from
-                // the group's start, so a coalesced chunk's dropped flag cannot skew it.
+                // The publishing chunk's flag only; every finish re-measures
+                // from the group's start, so a dropped flag cannot skew it.
                 !structuredReasoningContinues &&
                 !hasUnclosedThinkTag(cumulativeText)
               ) {
@@ -6310,9 +6305,7 @@ export function createOpenAIStreamAdapter(
           finalTokPerSec,
         );
 
-        // Finalize reasoning-only streams. A group whose only chunks the gate
-        // skipped was never started, so adopt it here or the persisted durations
-        // would have a hole where the rendered panel has a group.
+        // Finalize reasoning-only streams.
         const finalContent = buildAssistantContent(
           mergeContinuation(cumulativeText),
         );
@@ -6395,8 +6388,7 @@ export function createOpenAIStreamAdapter(
           const partialText = mergeContinuation(cumulativeText);
           const partialContent = buildAssistantContent(partialText);
           if (partialContent.length > 0) {
-            // Same hole as the success path: this partial can render a group
-            // the gate never let the tracker see.
+            // This partial can render a group the gate hid from the tracker.
             adoptGatedReasoningGroups(partialContent);
             reasoningDurationTracker.finishGroup();
             const partialTiming = buildTiming(

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -158,7 +158,7 @@ import {
   hasUnclosedThinkTag,
   parseAssistantContent,
 } from "../utils/parse-assistant-content";
-import { createFrameGate } from "../utils/stream-pacing";
+import { createStreamPublishGate } from "../utils/stream-pacing";
 import {
   countReasoningGroups,
   createReasoningDurationTracker,
@@ -5326,7 +5326,7 @@ export function createOpenAIStreamAdapter(
             requestedMaxTokens = requestPayload.max_tokens;
             await ThreadAutosaveHandle.awaitFirstSave(resolvedThreadId);
             const stream = streamChatCompletions(requestPayload, runSignal);
-            const canPublish = createFrameGate();
+            const canPublish = createStreamPublishGate();
 
             for await (const chunk of stream) {
               const chunkModel = (chunk as { model?: unknown }).model;
@@ -5491,17 +5491,23 @@ export function createOpenAIStreamAdapter(
                         args: partial.args as ToolCallMessagePart["args"],
                         argsText: partial.argsText,
                       };
-                      yield {
-                        content: liveAssistantContent(),
-                        metadata: {
-                          timing: buildTiming(
-                            streamStartTime,
-                            totalChunks,
-                            firstTokenTime,
-                          ),
-                          custom: liveCustom(),
-                        },
-                      };
+                      // Gated like the text path: this preview repeats per argument
+                      // delta and tool_start replaces it with the authoritative
+                      // parse. The tool events themselves are rare and carry the
+                      // card's state, so they publish ungated.
+                      if (canPublish(cumulativeText.length)) {
+                        yield {
+                          content: liveAssistantContent(),
+                          metadata: {
+                            timing: buildTiming(
+                              streamStartTime,
+                              totalChunks,
+                              firstTokenTime,
+                            ),
+                            custom: liveCustom(),
+                          },
+                        };
+                      }
                     }
                   }
                   continue;
@@ -6100,8 +6106,9 @@ export function createOpenAIStreamAdapter(
                   "",
                 );
               }
-              // Coalesce text received before the next frame; cumulativeText retains it.
-              if (!canPublish()) {
+              // Coalesce text received before the next frame; cumulativeText retains
+              // it. The gate publishes anyway once it holds more than a stop may drop.
+              if (!canPublish(cumulativeText.length)) {
                 continue;
               }
               const assistantContent = liveAssistantContent();
@@ -6130,6 +6137,9 @@ export function createOpenAIStreamAdapter(
               if (
                 reasoningDurationTracker.hasActiveGroup &&
                 !reasoningContentOpen &&
+                // The publishing chunk's flag only: a coalesced chunk never reaches
+                // here. Every finish re-measures from the group's start, so the
+                // final one still lands the right duration.
                 !structuredReasoningContinues &&
                 !hasUnclosedThinkTag(cumulativeText)
               ) {

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -4536,6 +4536,28 @@ export function createOpenAIStreamAdapter(
           reasoningDurationTracker.startGroup(groups - 1, firstSeenAt);
         }
       };
+      /**
+       * The whole tracker transition for a publish, not just the start: adopting
+       * a group and leaving it open publishes a group with no duration behind
+       * it, and leaves the timer running across whatever comes next. Every path
+       * that yields has to do all three, so they share one implementation.
+       */
+      const reconcileReasoning = (
+        content: readonly { type?: unknown; text?: unknown }[],
+        firstSeenAt?: number,
+      ) => {
+        adoptGatedReasoningGroups(content, firstSeenAt);
+        const groups = countReasoningGroups(content);
+        if (groups > 0) {
+          reasoningDurationTracker.resumeGroup(
+            groups - 1,
+            lastReasoningGroupTextLength(content),
+          );
+          if (!hasUnclosedThinkTag(cumulativeText)) {
+            reasoningDurationTracker.finishGroup();
+          }
+        }
+      };
       // Every streamed yield carries the repaired text, not just the terminal ones:
       // assistant-ui drops whatever is yielded after an abort, so on Stop the last
       // STREAMED yield is what gets saved.
@@ -6098,14 +6120,42 @@ export function createOpenAIStreamAdapter(
                     addedToolCall = true;
                   }
                 }
-                if (addedToolCall || canPublish(streamedChars)) {
+                if (
+                  addedToolCall ||
+                  replayStateChanged ||
+                  canPublish(streamedChars)
+                ) {
                   // This publish can be the first to expose a reasoning group
-                  // the gate was holding. Reconcile before yielding, or a Stop
-                  // during the tool run persists content with a group the
-                  // durations know nothing about.
-                  adoptGatedReasoningGroups(liveAssistantContent(), gateHeldSince);
+                  // the gate was holding. Starting it is not enough: left open
+                  // it yields with no duration and keeps timing across the tool
+                  // run, so run the full transition.
+                  reconcileReasoning(liveAssistantContent(), gateHeldSince);
+                  gateHeldSince = undefined;
                   yield {
                     content: liveAssistantContent(),
+                    metadata: {
+                      timing: buildTiming(
+                        streamStartTime,
+                        totalChunks,
+                        firstTokenTime,
+                      ),
+                      custom: liveCustom(),
+                    },
+                  };
+                }
+                continue;
+              }
+              // A chunk whose ONLY payload is extra_content: Gemini 3 ships a
+              // content-free thoughtSignature fragment, and the Codex client
+              // puts its reasoning ledger on a text-free terminal delta. The
+              // skip below would drop both before the gate ever sees them, so
+              // the metadata would reach the message only if some later chunk
+              // happened to publish.
+              if (replayStateChanged && !delta && !reasoning) {
+                const replayContent = liveAssistantContent();
+                if (replayContent.length > 0) {
+                  yield {
+                    content: replayContent,
                     metadata: {
                       timing: buildTiming(
                         streamStartTime,
@@ -6189,28 +6239,10 @@ export function createOpenAIStreamAdapter(
               gateHeldSince = undefined;
               const assistantContent = liveAssistantContent();
 
-              // Fallback when no server-side reasoning_summary arrives.
-              const parsedReasoningGroupCount =
-                countReasoningGroups(assistantContent);
-              if (
-                parsedReasoningGroupCount >
-                reasoningDurationTracker.groupCount
-              ) {
-                reasoningDurationTracker.startGroup(
-                  parsedReasoningGroupCount - 1,
-                  reasoningSeenAt,
-                );
-              }
-              if (parsedReasoningGroupCount > 0) {
-                // Providers that close every reasoning block atomically
-                // (structured parts wrapped as <think>..</think>) end the group
-                // on each chunk. Reopen while the reasoning text is still
-                // growing so the timer spans the whole pass.
-                reasoningDurationTracker.resumeGroup(
-                  parsedReasoningGroupCount - 1,
-                  lastReasoningGroupTextLength(assistantContent),
-                );
-              }
+              // Fallback when no server-side reasoning_summary arrives. Shared
+              // with the forced tool-call publish, which needs the same three
+              // transitions and used to do only the first.
+              reconcileReasoning(assistantContent, reasoningSeenAt);
               if (assistantContent.length > 0) {
                 yield {
                   content: assistantContent,

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -4501,6 +4501,10 @@ export function createOpenAIStreamAdapter(
       // Seeded with the partial so the bubble reads as one response; the boundary lets
       // the finalizers re-derive the new output and repair a repeat/restart.
       let cumulativeText = continuation ? continuation.partial : "";
+      // What the publish gate bounds. Only ever grows, unlike cumulativeText, which
+      // the ${...} strip below can shorten, and it also counts the tool-argument
+      // deltas that never reach cumulativeText at all.
+      let streamedChars = 0;
       const continuationPartial = continuation?.partial ?? "";
       // Local backends (and a self-hosted vLLM / llama-server, which get the flags)
       // resume at the exact token boundary, so their output is already the rest of the
@@ -5478,6 +5482,7 @@ export function createOpenAIStreamAdapter(
                     const accum =
                       (liveArgsTextById.get(liveId) ?? "") + fragment;
                     liveArgsTextById.set(liveId, accum);
+                    streamedChars += fragment.length;
                     const partial = parseLiveToolArgs(accum);
                     const idx = toolCallParts.findIndex(
                       (p) => p.toolCallId === liveId,
@@ -5495,7 +5500,7 @@ export function createOpenAIStreamAdapter(
                       // delta and tool_start replaces it with the authoritative
                       // parse. The tool events themselves are rare and carry the
                       // card's state, so they publish ungated.
-                      if (canPublish(cumulativeText.length)) {
+                      if (canPublish(streamedChars)) {
                         yield {
                           content: liveAssistantContent(),
                           metadata: {
@@ -6098,6 +6103,7 @@ export function createOpenAIStreamAdapter(
                 }
                 cumulativeText += delta;
               }
+              streamedChars += reasoning.length + delta.length;
               // Strip a trailing ${...} template-literal fragment from
               // external streams (mistral magistral occasionally emits one).
               if (isExternalRequest) {
@@ -6108,7 +6114,7 @@ export function createOpenAIStreamAdapter(
               }
               // Coalesce text received before the next frame; cumulativeText retains
               // it. The gate publishes anyway once it holds more than a stop may drop.
-              if (!canPublish(cumulativeText.length)) {
+              if (!canPublish(streamedChars)) {
                 continue;
               }
               const assistantContent = liveAssistantContent();
@@ -6269,11 +6275,20 @@ export function createOpenAIStreamAdapter(
           finalTokPerSec,
         );
 
-        // Finalize reasoning-only streams.
+        // Finalize reasoning-only streams. A group whose only chunks the gate
+        // skipped was never started, so adopt it here or the persisted durations
+        // would have a hole where the rendered panel has a group.
+        const finalContent = buildAssistantContent(
+          mergeContinuation(cumulativeText),
+        );
+        const finalReasoningGroups = countReasoningGroups(finalContent);
+        if (finalReasoningGroups > reasoningDurationTracker.groupCount) {
+          reasoningDurationTracker.startGroup(finalReasoningGroups - 1);
+        }
         reasoningDurationTracker.finishGroup();
         yield {
           content: [
-            ...buildAssistantContent(mergeContinuation(cumulativeText)),
+            ...finalContent,
             ...sourceParts,
             ...documentCitationParts,
           ],

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -4519,6 +4519,20 @@ export function createOpenAIStreamAdapter(
               text.slice(continuationPartial.length),
             )
           : text;
+      // The publish gate can hide a reasoning group entirely: if every chunk
+      // that revealed it was coalesced away, the tracker never started it and
+      // the persisted durations would have a hole where the rendered panel has
+      // a group. Both terminal publishes call this before reading metadata().
+      const adoptGatedReasoningGroups = (
+        content: readonly { type?: unknown; text?: unknown }[],
+      ) => {
+        const groups = countReasoningGroups(content);
+        if (groups > reasoningDurationTracker.groupCount) {
+          // startGroup back-fills every index it skips, so one call fills the
+          // whole hole, not just the last group.
+          reasoningDurationTracker.startGroup(groups - 1);
+        }
+      };
       // Every streamed yield carries the repaired text, not just the terminal ones:
       // assistant-ui drops whatever is yielded after an abort, so on Stop the last
       // STREAMED yield is what gets saved.
@@ -5958,6 +5972,12 @@ export function createOpenAIStreamAdapter(
                 rawDeltaToolCalls.length > 0
               ) {
                 closeReasoningContent();
+                // A fragment that only extends an existing call's arguments is
+                // the same per-delta preview as tool_args, so it is gated the
+                // same way. A fragment that introduces a call is not: that is
+                // the state an aborted turn would otherwise lose, so it always
+                // publishes.
+                let addedToolCall = false;
                 for (const tc of rawDeltaToolCalls) {
                   if (!tc || typeof tc !== "object") continue;
                   const call = tc as {
@@ -5995,6 +6015,8 @@ export function createOpenAIStreamAdapter(
                     );
                   }
                   const argsFragment = call.function?.arguments ?? "";
+                  streamedChars +=
+                    argsFragment.length + (call.function?.name?.length ?? 0);
                   if (existing) {
                     const prevName = existing.toolName ?? "";
                     const nextName = call.function?.name ?? prevName;
@@ -6063,19 +6085,22 @@ export function createOpenAIStreamAdapter(
                       ...(idx !== undefined ? { _delta_index: idx } : {}),
                     };
                     toolCallParts.push(fresh);
+                    addedToolCall = true;
                   }
                 }
-                yield {
-                  content: liveAssistantContent(),
-                  metadata: {
-                    timing: buildTiming(
-                      streamStartTime,
-                      totalChunks,
-                      firstTokenTime,
-                    ),
-                    custom: liveCustom(),
-                  },
-                };
+                if (addedToolCall || canPublish(streamedChars)) {
+                  yield {
+                    content: liveAssistantContent(),
+                    metadata: {
+                      timing: buildTiming(
+                        streamStartTime,
+                        totalChunks,
+                        firstTokenTime,
+                      ),
+                      custom: liveCustom(),
+                    },
+                  };
+                }
                 continue;
               }
               if (!delta && !reasoning) {
@@ -6111,6 +6136,16 @@ export function createOpenAIStreamAdapter(
                   /\s*\$\{[^}]*\}\s*$/,
                   "",
                 );
+              }
+              // A chunk the strip above emptied has nothing to show, and the
+              // yield below is skipped for it anyway. Asking the gate first
+              // would spend this cycle's publish on it and hold the next real
+              // chunk, so leave the gate untouched.
+              if (
+                mergeContinuation(cumulativeText).length === 0 &&
+                toolCallParts.length === 0
+              ) {
+                continue;
               }
               // Coalesce text received before the next frame; cumulativeText retains
               // it. The gate publishes anyway once it holds more than a stop may drop.
@@ -6281,10 +6316,7 @@ export function createOpenAIStreamAdapter(
         const finalContent = buildAssistantContent(
           mergeContinuation(cumulativeText),
         );
-        const finalReasoningGroups = countReasoningGroups(finalContent);
-        if (finalReasoningGroups > reasoningDurationTracker.groupCount) {
-          reasoningDurationTracker.startGroup(finalReasoningGroups - 1);
-        }
+        adoptGatedReasoningGroups(finalContent);
         reasoningDurationTracker.finishGroup();
         yield {
           content: [
@@ -6363,6 +6395,10 @@ export function createOpenAIStreamAdapter(
           const partialText = mergeContinuation(cumulativeText);
           const partialContent = buildAssistantContent(partialText);
           if (partialContent.length > 0) {
+            // Same hole as the success path: this partial can render a group
+            // the gate never let the tracker see.
+            adoptGatedReasoningGroups(partialContent);
+            reasoningDurationTracker.finishGroup();
             const partialTiming = buildTiming(
               streamStartTime,
               totalChunks,

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -158,6 +158,7 @@ import {
   hasUnclosedThinkTag,
   parseAssistantContent,
 } from "../utils/parse-assistant-content";
+import { createFrameGate } from "../utils/stream-pacing";
 import {
   countReasoningGroups,
   createReasoningDurationTracker,
@@ -5325,6 +5326,7 @@ export function createOpenAIStreamAdapter(
             requestedMaxTokens = requestPayload.max_tokens;
             await ThreadAutosaveHandle.awaitFirstSave(resolvedThreadId);
             const stream = streamChatCompletions(requestPayload, runSignal);
+            const canPublish = createFrameGate();
 
             for await (const chunk of stream) {
               const chunkModel = (chunk as { model?: unknown }).model;
@@ -6097,6 +6099,10 @@ export function createOpenAIStreamAdapter(
                   /\s*\$\{[^}]*\}\s*$/,
                   "",
                 );
+              }
+              // Coalesce text received before the next frame; cumulativeText retains it.
+              if (!canPublish()) {
+                continue;
               }
               const assistantContent = liveAssistantContent();
 

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -4504,6 +4504,11 @@ export function createOpenAIStreamAdapter(
       // What the gate bounds. Only grows, unlike cumulativeText, which the
       // ${...} strip can shorten, and it counts tool-argument deltas too.
       let streamedChars = 0;
+      // When the reasoning the next publish will reveal actually ARRIVED. The
+      // gate can only parse a group out of the text on a publishing chunk, so
+      // without this a pass that arrived while the gate was closed would be
+      // timed from the publish and measure as zero. Cleared on every publish.
+      let gateHeldSince: number | undefined;
       const continuationPartial = continuation?.partial ?? "";
       // Local backends (and a self-hosted vLLM / llama-server, which get the flags)
       // resume at the exact token boundary, so their output is already the rest of the
@@ -4523,11 +4528,12 @@ export function createOpenAIStreamAdapter(
       // renders a group. Both terminal publishes call this before metadata().
       const adoptGatedReasoningGroups = (
         content: readonly { type?: unknown; text?: unknown }[],
+        firstSeenAt?: number,
       ) => {
         const groups = countReasoningGroups(content);
         if (groups > reasoningDurationTracker.groupCount) {
           // startGroup back-fills the indexes it skips, so one call is enough.
-          reasoningDurationTracker.startGroup(groups - 1);
+          reasoningDurationTracker.startGroup(groups - 1, firstSeenAt);
         }
       };
       // Every streamed yield carries the repaired text, not just the terminal ones:
@@ -6145,8 +6151,12 @@ export function createOpenAIStreamAdapter(
               // Coalesce text arriving before the next frame; cumulativeText
               // keeps it, and the cap publishes before a stop could drop it.
               if (!canPublish(streamedChars)) {
+                // Earliest moment the text this publish will carry was here.
+                gateHeldSince ??= Date.now();
                 continue;
               }
+              const reasoningSeenAt = gateHeldSince;
+              gateHeldSince = undefined;
               const assistantContent = liveAssistantContent();
 
               // Fallback when no server-side reasoning_summary arrives.
@@ -6158,6 +6168,7 @@ export function createOpenAIStreamAdapter(
               ) {
                 reasoningDurationTracker.startGroup(
                   parsedReasoningGroupCount - 1,
+                  reasoningSeenAt,
                 );
               }
               if (parsedReasoningGroupCount > 0) {
@@ -6309,7 +6320,7 @@ export function createOpenAIStreamAdapter(
         const finalContent = buildAssistantContent(
           mergeContinuation(cumulativeText),
         );
-        adoptGatedReasoningGroups(finalContent);
+        adoptGatedReasoningGroups(finalContent, gateHeldSince);
         reasoningDurationTracker.finishGroup();
         yield {
           content: [
@@ -6389,7 +6400,7 @@ export function createOpenAIStreamAdapter(
           const partialContent = buildAssistantContent(partialText);
           if (partialContent.length > 0) {
             // This partial can render a group the gate hid from the tracker.
-            adoptGatedReasoningGroups(partialContent);
+            adoptGatedReasoningGroups(partialContent, gateHeldSince);
             reasoningDurationTracker.finishGroup();
             const partialTiming = buildTiming(
               streamStartTime,

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -5914,12 +5914,19 @@ export function createOpenAIStreamAdapter(
                   | { extra_content?: unknown }
                   | undefined
               )?.extra_content;
+              // Replay state, not a preview: a Gemini thought signature or a
+              // Codex reasoning ledger reaches the message only through a yield,
+              // and a Stop while the gate holds one would persist a turn that
+              // replays without it. Same rule as the tool events -- gate the
+              // previews, never the publishes that carry state.
+              let replayStateChanged = false;
               if (deltaExtraContent && typeof deltaExtraContent === "object") {
                 const extraRecord = deltaExtraContent as Record<string, unknown>;
                 const eGoogle = extraRecord.google;
                 if (eGoogle && typeof eGoogle === "object") {
                   const sig = (eGoogle as Record<string, unknown>).thought_signature;
                   if (typeof sig === "string" && sig) {
+                    replayStateChanged ||= sig !== latestTextThoughtSignature;
                     latestTextThoughtSignature = sig;
                   }
                 }
@@ -5930,6 +5937,7 @@ export function createOpenAIStreamAdapter(
                     codexReasoning,
                     codexRoundToolCallIds,
                   );
+                  replayStateChanged = true;
                 }
               }
 
@@ -6091,6 +6099,11 @@ export function createOpenAIStreamAdapter(
                   }
                 }
                 if (addedToolCall || canPublish(streamedChars)) {
+                  // This publish can be the first to expose a reasoning group
+                  // the gate was holding. Reconcile before yielding, or a Stop
+                  // during the tool run persists content with a group the
+                  // durations know nothing about.
+                  adoptGatedReasoningGroups(liveAssistantContent(), gateHeldSince);
                   yield {
                     content: liveAssistantContent(),
                     metadata: {
@@ -6139,6 +6152,18 @@ export function createOpenAIStreamAdapter(
                   "",
                 );
               }
+              // Closing a group reads only pre-gate state, so it runs on every
+              // arrival: deferring it to the next publish let a pause after the
+              // reasoning ended count as part of the reasoning. Only the START
+              // needs the parsed content, so only that stays gated.
+              if (
+                reasoningDurationTracker.hasActiveGroup &&
+                !reasoningContentOpen &&
+                !structuredReasoningContinues &&
+                !hasUnclosedThinkTag(cumulativeText)
+              ) {
+                reasoningDurationTracker.finishGroup();
+              }
               // A chunk the strip emptied has nothing to show and is skipped
               // below anyway; asking the gate would spend this cycle's publish
               // on it and hold the next real chunk.
@@ -6150,9 +6175,14 @@ export function createOpenAIStreamAdapter(
               }
               // Coalesce text arriving before the next frame; cumulativeText
               // keeps it, and the cap publishes before a stop could drop it.
-              if (!canPublish(streamedChars)) {
-                // Earliest moment the text this publish will carry was here.
-                gateHeldSince ??= Date.now();
+              if (!replayStateChanged && !canPublish(streamedChars)) {
+                // Only when the held chunk actually carries reasoning. Stamping
+                // on any held chunk backdated a group to a prose delta that
+                // arrived before reasoning began, which inflates the duration by
+                // the gap between them.
+                if (reasoning || delta.includes("<think>")) {
+                  gateHeldSince ??= Date.now();
+                }
                 continue;
               }
               const reasoningSeenAt = gateHeldSince;
@@ -6181,17 +6211,6 @@ export function createOpenAIStreamAdapter(
                   lastReasoningGroupTextLength(assistantContent),
                 );
               }
-              if (
-                reasoningDurationTracker.hasActiveGroup &&
-                !reasoningContentOpen &&
-                // The publishing chunk's flag only; every finish re-measures
-                // from the group's start, so a dropped flag cannot skew it.
-                !structuredReasoningContinues &&
-                !hasUnclosedThinkTag(cumulativeText)
-              ) {
-                reasoningDurationTracker.finishGroup();
-              }
-
               if (assistantContent.length > 0) {
                 yield {
                   content: assistantContent,

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -4509,6 +4509,11 @@ export function createOpenAIStreamAdapter(
       // without this a pass that arrived while the gate was closed would be
       // timed from the publish and measure as zero. Cleared on every publish.
       let gateHeldSince: number | undefined;
+      // When held reasoning ENDED, for the case where the gate has not revealed
+      // the group yet. hasActiveGroup is false until a publish parses it out, so
+      // the close below cannot record it, and finishing at the eventual publish
+      // would charge the whole wait in between to the reasoning.
+      let gateReasoningEndedAt: number | undefined;
       const continuationPartial = continuation?.partial ?? "";
       // Local backends (and a self-hosted vLLM / llama-server, which get the flags)
       // resume at the exact token boundary, so their output is already the rest of the
@@ -4554,9 +4559,10 @@ export function createOpenAIStreamAdapter(
             lastReasoningGroupTextLength(content),
           );
           if (!hasUnclosedThinkTag(cumulativeText)) {
-            reasoningDurationTracker.finishGroup();
+            reasoningDurationTracker.finishGroup(gateReasoningEndedAt);
           }
         }
+        gateReasoningEndedAt = undefined;
       };
       // Every streamed yield carries the repaired text, not just the terminal ones:
       // assistant-ui drops whatever is yielded after an abort, so on Stop the last
@@ -6153,6 +6159,11 @@ export function createOpenAIStreamAdapter(
               // happened to publish.
               if (replayStateChanged && !delta && !reasoning) {
                 const replayContent = liveAssistantContent();
+                // Third publish path, so it owes the same reconciliation as the
+                // other two: this yield can be the first to expose a group the
+                // gate was holding.
+                reconcileReasoning(replayContent, gateHeldSince);
+                gateHeldSince = undefined;
                 if (replayContent.length > 0) {
                   yield {
                     content: replayContent,
@@ -6213,6 +6224,15 @@ export function createOpenAIStreamAdapter(
                 !hasUnclosedThinkTag(cumulativeText)
               ) {
                 reasoningDurationTracker.finishGroup();
+              } else if (
+                // Same transition, but for a group still behind the gate: the
+                // tracker has never heard of it, so only the timestamp is kept.
+                gateHeldSince !== undefined &&
+                !reasoningContentOpen &&
+                !structuredReasoningContinues &&
+                !hasUnclosedThinkTag(cumulativeText)
+              ) {
+                gateReasoningEndedAt ??= Date.now();
               }
               // A chunk the strip emptied has nothing to show and is skipped
               // below anyway; asking the gate would spend this cycle's publish

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -4501,9 +4501,8 @@ export function createOpenAIStreamAdapter(
       // Seeded with the partial so the bubble reads as one response; the boundary lets
       // the finalizers re-derive the new output and repair a repeat/restart.
       let cumulativeText = continuation ? continuation.partial : "";
-      // What the gate's cap is measured against. Only grows, unlike
-      // cumulativeText, which the ${...} strip can shorten, and it counts
-      // tool-argument deltas, which never reach cumulativeText at all.
+      // What the cap is measured against: only grows, unlike cumulativeText,
+      // and counts tool-argument deltas, which never reach it.
       let streamedChars = 0;
       const continuationPartial = continuation?.partial ?? "";
       // Local backends (and a self-hosted vLLM / llama-server, which get the flags)
@@ -5497,10 +5496,9 @@ export function createOpenAIStreamAdapter(
                         args: partial.args as ToolCallMessagePart["args"],
                         argsText: partial.argsText,
                       };
-                      // Paced like the text path: this preview repeats per
-                      // argument delta and tool_start replaces it with the
-                      // authoritative parse. The tool events themselves are
-                      // rare and carry the card's state, so those stay ungated.
+                      // A preview: it repeats per argument delta and
+                      // tool_start replaces it. The tool events carry state, so
+                      // they stay ungated.
                       if (canPublish(streamedChars)) {
                         yield {
                           content: liveAssistantContent(),
@@ -5898,11 +5896,9 @@ export function createOpenAIStreamAdapter(
                   | { extra_content?: unknown }
                   | undefined
               )?.extra_content;
-              // Replay state, not a preview: a Gemini thought signature or a
-              // Codex reasoning ledger reaches the message only through a yield,
-              // and a Stop while the gate holds one persists a turn that then
-              // replays without it. Pace the previews, never a publish that
-              // carries state.
+              // Replay state reaches the message only through a yield, so a
+              // Stop while the gate holds one persists a turn that cannot
+              // replay. Pace previews, never state.
               let replayStateChanged = false;
               if (deltaExtraContent && typeof deltaExtraContent === "object") {
                 const extraRecord = deltaExtraContent as Record<string, unknown>;
@@ -5967,10 +5963,8 @@ export function createOpenAIStreamAdapter(
                 rawDeltaToolCalls.length > 0
               ) {
                 closeReasoningContent();
-                // A fragment extending an existing call's arguments is the same
-                // per-delta preview as tool_args, so it is paced the same way.
-                // One that introduces a call always publishes: that is state an
-                // aborted turn would otherwise lose.
+                // Extending a call's arguments is a preview; introducing one
+                // is state, so it always publishes.
                 let addedToolCall = false;
                 for (const tc of rawDeltaToolCalls) {
                   if (!tc || typeof tc !== "object") continue;
@@ -6035,9 +6029,8 @@ export function createOpenAIStreamAdapter(
                       JSON.stringify(call.extra_content) !==
                         JSON.stringify(prevExtra)
                     ) {
-                      // Gemini carries the thought signature on the call
-                      // itself, and the next turn is rejected outright without
-                      // it, so this is state rather than a preview.
+                      // Gemini puts the thought signature on the call, and
+                      // the next turn is rejected without it.
                       replayStateChanged = true;
                     }
                     const updated: PositionedToolCallPart = {
@@ -6111,11 +6104,9 @@ export function createOpenAIStreamAdapter(
                 }
                 continue;
               }
-              // A chunk whose ONLY payload is extra_content: Gemini ships a
-              // content-free thoughtSignature fragment, and the Codex client
-              // puts its reasoning ledger on a text-free terminal delta. The
-              // skip below would drop both, so the metadata would reach the
-              // message only if some later chunk happened to publish.
+              // extra_content can arrive with no content at all: a Gemini
+              // thoughtSignature fragment, or the codex reasoning ledger on a
+              // terminal delta. The skip below would drop both.
               if (replayStateChanged && !delta && !reasoning) {
                 const replayContent = liveAssistantContent();
                 if (replayContent.length > 0) {
@@ -6136,8 +6127,8 @@ export function createOpenAIStreamAdapter(
               if (!delta && !reasoning) {
                 continue;
               }
-              // Where this chunk's text starts, so the strip below can be
-              // told from a chunk that genuinely added nothing.
+              // So the strip below can be told from a chunk that added
+              // nothing.
               const textLenBeforeChunk = cumulativeText.length;
               if (waitingFirstChunk) {
                 waitingFirstChunk = false;
@@ -6202,16 +6193,14 @@ export function createOpenAIStreamAdapter(
                 reasoningDurationTracker.finishGroup();
               }
 
-              // Everything above runs on every arrival. Only the publish is
-              // coalesced, because the cost this is here to remove is what
-              // happens AFTER the yield -- assistant-ui, React, markdown and
-              // paint -- not the rebuild above, which measures in tens of
-              // milliseconds across a whole reply.
+              // Everything above runs on every arrival; only the publish is
+              // coalesced. The cost being removed is downstream of the yield
+              // (assistant-ui, React, markdown, paint), not the rebuild, which
+              // is tens of milliseconds across a whole reply.
               //
-              // A chunk the strip left with nothing new to show is skipped
-              // outright rather than paced: asking the gate would spend this
-              // cycle's publish on an identical rebuild and hold the next real
-              // chunk until a frame, the timer or the cap.
+              // A chunk with nothing new is skipped rather than paced: the gate
+              // would spend this cycle on an identical publish and hold the
+              // next real one.
               if (
                 !replayStateChanged &&
                 (assistantContent.length === 0 ||

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -4550,6 +4550,11 @@ export function createOpenAIStreamAdapter(
       const reconcileReasoning = (
         content: readonly { type?: unknown; text?: unknown }[],
         firstSeenAt?: number,
+        // At the end of the stream there is no later publish to close the
+        // group, so the unclosed-tag guard below has to be lifted: a provider
+        // that never emits the closing tag would otherwise leave the group
+        // open and unmeasured.
+        final = false,
       ) => {
         adoptGatedReasoningGroups(content, firstSeenAt);
         const groups = countReasoningGroups(content);
@@ -4565,7 +4570,7 @@ export function createOpenAIStreamAdapter(
             groups - 1,
             lastReasoningGroupTextLength(content),
           );
-          if (!hasUnclosedThinkTag(cumulativeText)) {
+          if (final || !hasUnclosedThinkTag(cumulativeText)) {
             reasoningDurationTracker.finishGroup(gateReasoningEndedAt);
           }
         }
@@ -6095,6 +6100,18 @@ export function createOpenAIStreamAdapter(
                     }
                     const prevExtra = (existing as PositionedToolCallPart)
                       .extra_content;
+                    if (
+                      call.extra_content !== undefined &&
+                      JSON.stringify(call.extra_content) !==
+                        JSON.stringify(prevExtra)
+                    ) {
+                      // Gemini carries the thought signature per tool call, not
+                      // only at message level, and the next turn is rejected
+                      // outright without it. Same rule as the message-level
+                      // ledger: gate the previews, never a publish that carries
+                      // state a Stop would persist without.
+                      replayStateChanged = true;
+                    }
                     const updated: PositionedToolCallPart = {
                       ...(existing as PositionedToolCallPart),
                       toolName: nextName,
@@ -6254,6 +6271,13 @@ export function createOpenAIStreamAdapter(
                 ) !== -1;
               if (reasoning || thinkOpenedNow) {
                 gateHeldSince ??= Date.now();
+                // A provider can emit several complete <think>...</think>
+                // blocks in a row, which the panel coalesces into one group.
+                // Keeping the first block's close would finish the whole group
+                // there and drop every later block's time, so a new block
+                // invalidates it. Answer-only arrivals leave it alone, which is
+                // what keeps a pause after the reasoning out of the duration.
+                gateReasoningEndedAt = undefined;
               }
               // Closing a group reads only pre-gate state, so it runs on every
               // arrival: deferring it to the next publish let a pause after the
@@ -6277,12 +6301,17 @@ export function createOpenAIStreamAdapter(
                   reasoningDurationTracker.finishGroup(gateReasoningEndedAt);
                 }
               }
-              // A chunk the strip emptied has nothing to show and is skipped
+              // A chunk the strip left with nothing new to show is skipped
               // below anyway; asking the gate would spend this cycle's publish
-              // on it and hold the next real chunk.
+              // on it and hold the next real chunk. Both shapes count: the
+              // reply emptied entirely, and a nonempty reply the strip returned
+              // to exactly its previous length, which is the ${...} fragment
+              // the Mistral path targets arriving mid-reply.
               if (
-                mergeContinuation(cumulativeText).length === 0 &&
-                toolCallParts.length === 0
+                (mergeContinuation(cumulativeText).length === 0 ||
+                  cumulativeText.length === textLenBeforeChunk) &&
+                toolCallParts.length === 0 &&
+                !replayStateChanged
               ) {
                 continue;
               }
@@ -6426,10 +6455,13 @@ export function createOpenAIStreamAdapter(
         const finalContent = buildAssistantContent(
           mergeContinuation(cumulativeText),
         );
-        adoptGatedReasoningGroups(finalContent, gateHeldSince);
-        // At the end the reasoning was seen to reach, not at stream close: any
-        // pause or trailing control frames in between are not reasoning.
-        reasoningDurationTracker.finishGroup(gateReasoningEndedAt);
+        // Adoption alone is not enough: reasoning held by the gate can extend
+        // a group that ALREADY exists, where there is nothing to adopt and the
+        // group was closed by the previous publish, so its duration would stay
+        // frozen there. resumeGroup reopens it on the grown text. Finishing at
+        // the recorded end keeps any pause or trailing control frames before
+        // stream close out of the reasoning.
+        reconcileReasoning(finalContent, gateHeldSince, true);
         yield {
           content: [
             ...finalContent,
@@ -6508,10 +6540,7 @@ export function createOpenAIStreamAdapter(
           const partialContent = buildAssistantContent(partialText);
           if (partialContent.length > 0) {
             // This partial can render a group the gate hid from the tracker.
-            adoptGatedReasoningGroups(partialContent, gateHeldSince);
-            // At the end the reasoning was seen to reach, not at stream close: any
-            // pause or trailing control frames in between are not reasoning.
-            reasoningDurationTracker.finishGroup(gateReasoningEndedAt);
+            reconcileReasoning(partialContent, gateHeldSince, true);
             const partialTiming = buildTiming(
               streamStartTime,
               totalChunks,

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -4559,17 +4559,22 @@ export function createOpenAIStreamAdapter(
         adoptGatedReasoningGroups(content, firstSeenAt);
         const groups = countReasoningGroups(content);
         if (groups > 0) {
-          // Dropped here rather than at the call sites, because a publish can
-          // land between the opening tag and any reasoning body: a provider
-          // that emits a bare "<think>" as its own delta parses to no parts at
-          // all. Clearing the stamp on that publish would start the group at
-          // whatever later publish first sees the body, and a pass that ran for
-          // 30s would measure 0.
-          gateHeldSince = undefined;
           reasoningDurationTracker.resumeGroup(
             groups - 1,
             lastReasoningGroupTextLength(content),
           );
+          // The stamp is dropped here rather than at the call sites, and only
+          // once the pass it marks is actually being timed. A publish can land
+          // between an opening tag and any reasoning body -- a provider that
+          // emits a bare "<think>" as its own delta parses to no parts at all
+          // -- and an EARLIER pass leaves groups > 0 on that publish, so the
+          // count alone cannot tell the two apart. An active group can only be
+          // one the adopt or resume above just took the stamp for. Between
+          // them, a pass whose body the gate held would start at whatever later
+          // publish first saw it and measure 0.
+          if (reasoningDurationTracker.hasActiveGroup) {
+            gateHeldSince = undefined;
+          }
           if (final || !hasUnclosedThinkTag(cumulativeText)) {
             reasoningDurationTracker.finishGroup(gateReasoningEndedAt);
           }

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -6188,6 +6188,9 @@ export function createOpenAIStreamAdapter(
               if (!delta && !reasoning) {
                 continue;
               }
+              // Where this chunk's text starts, so the tag check below can look
+              // at the join instead of at the delta alone.
+              const textLenBeforeChunk = cumulativeText.length;
               if (waitingFirstChunk) {
                 waitingFirstChunk = false;
                 firstTokenTime = Date.now() - streamStartTime;
@@ -6226,29 +6229,40 @@ export function createOpenAIStreamAdapter(
               // any pause in between was charged to the reasoning. Cleared on
               // every publish, so stamping a chunk that turns out to publish is
               // harmless.
-              if (reasoning || delta.includes("<think>")) {
+              // Searched from just before this chunk's first character, not in
+              // the delta, so an opening tag split across two arrivals still
+              // registers: "<thi" then "nk>reasoning" contains the tag only at
+              // the join. Bounded by the tag length, so still O(delta).
+              const THINK_OPEN = "<think>";
+              const thinkOpenedNow =
+                cumulativeText.indexOf(
+                  THINK_OPEN,
+                  Math.max(0, textLenBeforeChunk - (THINK_OPEN.length - 1)),
+                ) !== -1;
+              if (reasoning || thinkOpenedNow) {
                 gateHeldSince ??= Date.now();
               }
               // Closing a group reads only pre-gate state, so it runs on every
               // arrival: deferring it to the next publish let a pause after the
               // reasoning ended count as part of the reasoning. Only the START
               // needs the parsed content, so only that stays gated.
+              const reasoningJustClosed =
+                !reasoningContentOpen &&
+                !structuredReasoningContinues &&
+                !hasUnclosedThinkTag(cumulativeText);
               if (
-                reasoningDurationTracker.hasActiveGroup &&
-                !reasoningContentOpen &&
-                !structuredReasoningContinues &&
-                !hasUnclosedThinkTag(cumulativeText)
+                reasoningJustClosed &&
+                (reasoningDurationTracker.hasActiveGroup ||
+                  gateHeldSince !== undefined)
               ) {
-                reasoningDurationTracker.finishGroup();
-              } else if (
-                // Same transition, but for a group still behind the gate: the
-                // tracker has never heard of it, so only the timestamp is kept.
-                gateHeldSince !== undefined &&
-                !reasoningContentOpen &&
-                !structuredReasoningContinues &&
-                !hasUnclosedThinkTag(cumulativeText)
-              ) {
+                // Recorded even when the group is active and closed right here,
+                // because a later publish can resumeGroup it (its text grew) and
+                // the finish that follows would otherwise run at the publish and
+                // stretch the duration across the wait.
                 gateReasoningEndedAt ??= Date.now();
+                if (reasoningDurationTracker.hasActiveGroup) {
+                  reasoningDurationTracker.finishGroup(gateReasoningEndedAt);
+                }
               }
               // A chunk the strip emptied has nothing to show and is skipped
               // below anyway; asking the gate would spend this cycle's publish
@@ -6401,7 +6415,9 @@ export function createOpenAIStreamAdapter(
           mergeContinuation(cumulativeText),
         );
         adoptGatedReasoningGroups(finalContent, gateHeldSince);
-        reasoningDurationTracker.finishGroup();
+        // At the end the reasoning was seen to reach, not at stream close: any
+        // pause or trailing control frames in between are not reasoning.
+        reasoningDurationTracker.finishGroup(gateReasoningEndedAt);
         yield {
           content: [
             ...finalContent,
@@ -6481,7 +6497,9 @@ export function createOpenAIStreamAdapter(
           if (partialContent.length > 0) {
             // This partial can render a group the gate hid from the tracker.
             adoptGatedReasoningGroups(partialContent, gateHeldSince);
-            reasoningDurationTracker.finishGroup();
+            // At the end the reasoning was seen to reach, not at stream close: any
+            // pause or trailing control frames in between are not reasoning.
+            reasoningDurationTracker.finishGroup(gateReasoningEndedAt);
             const partialTiming = buildTiming(
               streamStartTime,
               totalChunks,

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -5402,6 +5402,15 @@ export function createOpenAIStreamAdapter(
               const reasoningMs = (
                 chunk as { _reasoningDurationMs?: number } | null | undefined
               )?._reasoningDurationMs;
+              if (reasoningMs !== undefined) {
+                // A reasoning pass short enough to fit inside one gate window
+                // is still unknown to the tracker when its summary lands, and
+                // the summary would then be consumed with nothing to assign it
+                // to, losing the authoritative duration in favour of a local
+                // measurement. Adopt what the text already shows first. Summary
+                // frames are one per pass, so this parse is not on the hot path.
+                reconcileReasoning(liveAssistantContent(), gateHeldSince);
+              }
               if (
                 reasoningDurationTracker.recordServerDuration(reasoningMs)
               ) {

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -4501,19 +4501,10 @@ export function createOpenAIStreamAdapter(
       // Seeded with the partial so the bubble reads as one response; the boundary lets
       // the finalizers re-derive the new output and repair a repeat/restart.
       let cumulativeText = continuation ? continuation.partial : "";
-      // What the gate bounds. Only grows, unlike cumulativeText, which the
-      // ${...} strip can shorten, and it counts tool-argument deltas too.
+      // What the gate's cap is measured against. Only grows, unlike
+      // cumulativeText, which the ${...} strip can shorten, and it counts
+      // tool-argument deltas, which never reach cumulativeText at all.
       let streamedChars = 0;
-      // When the reasoning the next publish will reveal actually ARRIVED. The
-      // gate can only parse a group out of the text on a publishing chunk, so
-      // without this a pass that arrived while the gate was closed would be
-      // timed from the publish and measure as zero. Cleared on every publish.
-      let gateHeldSince: number | undefined;
-      // When held reasoning ENDED, for the case where the gate has not revealed
-      // the group yet. hasActiveGroup is false until a publish parses it out, so
-      // the close below cannot record it, and finishing at the eventual publish
-      // would charge the whole wait in between to the reasoning.
-      let gateReasoningEndedAt: number | undefined;
       const continuationPartial = continuation?.partial ?? "";
       // Local backends (and a self-hosted vLLM / llama-server, which get the flags)
       // resume at the exact token boundary, so their output is already the rest of the
@@ -4528,59 +4519,6 @@ export function createOpenAIStreamAdapter(
               text.slice(continuationPartial.length),
             )
           : text;
-      // A group whose every revealing chunk the gate coalesced away was never
-      // started, leaving a hole in the persisted durations where the panel
-      // renders a group. Both terminal publishes call this before metadata().
-      const adoptGatedReasoningGroups = (
-        content: readonly { type?: unknown; text?: unknown }[],
-        firstSeenAt?: number,
-      ) => {
-        const groups = countReasoningGroups(content);
-        if (groups > reasoningDurationTracker.groupCount) {
-          // startGroup back-fills the indexes it skips, so one call is enough.
-          reasoningDurationTracker.startGroup(groups - 1, firstSeenAt);
-        }
-      };
-      /**
-       * The whole tracker transition for a publish, not just the start: adopting
-       * a group and leaving it open publishes a group with no duration behind
-       * it, and leaves the timer running across whatever comes next. Every path
-       * that yields has to do all three, so they share one implementation.
-       */
-      const reconcileReasoning = (
-        content: readonly { type?: unknown; text?: unknown }[],
-        firstSeenAt?: number,
-        // At the end of the stream there is no later publish to close the
-        // group, so the unclosed-tag guard below has to be lifted: a provider
-        // that never emits the closing tag would otherwise leave the group
-        // open and unmeasured.
-        final = false,
-      ) => {
-        adoptGatedReasoningGroups(content, firstSeenAt);
-        const groups = countReasoningGroups(content);
-        if (groups > 0) {
-          reasoningDurationTracker.resumeGroup(
-            groups - 1,
-            lastReasoningGroupTextLength(content),
-          );
-          // The stamp is dropped here rather than at the call sites, and only
-          // once the pass it marks is actually being timed. A publish can land
-          // between an opening tag and any reasoning body -- a provider that
-          // emits a bare "<think>" as its own delta parses to no parts at all
-          // -- and an EARLIER pass leaves groups > 0 on that publish, so the
-          // count alone cannot tell the two apart. An active group can only be
-          // one the adopt or resume above just took the stamp for. Between
-          // them, a pass whose body the gate held would start at whatever later
-          // publish first saw it and measure 0.
-          if (reasoningDurationTracker.hasActiveGroup) {
-            gateHeldSince = undefined;
-          }
-          if (final || !hasUnclosedThinkTag(cumulativeText)) {
-            reasoningDurationTracker.finishGroup(gateReasoningEndedAt);
-          }
-        }
-        gateReasoningEndedAt = undefined;
-      };
       // Every streamed yield carries the repaired text, not just the terminal ones:
       // assistant-ui drops whatever is yielded after an abort, so on Stop the last
       // STREAMED yield is what gets saved.
@@ -5392,6 +5330,7 @@ export function createOpenAIStreamAdapter(
             requestedMaxTokens = requestPayload.max_tokens;
             await ThreadAutosaveHandle.awaitFirstSave(resolvedThreadId);
             const stream = streamChatCompletions(requestPayload, runSignal);
+            // Per run, not per module: two turns must not share a cycle.
             const canPublish = createStreamPublishGate();
 
             for await (const chunk of stream) {
@@ -5419,15 +5358,6 @@ export function createOpenAIStreamAdapter(
               const reasoningMs = (
                 chunk as { _reasoningDurationMs?: number } | null | undefined
               )?._reasoningDurationMs;
-              if (reasoningMs !== undefined) {
-                // A reasoning pass short enough to fit inside one gate window
-                // is still unknown to the tracker when its summary lands, and
-                // the summary would then be consumed with nothing to assign it
-                // to, losing the authoritative duration in favour of a local
-                // measurement. Adopt what the text already shows first. Summary
-                // frames are one per pass, so this parse is not on the hot path.
-                reconcileReasoning(liveAssistantContent(), gateHeldSince);
-              }
               if (
                 reasoningDurationTracker.recordServerDuration(reasoningMs)
               ) {
@@ -5567,10 +5497,10 @@ export function createOpenAIStreamAdapter(
                         args: partial.args as ToolCallMessagePart["args"],
                         argsText: partial.argsText,
                       };
-                      // Gated like the text path: this preview repeats per
+                      // Paced like the text path: this preview repeats per
                       // argument delta and tool_start replaces it with the
-                      // authoritative parse. The tool events are rare and carry
-                      // the card's state, so those publish ungated.
+                      // authoritative parse. The tool events themselves are
+                      // rare and carry the card's state, so those stay ungated.
                       if (canPublish(streamedChars)) {
                         yield {
                           content: liveAssistantContent(),
@@ -5903,11 +5833,6 @@ export function createOpenAIStreamAdapter(
                     };
                   }
                 }
-                // Ungated and state-bearing, so it can be the first publish to
-                // expose a group the gate is holding: an external provider can
-                // synthesize a _toolEvent with no delta.tool_calls fragment
-                // before it.
-                reconcileReasoning(liveAssistantContent(), gateHeldSince);
                 yield {
                   content: liveAssistantContent(),
                   metadata: {
@@ -5975,9 +5900,9 @@ export function createOpenAIStreamAdapter(
               )?.extra_content;
               // Replay state, not a preview: a Gemini thought signature or a
               // Codex reasoning ledger reaches the message only through a yield,
-              // and a Stop while the gate holds one would persist a turn that
-              // replays without it. Same rule as the tool events -- gate the
-              // previews, never the publishes that carry state.
+              // and a Stop while the gate holds one persists a turn that then
+              // replays without it. Pace the previews, never a publish that
+              // carries state.
               let replayStateChanged = false;
               if (deltaExtraContent && typeof deltaExtraContent === "object") {
                 const extraRecord = deltaExtraContent as Record<string, unknown>;
@@ -6043,7 +5968,7 @@ export function createOpenAIStreamAdapter(
               ) {
                 closeReasoningContent();
                 // A fragment extending an existing call's arguments is the same
-                // per-delta preview as tool_args, so it is gated the same way.
+                // per-delta preview as tool_args, so it is paced the same way.
                 // One that introduces a call always publishes: that is state an
                 // aborted turn would otherwise lose.
                 let addedToolCall = false;
@@ -6110,11 +6035,9 @@ export function createOpenAIStreamAdapter(
                       JSON.stringify(call.extra_content) !==
                         JSON.stringify(prevExtra)
                     ) {
-                      // Gemini carries the thought signature per tool call, not
-                      // only at message level, and the next turn is rejected
-                      // outright without it. Same rule as the message-level
-                      // ledger: gate the previews, never a publish that carries
-                      // state a Stop would persist without.
+                      // Gemini carries the thought signature on the call
+                      // itself, and the next turn is rejected outright without
+                      // it, so this is state rather than a preview.
                       replayStateChanged = true;
                     }
                     const updated: PositionedToolCallPart = {
@@ -6174,11 +6097,6 @@ export function createOpenAIStreamAdapter(
                   replayStateChanged ||
                   canPublish(streamedChars)
                 ) {
-                  // This publish can be the first to expose a reasoning group
-                  // the gate was holding. Starting it is not enough: left open
-                  // it yields with no duration and keeps timing across the tool
-                  // run, so run the full transition.
-                  reconcileReasoning(liveAssistantContent(), gateHeldSince);
                   yield {
                     content: liveAssistantContent(),
                     metadata: {
@@ -6193,18 +6111,13 @@ export function createOpenAIStreamAdapter(
                 }
                 continue;
               }
-              // A chunk whose ONLY payload is extra_content: Gemini 3 ships a
+              // A chunk whose ONLY payload is extra_content: Gemini ships a
               // content-free thoughtSignature fragment, and the Codex client
               // puts its reasoning ledger on a text-free terminal delta. The
-              // skip below would drop both before the gate ever sees them, so
-              // the metadata would reach the message only if some later chunk
-              // happened to publish.
+              // skip below would drop both, so the metadata would reach the
+              // message only if some later chunk happened to publish.
               if (replayStateChanged && !delta && !reasoning) {
                 const replayContent = liveAssistantContent();
-                // Third publish path, so it owes the same reconciliation as the
-                // other two: this yield can be the first to expose a group the
-                // gate was holding.
-                reconcileReasoning(replayContent, gateHeldSince);
                 if (replayContent.length > 0) {
                   yield {
                     content: replayContent,
@@ -6223,8 +6136,8 @@ export function createOpenAIStreamAdapter(
               if (!delta && !reasoning) {
                 continue;
               }
-              // Where this chunk's text starts, so the tag check below can look
-              // at the join instead of at the delta alone.
+              // Where this chunk's text starts, so the strip below can be
+              // told from a chunk that genuinely added nothing.
               const textLenBeforeChunk = cumulativeText.length;
               if (waitingFirstChunk) {
                 waitingFirstChunk = false;
@@ -6257,81 +6170,59 @@ export function createOpenAIStreamAdapter(
                   "",
                 );
               }
-              // Stamped before the close below can read it. Assigning it only
-              // in the skip branch meant a chunk carrying a COMPLETE
-              // <think>...</think> block stamped its start after its own end
-              // check had already run, so the end fell to the next arrival and
-              // any pause in between was charged to the reasoning. Cleared on
-              // every publish, so stamping a chunk that turns out to publish is
-              // harmless.
-              // Searched from just before this chunk's first character, not in
-              // the delta, so an opening tag split across two arrivals still
-              // registers: "<thi" then "nk>reasoning" contains the tag only at
-              // the join. Bounded by the tag length, so still O(delta).
-              const THINK_OPEN = "<think>";
-              const thinkOpenedNow =
-                cumulativeText.indexOf(
-                  THINK_OPEN,
-                  Math.max(0, textLenBeforeChunk - (THINK_OPEN.length - 1)),
-                ) !== -1;
-              if (reasoning || thinkOpenedNow) {
-                gateHeldSince ??= Date.now();
-                // A provider can emit several complete <think>...</think>
-                // blocks in a row, which the panel coalesces into one group.
-                // Keeping the first block's close would finish the whole group
-                // there and drop every later block's time, so a new block
-                // invalidates it. Answer-only arrivals leave it alone, which is
-                // what keeps a pause after the reasoning out of the duration.
-                gateReasoningEndedAt = undefined;
+              const assistantContent = liveAssistantContent();
+
+              // Fallback when no server-side reasoning_summary arrives.
+              const parsedReasoningGroupCount =
+                countReasoningGroups(assistantContent);
+              if (
+                parsedReasoningGroupCount >
+                reasoningDurationTracker.groupCount
+              ) {
+                reasoningDurationTracker.startGroup(
+                  parsedReasoningGroupCount - 1,
+                );
               }
-              // Closing a group reads only pre-gate state, so it runs on every
-              // arrival: deferring it to the next publish let a pause after the
-              // reasoning ended count as part of the reasoning. Only the START
-              // needs the parsed content, so only that stays gated.
-              const reasoningJustClosed =
+              if (parsedReasoningGroupCount > 0) {
+                // Providers that close every reasoning block atomically
+                // (structured parts wrapped as <think>..</think>) end the group
+                // on each chunk. Reopen while the reasoning text is still
+                // growing so the timer spans the whole pass.
+                reasoningDurationTracker.resumeGroup(
+                  parsedReasoningGroupCount - 1,
+                  lastReasoningGroupTextLength(assistantContent),
+                );
+              }
+              if (
+                reasoningDurationTracker.hasActiveGroup &&
                 !reasoningContentOpen &&
                 !structuredReasoningContinues &&
-                !hasUnclosedThinkTag(cumulativeText);
-              if (
-                reasoningJustClosed &&
-                (reasoningDurationTracker.hasActiveGroup ||
-                  gateHeldSince !== undefined)
+                !hasUnclosedThinkTag(cumulativeText)
               ) {
-                // Recorded even when the group is active and closed right here,
-                // because a later publish can resumeGroup it (its text grew) and
-                // the finish that follows would otherwise run at the publish and
-                // stretch the duration across the wait.
-                gateReasoningEndedAt ??= Date.now();
-                if (reasoningDurationTracker.hasActiveGroup) {
-                  reasoningDurationTracker.finishGroup(gateReasoningEndedAt);
-                }
+                reasoningDurationTracker.finishGroup();
               }
+
+              // Everything above runs on every arrival. Only the publish is
+              // coalesced, because the cost this is here to remove is what
+              // happens AFTER the yield -- assistant-ui, React, markdown and
+              // paint -- not the rebuild above, which measures in tens of
+              // milliseconds across a whole reply.
+              //
               // A chunk the strip left with nothing new to show is skipped
-              // below anyway; asking the gate would spend this cycle's publish
-              // on it and hold the next real chunk. Both shapes count: the
-              // reply emptied entirely, and a nonempty reply the strip returned
-              // to exactly its previous length, which is the ${...} fragment
-              // the Mistral path targets arriving mid-reply.
+              // outright rather than paced: asking the gate would spend this
+              // cycle's publish on an identical rebuild and hold the next real
+              // chunk until a frame, the timer or the cap.
               if (
-                (mergeContinuation(cumulativeText).length === 0 ||
-                  cumulativeText.length === textLenBeforeChunk) &&
-                toolCallParts.length === 0 &&
-                !replayStateChanged
+                !replayStateChanged &&
+                (assistantContent.length === 0 ||
+                  cumulativeText.length === textLenBeforeChunk)
               ) {
                 continue;
               }
-              // Coalesce text arriving before the next frame; cumulativeText
-              // keeps it, and the cap publishes before a stop could drop it.
               if (!replayStateChanged && !canPublish(streamedChars)) {
                 continue;
               }
-              const reasoningSeenAt = gateHeldSince;
-              const assistantContent = liveAssistantContent();
 
-              // Fallback when no server-side reasoning_summary arrives. Shared
-              // with the forced tool-call publish, which needs the same three
-              // transitions and used to do only the first.
-              reconcileReasoning(assistantContent, reasoningSeenAt);
               if (assistantContent.length > 0) {
                 yield {
                   content: assistantContent,
@@ -6457,19 +6348,10 @@ export function createOpenAIStreamAdapter(
         );
 
         // Finalize reasoning-only streams.
-        const finalContent = buildAssistantContent(
-          mergeContinuation(cumulativeText),
-        );
-        // Adoption alone is not enough: reasoning held by the gate can extend
-        // a group that ALREADY exists, where there is nothing to adopt and the
-        // group was closed by the previous publish, so its duration would stay
-        // frozen there. resumeGroup reopens it on the grown text. Finishing at
-        // the recorded end keeps any pause or trailing control frames before
-        // stream close out of the reasoning.
-        reconcileReasoning(finalContent, gateHeldSince, true);
+        reasoningDurationTracker.finishGroup();
         yield {
           content: [
-            ...finalContent,
+            ...buildAssistantContent(mergeContinuation(cumulativeText)),
             ...sourceParts,
             ...documentCitationParts,
           ],
@@ -6544,8 +6426,6 @@ export function createOpenAIStreamAdapter(
           const partialText = mergeContinuation(cumulativeText);
           const partialContent = buildAssistantContent(partialText);
           if (partialContent.length > 0) {
-            // This partial can render a group the gate hid from the tracker.
-            reconcileReasoning(partialContent, gateHeldSince, true);
             const partialTiming = buildTiming(
               streamStartTime,
               totalChunks,

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -4554,6 +4554,13 @@ export function createOpenAIStreamAdapter(
         adoptGatedReasoningGroups(content, firstSeenAt);
         const groups = countReasoningGroups(content);
         if (groups > 0) {
+          // Dropped here rather than at the call sites, because a publish can
+          // land between the opening tag and any reasoning body: a provider
+          // that emits a bare "<think>" as its own delta parses to no parts at
+          // all. Clearing the stamp on that publish would start the group at
+          // whatever later publish first sees the body, and a pass that ran for
+          // 30s would measure 0.
+          gateHeldSince = undefined;
           reasoningDurationTracker.resumeGroup(
             groups - 1,
             lastReasoningGroupTextLength(content),
@@ -5891,7 +5898,6 @@ export function createOpenAIStreamAdapter(
                 // synthesize a _toolEvent with no delta.tool_calls fragment
                 // before it.
                 reconcileReasoning(liveAssistantContent(), gateHeldSince);
-                gateHeldSince = undefined;
                 yield {
                   content: liveAssistantContent(),
                   metadata: {
@@ -6151,7 +6157,6 @@ export function createOpenAIStreamAdapter(
                   // it yields with no duration and keeps timing across the tool
                   // run, so run the full transition.
                   reconcileReasoning(liveAssistantContent(), gateHeldSince);
-                  gateHeldSince = undefined;
                   yield {
                     content: liveAssistantContent(),
                     metadata: {
@@ -6178,7 +6183,6 @@ export function createOpenAIStreamAdapter(
                 // other two: this yield can be the first to expose a group the
                 // gate was holding.
                 reconcileReasoning(replayContent, gateHeldSince);
-                gateHeldSince = undefined;
                 if (replayContent.length > 0) {
                   yield {
                     content: replayContent,
@@ -6288,7 +6292,6 @@ export function createOpenAIStreamAdapter(
                 continue;
               }
               const reasoningSeenAt = gateHeldSince;
-              gateHeldSince = undefined;
               const assistantContent = liveAssistantContent();
 
               // Fallback when no server-side reasoning_summary arrives. Shared

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -5497,7 +5497,7 @@ export function createOpenAIStreamAdapter(
                         argsText: partial.argsText,
                       };
                       // A preview: it repeats per argument delta and
-                      // tool_start replaces it. The tool events carry state, so
+                      // tool_start replaces it. Tool events carry state, so
                       // they stay ungated.
                       if (canPublish(streamedChars)) {
                         yield {
@@ -6127,8 +6127,7 @@ export function createOpenAIStreamAdapter(
               if (!delta && !reasoning) {
                 continue;
               }
-              // So the strip below can be told from a chunk that added
-              // nothing.
+              // So the strip below can be told from a chunk that added nothing.
               const textLenBeforeChunk = cumulativeText.length;
               if (waitingFirstChunk) {
                 waitingFirstChunk = false;

--- a/studio/frontend/src/features/chat/utils/reasoning-duration.ts
+++ b/studio/frontend/src/features/chat/utils/reasoning-duration.ts
@@ -143,23 +143,31 @@ export function createReasoningDurationTracker(
     get hasActiveGroup() {
       return activeIndex !== null;
     },
-    startGroup(index = groupCount) {
+    /**
+     * `firstSeenAt` is when the reasoning ARRIVED, for a caller that learns of
+     * the group later than that. The adapter coalesces publishes, so it can
+     * only parse a group out of the text on a publishing chunk; without this
+     * the timer would start there and a pass that arrived seconds earlier would
+     * measure as zero.
+     */
+    startGroup(index = groupCount, firstSeenAt?: number) {
       if (activeIndex === index) {
         return;
       }
       const at = now();
+      const from = firstSeenAt ?? at;
       finishGroupAt(at);
       // A single delta can reveal more than one group at once. Any index we
       // skipped became visible and closed within this same chunk, so give it a
       // measured zero rather than leaving a hole in the persisted array.
       for (let skipped = groupCount; skipped < index; skipped += 1) {
         if (startedAt[skipped] === undefined) {
-          startedAt[skipped] = at;
+          startedAt[skipped] = from;
         }
         measure(skipped, at);
       }
       if (startedAt[index] === undefined) {
-        startedAt[index] = at;
+        startedAt[index] = from;
       }
       activeIndex = index;
       groupCount = Math.max(groupCount, index + 1);

--- a/studio/frontend/src/features/chat/utils/reasoning-duration.ts
+++ b/studio/frontend/src/features/chat/utils/reasoning-duration.ts
@@ -160,9 +160,13 @@ export function createReasoningDurationTracker(
       // A single delta can reveal more than one group at once. Any index we
       // skipped became visible and closed within this same chunk, so give it a
       // measured zero rather than leaving a hole in the persisted array.
+      // Deliberately `at`, not `from`: these indexes became visible AND closed
+      // inside one discovery, so they keep their measured zero. Backdating them
+      // too would give every one of them the whole coalescing interval and have
+      // them all overlap.
       for (let skipped = groupCount; skipped < index; skipped += 1) {
         if (startedAt[skipped] === undefined) {
-          startedAt[skipped] = from;
+          startedAt[skipped] = at;
         }
         measure(skipped, at);
       }

--- a/studio/frontend/src/features/chat/utils/reasoning-duration.ts
+++ b/studio/frontend/src/features/chat/utils/reasoning-duration.ts
@@ -196,8 +196,14 @@ export function createReasoningDurationTracker(
       finishGroupAt(now());
       activeIndex = index;
     },
-    finishGroup() {
-      finishGroupAt(now());
+    /**
+     * `finishedAt` is when the reasoning actually ENDED, for a caller that
+     * learns of it later. The adapter can see a group close on a chunk whose
+     * group it has not parsed out yet, and finishing at that later discovery
+     * would charge the wait in between to the reasoning.
+     */
+    finishGroup(finishedAt?: number) {
+      finishGroupAt(finishedAt ?? now());
     },
     recordServerDuration(reasoningMs: unknown): boolean {
       if (

--- a/studio/frontend/src/features/chat/utils/reasoning-duration.ts
+++ b/studio/frontend/src/features/chat/utils/reasoning-duration.ts
@@ -143,27 +143,15 @@ export function createReasoningDurationTracker(
     get hasActiveGroup() {
       return activeIndex !== null;
     },
-    /**
-     * `firstSeenAt` is when the reasoning ARRIVED, for a caller that learns of
-     * the group later than that. The adapter coalesces publishes, so it can
-     * only parse a group out of the text on a publishing chunk; without this
-     * the timer would start there and a pass that arrived seconds earlier would
-     * measure as zero.
-     */
-    startGroup(index = groupCount, firstSeenAt?: number) {
+    startGroup(index = groupCount) {
       if (activeIndex === index) {
         return;
       }
       const at = now();
-      const from = firstSeenAt ?? at;
       finishGroupAt(at);
       // A single delta can reveal more than one group at once. Any index we
       // skipped became visible and closed within this same chunk, so give it a
       // measured zero rather than leaving a hole in the persisted array.
-      // Deliberately `at`, not `from`: these indexes became visible AND closed
-      // inside one discovery, so they keep their measured zero. Backdating them
-      // too would give every one of them the whole coalescing interval and have
-      // them all overlap.
       for (let skipped = groupCount; skipped < index; skipped += 1) {
         if (startedAt[skipped] === undefined) {
           startedAt[skipped] = at;
@@ -171,7 +159,7 @@ export function createReasoningDurationTracker(
         measure(skipped, at);
       }
       if (startedAt[index] === undefined) {
-        startedAt[index] = from;
+        startedAt[index] = at;
       }
       activeIndex = index;
       groupCount = Math.max(groupCount, index + 1);
@@ -196,14 +184,8 @@ export function createReasoningDurationTracker(
       finishGroupAt(now());
       activeIndex = index;
     },
-    /**
-     * `finishedAt` is when the reasoning actually ENDED, for a caller that
-     * learns of it later. The adapter can see a group close on a chunk whose
-     * group it has not parsed out yet, and finishing at that later discovery
-     * would charge the wait in between to the reasoning.
-     */
-    finishGroup(finishedAt?: number) {
-      finishGroupAt(finishedAt ?? now());
+    finishGroup() {
+      finishGroupAt(now());
     },
     recordServerDuration(reasoningMs: unknown): boolean {
       if (

--- a/studio/frontend/src/features/chat/utils/stream-pacing.ts
+++ b/studio/frontend/src/features/chat/utils/stream-pacing.ts
@@ -1,11 +1,10 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-// A janked window may not paint for a long time, so do not wait on frames
-// alone. This is a scheduled fallback, not a deadline: a hidden page throttles
-// this timer too (>=1s, and ~1/min once Chrome's intensive throttling kicks in),
-// and pauses frames outright. There the cap below is what paces publishes,
-// which is why the cap is counted in arrivals rather than in time.
+// A janked window may not paint for a while, so do not wait on frames alone.
+// A scheduled fallback, not a deadline: a hidden page pauses frames and
+// throttles this timer (>=1s, ~1/min under Chrome's intensive throttling), so
+// there the cap below paces publishes. Hence a cap in arrivals, not in time.
 export const UNPAINTED_REOPEN_MS = 500;
 
 /**
@@ -38,9 +37,8 @@ export function createStreamPublishGate(): (streamed: number) => boolean {
       open = false;
       // Per cycle, so the loser of the previous race cannot reopen this one.
       let reopened = false;
-      // Initialised before reopen closes over them, so a scheduler that runs
-      // its callback synchronously cannot hit the temporal dead zone and throw
-      // out of the stream loop.
+      // Initialised before reopen closes over them, so a scheduler that calls
+      // back synchronously cannot hit the temporal dead zone and throw.
       const handles: {
         frame?: number;
         timer?: ReturnType<typeof setTimeout>;

--- a/studio/frontend/src/features/chat/utils/stream-pacing.ts
+++ b/studio/frontend/src/features/chat/utils/stream-pacing.ts
@@ -8,10 +8,9 @@ const UNPAINTED_REOPEN_MS = 500;
  * Text a closed gate may hold before it publishes regardless.
  *
  * assistant-ui drops whatever a run yields after an abort, so Stop keeps only the
- * last published text. Frames bound the hold in time, not in volume, and the
- * fallback above is what reopens a starved window, which is where the stream runs
- * fastest. This bounds it in characters instead: several frames of a fast local
- * stream, so it binds only once frames are already far apart.
+ * last published text, and frames bound that hold in time rather than in volume:
+ * the fallback above reopens a starved window, which is where the stream runs
+ * fastest. Several frames' worth, so it binds only once frames are far apart.
  */
 export const MAX_HELD_CHARS = 256;
 

--- a/studio/frontend/src/features/chat/utils/stream-pacing.ts
+++ b/studio/frontend/src/features/chat/utils/stream-pacing.ts
@@ -5,34 +5,47 @@
 const UNPAINTED_REOPEN_MS = 500;
 
 /**
- * Limits streamed publishes to one per browser frame.
+ * Text a closed gate may hold before it publishes regardless.
  *
- * Reopening does not flush pending text. Stop can therefore omit text received
- * during the current interval.
+ * assistant-ui drops whatever a run yields after an abort, so Stop keeps only the
+ * last published text. Frames bound the hold in time, not in volume, and the
+ * fallback above is what reopens a starved window, which is where the stream runs
+ * fastest. This bounds it in characters instead: several frames of a fast local
+ * stream, so it binds only once frames are already far apart.
  */
-export function createFrameGate(
-  schedule: (cb: () => void) => void = (cb) => {
-    let woken = false;
-    const wake = () => {
-      if (woken) {
-        return;
-      }
-      woken = true;
-      cb();
-    };
-    requestAnimationFrame(wake);
-    setTimeout(wake, UNPAINTED_REOPEN_MS);
-  },
-): () => boolean {
-  let painted = true;
-  return () => {
-    if (!painted) {
+export const MAX_HELD_CHARS = 256;
+
+/**
+ * Paces streamed publishes to one per frame while capping what a stop would discard.
+ *
+ * `length` is the caller's accumulated reply length. The gate closes on a publish and
+ * reopens on the next frame, or on UNPAINTED_REOPEN_MS when no frame comes. A closed
+ * gate publishes anyway once MAX_HELD_CHARS have arrived since the last publish.
+ */
+export function createStreamPublishGate(): (length: number) => boolean {
+  let open = true;
+  let publishedLength = 0;
+  return (length: number) => {
+    if (!open && length - publishedLength < MAX_HELD_CHARS) {
       return false;
     }
-    painted = false;
-    schedule(() => {
-      painted = true;
-    });
+    publishedLength = length;
+    if (open) {
+      open = false;
+      // Per cycle, so the loser of the previous race cannot reopen this one.
+      let reopened = false;
+      const reopen = () => {
+        if (reopened) {
+          return;
+        }
+        reopened = true;
+        cancelAnimationFrame(frame);
+        clearTimeout(timer);
+        open = true;
+      };
+      const frame = requestAnimationFrame(reopen);
+      const timer = setTimeout(reopen, UNPAINTED_REOPEN_MS);
+    }
     return true;
   };
 }

--- a/studio/frontend/src/features/chat/utils/stream-pacing.ts
+++ b/studio/frontend/src/features/chat/utils/stream-pacing.ts
@@ -1,8 +1,12 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-// Hidden or heavily janked windows may not produce frames, so bound the wait.
-const UNPAINTED_REOPEN_MS = 500;
+// A janked window may not paint for a long time, so do not wait on frames
+// alone. This is a scheduled fallback, not a deadline: a hidden page throttles
+// this timer too (>=1s, and ~1/min once Chrome's intensive throttling kicks in),
+// and pauses frames outright. There the cap below is what paces publishes,
+// which is why the cap is counted in arrivals rather than in time.
+export const UNPAINTED_REOPEN_MS = 500;
 
 /**
  * Text a closed gate may hold before it publishes regardless.
@@ -34,17 +38,28 @@ export function createStreamPublishGate(): (streamed: number) => boolean {
       open = false;
       // Per cycle, so the loser of the previous race cannot reopen this one.
       let reopened = false;
+      // Initialised before reopen closes over them, so a scheduler that runs
+      // its callback synchronously cannot hit the temporal dead zone and throw
+      // out of the stream loop.
+      const handles: {
+        frame?: number;
+        timer?: ReturnType<typeof setTimeout>;
+      } = {};
       const reopen = () => {
         if (reopened) {
           return;
         }
         reopened = true;
-        cancelAnimationFrame(frame);
-        clearTimeout(timer);
+        if (handles.frame !== undefined) {
+          cancelAnimationFrame(handles.frame);
+        }
+        if (handles.timer !== undefined) {
+          clearTimeout(handles.timer);
+        }
         open = true;
       };
-      const frame = requestAnimationFrame(reopen);
-      const timer = setTimeout(reopen, UNPAINTED_REOPEN_MS);
+      handles.frame = requestAnimationFrame(reopen);
+      handles.timer = setTimeout(reopen, UNPAINTED_REOPEN_MS);
     }
     return true;
   };

--- a/studio/frontend/src/features/chat/utils/stream-pacing.ts
+++ b/studio/frontend/src/features/chat/utils/stream-pacing.ts
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// Hidden or heavily janked windows may not produce frames, so bound the wait.
+const UNPAINTED_REOPEN_MS = 500;
+
+/**
+ * Limits streamed publishes to one per browser frame.
+ *
+ * Reopening does not flush pending text. Stop can therefore omit text received
+ * during the current interval.
+ */
+export function createFrameGate(
+  schedule: (cb: () => void) => void = (cb) => {
+    let woken = false;
+    const wake = () => {
+      if (woken) {
+        return;
+      }
+      woken = true;
+      cb();
+    };
+    requestAnimationFrame(wake);
+    setTimeout(wake, UNPAINTED_REOPEN_MS);
+  },
+): () => boolean {
+  let painted = true;
+  return () => {
+    if (!painted) {
+      return false;
+    }
+    painted = false;
+    schedule(() => {
+      painted = true;
+    });
+    return true;
+  };
+}

--- a/studio/frontend/src/features/chat/utils/stream-pacing.ts
+++ b/studio/frontend/src/features/chat/utils/stream-pacing.ts
@@ -17,18 +17,19 @@ export const MAX_HELD_CHARS = 256;
 /**
  * Paces streamed publishes to one per frame while capping what a stop would discard.
  *
- * `length` is the caller's accumulated reply length. The gate closes on a publish and
- * reopens on the next frame, or on UNPAINTED_REOPEN_MS when no frame comes. A closed
- * gate publishes anyway once MAX_HELD_CHARS have arrived since the last publish.
+ * `streamed` counts the characters the caller has received. It must only grow, since
+ * the cap is on the arrivals a publish has yet to carry. The gate closes on a publish
+ * and reopens on the next frame, or on UNPAINTED_REOPEN_MS when no frame comes; a
+ * closed gate publishes anyway once MAX_HELD_CHARS have arrived since the last one.
  */
-export function createStreamPublishGate(): (length: number) => boolean {
+export function createStreamPublishGate(): (streamed: number) => boolean {
   let open = true;
-  let publishedLength = 0;
-  return (length: number) => {
-    if (!open && length - publishedLength < MAX_HELD_CHARS) {
+  let publishedAt = 0;
+  return (streamed: number) => {
+    if (!open && streamed - publishedAt < MAX_HELD_CHARS) {
       return false;
     }
-    publishedLength = length;
+    publishedAt = streamed;
     if (open) {
       open = false;
       // Per cycle, so the loser of the previous race cannot reopen this one.

--- a/studio/frontend/src/features/chat/utils/stream-pacing.ts
+++ b/studio/frontend/src/features/chat/utils/stream-pacing.ts
@@ -3,17 +3,15 @@
 
 // A janked window may not paint for a while, so do not wait on frames alone.
 // A scheduled fallback, not a deadline: a hidden page pauses frames and
-// throttles this timer (>=1s, ~1/min under Chrome's intensive throttling), so
-// there the cap below paces publishes. Hence a cap in arrivals, not in time.
+// throttles this timer too, which is why the cap below is in arrivals.
 export const UNPAINTED_REOPEN_MS = 500;
 
 /**
  * Text a closed gate may hold before it publishes regardless.
  *
  * assistant-ui drops whatever a run yields after an abort, so Stop keeps only the
- * last published text, and frames bound that hold in time rather than in volume:
- * the fallback above reopens a starved window, which is where the stream runs
- * fastest. Several frames' worth, so it binds only once frames are far apart.
+ * last published text. Frames bound that hold in time, not in volume, so this
+ * bounds it in volume. Several frames' worth, to bind only when frames are far apart.
  */
 export const MAX_HELD_CHARS = 256;
 
@@ -37,8 +35,8 @@ export function createStreamPublishGate(): (streamed: number) => boolean {
       open = false;
       // Per cycle, so the loser of the previous race cannot reopen this one.
       let reopened = false;
-      // Initialised before reopen closes over them, so a scheduler that calls
-      // back synchronously cannot hit the temporal dead zone and throw.
+      // Assigned before reopen closes over them, so a synchronous scheduler
+      // cannot hit the temporal dead zone.
       const handles: {
         frame?: number;
         timer?: ReturnType<typeof setTimeout>;

--- a/studio/frontend/tests/chat-stream-publish-gate.test.ts
+++ b/studio/frontend/tests/chat-stream-publish-gate.test.ts
@@ -5,167 +5,316 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import test from "node:test";
 
-import { createFrameGate } from "../src/features/chat/utils/stream-pacing.ts";
+import {
+  MAX_HELD_CHARS,
+  createStreamPublishGate,
+} from "../src/features/chat/utils/stream-pacing.ts";
 
-test("the gate reopens once per painted frame", () => {
-  const frames: Array<() => void> = [];
-  const canPublish = createFrameGate((cb) => frames.push(cb));
+type Scheduled = {
+  frames: Array<() => void>;
+  timers: { run: () => void; ms: number }[];
+  cancelledFrames: number[];
+  clearedTimers: number[];
+};
 
-  assert.equal(canPublish(), true, "the first chunk always publishes");
-  assert.equal(canPublish(), false);
-  assert.equal(canPublish(), false);
-  assert.equal(frames.length, 1, "one pending frame, not one per chunk");
-
-  frames.shift()?.();
-  assert.equal(canPublish(), true);
-  assert.equal(canPublish(), false);
-});
-
-test("a burst between frames collapses into one update", () => {
-  const frames: Array<() => void> = [];
-  const canPublish = createFrameGate((cb) => frames.push(cb));
-  const chunks = ["a", "b", "c", "d", "e", "f"];
-
-  let cumulative = "";
-  const published: string[] = [];
-  chunks.forEach((chunk, index) => {
-    cumulative += chunk;
-    // A frame lands after the third chunk.
-    if (index === 3) {
-      frames.shift()?.();
-    }
-    if (canPublish()) {
-      published.push(cumulative);
-    }
-  });
-
-  assert.deepEqual(published, ["a", "abcd"]);
-  // Skipped chunks remain accumulated for the next publish.
-  assert.equal(cumulative, "abcdef");
-});
-
-test("a quiet tail waits for another chunk or the caller's final update", () => {
-  const frames: Array<() => void> = [];
-  const canPublish = createFrameGate((cb) => frames.push(cb));
-  let cumulative = "";
-  const published: string[] = [];
-  const feed = (chunk: string) => {
-    cumulative += chunk;
-    if (canPublish()) {
-      published.push(cumulative);
-    }
-  };
-
-  feed("a");
-  feed("b");
-  feed("c");
-  // Reopening alone cannot publish the quiet tail.
-  frames.shift()?.();
-  assert.deepEqual(published, ["a"]);
-  assert.equal(
-    published.at(-1),
-    "a",
-    "Stop here would retain only the previous streamed update",
-  );
-
-  // The next chunk carries everything withheld.
-  feed("d");
-  assert.deepEqual(published, ["a", "abcd"]);
-});
-
-test("a stream slower than the frame rate is never held back", () => {
-  const frames: Array<() => void> = [];
-  const canPublish = createFrameGate((cb) => frames.push(cb));
-
-  for (let i = 0; i < 5; i += 1) {
-    assert.equal(canPublish(), true, `chunk ${i} publishes`);
-    frames.shift()?.();
-  }
-});
-
-/** Stub the default frame and timer schedulers. */
-function withStubbedScheduling(
-  body: (frames: Array<() => void>, timers: [() => void, number][]) => void,
-): void {
+/** Run `body` with the frame and timer schedulers replaced by recording stubs. */
+function withStubbedScheduling(body: (scheduled: Scheduled) => void): void {
   const globals = globalThis as unknown as {
     requestAnimationFrame: (cb: () => void) => number;
+    cancelAnimationFrame: (handle: number) => void;
     setTimeout: (cb: () => void, ms: number) => number;
+    clearTimeout: (handle: number | undefined) => void;
   };
-  const realFrame = globals.requestAnimationFrame;
-  const realTimeout = globals.setTimeout;
-  const frames: Array<() => void> = [];
-  const timers: [() => void, number][] = [];
-  globals.requestAnimationFrame = (cb) => frames.push(cb);
-  globals.setTimeout = (cb, ms) => timers.push([cb, ms]);
+  const real = {
+    requestAnimationFrame: globals.requestAnimationFrame,
+    cancelAnimationFrame: globals.cancelAnimationFrame,
+    setTimeout: globals.setTimeout,
+    clearTimeout: globals.clearTimeout,
+  };
+  const scheduled: Scheduled = {
+    frames: [],
+    timers: [],
+    cancelledFrames: [],
+    clearedTimers: [],
+  };
+  globals.requestAnimationFrame = (cb) => scheduled.frames.push(cb);
+  globals.cancelAnimationFrame = (handle) => {
+    scheduled.cancelledFrames.push(handle);
+  };
+  globals.setTimeout = (run, ms) => scheduled.timers.push({ run, ms });
+  globals.clearTimeout = (handle) => {
+    scheduled.clearedTimers.push(handle as number);
+  };
   try {
-    body(frames, timers);
+    body(scheduled);
   } finally {
-    globals.requestAnimationFrame = realFrame;
-    globals.setTimeout = realTimeout;
+    Object.assign(globals, real);
   }
 }
 
-test("the default gate waits for a frame", () => {
-  withStubbedScheduling((frames, timers) => {
-    const canPublish = createFrameGate();
-    assert.equal(canPublish(), true);
-    assert.equal(frames.length, 1, "the wait is on a frame, not a timer alone");
-    assert.equal(canPublish(), false);
-    frames[0]?.();
-    assert.equal(canPublish(), true);
-    assert.ok(timers.length > 0);
+/** A stream feeding one gate, recording what each publish would carry. */
+function streamThrough(canPublish: (length: number) => boolean) {
+  let cumulative = "";
+  const published: string[] = [];
+  return {
+    feed(chunk: string) {
+      cumulative += chunk;
+      if (canPublish(cumulative.length)) {
+        published.push(cumulative);
+      }
+    },
+    published,
+    get cumulative() {
+      return cumulative;
+    },
+    /** What a stop right now would discard, since only published text survives. */
+    get held() {
+      return cumulative.length - (published.at(-1)?.length ?? 0);
+    },
+  };
+}
+
+test("the gate reopens once per frame", () => {
+  withStubbedScheduling(({ frames }) => {
+    const canPublish = createStreamPublishGate();
+
+    assert.equal(canPublish(1), true, "the first chunk always publishes");
+    assert.equal(canPublish(2), false);
+    assert.equal(canPublish(3), false);
+    assert.equal(frames.length, 1, "one pending frame, not one per chunk");
+
+    frames.shift()?.();
+    assert.equal(canPublish(4), true);
+    assert.equal(canPublish(5), false);
   });
 });
 
-test("the default gate reopens even when no frame ever comes", () => {
-  withStubbedScheduling((frames, timers) => {
-    const canPublish = createFrameGate();
-    assert.equal(canPublish(), true);
-    assert.equal(canPublish(), false);
-    assert.equal(frames.length, 1);
-    const [wake, delay] = timers[0] ?? [];
-    assert.equal(delay, 500, "the fallback bounds one unpainted interval");
-    wake?.();
-    assert.equal(canPublish(), true, "a stream off screen still lands updates");
+test("a burst between frames collapses into one update", () => {
+  withStubbedScheduling(({ frames }) => {
+    const stream = streamThrough(createStreamPublishGate());
+
+    ["a", "b", "c", "d", "e", "f"].forEach((chunk, index) => {
+      // A frame lands before the fourth chunk.
+      if (index === 3) {
+        frames.shift()?.();
+      }
+      stream.feed(chunk);
+    });
+
+    assert.deepEqual(stream.published, ["a", "abcd"]);
+    // Skipped chunks remain accumulated for the next publish.
+    assert.equal(stream.cumulative, "abcdef");
+  });
+});
+
+test("a quiet tail waits for another chunk or the caller's final update", () => {
+  withStubbedScheduling(({ frames }) => {
+    const stream = streamThrough(createStreamPublishGate());
+
+    stream.feed("a");
+    stream.feed("b");
+    stream.feed("c");
+    frames.shift()?.();
+    assert.deepEqual(
+      stream.published,
+      ["a"],
+      "reopening alone cannot publish the quiet tail",
+    );
+
+    // The next chunk carries everything withheld.
+    stream.feed("d");
+    assert.deepEqual(stream.published, ["a", "abcd"]);
+  });
+});
+
+test("a stream slower than the frame rate is never held back", () => {
+  withStubbedScheduling(({ frames }) => {
+    const canPublish = createStreamPublishGate();
+
+    for (let length = 1; length <= 5; length += 1) {
+      assert.equal(canPublish(length), true, `chunk ${length} publishes`);
+      frames.shift()?.();
+    }
+  });
+});
+
+test("the gate reopens even when no frame ever comes", () => {
+  withStubbedScheduling(({ frames, timers }) => {
+    const canPublish = createStreamPublishGate();
+
+    assert.equal(canPublish(1), true);
+    assert.equal(canPublish(2), false);
+    assert.equal(frames.length, 1, "the wait is on a frame, not a timer alone");
+    assert.equal(
+      timers[0]?.ms,
+      500,
+      "the fallback bounds one unpainted interval",
+    );
+
+    timers[0]?.run();
+    assert.equal(
+      canPublish(3),
+      true,
+      "a stream off screen still lands updates",
+    );
+  });
+});
+
+test("whichever wakes the gate cancels the other", () => {
+  withStubbedScheduling(({ frames, cancelledFrames, clearedTimers }) => {
+    const canPublish = createStreamPublishGate();
+    canPublish(1);
+
+    frames[0]?.();
+    assert.deepEqual(cancelledFrames, [1], "the frame handle is released");
+    assert.equal(
+      clearedTimers.length,
+      1,
+      "the 500ms fallback is not left pending",
+    );
   });
 });
 
 test("a frame arriving after the timer already reopened grants nothing extra", () => {
-  withStubbedScheduling((frames, timers) => {
-    const canPublish = createFrameGate();
-    canPublish();
-    timers[0]?.[0]?.();
-    assert.equal(canPublish(), true);
+  withStubbedScheduling(({ frames, timers }) => {
+    const canPublish = createStreamPublishGate();
+    canPublish(1);
+
+    timers[0]?.run();
+    assert.equal(canPublish(2), true);
     // The frame from the first cycle is late; it must not open the second one.
     frames[0]?.();
-    assert.equal(canPublish(), false);
+    assert.equal(canPublish(3), false);
   });
 });
 
-test("the chat stream loop gates the publish, not just the yield", () => {
-  const source = readFileSync(
-    new URL("../src/features/chat/api/chat-adapter.ts", import.meta.url),
-    "utf8",
-  );
-  const loopStart = source.indexOf("const canPublish = createFrameGate()");
-  assert.ok(loopStart > 0, "the run creates one gate per request");
+test("a closed gate publishes rather than hold more than the cap", () => {
+  // No frame and no timer ever fires here, so only the cap can publish again.
+  withStubbedScheduling(() => {
+    const stream = streamThrough(createStreamPublishGate());
 
-  const gate = source.indexOf("if (!canPublish()) {", loopStart);
-  const rebuild = source.indexOf(
+    stream.feed("a");
+    assert.deepEqual(stream.published, ["a"]);
+
+    stream.feed("b".repeat(MAX_HELD_CHARS - 2));
+    assert.equal(
+      stream.published.length,
+      1,
+      "a hold under the cap still coalesces",
+    );
+
+    stream.feed("cc");
+    assert.equal(stream.published.length, 2, "reaching the cap publishes");
+    assert.equal(stream.published.at(-1), stream.cumulative);
+  });
+});
+
+test("an unpainted burst never holds more than the cap", () => {
+  withStubbedScheduling(() => {
+    const stream = streamThrough(createStreamPublishGate());
+
+    for (let chunk = 0; chunk < 400; chunk += 1) {
+      stream.feed("0123456789");
+      assert.ok(
+        stream.held < MAX_HELD_CHARS,
+        `a stop after chunk ${chunk} would discard ${stream.held} characters`,
+      );
+    }
+  });
+});
+
+test("a painting window publishes on frames, never on the cap", () => {
+  withStubbedScheduling(({ frames }) => {
+    const stream = streamThrough(createStreamPublishGate());
+
+    // Two chunks well under the cap per frame is what a painting window looks like.
+    for (let frame = 0; frame < 20; frame += 1) {
+      stream.feed("x".repeat(30));
+      stream.feed("x".repeat(30));
+      frames.shift()?.();
+    }
+
+    assert.equal(stream.published.length, 20, "one publish per frame");
+  });
+});
+
+const ADAPTER = readFileSync(
+  new URL("../src/features/chat/api/chat-adapter.ts", import.meta.url),
+  "utf8",
+);
+
+/** Drop comments, so a commented-out gate cannot satisfy a search. */
+function withoutComments(source: string): string {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .split("\n")
+    .map((line) => {
+      const at = line.indexOf("//");
+      if (at === -1) {
+        return line;
+      }
+      // Keep a line whose "//" sits inside a string literal, as in "https://".
+      const quotes = line.slice(0, at).match(/["'`]/g)?.length ?? 0;
+      return quotes % 2 === 1 ? line : line.slice(0, at);
+    })
+    .join("\n");
+}
+
+/** The adapter between two anchors, without its comments. */
+function regionOf(from: string, to: string): string {
+  const start = ADAPTER.indexOf(from);
+  assert.notEqual(start, -1, `"${from}" is gone; this test needs rewriting`);
+  const end = ADAPTER.indexOf(to, start);
+  assert.notEqual(end, -1, `"${to}" is gone; this test needs rewriting`);
+  return withoutComments(ADAPTER.slice(start, end));
+}
+
+test("the stream loop gates the text publish, not just the yield", () => {
+  const loop = regionOf(
+    "for await (const chunk of stream) {",
+    "} catch (streamError) {",
+  );
+
+  const gate = loop.indexOf("if (!canPublish(cumulativeText.length)) {");
+  assert.notEqual(gate, -1, "the text publish is not gated");
+  const rebuild = loop.indexOf(
     "const assistantContent = liveAssistantContent()",
-    loopStart,
   );
-  assert.ok(
-    gate > 0 && rebuild > gate,
-    "the gate precedes the message rebuild",
-  );
-  const skip = source.indexOf("continue;", gate);
+  assert.ok(rebuild > gate, "the gate must precede the message rebuild");
+  const skip = loop.indexOf("continue;", gate);
   assert.ok(
     skip > gate && skip < rebuild,
-    "a closed gate skips the rebuild instead of becoming a no-op",
+    "a closed gate must skip the rebuild instead of becoming a no-op",
   );
 
-  // Accumulate text before the gate so skipped chunks are retained.
-  const append = source.indexOf("cumulativeText += delta", loopStart);
-  assert.ok(append > 0 && append < gate);
+  // Accumulate before the gate, so the next publish still carries a skipped chunk.
+  const append = loop.indexOf("cumulativeText += delta");
+  assert.ok(append !== -1 && append < gate);
+});
+
+test("the run creates one gate, not one per chunk", () => {
+  const source = withoutComments(ADAPTER);
+
+  const construction = source.indexOf(
+    "const canPublish = createStreamPublishGate()",
+  );
+  assert.notEqual(construction, -1, "the gate is gone");
+  const loop = source.indexOf("for await (const chunk of stream) {");
+  assert.notEqual(loop, -1, "the stream loop is gone");
+  assert.ok(
+    construction < loop,
+    "a gate built inside the loop is new for every chunk, so it coalesces nothing",
+  );
+});
+
+test("the live tool-argument preview shares the gate", () => {
+  const preview = regionOf(
+    'if (toolEvent.type === "tool_args") {',
+    "\n                closeReasoningContent();",
+  );
+
+  const gate = preview.indexOf("if (canPublish(cumulativeText.length)) {");
+  assert.notEqual(gate, -1, "the per-argument-delta preview is not gated");
+  const rebuild = preview.indexOf("content: liveAssistantContent()");
+  assert.ok(rebuild > gate, "the gate must precede the message rebuild");
 });

--- a/studio/frontend/tests/chat-stream-publish-gate.test.ts
+++ b/studio/frontend/tests/chat-stream-publish-gate.test.ts
@@ -534,10 +534,15 @@ test("the stream loop stamps when a held chunk arrived", () => {
   );
 
   const gate = loop.search(/if \([^)]*!canPublish\(streamedChars\)\) \{/);
-  const stamp = loop.indexOf("gateHeldSince ??= Date.now();", gate);
-  const skip = loop.indexOf("continue;", gate);
+  const stamp = loop.indexOf("gateHeldSince ??= Date.now();");
+  const close = loop.indexOf("gateReasoningEndedAt ??= Date.now();");
   assert.notEqual(stamp, -1, "a held chunk's arrival time is not recorded");
-  assert.ok(stamp < skip, "the stamp must be taken before the chunk is skipped");
+  // Before the close check, not just before the gate: a chunk carrying a
+  // COMPLETE <think>...</think> block has to stamp its own start early enough
+  // for its own end check to see it, or the end falls to the next arrival and
+  // any pause in between is charged to the reasoning.
+  assert.ok(stamp < close, "the arrival stamp must precede the close check");
+  assert.ok(stamp < gate, "and be taken whether or not the chunk publishes");
   assert.ok(
     loop.includes("reconcileReasoning(assistantContent, reasoningSeenAt)"),
     "the publish does not hand the arrival time to the tracker",
@@ -616,6 +621,20 @@ test("the replay-only publish reconciles like the other two", () => {
   const yielded = loop.indexOf("content: replayContent,", branch);
   assert.notEqual(reconcile, -1, "the replay publish does not reconcile");
   assert.ok(reconcile < yielded, "it must reconcile before it yields");
+});
+
+test("every publish path reconciles, including the backend tool events", () => {
+  const source = withoutComments(ADAPTER);
+
+  // Four paths can be the first to expose a group the gate is holding: the
+  // normal text publish, the forced tool-call publish, the replay-only publish
+  // and the ungated _toolEvent publish. Each needs the shared transition, and
+  // the last one was missed twice.
+  const calls = source.match(/reconcileReasoning\(/g) ?? [];
+  assert.ok(
+    calls.length >= 4,
+    `every publish path must reconcile; found ${calls.length} call sites`,
+  );
 });
 
 test("a scheduler that calls back synchronously does not throw", () => {

--- a/studio/frontend/tests/chat-stream-publish-gate.test.ts
+++ b/studio/frontend/tests/chat-stream-publish-gate.test.ts
@@ -9,6 +9,7 @@ import {
   MAX_HELD_CHARS,
   createStreamPublishGate,
 } from "../src/features/chat/utils/stream-pacing.ts";
+import { createReasoningDurationTracker } from "../src/features/chat/utils/reasoning-duration.ts";
 
 type Scheduled = {
   frames: Array<() => void>;
@@ -361,7 +362,7 @@ test("the gate is fed a counter that only grows", () => {
 test("a reasoning group the gate skipped is adopted before the final metadata", () => {
   const source = withoutComments(ADAPTER);
 
-  const adopt = source.indexOf("adoptGatedReasoningGroups(finalContent);");
+  const adopt = source.indexOf("adoptGatedReasoningGroups(finalContent,");
   assert.notEqual(adopt, -1, "a group revealed only by skipped chunks is lost");
   // Scoped to the finalizer, so a finishGroup() belonging to some later path
   // cannot stand in for the one that has to follow the adoption here.
@@ -381,7 +382,7 @@ test("the interrupted-stream partial adopts skipped groups too", () => {
   // needs the same adoption; otherwise an interrupted reply renders a reasoning
   // group with no duration entry behind it.
   assert.ok(
-    source.includes("adoptGatedReasoningGroups(partialContent);"),
+    source.includes("adoptGatedReasoningGroups(partialContent,"),
     "the non-abort failure path does not adopt gate-hidden reasoning groups",
   );
 });
@@ -454,6 +455,42 @@ test("a cap-forced publish resets the baseline for the next one", () => {
       assert.equal(canPublish(at), true, `cycle ${cycle} published at the cap`);
     }
   });
+});
+
+test("a gated reasoning group is timed from when it arrived", () => {
+  // The gate can only parse a group out of the text on a publishing chunk. A
+  // pass shorter than the cap, in a window that produces no frames, is revealed
+  // only at the terminal adoption, so without the arrival stamp it would start
+  // and finish there and persist 0s for a pass that really took seconds.
+  let clock = 0;
+  const tracker = createReasoningDurationTracker(() => clock);
+
+  clock = 1_000;
+  const arrivedAt = clock;         // the reasoning lands here, gate closed
+  clock = 11_000;                  // ...and is only parsed out ten seconds later
+  tracker.startGroup(0, arrivedAt);
+  tracker.finishGroup();
+
+  const durations = (tracker.metadata() as { reasoningDurations?: number[] })
+    .reasoningDurations;
+  assert.deepEqual(durations, [10], "the group must span its real arrival");
+});
+
+test("the stream loop stamps when a held chunk arrived", () => {
+  const loop = regionOf(
+    "for await (const chunk of stream) {",
+    "} catch (streamError) {",
+  );
+
+  const gate = loop.indexOf("if (!canPublish(streamedChars)) {");
+  const stamp = loop.indexOf("gateHeldSince ??= Date.now();", gate);
+  const skip = loop.indexOf("continue;", gate);
+  assert.notEqual(stamp, -1, "a held chunk's arrival time is not recorded");
+  assert.ok(stamp < skip, "the stamp must be taken before the chunk is skipped");
+  assert.ok(
+    loop.includes("reasoningSeenAt,"),
+    "the publish does not hand the arrival time to the tracker",
+  );
 });
 
 test("a scheduler that calls back synchronously does not throw", () => {

--- a/studio/frontend/tests/chat-stream-publish-gate.test.ts
+++ b/studio/frontend/tests/chat-stream-publish-gate.test.ts
@@ -275,7 +275,7 @@ test("the stream loop gates the text publish, not just the yield", () => {
     "} catch (streamError) {",
   );
 
-  const gate = loop.indexOf("if (!canPublish(cumulativeText.length)) {");
+  const gate = loop.indexOf("if (!canPublish(streamedChars)) {");
   assert.notEqual(gate, -1, "the text publish is not gated");
   const rebuild = loop.indexOf(
     "const assistantContent = liveAssistantContent()",
@@ -313,8 +313,52 @@ test("the live tool-argument preview shares the gate", () => {
     "\n                closeReasoningContent();",
   );
 
-  const gate = preview.indexOf("if (canPublish(cumulativeText.length)) {");
+  const gate = preview.indexOf("if (canPublish(streamedChars)) {");
   assert.notEqual(gate, -1, "the per-argument-delta preview is not gated");
   const rebuild = preview.indexOf("content: liveAssistantContent()");
   assert.ok(rebuild > gate, "the gate must precede the message rebuild");
+
+  // Argument deltas never reach cumulativeText, so without this the cap can
+  // never fire on a turn that is only streaming a tool call's arguments.
+  const count = preview.indexOf("streamedChars += fragment.length;");
+  assert.ok(
+    count !== -1 && count < gate,
+    "arguments must count toward the cap",
+  );
+});
+
+test("the gate is fed a counter that only grows", () => {
+  const source = withoutComments(ADAPTER);
+
+  // cumulativeText shrinks when the ${...} strip fires, which would let a closed
+  // gate hold the removed length on top of the cap before publishing again.
+  assert.equal(
+    source.indexOf("canPublish(cumulativeText"),
+    -1,
+    "the cap must not be measured against the mutable reply length",
+  );
+  assert.ok(source.includes("let streamedChars = 0;"), "the counter is gone");
+  const writes = source.match(/streamedChars\s*[+^*/-]?=[^=]/g) ?? [];
+  assert.equal(
+    writes.filter((write) => write.startsWith("streamedChars +=")).length,
+    writes.length - 1,
+    "the counter may only be initialised once and incremented after",
+  );
+});
+
+test("a reasoning group the gate skipped is adopted before the final metadata", () => {
+  const source = withoutComments(ADAPTER);
+
+  const adopt = source.indexOf(
+    "if (finalReasoningGroups > reasoningDurationTracker.groupCount) {",
+  );
+  assert.notEqual(adopt, -1, "a group revealed only by skipped chunks is lost");
+  const finalize = source.indexOf(
+    "reasoningDurationTracker.finishGroup();",
+    adopt,
+  );
+  assert.ok(
+    finalize > adopt,
+    "the group must be adopted before the run finalizes durations",
+  );
 });

--- a/studio/frontend/tests/chat-stream-publish-gate.test.ts
+++ b/studio/frontend/tests/chat-stream-publish-gate.test.ts
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+import { createFrameGate } from "../src/features/chat/utils/stream-pacing.ts";
+
+test("the gate reopens once per painted frame", () => {
+  const frames: Array<() => void> = [];
+  const canPublish = createFrameGate((cb) => frames.push(cb));
+
+  assert.equal(canPublish(), true, "the first chunk always publishes");
+  assert.equal(canPublish(), false);
+  assert.equal(canPublish(), false);
+  assert.equal(frames.length, 1, "one pending frame, not one per chunk");
+
+  frames.shift()?.();
+  assert.equal(canPublish(), true);
+  assert.equal(canPublish(), false);
+});
+
+test("a burst between frames collapses into one update", () => {
+  const frames: Array<() => void> = [];
+  const canPublish = createFrameGate((cb) => frames.push(cb));
+  const chunks = ["a", "b", "c", "d", "e", "f"];
+
+  let cumulative = "";
+  const published: string[] = [];
+  chunks.forEach((chunk, index) => {
+    cumulative += chunk;
+    // A frame lands after the third chunk.
+    if (index === 3) {
+      frames.shift()?.();
+    }
+    if (canPublish()) {
+      published.push(cumulative);
+    }
+  });
+
+  assert.deepEqual(published, ["a", "abcd"]);
+  // Skipped chunks remain accumulated for the next publish.
+  assert.equal(cumulative, "abcdef");
+});
+
+test("a quiet tail waits for another chunk or the caller's final update", () => {
+  const frames: Array<() => void> = [];
+  const canPublish = createFrameGate((cb) => frames.push(cb));
+  let cumulative = "";
+  const published: string[] = [];
+  const feed = (chunk: string) => {
+    cumulative += chunk;
+    if (canPublish()) {
+      published.push(cumulative);
+    }
+  };
+
+  feed("a");
+  feed("b");
+  feed("c");
+  // Reopening alone cannot publish the quiet tail.
+  frames.shift()?.();
+  assert.deepEqual(published, ["a"]);
+  assert.equal(
+    published.at(-1),
+    "a",
+    "Stop here would retain only the previous streamed update",
+  );
+
+  // The next chunk carries everything withheld.
+  feed("d");
+  assert.deepEqual(published, ["a", "abcd"]);
+});
+
+test("a stream slower than the frame rate is never held back", () => {
+  const frames: Array<() => void> = [];
+  const canPublish = createFrameGate((cb) => frames.push(cb));
+
+  for (let i = 0; i < 5; i += 1) {
+    assert.equal(canPublish(), true, `chunk ${i} publishes`);
+    frames.shift()?.();
+  }
+});
+
+/** Stub the default frame and timer schedulers. */
+function withStubbedScheduling(
+  body: (frames: Array<() => void>, timers: [() => void, number][]) => void,
+): void {
+  const globals = globalThis as unknown as {
+    requestAnimationFrame: (cb: () => void) => number;
+    setTimeout: (cb: () => void, ms: number) => number;
+  };
+  const realFrame = globals.requestAnimationFrame;
+  const realTimeout = globals.setTimeout;
+  const frames: Array<() => void> = [];
+  const timers: [() => void, number][] = [];
+  globals.requestAnimationFrame = (cb) => frames.push(cb);
+  globals.setTimeout = (cb, ms) => timers.push([cb, ms]);
+  try {
+    body(frames, timers);
+  } finally {
+    globals.requestAnimationFrame = realFrame;
+    globals.setTimeout = realTimeout;
+  }
+}
+
+test("the default gate waits for a frame", () => {
+  withStubbedScheduling((frames, timers) => {
+    const canPublish = createFrameGate();
+    assert.equal(canPublish(), true);
+    assert.equal(frames.length, 1, "the wait is on a frame, not a timer alone");
+    assert.equal(canPublish(), false);
+    frames[0]?.();
+    assert.equal(canPublish(), true);
+    assert.ok(timers.length > 0);
+  });
+});
+
+test("the default gate reopens even when no frame ever comes", () => {
+  withStubbedScheduling((frames, timers) => {
+    const canPublish = createFrameGate();
+    assert.equal(canPublish(), true);
+    assert.equal(canPublish(), false);
+    assert.equal(frames.length, 1);
+    const [wake, delay] = timers[0] ?? [];
+    assert.equal(delay, 500, "the fallback bounds one unpainted interval");
+    wake?.();
+    assert.equal(canPublish(), true, "a stream off screen still lands updates");
+  });
+});
+
+test("a frame arriving after the timer already reopened grants nothing extra", () => {
+  withStubbedScheduling((frames, timers) => {
+    const canPublish = createFrameGate();
+    canPublish();
+    timers[0]?.[0]?.();
+    assert.equal(canPublish(), true);
+    // The frame from the first cycle is late; it must not open the second one.
+    frames[0]?.();
+    assert.equal(canPublish(), false);
+  });
+});
+
+test("the chat stream loop gates the publish, not just the yield", () => {
+  const source = readFileSync(
+    new URL("../src/features/chat/api/chat-adapter.ts", import.meta.url),
+    "utf8",
+  );
+  const loopStart = source.indexOf("const canPublish = createFrameGate()");
+  assert.ok(loopStart > 0, "the run creates one gate per request");
+
+  const gate = source.indexOf("if (!canPublish()) {", loopStart);
+  const rebuild = source.indexOf(
+    "const assistantContent = liveAssistantContent()",
+    loopStart,
+  );
+  assert.ok(
+    gate > 0 && rebuild > gate,
+    "the gate precedes the message rebuild",
+  );
+  const skip = source.indexOf("continue;", gate);
+  assert.ok(
+    skip > gate && skip < rebuild,
+    "a closed gate skips the rebuild instead of becoming a no-op",
+  );
+
+  // Accumulate text before the gate so skipped chunks are retained.
+  const append = source.indexOf("cumulativeText += delta", loopStart);
+  assert.ok(append > 0 && append < gate);
+});

--- a/studio/frontend/tests/chat-stream-publish-gate.test.ts
+++ b/studio/frontend/tests/chat-stream-publish-gate.test.ts
@@ -402,7 +402,9 @@ test("streaming tool-call argument deltas are paced like the text path", () => {
   );
   assert.notEqual(count, -1, "tool-call argument deltas are not counted");
 
-  const gate = loop.indexOf("if (addedToolCall || canPublish(streamedChars)) {");
+  // Tolerant of extra forcing conditions (replay state), intolerant of the
+  // gate call going away.
+  const gate = loop.search(/addedToolCall \|\|[\s\S]{0,80}?canPublish\(streamedChars\)/);
   assert.notEqual(gate, -1, "the tool-call delta publish is not gated");
   assert.ok(gate > count, "the fragment must be counted before the gate");
 
@@ -537,8 +539,48 @@ test("the stream loop stamps when a held chunk arrived", () => {
   assert.notEqual(stamp, -1, "a held chunk's arrival time is not recorded");
   assert.ok(stamp < skip, "the stamp must be taken before the chunk is skipped");
   assert.ok(
-    loop.includes("reasoningSeenAt,"),
+    loop.includes("reconcileReasoning(assistantContent, reasoningSeenAt)"),
     "the publish does not hand the arrival time to the tracker",
+  );
+});
+
+test("a content-free replay delta still reaches the message", () => {
+  const loop = regionOf(
+    "for await (const chunk of stream) {",
+    "} catch (streamError) {",
+  );
+
+  // Gemini 3 ships a fragment whose only payload is a thoughtSignature, and the
+  // Codex client puts its reasoning ledger on a text-free terminal delta. The
+  // empty-content skip runs before the gate, so forcing a publish at the gate
+  // alone never sees either of them.
+  const replaySkip = loop.indexOf(
+    "if (replayStateChanged && !delta && !reasoning) {",
+  );
+  const emptySkip = loop.indexOf("if (!delta && !reasoning) {");
+  assert.notEqual(replaySkip, -1, "content-free replay metadata is dropped");
+  assert.ok(
+    replaySkip < emptySkip,
+    "replay state must be handled before the empty-content skip",
+  );
+});
+
+test("every publish runs the whole tracker transition, not just the start", () => {
+  const source = withoutComments(ADAPTER);
+
+  // Adopting a group and leaving it open yields a group with no duration behind
+  // it and keeps the timer running across whatever follows, so the forced
+  // tool-call publish and the normal publish share one reconciliation.
+  assert.ok(
+    source.includes("const reconcileReasoning = ("),
+    "the shared reasoning reconciliation is gone",
+  );
+  // Two CALL sites: the forced tool-call publish and the normal one. The
+  // definition uses `= (` and so does not match this.
+  const calls = source.match(/reconcileReasoning\(/g) ?? [];
+  assert.ok(
+    calls.length >= 2,
+    `both publish paths must reconcile; found ${calls.length} call sites`,
   );
 });
 

--- a/studio/frontend/tests/chat-stream-publish-gate.test.ts
+++ b/studio/frontend/tests/chat-stream-publish-gate.test.ts
@@ -284,7 +284,9 @@ test("the stream loop gates the text publish, not just the yield", () => {
     "} catch (streamError) {",
   );
 
-  const gate = loop.indexOf("if (!canPublish(streamedChars)) {");
+  // Tolerant of extra conditions on the same line (a state-bearing delta
+  // forces a publish), but not of the gate call going away.
+  const gate = loop.search(/if \([^)]*!canPublish\(streamedChars\)\) \{/);
   assert.notEqual(gate, -1, "the text publish is not gated");
   const rebuild = loop.indexOf(
     "const assistantContent = liveAssistantContent()",
@@ -420,7 +422,7 @@ test("a chunk with nothing to show does not spend the gate's publish", () => {
 
   const empty = loop.indexOf("mergeContinuation(cumulativeText).length === 0");
   assert.notEqual(empty, -1, "an emptied chunk still consumes a gate cycle");
-  const gate = loop.indexOf("if (!canPublish(streamedChars)) {");
+  const gate = loop.search(/if \([^)]*!canPublish\(streamedChars\)\) \{/);
   assert.ok(
     empty < gate,
     "the emptiness check must run before the gate is consulted",
@@ -476,13 +478,60 @@ test("a gated reasoning group is timed from when it arrived", () => {
   assert.deepEqual(durations, [10], "the group must span its real arrival");
 });
 
+test("groups revealed inside one discovery keep their measured zero", () => {
+  // Backdating the whole discovery would hand every skipped index the entire
+  // coalescing interval, so three groups revealed together would each claim the
+  // same 30s and overlap. Only the group still open takes the arrival time.
+  let clock = 0;
+  const tracker = createReasoningDurationTracker(() => clock);
+
+  const arrivedAt = 1_000;
+  clock = 31_000;
+  tracker.startGroup(2, arrivedAt);
+  tracker.finishGroup();
+
+  const durations = (tracker.metadata() as { reasoningDurations?: number[] })
+    .reasoningDurations;
+  assert.deepEqual(durations, [0, 0, 30]);
+});
+
+test("a state-bearing provider delta is never held by the gate", () => {
+  const loop = regionOf(
+    "for await (const chunk of stream) {",
+    "} catch (streamError) {",
+  );
+
+  // A thought signature or reasoning ledger reaches the message only through a
+  // yield, so holding one behind the gate loses it outright on Stop.
+  assert.ok(
+    loop.includes("let replayStateChanged = false;"),
+    "replay state changes are not tracked",
+  );
+  const gate = loop.search(/if \(!replayStateChanged && !canPublish\(/);
+  assert.notEqual(gate, -1, "replay state does not force a publish");
+});
+
+test("the reasoning timer stops on arrival, not on the next publish", () => {
+  const loop = regionOf(
+    "for await (const chunk of stream) {",
+    "} catch (streamError) {",
+  );
+
+  // finishGroup reads only pre-gate state, so deferring it to the next publish
+  // counted a post-reasoning pause as reasoning.
+  const finish = loop.indexOf("reasoningDurationTracker.finishGroup();");
+  const gate = loop.search(/if \([^)]*!canPublish\(streamedChars\)\) \{/);
+  assert.notEqual(finish, -1, "the group is never closed in the loop");
+  assert.ok(finish < gate, "the close must run before the gate can skip");
+});
+
 test("the stream loop stamps when a held chunk arrived", () => {
   const loop = regionOf(
     "for await (const chunk of stream) {",
     "} catch (streamError) {",
   );
 
-  const gate = loop.indexOf("if (!canPublish(streamedChars)) {");
+  const gate = loop.search(/if \([^)]*!canPublish\(streamedChars\)\) \{/);
   const stamp = loop.indexOf("gateHeldSince ??= Date.now();", gate);
   const skip = loop.indexOf("continue;", gate);
   assert.notEqual(stamp, -1, "a held chunk's arrival time is not recorded");

--- a/studio/frontend/tests/chat-stream-publish-gate.test.ts
+++ b/studio/frontend/tests/chat-stream-publish-gate.test.ts
@@ -584,6 +584,40 @@ test("every publish runs the whole tracker transition, not just the start", () =
   );
 });
 
+test("a group the gate never revealed is finished when it really ended", () => {
+  // The first <think>...</think> chunk can itself be gated, so the tracker has
+  // no group to close when the answer delta ends the reasoning. Finishing at
+  // the eventual publish charged the whole wait in between to the reasoning:
+  // a 1s pass followed by a 30s pause measured 31s.
+  let clock = 0;
+  const tracker = createReasoningDurationTracker(() => clock);
+
+  clock = 32_000;
+  tracker.startGroup(0, 1_000);
+  tracker.finishGroup(2_000);
+
+  const durations = (tracker.metadata() as { reasoningDurations?: number[] })
+    .reasoningDurations;
+  assert.deepEqual(durations, [1]);
+});
+
+test("the replay-only publish reconciles like the other two", () => {
+  const loop = regionOf(
+    "for await (const chunk of stream) {",
+    "} catch (streamError) {",
+  );
+
+  // It is a third publish path and can be the first to expose a held group.
+  const branch = loop.indexOf(
+    "if (replayStateChanged && !delta && !reasoning) {",
+  );
+  assert.notEqual(branch, -1, "the replay-only publish is gone");
+  const reconcile = loop.indexOf("reconcileReasoning(replayContent", branch);
+  const yielded = loop.indexOf("content: replayContent,", branch);
+  assert.notEqual(reconcile, -1, "the replay publish does not reconcile");
+  assert.ok(reconcile < yielded, "it must reconcile before it yields");
+});
+
 test("a scheduler that calls back synchronously does not throw", () => {
   const globals = globalThis as unknown as {
     requestAnimationFrame: (cb: () => void) => number;

--- a/studio/frontend/tests/chat-stream-publish-gate.test.ts
+++ b/studio/frontend/tests/chat-stream-publish-gate.test.ts
@@ -261,11 +261,19 @@ function withoutComments(source: string): string {
 }
 
 /** The adapter between two anchors, without its comments. */
-function regionOf(from: string, to: string): string {
+function regionOf(from: string, to: string, maxChars = 60_000): string {
   const start = ADAPTER.indexOf(from);
   assert.notEqual(start, -1, `"${from}" is gone; this test needs rewriting`);
   const end = ADAPTER.indexOf(to, start);
   assert.notEqual(end, -1, `"${to}" is gone; this test needs rewriting`);
+  // Without this, editing the end anchor's line (even adding a space) silently
+  // slides the region to the next match hundreds of lines away, and the
+  // ordering assertions below go on passing against the wrong slice.
+  assert.ok(
+    end - start < maxChars,
+    `the region from "${from}" to "${to}" is ${end - start} chars; ` +
+      "an anchor has drifted and this test needs rewriting",
+  );
   return withoutComments(ADAPTER.slice(start, end));
 }
 
@@ -311,6 +319,10 @@ test("the live tool-argument preview shares the gate", () => {
   const preview = regionOf(
     'if (toolEvent.type === "tool_args") {',
     "\n                closeReasoningContent();",
+    // This branch is short. Bounding it keeps a whitespace edit to the end
+    // anchor's line from sliding the region hundreds of lines down and leaving
+    // the ordering assertions below to pass against the wrong slice.
+    6_000,
   );
 
   const gate = preview.indexOf("if (canPublish(streamedChars)) {");
@@ -349,16 +361,132 @@ test("the gate is fed a counter that only grows", () => {
 test("a reasoning group the gate skipped is adopted before the final metadata", () => {
   const source = withoutComments(ADAPTER);
 
-  const adopt = source.indexOf(
-    "if (finalReasoningGroups > reasoningDurationTracker.groupCount) {",
-  );
+  const adopt = source.indexOf("adoptGatedReasoningGroups(finalContent);");
   assert.notEqual(adopt, -1, "a group revealed only by skipped chunks is lost");
-  const finalize = source.indexOf(
-    "reasoningDurationTracker.finishGroup();",
-    adopt,
-  );
-  assert.ok(
-    finalize > adopt,
+  // Scoped to the finalizer, so a finishGroup() belonging to some later path
+  // cannot stand in for the one that has to follow the adoption here.
+  const finalizer = source.slice(adopt, adopt + 400);
+  const finalize = finalizer.indexOf("reasoningDurationTracker.finishGroup();");
+  assert.notEqual(
+    finalize,
+    -1,
     "the group must be adopted before the run finalizes durations",
   );
+});
+
+test("the interrupted-stream partial adopts skipped groups too", () => {
+  const source = withoutComments(ADAPTER);
+
+  // A non-abort failure yields its own partial with its own metadata(), so it
+  // needs the same adoption; otherwise an interrupted reply renders a reasoning
+  // group with no duration entry behind it.
+  assert.ok(
+    source.includes("adoptGatedReasoningGroups(partialContent);"),
+    "the non-abort failure path does not adopt gate-hidden reasoning groups",
+  );
+});
+
+test("streaming tool-call argument deltas are paced like the text path", () => {
+  const loop = regionOf(
+    "for await (const chunk of stream) {",
+    "} catch (streamError) {",
+  );
+
+  // Both branches of the OpenAI delta.tool_calls accumulator feed the counter,
+  // so a turn that only streams a call's arguments is still capped.
+  const count = loop.indexOf(
+    "streamedChars +=\n                    argsFragment.length",
+  );
+  assert.notEqual(count, -1, "tool-call argument deltas are not counted");
+
+  const gate = loop.indexOf("if (addedToolCall || canPublish(streamedChars)) {");
+  assert.notEqual(gate, -1, "the tool-call delta publish is not gated");
+  assert.ok(gate > count, "the fragment must be counted before the gate");
+
+  // A fragment that introduces a call must never be coalesced away: that part
+  // is state an aborted turn would otherwise lose.
+  assert.ok(
+    loop.includes("addedToolCall = true;"),
+    "a newly created tool call no longer forces a publish",
+  );
+});
+
+test("a chunk with nothing to show does not spend the gate's publish", () => {
+  const loop = regionOf(
+    "for await (const chunk of stream) {",
+    "} catch (streamError) {",
+  );
+
+  const empty = loop.indexOf("mergeContinuation(cumulativeText).length === 0");
+  assert.notEqual(empty, -1, "an emptied chunk still consumes a gate cycle");
+  const gate = loop.indexOf("if (!canPublish(streamedChars)) {");
+  assert.ok(
+    empty < gate,
+    "the emptiness check must run before the gate is consulted",
+  );
+});
+
+test("the gate is fed every arrival, not only the tool-call ones", () => {
+  const loop = regionOf(
+    "for await (const chunk of stream) {",
+    "} catch (streamError) {",
+  );
+
+  // Without this the cap can never bind on a plain-text reply, which silently
+  // restores the unbounded stop loss the cap exists to prevent.
+  assert.ok(
+    loop.includes("streamedChars += reasoning.length + delta.length;"),
+    "text and reasoning arrivals are not counted toward the cap",
+  );
+});
+
+test("a cap-forced publish resets the baseline for the next one", () => {
+  withStubbedScheduling(() => {
+    const canPublish = createStreamPublishGate();
+    assert.equal(canPublish(0), true, "the first chunk publishes");
+
+    // No frame and no timer ever fire, so only the cap can publish. Each cycle
+    // must measure from the last publish; if the baseline only moved while the
+    // gate was open, the second cycle would publish on every single chunk.
+    for (let cycle = 1; cycle <= 4; cycle += 1) {
+      const at = cycle * MAX_HELD_CHARS;
+      assert.equal(canPublish(at - 1), false, `cycle ${cycle} held below cap`);
+      assert.equal(canPublish(at), true, `cycle ${cycle} published at the cap`);
+    }
+  });
+});
+
+test("a scheduler that calls back synchronously does not throw", () => {
+  const globals = globalThis as unknown as {
+    requestAnimationFrame: (cb: () => void) => number;
+  };
+  const real = globals.requestAnimationFrame;
+  // No browser does this, but a polyfill or a test double can, and reopen runs
+  // before the handles it cancels would have been assigned. Throwing here would
+  // escape the stream loop and surface as a failed generation.
+  globals.requestAnimationFrame = (cb) => {
+    cb();
+    return 1;
+  };
+  try {
+    const canPublish = createStreamPublishGate();
+    assert.equal(canPublish(0), true);
+    assert.equal(canPublish(1), true, "the synchronous frame reopened the gate");
+  } finally {
+    globals.requestAnimationFrame = real;
+  }
+});
+
+test("a cap-forced publish does not arm a second frame or timer", () => {
+  withStubbedScheduling((scheduled) => {
+    const canPublish = createStreamPublishGate();
+    canPublish(0);
+    assert.equal(scheduled.frames.length, 1);
+    assert.equal(scheduled.timers.length, 1);
+
+    canPublish(MAX_HELD_CHARS);
+    canPublish(MAX_HELD_CHARS * 2);
+    assert.equal(scheduled.frames.length, 1, "the cap re-armed a frame");
+    assert.equal(scheduled.timers.length, 1, "the cap re-armed a timer");
+  });
 });

--- a/studio/frontend/tests/chat-stream-publish-gate.test.ts
+++ b/studio/frontend/tests/chat-stream-publish-gate.test.ts
@@ -678,6 +678,58 @@ test("the arrival stamp survives a publish that adopted no group", () => {
   assert.ok(clear < finish, "the group is closed before the stamp is dropped");
 });
 
+test("a per-call thought signature forces a publish", () => {
+  const source = withoutComments(ADAPTER);
+
+  // Gemini carries the signature on the tool call itself, not only at message
+  // level, and the next turn is rejected outright without it. Updating an
+  // EXISTING call adds no part, so addedToolCall is false and the message-level
+  // latch never sees it; a Stop while the gate holds it persists a turn that
+  // cannot be replayed.
+  const update = source.indexOf("const prevExtra =");
+  assert.notEqual(update, -1, "the existing-call update path is gone");
+  const window = source.slice(update, update + 700);
+  assert.ok(
+    window.includes("replayStateChanged = true"),
+    "a changed per-call extra_content does not force a publish",
+  );
+  assert.ok(
+    window.includes("call.extra_content !== undefined"),
+    "the latch fires on calls that carry no extra_content at all",
+  );
+
+  // And the latch has to be honoured where the tool-call publish is decided.
+  const decide = source.indexOf("addedToolCall ||", update);
+  assert.ok(
+    decide !== -1 &&
+      source.slice(decide, decide + 120).includes("replayStateChanged"),
+    "the tool-call publish ignores the replay latch",
+  );
+});
+
+test("a chunk the strip left unchanged does not spend a gate cycle", () => {
+  const loop = regionOf(
+    "for await (const chunk of stream) {",
+    "} catch (streamError) {",
+  );
+
+  // The ${...} strip can return a nonempty reply to exactly its previous
+  // length. Checking only for an EMPTY reply lets that chunk consume the open
+  // cycle on an identical publish, and the next real token then waits for a
+  // frame, the timer or the cap.
+  const guard = loop.indexOf("cumulativeText.length === textLenBeforeChunk");
+  const gate = loop.indexOf("!canPublish(streamedChars)");
+  assert.notEqual(guard, -1, "an unchanged reply still reaches the gate");
+  assert.ok(guard < gate, "the skip must come before the gate is asked");
+
+  // Skipping must never swallow a publish that carries replay state.
+  const skip = loop.slice(guard, gate);
+  assert.ok(
+    skip.includes("!replayStateChanged"),
+    "the skip can drop a state-bearing publish",
+  );
+});
+
 test("a server reasoning summary is assigned to the gated group", () => {
   const source = withoutComments(ADAPTER);
 

--- a/studio/frontend/tests/chat-stream-publish-gate.test.ts
+++ b/studio/frontend/tests/chat-stream-publish-gate.test.ts
@@ -9,7 +9,12 @@ import {
   MAX_HELD_CHARS,
   createStreamPublishGate,
 } from "../src/features/chat/utils/stream-pacing.ts";
-import { createReasoningDurationTracker } from "../src/features/chat/utils/reasoning-duration.ts";
+import {
+  countReasoningGroups,
+  createReasoningDurationTracker,
+  lastReasoningGroupTextLength,
+} from "../src/features/chat/utils/reasoning-duration.ts";
+import { parseAssistantContent } from "../src/features/chat/utils/parse-assistant-content.ts";
 
 type Scheduled = {
   frames: Array<() => void>;
@@ -278,29 +283,157 @@ function regionOf(from: string, to: string, maxChars = 60_000): string {
   return withoutComments(ADAPTER.slice(start, end));
 }
 
-test("the stream loop gates the text publish, not just the yield", () => {
+test("the gate paces the publish, not the bookkeeping before it", () => {
   const loop = regionOf(
     "for await (const chunk of stream) {",
     "} catch (streamError) {",
   );
 
-  // Tolerant of extra conditions on the same line (a state-bearing delta
-  // forces a publish), but not of the gate call going away.
-  const gate = loop.search(/if \([^)]*!canPublish\(streamedChars\)\) \{/);
-  assert.notEqual(gate, -1, "the text publish is not gated");
+  // The whole shape of this change. Everything that interprets the stream --
+  // the content rebuild and the reasoning tracker -- runs on EVERY arrival, and
+  // only the yield to assistant-ui is coalesced. Pacing the interpretation too
+  // is what dragged reasoning timing, split tags, server summaries and replay
+  // metadata into a change that is about paint cost.
+  const append = loop.indexOf("cumulativeText += delta");
   const rebuild = loop.indexOf(
     "const assistantContent = liveAssistantContent()",
   );
-  assert.ok(rebuild > gate, "the gate must precede the message rebuild");
+  const track = loop.indexOf("countReasoningGroups(assistantContent)");
+  const finish = loop.indexOf("reasoningDurationTracker.finishGroup()");
+  const gate = loop.search(/if \([^)]*!canPublish\(streamedChars\)\) \{/);
+  const publish = loop.indexOf("content: assistantContent,");
+
+  for (const [name, at] of [
+    ["the text append", append],
+    ["the content rebuild", rebuild],
+    ["the reasoning tracker", track],
+    ["the group finish", finish],
+    ["the gate", gate],
+    ["the publish", publish],
+  ] as const) {
+    assert.notEqual(at, -1, `${name} is gone from the loop`);
+  }
+
+  assert.ok(append < rebuild, "the chunk must be accumulated before the rebuild");
+  assert.ok(rebuild < track, "the tracker reads the rebuilt content");
+  assert.ok(
+    finish < gate,
+    "the reasoning tracker must observe every arrival, not only publishing ones",
+  );
+  assert.ok(gate < publish, "the publish must be paced");
+
   const skip = loop.indexOf("continue;", gate);
   assert.ok(
-    skip > gate && skip < rebuild,
-    "a closed gate must skip the rebuild instead of becoming a no-op",
+    skip > gate && skip < publish,
+    "a closed gate must skip the publish instead of becoming a no-op",
   );
+});
 
-  // Accumulate before the gate, so the next publish still carries a skipped chunk.
-  const append = loop.indexOf("cumulativeText += delta");
-  assert.ok(append !== -1 && append < gate);
+test("pacing cannot change a reasoning duration", () => {
+  // The property the placement buys, stated directly: run the loop's
+  // interpretation over a set of arrivals, publish on every one, then publish
+  // on only the last, and require identical durations. Under the old placement
+  // each of these cases measured differently depending on which arrivals the
+  // gate let through, and each one cost a review round.
+  const hasUnclosed = (text: string) =>
+    text.lastIndexOf("<think>") > text.lastIndexOf("</think>");
+
+  const run = (
+    arrivals: Array<[number, string]>,
+    publishes: ReadonlySet<number>,
+  ) => {
+    let clock = 0;
+    const tracker = createReasoningDurationTracker(() => clock);
+    let cumulative = "";
+    let lastPublished = "";
+
+    arrivals.forEach(([at, delta], index) => {
+      clock = at;
+      cumulative += delta;
+      // Everything here is what the loop does before it consults the gate.
+      const content = parseAssistantContent(cumulative);
+      const groups = countReasoningGroups(content);
+      if (groups > tracker.groupCount) {
+        tracker.startGroup(groups - 1);
+      }
+      if (groups > 0) {
+        tracker.resumeGroup(groups - 1, lastReasoningGroupTextLength(content));
+      }
+      if (tracker.hasActiveGroup && !hasUnclosed(cumulative)) {
+        tracker.finishGroup();
+      }
+      if (publishes.has(index)) {
+        lastPublished = cumulative;
+      }
+    });
+    return { meta: tracker.metadata(), lastPublished };
+  };
+
+  const cases: Array<[string, Array<[number, string]>]> = [
+    [
+      "an opening tag split across two arrivals",
+      [[0, "Hello "], [1000, "<thi"], [1000, "nk>why"], [9000, "</think>"], [9500, "answer"]],
+    ],
+    [
+      "the opening tag as its own delta",
+      [[0, "<think>"], [1000, "body"], [30000, "</think>"], [30100, "answer"]],
+    ],
+    [
+      "several complete blocks in a row",
+      [[1000, "<think>a</think>"], [5000, "<think>b</think>"], [9000, "<think>c</think>"], [12000, "answer"]],
+    ],
+    [
+      "a later pass that opens bodyless",
+      [[1000, "<think>first</think>"], [2000, "text "], [3000, "<think>"], [4000, "second "], [30000, "more</think>"], [31000, "end"]],
+    ],
+    [
+      "a long pause between the reasoning and the answer",
+      [[1000, "<think>x"], [2000, "y</think>"], [32000, "answer"]],
+    ],
+  ];
+
+  for (const [name, arrivals] of cases) {
+    const everyChunk = run(
+      arrivals,
+      new Set(arrivals.map((_, index) => index)),
+    );
+    const onlyTheLast = run(arrivals, new Set([arrivals.length - 1]));
+    assert.deepEqual(
+      onlyTheLast.meta,
+      everyChunk.meta,
+      `pacing changed the durations for ${name}`,
+    );
+    assert.equal(
+      onlyTheLast.lastPublished,
+      everyChunk.lastPublished,
+      `pacing changed the final text for ${name}`,
+    );
+  }
+});
+
+test("no gate timestamp is threaded through the reasoning tracker", () => {
+  const source = withoutComments(ADAPTER);
+
+  // The tracker sees every arrival, so it never has to be told when something
+  // it missed happened. These are the names the deferred-parse design needed;
+  // if any comes back, the coalescing has leaked into the bookkeeping again.
+  for (const leaked of [
+    "gateHeldSince",
+    "gateReasoningEndedAt",
+    "reconcileReasoning",
+    "adoptGatedReasoningGroups",
+  ]) {
+    assert.ok(
+      !source.includes(leaked),
+      `${leaked} is back: the gate is deferring interpretation again`,
+    );
+  }
+
+  // And the tracker's own API stays free of the back-dating arguments.
+  assert.ok(
+    source.includes("reasoningDurationTracker.finishGroup()"),
+    "finishGroup is being given a timestamp again",
+  );
 });
 
 test("the run creates one gate, not one per chunk", () => {
@@ -361,34 +494,6 @@ test("the gate is fed a counter that only grows", () => {
   );
 });
 
-test("a reasoning group the gate skipped is adopted before the final metadata", () => {
-  const source = withoutComments(ADAPTER);
-
-  const adopt = source.indexOf("reconcileReasoning(finalContent,");
-  assert.notEqual(adopt, -1, "a group revealed only by skipped chunks is lost");
-  // Scoped to the finalizer, so a metadata() belonging to some later path
-  // cannot stand in for the one that has to follow the adoption here. The
-  // finish itself now lives inside reconcileReasoning, which is what makes it
-  // impossible for a caller to adopt and then forget to close.
-  const finalizer = source.slice(adopt, adopt + 600);
-  assert.ok(
-    finalizer.includes("reasoningDurationTracker.metadata()"),
-    "the group must be adopted before the run persists durations",
-  );
-});
-
-test("the interrupted-stream partial adopts skipped groups too", () => {
-  const source = withoutComments(ADAPTER);
-
-  // A non-abort failure yields its own partial with its own metadata(), so it
-  // needs the same adoption; otherwise an interrupted reply renders a reasoning
-  // group with no duration entry behind it.
-  assert.ok(
-    source.includes("reconcileReasoning(partialContent,"),
-    "the non-abort failure path does not adopt gate-hidden reasoning groups",
-  );
-});
-
 test("streaming tool-call argument deltas are paced like the text path", () => {
   const loop = regionOf(
     "for await (const chunk of stream) {",
@@ -413,21 +518,6 @@ test("streaming tool-call argument deltas are paced like the text path", () => {
   assert.ok(
     loop.includes("addedToolCall = true;"),
     "a newly created tool call no longer forces a publish",
-  );
-});
-
-test("a chunk with nothing to show does not spend the gate's publish", () => {
-  const loop = regionOf(
-    "for await (const chunk of stream) {",
-    "} catch (streamError) {",
-  );
-
-  const empty = loop.indexOf("mergeContinuation(cumulativeText).length === 0");
-  assert.notEqual(empty, -1, "an emptied chunk still consumes a gate cycle");
-  const gate = loop.search(/if \([^)]*!canPublish\(streamedChars\)\) \{/);
-  assert.ok(
-    empty < gate,
-    "the emptiness check must run before the gate is consulted",
   );
 });
 
@@ -461,42 +551,6 @@ test("a cap-forced publish resets the baseline for the next one", () => {
   });
 });
 
-test("a gated reasoning group is timed from when it arrived", () => {
-  // The gate can only parse a group out of the text on a publishing chunk. A
-  // pass shorter than the cap, in a window that produces no frames, is revealed
-  // only at the terminal adoption, so without the arrival stamp it would start
-  // and finish there and persist 0s for a pass that really took seconds.
-  let clock = 0;
-  const tracker = createReasoningDurationTracker(() => clock);
-
-  clock = 1_000;
-  const arrivedAt = clock;         // the reasoning lands here, gate closed
-  clock = 11_000;                  // ...and is only parsed out ten seconds later
-  tracker.startGroup(0, arrivedAt);
-  tracker.finishGroup();
-
-  const durations = (tracker.metadata() as { reasoningDurations?: number[] })
-    .reasoningDurations;
-  assert.deepEqual(durations, [10], "the group must span its real arrival");
-});
-
-test("groups revealed inside one discovery keep their measured zero", () => {
-  // Backdating the whole discovery would hand every skipped index the entire
-  // coalescing interval, so three groups revealed together would each claim the
-  // same 30s and overlap. Only the group still open takes the arrival time.
-  let clock = 0;
-  const tracker = createReasoningDurationTracker(() => clock);
-
-  const arrivedAt = 1_000;
-  clock = 31_000;
-  tracker.startGroup(2, arrivedAt);
-  tracker.finishGroup();
-
-  const durations = (tracker.metadata() as { reasoningDurations?: number[] })
-    .reasoningDurations;
-  assert.deepEqual(durations, [0, 0, 30]);
-});
-
 test("a state-bearing provider delta is never held by the gate", () => {
   const loop = regionOf(
     "for await (const chunk of stream) {",
@@ -511,42 +565,6 @@ test("a state-bearing provider delta is never held by the gate", () => {
   );
   const gate = loop.search(/if \(!replayStateChanged && !canPublish\(/);
   assert.notEqual(gate, -1, "replay state does not force a publish");
-});
-
-test("the reasoning timer stops on arrival, not on the next publish", () => {
-  const loop = regionOf(
-    "for await (const chunk of stream) {",
-    "} catch (streamError) {",
-  );
-
-  // finishGroup reads only pre-gate state, so deferring it to the next publish
-  // counted a post-reasoning pause as reasoning.
-  const finish = loop.search(/reasoningDurationTracker\.finishGroup\(/);
-  const gate = loop.search(/if \([^)]*!canPublish\(streamedChars\)\) \{/);
-  assert.notEqual(finish, -1, "the group is never closed in the loop");
-  assert.ok(finish < gate, "the close must run before the gate can skip");
-});
-
-test("the stream loop stamps when a held chunk arrived", () => {
-  const loop = regionOf(
-    "for await (const chunk of stream) {",
-    "} catch (streamError) {",
-  );
-
-  const gate = loop.search(/if \([^)]*!canPublish\(streamedChars\)\) \{/);
-  const stamp = loop.indexOf("gateHeldSince ??= Date.now();");
-  const close = loop.indexOf("gateReasoningEndedAt ??= Date.now();");
-  assert.notEqual(stamp, -1, "a held chunk's arrival time is not recorded");
-  // Before the close check, not just before the gate: a chunk carrying a
-  // COMPLETE <think>...</think> block has to stamp its own start early enough
-  // for its own end check to see it, or the end falls to the next arrival and
-  // any pause in between is charged to the reasoning.
-  assert.ok(stamp < close, "the arrival stamp must precede the close check");
-  assert.ok(stamp < gate, "and be taken whether or not the chunk publishes");
-  assert.ok(
-    loop.includes("reconcileReasoning(assistantContent, reasoningSeenAt)"),
-    "the publish does not hand the arrival time to the tracker",
-  );
 });
 
 test("a content-free replay delta still reaches the message", () => {
@@ -568,114 +586,6 @@ test("a content-free replay delta still reaches the message", () => {
     replaySkip < emptySkip,
     "replay state must be handled before the empty-content skip",
   );
-});
-
-test("every publish runs the whole tracker transition, not just the start", () => {
-  const source = withoutComments(ADAPTER);
-
-  // Adopting a group and leaving it open yields a group with no duration behind
-  // it and keeps the timer running across whatever follows, so the forced
-  // tool-call publish and the normal publish share one reconciliation.
-  assert.ok(
-    source.includes("const reconcileReasoning = ("),
-    "the shared reasoning reconciliation is gone",
-  );
-  // Two CALL sites: the forced tool-call publish and the normal one. The
-  // definition uses `= (` and so does not match this.
-  const calls = source.match(/reconcileReasoning\(/g) ?? [];
-  assert.ok(
-    calls.length >= 2,
-    `both publish paths must reconcile; found ${calls.length} call sites`,
-  );
-});
-
-test("a group the gate never revealed is finished when it really ended", () => {
-  // The first <think>...</think> chunk can itself be gated, so the tracker has
-  // no group to close when the answer delta ends the reasoning. Finishing at
-  // the eventual publish charged the whole wait in between to the reasoning:
-  // a 1s pass followed by a 30s pause measured 31s.
-  let clock = 0;
-  const tracker = createReasoningDurationTracker(() => clock);
-
-  clock = 32_000;
-  tracker.startGroup(0, 1_000);
-  tracker.finishGroup(2_000);
-
-  const durations = (tracker.metadata() as { reasoningDurations?: number[] })
-    .reasoningDurations;
-  assert.deepEqual(durations, [1]);
-});
-
-test("the replay-only publish reconciles like the other two", () => {
-  const loop = regionOf(
-    "for await (const chunk of stream) {",
-    "} catch (streamError) {",
-  );
-
-  // It is a third publish path and can be the first to expose a held group.
-  const branch = loop.indexOf(
-    "if (replayStateChanged && !delta && !reasoning) {",
-  );
-  assert.notEqual(branch, -1, "the replay-only publish is gone");
-  const reconcile = loop.indexOf("reconcileReasoning(replayContent", branch);
-  const yielded = loop.indexOf("content: replayContent,", branch);
-  assert.notEqual(reconcile, -1, "the replay publish does not reconcile");
-  assert.ok(reconcile < yielded, "it must reconcile before it yields");
-});
-
-test("every publish path reconciles, including the backend tool events", () => {
-  const source = withoutComments(ADAPTER);
-
-  // Four paths can be the first to expose a group the gate is holding: the
-  // normal text publish, the forced tool-call publish, the replay-only publish
-  // and the ungated _toolEvent publish. Each needs the shared transition, and
-  // the last one was missed twice.
-  const calls = source.match(/reconcileReasoning\(/g) ?? [];
-  assert.ok(
-    calls.length >= 4,
-    `every publish path must reconcile; found ${calls.length} call sites`,
-  );
-});
-
-test("the arrival stamp survives a publish that adopted no group", () => {
-  const source = withoutComments(ADAPTER);
-
-  // A provider can emit a bare "<think>" as its own delta. It parses to no
-  // parts at all, so a publish there is timing nothing yet; if it cleared the
-  // stamp, the group would start at whatever later publish first sees the body.
-  // Exactly one place may clear it, so a new publish path cannot get this wrong
-  // by omission.
-  const clears = [...source.matchAll(/gateHeldSince = undefined;/g)];
-  assert.equal(clears.length, 1, "the stamp is cleared in more than one place");
-
-  // And a mere group COUNT is not enough to clear on: an earlier pass leaves
-  // groups > 0 while a later bodyless pass is still pending, so the clear has
-  // to be gated on a group actually being timed, after the resume that could
-  // have started timing it.
-  const reconcile = source.indexOf("const reconcileReasoning = (");
-  const resume = source.indexOf("reasoningDurationTracker.resumeGroup(", reconcile);
-  const guard = source.indexOf(
-    "if (reasoningDurationTracker.hasActiveGroup) {",
-    reconcile,
-  );
-  const clear = clears[0].index ?? 0;
-  assert.ok(reconcile !== -1 && resume !== -1, "the reconcile shape changed");
-  assert.ok(
-    guard !== -1 && guard < clear,
-    "the stamp is cleared without checking that a group is being timed",
-  );
-  assert.ok(
-    resume < guard,
-    "the check runs before the resume that can start the timing",
-  );
-
-  // The finish must come after, or the clear would see the group it just closed
-  // as inactive and keep a stamp that has already been used.
-  const finish = source.indexOf(
-    "reasoningDurationTracker.finishGroup(",
-    reconcile,
-  );
-  assert.ok(clear < finish, "the group is closed before the stamp is dropped");
 });
 
 test("a per-call thought signature forces a publish", () => {
@@ -707,155 +617,37 @@ test("a per-call thought signature forces a publish", () => {
   );
 });
 
-test("a chunk the strip left unchanged does not spend a gate cycle", () => {
+test("a chunk with nothing new to show does not spend a gate cycle", () => {
   const loop = regionOf(
     "for await (const chunk of stream) {",
     "} catch (streamError) {",
   );
 
-  // The ${...} strip can return a nonempty reply to exactly its previous
-  // length. Checking only for an EMPTY reply lets that chunk consume the open
-  // cycle on an identical publish, and the next real token then waits for a
+  // Two shapes, one guard. The reply can be empty, and the ${...} strip can
+  // return a nonempty reply to exactly its previous length -- the Mistral case.
+  // Either way the publish would be identical to the last one, and asking the
+  // gate would spend the open cycle on it and hold the next real token until a
   // frame, the timer or the cap.
-  const guard = loop.indexOf("cumulativeText.length === textLenBeforeChunk");
-  const gate = loop.indexOf("!canPublish(streamedChars)");
-  assert.notEqual(guard, -1, "an unchanged reply still reaches the gate");
-  assert.ok(guard < gate, "the skip must come before the gate is asked");
+  const emptied = loop.indexOf("assistantContent.length === 0");
+  const unchanged = loop.indexOf(
+    "cumulativeText.length === textLenBeforeChunk",
+  );
+  const gate = loop.search(/if \([^)]*!canPublish\(streamedChars\)\) \{/);
+  assert.notEqual(emptied, -1, "an emptied reply still reaches the gate");
+  assert.notEqual(unchanged, -1, "an unchanged reply still reaches the gate");
+  assert.ok(
+    emptied < gate && unchanged < gate,
+    "the skip must come before the gate is asked",
+  );
 
-  // Skipping must never swallow a publish that carries replay state.
-  const skip = loop.slice(guard, gate);
+  // Skipping must never swallow a publish that carries replay state. The latch
+  // guards the condition, so look back from it rather than forward.
+  const start = loop.lastIndexOf("if (", Math.min(emptied, unchanged));
+  const skip = loop.slice(start, gate);
   assert.ok(
     skip.includes("!replayStateChanged"),
     "the skip can drop a state-bearing publish",
   );
-});
-
-test("a server reasoning summary is assigned to the gated group", () => {
-  const source = withoutComments(ADAPTER);
-
-  // The summary frame is authoritative and is consumed by index. A pass short
-  // enough to fit inside one gate window is not yet known to the tracker when
-  // its summary lands, so the value would be dropped and replaced by a local
-  // measurement. Adoption has to come first.
-  const consume = source.indexOf(
-    "reasoningDurationTracker.recordServerDuration(",
-  );
-  assert.notEqual(consume, -1, "the summary frame is no longer consumed");
-  const before = source.slice(Math.max(0, consume - 600), consume);
-  assert.ok(
-    before.includes("reconcileReasoning("),
-    "the summary is consumed before the gated group is adopted",
-  );
-});
-
-test("the reconcile before the summary is skipped for ordinary chunks", () => {
-  const source = withoutComments(ADAPTER);
-
-  // Reconciling on EVERY chunk would re-parse the whole reply per chunk, which
-  // is exactly the cost the gate exists to remove. It must be conditional on a
-  // summary actually being present.
-  const consume = source.indexOf(
-    "reasoningDurationTracker.recordServerDuration(",
-  );
-  const before = source.slice(Math.max(0, consume - 600), consume);
-  const guard = before.lastIndexOf("if (reasoningMs !== undefined) {");
-  assert.ok(
-    guard !== -1 && guard < before.lastIndexOf("reconcileReasoning("),
-    "the pre-summary reconcile is unguarded and runs on every chunk",
-  );
-});
-
-test("an opening think tag split across arrivals still stamps", () => {
-  // A provider can split the literal tag: "<thi" then "nk>reasoning". Testing
-  // the delta alone misses it, and the group then starts only at the eventual
-  // publish. The search runs from just before the chunk's first character, so
-  // the tag is found at the join.
-  const THINK_OPEN = "<think>";
-  const opensOn = (deltas: string[]) => {
-    let cumulative = "";
-    const hits: number[] = [];
-    deltas.forEach((delta, index) => {
-      const before = cumulative.length;
-      cumulative += delta;
-      const at = cumulative.indexOf(
-        THINK_OPEN,
-        Math.max(0, before - (THINK_OPEN.length - 1)),
-      );
-      if (at !== -1) hits.push(index);
-    });
-    return hits;
-  };
-
-  assert.deepEqual(opensOn(["Hello ", "<thi", "nk>reasoning"]), [2]);
-  assert.deepEqual(opensOn(["Hello ", "<think>reasoning"]), [1]);
-  // Not re-stamped for text that merely follows the tag.
-  assert.deepEqual(opensOn(["<think>a", "b", "c"]), [0]);
-});
-
-test("the terminal publishes run the full reasoning transition", () => {
-  const source = withoutComments(ADAPTER);
-
-  // Adoption alone only covers a group the gate hid ENTIRELY. Reasoning held by
-  // the gate can also extend a group that already exists and was closed by the
-  // previous publish, where there is nothing to adopt and the duration stays
-  // frozen there. Both terminal paths need resume as well, which is what
-  // reconcileReasoning does, and the terminal flag lifts its unclosed-tag guard
-  // because no later publish is coming.
-  const terminal = [...source.matchAll(/reconcileReasoning\([^;]*?true\)/gs)];
-  assert.equal(
-    terminal.length,
-    2,
-    "the success finalizer and the interrupted partial must both finalize",
-  );
-  for (const match of terminal) {
-    assert.ok(
-      match[0].includes("gateHeldSince"),
-      "a terminal reconcile drops the arrival stamp",
-    );
-  }
-  assert.ok(
-    source.includes("if (final || !hasUnclosedThinkTag(cumulativeText)) {"),
-    "the terminal flag no longer lifts the unclosed-tag guard",
-  );
-});
-
-test("a new reasoning block invalidates the recorded end", () => {
-  const loop = regionOf(
-    "for await (const chunk of stream) {",
-    "} catch (streamError) {",
-  );
-
-  // Several complete <think>...</think> blocks in a row render as one group.
-  // Holding the FIRST block's close would finish the whole group there and drop
-  // every later block's time, so an arriving block has to clear it. Answer-only
-  // arrivals must not, or a pause after the reasoning re-enters the duration.
-  const arrival = loop.indexOf("if (reasoning || thinkOpenedNow) {");
-  const clear = loop.indexOf("gateReasoningEndedAt = undefined;", arrival);
-  const close = loop.indexOf("gateReasoningEndedAt ??= Date.now();");
-  assert.ok(arrival !== -1 && clear !== -1, "the invalidation is gone");
-  assert.ok(clear < close, "the stamp is cleared after the close records it");
-  assert.ok(
-    close !== -1,
-    "the close no longer records an end time at all",
-  );
-});
-
-test("an active group records its close time as well", () => {
-  const loop = regionOf(
-    "for await (const chunk of stream) {",
-    "} catch (streamError) {",
-  );
-
-  // A later publish can resumeGroup an active-and-closed group because its text
-  // grew; the finish that follows must use the close time, not the publish time.
-  const closed = loop.indexOf("const reasoningJustClosed =");
-  const stamp = loop.indexOf("gateReasoningEndedAt ??= Date.now();", closed);
-  const finish = loop.indexOf(
-    "reasoningDurationTracker.finishGroup(gateReasoningEndedAt)",
-    closed,
-  );
-  assert.notEqual(closed, -1, "the close condition is gone");
-  assert.ok(stamp !== -1 && stamp < finish, "the close time must be recorded first");
 });
 
 test("a scheduler that calls back synchronously does not throw", () => {

--- a/studio/frontend/tests/chat-stream-publish-gate.test.ts
+++ b/studio/frontend/tests/chat-stream-publish-gate.test.ts
@@ -637,6 +637,41 @@ test("every publish path reconciles, including the backend tool events", () => {
   );
 });
 
+test("a server reasoning summary is assigned to the gated group", () => {
+  const source = withoutComments(ADAPTER);
+
+  // The summary frame is authoritative and is consumed by index. A pass short
+  // enough to fit inside one gate window is not yet known to the tracker when
+  // its summary lands, so the value would be dropped and replaced by a local
+  // measurement. Adoption has to come first.
+  const consume = source.indexOf(
+    "reasoningDurationTracker.recordServerDuration(",
+  );
+  assert.notEqual(consume, -1, "the summary frame is no longer consumed");
+  const before = source.slice(Math.max(0, consume - 600), consume);
+  assert.ok(
+    before.includes("reconcileReasoning("),
+    "the summary is consumed before the gated group is adopted",
+  );
+});
+
+test("the reconcile before the summary is skipped for ordinary chunks", () => {
+  const source = withoutComments(ADAPTER);
+
+  // Reconciling on EVERY chunk would re-parse the whole reply per chunk, which
+  // is exactly the cost the gate exists to remove. It must be conditional on a
+  // summary actually being present.
+  const consume = source.indexOf(
+    "reasoningDurationTracker.recordServerDuration(",
+  );
+  const before = source.slice(Math.max(0, consume - 600), consume);
+  const guard = before.lastIndexOf("if (reasoningMs !== undefined) {");
+  assert.ok(
+    guard !== -1 && guard < before.lastIndexOf("reconcileReasoning("),
+    "the pre-summary reconcile is unguarded and runs on every chunk",
+  );
+});
+
 test("an opening think tag split across arrivals still stamps", () => {
   // A provider can split the literal tag: "<thi" then "nk>reasoning". Testing
   // the delta alone misses it, and the group then starts only at the eventual

--- a/studio/frontend/tests/chat-stream-publish-gate.test.ts
+++ b/studio/frontend/tests/chat-stream-publish-gate.test.ts
@@ -369,7 +369,7 @@ test("a reasoning group the gate skipped is adopted before the final metadata", 
   // Scoped to the finalizer, so a finishGroup() belonging to some later path
   // cannot stand in for the one that has to follow the adoption here.
   const finalizer = source.slice(adopt, adopt + 400);
-  const finalize = finalizer.indexOf("reasoningDurationTracker.finishGroup();");
+  const finalize = finalizer.search(/reasoningDurationTracker\.finishGroup\(/);
   assert.notEqual(
     finalize,
     -1,
@@ -521,7 +521,7 @@ test("the reasoning timer stops on arrival, not on the next publish", () => {
 
   // finishGroup reads only pre-gate state, so deferring it to the next publish
   // counted a post-reasoning pause as reasoning.
-  const finish = loop.indexOf("reasoningDurationTracker.finishGroup();");
+  const finish = loop.search(/reasoningDurationTracker\.finishGroup\(/);
   const gate = loop.search(/if \([^)]*!canPublish\(streamedChars\)\) \{/);
   assert.notEqual(finish, -1, "the group is never closed in the loop");
   assert.ok(finish < gate, "the close must run before the gate can skip");
@@ -635,6 +635,77 @@ test("every publish path reconciles, including the backend tool events", () => {
     calls.length >= 4,
     `every publish path must reconcile; found ${calls.length} call sites`,
   );
+});
+
+test("an opening think tag split across arrivals still stamps", () => {
+  // A provider can split the literal tag: "<thi" then "nk>reasoning". Testing
+  // the delta alone misses it, and the group then starts only at the eventual
+  // publish. The search runs from just before the chunk's first character, so
+  // the tag is found at the join.
+  const THINK_OPEN = "<think>";
+  const opensOn = (deltas: string[]) => {
+    let cumulative = "";
+    const hits: number[] = [];
+    deltas.forEach((delta, index) => {
+      const before = cumulative.length;
+      cumulative += delta;
+      const at = cumulative.indexOf(
+        THINK_OPEN,
+        Math.max(0, before - (THINK_OPEN.length - 1)),
+      );
+      if (at !== -1) hits.push(index);
+    });
+    return hits;
+  };
+
+  assert.deepEqual(opensOn(["Hello ", "<thi", "nk>reasoning"]), [2]);
+  assert.deepEqual(opensOn(["Hello ", "<think>reasoning"]), [1]);
+  // Not re-stamped for text that merely follows the tag.
+  assert.deepEqual(opensOn(["<think>a", "b", "c"]), [0]);
+});
+
+test("the terminal adoption finishes at the recorded end", () => {
+  const source = withoutComments(ADAPTER);
+
+  // Every adoption is a group the gate hid from the tracker, so the finish that
+  // follows it must be given the time the reasoning was last seen. Finishing at
+  // "now" would charge the wait between the last reasoning arrival and stream
+  // close to the reasoning.
+  const adoptions = [...source.matchAll(/adoptGatedReasoningGroups\(/g)].filter(
+    (m) => !source.startsWith("const adoptGatedReasoningGroups", m.index ?? 0),
+  );
+  assert.ok(adoptions.length >= 2, "the terminal adoptions are gone");
+
+  for (const match of adoptions) {
+    const after = source.slice(match.index ?? 0, (match.index ?? 0) + 400);
+    const finish = after.indexOf("reasoningDurationTracker.finishGroup(");
+    if (finish === -1) continue;
+    assert.ok(
+      after.startsWith(
+        "reasoningDurationTracker.finishGroup(gateReasoningEndedAt)",
+        finish,
+      ),
+      "an adoption is followed by a finish that ignores the recorded end",
+    );
+  }
+});
+
+test("an active group records its close time as well", () => {
+  const loop = regionOf(
+    "for await (const chunk of stream) {",
+    "} catch (streamError) {",
+  );
+
+  // A later publish can resumeGroup an active-and-closed group because its text
+  // grew; the finish that follows must use the close time, not the publish time.
+  const closed = loop.indexOf("const reasoningJustClosed =");
+  const stamp = loop.indexOf("gateReasoningEndedAt ??= Date.now();", closed);
+  const finish = loop.indexOf(
+    "reasoningDurationTracker.finishGroup(gateReasoningEndedAt)",
+    closed,
+  );
+  assert.notEqual(closed, -1, "the close condition is gone");
+  assert.ok(stamp !== -1 && stamp < finish, "the close time must be recorded first");
 });
 
 test("a scheduler that calls back synchronously does not throw", () => {

--- a/studio/frontend/tests/chat-stream-publish-gate.test.ts
+++ b/studio/frontend/tests/chat-stream-publish-gate.test.ts
@@ -637,6 +637,25 @@ test("every publish path reconciles, including the backend tool events", () => {
   );
 });
 
+test("the arrival stamp survives a publish that adopted no group", () => {
+  const source = withoutComments(ADAPTER);
+
+  // A provider can emit a bare "<think>" as its own delta. It parses to no
+  // parts at all, so a publish there adopts nothing; if it still cleared the
+  // stamp, the group would start at whatever later publish first sees the
+  // reasoning body. Exactly one place may clear it, and it is inside the
+  // adopted branch, so a new publish path cannot get this wrong by omission.
+  const clears = [...source.matchAll(/gateHeldSince = undefined;/g)];
+  assert.equal(clears.length, 1, "the stamp is cleared in more than one place");
+
+  const reconcile = source.indexOf("const reconcileReasoning = (");
+  const adopted = source.indexOf("if (groups > 0) {", reconcile);
+  assert.ok(
+    reconcile !== -1 && adopted !== -1 && adopted < (clears[0].index ?? 0),
+    "the stamp is cleared outside the branch that adopted a group",
+  );
+});
+
 test("a server reasoning summary is assigned to the gated group", () => {
   const source = withoutComments(ADAPTER);
 

--- a/studio/frontend/tests/chat-stream-publish-gate.test.ts
+++ b/studio/frontend/tests/chat-stream-publish-gate.test.ts
@@ -551,6 +551,41 @@ test("a cap-forced publish resets the baseline for the next one", () => {
   });
 });
 
+test("the backend tool events publish ungated", () => {
+  const loop = regionOf(
+    "for await (const chunk of stream) {",
+    "} catch (streamError) {",
+  );
+
+  // tool_start / tool_end carry the card's state -- name, result, approval,
+  // provenance -- not a preview of it, and they are rare. Pacing them would
+  // let a Stop persist a card that never got its result. Only the per-delta
+  // argument preview above them is paced.
+  const preview = loop.indexOf('if (toolEvent.type === "tool_args") {');
+  const events = loop.indexOf("const toolProvenance = parseToolProvenance(");
+  assert.ok(preview !== -1 && events > preview, "the tool-event branch moved");
+
+  const between = loop.slice(preview, events);
+  const previewGate = between.indexOf("if (canPublish(streamedChars)) {");
+  assert.notEqual(previewGate, -1, "the argument preview is not paced");
+
+  // Exactly one gate call between the preview and the events: the preview's.
+  const gates = between.match(/canPublish\(/g) ?? [];
+  assert.equal(
+    gates.length,
+    1,
+    "a state-bearing tool event is being paced along with the preview",
+  );
+
+  // And none after them either, up to the publish they share.
+  const publish = loop.indexOf("yield {", events);
+  const after = loop.slice(events, publish);
+  assert.ok(
+    !after.includes("canPublish("),
+    "the tool-event publish itself is paced",
+  );
+});
+
 test("a state-bearing provider delta is never held by the gate", () => {
   const loop = regionOf(
     "for await (const chunk of stream) {",

--- a/studio/frontend/tests/chat-stream-publish-gate.test.ts
+++ b/studio/frontend/tests/chat-stream-publish-gate.test.ts
@@ -364,16 +364,16 @@ test("the gate is fed a counter that only grows", () => {
 test("a reasoning group the gate skipped is adopted before the final metadata", () => {
   const source = withoutComments(ADAPTER);
 
-  const adopt = source.indexOf("adoptGatedReasoningGroups(finalContent,");
+  const adopt = source.indexOf("reconcileReasoning(finalContent,");
   assert.notEqual(adopt, -1, "a group revealed only by skipped chunks is lost");
-  // Scoped to the finalizer, so a finishGroup() belonging to some later path
-  // cannot stand in for the one that has to follow the adoption here.
-  const finalizer = source.slice(adopt, adopt + 400);
-  const finalize = finalizer.search(/reasoningDurationTracker\.finishGroup\(/);
-  assert.notEqual(
-    finalize,
-    -1,
-    "the group must be adopted before the run finalizes durations",
+  // Scoped to the finalizer, so a metadata() belonging to some later path
+  // cannot stand in for the one that has to follow the adoption here. The
+  // finish itself now lives inside reconcileReasoning, which is what makes it
+  // impossible for a caller to adopt and then forget to close.
+  const finalizer = source.slice(adopt, adopt + 600);
+  assert.ok(
+    finalizer.includes("reasoningDurationTracker.metadata()"),
+    "the group must be adopted before the run persists durations",
   );
 });
 
@@ -384,7 +384,7 @@ test("the interrupted-stream partial adopts skipped groups too", () => {
   // needs the same adoption; otherwise an interrupted reply renders a reasoning
   // group with no duration entry behind it.
   assert.ok(
-    source.includes("adoptGatedReasoningGroups(partialContent,"),
+    source.includes("reconcileReasoning(partialContent,"),
     "the non-abort failure path does not adopt gate-hidden reasoning groups",
   );
 });
@@ -656,6 +656,58 @@ test("the arrival stamp survives a publish that adopted no group", () => {
   );
 });
 
+test("a per-call thought signature forces a publish", () => {
+  const source = withoutComments(ADAPTER);
+
+  // Gemini carries the signature on the tool call itself, not only at message
+  // level, and the next turn is rejected outright without it. Updating an
+  // EXISTING call adds no part, so addedToolCall is false and the message-level
+  // latch never sees it; a Stop while the gate holds it persists a turn that
+  // cannot be replayed.
+  const update = source.indexOf("const prevExtra =");
+  assert.notEqual(update, -1, "the existing-call update path is gone");
+  const window = source.slice(update, update + 700);
+  assert.ok(
+    window.includes("replayStateChanged = true"),
+    "a changed per-call extra_content does not force a publish",
+  );
+  assert.ok(
+    window.includes("call.extra_content !== undefined"),
+    "the latch fires on calls that carry no extra_content at all",
+  );
+
+  // And the latch has to be honoured where the tool-call publish is decided.
+  const decide = source.indexOf("addedToolCall ||", update);
+  assert.ok(
+    decide !== -1 &&
+      source.slice(decide, decide + 120).includes("replayStateChanged"),
+    "the tool-call publish ignores the replay latch",
+  );
+});
+
+test("a chunk the strip left unchanged does not spend a gate cycle", () => {
+  const loop = regionOf(
+    "for await (const chunk of stream) {",
+    "} catch (streamError) {",
+  );
+
+  // The ${...} strip can return a nonempty reply to exactly its previous
+  // length. Checking only for an EMPTY reply lets that chunk consume the open
+  // cycle on an identical publish, and the next real token then waits for a
+  // frame, the timer or the cap.
+  const guard = loop.indexOf("cumulativeText.length === textLenBeforeChunk");
+  const gate = loop.indexOf("!canPublish(streamedChars)");
+  assert.notEqual(guard, -1, "an unchanged reply still reaches the gate");
+  assert.ok(guard < gate, "the skip must come before the gate is asked");
+
+  // Skipping must never swallow a publish that carries replay state.
+  const skip = loop.slice(guard, gate);
+  assert.ok(
+    skip.includes("!replayStateChanged"),
+    "the skip can drop a state-bearing publish",
+  );
+});
+
 test("a server reasoning summary is assigned to the gated group", () => {
   const source = withoutComments(ADAPTER);
 
@@ -718,30 +770,52 @@ test("an opening think tag split across arrivals still stamps", () => {
   assert.deepEqual(opensOn(["<think>a", "b", "c"]), [0]);
 });
 
-test("the terminal adoption finishes at the recorded end", () => {
+test("the terminal publishes run the full reasoning transition", () => {
   const source = withoutComments(ADAPTER);
 
-  // Every adoption is a group the gate hid from the tracker, so the finish that
-  // follows it must be given the time the reasoning was last seen. Finishing at
-  // "now" would charge the wait between the last reasoning arrival and stream
-  // close to the reasoning.
-  const adoptions = [...source.matchAll(/adoptGatedReasoningGroups\(/g)].filter(
-    (m) => !source.startsWith("const adoptGatedReasoningGroups", m.index ?? 0),
+  // Adoption alone only covers a group the gate hid ENTIRELY. Reasoning held by
+  // the gate can also extend a group that already exists and was closed by the
+  // previous publish, where there is nothing to adopt and the duration stays
+  // frozen there. Both terminal paths need resume as well, which is what
+  // reconcileReasoning does, and the terminal flag lifts its unclosed-tag guard
+  // because no later publish is coming.
+  const terminal = [...source.matchAll(/reconcileReasoning\([^;]*?true\)/gs)];
+  assert.equal(
+    terminal.length,
+    2,
+    "the success finalizer and the interrupted partial must both finalize",
   );
-  assert.ok(adoptions.length >= 2, "the terminal adoptions are gone");
-
-  for (const match of adoptions) {
-    const after = source.slice(match.index ?? 0, (match.index ?? 0) + 400);
-    const finish = after.indexOf("reasoningDurationTracker.finishGroup(");
-    if (finish === -1) continue;
+  for (const match of terminal) {
     assert.ok(
-      after.startsWith(
-        "reasoningDurationTracker.finishGroup(gateReasoningEndedAt)",
-        finish,
-      ),
-      "an adoption is followed by a finish that ignores the recorded end",
+      match[0].includes("gateHeldSince"),
+      "a terminal reconcile drops the arrival stamp",
     );
   }
+  assert.ok(
+    source.includes("if (final || !hasUnclosedThinkTag(cumulativeText)) {"),
+    "the terminal flag no longer lifts the unclosed-tag guard",
+  );
+});
+
+test("a new reasoning block invalidates the recorded end", () => {
+  const loop = regionOf(
+    "for await (const chunk of stream) {",
+    "} catch (streamError) {",
+  );
+
+  // Several complete <think>...</think> blocks in a row render as one group.
+  // Holding the FIRST block's close would finish the whole group there and drop
+  // every later block's time, so an arriving block has to clear it. Answer-only
+  // arrivals must not, or a pause after the reasoning re-enters the duration.
+  const arrival = loop.indexOf("if (reasoning || thinkOpenedNow) {");
+  const clear = loop.indexOf("gateReasoningEndedAt = undefined;", arrival);
+  const close = loop.indexOf("gateReasoningEndedAt ??= Date.now();");
+  assert.ok(arrival !== -1 && clear !== -1, "the invalidation is gone");
+  assert.ok(clear < close, "the stamp is cleared after the close records it");
+  assert.ok(
+    close !== -1,
+    "the close no longer records an end time at all",
+  );
 });
 
 test("an active group records its close time as well", () => {

--- a/studio/frontend/tests/chat-stream-publish-gate.test.ts
+++ b/studio/frontend/tests/chat-stream-publish-gate.test.ts
@@ -641,71 +641,41 @@ test("the arrival stamp survives a publish that adopted no group", () => {
   const source = withoutComments(ADAPTER);
 
   // A provider can emit a bare "<think>" as its own delta. It parses to no
-  // parts at all, so a publish there adopts nothing; if it still cleared the
-  // stamp, the group would start at whatever later publish first sees the
-  // reasoning body. Exactly one place may clear it, and it is inside the
-  // adopted branch, so a new publish path cannot get this wrong by omission.
+  // parts at all, so a publish there is timing nothing yet; if it cleared the
+  // stamp, the group would start at whatever later publish first sees the body.
+  // Exactly one place may clear it, so a new publish path cannot get this wrong
+  // by omission.
   const clears = [...source.matchAll(/gateHeldSince = undefined;/g)];
   assert.equal(clears.length, 1, "the stamp is cleared in more than one place");
 
+  // And a mere group COUNT is not enough to clear on: an earlier pass leaves
+  // groups > 0 while a later bodyless pass is still pending, so the clear has
+  // to be gated on a group actually being timed, after the resume that could
+  // have started timing it.
   const reconcile = source.indexOf("const reconcileReasoning = (");
-  const adopted = source.indexOf("if (groups > 0) {", reconcile);
-  assert.ok(
-    reconcile !== -1 && adopted !== -1 && adopted < (clears[0].index ?? 0),
-    "the stamp is cleared outside the branch that adopted a group",
+  const resume = source.indexOf("reasoningDurationTracker.resumeGroup(", reconcile);
+  const guard = source.indexOf(
+    "if (reasoningDurationTracker.hasActiveGroup) {",
+    reconcile,
   );
-});
-
-test("a per-call thought signature forces a publish", () => {
-  const source = withoutComments(ADAPTER);
-
-  // Gemini carries the signature on the tool call itself, not only at message
-  // level, and the next turn is rejected outright without it. Updating an
-  // EXISTING call adds no part, so addedToolCall is false and the message-level
-  // latch never sees it; a Stop while the gate holds it persists a turn that
-  // cannot be replayed.
-  const update = source.indexOf("const prevExtra =");
-  assert.notEqual(update, -1, "the existing-call update path is gone");
-  const window = source.slice(update, update + 700);
+  const clear = clears[0].index ?? 0;
+  assert.ok(reconcile !== -1 && resume !== -1, "the reconcile shape changed");
   assert.ok(
-    window.includes("replayStateChanged = true"),
-    "a changed per-call extra_content does not force a publish",
+    guard !== -1 && guard < clear,
+    "the stamp is cleared without checking that a group is being timed",
   );
   assert.ok(
-    window.includes("call.extra_content !== undefined"),
-    "the latch fires on calls that carry no extra_content at all",
+    resume < guard,
+    "the check runs before the resume that can start the timing",
   );
 
-  // And the latch has to be honoured where the tool-call publish is decided.
-  const decide = source.indexOf("addedToolCall ||", update);
-  assert.ok(
-    decide !== -1 &&
-      source.slice(decide, decide + 120).includes("replayStateChanged"),
-    "the tool-call publish ignores the replay latch",
+  // The finish must come after, or the clear would see the group it just closed
+  // as inactive and keep a stamp that has already been used.
+  const finish = source.indexOf(
+    "reasoningDurationTracker.finishGroup(",
+    reconcile,
   );
-});
-
-test("a chunk the strip left unchanged does not spend a gate cycle", () => {
-  const loop = regionOf(
-    "for await (const chunk of stream) {",
-    "} catch (streamError) {",
-  );
-
-  // The ${...} strip can return a nonempty reply to exactly its previous
-  // length. Checking only for an EMPTY reply lets that chunk consume the open
-  // cycle on an identical publish, and the next real token then waits for a
-  // frame, the timer or the cap.
-  const guard = loop.indexOf("cumulativeText.length === textLenBeforeChunk");
-  const gate = loop.indexOf("!canPublish(streamedChars)");
-  assert.notEqual(guard, -1, "an unchanged reply still reaches the gate");
-  assert.ok(guard < gate, "the skip must come before the gate is asked");
-
-  // Skipping must never swallow a publish that carries replay state.
-  const skip = loop.slice(guard, gate);
-  assert.ok(
-    skip.includes("!replayStateChanged"),
-    "the skip can drop a state-bearing publish",
-  );
+  assert.ok(clear < finish, "the group is closed before the stamp is dropped");
 });
 
 test("a server reasoning summary is assigned to the gated group", () => {


### PR DESCRIPTION
This PR coalesces streamed text chunks that arrive before the browser's next frame. Slower streams still publish every chunk. When the renderer falls behind, more chunks are combined into each update instead of queueing separate message rebuilds.

Without this, a fast local reply can keep filling the chat bubble for several seconds after llama.cpp has finished and GPU usage has dropped to 0%. If the UI falls far enough behind, the page stops painting and Stop cannot run promptly.

Studio currently rebuilds and publishes the full accumulated message for every text chunk. With this change, the first chunk publishes immediately, later chunks accumulate until the next frame, and the next publish includes all of them. The final update remains unconditional, so completed replies persist in full. A 500 ms timer reopens the gate when a hidden or heavily loaded window does not produce a frame.

The gate sits immediately before the yield to assistant-ui, after the message rebuild and the reasoning bookkeeping. Those still run on every arrival, so nothing about how the stream is interpreted depends on which chunks happen to publish. The cost being removed is downstream of the yield: assistant-ui, React, markdown rendering and paint. Keeping the rebuild on every chunk measures 34 to 41 ms in total across a 64,000 character reply, and a per-engine comparison of the two placements retains 99.5% to 100% of the improvement.

Per-delta tool-call previews are paced the same way, since they repeat per argument fragment and are replaced by the authoritative parse. Anything state-bearing publishes immediately: `tool_start` and `tool_end`, a newly introduced tool call, and replay metadata, including a per-call `extra_content` change, which is where Gemini puts the thought signature.

## Measurements

Ranges come from alternating Chromium production-build runs on the same machine. The synthetic stream sent the same 60,000 characters at 800 chunks per second to both branches. Real-model runs used Qwen3.5-0.8B-MTP at about 440 tok/s.

| Workload | CPU throttle | Main painted at socket close | This PR painted at socket close | Main lag after close | This PR lag after close |
|---|---:|---:|---:|---:|---:|
| Synthetic | 8x | 1.2% to 1.6% | 98.1% to 98.5% | 11.4s to 11.8s | 1.38s to 1.44s |
| Synthetic | 12x | 2.8% to 3.5% | 96.2% to 96.9% | 26.9s to 28.7s | 2.30s to 2.57s |
| Qwen3.5-0.8B-MTP | 8x | 3.8% to 11.4% | 94.1% to 95.3% | 2.08s to 2.76s | 0.63s to 0.77s |
| Qwen3.5-0.8B-MTP | 12x | 0.0% | 86.5% to 91.8% | 5.68s to 5.70s | 0.96s to 0.98s |

In a 40,000-character stream at 6x throttling, a scheduled Stop click ran after 12.95s on main and 0.74s with this PR.

## Limitation

Reopening the gate does not publish by itself. If Stop is pressed before another chunk or the final update, text received during the current gate interval can be omitted. That loss is bounded: the gate publishes regardless once 256 characters have arrived since the last publish, measured in UTF-16 code units, so it is conservative in glyphs. Normal completion and non-abort failure keep the full reply.

The controlled Chromium benchmark needed CPU throttling to reproduce the backlog consistently. The original issue was observed during real llama.cpp generation on this machine. The same backlog and improvement reproduced in CPU-constrained webkit2gtk. Hidden-window testing also confirmed that the 500 ms fallback limits updates when animation frames stop.

## Checks

- `npm test`: 2,415 passed, including 26 gate tests
- `npm run typecheck`
- `npm run build`
- Synthetic-stream, real llama.cpp, and webkit2gtk constrained and hidden-window tests

