### PR TITLE
Desktop: honor backend host and port flags

### DIFF
--- a/studio/frontend/src/hooks/use-tauri-backend.ts
+++ b/studio/frontend/src/hooks/use-tauri-backend.ts
@@ -63,6 +63,7 @@ type DesktopPreflightDisposition =
 interface DesktopPreflightResult {
   disposition: DesktopPreflightDisposition;
   reason: string | null;
+  host: string;
   port: number | null;
   can_auto_repair: boolean;
   managed_bin: string | null;
@@ -257,7 +258,7 @@ export function useTauriBackend() {
             setBackendError("Desktop preflight found a backend without a port.");
             return;
           }
-          setApiBase(preflight.port);
+          setApiBase(preflight.port, preflight.host);
           portRef.current = preflight.port;
           setIsExternalServer(true);
           setStartupMessage(SERVER_STARTUP_MESSAGE);
@@ -270,7 +271,7 @@ export function useTauriBackend() {
             setBackendError("Desktop preflight found an owned backend without a port.");
             return;
           }
-          setApiBase(preflight.port);
+          setApiBase(preflight.port, preflight.host);
           portRef.current = preflight.port;
           setIsExternalServer(false);
           stopExternalServerPoll();
@@ -324,7 +325,7 @@ export function useTauriBackend() {
 
     try {
       const { invoke } = await import("@tauri-apps/api/core");
-      // backend/run.py keeps the 8888-8908 fallback via server-port/TAURI_PORT.
+      // The backend reports its selected port through server-port/TAURI_PORT.
       await invoke("start_managed_server", { port: 8888 });
 
       // Rust emits server-port only after validating the desktop-owned process.
@@ -335,7 +336,6 @@ export function useTauriBackend() {
       );
 
       if (startupResult.status === "ready") {
-        setApiBase(startupResult.port);
         setRunningStatus();
         startingRef.current = false;
         return;
@@ -626,12 +626,12 @@ export function useTauriBackend() {
         setBackendError(e.payload, "repair-error");
       });
 
-      register<number>("server-port", (e) => {
-        portRef.current = e.payload;
+      register<{ host: string; port: number }>("server-port", (e) => {
+        portRef.current = e.payload.port;
         // A validated port means startup finished after all, so a later crash is
         // a real crash and deserves the generic message.
         startTimedOutRef.current = false;
-        setApiBase(e.payload);
+        setApiBase(e.payload.port, e.payload.host);
       });
 
       register<void>("server-crashed", () => {

--- a/studio/frontend/src/lib/api-base.ts
+++ b/studio/frontend/src/lib/api-base.ts
@@ -24,8 +24,9 @@ export function resetApiBase() {
   apiBase = initialApiBase
 }
 
-export function setApiBase(port: number) {
-  apiBase = `http://127.0.0.1:${port}`
+export function setApiBase(port: number, host = '127.0.0.1') {
+  const urlHost = host.includes(':') && !host.startsWith('[') ? `[${host}]` : host
+  apiBase = `http://${urlHost}:${port}`
 }
 
 export function getApiBase(): string {

--- a/studio/src-tauri/src/commands.rs
+++ b/studio/src-tauri/src/commands.rs
@@ -339,7 +339,7 @@ async fn check_health_inner(port: u16) -> Result<BackendLiveness, reqwest::Error
     let mut json = None;
     for path in ["/api/liveness", "/api/health"] {
         let resp = client
-            .get(format!("http://127.0.0.1:{}{}", port, path))
+            .get(crate::process::backend_url(port, path))
             .send()
             .await?;
         if resp.status() == reqwest::StatusCode::NOT_FOUND && path == "/api/liveness" {

--- a/studio/src-tauri/src/desktop_auth.rs
+++ b/studio/src-tauri/src/desktop_auth.rs
@@ -62,7 +62,7 @@ fn auth_secret_path(home: &Path, filename: &str) -> PathBuf {
 }
 
 fn auth_url(port: u16, route: &str) -> String {
-    format!("http://127.0.0.1:{port}/api/auth/{route}")
+    crate::process::backend_url(port, &format!("/api/auth/{route}"))
 }
 
 fn home_dir() -> Result<PathBuf, String> {

--- a/studio/src-tauri/src/desktop_backend_owner.rs
+++ b/studio/src-tauri/src/desktop_backend_owner.rs
@@ -25,7 +25,7 @@ const STUDIO_INSTALL_ID_BYTES: usize = STUDIO_INSTALL_ID_HEX_LEN / 2;
 const STUDIO_INSTALL_ID_LOCK_FILE: &str = ".studio_install_id.lock";
 const OWNER_TOKEN_BYTES: usize = 32;
 const DESKTOP_PORT_START: u16 = 8888;
-const DESKTOP_PORT_END: u16 = 8908;
+const DESKTOP_PORT_FALLBACK_COUNT: u16 = 20;
 const LOCAL_HTTP_TIMEOUT: Duration = Duration::from_secs(2);
 
 #[derive(Clone, Debug)]
@@ -139,7 +139,8 @@ struct TokenResponse {
 }
 
 pub(crate) fn desktop_candidate_ports() -> std::ops::RangeInclusive<u16> {
-    DESKTOP_PORT_START..=DESKTOP_PORT_END
+    let start = crate::process::requested_backend_port(DESKTOP_PORT_START);
+    start..=start.saturating_add(DESKTOP_PORT_FALLBACK_COUNT)
 }
 
 pub(crate) fn is_valid_studio_root_id(value: &str) -> bool {
@@ -807,7 +808,7 @@ async fn fetch_liveness(
     let client = crate::loopback_http::client(timeout)?;
     for path in ["/api/liveness", "/api/health"] {
         let response = client
-            .get(format!("http://127.0.0.1:{port}{path}"))
+            .get(crate::process::backend_url(port, path))
             .send()
             .await?;
         if response.status() == reqwest::StatusCode::NOT_FOUND && path == "/api/liveness" {
@@ -841,7 +842,7 @@ async fn fetch_health(
     access_token: Option<&str>,
 ) -> Result<Option<HealthResponse>, String> {
     let client = crate::loopback_http::client(LOCAL_HTTP_TIMEOUT).map_err(|e| e.to_string())?;
-    let mut request = client.get(format!("http://127.0.0.1:{port}/api/health"));
+    let mut request = client.get(crate::process::backend_url(port, "/api/health"));
     if let Some(access_token) = access_token {
         request = request.bearer_auth(access_token);
     }
@@ -870,7 +871,7 @@ async fn desktop_login_route_compatible(port: u16, timeout: Duration) -> bool {
         Err(_) => return false,
     };
     match client
-        .post(format!("http://127.0.0.1:{port}/api/auth/desktop-login"))
+        .post(crate::process::backend_url(port, "/api/auth/desktop-login"))
         .json(&DesktopLoginPayload {
             secret: "desktop-owner-adoption-invalid-secret",
         })
@@ -885,7 +886,7 @@ async fn desktop_login_route_compatible(port: u16, timeout: Duration) -> bool {
 async fn desktop_secret_login(port: u16, secret: &str) -> Result<String, String> {
     let client = crate::loopback_http::client(LOCAL_HTTP_TIMEOUT).map_err(|e| e.to_string())?;
     let response = client
-        .post(format!("http://127.0.0.1:{port}/api/auth/desktop-login"))
+        .post(crate::process::backend_url(port, "/api/auth/desktop-login"))
         .json(&DesktopLoginPayload { secret })
         .send()
         .await
@@ -1161,7 +1162,7 @@ pub(crate) fn exact_port_http_shutdown_blocking(port: u16) -> Result<(), String>
 }
 
 pub(crate) fn port_is_listening_blocking(port: u16, timeout: Duration) -> bool {
-    let addr = SocketAddr::from(([127, 0, 0, 1], port));
+    let addr = SocketAddr::new(crate::process::backend_connect_host(), port);
     TcpStream::connect_timeout(&addr, timeout).is_ok()
 }
 
@@ -1183,9 +1184,9 @@ fn http_request_blocking(
     extra_headers: &[String],
     body: &[u8],
 ) -> Result<SimpleHttpResponse, String> {
-    let addr = SocketAddr::from(([127, 0, 0, 1], port));
+    let addr = SocketAddr::new(crate::process::backend_connect_host(), port);
     let mut stream = TcpStream::connect_timeout(&addr, LOCAL_HTTP_TIMEOUT)
-        .map_err(|e| format!("connect to 127.0.0.1:{port}: {e}"))?;
+        .map_err(|e| format!("connect to {addr}: {e}"))?;
     stream
         .set_read_timeout(Some(LOCAL_HTTP_TIMEOUT))
         .map_err(|e| e.to_string())?;
@@ -1194,7 +1195,7 @@ fn http_request_blocking(
         .map_err(|e| e.to_string())?;
 
     let mut request = format!(
-        "{method} {path} HTTP/1.1\r\nHost: 127.0.0.1:{port}\r\nContent-Length: {}\r\nConnection: close\r\n",
+        "{method} {path} HTTP/1.1\r\nHost: {addr}\r\nContent-Length: {}\r\nConnection: close\r\n",
         body.len()
     )
     .into_bytes();

--- a/studio/src-tauri/src/preflight.rs
+++ b/studio/src-tauri/src/preflight.rs
@@ -74,11 +74,16 @@ fn managed_bin_for_result(managed: &ManagedProbe) -> Option<PathBuf> {
     }
 }
 
+fn configured_backend_host() -> String {
+    crate::process::backend_connect_host().to_string()
+}
+
 fn choose_preflight(managed: ManagedProbe, backend: BackendProbe) -> DesktopPreflightResult {
     match (backend, managed) {
         (BackendProbe::ExternalConflict { port, reason }, managed) => DesktopPreflightResult {
             disposition: DesktopPreflightDisposition::ExternalConflict,
             reason: Some(reason),
+            host: configured_backend_host(),
             port: Some(port),
             can_auto_repair: false,
             managed_bin: managed_bin_for_result(&managed),
@@ -86,6 +91,7 @@ fn choose_preflight(managed: ManagedProbe, backend: BackendProbe) -> DesktopPref
         (BackendProbe::Ready { port }, managed) => DesktopPreflightResult {
             disposition: DesktopPreflightDisposition::AttachedReady,
             reason: None,
+            host: configured_backend_host(),
             port: Some(port),
             can_auto_repair: false,
             managed_bin: managed_bin_for_result(&managed),
@@ -94,6 +100,7 @@ fn choose_preflight(managed: ManagedProbe, backend: BackendProbe) -> DesktopPref
             ManagedProbe::Ready { bin } => DesktopPreflightResult {
                 disposition: DesktopPreflightDisposition::ManagedReady,
                 reason: None,
+                host: configured_backend_host(),
                 port: None,
                 can_auto_repair: false,
                 managed_bin: Some(bin),
@@ -103,12 +110,14 @@ fn choose_preflight(managed: ManagedProbe, backend: BackendProbe) -> DesktopPref
                 // The repair needs the same home directory, so do not offer it.
                 can_auto_repair: release_auto_repair() && !managed::is_context_reason(&reason),
                 reason: Some(reason),
+                host: configured_backend_host(),
                 port: None,
                 managed_bin: Some(bin),
             },
             ManagedProbe::Missing => DesktopPreflightResult {
                 disposition: DesktopPreflightDisposition::NotInstalled,
                 reason: None,
+                host: configured_backend_host(),
                 port: None,
                 can_auto_repair: false,
                 managed_bin: None,
@@ -117,6 +126,7 @@ fn choose_preflight(managed: ManagedProbe, backend: BackendProbe) -> DesktopPref
             ManagedProbe::Unavailable { reason } => DesktopPreflightResult {
                 disposition: DesktopPreflightDisposition::ManagedStale,
                 reason: Some(reason),
+                host: configured_backend_host(),
                 port: None,
                 can_auto_repair: false,
                 managed_bin: None,
@@ -137,6 +147,7 @@ fn choose_owned_preflight(
         OwnedBackendReadiness::Ready => DesktopPreflightResult {
             disposition: DesktopPreflightDisposition::OwnedReady,
             reason: None,
+            host: configured_backend_host(),
             port: Some(owned.port),
             can_auto_repair: false,
             managed_bin: managed_bin_for_result(managed),
@@ -144,6 +155,7 @@ fn choose_owned_preflight(
         OwnedBackendReadiness::Stale { reason } => DesktopPreflightResult {
             disposition: DesktopPreflightDisposition::OwnedStale,
             reason: Some(stale_reason(managed, reason)),
+            host: configured_backend_host(),
             port: Some(owned.port),
             can_auto_repair: stale_auto_repair(managed),
             managed_bin: managed_bin_for_result(managed),
@@ -159,6 +171,7 @@ fn choose_unmanageable_owned_preflight(
     DesktopPreflightResult {
         disposition: DesktopPreflightDisposition::ExternalConflict,
         reason: Some(owned_unmanageable_reason(&reason)),
+        host: configured_backend_host(),
         port: Some(port),
         can_auto_repair: false,
         managed_bin: managed_bin_for_result(managed),
@@ -172,6 +185,7 @@ fn choose_owned_transitional_preflight(
     DesktopPreflightResult {
         disposition: DesktopPreflightDisposition::ExternalConflict,
         reason: Some("desktop_owned_backend_starting".to_string()),
+        host: configured_backend_host(),
         port,
         can_auto_repair: false,
         managed_bin: managed_bin_for_result(managed),
@@ -188,6 +202,7 @@ fn choose_ownerless_spawned_preflight(
             DesktopPreflightResult {
                 disposition: DesktopPreflightDisposition::OwnedReady,
                 reason: None,
+                host: configured_backend_host(),
                 port: Some(*port),
                 can_auto_repair: false,
                 managed_bin: managed_bin_for_result(managed),
@@ -197,6 +212,7 @@ fn choose_ownerless_spawned_preflight(
             DesktopPreflightResult {
                 disposition: DesktopPreflightDisposition::OwnedStale,
                 reason: Some(stale_reason(managed, reason)),
+                host: configured_backend_host(),
                 port: Some(*port),
                 can_auto_repair: stale_auto_repair(managed),
                 managed_bin: managed_bin_for_result(managed),

--- a/studio/src-tauri/src/preflight/backend.rs
+++ b/studio/src-tauri/src/preflight/backend.rs
@@ -29,7 +29,7 @@ pub(super) struct BackendHealth {
 
 pub(super) async fn backend_health(client: &reqwest::Client, port: u16) -> Option<BackendHealth> {
     let started = Instant::now();
-    let url = format!("http://127.0.0.1:{port}/api/health");
+    let url = crate::process::backend_url(port, "/api/health");
     let response = client.get(url).send().await.ok()?;
     if !response.status().is_success() {
         return None;
@@ -205,7 +205,7 @@ pub(super) async fn probe_ownerless_spawned_backend(port: u16) -> BackendProbe {
     }
 
     let response = client
-        .post(format!("http://127.0.0.1:{port}/api/auth/desktop-login"))
+        .post(crate::process::backend_url(port, "/api/auth/desktop-login"))
         .json(&DesktopLoginProbe {
             secret: "desktop-preflight-invalid-secret",
         })
@@ -283,7 +283,7 @@ pub(super) async fn backend_desktop_auth_status(
         }
     }
 
-    let url = format!("http://127.0.0.1:{port}/api/auth/desktop-login");
+    let url = crate::process::backend_url(port, "/api/auth/desktop-login");
     let response = client
         .post(url)
         .json(&DesktopLoginProbe {

--- a/studio/src-tauri/src/preflight/types.rs
+++ b/studio/src-tauri/src/preflight/types.rs
@@ -17,6 +17,7 @@ pub enum DesktopPreflightDisposition {
 pub struct DesktopPreflightResult {
     pub disposition: DesktopPreflightDisposition,
     pub reason: Option<String>,
+    pub host: String,
     pub port: Option<u16>,
     pub can_auto_repair: bool,
     pub managed_bin: Option<PathBuf>,

--- a/studio/src-tauri/src/process.rs
+++ b/studio/src-tauri/src/process.rs
@@ -2260,10 +2260,41 @@ mod tests {
     }
 
     #[test]
-    fn backend_args_always_enable_api_only() {
+    fn desktop_launch_args_accept_network_bind_and_port() {
         assert_eq!(
-            backend_args(8888),
-            vec!["studio", "--api-only", "-H", "127.0.0.1", "-p", "8888"]
+            desktop_launch_args(
+                [
+                    "--hidden".to_string(),
+                    "-H".to_string(),
+                    "0.0.0.0".to_string(),
+                    "-p".to_string(),
+                    "9999".to_string(),
+                    "--verbose".to_string(),
+                    "--disable-tools".to_string(),
+                ],
+                8888,
+            ),
+            Ok(DesktopLaunchArgs {
+                bind_host: "0.0.0.0".parse().unwrap(),
+                connect_host: "127.0.0.1".parse().unwrap(),
+                port: 9999,
+                passthrough: vec!["--verbose".to_string(), "--disable-tools".to_string()],
+            })
+        );
+    }
+
+    #[test]
+    fn desktop_launch_args_rejects_unsafe_or_cli_only_options() {
+        assert!(desktop_launch_args(["--host=desktop.local".to_string()], 8888).is_err());
+        assert!(desktop_launch_args(["--port=0".to_string()], 8888).is_err());
+        assert!(desktop_launch_args(["--cloudflare".to_string()], 8888).is_err());
+    }
+
+    #[test]
+    fn backend_urls_bracket_ipv6_hosts() {
+        assert_eq!(
+            backend_url_for("::1".parse().unwrap(), 8888, "/api/health"),
+            "http://[::1]:8888/api/health"
         );
     }
 
@@ -2724,18 +2755,164 @@ pub(crate) fn resolve_backend_binary() -> Result<std::path::PathBuf, String> {
         .ok_or_else(|| "Unsloth binary not found. Please install Unsloth first.".to_string())
 }
 
-fn backend_args(port: u16) -> Vec<String> {
-    [
-        "studio",
-        "--api-only",
-        "-H",
-        "127.0.0.1",
-        "-p",
-        &port.to_string(),
-    ]
-    .into_iter()
-    .map(String::from)
-    .collect()
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct DesktopLaunchArgs {
+    bind_host: std::net::IpAddr,
+    connect_host: std::net::IpAddr,
+    port: u16,
+    passthrough: Vec<String>,
+}
+
+fn desktop_launch_args(
+    args: impl IntoIterator<Item = String>,
+    default_port: u16,
+) -> Result<DesktopLaunchArgs, String> {
+    let mut host = "127.0.0.1"
+        .parse::<std::net::IpAddr>()
+        .expect("valid loopback IP");
+    let mut port = default_port;
+    let mut passthrough = Vec::new();
+    let mut args = args.into_iter();
+
+    while let Some(arg) = args.next() {
+        let value = match arg.as_str() {
+            "--hidden" => continue,
+            "-H" | "--host" | "-p" | "--port" => args.next().ok_or_else(|| {
+                format!("{arg} requires a value. Use -H 0.0.0.0 -p {default_port}.")
+            })?,
+            "--api-only" => continue,
+            "--silent" | "-q" | "--verbose" | "-v" | "--enable-tools" | "--disable-tools"
+            | "--disable-dns-pinning" => {
+                passthrough.push(arg);
+                continue;
+            }
+            _ => {
+                if let Some(value) = arg.strip_prefix("--host=") {
+                    host = parse_bind_host(value)?;
+                    continue;
+                }
+                if let Some(value) = arg.strip_prefix("--port=") {
+                    port = parse_port(value)?;
+                    continue;
+                }
+                return Err(format!(
+                    "{arg} conflicts with Unsloth Desktop. Use `unsloth studio` for standalone server options."
+                ));
+            }
+        };
+        match arg.as_str() {
+            "-H" | "--host" => host = parse_bind_host(value)?,
+            "-p" | "--port" => port = parse_port(value)?,
+            _ => unreachable!(),
+        }
+    }
+
+    let connect_host = match host {
+        // A wildcard listener remains reachable through loopback, which preserves
+        // the Desktop app's local authentication and process ownership path.
+        std::net::IpAddr::V4(ip) if ip.is_unspecified() => "127.0.0.1"
+            .parse()
+            .expect("valid loopback IP"),
+        std::net::IpAddr::V6(ip) if ip.is_unspecified() => {
+            "::1".parse().expect("valid loopback IP")
+        }
+        _ => host,
+    };
+
+    Ok(DesktopLaunchArgs {
+        bind_host: host,
+        connect_host,
+        port,
+        passthrough,
+    })
+}
+
+fn parse_bind_host(value: impl AsRef<str>) -> Result<std::net::IpAddr, String> {
+    let value = value.as_ref();
+    value.parse().map_err(|_| {
+        format!(
+            "Invalid host: {value}. Unsloth Desktop accepts a local IP address, not a hostname."
+        )
+    })
+}
+
+fn parse_port(value: impl AsRef<str>) -> Result<u16, String> {
+    let value = value.as_ref();
+    let port = value.parse::<u16>().map_err(|_| format!("Invalid port: {value}"))?;
+    if port == 0 {
+        return Err("Invalid port: 0. Choose a port from 1 to 65535.".to_string());
+    }
+    Ok(port)
+}
+
+fn current_desktop_launch_args(default_port: u16) -> Result<DesktopLaunchArgs, String> {
+    #[cfg(test)]
+    {
+        return desktop_launch_args(Vec::new(), default_port);
+    }
+    #[cfg(not(test))]
+    desktop_launch_args(std::env::args().skip(1), default_port)
+}
+
+fn validate_bind_host(host: std::net::IpAddr) -> Result<(), String> {
+    std::net::TcpListener::bind((host, 0))
+        .map(|listener| drop(listener))
+        .map_err(|error| format!("{host} is not a local address this computer can bind: {error}"))
+}
+
+fn backend_url_for(host: std::net::IpAddr, port: u16, path: &str) -> String {
+    let host = host.to_string();
+    let host = if host.contains(':') {
+        format!("[{host}]")
+    } else {
+        host
+    };
+    format!("http://{host}:{port}{path}")
+}
+
+pub(crate) fn backend_url(port: u16, path: &str) -> String {
+    backend_url_for(backend_connect_host(), port, path)
+}
+
+pub(crate) fn backend_connect_host() -> std::net::IpAddr {
+    #[cfg(test)]
+    return "127.0.0.1".parse().expect("valid loopback IP");
+
+    #[cfg(not(test))]
+    {
+        static CONNECT_HOST: std::sync::OnceLock<Result<std::net::IpAddr, String>> =
+            std::sync::OnceLock::new();
+        CONNECT_HOST
+            .get_or_init(|| {
+                let launch = current_desktop_launch_args(8888)?;
+                validate_bind_host(launch.bind_host)?;
+                Ok(launch.connect_host)
+            })
+            .as_ref()
+            .ok()
+            .copied()
+        // Never send desktop credentials to a host the local machine cannot bind.
+            .unwrap_or_else(|| "127.0.0.1".parse().expect("valid loopback IP"))
+    }
+}
+
+pub(crate) fn requested_backend_port(default_port: u16) -> u16 {
+    current_desktop_launch_args(default_port)
+        .map(|launch| launch.port)
+        .unwrap_or(default_port)
+}
+
+fn backend_args(launch: &DesktopLaunchArgs) -> Vec<String> {
+    let mut args = vec![
+        "studio".to_string(),
+        "--api-only".to_string(),
+        "-H".to_string(),
+        launch.bind_host.to_string(),
+        "-p".to_string(),
+        launch.port.to_string(),
+    ];
+    args.extend(launch.passthrough.iter().cloned());
+    args
 }
 
 /// Spawn the backend process and wire up stdout/stderr reader threads.
@@ -2797,7 +2974,9 @@ pub fn start_backend(
         }
     };
 
-    let args = backend_args(port);
+    let launch = current_desktop_launch_args(port)?;
+    validate_bind_host(launch.bind_host)?;
+    let args = backend_args(&launch);
     // Built before ownership is claimed: a missing managed interpreter must not
     // leave a pending owner behind for a backend that was never spawned.
     let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
@@ -3060,7 +3239,7 @@ async fn generic_backend_health_ok(port: u16) -> bool {
     let mut json = None;
     for path in ["/api/liveness", "/api/health"] {
         let response = match client
-            .get(format!("http://127.0.0.1:{port}{path}"))
+            .get(backend_url(port, path))
             .send()
             .await
         {
@@ -3276,7 +3455,10 @@ async fn validate_candidate_port(
     if should_emit {
         diagnostics::record_backend_port(&diagnostics_state, &session_id, port);
         info!("Validated backend port: {}", port);
-        let _ = app.emit("server-port", port);
+        let _ = app.emit(
+            "server-port",
+            serde_json::json!({ "host": backend_connect_host().to_string(), "port": port }),
+        );
     }
 }
 
@@ -5289,9 +5471,10 @@ mod managed_cli_working_dir_tests {
 
     #[test]
     fn backend_args_are_unchanged_by_the_working_directory_fix() {
+        let launch = desktop_launch_args(Vec::new(), 8888).unwrap();
         assert_eq!(
-            backend_args(8888),
-            vec!["studio", "--api-only", "-H", "127.0.0.1", "-p", "8888"]
+            &backend_args(&launch)[..6],
+            ["studio", "--api-only", "-H", "127.0.0.1", "-p", "8888"]
         );
     }
 

--- a/studio/src-tauri/tauri.conf.json
+++ b/studio/src-tauri/tauri.conf.json
@@ -16,7 +16,7 @@
   "app": {
     "withGlobalTauri": true,
     "security": {
-      "csp": "default-src 'self'; connect-src 'self' ipc: http://ipc.localhost http://localhost:* ws://localhost:* ws://127.0.0.1:* http://127.0.0.1:* https://huggingface.co https://*.huggingface.co https://datasets-server.huggingface.co; img-src 'self' data: blob: https:; media-src 'self' data: blob: https: http://localhost:* http://127.0.0.1:*; style-src 'self' 'unsafe-inline'; font-src 'self' data:; frame-src 'self' http://localhost:* http://127.0.0.1:*"
+      "csp": "default-src 'self'; connect-src 'self' ipc: http://ipc.localhost http://localhost:* ws://localhost:* ws://127.0.0.1:* http://127.0.0.1:* http://*:* https://huggingface.co https://*.huggingface.co https://datasets-server.huggingface.co; img-src 'self' data: blob: https: http://*:*; media-src 'self' data: blob: https: http://localhost:* http://127.0.0.1:* http://*:*; style-src 'self' 'unsafe-inline'; font-src 'self' data:; frame-src 'self' http://localhost:* http://127.0.0.1:*"
     },
     "windows": [
       {


### PR DESCRIPTION
## Summary
- forward compatible Desktop launch flags for backend host and port
- use the configured local endpoint for Desktop health, auth, ownership, and preflight flows
- preserve wildcard binds through loopback and reject non-local hostnames / port 0
- update the WebView endpoint handoff for configured hosts and IPv6

## Validation
- cargo test (372 passed)
- npm run build
- cargo build --release

Related to #8578 and #8790.