### PR TITLE
chore(studio): give Radix portals a container that is not document.body

### DIFF
--- a/.github/workflows/studio-frontend-ci.yml
+++ b/.github/workflows/studio-frontend-ci.yml
@@ -21,9 +21,11 @@ on:
       - 'tests/studio/playwright_strip_ansi_smoke.py'
       - 'tests/studio/playwright_chat_autoscroll.py'
       - 'tests/studio/playwright_research_freeze.py'
-      # Shared lifecycle helpers, and the contract test that keeps verdicts from going unread.
+      - 'tests/studio/playwright_heavy_thread.py'
+      # Shared lifecycle helpers, and the contract tests that keep verdicts from going unread.
       - 'tests/studio/_playwright_robust.py'
       - 'tests/studio/test_autoscroll_harness_contract.py'
+      - 'tests/studio/test_heavy_thread_harness_contract.py'
       - 'tests/studio/test_playwright_server_lifecycle.py'
       - 'scripts/sync_allow_scripts_pins.py'
       - 'tests/studio/test_sync_allow_scripts_pins.py'
@@ -168,7 +170,8 @@ jobs:
         working-directory: ${{ github.workspace }}
         run: |
           python3 -m pytest tests/studio/test_playwright_server_lifecycle.py \
-            tests/studio/test_autoscroll_harness_contract.py -q
+            tests/studio/test_autoscroll_harness_contract.py \
+            tests/studio/test_heavy_thread_harness_contract.py -q
 
       - name: Browser smoke for ANSI tool output
         working-directory: ${{ github.workspace }}
@@ -185,6 +188,20 @@ jobs:
       - name: Browser smoke for research freeze
         working-directory: ${{ github.workspace }}
         run: python3 tests/studio/playwright_research_freeze.py
+
+      # Two small sizes and one repetition on Chromium: enough to prove the fixture still
+      # renders every kind of content it claims to and that the curve still rises, which is all
+      # a PR gate can afford. The measurement this harness exists for is the three-engine,
+      # three-size, three-repetition run, which takes tens of minutes and belongs on a runner
+      # asked for it deliberately, not on every frontend PR.
+      - name: Browser smoke for heavy-thread interaction cost
+        working-directory: ${{ github.workspace }}
+        env:
+          SMOKE_HEAVY_CHARS: '25000,100000'
+          SMOKE_HEAVY_ENGINES: chromium
+          SMOKE_HEAVY_REPEATS: '1'
+          PW_ART_DIR: logs/playwright_heavy_thread
+        run: python3 tests/studio/playwright_heavy_thread.py
 
       - name: Build
         run: npm run build

