### PR TITLE
Studio: read every launcher world size when resolving a step-capped run's passes

### DIFF
--- a/studio/backend/core/training/dataset_bounds.py
+++ b/studio/backend/core/training/dataset_bounds.py
@@ -29,11 +29,10 @@ MIN_MAX_STEPS_ROWS = 1024
 # Launchers that advertise a data-parallel process count. Read as env because this
 # module is torch-free and the bound is computed before any process group exists, so
 # torch.distributed cannot be asked: at bound time it is almost never initialised.
-# The same names routes/inference.py reads, but not the same test: that one pairs each
-# size with its rank partner and requires size > 1, because it is deciding whether to
-# refuse a request. This is sizing a row bound, so a bare size is enough and an absent
-# one costs nothing. Annotated with what actually sets each, since several of these are
-# widely miscited.
+# The MPI names routes/inference.py reads, plus the torchrun ones it does not, and a
+# looser test: it pairs each size with its rank partner because it refuses requests;
+# sizing a row bound only needs a bare size. Annotated per variable, several of which
+# are widely miscited.
 WORLD_SIZE_ENV_VARS = (
     "WORLD_SIZE",  # torchrun, accelerate launch, deepspeed. NOT set by any MPI
     "LOCAL_WORLD_SIZE",  # torchrun's --nproc-per-node; it sets WORLD_SIZE too
@@ -44,13 +43,11 @@ WORLD_SIZE_ENV_VARS = (
     "MPI_WORLD_SIZE",  # likewise undocumented in every MPI checked
     "MV2_COMM_WORLD_SIZE",  # MVAPICH2, and only under its mpirun_rsh launcher
 )
-# The count an mlx.launch advertises when it is not a number in the env: of its five
-# backends only NCCL (CUDA) exports MLX_WORLD_SIZE. Ring and JACCL export a path to a
-# JSON file with one entry per rank instead, and the world size is exactly the length
-# of that outer list. Without these two an mlx.launch reads as one process and the MLX
-# loader under-counts, which is the direction that recycles rows, so the Apple path --
-# the only one MLX training actually runs on -- would keep the bug this module's world
-# size exists to fix.
+# An mlx.launch world size that is not a number in the env: of its five backends only
+# NCCL (CUDA) exports MLX_WORLD_SIZE; ring and JACCL export a path to a JSON file whose
+# outer list has one entry per rank, and that length is the world size. Without these
+# two an mlx.launch reads as one process, and under-counting recycles rows -- so the
+# Apple path, the only one MLX training runs on, would keep the bug this fixes.
 WORLD_SIZE_ENV_FILES = (
     "MLX_HOSTFILE",  # ring backend: a path to [["ip:port", ...], ...], one per rank
     "MLX_IBV_DEVICES",  # jaccl backend: a path to the N x N RDMA matrix, one row per rank
@@ -114,10 +111,10 @@ def world_size_from_rank_files(environ: Any = None) -> int:
             if value.lstrip()[:1] in ("[", "{"):
                 payload = json.loads(value[:MAX_WORLD_SIZE_FILE_BYTES])
             elif os.path.isfile(value):
-                # Binary, so the cap is the bytes it says it is. A text handle's
-                # read() counts CHARACTERS, and a file of 4-byte codepoints would
-                # pull four times the cap off disk. json.loads takes bytes and
-                # raises UnicodeDecodeError, a ValueError, on anything not UTF-8.
+                # Binary, so the cap really is bytes: a text read() counts
+                # CHARACTERS, so 4-byte codepoints would pull 4x the cap off disk.
+                # json.loads takes bytes; non-UTF-8 raises UnicodeDecodeError (a
+                # ValueError), caught below.
                 with open(value, "rb") as handle:
                     payload = json.loads(handle.read(MAX_WORLD_SIZE_FILE_BYTES))
             else:

--- a/studio/backend/core/training/dataset_bounds.py
+++ b/studio/backend/core/training/dataset_bounds.py
@@ -87,7 +87,6 @@ def _seed_int(value: Any, default: int) -> int:
 def world_size_from_rank_files(environ: Any = None) -> int:
     """Ranks an mlx.launch listed in a hostfile, or 1 when there is no readable one.
 
-    Only a list counts, and its length is the count. Anything else -- no such file, a
     Either representation the rest of the repo accepts: the payload inline in the
     variable, or a path to a file holding it. `unsloth_cli/_inference.py`'s
     `_json_rank_count_from_env` reads the same two variables the same way, down to the

--- a/studio/backend/core/training/dataset_bounds.py
+++ b/studio/backend/core/training/dataset_bounds.py
@@ -29,28 +29,31 @@ MIN_MAX_STEPS_ROWS = 1024
 # Launchers that advertise a data-parallel process count. Read as env because this
 # module is torch-free and the bound is computed before any process group exists, so
 # torch.distributed cannot be asked: at bound time it is almost never initialised.
-# MLX_WORLD_SIZE and the MPI pairs mirror the set routes/inference.py already trusts
-# to detect an mlx.launch, so both loaders learn their rank count the same way.
+# The same names routes/inference.py reads, but not the same test: that one pairs each
+# size with its rank partner and requires size > 1, because it is deciding whether to
+# refuse a request. This is sizing a row bound, so a bare size is enough and an absent
+# one costs nothing. Annotated with what actually sets each, since several of these are
+# widely miscited.
 WORLD_SIZE_ENV_VARS = (
-    "WORLD_SIZE",  # torchrun, accelerate launch, deepspeed
-    "LOCAL_WORLD_SIZE",  # torchrun, and the only one it sets per node
+    "WORLD_SIZE",  # torchrun, accelerate launch, deepspeed. NOT set by any MPI
+    "LOCAL_WORLD_SIZE",  # torchrun's --nproc-per-node; it sets WORLD_SIZE too
     "MLX_WORLD_SIZE",  # only mlx.launch's NCCL backend, which is CUDA-only
-    "OMPI_COMM_WORLD_SIZE",
-    "PMI_SIZE",
-    "PMIX_SIZE",
-    "MPI_WORLD_SIZE",
-    "MV2_COMM_WORLD_SIZE",
+    "OMPI_COMM_WORLD_SIZE",  # Open MPI / prterun, alongside OMPI_COMM_WORLD_RANK
+    "PMI_SIZE",  # MPICH and Intel MPI via Hydra; srun only under --mpi=pmi2
+    "PMIX_SIZE",  # nothing sets this: PMIx answers job size through PMIx_Get
+    "MPI_WORLD_SIZE",  # likewise undocumented in every MPI checked
+    "MV2_COMM_WORLD_SIZE",  # MVAPICH2, and only under its mpirun_rsh launcher
 )
-# The count an mlx.launch on Apple silicon advertises, which is not a number in the
-# env: of its four backends only NCCL (CUDA) exports MLX_WORLD_SIZE. Ring and JACCL
-# export a path to a JSON file with one entry per rank instead, and MLX documents the
-# world size as exactly the length of that list. Without these two an mlx.launch reads
-# as one process and the MLX loader under-counts, which is the direction that recycles
-# rows, so the Apple path -- the only one MLX training actually runs on -- would keep
-# the bug this module's world size exists to fix.
+# The count an mlx.launch advertises when it is not a number in the env: of its five
+# backends only NCCL (CUDA) exports MLX_WORLD_SIZE. Ring and JACCL export a path to a
+# JSON file with one entry per rank instead, and the world size is exactly the length
+# of that outer list. Without these two an mlx.launch reads as one process and the MLX
+# loader under-counts, which is the direction that recycles rows, so the Apple path --
+# the only one MLX training actually runs on -- would keep the bug this module's world
+# size exists to fix.
 WORLD_SIZE_ENV_FILES = (
-    "MLX_HOSTFILE",  # ring backend: one "ip:port" list per rank
-    "MLX_IBV_DEVICES",  # jaccl backend: the RDMA matrix, one row per rank
+    "MLX_HOSTFILE",  # ring backend: a path to [["ip:port", ...], ...], one per rank
+    "MLX_IBV_DEVICES",  # jaccl backend: a path to the N x N RDMA matrix, one row per rank
 )
 # A hostfile is a few hundred bytes per rank. Read a bounded prefix so a wrong path
 # (an env var pointed at something enormous) cannot pull a file into memory; a
@@ -111,7 +114,11 @@ def world_size_from_rank_files(environ: Any = None) -> int:
             if value.lstrip()[:1] in ("[", "{"):
                 payload = json.loads(value[:MAX_WORLD_SIZE_FILE_BYTES])
             elif os.path.isfile(value):
-                with open(value, encoding = "utf-8") as handle:
+                # Binary, so the cap is the bytes it says it is. A text handle's
+                # read() counts CHARACTERS, and a file of 4-byte codepoints would
+                # pull four times the cap off disk. json.loads takes bytes and
+                # raises UnicodeDecodeError, a ValueError, on anything not UTF-8.
+                with open(value, "rb") as handle:
                     payload = json.loads(handle.read(MAX_WORLD_SIZE_FILE_BYTES))
             else:
                 continue
@@ -138,6 +145,28 @@ def world_size_from_env(environ: Any = None) -> int:
     source = os.environ if environ is None else environ
     numbers = max(_positive_int(source.get(name), 1) for name in WORLD_SIZE_ENV_VARS)
     return max(numbers, world_size_from_rank_files(source))
+
+
+def world_size_env_report(environ: Any = None) -> str:
+    """The launcher variables that are set, for a log line. Never raises.
+
+    Which variable claimed the rank count is the only thing a user can act on when
+    a run on one machine is told it makes several passes. mpirun, srun and some
+    container images leave a size variable behind, and a stale one reads as a
+    multi-rank launch here exactly as it does in the row bound.
+
+    Values are truncated: MLX_HOSTFILE legitimately carries a whole JSON payload.
+    """
+    source = os.environ if environ is None else environ
+    parts = []
+    for name in WORLD_SIZE_ENV_VARS + WORLD_SIZE_ENV_FILES:
+        try:
+            value = source.get(name)
+        except Exception:  # noqa: BLE001 - a log line must not be what fails a run
+            continue
+        if value:
+            parts.append(f"{name}={str(value)[:64]}")
+    return ", ".join(parts) or "no launcher variable set"
 
 
 def max_steps_dataset_rows(

--- a/studio/backend/core/training/trainer.py
+++ b/studio/backend/core/training/trainer.py
@@ -89,7 +89,7 @@ from .training import (
     should_use_mlx_training_backend,
 )
 
-from .dataset_bounds import bound_dataset_rows, world_size_from_env
+from .dataset_bounds import bound_dataset_rows, world_size_env_report, world_size_from_env
 
 logger = get_logger(__name__)
 
@@ -3479,12 +3479,15 @@ class UnslothTrainer:
         if max_steps > 0:
             try:
                 rows = len(train_dataset)
-                # Every launcher variable, not WORLD_SIZE alone: mpirun sets only
-                # OMPI_COMM_WORLD_SIZE, a per-node torchrun sets only
-                # LOCAL_WORLD_SIZE, and mlx.launch's NCCL backend (CUDA-only, so it
-                # does reach this path) sets MLX_WORLD_SIZE or a rank file. Reading
-                # one variable calls those runs single-process and engages a lazy
-                # view that re-tokenizes on every extra pass. It also coerces junk:
+                # Every launcher variable, not WORLD_SIZE alone. No MPI sets
+                # WORLD_SIZE: Open MPI advertises OMPI_COMM_WORLD_SIZE, Hydra and
+                # Intel MPI advertise PMI_SIZE, and mlx.launch's NCCL backend
+                # (CUDA-only, so it does reach this path) advertises
+                # MLX_WORLD_SIZE. LOCAL_WORLD_SIZE is defensive rather than
+                # necessary, since torchrun sets both and the max already prefers
+                # the global count on a multi-node run. Reading one variable calls
+                # an mpirun launch single-process and engages a lazy view that
+                # re-tokenizes on every extra pass. It also coerces junk:
                 # int("auto") raises, the except below leaves resolved_epochs None,
                 # and the gate then reads inf and disables the feature outright.
                 #
@@ -3498,6 +3501,19 @@ class UnslothTrainer:
                 # counting devices here would report 4x the passes and veto a
                 # qualifying run with a fabricated reason.
                 world_size = world_size_from_env()
+                if world_size > 1:
+                    # Say which variable said so. A size left behind by an earlier
+                    # mpirun, or baked into an HPC container image, reads as a
+                    # multi-rank launch on a machine running one process, and the
+                    # only symptom is this run being told it makes several passes.
+                    # The merged row bound already reads the same variables, so the
+                    # environment is being trusted either way; what was missing was
+                    # a way to see it.
+                    logger.info(
+                        f"Launcher environment reports {world_size} data-parallel "
+                        f"processes ({world_size_env_report()}); a step-capped run "
+                        f"consumes that many times the rows per step\n"
+                    )
                 per_step = (
                     int(config_args.get("per_device_train_batch_size", 1))
                     * int(config_args.get("gradient_accumulation_steps", 1))

--- a/studio/backend/core/training/trainer.py
+++ b/studio/backend/core/training/trainer.py
@@ -89,7 +89,7 @@ from .training import (
     should_use_mlx_training_backend,
 )
 
-from .dataset_bounds import bound_dataset_rows
+from .dataset_bounds import bound_dataset_rows, world_size_from_env
 
 logger = get_logger(__name__)
 
@@ -3479,7 +3479,25 @@ class UnslothTrainer:
         if max_steps > 0:
             try:
                 rows = len(train_dataset)
-                world_size = max(1, int(os.environ.get("WORLD_SIZE", "1")))
+                # Every launcher variable, not WORLD_SIZE alone: mpirun sets only
+                # OMPI_COMM_WORLD_SIZE, a per-node torchrun sets only
+                # LOCAL_WORLD_SIZE, and mlx.launch's NCCL backend (CUDA-only, so it
+                # does reach this path) sets MLX_WORLD_SIZE or a rank file. Reading
+                # one variable calls those runs single-process and engages a lazy
+                # view that re-tokenizes on every extra pass. It also coerces junk:
+                # int("auto") raises, the except below leaves resolved_epochs None,
+                # and the gate then reads inf and disables the feature outright.
+                #
+                # Deliberately env-only, and NOT worker.py's
+                # _data_parallel_world_size, which also counts visible CUDA devices.
+                # That one bounds a row subset, where over-counting costs nothing.
+                # This one feeds a veto, where both directions are wrong, and
+                # Studio's own multi-GPU load is device_map="balanced", which
+                # transformers treats as model-parallel and pins to _n_gpu = 1: a
+                # balanced 4-GPU run draws the same rows per step as one GPU, so
+                # counting devices here would report 4x the passes and veto a
+                # qualifying run with a fabricated reason.
+                world_size = world_size_from_env()
                 per_step = (
                     int(config_args.get("per_device_train_batch_size", 1))
                     * int(config_args.get("gradient_accumulation_steps", 1))

--- a/studio/backend/core/training/trainer.py
+++ b/studio/backend/core/training/trainer.py
@@ -3479,36 +3479,27 @@ class UnslothTrainer:
         if max_steps > 0:
             try:
                 rows = len(train_dataset)
-                # Every launcher variable, not WORLD_SIZE alone. No MPI sets
-                # WORLD_SIZE: Open MPI advertises OMPI_COMM_WORLD_SIZE, Hydra and
-                # Intel MPI advertise PMI_SIZE, and mlx.launch's NCCL backend
-                # (CUDA-only, so it does reach this path) advertises
-                # MLX_WORLD_SIZE. LOCAL_WORLD_SIZE is defensive rather than
-                # necessary, since torchrun sets both and the max already prefers
-                # the global count on a multi-node run. Reading one variable calls
-                # an mpirun launch single-process and engages a lazy view that
-                # re-tokenizes on every extra pass. It also coerces junk:
-                # int("auto") raises, the except below leaves resolved_epochs None,
-                # and the gate then reads inf and disables the feature outright.
-                #
-                # Deliberately env-only, and NOT worker.py's
-                # _data_parallel_world_size, which also counts visible CUDA devices.
-                # That one bounds a row subset, where over-counting costs nothing.
-                # This one feeds a veto, where both directions are wrong, and
-                # Studio's own multi-GPU load is device_map="balanced", which
-                # transformers treats as model-parallel and pins to _n_gpu = 1: a
-                # balanced 4-GPU run draws the same rows per step as one GPU, so
-                # counting devices here would report 4x the passes and veto a
-                # qualifying run with a fabricated reason.
+                # Every launcher variable, not WORLD_SIZE alone: no MPI sets it (Open
+                # MPI uses OMPI_COMM_WORLD_SIZE, Hydra/Intel MPI PMI_SIZE, mlx.launch's
+                # CUDA-only NCCL backend MLX_WORLD_SIZE), LOCAL_WORLD_SIZE is defensive
+                # since torchrun sets both and the max prefers the global count. Reading
+                # one variable calls an mpirun launch single-process and engages a view
+                # that re-tokenizes every extra pass; it also raises on junk like
+                # int("auto"), leaving resolved_epochs None so the gate reads inf and
+                # kills the feature. Env-only, deliberately NOT worker.py's
+                # _data_parallel_world_size, which also counts visible CUDA devices:
+                # that bounds a row subset where over-counting is free, this feeds a
+                # veto where both directions are wrong. Studio's multi-GPU load is
+                # device_map="balanced", model-parallel to transformers with _n_gpu = 1,
+                # so a balanced 4-GPU run draws one GPU's rows per step and counting
+                # devices would report 4x the passes, vetoing a qualifying run.
                 world_size = world_size_from_env()
                 if world_size > 1:
-                    # Say which variable said so. A size left behind by an earlier
-                    # mpirun, or baked into an HPC container image, reads as a
-                    # multi-rank launch on a machine running one process, and the
-                    # only symptom is this run being told it makes several passes.
-                    # The merged row bound already reads the same variables, so the
-                    # environment is being trusted either way; what was missing was
-                    # a way to see it.
+                    # Say which variable said so: a stale size from an earlier mpirun
+                    # or an HPC container image reads as a multi-rank launch on a
+                    # one-process machine, and the only symptom is this run being told
+                    # it makes several passes. The row bound already trusts the same
+                    # variables; what was missing was a way to see them.
                     logger.info(
                         f"Launcher environment reports {world_size} data-parallel "
                         f"processes ({world_size_env_report()}); a step-capped run "

--- a/studio/backend/tests/test_online_tokenization_wiring.py
+++ b/studio/backend/tests/test_online_tokenization_wiring.py
@@ -12,6 +12,7 @@ real method, because "silently takes the old path" is a claim about side effects
 """
 
 import contextlib
+import json
 import sys
 from types import SimpleNamespace
 
@@ -78,6 +79,32 @@ _configure = UnslothTrainer._configure_online_tokenization
 
 
 ROWS = MIN_ROWS_FOR_ONLINE + 5
+
+
+def _single_process_launch(monkeypatch):
+    """Clear every launcher variable, so a run reads as Studio's own launch.
+
+    Same helper and same constant tuples as ``test_training_preflight.py``: the
+    two must not disagree about what counts as a launcher, or one file starts
+    passing on a set of variables the other never clears.
+    """
+    from core.training.dataset_bounds import WORLD_SIZE_ENV_FILES, WORLD_SIZE_ENV_VARS
+
+    for name in WORLD_SIZE_ENV_VARS + WORLD_SIZE_ENV_FILES:
+        monkeypatch.delenv(name, raising = False)
+
+
+@pytest.fixture(autouse = True)
+def _no_ambient_launcher(monkeypatch):
+    """Every case in this file starts from a single-process launch.
+
+    The pass count is read out of the environment, so without this a case's
+    result depends on whatever the runner's shell happens to export, and on
+    whichever earlier test last set one of these. Both were live here: the file
+    already sets ``WORLD_SIZE`` in one test, and pytest's monkeypatch undo only
+    covers variables a test itself touched.
+    """
+    _single_process_launch(monkeypatch)
 
 
 class _Tokenizer:
@@ -412,6 +439,113 @@ def test_world_size_scales_the_rows_a_step_consumes(monkeypatch):
     )
     assert not decision.enabled and "one pass" in decision.reason
     _assert_untouched(config_args, wrapper, trainer, original)
+
+
+# 200 steps x 2 x 4 = 1600 rows per replica over a 10_005-row split: 0.16 passes on
+# one process, 1.28 on eight. Every launcher below advertises the same eight, so the
+# only thing separating these cases from the control at the bottom is whether the
+# variable is read at all.
+_EIGHT_RANK_STEPS = 200
+
+
+def _eight_ranks(monkeypatch, expect_enabled = False, **env):
+    for name, value in env.items():
+        monkeypatch.setenv(name, value)
+    original = _dataset()
+    decision, config_args, wrapper, trainer = _run(
+        monkeypatch,
+        wrapper = {"dataset": original},
+        config_overrides = {"max_steps": _EIGHT_RANK_STEPS},
+    )
+    if expect_enabled:
+        assert decision.enabled, decision.reason
+        return decision
+    assert not decision.enabled and "one pass" in decision.reason, decision.reason
+    _assert_untouched(config_args, wrapper, trainer, original)
+    return decision
+
+
+def test_an_mpirun_launch_scales_the_rows_a_step_consumes(monkeypatch):
+    """mpirun never sets WORLD_SIZE. Reading that one variable alone calls an
+    eight-rank run single-process and engages a view that re-tokenizes on every
+    extra pass."""
+    _eight_ranks(monkeypatch, OMPI_COMM_WORLD_SIZE = "8")
+
+
+def test_a_per_node_torchrun_scales_the_rows_a_step_consumes(monkeypatch):
+    """LOCAL_WORLD_SIZE is the only count torchrun sets per node, so a single-node
+    launch that lost WORLD_SIZE still has to be counted."""
+    _eight_ranks(monkeypatch, LOCAL_WORLD_SIZE = "8")
+
+
+def test_an_mlx_hostfile_scales_the_rows_a_step_consumes(monkeypatch, tmp_path):
+    """mlx.launch's ring backend advertises its ranks as a JSON file rather than a
+    number; its NCCL backend is CUDA-only, so this path is reachable."""
+    hostfile = tmp_path / "hosts.json"
+    hostfile.write_text(json.dumps([f"10.0.0.{i}:9000" for i in range(8)]), encoding = "utf-8")
+    _eight_ranks(monkeypatch, MLX_HOSTFILE = str(hostfile))
+
+
+def test_an_inline_hosts_payload_scales_the_rows_a_step_consumes(monkeypatch):
+    """The same variable also carries the payload inline, in the {"hosts": [...]}
+    object form `unsloth_cli/_inference.py` accepts."""
+    payload = json.dumps({"hosts": [f"10.0.0.{i}:9000" for i in range(8)]})
+    _eight_ranks(monkeypatch, MLX_HOSTFILE = payload)
+
+
+# Only values that RAISE. "0" and "-4" also read as one process, but the old
+# expression's max(1, int(...)) already answered 1 for those, so they would pass
+# against the bug and belong with dataset_bounds' own coercion tests, not here.
+@pytest.mark.parametrize("junk", ["auto", "", "eight"])
+def test_a_junk_world_size_no_longer_disables_online_tokenization(monkeypatch, junk):
+    """The direction this used to fail in was not the obvious one.
+
+    `int("auto")` raises, the enclosing `except` leaves the pass count unresolved,
+    and an unresolved step-capped run reads as infinite passes, so a launcher that
+    exported a non-numeric WORLD_SIZE silently turned the feature OFF on a run that
+    qualifies. Unusable values are a single process, which is what this host is.
+    """
+    monkeypatch.setenv("WORLD_SIZE", junk)
+    original = _dataset()
+    decision, config_args, wrapper, trainer = _run(
+        monkeypatch,
+        wrapper = {"dataset": original},
+        config_overrides = {"max_steps": 30},
+    )
+    assert decision.enabled, decision.reason
+    assert wrapper["dataset"] is not original
+    assert config_args["dataset_kwargs"] == {"skip_prepare_dataset": True}
+
+
+def test_the_resolved_pass_count_handed_to_the_gate_is_the_arithmetic(monkeypatch):
+    """The veto only sees a number, so assert the number rather than its verdict:
+    a wrong world size that still lands on the same side of 1.0 is a bug that has
+    not surfaced yet."""
+    monkeypatch.setenv("OMPI_COMM_WORLD_SIZE", "8")
+    seen: dict = {}
+    import utils.datasets.online_tokenization as online_mod
+
+    real = online_mod.decide_online_tokenization
+
+    def _record(**kwargs):
+        seen.update(kwargs)
+        return real(**kwargs)
+
+    monkeypatch.setattr(online_mod, "decide_online_tokenization", _record)
+    _run(
+        monkeypatch,
+        config_overrides = {"max_steps": _EIGHT_RANK_STEPS},
+    )
+    expected = (_EIGHT_RANK_STEPS * 2 * 4 * 8) / ROWS
+    assert seen["resolved_max_steps_epochs"] == pytest.approx(expected)
+    assert seen["resolved_max_steps_epochs"] > 1.0
+
+
+def test_a_single_process_launch_still_qualifies(monkeypatch):
+    """The control for every case above: same steps, same split, no launcher
+    variable at all. Counting a rank that is not there would veto this run."""
+    decision = _eight_ranks(monkeypatch, expect_enabled = True)
+    assert decision.prewarm_batches > 0
 
 
 # ------------------------------------------------------------- the prewarm barrier

--- a/studio/backend/tests/test_online_tokenization_wiring.py
+++ b/studio/backend/tests/test_online_tokenization_wiring.py
@@ -175,6 +175,17 @@ def _run(
         "utils.datasets.online_tokenization.trl_supports_skip_prepare_dataset",
         lambda: True,
     )
+    # Pin the worker count for the same reason. resolve_worker_count sizes itself
+    # from CPU affinity and the cgroup quota and returns 0 when the host cannot
+    # spare MIN_ONLINE_WORKERS, which vetoes before the pass count is ever
+    # compared. A two-core macOS or Windows runner therefore turned every case in
+    # this file into an assertion about the runner rather than about the wiring,
+    # and the veto reason it produced was the worker one, not the one under test.
+    # The worker gate has its own coverage in test_online_tokenization.py.
+    monkeypatch.setattr(
+        "utils.datasets.online_tokenization.resolve_worker_count",
+        lambda desired = None: 4,
+    )
     trainer = _fake_self(**(self_overrides or {}))
     config_args = _config_args(**(config_overrides or {}))
     wrapper = {"dataset": _dataset()} if wrapper is None else wrapper

--- a/studio/backend/tests/test_online_tokenization_wiring.py
+++ b/studio/backend/tests/test_online_tokenization_wiring.py
@@ -175,13 +175,11 @@ def _run(
         "utils.datasets.online_tokenization.trl_supports_skip_prepare_dataset",
         lambda: True,
     )
-    # Pin the worker count for the same reason. resolve_worker_count sizes itself
-    # from CPU affinity and the cgroup quota and returns 0 when the host cannot
-    # spare MIN_ONLINE_WORKERS, which vetoes before the pass count is ever
-    # compared. A two-core macOS or Windows runner therefore turned every case in
-    # this file into an assertion about the runner rather than about the wiring,
-    # and the veto reason it produced was the worker one, not the one under test.
-    # The worker gate has its own coverage in test_online_tokenization.py.
+    # Pin the worker count for the same reason: resolve_worker_count sizes itself from
+    # CPU affinity and the cgroup quota and returns 0 below MIN_ONLINE_WORKERS, vetoing
+    # before the pass count is compared. On a two-core runner every case here asserted
+    # about the runner, on the wrong veto reason. The worker gate is covered by
+    # test_online_tokenization.py.
     monkeypatch.setattr(
         "utils.datasets.online_tokenization.resolve_worker_count",
         lambda desired = None: 4,
@@ -452,9 +450,8 @@ def test_world_size_scales_the_rows_a_step_consumes(monkeypatch):
 
 
 # 200 steps x 2 x 4 = 1600 rows per replica over a 10_005-row split: 0.16 passes on
-# one process, 1.28 on eight. Every launcher below advertises the same eight, so the
-# only thing separating these cases from the control at the bottom is whether the
-# variable is read at all.
+# one process, 1.28 on eight. Every launcher below advertises the same eight, so these
+# cases differ from the control at the bottom only in whether the variable is read.
 _EIGHT_RANK_STEPS = 200
 
 
@@ -515,9 +512,8 @@ def test_an_inline_hosts_payload_scales_the_rows_a_step_consumes(monkeypatch):
     _eight_ranks(monkeypatch, MLX_HOSTFILE = payload)
 
 
-# Only values that RAISE. "0" and "-4" also read as one process, but the old
-# expression's max(1, int(...)) already answered 1 for those, so they would pass
-# against the bug and belong with dataset_bounds' own coercion tests, not here.
+# Only values that RAISE: the old max(1, int(...)) already answered 1 for "0" and
+# "-4", so those would pass against the bug and belong in dataset_bounds' own tests.
 @pytest.mark.parametrize("junk", ["auto", "", "eight"])
 def test_a_junk_world_size_no_longer_disables_online_tokenization(monkeypatch, junk):
     """The direction this used to fail in was not the obvious one.

--- a/studio/backend/tests/test_online_tokenization_wiring.py
+++ b/studio/backend/tests/test_online_tokenization_wiring.py
@@ -89,7 +89,6 @@ def _single_process_launch(monkeypatch):
     passing on a set of variables the other never clears.
     """
     from core.training.dataset_bounds import WORLD_SIZE_ENV_FILES, WORLD_SIZE_ENV_VARS
-
     for name in WORLD_SIZE_ENV_VARS + WORLD_SIZE_ENV_FILES:
         monkeypatch.delenv(name, raising = False)
 
@@ -448,7 +447,11 @@ def test_world_size_scales_the_rows_a_step_consumes(monkeypatch):
 _EIGHT_RANK_STEPS = 200
 
 
-def _eight_ranks(monkeypatch, expect_enabled = False, **env):
+def _eight_ranks(
+    monkeypatch,
+    expect_enabled = False,
+    **env,
+):
     for name, value in env.items():
         monkeypatch.setenv(name, value)
     original = _dataset()

--- a/studio/backend/tests/test_online_tokenization_wiring.py
+++ b/studio/backend/tests/test_online_tokenization_wiring.py
@@ -476,16 +476,24 @@ def test_an_mpirun_launch_scales_the_rows_a_step_consumes(monkeypatch):
 
 
 def test_a_per_node_torchrun_scales_the_rows_a_step_consumes(monkeypatch):
-    """LOCAL_WORLD_SIZE is the only count torchrun sets per node, so a single-node
-    launch that lost WORLD_SIZE still has to be counted."""
+    """torchrun sets WORLD_SIZE and LOCAL_WORLD_SIZE both, so this is the defensive
+    case: an environment that kept the per-node count and lost the global one still
+    has to be counted rather than read as a single process."""
     _eight_ranks(monkeypatch, LOCAL_WORLD_SIZE = "8")
 
 
 def test_an_mlx_hostfile_scales_the_rows_a_step_consumes(monkeypatch, tmp_path):
     """mlx.launch's ring backend advertises its ranks as a JSON file rather than a
-    number; its NCCL backend is CUDA-only, so this path is reachable."""
+    number; its NCCL backend is CUDA-only, so this path is reachable.
+
+    Written in the shape the ring backend really uses: the outer list has one entry
+    per rank, and each entry is that rank's own list of addresses, because a pair of
+    peers may hold several connections."""
     hostfile = tmp_path / "hosts.json"
-    hostfile.write_text(json.dumps([f"10.0.0.{i}:9000" for i in range(8)]), encoding = "utf-8")
+    hostfile.write_text(
+        json.dumps([[f"10.0.0.{i}:9000", f"10.0.0.{i}:9001"] for i in range(8)]),
+        encoding = "utf-8",
+    )
     _eight_ranks(monkeypatch, MLX_HOSTFILE = str(hostfile))
 
 
@@ -542,6 +550,44 @@ def test_the_resolved_pass_count_handed_to_the_gate_is_the_arithmetic(monkeypatc
     expected = (_EIGHT_RANK_STEPS * 2 * 4 * 8) / ROWS
     assert seen["resolved_max_steps_epochs"] == pytest.approx(expected)
     assert seen["resolved_max_steps_epochs"] > 1.0
+
+
+def _captured_logger(monkeypatch):
+    """Record what the trainer logs, without depending on the logging config."""
+    lines: list = []
+
+    class _Recorder:
+        def info(self, message, *args, **kwargs):
+            lines.append(str(message))
+
+        warning = error = debug = info
+
+    import core.training.trainer as trainer_mod
+
+    monkeypatch.setattr(trainer_mod, "logger", _Recorder())
+    return lines
+
+
+def test_a_multi_rank_launch_names_the_variable_that_claimed_the_ranks(monkeypatch):
+    """A size variable left behind by an earlier mpirun, or inherited from an
+    interactive srun, reads here as a multi-rank launch on a machine running one
+    process, and its whole visible effect is this run being told it makes several
+    passes. Name the variable so that verdict is not silent. The merged row bound
+    reads the same variables, so the environment is trusted either way."""
+    lines = _captured_logger(monkeypatch)
+    _eight_ranks(monkeypatch, OMPI_COMM_WORLD_SIZE = "8")
+    reported = [line for line in lines if "data-parallel processes" in line]
+    assert len(reported) == 1, lines
+    assert "8 data-parallel processes" in reported[0]
+    assert "OMPI_COMM_WORLD_SIZE=8" in reported[0]
+
+
+def test_a_single_process_launch_says_nothing_about_launchers(monkeypatch):
+    """The report is for the surprising case only; a normal run must not grow a
+    line about a world size of one."""
+    lines = _captured_logger(monkeypatch)
+    _eight_ranks(monkeypatch, expect_enabled = True)
+    assert not [line for line in lines if "data-parallel processes" in line], lines
 
 
 def test_a_single_process_launch_still_qualifies(monkeypatch):

--- a/studio/backend/tests/test_training_preflight.py
+++ b/studio/backend/tests/test_training_preflight.py
@@ -807,6 +807,66 @@ def test_world_size_comes_from_an_mlx_launch_hostfile(tmp_path, monkeypatch):
     assert world_size_from_rank_files({}) == 1
 
 
+def test_a_rank_file_read_is_capped_in_bytes_not_characters(tmp_path):
+    """The cap has to bound what comes off the disk, whatever the file holds.
+
+    A text-mode ``read(n)`` counts CHARACTERS, so a file of 4-byte codepoints
+    would pull four times ``MAX_WORLD_SIZE_FILE_BYTES`` into memory on a variable
+    that names an arbitrary path. Read in binary and the constant means what it
+    says; ``json.loads`` takes bytes, and non-UTF-8 raises ``UnicodeDecodeError``,
+    which is a ``ValueError`` and already discarded.
+    """
+    from core.training.dataset_bounds import (
+        MAX_WORLD_SIZE_FILE_BYTES,
+        world_size_from_rank_files,
+    )
+
+    # Sized so the two readings disagree: fewer characters than the cap, more
+    # bytes than the cap. A text handle would read the file whole and answer 8; a
+    # binary one truncates and the launch reads as one process. Under-counting is
+    # the safe direction here, and reading the whole file is what the cap forbids.
+    wide = tmp_path / "wide.json"
+    filler = "\U0001f600" * (MAX_WORLD_SIZE_FILE_BYTES // 3)  # 4 bytes per character
+    hosts = [filler] + [f"10.0.0.{rank}:5000" for rank in range(7)]
+    # ensure_ascii would escape every codepoint back to ASCII and make the two
+    # readings agree, which is exactly what this test needs them not to do.
+    wide.write_text(json.dumps(hosts, ensure_ascii = False), encoding = "utf-8")
+    assert len(wide.read_text(encoding = "utf-8")) < MAX_WORLD_SIZE_FILE_BYTES
+    assert wide.stat().st_size > MAX_WORLD_SIZE_FILE_BYTES
+    assert world_size_from_rank_files({"MLX_HOSTFILE": str(wide)}) == 1
+
+    # Bytes that are not UTF-8 at all must be discarded, not raised.
+    invalid = tmp_path / "invalid.bin"
+    invalid.write_bytes(b'["\xff\xfe10.0.0.1:5000"]')
+    assert world_size_from_rank_files({"MLX_HOSTFILE": str(invalid)}) == 1
+
+
+def test_the_launcher_env_report_names_the_variable_that_claimed_the_ranks():
+    """A stale size variable is otherwise invisible.
+
+    The report exists so a user whose single-machine run is told it makes several
+    passes can see which variable said so. It must never raise and never grow
+    without bound: MLX_HOSTFILE legitimately carries a whole JSON payload.
+    """
+    from core.training.dataset_bounds import world_size_env_report
+
+    assert world_size_env_report({}) == "no launcher variable set"
+    assert world_size_env_report({"WORLD_SIZE": ""}) == "no launcher variable set"
+    assert world_size_env_report({"NOT_A_LAUNCHER": "8"}) == "no launcher variable set"
+
+    report = world_size_env_report({"OMPI_COMM_WORLD_SIZE": "8", "WORLD_SIZE": "2"})
+    assert "OMPI_COMM_WORLD_SIZE=8" in report and "WORLD_SIZE=2" in report
+
+    long_payload = world_size_env_report({"MLX_HOSTFILE": json.dumps(["h"] * 500)})
+    assert len(long_payload) < 200
+
+    class _Hostile:
+        def get(self, name):
+            raise RuntimeError("environment lookup exploded")
+
+    assert world_size_env_report(_Hostile()) == "no launcher variable set"
+
+
 def test_effective_packing_decides_the_opt_out():
     from core.training.dataset_bounds import effective_packing, max_train_rows_for_config
 

--- a/studio/backend/tests/test_training_preflight.py
+++ b/studio/backend/tests/test_training_preflight.py
@@ -821,21 +821,20 @@ def test_a_rank_file_read_is_capped_in_bytes_not_characters(tmp_path):
         world_size_from_rank_files,
     )
 
-    # Sized so the two readings disagree: fewer characters than the cap, more
-    # bytes than the cap. A text handle would read the file whole and answer 8; a
-    # binary one truncates and the launch reads as one process. Under-counting is
-    # the safe direction here, and reading the whole file is what the cap forbids.
+    # Sized so the readings disagree: under the cap in characters, over it in bytes.
+    # A text handle reads it whole and answers 8; binary truncates to one process,
+    # the safe direction, and reading the whole file is what the cap forbids.
     wide = tmp_path / "wide.json"
     filler = "\U0001f600" * (MAX_WORLD_SIZE_FILE_BYTES // 3)  # 4 bytes per character
     hosts = [filler] + [f"10.0.0.{rank}:5000" for rank in range(7)]
-    # ensure_ascii would escape every codepoint back to ASCII and make the two
-    # readings agree, which is exactly what this test needs them not to do.
+    # ensure_ascii would escape the codepoints back to ASCII and make the two
+    # readings agree, which is what this test needs them not to do.
     wide.write_text(json.dumps(hosts, ensure_ascii = False), encoding = "utf-8")
     assert len(wide.read_text(encoding = "utf-8")) < MAX_WORLD_SIZE_FILE_BYTES
     assert wide.stat().st_size > MAX_WORLD_SIZE_FILE_BYTES
     assert world_size_from_rank_files({"MLX_HOSTFILE": str(wide)}) == 1
 
-    # Bytes that are not UTF-8 at all must be discarded, not raised.
+    # Non-UTF-8 bytes must be discarded, not raised.
     invalid = tmp_path / "invalid.bin"
     invalid.write_bytes(b'["\xff\xfe10.0.0.1:5000"]')
     assert world_size_from_rank_files({"MLX_HOSTFILE": str(invalid)}) == 1

--- a/unsloth/utils/packing.py
+++ b/unsloth/utils/packing.py
@@ -169,10 +169,16 @@ def enable_sample_packing(
                     if isinstance(ids, Iterable):
                         seq_lengths.append(len(ids))
             if seq_lengths:
-                # Boundary labels are NOT masked here: unsloth_zoo's
+                # Boundary labels are NOT masked here. unsloth_zoo's
                 # _unsloth_get_batch_samples counts num_items_in_batch off this batch and
-                # already subtracts the N-1 boundary targets, so masking here would deduct
-                # twice on TRL < 0.24 (no pre-masking). The guard runs in the forward.
+                # discounts the N-1 boundary targets itself. The contract is that the
+                # discount is idempotent -- it zeroes those slots rather than subtracting
+                # a constant -- so the count does not depend on whether something upstream
+                # already masked them (TRL >= 0.24's labels[position_ids == 0] = -100,
+                # completion-only masking, or assistant_masks on any TRL version). Masking
+                # here would therefore be harmless to the count; the labels are still left
+                # alone because the guard that needs these positions runs in the forward,
+                # off packed_seq_lengths.
                 batch["packed_seq_lengths"] = torch.tensor(seq_lengths, dtype = torch.int32)
                 if "attention_mask" in batch:
                     batch.pop("attention_mask")
@@ -216,7 +222,9 @@ def enable_padding_free_metadata(model, trainer):
         batch = original_torch_call(examples)
         if seq_lengths:
             # Labels left alone for the same reason as enable_sample_packing:
-            # num_items_in_batch is counted off this batch.
+            # num_items_in_batch is counted off this batch, and the zoo's discount of
+            # the boundary targets is idempotent by contract, so it does not matter to
+            # the count whether these slots arrive masked.
             batch["packed_seq_lengths"] = torch.tensor(
                 seq_lengths,
                 dtype = torch.int32,

--- a/unsloth/utils/packing.py
+++ b/unsloth/utils/packing.py
@@ -171,14 +171,12 @@ def enable_sample_packing(
             if seq_lengths:
                 # Boundary labels are NOT masked here. unsloth_zoo's
                 # _unsloth_get_batch_samples counts num_items_in_batch off this batch and
-                # discounts the N-1 boundary targets itself. The contract is that the
-                # discount is idempotent -- it zeroes those slots rather than subtracting
-                # a constant -- so the count does not depend on whether something upstream
-                # already masked them (TRL >= 0.24's labels[position_ids == 0] = -100,
-                # completion-only masking, or assistant_masks on any TRL version). Masking
-                # here would therefore be harmless to the count; the labels are still left
-                # alone because the guard that needs these positions runs in the forward,
-                # off packed_seq_lengths.
+                # discounts the N-1 boundary targets itself, idempotently: it zeroes those
+                # slots rather than subtracting a constant, so the count is unaffected by
+                # upstream masking (TRL >= 0.24's labels[position_ids == 0] = -100,
+                # completion-only masking, assistant_masks). Masking here would be harmless
+                # to the count; labels are left alone because the guard that needs these
+                # positions runs in the forward, off packed_seq_lengths.
                 batch["packed_seq_lengths"] = torch.tensor(seq_lengths, dtype = torch.int32)
                 if "attention_mask" in batch:
                     batch.pop("attention_mask")
@@ -222,9 +220,8 @@ def enable_padding_free_metadata(model, trainer):
         batch = original_torch_call(examples)
         if seq_lengths:
             # Labels left alone for the same reason as enable_sample_packing:
-            # num_items_in_batch is counted off this batch, and the zoo's discount of
-            # the boundary targets is idempotent by contract, so it does not matter to
-            # the count whether these slots arrive masked.
+            # num_items_in_batch is counted off this batch, and the zoo's discount of the
+            # boundary targets is idempotent, so masked slots do not change the count.
             batch["packed_seq_lengths"] = torch.tensor(
                 seq_lengths,
                 dtype = torch.int32,


### PR DESCRIPTION
### The bug

`UnslothTrainer._configure_online_tokenization` resolves how many passes a `max_steps` run makes over the split, and hands that number to the online-tokenization gate, whose only use of it is the `epochs > 1.0` veto. It read the process count like this:

```python
world_size = max(1, int(os.environ.get("WORLD_SIZE", "1")))
```

`dataset_bounds.world_size_from_env()` already reads eight launcher variables plus the MLX rank files, and both loaders use it for the row bound. Reading one variable here means these launches resolve as single-process and get the lazy re-tokenizing view on a run that makes more than one pass, which is the case the veto exists to keep on the Arrow cache:

- mpirun, which sets `OMPI_COMM_WORLD_SIZE` and never `WORLD_SIZE` ([Open MPI env vars](https://docs.open-mpi.org/en/v5.0.x/tuning-apps/environment-var.html))
- MPICH and Intel MPI under Hydra, and Slurm's `srun` with the pmi2 plugin, which set `PMI_SIZE` ([mpich hydra](https://github.com/pmodels/mpich/blob/main/src/pm/hydra/proxy/pmip_cb.c), [slurm pmi2](https://github.com/SchedMD/slurm/blob/master/src/plugins/mpi/pmi2/mpi_pmi2.c))
- an environment that kept torchrun's `LOCAL_WORLD_SIZE` and lost the global `WORLD_SIZE`
- mlx.launch's NCCL backend, which is CUDA-only and so does reach this path

This is not an Apple silicon fix and does not claim to be one. `worker.py` routes Apple silicon to `run_mlx_training_process` and returns before `UnslothTrainer()` is ever constructed, so this method is unreachable there. The rank-file branch is here for consistency with `worker.py` and `unsloth_cli/_inference.py`, not because that path is reachable today.

### A second bug in the same expression

`int("auto")` and `int("")` raise. The surrounding `try` swallows it, the pass count is left unresolved, and an unresolved step-capped run reads as infinite passes, so the gate vetoes. A junk `WORLD_SIZE` therefore silently **disabled** online tokenization on a run that qualifies. `world_size_from_env` coerces anything unusable to 1, so such a run now qualifies again. This is the direction that fails loudest on revert.

Exhaustively: `auto`, `""`, `3.5`, `1e3`, `0x8`, `None`, `true` all used to veto and now enable. `" 8 "`, `"8\n"`, `"+8"`, `"08"` read as 8. `0` and `-2` read as 1 under both expressions.

### The fix

`world_size = world_size_from_env()`, with `dataset_bounds` already imported one line above.

Deliberately **not** `worker.py`'s `_data_parallel_world_size`, which also counts visible CUDA devices. The two call sites want different numbers. That one bounds a row subset, where over-counting costs nothing and under-counting recycles rows, so taking the max of env, process group and device count is right. This one feeds a veto, where both directions are wrong, and Studio's own multi-GPU load is `device_map="balanced"`, which transformers treats as model-parallel and pins to `_n_gpu = 1`: a balanced 4-GPU run draws the same rows per step as one GPU, so counting devices here would report 4x the passes and veto a qualifying run with a fabricated reason. The comment at the call site records this so the two do not get "unified" later.

Also in this PR:

- `dataset_bounds.py`: `world_size_from_rank_files` read its bounded prefix from a **text** handle, where `read(n)` counts characters, so a rank file of four-byte codepoints could pull four times `MAX_WORLD_SIZE_FILE_BYTES` off disk. Now read in binary, so the constant means what its name says; `json.loads` takes bytes and still raises a `ValueError` on anything that is not UTF-8.
- `dataset_bounds.py`: deletes a duplicated line that had garbled the `world_size_from_rank_files` docstring mid-sentence.
- `unsloth/utils/packing.py`: two comments justified leaving boundary labels unmasked by saying unsloth_zoo "already subtracts the N-1 boundary targets". They now describe the idempotent contract instead, which is what the paired unsloth-zoo change establishes. The code is unchanged and was correct either way.

I checked whether any other site needs the same change. Inside `studio/backend/core/training` this was the only narrower reader; the other two are `world_size_from_env` itself and `_data_parallel_world_size`, and the latter is intentionally wider. `resolved_max_steps_epochs` has exactly one producer and one consumer in the tree. Nothing else computes an epoch count from `max_steps * batch * accum * world_size`.

### The risk this introduces, quantified

The pass count now depends on eight variables rather than one, so a size variable that is set but not truthful raises `resolved_epochs` and can veto a run that used to qualify. That is a behaviour change for an existing user on unchanged hardware, and it deserves a number rather than a shrug.

**When it can trigger.** With `S = max_steps * batch * accum` and `R` the rows the trainer sees, the old verdict is `S/R <= 1` and the new one `S*W/R > 1`, so the window is `S <= R < S*W`. The online-tokenization floor adds `R >= 10_000`. And the merged row bound, which runs earlier in the same worker process and reads the same variables, cuts any larger corpus to exactly `4*S*W` rows, at which point the new pass count is a constant `0.25` and the verdict cannot change at all. So the whole window is a corpus of between `max(10_000, S)` and `S*W` rows. With Studio's defaults and a 200-step run under an eight-rank variable, that is 10_000 to 12_799 rows.

**What it costs when it triggers.** The run takes the eager Arrow map, which is the path that shipped before #8960. No correctness, loss, gradient or checkpoint difference. The opposite direction, under-counting, engages a lazy view that re-tokenizes on every extra pass, so the over-count direction is the safer of the two.

**How realistic a stale variable is.** I could find no evidence of a login dotfile, module file or mainstream HPC container image exporting these unconditionally. What is real and structural: Slurm's pmi2 and cray_shasta plugins put `PMI_SIZE` in every task environment and `srun` defaults to `--export=ALL`, so anything started from an interactive `srun` shell inherits it with no MPI in sight. `mpirun -np 1 anything` sets `OMPI_COMM_WORLD_SIZE=1`, which is harmless because 1 is the answer either way.

**What I did about it.** The number is left alone. Narrowing it here, for instance by requiring the RANK partner as `routes/inference.py` does, would put this call site back into disagreement with the row bound that already reads exactly these variables and already decides which rows the run trains on, and that disagreement is the thing this PR exists to remove. What was actually missing is that the verdict was silent, so the trainer now logs the world size and the variables behind it whenever the environment raises it above 1:

```
Launcher environment reports 8 data-parallel processes (OMPI_COMM_WORLD_SIZE=8); a step-capped run consumes that many times the rows per step
```

Nothing is logged on a single-process run.

### Launcher contracts, checked against upstream

Several of the comments in `dataset_bounds` were wrong or imprecise and are corrected here:

| claim | verdict | source |
|---|---|---|
| `WORLD_SIZE` is set by MPI | **no**, torchrun / accelerate / deepspeed only | [Open MPI](https://docs.open-mpi.org/en/v5.0.x/tuning-apps/environment-var.html) |
| `LOCAL_WORLD_SIZE` is the only per-node count torchrun sets | **no**, it sets `WORLD_SIZE` too, plus `GROUP_WORLD_SIZE` | [torch elastic](https://docs.pytorch.org/docs/stable/elastic/run.html), [local_elastic_agent.py](https://github.com/pytorch/pytorch/blob/main/torch/distributed/elastic/agent/server/local_elastic_agent.py) |
| `PMIX_SIZE` is a launcher variable | **no such variable**; PMIx exports `PMIX_RANK` and answers job size through `PMIx_Get` | [pmix_server.c](https://github.com/openpmix/openpmix/blob/master/src/server/pmix_server.c) |
| `MPI_WORLD_SIZE` is a launcher variable | **not documented by any MPI checked** | as above |
| `srun` exports `PMI_SIZE` | **only** under the pmi2 and cray_shasta plugins, not pmix | [slurm mpi guide](https://slurm.schedmd.com/mpi_guide.html) |
| `MV2_COMM_WORLD_SIZE` | MVAPICH2, and only under `mpirun_rsh` | [MVAPICH2 guide](https://mvapich.cse.ohio-state.edu/static/media/mvapich/mvapich2-2.3.6-userguide.html) |
| `MLX_WORLD_SIZE` is NCCL-only and CUDA-only | **correct** | [launch.py](https://github.com/ml-explore/mlx/blob/main/python/mlx/_distributed_utils/launch.py), [no_nccl.cpp](https://github.com/ml-explore/mlx/blob/main/mlx/distributed/nccl/no_nccl.cpp) |
| `MLX_HOSTFILE` is a bare list of `"host:port"` | **no**, it names a file holding one address *list* per rank | [ring.cpp](https://github.com/ml-explore/mlx/blob/main/mlx/distributed/ring/ring.cpp) |
| `MLX_IBV_DEVICES` is an N x N RDMA matrix, one row per rank | **correct**, and it too names a file | [jaccl README](https://github.com/ml-explore/mlx/blob/main/mlx/distributed/jaccl/lib/README.md) |

`PMIX_SIZE` and `MPI_WORLD_SIZE` stay in the tuple, because `routes/inference.py` already lists them and the two must not disagree about what counts as a launcher, but the comments no longer claim anything sets them. The MLX hostfile test fixture now writes the real shape.

### Evidence 1: the decision log line

The observable consequence is a log line, and the trigger cannot be produced from the UI, so there is no screenshot or recording here on purpose. Instead `core.training.worker.run_training_process` was driven directly, four arms, Qwen3-0.6B LoRA 4bit on `unsloth/OpenMathReasoning` `cot` (192,523 rows), `max_steps=5000`, batch 2, accum 4. The run is killed the moment the line is emitted, so no optimizer step is taken. `OMPI_COMM_WORLD_SIZE=8` is injected into the worker's environment before the backend is imported, exactly as mpirun would have left it.

| arm | injected env | decision line |
|---|---|---|
| before | none | `Online tokenization: on (plain-text single-pass SFT run); workers=4, prefetch=4, prewarm=16 microbatches` |
| before | `OMPI_COMM_WORLD_SIZE=8` | `Online tokenization: on (plain-text single-pass SFT run); workers=4, prefetch=4, prewarm=16 microbatches` |
| after | none | `Online tokenization: on (plain-text single-pass SFT run); workers=4, prefetch=4, prewarm=16 microbatches` |
| after | `OMPI_COMM_WORLD_SIZE=8` | `Online tokenization: off (more than one pass over the data (1.66214 epochs))` |

Row two is the bug: an eight-rank mpirun launch drawing 320,000 rows over a 192,523-row split, reported as a single pass. Row three is the no-regression control on the same steps and the same split.

### Evidence 2: an old install upgrading, on a single-process run

The proof that matters most for an existing user is that nothing moves when no launcher variable is set. Merge base `27326c4d8` checked out in its own worktree, versus this branch, same config as above, stopped after three optimizer steps:

| | decision line | step 1 loss | step 2 loss | step 1 grad_norm |
|---|---|---|---|---|
| merge base | `on (plain-text single-pass SFT run); workers=4, prefetch=4, prewarm=16 microbatches` | 0.7147 | 0.8064 | 0.38770782947540283 |
| this branch | identical | 0.7147 | 0.8064 | 0.3877256214618683 |
| this branch, repeat | identical | 0.7147 | 0.8064 | 0.38774922490119934 |

Identical gate decision, identical decision line, identical loss. `grad_norm` differs in the fifth decimal, and the third row is why that is not a finding: two runs of the *same* code differ by more than the two arms do, which is ordinary nondeterministic reduction order on the GPU. Nothing on this branch can touch the arithmetic anyway.

### Tests

`studio/backend/tests/test_online_tokenization_wiring.py` gains an autouse fixture that clears every launcher variable, using the same constant tuples and the same `_single_process_launch` helper as `test_training_preflight.py`. That also retires this file's existing dependence on the ambient environment: the pass count is read out of the environment, so before this a case's result depended on what the runner's shell happened to export. Proved load-bearing by exporting `WORLD_SIZE=8 OMPI_COMM_WORLD_SIZE=4` and flipping the fixture to `autouse = False`: 1 failed, 30 passed.

New cases:

1. mpirun (`OMPI_COMM_WORLD_SIZE=8`) vetoes
2. torchrun's `LOCAL_WORLD_SIZE=8` alone vetoes
3. MLX ring hostfile written to `tmp_path`, in the real per-rank-list shape, vetoes
4. the same payload inline in the variable, in the `{"hosts": [...]}` object form, vetoes
5. junk `WORLD_SIZE` (`auto`, empty, `eight`) now **enables**, one parametrised case each
6. a direct assertion on the `resolved_max_steps_epochs` number handed to the gate, not just its verdict
7. a single-process control at the same step count, which must still qualify
8. the launcher report names the variable, and says nothing at all on a single-process run

Plus, in `test_training_preflight.py`, the byte cap on a rank-file read (a file with fewer characters than the cap but more bytes than it, which a text handle would have read whole) and the launcher report's own contract, including that it never raises on a hostile mapping.

`0` and `-4` were deliberately left out of case 5: the old `max(1, int(...))` already answered 1 for those, so they would pass against the bug and belong with `dataset_bounds`' own coercion tests.

Every case was proven discriminating by restoring the old expression and confirming it fails, in the default environment and in two others (python 3.10 / torch 2.6.0 / transformers 4.57.6 / TRL 0.22.2, and python 3.13 / torch 2.13.0 / transformers 5.15.0 / TRL 1.10.0), with an identical failure set each time:

```
$ git apply -R <the trainer.py hunk>
$ PYTHONPATH=studio/backend python -m pytest studio/backend/tests/test_online_tokenization_wiring.py -q
FAILED test_an_mpirun_launch_scales_the_rows_a_step_consumes
FAILED test_a_per_node_torchrun_scales_the_rows_a_step_consumes
FAILED test_an_mlx_hostfile_scales_the_rows_a_step_consumes
FAILED test_an_inline_hosts_payload_scales_the_rows_a_step_consumes
FAILED test_a_junk_world_size_no_longer_disables_online_tokenization[auto]
FAILED test_a_junk_world_size_no_longer_disables_online_tokenization[]
FAILED test_a_junk_world_size_no_longer_disables_online_tokenization[eight]
FAILED test_the_resolved_pass_count_handed_to_the_gate_is_the_arithmetic
8 failed, 23 passed
```

`test_a_single_process_launch_still_qualifies` correctly stays green there: it is the control, world size 1 either way. Reverting the byte-cap hunk fails `test_a_rank_file_read_is_capped_in_bytes_not_characters`, and removing the launcher report fails its own case.

With the fix in place, and unchanged with `CUDA_VISIBLE_DEVICES=""`:

```
test_online_tokenization_wiring.py + test_training_preflight.py + test_online_tokenization.py
176 passed
```

File order was permuted three ways and the same three files were run under `pytest-randomly` seeds 11, 22 and 33 in two separate interpreters: 172 passed every time at the point that was measured, so the new autouse fixture leaks nothing into its neighbours and nothing leaks into it.

### A pre-existing test defect this surfaced

The first cross-platform staging run failed on macos-14 and windows-latest with `not enough CPU workers to stay ahead of the GPU`. `resolve_worker_count` sizes itself from CPU affinity and the cgroup quota and returns 0 when the host cannot spare `MIN_ONLINE_WORKERS`, and that gate sits ahead of the pass-count veto, so on a small runner every case in the file was asserting about the runner rather than about the wiring.

Reproduced locally with `taskset -c 0`, which is the same condition:

| tree | result under one CPU |
|---|---|
| merge base `27326c4d8`, before any of this branch | 8 failed, 14 passed |
| this branch, before the fix | 18 failed, 15 passed |
| this branch, after pinning the worker count | 33 passed |

So the failure predates this branch; it is simply that this branch adds cases to a file that was already host-dependent. `_run` now pins `resolve_worker_count` for the same reason it already pins the TRL feature detector. The worker gate keeps its own coverage in `test_online_tokenization.py`.

### Compatibility, and what was actually executed

`dataset_bounds.py` stays torch-free, as its module docstring requires; asserted mechanically by importing it in a bare interpreter and checking that none of torch, transformers, trl, datasets, unsloth, unsloth_zoo or numpy enter `sys.modules`. The changed code uses only `os`, `json` and builtins, so no library version can change its answer; the version exposure is the test file, which imports the real trainer.

Eight stack combinations were executed on Linux, covering python 3.10 / 3.11 / 3.12 / 3.13, transformers 4.57.6 and 5.15.0, TRL 0.22.2 / 0.25.1 / 1.10.0, and torch 2.6.0 / 2.9.1 / 2.13.0, arranged so that all four `(transformers, TRL)` combinations appear and python and torch are crossed rather than held constant. Every cell reported a real pass count with no module-level skip and no `importorskip` firing, checked by probing that `datasets`, `torch` and the real `trl` all imported and that the live `trl_supports_skip_prepare_dataset()` returned True on every TRL. Note that transformers 5.x and torch 2.13 sit outside the range `studio-backend-ci.yml` declares, so those cells are future-proofing rather than evidence about the CI job.

The `os.path.isfile` on an arbitrary environment string was exercised against a directory, a fifo, a symlink loop, a dangling symlink, a mode-000 file as a non-root user, a 2 GB file, invalid UTF-8, `/dev/zero`, `/dev/null`, a missing path and a path containing spaces and non-ASCII characters. All return 1 without raising, the slowest case in the whole matrix is 2.7 ms, and nothing blocked. Payloads covered the bare list, the `{"hosts": [...]}` object, an empty list, a JSON string, a JSON number, `null`, a truncated payload, an inline payload above the cap and two rank-file variables disagreeing.

Honest limits. Windows, macOS and WSL were exercised as `sys.platform` fakes and through cross-platform staging CI, not as native development runs; on both of those platforms the online-tokenization platform gate vetoes before the pass count is read at all, so the changed expression cannot alter a decision there. A UNC path on Windows and a hung NFS mount on Linux are the one residual risk I could not clear: the block would be in the `stat`, which nothing here bounds, and I will not stage a fake hang and call it evidence. AMD/ROCm was not executed; the decision path reads no device state, which is an argument rather than a run. No real `torchrun`, `mpirun` or `mlx.launch` was involved; every world size in the tests is an injected variable or a temp-file payload. No browser is involved anywhere in this diff, so there is no browser testing to report.

Cross-platform staging CI, `test_online_tokenization_wiring.py` + `test_training_preflight.py` with `torch>=2.4 datasets trl>=0.24` installed so the tests cannot `importorskip` themselves into a vacuous exit 5:

| leg | before the worker-count pin | after |
|---|---|---|
| ubuntu-latest | 115 passed | 115 passed |
| windows-latest | 18 failed, 97 passed (pre-existing, see above) | 115 passed |
| macos-14 | failed on the same pre-existing gate | 115 passed |
