### PR TITLE
Stop the banner layout suite waiting out the update timer on every boot

### DIFF
--- a/studio/frontend/src/hooks/use-web-update-check.ts
+++ b/studio/frontend/src/hooks/use-web-update-check.ts
@@ -8,6 +8,27 @@ import { useCallback, useEffect, useState } from "react";
 // Checked once per launch only (no polling), to avoid background load. A
 // re-check happens naturally the next time the user reopens the app.
 const WEB_UPDATE_CHECK_DELAY_MS = 5000;
+
+// End-to-end override, absent in every real browser.
+//
+// The banner layout suite boots a fresh page for each case it measures, and every one of
+// those boots waits out this timer before the card it is there to measure exists at all.
+// At 33 boots that is over two and a half minutes of a five minute step spent waiting for
+// a delay whose entire purpose is to keep a network call off the critical path at launch,
+// which is not a property that suite is testing.
+//
+// Read at mount rather than at module load, so a test can set it from an init script and
+// so a bundle that is never driven by one behaves exactly as before: the global is
+// undefined, and the constant above stands. Deliberately not an env var, which would bake
+// the shortened delay into whatever build read it.
+const E2E_DELAY_GLOBAL = "__unslothE2EWebUpdateDelayMs";
+
+function overriddenDelayMs(): number | null {
+  if (typeof window === "undefined") return null;
+  const raw = (window as unknown as Record<string, unknown>)[E2E_DELAY_GLOBAL];
+  const value = typeof raw === "number" ? raw : Number.NaN;
+  return Number.isFinite(value) && value >= 0 ? value : null;
+}
 const DISMISS_PREFIX = "unsloth_web_update_dismissed";
 const CAN_SHOW_KEY = "can_show_web_notification";
 const UPDATE_AVAILABLE_KEY = "update_available";
@@ -136,7 +157,10 @@ export function useWebUpdateCheck({
           }
         })
         .catch(() => {});
