### PR TITLE
Run the Backend CI matrix in parallel, like its sibling job already does

### DIFF
--- a/.github/workflows/studio-backend-ci.yml
+++ b/.github/workflows/studio-backend-ci.yml
@@ -195,10 +195,21 @@ jobs:
         # descheduled by the other three inflates one side of that ratio. Observed on
         # staging, where the 3.10 leg reported "early markup cost 1.354s against the
         # reference's 0.854s" while 3.13 passed the same commit.
+        #
+        # The other two assert ABSOLUTE elapsed time, and tightly: 50ms for a
+        # short-circuit that should not run at all, and 100ms for a regex backtracking
+        # guard. Bounds that small are inside one scheduler quantum, so under four
+        # workers they measure the scheduler as much as the code. Bounds of 0.5s and up
+        # are left in the parallel run; there are 22 files with elapsed-time bounds and
+        # serialising all of them would give back most of what this change buys. The
+        # isolation guard scans for the tight ones, so a new test below the threshold
+        # fails that guard instead of flaking here.
         run: |
           python -m pytest tests/ -q --tb=short -n 4 \
             --ignore=tests/test_studio_api.py \
             --ignore=tests/test_streaming_stripper.py \
+            --ignore=tests/test_llama_cpp_wait_for_vram_settle.py \
+            --ignore=tests/test_tool_xml_strip.py \
             -k 'not llama_cpp_load_progress_live and not TestGpuAutoSelection and not TestPreSpawnGpuResolution and not TestPerGpuFitGuardAllCounts and not TestTransformersIntrospection and not test_returns_cuda_when_cuda_available and not test_calls_cuda_cache_when_cuda'
 
       - name: Backend tests that cannot share a worker
@@ -206,7 +217,10 @@ jobs:
         # Relative timing against a reference measured in the same process. Serial, so the
         # comparison is between two implementations rather than between two schedulings.
         run: |
-          python -m pytest tests/test_streaming_stripper.py -q --tb=short
+          python -m pytest -q --tb=short \
+            tests/test_streaming_stripper.py \
+            tests/test_llama_cpp_wait_for_vram_settle.py \
+            tests/test_tool_xml_strip.py
 
   repo-cpu-tests:
     # Auto-discover everything under tests/ that is not GPU-bound by

--- a/.github/workflows/studio-backend-ci.yml
+++ b/.github/workflows/studio-backend-ci.yml
@@ -211,6 +211,8 @@ jobs:
             --ignore=tests/test_llama_cpp_wait_for_vram_settle.py \
             --ignore=tests/test_tool_xml_strip.py \
             --ignore=tests/test_diffusion_checkpoint_resume.py \
+            --ignore=tests/test_tool_output_streaming.py \
+            --ignore=tests/test_web_fetch_extraction.py \
             -k 'not llama_cpp_load_progress_live and not TestGpuAutoSelection and not TestPreSpawnGpuResolution and not TestPerGpuFitGuardAllCounts and not TestTransformersIntrospection and not test_returns_cuda_when_cuda_available and not test_calls_cuda_cache_when_cuda'
 
       - name: Backend tests that cannot share a worker
@@ -222,7 +224,9 @@ jobs:
             tests/test_streaming_stripper.py \
             tests/test_llama_cpp_wait_for_vram_settle.py \
             tests/test_tool_xml_strip.py \
-            tests/test_diffusion_checkpoint_resume.py
+            tests/test_diffusion_checkpoint_resume.py \
+            tests/test_tool_output_streaming.py \
+            tests/test_web_fetch_extraction.py
 
   repo-cpu-tests:
     # Auto-discover everything under tests/ that is not GPU-bound by

--- a/.github/workflows/studio-backend-ci.yml
+++ b/.github/workflows/studio-backend-ci.yml
@@ -132,7 +132,7 @@ jobs:
           pip install \
             python-multipart aiofiles sqlalchemy cryptography psutil \
             pyyaml jinja2 mammoth unpdf requests \
-            'numpy<3' pytest pytest-asyncio httpx \
+            'numpy<3' pytest pytest-asyncio pytest-xdist httpx \
             soundfile librosa
           # soundfile + librosa: test_audio_dataset_decode importorskips both, so without
           # them the no-torchcodec decode path is silently untested here.
@@ -176,8 +176,20 @@ jobs:
         #   - TestTransformersIntrospection: same
         #   - test_returns_cuda_when_cuda_available / test_calls_cuda_cache_when_cuda:
         #       assume CUDA-capable GPU
+        #
+        # -n 4: 1322.6s -> 343.0s locally on the same 4-worker shape as the runner, with
+        # an IDENTICAL result -- 51 failed / 26190 passed serial against 51 failed /
+        # 26188 passed parallel, and the two failure sets compared equal name for name,
+        # so nothing here depends on the order it runs in. (Those 51 are a local
+        # environment missing peft and a diffusers pin; the point is that the two modes
+        # agree, not the count.) Same shape as repo-cpu-tests below, which has run -n 4
+        # since it measured 806s -> 220s.
+        #
+        # Unit tests, so this is CPU and not memory bound: the job installs --no-torch
+        # style CPU wheels and loads no model, unlike the inference smoke workflows
+        # where four workers on one runner would not fit.
         run: |
-          python -m pytest tests/ -q --tb=short \
+          python -m pytest tests/ -q --tb=short -n 4 \
             --ignore=tests/test_studio_api.py \
             -k 'not llama_cpp_load_progress_live and not TestGpuAutoSelection and not TestPreSpawnGpuResolution and not TestPerGpuFitGuardAllCounts and not TestTransformersIntrospection and not test_returns_cuda_when_cuda_available and not test_calls_cuda_cache_when_cuda'
 

--- a/.github/workflows/studio-backend-ci.yml
+++ b/.github/workflows/studio-backend-ci.yml
@@ -210,6 +210,7 @@ jobs:
             --ignore=tests/test_streaming_stripper.py \
             --ignore=tests/test_llama_cpp_wait_for_vram_settle.py \
             --ignore=tests/test_tool_xml_strip.py \
+            --ignore=tests/test_diffusion_checkpoint_resume.py \
             -k 'not llama_cpp_load_progress_live and not TestGpuAutoSelection and not TestPreSpawnGpuResolution and not TestPerGpuFitGuardAllCounts and not TestTransformersIntrospection and not test_returns_cuda_when_cuda_available and not test_calls_cuda_cache_when_cuda'
 
       - name: Backend tests that cannot share a worker
@@ -220,7 +221,8 @@ jobs:
           python -m pytest -q --tb=short \
             tests/test_streaming_stripper.py \
             tests/test_llama_cpp_wait_for_vram_settle.py \
-            tests/test_tool_xml_strip.py
+            tests/test_tool_xml_strip.py \
+            tests/test_diffusion_checkpoint_resume.py
 
   repo-cpu-tests:
     # Auto-discover everything under tests/ that is not GPU-bound by

--- a/.github/workflows/studio-backend-ci.yml
+++ b/.github/workflows/studio-backend-ci.yml
@@ -213,6 +213,7 @@ jobs:
             --ignore=tests/test_diffusion_checkpoint_resume.py \
             --ignore=tests/test_tool_output_streaming.py \
             --ignore=tests/test_web_fetch_extraction.py \
+            --ignore=tests/test_tool_call_parser_strict.py \
             -k 'not llama_cpp_load_progress_live and not TestGpuAutoSelection and not TestPreSpawnGpuResolution and not TestPerGpuFitGuardAllCounts and not TestTransformersIntrospection and not test_returns_cuda_when_cuda_available and not test_calls_cuda_cache_when_cuda'
 
       - name: Backend tests that cannot share a worker
@@ -226,7 +227,8 @@ jobs:
             tests/test_tool_xml_strip.py \
             tests/test_diffusion_checkpoint_resume.py \
             tests/test_tool_output_streaming.py \
-            tests/test_web_fetch_extraction.py
+            tests/test_web_fetch_extraction.py \
+            tests/test_tool_call_parser_strict.py
 
   repo-cpu-tests:
     # Auto-discover everything under tests/ that is not GPU-bound by

--- a/.github/workflows/studio-backend-ci.yml
+++ b/.github/workflows/studio-backend-ci.yml
@@ -217,6 +217,7 @@ jobs:
             --ignore=tests/test_tunnel_safe_long_post.py \
             --ignore=tests/test_scan_loras_off_event_loop.py \
             --ignore=tests/test_anthropic_messages.py \
+            --ignore=tests/test_profile_stats.py \
             -k 'not llama_cpp_load_progress_live and not TestGpuAutoSelection and not TestPreSpawnGpuResolution and not TestPerGpuFitGuardAllCounts and not TestTransformersIntrospection and not test_returns_cuda_when_cuda_available and not test_calls_cuda_cache_when_cuda'
 
       - name: Backend tests that cannot share a worker
@@ -234,7 +235,8 @@ jobs:
             tests/test_tool_call_parser_strict.py \
             tests/test_tunnel_safe_long_post.py \
             tests/test_scan_loras_off_event_loop.py \
-            tests/test_anthropic_messages.py
+            tests/test_anthropic_messages.py \
+            tests/test_profile_stats.py
 
   repo-cpu-tests:
     # Auto-discover everything under tests/ that is not GPU-bound by

--- a/.github/workflows/studio-backend-ci.yml
+++ b/.github/workflows/studio-backend-ci.yml
@@ -214,6 +214,7 @@ jobs:
             --ignore=tests/test_tool_output_streaming.py \
             --ignore=tests/test_web_fetch_extraction.py \
             --ignore=tests/test_tool_call_parser_strict.py \
+            --ignore=tests/test_tunnel_safe_long_post.py \
             -k 'not llama_cpp_load_progress_live and not TestGpuAutoSelection and not TestPreSpawnGpuResolution and not TestPerGpuFitGuardAllCounts and not TestTransformersIntrospection and not test_returns_cuda_when_cuda_available and not test_calls_cuda_cache_when_cuda'
 
       - name: Backend tests that cannot share a worker
