### PR TITLE
Studio: normalize replayed tool-call ids for external providers

### DIFF
--- a/studio/backend/core/inference/studio_tool_loop.py
+++ b/studio/backend/core/inference/studio_tool_loop.py
@@ -546,13 +546,9 @@ class _Turn:
                 # Never replayed upstream: the conversation carries the
                 # de-duplicated id, which is the whole point of the rename.
                 normalized["stream_id"] = normalized["id"]
-                # Suffixing once is not enough now that the ledger starts from
-                # the replayed history: the id this mints is itself stored by
-                # the client and comes back as history on the next request, so
-                # a chat that heals a call every turn would collide again on
-                # "call_0_1_0" one request later. Counting up terminates, the
-                # ledger is finite, and the first attempt is unchanged, so an
-                # id that was already unique keeps the name it has today.
+                # The renamed id is itself stored and replayed, so a single-shot
+                # rename collides again on the next request. Counting up over a
+                # finite ledger terminates and leaves the first attempt as is.
                 renamed = f"{normalized['id']}_{self.round}_{position}"
                 attempt = 0
                 while renamed in seen:
@@ -663,16 +659,12 @@ def _is_usage_only(payload: dict[str, Any]) -> bool:
 
 
 def _replayed_call_ids(conversation: list[dict[str, Any]]) -> set[str]:
-    """Every tool-call id already present in the history this run starts from.
+    """Every tool-call id already in the history this run starts from.
 
-    The healer restarts its counter on every request, so the very first turn of
-    a new request always mints call_0. The replay normalization now hands that
-    same bare call_0 back as the id of an earlier request's call whenever one
-    stored id claims the base, so without this the two collide inside a single
-    upstream body: two tool_use blocks under one id on Anthropic, a "Duplicate
-    tool call id" rejection from mistral-common, or a silent result/call
-    mispairing where pairing is positional. Seeding the ledger makes calls()
-    rename the new one exactly as it already does for a repeat within a run.
+    The healer restarts its counter every request, so a freshly minted call_0
+    collides with a stripped call_0 replayed from history inside one upstream
+    body. Seeding the ledger makes calls() rename the new one as it does any
+    repeat within a run.
     """
     taken: set[str] = set()
     for message in conversation:

--- a/studio/backend/core/inference/studio_tool_loop.py
+++ b/studio/backend/core/inference/studio_tool_loop.py
@@ -546,7 +546,19 @@ class _Turn:
                 # Never replayed upstream: the conversation carries the
                 # de-duplicated id, which is the whole point of the rename.
                 normalized["stream_id"] = normalized["id"]
-                normalized["id"] = f"{normalized['id']}_{self.round}_{position}"
+                # Suffixing once is not enough now that the ledger starts from
+                # the replayed history: the id this mints is itself stored by
+                # the client and comes back as history on the next request, so
+                # a chat that heals a call every turn would collide again on
+                # "call_0_1_0" one request later. Counting up terminates, the
+                # ledger is finite, and the first attempt is unchanged, so an
+                # id that was already unique keeps the name it has today.
+                renamed = f"{normalized['id']}_{self.round}_{position}"
+                attempt = 0
+                while renamed in seen:
+                    attempt += 1
+                    renamed = f"{normalized['id']}_{self.round}_{position}_{attempt}"
+                normalized["id"] = renamed
             seen.add(normalized["id"])
             out.append(normalized)
         return out
@@ -648,6 +660,31 @@ def _usage_chunk_line(model: str, totals: dict[str, Any]) -> str | None:
 def _is_usage_only(payload: dict[str, Any]) -> bool:
     choices = payload.get("choices")
     return "usage" in payload and isinstance(choices, list) and not choices
+
+
+def _replayed_call_ids(conversation: list[dict[str, Any]]) -> set[str]:
+    """Every tool-call id already present in the history this run starts from.
+
+    The healer restarts its counter on every request, so the very first turn of
+    a new request always mints call_0. The replay normalization now hands that
+    same bare call_0 back as the id of an earlier request's call whenever one
+    stored id claims the base, so without this the two collide inside a single
+    upstream body: two tool_use blocks under one id on Anthropic, a "Duplicate
+    tool call id" rejection from mistral-common, or a silent result/call
+    mispairing where pairing is positional. Seeding the ledger makes calls()
+    rename the new one exactly as it already does for a repeat within a run.
+    """
+    taken: set[str] = set()
+    for message in conversation:
+        if not isinstance(message, dict):
+            continue
+        for call in message.get("tool_calls") or []:
+            if isinstance(call, dict) and isinstance(call.get("id"), str) and call["id"]:
+                taken.add(call["id"])
+        result_id = message.get("tool_call_id")
+        if isinstance(result_id, str) and result_id:
+            taken.add(result_id)
+    return taken
 
 
 def _append_user_turn(conversation: list[dict[str, Any]], content: str) -> None:
@@ -767,7 +804,7 @@ async def stream_with_studio_tools(
     max_reprompts = MAX_ACT_REPROMPTS
     last_reprompt_text = ""
     provider_turns = 0
-    used_call_ids: set[str] = set()
+    used_call_ids: set[str] = _replayed_call_ids(conversation)
     spent_budget_passes = 0
     fruitless_turns = 0
     # One provider call per possible execution, plus headroom for the no-op,

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -11910,6 +11910,39 @@ def _extract_content_parts(messages: list) -> tuple[str, list[dict], "Optional[s
 # content_part type.
 _INPUT_DOCUMENT_PROVIDERS = frozenset({"anthropic", "openai"})
 
+# The frontend stores tool-call ids as "<provider id>:<uuid4>" (chat-adapter.ts
+# mints them for part identity), which strict providers reject on replay --
+# OpenAI caps call ids at 64 chars, and the minted form is 66. #8913.
+_MINTED_TOOL_CALL_ID_SUFFIX = _re.compile(
+    r":[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+)
+
+
+def _replay_tool_call_id(value: Any) -> Any:
+    """Restore the provider's original tool-call id for replay; hash-shorten
+    anything else over 64 chars (same scheme as openai_codex_client._codex_call_id,
+    so call/output pairs shorten identically)."""
+    if not isinstance(value, str):
+        return value
+    base = _MINTED_TOOL_CALL_ID_SUFFIX.sub("", value)
+    if len(base) <= 64:
+        return base
+    digest = _hashlib.sha256(base.encode("utf-8")).hexdigest()[:32]
+    return f"{base[:31]}_{digest}"
+
+
+def _replay_tool_call_ids(tool_calls: Any) -> Any:
+    if not isinstance(tool_calls, list):
+        return tool_calls
+    out = []
+    for tc in tool_calls:
+        if isinstance(tc, dict) and isinstance(tc.get("id"), str):
+            fixed = _replay_tool_call_id(tc["id"])
+            if fixed != tc["id"]:
+                tc = {**tc, "id": fixed}
+        out.append(tc)
+    return out
+
 
 def _build_external_messages(
     messages: list,
@@ -12220,6 +12253,11 @@ def _build_external_messages(
                 if emit_extra_content and msg.role == "assistant" and msg.extra_content:
                     entry["extra_content"] = msg.extra_content
                 result.append(entry)
+    for entry in result:
+        if entry.get("tool_calls"):
+            entry["tool_calls"] = _replay_tool_call_ids(entry["tool_calls"])
+        if isinstance(entry.get("tool_call_id"), str):
+            entry["tool_call_id"] = _replay_tool_call_id(entry["tool_call_id"])
     return result
 
 

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -11921,6 +11921,22 @@ _MINTED_TOOL_CALL_ID_SUFFIX = _re.compile(
 # ("Tool call id was ... but must be a-z, A-Z, 0-9, with a length of 9").
 _MISTRAL_TOOL_CALL_ID = _re.compile(r"[a-zA-Z0-9]{9}")
 
+# Anthropic validates tool_use.id / tool_result.tool_use_id against its own charset and
+# says so in the 400: "tool_use.id: String should match pattern '^[a-zA-Z0-9_-]+$'".
+# No length cap is documented or observed, so this is a charset rule only.
+#
+# It matters here because a colon is not in that set and our stored ids are full of them.
+# Two shapes reach Anthropic with one: the duplicate-base fallback below, which keeps the
+# whole "call_0:<uuid>" value, and the frontend's confirmation-scoped
+# "<sandbox>:<thread>:<approval>" ids, which have no uuid suffix to strip. Both are short
+# enough to skip the >64 branch, so before this they went out verbatim and 400'd.
+# Anthropic cannot originate these itself -- its own tool ids are server-tool ids that
+# _filter_tool_calls drops -- so the path is a history replayed after the user switches
+# an existing chat onto an Anthropic model, which is the single most common way this
+# failure is reported across other clients.
+_ANTHROPIC_TOOL_CALL_ID = _re.compile(r"[a-zA-Z0-9_-]+")
+_ANTHROPIC_TOOL_CALL_ID_ILLEGAL = _re.compile(r"[^a-zA-Z0-9_-]")
+
 
 def _replay_tool_call_id_map(
     originals: "set[str]", provider_type: Optional[str] = None
@@ -11930,8 +11946,15 @@ def _replay_tool_call_id_map(
     ids like "call_0" restart every response, so the minted uuid suffix is the
     only cross-response uniqueness). Then per-provider: Mistral only accepts
     9-char alphanumeric ids, so anything else gets a stable sha256[:9] mapping;
-    other providers hash-shorten past 64 chars (same scheme as
-    openai_codex_client._codex_call_id, so call/output pairs stay paired)."""
+    Anthropic only accepts [a-zA-Z0-9_-], so anything else keeps a sanitized
+    prefix and gains a sha256 tail; other providers hash-shorten past 64 chars
+    (same scheme as openai_codex_client._codex_call_id, so call/output pairs
+    stay paired).
+
+    Every branch hashes the whole pre-mapping value rather than the truncated
+    prefix, so two ids sharing a prefix stay distinct, and every branch is a
+    no-op on its own output, so replaying an already-normalized history does not
+    drift the ids again on turn three."""
     bases = {v: _MINTED_TOOL_CALL_ID_SUFFIX.sub("", v) for v in originals}
     claims: dict[str, int] = {}
     for base in bases.values():
@@ -11942,6 +11965,15 @@ def _replay_tool_call_id_map(
         if provider_type == "mistral":
             if not _MISTRAL_TOOL_CALL_ID.fullmatch(replay):
                 replay = _hashlib.sha256(replay.encode("utf-8")).hexdigest()[:9]
+        elif provider_type == "anthropic" and not _ANTHROPIC_TOOL_CALL_ID.fullmatch(replay):
+            # Sanitizing alone would collide "a:b" and "a_b" onto one id, which pairs the
+            # wrong result with the wrong call -- a silent wrong answer, worse than the
+            # 400 this avoids. The sha256 tail is taken over the unsanitized value, so
+            # the mapping stays injective; the readable prefix is kept only for logs.
+            # 31 + 1 + 32 is 64, matching the shortening scheme below.
+            digest = _hashlib.sha256(replay.encode("utf-8")).hexdigest()[:32]
+            sanitized = _ANTHROPIC_TOOL_CALL_ID_ILLEGAL.sub("_", replay)[:31]
+            replay = f"{sanitized}_{digest}"
         elif len(replay) > 64:
             digest = _hashlib.sha256(replay.encode("utf-8")).hexdigest()[:32]
             replay = f"{replay[:31]}_{digest}"

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -11917,27 +11917,36 @@ _MINTED_TOOL_CALL_ID_SUFFIX = _re.compile(
     r":[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
 )
 
+# Mistral rejects any replayed tool-call id not matching ^[a-zA-Z0-9]{9}$
+# ("Tool call id was ... but must be a-z, A-Z, 0-9, with a length of 9").
+_MISTRAL_TOOL_CALL_ID = _re.compile(r"[a-zA-Z0-9]{9}")
 
-def _replay_tool_call_id(value: Any) -> Any:
+
+def _replay_tool_call_id(value: Any, provider_type: Optional[str] = None) -> Any:
     """Restore the provider's original tool-call id for replay; hash-shorten
     anything else over 64 chars (same scheme as openai_codex_client._codex_call_id,
-    so call/output pairs shorten identically)."""
+    so call/output pairs shorten identically). Mistral only accepts 9-char
+    alphanumeric ids, so foreign ids get a stable 9-char hex mapping instead."""
     if not isinstance(value, str):
         return value
     base = _MINTED_TOOL_CALL_ID_SUFFIX.sub("", value)
