### PR TITLE
Repair the contract tests #8943 left behind on main

### DIFF
--- a/tests/studio/test_model_picker_contracts.py
+++ b/tests/studio/test_model_picker_contracts.py
@@ -1915,6 +1915,12 @@ def test_adopting_a_resident_model_reseeds_the_slot_and_batch_controls():
     So `slotsModelChanged` is `hydratingExistingModel` with nothing subtracted, which is
     how every other load param at this call site already treats a changed checkpoint or
     variant.
+
+    Reseeding is only safe because the same flag gates the remembered lookup: it does
+    not blank the control, it re-reads THIS model's own saved config through
+    resolveResidentInitialConfig. That is what makes #8943 right rather than merely
+    different, so it is asserted here too -- a future change that reseeds without
+    re-reading would take the user's saved slot count away for real.
     """
     status = " ".join(_read("features/chat/lib/apply-inference-status-to-store.ts").split())
     assert "const slotsModelChanged = hydratingExistingModel;" in status
@@ -1928,6 +1934,11 @@ def test_adopting_a_resident_model_reseeds_the_slot_and_batch_controls():
     assert "loadedNParallel: status.requested_parallel_slots," in status
     # The batch pair is told the same thing, from the same local, so the two cannot drift.
     assert "modelChanged: slotsModelChanged," in status
+    # And the reseed re-reads this model's remembered config rather than blanking.
+    assert (
+        "status.is_gguf && (slotsUnseeded || batchesUnseeded || slotsModelChanged) "
+        "? resolveResidentInitialConfig(checkpointId, status.gguf_variant ?? null)" in status
+    ), "the model-change reseed must feed the remembered lookup, or it discards the saved config"
 
     # And the rollback that makes the reseed necessary is still ordered before the
     # hydration it protects, in the adopt path.

--- a/tests/studio/test_model_picker_contracts.py
+++ b/tests/studio/test_model_picker_contracts.py
@@ -1934,8 +1934,9 @@ def test_adopting_a_resident_model_reseeds_the_slot_and_batch_controls():
     runtime = _read("features/chat/hooks/use-chat-model-runtime.ts")
     adopt = runtime[runtime.index("const confirmedStatus = await getInferenceStatus()") :]
     adopt = adopt[: adopt.index("void refreshContextUsage(")]
-    assert adopt.index("restorePreviousConfig();") < adopt.index(
-        "applyActiveModelStatusToStore(confirmedStatus, {"
+    assert (
+        adopt.index("restorePreviousConfig();")
+        < adopt.index("applyActiveModelStatusToStore(confirmedStatus, {")
     ), "the rollback must precede the hydration, or the staged snapshot wins over the resident status"
 
 

--- a/tests/studio/test_model_picker_contracts.py
+++ b/tests/studio/test_model_picker_contracts.py
@@ -1902,40 +1902,41 @@ def test_hydration_clears_the_slot_baseline_for_a_slotless_model():
     assert "status.requested_parallel_slots !== null && {" not in src
 
 
-def test_hydration_keeps_the_slot_control_when_readopting_the_running_model():
-    """`hydratingExistingModel` is true whenever the incoming status disagrees with what
-    this tab last recorded, which includes RE-ADOPTING a model the tab never lost: the
-    resident-adopt branch restores the model's own per-model config and only then
-    hydrates, passing the EXTERNAL id as `previousCheckpoint`."""
+def test_adopting_a_resident_model_reseeds_the_slot_and_batch_controls():
+    """The controls in the store belong to the model that just LEFT, so adoption reseeds them.
+
+    This test used to assert the opposite, through a `readoptingSameModel` option that
+    suppressed the reseed on re-adoption. #8943 removed the option deliberately and said
+    why: the adopt path rolls the outgoing model's config back into the store before it
+    hydrates, so the slot and batch controls sitting there describe the model the tab
+    just left. Suppressing the reseed left a resident model running 4 slots showing the
+    outgoing count, and the next Apply saved that over it.
+
+    So `slotsModelChanged` is `hydratingExistingModel` with nothing subtracted, which is
+    how every other load param at this call site already treats a changed checkpoint or
+    variant.
+    """
     status = " ".join(_read("features/chat/lib/apply-inference-status-to-store.ts").split())
-    assert (
-        "const slotsModelChanged = hydratingExistingModel && !options.readoptingSameModel;"
-        in status
-    )
+    assert "const slotsModelChanged = hydratingExistingModel;" in status
+    # Nothing may reintroduce a same-model exemption without this test being rewritten.
+    assert "readoptingSameModel" not in status
     assert "...(seedLoadParams && slotsModelChanged && { nParallel: null })," in status
     # Never a slot-count proxy for "same model".
     assert "prevState.loadedNParallel === (status.requested_parallel_slots" not in status
     # The baseline seed stays ungated, or a rollback after a tab reload restores
     # the model at the server default slots.
     assert "loadedNParallel: status.requested_parallel_slots," in status
+    # The batch pair is told the same thing, from the same local, so the two cannot drift.
+    assert "modelChanged: slotsModelChanged," in status
 
-    runtime = " ".join(_read("features/chat/hooks/use-chat-model-runtime.ts").split())
-    resident = runtime.split("if (!forceReload && isExternalModelId(selectedCheckpoint)) {", 1)[
-        1
-    ].split("const stopDecision", 1)[0]
-    # What makes the scenario reachable: the branch restores the model's own
-    # config, then hydrates against the external id.
-    assert "applyPerModelConfigToRuntime(selection.previousConfig);" in resident
-    assert "previousCheckpoint: selectedCheckpoint," in resident
-    # Only reachable because the branch matched the id AND the variant first.
-    assert "resolveInferenceCheckpointId(residentStatus) === modelId" in resident
-    assert "readoptingSameModel: true," in resident
-    # The refresh() hydrate must NOT claim it: there the model really can change.
-    poll = runtime.split("setModels(listRes.models.map(toChatModelSummary));", 1)[1].split(
-        "} else if (!statusRes.active_model", 1
-    )[0]
-    assert "applyActiveModelStatusToStore(statusRes, {" in poll
-    assert "readoptingSameModel" not in poll
+    # And the rollback that makes the reseed necessary is still ordered before the
+    # hydration it protects, in the adopt path.
+    runtime = _read("features/chat/hooks/use-chat-model-runtime.ts")
+    adopt = runtime[runtime.index("const confirmedStatus = await getInferenceStatus()") :]
+    adopt = adopt[: adopt.index("void refreshContextUsage(")]
+    assert adopt.index("restorePreviousConfig();") < adopt.index(
+        "applyActiveModelStatusToStore(confirmedStatus, {"
+    ), "the rollback must precede the hydration, or the staged snapshot wins over the resident status"
 
 
 def test_parallel_slots_are_never_recorded_for_a_diffusion_load():
@@ -2285,19 +2286,24 @@ def test_auth_retries_tag_transport_failures_like_the_first_attempt():
     assert "throw asTransportFailure(err);" in first
 
 
-def test_external_readoption_drops_a_pin_taken_for_another_model():
+def test_adoption_takes_its_own_pin_before_moving_the_checkpoint():
     """Status polling skips its own pin clearing while an external provider is selected, so the