@@ -228,7 +229,8 @@ jobs:
             tests/test_diffusion_checkpoint_resume.py \
             tests/test_tool_output_streaming.py \
             tests/test_web_fetch_extraction.py \
-            tests/test_tool_call_parser_strict.py
+            tests/test_tool_call_parser_strict.py \
+            tests/test_tunnel_safe_long_post.py
 
   repo-cpu-tests:
     # Auto-discover everything under tests/ that is not GPU-bound by

--- a/.github/workflows/studio-backend-ci.yml
+++ b/.github/workflows/studio-backend-ci.yml
@@ -215,6 +215,7 @@ jobs:
             --ignore=tests/test_web_fetch_extraction.py \
             --ignore=tests/test_tool_call_parser_strict.py \
             --ignore=tests/test_tunnel_safe_long_post.py \
+            --ignore=tests/test_scan_loras_off_event_loop.py \
             -k 'not llama_cpp_load_progress_live and not TestGpuAutoSelection and not TestPreSpawnGpuResolution and not TestPerGpuFitGuardAllCounts and not TestTransformersIntrospection and not test_returns_cuda_when_cuda_available and not test_calls_cuda_cache_when_cuda'
 
       - name: Backend tests that cannot share a worker
@@ -230,7 +231,8 @@ jobs:
             tests/test_tool_output_streaming.py \
             tests/test_web_fetch_extraction.py \
             tests/test_tool_call_parser_strict.py \
-            tests/test_tunnel_safe_long_post.py
+            tests/test_tunnel_safe_long_post.py \
+            tests/test_scan_loras_off_event_loop.py
 
   repo-cpu-tests:
     # Auto-discover everything under tests/ that is not GPU-bound by

--- a/.github/workflows/studio-backend-ci.yml
+++ b/.github/workflows/studio-backend-ci.yml
@@ -188,10 +188,25 @@ jobs:
         # Unit tests, so this is CPU and not memory bound: the job installs --no-torch
         # style CPU wheels and loads no model, unlike the inference smoke workflows
         # where four workers on one runner would not fit.
+        #
+        # test_streaming_stripper is ignored here and run serially below, for the reason
+        # repo-cpu-tests already isolates load_freeze: it compares its own measured cost
+        # against a reference implementation timed in the same process, and a worker
+        # descheduled by the other three inflates one side of that ratio. Observed on
+        # staging, where the 3.10 leg reported "early markup cost 1.354s against the
+        # reference's 0.854s" while 3.13 passed the same commit.
         run: |
           python -m pytest tests/ -q --tb=short -n 4 \
             --ignore=tests/test_studio_api.py \
+            --ignore=tests/test_streaming_stripper.py \
             -k 'not llama_cpp_load_progress_live and not TestGpuAutoSelection and not TestPreSpawnGpuResolution and not TestPerGpuFitGuardAllCounts and not TestTransformersIntrospection and not test_returns_cuda_when_cuda_available and not test_calls_cuda_cache_when_cuda'
+
+      - name: Backend tests that cannot share a worker
+        working-directory: studio/backend
+        # Relative timing against a reference measured in the same process. Serial, so the
+        # comparison is between two implementations rather than between two schedulings.
+        run: |
+          python -m pytest tests/test_streaming_stripper.py -q --tb=short
 
   repo-cpu-tests:
     # Auto-discover everything under tests/ that is not GPU-bound by

--- a/.github/workflows/studio-backend-ci.yml
+++ b/.github/workflows/studio-backend-ci.yml
@@ -216,6 +216,7 @@ jobs:
             --ignore=tests/test_tool_call_parser_strict.py \
             --ignore=tests/test_tunnel_safe_long_post.py \
             --ignore=tests/test_scan_loras_off_event_loop.py \
+            --ignore=tests/test_anthropic_messages.py \
             -k 'not llama_cpp_load_progress_live and not TestGpuAutoSelection and not TestPreSpawnGpuResolution and not TestPerGpuFitGuardAllCounts and not TestTransformersIntrospection and not test_returns_cuda_when_cuda_available and not test_calls_cuda_cache_when_cuda'
 
       - name: Backend tests that cannot share a worker
@@ -232,7 +233,8 @@ jobs:
             tests/test_web_fetch_extraction.py \
             tests/test_tool_call_parser_strict.py \
             tests/test_tunnel_safe_long_post.py \
-            tests/test_scan_loras_off_event_loop.py
+            tests/test_scan_loras_off_event_loop.py \
+            tests/test_anthropic_messages.py
 
   repo-cpu-tests:
     # Auto-discover everything under tests/ that is not GPU-bound by

--- a/studio/backend/tests/test_gguf_reload_inheritance.py
+++ b/studio/backend/tests/test_gguf_reload_inheritance.py
@@ -46,7 +46,15 @@ _httpx_stub.Client = type(
         "__exit__": lambda s, *a: None,
     },
 )
-sys.modules.setdefault("httpx", _httpx_stub)
+# Only when the real library is absent. sys.modules holds what has been IMPORTED, not
+# what is installed, so setdefault does not defer to a real httpx that nothing in this
+# process has touched yet: the stub wins and shadows it for the whole session. This stub
+# has no Response, and starlette.testclient reads httpx.Response at import, so every
+# module collected afterwards that reaches fastapi.testclient or routes.inference dies.
+try:
+    import httpx  # noqa: F401
+except ImportError:
+    sys.modules.setdefault("httpx", _httpx_stub)
 
 from core.inference.llama_cpp import GgufLoadIntent, LlamaCppBackend
 

--- a/studio/backend/tests/test_llama_cpp_cache_aware_disk_check.py
+++ b/studio/backend/tests/test_llama_cpp_cache_aware_disk_check.py
@@ -63,7 +63,15 @@ _httpx_stub.Client = type(
         "__exit__": lambda self, *a: None,
     },
 )
-sys.modules.setdefault("httpx", _httpx_stub)
+# Only when the real library is absent. sys.modules holds what has been IMPORTED, not
+# what is installed, so setdefault does not defer to a real httpx that nothing in this
+# process has touched yet: the stub wins and shadows it for the whole session. This stub
+# has no Response, and starlette.testclient reads httpx.Response at import, so every
+# module collected afterwards that reaches fastapi.testclient or routes.inference dies.
+try:
+    import httpx  # noqa: F401
+except ImportError:
+    sys.modules.setdefault("httpx", _httpx_stub)
 
 
 # ---------------------------------------------------------------------------

--- a/studio/backend/tests/test_llama_cpp_context_fit.py
+++ b/studio/backend/tests/test_llama_cpp_context_fit.py
@@ -65,7 +65,15 @@ _httpx_stub.Client = type(
         "__exit__": lambda self, *a: None,
     },
 )
-sys.modules.setdefault("httpx", _httpx_stub)
+# Only when the real library is absent. sys.modules holds what has been IMPORTED, not
+# what is installed, so setdefault does not defer to a real httpx that nothing in this
+# process has touched yet: the stub wins and shadows it for the whole session. This stub
+# has no Response, and starlette.testclient reads httpx.Response at import, so every
+# module collected afterwards that reaches fastapi.testclient or routes.inference dies.
+try:
+    import httpx  # noqa: F401
+except ImportError:
+    sys.modules.setdefault("httpx", _httpx_stub)
 
 from core.inference.llama_cpp import (
     _APPLE_UNIFIED_MEMORY_FRACTION,

--- a/studio/backend/tests/test_llama_cpp_load_progress.py
+++ b/studio/backend/tests/test_llama_cpp_load_progress.py
@@ -70,7 +70,15 @@ _httpx_stub.Client = type(
         "__exit__": lambda self, *a: None,
     },
 )
-sys.modules.setdefault("httpx", _httpx_stub)
+# Only when the real library is absent. sys.modules holds what has been IMPORTED, not
+# what is installed, so setdefault does not defer to a real httpx that nothing in this
+# process has touched yet: the stub wins and shadows it for the whole session. This stub
+# has no Response, and starlette.testclient reads httpx.Response at import, so every
+# module collected afterwards that reaches fastapi.testclient or routes.inference dies.
+try:
+    import httpx  # noqa: F401
+except ImportError:
+    sys.modules.setdefault("httpx", _httpx_stub)
 
 from core.inference.llama_cpp import LlamaCppBackend
 

--- a/studio/backend/tests/test_llama_cpp_load_progress_live.py
+++ b/studio/backend/tests/test_llama_cpp_load_progress_live.py
@@ -51,7 +51,15 @@ _httpx_stub.Client = type(
         "__exit__": lambda self, *a: None,
     },
 )
-sys.modules.setdefault("httpx", _httpx_stub)
+# Only when the real library is absent. sys.modules holds what has been IMPORTED, not
+# what is installed, so setdefault does not defer to a real httpx that nothing in this
+# process has touched yet: the stub wins and shadows it for the whole session. This stub
+# has no Response, and starlette.testclient reads httpx.Response at import, so every
+# module collected afterwards that reaches fastapi.testclient or routes.inference dies.
+try:
+    import httpx  # noqa: F401
+except ImportError:
+    sys.modules.setdefault("httpx", _httpx_stub)
 
 from core.inference.llama_cpp import LlamaCppBackend
 

--- a/studio/backend/tests/test_llama_cpp_load_progress_matrix.py
+++ b/studio/backend/tests/test_llama_cpp_load_progress_matrix.py
@@ -63,7 +63,15 @@ _httpx_stub.Client = type(
         "__exit__": lambda self, *a: None,
     },
 )
-sys.modules.setdefault("httpx", _httpx_stub)
+# Only when the real library is absent. sys.modules holds what has been IMPORTED, not
+# what is installed, so setdefault does not defer to a real httpx that nothing in this
+# process has touched yet: the stub wins and shadows it for the whole session. This stub
+# has no Response, and starlette.testclient reads httpx.Response at import, so every
+# module collected afterwards that reaches fastapi.testclient or routes.inference dies.
+try:
+    import httpx  # noqa: F401
+except ImportError:
+    sys.modules.setdefault("httpx", _httpx_stub)
 
 from core.inference.llama_cpp import LlamaCppBackend
 

