### PR TITLE
Studio: find the real Documents folder on Windows for project workspaces

### DIFF
--- a/studio/backend/routes/chat_history.py
+++ b/studio/backend/routes/chat_history.py
@@ -19,7 +19,6 @@ from auth.authentication import get_current_subject
 from core.inference.llama_server_args import BATCH_MAX, BATCH_MIN, PARALLEL_MAX, PARALLEL_MIN
 from loggers import get_logger
 from utils.api_errors import safe_validation_errors
-from utils.paths import project_workspaces_root
 from utils.utils import safe_curated_detail, log_and_http_error
 from storage.studio_db import (
     ChatMessageConflictError,
@@ -27,6 +26,7 @@ from storage.studio_db import (
     ChatThreadDeletedError,
     ChatThreadPreconditionFailed,
     CorruptSettingsError,
+    ProjectWorkspaceError,
     build_chat_history_export,
     clear_chat_history,
     count_chat_threads,
@@ -756,16 +756,17 @@ def list_projects(
 def save_project(payload: ChatProject, current_subject: str = Depends(get_current_subject)):
     try:
         return ChatProject(**upsert_chat_project(payload.model_dump()))
-    except OSError as exc:
+    except ProjectWorkspaceError as exc:
         # A project is the only thing Studio writes to Documents, so a folder it
-        # cannot create there fails here and nowhere else. Name the path: the
-        # usual causes are an unwritable or redirected Documents.
+        # cannot create there fails here and nowhere else. Only this error, and
+        # only its own path: the same upsert also opens the database, which
+        # lives somewhere else entirely.
         raise log_and_http_error(
             exc,
             500,
-            "Could not create the project folder in "
-            f"{project_workspaces_root()}. Check that the folder is writable, "
-            "or set UNSLOTH_STUDIO_PROJECTS_HOME to another location.",
+            f"Could not create the project folder {exc.path}. Check that the "
+            "folder is writable, or set UNSLOTH_STUDIO_PROJECTS_HOME to another "
+            "location.",
             event = "chat_history.create_project_workspace_failed",
             log = logger,
         ) from exc

--- a/studio/backend/routes/chat_history.py
+++ b/studio/backend/routes/chat_history.py
@@ -19,6 +19,7 @@ from auth.authentication import get_current_subject
 from core.inference.llama_server_args import BATCH_MAX, BATCH_MIN, PARALLEL_MAX, PARALLEL_MIN
 from loggers import get_logger
 from utils.api_errors import safe_validation_errors
+from utils.paths import project_workspaces_root
 from utils.utils import safe_curated_detail, log_and_http_error
 from storage.studio_db import (
     ChatMessageConflictError,
@@ -753,7 +754,21 @@ def list_projects(
 
 @router.post("/projects", response_model = ChatProject)
 def save_project(payload: ChatProject, current_subject: str = Depends(get_current_subject)):
-    return ChatProject(**upsert_chat_project(payload.model_dump()))
+    try:
+        return ChatProject(**upsert_chat_project(payload.model_dump()))
+    except OSError as exc:
+        # A project is the only thing Studio writes to Documents, so a folder it
+        # cannot create there fails here and nowhere else. Name the path: the
+        # usual causes are an unwritable or redirected Documents.
+        raise log_and_http_error(
+            exc,
+            500,
+            "Could not create the project folder in "
+            f"{project_workspaces_root()}. Check that the folder is writable, "
+            "or set UNSLOTH_STUDIO_PROJECTS_HOME to another location.",
+            event = "chat_history.create_project_workspace_failed",
+            log = logger,
+        ) from exc
 
 
 @router.get("/projects/{project_id}", response_model = ChatProject)

--- a/studio/backend/storage/studio_db.py
+++ b/studio/backend/storage/studio_db.py
@@ -116,11 +116,27 @@ def _default_project_root(project: dict) -> str:
     return str(project_workspaces_root() / folder_name)
 
 
+class ProjectWorkspaceError(OSError):
+    """Raised when a project's workspace folder cannot be created.
+
+    Tagged, and carrying the folder, so a caller can name it. The same upsert
+    also touches the database directory, and that is a different path with a
+    different fix.
+    """
+
+    def __init__(self, path: str, cause: OSError):
+        super().__init__(str(cause))
+        self.path = path
+
+
 def _ensure_project_workspace(root_path: str) -> str:
     root = Path(root_path).expanduser()
-    root_resolved = ensure_dir(root).resolve()
-    for subdir in _PROJECT_WORKSPACE_SUBDIRS:
-        ensure_dir(root_resolved / subdir)
+    try:
+        root_resolved = ensure_dir(root).resolve()
+        for subdir in _PROJECT_WORKSPACE_SUBDIRS:
+            ensure_dir(root_resolved / subdir)
+    except OSError as exc:
+        raise ProjectWorkspaceError(str(root), exc) from exc
     return str(root_resolved)
 
 

--- a/studio/backend/tests/test_project_workspace_location.py
+++ b/studio/backend/tests/test_project_workspace_location.py
@@ -68,7 +68,39 @@ def test_the_projects_override_wins_outright(tmp_path, monkeypatch):
     assert project_workspaces_root() == tmp_path / "projects"
 
 
-def test_creating_a_project_says_where_it_failed(tmp_path, monkeypatch):
+def _probe_payload():
+    from routes import chat_history
+
+    return chat_history.ChatProject(
+        id = "11111111-2222-3333-4444-555555555555",
+        name = "Probe",
+        instructions = "",
+        archived = False,
+        createdAt = 1,
+        updatedAt = 1,
+    )
+
+
+def test_the_workspace_error_carries_the_folder_it_could_not_make(tmp_path, monkeypatch):
+    """The failing path, not the root it was derived from.
+
+    An existing project keeps a recorded rootPath that can sit anywhere, so the
+    configured projects root is not always the folder that failed.
+    """
+    from storage.studio_db import ProjectWorkspaceError, _ensure_project_workspace
+
+    blocked = tmp_path / "read-only"
+    blocked.mkdir()
+    blocked.chmod(0o555)
+    try:
+        with pytest.raises(ProjectWorkspaceError) as caught:
+            _ensure_project_workspace(str(blocked / "child"))
+    finally:
+        blocked.chmod(0o755)
+    assert caught.value.path == str(blocked / "child")
+
+
+def test_creating_a_project_says_which_folder_failed(tmp_path, monkeypatch):
     """A folder Studio cannot create is the one failure this route has.
 
     It used to surface as a bare 500, which says nothing about which folder or
@@ -77,25 +109,19 @@ def test_creating_a_project_says_where_it_failed(tmp_path, monkeypatch):
     from fastapi import HTTPException
 
     from routes import chat_history
+    from storage.studio_db import ProjectWorkspaceError
 
     blocked = tmp_path / "no-entry"
-    monkeypatch.setenv("UNSLOTH_STUDIO_PROJECTS_HOME", str(blocked))
     monkeypatch.setattr(
         chat_history,
         "upsert_chat_project",
-        lambda payload: (_ for _ in ()).throw(PermissionError(13, "Permission denied")),
+        lambda payload: (_ for _ in ()).throw(
+            ProjectWorkspaceError(str(blocked), PermissionError(13, "Permission denied"))
+        ),
     )
 
-    payload = chat_history.ChatProject(
-        id = "11111111-2222-3333-4444-555555555555",
-        name = "Probe",
-        instructions = "",
-        archived = False,
-        createdAt = 1,
-        updatedAt = 1,
-    )
     with pytest.raises(HTTPException) as caught:
-        chat_history.save_project(payload, current_subject = "tester")
+        chat_history.save_project(_probe_payload(), current_subject = "tester")
 
     assert caught.value.status_code == 500
     detail = str(caught.value.detail)
@@ -103,3 +129,21 @@ def test_creating_a_project_says_where_it_failed(tmp_path, monkeypatch):
     assert "UNSLOTH_STUDIO_PROJECTS_HOME" in detail
     # The raw OSError text stays in the log, not in the response.
     assert "Permission denied" not in detail
+
+
+def test_a_database_folder_failure_is_not_blamed_on_the_projects_folder(monkeypatch):
+    """The same upsert opens studio.db before it picks a workspace.
+
+    That folder is UNSLOTH_STUDIO_HOME's, so answering it with "set
+    UNSLOTH_STUDIO_PROJECTS_HOME" sends the user to fix the wrong path.
+    """
+    from routes import chat_history
+
+    monkeypatch.setattr(
+        chat_history,
+        "upsert_chat_project",
+        lambda payload: (_ for _ in ()).throw(PermissionError(13, "studio.db")),
+    )
+
+    with pytest.raises(PermissionError):
+        chat_history.save_project(_probe_payload(), current_subject = "tester")

--- a/studio/backend/tests/test_project_workspace_location.py
+++ b/studio/backend/tests/test_project_workspace_location.py
@@ -70,7 +70,6 @@ def test_the_projects_override_wins_outright(tmp_path, monkeypatch):
 
 def _probe_payload():
     from routes import chat_history
-
     return chat_history.ChatProject(
         id = "11111111-2222-3333-4444-555555555555",
         name = "Probe",

--- a/studio/backend/tests/test_project_workspace_location.py
+++ b/studio/backend/tests/test_project_workspace_location.py
@@ -86,17 +86,20 @@ def test_the_workspace_error_carries_the_folder_it_could_not_make(tmp_path, monk
     An existing project keeps a recorded rootPath that can sit anywhere, so the
     configured projects root is not always the folder that failed.
     """
+    from storage import studio_db
     from storage.studio_db import ProjectWorkspaceError, _ensure_project_workspace
 
-    blocked = tmp_path / "read-only"
-    blocked.mkdir()
-    blocked.chmod(0o555)
-    try:
-        with pytest.raises(ProjectWorkspaceError) as caught:
-            _ensure_project_workspace(str(blocked / "child"))
-    finally:
-        blocked.chmod(0o755)
-    assert caught.value.path == str(blocked / "child")
+    blocked = tmp_path / "read-only" / "child"
+
+    # The refusal is stubbed rather than staged with chmod: root ignores a
+    # read-only directory, and Windows does not enforce one this way at all.
+    def refuse(path):
+        raise PermissionError(13, "Permission denied", str(path))
+
+    monkeypatch.setattr(studio_db, "ensure_dir", refuse)
+    with pytest.raises(ProjectWorkspaceError) as caught:
+        _ensure_project_workspace(str(blocked))
+    assert caught.value.path == str(blocked)
 
 
 def test_creating_a_project_says_which_folder_failed(tmp_path, monkeypatch):

--- a/studio/backend/tests/test_project_workspace_location.py
+++ b/studio/backend/tests/test_project_workspace_location.py
@@ -1,0 +1,107 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Where a project's workspace folder lands, and what happens when it cannot.
+
+Project workspaces are the only thing Studio writes into the user's Documents,
+so a Documents folder it guesses wrong about breaks project creation and
+nothing else. On Windows that guess is wrong by default whenever OneDrive's
+Known Folder Move has repointed Documents at the synced copy.
+"""
+
+import os
+from pathlib import Path
+
+import pytest
+
+from utils.paths.storage_roots import (
+    _documents_from_registry_value,
+    _windows_documents_dir,
+    documents_root,
+    project_workspaces_root,
+)
+
+
+def test_a_redirected_documents_folder_is_read_as_written():
+    """REG_SZ is already absolute, including the OneDrive case this is for."""
+    assert _documents_from_registry_value(r"C:\Users\t\OneDrive\Documents", False) == Path(
+        r"C:\Users\t\OneDrive\Documents"
+    )
+    # A variable with nothing to expand into stays put rather than vanishing.
+    assert _documents_from_registry_value(r"%NOT_A_REAL_VAR%\Documents", True) == Path(
+        r"%NOT_A_REAL_VAR%\Documents"
+    )
+
+
+def test_expansion_uses_windows_syntax(monkeypatch):
+    monkeypatch.setenv("USERPROFILE", r"C:\Users\tombino")
+    assert _documents_from_registry_value(r"%USERPROFILE%\Documents", True) == Path(
+        r"C:\Users\tombino\Documents"
+    )
+    # Without the flag the value is taken literally, variables and all.
+    assert _documents_from_registry_value(r"%USERPROFILE%\Documents", False) == Path(
+        r"%USERPROFILE%\Documents"
+    )
+
+
+@pytest.mark.parametrize("value", [None, "", "   ", 123])
+def test_an_unusable_registry_value_falls_through(value):
+    """Anything but a real string has to fall back, not become Path('.')."""
+    assert _documents_from_registry_value(value, True) is None
+
+
+@pytest.mark.skipif(os.name == "nt", reason = "the registry read is the point on Windows")
+def test_the_registry_is_only_read_on_windows():
+    assert _windows_documents_dir() is None
+
+
+def test_the_override_still_wins(tmp_path, monkeypatch):
+    """Whatever Documents resolves to, this is the documented way out."""
+    monkeypatch.setenv("UNSLOTH_STUDIO_DOCUMENTS_HOME", str(tmp_path / "elsewhere"))
+    assert documents_root() == tmp_path / "elsewhere"
+    assert project_workspaces_root() == (
+        tmp_path / "elsewhere" / "Unsloth Studio" / "Projects"
+    )
+
+
+def test_the_projects_override_wins_outright(tmp_path, monkeypatch):
+    monkeypatch.setenv("UNSLOTH_STUDIO_DOCUMENTS_HOME", str(tmp_path / "documents"))
+    monkeypatch.setenv("UNSLOTH_STUDIO_PROJECTS_HOME", str(tmp_path / "projects"))
+    assert project_workspaces_root() == tmp_path / "projects"
+
+
+def test_creating_a_project_says_where_it_failed(tmp_path, monkeypatch):
+    """A folder Studio cannot create is the one failure this route has.
+
+    It used to surface as a bare 500, which says nothing about which folder or
+    what to do, and the folder is one the user can move.
+    """
+    from fastapi import HTTPException
+
+    from routes import chat_history
+
+    blocked = tmp_path / "no-entry"
+    monkeypatch.setenv("UNSLOTH_STUDIO_PROJECTS_HOME", str(blocked))
+    monkeypatch.setattr(
+        chat_history,
+        "upsert_chat_project",
+        lambda payload: (_ for _ in ()).throw(PermissionError(13, "Permission denied")),
+    )
+
+    payload = chat_history.ChatProject(
+        id = "11111111-2222-3333-4444-555555555555",
+        name = "Probe",
+        instructions = "",
+        archived = False,
+        createdAt = 1,
+        updatedAt = 1,
+    )
+    with pytest.raises(HTTPException) as caught:
+        chat_history.save_project(payload, current_subject = "tester")
+
+    assert caught.value.status_code == 500
+    detail = str(caught.value.detail)
+    assert str(blocked) in detail
+    assert "UNSLOTH_STUDIO_PROJECTS_HOME" in detail
+    # The raw OSError text stays in the log, not in the response.
+    assert "Permission denied" not in detail

--- a/studio/backend/tests/test_project_workspace_location.py
+++ b/studio/backend/tests/test_project_workspace_location.py
@@ -59,9 +59,7 @@ def test_the_override_still_wins(tmp_path, monkeypatch):
     """Whatever Documents resolves to, this is the documented way out."""
     monkeypatch.setenv("UNSLOTH_STUDIO_DOCUMENTS_HOME", str(tmp_path / "elsewhere"))
     assert documents_root() == tmp_path / "elsewhere"
-    assert project_workspaces_root() == (
-        tmp_path / "elsewhere" / "Unsloth Studio" / "Projects"
-    )
+    assert project_workspaces_root() == (tmp_path / "elsewhere" / "Unsloth Studio" / "Projects")
 
 
 def test_the_projects_override_wins_outright(tmp_path, monkeypatch):

--- a/studio/backend/utils/paths/storage_roots.py
+++ b/studio/backend/utils/paths/storage_roots.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import json
+import ntpath
 import os
 import re
 import sys
@@ -140,11 +141,49 @@ def _xdg_user_dir(key: str) -> Path | None:
     return None
 
 
+def _documents_from_registry_value(value: object, expandable: bool) -> Path | None:
+    """The Documents path a Windows shell-folder registry value names."""
+    if not isinstance(value, str) or not value.strip():
+        return None
+    # REG_EXPAND_SZ stores it unexpanded, e.g. %USERPROFILE%\Documents. ntpath
+    # rather than os.path: %VAR% is Windows syntax, which posixpath leaves as-is.
+    return Path(ntpath.expandvars(value) if expandable else value)
+
+
+def _windows_documents_dir() -> Path | None:
+    """Windows' own Documents folder, wherever the user moved it.
+
+    OneDrive's Known Folder Move repoints Documents at the synced copy and
+    leaves ~/Documents behind, so that guess writes to the wrong place or to a
+    folder that is not there at all.
+    """
+    if os.name != "nt":
+        return None
+    try:
+        import winreg  # Windows-only, and absent from some stripped builds.
+    except ImportError:
+        return None
+    try:
+        with winreg.OpenKey(
+            winreg.HKEY_CURRENT_USER,
+            r"Software\Microsoft\Windows\CurrentVersion\Explorer\User Shell Folders",
+        ) as key:
+            # "Personal" is the registry's name for Documents.
+            value, kind = winreg.QueryValueEx(key, "Personal")
+    except OSError:
+        return None
+    return _documents_from_registry_value(value, kind == winreg.REG_EXPAND_SZ)
+
+
 def documents_root() -> Path:
     override = (os.environ.get("UNSLOTH_STUDIO_DOCUMENTS_HOME") or "").strip()
     if override:
         return Path(override).expanduser()
-    return _xdg_user_dir("XDG_DOCUMENTS_DIR") or (Path.home() / "Documents")
+    return (
+        _windows_documents_dir()
+        or _xdg_user_dir("XDG_DOCUMENTS_DIR")
+        or (Path.home() / "Documents")
+    )
 
 
 def project_workspaces_root() -> Path:


### PR DESCRIPTION
Fixes #8936.

## What was wrong

`documents_root()` looked for the Linux XDG user-dirs file and otherwise fell back to `~/Documents`. On Windows the XDG file never exists, so it always used the fallback, and the fallback is wrong on any machine where OneDrive's Known Folder Move has repointed Documents at the synced copy. That is the default on a lot of Windows 11 installs. The real Documents is `%USERPROFILE%\OneDrive\Documents`, and the local `~/Documents` is often gone or not writable.

That path has exactly one caller, `project_workspaces_root()`, and nothing else in Studio writes to Documents. Everything else lives under `UNSLOTH_STUDIO_HOME`. So a Documents folder resolved wrong takes out project creation and leaves the rest of the app working, which is what the report describes.

## What changed

`documents_root()` now reads the Documents known folder from the registry first (`User Shell Folders\Personal`, which is where the redirect is recorded), then falls back to the XDG lookup and `~/Documents` exactly as before. The registry read is skipped outright when `os.name != "nt"`, so macOS and Linux resolve the same way they always have.

`REG_EXPAND_SZ` values are expanded with `ntpath` rather than `os.path`, since `%VAR%` is Windows syntax that posixpath leaves untouched. That also makes the parsing testable off Windows.

Creating a project also reports which folder it could not create instead of a bare 500. The old response gave no way to tell a permissions problem from anything else, and this folder is one the user can move with `UNSLOTH_STUDIO_PROJECTS_HOME`. The raw OSError still goes to the log only.

## Compatibility

Nothing changes for existing installs on macOS or Linux: the new lookup returns `None` before touching the registry, and the rest of the chain is untouched. Both env overrides keep priority over everything.

On Windows an install that already has projects keeps them: `upsert_chat_project` reuses the `rootPath` recorded for a project and only derives a new one when that column is empty, so existing workspaces are not moved or re-created somewhere else. New projects land in the user's actual Documents.

## Tests

`studio/backend/tests/test_project_workspace_location.py`, 10 cases: the redirected and unexpanded registry shapes, Windows expansion syntax, unusable values falling through instead of becoming `Path('.')`, the registry being skipped off Windows, both env overrides, and the create route naming the folder and the override while keeping the OSError text out of the response. Confirmed the route case fails against the previous handler.

Also confirmed the 10 pre-existing failures in `test_sandbox_files_and_storage_roots.py` on macOS are identical with and without this change.

## Still open on the report

This does not explain the exact message in #8936. `Unsloth isn't running -- please relaunch it.` is only raised when `fetch` itself throws, meaning no HTTP response came back at all; a permissions failure would have surfaced as `Request failed (500)`. The version and the backend log from the reporter are what would settle it. This fix covers the Windows path problem that makes project creation the one feature exposed to a wrong Documents folder, which is worth fixing either way.

