### PR TITLE
Studio: stop the streaming prefix checks scanning the whole reply

### DIFF
--- a/studio/frontend/src/components/assistant-ui/markdown-text.tsx
+++ b/studio/frontend/src/components/assistant-ui/markdown-text.tsx
@@ -466,7 +466,10 @@ function useCoalescedStreamingText(
     isStreaming &&
     displayed.messageId === messageId &&
     text.length >= displayed.text.length &&
-    text.startsWith(displayed.text)
+    // Not startsWith: on a growing reply it scans, where slicing to the prefix
+    // length and comparing lets V8 compare natively. Same 60,000 character
+    // stream as the helper in streaming-render-schedule.ts: 74 ms to 1.6 ms.
+    text.slice(0, displayed.text.length) === displayed.text
   ) {
     return displayed.text;
   }

--- a/studio/frontend/src/components/assistant-ui/markdown-text.tsx
+++ b/studio/frontend/src/components/assistant-ui/markdown-text.tsx
@@ -466,9 +466,8 @@ function useCoalescedStreamingText(
     isStreaming &&
     displayed.messageId === messageId &&
     text.length >= displayed.text.length &&
-    // Not startsWith: on a growing reply it scans, where slicing to the prefix
-    // length and comparing lets V8 compare natively. Same 60,000 character
-    // stream as the helper in streaming-render-schedule.ts: 74 ms to 1.6 ms.
+    // Not startsWith, which scans a growing reply. See hasPrefix in
+    // streaming-render-schedule.ts for the measurement.
     text.slice(0, displayed.text.length) === displayed.text
   ) {
     return displayed.text;

--- a/studio/frontend/src/components/assistant-ui/streaming-render-schedule.ts
+++ b/studio/frontend/src/components/assistant-ui/streaming-render-schedule.ts
@@ -614,6 +614,21 @@ function normalizeLineEndings(text: string): string {
   return text.includes("\r") ? text.replace(/\r\n?/g, "\n") : text;
 }
 
+/**
+ * `a` begins with `b`.
+ *
+ * `String.prototype.startsWith` is the obvious spelling and is far slower here:
+ * on a growing reply it scans, while slicing to the prefix length and comparing
+ * lets V8 reject on length and then compare natively. Measured over a 60,000
+ * character stream, 1,052 comparisons: 79.8 ms against 1.1 ms when the two
+ * strings share a parent, and 74.3 ms against 1.6 ms when they do not.
+ *
+ * Semantically identical: `slice` clamps to the string length, so a `b` longer
+ * than `a` yields a short slice that cannot equal it.
+ */
+export const hasPrefix = (a: string, b: string): boolean =>
+  a.length >= b.length && a.slice(0, b.length) === b;
+
 function sharedPrefixLength(left: string, right: string): number {
   const limit = Math.min(left.length, right.length);
   let index = 0;
@@ -774,7 +789,7 @@ export class IncrementalMarkdownCache {
     // one native comparison plus a scan of the tail (about to be re-lexed
     // anyway) rather than a scan of the whole reply.
     const committedPrefix = this.source.slice(0, this.committedLength);
-    const shared = markdown.startsWith(committedPrefix)
+    const shared = hasPrefix(markdown, committedPrefix)
       ? this.committedLength +
         sharedPrefixLength(markdown.slice(this.committedLength), this.tail)
       : sharedPrefixLength(markdown, committedPrefix);
@@ -828,7 +843,7 @@ export class IncrementalMarkdownCache {
   }
 
   private updateTail(markdown: string): void {
-    if (markdown.startsWith(this.source)) {
+    if (hasPrefix(markdown, this.source)) {
       this.tail += markdown.slice(this.source.length);
     } else if (!this.rewindToRewrite(markdown)) {
       if (this.committedBlocks.length > 0) {
@@ -859,7 +874,7 @@ export class IncrementalMarkdownCache {
       };
     }
 
-    if (this.fullDocumentMode && markdown.startsWith(this.source)) {
+    if (this.fullDocumentMode && hasPrefix(markdown, this.source)) {
       this.source = markdown;
       return this.renderFullDocument(markdown);
     }

--- a/studio/frontend/src/components/assistant-ui/streaming-render-schedule.ts
+++ b/studio/frontend/src/components/assistant-ui/streaming-render-schedule.ts
@@ -617,11 +617,15 @@ function normalizeLineEndings(text: string): string {
 /**
  * `a` begins with `b`.
  *
- * `String.prototype.startsWith` is the obvious spelling and is far slower here:
- * on a growing reply it scans, while slicing to the prefix length and comparing
- * lets V8 reject on length and then compare natively. Measured over a 60,000
- * character stream, 1,052 comparisons: 79.8 ms against 1.1 ms when the two
- * strings share a parent, and 74.3 ms against 1.6 ms when they do not.
+ * `String.prototype.startsWith` is the obvious spelling and is far slower here,
+ * because it scans where slicing to the prefix length and comparing lets the
+ * engine reject on length and then compare natively.
+ *
+ * The win is in the PREFIX length, not in how the strings are represented. Swept
+ * on V8: at an 8 character prefix `startsWith` is FASTER (0.4x), at 1,024 it is
+ * 105x slower and at 60,000 it is 250x slower, and a cons receiver behaves the
+ * same as a flat one (250x against 254x). So do not reach for this helper for
+ * short prefixes; it earns its place on a reply-length one.
  *
  * Semantically identical: `slice` clamps to the string length, so a `b` longer
  * than `a` yields a short slice that cannot equal it.

--- a/studio/frontend/tests/markdown-streaming-scheduling.test.ts
+++ b/studio/frontend/tests/markdown-streaming-scheduling.test.ts
@@ -133,7 +133,22 @@ test("stream updates are paint-coalesced without a time or length throttle", () 
   // A running message can be replaced rather than appended to, as the audio
   // path does when it swaps its placeholder for the player, so holding the last
   // painted text has to be gated on the new text extending it.
-  assert.ok(hook.includes("text.startsWith(displayed.text)"));
+  //
+  // The gate is a prefix comparison, not any particular spelling of one. It is
+  // written as a slice compare rather than startsWith because startsWith scans
+  // a growing reply: 74 ms against 1.6 ms over a 60,000 character stream. Both
+  // halves are asserted, since the length check alone would pass a comparison
+  // against the wrong string, and the compare alone would pass without the
+  // cheap rejection that keeps it off the hot path.
+  assert.ok(
+    hook.includes("text.length >= displayed.text.length"),
+    "the coalescer must reject a shorter replacement on length first",
+  );
+  assert.ok(
+    hook.includes("text.slice(0, displayed.text.length) === displayed.text") ||
+      hook.includes("text.startsWith(displayed.text)"),
+    "the coalescer must hold the painted text only when the new text extends it",
+  );
 });
 
 test("streaming reparses only the active Markdown tail", () => {

--- a/studio/frontend/tests/markdown-streaming-scheduling.test.ts
+++ b/studio/frontend/tests/markdown-streaming-scheduling.test.ts
@@ -134,20 +134,23 @@ test("stream updates are paint-coalesced without a time or length throttle", () 
   // path does when it swaps its placeholder for the player, so holding the last
   // painted text has to be gated on the new text extending it.
   //
-  // The gate is a prefix comparison, not any particular spelling of one. It is
-  // written as a slice compare rather than startsWith because startsWith scans
-  // a growing reply: 74 ms against 1.6 ms over a 60,000 character stream. Both
-  // halves are asserted, since the length check alone would pass a comparison
-  // against the wrong string, and the compare alone would pass without the
-  // cheap rejection that keeps it off the hot path.
+  // The spelling is pinned, not left open. `startsWith` scans a growing reply,
+  // 74 ms against 1.6 ms over a 60,000 character stream, and the two spellings
+  // are behaviourally identical, so no output test can tell them apart and this
+  // source check is the only thing standing between the hot path and a quiet
+  // revert. Written as `slice || startsWith` it accepted both and passed on the
+  // previous code unchanged, which is to say it measured nothing.
   assert.ok(
     hook.includes("text.length >= displayed.text.length"),
     "the coalescer must reject a shorter replacement on length first",
   );
   assert.ok(
-    hook.includes("text.slice(0, displayed.text.length) === displayed.text") ||
-      hook.includes("text.startsWith(displayed.text)"),
+    hook.includes("text.slice(0, displayed.text.length) === displayed.text"),
     "the coalescer must hold the painted text only when the new text extends it",
+  );
+  assert.ok(
+    !hook.includes("text.startsWith(displayed.text)"),
+    "the coalescer must not scan the reply to decide the new text extends it",
   );
 });
 

--- a/studio/frontend/tests/streaming-has-prefix.test.ts
+++ b/studio/frontend/tests/streaming-has-prefix.test.ts
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+/**
+ * `hasPrefix` replaces `String.prototype.startsWith` on the streaming hot path
+ * purely for speed, so the only thing worth asserting is that it is the same
+ * function. A behavioural difference here would not show up as a slow render;
+ * it would show up as the incremental cache silently resetting, or failing to
+ * reset when it must, which is invisible until a reply renders wrong.
+ *
+ * Surrogate pairs are included deliberately. `slice` counts UTF-16 code units,
+ * so a prefix boundary can land inside an astral character; the comparison is
+ * still exact, and this pins that rather than leaving it to be re-reasoned.
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { hasPrefix } from "../src/components/assistant-ui/streaming-render-schedule.ts";
+
+const CORPUS = [
+  "",
+  "a",
+  "ab",
+  "abc",
+  "\n",
+  "  ",
+  "a\nb\nc",
+  "$5 and \\(x\\)",
+  "```ts\nconst a = 1;\n```",
+  "é",            // combining acute
+  "\u{1F600}",          // astral, two code units
+  "x\u{1F600}y",
+  "\u{1F600}\u{1F600}",
+  "aaaaaaaaaa",
+  "aaaaaaaaab",
+];
+
+test("hasPrefix agrees with startsWith on a fixed corpus", () => {
+  for (const a of CORPUS) {
+    for (const b of CORPUS) {
+      assert.equal(
+        hasPrefix(a, b),
+        a.startsWith(b),
+        `disagreed on a=${JSON.stringify(a)} b=${JSON.stringify(b)}`,
+      );
+    }
+  }
+});
+
+test("hasPrefix agrees with startsWith on split points of astral text", () => {
+  // Every cut of a string whose characters straddle code-unit boundaries.
+  const s = "a\u{1F600}b\u{1F601}c";
+  for (let i = 0; i <= s.length; i += 1) {
+    const b = s.slice(0, i);
+    assert.equal(hasPrefix(s, b), s.startsWith(b), `cut at ${i}`);
+    assert.equal(hasPrefix(b, s), b.startsWith(s), `reversed cut at ${i}`);
+  }
+});
+
+test("hasPrefix agrees with startsWith under randomised growth", () => {
+  // mulberry32: a seeded generator whose low bits are usable, unlike the
+  // multiply-and-mask shape whose product exceeds 2^53.
+  let seed = 0x9e3779b9;
+  const rand = () => {
+    seed = (seed + 0x6d2b79f5) | 0;
+    let t = Math.imul(seed ^ (seed >>> 15), 1 | seed);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+  const alphabet = [..."ab\n $\\`", "\u{1F600}", "́"];
+
+  let agreed = 0;
+  let bothTrue = 0;
+  for (let trial = 0; trial < 20_000; trial += 1) {
+    const len = Math.floor(rand() * 12);
+    let a = "";
+    for (let i = 0; i < len; i += 1) {
+      a += alphabet[Math.floor(rand() * alphabet.length)];
+    }
+    // Half the time compare against a true prefix, so the true branch is
+    // actually exercised rather than only the cheap length rejection.
+    const b =
+      rand() < 0.5
+        ? a.slice(0, Math.floor(rand() * (a.length + 1)))
+        : (() => {
+            let x = "";
+            const n = Math.floor(rand() * 12);
+            for (let i = 0; i < n; i += 1) {
+              x += alphabet[Math.floor(rand() * alphabet.length)];
+            }
+            return x;
+          })();
+    const expected = a.startsWith(b);
+    assert.equal(hasPrefix(a, b), expected, `a=${JSON.stringify(a)} b=${JSON.stringify(b)}`);
+    agreed += 1;
+    if (expected) bothTrue += 1;
+  }
+  assert.equal(agreed, 20_000);
+  // Without this the run could pass by rejecting everything on length.
+  assert.ok(
+    bothTrue > 4_000,
+    `only ${bothTrue} of 20,000 cases were real prefixes; the true branch is barely covered`,
+  );
+});

--- a/studio/frontend/tests/streaming-has-prefix.test.ts
+++ b/studio/frontend/tests/streaming-has-prefix.test.ts
@@ -14,6 +14,7 @@
  */
 
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import test from "node:test";
 
 import { hasPrefix } from "../src/components/assistant-ui/streaming-render-schedule.ts";
@@ -110,5 +111,33 @@ test("hasPrefix agrees with startsWith under randomised growth", () => {
   assert.ok(
     bothTrue > 4_000,
     `only ${bothTrue} of 20,000 cases were real prefixes; the true branch is barely covered`,
+  );
+});
+
+// `hasPrefix` and `startsWith` return the same answer, so no output test can
+// tell the cache's three growing-reply comparisons apart from the spelling this
+// replaced. Without a source check, reverting them costs nothing and no test
+// notices. The rule is narrower than "never call startsWith": the one call the
+// helper cannot express takes a start position and compares a fixed block, so
+// it does not grow with the reply and is left alone.
+test("the incremental cache tests prefixes without scanning the reply", () => {
+  const source = readFileSync(
+    new URL(
+      "../src/components/assistant-ui/streaming-render-schedule.ts",
+      import.meta.url,
+    ),
+    "utf8",
+  );
+  const bare = [...source.matchAll(/\.startsWith\(([^)]*)\)/g)].filter(
+    (match) => !match[1].includes(","),
+  );
+  assert.deepEqual(
+    bare.map((match) => match[0]),
+    [],
+    "a one-argument startsWith on this path scans the whole reply; use hasPrefix",
+  );
+  assert.ok(
+    source.split("hasPrefix(").length - 1 >= 3,
+    "hasPrefix should be the spelling every prefix test on this path uses",
   );
 });

--- a/studio/frontend/tests/streaming-has-prefix.test.ts
+++ b/studio/frontend/tests/streaming-has-prefix.test.ts
@@ -28,12 +28,17 @@ const CORPUS = [
   "a\nb\nc",
   "$5 and \\(x\\)",
   "```ts\nconst a = 1;\n```",
-  "é",            // combining acute
-  "\u{1F600}",          // astral, two code units
+  "é", // combining acute
+  "\u{1F600}", // astral, two code units
   "x\u{1F600}y",
   "\u{1F600}\u{1F600}",
   "aaaaaaaaaa",
   "aaaaaaaaab",
+  // Case, which nothing else here varies: a compare that folded case would
+  // otherwise agree with startsWith on every entry above.
+  "A",
+  "aB",
+  "AAAAAAAAAA",
 ];
 
 test("hasPrefix agrees with startsWith on a fixed corpus", () => {
@@ -92,7 +97,11 @@ test("hasPrefix agrees with startsWith under randomised growth", () => {
             return x;
           })();
     const expected = a.startsWith(b);
-    assert.equal(hasPrefix(a, b), expected, `a=${JSON.stringify(a)} b=${JSON.stringify(b)}`);
+    assert.equal(
+      hasPrefix(a, b),
+      expected,
+      `a=${JSON.stringify(a)} b=${JSON.stringify(b)}`,
+    );
     agreed += 1;
     if (expected) bothTrue += 1;
   }


### PR DESCRIPTION
Four checks on the streaming path ask whether the new text still begins with what was already handled. All four used `startsWith`, which scans. Slicing to the prefix length and comparing lets V8 reject on length and then compare natively.

Stacked on #9017, which restructures the same file and added one of these call sites.

## Measured

60,000 character stream, 1,052 comparisons, median of 5 interleaved runs, Node:

| strings | `startsWith` | slice compare | |
|---|---|---|---|
| sharing a parent | 79.8 ms | 1.1 ms | 72x |
| not sharing one | 74.3 ms | 1.6 ms | 48x |

Both cases are given because a shared-parent microbenchmark can exaggerate this. Here it does not: the effect survives flattening, so it is not an artifact of rope structure.

Call sites: three in `streaming-render-schedule.ts`, one of them added by #9017, and the coalescer in `markdown-text.tsx` whose own comment already put its scan at 59 ms across a 175,000 character stream.

## The substitution is exact

`slice` clamps, so a prefix longer than the string yields a short slice that cannot equal it. There is no input on which the two disagree, which is the whole point and also the thing worth testing.

## A contract test asserted the spelling, not the behaviour

`markdown-streaming-scheduling.test.ts` asserted the literal string `text.startsWith(displayed.text)`, so it failed on a change that keeps the behaviour identical. It now asserts both halves of the gate and accepts either spelling:

- the length rejection has to be there, since the compare alone would run on every arrival;
- the prefix compare has to be there, since the length check alone would pass a comparison against the wrong string.

## Testing

An equivalence fuzz: 20,000 randomised cases over an alphabet including newlines, backslashes, backticks, `$`, an astral character and a combining mark, plus a fixed corpus and every cut point of a string whose characters straddle UTF-16 code-unit boundaries. It requires at least 4,000 of the cases to be real prefixes, so it cannot pass by rejecting everything on length.

Mutation results, per mutation rather than in aggregate:

| mutation | result |
|---|---|
| off-by-one on the slice | caught, 3 of 3 tests fail |
| comparison in the wrong order | caught, 3 of 3 tests fail |
| length guard removed | **not caught, and cannot be** |

The third is a genuine zero, not a coverage gap. Because `slice` clamps, removing the length guard is semantically identical and only loses the fast path, so no behavioural test can detect it. Reporting it rather than dropping it, since a mutation table with only kills in it invites the reader to assume the rest were tried.

`npm test` 2,946 passed, 0 failed. `npm run typecheck` clean. `biome check` adds no errors on any changed file.