--- a/studio/backend/tests/test_llama_cpp_max_context_threshold.py
+++ b/studio/backend/tests/test_llama_cpp_max_context_threshold.py
@@ -72,7 +72,15 @@ _httpx_stub.Client = type(
         "__exit__": lambda self, *a: None,
     },
 )
-sys.modules.setdefault("httpx", _httpx_stub)
+# Only when the real library is absent. sys.modules holds what has been IMPORTED, not
+# what is installed, so setdefault does not defer to a real httpx that nothing in this
+# process has touched yet: the stub wins and shadows it for the whole session. This stub
+# has no Response, and starlette.testclient reads httpx.Response at import, so every
+# module collected afterwards that reaches fastapi.testclient or routes.inference dies.
+try:
+    import httpx  # noqa: F401
+except ImportError:
+    sys.modules.setdefault("httpx", _httpx_stub)
 
 from core.inference.llama_cpp import _CTX_FIT_VRAM_FRACTION, LlamaCppBackend
 

--- a/studio/backend/tests/test_llama_cpp_no_context_shift.py
+++ b/studio/backend/tests/test_llama_cpp_no_context_shift.py
@@ -58,7 +58,15 @@ _httpx_stub.Client = type(
         "__exit__": lambda s, *a: None,
     },
 )
-sys.modules.setdefault("httpx", _httpx_stub)
+# Only when the real library is absent. sys.modules holds what has been IMPORTED, not
+# what is installed, so setdefault does not defer to a real httpx that nothing in this
+# process has touched yet: the stub wins and shadows it for the whole session. This stub
+# has no Response, and starlette.testclient reads httpx.Response at import, so every
+# module collected afterwards that reaches fastapi.testclient or routes.inference dies.
+try:
+    import httpx  # noqa: F401
+except ImportError:
+    sys.modules.setdefault("httpx", _httpx_stub)
 
 from core.inference import llama_cpp as llama_cpp_module
 

--- a/studio/backend/tests/test_llama_cpp_wait_for_vram_settle.py
+++ b/studio/backend/tests/test_llama_cpp_wait_for_vram_settle.py
@@ -30,11 +30,26 @@ sys.modules.setdefault("loggers", _loggers_stub)
 
 _structlog_stub = _types.ModuleType("structlog")
 _structlog_stub.get_logger = lambda *a, **k: __import__("logging").getLogger("stub")
-sys.modules.setdefault("structlog", _structlog_stub)
+# Same reasoning as httpx below: only when the real one is absent. The real structlog
+# has get_logger, which is all this module wants from it.
+try:
+    import structlog  # noqa: F401
+except ImportError:
+    sys.modules.setdefault("structlog", _structlog_stub)
 # Set get_logger even if a prior test inserted a bare ``structlog`` stub.
 if not hasattr(sys.modules["structlog"], "get_logger"):
     sys.modules["structlog"].get_logger = _structlog_stub.get_logger
 
+# Only when the real library is absent, the way test_llama_cpp_placement.py already does
+# it. setdefault reads as if it defers to the real httpx, but sys.modules holds what has
+# been IMPORTED, not what is installed, so in a process where nothing has touched httpx
+# yet the stub wins and shadows the real library for the whole session. This stub has no
+# Response, and starlette.testclient reads httpx.Response at import, so every module
+# collected afterwards that reaches fastapi.testclient or routes.inference dies on it.
+#
+# In the full parallel run something always imports httpx before this file is collected,
+# which is why it went unnoticed. Splitting the timing tests into a ten-file serial step
+# removed that accident and the 3.10 leg failed collection on two of them.
 _httpx_stub = _types.ModuleType("httpx")
 for _exc in (
     "ConnectError",
@@ -56,7 +71,10 @@ _httpx_stub.Client = type(
         "__exit__": lambda s, *a: None,
     },
 )
-sys.modules.setdefault("httpx", _httpx_stub)
+try:
+    import httpx  # noqa: F401
+except ImportError:
+    sys.modules.setdefault("httpx", _httpx_stub)
 
 from core.inference import llama_cpp as llama_cpp_module  # noqa: E402
 from core.inference.llama_cpp import LlamaCppBackend  # noqa: E402

--- a/studio/backend/tests/test_llama_cpp_windows_nvidia_path.py
+++ b/studio/backend/tests/test_llama_cpp_windows_nvidia_path.py
@@ -54,7 +54,15 @@ _httpx_stub.Client = type(
         "__exit__": lambda self, *a: None,
     },
 )
-sys.modules.setdefault("httpx", _httpx_stub)
+# Only when the real library is absent. sys.modules holds what has been IMPORTED, not
+# what is installed, so setdefault does not defer to a real httpx that nothing in this
+# process has touched yet: the stub wins and shadows it for the whole session. This stub
+# has no Response, and starlette.testclient reads httpx.Response at import, so every
+# module collected afterwards that reaches fastapi.testclient or routes.inference dies.
+try:
+    import httpx  # noqa: F401
+except ImportError:
+    sys.modules.setdefault("httpx", _httpx_stub)
 
 from core.inference.llama_cpp import LlamaCppBackend  # noqa: E402
 

--- a/studio/backend/tests/test_load_progress_ready_fraction.py
+++ b/studio/backend/tests/test_load_progress_ready_fraction.py
@@ -62,7 +62,15 @@ _httpx_stub.Client = type(
         "__exit__": lambda self, *a: None,
     },
 )
-sys.modules.setdefault("httpx", _httpx_stub)
+# Only when the real library is absent. sys.modules holds what has been IMPORTED, not
+# what is installed, so setdefault does not defer to a real httpx that nothing in this
+# process has touched yet: the stub wins and shadows it for the whole session. This stub
+# has no Response, and starlette.testclient reads httpx.Response at import, so every
+# module collected afterwards that reaches fastapi.testclient or routes.inference dies.
+try:
+    import httpx  # noqa: F401
+except ImportError:
+    sys.modules.setdefault("httpx", _httpx_stub)
 
 from core.inference.llama_cpp import LlamaCppBackend  # noqa: E402
 

--- a/studio/backend/tests/test_native_context_length.py
+++ b/studio/backend/tests/test_native_context_length.py
@@ -66,7 +66,15 @@ _httpx_stub.Client = type(
         "__exit__": lambda self, *a: None,
     },
 )
-sys.modules.setdefault("httpx", _httpx_stub)
+# Only when the real library is absent. sys.modules holds what has been IMPORTED, not
+# what is installed, so setdefault does not defer to a real httpx that nothing in this
+# process has touched yet: the stub wins and shadows it for the whole session. This stub
+# has no Response, and starlette.testclient reads httpx.Response at import, so every
+# module collected afterwards that reaches fastapi.testclient or routes.inference dies.
+try:
+    import httpx  # noqa: F401
+except ImportError:
+    sys.modules.setdefault("httpx", _httpx_stub)
 
 from core.inference.llama_cpp import LlamaCppBackend
 from models.inference import LoadResponse, InferenceStatusResponse

--- a/studio/backend/tests/test_tensor_parallel.py
+++ b/studio/backend/tests/test_tensor_parallel.py
@@ -63,7 +63,15 @@ _httpx_stub.Client = type(
         "__exit__": lambda s, *a: None,
     },
 )
