### PR TITLE
Studio: stop later code spans changing whether an earlier one is escaped

### DIFF
--- a/studio/frontend/src/lib/latex.ts
+++ b/studio/frontend/src/lib/latex.ts
@@ -20,9 +20,9 @@ const CURRENCY_REGEX =
   /(?<![\\$])\$(?!\$)(?=\d+(?:,\d{3})*(?:\.\d+)?[KMBkmb]?(?:\s|$|[^a-zA-Z\d]))/g;
 
 /**
- * Merge two ascending span lists into their union, so the result is sorted and
- * non-overlapping. `isInRegion` binary-searches, which answers correctly only
- * for spans of that shape.
+ * Union of two span lists, each ascending by start (overlap within a list is
+ * fine, non-ascending input silently drops spans). The sorted, non-overlapping
+ * result is the shape `isInRegion`'s binary search needs.
  */
 function mergeRegions(
   left: ReadonlyArray<readonly [number, number]>,
@@ -79,12 +79,8 @@ function findCodeBlockRegions(content: string): Array<[number, number]> {
     }
   }
 
-  // The cursor above drops an inline span nested inside a fence, but an inline
-  // span can also CONTAIN one (`` `~~~a~~~ $5` ``), and that overlap made the
-  // binary search land on the inner span and miss the outer one. Which way it
-  // went depended on how many spans the rest of the reply added, so the same
-  // code span was escaped or left alone according to what came after it. Take
-  // the union of the two ascending lists instead.
+  // An inline span can CONTAIN a fence (`` `~~~a~~~ $5` ``); that overlap made
+  // the binary search land on the inner span and miss the outer one.
   return mergeRegions(fenced, inline);
 }
 

