### PR TITLE
fix(studio): resolve UUID-form CUDA_VISIBLE_DEVICES to physical GPU indices

### DIFF
--- a/studio/backend/models/inference.py
+++ b/studio/backend/models/inference.py
@@ -102,10 +102,11 @@ class LoadRequest(BaseModel):
             "automatic selection. CUDA/ROCm values are physical GPU indices; "
             "Vulkan values are ggml device ordinals. Explicit selection is not "
             "supported on XPU, and physical IDs are unsupported when the parent "
-            "visibility mask uses "
-            "non-numeric or subdevice entries, including CUDA_VISIBLE_DEVICES "
-            "with UUID/MIG entries and ZE_AFFINITY_MASK with subdevice tokens "
-            "(for example '0.0,0.1') or FLAT-hierarchy tile handles. For GGUF "
+            "visibility mask uses non-numeric or subdevice entries that can't be "
+            "resolved to physical IDs: MIG entries, an ambiguous UUID/prefix, or "
+            "ZE_AFFINITY_MASK with subdevice tokens (for example '0.0,0.1') or "
+            "FLAT-hierarchy tile handles. A CUDA_VISIBLE_DEVICES UUID mask that "
+            "nvidia-smi can resolve to root GPU UUIDs is supported. For GGUF "
             "models the fitter may pin the smallest subset of this pool that fits."
         ),
     )

--- a/studio/backend/models/inference.py
+++ b/studio/backend/models/inference.py
@@ -106,8 +106,12 @@ class LoadRequest(BaseModel):
             "resolved to physical IDs: MIG entries, an ambiguous UUID/prefix, or "
             "ZE_AFFINITY_MASK with subdevice tokens (for example '0.0,0.1') or "
             "FLAT-hierarchy tile handles. A CUDA_VISIBLE_DEVICES UUID mask that "
-            "nvidia-smi can resolve to root GPU UUIDs is supported. For GGUF "
-            "models the fitter may pin the smallest subset of this pool that fits."
+            "nvidia-smi can resolve to root GPU UUIDs is supported, but only "
+            "while CUDA_DEVICE_ORDER is PCI_BUS_ID (the default) and nvidia-smi's "
+            "own device index agrees with PCI bus order; an explicit "
+            "CUDA_DEVICE_ORDER=FASTEST_FIRST or a host where the two orderings "
+            "disagree falls back to the same unsupported case. For GGUF models "
+            "the fitter may pin the smallest subset of this pool that fits."
         ),
     )
     speculative_type: Optional[str] = Field(

--- a/studio/backend/models/training.py
+++ b/studio/backend/models/training.py
@@ -562,10 +562,12 @@ class TrainingStartRequest(BaseModel):
             "Physical GPU indices to use, for example [0, 1]. Omit or pass "
             "[] to use automatic selection. Explicit gpu_ids are unsupported "
             "when the parent visibility mask uses non-numeric or subdevice "
-            "entries -- this includes CUDA_VISIBLE_DEVICES with UUID/MIG "
-            "entries on NVIDIA, and ZE_AFFINITY_MASK with subdevice tokens "
-            "(e.g. '0.0,0.1') or FLAT-hierarchy (default) tile handles on "
-            "Intel XPU."
+            "entries that can't be resolved to physical IDs -- this includes "
+            "CUDA_VISIBLE_DEVICES with a MIG entry or an ambiguous UUID/prefix "
+            "on NVIDIA, and ZE_AFFINITY_MASK with subdevice tokens (e.g. "
+            "'0.0,0.1') or FLAT-hierarchy (default) tile handles on Intel XPU. "
+            "A CUDA_VISIBLE_DEVICES UUID mask that nvidia-smi can resolve to "
+            "root GPU UUIDs is supported."
         ),
     )
 

--- a/studio/backend/models/training.py
+++ b/studio/backend/models/training.py
@@ -567,7 +567,11 @@ class TrainingStartRequest(BaseModel):
             "on NVIDIA, and ZE_AFFINITY_MASK with subdevice tokens (e.g. "
             "'0.0,0.1') or FLAT-hierarchy (default) tile handles on Intel XPU. "
             "A CUDA_VISIBLE_DEVICES UUID mask that nvidia-smi can resolve to "
-            "root GPU UUIDs is supported."
+            "root GPU UUIDs is supported, but only while CUDA_DEVICE_ORDER is "
+            "PCI_BUS_ID (the default) and nvidia-smi's own device index agrees "
+            "with PCI bus order; an explicit CUDA_DEVICE_ORDER=FASTEST_FIRST or "
+            "a host where the two orderings disagree falls back to the same "
+            "unsupported case."
         ),
     )
 

--- a/studio/backend/tests/test_gpu_selection.py
+++ b/studio/backend/tests/test_gpu_selection.py
@@ -221,51 +221,66 @@ class TestResolveRequestedGpuIds(_GpuCacheResetMixin, unittest.TestCase):
 
 
 class TestResolveGpuUuidMask(_GpuCacheResetMixin, unittest.TestCase):
+    # Real values from issue #8873's own nvidia-smi output: PCI order and
+    # nvidia-smi's index happen to agree there, so other tests deliberately
+    # use bus ids where they DON'T, to prove the ordinal comes from sorting
+    # pci.bus_id rather than from trusting nvidia-smi's own index column.
+    _UUID_A = "GPU-d18a14b7-70a4-61bd-56f1-371055dfbb50"
+    _UUID_B = "GPU-2f902962-578c-0f96-69a5-3e18679211d7"
+
     def test_resolves_and_preserves_mask_order(self):
         smi_output = "\n".join(
             [
-                "0, GPU-d18a14b7-70a4-61bd-56f1-371055dfbb50",
-                "1, GPU-2f902962-578c-0f96-69a5-3e18679211d7",
+                f"{self._UUID_A}, 00000000:01:00.0, Disabled",
+                f"{self._UUID_B}, 00000000:04:00.0, Disabled",
             ]
         )
         with patch("utils.hardware.nvidia.subprocess.run") as mock_run:
             mock_run.return_value = SimpleNamespace(returncode = 0, stdout = smi_output)
-            # Mask order is reversed relative to nvidia-smi's index order --
-            # the resolved list must follow the mask, not the smi listing.
-            result = nvidia.resolve_gpu_uuid_mask(
-                [
-                    "GPU-2f902962-578c-0f96-69a5-3e18679211d7",
-                    "GPU-d18a14b7-70a4-61bd-56f1-371055dfbb50",
-                ]
-            )
+            # Mask order is reversed relative to the PCI listing -- the
+            # resolved list must follow the mask, not the smi listing.
+            result = nvidia.resolve_gpu_uuid_mask([self._UUID_B, self._UUID_A])
+        self.assertEqual(result, [1, 0])
+
+    def test_derives_order_from_pci_bus_id_not_nvidia_smi_index(self):
+        # nvidia-smi's own row order (and a hypothetical index column) lists
+        # UUID_A first, but its PCI bus id sorts *after* UUID_B's -- the
+        # resolved ordinal must follow pci.bus_id, not listing/index order.
+        smi_output = "\n".join(
+            [
+                f"{self._UUID_A}, 00000000:09:00.0, Disabled",
+                f"{self._UUID_B}, 00000000:02:00.0, Disabled",
+            ]
+        )
+        with patch("utils.hardware.nvidia.subprocess.run") as mock_run:
+            mock_run.return_value = SimpleNamespace(returncode = 0, stdout = smi_output)
+            result = nvidia.resolve_gpu_uuid_mask([self._UUID_A, self._UUID_B])
         self.assertEqual(result, [1, 0])
 
     def test_returns_none_when_a_token_does_not_match_any_device(self):
-        smi_output = "0, GPU-d18a14b7-70a4-61bd-56f1-371055dfbb50"
+        smi_output = f"{self._UUID_A}, 00000000:01:00.0, Disabled"
         with patch("utils.hardware.nvidia.subprocess.run") as mock_run:
             mock_run.return_value = SimpleNamespace(returncode = 0, stdout = smi_output)
-            # e.g. a MIG instance UUID nvidia-smi's index/uuid query never lists.
-            result = nvidia.resolve_gpu_uuid_mask(
-                ["GPU-d18a14b7-70a4-61bd-56f1-371055dfbb50", "MIG-not-a-root-gpu"]
-            )
+            # e.g. a MIG instance UUID nvidia-smi's uuid/pci.bus_id query never lists.
+            result = nvidia.resolve_gpu_uuid_mask([self._UUID_A, "MIG-not-a-root-gpu"])
         self.assertIsNone(result)
 
     def test_returns_none_when_nvidia_smi_fails(self):
         with patch("utils.hardware.nvidia.subprocess.run") as mock_run:
             mock_run.return_value = SimpleNamespace(returncode = 1, stdout = "")
-            result = nvidia.resolve_gpu_uuid_mask(["GPU-d18a14b7-70a4-61bd-56f1-371055dfbb50"])
+            result = nvidia.resolve_gpu_uuid_mask([self._UUID_A])
         self.assertIsNone(result)
 
     def test_returns_none_when_nvidia_smi_is_missing(self):
         with patch("utils.hardware.nvidia.subprocess.run", side_effect = FileNotFoundError()):
-            result = nvidia.resolve_gpu_uuid_mask(["GPU-d18a14b7-70a4-61bd-56f1-371055dfbb50"])
+            result = nvidia.resolve_gpu_uuid_mask([self._UUID_A])
         self.assertIsNone(result)
 
     def test_resolves_an_unambiguous_uuid_prefix(self):
         smi_output = "\n".join(
             [
-                "0, GPU-d18a14b7-70a4-61bd-56f1-371055dfbb50",
-                "1, GPU-2f902962-578c-0f96-69a5-3e18679211d7",
+                f"{self._UUID_A}, 00000000:01:00.0, Disabled",
+                f"{self._UUID_B}, 00000000:04:00.0, Disabled",
             ]
         )
         with patch("utils.hardware.nvidia.subprocess.run") as mock_run:
@@ -276,8 +291,8 @@ class TestResolveGpuUuidMask(_GpuCacheResetMixin, unittest.TestCase):
     def test_rejects_a_uuid_prefix_shared_by_two_devices(self):
         smi_output = "\n".join(
             [
-                "0, GPU-d18a14b7-70a4-61bd-56f1-371055dfbb50",
-                "1, GPU-d18a14b7-aaaa-bbbb-cccc-000000000000",
+                f"{self._UUID_A}, 00000000:01:00.0, Disabled",
+                "GPU-d18a14b7-aaaa-bbbb-cccc-000000000000, 00000000:04:00.0, Disabled",
             ]
         )
         with patch("utils.hardware.nvidia.subprocess.run") as mock_run:
@@ -286,9 +301,43 @@ class TestResolveGpuUuidMask(_GpuCacheResetMixin, unittest.TestCase):
             result = nvidia.resolve_gpu_uuid_mask(["GPU-d18a14b7"])
         self.assertIsNone(result)
 
+    def test_rejects_a_malformed_token_that_coincidentally_prefixes_a_uuid(self):
+        # A single-GPU host where a bare "GPU" (no trailing "-") happens to
+        # string-prefix the one UUID present must not resolve it -- "GPU" is
+        # not a valid CUDA UUID identifier and this token was never meant as one.
+        smi_output = f"{self._UUID_A}, 00000000:01:00.0, Disabled"
+        with patch("utils.hardware.nvidia.subprocess.run") as mock_run:
+            mock_run.return_value = SimpleNamespace(returncode = 0, stdout = smi_output)
+            self.assertIsNone(nvidia.resolve_gpu_uuid_mask(["GPU"]))
+            self.assertIsNone(nvidia.resolve_gpu_uuid_mask(["G"]))
+
+    def test_leaves_mig_enabled_root_uuid_unresolved(self):
+        smi_output = "\n".join(
+            [
+                f"{self._UUID_A}, 00000000:01:00.0, Enabled",
+                f"{self._UUID_B}, 00000000:04:00.0, Disabled",
+            ]
+        )
+        with patch("utils.hardware.nvidia.subprocess.run") as mock_run:
+            mock_run.return_value = SimpleNamespace(returncode = 0, stdout = smi_output)
+            # UUID_A is MIG-enabled -- its root UUID must not resolve, even
+            # though nvidia-smi still lists it as a normal row.
+            self.assertIsNone(nvidia.resolve_gpu_uuid_mask([self._UUID_A]))
+            # UUID_B is unaffected and still resolves on its own.
+            self.assertEqual(nvidia.resolve_gpu_uuid_mask([self._UUID_B]), [1])
+
+    def test_resolves_a_mixed_numeric_and_uuid_mask(self):
+        smi_output = f"{self._UUID_A}, 00000000:04:00.0, Disabled"
+        with patch("utils.hardware.nvidia.subprocess.run") as mock_run:
+            mock_run.return_value = SimpleNamespace(returncode = 0, stdout = smi_output)
+            # "0" passes through as-is (same trust level as the pure-numeric
+            # fast path); only the UUID token goes through nvidia-smi.
+            result = nvidia.resolve_gpu_uuid_mask(["0", self._UUID_A])
+        self.assertEqual(result, [0, 0])
+
     def test_caches_a_resolved_mask_and_does_not_requery(self):