-    re-adoption branch can adopt a resident the pin was never taken for and Apply would reload the
-    old model. The branch has to clear it itself."""
+    adoption branch can adopt a resident the pin was never taken for and Apply would reload the
+    old model. The branch has to write the pin itself.
+
+    It used to clear the pin to null. #8943 replaced that with adopting THIS pick's pin by
+    the rule a completed load writes it -- the load path, or null where that is just the id
+    -- which drops a stale pin the same way and additionally keeps a pinned cached row
+    loadable. The ordering requirement is unchanged and is what this still pins.
+    """
     src = _read("features/chat/hooks/use-chat-model-runtime.ts")
-    branch = src.split("if (!forceReload && isExternalModelId(selectedCheckpoint))", 1)[1]
-    branch = branch.split("const stopDecision = await confirmStopRunningChatsIfNeeded", 1)[0]
-    assert "activeLoadId !== modelId" in branch
-    assert "setState({ activeLoadId: null })" in branch
-    # Clearing must land before the checkpoint moves, so nothing reads the pair half updated.
-    assert branch.index("activeLoadId: null") < branch.index(
-        ".setCheckpoint(modelId, residentStatus.gguf_variant)"
-    ), "the pin must be cleared before the checkpoint is adopted"
+    branch = src[src.index("const confirmedStatus = await getInferenceStatus()") :]
+    branch = branch[: branch.index("void refreshContextUsage(")]
+    assert "activeLoadId: loadPath === modelId ? null : loadPath," in branch
+    # Landing before the checkpoint moves, so nothing reads the pair half updated.
+    assert branch.index("activeLoadId: loadPath === modelId ? null : loadPath,") < branch.index(
+        ".setCheckpoint(modelId, confirmedStatus.gguf_variant)"
+    ), "the pin must be written before the checkpoint is adopted"
 
 
 def test_only_gguf_configs_are_mirrored_to_the_server():

