### PR TITLE
One interpreter leg on a pull request, and a floor lint that reads more than syntax

### DIFF
--- a/.github/workflows/studio-backend-ci.yml
+++ b/.github/workflows/studio-backend-ci.yml
@@ -105,7 +105,7 @@ jobs:
         # peculiar to 3.11 or 3.12 alone.
         python: >-
           ${{ github.event_name == 'pull_request'
-              && fromJSON('["3.10", "3.13"]')
+              && fromJSON('["3.13"]')
               || fromJSON('["3.10", "3.11", "3.12", "3.13"]') }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1

--- a/.github/workflows/studio-backend-ci.yml
+++ b/.github/workflows/studio-backend-ci.yml
@@ -118,16 +118,26 @@ jobs:
         # scripts/lint_backend_python_floor.py, which reads stdlib API availability
         # rather than syntax alone and covers 1093 shipped and executed files.
         #
-        # Stated plainly, because it is a real reduction and not a free one: a static
-        # check does not run anything. Two interpreters that both accept a line can
-        # still behave differently on it, and a sys.version_info branch is only ever
-        # parsed, never taken. sitecustomize.py repoints pathlib's pre-3.11
-        # _NormalAccessor, native_path_leases.py and third_party_source.py branch on
-        # >= 3.12, and worker.py on a minimum below that; on 3.13 alone the older side of
-        # each is never executed. Those branches are covered by reading, by the floor
-        # lint's view of the names they use, and by test_python39_compatibility.py's
-        # parse, not by execution.
-        python: ['3.13']
+        # A static check does not run anything, though, and that part cannot be waved
+        # away: two interpreters that both accept a line can still behave differently on
+        # it, and a sys.version_info branch is only ever parsed, never taken.
+        #
+        # So the branches were counted rather than assumed. Seven files in the backend
+        # carry one, at 3.10, 3.12 and 3.14. The 3.10 ones were never straddled even by
+        # the old matrix, whose oldest leg was 3.10, so every leg took the same side of
+        # them and removing legs loses nothing there. 3.14 is above every leg there has
+        # ever been. What is genuinely lost is the PRE-3.12 side of three files, and that
+        # is small enough to keep executing directly.
+        #
+        # Hence the second entry: 3.11, the newest version that still takes that side,
+        # running those three files and nothing else. Roughly 40 tests in under ten
+        # seconds, not a second copy of the suite, and it runs beside the full leg rather
+        # than in front of it, so the critical path is unchanged.
+        include:
+          - python: '3.13'
+            scope: full
+          - python: '3.11'
+            scope: floor-spot-check
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
@@ -187,6 +197,7 @@ jobs:
           pip install torchao
 
       - name: Backend tests
+        if: matrix.scope == 'full'
         working-directory: studio/backend
         # Locally validated against this dep set: 831 passed, 5 skipped, 35 deselected.
         # Deselections (all environment-specific, would never pass on a GPU-less
@@ -242,6 +253,7 @@ jobs:
             -k 'not llama_cpp_load_progress_live and not TestGpuAutoSelection and not TestPreSpawnGpuResolution and not TestPerGpuFitGuardAllCounts and not TestTransformersIntrospection and not test_returns_cuda_when_cuda_available and not test_calls_cuda_cache_when_cuda'
 
       - name: Backend tests that cannot share a worker
+        if: matrix.scope == 'full'
         working-directory: studio/backend
         # Relative timing against a reference measured in the same process. Serial, so the
         # comparison is between two implementations rather than between two schedulings.
@@ -258,6 +270,26 @@ jobs:
             tests/test_scan_loras_off_event_loop.py \
             tests/test_anthropic_messages.py \
             tests/test_profile_stats.py
+
+      - name: Pre-3.12 branches, on the newest interpreter that takes them
+        if: matrix.scope == 'floor-spot-check'
+        working-directory: studio/backend
+        # Not a second copy of the suite. Seven backend files carry a sys.version_info
+        # branch, at 3.10, 3.12 and 3.14. The 3.10 ones were never straddled even by the
+        # old four-leg matrix, whose oldest leg WAS 3.10, so every leg took the same side
+        # and dropping legs loses nothing there. 3.14 is above every leg there has ever
+        # been. What a 3.13-only matrix genuinely stops executing is the pre-3.12 side of
+        # these files, and that is small enough to keep running rather than argue about.
+        #
+        # 3.11 because it is the newest version that still takes that side: closest to
+        # the ceiling, so anything it catches is about the boundary rather than about
+        # being old. Roughly 40 tests in under ten seconds, beside the full leg rather
+        # than in front of it, so the critical path is the full leg either way.
+        run: |
+          python -m pytest -q --tb=short \
+            tests/test_third_party_source.py \
+            tests/test_recommended_folders_permission.py \
+            tests/test_hf_cache_settings.py
 
   repo-cpu-tests:
     # Auto-discover everything under tests/ that is not GPU-bound by

--- a/.github/workflows/studio-backend-ci.yml
+++ b/.github/workflows/studio-backend-ci.yml
@@ -13,7 +13,7 @@
 #     not appropriate for CPU-only runners.
 #
 # Two jobs:
-#   - pytest matrix (3.10/3.11/3.12/3.13) over studio/backend/tests
+#   - pytest on 3.13 over studio/backend/tests, with the floor checked statically
 #   - repo-cpu-tests: auto-discovered tests/ + state-isolated spoof files
 #
 # Whole-repo Python lint (syntax + ruff + debugger-leftover scan)
@@ -61,6 +61,26 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  # The oldest interpreter this code is expected to run on.
+  #
+  # Nothing executes it any more. The 3.10, 3.11 and 3.12 legs ran the same suite as 3.13
+  # and differed by exactly one skip marker, at 97 runner-minutes per push against a queue
+  # that has been observed 195 deep, so they are gone and the wall-clock they were costing
+  # every other workflow is gone with them.
+  #
+  # What they were really defending is that nothing reaches for a symbol newer than this,
+  # which is static, and scripts/lint_backend_python_floor.py now checks it here on every
+  # pull request in seconds across 1093 files. Raise this number only with a reason, and
+  # remember that raising it is a support decision, not a CI one.
+  #
+  # 3.10 rather than the 3.9 pyproject.toml declares, because 3.9 is not true today:
+  # unsloth/models/_utils.py uses dataclasses.dataclass(kw_only) and
+  # tempfile.TemporaryDirectory(ignore_cleanup_errors), both 3.10. Reconciling those two
+  # is worth doing separately; this lint is what made it visible.
+  PYTHON_FLOOR: '3.10'
+
+
 jobs:
   pytest:
     name: (Python ${{ matrix.python }})
@@ -82,31 +102,32 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Both ends on a pull request, all four on main.
+        # 3.13 only, on pull requests and on main alike.
         #
-        # Measured on one runner over the same tree: the four legs collect the same
-        # 26,320 tests and differ by exactly ONE of them, the >= 3.12 gate on
-        # test_demonstrates_the_underlying_stdlib_regression. 3.10 and 3.11 report
-        # 26193 passed / 127 skipped, 3.12 and 3.13 report 26194 / 126. Four legs cost
-        # 97 runner-minutes per push (1663 + 1249 + 1419 + 1506 seconds) against a
-        # queue that has been observed 195 deep.
+        # Measured on one runner over the same tree: the four legs collected the same
+        # 26,320 tests and differed by exactly ONE of them, the >= 3.12 gate on
+        # test_demonstrates_the_underlying_stdlib_regression. 3.10 and 3.11 reported
+        # 26193 passed / 127 skipped, 3.12 and 3.13 reported 26194 / 126. Four legs cost
+        # 97 runner-minutes per push (1663 + 1249 + 1419 + 1506 seconds) against a queue
+        # that has been observed 195 deep, to re-run one identical suite four times and
+        # learn the value of a single skip marker.
         #
-        # A single leg was tried and is wrong. tests/test_python39_compatibility.py
-        # covers older SYNTAX statically, against the floor pyproject.toml declares
-        # (3.9), which is lower than any leg here. It cannot cover a version-conditional
-        # branch, because it parses rather than runs: sitecustomize.py repoints
-        # pathlib's pre-3.11 _NormalAccessor, native_path_leases.py and
-        # third_party_source.py branch on >= 3.12, and worker.py on a minimum below
-        # that. On 3.13 alone the older side of each is never executed.
+        # What the older legs were really defending is that nothing in the tree reaches
+        # for a symbol newer than the floor, and that is a static property. It is now
+        # checked statically, on every pull request, in seconds, by
+        # scripts/lint_backend_python_floor.py, which reads stdlib API availability
+        # rather than syntax alone and covers 1093 shipped and executed files.
         #
-        # So: the ends. The floor exercises those branches, the ceiling is where
-        # removals and deprecations land and where the one version-gated test runs
-        # rather than skipping. What is left uncovered until merge is a difference
-        # peculiar to 3.11 or 3.12 alone.
-        python: >-
-          ${{ github.event_name == 'pull_request'
-              && fromJSON('["3.13"]')
-              || fromJSON('["3.10", "3.11", "3.12", "3.13"]') }}
+        # Stated plainly, because it is a real reduction and not a free one: a static
+        # check does not run anything. Two interpreters that both accept a line can
+        # still behave differently on it, and a sys.version_info branch is only ever
+        # parsed, never taken. sitecustomize.py repoints pathlib's pre-3.11
+        # _NormalAccessor, native_path_leases.py and third_party_source.py branch on
+        # >= 3.12, and worker.py on a minimum below that; on 3.13 alone the older side of
+        # each is never executed. Those branches are covered by reading, by the floor
+        # lint's view of the names they use, and by test_python39_compatibility.py's
+        # parse, not by execution.
+        python: ['3.13']
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:

--- a/.github/workflows/workflow-trigger-lint.yml
+++ b/.github/workflows/workflow-trigger-lint.yml
@@ -80,6 +80,13 @@ jobs:
       - name: Backend still runs on the oldest interpreter the matrix claims
         run: python3 scripts/lint_backend_python_floor.py
 
+      # And the test that says the step above must exist. Without this, a pull request
+      # that edits only this workflow and deletes that step passes: Backend CI's paths
+      # cover its own YAML and studio/**, not .github/workflows/**, so the assertion
+      # protecting the step is never collected for the one change it exists to reject.
+      - name: The floor lint is still wired up
+        run: python3 -m pytest tests/studio/test_backend_ci_matrix.py -q
+
       # Runs here rather than in the Repo tests job, for this workflow's own reason:
       # the regression it catches is a workflow or .github/scripts edit that drops a
       # Playwright invocation, and studio-backend-ci.yml's paths do not include

--- a/.github/workflows/workflow-trigger-lint.yml
+++ b/.github/workflows/workflow-trigger-lint.yml
@@ -64,10 +64,21 @@ jobs:
           python-version: '3.12'
 
       - name: Install PyYAML
-        run: pip install pyyaml pytest
+        run: pip install pyyaml pytest vermin
 
       - name: Lint workflow triggers + cache keys
         run: python3 scripts/lint_workflow_triggers.py
+
+      # What the dropped interpreter legs used to catch, as far as a static check can.
+      # A pull request runs only the newest leg now, so nothing EXECUTES the backend on
+      # the oldest one until the push to main. ast.parse at a feature_version covers
+      # syntax and nothing else, which would miss the actual shape of this regression:
+      # reaching for a stdlib name that does not exist yet, like the `anext` in
+      # core/research_runs.py that already requires 3.10. vermin reads both, so a symbol
+      # added after the floor fails here in seconds rather than on main in 23 minutes.
+      # No paths filter on this workflow, so it sees every pull request.
+      - name: Backend still runs on the oldest interpreter the matrix claims
+        run: python3 scripts/lint_backend_python_floor.py
 
       # Runs here rather than in the Repo tests job, for this workflow's own reason:
       # the regression it catches is a workflow or .github/scripts edit that drops a

--- a/scripts/lint_backend_python_floor.py
+++ b/scripts/lint_backend_python_floor.py
@@ -55,10 +55,14 @@ ROOTS = (
 # It also named "loggers.py", which is a directory, so that entry matched nothing at all.
 # A check that covers most of the tree reads exactly like one that covers all of it.
 #
-# So the tree is the input and only these come out:
-#   tests   -- run by whatever interpreter runs them, and not shipped
-#   vendor  -- third party, pinned to its own support range
-EXCLUDE_PARTS = ("tests", "vendor", "node_modules", "__pycache__", ".venv")
+# So the tree is the input and only vendored code comes out, pinned to its own support
+# range. Tests are IN, which the first version had wrong on the theory that they are not
+# shipped: shipping is not the question, execution is. studio-backend-ci runs
+# `pytest tests/` from studio/backend on every leg, so a 3.11 API in a test file is
+# executed by the 3.10 leg exactly as one in a shipped module is. With the pull request
+# down to a single 3.13 leg, that leg and this lint would both pass and the failure would
+# arrive on the push to main, which is the whole gap this exists to close.
+EXCLUDE_PARTS = ("vendor", "node_modules", "__pycache__", ".venv")
 
 # An above-floor symbol reached deliberately is suppressed AT THE SITE, with `# novermin`
 # and a comment saying why, not by dropping its file from the scan. Excluding the file
@@ -90,7 +94,7 @@ def matrix_floor() -> tuple[int, int]:
 
 
 def targets() -> list[str]:
-    """Every shipped .py under the trees the matrix runs, found rather than listed."""
+    """Every .py the matrix legs ship or execute, found rather than listed."""
     found = []
     for root in ROOTS:
         if not root.is_dir():
@@ -119,7 +123,7 @@ def main() -> int:
         )
     files = targets()
     print(
-        f"[floor] {len(files)} shipped files must run on Python {target}, "
+        f"[floor] {len(files)} files must run on Python {target}, "
         f"the oldest leg in the matrix"
     )
     command = [
@@ -133,7 +137,7 @@ def main() -> int:
     sys.stdout.write(result.stdout)
     sys.stderr.write(result.stderr)
     if result.returncode == 0:
-        print(f"[floor] OK: nothing shipped needs more than {target}")
+        print(f"[floor] OK: nothing needs more than {target}")
         return 0
     print(
         f"::error title=Backend needs a newer Python than the matrix floor::"

--- a/scripts/lint_backend_python_floor.py
+++ b/scripts/lint_backend_python_floor.py
@@ -76,21 +76,34 @@ EXCLUDE_PARTS = ("vendor", "node_modules", "__pycache__", ".venv")
 # Comment parsing is therefore ON, which is what makes the annotation work.
 
 
-def matrix_floor() -> tuple[int, int]:
-    """The oldest interpreter the workflow's matrix names, read from the workflow.
+# The floor is DECLARED, in the workflow, next to where the legs used to be.
+#
+# It used to be derived from the matrix, which was right while the matrix ran several
+# interpreters and became self-defeating the moment it ran one: a 3.13-only matrix would
+# have moved the floor to 3.13 and left this check asserting that code written for 3.13
+# runs on 3.13. Deriving it from pyproject.toml is not the answer either, because that
+# says >= 3.9 and is not true today: unsloth/models/_utils.py already uses
+# dataclasses.dataclass(kw_only) and tempfile.TemporaryDirectory(ignore_cleanup_errors),
+# both 3.10, so a 3.9 target fails on the tree as it stands. That mismatch is worth
+# fixing, in its own change, and this lint is what makes it visible rather than what
+# hides it.
+#
+# So it is a number, written down once, in the workflow that would otherwise have tested
+# it, and read from there.
+FLOOR_KEY = "PYTHON_FLOOR"
 
-    Taken from the FULL list rather than the pull-request subset: the subset is the
-    ceiling only, and the floor this lint defends is the oldest version main still runs.
-    """
+
+def declared_floor() -> tuple[int, int]:
+    """The floor the workflow declares, as (major, minor)."""
     text = WORKFLOW.read_text(encoding = "utf-8")
-    lists = re.findall(r"fromJSON\('(\[[^']*\])'\)", text)
-    if not lists:
-        raise SystemExit(f"no fromJSON matrix found in {WORKFLOW.name}; this lint cannot aim")
-    versions = []
-    for item in lists:
-        versions.extend(json.loads(item))
-    parsed = sorted(tuple(int(part) for part in v.split(".")) for v in versions)
-    return parsed[0]
+    found = re.search(rf"^\s*{FLOOR_KEY}:\s*['\"]?(\d+)\.(\d+)['\"]?\s*$", text, re.M)
+    if not found:
+        raise SystemExit(
+            f"{WORKFLOW.name} declares no {FLOOR_KEY}, so this lint has no target. It is "
+            f"declared there rather than here so that the number lives with the CI that "
+            f"used to test it."
+        )
+    return int(found.group(1)), int(found.group(2))
 
 
 def targets() -> list[str]:
@@ -110,7 +123,7 @@ def targets() -> list[str]:
 
 
 def main() -> int:
-    floor = matrix_floor()
+    floor = declared_floor()
     target = f"{floor[0]}.{floor[1]}"
     # The console script, not `python -m vermin`: the package has no __main__, so that
     # form exits nonzero for the wrong reason and this lint would fail on every run while
@@ -124,7 +137,7 @@ def main() -> int:
     files = targets()
     print(
         f"[floor] {len(files)} files must run on Python {target}, "
-        f"the oldest leg in the matrix"
+        f"the declared floor"
     )
     command = [
         vermin,
@@ -143,9 +156,10 @@ def main() -> int:
         f"::error title=Backend needs a newer Python than the matrix floor::"
         f"something under studio/backend or unsloth_cli requires more than Python {target}, "
         f"which is the "
-        f"oldest leg studio-backend-ci runs. A pull request only runs the newest leg, so "
-        f"this would otherwise fail on the push to main. Either guard the usage behind a "
-        f"sys.version_info check, or raise the floor in the workflow matrix and say why."
+        f"floor studio-backend-ci declares. Nothing runs that interpreter any more, so "
+        f"this check is the only thing standing between an above-floor symbol and a user "
+        f"on that version. Either guard the usage behind a sys.version_info check, or "
+        f"raise {FLOOR_KEY} in the workflow and say why."
     )
     return 1
 

--- a/scripts/lint_backend_python_floor.py
+++ b/scripts/lint_backend_python_floor.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Refuse backend source that needs a newer interpreter than the matrix floor.
+
+A pull request runs Backend CI on the NEWEST interpreter only. Every older leg still runs
+on the push to main, so a version-specific break is caught at merge rather than never, but
+between opening a pull request and merging it nothing executes the backend on the oldest
+one. This closes as much of that gap as a static check can.
+
+Syntax is the easy half, and ``tests/test_python39_compatibility.py`` already covers it by
+parsing at the version ``pyproject.toml`` declares. Syntax is also not the shape this
+regression takes. The realistic mistake is reaching for a stdlib name that does not exist
+yet -- ``core/research_runs.py`` already uses ``anext``, which is 3.10 -- and that parses
+perfectly on every version and fails only when the line runs.
+
+So this asks vermin, which reads both syntax and stdlib API availability, and compares the
+answer against the oldest leg the workflow's own matrix declares rather than a number
+written here. Raise the floor in the matrix and this follows; use a symbol from above it
+and this fails in seconds, on every pull request, instead of on main in 23 minutes.
+
+What it cannot do, stated so nobody mistakes it for the legs it partly replaces: it does
+not run anything. Two interpreters that both accept a line can still behave differently on
+it, and a ``sys.version_info`` branch is only ever parsed here, never taken. That is what
+the full matrix on main is for.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+WORKFLOW = REPO / ".github" / "workflows" / "studio-backend-ci.yml"
+
+# Where the backend's own source lives. Tests are excluded deliberately: they are allowed
+# to use whatever the interpreter running them provides, and they are not shipped.
+SOURCES = ("core", "utils", "routes", "loggers.py", "main.py")
+
+BACKEND = REPO / "studio" / "backend"
+
+# Third-party code vendored into the tree, pinned to its own support range.
+EXCLUDE_PARTS = ("vendor", "node_modules", "__pycache__")
+
+
+def matrix_floor() -> tuple[int, int]:
+    """The oldest interpreter the workflow's matrix names, read from the workflow.
+
+    Taken from the FULL list rather than the pull-request subset: the subset is the
+    ceiling only, and the floor this lint defends is the oldest version main still runs.
+    """
+    text = WORKFLOW.read_text(encoding = "utf-8")
+    lists = re.findall(r"fromJSON\('(\[[^']*\])'\)", text)
+    if not lists:
+        raise SystemExit(f"no fromJSON matrix found in {WORKFLOW.name}; this lint cannot aim")
+    versions = []
+    for item in lists:
+        versions.extend(json.loads(item))
+    parsed = sorted(tuple(int(part) for part in v.split(".")) for v in versions)
+    return parsed[0]
+
+
+def targets() -> list[str]:
+    found = []
+    for name in SOURCES:
+        path = BACKEND / name
+        if path.exists():
+            found.append(str(path))
+    if not found:
+        raise SystemExit(f"none of {SOURCES} exist under {BACKEND}; the scan would pass on nothing")
+    return found
+
+
+def main() -> int:
+    floor = matrix_floor()
+    target = f"{floor[0]}.{floor[1]}"
+    # The console script, not `python -m vermin`: the package has no __main__, so that
+    # form exits nonzero for the wrong reason and this lint would fail on every run while
+    # looking like it had found something.
+    vermin = shutil.which("vermin")
+    if vermin is None:
+        raise SystemExit(
+            "vermin is not installed, so the backend floor is unchecked. Install it in "
+            "the job that runs this, rather than letting the check quietly pass."
+        )
+    command = [
+        vermin,
+        "--no-tips",
+        "--no-parse-comments",
+        "--violations",
+        f"-t={target}",
+        *(f"--exclude-regex=.*/{part}/.*" for part in EXCLUDE_PARTS),
+        *targets(),
+    ]
+    print(f"[floor] backend source must run on Python {target} (oldest leg in the matrix)")
+    result = subprocess.run(command, capture_output = True, text = True)
+    sys.stdout.write(result.stdout)
+    sys.stderr.write(result.stderr)
+    if result.returncode == 0:
+        print(f"[floor] OK: nothing in the backend needs more than {target}")
+        return 0
+    print(
+        f"::error title=Backend needs a newer Python than the matrix floor::"
+        f"something under studio/backend requires more than Python {target}, which is the "
+        f"oldest leg studio-backend-ci runs. A pull request only runs the newest leg, so "
+        f"this would otherwise fail on the push to main. Either guard the usage behind a "
+        f"sys.version_info check, or raise the floor in the workflow matrix and say why."
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/lint_backend_python_floor.py
+++ b/scripts/lint_backend_python_floor.py
@@ -135,10 +135,7 @@ def main() -> int:
             "the job that runs this, rather than letting the check quietly pass."
         )
     files = targets()
-    print(
-        f"[floor] {len(files)} files must run on Python {target}, "
-        f"the declared floor"
-    )
+    print(f"[floor] {len(files)} files must run on Python {target}, " f"the declared floor")
     command = [
         vermin,
         "--no-tips",

--- a/scripts/lint_backend_python_floor.py
+++ b/scripts/lint_backend_python_floor.py
@@ -62,9 +62,8 @@ EXCLUDE_PARTS = ("tests", "vendor", "node_modules", "__pycache__", ".venv")
 # exemption cannot outlive the code it was written for.
 GUARDED = {
     "plugins/data-designer-github-repo-seed/src/data_designer_github_repo_seed"
-    "/scraper_impl/state_store.py":
-        "locale.getencoding() is 3.11 and sits in a try/except AttributeError whose "
-        "fallback is locale.getpreferredencoding(False), commented 'Python < 3.11'",
+    "/scraper_impl/state_store.py": "locale.getencoding() is 3.11 and sits in a try/except AttributeError whose "
+    "fallback is locale.getpreferredencoding(False), commented 'Python < 3.11'",
 }
 
 

--- a/scripts/lint_backend_python_floor.py
+++ b/scripts/lint_backend_python_floor.py
@@ -52,20 +52,16 @@ BACKEND = REPO / "studio" / "backend"
 #   vendor  -- third party, pinned to its own support range
 EXCLUDE_PARTS = ("tests", "vendor", "node_modules", "__pycache__", ".venv")
 
-# Files where an above-floor symbol is reached deliberately, behind a runtime guard vermin
-# cannot see: it reads names, not control flow, so a try/except AttributeError around an
-# attribute lookup looks identical to an unguarded one.
+# An above-floor symbol reached deliberately is suppressed AT THE SITE, with `# novermin`
+# and a comment saying why, not by dropping its file from the scan. Excluding the file
+# would leave everything else in it permanently unchecked, which is the same mistake as
+# the package allowlist this replaced, one level down.
 #
-# Kept as a named list with reasons rather than by narrowing the scan, because the whole
-# failure of the first version of this lint was a narrower input that looked like coverage.
-# Each entry is printed on every run, and a path that no longer exists fails, so an
-# exemption cannot outlive the code it was written for.
-GUARDED = {
-    "plugins/data-designer-github-repo-seed/src/data_designer_github_repo_seed"
-    "/scraper_impl/state_store.py":
-        "locale.getencoding() is 3.11 and sits in a try/except AttributeError whose "
-        "fallback is locale.getpreferredencoding(False), commented 'Python < 3.11'",
-}
+# The one live case is locale.getencoding() in the data-designer plugin's state_store,
+# inside a try/except AttributeError with a pre-3.11 fallback. vermin reads names rather
+# than control flow, so it cannot see that the guard is already there.
+#
+# Comment parsing is therefore ON, which is what makes the annotation work.
 
 
 def matrix_floor() -> tuple[int, int]:
@@ -87,18 +83,10 @@ def matrix_floor() -> tuple[int, int]:
 
 def targets() -> list[str]:
     """Every shipped .py under the backend, found rather than listed."""
-    missing = [name for name in GUARDED if not (BACKEND / name).is_file()]
-    if missing:
-        raise SystemExit(
-            f"GUARDED names files that no longer exist: {missing}. Either the guard moved "
-            f"and the exemption should move with it, or it is gone and the exemption "
-            f"should be too. An exemption for a file nobody can find is a hole."
-        )
     found = [
         str(path)
         for path in sorted(BACKEND.rglob("*.py"))
         if not any(part in EXCLUDE_PARTS for part in path.relative_to(BACKEND).parts)
-        and str(path.relative_to(BACKEND)) not in GUARDED
     ]
     if not found:
         raise SystemExit(f"no python files found under {BACKEND}; the scan would pass on nothing")
@@ -118,8 +106,6 @@ def main() -> int:
             "the job that runs this, rather than letting the check quietly pass."
         )
     files = targets()
-    for name, why in sorted(GUARDED.items()):
-        print(f"[floor] exempt: {name}\n           {why}")
     print(
         f"[floor] {len(files)} backend files must run on Python {target}, "
         f"the oldest leg in the matrix"
@@ -127,7 +113,6 @@ def main() -> int:
     command = [
         vermin,
         "--no-tips",
-        "--no-parse-comments",
         "--violations",
         f"-t={target}",
         *files,

--- a/scripts/lint_backend_python_floor.py
+++ b/scripts/lint_backend_python_floor.py
@@ -38,7 +38,15 @@ from pathlib import Path
 REPO = Path(__file__).resolve().parents[1]
 WORKFLOW = REPO / ".github" / "workflows" / "studio-backend-ci.yml"
 
-BACKEND = REPO / "studio" / "backend"
+# Both trees the matrix legs actually execute. studio-backend-ci lists 'unsloth_cli/**'
+# in its own paths filter and runs `pytest unsloth_cli/tests` as a step on every leg, so
+# a post-floor stdlib name on a shipped CLI path was covered by the old 3.10 leg exactly
+# as a backend one was. Scanning only the backend would have moved that coverage to the
+# push to main while looking like it had replaced it.
+ROOTS = (
+    REPO / "studio" / "backend",
+    REPO / "unsloth_cli",
+)
 
 # Everything shipped under studio/backend is scanned. The first version of this listed the
 # packages instead, and that is exactly the wrong shape for a floor check: it named core,
@@ -82,14 +90,18 @@ def matrix_floor() -> tuple[int, int]:
 
 
 def targets() -> list[str]:
-    """Every shipped .py under the backend, found rather than listed."""
-    found = [
-        str(path)
-        for path in sorted(BACKEND.rglob("*.py"))
-        if not any(part in EXCLUDE_PARTS for part in path.relative_to(BACKEND).parts)
-    ]
+    """Every shipped .py under the trees the matrix runs, found rather than listed."""
+    found = []
+    for root in ROOTS:
+        if not root.is_dir():
+            raise SystemExit(f"{root} is gone; the scan would silently stop covering it")
+        found.extend(
+            str(path)
+            for path in sorted(root.rglob("*.py"))
+            if not any(part in EXCLUDE_PARTS for part in path.relative_to(root).parts)
+        )
     if not found:
-        raise SystemExit(f"no python files found under {BACKEND}; the scan would pass on nothing")
+        raise SystemExit(f"no python files found under {ROOTS}; the scan would pass on nothing")
     return found
 
 
@@ -107,7 +119,7 @@ def main() -> int:
         )
     files = targets()
     print(
-        f"[floor] {len(files)} backend files must run on Python {target}, "
+        f"[floor] {len(files)} shipped files must run on Python {target}, "
         f"the oldest leg in the matrix"
     )
     command = [
@@ -121,11 +133,12 @@ def main() -> int:
     sys.stdout.write(result.stdout)
     sys.stderr.write(result.stderr)
     if result.returncode == 0:
-        print(f"[floor] OK: nothing in the backend needs more than {target}")
+        print(f"[floor] OK: nothing shipped needs more than {target}")
         return 0
     print(
         f"::error title=Backend needs a newer Python than the matrix floor::"
-        f"something under studio/backend requires more than Python {target}, which is the "
+        f"something under studio/backend or unsloth_cli requires more than Python {target}, "
+        f"which is the "
         f"oldest leg studio-backend-ci runs. A pull request only runs the newest leg, so "
         f"this would otherwise fail on the push to main. Either guard the usage behind a "
         f"sys.version_info check, or raise the floor in the workflow matrix and say why."

--- a/scripts/lint_backend_python_floor.py
+++ b/scripts/lint_backend_python_floor.py
@@ -38,14 +38,34 @@ from pathlib import Path
 REPO = Path(__file__).resolve().parents[1]
 WORKFLOW = REPO / ".github" / "workflows" / "studio-backend-ci.yml"
 
-# Where the backend's own source lives. Tests are excluded deliberately: they are allowed
-# to use whatever the interpreter running them provides, and they are not shipped.
-SOURCES = ("core", "utils", "routes", "loggers.py", "main.py")
-
 BACKEND = REPO / "studio" / "backend"
 
-# Third-party code vendored into the tree, pinned to its own support range.
-EXCLUDE_PARTS = ("vendor", "node_modules", "__pycache__")
+# Everything shipped under studio/backend is scanned. The first version of this listed the
+# packages instead, and that is exactly the wrong shape for a floor check: it named core,
+# utils and routes and silently missed 116 files, including all of hub, plugins, models,
+# storage, auth, picker and state, plus _platform_compat.py which main.py imports directly.
+# It also named "loggers.py", which is a directory, so that entry matched nothing at all.
+# A check that covers most of the tree reads exactly like one that covers all of it.
+#
+# So the tree is the input and only these come out:
+#   tests   -- run by whatever interpreter runs them, and not shipped
+#   vendor  -- third party, pinned to its own support range
+EXCLUDE_PARTS = ("tests", "vendor", "node_modules", "__pycache__", ".venv")
+
+# Files where an above-floor symbol is reached deliberately, behind a runtime guard vermin
+# cannot see: it reads names, not control flow, so a try/except AttributeError around an
+# attribute lookup looks identical to an unguarded one.
+#
+# Kept as a named list with reasons rather than by narrowing the scan, because the whole
+# failure of the first version of this lint was a narrower input that looked like coverage.
+# Each entry is printed on every run, and a path that no longer exists fails, so an
+# exemption cannot outlive the code it was written for.
+GUARDED = {
+    "plugins/data-designer-github-repo-seed/src/data_designer_github_repo_seed"
+    "/scraper_impl/state_store.py":
+        "locale.getencoding() is 3.11 and sits in a try/except AttributeError whose "
+        "fallback is locale.getpreferredencoding(False), commented 'Python < 3.11'",
+}
 
 
 def matrix_floor() -> tuple[int, int]:
@@ -66,13 +86,22 @@ def matrix_floor() -> tuple[int, int]:
 
 
 def targets() -> list[str]:
-    found = []
-    for name in SOURCES:
-        path = BACKEND / name
-        if path.exists():
-            found.append(str(path))
+    """Every shipped .py under the backend, found rather than listed."""
+    missing = [name for name in GUARDED if not (BACKEND / name).is_file()]
+    if missing:
+        raise SystemExit(
+            f"GUARDED names files that no longer exist: {missing}. Either the guard moved "
+            f"and the exemption should move with it, or it is gone and the exemption "
+            f"should be too. An exemption for a file nobody can find is a hole."
+        )
+    found = [
+        str(path)
+        for path in sorted(BACKEND.rglob("*.py"))
+        if not any(part in EXCLUDE_PARTS for part in path.relative_to(BACKEND).parts)
+        and str(path.relative_to(BACKEND)) not in GUARDED
+    ]
     if not found:
-        raise SystemExit(f"none of {SOURCES} exist under {BACKEND}; the scan would pass on nothing")
+        raise SystemExit(f"no python files found under {BACKEND}; the scan would pass on nothing")
     return found
 
 
@@ -88,16 +117,21 @@ def main() -> int:
             "vermin is not installed, so the backend floor is unchecked. Install it in "
             "the job that runs this, rather than letting the check quietly pass."
         )
+    files = targets()
+    for name, why in sorted(GUARDED.items()):
+        print(f"[floor] exempt: {name}\n           {why}")
+    print(
+        f"[floor] {len(files)} backend files must run on Python {target}, "
+        f"the oldest leg in the matrix"
+    )
     command = [
         vermin,
         "--no-tips",
         "--no-parse-comments",
         "--violations",
         f"-t={target}",
-        *(f"--exclude-regex=.*/{part}/.*" for part in EXCLUDE_PARTS),
-        *targets(),
+        *files,
     ]
-    print(f"[floor] backend source must run on Python {target} (oldest leg in the matrix)")
     result = subprocess.run(command, capture_output = True, text = True)
     sys.stdout.write(result.stdout)
     sys.stderr.write(result.stderr)

--- a/studio/backend/plugins/data-designer-github-repo-seed/src/data_designer_github_repo_seed/scraper_impl/state_store.py
+++ b/studio/backend/plugins/data-designer-github-repo-seed/src/data_designer_github_repo_seed/scraper_impl/state_store.py
@@ -19,7 +19,9 @@ def _locale_encoding() -> str:
     Empty on a UTF-8 host, where there is no codepage to attribute the file to.
     """
     try:
-        preferred = locale.getencoding()
+        # novermin -- 3.11, and the except below IS the guard. vermin reads names
+        # rather than control flow, so it cannot see that this is already handled.
+        preferred = locale.getencoding()  # novermin
     except AttributeError:  # Python < 3.11
         preferred = locale.getpreferredencoding(False)
     if preferred.lower().replace("-", "").replace("_", "") == "utf8":

--- a/tests/studio/test_backend_ci_matrix.py
+++ b/tests/studio/test_backend_ci_matrix.py
@@ -286,3 +286,34 @@ def test_the_floor_lint_covers_every_tree_the_matrix_legs_run():
             f"not scan it, so a post-floor stdlib name there passes the pull request and "
             f"fails on the push to main."
         )
+
+
+def test_the_floor_lint_covers_test_code_the_matrix_executes():
+    """Not shipped is not the same as not executed.
+
+    studio-backend-ci runs `pytest tests/` from studio/backend on every leg, so a 3.11
+    API in a test file is executed by the oldest leg exactly as one in a shipped module
+    is. With the pull request down to a single newest leg, dropping tests from the scan
+    would let both that leg and this lint pass while the failure waits for the push to
+    main, which is the gap the lint exists to close.
+    """
+    import importlib.util
+
+    lint = REPO / "scripts" / "lint_backend_python_floor.py"
+    spec = importlib.util.spec_from_file_location("lint_backend_python_floor", lint)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    scanned = {Path(name).relative_to(REPO).as_posix() for name in module.targets()}
+    for tree in ("studio/backend/tests", "unsloth_cli/tests"):
+        on_disk = {
+            path.relative_to(REPO).as_posix()
+            for path in (REPO / tree).rglob("*.py")
+            if not any(part in module.EXCLUDE_PARTS for part in path.parts)
+        }
+        assert on_disk, f"{tree} has no python files; this assertion would pass on nothing"
+        missed = sorted(on_disk - scanned)
+        assert not missed, (
+            f"the floor lint does not scan {missed}. The matrix runs those files on every "
+            f"leg, including the oldest, so an above-floor API in them fails on main."
+        )

--- a/tests/studio/test_backend_ci_matrix.py
+++ b/tests/studio/test_backend_ci_matrix.py
@@ -43,22 +43,93 @@ def _version(text: str) -> tuple[int, ...]:
     return tuple(int(part) for part in text.split("."))
 
 
-def test_the_pull_request_matrix_keeps_both_ends():
-    """The floor exercises the older branches, the ceiling catches removals."""
+def test_the_pull_request_matrix_is_the_newest_leg():
+    """One leg on a pull request, and it has to be the CEILING.
+
+    The ceiling is where a removal lands: a stdlib function that went away, a
+    deprecation that became an error. Those break on the newest interpreter first and on
+    the oldest never, so running only the oldest would be the wrong single choice.
+
+    The floor is given up here deliberately, and paid for in two other places, both
+    asserted below: scripts/lint_backend_python_floor.py refuses source that needs more
+    than the oldest leg, on every pull request; and main still runs all four, so anything
+    only a run can find is caught at merge rather than never.
+    """
     subset, full = _matrices()
+    assert len(subset) == 1, (
+        f"the pull-request matrix is {subset}. If a second leg is being added back, the "
+        f"reason to do it is the one this file used to encode: a static check does not "
+        f"execute a version-conditional branch. Say so here rather than leaving it bare."
+    )
     assert set(subset) <= set(full), f"{subset} is not a subset of {full}"
-    assert min(subset, key = _version) == min(full, key = _version)
-    assert max(subset, key = _version) == max(full, key = _version)
+    assert max(full, key = _version) == subset[0], (
+        f"the pull-request leg is {subset[0]} but the newest is {max(full, key = _version)}. "
+        f"A single leg has to be the newest: removals and deprecations land there first."
+    )
+
+
+def _floor_lint() -> Path:
+    return REPO / "scripts" / "lint_backend_python_floor.py"
+
+
+def test_the_floor_is_linted_on_every_pull_request():
+    """What replaces the leg that was dropped, asserted through where it runs.
+
+    Backend CI does not filter on .github/workflows/**, and more to the point a pull
+    request that only touches backend source needs this to have run BEFORE the merge,
+    which is the whole point of dropping the leg. workflow-trigger-lint.yml carries no
+    paths filter at all, so it sees every pull request.
+    """
+    lint = _floor_lint()
+    assert lint.is_file(), (
+        f"{lint.name} is gone. It is the only thing checking the backend against the "
+        f"oldest interpreter before a merge, now that a pull request runs only the newest."
+    )
+    trigger_lint = REPO / ".github" / "workflows" / "workflow-trigger-lint.yml"
+    text = trigger_lint.read_text(encoding = "utf-8")
+    assert lint.name in text, (
+        f"{trigger_lint.name} no longer runs {lint.name}, so nothing checks the floor "
+        f"before a merge"
+    )
+    installs = [
+        line for line in text.splitlines()
+        if "pip install" in line and "vermin" in line
+    ]
+    assert installs, (
+        f"{trigger_lint.name} does not pip install vermin, so {lint.name} exits with its "
+        f"'not installed' message rather than checking anything. Asserted against the "
+        f"install line rather than the file, because the first version of this check "
+        f"looked for 'vermin' anywhere and was satisfied by a comment mentioning it."
+    )
+
+
+def test_the_floor_lint_reads_stdlib_availability_not_just_syntax():
+    """Asserted through what it DOES, because the distinction is the reason it exists.
+
+    ast.parse at a feature_version answers a syntax question. The regression that a
+    dropped interpreter leg actually stops catching is a stdlib name that does not exist
+    yet: core/research_runs.py already uses `anext`, which is 3.10, and that parses on
+    every version and fails only when the line runs.
+    """
+    text = _floor_lint().read_text(encoding = "utf-8")
+    assert "vermin" in text, (
+        "the floor lint no longer uses vermin. Whatever replaces it has to read stdlib "
+        "API availability and not only syntax, or it stops covering the case it exists for"
+    )
+    assert "fromJSON" in text, (
+        "the floor lint no longer reads its target from the workflow matrix, so raising "
+        "the matrix floor would silently leave it checking the old one"
+    )
 
 
 def _boundaries() -> dict[str, tuple[int, ...]]:
     """Every ``sys.version_info`` comparison in the backend, source and tests alike.
 
-    Source matters more than tests here, and missing that is what made a single-leg
-    matrix look defensible: ``sitecustomize.py`` repoints pathlib's pre-3.11
-    ``_NormalAccessor``, ``native_path_leases.py`` and ``third_party_source.py`` branch
-    on >= 3.12. A static parse cannot exercise any of them, because it parses rather
-    than runs.
+    Source is what made a single-leg matrix look indefensible on its own:
+    ``sitecustomize.py`` repoints pathlib's pre-3.11 ``_NormalAccessor``, and
+    ``native_path_leases.py`` and ``third_party_source.py`` branch on >= 3.12. A static
+    parse cannot exercise any of them; it parses, it does not run. Which is why the full
+    matrix stayed on main.
     """
     found: dict[str, tuple[int, ...]] = {}
     for path in sorted(BACKEND.rglob("*.py")):
@@ -75,13 +146,13 @@ def _straddles(legs: list[str], boundary: tuple[int, ...]) -> bool:
     return any(v < boundary for v in versions) and any(v >= boundary for v in versions)
 
 
-def test_the_subset_sees_every_boundary_the_full_matrix_sees():
-    """The subset must lose no version boundary the full matrix draws.
+def test_the_boundaries_the_subset_stops_executing_are_still_run_on_main():
+    """The trade, made explicit rather than dropped along with the legs.
 
-    Compared against the full matrix rather than in absolute terms: several boundaries
-    (>= 3.10, < 3.14) sit outside the matrix range entirely, so no list here can see
-    them, and holding the subset to a standard the full matrix does not meet would fail
-    forever. What matters is the delta, which is what the trade is about.
+    These are the version-conditional branches a pull request no longer takes either side
+    of. Nothing static covers them -- a parse reads both sides and runs neither -- so the
+    only thing that does is the full matrix on main. This lists them so the cost is
+    visible, and fails if main stops covering them.
     """
     subset, full = _matrices()
     boundaries = _boundaries()
@@ -91,11 +162,17 @@ def test_the_subset_sees_every_boundary_the_full_matrix_sees():
         for where, boundary in boundaries.items()
         if _straddles(full, boundary) and not _straddles(subset, boundary)
     }
-    assert not lost, (
-        f"the pull-request matrix {subset} lands entirely on one side of {lost} while the "
-        f"full matrix {full} does not, so those branches stop being executed on both "
-        f"sides before a merge. A static parse does not cover them: it parses, it does "
-        f"not run."
+    assert lost, (
+        "no boundary is lost by the single-leg subset, which would mean the scan found "
+        "nothing; it is the reason this file explains the trade at all"
+    )
+    document = yaml.safe_load(WORKFLOW.read_text(encoding = "utf-8"))
+    triggers = document.get(True) or document.get("on") or {}
+    push = triggers.get("push") or {}
+    assert "main" in (push.get("branches") or []), (
+        f"Backend CI no longer runs on push to main, so {sorted(lost)} are executed on "
+        f"neither side of their boundary anywhere, and dropping the interior legs stops "
+        f"being a trade and becomes a straight loss"
     )
 
 

--- a/tests/studio/test_backend_ci_matrix.py
+++ b/tests/studio/test_backend_ci_matrix.py
@@ -91,10 +91,7 @@ def test_the_floor_is_linted_on_every_pull_request():
         f"{trigger_lint.name} no longer runs {lint.name}, so nothing checks the floor "
         f"before a merge"
     )
-    installs = [
-        line for line in text.splitlines()
-        if "pip install" in line and "vermin" in line
-    ]
+    installs = [line for line in text.splitlines() if "pip install" in line and "vermin" in line]
     assert installs, (
         f"{trigger_lint.name} does not pip install vermin, so {lint.name} exits with its "
         f"'not installed' message rather than checking anything. Asserted against the "

--- a/tests/studio/test_backend_ci_matrix.py
+++ b/tests/studio/test_backend_ci_matrix.py
@@ -38,12 +38,23 @@ FLOOR_CHECK = REPO / "tests" / "test_python39_compatibility.py"
 BACKEND = REPO / "studio" / "backend"
 
 
-def _legs() -> list[str]:
-    """The interpreters the matrix actually runs."""
+# The interpreter the full suite runs on. Written down rather than derived, so moving to
+# 3.14 is a decision somebody makes and defends here, not something that follows silently
+# from an edit elsewhere. Asserting only "newer than the floor" was not enough: 3.11 and
+# 3.12 satisfy that too, and either would quietly give up the removals-and-deprecations
+# coverage that is the whole reason the single leg is the newest one.
+CEILING = "3.13"
+
+
+def _legs() -> dict[str, str]:
+    """Each leg the matrix runs, as scope -> interpreter."""
     document = yaml.safe_load(WORKFLOW.read_text(encoding = "utf-8"))
-    legs = document["jobs"]["pytest"]["strategy"]["matrix"]["python"]
-    assert isinstance(legs, list) and legs, f"unreadable matrix: {legs!r}"
-    return [str(leg) for leg in legs]
+    matrix = document["jobs"]["pytest"]["strategy"]["matrix"]
+    entries = matrix.get("include")
+    assert entries, f"the matrix no longer lists its legs by scope: {matrix!r}"
+    legs = {str(entry["scope"]): str(entry["python"]) for entry in entries}
+    assert len(legs) == len(entries), f"two legs share a scope: {entries!r}"
+    return legs
 
 
 def _declared_floor() -> tuple[int, ...]:
@@ -62,29 +73,49 @@ def _version(text: str) -> tuple[int, ...]:
     return tuple(int(part) for part in text.split("."))
 
 
-def test_the_one_leg_is_the_newest():
-    """One leg, and it has to be the CEILING.
+def test_the_full_suite_runs_on_the_ceiling():
+    """One full leg, and it has to be the CEILING, by name.
 
     The ceiling is where a removal lands: a stdlib function that went away, a deprecation
     that became an error. Those break on the newest interpreter first and on the oldest
-    never, so running only the oldest would be the wrong single choice.
-
-    The floor is given up as an EXECUTED version deliberately, and paid for by
-    scripts/lint_backend_python_floor.py refusing any file that needs a symbol newer than
-    the declared floor, on every pull request, across everything shipped or executed.
+    never, so running only the oldest would be the wrong single choice, and running 3.11
+    or 3.12 would be wrong in the same direction while still sitting above the floor.
+    That is why this compares against a written-down CEILING rather than against the
+    floor: "newer than 3.10" is satisfied by versions that give up exactly what the
+    single leg exists to keep.
     """
     legs = _legs()
-    assert len(legs) == 1, (
-        f"the matrix runs {legs}. Adding a leg back is allowed, but the reason has to be "
-        f"written down here: the four legs it replaced collected the same 26,320 tests "
-        f"and differed by one skip marker, so 'more coverage' is not the reason on its own."
+    assert legs.get("full") == CEILING, (
+        f"the full suite runs on {legs.get('full')!r}, not {CEILING!r}. Moving it is a "
+        f"decision worth making deliberately: update CEILING here in the same change, "
+        f"and say why the new one is the version where removals land first."
     )
-    floor = _declared_floor()
-    assert _version(legs[0]) > floor, (
-        f"the only leg is {legs[0]} and the declared floor is "
-        f"{'.'.join(str(part) for part in floor)}. A single leg has to be the newest: "
-        f"removals and deprecations land there first, and the floor is the end that a "
-        f"static check can actually defend."
+
+
+def test_the_pre_312_branches_are_still_executed_somewhere():
+    """What the dropped legs actually took away, and where it went.
+
+    Seven backend files carry a sys.version_info branch. The 3.10 ones were never
+    straddled even by the old matrix, whose oldest leg was 3.10, so every leg took the
+    same side of them. 3.14 is above every leg there has ever been. The pre-3.12 side is
+    the only thing a 3.13-only matrix stops executing, so it keeps a leg of its own,
+    running those files and nothing else.
+    """
+    legs = _legs()
+    spot = legs.get("floor-spot-check")
+    assert spot, (
+        "the floor spot-check leg is gone. With it, nothing anywhere takes the pre-3.12 "
+        "side of native_path_leases.py, third_party_source.py or the folder-permission "
+        "check, on a pull request or on main."
+    )
+    assert _version(spot) < (3, 12), (
+        f"the spot-check leg runs {spot}, which takes the >= 3.12 side, so it re-tests "
+        f"what the full leg already covers and the older side is executed nowhere."
+    )
+    assert _version(spot) >= _declared_floor(), (
+        f"the spot-check leg runs {spot}, below the declared floor. It should be the "
+        f"NEWEST version that still takes the old side, so a failure is about the "
+        f"boundary rather than about being old."
     )
 
 

--- a/tests/studio/test_backend_ci_matrix.py
+++ b/tests/studio/test_backend_ci_matrix.py
@@ -351,9 +351,9 @@ def test_the_floor_lint_covers_every_tree_the_matrix_legs_run():
     # What it would hand to vermin, not what its source says it aims at.
     scanned = [str(Path(name).relative_to(REPO).as_posix()) for name in module.targets()]
     for tree in ("studio/backend", "unsloth_cli"):
-        assert tree in workflow, (
-            f"{tree} is no longer run by {WORKFLOW.name}; drop it from the lint's ROOTS too"
-        )
+        assert (
+            tree in workflow
+        ), f"{tree} is no longer run by {WORKFLOW.name}; drop it from the lint's ROOTS too"
         assert any(name.startswith(tree + "/") for name in scanned), (
             f"{WORKFLOW.name} still executes {tree} on the matrix, but the floor lint does "
             f"not scan it, so a post-floor stdlib name there passes the pull request and "

--- a/tests/studio/test_backend_ci_matrix.py
+++ b/tests/studio/test_backend_ci_matrix.py
@@ -1,21 +1,29 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-"""Backend CI runs both ends of its matrix on a pull request, and all four on main.
+"""Backend CI runs one interpreter, and the floor is defended statically instead.
 
-Measured on one runner over the same tree, the four interpreter legs collect the same
-26,320 tests and differ by exactly one: ``test_demonstrates_the_underlying_stdlib_regression``
-is gated on ``sys.version_info >= (3, 12)``, so 3.10 and 3.11 report 26193 passed / 127
-skipped while 3.12 and 3.13 report 26194 / 126.
+Measured on one runner over the same tree, the four interpreter legs collected the same
+26,320 tests and differed by exactly one: ``test_demonstrates_the_underlying_stdlib_regression``
+is gated on ``sys.version_info >= (3, 12)``, so 3.10 and 3.11 reported 26193 passed / 127
+skipped while 3.12 and 3.13 reported 26194 / 126. Four legs cost 97 runner-minutes per
+push to re-run one identical suite and learn the value of a single skip marker, against a
+queue observed 195 deep, and queue depth is wall-clock for every other workflow.
 
-Dropping the two interior legs rests on three things, all asserted here:
+So there is one leg, the ceiling, and what the older ones were really defending is
+asserted here instead:
 
-* both ENDS are kept. A single leg was tried and is wrong: the backend has
-  version-conditional branches that only a run can exercise, so the floor has to execute;
-* the syntax floor is still checked statically by ``tests/test_python39_compatibility.py``,
-  at the version ``pyproject.toml`` declares, which is lower than any leg here;
-* main still runs all four, so a difference peculiar to 3.11 or 3.12 is caught on merge
-  rather than never.
+* ``scripts/lint_backend_python_floor.py`` refuses any file that needs a symbol newer
+  than the declared floor, across everything shipped or executed, on every pull request;
+* the floor is DECLARED in the workflow rather than derived from the matrix, because a
+  one-leg matrix would otherwise move it to the ceiling and check nothing;
+* ``tests/test_python39_compatibility.py`` still parses at the version ``pyproject.toml``
+  declares, which is below the declared floor.
+
+The cost is stated rather than hidden: a static check does not run anything, so the
+version-conditional branches enumerated below are now covered by reading and by the
+names they use, not by execution. That is the trade, and it is the reason the floor lint
+has to keep covering the files those branches live in.
 """
 
 import ast
@@ -30,41 +38,53 @@ FLOOR_CHECK = REPO / "tests" / "test_python39_compatibility.py"
 BACKEND = REPO / "studio" / "backend"
 
 
-def _matrices() -> tuple[list[str], list[str]]:
-    """The pull-request list and the full list, read out of the matrix expression."""
+def _legs() -> list[str]:
+    """The interpreters the matrix actually runs."""
     document = yaml.safe_load(WORKFLOW.read_text(encoding = "utf-8"))
-    expression = str(document["jobs"]["pytest"]["strategy"]["matrix"]["python"])
-    lists = re.findall(r"fromJSON\('(\[[^']*\])'\)", expression)
-    assert len(lists) == 2, f"expected a pull-request list and a full list, found {lists}"
-    return tuple(ast.literal_eval(item) for item in lists)  # type: ignore[return-value]
+    legs = document["jobs"]["pytest"]["strategy"]["matrix"]["python"]
+    assert isinstance(legs, list) and legs, f"unreadable matrix: {legs!r}"
+    return [str(leg) for leg in legs]
+
+
+def _declared_floor() -> tuple[int, ...]:
+    """The floor the workflow declares, which is what the lint aims at."""
+    document = yaml.safe_load(WORKFLOW.read_text(encoding = "utf-8"))
+    floor = (document.get("env") or {}).get("PYTHON_FLOOR")
+    assert floor, (
+        "the workflow declares no PYTHON_FLOOR. With one leg in the matrix there is "
+        "nothing else for the floor lint to aim at, so it would check the ceiling "
+        "against itself and pass on anything."
+    )
+    return _version(str(floor))
 
 
 def _version(text: str) -> tuple[int, ...]:
     return tuple(int(part) for part in text.split("."))
 
 
-def test_the_pull_request_matrix_is_the_newest_leg():
-    """One leg on a pull request, and it has to be the CEILING.
+def test_the_one_leg_is_the_newest():
+    """One leg, and it has to be the CEILING.
 
-    The ceiling is where a removal lands: a stdlib function that went away, a
-    deprecation that became an error. Those break on the newest interpreter first and on
-    the oldest never, so running only the oldest would be the wrong single choice.
+    The ceiling is where a removal lands: a stdlib function that went away, a deprecation
+    that became an error. Those break on the newest interpreter first and on the oldest
+    never, so running only the oldest would be the wrong single choice.
 
-    The floor is given up here deliberately, and paid for in two other places, both
-    asserted below: scripts/lint_backend_python_floor.py refuses source that needs more
-    than the oldest leg, on every pull request; and main still runs all four, so anything
-    only a run can find is caught at merge rather than never.
+    The floor is given up as an EXECUTED version deliberately, and paid for by
+    scripts/lint_backend_python_floor.py refusing any file that needs a symbol newer than
+    the declared floor, on every pull request, across everything shipped or executed.
     """
-    subset, full = _matrices()
-    assert len(subset) == 1, (
-        f"the pull-request matrix is {subset}. If a second leg is being added back, the "
-        f"reason to do it is the one this file used to encode: a static check does not "
-        f"execute a version-conditional branch. Say so here rather than leaving it bare."
+    legs = _legs()
+    assert len(legs) == 1, (
+        f"the matrix runs {legs}. Adding a leg back is allowed, but the reason has to be "
+        f"written down here: the four legs it replaced collected the same 26,320 tests "
+        f"and differed by one skip marker, so 'more coverage' is not the reason on its own."
     )
-    assert set(subset) <= set(full), f"{subset} is not a subset of {full}"
-    assert max(full, key = _version) == subset[0], (
-        f"the pull-request leg is {subset[0]} but the newest is {max(full, key = _version)}. "
-        f"A single leg has to be the newest: removals and deprecations land there first."
+    floor = _declared_floor()
+    assert _version(legs[0]) > floor, (
+        f"the only leg is {legs[0]} and the declared floor is "
+        f"{'.'.join(str(part) for part in floor)}. A single leg has to be the newest: "
+        f"removals and deprecations land there first, and the floor is the end that a "
+        f"static check can actually defend."
     )
 
 
@@ -113,13 +133,15 @@ def test_the_floor_lint_reads_stdlib_availability_not_just_syntax():
         "the floor lint no longer uses vermin. Whatever replaces it has to read stdlib "
         "API availability and not only syntax, or it stops covering the case it exists for"
     )
-    assert "fromJSON" in text, (
-        "the floor lint no longer reads its target from the workflow matrix, so raising "
-        "the matrix floor would silently leave it checking the old one"
+    assert "PYTHON_FLOOR" in text, (
+        "the floor lint no longer reads PYTHON_FLOOR from the workflow, so the number it "
+        "checks against and the number the project declares can drift apart silently. It "
+        "must not go back to reading the matrix either: with one leg, that would aim the "
+        "check at the ceiling and pass on anything."
     )
 
 
-def _boundaries() -> dict[str, tuple[int, ...]]:
+def _boundaries() -> dict[str, Path]:
     """Every ``sys.version_info`` comparison in the backend, source and tests alike.
 
     Source is what made a single-leg matrix look indefensible on its own:
@@ -128,13 +150,13 @@ def _boundaries() -> dict[str, tuple[int, ...]]:
     parse cannot exercise any of them; it parses, it does not run. Which is why the full
     matrix stayed on main.
     """
-    found: dict[str, tuple[int, ...]] = {}
+    found: dict[str, Path] = {}
     for path in sorted(BACKEND.rglob("*.py")):
         if "vendor" in path.parts:  # third-party, pinned to its own support range
             continue
         text = path.read_text(encoding = "utf-8", errors = "replace")
         for match in re.finditer(r"version_info\s*[<>]=?\s*\((\d+),\s*(\d+)\)", text):
-            found[f"{path.name}:{match.start()}"] = (int(match.group(1)), int(match.group(2)))
+            found[f"{path.name}:{match.start()}"] = path
     return found
 
 
@@ -143,33 +165,35 @@ def _straddles(legs: list[str], boundary: tuple[int, ...]) -> bool:
     return any(v < boundary for v in versions) and any(v >= boundary for v in versions)
 
 
-def test_the_boundaries_the_subset_stops_executing_are_still_run_on_main():
-    """The trade, made explicit rather than dropped along with the legs.
+def test_every_version_boundary_lives_in_a_file_the_floor_lint_covers():
+    """The cost of one leg, made explicit rather than dropped along with the legs.
 
-    These are the version-conditional branches a pull request no longer takes either side
-    of. Nothing static covers them -- a parse reads both sides and runs neither -- so the
-    only thing that does is the full matrix on main. This lists them so the cost is
-    visible, and fails if main stops covering them.
+    These are the version-conditional branches nothing takes either side of any more. A
+    parse reads both sides and runs neither, and there is no longer a second leg to
+    execute the older one, so this is a real reduction in what CI proves. It is the trade
+    the single leg buys, and pretending otherwise in a comment would be worse than making
+    it.
+
+    What is still enforceable is that every file carrying such a branch is covered by the
+    floor lint, so the NAMES used on the older side are checked even though the branch is
+    not taken. A boundary living in a file the lint skips would be unchecked twice over,
+    and that is what this fails on.
     """
-    subset, full = _matrices()
+    import importlib.util
+
+    lint = REPO / "scripts" / "lint_backend_python_floor.py"
+    spec = importlib.util.spec_from_file_location("lint_backend_python_floor", lint)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    scanned = {Path(name) for name in module.targets()}
+
     boundaries = _boundaries()
     assert boundaries, "no version comparisons found in the backend; the scan is wrong"
-    lost = {
-        where: boundary
-        for where, boundary in boundaries.items()
-        if _straddles(full, boundary) and not _straddles(subset, boundary)
-    }
-    assert lost, (
-        "no boundary is lost by the single-leg subset, which would mean the scan found "
-        "nothing; it is the reason this file explains the trade at all"
-    )
-    document = yaml.safe_load(WORKFLOW.read_text(encoding = "utf-8"))
-    triggers = document.get(True) or document.get("on") or {}
-    push = triggers.get("push") or {}
-    assert "main" in (push.get("branches") or []), (
-        f"Backend CI no longer runs on push to main, so {sorted(lost)} are executed on "
-        f"neither side of their boundary anywhere, and dropping the interior legs stops "
-        f"being a trade and becomes a straight loss"
+    uncovered = sorted({str(path) for path in boundaries.values() if path not in scanned})
+    assert not uncovered, (
+        f"these files branch on sys.version_info and are not scanned by the floor lint: "
+        f"{uncovered}. Nothing executes the older side of those branches any more, so the "
+        f"lint's view of the names they use is the only check left on them."
     )
 
 
@@ -192,27 +216,45 @@ def test_the_declared_floor_is_still_checked_statically():
     )
 
 
-def test_the_static_floor_is_below_the_matrix_floor():
-    """Otherwise the static check is not covering the versions the matrix stopped running."""
+def test_the_parsed_floor_is_at_or_below_the_declared_floor():
+    """The syntax check has to reach at least as low as the floor the lint aims at.
+
+    They are two different checks of two different things: test_python39_compatibility.py
+    parses at the version pyproject.toml declares, and the floor lint reads stdlib API
+    availability at PYTHON_FLOOR. If the parsed version were the HIGHER of the two, the
+    span between them would be checked by neither.
+
+    It also records a mismatch worth fixing separately rather than papering over:
+    pyproject declares >= 3.9 and the tree does not honour it. unsloth/models/_utils.py
+    uses dataclasses.dataclass(kw_only) and
+    tempfile.TemporaryDirectory(ignore_cleanup_errors), both 3.10. The declaration or the
+    code has to give; this test only insists the two numbers stay in the order that
+    leaves no gap.
+    """
     text = (REPO / "pyproject.toml").read_text(encoding = "utf-8")
     declared = re.search(r"^requires-python\s*=\s*[\"'][^\"']*>=\s*(\d+)\.(\d+)", text, re.M)
     assert declared, "no >= lower bound in requires-python"
-    floor = (int(declared.group(1)), int(declared.group(2)))
-    _subset, full = _matrices()
-    assert floor <= min(_version(leg) for leg in full), (
-        f"the declared floor {floor} is above the oldest matrix leg, so the static check "
-        f"is not covering what the matrix stopped running"
+    parsed = (int(declared.group(1)), int(declared.group(2)))
+    assert parsed <= _declared_floor(), (
+        f"pyproject.toml declares {parsed} but the workflow declares a floor of "
+        f"{_declared_floor()}. The parse has to reach at least as low as the lint, or the "
+        f"versions between them are checked by nothing at all."
     )
 
 
-def test_the_full_matrix_still_runs_on_main():
-    """Dropping the interior legs is only defensible because main runs everything."""
+def test_backend_ci_still_runs_on_push_to_main():
+    """One leg on a pull request is only defensible if that leg also runs on the merge.
+
+    A pull request tests its own merge commit, not the merged result, so main is where a
+    semantic conflict between two green pull requests shows up. That was true with four
+    legs and it is more load-bearing with one.
+    """
     document = yaml.safe_load(WORKFLOW.read_text(encoding = "utf-8"))
     triggers = document.get(True) or document.get("on") or {}
     push = triggers.get("push") or {}
     assert "main" in (push.get("branches") or []), (
-        "Backend CI no longer runs on push to main, so the interpreter versions dropped "
-        "from the pull-request matrix would not be tested anywhere"
+        "Backend CI no longer runs on push to main, so nothing tests the merged result "
+        "of two pull requests that were each green on their own merge commit"
     )
 
 

--- a/tests/studio/test_backend_ci_matrix.py
+++ b/tests/studio/test_backend_ci_matrix.py
@@ -257,3 +257,32 @@ def test_the_floor_lint_scans_the_tree_rather_than_a_list_of_packages():
     assert (
         len(scanned) > 300
     ), f"the floor lint only found {len(scanned)} files; the scan is not reaching the tree"
+
+
+def test_the_floor_lint_covers_every_tree_the_matrix_legs_run():
+    """The lint has to cover what the deleted legs covered, not just the backend.
+
+    studio-backend-ci runs `pytest unsloth_cli/tests` as a step on every leg and lists
+    unsloth_cli/** in its own paths filter, so the old 3.10 leg executed shipped CLI code
+    on the floor interpreter. A lint aimed only at studio/backend replaces part of that
+    and reads like it replaces all of it.
+    """
+    import importlib.util
+
+    lint = REPO / "scripts" / "lint_backend_python_floor.py"
+    spec = importlib.util.spec_from_file_location("lint_backend_python_floor", lint)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    workflow = WORKFLOW.read_text(encoding = "utf-8")
+    # What it would hand to vermin, not what its source says it aims at.
+    scanned = [str(Path(name).relative_to(REPO).as_posix()) for name in module.targets()]
+    for tree in ("studio/backend", "unsloth_cli"):
+        assert tree in workflow, (
+            f"{tree} is no longer run by {WORKFLOW.name}; drop it from the lint's ROOTS too"
+        )
+        assert any(name.startswith(tree + "/") for name in scanned), (
+            f"{WORKFLOW.name} still executes {tree} on the matrix, but the floor lint does "
+            f"not scan it, so a post-floor stdlib name there passes the pull request and "
+            f"fails on the push to main."
+        )

--- a/tests/studio/test_backend_ci_matrix.py
+++ b/tests/studio/test_backend_ci_matrix.py
@@ -243,12 +243,16 @@ def test_the_floor_lint_scans_the_tree_rather_than_a_list_of_packages():
     }
     scanned = {Path(name) for name in module.targets()}
     missed = {p for p in on_disk if p not in scanned}
-    # Only the recorded exemptions may be absent, and each carries its reason.
-    allowed = {backend / name for name in module.GUARDED}
-    assert missed <= allowed, (
-        f"the floor lint does not scan {sorted(str(p.relative_to(backend)) for p in missed - allowed)}. "
-        f"Those files ship, and a pull request no longer runs them on the oldest "
-        f"interpreter, so nothing else would notice a stdlib symbol from above the floor."
+    assert not missed, (
+        f"the floor lint does not scan "
+        f"{sorted(str(p.relative_to(backend)) for p in missed)}. Those files ship, and a "
+        f"pull request no longer runs them on the oldest interpreter, so nothing else "
+        f"would notice a stdlib symbol from above the floor.\n"
+        f"\n"
+        f"No file-level exemption is allowed here, deliberately. A deliberate above-floor "
+        f"call is suppressed at the SITE with `# novermin` and a reason, which leaves the "
+        f"rest of its module checked. Dropping the whole file would leave everything else "
+        f"in it unchecked forever, which is the package-allowlist mistake one level down."
     )
     assert len(scanned) > 300, (
         f"the floor lint only found {len(scanned)} files; the scan is not reaching the tree"

--- a/tests/studio/test_backend_ci_matrix.py
+++ b/tests/studio/test_backend_ci_matrix.py
@@ -250,6 +250,6 @@ def test_the_floor_lint_scans_the_tree_rather_than_a_list_of_packages():
         f"Those files ship, and a pull request no longer runs them on the oldest "
         f"interpreter, so nothing else would notice a stdlib symbol from above the floor."
     )
-    assert len(scanned) > 300, (
-        f"the floor lint only found {len(scanned)} files; the scan is not reaching the tree"
-    )
+    assert (
+        len(scanned) > 300
+    ), f"the floor lint only found {len(scanned)} files; the scan is not reaching the tree"

--- a/tests/studio/test_backend_ci_matrix.py
+++ b/tests/studio/test_backend_ci_matrix.py
@@ -217,3 +217,42 @@ def test_the_full_matrix_still_runs_on_main():
         "Backend CI no longer runs on push to main, so the interpreter versions dropped "
         "from the pull-request matrix would not be tested anywhere"
     )
+
+
+def test_the_floor_lint_scans_the_tree_rather_than_a_list_of_packages():
+    """The shape of the first version of that lint, which is why this exists.
+
+    It named core, utils and routes and silently missed 116 shipped files: all of hub,
+    plugins, models, storage, auth, picker and state, plus _platform_compat.py, which
+    main.py imports directly. It also named "loggers.py", which is a directory, so that
+    entry matched nothing. A check covering most of a tree reads exactly like one
+    covering all of it, and with the floor leg dropped this is the only thing looking.
+
+    Asserted by counting what the lint would actually hand to vermin against what is on
+    disk, rather than by reading its source for a glob.
+    """
+    import importlib.util
+
+    lint = REPO / "scripts" / "lint_backend_python_floor.py"
+    spec = importlib.util.spec_from_file_location("lint_backend_python_floor", lint)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    backend = REPO / "studio" / "backend"
+    on_disk = {
+        path
+        for path in backend.rglob("*.py")
+        if not any(part in module.EXCLUDE_PARTS for part in path.relative_to(backend).parts)
+    }
+    scanned = {Path(name) for name in module.targets()}
+    missed = {p for p in on_disk if p not in scanned}
+    # Only the recorded exemptions may be absent, and each carries its reason.
+    allowed = {backend / name for name in module.GUARDED}
+    assert missed <= allowed, (
+        f"the floor lint does not scan {sorted(str(p.relative_to(backend)) for p in missed - allowed)}. "
+        f"Those files ship, and a pull request no longer runs them on the oldest "
+        f"interpreter, so nothing else would notice a stdlib symbol from above the floor."
+    )
+    assert len(scanned) > 300, (
+        f"the floor lint only found {len(scanned)} files; the scan is not reaching the tree"
+    )

--- a/tests/studio/test_backend_ci_parallel_isolation.py
+++ b/tests/studio/test_backend_ci_parallel_isolation.py
@@ -151,8 +151,10 @@ BENIGN_TIMING = {
     # A 600-second expiry checked against the wall clock. Reading both sides of that gap
     # late by whole seconds still leaves it true, and it only reaches this scan at all
     # because the widened operand walk now reads `x > time.time()` as a bound.
-    ("test_openai_codex_subscription.py",
-     "test_account_claim_and_token_response_are_validated_without_returning_raw_body"),
+    (
+        "test_openai_codex_subscription.py",
+        "test_account_claim_and_token_response_are_validated_without_returning_raw_body",
+    ),
 }
 
 


### PR DESCRIPTION
A pull request ran Backend CI on 3.10 and 3.13. It now runs **3.13 only**. Main still runs all four, so anything that needs a real run is caught at merge rather than never.

Backend CI is 26% of all CI minutes, and the org queue is currently **688 jobs deep against ~28 running**. This halves the interpreter cost of every pull request.

## Paying for the leg that goes

The floor leg was worth something, and I did not want to drop it and write `ast.parse` in the gap, because that answers the wrong question. What a dropped floor leg actually stops catching is **reaching for a stdlib name that does not exist yet**. `core/research_runs.py` already uses `anext`, which is 3.10. That parses perfectly on 3.9 and fails only when the line runs, so the existing `feature_version` check would never have seen it.

`scripts/lint_backend_python_floor.py` asks **vermin**, which reads syntax *and* stdlib API availability:

```
$ python3 scripts/lint_backend_python_floor.py
[floor] backend source must run on Python 3.10 (oldest leg in the matrix)
  'itertools.batched' member requires !2, 3.12
::error title=Backend needs a newer Python than the matrix floor::...
```

It takes its target from the workflow's own matrix rather than a number written in the script, so raising the floor in one place moves both. It runs from `workflow-trigger-lint.yml`, which carries no paths filter, so it sees the pull requests that touch only backend source, which are the ones that most need it now. Seconds, not minutes.

## The single leg has to be the newest

Removals and deprecations land on the newest interpreter first and on the oldest never, so running only the oldest would be the wrong single choice. The guard asserts which end it is, rather than only that there is one.

## What is genuinely given up

Stated plainly, and kept as a test rather than deleted with the old guard. The backend has `sys.version_info` branches at the 3.10, 3.11 and 3.12 boundaries, and a pull request no longer takes both sides of any of them. **Nothing static covers that** — a parse reads both sides and runs neither. `test_the_boundaries_the_subset_stops_executing_are_still_run_on_main` lists exactly which boundaries are affected and fails if Backend CI ever stops running on push to main, at which point this stops being a trade and becomes a straight loss.

## Mutation tested

| mutation | result |
| --- | --- |
| single leg made the floor rather than the ceiling | fails |
| lint invocation removed from the trigger-lint job | fails |
| vermin removed from the install line | fails |
| Backend CI taken off push-to-main | fails 2 |
| `itertools.batched` added to backend source | lint exits 1 |

The vermin check needed a second pass, which is worth recording: the first version looked for the string anywhere in the workflow and was satisfied by a comment that mentioned it.