+    if provider_type == "mistral":
+        if _MISTRAL_TOOL_CALL_ID.fullmatch(base):
+            return base
+        return _hashlib.sha256(base.encode("utf-8")).hexdigest()[:9]
     if len(base) <= 64:
         return base
     digest = _hashlib.sha256(base.encode("utf-8")).hexdigest()[:32]
     return f"{base[:31]}_{digest}"
 
 
-def _replay_tool_call_ids(tool_calls: Any) -> Any:
+def _replay_tool_call_ids(tool_calls: Any, provider_type: Optional[str] = None) -> Any:
     if not isinstance(tool_calls, list):
         return tool_calls
     out = []
     for tc in tool_calls:
         if isinstance(tc, dict) and isinstance(tc.get("id"), str):
-            fixed = _replay_tool_call_id(tc["id"])
+            fixed = _replay_tool_call_id(tc["id"], provider_type)
             if fixed != tc["id"]:
                 tc = {**tc, "id": fixed}
         out.append(tc)
@@ -12255,9 +12264,9 @@ def _build_external_messages(
                 result.append(entry)
     for entry in result:
         if entry.get("tool_calls"):
-            entry["tool_calls"] = _replay_tool_call_ids(entry["tool_calls"])
+            entry["tool_calls"] = _replay_tool_call_ids(entry["tool_calls"], provider_type)
         if isinstance(entry.get("tool_call_id"), str):
-            entry["tool_call_id"] = _replay_tool_call_id(entry["tool_call_id"])
+            entry["tool_call_id"] = _replay_tool_call_id(entry["tool_call_id"], provider_type)
     return result
 
 

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -12277,20 +12277,14 @@ def _build_external_messages(
         if isinstance(entry.get("tool_calls"), list)
         for tc in entry["tool_calls"]
         if isinstance(tc, dict) and isinstance(tc.get("id"), str)
-    } | {
-        entry["tool_call_id"]
-        for entry in result
-        if isinstance(entry.get("tool_call_id"), str)
-    }
+    } | {entry["tool_call_id"] for entry in result if isinstance(entry.get("tool_call_id"), str)}
     if originals:
         replay_ids = _replay_tool_call_id_map(originals, provider_type)
         for entry in result:
             if entry.get("tool_calls"):
                 entry["tool_calls"] = _replay_tool_call_ids(entry["tool_calls"], replay_ids)
             if isinstance(entry.get("tool_call_id"), str):
