### PR TITLE
Keep the killed-by-signal exit status when release() fails

### DIFF
--- a/.github/scripts/kaggle_t4_ci/launch.py
+++ b/.github/scripts/kaggle_t4_ci/launch.py
@@ -936,7 +936,30 @@ def _install_release_handlers(release: Callable[[], None]) -> None:
 
     def _release_and_die(signum, _frame):
         _log(f"received signal {signum}; deleting kernels before exiting")
-        release()
+        try:
+            release()
+        except BaseException as exc:  # noqa: BLE001
+            # A raise here used to leave the handler entirely: it propagated
+            # into whatever the main thread was doing, main()'s `except
+            # BaseException` caught it, and finish() called release() a second
+            # time. If that second call worked -- which it does when the first
+            # failure was transient, an OSError out of a subprocess spawn on a
+            # loaded runner being the observed one -- main RETURNED 0 and a
+            # cancelled job reported success. Deleting is best effort; the exit
+            # status is not, so the raise is logged and the death below still
+            # happens. One retry, because the failure this catches is transient
+            # by nature and the kernel is billing meanwhile.
+            _log(f"release() failed under signal {signum}: {type(exc).__name__}: {exc}")
+            try:
+                release()
+            except BaseException as retry_exc:  # noqa: BLE001
+                # Nothing more to try in-process. The slug stays in the
+                # registry, so the orphan sweep at the next launch reclaims it,
+                # which is the same path a kill -9 leaves behind.
+                _log(
+                    f"release() failed again: {type(retry_exc).__name__}: {retry_exc}. "
+                    f"The kernels stay in the registry for the next launcher's sweep"
+                )
         # Die of the original signal rather than exiting 0, so the status
         # still reads "killed by signal N". A CI system treats a 0 from a
         # cancelled job as a completed one.

--- a/.github/scripts/kaggle_t4_ci/launch.py
+++ b/.github/scripts/kaggle_t4_ci/launch.py
@@ -939,23 +939,19 @@ def _install_release_handlers(release: Callable[[], None]) -> None:
         try:
             release()
         except BaseException as exc:  # noqa: BLE001
-            # A raise here used to leave the handler entirely: it propagated
-            # into whatever the main thread was doing, main()'s `except
-            # BaseException` caught it, and finish() called release() a second
-            # time. If that second call worked -- which it does when the first
-            # failure was transient, an OSError out of a subprocess spawn on a
-            # loaded runner being the observed one -- main RETURNED 0 and a
-            # cancelled job reported success. Deleting is best effort; the exit
-            # status is not, so the raise is logged and the death below still
-            # happens. One retry, because the failure this catches is transient
-            # by nature and the kernel is billing meanwhile.
+            # A raise here used to propagate into the main thread, where main()'s
+            # `except BaseException` caught it and finish() called release() again.
+            # A transient first failure (the observed one: an OSError from a
+            # subprocess spawn on a loaded runner) therefore ended in main
+            # RETURNING 0, and the cancelled job read as completed. Deleting is
+            # best effort, the exit status is not. Retried once, since the kernel
+            # is billing meanwhile.
             _log(f"release() failed under signal {signum}: {type(exc).__name__}: {exc}")
             try:
                 release()
             except BaseException as retry_exc:  # noqa: BLE001
-                # Nothing more to try in-process. The slug stays in the
-                # registry, so the orphan sweep at the next launch reclaims it,
-                # which is the same path a kill -9 leaves behind.
+                # Nothing more to try in-process: the slug stays in the registry
+                # for the next launch's orphan sweep, as after a kill -9.
                 _log(
                     f"release() failed again: {type(retry_exc).__name__}: {retry_exc}. "
                     f"The kernels stay in the registry for the next launcher's sweep"

--- a/tests/kaggle/test_launch_cleanup.py
+++ b/tests/kaggle/test_launch_cleanup.py
@@ -75,6 +75,15 @@ def _runner(tmp_path: Path, body: str) -> subprocess.Popen:
     )
 
 
