### PR TITLE
Stop TestProbeGating asserting a tier the mapping check is meant to upgrade

### DIFF
--- a/studio/backend/tests/test_transformers_version.py
+++ b/studio/backend/tests/test_transformers_version.py
@@ -1565,7 +1565,9 @@ class TestProbeGating:
         assert get_transformers_tier("org/new") == "550"
         assert seen == ["", tv._VENV_T5_530_DIR, tv._VENV_T5_550_DIR]
 
-    def test_a_model_type_the_default_lacks_never_reaches_the_version_field_probe(self, monkeypatch):
+    def test_a_model_type_the_default_lacks_never_reaches_the_version_field_probe(
+        self, monkeypatch
+    ):
         """The mapping check answers first, and short-circuits the probe below it.
 
         This ordering is what quietly invalidated the two tests above. They pinned
@@ -1584,7 +1586,9 @@ class TestProbeGating:
             "utils.transformers_version._check_tokenizer_config_needs_v5", lambda m, t = None: False
         )
         monkeypatch.setattr(
-            tv, "_config_model_types", lambda tier: frozenset({"llama"} if tier == "default" else {"llama", "brandnew"})
+            tv,
+            "_config_model_types",
+            lambda tier: frozenset({"llama"} if tier == "default" else {"llama", "brandnew"}),
         )
         # Declares 5.x too, so the version-field probe below WOULD fire if it were reached.
         _config_json_cache[("org/brandnew", None)] = {
@@ -1600,7 +1604,6 @@ class TestProbeGating:
         tier = get_transformers_tier("org/brandnew")
         assert tier != "default", f"a model_type the default lacks must be raised, got {tier!r}"
         assert probed == [], "the mapping check must answer before any sidecar probe runs"
-
 
     def test_ordinary_4x_config_does_not_probe(self, monkeypatch):
         self._patch_venvs(monkeypatch)

--- a/studio/backend/tests/test_transformers_version.py
+++ b/studio/backend/tests/test_transformers_version.py
@@ -49,6 +49,7 @@ from utils.transformers_version import (
     _higher_tier,
     _config_json_cache,
     _tokenizer_class_cache,
+    _config_mapping_cache,
     _config_needs_510_cache,
     _config_needs_530_cache,
     _config_needs_550_cache,
@@ -1473,6 +1474,10 @@ class TestProbeGating:
         _config_needs_510_cache.clear()
         _config_needs_550_cache.clear()
         _tokenizer_class_cache.clear()
+        # Sixth cache, and the one this class used to miss. get_transformers_tier consults
+        # CONFIG_MAPPING_NAMES per tier and upgrades a model_type the ambient default does
+        # not ship, so a mapping parsed by an earlier test decides the answer here.
+        _config_mapping_cache.clear()
 
     def _patch_venvs(self, monkeypatch):
         for fn in (
@@ -1522,8 +1527,13 @@ class TestProbeGating:
         monkeypatch.setattr(
             "utils.transformers_version._check_tokenizer_config_needs_v5", lambda m, t = None: False
         )
+        # A model_type the ambient default DOES ship. "brandnew" is in none of the
+        # mappings, so the static config-mapping tier upgraded it to 530 before the
+        # version-field probe under test ever ran, and the assert below only passed
+        # when an earlier test had left _config_mapping_cache in a state that skipped
+        # that path. The probe, not the mapping upgrade, is the subject here.
         _config_json_cache[("org/new", None)] = {
-            "model_type": "brandnew",
+            "model_type": "llama",
             "transformers_version": "5.0.0",
         }
         seen = []
@@ -1541,8 +1551,9 @@ class TestProbeGating:
         monkeypatch.setattr(
             "utils.transformers_version._check_tokenizer_config_needs_v5", lambda m, t = None: False
         )
+        # Shipped by the ambient default, for the same reason as the test above.
         _config_json_cache[("org/new", None)] = {
-            "model_type": "brandnew",
+            "model_type": "llama",
             "transformers_version": "5.6.0",
         }
         results = iter([_proc(1, "KeyError: 'x'"), _proc(1, "KeyError: 'x'"), _proc(0)])
@@ -1553,6 +1564,43 @@ class TestProbeGating:
         )
         assert get_transformers_tier("org/new") == "550"
         assert seen == ["", tv._VENV_T5_530_DIR, tv._VENV_T5_550_DIR]
+
+    def test_a_model_type_the_default_lacks_never_reaches_the_version_field_probe(self, monkeypatch):
+        """The mapping check answers first, and short-circuits the probe below it.
+
+        This ordering is what quietly invalidated the two tests above. They pinned
+        model_type "brandnew", which no mapping ships, so once #7043 landed the mapping
+        check answered before the version-field probe they were written for ever ran, and
+        they began asserting the wrong branch's answer. Nothing pinned the ordering, so
+        the only symptom was those two failing in a way that read like a probe bug.
+
+        Pinning it here means a future reshuffle that puts the probe first fails as
+        itself, and the two tests above keep testing the probe rather than this.
+        """
+        import utils.transformers_version as tv
+
+        self._patch_venvs(monkeypatch)
+        monkeypatch.setattr(
+            "utils.transformers_version._check_tokenizer_config_needs_v5", lambda m, t = None: False
+        )
+        monkeypatch.setattr(
+            tv, "_config_model_types", lambda tier: frozenset({"llama"} if tier == "default" else {"llama", "brandnew"})
+        )
+        # Declares 5.x too, so the version-field probe below WOULD fire if it were reached.
+        _config_json_cache[("org/brandnew", None)] = {
+            "model_type": "brandnew",
+            "transformers_version": "5.0.0",
+        }
+        probed = []
+        monkeypatch.setattr(
+            "utils.transformers_version.subprocess.run",
+            lambda cmd, **k: probed.append(cmd[3]) or _proc(0),
+        )
+
+        tier = get_transformers_tier("org/brandnew")
+        assert tier != "default", f"a model_type the default lacks must be raised, got {tier!r}"
+        assert probed == [], "the mapping check must answer before any sidecar probe runs"
+
 
     def test_ordinary_4x_config_does_not_probe(self, monkeypatch):
         self._patch_venvs(monkeypatch)


### PR DESCRIPTION
Two tests in `TestProbeGating` fail standalone on `main`:

```
tests/test_transformers_version.py::TestProbeGating::test_version_field_probe_stays_default_when_default_parses
  assert get_transformers_tier("org/new") == "default"
E AssertionError: assert '530' == 'default'

tests/test_transformers_version.py::TestProbeGating::test_version_field_probe_escalates_when_default_fails
E AssertionError: assert '530' == '550'
```

They are not wrong about the probe. They are wrong about the `model_type`.

## What actually happens

`get_transformers_tier` consults `CONFIG_MAPPING_NAMES` per tier and upgrades a `model_type` the ambient default does not ship. That is deliberate, and it says so:

```
Transformers tier 530 selected for org/new (config mapping: model_type absent below)
```

```python
# A model_type absent from an overlay's mapping can't load there. Parse each sidecar's
# config map and pick the lowest tier that ships it. Only upgrades default, never lowers.
_config_mapping_cache: dict[str, frozenset[str]] = {}
```

Both tests pinned `model_type: "brandnew"`, which no mapping ships. Driving it directly:

```
mapping cache pre: {}
Transformers tier 530 selected for org/new (config mapping: model_type absent below)
tier: 530
mapping cache post: {'default': 421, '530': 1}
```

So the static mapping tier upgraded to 530 before the version-field probe under test ever ran. The assertions were measuring the wrong thing, and they were green only when an earlier test had left `_config_mapping_cache` populated in a way that skipped that path. That is why they pass in the suite's serial order and fail on their own.

**Source is correct here; the tests are.** Nothing about the upgrade behaviour changes.

## Fix

Use a `model_type` the ambient default does ship, so the probe rather than the mapping upgrade is what the assertions measure.

`setup_method` also now clears `_config_mapping_cache`. It clears five caches and missed the sixth, which is exactly what let an unrelated test decide this one's answer.

I checked which half does the work rather than assuming:

| | standalone result |
| --- | --- |
| main | 2 failed, 5 passed |
| cache clear only (old model_type) | **3 failed**, 4 passed |
| model_type only (no clear) | 7 passed |
| both (this PR) | **7 passed** |

The clear is not the fix, and on its own it makes things worse: a third test was leaning on the same stale mapping. It is kept because with the corrected `model_type` all seven pass and the class stops depending on what ran before it.

Whole file: 5 failed -> 3 failed. The remaining three are a pre-existing `TestDamagedLatestSidecarRepairHandoff` group, unrelated to this change and failing identically on unmodified `main`.

## Which PR, and which side is wrong

| | |
| --- | --- |
| these two tests | #6550 (2026-06-22) |
| the `CONFIG_MAPPING_NAMES` tier | **#7043 (2026-07-11)** |

**#7043 is right and is not reverted.** Routing by the real mapping beats the hardcoded tables it replaced, and raising a `model_type` the ambient default does not ship is the point of it. What #7043 missed is that it now answers *before* the version-field probe, so the two tests written against that probe stopped reaching it. They were correct when written and became wrong under a later, correct source change.

## Robustification, and the real gap

**Nothing pinned the ordering #7043 introduced.** Had it been pinned, #7043 would have had to update these two tests instead of silently changing what they measure.

A new test asserts that a `model_type` the default lacks is answered by the mapping and never reaches the probe. Both halves were mutation-checked:

| mutation | failure |
| --- | --- |
| mapping short-circuit disabled | `a model_type the default lacks must be raised, got 'default'` |
| probe moved above the mapping | `the mapping check must answer before any sidecar probe runs` |

Standalone: 2 failed, 5 passed -> **8 passed**.

One consequence worth stating: after #7043 the version-field probe is only reachable for a `model_type` the default mapping *does* ship, because a brand-new one is caught by the branch above it. So `llama` is not a weakening of the original scenario, it is the only input domain where the code under test is still live.

Found while measuring whether the backend suite can run under `pytest-xdist`: these two fail on a runner under `-n 4` and pass serially, for exactly this reason.