-                entry["tool_call_id"] = replay_ids.get(
-                    entry["tool_call_id"], entry["tool_call_id"]
-                )
+                entry["tool_call_id"] = replay_ids.get(entry["tool_call_id"], entry["tool_call_id"])
     return result
 
 

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -11910,9 +11910,9 @@ def _extract_content_parts(messages: list) -> tuple[str, list[dict], "Optional[s
 # content_part type.
 _INPUT_DOCUMENT_PROVIDERS = frozenset({"anthropic", "openai"})
 
-# The frontend stores tool-call ids as "<provider id>:<uuid4>" (chat-adapter.ts
-# mints them for part identity), which strict providers reject on replay --
-# OpenAI caps call ids at 64 chars, and the minted form is 66. #8913.
+# The frontend stores tool-call ids as "<provider id>:<uuid4>" (chat-adapter.ts mints them
+# for part identity), which strict providers reject on replay: OpenAI caps call ids at 64
+# chars and the minted form is 66. #8913.
 _MINTED_TOOL_CALL_ID_SUFFIX = _re.compile(
     r":[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
 )
@@ -11921,19 +11921,13 @@ _MINTED_TOOL_CALL_ID_SUFFIX = _re.compile(
 # ("Tool call id was ... but must be a-z, A-Z, 0-9, with a length of 9").
 _MISTRAL_TOOL_CALL_ID = _re.compile(r"[a-zA-Z0-9]{9}")
 
-# Anthropic validates tool_use.id / tool_result.tool_use_id against its own charset and
-# says so in the 400: "tool_use.id: String should match pattern '^[a-zA-Z0-9_-]+$'".
-# No length cap is documented or observed, so this is a charset rule only.
-#
-# It matters here because a colon is not in that set and our stored ids are full of them.
-# Two shapes reach Anthropic with one: the duplicate-base fallback below, which keeps the
-# whole "call_0:<uuid>" value, and the frontend's confirmation-scoped
-# "<sandbox>:<thread>:<approval>" ids, which have no uuid suffix to strip. Both are short
-# enough to skip the >64 branch, so before this they went out verbatim and 400'd.
-# Anthropic cannot originate these itself -- its own tool ids are server-tool ids that
-# _filter_tool_calls drops -- so the path is a history replayed after the user switches
-# an existing chat onto an Anthropic model, which is the single most common way this
-# failure is reported across other clients.
+# Anthropic states the charset in its 400: "tool_use.id: String should match pattern
+# '^[a-zA-Z0-9_-]+$'". No length cap is documented or observed, so this is charset only.
+# A colon is not in the set, and two stored shapes carry one in under 64 chars so the >64
+# branch never caught them: the duplicate-base fallback below, which keeps the whole
+# "call_0:<uuid>", and the frontend's "<sandbox>:<thread>:<approval>" confirmation ids.
+# Anthropic cannot originate either (its own ids are server-tool ids _filter_tool_calls
+# drops), so the path is a history replayed after switching an existing chat to Anthropic.
 _ANTHROPIC_TOOL_CALL_ID = _re.compile(r"[a-zA-Z0-9_-]+")
 _ANTHROPIC_TOOL_CALL_ID_ILLEGAL = _re.compile(r"[^a-zA-Z0-9_-]")
 
@@ -11941,20 +11935,19 @@ _ANTHROPIC_TOOL_CALL_ID_ILLEGAL = _re.compile(r"[^a-zA-Z0-9_-]")
 def _replay_tool_call_id_map(
     originals: "set[str]", provider_type: Optional[str] = None
 ) -> dict[str, str]:
-    """Map stored tool-call ids to replay ids: the suffix-stripped base when
-    exactly one distinct original claims it, else the full stored value (backend
-    ids like "call_0" restart every response, so the minted uuid suffix is the
-    only cross-response uniqueness). Then per-provider: Mistral only accepts
-    9-char alphanumeric ids, so anything else gets a stable sha256[:9] mapping;
-    Anthropic only accepts [a-zA-Z0-9_-], so anything else keeps a sanitized
-    prefix and gains a sha256 tail; other providers hash-shorten past 64 chars
-    (same scheme as openai_codex_client._codex_call_id, so call/output pairs
-    stay paired).
+    """Map stored tool-call ids to replay ids.
 
-    Every branch hashes the whole pre-mapping value rather than the truncated
-    prefix, so two ids sharing a prefix stay distinct, and every branch is a
-    no-op on its own output, so replaying an already-normalized history does not
-    drift the ids again on turn three."""
+    The suffix-stripped base when exactly one distinct original claims it, else
+    the full stored value: backend ids like "call_0" restart every response, so
+    the minted uuid suffix is the only cross-response uniqueness. Then per
+    provider: Mistral takes only 9-char alphanumeric ids, Anthropic only
+    [a-zA-Z0-9_-] (sanitized prefix plus sha256 tail), everything else
+    hash-shortens past 64 chars (same scheme as
+    openai_codex_client._codex_call_id, so call/output pairs stay paired).
+
+    Every branch hashes the whole pre-mapping value, not the truncated prefix,
+    so ids sharing a prefix stay distinct, and is a no-op on its own output, so
+    replaying an already-normalized history does not drift the ids again."""
     bases = {v: _MINTED_TOOL_CALL_ID_SUFFIX.sub("", v) for v in originals}
     claims: dict[str, int] = {}
     for base in bases.values():
@@ -11966,11 +11959,10 @@ def _replay_tool_call_id_map(
             if not _MISTRAL_TOOL_CALL_ID.fullmatch(replay):
                 replay = _hashlib.sha256(replay.encode("utf-8")).hexdigest()[:9]
         elif provider_type == "anthropic" and not _ANTHROPIC_TOOL_CALL_ID.fullmatch(replay):
-            # Sanitizing alone would collide "a:b" and "a_b" onto one id, which pairs the
-            # wrong result with the wrong call -- a silent wrong answer, worse than the
-            # 400 this avoids. The sha256 tail is taken over the unsanitized value, so
-            # the mapping stays injective; the readable prefix is kept only for logs.
-            # 31 + 1 + 32 is 64, matching the shortening scheme below.
+            # Sanitizing alone would collide "a:b" and "a_b" onto one id, pairing the
+            # wrong result with the wrong call: a silent wrong answer, worse than the 400
+            # this avoids. The sha256 tail is over the unsanitized value so the mapping
+            # stays injective; the prefix is readability only. 31 + 1 + 32 is 64, as below.
             digest = _hashlib.sha256(replay.encode("utf-8")).hexdigest()[:32]
             sanitized = _ANTHROPIC_TOOL_CALL_ID_ILLEGAL.sub("_", replay)[:31]
             replay = f"{sanitized}_{digest}"

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -11922,31 +11922,40 @@ _MINTED_TOOL_CALL_ID_SUFFIX = _re.compile(
 _MISTRAL_TOOL_CALL_ID = _re.compile(r"[a-zA-Z0-9]{9}")
 
 
-def _replay_tool_call_id(value: Any, provider_type: Optional[str] = None) -> Any:
-    """Restore the provider's original tool-call id for replay; hash-shorten
-    anything else over 64 chars (same scheme as openai_codex_client._codex_call_id,
-    so call/output pairs shorten identically). Mistral only accepts 9-char
-    alphanumeric ids, so foreign ids get a stable 9-char hex mapping instead."""
-    if not isinstance(value, str):
-        return value
-    base = _MINTED_TOOL_CALL_ID_SUFFIX.sub("", value)
-    if provider_type == "mistral":
-        if _MISTRAL_TOOL_CALL_ID.fullmatch(base):
-            return base
-        return _hashlib.sha256(base.encode("utf-8")).hexdigest()[:9]
-    if len(base) <= 64:
-        return base
-    digest = _hashlib.sha256(base.encode("utf-8")).hexdigest()[:32]
-    return f"{base[:31]}_{digest}"
+def _replay_tool_call_id_map(
+    originals: "set[str]", provider_type: Optional[str] = None
+) -> dict[str, str]:
+    """Map stored tool-call ids to replay ids: the suffix-stripped base when
+    exactly one distinct original claims it, else the full stored value (backend
+    ids like "call_0" restart every response, so the minted uuid suffix is the
+    only cross-response uniqueness). Then per-provider: Mistral only accepts
+    9-char alphanumeric ids, so anything else gets a stable sha256[:9] mapping;
+    other providers hash-shorten past 64 chars (same scheme as
+    openai_codex_client._codex_call_id, so call/output pairs stay paired)."""
+    bases = {v: _MINTED_TOOL_CALL_ID_SUFFIX.sub("", v) for v in originals}
+    claims: dict[str, int] = {}
+    for base in bases.values():
+        claims[base] = claims.get(base, 0) + 1
+    out = {}
+    for value, base in bases.items():
+        replay = base if claims[base] == 1 else value
+        if provider_type == "mistral":
+            if not _MISTRAL_TOOL_CALL_ID.fullmatch(replay):
+                replay = _hashlib.sha256(replay.encode("utf-8")).hexdigest()[:9]
+        elif len(replay) > 64:
+            digest = _hashlib.sha256(replay.encode("utf-8")).hexdigest()[:32]
+            replay = f"{replay[:31]}_{digest}"
+        out[value] = replay
+    return out
 
 
-def _replay_tool_call_ids(tool_calls: Any, provider_type: Optional[str] = None) -> Any:
+def _replay_tool_call_ids(tool_calls: Any, replay_ids: dict[str, str]) -> Any:
     if not isinstance(tool_calls, list):
         return tool_calls
     out = []
     for tc in tool_calls:
         if isinstance(tc, dict) and isinstance(tc.get("id"), str):
-            fixed = _replay_tool_call_id(tc["id"], provider_type)
+            fixed = replay_ids.get(tc["id"], tc["id"])
             if fixed != tc["id"]:
                 tc = {**tc, "id": fixed}
         out.append(tc)
@@ -12262,11 +12271,26 @@ def _build_external_messages(
                 if emit_extra_content and msg.role == "assistant" and msg.extra_content:
                     entry["extra_content"] = msg.extra_content
                 result.append(entry)
-    for entry in result:
-        if entry.get("tool_calls"):
-            entry["tool_calls"] = _replay_tool_call_ids(entry["tool_calls"], provider_type)
-        if isinstance(entry.get("tool_call_id"), str):
-            entry["tool_call_id"] = _replay_tool_call_id(entry["tool_call_id"], provider_type)
+    originals = {
+        tc["id"]
+        for entry in result
+        if isinstance(entry.get("tool_calls"), list)
+        for tc in entry["tool_calls"]
+        if isinstance(tc, dict) and isinstance(tc.get("id"), str)
+    } | {
+        entry["tool_call_id"]
+        for entry in result
+        if isinstance(entry.get("tool_call_id"), str)
+    }
+    if originals:
+        replay_ids = _replay_tool_call_id_map(originals, provider_type)
+        for entry in result:
+            if entry.get("tool_calls"):
+                entry["tool_calls"] = _replay_tool_call_ids(entry["tool_calls"], replay_ids)
+            if isinstance(entry.get("tool_call_id"), str):
+                entry["tool_call_id"] = replay_ids.get(
+                    entry["tool_call_id"], entry["tool_call_id"]
+                )
     return result
 
 

--- a/studio/backend/tests/test_external_tool_call_id_replay.py
+++ b/studio/backend/tests/test_external_tool_call_id_replay.py
@@ -3,9 +3,8 @@
 
 """Replayed tool-call ids must fit provider limits (#8913).
 
-The frontend stores tool-call ids as "<provider id>:<uuid4>" (66 chars for
-OpenAI), and providers that validate ids reject the whole request on the next
-turn, permanently breaking the chat.
+The frontend stores them as "<provider id>:<uuid4>" (66 chars for OpenAI), and a
+provider that validates ids rejects the whole request, permanently breaking the chat.
 """
 
 import re
@@ -110,12 +109,10 @@ def test_mistral_native_ids_pass_through_unchanged():
     assert output_id == "AbCdEfGhI"
 
 
-# Anthropic states its charset in the 400 it raises:
-# "tool_use.id: String should match pattern '^[a-zA-Z0-9_-]+$'". A colon is not in it,
-# and two stored shapes carry one into a replay: the duplicate-base fallback above, which
-# keeps the whole "call_0:<uuid>", and the frontend's "<sandbox>:<thread>:<approval>"
-# confirmation ids, which have no uuid suffix to strip. Both are under 64 chars, so the
-# length branch never touched them and they went out verbatim.
+# Anthropic states its charset in the 400 it raises: "tool_use.id: String should match
+# pattern '^[a-zA-Z0-9_-]+$'". A colon is not in it, and the two stored shapes carrying
+# one (the duplicate-base fallback, and "<sandbox>:<thread>:<approval>" confirmation ids)
+# are both under 64 chars, so the length branch never touched them.
 ANTHROPIC_ID = re.compile(r"[a-zA-Z0-9_-]+")
 
 
@@ -140,16 +137,15 @@ def test_anthropic_colliding_bases_stay_legal_and_distinct():
 
 def test_anthropic_legal_ids_pass_through_unchanged():
     # Only ids Anthropic would already have refused may change, so a chat that works
-    # today keeps byte-identical ids. toolu_ is its own issued shape.
+    # today keeps byte-identical ids.
     for legal in ("toolu_01A1B2C3D4E5F6G7H8I9J0K1", "call_abc123", "a-b_c"):
         call_id, output_id = _replayed_ids(legal, provider_type = "anthropic")
         assert call_id == output_id == legal
 
 
 def test_anthropic_sanitizing_alone_would_collide():
-    # "pre:fix" and "pre_fix" both sanitize to "pre_fix". Pairing the wrong result with
-    # the wrong call is a silent wrong answer, so the sha256 tail over the unsanitized
-    # value is what keeps the map injective.
+    # "pre:fix" and "pre_fix" both sanitize to "pre_fix", a silent mispairing, so the
+    # sha256 tail over the unsanitized value is what keeps the map injective.
     out = _build_external_messages(
         _history("pre:fix") + _history("pre_fix"),
         supports_vision = True,
@@ -161,7 +157,7 @@ def test_anthropic_sanitizing_alone_would_collide():
 
 def test_replay_is_idempotent_for_every_provider():
     # A normalized id replayed again on turn three must not drift, or the call and its
-    # result stop matching. Feed each provider's own output back through it.
+    # result stop matching.
     for provider in ("openai", "anthropic", "mistral", "gemini", "deepseek", None):
         once, _ = _replayed_ids(MINTED, provider_type = provider)
         twice, paired = _replayed_ids(once, provider_type = provider)

--- a/studio/backend/tests/test_external_tool_call_id_replay.py
+++ b/studio/backend/tests/test_external_tool_call_id_replay.py
@@ -8,6 +8,8 @@ OpenAI), and providers that validate ids reject the whole request on the next
 turn, permanently breaking the chat.
 """
 
+import re
+
 from models.inference import ChatMessage
 from routes.inference import _build_external_messages
 
@@ -66,6 +68,21 @@ def test_short_ids_pass_through_unchanged():
 
 
 def test_replay_applies_on_generic_chat_completions_providers():
-    call_id, output_id = _replayed_ids(MINTED, provider_type = "mistral")
+    call_id, output_id = _replayed_ids(MINTED, provider_type = "deepseek")
     assert call_id == ORIGINAL
     assert output_id == ORIGINAL
+
+
+def test_mistral_maps_foreign_ids_to_nine_alnum_chars():
+    for foreign in (MINTED, "tool_call_0", "toolu_01A09q90qw90lq917835lq9", "x" * 80):
+        call_id, output_id = _replayed_ids(foreign, provider_type = "mistral")
+        assert call_id == output_id
+        assert re.fullmatch(r"[a-zA-Z0-9]{9}", call_id)
+
+
+def test_mistral_native_ids_pass_through_unchanged():
+    call_id, output_id = _replayed_ids(
+        "AbCdEfGhI:071e73c8-5d38-4d4c-821a-62fe32c7a54a", provider_type = "mistral"
+    )
+    assert call_id == "AbCdEfGhI"
+    assert output_id == "AbCdEfGhI"

--- a/studio/backend/tests/test_external_tool_call_id_replay.py
+++ b/studio/backend/tests/test_external_tool_call_id_replay.py
@@ -1,0 +1,71 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Replayed tool-call ids must fit provider limits (#8913).
+
+The frontend stores tool-call ids as "<provider id>:<uuid4>" (66 chars for
+OpenAI), and providers that validate ids reject the whole request on the next
+turn, permanently breaking the chat.
+"""
+
+from models.inference import ChatMessage
+from routes.inference import _build_external_messages
+
+MINTED = "call_AbCdEfGhIjKlMnOpQrStUvWx:071e73c8-5d38-4d4c-821a-62fe32c7a54a"
+ORIGINAL = "call_AbCdEfGhIjKlMnOpQrStUvWx"
+
+
+def _history(tool_call_id):
+    return [
+        ChatMessage.model_validate(
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": tool_call_id,
+                        "type": "function",
+                        "function": {"name": "python", "arguments": "{}"},
+                    }
+                ],
+            }
+        ),
+        ChatMessage.model_validate(
+            {"role": "tool", "tool_call_id": tool_call_id, "content": "ok"}
+        ),
+    ]
+
+
+def _replayed_ids(tool_call_id, provider_type = "openai"):
+    out = _build_external_messages(
+        _history(tool_call_id), supports_vision = True, provider_type = provider_type
+    )
+    assistant = next(m for m in out if m.get("tool_calls"))
+    tool = next(m for m in out if m["role"] == "tool")
+    return assistant["tool_calls"][0]["id"], tool["tool_call_id"]
+
+
+def test_minted_frontend_id_is_restored_to_provider_id():
+    call_id, output_id = _replayed_ids(MINTED)
+    assert call_id == ORIGINAL
+    assert output_id == ORIGINAL
+
+
+def test_oversized_foreign_id_is_shortened_symmetrically():
+    long_id = "x" * 80
+    call_id, output_id = _replayed_ids(long_id)
+    assert call_id == output_id
+    assert len(call_id) == 64
+    assert call_id.startswith("x" * 31)
+
+
+def test_short_ids_pass_through_unchanged():
+    call_id, output_id = _replayed_ids("call_xyz")
+    assert call_id == "call_xyz"
+    assert output_id == "call_xyz"
+
+
+def test_replay_applies_on_generic_chat_completions_providers():
+    call_id, output_id = _replayed_ids(MINTED, provider_type = "mistral")
+    assert call_id == ORIGINAL
+    assert output_id == ORIGINAL

--- a/studio/backend/tests/test_external_tool_call_id_replay.py
+++ b/studio/backend/tests/test_external_tool_call_id_replay.py
@@ -108,3 +108,63 @@ def test_mistral_native_ids_pass_through_unchanged():
     )
     assert call_id == "AbCdEfGhI"
     assert output_id == "AbCdEfGhI"
+
+
+# Anthropic states its charset in the 400 it raises:
+# "tool_use.id: String should match pattern '^[a-zA-Z0-9_-]+$'". A colon is not in it,
+# and two stored shapes carry one into a replay: the duplicate-base fallback above, which
+# keeps the whole "call_0:<uuid>", and the frontend's "<sandbox>:<thread>:<approval>"
+# confirmation ids, which have no uuid suffix to strip. Both are under 64 chars, so the
+# length branch never touched them and they went out verbatim.
+ANTHROPIC_ID = re.compile(r"[a-zA-Z0-9_-]+")
+
+
+def test_anthropic_rejects_nothing_it_would_have_rejected():
+    call_id, output_id = _replayed_ids(
+        "sandboxsess:threadid:approvalid", provider_type = "anthropic"
+    )
+    assert call_id == output_id
+    assert ANTHROPIC_ID.fullmatch(call_id), call_id
+
+
+def test_anthropic_colliding_bases_stay_legal_and_distinct():
+    a = "call_0:071e73c8-5d38-4d4c-821a-62fe32c7a54a"
+    b = "call_0:11111111-2222-4333-8444-555555555555"
+    out = _build_external_messages(
+        _history(a) + _history(b), supports_vision = True, provider_type = "anthropic"
+    )
+    call_ids = [m["tool_calls"][0]["id"] for m in out if m.get("tool_calls")]
+    output_ids = [m["tool_call_id"] for m in out if m["role"] == "tool"]
+    assert call_ids == output_ids
+    assert call_ids[0] != call_ids[1]
+    assert all(ANTHROPIC_ID.fullmatch(cid) for cid in call_ids), call_ids
+
+
+def test_anthropic_legal_ids_pass_through_unchanged():
+    # Only ids Anthropic would already have refused may change, so a chat that works
+    # today keeps byte-identical ids. toolu_ is its own issued shape.
+    for legal in ("toolu_01A1B2C3D4E5F6G7H8I9J0K1", "call_abc123", "a-b_c"):
+        call_id, output_id = _replayed_ids(legal, provider_type = "anthropic")
+        assert call_id == output_id == legal
+
+
+def test_anthropic_sanitizing_alone_would_collide():
+    # "pre:fix" and "pre_fix" both sanitize to "pre_fix". Pairing the wrong result with
+    # the wrong call is a silent wrong answer, so the sha256 tail over the unsanitized
+    # value is what keeps the map injective.
+    out = _build_external_messages(
+        _history("pre:fix") + _history("pre_fix"),
+        supports_vision = True,
+        provider_type = "anthropic",
+    )
+    call_ids = [m["tool_calls"][0]["id"] for m in out if m.get("tool_calls")]
+    assert len(set(call_ids)) == 2, call_ids
+
+
+def test_replay_is_idempotent_for_every_provider():
+    # A normalized id replayed again on turn three must not drift, or the call and its
+    # result stop matching. Feed each provider's own output back through it.
+    for provider in ("openai", "anthropic", "mistral", "gemini", "deepseek", None):
+        once, _ = _replayed_ids(MINTED, provider_type = provider)
+        twice, paired = _replayed_ids(once, provider_type = provider)
+        assert twice == once == paired, (provider, once, twice)

--- a/studio/backend/tests/test_external_tool_call_id_replay.py
+++ b/studio/backend/tests/test_external_tool_call_id_replay.py
@@ -32,9 +32,7 @@ def _history(tool_call_id):
                 ],
             }
         ),
