### PR TITLE
Let every main run finish instead of cancelling it before it starts

### DIFF
--- a/.github/workflows/clean-machine-install-ci.yml
+++ b/.github/workflows/clean-machine-install-ci.yml
@@ -100,10 +100,10 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  # Latest-only on branches, never on main. Pushes to main land in bursts, so
-  # cancelling superseded runs there throws away the run that would have
-  # reported a regression, and the run that writes the shared caches. Same
-  # reasoning, and the same incident, as studio-ui-smoke.yml.
+  # Latest-only on a PR branch. On main this does less than it reads like: it stops
+  # a RUNNING main job being killed, but GitHub cancels any PENDING run in the group
+  # the moment a newer one is queued, so a merge burst still leaves only the tip.
+  # See studio-backend-ci.yml, which is grouped per commit on main for that reason.
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:

--- a/.github/workflows/clean-machine-install-ci.yml
+++ b/.github/workflows/clean-machine-install-ci.yml
@@ -99,7 +99,7 @@ on:
         default: tree
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   # Latest-only on a PR branch. On main this does less than it reads like: it stops
   # a RUNNING main job being killed, but GitHub cancels any PENDING run in the group
   # the moment a newer one is queued, so a merge burst still leaves only the tip.

--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -58,7 +58,7 @@ on:
         default: 'main'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   # Latest-only on a PR branch. On main this does less than it reads like: it stops
   # a RUNNING main job being killed, but GitHub cancels any PENDING run in the group
   # the moment a newer one is queued, so a merge burst still leaves only the tip.

--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -59,10 +59,10 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  # Latest-only on branches, never on main. Pushes to main land in bursts, so
-  # cancelling superseded runs there throws away the run that would have
-  # reported a regression, and the run that writes the shared caches. Same
-  # reasoning, and the same incident, as studio-ui-smoke.yml.
+  # Latest-only on a PR branch. On main this does less than it reads like: it stops
+  # a RUNNING main job being killed, but GitHub cancels any PENDING run in the group
+  # the moment a newer one is queued, so a merge burst still leaves only the tip.
+  # See studio-backend-ci.yml, which is grouped per commit on main for that reason.
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:

--- a/.github/workflows/cross-platform-parity-ci.yml
+++ b/.github/workflows/cross-platform-parity-ci.yml
@@ -145,10 +145,10 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  # Latest-only on branches, never on main. Pushes to main land in bursts, so
-  # cancelling superseded runs there throws away the run that would have
-  # reported a regression, and the run that writes the shared caches. Same
-  # reasoning, and the same incident, as studio-ui-smoke.yml.
+  # Latest-only on a PR branch. On main this does less than it reads like: it stops
+  # a RUNNING main job being killed, but GitHub cancels any PENDING run in the group
+  # the moment a newer one is queued, so a merge burst still leaves only the tip.
+  # See studio-backend-ci.yml, which is grouped per commit on main for that reason.
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:

--- a/.github/workflows/cross-platform-parity-ci.yml
+++ b/.github/workflows/cross-platform-parity-ci.yml
@@ -144,7 +144,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   # Latest-only on a PR branch. On main this does less than it reads like: it stops
   # a RUNNING main job being killed, but GitHub cancels any PENDING run in the group
   # the moment a newer one is queued, so a merge burst still leaves only the tip.

--- a/.github/workflows/desktop-app-clean-machine-ci.yml
+++ b/.github/workflows/desktop-app-clean-machine-ci.yml
@@ -51,10 +51,10 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  # Latest-only on branches, never on main. Pushes to main land in bursts, so
-  # cancelling superseded runs there throws away the run that would have
-  # reported a regression, and the run that writes the shared caches. Same
-  # reasoning, and the same incident, as studio-ui-smoke.yml.
+  # Latest-only on a PR branch. On main this does less than it reads like: it stops
+  # a RUNNING main job being killed, but GitHub cancels any PENDING run in the group
+  # the moment a newer one is queued, so a merge burst still leaves only the tip.
+  # See studio-backend-ci.yml, which is grouped per commit on main for that reason.
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:

--- a/.github/workflows/lint-ci.yml
+++ b/.github/workflows/lint-ci.yml
@@ -31,7 +31,7 @@ on:
     branches: [main]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   # Latest-only on a PR branch. On main this does less than it reads like: it stops
   # a RUNNING main job being killed, but GitHub cancels any PENDING run in the group
   # the moment a newer one is queued, so a merge burst still leaves only the tip.

--- a/.github/workflows/lint-ci.yml
+++ b/.github/workflows/lint-ci.yml
@@ -32,10 +32,10 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  # Latest-only on branches, never on main. Pushes to main land in bursts, so
-  # cancelling superseded runs there throws away the run that would have
-  # reported a regression, and the run that writes the shared caches. Same
-  # reasoning, and the same incident, as studio-ui-smoke.yml.
+  # Latest-only on a PR branch. On main this does less than it reads like: it stops
+  # a RUNNING main job being killed, but GitHub cancels any PENDING run in the group
+  # the moment a newer one is queued, so a merge burst still leaves only the tip.
+  # See studio-backend-ci.yml, which is grouped per commit on main for that reason.
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:

--- a/.github/workflows/local-agent-guides-ci.yml
+++ b/.github/workflows/local-agent-guides-ci.yml
@@ -89,10 +89,10 @@ concurrency:
   # only one pending run, so without this a merge burst silently drops the nightly:
   # cancel-in-progress protects the running run, never the pending one.
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
-  # Latest-only on branches, never on main. Pushes to main land in bursts, so
-  # cancelling superseded runs there throws away the run that would have
-  # reported a regression, and the run that writes the shared caches. Same
-  # reasoning, and the same incident, as studio-ui-smoke.yml.
+  # Latest-only on a PR branch. On main this does less than it reads like: it stops
+  # a RUNNING main job being killed, but GitHub cancels any PENDING run in the group
+  # the moment a newer one is queued, so a merge burst still leaves only the tip.
+  # See studio-backend-ci.yml, which is grouped per commit on main for that reason.
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:

--- a/.github/workflows/local-agent-guides-ci.yml
+++ b/.github/workflows/local-agent-guides-ci.yml
@@ -88,7 +88,7 @@ concurrency:
   # coalesce. Both resolve to refs/heads/main, and the default queue: single keeps
   # only one pending run, so without this a merge burst silently drops the nightly:
   # cancel-in-progress protects the running run, never the pending one.
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   # Latest-only on a PR branch. On main this does less than it reads like: it stops
   # a RUNNING main job being killed, but GitHub cancels any PENDING run in the group
   # the moment a newer one is queued, so a merge burst still leaves only the tip.

--- a/.github/workflows/lockfile-audit.yml
+++ b/.github/workflows/lockfile-audit.yml
@@ -51,7 +51,7 @@ concurrency:
   # coalesce. Both resolve to refs/heads/main, and the default queue: single keeps
   # only one pending run, so without this a merge burst silently drops the nightly:
   # cancel-in-progress protects the running run, never the pending one.
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   # Latest-only on a PR branch. On main this does less than it reads like: it stops
   # a RUNNING main job being killed, but GitHub cancels any PENDING run in the group
   # the moment a newer one is queued, so a merge burst still leaves only the tip.

