### PR TITLE
Stub the implicit STT load in the disconnect-cancellation test

### DIFF
--- a/studio/backend/tests/test_stt_transcription_cancellation.py
+++ b/studio/backend/tests/test_stt_transcription_cancellation.py
@@ -167,8 +167,21 @@ def test_disconnected_raw_transcription_cancels_its_sidecar(monkeypatch):
             assert cancel_event.wait(1), "disconnect must reach the sidecar"
             raise SttTranscriptionCancelledError("Transcription cancelled.")
 
+    loaded = []
+
+    def load(model, _engine, _request_cancel_event):
+        # Stubbed for the same reason the sibling test above stubs it: the real
+        # implicit load goes through the registry, which refuses with
+        # SttModelNotDownloadedError (409) unless a snapshot happens to be on disk.
+        # Without this the disconnect below is never reached and the assert reads
+        # `409 == 499`, which is what this test does on a machine that has never
+        # downloaded an STT model. Cancellation, not download state, is the subject.
+        loaded.append(model)
+        return None
+
     sidecar = _Sidecar()
     monkeypatch.setattr(inference_route, "_stt_sidecar_for", lambda _engine: sidecar)
+    monkeypatch.setattr(inference_route, "_stt_lifecycle", lambda: (load, None))
     monkeypatch.setattr(
         inference_route,
         "_resolve_serving_stt_engine",
@@ -189,6 +202,10 @@ def test_disconnected_raw_transcription_cancels_its_sidecar(monkeypatch):
 
     assert raised.value.status_code == 499
     assert sidecar.cancelled is True
+    # The stub has to stay load-bearing. If the route stops loading through the
+    # registry, this records nothing and the stub quietly becomes dead code that
+    # keeps the test green for a path it no longer covers.
+    assert loaded == ["small"], f"the transcribe path did not load through the registry: {loaded}"
 
 
 def test_server_cancel_watcher_abandons_the_request_and_keeps_the_server():


### PR DESCRIPTION
`test_disconnected_raw_transcription_cancels_its_sidecar` passes in its file and fails on its own, on any machine that has not downloaded an STT model:

```
tests/test_stt_transcription_cancellation.py:190
    assert raised.value.status_code == 499
E   assert 409 == 499
E    +  where 409 = HTTPException(status_code=409, detail="STT model 'small' is not
       downloaded. Download it in Settings, then Voice, before loading it.").status_code
```

## Cause

`_transcribe_audio_result` does an implicit load through the registry before it ever reaches the sidecar:

```python
load_stt, _ = _stt_lifecycle()
await asyncio.to_thread(load_stt, model, serving_engine, cancel_event)
```

and the registry refuses unless a complete snapshot is on disk:

```python
snapshot_path = _find_complete_cached_snapshot(model_id)
if snapshot_path is None:
    raise SttModelNotDownloadedError(...)
```

The test stubs `_stt_sidecar_for` and `_resolve_serving_stt_engine`, but not the load. So the disconnect it exists to test is never reached. It gets there only when an earlier test in the file has left an engine resident, or when the host happens to have the model cached.

The sibling test directly above it already stubs `_stt_lifecycle` for exactly this reason:

```python
monkeypatch.setattr(inference_route, "_stt_sidecar_for", lambda _engine: sidecar)
monkeypatch.setattr(inference_route, "_stt_lifecycle", lambda: (load, None))
```

## Fix

Do the same. Cancellation, not download state, is the subject of this test.

## Verification

Forcing the no-snapshot condition (`_find_complete_cached_snapshot` returning `None`, which is what a runner that has never downloaded an STT model looks like):

| | result |
| --- | --- |
| main, this test alone | **1 failed** (`409 == 499`) |
| main, whole file | 9 passed |
| this PR, this test alone | 9 passed |
| this PR, on a host that does have the model cached | 9 passed |

The gap between rows one and two is the order dependency.

## Which PR, and which side is wrong

Both this test and the implicit registry load it trips over came from the **same PR, #7984** (`d20db3f1f`, 2026-08-11). The test was incomplete from birth, and the sibling test directly above it, added by that same PR, does stub `_stt_lifecycle`.

Worth flagging: #7984 is also the PR behind the `stt_unload` 500 in #9013, and behind the two `test_stt_ggml_sidecar.py` unload tests that fail standalone on `main`. Three defects in one area, each invisible because a serial run happened to leave the right state behind.

## Robustification

The stub now records what it was asked to load, and the test asserts it. Otherwise, if the route ever stops loading through the registry, the stub silently becomes dead code and the test stays green for a path it no longer covers. Mutating the route to skip the load:

```
AssertionError: the transcribe path did not load through the registry: []
```

Found while measuring whether the backend suite can run under `pytest-xdist`. `--dist load` splits the file across workers, so the test lands on a worker where nothing loaded an engine first and it fails. The dependency is on `main` today though, which is why this is a standalone fix.
