### PR TITLE
Make the packed-boundary guard reachable on the fused cross-entropy path

### DIFF
--- a/tests/utils/test_packing.py
+++ b/tests/utils/test_packing.py
@@ -1441,44 +1441,6 @@ def test_mask_packed_boundary_labels_lengths_covering_whole_row():
     assert out.reshape(-1).tolist() == [-100, 1, -100, 3]
 
 
-def test_enable_sample_packing_masks_boundary_labels():
-    model = _DummyModel()
-    trainer = _DummyTrainer()
-    enable_sample_packing(model, trainer)
-
-    batch = trainer.data_collator.torch_call(
-        [
-            {"input_ids": [0, 1, 2], "labels": [0, 1, 2], "seq_lengths": [2, 1]},
-            {"input_ids": [3, 4, 5], "labels": [3, 4, 5], "seq_lengths": [3]},
-        ]
-    )
-    flat = batch["labels"].reshape(-1)[:6].tolist()
-    # docs [0,1] [2] [3,4,5] -> boundary slots 2 and 3
-    assert flat[2] == -100 and flat[3] == -100
-    assert flat[1] != -100 and flat[4] != -100 and flat[5] != -100
-
-
-def test_enable_padding_free_metadata_masks_boundary_labels():
-    model = _DummyModel()
-    trainer = SimpleNamespace(
-        args = SimpleNamespace(remove_unused_columns = True),
-        data_collator = _PaddingFreeCollator(),
-    )
-    enable_padding_free_metadata(model, trainer)
-
-    batch = trainer.data_collator.torch_call(
-        [
-            {"input_ids": [0, 1, 2], "labels": [0, 1, 2]},
-            {"input_ids": [3, 4], "labels": [3, 4]},
-        ]
-    )
-    if batch.get("labels") is None:
-        pytest.skip("collator stub does not emit labels")
-    flat = batch["labels"].reshape(-1)[:5].tolist()
-    assert flat[3] == -100
-    assert flat[1] != -100 and flat[2] != -100 and flat[4] != -100
-
-
 # ==========================================================================
 # Each test below fails when its production hunk is reverted.
 # 1 + 2. the two fused-CE call sites (llama.py / mistral.py)
@@ -1564,10 +1526,11 @@ def test_fused_ce_branch_masks_packed_boundaries(monkeypatch, module_name):
     assert labels.reshape(-1).tolist() == list(range(seq))
 
 
-# 3. enable_sample_packing collator hunk
+# 3. the collator wrappers must leave the boundary targets in place, because
+#    unsloth_zoo counts num_items_in_batch off this batch and already deducts them
 class _UnmaskedPackingCollator:
-    """A padding-free collator that does NOT pre-mask boundaries, unlike TRL's own -
-    a test built on TRL's would pass with or without the wrapper."""
+    """A padding-free collator that does NOT pre-mask boundaries, like TRL < 0.24 -
+    a test built on TRL 0.24+ output would pass either way."""
 
     def __init__(self):
         self.padding_free = True
@@ -1581,13 +1544,23 @@ class _UnmaskedPackingCollator:
         }
 
 
-def test_enable_sample_packing_masks_boundaries_a_collator_left_open():
+def _zoo_num_items_in_batch(batch):
+    """The count unsloth_zoo._unsloth_get_batch_samples derives from a batch."""
+    count = int((batch["labels"][..., 1:] != -100).sum())
+    lengths = batch.get("packed_seq_lengths")
+    if lengths is not None:
+        count -= int(torch.count_nonzero(lengths > 0)) - 1
+    return count
+
+
+@pytest.mark.parametrize("wrapper", [enable_sample_packing, enable_padding_free_metadata])
+def test_collator_keeps_boundary_targets_for_the_num_items_deduction(wrapper):
     model = SimpleNamespace(max_seq_length = 16, children = lambda: [])
     trainer = SimpleNamespace(
         args = SimpleNamespace(remove_unused_columns = True),
         data_collator = _UnmaskedPackingCollator(),
     )
-    enable_sample_packing(model, trainer)
+    wrapper(model, trainer)
 
     batch = trainer.data_collator.torch_call(
         [
@@ -1595,26 +1568,9 @@ def test_enable_sample_packing_masks_boundaries_a_collator_left_open():
             {"input_ids": [13, 14, 15], "seq_lengths": [3]},
         ]
     )
-    # docs [10,11] [12] [13,14,15] -> boundary slots 2 and 3
-    assert batch["labels"].reshape(-1).tolist() == [-100, 11, -100, -100, 14, 15]
-
-
-def test_enable_padding_free_metadata_masks_boundaries_a_collator_left_open():
-    model = SimpleNamespace(max_seq_length = 16, children = lambda: [])
-    trainer = SimpleNamespace(
-        args = SimpleNamespace(remove_unused_columns = True),
-        data_collator = _UnmaskedPackingCollator(),
-    )
-    enable_padding_free_metadata(model, trainer)
-
-    batch = trainer.data_collator.torch_call(
-        [
-            {"input_ids": [10, 11, 12]},
-            {"input_ids": [13, 14]},
-        ]
-    )
-    # two flattened examples -> boundary slot 3
-    assert batch["labels"].reshape(-1).tolist() == [-100, 11, 12, -100, 14]
+    assert batch["labels"].reshape(-1).tolist() == [10, 11, 12, 13, 14, 15]
+    # docs [10,11] [12] [13,14,15] -> 1 + 0 + 2 real cross-entropy targets
+    assert _zoo_num_items_in_batch(batch) == 3
 
 
 # 4. idempotence, discriminating (an identity helper must not pass)

--- a/tests/utils/test_packing.py
+++ b/tests/utils/test_packing.py
@@ -1426,9 +1426,7 @@ def test_mask_packed_boundary_labels_is_idempotent_on_trl_masked_labels():
 def test_mask_packed_boundary_labels_is_a_noop_without_packing():
     labels = torch.arange(6, dtype = torch.long).view(1, 6)
     assert mask_packed_boundary_labels(labels, None) is labels
-    assert mask_packed_boundary_labels(
-        labels, torch.tensor([], dtype = torch.int32)
-    ) is labels
+    assert mask_packed_boundary_labels(labels, torch.tensor([], dtype = torch.int32)) is labels
     assert mask_packed_boundary_labels(None, torch.tensor([2, 4])) is None
 
 

--- a/tests/utils/test_packing.py
+++ b/tests/utils/test_packing.py
@@ -22,6 +22,7 @@ from unsloth.utils.packing import (
     configure_sample_packing,
     enable_padding_free_metadata,
     enable_sample_packing,
+    mask_packed_boundary_labels,
     mask_packed_sequence_boundaries,
     patch_hybrid_linear_attention_varlen,
 )
@@ -1364,3 +1365,121 @@ def test_packing_skip_warning_keeps_custom_collator_reason(monkeypatch, caplog):
     assert len(messages) == 1
     assert "custom data collator" in messages[0]
     assert "UNSLOTH_RETURN_LOGITS" not in messages[0]