--- a/.github/workflows/lockfile-audit.yml
+++ b/.github/workflows/lockfile-audit.yml
@@ -52,10 +52,10 @@ concurrency:
   # only one pending run, so without this a merge burst silently drops the nightly:
   # cancel-in-progress protects the running run, never the pending one.
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
-  # Latest-only on branches, never on main. Pushes to main land in bursts, so
-  # cancelling superseded runs there throws away the run that would have
-  # reported a regression, and the run that writes the shared caches. Same
-  # reasoning, and the same incident, as studio-ui-smoke.yml.
+  # Latest-only on a PR branch. On main this does less than it reads like: it stops
+  # a RUNNING main job being killed, but GitHub cancels any PENDING run in the group
+  # the moment a newer one is queued, so a merge burst still leaves only the tip.
+  # See studio-backend-ci.yml, which is grouped per commit on main for that reason.
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:

--- a/.github/workflows/mlx-ci.yml
+++ b/.github/workflows/mlx-ci.yml
@@ -120,7 +120,7 @@ on:
       - '.github/workflows/mlx-ci.yml'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   # Latest-only on a PR branch. On main this does less than it reads like: it stops
   # a RUNNING main job being killed, but GitHub cancels any PENDING run in the group
   # the moment a newer one is queued, so a merge burst still leaves only the tip.

--- a/.github/workflows/mlx-ci.yml
+++ b/.github/workflows/mlx-ci.yml
@@ -121,10 +121,10 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  # Latest-only on branches, never on main. Pushes to main land in bursts, so
-  # cancelling superseded runs there throws away the run that would have
-  # reported a regression, and the run that writes the shared caches. Same
-  # reasoning, and the same incident, as studio-ui-smoke.yml.
+  # Latest-only on a PR branch. On main this does less than it reads like: it stops
+  # a RUNNING main job being killed, but GitHub cancels any PENDING run in the group
+  # the moment a newer one is queued, so a merge burst still leaves only the tip.
+  # See studio-backend-ci.yml, which is grouped per commit on main for that reason.
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:

--- a/.github/workflows/notebooks-ci.yml
+++ b/.github/workflows/notebooks-ci.yml
@@ -50,10 +50,10 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  # Latest-only on branches, never on main. Pushes to main land in bursts, so
-  # cancelling superseded runs there throws away the run that would have
-  # reported a regression, and the run that writes the shared caches. Same
-  # reasoning, and the same incident, as studio-ui-smoke.yml.
+  # Latest-only on a PR branch. On main this does less than it reads like: it stops
+  # a RUNNING main job being killed, but GitHub cancels any PENDING run in the group
+  # the moment a newer one is queued, so a merge burst still leaves only the tip.
+  # See studio-backend-ci.yml, which is grouped per commit on main for that reason.
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:

--- a/.github/workflows/ossf.yml
+++ b/.github/workflows/ossf.yml
@@ -23,7 +23,7 @@ concurrency:
   # coalesce. Both resolve to refs/heads/main, and the default queue: single keeps
   # only one pending run, so without this a merge burst silently drops the nightly:
   # cancel-in-progress protects the running run, never the pending one.
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   cancel-in-progress: false
 
 # Declare default permissions as read only.

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -90,10 +90,10 @@ concurrency:
   # only one pending run, so without this a merge burst silently drops the nightly:
   # cancel-in-progress protects the running run, never the pending one.
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
-  # Latest-only on branches, never on main. Pushes to main land in bursts, so
-  # cancelling superseded runs there throws away the run that would have
-  # reported a regression, and the run that writes the shared caches. Same
-  # reasoning, and the same incident, as studio-ui-smoke.yml.
+  # Latest-only on a PR branch. On main this does less than it reads like: it stops
+  # a RUNNING main job being killed, but GitHub cancels any PENDING run in the group
+  # the moment a newer one is queued, so a merge burst still leaves only the tip.
+  # See studio-backend-ci.yml, which is grouped per commit on main for that reason.
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -89,7 +89,7 @@ concurrency:
   # coalesce. Both resolve to refs/heads/main, and the default queue: single keeps
   # only one pending run, so without this a merge burst silently drops the nightly:
   # cancel-in-progress protects the running run, never the pending one.
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   # Latest-only on a PR branch. On main this does less than it reads like: it stops
   # a RUNNING main job being killed, but GitHub cancels any PENDING run in the group
   # the moment a newer one is queued, so a merge burst still leaves only the tip.

--- a/.github/workflows/studio-api-smoke.yml
+++ b/.github/workflows/studio-api-smoke.yml
@@ -40,7 +40,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   # Latest-only on a PR branch. On main this does less than it reads like: it stops
   # a RUNNING main job being killed, but GitHub cancels any PENDING run in the group
   # the moment a newer one is queued, so a merge burst still leaves only the tip.

--- a/.github/workflows/studio-api-smoke.yml
+++ b/.github/workflows/studio-api-smoke.yml
@@ -41,10 +41,10 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  # Latest-only on branches, never on main. Pushes to main land in bursts, so
-  # cancelling superseded runs there throws away the run that would have
-  # reported a regression, and the run that writes the shared caches. Same
-  # reasoning, and the same incident, as studio-ui-smoke.yml.
+  # Latest-only on a PR branch. On main this does less than it reads like: it stops
+  # a RUNNING main job being killed, but GitHub cancels any PENDING run in the group
+  # the moment a newer one is queued, so a merge burst still leaves only the tip.
+  # See studio-backend-ci.yml, which is grouped per commit on main for that reason.
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:

--- a/.github/workflows/studio-backend-ci.yml
+++ b/.github/workflows/studio-backend-ci.yml
@@ -43,11 +43,19 @@ on:
     branches: [main]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  # Latest-only on branches, never on main. Pushes to main land in bursts, so
-  # cancelling superseded runs there throws away the run that would have
-  # reported a regression, and the run that writes the shared caches. Same
-  # reasoning, and the same incident, as studio-ui-smoke.yml.
+  # Unique per commit on main, so a merge burst cannot cancel a pending run
+  # before it starts. See the note below for what this is buying.
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
+  # On a PR branch: latest-only, which is what cancel-in-progress buys.
+  #
+  # On main it buys less than it looks like. GitHub cancels any PENDING run in a
+  # concurrency group as soon as a newer one is queued, and cancel-in-progress
+  # governs only runs that are already EXECUTING ("any existing pending job or
+  # workflow in the same concurrency group will be canceled", workflow-syntax docs).
+  # So a burst of merges leaves only the tip's run alive: on 2026-08-17 four merges
+  # in 37 minutes cancelled three consecutive main runs of this workflow and none
+  # completed. Detection survives on the tip, since the tree is cumulative;
+  # per-commit attribution does not.
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:

--- a/.github/workflows/studio-export-capability-ci.yml
+++ b/.github/workflows/studio-export-capability-ci.yml
@@ -26,10 +26,10 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  # Latest-only on branches, never on main. Pushes to main land in bursts, so
-  # cancelling superseded runs there throws away the run that would have
-  # reported a regression, and the run that writes the shared caches. Same
-  # reasoning, and the same incident, as studio-ui-smoke.yml.
+  # Latest-only on a PR branch. On main this does less than it reads like: it stops
+  # a RUNNING main job being killed, but GitHub cancels any PENDING run in the group
+  # the moment a newer one is queued, so a merge burst still leaves only the tip.
+  # See studio-backend-ci.yml, which is grouped per commit on main for that reason.
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:

