### PR TITLE
docs: fix dead Linux .deb download link

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ The Tauri based desktop app is the easiest way to use Unsloth and needs no setup
   </tr>
   <tr>
     <td><b>Linux / Ubuntu (deb)</b></td>
-    <td><a href='https://github.com/unslothai/unsloth/releases/download/v0.1.800-beta/Unsloth-Desktop-0_1_800_beta-Linux.deb'>Download</a></td>
+    <td><a href='https://github.com/unslothai/unsloth/releases/download/v0.1.800-beta/Unsloth-Desktop-0_1_800_beta-Ubuntu.deb'>Download</a></td>
   </tr>
   <tr>
     <td><b>Linux (AppImage)</b></td>


### PR DESCRIPTION
The second download table in the README links to `Unsloth-Desktop-0_1_800_beta-Linux.deb`, which does not exist in the v0.1.800-beta release assets (404). The actual .deb asset is named `Unsloth-Desktop-0_1_800_beta-Ubuntu.deb` — exactly what the first download table already links to. Updated the dead link to the real asset name.