-        smi_output = "0, GPU-d18a14b7-70a4-61bd-56f1-371055dfbb50"
-        tokens = ["GPU-d18a14b7-70a4-61bd-56f1-371055dfbb50"]
+        smi_output = f"{self._UUID_A}, 00000000:01:00.0, Disabled"
+        tokens = [self._UUID_A]
         with patch("utils.hardware.nvidia.subprocess.run") as mock_run:
             mock_run.return_value = SimpleNamespace(returncode = 0, stdout = smi_output)
             first = nvidia.resolve_gpu_uuid_mask(tokens)
@@ -297,14 +346,37 @@ class TestResolveGpuUuidMask(_GpuCacheResetMixin, unittest.TestCase):
         self.assertEqual(second, [0])
         mock_run.assert_called_once()
 
-    def test_caches_a_failed_resolution_and_does_not_requery(self):
-        tokens = ["GPU-d18a14b7-70a4-61bd-56f1-371055dfbb50"]
+    def test_caches_a_failed_resolution_within_the_ttl_and_does_not_requery(self):
+        tokens = [self._UUID_A]
         with patch("utils.hardware.nvidia.subprocess.run") as mock_run:
             mock_run.return_value = SimpleNamespace(returncode = 1, stdout = "")
             first = nvidia.resolve_gpu_uuid_mask(tokens)
             second = nvidia.resolve_gpu_uuid_mask(tokens)
         self.assertIsNone(first)
         self.assertIsNone(second)
+        mock_run.assert_called_once()
+
+    def test_retries_a_failed_resolution_once_the_ttl_expires(self):
+        tokens = [self._UUID_A]
+        smi_output = f"{self._UUID_A}, 00000000:01:00.0, Disabled"
+        with patch("utils.hardware.nvidia.subprocess.run") as mock_run:
+            mock_run.return_value = SimpleNamespace(returncode = 1, stdout = "")
+            first = nvidia.resolve_gpu_uuid_mask(tokens)
+        self.assertIsNone(first)
+
+        # Simulate the TTL elapsing without a real sleep: back-date the
+        # cached failure's timestamp past the expiry window.
+        cache_key = tuple(tokens)
+        _value, cached_at = nvidia._uuid_mask_resolution_cache[cache_key]
+        nvidia._uuid_mask_resolution_cache[cache_key] = (
+            _value,
+            cached_at - nvidia._FAILED_RESOLUTION_TTL_SECONDS - 1,
+        )
+
+        with patch("utils.hardware.nvidia.subprocess.run") as mock_run:
+            mock_run.return_value = SimpleNamespace(returncode = 0, stdout = smi_output)
+            second = nvidia.resolve_gpu_uuid_mask(tokens)
+        self.assertEqual(second, [0])
         mock_run.assert_called_once()
 
 

--- a/studio/backend/tests/test_gpu_selection.py
+++ b/studio/backend/tests/test_gpu_selection.py
@@ -69,6 +69,7 @@ class _GpuCacheResetMixin:
     def tearDown(self):
         _hw_module._physical_gpu_count = None
         _hw_module._visible_gpu_count = None
+        nvidia._uuid_mask_resolution_cache.clear()
 
 
 class TestResolveRequestedGpuIds(_GpuCacheResetMixin, unittest.TestCase):
@@ -89,7 +90,11 @@ class TestResolveRequestedGpuIds(_GpuCacheResetMixin, unittest.TestCase):
         self,
     ):
         with (
-            patch.dict(os.environ, {"CUDA_VISIBLE_DEVICES": "GPU-aaa,GPU-bbb"}, clear = True),
+            patch.dict(
+                os.environ,
+                {"CUDA_VISIBLE_DEVICES": "GPU-aaa,GPU-bbb", "CUDA_DEVICE_ORDER": "PCI_BUS_ID"},
+                clear = True,
+            ),
             patch("utils.hardware.hardware.get_physical_gpu_count", return_value = 8),
             patch("utils.hardware.nvidia.resolve_gpu_uuid_mask", return_value = None),
         ):
