### PR TITLE
Studio: give the backend test stubs the context_length the route reads

### DIFF
--- a/studio/backend/tests/test_gguf_completion_usage.py
+++ b/studio/backend/tests/test_gguf_completion_usage.py
@@ -13,6 +13,7 @@ import routes.inference as inference_route
 class _GgufBackend:
     is_loaded = True
     model_identifier = "test/model.gguf"
+    context_length = None
     _is_audio = False
     is_vision = False
     supports_tools = False

--- a/studio/backend/tests/test_gguf_tool_non_streaming.py
+++ b/studio/backend/tests/test_gguf_tool_non_streaming.py
@@ -22,6 +22,7 @@ import routes.inference as inference_route
 class _ToolGgufBackend:
     is_loaded = True
     model_identifier = "test/model.gguf"
+    context_length = None
     _is_audio = False
     is_vision = False
     supports_tools = True

--- a/studio/backend/tests/test_research_internal_call_tool_gate.py
+++ b/studio/backend/tests/test_research_internal_call_tool_gate.py
@@ -32,6 +32,7 @@ class _Backend:
 
     is_loaded = True
     model_identifier = "test/model.gguf"
+    context_length = None
     _is_audio = False
     is_vision = False
     supports_tools = True
@@ -110,8 +111,9 @@ def test_the_opt_out_changes_nothing_a_default_install_does(monkeypatch, policy)
     after_entry, after_kwargs = _entry_point(monkeypatch, policy = policy, opt_out = True)
 
     assert (before_entry, after_entry) == ("plain", "plain")
-    # cancel_event is a fresh object per request, so identity differences say nothing.
-    drop = {"cancel_event"}
+    # cancel_event and perf_callback are built fresh per request, so their identities
+    # differ between the two hops and say nothing about what the model is handed.
+    drop = {"cancel_event", "perf_callback"}
     assert {k: v for k, v in before_kwargs.items() if k not in drop} == {
         k: v for k, v in after_kwargs.items() if k not in drop
     }

--- a/studio/backend/tests/test_research_internal_call_tool_gate.py
+++ b/studio/backend/tests/test_research_internal_call_tool_gate.py
@@ -111,8 +111,7 @@ def test_the_opt_out_changes_nothing_a_default_install_does(monkeypatch, policy)
     after_entry, after_kwargs = _entry_point(monkeypatch, policy = policy, opt_out = True)
 
     assert (before_entry, after_entry) == ("plain", "plain")
-    # cancel_event and perf_callback are built fresh per request, so their identities
-    # differ between the two hops and say nothing about what the model is handed.
+    # Both are built fresh per request, so their identities say nothing.
     drop = {"cancel_event", "perf_callback"}
     assert {k: v for k, v in before_kwargs.items() if k not in drop} == {
         k: v for k, v in after_kwargs.items() if k not in drop


### PR DESCRIPTION
The inference route reads `llama_backend.context_length` in several places, for example:

```python
_gguf_perf_callback = (
    _monitor_perf_callback(monitor_id, llama_backend.context_length)
    if not _wants_multiple_choices(payload)
    else None
)
```

The real backend has that attribute. Three hand-written stubs in the studio backend tests do not, and they are swapped in with `monkeypatch.setattr(inference_route, "get_llama_cpp_backend", ...)`, so those tests raised `AttributeError` before reaching a single assertion:

```
AttributeError: '_GgufBackend' object has no attribute 'context_length'
```

## What this changes

Adds `context_length = None` to the three stubs that the route actually reaches:

| stub | file | tests fixed |
|---|---|---|
| `_GgufBackend` | `tests/test_gguf_completion_usage.py` | 2 |
| `_ToolGgufBackend` (and `_EventsBackend`, which subclasses it) | `tests/test_gguf_tool_non_streaming.py` | 5 |
| `_Backend` | `tests/test_research_internal_call_tool_gate.py` | 6 |

`None` is the faithful value rather than an invented number. The route already handles a missing context (`llama_backend.context_length or _DEFAULT_MAX_TOKENS_FLOOR`), and none of these tests are about context limits, so pinning a size would assert something they never meant to.

One follow-on in the same file. `test_the_opt_out_changes_nothing_a_default_install_does` compares the generation kwargs of two hops, and once the `AttributeError` is gone it fails on `perf_callback`, which is a closure built fresh per request:

```
Differing items:
{'perf_callback': <function _monitor_perf_callback.<locals>._callback at 0x...>} !=
{'perf_callback': <function _monitor_perf_callback.<locals>._callback at 0x...>}
```

That is the same category as the `cancel_event` the test already ignores, so it joins the drop set. The test still compares every field that describes what the model is handed.

## Verification

Ran every backend test file that monkeypatches `get_llama_cpp_backend` (~3200 tests), before and after:

- before: 25 failed, 3168 passed
- after: 11 failed, 3182 passed
- `context_length` errors after: 0
- diffing the two failure lists shows only removals, so nothing new broke

The 11 that remain are unrelated and pre-existing: `TimeoutError` in the gguf stream slot ordering tests, plus failures in `test_desktop_auth.py`, `test_cached_gguf_routes.py` and `test_audio_tts_cancellation.py`.

One note for accuracy: the counts above differ by 14, but only 13 are from this change. `test_openai_auto_download.py::test_a_directory_loaded_model_is_not_refused_under_its_own_hub_id` also flipped, and it is an order-dependent flake, not something this fixes. That file passes 160/160 in isolation on clean `main` and with this change alike.

Stub-only, no production code touched.