### PR TITLE
Fix: Prevent Fatal Transformers In-Place Loss Crash during CPT/SFT

### DIFF
--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -3809,6 +3809,7 @@ class FastLlamaModel:
 
         # Prevent transformers >= 4.43+ inplace loss modification crash
         old_forward = model.forward
+
         def new_forward(*args, **kwargs):
             outputs = old_forward(*args, **kwargs)
             if hasattr(outputs, "loss") and outputs.loss is not None:
@@ -3816,6 +3817,7 @@ class FastLlamaModel:
             elif isinstance(outputs, tuple) and outputs[0] is not None:
                 outputs = (outputs[0].clone(),) + outputs[1:]
             return outputs
+
         model.forward = new_forward
 
         return model

--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -3806,6 +3806,18 @@ class FastLlamaModel:
         # Detect a stray pre-train forward so train() can drop the torch.compile
         # graph cache it would otherwise poison (see prepare_for_training_mode).
         _unsloth_install_pretrain_detector(model)
+
+        # Prevent transformers >= 4.43+ inplace loss modification crash
+        old_forward = model.forward
+        def new_forward(*args, **kwargs):
+            outputs = old_forward(*args, **kwargs)
+            if hasattr(outputs, "loss") and outputs.loss is not None:
+                outputs.loss = outputs.loss.clone()
+            elif isinstance(outputs, tuple) and outputs[0] is not None:
+                outputs = (outputs[0].clone(),) + outputs[1:]
+            return outputs
+        model.forward = new_forward
+
         return model
 
     @staticmethod


### PR DESCRIPTION
 ### Description

 Fixes a fatal RuntimeError during training caused by recent transformers versions.

In recent versions of transformers (specifically >= 4.43.0), the loss tensor is sometimes modified in-place during the training loop. This causes a memory corruption crash when Unsloth attempts to run its custom C++ UnslothFusedLossBackward function, throwing an error like:
│ RuntimeError: Output 0 of UnslothFusedLossBackward is a view and is being modified inplace.

  ### The Fix
This PR intercepts the loss tensor in FastLlamaModel.patch_peft_model inside unsloth/models/llama.py. By forcing a .clone() on the loss tensor right after the base model's forward pass, we create a safe, disconnected copy in memory. This permanently prevents transformers from modifying the tensor in-place and safely bypasses the crash during CPT and SFT stages without affecting training performance.
