### PR TITLE
fix(studio): Windows ROCm reports Unknown VRAM on single-GPU hosts with an iGPU

### DIFF
--- a/studio/backend/utils/hardware/hardware.py
+++ b/studio/backend/utils/hardware/hardware.py
@@ -1855,7 +1855,7 @@ def _match_adapter_used_to_devices(
         # Keeps 40 GiB over 48/8 GiB -> [40, None].
         assigned = [None] * n
         for rank, pos in enumerate(ranked_positions):
-            if rank + 1 < n and ranked_useds[rank] > ranked_totals[rank + 1]:
+            if n == 1 or (rank + 1 < n and ranked_useds[rank] > ranked_totals[rank + 1]):
                 assigned[pos] = min(ranked_useds[rank], device_totals[pos])
         return assigned
     # No hidden adapters: every counter is a visible card, so ranking is a permutation.


### PR DESCRIPTION
On Windows ROCm hosts with one discrete AMD GPU and an enabled iGPU, the Studio GPU panel shows Unknown used / Unknown free / <correct> total. The perf-counter path added in #5301 works correctly and returns valid data — the failure is in _match_adapter_used_to_devices, where the capacity-forcing condition can never be true when n == 1.

This affects any host with a single Radeon plus an integrated GPU, i.e. every Ryzen without an F suffix and every Intel CPU with the iGPU enabled. Paradoxically, a two-discrete-GPU host is less affected.

Note it only surfaces when amd-smi is absent, since the perf-counter path is a fallback. That is the case on a pip-wheel install without the system-wide HIP SDK — the documented default path on Windows — which is why it does not show up on every AMD box.

Environment
OS: Windows 11 (German locale)
GPU: AMD Radeon RX 7900 XTX (gfx1100), 24 GiB
CPU: AMD Ryzen 7 9800X3D (iGPU enabled)
unsloth: 2026.8.18
torch: 2.11.0+rocm7.13.0
ROCm: 7.13.0 via AMD pip wheels (rocm-sdk-core, rocm-sdk-libraries-gfx110X-all)
HIP SDK: not installed system-wide — no hipconfig, no amd-smi on the host, so the perf-counter path is the active VRAM source
Evidence

Torch sees exactly one device:

devices: 1
0 AMD Radeon RX 7900 XTX 25753026560

The perf counter returns two instances — the discrete card and the idle iGPU:

'luid_0x00000000_0x000119d6_phys_0|2390851584\nluid_0x00000000_0x0001465f_phys_0|0\n'
rc 0
1.3 s

So the data collection is fine: exit code 0, well within the 5 s timeout, both adapters parsed.

Root cause

In _match_adapter_used_to_devices, with adapter_useds = [2390851584, 0] and device_totals = [25753026560] (n = 1):

len(useds) > n → 2 > 1, branch taken.
non_trivial drops the 0-byte iGPU entry → [2390851584], length 1 == n, so the bijection is considered plausible.
ranked_useds[0] > ranked_totals[0] → 2.39 GB > 25.75 GB is false, so the usage fits the card.
if rank + 1 < n and ... → with n == 1 this is 0 + 1 < 1, which is always false. Nothing is ever assigned and assigned stays [None].

The condition exists to avoid attributing a usage that capacity does not force. But with exactly one visible device and exactly one supra-threshold counter there is nothing to disambiguate — step 2 has already established the bijection, and step 3 has already verified the usage fits.

Change
diff
-            if rank + 1 < n and ranked_useds[rank] > ranked_totals[rank + 1]:
+            if n == 1 or (rank + 1 < n and ranked_useds[rank] > ranked_totals[rank + 1]):

Verified locally: the panel now shows ~2.3 GiB used / ~21.7 GiB free of 24 GiB, and the value tracks model loading and training as expected.

Note the assumption this makes explicit, since the counters carry no vendor/LUID/PCI key: it trusts that the single supra-threshold counter belongs to the visible card rather than to a busy foreign adapter while the visible card sits idle. That is the same class of assumption the surrounding code already documents, and the 64 MiB threshold plus the capacity check bound it.

Related

_rocm_windows_aggregate_used_bytes fails on the same host for a related reason: it returns None when len(adapter_useds) != n, and the raw (unfiltered) list contains the idle iGPU instance, so 2 != 1. The System tab therefore loses the aggregate too, even though the sum is unambiguous here. Left untouched in this PR since that function deliberately avoids the noise filter — happy to follow up separately if you want it addressed.