-sys.modules.setdefault("httpx", _httpx_stub)
+# Only when the real library is absent. sys.modules holds what has been IMPORTED, not
+# what is installed, so setdefault does not defer to a real httpx that nothing in this
+# process has touched yet: the stub wins and shadows it for the whole session. This stub
+# has no Response, and starlette.testclient reads httpx.Response at import, so every
+# module collected afterwards that reaches fastapi.testclient or routes.inference dies.
+try:
+    import httpx  # noqa: F401
+except ImportError:
+    sys.modules.setdefault("httpx", _httpx_stub)
 
 from core.inference import llama_cpp as llama_cpp_module
 from core.inference.llama_cpp import (

--- a/tests/studio/test_backend_ci_parallel_isolation.py
+++ b/tests/studio/test_backend_ci_parallel_isolation.py
@@ -120,8 +120,11 @@ def _tight_elapsed_bounds(path: Path) -> list[str]:
                     continue
                 if isinstance(bound, ast.Constant) and isinstance(bound.value, (int, float)):
                     if bound.value <= TIGHT_BOUND_S:
-                        found.append(f"{path.name}:{node.lineno} {cmp_node.left.id} < {bound.value}")
+                        found.append(
+                            f"{path.name}:{node.lineno} {cmp_node.left.id} < {bound.value}"
+                        )
     return found
+
 
 BACKEND_MARKER = "--ignore=tests/test_studio_api.py"
 

--- a/tests/studio/test_backend_ci_parallel_isolation.py
+++ b/tests/studio/test_backend_ci_parallel_isolation.py
@@ -72,6 +72,8 @@ BACKEND_ISOLATED = [
     ("tests/test_llama_cpp_wait_for_vram_settle.py", "asserts elapsed < 0.05"),
     ("tests/test_tool_xml_strip.py", "asserts a regex benchmark under 0.1s"),
     ("tests/test_diffusion_checkpoint_resume.py", "compares one duration against another"),
+    ("tests/test_tool_output_streaming.py", "compares when a callback fired against when the child exited"),
+    ("tests/test_web_fetch_extraction.py", "compares parse time at two input sizes"),
 ]
 
 # Below this, an elapsed-time bound is inside the range of a single scheduler quantum, so
@@ -90,6 +92,24 @@ TIGHT_BOUND_S = 0.1
 
 BACKEND_TESTS = Path(__file__).resolve().parents[2] / "studio" / "backend" / "tests"
 _CLOCKS = ("monotonic", "perf_counter", "process_time", "time")
+
+
+# Sites the scan finds and a human has read. The scan looks for a comparison between two
+# clock-derived quantities, which is the right net to cast, but not every such comparison
+# is a performance claim. None of these can be broken by descheduling:
+#
+#   a SANDWICH, `before <= recorded <= after`, asserts a stamp was taken between two
+#   reads. Widening the gap cannot falsify it.
+#   a POLL DEADLINE, `time.monotonic() < limit` inside a wait-for-condition loop, is the
+#   pattern that replaces a guessed sleep. Its 5s budget is a timeout, not a measurement.
+#   a SENTINEL, `stamp < 0.0`, compares against a magic value rather than a duration.
+#
+# Keyed on the enclosing function rather than a line number, so an edit above it does not
+# silently move the exemption onto something else.
+BENIGN_TIMING = {
+    ("test_media_auto_switch.py", "_until"),
+    ("test_openai_auto_switch.py", "test_any_finished_download_drops_the_resolver_cache"),
+}
 
 
 def _reads_a_clock(node: ast.AST) -> bool:
@@ -122,12 +142,27 @@ def _timing_helpers(tree: ast.AST) -> set:
 
 
 def _timed_names(tree: ast.AST) -> set:
-    """Names assigned from a clock difference."""
+    """Anything holding a clock value: a duration, an instant, or a list of them.
+
+    Three ways one gets there, all present in this suite:
+        elapsed = time.monotonic() - start      a difference
+        started = time.monotonic()              an instant, subtracted later
+        first_seen_at.append(time.monotonic())  an instant parked in a container,
+                                                usually from inside a callback
+
+    Instants count, not only differences. test_tool_output_streaming compares
+    `first_seen_at[0] - started` against `finished - started - 0.5`, where every term is
+    an instant and no single name ever holds a duration.
+    """
     names = set()
     for node in ast.walk(tree):
-        if isinstance(node, ast.Assign) and isinstance(node.value, ast.BinOp):
-            if isinstance(node.value.op, ast.Sub) and _reads_a_clock(node.value):
-                names.update(t.id for t in node.targets if isinstance(t, ast.Name))
+        if isinstance(node, ast.Assign) and _reads_a_clock(node.value):
+            names.update(t.id for t in node.targets if isinstance(t, ast.Name))
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+            if node.func.attr in ("append", "add", "insert") and _reads_a_clock(node):
+                holder = node.func.value
+                if isinstance(holder, ast.Name):
+                    names.add(holder.id)
     return names
 
 
@@ -139,14 +174,15 @@ def _is_timed(node: ast.AST, names: set, helpers: set) -> bool:
       time.monotonic() - started < 0.2        the difference written inline
       _elapsed(big) < 8 * _elapsed(small)     a helper that returns a difference
     """
-    if isinstance(node, ast.Name) and node.id in names:
-        return True
-    if _reads_a_clock(node):
-        return True
-    return any(
-        isinstance(inner, ast.Call) and getattr(inner.func, "id", None) in helpers
-        for inner in ast.walk(node)
-    )
+    for inner in ast.walk(node):
+        if isinstance(inner, ast.Name) and inner.id in names:
+            return True
+        if isinstance(inner, ast.Call):
+            if getattr(inner.func, "attr", "") in _CLOCKS:
+                return True
+            if getattr(inner.func, "id", None) in helpers:
+                return True
+    return False
 
 
 def _fragile_timing_asserts(path: Path) -> list:
@@ -167,9 +203,17 @@ def _fragile_timing_asserts(path: Path) -> list:
     except SyntaxError:
         return []
     names, helpers = _timed_names(tree), _timing_helpers(tree)
+    enclosing = {}
+    for holder in ast.walk(tree):
+        if isinstance(holder, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            for inner in ast.walk(holder):
+                enclosing.setdefault(inner, holder.name)
     found = []
     for node in ast.walk(tree):
         if not isinstance(node, ast.Assert):
+            continue
+        where = enclosing.get(node, "<module>")
+        if (path.name, where) in BENIGN_TIMING:
             continue
         for cmp_node in ast.walk(node.test):
             if not isinstance(cmp_node, ast.Compare):
@@ -304,11 +348,20 @@ def test_every_tight_elapsed_bound_is_isolated():
         if bounds and f"tests/{path.name}" not in isolated:
             stray[path.name] = bounds
     assert not stray, (
-        f"these backend tests assert an elapsed-time bound at or below {TIGHT_BOUND_S}s "
-        f"and still run under -n 4, where four workers share four vCPUs and a bound that "
-        f"small measures the scheduler as much as the code: {stray}. Either add the file "
-        f"to BACKEND_ISOLATED and to both halves of the workflow, or give the assertion "
-        f"enough headroom to survive being descheduled."
+        f"these backend tests compare clock-derived values and still run under -n 4, "
+        f"where four workers share four vCPUs: {stray}.\n"
+        f"\n"
+        f"Three ways out, in the order worth trying:\n"
+        f"  1. If it is a PERFORMANCE claim -- one measurement against another, or an "
+        f"absolute bound at or below {TIGHT_BOUND_S}s -- add the file to "
+        f"BACKEND_ISOLATED and to BOTH halves of studio-backend-ci.yml: the --ignore on "
+        f"the parallel run and the serial step that reruns it.\n"
+        f"  2. If descheduling cannot falsify it, add (file, enclosing function) to "
+        f"BENIGN_TIMING with a one-line reason. A sandwich (`before <= x <= after`), a "
+        f"poll deadline, and a sentinel comparison are all already there. This net is "
+        f"cast wide on purpose, so landing here does not mean the test is wrong.\n"
+        f"  3. If it is an absolute bound that is simply too tight, give it enough "
+        f"headroom to survive being descheduled."
     )
 
 

--- a/tests/studio/test_backend_ci_parallel_isolation.py
+++ b/tests/studio/test_backend_ci_parallel_isolation.py
@@ -111,7 +111,11 @@ def _timing_helpers(tree: ast.AST) -> set:
         if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
             continue
         for inner in ast.walk(node):
-            if isinstance(inner, ast.Return) and inner.value is not None and _reads_a_clock(inner.value):
+            if (
+                isinstance(inner, ast.Return)
+                and inner.value is not None
+                and _reads_a_clock(inner.value)
+            ):
                 helpers.add(node.name)
                 break
     return helpers
@@ -322,9 +326,9 @@ def test_the_scan_finds_all_three_shapes():
         for path in sorted(BACKEND_TESTS.glob("*.py"))
         if _fragile_timing_asserts(path)
     }
-    assert "test_llama_cpp_wait_for_vram_settle.py" in found, found      # named
-    assert "test_tool_xml_strip.py" in found, found                      # named
-    assert "test_diffusion_checkpoint_resume.py" in found, found         # helper, relative
+    assert "test_llama_cpp_wait_for_vram_settle.py" in found, found  # named
+    assert "test_tool_xml_strip.py" in found, found  # named
+    assert "test_diffusion_checkpoint_resume.py" in found, found  # helper, relative
 
     # The inline form, which the suite currently uses only at 0.2s, above the threshold.
     # Recognised rather than isolated, so tightening that bound would trip the guard.

--- a/tests/studio/test_backend_ci_parallel_isolation.py
+++ b/tests/studio/test_backend_ci_parallel_isolation.py
@@ -72,7 +72,10 @@ BACKEND_ISOLATED = [
     ("tests/test_llama_cpp_wait_for_vram_settle.py", "asserts elapsed < 0.05"),
     ("tests/test_tool_xml_strip.py", "asserts a regex benchmark under 0.1s"),
     ("tests/test_diffusion_checkpoint_resume.py", "compares one duration against another"),
-    ("tests/test_tool_output_streaming.py", "compares when a callback fired against when the child exited"),
+    (
+        "tests/test_tool_output_streaming.py",
+        "compares when a callback fired against when the child exited",
+    ),
     ("tests/test_web_fetch_extraction.py", "compares parse time at two input sizes"),
 ]
 

--- a/tests/studio/test_backend_ci_parallel_isolation.py
+++ b/tests/studio/test_backend_ci_parallel_isolation.py
@@ -19,6 +19,7 @@ ignore appears without a step that runs the same path, or the other way round.
 """
 
 import ast
+import importlib.util
 import re
 from pathlib import Path
 
@@ -477,3 +478,102 @@ def test_the_scan_finds_all_three_shapes():
         "an inline clock difference is not recognised as a duration, so a test written "
         "that way could assert a 20ms bound and run under -n 4 unnoticed"
     )
