### PR TITLE
Model hub: show the Meta mark on the Unsloth re-upload of Muse Glimmer

### DIFF
--- a/studio/frontend/src/features/hub/lib/provider-logos.ts
+++ b/studio/frontend/src/features/hub/lib/provider-logos.ts
@@ -257,7 +257,9 @@ export const PROVIDER_LOGOS: readonly ProviderLogo[] = [
 			"CodeLlama-",
 			"Llama-",
 			"llama-",
-			"meta-"
+			"meta-",
+			// Carries no Llama token, so the re-upload needs its own stem.
+			"Muse-Glimmer"
 		],
 		// "Meta Inc." / "Meta Llama" / "AI at Meta". Not facebookresearch, which is
 		// an unrelated account despite the name.

--- a/studio/frontend/tests/hub-provider-logo-muse-glimmer.test.ts
+++ b/studio/frontend/tests/hub-provider-logo-muse-glimmer.test.ts
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  matchProviderLogo,
+  resolveOwnerProviderLogo,
+} from "../src/features/hub/lib/provider-logos.ts";
+
+const META = "/hub/profile/logo/meta.svg";
+
+test("the Unsloth re-upload of Muse Glimmer shows the Meta mark", () => {
+  // The row the Model hub actually lists. Owner is unsloth, so the org rule
+  // never fires and the repo name has to carry it.
+  assert.equal(
+    resolveOwnerProviderLogo("unsloth", "Muse-Glimmer-30B-GGUF")?.logoPath,
+    META,
+  );
+});
+
+test("every Muse Glimmer variant rides the same stem", () => {
+  for (const repo of [
+    "Muse-Glimmer-30B",
+    "Muse-Glimmer-30B-GGUF",
+    "Muse-Glimmer-30B-unsloth-bnb-4bit",
+    "Muse-Glimmer-30B-Instruct",
+    // No trailing dash in the stem, so a future minor version is picked up.
+    "Muse-Glimmer2-30B-GGUF",
+  ]) {
+    assert.equal(matchProviderLogo(repo)?.id, "meta-llama", repo);
+  }
+});
+
+test("the stem is case-sensitive and anchored at the start", () => {
+  assert.equal(matchProviderLogo("muse-glimmer-30b-gguf"), null);
+  assert.equal(matchProviderLogo("Retro-Muse-Glimmer-30B"), null);
+  assert.equal(matchProviderLogo("Muse-30B"), null);
+});
+
+test("the org rule still covers Meta's own upload", () => {
+  assert.equal(
+    resolveOwnerProviderLogo("meta-models", "Muse-Glimmer-30B")?.logoPath,
+    META,
+  );
+});
+
+test("an ineligible owner gets nothing from the new stem", () => {
+  // Only RELABELED_OWNERS resolve by repo name; everyone else keeps their avatar.
+  assert.equal(
+    resolveOwnerProviderLogo("someone-else", "Muse-Glimmer-30B-GGUF"),
+    null,
+  );
+});


### PR DESCRIPTION
## The problem

PR #8691 was meant to put Meta's mark on Muse Glimmer. It merged, and Muse Glimmer in the Model hub still shows the Unsloth sloth.

The PR is not broken. It fixes a different repo than the one the hub lists.

`#8691` matches on the **owner** segment, and Meta claims `meta-models`, `meta-llama` and `facebook`. But the row in "Latest Unsloth Models" is `unsloth/Muse-Glimmer-30B-GGUF`, owned by `unsloth`. `meta-models/Muse-Glimmer-30B` only ever appears as the Base chip in the inspector, which the resolver never reads.

Replaying `resolveOwnerProviderLogo` on the real inputs:

```
unsloth/Muse-Glimmer-30B-GGUF                 -> no logo, falls back to the owner avatar
meta-models/Muse-Glimmer-30B                  -> Meta
unsloth/Llama-4-Scout-17B-16E-Instruct-GGUF   -> Meta
unsloth/Qwen3.8-27B-GGUF                      -> Qwen
```

The repo #8691 targeted resolves. The repo on screen does not.

## Why it falls through

1. `matchProviderLogoByOwner("unsloth")` returns null, by design: `unsloth` is in no provider's `owners` list.
2. `isProviderRelabeledOwner("unsloth")` is true, so it tries the repo name.
3. `matchProviderLogo("Muse-Glimmer-30B-GGUF")` returns null. Meta's prefixes are all Llama-shaped (`Meta-Llama-`, `Llama-Guard-`, `LlamaGuard-`, `CodeLlama-`, `Llama-`, `llama-`, `meta-`), and the only `stems` in the registry is Google's `gemma`.

With no provider, `owner-avatar.tsx` takes the `isUnslothOwner` branch and renders the Unsloth mark. That is what both avatars in the hub are showing.

This is the gap #8691 names in its own description: the logos "match on repo name", so `Llama-4-Scout` picks up Meta from its prefix. Muse Glimmer carries no Meta-shaped token, so there is nothing to match.

## The change

One entry: `Muse-Glimmer` joins Meta's `prefixes`.

No trailing dash, following the registry's own instruction to match on the family stem so future minor versions ride along. Prefixes are case-sensitive and anchored at the start, so `muse-glimmer-30b-gguf` and `Retro-Muse-Glimmer-30B` do not match.

Blast radius is only Unsloth re-uploads whose name starts with `Muse-Glimmer`, since the repo-name pass runs for `RELABELED_OWNERS` alone. Meta's own `meta-models` upload keeps resolving through the org rule from #8691, unchanged.

## Relationship to PR #8468

#8468 is the general fix: it resolves an Unsloth re-upload through its `base_model` provenance, which would pick Meta up from the Base chip with no registry edit at all, for this model and every future one named this way. That PR is still open.

This is the stopgap while it is. The two compose fine, and this entry costs nothing to drop once #8468 lands.

## Testing

New `tests/hub-provider-logo-muse-glimmer.test.ts`, 5 cases: the exact row the hub lists, the variants that ride the stem including a hypothetical `Muse-Glimmer2`, case sensitivity and start anchoring, Meta's own org still resolving, and an ineligible owner getting nothing from the new stem.

Two of the five fail against unmodified source.

Full frontend suite passes at 2707 and typecheck is clean.