### PR TITLE
Studio: stabilize long reasoning streams

### DIFF
--- a/studio/frontend/package-lock.json
+++ b/studio/frontend/package-lock.json
@@ -8,9 +8,9 @@
       "name": "unsloth-theme",
       "version": "0.0.0",
       "dependencies": {
-        "@assistant-ui/core": "0.1.17",
-        "@assistant-ui/react": "0.12.28",
-        "@assistant-ui/tap": "0.5.10",
+        "@assistant-ui/core": "0.2.23",
+        "@assistant-ui/react": "0.14.29",
+        "@assistant-ui/tap": "0.9.6",
         "@base-ui/react": "^1.2.0",
         "@dagrejs/dagre": "^2.0.4",
         "@dagrejs/graphlib": "^3.0.4",
@@ -42,7 +42,7 @@
         "@tauri-apps/plugin-window-state": "^2.4.1",
         "@toolwind/corner-shape": "^0.0.8-3",
         "@xyflow/react": "^12.10.0",
-        "assistant-stream": "0.3.12",
+        "assistant-stream": "0.3.28",
         "canvas-confetti": "^1.9.4",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -60,7 +60,7 @@
         "micromark-extension-math": "3.1.0",
         "motion": "^12.34.0",
         "node-forge": "^1.4.0",
-        "radix-ui": "^1.4.3",
+        "radix-ui": "^1.6.7",
         "react": "^19.2.4",
         "react-day-picker": "^9.13.2",
         "react-dom": "^19.2.4",
@@ -77,7 +77,7 @@
         "tw-animate-css": "^1.4.0",
         "tw-shimmer": "^0.4.6",
         "unpdf": "^1.4.0",
-        "zustand": "^5.0.11"
+        "zustand": "^5.0.14"
       },
       "devDependencies": {
         "@biomejs/biome": "^1.9.4",
@@ -115,19 +115,19 @@
       }
     },
     "node_modules/@assistant-ui/core": {
-      "version": "0.1.17",
-      "resolved": "https://registry.npmjs.org/@assistant-ui/core/-/core-0.1.17.tgz",
-      "integrity": "sha512-IWIP98UVQ9W+oF0yz8XqFRtaX8HtozWVUWt6D/BSV6cyKwLfJ8niHtLG74bSnllTnGcreU2El3GR/tIodR1XuA==",
+      "version": "0.2.23",
+      "resolved": "https://registry.npmjs.org/@assistant-ui/core/-/core-0.2.23.tgz",
+      "integrity": "sha512-mD/sWrdH4SF1POxWE0Wn8jrxOSnuGOJfj8j5coDuEtdtoevQT3Z8LzD5mkd2UdyXHIkwFsMb3/vIL1kH8XKyGg==",
       "license": "MIT",
       "dependencies": {
-        "assistant-stream": "^0.3.12",
-        "nanoid": "^5.1.9"
+        "assistant-stream": "^0.3.28",
+        "nanoid": "^6.0.0"
       },
       "peerDependencies": {
-        "@assistant-ui/store": "^0.2.9",
-        "@assistant-ui/tap": "^0.5.10",
+        "@assistant-ui/store": "^0.2.13",
+        "@assistant-ui/tap": "^0.9.0",
         "@types/react": "*",
-        "assistant-cloud": "^0.1.27",
+        "assistant-cloud": "^0.1.31",
         "react": "^18 || ^19",
         "zustand": "^5.0.11"
       },
@@ -147,27 +147,30 @@
       }
     },
     "node_modules/@assistant-ui/react": {
-      "version": "0.12.28",
-      "resolved": "https://registry.npmjs.org/@assistant-ui/react/-/react-0.12.28.tgz",
-      "integrity": "sha512-czjpexLK1lKnNDNM1YMJi8SufeKUWBICqiVUtiHMV+86PYGCwJykOZKkchI8MVbSQ62xZ8A1LfPO5W2IDjed3A==",
+      "version": "0.14.29",
+      "resolved": "https://registry.npmjs.org/@assistant-ui/react/-/react-0.14.29.tgz",
+      "integrity": "sha512-QJkrFx1uaf5EiC892EDGSfTPsQ/K6HhXlfcLcuG7Ht8LRM2OKKyKRt79ZB4gzs8iMt81DcyifDXq+MScydTmMg==",
       "license": "MIT",
       "dependencies": {
-        "@assistant-ui/core": "^0.1.17",
-        "@assistant-ui/store": "^0.2.9",
-        "@assistant-ui/tap": "^0.5.10",
-        "@radix-ui/primitive": "^1.1.3",
-        "@radix-ui/react-compose-refs": "^1.1.2",
-        "@radix-ui/react-context": "^1.1.3",
-        "@radix-ui/react-primitive": "^2.1.4",
-        "@radix-ui/react-use-callback-ref": "^1.1.1",
-        "@radix-ui/react-use-escape-keydown": "^1.1.1",
-        "assistant-cloud": "^0.1.27",
-        "assistant-stream": "^0.3.12",
-        "nanoid": "^5.1.9",
-        "radix-ui": "^1.4.3",
+        "@assistant-ui/core": "^0.2.23",
+        "@assistant-ui/store": "^0.2.22",
+        "@assistant-ui/tap": "^0.9.6",
+        "@radix-ui/primitive": "^1.1.7",
+        "@radix-ui/react-collection": "^1.1.15",
+        "@radix-ui/react-compose-refs": "^1.1.5",
+        "@radix-ui/react-context": "^1.2.2",
+        "@radix-ui/react-primitive": "^2.1.10",
+        "@radix-ui/react-use-callback-ref": "^1.1.4",
+        "@radix-ui/react-use-controllable-state": "^1.2.6",
+        "@radix-ui/react-use-escape-keydown": "^1.1.5",
+        "assistant-cloud": "^0.1.37",
+        "assistant-stream": "^0.3.28",
+        "nanoid": "^6.0.0",
+        "radix-ui": "^1.6.7",
         "react-textarea-autosize": "^8.5.9",
-        "zod": "^4.3.6",
-        "zustand": "^5.0.12"
+        "safe-content-frame": "^0.0.25",
+        "zod": "^4.4.3",
+        "zustand": "^5.0.14"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -185,15 +188,15 @@
       }
     },
     "node_modules/@assistant-ui/store": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/@assistant-ui/store/-/store-0.2.9.tgz",
-      "integrity": "sha512-EDd6yCfirb2OsAKoTo7HeMtqPG+1cqVlNXOzUsho35ZF3O1XQ2CyEY4iUbdhj3HfmWeZo7rmfhvbaYQVEqAfeA==",
+      "version": "0.2.22",
+      "resolved": "https://registry.npmjs.org/@assistant-ui/store/-/store-0.2.22.tgz",
+      "integrity": "sha512-RdUFLOFJ3ZwIoOZYrRvps3OAODwnWoUAuNfqbROKrj5qtlQsIJRqxUNdLTjcf4AimhkjCwOaFacGHHm9lE4qBw==",
       "license": "MIT",
       "dependencies": {
         "use-effect-event": "^2.0.3"
       },
       "peerDependencies": {
-        "@assistant-ui/tap": "^0.5.10",
+        "@assistant-ui/tap": "^0.9.0",
         "@types/react": "*",
         "react": "^18 || ^19"
       },
@@ -204,9 +207,9 @@
       }
     },
     "node_modules/@assistant-ui/tap": {
-      "version": "0.5.10",
-      "resolved": "https://registry.npmjs.org/@assistant-ui/tap/-/tap-0.5.10.tgz",
-      "integrity": "sha512-sBHTf+q1geRyu5l4gJJp2hk6ZxwhHZHj39ixjC9ARADuIYedYv1B8bCNS82eTC/COpD1xe86mzvT/+HwIsO9WA==",
+      "version": "0.9.6",
+      "resolved": "https://registry.npmjs.org/@assistant-ui/tap/-/tap-0.9.6.tgz",
+      "integrity": "sha512-0Ty2ufeky+Zy7ByyCGUmSy2Pu5TeeNkdz2vDqYona/hDjy95wRdDJK3WEVqvaMnR5sgLnUdIDcnt4CyrzSpaDQ==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
@@ -214,9 +217,6 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
-          "optional": true
-        },
-        "react": {
           "optional": true
         }
       }
@@ -2046,24 +2046,24 @@
       }
     },
     "node_modules/@radix-ui/number": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.1.tgz",
-      "integrity": "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.3.tgz",
+      "integrity": "sha512-Road2bidD0uu/1BGDOWNdPI06g0lIRy6IF9GZcIrDK2KGItfor8IQwQa+yM2ERgHM1MmHxaxpTzk0/Jp42lNfA==",
       "license": "MIT"
     },
     "node_modules/@radix-ui/primitive": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
-      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.7.tgz",
+      "integrity": "sha512-rqWnm76nYT8HoNNqEjpgJ7Pw/DrBj5iBTrmEPo6HTX5+VJyBNOqTdv4g89G63HuR5g0AaENoAcH7Is5fF2kZ8Q==",
       "license": "MIT"
     },
     "node_modules/@radix-ui/react-accessible-icon": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-accessible-icon/-/react-accessible-icon-1.1.7.tgz",
-      "integrity": "sha512-XM+E4WXl0OqUJFovy6GjmxxFyx9opfCAIUku4dlKRd5YEPqt4kALOkQOp0Of6reHuUkJuiPBEc5k0o4z4lTC8A==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-accessible-icon/-/react-accessible-icon-1.1.15.tgz",
+      "integrity": "sha512-WTQwcAvQf5sOcuUyi90lKPbhwcvQ+j55cjrSmeaN+L2vKU3DooOvlKw2MDeiJ5IkV5N905KW0/fGojKOBhD11A==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-visually-hidden": "1.2.3"
+        "@radix-ui/react-visually-hidden": "1.2.11"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -2081,20 +2081,20 @@
       }
     },
     "node_modules/@radix-ui/react-accordion": {
-      "version": "1.2.12",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-accordion/-/react-accordion-1.2.12.tgz",
-      "integrity": "sha512-T4nygeh9YE9dLRPhAHSeOZi7HBXo+0kYIPJXayZfvWOWA0+n3dESrZbjfDPUABkUNym6Hd+f2IR113To8D2GPA==",
+      "version": "1.2.20",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-accordion/-/react-accordion-1.2.20.tgz",
+      "integrity": "sha512-jDhG9FvAEnlhnjrsINbNXcUa4G+L1KqSkJSunkbKEzFRcAb52jvM0PjPxPRvhe1HNc5F5yc0yzzWeeqlH4yBIg==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-collapsible": "1.1.12",
-        "@radix-ui/react-collection": "1.1.7",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-direction": "1.1.1",
-        "@radix-ui/react-id": "1.1.1",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-controllable-state": "1.2.2"
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-collapsible": "1.1.20",
+        "@radix-ui/react-collection": "1.1.15",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-direction": "1.1.4",
+        "@radix-ui/react-id": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-controllable-state": "1.2.6"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -2107,78 +2107,21 @@
           "optional": true
         },
         "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-accordion/node_modules/@radix-ui/react-context": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
-      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-accordion/node_modules/@radix-ui/react-primitive": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
-      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-slot": "1.2.3"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-accordion/node_modules/@radix-ui/react-slot": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
-      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
           "optional": true
         }
       }
     },
     "node_modules/@radix-ui/react-alert-dialog": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-alert-dialog/-/react-alert-dialog-1.1.15.tgz",
-      "integrity": "sha512-oTVLkEw5GpdRe29BqJ0LSDFWI3qu0vR1M0mUkOQWDIUnY/QIkLpgDMWuKxP94c2NAC2LGcgVhG1ImF3jkZ5wXw==",
+      "version": "1.1.23",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-alert-dialog/-/react-alert-dialog-1.1.23.tgz",
+      "integrity": "sha512-VAYOiQRqj3GPpYJE0I9J+X8Ip05cyVlNdKOFeiGS2Ou1HHGfpl0BxOyZm6nmVDyU+W+NF3/XLzmjHmVGydhwgA==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-dialog": "1.1.15",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-slot": "1.2.3"
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-dialog": "1.1.23",
+        "@radix-ui/react-primitive": "2.1.10"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -2191,73 +2134,17 @@
           "optional": true
         },
         "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-alert-dialog/node_modules/@radix-ui/react-context": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
-      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-alert-dialog/node_modules/@radix-ui/react-primitive": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
-      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-slot": "1.2.3"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-alert-dialog/node_modules/@radix-ui/react-slot": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
-      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
           "optional": true
         }
       }
     },
     "node_modules/@radix-ui/react-arrow": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.7.tgz",
-      "integrity": "sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.15.tgz",
+      "integrity": "sha512-v4zggRcjadnI+ClKDuijlQEW4tw3NoaeHc/PwpKnLoLLKNUG4InLegkstooLcRIUWCs+8L22dGURCVuFfOKfnA==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-primitive": "2.1.3"
+        "@radix-ui/react-primitive": "2.1.10"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -2270,58 +2157,17 @@
           "optional": true
         },
         "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-arrow/node_modules/@radix-ui/react-primitive": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
-      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-slot": "1.2.3"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-arrow/node_modules/@radix-ui/react-slot": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
-      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
           "optional": true
         }
       }
     },
     "node_modules/@radix-ui/react-aspect-ratio": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-aspect-ratio/-/react-aspect-ratio-1.1.7.tgz",
-      "integrity": "sha512-Yq6lvO9HQyPwev1onK1daHCHqXVLzPhSVjmsNjCa2Zcxy2f7uJD2itDtxknv6FzAKCwD1qQkeVDmX/cev13n/g==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-aspect-ratio/-/react-aspect-ratio-1.1.15.tgz",
+      "integrity": "sha512-fy+dyVR+90nelK8rqIznFlxzx7uPcGbhxH8Nfr2bHb4UfSe+e3hklOC0luK0hDwVwnRX7xTRySpsrQVeW+/oNQ==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-primitive": "2.1.3"
+        "@radix-ui/react-primitive": "2.1.10"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -2334,62 +2180,22 @@
           "optional": true
         },
         "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-aspect-ratio/node_modules/@radix-ui/react-primitive": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
-      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-slot": "1.2.3"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-aspect-ratio/node_modules/@radix-ui/react-slot": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
-      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
           "optional": true
         }
       }
     },
     "node_modules/@radix-ui/react-avatar": {
-      "version": "1.1.10",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-avatar/-/react-avatar-1.1.10.tgz",
-      "integrity": "sha512-V8piFfWapM5OmNCXTzVQY+E1rDa53zY+MQ4Y7356v4fFz6vqCyUtIz2rUD44ZEdwg78/jKmMJHj07+C/Z/rcog==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-avatar/-/react-avatar-1.2.6.tgz",
+      "integrity": "sha512-4ULOTJ/mqy2hT9GlWa/MFHxHSvH3nJzHnZM1waNsc5Bonv7i70aNenghXmD97S6OJ81ekXONGGt4nT1r0PfEdA==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-callback-ref": "1.1.1",
-        "@radix-ui/react-use-is-hydrated": "0.1.0",
-        "@radix-ui/react-use-layout-effect": "1.1.1"
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-callback-ref": "1.1.4",
+        "@radix-ui/react-use-is-hydrated": "0.1.3",
+        "@radix-ui/react-use-layout-effect": "1.1.4"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -2402,80 +2208,23 @@
           "optional": true
         },
         "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-avatar/node_modules/@radix-ui/react-context": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
-      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-avatar/node_modules/@radix-ui/react-primitive": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
-      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-slot": "1.2.3"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-avatar/node_modules/@radix-ui/react-slot": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
-      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
           "optional": true
         }
       }
     },
     "node_modules/@radix-ui/react-checkbox": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.3.3.tgz",
-      "integrity": "sha512-wBbpv+NQftHDdG86Qc0pIyXk5IR3tM8Vd0nWLKDcX8nNn4nXFOFwsKuqw2okA/1D/mpaAkmuyndrPJTYDNZtFw==",
+      "version": "1.3.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.3.11.tgz",
+      "integrity": "sha512-Gnptr9pDDQxD3hgq2dtPbtrp/c2qH1mBwIzw3X/ivrMb2e1t0jMTi606fVEqFPaQR1ggXIVQWKj3P2WW9v7zGQ==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-presence": "1.1.5",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-controllable-state": "1.2.2",
-        "@radix-ui/react-use-previous": "1.1.1",
-        "@radix-ui/react-use-size": "1.1.1"
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-presence": "1.1.10",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-controllable-state": "1.2.6",
+        "@radix-ui/react-use-size": "1.1.4"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -2488,80 +2237,24 @@
           "optional": true
         },
         "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-checkbox/node_modules/@radix-ui/react-context": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
-      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-checkbox/node_modules/@radix-ui/react-primitive": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
-      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-slot": "1.2.3"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-checkbox/node_modules/@radix-ui/react-slot": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
-      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
           "optional": true
         }
       }
     },
     "node_modules/@radix-ui/react-collapsible": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-collapsible/-/react-collapsible-1.1.12.tgz",
-      "integrity": "sha512-Uu+mSh4agx2ib1uIGPP4/CKNULyajb3p92LsVXmH2EHVMTfZWpll88XJ0j4W0z3f8NK1eYl1+Mf/szHPmcHzyA==",
+      "version": "1.1.20",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collapsible/-/react-collapsible-1.1.20.tgz",
+      "integrity": "sha512-mcGesGplBnzN2sbvJETzpCNfSMyPnb29q1GRLU+Ib7bJrpIG2ywmRoh2V5VbA2uNvKikKUlVbAPks7JDjz4A8Q==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-id": "1.1.1",
-        "@radix-ui/react-presence": "1.1.5",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-controllable-state": "1.2.2",
-        "@radix-ui/react-use-layout-effect": "1.1.1"
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-id": "1.1.4",
+        "@radix-ui/react-presence": "1.1.10",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-controllable-state": "1.2.6",
+        "@radix-ui/react-use-layout-effect": "1.1.4"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -2574,76 +2267,20 @@
           "optional": true
         },
         "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-collapsible/node_modules/@radix-ui/react-context": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
-      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-collapsible/node_modules/@radix-ui/react-primitive": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
-      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-slot": "1.2.3"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-collapsible/node_modules/@radix-ui/react-slot": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
-      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
           "optional": true
         }
       }
     },
     "node_modules/@radix-ui/react-collection": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.7.tgz",
-      "integrity": "sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.15.tgz",
+      "integrity": "sha512-9W+B9NPF0NaaPh/1NJd3+KqsnlLqU9H7T2rvww+fp+T/evVXdNAyYcnfRQZFOjkR1ajQp3yORlqnI8soawLvNA==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-slot": "1.2.3"
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-slot": "1.3.3"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -2656,70 +2293,14 @@
           "optional": true
         },
         "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-collection/node_modules/@radix-ui/react-context": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
-      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-collection/node_modules/@radix-ui/react-primitive": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
-      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-slot": "1.2.3"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-collection/node_modules/@radix-ui/react-slot": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
-      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
           "optional": true
         }
       }
     },
     "node_modules/@radix-ui/react-compose-refs": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
-      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.5.tgz",
+      "integrity": "sha512-+48PbAAbq3didjJxa+OaWY2ZwgAKsNiRGyeHKszblZMQ+kcpd9pAaT11cMkGEie0vsOi3QdeTE6d5Fe3Gn61kA==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
@@ -2732,9 +2313,9 @@
       }
     },
     "node_modules/@radix-ui/react-context": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.3.tgz",
-      "integrity": "sha512-ieIFACdMpYfMEjF0rEf5KLvfVyIkOz6PDGyNnP+u+4xQ6jny3VCgA4OgXOwNx2aUkxn8zx9fiVcM8CfFYv9Lxw==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.2.2.tgz",
+      "integrity": "sha512-RHCUGwKHDr0hDGg4X7ma4JG4/+12qxw8rkh5QKdDldlCvtja6nUx1Ef/8HVrJze81lEsgLQlqjzjGNHantgnQA==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
@@ -2747,17 +2328,16 @@
       }
     },
     "node_modules/@radix-ui/react-context-menu": {
-      "version": "2.2.16",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-context-menu/-/react-context-menu-2.2.16.tgz",
-      "integrity": "sha512-O8morBEW+HsVG28gYDZPTrT9UUovQUlJue5YO836tiTJhuIWBm/zQHc7j388sHWtdH/xUZurK9olD2+pcqx5ww==",
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context-menu/-/react-context-menu-2.3.7.tgz",
+      "integrity": "sha512-CtXP35dxaB5T3zXSd+E3uHe/QpXcpYnZmxp6OaIbfthtfW4wyb77M23BG+bwIJDtsMwEP/YssdsmNyZu7jhWew==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-menu": "2.1.16",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-callback-ref": "1.1.1",
-        "@radix-ui/react-use-controllable-state": "1.2.2"
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-menu": "2.1.24",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-controllable-state": "1.2.6"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -2770,86 +2350,31 @@
           "optional": true
         },
         "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-context-menu/node_modules/@radix-ui/react-context": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
-      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-context-menu/node_modules/@radix-ui/react-primitive": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
-      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-slot": "1.2.3"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-context-menu/node_modules/@radix-ui/react-slot": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
-      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
           "optional": true
         }
       }
     },
     "node_modules/@radix-ui/react-dialog": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.15.tgz",
-      "integrity": "sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==",
+      "version": "1.1.23",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.23.tgz",
+      "integrity": "sha512-Ksw4WeROkO4rC9k/onilX/Ao2Cr1ku1unMNH+XSCcP4jSXYu7HDsg9n4ojMjVb22XpYjAQ9qfrFlVbru1vXDUA==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-dismissable-layer": "1.1.11",
-        "@radix-ui/react-focus-guards": "1.1.3",
-        "@radix-ui/react-focus-scope": "1.1.7",
-        "@radix-ui/react-id": "1.1.1",
-        "@radix-ui/react-portal": "1.1.9",
-        "@radix-ui/react-presence": "1.1.5",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-slot": "1.2.3",
-        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-dismissable-layer": "1.1.19",
+        "@radix-ui/react-focus-guards": "1.1.6",
+        "@radix-ui/react-focus-scope": "1.1.16",
+        "@radix-ui/react-id": "1.1.4",
+        "@radix-ui/react-portal": "1.1.17",
+        "@radix-ui/react-presence": "1.1.10",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-slot": "1.3.3",
+        "@radix-ui/react-use-controllable-state": "1.2.6",
+        "@radix-ui/react-use-layout-effect": "1.1.4",
         "aria-hidden": "^1.2.4",
-        "react-remove-scroll": "^2.6.3"
+        "react-remove-scroll": "^2.7.2"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -2862,70 +2387,14 @@
           "optional": true
         },
         "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-context": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
-      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-primitive": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
-      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-slot": "1.2.3"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-slot": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
-      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
           "optional": true
         }
       }
     },
     "node_modules/@radix-ui/react-direction": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.1.tgz",
-      "integrity": "sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.4.tgz",
+      "integrity": "sha512-5pzg4FGQNpExhnhT2zlrP1wZFaYCd1K0nYWoFAdcYoYK868IEigqMX3B3f8yIoRlAhAeDWciLI6ZdCKHF9P4Vg==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
@@ -2938,16 +2407,16 @@
       }
     },
     "node_modules/@radix-ui/react-dismissable-layer": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.11.tgz",
-      "integrity": "sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==",
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.19.tgz",
+      "integrity": "sha512-8g4pfOL9HoKKLWGiypT+dphVqjFfmcXO5GBnhsG6zI+lxAx/8feQpr+1LSN8Re3hiZ+XkLNS4O9ztK11/LzQ6w==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-callback-ref": "1.1.1",
-        "@radix-ui/react-use-escape-keydown": "1.1.1"
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-callback-ref": "1.1.4",
+        "@radix-ui/react-use-effect-event": "0.0.5"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -2960,64 +2429,23 @@
           "optional": true
         },
         "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-dismissable-layer/node_modules/@radix-ui/react-primitive": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
-      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-slot": "1.2.3"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-dismissable-layer/node_modules/@radix-ui/react-slot": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
-      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
           "optional": true
         }
       }
     },
     "node_modules/@radix-ui/react-dropdown-menu": {
-      "version": "2.1.16",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.1.16.tgz",
-      "integrity": "sha512-1PLGQEynI/3OX/ftV54COn+3Sud/Mn8vALg2rWnBLnRaGtJDduNW/22XjlGgPdpcIbiQxjKtb7BkcjP00nqfJw==",
+      "version": "2.1.24",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.1.24.tgz",
+      "integrity": "sha512-geq8l2rJkxvkXsT9RMgtUE3P8pITFpTsvYpbySi1IH4fZEABD/Gp85myayFgxk0ktljGMJnCbeFkyTusvSvv7g==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-id": "1.1.1",
-        "@radix-ui/react-menu": "2.1.16",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-controllable-state": "1.2.2"
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-id": "1.1.4",
+        "@radix-ui/react-menu": "2.1.24",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-controllable-state": "1.2.6"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3030,70 +2458,14 @@
           "optional": true
         },
         "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-dropdown-menu/node_modules/@radix-ui/react-context": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
-      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-dropdown-menu/node_modules/@radix-ui/react-primitive": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
-      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-slot": "1.2.3"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-dropdown-menu/node_modules/@radix-ui/react-slot": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
-      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
           "optional": true
         }
       }
     },
     "node_modules/@radix-ui/react-focus-guards": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.3.tgz",
-      "integrity": "sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.6.tgz",
+      "integrity": "sha512-RNOJjfZMTyBM6xYmV3IVGXkPjIhcBAuv48POevAXwrGJhkWZ9p1rFoIS1JFooPuT193AZmRsCPhpoVJxx6OPoQ==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
@@ -3106,14 +2478,14 @@
       }
     },
     "node_modules/@radix-ui/react-focus-scope": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.7.tgz",
-      "integrity": "sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.16.tgz",
+      "integrity": "sha512-wmRZ2WWLvmt6KHy2rNPOdPUjwq5xOHY02+m+udwJTn0aNIox/rkskAvJTyTLGhPK6KgrUjlJUJpgmx/+wFiFIQ==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-callback-ref": "1.1.1"
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-callback-ref": "1.1.4"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3126,63 +2498,22 @@
           "optional": true
         },
         "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-focus-scope/node_modules/@radix-ui/react-primitive": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
-      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-slot": "1.2.3"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-focus-scope/node_modules/@radix-ui/react-slot": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
-      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
           "optional": true
         }
       }
     },
     "node_modules/@radix-ui/react-form": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-form/-/react-form-0.1.8.tgz",
-      "integrity": "sha512-QM70k4Zwjttifr5a4sZFts9fn8FzHYvQ5PiB19O2HsYibaHSVt9fH9rzB0XZo/YcM+b7t/p7lYCT/F5eOeF5yQ==",
+      "version": "0.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-form/-/react-form-0.1.16.tgz",
+      "integrity": "sha512-Q4TLEn2A7TAypxwmd6R9EwrlXDvkfYSDMrq9/887AXAGh+G1rH+kYJKSTv+Si9Y0JPKTwKYv6PviAJosysNimA==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-id": "1.1.1",
-        "@radix-ui/react-label": "2.1.7",
-        "@radix-ui/react-primitive": "2.1.3"
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-id": "1.1.4",
+        "@radix-ui/react-label": "2.1.15",
+        "@radix-ui/react-primitive": "2.1.10"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3195,104 +2526,25 @@
           "optional": true
         },
         "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-form/node_modules/@radix-ui/react-context": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
-      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-form/node_modules/@radix-ui/react-label": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.7.tgz",
-      "integrity": "sha512-YT1GqPSL8kJn20djelMX7/cTRp/Y9w5IZHvfxQTVHrOqa2yMl7i/UfMqKRU5V7mEyKTrUVgJXhNQPVCG8PBLoQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-primitive": "2.1.3"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-form/node_modules/@radix-ui/react-primitive": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
-      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-slot": "1.2.3"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-form/node_modules/@radix-ui/react-slot": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
-      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
           "optional": true
         }
       }
     },
     "node_modules/@radix-ui/react-hover-card": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-hover-card/-/react-hover-card-1.1.15.tgz",
-      "integrity": "sha512-qgTkjNT1CfKMoP0rcasmlH2r1DAiYicWsDsufxl940sT2wHNEWWv6FMWIQXWhVdmC1d/HYfbhQx60KYyAtKxjg==",
+      "version": "1.1.23",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-hover-card/-/react-hover-card-1.1.23.tgz",
+      "integrity": "sha512-H8qONfZd3ltrU3+jHCIgITbWo6e1iTKvP9DHdrvYbX48ooRM5FjEDTn16AMwdfuOGkWdZEhpl3PLL/Wk/AnHDQ==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-dismissable-layer": "1.1.11",
-        "@radix-ui/react-popper": "1.2.8",
-        "@radix-ui/react-portal": "1.1.9",
-        "@radix-ui/react-presence": "1.1.5",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-controllable-state": "1.2.2"
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-dismissable-layer": "1.1.19",
+        "@radix-ui/react-popper": "1.3.7",
+        "@radix-ui/react-portal": "1.1.17",
+        "@radix-ui/react-presence": "1.1.10",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-controllable-state": "1.2.6"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3305,73 +2557,17 @@
           "optional": true
         },
         "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-hover-card/node_modules/@radix-ui/react-context": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