-    }, delayMs);
+      // The override wins over the caller's delayMs as well as over the constant: the
+      // only caller that passes one is a unit test asserting the timer's behaviour, and
+      // it does not set the global.
+    }, overriddenDelayMs() ?? delayMs);
 
     return () => {
       canceled = true;

--- a/tests/studio/playwright_update_banner_layout.py
+++ b/tests/studio/playwright_update_banner_layout.py
@@ -53,6 +53,11 @@ SETTLE_MS = int(os.environ.get("STUDIO_UI_BANNER_SETTLE_MS", "9000"))
 # What the cards need after they mount, to animate in and lay out.
 SETTLED_MS = int(os.environ.get("STUDIO_UI_BANNER_SETTLED_MS", "900"))
 
+# Must match the name use-web-update-check.ts reads. Kept short rather than zero so the
+# card still arrives after first paint, which is the situation the layout checks exist for.
+E2E_DELAY_GLOBAL = "__unslothE2EWebUpdateDelayMs"
+E2E_DELAY_MS = int(os.environ.get("STUDIO_UI_BANNER_UPDATE_DELAY_MS", "150"))
+
 LATEST = "2099.1.0"
 
 # Long enough that the collapsed preview alone overflows a capped card.
@@ -630,9 +635,10 @@ def settle_stack(
 
 def boot(page, path: str) -> None:
     page.goto(f"{BASE}{path}", wait_until = "domcontentloaded")
-    # Both cards are on a timer, the app one at 5s and llama.cpp at 1s, so wait
-    # for them rather than for the worst case: this step runs 24 times and the
-    # job it shares has minutes, not tens of minutes, to spare.
+    # Both cards are on a timer, so wait for them rather than for the worst case: this
+    # step runs 24 times and the job it shares has minutes, not tens of minutes, to
+    # spare. The app card's 5s is shortened to E2E_DELAY_MS by the seed script, llama.cpp
+    # keeps its 1s, and both still mount after first paint.
     for testid in ("web-update-banner", "llama-update-banner"):
         try:
             page.wait_for_selector(f'[data-testid="{testid}"]', state = "attached", timeout = SETTLE_MS)
@@ -674,6 +680,15 @@ def main() -> int:
     # add_init_script takes raw source, not a function to call.
     seed_js = (
         "(() => {"
+        # The app arms its update check on a 5s timer so the request stays off the
+        # critical path at launch. This suite boots a fresh page for every case it
+        # measures and waits out that timer each time before the card it is measuring
+        # exists, which was over two and a half minutes of a five minute step. The
+        # override is read at mount from a global that exists only here, so the shortened
+        # delay reaches no build and no browser but this one, and it stays a timer rather
+        # than becoming synchronous, because a card that mounts on the first frame would
+        # not exercise the late-mount reflow this file is about.
+        f"  window.{E2E_DELAY_GLOBAL} = {E2E_DELAY_MS};"
         f"  localStorage.setItem('unsloth_auth_token', {json.dumps(session['access_token'])});"
         f"  localStorage.setItem('unsloth_refresh_token', {json.dumps(session.get('refresh_token', ''))});"
         "  localStorage.setItem('unsloth_show_llama_update_banner', 'true');"

--- a/tests/studio/test_banner_update_delay_override.py
+++ b/tests/studio/test_banner_update_delay_override.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""The update-check delay override is one name shared by two languages.
+
+The banner layout suite boots a fresh page per case and, before this, waited out the
+app's 5s update-check timer on each of them: 33 boots, over two and a half minutes of a
+five minute step, spent waiting for a delay whose purpose is to keep a request off the
+critical path at launch. That is not a property the layout suite tests.
+
+The override is a global set by the suite's init script and read by the hook at mount.
+Nothing connects the two but the spelling, and a typo on either side fails silently in
+the worst possible way: the timer simply stays at 5s and the step goes back to being slow
+while every assertion still passes. So the spelling is asserted here.
+
+Deliberately NOT asserted: that the delay is short. A value is a judgement, and the
+suite can raise it with an env var when a browser needs longer. What must hold is that
+the two sides mean the same thing, and that production is untouched when nobody sets it.
+"""
+
+import re
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+HOOK = REPO / "studio" / "frontend" / "src" / "hooks" / "use-web-update-check.ts"
+SUITE = REPO / "tests" / "studio" / "playwright_update_banner_layout.py"
+
+
+def test_both_sides_spell_the_override_the_same_way():
+    hook = HOOK.read_text(encoding = "utf-8")
+    suite = SUITE.read_text(encoding = "utf-8")
+
+    in_hook = re.search(r'E2E_DELAY_GLOBAL\s*=\s*"([^"]+)"', hook)
+    assert in_hook, f"{HOOK.name} no longer names the override global"
+    in_suite = re.search(r'E2E_DELAY_GLOBAL\s*=\s*"([^"]+)"', suite)
+    assert in_suite, f"{SUITE.name} no longer names the override global"
+
+    assert in_hook.group(1) == in_suite.group(1), (
+        f"{HOOK.name} reads {in_hook.group(1)!r} and {SUITE.name} sets "
+        f"{in_suite.group(1)!r}. Nothing else connects them, so this drift does not fail "
+        f"a single assertion: the timer stays at 5s and the step silently costs the "
+        f"minutes this override was added to give back."
+    )
+
+
+def test_the_suite_actually_sets_it_before_the_app_runs():
+    """An init script, not a page.evaluate after navigation.
+
+    Setting it after load would be too late by definition: the hook reads it when the
+    effect mounts, which has already happened.
+    """
+    suite = SUITE.read_text(encoding = "utf-8")
+    assert "add_init_script" in suite, (
+        f"{SUITE.name} no longer installs an init script, so the override cannot be in "
+        f"place before the hook mounts and reads it"
+    )
+    seed = suite[suite.index("seed_js = ("):suite.index("if PLAYWRIGHT_BROWSER")]
+    assert "E2E_DELAY_GLOBAL" in seed, (
+        f"the override moved out of seed_js in {SUITE.name}. seed_js is what is handed to "
+        f"add_init_script; anywhere else runs after the app has already armed the timer."
+    )
+
+
+def test_production_keeps_the_five_second_delay():
+    """The override is absent in a real browser, and the constant is what remains.
+
+    A default of anything but 5000, or a read at module load rather than at mount, would
+    change what users get. This is the assertion that keeps the optimisation confined to
+    CI.
+    """
+    hook = HOOK.read_text(encoding = "utf-8")
+    assert re.search(r"const WEB_UPDATE_CHECK_DELAY_MS = 5000;", hook), (
+        "the production update-check delay is no longer 5000ms. Shortening the CI wait "
+        "must not shorten the real one: that delay exists to keep the request off the "
+        "critical path while the app is starting."
+    )
+    assert "typeof window === \"undefined\"" in hook, (
+        "the override no longer guards against a server-side render, where there is no "
+        "window to read it from"
+    )

--- a/tests/studio/test_banner_update_delay_override.py
+++ b/tests/studio/test_banner_update_delay_override.py
@@ -54,7 +54,7 @@ def test_the_suite_actually_sets_it_before_the_app_runs():
         f"{SUITE.name} no longer installs an init script, so the override cannot be in "
         f"place before the hook mounts and reads it"
     )
-    seed = suite[suite.index("seed_js = ("):suite.index("if PLAYWRIGHT_BROWSER")]
+    seed = suite[suite.index("seed_js = (") : suite.index("if PLAYWRIGHT_BROWSER")]
     assert "E2E_DELAY_GLOBAL" in seed, (
         f"the override moved out of seed_js in {SUITE.name}. seed_js is what is handed to "
         f"add_init_script; anywhere else runs after the app has already armed the timer."
@@ -74,7 +74,7 @@ def test_production_keeps_the_five_second_delay():
         "must not shorten the real one: that delay exists to keep the request off the "
         "critical path while the app is starting."
     )
-    assert "typeof window === \"undefined\"" in hook, (
+    assert 'typeof window === "undefined"' in hook, (
         "the override no longer guards against a server-side render, where there is no "
         "window to read it from"
     )


### PR DESCRIPTION
`Update banner layout regression` is the largest step in `Chat UI Tests` at 4.98 of the job's 17.6 minutes, and the second banner step adds 2.27 more. Together that is 41% of a job that runs on Linux, Windows and macOS.

### Where the time goes

The suite boots a fresh page for each case it measures, and the card it is measuring is mounted by the app's 5s update-check timer, so `wait_for_selector` on it cannot return sooner than that. At 33 boots the timer alone is over two and a half minutes.

The rest of each boot is the 900ms animation settle and `settle_stack`, both of which are render waits, and both are left exactly as they are. Measured earlier as 33 gaps of about 7.5s: 5 for the timer, 0.9 for the settle, roughly 1.6 of stability polling. The stability poll is converging rather than exhausting, so it is not the thing to change.

### The change

The delay becomes overridable from a global that the hook reads **at mount**, and the suite sets it in the init script it already installs, to 150ms. Not zero, because a card that mounts on the first frame would stop exercising the late-mount reflow this file exists to measure.

Production is untouched: the global is undefined in every real browser and the 5000ms constant stands. It is a global rather than an env var specifically so that no build can bake the shortened delay in.

### Why there is a test for a two-line change

The two sides are connected by nothing but the spelling of the global, and a typo on either would fail in the worst way available: the timer quietly stays at 5s, the step goes back to being slow, and every assertion still passes. `tests/studio/test_banner_update_delay_override.py` asserts the spelling matches, that the suite sets it before the app runs rather than after navigation, and that the production constant is still 5000.