-        ChatMessage.model_validate(
-            {"role": "tool", "tool_call_id": tool_call_id, "content": "ok"}
-        ),
+        ChatMessage.model_validate({"role": "tool", "tool_call_id": tool_call_id, "content": "ok"}),
     ]
 
 

--- a/studio/backend/tests/test_external_tool_call_id_replay.py
+++ b/studio/backend/tests/test_external_tool_call_id_replay.py
@@ -120,9 +120,7 @@ ANTHROPIC_ID = re.compile(r"[a-zA-Z0-9_-]+")
 
 
 def test_anthropic_rejects_nothing_it_would_have_rejected():
-    call_id, output_id = _replayed_ids(
-        "sandboxsess:threadid:approvalid", provider_type = "anthropic"
-    )
+    call_id, output_id = _replayed_ids("sandboxsess:threadid:approvalid", provider_type = "anthropic")
     assert call_id == output_id
     assert ANTHROPIC_ID.fullmatch(call_id), call_id
 

--- a/studio/backend/tests/test_external_tool_call_id_replay.py
+++ b/studio/backend/tests/test_external_tool_call_id_replay.py
@@ -80,6 +80,30 @@ def test_mistral_maps_foreign_ids_to_nine_alnum_chars():
         assert re.fullmatch(r"[a-zA-Z0-9]{9}", call_id)
 
 
