### PR TITLE
Studio: run the frontend unit tests on Windows in CI

### DIFF
--- a/.github/workflows/studio-frontend-ci.yml
+++ b/.github/workflows/studio-frontend-ci.yml
@@ -239,3 +239,50 @@ jobs:
           name: studio-frontend-dist
           path: studio/frontend/dist
           retention-days: 1
+
+  # The suite reads its own sources off disk, resolves modules by URL and walks
+  # directories, so it can be correct on POSIX and wrong on Windows. Running it
+  # on ubuntu only, this job's absence let 13 such failures accumulate unseen
+  # across three files: two shapes of path/URL confusion, one of them added by a
+  # PR whose whole purpose was to fix a Windows bug.
+  #
+  # Deliberately NOT a matrix over the job above. Measured on a staging replica
+  # of this workflow, `windows-latest` runs `npm test` in 49s against ubuntu's
+  # 47s, so the tests themselves are not the expensive part; typecheck (48s),
+  # build (33s), the Chromium install and the three browser smokes are, and none
+  # of them can fail on Windows for a reason they would not also fail on ubuntu.
+  # Repeating them would roughly triple the cost of this workflow to re-answer a
+  # question ubuntu already answered. Checkout, node, `npm ci` and `npm test` on
+  # Windows measured ~110s.
+  #
+  # Line endings need no special handling here: .gitattributes pins
+  # `studio/frontend/** text=auto eol=lf`, so the tree checks out LF whatever the
+  # runner's core.autocrlf says, and the assertions that match on exact source
+  # substrings see the bytes in the repo.
+  windows:
+    name: Frontend unit tests (Windows)
+    runs-on: windows-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        shell: bash
+        working-directory: studio/frontend
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
+        with:
+          node-version: '22'
+
+      # Plain `npm ci`, not the hardened install the ubuntu job runs. The
+      # lockfile audit, the allowScripts pins and `--strict-allow-scripts` are
+      # supply-chain gates on the same lockfile, and this job is a platform gate;
+      # duplicating them here would spend a second runner to re-check bytes that
+      # cannot differ, and `--strict-allow-scripts` needs the npm 11.16 upgrade
+      # step besides.
+      - run: npm ci --no-fund --no-audit
+
+      - name: Unit tests
+        run: npm test

--- a/.github/workflows/studio-frontend-ci.yml
+++ b/.github/workflows/studio-frontend-ci.yml
@@ -253,7 +253,7 @@ jobs:
   # of them can fail on Windows for a reason they would not also fail on ubuntu.
   # Repeating them would roughly triple the cost of this workflow to re-answer a
   # question ubuntu already answered. Checkout, node, `npm ci` and `npm test` on
-  # Windows measured ~110s.
+  # Windows measured ~132s.
   #
   # Line endings need no special handling here: .gitattributes pins
   # `studio/frontend/** text=auto eol=lf`, so the tree checks out LF whatever the
@@ -276,13 +276,26 @@ jobs:
         with:
           node-version: '22'
 
-      # Plain `npm ci`, not the hardened install the ubuntu job runs. The
-      # lockfile audit, the allowScripts pins and `--strict-allow-scripts` are
-      # supply-chain gates on the same lockfile, and this job is a platform gate;
-      # duplicating them here would spend a second runner to re-check bytes that
-      # cannot differ, and `--strict-allow-scripts` needs the npm 11.16 upgrade
-      # step besides.
-      - run: npm ci --no-fund --no-audit
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
+        with:
+          python-version: '3.12'
+
+      # The same pre-install scan the ubuntu job runs, and for the same reason:
+      # a compromised tarball runs its `prepare` / `postinstall` during `npm ci`,
+      # so any catch has to fire upstream of that. Jobs run concurrently, so the
+      # ubuntu job rejecting the lockfile does not help a Windows runner that has
+      # already installed it. Pure-Python and read-only.
+      - name: Lockfile supply-chain audit (pre-install scan)
+        working-directory: ${{ github.workspace }}
+        run: python scripts/lockfile_supply_chain_audit.py
+
+      # `--ignore-scripts`, not the `--strict-allow-scripts` install the ubuntu
+      # job runs. That one needs the npm 11.16 upgrade step, and the pins it
+      # enforces are a property of the lockfile, which this job does not need to
+      # re-check: it is a platform gate. Running no install script at all is the
+      # stronger position anyway, and the suite is node:test over TypeScript
+      # sources, so nothing here needs a native build step.
+      - run: npm ci --ignore-scripts --no-fund --no-audit
 
       - name: Unit tests
         run: npm test