--- a/.github/workflows/studio-export-capability-ci.yml
+++ b/.github/workflows/studio-export-capability-ci.yml
@@ -25,7 +25,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   # Latest-only on a PR branch. On main this does less than it reads like: it stops
   # a RUNNING main job being killed, but GitHub cancels any PENDING run in the group
   # the moment a newer one is queued, so a merge burst still leaves only the tip.

--- a/.github/workflows/studio-frontend-ci.yml
+++ b/.github/workflows/studio-frontend-ci.yml
@@ -33,10 +33,10 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  # Latest-only on branches, never on main. Pushes to main land in bursts, so
-  # cancelling superseded runs there throws away the run that would have
-  # reported a regression, and the run that writes the shared caches. Same
-  # reasoning, and the same incident, as studio-ui-smoke.yml.
+  # Latest-only on a PR branch. On main this does less than it reads like: it stops
+  # a RUNNING main job being killed, but GitHub cancels any PENDING run in the group
+  # the moment a newer one is queued, so a merge burst still leaves only the tip.
+  # See studio-backend-ci.yml, which is grouped per commit on main for that reason.
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:

--- a/.github/workflows/studio-frontend-ci.yml
+++ b/.github/workflows/studio-frontend-ci.yml
@@ -32,7 +32,7 @@ on:
     branches: [main]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   # Latest-only on a PR branch. On main this does less than it reads like: it stops
   # a RUNNING main job being killed, but GitHub cancels any PENDING run in the group
   # the moment a newer one is queued, so a merge burst still leaves only the tip.

--- a/.github/workflows/studio-inference-smoke.yml
+++ b/.github/workflows/studio-inference-smoke.yml
@@ -54,10 +54,10 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  # Latest-only on branches, never on main. Pushes to main land in bursts, so
-  # cancelling superseded runs there throws away the run that would have
-  # reported a regression, and the run that writes the shared caches. Same
-  # reasoning, and the same incident, as studio-ui-smoke.yml.
+  # Latest-only on a PR branch. On main this does less than it reads like: it stops
+  # a RUNNING main job being killed, but GitHub cancels any PENDING run in the group
+  # the moment a newer one is queued, so a merge burst still leaves only the tip.
+  # See studio-backend-ci.yml, which is grouped per commit on main for that reason.
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:

--- a/.github/workflows/studio-inference-smoke.yml
+++ b/.github/workflows/studio-inference-smoke.yml
@@ -53,7 +53,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   # Latest-only on a PR branch. On main this does less than it reads like: it stops
   # a RUNNING main job being killed, but GitHub cancels any PENDING run in the group
   # the moment a newer one is queued, so a merge burst still leaves only the tip.

--- a/.github/workflows/studio-load-orchestrator-ci.yml
+++ b/.github/workflows/studio-load-orchestrator-ci.yml
@@ -29,10 +29,10 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  # Latest-only on branches, never on main. Pushes to main land in bursts, so
-  # cancelling superseded runs there throws away the run that would have
-  # reported a regression, and the run that writes the shared caches. Same
-  # reasoning, and the same incident, as studio-ui-smoke.yml.
+  # Latest-only on a PR branch. On main this does less than it reads like: it stops
+  # a RUNNING main job being killed, but GitHub cancels any PENDING run in the group
+  # the moment a newer one is queued, so a merge burst still leaves only the tip.
+  # See studio-backend-ci.yml, which is grouped per commit on main for that reason.
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:

--- a/.github/workflows/studio-load-orchestrator-ci.yml
+++ b/.github/workflows/studio-load-orchestrator-ci.yml
@@ -28,7 +28,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   # Latest-only on a PR branch. On main this does less than it reads like: it stops
   # a RUNNING main job being killed, but GitHub cancels any PENDING run in the group
   # the moment a newer one is queued, so a merge burst still leaves only the tip.

--- a/.github/workflows/studio-mac-inference-smoke.yml
+++ b/.github/workflows/studio-mac-inference-smoke.yml
@@ -56,10 +56,10 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  # Latest-only on branches, never on main. Pushes to main land in bursts, so
-  # cancelling superseded runs there throws away the run that would have
-  # reported a regression, and the run that writes the shared caches. Same
-  # reasoning, and the same incident, as studio-ui-smoke.yml.
+  # Latest-only on a PR branch. On main this does less than it reads like: it stops
+  # a RUNNING main job being killed, but GitHub cancels any PENDING run in the group
+  # the moment a newer one is queued, so a merge burst still leaves only the tip.
+  # See studio-backend-ci.yml, which is grouped per commit on main for that reason.
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:

--- a/.github/workflows/studio-mac-inference-smoke.yml
+++ b/.github/workflows/studio-mac-inference-smoke.yml
@@ -55,7 +55,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   # Latest-only on a PR branch. On main this does less than it reads like: it stops
   # a RUNNING main job being killed, but GitHub cancels any PENDING run in the group
   # the moment a newer one is queued, so a merge burst still leaves only the tip.

--- a/.github/workflows/studio-mac-install-matrix.yml
+++ b/.github/workflows/studio-mac-install-matrix.yml
@@ -25,10 +25,10 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  # Latest-only on branches, never on main. Pushes to main land in bursts, so
-  # cancelling superseded runs there throws away the run that would have
-  # reported a regression, and the run that writes the shared caches. Same
-  # reasoning, and the same incident, as studio-ui-smoke.yml.
+  # Latest-only on a PR branch. On main this does less than it reads like: it stops
+  # a RUNNING main job being killed, but GitHub cancels any PENDING run in the group
+  # the moment a newer one is queued, so a merge burst still leaves only the tip.
+  # See studio-backend-ci.yml, which is grouped per commit on main for that reason.
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:

--- a/.github/workflows/studio-mac-install-matrix.yml
+++ b/.github/workflows/studio-mac-install-matrix.yml
@@ -24,7 +24,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   # Latest-only on a PR branch. On main this does less than it reads like: it stops
   # a RUNNING main job being killed, but GitHub cancels any PENDING run in the group
   # the moment a newer one is queued, so a merge burst still leaves only the tip.

--- a/.github/workflows/studio-mac-ui-smoke.yml
+++ b/.github/workflows/studio-mac-ui-smoke.yml
@@ -56,10 +56,10 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  # Latest-only on branches, never on main. Pushes to main land in bursts, so
-  # cancelling superseded runs there throws away the run that would have
-  # reported a regression, and the run that writes the shared caches. Same
-  # reasoning, and the same incident, as studio-ui-smoke.yml.
+  # Latest-only on a PR branch. On main this does less than it reads like: it stops
+  # a RUNNING main job being killed, but GitHub cancels any PENDING run in the group
+  # the moment a newer one is queued, so a merge burst still leaves only the tip.
+  # See studio-backend-ci.yml, which is grouped per commit on main for that reason.
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:

--- a/.github/workflows/studio-mac-ui-smoke.yml
+++ b/.github/workflows/studio-mac-ui-smoke.yml
@@ -55,7 +55,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   # Latest-only on a PR branch. On main this does less than it reads like: it stops
   # a RUNNING main job being killed, but GitHub cancels any PENDING run in the group
   # the moment a newer one is queued, so a merge burst still leaves only the tip.

