### PR TITLE
Give the pasted-text import an extension so the node test runner can load it

### DIFF
--- a/studio/frontend/src/features/chat/stores/chat-preferences-store.ts
+++ b/studio/frontend/src/features/chat/stores/chat-preferences-store.ts
@@ -6,7 +6,7 @@ import { persist } from "zustand/middleware";
 import {
   PASTED_TEXT_DEFAULT_MIN_CHARS,
   PASTED_TEXT_THRESHOLD_CHOICES,
-} from "../utils/pasted-text";
+} from "../utils/pasted-text.ts";
 
 // Client-side chat UI prefs kept in localStorage, not the chat DB.
 // confirmDeleteChats: when off, deleting a chat skips the confirm dialog.


### PR DESCRIPTION
`Frontend build + bundle sanity` is red on `main`. `tests/delete-chat-files-preference.test.ts` fails with:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module
  .../studio/frontend/src/features/chat/utils/pasted-text
```

and the file is right there. The missing piece is the extension.

## Cause

The frontend suite runs under `node --experimental-strip-types --test`, and Node's ESM resolver does not append extensions. #8963 added

```ts
} from "../utils/pasted-text";
```

to `chat-preferences-store.ts`, and the test imports that store for its value:

```ts
import { useChatPreferencesStore } from "../src/features/chat/stores/chat-preferences-store.ts";
```

so the resolver is asked for a file literally named `pasted-text`, and there is not one.

The two sibling modules importing the same file already write it with the extension, `use-chat-search-index.ts` and `prompt-storage-dialog.tsx`, so this restores the existing convention rather than inventing one.

## Reproduced in isolation

```
$ node --experimental-strip-types a_noext.ts   # import { x } from "./b"
Error [ERR_MODULE_NOT_FOUND]: Cannot find module .../b

$ node --experimental-strip-types a_ext.ts     # import { x } from "./b.ts"
resolved 1
```

## Scope, and why this is one line

47 other relative imports without an extension live in modules the tests name, which looks alarming until you separate them. All but two are erased before resolution: they are `import type`, or a braced clause containing nothing but `type` members, so type stripping removes them and the resolver never sees the specifier.

The two genuine value imports are `chat-settings-api.ts -> ../utils/settings-retry` and `per-model-config.ts -> ./model-identity`. Neither is reached at runtime: the tests that mention those files hand the path to `readFile` and assert on the source text, or import only their types. They are latent rather than broken, so they are not touched here. They will bite the day a test imports either module for its value, which is worth a follow-up but not a silent change in a red-main fix.