+# Every wait below is a guard against a launcher that never dies, not a latency
+# target. These tests each drive a real subprocess that spawns further processes,
+# and the repo suite now runs four of them at once on a four-core runner, where
+# the SIGINT case was observed to need more than 30 seconds of wall clock purely
+# to be scheduled. A wedged launcher still fails this, just later; a starved one
+# no longer reports a defect it does not have.
+_DEATH_BUDGET_SEC = 120
+
+
 def _await_ready(proc: subprocess.Popen) -> None:
     """Wait for the runner to say it is where the test wants it, past whatever
     the launcher logged on the way there."""
@@ -382,7 +391,7 @@ def test_a_signalled_launcher_deletes_its_kernels(tmp_path, signame):
     try:
         _await_ready(proc)
         proc.send_signal(getattr(signal, signame))
-        proc.wait(timeout = 30)
+        proc.wait(timeout = _DEATH_BUDGET_SEC)
     finally:
         if proc.poll() is None:
             proc.kill()
@@ -400,13 +409,61 @@ def test_the_exit_status_still_says_it_was_killed(tmp_path):
     try:
         _await_ready(proc)
         proc.send_signal(signal.SIGTERM)
-        proc.wait(timeout = 30)
+        proc.wait(timeout = _DEATH_BUDGET_SEC)
     finally:
         if proc.poll() is None:
             proc.kill()
     assert (
         proc.returncode == -signal.SIGTERM
     ), f"expected death by SIGTERM, got returncode {proc.returncode}"
+
+
+def test_the_exit_status_survives_a_release_that_fails(tmp_path):
+    """The way the status above was actually observed to come back 0.
+
+    A delete that raises inside the handler used to propagate out of it, into
+    whatever the main thread was doing. main() catches BaseException and reaches
+    release() by RETURNING, so a first delete that failed and a second that
+    worked -- which is what a transient OSError out of a subprocess spawn on a
+    loaded runner looks like -- turned a cancelled run into `exit 0`. Caught on
+    a contended runner, not by inspection, and reproduced by failing the first
+    delete only.
+
+    The kernel is still deleted, by the retry. What this pins is that the exit
+    status does not depend on the delete having worked at all.
+    """
+    proc = _runner(
+        tmp_path,
+        _waiting_launcher(tmp_path / "out").replace(
+            "        launch.main()",
+            "\n".join(
+                [
+                    "        _calls = []",
+                    "        _real_delete = launch.delete_kernel",
+                    "        def _flaky_delete(slug):",
+                    "            _calls.append(slug)",
+                    "            if len(_calls) == 1:",
+                    "                raise OSError(11, 'Resource temporarily unavailable')",
+                    "            return _real_delete(slug)",
+                    "        launch.delete_kernel = _flaky_delete",
+                    "        launch.main()",
+                ]
+            ),
+        ),
+    )
+    try:
+        _await_ready(proc)
+        proc.send_signal(signal.SIGTERM)
+        proc.wait(timeout = _DEATH_BUDGET_SEC)
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+    assert proc.returncode == -signal.SIGTERM, (
+        f"a release() that raised turned SIGTERM into returncode {proc.returncode}; "
+        f"a cancelled job would read as a completed one"
+    )
+    # And the retry still did the budget control the handler exists for.
+    assert any("me/k-1" in c for c in _deletions(tmp_path))
 
 
 def test_an_unhandled_exception_still_deletes(tmp_path):