-      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-hover-card/node_modules/@radix-ui/react-primitive": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
-      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-slot": "1.2.3"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-hover-card/node_modules/@radix-ui/react-slot": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
-      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
           "optional": true
         }
       }
     },
     "node_modules/@radix-ui/react-id": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.1.tgz",
-      "integrity": "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.4.tgz",
+      "integrity": "sha512-TMQp2llA+RYn7JcjnrMnz7wN4pcVttPZnRZo52PLQsoLVKzNlVwUeHmfePgTgRluXFvlD3GD5g5MOVVTJCO0qA==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-use-layout-effect": "1.1.1"
+        "@radix-ui/react-use-layout-effect": "1.1.4"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3384,12 +2580,12 @@
       }
     },
     "node_modules/@radix-ui/react-label": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.8.tgz",
-      "integrity": "sha512-FmXs37I6hSBVDlO4y764TNz1rLgKwjJMQ0EGte6F3Cb3f4bIuHB/iLa/8I9VKkmOy+gNHq8rql3j686ACVV21A==",
+      "version": "2.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.15.tgz",
+      "integrity": "sha512-o/rdYEwZTTo5tjknnPeyQFU45kUC4i/XyeDPP+HGyi6XqpOP6Zf5Ya5vh/Yfe9Id5JiuWnnAx2XqIeD3UYZt0g==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-primitive": "2.1.4"
+        "@radix-ui/react-primitive": "2.1.10"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3407,29 +2603,29 @@
       }
     },
     "node_modules/@radix-ui/react-menu": {
-      "version": "2.1.16",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-2.1.16.tgz",
-      "integrity": "sha512-72F2T+PLlphrqLcAotYPp0uJMr5SjP5SL01wfEspJbru5Zs5vQaSHb4VB3ZMJPimgHHCHG7gMOeOB9H3Hdmtxg==",
+      "version": "2.1.24",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-2.1.24.tgz",
+      "integrity": "sha512-uW7RVuU6Lp/ZtfeY4b3kL32zccgEWvPv1+cf17ubYzHa9cL8AHokmk36cG/XEiH/smbQvumnieXX9j/e9RqJWA==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-collection": "1.1.7",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-direction": "1.1.1",
-        "@radix-ui/react-dismissable-layer": "1.1.11",
-        "@radix-ui/react-focus-guards": "1.1.3",
-        "@radix-ui/react-focus-scope": "1.1.7",
-        "@radix-ui/react-id": "1.1.1",
-        "@radix-ui/react-popper": "1.2.8",
-        "@radix-ui/react-portal": "1.1.9",
-        "@radix-ui/react-presence": "1.1.5",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-roving-focus": "1.1.11",
-        "@radix-ui/react-slot": "1.2.3",
-        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-collection": "1.1.15",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-direction": "1.1.4",
+        "@radix-ui/react-dismissable-layer": "1.1.19",
+        "@radix-ui/react-focus-guards": "1.1.6",
+        "@radix-ui/react-focus-scope": "1.1.16",
+        "@radix-ui/react-id": "1.1.4",
+        "@radix-ui/react-popper": "1.3.7",
+        "@radix-ui/react-portal": "1.1.17",
+        "@radix-ui/react-presence": "1.1.10",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-roving-focus": "1.1.19",
+        "@radix-ui/react-slot": "1.3.3",
+        "@radix-ui/react-use-callback-ref": "1.1.4",
         "aria-hidden": "^1.2.4",
-        "react-remove-scroll": "^2.6.3"
+        "react-remove-scroll": "^2.7.2"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3442,82 +2638,26 @@
           "optional": true
         },
         "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-context": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
-      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-primitive": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
-      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-slot": "1.2.3"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-slot": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
-      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
           "optional": true
         }
       }
     },
     "node_modules/@radix-ui/react-menubar": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-menubar/-/react-menubar-1.1.16.tgz",
-      "integrity": "sha512-EB1FktTz5xRRi2Er974AUQZWg2yVBb1yjip38/lgwtCVRd3a+maUoGHN/xs9Yv8SY8QwbSEb+YrxGadVWbEutA==",
+      "version": "1.1.24",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-menubar/-/react-menubar-1.1.24.tgz",
+      "integrity": "sha512-eeVs0vf7cuqXaM0qLQCPcufImiJNVBXdJDLu7ZGYl2732UH23Qat/foNGrr6vYV3/DdTsBqASoggUFgH14OcZA==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-collection": "1.1.7",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-direction": "1.1.1",
-        "@radix-ui/react-id": "1.1.1",
-        "@radix-ui/react-menu": "2.1.16",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-roving-focus": "1.1.11",
-        "@radix-ui/react-use-controllable-state": "1.2.2"
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-collection": "1.1.15",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-direction": "1.1.4",
+        "@radix-ui/react-id": "1.1.4",
+        "@radix-ui/react-menu": "2.1.24",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-roving-focus": "1.1.19",
+        "@radix-ui/react-use-controllable-state": "1.2.6"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3530,86 +2670,30 @@
           "optional": true
         },
         "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-menubar/node_modules/@radix-ui/react-context": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
-      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-menubar/node_modules/@radix-ui/react-primitive": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
-      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-slot": "1.2.3"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-menubar/node_modules/@radix-ui/react-slot": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
-      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
           "optional": true
         }
       }
     },
     "node_modules/@radix-ui/react-navigation-menu": {
-      "version": "1.2.14",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-navigation-menu/-/react-navigation-menu-1.2.14.tgz",
-      "integrity": "sha512-YB9mTFQvCOAQMHU+C/jVl96WmuWeltyUEpRJJky51huhds5W2FQr1J8D/16sQlf0ozxkPK8uF3niQMdUwZPv5w==",
+      "version": "1.2.22",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-navigation-menu/-/react-navigation-menu-1.2.22.tgz",
+      "integrity": "sha512-ou7iLEJ+yrhQndkkA4U21XIdS/CS45F4iXIkTZcb6/Ne9EMsOuDudVmCwmDnfFZZ+y1FZqXRNSIgBy+YMvZVZg==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-collection": "1.1.7",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-direction": "1.1.1",
-        "@radix-ui/react-dismissable-layer": "1.1.11",
-        "@radix-ui/react-id": "1.1.1",
-        "@radix-ui/react-presence": "1.1.5",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-callback-ref": "1.1.1",
-        "@radix-ui/react-use-controllable-state": "1.2.2",
-        "@radix-ui/react-use-layout-effect": "1.1.1",
-        "@radix-ui/react-use-previous": "1.1.1",
-        "@radix-ui/react-visually-hidden": "1.2.3"
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-collection": "1.1.15",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-direction": "1.1.4",
+        "@radix-ui/react-dismissable-layer": "1.1.19",
+        "@radix-ui/react-id": "1.1.4",
+        "@radix-ui/react-presence": "1.1.10",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-callback-ref": "1.1.4",
+        "@radix-ui/react-use-controllable-state": "1.2.6",
+        "@radix-ui/react-use-layout-effect": "1.1.4",
+        "@radix-ui/react-use-previous": "1.1.4",
+        "@radix-ui/react-visually-hidden": "1.2.11"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3622,84 +2706,28 @@
           "optional": true
         },
         "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-navigation-menu/node_modules/@radix-ui/react-context": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
-      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-navigation-menu/node_modules/@radix-ui/react-primitive": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
-      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-slot": "1.2.3"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-navigation-menu/node_modules/@radix-ui/react-slot": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
-      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
           "optional": true
         }
       }
     },
     "node_modules/@radix-ui/react-one-time-password-field": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-one-time-password-field/-/react-one-time-password-field-0.1.8.tgz",
-      "integrity": "sha512-ycS4rbwURavDPVjCb5iS3aG4lURFDILi6sKI/WITUMZ13gMmn/xGjpLoqBAalhJaDk8I3UbCM5GzKHrnzwHbvg==",
+      "version": "0.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-one-time-password-field/-/react-one-time-password-field-0.1.16.tgz",
+      "integrity": "sha512-Tj9P6ntAJEw52oq/F0AGknXR4XncxEt7XU47O3xJQOiWfLzEy3d9gtgKfvjSzGxzHkfL+VzvxGu2KTFsloJqXw==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/number": "1.1.1",
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-collection": "1.1.7",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-direction": "1.1.1",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-roving-focus": "1.1.11",
-        "@radix-ui/react-use-controllable-state": "1.2.2",
-        "@radix-ui/react-use-effect-event": "0.0.2",
-        "@radix-ui/react-use-is-hydrated": "0.1.0",
-        "@radix-ui/react-use-layout-effect": "1.1.1"
+        "@radix-ui/number": "1.1.3",
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-collection": "1.1.15",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-direction": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-roving-focus": "1.1.19",
+        "@radix-ui/react-use-controllable-state": "1.2.6",
+        "@radix-ui/react-use-effect-event": "0.0.5",
+        "@radix-ui/react-use-is-hydrated": "0.1.3",
+        "@radix-ui/react-use-layout-effect": "1.1.4"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3712,80 +2740,24 @@
           "optional": true
         },
         "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-one-time-password-field/node_modules/@radix-ui/react-context": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
-      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-one-time-password-field/node_modules/@radix-ui/react-primitive": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
-      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-slot": "1.2.3"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-one-time-password-field/node_modules/@radix-ui/react-slot": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
-      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
           "optional": true
         }
       }
     },
     "node_modules/@radix-ui/react-password-toggle-field": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-password-toggle-field/-/react-password-toggle-field-0.1.3.tgz",
-      "integrity": "sha512-/UuCrDBWravcaMix4TdT+qlNdVwOM1Nck9kWx/vafXsdfj1ChfhOdfi3cy9SGBpWgTXwYCuboT/oYpJy3clqfw==",
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-password-toggle-field/-/react-password-toggle-field-0.1.11.tgz",
+      "integrity": "sha512-4gvFnmDXu3dgj21CqsufzIameRvlRd4SBqaWhcrlrNhRo0Y5i/49AmRJYe1fdAM3G2VNBbmin4b0D6cdQocwgw==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-id": "1.1.1",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-controllable-state": "1.2.2",
-        "@radix-ui/react-use-effect-event": "0.0.2",
-        "@radix-ui/react-use-is-hydrated": "0.1.0"
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-id": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-controllable-state": "1.2.6",
+        "@radix-ui/react-use-effect-event": "0.0.5",
+        "@radix-ui/react-use-is-hydrated": "0.1.3"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3798,87 +2770,31 @@
           "optional": true
         },
         "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-password-toggle-field/node_modules/@radix-ui/react-context": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
-      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-password-toggle-field/node_modules/@radix-ui/react-primitive": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
-      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-slot": "1.2.3"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-password-toggle-field/node_modules/@radix-ui/react-slot": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
-      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
           "optional": true
         }
       }
     },
     "node_modules/@radix-ui/react-popover": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-1.1.15.tgz",
-      "integrity": "sha512-kr0X2+6Yy/vJzLYJUPCZEc8SfQcf+1COFoAqauJm74umQhta9M7lNJHP7QQS3vkvcGLQUbWpMzwrXYwrYztHKA==",
+      "version": "1.1.23",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-1.1.23.tgz",
+      "integrity": "sha512-mw58MrBlyHWFisTOYignD0vf/3gdcgAR+9of1s9G/38CbFiUwH1nCDkc0AUM9IrXFgN5Ue8n45j9WCgyM1sbiQ==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-dismissable-layer": "1.1.11",
-        "@radix-ui/react-focus-guards": "1.1.3",
-        "@radix-ui/react-focus-scope": "1.1.7",
-        "@radix-ui/react-id": "1.1.1",
-        "@radix-ui/react-popper": "1.2.8",
-        "@radix-ui/react-portal": "1.1.9",
-        "@radix-ui/react-presence": "1.1.5",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-slot": "1.2.3",
-        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-dismissable-layer": "1.1.19",
+        "@radix-ui/react-focus-guards": "1.1.6",
+        "@radix-ui/react-focus-scope": "1.1.16",
+        "@radix-ui/react-id": "1.1.4",
+        "@radix-ui/react-popper": "1.3.7",
+        "@radix-ui/react-portal": "1.1.17",
+        "@radix-ui/react-presence": "1.1.10",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-slot": "1.3.3",
+        "@radix-ui/react-use-controllable-state": "1.2.6",
         "aria-hidden": "^1.2.4",
-        "react-remove-scroll": "^2.6.3"
+        "react-remove-scroll": "^2.7.2"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3891,82 +2807,26 @@
           "optional": true
         },
         "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-context": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
-      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-primitive": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
-      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-slot": "1.2.3"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-slot": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
-      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
           "optional": true
         }
       }
     },
     "node_modules/@radix-ui/react-popper": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.2.8.tgz",
-      "integrity": "sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw==",
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.3.7.tgz",
+      "integrity": "sha512-UsJrrd7w4wuKKTdvd/DNERVlwSlUcyXzjhyDwBk+3aPOsCjOY6ZSbxuw8E6lZTjjfP8Cpd0J8VVkrYUWyGYXyg==",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/react-dom": "^2.0.0",
-        "@radix-ui/react-arrow": "1.1.7",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-callback-ref": "1.1.1",
-        "@radix-ui/react-use-layout-effect": "1.1.1",
-        "@radix-ui/react-use-rect": "1.1.1",
-        "@radix-ui/react-use-size": "1.1.1",
-        "@radix-ui/rect": "1.1.1"
+        "@radix-ui/react-arrow": "1.1.15",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-callback-ref": "1.1.4",
+        "@radix-ui/react-use-layout-effect": "1.1.4",
+        "@radix-ui/react-use-rect": "1.1.4",
+        "@radix-ui/react-use-size": "1.1.4",
+        "@radix-ui/rect": "1.1.3"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3979,74 +2839,18 @@
           "optional": true
         },
         "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-popper/node_modules/@radix-ui/react-context": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
-      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-popper/node_modules/@radix-ui/react-primitive": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
-      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-slot": "1.2.3"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-popper/node_modules/@radix-ui/react-slot": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
-      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
           "optional": true
         }
       }
     },
     "node_modules/@radix-ui/react-portal": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.9.tgz",
-      "integrity": "sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==",
+      "version": "1.1.17",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.17.tgz",
+      "integrity": "sha512-vKQLcWypUnwZVvfV7UkGahH2g6ySe8M8R+zYBwPrv5byZ9QAW6cQVvNKo7GgmD+p8aYb6D9JBuvy8/WhOno2wQ==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-layout-effect": "1.1.1"
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-layout-effect": "1.1.4"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -4059,59 +2863,17 @@
           "optional": true
         },
         "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-portal/node_modules/@radix-ui/react-primitive": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
-      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-slot": "1.2.3"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-portal/node_modules/@radix-ui/react-slot": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
-      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
           "optional": true
         }
       }
     },
     "node_modules/@radix-ui/react-presence": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.5.tgz",
-      "integrity": "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==",
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.10.tgz",
+      "integrity": "sha512-3wyzCQ6+ubRA+D4uv9m95JYLXxmOHp05qjrkjeA7uKHHtjpPggQzc6DAb0URl7j67oR0K2foO4ip27TiX037Bw==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-use-layout-effect": "1.1.1"
+        "@radix-ui/react-use-layout-effect": "1.1.4"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -4129,12 +2891,12 @@
       }
     },
     "node_modules/@radix-ui/react-primitive": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.4.tgz",
-      "integrity": "sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg==",
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.10.tgz",
+      "integrity": "sha512-MucOnzh6hR5mid6VpkbglRAMYMjKLqRnGBbjXkzjK52fuQDd1qbkx78a5P40mkcnVXJdEVxm26E9OPAiUq7nBg==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-slot": "1.2.4"
+        "@radix-ui/react-slot": "1.3.3"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -4152,13 +2914,13 @@
       }
     },
     "node_modules/@radix-ui/react-progress": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-progress/-/react-progress-1.1.7.tgz",
-      "integrity": "sha512-vPdg/tF6YC/ynuBIJlk1mm7Le0VgW6ub6J2UWnTQ7/D23KXcPI1qy+0vBkgKgd38RCMJavBXpB83HPNFMTb0Fg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-progress/-/react-progress-1.1.16.tgz",
+      "integrity": "sha512-5XnomAsoZZCY+KNTxbIghpGqPruZvKFNlvcAljVAOdDRDsH4/OZQxhtwo5wdtoDM5R6MhJBb2sPnDuRFep3lzg==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-primitive": "2.1.3"
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-primitive": "2.1.10"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -4171,82 +2933,25 @@
           "optional": true
         },
         "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-progress/node_modules/@radix-ui/react-context": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
-      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-progress/node_modules/@radix-ui/react-primitive": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
-      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-slot": "1.2.3"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-progress/node_modules/@radix-ui/react-slot": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
-      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
           "optional": true
         }
       }
     },
     "node_modules/@radix-ui/react-radio-group": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-radio-group/-/react-radio-group-1.3.8.tgz",
-      "integrity": "sha512-VBKYIYImA5zsxACdisNQ3BjCBfmbGH3kQlnFVqlWU4tXwjy7cGX8ta80BcrO+WJXIn5iBylEH3K6ZTlee//lgQ==",
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-radio-group/-/react-radio-group-1.4.7.tgz",
+      "integrity": "sha512-cgYFEkntCxppHZgtSZ+7vh0wbZQ+IC7PPMw8DSnRG27B6kDd32/Zw0OJt7dGDigCoprMuWHjg2PvUn3PYvPFoQ==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-direction": "1.1.1",
-        "@radix-ui/react-presence": "1.1.5",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-roving-focus": "1.1.11",
-        "@radix-ui/react-use-controllable-state": "1.2.2",
-        "@radix-ui/react-use-previous": "1.1.1",
-        "@radix-ui/react-use-size": "1.1.1"
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-direction": "1.1.4",
+        "@radix-ui/react-presence": "1.1.10",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-roving-focus": "1.1.19",
+        "@radix-ui/react-use-controllable-state": "1.2.6",
+        "@radix-ui/react-use-size": "1.1.4"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -4259,81 +2964,27 @@
           "optional": true
         },
         "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-radio-group/node_modules/@radix-ui/react-context": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
-      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-radio-group/node_modules/@radix-ui/react-primitive": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
-      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-slot": "1.2.3"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-radio-group/node_modules/@radix-ui/react-slot": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
-      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
           "optional": true
         }
       }
     },
     "node_modules/@radix-ui/react-roving-focus": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.11.tgz",
-      "integrity": "sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==",
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.19.tgz",
+      "integrity": "sha512-V9jI6hDjT7l3jsCQD9bLNvDLM3tH/gdbOTp7Tefp3hbbgCGQoK7tUvrWiRlcoBHIZ809ElXwNQwVo0B98LuTXQ==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-collection": "1.1.7",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-direction": "1.1.1",
-        "@radix-ui/react-id": "1.1.1",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-callback-ref": "1.1.1",
-        "@radix-ui/react-use-controllable-state": "1.2.2"
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-collection": "1.1.15",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-direction": "1.1.4",
+        "@radix-ui/react-id": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-callback-ref": "1.1.4",
+        "@radix-ui/react-use-controllable-state": "1.2.6",
+        "@radix-ui/react-use-is-hydrated": "0.1.3",
+        "@radix-ui/react-use-layout-effect": "1.1.4"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -4346,81 +2997,25 @@
           "optional": true
         },
         "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-roving-focus/node_modules/@radix-ui/react-context": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
-      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-roving-focus/node_modules/@radix-ui/react-primitive": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
-      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-slot": "1.2.3"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-roving-focus/node_modules/@radix-ui/react-slot": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
-      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
           "optional": true
         }
       }
     },
     "node_modules/@radix-ui/react-scroll-area": {
-      "version": "1.2.10",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-scroll-area/-/react-scroll-area-1.2.10.tgz",
-      "integrity": "sha512-tAXIa1g3sM5CGpVT0uIbUx/U3Gs5N8T52IICuCtObaos1S8fzsrPXG5WObkQN3S6NVl6wKgPhAIiBGbWnvc97A==",
+      "version": "1.2.18",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-scroll-area/-/react-scroll-area-1.2.18.tgz",
+      "integrity": "sha512-Zn5Cd171wxsO3Dfg8HaW6RifTb9CYTKQJHs/G4+LN1GfmJpaQMZQyQxMprVPHpaz7QY4l9BxK2JwQuzHsXC8nA==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/number": "1.1.1",
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-direction": "1.1.1",
-        "@radix-ui/react-presence": "1.1.5",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-callback-ref": "1.1.1",
-        "@radix-ui/react-use-layout-effect": "1.1.1"
+        "@radix-ui/number": "1.1.3",
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-direction": "1.1.4",
+        "@radix-ui/react-presence": "1.1.10",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-callback-ref": "1.1.4",
+        "@radix-ui/react-use-layout-effect": "1.1.4"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -4433,93 +3028,38 @@
           "optional": true
         },
         "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-scroll-area/node_modules/@radix-ui/react-context": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
-      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-scroll-area/node_modules/@radix-ui/react-primitive": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
-      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-slot": "1.2.3"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-scroll-area/node_modules/@radix-ui/react-slot": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
-      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
           "optional": true
         }
       }
     },
     "node_modules/@radix-ui/react-select": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.2.6.tgz",
-      "integrity": "sha512-I30RydO+bnn2PQztvo25tswPH+wFBjehVGtmagkU78yMdwTwVf12wnAOF+AeP8S2N8xD+5UPbGhkUfPyvT+mwQ==",
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.3.7.tgz",
+      "integrity": "sha512-WFGImkmbzcfxeIwq/+4HvRN0pizBwbwQUED4I13ezQsDdfl38ZntN6TmR8XaSzPBqoCToe8rF75j6NPNDSzhbg==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/number": "1.1.1",
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-collection": "1.1.7",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-direction": "1.1.1",
-        "@radix-ui/react-dismissable-layer": "1.1.11",
-        "@radix-ui/react-focus-guards": "1.1.3",
-        "@radix-ui/react-focus-scope": "1.1.7",
-        "@radix-ui/react-id": "1.1.1",
-        "@radix-ui/react-popper": "1.2.8",
-        "@radix-ui/react-portal": "1.1.9",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-slot": "1.2.3",
-        "@radix-ui/react-use-callback-ref": "1.1.1",
-        "@radix-ui/react-use-controllable-state": "1.2.2",
-        "@radix-ui/react-use-layout-effect": "1.1.1",
-        "@radix-ui/react-use-previous": "1.1.1",
-        "@radix-ui/react-visually-hidden": "1.2.3",
+        "@radix-ui/number": "1.1.3",
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-collection": "1.1.15",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-direction": "1.1.4",
+        "@radix-ui/react-dismissable-layer": "1.1.19",
+        "@radix-ui/react-focus-guards": "1.1.6",
+        "@radix-ui/react-focus-scope": "1.1.16",
+        "@radix-ui/react-id": "1.1.4",
+        "@radix-ui/react-popper": "1.3.7",
+        "@radix-ui/react-portal": "1.1.17",
+        "@radix-ui/react-presence": "1.1.10",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-slot": "1.3.3",
+        "@radix-ui/react-use-callback-ref": "1.1.4",
+        "@radix-ui/react-use-controllable-state": "1.2.6",
+        "@radix-ui/react-use-layout-effect": "1.1.4",
+        "@radix-ui/react-use-previous": "1.1.4",
+        "@radix-ui/react-visually-hidden": "1.2.11",
         "aria-hidden": "^1.2.4",
-        "react-remove-scroll": "^2.6.3"
+        "react-remove-scroll": "^2.7.2"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -4532,73 +3072,17 @@
           "optional": true
         },
         "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-context": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
-      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-primitive": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
-      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-slot": "1.2.3"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-slot": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
-      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
           "optional": true
         }
       }
     },
     "node_modules/@radix-ui/react-separator": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-separator/-/react-separator-1.1.8.tgz",
-      "integrity": "sha512-sDvqVY4itsKwwSMEe0jtKgfTh+72Sy3gPmQpjqcQneqQ4PFmr/1I0YA+2/puilhggCe2gJcx5EBAYFkWkdpa5g==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-separator/-/react-separator-1.1.15.tgz",
+      "integrity": "sha512-jOLO4lssEzWpoDu7G+Ze4VjwMRUBt291pnZD0gmalREZipnTX3wadQo7Fy48GCTfe14/YRN6rw/rOJqrE85Wxw==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-primitive": "2.1.4"
+        "@radix-ui/react-primitive": "2.1.10"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -4616,22 +3100,22 @@
       }
     },
     "node_modules/@radix-ui/react-slider": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slider/-/react-slider-1.3.6.tgz",
-      "integrity": "sha512-JPYb1GuM1bxfjMRlNLE+BcmBC8onfCi60Blk7OBqi2MLTFdS+8401U4uFjnwkOr49BLmXxLC6JHkvAsx5OJvHw==",
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slider/-/react-slider-1.4.7.tgz",
+      "integrity": "sha512-mTSLf1GC/C0moWjTbvCM6Qn/gBjvlFt1azuWF2v7MN5C3Zq2U2J2lN3ZEYkpujuOU5Ro7A28wkviSxaKnG0BYg==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/number": "1.1.1",
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-collection": "1.1.7",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-direction": "1.1.1",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-controllable-state": "1.2.2",
-        "@radix-ui/react-use-layout-effect": "1.1.1",
-        "@radix-ui/react-use-previous": "1.1.1",
-        "@radix-ui/react-use-size": "1.1.1"
+        "@radix-ui/number": "1.1.3",
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-collection": "1.1.15",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-direction": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-controllable-state": "1.2.6",
+        "@radix-ui/react-use-layout-effect": "1.1.4",
+        "@radix-ui/react-use-previous": "1.1.4",
+        "@radix-ui/react-use-size": "1.1.4"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -4644,73 +3128,17 @@
           "optional": true
         },
         "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-slider/node_modules/@radix-ui/react-context": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
-      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-slider/node_modules/@radix-ui/react-primitive": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
-      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-slot": "1.2.3"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-slider/node_modules/@radix-ui/react-slot": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
-      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
           "optional": true
         }
       }
     },
     "node_modules/@radix-ui/react-slot": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.4.tgz",
-      "integrity": "sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.3.tgz",
+      "integrity": "sha512-qx7oqnYbxnK9kYI9m317qmFmEgo6ywqWvbTogdj7cL9p3/yx4M48p7Rnw5z3H890cL/ow/EeWJsuTykeZVXP5Q==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2"
+        "@radix-ui/react-compose-refs": "1.1.5"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -4723,18 +3151,17 @@
       }
     },
     "node_modules/@radix-ui/react-switch": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-switch/-/react-switch-1.2.6.tgz",
-      "integrity": "sha512-bByzr1+ep1zk4VubeEVViV592vu2lHE2BZY5OnzehZqOOgogN80+mNtCqPkhn2gklJqOpxWgPoYTSnhBCqpOXQ==",
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-switch/-/react-switch-1.3.7.tgz",
+      "integrity": "sha512-48tB/4dn2UVLBCYhTu9AuR63IHl73l/qLbLgxd86noTUor4/K4LFDAcYjK+isP5313qxaFpjPVogE7+Y0/V3Kw==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-controllable-state": "1.2.2",
-        "@radix-ui/react-use-previous": "1.1.1",
-        "@radix-ui/react-use-size": "1.1.1"
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-controllable-state": "1.2.6",
+        "@radix-ui/react-use-size": "1.1.4"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -4747,80 +3174,24 @@
           "optional": true
         },
         "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-switch/node_modules/@radix-ui/react-context": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
-      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-switch/node_modules/@radix-ui/react-primitive": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
-      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-slot": "1.2.3"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-switch/node_modules/@radix-ui/react-slot": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
-      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
           "optional": true
         }
       }
     },
     "node_modules/@radix-ui/react-tabs": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.13.tgz",
-      "integrity": "sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A==",
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.21.tgz",
+      "integrity": "sha512-UKxJlZid7FVtsk/WTxj4i4uSEgj2Au+KBbS7SQyTlzMhhn+86Cz3tISZdTa87bfEfcuvZezf2ZsxD4xuEKtkog==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-direction": "1.1.1",
-        "@radix-ui/react-id": "1.1.1",
-        "@radix-ui/react-presence": "1.1.5",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-roving-focus": "1.1.11",
-        "@radix-ui/react-use-controllable-state": "1.2.2"
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-direction": "1.1.4",
+        "@radix-ui/react-id": "1.1.4",
+        "@radix-ui/react-presence": "1.1.10",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-roving-focus": "1.1.19",
+        "@radix-ui/react-use-controllable-state": "1.2.6"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -4833,84 +3204,28 @@
           "optional": true
         },
         "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-context": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