+
+
+# --- packed-boundary guard on the fused-CE path ---------------------------------------
+# mask_packed_sequence_boundaries only works on already-shifted labels, so it can never
+# be used by a loss path that shifts internally (every fused-CE path). These cover
+# mask_packed_boundary_labels, the pre-shift equivalent that the fused branch calls.
+
+
+def test_mask_packed_boundary_labels_masks_next_document_first_token():
+    labels = torch.arange(6, dtype = torch.long).view(1, 6)
+    out = mask_packed_boundary_labels(labels, torch.tensor([2, 1, 3], dtype = torch.int32))
+    # Documents start at 0, 2, 3; the FIRST token of documents 2 and 3 is what the
+    # previous document would otherwise be trained to predict. Slot 0 is also -100:
+    # the final cumulative sum lands out of range and is redirected there, which is a
+    # no-op because the shift discards labels[0] - and it matches TRL, whose
+    # `labels[position_ids == 0] = -100` masks slot 0 too.
+    assert out.reshape(-1).tolist() == [-100, 1, -100, -100, 4, 5]
+    # out-of-place: the caller's batch tensor is untouched
+    assert labels.reshape(-1).tolist() == [0, 1, 2, 3, 4, 5]
+    assert out.shape == labels.shape
+    assert out.dtype == labels.dtype
+
+
+def test_mask_packed_boundary_labels_matches_the_shifted_guard():
+    """The two entry points must mask exactly the same CE targets."""
+    labels = torch.arange(100, 112, dtype = torch.long).view(1, 12)
+    lengths = torch.tensor([5, 4, 3], dtype = torch.int32)
+
+    # Route A: shift first, then the original in-place guard.
+    shift_a = torch.empty_like(labels)
+    shift_a[..., :-1] = labels[..., 1:]
+    shift_a[..., -1] = -100
+    mask_packed_sequence_boundaries(shift_a, lengths)
+
+    # Route B: the new guard on raw labels, shifted afterwards (what fused CE does).
+    masked = mask_packed_boundary_labels(labels, lengths)
+    shift_b = torch.empty_like(masked)
+    shift_b[..., :-1] = masked[..., 1:]
+    shift_b[..., -1] = -100
+
+    assert torch.equal(shift_a, shift_b)
+
+
+def test_mask_packed_boundary_labels_is_idempotent_on_trl_masked_labels():
+    """TRL's collator already sets labels[position_ids == 0] = -100, so applying the
+    guard on top of TRL output must return the identical values."""
+    lengths = torch.tensor([2, 1, 3], dtype = torch.int32)
+    labels = torch.arange(6, dtype = torch.long).view(1, 6)
+    position_ids = torch.tensor([[0, 1, 0, 0, 1, 2]], dtype = torch.long)
+    trl_labels = labels.clone()
+    trl_labels[position_ids == 0] = -100
+
+    once = mask_packed_boundary_labels(trl_labels, lengths)
+    twice = mask_packed_boundary_labels(once, lengths)
+    assert torch.equal(once, trl_labels)
+    assert torch.equal(twice, once)
+
+
+def test_mask_packed_boundary_labels_is_a_noop_without_packing():
+    labels = torch.arange(6, dtype = torch.long).view(1, 6)
+    assert mask_packed_boundary_labels(labels, None) is labels
+    assert mask_packed_boundary_labels(
+        labels, torch.tensor([], dtype = torch.int32)
+    ) is labels
+    assert mask_packed_boundary_labels(None, torch.tensor([2, 4])) is None
+
+
+def test_mask_packed_boundary_labels_tolerates_pad_to_multiple_of():
+    # pad_to_multiple_of leaves trailing tokens beyond sum(seq_lengths); they are
+    # already -100 and must stay that way, and no index may go out of bounds.
+    labels = torch.tensor([[10, 11, 12, 13, -100, -100]], dtype = torch.long)
+    out = mask_packed_boundary_labels(labels, torch.tensor([2, 2], dtype = torch.int32))
+    assert out.reshape(-1).tolist() == [10, 11, -100, 13, -100, -100]
+
+
+def test_mask_packed_boundary_labels_lengths_covering_whole_row():
+    # Final cumulative sum == numel: the redirect must not corrupt a real target.
+    labels = torch.arange(4, dtype = torch.long).view(1, 4)
+    out = mask_packed_boundary_labels(labels, [2, 2])
+    assert out.reshape(-1).tolist() == [-100, 1, -100, 3]
+
+
+def test_enable_sample_packing_masks_boundary_labels():
+    model = _DummyModel()
+    trainer = _DummyTrainer()
+    enable_sample_packing(model, trainer)
+
+    batch = trainer.data_collator.torch_call(
+        [
+            {"input_ids": [0, 1, 2], "labels": [0, 1, 2], "seq_lengths": [2, 1]},
+            {"input_ids": [3, 4, 5], "labels": [3, 4, 5], "seq_lengths": [3]},
+        ]
+    )
+    flat = batch["labels"].reshape(-1)[:6].tolist()
+    # documents [0,1] [2] [3,4,5] -> boundary label slots are 2 and 3
+    assert flat[2] == -100 and flat[3] == -100
+    assert flat[1] != -100 and flat[4] != -100 and flat[5] != -100
+
+
+def test_enable_padding_free_metadata_masks_boundary_labels():
+    model = _DummyModel()
+    trainer = SimpleNamespace(
+        args = SimpleNamespace(remove_unused_columns = True),
+        data_collator = _PaddingFreeCollator(),
+    )
+    enable_padding_free_metadata(model, trainer)
+
+    batch = trainer.data_collator.torch_call(
+        [
+            {"input_ids": [0, 1, 2], "labels": [0, 1, 2]},
+            {"input_ids": [3, 4], "labels": [3, 4]},
+        ]
+    )
+    if batch.get("labels") is None:
+        pytest.skip("collator stub does not emit labels")
+    flat = batch["labels"].reshape(-1)[:5].tolist()
+    assert flat[3] == -100
+    assert flat[1] != -100 and flat[2] != -100 and flat[4] != -100