@@ -430,7 +487,7 @@ def test_an_unhandled_exception_still_deletes(tmp_path):
         raise RuntimeError("boom")
     """,
     )
-    proc.wait(timeout = 30)
+    proc.wait(timeout = _DEATH_BUDGET_SEC)
     assert any("me/k-1" in c for c in _deletions(tmp_path))
     assert json.loads((tmp_path / "inflight.json").read_text()) == []
 
@@ -450,7 +507,7 @@ def test_kill_9_leaves_it_for_the_sweep(tmp_path):
     try:
         assert proc.stdout.readline().strip() == "READY"
         proc.send_signal(signal.SIGKILL)
-        proc.wait(timeout = 30)
+        proc.wait(timeout = _DEATH_BUDGET_SEC)
     finally:
         if proc.poll() is None:
             proc.kill()
@@ -580,7 +637,7 @@ def test_a_kernel_pushed_before_the_signal_is_still_deleted(tmp_path):
     try:
         _await_ready(proc)
         proc.send_signal(signal.SIGTERM)
-        proc.wait(timeout = 30)
+        proc.wait(timeout = _DEATH_BUDGET_SEC)
     finally:
         if proc.poll() is None:
             proc.kill()

--- a/tests/kaggle/test_launch_cleanup.py
+++ b/tests/kaggle/test_launch_cleanup.py
@@ -83,6 +83,15 @@ def _runner(tmp_path: Path, body: str) -> subprocess.Popen:
 # no longer reports a defect it does not have.
 _DEATH_BUDGET_SEC = 120
 
+# The stall the launcher sits in while a test signals it. It has to OUTLAST the
+# budget above, which is the whole reason both are named here rather than written
+# at each site. A handler that swallows its signal leaves the process asleep and
+# then resuming: with a stall shorter than the budget it wakes up, runs finish(),
+# deletes the kernels through the ordinary path and exits inside the wait, so the
+# deletion tests pass on a launcher that ignored the signal entirely. Reported on
+# this PR, against a first version that raised the budget past a 60 second stall.
+_STALL_SEC = 900
+
 
 def _await_ready(proc: subprocess.Popen) -> None:
     """Wait for the runner to say it is where the test wants it, past whatever
@@ -373,7 +382,7 @@ def _waiting_launcher(outdir: Path) -> str:
             "        launch.push = _push",
             "        def _wait(*a, **kw):",
             "            print('READY', flush=True)",
-            "            time.sleep(60)",
+            "            time.sleep(%d)" % _STALL_SEC,
             "        launch.wait = _wait",
             "        sys.argv = ['launch.py', '--notebook', 'a.ipynb', '--user', 'me',",
             f"                    '--outdir', {str(outdir)!r}]",
@@ -400,6 +409,13 @@ def test_a_signalled_launcher_deletes_its_kernels(tmp_path, signame):
     ), f"{signame} left the kernel behind; it would bill to its ceiling"
     # And the registry agrees, so no later sweep chases a kernel that is gone.
     assert json.loads((tmp_path / "inflight.json").read_text()) == []
+    # On the signal path, not on the way out of an ordinary run. Without this the
+    # deletion above is satisfied by finish() doing its usual work, so a handler
+    # that swallowed the signal and let the launcher finish normally would pass.
+    assert proc.returncode == -getattr(signal, signame), (
+        f"the kernel was deleted, but the launcher exited {proc.returncode} rather than "
+        f"dying of {signame}, so nothing here says the signal is what did it"
+    )
 
 
 def test_the_exit_status_still_says_it_was_killed(tmp_path):
@@ -466,6 +482,22 @@ def test_the_exit_status_survives_a_release_that_fails(tmp_path):
     assert any("me/k-1" in c for c in _deletions(tmp_path))
 
 