--- a/.github/workflows/studio-tauri-smoke.yml
+++ b/.github/workflows/studio-tauri-smoke.yml
@@ -30,10 +30,10 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  # Latest-only on branches, never on main. Pushes to main land in bursts, so
-  # cancelling superseded runs there throws away the run that would have
-  # reported a regression, and the run that writes the shared caches. Same
-  # reasoning, and the same incident, as studio-ui-smoke.yml.
+  # Latest-only on a PR branch. On main this does less than it reads like: it stops
+  # a RUNNING main job being killed, but GitHub cancels any PENDING run in the group
+  # the moment a newer one is queued, so a merge burst still leaves only the tip.
+  # See studio-backend-ci.yml, which is grouped per commit on main for that reason.
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:

--- a/.github/workflows/studio-tauri-smoke.yml
+++ b/.github/workflows/studio-tauri-smoke.yml
@@ -29,7 +29,7 @@ on:
     branches: [main]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   # Latest-only on a PR branch. On main this does less than it reads like: it stops
   # a RUNNING main job being killed, but GitHub cancels any PENDING run in the group
   # the moment a newer one is queued, so a merge burst still leaves only the tip.

--- a/.github/workflows/studio-ui-smoke.yml
+++ b/.github/workflows/studio-ui-smoke.yml
@@ -43,11 +43,19 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  # Never on main: pushes land in bursts, so cancelling superseded runs there means
-  # a deterministic failure can go unreported for as long as the bursts continue.
-  # The collapsed-row break below sat on main for 14 hours behind four cancelled
-  # runs. On a PR branch cancelling is still what you want.
+  # Unique per commit on main, so a merge burst cannot cancel a pending run
+  # before it starts. See the note below for what this is buying.
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
+  # On a PR branch: latest-only, which is what cancel-in-progress buys.
+  #
+  # On main it buys less than it looks like. GitHub cancels any PENDING run in a
+  # concurrency group as soon as a newer one is queued, and cancel-in-progress
+  # governs only runs that are already EXECUTING ("any existing pending job or
+  # workflow in the same concurrency group will be canceled", workflow-syntax docs).
+  # So a burst of merges leaves only the tip's run alive: on 2026-08-17 four merges
+  # in 37 minutes cancelled three consecutive main runs of this workflow and none
+  # completed. Detection survives on the tip, since the tree is cumulative;
+  # per-commit attribution does not.
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:

--- a/.github/workflows/studio-update-smoke.yml
+++ b/.github/workflows/studio-update-smoke.yml
@@ -34,10 +34,10 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  # Latest-only on branches, never on main. Pushes to main land in bursts, so
-  # cancelling superseded runs there throws away the run that would have
-  # reported a regression, and the run that writes the shared caches. Same
-  # reasoning, and the same incident, as studio-ui-smoke.yml.
+  # Latest-only on a PR branch. On main this does less than it reads like: it stops
+  # a RUNNING main job being killed, but GitHub cancels any PENDING run in the group
+  # the moment a newer one is queued, so a merge burst still leaves only the tip.
+  # See studio-backend-ci.yml, which is grouped per commit on main for that reason.
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:

--- a/.github/workflows/studio-update-smoke.yml
+++ b/.github/workflows/studio-update-smoke.yml
@@ -33,7 +33,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   # Latest-only on a PR branch. On main this does less than it reads like: it stops
   # a RUNNING main job being killed, but GitHub cancels any PENDING run in the group
   # the moment a newer one is queued, so a merge burst still leaves only the tip.

--- a/.github/workflows/studio-windows-api-smoke.yml
+++ b/.github/workflows/studio-windows-api-smoke.yml
@@ -33,10 +33,10 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  # Latest-only on branches, never on main. Pushes to main land in bursts, so
-  # cancelling superseded runs there throws away the run that would have
-  # reported a regression, and the run that writes the shared caches. Same
-  # reasoning, and the same incident, as studio-ui-smoke.yml.
+  # Latest-only on a PR branch. On main this does less than it reads like: it stops
+  # a RUNNING main job being killed, but GitHub cancels any PENDING run in the group
+  # the moment a newer one is queued, so a merge burst still leaves only the tip.
+  # See studio-backend-ci.yml, which is grouped per commit on main for that reason.
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:

--- a/.github/workflows/studio-windows-api-smoke.yml
+++ b/.github/workflows/studio-windows-api-smoke.yml
@@ -32,7 +32,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   # Latest-only on a PR branch. On main this does less than it reads like: it stops
   # a RUNNING main job being killed, but GitHub cancels any PENDING run in the group
   # the moment a newer one is queued, so a merge burst still leaves only the tip.

--- a/.github/workflows/studio-windows-inference-smoke.yml
+++ b/.github/workflows/studio-windows-inference-smoke.yml
@@ -47,10 +47,10 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  # Latest-only on branches, never on main. Pushes to main land in bursts, so
-  # cancelling superseded runs there throws away the run that would have
-  # reported a regression, and the run that writes the shared caches. Same
-  # reasoning, and the same incident, as studio-ui-smoke.yml.
+  # Latest-only on a PR branch. On main this does less than it reads like: it stops
+  # a RUNNING main job being killed, but GitHub cancels any PENDING run in the group
+  # the moment a newer one is queued, so a merge burst still leaves only the tip.
+  # See studio-backend-ci.yml, which is grouped per commit on main for that reason.
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:

--- a/.github/workflows/studio-windows-inference-smoke.yml
+++ b/.github/workflows/studio-windows-inference-smoke.yml
@@ -46,7 +46,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   # Latest-only on a PR branch. On main this does less than it reads like: it stops
   # a RUNNING main job being killed, but GitHub cancels any PENDING run in the group
   # the moment a newer one is queued, so a merge burst still leaves only the tip.

--- a/.github/workflows/studio-windows-ui-smoke.yml
+++ b/.github/workflows/studio-windows-ui-smoke.yml
@@ -33,10 +33,10 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  # Latest-only on branches, never on main. Pushes to main land in bursts, so
-  # cancelling superseded runs there throws away the run that would have
-  # reported a regression, and the run that writes the shared caches. Same
-  # reasoning, and the same incident, as studio-ui-smoke.yml.
+  # Latest-only on a PR branch. On main this does less than it reads like: it stops
+  # a RUNNING main job being killed, but GitHub cancels any PENDING run in the group
+  # the moment a newer one is queued, so a merge burst still leaves only the tip.
+  # See studio-backend-ci.yml, which is grouped per commit on main for that reason.
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:

--- a/.github/workflows/studio-windows-ui-smoke.yml
+++ b/.github/workflows/studio-windows-ui-smoke.yml
@@ -32,7 +32,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   # Latest-only on a PR branch. On main this does less than it reads like: it stops
   # a RUNNING main job being killed, but GitHub cancels any PENDING run in the group
   # the moment a newer one is queued, so a merge burst still leaves only the tip.

--- a/.github/workflows/studio-windows-update-smoke.yml
+++ b/.github/workflows/studio-windows-update-smoke.yml
@@ -42,10 +42,10 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  # Latest-only on branches, never on main. Pushes to main land in bursts, so
-  # cancelling superseded runs there throws away the run that would have
-  # reported a regression, and the run that writes the shared caches. Same
-  # reasoning, and the same incident, as studio-ui-smoke.yml.
+  # Latest-only on a PR branch. On main this does less than it reads like: it stops
+  # a RUNNING main job being killed, but GitHub cancels any PENDING run in the group
+  # the moment a newer one is queued, so a merge burst still leaves only the tip.
+  # See studio-backend-ci.yml, which is grouped per commit on main for that reason.
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:

--- a/.github/workflows/studio-windows-update-smoke.yml
+++ b/.github/workflows/studio-windows-update-smoke.yml
@@ -41,7 +41,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   # Latest-only on a PR branch. On main this does less than it reads like: it stops
   # a RUNNING main job being killed, but GitHub cancels any PENDING run in the group
   # the moment a newer one is queued, so a merge burst still leaves only the tip.

--- a/.github/workflows/version-compat-ci.yml
+++ b/.github/workflows/version-compat-ci.yml
@@ -46,10 +46,10 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  # Latest-only on branches, never on main. Pushes to main land in bursts, so
-  # cancelling superseded runs there throws away the run that would have
-  # reported a regression, and the run that writes the shared caches. Same
-  # reasoning, and the same incident, as studio-ui-smoke.yml.
+  # Latest-only on a PR branch. On main this does less than it reads like: it stops
+  # a RUNNING main job being killed, but GitHub cancels any PENDING run in the group
+  # the moment a newer one is queued, so a merge burst still leaves only the tip.
+  # See studio-backend-ci.yml, which is grouped per commit on main for that reason.
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:

--- a/.github/workflows/wheel-smoke.yml
+++ b/.github/workflows/wheel-smoke.yml
@@ -36,10 +36,10 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  # Latest-only on branches, never on main. Pushes to main land in bursts, so
-  # cancelling superseded runs there throws away the run that would have
-  # reported a regression, and the run that writes the shared caches. Same
-  # reasoning, and the same incident, as studio-ui-smoke.yml.
+  # Latest-only on a PR branch. On main this does less than it reads like: it stops
+  # a RUNNING main job being killed, but GitHub cancels any PENDING run in the group
+  # the moment a newer one is queued, so a merge burst still leaves only the tip.
+  # See studio-backend-ci.yml, which is grouped per commit on main for that reason.
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:

--- a/.github/workflows/wheel-smoke.yml
+++ b/.github/workflows/wheel-smoke.yml
@@ -35,7 +35,7 @@ on:
       - '.github/workflows/wheel-smoke.yml'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   # Latest-only on a PR branch. On main this does less than it reads like: it stops
   # a RUNNING main job being killed, but GitHub cancels any PENDING run in the group
   # the moment a newer one is queued, so a merge burst still leaves only the tip.

--- a/.github/workflows/windows-application-control-ci.yml
+++ b/.github/workflows/windows-application-control-ci.yml
@@ -58,7 +58,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:

--- a/.github/workflows/workflow-trigger-lint.yml
+++ b/.github/workflows/workflow-trigger-lint.yml
@@ -78,3 +78,11 @@ jobs:
       # Same cost shape as the lint above: filesystem reads, seconds.
       - name: Playwright suites still run somewhere
         run: python3 -m pytest tests/studio/test_playwright_suites_run_in_ci.py -q
+
+      # Here for the same reason, one step further out: this guard reads the concurrency
+      # block of EVERY workflow, so the PR that breaks it is a PR that edits some other
+      # workflow's YAML. No workflow's paths filter contains .github/workflows/**, so a
+      # revert of, say, wheel-smoke.yml back to a shared main group never collected this
+      # test and merged green. Only this job sees such a PR.
+      - name: Main runs still survive a merge burst
+        run: python3 -m pytest tests/studio/test_main_runs_survive_merge_bursts.py -q

--- a/.github/workflows/workflow-trigger-lint.yml
+++ b/.github/workflows/workflow-trigger-lint.yml
@@ -30,7 +30,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:

--- a/tests/studio/test_main_runs_survive_merge_bursts.py
+++ b/tests/studio/test_main_runs_survive_merge_bursts.py
@@ -123,6 +123,6 @@ def test_a_pull_request_still_gets_latest_only():
             f"burning a runner"
         )
         concurrency = document.get("concurrency") or {}
-        assert "github.ref != 'refs/heads/main'" in str(concurrency.get("cancel-in-progress")), (
-            f"{name} no longer cancels superseded PR runs"
-        )
+        assert "github.ref != 'refs/heads/main'" in str(
+            concurrency.get("cancel-in-progress")
+        ), f"{name} no longer cancels superseded PR runs"