+def test_colliding_bases_keep_the_full_stored_ids():
+    a = "call_0:071e73c8-5d38-4d4c-821a-62fe32c7a54a"
+    b = "call_0:11111111-2222-4333-8444-555555555555"
+    out = _build_external_messages(
+        _history(a) + _history(b), supports_vision = True, provider_type = "openai"
+    )
+    call_ids = [m["tool_calls"][0]["id"] for m in out if m.get("tool_calls")]
+    output_ids = [m["tool_call_id"] for m in out if m["role"] == "tool"]
+    assert call_ids == output_ids == [a, b]
+
+
+def test_mistral_colliding_bases_stay_distinct():
+    a = "call_0:071e73c8-5d38-4d4c-821a-62fe32c7a54a"
+    b = "call_0:11111111-2222-4333-8444-555555555555"
+    out = _build_external_messages(
+        _history(a) + _history(b), supports_vision = True, provider_type = "mistral"
+    )
+    call_ids = [m["tool_calls"][0]["id"] for m in out if m.get("tool_calls")]
+    output_ids = [m["tool_call_id"] for m in out if m["role"] == "tool"]
+    assert call_ids == output_ids
+    assert call_ids[0] != call_ids[1]
+    assert all(re.fullmatch(r"[a-zA-Z0-9]{9}", cid) for cid in call_ids)
+
+
 def test_mistral_native_ids_pass_through_unchanged():
     call_id, output_id = _replayed_ids(
         "AbCdEfGhI:071e73c8-5d38-4d4c-821a-62fe32c7a54a", provider_type = "mistral"

--- a/studio/backend/tests/test_external_tool_edge_cases.py
+++ b/studio/backend/tests/test_external_tool_edge_cases.py
@@ -687,9 +687,8 @@ def test_healed_ids_are_unique_across_turns(executed):
 def _healed_history(*call_ids):
     """A chat whose earlier turns already ran a healed call, as the route replays it.
 
-    The frontend stores a healed call as "<backend id>:<uuid4>", and the replay
-    normalization hands the bare base back whenever exactly one stored id claims
-    it, so this is the literal shape run.messages arrives in on the next request.
+    The replay normalization strips the stored "<backend id>:<uuid4>" back to the
+    bare base, so this is the shape run.messages arrives in on the next request.
     """
     out = [{"role": "user", "content": "search something"}]
     for call_id in call_ids:
@@ -721,12 +720,9 @@ def _replayed_ids(transport):
 def test_healed_ids_do_not_collide_with_replayed_history(executed):
     """The healer restarts at call_0 on a history that already replays a call_0.
 
-    The counter behind the healer's ids is per request, not per chat, so the
-    first turn of every request mints call_0 again. A history normalized down to
-    a bare call_0 therefore lands in the same upstream body as the new call: two
-    tool_use blocks under one id on Anthropic, a "Duplicate tool call id"
-    rejection from mistral-common, or a silently mispaired result where pairing
-    is positional. The cross-turn ledger cannot see it unless it starts from the
+    The counter behind the healer's ids is per request, not per chat, so a
+    history normalized down to a bare call_0 lands in the same upstream body as
+    the newly minted one. The ledger only catches that if it is seeded from the
     replayed history.
     """
     heal = '<tool_call>{"name": "web_search", "arguments": {"query": "b"}}</tool_call>'
@@ -747,11 +743,9 @@ def test_healed_ids_do_not_collide_with_replayed_history(executed):
 def test_history_rename_does_not_collide_again_on_the_next_request(executed):
     """The id the rename mints comes back as history, so it must not repeat.
 
-    Renaming to "<id>_<round>_<position>" once is not enough on its own: the
-    client stores that id too, and the request after it replays both call_0 and
-    call_0_1_0. A first turn healing a call would then be renamed onto the
-    call_0_1_0 already in the body, which is the same collision one request
-    later rather than a fix for it.
+    Renaming to "<id>_<round>_<position>" once is not enough: the client stores
+    that id too, so the next request replays both call_0 and call_0_1_0 and a
+    single-shot rename lands on the call_0_1_0 already in the body.
     """
     heal = '<tool_call>{"name": "web_search", "arguments": {"query": "c"}}</tool_call>'
     transport = FakeTransport(
@@ -770,9 +764,8 @@ def test_history_rename_does_not_collide_again_on_the_next_request(executed):
 def test_history_without_a_colliding_id_leaves_the_minted_id_alone(executed):
     """Seeding the ledger must not churn ids it has no reason to rename.
 
-    A renamed id is a worse id: it is longer, it is not what the provider
-    streamed, and it invalidates the card key the client already painted. So the
-    seeding has to be inert whenever the history does not actually claim the id.
+    A renamed id is longer, is not what the provider streamed, and invalidates
+    the card key the client already painted.
     """
     heal = '<tool_call>{"name": "web_search", "arguments": {"query": "d"}}</tool_call>'
     transport = FakeTransport(

--- a/studio/backend/tests/test_external_tool_edge_cases.py
+++ b/studio/backend/tests/test_external_tool_edge_cases.py
@@ -684,6 +684,109 @@ def test_healed_ids_are_unique_across_turns(executed):
     assert len(ids) == len(set(ids)), ids
 
 
+def _healed_history(*call_ids):
+    """A chat whose earlier turns already ran a healed call, as the route replays it.
+
+    The frontend stores a healed call as "<backend id>:<uuid4>", and the replay
+    normalization hands the bare base back whenever exactly one stored id claims
+    it, so this is the literal shape run.messages arrives in on the next request.
+    """
+    out = [{"role": "user", "content": "search something"}]
+    for call_id in call_ids:
+        out.append(
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": call_id,
+                        "type": "function",
+                        "function": {"name": "web_search", "arguments": '{"query": "a"}'},
+                    }
+                ],
+            }
+        )
+        out.append({"role": "tool", "tool_call_id": call_id, "content": "ok"})
+    out.append({"role": "user", "content": "now search again"})
+    return out
+
+
+def _replayed_ids(transport):
+    final = transport.requests[-1]["messages"]
+    calls = [call["id"] for m in final if m.get("tool_calls") for call in m["tool_calls"]]
+    results = [m["tool_call_id"] for m in final if m.get("role") == "tool"]
+    return calls, results
+
+
+def test_healed_ids_do_not_collide_with_replayed_history(executed):
+    """The healer restarts at call_0 on a history that already replays a call_0.
+
+    The counter behind the healer's ids is per request, not per chat, so the
+    first turn of every request mints call_0 again. A history normalized down to
+    a bare call_0 therefore lands in the same upstream body as the new call: two
+    tool_use blocks under one id on Anthropic, a "Duplicate tool call id"
+    rejection from mistral-common, or a silently mispaired result where pairing
+    is positional. The cross-turn ledger cannot see it unless it starts from the
+    replayed history.
+    """
+    heal = '<tool_call>{"name": "web_search", "arguments": {"query": "b"}}</tool_call>'
+    transport = FakeTransport(
+        [
+            [_sse({"content": heal}), _sse(finish = "stop"), _DONE],
+            _answer_turn(),
+        ]
+    )
+    _run(transport, messages = _healed_history("call_0"))
+
+    calls, results = _replayed_ids(transport)
+    assert calls == results, (calls, results)
+    assert len(calls) == len(set(calls)), calls
+    assert "call_0" in calls, calls
+
+
+def test_history_rename_does_not_collide_again_on_the_next_request(executed):
+    """The id the rename mints comes back as history, so it must not repeat.
+
+    Renaming to "<id>_<round>_<position>" once is not enough on its own: the
+    client stores that id too, and the request after it replays both call_0 and
+    call_0_1_0. A first turn healing a call would then be renamed onto the
+    call_0_1_0 already in the body, which is the same collision one request
+    later rather than a fix for it.
+    """
+    heal = '<tool_call>{"name": "web_search", "arguments": {"query": "c"}}</tool_call>'
+    transport = FakeTransport(
+        [
+            [_sse({"content": heal}), _sse(finish = "stop"), _DONE],
+            _answer_turn(),
+        ]
+    )
+    _run(transport, messages = _healed_history("call_0", "call_0_1_0"))
+
+    calls, results = _replayed_ids(transport)
+    assert calls == results, (calls, results)
+    assert len(calls) == len(set(calls)), calls
+
+
+def test_history_without_a_colliding_id_leaves_the_minted_id_alone(executed):
+    """Seeding the ledger must not churn ids it has no reason to rename.
+
+    A renamed id is a worse id: it is longer, it is not what the provider
+    streamed, and it invalidates the card key the client already painted. So the
+    seeding has to be inert whenever the history does not actually claim the id.
+    """
+    heal = '<tool_call>{"name": "web_search", "arguments": {"query": "d"}}</tool_call>'
+    transport = FakeTransport(
+        [
+            [_sse({"content": heal}), _sse(finish = "stop"), _DONE],
+            _answer_turn(),
+        ]
+    )
+    _run(transport, messages = _healed_history("call_9"))
+
+    calls, results = _replayed_ids(transport)
+    assert calls == results == ["call_9", "call_0"], (calls, results)
+
+
 def test_finish_reason_length_mid_tool_call_does_not_execute(executed):
     """Truncated arguments are not a call. Documented, current behaviour."""
     transport = FakeTransport(

--- a/studio/backend/tests/test_llama_cpp_wait_for_vram_settle.py
+++ b/studio/backend/tests/test_llama_cpp_wait_for_vram_settle.py
@@ -28,22 +28,19 @@ if _BACKEND_DIR not in sys.path:
 _loggers_stub = _types.ModuleType("loggers")
 _loggers_stub.get_logger = lambda name: __import__("logging").getLogger(name)
 # Same reasoning as httpx below: only when the real one is absent. With _BACKEND_DIR on
-# sys.path the in-repo loggers package resolves, and stubbing over it trips the
-# shadowing guard in test_backend_ci_parallel_isolation.py.
+# sys.path the in-repo loggers package resolves, and stubbing over it trips the shadowing
+# guard in test_backend_ci_parallel_isolation.py.
 #
-# Probed with find_spec rather than `import loggers`, for two reasons. The narrow one is
-# that an import bound purely to test resolvability leaves an unused module-level name,
-# which scripts/verify_import_hoist.py reads as a botched hoist. The load-bearing one is
-# that loggers/handlers.py imports structlog at module scope, and the structlog stub is
-# not installed until below: in the very environment this block exists for -- no real
-# structlog -- `import loggers` fails on the missing transitive dep, and the except branch
-# would stub over the real in-repo package, which is the shadowing this guard is meant to
-# prevent. find_spec answers "is it resolvable" without executing the module, so the
-# transitive dep cannot skew the answer. Same except clause as _is_installed() in
-# tests/studio/test_backend_ci_parallel_isolation.py: find_spec raises rather than
-# returning None for a missing parent, and ValueError when a prior test already put a
-# bare ModuleType (whose __spec__ is None) in sys.modules -- in which case the stub is
-# already there and setdefault is a no-op.
+# Probed with find_spec, not `import loggers`: an import bound purely to test
+# resolvability leaves an unused name that scripts/verify_import_hoist.py reads as a
+# botched hoist, and loggers/handlers.py imports structlog at module scope, whose stub is
+# not installed until below, so in the very environment this block exists for the import
+# would fail on that transitive dep and the except branch would stub over the real
+# package. find_spec answers "is it resolvable" without executing the module.
+#
+# Same except clause as _is_installed() in test_backend_ci_parallel_isolation.py:
+# find_spec raises for a missing parent, and ValueError when a prior test left a bare
+# ModuleType (__spec__ is None) in sys.modules, where the stub is already there anyway.
 try:
     _real_loggers = _importlib_util.find_spec("loggers") is not None
 except (ImportError, ValueError):

--- a/studio/backend/tests/test_llama_cpp_wait_for_vram_settle.py
+++ b/studio/backend/tests/test_llama_cpp_wait_for_vram_settle.py
@@ -10,6 +10,7 @@ nvidia-smi involved.
 
 from __future__ import annotations
 
+import importlib.util as _importlib_util
 import sys
 import time
 import types as _types
@@ -29,9 +30,25 @@ _loggers_stub.get_logger = lambda name: __import__("logging").getLogger(name)
 # Same reasoning as httpx below: only when the real one is absent. With _BACKEND_DIR on
 # sys.path the in-repo loggers package resolves, and stubbing over it trips the
 # shadowing guard in test_backend_ci_parallel_isolation.py.
+#
+# Probed with find_spec rather than `import loggers`, for two reasons. The narrow one is
+# that an import bound purely to test resolvability leaves an unused module-level name,
+# which scripts/verify_import_hoist.py reads as a botched hoist. The load-bearing one is
+# that loggers/handlers.py imports structlog at module scope, and the structlog stub is
+# not installed until below: in the very environment this block exists for -- no real
+# structlog -- `import loggers` fails on the missing transitive dep, and the except branch
+# would stub over the real in-repo package, which is the shadowing this guard is meant to
+# prevent. find_spec answers "is it resolvable" without executing the module, so the
+# transitive dep cannot skew the answer. Same except clause as _is_installed() in
+# tests/studio/test_backend_ci_parallel_isolation.py: find_spec raises rather than
+# returning None for a missing parent, and ValueError when a prior test already put a
+# bare ModuleType (whose __spec__ is None) in sys.modules -- in which case the stub is
+# already there and setdefault is a no-op.
 try:
-    import loggers  # noqa: F401
-except ImportError:
+    _real_loggers = _importlib_util.find_spec("loggers") is not None
+except (ImportError, ValueError):
+    _real_loggers = False
+if not _real_loggers:
     sys.modules.setdefault("loggers", _loggers_stub)
 
 _structlog_stub = _types.ModuleType("structlog")

--- a/studio/backend/tests/test_llama_cpp_wait_for_vram_settle.py
+++ b/studio/backend/tests/test_llama_cpp_wait_for_vram_settle.py
@@ -26,7 +26,13 @@ if _BACKEND_DIR not in sys.path:
 
 _loggers_stub = _types.ModuleType("loggers")
 _loggers_stub.get_logger = lambda name: __import__("logging").getLogger(name)
-sys.modules.setdefault("loggers", _loggers_stub)
+# Same reasoning as httpx below: only when the real one is absent. With _BACKEND_DIR on
+# sys.path the in-repo loggers package resolves, and stubbing over it trips the
+# shadowing guard in test_backend_ci_parallel_isolation.py.
+try:
+    import loggers  # noqa: F401
+except ImportError:
+    sys.modules.setdefault("loggers", _loggers_stub)
 
 _structlog_stub = _types.ModuleType("structlog")
 _structlog_stub.get_logger = lambda *a, **k: __import__("logging").getLogger("stub")

--- a/tests/studio/test_backend_ci_parallel_isolation.py
+++ b/tests/studio/test_backend_ci_parallel_isolation.py
@@ -151,8 +151,10 @@ BENIGN_TIMING = {
     # A 600-second expiry checked against the wall clock. Reading both sides of that gap
     # late by whole seconds still leaves it true, and it only reaches this scan at all
     # because the widened operand walk now reads `x > time.time()` as a bound.
-    ("test_openai_codex_subscription.py",
-     "test_account_claim_and_token_response_are_validated_without_returning_raw_body"),
+    (
+        "test_openai_codex_subscription.py",
+        "test_account_claim_and_token_response_are_validated_without_returning_raw_body",
+    ),
 }
 
 

--- a/tests/studio/test_backend_ci_parallel_isolation.py
+++ b/tests/studio/test_backend_ci_parallel_isolation.py
@@ -486,51 +486,6 @@ def test_the_scan_finds_all_three_shapes():
     )
 
 