+def test_the_stall_outlasts_the_death_budget():
+    """The relationship the signal tests rest on, asserted rather than assumed.
+
+    Every test above signals a launcher that is asleep and then waits a bounded
+    time for it to die. If the sleep is the shorter of the two, a launcher that
+    ignored its signal simply wakes up, finishes normally and exits inside the
+    wait, and the tests pass on the behaviour they exist to forbid. Tuning either
+    number without the other is easy and silent, so this fails instead.
+    """
+    assert _STALL_SEC > _DEATH_BUDGET_SEC, (
+        f"a launcher that swallows its signal wakes after {_STALL_SEC}s and exits "
+        f"normally inside the {_DEATH_BUDGET_SEC}s wait, so the signal tests would "
+        f"pass without any signal handling at all"
+    )
+
+
 def test_an_unhandled_exception_still_deletes(tmp_path):
     """atexit covers the path no signal handler sees.
 
@@ -501,7 +533,7 @@ def test_kill_9_leaves_it_for_the_sweep(tmp_path):
         f"""
         launch._inflight_add("me/k-9")
         print("READY", flush=True)
-        time.sleep(60)
+        time.sleep({_STALL_SEC})
     """,
     )
     try:
@@ -626,7 +658,7 @@ def test_a_kernel_pushed_before_the_signal_is_still_deleted(tmp_path):
             "            if len(calls) == 1:",
             "                return {'ok': True, 'slug': slug, 'attempts': attempted}",
             "            print('READY', flush=True)",
-            "            time.sleep(60)",
+            "            time.sleep(%d)" % _STALL_SEC,
             "        launch.push = _push",
             "        sys.argv = ['launch.py', '--notebook', 'a.ipynb', '--notebook', 'b.ipynb',",
             f"                    '--user', 'me', '--outdir', {str(tmp_path / 'out')!r}]",

--- a/tests/kaggle/test_launch_cleanup.py
+++ b/tests/kaggle/test_launch_cleanup.py
@@ -75,21 +75,15 @@ def _runner(tmp_path: Path, body: str) -> subprocess.Popen:
     )
 
 
-# Every wait below is a guard against a launcher that never dies, not a latency
-# target. These tests each drive a real subprocess that spawns further processes,
-# and the repo suite now runs four of them at once on a four-core runner, where
-# the SIGINT case was observed to need more than 30 seconds of wall clock purely
-# to be scheduled. A wedged launcher still fails this, just later; a starved one
-# no longer reports a defect it does not have.
+# A guard against a launcher that never dies, not a latency target: four of these
+# subprocess tests now run at once on a four-core runner, where the SIGINT case
+# was observed to need over 30 seconds purely to be scheduled.
 _DEATH_BUDGET_SEC = 120
 
-# The stall the launcher sits in while a test signals it. It has to OUTLAST the
-# budget above, which is the whole reason both are named here rather than written
-# at each site. A handler that swallows its signal leaves the process asleep and
-# then resuming: with a stall shorter than the budget it wakes up, runs finish(),
-# deletes the kernels through the ordinary path and exits inside the wait, so the
-# deletion tests pass on a launcher that ignored the signal entirely. Reported on
-# this PR, against a first version that raised the budget past a 60 second stall.
+# How long the launcher stalls while a test signals it. Must OUTLAST the budget
+# above: a handler that swallows its signal leaves the process asleep and then
+# resuming, so a shorter stall lets it wake, run finish(), delete through the
+# ordinary path and exit inside the wait, passing every deletion test.
 _STALL_SEC = 900
 
 
@@ -409,9 +403,8 @@ def test_a_signalled_launcher_deletes_its_kernels(tmp_path, signame):
     ), f"{signame} left the kernel behind; it would bill to its ceiling"
     # And the registry agrees, so no later sweep chases a kernel that is gone.
     assert json.loads((tmp_path / "inflight.json").read_text()) == []
-    # On the signal path, not on the way out of an ordinary run. Without this the
-    # deletion above is satisfied by finish() doing its usual work, so a handler
-    # that swallowed the signal and let the launcher finish normally would pass.
+    # On the signal path, not on the way out of an ordinary run: finish() satisfies
+    # the deletion above on its own, so a swallowed signal would pass without this.
     assert proc.returncode == -getattr(signal, signame), (
         f"the kernel was deleted, but the launcher exited {proc.returncode} rather than "
         f"dying of {signame}, so nothing here says the signal is what did it"
@@ -437,16 +430,12 @@ def test_the_exit_status_still_says_it_was_killed(tmp_path):
 def test_the_exit_status_survives_a_release_that_fails(tmp_path):
     """The way the status above was actually observed to come back 0.
 
