### PR TITLE
Measure the streaming stripper against CPU time, not wall clock

### DIFF
--- a/studio/backend/tests/test_streaming_stripper.py
+++ b/studio/backend/tests/test_streaming_stripper.py
@@ -475,8 +475,12 @@ def test_early_markup_is_not_slower_than_the_code_it_replaces():
     # true. Without a floor a clock that stopped reporting, or a `count` someone lowered,
     # turns this into an assertion that cannot fail. 0.05s is far below the ~1.3s each arm
     # actually takes and far above the clock's resolution.
-    assert reference > 0.05, f"reference arm measured {reference:.4f}s; too small to compare against"
-    assert incremental > 0.05, f"incremental arm measured {incremental:.4f}s; too small to compare against"
+    assert (
+        reference > 0.05
+    ), f"reference arm measured {reference:.4f}s; too small to compare against"
+    assert (
+        incremental > 0.05
+    ), f"incremental arm measured {incremental:.4f}s; too small to compare against"
 
     assert (
         incremental <= reference * 1.10

--- a/studio/backend/tests/test_streaming_stripper.py
+++ b/studio/backend/tests/test_streaming_stripper.py
@@ -454,16 +454,29 @@ def test_early_markup_is_not_slower_than_the_code_it_replaces():
     prefix = '`x` <tool_call>{"name": "search", "arguments": {}}</tool_call> '
 
     def elapsed(fn, count):
+        # process_time, not perf_counter: this compares how much work two code paths do,
+        # and wall clock also measures whatever else the machine is running. A 10% margin
+        # does not survive that. On a 4-vCPU CI runner with other test workers in flight
+        # the wall-clock version failed outright (1.451s against 1.316s) while the code
+        # under test had not changed. CPU time of this process is the quantity the
+        # assertion is actually about, and it is unaffected by neighbours.
         text = prefix
-        start = time.perf_counter()
+        start = time.process_time()
         for _ in range(count):
             text += "word "
             fn(text)
-        return time.perf_counter() - start
+        return time.process_time() - start
 
     count = 1500
     reference = min(elapsed(_reference_strip, count) for _ in range(3))
     incremental = min(elapsed(StreamingMarkupStripper(ENABLED).strip, count) for _ in range(3))
+
+    # process_time has coarser granularity than perf_counter, and `0.0 <= 0.0 * 1.10` is
+    # true. Without a floor a clock that stopped reporting, or a `count` someone lowered,
+    # turns this into an assertion that cannot fail. 0.05s is far below the ~1.3s each arm
+    # actually takes and far above the clock's resolution.
+    assert reference > 0.05, f"reference arm measured {reference:.4f}s; too small to compare against"
+    assert incremental > 0.05, f"incremental arm measured {incremental:.4f}s; too small to compare against"
 
     assert (
         incremental <= reference * 1.10


### PR DESCRIPTION
```
tests/test_streaming_stripper.py:468: in test_early_markup_is_not_slower_than_the_code_it_replaces
E   AssertionError: early markup cost 1.451s against the reference's 1.316s
E   assert 1.4506334609999385 <= (1.3157524960000728 * 1.1)
```

## Cause

The test compares how much work two code paths do, with a 10% margin:

```python
count = 1500
reference = min(elapsed(_reference_strip, count) for _ in range(3))
incremental = min(elapsed(StreamingMarkupStripper(ENABLED).strip, count) for _ in range(3))
assert incremental <= reference * 1.10
```

`elapsed` used `time.perf_counter`, which measures wall clock, which also measures whatever else the machine is doing. A 10% margin does not survive that. On a 4-vCPU runner with other pytest workers in flight it fails while the code under test has not changed.

`time.process_time` measures this process's CPU time. That is the quantity the assertion is actually about, and neighbours do not move it. **The 10% margin is untouched** and both `min`-of-3 samples stay.

## What is and is not verified

I have **not** reproduced the original failure locally, so I cannot claim this is verified as a fix for that specific run. Three busy processes pinned to the same core slow both arms equally, so the ratio holds and both clocks pass (5 runs each, all green).

What is demonstrated is the mechanism, on identical work:

| | wall | cpu |
| --- | --- | --- |
| idle core | 0.0161s | 0.0160s |
| core shared with 3 busy processes | **0.0599s** | 0.0150s |

Wall clock inflates 3.7x under contention. CPU time does not move.

Whole file: 64 passed.

## Which PR, and which side is wrong

Introduced by **#8538** (2026-08-12), which added this test using `time.perf_counter`. The source it guards is fine and is untouched here; the test has measured the wrong quantity since it was written.

## Robustification

`process_time` is coarser than `perf_counter`, and `0.0 <= 0.0 * 1.10` is true. A stopped clock, or a `count` someone lowers, would silently turn this into an assertion that cannot fail. Both arms now have to measure something, with a 0.05s floor that sits far below the ~1.3s each arm actually takes and far above the clock's resolution. Mutating `elapsed` to return `0.0`:

```
AssertionError: reference arm measured 0.0000s; too small to compare against
```

Found while measuring whether the backend suite can run under `pytest-xdist`. This is the one failure in that set that is not an order dependency: it is a timing assertion that cannot share a machine, and I would rather fix the clock than widen the margin.