-      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-primitive": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
-      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-slot": "1.2.3"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-slot": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
-      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
           "optional": true
         }
       }
     },
     "node_modules/@radix-ui/react-toast": {
-      "version": "1.2.15",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-toast/-/react-toast-1.2.15.tgz",
-      "integrity": "sha512-3OSz3TacUWy4WtOXV38DggwxoqJK4+eDkNMl5Z/MJZaoUPaP4/9lf81xXMe1I2ReTAptverZUpbPY4wWwWyL5g==",
+      "version": "1.2.23",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toast/-/react-toast-1.2.23.tgz",
+      "integrity": "sha512-ofhyAsYaocRGOs/n0XWdUOSVzEAG6BfrMVM8z0c0kLEWY38w/0WuMFPTJP/HVaZPYkMvHZoKIIhNcjbTCBILPg==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-collection": "1.1.7",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-dismissable-layer": "1.1.11",
-        "@radix-ui/react-portal": "1.1.9",
-        "@radix-ui/react-presence": "1.1.5",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-callback-ref": "1.1.1",
-        "@radix-ui/react-use-controllable-state": "1.2.2",
-        "@radix-ui/react-use-layout-effect": "1.1.1",
-        "@radix-ui/react-visually-hidden": "1.2.3"
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-collection": "1.1.15",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-dismissable-layer": "1.1.19",
+        "@radix-ui/react-portal": "1.1.17",
+        "@radix-ui/react-presence": "1.1.10",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-callback-ref": "1.1.4",
+        "@radix-ui/react-use-controllable-state": "1.2.6",
+        "@radix-ui/react-use-layout-effect": "1.1.4",
+        "@radix-ui/react-visually-hidden": "1.2.11"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -4923,75 +3238,19 @@
           "optional": true
         },
         "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-toast/node_modules/@radix-ui/react-context": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
-      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-toast/node_modules/@radix-ui/react-primitive": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
-      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-slot": "1.2.3"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-toast/node_modules/@radix-ui/react-slot": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
-      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
           "optional": true
         }
       }
     },
     "node_modules/@radix-ui/react-toggle": {
-      "version": "1.1.10",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle/-/react-toggle-1.1.10.tgz",
-      "integrity": "sha512-lS1odchhFTeZv3xwHH31YPObmJn8gOg7Lq12inrr0+BH/l3Tsq32VfjqH1oh80ARM3mlkfMic15n0kg4sD1poQ==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle/-/react-toggle-1.1.18.tgz",
+      "integrity": "sha512-7lonPlKfSacd20GlOBx2ltuVKz9oqWYZz+oMQyOltw6t1y2nyftj2ZmwwUHYn49kqfDWcp8dNZm5NgV+5Z+mug==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-controllable-state": "1.2.2"
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-controllable-state": "1.2.6"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -5009,18 +3268,18 @@
       }
     },
     "node_modules/@radix-ui/react-toggle-group": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle-group/-/react-toggle-group-1.1.11.tgz",
-      "integrity": "sha512-5umnS0T8JQzQT6HbPyO7Hh9dgd82NmS36DQr+X/YJ9ctFNCiiQd6IJAYYZ33LUwm8M+taCz5t2ui29fHZc4Y6Q==",
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle-group/-/react-toggle-group-1.1.19.tgz",
+      "integrity": "sha512-OtnwuSVjd1Ofi+AdnvhsjQdyuhCDwYs1w9RyB5BN/OavXOVQo42SYqQjwUnbPnaiPFBpQ9aX70dWeee+v2oBLA==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-direction": "1.1.1",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-roving-focus": "1.1.11",
-        "@radix-ui/react-toggle": "1.1.10",
-        "@radix-ui/react-use-controllable-state": "1.2.2"
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-direction": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-roving-focus": "1.1.19",
+        "@radix-ui/react-toggle": "1.1.18",
+        "@radix-ui/react-use-controllable-state": "1.2.6"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -5033,120 +3292,23 @@
           "optional": true
         },
         "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-toggle-group/node_modules/@radix-ui/react-context": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
-      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-toggle-group/node_modules/@radix-ui/react-primitive": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
-      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-slot": "1.2.3"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-toggle-group/node_modules/@radix-ui/react-slot": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
-      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-toggle/node_modules/@radix-ui/react-primitive": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
-      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-slot": "1.2.3"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-toggle/node_modules/@radix-ui/react-slot": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
-      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
           "optional": true
         }
       }
     },
     "node_modules/@radix-ui/react-toolbar": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-toolbar/-/react-toolbar-1.1.11.tgz",
-      "integrity": "sha512-4ol06/1bLoFu1nwUqzdD4Y5RZ9oDdKeiHIsntug54Hcr1pgaHiPqHFEaXI1IFP/EsOfROQZ8Mig9VTIRza6Tjg==",
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toolbar/-/react-toolbar-1.1.19.tgz",
+      "integrity": "sha512-Ph0IvtYw4VB12ZnZg+YtrGs8yJQsnizwo/zu0R4Y/nWugtJzA7Pg1eWeuDR9+LSqn+xjamss+UOSOJJJ4gx8jw==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-direction": "1.1.1",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-roving-focus": "1.1.11",
-        "@radix-ui/react-separator": "1.1.7",
-        "@radix-ui/react-toggle-group": "1.1.11"
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-direction": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-roving-focus": "1.1.19",
+        "@radix-ui/react-separator": "1.1.15",
+        "@radix-ui/react-toggle-group": "1.1.19"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -5159,107 +3321,29 @@
           "optional": true
         },
         "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-toolbar/node_modules/@radix-ui/react-context": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
-      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-toolbar/node_modules/@radix-ui/react-primitive": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
-      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-slot": "1.2.3"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-toolbar/node_modules/@radix-ui/react-separator": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-separator/-/react-separator-1.1.7.tgz",
-      "integrity": "sha512-0HEb8R9E8A+jZjvmFCy/J4xhbXy3TV+9XSnGJ3KvTtjlIUy/YQ/p6UYZvi7YbeoeXdyU9+Y3scizK6hkY37baA==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-primitive": "2.1.3"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-toolbar/node_modules/@radix-ui/react-slot": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
-      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
           "optional": true
         }
       }
     },
     "node_modules/@radix-ui/react-tooltip": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.2.8.tgz",
-      "integrity": "sha512-tY7sVt1yL9ozIxvmbtN5qtmH2krXcBCfjEiCgKGLqunJHvgvZG2Pcl2oQ3kbcZARb1BGEHdkLzcYGO8ynVlieg==",
+      "version": "1.2.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.2.16.tgz",
+      "integrity": "sha512-6EamKFRRnlpdadndbZ6LMwycfwkwPte1B42hs6QA0gYhjaOKqW4PZ4pjaW9UrlDX5eVt/OjncE7BFTPL5nmZhg==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-dismissable-layer": "1.1.11",
-        "@radix-ui/react-id": "1.1.1",
-        "@radix-ui/react-popper": "1.2.8",
-        "@radix-ui/react-portal": "1.1.9",
-        "@radix-ui/react-presence": "1.1.5",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-slot": "1.2.3",
-        "@radix-ui/react-use-controllable-state": "1.2.2",
-        "@radix-ui/react-visually-hidden": "1.2.3"
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-dismissable-layer": "1.1.19",
+        "@radix-ui/react-id": "1.1.4",
+        "@radix-ui/react-popper": "1.3.7",
+        "@radix-ui/react-portal": "1.1.17",
+        "@radix-ui/react-presence": "1.1.10",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-slot": "1.3.3",
+        "@radix-ui/react-use-controllable-state": "1.2.6",
+        "@radix-ui/react-use-layout-effect": "1.1.4",
+        "@radix-ui/react-visually-hidden": "1.2.11"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -5272,70 +3356,14 @@
           "optional": true
         },
         "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-context": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
-      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-primitive": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
-      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-slot": "1.2.3"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-slot": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
-      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
           "optional": true
         }
       }
     },
     "node_modules/@radix-ui/react-use-callback-ref": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz",
-      "integrity": "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.4.tgz",
+      "integrity": "sha512-R6OUY2e2fA6Yn6s+VSx5KBV6Nx8LQEhu+cz7LCej18rQ1HLyg9PSC9jP/ZNx0o6FAIK9c0F1kHylzSxKsdlkrQ==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
@@ -5348,13 +3376,14 @@
       }
     },
     "node_modules/@radix-ui/react-use-controllable-state": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz",
-      "integrity": "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.6.tgz",
+      "integrity": "sha512-uEQJGT97ZA/TgP/Hydw47lHu+/vQj6z/0jA+WeTbK1o9Rx45GImjpD0tc3W5ad3D6XTSR6e1yEO0FvGq6WQfVQ==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-use-effect-event": "0.0.2",
-        "@radix-ui/react-use-layout-effect": "1.1.1"
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-use-effect-event": "0.0.5",
+        "@radix-ui/react-use-layout-effect": "1.1.4"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -5367,12 +3396,12 @@
       }
     },
     "node_modules/@radix-ui/react-use-effect-event": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz",
-      "integrity": "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==",
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.5.tgz",
+      "integrity": "sha512-7cshFL8HGS/7HEiHH+9kL9HBwp2sa9yX18Knwek6KYWmXwM7pegMgta2AXMQKI+rq3JnfSj9x8wYqFMTdG1Jgg==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-use-layout-effect": "1.1.1"
+        "@radix-ui/react-use-layout-effect": "1.1.4"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -5385,12 +3414,12 @@
       }
     },
     "node_modules/@radix-ui/react-use-escape-keydown": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.1.tgz",
-      "integrity": "sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.5.tgz",
+      "integrity": "sha512-ge3ipobwSXTj4JyVtswQ7qZj0ZHdtbGuOno/LrgAAeSxtsJ6Vs4Gz5IkPH2bmqpjcLUFoqGhA/mueuIf63UXlA==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-use-callback-ref": "1.1.1"
+        "@radix-ui/react-use-callback-ref": "1.1.4"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -5403,13 +3432,10 @@
       }
     },
     "node_modules/@radix-ui/react-use-is-hydrated": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-is-hydrated/-/react-use-is-hydrated-0.1.0.tgz",
-      "integrity": "sha512-U+UORVEq+cTnRIaostJv9AGdV3G6Y+zbVd+12e18jQ5A3c0xL03IhnHuiU4UV69wolOQp5GfR58NW/EgdQhwOA==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-is-hydrated/-/react-use-is-hydrated-0.1.3.tgz",
+      "integrity": "sha512-umO/aJ+82CpOnhDZUTbILCQf7kU/g0iv+oGs/Q8jw7IkhWBzaEP4sA268PhFAJTFetbwp3ICc6ktpI4TqtxcIw==",
       "license": "MIT",
-      "dependencies": {
-        "use-sync-external-store": "^1.5.0"
-      },
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
@@ -5421,9 +3447,9 @@
       }
     },
     "node_modules/@radix-ui/react-use-layout-effect": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
-      "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.4.tgz",
+      "integrity": "sha512-K20DkRkUwDnxEYMBPcg3Y6voLkEy5p5QQmszZgLngKKiC7dzBR/aEuK3w1qlx2JWDUNH6FluahYdgR3BP+QbYw==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
@@ -5436,9 +3462,9 @@
       }
     },
     "node_modules/@radix-ui/react-use-previous": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.1.tgz",
-      "integrity": "sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.4.tgz",
+      "integrity": "sha512-XoSLhbRbqxFtgJoi2fNHA3C6pDlY34x508vUpUGoFZfvePfHXHbE1lC4FYFMnJWgiCRroSTw6fOsXQoVS9RwZg==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
@@ -5451,12 +3477,12 @@
       }
     },
     "node_modules/@radix-ui/react-use-rect": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.1.tgz",
-      "integrity": "sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.4.tgz",
+      "integrity": "sha512-cSOCh6JlkmfjLyNcLiu2nB4v+nm+dkZ+Q5KHWk/soo4U7ZLiEQFKHK9/YmtBHjfCEaU43IBKQOc4/uJmCaiCTQ==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/rect": "1.1.1"
+        "@radix-ui/rect": "1.1.3"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -5469,12 +3495,12 @@
       }
     },
     "node_modules/@radix-ui/react-use-size": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.1.tgz",
-      "integrity": "sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.4.tgz",
+      "integrity": "sha512-D3anSY15EJoxrihpsXI6SMrmmonnQtR2ni7arO+Lfdg3O95b9hNXxONk8jA5C8ANdF/h5HMAxejgs8PWJ6rlhw==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-use-layout-effect": "1.1.1"
+        "@radix-ui/react-use-layout-effect": "1.1.4"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -5487,12 +3513,12 @@
       }
     },
     "node_modules/@radix-ui/react-visually-hidden": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.3.tgz",
-      "integrity": "sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug==",
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.11.tgz",
+      "integrity": "sha512-NFS86RYYZb4/exihaESBGOpMJFz8MGLAfu3mOBSGByVnVPC9JPASfYubxd/8KbkQK0sYAv8lVQDEQukDX/qXvQ==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-primitive": "2.1.3"
+        "@radix-ui/react-primitive": "2.1.10"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -5505,55 +3531,14 @@
           "optional": true
         },
         "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-visually-hidden/node_modules/@radix-ui/react-primitive": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
-      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-slot": "1.2.3"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-visually-hidden/node_modules/@radix-ui/react-slot": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
-      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
           "optional": true
         }
       }
     },
     "node_modules/@radix-ui/rect": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.1.tgz",
-      "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.3.tgz",
+      "integrity": "sha512-JtyZR+mqgBibTo8xea3B6ZRmzZiM/YeVBtUkas6zMuXjAlfIFIW2FgqeM9eLyvEaYX66vr6DJMK+4U6LV0KhNw==",
       "license": "MIT"
     },
     "node_modules/@reduxjs/toolkit": {
@@ -7577,23 +5562,58 @@
       }
     },
     "node_modules/assistant-cloud": {
-      "version": "0.1.27",
-      "resolved": "https://registry.npmjs.org/assistant-cloud/-/assistant-cloud-0.1.27.tgz",
-      "integrity": "sha512-BGfVnx7YFN5xtB/kbrgGxRI0TfSWq4yxB3MwYn6RDPlv4JvdtPupvDC1Y6An0EhAe42Z0AYtSmDSsR6p6eeBng==",
+      "version": "0.1.39",
+      "resolved": "https://registry.npmjs.org/assistant-cloud/-/assistant-cloud-0.1.39.tgz",
+      "integrity": "sha512-cFVueA++JdklgmvkWqoRlmC3Qy8bjrnd/ptKIcOt1WYjQzGcrYUrxHDXijfpl8x3Hog4AuzwvjAk+8QAekhl/w==",
       "license": "MIT",
       "dependencies": {
-        "assistant-stream": "^0.3.12"
+        "assistant-stream": "^0.3.36"
       }
     },
-    "node_modules/assistant-stream": {
-      "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/assistant-stream/-/assistant-stream-0.3.12.tgz",
-      "integrity": "sha512-ZdfdyeZjeffkUfZLGTre9rW+9nBSPi6U5tYvchYjAxVuyiYVf5H9vw7SxegTq5bAMT9IitpDOaYMZGWFoMtaow==",
+    "node_modules/assistant-cloud/node_modules/assistant-stream": {
+      "version": "0.3.37",
+      "resolved": "https://registry.npmjs.org/assistant-stream/-/assistant-stream-0.3.37.tgz",
+      "integrity": "sha512-oxomJOPM7z09+nj2lwOhAaoH/TbRZ3EDOJ83TIgh6X1S1+CL5To/azmE8ZA2YMiXsKhhdDzqhyc5CQfU19ob5g==",
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
-        "nanoid": "^5.1.9",
+        "nanoid": "^6.0.1",
         "secure-json-parse": "^4.1.0"
+      },
+      "peerDependencies": {
+        "ioredis": "^5.10.1 || ^6.0.0",
+        "redis": "^5.12.1"
+      },
+      "peerDependenciesMeta": {
+        "ioredis": {
+          "optional": true
+        },
+        "redis": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/assistant-stream": {
+      "version": "0.3.28",
+      "resolved": "https://registry.npmjs.org/assistant-stream/-/assistant-stream-0.3.28.tgz",
+      "integrity": "sha512-ixBwkGIv0iVVXQCnaNrTsqNF2zviN1qChuWf4zFhXE1vtXadLRhVXisn+UYe7034pofs3PU0uJlv2M0W63wwUA==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "nanoid": "^6.0.0",
+        "secure-json-parse": "^4.1.0"
+      },
+      "peerDependencies": {
+        "ioredis": "^5.10.1",
+        "redis": "^5.12.1"
+      },
+      "peerDependenciesMeta": {
+        "ioredis": {
+          "optional": true
+        },
+        "redis": {
+          "optional": true
+        }
       }
     },
     "node_modules/ast-types": {
@@ -12575,9 +10595,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "5.1.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.11.tgz",
-      "integrity": "sha512-v+KEsUv2ps74PaSKv0gHTxTCgMXOIfBEbaqa6w6ISIGC7ZsvHN4N9oJ8d4cmf0n5oTzQz2SLmThbQWhjd/8eKg==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-6.0.1.tgz",
+      "integrity": "sha512-3wVS3i51pE2pi1k5FFL/95BGfVS0kSsvDVuGXHOtxox/TywUmtgq+3qiTOTbs9J7KfHaXPiN171k/A6dBnaXFw==",
       "funding": [
         {
           "type": "github",
@@ -12589,7 +10609,7 @@
         "nanoid": "bin/nanoid.js"
       },
       "engines": {
-        "node": "^18 || >=20"
+        "node": "^22 || ^24 || >=26"
       }
     },
     "node_modules/natural-compare": {
@@ -13346,66 +11366,66 @@
       "license": "MIT"
     },
     "node_modules/radix-ui": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/radix-ui/-/radix-ui-1.4.3.tgz",
-      "integrity": "sha512-aWizCQiyeAenIdUbqEpXgRA1ya65P13NKn/W8rWkcN0OPkRDxdBVLWnIEDsS2RpwCK2nobI7oMUSmexzTDyAmA==",
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/radix-ui/-/radix-ui-1.6.7.tgz",
+      "integrity": "sha512-QBdhh1arIEUvPC0dQ5+nwWAxt7+N+oP/9jPwjJkGFoSk/sqxg32gJtSXGtFh8frAIcS6oC9cx2Q+7KYCQLOAeA==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-accessible-icon": "1.1.7",
-        "@radix-ui/react-accordion": "1.2.12",
-        "@radix-ui/react-alert-dialog": "1.1.15",
-        "@radix-ui/react-arrow": "1.1.7",
-        "@radix-ui/react-aspect-ratio": "1.1.7",
-        "@radix-ui/react-avatar": "1.1.10",
-        "@radix-ui/react-checkbox": "1.3.3",
-        "@radix-ui/react-collapsible": "1.1.12",
-        "@radix-ui/react-collection": "1.1.7",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-context-menu": "2.2.16",
-        "@radix-ui/react-dialog": "1.1.15",
-        "@radix-ui/react-direction": "1.1.1",
-        "@radix-ui/react-dismissable-layer": "1.1.11",
-        "@radix-ui/react-dropdown-menu": "2.1.16",
-        "@radix-ui/react-focus-guards": "1.1.3",
-        "@radix-ui/react-focus-scope": "1.1.7",
-        "@radix-ui/react-form": "0.1.8",
-        "@radix-ui/react-hover-card": "1.1.15",
-        "@radix-ui/react-label": "2.1.7",
-        "@radix-ui/react-menu": "2.1.16",
-        "@radix-ui/react-menubar": "1.1.16",
-        "@radix-ui/react-navigation-menu": "1.2.14",
-        "@radix-ui/react-one-time-password-field": "0.1.8",
-        "@radix-ui/react-password-toggle-field": "0.1.3",
-        "@radix-ui/react-popover": "1.1.15",
-        "@radix-ui/react-popper": "1.2.8",
-        "@radix-ui/react-portal": "1.1.9",
-        "@radix-ui/react-presence": "1.1.5",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-progress": "1.1.7",
-        "@radix-ui/react-radio-group": "1.3.8",
-        "@radix-ui/react-roving-focus": "1.1.11",
-        "@radix-ui/react-scroll-area": "1.2.10",
-        "@radix-ui/react-select": "2.2.6",
-        "@radix-ui/react-separator": "1.1.7",
-        "@radix-ui/react-slider": "1.3.6",
-        "@radix-ui/react-slot": "1.2.3",
-        "@radix-ui/react-switch": "1.2.6",
-        "@radix-ui/react-tabs": "1.1.13",
-        "@radix-ui/react-toast": "1.2.15",
-        "@radix-ui/react-toggle": "1.1.10",
-        "@radix-ui/react-toggle-group": "1.1.11",
-        "@radix-ui/react-toolbar": "1.1.11",
-        "@radix-ui/react-tooltip": "1.2.8",
-        "@radix-ui/react-use-callback-ref": "1.1.1",
-        "@radix-ui/react-use-controllable-state": "1.2.2",
-        "@radix-ui/react-use-effect-event": "0.0.2",
-        "@radix-ui/react-use-escape-keydown": "1.1.1",
-        "@radix-ui/react-use-is-hydrated": "0.1.0",
-        "@radix-ui/react-use-layout-effect": "1.1.1",
-        "@radix-ui/react-use-size": "1.1.1",
-        "@radix-ui/react-visually-hidden": "1.2.3"
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-accessible-icon": "1.1.15",
+        "@radix-ui/react-accordion": "1.2.20",
+        "@radix-ui/react-alert-dialog": "1.1.23",
+        "@radix-ui/react-arrow": "1.1.15",
+        "@radix-ui/react-aspect-ratio": "1.1.15",
+        "@radix-ui/react-avatar": "1.2.6",
+        "@radix-ui/react-checkbox": "1.3.11",
+        "@radix-ui/react-collapsible": "1.1.20",
+        "@radix-ui/react-collection": "1.1.15",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-context-menu": "2.3.7",
+        "@radix-ui/react-dialog": "1.1.23",
+        "@radix-ui/react-direction": "1.1.4",
+        "@radix-ui/react-dismissable-layer": "1.1.19",
+        "@radix-ui/react-dropdown-menu": "2.1.24",
+        "@radix-ui/react-focus-guards": "1.1.6",
+        "@radix-ui/react-focus-scope": "1.1.16",
+        "@radix-ui/react-form": "0.1.16",
+        "@radix-ui/react-hover-card": "1.1.23",
+        "@radix-ui/react-label": "2.1.15",
+        "@radix-ui/react-menu": "2.1.24",
+        "@radix-ui/react-menubar": "1.1.24",
+        "@radix-ui/react-navigation-menu": "1.2.22",
+        "@radix-ui/react-one-time-password-field": "0.1.16",
+        "@radix-ui/react-password-toggle-field": "0.1.11",
+        "@radix-ui/react-popover": "1.1.23",
+        "@radix-ui/react-popper": "1.3.7",
+        "@radix-ui/react-portal": "1.1.17",
+        "@radix-ui/react-presence": "1.1.10",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-progress": "1.1.16",
+        "@radix-ui/react-radio-group": "1.4.7",
+        "@radix-ui/react-roving-focus": "1.1.19",
+        "@radix-ui/react-scroll-area": "1.2.18",
+        "@radix-ui/react-select": "2.3.7",
+        "@radix-ui/react-separator": "1.1.15",
+        "@radix-ui/react-slider": "1.4.7",
+        "@radix-ui/react-slot": "1.3.3",
+        "@radix-ui/react-switch": "1.3.7",
+        "@radix-ui/react-tabs": "1.1.21",
+        "@radix-ui/react-toast": "1.2.23",
+        "@radix-ui/react-toggle": "1.1.18",
+        "@radix-ui/react-toggle-group": "1.1.19",
+        "@radix-ui/react-toolbar": "1.1.19",
+        "@radix-ui/react-tooltip": "1.2.16",
+        "@radix-ui/react-use-callback-ref": "1.1.4",
+        "@radix-ui/react-use-controllable-state": "1.2.6",
+        "@radix-ui/react-use-effect-event": "0.0.5",
+        "@radix-ui/react-use-escape-keydown": "1.1.5",
+        "@radix-ui/react-use-is-hydrated": "0.1.3",
+        "@radix-ui/react-use-layout-effect": "1.1.4",
+        "@radix-ui/react-use-size": "1.1.4",
+        "@radix-ui/react-visually-hidden": "1.2.11"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -13418,108 +11438,6 @@
           "optional": true
         },
         "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/radix-ui/node_modules/@radix-ui/react-context": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
-      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/radix-ui/node_modules/@radix-ui/react-label": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.7.tgz",
-      "integrity": "sha512-YT1GqPSL8kJn20djelMX7/cTRp/Y9w5IZHvfxQTVHrOqa2yMl7i/UfMqKRU5V7mEyKTrUVgJXhNQPVCG8PBLoQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-primitive": "2.1.3"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/radix-ui/node_modules/@radix-ui/react-primitive": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
-      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-slot": "1.2.3"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/radix-ui/node_modules/@radix-ui/react-separator": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-separator/-/react-separator-1.1.7.tgz",
-      "integrity": "sha512-0HEb8R9E8A+jZjvmFCy/J4xhbXy3TV+9XSnGJ3KvTtjlIUy/YQ/p6UYZvi7YbeoeXdyU9+Y3scizK6hkY37baA==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-primitive": "2.1.3"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/radix-ui/node_modules/@radix-ui/react-slot": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
-      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
           "optional": true
         }
       }