--- a/studio/frontend/tests/background-load-notice.test.ts
+++ b/studio/frontend/tests/background-load-notice.test.ts
@@ -320,29 +320,62 @@ test("a long but healthy download is never abandoned", async () => {
   stop();
 });
 
-test("a healthy read resets the stall window", async () => {
+const STALL_MS = 400;
+
+/**
+ * Poll until the notice settles, with the read at `healthyAt` reporting progress
+ * and every other read unreadable. `healthyAt: 0` means none of them do.
+ * Returns how many reads the loop survived.
+ */
+async function readsBeforeSettling(healthyAt: number): Promise<number> {
   const { settled, stop } = record();
   let read = 0;
-
   await withBackgroundLoadNotice(
     "image",
     "unsloth/flux",
     async () => null,
     async () => {
       read += 1;
-      // Unreadable, then healthy, then unreadable again. Without the reset the
-      // second run of failures would inherit the first one's elapsed time.
-      if (read === 1 || read === 2) throw new Error("backend restarting");
-      if (read === 3) return "downloading";
+      if (read === healthyAt) return "downloading";
       throw new Error("backend restarting");
     },
-    { pollMs: 1, readTimeoutMs: 25, stallMs: 30 },
+    // readTimeoutMs is generous on purpose: the read answers immediately, and a
+    // busy runner must not turn a healthy read into an unreadable one.
+    { pollMs: 1, readTimeoutMs: 5_000, stallMs: STALL_MS },
+  );
+  await settled;
+  stop();
+  return read;
+}
+
+test("a healthy read resets the stall window", async () => {
+  // The source reads `Date.now()` and arms `setTimeout` itself, so this runs on
+  // the wall clock. That rules out asserting a read count against a millisecond
+  // budget: one poll costs about 1 ms here and about 15 ms on a Windows runner,
+  // whose default timer granularity is coarser than any margin small enough to
+  // keep the test quick. The previous version asserted `reads > 4` against a
+  // 30 ms window and was both flaky on Windows (2 reads consumed it before the
+  // healthy one arrived) and vacuous on Linux, where 30 ms of 1 ms polls clears
+  // 4 reads whether or not the window is ever reset.
+  //
+  // So measure the reset against the same loop without one. The comparison
+  // divides the platform out: whatever a poll costs, a window restarted halfway
+  // through must carry the loop about half as far again.
+  const withoutReset = await readsBeforeSettling(0);
+  assert.ok(
+    withoutReset > 8,
+    `the baseline is too short to compare against: ${withoutReset} reads. ` +
+      "Raise STALL_MS.",
   );
 
-  await settled;
-  // It survived past the point an unreset window would have expired.
-  assert.ok(read > 4, `expected the window to restart, got ${read} reads`);
-  stop();
+  const withReset = await readsBeforeSettling(Math.floor(withoutReset / 2));
+  assert.ok(
+    withReset >= withoutReset * 1.25,
+    "a healthy read did not restart the stall window: " +
+      `${withReset} reads with one, ${withoutReset} without. A run of ` +
+      "unreadable polls is inheriting the elapsed time of the run before it, so " +
+      "a slow download that keeps reporting progress can still be abandoned.",
+  );
 });
 
 test("the load is announced again once the POST has committed", async () => {


### PR DESCRIPTION
Frontend CI runs on `ubuntu-latest` only, so nothing in this org has ever executed the frontend unit suite on Windows. A test that is correct on POSIX and wrong on Windows therefore stays green here forever.

## What that has cost

Measured on a staging replica of this workflow, against `main` at 34c9d98:

| runner | tests | pass | fail |
|---|---|---|---|
| `ubuntu-latest` | 3594 | 3594 | 0 |
| `windows-latest` | 3594 | 3581 | **13** |

The 13 are path and URL confusion in three test files and are fixed in #8980, which also adds a static rule so those two shapes fail on Linux. This PR is the other half: the shapes nobody has thought of yet.

## The job

Deliberately not a matrix over the existing job. Per-step measurement on the staging replica:

| step | ubuntu | windows |
|---|---|---|
| checkout + setup-node | 6s | 17s |
| `npm ci` | 20s | 44s |
| `npm run typecheck` | 54s | 48s |
| `npm run build` | 35s | 33s |
| `npm test` | 47s | 49s |
| whole job | 167s | 198s |

The tests themselves are not the expensive part, and typecheck, build, the Chromium install and the three browser smokes cannot fail on Windows for a reason they would not also fail on ubuntu. Repeating them would roughly triple the cost of this workflow to re-answer a question ubuntu already answered.

So the new job is checkout, node, `npm ci`, `npm test`. Measured at **123s** as a standalone Windows job, against 167s for the existing ubuntu one. It is a public repo, so the runner minutes are free; the real cost is one more concurrent job slot per frontend PR, which is what the scope above is minimising.

`npm ci` there is the plain form, not the hardened install the ubuntu job runs. The lockfile audit, the allowScripts pins and `--strict-allow-scripts` are supply-chain gates on the same lockfile, and this job is a platform gate, so duplicating them would spend a second runner re-checking bytes that cannot differ.

## Line endings

No special handling, and this is measured rather than assumed. `.gitattributes` pins `studio/frontend/** text=auto eol=lf`, so the tree checks out LF whatever the runner's `core.autocrlf` says. A Windows job run with the runner's default git config, with no override, reported no CRLF in either a source file or a test file and passed the suite.

That matters because many tests in this suite read their own sources with `readFileSync` and assert on exact substrings including indentation.

Measured rather than reasoned: a `windows-latest` job with no git config step at all reported

```
core.autocrlf: true   (file:C:/Program Files/Git/etc/gitconfig)
CRLF in app.tsx: false
CRLF in a test:  false
```

so the runner does default to `autocrlf=true` and `.gitattributes` does override it for this tree.

## The one test that could not pass

`background-load-notice.test.ts`, "a healthy read resets the stall window", failed on one of two Windows runs of the same commit:

```
expected the window to restart, got 2 reads
```

It drove the poll loop with `pollMs: 1, stallMs: 30` and asserted `reads > 4`. The default timer resolution on Windows is about 15.6 ms, so two polls consume the whole 30 ms window before the healthy read at poll 3 ever arrives.

Both readings, since a Windows-only failure can be either side:

- **The test is wrong.** In production the same values are `pollMs: 2000` and `stallMs: 3600000`. A 15 ms timer skew is five orders of magnitude below the margin the product actually uses, so no user is affected. The test asserts a property of the algorithm using a stopwatch too coarse to read it.
- **The source is wrong.** It would have to be that `Date.now()` plus `setTimeout` genuinely mis-sequences on Windows in a way a user meets. It does not: the loop is correct, and at the real cadences the granularity is irrelevant.

The test is wrong, so it is fixed rather than skipped. And it was worth more than that:

**The old assertion measured nothing.** With `lastHealthy = Date.now()` deleted from `settleWhenLoadEnds`, so that the stall window is never reset at all, the old test still passed on Linux 5 times out of 5. 30 ms of 1 ms polls clears 4 reads whether or not the window restarts.

The replacement drops the millisecond budget and compares the loop against itself: run it with no healthy read at all, then run it again with one healthy read halfway through that count, and require the second run to survive at least 25 percent more polls. Whatever a poll costs on the platform, a window restarted halfway must carry the loop about half as far again, so the comparison divides the platform out.

Checked against a deliberately broken tree, the same one as above:

| tree | old assertion | new assertion |
|---|---|---|
| `lastHealthy` reset present | pass 5/5 | pass 5/5 |
| `lastHealthy` reset deleted | **pass 5/5** | **fail 5/5** |

It costs about 1s, since it now runs the settle loop twice at a 400 ms stall window rather than once at 30 ms. The whole suite is about 10s.

## Testing

Test and workflow only; no source changes and nothing a user can see changes.

`npm test` 3594 passed 0 failed and `npm run typecheck` clean locally. `scripts/lint_workflow_triggers.py`, `tests/studio/test_playwright_suites_run_in_ci.py`, `tests/studio/test_main_runs_survive_merge_bursts.py` and `tests/studio/test_smoke_workflows_share_one_script.py` all pass with the new job in place.


## Merge order

**This needs #8980 first.** The new job runs the suite as it is, so on `main` today it reports the 13 path failures and Frontend CI goes red. Staged on current `main`, it does exactly that:

```
# tests 3594
# pass 3581
# fail 13
```

which is the point of the job, and is #8980's diff. With #8980 applied the same job is 3598 passed, 0 failed. The stall-window fix in this PR is already accounted for in both numbers: it passed on `windows-latest` here.



## The job as shipped, on a real Windows runner

Not a lookalike: the `windows` job was lifted verbatim out of this file onto a staging branch made of `main` + #8980 + this PR, and run on `windows-latest`.

```
Frontend unit tests (Windows)  success  123s
  checkout                                        11s
  setup-node                                       5s
  setup-python                                     0s
  Lockfile supply-chain audit (pre-install scan)   2s
  npm ci --ignore-scripts --no-fund --no-audit    44s
  Unit tests                                      56s

# tests 3598
# pass 3598
# fail 0
```

So the audit step, the `--ignore-scripts` install and the suite all pass on Windows in the configuration this PR ships, at 123s against the ubuntu job's 167s.
