### PR TITLE
Make the startup profile a gate, with budgets from its own measurements

### DIFF
--- a/.github/workflows/startup-profile-ci.yml
+++ b/.github/workflows/startup-profile-ci.yml
@@ -82,9 +82,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # 2x the median this workflow has measured, rounded up to the next 0.5s, floored
-        # at 1.4x the slowest median in 33 runs. median / slowest median observed:
-        # ubuntu 3.24s / 3.52s, macos 3.02s / 5.52s, windows 5.11s / 5.55s.
+        # Per the header rule. Slowest median seen in 33 runs, which is what the 1.4x
+        # floor is taken from: ubuntu 3.52s, macos 5.52s, windows 5.55s.
         include:
           - os: ubuntu-latest
             max_healthz_seconds: '6.5'

--- a/.github/workflows/startup-profile-ci.yml
+++ b/.github/workflows/startup-profile-ci.yml
@@ -9,8 +9,12 @@
 # the server can bind, dominated by eager module-level imports pulled in by routes:
 # torch ~1.9s self, unsloth_zoo ~0.8s, routes ~0.6s, transformers ~0.5s.
 #
-# Not a gate yet: --max-healthz-seconds exists, but a budget should come from
-# observed numbers rather than a guess.
+# Now a gate. The budgets below come from observed medians on this workflow rather
+# than a guess, set loose enough that runner noise cannot fail a PR and tight enough
+# to catch a regression of the size the ones already found were: the pandas edge in
+# routes.data_recipe.seed was 2.2s of 7.3s on Windows, torch was about 5s before that.
+# Raise a budget in the same PR as the import that needed it, with the run that shows
+# it, exactly as with the frontend startup budget.
 
 name: Startup profile
 
@@ -60,11 +64,19 @@ jobs:
     name: startup ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
-    continue-on-error: true
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-15, windows-latest]
+        # Budgets are medians observed on this workflow, rounded up with room for
+        # runner variance. Observed at 17363f8a2: ubuntu 2.99s, macos 3.33s,
+        # windows 5.21s.
+        include:
+          - os: ubuntu-latest
+            max_healthz_seconds: '5.0'
+          - os: macos-15
+            max_healthz_seconds: '6.0'
+          - os: windows-latest
+            max_healthz_seconds: '9.0'
 
     env:
       UNSLOTH_STUDIO_HOME: ${{ github.workspace }}/.studio-home
@@ -94,6 +106,9 @@ jobs:
       - name: Profile startup
         shell: bash
         run: |
+          # Load-bearing now that the budget is a gate: the profiler's exit code
+          # reaches this step only through the pipe into tee.
+          set -o pipefail
           BIN="$UNSLOTH_STUDIO_HOME/unsloth_studio/bin/unsloth"
           [ -x "$BIN" ] || BIN="$UNSLOTH_STUDIO_HOME/unsloth_studio/Scripts/unsloth.exe"
           [ -x "$BIN" ] || BIN=""
@@ -105,6 +120,7 @@ jobs:
             --python "$PY" \
             ${BIN:+--bin "$BIN"} \
             --repeats "${{ inputs.repeats || '3' }}" \
+            --max-healthz-seconds "${{ matrix.max_healthz_seconds }}" \
             --json "startup-${{ matrix.os }}.json" 2>&1 | tee logs/profile.log
 
       - name: Summary

--- a/.github/workflows/startup-profile-ci.yml
+++ b/.github/workflows/startup-profile-ci.yml
@@ -25,6 +25,11 @@
 #
 # Raise a budget in the same PR as the import that needed it, with the run that shows
 # it, exactly as with the frontend startup budget.
+#
+# Do not make this a required status check while it is filtered by paths. A workflow
+# skipped by path filtering never reports, so a required check on it sits Pending and
+# blocks every PR that does not touch the list below:
+# https://docs.github.com/en/pull-requests/how-tos/merge-and-close-pull-requests/troubleshooting-required-status-checks
 
 name: Startup profile
 