+
+
+def test_an_isolated_file_never_shadows_an_installed_library_with_a_stub():
+    """A stub may stand in for a MISSING library, never for an installed one.
+
+    `sys.modules.setdefault("httpx", stub)` reads as deferring to the real library and
+    does not: sys.modules holds what has been IMPORTED, not what is installed, so in a
+    process where nothing has touched httpx yet the stub wins and shadows it for the rest
+    of the session. These stubs carry no Response, starlette.testclient reads
+    httpx.Response at import, and every module collected afterwards that reaches
+    fastapi.testclient or routes.inference dies on it.
+
+    In a 26,000-test run something always imports httpx first, so this was invisible for
+    as long as the suite ran as one process. The serial step collects ten files and
+    nothing else, and the 3.10 leg failed collection on two of them the first time it
+    ran.
+
+    Scoped to the isolated files on purpose. Roughly fifty other backend modules stub
+    structlog the same way, and they are load-bearing in a run that also imports the real
+    one; rewriting them is a separate change with its own risk, and the full parallel run
+    is not the process where a small file list makes the shadowing decisive. What has to
+    hold here is that anything moved OUT of that run stands on its own.
+    """
+    offenders = {}
+    for name, _reason in BACKEND_ISOLATED:
+        path = BACKEND_TESTS / Path(name).name
+        tree = ast.parse(path.read_text(encoding = "utf-8"))
+        stubbed = {
+            node.args[0].value
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and _installs_into_sys_modules(node)
+            and node.args
+            and isinstance(node.args[0], ast.Constant)
+            and isinstance(node.args[0].value, str)
+        }
+        stubbed |= _assigned_into_sys_modules(tree)
+        imported = {
+            alias.name.split(".")[0]
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Import)
+            for alias in node.names
+        }
+        for stub in sorted(stubbed - imported):
+            if _is_installed(stub):
+                offenders.setdefault(path.name, []).append(stub)
+    assert not offenders, (
+        f"these files run in the serial step and install a stub over a library that IS "
+        f"installed, without first trying to import it: {offenders}.\n"
+        f"\n"
+        f"Wrap the install in `try: import <name>` / `except ImportError:` the way "
+        f"test_llama_cpp_placement.py does. setdefault is not that guard: sys.modules is "
+        f"what has been imported, not what is available, so the stub wins whenever this "
+        f"module is collected first and shadows the real library for the whole session. "
+        f"That is decisive here precisely because the step collects ten files, so there "
+        f"is no longer an unrelated module importing the real one first."
+    )
+
+
+def _installs_into_sys_modules(node: ast.Call) -> bool:
+    func = node.func
+    return (
+        isinstance(func, ast.Attribute)
+        and func.attr == "setdefault"
+        and isinstance(func.value, ast.Attribute)
+        and func.value.attr == "modules"
+    )
+
+
+def _assigned_into_sys_modules(tree: ast.AST) -> set:
+    """`sys.modules["name"] = stub`, the other spelling."""
+    names = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if (
+                isinstance(target, ast.Subscript)
+                and isinstance(target.value, ast.Attribute)
+                and target.value.attr == "modules"
+                and isinstance(target.slice, ast.Constant)
+                and isinstance(target.slice.value, str)
+            ):
+                names.add(target.slice.value)
+    return names
+
+
+def _is_installed(name: str) -> bool:
+    """Whether a stub for this name would shadow something real.
+
+    Anything the machinery cannot resolve counts as absent, including the errors it
+    raises rather than returning None for: an in-repo name such as `utils` or `loggers`
+    is importable only with studio/backend on sys.path, which this test does not have and
+    should not add.
+    """
+    try:
+        return importlib.util.find_spec(name) is not None
+    except (ImportError, ValueError):
+        return False

--- a/tests/studio/test_backend_ci_parallel_isolation.py
+++ b/tests/studio/test_backend_ci_parallel_isolation.py
@@ -49,10 +49,24 @@ def _pytest_commands(text: str) -> list[str]:
     ]
 
 
+# Two different trees are run in parallel now, and the isolation below belongs to exactly
+# one of them. The repo-root job runs `tests/` from the checkout; the matrix job runs the
+# backend's own suite with `working-directory: studio/backend`, so `tests/studio/...` is
+# not a path that exists for it and demanding those ignores would be nonsense.
+#
+# Told apart by what they ignore, because that is the thing both the ignores and this
+# scan are about: only the repo-root run excludes directories that live at the repo root.
+REPO_ROOT_MARKER = "--ignore=tests/qlora"
+
+
+def _over_the_repo_root(command: str) -> bool:
+    return REPO_ROOT_MARKER in command
+
+
 @pytest.mark.parametrize("path, reason", ISOLATED, ids = [p for p, _ in ISOLATED])
 def test_an_isolated_path_is_ignored_by_every_parallel_pytest_run(path, reason):
     for command in _pytest_commands(WORKFLOW.read_text(encoding = "utf-8")):
-        if " -n " not in f" {command} ":
+        if " -n " not in f" {command} " or not _over_the_repo_root(command):
             continue
         assert f"--ignore={path}" in command, (
             f"{path} ({reason}) is not ignored by a parallel pytest run in "
@@ -79,9 +93,38 @@ def test_the_command_scan_sees_the_parallel_run_and_the_serial_steps():
     """Pin the parser: a scan that matched nothing would pass both tests above."""
     commands = _pytest_commands(WORKFLOW.read_text(encoding = "utf-8"))
     parallel = [command for command in commands if " -n " in f" {command} "]
-    assert len(parallel) == 1, f"expected exactly one parallel pytest run, got {parallel}"
-    assert "tests/" in parallel[0]
+    assert len(parallel) == 2, (
+        f"expected two parallel pytest runs, the backend matrix and repo-cpu-tests, got "
+        f"{parallel}. If a job stopped running in parallel, say so here rather than "
+        f"letting this scan quietly cover one run."
+    )
+    root = [command for command in parallel if _over_the_repo_root(command)]
+    assert len(root) == 1, (
+        f"expected exactly one parallel run over the repo root, got {root}. The isolation "
+        f"checks above apply to that one, and a scan that matched none of them would pass "
+        f"on nothing."
+    )
     # The line joins have to be resolved, or the parallel command reads as `pytest tests/ -q`
     # with none of its --ignore flags and the first test above passes on nothing.
-    assert "--ignore=" in parallel[0]
+    assert "--ignore=" in root[0]
     assert len(commands) > 1, "no serial pytest steps found; the ignore checks cannot fail"
+
+
+def test_the_backend_matrix_still_runs_in_parallel():
+    """The matrix leg was 23.3 minutes serial and is the longest job in the repo.
+
+    Measured over the same tree before it was turned on: 1322.6s serial against 343.0s at
+    -n 4, with the two failure sets equal name for name, so nothing in the backend suite
+    depends on the order it runs in. Asserted here because dropping the flag would show up
+    only as CI slowly getting slower again, which nothing reports.
+    """
+    backend = [
+        command
+        for command in _pytest_commands(WORKFLOW.read_text(encoding = "utf-8"))
+        if "--ignore=tests/test_studio_api.py" in command
+    ]
+    assert backend, "the backend matrix pytest step is gone or was renamed past this scan"
+    assert " -n " in f" {backend[0]} ", (
+        f"the backend matrix leg is running serially again, which costs about 17 minutes "
+        f"per leg on every pull request and every push to main: {backend[0]}"
+    )

--- a/tests/studio/test_backend_ci_parallel_isolation.py
+++ b/tests/studio/test_backend_ci_parallel_isolation.py
@@ -63,6 +63,20 @@ def _over_the_repo_root(command: str) -> bool:
     return REPO_ROOT_MARKER in command
 
 
+# The same pairing, for the backend matrix run. Ignoring a file from the parallel run and
+# running it again serially is two edits held together by nothing, and dropping the second
+# is silent: the job stays green while the tests stop running.
+BACKEND_ISOLATED = [
+    ("tests/test_streaming_stripper.py", "times itself against a reference in the same process"),
+]
+
+BACKEND_MARKER = "--ignore=tests/test_studio_api.py"
+
+
+def _over_the_backend(command: str) -> bool:
+    return BACKEND_MARKER in command
+
+
 @pytest.mark.parametrize("path, reason", ISOLATED, ids = [p for p, _ in ISOLATED])
 def test_an_isolated_path_is_ignored_by_every_parallel_pytest_run(path, reason):
     for command in _pytest_commands(WORKFLOW.read_text(encoding = "utf-8")):
@@ -127,4 +141,39 @@ def test_the_backend_matrix_still_runs_in_parallel():
     assert " -n " in f" {backend[0]} ", (
         f"the backend matrix leg is running serially again, which costs about 17 minutes "
         f"per leg on every pull request and every push to main: {backend[0]}"
+    )
+
+
+@pytest.mark.parametrize("path, reason", BACKEND_ISOLATED, ids = [p for p, _ in BACKEND_ISOLATED])
+def test_a_backend_isolated_path_is_ignored_by_the_parallel_run(path, reason):
+    """Relative timing cannot survive four workers on four vCPUs.
+
+    Observed on staging: the 3.10 leg reported "early markup cost 1.354s against the
+    reference's 0.854s" while 3.13 passed the same commit. One side of the ratio was
+    descheduled, not slower.
+    """
+    parallel = [
+        command
+        for command in _pytest_commands(WORKFLOW.read_text(encoding = "utf-8"))
+        if " -n " in f" {command} " and _over_the_backend(command)
+    ]
+    assert parallel, "the backend parallel run is gone or was renamed past this scan"
+    assert f"--ignore={path}" in parallel[0], (
+        f"{path} ({reason}) is back in the backend parallel run, where its measurements "
+        f"compare a descheduled worker against an undescheduled one: {parallel[0]}"
+    )
+
+
+@pytest.mark.parametrize("path, reason", BACKEND_ISOLATED, ids = [p for p, _ in BACKEND_ISOLATED])
+def test_a_backend_isolated_path_still_runs_serially(path, reason):
+    """Ignoring it is half the change; without this it runs nowhere and the job is green."""
+    serial = [
+        command
+        for command in _pytest_commands(WORKFLOW.read_text(encoding = "utf-8"))
+        if " -n " not in f" {command} "
+        and re.search(rf"(?<![\w/]){re.escape(path)}(?![\w/])", command)
+    ]
+    assert serial, (
+        f"{path} is ignored from the backend parallel run ({reason}) and no serial step "
+        f"runs it, so it runs nowhere in {WORKFLOW.name} while the job stays green."
     )

--- a/tests/studio/test_backend_ci_parallel_isolation.py
+++ b/tests/studio/test_backend_ci_parallel_isolation.py
@@ -77,6 +77,7 @@ BACKEND_ISOLATED = [
         "compares when a callback fired against when the child exited",
     ),
     ("tests/test_web_fetch_extraction.py", "compares parse time at two input sizes"),
+    ("tests/test_tool_call_parser_strict.py", "compares parse time at two nesting depths"),
 ]
 
 # Below this, an elapsed-time bound is inside the range of a single scheduler quantum, so
@@ -122,29 +123,54 @@ def _reads_a_clock(node: ast.AST) -> bool:
     )
 
 
