### PR TITLE
Studio: give a CRLF reply the same incremental rendering as an LF one

### DIFF
--- a/studio/frontend/src/components/assistant-ui/streaming-render-schedule.ts
+++ b/studio/frontend/src/components/assistant-ui/streaming-render-schedule.ts
@@ -604,6 +604,16 @@ type CommitPoint = {
   context: RetainedContext;
 };
 
+// CommonMark counts a line feed, a lone carriage return, and a carriage return
+// followed by a line feed as the same line ending, and reference parsers
+// normalise to LF before parsing, so this cannot change what is rendered. The
+// scan runs per frame and is a native `indexOf`, which costs nothing next to
+// the repair and lex it protects; the replace itself only runs for a reply that
+// actually carries a carriage return.
+function normalizeLineEndings(text: string): string {
+  return text.includes("\r") ? text.replace(/\r\n?/g, "\n") : text;
+}
+
 function sharedPrefixLength(left: string, right: string): number {
   const limit = Math.min(left.length, right.length);
   let index = 0;
@@ -830,7 +840,15 @@ export class IncrementalMarkdownCache {
     this.source = markdown;
   }
 
-  update(markdown: string): IncrementalMarkdownRender {
+  update(rawMarkdown: string): IncrementalMarkdownRender {
+    // Every boundary this class finds is a byte offset into the text it was
+    // handed, but the blocks it compares against come back from Streamdown with
+    // their line endings already normalised. On a CRLF reply the two disagree
+    // one block in, `findCommitBoundary` sees `"para"` where the source holds
+    // `"para\r"`, nothing is ever committed, and the whole reply re-repairs and
+    // re-lexes on every frame. Normalise first so both sides speak LF.
+    const markdown = normalizeLineEndings(rawMarkdown);
+
     // Tokens arrive faster than frames, so the coalescer hands the same text to
     // several renders. Nothing about the result can differ, and repeating the
     // work would be the whole reply again once the document path is in use.

--- a/studio/frontend/src/components/assistant-ui/streaming-render-schedule.ts
+++ b/studio/frontend/src/components/assistant-ui/streaming-render-schedule.ts
@@ -607,8 +607,8 @@ type CommitPoint = {
 // CommonMark counts a line feed, a lone carriage return, and a carriage return
 // followed by a line feed as the same line ending, and reference parsers
 // normalise to LF before parsing, so this cannot change what is rendered. The
-// scan runs per frame and is a native `indexOf`, which costs nothing next to
-// the repair and lex it protects; the replace itself only runs for a reply that
+// scan runs per frame and costs nothing next to the repair and lex it protects
+// (0.4 us on an 88,000 character reply); the replace only runs for a reply that
 // actually carries a carriage return.
 function normalizeLineEndings(text: string): string {
   return text.includes("\r") ? text.replace(/\r\n?/g, "\n") : text;

--- a/studio/frontend/tests/streaming-crlf-retention.test.ts
+++ b/studio/frontend/tests/streaming-crlf-retention.test.ts
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import remend from "remend";
+import { parseMarkdownIntoBlocks } from "streamdown";
+
+import { stabilizeStreamingMarkdown } from "../src/components/assistant-ui/streaming-markdown.ts";
+import { IncrementalMarkdownCache } from "../src/components/assistant-ui/streaming-render-schedule.ts";
+import { preprocessLaTeX } from "../src/lib/latex.ts";
+
+const processStreamingText = (text: string): string =>
+  stabilizeStreamingMarkdown(preprocessLaTeX(text), true);
+
+const asCrlf = (text: string): string => text.replace(/\r?\n/g, "\r\n");
+const asLf = (text: string): string => text.replace(/\r\n?/g, "\n");
+
+const UNITS = [
+  "The residual \\(r_i = y_i - \\hat{y}_i\\) shrinks as the fit improves.\n\n",
+  "Rewriting gives\n\n\\[ L(\\theta) = \\sum_i (y_i - \\theta x_i)^2 \\]\n\nwhich is convex.\n\n",
+  "At that batch size the run costs about $1,200 per epoch.\n\n",
+  "- learning rate three ten-thousandths\n- budget $250\n\n",
+  "```python\ndef step(theta, grad, lr):\n    return theta - lr * grad\n```\n\n",
+];
+
+function buildReply(count: number): string {
+  let out = "";
+  for (let index = 0; index < count; index += 1) {
+    out += UNITS[index % UNITS.length];
+  }
+  return out;
+}
+
+function stream(reply: string, step: number) {
+  const cache = new IncrementalMarkdownCache();
+  let blocks: string[] = [];
+  for (let length = step; length <= reply.length; length += step) {
+    const render = cache.update(processStreamingText(reply.slice(0, length)));
+    blocks = render.parseMarkdownIntoBlocks(render.markdown);
+  }
+  const render = cache.update(processStreamingText(reply));
+  blocks = render.parseMarkdownIntoBlocks(render.markdown);
+  const internals = cache as unknown as { committedLength: number };
+  return { blocks, retained: internals.committedLength };
+}
+
+test("a CRLF reply retains as much as the same reply in LF", () => {
+  // Providers and platforms disagree about line endings, and the cache compares
+  // byte offsets in the text it is handed against blocks Streamdown returns with
+  // the line endings already normalised. Before this was fixed the two disagreed
+  // one block in: nothing was ever committed, the sticky full-document path took
+  // over, and a CRLF reader paid a repair and a lex of the whole reply on every
+  // frame for a reply that rendered exactly the same. Nothing in the output says
+  // so, which is why it survived.
+  const lf = buildReply(160);
+  const crlf = asCrlf(lf);
+  assert.ok(lf.length > 8_000, `fixture too small: ${lf.length}`);
+
+  const lfRun = stream(lf, 24);
+  const crlfRun = stream(crlf, 24);
+
+  assert.ok(
+    lfRun.retained > lf.length * 0.8,
+    `the LF control retained only ${lfRun.retained} of ${lf.length}`,
+  );
+  assert.equal(
+    crlfRun.retained,
+    lfRun.retained,
+    `CRLF retained ${crlfRun.retained} characters against LF's ${lfRun.retained}`,
+  );
+  // Retention is only worth having if the blocks are the same ones, so pin the
+  // output too: a CRLF reply must render as the identical block list.
+  assert.deepEqual(crlfRun.blocks, lfRun.blocks);
+});
+
+test("a CRLF reply matches a whole-document split at every prefix", () => {
+  // The correctness half. The comparison is against a parse of the NORMALISED
+  // text, because that is what a CommonMark parser sees: the spec counts a line
+  // feed, a lone carriage return, and a carriage return followed by a line feed
+  // as the same line ending, and reference parsers normalise before parsing.
+  const sources = [
+    "para one\r\n\r\npara two\r\n\r\npara three\r\n\r\npara four\r\n\r\n",
+    asCrlf("Cost $1,200 now.\n\nThe value \\(x^2\\) here.\n\n\\[a = b\\]\n\ndone\n\n"),
+    asCrlf("```sh\nrun --seed $1\n```\n\nAfter the fence $5.\n\n"),
+    asCrlf("| a | b |\n| --- | --- |\n| $5 | \\(x\\) |\n\nAfter the table.\n\n"),
+    // A carriage return can land at the end of a frame with its line feed still
+    // to come, so a lone trailing CR has to read as a line ending too. Treating
+    // only the pair would leave that CR in place and then delete it a frame
+    // later, which is one more rewrite for the cache to absorb.
+    "a\r\n\r\nb\r",
+  ];
+  for (const source of sources) {
+    const cache = new IncrementalMarkdownCache();
+    for (let length = 0; length <= source.length; length += 1) {
+      const input = processStreamingText(source.slice(0, length));
+      const render = cache.update(input);
+      assert.deepEqual(
+        render.parseMarkdownIntoBlocks(render.markdown),
+        parseMarkdownIntoBlocks(remend(asLf(input))),
+        `block mismatch at prefix ${length} of ${JSON.stringify(source.slice(0, 60))}`,
+      );
+    }
+  }
+});
+
+test("an LF reply is untouched by the line-ending handling", () => {
+  // The guard on the other side: a reply with no carriage return in it must take
+  // exactly the path it took before, so this cannot cost the common case
+  // anything or move its output.
+  const reply = buildReply(60);
+  assert.ok(!reply.includes("\r"));
+  const run = stream(reply, 24);
+  const cache = new IncrementalMarkdownCache();
+  for (let length = 0; length <= reply.length; length += 24) {
+    const input = processStreamingText(reply.slice(0, length));
+    const render = cache.update(input);
+    assert.deepEqual(
+      render.parseMarkdownIntoBlocks(render.markdown),
+      parseMarkdownIntoBlocks(remend(input)),
+      `block mismatch at prefix ${length}`,
+    );
+  }
+  assert.ok(run.retained > reply.length * 0.8);
+});


### PR DESCRIPTION
## Problem

`IncrementalMarkdownCache` measures every boundary as an offset into the text it is
handed. It compares those offsets against the blocks `parseMarkdownIntoBlocks`
returns, and Streamdown hands those back with their line endings already
normalised. On a CRLF reply the two disagree one block in:

```js
parseMarkdownIntoBlocks(remend("para one\r\n\r\npara two\r\n\r\n"))
// ["para one", "\n\n", "para two", "\n\n"]      the source holds "para one\r"
```

`findCommitBoundary` matches block 0 at offset 0, advances to 8, then asks whether
the tail continues `"\n\n"` where it actually holds `"\r\n\r\n"`. The check fails,
`repairBroke` is set, and `update` takes the **sticky full-document path**. From
that point the whole reply is repaired and lexed on every frame, for the rest of
the reply.

A user whose provider or platform emits CRLF gets no incremental rendering at all.

**It is not only a cost bug.** Streamed at every prefix over a 454 reply corpus, a
CRLF reply's block list already differs from the same reply in LF in **11 of 454**
replies on `main`, and the block count differs in one. After this change it does not
differ in any. So `main` renders some CRLF replies into a different block list than
the identical LF reply, which is a correctness difference, not a performance trade.
The rest of the difference is time, and nothing in the output says so, which is why
this has survived.

## The change

Normalise the line endings at the entry to the cache.

Per the [CommonMark spec](https://spec.commonmark.org/0.30/), "a line ending is a
line feed (U+000A), a carriage return (U+000D) not followed by a line feed, or a
carriage return and a following line feed", and reference parsers normalise to LF
before parsing, so this cannot change what is rendered. A **lone** carriage return
is included deliberately: a CRLF pair can be split across two frames, and treating
only the pair would leave that CR in place for one frame and delete it the next,
which is one more retro-edit for the cache to absorb.

The scan is a native `includes`, and the replace runs only for a reply that actually
carries a carriage return.

## Measurement

Paired A/B in a single process, both versions of the cache imported side by side and
run alternately so host load lands on both arms, 24 character frames, median of 5
paired ratios.

| CRLF reply | on `main` | with this change | the same reply in LF, for scale |
| --- | --- | --- | --- |
| 8,520 chars, 355 frames | 333 ms | **68 ms** (4.86x, 4.58 to 4.90) | 59 ms |
| 34,080 chars, 1,420 frames | 20,177 ms | **701 ms** (28.65x, 23.07 to 29.11) | 521 ms |

The ratio grows with the reply because the discarded work is the whole reply each
time. After the change a CRLF reply sits within 1.35x of the same reply in LF; the
gap left is the per-frame preprocessing, not the cache.

Retention over a 454 reply corpus streamed at every prefix:

| | retained characters |
| --- | --- |
| LF on `main` | 7,591 |
| CRLF on `main` | **281** |
| CRLF with this change | 7,591 |

Exact parity with the LF corpus.

## Rendered output is unchanged

454 replies streamed at every prefix in both line endings, comparing the mdast text
and math nodes of the whole document, of every block on its own, and the block count:

| comparison | documentText | documentMath | blockText | blockMath | blockCount |
| --- | --- | --- | --- | --- | --- |
| **LF: this change vs `main`** | 0 | 0 | 0 | 0 | 0 |
| **CRLF: this change vs the same reply in LF** | 1 | 85 | **0** | **0** | **0** |
| CRLF vs LF on `main` today | 1 | 85 | 1 | 11 | 1 |

Row 1 is the guarantee for the common case: an LF reply is not touched.

Row 2 is the goal, reached: a CRLF reply now renders as the identical block list to
the same reply in LF. The `documentText` and `documentMath` columns in that row are
**not** this cache: that fingerprint is a direct whole-document parse of the CRLF
text, bypassing the cache entirely, and row 3 shows the same 1 and 85 on `main`.
That is a pre-existing property of parsing CRLF markdown with micromark, unchanged
here in either direction.

Row 3 is the correctness point above, in the table: on `main` a CRLF reply's block
list diverges from the LF one in 11 replies and the block count in 1. Row 2 shows
both at 0.

The oracle, the cache's block list against a whole-document split at every prefix of
353 CRLF replies: **0 mismatches**, comparing against a parse of the normalised text,
which is what a CommonMark parser sees.

## Tests

`studio/frontend/tests/streaming-crlf-retention.test.ts`, three tests. Being explicit
about which are detectors, since a test that passes on the broken tree proves nothing
about the bug:

- **`a CRLF reply retains as much as the same reply in LF`** - **fails on `main`**
  with `CRLF retained 0 characters against LF's 10518`. This is the defect. It also
  pins the block list, so retention that returned different blocks would not pass.
- **`a CRLF reply matches a whole-document split at every prefix`** - passes on `main`
  as well. It is the output guard, including a reply ending in a lone carriage
  return, not a defect detector.
- **`an LF reply is untouched by the line-ending handling`** - passes on `main` as
  well, by design: it is the regression guard for the common path.

`npm test` (3,590 pass), `npm run typecheck`, `npm run build` and `npx eslint` on
both changed files are clean.

## Scope

Found while verifying #9017, and deliberately not folded into it: it is a separate,
pre-existing defect that predates that PR, and #9017's own Codex round raised a CRLF
issue in the blank-line scan whose stated CPU consequence turned out to be this,
rather than anything #9017 introduced.