--- a/.github/workflows/startup-profile-ci.yml
+++ b/.github/workflows/startup-profile-ci.yml
@@ -9,10 +9,20 @@
 # the server can bind, dominated by eager module-level imports pulled in by routes:
 # torch ~1.9s self, unsloth_zoo ~0.8s, routes ~0.6s, transformers ~0.5s.
 #
-# Now a gate. The budgets below come from observed medians on this workflow rather
-# than a guess, set loose enough that runner noise cannot fail a PR and tight enough
-# to catch a regression of the size the ones already found were: the pandas edge in
-# routes.data_recipe.seed was 2.2s of 7.3s on Windows, torch was about 5s before that.
+# Now a gate. The budgets below come from this workflow's own history rather than a
+# guess: 33 completed runs, 99 profiles, 297 launches, no failed launch. Median time to
+# a healthy port was 3.24s on ubuntu, 3.02s on macos, 5.11s on windows.
+#
+# Sized for a slow runner, not for the median one. A hosted runner can be slow for a
+# whole run: macos-15 in run 31932608086 came in at 5.03/5.52/5.66s, 1.8x its own
+# median, on a PR that changed nothing here. So each budget is 2x the observed median
+# rounded up to the next half second, floored at 1.4x the slowest median seen. Anything
+# tighter fails unrelated PRs on runner luck.
+#
+# What that catches is a torch-sized regression, about 5s, not a 1-2s one. A 2.2s
+# regression of the pandas kind shows up in the import table in the job summary, which
+# is what found it; the gate is here to stop the catastrophic case, not to measure.
+#
 # Raise a budget in the same PR as the import that needed it, with the run that shows
 # it, exactly as with the frontend startup budget.
 
@@ -67,16 +77,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Budgets are medians observed on this workflow, rounded up with room for
-        # runner variance. Observed at 17363f8a2: ubuntu 2.99s, macos 3.33s,
-        # windows 5.21s.
+        # 2x the median this workflow has measured, rounded up to the next 0.5s, floored
+        # at 1.4x the slowest median in 33 runs. median / slowest median observed:
+        # ubuntu 3.24s / 3.52s, macos 3.02s / 5.52s, windows 5.11s / 5.55s.
         include:
           - os: ubuntu-latest
-            max_healthz_seconds: '5.0'
+            max_healthz_seconds: '6.5'
           - os: macos-15
-            max_healthz_seconds: '6.0'
+            max_healthz_seconds: '8.0'
           - os: windows-latest
-            max_healthz_seconds: '9.0'
+            max_healthz_seconds: '10.5'
 
     env:
       UNSLOTH_STUDIO_HOME: ${{ github.workspace }}/.studio-home
@@ -106,8 +116,10 @@ jobs:
       - name: Profile startup
         shell: bash
         run: |
-          # Load-bearing now that the budget is a gate: the profiler's exit code
-          # reaches this step only through the pipe into tee.
+          # Explicit rather than load-bearing: `shell: bash` already runs
+          # `bash --noprofile --norc -eo pipefail {0}`. Written out because the gate's
+          # exit code reaches this step only through the pipe into tee, so it has to
+          # survive the shell key being dropped or changed to `bash {0}`.
           set -o pipefail
           BIN="$UNSLOTH_STUDIO_HOME/unsloth_studio/bin/unsloth"
           [ -x "$BIN" ] || BIN="$UNSLOTH_STUDIO_HOME/unsloth_studio/Scripts/unsloth.exe"

--- a/tests/test_profile_startup_gate.py
+++ b/tests/test_profile_startup_gate.py
@@ -241,3 +241,47 @@ def test_terminate_tree_posix_uses_terminate():
     proc = _Proc()
     mod._terminate_tree(proc)
     assert proc.terminated
