### PR TITLE
Restore crypto.randomUUID before the Studio bundle evaluates

### DIFF
--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -2481,6 +2481,16 @@ _ARTIFACT_PREVIEW_FRAME_HTML = """<!doctype html>
           installStorageFallback("localStorage");
           installStorageFallback("sessionStorage");
         };
+        // crypto.randomUUID() is secure-context only, so a canvas reached over
+        // plain http loses it. Inlined rather than shared with the app's
+        // crypto-boot.js because the strict CSP here allows no external script.
+        const installRandomUUIDFallback = () => {
+          if (!window.crypto || typeof crypto.randomUUID === "function") return;
+          const randomByte = () => crypto.getRandomValues(new Uint8Array(1))[0];
+          crypto.randomUUID = () =>
+            "10000000-1000-4000-8000-100000000000".replace(/[018]/g, (c) =>
+              (+c ^ (randomByte() & (15 >> (+c / 4)))).toString(16));
+        };
         // Stamp the load this frame was served for. A report still in flight
         // when the canvas is swapped would otherwise be read as the new one's.
         const loadVersion = new URLSearchParams(location.search).get("v") || "";
@@ -2501,6 +2511,8 @@ _ARTIFACT_PREVIEW_FRAME_HTML = """<!doctype html>
           document.addEventListener("securitypolicyviolation", reportBlocked, true);
         };
         installStorageFallbacks();
