### PR TITLE
Fix fbgemm blockwise FP8 crashes on unsupported shapes and blocksizes

### DIFF
--- a/tests/test_fp8_fbgemm_block_shapes.py
+++ b/tests/test_fp8_fbgemm_block_shapes.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team.
 """FP8 fbgemm blockwise linear must stay correct across tile grids and shapes.
 
 Guards three things:

--- a/tests/test_fp8_fbgemm_block_shapes.py
+++ b/tests/test_fp8_fbgemm_block_shapes.py
@@ -29,7 +29,6 @@ def _fbgemm_block_selected():
         return False
     try:
         from unsloth.kernels import fp8
-
         return fp8.fp8_block_quant_linear is fp8.fp8_fbgemm_block_linear
     except Exception:
         return False
@@ -38,7 +37,8 @@ def _fbgemm_block_selected():
 # Only the kernel battery needs fbgemm; the fallback tests below never reach it.
 pytestmark = pytest.mark.skipif(not cuda_available, reason = "needs CUDA")
 needs_fbgemm = pytest.mark.skipif(
-    not _fbgemm_block_selected(), reason = "needs fbgemm f8f8bf16_blockwise",
+    not _fbgemm_block_selected(),
+    reason = "needs fbgemm f8f8bf16_blockwise",
 )
 
 

--- a/tests/test_fp8_fbgemm_block_shapes.py
+++ b/tests/test_fp8_fbgemm_block_shapes.py
@@ -20,31 +20,25 @@ import pytest
 import torch
 
 cuda_available = torch.cuda.is_available()
-sm90 = cuda_available and torch.cuda.get_device_capability(0)[0] == 9
 
 
-def _has_blockwise_fbgemm():
-    if not sm90:
+def _fbgemm_block_selected():
+    # Ask unsloth's own import-time probe rather than checking for sm_90: that is
+    # exactly when the kernel path is reachable, and future arches enable themselves.
+    if not cuda_available:
         return False
     try:
-        import fbgemm_gpu
+        from unsloth.kernels import fp8
 
-        try:
-            import fbgemm_gpu.experimental.gen_ai  # noqa: F401
-        except Exception:
-            pass
-        from packaging.version import Version
-
-        if Version(fbgemm_gpu.__version__) < Version("1.4.0"):
-            return False  # <=1.3.0 corrupts some shapes; unsloth gates it off
+        return fp8.fp8_block_quant_linear is fp8.fp8_fbgemm_block_linear
     except Exception:
         return False
-    return hasattr(torch.ops.fbgemm, "f8f8bf16_blockwise")
 
 
-pytestmark = pytest.mark.skipif(
-    not _has_blockwise_fbgemm(),
-    reason = "needs sm_90 CUDA and fbgemm f8f8bf16_blockwise",
+# Only the kernel battery needs fbgemm; the fallback tests below never reach it.
+pytestmark = pytest.mark.skipif(not cuda_available, reason = "needs CUDA")
+needs_fbgemm = pytest.mark.skipif(
+    not _fbgemm_block_selected(), reason = "needs fbgemm f8f8bf16_blockwise",
 )
 
 
@@ -89,9 +83,11 @@ def _check_grad(X, out, Wq, scale, block):
 
 
 def _rel_err(out, ref):
-    return float((out.float() - ref.float()).abs().mean() / ref.float().abs().mean())
+    out, ref = out.detach().float(), ref.detach().float()
+    return float((out - ref).abs().mean() / ref.abs().mean())
 
 
+@needs_fbgemm
 def test_output_tile_grid_battery_matches_reference():
     # Shapes cover both dispatch buckets' former failure zones plus safe ones.
     # On fbgemm <=1.3.0 the failing ones returned whole outputs at ~0.7 relative

--- a/tests/test_fp8_fbgemm_block_shapes.py
+++ b/tests/test_fp8_fbgemm_block_shapes.py
@@ -163,8 +163,7 @@ def test_non_square_block_uses_dequant_fallback():
 @pytest.mark.parametrize("kind", ["per_tensor", "per_tensor_2d", "bf16_scale", "strided_3d"])
 def test_inputs_the_kernel_rejects_use_dequant_fallback(kind):
     # All four used to reach f8f8bf16_blockwise and raise: no block grid to unpack
-    # (0-dim or (1, 1)), a non-float32 scale, and a strided view that cannot be
-    # .view()ed. fp8_linear routes every numel() == 1 scale here.
+    # (0-dim or (1, 1)), a non-float32 scale, and a strided view no .view() flattens.
     from unsloth.kernels.fp8 import FP8_fbgemm_block_linear
 
     torch.manual_seed(0)
@@ -198,9 +197,8 @@ def test_inputs_the_kernel_rejects_use_dequant_fallback(kind):
 @pytest.mark.parametrize("block", [[128, 64], [64, 128]])  # square stays on the kernel
 @pytest.mark.parametrize("N,K", [(256, 512), (256, 256)])
 def test_transposed_weight_swaps_block_axes(block, N, K):
-    # fast_lora's backward passes downW.t(), so the transposed weight's block axes
-    # are swapped as well. At N == K both grids validate and only the stride tells
-    # them apart, which is where a rectangular block silently mis-scaled dX.
+    # fast_lora's backward passes downW.t(), whose block axes are swapped too. At
+    # N == K both grids validate, which is where a rectangular block mis-scaled dX.
     from unsloth.kernels.fp8 import FP8_fbgemm_block_linear
 
     torch.manual_seed(0)

--- a/tests/test_fp8_fbgemm_block_shapes.py
+++ b/tests/test_fp8_fbgemm_block_shapes.py
@@ -1,16 +1,10 @@
-"""FP8 fbgemm blockwise linear must stay correct across output tile grids and shapes.
+"""FP8 fbgemm blockwise linear must stay correct across tile grids and shapes.
 
-Three things this guards:
-  * fbgemm <=1.3.0 silently corrupted whole outputs for some output tile grids
-    (raster-order bug in its vendored CUTLASS scheduler). The import-time probe
-    uses a 128^3 all-ones GEMM whose 1x1 tile grid can never trigger that class
-    of bug, so a regression would load fine and corrupt training. The shape
-    battery here covers both scheduler cluster buckets' former failure zones.
-  * f8f8bf16_blockwise only supports 128x128x128 blocks with
-    in_features % 16 == 0 and out_features % 8 == 0 (measured on H800 /
-    fbgemm 1.4.0); anything else crashed the kernel ("cutlass cannot
-    implement" / "Only 128x128x128 block size is supported") instead of
-    falling back to dequant + matmul.
+Guards three things:
+  * fbgemm <=1.3.0 corrupted whole outputs for some tile grids; the import-time
+    probe's 1x1 grid cannot catch that, so this battery covers the failure zones.
+  * f8f8bf16_blockwise takes only 128x128x128 blocks with in_features % 16 == 0
+    and out_features % 8 == 0; anything else crashed instead of falling back.
   * activations are (tokens, K): they quantize with block width bs_k, not bs_n.
 """
 