--- a/tests/studio/test_new_chat_context_recount.py
+++ b/tests/studio/test_new_chat_context_recount.py
@@ -468,7 +468,6 @@ __FAST_PATH__
 """
 
 
-
 def _rendered_effects(effects: list[tuple[list[str], str]]) -> str:
     blocks = []
     for deps, body in effects:

--- a/tests/studio/test_new_chat_context_recount.py
+++ b/tests/studio/test_new_chat_context_recount.py
@@ -110,11 +110,25 @@ def _store_reducers() -> str:
 
 
 def _resident_fast_path() -> str:
-    """loadModel's already-resident branch, verbatim."""
+    """The adoption tail of loadModel's already-resident branch, verbatim.
+
+    The tail, not the whole branch. #8943 grew that branch from a short early return
+    into the residency decision itself: it now reconciles GPU pools, speculative type,
+    managed llama flags and per-model config through 17 imported collaborators. Slicing
+    all of it would mean stubbing all 17, and a replay under 17 stubs asserts against a
+    construction rather than the product.
+
+    What this file is about is what happens AFTER the model is judged resident --
+    setCheckpoint blanks the bar, this path returns before the post-load recount, and a
+    mounted thread does not rerun its history loader -- so the slice starts where the
+    adoption is confirmed. The decision itself is `adoptable`, stubbed below, and it is
+    covered on its own by the resident-model-match and resident-config-match suites that
+    #8943 added beside it.
+    """
     return slice_between(
         read(RUNTIME),
-        "      // Picking an external provider leaves the local model resident",
-        "      // Every chat decodes on the llama-server this load replaces",
+        "          const confirmedStatus = await getInferenceStatus().catch(() => null);",
+        "      // Block queue materialization before taking the cancellation snapshot.",
     )
 
 