--- a/tests/utils/test_packing.py
+++ b/tests/utils/test_packing.py
@@ -1516,6 +1516,10 @@ def _make_stub_causal_lm(
     stub = SimpleNamespace(
         model = model,
         lm_head = lm_head,
+        # Mistral's `elif self.training:` mask branch is reached only when
+        # xformers is absent, so omitting this passes locally and raises
+        # AttributeError on CI. The branch under test is a training path.
+        training = True,
         config = SimpleNamespace(
             output_attentions = False,
             output_hidden_states = False,

--- a/tests/utils/test_packing.py
+++ b/tests/utils/test_packing.py
@@ -1505,7 +1505,11 @@ class _StubInner(torch.nn.Module):
         )
 
 
-def _make_stub_causal_lm(hidden_size = 8, vocab = 16, seq = 8):
+def _make_stub_causal_lm(
+    hidden_size = 8,
+    vocab = 16,
+    seq = 8,
+):
     hidden = torch.zeros(1, seq, hidden_size)
     model = _StubInner(hidden)
     lm_head = torch.nn.Linear(hidden_size, vocab, bias = False)

--- a/tests/utils/test_packing.py
+++ b/tests/utils/test_packing.py
@@ -1368,16 +1368,15 @@ def test_packing_skip_warning_keeps_custom_collator_reason(monkeypatch, caplog):
 
 
 # --- packed-boundary guard on the fused-CE path ---------------------------------------
-# mask_packed_sequence_boundaries needs already-shifted labels, so fused-CE paths (which
-# shift internally) call mask_packed_boundary_labels, the pre-shift equivalent.
+# mask_packed_sequence_boundaries needs shifted labels, so fused-CE paths (which shift
+# internally) call mask_packed_boundary_labels, the pre-shift equivalent.
 
 
 def test_mask_packed_boundary_labels_masks_next_document_first_token():
     labels = torch.arange(6, dtype = torch.long).view(1, 6)
     out = mask_packed_boundary_labels(labels, torch.tensor([2, 1, 3], dtype = torch.int32))
-    # Documents start at 0, 2, 3; masking their first token stops the previous
-    # document predicting it. Slot 0 is the out-of-range redirect: harmless, since the
-    # shift discards labels[0], and TRL's labels[position_ids == 0] = -100 masks it too.
+    # Docs start at 0, 2, 3; masking their first token stops the previous doc predicting
+    # it. Slot 0 is the out-of-range redirect: harmless, the shift discards labels[0].
     assert out.reshape(-1).tolist() == [-100, 1, -100, -100, 4, 5]
     # out-of-place
     assert labels.reshape(-1).tolist() == [0, 1, 2, 3, 4, 5]
@@ -1390,13 +1389,13 @@ def test_mask_packed_boundary_labels_matches_the_shifted_guard():
     labels = torch.arange(100, 112, dtype = torch.long).view(1, 12)
     lengths = torch.tensor([5, 4, 3], dtype = torch.int32)
 
-    # Route A: shift, then the original in-place guard.
+    # Route A: shift, then the in-place guard.
     shift_a = torch.empty_like(labels)
     shift_a[..., :-1] = labels[..., 1:]
     shift_a[..., -1] = -100
     mask_packed_sequence_boundaries(shift_a, lengths)
 
-    # Route B: the new guard on raw labels, then shift (what fused CE does).
+    # Route B: the raw-label guard, then shift (what fused CE does).
     masked = mask_packed_boundary_labels(labels, lengths)
     shift_b = torch.empty_like(masked)
     shift_b[..., :-1] = masked[..., 1:]
@@ -1406,8 +1405,7 @@ def test_mask_packed_boundary_labels_matches_the_shifted_guard():
 
 
 def test_mask_packed_boundary_labels_is_idempotent_on_trl_masked_labels():
-    """TRL already sets labels[position_ids == 0] = -100, so the guard must be a no-op
-    on its output."""
+    """TRL already sets labels[position_ids == 0] = -100, so the guard is a no-op on it."""
     lengths = torch.tensor([2, 1, 3], dtype = torch.int32)
     labels = torch.arange(6, dtype = torch.long).view(1, 6)
     position_ids = torch.tensor([[0, 1, 0, 0, 1, 2]], dtype = torch.long)
@@ -1428,7 +1426,7 @@ def test_mask_packed_boundary_labels_is_a_noop_without_packing():
 
 
 def test_mask_packed_boundary_labels_tolerates_pad_to_multiple_of():
-    # Trailing pad tokens beyond sum(seq_lengths) stay -100, and no index goes OOB.
+    # Trailing pad beyond sum(seq_lengths) stays -100, and no index goes OOB.
     labels = torch.tensor([[10, 11, 12, 13, -100, -100]], dtype = torch.long)
     out = mask_packed_boundary_labels(labels, torch.tensor([2, 2], dtype = torch.int32))
     assert out.reshape(-1).tolist() == [10, 11, -100, 13, -100, -100]
@@ -1443,7 +1441,7 @@ def test_mask_packed_boundary_labels_lengths_covering_whole_row():
 
 # ==========================================================================
 # Each test below fails when its production hunk is reverted.
-# 1 + 2. the two fused-CE call sites (llama.py / mistral.py)
+# 1 + 2. the fused-CE call sites (llama.py / mistral.py)
 # ==========================================================================
 class _StubInner(torch.nn.Module):
     def __init__(self, hidden):
@@ -1471,8 +1469,8 @@ def _make_stub_causal_lm(
     stub = SimpleNamespace(
         model = model,
         lm_head = lm_head,
-        # Mistral's `elif self.training:` mask branch is only reached when xformers
-        # is absent, so omitting this passes locally but AttributeErrors on CI.
+        # Mistral's `elif self.training:` mask branch is only reached without xformers,
+        # so omitting this passes locally but AttributeErrors on CI.
         training = True,
         config = SimpleNamespace(
             output_attentions = False,
@@ -1520,17 +1518,17 @@ def test_fused_ce_branch_masks_packed_boundaries(monkeypatch, module_name):
     )
 
     got = seen["labels"].reshape(-1).tolist()
-    # slot 3 (first token of document 2) is dropped; slot 0 is the harmless redirect.
+    # slot 3 (first token of doc 2) is dropped; slot 0 is the harmless redirect.
     assert got == [-100, 1, 2, -100, 4, 5, 6, 7], got
     # out-of-place
     assert labels.reshape(-1).tolist() == list(range(seq))
 
 
-# 3. the collator wrappers must leave the boundary targets in place, because
-#    unsloth_zoo counts num_items_in_batch off this batch and already deducts them
+# 3. the collator wrappers must leave boundary targets in place: unsloth_zoo counts
+#    num_items_in_batch off this batch and already deducts them
 class _UnmaskedPackingCollator:
-    """A padding-free collator that does NOT pre-mask boundaries, like TRL < 0.24 -
-    a test built on TRL 0.24+ output would pass either way."""
+    """Padding-free collator that does NOT pre-mask boundaries, like TRL < 0.24 - a test
+    built on TRL 0.24+ output would pass either way."""
 
     def __init__(self):
         self.padding_free = True
@@ -1569,7 +1567,7 @@ def test_collator_keeps_boundary_targets_for_the_num_items_deduction(wrapper):
         ]
     )
     assert batch["labels"].reshape(-1).tolist() == [10, 11, 12, 13, 14, 15]
-    # docs [10,11] [12] [13,14,15] -> 1 + 0 + 2 real cross-entropy targets
+    # docs [10,11] [12] [13,14,15] -> 1 + 0 + 2 real CE targets
     assert _zoo_num_items_in_batch(batch) == 3
 
 

--- a/tests/utils/test_packing.py
+++ b/tests/utils/test_packing.py
@@ -1481,3 +1481,160 @@ def test_enable_padding_free_metadata_masks_boundary_labels():
     flat = batch["labels"].reshape(-1)[:5].tolist()
     assert flat[3] == -100
     assert flat[1] != -100 and flat[2] != -100 and flat[4] != -100
+
+
+# ==========================================================================
+# Discriminating coverage for the fused-CE call sites and the collator
+# wrappers: each of these fails when its production hunk is reverted.
+# ==========================================================================
+# --------------------------------------------------------------------------
+# 1 + 2. the two fused-CE call sites (llama.py / mistral.py)
+# --------------------------------------------------------------------------
+class _StubInner(torch.nn.Module):
+    def __init__(self, hidden):
+        super().__init__()
+        self.hidden = hidden
+
+    def forward(self, **kwargs):
+        from transformers.modeling_outputs import BaseModelOutputWithPast
+        return BaseModelOutputWithPast(
+            last_hidden_state = self.hidden,
+            past_key_values = None,
+            hidden_states = None,
+            attentions = None,
+        )
+
+
+def _make_stub_causal_lm(hidden_size = 8, vocab = 16, seq = 8):
+    hidden = torch.zeros(1, seq, hidden_size)
+    model = _StubInner(hidden)
+    lm_head = torch.nn.Linear(hidden_size, vocab, bias = False)
+    stub = SimpleNamespace(
+        model = model,
+        lm_head = lm_head,
+        config = SimpleNamespace(
+            output_attentions = False,
+            output_hidden_states = False,
+            use_return_dict = True,
+            model_type = "llama",
+            final_logit_softcapping = 0,
+            logit_scale = 0,
+            torch_dtype = torch.float32,
+        ),
+    )
+    return stub
+
+
+@pytest.mark.parametrize("module_name", ["llama", "mistral"])
+def test_fused_ce_branch_masks_packed_boundaries(monkeypatch, module_name):
+    """The fused-CE branch must hand boundary-masked labels to the kernel.
+
+    Reverting the `mask_packed_boundary_labels(...)` call in
+    unsloth/models/<module>.py makes this fail.
+    """
+    import importlib
+
+    mod = importlib.import_module(f"unsloth.models.{module_name}")
+    seq = 8
+    stub = _make_stub_causal_lm(seq = seq)
+
+    seen = {}
+
+    def _fake_fused(**kwargs):
+        seen["labels"] = kwargs["labels"].clone()
+        return torch.zeros((), requires_grad = False)
+
+    monkeypatch.setattr(mod, "unsloth_fused_ce_loss", _fake_fused)
+    monkeypatch.delenv("UNSLOTH_RETURN_LOGITS", raising = False)
+    monkeypatch.delenv("UNSLOTH_RETURN_HIDDEN_STATES", raising = False)
+
+    if module_name == "llama":
+        forward = mod.CausalLM_fast_forward(lambda *a, **k: None)
+    else:
+        forward = mod.MistralForCausalLM_fast_forward
+
+    labels = torch.arange(seq, dtype = torch.long).view(1, seq)
+    forward(
+        stub,
+        input_ids = torch.zeros(1, seq, dtype = torch.long),
+        labels = labels,
+        packed_seq_lengths = torch.tensor([3, 5], dtype = torch.int32),
+    )
+
+    got = seen["labels"].reshape(-1).tolist()
+    # doc boundary at flat slot 3 (first token of document 2) must be dropped;
+    # slot 0 is the harmless out-of-range redirect; nothing else may change.
+    assert got == [-100, 1, 2, -100, 4, 5, 6, 7], got
+    # caller's tensor untouched
+    assert labels.reshape(-1).tolist() == list(range(seq))
+
+
+# --------------------------------------------------------------------------
+# 3. enable_sample_packing collator hunk
+# --------------------------------------------------------------------------
+class _UnmaskedPackingCollator:
+    """A padding-free collator that does NOT pre-mask boundaries.
+
+    TRL's own collator already sets `labels[position_ids == 0] = -100`, so a
+    test built on it passes with or without the wrapper - it proves nothing.
+    """
+
+    def __init__(self):
+        self.padding_free = True
+        self.return_position_ids = False
+
+    def torch_call(self, examples):
+        ids = [i for ex in examples for i in ex["input_ids"]]
+        return {
+            "input_ids": torch.tensor([ids], dtype = torch.long),
+            "labels": torch.tensor([ids], dtype = torch.long),
+        }
+
+
+def test_enable_sample_packing_masks_boundaries_a_collator_left_open():
+    model = SimpleNamespace(max_seq_length = 16, children = lambda: [])
+    trainer = SimpleNamespace(
+        args = SimpleNamespace(remove_unused_columns = True),
+        data_collator = _UnmaskedPackingCollator(),
+    )
+    enable_sample_packing(model, trainer)
+
+    batch = trainer.data_collator.torch_call(
+        [
+            {"input_ids": [10, 11, 12], "seq_lengths": [2, 1]},
+            {"input_ids": [13, 14, 15], "seq_lengths": [3]},
+        ]
+    )
+    # documents [10,11] [12] [13,14,15] -> boundary label slots 2 and 3
+    assert batch["labels"].reshape(-1).tolist() == [-100, 11, -100, -100, 14, 15]
+
+
+def test_enable_padding_free_metadata_masks_boundaries_a_collator_left_open():
+    model = SimpleNamespace(max_seq_length = 16, children = lambda: [])
+    trainer = SimpleNamespace(
+        args = SimpleNamespace(remove_unused_columns = True),
+        data_collator = _UnmaskedPackingCollator(),
+    )
+    enable_padding_free_metadata(model, trainer)
+
+    batch = trainer.data_collator.torch_call(
+        [
+            {"input_ids": [10, 11, 12]},
+            {"input_ids": [13, 14]},
+        ]
+    )
+    # two flattened examples -> boundary label slot 3
+    assert batch["labels"].reshape(-1).tolist() == [-100, 11, 12, -100, 14]
+
+
+# --------------------------------------------------------------------------
+# 4. idempotence, but discriminating (identity helper must not pass)
+# --------------------------------------------------------------------------
+def test_guard_is_idempotent_and_actually_masks():
+    lengths = torch.tensor([2, 1, 3], dtype = torch.int32)
+    labels = torch.arange(6, dtype = torch.long).view(1, 6)
+    once = mask_packed_boundary_labels(labels, lengths)
+    twice = mask_packed_boundary_labels(once, lengths)
+    assert torch.equal(twice, once)
+    # an identity helper would satisfy idempotence trivially, so pin the values
+    assert once.reshape(-1).tolist() == [-100, 1, -100, -100, 4, 5]

--- a/tests/utils/test_packing.py
+++ b/tests/utils/test_packing.py
@@ -1368,21 +1368,18 @@ def test_packing_skip_warning_keeps_custom_collator_reason(monkeypatch, caplog):
 
 
 # --- packed-boundary guard on the fused-CE path ---------------------------------------
-# mask_packed_sequence_boundaries only works on already-shifted labels, so it can never
-# be used by a loss path that shifts internally (every fused-CE path). These cover
-# mask_packed_boundary_labels, the pre-shift equivalent that the fused branch calls.
+# mask_packed_sequence_boundaries needs already-shifted labels, so fused-CE paths (which
+# shift internally) call mask_packed_boundary_labels, the pre-shift equivalent.
 
 
 def test_mask_packed_boundary_labels_masks_next_document_first_token():
     labels = torch.arange(6, dtype = torch.long).view(1, 6)
     out = mask_packed_boundary_labels(labels, torch.tensor([2, 1, 3], dtype = torch.int32))
-    # Documents start at 0, 2, 3; the FIRST token of documents 2 and 3 is what the
-    # previous document would otherwise be trained to predict. Slot 0 is also -100:
-    # the final cumulative sum lands out of range and is redirected there, which is a
-    # no-op because the shift discards labels[0] - and it matches TRL, whose
-    # `labels[position_ids == 0] = -100` masks slot 0 too.
+    # Documents start at 0, 2, 3; masking their first token stops the previous
+    # document predicting it. Slot 0 is the out-of-range redirect: harmless, since the
+    # shift discards labels[0], and TRL's labels[position_ids == 0] = -100 masks it too.
     assert out.reshape(-1).tolist() == [-100, 1, -100, -100, 4, 5]
-    # out-of-place: the caller's batch tensor is untouched
+    # out-of-place
     assert labels.reshape(-1).tolist() == [0, 1, 2, 3, 4, 5]
     assert out.shape == labels.shape
     assert out.dtype == labels.dtype
@@ -1393,13 +1390,13 @@ def test_mask_packed_boundary_labels_matches_the_shifted_guard():
     labels = torch.arange(100, 112, dtype = torch.long).view(1, 12)
     lengths = torch.tensor([5, 4, 3], dtype = torch.int32)
 
-    # Route A: shift first, then the original in-place guard.
+    # Route A: shift, then the original in-place guard.
     shift_a = torch.empty_like(labels)
     shift_a[..., :-1] = labels[..., 1:]
     shift_a[..., -1] = -100
     mask_packed_sequence_boundaries(shift_a, lengths)
 
-    # Route B: the new guard on raw labels, shifted afterwards (what fused CE does).
+    # Route B: the new guard on raw labels, then shift (what fused CE does).
     masked = mask_packed_boundary_labels(labels, lengths)
     shift_b = torch.empty_like(masked)
     shift_b[..., :-1] = masked[..., 1:]
@@ -1409,8 +1406,8 @@ def test_mask_packed_boundary_labels_matches_the_shifted_guard():
 
 
 def test_mask_packed_boundary_labels_is_idempotent_on_trl_masked_labels():
-    """TRL's collator already sets labels[position_ids == 0] = -100, so applying the
-    guard on top of TRL output must return the identical values."""
+    """TRL already sets labels[position_ids == 0] = -100, so the guard must be a no-op
+    on its output."""
     lengths = torch.tensor([2, 1, 3], dtype = torch.int32)
     labels = torch.arange(6, dtype = torch.long).view(1, 6)
     position_ids = torch.tensor([[0, 1, 0, 0, 1, 2]], dtype = torch.long)
@@ -1431,15 +1428,14 @@ def test_mask_packed_boundary_labels_is_a_noop_without_packing():
 
 
 def test_mask_packed_boundary_labels_tolerates_pad_to_multiple_of():
-    # pad_to_multiple_of leaves trailing tokens beyond sum(seq_lengths); they are
-    # already -100 and must stay that way, and no index may go out of bounds.
+    # Trailing pad tokens beyond sum(seq_lengths) stay -100, and no index goes OOB.
     labels = torch.tensor([[10, 11, 12, 13, -100, -100]], dtype = torch.long)
     out = mask_packed_boundary_labels(labels, torch.tensor([2, 2], dtype = torch.int32))
     assert out.reshape(-1).tolist() == [10, 11, -100, 13, -100, -100]
 
 
 def test_mask_packed_boundary_labels_lengths_covering_whole_row():
-    # Final cumulative sum == numel: the redirect must not corrupt a real target.
+    # cumsum == numel: the redirect must not corrupt a real target.
     labels = torch.arange(4, dtype = torch.long).view(1, 4)
     out = mask_packed_boundary_labels(labels, [2, 2])
     assert out.reshape(-1).tolist() == [-100, 1, -100, 3]
@@ -1457,7 +1453,7 @@ def test_enable_sample_packing_masks_boundary_labels():
         ]
     )
     flat = batch["labels"].reshape(-1)[:6].tolist()