+        // Survives the document.open() in render(), so once is enough.
+        installRandomUUIDFallback();
         window.addEventListener("message", (event) => {
           const data = event.data;
           if (!data || data.type !== "unsloth:artifact-html" || typeof data.html !== "string") return;

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -2481,9 +2481,8 @@ _ARTIFACT_PREVIEW_FRAME_HTML = """<!doctype html>
           installStorageFallback("localStorage");
           installStorageFallback("sessionStorage");
         };
-        // crypto.randomUUID() is secure-context only, so a canvas reached over
-        // plain http loses it. Inlined rather than shared with the app's
-        // crypto-boot.js because the strict CSP here allows no external script.
+        // randomUUID is unavailable in this opaque HTTP context. The strict CSP
+        // forbids crypto-boot.js, so install the same fallback inline.
         const installRandomUUIDFallback = () => {
           if (!window.crypto || typeof crypto.randomUUID === "function") return;
           const randomByte = () => crypto.getRandomValues(new Uint8Array(1))[0];

--- a/studio/backend/tests/test_artifact_preview_frame_csp.py
+++ b/studio/backend/tests/test_artifact_preview_frame_csp.py
@@ -126,10 +126,7 @@ def test_the_permissive_policy_widens_every_hostless_scheme_but_one():
 
 
 def test_the_shell_restores_randomuuid_for_insecure_canvases():
-    # crypto.randomUUID() is secure-context only, so a canvas served over plain
-    # http throws without it. The shell's script cannot run from here, so these
-    # pin its parts and the behaviour is checked in a browser: it defers to a
-    # real randomUUID, assigns one when there is none, and runs the installer.
+    # This test cannot execute the shell, so pin the fallback's required pieces.
     shell = inf_mod._ARTIFACT_PREVIEW_FRAME_HTML
     assert 'typeof crypto.randomUUID === "function"' in shell
     assert "crypto.randomUUID = () =>" in shell
@@ -137,10 +134,7 @@ def test_the_shell_restores_randomuuid_for_insecure_canvases():
 
 
 def test_the_shell_generator_matches_the_app_one():
-    # The strict CSP allows no external script, so the app's crypto-boot.js
-    # cannot be reused here and its generator is duplicated. Pin the copies to
-    # each other: crypto-boot.js is the one with a golden test over its output,
-    # so a change made to only one side would otherwise go uncovered here.
+    # The strict CSP forbids sharing crypto-boot.js, so keep both copies aligned.
     shell = inf_mod._ARTIFACT_PREVIEW_FRAME_HTML
     boot = (
         pathlib.Path(__file__).resolve().parents[2] / "frontend/public/crypto-boot.js"

--- a/studio/backend/tests/test_artifact_preview_frame_csp.py
+++ b/studio/backend/tests/test_artifact_preview_frame_csp.py
@@ -8,6 +8,7 @@ reaches this route now, fenced HTML included, not just approved render_html
 output."""
 
 import asyncio
+import pathlib
 
 import routes.inference as inf_mod
 
@@ -122,3 +123,31 @@ def test_the_permissive_policy_widens_every_hostless_scheme_but_one():
         if scheme not in value.split()
     }
     assert gaps == {"worker-src": "data:"}
+
+
+def test_the_shell_restores_randomuuid_for_insecure_canvases():
+    # crypto.randomUUID() is secure-context only, so a canvas served over plain
+    # http throws without it. The shell's script cannot run from here, so these
+    # pin its parts and the behaviour is checked in a browser: it defers to a
+    # real randomUUID, assigns one when there is none, and runs the installer.
+    shell = inf_mod._ARTIFACT_PREVIEW_FRAME_HTML
+    assert 'typeof crypto.randomUUID === "function"' in shell
+    assert "crypto.randomUUID = () =>" in shell
+    assert "installRandomUUIDFallback();" in shell
+
+
+def test_the_shell_generator_matches_the_app_one():
+    # The strict CSP allows no external script, so the app's crypto-boot.js
+    # cannot be reused here and its generator is duplicated. Pin the copies to
+    # each other: crypto-boot.js is the one with a golden test over its output,
+    # so a change made to only one side would otherwise go uncovered here.
+    shell = inf_mod._ARTIFACT_PREVIEW_FRAME_HTML
+    boot = (
+        pathlib.Path(__file__).resolve().parents[2] / "frontend/public/crypto-boot.js"
+    ).read_text(encoding = "utf-8")
+    for expression in (
+        '"10000000-1000-4000-8000-100000000000".replace(/[018]/g, (c) =>',
+        "(+c ^ (randomByte() & (15 >> (+c / 4)))).toString(16)",
+    ):
+        assert expression in boot
+        assert expression in shell

--- a/studio/frontend/index.html
+++ b/studio/frontend/index.html
@@ -8,8 +8,7 @@
     <link rel="icon" type="image/png" href="/favicon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Unsloth</title>
-    <!-- External because the backend CSP is script-src 'self', and non-async so
-         both run before the deferred module entry. -->
+    <!-- Classic boot scripts satisfy script-src 'self' and run before modules. -->
     <script src="/crypto-boot.js"></script>
     <script src="/theme-boot.js"></script>
   </head>

--- a/studio/frontend/index.html
+++ b/studio/frontend/index.html
@@ -8,8 +8,9 @@
     <link rel="icon" type="image/png" href="/favicon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Unsloth</title>
-    <!-- Applies the stored theme before the bundle loads; external file
-         because the backend CSP is script-src 'self'. -->
+    <!-- External because the backend CSP is script-src 'self', and non-async so
+         both run before the deferred module entry. -->
+    <script src="/crypto-boot.js"></script>
     <script src="/theme-boot.js"></script>
   </head>
   <body>

--- a/studio/frontend/public/crypto-boot.js
+++ b/studio/frontend/public/crypto-boot.js
@@ -1,11 +1,9 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-// `crypto.randomUUID()` is secure-context only, so it is missing over plain http
-// on a LAN address, and the bundle calls it as its modules evaluate. The head is
-// ahead of the whole module graph; external because the CSP is script-src 'self'.
+// randomUUID is unavailable on insecure HTTP origins. Install it before the
+// module graph, which may call it during evaluation.
 if (globalThis.crypto && typeof globalThis.crypto.randomUUID !== "function") {
-  // Bound in the block so this classic script leaks no global.
   const cryptoRef = globalThis.crypto;
   const randomByte = () =>
     typeof cryptoRef.getRandomValues === "function"

--- a/studio/frontend/public/crypto-boot.js
+++ b/studio/frontend/public/crypto-boot.js
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// `crypto.randomUUID()` is secure-context only, so it is missing over plain http
+// on a LAN address, and the bundle calls it as its modules evaluate. The head is
+// ahead of the whole module graph; external because the CSP is script-src 'self'.
+if (globalThis.crypto && typeof globalThis.crypto.randomUUID !== "function") {
+  // Bound in the block so this classic script leaks no global.
+  const cryptoRef = globalThis.crypto;
+  const randomByte = () =>
+    typeof cryptoRef.getRandomValues === "function"
+      ? cryptoRef.getRandomValues(new Uint8Array(1))[0]
+      : Math.floor(Math.random() * 256);
+
+  cryptoRef.randomUUID = () =>
+    "10000000-1000-4000-8000-100000000000".replace(/[018]/g, (c) =>
+      (+c ^ (randomByte() & (15 >> (+c / 4)))).toString(16),
+    );
+}

--- a/studio/frontend/smoke-ansi.html
+++ b/studio/frontend/smoke-ansi.html
@@ -2,6 +2,8 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <!-- Same boot script index.html loads; see public/crypto-boot.js. -->
+    <script src="/crypto-boot.js"></script>
     <title>strip-ansi smoke</title>
   </head>
   <body>

--- a/studio/frontend/smoke-ansi.html
+++ b/studio/frontend/smoke-ansi.html
@@ -2,7 +2,6 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <!-- Same boot script index.html loads; see public/crypto-boot.js. -->
     <script src="/crypto-boot.js"></script>
     <title>strip-ansi smoke</title>
   </head>

--- a/studio/frontend/smoke-autoscroll.html
+++ b/studio/frontend/smoke-autoscroll.html
@@ -2,7 +2,6 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <!-- Same boot script index.html loads; see public/crypto-boot.js. -->
     <script src="/crypto-boot.js"></script>
     <title>chat autoscroll smoke</title>
   </head>

--- a/studio/frontend/smoke-autoscroll.html
+++ b/studio/frontend/smoke-autoscroll.html
@@ -2,6 +2,8 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <!-- Same boot script index.html loads; see public/crypto-boot.js. -->
+    <script src="/crypto-boot.js"></script>
     <title>chat autoscroll smoke</title>
   </head>
   <body>

--- a/studio/frontend/smoke-research.html
+++ b/studio/frontend/smoke-research.html
@@ -2,7 +2,6 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <!-- Same boot script index.html loads; see public/crypto-boot.js. -->
     <script src="/crypto-boot.js"></script>
     <title>deep research freeze smoke</title>
   </head>

--- a/studio/frontend/smoke-research.html
+++ b/studio/frontend/smoke-research.html
@@ -2,6 +2,8 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <!-- Same boot script index.html loads; see public/crypto-boot.js. -->
+    <script src="/crypto-boot.js"></script>
     <title>deep research freeze smoke</title>
   </head>
   <body>

--- a/studio/frontend/src/main.tsx
+++ b/studio/frontend/src/main.tsx
@@ -11,26 +11,6 @@ import { initializeLocale } from "./i18n";
 import { isTauri } from "./lib/api-base";
 import { watchOverlayScrollbarGutter } from "./lib/overlay-scrollbar";
 
-const globalCrypto = globalThis.crypto as Crypto | undefined;
-
-if (globalCrypto && typeof globalCrypto.randomUUID !== "function") {
-  // Some envs ship `crypto` without `randomUUID()`. Provide a best-effort v4
-  // UUID using `getRandomValues` when available.
-  const cryptoRef = globalCrypto;
-
-  function getRandomByte(): number {
-    if (typeof cryptoRef.getRandomValues === "function") {
-      return cryptoRef.getRandomValues(new Uint8Array(1))[0];
-    }
-    return Math.floor(Math.random() * 256);
-  }
-
-  cryptoRef.randomUUID = (() =>
-    "10000000-1000-4000-8000-100000000000".replace(/[018]/g, (c) =>
-      (+c ^ (getRandomByte() & (15 >> (+c / 4)))).toString(16),
-    )) as Crypto["randomUUID"];
-}
-
 const rootElement = document.getElementById("root");
 if (!rootElement) {
   throw new Error("Root element not found");

--- a/studio/frontend/tests/crypto-uuid-boot.test.ts
+++ b/studio/frontend/tests/crypto-uuid-boot.test.ts
@@ -2,7 +2,7 @@
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
+import { readFileSync, readdirSync } from "node:fs";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
 import { createContext, runInContext } from "node:vm";
@@ -12,14 +12,18 @@ const read = (relative: string): string =>
 
 const HTML_COMMENT = /<!--[\s\S]*?-->/g;
 const POLYFILL_TAG = /<script\b[^>]*src="\/crypto-boot\.js"[^>]*>/;
-const ENTRY_TAG = /<script\b[^>]*src="\/src\/main\.tsx"[^>]*>/;
+const ENTRY_TAG = /<script\b[^>]*\btype="module"[^>]*>/;
+const APP_ENTRY = /<script\b[^>]*src="\/src\/main\.tsx"[^>]*>/;
 const ASYNC_ATTR = /\basync\b/;
 const UUID_V4 =
   /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
 
-// Markup, not a parsed DOM: catches the tag being dropped, moved or made async,
-// not every way of making it inert. Comments would otherwise satisfy that.
-const MARKUP = read("../index.html").replace(HTML_COMMENT, "");
+// Every HTML entry, so a new page cannot ship without the polyfill. Markup, not
+// a parsed DOM: catches a tag dropped, moved or made async, not every way of
+// making it inert. Comments would otherwise satisfy that.
+const PAGES = readdirSync(new URL("../", import.meta.url))
+  .filter((name) => name.endsWith(".html"))
+  .map((name) => [name, read(`../${name}`).replace(HTML_COMMENT, "")] as const);
 const BOOT_SCRIPT = read("../public/crypto-boot.js");
 
 function boot(cryptoStub: unknown): { randomUUID?: () => string } {
@@ -30,22 +34,28 @@ function boot(cryptoStub: unknown): { randomUUID?: () => string } {
   return sandbox.crypto;
 }
 
-test("index.html loads the polyfill before the module entry", () => {
-  const polyfill = MARKUP.search(POLYFILL_TAG);
-  const entry = MARKUP.search(ENTRY_TAG);
-  assert.ok(polyfill !== -1, "index.html must load /crypto-boot.js");
-  assert.ok(entry !== -1, "index.html must load the module entry");
-  assert.ok(
-    polyfill < entry,
-    "the polyfill must be parsed before the module entry",
-  );
+test("every page loads the polyfill before its module entry", () => {
+  assert.ok(PAGES.length > 0, "no HTML entries found");
+  // Generalising the entry pattern would otherwise accept index.html pointing
+  // at another page's harness.
+  const index = PAGES.find(([name]) => name === "index.html")?.[1];
+  assert.match(index ?? "", APP_ENTRY, "index.html must keep the app entry");
+  for (const [name, markup] of PAGES) {
+    const polyfill = markup.search(POLYFILL_TAG);
+    const entry = markup.search(ENTRY_TAG);
+    assert.ok(polyfill !== -1, `${name} must load /crypto-boot.js`);
+    assert.ok(entry !== -1, `${name} must load a module entry`);
+    assert.ok(polyfill < entry, `${name} loads the polyfill too late`);
+  }
 });
 
-test("neither the polyfill nor the entry opts out of ordered execution", () => {
+test("no page lets the polyfill or its entry opt out of ordered execution", () => {
   // The entry is deferred, so anything above it runs first and `defer` here
   // would too. `async` leaves that ordering and lets the entry win.
-  assert.doesNotMatch(POLYFILL_TAG.exec(MARKUP)?.[0] ?? "", ASYNC_ATTR);
-  assert.doesNotMatch(ENTRY_TAG.exec(MARKUP)?.[0] ?? "", ASYNC_ATTR);
+  for (const [name, markup] of PAGES) {
+    assert.doesNotMatch(POLYFILL_TAG.exec(markup)?.[0] ?? "", ASYNC_ATTR, name);
+    assert.doesNotMatch(ENTRY_TAG.exec(markup)?.[0] ?? "", ASYNC_ATTR, name);
+  }
 });
 
 // Arbitrary and non-sequential, so no substitute source reproduces it.

--- a/studio/frontend/tests/crypto-uuid-boot.test.ts
+++ b/studio/frontend/tests/crypto-uuid-boot.test.ts
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { createContext, runInContext } from "node:vm";
+
+const read = (relative: string): string =>
+  readFileSync(fileURLToPath(new URL(relative, import.meta.url)), "utf8");
+
+const HTML_COMMENT = /<!--[\s\S]*?-->/g;
+const POLYFILL_TAG = /<script\b[^>]*src="\/crypto-boot\.js"[^>]*>/;
+const ENTRY_TAG = /<script\b[^>]*src="\/src\/main\.tsx"[^>]*>/;
+const ASYNC_ATTR = /\basync\b/;
+const UUID_V4 =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+// Markup, not a parsed DOM: catches the tag being dropped, moved or made async,
+// not every way of making it inert. Comments would otherwise satisfy that.
+const MARKUP = read("../index.html").replace(HTML_COMMENT, "");
+const BOOT_SCRIPT = read("../public/crypto-boot.js");
+
+function boot(cryptoStub: unknown): { randomUUID?: () => string } {
+  const sandbox = { crypto: cryptoStub } as {
+    crypto: { randomUUID?: () => string };
+  };
+  runInContext(BOOT_SCRIPT, createContext(sandbox));
+  return sandbox.crypto;
+}
+
+test("index.html loads the polyfill before the module entry", () => {
+  const polyfill = MARKUP.search(POLYFILL_TAG);
+  const entry = MARKUP.search(ENTRY_TAG);
+  assert.ok(polyfill !== -1, "index.html must load /crypto-boot.js");
+  assert.ok(entry !== -1, "index.html must load the module entry");
+  assert.ok(
+    polyfill < entry,
+    "the polyfill must be parsed before the module entry",
+  );
+});
+
+test("neither the polyfill nor the entry opts out of ordered execution", () => {
+  // The entry is deferred, so anything above it runs first and `defer` here
+  // would too. `async` leaves that ordering and lets the entry win.
+  assert.doesNotMatch(POLYFILL_TAG.exec(MARKUP)?.[0] ?? "", ASYNC_ATTR);
+  assert.doesNotMatch(ENTRY_TAG.exec(MARKUP)?.[0] ?? "", ASYNC_ATTR);
+});
+
+// Arbitrary and non-sequential, so no substitute source reproduces it.
+const STREAM = [
+  0x9e, 0x37, 0x79, 0xb9, 0x7f, 0x4a, 0x7c, 0x15, 0xf3, 0x9c, 0xc0, 0x60, 0x5c,
+  0xed, 0xc8, 0x34,
+];
+
+let cursor = 0;
+const generate = boot({
+  getRandomValues: (array: Uint8Array) => {
+    for (let i = 0; i < array.length; i += 1) {
+      array[i] = STREAM[cursor % STREAM.length];
+      cursor += 1;
+    }
+    return array;
+  },
+}).randomUUID;
+
+test("the drawn bytes are what the UUID is built from", () => {
+  // The generator is pure given its bytes, so a golden value catches masking,
+  // folding, or an ignored stream. It certifies no entropy — no unit test can —
+  // and a generator rewrite is expected to change it.
+  cursor = 0;
+  const uuid = generate?.() ?? "";
+  assert.equal(uuid, "f799fac5-2c00-4cd8-8e79-8fac53c00cd8");
+  assert.match(uuid, UUID_V4);
+});
+
+test("the polyfill leaves a real randomUUID alone", () => {
+  const native = () => "native";
+  const patched = boot({
+    randomUUID: native,
+    getRandomValues: () => undefined,
+  });
+  assert.equal(patched.randomUUID, native);
+});

--- a/studio/frontend/tests/crypto-uuid-boot.test.ts
+++ b/studio/frontend/tests/crypto-uuid-boot.test.ts
@@ -18,9 +18,7 @@ const ASYNC_ATTR = /\basync\b/;
 const UUID_V4 =
   /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
 
-// Every HTML entry, so a new page cannot ship without the polyfill. Markup, not
-// a parsed DOM: catches a tag dropped, moved or made async, not every way of
-// making it inert. Comments would otherwise satisfy that.
+// Check every HTML entry as raw markup so comments cannot satisfy the patterns.
 const PAGES = readdirSync(new URL("../", import.meta.url))
   .filter((name) => name.endsWith(".html"))
   .map((name) => [name, read(`../${name}`).replace(HTML_COMMENT, "")] as const);
@@ -36,8 +34,6 @@ function boot(cryptoStub: unknown): { randomUUID?: () => string } {
 
 test("every page loads the polyfill before its module entry", () => {
   assert.ok(PAGES.length > 0, "no HTML entries found");
-  // Generalising the entry pattern would otherwise accept index.html pointing
-  // at another page's harness.
   const index = PAGES.find(([name]) => name === "index.html")?.[1];
   assert.match(index ?? "", APP_ENTRY, "index.html must keep the app entry");
   for (const [name, markup] of PAGES) {
@@ -50,15 +46,12 @@ test("every page loads the polyfill before its module entry", () => {
 });
 
 test("no page lets the polyfill or its entry opt out of ordered execution", () => {
-  // The entry is deferred, so anything above it runs first and `defer` here
-  // would too. `async` leaves that ordering and lets the entry win.
   for (const [name, markup] of PAGES) {
     assert.doesNotMatch(POLYFILL_TAG.exec(markup)?.[0] ?? "", ASYNC_ATTR, name);
     assert.doesNotMatch(ENTRY_TAG.exec(markup)?.[0] ?? "", ASYNC_ATTR, name);
   }
 });
 
-// Arbitrary and non-sequential, so no substitute source reproduces it.
 const STREAM = [
   0x9e, 0x37, 0x79, 0xb9, 0x7f, 0x4a, 0x7c, 0x15, 0xf3, 0x9c, 0xc0, 0x60, 0x5c,
   0xed, 0xc8, 0x34,
@@ -76,9 +69,7 @@ const generate = boot({
 }).randomUUID;
 
 test("the drawn bytes are what the UUID is built from", () => {
-  // The generator is pure given its bytes, so a golden value catches masking,
-  // folding, or an ignored stream. It certifies no entropy — no unit test can —
-  // and a generator rewrite is expected to change it.
+  // A fixed byte stream catches changes to UUID masking and folding.
   cursor = 0;
   const uuid = generate?.() ?? "";
   assert.equal(uuid, "f799fac5-2c00-4cd8-8e79-8fac53c00cd8");


### PR DESCRIPTION
Fixes #9046

## The bug

Studio's web UI renders a blank page when it is reached over plain `http://` at a LAN address — `unsloth studio -H 0.0.0.0`, then opening `http://<LAN-IP>:<PORT>` from another machine. The console shows:

```text
Uncaught TypeError: crypto.randomUUID is not a function
    <anonymous> http://<LAN-IP>:<PORT>/assets/settings-*.js
```

`crypto.randomUUID()` is a secure-context API, so it is absent on a page served over plain http from a LAN address. `localhost` is a secure context by definition, which is why local runs never hit this.

## Root cause

The frontend has 67 `crypto.randomUUID()` references, and exactly one of them runs at module scope rather than inside a function:

```ts
// studio/frontend/src/features/chat/stores/chat-runtime-store.ts
const threadSettingsWriter = crypto.randomUUID();
```

`main.tsx` already carried a `randomUUID` polyfill, but in the module **body**. A module's static imports are evaluated before its own body, and the path from the entry to that store is entirely static (`main.tsx` → `app/app` → `app/router` → `routes/chat` → `features/chat` → `chat-runtime-store`, where `routes/chat.tsx` uses a plain import rather than `lazyRouteComponent`). So the throwing module always evaluated first and the polyfill could never precede it, wherever in `main.tsx` it was placed. The throw kills the entry chunk, React never mounts, and the page stays blank.

## The fix

Move the polyfill out of the bundle and into an external classic script loaded from `index.html` ahead of the module entry, which is the one position that runs before module evaluation. The generator itself is unchanged from the one previously in `main.tsx`.

External rather than inline because the backend sends `script-src 'self'` with no `'unsafe-inline'` and no nonce on normal requests, so an inline bootstrap is blocked. This mirrors the existing `public/theme-boot.js`, which is an external file for exactly the same reason. Files in `public/` are emitted to the build root and served by the frontend catch-all, the same path `theme-boot.js` already takes in production.

## Reviewer notes and trade-offs

- **Ordering.** The module entry is deferred, so any non-`async` script above it runs first. `defer` on the boot scripts would preserve that too, since deferred classic scripts and the module entry share one execution list in document order; `async` on either would not. The test asserts the tags are non-`async` rather than forbidding `defer`.
- **The other 66 call sites were left alone.** With the polyfill installed ahead of the module graph, bare `crypto.randomUUID()` is correct everywhere, including at module scope. Seven files that hand-roll their own fallback are now redundant, but removing them is a behavior-neutral refactor and is better done separately than mixed into this fix.
- **The UUID test is a golden value, not a randomness test.** The generator is a pure function of the bytes it draws, so pinning its output for a fixed stream catches the ways it can quietly degrade — bits masked off, draws folded together, or the stream ignored. It certifies no entropy, and a deliberate rewrite of the generator is expected to change the value.
- **Scope.** This makes Studio boot over plain http. It does not make plain http a fully working deployment: dictation, microphone capture and parts of the clipboard API remain unavailable outside a secure context by browser design, and the code already guards those. `unsloth studio --secure` remains the supported path for full remote access.

## Validation

Built the frontend, served the build over a LAN address, and loaded it in a browser with `window.isSecureContext === false`.

Before, with the boot script omitted from the same build:

```text
Uncaught TypeError: crypto.randomUUID is not a function
    at assets/settings-*.js
#root child elements: 0
```

After:

```text
typeof crypto.randomUUID === "function"
#root child elements: 3   (login screen renders)
```

Inline was also checked against the running backend rather than assumed — an inline polyfill in the served `index.html` is rejected:

```text
Executing inline script violates the following Content Security Policy directive 'script-src 'self''.
Uncaught TypeError: crypto.randomUUID is not a function
```

Each added assertion was mutation-checked, and each of these fails exactly one test: removing the script tag, commenting it out, moving it below the module entry, marking either tag `async`, changing the nibble mask `15` to `14`, dropping the mask, replacing the source with `Math.random`, folding the drawn bytes together, reusing one byte, and overwriting an existing `randomUUID`. `defer` on the boot script alone still passes, as intended.

```bash
cd studio/frontend
npm run typecheck
node --experimental-strip-types --test tests/crypto-uuid-boot.test.ts
```
