### PR TITLE
Studio: contain native ROCm APU telemetry crashes

### DIFF
--- a/studio/backend/tests/test_system_poll_no_cuda_context.py
+++ b/studio/backend/tests/test_system_poll_no_cuda_context.py
@@ -58,6 +58,7 @@ _maybe_stub("structlog", _build_structlog_stub)
 import pytest
 
 import utils.hardware.hardware as hw  # noqa: E402
+from utils import torch_device_probe  # noqa: E402
 
 
 def _has_cuda() -> bool:
@@ -309,12 +310,72 @@ def test_rocm_apu_inventory_keeps_the_gtt_total(monkeypatch):
     monkeypatch.setattr(hw, "_torch_get_device_module", lambda: (mod, "cuda"))
     monkeypatch.setattr(hw, "get_device", lambda: hw.DeviceType.CUDA)
     monkeypatch.setattr(hw, "rocm_windows_free_is_untrusted", lambda: False)
+    monkeypatch.setattr(
+        torch_device_probe, "rocm_memory_totals", lambda ordinals: {0: _APU_GTT_TOTAL}
+    )
+
+    def _parent_abort(_ordinal):
+        raise AssertionError("mem_get_info must run only in the child probe")
+
+    inventory_mod = _apu_mod()
+    inventory_mod.mem_get_info = _parent_abort
+    monkeypatch.setattr(hw, "_torch_get_device_module", lambda: (inventory_mod, "cuda"))
 
     inventory = hw._torch_get_device_inventory([0])
+    monkeypatch.setattr(hw, "_torch_get_device_module", lambda: (mod, "cuda"))
     occupancy = hw._torch_get_per_device_info([0])
 
     assert inventory[0]["total_gb"] == occupancy[0]["total_gb"] == 100.0
     assert inventory[0]["total_gb"] != round(_APU_CARVE_OUT / (1024**3), 2)
