### PR TITLE
CI: stop three workflows paying for work they throw away

### DIFF
--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -139,6 +139,15 @@ jobs:
         with:
           python-version: '3.12'
           cache: 'pip'
+          # Without this, setup-python's default glob resolves to the repo's only
+          # requirements.txt, unsloth/kernels/moe/requirements.txt: five lines that have
+          # nothing to do with what this job installs. Every job in the repo therefore
+          # shared one cache slot keyed on an unrelated file, so a "hit" restored a few MB
+          # and the install still downloaded the whole tree. Key on what this job actually
+          # reads instead.
+          cache-dependency-path: |
+            pyproject.toml
+            studio/backend/requirements/*.txt
 
       # Node 22 unblocks tests/studio/test_chat_preset_builtin_invariants.py's
       # `node --experimental-strip-types` subprocess. Cheap to install; keeps
@@ -211,6 +220,14 @@ jobs:
           set -euxo pipefail
           python -m pip install --upgrade pip
           pip install -r studio/backend/requirements/studio.txt
+          # CPU torch FIRST, before anything that depends on torch. peft, accelerate and
+          # datasets all declare a torch dependency, so installing them first made pip
+          # resolve it from PyPI: the default CUDA build, plus 14 nvidia_* wheels and
+          # cuda-toolkit, roughly 2.3 GB, which the pinned CPU wheel below then replaced
+          # seconds later. Same end state either way; this just stops paying for the
+          # download. torchvision: unsloth_zoo.vision_utils imports it at module scope.
+          pip install --index-url https://download.pytorch.org/whl/cpu --extra-index-url https://pypi.org/simple \
+            'torch>=2.4,<2.11' 'torchvision<0.26'
           pip install \
             python-multipart aiofiles sqlalchemy cryptography \
             pyyaml jinja2 mammoth unpdf requests typer \
@@ -219,9 +236,6 @@ jobs:
             psutil packaging tqdm safetensors datasets \
             'peft>=0.18,<0.20' 'accelerate>=0.34,<2' \
             ipython
-          # torchvision: unsloth_zoo.vision_utils imports it at module scope.
-          pip install --index-url https://download.pytorch.org/whl/cpu --extra-index-url https://pypi.org/simple \
-            'torch>=2.4,<2.11' 'torchvision<0.26'
           # transformers + trl from the matrix combo.
           pip install "$RESOLVED_TRANSFORMERS_SPEC"
           pip install "$RESOLVED_TRL_SPEC"
@@ -2223,6 +2237,15 @@ jobs:
         with:
           python-version: '3.12'
           cache: 'pip'
+          # Without this, setup-python's default glob resolves to the repo's only
+          # requirements.txt, unsloth/kernels/moe/requirements.txt: five lines that have
+          # nothing to do with what this job installs. Every job in the repo therefore
+          # shared one cache slot keyed on an unrelated file, so a "hit" restored a few MB
+          # and the install still downloaded the whole tree. Key on what this job actually
+          # reads instead.
+          cache-dependency-path: |
+            pyproject.toml
+            studio/backend/requirements/*.txt
 
       - name: Install runtime deps for unsloth_zoo.llama_cpp
         # unsloth_zoo's `__init__` imports `temporary_patches`, which

--- a/.github/workflows/lint-ci.yml
+++ b/.github/workflows/lint-ci.yml
@@ -55,6 +55,11 @@ jobs:
         with:
           python-version: '3.12'
           cache: 'pip'
+          # This job installs three linters and nothing else. Without an explicit path it
+          # shared one cache key with every other Python 3.12 job in the repo, and whichever
+          # ran first won the slot: in practice this one, leaving a 9 MB cache that Core then
+          # restored before downloading 3.2 GB. Its pins are inline below, so key on this file.
+          cache-dependency-path: .github/workflows/lint-ci.yml
 
       # Pin ruff to match .pre-commit-config.yaml so a CI-only ruff
       # bump cannot disagree with what pre-commit accepted.

--- a/.github/workflows/notebooks-ci.yml
+++ b/.github/workflows/notebooks-ci.yml
@@ -433,14 +433,26 @@ jobs:
       - name: Install Colab-shaped venv
         run: |
           python -m pip install --upgrade pip
-          # Best-effort: any single line that fails to resolve on CPU is
-          # tolerated; the smoke contract is "the install cell + the unsloth
-          # import works", not "the entire Colab venv reproduces."
-          while IFS= read -r spec; do
-            pip install "$spec" --index-url https://download.pytorch.org/whl/cpu \
-              --extra-index-url https://pypi.org/simple || \
-              echo "::warning::pin failed: $spec"
-          done < /tmp/seed_pins.txt
+          # One resolve for the whole pin set instead of one per line. The per-line loop
+          # below re-resolved against both indexes for every one of ~683 pins, which is
+          # why this step spent its entire 25 minute cap here and never once reached
+          # "Verify imports under spoof".
+          #
+          # Best-effort is preserved, just moved: a single unresolvable pin fails the bulk
+          # install, and the fallback then walks the list line by line exactly as before,
+          # tolerating the ones that cannot resolve on CPU. The smoke contract is "the
+          # install cell + the unsloth import works", not "the entire Colab venv
+          # reproduces."
+          if ! pip install -r /tmp/seed_pins.txt \
+                --index-url https://download.pytorch.org/whl/cpu \
+                --extra-index-url https://pypi.org/simple; then
+            echo "::warning::bulk resolve failed, falling back to per-pin best effort"
+            while IFS= read -r spec; do
+              pip install "$spec" --index-url https://download.pytorch.org/whl/cpu \
+                --extra-index-url https://pypi.org/simple || \
+                echo "::warning::pin failed: $spec"
+            done < /tmp/seed_pins.txt
+          fi
 
       - name: Run install cell
         run: |

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -53,7 +53,31 @@
 name: Security audit
 
 on:
+  # PRs run this only when they touch something it actually reads. Every job here is a
+  # function of the dependency manifests, the lockfiles, or the scanner sources: the pip
+  # shards build their input entirely from pyproject.toml + studio/backend/requirements/**,
+  # the npm jobs read studio/frontend/package*.json, and advisory-audit adds
+  # studio/src-tauri/Cargo.lock. A PR touching none of those cannot change any verdict, and
+  # over a 198 PR sample only 3.5% touched them, so the other 96.5% were re-scanning an
+  # unchanged dependency tree for roughly 40 minutes each.
+  #
+  # The floating pins that CAN change a verdict without a diff (a version range resolving to
+  # a new release, a fresh advisory) are covered by the daily cron below, which is
+  # deliberately left unfiltered, as is every push to main. So the worst case a filter
+  # introduces is that a newly published malicious version is caught by the nightly run or at
+  # merge instead of on the PR that did not touch dependencies.
   pull_request:
+    paths:
+      - 'pyproject.toml'
+      - 'studio/backend/requirements/**'
+      - 'studio/frontend/package.json'
+      - 'studio/frontend/package-lock.json'
+      - 'studio/src-tauri/Cargo.lock'
+      - 'studio/src-tauri/Cargo.toml'
+      - 'scripts/scan_packages.py'
+      - 'scripts/scan_packages_baseline.json'
+      - 'tests/security/**'
+      - '.github/workflows/security-audit.yml'
   push:
     branches: [main]
   schedule:

--- a/.github/workflows/studio-backend-ci.yml
+++ b/.github/workflows/studio-backend-ci.yml
@@ -75,6 +75,9 @@ jobs:
         with:
           python-version: '${{ matrix.python }}'
           cache: 'pip'
+          cache-dependency-path: |
+            pyproject.toml
+            studio/backend/requirements/*.txt
 
       - name: Install backend test dependencies (CPU only)
         run: |
@@ -142,6 +145,9 @@ jobs:
         with:
           python-version: '3.12'
           cache: 'pip'
+          cache-dependency-path: |
+            pyproject.toml
+            studio/backend/requirements/*.txt
 
       # node + uv unlock ~60 tests that previously skipped on CI:
       #   - 9 tests in test_chat_preset_builtin_invariants.py need node to


### PR DESCRIPTION
Three independent bits of waste in the workflow layer. None of them changes what any job verifies.

Measured over a closed 3 hour window where all 248 runs were terminal, the repo burns about 28,500 raw runner-minutes a day, and `pull_request` is 98.3% of it. Top three workflows are 51.8% of the total: Backend CI 25.4%, Core 14.5%, Security audit 11.9%.

## Core downloads CUDA torch and then throws it away

`peft`, `accelerate` and `datasets` were installed **before** the CPU torch pin. All three declare a torch dependency, so pip resolved it from PyPI first: the default CUDA build, plus fourteen `nvidia_*` wheels and cuda-toolkit, roughly 2.3 GB. The next command replaced it with `torch==2.10.0+cpu` seconds later.

Installing the CPU wheel first leaves a byte-identical environment. Timestamped at **73s of a 148s step, times three matrix legs**, and about 7 GB of pointless egress per run.

## Notebooks CI has never completed its smoke install

The step built its Colab-shaped venv with a shell loop, one `pip install` per pin, each a full resolve against two indexes. With roughly 683 pins it consumed its entire `timeout-minutes: 25` cap on every leg of every run, and **has never once reached the `Verify imports under spoof` step that follows it**: 8 legs timed out on 15 Aug, 6 failed and 2 timed out on 16 Aug, 7 and 1 on 14 Aug.

It now does one bulk `pip install -r` and falls back to the per-pin loop only if that fails, so the best-effort contract that tolerates an unresolvable pin is preserved, just moved.

Not fixed here, worth a follow-up: the step ignores `matrix.notebook` entirely, so all 8 legs build an identical venv.

## Every pip cache is keyed on an unrelated file

`setup-python`'s default glob resolves to the repo's only `requirements.txt`, which is `unsloth/kernels/moe/requirements.txt`, five lines that have nothing to do with what most jobs install. Confirmed by reproducing `hashFiles` against the live cache keys.

Core's Python 3.12 Linux slot held about **8 MB** put there by Lint CI, and the install then downloaded **3,249.7 MB** anyway. The "hit" covered 0.14%.

Core now keys on `pyproject.toml` plus `studio/backend/requirements/*.txt`. Sixteen other workflows share the defect and are deliberately left alone in this PR.

## Security audit ran on every PR with no path filter

Every job in that workflow is a function of the dependency manifests, the lockfiles, or the scanner sources. The three pip shards build their input entirely from `pyproject.toml` and `studio/backend/requirements/**`, the npm jobs read `studio/frontend/package*.json`, and advisory-audit adds `studio/src-tauri/Cargo.lock`.

Over a 198 PR sample, **3.5% touched any of those**. The other 96.5% re-scanned an unchanged dependency tree for about 40 minutes each. The three scan shards alone are 28.4 of the workflow's 40 minutes.

The filter is on `pull_request` only, and that matters. The daily cron and every push to `main` stay unfiltered, because they are what catches the case a path filter structurally cannot see: a floating version range resolving to a newly published malicious release, with no diff to trigger on. So the worst case this introduces is that such a release is caught by the nightly run or at merge, rather than on a PR that did not touch dependencies. That seemed the right trade at 96.5%, but it is the one change here I would most want a second opinion on.

## Checks

`scripts/lint_workflow_triggers.py` passes: 42 workflow files scanned, no `pull_request_target`, no unjustified `workflow_run`, no PR/publish cache-key collision. All three modified files parse.

## Not proposed here

Backend CI's four-Python matrix is the weakest fan-out in the repo, with sole-failure counts of 2/1/1/0 across 34 quorum runs and never 2 or 3 legs agreeing, which is a flake signature rather than a version signature. Narrowing it on PRs while keeping the full matrix on push and nightly would be a further large saving, but it is a coverage-latency tradeoff rather than pure waste, so it belongs in its own discussion. Core's three HF/TRL legs were checked and are genuinely distinct: they resolve 4.57.6/0.29.1, 5.5.0/0.24.0 and 5.15.0/1.10.0. Keep all three.