--- a/tests/studio/test_main_runs_survive_merge_bursts.py
+++ b/tests/studio/test_main_runs_survive_merge_bursts.py
@@ -92,7 +92,8 @@ def test_every_workflow_that_runs_on_main_is_grouped_per_commit():
     the workflow simply never reported on that commit.
     """
     offenders = sorted(
-        name for name, document in _protected().items()
+        name
+        for name, document in _protected().items()
         if not _is_per_commit_on_main(_group(document))
     )
     assert not offenders, (

--- a/tests/studio/test_main_runs_survive_merge_bursts.py
+++ b/tests/studio/test_main_runs_survive_merge_bursts.py
@@ -102,7 +102,13 @@ def _evaluate(expression: str, context: dict[str, str]) -> str:
     return _term(expression, context)
 
 
-def _render(group: str, *, ref: str, sha: str, event_name: str = "push") -> str:
+def _render(
+    group: str,
+    *,
+    ref: str,
+    sha: str,
+    event_name: str = "push",
+) -> str:
     """The literal group string GitHub would compute for one run."""
     context = {
         "github.workflow": "a-workflow",

--- a/tests/studio/test_main_runs_survive_merge_bursts.py
+++ b/tests/studio/test_main_runs_survive_merge_bursts.py
@@ -1,0 +1,128 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""``cancel-in-progress: false`` does not keep a main run alive, and the repo believed it did.
+
+GitHub cancels any PENDING run in a concurrency group the moment a newer one is queued.
+``cancel-in-progress`` governs only runs that are already EXECUTING: "any existing pending
+job or workflow in the same concurrency group will be canceled and the new queued job or
+workflow will take its place" (workflow-syntax reference).
+
+So on a branch where pushes land in bursts, ``cancel-in-progress: false`` buys nothing for
+the runs in the middle of the burst. Twenty-seven workflows carried a comment saying it did.
+Both incidents the repo wrote down are this: studio-ui-smoke.yml records a break sitting on
+main "for 14 hours behind four cancelled runs", and on 2026-08-17 four merges in 37 minutes
+cancelled three consecutive main runs of Backend CI, which completed none.
+
+The only thing that actually protects a main run is a concurrency group it does not share
+with the next commit. This checks that the workflows claiming that protection have it.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO = Path(__file__).resolve().parents[2]
+WORKFLOWS = REPO / ".github" / "workflows"
+
+# Workflows whose main run must survive a merge burst. Both are here because a regression
+# went unreported behind cancelled main runs of exactly these two.
+PROTECTED_ON_MAIN = ("studio-backend-ci.yml", "studio-ui-smoke.yml")
+
+# Phrasings that assert main runs are not cancelled. A workflow may only say this if its
+# group makes it true.
+CLAIMS_PROTECTION = re.compile(
+    r"never on main|never cancelled on main|not cancelled on main|never cancels on main",
+    re.IGNORECASE,
+)
+
+
+def _documents() -> dict[str, dict]:
+    out = {}
+    for path in sorted(WORKFLOWS.glob("*.y*ml")):
+        try:
+            document = yaml.safe_load(path.read_text(encoding = "utf-8"))
+        except yaml.YAMLError:  # not this guard's job to report
+            continue
+        if isinstance(document, dict):
+            out[path.name] = document
+    return out
+
+
+def _group(document: dict) -> str:
+    concurrency = document.get("concurrency")
+    if isinstance(concurrency, str):
+        return concurrency
+    if isinstance(concurrency, dict):
+        return str(concurrency.get("group", ""))
+    return ""
+
+
+def _is_per_commit_on_main(group: str) -> bool:
+    """Whether this group differs between two commits on main.
+
+    ``github.sha`` is the only thing in the expression context that does. A group without it
+    is shared by every main commit, so a pending run in it is replaced by the next merge.
+    """
+    return "github.sha" in group
+
+
+@pytest.mark.parametrize("name", PROTECTED_ON_MAIN)
+def test_the_protected_workflows_are_grouped_per_commit_on_main(name):
+    documents = _documents()
+    assert name in documents, f"{name} is gone; if it moved, move this guard with it"
+    group = _group(documents[name])
+    assert group, f"{name} has no concurrency group at all"
+    assert _is_per_commit_on_main(group), (
+        f"{name} shares one concurrency group across main commits ({group!r}), so a merge "
+        f"burst cancels its pending runs before they start. cancel-in-progress does not "
+        f"prevent that: it only spares runs that are already executing. Include github.sha "
+        f"in the group on main."
+    )
+
+
+def test_no_workflow_claims_a_main_protection_it_does_not_have():
+    """The comment that made this repo believe it was covered, in 27 files.
+
+    Read from the raw text rather than the parsed document, because a comment is exactly
+    what YAML throws away, and the comment is what people act on.
+    """
+    offenders = []
+    for path in sorted(WORKFLOWS.glob("*.y*ml")):
+        text = path.read_text(encoding = "utf-8")
+        if not CLAIMS_PROTECTION.search(text):
+            continue
+        try:
+            document = yaml.safe_load(text)
+        except yaml.YAMLError:
+            continue
+        if isinstance(document, dict) and not _is_per_commit_on_main(_group(document)):
+            offenders.append(path.name)
+    assert not offenders, (
+        f"{offenders} say main runs are never cancelled while sharing one concurrency group "
+        f"across main commits, which is the belief that let a regression sit on main for 14 "
+        f"hours behind four cancelled runs. Either group per commit, or do not claim it."
+    )
+
+
+def test_a_pull_request_still_gets_latest_only():
+    """The protection is for main; superseding a PR push is still what we want.
+
+    A group keyed on github.sha for pull requests too would leave every superseded PR run
+    executing, which is the opposite of the intent and the expensive direction.
+    """
+    for name in PROTECTED_ON_MAIN:
+        document = _documents()[name]
+        group = _group(document)
+        assert "github.ref" in group, f"{name} no longer separates refs: {group!r}"
+        assert "refs/heads/main" in group, (
+            f"{name} applies its per-commit group unconditionally ({group!r}), so pull "
+            f"request pushes stop superseding each other and every abandoned run keeps "
+            f"burning a runner"
+        )
+        concurrency = document.get("concurrency") or {}
+        assert "github.ref != 'refs/heads/main'" in str(concurrency.get("cancel-in-progress")), (
+            f"{name} no longer cancels superseded PR runs"
+        )

--- a/tests/studio/test_main_runs_survive_merge_bursts.py
+++ b/tests/studio/test_main_runs_survive_merge_bursts.py
@@ -11,25 +11,26 @@ workflow will take its place" (workflow-syntax reference).
 So on a branch where pushes land in bursts, ``cancel-in-progress: false`` buys nothing for
 the runs in the middle of the burst. Twenty-seven workflows carried a comment saying it did.
 Both incidents the repo wrote down are this: studio-ui-smoke.yml records a break sitting on
-main "for 14 hours behind four cancelled runs", and on 2026-08-17 four merges in 37 minutes
-cancelled three consecutive main runs of Backend CI, which completed none.
+main "for 14 hours behind four cancelled runs", and on 2026-08-17 five merges cancelled four
+consecutive main runs of Backend CI, which completed none. Each was cancelled with ZERO jobs
+recorded, so nothing ever showed up as a failure; the workflow simply never reported.
 
-The only thing that actually protects a main run is a concurrency group it does not share
-with the next commit. This checks that the workflows claiming that protection have it.
+The only thing that protects a main run is a concurrency group it does not share with the
+next commit.
 """
 
 import re
 from pathlib import Path
 
-import pytest
 import yaml
 
 REPO = Path(__file__).resolve().parents[2]
 WORKFLOWS = REPO / ".github" / "workflows"
 
-# Workflows whose main run must survive a merge burst. Both are here because a regression
-# went unreported behind cancelled main runs of exactly these two.
-PROTECTED_ON_MAIN = ("studio-backend-ci.yml", "studio-ui-smoke.yml")
+# Kaggle spends an external GPU quota rather than runner minutes. There a superseded run
+# genuinely should be dropped instead of replayed per commit, so these keep one shared group
+# and are the only workflows allowed to lose a main run.
+QUOTA_BOUND = frozenset({"kaggle-t4-notebook-ci.yml", "kaggle-t4-studio-gpu-ci.yml"})
 
 # Phrasings that assert main runs are not cancelled. A workflow may only say this if its
 # group makes it true.
@@ -69,25 +70,74 @@ def _is_per_commit_on_main(group: str) -> bool:
     return "github.sha" in group
 
 