@@ -14219,6 +12137,12 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/safe-content-frame": {
+      "version": "0.0.25",
+      "resolved": "https://registry.npmjs.org/safe-content-frame/-/safe-content-frame-0.0.25.tgz",
+      "integrity": "sha512-Oztqn3kWTbNzMlWSr6SQiUBPtLJLbjzaJUYtO7PN5SfC5PxtOrBnEfnVy0IMT7do1SGqUkd/o1KTSXMRS+FBMw==",
       "license": "MIT"
     },
     "node_modules/safer-buffer": {
@@ -15872,9 +13796,9 @@
       }
     },
     "node_modules/zustand": {
-      "version": "5.0.13",
-      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.13.tgz",
-      "integrity": "sha512-efI2tVaVQPqtOh114loML/Z80Y4NP3yc+Ff0fYiZJPauNeWZeIp/bRFD7I9bfmCOYBh/PHxlglQ9+wvlwnPikQ==",
+      "version": "5.0.14",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.14.tgz",
+      "integrity": "sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==",
       "license": "MIT",
       "engines": {
         "node": ">=12.20.0"

--- a/studio/frontend/package.json
+++ b/studio/frontend/package.json
@@ -21,9 +21,9 @@
     "biome:fix": "biome check --write"
   },
   "dependencies": {
-    "@assistant-ui/core": "0.1.17",
-    "@assistant-ui/react": "0.12.28",
-    "@assistant-ui/tap": "0.5.10",
+    "@assistant-ui/core": "0.2.23",
+    "@assistant-ui/react": "0.14.29",
+    "@assistant-ui/tap": "0.9.6",
     "@base-ui/react": "^1.2.0",
     "@dagrejs/dagre": "^2.0.4",
     "@dagrejs/graphlib": "^3.0.4",
@@ -55,7 +55,7 @@
     "@tauri-apps/plugin-window-state": "^2.4.1",
     "@toolwind/corner-shape": "^0.0.8-3",
     "@xyflow/react": "^12.10.0",
-    "assistant-stream": "0.3.12",
+    "assistant-stream": "0.3.28",
     "canvas-confetti": "^1.9.4",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
@@ -73,7 +73,7 @@
     "micromark-extension-math": "3.1.0",
     "motion": "^12.34.0",
     "node-forge": "^1.4.0",
-    "radix-ui": "^1.4.3",
+    "radix-ui": "^1.6.7",
     "react": "^19.2.4",
     "react-day-picker": "^9.13.2",
     "react-dom": "^19.2.4",
@@ -90,7 +90,7 @@
     "tw-animate-css": "^1.4.0",
     "tw-shimmer": "^0.4.6",
     "unpdf": "^1.4.0",
-    "zustand": "^5.0.11"
+    "zustand": "^5.0.14"
   },
   "overrides": {
     "@tanstack/react-router": "1.169.2",

--- a/studio/frontend/src/components/assistant-ui/code-plugin.ts
+++ b/studio/frontend/src/components/assistant-ui/code-plugin.ts
@@ -115,6 +115,26 @@ const plainLine = (content: string): TokenLine =>
 const themeName = (theme: ThemeInput): string =>
   typeof theme === "string" ? theme : (theme.name ?? "custom");
 
+// Two custom themes can share a name, or carry none, so a cache key built from
+// names alone would serve one theme's tokens for another. Reduce each distinct
+// definition to a short id once: the key is compared on every lookup.
+const themeIds = new Map<string, string>();
+const themeIdByInput = new WeakMap<object, string>();
+
+const themeKey = (theme: ThemeInput): string => {
+  if (typeof theme === "string") return theme;
+  const known = themeIdByInput.get(theme);
+  if (known !== undefined) return known;
+  const definition = JSON.stringify(theme);
+  let id = themeIds.get(definition);
+  if (id === undefined) {
+    id = `${themeName(theme)}#${themeIds.size}`;
+    themeIds.set(definition, id);
+  }
+  themeIdByInput.set(theme, id);
+  return id;
+};
+
 const stripTokens = (result: HighlightResult): ResultMeta => ({
   bg: result.bg,
   fg: result.fg,
@@ -129,8 +149,9 @@ const shiftLine = (line: TokenLine, offset: number): TokenLine =>
     : line.map((token) => ({ ...token, offset: token.offset + offset }));
 
 // Markdown reports a closing fence as body until it recognizes it, so all a
-// fence can lose is indentation, a backtick or tilde run, and whitespace.
-const CLOSING_DELIMITER = /^[\s`~]*$/;
+// fence can lose is a backtick or tilde run plus surrounding whitespace. The
+// run has to be there: whitespace alone never closes a fence.
+const CLOSING_DELIMITER = /^[\s`~]*[`~][\s`~]*$/;
 
 /** Whether `code` is the fence's own body with just its closing delimiter gone. */
 const isClosingReparse = (fence: Fence, code: string): boolean =>
@@ -395,7 +416,7 @@ export function createCodePlugin(
         light: themeName(opts.themes[0]),
         dark: themeName(opts.themes[1]),
       };
-      const key = `${language} ${themes.light} ${themes.dark}`;
+      const key = `${language} ${themeKey(opts.themes[0])} ${themeKey(opts.themes[1])}`;
       const fence = findFence(key, opts.code);
 
       if (fence.result && fence.code === opts.code && !fence.approximate) {

--- a/studio/frontend/src/components/assistant-ui/code-plugin.ts
+++ b/studio/frontend/src/components/assistant-ui/code-plugin.ts
@@ -1,14 +1,22 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-import {
-  createCodePlugin as createShikiCodePlugin,
-  type CodeHighlighterPlugin,
-  type CodePluginOptions,
-  type HighlightOptions,
-  type HighlightResult,
+import type {
+  CodeHighlighterPlugin,
+  CodePluginOptions,
+  HighlightOptions,
+  HighlightResult,
+  ThemeInput,
 } from "@streamdown/code";
-import type { BundledLanguage } from "shiki";
+import {
+  type BundledLanguage,
+  bundledLanguages,
+  bundledLanguagesInfo,
+  createHighlighter,
+  type GrammarState,
+  type ThemedToken,
+} from "shiki";
+import { createJavaScriptRegexEngine } from "shiki/engine/javascript";
 
 // Common fence tags shiki doesn't expose as aliases.
 // Keys: lower-cased input; values: canonical shiki language ids.
@@ -41,17 +49,33 @@ const LANGUAGE_ALIAS_OVERRIDES: Record<string, BundledLanguage> = {
   "vue-html": "vue",
 };
 
+const SHIKI_LANGUAGE_ALIASES: Record<string, BundledLanguage> =
+  Object.fromEntries(
+    bundledLanguagesInfo.flatMap((info) =>
+      (info.aliases ?? []).map((alias) => [alias, info.id as BundledLanguage]),
+    ),
+  );
+const SUPPORTED_LANGUAGES = new Set(Object.keys(bundledLanguages));
+const SUPPORTED_LANGUAGE_LIST = Array.from(
+  SUPPORTED_LANGUAGES,
+) as BundledLanguage[];
+const PLAIN_TEXT = "text" as BundledLanguage;
+
 const normalizeLanguage = (language: string): BundledLanguage => {
   const key = language.trim().toLowerCase();
-  const override = LANGUAGE_ALIAS_OVERRIDES[key];
-  return (override ?? (key as BundledLanguage));
+  const alias = LANGUAGE_ALIAS_OVERRIDES[key] ?? SHIKI_LANGUAGE_ALIASES[key];
+  return alias ?? (key as BundledLanguage);
 };
 
-// A streaming fence re-enters highlight() every frame with the whole block, so
-// Shiki re-tokenizes it in full ~60x/sec. Past MIN_INCREMENTAL_CHARS, reuse the
-// cached tokens with an unstyled tail, re-tokenizing at most every REFRESH_MS.
+// Cache completed lines and their grammar state so each refresh tokenizes only
+// new text. Large fences retain the previous 250 ms plain-tail cadence.
 const MIN_INCREMENTAL_CHARS = 2000;
 const REFRESH_MS = 250;
+// An unvirtualized thread mounts every fence. Bound both their count and source
+// size; token data measured roughly 30 bytes per source character.
+const MAX_FENCES = 512;
+const MAX_CACHED_CHARACTERS = 512_000;
+
 // Wall-clock Date.now() can step backwards (NTP, sleep resume) and make
 // `elapsed` negative; the throttle only needs elapsed time, so stay monotonic.
 const monotonicNow = (): number =>
@@ -59,139 +83,361 @@ const monotonicNow = (): number =>
     ? performance.now()
     : Date.now();
 
-// One slot per fence: a message can hold several large fences, and Streamdown
-// revisits all of them on every render.
-const MAX_SLOTS_PER_KEY = 8;
-
+type Highlighter = Awaited<ReturnType<typeof createHighlighter>>;
 type TokenLine = HighlightResult["tokens"][number];
-type Dispatch = {
-  opts: HighlightOptions;
-  language: BundledLanguage;
-  callback?: (result: HighlightResult) => void;
-};
-type Slot = {
-  /** Code that produced `result`. Only ever set together with it. */
+type ResultMeta = Omit<HighlightResult, "tokens">;
+type ThemeNames = { light: string; dark: string };
+type HighlightCallback = (result: HighlightResult) => void;
+type Pending = { code: string; callbacks: Set<HighlightCallback> };
+
+type Fence = {
+  key: string;
   code: string;
   result: HighlightResult | null;
-  /** Code of the dispatch awaiting a callback. */
-  inFlight: string | null;
-  lastDispatchAt: number;
+  meta: ResultMeta | null;
+  /** Absolute-offset tokens for completed lines. */
+  lines: TokenLine[];
+  /** Source prefix covered by `lines`. */
+  committedLength: number;
+  state: GrammarState | undefined;
+  liveTokens: TokenLine | null;
+  lastTokenizedAt: number;
+  /** Whether `result` has a plain tail awaiting refresh. */
+  approximate: boolean;
   trailing: ReturnType<typeof setTimeout> | null;
-  pending: Dispatch | null;
+  pending: Pending | null;
 };
 
-// No colour fields, so it renders in the default foreground instead of
-// inheriting a neighbouring token's colour.
-const plainLine = (text: string): TokenLine =>
-  [{ content: text, offset: 0 }] as unknown as TokenLine;
+// Tokens without colors preserve the previous plain-tail rendering.
+const plainLine = (content: string): TokenLine =>
+  [{ content, offset: 0 } as unknown as ThemedToken] as TokenLine;
+
+const themeName = (theme: ThemeInput): string =>
+  typeof theme === "string" ? theme : (theme.name ?? "custom");
+
+const stripTokens = (result: HighlightResult): ResultMeta => ({
+  bg: result.bg,
+  fg: result.fg,
+  themeName: result.themeName,
+  rootStyle: result.rootStyle,
+  grammarState: result.grammarState,
+});
+
+const shiftLine = (line: TokenLine, offset: number): TokenLine =>
+  offset === 0
+    ? line
+    : line.map((token) => ({ ...token, offset: token.offset + offset }));
 
 export function createCodePlugin(
   options: CodePluginOptions = {},
 ): CodeHighlighterPlugin {
-  const inner = createShikiCodePlugin(options);
-  const slotsByKey = new Map<string, Slot[]>();
+  const defaultThemes: [ThemeInput, ThemeInput] = options.themes ?? [
+    "github-light",
+    "github-dark",
+  ];
+  const engine = createJavaScriptRegexEngine({ forgiving: true });
+  const highlighters = new Map<string, { highlighter: Highlighter | null }>();
+  // Most recently used first.
+  const fences: Fence[] = [];
+  // Avoid scanning every fence for exact cache hits.
+  const fencesByCode = new Map<string, Fence>();
+  let cachedCharacters = 0;
 
-  const clearTrailing = (slot: Slot) => {
-    if (slot.trailing !== null) clearTimeout(slot.trailing);
-    slot.trailing = null;
-    slot.pending = null;
+  // Avoid hashing the whole source on each update; verify compact-key hits.
+  const codeKey = (key: string, code: string): string =>
+    `${key}\n${code.length}\n${code.slice(0, 32)}\n${code.slice(-32)}`;
+
+  // Identical fences can share an index key.
+  const dropCodeIndex = (fence: Fence): void => {
+    const indexKey = codeKey(fence.key, fence.code);
+    if (fencesByCode.get(indexKey) === fence) fencesByCode.delete(indexKey);
   };
 
-  const adopt = (slot: Slot, code: string, result: HighlightResult) => {
-    // Write code and result together so a reuse cannot slice one against the other.
-    slot.code = code;
-    slot.result = result;
-    slot.inFlight = null;
+  const clearTrailing = (fence: Fence): void => {
+    if (fence.trailing !== null) clearTimeout(fence.trailing);
+    fence.trailing = null;
+    fence.pending = null;
   };
 
-  const dispatch = (slot: Slot, d: Dispatch) => {
-    slot.inFlight = d.opts.code;
-    slot.lastDispatchAt = monotonicNow();
-    const immediate = inner.highlight({ ...d.opts, language: d.language }, (result) => {
-      if (slot.inFlight === d.opts.code) {
-        adopt(slot, d.opts.code, result);
-      }
-      d.callback?.(result);
-    });
-    // @streamdown/code answers out of its own cache synchronously and never
-    // invokes the callback, so adopt here too or the slot keeps older tokens.
-    if (immediate) {
-      adopt(slot, d.opts.code, immediate);
+  const queuePending = (
+    fence: Fence,
+    code: string,
+    callback?: HighlightCallback,
+  ): void => {
+    if (!fence.pending || fence.pending.code !== code) {
+      fence.pending = { code, callbacks: new Set() };
     }
-    return immediate;
+    if (callback) fence.pending.callbacks.add(callback);
+  };
+
+  const notifyPending = (
+    pending: Pending,
+    result: HighlightResult,
+  ): void => {
+    for (const callback of pending.callbacks) callback(result);
+  };
+
+  const evict = (): void => {
+    while (
+      fences.length > MAX_FENCES ||
+      (cachedCharacters > MAX_CACHED_CHARACTERS && fences.length > 1)
+    ) {
+      // Keep pending callbacks until their grammar resolves.
+      let dropIndex = fences.length - 1;
+      while (dropIndex >= 0 && fences[dropIndex].pending !== null) {
+        dropIndex -= 1;
+      }
+      if (dropIndex < 0) return;
+      const [dropped] = fences.splice(dropIndex, 1);
+      cachedCharacters -= dropped.code.length;
+      dropCodeIndex(dropped);
+      clearTrailing(dropped);
+    }
+  };
+
+  const promote = (fence: Fence): Fence => {
+    const index = fences.indexOf(fence);
+    if (index > 0) {
+      fences.splice(index, 1);
+      fences.unshift(fence);
+    }
+    return fence;
+  };
+
+  /** The fence whose cached code reaches furthest into `code`. */
+  const findFence = (key: string, code: string): Fence => {
+    const exact = fencesByCode.get(codeKey(key, code));
+    if (exact && exact.code === code) return promote(exact);
+    let match: Fence | null = null;
+    let matchLength = -1;
+    for (const fence of fences) {
+      if (fence.key !== key) continue;
+      // Prefix-related pending calls may belong to different blocks.
+      if (fence.result === null) {
+        if (fence.pending?.code === code) return promote(fence);
+        continue;
+      }
+      const anchor = fence.code;
+      // Closing backticks can briefly make Markdown return a shorter body.
+      const reaches =
+        code.startsWith(anchor) ||
+        (anchor.startsWith(code) && code.length >= fence.committedLength);
+      const reach = Math.min(anchor.length, code.length);
+      if (!anchor || reach <= matchLength || !reaches) continue;
+      match = fence;
+      matchLength = reach;
+    }
+    if (match) return promote(match);
+    const fence: Fence = {
+      key,
+      code: "",
+      result: null,
+      meta: null,
+      lines: [],
+      committedLength: 0,
+      state: undefined,
+      liveTokens: null,
+      lastTokenizedAt: 0,
+      approximate: false,
+      trailing: null,
+      pending: null,
+    };
+    fences.unshift(fence);
+    return fence;
+  };
+
+  /** Tokenize what `fence` has not seen yet and return the whole fence. */
+  const tokenize = (
+    fence: Fence,
+    highlighter: Highlighter,
+    code: string,
+    language: BundledLanguage,
+    themes: ThemeNames,
+  ): HighlightResult => {
+    const lang = highlighter.getLoadedLanguages().includes(language)
+      ? language
+      : PLAIN_TEXT;
+    const tokenizeFrom = (text: string) =>
+      highlighter.codeToTokens(text, {
+        lang,
+        themes,
+        grammarState: fence.state,
+      });
+
+    // Commit every newly completed line.
+    const lastNewline = code.lastIndexOf("\n");
+    if (lastNewline >= fence.committedLength) {
+      // Shiki omits CR from CRLF token content.
+      const completedEnd =
+        lastNewline > 0 && code[lastNewline - 1] === "\r"
+          ? lastNewline - 1
+          : lastNewline;
+      const completed = tokenizeFrom(
+        code.slice(fence.committedLength, completedEnd),
+      );
+      for (const line of completed.tokens) {
+        fence.lines.push(shiftLine(line, fence.committedLength));
+      }
+      fence.state = completed.grammarState;
+      fence.committedLength = lastNewline + 1;
+      fence.liveTokens = null;
+      fence.meta = stripTokens(completed);
+    }
+
+    const live = code.slice(fence.committedLength);
+    const liveResult = tokenizeFrom(live);
+    fence.meta = stripTokens(liveResult);
+    fence.liveTokens = shiftLine(
+      liveResult.tokens[0] ?? [],
+      fence.committedLength,
+    );
+    fence.lastTokenizedAt = monotonicNow();
+    fence.approximate = false;
+    return { ...fence.meta, tokens: [...fence.lines, fence.liveTokens] };
+  };
+
+  const approximateResult = (fence: Fence, code: string): HighlightResult => {
+    const exact = fence.result as HighlightResult;
+    // A live line may have grown mid-token, so render the whole tail plain.
+    const keptLines = exact.tokens.slice(0, fence.lines.length);
+    const tail = code.slice(fence.committedLength).split("\n");
+    fence.approximate = true;
+    return { ...exact, tokens: [...keptLines, ...tail.map(plainLine)] };
+  };
+
+  const resetFence = (fence: Fence): void => {
+    fence.lines = [];
+    fence.committedLength = 0;
+    fence.state = undefined;
+    fence.liveTokens = null;
+    fence.meta = null;
+    fence.approximate = false;
+  };
+
+  // Leave the block plain if highlighting fails instead of breaking render.
+  const update = (
+    fence: Fence,
+    highlighter: Highlighter,
+    code: string,
+    language: BundledLanguage,
+    themes: ThemeNames,
+  ): HighlightResult | null => {
+    let result: HighlightResult;
+    try {
+      result = tokenize(fence, highlighter, code, language, themes);
+    } catch (error) {
+      console.error("[Studio Code] Failed to highlight code:", error);
+      resetFence(fence);
+      return null;
+    }
+    cachedCharacters += code.length - fence.code.length;
+    dropCodeIndex(fence);
+    fence.code = code;
+    fence.result = result;
+    fencesByCode.set(codeKey(fence.key, code), fence);
+    evict();
+    return result;
+  };
+
+  const loadHighlighter = (
+    key: string,
+    language: BundledLanguage,
+    themes: [ThemeInput, ThemeInput],
+    resume: (highlighter: Highlighter) => void,
+  ): Highlighter | null => {
+    const loading = highlighters.get(key);
+    if (loading) return loading.highlighter;
+    const entry: { highlighter: Highlighter | null } = { highlighter: null };
+    highlighters.set(key, entry);
+    createHighlighter({
+      themes,
+      langs: [SUPPORTED_LANGUAGES.has(language) ? language : PLAIN_TEXT],
+      engine,
+    })
+      .then((highlighter) => {
+        entry.highlighter = highlighter;
+        resume(highlighter);
+      })
+      .catch((error) => {
+        console.error("[Studio Code] Failed to highlight code:", error);
+        highlighters.delete(key);
+        // Failed callbacks must not pin fences or fire after a later retry.
+        for (const waiting of fences) {
+          if (waiting.key === key) clearTrailing(waiting);
+        }
+        evict();
+      });
+    return null;
   };
 
   return {
-    ...inner,
+    name: "shiki",
+    type: "code-highlighter",
+    getSupportedLanguages: () => SUPPORTED_LANGUAGE_LIST,
+    getThemes: () => defaultThemes,
     supportsLanguage: (language) =>
-      inner.supportsLanguage(normalizeLanguage(language)),
+      SUPPORTED_LANGUAGES.has(normalizeLanguage(language)),
     highlight: (
       opts: HighlightOptions,
       callback?: (result: HighlightResult) => void,
-    ) => {
+    ): HighlightResult | null => {
       const language = normalizeLanguage(opts.language);
-      if (opts.code.length < MIN_INCREMENTAL_CHARS) {
-        return inner.highlight({ ...opts, language }, callback);
+      const themes: ThemeNames = {
+        light: themeName(opts.themes[0]),
+        dark: themeName(opts.themes[1]),
+      };
+      const key = `${language} ${themes.light} ${themes.dark}`;
+      const fence = findFence(key, opts.code);
+
+      if (fence.result && fence.code === opts.code && !fence.approximate) {
+        return fence.result;
       }
 
-      const key = `${language} ${JSON.stringify(opts.themes)}`;
-      let slots = slotsByKey.get(key);
-      if (!slots) {
-        slots = [];
-        slotsByKey.set(key, slots);
-      }
-
-      // Longest-prefix match, so sibling fences do not evict each other.
-      let slot: Slot | null = null;
-      let bestLength = -1;
-      for (const candidate of slots) {
-        const anchor = candidate.code || candidate.inFlight || "";
-        if (!anchor || !opts.code.startsWith(anchor)) continue;
-        if (anchor.length > bestLength) {
-          slot = candidate;
-          bestLength = anchor.length;
+      const highlighter = loadHighlighter(key, language, opts.themes, (ready) => {
+        // Use a stable, oldest-first snapshot because updates can evict fences.
+        for (const waiting of [...fences].reverse()) {
+          const pending = waiting.pending;
+          if (waiting.key !== key || !pending) continue;
+          clearTrailing(waiting);
+          const resumed = update(waiting, ready, pending.code, language, themes);
+          if (resumed) notifyPending(pending, resumed);
         }
-      }
-      if (!slot) {
-        slot = { code: "", result: null, inFlight: null, lastDispatchAt: 0, trailing: null, pending: null };
-        slots.unshift(slot);
-        for (const dropped of slots.splice(MAX_SLOTS_PER_KEY)) clearTrailing(dropped);
-      }
-
-      // Finished fence re-rendered unchanged: serve it, never re-tokenize.
-      if (slot.result && slot.code === opts.code) return slot.result;
-
-      const elapsed = monotonicNow() - slot.lastDispatchAt;
-      const grew = slot.result !== null && opts.code.length > slot.code.length;
-      if (!grew || elapsed >= REFRESH_MS) {
-        clearTrailing(slot);
-        return dispatch(slot, { opts, language, callback });
+      });
+      if (!highlighter) {
+        queuePending(fence, opts.code, callback);
+        evict();
+        return null;
       }
 
-      // Close out a reused run, so a final render is never left unstyled.
-      slot.pending = { opts, language, callback };
-      if (slot.trailing === null) {
-        const target = slot;
-        target.trailing = setTimeout(() => {
-          target.trailing = null;
-          const next = target.pending;
-          target.pending = null;
-          if (!next) return;
-          const immediate = dispatch(target, next);
-          // Nothing consumes this return value, so hand a synchronous cache
-          // hit to the callback or the fence keeps its unstyled tail.
-          if (immediate) next.callback?.(immediate);
-        }, Math.max(0, REFRESH_MS - elapsed));
+      clearTrailing(fence);
+      const elapsed = monotonicNow() - fence.lastTokenizedAt;
+      const grewLargeFence =
+        fence.result !== null &&
+        fence.code.length >= MIN_INCREMENTAL_CHARS &&
+        opts.code.length > fence.code.length;
+      if (grewLargeFence && elapsed < REFRESH_MS) {
+        const result = approximateResult(fence, opts.code);
+        queuePending(fence, opts.code, callback);
+        fence.trailing = setTimeout(
+          () => {
+            const pending = fence.pending;
+            fence.trailing = null;
+            fence.pending = null;
+            if (!pending) return;
+            const refreshed = update(
+              fence,
+              highlighter,
+              pending.code,
+              language,
+              themes,
+            );
+            if (refreshed) notifyPending(pending, refreshed);
+          },
+          Math.max(0, REFRESH_MS - elapsed),
+        );
+        return result;
       }
-
-      const previous = slot.result as HighlightResult;
-      // Drop the cached final line: it may have been cut mid-token.
-      const keptLines = previous.tokens.slice(
-        0,
-        Math.max(0, slot.code.split("\n").length - 1),
-      );
-      const tail = opts.code.split("\n").slice(keptLines.length);
-      return { ...previous, tokens: [...keptLines, ...tail.map(plainLine)] };
+      return update(fence, highlighter, opts.code, language, themes);
     },
   };
 }

--- a/studio/frontend/src/components/assistant-ui/code-plugin.ts
+++ b/studio/frontend/src/components/assistant-ui/code-plugin.ts
@@ -128,9 +128,8 @@ const shiftLine = (line: TokenLine, offset: number): TokenLine =>
     ? line
     : line.map((token) => ({ ...token, offset: token.offset + offset }));
 
-// Markdown reports a closing fence as body until it recognizes it, so the only
-// text a fence can lose is indentation, a run of backticks or tildes, and
-// trailing whitespace.
+// Markdown reports a closing fence as body until it recognizes it, so all a
+// fence can lose is indentation, a backtick or tilde run, and whitespace.
 const CLOSING_DELIMITER = /^[\s`~]*$/;
 
 /** Whether `code` is the fence's own body with just its closing delimiter gone. */
@@ -229,8 +228,8 @@ export function createCodePlugin(
         continue;
       }
       const anchor = fence.code;
-      // A fence that lost more than its closing delimiter is a different block
-      // sharing a prefix, and reusing this entry would cancel its refresh.
+      // A block that lost more than its closing delimiter is a different fence;
+      // sharing this entry would cancel the refresh it has queued.
       const reaches = code.startsWith(anchor) || isClosingReparse(fence, code);
       const reach = Math.min(anchor.length, code.length);
       if (!anchor || reach <= matchLength || !reaches) continue;

--- a/studio/frontend/src/components/assistant-ui/code-plugin.ts
+++ b/studio/frontend/src/components/assistant-ui/code-plugin.ts
@@ -102,8 +102,6 @@ type Fence = {
   state: GrammarState | undefined;
   liveTokens: TokenLine | null;
   lastTokenizedAt: number;
-  /** Whether `result` has a plain tail awaiting refresh. */
-  approximate: boolean;
   trailing: ReturnType<typeof setTimeout> | null;
   pending: Pending | null;
 };
@@ -149,15 +147,14 @@ const shiftLine = (line: TokenLine, offset: number): TokenLine =>
     : line.map((token) => ({ ...token, offset: token.offset + offset }));
 
 // Markdown reports a closing fence as body until it recognizes it, so all a
-// fence can lose is a backtick or tilde run plus surrounding whitespace. The
-// run has to be there: whitespace alone never closes a fence.
-const CLOSING_DELIMITER = /^[\s`~]*[`~][\s`~]*$/;
+// fence can lose is one run of backticks or tildes plus surrounding whitespace.
+// A closing run is never empty and never mixes the two markers.
+const CLOSING_DELIMITER = /^\s*(?:`+|~+)\s*$/;
 
-/** Whether `code` is the fence's own body with just its closing delimiter gone. */
-const isClosingReparse = (fence: Fence, code: string): boolean =>
-  fence.code.startsWith(code) &&
-  code.length >= fence.committedLength &&
-  CLOSING_DELIMITER.test(fence.code.slice(code.length));
+/** Whether `longer` is one fence's body, `shorter`, plus its closing run. */
+const shedsClosingRun = (shorter: string, longer: string): boolean =>
+  longer.startsWith(shorter) &&
+  CLOSING_DELIMITER.test(longer.slice(shorter.length));
 
 export function createCodePlugin(
   options: CodePluginOptions = {},
@@ -251,7 +248,9 @@ export function createCodePlugin(
       const anchor = fence.code;
       // A block that lost more than its closing delimiter is a different fence;
       // sharing this entry would cancel the refresh it has queued.
-      const reaches = code.startsWith(anchor) || isClosingReparse(fence, code);
+      const reaches =
+        code.startsWith(anchor) ||
+        (code.length >= fence.committedLength && shedsClosingRun(code, anchor));
       const reach = Math.min(anchor.length, code.length);
       if (!anchor || reach <= matchLength || !reaches) continue;
       match = fence;
@@ -268,7 +267,6 @@ export function createCodePlugin(
       state: undefined,
       liveTokens: null,
       lastTokenizedAt: 0,
-      approximate: false,
       trailing: null,
       pending: null,
     };
@@ -322,7 +320,6 @@ export function createCodePlugin(
       fence.committedLength,
     );
     fence.lastTokenizedAt = monotonicNow();
-    fence.approximate = false;
     return { ...fence.meta, tokens: [...fence.lines, fence.liveTokens] };
   };
 
@@ -331,7 +328,6 @@ export function createCodePlugin(
     // A live line may have grown mid-token, so render the whole tail plain.
     const keptLines = exact.tokens.slice(0, fence.lines.length);
     const tail = code.slice(fence.committedLength).split("\n");
-    fence.approximate = true;
     return { ...exact, tokens: [...keptLines, ...tail.map(plainLine)] };
   };
 
@@ -341,7 +337,6 @@ export function createCodePlugin(
     fence.state = undefined;
     fence.liveTokens = null;
     fence.meta = null;
-    fence.approximate = false;
   };
 
   // Leave the block plain if highlighting fails instead of breaking render.
@@ -419,7 +414,14 @@ export function createCodePlugin(
       const key = `${language} ${themeKey(opts.themes[0])} ${themeKey(opts.themes[1])}`;
       const fence = findFence(key, opts.code);
 
-      if (fence.result && fence.code === opts.code && !fence.approximate) {
+      if (fence.result && fence.code === opts.code) {
+        // A refresh queued for this body plus a closing run is this same fence
+        // finishing, so it is spent; a longer body belongs to a sibling sharing
+        // the entry and has to survive. Either way the cache answers this code.
+        const queued = fence.pending?.code;
+        if (queued !== undefined && shedsClosingRun(opts.code, queued)) {
+          clearTrailing(fence);
+        }
         return fence.result;
       }
 

--- a/studio/frontend/src/components/assistant-ui/code-plugin.ts
+++ b/studio/frontend/src/components/assistant-ui/code-plugin.ts
@@ -128,6 +128,17 @@ const shiftLine = (line: TokenLine, offset: number): TokenLine =>
     ? line
     : line.map((token) => ({ ...token, offset: token.offset + offset }));
 
+// Markdown reports a closing fence as body until it recognizes it, so the only
+// text a fence can lose is indentation, a run of backticks or tildes, and
+// trailing whitespace.
+const CLOSING_DELIMITER = /^[\s`~]*$/;
+
+/** Whether `code` is the fence's own body with just its closing delimiter gone. */
+const isClosingReparse = (fence: Fence, code: string): boolean =>
+  fence.code.startsWith(code) &&
+  code.length >= fence.committedLength &&
+  CLOSING_DELIMITER.test(fence.code.slice(code.length));
+
 export function createCodePlugin(
   options: CodePluginOptions = {},
 ): CodeHighlighterPlugin {
@@ -218,10 +229,9 @@ export function createCodePlugin(
         continue;
       }
       const anchor = fence.code;
-      // Closing backticks can briefly make Markdown return a shorter body.
-      const reaches =
-        code.startsWith(anchor) ||
-        (anchor.startsWith(code) && code.length >= fence.committedLength);
+      // A fence that lost more than its closing delimiter is a different block
+      // sharing a prefix, and reusing this entry would cancel its refresh.
+      const reaches = code.startsWith(anchor) || isClosingReparse(fence, code);
       const reach = Math.min(anchor.length, code.length);
       if (!anchor || reach <= matchLength || !reaches) continue;
       match = fence;

--- a/studio/frontend/src/components/assistant-ui/code-plugin.ts
+++ b/studio/frontend/src/components/assistant-ui/code-plugin.ts
@@ -146,15 +146,18 @@ const shiftLine = (line: TokenLine, offset: number): TokenLine =>
     ? line
     : line.map((token) => ({ ...token, offset: token.offset + offset }));
 
-// Markdown reports a closing fence as body until it recognizes it, so all a
-// fence can lose is one run of backticks or tildes plus surrounding whitespace.
-// A closing run is never empty and never mixes the two markers.
-const CLOSING_DELIMITER = /^\s*(?:`+|~+)\s*$/;
+// Markdown reports a closing fence as body until it recognizes it, so that
+// line is all a fence can lose: up to three spaces, one run of backticks or
+// tildes, then spaces. It also starts a line, so the body it leaves behind ends
+// at a newline. The run can be short, because the cached code is the last text
+// tokenized and the run may still have been arriving then.
+const CLOSING_FENCE = /^ {0,3}(?:`+|~+)[ \t]*$/;
 
-/** Whether `longer` is one fence's body, `shorter`, plus its closing run. */
+/** Whether `longer` is one fence's body, `shorter`, plus its closing line. */
 const shedsClosingRun = (shorter: string, longer: string): boolean =>
+  (shorter === "" || shorter.endsWith("\n")) &&
   longer.startsWith(shorter) &&
-  CLOSING_DELIMITER.test(longer.slice(shorter.length));
+  CLOSING_FENCE.test(longer.slice(shorter.length));
 
 export function createCodePlugin(
   options: CodePluginOptions = {},
@@ -205,6 +208,15 @@ export function createCodePlugin(
     for (const callback of pending.callbacks) callback(result);
   };
 
+  const dropFence = (fence: Fence): void => {
+    const index = fences.indexOf(fence);
+    if (index < 0) return;
+    fences.splice(index, 1);
+    cachedCharacters -= fence.code.length;
+    dropCodeIndex(fence);
+    clearTrailing(fence);
+  };
+
   const evict = (): void => {
     while (
       fences.length > MAX_FENCES ||
@@ -216,10 +228,7 @@ export function createCodePlugin(
         dropIndex -= 1;
       }
       if (dropIndex < 0) return;
-      const [dropped] = fences.splice(dropIndex, 1);
-      cachedCharacters -= dropped.code.length;
-      dropCodeIndex(dropped);
-      clearTrailing(dropped);
+      dropFence(fences[dropIndex]);
     }
   };
 
@@ -353,6 +362,9 @@ export function createCodePlugin(
     } catch (error) {
       console.error("[Studio Code] Failed to highlight code:", error);
       resetFence(fence);
+      // A fence that never produced tokens has no anchor to match on, so a
+      // block that keeps failing would strand a new one on every render.
+      if (fence.result === null) dropFence(fence);
       return null;
     }
     cachedCharacters += code.length - fence.code.length;

--- a/studio/frontend/src/components/assistant-ui/code-plugin.ts
+++ b/studio/frontend/src/components/assistant-ui/code-plugin.ts
@@ -88,6 +88,11 @@ type TokenLine = HighlightResult["tokens"][number];
 type ResultMeta = Omit<HighlightResult, "tokens">;
 type ThemeNames = { light: string; dark: string };
 type HighlightCallback = (result: HighlightResult) => void;
+
+
+export type StudioCodeHighlighterPlugin = CodeHighlighterPlugin & {
+  cancelHighlight: (callback: HighlightCallback) => void;
+};
 type Pending = { code: string; callbacks: Set<HighlightCallback> };
 
 type Fence = {
@@ -161,7 +166,7 @@ const shedsClosingRun = (shorter: string, longer: string): boolean =>
 
 export function createCodePlugin(
   options: CodePluginOptions = {},
-): CodeHighlighterPlugin {
+): StudioCodeHighlighterPlugin {
   const defaultThemes: [ThemeInput, ThemeInput] = options.themes ?? [
     "github-light",
     "github-dark",
@@ -410,6 +415,12 @@ export function createCodePlugin(
   return {
     name: "shiki",
     type: "code-highlighter",
+
+    cancelHighlight: (callback) => {
+      for (const fence of fences) {
+        fence.pending?.callbacks.delete(callback);
+      }
+    },
     getSupportedLanguages: () => SUPPORTED_LANGUAGE_LIST,
     getThemes: () => defaultThemes,
     supportsLanguage: (language) =>

--- a/studio/frontend/src/components/assistant-ui/markdown-text.tsx
+++ b/studio/frontend/src/components/assistant-ui/markdown-text.tsx
@@ -30,10 +30,14 @@ import { useVirtualizer } from "@tanstack/react-virtual";
 import {
   type ComponentProps,
   type CSSProperties,
+
+  createContext,
   isValidElement,
   memo,
   type ReactNode,
   useCallback,
+
+  useContext,
   useEffect,
   useLayoutEffect,
   useMemo,
@@ -65,6 +69,12 @@ const code = createCodePlugin({
   themes: [unslothLightTheme, unslothDarkTheme],
 });
 const STREAMDOWN_PLUGINS = { code, math, mermaid } satisfies NonNullable<
+  StreamdownProps["plugins"]
+>;
+
+// Syntax highlighting is finalized once generation stops. Even completed fences
+// can be remounted repeatedly while the virtualized live edge is moving.
+const STREAMDOWN_STREAMING_PLUGINS = { math, mermaid } satisfies NonNullable<
   StreamdownProps["plugins"]
 >;
 const STREAMDOWN_CONTROLS = {
@@ -108,6 +118,10 @@ const STREAMDOWN_COMPONENTS = {
     </a>
   ),
 };
+
+const ActiveStreamingBlockContext = createContext(false);
+
+export const PlainStreamingMarkdownContext = createContext(false);
 const COPY_RESET_MS = 2000;
 const MERMAID_SOURCE_RE = /```mermaid\s*([\s\S]*?)```/i;
 const ACTION_PANEL_CLASS =
@@ -305,10 +319,50 @@ function useAnimationFreeBlockProps(props: BlockProps): BlockProps {
   } satisfies BlockProps;
 }
 
+// Active fences intentionally remain plain: one text node is substantially
+// cheaper and more stable than a Shiki token tree that changes ten times/second.
+function StreamingPlainCodeBlock({
+  language,
+  source,
+}: {
+  language: string | null;
+  source: string;
+}) {
+  const label = language?.trim() || "text";
+  return (
+    <div
+      className="my-4 flex w-full flex-col gap-2 rounded-xl border border-border bg-sidebar p-2"
+      data-incomplete="true"
+      data-language={label}
+      data-streamdown="code-block"
+      data-streaming-code="true"
+    >
+      <div
+        className="flex h-8 items-center text-xs text-muted-foreground"
+        data-language={label}
+        data-streamdown="code-block-header"
+      >
+        <span className="ml-1 font-mono lowercase">{label}</span>
+      </div>
+      <div
+        className="overflow-x-auto rounded-md border border-border bg-background p-4 text-sm"
+        data-language={label}
+        data-streamdown="code-block-body"
+      >
+        <pre className="m-0 min-w-max bg-transparent p-0 font-mono text-sm leading-5">
+          <code>{source || "\n"}</code>
+        </pre>
+      </div>
+    </div>
+  );
+}
+
 // Collapse a full-HTML answer in place into an artifact card. Diffusion keeps the
 // raw code visible instead (the trailing MessageHtmlArtifacts appends its card).
 function StreamdownBlockContent(props: BlockProps) {
   const blockProps = useAnimationFreeBlockProps(props);
+
+  const activeStreamingBlock = useContext(ActiveStreamingBlockContext);
   const shouldCollapseHtmlArtifacts = useChatRuntimeStore(
     (state) =>
       (state.artifactsEnabled || state.collapseHtmlArtifacts) &&
@@ -356,6 +410,18 @@ function StreamdownBlockContent(props: BlockProps) {
       <div className="my-4 flex h-48 items-center justify-center rounded-xl border border-border bg-muted/30 text-sm text-muted-foreground animate-pulse">
         Loading canvas preview...
       </div>
+    );
+  }
+
+  // Re-tokenizing and reconciling a growing Shiki tree is the dominant WebKit
+  // cost for long generations. Keep the active fence as one native text node;
+  // the completed fence is highlighted (and virtualized when large) once.
+  if ((props.isIncomplete || activeStreamingBlock) && codeFence) {
+    return (
+      <StreamingPlainCodeBlock
+        language={codeFence.language}
+        source={codeFence.source}
+      />
     );
   }
 
@@ -407,9 +473,13 @@ function StreamdownBlockContent(props: BlockProps) {
 const StreamdownBlock = memo(StreamdownBlockContent);
 const AUDIO_PLAYER_RE = /<audio-player\s+src="([^"]+)"\s*\/>/;
 
-// Coalesce only token events that arrive before the browser's next paint, as
-// textgen does. There is no time or length throttle. Incremental block parsing
-// bounds the work performed per paint, and completion returns immediately.
+// Limit expensive Markdown work to ten paint-aligned commits per second. The
+// transport can deliver hundreds of token events per second; rendering every
+// animation frame leaves WebKit no idle time for scrolling or input once the
+// active block becomes substantial. Completion and non-prefix replacements
+// still bypass the held snapshot in the return path below.
+const STREAM_RENDER_INTERVAL_MS = 100;
+
 function useCoalescedStreamingText(
   text: string,
   isStreaming: boolean,
@@ -418,13 +488,29 @@ function useCoalescedStreamingText(
   const [displayed, setDisplayed] = useState({ messageId, text });
   const pendingRef = useRef({ messageId, text });
   const rafRef = useRef<number | null>(null);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const lastRenderAtRef = useRef(0);
   const activeMessageIdRef = useRef(messageId);
 
   const cancelScheduledRender = useCallback(() => {
+    if (timeoutRef.current !== null) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
     if (rafRef.current !== null) {
       cancelAnimationFrame(rafRef.current);
       rafRef.current = null;
     }
+  }, []);
+
+  const schedulePaint = useCallback(() => {
+    timeoutRef.current = null;
+    if (rafRef.current !== null) return;
+    rafRef.current = requestAnimationFrame(() => {
+      rafRef.current = null;
+      lastRenderAtRef.current = performance.now();
+      setDisplayed(pendingRef.current);
+    });
   }, []);
 
   useEffect(() => {
@@ -432,31 +518,25 @@ function useCoalescedStreamingText(
     if (activeMessageIdRef.current !== messageId) {
       cancelScheduledRender();
       activeMessageIdRef.current = messageId;
+      lastRenderAtRef.current = 0;
     }
     if (!isStreaming) {
       cancelScheduledRender();
       return;
     }
+    if (timeoutRef.current !== null || rafRef.current !== null) return;
 
-    if (rafRef.current !== null) {
-      return;
-    }
+    const elapsed = performance.now() - lastRenderAtRef.current;
+    const delay = Math.max(0, STREAM_RENDER_INTERVAL_MS - elapsed);
+    if (delay === 0) schedulePaint();
+    else timeoutRef.current = setTimeout(schedulePaint, delay);
+  }, [cancelScheduledRender, isStreaming, messageId, schedulePaint, text]);
 
-    rafRef.current = requestAnimationFrame(() => {
-      rafRef.current = null;
-      setDisplayed(pendingRef.current);
-    });
-  }, [cancelScheduledRender, messageId, text, isStreaming]);
-
-  useEffect(() => {
-    return cancelScheduledRender;
-  }, [cancelScheduledRender]);
+  useEffect(() => cancelScheduledRender, [cancelScheduledRender]);
 
   // Holding the last painted text is only correct while the reply is being
   // appended to. A running message can also be replaced, as the audio path does
   // when it swaps its placeholder for the player, and that must show at once.
-  // The length check rejects most of those before the prefix scan runs; the
-  // scan itself costs about 59 ms across a 175,000 character stream.
   if (
     isStreaming &&
     displayed.messageId === messageId &&
@@ -684,8 +764,7 @@ function VirtualizedCodeLines({ result }: { result: HighlightResult }) {
             style={{
               left: 0,
               position: "absolute",
-              top: 0,
-              transform: `translateY(${virtualLine.start - scrollMargin}px)`,
+              top: virtualLine.start - scrollMargin,
             }}
           >
             <HighlightedCodeLine
@@ -717,7 +796,6 @@ function VirtualizedCodeBlock({
       data-incomplete={isIncomplete || undefined}
       data-language={language}
       data-streamdown="code-block"
-      style={{ contentVisibility: "auto", containIntrinsicSize: "auto 200px" }}
     >
       <div
         className="flex h-8 items-center text-xs text-muted-foreground"
@@ -862,21 +940,27 @@ function VirtualizedMarkdown({
             style={{
               left: 0,
               position: "absolute",
-              top: 0,
-
+              top: virtualBlock.start - scrollMargin,
               paddingBottom: isLast ? 0 : "1rem",
-              transform: `translateY(${virtualBlock.start - scrollMargin}px)`,
               width: "100%",
             }}
           >
+            <ActiveStreamingBlockContext.Provider
+              value={isStreaming}
+            >
+
             <Streamdown
               mode="streaming"
               parseIncompleteMarkdown={isStreaming && isLast}
               isAnimating={isStreaming && isLast}
               animated={STREAMDOWN_IMMEDIATE_UPDATES}
-              plugins={STREAMDOWN_PLUGINS}
+              plugins={
+                isStreaming
+                  ? STREAMDOWN_STREAMING_PLUGINS
+                  : STREAMDOWN_PLUGINS
+              }
               components={
-                shouldVirtualizeCode(block)
+                !isStreaming && shouldVirtualizeCode(block)
                   ? VIRTUALIZED_CODE_COMPONENTS
                   : STREAMDOWN_COMPONENTS
               }
@@ -887,9 +971,51 @@ function VirtualizedMarkdown({
             >
               {block.content}
             </Streamdown>
+
+            </ActiveStreamingBlockContext.Provider>
           </div>
         );
       })}
+    </div>
+  );
+}
+
+
+const PLAIN_STREAM_CHUNK_SIZE = 4096;
+const PlainStreamingChunk = memo(function PlainStreamingChunk({
+  text,
+}: {
+  text: string;
+}) {
+  return <span>{text}</span>;
+});
+
+function PlainStreamingText({ text, status }: { text: string; status: string }) {
+  const rootRef = useRef<HTMLDivElement>(null);
+  const chunks = useMemo(() => {
+    const next: string[] = [];
+    for (let offset = 0; offset < text.length; offset += PLAIN_STREAM_CHUNK_SIZE) {
+      next.push(text.slice(offset, offset + PLAIN_STREAM_CHUNK_SIZE));
+    }
+    return next;
+  }, [text]);
+
+  useLayoutEffect(() => {
+    rootRef.current?.dispatchEvent(
+      new CustomEvent(MARKDOWN_LAYOUT_EVENT, { bubbles: true }),
+    );
+  }, [text]);
+
+  return (
+    <div
+      ref={rootRef}
+      data-status={status}
+      data-streaming-plain-text="true"
+      className="min-w-0 max-w-full whitespace-pre-wrap break-words"
+    >
+      {chunks.map((chunk, index) => (
+        <PlainStreamingChunk key={index} text={chunk} />
+      ))}
     </div>
   );
 }
@@ -905,10 +1031,16 @@ const MarkdownTextImpl = () => {
   // cannot express, an edit that drops retained blocks without changing the tail.
   const messageId = useAuiState(({ message }) => message.id);
   const isStreaming = status.type === "running";
+
+  const preferPlainStreaming = useContext(PlainStreamingMarkdownContext);
+  const plainStreaming = isStreaming && preferPlainStreaming;
   const displayText = useCoalescedStreamingText(text, isStreaming, messageId);
   const processedText = useMemo(
-    () => stabilizeStreamingMarkdown(preprocessLaTeX(displayText), isStreaming),
-    [displayText, isStreaming],
+    () =>
+      plainStreaming
+        ? ""
+        : stabilizeStreamingMarkdown(preprocessLaTeX(displayText), isStreaming),
+    [displayText, isStreaming, plainStreaming],
   );
   const incrementalCacheRef = useRef({
     messageId,
@@ -921,14 +1053,16 @@ const MarkdownTextImpl = () => {
     };
   }
   const incrementalCache = incrementalCacheRef.current.cache;
-  const incrementalRender = isStreaming
+  const incrementalRender = isStreaming && !plainStreaming
     ? incrementalCache.update(processedText)
     : null;
-  const blocks = incrementalRender?.blocks ??
-    parseMarkdownIntoBlocks(processedText).map((content, index) => ({
-      id: index + 1,
-      content,
-    }));
+  const blocks = plainStreaming
+    ? []
+    : incrementalRender?.blocks ??
+      parseMarkdownIntoBlocks(processedText).map((content, index) => ({
+        id: index + 1,
+        content,
+      }));
   const shouldVirtualize =
     blocks.length >= VIRTUALIZE_AFTER_BLOCKS || blocks.some(shouldVirtualizeCode);
 
@@ -941,6 +1075,10 @@ const MarkdownTextImpl = () => {
   const audioMatch = displayText.match(AUDIO_PLAYER_RE);
   if (audioMatch) {
     return <AudioPlayer src={audioMatch[1]} />;
+  }
+
+  if (plainStreaming) {
+    return <PlainStreamingText text={displayText} status={status.type} />;
   }
 
   return (
@@ -956,6 +1094,8 @@ const MarkdownTextImpl = () => {
           messageId={messageId}
         />
       ) : (
+        <ActiveStreamingBlockContext.Provider value={isStreaming}>
+
         <Streamdown
           key={`${messageId}:${incrementalCache.renderGeneration}`}
           mode="streaming"
@@ -963,7 +1103,9 @@ const MarkdownTextImpl = () => {
           parseMarkdownIntoBlocksFn={incrementalRender?.parseMarkdownIntoBlocks}
           isAnimating={isStreaming}
           animated={STREAMDOWN_IMMEDIATE_UPDATES}
-          plugins={STREAMDOWN_PLUGINS}
+          plugins={
+            isStreaming ? STREAMDOWN_STREAMING_PLUGINS : STREAMDOWN_PLUGINS
+          }
           components={STREAMDOWN_COMPONENTS}
           urlTransform={safeMarkdownUrl}
           controls={STREAMDOWN_CONTROLS}
@@ -972,6 +1114,8 @@ const MarkdownTextImpl = () => {
         >
           {incrementalRender?.markdown ?? processedText}
         </Streamdown>
+
+        </ActiveStreamingBlockContext.Provider>
       )}
     </div>
   );

--- a/studio/frontend/src/components/assistant-ui/markdown-text.tsx
+++ b/studio/frontend/src/components/assistant-ui/markdown-text.tsx
@@ -19,15 +19,23 @@ import { safeMarkdownUrl } from "@/lib/safe-markdown-url";
 import { Tick02Icon } from "@/lib/tick-icon";
 import { toast } from "@/lib/toast";
 import { INTERNAL, useAuiState, useMessagePartText } from "@assistant-ui/react";
+
+import type { HighlightResult } from "@streamdown/code";
 import { Copy01Icon, Download01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { createMathPlugin } from "@streamdown/math";
 import { mermaid } from "@streamdown/mermaid";
+
+import { useVirtualizer } from "@tanstack/react-virtual";
 import {
   type ComponentProps,
+  type CSSProperties,
+  isValidElement,
   memo,
+  type ReactNode,
   useCallback,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -35,8 +43,11 @@ import {
 import {
   Block,
   type BlockProps,
+  type ExtraProps,
+  parseMarkdownIntoBlocks,
   Streamdown,
   type StreamdownProps,
+  useIsCodeFenceIncomplete,
 } from "streamdown";
 import { createCodePlugin } from "./code-plugin";
 import "katex/dist/katex.min.css";
@@ -45,6 +56,7 @@ import { unslothDarkTheme, unslothLightTheme } from "./code-themes";
 import { stabilizeStreamingMarkdown } from "./streaming-markdown";
 import {
   IncrementalMarkdownCache,
+  type MarkdownBlockSnapshot,
   withoutStreamdownAnimationPlugin,
 } from "./streaming-render-schedule";
 
@@ -456,7 +468,436 @@ function useCoalescedStreamingText(
   return text;
 }
 
+export const MARKDOWN_LAYOUT_EVENT = "aui-markdown-layout";
+
+const VIRTUALIZE_AFTER_BLOCKS = 24;
+const MARKDOWN_BLOCK_ESTIMATE_PX = 32;
+const MARKDOWN_BLOCK_OVERSCAN = 12;
+
+function findVerticalScrollOwner(element: HTMLElement): HTMLElement | null {
+  for (let parent = element.parentElement; parent; parent = parent.parentElement) {
+    const style = getComputedStyle(parent);
+    if (/(auto|scroll)/.test(style.overflowY)) {
+      return parent;
+    }
+  }
+  return null;
+}
+
+const VIRTUALIZE_CODE_AFTER_LINES = 120;
+const VIRTUALIZE_CODE_AFTER_CHARS = 20_000;
+const CODE_LINE_ESTIMATE_PX = 20;
+const CODE_LINE_OVERSCAN = 24;
+const PLAIN_LONG_LINE_AFTER_CHARS = 8_000;
+const CODE_LANGUAGE_RE = /language-([^\s]+)/;
+
+function readCodeChildren(children: ReactNode): string {
+  if (typeof children === "string") return children;
+  if (Array.isArray(children)) return children.map(readCodeChildren).join("");
+  if (
+    isValidElement<{ children?: ReactNode }>(children) &&
+    children.props.children !== undefined
+  ) {
+    return readCodeChildren(children.props.children);
+  }
+  return "";
+}
+
+function trimTrailingNewlines(source: string): string {
+  let end = source.length;
+  while (end > 0 && source[end - 1] === "\n") end -= 1;
+  return source.slice(0, end);
+}
+
+function plainHighlight(source: string): HighlightResult {
+  return {
+    bg: "transparent",
+    fg: "inherit",
+    tokens: source.split("\n").map((content) => [
+      {
+        content,
+        offset: 0,
+      },
+    ]),
+  } as HighlightResult;
+}
+
+function useHighlightedCode(source: string, language: string): HighlightResult {
+  const raw = useMemo(() => plainHighlight(source), [source]);
+  const [snapshot, setSnapshot] = useState({ source, result: raw });
+
+  useEffect(() => {
+    let active = true;
+    const publish = (next: HighlightResult) => {
+      if (active) setSnapshot({ source, result: next });
+    };
+    const immediate = code.highlight(
+      {
+        code: source,
+        language: language as Parameters<typeof code.highlight>[0]["language"],
+        themes: STREAMDOWN_SHIKI_THEME,
+      },
+      publish,
+    );
+    queueMicrotask(() => publish(immediate ?? raw));
+    return () => {
+      active = false;
+      code.cancelHighlight(publish);
+    };
+  }, [language, raw, source]);
+
+  return snapshot.source === source ? snapshot.result : raw;
+}
+
+function resultRootStyle(result: HighlightResult): CSSProperties {
+  const style: Record<string, string> = {};
+  if (result.bg) style["--sdm-bg"] = result.bg;
+  if (result.fg) style["--sdm-fg"] = result.fg;
+  if (result.rootStyle) {
+    for (const declaration of result.rootStyle.split(";")) {
+      const separator = declaration.indexOf(":");
+      if (separator <= 0) continue;
+      const property = declaration.slice(0, separator).trim();
+      const value = declaration.slice(separator + 1).trim();
+      if (property && value) style[property] = value;
+    }
+  }
+  return style as CSSProperties;
+}
+
+function tokenStyle(
+  token: HighlightResult["tokens"][number][number],
+): CSSProperties {
+  const style: Record<string, string> = {};
+  if (token.color) style["--sdm-c"] = token.color;
+  if (token.bgColor) style["--sdm-tbg"] = token.bgColor;
+  for (const [property, value] of Object.entries(token.htmlStyle ?? {})) {
+    if (property === "color") style["--sdm-c"] = value;
+    else if (property === "background-color") style["--sdm-tbg"] = value;
+    else style[property] = value;
+  }
+  return style as CSSProperties;
+}
+
+function HighlightedCodeLine({
+  line,
+  lineNumber,
+}: {
+  line: HighlightResult["tokens"][number];
+  lineNumber: number;
+}) {
+  const content = line.map((token) => token.content).join("");
+  return (
+    <span className="block min-w-max" data-code-line={lineNumber}>
+      <span
+        aria-hidden="true"
+        className="mr-4 inline-block w-6 select-none text-right font-mono text-[13px] text-muted-foreground/50"
+      >
+        {lineNumber}
+      </span>
+      {content.length > PLAIN_LONG_LINE_AFTER_CHARS ? (
+        content
+      ) : line.length === 0 || (line.length === 1 && content === "") ? (
+        "\n"
+      ) : (
+        line.map((token, index) => {
+          const hasBackground = Boolean(
+            token.bgColor ?? token.htmlStyle?.["background-color"],
+          );
+          return (
+            <span
+              // A completed Shiki line retains token order and object identity.
+              // The line wrapper, not each token, is the virtualized unit.
+              key={index}
+              className={`text-[var(--sdm-c,inherit)] dark:text-[var(--shiki-dark,var(--sdm-c,inherit))]${
+                hasBackground
+                  ? " bg-[var(--sdm-tbg)] dark:bg-[var(--shiki-dark-bg,var(--sdm-tbg))]"
+                  : ""
+              }`}
+              style={tokenStyle(token)}
+              {...token.htmlAttrs}
+            >
+              {token.content}
+            </span>
+          );
+        })
+      )}
+    </span>
+  );
+}
+
+function VirtualizedCodeLines({ result }: { result: HighlightResult }) {
+  const rootRef = useRef<HTMLSpanElement>(null);
+  const [scrollElement, setScrollElement] = useState<HTMLElement | null>(null);
+  const [scrollMargin, setScrollMargin] = useState(0);
+
+  useLayoutEffect(() => {
+    const root = rootRef.current;
+    if (!root) return;
+    const owner = findVerticalScrollOwner(root);
+    setScrollElement(owner);
+    if (!owner) return;
+    const measureOffset = () => {
+      const rootRect = root.getBoundingClientRect();
+      const ownerRect = owner.getBoundingClientRect();
+      setScrollMargin(rootRect.top - ownerRect.top + owner.scrollTop);
+    };
+    measureOffset();
+    const resizeObserver = new ResizeObserver(measureOffset);
+    resizeObserver.observe(root);
+    resizeObserver.observe(owner);
+    return () => resizeObserver.disconnect();
+  }, []);
+
+  // eslint-disable-next-line react-hooks/incompatible-library
+  const virtualizer = useVirtualizer({
+    count: result.tokens.length,
+    getScrollElement: () => scrollElement,
+    estimateSize: () => CODE_LINE_ESTIMATE_PX,
+    overscan: CODE_LINE_OVERSCAN,
+    scrollMargin,
+  });
+  const totalSize = virtualizer.getTotalSize();
+
+  useLayoutEffect(() => {
+    rootRef.current?.dispatchEvent(
+      new CustomEvent(MARKDOWN_LAYOUT_EVENT, { bubbles: true }),
+    );
+  }, [totalSize]);
+
+  return (
+    <span
+      ref={rootRef}
+      className="block"
+      data-virtualized-code="true"
+      style={{ height: `${totalSize}px`, position: "relative" }}
+    >
+      {virtualizer.getVirtualItems().map((virtualLine) => {
+        const line = result.tokens[virtualLine.index];
+        if (!line) return null;
+        return (
+          <span
+            className="block"
+            key={virtualLine.key}
+            data-index={virtualLine.index}
+            ref={virtualizer.measureElement}
+            style={{
+              left: 0,
+              position: "absolute",
+              top: 0,
+              transform: `translateY(${virtualLine.start - scrollMargin}px)`,
+            }}
+          >
+            <HighlightedCodeLine
+              line={line}
+              lineNumber={virtualLine.index + 1}
+            />
+          </span>
+        );
+      })}
+    </span>
+  );
+}
+
+function VirtualizedCodeBlock({
+  className,
+  language,
+  source,
+}: {
+  className?: string;
+  language: string;
+  source: string;
+}) {
+  const isIncomplete = useIsCodeFenceIncomplete();
+  const result = useHighlightedCode(source, language);
+
+  return (
+    <div
+      className={`my-4 flex w-full flex-col gap-2 rounded-xl border border-border bg-sidebar p-2 ${className ?? ""}`}
+      data-incomplete={isIncomplete || undefined}
+      data-language={language}
+      data-streamdown="code-block"
+      style={{ contentVisibility: "auto", containIntrinsicSize: "auto 200px" }}
+    >
+      <div
+        className="flex h-8 items-center text-xs text-muted-foreground"
+        data-language={language}
+        data-streamdown="code-block-header"
+      >
+        <span className="ml-1 font-mono lowercase">{language}</span>
+      </div>
+      <div
+        className="overflow-x-auto rounded-md border border-border bg-background p-4 text-sm"
+        data-language={language}
+        data-streamdown="code-block-body"
+      >
+        <pre
+          className="bg-[var(--sdm-bg,inherit)] dark:bg-[var(--shiki-dark-bg,var(--sdm-bg,inherit))]"
+          style={resultRootStyle(result)}
+        >
+          <code>
+            <VirtualizedCodeLines result={result} />
+          </code>
+        </pre>
+      </div>
+    </div>
+  );
+}
+
+function VirtualizedCode({
+  children,
+  className,
+  node: _node,
+  ...props
+}: ComponentProps<"code"> & ExtraProps) {
+
+  void _node;
+  if (!("data-block" in props)) {
+    return (
+      <code
+        className={`rounded bg-muted px-1.5 py-0.5 font-mono text-sm ${className ?? ""}`}
+        data-streamdown="inline-code"
+        {...props}
+      >
+        {children}
+      </code>
+    );
+  }
+
+  return (
+    <VirtualizedCodeBlock
+      className={className}
+      language={className?.match(CODE_LANGUAGE_RE)?.[1] ?? "text"}
+      source={trimTrailingNewlines(readCodeChildren(children))}
+    />
+  );
+}
+
+const VIRTUALIZED_CODE_COMPONENTS = {
+  ...STREAMDOWN_COMPONENTS,
+  code: VirtualizedCode,
+} as NonNullable<StreamdownProps["components"]>;
+
+function shouldVirtualizeCode(block: MarkdownBlockSnapshot): boolean {
+  const fence = getCodeFence(block.content);
+  if (!fence || fence.language?.toLowerCase() === "mermaid") return false;
+  return (
+    fence.source.length >= VIRTUALIZE_CODE_AFTER_CHARS ||
+    fence.source.split("\n").length >= VIRTUALIZE_CODE_AFTER_LINES
+  );
+}
+
+
+type VirtualizedMarkdownProps = {
+  blocks: readonly MarkdownBlockSnapshot[];
+  isStreaming: boolean;
+  messageId: string;
+};
+
+function VirtualizedMarkdown({
+  blocks,
+  isStreaming,
+  messageId,
+}: VirtualizedMarkdownProps) {
+  const rootRef = useRef<HTMLDivElement>(null);
+  const [scrollElement, setScrollElement] = useState<HTMLElement | null>(null);
+  const [scrollMargin, setScrollMargin] = useState(0);
+
+  useLayoutEffect(() => {
+    const root = rootRef.current;
+    if (!root) return;
+    const owner = findVerticalScrollOwner(root);
+    setScrollElement(owner);
+    if (!owner) return;
+
+    const measureOffset = () => {
+      const rootRect = root.getBoundingClientRect();
+      const ownerRect = owner.getBoundingClientRect();
+      setScrollMargin(rootRect.top - ownerRect.top + owner.scrollTop);
+    };
+    measureOffset();
+    const resizeObserver = new ResizeObserver(measureOffset);
+    resizeObserver.observe(root);
+    resizeObserver.observe(owner);
+    return () => resizeObserver.disconnect();
+  }, [messageId]);
+
+  // eslint-disable-next-line react-hooks/incompatible-library
+  const virtualizer = useVirtualizer({
+    count: blocks.length,
+    getScrollElement: () => scrollElement,
+    estimateSize: () => MARKDOWN_BLOCK_ESTIMATE_PX,
+    getItemKey: (index) => blocks[index]?.id ?? index,
+    overscan: MARKDOWN_BLOCK_OVERSCAN,
+    scrollMargin,
+  });
+
+  const totalSize = virtualizer.getTotalSize();
+  useLayoutEffect(() => {
+    rootRef.current?.dispatchEvent(
+      new CustomEvent(MARKDOWN_LAYOUT_EVENT, { bubbles: true }),
+    );
+  }, [totalSize]);
+
+  return (
+    <div
+      ref={rootRef}
+      data-virtualized-markdown="true"
+      style={{
+        height: `${totalSize}px`,
+        position: "relative",
+        width: "100%",
+      }}
+    >
+      {virtualizer.getVirtualItems().map((virtualBlock) => {
+        const block = blocks[virtualBlock.index];
+        if (!block) return null;
+        const isLast = virtualBlock.index === blocks.length - 1;
+        return (
+          <div
+            key={block.id}
+            ref={virtualizer.measureElement}
+            data-index={virtualBlock.index}
+            data-markdown-block-id={block.id}
+            style={{
+              left: 0,
+              position: "absolute",
+              top: 0,
+
+              paddingBottom: isLast ? 0 : "1rem",
+              transform: `translateY(${virtualBlock.start - scrollMargin}px)`,
+              width: "100%",
+            }}
+          >
+            <Streamdown
+              mode="streaming"
+              parseIncompleteMarkdown={isStreaming && isLast}
+              isAnimating={isStreaming && isLast}
+              animated={STREAMDOWN_IMMEDIATE_UPDATES}
+              plugins={STREAMDOWN_PLUGINS}
+              components={
+                shouldVirtualizeCode(block)
+                  ? VIRTUALIZED_CODE_COMPONENTS
+                  : STREAMDOWN_COMPONENTS
+              }
+              urlTransform={safeMarkdownUrl}
+              controls={STREAMDOWN_CONTROLS}
+              shikiTheme={STREAMDOWN_SHIKI_THEME}
+              BlockComponent={StreamdownBlock}
+            >
+              {block.content}
+            </Streamdown>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+
 const MarkdownTextImpl = () => {
+
+  const layoutRef = useRef<HTMLDivElement>(null);
   const { text, status } = useMessagePartText();
   // Parts are keyed by index, so switching conversations hands this instance a
   // different message, and Streamdown only extends its parsed blocks: key it per
@@ -483,6 +924,19 @@ const MarkdownTextImpl = () => {
   const incrementalRender = isStreaming
     ? incrementalCache.update(processedText)
     : null;
+  const blocks = incrementalRender?.blocks ??
+    parseMarkdownIntoBlocks(processedText).map((content, index) => ({
+      id: index + 1,
+      content,
+    }));
+  const shouldVirtualize =
+    blocks.length >= VIRTUALIZE_AFTER_BLOCKS || blocks.some(shouldVirtualizeCode);
+
+  useLayoutEffect(() => {
+    layoutRef.current?.dispatchEvent(
+      new CustomEvent(MARKDOWN_LAYOUT_EVENT, { bubbles: true }),
+    );
+  }, [processedText, shouldVirtualize]);
 
   const audioMatch = displayText.match(AUDIO_PLAYER_RE);
   if (audioMatch) {
@@ -490,23 +944,35 @@ const MarkdownTextImpl = () => {
   }
 
   return (
-    <div data-status={status.type} className="min-w-0 max-w-full">
-      <Streamdown
-        key={`${messageId}:${incrementalCache.renderGeneration}`}
-        mode="streaming"
-        parseIncompleteMarkdown={!incrementalRender}
-        parseMarkdownIntoBlocksFn={incrementalRender?.parseMarkdownIntoBlocks}
-        isAnimating={isStreaming}
-        animated={STREAMDOWN_IMMEDIATE_UPDATES}
-        plugins={STREAMDOWN_PLUGINS}
-        components={STREAMDOWN_COMPONENTS}
-        urlTransform={safeMarkdownUrl}
-        controls={STREAMDOWN_CONTROLS}
-        shikiTheme={STREAMDOWN_SHIKI_THEME}
-        BlockComponent={StreamdownBlock}
-      >
-        {incrementalRender?.markdown ?? processedText}
-      </Streamdown>
+    <div
+      ref={layoutRef}
+      data-status={status.type}
+      className="min-w-0 max-w-full"
+    >
+      {shouldVirtualize ? (
+        <VirtualizedMarkdown
+          blocks={blocks}
+          isStreaming={isStreaming}
+          messageId={messageId}
+        />
+      ) : (
+        <Streamdown
+          key={`${messageId}:${incrementalCache.renderGeneration}`}
+          mode="streaming"
+          parseIncompleteMarkdown={!incrementalRender}
+          parseMarkdownIntoBlocksFn={incrementalRender?.parseMarkdownIntoBlocks}
+          isAnimating={isStreaming}
+          animated={STREAMDOWN_IMMEDIATE_UPDATES}
+          plugins={STREAMDOWN_PLUGINS}
+          components={STREAMDOWN_COMPONENTS}
+          urlTransform={safeMarkdownUrl}
+          controls={STREAMDOWN_CONTROLS}
+          shikiTheme={STREAMDOWN_SHIKI_THEME}
+          BlockComponent={StreamdownBlock}
+        >
+          {incrementalRender?.markdown ?? processedText}
+        </Streamdown>
+      )}
     </div>
   );
 };

--- a/studio/frontend/src/components/assistant-ui/reasoning.tsx
+++ b/studio/frontend/src/components/assistant-ui/reasoning.tsx
@@ -7,6 +7,8 @@
 
 import {
   MARKDOWN_LAYOUT_EVENT,
+
+  PlainStreamingMarkdownContext,
   MarkdownText,
 } from "@/components/assistant-ui/markdown-text";
 import {
@@ -40,6 +42,7 @@ import {
   memo,
   useCallback,
   useEffect,
+  useLayoutEffect,
   useRef,
   useState,
 } from "react";
@@ -200,54 +203,104 @@ function ReasoningText({
   const shouldAutoScrollRef = useRef(true);
   const detachedFromBottomRef = useRef(false);
   const lastScrollTopRef = useRef(0);
+  const userScrollIntentRef = useRef(false);
+  const pointerScrollIntentRef = useRef(false);
 
-  useEffect(() => {
-    if (!(streaming && scrollRef.current)) {
+  useLayoutEffect(() => {
+    if (!streaming) {
+      shouldAutoScrollRef.current = true;
+      detachedFromBottomRef.current = false;
+      userScrollIntentRef.current = false;
+      pointerScrollIntentRef.current = false;
       return;
     }
     const el = scrollRef.current;
+    if (!el) return;
+
     const updateAutoScroll = () => {
       const currentScrollTop = el.scrollTop;
-      if (currentScrollTop < lastScrollTopRef.current) {
+      const hasUserScrollIntent =
+        userScrollIntentRef.current || pointerScrollIntentRef.current;
+      const movedAwayFromBottom = currentScrollTop < lastScrollTopRef.current;
+      const movedTowardBottom = currentScrollTop > lastScrollTopRef.current;
+
+      if (hasUserScrollIntent && movedAwayFromBottom) {
         detachedFromBottomRef.current = true;
       }
-      const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
+      const distanceFromBottom =
+        el.scrollHeight - currentScrollTop - el.clientHeight;
       if (
         detachedFromBottomRef.current &&
+        hasUserScrollIntent && movedTowardBottom &&
         distanceFromBottom <= AUTO_SCROLL_THRESHOLD_PX
       ) {
         detachedFromBottomRef.current = false;
       }
       shouldAutoScrollRef.current = !detachedFromBottomRef.current;
       lastScrollTopRef.current = currentScrollTop;
-    };
-    const handleWheel = (event: WheelEvent) => {
-      if (event.deltaY < 0) {
-        detachedFromBottomRef.current = true;
-        shouldAutoScrollRef.current = false;
+      if (!pointerScrollIntentRef.current) {
+        // Consume wheel/key intent with the scroll event it caused. WebKit can
+        // later clamp scrollTop when virtual rows resize; that is not consent
+        // to snap a reader back to the live edge.
+        userScrollIntentRef.current = false;
       }
     };
-    let scrollRaf: number | null = null;
-    const schedulePinnedScroll = () => {
-      if (!shouldAutoScrollRef.current || scrollRaf !== null) return;
-      scrollRaf = requestAnimationFrame(() => {
-        scrollRaf = null;
-        if (shouldAutoScrollRef.current) {
-          el.scrollTop = el.scrollHeight;
-        }
-      });
+    const detachFromBottom = () => {
+      userScrollIntentRef.current = true;
+      detachedFromBottomRef.current = true;
+      shouldAutoScrollRef.current = false;
     };
+    const handleWheel = (event: WheelEvent) => {
+      if (event.deltaY === 0) return;
+      userScrollIntentRef.current = true;
+      if (event.deltaY < 0) detachFromBottom();
+    };
+    const handlePointerDown = () => {
+      pointerScrollIntentRef.current = true;
+      userScrollIntentRef.current = true;
+    };
+    const handlePointerUp = () => {
+      pointerScrollIntentRef.current = false;
+      userScrollIntentRef.current = false;
+    };
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (["ArrowUp", "PageUp", "Home"].includes(event.key)) {
+        detachFromBottom();
+      } else if (["ArrowDown", "PageDown", "End", " "].includes(event.key)) {
+        userScrollIntentRef.current = true;
+      }
+    };
+    const pinToBottom = () => {
+      if (!shouldAutoScrollRef.current) return;
+      // Layout events are dispatched from child layout effects. Pinning here,
+      // rather than one animation frame later, avoids painting an old scroll
+      // position for one frame and then producing the visible up/down flash.
+      el.scrollTop = el.scrollHeight;
+      lastScrollTopRef.current = el.scrollTop;
+    };
+
     el.addEventListener("scroll", updateAutoScroll);
     el.addEventListener("wheel", handleWheel, { passive: true });
-    el.addEventListener(MARKDOWN_LAYOUT_EVENT, schedulePinnedScroll);
+    el.addEventListener("pointerdown", handlePointerDown, { passive: true });
+    el.addEventListener("pointerup", handlePointerUp, { passive: true });
+    el.addEventListener("pointercancel", handlePointerUp, { passive: true });
+    el.addEventListener("touchstart", handlePointerDown, { passive: true });
+    el.addEventListener("touchend", handlePointerUp, { passive: true });
+    el.addEventListener("keydown", handleKeyDown);
+    el.addEventListener(MARKDOWN_LAYOUT_EVENT, pinToBottom);
     lastScrollTopRef.current = el.scrollTop;
-    detachedFromBottomRef.current = false;
     updateAutoScroll();
+    pinToBottom();
     return () => {
-      if (scrollRaf !== null) cancelAnimationFrame(scrollRaf);
-      el.removeEventListener(MARKDOWN_LAYOUT_EVENT, schedulePinnedScroll);
+      el.removeEventListener(MARKDOWN_LAYOUT_EVENT, pinToBottom);
       el.removeEventListener("scroll", updateAutoScroll);
       el.removeEventListener("wheel", handleWheel);
+      el.removeEventListener("pointerdown", handlePointerDown);
+      el.removeEventListener("pointerup", handlePointerUp);
+      el.removeEventListener("pointercancel", handlePointerUp);
+      el.removeEventListener("touchstart", handlePointerDown);
+      el.removeEventListener("touchend", handlePointerUp);
+      el.removeEventListener("keydown", handleKeyDown);
     };
   }, [streaming]);
 
@@ -256,9 +309,8 @@ function ReasoningText({
       ref={scrollRef}
       data-slot="reasoning-text"
       className={cn(
-        "aui-reasoning-text relative z-0 overflow-y-auto pt-2 pb-0 pl-0 leading-relaxed",
-        streaming ? "max-h-64" : "",
-        "transform-gpu transition-[transform,opacity]",
+        "aui-reasoning-text relative z-0 max-h-64 overflow-y-auto pt-2 pb-0 pl-0 leading-relaxed [overflow-anchor:none]",
+        "transition-[transform,opacity]",
         "group-data-[state=open]/collapsible-content:animate-in",
         "group-data-[state=closed]/collapsible-content:animate-out",
         "group-data-[state=open]/collapsible-content:fade-in-0",
@@ -276,7 +328,11 @@ function ReasoningText({
   );
 }
 
-const ReasoningImpl: ReasoningMessagePartComponent = () => <MarkdownText />;
+const ReasoningImpl: ReasoningMessagePartComponent = () => (
+  <PlainStreamingMarkdownContext.Provider value>
+    <MarkdownText />
+  </PlainStreamingMarkdownContext.Provider>
+);
 
 const COPY_RESET_MS = 2000;
 

--- a/studio/frontend/src/components/assistant-ui/reasoning.tsx
+++ b/studio/frontend/src/components/assistant-ui/reasoning.tsx
@@ -5,7 +5,10 @@
 
 /* eslint-disable react-refresh/only-export-components */
 
-import { MarkdownText } from "@/components/assistant-ui/markdown-text";
+import {
+  MARKDOWN_LAYOUT_EVENT,
+  MarkdownText,
+} from "@/components/assistant-ui/markdown-text";
 import {
   Collapsible,
   CollapsibleContent,
@@ -224,23 +227,25 @@ function ReasoningText({
         shouldAutoScrollRef.current = false;
       }
     };
-    const observer = new MutationObserver(() => {
-      if (shouldAutoScrollRef.current) {
-        el.scrollTop = el.scrollHeight;
-      }
-    });
+    let scrollRaf: number | null = null;
+    const schedulePinnedScroll = () => {
+      if (!shouldAutoScrollRef.current || scrollRaf !== null) return;
+      scrollRaf = requestAnimationFrame(() => {
+        scrollRaf = null;
+        if (shouldAutoScrollRef.current) {
+          el.scrollTop = el.scrollHeight;
+        }
+      });
+    };
     el.addEventListener("scroll", updateAutoScroll);
     el.addEventListener("wheel", handleWheel, { passive: true });
-    observer.observe(el, {
-      childList: true,
-      subtree: true,
-      characterData: true,
-    });
+    el.addEventListener(MARKDOWN_LAYOUT_EVENT, schedulePinnedScroll);
     lastScrollTopRef.current = el.scrollTop;
     detachedFromBottomRef.current = false;
     updateAutoScroll();
     return () => {
-      observer.disconnect();
+      if (scrollRaf !== null) cancelAnimationFrame(scrollRaf);
+      el.removeEventListener(MARKDOWN_LAYOUT_EVENT, schedulePinnedScroll);
       el.removeEventListener("scroll", updateAutoScroll);
       el.removeEventListener("wheel", handleWheel);
     };

--- a/studio/frontend/src/components/assistant-ui/streaming-render-schedule.ts
+++ b/studio/frontend/src/components/assistant-ui/streaming-render-schedule.ts
@@ -504,8 +504,14 @@ const hasNeutralRepairParity = (parity: RepairParity): boolean =>
     parity.inlineMath,
   ].includes(true);
 
+export type MarkdownBlockSnapshot = {
+  readonly id: number;
+  readonly content: string;
+};
+
 export type IncrementalMarkdownRender = {
   markdown: string;
+  blocks: readonly MarkdownBlockSnapshot[];
   parseMarkdownIntoBlocks: (markdown: string) => string[];
 };
 
@@ -637,7 +643,9 @@ function findCommitBoundary(
 export class IncrementalMarkdownCache {
   private source = "";
   private tail = "";
-  private committedBlocks: string[] = [];
+  private committedBlocks: MarkdownBlockSnapshot[] = [];
+  private liveBlocks: MarkdownBlockSnapshot[] = [];
+  private nextBlockId = 1;
   private context = createRetainedContext();
   private fullDocumentMode = false;
   private lastMarkdown: string | null = null;
@@ -646,9 +654,34 @@ export class IncrementalMarkdownCache {
   renderGeneration = 0;
 
   readonly parseMarkdownIntoBlocks = (markdown: string): string[] => [
-    ...this.committedBlocks,
+    ...this.committedBlocks.map((block) => block.content),
     ...parseMarkdownIntoBlocks(markdown),
   ];
+
+  private reconcileBlocks(
+    previous: readonly MarkdownBlockSnapshot[],
+    contents: readonly string[],
+  ): MarkdownBlockSnapshot[] {
+    const next: MarkdownBlockSnapshot[] = [];
+    for (let index = 0; index < contents.length; index += 1) {
+      const current = previous[index];
+      next.push(
+        current?.content === contents[index]
+          ? current
+          : { id: this.nextBlockId++, content: contents[index] },
+      );
+    }
+    return next;
+  }
+
+  private snapshot(markdown: string): readonly MarkdownBlockSnapshot[] {
+    this.liveBlocks = this.reconcileBlocks(
+      this.liveBlocks,
+      parseMarkdownIntoBlocks(markdown),
+    );
+    return [...this.committedBlocks, ...this.liveBlocks];
+  }
+
 
   // Streamdown memoises the whole component on the Markdown string and ignores
   // the parser callback, so the string is the only thing that can schedule a
@@ -660,7 +693,11 @@ export class IncrementalMarkdownCache {
     }
     this.droppedRetainedBlocks = false;
     this.lastMarkdown = markdown;
-    return { markdown, parseMarkdownIntoBlocks: this.parseMarkdownIntoBlocks };
+    return {
+      markdown,
+      blocks: this.snapshot(markdown),
+      parseMarkdownIntoBlocks: this.parseMarkdownIntoBlocks,
+    };
   }
 
   private resetIncrementalState(markdown: string): void {
@@ -668,6 +705,7 @@ export class IncrementalMarkdownCache {
     this.source = markdown;
     this.tail = markdown;
     this.committedBlocks = [];
+    this.liveBlocks = [];
     this.context = createRetainedContext();
   }
 
@@ -694,6 +732,7 @@ export class IncrementalMarkdownCache {
     if (markdown === this.source && this.lastMarkdown !== null) {
       return {
         markdown: this.lastMarkdown,
+        blocks: [...this.committedBlocks, ...this.liveBlocks],
         parseMarkdownIntoBlocks: this.parseMarkdownIntoBlocks,
       };
     }
@@ -754,7 +793,9 @@ export class IncrementalMarkdownCache {
       return this.render(repaired);
     }
 
-    this.committedBlocks.push(...blocks.slice(0, commit.count));
+    const describedBlocks = this.reconcileBlocks(this.liveBlocks, blocks);
+    this.committedBlocks.push(...describedBlocks.slice(0, commit.count));
+    this.liveBlocks = describedBlocks.slice(commit.count);
     this.context = nextContext;
     this.tail = nextTail;
 

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -209,7 +209,7 @@ import {
   useAuiEvent,
   useAuiState,
 } from "@assistant-ui/react";
-import { flushResourcesSync } from "@assistant-ui/tap";
+import { flushTapSync } from "@assistant-ui/tap";
 import {
   AttachmentIcon,
   Bookmark02Icon,
@@ -3141,7 +3141,7 @@ const Composer: FC<{
               return;
             }
             void composer.clearAttachments();
-            flushResourcesSync(() => {
+            flushTapSync(() => {
               composer.setText("");
             });
             clearStoredDraft();
@@ -3527,7 +3527,7 @@ const Composer: FC<{
             if (aui.composer().getState().text.trim() !== queuedPrompt) {
               return;
             }
-            flushResourcesSync(() => {
+            flushTapSync(() => {
               aui.composer().setText("");
             });
             clearStoredDraft();
@@ -3571,7 +3571,7 @@ const Composer: FC<{
             : {}),
           openaiReasoningItem: overlay.openaiReasoningItem,
         });
-        flushResourcesSync(() => {
+        flushTapSync(() => {
           aui
             .composer()
             .setText(
@@ -3770,7 +3770,7 @@ const Composer: FC<{
                     ) {
                       return;
                     }
-                    flushResourcesSync(() => {
+                    flushTapSync(() => {
                       aui.composer().setText("");
                     });
                     clearStoredDraft();
@@ -3913,7 +3913,7 @@ function useImeComposerInputHandlers({
       if (!composer.getState().isEditing) {
         return;
       }
-      flushResourcesSync(() => {
+      flushTapSync(() => {
         composer.setText(value);
       });
     },

--- a/studio/frontend/src/features/chat/runtime-provider.tsx
+++ b/studio/frontend/src/features/chat/runtime-provider.tsx
@@ -16,12 +16,12 @@ import {
   type PendingAttachment,
   type ThreadHistoryAdapter,
   type ThreadMessage,
-  type unstable_RemoteThreadListAdapter,
+  type RemoteThreadListAdapter,
   useAui,
   useAuiEvent,
   useAuiState,
   useLocalRuntime,
-  unstable_useRemoteThreadListRuntime as useRemoteThreadListRuntime,
+  useRemoteThreadListRuntime,
 } from "@assistant-ui/react";
 import { createAssistantStream } from "assistant-stream";
 import {
@@ -757,7 +757,7 @@ function createStudioDbAdapter(
   pairId?: string,
   projectId?: string | null,
   listThreads = true,
-): unstable_RemoteThreadListAdapter {
+): RemoteThreadListAdapter {
   return {
     async fetch(remoteId: string) {
       const thread = await getStoredChatThread(remoteId);

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -2481,33 +2481,10 @@ html[data-chat-font] .aui-root {
 		border: 1px solid oklch(1 0 0 / 0.08);
 	}
 
-	/* Streamdown code-block stability hardening.
-	 *
-	 * Two streamdown internals cause a visible "reload"-style flicker on
-	 * trailing code blocks the moment streaming ends. Both are addressable
-	 * purely in CSS without patching the library:
-	 *
-	 * 1. `content-visibility: auto` + `contain-intrinsic-size: auto 200px`
-	 *    (set inline by streamdown's <ot> wrapper). The IntersectionObserver
-	 *    that gates content-visibility flips rendered height between the
-	 *    200px placeholder and the actual code-block height as the block
-	 *    sits near the viewport edge during stream finalization. The
-	 *    height jump is small but visible, and the rendering optimization
-	 *    is unnecessary for chat content (thread length is bounded). We
-	 *    force `visible` to keep the rendered height of code blocks fully
-	 *    determined by their actual content at all times.
-	 *
-	 * 2. `[data-sd-animate]` (`sd-fadeIn`, 150ms). Streamdown wraps each
-	 *    streaming text segment in a span carrying this attribute. When
-	 *    shiki re-renders the code body at stream end, those wrapper
-	 *    spans get re-keyed and the fade animation replays across the
-	 *    whole block at once — exactly the visual that reads as the chat
-	 *    area "reloading for a frame." We disable the animation only
-	 *    inside code blocks; prose token fade-in elsewhere is untouched. */
-	.aui-thread-root [data-streamdown="code-block"] {
-		content-visibility: visible !important;
-		contain-intrinsic-size: none !important;
-	}
+	/* Streamdown's animated wrapper is unnecessary inside highlighted code and
+	 * causes a full-block fade when Shiki publishes its final tokens. Long chat
+	 * replies now unmount offscreen Markdown blocks, so keep Streamdown's native
+	 * content-visibility behavior instead of forcing every code fence to paint. */
 	.aui-thread-root [data-streamdown="code-block"] [data-sd-animate] {
 		animation: none !important;
 	}

--- a/studio/frontend/tests/code-plugin-embedded-grammars.test.ts
+++ b/studio/frontend/tests/code-plugin-embedded-grammars.test.ts
@@ -1,0 +1,275 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+/**
+ * Incremental tokenization has to survive a grammar switching mid-document.
+ *
+ * `code-plugin.ts` commits completed lines with the shiki `GrammarState` that
+ * follows them and resumes from it on the next refresh. Every fixture in
+ * `code-plugin-incremental.test.ts` is python, json or typescript, where one
+ * grammar covers the whole fence. The interesting case is the one none of them
+ * reach: HTML pushing into javascript and css, TSX alternating between JS and
+ * JSX, markdown opening a nested fence, a heredoc whose terminator is chosen at
+ * runtime. There the saved state is a stack several grammars deep, and a
+ * resume that loses a level produces plausible-looking tokens with the wrong
+ * scopes rather than an obvious break.
+ *
+ * The oracle is the same one the sibling file uses: whole-document
+ * `codeToTokens` at every prefix. Deliberately self-contained, so these can be
+ * read and moved independently of the sibling file's helpers.
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import type {
+  HighlightOptions,
+  HighlightResult,
+  ThemeInput,
+} from "@streamdown/code";
+import { createHighlighter } from "shiki";
+import { createJavaScriptRegexEngine } from "shiki/engine/javascript";
+
+import { createCodePlugin } from "../src/components/assistant-ui/code-plugin.ts";
+
+const THEMES: [ThemeInput, ThemeInput] = ["github-light", "github-dark"];
+
+const highlightOnce = (
+  plugin: ReturnType<typeof createCodePlugin>,
+  options: HighlightOptions,
+): Promise<HighlightResult> =>
+  new Promise((resolve) => {
+    const immediate = plugin.highlight(options, resolve);
+    if (immediate) resolve(immediate);
+  });
+
+const referenceHighlighters = new Map<
+  string,
+  ReturnType<typeof createHighlighter>
+>();
+
+/** What shiki returns for the whole string in one call. */
+async function reference(code: string, language: HighlightOptions["language"]) {
+  let loading = referenceHighlighters.get(language);
+  if (!loading) {
+    loading = createHighlighter({
+      themes: THEMES,
+      langs: [language],
+      engine: createJavaScriptRegexEngine({ forgiving: true }),
+    });
+    referenceHighlighters.set(language, loading);
+  }
+  const highlighter = await loading;
+  return highlighter.codeToTokens(code, {
+    lang: language,
+    themes: { light: "github-light", dark: "github-dark" },
+  });
+}
+
+/**
+ * Stream `source` one prefix at a time and require every settled result to
+ * equal whole-document tokenization of that same prefix.
+ *
+ * `cuts` are extra prefix lengths to test on top of the `step` walk, for the
+ * boundaries that matter here: the character before and after a delimiter that
+ * pushes or pops a grammar. A step walk alone can stride straight over them.
+ */
+async function assertMatchesWholeDocument(
+  source: string,
+  language: HighlightOptions["language"],
+  { step = 1, cuts = [] as number[] } = {},
+) {
+  const lengths = new Set<number>(cuts.filter((n) => n > 0 && n <= source.length));
+  for (let length = 1; length <= source.length; length += step) {
+    lengths.add(length);
+  }
+  lengths.add(source.length);
+
+  const plugin = createCodePlugin({ themes: THEMES });
+  for (const length of [...lengths].sort((a, b) => a - b)) {
+    const code = source.slice(0, length);
+    const streamed = await highlightOnce(plugin, {
+      code,
+      language,
+      themes: THEMES,
+    });
+    const full = await reference(code, language);
+    assert.deepEqual(
+      streamed.tokens,
+      full.tokens,
+      `${language} diverged at ${length} of ${source.length} characters, ` +
+        `after ${JSON.stringify(code.slice(-24))}`,
+    );
+  }
+}
+
+/** Every index just before and just after each occurrence of `marker`. */
+const cutsAround = (source: string, marker: string): number[] => {
+  const out: number[] = [];
+  for (let i = source.indexOf(marker); i >= 0; i = source.indexOf(marker, i + 1)) {
+    out.push(i, i + 1, i + marker.length, i + marker.length + 1);
+  }
+  return out;
+};
+
+// ── HTML: the grammar pushes into javascript and css and back ──────────
+
+const HTML = `<!doctype html>
+<html lang="en">
+  <head>
+    <style>
+      .card { color: #333; /* a comment
+         spanning lines */ }
+    </style>
+  </head>
+  <body>
+    <div class="card" data-note="a > b">text</div>
+    <script>
+      const total = items.reduce((sum, item) => sum + item.n, 0);
+      /* block comment
+         still open */
+      console.log(\`total \${total}\`);
+    </script>
+  </body>
+</html>
+`;
+
+test("an HTML fence with embedded script and style matches whole-document tokenization", async () => {
+  await assertMatchesWholeDocument(HTML, "html", {
+    step: 7,
+    cuts: [
+      ...cutsAround(HTML, "<style>"),
+      ...cutsAround(HTML, "</style>"),
+      ...cutsAround(HTML, "<script>"),
+      ...cutsAround(HTML, "</script>"),
+      ...cutsAround(HTML, "/*"),
+      ...cutsAround(HTML, "*/"),
+      ...cutsAround(HTML, "${"),
+    ],
+  });
+});
+
+// ── TSX: JSX children and an expression container ──────────────────────
+
+const TSX = `type Props = { items: string[] };
+
+export function List({ items }: Props) {
+  return (
+    <ul className="list">
+      {items.map((item) => (
+        <li key={item} title={\`row \${item}\`}>
+          {/* a JSX comment, which is not a JS comment */}
+          {item.length > 2 ? <strong>{item}</strong> : item}
+        </li>
+      ))}
+    </ul>
+  );
+}
+`;
+
+test("a TSX fence with JSX children matches whole-document tokenization", async () => {
+  await assertMatchesWholeDocument(TSX, "tsx", {
+    step: 5,
+    cuts: [
+      ...cutsAround(TSX, "<ul"),
+      ...cutsAround(TSX, "{items"),
+      ...cutsAround(TSX, "{/*"),
+      ...cutsAround(TSX, "*/}"),
+      ...cutsAround(TSX, "${"),
+      ...cutsAround(TSX, "</ul>"),
+    ],
+  });
+});
+
+// ── Markdown containing a fence: the grammar nests into itself ─────────
+
+// The nested fence is here because it is what users actually paste, but it is
+// NOT what makes this discriminate: shiki's markdown grammar leaves a fenced
+// body uncoloured, so its tail tokenizes the same with or without a resumed
+// state. The multi-line HTML comment is the part that carries state across
+// lines, verified by tokenizing the tail both ways at every line boundary.
+const MARKDOWN = `# Title
+
+Some prose with \`inline code\` and a [link](https://example.com).
+
+<!-- an HTML comment
+that stays open across
+several lines -->
+
+\`\`\`python
+def f(x):
+    """docstring
+    across lines"""
+    return x
+\`\`\`
+
+More prose after the fence.
+`;
+
+test("a markdown fence with a multi-line comment matches whole-document tokenization", async () => {
+  await assertMatchesWholeDocument(MARKDOWN, "markdown", {
+    step: 5,
+    cuts: [
+      ...cutsAround(MARKDOWN, "<!--"),
+      ...cutsAround(MARKDOWN, "-->"),
+      ...cutsAround(MARKDOWN, "```python"),
+      ...cutsAround(MARKDOWN, '"""'),
+      ...cutsAround(MARKDOWN, "```\n\nMore"),
+    ],
+  });
+});
+
+// ── Shell heredoc: the terminator is chosen by the document ────────────
+
+const SHELL = `#!/usr/bin/env bash
+set -euo pipefail
+
+cat <<'END_SQL'
+$HOME is not expanded here
+SELECT '\${value}' FROM t;
+END_SQL
+
+cat <<EOF
+$HOME is expanded here
+EOF
+
+echo done
+`;
+
+test("a shell heredoc keeps its scope across updates", async () => {
+  await assertMatchesWholeDocument(SHELL, "shellscript", {
+    step: 4,
+    cuts: [
+      ...cutsAround(SHELL, "<<'END_SQL'"),
+      ...cutsAround(SHELL, "END_SQL"),
+      ...cutsAround(SHELL, "<<EOF"),
+      ...cutsAround(SHELL, "EOF"),
+    ],
+  });
+});
+
+// ── Nested template literals: interpolation inside interpolation ───────
+
+const TEMPLATE = `const name = "row";
+const value = \`outer
+\${render({
+  inner: \`nested \${name} deep\`,
+  note: "a } brace in a string",
+})}
+tail\`;
+const escaped = \`not \\\${an} interpolation\`;
+const done = true;
+`;
+
+test("nested template literals match whole-document tokenization", async () => {
+  await assertMatchesWholeDocument(TEMPLATE, "typescript", {
+    step: 3,
+    cuts: [
+      ...cutsAround(TEMPLATE, "`outer"),
+      ...cutsAround(TEMPLATE, "${render"),
+      ...cutsAround(TEMPLATE, "`nested"),
+      ...cutsAround(TEMPLATE, "})}"),
+      ...cutsAround(TEMPLATE, "tail`"),
+      ...cutsAround(TEMPLATE, "\\${an}"),
+    ],
+  });
+});

--- a/studio/frontend/tests/code-plugin-engine-and-cache.test.ts
+++ b/studio/frontend/tests/code-plugin-engine-and-cache.test.ts
@@ -1,0 +1,252 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+/**
+ * Two guards on `code-plugin.ts` that nothing else covers.
+ *
+ * 1. The regex engine. The desktop app's CSP is `default-src 'self'` with no
+ *    `wasm-unsafe-eval` (studio/src-tauri/tauri.conf.json), and the packaged
+ *    frontend is the same bundle the browser gets. Shiki's default Oniguruma
+ *    engine is WebAssembly, so swapping to it would work in every browser and
+ *    every test here, and be blocked at runtime in the packaged desktop app.
+ *    No CI job builds the desktop bundle and drives its webview, so this is
+ *    the only thing standing between that change and a shipped regression.
+ *
+ * 2. The cache budget. `MAX_CACHED_CHARACTERS` is 512,000 and the largest
+ *    fixture in the sibling files is ~36 KB, so the character-budget branch,
+ *    its "never evict the only fence" carve-out, and the running character
+ *    count were all unreachable. A miscount there degrades silently: either
+ *    the cache stops evicting and grows without bound, or it evicts fences it
+ *    should have kept and quietly reverts to full re-tokenization.
+ */
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import type {
+  HighlightOptions,
+  HighlightResult,
+  ThemeInput,
+} from "@streamdown/code";
+
+import { createHighlighter } from "shiki";
+import { createJavaScriptRegexEngine } from "shiki/engine/javascript";
+
+import { createCodePlugin } from "../src/components/assistant-ui/code-plugin.ts";
+
+const THEMES: [ThemeInput, ThemeInput] = ["github-light", "github-dark"];
+
+const PLUGIN_SOURCE = readFileSync(
+  new URL("../src/components/assistant-ui/code-plugin.ts", import.meta.url),
+  "utf8",
+);
+
+const highlightOnce = (
+  plugin: ReturnType<typeof createCodePlugin>,
+  options: HighlightOptions,
+): Promise<HighlightResult> =>
+  new Promise((resolve) => {
+    const immediate = plugin.highlight(options, resolve);
+    if (immediate) resolve(immediate);
+  });
+
+// ── 1. the engine the desktop CSP allows ───────────────────────────────
+
+test("the highlighter uses the JavaScript regex engine, not the WASM one", () => {
+  assert.match(
+    PLUGIN_SOURCE,
+    /createJavaScriptRegexEngine/,
+    "code-plugin must build its highlighter with shiki's JavaScript regex engine",
+  );
+  assert.doesNotMatch(
+    PLUGIN_SOURCE,
+    /shiki\/wasm|loadWasm|createOnigurumaEngine/,
+    // This is a source-text assertion, not a behavioural one: it pins the name,
+    // so an alias would trip it and a same-named wrapper would slip past. That
+    // is the accepted cost of covering a constraint no runtime here can check,
+    // since nothing in CI drives the packaged webview.
+    "shiki's Oniguruma engine is WebAssembly, which the desktop app's CSP " +
+      "(default-src 'self', no wasm-unsafe-eval) blocks; the packaged app ships " +
+      "this same bundle and no CI job would catch it",
+  );
+});
+
+// ── 2. the character budget ────────────────────────────────────────────
+
+/** Distinct, cheap-to-tokenize source of roughly `chars` characters. */
+const sourceOfSize = (id: number, chars: number): string => {
+  const lines: string[] = [];
+  let length = 0;
+  for (let i = 0; length < chars; i += 1) {
+    const line = `const value_${id}_${i} = ${i};`;
+    lines.push(line);
+    length += line.length + 1;
+  }
+  return `${lines.join("\n")}\n`;
+};
+
+/**
+ * Whether the plugin still holds the entry that produced `previous`.
+ *
+ * Re-requesting is not enough on its own: a miss re-tokenizes and re-caches, so
+ * asking twice always agrees with itself. The only signal is whether the entry
+ * from before is still the one being served, so compare against the object the
+ * cache handed out earlier.
+ */
+const stillCached = async (
+  plugin: ReturnType<typeof createCodePlugin>,
+  previous: HighlightResult,
+  code: string,
+  language: HighlightOptions["language"],
+): Promise<boolean> =>
+  (await highlightOnce(plugin, { code, language, themes: THEMES })) === previous;
+
+test("the character budget evicts even while the fence count is under its limit", async () => {
+  // 100 fences of ~6 KB is 600 KB, past MAX_CACHED_CHARACTERS, while staying
+  // well under MAX_FENCES. Only the character branch can evict here, so this
+  // fails outright if that branch is unreachable or miscounted.
+  const plugin = createCodePlugin({ themes: THEMES });
+  const first = sourceOfSize(0, 6_000);
+  const held = await highlightOnce(plugin, {
+    code: first,
+    language: "typescript",
+    themes: THEMES,
+  });
+  assert.equal(
+    await stillCached(plugin, held, first, "typescript"),
+    true,
+    "the fence was not cached to begin with, so the check below proves nothing",
+  );
+
+  for (let id = 1; id < 100; id += 1) {
+    await highlightOnce(plugin, {
+      code: sourceOfSize(id, 6_000),
+      language: "typescript",
+      themes: THEMES,
+    });
+  }
+
+  assert.equal(
+    await stillCached(plugin, held, first, "typescript"),
+    false,
+    "600 KB of fences did not evict the oldest; the character budget is not being enforced",
+  );
+});
+
+test("a fence larger than the whole budget is kept rather than evicting itself", async () => {
+  // The carve-out at the eviction loop: stop when one fence is left, so a
+  // single oversized fence is retained. Without it the only fence in the cache
+  // would be dropped the moment it exceeded the budget, and every refresh of a
+  // long block would re-tokenize from zero, which is the case this PR exists
+  // to remove.
+  const plugin = createCodePlugin({ themes: THEMES });
+  const huge = sourceOfSize(1, 600_000);
+  assert.ok(huge.length > 512_000, "fixture must exceed MAX_CACHED_CHARACTERS");
+
+  const held = await highlightOnce(plugin, {
+    code: huge,
+    language: "typescript",
+    themes: THEMES,
+  });
+  assert.equal(
+    await stillCached(plugin, held, huge, "typescript"),
+    true,
+    "the only fence in the cache was evicted for being over budget",
+  );
+});
+
+test("a fence evicted mid-stream still tokenizes correctly when it resumes", async () => {
+  // Eviction drops the committed lines and the grammar state, so the fence
+  // restarts from offset 0 and rebuilds incremental state as it keeps growing.
+  // That is a performance loss by design; it must not be a correctness one.
+  //
+  // Two things this test needs that are easy to get wrong, both found by
+  // measurement rather than assumed:
+  //
+  //  - It must wait out REFRESH_MS between updates. Past MIN_INCREMENTAL_CHARS,
+  //    two updates inside that window return the throttled approximation, which
+  //    renders the uncommitted tail plain and never reads the grammar state.
+  //    Without the wait, 22 of 23 comparisons took that path and the test could
+  //    not fail however the resume was broken.
+  //  - The fixture must be one whose tokens actually change when the resumed
+  //    state is dropped. A python triple-quoted string is not: dropping the
+  //    state left its tokens byte-identical. HTML with an embedded script is,
+  //    because the grammar is several levels deep at the resume point.
+  const chunk = [
+    "  <section>",
+    '    <div class="card" data-note="a > b">text</div>',
+    "    <script>",
+    "      /* a block comment",
+    "         that stays open across lines */",
+    "      const total = items.reduce((sum, item) => sum + item.n, 0);",
+    "      console.log(`total ${total}`);",
+    "    <\/script>",
+    "    <style>",
+    "      .card { color: #333; /* comment",
+    "         spanning lines */ }",
+    "    <\/style>",
+    "  <\/section>",
+  ].join("\n");
+  let source = "<!doctype html>\n<html>\n<body>\n";
+  for (let i = 0; i < 12; i += 1) source += `${chunk}\n`;
+  source += "<\/body>\n<\/html>\n";
+  assert.ok(source.length > 4_000, "fixture must clear MIN_INCREMENTAL_CHARS");
+
+  const highlighter = await createHighlighter({
+    themes: THEMES,
+    langs: ["html"],
+    engine: createJavaScriptRegexEngine({ forgiving: true }),
+  });
+  const oracle = (code: string) =>
+    highlighter.codeToTokens(code, {
+      lang: "html",
+      themes: { light: "github-light", dark: "github-dark" },
+    }).tokens;
+
+  const settle = () => new Promise((r) => setTimeout(r, 260));
+  const plugin = createCodePlugin({ themes: THEMES });
+  const half = Math.floor(source.length / 2);
+
+  // Grow past the incremental threshold so committed state exists to lose.
+  for (let length = 2_100; length <= half; length += 700) {
+    await settle();
+    await highlightOnce(plugin, {
+      code: source.slice(0, length),
+      language: "html",
+      themes: THEMES,
+    });
+  }
+
+  // Evict it.
+  for (let id = 0; id < 100; id += 1) {
+    await highlightOnce(plugin, {
+      code: sourceOfSize(id, 6_000),
+      language: "html",
+      themes: THEMES,
+    });
+  }
+
+  // Keep streaming. Every prefix must still match the whole document.
+  for (let length = half; length <= source.length; length += 700) {
+    await settle();
+    const code = source.slice(0, length);
+    const streamed = await highlightOnce(plugin, {
+      code,
+      language: "html",
+      themes: THEMES,
+    });
+    assert.deepEqual(
+      streamed.tokens,
+      oracle(code),
+      `a fence that lost its cache mid-stream diverged at ${length} of ${source.length}`,
+    );
+  }
+
+  await settle();
+  const final = await highlightOnce(plugin, {
+    code: source,
+    language: "html",
+    themes: THEMES,
+  });
+  assert.deepEqual(final.tokens, oracle(source));
+});

--- a/studio/frontend/tests/code-plugin-incremental.test.ts
+++ b/studio/frontend/tests/code-plugin-incremental.test.ts
@@ -605,3 +605,24 @@ test("a throttled multiline tail matches the previous plugin", async () => {
     ...expectedTail,
   ]);
 });
+
+
+test("a released highlight callback cannot update an unmounted fence", async () => {
+  const plugin = createCodePlugin({ themes: THEMES });
+  const options = {
+    code: "const released = true;\n",
+    language: "typescript" as HighlightOptions["language"],
+    themes: THEMES,
+  };
+  let releasedCallbackRan = false;
+  const releasedCallback = () => {
+    releasedCallbackRan = true;
+  };
+
+  plugin.highlight(options, releasedCallback);
+  plugin.cancelHighlight(releasedCallback);
+  await highlightOnce(plugin, options);
+  await Promise.resolve();
+
+  assert.equal(releasedCallbackRan, false);
+});

--- a/studio/frontend/tests/code-plugin-incremental.test.ts
+++ b/studio/frontend/tests/code-plugin-incremental.test.ts
@@ -430,6 +430,60 @@ test("a shorter prefix sibling fence keeps the longer one highlighted", async ()
   );
 });
 
+test("a sibling that differs only by trailing spaces keeps its own entry", async () => {
+  const plugin = createCodePlugin({ themes: THEMES });
+  const language = "json" as HighlightOptions["language"];
+  const shorter = `{"values": [${Array.from({ length: 300 }, (_, i) => `"item-${i}"`).join(", ")}`;
+  // Whitespace alone never closes a fence, so this is a separate block.
+  const longer = `${shorter}   `;
+
+  await highlightOnce(plugin, { code: longer, language, themes: THEMES });
+  await highlightOnce(plugin, { code: shorter, language, themes: THEMES });
+
+  let rendered: HighlightResult | null = null;
+  for (let frame = 0; frame < 3; frame += 1) {
+    rendered = plugin.highlight({ code: longer, language, themes: THEMES });
+    plugin.highlight({ code: shorter, language, themes: THEMES });
+  }
+
+  assert.deepEqual(
+    rendered?.tokens,
+    (await reference(longer, "json")).tokens,
+    "the longer fence must not be left as an unhighlighted plain tail",
+  );
+});
+
+test("a changed theme definition is not answered from the old theme's cache", async () => {
+  const plugin = createCodePlugin({ themes: THEMES });
+  const language = "python" as HighlightOptions["language"];
+  const code = "value = 1\n";
+  // Same names, different definitions: only the definitions tell them apart.
+  const pair = (background: string): [ThemeInput, ThemeInput] =>
+    (["swap-light", "swap-dark"] as const).map(
+      (name) =>
+        ({
+          name,
+          settings: [{ settings: { foreground: "#101010", background } }],
+        }) as unknown as ThemeInput,
+    ) as [ThemeInput, ThemeInput];
+
+  const first = await highlightOnce(plugin, {
+    code,
+    language,
+    themes: pair("#111111"),
+  });
+  const second = await highlightOnce(plugin, {
+    code,
+    language,
+    themes: pair("#eeeeee"),
+  });
+  assert.notEqual(
+    second.bg,
+    first.bg,
+    "a redefined theme must not reuse the previous definition's tokens",
+  );
+});
+
 test("shedding a closing delimiter drops the refresh queued for it", async () => {
   const plugin = createCodePlugin({ themes: THEMES });
   const language = "python" as HighlightOptions["language"];

--- a/studio/frontend/tests/code-plugin-incremental.test.ts
+++ b/studio/frontend/tests/code-plugin-incremental.test.ts
@@ -403,6 +403,57 @@ test("a single line past the throttle keeps its text and settles exact", async (
   assert.deepEqual(settled.tokens, full.tokens);
 });
 
+test("a shorter prefix sibling fence keeps the longer one highlighted", async () => {
+  const plugin = createCodePlugin({ themes: THEMES });
+  const language = "json" as HighlightOptions["language"];
+  // Single-line, so the longer fence commits no line and its whole body stays
+  // reachable by a prefix match.
+  const shorter = `{"values": [${Array.from({ length: 300 }, (_, i) => `"item-${i}"`).join(", ")}`;
+  const longer = `${shorter}, "only-in-the-longer-fence"]}`;
+
+  await highlightOnce(plugin, { code: longer, language, themes: THEMES });
+  await highlightOnce(plugin, { code: shorter, language, themes: THEMES });
+
+  // A thread re-renders every block in document order, so the shorter fence
+  // follows the longer one inside one refresh interval.
+  let rendered: HighlightResult | null = null;
+  for (let frame = 0; frame < 3; frame += 1) {
+    rendered = plugin.highlight({ code: longer, language, themes: THEMES });
+    plugin.highlight({ code: shorter, language, themes: THEMES });
+  }
+
+  assert.deepEqual(
+    rendered?.tokens,
+    (await reference(longer, "json")).tokens,
+    "the longer fence must not be left as an unhighlighted plain tail",
+  );
+  assert.deepEqual(
+    plugin.highlight({ code: shorter, language, themes: THEMES })?.tokens,
+    (await reference(shorter, "json")).tokens,
+  );
+});
+
+test("shedding a closing delimiter drops the refresh queued for it", async () => {
+  const plugin = createCodePlugin({ themes: THEMES });
+  const language = "python" as HighlightOptions["language"];
+  const body = `${Array.from(
+    { length: 120 },
+    (_, index) => `value_${index} = ${index}  # a completed Python line`,
+  ).join("\n")}\n`;
+  // Markdown reports the closing run as body until it closes the fence.
+  await highlightOnce(plugin, { code: `${body}\`\``, language, themes: THEMES });
+
+  const stale: HighlightResult[] = [];
+  plugin.highlight({ code: `${body}\`\`\``, language, themes: THEMES }, (result) =>
+    stale.push(result),
+  );
+  const closed = plugin.highlight({ code: body, language, themes: THEMES });
+  await new Promise((resolve) => setTimeout(resolve, 400));
+
+  assert.equal(stale.length, 0, "the closed fence must cancel the delimiter refresh");
+  assert.deepEqual(closed?.tokens, (await reference(body, "python")).tokens);
+});
+
 test("a throttled multiline tail matches the previous plugin", async () => {
   const plugin = createCodePlugin({ themes: THEMES });
   const language = "python" as HighlightOptions["language"];

--- a/studio/frontend/tests/code-plugin-incremental.test.ts
+++ b/studio/frontend/tests/code-plugin-incremental.test.ts
@@ -351,8 +351,7 @@ test("re-opening a thread answers every fence from cache", async () => {
   for (const code of blocks) {
     first.push(await highlightOnce(plugin, { code, language, themes: THEMES }));
   }
-  // A thread is mounted whole, so the second pass asks for all of them again.
-  // The same object back means the tokenizer was never reached.
+  // A thread mounts whole: the same object back means no tokenizer was reached.
   const reused = blocks.filter(
     (code, index) =>
       plugin.highlight({ code, language, themes: THEMES }) === first[index],
@@ -406,16 +405,14 @@ test("a single line past the throttle keeps its text and settles exact", async (
 test("a shorter prefix sibling fence keeps the longer one highlighted", async () => {
   const plugin = createCodePlugin({ themes: THEMES });
   const language = "json" as HighlightOptions["language"];
-  // Single-line, so the longer fence commits no line and its whole body stays
-  // reachable by a prefix match.
+  // Single-line, so the longer fence commits nothing and stays prefix-reachable.
   const shorter = `{"values": [${Array.from({ length: 300 }, (_, i) => `"item-${i}"`).join(", ")}`;
   const longer = `${shorter}, "only-in-the-longer-fence"]}`;
 
   await highlightOnce(plugin, { code: longer, language, themes: THEMES });
   await highlightOnce(plugin, { code: shorter, language, themes: THEMES });
 
-  // A thread re-renders every block in document order, so the shorter fence
-  // follows the longer one inside one refresh interval.
+  // Document order renders the shorter fence next, within one refresh interval.
   let rendered: HighlightResult | null = null;
   for (let frame = 0; frame < 3; frame += 1) {
     rendered = plugin.highlight({ code: longer, language, themes: THEMES });

--- a/studio/frontend/tests/code-plugin-incremental.test.ts
+++ b/studio/frontend/tests/code-plugin-incremental.test.ts
@@ -430,28 +430,31 @@ test("a shorter prefix sibling fence keeps the longer one highlighted", async ()
   );
 });
 
-test("a sibling that differs only by trailing spaces keeps its own entry", async () => {
-  const plugin = createCodePlugin({ themes: THEMES });
-  const language = "json" as HighlightOptions["language"];
-  const shorter = `{"values": [${Array.from({ length: 300 }, (_, i) => `"item-${i}"`).join(", ")}`;
-  // Whitespace alone never closes a fence, so this is a separate block.
-  const longer = `${shorter}   `;
+// Neither of these can close a fence: whitespace carries no marker, and a
+// closing run never mixes backticks with tildes.
+for (const suffix of ["   ", "`~"]) {
+  test(`a sibling ending in ${JSON.stringify(suffix)} keeps its own entry`, async () => {
+    const plugin = createCodePlugin({ themes: THEMES });
+    const language = "json" as HighlightOptions["language"];
+    const shorter = `{"values": [${Array.from({ length: 300 }, (_, i) => `"item-${i}"`).join(", ")}`;
+    const longer = `${shorter}${suffix}`;
 
-  await highlightOnce(plugin, { code: longer, language, themes: THEMES });
-  await highlightOnce(plugin, { code: shorter, language, themes: THEMES });
+    await highlightOnce(plugin, { code: longer, language, themes: THEMES });
+    await highlightOnce(plugin, { code: shorter, language, themes: THEMES });
 
-  let rendered: HighlightResult | null = null;
-  for (let frame = 0; frame < 3; frame += 1) {
-    rendered = plugin.highlight({ code: longer, language, themes: THEMES });
-    plugin.highlight({ code: shorter, language, themes: THEMES });
-  }
+    let rendered: HighlightResult | null = null;
+    for (let frame = 0; frame < 3; frame += 1) {
+      rendered = plugin.highlight({ code: longer, language, themes: THEMES });
+      plugin.highlight({ code: shorter, language, themes: THEMES });
+    }
 
-  assert.deepEqual(
-    rendered?.tokens,
-    (await reference(longer, "json")).tokens,
-    "the longer fence must not be left as an unhighlighted plain tail",
-  );
-});
+    assert.deepEqual(
+      rendered?.tokens,
+      (await reference(longer, "json")).tokens,
+      "the longer fence must not be left as an unhighlighted plain tail",
+    );
+  });
+}
 
 test("a changed theme definition is not answered from the old theme's cache", async () => {
   const plugin = createCodePlugin({ themes: THEMES });
@@ -503,6 +506,36 @@ test("shedding a closing delimiter drops the refresh queued for it", async () =>
 
   assert.equal(stale.length, 0, "the closed fence must cancel the delimiter refresh");
   assert.deepEqual(closed?.tokens, (await reference(body, "python")).tokens);
+});
+
+test("an unchanged fence does not cancel an identical sibling's refresh", async () => {
+  const plugin = createCodePlugin({ themes: THEMES });
+  const language = "python" as HighlightOptions["language"];
+  const body = `${Array.from(
+    { length: 120 },
+    (_, index) => `value_${index} = ${index}  # a completed Python line`,
+  ).join("\n")}\n`;
+  // Byte-identical fences cannot be told apart, so they share one entry.
+  await highlightOnce(plugin, { code: body, language, themes: THEMES });
+  await highlightOnce(plugin, { code: body, language, themes: THEMES });
+
+  let grown = body;
+  let latest: HighlightResult | null = null;
+  const receive = (result: HighlightResult) => {
+    latest = result;
+  };
+  for (let frame = 0; frame < 3; frame += 1) {
+    grown = `${grown}appended_${frame} = ${frame}\n`;
+    latest = plugin.highlight({ code: grown, language, themes: THEMES }, receive);
+    plugin.highlight({ code: body, language, themes: THEMES });
+  }
+  await new Promise((resolve) => setTimeout(resolve, 500));
+
+  assert.deepEqual(
+    (latest as HighlightResult | null)?.tokens,
+    (await reference(grown, "python")).tokens,
+    "the growing fence must still receive its refresh",
+  );
 });
 
 test("a throttled multiline tail matches the previous plugin", async () => {

--- a/studio/frontend/tests/code-plugin-incremental.test.ts
+++ b/studio/frontend/tests/code-plugin-incremental.test.ts
@@ -1,0 +1,434 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import type {
+  HighlightOptions,
+  HighlightResult,
+  ThemeInput,
+} from "@streamdown/code";
+import { createHighlighter } from "shiki";
+import { createJavaScriptRegexEngine } from "shiki/engine/javascript";
+
+import { createCodePlugin } from "../src/components/assistant-ui/code-plugin.ts";
+
+const THEMES: [ThemeInput, ThemeInput] = ["github-light", "github-dark"];
+
+const PYTHON = `import json
+
+
+def render(payload: dict) -> str:
+    """Return the payload as text.
+
+    A docstring is one grammar scope spanning several lines, so a line that
+    only continues it has no meaning of its own.
+    """
+    if not payload:
+        return ""
+    return json.dumps(payload, indent=2)  # trailing comment
+
+
+class Runner:
+    def __init__(self, name: str = "runner"):
+        self.name = name
+
+    def run(self, *args, **kwargs):
+        return f"{self.name}: {args!r} {kwargs!r}"
+`;
+
+const TYPESCRIPT = `export type Slot = {
+  code: string;
+  /** Tokens for the lines a newline has already terminated. */
+  lines: string[][];
+};
+
+export function commit(slot: Slot, code: string): Slot {
+  const boundary = code.lastIndexOf("\\n");
+  if (boundary < 0) return slot;
+  return { ...slot, code: code.slice(0, boundary + 1) };
+}
+`;
+
+const UNBALANCED = "x = '''\nstill inside the string\nand still\n";
+
+function highlightOnce(
+  plugin: ReturnType<typeof createCodePlugin>,
+  options: HighlightOptions,
+): Promise<HighlightResult> {
+  return new Promise((resolve) => {
+    const immediate = plugin.highlight(options, resolve);
+    if (immediate) resolve(immediate);
+  });
+}
+
+async function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  message: string,
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error(message)), timeoutMs);
+  });
+  try {
+    return await Promise.race([promise, timeout]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+const referenceHighlighters = new Map<
+  HighlightOptions["language"],
+  ReturnType<typeof createHighlighter>
+>();
+
+/** Tokens shiki returns for the whole string in one call. */
+async function reference(code: string, language: HighlightOptions["language"]) {
+  let loading = referenceHighlighters.get(language);
+  if (!loading) {
+    loading = createHighlighter({
+      themes: THEMES,
+      langs: [language],
+      engine: createJavaScriptRegexEngine({ forgiving: true }),
+    });
+    referenceHighlighters.set(language, loading);
+  }
+  const highlighter = await loading;
+  return highlighter.codeToTokens(code, {
+    lang: language,
+    themes: { light: "github-light", dark: "github-dark" },
+  });
+}
+
+async function assertMatchesFullTokenization(
+  source: string,
+  language: HighlightOptions["language"],
+  step: number,
+) {
+  const plugin = createCodePlugin({ themes: THEMES });
+  for (let length = 1; length <= source.length; length += step) {
+    const code = source.slice(0, length);
+    const streamed = await highlightOnce(plugin, {
+      code,
+      language,
+      themes: THEMES,
+    });
+    const full = await reference(code, language);
+    assert.deepEqual(
+      streamed.tokens,
+      full.tokens,
+      `tokens diverged after ${length} of ${source.length} characters`,
+    );
+    assert.equal(streamed.fg, full.fg);
+    assert.equal(streamed.bg, full.bg);
+    assert.equal(streamed.themeName, full.themeName);
+    assert.equal(streamed.rootStyle, full.rootStyle);
+  }
+}
+
+test("a streamed Python fence tokenizes exactly like a whole one", async () => {
+  await assertMatchesFullTokenization(PYTHON, "python", 1);
+});
+
+test("a streamed TypeScript fence tokenizes exactly like a whole one", async () => {
+  await assertMatchesFullTokenization(TYPESCRIPT, "typescript", 1);
+});
+
+test("an unterminated multi-line string keeps its scope across updates", async () => {
+  await assertMatchesFullTokenization(UNBALANCED, "python", 1);
+});
+
+test("a fence arriving in line-sized chunks matches a whole one", async () => {
+  await assertMatchesFullTokenization(PYTHON, "python", 17);
+});
+
+test("aliases resolve to the language shiki tokenizes with", async () => {
+  const plugin = createCodePlugin({ themes: THEMES });
+  const aliased = await highlightOnce(plugin, {
+    code: PYTHON,
+    language: "py" as HighlightOptions["language"],
+    themes: THEMES,
+  });
+  const full = await reference(PYTHON, "python");
+  assert.deepEqual(aliased.tokens, full.tokens);
+  assert.equal(plugin.supportsLanguage("py" as HighlightOptions["language"]), true);
+  assert.equal(
+    plugin.supportsLanguage("not-a-language" as HighlightOptions["language"]),
+    false,
+  );
+});
+
+test("an unchanged fence is answered from cache without new tokens", async () => {
+  const plugin = createCodePlugin({ themes: THEMES });
+  const options: HighlightOptions = {
+    code: PYTHON,
+    language: "python" as HighlightOptions["language"],
+    themes: THEMES,
+  };
+  const first = await highlightOnce(plugin, options);
+  const second = plugin.highlight(options);
+  assert.equal(second, first, "a repeat render must reuse the same result");
+});
+
+test("two fences of one language keep their own tokens", async () => {
+  const plugin = createCodePlugin({ themes: THEMES });
+  const language = "python" as HighlightOptions["language"];
+  await highlightOnce(plugin, { code: PYTHON, language, themes: THEMES });
+  const other = `${PYTHON}\n# a second fence that starts differently\nvalue = 1\n`;
+  const shifted = other.slice(20);
+  const streamed = await highlightOnce(plugin, {
+    code: shifted,
+    language,
+    themes: THEMES,
+  });
+  const full = await reference(shifted, "python");
+  assert.deepEqual(streamed.tokens, full.tokens);
+});
+
+test("all fences mounted while one grammar loads receive their result", async () => {
+  const plugin = createCodePlugin({ themes: THEMES });
+  const language = "python" as HighlightOptions["language"];
+  const blocks = [
+    "value = 1\n",
+    "value = 1\n",
+    "value = 1\nprint(value)\n",
+  ];
+
+  const highlighted = blocks.map(
+    (code) =>
+      new Promise<HighlightResult>((resolve) => {
+        const immediate = plugin.highlight(
+          { code, language, themes: THEMES },
+          resolve,
+        );
+        if (immediate) resolve(immediate);
+      }),
+  );
+  const results = await withTimeout(
+    Promise.all(highlighted),
+    500,
+    "a highlight callback was lost",
+  );
+
+  for (let index = 0; index < blocks.length; index += 1) {
+    const full = await reference(blocks[index], "python");
+    assert.deepEqual(results[index].tokens, full.tokens);
+  }
+});
+
+test("updates queued during grammar load settle on the newest source", async () => {
+  const plugin = createCodePlugin({ themes: THEMES });
+  const language = "python" as HighlightOptions["language"];
+  const blocks = ["value = 1", "value = 10", "value = 100\n"];
+  const seen: HighlightResult[] = [];
+  const completed = blocks.map(
+    (code) =>
+      new Promise<void>((resolve) => {
+        const receive = (result: HighlightResult) => {
+          seen.push(result);
+          resolve();
+        };
+        const immediate = plugin.highlight(
+          { code, language, themes: THEMES },
+          receive,
+        );
+        if (immediate) receive(immediate);
+      }),
+  );
+  await withTimeout(
+    Promise.all(completed),
+    500,
+    "a queued update was not highlighted",
+  );
+
+  const latest = await reference(blocks.at(-1)!, "python");
+  assert.deepEqual(seen.at(-1)?.tokens, latest.tokens);
+});
+
+test("the cache limit does not discard grammar-load callbacks", async () => {
+  const plugin = createCodePlugin({ themes: THEMES });
+  const language = "python" as HighlightOptions["language"];
+  const blocks = Array.from(
+    { length: 520 },
+    (_, index) => `value_${index} = ${index}\n`,
+  );
+  const highlighted = blocks.map(
+    (code) =>
+      new Promise<HighlightResult>((resolve) => {
+        const immediate = plugin.highlight(
+          { code, language, themes: THEMES },
+          resolve,
+        );
+        if (immediate) resolve(immediate);
+      }),
+  );
+  const results = await withTimeout(
+    Promise.all(highlighted),
+    2000,
+    "a pending fence was evicted",
+  );
+
+  assert.equal(results.length, blocks.length);
+  for (const index of [0, blocks.length - 1]) {
+    const full = await reference(blocks[index], "python");
+    assert.deepEqual(results[index].tokens, full.tokens);
+  }
+});
+
+test("a failed grammar load releases pending callbacks before retry", async () => {
+  const plugin = createCodePlugin({ themes: THEMES });
+  const language = "python" as HighlightOptions["language"];
+  const invalidThemes = [
+    { name: "retry-light", settings: 42 } as unknown as ThemeInput,
+    { name: "retry-dark", settings: 42 } as unknown as ThemeInput,
+  ] as [ThemeInput, ThemeInput];
+  const validThemes = [
+    { name: "retry-light", settings: [] } as unknown as ThemeInput,
+    { name: "retry-dark", settings: [] } as unknown as ThemeInput,
+  ] as [ThemeInput, ThemeInput];
+  const blocks = Array.from(
+    { length: 520 },
+    (_, index) => `value_${index} = ${index}\n`,
+  );
+
+  let reportFailure!: () => void;
+  const failed = new Promise<void>((resolve) => {
+    reportFailure = resolve;
+  });
+  const originalError = console.error;
+  let staleCallbacks = 0;
+  try {
+    console.error = (message?: unknown) => {
+      if (message === "[Studio Code] Failed to highlight code:") {
+        reportFailure();
+      }
+    };
+    for (const code of blocks) {
+      plugin.highlight(
+        { code, language, themes: invalidThemes },
+        () => {
+          staleCallbacks += 1;
+        },
+      );
+    }
+    await withTimeout(failed, 500, "the invalid grammar load did not fail");
+  } finally {
+    console.error = originalError;
+  }
+
+  const retried = await highlightOnce(plugin, {
+    code: blocks.at(-1)!,
+    language,
+    themes: validThemes,
+  });
+  assert.equal(staleCallbacks, 0, "a retry invoked callbacks from a failed load");
+  assert.equal(
+    retried.tokens
+      .map((line) => line.map((token) => token.content).join(""))
+      .join("\n"),
+    blocks.at(-1),
+  );
+});
+
+test("CRLF streaming matches whole-document tokenization", async () => {
+  await assertMatchesFullTokenization(
+    "def render():\r\n    value = '''first\r\nsecond'''\r\n    return value\r\n",
+    "python",
+    7,
+  );
+});
+
+test("re-opening a thread answers every fence from cache", async () => {
+  const plugin = createCodePlugin({ themes: THEMES });
+  const language = "python" as HighlightOptions["language"];
+  const blocks = Array.from(
+    { length: 60 },
+    (_, index) =>
+      `# block ${index}\n${PYTHON}\nvalue_${index} = ${index}\n`,
+  );
+  const first: HighlightResult[] = [];
+  for (const code of blocks) {
+    first.push(await highlightOnce(plugin, { code, language, themes: THEMES }));
+  }
+  // A thread is mounted whole, so the second pass asks for all of them again.
+  // The same object back means the tokenizer was never reached.
+  const reused = blocks.filter(
+    (code, index) =>
+      plugin.highlight({ code, language, themes: THEMES }) === first[index],
+  );
+  assert.equal(
+    reused.length,
+    blocks.length,
+    "every fence should come back from cache on a second mount",
+  );
+});
+
+test("a single line past the throttle keeps its text and settles exact", async () => {
+  const plugin = createCodePlugin({ themes: THEMES });
+  const language = "json" as HighlightOptions["language"];
+  const long = `{"values": [${Array.from({ length: 400 }, (_, i) => `"item-${i}"`).join(", ")}`;
+  await highlightOnce(plugin, { code: long, language, themes: THEMES });
+  const grown = `${long}, "tail"`;
+  const throttled = (await highlightOnce(plugin, {
+    code: grown,
+    language,
+    themes: THEMES,
+  })) as HighlightResult;
+  assert.deepEqual(
+    throttled.tokens,
+    [[{ content: grown, offset: 0 }]],
+    "the throttled frame must retain the previous plugin's plain live line",
+  );
+  assert.equal(
+    throttled.tokens.map((line) => line.map((t) => t.content).join("")).join("\n"),
+    grown,
+    "every character has to be rendered even while the line is throttled",
+  );
+
+  const settled = await new Promise<HighlightResult>((resolve) => {
+    const immediate = plugin.highlight(
+      { code: grown, language, themes: THEMES },
+      resolve,
+    );
+    if (immediate) {
+      // Still inside the refresh interval: the trailing refresh resolves it.
+      setTimeout(() => {
+        const after = plugin.highlight({ code: grown, language, themes: THEMES });
+        if (after) resolve(after);
+      }, 400);
+    }
+  });
+  const full = await reference(grown, "json");
+  assert.deepEqual(settled.tokens, full.tokens);
+});
+
+test("a throttled multiline tail matches the previous plugin", async () => {
+  const plugin = createCodePlugin({ themes: THEMES });
+  const language = "python" as HighlightOptions["language"];
+  const initial = Array.from(
+    { length: 90 },
+    (_, index) => `value_${index} = ${index}  # a completed Python line`,
+  ).join("\n");
+  const first = await highlightOnce(plugin, {
+    code: initial,
+    language,
+    themes: THEMES,
+  });
+  const grown = `${initial}\nnext_value = 100\nand_more = 101`;
+  const throttled = await highlightOnce(plugin, {
+    code: grown,
+    language,
+    themes: THEMES,
+  });
+
+  const keptLineCount = initial.split("\n").length - 1;
+  const expectedTail = grown
+    .split("\n")
+    .slice(keptLineCount)
+    .map((content) => [{ content, offset: 0 }]);
+  assert.deepEqual(throttled.tokens, [
+    ...first.tokens.slice(0, keptLineCount),
+    ...expectedTail,
+  ]);
+});

--- a/studio/frontend/tests/code-plugin-incremental.test.ts
+++ b/studio/frontend/tests/code-plugin-incremental.test.ts
@@ -430,9 +430,9 @@ test("a shorter prefix sibling fence keeps the longer one highlighted", async ()
   );
 });
 
-// Neither of these can close a fence: whitespace carries no marker, and a
-// closing run never mixes backticks with tildes.
-for (const suffix of ["   ", "`~"]) {
+// None of these can close a fence: whitespace carries no marker, a closing run
+// never mixes backticks with tildes, and a closer starts its own line.
+for (const suffix of ["   ", "`~", "```"]) {
   test(`a sibling ending in ${JSON.stringify(suffix)} keeps its own entry`, async () => {
     const plugin = createCodePlugin({ themes: THEMES });
     const language = "json" as HighlightOptions["language"];
@@ -535,6 +535,44 @@ test("an unchanged fence does not cancel an identical sibling's refresh", async 
     (latest as HighlightResult | null)?.tokens,
     (await reference(grown, "python")).tokens,
     "the growing fence must still receive its refresh",
+  );
+});
+
+test("a block that keeps failing to tokenize does not fill the cache", async () => {
+  const plugin = createCodePlugin({ themes: THEMES });
+  const language = "python" as HighlightOptions["language"];
+  // createHighlighter accepts a nameless theme, but codeToTokens cannot find it
+  // again, so tokenization throws after the grammar has loaded.
+  const nameless = [{ settings: [] }, { settings: [] }] as unknown as [
+    ThemeInput,
+    ThemeInput,
+  ];
+  const kept = "kept = 1\n";
+  const first = await highlightOnce(plugin, {
+    code: kept,
+    language,
+    themes: THEMES,
+  });
+
+  const originalError = console.error;
+  try {
+    console.error = () => {};
+    for (let render = 0; render < 600; render += 1) {
+      plugin.highlight({ code: "broken = 1\n", language, themes: nameless });
+      // The first render only queues; let the grammar load resolve.
+      if (render === 0) await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+  } finally {
+    console.error = originalError;
+  }
+
+  // A successful update runs eviction. Failed fences must not have crowded the
+  // cache past MAX_FENCES in the meantime.
+  await highlightOnce(plugin, { code: "later = 2\n", language, themes: THEMES });
+  assert.equal(
+    plugin.highlight({ code: kept, language, themes: THEMES }),
+    first,
+    "a failing block evicted a healthy fence",
   );
 });
 

--- a/studio/frontend/tests/markdown-streaming-scheduling.test.ts
+++ b/studio/frontend/tests/markdown-streaming-scheduling.test.ts
@@ -19,6 +19,12 @@ const source = ts.createSourceFile(
   ts.ScriptKind.TSX,
 );
 
+const REASONING_PATH = new URL(
+  "../src/components/assistant-ui/reasoning.tsx",
+  import.meta.url,
+);
+const reasoningSource = readFileSync(REASONING_PATH, "utf8");
+
 function findImmediateUpdateConfig(): ts.ObjectLiteralExpression | null {
   let config: ts.ObjectLiteralExpression | null = null;
   const visit = (node: ts.Node): void => {
@@ -106,19 +112,34 @@ test("token updates keep Streamdown's expensive configuration props stable", () 
   assert.ok(streamdown, "chat <Streamdown> is missing");
 
   for (const [attribute, constant] of [
-    ["plugins", "STREAMDOWN_PLUGINS"],
+    ["plugins", "isStreaming ? STREAMDOWN_STREAMING_PLUGINS : STREAMDOWN_PLUGINS"],
     ["controls", "STREAMDOWN_CONTROLS"],
     ["shikiTheme", "STREAMDOWN_SHIKI_THEME"],
   ]) {
     assert.equal(
-      jsxAttribute(streamdown, attribute)?.initializer?.getText(source),
-      `{${constant}}`,
+      jsxAttribute(streamdown, attribute)
+        ?.initializer?.getText(source)
+        .replace(/\s+/g, ""),
+      `{${constant}}`.replace(/\s+/g, ""),
       `${attribute} must retain object identity while raw tokens arrive`,
     );
   }
 });
 
-test("stream updates are paint-coalesced without a time or length throttle", () => {
+
+test("syntax highlighting is deferred until the stream completes", () => {
+  const markdownSource = source.getText();
+  assert.ok(
+    markdownSource.includes(
+      "const STREAMDOWN_STREAMING_PLUGINS = { math, mermaid }",
+    ),
+  );
+  assert.ok(
+    markdownSource.includes("!isStreaming && shouldVirtualizeCode(block)"),
+  );
+});
+
+test("stream updates are paint-aligned and rate-limited", () => {
   const markdownSource = source.getText();
   const hookStart = markdownSource.indexOf(
     "function useCoalescedStreamingText",
@@ -128,12 +149,32 @@ test("stream updates are paint-coalesced without a time or length throttle", () 
   const hook = markdownSource.slice(hookStart, hookEnd);
 
   assert.ok(hook.includes("requestAnimationFrame"));
-  assert.ok(!hook.includes("setTimeout"));
+  assert.ok(hook.includes("setTimeout"));
+  assert.ok(hook.includes("STREAM_RENDER_INTERVAL_MS"));
 
   // A running message can be replaced rather than appended to, as the audio
   // path does when it swaps its placeholder for the player, so holding the last
   // painted text has to be gated on the new text extending it.
   assert.ok(hook.includes("text.startsWith(displayed.text)"));
+});
+
+test("virtual rows avoid nested transformed layers and browser culling", () => {
+  const markdownSource = source.getText();
+  const codeStart = markdownSource.indexOf("function VirtualizedCodeLines");
+  const markdownStart = markdownSource.indexOf("function VirtualizedMarkdown");
+  const implementationEnd = markdownSource.indexOf(
+    "const MarkdownTextImpl",
+    markdownStart,
+  );
+  assert.ok(
+    codeStart >= 0 && markdownStart > codeStart && implementationEnd > markdownStart,
+  );
+  const virtualized = markdownSource.slice(codeStart, implementationEnd);
+
+  assert.ok(virtualized.includes("top: virtualLine.start - scrollMargin"));
+  assert.ok(virtualized.includes("top: virtualBlock.start - scrollMargin"));
+  assert.ok(!virtualized.includes("transform: `translateY"));
+  assert.ok(!virtualized.includes('contentVisibility: "auto"'));
 });
 
 test("streaming reparses only the active Markdown tail", () => {
@@ -162,4 +203,54 @@ test("dropping retained blocks moves Streamdown's render identity", () => {
     jsxAttribute(streamdown, "key")?.initializer?.getText(source),
     "{`${messageId}:${incrementalCache.renderGeneration}`}",
   );
+});
+
+
+test("an active code fence stays plain until the closing fence arrives", () => {
+  const markdownSource = source.getText();
+  const blockStart = markdownSource.indexOf("function StreamdownBlockContent");
+  const blockEnd = markdownSource.indexOf("const StreamdownBlock = memo", blockStart);
+  assert.ok(blockStart >= 0 && blockEnd > blockStart);
+  const block = markdownSource.slice(blockStart, blockEnd);
+
+  const plainBranch = block.indexOf(
+    "(props.isIncomplete || activeStreamingBlock) && codeFence",
+  );
+  const completedBranch = block.indexOf("if (codeFence)");
+  assert.ok(plainBranch >= 0, "the live tail needs a plain streaming branch");
+  assert.ok(
+    completedBranch > plainBranch,
+    "the plain branch must run before syntax-highlighted code rendering",
+  );
+  assert.ok(block.includes("<StreamingPlainCodeBlock"));
+  assert.ok(markdownSource.includes('data-streaming-code="true"'));
+
+  assert.ok(markdownSource.includes("ActiveStreamingBlockContext.Provider"));
+  assert.ok(!markdownSource.includes("value={isStreaming && isLast}"));
+  assert.ok(markdownSource.includes("value={isStreaming}"));
+});
+
+test("reasoning streams stable plain-text chunks and formats Markdown on completion", () => {
+  const markdownSource = source.getText();
+  assert.ok(markdownSource.includes("data-streaming-plain-text"));
+  assert.ok(markdownSource.includes("PLAIN_STREAM_CHUNK_SIZE"));
+  assert.ok(markdownSource.includes("const blocks = plainStreaming"));
+  assert.ok(reasoningSource.includes("PlainStreamingMarkdownContext.Provider"));
+});
+
+
+test("reasoning scroll pinning happens before paint and only user input can reattach", () => {
+  const textStart = reasoningSource.indexOf("function ReasoningText");
+  const textEnd = reasoningSource.indexOf("const ReasoningImpl", textStart);
+  assert.ok(textStart >= 0 && textEnd > textStart);
+  const implementation = reasoningSource.slice(textStart, textEnd);
+
+  assert.ok(implementation.includes("pointerScrollIntentRef"));
+  assert.ok(implementation.includes("hasUserScrollIntent && movedTowardBottom"));
+  assert.ok(implementation.includes("!pointerScrollIntentRef.current"));
+  assert.ok(!implementation.includes("requestAnimationFrame"));
+  assert.ok(implementation.includes("[overflow-anchor:none]"));
+
+  assert.ok(implementation.includes("max-h-64 overflow-y-auto"));
+  assert.ok(!implementation.includes('streaming ? "max-h-64'));
 });

--- a/studio/frontend/tests/streaming-render-schedule.test.ts
+++ b/studio/frontend/tests/streaming-render-schedule.test.ts
@@ -415,3 +415,32 @@ test("a fenced block larger than the budget keeps retaining", () => {
     parseMarkdownIntoBlocks(remend(input)),
   );
 });
+
+test("completed block snapshots keep identity while only the live tail changes", () => {
+  const source = paragraphs(80);
+  const cache = new IncrementalMarkdownCache();
+  const first = cache.update(source);
+  assert.ok(first.blocks.length > 100);
+
+  const stablePrefix = first.blocks.slice(0, 80);
+  const next = cache.update(`${source}live tail`);
+  assert.deepEqual(
+    next.blocks.map((block) => block.content),
+    next.parseMarkdownIntoBlocks(next.markdown),
+  );
+  for (let index = 0; index < stablePrefix.length; index += 1) {
+    assert.equal(next.blocks[index], stablePrefix[index]);
+  }
+});
+
+test("a replacement invalidates snapshots instead of reusing stale identities", () => {
+  const cache = new IncrementalMarkdownCache();
+  const first = cache.update(paragraphs(40, "first"));
+  const replacement = cache.update(paragraphs(40, "replacement"));
+
+  assert.notEqual(replacement.blocks[0]?.id, first.blocks[0]?.id);
+  assert.deepEqual(
+    replacement.blocks.map((block) => block.content),
+    parseMarkdownIntoBlocks(remend(paragraphs(40, "replacement"))),
+  );
+});


### PR DESCRIPTION
Depends on #8935 by @oobabooga.

This is a stacked follow-up built directly on #8935 head `f961eb48a4db2cbc3fe405dad2d6b1a3b4db38db`; it preserves all of that PR's commits and authorship. While #8935 is open, please review only `f961eb48..d695635d7` (the three commits added here). After #8935 merges, I will update this branch so GitHub shows only the follow-up diff.

## Why this follow-up

#8935 substantially reduces Shiki tokenization work by resuming from saved grammar state, but long reasoning streams still accumulated Markdown parsing, React reconciliation, mounted DOM, highlighted spans, layout work, and WebKit memory.

The retained #8935 Tauri run fell from about 60 FPS at 20K reasoning characters to 16.4 FPS at 90K, while WebKit RSS reached 3.04 GB at 290 seconds. A follow-up ablation that suppressed Shiki still fell from 63.9 FPS to 12.7 FPS by 151 seconds, confirming syntax highlighting was only one contributor.

## What changed

- Incrementally retain completed Markdown blocks and reparse only the active rollback tail during ordinary append-only answer streams.
- Virtualize large Markdown block lists and large code blocks, retaining stable block/line identities and bounded mounted DOM.
- Keep #8935's incremental Shiki cache and prevent pending callbacks from updating an unmounted fence.
- Stabilize reasoning autoscroll so user detachment is preserved and bottom pinning happens before paint.
- Stream long reasoning as stable 4 KiB plain-text chunks, so only the final chunk changes while generation is active.
- On reasoning completion, render the full formatted Markdown through the bounded/virtualized renderer.
- Update assistant-ui runtime packages and their compatibility APIs in a separate first commit.

## Streaming reasoning tradeoff

Reasoning remains plain text while it is actively streaming. Markdown markers and backticks may therefore be visible temporarily. Full Markdown formatting and syntax highlighting appear when reasoning completes.

This is intentional: keeping live Streamdown while disabling most syntax highlighting still degraded to 12.7 FPS. The plain-chunk path was the only tested path that kept the application responsive through a long real Tauri generation.

Normal answer Markdown continues through the incremental formatted block renderer.

## Tauri/WebKit evidence

Same cached Qwen 27B model and in-page WebKit instrumentation:

| Path | Early FPS | Late FPS | Reasoning size | Reasoning DOM | Mutations |
|---|---:|---:|---:|---:|---:|
| Full live Markdown follow-up | 64.5 | 3.6 at 304 s (2.9 minimum) | run-dependent | 466 elements at final sample | 577,120 |
| Live Markdown, Shiki suppressed | 63.9 | 12.7 at 151 s | run-dependent | 49 elements at final sample | 54,079 |
| Stable plain reasoning chunks | 64.1 | 57.0 at 221 s (56.0 minimum) | 64,473 chars | 17 elements | 2,052 |

The plain-chunk run remained approximately 56–64 FPS through 220 seconds. At 60 seconds, a separate bounded confirmation held 61.9–63.7 FPS with 20,726 reasoning characters and seven reasoning descendants.

No benchmark artifacts are included in the source diff.

## Commits added after #8935

1. `b89420a2e` — Studio: update assistant runtime dependencies
2. `afc81e24c` — Studio: bound streaming Markdown rendering
3. `d695635d7` — Studio: stabilize long reasoning streams

## Checks

- Focused streaming/highlighting tests: 52 passed
- Full frontend test suite: passed
- Typecheck: passed
- Production frontend build: passed
- `git diff --check f961eb48..HEAD`: passed