@@ -97,7 +102,11 @@ class TestResolveRequestedGpuIds(_GpuCacheResetMixin, unittest.TestCase):
 
     def test_parent_visibility_resolves_uuid_masks_via_nvidia_smi(self):
         with (
-            patch.dict(os.environ, {"CUDA_VISIBLE_DEVICES": "GPU-aaa,GPU-bbb"}, clear = True),
+            patch.dict(
+                os.environ,
+                {"CUDA_VISIBLE_DEVICES": "GPU-aaa,GPU-bbb", "CUDA_DEVICE_ORDER": "PCI_BUS_ID"},
+                clear = True,
+            ),
             patch("utils.hardware.hardware.get_physical_gpu_count", return_value = 8),
             patch(
                 "utils.hardware.nvidia.resolve_gpu_uuid_mask", return_value = [2, 5]
@@ -110,9 +119,30 @@ class TestResolveRequestedGpuIds(_GpuCacheResetMixin, unittest.TestCase):
         # ROCm has no nvidia-smi; a non-numeric mask there must stay unresolved
         # rather than attempt an nvidia-only resolution path.
         with (
-            patch.dict(os.environ, {"CUDA_VISIBLE_DEVICES": "GPU-aaa,GPU-bbb"}, clear = True),
+            patch.dict(
+                os.environ,
+                {"CUDA_VISIBLE_DEVICES": "GPU-aaa,GPU-bbb", "CUDA_DEVICE_ORDER": "PCI_BUS_ID"},
+                clear = True,
+            ),
             patch("utils.hardware.hardware.get_physical_gpu_count", return_value = 8),
             patch("utils.hardware.hardware.IS_ROCM", True),
+            patch("utils.hardware.nvidia.resolve_gpu_uuid_mask") as mock_resolve,
+        ):
+            self.assertEqual(get_parent_visible_gpu_ids(), [])
+            mock_resolve.assert_not_called()
+
+    def test_parent_visibility_does_not_resolve_uuid_masks_off_pci_bus_id_order(self):
+        # nvidia-smi always numbers by PCI bus id; trusting its indices while
+        # CUDA_DEVICE_ORDER=FASTEST_FIRST is in effect could select the wrong
+        # physical GPU once those indices are written back to
+        # CUDA_VISIBLE_DEVICES for a worker (see the P1 review on #8917).
+        with (
+            patch.dict(
+                os.environ,
+                {"CUDA_VISIBLE_DEVICES": "GPU-aaa,GPU-bbb", "CUDA_DEVICE_ORDER": "FASTEST_FIRST"},
+                clear = True,
+            ),
+            patch("utils.hardware.hardware.get_physical_gpu_count", return_value = 8),
             patch("utils.hardware.nvidia.resolve_gpu_uuid_mask") as mock_resolve,
         ):
             self.assertEqual(get_parent_visible_gpu_ids(), [])
@@ -190,7 +220,7 @@ class TestResolveRequestedGpuIds(_GpuCacheResetMixin, unittest.TestCase):
             self.assertEqual(os.environ["TEST_PARENT_ENV"], "keep-me")
 
 
-class TestResolveGpuUuidMask(unittest.TestCase):
+class TestResolveGpuUuidMask(_GpuCacheResetMixin, unittest.TestCase):
     def test_resolves_and_preserves_mask_order(self):
         smi_output = "\n".join(
             [
@@ -230,6 +260,52 @@ class TestResolveGpuUuidMask(unittest.TestCase):
         with patch("utils.hardware.nvidia.subprocess.run", side_effect = FileNotFoundError()):
             result = nvidia.resolve_gpu_uuid_mask(["GPU-d18a14b7-70a4-61bd-56f1-371055dfbb50"])
         self.assertIsNone(result)
+
+    def test_resolves_an_unambiguous_uuid_prefix(self):
+        smi_output = "\n".join(
+            [
+                "0, GPU-d18a14b7-70a4-61bd-56f1-371055dfbb50",
+                "1, GPU-2f902962-578c-0f96-69a5-3e18679211d7",
+            ]
+        )
+        with patch("utils.hardware.nvidia.subprocess.run") as mock_run:
+            mock_run.return_value = SimpleNamespace(returncode = 0, stdout = smi_output)
+            result = nvidia.resolve_gpu_uuid_mask(["GPU-d18a14b7"])
+        self.assertEqual(result, [0])
+
+    def test_rejects_a_uuid_prefix_shared_by_two_devices(self):
+        smi_output = "\n".join(
+            [
+                "0, GPU-d18a14b7-70a4-61bd-56f1-371055dfbb50",
+                "1, GPU-d18a14b7-aaaa-bbbb-cccc-000000000000",
+            ]
+        )
+        with patch("utils.hardware.nvidia.subprocess.run") as mock_run:
+            mock_run.return_value = SimpleNamespace(returncode = 0, stdout = smi_output)
+            # Both devices share this prefix -- neither is a safe match.
+            result = nvidia.resolve_gpu_uuid_mask(["GPU-d18a14b7"])
+        self.assertIsNone(result)
+
+    def test_caches_a_resolved_mask_and_does_not_requery(self):
+        smi_output = "0, GPU-d18a14b7-70a4-61bd-56f1-371055dfbb50"
+        tokens = ["GPU-d18a14b7-70a4-61bd-56f1-371055dfbb50"]
+        with patch("utils.hardware.nvidia.subprocess.run") as mock_run:
+            mock_run.return_value = SimpleNamespace(returncode = 0, stdout = smi_output)
+            first = nvidia.resolve_gpu_uuid_mask(tokens)
+            second = nvidia.resolve_gpu_uuid_mask(tokens)
+        self.assertEqual(first, [0])
+        self.assertEqual(second, [0])
+        mock_run.assert_called_once()
+
+    def test_caches_a_failed_resolution_and_does_not_requery(self):
+        tokens = ["GPU-d18a14b7-70a4-61bd-56f1-371055dfbb50"]
+        with patch("utils.hardware.nvidia.subprocess.run") as mock_run:
+            mock_run.return_value = SimpleNamespace(returncode = 1, stdout = "")
+            first = nvidia.resolve_gpu_uuid_mask(tokens)
+            second = nvidia.resolve_gpu_uuid_mask(tokens)
+        self.assertIsNone(first)
+        self.assertIsNone(second)
+        mock_run.assert_called_once()
 
 
 class TestVisibleGpuUtilization(_GpuCacheResetMixin, unittest.TestCase):
@@ -446,7 +522,11 @@ class TestVisibleGpuUtilization(_GpuCacheResetMixin, unittest.TestCase):
             },
         ]
         with (
-            patch.dict(os.environ, {"CUDA_VISIBLE_DEVICES": "GPU-aaa,GPU-bbb"}, clear = True),
+            patch.dict(
+                os.environ,
+                {"CUDA_VISIBLE_DEVICES": "GPU-aaa,GPU-bbb", "CUDA_DEVICE_ORDER": "PCI_BUS_ID"},
+                clear = True,
+            ),
             patch("utils.hardware.hardware.get_device", return_value = DeviceType.CUDA),
             patch("utils.hardware.hardware._torch_get_physical_gpu_count", return_value = 2),
             patch(
@@ -472,7 +552,11 @@ class TestVisibleGpuUtilization(_GpuCacheResetMixin, unittest.TestCase):
             ]
         )
         with (
-            patch.dict(os.environ, {"CUDA_VISIBLE_DEVICES": "GPU-aaa,GPU-bbb"}, clear = True),
+            patch.dict(
+                os.environ,
+                {"CUDA_VISIBLE_DEVICES": "GPU-aaa,GPU-bbb", "CUDA_DEVICE_ORDER": "PCI_BUS_ID"},
+                clear = True,
+            ),
             patch("utils.hardware.hardware.get_device", return_value = DeviceType.CUDA),
             patch("utils.hardware.nvidia.resolve_gpu_uuid_mask", return_value = [0, 1]),
             patch("utils.hardware.nvidia.subprocess.run") as mock_run,

--- a/studio/backend/tests/test_gpu_selection.py
+++ b/studio/backend/tests/test_gpu_selection.py
@@ -32,6 +32,7 @@ from utils.hardware import (
     prepare_gpu_selection,
     resolve_requested_gpu_ids,
 )
+from utils.hardware import nvidia
 import utils.hardware.hardware as _hw_module
 
 _BACKEND_ROOT = Path(__file__).resolve().parent.parent
@@ -84,12 +85,38 @@ class TestResolveRequestedGpuIds(_GpuCacheResetMixin, unittest.TestCase):
             self.assertEqual(get_parent_visible_gpu_ids(), [1, 3])
             self.assertEqual(resolve_requested_gpu_ids(None), [1, 3])
 
-    def test_parent_visibility_uses_empty_numeric_ids_for_uuid_masks(self):
+    def test_parent_visibility_uses_empty_numeric_ids_for_uuid_masks_nvidia_smi_cannot_resolve(
+        self,
+    ):
         with (
             patch.dict(os.environ, {"CUDA_VISIBLE_DEVICES": "GPU-aaa,GPU-bbb"}, clear = True),
             patch("utils.hardware.hardware.get_physical_gpu_count", return_value = 8),
+            patch("utils.hardware.nvidia.resolve_gpu_uuid_mask", return_value = None),
         ):
             self.assertEqual(get_parent_visible_gpu_ids(), [])
+
+    def test_parent_visibility_resolves_uuid_masks_via_nvidia_smi(self):
+        with (
+            patch.dict(os.environ, {"CUDA_VISIBLE_DEVICES": "GPU-aaa,GPU-bbb"}, clear = True),
+            patch("utils.hardware.hardware.get_physical_gpu_count", return_value = 8),
+            patch(
+                "utils.hardware.nvidia.resolve_gpu_uuid_mask", return_value = [2, 5]
+            ) as mock_resolve,
+        ):
+            self.assertEqual(get_parent_visible_gpu_ids(), [2, 5])
+            mock_resolve.assert_called_once_with(["GPU-aaa", "GPU-bbb"])
+
+    def test_parent_visibility_does_not_resolve_uuid_masks_on_rocm(self):
+        # ROCm has no nvidia-smi; a non-numeric mask there must stay unresolved
+        # rather than attempt an nvidia-only resolution path.
+        with (
+            patch.dict(os.environ, {"CUDA_VISIBLE_DEVICES": "GPU-aaa,GPU-bbb"}, clear = True),
+            patch("utils.hardware.hardware.get_physical_gpu_count", return_value = 8),
+            patch("utils.hardware.hardware.IS_ROCM", True),
+            patch("utils.hardware.nvidia.resolve_gpu_uuid_mask") as mock_resolve,
+        ):
+            self.assertEqual(get_parent_visible_gpu_ids(), [])
+            mock_resolve.assert_not_called()
 
     def test_invalid_requests_raise_clear_value_errors(self):
         cases = [
@@ -161,6 +188,48 @@ class TestResolveRequestedGpuIds(_GpuCacheResetMixin, unittest.TestCase):
 
             self.assertEqual(os.environ["CUDA_VISIBLE_DEVICES"], "5,6")
             self.assertEqual(os.environ["TEST_PARENT_ENV"], "keep-me")
+
+
+class TestResolveGpuUuidMask(unittest.TestCase):
+    def test_resolves_and_preserves_mask_order(self):
+        smi_output = "\n".join(
+            [
+                "0, GPU-d18a14b7-70a4-61bd-56f1-371055dfbb50",
+                "1, GPU-2f902962-578c-0f96-69a5-3e18679211d7",
+            ]
+        )
+        with patch("utils.hardware.nvidia.subprocess.run") as mock_run:
+            mock_run.return_value = SimpleNamespace(returncode = 0, stdout = smi_output)
+            # Mask order is reversed relative to nvidia-smi's index order --
+            # the resolved list must follow the mask, not the smi listing.
+            result = nvidia.resolve_gpu_uuid_mask(
+                [
+                    "GPU-2f902962-578c-0f96-69a5-3e18679211d7",
+                    "GPU-d18a14b7-70a4-61bd-56f1-371055dfbb50",
+                ]
+            )
+        self.assertEqual(result, [1, 0])
+
+    def test_returns_none_when_a_token_does_not_match_any_device(self):
+        smi_output = "0, GPU-d18a14b7-70a4-61bd-56f1-371055dfbb50"
+        with patch("utils.hardware.nvidia.subprocess.run") as mock_run:
+            mock_run.return_value = SimpleNamespace(returncode = 0, stdout = smi_output)
+            # e.g. a MIG instance UUID nvidia-smi's index/uuid query never lists.
+            result = nvidia.resolve_gpu_uuid_mask(
+                ["GPU-d18a14b7-70a4-61bd-56f1-371055dfbb50", "MIG-not-a-root-gpu"]
+            )
+        self.assertIsNone(result)
+
+    def test_returns_none_when_nvidia_smi_fails(self):
+        with patch("utils.hardware.nvidia.subprocess.run") as mock_run:
+            mock_run.return_value = SimpleNamespace(returncode = 1, stdout = "")
+            result = nvidia.resolve_gpu_uuid_mask(["GPU-d18a14b7-70a4-61bd-56f1-371055dfbb50"])
+        self.assertIsNone(result)
+
+    def test_returns_none_when_nvidia_smi_is_missing(self):
+        with patch("utils.hardware.nvidia.subprocess.run", side_effect = FileNotFoundError()):
+            result = nvidia.resolve_gpu_uuid_mask(["GPU-d18a14b7-70a4-61bd-56f1-371055dfbb50"])
+        self.assertIsNone(result)
 
 
 class TestVisibleGpuUtilization(_GpuCacheResetMixin, unittest.TestCase):
@@ -384,6 +453,7 @@ class TestVisibleGpuUtilization(_GpuCacheResetMixin, unittest.TestCase):
                 "utils.hardware.hardware._torch_get_device_inventory",
                 return_value = fake_torch_devices,
             ),
+            patch("utils.hardware.nvidia.resolve_gpu_uuid_mask", return_value = None),
         ):
             result = get_backend_visible_gpu_info()
 
@@ -391,6 +461,29 @@ class TestVisibleGpuUtilization(_GpuCacheResetMixin, unittest.TestCase):
         self.assertEqual(result["parent_visible_gpu_ids"], [])
         self.assertEqual(len(result["devices"]), 2)
         self.assertEqual(result["index_kind"], "relative")
+
+    def test_uuid_parent_visibility_resolves_to_physical_indices(self):
+        """A UUID mask nvidia-smi can resolve (issue #8873) must surface
+        physical indices, not fall back to relative torch ordinals."""
+        smi_output = "\n".join(
+            [
+                "0, GPU Zero, 10000",
+                "1, GPU One, 20000",
+            ]
+        )
+        with (
+            patch.dict(os.environ, {"CUDA_VISIBLE_DEVICES": "GPU-aaa,GPU-bbb"}, clear = True),
+            patch("utils.hardware.hardware.get_device", return_value = DeviceType.CUDA),
+            patch("utils.hardware.nvidia.resolve_gpu_uuid_mask", return_value = [0, 1]),
+            patch("utils.hardware.nvidia.subprocess.run") as mock_run,
+        ):
+            mock_run.return_value = SimpleNamespace(returncode = 0, stdout = smi_output)
+            result = get_backend_visible_gpu_info()
+
+        self.assertTrue(result["available"])
+        self.assertEqual(result["parent_visible_gpu_ids"], [0, 1])
+        self.assertEqual(result["index_kind"], "physical")
+        self.assertEqual([device["index"] for device in result["devices"]], [0, 1])
 
     def test_mlx_visible_gpu_info_is_best_effort_relative(self):
         with (

--- a/studio/backend/tests/test_gpu_selection.py
+++ b/studio/backend/tests/test_gpu_selection.py
@@ -221,18 +221,22 @@ class TestResolveRequestedGpuIds(_GpuCacheResetMixin, unittest.TestCase):
 
 
 class TestResolveGpuUuidMask(_GpuCacheResetMixin, unittest.TestCase):
-    # Real values from issue #8873's own nvidia-smi output: PCI order and
-    # nvidia-smi's index happen to agree there, so other tests deliberately
-    # use bus ids where they DON'T, to prove the ordinal comes from sorting
-    # pci.bus_id rather than from trusting nvidia-smi's own index column.
+    # Real UUIDs from issue #8873's own nvidia-smi output. Every fixture here
+    # keeps index == its position when rows are sorted by pci.bus_id --
+    # get_visible_gpu_utilization() and get_backend_visible_gpu_info() key
+    # their own nvidia-smi rows by index, so resolve_gpu_uuid_mask() only
+    # ever hands back nvidia-smi's own index (verified consistent with PCI
+    # order), never an independently-computed ordinal that could disagree
+    # with those other probes. The one exception is the dedicated
+    # index-mismatch test below.
     _UUID_A = "GPU-d18a14b7-70a4-61bd-56f1-371055dfbb50"
     _UUID_B = "GPU-2f902962-578c-0f96-69a5-3e18679211d7"
 
     def test_resolves_and_preserves_mask_order(self):
         smi_output = "\n".join(
             [
-                f"{self._UUID_A}, 00000000:01:00.0, Disabled",
-                f"{self._UUID_B}, 00000000:04:00.0, Disabled",
+                f"0, {self._UUID_A}, 00000000:01:00.0, Disabled",
+                f"1, {self._UUID_B}, 00000000:04:00.0, Disabled",
             ]
         )
         with patch("utils.hardware.nvidia.subprocess.run") as mock_run:
@@ -242,23 +246,28 @@ class TestResolveGpuUuidMask(_GpuCacheResetMixin, unittest.TestCase):
             result = nvidia.resolve_gpu_uuid_mask([self._UUID_B, self._UUID_A])
         self.assertEqual(result, [1, 0])
 
-    def test_derives_order_from_pci_bus_id_not_nvidia_smi_index(self):
-        # nvidia-smi's own row order (and a hypothetical index column) lists
-        # UUID_A first, but its PCI bus id sorts *after* UUID_B's -- the
-        # resolved ordinal must follow pci.bus_id, not listing/index order.
+    def test_fails_closed_when_nvidia_smi_index_does_not_match_pci_bus_order(self):
+        # UUID_A's PCI bus id sorts *after* UUID_B's, but nvidia-smi reports
+        # UUID_A at index 0 and UUID_B at index 1 -- an index that disagrees
+        # with PCI order. get_visible_gpu_utilization() and
+        # get_backend_visible_gpu_info() are both keyed by nvidia-smi's index
+        # elsewhere in this file, so a resolved index that doesn't match PCI
+        # order can't be trusted to line up with them; this must decline to
+        # resolve rather than guess which ordering the rest of the codebase
+        # will actually use for this host.
         smi_output = "\n".join(
             [
-                f"{self._UUID_A}, 00000000:09:00.0, Disabled",
-                f"{self._UUID_B}, 00000000:02:00.0, Disabled",
+                f"0, {self._UUID_A}, 00000000:09:00.0, Disabled",
+                f"1, {self._UUID_B}, 00000000:02:00.0, Disabled",
             ]
         )
         with patch("utils.hardware.nvidia.subprocess.run") as mock_run:
             mock_run.return_value = SimpleNamespace(returncode = 0, stdout = smi_output)
             result = nvidia.resolve_gpu_uuid_mask([self._UUID_A, self._UUID_B])
-        self.assertEqual(result, [1, 0])
+        self.assertIsNone(result)
 
     def test_returns_none_when_a_token_does_not_match_any_device(self):
-        smi_output = f"{self._UUID_A}, 00000000:01:00.0, Disabled"
+        smi_output = f"0, {self._UUID_A}, 00000000:01:00.0, Disabled"
         with patch("utils.hardware.nvidia.subprocess.run") as mock_run:
             mock_run.return_value = SimpleNamespace(returncode = 0, stdout = smi_output)
             # e.g. a MIG instance UUID nvidia-smi's uuid/pci.bus_id query never lists.
@@ -279,8 +288,8 @@ class TestResolveGpuUuidMask(_GpuCacheResetMixin, unittest.TestCase):
     def test_resolves_an_unambiguous_uuid_prefix(self):
         smi_output = "\n".join(
             [
-                f"{self._UUID_A}, 00000000:01:00.0, Disabled",
-                f"{self._UUID_B}, 00000000:04:00.0, Disabled",
+                f"0, {self._UUID_A}, 00000000:01:00.0, Disabled",
+                f"1, {self._UUID_B}, 00000000:04:00.0, Disabled",
             ]
         )
         with patch("utils.hardware.nvidia.subprocess.run") as mock_run:
@@ -291,8 +300,8 @@ class TestResolveGpuUuidMask(_GpuCacheResetMixin, unittest.TestCase):
     def test_rejects_a_uuid_prefix_shared_by_two_devices(self):
         smi_output = "\n".join(
             [
-                f"{self._UUID_A}, 00000000:01:00.0, Disabled",
-                "GPU-d18a14b7-aaaa-bbbb-cccc-000000000000, 00000000:04:00.0, Disabled",
+                f"0, {self._UUID_A}, 00000000:01:00.0, Disabled",
+                "1, GPU-d18a14b7-aaaa-bbbb-cccc-000000000000, 00000000:04:00.0, Disabled",
             ]
         )
         with patch("utils.hardware.nvidia.subprocess.run") as mock_run:
@@ -305,7 +314,7 @@ class TestResolveGpuUuidMask(_GpuCacheResetMixin, unittest.TestCase):
         # A single-GPU host where a bare "GPU" (no trailing "-") happens to
         # string-prefix the one UUID present must not resolve it -- "GPU" is
         # not a valid CUDA UUID identifier and this token was never meant as one.
-        smi_output = f"{self._UUID_A}, 00000000:01:00.0, Disabled"
+        smi_output = f"0, {self._UUID_A}, 00000000:01:00.0, Disabled"
         with patch("utils.hardware.nvidia.subprocess.run") as mock_run:
             mock_run.return_value = SimpleNamespace(returncode = 0, stdout = smi_output)
             self.assertIsNone(nvidia.resolve_gpu_uuid_mask(["GPU"]))
@@ -314,8 +323,8 @@ class TestResolveGpuUuidMask(_GpuCacheResetMixin, unittest.TestCase):
     def test_leaves_mig_enabled_root_uuid_unresolved(self):
         smi_output = "\n".join(
             [
-                f"{self._UUID_A}, 00000000:01:00.0, Enabled",
-                f"{self._UUID_B}, 00000000:04:00.0, Disabled",
+                f"0, {self._UUID_A}, 00000000:01:00.0, Enabled",
+                f"1, {self._UUID_B}, 00000000:04:00.0, Disabled",
             ]
         )
         with patch("utils.hardware.nvidia.subprocess.run") as mock_run:
@@ -327,7 +336,7 @@ class TestResolveGpuUuidMask(_GpuCacheResetMixin, unittest.TestCase):
             self.assertEqual(nvidia.resolve_gpu_uuid_mask([self._UUID_B]), [1])
 
     def test_resolves_a_mixed_numeric_and_uuid_mask(self):
-        smi_output = f"{self._UUID_A}, 00000000:04:00.0, Disabled"
+        smi_output = f"0, {self._UUID_A}, 00000000:04:00.0, Disabled"
         with patch("utils.hardware.nvidia.subprocess.run") as mock_run:
             mock_run.return_value = SimpleNamespace(returncode = 0, stdout = smi_output)
             # "0" passes through as-is (same trust level as the pure-numeric
@@ -336,7 +345,7 @@ class TestResolveGpuUuidMask(_GpuCacheResetMixin, unittest.TestCase):
         self.assertEqual(result, [0, 0])
 
     def test_caches_a_resolved_mask_and_does_not_requery(self):
-        smi_output = f"{self._UUID_A}, 00000000:01:00.0, Disabled"
+        smi_output = f"0, {self._UUID_A}, 00000000:01:00.0, Disabled"
         tokens = [self._UUID_A]
         with patch("utils.hardware.nvidia.subprocess.run") as mock_run:
             mock_run.return_value = SimpleNamespace(returncode = 0, stdout = smi_output)
@@ -358,7 +367,7 @@ class TestResolveGpuUuidMask(_GpuCacheResetMixin, unittest.TestCase):
 
     def test_retries_a_failed_resolution_once_the_ttl_expires(self):
         tokens = [self._UUID_A]
-        smi_output = f"{self._UUID_A}, 00000000:01:00.0, Disabled"
+        smi_output = f"0, {self._UUID_A}, 00000000:01:00.0, Disabled"
         with patch("utils.hardware.nvidia.subprocess.run") as mock_run:
             mock_run.return_value = SimpleNamespace(returncode = 1, stdout = "")
             first = nvidia.resolve_gpu_uuid_mask(tokens)

--- a/studio/backend/tests/test_gpu_selection.py
+++ b/studio/backend/tests/test_gpu_selection.py
@@ -335,6 +335,24 @@ class TestResolveGpuUuidMask(_GpuCacheResetMixin, unittest.TestCase):
             # UUID_B is unaffected and still resolves on its own.
             self.assertEqual(nvidia.resolve_gpu_uuid_mask([self._UUID_B]), [1])
 
+    def test_prefix_ambiguous_with_a_mig_enabled_root_stays_unresolved(self):
+        # A normal GPU and a MIG-enabled root share the "GPU-d18a14b7" prefix.
+        # Excluding the MIG root before checking ambiguity would make this
+        # prefix look like it has exactly one candidate (the normal GPU) and
+        # resolve it -- it must instead be treated as ambiguous, the same as
+        # any prefix shared by two non-MIG cards.
+        mig_uuid = "GPU-d18a14b7-aaaa-bbbb-cccc-000000000000"
+        smi_output = "\n".join(
+            [
+                f"0, {self._UUID_A}, 00000000:01:00.0, Disabled",
+                f"1, {mig_uuid}, 00000000:04:00.0, Enabled",
+            ]
+        )
+        with patch("utils.hardware.nvidia.subprocess.run") as mock_run:
+            mock_run.return_value = SimpleNamespace(returncode = 0, stdout = smi_output)
+            result = nvidia.resolve_gpu_uuid_mask(["GPU-d18a14b7"])
+        self.assertIsNone(result)
+
     def test_resolves_a_mixed_numeric_and_uuid_mask(self):
         smi_output = "\n".join(
             [

--- a/studio/backend/tests/test_gpu_selection.py
+++ b/studio/backend/tests/test_gpu_selection.py
@@ -410,6 +410,22 @@ class TestResolveGpuUuidMask(_GpuCacheResetMixin, unittest.TestCase):
             result = nvidia.resolve_gpu_uuid_mask(["5", self._UUID_A])
         self.assertIsNone(result)
 
+    def test_rejects_a_numeric_token_that_names_a_mig_enabled_root(self):
+        # "0" numerically names the same MIG-enabled root that UUID
+        # resolution would already reject -- a mixed mask must not be able
+        # to route around that protection just by spelling the index instead
+        # of the UUID.
+        smi_output = "\n".join(
+            [
+                f"0, {self._UUID_A}, 00000000:01:00.0, Enabled",
+                f"1, {self._UUID_B}, 00000000:04:00.0, Disabled",
+            ]
+        )
+        with patch("utils.hardware.nvidia.subprocess.run") as mock_run:
+            mock_run.return_value = SimpleNamespace(returncode = 0, stdout = smi_output)
+            result = nvidia.resolve_gpu_uuid_mask(["0", self._UUID_B])
+        self.assertIsNone(result)
+
     def test_caches_a_resolved_mask_and_does_not_requery(self):
         smi_output = f"0, {self._UUID_A}, 00000000:01:00.0, Disabled"
         tokens = [self._UUID_A]

--- a/studio/backend/tests/test_gpu_selection.py
+++ b/studio/backend/tests/test_gpu_selection.py
@@ -426,6 +426,21 @@ class TestResolveGpuUuidMask(_GpuCacheResetMixin, unittest.TestCase):
             result = nvidia.resolve_gpu_uuid_mask(["0", self._UUID_B])
         self.assertIsNone(result)
 
+    def test_rejects_a_python_only_integer_spelling(self):
+        # int("0_0") == 0 in Python (PEP 515 digit-group underscores), but
+        # that's not a decimal GPU identifier CUDA's own parser would accept
+        # -- it must fail closed rather than be silently normalized to "0".
+        smi_output = "\n".join(
+            [
+                f"0, {self._UUID_B}, 00000000:01:00.0, Disabled",
+                f"1, {self._UUID_A}, 00000000:04:00.0, Disabled",
+            ]
+        )
+        with patch("utils.hardware.nvidia.subprocess.run") as mock_run:
+            mock_run.return_value = SimpleNamespace(returncode = 0, stdout = smi_output)
+            result = nvidia.resolve_gpu_uuid_mask(["0_0", self._UUID_A])
+        self.assertIsNone(result)
+
     def test_caches_a_resolved_mask_and_does_not_requery(self):
         smi_output = f"0, {self._UUID_A}, 00000000:01:00.0, Disabled"
         tokens = [self._UUID_A]

--- a/studio/backend/tests/test_gpu_selection.py
+++ b/studio/backend/tests/test_gpu_selection.py
@@ -336,13 +336,30 @@ class TestResolveGpuUuidMask(_GpuCacheResetMixin, unittest.TestCase):
             self.assertEqual(nvidia.resolve_gpu_uuid_mask([self._UUID_B]), [1])
 
     def test_resolves_a_mixed_numeric_and_uuid_mask(self):
-        smi_output = f"0, {self._UUID_A}, 00000000:04:00.0, Disabled"
+        smi_output = "\n".join(
+            [
+                f"0, {self._UUID_B}, 00000000:01:00.0, Disabled",
+                f"1, {self._UUID_A}, 00000000:04:00.0, Disabled",
+            ]
+        )
         with patch("utils.hardware.nvidia.subprocess.run") as mock_run:
             mock_run.return_value = SimpleNamespace(returncode = 0, stdout = smi_output)
             # "0" passes through as-is (same trust level as the pure-numeric
-            # fast path); only the UUID token goes through nvidia-smi.
+            # fast path); only the UUID token goes through nvidia-smi. Distinct
+            # physical IDs here on purpose -- see the duplicate-rejection test
+            # below for what happens when they alias the same card.
             result = nvidia.resolve_gpu_uuid_mask(["0", self._UUID_A])
-        self.assertEqual(result, [0, 0])
+        self.assertEqual(result, [0, 1])
+
+    def test_rejects_a_mask_that_resolves_to_duplicate_physical_ids(self):
+        # "0" and UUID_A both name physical GPU 0 -- _visible_ordinal_map()
+        # is keyed by physical ID, so a duplicate would silently collapse one
+        # of the mask's two distinct visible ordinals onto the other.
+        smi_output = f"0, {self._UUID_A}, 00000000:01:00.0, Disabled"
+        with patch("utils.hardware.nvidia.subprocess.run") as mock_run:
+            mock_run.return_value = SimpleNamespace(returncode = 0, stdout = smi_output)
+            result = nvidia.resolve_gpu_uuid_mask(["0", self._UUID_A])
+        self.assertIsNone(result)
 
     def test_caches_a_resolved_mask_and_does_not_requery(self):
         smi_output = f"0, {self._UUID_A}, 00000000:01:00.0, Disabled"
@@ -353,6 +370,36 @@ class TestResolveGpuUuidMask(_GpuCacheResetMixin, unittest.TestCase):
             second = nvidia.resolve_gpu_uuid_mask(tokens)
         self.assertEqual(first, [0])
         self.assertEqual(second, [0])
+        mock_run.assert_called_once()
+
+    def test_revalidates_a_resolved_mask_once_its_ttl_expires(self):
+        # GPU topology/MIG mode isn't provably immutable for a whole Studio
+        # session (an admin can enable MIG on a running host) -- a resolution
+        # from before that change must eventually be revalidated rather than
+        # kept forever.
+        tokens = [self._UUID_A]
+        smi_output = f"0, {self._UUID_A}, 00000000:01:00.0, Disabled"
+        with patch("utils.hardware.nvidia.subprocess.run") as mock_run:
+            mock_run.return_value = SimpleNamespace(returncode = 0, stdout = smi_output)
+            first = nvidia.resolve_gpu_uuid_mask(tokens)
+        self.assertEqual(first, [0])
+
+        # Simulate the TTL elapsing without a real sleep: back-date the
+        # cached success's timestamp past the expiry window.
+        cache_key = tuple(tokens)
+        _value, cached_at = nvidia._uuid_mask_resolution_cache[cache_key]
+        nvidia._uuid_mask_resolution_cache[cache_key] = (
+            _value,
+            cached_at - nvidia._RESOLVED_MASK_TTL_SECONDS - 1,
+        )
+
+        # UUID_A is now MIG-enabled -- the revalidated resolution must reflect
+        # that instead of trusting the stale cached success.
+        mig_smi_output = f"0, {self._UUID_A}, 00000000:01:00.0, Enabled"
+        with patch("utils.hardware.nvidia.subprocess.run") as mock_run:
+            mock_run.return_value = SimpleNamespace(returncode = 0, stdout = mig_smi_output)
+            second = nvidia.resolve_gpu_uuid_mask(tokens)
+        self.assertIsNone(second)
         mock_run.assert_called_once()
 
     def test_caches_a_failed_resolution_within_the_ttl_and_does_not_requery(self):

--- a/studio/backend/tests/test_gpu_selection.py
+++ b/studio/backend/tests/test_gpu_selection.py
@@ -362,10 +362,12 @@ class TestResolveGpuUuidMask(_GpuCacheResetMixin, unittest.TestCase):
         )
         with patch("utils.hardware.nvidia.subprocess.run") as mock_run:
             mock_run.return_value = SimpleNamespace(returncode = 0, stdout = smi_output)
-            # "0" passes through as-is (same trust level as the pure-numeric
-            # fast path); only the UUID token goes through nvidia-smi. Distinct
-            # physical IDs here on purpose -- see the duplicate-rejection test
-            # below for what happens when they alias the same card.
+            # "0" is validated against the queried GPUs (a real, non-negative
+            # index -- see the invalid-numeric-member tests below for what
+            # happens when it isn't); only the UUID token goes through
+            # resolution proper. Distinct physical IDs here on purpose -- see
+            # the duplicate-rejection test below for what happens when they
+            # alias the same card.
             result = nvidia.resolve_gpu_uuid_mask(["0", self._UUID_A])
         self.assertEqual(result, [0, 1])
 
@@ -377,6 +379,35 @@ class TestResolveGpuUuidMask(_GpuCacheResetMixin, unittest.TestCase):
         with patch("utils.hardware.nvidia.subprocess.run") as mock_run:
             mock_run.return_value = SimpleNamespace(returncode = 0, stdout = smi_output)
             result = nvidia.resolve_gpu_uuid_mask(["0", self._UUID_A])
+        self.assertIsNone(result)
+
+    def test_rejects_a_mixed_mask_with_a_negative_numeric_member(self):
+        # Real CUDA_VISIBLE_DEVICES semantics: an invalid member (negative or
+        # out-of-range) truncates enumeration there, hiding everything listed
+        # after it. Rather than replicate that exact truncation point, this
+        # must fail the whole resolution -- falling back to relative ordinals
+        # (no explicit selection at all) rather than resolve a UUID that real
+        # CUDA parsing would never have exposed in the first place.
+        smi_output = "\n".join(
+            [
+                f"0, {self._UUID_B}, 00000000:01:00.0, Disabled",
+                f"1, {self._UUID_A}, 00000000:04:00.0, Disabled",
+            ]
+        )
+        with patch("utils.hardware.nvidia.subprocess.run") as mock_run:
+            mock_run.return_value = SimpleNamespace(returncode = 0, stdout = smi_output)
+            result = nvidia.resolve_gpu_uuid_mask(["0", "-1", self._UUID_A])
+        self.assertIsNone(result)
+
+    def test_rejects_a_mixed_mask_with_an_out_of_range_numeric_member(self):
+        # "5" doesn't correspond to any GPU nvidia-smi actually reported --
+        # blindly trusting it (as opposed to the pure-numeric fast path,
+        # which never queries nvidia-smi at all to cross-check) would let a
+        # typo'd or stale index slip through resolution as if it were real.
+        smi_output = f"0, {self._UUID_A}, 00000000:01:00.0, Disabled"
+        with patch("utils.hardware.nvidia.subprocess.run") as mock_run:
+            mock_run.return_value = SimpleNamespace(returncode = 0, stdout = smi_output)
+            result = nvidia.resolve_gpu_uuid_mask(["5", self._UUID_A])
         self.assertIsNone(result)
 
     def test_caches_a_resolved_mask_and_does_not_requery(self):

--- a/studio/backend/utils/hardware/hardware.py
+++ b/studio/backend/utils/hardware/hardware.py
@@ -2721,6 +2721,20 @@ def _get_parent_visible_gpu_spec() -> Dict[str, Any]:
     try:
         numeric_ids = [int(value) for value in tokens]
     except ValueError:
+        # A UUID mask ("GPU-<uuid>", ...) is a legitimate, common NVIDIA config
+        # (stable across PCIe reordering). ROCm doesn't have nvidia-smi, so only
+        # CUDA hosts get a resolution attempt; anything nvidia-smi can't match
+        # (MIG instance UUIDs, nvidia-smi missing) keeps the prior unresolved
+        # behaviour so relative ordinals are used instead.
+        if not _is_rocm_spec:
+            from . import nvidia
+            resolved_ids = nvidia.resolve_gpu_uuid_mask(tokens)
+            if resolved_ids is not None:
+                return {
+                    "raw": cuda_visible,
+                    "numeric_ids": resolved_ids,
+                    "supports_explicit_gpu_ids": True,
+                }
         return {
             "raw": cuda_visible,
             "numeric_ids": None,

--- a/studio/backend/utils/hardware/hardware.py
+++ b/studio/backend/utils/hardware/hardware.py
@@ -2726,7 +2726,15 @@ def _get_parent_visible_gpu_spec() -> Dict[str, Any]:
         # CUDA hosts get a resolution attempt; anything nvidia-smi can't match
         # (MIG instance UUIDs, nvidia-smi missing) keeps the prior unresolved
         # behaviour so relative ordinals are used instead.
-        if not _is_rocm_spec:
+        #
+        # nvidia-smi always numbers by PCI bus id (see the "GPU index ordering"
+        # note above) regardless of CUDA_DEVICE_ORDER, so its indices are only
+        # safe to hand back as explicit-selectable physical IDs while the app's
+        # own PCI_BUS_ID pin is actually in effect. If something upstream opted
+        # back into FASTEST_FIRST, index N from nvidia-smi and index N under
+        # FASTEST_FIRST can be two different cards, so stay unresolved instead
+        # of risking a CUDA_VISIBLE_DEVICES write that selects the wrong GPU.
+        if not _is_rocm_spec and os.environ.get("CUDA_DEVICE_ORDER") == "PCI_BUS_ID":
             from . import nvidia
             resolved_ids = nvidia.resolve_gpu_uuid_mask(tokens)
             if resolved_ids is not None:

--- a/studio/backend/utils/hardware/nvidia.py
+++ b/studio/backend/utils/hardware/nvidia.py
@@ -48,12 +48,10 @@ def _visible_ordinal_map(parent_visible_ids: Optional[list[int]]) -> Optional[di
     return {gpu_id: ordinal for ordinal, gpu_id in enumerate(parent_visible_ids)}
 
 
-def resolve_gpu_uuid_mask(tokens: list[str]) -> Optional[list[int]]:
-    """Resolve a CUDA_VISIBLE_DEVICES UUID mask (e.g. ["GPU-<uuid>", ...]) to
-    physical indices via nvidia-smi. Order is preserved to match the mask, since
-    it defines the visible-ordinal mapping downstream. Returns None -- and the
-    caller falls back to relative ordinals -- if nvidia-smi is unavailable or
-    any token doesn't match a physical device (e.g. a MIG instance UUID)."""
+_uuid_mask_resolution_cache: dict[tuple[str, ...], Optional[list[int]]] = {}
+
+
+def _query_uuid_to_index() -> Optional[dict[str, int]]:
     try:
         result = subprocess.run(
             ["nvidia-smi", "--query-gpu=index,uuid", "--format=csv,noheader"],
@@ -81,13 +79,50 @@ def resolve_gpu_uuid_mask(tokens: list[str]) -> Optional[list[int]]:
         except (ValueError, TypeError):
             continue
         uuid_to_index[parts[1]] = idx
+    return uuid_to_index
+
+
+def _resolve_one(token: str, uuid_to_index: dict[str, int]) -> Optional[int]:
+    exact = uuid_to_index.get(token)
+    if exact is not None:
+        return exact
+    # NVIDIA accepts an unambiguous UUID prefix (e.g. "GPU-abcdef12") as a
+    # device identifier -- resolve one only if exactly one device matches it,
+    # since a prefix shared by more than one card can't be trusted either way.
+    prefix_matches = [idx for uuid, idx in uuid_to_index.items() if uuid.startswith(token)]
+    if len(prefix_matches) == 1:
+        return prefix_matches[0]
+    return None
+
+
+def resolve_gpu_uuid_mask(tokens: list[str]) -> Optional[list[int]]:
+    """Resolve a CUDA_VISIBLE_DEVICES UUID mask (e.g. ["GPU-<uuid>", ...]) to
+    physical indices via nvidia-smi. Order is preserved to match the mask, since
+    it defines the visible-ordinal mapping downstream. Returns None -- and the
+    caller falls back to relative ordinals -- if nvidia-smi is unavailable, or
+    any token doesn't match exactly one physical device (a MIG instance UUID,
+    or a UUID/prefix ambiguous across cards). Cached per token tuple: the mask
+    is only re-queried once per distinct CUDA_VISIBLE_DEVICES value a process
+    sees, not on every poll -- a hung or missing nvidia-smi would otherwise cost
+    its full timeout on every caller of _get_parent_visible_gpu_spec()."""
+    cache_key = tuple(tokens)
+    if cache_key in _uuid_mask_resolution_cache:
+        return _uuid_mask_resolution_cache[cache_key]
+
+    uuid_to_index = _query_uuid_to_index()
+    if uuid_to_index is None:
+        _uuid_mask_resolution_cache[cache_key] = None
+        return None
 
     resolved = []
     for token in tokens:
-        idx = uuid_to_index.get(token)
+        idx = _resolve_one(token, uuid_to_index)
         if idx is None:
+            _uuid_mask_resolution_cache[cache_key] = None
             return None
         resolved.append(idx)
+
+    _uuid_mask_resolution_cache[cache_key] = resolved
     return resolved
 
 

--- a/studio/backend/utils/hardware/nvidia.py
+++ b/studio/backend/utils/hardware/nvidia.py
@@ -2,6 +2,7 @@
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
 import subprocess
+import time
 from typing import Any, Optional
 
 from loggers import get_logger
@@ -48,13 +49,25 @@ def _visible_ordinal_map(parent_visible_ids: Optional[list[int]]) -> Optional[di
     return {gpu_id: ordinal for ordinal, gpu_id in enumerate(parent_visible_ids)}
 
 
-_uuid_mask_resolution_cache: dict[tuple[str, ...], Optional[list[int]]] = {}
+# Failures aren't cached forever: a hung/missing nvidia-smi at Studio startup
+# (driver still initializing, momentary system load) can recover mid-session,
+# and the picker shouldn't stay hidden until a restart on the strength of one
+# bad probe. Successes ARE cached forever -- GPU topology doesn't change
+# mid-process -- so only failure entries carry a timestamp to expire against.
+_FAILED_RESOLUTION_TTL_SECONDS = 30
+_uuid_mask_resolution_cache: dict[tuple[str, ...], tuple[Optional[list[int]], float]] = {}
+
+_GPU_UUID_PREFIX = "GPU-"
 
 
-def _query_uuid_to_index() -> Optional[dict[str, int]]:
+def _query_uuid_to_ordinal() -> Optional[dict[str, int]]:
     try:
         result = subprocess.run(
-            ["nvidia-smi", "--query-gpu=index,uuid", "--format=csv,noheader"],
+            [
+                "nvidia-smi",
+                "--query-gpu=uuid,pci.bus_id,mig.mode.current",
+                "--format=csv,noheader",
+            ],
             capture_output = True,
             text = True,
             encoding = "utf-8",
@@ -69,60 +82,96 @@ def _query_uuid_to_index() -> Optional[dict[str, int]]:
     if result.returncode != 0:
         return None
 
-    uuid_to_index: dict[str, int] = {}
+    rows = []
     for line in result.stdout.strip().splitlines():
         parts = [p.strip() for p in line.split(",")]
-        if len(parts) != 2:
+        if len(parts) != 3:
             continue
-        try:
-            idx = int(parts[0])
-        except (ValueError, TypeError):
+        rows.append(parts)
+
+    # nvidia-smi's own index column isn't guaranteed to match CUDA's PCI-bus
+    # enumeration: NVIDIA's docs note device enumeration ordering isn't
+    # guaranteed consistent and recommend deriving order from UUID or PCI bus
+    # ID instead. Sort by pci.bus_id ourselves -- its fixed-width
+    # "domain:bus:device.function" hex format sorts correctly as plain text --
+    # to compute the same ordinal CUDA_DEVICE_ORDER=PCI_BUS_ID would assign,
+    # rather than trusting nvidia-smi's index to already match it.
+    rows.sort(key = lambda row: row[1])
+
+    uuid_to_ordinal: dict[str, int] = {}
+    for ordinal, (uuid, _bus_id, mig_mode) in enumerate(rows):
+        # A MIG-enabled root GPU's UUID isn't a normal selectable compute
+        # device -- CUDA exposes its MIG instances instead of the whole card.
+        # Leave it out of the map so it fails resolution the same way an
+        # actual MIG instance UUID already does, rather than resolving to an
+        # index that silently selects a partitioned view of the card.
+        if mig_mode == "Enabled":
             continue
-        uuid_to_index[parts[1]] = idx
-    return uuid_to_index
+        uuid_to_ordinal[uuid] = ordinal
+    return uuid_to_ordinal
 
 
-def _resolve_one(token: str, uuid_to_index: dict[str, int]) -> Optional[int]:
-    exact = uuid_to_index.get(token)
+def _resolve_uuid_token(token: str, uuid_to_ordinal: dict[str, int]) -> Optional[int]:
+    exact = uuid_to_ordinal.get(token)
     if exact is not None:
         return exact
     # NVIDIA accepts an unambiguous UUID prefix (e.g. "GPU-abcdef12") as a
-    # device identifier -- resolve one only if exactly one device matches it,
-    # since a prefix shared by more than one card can't be trusted either way.
-    prefix_matches = [idx for uuid, idx in uuid_to_index.items() if uuid.startswith(token)]
+    # device identifier. Require the token to actually look like a GPU UUID
+    # before attempting a prefix match -- otherwise a malformed token like
+    # "G" or "GPU" (no trailing "-") could coincidentally prefix a real UUID
+    # on a single-GPU host and get treated as a valid, intentional selector.
+    if not (token.startswith(_GPU_UUID_PREFIX) and len(token) > len(_GPU_UUID_PREFIX)):
+        return None
+    # A prefix shared by more than one card can't be trusted either way.
+    prefix_matches = [
+        ordinal for uuid, ordinal in uuid_to_ordinal.items() if uuid.startswith(token)
+    ]
     if len(prefix_matches) == 1:
         return prefix_matches[0]
     return None
 
 
 def resolve_gpu_uuid_mask(tokens: list[str]) -> Optional[list[int]]:
-    """Resolve a CUDA_VISIBLE_DEVICES UUID mask (e.g. ["GPU-<uuid>", ...]) to
-    physical indices via nvidia-smi. Order is preserved to match the mask, since
-    it defines the visible-ordinal mapping downstream. Returns None -- and the
-    caller falls back to relative ordinals -- if nvidia-smi is unavailable, or
-    any token doesn't match exactly one physical device (a MIG instance UUID,
-    or a UUID/prefix ambiguous across cards). Cached per token tuple: the mask
-    is only re-queried once per distinct CUDA_VISIBLE_DEVICES value a process
-    sees, not on every poll -- a hung or missing nvidia-smi would otherwise cost
-    its full timeout on every caller of _get_parent_visible_gpu_spec()."""
+    """Resolve a CUDA_VISIBLE_DEVICES mask that mixes numeric indices and GPU
+    UUIDs (e.g. ["0", "GPU-<uuid>"]) to physical PCI-bus-order indices, so a
+    UUID mask is exactly as selectable as the equivalent numeric one. Numeric
+    tokens pass through as-is, matching the trust level of the plain-numeric
+    fast path in _get_parent_visible_gpu_spec(); UUID tokens are resolved via
+    nvidia-smi. Order is preserved to match the mask, since it defines the
+    visible-ordinal mapping downstream. Returns None -- and the caller falls
+    back to relative ordinals -- if nvidia-smi is unavailable, or any UUID
+    token doesn't match exactly one non-MIG physical device (an actual MIG
+    instance UUID, a MIG-enabled root's UUID, or a UUID/prefix ambiguous
+    across cards). Successes are cached per token tuple for the process
+    lifetime; failures are cached for _FAILED_RESOLUTION_TTL_SECONDS, since a
+    hung or missing nvidia-smi would otherwise cost its full timeout on every
+    caller of _get_parent_visible_gpu_spec() every poll cycle."""
     cache_key = tuple(tokens)
-    if cache_key in _uuid_mask_resolution_cache:
-        return _uuid_mask_resolution_cache[cache_key]
+    cached = _uuid_mask_resolution_cache.get(cache_key)
+    if cached is not None:
+        value, cached_at = cached
+        if value is not None or time.monotonic() - cached_at < _FAILED_RESOLUTION_TTL_SECONDS:
+            return value
 
-    uuid_to_index = _query_uuid_to_index()
-    if uuid_to_index is None:
-        _uuid_mask_resolution_cache[cache_key] = None
+    uuid_to_ordinal = _query_uuid_to_ordinal()
+    if uuid_to_ordinal is None:
+        _uuid_mask_resolution_cache[cache_key] = (None, time.monotonic())
         return None
 
     resolved = []
     for token in tokens:
-        idx = _resolve_one(token, uuid_to_index)
+        try:
+            resolved.append(int(token))
+            continue
+        except ValueError:
+            pass
+        idx = _resolve_uuid_token(token, uuid_to_ordinal)
         if idx is None:
-            _uuid_mask_resolution_cache[cache_key] = None
+            _uuid_mask_resolution_cache[cache_key] = (None, time.monotonic())
             return None
         resolved.append(idx)
 
-    _uuid_mask_resolution_cache[cache_key] = resolved
+    _uuid_mask_resolution_cache[cache_key] = (resolved, time.monotonic())
     return resolved
 
 

--- a/studio/backend/utils/hardware/nvidia.py
+++ b/studio/backend/utils/hardware/nvidia.py
@@ -48,6 +48,49 @@ def _visible_ordinal_map(parent_visible_ids: Optional[list[int]]) -> Optional[di
     return {gpu_id: ordinal for ordinal, gpu_id in enumerate(parent_visible_ids)}
 
 
+def resolve_gpu_uuid_mask(tokens: list[str]) -> Optional[list[int]]:
+    """Resolve a CUDA_VISIBLE_DEVICES UUID mask (e.g. ["GPU-<uuid>", ...]) to
+    physical indices via nvidia-smi. Order is preserved to match the mask, since
+    it defines the visible-ordinal mapping downstream. Returns None -- and the
+    caller falls back to relative ordinals -- if nvidia-smi is unavailable or
+    any token doesn't match a physical device (e.g. a MIG instance UUID)."""
+    try:
+        result = subprocess.run(
+            ["nvidia-smi", "--query-gpu=index,uuid", "--format=csv,noheader"],
+            capture_output = True,
+            text = True,
+            encoding = "utf-8",
+            errors = "replace",
+            timeout = 5,
+            env = child_env_without_native_path_secret(),
+            **_windows_hidden_subprocess_kwargs(),
+        )
+    except (OSError, subprocess.TimeoutExpired) as e:
+        logger.warning("nvidia-smi query failed while resolving a UUID mask: %s", e)
+        return None
+    if result.returncode != 0:
+        return None
+
+    uuid_to_index: dict[str, int] = {}
+    for line in result.stdout.strip().splitlines():
+        parts = [p.strip() for p in line.split(",")]
+        if len(parts) != 2:
+            continue
+        try:
+            idx = int(parts[0])
+        except (ValueError, TypeError):
+            continue
+        uuid_to_index[parts[1]] = idx
+
+    resolved = []
+    for token in tokens:
+        idx = uuid_to_index.get(token)
+        if idx is None:
+            return None
+        resolved.append(idx)
+    return resolved
+
+
 def get_physical_gpu_count() -> Optional[int]:
     """Return physical GPU count via nvidia-smi, or None on failure."""
     try:

--- a/studio/backend/utils/hardware/nvidia.py
+++ b/studio/backend/utils/hardware/nvidia.py
@@ -65,7 +65,7 @@ def _query_uuid_to_ordinal() -> Optional[dict[str, int]]:
         result = subprocess.run(
             [
                 "nvidia-smi",
-                "--query-gpu=uuid,pci.bus_id,mig.mode.current",
+                "--query-gpu=index,uuid,pci.bus_id,mig.mode.current",
                 "--format=csv,noheader",
             ],
             capture_output = True,
@@ -85,21 +85,45 @@ def _query_uuid_to_ordinal() -> Optional[dict[str, int]]:
     rows = []
     for line in result.stdout.strip().splitlines():
         parts = [p.strip() for p in line.split(",")]
-        if len(parts) != 3:
+        if len(parts) != 4:
             continue
-        rows.append(parts)
+        idx_str, uuid, bus_id, mig_mode = parts
+        try:
+            idx = int(idx_str)
+        except (ValueError, TypeError):
+            continue
+        rows.append((idx, uuid, bus_id, mig_mode))
 
-    # nvidia-smi's own index column isn't guaranteed to match CUDA's PCI-bus
-    # enumeration: NVIDIA's docs note device enumeration ordering isn't
-    # guaranteed consistent and recommend deriving order from UUID or PCI bus
-    # ID instead. Sort by pci.bus_id ourselves -- its fixed-width
-    # "domain:bus:device.function" hex format sorts correctly as plain text --
-    # to compute the same ordinal CUDA_DEVICE_ORDER=PCI_BUS_ID would assign,
-    # rather than trusting nvidia-smi's index to already match it.
-    rows.sort(key = lambda row: row[1])
+    # get_visible_gpu_utilization() and get_backend_visible_gpu_info() below,
+    # and the "GPU index ordering" pin in hardware.py, all assume nvidia-smi's
+    # own index column already matches PCI bus order -- that's the load-bearing
+    # invariant this whole file leans on. NVIDIA's own docs stop short of
+    # guaranteeing it, so verify it here instead of silently trusting it (or
+    # silently computing an independent ordinal that would then disagree with
+    # every other index-keyed probe in this file): sort by pci.bus_id
+    # ourselves -- its fixed-width "domain:bus:device.function" hex format
+    # sorts correctly as plain text -- and confirm every row's index equals
+    # its position in that sort. If it does, resolving to nvidia-smi's own
+    # index is safe and stays consistent with those other probes. If it
+    # doesn't, the assumption this file depends on doesn't hold on this host
+    # and no ordinal from either source can be trusted to line up with the
+    # others, so fail closed rather than resolve to a value that only agrees
+    # with half the codebase's telemetry.
+    by_pci_order = sorted(rows, key = lambda row: row[2])
+    for expected_idx, (idx, _uuid, bus_id, _mig_mode) in enumerate(by_pci_order):
+        if idx != expected_idx:
+            logger.warning(
+                "nvidia-smi index does not match PCI bus order (index=%s, "
+                "pci.bus_id=%s, expected position=%s); declining to resolve "
+                "UUID masks on this host",
+                idx,
+                bus_id,
+                expected_idx,
+            )
+            return None
 
     uuid_to_ordinal: dict[str, int] = {}
-    for ordinal, (uuid, _bus_id, mig_mode) in enumerate(rows):
+    for idx, uuid, _bus_id, mig_mode in rows:
         # A MIG-enabled root GPU's UUID isn't a normal selectable compute
         # device -- CUDA exposes its MIG instances instead of the whole card.
         # Leave it out of the map so it fails resolution the same way an
@@ -107,7 +131,7 @@ def _query_uuid_to_ordinal() -> Optional[dict[str, int]]:
         # index that silently selects a partitioned view of the card.
         if mig_mode == "Enabled":
             continue
-        uuid_to_ordinal[uuid] = ordinal
+        uuid_to_ordinal[uuid] = idx
     return uuid_to_ordinal
 
 
@@ -133,19 +157,23 @@ def _resolve_uuid_token(token: str, uuid_to_ordinal: dict[str, int]) -> Optional
 
 def resolve_gpu_uuid_mask(tokens: list[str]) -> Optional[list[int]]:
     """Resolve a CUDA_VISIBLE_DEVICES mask that mixes numeric indices and GPU
-    UUIDs (e.g. ["0", "GPU-<uuid>"]) to physical PCI-bus-order indices, so a
-    UUID mask is exactly as selectable as the equivalent numeric one. Numeric
-    tokens pass through as-is, matching the trust level of the plain-numeric
-    fast path in _get_parent_visible_gpu_spec(); UUID tokens are resolved via
-    nvidia-smi. Order is preserved to match the mask, since it defines the
-    visible-ordinal mapping downstream. Returns None -- and the caller falls
-    back to relative ordinals -- if nvidia-smi is unavailable, or any UUID
-    token doesn't match exactly one non-MIG physical device (an actual MIG
-    instance UUID, a MIG-enabled root's UUID, or a UUID/prefix ambiguous
-    across cards). Successes are cached per token tuple for the process
-    lifetime; failures are cached for _FAILED_RESOLUTION_TTL_SECONDS, since a
-    hung or missing nvidia-smi would otherwise cost its full timeout on every
-    caller of _get_parent_visible_gpu_spec() every poll cycle."""
+    UUIDs (e.g. ["0", "GPU-<uuid>"]) to physical indices, so a UUID mask is
+    exactly as selectable as the equivalent numeric one. Numeric tokens pass
+    through as-is, matching the trust level of the plain-numeric fast path in
+    _get_parent_visible_gpu_spec(); UUID tokens are resolved via nvidia-smi,
+    to the same index get_visible_gpu_utilization() and
+    get_backend_visible_gpu_info() already key their own nvidia-smi rows by
+    (see _query_uuid_to_ordinal()'s PCI-bus cross-check). Order is preserved
+    to match the mask, since it defines the visible-ordinal mapping
+    downstream. Returns None -- and the caller falls back to relative
+    ordinals -- if nvidia-smi is unavailable, its index doesn't match PCI bus
+    order, or any UUID token doesn't match exactly one non-MIG physical
+    device (an actual MIG instance UUID, a MIG-enabled root's UUID, or a
+    UUID/prefix ambiguous across cards). Successes are cached per token tuple
+    for the process lifetime; failures are cached for
+    _FAILED_RESOLUTION_TTL_SECONDS, since a hung or missing nvidia-smi would
+    otherwise cost its full timeout on every caller of
+    _get_parent_visible_gpu_spec() every poll cycle."""
     cache_key = tuple(tokens)
     cached = _uuid_mask_resolution_cache.get(cache_key)
     if cached is not None:

--- a/studio/backend/utils/hardware/nvidia.py
+++ b/studio/backend/utils/hardware/nvidia.py
@@ -160,18 +160,23 @@ def _resolve_uuid_token(token: str, uuid_info: dict[str, tuple[int, bool]]) -> O
 def resolve_gpu_uuid_mask(tokens: list[str]) -> Optional[list[int]]:
     """Resolve a CUDA_VISIBLE_DEVICES mask that mixes numeric indices and GPU
     UUIDs (e.g. ["0", "GPU-<uuid>"]) to physical indices, so a UUID mask is
-    exactly as selectable as the equivalent numeric one. Numeric tokens pass
-    through as-is, matching the trust level of the plain-numeric fast path in
-    _get_parent_visible_gpu_spec(); UUID tokens are resolved via nvidia-smi,
-    to the same index get_visible_gpu_utilization() and
-    get_backend_visible_gpu_info() already key their own nvidia-smi rows by
-    (see _query_uuid_to_ordinal()'s PCI-bus cross-check). Order is preserved
-    to match the mask, since it defines the visible-ordinal mapping
-    downstream. Returns None -- and the caller falls back to relative
-    ordinals -- if nvidia-smi is unavailable, its index doesn't match PCI bus
-    order, any UUID token doesn't match exactly one non-MIG physical device
-    (an actual MIG instance UUID, a MIG-enabled root's UUID, or a UUID/prefix
-    ambiguous across cards), or two tokens resolve to the same physical ID
+    exactly as selectable as the equivalent numeric one. Numeric tokens are
+    validated against the GPUs nvidia-smi actually reports (real CUDA
+    semantics truncate enumeration at the first negative or out-of-range
+    member of a mixed mask, hiding everything after it -- rather than
+    replicate that exact truncation point, an invalid numeric member fails
+    the whole resolution); UUID tokens are resolved to the same index
+    get_visible_gpu_utilization() and get_backend_visible_gpu_info() already
+    key their own nvidia-smi rows by (see _query_uuid_to_ordinal()'s PCI-bus
+    cross-check). Order is preserved to match the mask, since it defines the
+    visible-ordinal mapping downstream. Returns None -- and the caller falls
+    back to relative ordinals -- if nvidia-smi is unavailable, its index
+    doesn't match PCI bus order, a numeric token is negative or not a
+    queried GPU, any UUID token doesn't match exactly one non-MIG physical
+    device (an actual MIG instance UUID, a MIG-enabled root's UUID, or a
+    UUID/prefix ambiguous across cards -- checked against every root
+    regardless of MIG state, so a MIG root can't make an otherwise-ambiguous
+    prefix look unambiguous), or two tokens resolve to the same physical ID
     (a repeated or aliased UUID/index pair): _visible_ordinal_map() is keyed
     by physical ID, so a duplicate silently collapses one of the mask's
     visible ordinals rather than giving it its own device entry. Cached per
@@ -193,19 +198,32 @@ def resolve_gpu_uuid_mask(tokens: list[str]) -> Optional[list[int]]:
     if uuid_info is None:
         _uuid_mask_resolution_cache[cache_key] = (None, time.monotonic())
         return None
+    valid_indices = {idx for idx, _is_mig_enabled in uuid_info.values()}
 
     resolved = []
     for token in tokens:
         try:
-            resolved.append(int(token))
-            continue
+            numeric_idx = int(token)
         except ValueError:
-            pass
-        idx = _resolve_uuid_token(token, uuid_info)
-        if idx is None:
+            idx = _resolve_uuid_token(token, uuid_info)
+            if idx is None:
+                _uuid_mask_resolution_cache[cache_key] = (None, time.monotonic())
+                return None
+            resolved.append(idx)
+            continue
+        # CUDA truncates enumeration at the first invalid member of a mixed
+        # mask (negative or not a real device) -- everything listed after it
+        # in the real CUDA_VISIBLE_DEVICES semantics is not visible at all,
+        # not merely skipped. Replicating that exact truncation point would
+        # mean returning a list shorter than the mask, which every caller of
+        # _get_parent_visible_gpu_spec() would then have to special-case, so
+        # fail the whole resolution instead: falling back to relative
+        # ordinals (no explicit selection) is safer than resolving a later
+        # UUID token that real CUDA_VISIBLE_DEVICES parsing would have hidden.
+        if numeric_idx < 0 or numeric_idx not in valid_indices:
             _uuid_mask_resolution_cache[cache_key] = (None, time.monotonic())
             return None
-        resolved.append(idx)
+        resolved.append(numeric_idx)
 
     if len(set(resolved)) != len(resolved):
         logger.warning(

--- a/studio/backend/utils/hardware/nvidia.py
+++ b/studio/backend/utils/hardware/nvidia.py
@@ -63,7 +63,7 @@ _uuid_mask_resolution_cache: dict[tuple[str, ...], tuple[Optional[list[int]], fl
 _GPU_UUID_PREFIX = "GPU-"
 
 
-def _query_uuid_to_ordinal() -> Optional[dict[str, int]]:
+def _query_uuid_to_ordinal() -> Optional[dict[str, tuple[int, bool]]]:
     try:
         result = subprocess.run(
             [
@@ -125,23 +125,22 @@ def _query_uuid_to_ordinal() -> Optional[dict[str, int]]:
             )
             return None
 
-    uuid_to_ordinal: dict[str, int] = {}
+    # (index, is_mig_enabled) per UUID, for every row -- including MIG-enabled
+    # roots. A MIG-enabled root is never itself a valid resolution (CUDA
+    # exposes its MIG instances instead of the whole card), but it must still
+    # be visible during *ambiguity* checking below: excluding it here first
+    # would let a prefix shared with a MIG root look falsely unambiguous.
+    uuid_info: dict[str, tuple[int, bool]] = {}
     for idx, uuid, _bus_id, mig_mode in rows:
-        # A MIG-enabled root GPU's UUID isn't a normal selectable compute
-        # device -- CUDA exposes its MIG instances instead of the whole card.
-        # Leave it out of the map so it fails resolution the same way an
-        # actual MIG instance UUID already does, rather than resolving to an
-        # index that silently selects a partitioned view of the card.
-        if mig_mode == "Enabled":
-            continue
-        uuid_to_ordinal[uuid] = idx
-    return uuid_to_ordinal
+        uuid_info[uuid] = (idx, mig_mode == "Enabled")
+    return uuid_info
 
 
-def _resolve_uuid_token(token: str, uuid_to_ordinal: dict[str, int]) -> Optional[int]:
-    exact = uuid_to_ordinal.get(token)
+def _resolve_uuid_token(token: str, uuid_info: dict[str, tuple[int, bool]]) -> Optional[int]:
+    exact = uuid_info.get(token)
     if exact is not None:
-        return exact
+        idx, is_mig_enabled = exact
+        return None if is_mig_enabled else idx
     # NVIDIA accepts an unambiguous UUID prefix (e.g. "GPU-abcdef12") as a
     # device identifier. Require the token to actually look like a GPU UUID
     # before attempting a prefix match -- otherwise a malformed token like
@@ -149,13 +148,13 @@ def _resolve_uuid_token(token: str, uuid_to_ordinal: dict[str, int]) -> Optional
     # on a single-GPU host and get treated as a valid, intentional selector.
     if not (token.startswith(_GPU_UUID_PREFIX) and len(token) > len(_GPU_UUID_PREFIX)):
         return None
-    # A prefix shared by more than one card can't be trusted either way.
-    prefix_matches = [
-        ordinal for uuid, ordinal in uuid_to_ordinal.items() if uuid.startswith(token)
-    ]
-    if len(prefix_matches) == 1:
-        return prefix_matches[0]
-    return None
+    # Checked against every root UUID, MIG-enabled or not -- a prefix shared
+    # by more than one card, MIG or otherwise, can't be trusted either way.
+    prefix_matches = [uuid for uuid in uuid_info if uuid.startswith(token)]
+    if len(prefix_matches) != 1:
+        return None
+    idx, is_mig_enabled = uuid_info[prefix_matches[0]]
+    return None if is_mig_enabled else idx
 
 
 def resolve_gpu_uuid_mask(tokens: list[str]) -> Optional[list[int]]:
@@ -190,8 +189,8 @@ def resolve_gpu_uuid_mask(tokens: list[str]) -> Optional[list[int]]:
         if time.monotonic() - cached_at < ttl:
             return value
 
-    uuid_to_ordinal = _query_uuid_to_ordinal()
-    if uuid_to_ordinal is None:
+    uuid_info = _query_uuid_to_ordinal()
+    if uuid_info is None:
         _uuid_mask_resolution_cache[cache_key] = (None, time.monotonic())
         return None
 
@@ -202,7 +201,7 @@ def resolve_gpu_uuid_mask(tokens: list[str]) -> Optional[list[int]]:
             continue
         except ValueError:
             pass
-        idx = _resolve_uuid_token(token, uuid_to_ordinal)
+        idx = _resolve_uuid_token(token, uuid_info)
         if idx is None:
             _uuid_mask_resolution_cache[cache_key] = (None, time.monotonic())
             return None

--- a/studio/backend/utils/hardware/nvidia.py
+++ b/studio/backend/utils/hardware/nvidia.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
+import re
 import subprocess
 import time
 from typing import Any, Optional
@@ -61,6 +62,11 @@ _RESOLVED_MASK_TTL_SECONDS = 300
 _uuid_mask_resolution_cache: dict[tuple[str, ...], tuple[Optional[list[int]], float]] = {}
 
 _GPU_UUID_PREFIX = "GPU-"
+# Python's int() accepts spellings CUDA's own decimal parser wouldn't -- most
+# notably PEP 515 digit-group underscores (int("0_0") == 0), but also a
+# leading "+" and surrounding whitespace. A mixed-mask numeric member must be
+# a plain, unsigned-lexically decimal token before it's trusted as one.
+_DECIMAL_TOKEN_RE = re.compile(r"^-?[0-9]+$")
 
 
 def _query_uuid_to_ordinal() -> Optional[dict[str, tuple[int, bool]]]:
@@ -160,12 +166,15 @@ def _resolve_uuid_token(token: str, uuid_info: dict[str, tuple[int, bool]]) -> O
 def resolve_gpu_uuid_mask(tokens: list[str]) -> Optional[list[int]]:
     """Resolve a CUDA_VISIBLE_DEVICES mask that mixes numeric indices and GPU
     UUIDs (e.g. ["0", "GPU-<uuid>"]) to physical indices, so a UUID mask is
-    exactly as selectable as the equivalent numeric one. Numeric tokens are
-    validated against the GPUs nvidia-smi actually reports (real CUDA
-    semantics truncate enumeration at the first negative or out-of-range
-    member of a mixed mask, hiding everything after it -- rather than
-    replicate that exact truncation point, an invalid numeric member fails
-    the whole resolution); UUID tokens are resolved to the same index
+    exactly as selectable as the equivalent numeric one. A numeric token must
+    be a plain decimal (ASCII digits, optional leading "-") -- Python's int()
+    is more permissive than CUDA's own parser (e.g. int("0_0") == 0 via PEP
+    515 digit-group underscores) -- and is then validated against the GPUs
+    nvidia-smi actually reports and excludes MIG-enabled roots from (real
+    CUDA semantics truncate enumeration at the first invalid member of a
+    mixed mask, hiding everything after it -- rather than replicate that
+    exact truncation point, an invalid numeric member fails the whole
+    resolution); UUID tokens are resolved to the same index
     get_visible_gpu_utilization() and get_backend_visible_gpu_info() already
     key their own nvidia-smi rows by (see _query_uuid_to_ordinal()'s PCI-bus
     cross-check). Order is preserved to match the mask, since it defines the
@@ -206,28 +215,28 @@ def resolve_gpu_uuid_mask(tokens: list[str]) -> Optional[list[int]]:
 
     resolved = []
     for token in tokens:
-        try:
+        if _DECIMAL_TOKEN_RE.match(token):
             numeric_idx = int(token)
-        except ValueError:
-            idx = _resolve_uuid_token(token, uuid_info)
-            if idx is None:
+            # CUDA truncates enumeration at the first invalid member of a
+            # mixed mask (negative or not a real device) -- everything
+            # listed after it in the real CUDA_VISIBLE_DEVICES semantics is
+            # not visible at all, not merely skipped. Replicating that exact
+            # truncation point would mean returning a list shorter than the
+            # mask, which every caller of _get_parent_visible_gpu_spec()
+            # would then have to special-case, so fail the whole resolution
+            # instead: falling back to relative ordinals (no explicit
+            # selection) is safer than resolving a later UUID token that
+            # real CUDA_VISIBLE_DEVICES parsing would have hidden.
+            if numeric_idx < 0 or numeric_idx not in valid_indices:
                 _uuid_mask_resolution_cache[cache_key] = (None, time.monotonic())
                 return None
-            resolved.append(idx)
+            resolved.append(numeric_idx)
             continue
-        # CUDA truncates enumeration at the first invalid member of a mixed
-        # mask (negative or not a real device) -- everything listed after it
-        # in the real CUDA_VISIBLE_DEVICES semantics is not visible at all,
-        # not merely skipped. Replicating that exact truncation point would
-        # mean returning a list shorter than the mask, which every caller of
-        # _get_parent_visible_gpu_spec() would then have to special-case, so
-        # fail the whole resolution instead: falling back to relative
-        # ordinals (no explicit selection) is safer than resolving a later
-        # UUID token that real CUDA_VISIBLE_DEVICES parsing would have hidden.
-        if numeric_idx < 0 or numeric_idx not in valid_indices:
+        idx = _resolve_uuid_token(token, uuid_info)
+        if idx is None:
             _uuid_mask_resolution_cache[cache_key] = (None, time.monotonic())
             return None
-        resolved.append(numeric_idx)
+        resolved.append(idx)
 
     if len(set(resolved)) != len(resolved):
         logger.warning(

--- a/studio/backend/utils/hardware/nvidia.py
+++ b/studio/backend/utils/hardware/nvidia.py
@@ -52,9 +52,12 @@ def _visible_ordinal_map(parent_visible_ids: Optional[list[int]]) -> Optional[di
 # Failures aren't cached forever: a hung/missing nvidia-smi at Studio startup
 # (driver still initializing, momentary system load) can recover mid-session,
 # and the picker shouldn't stay hidden until a restart on the strength of one
-# bad probe. Successes ARE cached forever -- GPU topology doesn't change
-# mid-process -- so only failure entries carry a timestamp to expire against.
+# bad probe. Successes also expire, just on a much longer horizon -- GPU
+# topology and MIG mode are effectively static, but not provably immutable
+# for a whole Studio session (an admin can toggle MIG on a running host) --
+# so a resolution is revalidated periodically rather than trusted forever.
 _FAILED_RESOLUTION_TTL_SECONDS = 30
+_RESOLVED_MASK_TTL_SECONDS = 300
 _uuid_mask_resolution_cache: dict[tuple[str, ...], tuple[Optional[list[int]], float]] = {}
 
 _GPU_UUID_PREFIX = "GPU-"
@@ -167,18 +170,24 @@ def resolve_gpu_uuid_mask(tokens: list[str]) -> Optional[list[int]]:
     to match the mask, since it defines the visible-ordinal mapping
     downstream. Returns None -- and the caller falls back to relative
     ordinals -- if nvidia-smi is unavailable, its index doesn't match PCI bus
-    order, or any UUID token doesn't match exactly one non-MIG physical
-    device (an actual MIG instance UUID, a MIG-enabled root's UUID, or a
-    UUID/prefix ambiguous across cards). Successes are cached per token tuple
-    for the process lifetime; failures are cached for
-    _FAILED_RESOLUTION_TTL_SECONDS, since a hung or missing nvidia-smi would
-    otherwise cost its full timeout on every caller of
-    _get_parent_visible_gpu_spec() every poll cycle."""
+    order, any UUID token doesn't match exactly one non-MIG physical device
+    (an actual MIG instance UUID, a MIG-enabled root's UUID, or a UUID/prefix
+    ambiguous across cards), or two tokens resolve to the same physical ID
+    (a repeated or aliased UUID/index pair): _visible_ordinal_map() is keyed
+    by physical ID, so a duplicate silently collapses one of the mask's
+    visible ordinals rather than giving it its own device entry. Cached per
+    token tuple -- successes for _RESOLVED_MASK_TTL_SECONDS, since GPU
+    topology/MIG mode can change while Studio keeps running (an admin
+    enabling MIG on a previously plain card, without a restart); failures
+    for the much shorter _FAILED_RESOLUTION_TTL_SECONDS, since a hung or
+    missing nvidia-smi would otherwise cost its full timeout on every caller
+    of _get_parent_visible_gpu_spec() every poll cycle."""
     cache_key = tuple(tokens)
     cached = _uuid_mask_resolution_cache.get(cache_key)
     if cached is not None:
         value, cached_at = cached
-        if value is not None or time.monotonic() - cached_at < _FAILED_RESOLUTION_TTL_SECONDS:
+        ttl = _RESOLVED_MASK_TTL_SECONDS if value is not None else _FAILED_RESOLUTION_TTL_SECONDS
+        if time.monotonic() - cached_at < ttl:
             return value
 
     uuid_to_ordinal = _query_uuid_to_ordinal()
@@ -198,6 +207,16 @@ def resolve_gpu_uuid_mask(tokens: list[str]) -> Optional[list[int]]:
             _uuid_mask_resolution_cache[cache_key] = (None, time.monotonic())
             return None
         resolved.append(idx)
+
+    if len(set(resolved)) != len(resolved):
+        logger.warning(
+            "GPU mask %r resolved to duplicate physical IDs %r; a physical "
+            "ID mask can't represent this many distinct visible ordinals",
+            tokens,
+            resolved,
+        )
+        _uuid_mask_resolution_cache[cache_key] = (None, time.monotonic())
+        return None
 
     _uuid_mask_resolution_cache[cache_key] = (resolved, time.monotonic())
     return resolved

--- a/studio/backend/utils/hardware/nvidia.py
+++ b/studio/backend/utils/hardware/nvidia.py
@@ -198,7 +198,11 @@ def resolve_gpu_uuid_mask(tokens: list[str]) -> Optional[list[int]]:
     if uuid_info is None:
         _uuid_mask_resolution_cache[cache_key] = (None, time.monotonic())
         return None
-    valid_indices = {idx for idx, _is_mig_enabled in uuid_info.values()}
+    # A MIG-enabled root is excluded from UUID resolution below (its own
+    # index isn't a valid selectable device); a plain numeric token equal to
+    # that same index must be rejected the same way, or a mixed mask could
+    # route around the UUID-side MIG protection entirely.
+    valid_indices = {idx for idx, is_mig_enabled in uuid_info.values() if not is_mig_enabled}
 
     resolved = []
     for token in tokens:


### PR DESCRIPTION
## Summary

Fixes #8873. On a multi-GPU CUDA host, the per-model **GPUs** picker in Studio silently disappears when `CUDA_VISIBLE_DEVICES` is set using GPU UUIDs (`GPU-<uuid>,GPU-<uuid>`) instead of numeric indices -- a legitimate, common NVIDIA configuration used to keep device ordering stable across PCIe reordering.

Root cause, traced by the reporter down to the exact function: `_get_parent_visible_gpu_spec()` in `studio/backend/utils/hardware/hardware.py` gives up as soon as a `CUDA_VISIBLE_DEVICES` token fails `int()` parsing, returning `numeric_ids=None` for any UUID mask. Every downstream consumer treats `numeric_ids=None` as "physical IDs unresolvable" and falls back to relative torch ordinals, which the frontend never marks pinnable -- so the picker section is omitted entirely rather than disabled-with-a-reason, making the feature look like it doesn't exist.

## Fix

- Added `nvidia.resolve_gpu_uuid_mask()` in `studio/backend/utils/hardware/nvidia.py`, which maps a UUID mask to physical indices via `nvidia-smi --query-gpu=index,uuid --format=csv,noheader`, preserving the mask's token order (that order defines the visible-ordinal mapping downstream).
- Wired it into the `except ValueError` branch of `_get_parent_visible_gpu_spec()`, gated to CUDA hosts only (`not _is_rocm_spec`) -- ROCm has no `nvidia-smi`.
- Fails closed: anything nvidia-smi can't resolve (a MIG instance UUID, `nvidia-smi` missing/erroring) keeps the previous `numeric_ids=None` behaviour unchanged, so this is additive rather than a behavior change for cases that were already correctly falling back.

## Testing

Ran `studio/backend/tests/test_gpu_selection.py` locally (Python 3.12, CPU-only torch, matching the CI dependency recipe) -- 57 passed / 23 deselected (the deselections match the suite's own documented GPU-only exclusions), plus the other test files that share `_get_parent_visible_gpu_spec()` (`test_rocm_multi_gpu_vram_system_wide.py`, `test_system_poll_no_cuda_context.py`, `test_diffusion_device.py`, `test_gpu_selection_sandbox.py`) -- no new failures. `ruff check` and the project's canonical formatter (`scripts/run_ruff_format.py`) are clean.

Added test coverage:
- `TestResolveGpuUuidMask` -- unit tests for the new resolver directly (order preservation against nvidia-smi's own listing order, partial-mismatch fails closed, nvidia-smi failure/missing fails closed).
- `_get_parent_visible_gpu_spec`-level tests for the resolved case, the still-unresolvable case, and confirming ROCm hosts never attempt nvidia-smi resolution.
- An end-to-end `get_backend_visible_gpu_info()` test confirming a resolvable UUID mask now surfaces `index_kind: "physical"` instead of falling back to `"relative"`.

I don't have multi-GPU hardware to verify the actual frontend picker rendering end-to-end, so it'd be good to get confirmation from the reporter (or anyone with a multi-GPU CUDA host using a UUID mask) that the picker now appears.