@@ -27,8 +21,7 @@ pytestmark = pytest.mark.skipif(not cuda_available, reason = "needs CUDA")
 
 
 def skip_without_fbgemm():
-    # Ask unsloth's own import-time probe rather than checking for sm_90: that is
-    # exactly when the kernel path is reachable, and future arches enable themselves.
+    # unsloth's own probe, not an sm_90 check, so future arches enable themselves.
     # Called inside the test so collection never imports unsloth.
     from unsloth.kernels import fp8
     if fp8.fp8_block_quant_linear is not fp8.fp8_fbgemm_block_linear:
@@ -64,9 +57,8 @@ def _reference(X, Wq, scale, block):
 
 
 def _check_grad(X, out, Wq, scale, block):
-    # out.sum() makes grad_output all-ones, so grad_X is the row-sum of the
-    # dequantized weight; the old backward dequantized with a hardcoded
-    # 128x128 block and produced finite but mis-scaled gradients here.
+    # grad_output is all-ones, so grad_X is the row-sum of the dequantized weight.
+    # The old backward hardcoded 128x128 and returned finite but mis-scaled grads.
     out.sum().backward()
     assert X.grad is not None and torch.isfinite(X.grad).all()
     grad_ref = torch.ones(out.shape, device = out.device, dtype = torch.float32) @ _dequant(
@@ -82,9 +74,8 @@ def _rel_err(out, ref):
 
 def test_output_tile_grid_battery_matches_reference():
     skip_without_fbgemm()
-    # Shapes cover both dispatch buckets' former failure zones plus safe ones.
-    # On fbgemm <=1.3.0 the failing ones returned whole outputs at ~0.7 relative
-    # error; the healthy bound (activation quant noise) sits around 0.04.
+    # Both dispatch buckets' former failure zones plus safe shapes. On fbgemm
+    # <=1.3.0 the bad ones hit ~0.7 rel error; healthy quant noise is ~0.04.
     from unsloth.kernels.fp8 import FP8_fbgemm_block_linear
 
     torch.manual_seed(0)
@@ -169,9 +160,8 @@ def test_non_square_block_uses_dequant_fallback():
 
 @pytest.mark.parametrize("kind", ["per_tensor", "bf16_scale", "strided_3d"])
 def test_inputs_the_kernel_rejects_use_dequant_fallback(kind):
-    # Each of these used to reach f8f8bf16_blockwise and raise: a per-tensor scale
-    # has no block grid to unpack, the kernel demands float32 scales, and a strided
-    # view cannot be .view()ed flat.
+    # All three used to reach f8f8bf16_blockwise and raise: no block grid to
+    # unpack, a non-float32 scale, and a strided view that cannot be .view()ed.
     from unsloth.kernels.fp8 import FP8_fbgemm_block_linear
 
     torch.manual_seed(0)

--- a/tests/test_fp8_fbgemm_block_shapes.py
+++ b/tests/test_fp8_fbgemm_block_shapes.py
@@ -22,24 +22,17 @@ import torch
 cuda_available = torch.cuda.is_available()
 
 
-def _fbgemm_block_selected():
-    # Ask unsloth's own import-time probe rather than checking for sm_90: that is
-    # exactly when the kernel path is reachable, and future arches enable themselves.
-    if not cuda_available:
-        return False
-    try:
-        from unsloth.kernels import fp8
-        return fp8.fp8_block_quant_linear is fp8.fp8_fbgemm_block_linear
-    except Exception:
-        return False
-
-
 # Only the kernel battery needs fbgemm; the fallback tests below never reach it.
 pytestmark = pytest.mark.skipif(not cuda_available, reason = "needs CUDA")
-needs_fbgemm = pytest.mark.skipif(
-    not _fbgemm_block_selected(),
-    reason = "needs fbgemm f8f8bf16_blockwise",
-)
+
+
+def skip_without_fbgemm():
+    # Ask unsloth's own import-time probe rather than checking for sm_90: that is
+    # exactly when the kernel path is reachable, and future arches enable themselves.
+    # Called inside the test so collection never imports unsloth.
+    from unsloth.kernels import fp8
+    if fp8.fp8_block_quant_linear is not fp8.fp8_fbgemm_block_linear:
+        pytest.skip("needs fbgemm f8f8bf16_blockwise")
 
 
 def _block_quantize_weight(W, block):
@@ -87,8 +80,8 @@ def _rel_err(out, ref):
     return float((out - ref).abs().mean() / ref.abs().mean())
 
 
-@needs_fbgemm
 def test_output_tile_grid_battery_matches_reference():
+    skip_without_fbgemm()
     # Shapes cover both dispatch buckets' former failure zones plus safe ones.
     # On fbgemm <=1.3.0 the failing ones returned whole outputs at ~0.7 relative
     # error; the healthy bound (activation quant noise) sits around 0.04.
@@ -172,6 +165,39 @@ def test_non_square_block_uses_dequant_fallback():
     assert rel < 0.10, f"rel_err={rel:.4f}"
 
     _check_grad(X, out, Wq, scale, block)
+
+
+@pytest.mark.parametrize("kind", ["per_tensor", "bf16_scale", "strided_3d"])
+def test_inputs_the_kernel_rejects_use_dequant_fallback(kind):
+    # Each of these used to reach f8f8bf16_blockwise and raise: a per-tensor scale
+    # has no block grid to unpack, the kernel demands float32 scales, and a strided
+    # view cannot be .view()ed flat.
+    from unsloth.kernels.fp8 import FP8_fbgemm_block_linear
+
+    torch.manual_seed(0)
+    block = [128, 128]
+    # strided_3d needs a shape the kernel rejects too, else it stays on the fast path
+    N, K = (250, 130) if kind == "strided_3d" else (256, 256)
+    W = torch.randn(N, K, device = "cuda", dtype = torch.bfloat16)
+    Wq, scale = _block_quantize_weight(W, block)
+    X = torch.randn(8, K, device = "cuda", dtype = torch.bfloat16)
+
+    if kind == "per_tensor":
+        scale = scale.amax().clone()
+        ref = (X.float() @ (Wq.to(torch.float32) * scale).T).to(X.dtype)
+    else:
+        if kind == "bf16_scale":
+            scale = scale.to(torch.bfloat16)
+        else:
+            X = torch.randn(2, 4, K * 2, device = "cuda", dtype = torch.bfloat16)[..., ::2]
+        scale.block_size = block
+        ref = _reference(X, Wq, scale, block)
+
+    out = FP8_fbgemm_block_linear.apply(X.requires_grad_(True), Wq, scale)
+    assert out.shape == (*X.shape[:-1], N) and out.dtype == X.dtype
+    assert _rel_err(out, ref) < 0.10
+    out.sum().backward()
+    assert X.grad is not None and torch.isfinite(X.grad).all()
 
 
 if __name__ == "__main__":

--- a/tests/test_fp8_fbgemm_block_shapes.py
+++ b/tests/test_fp8_fbgemm_block_shapes.py
@@ -160,10 +160,11 @@ def test_non_square_block_uses_dequant_fallback():
     _check_grad(X, out, Wq, scale, block)
 
 
-@pytest.mark.parametrize("kind", ["per_tensor", "bf16_scale", "strided_3d"])
+@pytest.mark.parametrize("kind", ["per_tensor", "per_tensor_2d", "bf16_scale", "strided_3d"])
 def test_inputs_the_kernel_rejects_use_dequant_fallback(kind):
-    # All three used to reach f8f8bf16_blockwise and raise: no block grid to
-    # unpack, a non-float32 scale, and a strided view that cannot be .view()ed.
+    # All four used to reach f8f8bf16_blockwise and raise: no block grid to unpack
+    # (0-dim or (1, 1)), a non-float32 scale, and a strided view that cannot be
+    # .view()ed. fp8_linear routes every numel() == 1 scale here.
     from unsloth.kernels.fp8 import FP8_fbgemm_block_linear
 
     torch.manual_seed(0)
@@ -174,8 +175,10 @@ def test_inputs_the_kernel_rejects_use_dequant_fallback(kind):
     Wq, scale = _block_quantize_weight(W, block)
     X = torch.randn(8, K, device = "cuda", dtype = torch.bfloat16)
 
-    if kind == "per_tensor":
+    if kind.startswith("per_tensor"):
         scale = scale.amax().clone()
+        if kind == "per_tensor_2d":
+            scale = scale.reshape(1, 1)
         ref = (X.float() @ (Wq.to(torch.float32) * scale).T).to(X.dtype)
     else:
         if kind == "bf16_scale":
@@ -190,6 +193,28 @@ def test_inputs_the_kernel_rejects_use_dequant_fallback(kind):
     assert _rel_err(out, ref) < 0.10
     out.sum().backward()
     assert X.grad is not None and torch.isfinite(X.grad).all()
+
+
+@pytest.mark.parametrize("block", [[128, 64], [64, 128]])  # square stays on the kernel
+@pytest.mark.parametrize("N,K", [(256, 512), (256, 256)])
+def test_transposed_weight_swaps_block_axes(block, N, K):
+    # fast_lora's backward passes downW.t(), so the transposed weight's block axes
+    # are swapped as well. At N == K both grids validate and only the stride tells
+    # them apart, which is where a rectangular block silently mis-scaled dX.
+    from unsloth.kernels.fp8 import FP8_fbgemm_block_linear
+
+    torch.manual_seed(0)
+    W = torch.randn(N, K, device = "cuda", dtype = torch.bfloat16)
+    Wq, scale = _block_quantize_weight(W, block)
+    scale.block_size = block
+    Wt = Wq.t()
+    Wt.block_size = block
+
+    dY = torch.randn(8, N, device = "cuda", dtype = torch.bfloat16)
+    out = FP8_fbgemm_block_linear.apply(dY, Wt, scale)
+    ref = (dY.float() @ _dequant(Wq, scale, block)).to(dY.dtype)
+    assert out.shape == (8, K)
+    assert _rel_err(out, ref) < 0.10
 
 
 if __name__ == "__main__":

--- a/tests/test_fp8_fbgemm_block_shapes.py
+++ b/tests/test_fp8_fbgemm_block_shapes.py
@@ -1,0 +1,181 @@
+"""FP8 fbgemm blockwise linear must stay correct across output tile grids and shapes.
+
+Three things this guards:
+  * fbgemm <=1.3.0 silently corrupted whole outputs for some output tile grids
+    (raster-order bug in its vendored CUTLASS scheduler). The import-time probe
+    uses a 128^3 all-ones GEMM whose 1x1 tile grid can never trigger that class
+    of bug, so a regression would load fine and corrupt training. The shape
+    battery here covers both scheduler cluster buckets' former failure zones.
+  * f8f8bf16_blockwise only supports 128x128x128 blocks with
+    in_features % 16 == 0 and out_features % 8 == 0 (measured on H800 /
+    fbgemm 1.4.0); anything else crashed the kernel ("cutlass cannot
+    implement" / "Only 128x128x128 block size is supported") instead of
+    falling back to dequant + matmul.
+  * activations are (tokens, K): they quantize with block width bs_k, not bs_n.
+"""
+
+import math
+
+import pytest
+import torch
+
+cuda_available = torch.cuda.is_available()
+sm90 = cuda_available and torch.cuda.get_device_capability(0)[0] == 9
+
+
+def _has_blockwise_fbgemm():
+    if not sm90:
+        return False
+    try:
+        import fbgemm_gpu
+        try:
+            import fbgemm_gpu.experimental.gen_ai  # noqa: F401
+        except Exception:
+            pass
+        from packaging.version import Version
+        if Version(fbgemm_gpu.__version__) < Version("1.4.0"):
+            return False  # <=1.3.0 corrupts some shapes; unsloth gates it off
+    except Exception:
+        return False
+    return hasattr(torch.ops.fbgemm, "f8f8bf16_blockwise")
+
+
+pytestmark = pytest.mark.skipif(
+    not _has_blockwise_fbgemm(),
+    reason = "needs sm_90 CUDA and fbgemm f8f8bf16_blockwise",
+)
+
+
+def _block_quantize_weight(W, block):
+    # Per (block[0], block[1])-block absmax quantization to float8_e4m3fn.
+    n, k = W.shape
+    p, q = math.ceil(n / block[0]), math.ceil(k / block[1])
+    scale = torch.empty(p, q, device = W.device, dtype = torch.float32)
+    Wq = torch.empty(n, k, device = W.device, dtype = torch.float8_e4m3fn)
+    for i in range(p):
+        for j in range(q):
+            blk = W[i * block[0]:(i + 1) * block[0], j * block[1]:(j + 1) * block[1]].float()
+            s = blk.abs().amax() / 448.0
+            s = torch.tensor(1.0, device = W.device) if s == 0 else s
+            scale[i, j] = s
+            Wq[i * block[0]:(i + 1) * block[0], j * block[1]:(j + 1) * block[1]] = (blk / s).to(
+                torch.float8_e4m3fn
+            )
+    return Wq, scale
+
+
+def _dequant(Wq, scale, block):
+    n, k = Wq.shape
+    s = scale.repeat_interleave(block[0], 0)[:n].repeat_interleave(block[1], 1)[:, :k]
+    return Wq.to(torch.float32) * s
+
+
+def _reference(X, Wq, scale, block):
+    return (X.float() @ _dequant(Wq, scale, block).T).to(X.dtype)
+
+
+def _check_grad(X, out, Wq, scale, block):
+    # out.sum() makes grad_output all-ones, so grad_X is the row-sum of the
+    # dequantized weight; the old backward dequantized with a hardcoded
+    # 128x128 block and produced finite but mis-scaled gradients here.
+    out.sum().backward()
+    assert X.grad is not None and torch.isfinite(X.grad).all()
+    grad_ref = torch.ones(out.shape, device = out.device, dtype = torch.float32) @ _dequant(
+        Wq, scale, block
+    )
+    torch.testing.assert_close(X.grad.float(), grad_ref, atol = 5e-2, rtol = 5e-2)
+
+
+def _rel_err(out, ref):
+    return float((out.float() - ref.float()).abs().mean() / ref.float().abs().mean())
+
+
+def test_output_tile_grid_battery_matches_reference():
+    # Shapes cover both dispatch buckets' former failure zones plus safe ones.
+    # On fbgemm <=1.3.0 the failing ones returned whole outputs at ~0.7 relative
+    # error; the healthy bound (activation quant noise) sits around 0.04.
+    from unsloth.kernels.fp8 import FP8_fbgemm_block_linear
+
+    torch.manual_seed(0)
+    block = [128, 128]
+    for M, N, K in [
+        (256, 512, 384),
+        (512, 1024, 4096),
+        (640, 128, 256),
+        (128, 128, 128),
+        (256, 256, 512),
+        # ragged tails the kernel does support: any M, N % 8, K % 16
+        (100, 136, 272),
+        (64, 8, 16),
+    ]:
+        W = torch.randn(N, K, device = "cuda", dtype = torch.bfloat16)
+        Wq, scale = _block_quantize_weight(W, block)
+        scale.block_size = block
+        X = torch.randn(M, K, device = "cuda", dtype = torch.bfloat16)
+
+        out = FP8_fbgemm_block_linear.apply(X, Wq, scale)
+        ref = _reference(X, Wq, scale, block)
+        rel = _rel_err(out, ref)
+        assert rel < 0.10, f"({M},{N},{K}) rel_err={rel:.4f}"
+
+
+def test_odd_k_uses_dequant_fallback():
+    from unsloth.kernels.fp8 import FP8_fbgemm_block_linear
+
+    torch.manual_seed(0)
+    block = [128, 128]
+    N, K = 320, 130  # K % 16 != 0 used to crash inside the CUTLASS kernel
+    W = torch.randn(N, K, device = "cuda", dtype = torch.bfloat16)
+    Wq, scale = _block_quantize_weight(W, block)
+    scale.block_size = block
+    X = torch.randn(4, K, device = "cuda", dtype = torch.bfloat16, requires_grad = True)
+
+    out = FP8_fbgemm_block_linear.apply(X, Wq, scale)
+    assert torch.isfinite(out).all()
+
+    ref = _reference(X.detach(), Wq, scale, block)
+    torch.testing.assert_close(out, ref, atol = 5e-2, rtol = 5e-2)
+
+    _check_grad(X, out, Wq, scale, block)
+
+
+def test_odd_n_uses_dequant_fallback():
+    from unsloth.kernels.fp8 import FP8_fbgemm_block_linear
+
+    torch.manual_seed(0)
+    block = [128, 128]
+    N, K = 250, 256  # N % 8 != 0 used to crash inside the CUTLASS kernel
+    W = torch.randn(N, K, device = "cuda", dtype = torch.bfloat16)
+    Wq, scale = _block_quantize_weight(W, block)
+    scale.block_size = block
+    X = torch.randn(4, K, device = "cuda", dtype = torch.bfloat16, requires_grad = True)
+
+    out = FP8_fbgemm_block_linear.apply(X, Wq, scale)
+    ref = _reference(X.detach(), Wq, scale, block)
+    torch.testing.assert_close(out, ref, atol = 5e-2, rtol = 5e-2)
+
+    _check_grad(X, out, Wq, scale, block)
+
+
+def test_non_square_block_uses_dequant_fallback():
+    from unsloth.kernels.fp8 import FP8_fbgemm_block_linear
+
+    torch.manual_seed(0)
+    block = [128, 64]  # kernel only implements 128x128x128, used to crash
+    N, K = 256, 256
+    W = torch.randn(N, K, device = "cuda", dtype = torch.bfloat16)
+    Wq, scale = _block_quantize_weight(W, block)
+    scale.block_size = block
+    X = torch.randn(64, K, device = "cuda", dtype = torch.bfloat16, requires_grad = True)
+
+    out = FP8_fbgemm_block_linear.apply(X, Wq, scale)
+    ref = _reference(X.detach(), Wq, scale, block)
+    rel = _rel_err(out, ref)
+    assert rel < 0.10, f"rel_err={rel:.4f}"
+
+    _check_grad(X, out, Wq, scale, block)
+
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(pytest.main([__file__, "-q"]))

--- a/tests/test_fp8_fbgemm_block_shapes.py
+++ b/tests/test_fp8_fbgemm_block_shapes.py
@@ -28,11 +28,13 @@ def _has_blockwise_fbgemm():
         return False
     try:
         import fbgemm_gpu
+
         try:
             import fbgemm_gpu.experimental.gen_ai  # noqa: F401
         except Exception:
             pass
         from packaging.version import Version
+
         if Version(fbgemm_gpu.__version__) < Version("1.4.0"):
             return False  # <=1.3.0 corrupts some shapes; unsloth gates it off
     except Exception:
@@ -54,11 +56,11 @@ def _block_quantize_weight(W, block):
     Wq = torch.empty(n, k, device = W.device, dtype = torch.float8_e4m3fn)
     for i in range(p):
         for j in range(q):
-            blk = W[i * block[0]:(i + 1) * block[0], j * block[1]:(j + 1) * block[1]].float()
+            blk = W[i * block[0] : (i + 1) * block[0], j * block[1] : (j + 1) * block[1]].float()
             s = blk.abs().amax() / 448.0
             s = torch.tensor(1.0, device = W.device) if s == 0 else s
             scale[i, j] = s
-            Wq[i * block[0]:(i + 1) * block[0], j * block[1]:(j + 1) * block[1]] = (blk / s).to(
+            Wq[i * block[0] : (i + 1) * block[0], j * block[1] : (j + 1) * block[1]] = (blk / s).to(
                 torch.float8_e4m3fn
             )
     return Wq, scale

--- a/unsloth/kernels/fp8.py
+++ b/unsloth/kernels/fp8.py
@@ -582,9 +582,10 @@ class FP8_fbgemm_block_linear(torch.autograd.Function):
         with _fp8_triton_device_context(X):
             # X is (tokens, K): its blocks are (bs_m, bs_k), not (bs_m, bs_n).
             xq, xs = triton_quantize_fp8_block(X, bs_m, bs_k, None)
+        # f8f8bf16 always returns bf16; cast so both branches return X.dtype.
         output = torch.ops.fbgemm.f8f8bf16_blockwise(
             xq, weight.contiguous(), xs, weight_scale.contiguous(), bs_m, bs_n, bs_k
-        )
+        ).to(X.dtype)
         output = output + bias if bias is not None else output
 
         output = output.view(*orig_shape[:-1], -1)

--- a/unsloth/kernels/fp8.py
+++ b/unsloth/kernels/fp8.py
@@ -340,8 +340,8 @@ def torchao_block_matmul(
     return out.to(output_dtype)
 
 
-# fbgemm <=1.3.0 silently corrupts blockwise GEMM outputs for some output
-# shapes (fixed upstream in 1.4.0), so never use it for block FP8.
+# fbgemm <=1.3.0 silently corrupts blockwise outputs for some shapes
+# (fixed upstream in 1.4.0), so never use it for block FP8.
 # Preference: fbgemm (>=1.4.0) > torchao > triton (similar outputs/losses).
 # torchao is ~3x faster than the triton kernel but 15-30% slower than fbgemm (H100).
 fp8_block_matmul = (
@@ -540,7 +540,7 @@ class FP8_fbgemm_block_linear(torch.autograd.Function):
         bias = None,
     ):
         orig_shape = X.shape
-        X = X.reshape(-1, X.shape[-1])  # reshape, not view: X may be a strided slice
+        X = X.reshape(-1, X.shape[-1])  # reshape, not view: X may be strided
 
         bs_n, bs_k = getattr(weight, "block_size", None) or getattr(
             weight_scale, "block_size", [128, 128]
@@ -551,8 +551,7 @@ class FP8_fbgemm_block_linear(torch.autograd.Function):
             weight_scale = weight_scale.to(torch.float32)  # e8m0 scales break triton
 
         m, n = weight.shape
-        # A per-tensor scale has no block grid to check or transpose; the fallback
-        # below scales by it directly.
+        # A per-tensor scale has no block grid; the fallback scales by it directly.
         per_tensor = weight_scale.ndim != 2
         if not per_tensor:
             p, q = weight_scale.shape
@@ -566,12 +565,9 @@ class FP8_fbgemm_block_linear(torch.autograd.Function):
                         f"Weight shape {weight.shape} and scales shape {weight_scale.shape} is not compatible with block size {bs_n, bs_k}"
                     )
 
-        # f8f8bf16_blockwise raises on non-128x128x128 blocks ("Only
-        # 128x128x128 block size is supported"), on scales that are not a float32
-        # grid ("Scale tensors must be float32."), and, measured on H800 with
-        # fbgemm 1.4.0, on in_features % 16 != 0 or out_features % 8 != 0
-        # ("cutlass cannot implement"). Dequant + plain matmul for those,
-        # the same fallback FP8BlockQuantLinear uses for unevenly tiled K.
+        # f8f8bf16_blockwise takes only 128x128x128 blocks, float32 scale grids and
+        # (measured on H800 / fbgemm 1.4.0) in_features % 16 == 0, out_features % 8
+        # == 0. Anything else raises, so dequant + matmul as FP8BlockQuantLinear does.
         kernel_supported = (
             not per_tensor
             and weight_scale.dtype == torch.float32
@@ -611,8 +607,7 @@ class FP8_fbgemm_block_linear(torch.autograd.Function):
 
     @staticmethod
     def backward(ctx, grad_output):
-        # weight_dequant would fall back to its default 128x128 block here and
-        # silently mis-scale non-default block sizes; expand with the real one.
+        # weight_dequant assumes 128x128 and would mis-scale other block sizes.
         bs_m, bs_n, bs_k = ctx.block_size
         W_deq = _blockwise_weight_dequant_any_shape(
             ctx.weight, ctx.weight_scale, [bs_n, bs_k], grad_output.dtype
@@ -682,9 +677,8 @@ if "UNSLOTH_HAS_FBGEMM" not in os.environ:
 try:
     import fbgemm_gpu
 
-    # >=1.4.0 is fast and accurate (older versions silently corrupt outputs
-    # for some shapes, independent of the input values); ~15% faster
-    # than torchao. Must probe blockwise FBGEMM since consumer GPUs fail.
+    # >=1.4.0 is fast and accurate (older versions corrupt some shapes whatever the
+    # input values); ~15% faster than torchao. Probe it: consumer GPUs fail.
     if Version(fbgemm_gpu.__version__) >= Version("1.4.0"):
         # Suppress CUDA printf during probe: on Blackwell (SM100), FBGEMM's
         # SM90 CUTLASS kernel floods stdout with "Arch conditional MMA" before aborting.

--- a/unsloth/kernels/fp8.py
+++ b/unsloth/kernels/fp8.py
@@ -540,33 +540,44 @@ class FP8_fbgemm_block_linear(torch.autograd.Function):
         bias = None,
     ):
         orig_shape = X.shape
-        X = X.view(-1, X.shape[-1])
+        X = X.reshape(-1, X.shape[-1])  # reshape, not view: X may be a strided slice
 
         bs_n, bs_k = getattr(weight, "block_size", None) or getattr(
             weight_scale, "block_size", [128, 128]
         )
         bs_m = bs_n
 
-        m, n = weight.shape
-        p, q = weight_scale.shape
+        if weight_scale.dtype not in (torch.float32, torch.float16, torch.bfloat16):
+            weight_scale = weight_scale.to(torch.float32)  # e8m0 scales break triton
 
-        if triton.cdiv(m, bs_n) != p or triton.cdiv(n, bs_k) != q:
-            if triton.cdiv(m, bs_n) == q and triton.cdiv(n, bs_k) == p:
-                # Backward transposes the weight; transpose the scale to match
-                # (transposing the weight itself would break matmul with X).
-                weight_scale = weight_scale.T
-            else:
-                raise ValueError(
-                    f"Weight shape {weight.shape} and scales shape {weight_scale.shape} is not compatible with block size {bs_n, bs_k}"
-                )
+        m, n = weight.shape
+        # A per-tensor scale has no block grid to check or transpose; the fallback
+        # below scales by it directly.
+        per_tensor = weight_scale.ndim != 2
+        if not per_tensor:
+            p, q = weight_scale.shape
+            if triton.cdiv(m, bs_n) != p or triton.cdiv(n, bs_k) != q:
+                if triton.cdiv(m, bs_n) == q and triton.cdiv(n, bs_k) == p:
+                    # Backward transposes the weight; transpose the scale to match
+                    # (transposing the weight itself would break matmul with X).
+                    weight_scale = weight_scale.T
+                else:
+                    raise ValueError(
+                        f"Weight shape {weight.shape} and scales shape {weight_scale.shape} is not compatible with block size {bs_n, bs_k}"
+                    )
 
         # f8f8bf16_blockwise raises on non-128x128x128 blocks ("Only
-        # 128x128x128 block size is supported") and, measured on H800 with
+        # 128x128x128 block size is supported"), on scales that are not a float32
+        # grid ("Scale tensors must be float32."), and, measured on H800 with
         # fbgemm 1.4.0, on in_features % 16 != 0 or out_features % 8 != 0
         # ("cutlass cannot implement"). Dequant + plain matmul for those,
         # the same fallback FP8BlockQuantLinear uses for unevenly tiled K.
         kernel_supported = (
-            (bs_m, bs_n, bs_k) == (128, 128, 128) and X.shape[-1] % 16 == 0 and m % 8 == 0
+            not per_tensor
+            and weight_scale.dtype == torch.float32
+            and (bs_m, bs_n, bs_k) == (128, 128, 128)
+            and X.shape[-1] % 16 == 0
+            and m % 8 == 0
         )
         if not kernel_supported:
             W_deq = _blockwise_weight_dequant_any_shape(weight, weight_scale, [bs_n, bs_k], X.dtype)

--- a/unsloth/kernels/fp8.py
+++ b/unsloth/kernels/fp8.py
@@ -551,19 +551,24 @@ class FP8_fbgemm_block_linear(torch.autograd.Function):
             weight_scale = weight_scale.to(torch.float32)  # e8m0 scales break triton
 
         m, n = weight.shape
-        # A per-tensor scale has no block grid; the fallback scales by it directly.
-        per_tensor = weight_scale.ndim != 2
+        p, q = weight_scale.shape if weight_scale.ndim == 2 else (0, 0)
+        fits = triton.cdiv(m, bs_n) == p and triton.cdiv(n, bs_k) == q
+        # numel() == 1 like fp8_linear and the dequant helper, so a (1, 1) per-tensor
+        # scale reaches the fallback too, which scales by it directly. A (1, 1) that
+        # really is this weight's grid still fits, and stays on the block path.
+        per_tensor = weight_scale.numel() == 1 and not fits
         if not per_tensor:
-            p, q = weight_scale.shape
-            if triton.cdiv(m, bs_n) != p or triton.cdiv(n, bs_k) != q:
-                if triton.cdiv(m, bs_n) == q and triton.cdiv(n, bs_k) == p:
-                    # Backward transposes the weight; transpose the scale to match
-                    # (transposing the weight itself would break matmul with X).
-                    weight_scale = weight_scale.T
-                else:
-                    raise ValueError(
-                        f"Weight shape {weight.shape} and scales shape {weight_scale.shape} is not compatible with block size {bs_n, bs_k}"
-                    )
+            fits_transposed = triton.cdiv(n, bs_n) == p and triton.cdiv(m, bs_k) == q
+            # Backward passes W.t() (fast_lora's downW.t()), so its block axes are
+            # swapped too. Transpose the scale, not W, which X still has to matmul.
+            # Both grids fit at once when m == n, and only the stride separates them.
+            if fits_transposed and (not fits or (bs_n != bs_k and weight.stride(0) == 1)):
+                weight_scale = weight_scale.T
+                bs_n, bs_k = bs_k, bs_n
+            elif not fits:
+                raise ValueError(
+                    f"Weight shape {weight.shape} and scales shape {weight_scale.shape} is not compatible with block size {bs_n, bs_k}"
+                )
 
         # f8f8bf16_blockwise takes only 128x128x128 blocks, float32 scale grids and
         # (measured on H800 / fbgemm 1.4.0) in_features % 16 == 0, out_features % 8

--- a/unsloth/kernels/fp8.py
+++ b/unsloth/kernels/fp8.py
@@ -553,15 +553,14 @@ class FP8_fbgemm_block_linear(torch.autograd.Function):
         m, n = weight.shape
         p, q = weight_scale.shape if weight_scale.ndim == 2 else (0, 0)
         fits = triton.cdiv(m, bs_n) == p and triton.cdiv(n, bs_k) == q
-        # numel() == 1 like fp8_linear and the dequant helper, so a (1, 1) per-tensor
-        # scale reaches the fallback too, which scales by it directly. A (1, 1) that
-        # really is this weight's grid still fits, and stays on the block path.
+        # numel() == 1 like fp8_linear and the dequant helper, but a (1, 1) that really
+        # is this weight's grid still fits, so only a true per-tensor scale falls back.
         per_tensor = weight_scale.numel() == 1 and not fits
         if not per_tensor:
             fits_transposed = triton.cdiv(n, bs_n) == p and triton.cdiv(m, bs_k) == q
-            # Backward passes W.t() (fast_lora's downW.t()), so its block axes are
-            # swapped too. Transpose the scale, not W, which X still has to matmul.
-            # Both grids fit at once when m == n, and only the stride separates them.
+            # Backward passes W.t() (fast_lora's downW.t()), so its block axes swap
+            # too; at m == n only the stride tells the two grids apart. Transpose the
+            # scale, not W, which X still has to matmul.
             if fits_transposed and (not fits or (bs_n != bs_k and weight.stride(0) == 1)):
                 weight_scale = weight_scale.T
                 bs_n, bs_k = bs_k, bs_n

--- a/unsloth/kernels/fp8.py
+++ b/unsloth/kernels/fp8.py
@@ -340,7 +340,8 @@ def torchao_block_matmul(
     return out.to(output_dtype)
 
 
-# fbgemm <=1.3.0 causes NaNs for high X values, so never use it for block FP8.
+# fbgemm <=1.3.0 silently corrupts blockwise GEMM outputs for some output
+# shapes (fixed upstream in 1.4.0), so never use it for block FP8.
 # Preference: fbgemm (>=1.4.0) > torchao > triton (similar outputs/losses).
 # torchao is ~3x faster than the triton kernel but 15-30% slower than fbgemm (H100).
 fp8_block_matmul = (
@@ -559,11 +560,32 @@ class FP8_fbgemm_block_linear(torch.autograd.Function):
                     f"Weight shape {weight.shape} and scales shape {weight_scale.shape} is not compatible with block size {bs_n, bs_k}"
                 )
 
+        # f8f8bf16_blockwise raises on non-128x128x128 blocks ("Only
+        # 128x128x128 block size is supported") and, measured on H800 with
+        # fbgemm 1.4.0, on in_features % 16 != 0 or out_features % 8 != 0
+        # ("cutlass cannot implement"). Dequant + plain matmul for those,
+        # the same fallback FP8BlockQuantLinear uses for unevenly tiled K.
+        kernel_supported = (
+            (bs_m, bs_n, bs_k) == (128, 128, 128)
+            and X.shape[-1] % 16 == 0
+            and m % 8 == 0
+        )
+        if not kernel_supported:
+            W_deq = _blockwise_weight_dequant_any_shape(
+                weight, weight_scale, [bs_n, bs_k], X.dtype
+            )
+            output = torch_matmul(X, W_deq.T)
+            output = output + bias if bias is not None else output
+            output = output.view(*orig_shape[:-1], -1)
+            del W_deq
+            ctx.weight = weight
+            ctx.weight_scale = weight_scale
+            ctx.block_size = [bs_m, bs_n, bs_k]
+            return output
+
         with _fp8_triton_device_context(X):
-            xq, xs = triton_quantize_fp8_block(X, bs_m, bs_n, None)
-        # TODO: WARNING - diverges from baseline for high X values, producing
-        # gibberish / high starting loss. Do not use until resolved; kept for a
-        # future headstart.
+            # X is (tokens, K): its blocks are (bs_m, bs_k), not (bs_m, bs_n).
+            xq, xs = triton_quantize_fp8_block(X, bs_m, bs_k, None)
         output = torch.ops.fbgemm.f8f8bf16_blockwise(
             xq, weight.contiguous(), xs, weight_scale.contiguous(), bs_m, bs_n, bs_k
         )
@@ -581,7 +603,12 @@ class FP8_fbgemm_block_linear(torch.autograd.Function):
 
     @staticmethod
     def backward(ctx, grad_output):
-        W_deq = weight_dequant(ctx.weight, ctx.weight_scale)
+        # weight_dequant would fall back to its default 128x128 block here and
+        # silently mis-scale non-default block sizes; expand with the real one.
+        bs_m, bs_n, bs_k = ctx.block_size
+        W_deq = _blockwise_weight_dequant_any_shape(
+            ctx.weight, ctx.weight_scale, [bs_n, bs_k], grad_output.dtype
+        )
         grad_X = torch_matmul(grad_output, W_deq)
         del W_deq
         return grad_X, None, None, None, None
@@ -647,7 +674,8 @@ if "UNSLOTH_HAS_FBGEMM" not in os.environ:
 try:
     import fbgemm_gpu
 
-    # >=1.4.0 is fast and accurate (older versions NaN on high X); ~15% faster
+    # >=1.4.0 is fast and accurate (older versions silently corrupt outputs
+    # for some shapes, independent of the input values); ~15% faster
     # than torchao. Must probe blockwise FBGEMM since consumer GPUs fail.
     if Version(fbgemm_gpu.__version__) >= Version("1.4.0"):
         # Suppress CUDA printf during probe: on Blackwell (SM100), FBGEMM's

--- a/unsloth/kernels/fp8.py
+++ b/unsloth/kernels/fp8.py
@@ -566,14 +566,10 @@ class FP8_fbgemm_block_linear(torch.autograd.Function):
         # ("cutlass cannot implement"). Dequant + plain matmul for those,
         # the same fallback FP8BlockQuantLinear uses for unevenly tiled K.
         kernel_supported = (
-            (bs_m, bs_n, bs_k) == (128, 128, 128)
-            and X.shape[-1] % 16 == 0
-            and m % 8 == 0
+            (bs_m, bs_n, bs_k) == (128, 128, 128) and X.shape[-1] % 16 == 0 and m % 8 == 0
         )
         if not kernel_supported:
-            W_deq = _blockwise_weight_dequant_any_shape(
-                weight, weight_scale, [bs_n, bs_k], X.dtype
-            )
+            W_deq = _blockwise_weight_dequant_any_shape(weight, weight_scale, [bs_n, bs_k], X.dtype)
             output = torch_matmul(X, W_deq.T)
             output = output + bias if bias is not None else output
             output = output.view(*orig_shape[:-1], -1)


### PR DESCRIPTION
fbgemm's f8f8bf16_blockwise kernel only accepts 128x128x128 blocks and raises "only 128x128x128 block size is supported" on anything else. On H800 with fbgemm-gpu-genai `1.4.0` it also raises "cutlass cannot implement" when in_features is unaligned to 16 or out_features is unaligned to 8. A Linear with such a shape crashes at runtime once the fbgemm path is picked.

This PR routes those shapes to the dequant + matmul fallback that FP8BlockQuantLinear already uses for unevenly tiled K.

The fallback lets layers with other block sizes reach backward for the first time. Backward dequantized the weight through weight_dequant, which assumes 128x128 blocks and would mis-scale their gradients, so it now expands the scales with the layer's actual block size.
The activation quantizer was also called with bs_n as its block width; activations tile along K, so it now gets bs_k. On supported shapes outputs are bitwise identical to main.

Also rewrote the stale comments: the old divergence was a shape-dependent bug in the blockwise kernel of fbgemm `1.3.0` and older, fixed upstream in `1.4.0` by pytorch/FBGEMM#5002, which matches the version gate already in place.

Added tests/test_fp8_fbgemm_block_shapes.py. It needs sm_90 and
fbgemm-gpu-genai 1.4.0 or newer, and skips otherwise. The odd-shape tests
crash on main and pass with this patch, with gradients checked against a
reference dequant. Existing fp8 tests pass unchanged. Validated on an H800.