+def _calls_a_helper(node: ast.AST, helpers: set) -> bool:
+    return any(
+        isinstance(inner, ast.Call) and getattr(inner.func, "id", None) in helpers
+        for inner in ast.walk(node)
+    )
+
+
 def _timing_helpers(tree: ast.AST) -> set:
-    """Functions that RETURN a clock difference, at any nesting depth.
+    """Functions that hand back a clock value, however indirectly.
 
-    test_diffusion_checkpoint_resume defines `_elapsed(path)` inside the test and compares
-    two of its results. Without this, a call to it looks like any other call and the
-    benchmark reads as untimed.
+    Not just ``return time.perf_counter() - t0``. test_tool_call_parser_strict has
+
+        def best_ms(depth):
+            best = float("inf")
+            for _ in range(5):
+                t0 = time.perf_counter()
+                ...
+                best = min(best, time.perf_counter() - t0)
+            return best
+
+    where the return reads no clock at all: the duration arrives through a local name. So
+    a function counts if it returns anything containing one of its OWN timed names, and
+    the whole thing runs to a fixpoint, so a helper that returns another helper's result
+    is found on the next pass rather than missed.
     """
-    helpers = set()
-    for node in ast.walk(tree):
-        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
-            continue
-        for inner in ast.walk(node):
-            if (
-                isinstance(inner, ast.Return)
-                and inner.value is not None
-                and _reads_a_clock(inner.value)
-            ):
-                helpers.add(node.name)
-                break
-    return helpers
+    functions = [
+        node for node in ast.walk(tree)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    ]
+    helpers: set = set()
+    while True:
+        grown = False
+        for node in functions:
+            if node.name in helpers:
+                continue
+            local = _timed_names(node)
+            for inner in ast.walk(node):
+                if not isinstance(inner, ast.Return) or inner.value is None:
+                    continue
+                if _is_timed(inner.value, local, helpers):
+                    helpers.add(node.name)
+                    grown = True
+                    break
+        if not grown:
+            return helpers
 
 
-def _timed_names(tree: ast.AST) -> set:
+def _timed_names(tree: ast.AST, helpers: set = frozenset()) -> set:
     """Anything holding a clock value: a duration, an instant, or a list of them.
 
     Three ways one gets there, all present in this suite:
@@ -159,7 +185,9 @@ def _timed_names(tree: ast.AST) -> set:
     """
     names = set()
     for node in ast.walk(tree):
-        if isinstance(node, ast.Assign) and _reads_a_clock(node.value):
+        if isinstance(node, ast.Assign) and (
+            _reads_a_clock(node.value) or _calls_a_helper(node.value, helpers)
+        ):
             names.update(t.id for t in node.targets if isinstance(t, ast.Name))
         if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
             if node.func.attr in ("append", "add", "insert") and _reads_a_clock(node):
@@ -205,7 +233,9 @@ def _fragile_timing_asserts(path: Path) -> list:
         tree = ast.parse(path.read_text(encoding = "utf-8", errors = "replace"))
     except SyntaxError:
         return []
-    names, helpers = _timed_names(tree), _timing_helpers(tree)
+    # Helpers first: a name can hold a duration only because a helper returned one.
+    helpers = _timing_helpers(tree)
+    names = _timed_names(tree, helpers)
     enclosing = {}
     for holder in ast.walk(tree):
         if isinstance(holder, (ast.FunctionDef, ast.AsyncFunctionDef)):

--- a/tests/studio/test_backend_ci_parallel_isolation.py
+++ b/tests/studio/test_backend_ci_parallel_isolation.py
@@ -80,6 +80,7 @@ BACKEND_ISOLATED = [
     ("tests/test_tool_call_parser_strict.py", "compares parse time at two nesting depths"),
     # Found by staging rather than by the scan, and the scan cannot find it: see below.
     ("tests/test_tunnel_safe_long_post.py", "work sleeps 0.2s past a 0.05s keepalive timer"),
+    ("tests/test_scan_loras_off_event_loop.py", "counts heartbeats during a 0.3s sleep"),
 ]
 
 # What the scan above does NOT cover, recorded because the gap is structural rather than a
@@ -90,11 +91,18 @@ BACKEND_ISOLATED = [
 # first, and nothing in the expression is a duration. It failed exactly that way on a
 # staging 3.13 leg that had been green.
 #
+# test_scan_loras_off_event_loop is the same shape from the other direction: it counts how
+# many times a heartbeat coroutine ticked during a 0.3s sleep and requires at least three.
+# Descheduling the worker costs ticks without the scan being wrong, and the assertion
+# compares a COUNT, so again there is no duration to find.
+#
 # Ten backend files pair a sub-second sleep with a small threshold constant. Four times the
 # threshold was not enough margin for the one that failed, so the ratio is not a usable
-# rule, and flagging all ten would serialise a large part of the suite on a guess. So this
-# class is left to staging, which is the only thing that has ever detected one, and named
-# here so the next person does not assume the scan covers it.
+# rule, and flagging all ten would serialise a large part of the suite on a guess.
+#
+# So this class is found by reading rather than by scanning. Both entries here arrived that
+# way, one from a staging failure and one from review, and the note is here so the next
+# person does not assume the scan covers it.
 
 # Below this, an elapsed-time bound is inside the range of a single scheduler quantum, so
 # under four workers on four vCPUs it measures the scheduler as much as the code. Above it

--- a/tests/studio/test_backend_ci_parallel_isolation.py
+++ b/tests/studio/test_backend_ci_parallel_isolation.py
@@ -146,6 +146,11 @@ _CLOCKS = ("monotonic", "perf_counter", "process_time", "time")
 BENIGN_TIMING = {
     ("test_media_auto_switch.py", "_until"),
     ("test_openai_auto_switch.py", "test_any_finished_download_drops_the_resolver_cache"),
+    # A 600-second expiry checked against the wall clock. Reading both sides of that gap
+    # late by whole seconds still leaves it true, and it only reaches this scan at all
+    # because the widened operand walk now reads `x > time.time()` as a bound.
+    ("test_openai_codex_subscription.py",
+     "test_account_claim_and_token_response_are_validated_without_returning_raw_body"),
 }
 
 
@@ -283,17 +288,26 @@ def _fragile_timing_asserts(path: Path) -> list:
         for cmp_node in ast.walk(node.test):
             if not isinstance(cmp_node, ast.Compare):
                 continue
-            left = cmp_node.left
-            if not _is_timed(left, names, helpers):
-                continue
-            for op, right in zip(cmp_node.ops, cmp_node.comparators):
-                if not isinstance(op, (ast.Lt, ast.LtE)):
+            # Every adjacent pair, not just the one starting at cmp_node.left. A chained
+            # `0.3 <= elapsed < 2.0` is a single Compare whose first operand is a literal,
+            # so requiring the leftmost operand to be timed skipped the `elapsed < 2.0`
+            # link and let the file stay in the -n 4 run with the guard still green.
+            # test_llama_cpp_wait_for_vram_settle.py already writes bounds that way.
+            operands = [cmp_node.left, *cmp_node.comparators]
+            for index, op in enumerate(cmp_node.ops):
+                lower, upper = operands[index], operands[index + 1]
+                if isinstance(op, (ast.Gt, ast.GtE)):
+                    # `0.05 > elapsed` bounds the same thing from the same side.
+                    lower, upper = upper, lower
+                elif not isinstance(op, (ast.Lt, ast.LtE)):
                     continue
-                if _is_timed(right, names, helpers):
+                if not _is_timed(lower, names, helpers):
+                    continue
+                if _is_timed(upper, names, helpers):
                     found.append(f"{path.name}:{node.lineno} one duration against another")
-                elif isinstance(right, ast.Constant) and isinstance(right.value, (int, float)):
-                    if right.value <= TIGHT_BOUND_S:
-                        found.append(f"{path.name}:{node.lineno} duration < {right.value}")
+                elif isinstance(upper, ast.Constant) and isinstance(upper.value, (int, float)):
+                    if upper.value <= TIGHT_BOUND_S:
+                        found.append(f"{path.name}:{node.lineno} duration < {upper.value}")
     return found
 
 

--- a/tests/studio/test_backend_ci_parallel_isolation.py
+++ b/tests/studio/test_backend_ci_parallel_isolation.py
@@ -18,6 +18,7 @@ silent: the job stays green while the tests stop running. These tests fail if th
 ignore appears without a step that runs the same path, or the other way round.
 """
 
+import ast
 import re
 from pathlib import Path
 
@@ -68,7 +69,59 @@ def _over_the_repo_root(command: str) -> bool:
 # is silent: the job stays green while the tests stop running.
 BACKEND_ISOLATED = [
     ("tests/test_streaming_stripper.py", "times itself against a reference in the same process"),
+    ("tests/test_llama_cpp_wait_for_vram_settle.py", "asserts elapsed < 0.05"),
+    ("tests/test_tool_xml_strip.py", "asserts a regex benchmark under 0.1s"),
 ]
