### PR TITLE
Stop the media switch test racing a 0.3s budget against 2s of cold path

### DIFF
--- a/studio/backend/tests/test_media_auto_switch.py
+++ b/studio/backend/tests/test_media_auto_switch.py
@@ -1036,7 +1036,12 @@ def test_setup_keeps_the_gate_and_lock_after_the_caller_gives_up(
         # budget measure the block and only the block.
         warmed = asyncio.Event()
 
-        async def _quick_setup(owner, pick, current_subject, hf_token = None):
+        async def _quick_setup(
+            owner,
+            pick,
+            current_subject,
+            hf_token = None,
+        ):
             warmed.set()
 
         monkeypatch.setattr(mas, "_start_load", _quick_setup)

--- a/studio/backend/tests/test_media_auto_switch.py
+++ b/studio/backend/tests/test_media_auto_switch.py
@@ -1010,7 +1010,6 @@ def test_setup_keeps_the_gate_and_lock_after_the_caller_gives_up(
     # begin_load, so a newly admitted generation could be cut short by the orphaned switch.
     import core.inference.media_keepwarm as keepwarm
 
-    monkeypatch.setattr(mas, "_SWITCH_BUDGET_S", 0.3)
     started = asyncio.Event()
     release = asyncio.Event()
 
@@ -1023,9 +1022,38 @@ def test_setup_keeps_the_gate_and_lock_after_the_caller_gives_up(
         started.set()
         await release.wait()
 
-    monkeypatch.setattr(mas, "_start_load", _slow_setup)
-
     async def _drive():
+        # One warm pass over the same path, at the production budget, with a setup that
+        # returns instead of blocking. Reaching _start_load the FIRST time measured 1.98s
+        # here, and media_auto_switch counts that against the switch budget on purpose
+        # ("the cold scan is part of the wait the caller experiences"). At the production
+        # 90s that is nothing. This test shrinks the budget to 0.3s because a large one
+        # has to be waited out -- at 30s the test took 31.8s -- and a cold path then blows
+        # 0.3s before setup is entered: the 503 comes from the scan rather than from the
+        # block under test, the status-code assertion still passes, and the failure lands
+        # further down on `started.is_set()` explaining nothing. That is how it failed on
+        # the 3.13 leg while 3.10 passed the same commit. Warming is what makes the small
+        # budget measure the block and only the block.
+        warmed = asyncio.Event()
+
+        async def _quick_setup(owner, pick, current_subject, hf_token = None):
+            warmed.set()
+
+        monkeypatch.setattr(mas, "_start_load", _quick_setup)
+        with contextlib.suppress(HTTPException):
+            await mas.maybe_auto_switch_media_model(
+                "black-forest-labs/FLUX.1-dev",
+                owner = arb.DIFFUSION,
+                current_subject = "test-user",
+                openai_errors = True,
+            )
+        assert warmed.is_set(), (
+            "the warm pass never reached _start_load at the production budget, so the "
+            "timed run below cannot be measuring what this test is about"
+        )
+
+        monkeypatch.setattr(mas, "_SWITCH_BUDGET_S", 0.3)
+        monkeypatch.setattr(mas, "_start_load", _slow_setup)
         task = asyncio.ensure_future(
             mas.maybe_auto_switch_media_model(
                 "black-forest-labs/FLUX.1-dev",


### PR DESCRIPTION
`test_setup_keeps_the_gate_and_lock_after_the_caller_gives_up` failed on the **3.13 leg while 3.10 passed the same commit**, and it fails every time when run alone. It surfaced on a staging Backend CI run; main has not completed a Backend CI run in a day, so nothing was reporting it.

## What is actually wrong

Measured: reaching `_start_load` the first time takes **1.98s**. The test sets the budget to **0.3s**. So the 503 arrives from the cold path rather than from the block under test. The status-code assertion passes anyway, because both paths 503, and the failure lands further down on `started.is_set()`:

```
FAILED tests/test_media_auto_switch.py::test_setup_keeps_the_gate_and_lock_after_the_caller_gives_up
assert False
 +  where False = is_set()
 +    where is_set = <asyncio.locks.Event object at 0x... [unset]>.is_set
```

**The source is right.** `media_auto_switch` counts the cold scan against the budget deliberately, and says so at the deadline: *"started before resolution: the cold scan is part of the wait the caller experiences"*. In production `_SWITCH_BUDGET_S` is **90.0**, where 2s is nothing. Inside the file the test passes only because its siblings warm the path first, which is why this never showed up until a leg ran slow enough to lose the race even warm.

## Three fixes that do not work

- **Widen the budget.** The test has to wait the budget out, so it just gets slower: 3.5s at 0.3s, **31.8s at 30s**. And any fixed value is still a race.
- **Stop the clock.** The timeout is derived (`deadline - time.monotonic()`) and handed to asyncio in real time, so freezing it changes nothing. Patching `time.monotonic` globally also stops the event loop's clock, and the test hangs instead of failing.
- **Warm just the download scan.** Not enough; the 2s is spread across the path.

## What this does

One warm pass over the same call at the production budget, with a setup that returns instead of blocking, asserting that pass reached `_start_load` before the budget is shrunk for the run being measured. The small budget then measures the block and only the block.

## Verification

- fails on main's shape **every time** in isolation
- passes **5 consecutive** isolated runs
- passes **3 more with four cores deliberately saturated**
- the file still passes 103 tests in 11.9s

This also de-risks #9095, which runs this suite under `-n 4`: four workers on four vCPUs is exactly the contention that loses this race.