### PR TITLE
Read the logit transforms from one place instead of four

### DIFF
--- a/tests/python/test_grpo_ddp_model_config.py
+++ b/tests/python/test_grpo_ddp_model_config.py
@@ -29,3 +29,56 @@ def test_grpo_logit_scaling_uses_model_config_helper():
     assert "inspect.getsource(_unsloth_get_model_config)" in src
     # No direct model.config access remains in the RL logit path.
     assert "model.config" not in src
+
+
+def test_detect_logit_transforms_reads_the_unwrapped_config():
+    """The shared helper must be handed model_config, never the bare model.
+
+    detect_logit_transforms only does getattr(x, "config", x), so a DDP or
+    Accelerate wrapper (which does not forward .config) makes it read the
+    transforms off the wrapper and report zeros. That silently drops Gemma
+    softcapping and Cohere/Granite/Falcon-H1 scaling on multi-GPU runs.
+    """
+    src = _read_source()
+    assert "detect_logit_transforms(model)" not in src
+    assert src.count("detect_logit_transforms(model_config)") >= 2
+
+
+def test_detect_logit_transforms_zeroes_out_on_a_wrapped_model():
+    """Behavioural counterpart: prove the wrapper really does hide .config."""
+    torch = __import__("importlib").import_module("torch")
+    transformers = __import__("importlib").import_module("transformers")
+    planner = __import__("importlib").import_module("unsloth_zoo.device_map_planner")
+    detect = getattr(planner, "detect_logit_transforms", None)
+    if detect is None:
+        return  # older unsloth_zoo: the fallback branch is in use
+
+    class _Inner(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.config = transformers.Gemma2Config()
+
+    class _Wrapper(torch.nn.Module):
+        """Same shape as DistributedDataParallel: real model under .module."""
+
+        def __init__(self, module):
+            super().__init__()
+            self.module = module
+
+    inner = _Inner()
+    wrapped = _Wrapper(inner)
+    assert not hasattr(wrapped, "config")
+    # The bare wrapper hides the config, so the helper finds nothing.
+    assert detect(wrapped)["logit_softcapping"] == 0.0
+    # Unwrapped through the helper the real value comes back.
+    config = _unsloth_get_model_config_reference(wrapped)
+    assert detect(config)["logit_softcapping"] == inner.config.final_logit_softcapping
+
+
+def _unsloth_get_model_config_reference(model):
+    """Mirror of rl_replacements._unsloth_get_model_config, kept local so this
+    test does not need to import the heavyweight module."""
+    config = getattr(model, "config", None)
+    if config is None and hasattr(model, "module"):
+        config = getattr(model.module, "config", None)
+    return config

--- a/tests/python/test_grpo_ddp_model_config.py
+++ b/tests/python/test_grpo_ddp_model_config.py
@@ -45,7 +45,15 @@ def test_detect_logit_transforms_reads_the_unwrapped_config():
 
 
 def test_detect_logit_transforms_zeroes_out_on_a_wrapped_model():
-    """Behavioural counterpart: prove the wrapper really does hide .config."""
+    """Behavioural counterpart: the resolved config must yield the transforms.
+
+    Deliberately does not assert what the helper does with the *bare* wrapper.
+    Older unsloth_zoo only did ``getattr(x, "config", x)`` and reported nothing;
+    newer versions unwrap ``.module`` / ``._orig_mod`` themselves. Both are fine,
+    and pinning either would make this test track the zoo's internals. What must
+    hold on every version is that the config we resolve and pass in is the one
+    the transforms come back from, which is why the call sites pass model_config.
+    """
     torch = __import__("importlib").import_module("torch")
     transformers = __import__("importlib").import_module("transformers")
     planner = __import__("importlib").import_module("unsloth_zoo.device_map_planner")
@@ -67,11 +75,11 @@ def test_detect_logit_transforms_zeroes_out_on_a_wrapped_model():
 
     inner = _Inner()
     wrapped = _Wrapper(inner)
+    # The wrapper itself exposes no .config, which is the whole reason the
+    # call sites have to resolve it before handing it over.
     assert not hasattr(wrapped, "config")
-    # The bare wrapper hides the config, so the helper finds nothing.
-    assert detect(wrapped)["logit_softcapping"] == 0.0
-    # Unwrapped through the helper the real value comes back.
     config = _unsloth_get_model_config_reference(wrapped)
+    assert config is inner.config
     assert detect(config)["logit_softcapping"] == inner.config.final_logit_softcapping
 
 

--- a/tests/python/test_grpo_ddp_model_config.py
+++ b/tests/python/test_grpo_ddp_model_config.py
@@ -34,10 +34,9 @@ def test_grpo_logit_scaling_uses_model_config_helper():
 def test_detect_logit_transforms_reads_the_unwrapped_config():
     """The shared helper must be handed model_config, never the bare model.
 
-    detect_logit_transforms only does getattr(x, "config", x), so a DDP or
-    Accelerate wrapper (which does not forward .config) makes it read the
-    transforms off the wrapper and report zeros. That silently drops Gemma
-    softcapping and Cohere/Granite/Falcon-H1 scaling on multi-GPU runs.
+    A DDP/Accelerate wrapper does not forward .config, so passing the model makes
+    the helper report zeros, silently dropping Gemma softcapping and
+    Cohere/Granite/Falcon-H1 scaling on multi-GPU runs.
     """
     src = _read_source()
     assert "detect_logit_transforms(model)" not in src
@@ -47,12 +46,11 @@ def test_detect_logit_transforms_reads_the_unwrapped_config():
 def test_detect_logit_transforms_zeroes_out_on_a_wrapped_model():
     """Behavioural counterpart: the resolved config must yield the transforms.
 
-    Deliberately does not assert what the helper does with the *bare* wrapper.
-    Older unsloth_zoo only did ``getattr(x, "config", x)`` and reported nothing;
-    newer versions unwrap ``.module`` / ``._orig_mod`` themselves. Both are fine,
-    and pinning either would make this test track the zoo's internals. What must
-    hold on every version is that the config we resolve and pass in is the one
-    the transforms come back from, which is why the call sites pass model_config.
+    Deliberately does not assert what the helper does with the *bare* wrapper: older
+    unsloth_zoo reported nothing, newer versions unwrap ``.module`` / ``._orig_mod``
+    themselves, and pinning either would make this test track the zoo's internals.
+    What holds on every version is that the config we resolve is the one the
+    transforms come back from, which is why the call sites pass model_config.
     """
     torch = __import__("importlib").import_module("torch")
     transformers = __import__("importlib").import_module("transformers")
@@ -75,8 +73,7 @@ def test_detect_logit_transforms_zeroes_out_on_a_wrapped_model():
 
     inner = _Inner()
     wrapped = _Wrapper(inner)
-    # The wrapper itself exposes no .config, which is the whole reason the
-    # call sites have to resolve it before handing it over.
+    # No .config on the wrapper, which is why call sites resolve it first.
     assert not hasattr(wrapped, "config")
     config = _unsloth_get_model_config_reference(wrapped)
     assert config is inner.config
@@ -84,8 +81,8 @@ def test_detect_logit_transforms_zeroes_out_on_a_wrapped_model():
 
 
 def _unsloth_get_model_config_reference(model):
-    """Mirror of rl_replacements._unsloth_get_model_config, kept local so this
-    test does not need to import the heavyweight module."""
+    """Mirror of rl_replacements._unsloth_get_model_config, kept local to avoid
+    importing the heavyweight module."""
     config = getattr(model, "config", None)
     if config is None and hasattr(model, "module"):
         config = getattr(model.module, "config", None)

--- a/tests/python/test_grpo_logit_transform_families.py
+++ b/tests/python/test_grpo_logit_transform_families.py
@@ -1,0 +1,135 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team.
+"""Pins the logit transforms the GRPO path applies, per model family.
+
+The GRPO loss recomputes log-probs from hidden states, so whatever the model's
+own ``forward`` does to its logits has to be reproduced here exactly. Getting a
+factor wrong does not raise: it silently shifts every log-prob, and with it the
+importance ratio the policy gradient is built from.
+
+``unsloth_zoo.device_map_planner.detect_logit_transforms`` owns the field names.
+This test owns the expected *values*, so that a change in the helper's coverage
+shows up here as a diff to read rather than as a quiet numerics shift.
+
+The order the loss applies them in is multiply, then divide, then soft cap
+(``unsloth_zoo/rl_replacements.py``), which matches what each family's
+``modeling_*.py`` does on the line after ``lm_head``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+detect = pytest.importorskip(
+    "unsloth_zoo.device_map_planner",
+    reason = "unsloth_zoo without the planner: the fallback branch is in use",
+).__dict__.get("detect_logit_transforms")
+
+pytestmark = pytest.mark.skipif(
+    detect is None,
+    reason = "installed unsloth_zoo predates detect_logit_transforms",
+)
+
+
+class _Cfg:
+    """Minimal stand-in for a PretrainedConfig.
+
+    Built by hand rather than imported, because the three families that changed
+    most recently only exist on transformers 5.9+, and this test has to keep
+    running on the pinned version.
+    """
+
+    def __init__(self, **fields):
+        for key, value in fields.items():
+            setattr(self, key, _Cfg(**value) if isinstance(value, dict) else value)
+
+
+def _grpo_transforms(config):
+    """Exactly what rl_replacements derives before handing off to the loss."""
+    t = detect(config)
+    return (
+        t["logit_softcapping"],
+        t["logit_scale_multiply"],
+        t["logit_scale_divide"],
+    )
+
+
+# (name, config, (softcapping, multiply, divide), why)
+_COVERED = [
+    (
+        "granite",
+        _Cfg(model_type = "granite", logits_scaling = 8.0),
+        (0.0, 0.0, 8.0),
+        "modeling_granite.py divides: logits = logits / config.logits_scaling",
+    ),
+    (
+        "cohere",
+        _Cfg(model_type = "cohere", logit_scale = 0.0625),
+        (0.0, 0.0625, 0.0),
+        "modeling_cohere.py multiplies: logits = logits * self.logit_scale",
+    ),
+    (
+        "falcon_h1",
+        _Cfg(model_type = "falcon_h1", lm_head_multiplier = 0.01953125),
+        (0.0, 0.01953125, 0.0),
+        "modeling_falcon_h1.py multiplies by model.lm_head_multiplier",
+    ),
+    (
+        "gemma2",
+        _Cfg(model_type = "gemma2", final_logit_softcapping = 30.0),
+        (30.0, 0.0, 0.0),
+        "Gemma-style tanh soft cap, no scale",
+    ),
+]
+
+
+@pytest.mark.parametrize("name, config, expected, why", _COVERED)
+def test_stable_families(name, config, expected, why):
+    assert _grpo_transforms(config) == expected, why
+
+
+# Families whose bucketing the helper only learned recently. Each entry records
+# what the GRPO path used to apply, so the behaviour change stays legible.
+_RECENT = [
+    (
+        "muse_glimmer",
+        _Cfg(
+            model_type = "muse_glimmer",
+            text_config = {
+                "final_logit_softcapping": 20.0,
+                "output_multiplier": 0.19611613513818404,
+            },
+        ),
+        (20.0, 0.19611613513818404, 0.0),
+        (20.0, 0.0, 0.0),
+        "transformers applies logits * output_multiplier before the soft cap",
+    ),
+    (
+        "hyperclovax",
+        _Cfg(model_type = "hyperclovax", logits_scaling = 8.0),
+        (0.0, 8.0, 0.0),
+        (0.0, 0.0, 8.0),
+        "MuP multiplies by logits_scaling, unlike Granite which divides",
+    ),
+    (
+        "minicpm3",
+        _Cfg(model_type = "minicpm3", logits_scaling = 8.0),
+        (0.0, 0.0, 0.0),
+        (0.0, 0.0, 8.0),
+        "logits_scaling scales hidden states before the head, not the logits",
+    ),
+]
+
+
+@pytest.mark.parametrize("name, config, expected, previously, why", _RECENT)
+def test_recently_rebucketed_families(name, config, expected, previously, why):
+    """These three changed what the GRPO path applies. Deliberate, see the PR body.
+
+    Skips rather than fails on an unsloth_zoo that predates the coverage, so the
+    suite stays green across the version window instead of pinning one release.
+    """
+    got = _grpo_transforms(config)
+    if got == previously:
+        pytest.skip(f"installed unsloth_zoo predates {name} coverage")
+    assert got == expected, why

--- a/tests/python/test_grpo_logit_transform_families.py
+++ b/tests/python/test_grpo_logit_transform_families.py
@@ -2,18 +2,17 @@
 # Copyright 2026-present the Unsloth AI Inc. team.
 """Pins the logit transforms the GRPO path applies, per model family.
 
-The GRPO loss recomputes log-probs from hidden states, so whatever the model's
-own ``forward`` does to its logits has to be reproduced here exactly. Getting a
-factor wrong does not raise: it silently shifts every log-prob, and with it the
-importance ratio the policy gradient is built from.
+The GRPO loss recomputes log-probs from hidden states, so it has to reproduce what
+the model's own ``forward`` does to its logits. A wrong factor does not raise: it
+silently shifts every log-prob, and with it the importance ratio.
 
-``unsloth_zoo.device_map_planner.detect_logit_transforms`` owns the field names.
-This test owns the expected *values*, so that a change in the helper's coverage
-shows up here as a diff to read rather than as a quiet numerics shift.
+``detect_logit_transforms`` owns the field names, this test owns the expected
+*values*, so a change in its coverage shows up here as a diff rather than a quiet
+numerics shift.
 
-The order the loss applies them in is multiply, then divide, then soft cap
-(``unsloth_zoo/rl_replacements.py``), which matches what each family's
-``modeling_*.py`` does on the line after ``lm_head``.
+The loss applies them in the order multiply, divide, soft cap
+(``unsloth_zoo/rl_replacements.py``), matching what each family's ``modeling_*.py``
+does on the line after ``lm_head``.
 """
 
 from __future__ import annotations
@@ -33,12 +32,8 @@ pytestmark = pytest.mark.skipif(
 
 
 class _Cfg:
-    """Minimal stand-in for a PretrainedConfig.
-
-    Built by hand rather than imported, because the three families that changed
-    most recently only exist on transformers 5.9+, and this test has to keep
-    running on the pinned version.
-    """
+    """Stand-in for a PretrainedConfig, built by hand because the newest families
+    here only exist on transformers 5.9+ and this test runs on the pinned version."""
 
     def __init__(self, **fields):
         for key, value in fields.items():
@@ -89,8 +84,8 @@ def test_stable_families(name, config, expected, why):
     assert _grpo_transforms(config) == expected, why
 
 
-# Families whose bucketing the helper only learned recently. Each entry records
-# what the GRPO path used to apply, so the behaviour change stays legible.
+# Families the helper only bucketed recently. Each entry records what the GRPO path
+# used to apply, so the behaviour change stays legible.
 _RECENT = [
     (
         "muse_glimmer",
@@ -126,8 +121,8 @@ _RECENT = [
 def test_recently_rebucketed_families(name, config, expected, previously, why):
     """These three changed what the GRPO path applies. Deliberate, see the PR body.
 
-    Skips rather than fails on an unsloth_zoo that predates the coverage, so the
-    suite stays green across the version window instead of pinning one release.
+    Skips rather than fails on an unsloth_zoo predating the coverage, so the suite
+    stays green across the version window instead of pinning one release.
     """
     got = _grpo_transforms(config)
     if got == previously:

--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -63,10 +63,9 @@ from unsloth_zoo.hf_utils import (
 from unsloth_zoo.peft_utils import SKIP_QUANTIZATION_MODULES
 
 try:
-    # The same three values the device map planner sizes the head's card from.
     from unsloth_zoo.device_map_planner import detect_logit_transforms
 except ImportError:
-    # Older unsloth_zoo. Fall back to reading the fields directly.
+    # Older unsloth_zoo: fall back to reading the config fields directly.
     detect_logit_transforms = None
 from ..device_type import (
     is_hip,
@@ -1529,11 +1528,10 @@ def CausalLM_fast_forward(fast_forward_inference):
 
         logits = logits.to(_get_dtype(dtype_from_config(self.config)))
         loss = None
-        # Which field carries the scale is per family: cohere multiplies by
-        # logit_scale (0.125), granite divides by logits_scaling (16), falcon_h1
-        # multiplies by lm_head_multiplier. detect_logit_transforms knows all of
-        # them, and the device map planner sizes the head's card from the same
-        # answer, so a new architecture is taught once instead of twice.
+        # Which field carries the scale is per family: cohere multiplies by logit_scale,
+        # granite divides by logits_scaling, falcon_h1 multiplies by lm_head_multiplier.
+        # detect_logit_transforms knows all of them, and the device map planner sizes the
+        # head's card from the same answer, so a new family is taught once, not twice.
         # granite: https://github.com/huggingface/transformers/blob/4d1d0f29a493098e6bc6b904b82e29cb331827f5/src/transformers/models/granite/modeling_granite.py#L1103
         # cohere: https://github.com/huggingface/transformers/blob/4d1d0f29a493098e6bc6b904b82e29cb331827f5/src/transformers/models/cohere/modeling_cohere.py#L1176
         if detect_logit_transforms is not None:

--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -61,6 +61,12 @@ from unsloth_zoo.hf_utils import (
     fix_lora_auto_mapping,
 )
 from unsloth_zoo.peft_utils import SKIP_QUANTIZATION_MODULES
+try:
+    # The same three values the device map planner sizes the head's card from.
+    from unsloth_zoo.device_map_planner import detect_logit_transforms
+except ImportError:
+    # Older unsloth_zoo. Fall back to reading the fields directly.
+    detect_logit_transforms = None
 from ..device_type import (
     is_hip,
     get_device_type,
@@ -1522,15 +1528,26 @@ def CausalLM_fast_forward(fast_forward_inference):
 
         logits = logits.to(_get_dtype(dtype_from_config(self.config)))
         loss = None
-        logit_softcapping = getattr(self.config, "final_logit_softcapping", 0)
-        logit_scaling = getattr(self.config, "logit_scale", 0)
-        if self.config.model_type == "granite":
-            # granite divides by logits_scaling (16) unlike cohere which multiplies by 0.125.
-            # granite: https://github.com/huggingface/transformers/blob/4d1d0f29a493098e6bc6b904b82e29cb331827f5/src/transformers/models/granite/modeling_granite.py#L1103
-            # cohere: https://github.com/huggingface/transformers/blob/4d1d0f29a493098e6bc6b904b82e29cb331827f5/src/transformers/models/cohere/modeling_cohere.py#L1176
-            logit_scaling = 1 / getattr(self.config, "logits_scaling", 1)
-        elif self.config.model_type == "falcon_h1":
-            logit_scaling = self.config.lm_head_multiplier
+        # Which field carries the scale is per family: cohere multiplies by
+        # logit_scale (0.125), granite divides by logits_scaling (16), falcon_h1
+        # multiplies by lm_head_multiplier. detect_logit_transforms knows all of
+        # them, and the device map planner sizes the head's card from the same
+        # answer, so a new architecture is taught once instead of twice.
+        # granite: https://github.com/huggingface/transformers/blob/4d1d0f29a493098e6bc6b904b82e29cb331827f5/src/transformers/models/granite/modeling_granite.py#L1103
+        # cohere: https://github.com/huggingface/transformers/blob/4d1d0f29a493098e6bc6b904b82e29cb331827f5/src/transformers/models/cohere/modeling_cohere.py#L1176
+        if detect_logit_transforms is not None:
+            _transforms = detect_logit_transforms(self.config)
+            logit_softcapping = _transforms["logit_softcapping"]
+            logit_scaling = _transforms["logit_scale_multiply"]
+            if not logit_scaling and _transforms["logit_scale_divide"]:
+                logit_scaling = 1 / _transforms["logit_scale_divide"]
+        else:
+            logit_softcapping = getattr(self.config, "final_logit_softcapping", 0)
+            logit_scaling = getattr(self.config, "logit_scale", 0)
+            if self.config.model_type == "granite":
+                logit_scaling = 1 / getattr(self.config, "logits_scaling", 1)
+            elif self.config.model_type == "falcon_h1":
+                logit_scaling = self.config.lm_head_multiplier
 
         if labels is not None:
             shift_logits = logits

--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -61,6 +61,7 @@ from unsloth_zoo.hf_utils import (
     fix_lora_auto_mapping,
 )
 from unsloth_zoo.peft_utils import SKIP_QUANTIZATION_MODULES
+
 try:
     # The same three values the device map planner sizes the head's card from.
     from unsloth_zoo.device_map_planner import detect_logit_transforms

--- a/unsloth/models/rl_replacements.py
+++ b/unsloth/models/rl_replacements.py
@@ -2626,6 +2626,15 @@ RL_PRE_ITEMS["grpo_trainer"].append(
     "    except Exception:\n"
     "        UNSLOTH_GRPO_PREFIX_GROUPER_ON = False\n"
 )
+# The inlined grpo functions call detect_logit_transforms, and getsource copies their
+# bodies but not this file's imports, so the generated cache needs its own guarded
+# import or the call raises NameError.
+RL_PRE_ITEMS["grpo_trainer"].append(
+    "try:\n"
+    "    from unsloth_zoo.device_map_planner import detect_logit_transforms\n"
+    "except Exception:\n"
+    "    detect_logit_transforms = None\n"
+)
 
 
 # Edit _get_per_token_logps to handle mixed precision
@@ -2736,13 +2745,22 @@ def grpo_trainer_compute_loss(function_name, function):
 
         # Get logit softcapping and logit scale
         model_config = _unsloth_get_model_config(model)
-        logit_softcapping = _unsloth_get_final_logit_softcapping(model)  # Gemma
-        logit_scale_multiply = getattr(model_config, "logit_scale", 0)  # Cohere
-        if logit_scale_multiply is None:
-            logit_scale_multiply = 0
-        logit_scale_divide = getattr(model_config, "logits_scaling", 0)  # Granite
-        if logit_scale_divide is None:
-            logit_scale_divide = 0
+        # Same source as _get_per_token_logps_and_entropies: the old and reference
+        # logps come from there and the gradient logps from here, so both have to read
+        # the transforms the same way or the ratio compares two different policies.
+        if detect_logit_transforms is not None:
+            _transforms = detect_logit_transforms(model)
+            logit_softcapping = _transforms["logit_softcapping"]
+            logit_scale_multiply = _transforms["logit_scale_multiply"]
+            logit_scale_divide = _transforms["logit_scale_divide"]
+        else:
+            logit_softcapping = _unsloth_get_final_logit_softcapping(model)  # Gemma
+            logit_scale_multiply = getattr(model_config, "logit_scale", 0)  # Cohere
+            if logit_scale_multiply is None:
+                logit_scale_multiply = 0
+            logit_scale_divide = getattr(model_config, "logits_scaling", 0)  # Granite
+            if logit_scale_divide is None:
+                logit_scale_divide = 0
 
         max_left_pad = inputs.get("max_left_pad", 0)
         if per_token_logps is not None:

--- a/unsloth/models/rl_replacements.py
+++ b/unsloth/models/rl_replacements.py
@@ -40,6 +40,7 @@ from trl import __version__ as trl_version_raw
 from importlib.metadata import version as importlib_version
 from unsloth_zoo.log import logger
 from unsloth_zoo.device_type import device_synchronize
+
 try:
     # The device map planner sizes the head's card from the same three values,
     # so both read them here rather than each deriving its own.

--- a/unsloth/models/rl_replacements.py
+++ b/unsloth/models/rl_replacements.py
@@ -42,11 +42,9 @@ from unsloth_zoo.log import logger
 from unsloth_zoo.device_type import device_synchronize
 
 try:
-    # The device map planner sizes the head's card from the same three values,
-    # so both read them here rather than each deriving its own.
     from unsloth_zoo.device_map_planner import detect_logit_transforms
 except ImportError:
-    # Older unsloth_zoo. Fall back to reading the fields directly.
+    # Older unsloth_zoo: fall back to reading the config fields directly.
     detect_logit_transforms = None
 import importlib.util
 from ..device_type import (
@@ -1727,8 +1725,8 @@ def grpo_trainer__get_per_token_logps_and_entropies(function_name, function):
             temperature = self.temperature
             model_config = _unsloth_get_model_config(model)
             if detect_logit_transforms is not None:
-                # model_config, not model: under DDP/Accelerate `model` is a wrapper
-                # that never forwards `.config`, so the helper would read zeros.
+                # model_config, not model: under DDP/Accelerate `model` is a wrapper that
+                # does not forward `.config`, so the helper would report zeros.
                 _transforms = detect_logit_transforms(model_config)
                 logit_softcapping = _transforms["logit_softcapping"]
                 logit_scale_multiply = _transforms["logit_scale_multiply"]
@@ -2628,9 +2626,8 @@ RL_PRE_ITEMS["grpo_trainer"].append(
     "    except Exception:\n"
     "        UNSLOTH_GRPO_PREFIX_GROUPER_ON = False\n"
 )
-# The inlined grpo functions call detect_logit_transforms, and getsource copies their
-# bodies but not this file's imports, so the generated cache needs its own guarded
-# import or the call raises NameError.
+# getsource inlines the grpo function bodies but not this file's imports, so the
+# generated cache needs its own guarded import or detect_logit_transforms is a NameError.
 RL_PRE_ITEMS["grpo_trainer"].append(
     "try:\n"
     "    from unsloth_zoo.device_map_planner import detect_logit_transforms\n"
@@ -2747,9 +2744,9 @@ def grpo_trainer_compute_loss(function_name, function):
 
         # Get logit softcapping and logit scale
         model_config = _unsloth_get_model_config(model)
-        # Same source as _get_per_token_logps_and_entropies: the old and reference
-        # logps come from there and the gradient logps from here, so both have to read
-        # the transforms the same way or the ratio compares two different policies.
+        # The old and reference logps come from _get_per_token_logps_and_entropies and the
+        # gradient logps from here, so both must read the transforms the same way or the
+        # importance ratio compares two different policies.
         if detect_logit_transforms is not None:
             # model_config, not model: see _get_per_token_logps_and_entropies.
             _transforms = detect_logit_transforms(model_config)

--- a/unsloth/models/rl_replacements.py
+++ b/unsloth/models/rl_replacements.py
@@ -1727,7 +1727,9 @@ def grpo_trainer__get_per_token_logps_and_entropies(function_name, function):
             temperature = self.temperature
             model_config = _unsloth_get_model_config(model)
             if detect_logit_transforms is not None:
-                _transforms = detect_logit_transforms(model)
+                # model_config, not model: under DDP/Accelerate `model` is a wrapper
+                # that never forwards `.config`, so the helper would read zeros.
+                _transforms = detect_logit_transforms(model_config)
                 logit_softcapping = _transforms["logit_softcapping"]
                 logit_scale_multiply = _transforms["logit_scale_multiply"]
                 logit_scale_divide = _transforms["logit_scale_divide"]
@@ -2749,7 +2751,8 @@ def grpo_trainer_compute_loss(function_name, function):
         # logps come from there and the gradient logps from here, so both have to read
         # the transforms the same way or the ratio compares two different policies.
         if detect_logit_transforms is not None:
-            _transforms = detect_logit_transforms(model)
+            # model_config, not model: see _get_per_token_logps_and_entropies.
+            _transforms = detect_logit_transforms(model_config)
             logit_softcapping = _transforms["logit_softcapping"]
             logit_scale_multiply = _transforms["logit_scale_multiply"]
             logit_scale_divide = _transforms["logit_scale_divide"]

--- a/unsloth/models/rl_replacements.py
+++ b/unsloth/models/rl_replacements.py
@@ -40,6 +40,13 @@ from trl import __version__ as trl_version_raw
 from importlib.metadata import version as importlib_version
 from unsloth_zoo.log import logger
 from unsloth_zoo.device_type import device_synchronize
+try:
+    # The device map planner sizes the head's card from the same three values,
+    # so both read them here rather than each deriving its own.
+    from unsloth_zoo.device_map_planner import detect_logit_transforms
+except ImportError:
+    # Older unsloth_zoo. Fall back to reading the fields directly.
+    detect_logit_transforms = None
 import importlib.util
 from ..device_type import (
     is_hip,
@@ -1718,13 +1725,19 @@ def grpo_trainer__get_per_token_logps_and_entropies(function_name, function):
 
             temperature = self.temperature
             model_config = _unsloth_get_model_config(model)
-            logit_softcapping = _unsloth_get_final_logit_softcapping(model)
-            logit_scale_multiply = getattr(model_config, "logit_scale", 0)
-            if logit_scale_multiply is None:
-                logit_scale_multiply = 0
-            logit_scale_divide = getattr(model_config, "logits_scaling", 0)
-            if logit_scale_divide is None:
-                logit_scale_divide = 0
+            if detect_logit_transforms is not None:
+                _transforms = detect_logit_transforms(model)
+                logit_softcapping = _transforms["logit_softcapping"]
+                logit_scale_multiply = _transforms["logit_scale_multiply"]
+                logit_scale_divide = _transforms["logit_scale_divide"]
+            else:
+                logit_softcapping = _unsloth_get_final_logit_softcapping(model)
+                logit_scale_multiply = getattr(model_config, "logit_scale", 0)
+                if logit_scale_multiply is None:
+                    logit_scale_multiply = 0
+                logit_scale_divide = getattr(model_config, "logits_scaling", 0)
+                if logit_scale_divide is None:
+                    logit_scale_divide = 0
 
             zipped_inputs = zip(
                 input_ids_chunks,


### PR DESCRIPTION
Several places in unsloth derive the same three values off the model config: the soft cap, and the two logit scales (multiply or divide, depending on the family). Each derivation knows about a different subset of the architectures:

- `rl_replacements.py:1721` reads `final_logit_softcapping`, `logit_scale` and `logits_scaling`, but misses Falcon-H1's `lm_head_multiplier` and does not look at `config.text_config`.
- `llama.py:1525` special-cases `granite` and `falcon_h1` by `model_type` string, so a variant with a different `model_type` but the same field silently gets nothing.
- `rl_replacements.py:2737` derives the same values a third time, for the gradient path.

`unslothai/unsloth-zoo#1067` adds `detect_logit_transforms`, which the device map planner now uses to size the head's headroom. Since the planner and the loss must agree on which transforms are applied (the planner reserves for exactly the temporaries the loss allocates), they should be reading the same function rather than each deriving its own answer.

## What changed

`rl_replacements.py` and `llama.py` call `detect_logit_transforms` behind a guarded import:

```python
try:
    from unsloth_zoo.device_map_planner import detect_logit_transforms
except ImportError:
    # Older unsloth_zoo. Fall back to reading the fields directly.
    detect_logit_transforms = None
```

Every existing derivation is kept intact on the `None` branch, so an older `unsloth_zoo` behaves exactly as it does today. Nothing here requires the zoo PR to have landed.

`llama.py` divides where the zoo helper reports a divide, so `granite`'s `1 / logits_scaling` is preserved without the `model_type` check.

Both GRPO sites pass `model_config`, not the bare `model`. The helper only does `getattr(x, "config", x)`, and a DDP or Accelerate wrapper does not forward `.config`, so handing it the model would make it read the wrapper and report no transforms at all. That is the same trap `_unsloth_get_model_config` was added to close in #5955.

The generated GRPO trainer gets its own copy of the guarded import via `RL_PRE_ITEMS["grpo_trainer"]`. `inspect.getsource` inlines the patched function bodies but not this file's imports, so without it the name is referenced in `UnslothGRPOTrainer.py` and bound nowhere.

## This is currently a no-op for every user

Worth being explicit about, because it bounds the risk: no released `unsloth_zoo` through 2026.8.12 contains `detect_logit_transforms`, and `pyproject.toml` pins `unsloth_zoo>=2026.8.11`. So on every install that exists today the guarded import fails and the fallback branch runs, which is the pre-PR code verbatim. Nothing changes for anyone until `unsloth-zoo#1067` ships. Both directions of the version skew are safe: new unsloth with old zoo takes the fallback, and old unsloth with new zoo is unaffected because the zoo addition is purely additive.

## Verification

Equivalence-tested the collapsed `llama.py` branch against the old one across gemma2, gemma3, cohere, granite, falcon_h1 and llama configs: 0 mismatches. The new path additionally picks up Falcon-H1 through the config rather than the `model_type` string, and picks up nested `text_config` models the old path missed.

Regenerated `unsloth_compiled_cache/UnslothGRPOTrainer.py` off this branch and confirmed the guarded import lands at module level ahead of both call sites and resolves in the generated module's globals.

`get_text_config()` is the only transformers API the new path leans on. Its signature is identical at 4.57.6, 5.0.0 and 5.15.0, and the only body difference between them sits inside a branch a no-arg call never reaches. It raises `ValueError` when several sub-config names are present, which the helper catches and degrades to "no transforms", i.e. the pre-PR answer. The changed lines contain no torch, vllm or CUDA API, no filesystem path and no shell, so there is no OS-specific or browser-facing surface here.

## Unrelated test noise

A full-suite run on this branch shows a cluster of 5 errors at the 18% mark, all of `tests/saving/test_gguf_export_and_inference.py`. These are pre-existing and not from this PR:

- Root cause is `RuntimeError: Triton Error [CUDA]: no kernel image is available for execution on the device`, raised from two module-scoped fixtures that train a tiny LoRA on GPU. It is GPU/Triton contention inside the long shared-GPU suite, not a logits or config problem.
- A full-suite log captured on upstream `main` before this branch existed has the byte-identical progress line (`..........EEEEE.........  [ 18%]`) and the same five node ids.
- Run standalone in this worktree the module is green: 3 passed, 2 skipped.

## Re-verified against the current unsloth-zoo#1067 helper

The zoo helper changed after this branch was written (`f78ed1f`): it now unwraps `.module` / `._orig_mod` itself, excludes `aya_vision` and `cohere2_vision` (whose `text_config.logit_scale` is never applied by their own head), and additionally detects xLSTM's `output_logit_soft_cap` and T5Gemma's cap on `config.decoder`. Re-ran the per-family diff against that revision: still 0 divergences for every family that reaches `CausalLM_fast_forward` (llama, mistral, gemma, gemma2, qwen2, qwen3, qwen3_moe, glm4_moe).

The call sites keep resolving the config themselves rather than leaning on the helper's new unwrapping. It is a no-op when the helper also unwraps, and it is still required on the fallback branch and against any already-released zoo, so the GRPO path stays correct on every version rather than only the newest.

The xLSTM and T5Gemma additions do change what the GRPO path sees for those two families, from "no cap" to the cap their forward actually applies. That is the intended direction: the recomputed log-probs have to mirror the model's own forward, and previously they did not.

### Deliberate behaviour change: three families in the GRPO path

`unsloth-zoo#1067` now covers three families the old derivation got wrong. Because these call sites *apply* the transform rather than merely size for it, that is a numerics change and not just better coverage, so it is spelled out here with the exact factors.

The `llama.py` path is unaffected: 0 divergences for every family that reaches `CausalLM_fast_forward`. Only the GRPO log-prob path changes, and only for these three.

- **hyperclovax** is the significant one, because it is a re-bucketing rather than a new detection. `logits_scaling` was read as a divisor and is a multiplier (`modeling_hyperclovax.py`: "MuP: multiply logits by logits_scaling (cf. GraniteForCausalLM which divides)"). The path previously applied `logits / s` and now applies `logits * s`, so for a config with `logits_scaling = s` the factor moves by `s**2`. That `s**2` is the size of the bug being corrected, not of a regression being introduced.
- **muse_glimmer** gains a multiplier that was previously dropped entirely: `text_config.output_multiplier`, about `0.196` on the released config. Its soft cap of `20.0` was already applied by both the old and new code.
- **minicpm3** loses a divisor it should never have had. Its `logits_scaling` scales hidden states *before* the head, so applying it to logits was wrong.

Order of operations was checked rather than assumed. The loss applies multiply, then divide, then soft cap. `modeling_muse_glimmer.py:1257` does `logits * output_multiplier` and *then* the tanh cap, i.e. `T * tanh(logits * mult / T)`, which is the same order. Granite and Cohere are unchanged.

`tests/python/test_grpo_logit_transform_families.py` pins the expected triple per family, recording for these three what the path used to apply, so any further movement in the helper's coverage shows up as a failing assertion instead of a silent shift.

**Who this actually affects.** Muse Glimmer GRPO users on transformers 5.15 will see log-probs change by the `0.196` factor, which brings Unsloth into agreement with what transformers actually computes; hyperclovax users on 5.9+ get the `s**2` correction described above. This is reachable, not theoretical. `muse_glimmer` is absent from transformers at `v5.5.0` and `v5.9.0` (HTTP 404 for its `modeling_*.py`) and present at `v5.15.0`, and nothing stops a user from being on 5.15: the `transformers<=5.5.0` bound appears in only 2 of the 173 extras, the core `[project].dependencies` table does not constrain transformers at all, and there is no runtime ceiling check. The Glimmer GRPO notebook installs transformers 5.15 outright. So the affected user is a first-party, shipped one, and for them this is a fix rather than a hazard.

**Why it is not gated off anyway.** Filtering at the call site would mean reintroducing a per-family allow-list, which is the construct this PR removes, and would recreate the same failure mode one level down: the next family added to the helper would be silently ignored by the loss. It would also put the loss and the planner back into disagreement about which transforms exist, which is the invariant this PR is for. Correcting a multiplier that was previously dropped, or applied in the wrong direction, is the right outcome for the users who reach it.

## Base

Opened against `glimmer-loader-quant-metadata-and-device-map` (`#8968`, converged and unmerged), which already touches the `device_map_planner_kwargs` plumbing in these files. Retarget to `main` once that merges.