--- a/studio/frontend/src/lib/latex.ts
+++ b/studio/frontend/src/lib/latex.ts
@@ -20,40 +20,72 @@ const CURRENCY_REGEX =
   /(?<![\\$])\$(?!\$)(?=\d+(?:,\d{3})*(?:\.\d+)?[KMBkmb]?(?:\s|$|[^a-zA-Z\d]))/g;
 
 /**
+ * Merge two ascending span lists into their union, so the result is sorted and
+ * non-overlapping. `isInRegion` binary-searches, which answers correctly only
+ * for spans of that shape.
+ */
+function mergeRegions(
+  left: ReadonlyArray<readonly [number, number]>,
+  right: ReadonlyArray<readonly [number, number]>,
+): Array<[number, number]> {
+  const merged: Array<[number, number]> = [];
+  let leftIndex = 0;
+  let rightIndex = 0;
+  while (leftIndex < left.length || rightIndex < right.length) {
+    const takeLeft =
+      rightIndex >= right.length ||
+      (leftIndex < left.length && left[leftIndex][0] <= right[rightIndex][0]);
+    const next = takeLeft ? left[leftIndex++] : right[rightIndex++];
+    const last = merged[merged.length - 1];
+    if (last && next[0] < last[1]) {
+      if (next[1] > last[1]) {
+        last[1] = next[1];
+      }
+      continue;
+    }
+    merged.push([next[0], next[1]]);
+  }
+  return merged;
+}
+
+/**
  * Find code-block regions (``` ... ```, ~~~ ... ~~~, and ` ... `) to skip.
- * Returns a sorted array of [start, end] index pairs.
+ * Returns a sorted, non-overlapping array of [start, end] index pairs.
  */
 function findCodeBlockRegions(content: string): Array<[number, number]> {
-  const regions: Array<[number, number]> = [];
-
   // Fenced code blocks: ```...``` and ~~~...~~~ (both are code in GFM)
+  const fenced: Array<[number, number]> = [];
   const fencedRe = /```[\s\S]*?```|~~~[\s\S]*?~~~/g;
   let match: RegExpExecArray | null;
   while ((match = fencedRe.exec(content)) !== null) {
-    regions.push([match.index, match.index + match[0].length]);
+    fenced.push([match.index, match.index + match[0].length]);
   }
 
   // Inline code: `...`, skipped when inside a fenced block. Both loops yield
   // ascending matches, so walk the fenced list with a cursor rather than
   // rescanning it per match (was quadratic on code-heavy text).
-  const fencedCount = regions.length;
+  const inline: Array<[number, number]> = [];
   const inlineRe = /`[^`\n]+`/g;
   let fencedIndex = 0;
   while ((match = inlineRe.exec(content)) !== null) {
     const start = match.index;
     const end = start + match[0].length;
-    while (fencedIndex < fencedCount && regions[fencedIndex][1] <= start) {
+    while (fencedIndex < fenced.length && fenced[fencedIndex][1] <= start) {
       fencedIndex += 1;
     }
-    const fenced = fencedIndex < fencedCount ? regions[fencedIndex] : null;
-    if (!(fenced && start >= fenced[0] && end <= fenced[1])) {
-      regions.push([start, end]);
+    const block = fencedIndex < fenced.length ? fenced[fencedIndex] : null;
+    if (!(block && start >= block[0] && end <= block[1])) {
+      inline.push([start, end]);
     }
   }
 
-  // Sort by start position for binary search.
-  regions.sort((a, b) => a[0] - b[0]);
-  return regions;
+  // The cursor above drops an inline span nested inside a fence, but an inline
+  // span can also CONTAIN one (`` `~~~a~~~ $5` ``), and that overlap made the
+  // binary search land on the inner span and miss the outer one. Which way it
+  // went depended on how many spans the rest of the reply added, so the same
+  // code span was escaped or left alone according to what came after it. Take
+  // the union of the two ascending lists instead.
+  return mergeRegions(fenced, inline);
 }
 
 /**
@@ -179,8 +211,8 @@ function hasInlineMathCloser(
   offset: number,
   mathRegions: Array<[number, number]>,
 ): boolean {
-  const MAX_SPAN = 200;
-  const limit = Math.min(content.length, offset + 1 + MAX_SPAN);
+  const maxSpan = 200;
+  const limit = Math.min(content.length, offset + 1 + maxSpan);
   for (let i = offset + 1; i < limit; i++) {
     const c = content[i];
     if (c === "\n") return false;

--- a/studio/frontend/tests/latex-code-regions.test.ts
+++ b/studio/frontend/tests/latex-code-regions.test.ts
@@ -7,12 +7,8 @@ import test from "node:test";
 import { preprocessLaTeX } from "../src/lib/latex.ts";
 
 test("currency inside inline code survives unrelated later code spans", () => {
-  // `findCodeBlockRegions` looks up a position with a binary search, which needs
-  // sorted, non-overlapping spans. An inline span that CONTAINS a `~~~...~~~`
-  // pair produced two overlapping spans, and the search then landed on the
-  // inner one and missed the outer. Whether it did so depended on how many
-  // spans the rest of the reply happened to add, so the same code span was
-  // escaped or not according to what came after it.
+  // An inline span containing a `~~~...~~~` pair used to yield overlapping
+  // spans, so the binary search hit the inner one and missed the outer.
   const span = "`~~~a~~~ $5`";
   assert.equal(preprocessLaTeX(span), span);
 
@@ -30,8 +26,7 @@ test("currency inside inline code survives unrelated later code spans", () => {
 });
 
 test("a code span's own text decides its escaping, whatever follows it", () => {
-  // The property the binary search was silently breaking: appending an
-  // unrelated code span must never change an earlier one.
+  // Appending an unrelated code span must never change an earlier one.
   const heads = [
     "`~~~a~~~ $5`",
     "`~~~ $5 ~~~`",
@@ -55,16 +50,14 @@ test("a code span's own text decides its escaping, whatever follows it", () => {
 });
 
 test("LaTeX inside inline code stays literal whatever follows it", () => {
-  // The same lookup guards `convertLatexDelimiters`, so the overlap could also
-  // turn a code sample showing `\(x\)` into real math.
+  // The same lookup guards `convertLatexDelimiters`.
   const span = "`~~~a~~~ \\(x\\)`";
   assert.equal(preprocessLaTeX(span), span);
   assert.equal(preprocessLaTeX(`${span}\n\n\`x\``), `${span}\n\n\`x\``);
 });
 
 test("ordinary code spans and fences are unchanged", () => {
-  // The regression guard for the merge itself: nothing that was already
-  // non-overlapping may move.
+  // Nothing that was already non-overlapping may move.
   const cases: [string, string][] = [
     ["`costs $5`", "`costs $5`"],
     ["`costs $5`\n\n`x`", "`costs $5`\n\n`x`"],

--- a/studio/frontend/tests/latex-code-regions.test.ts
+++ b/studio/frontend/tests/latex-code-regions.test.ts
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { preprocessLaTeX } from "../src/lib/latex.ts";
+
+test("currency inside inline code survives unrelated later code spans", () => {
+  // `findCodeBlockRegions` looks up a position with a binary search, which needs
+  // sorted, non-overlapping spans. An inline span that CONTAINS a `~~~...~~~`
+  // pair produced two overlapping spans, and the search then landed on the
+  // inner one and missed the outer. Whether it did so depended on how many
+  // spans the rest of the reply happened to add, so the same code span was
+  // escaped or not according to what came after it.
+  const span = "`~~~a~~~ $5`";
+  assert.equal(preprocessLaTeX(span), span);
+
+  for (const trailer of [
+    "\n\n`x`",
+    "\n\n`x`\n\n`y`",
+    "\n\n`x`\n\n`y`\n\n`z`",
+  ]) {
+    assert.equal(
+      preprocessLaTeX(`${span}${trailer}`),
+      `${span}${trailer}`,
+      `currency inside inline code was rewritten by ${JSON.stringify(trailer)}`,
+    );
+  }
+});
+
+test("a code span's own text decides its escaping, whatever follows it", () => {
+  // The property the binary search was silently breaking: appending an
+  // unrelated code span must never change an earlier one.
+  const heads = [
+    "`~~~a~~~ $5`",
+    "`~~~ $5 ~~~`",
+    "`a ``` b $5`",
+    "`plain $5 here`",
+    "```\nfenced $5\n```",
+    "~~~\nfenced $5\n~~~",
+    "`~~~a~~~ \\(x\\)`",
+  ];
+  for (const head of heads) {
+    const alone = preprocessLaTeX(head);
+    for (let count = 1; count <= 4; count += 1) {
+      const trailer = "\n\n`t`".repeat(count);
+      assert.equal(
+        preprocessLaTeX(`${head}${trailer}`),
+        `${alone}${trailer}`,
+        `${JSON.stringify(head)} changed after ${count} trailing span(s)`,
+      );
+    }
+  }
+});
+
+test("LaTeX inside inline code stays literal whatever follows it", () => {
+  // The same lookup guards `convertLatexDelimiters`, so the overlap could also
+  // turn a code sample showing `\(x\)` into real math.
+  const span = "`~~~a~~~ \\(x\\)`";
+  assert.equal(preprocessLaTeX(span), span);
+  assert.equal(preprocessLaTeX(`${span}\n\n\`x\``), `${span}\n\n\`x\``);
+});
+
+test("ordinary code spans and fences are unchanged", () => {
+  // The regression guard for the merge itself: nothing that was already
+  // non-overlapping may move.
+  const cases: [string, string][] = [
+    ["`costs $5`", "`costs $5`"],
+    ["`costs $5`\n\n`x`", "`costs $5`\n\n`x`"],
+    ["```\ncosts $5\n```", "```\ncosts $5\n```"],
+    ["```\ncosts $5\n```\n\n`x`", "```\ncosts $5\n```\n\n`x`"],
+    ["a `b` c `d` e", "a `b` c `d` e"],
+    ["costs $5 outside", "costs \\$5 outside"],
+    ["costs $5 outside\n\n`x`", "costs \\$5 outside\n\n`x`"],
+    ["```\n`inner`\n```", "```\n`inner`\n```"],
+    ["`\\(x\\)` and \\(y\\)", "`\\(x\\)` and $y$"],
+    ["```\n\\(x\\)\n```\n\nthen \\(y\\)", "```\n\\(x\\)\n```\n\nthen $y$"],
+  ];
+  for (const [input, expected] of cases) {
+    assert.equal(
+      preprocessLaTeX(input),
+      expected,
+      `changed for ${JSON.stringify(input)}`,
+    );
+  }
+});


### PR DESCRIPTION
## Problem

`findCodeBlockRegions` in `studio/frontend/src/lib/latex.ts` feeds `isInRegion`,
which binary-searches and therefore requires sorted, **non-overlapping** spans.
It does not always produce them.

The inline-code pass drops a span that sits *inside* a fence, but an inline span
can also *contain* a fence pair:

```
`~~~a~~~ $5`
```

The fenced scan matches `~~~a~~~` at `[1, 8)`, the inline scan matches the whole
`` `~~~a~~~ $5` `` at `[0, 12)`, and both are kept. The search then descends into
the inner span and misses the outer one, so whether a position is reported as
"inside code" depends on how many spans the rest of the reply happens to add.

The visible effect is that a finished code span gets rewritten by text that
arrives after it:

```js
preprocessLaTeX("`~~~a~~~ $5`");        // "`~~~a~~~ $5`"      correct
preprocessLaTeX("`~~~a~~~ $5`\n\n`x`"); // "`~~~a~~~ \$5`\n\n`x`"  wrong
```

That contradicts the contract stated in the file's own doc comment, "Currency
inside code blocks/spans is untouched". The same lookup guards
`convertLatexDelimiters`, so a code sample showing `\(x\)` can also be turned
into real math once another code span appears later in the reply.

Because replies stream, "text that arrives after it" is the normal case: a code
span can render correctly and then change as generation continues.

## The change

Collect the fenced and inline spans into two ascending lists and merge them into
their union, which is sorted and non-overlapping by construction. For input that
was already non-overlapping the merge reproduces the previous list exactly, so
the only behaviour that moves is the broken case. The merge also replaces the
`sort`.

## Testing

`npm test` (2,940 pass), `npm run typecheck`, `npm run build` and `npx eslint` on
both changed files are clean. `npm run biome:check` reports the same 5 errors and
16 warnings for `latex.ts` as it does on `main`, so this adds none; biome is
already non-blocking in `studio-frontend-ci.yml`.

### Differential fuzz

200,000 generated documents built from fragments mixing inline math, display
math, currency, bold-wrapped math, inline code, fenced code, tilde fences, links
with parentheses in the destination, tables, quotes and escaped backslashes, each
compared against the previous implementation:

| documents | output changed | explained by overlapping spans | unexplained |
| --- | --- | --- | --- |
| 200,000 | 6,004 | 6,004 | **0** |

Every difference is a case where the old code emitted overlapping spans. Nothing
else moved.

### New tests, and what each one catches

`studio/frontend/tests/latex-code-regions.test.ts`. There was previously no test
file for `latex.ts` at all; its only coverage was indirect, through the streaming
schedule tests.

Run against the unmodified tree, three of the four fail and one passes:

- **`currency inside inline code survives unrelated later code spans`** - fails
  on `main` with `` `~~~a~~~ \$5`\n\n`x` `` against the expected
  `` `~~~a~~~ $5`\n\n`x` ``. This is the reported defect.
- **`a code span's own text decides its escaping, whatever follows it`** - fails
  on `main`. Sweeps seven code-span shapes against one to four trailing spans,
  so it pins the general property rather than the one input, and would catch a
  fix that special-cased `~~~` inside backticks.
- **`LaTeX inside inline code stays literal whatever follows it`** - fails on
  `main`. Covers the delimiter-conversion path, which uses the same lookup and
  would otherwise turn a code sample into a rendered formula.
- **`ordinary code spans and fences are unchanged`** - **passes on `main` as
  well.** It is the regression guard for the merge itself, not a defect
  detector: it pins ten already-correct shapes so that a future change to the
  merge cannot move them. Stating this explicitly because a test that passes
  both ways proves nothing about the bug.