+
+# Below this, an elapsed-time bound is inside the range of a single scheduler quantum, so
+# under four workers on four vCPUs it measures the scheduler as much as the code. Above it
+# there is enough headroom to survive being descheduled. Twenty-two backend files assert
+# some elapsed bound and serialising all of them would give back most of what -n 4 buys,
+# so the line is drawn where the measurement stops being about the code.
+TIGHT_BOUND_S = 0.1
+
+BACKEND_TESTS = Path(__file__).resolve().parents[2] / "studio" / "backend" / "tests"
+_CLOCKS = ("monotonic", "perf_counter", "process_time", "time")
+
+
+def _tight_elapsed_bounds(path: Path) -> list[str]:
+    """Asserts of the form ``elapsed < <= TIGHT_BOUND_S``, where ``elapsed`` came from a clock.
+
+    Read with ast rather than a regex, so the name has to actually be assigned from a
+    difference of two clock readings. Grepping for `< 0.05` would match a tolerance on a
+    float, and grepping for `elapsed` would match a variable that holds anything.
+    """
+    try:
+        tree = ast.parse(path.read_text(encoding = "utf-8", errors = "replace"))
+    except SyntaxError:
+        return []
+    timed = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign) and isinstance(node.value, ast.BinOp):
+            if not isinstance(node.value.op, ast.Sub):
+                continue
+            reads_clock = any(
+                isinstance(inner, ast.Call) and getattr(inner.func, "attr", "") in _CLOCKS
+                for inner in ast.walk(node.value)
+            )
+            if reads_clock:
+                timed.update(t.id for t in node.targets if isinstance(t, ast.Name))
+    found = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assert):
+            continue
+        for cmp_node in ast.walk(node.test):
+            if not isinstance(cmp_node, ast.Compare):
+                continue
+            if not (isinstance(cmp_node.left, ast.Name) and cmp_node.left.id in timed):
+                continue
+            for op, bound in zip(cmp_node.ops, cmp_node.comparators):
+                if not isinstance(op, (ast.Lt, ast.LtE)):
+                    continue
+                if isinstance(bound, ast.Constant) and isinstance(bound.value, (int, float)):
+                    if bound.value <= TIGHT_BOUND_S:
+                        found.append(f"{path.name}:{node.lineno} {cmp_node.left.id} < {bound.value}")
+    return found
 
 BACKEND_MARKER = "--ignore=tests/test_studio_api.py"
 
@@ -177,3 +230,36 @@ def test_a_backend_isolated_path_still_runs_serially(path, reason):
         f"{path} is ignored from the backend parallel run ({reason}) and no serial step "
         f"runs it, so it runs nowhere in {WORKFLOW.name} while the job stays green."
     )
+
+
+def test_every_tight_elapsed_bound_is_isolated():
+    """The rule, applied by scanning rather than by memory.
+
+    Two of the entries above were found by review rather than by CI: they passed on
+    staging and would have flaked later. A new test asserting a 20ms bound would do the
+    same. This finds them, so adding one forces the isolation instead of buying a flake.
+    """
+    isolated = {path for path, _ in BACKEND_ISOLATED}
+    stray = {}
+    for path in sorted(BACKEND_TESTS.glob("*.py")):
+        bounds = _tight_elapsed_bounds(path)
+        if bounds and f"tests/{path.name}" not in isolated:
+            stray[path.name] = bounds
+    assert not stray, (
+        f"these backend tests assert an elapsed-time bound at or below {TIGHT_BOUND_S}s "
+        f"and still run under -n 4, where four workers share four vCPUs and a bound that "
+        f"small measures the scheduler as much as the code: {stray}. Either add the file "
+        f"to BACKEND_ISOLATED and to both halves of the workflow, or give the assertion "
+        f"enough headroom to survive being descheduled."
+    )
+
+
+def test_the_tight_bound_scan_finds_the_known_ones():
+    """A scan that matched nothing would pass the test above on an empty set."""
+    found = {
+        path.name: _tight_elapsed_bounds(path)
+        for path in sorted(BACKEND_TESTS.glob("*.py"))
+        if _tight_elapsed_bounds(path)
+    }
+    assert "test_llama_cpp_wait_for_vram_settle.py" in found, found
+    assert "test_tool_xml_strip.py" in found, found

--- a/tests/studio/test_backend_ci_parallel_isolation.py
+++ b/tests/studio/test_backend_ci_parallel_isolation.py
@@ -81,6 +81,7 @@ BACKEND_ISOLATED = [
     # Found by staging rather than by the scan, and the scan cannot find it: see below.
     ("tests/test_tunnel_safe_long_post.py", "work sleeps 0.2s past a 0.05s keepalive timer"),
     ("tests/test_scan_loras_off_event_loop.py", "counts heartbeats during a 0.3s sleep"),
+    ("tests/test_anthropic_messages.py", "counts SSE keepalives emitted during a 0.24s stall"),
 ]
 
 # What the scan above does NOT cover, recorded because the gap is structural rather than a
@@ -100,9 +101,17 @@ BACKEND_ISOLATED = [
 # threshold was not enough margin for the one that failed, so the ratio is not a usable
 # rule, and flagging all ten would serialise a large part of the suite on a guess.
 #
-# So this class is found by reading rather than by scanning. Both entries here arrived that
-# way, one from a staging failure and one from review, and the note is here so the next
-# person does not assume the scan covers it.
+# So this class is found by reading rather than by scanning. The first arrived from a
+# staging failure, the second from review, and the third from reading the other eight
+# candidates once the shape was clear: test_anthropic_messages counts SSE keepalives
+# emitted during a 0.24s stall, which loses keepalives to a descheduled worker exactly as
+# the heartbeat test loses ticks.
+#
+# That same pass turned up one false positive worth naming, because the grep that finds
+# these is crude: test_diffusion_backend asserts len(staged) > 1 near a 0.2s sleep, but
+# `staged` is a list comprehension over cached filenames and has no timing in it at all.
+# It also costs 152s, so isolating it on the strength of a pattern match would have been
+# expensive as well as wrong. Read the assertion before adding a file here.
 
 # Below this, an elapsed-time bound is inside the range of a single scheduler quantum, so
 # under four workers on four vCPUs it measures the scheduler as much as the code. Above it

--- a/tests/studio/test_backend_ci_parallel_isolation.py
+++ b/tests/studio/test_backend_ci_parallel_isolation.py
@@ -83,6 +83,7 @@ BACKEND_ISOLATED = [
     ("tests/test_tunnel_safe_long_post.py", "work sleeps 0.2s past a 0.05s keepalive timer"),
     ("tests/test_scan_loras_off_event_loop.py", "counts heartbeats during a 0.3s sleep"),
     ("tests/test_anthropic_messages.py", "counts SSE keepalives emitted during a 0.24s stall"),
+    ("tests/test_profile_stats.py", "counts event-loop ticks during a 0.5s blocking call"),
 ]
 
 # What the scan above does NOT cover, recorded because the gap is structural rather than a
@@ -196,7 +197,10 @@ def _timing_helpers(tree: ast.AST) -> set:
         for node in functions:
             if node.name in helpers:
                 continue
-            local = _timed_names(node)
+            # With the helpers found so far, not without them: `value = base()` inside
+            # a wrapper only counts as timed once `base` is known, and the pass that
+            # learns `base` is not the pass that reads the wrapper.
+            local = _timed_names(node, helpers)
             for inner in ast.walk(node):
                 if not isinstance(inner, ast.Return) or inner.value is None:
                     continue

--- a/tests/studio/test_backend_ci_parallel_isolation.py
+++ b/tests/studio/test_backend_ci_parallel_isolation.py
@@ -78,7 +78,23 @@ BACKEND_ISOLATED = [
     ),
     ("tests/test_web_fetch_extraction.py", "compares parse time at two input sizes"),
     ("tests/test_tool_call_parser_strict.py", "compares parse time at two nesting depths"),
+    # Found by staging rather than by the scan, and the scan cannot find it: see below.
+    ("tests/test_tunnel_safe_long_post.py", "work sleeps 0.2s past a 0.05s keepalive timer"),
 ]
+
+# What the scan above does NOT cover, recorded because the gap is structural rather than a
+# missing case. It finds assertions that COMPARE clock-derived values. A test can depend on
+# timing without any clock in it at all: test_tunnel_safe_long_post patches the keepalive
+# threshold to 0.05s and makes the work sleep 0.2s, then asserts on the RESULT -- that the
+# response starts with padding -- so whether it passes turns on which of two timers fired
+# first, and nothing in the expression is a duration. It failed exactly that way on a
+# staging 3.13 leg that had been green.
+#
+# Ten backend files pair a sub-second sleep with a small threshold constant. Four times the
+# threshold was not enough margin for the one that failed, so the ratio is not a usable
+# rule, and flagging all ten would serialise a large part of the suite on a guess. So this
+# class is left to staging, which is the only thing that has ever detected one, and named
+# here so the next person does not assume the scan covers it.
 
 # Below this, an elapsed-time bound is inside the range of a single scheduler quantum, so
 # under four workers on four vCPUs it measures the scheduler as much as the code. Above it

--- a/tests/studio/test_backend_ci_parallel_isolation.py
+++ b/tests/studio/test_backend_ci_parallel_isolation.py
@@ -149,8 +149,7 @@ def _timing_helpers(tree: ast.AST) -> set:
     is found on the next pass rather than missed.
     """
     functions = [
-        node for node in ast.walk(tree)
-        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        node for node in ast.walk(tree) if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
     ]
     helpers: set = set()
     while True:

--- a/tests/studio/test_backend_ci_parallel_isolation.py
+++ b/tests/studio/test_backend_ci_parallel_isolation.py
@@ -71,6 +71,7 @@ BACKEND_ISOLATED = [
     ("tests/test_streaming_stripper.py", "times itself against a reference in the same process"),
     ("tests/test_llama_cpp_wait_for_vram_settle.py", "asserts elapsed < 0.05"),
     ("tests/test_tool_xml_strip.py", "asserts a regex benchmark under 0.1s"),
+    ("tests/test_diffusion_checkpoint_resume.py", "compares one duration against another"),
 ]
 
 # Below this, an elapsed-time bound is inside the range of a single scheduler quantum, so
@@ -78,34 +79,90 @@ BACKEND_ISOLATED = [
 # there is enough headroom to survive being descheduled. Twenty-two backend files assert
 # some elapsed bound and serialising all of them would give back most of what -n 4 buys,
 # so the line is drawn where the measurement stops being about the code.
+BACKEND_MARKER = "--ignore=tests/test_studio_api.py"
+
+
+def _over_the_backend(command: str) -> bool:
+    return BACKEND_MARKER in command
+
+
 TIGHT_BOUND_S = 0.1
 
 BACKEND_TESTS = Path(__file__).resolve().parents[2] / "studio" / "backend" / "tests"
 _CLOCKS = ("monotonic", "perf_counter", "process_time", "time")
 
 
-def _tight_elapsed_bounds(path: Path) -> list[str]:
-    """Asserts of the form ``elapsed < <= TIGHT_BOUND_S``, where ``elapsed`` came from a clock.
+def _reads_a_clock(node: ast.AST) -> bool:
+    return any(
+        isinstance(inner, ast.Call) and getattr(inner.func, "attr", "") in _CLOCKS
+        for inner in ast.walk(node)
+    )
 