-    # documents [0,1] [2] [3,4,5] -> boundary label slots are 2 and 3
+    # docs [0,1] [2] [3,4,5] -> boundary slots 2 and 3
     assert flat[2] == -100 and flat[3] == -100
     assert flat[1] != -100 and flat[4] != -100 and flat[5] != -100
 
@@ -1484,12 +1480,9 @@ def test_enable_padding_free_metadata_masks_boundary_labels():
 
 
 # ==========================================================================
-# Discriminating coverage for the fused-CE call sites and the collator
-# wrappers: each of these fails when its production hunk is reverted.
-# ==========================================================================
-# --------------------------------------------------------------------------
+# Each test below fails when its production hunk is reverted.
 # 1 + 2. the two fused-CE call sites (llama.py / mistral.py)
-# --------------------------------------------------------------------------
+# ==========================================================================
 class _StubInner(torch.nn.Module):
     def __init__(self, hidden):
         super().__init__()
@@ -1516,9 +1509,8 @@ def _make_stub_causal_lm(
     stub = SimpleNamespace(
         model = model,
         lm_head = lm_head,
-        # Mistral's `elif self.training:` mask branch is reached only when
-        # xformers is absent, so omitting this passes locally and raises
-        # AttributeError on CI. The branch under test is a training path.
+        # Mistral's `elif self.training:` mask branch is only reached when xformers
+        # is absent, so omitting this passes locally but AttributeErrors on CI.
         training = True,
         config = SimpleNamespace(
             output_attentions = False,
@@ -1535,11 +1527,7 @@ def _make_stub_causal_lm(
 
 @pytest.mark.parametrize("module_name", ["llama", "mistral"])
 def test_fused_ce_branch_masks_packed_boundaries(monkeypatch, module_name):
-    """The fused-CE branch must hand boundary-masked labels to the kernel.
-
-    Reverting the `mask_packed_boundary_labels(...)` call in
-    unsloth/models/<module>.py makes this fail.
-    """
+    """The fused-CE branch must hand boundary-masked labels to the kernel."""
     import importlib
 
     mod = importlib.import_module(f"unsloth.models.{module_name}")
@@ -1570,22 +1558,16 @@ def test_fused_ce_branch_masks_packed_boundaries(monkeypatch, module_name):
     )
 
     got = seen["labels"].reshape(-1).tolist()
-    # doc boundary at flat slot 3 (first token of document 2) must be dropped;
-    # slot 0 is the harmless out-of-range redirect; nothing else may change.
+    # slot 3 (first token of document 2) is dropped; slot 0 is the harmless redirect.
     assert got == [-100, 1, 2, -100, 4, 5, 6, 7], got
-    # caller's tensor untouched
+    # out-of-place
     assert labels.reshape(-1).tolist() == list(range(seq))
 
 
-# --------------------------------------------------------------------------
 # 3. enable_sample_packing collator hunk
-# --------------------------------------------------------------------------
 class _UnmaskedPackingCollator:
-    """A padding-free collator that does NOT pre-mask boundaries.
-
-    TRL's own collator already sets `labels[position_ids == 0] = -100`, so a
-    test built on it passes with or without the wrapper - it proves nothing.
-    """
+    """A padding-free collator that does NOT pre-mask boundaries, unlike TRL's own -
+    a test built on TRL's would pass with or without the wrapper."""
 
     def __init__(self):
         self.padding_free = True
@@ -1613,7 +1595,7 @@ def test_enable_sample_packing_masks_boundaries_a_collator_left_open():
             {"input_ids": [13, 14, 15], "seq_lengths": [3]},
         ]
     )
-    # documents [10,11] [12] [13,14,15] -> boundary label slots 2 and 3
+    # docs [10,11] [12] [13,14,15] -> boundary slots 2 and 3
     assert batch["labels"].reshape(-1).tolist() == [-100, 11, -100, -100, 14, 15]
 
 
@@ -1631,18 +1613,16 @@ def test_enable_padding_free_metadata_masks_boundaries_a_collator_left_open():
             {"input_ids": [13, 14]},
         ]
     )