--- a/studio/frontend/smoke-heavy-thread-main.tsx
+++ b/studio/frontend/smoke-heavy-thread-main.tsx
@@ -1,0 +1,767 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// Harness page for tests/studio/playwright_heavy_thread.py: the real Thread holding a HEAVY
+// thread, so the measured cost of typing, scrolling, opening a menu, deleting and re-opening is
+// the app's own and grows the way a long session's does.
+//
+// The axis is CHARACTERS OF THREAD CONTENT, not messages. Users report the slowdown after "long
+// generations with any code cells and/or text", which is a statement about volume, so a fixture
+// of N short paragraphs would measure the wrong variable.
+//
+// The content mix is the one the report names, and every kind of it is present at every size
+// because the fixture is built in whole CYCLES of one message per kind (~26K characters a
+// cycle). Building "until the budget runs out" instead would give the smallest size only the
+// first few kinds, and the curve would then be reporting a change of fixture, not of size.
+//
+//   prose                long multi-paragraph answers
+//   python fence         a large highlighted code fence
+//   typescript fence     a second language, so one grammar is not the whole Shiki story
+//   python tool call     collapsible card with a code-execution result pane
+//   bash tool call       code_execution card, the other result-pane shape
+//   html artifact        a full ```html document, which Studio collapses into an artifact card
+//   render_html tool     the HTML canvas artifact, as a tool part rather than a fence
+//   svg fence            a highlighted fence that also renders an inline <img> preview
+//   image parts          a raster PNG data URL and a unique SVG data URL, as image content parts
+//   json fence           one very long line, the shape that behaves worst in a highlighter
+//
+// Two honest limits, both of which the harness's own docstring repeats:
+//
+//   * The HTML artifact renders as an artifact CARD here, not as a live preview. The <iframe>
+//     lives in ArtifactSurface on the chat page, and it loads its content from the backend
+//     (/api/inference/artifact-preview-frame), so it cannot exist on a backend-free smoke page.
+//     What is measured is the in-thread cost of an artifact, which is what a scroll pays.
+//   * `python` results carry `images: []`. A non-empty list makes the card fetch each image from
+//     the backend, which would put a network round trip inside a timed region.
+//
+// Same shape as smoke-autoscroll.html and smoke-thread-weight.html: a vite entry, no backend, no
+// auth. Thread itself and the message bodies are real on purpose; mocking either deletes the
+// measurement. The runtime is synthetic -- a local runtime whose model adapter never runs,
+// seeded through `thread.import`.
+//
+// useLocalRuntime rather than useExternalStoreRuntime: the delete path under measurement is
+// `thread.export()` -> MessageRepository -> `thread.import()`, which only the local runtime backs.
+
+import { Thread } from "@/components/assistant-ui/thread";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import {
+  AssistantRuntimeProvider,
+  type ChatModelAdapter,
+  ExportedMessageRepository,
+  type ThreadMessageLike,
+  useAui,
+  useLocalRuntime,
+} from "@assistant-ui/react";
+import {
+  RouterProvider,
+  createMemoryHistory,
+  createRootRoute,
+  createRouter,
+} from "@tanstack/react-router";
+import { type ReactElement, useEffect, useState } from "react";
+import { createRoot } from "react-dom/client";
+import "./src/index.css";
+
+// The local runtime's thread list item reports a synthetic `__LOCALID_...` remoteId, which is
+// truthy, so the fork-count badge really does fire one GET per assistant message. Answering them
+// here, before anything mounts, keeps that off the wire entirely; answering them from the
+// Playwright side instead would put a round trip to another process inside a timed region, once
+// per assistant message.
+const realFetch = window.fetch.bind(window);
+window.fetch = (input, init) => {
+  const url =
+    typeof input === "string" ? input : ((input as Request).url ?? String(input));
+  if (url.includes("/api/")) {
+    return Promise.resolve(
+      new Response("{}", {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+  }
+  return realFetch(input, init);
+};
+
+// ── content generators ──────────────────────────────────────────────
+//
+// Every generator takes the block index and produces content that is UNIQUE to it. That is not
+// decoration: code-plugin.ts caches highlighted tokens keyed on the exact source string, so a
+// fixture that repeats one fence would highlight it once and hand back the cached result for
+// every other copy, and the Shiki cost would vanish from the curve.
+
+const PROSE_SENTENCES = [
+  "The reception of a long thread is decided by what the renderer does on every interaction, not by what it did once at load.",
+  "A reply that arrives quickly can still leave a thread that answers a keystroke slowly, because the two costs are paid in different places.",
+  "Anything that walks the whole message list on each frame turns a pleasant session into an unpleasant one somewhere around the twentieth long answer.",
+  "The tell is that generation stays fast while the surrounding interface does not, which points at per-message renderer work rather than at the model.",
+  "Layout that is not contained propagates upward, so a change inside one message can force the entire column to be measured again.",
+  "None of this is visible on a short thread, which is why the fixture here is sized in characters rather than in messages.",
+];
+
+function prose(index: number, targetChars: number): string {
+  const parts: string[] = [`Reply ${index}.`];
+  let length = parts[0].length;
+  let cursor = index;
+  while (length < targetChars) {
+    const sentence = PROSE_SENTENCES[cursor % PROSE_SENTENCES.length];
+    parts.push(`${sentence} (paragraph ${cursor - index + 1} of reply ${index})`);
+    length += parts[parts.length - 1].length + 2;
+    cursor += 1;
+  }
+  return parts.join("\n\n");
+}
+
+function pythonFence(index: number, targetChars: number): string {
+  const lines = [
+    "```python",
+    `# reply ${index}: a batch scorer, long enough that the highlighter has real work to do`,
+    "from dataclasses import dataclass",
+    "",
+    "@dataclass",
+    `class Row${index}:`,
+    "    weight: float",
+    "    count: int",
+    "    label: str",
+    "",
+  ];
+  let step = 0;
+  while (lines.join("\n").length < targetChars) {
+    lines.push(
+      `def score_${index}_${step}(rows: list[Row${index}]) -> float:`,
+      `    """Step ${step} of reply ${index}: sum the weighted counts, skipping the empties."""`,
+      "    total = 0.0",
+      "    for row in rows:",
+      `        if row.count == 0 or row.label == "skip-${step}":`,
+      "            continue",
+      `        total += row.weight * row.count * {0}.{1}`.replace("{0}", String(step + 1)).replace("{1}", String((index * 7 + step) % 97)),
+      "    return total",
+      "",
+    );
+    step += 1;
+  }
+  lines.push("```");
+  return lines.join("\n");
+}
+
+function typescriptFence(index: number, targetChars: number): string {
+  const lines = [
+    "```typescript",
+    `// reply ${index}: the client half, so the fixture is not one grammar repeated`,
+    `export interface Row${index} {`,
+    "  readonly weight: number;",
+    "  readonly count: number;",
+    "  readonly label: string;",
+    "}",
+    "",
+  ];
+  let step = 0;
+  while (lines.join("\n").length < targetChars) {
+    lines.push(
+      `export function score${index}_${step}(rows: readonly Row${index}[]): number {`,
+      "  let total = 0;",
+      "  for (const row of rows) {",
+      `    if (row.count === 0 || row.label === "skip-${step}") continue;`,
+      `    total += row.weight * row.count * ${step + 1}.${(index * 5 + step) % 89};`,
+      "  }",
+      "  return total;",
+      "}",
+      "",
+    );
+    step += 1;
+  }
+  lines.push("```");
+  return lines.join("\n");
+}
+
+function jsonFence(index: number, targetChars: number): string {
+  // One very long line on purpose. A single-line document is the shape that behaves worst in a
+  // highlighter and in any code that scans for line boundaries.
+  const entries: string[] = [];
+  let step = 0;
+  let body = "";
+  while (body.length < targetChars) {
+    entries.push(
+      `{"id":"row-${index}-${step}","weight":${(step % 17) + 0.5},"count":${step * 3 + index},"label":"batch-${index}-${step}"}`,
+    );
+    body = `{"reply":${index},"rows":[${entries.join(",")}]}`;
+    step += 1;
+  }
+  return ["```json", body, "```"].join("\n");
+}
+
+function htmlArtifact(index: number, targetChars: number): string {
+  // A full document, which is what Studio treats as an artifact rather than as a code block,
+  // and it draws on a <canvas> so the fixture carries the shape users call a canvas artifact.
+  const head = [
+    "<!doctype html>",
+    "<html>",
+    "  <head>",
+    `    <title>Reply ${index} canvas</title>`,
+    "    <style>",
+    "      body { margin: 0; font-family: system-ui, sans-serif; background: #101014; color: #f4f4f5; }",
+    "      canvas { display: block; width: 100%; height: 240px; }",
+    "    </style>",
+    "  </head>",
+    "  <body>",
+    `    <canvas id="plot-${index}" width="640" height="240"></canvas>`,
+    "    <script>",
+    `      const ctx = document.getElementById("plot-${index}").getContext("2d");`,
+  ];
+  const tail = ["    </script>", "  </body>", "</html>"];
+  const body: string[] = [];
+  let step = 0;
+  while ([...head, ...body, ...tail].join("\n").length < targetChars) {
+    body.push(
+      `      ctx.fillStyle = "hsl(${(index * 31 + step * 7) % 360}, 70%, 55%)";`,
+      `      ctx.fillRect(${step * 12}, ${(step * 5) % 200}, 10, ${20 + (step % 40)});`,
+    );
+    step += 1;
+  }
+  return ["```html", ...head, ...body, ...tail, "```"].join("\n");
+}
+
+function svgFence(index: number, targetChars: number): string {
+  // Studio renders a highlighted fence AND an inline <img> preview for an svg fence, so this one
+  // block buys both a Shiki pass and an image decode. No <script>, no on*= handlers, no
+  // <foreignObject>: any of those make the preview refuse to render and the block silently
+  // becomes an ordinary code fence.
+  const open = [`<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 160" width="320" height="160">`];
+  const close = ["</svg>"];
+  const body: string[] = [];
+  let step = 0;
+  while ([...open, ...body, ...close].join("\n").length < targetChars) {
+    body.push(
+      `  <rect x="${(step * 9) % 300}" y="${(step * 6) % 140}" width="14" height="${8 + (step % 40)}" fill="hsl(${(index * 23 + step * 11) % 360}, 65%, 55%)" />`,
+    );
+    step += 1;
+  }
+  return ["```svg", ...open, ...body, ...close, "```"].join("\n");
+}
+
+function pythonScript(index: number, targetChars: number): string {
+  const lines = [`# tool script for block ${index}`, "import json", ""];
+  let step = 0;
+  while (lines.join("\n").length < targetChars) {
+    lines.push(
+      `rows_${step} = [{"weight": ${step + 1}, "count": ${index + step}}]`,
+      `print(json.dumps({"step": ${step}, "total": sum(r["weight"] * r["count"] for r in rows_${step})}))`,
+    );
+    step += 1;
+  }
+  return lines.join("\n");
+}
+
+function toolOutput(index: number, targetChars: number): string {
+  const lines: string[] = [];
+  let step = 0;
+  while (lines.join("\n").length < targetChars) {
+    lines.push(
+      `[block ${index}] step ${step}: processed ${step * 128 + index} rows, ${((step * 37) % 100) / 10} MB resident`,
+    );
+    step += 1;
+  }
+  return lines.join("\n");
+}
+
+function bashOutput(index: number, targetChars: number): string {
+  const lines: string[] = [`total ${index * 4 + 12}`];
+  let step = 0;
+  while (lines.join("\n").length < targetChars) {
+    lines.push(
+      `-rw-r--r--  1 unsloth  staff  ${step * 733 + index}  Jan ${(step % 28) + 1} 09:${String((step * 7) % 60).padStart(2, "0")}  shard-${index}-${step}.safetensors`,
+    );
+    step += 1;
+  }
+  return lines.join("\n");
+}
+
+// 64x64 RGB PNG, 288 bytes. A real raster decode rather than a 1x1 placeholder, and small enough
+// that its data URL does not dominate the character budget it is counted against.
+const PNG_DATA_URL =
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAIAAAAlC+aJAAAA50lEQVR42u3PkVIlAABA0VcTBEEQBEGwECwEQRAEwUIQBAtBEARBEFwIgiAIgiAIFoIgCIIgWFi4EARBEARBEAQLQdBXBM3cmfMDZzDAERzFMRzHCZzEKZzGHziDP3EW53AeF3ARl/AXLuMKruJvXMN13MBN3MJt3EFwF/dwHw/wEI/wGE/wFP/gGZ7jBV7iFV7jDf7Ffyje4h3e4wM+4hM+4wu+4hv+x3f8wOHB8NC3VqBAgQIFChQoUKBAgQIFChQoUKBAgQIFChQoUKBAgQIFChQoUKBAgQIFChQoUKBAgQIFCny9T1mrnz8ZmAtoAAAAAElFTkSuQmCC";
+
+const pngCache = new Map<number, string>();
+
+/**
+ * A PNG that is unique to this block, so each one is a separate decode rather than a cache hit
+ * on the last.
+ *
+ * Drawn and exported here rather than embedded as a literal because assistant-ui only accepts
+ * `data:image/(png|jpeg|jpg|gif|webp);base64,` for an image part and drops anything else with a
+ * console warning -- an SVG data URL, which would have been the easy way to vary the bytes, is
+ * silently discarded.
+ */
+function pngDataUrl(index: number): string {
+  const cached = pngCache.get(index);
+  if (cached !== undefined) return cached;
+  let url = PNG_DATA_URL;
+  try {
+    const canvas = document.createElement("canvas");
+    canvas.width = 96;
+    canvas.height = 64;
+    const ctx = canvas.getContext("2d");
+    if (ctx) {
+      ctx.fillStyle = `hsl(${(index * 47) % 360}, 60%, 40%)`;
+      ctx.fillRect(0, 0, 96, 64);
+      ctx.fillStyle = `hsl(${(index * 91) % 360}, 70%, 65%)`;
+      ctx.beginPath();
+      ctx.arc(24 + (index % 48), 34, 18, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.fillStyle = "#ffffff";
+      ctx.font = "12px sans-serif";
+      ctx.fillText(`block ${index}`, 6, 16);
+      url = canvas.toDataURL("image/png");
+    }
+  } catch {
+    url = PNG_DATA_URL;
+  }
+  pngCache.set(index, url);
+  return url;
+}
+
+// ── the cycle ───────────────────────────────────────────────────────
+
+type Part = NonNullable<Exclude<ThreadMessageLike["content"], string>>[number];
+
+/** One block: the user's prompt and the assistant messages it produced. */
+type Block = { user: string; assistant: ThreadMessageLike[] };
+
+function textPart(text: string): Part {
+  return { type: "text", text };
+}
+
+const KIND_COUNT = 10;
+
+function buildBlock(index: number): Block {
+  const kind = index % KIND_COUNT;
+  const ask = `Prompt ${index}. Walk me through step ${index} of the batch scorer, and show the code and the run.`;
+  switch (kind) {
+    case 0:
+      return { user: ask, assistant: [{ role: "assistant", content: [textPart(prose(index, 2600))] }] };
+    case 1:
+      return {
+        user: ask,
+        assistant: [
+          {
+            role: "assistant",
+            content: [
+              textPart(
+                `${prose(index, 300)}\n\n${pythonFence(index, 2900)}\n\nThat is the scoring half.`,
+              ),
+            ],
+          },
+        ],
+      };
+    case 2:
+      return {
+        user: ask,
+        assistant: [
+          {
+            role: "assistant",
+            content: [
+              textPart(
+                `${prose(index, 300)}\n\n${typescriptFence(index, 2900)}\n\nAnd the client half.`,
+              ),
+            ],
+          },
+        ],
+      };
+    case 3:
+      // python is one of the two tools the renderer never folds into a tool GROUP, so its card
+      // stays a top-level collapsible even when it sits next to other calls.
+      return {
+        user: ask,
+        assistant: [
+          {
+            role: "assistant",
+            content: [
+              textPart(`Running it now for block ${index}.`),
+              {
+                type: "tool-call",
+                toolCallId: `heavy-python-${index}`,
+                toolName: "python",
+                args: { code: pythonScript(index, 900) },
+                // All three keys, or the card falls back to stringifying the whole object.
+                // `images` stays empty: a non-empty list makes the card fetch each one from a
+                // backend this page does not have.
+                result: { text: toolOutput(index, 1400), images: [], sessionId: `heavy-${index}` },
+              },
+            ],
+          },
+        ],
+      };
+    case 4:
+      // No text part in this message on purpose. CodeExecutionToolUI is a CONTROLLED collapsible
+      // that force-closes itself as soon as its message carries text, so a card with prose beside
+      // it cannot be held open for the measurement.
+      return {
+        user: ask,
+        assistant: [
+          {
+            role: "assistant",
+            content: [
+              {
+                type: "tool-call",
+                toolCallId: `heavy-bash-${index}`,
+                toolName: "code_execution",
+                args: { kind: "bash", command: `ls -la /workspace/shards/block-${index}` },
+                result: bashOutput(index, 1700),
+              },
+            ],
+          },
+        ],
+      };
+    case 5:
+      return {
+        user: ask,
+        assistant: [
+          {
+            role: "assistant",
+            content: [
+              textPart(
+                `Here is the preview for block ${index}.\n\n${htmlArtifact(index, 2400)}\n\nOpen it to see the plot.`,
+              ),
+            ],
+          },
+        ],
+      };
+    case 6:
+      return {
+        user: ask,
+        assistant: [
+          {
+            role: "assistant",
+            content: [
+              textPart(`Rendering the canvas for block ${index}.`),
+              {
+                type: "tool-call",
+                toolCallId: `heavy-canvas-${index}`,
+                toolName: "render_html",
+                args: {
+                  title: `Block ${index} canvas`,
+                  code: htmlArtifact(index, 2300).replace(/^```html\n/, "").replace(/\n```$/, ""),
+                },
+                result: `Rendered HTML canvas for block ${index}`,
+              },
+            ],
+          },
+        ],
+      };
+    case 7:
+      return {
+        user: ask,
+        assistant: [
+          {
+            role: "assistant",
+            content: [
+              textPart(`A diagram for block ${index}.\n\n${svgFence(index, 1500)}`),
+            ],
+          },
+        ],
+      };
+    case 8:
+      return {
+        user: ask,
+        assistant: [
+          {
+            role: "assistant",
+            content: [
+              textPart(`Two attachments for block ${index}: a rendered plot and a chart.`),
+              // One repeated attachment and one that is unique to this block: a thread has both,
+              // and only the second is a fresh decode every time.
+              { type: "image", image: PNG_DATA_URL },
+              { type: "image", image: pngDataUrl(index) },
+              textPart(prose(index, 400)),
+            ],
+          },
+        ],
+      };
+    default:
+      return {
+        user: ask,
+        assistant: [
+          {
+            role: "assistant",
+            content: [
+              textPart(`The raw rows for block ${index}.\n\n${jsonFence(index, 2700)}`),
+            ],
+          },
+        ],
+      };
+  }
+}
+
+function partChars(part: Part): number {
+  const anyPart = part as Record<string, unknown>;
+  if (anyPart.type === "text") return String(anyPart.text ?? "").length;
+  if (anyPart.type === "image") return String(anyPart.image ?? "").length;
+  if (anyPart.type === "tool-call") {
+    return (
+      JSON.stringify(anyPart.args ?? {}).length +
+      (typeof anyPart.result === "string"
+        ? anyPart.result.length
+        : JSON.stringify(anyPart.result ?? "").length)
+    );
+  }
+  return 0;
+}
+
+function messageChars(message: ThreadMessageLike): number {
+  if (typeof message.content === "string") return message.content.length;
+  return message.content.reduce((total, part) => total + partChars(part as Part), 0);
+}
+
+type Plan = {
+  chars: number;
+  messages: number;
+  blocks: number;
+  cycles: number;
+  kinds: number;
+  cycleChars: number;
+  expectedPerCycle: Record<string, number>;
+};
+
+/**
+ * What one cycle must put on screen. The Python side multiplies these by the cycle count and
+ * fails the run if the DOM holds fewer.
+ *
+ * This is not belt and braces. assistant-ui drops an image part whose data URL is not
+ * `data:image/(png|jpeg|jpg|gif|webp);base64,` with nothing but a console.warn, and a fixture
+ * that quietly loses its images still renders 300K characters of prose and code and still
+ * produces a rising curve -- of the wrong thing.
+ */
+const EXPECTED_PER_CYCLE: Record<string, number> = {
+  // Two image parts in the image block, plus the inline preview the svg fence renders.
+  images: 3,
+  // The python card and the code_execution card. render_html renders an artifact card instead.
+  toolParts: 2,
+  collapsibleOutputs: 2,
+  codeExecutionPanes: 2,
+  // The full ```html document and the render_html tool call.
+  artifactCards: 2,
+  // python, typescript, json, svg, the html document, and the two tool result panes.
+  codeBlocks: 7,
+  // Shiki is async and per block, so a <pre> exists long before it is highlighted. A floor under
+  // the token count is what tells a finished thread apart from one still building itself; a
+  // settled-looking count of 577 against the 3216 a whole cycle produces is a real measured
+  // failure of the naive "it stopped moving" gate.
+  highlightedTokens: 2500,
+};
+
+/**
+ * Whole cycles of one block per kind until `targetChars` is reached, never fewer than one.
+ *
+ * Whole cycles, not "blocks until the budget runs out": a partial cycle would give the smallest
+ * size only the first few kinds of content, so the curve across sizes would be reporting a change
+ * of fixture as well as a change of size.
+ */
+function buildThread(targetChars: number): { messages: ThreadMessageLike[]; plan: Plan } {
+  const messages: ThreadMessageLike[] = [];
+  let chars = 0;
+  let cycles = 0;
+  let blocks = 0;
+  let cycleChars = 0;
+  do {
+    const cycleStart = chars;
+    for (let k = 0; k < KIND_COUNT; k += 1) {
+      const block = buildBlock(blocks);
+      const user: ThreadMessageLike = { role: "user", content: [textPart(block.user)] };
+      messages.push(user, ...block.assistant);
+      chars += messageChars(user);
+      for (const message of block.assistant) chars += messageChars(message);
+      blocks += 1;
+    }
+    cycles += 1;
+    if (cycleChars === 0) cycleChars = chars - cycleStart;
+  } while (chars < targetChars);
+  return {
+    messages,
+    plan: {
+      chars,
+      messages: messages.length,
+      blocks,
+      cycles,
+      kinds: KIND_COUNT,
+      cycleChars,
+      expectedPerCycle: EXPECTED_PER_CYCLE,
+    },
+  };
+}
+
+// A run would need a backend. Seeding goes through `thread.import`, which does not use this.
+const NEVER_RUNS: ChatModelAdapter = {
+  run: () => {
+    throw new Error("smoke-heavy-thread does not run the model");
+  },
+};
+
+function HeavyThreadApi({
+  mounted,
+  setMounted,
+}: {
+  mounted: boolean;
+  setMounted: (value: boolean) => void;
+}): null {
+  const aui = useAui();
+
+  useEffect(() => {
+    const api = {
+      /** Replace the thread with whole cycles of content until `targetChars` is reached. */
+      seed(targetChars: number): Plan {
+        const built = buildThread(targetChars);
+        aui.thread().import(ExportedMessageRepository.fromArray(built.messages));
+        return built.plan;
+      },
+      /**
+       * Open every tool card. Radix unmounts collapsed content, so a thread of closed cards
+       * carries no result panes at all and the "tool calls with collapsible output" half of the
+       * fixture would be a row of buttons. A user who has just watched those tools run is
+       * looking at them open, which is the state worth measuring.
+       */
+      expandTools(): number {
+        const triggers = Array.from(
+          document.querySelectorAll<HTMLElement>('[data-slot="tool-fallback-trigger"]'),
+        );
+        for (const trigger of triggers) {
+          if (trigger.getAttribute("data-state") !== "open") trigger.click();
+        }
+        return triggers.length;
+      },
+      /** Leave the thread. The runtime keeps the messages; the view is torn down. */
+      closeThread(): void {
+        setMounted(false);
+      },
+      /** Come back to it, which rebuilds every message from nothing. */
+      openThread(): void {
+        setMounted(true);
+      },
+      isOpen(): boolean {
+        return mounted;
+      },
+      /**
+       * One selector pass. Polling for a deletion has to read this, not counts(): counts() is a
+       * dozen document-wide queries including a walk of every element, so at 300K characters a
+       * poll loop built on it would spend more time measuring than the delete itself takes.
+       */
+      messageCount(): number {
+        return document.querySelectorAll("[data-role]").length;
+      },
+      /** Highlighted tokens. Shiki runs after the <pre> exists, so counting <pre> gates nothing. */
+      highlightedTokenCount(): number {
+        return document.querySelectorAll("pre code span").length;
+      },
+      /**
+       * Everything a caller might use to prove the fixture landed. A harness that asks for 300K
+       * characters of mixed content and silently renders 200K of prose measures the wrong thing,
+       * so the Python side prints every one of these and fails on any that is zero.
+       */
+      counts(): Record<string, number> {
+        return {
+          messages: document.querySelectorAll("[data-role]").length,
+          assistantMessages: document.querySelectorAll('[data-role="assistant"]').length,
+          userMessages: document.querySelectorAll('[data-role="user"]').length,
+          domNodes: document.getElementsByTagName("*").length,
+          codeBlocks: document.querySelectorAll("pre").length,
+          highlightedTokens: document.querySelectorAll("pre code span").length,
+          toolParts: document.querySelectorAll(".aui-tool-fallback-root").length,
+          // Radix mounts collapsible content only while it is open, so this counts the panes a
+          // user can actually see rather than the cards that could produce one.
+          collapsibleOutputs: document.querySelectorAll(
+            '[data-slot="tool-fallback-content"]',
+          ).length,
+          codeExecutionPanes: document.querySelectorAll(
+            '[data-slot="tool-fallback-content"] pre',
+          ).length,
+          // ArtifactCard carries no class of its own; the accessible name is its stable handle.
+          artifactCards: document.querySelectorAll('button[aria-label^="Open "]').length,
+          images: document.querySelectorAll("img").length,
+          katexNodes: document.querySelectorAll(".katex").length,
+          actionBars: document.querySelectorAll(".aui-assistant-action-bar-root").length,
+          tooltipTriggers: document.querySelectorAll('[data-slot="tooltip-trigger"]').length,
+        };
+      },
+      viewportMetrics(): { scrollHeight: number; scrollTop: number; clientHeight: number } {
+        const element = api.viewport();
+        if (!element) return { scrollHeight: -1, scrollTop: -1, clientHeight: -1 };
+        return {
+          scrollHeight: element.scrollHeight,
+          scrollTop: element.scrollTop,
+          clientHeight: element.clientHeight,
+        };
+      },
+      viewport(): HTMLElement | null {
+        return document.querySelector<HTMLElement>(".aui-thread-viewport");
+      },
+      composer(): HTMLTextAreaElement | null {
+        return document.querySelector<HTMLTextAreaElement>(".aui-composer-input");
+      },
+      /**
+       * What the RUNTIME thinks the composer holds. Reading the textarea back instead would only
+       * echo the value the caller just wrote, so a keystroke that never reached React would still
+       * look like it landed.
+       */
+      composerText(): string {
+        return aui.composer().getState().text;
+      },
+      /** Items in the open action menu. An empty popover satisfies "the menu opened". */
+      openMenuItemCount(): number {
+        return document.querySelectorAll(".aui-action-bar-more-item").length;
+      },
+      lastAssistantMessage(): HTMLElement | null {
+        const messages = document.querySelectorAll<HTMLElement>('[data-role="assistant"]');
+        return messages[messages.length - 1] ?? null;
+      },
+      /**
+       * The last assistant message's action-bar button with accessible name `label`.
+       * TooltipIconButton puts that name in an `sr-only` span rather than an aria-label, so this
+       * matches on text and stays correct if the styling classes are renamed.
+       */
+      actionButton(label: string): HTMLButtonElement | null {
+        const last = api.lastAssistantMessage();
+        if (!last) return null;
+        const buttons = Array.from(last.querySelectorAll("button"));
+        return buttons.find((button) => (button.textContent ?? "").trim() === label) ?? null;
+      },
+    };
+    (window as unknown as { __heavyThread: typeof api }).__heavyThread = api;
+  }, [aui, mounted, setMounted]);
+
+  return null;
+}
+
+function Harness(): ReactElement {
+  const runtime = useLocalRuntime(NEVER_RUNS);
+  // The runtime lives outside this flag, so unmounting Thread leaves the messages intact. That is
+  // what re-opening a thread costs: the view is rebuilt, the data is not re-fetched.
+  const [mounted, setMounted] = useState(true);
+  return (
+    <TooltipProvider>
+      <AssistantRuntimeProvider runtime={runtime}>
+        <HeavyThreadApi mounted={mounted} setMounted={setMounted} />
+        {/* Thread is flex-1 basis-0 min-h-0, so it needs a bounded flex parent to scroll. */}
+        <div
+          data-smoke="heavy-thread"
+          style={{ display: "flex", flexDirection: "column", height: "100vh" }}
+        >
+          {mounted ? <Thread hideWelcome={true} /> : null}
+        </div>
+      </AssistantRuntimeProvider>
+    </TooltipProvider>
+  );
+}
+
+// Thread reaches useNavigate (the fork action, the composer tools menu). Without a router in
+// context tanstack's useRouter still works, but console.warns on every render of every action
+// bar, which scales with the thread and is serialised over the debugging channel. A memory router
+// with one route removes that without pulling in the app shell.
+const rootRoute = createRootRoute({ component: Harness });
+const router = createRouter({
+  routeTree: rootRoute,
+  history: createMemoryHistory({ initialEntries: ["/"] }),
+});
+
+const root = document.getElementById("root");
+if (!root) {
+  throw new Error("missing #root");
+}
+createRoot(root).render(<RouterProvider router={router as unknown as never} />);

--- a/studio/frontend/smoke-heavy-thread.html
+++ b/studio/frontend/smoke-heavy-thread.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>heavy thread smoke</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/smoke-heavy-thread-main.tsx"></script>
+  </body>
+</html>

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -209,6 +209,7 @@ import { useVoiceSettingsStore } from "@/features/settings/stores/voice-settings
 import { applyQwenThinkingParams } from "@/features/chat/utils/qwen-params";
 import { isTauri } from "@/lib/api-base";
 import { copyToClipboard } from "@/lib/copy-to-clipboard";
+import { swallowDismissingClick } from "@/lib/menu-dismiss";
 import { MicIcon } from "@/lib/mic-icon";
 import { downloadFile, isDownloadCancelled } from "@/lib/native-files";
 import { toast } from "@/lib/toast";
@@ -4662,7 +4663,7 @@ const ReasoningToggle: FC<{ side?: "top" | "bottom" }> = ({
 
   if (useDropdown) {
     return (
-      <DropdownMenu>
+      <DropdownMenu modal={false}>
         <DropdownMenuTrigger asChild={true}>
           <button
             type="button"
@@ -4686,6 +4687,7 @@ const ReasoningToggle: FC<{ side?: "top" | "bottom" }> = ({
           </button>
         </DropdownMenuTrigger>
         <DropdownMenuContent
+          onPointerDownOutside={swallowDismissingClick}
           side={side}
           align="end"
           avoidCollisions={true}
@@ -5481,6 +5483,7 @@ const ComposerToolsMenu: FC<{
       }}
     />
     <DropdownMenu
+      modal={false}
       onOpenChange={(open) => {
         if (open) void refreshRecentPrompts();
       }}
@@ -5496,6 +5499,7 @@ const ComposerToolsMenu: FC<{
         </button>
       </DropdownMenuTrigger>
       <DropdownMenuContent
+        onPointerDownOutside={swallowDismissingClick}
         side={side}
         align="start"
         sideOffset={0}
@@ -6863,7 +6867,7 @@ const AssistantActionBar: FC = () => {
             </TooltipIconButton>
           </ActionBarPrimitive.StopSpeaking>
         </MessagePrimitive.If>
-        <ActionBarMorePrimitive.Root>
+        <ActionBarMorePrimitive.Root modal={false}>
           <ActionBarMorePrimitive.Trigger asChild={true}>
             <TooltipIconButton
               tooltip="More"
@@ -6873,6 +6877,7 @@ const AssistantActionBar: FC = () => {
             </TooltipIconButton>
           </ActionBarMorePrimitive.Trigger>
           <ActionBarMorePrimitive.Content
+            onPointerDownOutside={swallowDismissingClick}
             side="bottom"
             align="start"
             onCloseAutoFocus={(e) => e.preventDefault()}

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -210,6 +210,7 @@ import { applyQwenThinkingParams } from "@/features/chat/utils/qwen-params";
 import { isTauri } from "@/lib/api-base";
 import { copyToClipboard } from "@/lib/copy-to-clipboard";
 import { swallowDismissingClick } from "@/lib/menu-dismiss";
+import { getPortalHost } from "@/lib/portal-host";
 import { MicIcon } from "@/lib/mic-icon";
 import { downloadFile, isDownloadCancelled } from "@/lib/native-files";
 import { toast } from "@/lib/toast";
@@ -6877,6 +6878,13 @@ const AssistantActionBar: FC = () => {
             </TooltipIconButton>
           </ActionBarMorePrimitive.Trigger>
           <ActionBarMorePrimitive.Content
+            // This menu is assistant-ui's, not components/ui/dropdown-menu.tsx's, so routing
+            // Studio's own Radix wrappers at the shared portal host does NOT cover it. Measured:
+            // with the wrappers alone the menu still reported popperParentIsBody true and
+            // `document.body` still went from 1 listener type to 85. `portalProps` is spread
+            // straight onto assistant-ui's `DropdownMenuPrimitive.Portal`, which is the only
+            // handle on its container.
+            portalProps={{ container: getPortalHost() }}
             onPointerDownOutside={swallowDismissingClick}
             side="bottom"
             align="start"

--- a/studio/frontend/src/components/ui/alert-dialog.tsx
+++ b/studio/frontend/src/components/ui/alert-dialog.tsx
@@ -6,6 +6,7 @@ import type * as React from "react";
 
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import { getPortalHost } from "@/lib/portal-host";
 
 function AlertDialog({
   ...props
@@ -25,7 +26,11 @@ function AlertDialogPortal({
   ...props
 }: React.ComponentProps<typeof AlertDialogPrimitive.Portal>) {
   return (
-    <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />
+    <AlertDialogPrimitive.Portal
+      data-slot="alert-dialog-portal"
+      container={getPortalHost()}
+      {...props}
+    />
   );
 }
 

--- a/studio/frontend/src/components/ui/combobox.tsx
+++ b/studio/frontend/src/components/ui/combobox.tsx
@@ -23,6 +23,7 @@ import { ChevronDownStandardIcon } from "@/lib/chevron-icons";
 import { cn } from "@/lib/utils";
 import { Cancel01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
+import { getPortalHost } from "@/lib/portal-host";
 
 const ComboboxOpenContext = createContext(false);
 type ComboboxRootProps = ComboboxPrimitive.Root.Props<string, false>;
@@ -157,7 +158,7 @@ function ComboboxContent({
   }): React.ReactElement {
   const dialogContainer = useDialogPortalContainer();
   return (
-    <ComboboxPrimitive.Portal container={container ?? dialogContainer ?? undefined}>
+    <ComboboxPrimitive.Portal container={container ?? dialogContainer ?? getPortalHost()}>
       <ComboboxPrimitive.Positioner
         side={side}
         sideOffset={sideOffset}

--- a/studio/frontend/src/components/ui/context-menu.tsx
+++ b/studio/frontend/src/components/ui/context-menu.tsx
@@ -10,6 +10,7 @@ import { Tick02Icon } from "@/lib/tick-icon";
 import { cn } from "@/lib/utils";
 import { ArrowRight01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
+import { getPortalHost } from "@/lib/portal-host";
 
 function ContextMenu({
   ...props
@@ -42,7 +43,11 @@ function ContextMenuPortal({
   ...props
 }: React.ComponentProps<typeof ContextMenuPrimitive.Portal>) {
   return (
-    <ContextMenuPrimitive.Portal data-slot="context-menu-portal" {...props} />
+    <ContextMenuPrimitive.Portal
+      data-slot="context-menu-portal"
+      container={getPortalHost()}
+      {...props}
+    />
   );
 }
 
@@ -70,7 +75,7 @@ function ContextMenuContent({
   side?: "top" | "right" | "bottom" | "left";
 }) {
   return (
-    <ContextMenuPrimitive.Portal>
+    <ContextMenuPrimitive.Portal container={getPortalHost()}>
       <ContextMenuPrimitive.Content
         data-slot="context-menu-content"
         className={cn(

--- a/studio/frontend/src/components/ui/dialog.tsx
+++ b/studio/frontend/src/components/ui/dialog.tsx
@@ -11,6 +11,7 @@ import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { Cancel01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
+import { getPortalHost } from "@/lib/portal-host";
 
 const DialogPortalContainerContext = createContext<HTMLElement | null>(null);
 
@@ -33,7 +34,13 @@ function DialogTrigger({
 function DialogPortal({
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Portal>) {
-  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />;
+  return (
+    <DialogPrimitive.Portal
+      data-slot="dialog-portal"
+      container={getPortalHost()}
+      {...props}
+    />
+  );
 }
 
 function DialogClose({

--- a/studio/frontend/src/components/ui/dropdown-menu.tsx
+++ b/studio/frontend/src/components/ui/dropdown-menu.tsx
@@ -9,6 +9,7 @@ import { ChevronRightStandardIcon } from "@/lib/chevron-icons";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { cn } from "@/lib/utils";
 import { HugeiconsIcon } from "@hugeicons/react";
+import { getPortalHost } from "@/lib/portal-host";
 
 function DropdownMenu({
   ...props
@@ -20,7 +21,11 @@ function DropdownMenuPortal({
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Portal>) {
   return (
-    <DropdownMenuPrimitive.Portal data-slot="dropdown-menu-portal" {...props} />
+    <DropdownMenuPrimitive.Portal
+      data-slot="dropdown-menu-portal"
+      container={getPortalHost()}
+      {...props}
+    />
   );
 }
 
@@ -43,7 +48,7 @@ function DropdownMenuContent({
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Content>) {
   return (
-    <DropdownMenuPrimitive.Portal>
+    <DropdownMenuPrimitive.Portal container={getPortalHost()}>
       <DropdownMenuPrimitive.Content
         data-slot="dropdown-menu-content"
         sideOffset={sideOffset}
@@ -307,7 +312,7 @@ function DropdownMenuSubContent({
     // Portaled like DropdownMenuContent: rendered inline, the fixed popper
     // wrapper is a descendant of the parent menu's scroll container, so any
     // transform there turns on overflow clipping and hides the submenu.
-    <DropdownMenuPrimitive.Portal>
+    <DropdownMenuPrimitive.Portal container={getPortalHost()}>
       <DropdownMenuPrimitive.SubContent
         ref={composedRef}
         data-slot="dropdown-menu-sub-content"

--- a/studio/frontend/src/components/ui/hover-card.tsx
+++ b/studio/frontend/src/components/ui/hover-card.tsx
@@ -5,6 +5,7 @@ import { HoverCard as HoverCardPrimitive } from "radix-ui";
 import type * as React from "react";
 
 import { cn } from "@/lib/utils";
+import { getPortalHost } from "@/lib/portal-host";
 
 function HoverCard({
   ...props
@@ -27,7 +28,10 @@ function HoverCardContent({
   ...props
 }: React.ComponentProps<typeof HoverCardPrimitive.Content>) {
   return (
-    <HoverCardPrimitive.Portal data-slot="hover-card-portal">
+    <HoverCardPrimitive.Portal
+      data-slot="hover-card-portal"
+      container={getPortalHost()}
+    >
       <HoverCardPrimitive.Content
         data-slot="hover-card-content"
         align={align}

--- a/studio/frontend/src/components/ui/menubar.tsx
+++ b/studio/frontend/src/components/ui/menubar.tsx
@@ -10,6 +10,7 @@ import { Tick02Icon } from "@/lib/tick-icon";
 import { cn } from "@/lib/utils";
 import { ChevronRightStandardIcon } from "@/lib/chevron-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
+import { getPortalHost } from "@/lib/portal-host";
 
 function Menubar({
   className,
@@ -42,7 +43,13 @@ function MenubarGroup({
 function MenubarPortal({
   ...props
 }: React.ComponentProps<typeof MenubarPrimitive.Portal>) {
-  return <MenubarPrimitive.Portal data-slot="menubar-portal" {...props} />;
+  return (
+    <MenubarPrimitive.Portal
+      data-slot="menubar-portal"
+      container={getPortalHost()}
+      {...props}
+    />
+  );
 }
 
 function MenubarRadioGroup({

--- a/studio/frontend/src/components/ui/popover.tsx
+++ b/studio/frontend/src/components/ui/popover.tsx
@@ -8,6 +8,7 @@ import type * as React from "react";
 
 import { useDialogPortalContainer } from "@/components/ui/dialog";
 import { cn } from "@/lib/utils";
+import { getPortalHost } from "@/lib/portal-host";
 
 function Popover({
   ...props
@@ -35,7 +36,7 @@ function PopoverContent({
   const dialogContainer = useDialogPortalContainer();
   return (
     <PopoverPrimitive.Portal
-      container={container ?? dialogContainer ?? undefined}
+      container={container ?? dialogContainer ?? getPortalHost()}
     >
       <PopoverPrimitive.Content
         data-slot="popover-content"

--- a/studio/frontend/src/components/ui/select.tsx
+++ b/studio/frontend/src/components/ui/select.tsx
@@ -15,6 +15,7 @@ import {
 import { cn } from "@/lib/utils";
 import { useDialogPortalContainer } from "@/components/ui/dialog";
 import { HugeiconsIcon } from "@hugeicons/react";
+import { getPortalHost } from "@/lib/portal-host";
 
 const SelectOpenContext = createContext(false);
 
@@ -121,7 +122,7 @@ function SelectContent({
 }) {
   const dialogContainer = useDialogPortalContainer();
   return (
-    <SelectPrimitive.Portal container={container ?? dialogContainer ?? undefined}>
+    <SelectPrimitive.Portal container={container ?? dialogContainer ?? getPortalHost()}>
       <SelectPrimitive.Content
         data-slot="select-content"
         data-align-trigger={position === "item-aligned"}

--- a/studio/frontend/src/components/ui/sheet.tsx
+++ b/studio/frontend/src/components/ui/sheet.tsx
@@ -10,6 +10,7 @@ import { DialogPortalContainerContext } from "@/components/ui/dialog";
 import { cn } from "@/lib/utils";
 import { Cancel01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
+import { getPortalHost } from "@/lib/portal-host";
 
 // Windows/Linux custom titlebar paints over the viewport at z-70, so a fixed
 // sheet must start below it. DesktopChromeVarsEffect mirrors the height onto
@@ -51,7 +52,13 @@ function SheetCloseButton({ className }: { className?: string }) {
 function SheetPortal({
   ...props
 }: React.ComponentProps<typeof SheetPrimitive.Portal>) {
-  return <SheetPrimitive.Portal data-slot="sheet-portal" {...props} />;
+  return (
+    <SheetPrimitive.Portal
+      data-slot="sheet-portal"
+      container={getPortalHost()}
+      {...props}
+    />
+  );
 }
 
 function SheetOverlay({

--- a/studio/frontend/src/components/ui/tooltip.tsx
+++ b/studio/frontend/src/components/ui/tooltip.tsx
@@ -19,6 +19,7 @@ import {
 } from "@/components/ui/tooltip-modal-layer";
 import { resolveTooltipOpen } from "@/components/ui/tooltip-open-state";
 import { cn } from "@/lib/utils";
+import { getPortalHost } from "@/lib/portal-host";
 
 type ToggleFn = () => void;
 const TooltipToggleCtx = createContext<ToggleFn | null>(null);
@@ -308,7 +309,7 @@ function TooltipContent({
     [ref, variant],
   );
   return (
-    <TooltipPrimitive.Portal>
+    <TooltipPrimitive.Portal container={getPortalHost()}>
       <TooltipPrimitive.Content
         ref={contentRef}
         data-slot="tooltip-content"

--- a/studio/frontend/src/features/chat/chat-settings-sheet.tsx
+++ b/studio/frontend/src/features/chat/chat-settings-sheet.tsx
@@ -58,6 +58,7 @@ import {
 import { useIsMobile } from "@/hooks/use-mobile";
 import { useT } from "@/i18n";
 import { ChevronDownStandardIcon } from "@/lib/chevron-icons";
+import { swallowDismissingClick } from "@/lib/menu-dismiss";
 import { toast } from "@/lib/toast";
 import { cn } from "@/lib/utils";
 import { Edit03Icon, LayoutAlignRightIcon } from "@hugeicons/core-free-icons";
@@ -1096,7 +1097,7 @@ export function ChatSettingsPanel({
           first={!hasModelContent && !modelConfig}
         >
           <div className="flex flex-col gap-3 pt-1">
-            <DropdownMenu>
+            <DropdownMenu modal={false}>
                   <DropdownMenuTrigger asChild={true}>
                 <div
                   className="w-full min-w-0 cursor-pointer outline-none focus-visible:outline-none"
@@ -1149,6 +1150,7 @@ export function ChatSettingsPanel({
                 </div>
               </DropdownMenuTrigger>
               <DropdownMenuContent
+                onPointerDownOutside={swallowDismissingClick}
                 align="start"
                 sideOffset={0}
                 className="menu-soft-surface ring-0 border-0 rounded-lg p-1.5"

--- a/studio/frontend/src/features/chat/components/project-switcher.tsx
+++ b/studio/frontend/src/features/chat/components/project-switcher.tsx
@@ -9,6 +9,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Folder01Icon } from "@hugeicons/core-free-icons";
+import { swallowDismissingClick } from "@/lib/menu-dismiss";
 import { Tick02Icon } from "@/lib/tick-icon";
 import { ChevronDownStandardIcon } from "@/lib/chevron-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
@@ -38,7 +39,7 @@ export function ProjectSwitcher({
   const [open, setOpen] = useState(false);
 
   return (
-    <DropdownMenu open={active && open} onOpenChange={(o) => setOpen(active && o)}>
+    <DropdownMenu open={active && open} onOpenChange={(o) => setOpen(active && o)} modal={false}>
       <DropdownMenuTrigger asChild={true}>
         <button
           type="button"
@@ -72,6 +73,7 @@ export function ProjectSwitcher({
         </button>
       </DropdownMenuTrigger>
       <DropdownMenuContent
+        onPointerDownOutside={swallowDismissingClick}
         side="bottom"
         align="start"
         sideOffset={0}

--- a/studio/frontend/src/features/chat/mcp-composer-button.tsx
+++ b/studio/frontend/src/features/chat/mcp-composer-button.tsx
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
+import { swallowDismissingClick } from "@/lib/menu-dismiss";
 import { Tick02Icon } from "@/lib/tick-icon";
 import { McpServerIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
@@ -242,6 +243,7 @@ export function McpComposerButton({
     <>
       {usable ? (
         <DropdownMenu
+          modal={false}
           open={menuOpen}
           onOpenChange={(open) => {
             setMenuOpen(open);
@@ -287,6 +289,7 @@ export function McpComposerButton({
             </button>
           </DropdownMenuTrigger>
           <DropdownMenuContent
+            onPointerDownOutside={swallowDismissingClick}
             side={side}
             align="start"
             sideOffset={0}

--- a/studio/frontend/src/features/chat/permission-mode-select.tsx
+++ b/studio/frontend/src/features/chat/permission-mode-select.tsx
@@ -24,6 +24,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { ChevronDownStandardIcon } from "@/lib/chevron-icons";
+import { swallowDismissingClick } from "@/lib/menu-dismiss";
 import { SparklesGlyph } from "@/lib/sparkles-icon";
 import { Tick02Icon } from "@/lib/tick-icon";
 import { cn } from "@/lib/utils";
@@ -195,7 +196,7 @@ export function PermissionModeDropdown({
 
   return (
     <>
-      <DropdownMenu>
+      <DropdownMenu modal={false}>
         <DropdownMenuTrigger asChild={true}>
           <Button
             variant="outline"
@@ -217,6 +218,7 @@ export function PermissionModeDropdown({
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent
+          onPointerDownOutside={swallowDismissingClick}
           side={side}
           align={align}
           className="w-[300px]"
@@ -263,7 +265,7 @@ export function PermissionModeComposerPill({
   const fullAccess = permissionMode === "full";
 
   return (
-    <DropdownMenu>
+    <DropdownMenu modal={false}>
       <DropdownMenuTrigger asChild={true}>
         <button
           type="button"
@@ -286,6 +288,7 @@ export function PermissionModeComposerPill({
         </button>
       </DropdownMenuTrigger>
       <DropdownMenuContent
+        onPointerDownOutside={swallowDismissingClick}
         side={side}
         align="start"
         sideOffset={0}

--- a/studio/frontend/src/features/chat/shared-composer.tsx
+++ b/studio/frontend/src/features/chat/shared-composer.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/components/assistant-ui/think-aria-label";
 import { Button } from "@/components/ui/button";
 import { BulbIcon } from "@/lib/bulb-icon";
+import { swallowDismissingClick } from "@/lib/menu-dismiss";
 import { MicIcon } from "@/lib/mic-icon";
 import { Tick02Icon } from "@/lib/tick-icon";
 import { cn } from "@/lib/utils";
@@ -2141,6 +2142,7 @@ export function SharedComposer({
           {/* Same + menu as single-chat (ComposerToolsMenu), wired to the
               compare composer's own file/audio inputs and tools. */}
           <DropdownMenu
+            modal={false}
             onOpenChange={(open) => {
               if (open) void refreshRecentPrompts();
             }}
@@ -2155,6 +2157,7 @@ export function SharedComposer({
               </button>
             </DropdownMenuTrigger>
             <DropdownMenuContent
+              onPointerDownOutside={swallowDismissingClick}
               side="top"
               align="start"
               sideOffset={0}
@@ -2405,7 +2408,7 @@ export function SharedComposer({
         <div className="ml-auto mr-0.5 flex items-center gap-1.5">
           {showReasoningControl ? (
             isEffort || supportsPreserveThinking ? (
-              <DropdownMenu>
+              <DropdownMenu modal={false}>
                 <DropdownMenuTrigger asChild={true}>
                   <button
                     type="button"
@@ -2434,6 +2437,7 @@ export function SharedComposer({
                   </button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent
+                  onPointerDownOutside={swallowDismissingClick}
                   side="top"
                   align="end"
                   className={cn(

--- a/studio/frontend/src/features/chat/thread-sidebar.tsx
+++ b/studio/frontend/src/features/chat/thread-sidebar.tsx
@@ -32,6 +32,7 @@ import {
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { swallowDismissingClick } from "@/lib/menu-dismiss";
 import {
   BookOpen02Icon,
   ColumnInsertIcon,
@@ -207,7 +208,7 @@ export function ThreadSidebar({
           {/* Recents label with export-all menu */}
           <div className="flex items-center justify-between px-2 py-1.5">
             <span className="text-xs font-medium text-muted-foreground/80">Recents</span>
-            <DropdownMenu>
+            <DropdownMenu modal={false}>
               <DropdownMenuTrigger asChild>
                 <button
                   type="button"
@@ -217,7 +218,7 @@ export function ThreadSidebar({
                   <HugeiconsIcon icon={MoreHorizontalIcon} className="size-3.5" />
                 </button>
               </DropdownMenuTrigger>
-              <DropdownMenuContent side="bottom" align="end" className="w-56">
+              <DropdownMenuContent side="bottom" align="end" className="w-56" onPointerDownOutside={swallowDismissingClick}>
                 <DropdownMenuSub>
                   <DropdownMenuSubTrigger>
                     <HugeiconsIcon icon={Download01Icon} className="mr-2 size-4" />
@@ -277,14 +278,14 @@ export function ThreadSidebar({
                     ) : null}
                     <span>{item.title}</span>
                   </SidebarMenuButton>
-                  <DropdownMenu>
+                  <DropdownMenu modal={false}>
                     <DropdownMenuTrigger asChild>
                       <SidebarMenuAction showOnHover className="focus:outline-none focus-visible:ring-0" onClick={(e) => e.stopPropagation()}>
                         <HugeiconsIcon icon={MoreHorizontalIcon} className="size-4" />
                         <span className="sr-only">More options</span>
                       </SidebarMenuAction>
                     </DropdownMenuTrigger>
-                    <DropdownMenuContent side="bottom" align="end" className="w-44">
+                    <DropdownMenuContent side="bottom" align="end" className="w-44" onPointerDownOutside={swallowDismissingClick}>
                       <DropdownMenuItem onSelect={() => openRename(item)}>
                         <HugeiconsIcon icon={PencilEdit02Icon} className="mr-2 size-4" />
                         Rename

--- a/studio/frontend/src/lib/menu-dismiss.ts
+++ b/studio/frontend/src/lib/menu-dismiss.ts
@@ -1,0 +1,36 @@
+/**
+ * Swallow the single click that dismisses an open non-modal Radix menu.
+ *
+ * Why these menus are `modal={false}` at all: a modal Radix layer parks
+ * `pointer-events: none` on `<body>` for as long as it is open. `pointer-events` is an
+ * INHERITED property, so that one write invalidates computed style for the entire
+ * mounted subtree underneath it. On a long chat thread that subtree is the thread, and
+ * opening a menu turns into a full-document style recalculation whose cost scales with
+ * the thread rather than with the menu.
+ *
+ * What that shield also did, incidentally, was absorb the click that dismisses the menu,
+ * so the first click outside only ever closed it. Dropping the shield brings back a real
+ * footgun: Radix's outside-pointerdown handler dismisses but never cancels the event, so
+ * one click on a control next to the menu both closes the menu and fires that control.
+ * In the assistant action bar the neighbours are "Refresh" and an unconfirmed
+ * "Delete message", two buttons from the trigger.
+ *
+ * Restoring only the swallow keeps dismissal costing exactly one click, as it always
+ * has, and costs no style invalidation: the listener is armed for the one click that
+ * immediately follows and is disarmed either by firing or by the timeout.
+ *
+ * Pass as `onPointerDownOutside` on the menu content.
+ */
+export const swallowDismissingClick = (): void => {
+  if (typeof document === "undefined") return;
+  const swallow = (event: Event): void => {
+    event.stopPropagation();
+    event.preventDefault();
+  };
+  document.addEventListener("click", swallow, { capture: true, once: true });
+  // A pointerdown that never becomes a click (a drag, a right click, a pointercancel)
+  // would otherwise leave the swallower armed and eat an unrelated later click.
+  window.setTimeout(() => {
+    document.removeEventListener("click", swallow, { capture: true });
+  }, 300);
+};

--- a/studio/frontend/src/lib/portal-host.ts
+++ b/studio/frontend/src/lib/portal-host.ts
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+/**
+ * One shared container for every Radix portal, so that React never attaches its delegated
+ * event listeners to `<body>`.
+ *
+ * WHY THIS EXISTS, AND WHAT IT IS NOT
+ *
+ * React attaches its full delegated event listener set to the container of every portal, the
+ * first time a portal targets it, and never removes it. Radix's `Portal` defaults its container
+ * to `document.body`. So the first time ANY menu, tooltip, popover, dialog or select opens,
+ * `document.body` acquires a second React event root -- and `<body>` is an ancestor of the whole
+ * application, so from then on every event anywhere in the app is dispatched twice, once at
+ * `#root` and once at `<body>`. Measured on the chat thread, `document.body` goes from 1 event
+ * listener type to 85 the first time a menu opens, and stays there for the life of the tab.
+ *
+ * THIS WAS BUILT AS A PERFORMANCE FIX AND IT IS NOT ONE. It was measured for exactly that and
+ * found to buy nothing. On chromium at 300K characters of thread (43,422 DOM nodes, 110 assistant
+ * messages), fresh page per arm, medians of 3, the same 20-step scroll gesture after a menu:
+ *
+ *     without this change   1543.6 ms, 11 frames over 33 ms, 11 long tasks
+ *     with this change      1527.0 ms, 11 frames over 33 ms, 11 long tasks
+ *
+ * and the trace's caller attribution is the same on both sides, 36 React commits at
+ * react-dom_client.js:9077. The census does move, 85 listener types back to 1, so the change does
+ * what it says. The cost simply was not coming from there: it is driven by the element under a
+ * stationary cursor changing as content scrolls past it, which is live work and has nothing to do
+ * with which container a portal uses. See the correction section in
+ * tests/studio/playwright_heavy_thread.py.
+ *
+ * So the case for this file is hygiene, not speed: one app-wide React event root instead of two,
+ * and floating surfaces that stop double-dispatching every event in the application. Do not cite
+ * it in a performance claim.
+ *
+ * WHY A `display: contents` DIV AND NOT `#root`
+ *
+ * Portaling into `#root` instead would also avoid the body root, but it puts every floating
+ * surface inside the application's own layout and stacking context, where any ancestor carrying
+ * `transform`, `filter`, `backdrop-filter`, `perspective` or `contain` becomes the containing
+ * block for `position: fixed` popper wrappers and clips them. This tree has all of those.
+ *
+ * A dedicated div appended to `<body>` keeps the portal content in exactly the position in the
+ * box tree it already had, and `display: contents` means the host generates no box at all, so
+ * its children participate in the body stacking context precisely as they did when Radix
+ * appended them to `<body>` directly. React attaches its listener set to this div rather than to
+ * `<body>`, and a div that is a leaf of `<body>` only ever sees events from the floating surface
+ * inside it, which is a menu rather than a 43,422-node thread.
+ */
+
+const HOST_ID = "unsloth-portal-host";
+
+let cached: HTMLElement | null = null;
+
+/**
+ * The shared portal container, created on first use.
+ *
+ * Returns `undefined` rather than throwing when there is no document, so that a caller can spread
+ * it into a Radix `Portal` unconditionally: `container={undefined}` is what Radix already
+ * defaults to, so server rendering and tests keep the old behaviour instead of crashing.
+ *
+ * The `isConnected` check is load-bearing rather than defensive. A test that swaps the document
+ * body, and the thread fixture that mounts a fresh tree per case, both leave the cached node
+ * detached, and a detached container renders the menu into nothing at all -- which looks exactly
+ * like a menu that failed to open.
+ */
+export const getPortalHost = (): HTMLElement | undefined => {
+  if (typeof document === "undefined") return undefined;
+  if (cached?.isConnected) return cached;
+  const existing = document.getElementById(HOST_ID);
+  if (existing instanceof HTMLElement) {
+    cached = existing;
+    return cached;
+  }
+  const host = document.createElement("div");
+  host.id = HOST_ID;
+  // No box of its own: see the note above on stacking fidelity.
+  host.style.display = "contents";
+  document.body.appendChild(host);
+  cached = host;
+  return cached;
+};

--- a/studio/frontend/tsconfig.app.json
+++ b/studio/frontend/tsconfig.app.json
@@ -32,6 +32,7 @@
     "src",
     "smoke-ansi-main.tsx",
     "smoke-autoscroll-main.tsx",
-    "smoke-research-main.tsx"
+    "smoke-research-main.tsx",
+    "smoke-heavy-thread-main.tsx"
   ]
 }

--- a/tests/studio/playwright_heavy_thread.py
+++ b/tests/studio/playwright_heavy_thread.py
@@ -76,6 +76,20 @@ Run:
 It starts and stops its own vite dev server. Point it at one you already have with
 SMOKE_BASE_URL, or move the port it picks with SMOKE_PORT.
 
+RUN ONE ENGINE PER INVOCATION IN CI, UNDER AN EXTERNAL TIMEOUT. Measured on a macos-14 runner:
+Chromium finished all three sizes in 90 seconds, and then Playwright's WebKit wedged at the
+smallest size and never came back. `page.evaluate` and `browser.new_page` have no timeout of
+their own, and a SIGALRM does not help, because Playwright's sync API blocks the main thread
+inside a greenlet and the exception lands in the driver rather than in the caller. The only
+bound that works is the process one, so drive the engines as separate invocations:
+
+    for engine in chromium webkit firefox; do
+      SMOKE_HEAVY_ENGINES=$engine SMOKE_LABEL=run-$engine timeout 1800 \\
+        python -u tests/studio/playwright_heavy_thread.py || echo "$engine did not finish"
+    done
+
+One wedged engine then costs one engine's column instead of the whole matrix.
+
 The dev server is deliberate and is a limitation to read the numbers against: React runs in
 development mode, nothing is minified, and vite serves unbundled modules. Absolute milliseconds
 are therefore higher than a packaged Studio's. The curve across sizes and the ranking across
@@ -139,7 +153,6 @@ ACTION_TIMEOUT_MS = int(os.environ.get("SMOKE_ACTION_TIMEOUT_MS", "120000"))
 # action that never happened and nothing else, so it has to stay well above the slowest honest
 # measurement or a very slow open is reported as "never opened".
 SETTLE_TIMEOUT_MS = int(os.environ.get("SMOKE_SETTLE_TIMEOUT_MS", "120000"))
-
 ACTIONS = ("keystroke", "scroll", "jump", "menu", "delete", "reopen")
 
 # Installed into every page before anything else runs.

--- a/tests/studio/playwright_heavy_thread.py
+++ b/tests/studio/playwright_heavy_thread.py
@@ -83,12 +83,25 @@ their own, and a SIGALRM does not help, because Playwright's sync API blocks the
 inside a greenlet and the exception lands in the driver rather than in the caller. The only
 bound that works is the process one, so drive the engines as separate invocations:
 
+    bounded() {                       # not `timeout`: macOS runners do not ship coreutils, and
+      local secs=$1; shift            # `timeout: command not found` fails the step instantly
+      "$@" & local pid=$!
+      ( sleep "$secs"; kill -TERM $pid 2>/dev/null; sleep 15; kill -KILL $pid 2>/dev/null ) &
+      local watcher=$!
+      wait $pid; local rc=$?
+      kill -TERM $watcher 2>/dev/null
+      return $rc
+    }
+    port=5215
     for engine in chromium webkit firefox; do
-      SMOKE_HEAVY_ENGINES=$engine SMOKE_LABEL=run-$engine timeout 1800 \\
-        python -u tests/studio/playwright_heavy_thread.py || echo "$engine did not finish"
+      SMOKE_HEAVY_ENGINES=$engine SMOKE_PORT=$port SMOKE_LABEL=run-$engine \\
+        bounded 1800 python -u tests/studio/playwright_heavy_thread.py \\
+        || echo "$engine did not finish"
+      port=$((port + 1))
     done
 
-One wedged engine then costs one engine's column instead of the whole matrix.
+One wedged engine then costs one engine's column instead of the whole matrix. Each invocation
+needs its own port: a killed run can leave its vite dev server holding the previous one.
 
 The dev server is deliberate and is a limitation to read the numbers against: React runs in
 development mode, nothing is minified, and vite serves unbundled modules. Absolute milliseconds

--- a/tests/studio/playwright_heavy_thread.py
+++ b/tests/studio/playwright_heavy_thread.py
@@ -883,7 +883,20 @@ def run() -> dict:
             )
             for size in SIZES:
                 info(f"measuring {engine} at {size} chars")
-                cell = measure_cell(context, engine, size)
+                # A renderer that dies mid-cell used to take the whole matrix with it: nine cells
+                # of work thrown away because one WebKit page ran out of memory at 300K on a
+                # loaded machine. The cell is recorded as crashed, the run continues, and
+                # harness_failures reports it -- a crash is still a failure, it is just no longer
+                # a failure that destroys the eight measurements that did work.
+                try:
+                    cell = measure_cell(context, engine, size)
+                except Exception as exc:  # noqa: BLE001 - the message is the whole point
+                    info(f"CRASHED {engine} at {size} chars: {type(exc).__name__}: {exc}")
+                    cell = {
+                        "chars_requested": size,
+                        "engine": engine,
+                        "crashed": f"{type(exc).__name__}: {exc}"[:400],
+                    }
                 results["by_engine"][engine]["by_size"][str(size)] = cell
             context.close()
             browser.close()
@@ -1164,6 +1177,9 @@ def harness_failures(results: dict, report: dict) -> list[str]:
         for size in results["sizes"]:
             row = results["by_engine"][engine]["by_size"][str(size)]
             where = f"{engine} at {size} chars"
+            if "crashed" in row:
+                failures.append(f"{where} crashed before it produced a measurement: {row['crashed']}")
+                continue
             counts = row["counts"]
             plan = row["plan"]
             # A request reaching the server is a round trip to another process inside a region
@@ -1306,10 +1322,12 @@ def harness_failures(results: dict, report: dict) -> list[str]:
         # cost wildly different amounts. Either is a legitimate tree, but a run that mixes them
         # across sizes is comparing columns measured on different mechanisms.
         layers = {
-            results["by_engine"][engine]["by_size"][str(size)]["actions"]["menu"].get(
-                "bodyPointerEvents"
-            )
+            results["by_engine"][engine]["by_size"][str(size)]
+            .get("actions", {})
+            .get("menu", {})
+            .get("bodyPointerEvents")
             for size in results["sizes"]
+            if "crashed" not in results["by_engine"][engine]["by_size"][str(size)]
         }
         if len(layers) > 1:
             failures.append(

--- a/tests/studio/playwright_heavy_thread.py
+++ b/tests/studio/playwright_heavy_thread.py
@@ -599,6 +599,30 @@ def reset_long_tasks(page) -> None:
     page.evaluate("window.__longTasks.length = 0")
 
 
+def wait_for_highlighting_settled(page, timeout_ms: int) -> None:
+    """Block until Shiki has stopped adding tokens.
+
+    FIVE stable reads a quarter of a second apart, not two consecutive ones. Two adjacent
+    rAF-polled reads land inside the lull between two async highlight batches all the time:
+    measured on WebKit, a two-read version released the gate at 577 highlighted tokens where the
+    finished thread has 3216, so the whole engine column was measured against a thread that was
+    still building itself.
+    """
+    page.evaluate("() => { window.__hvTokens = undefined; }")
+    page.wait_for_function(
+        """() => {
+            const n = window.__heavyThread.highlightedTokenCount();
+            const state = window.__hvTokens || { value: -1, stable: 0 };
+            if (n === state.value && n > 0) state.stable += 1;
+            else { state.value = n; state.stable = 0; }
+            window.__hvTokens = state;
+            return state.stable >= 5;
+        }""",
+        polling = 250,
+        timeout = timeout_ms,
+    )
+
+
 def run_action(page, cdp, name: str, script: str, arg) -> dict:
     """One action, with the portable recorder inside it and the CDP counters bracketing it."""
     reset_long_tasks(page)
@@ -618,6 +642,12 @@ def run_action(page, cdp, name: str, script: str, arg) -> dict:
 def one_repetition(page, cdp) -> dict[str, dict]:
     """The five scripted actions, once, in the order a user meets them."""
     rep: dict[str, dict] = {}
+    # The previous repetition ended by re-opening the thread, which throws away every highlighted
+    # fence and starts Shiki again. Without this wait, repetitions 2 and 3 measure a thread that
+    # is still building itself: measured on Chromium at 300K, the scroll gesture read 667ms on
+    # the first repetition and 1100ms on the two that followed, and the difference was the
+    # re-highlighting, not the scroll.
+    wait_for_highlighting_settled(page, ACTION_TIMEOUT_MS)
     # Re-open unmounts the thread, and an uncontrolled Radix collapsible comes back closed, so
     # without this every repetition after the first would run against a thread with no tool
     # result panes in it -- a different, cheaper fixture wearing the same label. Idempotent: on
@@ -760,24 +790,7 @@ def measure_cell(context, engine: str, size: int) -> dict:
         # Shiki is async and per block, and a <pre> exists before it is highlighted, so counting
         # code blocks gates nothing. Wait for the token count to stop moving instead: unfinished
         # highlighting would otherwise land in the keystroke window, the first action measured.
-        #
-        # FIVE stable reads a quarter of a second apart, not two consecutive ones. Two adjacent
-        # rAF-polled reads land inside the lull between two async highlight batches all the time:
-        # measured on WebKit, the two-read version released the gate at 577 highlighted tokens
-        # where the finished thread has 3216, so the whole engine column was measured against a
-        # thread that was still building itself.
-        page.wait_for_function(
-            """() => {
-                const n = window.__heavyThread.highlightedTokenCount();
-                const state = window.__hvTokens || { value: -1, stable: 0 };
-                if (n === state.value && n > 0) state.stable += 1;
-                else { state.value = n; state.stable = 0; }
-                window.__hvTokens = state;
-                return state.stable >= 5;
-            }""",
-            polling = 250,
-            timeout = SEED_TIMEOUT_MS,
-        )
+        wait_for_highlighting_settled(page, SEED_TIMEOUT_MS)
         result["counts"] = page.evaluate("window.__heavyThread.counts()")
         result["viewport"] = page.evaluate("window.__heavyThread.viewportMetrics()")
         result["seed_api_requests"] = len(stray_requests)
@@ -1012,6 +1025,10 @@ GROWTH_AXES = tuple(
 # to twelve times the content. That is not a flat curve, it is an axis that is not measuring the
 # thing being varied.
 DISCRIMINATION_RATIO = float(os.environ.get("SMOKE_DISCRIMINATION_RATIO", "1.5"))
+# Constant engine chatter is tolerated up to this many warnings per size; anything above it, or
+# any count that rises with the thread, fails the run. Gecko's two scroll-anchoring notices are
+# what this number exists for.
+CONSOLE_WARNING_ALLOWANCE = int(os.environ.get("SMOKE_CONSOLE_WARNING_ALLOWANCE", "2"))
 
 
 def growth(cells: dict, pick, floored: bool, sizes: list[int]) -> tuple[float | None, float | None]:
@@ -1102,10 +1119,26 @@ def harness_failures(results: dict, report: dict) -> list[str]:
                     f"{where} let {row['stray_api_requests']} /api/ requests reach the network "
                     "during the measured actions; the timings include a round trip per request"
                 )
-            if row["console_warnings"]:
+            # A warning count that GROWS with the thread is the app talking, once per message,
+            # and it is serialised over the debugging channel from inside a timed region, so it
+            # would forge the curve. A count that is identical at every size is the engine
+            # talking about itself: Firefox 153 emits exactly two "Scroll anchoring was disabled
+            # in a scroll container" notices per run, at 25K and at 300K alike, and failing on
+            # those would mean this harness could never report a Gecko number at all. Both are
+            # printed either way.
+            smallest = results["by_engine"][engine]["by_size"][str(results["sizes"][0])]
+            if row["console_warnings"] > smallest["console_warnings"]:
                 failures.append(
                     f"{where} logged {row['console_warnings']} console warnings during the "
-                    f"measured actions, the first being {row['first_console_warning']!r}"
+                    f"measured actions against {smallest['console_warnings']} at the smallest "
+                    f"size, the first being {row['first_console_warning']!r}; a count that grows "
+                    "with the thread is charged to the app once per message"
+                )
+            elif row["console_warnings"] > CONSOLE_WARNING_ALLOWANCE:
+                failures.append(
+                    f"{where} logged {row['console_warnings']} console warnings during the "
+                    f"measured actions, the first being {row['first_console_warning']!r}; that is "
+                    f"more than the {CONSOLE_WARNING_ALLOWANCE} allowed for engine chatter"
                 )
             if plan["chars"] < size * 0.9:
                 failures.append(

--- a/tests/studio/playwright_heavy_thread.py
+++ b/tests/studio/playwright_heavy_thread.py
@@ -230,7 +230,14 @@ RECORDER_INIT = """
         stalls_over_33: stalls.filter((ms) => ms > 33).length,
       };
     },
-    /** Frames until the page goes quiet again: what "it is still catching up" costs a user. */
+    /**
+     * Time to settle, measured from the START of the action, not from the end of the input.
+     *
+     * Measured from the end of the gesture it reads ~50ms at every size on every engine, because
+     * the answer is then "three frames", which is the minimum this loop can return. From the
+     * start of the action it is what a user actually waits: the input, plus everything the page
+     * does afterwards before it is calm again.
+     */
     async quiet(timeoutMs) {
       const started = performance.now();
       let calm = 0;
@@ -240,7 +247,7 @@ RECORDER_INIT = """
         const now = performance.now();
         calm = now - last > 33 ? 0 : calm + 1;
         last = now;
-        if (calm >= 3) return performance.now() - started;
+        if (calm >= 3) return performance.now() - this.startedAt;
       }
       return null;
     },
@@ -1025,10 +1032,10 @@ GROWTH_AXES = tuple(
 # to twelve times the content. That is not a flat curve, it is an axis that is not measuring the
 # thing being varied.
 DISCRIMINATION_RATIO = float(os.environ.get("SMOKE_DISCRIMINATION_RATIO", "1.5"))
-# Constant engine chatter is tolerated up to this many warnings per size; anything above it, or
-# any count that rises with the thread, fails the run. Gecko's two scroll-anchoring notices are
-# what this number exists for.
-CONSOLE_WARNING_ALLOWANCE = int(os.environ.get("SMOKE_CONSOLE_WARNING_ALLOWANCE", "2"))
+# Engine chatter is tolerated up to this many warnings per size. Gecko's two scroll-anchoring
+# notices are what this number exists for; anything the app emits per message would be two orders
+# of magnitude above it at 220 messages.
+CONSOLE_WARNING_ALLOWANCE = int(os.environ.get("SMOKE_CONSOLE_WARNING_ALLOWANCE", "4"))
 
 
 def growth(cells: dict, pick, floored: bool, sizes: list[int]) -> tuple[float | None, float | None]:
@@ -1060,9 +1067,20 @@ def report_growth(results: dict) -> dict[str, dict[str, dict]]:
                                   "discriminated": False, "reason": "not recorded"}
                 continue
             if small <= 0:
-                # A count that is 0 at the smallest size and 4 at the largest has no ratio and
-                # has still answered the question. Treated as discriminating only when it really
-                # rose: 0 -> 0 is the flattest result there is.
+                # A COUNT that is 0 at the smallest size and 4 at the largest has no ratio and has
+                # still answered the question, so it counts as discriminating when it really rose.
+                #
+                # A TIMING does not get that credit. `floored` means the value had the ~33ms vsync
+                # floor subtracted from it, so a zero or negative here says the action resolved at
+                # or under one frame at the smallest size, which is a metric with no room to move
+                # rather than a metric that grew from nothing.
+                if floored:
+                    per_axis[name] = {
+                        "small": small, "large": large, "ratio": None, "discriminated": False,
+                        "reason": "at or under the paint floor at the smallest size",
+                        "floored": floored,
+                    }
+                    continue
                 rose = large > small
                 per_axis[name] = {
                     "small": small, "large": large, "ratio": None,
@@ -1119,26 +1137,21 @@ def harness_failures(results: dict, report: dict) -> list[str]:
                     f"{where} let {row['stray_api_requests']} /api/ requests reach the network "
                     "during the measured actions; the timings include a round trip per request"
                 )
-            # A warning count that GROWS with the thread is the app talking, once per message,
-            # and it is serialised over the debugging channel from inside a timed region, so it
-            # would forge the curve. A count that is identical at every size is the engine
-            # talking about itself: Firefox 153 emits exactly two "Scroll anchoring was disabled
-            # in a scroll container" notices per run, at 25K and at 300K alike, and failing on
-            # those would mean this harness could never report a Gecko number at all. Both are
-            # printed either way.
-            smallest = results["by_engine"][engine]["by_size"][str(results["sizes"][0])]
-            if row["console_warnings"] > smallest["console_warnings"]:
-                failures.append(
-                    f"{where} logged {row['console_warnings']} console warnings during the "
-                    f"measured actions against {smallest['console_warnings']} at the smallest "
-                    f"size, the first being {row['first_console_warning']!r}; a count that grows "
-                    "with the thread is charged to the app once per message"
-                )
-            elif row["console_warnings"] > CONSOLE_WARNING_ALLOWANCE:
+            # Console output from inside a timed region is serialised over the debugging channel,
+            # so a warning the app emits once per message would both cost time and grow like the
+            # signal. The instrument for that is an ABSOLUTE cap, not a growth check: at 220
+            # messages a per-message warning is in the hundreds, while what an engine says about
+            # itself is a handful. Firefox 153 emits exactly two "Scroll anchoring was disabled
+            # in a scroll container" notices once the container is large enough, which is zero at
+            # 25K and two at both 100K and 300K -- a growth check fails on that and would leave
+            # this harness unable to report a Gecko number at all. The count and the first
+            # message are printed per size either way, so a reader can see what was tolerated.
+            if row["console_warnings"] > CONSOLE_WARNING_ALLOWANCE:
                 failures.append(
                     f"{where} logged {row['console_warnings']} console warnings during the "
                     f"measured actions, the first being {row['first_console_warning']!r}; that is "
-                    f"more than the {CONSOLE_WARNING_ALLOWANCE} allowed for engine chatter"
+                    f"more than the {CONSOLE_WARNING_ALLOWANCE} allowed for engine chatter, so "
+                    "the timings include work this harness is charging to the app"
                 )
             if plan["chars"] < size * 0.9:
                 failures.append(

--- a/tests/studio/playwright_heavy_thread.py
+++ b/tests/studio/playwright_heavy_thread.py
@@ -112,8 +112,14 @@ OUT.mkdir(parents = True, exist_ok = True)
 # Characters of thread content, not messages. Sorted: the growth check reads the first and last
 # entries as smallest and largest, so an unsorted override would invert every ratio and report a
 # good run as measuring nothing.
-SIZES = sorted(int(n) for n in os.environ.get("SMOKE_HEAVY_CHARS", "25000,100000,300000").split(","))
-ENGINES = [e.strip() for e in os.environ.get("SMOKE_HEAVY_ENGINES", "chromium,webkit,firefox").split(",") if e.strip()]
+SIZES = sorted(
+    int(n) for n in os.environ.get("SMOKE_HEAVY_CHARS", "25000,100000,300000").split(",")
+)
+ENGINES = [
+    e.strip()
+    for e in os.environ.get("SMOKE_HEAVY_ENGINES", "chromium,webkit,firefox").split(",")
+    if e.strip()
+]
 # Every action set is run this many times on the seeded page and the table reports the MEDIAN.
 # The first repetition is systematically the slowest (cold Shiki cache, cold layout), which is
 # exactly why the headline is a median rather than a mean or a single shot.
@@ -563,8 +569,11 @@ def cdp_counters(before: dict[str, float], after: dict[str, float]) -> dict[str,
     """CHROMIUM-ONLY. Empty dicts off Chromium, and every consumer prints `-` for that."""
     if not before or not after:
         return {
-            "layout_count": None, "recalc_style_count": None,
-            "layout_ms": None, "recalc_style_ms": None, "task_ms": None,
+            "layout_count": None,
+            "recalc_style_count": None,
+            "layout_ms": None,
+            "recalc_style_ms": None,
+            "task_ms": None,
         }
 
     def d(name: str) -> float:
@@ -668,7 +677,11 @@ def one_repetition(page, cdp) -> dict[str, dict]:
         )
     rep["keystroke"] = run_action(page, cdp, "keystroke", KEYSTROKE_JS, KEYSTROKES)
     rep["scroll"] = run_action(
-        page, cdp, "scroll", SCROLL_JS, [SCROLL_STEPS, SCROLL_STEP_PX, SETTLE_TIMEOUT_MS],
+        page,
+        cdp,
+        "scroll",
+        SCROLL_JS,
+        [SCROLL_STEPS, SCROLL_STEP_PX, SETTLE_TIMEOUT_MS],
     )
     rep["jump"] = run_action(page, cdp, "jump", JUMP_JS, SETTLE_TIMEOUT_MS)
 
@@ -695,7 +708,11 @@ def one_repetition(page, cdp) -> dict[str, dict]:
     rep["delete"] = run_action(page, cdp, "delete", DELETE_JS, SETTLE_TIMEOUT_MS)
 
     rep["reopen"] = run_action(
-        page, cdp, "reopen", REOPEN_JS, [SETTLE_TIMEOUT_MS, SETTLE_TIMEOUT_MS],
+        page,
+        cdp,
+        "reopen",
+        REOPEN_JS,
+        [SETTLE_TIMEOUT_MS, SETTLE_TIMEOUT_MS],
     )
     return rep
 
@@ -786,9 +803,7 @@ def measure_cell(context, engine: str, size: int) -> dict:
         # Radix unmounts collapsed content, so a thread of closed tool cards carries no result
         # panes at all. Open them before the census: a user who has just watched those tools run
         # is looking at them open, and the closed thread is a different fixture.
-        result["tool_triggers_expanded"] = page.evaluate(
-            "() => window.__heavyThread.expandTools()"
-        )
+        result["tool_triggers_expanded"] = page.evaluate("() => window.__heavyThread.expandTools()")
         page.wait_for_function(
             "(n) => window.__heavyThread.counts().collapsibleOutputs >= n",
             arg = max(1, result["tool_triggers_expanded"]),
@@ -861,7 +876,9 @@ def run() -> dict:
             context.route(
                 re.compile(rf"^{re.escape(BASE)}/api/"),
                 lambda route: route.fulfill(
-                    status = 200, content_type = "application/json", body = "{}",
+                    status = 200,
+                    content_type = "application/json",
+                    body = "{}",
                 ),
             )
             for size in SIZES:
@@ -940,21 +957,26 @@ for _name in ACTIONS:
 TABLE_ROWS = TABLE_ROWS + (
     ("keystroke median ms", _action("keystroke", "median_sample_ms")),
     ("keystroke worst ms", _action("keystroke", "worst_sample_ms")),
-    ("keystroke per repetition", lambda r: "/".join(
-        str(v) for v in r["actions"]["keystroke"]["per_repetition"]
-    )),
-    ("scroll per repetition", lambda r: "/".join(
-        str(v) for v in r["actions"]["scroll"]["per_repetition"]
-    )),
-    ("menu per repetition", lambda r: "/".join(
-        str(v) for v in r["actions"]["menu"]["per_repetition"]
-    )),
-    ("delete per repetition", lambda r: "/".join(
-        str(v) for v in r["actions"]["delete"]["per_repetition"]
-    )),
-    ("reopen per repetition", lambda r: "/".join(
-        str(v) for v in r["actions"]["reopen"]["per_repetition"]
-    )),
+    (
+        "keystroke per repetition",
+        lambda r: "/".join(str(v) for v in r["actions"]["keystroke"]["per_repetition"]),
+    ),
+    (
+        "scroll per repetition",
+        lambda r: "/".join(str(v) for v in r["actions"]["scroll"]["per_repetition"]),
+    ),
+    (
+        "menu per repetition",
+        lambda r: "/".join(str(v) for v in r["actions"]["menu"]["per_repetition"]),
+    ),
+    (
+        "delete per repetition",
+        lambda r: "/".join(str(v) for v in r["actions"]["delete"]["per_repetition"]),
+    ),
+    (
+        "reopen per repetition",
+        lambda r: "/".join(str(v) for v in r["actions"]["reopen"]["per_repetition"]),
+    ),
     ("keystroke dom text", _action("keystroke", "domText")),
     ("keystroke runtime text", _action("keystroke", "runtimeText")),
     ("scroll gesture ms", _action("scroll", "gestureMs")),
@@ -984,9 +1006,7 @@ TABLE_ROWS = TABLE_ROWS + (
 
 def print_table(results: dict) -> None:
     """Every recorded metric, printed, one column per (engine, size)."""
-    columns = [
-        (engine, str(size)) for engine in results["engines"] for size in results["sizes"]
-    ]
+    columns = [(engine, str(size)) for engine in results["engines"] for size in results["sizes"]]
     rows = []
     for name, pick in TABLE_ROWS:
         cells = []
@@ -1063,8 +1083,13 @@ def report_growth(results: dict) -> dict[str, dict[str, dict]]:
         for name, pick, floored in GROWTH_AXES:
             small, large = growth(cells, pick, floored, results["sizes"])
             if small is None or large is None:
-                per_axis[name] = {"small": None, "large": None, "ratio": None,
-                                  "discriminated": False, "reason": "not recorded"}
+                per_axis[name] = {
+                    "small": None,
+                    "large": None,
+                    "ratio": None,
+                    "discriminated": False,
+                    "reason": "not recorded",
+                }
                 continue
             if small <= 0:
                 # A COUNT that is 0 at the smallest size and 4 at the largest has no ratio and has
@@ -1076,14 +1101,19 @@ def report_growth(results: dict) -> dict[str, dict[str, dict]]:
                 # rather than a metric that grew from nothing.
                 if floored:
                     per_axis[name] = {
-                        "small": small, "large": large, "ratio": None, "discriminated": False,
+                        "small": small,
+                        "large": large,
+                        "ratio": None,
+                        "discriminated": False,
                         "reason": "at or under the paint floor at the smallest size",
                         "floored": floored,
                     }
                     continue
                 rose = large > small
                 per_axis[name] = {
-                    "small": small, "large": large, "ratio": None,
+                    "small": small,
+                    "large": large,
+                    "ratio": None,
                     "discriminated": rose,
                     "reason": "rose from zero" if rose else "zero at both ends",
                     "floored": floored,
@@ -1091,7 +1121,9 @@ def report_growth(results: dict) -> dict[str, dict[str, dict]]:
                 continue
             ratio = round(large / small, 2)
             per_axis[name] = {
-                "small": small, "large": large, "ratio": ratio,
+                "small": small,
+                "large": large,
+                "ratio": ratio,
                 "discriminated": ratio > DISCRIMINATION_RATIO,
                 "reason": "-",
                 "floored": floored,
@@ -1103,20 +1135,25 @@ def report_growth(results: dict) -> dict[str, dict[str, dict]]:
 def print_growth(results: dict, report: dict) -> None:
     for engine, per_axis in report.items():
         info("")
-        info(f"growth on {engine} ({results['sizes'][0]} -> {results['sizes'][-1]} chars, "
-             f"median of {results['repetitions']} repetitions)")
+        info(
+            f"growth on {engine} ({results['sizes'][0]} -> {results['sizes'][-1]} chars, "
+            f"median of {results['repetitions']} repetitions)"
+        )
         for name, row in per_axis.items():
             if row["ratio"] is None:
                 mark = "DISCRIMINATES" if row["discriminated"] else "flat"
                 small = "-" if row["small"] is None else row["small"]
                 large = "-" if row["large"] is None else row["large"]
-                info(f"  {name:<34} {small:>10} -> {large:>10}       -  "
-                     f"{mark} ({row['reason']})")
+                info(
+                    f"  {name:<34} {small:>10} -> {large:>10}       -  " f"{mark} ({row['reason']})"
+                )
                 continue
             mark = "DISCRIMINATES" if row["discriminated"] else "flat"
             floor_note = " (paint floor removed)" if row.get("floored") else ""
-            info(f"  {name:<34} {row['small']:>10} -> {row['large']:>10}  "
-                 f"{row['ratio']:>6.2f}x  {mark}{floor_note}")
+            info(
+                f"  {name:<34} {row['small']:>10} -> {row['large']:>10}  "
+                f"{row['ratio']:>6.2f}x  {mark}{floor_note}"
+            )
 
 
 def harness_failures(results: dict, report: dict) -> list[str]:
@@ -1183,7 +1220,9 @@ def harness_failures(results: dict, report: dict) -> list[str]:
                 failures.append(f"{where} highlighted nothing; Shiki never ran")
             viewport = row["viewport"]
             if viewport["scrollHeight"] <= viewport["clientHeight"]:
-                failures.append(f"{where} does not overflow its viewport; the scroll measures nothing")
+                failures.append(
+                    f"{where} does not overflow its viewport; the scroll measures nothing"
+                )
 
             actions = row["actions"]
             for name in ACTIONS:
@@ -1237,7 +1276,9 @@ def harness_failures(results: dict, report: dict) -> list[str]:
                 elif menu["closeMs"] is None:
                     failures.append(f"{where} opened the action menu and it never closed")
                 elif menu["bodyPointerEventsAfterClose"] == "none":
-                    failures.append(f"{where} left the body on the modal layer after closing the menu")
+                    failures.append(
+                        f"{where} left the body on the modal layer after closing the menu"
+                    )
                 # An empty popover satisfies "the menu opened" and costs nothing to render.
                 elif not menu["itemsWhileOpen"]:
                     failures.append(f"{where} opened an action menu with no items in it")

--- a/tests/studio/playwright_heavy_thread.py
+++ b/tests/studio/playwright_heavy_thread.py
@@ -1,0 +1,1283 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Where a HEAVY thread stalls, as a curve over how much content the thread holds.
+
+Users report Studio and Desktop going sluggish "after long generations with any code cells
+and/or text": typing, scrolling, opening a message menu, deleting and re-opening the thread all
+lag once a session has accumulated a few very long replies. That report is about CONTENT VOLUME,
+not message count, so the axis here is characters of thread content, not messages, and the
+fixture is the mix the report names rather than one paragraph repeated:
+
+    long prose, several large code fences, tool calls with collapsible output, an HTML artifact,
+    a code-execution result pane, an HTML canvas artifact and inline images.
+
+studio/frontend/smoke-heavy-thread.html mounts the REAL Thread with that content, so what is
+timed is the app's own renderer.
+
+WHAT IS MEASURED, AND WHY THESE METRICS
+
+Every primary number here is DOM-observable and wall-clock, because the interesting engines are
+not Chromium. Unsloth Desktop is Tauri: WebView2 on Windows, WKWebView on macOS, WebKitGTK on
+Linux. The Long Tasks API does not exist on JavaScriptCore, so a `longtask` PerformanceObserver
+silently reports NOTHING on Desktop macOS and Desktop Linux -- it does not error, it just never
+fires, which reads as "no jank" instead of "no measurement". `Performance.getMetrics` and
+`Emulation.setCPUThrottlingRate` are CDP, so they do not exist off Chromium either.
+
+So the primary four, all portable:
+
+    longest stall ms   the largest gap between consecutive ticks of a 1ms setTimeout loop. This
+                       is the portable stand-in for a long task: the main thread cannot answer
+                       the timer while it is busy, so the gap IS the block. Accurate to the
+                       timer clamp (~4ms), which is far below anything a user notices.
+    worst frame ms     the largest gap between consecutive requestAnimationFrame callbacks.
+    frames over 33ms   how many frames in the action missed two vsyncs at 60Hz. A single worst
+                       frame can be an outlier; a count says how much of the gesture was rough.
+    wall ms            how long the action took end to end, and for the gestures that keep
+                       working after the input stops, a separate settle time.
+
+A MessageChannel ping-pong is the usual way to build the stall detector and it was measured and
+rejected here: it spins ~150k times a second, and on Firefox that HALVED the frame rate of the
+page under test (38 frames -> 14, median frame 17ms -> 34ms) before any Studio code ran. The
+1ms setTimeout loop ticks ~150 times a second, costs nothing measurable on any of the three
+engines, and reported the same 120ms synthetic stall on all three.
+
+CDP counters (LayoutCount, RecalcStyleCount, LayoutDuration, RecalcStyleDuration, TaskDuration)
+and the longtask observer are ALSO recorded, and every one of them is labelled CHROMIUM-ONLY in
+the table. They attribute cost to layout versus script, which nothing portable does. They are
+never the headline.
+
+ENGINES
+
+    chromium   proxy for WebView2, i.e. Unsloth Desktop on Windows.
+    webkit     proxy for WKWebView and WebKitGTK, i.e. Unsloth Desktop on macOS and Linux.
+    firefox    control. Not shipped by anything here; it is in the table so that a number which
+               moves on one engine only can be told apart from a number that moves everywhere.
+
+Playwright's WebKit is a PROXY, not the webview Desktop embeds. It is Apple's WebKit built for
+Playwright, driven headless, with no Tauri IPC layer and no WebKitGTK compositor. Read it as
+"JavaScriptCore plus WebKit layout", not as "Unsloth Desktop on macOS".
+
+Desktop Linux under Wayland is WORSE than any number this file can produce, and not by a little:
+studio/src-tauri/src/linux_webkit.rs sets WEBKIT_DMABUF_RENDERER_FORCE_SHM=1, which forces the
+software rendering transport. Everything below runs on a normal compositor path.
+
+THIS HARNESS MEASURES, IT DOES NOT GATE. It prints the table and exits 0 on any timing. It exits
+non-zero only when the harness itself is broken: the seed did not land, an element it drives went
+missing, or the curve did not rise with content -- which would mean it is measuring nothing.
+Budgets belong in a later change, set from numbers taken on real hardware.
+
+Run:
+    python tests/studio/playwright_heavy_thread.py
+    SMOKE_HEAVY_CHARS=100000,300000 SMOKE_HEAVY_ENGINES=chromium python tests/studio/playwright_heavy_thread.py
+
+It starts and stops its own vite dev server. Point it at one you already have with
+SMOKE_BASE_URL, or move the port it picks with SMOKE_PORT.
+
+The dev server is deliberate and is a limitation to read the numbers against: React runs in
+development mode, nothing is minified, and vite serves unbundled modules. Absolute milliseconds
+are therefore higher than a packaged Studio's. The curve across sizes and the ranking across
+actions are what this file is for.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+from playwright.sync_api import sync_playwright
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _playwright_robust import (  # noqa: E402
+    chromium_launch_args,
+    start_vite,
+    stop_process,
+    wait_for_smoke_page,
+)
+
+PORT = int(os.environ.get("SMOKE_PORT", "5215"))
+# Exported-but-empty counts as unset, else we skip the server and drive "" as the URL.
+# rstrip("/"): a trailing slash makes the anchored /api/ route regex below never match, silently
+# turning the stubbed fan-out back into live HTTP.
+_EXTERNAL = os.environ.get("SMOKE_BASE_URL", "").strip().rstrip("/")
+BASE = _EXTERNAL or f"http://127.0.0.1:{PORT}"
+OWNS_SERVER = not _EXTERNAL
+LABEL = os.environ.get("SMOKE_LABEL", "tree")
+OUT = Path(os.environ.get("PW_ART_DIR", "logs/playwright-heavy-thread"))
+OUT.mkdir(parents = True, exist_ok = True)
+
+# Characters of thread content, not messages. Sorted: the growth check reads the first and last
+# entries as smallest and largest, so an unsorted override would invert every ratio and report a
+# good run as measuring nothing.
+SIZES = sorted(int(n) for n in os.environ.get("SMOKE_HEAVY_CHARS", "25000,100000,300000").split(","))
+ENGINES = [e.strip() for e in os.environ.get("SMOKE_HEAVY_ENGINES", "chromium,webkit,firefox").split(",") if e.strip()]
+# Every action set is run this many times on the seeded page and the table reports the MEDIAN.
+# The first repetition is systematically the slowest (cold Shiki cache, cold layout), which is
+# exactly why the headline is a median rather than a mean or a single shot.
+REPEATS = int(os.environ.get("SMOKE_HEAVY_REPEATS", "3"))
+# Chromium only, and off by default. Throttling is a CDP feature, so switching it on makes the
+# chromium column incomparable with the other two.
+CPU_THROTTLE_RATE = float(os.environ.get("SMOKE_CPU_THROTTLE", "1"))
+
+KEYSTROKES = int(os.environ.get("SMOKE_KEYSTROKES", "5"))
+SCROLL_STEPS = int(os.environ.get("SMOKE_SCROLL_STEPS", "20"))
+SCROLL_STEP_PX = int(os.environ.get("SMOKE_SCROLL_STEP_PX", "400"))
+SEED_TIMEOUT_MS = int(os.environ.get("SMOKE_SEED_TIMEOUT_MS", "300000"))
+ACTION_TIMEOUT_MS = int(os.environ.get("SMOKE_ACTION_TIMEOUT_MS", "120000"))
+# How long an in-page action waits for the DOM to reach the state it asked for. This bounds an
+# action that never happened and nothing else, so it has to stay well above the slowest honest
+# measurement or a very slow open is reported as "never opened".
+SETTLE_TIMEOUT_MS = int(os.environ.get("SMOKE_SETTLE_TIMEOUT_MS", "120000"))
+
+ACTIONS = ("keystroke", "scroll", "jump", "menu", "delete", "reopen")
+
+# Installed into every page before anything else runs.
+#
+# The rAF wrapper COUNTS, it does not pump. Replacing rAF with a fixed timer -- which
+# playwright_chat_autoscroll.py does on purpose, because it counts frames -- would destroy every
+# time-to-paint number this file exists to read. The harness's own waits use the unwrapped
+# reference, so __rafCount stays a count of the page's frames rather than of this file's.
+RECORDER_INIT = """
+(() => {
+  const nativeRaf = window.requestAnimationFrame.bind(window);
+  window.__nativeRaf = nativeRaf;
+  window.__rafCount = 0;
+  window.requestAnimationFrame = (cb) =>
+    nativeRaf((t) => {
+      window.__rafCount += 1;
+      cb(t);
+    });
+  window.__nextPaint = () =>
+    new Promise((resolve) => nativeRaf(() => nativeRaf(() => resolve())));
+
+  // Chromium-only, recorded as a cross-check on the portable stall number and never as the
+  // headline.
+  //
+  // Support is read from supportedEntryTypes, NOT from whether observe() throws. Measured on
+  // this tree: PerformanceObserver.observe({ type: "longtask" }) throws on neither WebKit 26.5
+  // nor Firefox 153 -- it is accepted and then never fires. A try/catch therefore reports both
+  // as supported and both then report zero long tasks, which reads as "no jank on the engine
+  // Unsloth Desktop ships on macOS and Linux" rather than as "this API does not exist there".
+  // supportedEntryTypes lists `longtask` on Chromium alone.
+  window.__longTasks = [];
+  window.__longTaskSupported = Boolean(
+    (PerformanceObserver.supportedEntryTypes || []).includes("longtask"),
+  );
+  if (window.__longTaskSupported) {
+    try {
+      new PerformanceObserver((list) => {
+        for (const entry of list.getEntries()) {
+          window.__longTasks.push({ start: entry.startTime, duration: entry.duration });
+        }
+      }).observe({ type: "longtask", buffered: true });
+    } catch (e) {
+      window.__longTaskSupported = false;
+    }
+  }
+
+  const recorder = {
+    running: false,
+    frames: [],
+    stalls: [],
+    startedAt: 0,
+    begin() {
+      this.running = true;
+      this.frames = [];
+      this.stalls = [];
+      this.startedAt = performance.now();
+      let lastFrame = performance.now();
+      const frame = () => {
+        const now = performance.now();
+        this.frames.push(now - lastFrame);
+        lastFrame = now;
+        if (this.running) nativeRaf(frame);
+      };
+      nativeRaf(frame);
+      // 1ms setTimeout, not a MessageChannel ping-pong. Measured: the MessageChannel version
+      // ticks ~150k/s and halves Firefox's frame rate before any app code runs; this one ticks
+      // ~150/s and costs nothing on any engine. The clamp puts a ~4ms floor under the
+      // resolution, which is far below any stall a user can feel.
+      let lastStall = performance.now();
+      const stall = () => {
+        const now = performance.now();
+        this.stalls.push(now - lastStall);
+        lastStall = now;
+        if (this.running) setTimeout(stall, 1);
+      };
+      setTimeout(stall, 1);
+    },
+    end() {
+      this.running = false;
+      const wallMs = performance.now() - this.startedAt;
+      const frames = this.frames;
+      const stalls = this.stalls;
+      const sorted = frames.slice().sort((a, b) => a - b);
+      return {
+        wall_ms: Math.round(wallMs * 10) / 10,
+        frames: frames.length,
+        // The first entry spans begin() to the first callback, so it is the wait for the next
+        // vsync as much as a rendered frame. Kept: at these timescales it is ~16ms, well under
+        // the 33ms threshold, and dropping it would also drop a genuine stall that landed there.
+        worst_frame_ms: Math.round(Math.max(0, ...frames) * 10) / 10,
+        median_frame_ms:
+          sorted.length === 0 ? 0 : Math.round(sorted[Math.floor(sorted.length / 2)] * 10) / 10,
+        frames_over_33: frames.filter((ms) => ms > 33).length,
+        stall_ticks: stalls.length,
+        longest_stall_ms: Math.round(Math.max(0, ...stalls) * 10) / 10,
+        stalls_over_33: stalls.filter((ms) => ms > 33).length,
+      };
+    },
+    /** Frames until the page goes quiet again: what "it is still catching up" costs a user. */
+    async quiet(timeoutMs) {
+      const started = performance.now();
+      let calm = 0;
+      let last = performance.now();
+      while (performance.now() - started < timeoutMs) {
+        await new Promise((resolve) => nativeRaf(() => resolve()));
+        const now = performance.now();
+        calm = now - last > 33 ? 0 : calm + 1;
+        last = now;
+        if (calm >= 3) return performance.now() - started;
+      }
+      return null;
+    },
+  };
+  window.__hv = recorder;
+})();
+"""
+
+
+def info(message: str) -> None:
+    print(f"[heavy-thread] {message}", flush = True)
+
+
+# ── in-page actions ───────────────────────────────────────────────────
+#
+# Each one brackets itself with __hv.begin()/__hv.end(), so the recorder window is exactly the
+# action rather than the action plus a CDP round trip.
+
+# One character through the native value setter plus an input event: what the browser leaves
+# behind after a real keypress, and what React's controlled textarea reacts to. Resolved on the
+# second rAF, which is the frame that has painted it.
+KEYSTROKE_JS = """
+async (count) => {
+  const api = window.__heavyThread;
+  const input = api.composer();
+  if (!input) return null;
+  input.focus();
+  const setValue = Object.getOwnPropertyDescriptor(
+    HTMLTextAreaElement.prototype, "value",
+  ).set;
+  const samples = [];
+  window.__hv.begin();
+  for (let i = 0; i < count; i += 1) {
+    await window.__nextPaint();
+    const started = performance.now();
+    setValue.call(input, input.value + "a");
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+    await window.__nextPaint();
+    samples.push(performance.now() - started);
+  }
+  const metrics = window.__hv.end();
+  const sorted = samples.slice().sort((a, b) => a - b);
+  // domText is what the harness itself wrote; runtimeText is what the runtime received. Only
+  // the second can show the keystroke reached React rather than just the DOM node.
+  return {
+    samples: samples.map((s) => Math.round(s * 10) / 10),
+    // The first sample is systematically a cold outlier, which is why the headline is a median.
+    median_sample_ms: Math.round(sorted[Math.floor(sorted.length / 2)] * 10) / 10,
+    worst_sample_ms: Math.round(sorted[sorted.length - 1] * 10) / 10,
+    domText: input.value,
+    runtimeText: api.composerText(),
+    metrics,
+  };
+}
+"""
+
+SCROLL_JS = """
+async ([steps, stepPx, settleMs]) => {
+  const api = window.__heavyThread;
+  const viewport = api.viewport();
+  if (!viewport) return null;
+  // The viewport carries `scroll-smooth`, so each scrollTop write starts an animation and the
+  // next read lands mid-flight. Stepping from a tracked target with an explicit instant
+  // behaviour is what a wheel gesture actually does, and it is the only way the gesture moves
+  // the distance it asks for.
+  const bottom = viewport.scrollHeight - viewport.clientHeight;
+  viewport.scrollTo({ top: bottom, behavior: "instant" });
+  await window.__nextPaint();
+  let target = viewport.scrollTop;
+  // Reverse at either end rather than stopping. A small thread runs out of travel long before a
+  // large one does, and a gesture that covers 2600px at 25K chars and 8000px at 300K is not the
+  // same gesture, so the two columns would not be comparable.
+  let direction = -1;
+  let travelled = 0;
+  window.__hv.begin();
+  for (let i = 0; i < steps; i += 1) {
+    if (direction < 0 && target <= 0) direction = 1;
+    else if (direction > 0 && target >= bottom) direction = -1;
+    const next = Math.min(bottom, Math.max(0, target + direction * stepPx));
+    // The wheel event is what the app's own scroll listeners key off; the scrollTo is what
+    // moves the viewport in a headless run with no compositor input.
+    viewport.dispatchEvent(
+      new WheelEvent("wheel", { deltaY: direction * stepPx, bubbles: true, cancelable: true }),
+    );
+    viewport.scrollTo({ top: next, behavior: "instant" });
+    await window.__nextPaint();
+    travelled += Math.abs(next - target);
+    target = next;
+  }
+  const gestureMs = performance.now() - window.__hv.startedAt;
+  const settleMsTaken = await window.__hv.quiet(settleMs);
+  const metrics = window.__hv.end();
+  return {
+    scrolledPx: travelled,
+    gestureMs: Math.round(gestureMs * 10) / 10,
+    settleMs: settleMsTaken === null ? null : Math.round(settleMsTaken * 10) / 10,
+    metrics,
+  };
+}
+"""
+
+# A wheel gesture of fixed length traverses a fixed number of pixels, so it is comparable across
+# sizes -- and, measured, it turns out to be nearly free at any size, because the layout was
+# already done at mount. That is a real answer, but it is only half of "scrolling". The other half
+# is the jump: dragging the scrollbar or hitting Home moves the viewport to a region the compositor
+# has nothing for, which is what a user does when they go looking for an earlier answer.
+JUMP_JS = """
+async (settleMs) => {
+  const api = window.__heavyThread;
+  const viewport = api.viewport();
+  if (!viewport) return null;
+  const bottom = viewport.scrollHeight - viewport.clientHeight;
+  viewport.scrollTo({ top: bottom, behavior: "instant" });
+  await window.__nextPaint();
+  window.__hv.begin();
+  const started = performance.now();
+  // The wheel event first, and it is load-bearing. Studio replaces assistant-ui's autoscroll
+  // with an intent-aware one, and a bare scrollTo from the bottom is read as programmatic and
+  // snapped straight back: measured, the jump landed at the bottom it started from and the whole
+  // column timed nothing. A wheel is what says a person did this.
+  viewport.dispatchEvent(
+    new WheelEvent("wheel", { deltaY: -bottom, bubbles: true, cancelable: true }),
+  );
+  viewport.scrollTo({ top: 0, behavior: "instant" });
+  await window.__nextPaint();
+  const paintedMs = performance.now() - started;
+  const settleMsTaken = await window.__hv.quiet(settleMs);
+  const metrics = window.__hv.end();
+  const landedAt = viewport.scrollTop;
+  viewport.scrollTo({ top: bottom, behavior: "instant" });
+  await window.__nextPaint();
+  return {
+    paintedMs: Math.round(paintedMs * 10) / 10,
+    settleMs: settleMsTaken === null ? null : Math.round(settleMsTaken * 10) / 10,
+    travelledPx: bottom,
+    landedAt,
+    metrics,
+  };
+}
+"""
+
+# Radix portals the menu to document.body and puts the body on the modal layer, which is the
+# fan-out under suspicion. bodyPointerEvents proves the open really took that path.
+#
+# The trigger opens on `pointerdown`, not on `click`: an element.click() leaves the menu shut and
+# the whole measurement silently reads zero. Hence the pointer pair.
+MENU_JS = """
+async (timeoutMs) => {
+  const api = window.__heavyThread;
+  const trigger = api.actionButton("More");
+  if (!trigger) return null;
+  // A MutationObserver flag, not a querySelector per frame. The menu content is portaled to the
+  // end of document.body, so polling for it walks the whole message list and finds nothing for
+  // the entire open latency -- a cost that grows like the signal being measured.
+  let open = Boolean(document.querySelector(".aui-action-bar-more-content"));
+  const watcher = new MutationObserver(() => {
+    open = Boolean(document.querySelector(".aui-action-bar-more-content"));
+  });
+  watcher.observe(document.body, { childList: true, subtree: false });
+  const settle = async (want) => {
+    const started = performance.now();
+    while (performance.now() - started < timeoutMs) {
+      if (open === want) return performance.now() - started;
+      await window.__nextPaint();
+    }
+    return null;
+  };
+  const pointer = {
+    bubbles: true, cancelable: true, composed: true,
+    button: 0, pointerId: 1, pointerType: "mouse", isPrimary: true,
+  };
+  window.__hv.begin();
+  const openStarted = performance.now();
+  trigger.dispatchEvent(new PointerEvent("pointerdown", { ...pointer, buttons: 1 }));
+  trigger.dispatchEvent(new PointerEvent("pointerup", { ...pointer, buttons: 0 }));
+  const opened = await settle(true);
+  const openMs = opened === null ? null : performance.now() - openStarted;
+  const bodyPointerEvents = getComputedStyle(document.body).pointerEvents;
+  const itemsWhileOpen = api.openMenuItemCount();
+  // Counted here, under the pointer, not in the resting-state census. An autohidden bar is
+  // absent at rest by design; one that never mounts at all is a broken page, and only a hovered
+  // count tells the two apart.
+  const triggersWhileHovered = document.querySelectorAll('[data-slot="tooltip-trigger"]').length;
+  // The clock starts BEFORE the dispatch. Radix dismisses synchronously inside it -- layer
+  // teardown, focus restore, the body coming off the modal layer and the re-render that follows
+  // -- which is the fan-out being measured. Starting it after the dispatch excluded exactly the
+  // part worth timing.
+  const closeStarted = performance.now();
+  document.dispatchEvent(
+    new KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true }),
+  );
+  const closed = await settle(false);
+  const metrics = window.__hv.end();
+  watcher.disconnect();
+  const closeMs = closed === null ? null : performance.now() - closeStarted;
+  return {
+    openMs: openMs === null ? null : Math.round(openMs * 10) / 10,
+    closeMs: closeMs === null ? null : Math.round(closeMs * 10) / 10,
+    open_close_ms:
+      openMs === null || closeMs === null ? null : Math.round((openMs + closeMs) * 10) / 10,
+    bodyPointerEvents,
+    bodyPointerEventsAfterClose: getComputedStyle(document.body).pointerEvents,
+    itemsWhileOpen,
+    triggersWhileHovered,
+    metrics,
+  };
+}
+"""
+
+DELETE_JS = """
+async (timeoutMs) => {
+  const api = window.__heavyThread;
+  const button = api.actionButton("Delete message");
+  if (!button) return null;
+  // The last assistant message. That is the cheapest delete on the React side -- one subtree
+  // unmounts -- so this column under-measures reconciliation, though the export/rebuild/import
+  // half is O(messages) wherever the target sits.
+  const target = api.lastAssistantMessage();
+  const before = api.messageCount();
+  window.__hv.begin();
+  const started = performance.now();
+  button.click();
+  let ms = null;
+  // isConnected on the captured node is O(1). Re-counting [data-role] every frame would put an
+  // O(messages) query inside the window being timed, growing like the signal.
+  while (performance.now() - started < timeoutMs) {
+    if (target === null || !target.isConnected) {
+      ms = performance.now() - started;
+      break;
+    }
+    await window.__nextPaint();
+  }
+  const metrics = window.__hv.end();
+  return { ms, before, after: api.messageCount(), metrics };
+}
+"""
+
+# Leaving a thread and coming back. The runtime keeps the messages; the Thread subtree is torn
+# down and rebuilt, which is every markdown block, every Shiki fence and every action bar mounted
+# again from nothing. This is the action users describe as "it hangs when I click back into the
+# conversation", and it is the one that has no incremental path at all.
+REOPEN_JS = """
+async ([timeoutMs, settleMs]) => {
+  const api = window.__heavyThread;
+  const before = api.messageCount();
+  if (!before) return null;
+  window.__hv.begin();
+  const started = performance.now();
+  api.closeThread();
+  // Unmount first, or "already back" is indistinguishable from "never left".
+  let closedMs = null;
+  while (performance.now() - started < timeoutMs) {
+    if (api.messageCount() === 0) { closedMs = performance.now() - started; break; }
+    await window.__nextPaint();
+  }
+  const reopenStarted = performance.now();
+  api.openThread();
+  let ms = null;
+  while (performance.now() - reopenStarted < timeoutMs) {
+    if (api.messageCount() >= before) { ms = performance.now() - reopenStarted; break; }
+    await window.__nextPaint();
+  }
+  const settleMsTaken = await window.__hv.quiet(settleMs);
+  const metrics = window.__hv.end();
+  return {
+    ms,
+    closedMs: closedMs === null ? null : Math.round(closedMs * 10) / 10,
+    settleMs: settleMsTaken === null ? null : Math.round(settleMsTaken * 10) / 10,
+    before,
+    after: api.messageCount(),
+    metrics,
+  };
+}
+"""
+
+# The floor under every timing clocked across a double rAF: two rAFs resolve no sooner than two
+# vsync intervals. An action that never happened therefore still reports ~33ms, which reads as a
+# plausible measurement rather than as a failure, so the floor is recorded per cell and
+# subtracted before any growth ratio.
+PAINT_FLOOR_JS = """
+async (samples) => {
+  const values = [];
+  for (let i = 0; i < samples; i += 1) {
+    await window.__nextPaint();
+    const started = performance.now();
+    await window.__nextPaint();
+    values.push(performance.now() - started);
+  }
+  values.sort((a, b) => a - b);
+  return values[Math.floor(values.length / 2)];
+}
+"""
+
+
+def median(values: list[float]) -> float | None:
+    ordered = sorted(v for v in values if v is not None)
+    if not ordered:
+        return None
+    middle = len(ordered) // 2
+    if len(ordered) % 2:
+        return round(ordered[middle], 1)
+    return round((ordered[middle - 1] + ordered[middle]) / 2, 1)
+
+
+def cdp_metrics(cdp) -> dict[str, float]:
+    if cdp is None:
+        return {}
+    got = cdp.send("Performance.getMetrics")
+    return {m["name"]: m["value"] for m in got["metrics"]}
+
+
+def cdp_counters(before: dict[str, float], after: dict[str, float]) -> dict[str, float | None]:
+    """CHROMIUM-ONLY. Empty dicts off Chromium, and every consumer prints `-` for that."""
+    if not before or not after:
+        return {
+            "layout_count": None, "recalc_style_count": None,
+            "layout_ms": None, "recalc_style_ms": None, "task_ms": None,
+        }
+
+    def d(name: str) -> float:
+        return after.get(name, 0.0) - before.get(name, 0.0)
+
+    return {
+        "layout_count": round(d("LayoutCount"), 1),
+        "recalc_style_count": round(d("RecalcStyleCount"), 1),
+        "layout_ms": round(d("LayoutDuration") * 1000, 1),
+        "recalc_style_ms": round(d("RecalcStyleDuration") * 1000, 1),
+        "task_ms": round(d("TaskDuration") * 1000, 1),
+    }
+
+
+def long_task_summary(page) -> dict[str, float | None]:
+    """CHROMIUM-ONLY. `supported` is the point: without it, an engine with no Long Tasks API
+    reports zero jank in exactly the same shape as an engine that had none."""
+    # PerformanceObserver callbacks are delivered on a later task, so the entry for the long task
+    # at the tail of an action is not in the array yet. Yield once before reading, or the worst
+    # entry is silently dropped -- flakily, and most often at large sizes where that tail task is
+    # longest.
+    got = page.evaluate(
+        """async () => {
+            await new Promise((r) => setTimeout(r, 0));
+            return { supported: window.__longTaskSupported, tasks: window.__longTasks };
+        }"""
+    )
+    if not got["supported"]:
+        return {"long_tasks": None, "long_task_ms": None, "worst_long_task_ms": None}
+    tasks = got["tasks"]
+    return {
+        "long_tasks": len(tasks),
+        "long_task_ms": round(sum(t["duration"] for t in tasks), 1),
+        "worst_long_task_ms": round(max((t["duration"] for t in tasks), default = 0.0), 1),
+    }
+
+
+def reset_long_tasks(page) -> None:
+    page.evaluate("window.__longTasks.length = 0")
+
+
+def run_action(page, cdp, name: str, script: str, arg) -> dict:
+    """One action, with the portable recorder inside it and the CDP counters bracketing it."""
+    reset_long_tasks(page)
+    before = cdp_metrics(cdp)
+    raw = page.evaluate(script, arg)
+    after = cdp_metrics(cdp)
+    if raw is None:
+        return {"name": name, "ran": False, **cdp_counters({}, {}), **long_task_summary(page)}
+    out = {"name": name, "ran": True}
+    out.update(raw.pop("metrics"))
+    out.update(raw)
+    out.update(cdp_counters(before, after))
+    out.update(long_task_summary(page))
+    return out
+
+
+def one_repetition(page, cdp) -> dict[str, dict]:
+    """The five scripted actions, once, in the order a user meets them."""
+    rep: dict[str, dict] = {}
+    # Re-open unmounts the thread, and an uncontrolled Radix collapsible comes back closed, so
+    # without this every repetition after the first would run against a thread with no tool
+    # result panes in it -- a different, cheaper fixture wearing the same label. Idempotent: on
+    # the first repetition the cards are already open and nothing is clicked. Untimed.
+    expanded = page.evaluate("() => window.__heavyThread.expandTools()")
+    if expanded:
+        page.wait_for_function(
+            "(n) => window.__heavyThread.counts().collapsibleOutputs >= n",
+            arg = expanded,
+            timeout = ACTION_TIMEOUT_MS,
+        )
+    rep["keystroke"] = run_action(page, cdp, "keystroke", KEYSTROKE_JS, KEYSTROKES)
+    rep["scroll"] = run_action(
+        page, cdp, "scroll", SCROLL_JS, [SCROLL_STEPS, SCROLL_STEP_PX, SETTLE_TIMEOUT_MS],
+    )
+    rep["jump"] = run_action(page, cdp, "jump", JUMP_JS, SETTLE_TIMEOUT_MS)
+
+    # The action bar is hover-revealed, so put the pointer on the message before reaching for it.
+    # behavior: "instant" -- the viewport carries scroll-smooth, so the default animates and at
+    # large sizes leaves that animation in flight inside the menu counters.
+    page.evaluate(
+        """() => { const m = window.__heavyThread.lastAssistantMessage();
+            if (m) m.scrollIntoView({ block: "center", behavior: "instant" }); }"""
+    )
+    page.wait_for_function(
+        """() => {
+            const top = window.__heavyThread.viewportMetrics().scrollTop;
+            const settled = window.__hvTop === top;
+            window.__hvTop = top;
+            return settled;
+        }""",
+        timeout = ACTION_TIMEOUT_MS,
+    )
+    page.locator('[data-role="assistant"]').last.hover(timeout = ACTION_TIMEOUT_MS)
+    rep["menu"] = run_action(page, cdp, "menu", MENU_JS, SETTLE_TIMEOUT_MS)
+
+    page.locator('[data-role="assistant"]').last.hover(timeout = ACTION_TIMEOUT_MS)
+    rep["delete"] = run_action(page, cdp, "delete", DELETE_JS, SETTLE_TIMEOUT_MS)
+
+    rep["reopen"] = run_action(
+        page, cdp, "reopen", REOPEN_JS, [SETTLE_TIMEOUT_MS, SETTLE_TIMEOUT_MS],
+    )
+    return rep
+
+
+# Portable headline per action, plus the action's own DOM-observable duration. `floored` marks a
+# value clocked across a double rAF, which carries the ~33ms vsync floor.
+HEADLINE = {
+    "keystroke": ("median_sample_ms", True),
+    "scroll": ("gestureMs", False),
+    "jump": ("paintedMs", True),
+    "menu": ("open_close_ms", True),
+    "delete": ("ms", True),
+    "reopen": ("ms", False),
+}
+
+
+def summarise(reps: list[dict[str, dict]]) -> dict[str, dict]:
+    """Median across repetitions, per action, per metric. Medians because the first repetition is
+    systematically the slowest and a mean would carry it into every cell."""
+    out: dict[str, dict] = {}
+    for action in ACTIONS:
+        rows = [r[action] for r in reps if action in r]
+        if not rows or not all(r.get("ran") for r in rows):
+            out[action] = {"ran": False}
+            continue
+        merged: dict = {"ran": True, "repetitions": len(rows)}
+        numeric_keys = set()
+        for row in rows:
+            for key, value in row.items():
+                if isinstance(value, (int, float)) and not isinstance(value, bool):
+                    numeric_keys.add(key)
+        for key in sorted(numeric_keys):
+            merged[key] = median([r.get(key) for r in rows])
+        # Values that are not numbers are proofs the action really happened, not timings, so the
+        # last repetition's is kept verbatim rather than aggregated.
+        for key in ("domText", "runtimeText", "bodyPointerEvents", "bodyPointerEventsAfterClose"):
+            if key in rows[-1]:
+                merged[key] = rows[-1][key]
+        # The headline value from each repetition, unaggregated, so a median can be checked
+        # against the spread it came from rather than taken on trust.
+        merged["per_repetition"] = [r.get(HEADLINE[action][0]) for r in rows]
+        out[action] = merged
+    return out
+
+
+def measure_cell(context, engine: str, size: int) -> dict:
+    """Seed a fresh page to `size` characters of content and run the action set REPEATS times."""
+    page = context.new_page()
+    result: dict = {"chars_requested": size, "engine": engine}
+    # A request that escapes to the server, or a warning storm, is work this harness would be
+    # charging to the app once per message. Both are cleared after seeding, so what is asserted on
+    # is the measured actions rather than page load.
+    #
+    # startswith, not `"/api/" in url`: vite serves the app's own source modules from paths like
+    # /src/features/chat/api/chat-api.ts, and a substring match counts dozens of those as network
+    # calls. Same trap the route regex is anchored to avoid.
+    api_prefix = f"{BASE}/api/"
+    stray_requests: list[str] = []
+    console_warnings: list[str] = []
+    page.on(
+        "request",
+        lambda r: stray_requests.append(r.url) if r.url.startswith(api_prefix) else None,
+    )
+    page.on(
+        "console",
+        lambda m: console_warnings.append(m.text[:200]) if m.type in ("warning", "error") else None,
+    )
+    page.on("pageerror", lambda e: console_warnings.append(f"pageerror: {e}"[:200]))
+    cdp = None
+    try:
+        page.goto(f"{BASE}/smoke-heavy-thread.html", wait_until = "domcontentloaded")
+        page.wait_for_function("() => Boolean(window.__heavyThread)", timeout = 60_000)
+        if engine == "chromium":
+            cdp = context.new_cdp_session(page)
+            cdp.send("Performance.enable")
+
+        # Seeding unthrottled and untimed: this measures interaction cost at a thread size, not
+        # the cost of building the thread.
+        plan = page.evaluate("(n) => window.__heavyThread.seed(n)", size)
+        result["plan"] = plan
+        # Single-selector gates. counts() walks every element in the document, so polling it per
+        # frame makes seeding superlinear in the thing being seeded.
+        page.wait_for_function(
+            "(n) => window.__heavyThread.messageCount() >= n",
+            arg = plan["messages"],
+            timeout = SEED_TIMEOUT_MS,
+        )
+        # Radix unmounts collapsed content, so a thread of closed tool cards carries no result
+        # panes at all. Open them before the census: a user who has just watched those tools run
+        # is looking at them open, and the closed thread is a different fixture.
+        result["tool_triggers_expanded"] = page.evaluate(
+            "() => window.__heavyThread.expandTools()"
+        )
+        page.wait_for_function(
+            "(n) => window.__heavyThread.counts().collapsibleOutputs >= n",
+            arg = max(1, result["tool_triggers_expanded"]),
+            timeout = SEED_TIMEOUT_MS,
+        )
+        # Shiki is async and per block, and a <pre> exists before it is highlighted, so counting
+        # code blocks gates nothing. Wait for the token count to stop moving instead: unfinished
+        # highlighting would otherwise land in the keystroke window, the first action measured.
+        #
+        # FIVE stable reads a quarter of a second apart, not two consecutive ones. Two adjacent
+        # rAF-polled reads land inside the lull between two async highlight batches all the time:
+        # measured on WebKit, the two-read version released the gate at 577 highlighted tokens
+        # where the finished thread has 3216, so the whole engine column was measured against a
+        # thread that was still building itself.
+        page.wait_for_function(
+            """() => {
+                const n = window.__heavyThread.highlightedTokenCount();
+                const state = window.__hvTokens || { value: -1, stable: 0 };
+                if (n === state.value && n > 0) state.stable += 1;
+                else { state.value = n; state.stable = 0; }
+                window.__hvTokens = state;
+                return state.stable >= 5;
+            }""",
+            polling = 250,
+            timeout = SEED_TIMEOUT_MS,
+        )
+        result["counts"] = page.evaluate("window.__heavyThread.counts()")
+        result["viewport"] = page.evaluate("window.__heavyThread.viewportMetrics()")
+        result["seed_api_requests"] = len(stray_requests)
+        result["seed_console_warnings"] = len(console_warnings)
+        result["first_seed_warning"] = console_warnings[0] if console_warnings else "-"
+        stray_requests.clear()
+        console_warnings.clear()
+
+        result["cpu_throttle_rate"] = 1.0
+        if cdp is not None and CPU_THROTTLE_RATE != 1.0:
+            cdp.send("Emulation.setCPUThrottlingRate", {"rate": CPU_THROTTLE_RATE})
+            result["cpu_throttle_rate"] = CPU_THROTTLE_RATE
+        result["long_task_supported"] = page.evaluate("window.__longTaskSupported")
+        result["paint_floor_ms"] = round(page.evaluate(PAINT_FLOOR_JS, 9), 2)
+
+        reps = []
+        for index in range(REPEATS):
+            info(f"  {engine} {size} chars: repetition {index + 1}/{REPEATS}")
+            reps.append(one_repetition(page, cdp))
+        result["repetitions"] = REPEATS
+        result["actions"] = summarise(reps)
+        result["raw_repetitions"] = reps
+
+        if cdp is not None and CPU_THROTTLE_RATE != 1.0:
+            cdp.send("Emulation.setCPUThrottlingRate", {"rate": 1})
+        # Cumulative over seeding and every action: a liveness check, not attributable to any one.
+        result["raf_callbacks"] = page.evaluate("window.__rafCount")
+        result["stray_api_requests"] = len(stray_requests)
+        result["console_warnings"] = len(console_warnings)
+        result["first_console_warning"] = console_warnings[0] if console_warnings else "-"
+    finally:
+        page.close()
+    return result
+
+
+def run() -> dict:
+    results: dict = {
+        "label": LABEL,
+        "base": BASE,
+        "sizes": SIZES,
+        "engines": ENGINES,
+        "repetitions": REPEATS,
+        "cpu_throttle_rate_requested": CPU_THROTTLE_RATE,
+        "by_engine": {},
+    }
+    with sync_playwright() as p:
+        for engine in ENGINES:
+            info(f"engine {engine}")
+            launcher = getattr(p, engine)
+            kwargs = {"headless": os.environ.get("SMOKE_HEADLESS", "1") == "1"}
+            # Chromium-only flags. Passing them to Firefox or WebKit is not "ignored", it is a
+            # launch failure, which would read as "this engine is unavailable".
+            if engine == "chromium":
+                kwargs["args"] = chromium_launch_args()
+            browser = launcher.launch(**kwargs)
+            results["by_engine"][engine] = {"version": browser.version, "by_size": {}}
+            context = browser.new_context(viewport = {"width": 1440, "height": 900})
+            context.add_init_script(RECORDER_INIT)
+            # Anchored at the origin so it cannot swallow vite's own module URLs, which live
+            # under src/features/**/api/ and would otherwise match a bare "/api/" pattern.
+            context.route(
+                re.compile(rf"^{re.escape(BASE)}/api/"),
+                lambda route: route.fulfill(
+                    status = 200, content_type = "application/json", body = "{}",
+                ),
+            )
+            for size in SIZES:
+                info(f"measuring {engine} at {size} chars")
+                cell = measure_cell(context, engine, size)
+                results["by_engine"][engine]["by_size"][str(size)] = cell
+            context.close()
+            browser.close()
+    return results
+
+
+# Every recorded metric appears here. That is the rule the harnesses in this directory are held
+# to: a metric that is recorded and never read is how one goes false-green, and
+# tests/studio/test_heavy_thread_harness_contract.py fails if anything recorded below is missing.
+# CHROMIUM-ONLY rows are labelled in their own name, because off Chromium they print `-` and a
+# `-` that means "not supported here" must not read as "zero".
+def _action(action: str, key: str):
+    return lambda r: r["actions"][action][key]
+
+
+TABLE_ROWS = (
+    ("chars requested", lambda r: r["chars_requested"]),
+    ("chars rendered", lambda r: r["plan"]["chars"]),
+    ("messages seeded", lambda r: r["plan"]["messages"]),
+    ("content cycles", lambda r: r["plan"]["cycles"]),
+    ("chars per cycle", lambda r: r["plan"]["cycleChars"]),
+    ("content kinds", lambda r: r["plan"]["kinds"]),
+    ("tool cards expanded", lambda r: r["tool_triggers_expanded"]),
+    ("repetitions", lambda r: r["repetitions"]),
+    ("cpu throttle rate", lambda r: r["cpu_throttle_rate"]),
+    ("paint floor ms", lambda r: r["paint_floor_ms"]),
+    ("longtask api supported", lambda r: r["long_task_supported"]),
+    ("seed api requests", lambda r: r["seed_api_requests"]),
+    ("seed console warnings", lambda r: r["seed_console_warnings"]),
+    ("first seed warning", lambda r: r["first_seed_warning"]),
+    ("action api requests", lambda r: r["stray_api_requests"]),
+    ("action console warnings", lambda r: r["console_warnings"]),
+    ("first action warning", lambda r: r["first_console_warning"]),
+    ("messages rendered", lambda r: r["counts"]["messages"]),
+    ("dom nodes", lambda r: r["counts"]["domNodes"]),
+    ("code blocks", lambda r: r["counts"]["codeBlocks"]),
+    ("highlighted tokens", lambda r: r["counts"]["highlightedTokens"]),
+    ("tool parts", lambda r: r["counts"]["toolParts"]),
+    ("collapsible tool outputs", lambda r: r["counts"]["collapsibleOutputs"]),
+    ("code execution panes", lambda r: r["counts"]["codeExecutionPanes"]),
+    ("artifact cards", lambda r: r["counts"]["artifactCards"]),
+    ("images", lambda r: r["counts"]["images"]),
+    ("action bars", lambda r: r["counts"]["actionBars"]),
+    ("tooltip triggers", lambda r: r["counts"]["tooltipTriggers"]),
+    ("viewport scrollHeight", lambda r: r["viewport"]["scrollHeight"]),
+    ("viewport clientHeight", lambda r: r["viewport"]["clientHeight"]),
+    ("rAF callbacks", lambda r: r["raf_callbacks"]),
+)
+
+for _name in ACTIONS:
+    TABLE_ROWS = TABLE_ROWS + (
+        (f"{_name} ran", _action(_name, "ran")),
+        (f"{_name} wall ms", _action(_name, "wall_ms")),
+        (f"{_name} longest stall ms", _action(_name, "longest_stall_ms")),
+        (f"{_name} worst frame ms", _action(_name, "worst_frame_ms")),
+        (f"{_name} median frame ms", _action(_name, "median_frame_ms")),
+        (f"{_name} frames over 33ms", _action(_name, "frames_over_33")),
+        (f"{_name} frames", _action(_name, "frames")),
+        (f"{_name} stalls over 33ms", _action(_name, "stalls_over_33")),
+        (f"{_name} stall ticks", _action(_name, "stall_ticks")),
+        (f"{_name} layouts (chromium only)", _action(_name, "layout_count")),
+        (f"{_name} layout ms (chromium only)", _action(_name, "layout_ms")),
+        (f"{_name} recalcs (chromium only)", _action(_name, "recalc_style_count")),
+        (f"{_name} recalc ms (chromium only)", _action(_name, "recalc_style_ms")),
+        (f"{_name} task ms (chromium only)", _action(_name, "task_ms")),
+        (f"{_name} longtasks (chromium only)", _action(_name, "long_tasks")),
+        (f"{_name} longtask ms (chromium only)", _action(_name, "long_task_ms")),
+        (f"{_name} worst longtask ms (chromium only)", _action(_name, "worst_long_task_ms")),
+    )
+
+TABLE_ROWS = TABLE_ROWS + (
+    ("keystroke median ms", _action("keystroke", "median_sample_ms")),
+    ("keystroke worst ms", _action("keystroke", "worst_sample_ms")),
+    ("keystroke per repetition", lambda r: "/".join(
+        str(v) for v in r["actions"]["keystroke"]["per_repetition"]
+    )),
+    ("scroll per repetition", lambda r: "/".join(
+        str(v) for v in r["actions"]["scroll"]["per_repetition"]
+    )),
+    ("menu per repetition", lambda r: "/".join(
+        str(v) for v in r["actions"]["menu"]["per_repetition"]
+    )),
+    ("delete per repetition", lambda r: "/".join(
+        str(v) for v in r["actions"]["delete"]["per_repetition"]
+    )),
+    ("reopen per repetition", lambda r: "/".join(
+        str(v) for v in r["actions"]["reopen"]["per_repetition"]
+    )),
+    ("keystroke dom text", _action("keystroke", "domText")),
+    ("keystroke runtime text", _action("keystroke", "runtimeText")),
+    ("scroll gesture ms", _action("scroll", "gestureMs")),
+    ("scroll settle ms", _action("scroll", "settleMs")),
+    ("scroll px", _action("scroll", "scrolledPx")),
+    ("jump painted ms", _action("jump", "paintedMs")),
+    ("jump settle ms", _action("jump", "settleMs")),
+    ("jump px", _action("jump", "travelledPx")),
+    ("jump landed at", _action("jump", "landedAt")),
+    ("menu open ms", _action("menu", "openMs")),
+    ("menu close ms", _action("menu", "closeMs")),
+    ("menu open+close ms", _action("menu", "open_close_ms")),
+    ("menu items while open", _action("menu", "itemsWhileOpen")),
+    ("menu body pe while open", _action("menu", "bodyPointerEvents")),
+    ("menu body pe after close", _action("menu", "bodyPointerEventsAfterClose")),
+    ("menu triggers hovered", _action("menu", "triggersWhileHovered")),
+    ("delete ms", _action("delete", "ms")),
+    ("delete messages before", _action("delete", "before")),
+    ("delete messages after", _action("delete", "after")),
+    ("reopen ms", _action("reopen", "ms")),
+    ("reopen unmount ms", _action("reopen", "closedMs")),
+    ("reopen settle ms", _action("reopen", "settleMs")),
+    ("reopen messages before", _action("reopen", "before")),
+    ("reopen messages after", _action("reopen", "after")),
+)
+
+
+def print_table(results: dict) -> None:
+    """Every recorded metric, printed, one column per (engine, size)."""
+    columns = [
+        (engine, str(size)) for engine in results["engines"] for size in results["sizes"]
+    ]
+    rows = []
+    for name, pick in TABLE_ROWS:
+        cells = []
+        for engine, size in columns:
+            try:
+                value = pick(results["by_engine"][engine]["by_size"][size])
+                cells.append("-" if value is None else str(value))
+            except (KeyError, TypeError):
+                cells.append("-")
+        rows.append((name, cells))
+    label_width = max(len(name) for name, _ in rows) + 2
+    # From the widest cell, not a constant: a fixed width silently runs the columns together on
+    # the one row that overflows it, which is the row you were reading.
+    headers = [f"{engine[:4]}/{int(size) // 1000}K" for engine, size in columns]
+    cell_width = max([len(c) for _, cells in rows for c in cells] + [len(h) for h in headers]) + 2
+    header = "".ljust(label_width) + "".join(h.rjust(cell_width) for h in headers)
+    info(header)
+    info("-" * len(header))
+    for name, cells in rows:
+        info(name.ljust(label_width) + "".join(cell.rjust(cell_width) for cell in cells))
+
+
+# Growth axes: the whole point of the harness is that these rise with content. `floored` marks a
+# metric clocked across a double rAF, which carries the ~33ms vsync floor; left in, the floor
+# compresses every ratio towards 1 and lets a real regression sit under the threshold.
+GROWTH_AXES = tuple(
+    [(f"{a} longest stall ms", _action(a, "longest_stall_ms"), False) for a in ACTIONS]
+    + [(f"{a} worst frame ms", _action(a, "worst_frame_ms"), False) for a in ACTIONS]
+    + [(f"{a} frames over 33ms", _action(a, "frames_over_33"), False) for a in ACTIONS]
+    + [(f"{a} wall ms", _action(a, "wall_ms"), False) for a in ACTIONS]
+    + [
+        ("keystroke median ms", _action("keystroke", "median_sample_ms"), True),
+        ("scroll gesture ms", _action("scroll", "gestureMs"), False),
+        ("scroll settle ms", _action("scroll", "settleMs"), False),
+        ("jump painted ms", _action("jump", "paintedMs"), True),
+        ("jump settle ms", _action("jump", "settleMs"), False),
+        ("menu open+close ms", _action("menu", "open_close_ms"), True),
+        ("delete ms", _action("delete", "ms"), True),
+        ("reopen ms", _action("reopen", "ms"), False),
+    ]
+)
+# A ratio at or below this from the smallest size to the largest means the axis did not respond
+# to twelve times the content. That is not a flat curve, it is an axis that is not measuring the
+# thing being varied.
+DISCRIMINATION_RATIO = float(os.environ.get("SMOKE_DISCRIMINATION_RATIO", "1.5"))
+
+
+def growth(cells: dict, pick, floored: bool, sizes: list[int]) -> tuple[float | None, float | None]:
+    try:
+        rows = (cells[str(sizes[0])], cells[str(sizes[-1])])
+        values = []
+        for row in rows:
+            value = pick(row)
+            if value is None:
+                return None, None
+            if floored:
+                value -= row["paint_floor_ms"]
+            values.append(round(value, 2))
+        return values[0], values[1]
+    except (KeyError, TypeError):
+        return None, None
+
+
+def report_growth(results: dict) -> dict[str, dict[str, dict]]:
+    """Per engine, per axis: the value at the smallest and largest size and their ratio."""
+    report: dict[str, dict[str, dict]] = {}
+    for engine in results["engines"]:
+        cells = results["by_engine"][engine]["by_size"]
+        per_axis: dict[str, dict] = {}
+        for name, pick, floored in GROWTH_AXES:
+            small, large = growth(cells, pick, floored, results["sizes"])
+            if small is None or large is None:
+                per_axis[name] = {"small": None, "large": None, "ratio": None,
+                                  "discriminated": False, "reason": "not recorded"}
+                continue
+            if small <= 0:
+                # A count that is 0 at the smallest size and 4 at the largest has no ratio and
+                # has still answered the question. Treated as discriminating only when it really
+                # rose: 0 -> 0 is the flattest result there is.
+                rose = large > small
+                per_axis[name] = {
+                    "small": small, "large": large, "ratio": None,
+                    "discriminated": rose,
+                    "reason": "rose from zero" if rose else "zero at both ends",
+                    "floored": floored,
+                }
+                continue
+            ratio = round(large / small, 2)
+            per_axis[name] = {
+                "small": small, "large": large, "ratio": ratio,
+                "discriminated": ratio > DISCRIMINATION_RATIO,
+                "reason": "-",
+                "floored": floored,
+            }
+        report[engine] = per_axis
+    return report
+
+
+def print_growth(results: dict, report: dict) -> None:
+    for engine, per_axis in report.items():
+        info("")
+        info(f"growth on {engine} ({results['sizes'][0]} -> {results['sizes'][-1]} chars, "
+             f"median of {results['repetitions']} repetitions)")
+        for name, row in per_axis.items():
+            if row["ratio"] is None:
+                mark = "DISCRIMINATES" if row["discriminated"] else "flat"
+                small = "-" if row["small"] is None else row["small"]
+                large = "-" if row["large"] is None else row["large"]
+                info(f"  {name:<34} {small:>10} -> {large:>10}       -  "
+                     f"{mark} ({row['reason']})")
+                continue
+            mark = "DISCRIMINATES" if row["discriminated"] else "flat"
+            floor_note = " (paint floor removed)" if row.get("floored") else ""
+            info(f"  {name:<34} {row['small']:>10} -> {row['large']:>10}  "
+                 f"{row['ratio']:>6.2f}x  {mark}{floor_note}")
+
+
+def harness_failures(results: dict, report: dict) -> list[str]:
+    """Only the ways this harness can be measuring nothing. No performance budgets: see the
+    module docstring."""
+    failures: list[str] = []
+    for engine in results["engines"]:
+        for size in results["sizes"]:
+            row = results["by_engine"][engine]["by_size"][str(size)]
+            where = f"{engine} at {size} chars"
+            counts = row["counts"]
+            plan = row["plan"]
+            # A request reaching the server is a round trip to another process inside a region
+            # being timed, once per message. A warning storm is the same cost via the console
+            # channel. Both scale with content, so both would forge the curve.
+            if row["stray_api_requests"]:
+                failures.append(
+                    f"{where} let {row['stray_api_requests']} /api/ requests reach the network "
+                    "during the measured actions; the timings include a round trip per request"
+                )
+            if row["console_warnings"]:
+                failures.append(
+                    f"{where} logged {row['console_warnings']} console warnings during the "
+                    f"measured actions, the first being {row['first_console_warning']!r}"
+                )
+            if plan["chars"] < size * 0.9:
+                failures.append(
+                    f"{where} only built {plan['chars']} characters of the {size} asked for"
+                )
+            if counts["messages"] < plan["messages"]:
+                failures.append(
+                    f"{where} rendered {counts['messages']} of {plan['messages']} messages; the "
+                    "seed did not land"
+                )
+            # The fixture IS the measurement. A thread of plain paragraphs would be cheap for
+            # reasons the app is not, so every kind the user report names has to be on screen,
+            # in proportion, at every size.
+            #
+            # Counted against the page's own per-cycle expectation rather than against zero. The
+            # renderer drops content silently in more than one place -- an image part whose data
+            # URL is not base64 PNG/JPEG/GIF/WebP is discarded with a console.warn -- and a
+            # fixture that has quietly lost a whole kind still produces a rising curve, of
+            # something else.
+            for key, per_cycle in plan["expectedPerCycle"].items():
+                want = per_cycle * plan["cycles"]
+                if counts.get(key, 0) < want:
+                    failures.append(
+                        f"{where} rendered {counts.get(key, 0)} {key}, short of the {want} its "
+                        f"{plan['cycles']} content cycles should produce; the fixture is not the "
+                        "heavy thread this harness claims to measure"
+                    )
+            if counts.get("highlightedTokens", 0) <= 0:
+                failures.append(f"{where} highlighted nothing; Shiki never ran")
+            viewport = row["viewport"]
+            if viewport["scrollHeight"] <= viewport["clientHeight"]:
+                failures.append(f"{where} does not overflow its viewport; the scroll measures nothing")
+
+            actions = row["actions"]
+            for name in ACTIONS:
+                if not actions[name].get("ran"):
+                    failures.append(f"{where} could not run the {name} action at all")
+            keystroke = actions["keystroke"]
+            if keystroke.get("ran"):
+                # The DOM value is what the harness itself wrote, so it proves nothing on its
+                # own. Only the runtime's copy shows the keystroke reached React rather than just
+                # the textarea, and a keystroke that reached nothing still reports the ~33ms
+                # paint floor, which reads as a plausible timing.
+                if keystroke["runtimeText"] != keystroke["domText"]:
+                    failures.append(
+                        f"{where} typed {keystroke['domText']!r} into the DOM but the runtime "
+                        f"holds {keystroke['runtimeText']!r}; the keystroke never reached the "
+                        "composer state"
+                    )
+                # Sitting on the paint floor is NOT a harness failure here, and the reason is a
+                # finding rather than an excuse: the character reaches the composer and paints on
+                # the very next frame at every size, while the thread churns for another 180ms
+                # afterwards. `runtimeText == domText` above is what proves the keystroke landed;
+                # the floor comparison only says this particular axis has no room to move, which
+                # the growth report states per axis.
+            scroll = actions["scroll"]
+            # Equal travel at every size or the columns are not the same gesture.
+            if scroll.get("ran") and scroll["scrolledPx"] < SCROLL_STEPS * SCROLL_STEP_PX * 0.9:
+                failures.append(
+                    f"{where} travelled only {scroll['scrolledPx']}px of the "
+                    f"{SCROLL_STEPS * SCROLL_STEP_PX}px gesture, so its scroll column is not "
+                    "comparable with the others"
+                )
+            jumped = actions["jump"]
+            if jumped.get("ran"):
+                # Unlike the gesture, the jump is DELIBERATELY not the same distance at every
+                # size: it is bottom to top, which is the point. What has to hold is that it
+                # arrived, or the column is timing a scroll that did not move.
+                if jumped["landedAt"] > 1:
+                    failures.append(
+                        f"{where} jumped to the top of the thread and landed at "
+                        f"{jumped['landedAt']}px; the viewport did not move"
+                    )
+                if jumped["travelledPx"] <= viewport["clientHeight"]:
+                    failures.append(
+                        f"{where} had only {jumped['travelledPx']}px to jump through, which is "
+                        "less than one viewport; nothing had to be painted"
+                    )
+            menu = actions["menu"]
+            if menu.get("ran"):
+                if menu["openMs"] is None:
+                    failures.append(f"{where} never opened the message action menu")
+                elif menu["closeMs"] is None:
+                    failures.append(f"{where} opened the action menu and it never closed")
+                elif menu["bodyPointerEventsAfterClose"] == "none":
+                    failures.append(f"{where} left the body on the modal layer after closing the menu")
+                # An empty popover satisfies "the menu opened" and costs nothing to render.
+                elif not menu["itemsWhileOpen"]:
+                    failures.append(f"{where} opened an action menu with no items in it")
+                if not menu["triggersWhileHovered"] and counts["actionBars"] <= 0:
+                    failures.append(
+                        f"{where} mounted no action bar at rest and none under the pointer either"
+                    )
+            deleted = actions["delete"]
+            if deleted.get("ran"):
+                if deleted["ms"] is None:
+                    failures.append(f"{where} never deleted a message")
+                elif deleted["after"] >= deleted["before"]:
+                    failures.append(f"{where} clicked delete and the message count did not drop")
+            reopened = actions["reopen"]
+            if reopened.get("ran"):
+                if reopened["ms"] is None:
+                    failures.append(f"{where} re-opened the thread and it never came back")
+                elif reopened["closedMs"] is None:
+                    failures.append(
+                        f"{where} never saw the thread unmount, so its re-open time is the cost "
+                        "of a thread that never left"
+                    )
+
+        # A modal menu puts the body on the modal layer and a non-modal one does not, and the two
+        # cost wildly different amounts. Either is a legitimate tree, but a run that mixes them
+        # across sizes is comparing columns measured on different mechanisms.
+        layers = {
+            results["by_engine"][engine]["by_size"][str(size)]["actions"]["menu"].get(
+                "bodyPointerEvents"
+            )
+            for size in results["sizes"]
+        }
+        if len(layers) > 1:
+            failures.append(
+                f"on {engine} the menu put the body on {sorted(str(x) for x in layers)} across "
+                "sizes; the columns are not measuring the same mechanism"
+            )
+
+    # Discrimination. Not a budget: a harness where the largest thread costs what the smallest
+    # does is not reporting a flat curve, it is reporting that it never drove the page.
+    if len(results["sizes"]) >= 2:
+        for engine, per_axis in report.items():
+            if not any(row["discriminated"] for row in per_axis.values()):
+                failures.append(
+                    f"on {engine} no measured axis rose by more than {DISCRIMINATION_RATIO}x "
+                    f"from {results['sizes'][0]} to {results['sizes'][-1]} characters. Either the "
+                    "page was never driven or every action is being measured somewhere it does "
+                    "not run; the numbers above cannot size any change."
+                )
+    return failures
+
+
+def main() -> int:
+    vite = None
+    if OWNS_SERVER:
+        info(f"starting vite dev server on port {PORT}")
+        vite = start_vite(PORT)
+    try:
+        wait_for_smoke_page(
+            f"{BASE}/smoke-heavy-thread.html",
+            "smoke-heavy-thread-main.tsx",
+            proc = vite,
+            info = info,
+        )
+        results = run()
+    finally:
+        if vite is not None:
+            stop_process(vite)
+            info("vite stopped")
+
+    report = report_growth(results)
+    results["growth"] = report
+    out = OUT / f"{LABEL}.json"
+    out.write_text(json.dumps(results, indent = 2), encoding = "utf-8")
+    print_table(results)
+    print_growth(results, report)
+    info(f"wrote {out}")
+
+    failures = harness_failures(results, report)
+    for problem in failures:
+        info(f"HARNESS-BROKEN {problem}")
+    if failures:
+        return 1
+    info("measurement only: no budgets are asserted here, so this exits 0 on any timing.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/studio/playwright_heavy_thread.py
+++ b/tests/studio/playwright_heavy_thread.py
@@ -20,8 +20,10 @@ WHAT IS MEASURED, AND WHY THESE METRICS
 Every primary number here is DOM-observable and wall-clock, because the interesting engines are
 not Chromium. Unsloth Desktop is Tauri: WebView2 on Windows, WKWebView on macOS, WebKitGTK on
 Linux. The Long Tasks API does not exist on JavaScriptCore, so a `longtask` PerformanceObserver
-silently reports NOTHING on Desktop macOS and Desktop Linux -- it does not error, it just never
-fires, which reads as "no jank" instead of "no measurement". `Performance.getMetrics` and
+silently reports NOTHING on Desktop macOS and Desktop Linux. Measured here: on WebKit 26.5 and
+Firefox 153 the `observe({ type: "longtask" })` call does not even throw. It is accepted and then
+never fires, which reads as "no jank" instead of "no measurement", so support is read from
+`PerformanceObserver.supportedEntryTypes` instead. `Performance.getMetrics` and
 `Emulation.setCPUThrottlingRate` are CDP, so they do not exist off Chromium either.
 
 So the primary four, all portable:

--- a/tests/studio/playwright_heavy_thread.py
+++ b/tests/studio/playwright_heavy_thread.py
@@ -1178,7 +1178,9 @@ def harness_failures(results: dict, report: dict) -> list[str]:
             row = results["by_engine"][engine]["by_size"][str(size)]
             where = f"{engine} at {size} chars"
             if "crashed" in row:
-                failures.append(f"{where} crashed before it produced a measurement: {row['crashed']}")
+                failures.append(
+                    f"{where} crashed before it produced a measurement: {row['crashed']}"
+                )
                 continue
             counts = row["counts"]
             plan = row["plan"]

--- a/tests/studio/portal_host_behaviour.py
+++ b/tests/studio/portal_host_behaviour.py
@@ -1,0 +1,279 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Does moving every Radix portal off `<body>` change what the user sees or can click?
+
+lib/portal-host.ts moves floating surfaces from `document.body` into a `display: contents` div
+that is a child of `document.body`, so React stops attaching its delegated event listener set to
+`<body>`. That is event plumbing, and a regression in it would be invisible in a screenshot and
+very visible in use, so the listener census is not the test. This is.
+
+Per engine, on a seeded thread, this asserts:
+
+    the menu opens, and reports the same item count as before
+    the menu content is inside the portal host, not a child of body
+    the menu's bounding box is where it was, to the pixel
+    every menu item is HIT TESTABLE: document.elementFromPoint at the item's centre lands
+      inside that item. This is the check that catches a stacking or pointer-events regression,
+      which a screenshot cannot
+    Escape dismisses it, and one click outside dismisses it and does NOT actuate the control
+      underneath, which is the footgun PR 9051's swallowDismissingClick exists to hold shut
+    a tooltip still appears on hover and is itself hit testable
+
+Geometry is compared BETWEEN TREES rather than against a constant: run this on the control tree
+and on the fix tree and diff the JSON. A menu that moved by a pixel is a real regression and a
+hard-coded expectation would either miss it or fail on every unrelated layout change.
+
+Run:
+    SMOKE_PORT=5601 PROBE_CHARS=25000 python tests/studio/portal_host_behaviour.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+import sys
+import time
+from pathlib import Path
+
+from playwright.sync_api import sync_playwright
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _playwright_robust import chromium_launch_args, start_vite, stop_process  # noqa: E402
+import playwright_heavy_thread as hv  # noqa: E402
+
+PORT = int(os.environ.get("SMOKE_PORT", "5601"))
+BASE = os.environ.get("SMOKE_BASE_URL", "").strip().rstrip("/") or f"http://127.0.0.1:{PORT}"
+OWNS_SERVER = not os.environ.get("SMOKE_BASE_URL", "").strip()
+CHARS = int(os.environ.get("PROBE_CHARS", "25000"))
+ENGINES = [e.strip() for e in os.environ.get("PROBE_ENGINES", "chromium").split(",") if e.strip()]
+LABEL = os.environ.get("PROBE_LABEL", "portal_behaviour")
+OUT = Path(os.environ.get("PW_ART_DIR", "logs/portal-host"))
+OUT.mkdir(parents = True, exist_ok = True)
+
+
+def info(m: str) -> None:
+    print(f"[portal] {m}", flush = True)
+
+
+# Open the More menu and describe it completely enough that two trees can be diffed.
+INSPECT_JS = """
+async () => {
+  const api = window.__heavyThread;
+  const trigger = api.actionButton("More");
+  if (!trigger) return { error: "no More trigger" };
+  const pointer = { bubbles: true, cancelable: true, composed: true, button: 0,
+                    pointerId: 1, pointerType: "mouse", isPrimary: true };
+  trigger.dispatchEvent(new PointerEvent("pointerdown", { ...pointer, buttons: 1 }));
+  trigger.dispatchEvent(new PointerEvent("pointerup", { ...pointer, buttons: 0 }));
+  const deadline = performance.now() + 30000;
+  let content = null;
+  while (performance.now() < deadline) {
+    content = document.querySelector(".aui-action-bar-more-content");
+    if (content) break;
+    await new Promise((r) => requestAnimationFrame(() => r()));
+  }
+  if (!content) return { error: "menu never opened" };
+  // Two frames so the popper has positioned and any open animation has committed.
+  await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(() => r())));
+
+  const round = (r) => ({ x: Math.round(r.x), y: Math.round(r.y),
+                          w: Math.round(r.width), h: Math.round(r.height) });
+  const host = document.getElementById("unsloth-portal-host");
+  const items = [...content.querySelectorAll('[role="menuitem"], [role="menuitemcheckbox"]')];
+  const hitTests = items.map((it) => {
+    const r = it.getBoundingClientRect();
+    const el = document.elementFromPoint(Math.round(r.x + r.width / 2),
+                                        Math.round(r.y + r.height / 2));
+    return {
+      label: (it.textContent || "").trim().slice(0, 24),
+      rect: round(r),
+      // `contains` and not identity: the centre of an item legitimately lands on an icon or a
+      // label span INSIDE it. What must not happen is landing outside the item entirely, which
+      // is what a stacking or pointer-events regression looks like.
+      hit: Boolean(el && it.contains(el)),
+      hitTag: el ? el.tagName.toLowerCase() : null,
+    };
+  });
+  const cs = getComputedStyle(content);
+  return {
+    itemCount: items.length,
+    contentRect: round(content.getBoundingClientRect()),
+    triggerRect: round(trigger.getBoundingClientRect()),
+    zIndex: cs.zIndex,
+    position: cs.position,
+    visibility: cs.visibility,
+    opacity: cs.opacity,
+    hitTests,
+    allItemsHit: hitTests.every((h) => h.hit),
+    portalHostExists: Boolean(host),
+    portalHostDisplay: host ? getComputedStyle(host).display : null,
+    // Where the floating surface actually lives. On the control tree the popper wrapper is a
+    // direct child of body; on the fix tree it is inside the host, and the host is a child of
+    // body, so the surface is at the same depth in the box tree because the host generates no box.
+    contentInsideHost: Boolean(host && host.contains(content)),
+    popperParentIsBody:
+      content.closest("[data-radix-popper-content-wrapper]")?.parentElement === document.body,
+    bodyListenerHostId: document.body.lastElementChild?.id || null,
+  };
+}
+"""
+
+# Escape closes it, and then a single click on the neighbouring control must close a REOPENED
+# menu without actuating that control. That second half is the swallowDismissingClick contract
+# from PR 9051, which this change must not break.
+DISMISS_JS = """
+async () => {
+  const api = window.__heavyThread;
+  const gone = async () => {
+    const deadline = performance.now() + 15000;
+    while (performance.now() < deadline) {
+      if (!document.querySelector(".aui-action-bar-more-content")) return true;
+      await new Promise((r) => requestAnimationFrame(() => r()));
+    }
+    return false;
+  };
+  document.dispatchEvent(
+    new KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true }),
+  );
+  const closedByEscape = await gone();
+
+  // Reopen, then click a sibling action button and check the click was swallowed.
+  const trigger = api.actionButton("More");
+  const neighbour = api.actionButton("Refresh") || api.actionButton("Copy");
+  if (!trigger || !neighbour) return { closedByEscape, neighbourTested: false };
+  const pointer = { bubbles: true, cancelable: true, composed: true, button: 0,
+                    pointerId: 1, pointerType: "mouse", isPrimary: true };
+  trigger.dispatchEvent(new PointerEvent("pointerdown", { ...pointer, buttons: 1 }));
+  trigger.dispatchEvent(new PointerEvent("pointerup", { ...pointer, buttons: 0 }));
+  const deadline = performance.now() + 15000;
+  while (performance.now() < deadline) {
+    if (document.querySelector(".aui-action-bar-more-content")) break;
+    await new Promise((r) => requestAnimationFrame(() => r()));
+  }
+  let neighbourFired = false;
+  const spy = () => { neighbourFired = true; };
+  neighbour.addEventListener("click", spy);
+  neighbour.dispatchEvent(new PointerEvent("pointerdown", { ...pointer, buttons: 1 }));
+  neighbour.dispatchEvent(new PointerEvent("pointerup", { ...pointer, buttons: 0 }));
+  neighbour.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+  const closedByOutsideClick = await gone();
+  neighbour.removeEventListener("click", spy);
+  return {
+    closedByEscape,
+    neighbourTested: true,
+    closedByOutsideClick,
+    // The whole point of the swallow: dismissing must not also press the button next door.
+    neighbourFired,
+  };
+}
+"""
+
+TOOLTIP_JS = """
+async () => {
+  const t = document.querySelector('[data-slot="tooltip-trigger"]');
+  if (!t) return { tested: false };
+  t.scrollIntoView({ block: "center", behavior: "instant" });
+  await new Promise((r) => requestAnimationFrame(() => r()));
+  for (const type of ["pointerover", "pointerenter", "mouseover", "mouseenter", "focus"]) {
+    t.dispatchEvent(new (type.startsWith("pointer") ? PointerEvent : type === "focus" ? FocusEvent : MouseEvent)(
+      type, { bubbles: type !== "pointerenter" && type !== "mouseenter" && type !== "focus", cancelable: true },
+    ));
+  }
+  const deadline = performance.now() + 8000;
+  let tip = null;
+  while (performance.now() < deadline) {
+    tip = document.querySelector('[data-slot="tooltip-content"], [role="tooltip"]');
+    if (tip && tip.getBoundingClientRect().width > 0) break;
+    await new Promise((r) => setTimeout(r, 50));
+  }
+  if (!tip) return { tested: true, appeared: false };
+  const r = tip.getBoundingClientRect();
+  const host = document.getElementById("unsloth-portal-host");
+  return {
+    tested: true,
+    appeared: true,
+    rect: { x: Math.round(r.x), y: Math.round(r.y), w: Math.round(r.width), h: Math.round(r.height) },
+    insideHost: Boolean(host && host.contains(tip)),
+    visible: getComputedStyle(tip).visibility,
+  };
+}
+"""
+
+
+def main() -> int:
+    results = {"label": LABEL, "chars": CHARS, "engines": {}}
+    vite = None
+    try:
+        if OWNS_SERVER:
+            info(f"starting vite on {PORT}")
+            vite = start_vite(PORT)
+            deadline = time.time() + 300
+            while time.time() < deadline:
+                with socket.socket() as s:
+                    s.settimeout(1)
+                    if s.connect_ex(("127.0.0.1", PORT)) == 0:
+                        break
+                time.sleep(1)
+            info("vite ready")
+        with sync_playwright() as pw:
+            for engine in ENGINES:
+                info(f"--- {engine}")
+                launcher = getattr(pw, engine)
+                kwargs = {"args": chromium_launch_args()} if engine == "chromium" else {}
+                browser = launcher.launch(**kwargs)
+                ctx = browser.new_context(viewport = {"width": 1280, "height": 900})
+                ctx.add_init_script(hv.RECORDER_INIT)
+                page = ctx.new_page()
+                try:
+                    page.goto(f"{BASE}/smoke-heavy-thread.html", wait_until = "domcontentloaded")
+                    page.wait_for_function(
+                        "() => Boolean(window.__heavyThread)", timeout = 180_000
+                    )
+                    plan = page.evaluate("(n) => window.__heavyThread.seed(n)", CHARS)
+                    page.wait_for_function(
+                        "(n) => window.__heavyThread.messageCount() >= n",
+                        arg = plan["messages"], timeout = 600_000,
+                    )
+                    n = page.evaluate("() => window.__heavyThread.expandTools()")
+                    if n:
+                        page.wait_for_function(
+                            "(k) => window.__heavyThread.counts().collapsibleOutputs >= k",
+                            arg = n, timeout = 300_000,
+                        )
+                    hv.wait_for_highlighting_settled(page, 600_000)
+                    page.evaluate(
+                        """() => { const m = window.__heavyThread.lastAssistantMessage();
+                            if (m) m.scrollIntoView({ block: "center", behavior: "instant" }); }"""
+                    )
+                    page.wait_for_timeout(500)
+                    page.locator('[data-role="assistant"]').last.hover(timeout = 300_000)
+
+                    row: dict = {}
+                    row["menu"] = page.evaluate(INSPECT_JS)
+                    page.screenshot(path = str(OUT / f"{LABEL}_{engine}_menu_open.png"))
+                    row["dismiss"] = page.evaluate(DISMISS_JS)
+                    row["tooltip"] = page.evaluate(TOOLTIP_JS)
+                    page.screenshot(path = str(OUT / f"{LABEL}_{engine}_tooltip.png"))
+                    results["engines"][engine] = row
+                    info(f"  menu {json.dumps(row['menu'])[:400]}")
+                    info(f"  dismiss {json.dumps(row['dismiss'])}")
+                    info(f"  tooltip {json.dumps(row['tooltip'])}")
+                except Exception as exc:  # noqa: BLE001
+                    results["engines"][engine] = {"failed": repr(exc)}
+                    info(f"  FAILED {exc!r}")
+                finally:
+                    ctx.close()
+                    browser.close()
+        out = OUT / f"{LABEL}.json"
+        out.write_text(json.dumps(results, indent = 2))
+        info(f"wrote {out}")
+    finally:
+        if vite is not None:
+            stop_process(vite)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/studio/portal_host_behaviour.py
+++ b/tests/studio/portal_host_behaviour.py
@@ -228,19 +228,19 @@ def main() -> int:
                 page = ctx.new_page()
                 try:
                     page.goto(f"{BASE}/smoke-heavy-thread.html", wait_until = "domcontentloaded")
-                    page.wait_for_function(
-                        "() => Boolean(window.__heavyThread)", timeout = 180_000
-                    )
+                    page.wait_for_function("() => Boolean(window.__heavyThread)", timeout = 180_000)
                     plan = page.evaluate("(n) => window.__heavyThread.seed(n)", CHARS)
                     page.wait_for_function(
                         "(n) => window.__heavyThread.messageCount() >= n",
-                        arg = plan["messages"], timeout = 600_000,
+                        arg = plan["messages"],
+                        timeout = 600_000,
                     )
                     n = page.evaluate("() => window.__heavyThread.expandTools()")
                     if n:
                         page.wait_for_function(
                             "(k) => window.__heavyThread.counts().collapsibleOutputs >= k",
-                            arg = n, timeout = 300_000,
+                            arg = n,
+                            timeout = 300_000,
                         )
                     hv.wait_for_highlighting_settled(page, 600_000)
                     page.evaluate(

--- a/tests/studio/probe_menu_behaviour.py
+++ b/tests/studio/probe_menu_behaviour.py
@@ -1,0 +1,256 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Behavioural probe for the message action menu's modal/non-modal switch.
+
+Answers the three questions a reviewer will ask about dropping `modal`, and one the
+coordinator added that matters more than the other three:
+
+  destructive  with the menu open, does ONE click on the adjacent "Delete message"
+               button both dismiss the menu AND delete the message? The action bar is
+               a single flex row and its order is
+               Copy, Edit, Refresh, ForkCount, Delete, [Speak], More
+               so Delete sits two 32 px buttons from the More trigger and the menu
+               opens directly beneath it (side="bottom" align="start"). Under `modal`
+               the body carries pointer-events:none and that click is swallowed. This
+               probe measures whether it stops being swallowed.
+  scroll       does the thread scroll under an open menu (no RemoveScroll)?
+  ariaHidden   is the rest of the page still aria-hidden while the menu is open?
+
+Every click here goes through `page.mouse.click(x, y)`, a real hit test that honours
+pointer-events. `locator.click()` and `element.click()` would each lie in a different
+direction: the first throws on an intercepted click, the second bypasses hit testing
+entirely and would report the destructive click as landing in BOTH states.
+
+Usage:  python tests/studio/probe_menu_behaviour.py --label baseline|patched
+Writes logs/pw/probe_<label>.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from playwright_heavy_thread import (  # noqa: E402
+    BASE,
+    OWNS_SERVER,
+    PORT,
+    start_vite,
+    stop_process,
+    wait_for_smoke_page,
+)
+
+CHARS = int(os.environ.get("PROBE_CHARS", "25000"))
+SHOT_DIR = Path(os.environ.get("PROBE_SHOT_DIR", "logs/pw/shots"))
+
+
+OPEN_MENU_JS = """
+async () => {
+  const api = window.__heavyThread;
+  const trigger = api.actionButton("More");
+  if (!trigger) return { ok: false, why: "no More trigger" };
+  const pointer = {
+    bubbles: true, cancelable: true, composed: true,
+    button: 0, pointerId: 1, pointerType: "mouse", isPrimary: true,
+  };
+  trigger.dispatchEvent(new PointerEvent("pointerdown", { ...pointer, buttons: 1 }));
+  trigger.dispatchEvent(new PointerEvent("pointerup", { ...pointer, buttons: 0 }));
+  const deadline = performance.now() + 15000;
+  while (performance.now() < deadline) {
+    if (document.querySelector(".aui-action-bar-more-content")) break;
+    await new Promise((r) => requestAnimationFrame(r));
+  }
+  return { ok: Boolean(document.querySelector(".aui-action-bar-more-content")) };
+}
+"""
+
+# Read the facts a screenshot cannot show. aria-hidden is invisible by construction and
+# the body's pointer-events is the whole mechanism under test.
+FACTS_JS = """
+() => {
+  const api = window.__heavyThread;
+  const del = api.actionButton("Delete message");
+  const r = del ? del.getBoundingClientRect() : null;
+  // hideOthers() marks the target's SIBLINGS, so count aria-hidden among body's children.
+  const bodyKids = Array.from(document.body.children);
+  return {
+    menuOpen: Boolean(document.querySelector(".aui-action-bar-more-content")),
+    menuItems: document.querySelectorAll(".aui-action-bar-more-item").length,
+    bodyPointerEvents: getComputedStyle(document.body).pointerEvents,
+    deleteButtonPresent: Boolean(del),
+    deleteComputedPointerEvents: del ? getComputedStyle(del).pointerEvents : null,
+    deleteRect: r ? { x: r.x + r.width / 2, y: r.y + r.height / 2 } : null,
+    // What the browser says is actually at the Delete button's centre. If a shield is
+    // in place this is NOT the delete button.
+    hitAtDelete: r
+      ? (() => {
+          const el = document.elementFromPoint(r.x + r.width / 2, r.y + r.height / 2);
+          if (!el) return null;
+          const btn = el.closest("button");
+          return {
+            tag: el.tagName,
+            insideDeleteButton: Boolean(btn && btn === del),
+            text: (btn ? btn.textContent : el.textContent || "").trim().slice(0, 40),
+          };
+        })()
+      : null,
+    ariaHiddenBodyChildren: bodyKids.filter(
+      (el) => el.getAttribute("aria-hidden") === "true"
+    ).length,
+    bodyChildren: bodyKids.length,
+    assistantMessages: document.querySelectorAll('[data-role="assistant"]').length,
+    scrollTop: Math.round(window.__heavyThread.viewportMetrics().scrollTop),
+  };
+}
+"""
+
+# A real wheel gesture over the viewport, which is what RemoveScroll actually gates.
+# A programmatic scrollTop write is not blocked by RemoveScroll in either state and
+# would report "scrolls" on both sides, i.e. prove nothing.
+SCROLL_JS = """
+async () => {
+  const before = window.__heavyThread.viewportMetrics().scrollTop;
+  return { before: Math.round(before) };
+}
+"""
+
+SCROLL_AFTER_JS = """
+async () => {
+  const after = window.__heavyThread.viewportMetrics().scrollTop;
+  return { after: Math.round(after) };
+}
+"""
+
+
+async def drive(page, label: str) -> dict:
+    out: dict = {"label": label}
+    SHOT_DIR.mkdir(parents = True, exist_ok = True)
+
+    opened = await page.evaluate(OPEN_MENU_JS)
+    out["menu_opened"] = opened
+    if not opened.get("ok"):
+        out["fatal"] = "menu never opened"
+        return out
+
+    out["while_open"] = await page.evaluate(FACTS_JS)
+    await page.screenshot(path = str(SHOT_DIR / f"{label}_1_menu_open.png"))
+
+    # --- the destructive question -------------------------------------------------
+    # A real hit test at the Delete button's centre, with the menu still open.
+    rect = out["while_open"]["deleteRect"]
+    before_msgs = out["while_open"]["assistantMessages"]
+    if rect:
+        await page.mouse.click(rect["x"], rect["y"])
+        await page.wait_for_timeout(1200)
+        after = await page.evaluate(FACTS_JS)
+        out["after_click_on_delete"] = after
+        out["destructive_click_through"] = (
+            after["assistantMessages"] < before_msgs
+        )
+        out["menu_closed_by_that_click"] = not after["menuOpen"]
+        await page.screenshot(path = str(SHOT_DIR / f"{label}_2_after_click_delete.png"))
+    else:
+        out["fatal"] = "no Delete message button found"
+        return out
+
+    # --- scroll lock ---------------------------------------------------------------
+    # Re-open, then try to scroll the thread underneath it.
+    reopened = await page.evaluate(OPEN_MENU_JS)
+    if reopened.get("ok"):
+        before = await page.evaluate(SCROLL_JS)
+        vp = await page.evaluate(
+            "() => { const v = window.__heavyThread.viewport();"
+            "if (!v) return null; const r = v.getBoundingClientRect();"
+            "return { x: r.x + r.width / 2, y: r.y + r.height / 2 }; }"
+        )
+        if vp:
+            await page.mouse.move(vp["x"], vp["y"])
+            for _ in range(6):
+                await page.mouse.wheel(0, -400)
+                await page.wait_for_timeout(120)
+        after = await page.evaluate(SCROLL_AFTER_JS)
+        out["scroll_under_open_menu"] = {
+            **before, **after,
+            "delta": after["after"] - before["before"],
+            "scrolled": after["after"] != before["before"],
+        }
+        await page.screenshot(path = str(SHOT_DIR / f"{label}_3_scrolled_under_menu.png"))
+        out["after_scroll"] = await page.evaluate(FACTS_JS)
+    else:
+        out["scroll_under_open_menu"] = {"error": "menu did not re-open"}
+    return out
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--label", required = True)
+    ap.add_argument("--engine", default = "chromium",
+                    choices = ("chromium", "webkit", "firefox"))
+    args = ap.parse_args()
+
+    from playwright.async_api import async_playwright
+    import asyncio
+
+    async def run() -> dict:
+        async with async_playwright() as pw:
+            browser = await getattr(pw, args.engine).launch(headless = True)
+            page = await browser.new_page(viewport = {"width": 1280, "height": 900})
+            await page.goto(
+                f"{BASE}/smoke-heavy-thread.html", wait_until = "domcontentloaded"
+            )
+            await page.wait_for_function(
+                "() => Boolean(window.__heavyThread)", timeout = 60_000
+            )
+            plan = await page.evaluate(
+                "(n) => window.__heavyThread.seed(n)", CHARS
+            )
+            await page.wait_for_function(
+                "(n) => window.__heavyThread.messageCount() >= n",
+                arg = plan["messages"],
+                timeout = 300_000,
+            )
+            # Hover the last assistant message so its action bar mounts.
+            await page.evaluate(
+                "() => window.__heavyThread.lastAssistantMessage()"
+                "?.scrollIntoView({ block: 'center' })"
+            )
+            box = await page.evaluate(
+                "() => { const m = window.__heavyThread.lastAssistantMessage();"
+                "if (!m) return null; const r = m.getBoundingClientRect();"
+                "return { x: r.x + r.width / 2, y: r.y + r.height / 2 }; }"
+            )
+            if box:
+                await page.mouse.move(box["x"], box["y"])
+                await page.wait_for_timeout(600)
+            result = await drive(page, args.label)
+            await browser.close()
+            return result
+
+    vite = start_vite(PORT) if OWNS_SERVER else None
+    try:
+        wait_for_smoke_page(
+            f"{BASE}/smoke-heavy-thread.html",
+            "smoke-heavy-thread-main.tsx",
+            proc = vite,
+            info = lambda m: print(f"[probe] {m}", flush = True),
+        )
+        result = asyncio.run(run())
+    finally:
+        if vite is not None:
+            stop_process(vite)
+
+    out = Path("logs/pw") / f"probe_{args.label}_{args.engine}.json"
+    out.parent.mkdir(parents = True, exist_ok = True)
+    out.write_text(json.dumps(result, indent = 2), encoding = "utf-8")
+    print(json.dumps(result, indent = 2))
+    print(f"[probe] wrote {out}", flush = True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/studio/probe_menu_behaviour.py
+++ b/tests/studio/probe_menu_behaviour.py
@@ -187,7 +187,8 @@ async def drive(page, label: str) -> dict:
 
 def main() -> int:
     ap = argparse.ArgumentParser()
-    ap.add_argument("--label", required = True)
+    # Defaulted so a generic CI driver can invoke this with no arguments.
+    ap.add_argument("--label", default = "run")
     ap.add_argument("--engine", default = "chromium", choices = ("chromium", "webkit", "firefox"))
     args = ap.parse_args()
 

--- a/tests/studio/probe_menu_behaviour.py
+++ b/tests/studio/probe_menu_behaviour.py
@@ -149,9 +149,7 @@ async def drive(page, label: str) -> dict:
         await page.wait_for_timeout(1200)
         after = await page.evaluate(FACTS_JS)
         out["after_click_on_delete"] = after
-        out["destructive_click_through"] = (
-            after["assistantMessages"] < before_msgs
-        )
+        out["destructive_click_through"] = after["assistantMessages"] < before_msgs
         out["menu_closed_by_that_click"] = not after["menuOpen"]
         await page.screenshot(path = str(SHOT_DIR / f"{label}_2_after_click_delete.png"))
     else:
@@ -175,7 +173,8 @@ async def drive(page, label: str) -> dict:
                 await page.wait_for_timeout(120)
         after = await page.evaluate(SCROLL_AFTER_JS)
         out["scroll_under_open_menu"] = {
-            **before, **after,
+            **before,
+            **after,
             "delta": after["after"] - before["before"],
             "scrolled": after["after"] != before["before"],
         }
@@ -189,8 +188,7 @@ async def drive(page, label: str) -> dict:
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--label", required = True)
-    ap.add_argument("--engine", default = "chromium",
-                    choices = ("chromium", "webkit", "firefox"))
+    ap.add_argument("--engine", default = "chromium", choices = ("chromium", "webkit", "firefox"))
     args = ap.parse_args()
 
     from playwright.async_api import async_playwright
@@ -200,15 +198,9 @@ def main() -> int:
         async with async_playwright() as pw:
             browser = await getattr(pw, args.engine).launch(headless = True)
             page = await browser.new_page(viewport = {"width": 1280, "height": 900})
-            await page.goto(
-                f"{BASE}/smoke-heavy-thread.html", wait_until = "domcontentloaded"
-            )
-            await page.wait_for_function(
-                "() => Boolean(window.__heavyThread)", timeout = 60_000
-            )
-            plan = await page.evaluate(
-                "(n) => window.__heavyThread.seed(n)", CHARS
-            )
+            await page.goto(f"{BASE}/smoke-heavy-thread.html", wait_until = "domcontentloaded")
+            await page.wait_for_function("() => Boolean(window.__heavyThread)", timeout = 60_000)
+            plan = await page.evaluate("(n) => window.__heavyThread.seed(n)", CHARS)
             await page.wait_for_function(
                 "(n) => window.__heavyThread.messageCount() >= n",
                 arg = plan["messages"],

--- a/tests/studio/probe_menus_growth.py
+++ b/tests/studio/probe_menus_growth.py
@@ -1,0 +1,186 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Does EVERY Radix menu mounted over a long thread pay the body pointer-events cost?
+
+The action menu was fixed by `modal={false}`, but the mechanism is not specific to it:
+a modal Radix layer writes `pointer-events` onto `<body>`, an INHERITED property, so the
+whole mounted thread subtree is invalidated no matter which menu opened. This walks every
+open-able menu trigger on the page at two thread sizes and reports open+close per menu,
+so "extend the fix" is a decision with a per-menu number behind it rather than a guess.
+
+`bodyPointerEvents` while open is the discriminator: `none` means the menu took the modal
+path and pays the cost, `auto` means it did not.
+
+Usage: python tests/studio/probe_menus_growth.py --label before --chars 25000,300000
+Writes logs/pw/menus_<label>.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from playwright_heavy_thread import (  # noqa: E402
+    BASE,
+    OWNS_SERVER,
+    PORT,
+    start_vite,
+    stop_process,
+    wait_for_smoke_page,
+)
+
+# Radix menu triggers carry aria-haspopup="menu". Selects use listbox, so both are
+# enumerated: the expansion list contains only menus and selects.
+ENUMERATE_JS = """
+() => {
+  const nodes = Array.from(
+    document.querySelectorAll('button[aria-haspopup="menu"], button[aria-haspopup="listbox"]')
+  );
+  return nodes.map((el, i) => {
+    el.setAttribute("data-menuprobe", String(i));
+    const r = el.getBoundingClientRect();
+    return {
+      index: i,
+      name: (el.textContent || el.getAttribute("aria-label") || "").trim().slice(0, 48),
+      haspopup: el.getAttribute("aria-haspopup"),
+      visible: r.width > 0 && r.height > 0,
+    };
+  });
+}
+"""
+
+# Open by real pointer events (Radix triggers open on pointerdown, not click), then wait
+# for the portaled content. Timed the same way the 9016 harness times the action menu:
+# the clock starts before the dispatch, because Radix does its layer work synchronously
+# inside it.
+CYCLE_JS = """
+async (index) => {
+  const el = document.querySelector(`[data-menuprobe="${index}"]`);
+  if (!el) return { ok: false, why: "trigger vanished" };
+  const isOpen = () => Boolean(
+    document.querySelector('[data-radix-menu-content], [data-radix-select-content], [role="menu"][data-state="open"]')
+  );
+  if (isOpen()) return { ok: false, why: "something already open" };
+  const pointer = {
+    bubbles: true, cancelable: true, composed: true,
+    button: 0, pointerId: 1, pointerType: "mouse", isPrimary: true,
+  };
+  const settle = async (want, budget) => {
+    const t0 = performance.now();
+    while (performance.now() - t0 < budget) {
+      if (isOpen() === want) return performance.now() - t0;
+      await new Promise((r) => requestAnimationFrame(r));
+    }
+    return null;
+  };
+  const openStart = performance.now();
+  el.scrollIntoView({ block: "center" });
+  el.dispatchEvent(new PointerEvent("pointerdown", { ...pointer, buttons: 1 }));
+  el.dispatchEvent(new PointerEvent("pointerup", { ...pointer, buttons: 0 }));
+  const openedIn = await settle(true, 20000);
+  if (openedIn === null) return { ok: false, why: "never opened" };
+  const openMs = performance.now() - openStart;
+  const bodyPointerEvents = getComputedStyle(document.body).pointerEvents;
+
+  const closeStart = performance.now();
+  document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+  const closedIn = await settle(false, 20000);
+  const closeMs = closedIn === null ? null : performance.now() - closeStart;
+  return {
+    ok: closeMs !== null,
+    openMs: Math.round(openMs * 10) / 10,
+    closeMs: closeMs === null ? null : Math.round(closeMs * 10) / 10,
+    open_close_ms: closeMs === null ? null : Math.round((openMs + closeMs) * 10) / 10,
+    bodyPointerEvents,
+  };
+}
+"""
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--label", required = True)
+    ap.add_argument("--chars", default = "25000,300000")
+    ap.add_argument("--reps", type = int, default = 3)
+    ap.add_argument("--engine", default = "chromium")
+    args = ap.parse_args()
+
+    sizes = [int(c) for c in args.chars.split(",")]
+
+    from playwright.sync_api import sync_playwright
+
+    results: dict = {"label": args.label, "engine": args.engine, "by_size": {}}
+
+    vite = start_vite(PORT) if OWNS_SERVER else None
+    try:
+        wait_for_smoke_page(
+            f"{BASE}/smoke-heavy-thread.html",
+            "smoke-heavy-thread-main.tsx",
+            proc = vite,
+            info = lambda m: print(f"[menus] {m}", flush = True),
+        )
+        with sync_playwright() as pw:
+            browser = getattr(pw, args.engine).launch(headless = True)
+            for size in sizes:
+                print(f"[menus] seeding {size}", flush = True)
+                page = browser.new_page(viewport = {"width": 1440, "height": 950})
+                page.goto(f"{BASE}/smoke-heavy-thread.html",
+                          wait_until = "domcontentloaded")
+                page.wait_for_function("() => Boolean(window.__heavyThread)",
+                                       timeout = 60_000)
+                plan = page.evaluate("(n) => window.__heavyThread.seed(n)", size)
+                page.wait_for_function(
+                    "(n) => window.__heavyThread.messageCount() >= n",
+                    arg = plan["messages"], timeout = 300_000,
+                )
+                page.wait_for_timeout(1500)
+
+                triggers = [t for t in page.evaluate(ENUMERATE_JS) if t["visible"]]
+                print(f"[menus] {size}: {len(triggers)} visible menu triggers",
+                      flush = True)
+                per_menu: dict = {}
+                for t in triggers:
+                    samples = []
+                    body_pe = None
+                    for _ in range(args.reps):
+                        r = page.evaluate(CYCLE_JS, t["index"])
+                        if r.get("ok"):
+                            samples.append(r["open_close_ms"])
+                            body_pe = r["bodyPointerEvents"]
+                        page.keyboard.press("Escape")
+                        page.wait_for_timeout(250)
+                    key = t["name"] or f"trigger#{t['index']}"
+                    per_menu[key] = {
+                        "haspopup": t["haspopup"],
+                        "samples": samples,
+                        "median_open_close_ms": (
+                            round(statistics.median(samples), 1) if samples else None
+                        ),
+                        "bodyPointerEvents": body_pe,
+                    }
+                    print(f"[menus]   {key}: {per_menu[key]['median_open_close_ms']} ms "
+                          f"body={body_pe}", flush = True)
+                results["by_size"][str(size)] = {
+                    "messages": plan["messages"], "menus": per_menu,
+                }
+                page.close()
+            browser.close()
+    finally:
+        if vite is not None:
+            stop_process(vite)
+
+    out = Path("logs/pw") / f"menus_{args.label}_{args.engine}.json"
+    out.parent.mkdir(parents = True, exist_ok = True)
+    out.write_text(json.dumps(results, indent = 2), encoding = "utf-8")
+    print(f"[menus] wrote {out}", flush = True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/studio/probe_menus_growth.py
+++ b/tests/studio/probe_menus_growth.py
@@ -130,20 +130,18 @@ def main() -> int:
             for size in sizes:
                 print(f"[menus] seeding {size}", flush = True)
                 page = browser.new_page(viewport = {"width": 1440, "height": 950})
-                page.goto(f"{BASE}/smoke-heavy-thread.html",
-                          wait_until = "domcontentloaded")
-                page.wait_for_function("() => Boolean(window.__heavyThread)",
-                                       timeout = 60_000)
+                page.goto(f"{BASE}/smoke-heavy-thread.html", wait_until = "domcontentloaded")
+                page.wait_for_function("() => Boolean(window.__heavyThread)", timeout = 60_000)
                 plan = page.evaluate("(n) => window.__heavyThread.seed(n)", size)
                 page.wait_for_function(
                     "(n) => window.__heavyThread.messageCount() >= n",
-                    arg = plan["messages"], timeout = 300_000,
+                    arg = plan["messages"],
+                    timeout = 300_000,
                 )
                 page.wait_for_timeout(1500)
 
                 triggers = [t for t in page.evaluate(ENUMERATE_JS) if t["visible"]]
-                print(f"[menus] {size}: {len(triggers)} visible menu triggers",
-                      flush = True)
+                print(f"[menus] {size}: {len(triggers)} visible menu triggers", flush = True)
                 per_menu: dict = {}
                 for t in triggers:
                     samples = []
@@ -164,10 +162,14 @@ def main() -> int:
                         ),
                         "bodyPointerEvents": body_pe,
                     }
-                    print(f"[menus]   {key}: {per_menu[key]['median_open_close_ms']} ms "
-                          f"body={body_pe}", flush = True)
+                    print(
+                        f"[menus]   {key}: {per_menu[key]['median_open_close_ms']} ms "
+                        f"body={body_pe}",
+                        flush = True,
+                    )
                 results["by_size"][str(size)] = {
-                    "messages": plan["messages"], "menus": per_menu,
+                    "messages": plan["messages"],
+                    "menus": per_menu,
                 }
                 page.close()
             browser.close()

--- a/tests/studio/probe_menus_growth.py
+++ b/tests/studio/probe_menus_growth.py
@@ -105,7 +105,8 @@ async (index) => {
 
 def main() -> int:
     ap = argparse.ArgumentParser()
-    ap.add_argument("--label", required = True)
+    # Defaulted so a generic CI driver can invoke this with no arguments.
+    ap.add_argument("--label", default = "run")
     ap.add_argument("--chars", default = "25000,300000")
     ap.add_argument("--reps", type = int, default = 3)
     ap.add_argument("--engine", default = "chromium")

--- a/tests/studio/test_heavy_thread_harness_contract.py
+++ b/tests/studio/test_heavy_thread_harness_contract.py
@@ -1,0 +1,173 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""The heavy-thread harness must read every guard it records, and must stay portable.
+
+`tests/studio/playwright_heavy_thread.py` measures in a browser and then decides pass/fail in
+`main()`. A metric that is recorded but never compared is how a harness goes false-green, which is
+the rule already pinned for the #8483 harnesses in test_autoscroll_harness_contract.py.
+
+This file adds the constraint that is specific to this harness: it is meant to run on WebKit and
+Firefox as well as Chromium, because Unsloth Desktop is a Tauri webview and not Chromium. Every
+CDP counter and the Long Tasks API are Chromium-only, and the failure mode is silent -- a
+`longtask` PerformanceObserver on JavaScriptCore never fires, which reads as "no jank" rather than
+as "no measurement". So no growth axis and no pass/fail decision may rest on one.
+"""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+STUDIO_TESTS = ROOT / "tests" / "studio"
+FRONTEND = ROOT / "studio" / "frontend"
+
+HARNESS = "playwright_heavy_thread.py"
+# Recorded by the harness, produced only by Chromium. None of these may decide anything.
+CHROMIUM_ONLY = (
+    "layout_count",
+    "layout_ms",
+    "recalc_style_count",
+    "recalc_style_ms",
+    "task_ms",
+    "long_tasks",
+    "long_task_ms",
+    "worst_long_task_ms",
+)
+# The portable four the module docstring promises as the primary numbers.
+PORTABLE_PRIMARY = ("longest_stall_ms", "worst_frame_ms", "frames_over_33", "wall_ms")
+ACTIONS = ("keystroke", "scroll", "jump", "menu", "delete", "reopen")
+
+
+def source(name: str) -> str:
+    return (STUDIO_TESTS / name).read_text(encoding = "utf-8")
+
+
+def section(text: str, start: str, end: str) -> str:
+    head = text.index(start)
+    return text[head : text.index(end, head)]
+
+
+def growth_axes() -> str:
+    return section(source(HARNESS), "GROWTH_AXES = tuple(", "DISCRIMINATION_RATIO")
+
+
+def verdict() -> str:
+    """Everything from `def harness_failures` on: the only place a metric turns into an exit
+    code."""
+    text = source(HARNESS)
+    return text[text.index("def harness_failures") :]
+
+
+def test_every_measured_action_has_a_growth_axis() -> None:
+    # An action that is driven but never checked for growth is an action whose column could be
+    # constant at every size without anything failing. The axes are generated from ACTIONS, so
+    # what has to hold is that ACTIONS is the generator and that it still lists all six.
+    text = source(HARNESS)
+    declared = section(text, "ACTIONS = (", ")")
+    for action in ACTIONS:
+        assert f'"{action}"' in declared, action
+    axes = growth_axes()
+    for metric in PORTABLE_PRIMARY:
+        assert f"for a in ACTIONS" in axes and f'"{metric}"' in axes, metric
+
+
+def test_the_portable_primaries_are_the_growth_axes() -> None:
+    axes = growth_axes()
+    for metric in PORTABLE_PRIMARY:
+        assert f'"{metric}"' in axes, metric
+
+
+def test_no_growth_axis_is_chromium_only() -> None:
+    # The whole point of the portable metrics: a curve built on CDP counters is a curve that does
+    # not exist on the engine Unsloth Desktop actually ships on macOS and Linux.
+    axes = growth_axes()
+    for metric in CHROMIUM_ONLY:
+        assert f'"{metric}"' not in axes, metric
+
+
+def test_the_verdict_never_rests_on_a_chromium_only_metric() -> None:
+    decision = verdict()
+    for metric in CHROMIUM_ONLY:
+        assert f'["{metric}"]' not in decision, metric
+
+
+def test_chromium_only_rows_say_so_in_their_own_label() -> None:
+    # Off Chromium these print `-`, and a `-` that means "not supported here" must not be read as
+    # a zero. The label is the only thing carrying that.
+    text = source(HARNESS)
+    table = section(text, "TABLE_ROWS = (", "def print_table")
+    for metric in CHROMIUM_ONLY:
+        for line in table.splitlines():
+            if f'"{metric}"' in line:
+                assert "chromium only" in line, line
+
+
+def test_the_longtask_api_is_recorded_as_supported_or_not() -> None:
+    # Without this flag an engine with no Long Tasks API reports zero long tasks in exactly the
+    # same shape as an engine that had none.
+    text = source(HARNESS)
+    assert "__longTaskSupported" in text
+    assert '("longtask api supported", lambda r: r["long_task_supported"])' in text
+
+
+def test_the_stall_detector_is_a_timer_and_not_a_message_channel() -> None:
+    # Measured, not preference: the MessageChannel ping-pong halves Firefox's frame rate before
+    # any application code runs, so it changes the thing it is there to measure.
+    text = source(HARNESS)
+    assert "new MessageChannel(" not in text, "the recorder must not spin a port"
+    assert "setTimeout(stall, 1)" in text
+
+
+def test_the_verdict_asserts_the_fixture_and_not_just_its_size() -> None:
+    # 300K characters of prose would produce a rising curve too, and would be measuring something
+    # nobody reported.
+    decision = verdict()
+    assert 'plan["expectedPerCycle"]' in decision
+    assert 'counts.get("highlightedTokens", 0)' in decision
+
+
+def test_the_verdict_asserts_the_keystroke_reached_the_runtime() -> None:
+    # The DOM value is what the harness itself wrote. A keystroke that reached nothing still
+    # reports the ~33ms paint floor, which reads as a plausible timing.
+    decision = verdict()
+    assert 'keystroke["runtimeText"] != keystroke["domText"]' in decision
+
+
+def test_the_paint_floor_is_measured_and_subtracted() -> None:
+    # Two rAFs resolve no sooner than two vsync intervals, so an action that never happened still
+    # reports ~33ms. Left in a ratio, that floor compresses every axis towards 1 and lets a real
+    # regression sit under the discrimination threshold.
+    text = source(HARNESS)
+    assert "PAINT_FLOOR_JS" in text
+    assert 'value -= row["paint_floor_ms"]' in section(text, "def growth(", "def report_growth")
+
+
+def test_the_verdict_asserts_the_reopen_really_unmounted() -> None:
+    # Without this, "re-open" is timing a thread that never left, which is free.
+    decision = verdict()
+    assert 'reopened["closedMs"] is None' in decision
+
+
+def test_the_verdict_asserts_discrimination() -> None:
+    # A harness where the largest thread costs what the smallest does is not reporting a flat
+    # curve, it is reporting that it never drove the page.
+    decision = verdict()
+    assert 'row["discriminated"]' in decision
+    assert "DISCRIMINATION_RATIO" in decision
+
+
+def test_the_smoke_page_exposes_every_count_the_fixture_gate_needs() -> None:
+    page = (FRONTEND / "smoke-heavy-thread-main.tsx").read_text(encoding = "utf-8")
+    expected = section(page, "const EXPECTED_PER_CYCLE", "};")
+    counts = section(page, "counts(): Record<string, number>", "viewportMetrics()")
+    for line in expected.splitlines():
+        key = line.strip().split(":")[0]
+        if key.isidentifier():
+            assert f"{key}:" in counts, key
+
+
+def test_the_smoke_page_is_served_and_owns_its_dev_server() -> None:
+    text = source(HARNESS)
+    assert (FRONTEND / "smoke-heavy-thread.html").exists()
+    assert (FRONTEND / "smoke-heavy-thread-main.tsx").exists()
+    assert "start_vite(PORT)" in text
+    assert "stop_process(vite)" in text


### PR DESCRIPTION
## What

Radix's `Portal` defaults its container to `document.body`. React attaches its full delegated event listener set to the container of every portal, the first time a portal targets it, and never removes it. So the first time any menu, tooltip, popover, dialog or select opens, `document.body` acquires a second React event root, and because `<body>` is an ancestor of the whole application, every event anywhere in the app is dispatched twice from then on: once at `#root` and once at `<body>`.

Measured on a 300K character chat thread, `document.body` goes from 1 event listener type to 85 the first time a menu opens, and stays there for the life of the tab.

This routes every portal at one shared `display: contents` div appended to `<body>` instead. The host generates no box, so its children participate in the body stacking context exactly as they did when Radix appended them to `<body>` directly, and React attaches its listener set to the div rather than to `<body>`.

The action bar menu is assistant-ui's, not `components/ui/dropdown-menu.tsx`'s, so routing Studio's own wrappers does not reach it. It accepts `portalProps`, which is spread straight onto its `Portal`.

## This is not a performance change, and it was measured

It was built as one. It is not one, and the PR should not be read as one.

Chromium, 300K characters of thread (43,422 DOM nodes, 110 assistant messages), fresh page per arm, medians of 3, identical 20-step scroll gesture after a menu:

| | gesture ms | frames over 33 ms | long tasks |
|---|---|---|---|
| without this change | 1543.6 | 11 | 11 |
| with this change | 1527.0 | 11 | 11 |

The trace's caller attribution is the same on both sides: 36 React commits at `react-dom_client.js:9077`. The census does move, 85 listener types back to 1, so the change does what it says. The cost simply was not coming from there.

The scroll cost on a heavy thread is driven by the element under a stationary cursor changing as content scrolls past it, one `pointerover` per scroll step at about 63 ms of React work apiece. That is live work and has nothing to do with which container a portal uses. A separate change corrects the harness that made this look like a menu problem.

So the case here is hygiene: one app-wide React event root instead of two, and floating surfaces that stop double-dispatching every event in the application.

## Behaviour, not just listener counts

This is event plumbing, so a regression would be invisible in a screenshot and very visible in use. `tests/studio/portal_host_behaviour.py` asserts, per engine:

| | control | this branch |
|---|---|---|
| menu content inside the portal host | false | true |
| popper wrapper's parent is `<body>` | true | false |
| `document.body` listener types after a menu | 1 to 85 | 1 to 1 |
| menu rect (chromium) | x470 y689 w187 h120 | identical |
| all menu items hit testable via `elementFromPoint` | true | true |
| Escape dismisses | true | true |
| one outside click dismisses without firing the neighbour button | true | true |

Confirmed on chromium, webkit and firefox. That last row is #9051's `swallowDismissingClick` contract, which this must not break, and does not.

## Not covered

The tooltip arm of the behaviour test reports `appeared: false` on all three engines on both the control and this branch, because synthetic pointer events do not satisfy Radix's tooltip open delay. It is equally uninformative on both sides, so it neither supports nor contradicts this change. Tooltips are the most frequently opened portal in the app and are worth a real-pointer check before this is relied on.