+
+
+def test_windows_rocm_reconciliation_never_uses_parent_occupancy(monkeypatch):
+    expected = [
+        {
+            "index": 0,
+            "visible_ordinal": 0,
+            "name": "AMD Radeon 8060S Graphics",
+            "total_gb": 100.0,
+            "used_gb": None,
+        }
+    ]
+    monkeypatch.setattr(hw.platform, "system", lambda: "Windows")
+    monkeypatch.setattr(hw, "_torch_get_device_inventory", lambda indices: expected)
+    monkeypatch.setattr(
+        hw,
+        "_torch_get_per_device_info",
+        lambda indices: pytest.fail("Windows telemetry must not call mem_get_info in the parent"),
+    )
+
+    visible = {
+        "devices": [
+            {"index": 0, "vram_total_gb": 8.0, "vram_used_gb": 2.0, "vram_utilization_pct": 25.0}
+        ]
+    }
+    hw._reconcile_rocm_unified_memory(visible, [0])
+    assert visible["devices"][0]["vram_total_gb"] == 100.0
+    assert visible["devices"][0]["vram_used_gb"] == 2.0
+
+    primary = {"vram_total_gb": 8.0, "vram_used_gb": 2.0, "vram_utilization_pct": 25.0}
+    hw._reconcile_primary_rocm_unified_memory(primary, {"numeric_ids": [0]})
+    assert primary["vram_total_gb"] == 100.0
+    assert primary["vram_used_gb"] == 2.0
+
+
+def test_non_windows_rocm_reconciliation_keeps_live_occupancy(monkeypatch):
+    expected = [
+        {
+            "index": 0,
+            "visible_ordinal": 0,
+            "name": "AMD Radeon 8060S Graphics",
+            "total_gb": 100.0,
+            "used_gb": 12.0,
+        }
+    ]
+    monkeypatch.setattr(hw.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(hw, "_torch_get_per_device_info", lambda indices: expected)
+
+    assert hw._rocm_reconciliation_device_info([0]) == expected
 
 
 class _FakeRocmProps(_FakeProps):
@@ -361,13 +422,9 @@ def test_an_apu_shaped_name_on_cuda_stays_context_free(monkeypatch):
 def test_rocm_apu_keeps_the_carve_out_when_the_driver_total_fails(monkeypatch):
     # Degraded, not dropped: the device still has to appear in the inventory.
     mod = _apu_mod()
-
-    def _fail(o):
-        raise RuntimeError("hipMemGetInfo unavailable")
-
-    mod.mem_get_info = _fail
     monkeypatch.setattr(hw, "IS_ROCM", True)
     monkeypatch.setattr(hw, "_torch_get_device_module", lambda: (mod, "cuda"))
+    monkeypatch.setattr(torch_device_probe, "rocm_memory_totals", lambda ordinals: {})
     assert [d["total_gb"] for d in hw._torch_get_device_inventory([0])] == [8.0]
 
 
@@ -378,6 +435,9 @@ def test_rocm_apu_sysfs_overlay_still_declines_against_the_gtt_total(monkeypatch
     mod = _apu_mod()
     monkeypatch.setattr(hw, "IS_ROCM", True)
     monkeypatch.setattr(hw, "_torch_get_device_module", lambda: (mod, "cuda"))
+    monkeypatch.setattr(
+        torch_device_probe, "rocm_memory_totals", lambda ordinals: {0: _APU_GTT_TOTAL}
+    )
     monkeypatch.setattr(hw, "platform", types.SimpleNamespace(system = lambda: "Linux"))
     monkeypatch.setattr(hw, "_rocm_kfd_gpu_pci_ids", lambda: {0: "0000:03:00.0"})
     monkeypatch.setattr(hw, "_rocm_visibility_mask_active", lambda: False)
@@ -419,6 +479,9 @@ def test_rocm_unclassified_apu_keeps_the_driver_total_on_an_older_runtime(monkey
     monkeypatch.setattr(hw, "IS_ROCM", True)
     monkeypatch.setattr(hw, "_hip_runtime_version", lambda: (6, 1))
     monkeypatch.setattr(hw, "_torch_get_device_module", lambda: (mod, "cuda"))
+    monkeypatch.setattr(
+        torch_device_probe, "rocm_memory_totals", lambda ordinals: {0: _APU_GTT_TOTAL}
+    )
     assert hw._torch_get_device_inventory([0])[0]["total_gb"] == 100.0
 
 
@@ -429,6 +492,9 @@ def test_rocm_unclassified_apu_keeps_the_driver_total_without_the_flag(monkeypat
     monkeypatch.setattr(hw, "IS_ROCM", True)
     monkeypatch.setattr(hw, "_hip_runtime_version", lambda: (6, 4))
     monkeypatch.setattr(hw, "_torch_get_device_module", lambda: (mod, "cuda"))
+    monkeypatch.setattr(
+        torch_device_probe, "rocm_memory_totals", lambda ordinals: {0: _APU_GTT_TOTAL}
+    )
     assert hw._torch_get_device_inventory([0])[0]["total_gb"] == 100.0
 
 
@@ -445,6 +511,9 @@ def test_rocm_props_that_cannot_be_classified_keep_the_driver_total(monkeypatch)
     monkeypatch.setattr(hw, "IS_ROCM", True)
     monkeypatch.setattr(hw, "_hip_runtime_version", lambda: (6, 4))
     monkeypatch.setattr(hw, "_torch_get_device_module", lambda: (mod, "cuda"))
+    monkeypatch.setattr(
+        torch_device_probe, "rocm_memory_totals", lambda ordinals: {0: _APU_GTT_TOTAL}
+    )
     assert hw._torch_get_device_inventory([0])[0]["total_gb"] == 100.0
 
 

--- a/studio/backend/tests/test_torch_device_probe.py
+++ b/studio/backend/tests/test_torch_device_probe.py
@@ -1,9 +1,10 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-"""Tests for the out-of-process torch allocation probe."""
+"""Tests for the out-of-process native torch probes."""
 
 import ast
+import json
 import os
 import signal
 import subprocess
@@ -39,8 +40,10 @@ def _fresh_probe(monkeypatch):
     monkeypatch.setattr(process_lifetime, "adopt_pid", lambda _pid: None)
     monkeypatch.setattr(process_lifetime, "forget_pid", lambda _pid: None)
     torch_device_probe.device_can_allocate.cache_clear()
+    torch_device_probe.rocm_memory_totals.cache_clear()
     yield
     torch_device_probe.device_can_allocate.cache_clear()
+    torch_device_probe.rocm_memory_totals.cache_clear()
 
 
 class _FakeProcess:
@@ -48,11 +51,13 @@ class _FakeProcess:
         self,
         *,
         returncode = 0,
+        stdout = "",
         stderr = "",
         timeouts = 0,
     ):
         self.returncode = returncode
         self.pid = 4242
+        self.stdout = stdout
         self.stderr = stderr
         self.timeouts = timeouts
         self.calls: list[str] = []
@@ -62,7 +67,7 @@ class _FakeProcess:
         if self.timeouts:
             self.timeouts -= 1
             raise subprocess.TimeoutExpired("probe", timeout or 0)
-        return None, self.stderr
+        return self.stdout, self.stderr
 
     def terminate(self):
         self.calls.append("terminate")
@@ -100,6 +105,87 @@ def test_probe_script_initializes_blas_and_synchronizes():
     assert "torch.ones" in script
     assert "tensor @ tensor" in script
     assert ".item()" in script
+
+
+def test_rocm_memory_total_script_is_valid_and_synchronizes():
+    script = torch_device_probe._ROCM_MEMORY_TOTAL_PROBE_SCRIPT
+    compile(script, "<memory-total-probe>", "exec")
+    assert "torch.cuda.mem_get_info" in script
+    assert "torch.ones" in script
+    assert ".item()" in script
+    assert torch_device_probe._MEMORY_TOTAL_RESULT_PREFIX in script
+
+
+def test_rocm_memory_totals_parse_and_cache_a_clean_child(monkeypatch):
+    calls: list = []
+    prefix = torch_device_probe._MEMORY_TOTAL_RESULT_PREFIX
+    process = _FakeProcess(
+        stdout = "torch banner\n" + prefix + json.dumps({"0": 100 << 30, "1": 24 << 30}) + "\n"
+    )
+    _patch_popen(monkeypatch, process, calls)
+
+    expected = {0: 100 << 30, 1: 24 << 30}
+    assert torch_device_probe.rocm_memory_totals([0, 1]) == expected
+    assert torch_device_probe.rocm_memory_totals([0, 1]) == expected
+    assert len(calls) == 1
+    assert json.loads(calls[0][0][-2]) == [0, 1]
+    assert calls[0][1]["stdout"] is subprocess.PIPE
+
+
+def test_rocm_memory_total_cache_follows_device_identity(monkeypatch):
+    calls: list = []
+    prefix = torch_device_probe._MEMORY_TOTAL_RESULT_PREFIX
+    _patch_popen(
+        monkeypatch,
+        _FakeProcess(stdout = prefix + json.dumps({"0": 100 << 30}) + "\n"),
+        calls,
+    )
+    monkeypatch.delenv("HIP_VISIBLE_DEVICES", raising = False)
+
+    assert torch_device_probe.rocm_memory_totals([0]) == {0: 100 << 30}
+    monkeypatch.setenv("HIP_VISIBLE_DEVICES", "1")
+    assert torch_device_probe.rocm_memory_totals([0]) == {0: 100 << 30}
+    assert len(calls) == 2
+
+
+def test_rocm_memory_total_child_abort_is_contained_and_cached(monkeypatch):
+    calls: list = []
+    _patch_popen(
+        monkeypatch,
+        _FakeProcess(returncode = torch_device_probe._WINDOWS_ABORT_EXIT_STATUS),
+        calls,
+    )
+
+    assert torch_device_probe.rocm_memory_totals([0]) == {}
+    assert torch_device_probe.rocm_memory_totals([0]) == {}
+    assert len(calls) == 1
+
+
+def test_real_rocm_memory_total_child_crash_does_not_kill_parent(monkeypatch):
+    monkeypatch.setattr(torch_device_probe, "_ROCM_MEMORY_TOTAL_PROBE_SCRIPT", _CRASHING_SCRIPT)
+    assert torch_device_probe.rocm_memory_totals([0]) == {}
+
+
+def test_rocm_memory_total_timeout_is_terminated(monkeypatch):
+    process = _FakeProcess(returncode = None, timeouts = 1)
+    _patch_popen(monkeypatch, process)
+    monkeypatch.setattr(torch_device_probe, "PROBE_TIMEOUT_SECONDS", 0.01)
+
+    assert torch_device_probe.rocm_memory_totals([0]) == {}
+    assert "terminate" in process.calls
+
+
+@pytest.mark.parametrize(
+    "stdout",
+    [
+        "",
+        "UNSLOTH_ROCM_MEMORY_TOTALS=not-json\n",
+        'UNSLOTH_ROCM_MEMORY_TOTALS={"0": true}\n',
+    ],
+)
+def test_rocm_memory_total_malformed_result_falls_back(monkeypatch, stdout):
+    _patch_popen(monkeypatch, _FakeProcess(stdout = stdout))
+    assert torch_device_probe.rocm_memory_totals([0]) == {}
 
 
 def test_child_that_crashes_marks_the_device_unusable(monkeypatch):

--- a/studio/backend/utils/hardware/hardware.py
+++ b/studio/backend/utils/hardware/hardware.py
@@ -1223,7 +1223,6 @@ def _torch_get_device_inventory(device_indices: list[int]) -> list[Dict[str, Any
     if driver_total_ordinals:
         try:
             from utils.torch_device_probe import rocm_memory_totals
-
             driver_totals = rocm_memory_totals(driver_total_ordinals)
         except Exception as e:
             # Keep the carve-out rather than dropping the device: an understated

--- a/studio/backend/utils/hardware/hardware.py
+++ b/studio/backend/utils/hardware/hardware.py
@@ -1207,30 +1207,41 @@ def _torch_get_device_inventory(device_indices: list[int]) -> list[Dict[str, Any
     if mod is None:
         return []
 
-    devices = []
+    inventory = []
+    driver_total_ordinals = []
     for ordinal, phys_idx in enumerate(device_indices):
         try:
             # torch ordinals are 0-based relative to CUDA_VISIBLE_DEVICES.
             props = mod.get_device_properties(ordinal)
-            total_bytes = props.total_memory
             if _rocm_props_total_is_carve_out(props) and hasattr(mod, "mem_get_info"):
-                try:
-                    total_bytes = mod.mem_get_info(ordinal)[1]
-                except Exception as e:
-                    # Keep the carve-out rather than dropping the device: an
-                    # understated total still beats no device at all.
-                    logger.debug("ROCm APU driver total failed for ordinal %d: %s", ordinal, e)
-            devices.append(
-                {
-                    "index": phys_idx,
-                    "visible_ordinal": ordinal,
-                    "name": props.name,
-                    "total_gb": round(total_bytes / (1024**3), 2),
-                    "used_gb": None,
-                }
-            )
+                driver_total_ordinals.append(ordinal)
+            inventory.append((ordinal, phys_idx, props))
         except Exception as e:
             logger.debug("torch inventory probe failed for ordinal %d: %s", ordinal, e)
+
+    driver_totals: dict[int, int] = {}
+    if driver_total_ordinals:
+        try:
+            from utils.torch_device_probe import rocm_memory_totals
+
+            driver_totals = rocm_memory_totals(driver_total_ordinals)
+        except Exception as e:
+            # Keep the carve-out rather than dropping the device: an understated
+            # total still beats no device at all.
+            logger.debug("ROCm APU child memory-total probe failed: %s", e)
+
+    devices = []
+    for ordinal, phys_idx, props in inventory:
+        total_bytes = driver_totals.get(ordinal, props.total_memory)
+        devices.append(
+            {
+                "index": phys_idx,
+                "visible_ordinal": ordinal,
+                "name": props.name,
+                "total_gb": round(total_bytes / (1024**3), 2),
+                "used_gb": None,
+            }
+        )
     return devices
 
 
@@ -2271,13 +2282,23 @@ def _apply_unified_memory_correction(
         )
 
 
+def _rocm_reconciliation_device_info(device_indices: list[int]) -> list[Dict[str, Any]]:
+    """Read the fields needed to correct amd-smi without unsafe Windows occupancy."""
+    if platform.system() == "Windows":
+        # Windows ROCm reports free == total, so occupancy is unknown even on a healthy
+        # runtime. Inventory preserves the useful total and keeps mem_get_info in the
+        # crash-contained child instead of the long-lived backend.
+        return _torch_get_device_inventory(device_indices)
+    return _torch_get_per_device_info(device_indices)
+
+
 def _reconcile_rocm_unified_memory(utilization: Dict[str, Any], device_indices: list[int]) -> None:
     """Fix amd-smi VRAM for ROCm unified-memory GPUs (e.g. Strix Halo).
 
     amd-smi reports only the dedicated slice; torch sees the full GTT pool. When
     torch total > smi total, overwrite per-device VRAM fields with the real value.
     """
-    torch_devices = _torch_get_per_device_info(device_indices)
+    torch_devices = _rocm_reconciliation_device_info(device_indices)
     if not torch_devices:
         return
     torch_by_index = {td["index"]: td for td in torch_devices}
@@ -2302,7 +2323,7 @@ def _reconcile_primary_rocm_unified_memory(
         return
     else:
         primary_idx = [int(numeric_ids[0])]
-    torch_devices = _torch_get_per_device_info(primary_idx)
+    torch_devices = _rocm_reconciliation_device_info(primary_idx)
     if not torch_devices:
         return
     _apply_unified_memory_correction(utilization, torch_devices[0])

--- a/studio/backend/utils/torch_device_probe.py
+++ b/studio/backend/utils/torch_device_probe.py
@@ -1,19 +1,17 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-"""Probe torch allocation in a child so driver crashes do not kill the backend.
+"""Probe native torch operations in a child so driver crashes do not kill the backend.
 
-Only a child that ran cleanly to the end marks an accelerator usable. A crash, a hang, a
-kill and a probe that could not run or be read all leave it unusable, since the allocation
-this stands in front of ends the process rather than raising. Ordinary Python errors are
-the exception: the child ran and reported, so the in-process loader raises the same error
-and describes it better. CPU takes the opposite default, because it cannot fault a driver
-and condemning it would change the embedding backend. Set
-``UNSLOTH_STUDIO_DISABLE_DEVICE_PROBE=1`` to skip the probe.
+The allocation probe marks an accelerator usable only when its child runs cleanly to the
+end. The memory-total probe gives unified-memory telemetry the same native-fault boundary
+and falls back to device properties when it cannot return a trustworthy total. Set
+``UNSLOTH_STUDIO_DISABLE_DEVICE_PROBE=1`` to skip the allocation probe.
 """
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 import subprocess
@@ -47,6 +45,7 @@ _SIGALRM_NUMBER = 14
 # an NTSTATUS, so nothing else here would recognise it. Same value LlamaCppBackend
 # ._is_abort_exit already matches for GGML_ASSERT deaths.
 _WINDOWS_ABORT_EXIT_STATUS = 3
+_MEMORY_TOTAL_RESULT_PREFIX = "UNSLOTH_ROCM_MEMORY_TOTALS="
 
 # Anything that changes which physical device a device string names, or which kernels the
 # runtime emits for it. A change invalidates a cached verdict, since the same "cuda" or
@@ -109,6 +108,59 @@ import torch
 device = sys.argv[1]
 tensor = torch.ones((8, 8), dtype = torch.float16, device = device)
 (tensor @ tensor).sum().item()
+"""
+
+# ``mem_get_info`` is not an exception boundary: a broken HIP runtime can abort the
+# interpreter from inside the native call. The system endpoint still needs its total on a
+# unified-memory APU because device properties expose only the dedicated carve-out. Query
+# it in a disposable process, then perform a tiny synchronized allocation so a deferred
+# runtime fault happens before the child reports success.
+_ROCM_MEMORY_TOTAL_PROBE_SCRIPT = f"""
+import json
+import os
+import signal
+import sys
+import threading
+
+_deadline = float(sys.argv[2])
+if hasattr(signal, "alarm"):
+    signal.signal(signal.SIGALRM, signal.SIG_DFL)
+    if hasattr(signal, "pthread_sigmask"):
+        signal.pthread_sigmask(signal.SIG_UNBLOCK, {{signal.SIGALRM}})
+    signal.alarm(int(_deadline) or 1)
+else:
+    _watchdog = threading.Timer(_deadline, lambda: os._exit(70))
+    _watchdog.daemon = True
+    _watchdog.start()
+
+if sys.platform == "win32":
+    _handles = []
+    for _directory in os.environ.get(
+        "UNSLOTH_STUDIO_PROBE_ROCM_DLL_DIRS", ""
+    ).split(os.pathsep):
+        if _directory and os.path.isdir(_directory):
+            try:
+                _handles.append(os.add_dll_directory(_directory))
+            except (OSError, AttributeError):
+                pass
+
+import torch
+
+_totals = {{}}
+for _ordinal in json.loads(sys.argv[1]):
+    try:
+        _ordinal = int(_ordinal)
+        _total = int(torch.cuda.mem_get_info(_ordinal)[1])
+        _tensor = torch.ones((1,), dtype = torch.float16, device = f"cuda:{{_ordinal}}")
+        _tensor.sum().item()
+        _totals[str(_ordinal)] = _total
+    except Exception:
+        _totals[str(_ordinal)] = None
+
+print(
+    "{_MEMORY_TOTAL_RESULT_PREFIX}" + json.dumps(_totals, sort_keys = True),
+    flush = True,
+)
 """
 
 
@@ -214,6 +266,14 @@ def _identity_key() -> tuple[str | None, ...]:
     return tuple(os.environ.get(name) for name in _DEVICE_IDENTITY_ENV_VARS)
 
 
+def _probe_env() -> dict[str, str]:
+    env = child_env_without_native_path_secret()
+    dll_directories = _rocm_dll_directories()
+    if dll_directories:
+        env[ROCM_DLL_DIRS_ENV_VAR] = os.pathsep.join(dll_directories)
+    return utf8_child_env(env)
+
+
 def device_can_allocate(device: str) -> bool:
     """Return false unless the device is known to be usable.
 
@@ -235,11 +295,6 @@ def _device_can_allocate_cached(device: str, _identity: tuple[str | None, ...]) 
     if os.environ.get(DISABLE_ENV_VAR) == "1":
         return True
 
-    env = child_env_without_native_path_secret()
-    dll_directories = _rocm_dll_directories()
-    if dll_directories:
-        env[ROCM_DLL_DIRS_ENV_VAR] = os.pathsep.join(dll_directories)
-
     try:
         process = subprocess.Popen(
             [sys.executable, "-c", _PROBE_SCRIPT, device, str(_CHILD_SELF_LIMIT_SECONDS)],
@@ -248,7 +303,7 @@ def _device_can_allocate_cached(device: str, _identity: tuple[str | None, ...]) 
             text = True,
             encoding = "utf-8",
             errors = "replace",
-            env = utf8_child_env(env),
+            env = _probe_env(),
             # No child_popen_kwargs() here. Its Linux preexec_fn can deadlock when
             # this multithreaded backend forks and executes Python before exec.
             **windows_hidden_subprocess_kwargs(),
@@ -315,6 +370,126 @@ def _device_can_allocate_cached(device: str, _identity: tuple[str | None, ...]) 
             forget_pid(process.pid)
 
 
+def rocm_memory_totals(device_ordinals: list[int] | tuple[int, ...]) -> dict[int, int]:
+    """Return HIP memory totals without letting a native abort kill the backend.
+
+    Results, including failure, are cached for the backend lifetime. Device capacity is
+    fixed, and retrying a probe that already crashed would only make every system poll pay
+    the same cold torch import and native fault again.
+    """
+    ordinals = tuple(dict.fromkeys(int(ordinal) for ordinal in device_ordinals if ordinal >= 0))
+    return dict(_rocm_memory_totals_cached(ordinals, _identity_key()))
+
+
+@lru_cache(maxsize = None)
+def _rocm_memory_totals_cached(
+    device_ordinals: tuple[int, ...], _identity: tuple[str | None, ...]
+) -> tuple[tuple[int, int], ...]:
+    if not device_ordinals:
+        return ()
+
+    try:
+        process = subprocess.Popen(
+            [
+                sys.executable,
+                "-c",
+                _ROCM_MEMORY_TOTAL_PROBE_SCRIPT,
+                json.dumps(device_ordinals),
+                str(_CHILD_SELF_LIMIT_SECONDS),
+            ],
+            stdout = subprocess.PIPE,
+            stderr = subprocess.PIPE,
+            text = True,
+            encoding = "utf-8",
+            errors = "replace",
+            env = _probe_env(),
+            # See the allocation probe above: no preexec_fn in a threaded backend.
+            **windows_hidden_subprocess_kwargs(),
+        )
+    except Exception:  # noqa: BLE001 - telemetry falls back to the carve-out
+        logger.warning(
+            "ROCm memory-total probe could not run; using device-property totals",
+            exc_info = True,
+        )
+        return ()
+
+    from utils.process_lifetime import adopt_pid, forget_pid
+
+    adopt_pid(process.pid)
+    try:
+        try:
+            stdout, stderr = process.communicate(timeout = PROBE_TIMEOUT_SECONDS)
+        except subprocess.TimeoutExpired:
+            stderr = _terminate_and_drain(process)
+            tail = (stderr or "").strip()[-_STDERR_TAIL_CHARS:]
+            logger.warning(
+                "ROCm memory-total probe did not finish in %.0fs; using device-property "
+                "totals%s",
+                PROBE_TIMEOUT_SECONDS,
+                f": {tail}" if tail else "",
+            )
+            return ()
+        except Exception:  # noqa: BLE001 - telemetry falls back to the carve-out
+            _terminate_and_drain(process)
+            logger.warning(
+                "ROCm memory-total probe could not be read; using device-property totals",
+                exc_info = True,
+            )
+            return ()
+
+        if process.returncode != 0:
+            tail = (stderr or "").strip()[-_STDERR_TAIL_CHARS:]
+            logger.warning(
+                "ROCm memory-total probe exited with status %s; using device-property "
+                "totals%s",
+                process.returncode,
+                f": {tail}" if tail else "",
+            )
+            return ()
+
+        result_line = next(
+            (
+                line[len(_MEMORY_TOTAL_RESULT_PREFIX) :]
+                for line in reversed((stdout or "").splitlines())
+                if line.startswith(_MEMORY_TOTAL_RESULT_PREFIX)
+            ),
+            None,
+        )
+        if result_line is None:
+            logger.warning(
+                "ROCm memory-total probe returned no result; using device-property totals"
+            )
+            return ()
+        try:
+            payload = json.loads(result_line)
+            expected = set(device_ordinals)
+            totals = tuple(
+                sorted(
+                    (int(raw_ordinal), int(raw_total))
+                    for raw_ordinal, raw_total in payload.items()
+                    if int(raw_ordinal) in expected
+                    and type(raw_total) is int
+                    and raw_total > 0
+                )
+            )
+        except (AttributeError, TypeError, ValueError, json.JSONDecodeError):
+            logger.warning(
+                "ROCm memory-total probe returned malformed data; using device-property totals"
+            )
+            return ()
+        missing = expected - {ordinal for ordinal, _total in totals}
+        if missing:
+            logger.warning(
+                "ROCm memory-total probe could not query ordinals %s; using device-property "
+                "totals for them",
+                sorted(missing),
+            )
+        return totals
+    finally:
+        if process.returncode is not None:
+            forget_pid(process.pid)
+
+
 def _terminate_and_drain(process: subprocess.Popen) -> str:
     """Bound cleanup after timeout and retain an unkillable child for reaping.
 
@@ -370,5 +545,10 @@ def _clear_probe_cache() -> None:
     _device_can_allocate_cached.cache_clear()
 
 
+def _clear_memory_total_probe_cache() -> None:
+    _rocm_memory_totals_cached.cache_clear()
+
+
 # Preserve the cache-control hook used by existing tests and callers.
 device_can_allocate.cache_clear = _clear_probe_cache  # type: ignore[attr-defined]
+rocm_memory_totals.cache_clear = _clear_memory_total_probe_cache  # type: ignore[attr-defined]

--- a/studio/backend/utils/torch_device_probe.py
+++ b/studio/backend/utils/torch_device_probe.py
@@ -440,8 +440,7 @@ def _rocm_memory_totals_cached(
         if process.returncode != 0:
             tail = (stderr or "").strip()[-_STDERR_TAIL_CHARS:]
             logger.warning(
-                "ROCm memory-total probe exited with status %s; using device-property "
-                "totals%s",
+                "ROCm memory-total probe exited with status %s; using device-property totals%s",
                 process.returncode,
                 f": {tail}" if tail else "",
             )
@@ -467,9 +466,7 @@ def _rocm_memory_totals_cached(
                 sorted(
                     (int(raw_ordinal), int(raw_total))
                     for raw_ordinal, raw_total in payload.items()
-                    if int(raw_ordinal) in expected
-                    and type(raw_total) is int
-                    and raw_total > 0
+                    if int(raw_ordinal) in expected and type(raw_total) is int and raw_total > 0
                 )
             )
         except (AttributeError, TypeError, ValueError, json.JSONDecodeError):


### PR DESCRIPTION
## Summary

[Reported on Reddit](https://www.reddit.com/r/unsloth/comments/1voc8jj/comment/p3ol9ec/).

- run the ROCm APU memory-total query in a cached child process so a native HIP abort cannot kill Studio
- fall back to the device-property total when the probe crashes, hangs, or returns invalid data
- keep Windows ROCm system telemetry out of the parent-process occupancy path

## Testing

- `python -m pytest -q studio/backend/tests/test_torch_device_probe.py studio/backend/tests/test_system_poll_no_cuda_context.py studio/backend/tests/test_rocm_windows_vram_7072.py`
- `python -m pytest -q studio/backend/tests/test_gpu_selection.py tests/studio/install/test_rocm_support.py`
- `ruff check` on the changed Python files