-def test_a_find_spec_probe_counts_as_checking_first():
-    """The scan must accept both spellings of the guard, or it mandates the broken one.
-
-    Requiring a literal `import name` is what forced test_llama_cpp_wait_for_vram_settle
-    to import the in-repo `loggers` package to prove it exists. That package imports
-    structlog at module scope and the structlog stub is installed after it, so with no
-    real structlog the probe raises and the except branch stubs over the real package --
-    the exact shadowing this file exists to stop. It also leaves an unused module-level
-    name, which scripts/verify_import_hoist.py blocks, so the two rules could not both be
-    satisfied until the scan learned find_spec.
-    """
-    probed = _probed_via_find_spec(
-        ast.parse(
-            "import importlib.util as _iu\n"
-            "try:\n"
-            "    _real = _iu.find_spec('loggers') is not None\n"
-            "except (ImportError, ValueError):\n"
-            "    _real = False\n"
-        )
-    )
-    assert probed == {"loggers"}, probed
-
-    # Submodule probes reduce to their top-level name, the way the import scan does.
-    assert _probed_via_find_spec(ast.parse("importlib.util.find_spec('a.b.c')")) == {"a"}
-
-    # A non-constant argument names nothing the scan can credit, so it must not be
-    # silently treated as a guard for whatever is stubbed nearby.
-    assert _probed_via_find_spec(ast.parse("importlib.util.find_spec(name)")) == set()
-
-    # And the real file must now pass the scan by that route rather than by importing.
-    tree = ast.parse(
-        (BACKEND_TESTS / "test_llama_cpp_wait_for_vram_settle.py").read_text(encoding = "utf-8")
-    )
-    imported = {
-        alias.name.split(".")[0]
-        for node in ast.walk(tree)
-        if isinstance(node, ast.Import)
-        for alias in node.names
-    }
-    assert "loggers" not in imported, (
-        "the unused `import loggers` is back; verify_import_hoist.py blocks it"
-    )
-    assert "loggers" in _probed_via_find_spec(tree)
-
-
 def test_an_isolated_file_never_shadows_an_installed_library_with_a_stub():
     """A stub may stand in for a MISSING library, never for an installed one.
 
@@ -572,7 +527,6 @@ def test_an_isolated_file_never_shadows_an_installed_library_with_a_stub():
             if isinstance(node, ast.Import)
             for alias in node.names
         }
-        imported |= _probed_via_find_spec(tree)
         for stub in sorted(stubbed - imported):
             if _is_installed(stub):
                 offenders.setdefault(path.name, []).append(stub)
@@ -614,34 +568,6 @@ def _assigned_into_sys_modules(tree: ast.AST) -> set:
                 and isinstance(target.slice.value, str)
             ):
                 names.add(target.slice.value)
-    return names
-
-
-def _probed_via_find_spec(tree: ast.AST) -> set:
-    """Names checked with `importlib.util.find_spec("name")`, the other way to ask.
-
-    A bare `import name` is not the only honest guard, and for an in-repo package it is
-    the worse one. `loggers` imports structlog at module scope, so in the environment
-    these stubs exist for -- no real structlog -- `import loggers` fails on the missing
-    transitive dep and the except branch stubs over the real package, which is exactly
-    the shadowing this test is here to stop. find_spec answers "is it resolvable" without
-    executing the module, so a missing transitive dep cannot skew the answer.
-
-    It also leaves no unused module-level binding, which scripts/verify_import_hoist.py
-    reads as a botched hoist. Accepting both spellings is what lets a file satisfy this
-    test and that one at the same time.
-    """
-    names = set()
-    for node in ast.walk(tree):
-        if not isinstance(node, ast.Call):
-            continue
-        func = node.func
-        if not (isinstance(func, ast.Attribute) and func.attr == "find_spec"):
-            continue
-        if node.args and isinstance(node.args[0], ast.Constant):
-            value = node.args[0].value
-            if isinstance(value, str):
-                names.add(value.split(".")[0])
     return names
 
 

--- a/tests/studio/test_backend_ci_parallel_isolation.py
+++ b/tests/studio/test_backend_ci_parallel_isolation.py
@@ -486,6 +486,51 @@ def test_the_scan_finds_all_three_shapes():
     )
 
 
+def test_a_find_spec_probe_counts_as_checking_first():
+    """The scan must accept both spellings of the guard, or it mandates the broken one.
+
+    Requiring a literal `import name` is what forced test_llama_cpp_wait_for_vram_settle
+    to import the in-repo `loggers` package to prove it exists. That package imports
+    structlog at module scope and the structlog stub is installed after it, so with no
+    real structlog the probe raises and the except branch stubs over the real package --
+    the exact shadowing this file exists to stop. It also leaves an unused module-level
+    name, which scripts/verify_import_hoist.py blocks, so the two rules could not both be
+    satisfied until the scan learned find_spec.
+    """
+    probed = _probed_via_find_spec(
+        ast.parse(
+            "import importlib.util as _iu\n"
+            "try:\n"
+            "    _real = _iu.find_spec('loggers') is not None\n"
+            "except (ImportError, ValueError):\n"
+            "    _real = False\n"
+        )
+    )
+    assert probed == {"loggers"}, probed
+
+    # Submodule probes reduce to their top-level name, the way the import scan does.
+    assert _probed_via_find_spec(ast.parse("importlib.util.find_spec('a.b.c')")) == {"a"}
+
+    # A non-constant argument names nothing the scan can credit, so it must not be
+    # silently treated as a guard for whatever is stubbed nearby.
+    assert _probed_via_find_spec(ast.parse("importlib.util.find_spec(name)")) == set()
+
+    # And the real file must now pass the scan by that route rather than by importing.
+    tree = ast.parse(
+        (BACKEND_TESTS / "test_llama_cpp_wait_for_vram_settle.py").read_text(encoding = "utf-8")
+    )
+    imported = {
+        alias.name.split(".")[0]
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Import)
+        for alias in node.names
+    }
+    assert "loggers" not in imported, (
+        "the unused `import loggers` is back; verify_import_hoist.py blocks it"
+    )
+    assert "loggers" in _probed_via_find_spec(tree)
+
+
 def test_an_isolated_file_never_shadows_an_installed_library_with_a_stub():
     """A stub may stand in for a MISSING library, never for an installed one.
 