-@pytest.mark.parametrize("name", PROTECTED_ON_MAIN)
-def test_the_protected_workflows_are_grouped_per_commit_on_main(name):
-    documents = _documents()
-    assert name in documents, f"{name} is gone; if it moved, move this guard with it"
-    group = _group(documents[name])
-    assert group, f"{name} has no concurrency group at all"
-    assert _is_per_commit_on_main(group), (
-        f"{name} shares one concurrency group across main commits ({group!r}), so a merge "
-        f"burst cancels its pending runs before they start. cancel-in-progress does not "
-        f"prevent that: it only spares runs that are already executing. Include github.sha "
-        f"in the group on main."
+def _runs_on_main_push(document: dict) -> bool:
+    triggers = document.get(True) or document.get("on") or {}
+    push = triggers.get("push") if isinstance(triggers, dict) else None
+    return isinstance(push, dict) and "main" in (push.get("branches") or [])
+
+
+def _protected() -> dict[str, dict]:
+    return {
+        name: document
+        for name, document in _documents().items()
+        if name not in QUOTA_BOUND and _runs_on_main_push(document)
+    }
+
+
+def test_every_workflow_that_runs_on_main_is_grouped_per_commit():
+    """Otherwise a merge burst discards it before it starts.
+
+    Checked across all of them rather than a named few, because the failure is invisible:
+    the run is cancelled with zero jobs recorded, so nothing surfaces as a test failure and
+    the workflow simply never reported on that commit.
+    """
+    offenders = sorted(
+        name for name, document in _protected().items()
+        if not _is_per_commit_on_main(_group(document))
     )
+    assert not offenders, (
+        f"{offenders} share one concurrency group across main commits, so a merge burst "
+        f"cancels their pending runs before they start. cancel-in-progress does not prevent "
+        f"that: it only spares runs already executing. Append "
+        f"-${{{{ github.ref == 'refs/heads/main' && github.sha || '' }}}} to the group."
+    )
+
+
+def test_the_scan_actually_found_the_workflows():
+    """A glob that matched nothing would pass every check above."""
+    protected = _protected()
+    assert len(protected) > 20, f"only found {len(protected)} main workflows; the scan is wrong"
+    assert "studio-backend-ci.yml" in protected
+
+
+def test_the_quota_bound_exemptions_still_exist():
+    """An exemption naming a file that moved would silently widen to nothing."""
+    documents = _documents()
+    missing = sorted(name for name in QUOTA_BOUND if name not in documents)
+    assert not missing, f"QUOTA_BOUND names workflows that no longer exist: {missing}"
+
+
+def test_a_pull_request_still_gets_latest_only():
+    """The protection is for main; superseding a PR push is still what we want.
+
+    A group keyed on github.sha unconditionally would leave every abandoned PR run
+    executing, which is the opposite of the intent and the expensive direction.
+    """
+    for name, document in _protected().items():
+        group = _group(document)
+        assert "github.ref" in group, f"{name} no longer separates refs: {group!r}"
+        assert "refs/heads/main" in group, (
+            f"{name} applies its per-commit group unconditionally ({group!r}), so pull "
+            f"request pushes stop superseding each other and every abandoned run keeps "
+            f"burning a runner"
+        )
 
 
 def test_no_workflow_claims_a_main_protection_it_does_not_have():
     """The comment that made this repo believe it was covered, in 27 files.
 
-    Read from the raw text rather than the parsed document, because a comment is exactly
-    what YAML throws away, and the comment is what people act on.
+    Read from the raw text rather than the parsed document, because a comment is exactly what
+    YAML throws away, and the comment is what people act on.
     """
     offenders = []
     for path in sorted(WORKFLOWS.glob("*.y*ml")):
@@ -105,24 +155,3 @@ def test_no_workflow_claims_a_main_protection_it_does_not_have():
         f"across main commits, which is the belief that let a regression sit on main for 14 "
         f"hours behind four cancelled runs. Either group per commit, or do not claim it."
     )
-
-
-def test_a_pull_request_still_gets_latest_only():
-    """The protection is for main; superseding a PR push is still what we want.
-
-    A group keyed on github.sha for pull requests too would leave every superseded PR run
-    executing, which is the opposite of the intent and the expensive direction.
-    """
-    for name in PROTECTED_ON_MAIN:
-        document = _documents()[name]
-        group = _group(document)
-        assert "github.ref" in group, f"{name} no longer separates refs: {group!r}"
-        assert "refs/heads/main" in group, (
-            f"{name} applies its per-commit group unconditionally ({group!r}), so pull "
-            f"request pushes stop superseding each other and every abandoned run keeps "
-            f"burning a runner"
-        )
-        concurrency = document.get("concurrency") or {}
-        assert "github.ref != 'refs/heads/main'" in str(
-            concurrency.get("cancel-in-progress")
-        ), f"{name} no longer cancels superseded PR runs"

--- a/tests/studio/test_main_runs_survive_merge_bursts.py
+++ b/tests/studio/test_main_runs_survive_merge_bursts.py
@@ -61,13 +61,71 @@ def _group(document: dict) -> str:
     return ""
 
 
