### PR TITLE
Windows: keep uv cache under the Studio root

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -2428,6 +2428,8 @@ exit 0
     $studioNeedsRuntimeLock = $true
     $studioUsesLegacyLayout = ($StudioRedirectMode -ne 'env') -or $studioUsesTauriManagedRoot
     $studioAutoStartProcess = $null
+    $previousUvCacheDir = $env:UV_CACHE_DIR
+    $hadPreviousUvCacheDir = ($null -ne $previousUvCacheDir)
     try {
         if ($studioNeedsRuntimeLock) {
             try {
@@ -3226,6 +3228,7 @@ exit 0
     # Keep uv's install cache with Studio's managed cache tree rather than the
     # user-wide LOCALAPPDATA default. A regular file left at this managed path
     # would otherwise make uv fail before it can create the virtual environment.
+    # The outer install finally restores the caller's value after every exit path.
     if ([string]::IsNullOrWhiteSpace($env:UV_CACHE_DIR)) {
         $env:UV_CACHE_DIR = Join-Path (Join-Path $StudioHome "cache") "uv"
         if (Test-Path -LiteralPath $env:UV_CACHE_DIR -PathType Leaf) {
@@ -5762,6 +5765,11 @@ exit 0
         Write-StudioLine ""
     }
     } finally {
+        if ($hadPreviousUvCacheDir) {
+            $env:UV_CACHE_DIR = $previousUvCacheDir
+        } else {
+            Remove-Item Env:UV_CACHE_DIR -ErrorAction SilentlyContinue
+        }
         for ($i = $studioRuntimeMutexes.Count - 1; $i -ge 0; $i--) {
             Exit-StudioInstallMutex -Mutex $studioRuntimeMutexes[$i]
         }

--- a/install.ps1
+++ b/install.ps1
@@ -3225,20 +3225,6 @@ exit 0
         return (Exit-InstallFailure "uv could not be installed")
     }
 
-    # Keep uv's install cache with Studio's managed cache tree rather than the
-    # user-wide LOCALAPPDATA default. A regular file left at this managed path
-    # would otherwise make uv fail before it can create the virtual environment.
-    # The outer install finally restores the caller's value after every exit path.
-    if ([string]::IsNullOrWhiteSpace($env:UV_CACHE_DIR)) {
-        $env:UV_CACHE_DIR = Join-Path (Join-Path $StudioHome "cache") "uv"
-        if (Test-Path -LiteralPath $env:UV_CACHE_DIR -PathType Leaf) {
-            $invalidUvCache = "$($env:UV_CACHE_DIR).invalid.$(Get-Date -Format 'yyyyMMddHHmmss').$PID"
-            Move-Item -LiteralPath $env:UV_CACHE_DIR -Destination $invalidUvCache
-            substep "moved conflicting uv cache file aside to $invalidUvCache" "Yellow"
-        }
-        [System.IO.Directory]::CreateDirectory($env:UV_CACHE_DIR) | Out-Null
-    }
-
     # When bytecode compilation is enabled, large installs can exceed uv's 60s
     # default on slow machines. Default to 180s, preserving overrides ("0" disables).
     if (-not $env:UV_COMPILE_BYTECODE_TIMEOUT) {
@@ -3593,6 +3579,21 @@ exit 0
         Move-Item -LiteralPath $CwdVenv -Destination $VenvDir -Force
         substep "moved ~/unsloth_studio -> ~/.unsloth/studio/unsloth_studio"
         $_Migrated = $true
+    }
+
+    # Keep uv's install cache with Studio's managed cache tree rather than the
+    # user-wide LOCALAPPDATA default. A regular file left at this managed path
+    # would otherwise make uv fail before it can create the virtual environment.
+    # Defer mutating the cache path until any existing venv passes its ownership
+    # guard. The outer install finally restores the caller's value on every exit.
+    if ([string]::IsNullOrWhiteSpace($env:UV_CACHE_DIR)) {
+        $env:UV_CACHE_DIR = Join-Path (Join-Path $StudioHome "cache") "uv"
+        if (Test-Path -LiteralPath $env:UV_CACHE_DIR -PathType Leaf) {
+            $invalidUvCache = "$($env:UV_CACHE_DIR).invalid.$(Get-Date -Format 'yyyyMMddHHmmss').$PID"
+            Move-Item -LiteralPath $env:UV_CACHE_DIR -Destination $invalidUvCache
+            substep "moved conflicting uv cache file aside to $invalidUvCache" "Yellow"
+        }
+        [System.IO.Directory]::CreateDirectory($env:UV_CACHE_DIR) | Out-Null
     }
 
     if (-not (Test-Path -LiteralPath $VenvPython)) {

--- a/install.ps1
+++ b/install.ps1
@@ -3581,11 +3581,8 @@ exit 0
         $_Migrated = $true
     }
 
-    # Keep uv's install cache with Studio's managed cache tree rather than the
-    # user-wide LOCALAPPDATA default. A regular file left at this managed path
-    # would otherwise make uv fail before it can create the virtual environment.
-    # Defer mutating the cache path until any existing venv passes its ownership
-    # guard. The outer install finally restores the caller's value on every exit.
+    # Keep uv's default cache under Studio so it is removed with Studio. Wait until any
+    # existing venv passes ownership validation; the outer finally restores the caller's value.
     if ([string]::IsNullOrWhiteSpace($env:UV_CACHE_DIR)) {
         $env:UV_CACHE_DIR = Join-Path (Join-Path $StudioHome "cache") "uv"
         if (Test-Path -LiteralPath $env:UV_CACHE_DIR -PathType Leaf) {

--- a/install.ps1
+++ b/install.ps1
@@ -3223,6 +3223,19 @@ exit 0
         return (Exit-InstallFailure "uv could not be installed")
     }
 
+    # Keep uv's install cache with Studio's managed cache tree rather than the
+    # user-wide LOCALAPPDATA default. A regular file left at this managed path
+    # would otherwise make uv fail before it can create the virtual environment.
+    if ([string]::IsNullOrWhiteSpace($env:UV_CACHE_DIR)) {
+        $env:UV_CACHE_DIR = Join-Path (Join-Path $StudioHome "cache") "uv"
+        if (Test-Path -LiteralPath $env:UV_CACHE_DIR -PathType Leaf) {
+            $invalidUvCache = "$($env:UV_CACHE_DIR).invalid.$(Get-Date -Format 'yyyyMMddHHmmss').$PID"
+            Move-Item -LiteralPath $env:UV_CACHE_DIR -Destination $invalidUvCache
+            substep "moved conflicting uv cache file aside to $invalidUvCache" "Yellow"
+        }
+        [System.IO.Directory]::CreateDirectory($env:UV_CACHE_DIR) | Out-Null
+    }
+
     # When bytecode compilation is enabled, large installs can exceed uv's 60s
     # default on slow machines. Default to 180s, preserving overrides ("0" disables).
     if (-not $env:UV_COMPILE_BYTECODE_TIMEOUT) {

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -4650,6 +4650,33 @@ if (Get-Command uv -ErrorAction SilentlyContinue) {
 # the catch: this is the last statement before Fast-Install starts resolving `python`.
 Assert-VenvActivated -VenvDir $VenvDir
 
+$previousUvCacheDir = $env:UV_CACHE_DIR
+$hadPreviousUvCacheDir = ($null -ne $previousUvCacheDir)
+try {
+    # Standalone updates and desktop repairs do not pass through install.ps1, so give every
+    # setup path the same Studio-managed cache default, and the same recovery from a regular
+    # file sitting on it (#8991). An explicit caller override is left alone.
+    # The environment variable rather than `uv --cache-dir`: install_python_stack.py, spawned
+    # further down, runs its own `uv pip install`, and only an inherited variable reaches it.
+    # Restored on every exit, hence the span: .NOTES documents `.\setup.ps1 --verbose`, which
+    # runs in the caller's own PowerShell session, where a left-behind UV_CACHE_DIR would
+    # silently redirect their later, unrelated uv commands into the Studio cache.
+    if ([string]::IsNullOrWhiteSpace($env:UV_CACHE_DIR)) {
+        $env:UV_CACHE_DIR = Join-Path (Join-Path $StudioHome "cache") "uv"
+        try {
+            if (Test-Path -LiteralPath $env:UV_CACHE_DIR -PathType Leaf) {
+                $invalidUvCache = "$($env:UV_CACHE_DIR).invalid.$(Get-Date -Format 'yyyyMMddHHmmss').$PID"
+                Move-Item -LiteralPath $env:UV_CACHE_DIR -Destination $invalidUvCache -ErrorAction Stop
+                substep "moved conflicting uv cache file aside to $invalidUvCache" "Yellow"
+            }
+            [System.IO.Directory]::CreateDirectory($env:UV_CACHE_DIR) | Out-Null
+        } catch {
+            # Through Exit-SetupFailure, not a raw throw: the Tauri update path reads
+            # [TAURI:ERROR] and would otherwise surface an unhandled exception with no message.
+            Exit-SetupFailure "could not prepare the uv cache at $($env:UV_CACHE_DIR): $_"
+        }
+    }
+
 # Helper: install a package, preferring uv with pip fallback
 function Fast-Install {
     param([Parameter(ValueFromRemainingArguments=$true)]$Args_)
@@ -6863,5 +6890,12 @@ if ($script:LlamaCppDegraded -and $env:SKIP_STUDIO_BASE -eq "1") {
         [Console]::Out.Flush()
     } else {
         Exit-SetupFailure "llama.cpp setup did not produce a usable server"
+    }
+}
+} finally {
+    if ($hadPreviousUvCacheDir) {
+        $env:UV_CACHE_DIR = $previousUvCacheDir
+    } else {
+        Remove-Item Env:UV_CACHE_DIR -ErrorAction SilentlyContinue
     }
 }

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -4653,14 +4653,8 @@ Assert-VenvActivated -VenvDir $VenvDir
 $previousUvCacheDir = $env:UV_CACHE_DIR
 $hadPreviousUvCacheDir = ($null -ne $previousUvCacheDir)
 try {
-    # Standalone updates and desktop repairs do not pass through install.ps1, so give every
-    # setup path the same Studio-managed cache default, and the same recovery from a regular
-    # file sitting on it (#8991). An explicit caller override is left alone.
-    # The environment variable rather than `uv --cache-dir`: install_python_stack.py, spawned
-    # further down, runs its own `uv pip install`, and only an inherited variable reaches it.
-    # Restored on every exit, hence the span: .NOTES documents `.\setup.ps1 --verbose`, which
-    # runs in the caller's own PowerShell session, where a left-behind UV_CACHE_DIR would
-    # silently redirect their later, unrelated uv commands into the Studio cache.
+    # Match the installer cache policy for update and repair. The variable reaches the uv child
+    # in install_python_stack.py; the outer finally restores it after direct script runs.
     if ([string]::IsNullOrWhiteSpace($env:UV_CACHE_DIR)) {
         $env:UV_CACHE_DIR = Join-Path (Join-Path $StudioHome "cache") "uv"
         try {
@@ -4671,8 +4665,7 @@ try {
             }
             [System.IO.Directory]::CreateDirectory($env:UV_CACHE_DIR) | Out-Null
         } catch {
-            # Through Exit-SetupFailure, not a raw throw: the Tauri update path reads
-            # [TAURI:ERROR] and would otherwise surface an unhandled exception with no message.
+            # Keep Tauri update failures structured.
             Exit-SetupFailure "could not prepare the uv cache at $($env:UV_CACHE_DIR): $_"
         }
     }

--- a/tests/python/test_windows_python_venv_hardening.py
+++ b/tests/python/test_windows_python_venv_hardening.py
@@ -435,14 +435,9 @@ def _uv_cache_lifecycle_blocks(source: str) -> tuple[str, str, str]:
     )
     setup = _extract(
         r"    if \(\[string\]::IsNullOrWhiteSpace\(\$env:UV_CACHE_DIR\)\) \{"
-        r".*?\n    \}\n\n"
-        r"    # When bytecode compilation is enabled",
+        r".*?\n    \}\n",
         source,
     )
-    setup = setup.rsplit(
-        "\n\n    # When bytecode compilation is enabled",
-        1,
-    )[0]
     restore = _extract(
         r"        if \(\$hadPreviousUvCacheDir\) \{.*?\n        \}\n"
         r"(?=        for \(\$i = \$studioRuntimeMutexes.Count)",
@@ -466,6 +461,19 @@ def test_uv_cache_lifecycle_wraps_outer_install_try():
     assert capture_at < outer_try_at < setup_at < restore_at < lock_release_at
     assert "$env:UV_CACHE_DIR = $previousUvCacheDir" in restore
     assert "Remove-Item Env:UV_CACHE_DIR -ErrorAction SilentlyContinue" in restore
+
+
+def test_uv_cache_recovery_follows_existing_venv_ownership_guard():
+    source = INSTALL_PS1.read_text(encoding = "utf-8")
+    _, cache_setup, _ = _uv_cache_lifecycle_blocks(source)
+    ownership_rejection_at = source.index('throw "Refusing to delete non-Unsloth venv at $VenvDir"')
+    cache_setup_at = source.index(cache_setup)
+    uv_venv_at = source.index(
+        'Invoke-InstallCommand -Label "create virtual environment"',
+        cache_setup_at,
+    )
+
+    assert ownership_rejection_at < cache_setup_at < uv_venv_at
 
 
 @pytest.mark.skipif(not POWERSHELLS, reason = "PowerShell is unavailable")

--- a/tests/python/test_windows_python_venv_hardening.py
+++ b/tests/python/test_windows_python_venv_hardening.py
@@ -503,11 +503,8 @@ def test_setup_uv_cache_guard_covers_every_setup_uv_call_after_ownership_validat
     outer_try_at = source.index("try {", capture_at)
     cache_setup_at = source.index(cache_setup, outer_try_at)
     restore_at = source.index(restore, cache_setup_at)
-    # Every uv/uvx invocation, not just the `uv pip` pair that exists today: the point of
-    # the guard is that a later `uv venv` or `uv sync` cannot land ahead of it.
+    # Direct uv calls and the Python child that invokes uv must stay inside the region.
     uv_calls = [match.start() for match in re.finditer(r"(?m)^\s*(?:\$\w+ = )?& uvx?\b", source)]
-    # The reason this has to be the environment variable and not `uv --cache-dir`: this child
-    # runs its own `uv pip install`, so it has to inherit the setting.
     python_stack_at = source.index(r'python "$PSScriptRoot\install_python_stack.py"')
 
     assert ownership_rejection_at < capture_at < outer_try_at < cache_setup_at < restore_at

--- a/tests/python/test_windows_python_venv_hardening.py
+++ b/tests/python/test_windows_python_venv_hardening.py
@@ -18,12 +18,13 @@ import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 INSTALL_PS1 = REPO_ROOT / "install.ps1"
+SETUP_PS1 = REPO_ROOT / "studio" / "setup.ps1"
 POWERSHELLS = [shell for shell in ("pwsh", "powershell") if shutil.which(shell)]
 
 
 def _extract(pattern: str, source: str) -> str:
     match = re.search(pattern, source, flags = re.DOTALL)
-    assert match is not None, f"install.ps1 block not found: {pattern}"
+    assert match is not None, f"PowerShell block not found: {pattern}"
     return match.group(0)
 
 
@@ -445,6 +446,23 @@ def _uv_cache_lifecycle_blocks(source: str) -> tuple[str, str, str]:
     return capture, setup, restore
 
 
+def _setup_uv_cache_lifecycle_blocks(source: str) -> tuple[str, str, str]:
+    capture = _extract(
+        r"(?m)^\$previousUvCacheDir = \$env:UV_CACHE_DIR\n"
+        r"\$hadPreviousUvCacheDir = \(\$null -ne \$previousUvCacheDir\)\n",
+        source,
+    )
+    setup = _extract(
+        r"    if \(\[string\]::IsNullOrWhiteSpace\(\$env:UV_CACHE_DIR\)\) \{.*?\n    \}\n",
+        source,
+    )
+    restore = _extract(
+        r"    if \(\$hadPreviousUvCacheDir\) \{.*?\n    \}\n(?=\}\n\Z)",
+        source,
+    )
+    return capture, setup, restore
+
+
 def test_uv_cache_lifecycle_wraps_outer_install_try():
     source = INSTALL_PS1.read_text(encoding = "utf-8")
     capture, _, restore = _uv_cache_lifecycle_blocks(source)
@@ -475,14 +493,45 @@ def test_uv_cache_recovery_follows_existing_venv_ownership_guard():
     assert ownership_rejection_at < cache_setup_at < uv_venv_at
 
 
+def test_setup_uv_cache_guard_covers_every_setup_uv_call_after_ownership_validation():
+    source = SETUP_PS1.read_text(encoding = "utf-8")
+    capture, cache_setup, restore = _setup_uv_cache_lifecycle_blocks(source)
+    ownership_rejection_at = source.index(
+        'Exit-SetupFailure "$VenvDir is not an Unsloth Studio environment"'
+    )
+    capture_at = source.index(capture)
+    outer_try_at = source.index("try {", capture_at)
+    cache_setup_at = source.index(cache_setup, outer_try_at)
+    restore_at = source.index(restore, cache_setup_at)
+    # Every uv/uvx invocation, not just the `uv pip` pair that exists today: the point of
+    # the guard is that a later `uv venv` or `uv sync` cannot land ahead of it.
+    uv_calls = [match.start() for match in re.finditer(r"(?m)^\s*(?:\$\w+ = )?& uvx?\b", source)]
+    # The reason this has to be the environment variable and not `uv --cache-dir`: this child
+    # runs its own `uv pip install`, so it has to inherit the setting.
+    python_stack_at = source.index(r'python "$PSScriptRoot\install_python_stack.py"')
+
+    assert ownership_rejection_at < capture_at < outer_try_at < cache_setup_at < restore_at
+    assert uv_calls
+    assert all(cache_setup_at < call_at < restore_at for call_at in uv_calls)
+    assert cache_setup_at < python_stack_at < restore_at
+
+
 @pytest.mark.skipif(not POWERSHELLS, reason = "PowerShell is unavailable")
 @pytest.mark.parametrize("shell", POWERSHELLS)
 @pytest.mark.parametrize("mode", ["default", "override", "blank"])
+@pytest.mark.parametrize(
+    ("source_path", "lifecycle_blocks"),
+    [
+        (INSTALL_PS1, _uv_cache_lifecycle_blocks),
+        (SETUP_PS1, _setup_uv_cache_lifecycle_blocks),
+    ],
+    ids = ["installer", "setup"],
+)
 def test_uv_cache_defaults_to_studio_root_and_restores_caller(
-    tmp_path: Path, shell: str, mode: str
+    tmp_path: Path, shell: str, mode: str, source_path: Path, lifecycle_blocks
 ):
-    source = INSTALL_PS1.read_text(encoding = "utf-8")
-    capture, cache_setup, restore = _uv_cache_lifecycle_blocks(source)
+    source = source_path.read_text(encoding = "utf-8")
+    capture, cache_setup, restore = lifecycle_blocks(source)
 
     studio_home = tmp_path / "studio"
     default_cache = studio_home / "cache" / "uv"
@@ -506,6 +555,10 @@ def test_uv_cache_defaults_to_studio_root_and_restores_caller(
 $ErrorActionPreference = "Stop"
 $StudioHome = $env:TEST_STUDIO_HOME
 function substep {{ param([string]$Text, [string]$Color) }}
+function Exit-SetupFailure {{
+    param([string]$Message, [int]$Code = 1)
+    throw $Message
+}}
 {capture}
 try {{
 {cache_setup}
@@ -538,15 +591,29 @@ if (Test-Path Env:UV_CACHE_DIR) {{
 
 @pytest.mark.skipif(not POWERSHELLS, reason = "PowerShell is unavailable")
 @pytest.mark.parametrize("shell", POWERSHELLS)
-def test_uv_cache_two_runs_in_one_session_use_their_own_studio_root(tmp_path: Path, shell: str):
-    source = INSTALL_PS1.read_text(encoding = "utf-8")
-    capture, cache_setup, restore = _uv_cache_lifecycle_blocks(source)
+@pytest.mark.parametrize(
+    ("source_path", "lifecycle_blocks"),
+    [
+        (INSTALL_PS1, _uv_cache_lifecycle_blocks),
+        (SETUP_PS1, _setup_uv_cache_lifecycle_blocks),
+    ],
+    ids = ["installer", "setup"],
+)
+def test_uv_cache_two_runs_in_one_session_use_their_own_studio_root(
+    tmp_path: Path, shell: str, source_path: Path, lifecycle_blocks
+):
+    source = source_path.read_text(encoding = "utf-8")
+    capture, cache_setup, restore = lifecycle_blocks(source)
     first_home = tmp_path / "first-studio"
     second_home = tmp_path / "second-studio"
 
     script = f"""
 $ErrorActionPreference = "Stop"
 function substep {{ param([string]$Text, [string]$Color) }}
+function Exit-SetupFailure {{
+    param([string]$Message, [int]$Code = 1)
+    throw $Message
+}}
 function Invoke-UvCacheRun {{
     param([string]$RequestedHome)
     $StudioHome = $RequestedHome

--- a/tests/python/test_windows_python_venv_hardening.py
+++ b/tests/python/test_windows_python_venv_hardening.py
@@ -427,23 +427,55 @@ def test_readiness_gate_precedes_installs_and_names_both_interpreters():
     assert 'return (Exit-InstallFailure "Managed Python is unavailable' in source
 
 
-@pytest.mark.skipif(not POWERSHELLS, reason = "PowerShell is unavailable")
-@pytest.mark.parametrize("shell", POWERSHELLS)
-@pytest.mark.parametrize("mode", ["default", "override"])
-def test_uv_cache_defaults_to_studio_root_and_preserves_override(
-    tmp_path: Path, shell: str, mode: str
-):
-    source = INSTALL_PS1.read_text(encoding = "utf-8")
-    cache_setup = _extract(
+def _uv_cache_lifecycle_blocks(source: str) -> tuple[str, str, str]:
+    capture = _extract(
+        r"    \$previousUvCacheDir = \$env:UV_CACHE_DIR\n"
+        r"    \$hadPreviousUvCacheDir = \(\$null -ne \$previousUvCacheDir\)\n",
+        source,
+    )
+    setup = _extract(
         r"    if \(\[string\]::IsNullOrWhiteSpace\(\$env:UV_CACHE_DIR\)\) \{"
         r".*?\n    \}\n\n"
         r"    # When bytecode compilation is enabled",
         source,
     )
-    cache_setup = cache_setup.rsplit(
+    setup = setup.rsplit(
         "\n\n    # When bytecode compilation is enabled",
         1,
     )[0]
+    restore = _extract(
+        r"        if \(\$hadPreviousUvCacheDir\) \{.*?\n        \}\n"
+        r"(?=        for \(\$i = \$studioRuntimeMutexes.Count)",
+        source,
+    )
+    return capture, setup, restore
+
+
+def test_uv_cache_lifecycle_wraps_outer_install_try():
+    source = INSTALL_PS1.read_text(encoding = "utf-8")
+    capture, _, restore = _uv_cache_lifecycle_blocks(source)
+    capture_at = source.index(capture)
+    outer_try_at = source.index("    try {", capture_at)
+    setup_at = source.index("if ([string]::IsNullOrWhiteSpace($env:UV_CACHE_DIR))")
+    restore_at = source.index(restore)
+    lock_release_at = source.index(
+        "for ($i = $studioRuntimeMutexes.Count - 1; $i -ge 0; $i--)",
+        restore_at,
+    )
+
+    assert capture_at < outer_try_at < setup_at < restore_at < lock_release_at
+    assert "$env:UV_CACHE_DIR = $previousUvCacheDir" in restore
+    assert "Remove-Item Env:UV_CACHE_DIR -ErrorAction SilentlyContinue" in restore
+
+
+@pytest.mark.skipif(not POWERSHELLS, reason = "PowerShell is unavailable")
+@pytest.mark.parametrize("shell", POWERSHELLS)
+@pytest.mark.parametrize("mode", ["default", "override", "blank"])
+def test_uv_cache_defaults_to_studio_root_and_restores_caller(
+    tmp_path: Path, shell: str, mode: str
+):
+    source = INSTALL_PS1.read_text(encoding = "utf-8")
+    capture, cache_setup, restore = _uv_cache_lifecycle_blocks(source)
 
     studio_home = tmp_path / "studio"
     default_cache = studio_home / "cache" / "uv"
@@ -455,25 +487,88 @@ def test_uv_cache_defaults_to_studio_root_and_preserves_override(
         default_cache.write_text("blocking file", encoding = "utf-8")
         env.pop("UV_CACHE_DIR", None)
         expected = default_cache
-    else:
+    elif mode == "override":
         expected = tmp_path / "explicit-uv-cache"
         expected.mkdir()
         env["UV_CACHE_DIR"] = str(expected)
+    else:
+        expected = default_cache
+        env["UV_CACHE_DIR"] = "   "
 
     script = f"""
 $ErrorActionPreference = "Stop"
 $StudioHome = $env:TEST_STUDIO_HOME
 function substep {{ param([string]$Text, [string]$Color) }}
+{capture}
+try {{
 {cache_setup}
-Write-Output $env:UV_CACHE_DIR
+    Write-Output ("active=" + $env:UV_CACHE_DIR)
+}} finally {{
+{restore}
+}}
+if (Test-Path Env:UV_CACHE_DIR) {{
+    Write-Output ("after=[" + $env:UV_CACHE_DIR + "]")
+}} else {{
+    Write-Output "after=<missing>"
+}}
 """
-    configured = Path(_run_powershell(shell, script, env))
+    lines = _run_powershell(shell, script, env).splitlines()
+    configured = Path(lines[0].removeprefix("active="))
     assert configured.resolve() == expected.resolve()
 
     if mode == "default":
+        assert lines[1] == "after=<missing>"
         assert default_cache.is_dir()
         moved = list(default_cache.parent.glob("uv.invalid.*"))
         assert len(moved) == 1
         assert moved[0].read_text(encoding = "utf-8") == "blocking file"
-    else:
+    elif mode == "override":
+        assert lines[1] == f"after=[{expected}]"
         assert not default_cache.exists()
+    else:
+        assert lines[1] == "after=[   ]"
+
+
+@pytest.mark.skipif(not POWERSHELLS, reason = "PowerShell is unavailable")
+@pytest.mark.parametrize("shell", POWERSHELLS)
+def test_uv_cache_two_runs_in_one_session_use_their_own_studio_root(tmp_path: Path, shell: str):
+    source = INSTALL_PS1.read_text(encoding = "utf-8")
+    capture, cache_setup, restore = _uv_cache_lifecycle_blocks(source)
+    first_home = tmp_path / "first-studio"
+    second_home = tmp_path / "second-studio"
+
+    script = f"""
+$ErrorActionPreference = "Stop"
+function substep {{ param([string]$Text, [string]$Color) }}
+function Invoke-UvCacheRun {{
+    param([string]$RequestedHome)
+    $StudioHome = $RequestedHome
+{capture}
+    try {{
+{cache_setup}
+        Write-Output ("active=" + $env:UV_CACHE_DIR)
+    }} finally {{
+{restore}
+    }}
+}}
+Remove-Item Env:UV_CACHE_DIR -ErrorAction SilentlyContinue
+Invoke-UvCacheRun $env:TEST_FIRST_STUDIO_HOME
+Invoke-UvCacheRun $env:TEST_SECOND_STUDIO_HOME
+if (Test-Path Env:UV_CACHE_DIR) {{
+    Write-Output ("after=[" + $env:UV_CACHE_DIR + "]")
+}} else {{
+    Write-Output "after=<missing>"
+}}
+"""
+    env = os.environ.copy()
+    env["TEST_FIRST_STUDIO_HOME"] = str(first_home)
+    env["TEST_SECOND_STUDIO_HOME"] = str(second_home)
+    lines = _run_powershell(shell, script, env).splitlines()
+
+    assert (
+        Path(lines[0].removeprefix("active=")).resolve() == (first_home / "cache" / "uv").resolve()
+    )
+    assert (
+        Path(lines[1].removeprefix("active=")).resolve() == (second_home / "cache" / "uv").resolve()
+    )
+    assert lines[2] == "after=<missing>"

--- a/tests/python/test_windows_python_venv_hardening.py
+++ b/tests/python/test_windows_python_venv_hardening.py
@@ -425,3 +425,55 @@ def test_readiness_gate_precedes_installs_and_names_both_interpreters():
     assert 'Write-StudioLine "        Managed Python: $VenvPython"' in source
     assert 'Write-StudioLine "        Recorded base Python home: $recordedBaseHome"' in source
     assert 'return (Exit-InstallFailure "Managed Python is unavailable' in source
+
+
+@pytest.mark.skipif(not POWERSHELLS, reason = "PowerShell is unavailable")
+@pytest.mark.parametrize("shell", POWERSHELLS)
+@pytest.mark.parametrize("mode", ["default", "override"])
+def test_uv_cache_defaults_to_studio_root_and_preserves_override(
+    tmp_path: Path, shell: str, mode: str
+):
+    source = INSTALL_PS1.read_text(encoding = "utf-8")
+    cache_setup = _extract(
+        r"    if \(\[string\]::IsNullOrWhiteSpace\(\$env:UV_CACHE_DIR\)\) \{"
+        r".*?\n    \}\n\n"
+        r"    # When bytecode compilation is enabled",
+        source,
+    )
+    cache_setup = cache_setup.rsplit(
+        "\n\n    # When bytecode compilation is enabled",
+        1,
+    )[0]
+
+    studio_home = tmp_path / "studio"
+    default_cache = studio_home / "cache" / "uv"
+    env = os.environ.copy()
+    env["TEST_STUDIO_HOME"] = str(studio_home)
+
+    if mode == "default":
+        default_cache.parent.mkdir(parents = True)
+        default_cache.write_text("blocking file", encoding = "utf-8")
+        env.pop("UV_CACHE_DIR", None)
+        expected = default_cache
+    else:
+        expected = tmp_path / "explicit-uv-cache"
+        expected.mkdir()
+        env["UV_CACHE_DIR"] = str(expected)
+
+    script = f"""
+$ErrorActionPreference = "Stop"
+$StudioHome = $env:TEST_STUDIO_HOME
+function substep {{ param([string]$Text, [string]$Color) }}
+{cache_setup}
+Write-Output $env:UV_CACHE_DIR
+"""
+    configured = Path(_run_powershell(shell, script, env))
+    assert configured.resolve() == expected.resolve()
+
+    if mode == "default":
+        assert default_cache.is_dir()
+        moved = list(default_cache.parent.glob("uv.invalid.*"))
+        assert len(moved) == 1
+        assert moved[0].read_text(encoding = "utf-8") == "blocking file"
+    else:
+        assert not default_cache.exists()

--- a/tests/python/test_windows_python_venv_hardening.py
+++ b/tests/python/test_windows_python_venv_hardening.py
@@ -434,8 +434,7 @@ def _uv_cache_lifecycle_blocks(source: str) -> tuple[str, str, str]:
         source,
     )
     setup = _extract(
-        r"    if \(\[string\]::IsNullOrWhiteSpace\(\$env:UV_CACHE_DIR\)\) \{"
-        r".*?\n    \}\n",
+        r"    if \(\[string\]::IsNullOrWhiteSpace\(\$env:UV_CACHE_DIR\)\) \{.*?\n    \}\n",
         source,
     )
     restore = _extract(


### PR DESCRIPTION
## Changes

- Configure the Windows installer to use StudioHome/cache/uv when UV_CACHE_DIR is not explicitly set.
- Move a conflicting regular file at the managed uv cache path aside before creating the directory.
- Preserve an explicitly configured UV_CACHE_DIR.
- Add Windows PowerShell regression coverage for the cache-file collision.

## Why

The Windows installer currently lets uv use its user-wide default cache under LOCALAPPDATA. If that path is a regular file, uv venv fails with Windows error 183 before the managed Studio environment can be created.

Keeping the default uv cache inside the existing Studio cache tree avoids the broken user-wide path and matches the cache location used by the Studio runtime.

## Testing

- pytest tests/python/test_windows_python_venv_hardening.py -q: 1 passed, 14 skipped on macOS because PowerShell is unavailable
- ruff check tests/python/test_windows_python_venv_hardening.py: passed
- project Python formatter: passed
- git diff --check: passed
- source-order contract confirms cache setup and recovery precede uv venv
- Windows PowerShell behavior test will run on Windows CI

## Scope

This PR fixes the uv cache collision reported in the issue. It does not change the Tauri application install location, redirect all Studio data to that location, or change Python discovery.

Fixes #8991

## Checklist

- [x] The PR contains only the Windows installer fix and its regression test.
- [x] No unrelated formatting or refactoring is included.
- [x] Explicit UV_CACHE_DIR configuration remains unchanged.
- [x] Available local checks pass.
- [ ] Windows PowerShell CI passes.