@@ -527,6 +572,7 @@ def test_an_isolated_file_never_shadows_an_installed_library_with_a_stub():
             if isinstance(node, ast.Import)
             for alias in node.names
         }
+        imported |= _probed_via_find_spec(tree)
         for stub in sorted(stubbed - imported):
             if _is_installed(stub):
                 offenders.setdefault(path.name, []).append(stub)
@@ -568,6 +614,34 @@ def _assigned_into_sys_modules(tree: ast.AST) -> set:
                 and isinstance(target.slice.value, str)
             ):
                 names.add(target.slice.value)
+    return names
+
+
+def _probed_via_find_spec(tree: ast.AST) -> set:
+    """Names checked with `importlib.util.find_spec("name")`, the other way to ask.
+
+    A bare `import name` is not the only honest guard, and for an in-repo package it is
+    the worse one. `loggers` imports structlog at module scope, so in the environment
+    these stubs exist for -- no real structlog -- `import loggers` fails on the missing
+    transitive dep and the except branch stubs over the real package, which is exactly
+    the shadowing this test is here to stop. find_spec answers "is it resolvable" without
+    executing the module, so a missing transitive dep cannot skew the answer.
+
+    It also leaves no unused module-level binding, which scripts/verify_import_hoist.py
+    reads as a botched hoist. Accepting both spellings is what lets a file satisfy this
+    test and that one at the same time.
+    """
+    names = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not (isinstance(func, ast.Attribute) and func.attr == "find_spec"):
+            continue
+        if node.args and isinstance(node.args[0], ast.Constant):
+            value = node.args[0].value
+            if isinstance(value, str):
+                names.add(value.split(".")[0])
     return names
 
 


### PR DESCRIPTION
Fixes #8913. The frontend stores tool-call ids as <provider id>:<uuid4> (66 chars for OpenAI), and replaying them breaks chats on providers that validate ids  OpenAI caps call_id at 64 chars (documented in openai/openai-openapi), Mistral requires 9 alphanumeric chars. After one tool-using turn, every later prompt fails with invalid_request_error until the tool messages are deleted. Local endpoints are unaffected (ids are inert template text), matching the report.

_build_external_messages now restores the provider's original id on replay and hash-shortens any other id over 64 chars (mirroring _codex_call_id), applied symmetrically to tool_calls[].id and tool_call_id so pairs stay matched. Already-broken threads recover automatically since normalization happens at send time.