-def _is_per_commit_on_main(group: str) -> bool:
-    """Whether this group differs between two commits on main.
+MAIN = "refs/heads/main"
+A_PULL_REQUEST = "refs/pull/9082/merge"
 
-    ``github.sha`` is the only thing in the expression context that does. A group without it
-    is shared by every main commit, so a pending run in it is replaced by the next merge.
+_INTERPOLATION = re.compile(r"\$\{\{(.*?)\}\}", re.S)
+_COMPARISON = re.compile(r"(.+?)(==|!=)(.+)")
+_TERNARY = re.compile(r"(.+?)&&(.+?)\|\|(.+)")
+
+
+class Unparsed(Exception):
+    """A group expression this evaluator does not model.
+
+    Raised rather than guessed. A guess here would silently answer the one question this
+    file exists to ask, which is how a group behaves on main.
     """
-    return "github.sha" in group
+
+
+def _term(text: str, context: dict[str, str]) -> str:
+    text = text.strip()
+    if len(text) >= 2 and text[0] == text[-1] == "'":
+        return text[1:-1]
+    if text in context:
+        return context[text]
+    raise Unparsed(text)
+
+
+def _condition(text: str, context: dict[str, str]) -> bool:
+    match = _COMPARISON.fullmatch(text.strip())
+    if not match:
+        return bool(_term(text, context))
+    left, right = _term(match.group(1), context), _term(match.group(3), context)
+    return left == right if match.group(2) == "==" else left != right
+
+
+def _evaluate(expression: str, context: dict[str, str]) -> str:
+    ternary = _TERNARY.fullmatch(expression.strip())
+    if ternary:
+        taken = ternary.group(2) if _condition(ternary.group(1), context) else ternary.group(3)
+        return _term(taken, context)
+    return _term(expression, context)
+
+
+def _render(group: str, *, ref: str, sha: str, event_name: str = "push") -> str:
+    """The literal group string GitHub would compute for one run."""
+    context = {
+        "github.workflow": "a-workflow",
+        "github.ref": ref,
+        "github.sha": sha,
+        "github.event_name": event_name,
+        "github.repository": "unslothai/unsloth",
+        "github.ref_name": ref.rsplit("/", 1)[-1],
+    }
+    return _INTERPOLATION.sub(lambda m: _evaluate(m.group(1), context), group)
+
+
+def _is_per_commit_on_main(group: str) -> bool:
+    """Whether two commits on main land in DIFFERENT groups.
+
+    Evaluated rather than grepped. ``"github.sha" in group`` was the first form of this and
+    it is not the invariant: reverse the conditional to
+    ``github.ref != 'refs/heads/main' && github.sha || ''`` and the substring is still
+    present, every workflow still names ``refs/heads/main``, and main commits share one
+    group again. Rendering both sides asks the question directly, so which branch supplies
+    the SHA is what decides the answer.
+    """
+    return _render(group, ref = MAIN, sha = "a" * 40) != _render(group, ref = MAIN, sha = "b" * 40)
 
 
 def _runs_on_main_push(document: dict) -> bool:
@@ -111,6 +169,30 @@ def test_the_scan_actually_found_the_workflows():
     assert "studio-backend-ci.yml" in protected
 
 
+def test_this_guard_runs_on_a_workflow_only_pull_request():
+    """Where it is invoked from is part of what it checks.
+
+    The regression this file catches is an edit to some OTHER workflow's concurrency block.
+    No workflow filters on .github/workflows/**, so a PR touching only wheel-smoke.yml
+    collects no test that reads it. workflow-trigger-lint.yml carries no paths filter at
+    all, by design, so it is the one job that sees such a PR.
+    """
+    lint = WORKFLOWS / "workflow-trigger-lint.yml"
+    text = lint.read_text(encoding = "utf-8")
+    assert Path(__file__).name in text, (
+        f"{lint.name} no longer runs {Path(__file__).name}. Backend CI does not filter on "
+        f".github/workflows/**, so this guard would then be absent from exactly the pull "
+        f"requests it exists to check: the ones that edit a workflow and nothing else."
+    )
+    triggers = yaml.safe_load(text).get(True) or yaml.safe_load(text).get("on") or {}
+    pull_request = triggers.get("pull_request")
+    assert isinstance(pull_request, dict) or pull_request is None, pull_request
+    assert not (pull_request or {}).get("paths"), (
+        f"{lint.name} gained a paths filter, so it stopped being the job that sees every "
+        f"pull request and this guard is skippable again"
+    )
+
+
 def test_the_quota_bound_exemptions_still_exist():
     """An exemption naming a file that moved would silently widen to nothing."""
     documents = _documents()
@@ -122,16 +204,64 @@ def test_a_pull_request_still_gets_latest_only():
     """The protection is for main; superseding a PR push is still what we want.
 
     A group keyed on github.sha unconditionally would leave every abandoned PR run
-    executing, which is the opposite of the intent and the expensive direction.
+    executing, which is the opposite of the intent and the expensive direction. Asked by
+    rendering two commits on a pull request ref and requiring the SAME group.
     """
+    offenders = {}
     for name, document in _protected().items():
         group = _group(document)
-        assert "github.ref" in group, f"{name} no longer separates refs: {group!r}"
-        assert "refs/heads/main" in group, (
-            f"{name} applies its per-commit group unconditionally ({group!r}), so pull "
-            f"request pushes stop superseding each other and every abandoned run keeps "
-            f"burning a runner"
+        first = _render(group, ref = A_PULL_REQUEST, sha = "a" * 40, event_name = "pull_request")
+        second = _render(group, ref = A_PULL_REQUEST, sha = "b" * 40, event_name = "pull_request")
+        if first != second:
+            offenders[name] = group
+    assert not offenders, (
+        f"{offenders} put two commits on the same pull request in different concurrency "
+        f"groups, so pushes stop superseding each other and every abandoned run keeps "
+        f"burning a runner. Gate the SHA on github.ref == 'refs/heads/main'."
+    )
+
+
+def test_every_group_expression_is_understood():
+    """The evaluator refuses to guess, and a refusal must be loud rather than a skip."""
+    unreadable = {}
+    for name, document in _protected().items():
+        group = _group(document)
+        try:
+            _render(group, ref = MAIN, sha = "a" * 40)
+        except Unparsed as exc:
+            unreadable[name] = f"{group!r} contains {exc}"
+    assert not unreadable, (
+        f"the concurrency evaluator in this file cannot read {unreadable}, so it cannot say "
+        f"whether those workflows survive a merge burst. Extend _term/_evaluate to cover the "
+        f"new syntax rather than removing the workflow from the scan."
+    )
+
+
+def test_the_evaluator_reads_which_branch_supplies_the_sha():
+    """The predicate above is only worth its assertions if this holds.
+
+    Each of these renders to a string containing ``github.sha`` in its source text, and the
+    substring test that this file first shipped with called all four per-commit. Only the
+    first one is.
+    """
+    gated = "${{ github.ref }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}"
+    reversed_ = "${{ github.ref }}-${{ github.ref != 'refs/heads/main' && github.sha || '' }}"
+    wrong_branch = "${{ github.ref }}-${{ github.ref == 'refs/heads/main' && '' || github.sha }}"
+    unconditional = "${{ github.ref }}-${{ github.sha }}"
+
+    assert _is_per_commit_on_main(gated)
+    assert not _is_per_commit_on_main(reversed_), "a reversed conditional shares one main group"
+    assert not _is_per_commit_on_main(wrong_branch), "the SHA is on the pull request branch"
+    assert _is_per_commit_on_main(unconditional)
+
+    # ... and the pull request half, which is what disqualifies the unconditional form.
+    def _same_on_a_pull_request(group: str) -> bool:
+        return _render(group, ref = A_PULL_REQUEST, sha = "a" * 40) == _render(
+            group, ref = A_PULL_REQUEST, sha = "b" * 40
         )
+
+    assert _same_on_a_pull_request(gated)
+    assert not _same_on_a_pull_request(unconditional)
 
 
 def test_no_workflow_claims_a_main_protection_it_does_not_have():


### PR DESCRIPTION
`cancel-in-progress: false` does not keep a main run alive. Twenty-seven workflows said it does.

GitHub cancels any **pending** run in a concurrency group as soon as a newer one is queued. `cancel-in-progress` governs only runs that are already **executing**. From the workflow-syntax reference:

> any existing `pending` job or workflow in the same concurrency group will be canceled and the new queued job or workflow will take its place

Every commit on main shares one group (`${{ github.workflow }}-${{ github.ref }}`), so on a branch where pushes land in bursts, the runs in the middle are discarded whatever `cancel-in-progress` says.

## Evidence

`studio-ui-smoke.yml` already records one incident in its own comment: a break sat on main *"for 14 hours behind four cancelled runs"*. The comment added to prevent a recurrence cannot prevent it.

And today, five merges:

```
09:19:48 -> 09:45:00  cancelled  0ac2e799   Backend CI
09:44:59 -> 09:55:17  cancelled  4d1f9c51   Backend CI
09:55:16 -> 09:56:59  cancelled  9156c36e   Backend CI
09:56:57 -> 10:08:27  cancelled  6453075c   Backend CI
10:08:26 ->           pending    a41f7785   Backend CI
```

Each cancelled within a second of the next merge being queued. `6453075c` had waited 11 minutes. **Main Backend CI completed zero times**, and the same happened to all 23 workflows on each commit.

**Nothing was saved by any of it.** Every one of those runs recorded `jobs: 0` -- they were discarded before allocating a single job, so they consumed no runner minutes. The cancellation bought nothing and cost the repo its main signal.

## The change

Every workflow that triggers on push to main keys its concurrency group on `github.sha` when the ref is main:

```yaml
group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
```

Each main commit gets its own group, so nothing supersedes it and every main run finishes.

Pull requests are untouched. The `sha` term is empty off main, so the group is byte-identical to before and superseded PR runs are still cancelled -- that is the direction where cancelling genuinely saves runner time, and the guard asserts it stays that way.

**One exception.** The two Kaggle workflows keep a shared group. They spend an external GPU quota rather than runner minutes, so there a superseded run really should be dropped instead of replayed per commit.

## The guard

`tests/studio/test_main_runs_survive_merge_bursts.py`:

1. every workflow triggered on push to main is grouped per commit;
2. pull requests still get latest-only, so this cannot drift into "never cancel anything";
3. no workflow claims main protection in a comment while sharing a group across main commits -- read from raw text, since a comment is exactly what YAML discards and the comment is what people act on;
4. the scan actually matched workflows, since a broken glob would pass the rest.

Mutation-checked four ways: reverting one workflow to a shared group, applying `github.sha` unconditionally, pointing the exemption at a missing file, and re-adding the old claim to a workflow that still shares a group.

## On cost

This does mean main runs more during a merge burst, and that is the point rather than a side effect: the alternative on offer was never "cheaper CI", it was "no CI on main". The place to win time back is duplicated work, not discarded runs -- the three OS smoke triples carry ~1,766 lines of test logic inline in YAML at 68-83% similarity, which is tracked separately.