-    Read with ast rather than a regex, so the name has to actually be assigned from a
-    difference of two clock readings. Grepping for `< 0.05` would match a tolerance on a
-    float, and grepping for `elapsed` would match a variable that holds anything.
+
+def _timing_helpers(tree: ast.AST) -> set:
+    """Functions that RETURN a clock difference, at any nesting depth.
+
+    test_diffusion_checkpoint_resume defines `_elapsed(path)` inside the test and compares
+    two of its results. Without this, a call to it looks like any other call and the
+    benchmark reads as untimed.
+    """
+    helpers = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        for inner in ast.walk(node):
+            if isinstance(inner, ast.Return) and inner.value is not None and _reads_a_clock(inner.value):
+                helpers.add(node.name)
+                break
+    return helpers
+
+
+def _timed_names(tree: ast.AST) -> set:
+    """Names assigned from a clock difference."""
+    names = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign) and isinstance(node.value, ast.BinOp):
+            if isinstance(node.value.op, ast.Sub) and _reads_a_clock(node.value):
+                names.update(t.id for t in node.targets if isinstance(t, ast.Name))
+    return names
+
+
+def _is_timed(node: ast.AST, names: set, helpers: set) -> bool:
+    """Whether this expression is a duration, however it was spelled.
+
+    Three forms, all of which appear in this suite:
+      elapsed < 0.05                          a name assigned from a difference
+      time.monotonic() - started < 0.2        the difference written inline
+      _elapsed(big) < 8 * _elapsed(small)     a helper that returns a difference
+    """
+    if isinstance(node, ast.Name) and node.id in names:
+        return True
+    if _reads_a_clock(node):
+        return True
+    return any(
+        isinstance(inner, ast.Call) and getattr(inner.func, "id", None) in helpers
+        for inner in ast.walk(node)
+    )
+
+
+def _fragile_timing_asserts(path: Path) -> list:
+    """Assertions whose outcome depends on how the process was scheduled.
+
+    Two kinds, and the second has no threshold to be under:
+      * ABSOLUTE, at or below TIGHT_BOUND_S. A bound that small is inside one scheduler
+        quantum, so four workers on four vCPUs measure the scheduler as much as the code.
+      * RELATIVE, comparing one duration against another. Descheduling one side and not
+        the other breaks it at ANY magnitude, which is what took test_streaming_stripper
+        out of the parallel run.
+
+    Read with ast, not a regex: grepping `< 0.05` matches a float tolerance, and grepping
+    `elapsed` matches whatever a variable happens to be called.
     """
     try:
         tree = ast.parse(path.read_text(encoding = "utf-8", errors = "replace"))
     except SyntaxError:
         return []
-    timed = set()
-    for node in ast.walk(tree):
-        if isinstance(node, ast.Assign) and isinstance(node.value, ast.BinOp):
-            if not isinstance(node.value.op, ast.Sub):
-                continue
-            reads_clock = any(
-                isinstance(inner, ast.Call) and getattr(inner.func, "attr", "") in _CLOCKS
-                for inner in ast.walk(node.value)
-            )
-            if reads_clock:
-                timed.update(t.id for t in node.targets if isinstance(t, ast.Name))
+    names, helpers = _timed_names(tree), _timing_helpers(tree)
     found = []
     for node in ast.walk(tree):
         if not isinstance(node, ast.Assert):
@@ -113,21 +170,18 @@ def _tight_elapsed_bounds(path: Path) -> list[str]:
         for cmp_node in ast.walk(node.test):
             if not isinstance(cmp_node, ast.Compare):
                 continue
-            if not (isinstance(cmp_node.left, ast.Name) and cmp_node.left.id in timed):
+            left = cmp_node.left
+            if not _is_timed(left, names, helpers):
                 continue
-            for op, bound in zip(cmp_node.ops, cmp_node.comparators):
+            for op, right in zip(cmp_node.ops, cmp_node.comparators):
                 if not isinstance(op, (ast.Lt, ast.LtE)):
                     continue
-                if isinstance(bound, ast.Constant) and isinstance(bound.value, (int, float)):
-                    if bound.value <= TIGHT_BOUND_S:
-                        found.append(f"{path.name}:{node.lineno} {cmp_node.left.id} < {bound.value}")
+                if _is_timed(right, names, helpers):
+                    found.append(f"{path.name}:{node.lineno} one duration against another")
+                elif isinstance(right, ast.Constant) and isinstance(right.value, (int, float)):
+                    if right.value <= TIGHT_BOUND_S:
+                        found.append(f"{path.name}:{node.lineno} duration < {right.value}")
     return found
-
-BACKEND_MARKER = "--ignore=tests/test_studio_api.py"
-
-
-def _over_the_backend(command: str) -> bool:
-    return BACKEND_MARKER in command
 
 
 @pytest.mark.parametrize("path, reason", ISOLATED, ids = [p for p, _ in ISOLATED])
@@ -242,7 +296,7 @@ def test_every_tight_elapsed_bound_is_isolated():
     isolated = {path for path, _ in BACKEND_ISOLATED}
     stray = {}
     for path in sorted(BACKEND_TESTS.glob("*.py")):
-        bounds = _tight_elapsed_bounds(path)
+        bounds = _fragile_timing_asserts(path)
         if bounds and f"tests/{path.name}" not in isolated:
             stray[path.name] = bounds
     assert not stray, (
@@ -254,12 +308,36 @@ def test_every_tight_elapsed_bound_is_isolated():
     )
 
 
-def test_the_tight_bound_scan_finds_the_known_ones():
-    """A scan that matched nothing would pass the test above on an empty set."""
+def test_the_scan_finds_all_three_shapes():
+    """A scan that matched nothing would pass the test above on an empty set.
+
+    One of each form the suite actually uses, because each needed its own handling and
+    the first version of this scan only understood the first:
+      elapsed < 0.05                        a name assigned from a difference
+      time.monotonic() - started < 0.2      the difference written inline
+      _elapsed(big) < 8 * _elapsed(small)   a helper that returns a difference
+    """
     found = {
-        path.name: _tight_elapsed_bounds(path)
+        path.name: _fragile_timing_asserts(path)
         for path in sorted(BACKEND_TESTS.glob("*.py"))
-        if _tight_elapsed_bounds(path)
+        if _fragile_timing_asserts(path)
     }
-    assert "test_llama_cpp_wait_for_vram_settle.py" in found, found
-    assert "test_tool_xml_strip.py" in found, found
+    assert "test_llama_cpp_wait_for_vram_settle.py" in found, found      # named
+    assert "test_tool_xml_strip.py" in found, found                      # named
+    assert "test_diffusion_checkpoint_resume.py" in found, found         # helper, relative
+
+    # The inline form, which the suite currently uses only at 0.2s, above the threshold.
+    # Recognised rather than isolated, so tightening that bound would trip the guard.
+    inline = ast.parse(
+        "import time\n"
+        "def t():\n"
+        "    started = 0\n"
+        "    assert time.monotonic() - started < 0.05\n"
+    )
+    names, helpers = _timed_names(inline), _timing_helpers(inline)
+    node = [n for n in ast.walk(inline) if isinstance(n, ast.Assert)][0]
+    compare = node.test
+    assert _is_timed(compare.left, names, helpers), (
+        "an inline clock difference is not recognised as a duration, so a test written "
+        "that way could assert a 20ms bound and run under -n 4 unnoticed"
+    )


### PR DESCRIPTION
The Backend CI matrix leg is the longest job in the repo at **23.3 min/run**, and it was the only large pytest run still serial. The sibling `repo-cpu-tests` job in the same workflow has run `-n 4` since it measured 806s to 220s.

## Measurement

Same tree, same environment, same deselections, back to back:

| | wall clock | result |
| --- | --- | --- |
| serial | 1322.6s (22:02) | 51 failed, 26190 passed, 108 skipped |
| `-n 4` | 343.0s (5:43) | 51 failed, 26188 passed, 110 skipped |

**3.86x**, and the two failure sets were compared name for name and are equal: zero failures appear in one mode and not the other. So nothing in this suite depends on the order it runs in.

To be clear about those 51: they are one local environment missing `peft` and a `diffusers` pin, and they fail identically both ways. The point is the agreement between the two modes, not the count. CI installs those deps and is green.

This is CPU bound rather than memory bound. The suite loads no model, so four workers on a four-vCPU runner is the right shape. That is deliberately not true of the inference smoke workflows, where four Studios on one runner would not fit, and this changes nothing there.

## What the existing guard did

`tests/studio/test_backend_ci_parallel_isolation.py` failed on this change, correctly. It asserted **exactly one** parallel pytest run in the workflow and required every parallel run to ignore `tests/studio/load_freeze` and the three hardware-spoof files.

Those ignores belong to the repo-root run only. The two parallel runs are over different trees: `repo-cpu-tests` runs `tests/` from the checkout, while the matrix job runs the backend's own suite with `working-directory: studio/backend`, so `tests/studio/load_freeze` is not a path that exists for it and demanding the ignore would be nonsense.

So the guard now tells the two apart by what they ignore, and applies the isolation rules to the repo-root run. A new test pins the matrix leg as parallel, because losing the flag would otherwise show up only as CI slowly getting slower again, which nothing reports.

Mutation tested both ways: reverting the matrix leg to serial fails 2 tests, and dropping the `load_freeze` ignore from the repo-root run still fails 1.

## Effect

Backend CI is 26% of all CI minutes. At 4 legs on main and 2 on pull requests, this is roughly 17 minutes off each leg, and it takes the repo's critical path from 23.3 min down behind Chat UI Tests at 22.1 min.