### PR TITLE
Cut Repo tests (CPU) roughly in half: stop the synthetic vLLM tests reaping a fake server

### DIFF
--- a/tests/test_synthetic_vllm_startup_failure.py
+++ b/tests/test_synthetic_vllm_startup_failure.py
@@ -89,12 +89,42 @@ class _FakeProcess:
         return self._returncode
 
 
+# Every kit built here, kept alive past the end of the test that made it so the
+# fixture below, and not the dying test frame, decides when it is collected.
+_LIVE_KITS = []
+
+
 def _kit(stdout_capture, stderr_capture, process):
     kit = SyntheticDataKit.__new__(SyntheticDataKit)
     kit.stdout_capture = stdout_capture
     kit.stderr_capture = stderr_capture
     kit.vllm_process = process
+    _LIVE_KITS.append(kit)
     return kit
+
+
+@pytest.fixture(autouse = True)
+def _retire_kits_without_reaping_a_server():
+    """Stop `__del__` running a real server teardown against a fake process.
+
+    `SyntheticDataKit.__del__` calls `cleanup()`, which ends in
+    `for _ in range(10): torch.cuda.empty_cache(); gc.collect()`. Ten full
+    collections cost about 3s per test when this file runs alone, but scale with
+    the live heap: inside the whole repo suite they cost about 40s per test, which
+    is why 15 of the 16 slowest tests in the suite are in this file.
+
+    None of these tests have a server to reap, and none of them assert on
+    `cleanup()`. `cleanup()` returns immediately when `vllm_process` is absent, so
+    dropping the attribute retires the kit without the collections. The teardown
+    the tests do care about, `terminate_tree` on the failure path, is asserted
+    inside the tests themselves and is untouched.
+    """
+    yield
+    while _LIVE_KITS:
+        kit = _LIVE_KITS.pop()
+        for attribute in ("vllm_process", "_delete_vllm"):
+            if hasattr(kit, attribute):
+                delattr(kit, attribute)
 
 
 REAL_STDERR_TAIL = (
@@ -344,7 +374,7 @@ def test_the_metrics_wait_is_bounded_by_time_not_by_attempts(monkeypatch):
         kit._await_metrics_endpoint()
     spent = clock["now"] - started
     assert spent <= 110, (
-        f"spent {spent:.0f}s of simulated time on a wait the message calls " f"100 seconds"
+        f"spent {spent:.0f}s of simulated time on a wait the message calls 100 seconds"
     )
 
 

--- a/tests/test_synthetic_vllm_startup_failure.py
+++ b/tests/test_synthetic_vllm_startup_failure.py
@@ -373,9 +373,9 @@ def test_the_metrics_wait_is_bounded_by_time_not_by_attempts(monkeypatch):
     with pytest.raises(RuntimeError):
         kit._await_metrics_endpoint()
     spent = clock["now"] - started
-    assert spent <= 110, (
-        f"spent {spent:.0f}s of simulated time on a wait the message calls 100 seconds"
-    )
+    assert (
+        spent <= 110
+    ), f"spent {spent:.0f}s of simulated time on a wait the message calls 100 seconds"
 
 
 def test_an_unbounded_timeout_is_a_wait_not_a_type_error():


### PR DESCRIPTION
`Repo tests (CPU)` takes about 26 minutes. Roughly 640s of that is one test file.

## What is slow

15 of the 16 slowest calls in the whole repo suite are in `tests/test_synthetic_vllm_startup_failure.py`, at about 40s each.

The tests themselves are not slow. Each builds a `SyntheticDataKit` through `__new__` and lets it be collected, so `SyntheticDataKit.__del__` runs `cleanup()`, which ends in:

```python
for _ in range(10):
    torch.cuda.empty_cache()
    gc.collect()
```

Ten full collections per test. Their cost scales with the live heap, which is why this is invisible when you run the file on its own and dominates inside the suite:

| context | per test |
| --- | --- |
| the file alone | about 3.0s |
| after `tests/studio` (3908 tests) | about 5.5s |
| the full repo suite (about 10.7k tests) | about 40.0s |

That measurement order matters: running the file by itself is the one context where the problem does not appear, so it is easy to conclude there is nothing here.

## The fix

Test-side. **No production code changes.**

None of these tests have a server to reap, and none of them assert on `cleanup()`. `cleanup()` already returns immediately when `vllm_process` is absent, so each kit is held past the end of its test and that attribute is dropped in teardown. The teardown the tests do care about, `terminate_tree` on the failure path, is asserted inside the tests and is untouched.

I deliberately did not touch the `range(10)` loop in `unsloth/dataprep/synthetic.py`. It is real VRAM-release behaviour for real users, and changing production to suit a test would be the wrong trade. Worth a separate look on its own merits, since calling `gc.collect()` from inside `__del__` is a questionable pattern, but not here.

## Numbers

The file alone: **43.44s to 0.59s**, 23 passed either way.

Full `Repo tests (CPU)` command, CPU-only, same machine, four runs:

| tree | serial | `-n 4` |
| --- | --- | --- |
| before | 1396.3s | 798.1s |
| after | **731.6s** | **202.4s** |

Serial drops 664.7s, or 47.6%.

All four runs produce the **identical** result set: 8067 passed, 178 skipped, and the same single failure, `tests/test_torchao_nf4tensor_move.py::test_it_is_idempotent`, which fails on my machine even as a lone test because a real `torchao` is installed here. It is green on CI and unrelated to this change.

The `-n 4` column is measurement only, not a proposal in this PR. It is there because it shows the two effects compound: before this change one xdist worker spent about 10.6 minutes on this file while the other three sat idle, which is why parallelism alone only bought 1.75x.

## Note

CI on this branch will also show `tests/studio/test_deep_research_frontend_contract.py::test_research_presentation_is_integrated` failing. That is the pre-existing failure on main, fixed separately in #8986, not something from this change.