-    A delete that raises inside the handler used to propagate out of it, into
-    whatever the main thread was doing. main() catches BaseException and reaches
-    release() by RETURNING, so a first delete that failed and a second that
-    worked -- which is what a transient OSError out of a subprocess spawn on a
-    loaded runner looks like -- turned a cancelled run into `exit 0`. Caught on
-    a contended runner, not by inspection, and reproduced by failing the first
-    delete only.
-
-    The kernel is still deleted, by the retry. What this pins is that the exit
-    status does not depend on the delete having worked at all.
+    A delete raising inside the handler propagated into the main thread, where
+    main() catches BaseException and reaches release() by RETURNING. A first
+    delete that failed and a second that worked -- a transient OSError from a
+    subprocess spawn on a loaded runner -- therefore turned a cancelled run into
+    `exit 0`. The retry still deletes the kernel; what this pins is that the exit
+    status does not depend on the delete having worked.
     """
     proc = _runner(
         tmp_path,
@@ -485,11 +474,9 @@ def test_the_exit_status_survives_a_release_that_fails(tmp_path):
 def test_the_stall_outlasts_the_death_budget():
     """The relationship the signal tests rest on, asserted rather than assumed.
 
-    Every test above signals a launcher that is asleep and then waits a bounded
-    time for it to die. If the sleep is the shorter of the two, a launcher that
-    ignored its signal simply wakes up, finishes normally and exits inside the
-    wait, and the tests pass on the behaviour they exist to forbid. Tuning either
-    number without the other is easy and silent, so this fails instead.
+    If the sleep is the shorter of the two, a launcher that ignored its signal
+    wakes up, finishes normally and exits inside the wait, so the tests pass on
+    the behaviour they forbid. Tuning one number without the other is silent.
     """
     assert _STALL_SEC > _DEATH_BUDGET_SEC, (
         f"a launcher that swallows its signal wakes after {_STALL_SEC}s and exits "


### PR DESCRIPTION
A cancelled Kaggle launcher could report success.

`_install_release_handlers` deletes every kernel the process pushed and then re-raises the signal, so the status still reads "killed by signal N" rather than 0, because a CI system treats a 0 from a cancelled job as a completed one. The delete was outside any `try`. A raise there propagated out of the handler into whatever the main thread was doing, `main()`'s `except BaseException` caught it, and `finish()` called `release()` a second time. When that second call worked, `main` RETURNED 0.

That second call working is the normal case for the failure it recovers from: a transient `OSError` out of a subprocess spawn on a loaded runner.

## How it was found

`tests/kaggle/test_launch_cleanup.py::test_the_exit_status_still_says_it_was_killed` failed on a staging runner with `expected death by SIGTERM, got returncode 0`, alongside a 30 second timeout in the SIGINT case. The repo CPU suite now runs four workers on a four-core runner, which is the contention that surfaced it. Neither test is flaky and neither was pinned to old behaviour; both were reporting the defect.

Reproduced deterministically by failing the first delete only, which gives returncode 0 in place of -15.

## The fix

The delete becomes best effort, retried once, and the death by signal happens either way. If both attempts fail, the slugs stay in the registry and the orphan sweep at the next launch reclaims them, which is the path a `kill -9` already takes.

A new test pins it: with a delete that raises the first time, the process must still die of the signal, and the kernel must still be deleted by the retry. Reverting the handler change fails that test alone, all 21 pass with it.

## Also

The subprocess waits in that suite move from a bare `30` to a named `_DEATH_BUDGET_SEC = 120`. They exist to catch a launcher that never dies, not to enforce latency, and four of these tests can now run at once on four cores. A wedged launcher still fails, just later; a starved one no longer reports a defect it does not have.