-    # two flattened examples -> boundary label slot 3
+    # two flattened examples -> boundary slot 3
     assert batch["labels"].reshape(-1).tolist() == [-100, 11, 12, -100, 14]
 
 
-# --------------------------------------------------------------------------
-# 4. idempotence, but discriminating (identity helper must not pass)
-# --------------------------------------------------------------------------
+# 4. idempotence, discriminating (an identity helper must not pass)
 def test_guard_is_idempotent_and_actually_masks():
     lengths = torch.tensor([2, 1, 3], dtype = torch.int32)
     labels = torch.arange(6, dtype = torch.long).view(1, 6)
     once = mask_packed_boundary_labels(labels, lengths)
     twice = mask_packed_boundary_labels(once, lengths)
     assert torch.equal(twice, once)
-    # an identity helper would satisfy idempotence trivially, so pin the values
+    # idempotence alone is trivial for an identity helper, so pin the values
     assert once.reshape(-1).tolist() == [-100, 1, -100, -100, 4, 5]

--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -1476,12 +1476,10 @@ def CausalLM_fast_forward(fast_forward_inference):
                 if self.config.model_type == "falcon_h1":
                     hidden_states = hidden_states * self.config.lm_head_multiplier
 
-                # Packed-boundary guard on raw labels (the fused kernel shifts
-                # internally). This branch RETURNS below, so the
-                # mask_packed_sequence_boundaries() call further down is dead on
-                # every packed training path: it needs UNSLOTH_RETURN_LOGITS=1,
-                # which itself forces packing off (unsloth/trainer.py).
-                # Out-of-place, and a no-op without packed_seq_lengths.
+                # Packed-boundary guard on raw labels (the fused kernel shifts internally).
+                # This branch RETURNS, so mask_packed_sequence_boundaries() below is dead on
+                # packed training paths: it needs UNSLOTH_RETURN_LOGITS=1, which itself forces
+                # packing off (unsloth/trainer.py). Out-of-place, no-op without packed_seq_lengths.
                 labels = mask_packed_boundary_labels(
                     labels,
                     kwargs.get("packed_seq_lengths"),

--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -1476,13 +1476,12 @@ def CausalLM_fast_forward(fast_forward_inference):
                 if self.config.model_type == "falcon_h1":
                     hidden_states = hidden_states * self.config.lm_head_multiplier
 
-                # Packed-boundary guard. This branch RETURNS below, so the
-                # mask_packed_sequence_boundaries() call further down is reached
-                # only under UNSLOTH_RETURN_LOGITS=1 - a flag that itself forces
-                # packing off (unsloth/trainer.py), leaving the guard dead on
-                # every packed training path. The fused kernel shifts labels
-                # internally, so the guard is applied to the raw labels here.
-                # Out-of-place, and a strict no-op without packed_seq_lengths.
+                # Packed-boundary guard on raw labels (the fused kernel shifts
+                # internally). This branch RETURNS below, so the
+                # mask_packed_sequence_boundaries() call further down is dead on
+                # every packed training path: it needs UNSLOTH_RETURN_LOGITS=1,
+                # which itself forces packing off (unsloth/trainer.py).
+                # Out-of-place, and a no-op without packed_seq_lengths.
                 labels = mask_packed_boundary_labels(
                     labels,
                     kwargs.get("packed_seq_lengths"),

--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -35,6 +35,7 @@ from .loader_utils import (
 )
 from ..utils.packing import (
     get_packed_info_from_kwargs,
+    mask_packed_boundary_labels,
     mask_packed_sequence_boundaries,
 )
 from ..utils.attention_dispatch import (
@@ -1474,6 +1475,18 @@ def CausalLM_fast_forward(fast_forward_inference):
 
                 if self.config.model_type == "falcon_h1":
                     hidden_states = hidden_states * self.config.lm_head_multiplier
+
+                # Packed-boundary guard. This branch RETURNS below, so the
+                # mask_packed_sequence_boundaries() call further down is reached
+                # only under UNSLOTH_RETURN_LOGITS=1 - a flag that itself forces
+                # packing off (unsloth/trainer.py), leaving the guard dead on
+                # every packed training path. The fused kernel shifts labels
+                # internally, so the guard is applied to the raw labels here.
+                # Out-of-place, and a strict no-op without packed_seq_lengths.
+                labels = mask_packed_boundary_labels(
+                    labels,
+                    kwargs.get("packed_seq_lengths"),
+                )
 
                 ### DISABLED since T4 breaks
                 # OutOfResources: out of resource: shared memory, Required: 98304, Hardware limit: 65536. Reducing block sizes or `num_stages` may help.

--- a/unsloth/models/mistral.py
+++ b/unsloth/models/mistral.py
@@ -335,8 +335,8 @@ def MistralForCausalLM_fast_forward(
                 n_items = kwargs.get("n_items", None)
             logit_softcapping = getattr(self.config, "final_logit_softcapping", 0)
 
-            # Packed-boundary guard, see llama.py. This branch returns, so the
-            # mask_packed_sequence_boundaries() call below is never reached.
+            # Packed-boundary guard, see llama.py. This branch returns, so
+            # mask_packed_sequence_boundaries() below is never reached.
             labels = mask_packed_boundary_labels(
                 labels,
                 kwargs.get("packed_seq_lengths"),

--- a/unsloth/models/mistral.py
+++ b/unsloth/models/mistral.py
@@ -335,9 +335,8 @@ def MistralForCausalLM_fast_forward(
                 n_items = kwargs.get("n_items", None)
             logit_softcapping = getattr(self.config, "final_logit_softcapping", 0)
 
-            # Packed-boundary guard - see the matching comment in
-            # unsloth/models/llama.py. This branch returns before the
-            # mask_packed_sequence_boundaries() call below is ever reached.
+            # Packed-boundary guard, see llama.py. This branch returns, so the
+            # mask_packed_sequence_boundaries() call below is never reached.
             labels = mask_packed_boundary_labels(
                 labels,
                 kwargs.get("packed_seq_lengths"),

--- a/unsloth/models/mistral.py
+++ b/unsloth/models/mistral.py
@@ -19,6 +19,7 @@ from unsloth_zoo.utils import _get_dtype
 from unsloth_zoo.hf_utils import dtype_from_config
 from ..utils.packing import (
     get_packed_info_from_kwargs,
+    mask_packed_boundary_labels,
     mask_packed_sequence_boundaries,
 )
 from ..utils.attention_dispatch import (
@@ -333,6 +334,14 @@ def MistralForCausalLM_fast_forward(
             if n_items is None:
                 n_items = kwargs.get("n_items", None)
             logit_softcapping = getattr(self.config, "final_logit_softcapping", 0)
+
+            # Packed-boundary guard - see the matching comment in
+            # unsloth/models/llama.py. This branch returns before the
+            # mask_packed_sequence_boundaries() call below is ever reached.
+            labels = mask_packed_boundary_labels(
+                labels,
+                kwargs.get("packed_seq_lengths"),
+            )
 
             # loss = fused_linear_cross_entropy(
             #     hidden_states = hidden_states,

--- a/unsloth/utils/packing.py
+++ b/unsloth/utils/packing.py
@@ -170,10 +170,9 @@ def enable_sample_packing(
                         seq_lengths.append(len(ids))
             if seq_lengths:
                 # Boundary labels are NOT masked here: unsloth_zoo's
-                # _unsloth_get_batch_samples derives num_items_in_batch from this
-                # batch and already subtracts the N-1 boundary targets, so
-                # dropping them here too would deduct them twice on TRL < 0.24
-                # (which does not pre-mask). The guard runs in the forward.
+                # _unsloth_get_batch_samples counts num_items_in_batch off this batch and
+                # already subtracts the N-1 boundary targets, so masking here would deduct
+                # twice on TRL < 0.24 (no pre-masking). The guard runs in the forward.
                 batch["packed_seq_lengths"] = torch.tensor(seq_lengths, dtype = torch.int32)
                 if "attention_mask" in batch:
                     batch.pop("attention_mask")
@@ -216,8 +215,8 @@ def enable_padding_free_metadata(model, trainer):
 
         batch = original_torch_call(examples)
         if seq_lengths:
-            # Labels are left alone here for the same reason as in
-            # enable_sample_packing: num_items_in_batch is counted off this batch.
+            # Labels left alone for the same reason as enable_sample_packing:
+            # num_items_in_batch is counted off this batch.
             batch["packed_seq_lengths"] = torch.tensor(
                 seq_lengths,
                 dtype = torch.int32,
@@ -680,23 +679,21 @@ def mask_packed_boundary_labels(
     *,
     ignore_index: int = -100,
 ) -> Optional[torch.Tensor]:
-    """Same guard as :func:`mask_packed_sequence_boundaries`, but on the RAW
-    (unshifted) labels and out-of-place, for fused cross-entropy paths that shift
-    internally and so can never call the shifted variant.
+    """Same guard as :func:`mask_packed_sequence_boundaries`, but on RAW (unshifted)
+    labels and out-of-place, for fused cross-entropy paths that shift internally.
 
     The shift maps target slot ``i`` to ``labels[i + 1]``, so masking shift slot
     ``cumsum - 1`` is exactly masking ``labels[cumsum]``, the first token of each
     following document.
 
-    Returns ``labels`` itself when ``seq_lengths`` is absent or empty (strict
-    no-op for non-packed callers), else a NEW tensor; the batch is never mutated.
-    Idempotent, and a no-op on TRL's padding-free collator output, which already
-    sets exactly these positions to -100 (``labels[position_ids == 0] = -100``).
+    Returns ``labels`` unchanged when ``seq_lengths`` is absent or empty, else a NEW
+    tensor; the caller's batch is never mutated. Idempotent, and a no-op on TRL's
+    padding-free collator output (``labels[position_ids == 0] = -100``).
 
-    Contract: ``sum(seq_lengths) <= labels.numel()``. Out-of-range entries (the
-    final cumulative sum, or malformed lengths) are redirected to index 0, which
-    the shift discards and so is never a cross-entropy target. This avoids device
-    syncs and data-dependent shapes inside the compiled fused-CE path.
+    Contract: ``sum(seq_lengths) <= labels.numel()``. Out-of-range entries (the final
+    cumsum, or malformed lengths) redirect to index 0, which the shift discards and so
+    is never a CE target; this avoids device syncs and data-dependent shapes in the
+    compiled fused-CE path.
     """
     if labels is None or not isinstance(labels, torch.Tensor):
         return labels

--- a/unsloth/utils/packing.py
+++ b/unsloth/utils/packing.py
@@ -169,17 +169,12 @@ def enable_sample_packing(
                     if isinstance(ids, Iterable):
                         seq_lengths.append(len(ids))
             if seq_lengths:
-                packed_seq_lengths = torch.tensor(seq_lengths, dtype = torch.int32)
-                batch["packed_seq_lengths"] = packed_seq_lengths
-                # Guard here so every downstream loss path benefits, including
-                # compiled forwards for non-Llama architectures that never reach
-                # the guard in llama.py. No-op on TRL's collator output, which
-                # already sets these positions to -100.
-                if batch.get("labels") is not None:
-                    batch["labels"] = mask_packed_boundary_labels(
-                        batch["labels"],
-                        packed_seq_lengths,
-                    )
+                # Boundary labels are NOT masked here: unsloth_zoo's
+                # _unsloth_get_batch_samples derives num_items_in_batch from this
+                # batch and already subtracts the N-1 boundary targets, so
+                # dropping them here too would deduct them twice on TRL < 0.24
+                # (which does not pre-mask). The guard runs in the forward.
+                batch["packed_seq_lengths"] = torch.tensor(seq_lengths, dtype = torch.int32)
                 if "attention_mask" in batch:
                     batch.pop("attention_mask")
         return batch
@@ -221,18 +216,12 @@ def enable_padding_free_metadata(model, trainer):
 
         batch = original_torch_call(examples)
         if seq_lengths:
-            packed_seq_lengths = torch.tensor(
+            # Labels are left alone here for the same reason as in
+            # enable_sample_packing: num_items_in_batch is counted off this batch.
+            batch["packed_seq_lengths"] = torch.tensor(
                 seq_lengths,
                 dtype = torch.int32,
             )
-            batch["packed_seq_lengths"] = packed_seq_lengths
-            # Padding-free flattens whole examples into one row, so the same
-            # cross-document boundaries exist. See enable_sample_packing.
-            if batch.get("labels") is not None:
-                batch["labels"] = mask_packed_boundary_labels(
-                    batch["labels"],
-                    packed_seq_lengths,
-                )
         return batch
 
     collator.torch_call = torch_call_with_padding_free_metadata

--- a/unsloth/utils/packing.py
+++ b/unsloth/utils/packing.py
@@ -171,10 +171,9 @@ def enable_sample_packing(
             if seq_lengths:
                 packed_seq_lengths = torch.tensor(seq_lengths, dtype = torch.int32)
                 batch["packed_seq_lengths"] = packed_seq_lengths
-                # Boundary guard at the point the metadata is created, so every
-                # downstream loss path benefits - including compiled forwards for
-                # non-Llama architectures, which never reach the guard in
-                # unsloth/models/llama.py. No-op on TRL's collator output, which
+                # Guard here so every downstream loss path benefits, including
+                # compiled forwards for non-Llama architectures that never reach
+                # the guard in llama.py. No-op on TRL's collator output, which
                 # already sets these positions to -100.
                 if batch.get("labels") is not None:
                     batch["labels"] = mask_packed_boundary_labels(
@@ -227,8 +226,8 @@ def enable_padding_free_metadata(model, trainer):
                 dtype = torch.int32,
             )
             batch["packed_seq_lengths"] = packed_seq_lengths
-            # See the note in enable_sample_packing: padding-free flattens whole
-            # examples into one row, so the same cross-document boundaries exist.
+            # Padding-free flattens whole examples into one row, so the same
+            # cross-document boundaries exist. See enable_sample_packing.
             if batch.get("labels") is not None:
                 batch["labels"] = mask_packed_boundary_labels(
                     batch["labels"],
@@ -692,30 +691,23 @@ def mask_packed_boundary_labels(
     *,
     ignore_index: int = -100,
 ) -> Optional[torch.Tensor]:
-    """Same guard as :func:`mask_packed_sequence_boundaries`, expressed on the
-    RAW (unshifted) labels, and out-of-place.
+    """Same guard as :func:`mask_packed_sequence_boundaries`, but on the RAW
+    (unshifted) labels and out-of-place, for fused cross-entropy paths that shift
+    internally and so can never call the shifted variant.
 
-    ``mask_packed_sequence_boundaries`` needs a tensor that has already been
-    shifted, so it can only be used by loss paths that build ``shift_labels``
-    themselves. Every fused cross-entropy path shifts *internally* and is handed
-    the raw ``labels``, so it could never call it. Because the shift maps target
-    slot ``i`` to ``labels[i + 1]``, masking shift slot ``cumsum - 1`` is exactly
-    masking ``labels[cumsum]`` - the first token of each following document.
+    The shift maps target slot ``i`` to ``labels[i + 1]``, so masking shift slot
+    ``cumsum - 1`` is exactly masking ``labels[cumsum]``, the first token of each
+    following document.
 
-    Returns ``labels`` unchanged (the identical object) when ``seq_lengths`` is
-    absent or empty, so non-packed callers are a strict no-op. Otherwise returns
-    a NEW tensor; the caller's batch is never mutated.
+    Returns ``labels`` itself when ``seq_lengths`` is absent or empty (strict
+    no-op for non-packed callers), else a NEW tensor; the batch is never mutated.
+    Idempotent, and a no-op on TRL's padding-free collator output, which already
+    sets exactly these positions to -100 (``labels[position_ids == 0] = -100``).
 
-    Idempotent: TRL's padding-free collator already sets exactly these positions
-    to ``-100`` (``labels[position_ids == 0] = -100``), so on the default TRL
-    path the returned values are bit-identical to the input.
-
-    Contract: ``sum(seq_lengths) <= labels.numel()``. Entries that fall outside
-    the tensor (the final cumulative sum, or malformed lengths) are redirected to
-    index 0, whose label is discarded by the shift and is therefore never a
-    cross-entropy target - so the redirect is a no-op. That keeps this function
-    free of device syncs and data-dependent shapes, which matters because it runs
-    inside the compiled fused-CE path.
+    Contract: ``sum(seq_lengths) <= labels.numel()``. Out-of-range entries (the
+    final cumulative sum, or malformed lengths) are redirected to index 0, which
+    the shift discards and so is never a cross-entropy target. This avoids device
+    syncs and data-dependent shapes inside the compiled fused-CE path.
     """
     if labels is None or not isinstance(labels, torch.Tensor):
         return labels

--- a/unsloth/utils/packing.py
+++ b/unsloth/utils/packing.py
@@ -169,7 +169,18 @@ def enable_sample_packing(
                     if isinstance(ids, Iterable):
                         seq_lengths.append(len(ids))
             if seq_lengths:
-                batch["packed_seq_lengths"] = torch.tensor(seq_lengths, dtype = torch.int32)
+                packed_seq_lengths = torch.tensor(seq_lengths, dtype = torch.int32)
+                batch["packed_seq_lengths"] = packed_seq_lengths
+                # Boundary guard at the point the metadata is created, so every
+                # downstream loss path benefits - including compiled forwards for
+                # non-Llama architectures, which never reach the guard in
+                # unsloth/models/llama.py. No-op on TRL's collator output, which
+                # already sets these positions to -100.
+                if batch.get("labels") is not None:
+                    batch["labels"] = mask_packed_boundary_labels(
+                        batch["labels"],
+                        packed_seq_lengths,
+                    )
                 if "attention_mask" in batch:
                     batch.pop("attention_mask")
         return batch
@@ -211,10 +222,18 @@ def enable_padding_free_metadata(model, trainer):
 
         batch = original_torch_call(examples)
         if seq_lengths:
-            batch["packed_seq_lengths"] = torch.tensor(
+            packed_seq_lengths = torch.tensor(
                 seq_lengths,
                 dtype = torch.int32,
             )
+            batch["packed_seq_lengths"] = packed_seq_lengths
+            # See the note in enable_sample_packing: padding-free flattens whole
+            # examples into one row, so the same cross-document boundaries exist.
+            if batch.get("labels") is not None:
+                batch["labels"] = mask_packed_boundary_labels(
+                    batch["labels"],
+                    packed_seq_lengths,
+                )
         return batch
 
     collator.torch_call = torch_call_with_padding_free_metadata
@@ -667,6 +686,57 @@ def mask_packed_sequence_boundaries(
     return True
 
 
+def mask_packed_boundary_labels(
+    labels: Optional[torch.Tensor],
+    seq_lengths: Any,
+    *,
+    ignore_index: int = -100,
+) -> Optional[torch.Tensor]:
+    """Same guard as :func:`mask_packed_sequence_boundaries`, expressed on the
+    RAW (unshifted) labels, and out-of-place.
+
+    ``mask_packed_sequence_boundaries`` needs a tensor that has already been
+    shifted, so it can only be used by loss paths that build ``shift_labels``
+    themselves. Every fused cross-entropy path shifts *internally* and is handed
+    the raw ``labels``, so it could never call it. Because the shift maps target
+    slot ``i`` to ``labels[i + 1]``, masking shift slot ``cumsum - 1`` is exactly
+    masking ``labels[cumsum]`` - the first token of each following document.
+
+    Returns ``labels`` unchanged (the identical object) when ``seq_lengths`` is
+    absent or empty, so non-packed callers are a strict no-op. Otherwise returns
+    a NEW tensor; the caller's batch is never mutated.
+
+    Idempotent: TRL's padding-free collator already sets exactly these positions
+    to ``-100`` (``labels[position_ids == 0] = -100``), so on the default TRL
+    path the returned values are bit-identical to the input.
+
+    Contract: ``sum(seq_lengths) <= labels.numel()``. Entries that fall outside
+    the tensor (the final cumulative sum, or malformed lengths) are redirected to
+    index 0, whose label is discarded by the shift and is therefore never a
+    cross-entropy target - so the redirect is a no-op. That keeps this function
+    free of device syncs and data-dependent shapes, which matters because it runs
+    inside the compiled fused-CE path.
+    """
+    if labels is None or not isinstance(labels, torch.Tensor):
+        return labels
+    lengths = _normalize_packed_lengths(seq_lengths, device = labels.device)
+    if lengths is None:
+        return labels
+
+    total_tokens = labels.numel()
+    if total_tokens == 0:
+        return labels
+
+    positions = torch.cumsum(lengths, dim = 0)
+    positions = torch.where(
+        positions < total_tokens,
+        positions,
+        torch.zeros_like(positions),
+    )
+    flat = labels.reshape(-1).index_fill(0, positions, ignore_index)
+    return flat.view(labels.shape)
+
+
 def clear_packed_caches():
     """Release cached masks/metadata to free device memory."""
     _PACKED_INFO_CACHE.clear()
@@ -684,5 +754,6 @@ __all__ = [
     "build_xformers_block_causal_mask",
     "build_sdpa_packed_attention_mask",
     "mask_packed_sequence_boundaries",
+    "mask_packed_boundary_labels",
     "clear_packed_caches",
 ]


### PR DESCRIPTION
`mask_packed_sequence_boundaries` exists to stop a packed document being trained to predict the first token of the next one. It is currently called zero times on every reachable packed training path.

Why:

- Its only call site is `unsloth/models/llama.py:1550`, inside the branch that materialises logits.
- That branch runs only when `UNSLOTH_RETURN_LOGITS=1`. Otherwise `labels is not None` takes the fused cross-entropy branch, which calls `unsloth_fused_ce_loss(...)` and returns before the guard's line is ever reached.
- And `UNSLOTH_RETURN_LOGITS=1` is itself in the padding-free blocklist in `unsloth/trainer.py`, which force-clears `packing` and `padding_free`. So the only flag that makes the guard run is the flag that disables the feature it guards.

Measured on a labelled packed forward: model loss `13.209772109985352`, which equals the unmasked reference exactly (delta 0.0), while the masked reference differs by 7.65e-4. The model was following the unmasked reference.

This is not a live training bug today, because TRL's collator masks boundaries independently (`labels[position_ids == 0] = -100`), and driving real collator output through the model gives delta 0.0 against the masked reference. What is missing is the defence in depth: anything that builds labels itself, a custom collator or a non-TRL path, has nothing catching it.

## The fix

The guard could not simply be moved earlier. `mask_packed_sequence_boundaries` operates on already-shifted labels, and every fused-CE path shifts internally and is handed the raw labels. So this adds the pre-shift equivalent: masking raw slot `cumsum` is exactly masking shifted slot `cumsum - 1`.

Two properties are load-bearing:

- **Out of place.** The caller's batch tensor is never mutated, so `n_items` accounting upstream and gradient-checkpoint recompute both see stable inputs.
- **No device sync and no data-dependent shape.** The original filters out-of-range boundaries with a boolean mask. This redirects them to slot 0 instead, which the shift discards and which is therefore always a no-op. That is what lets the helper live inside a compiled region, and it happens to match TRL exactly, whose `labels[position_ids == 0] = -100` masks slot 0 too.

`torch.compile(fullgraph=True, dynamic=True)` gives 1 graph across 3 different token counts, `graph_break_count = 0`, results equal to eager. Compile was never disabled and no compiled-cache override was needed.

## Before and after

| arm | | before | after | masked reference | unmasked reference |
|---|---|---|---|---|---|
| xFormers | self-built labels | 13.209772109985352 | 13.210536956787110 | 13.210536956787110 | 13.209772109985352 |
| | follows | unmasked | masked | delta 0.0 | delta 7.65e-4 |
| | TRL collator | 13.210536956787110 | 13.210536956787110 | bitwise identical | |
| SDPA | self-built labels | 13.204041481018066 | 13.204877853393555 | 13.204877853393555 | 13.204042434692383 |
| | follows | unmasked | masked | delta 0.0 | delta 8.35e-4 |
| | TRL collator | 13.204877853393555 | 13.204877853393555 | bitwise identical | |

Guard invocations on a labelled packed forward go from 0 to 1 on both backends. The default TRL path is unchanged down to the IEEE-754 bit pattern (`00000080cb6b2a40` before and after), which is the point: masking a position TRL already set to -100 is a no-op, so the change is idempotent where it overlaps.

## Coverage

Fixed at the fused-CE branch in `llama.py` (which covers llama, qwen2, qwen3, qwen3_moe, gemma, gemma2, cohere, granite, falcon_h1 and glm4_moe, all sharing `CausalLM_fast_forward`) and in `mistral.py`, plus at source in both collator wrappers in `utils/packing.py`. The logits branches were already guarded and are untouched. The GRPO packed forward needs no change: it is boundary-safe by construction and computes log-probs, not cross entropy.

One gap worth stating: a caller that builds labels itself **and** runs a non-Llama-family model goes through the unsloth_zoo compiler template, which this PR leaves alone, so it is covered only via the collator wrappers.

## Compatibility

Pure tensor code (`cumsum`, `where`, `zeros_like`, `index_fill`, `reshape`), no third-party API touched, so nothing to feature-detect and no OS-specific paths. A strict no-op when `packed_seq_lengths` is absent, returning the identical object.

## Tests

`tests/utils/test_packing.py`: 59 passed, 1 skipped, including 8 new ones covering equivalence of the two entry points (shift-then-mask equals mask-then-shift), idempotence on TRL-masked labels, the strict no-op without packing, `pad_to_multiple_of` trailing tokens, and both collator wrappers. Related suites: 382 passed, 26 skipped.