### PR TITLE
Studio: recover a research report whatever its headings say

### DIFF
--- a/studio/backend/core/research/parsing.py
+++ b/studio/backend/core/research/parsing.py
@@ -262,14 +262,26 @@ def _parse_and_validate_plan(response: str, reasoning: str, max_steps: int) -> d
     raise ValueError("Planner did not return a JSON object")
 
 
+# A heading on its own line -- any level, or a standalone bold line -- is where the model
+# stopped narrating and started writing. The synthesis prompt mandates "clear Markdown
+# headings" and explicitly asks for more than an executive summary, so the heading is the
+# structural signal and its WORDING is not: keying on the English word "Summary" discarded
+# every report headed anything else, in any other language, while its text sat in the
+# reasoning the run had already captured.
+#
+# The heading requirement is what keeps thinking-out-loud from being published as a report:
+# unheaded prose recovers nothing however long it runs. A model that also headed its
+# reasoning can still carry that preamble into the recovered text -- worth it, because the
+# alternative is losing a finished report to "returned an empty report".
+_REPORT_HEADING_RE = re.compile(r"(?m)^(?:#{1,6}[ \t]+\S|\*\*[^*\n]+\*\*[ \t]*$)")
+# Below this a heading is a plan or an interrupted attempt, not a report.
+_MIN_RECOVERED_REPORT_CHARS = 500
+
+
 def _recover_report_from_reasoning(reasoning: str) -> str:
     text = reasoning.strip()
-    marker = re.search(
-        r"(?m)^(?:#{1,2}\s+(?:Executive\s+)?Summary\b|\*\*(?:Executive\s+)?Summary\*\*)",
-        text,
-        flags = re.IGNORECASE,
-    )
+    marker = _REPORT_HEADING_RE.search(text)
     if marker is None:
         return ""
     report = text[marker.start() :].strip()
-    return report if len(report) >= 500 else ""
+    return report if len(report) >= _MIN_RECOVERED_REPORT_CHARS else ""