+
+
+# ---------------------------------------------------------------------------
+# The budget is only a gate if the workflow asks for it and can see it fail
+# ---------------------------------------------------------------------------
+
+
+def _profile_job() -> dict:
+    wf = yaml.safe_load(WORKFLOW.read_text(encoding = "utf-8"))
+    return wf["jobs"]["profile"]
+
+
+def _profile_step() -> dict:
+    for step in _profile_job()["steps"]:
+        if step.get("name") == "Profile startup":
+            return step
+    raise AssertionError("no 'Profile startup' step in the workflow")
+
+
+def test_every_platform_carries_a_budget():
+    """A matrix entry without one would profile and assert nothing."""
+    entries = _profile_job()["strategy"]["matrix"]["include"]
+    assert entries, "the matrix no longer lists platforms by include"
+    for entry in entries:
+        budget = entry.get("max_healthz_seconds")
+        assert budget, f"{entry.get('os')} has no max_healthz_seconds"
+        assert float(budget) > 0
+
+
+def test_the_profile_step_passes_the_budget():
+    assert "--max-healthz-seconds" in _profile_step()["run"]
+
+
+def test_the_profile_step_sets_pipefail():
+    """The profiler pipes into tee, so without pipefail the step reports tee's 0
+    and a blown budget passes silently."""
+    run = _profile_step()["run"]
+    assert "| tee" in run, "no pipe left; this guard can go"
+    assert "set -o pipefail" in run
+
+
+def test_the_job_is_not_advisory():
+    """continue-on-error would let the gate fail without failing the check."""
+    assert _profile_job().get("continue-on-error") is not True

--- a/tests/test_profile_startup_gate.py
+++ b/tests/test_profile_startup_gate.py
@@ -275,8 +275,9 @@ def test_the_profile_step_passes_the_budget():
 
 
 def test_the_profile_step_sets_pipefail():
-    """The profiler pipes into tee, so without pipefail the step reports tee's 0
-    and a blown budget passes silently."""
+    """`shell: bash` already implies -o pipefail, so this is belt and braces: the
+    gate's exit code only reaches the step through the pipe into tee, and it has to
+    survive that shell key being dropped or changed to `bash {0}`."""
     run = _profile_step()["run"]
     assert "| tee" in run, "no pipe left; this guard can go"
     assert "set -o pipefail" in run


### PR DESCRIPTION
The Startup profile workflow has been measuring `import main` and time to a healthy port on three platforms, and asserting nothing. Its own header said why: `--max-healthz-seconds` existed, but a budget should come from observed numbers rather than a guess. There are observed numbers now, and there are enough of them to size the budget against runner variance rather than against a single run.

## The data

Every completed run of this workflow whose artifacts are still in retention: **33 runs, 99 profiles, 297 launches, no failed launch, no skipped launch phase, no failed import.** The gate reads the median of 3 launches per job.

| OS | median of the per-run medians | slowest run's median | slowest single launch | budget set here |
|---|---:|---:|---:|---:|
| ubuntu-latest | 3.235s | 3.524s | 3.71s | 6.5s |
| macos-15 | 3.022s | 5.519s | 5.662s | 8.0s |
| windows-latest | 5.111s | 5.545s | 8.21s | 10.5s |

The macOS row is the one that matters. Run 31932608086 measured 5.027 / 5.519 / 5.662s, 1.8x that runner's own median, on a PR that touched nothing in the import graph. It was not one flaky launch, it was a slow machine for the whole job. A 6.0s budget would have passed that run with 0.48s to spare, and the same 1.8x on ubuntu or windows clears 5.0s and 9.0s outright.

So the rule is **2x the observed median, rounded up to the next 0.5s, floored at 1.4x the slowest median seen**. That is what the three numbers above are.

## What a budget that size actually catches