@@ -224,6 +238,13 @@ function shouldAdvanceQueuedSettingsEpoch(
 
 const actions: any = {
 __STORE_REDUCERS__
+  // Not the real reducer. The adoption tail calls this only to restore the outgoing
+  // maxSeqLength cap, which this file does not measure, while the real one reaches
+  // preset policy, per-turn counters and loaded-context bookkeeping -- a web of
+  // collaborators that would have to be stubbed to replay a merge. The merge is what
+  // the tail depends on, so the merge is what this does.
+  setParams: (params: any) =>
+    set((current: any) => ({ params: { ...current.params, ...params } })),
 };
 
 export const useChatRuntimeStore: any = {
@@ -394,19 +415,27 @@ __EFFECTS__
 
 HARNESS_RESIDENT = """
 
-// Picking the model that never left memory takes loadModel's already-resident branch,
-// sliced verbatim below. It returns early, so it is replayed inside its own function
-// with the surrounding load machinery stubbed.
+// Adopting the model that never left memory returns before the post-load recount, so
+// the adoption tail is sliced verbatim below and replayed inside its own function with
+// the surrounding load machinery stubbed. Every stub is either derived exactly as the
+// source derives it, or a collaborator this file does not measure.
 export async function adoptResidentModel(props: any): Promise<void> {
-  const forceReload = false;
   const selection = "pick";
   const modelId: string = props.modelId;
-  const ggufVariant = props.ggufVariant ?? null;
+  const loadPath: string = props.modelId;
+  const selectedCheckpoint: string | null = state.params?.checkpoint ?? null;
+  const previousGgufVariant: string | null = state.activeGgufVariant ?? null;
+  const pendingConfig: any = undefined;
+  // The residency decision itself, which this file does not measure: the caller has
+  // already seeded the status it wants adopted. resident-model-match.test.ts and
+  // resident-config-match.test.ts cover the real predicate.
+  const adoptable = (_status: any): boolean => true;
   const bailIfLoadInFlight = (): boolean => false;
-  const applyPerModelConfigToRuntime = (_config: any): void => {};
+  const restorePreviousConfig = (): void => {};
   const getInferenceStatus = async (): Promise<any> => props.residentStatus;
-  const resolveInferenceCheckpointId = (status: any): string | null =>
-    status?.active_model ?? null;
+  const reconcilePersistedGpuIds = (ids: any): any => ids;
+  const sameGpuSelection = (a: any, b: any): boolean =>
+    JSON.stringify(a ?? null) === JSON.stringify(b ?? null);
   // The real hydration writes the whole status; the recount only reads the window.
   const applyActiveModelStatusToStore = (status: any, _options: any): void => {
     set({
@@ -414,9 +443,30 @@ export async function adoptResidentModel(props: any): Promise<void> {
     });
   };
   const syncModelCapabilities = (_id: string, _status: any): void => {};
+  const applyPerModelConfigToRuntime = (_config: any, _options?: any): void => {};
+  // Only maxSeqLength is read here, and only to decide whether the pick names a cap.
+  // The real normalizer snaps and clamps, which this file does not measure; what it
+  // must keep is the null-for-absent answer the branch below tests against.
+  const normalizeMaxSeqLength = (value: unknown): number | null =>
+    typeof value === "number" && Number.isFinite(value) && value > 0 ? value : null;
+  const defaultInferenceParams: any = { maxSeqLength: null };
+  const forceReload = false;
+  const nativePathToken = undefined;
+  const residentStatus: any = props.residentStatus;
+  const readServerWideReloadHints = async (): Promise<boolean> => false;
+  // The two conditions the sliced tail sits inside, restated so the braces balance and
+  // the entry conditions are visible rather than implied. Both are the same judgement:
+  // this pick needs no load. The caller decides it by seeding the resident status.
+  if (!forceReload && !nativePathToken) {
+    if (
+      residentStatus &&
+      adoptable(residentStatus) &&
+      !(await readServerWideReloadHints())
+    ) {
 __FAST_PATH__
 }
 """
+
 
 
 def _rendered_effects(effects: list[tuple[list[str], str]]) -> str:

--- a/tests/studio/test_new_chat_context_recount.py
+++ b/tests/studio/test_new_chat_context_recount.py
@@ -112,18 +112,12 @@ def _store_reducers() -> str:
 def _resident_fast_path() -> str:
     """The adoption tail of loadModel's already-resident branch, verbatim.
 
-    The tail, not the whole branch. #8943 grew that branch from a short early return
-    into the residency decision itself: it now reconciles GPU pools, speculative type,
-    managed llama flags and per-model config through 17 imported collaborators. Slicing
-    all of it would mean stubbing all 17, and a replay under 17 stubs asserts against a
-    construction rather than the product.
-
-    What this file is about is what happens AFTER the model is judged resident --
-    setCheckpoint blanks the bar, this path returns before the post-load recount, and a
-    mounted thread does not rerun its history loader -- so the slice starts where the
-    adoption is confirmed. The decision itself is `adoptable`, stubbed below, and it is
-    covered on its own by the resident-model-match and resident-config-match suites that
-    #8943 added beside it.
+    The tail, not the whole branch: #8943 grew that branch into the residency decision
+    itself, reaching 17 imported collaborators, and a replay under 17 stubs asserts
+    against a construction rather than the product. This file is about what happens
+    AFTER the model is judged resident, so the slice starts where adoption is confirmed.
+    The decision is `adoptable`, stubbed below and covered by the resident-model-match
+    and resident-config-match suites #8943 added.
     """
     return slice_between(
         read(RUNTIME),
@@ -415,10 +409,10 @@ __EFFECTS__
 
 HARNESS_RESIDENT = """
 
-// Adopting the model that never left memory returns before the post-load recount, so
-// the adoption tail is sliced verbatim below and replayed inside its own function with
-// the surrounding load machinery stubbed. Every stub is either derived exactly as the
-// source derives it, or a collaborator this file does not measure.
+// Adopting a model that never left memory returns before the post-load recount, so the
+// tail is sliced verbatim below and replayed with the load machinery stubbed. Each stub
+// is either derived as the source derives it, or a collaborator this file does not
+// measure.
 export async function adoptResidentModel(props: any): Promise<void> {
   const selection = "pick";
   const modelId: string = props.modelId;
@@ -426,9 +420,8 @@ export async function adoptResidentModel(props: any): Promise<void> {
   const selectedCheckpoint: string | null = state.params?.checkpoint ?? null;
   const previousGgufVariant: string | null = state.activeGgufVariant ?? null;
   const pendingConfig: any = undefined;
-  // The residency decision itself, which this file does not measure: the caller has
-  // already seeded the status it wants adopted. resident-model-match.test.ts and
-  // resident-config-match.test.ts cover the real predicate.
+  // The residency decision, which this file does not measure: the caller seeds the
+  // status it wants adopted. resident-model-match.test.ts covers the real predicate.
   const adoptable = (_status: any): boolean => true;
   const bailIfLoadInFlight = (): boolean => false;
   const restorePreviousConfig = (): void => {};
@@ -444,9 +437,8 @@ export async function adoptResidentModel(props: any): Promise<void> {
   };
   const syncModelCapabilities = (_id: string, _status: any): void => {};
   const applyPerModelConfigToRuntime = (_config: any, _options?: any): void => {};
-  // Only maxSeqLength is read here, and only to decide whether the pick names a cap.
-  // The real normalizer snaps and clamps, which this file does not measure; what it
-  // must keep is the null-for-absent answer the branch below tests against.
+  // Only maxSeqLength is read, and only to decide whether the pick names a cap. The
+  // real normalizer also snaps and clamps; what matters here is null-for-absent.
   const normalizeMaxSeqLength = (value: unknown): number | null =>
     typeof value === "number" && Number.isFinite(value) && value > 0 ? value : null;
   const defaultInferenceParams: any = { maxSeqLength: null };
@@ -454,9 +446,8 @@ export async function adoptResidentModel(props: any): Promise<void> {
   const nativePathToken = undefined;
   const residentStatus: any = props.residentStatus;
   const readServerWideReloadHints = async (): Promise<boolean> => false;
-  // The two conditions the sliced tail sits inside, restated so the braces balance and
-  // the entry conditions are visible rather than implied. Both are the same judgement:
-  // this pick needs no load. The caller decides it by seeding the resident status.
+  // The two conditions the tail sits inside, restated so the braces balance and the
+  // entry conditions are visible. Both say the same thing: this pick needs no load.
   if (!forceReload && !nativePathToken) {
     if (
       residentStatus &&


### PR DESCRIPTION
Repair the contract tests #8943 left behind, and correct one that pinned the old behaviour

Repo tests (CPU) has been failing on main since #8943 landed: 54 tests across
tests/studio/test_new_chat_context_recount.py and
tests/studio/test_model_picker_contracts.py. #9026, immediately before it, is
clean. Nothing in the batch of test fixes merged after it caused this.

Three separate problems, and the third is a behaviour change, not a stale anchor.

1. test_new_chat_context_recount.py sliced loadModel's already-resident branch by
   a comment #8943 rewrote, so 52 tests died at the slice. That branch is also no
   longer a short early return: it now IS the residency decision, reconciling GPU
   pools, speculative type, managed llama flags and per-model config through 17
   imported collaborators. Re-anchoring to the top of it would have meant stubbing
   all 17, and a replay under 17 stubs asserts against a construction rather than
   the product.

   The slice is now the adoption TAIL, which is what this file is about: what
   happens after the model is judged resident. The judgement itself is stubbed as
   `adoptable` and is covered on its own by the resident-model-match and
   resident-config-match suites #8943 added. Six stubs, each derived exactly the
   way the source derives it, and the two enclosing conditions restated so the
   entry conditions are visible rather than implied.

   setParams is stubbed to the merge the tail depends on rather than sliced: the
   real reducer reaches preset policy, per-turn counters and loaded-context
   bookkeeping, none of which this file measures.

2. test_external_readoption_drops_a_pin_taken_for_another_model sliced on a
   condition that no longer exists. The contract survives in a better form: the
   branch used to clear the pin to null, and now adopts this pick's own pin by the
   rule a completed load writes it, which drops a stale pin the same way and keeps
   a pinned cached row loadable. Rewritten against that, ordering requirement
   unchanged.

3. test_hydration_keeps_the_slot_control_when_readopting_the_running_model was
   asserting behaviour #8943 deliberately reversed, and #8943 is right. Its commit
   says why: the adopt path rolls the outgoing model's config back into the store
   before it hydrates, so the slot and batch controls sitting there belong to the
   model the tab just left, and suppressing the reseed left a resident model
   running 4 slots showing the outgoing count for the next Apply to save over it.
   The test now pins the new contract, asserts nothing reintroduces a same-model
   exemption, and additionally pins the ordering that makes the reseed necessary:
   the rollback must precede the hydration.

  tests/studio: 3896 passed, 4 skipped
  reinstating the readoptingSameModel guard, or moving the rollback after the
  hydration, fails the rewritten test
