### PR TITLE
fix(studio): tell coding tools the real sandbox workdir path (#8892)

### DIFF
--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -7160,7 +7160,8 @@ def _msys_path(path: str) -> str:
     """Convert a native Win32 path to the MSYS form Git Bash reports as pwd."""
     norm = os.path.normpath(path)
     if norm.startswith("\\\\"):
-        return "/" + norm.replace("\\", "/").lstrip("/")
+        # UNC: Git Bash uses //server/share, not /server/share.
+        return "//" + norm[2:].replace("\\", "/")
     if len(norm) >= 2 and norm[1] == ":":
         drive = norm[0].lower()
         rest = norm[2:].replace("\\", "/")
@@ -9135,12 +9136,13 @@ _TERMINAL_SHELL_NOTE = _build_terminal_shell_note()
 def build_sandbox_workdir_nudge(session_id: str | None = None) -> str:
     """Tell the model which directory python/terminal tools run in.
 
-    Read-only: does not create a sandbox directory for ids that have never run
-    a tool. The path matches ``GET /sandbox/{session_id}`` and where users can
-    drop files for the model to read.
+    Uses the same resolver as execution (including legacy migration), so the
+    path matches the first tool call. The path also matches
+    ``GET /sandbox/{session_id}`` and where users can drop files for the model
+    to read.
     """
     try:
-        workdir = resolve_sandbox_workdir(session_id)
+        workdir = get_sandbox_workdir(session_id)
     except Exception:  # noqa: BLE001 - nudge is best effort
         return ""
     if not workdir:

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -6773,9 +6773,11 @@ def _build_safe_env(workdir: str) -> dict[str, str]:
     # Deduplicate, preserving order.
     deduped = list(dict.fromkeys(p for p in path_entries if p))
 
+    shell_workdir = _shell_visible_workdir(workdir)
     env = {
         "PATH": os.pathsep.join(deduped),
         "HOME": workdir,
+        "PWD": shell_workdir,
         "TMPDIR": workdir,
         "LANG": os.environ.get("LANG", "C.UTF-8"),
         "TERM": "dumb",
@@ -6974,6 +6976,7 @@ def _build_bypass_env(workdir: str) -> dict[str, str]:
         and not _is_cred_location_env_name(k)
     }
     env["HOME"] = workdir
+    env["PWD"] = _shell_visible_workdir(workdir)
     env["TMPDIR"] = workdir
     # Windows tempfile / SDKs honour TEMP/TMP, not TMPDIR; repoint all three so
     # the bypassed tool writes under the per-session sandbox dir on every OS.
@@ -7151,6 +7154,38 @@ def _windows_bash() -> "str | None":
         if os.path.isfile(candidate) and _is_trusted_windows_bash(candidate):
             return candidate
     return None
+
+
+def _msys_path(path: str) -> str:
+    """Convert a native Win32 path to the MSYS form Git Bash reports as pwd."""
+    norm = os.path.normpath(path)
+    if norm.startswith("\\\\"):
+        return "/" + norm.replace("\\", "/").lstrip("/")
+    if len(norm) >= 2 and norm[1] == ":":
+        drive = norm[0].lower()
+        rest = norm[2:].replace("\\", "/")
+        return f"/{drive}{rest}"
+    return norm.replace("\\", "/")
+
+
+def _shell_visible_workdir(workdir: str) -> str:
+    """Path form a sandbox shell reports (pwd / ``$PWD``)."""
+    resolved = os.path.realpath(workdir)
+    if sys.platform == "win32" and _windows_bash():
+        return _msys_path(resolved)
+    return resolved
+
+
+def _bash_wrap_for_workdir(workdir: str, command: str) -> str:
+    """Ensure a Win32 ``bash -c`` script starts in the sandbox workdir.
+
+    ``CreateProcess`` cwd is not always honoured by Git Bash; an explicit ``cd``
+    keeps ``pwd`` and relative writes aligned with the per-chat folder (#8892).
+    """
+    if sys.platform != "win32" or not _windows_bash():
+        return command
+    shell_dir = _shell_visible_workdir(workdir).replace("'", "'\"'\"'")
+    return f"cd '{shell_dir}' && {command}"
 
 
 def _windows_bash_userland_dirs() -> list[str]:
@@ -8923,8 +8958,9 @@ def _build_sandbox_paths_note() -> str:
     # says so, which reads as "the file was not really created".
     created = (
         " Any file you create here is kept and shown to the user with a download "
-        "link, so name the files you created in your reply -- by file name only, "
-        "since you do not know their absolute path."
+        "link, so name the files you created in your reply. Your working directory "
+        "path is provided in the system message; use relative paths for reads and "
+        "writes."
     )
     if sys.platform != "win32":
         return (
@@ -9094,6 +9130,28 @@ def _build_terminal_shell_note() -> str:
 
 _SANDBOX_PATHS_NOTE = _build_sandbox_paths_note()
 _TERMINAL_SHELL_NOTE = _build_terminal_shell_note()
+
+
+def build_sandbox_workdir_nudge(session_id: str | None = None) -> str:
+    """Tell the model which directory python/terminal tools run in.
+
+    Read-only: does not create a sandbox directory for ids that have never run
+    a tool. The path matches ``GET /sandbox/{session_id}`` and where users can
+    drop files for the model to read.
+    """
+    try:
+        workdir = resolve_sandbox_workdir(session_id)
+    except Exception:  # noqa: BLE001 - nudge is best effort
+        return ""
+    if not workdir:
+        return ""
+    visible = _shell_visible_workdir(workdir)
+    return (
+        f"Your code working directory for this conversation is: {visible}. "
+        "Use relative paths there for reads and writes; files you create are "
+        "kept for the user."
+    )
+
 
 PYTHON_TOOL = {
     "type": "function",
@@ -12842,7 +12900,10 @@ def _bash_exec(
         else:
             popen_kwargs["creationflags"] = subprocess.CREATE_NO_WINDOW
 
-        proc = subprocess.Popen(_get_shell_cmd(command), **popen_kwargs)
+        proc = subprocess.Popen(
+            _get_shell_cmd(_bash_wrap_for_workdir(workdir, command)),
+            **popen_kwargs,
+        )
 
         # Capture the group before any watcher can poll/reap the leader (see
         # _python_exec); None on Windows.

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -6718,7 +6718,7 @@ def _is_trusted_windows_program_dir(path: str) -> bool:
     return False
 
 
-def _build_safe_env(workdir: str) -> dict[str, str]:
+def _build_safe_env(workdir: str, *, posix_shell: bool = False) -> dict[str, str]:
     """Build a minimal, credential-free environment for sandboxed subprocesses.
 
     Whitelist-built from scratch (parent env NOT inherited): only PATH/HOME/
@@ -6773,11 +6773,11 @@ def _build_safe_env(workdir: str) -> dict[str, str]:
     # Deduplicate, preserving order.
     deduped = list(dict.fromkeys(p for p in path_entries if p))
 
-    shell_workdir = _shell_visible_workdir(workdir)
+    pwd = _bash_visible_workdir(workdir) if posix_shell else _native_workdir(workdir)
     env = {
         "PATH": os.pathsep.join(deduped),
         "HOME": workdir,
-        "PWD": shell_workdir,
+        "PWD": pwd,
         "TMPDIR": workdir,
         "LANG": os.environ.get("LANG", "C.UTF-8"),
         "TERM": "dumb",
@@ -6960,7 +6960,7 @@ def _is_secret_env_value(value: str) -> bool:
     return _URL_USERINFO_RE.search(value) is not None or _SECRET_VALUE_RE.search(value) is not None
 
 
-def _build_bypass_env(workdir: str) -> dict[str, str]:
+def _build_bypass_env(workdir: str, *, posix_shell: bool = False) -> dict[str, str]:
     """Env for bypass exec: full host env minus credential vars, with HOME/TMPDIR
     repointed at the workdir so SDKs cannot read cached creds.
 
@@ -6976,7 +6976,7 @@ def _build_bypass_env(workdir: str) -> dict[str, str]:
         and not _is_cred_location_env_name(k)
     }
     env["HOME"] = workdir
-    env["PWD"] = _shell_visible_workdir(workdir)
+    env["PWD"] = _bash_visible_workdir(workdir) if posix_shell else _native_workdir(workdir)
     env["TMPDIR"] = workdir
     # Windows tempfile / SDKs honour TEMP/TMP, not TMPDIR; repoint all three so
     # the bypassed tool writes under the per-session sandbox dir on every OS.
@@ -7169,9 +7169,14 @@ def _msys_path(path: str) -> str:
     return norm.replace("\\", "/")
 
 
-def _shell_visible_workdir(workdir: str) -> str:
-    """Path form a sandbox shell reports (pwd / ``$PWD``)."""
-    resolved = os.path.realpath(workdir)
+def _native_workdir(workdir: str) -> str:
+    """Native absolute path for the sandbox directory (CPython / Explorer)."""
+    return os.path.realpath(workdir)
+
+
+def _bash_visible_workdir(workdir: str) -> str:
+    """Path form Git Bash reports as pwd / ``$PWD``."""
+    resolved = _native_workdir(workdir)
     if sys.platform == "win32" and _windows_bash():
         return _msys_path(resolved)
     return resolved
@@ -7185,7 +7190,7 @@ def _bash_wrap_for_workdir(workdir: str, command: str) -> str:
     """
     if sys.platform != "win32" or not _windows_bash():
         return command
-    shell_dir = _shell_visible_workdir(workdir).replace("'", "'\"'\"'")
+    shell_dir = _bash_visible_workdir(workdir).replace("'", "'\"'\"'")
     return f"cd '{shell_dir}' && {command}"
 
 
@@ -9147,7 +9152,7 @@ def build_sandbox_workdir_nudge(session_id: str | None = None) -> str:
         return ""
     if not workdir:
         return ""
-    visible = _shell_visible_workdir(workdir)
+    visible = _native_workdir(workdir)
     return (
         f"Your code working directory for this conversation is: {visible}. "
         "Use relative paths there for reads and writes; files you create are "
@@ -12884,7 +12889,12 @@ def _bash_exec(
         # Same pre-run snapshot as _python_exec. A command that writes a file used
         # to produce "(no output)" and no other trace anywhere in the product.
         _before = _snapshot_workdir_files(workdir)
-        safe_env = _build_bypass_env(workdir) if disable_sandbox else _build_safe_env(workdir)
+        posix_shell = _shell_is_posix()
+        safe_env = (
+            _build_bypass_env(workdir, posix_shell = posix_shell)
+            if disable_sandbox
+            else _build_safe_env(workdir, posix_shell = posix_shell)
+        )
         popen_kwargs = dict(
             stdout = subprocess.PIPE,
             stderr = subprocess.STDOUT,

--- a/studio/backend/models/inference.py
+++ b/studio/backend/models/inference.py
@@ -1916,6 +1916,10 @@ class ChatCountTokensRequest(BaseModel):
         description = "[x-unsloth] Equivalent of permission_mode='full'. Declared explicitly (not "
         "left to extra='allow') so an omitted flag reads as None instead of raising AttributeError.",
     )
+    session_id: Optional[str] = Field(
+        None,
+        description = "[x-unsloth] Session/thread ID for scoping tool execution sandbox.",
+    )
 
     @field_validator("permission_mode", mode = "before")
     @classmethod

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -12298,9 +12298,7 @@ async def _proxy_to_external_provider(
                 session_id = payload.session_id,
             )
             if _codex_workdir_nudge and not payload.bypass_permissions:
-                chat_messages = _append_to_codex_instructions(
-                    chat_messages, _codex_workdir_nudge
-                )
+                chat_messages = _append_to_codex_instructions(chat_messages, _codex_workdir_nudge)
             if payload.bypass_permissions:
                 _codex_full_access_nudge = _build_tool_action_nudge(
                     tools = studio_tool_payloads,

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -3254,11 +3254,15 @@ def _build_tool_action_nudge(
     model_name: str,
     full_access: bool = False,
     full_access_only: bool = False,
+    workdir_only: bool = False,
     session_id: str | None = None,
 ) -> str:
     """``full_access_only`` returns the Full access sentence alone, for a caller
     that wants to state the environment without also introducing the general
-    tool guidance (and the date) to a path that has never carried it."""
+    tool guidance (and the date) to a path that has never carried it.
+
+    ``workdir_only`` returns only the sandbox workdir line (for external tool
+    loops that have never carried the general tool nudge)."""
     from core.inference.tools import build_sandbox_workdir_nudge
 
     tool_names = {
@@ -3272,8 +3276,17 @@ def _build_tool_action_nudge(
     has_artifact = "render_html" in tool_names
     if not (has_web or has_code or has_artifact):
         return ""
+    if workdir_only:
+        return build_sandbox_workdir_nudge(session_id) if has_code else ""
     if full_access_only:
-        return _full_access_tip(code_tools) if (full_access and has_code) else ""
+        parts: list[str] = []
+        if full_access and has_code:
+            parts.append(_full_access_tip(code_tools))
+        if has_code:
+            workdir_tip = build_sandbox_workdir_nudge(session_id)
+            if workdir_tip:
+                parts.append(workdir_tip)
+        return " ".join(parts) if parts else ""
 
     model_size_b = _extract_model_size_b(model_name)
     compact_web_tip = model_size_b is not None and model_size_b < 9
@@ -12278,16 +12291,28 @@ async def _proxy_to_external_provider(
             # Only the Full access sentence is added: the path has never carried
             # the general tool nudge, and widening it would change every
             # non-Full-access Codex run as a side effect.
+            _codex_workdir_nudge = _build_tool_action_nudge(
+                tools = studio_tool_payloads,
+                model_name = model,
+                workdir_only = True,
+                session_id = payload.session_id,
+            )
+            if _codex_workdir_nudge and not payload.bypass_permissions:
+                chat_messages = _append_to_codex_instructions(
+                    chat_messages, _codex_workdir_nudge
+                )
             if payload.bypass_permissions:
                 _codex_full_access_nudge = _build_tool_action_nudge(
                     tools = studio_tool_payloads,
                     model_name = model,
                     full_access = True,
                     full_access_only = True,
+                    session_id = payload.session_id,
                 )
-                chat_messages = _append_to_codex_instructions(
-                    chat_messages, _codex_full_access_nudge
-                )
+                if _codex_full_access_nudge:
+                    chat_messages = _append_to_codex_instructions(
+                        chat_messages, _codex_full_access_nudge
+                    )
         cancel_event = threading.Event()
         cancel_keys = tuple(key for key in (payload.cancel_id, payload.session_id) if key)
 
@@ -12545,15 +12570,22 @@ async def _proxy_to_external_provider(
             mcp_allowed = bool(payload.mcp_enabled),
         )
     run_studio_tool_loop = bool(external_studio_tools)
-    if run_studio_tool_loop and payload.bypass_permissions:
-        # Full access disables the sandbox at execution time, so the schemas must
-        # say so too rather than describing a sandbox the model will not get.
-        _external_nudge = _build_tool_action_nudge(
-            tools = external_studio_tools,
-            model_name = model,
-            full_access = True,
-            full_access_only = True,
-        )
+    if run_studio_tool_loop:
+        if payload.bypass_permissions:
+            _external_nudge = _build_tool_action_nudge(
+                tools = external_studio_tools,
+                model_name = model,
+                full_access = True,
+                full_access_only = True,
+                session_id = payload.session_id,
+            )
+        else:
+            _external_nudge = _build_tool_action_nudge(
+                tools = external_studio_tools,
+                model_name = model,
+                workdir_only = True,
+                session_id = payload.session_id,
+            )
         if _external_nudge:
             chat_messages = _append_to_system_message(chat_messages, _external_nudge)
 

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -3254,10 +3254,13 @@ def _build_tool_action_nudge(
     model_name: str,
     full_access: bool = False,
     full_access_only: bool = False,
+    session_id: str | None = None,
 ) -> str:
     """``full_access_only`` returns the Full access sentence alone, for a caller
     that wants to state the environment without also introducing the general
     tool guidance (and the date) to a path that has never carried it."""
+    from core.inference.tools import build_sandbox_workdir_nudge
+
     tool_names = {
         (tool.get("function") or {}).get("name")
         for tool in tools
@@ -3279,6 +3282,9 @@ def _build_tool_action_nudge(
         tool_tip_parts.append(_TOOL_WEB_COMPACT_TIP if compact_web_tip else _TOOL_WEB_EXPANDED_TIP)
     if has_code:
         tool_tip_parts.append(_TOOL_CODE_TIP)
+        workdir_tip = build_sandbox_workdir_nudge(session_id)
+        if workdir_tip:
+            tool_tip_parts.append(workdir_tip)
         if full_access:
             tool_tip_parts.append(_full_access_tip(code_tools))
     if has_artifact:
@@ -13761,6 +13767,7 @@ async def openai_chat_completions(
                 tools = tools_to_use,
                 model_name = model_name,
                 full_access = bool(payload.bypass_permissions),
+                session_id = payload.session_id,
             )
 
             # Nudge the model to ground in attached documents instead of memory.
@@ -15275,6 +15282,7 @@ async def openai_chat_completions(
             tools = _sf_tools_to_use,
             model_name = model_name,
             full_access = bool(payload.bypass_permissions),
+            session_id = payload.session_id,
         )
 
         # RAG nudge, mirroring the GGUF path.
@@ -19398,6 +19406,7 @@ async def chat_count_tokens(
                         tools = tools_to_use,
                         model_name = _llama_public_model_id(llama_backend, payload.model),
                         full_access = bool(payload.bypass_permissions),
+                        session_id = payload.session_id,
                     ),
                     tools_to_use,
                     rag_scope = payload.rag_scope,
@@ -20135,6 +20144,7 @@ async def anthropic_messages(
             tools = openai_tools,
             model_name = model_name,
             full_access = _full_access,
+            session_id = payload.session_id,
         )
 
         if _nudge:

--- a/studio/backend/tests/test_anthropic_messages.py
+++ b/studio/backend/tests/test_anthropic_messages.py
@@ -157,6 +157,15 @@ class TestToolActionNudge:
         assert "Use code execution for math" in nudge
         assert "render_html" not in nudge
 
+    def test_code_nudge_includes_workdir_when_session_id_given(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("UNSLOTH_STUDIO_SANDBOX_HOME", str(tmp_path / "sb"))
+        nudge = _build_tool_action_nudge(
+            tools = [{"type": "function", "function": {"name": "python"}}],
+            model_name = "Llama-3.1-70B-Instruct",
+            session_id = "__LOCALID_nudge02",
+        )
+        assert "Your code working directory for this conversation is:" in nudge
+
     def test_balanced_nudge_preserves_compact_web_tip_and_canvas_gate(self):
         nudge = _build_tool_action_nudge(
             tools = [

--- a/studio/backend/tests/test_full_access_tool_prompt.py
+++ b/studio/backend/tests/test_full_access_tool_prompt.py
@@ -405,6 +405,11 @@ def test_count_request_reads_the_flag_when_omitted():
     """The count route reaches for payload.bypass_permissions unconditionally,
     so the field has to exist rather than arrive via extra='allow'."""
     assert _count_request().bypass_permissions is None
+    assert _count_request().session_id is None
+
+
+def test_count_request_accepts_session_id():
+    assert _count_request(session_id = "__LOCALID_count01").session_id == "__LOCALID_count01"
 
 
 @pytest.mark.parametrize(

--- a/studio/backend/tests/test_sandbox_files_and_storage_roots.py
+++ b/studio/backend/tests/test_sandbox_files_and_storage_roots.py
@@ -242,7 +242,7 @@ def test_tool_description_says_files_are_kept():
     print(f"\nsandbox note = {note!r}")
     assert "download link" in note
     assert "name the files you created" in note
-    assert "absolute path" in note
+    assert "system message" in note
 
 
 # ---------------------------------------------------------------------------

--- a/studio/backend/tests/test_sandbox_tools.py
+++ b/studio/backend/tests/test_sandbox_tools.py
@@ -1978,7 +1978,6 @@ class TestHfUploadEnvAndSecretLeakBlock:
 class TestSandboxWorkdirVisibility:
     def test_msys_path_maps_drive_letters(self):
         from core.inference.tools import _msys_path
-
         assert _msys_path("C:\\Users\\foo\\sandbox") == "/c/Users/foo/sandbox"
 
     def test_bash_wrap_prepends_cd_on_windows(self, monkeypatch):

--- a/studio/backend/tests/test_sandbox_tools.py
+++ b/studio/backend/tests/test_sandbox_tools.py
@@ -1982,7 +1982,6 @@ class TestSandboxWorkdirVisibility:
 
     def test_msys_path_preserves_unc_prefix(self):
         from core.inference.tools import _msys_path
-
         assert _msys_path("\\\\server\\share\\chat") == "//server/share/chat"
 
     def test_bash_wrap_prepends_cd_on_windows(self, monkeypatch):

--- a/studio/backend/tests/test_sandbox_tools.py
+++ b/studio/backend/tests/test_sandbox_tools.py
@@ -1997,9 +1997,9 @@ class TestSandboxWorkdirVisibility:
         wrapped = _bash_wrap_for_workdir("C:\\Users\\foo\\chat", "pwd")
         assert wrapped.startswith("cd '/c/Users/foo/chat' && pwd")
 
-    def test_python_env_uses_native_pwd_on_windows(self, monkeypatch, tmp_path):
+    def test_python_env_uses_native_pwd_not_msys(self, monkeypatch, tmp_path):
         import core.inference.tools as tools_mod
-        from core.inference.tools import _build_safe_env
+        from core.inference.tools import _build_safe_env, _native_workdir
 
         monkeypatch.setattr(sys, "platform", "win32")
         monkeypatch.setattr(
@@ -2007,11 +2007,10 @@ class TestSandboxWorkdirVisibility:
             "_windows_bash",
             lambda: r"C:\Program Files\Git\bin\bash.exe",
         )
-        native = str(tmp_path / "sandbox")
-        env = _build_safe_env(native)
-        assert env["PWD"] == native
-        bash_env = _build_safe_env(native, posix_shell = True)
-        assert bash_env["PWD"] == "/c" + native.replace("\\", "/").replace(":", "")
+        monkeypatch.setattr(tools_mod, "_bash_visible_workdir", lambda w: "/c/msys/path")
+        wd = str(tmp_path)
+        assert _build_safe_env(wd)["PWD"] == _native_workdir(wd)
+        assert _build_safe_env(wd, posix_shell = True)["PWD"] == "/c/msys/path"
 
     def test_build_sandbox_workdir_nudge_names_the_folder(self, tmp_path, monkeypatch):
         from core.inference.tools import build_sandbox_workdir_nudge

--- a/studio/backend/tests/test_sandbox_tools.py
+++ b/studio/backend/tests/test_sandbox_tools.py
@@ -625,6 +625,7 @@ class TestSandboxEnvIsolation:
 
         env = _build_safe_env(str(tmp_path))
         assert env["HOME"] == str(tmp_path)
+        assert env["PWD"] == str(tmp_path)
         assert env["TMPDIR"] == str(tmp_path)
 
     def test_term_is_dumb(self, tmp_path):
@@ -1972,3 +1973,31 @@ class TestHfUploadEnvAndSecretLeakBlock:
             ' operations=[], token="hf_xxx")',
             expect_phrase = "HF upload token= cannot be set",
         )
+
+
+class TestSandboxWorkdirVisibility:
+    def test_msys_path_maps_drive_letters(self):
+        from core.inference.tools import _msys_path
+
+        assert _msys_path("C:\\Users\\foo\\sandbox") == "/c/Users/foo/sandbox"
+
+    def test_bash_wrap_prepends_cd_on_windows(self, monkeypatch):
+        import core.inference.tools as tools_mod
+        from core.inference.tools import _bash_wrap_for_workdir
+
+        monkeypatch.setattr(sys, "platform", "win32")
+        monkeypatch.setattr(
+            tools_mod,
+            "_windows_bash",
+            lambda: r"C:\Program Files\Git\bin\bash.exe",
+        )
+        wrapped = _bash_wrap_for_workdir("C:\\Users\\foo\\chat", "pwd")
+        assert wrapped.startswith("cd '/c/Users/foo/chat' && pwd")
+
+    def test_build_sandbox_workdir_nudge_names_the_folder(self, tmp_path, monkeypatch):
+        from core.inference.tools import build_sandbox_workdir_nudge
+
+        monkeypatch.setenv("UNSLOTH_STUDIO_SANDBOX_HOME", str(tmp_path / "sb"))
+        nudge = build_sandbox_workdir_nudge("__LOCALID_nudge01")
+        assert "Your code working directory for this conversation is:" in nudge
+        assert "__LOCALID_nudge01" in nudge or "nudge01" in nudge

--- a/studio/backend/tests/test_sandbox_tools.py
+++ b/studio/backend/tests/test_sandbox_tools.py
@@ -1980,6 +1980,11 @@ class TestSandboxWorkdirVisibility:
         from core.inference.tools import _msys_path
         assert _msys_path("C:\\Users\\foo\\sandbox") == "/c/Users/foo/sandbox"
 
+    def test_msys_path_preserves_unc_prefix(self):
+        from core.inference.tools import _msys_path
+
+        assert _msys_path("\\\\server\\share\\chat") == "//server/share/chat"
+
     def test_bash_wrap_prepends_cd_on_windows(self, monkeypatch):
         import core.inference.tools as tools_mod
         from core.inference.tools import _bash_wrap_for_workdir

--- a/studio/backend/tests/test_sandbox_tools.py
+++ b/studio/backend/tests/test_sandbox_tools.py
@@ -1997,6 +1997,22 @@ class TestSandboxWorkdirVisibility:
         wrapped = _bash_wrap_for_workdir("C:\\Users\\foo\\chat", "pwd")
         assert wrapped.startswith("cd '/c/Users/foo/chat' && pwd")
 
+    def test_python_env_uses_native_pwd_on_windows(self, monkeypatch, tmp_path):
+        import core.inference.tools as tools_mod
+        from core.inference.tools import _build_safe_env
+
+        monkeypatch.setattr(sys, "platform", "win32")
+        monkeypatch.setattr(
+            tools_mod,
+            "_windows_bash",
+            lambda: r"C:\Program Files\Git\bin\bash.exe",
+        )
+        native = str(tmp_path / "sandbox")
+        env = _build_safe_env(native)
+        assert env["PWD"] == native
+        bash_env = _build_safe_env(native, posix_shell = True)
+        assert bash_env["PWD"] == "/c" + native.replace("\\", "/").replace(":", "")
+
     def test_build_sandbox_workdir_nudge_names_the_folder(self, tmp_path, monkeypatch):
         from core.inference.tools import build_sandbox_workdir_nudge
 

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -1637,6 +1637,7 @@ export async function buildLocalTokenCountExtras(
   if (!supportsTools) return {};
 
   const ragProjectId = await resolveProjectId(threadId);
+  const sandboxSessionId = await resolveSandboxSessionId(threadId);
   const projectRagEnabled = ragProjectId
     ? await projectHasSources(ragProjectId)
     : false;
@@ -1660,6 +1661,7 @@ export async function buildLocalTokenCountExtras(
 
   return {
     enable_tools: true,
+    ...(sandboxSessionId ? { session_id: sandboxSessionId } : {}),
     // Auto-Heal off leaves leaked tool markup in the real prompt, so the count keeps it.
     auto_heal_tool_calls: autoHealToolCalls,
     // Full access swaps the python/terminal descriptions and adds a nudge

--- a/studio/frontend/src/features/chat/api/chat-api.ts
+++ b/studio/frontend/src/features/chat/api/chat-api.ts
@@ -277,6 +277,7 @@ export async function countChatInputTokens(payload: {
   mcp_enabled?: boolean;
   rag_scope?: Record<string, unknown>;
   auto_heal_tool_calls?: boolean;
+  session_id?: string;
   /** Run the selected tools here rather than as the provider's hosted builtins. */
   run_tools_locally?: boolean;
   // `model` is informational: the endpoint counts with whatever is resident and reports which.


### PR DESCRIPTION
Fixes #8892

## Problem

When using python/terminal tools in a chat, models often reported `/tmp` as their working directory (e.g. via `pwd`) while files actually lived in per-chat sandbox folders under the studio home. Tool descriptions also told models they do not know the absolute path, which made it hard for users to find where to drop files for the model.

## Solution

- Set `PWD` in the sandbox subprocess environment to match the real workdir
- On Windows + Git Bash, prepend `cd '<msys-path>' &&` to terminal commands so `pwd` aligns with the per-chat folder (Git Bash does not always honor `CreateProcess` cwd)
- Inject the resolved workdir into the tool system nudge when code tools are enabled
- Update tool descriptions to reference the system-message path instead of claiming the model cannot know it

## Testing

- Manual verification of `pwd`, `PWD` env, and nudge text on Linux
- Unit tests added in `test_sandbox_tools.py` (msys path, bash wrap, nudge helper)