### PR TITLE
Stop test_begin_load_never_refuses_auto racing the thread it is asserting about

### DIFF
--- a/studio/backend/tests/test_diffusion_backend.py
+++ b/studio/backend/tests/test_diffusion_backend.py
@@ -3572,6 +3572,25 @@ def test_begin_load_never_refuses_auto(fake_runtime, tmp_path, monkeypatch):
     # The same CPU host with `auto` must sail through: delegating the choice is not a contract.
     (tmp_path / "m.gguf").write_bytes(b"x")
     backend = DiffusionBackend()
+
+    # Hold the worker thread at its first instruction, so `loaded` CANNOT be True yet.
+    # begin_load documents "Returns at once", and the assertion below used to race the
+    # daemon thread for it: on an idle host the caller wins and it passes, on a busy one
+    # the thread finishes first and it fails with `assert True is False`. Blocking the
+    # worker makes the same claim unraceable. The refusal this test is named for happens
+    # in begin_load's validation, before the thread is spawned, so stubbing the body
+    # costs no coverage.
+    release = threading.Event()
+    entered = threading.Event()
+    worker: dict = {}
+
+    def _blocked_run_load(self, **kwargs):
+        worker["thread"] = threading.current_thread()
+        entered.set()
+        release.wait(30)
+
+    monkeypatch.setattr(DiffusionBackend, "_run_load", _blocked_run_load)
+
     started = backend.begin_load(
         str(tmp_path),
         gguf_filename = "m.gguf",
@@ -3579,7 +3598,15 @@ def test_begin_load_never_refuses_auto(fake_runtime, tmp_path, monkeypatch):
         model_kind = "gguf",
         transformer_quant = "auto",
     )
-    assert started["loaded"] is False  # returns immediately; the load runs on a thread
+    assert started["loaded"] is False  # returned without waiting on the load
+    assert entered.wait(30), "begin_load never started the load thread"
+    # The load is still in flight, which is the whole claim. Checked from the caller,
+    # not with an assert inside the worker: an assertion that fails on a non-main
+    # thread does not fail the test, so that version reported a pass against a
+    # begin_load mutated to join its own thread.
+    assert worker["thread"].is_alive(), "begin_load waited for the load instead of returning"
+    release.set()
+    worker["thread"].join(30)
 
 
 def test_transformer_quant_falls_back_to_gguf_on_failure(


### PR DESCRIPTION
```
tests/test_diffusion_backend.py:3582: in test_begin_load_never_refuses_auto
    assert started["loaded"] is False  # returns immediately; the load runs on a thread
E   assert True is False
```

## Cause

`begin_load` spawns a daemon thread and returns `self.status()` straight after:

```python
threading.Thread(
    target = self._run_load,
    ...
).start()
...
return self.status()
```

So whether `loaded` is still `False` at the assert depends on which of the two wins. On an idle host the caller wins and the test passes. On a busy one the load finishes first and it fails, which is what it does on a 4-vCPU runner with three other pytest workers in flight.

The claim is right. The way it was checked was not: it was a race, and it happened to have been winning.

## Fix

Hold the worker on an event so `loaded` **cannot** be `True` yet, and have the caller check the worker is still alive after `begin_load` returned.

The refusal this test is named for happens in `begin_load`'s validation, before the thread is spawned, so holding the worker body costs no coverage.

## The first version of this fix was wrong

I initially asserted from inside the worker:

```python
def _blocked_run_load(self, **kwargs):
    entered.set()
    assert release.wait(30), "the load thread was never released"
```

An assertion that fails on a non-main thread does not fail the test. Against a `begin_load` mutated to `join()` its own thread, that version sat there for 34s and then reported **1 passed**. It would have accepted exactly the regression it was supposed to catch.

The check is now made from the caller, and the mutation fails by name:

| `begin_load` | result |
| --- | --- |
| as it is | 1 passed |
| mutated to join its own thread | **1 failed** — `begin_load waited for the load instead of returning` |

Whole file, either way: 313 passed, identical to `main`.

## Which PR, and which side is wrong

| | |
| --- | --- |
| `begin_load`'s daemon thread | #6763 (2026-08-04) |
| this test | **#8165 (2026-08-09)** |

The threading behaviour was five days old when the test was written against it, so this is not a regression in `begin_load` and nothing in `core/inference/diffusion.py` changes here. The test raced from birth and had simply been winning.

Found while measuring whether the backend suite can run under `pytest-xdist`, but the race is on `main` today and any loaded machine can lose it.