--- a/studio/backend/tests/test_research_runs_hardening.py
+++ b/studio/backend/tests/test_research_runs_hardening.py
@@ -1867,3 +1867,75 @@ def test_stream_completion_gives_a_model_switch_more_than_the_generic_backoff(mo
     assert len(sent) == research_runs._MAX_MODEL_WAITS + 1
     # Each wait is longer than the last: a swap that has not finished in 5s needs more, not less.
     assert sum(delays) == 30.0
+
+
+def _accept_worker_events(monkeypatch) -> None:
+    """Reasoning deltas are flushed to the run's event log regardless of report_progress,
+    and a flush that writes nothing raises LeaseLost. Accept the writes so a stream longer
+    than one flush window can be exercised."""
+    counter = iter(range(1, 10_000))
+    monkeypatch.setattr(
+        research_runs.db,
+        "append_worker_event",
+        lambda *_a, **_k: next(counter),
+        raising = False,
+    )
+
+
+def _reasoning_only_stream_body(reasoning: str) -> str:
+    """What a thinking model whose template never closes the reasoning channel sends:
+    every delta arrives as reasoning_content and `content` is never populated."""
+    chunks = [
+        json.dumps({"choices": [{"delta": {"reasoning_content": piece}}]})
+        for piece in (reasoning[i : i + 40] for i in range(0, len(reasoning), 40))
+    ]
+    chunks.append(json.dumps({"choices": [{"delta": {}, "finish_reason": "stop"}]}))
+    return "".join(f"data: {c}\n\n" for c in chunks) + "data: [DONE]\n\n"
+
+
+def test_a_reasoning_only_stream_leaves_the_report_empty(monkeypatch):
+    """Reproduces the observed failure through the real streaming code: fourteen successful
+    web_search calls, then "Local model returned an empty report". `content` never arrives,
+    so `report` stays empty while the finished text lands in `reasoning`."""
+    report_text = "## Zusammenfassung\n\n" + ("Der Markt wuchs 2026 deutlich. " * 20)
+    _install_fake_client(
+        monkeypatch,
+        [
+            _response(
+                200,
+                body = _reasoning_only_stream_body("Ich ordne die Antwort.\n" + report_text),
+            )
+        ],
+    )
+    _accept_worker_events(monkeypatch)
+    supervisor = _make_supervisor(check_active = _noop_check_active)
+
+    report, reasoning, finish_reason, _usage = _run_stream(supervisor)
+
+    assert report == "", "the report field is what the run checks, and it is empty"
+    assert report_text in reasoning, "the finished report is sitting in the reasoning"
+    assert finish_reason == "stop", "the model completed; it did not time out or get cut off"
+
+
+def test_that_stream_now_yields_its_report_instead_of_failing(monkeypatch):
+    """The payoff: the same stream the run used to discard now recovers, because the rescue
+    keys on the heading rather than on the English word "Summary"."""
+    report_text = "## Zusammenfassung\n\n" + ("Der Markt wuchs 2026 deutlich. " * 20)
+    _install_fake_client(
+        monkeypatch,
+        [
+            _response(
+                200,
+                body = _reasoning_only_stream_body("Ich ordne die Antwort.\n" + report_text),
+            )
+        ],
+    )
+    _accept_worker_events(monkeypatch)
+    supervisor = _make_supervisor(check_active = _noop_check_active)
+    _report, reasoning, _finish, _usage = _run_stream(supervisor)
+
+    recovered = research_runs._recover_report_from_reasoning(reasoning)
+
+    assert recovered.startswith("## Zusammenfassung")
+    assert "Der Markt wuchs 2026 deutlich." in recovered
+    assert "Ich ordne die Antwort." not in recovered, "the narration before the report is dropped"

--- a/studio/backend/tests/test_research_runs_storage.py
+++ b/studio/backend/tests/test_research_runs_storage.py
@@ -3704,3 +3704,40 @@ def test_an_authorized_reparent_of_a_research_row_is_not_overwritten(research_ho
     assert studio_db.get_chat_message("thread-1", "ancestor") is None
     assert studio_db.get_chat_message("thread-1", "user-1")["parentId"] == "keeper"
     assert _thread_imports_cleanly()
+
+
+def test_report_is_recovered_whatever_the_heading_says():
+    """The synthesis prompt mandates "clear Markdown headings" and explicitly asks for more
+    than an executive summary, so keying recovery on the English word "Summary" contradicts
+    the instruction the model was given. A report headed in another language, or with any
+    other section name, was lost with "returned an empty report" while its text sat in the
+    captured reasoning."""
+    from core import research_runs as worker
+
+    body = "Der Markt wuchs 2026 deutlich, getragen von Nachfrage aus Europa. " * 12
+    for heading in (
+        "## Zusammenfassung",
+        "# Überblick",
+        "## Overview",
+        "### Findings",
+        "**Ergebnisse**",
+    ):
+        report = f"{heading}\n\n{body}"
+        reasoning = "Let me organise the answer.\n" + report
+        assert worker._recover_report_from_reasoning(reasoning) == report.strip(), heading
+
+
+def test_recovery_still_refuses_reasoning_that_is_not_a_report():
+    """The structural guard is the heading, not its wording: prose the model thought out
+    loud must never be published as a report, however long it runs."""
+    from core import research_runs as worker
+
+    assert worker._recover_report_from_reasoning("Internal analysis. " * 200) == ""
+    assert worker._recover_report_from_reasoning("Too short") == ""
+    # A heading with nothing substantial behind it is a plan, not a report.
+    assert (
+        worker._recover_report_from_reasoning(
+            ("Long preamble. " * 50) + "\n## Zusammenfassung\nUnvollständig."
+        )
+        == ""
+    )


### PR DESCRIPTION
Fixes #9004.

## Motivation

Deep Research with a local thinking model gathers its evidence, then fails at the final step with `Research failed: Local model returned an empty report` — and throws away a report it had already captured.

The synthesis splits the stream on the OpenAI field names: `delta.content` accumulates into the report, `delta.reasoning_content` into the reasoning. A thinking model whose template never closes the reasoning channel streams the whole report through `reasoning_content`, so `report` is empty while `reasoning` holds the finished text. `_recover_report_from_reasoning` exists for exactly this and rescues it — but only on an English `Summary` / `Executive Summary` heading followed by 500 characters. A report headed `## Zusammenfassung`, `## Overview` or `### Findings` falls through to the error.

That threshold is narrower than what the run asks the model for. `core/research/prompts.py` instructs it to "use clear Markdown headings and substantive sections, **not** an executive-summary-only response". So the rescue keyed on a heading the model was explicitly told not to make the whole report, and hard-coded English into a path that has nothing to do with language.

## What this does

A heading on its own line — any level, or a standalone bold line — now marks where the model stopped narrating and started writing:

```python
_REPORT_HEADING_RE = re.compile(r"(?m)^(?:#{1,6}[ \t]+\S|\*\*[^*\n]+\*\*[ \t]*$)")
```

Both guards that made the old rule safe are kept, with their existing tests:

- **unheaded prose recovers nothing**, however long it runs — that is what stops thinking-out-loud being published as a report, and it is the heading, not its wording, that provides it;
- **a heading with fewer than 500 characters behind it** is still treated as a plan or an interrupted attempt.

Known limit, accepted deliberately: a model that also headed its *reasoning* can carry that preamble into the recovered text. That is the better trade — the alternative is discarding a finished report.

## Tests

Reproduced through the real streaming path, not only at the helper. One test drives `_stream_completion` with an SSE stream whose every delta arrives as `reasoning_content`, and pins the failing condition: `report == ""`, `finish_reason == "stop"`, the finished text in `reasoning`. A second drives the same stream and shows it now yields its report. The new harness helper accepts the worker's reasoning-delta writes, which are flushed regardless of `report_progress` and raise `LeaseLost` when the write returns nothing.

Beyond that: the non-English and non-`Summary` headings, and the refusals — unheaded prose, too-short text, and a heading with nothing substantial behind it.

Measured on macOS 26.6.1 / Apple M4 Max, Python 3.13, against current main: the five research suites (`test_research_runs_hardening`, `test_research_runs_storage`, `test_research_progress_events`, `test_research_internal_key_monitor`, `test_research_internal_call_tool_gate`) give **277 passed, 0 failed**.