A torch-sized regression, about 5s. Not a 1-2s one, and the header should not have claimed otherwise: on windows, 5.11s + the 2.2s pandas edge is 7.3s, which never tripped 9.0s either. No budget that would catch 2.2s on windows sits outside the runner noise measured above.

That is fine, because that is not how the 2.2s was found. It was found by reading the per-package import table this job already writes to the step summary. The gate is here to stop the catastrophic case without failing unrelated PRs on runner luck; the summary is the measuring instrument. The header now says this instead of the other thing.

## Change

- The matrix carries a per-OS `max_healthz_seconds` and the profile step passes it.
- The job drops `continue-on-error: true`.
- The profile step sets `pipefail`. Belt and braces, not the load-bearing part: a step with `shell: bash` on a hosted runner is already invoked as `bash --noprofile --norc -eo pipefail {0}` ([workflow syntax](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions)), which the runner logs of run 31933219076 confirm verbatim. It is written out because the gate's exit code only reaches the step through the pipe into `tee`, so it should survive that shell key being dropped or changed to `bash {0}`.

## Blast radius

The paths filter is the backend tree, `unsloth_cli`, the installers, `pyproject.toml`, `studio/setup.*`, `install_python_stack.py`, `process.rs` and this workflow, so the job can now go red on those PRs.

Precisely what `continue-on-error` was doing, since it is easy to over-read: at job level it stops a failing job from failing the **workflow run**, and nothing more. The job's own check run is still reported as `failure` to the checks API and the PR checks list. So a failed install was already visible as a red `startup <os>` check. What actually made this job advisory is that the profiler was never handed a budget, so it exited 0 however slow startup got. Dropping `continue-on-error` is what keeps a blown budget from leaving the run itself green.

Two things bound the risk. Across the same 33 runs, all 99 jobs, all 99 `Install Studio` steps and all 99 `Profile startup` steps were green, and 19 of those 33 runs came from fork PRs, where `GITHUB_TOKEN` is read-only, so that path is exercised too. And `main` has no required status checks and no ruleset, and no workflow in the repo uses `merge_group`, so nothing here is wired into a merge queue. The workflow header now carries a note not to make this a required check while it is path-filtered: a workflow skipped by path filtering never reports, so a required check on it would sit Pending on every PR that misses the filter.

A failed install is not worth tolerating separately. If `install.sh --local` fails, `BIN` and `PY` fall back, `import main` fails, no launch reaches healthz, and the profiler exits 1 anyway with "the budget was never checked". Excusing the install step would move the same red one step later behind a worse message.

## Coverage

`tests/test_profile_startup_gate.py` already covers the profiler's own budget logic (a budget with no measured launch fails rather than passes, non-finite values are rejected, `--import-only` is refused). Four tests are added for the wiring, which is the part that was missing:

- every matrix entry carries a positive budget
- the profile step passes `--max-healthz-seconds`
- the profile step sets `pipefail` while it still pipes into `tee`
- the job is not `continue-on-error`

## Follow-up

#8962 takes about 2.2s off Windows and 0.9s off macOS by moving pandas out of the import graph. These budgets are set from `main` as it is today, so they should be re-derived from the same rule once that lands.

## Testing

- `python -m pytest tests/test_profile_startup_gate.py -q` (21 passed)
- Run 31933219076 on this branch: three jobs, one per matrix entry, each resolving `matrix.os` for `runs-on`, the job name and the `startup-<os>.json` artifact, each passing its own budget on the command line (`--max-healthz-seconds "9.0"` on windows, from the runner log), each producing a summary. Windows resolved `Scripts/unsloth.exe` and `Scripts/python.exe` and reported a 3.483s median.
- The budget path exercised directly over 23 cases: median under, exactly at, and over budget; no launch measured; one of three launches never healthy; `--repeats 0` and negative; budget `nan`, `inf`, `-inf`, empty, non-numeric, zero and negative. Exit 0 only where it should be, exit 1 for every unchecked or blown budget, exit 2 for every malformed argument.
