### PR TITLE
Fix a 500 on dictation Unload before any backend is resident

### DIFF
--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -11304,7 +11304,12 @@ async def stt_unload(
     # Every engine is attempted even if one raises, so failing to free one never
     # skips the other (both can be resident after a switch).
     _, unload_stt = _stt_lifecycle()
-    failed: list[str] = await asyncio.to_thread(unload_stt, engines, model)
+    # expected_model by keyword: _stt_lifecycle returns the orchestrator's
+    # unload_stt_model when a backend is resident and stt_registry.unload when one
+    # is not, and only the former takes it positionally. Registry-side it sits
+    # behind a `*`, so passing it positionally raised TypeError, which is the
+    # state a fresh process is in before anything has loaded.
+    failed: list[str] = await asyncio.to_thread(unload_stt, engines, expected_model = model)
     if failed:
         raise HTTPException(
             status_code = 500,

--- a/studio/backend/tests/test_stt_ggml_sidecar.py
+++ b/studio/backend/tests/test_stt_ggml_sidecar.py
@@ -1223,9 +1223,9 @@ def test_both_unload_callables_accept_the_arguments_the_route_passes(monkeypatch
     orchestrator_unload = ri._stt_lifecycle()[1]
 
     assert registry_unload is stt_registry.unload
-    assert registry_unload is not orchestrator_unload, (
-        "both branches resolved to the same callable, so this proves nothing"
-    )
+    assert (
+        registry_unload is not orchestrator_unload
+    ), "both branches resolved to the same callable, so this proves nothing"
 
     for unload in (registry_unload, orchestrator_unload):
         # Exactly how routes/inference.py::stt_unload calls it.

--- a/studio/backend/tests/test_stt_ggml_sidecar.py
+++ b/studio/backend/tests/test_stt_ggml_sidecar.py
@@ -1193,3 +1193,40 @@ def test_unload_without_a_resident_backend_does_not_crash(monkeypatch):
 
     assert seen["engines"] is None
     assert seen["expected_model"] == "whisper-small"
+
+
+def test_both_unload_callables_accept_the_arguments_the_route_passes(monkeypatch):
+    """_stt_lifecycle returns two DIFFERENT callables, and the route has one call site.
+
+    That is the shape of the bug the test above covers: the orchestrator's
+    unload_stt_model takes expected_model positionally, the registry's unload keeps it
+    behind a `*`, and the route gets whichever branch is live. A call that suits one is a
+    TypeError on the other, and which one runs depends on whether a backend happens to be
+    resident, so the broken half only shows on a fresh process.
+
+    Binding both real signatures against the route's actual call keeps them compatible
+    without demanding they be identical. If either grows a parameter the other cannot
+    accept in the same position, this fails here rather than as a 500 in dictation.
+    """
+    import inspect
+    import routes.inference as ri
+    from core.inference import orchestrator, stt_registry
+    from core.inference.orchestrator import InferenceOrchestrator
+
+    class _Resident:
+        load_stt_model = InferenceOrchestrator.load_stt_model
+        unload_stt_model = InferenceOrchestrator.unload_stt_model
+
+    monkeypatch.setattr(orchestrator, "peek_inference_backend", lambda: None)
+    registry_unload = ri._stt_lifecycle()[1]
+    monkeypatch.setattr(orchestrator, "peek_inference_backend", lambda: _Resident())
+    orchestrator_unload = ri._stt_lifecycle()[1]
+
+    assert registry_unload is stt_registry.unload
+    assert registry_unload is not orchestrator_unload, (
+        "both branches resolved to the same callable, so this proves nothing"
+    )
+
+    for unload in (registry_unload, orchestrator_unload):
+        # Exactly how routes/inference.py::stt_unload calls it.
+        inspect.signature(unload).bind(["whisper"], expected_model = "whisper-small")

--- a/studio/backend/tests/test_stt_ggml_sidecar.py
+++ b/studio/backend/tests/test_stt_ggml_sidecar.py
@@ -1158,3 +1158,38 @@ def test_free_stt_frees_gguf_even_when_transformers_unload_raises(monkeypatch):
     # The Transformers failure must not skip GGUF eviction.
     assert ggml.unloaded is True
     assert any("small" in entry for entry in freed)
+
+
+def test_unload_without_a_resident_backend_does_not_crash(monkeypatch):
+    """Unload before anything has loaded used to raise TypeError, so the route 500'd.
+
+    _stt_lifecycle() hands back the orchestrator's unload_stt_model when a backend is
+    resident and stt_registry.unload when one is not. Only the first takes
+    expected_model positionally; on the registry it is keyword-only, and the route
+    passed it positionally. A fresh process is in exactly that state, so the two
+    unload tests above only passed because an earlier test in the full suite had left
+    a backend resident. Pin the no-backend path directly so neither the signature nor
+    the call site can drift back.
+    """
+    import routes.inference as ri
+    from core.inference import orchestrator, stt_registry
+
+    seen: dict = {}
+
+    def _unload(
+        engines = None,
+        *,
+        wait = True,
+        expected_model = None,
+    ):
+        seen["engines"] = engines
+        seen["expected_model"] = expected_model
+        return []
+
+    monkeypatch.setattr(orchestrator, "peek_inference_backend", lambda: None)
+    monkeypatch.setattr(stt_registry, "unload", _unload)
+
+    asyncio.run(ri.stt_unload(engine = None, model = "whisper-small", current_subject = "tester"))
+
+    assert seen["engines"] is None
+    assert seen["expected_model"] == "whisper-small"


### PR DESCRIPTION
Unload for dictation raises `TypeError` and the route answers 500 whenever no inference backend is resident, which is the state a freshly started process is in.

Reproduced outside pytest, on main:

```
peek_inference_backend() fresh process: None
stt_unload -> TypeError: unload() takes from 0 to 1 positional arguments but 2 were given
```

## Cause

`stt_unload` passes `expected_model` positionally:

```python
_, unload_stt = _stt_lifecycle()
failed = await asyncio.to_thread(unload_stt, engines, model)
```

`_stt_lifecycle()` returns two different callables:

```python
def unload(engines = None, *, wait = True, expected_model = None)          # stt_registry
def unload_stt_model(self, engines = None, expected_model = None)          # orchestrator
```

Only the orchestrator's takes `expected_model` positionally. On the registry it sits behind a `*`. The registry branch is the one taken when `peek_inference_backend()` is `None`, so the call blows up exactly when nothing has loaded yet.

Introduced in #7984 (`d20db3f1f`), which added both signatures.

## Fix

Pass it by keyword. Both callables accept that, so the call is correct on either branch.

## Why the tests did not catch it

They were order dependent, and that is the interesting part.

The two existing unload tests in `test_stt_ggml_sidecar.py` **fail standalone and fail in their own file**. They only went green inside the full serial run, because an earlier test in another file had left a backend resident, which routed the call down the orchestrator branch where positional works.

```
before, file alone:  2 failed, 53 passed
after,  file alone:  56 passed
```

So the order dependence was not a nuisance, it was hiding a live bug.

The new test drives the no-backend path directly, stubbing `peek_inference_backend` to `None` and asserting the registry receives `expected_model`, so neither the signature nor the call site can drift back.

## Verification

Mutation checked. Reverting the one-line fix while keeping the new test reproduces the production error:

```
E  TypeError: unload() takes from 0 to 1 positional arguments but 2 were given
```

Full backend suite on a CPU-only shape, same command the workflow runs:

| | result |
| --- | --- |
| before | 40 failed, 26149 passed |
| after | **38 failed, 26152 passed** |

The 2 that flip are exactly these unload tests. The remaining 38 are pre-existing and unrelated to this change (missing optional `rag` / `video` / `diffusion` extras and network-blocked probes in my local venv).

## Robustification

The fix is one keyword, but the shape that produced it will recur: `_stt_lifecycle` hands back two different callables and the route has one call site, so which signature must be satisfied depends on whether a backend happens to be resident.

A second test binds **both real signatures** against the arguments the route actually passes. It does not demand they be identical, only that one call site can serve both. Checked against two mutations:

| mutation | result |
| --- | --- |
| registry grows a keyword-only param | passes (benign, and it should) |
| registry drops `expected_model` | **fails** — `got an unexpected keyword argument 'expected_model'` |

Paired with the first test, which covers the call site on a cold process, the two cover both directions of the drift.

## Related

This PR's root cause, #7984 (`d20db3f1f`), also accounts for two other order-masked defects I hit while profiling: the disconnect-cancellation test that never stubs the implicit registry load (#9031), and the two `test_stt_ggml_sidecar.py` unload tests noted above. Three defects in one area, each invisible because a serial run left the right state behind.

Found while profiling CI runtime, not by a failing check.
