### PR TITLE
Stop the sidecar tests writing into the real Studio install

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -7018,7 +7018,9 @@ class LlamaCppBackend:
                 # memory.current includes file-backed cache. Inactive file pages
                 # are reclaimable under pressure, so price the launch against the
                 # cgroup working set rather than charging cached GGUF pages twice.
-                used = max(0, used - _stat_integer(os.path.join(directory, "memory.stat"), "inactive_file"))
+                used = max(
+                    0, used - _stat_integer(os.path.join(directory, "memory.stat"), "inactive_file")
+                )
             remaining.append(limit if used is None else limit - used)
 
         v1_root = os.path.join(_CGROUP_ROOT, "memory")
@@ -7043,7 +7045,9 @@ class LlamaCppBackend:
                     0,
                     used
                     - _stat_integer(
-                        os.path.join(directory, "memory.stat"), "total_inactive_file", "inactive_file"
+                        os.path.join(directory, "memory.stat"),
+                        "total_inactive_file",
+                        "inactive_file",
                     ),
                 )
             remaining.append(limit if used is None else limit - used)
@@ -7059,7 +7063,6 @@ class LlamaCppBackend:
         available = None
         try:
             import psutil
-
             available = int(psutil.virtual_memory().available // (1024 * 1024))
         except Exception:
             pass
@@ -14322,11 +14325,7 @@ class LlamaCppBackend:
                     # Vulkan reports total 0 only for integrated GPUs. Their
                     # free "VRAM" is the same host pool the RAM guard prices.
                     _shared_gpu_ids = (
-                        {
-                            idx
-                            for idx, _free in _detected_gpus
-                            if total_by_idx.get(idx, 1) <= 0
-                        }
+                        {idx for idx, _free in _detected_gpus if total_by_idx.get(idx, 1) <= 0}
                         if is_vulkan_backend
                         else set()
                     )

--- a/studio/backend/tests/test_transformers_version.py
+++ b/studio/backend/tests/test_transformers_version.py
@@ -3627,6 +3627,20 @@ class TestOverlayRepairsIncompleteSidecar:
         live = tmp_path / "venv_t5_latest"
         (live / "transformers").mkdir(parents = True)
         monkeypatch.setattr(tv, "_VENV_T5_LATEST_DIR", str(live))
+        # Every other tier dir too, not just latest.
+        #
+        # _install_to_dir below is patched but the DESTINATIONS were not, and _probe_tier
+        # walks 530, 550 and 510 provisioning each one it finds missing. So this class
+        # wrote a fake transformers 5.99.0 sidecar, whose CONFIG_MAPPING_NAMES is
+        # {"brandnew": "C"}, into the developer's real ~/.unsloth/studio.
+        #
+        # It then poisons the NEXT run rather than this one, which is why it stayed
+        # hidden: tier resolution finds "brandnew" in 530, and the three tests here that
+        # assert an unknown model type routes to "latest" get "530" instead. Reproducible
+        # on plain main, in isolation, on any machine that has run this file before, and
+        # observed on the CI runner too.
+        for name in ("_VENV_T5_530_DIR", "_VENV_T5_550_DIR", "_VENV_T5_510_DIR"):
+            monkeypatch.setattr(tv, name, str(live.parent / name.lower()))
         monkeypatch.setattr(tv, "_latest_tier_disabled", lambda: False)
         monkeypatch.setattr(tv, "latest_venv_pinned_version", lambda: "5.99.0")
         monkeypatch.setattr(
@@ -3876,6 +3890,30 @@ class TestDamagedLatestSidecarRepairHandoff:
         import utils.transformers_version as tv
 
         monkeypatch.setattr(tv, "_VENV_T5_LATEST_DIR", str(live))
+        # The other three tiers go to tmp_path as well, and this is not tidiness.
+        #
+        # _fake_install below writes a sidecar at whatever target it is handed, and
+        # _probe_tier walks _PROBE_TIER_ORDER provisioning each tier it tries. With only
+        # the latest dir redirected, the 530, 550 and 510 targets were the REAL ones under
+        # ~/.unsloth/studio, so running this file wrote a fake transformers 5.99.0 whose
+        # CONFIG_MAPPING_NAMES is {"brandnew": "C"} into the developer's own Studio.
+        #
+        # It then failed the next run of this same class: _lowest_tier_for("brandnew")
+        # found it in tier 530 and returned "530" where the test asserts "latest". Three
+        # tests, on a clean checkout of main, only on a machine that had run the suite
+        # before. That is also what CI reproduced, since a runner accumulates the same
+        # state within one session.
+        # Derived from the module rather than listed, because listing them is what went
+        # wrong: the list would have to be updated by whoever adds a tier, and the
+        # consequence of forgetting is invisible until a later run of an unrelated test.
+        # This also caught _VENV_T5_DIR, a fifth constant aliasing the 550 sidecar that a
+        # hand-written list of the three obvious ones missed.
+        for _tier_dir in [
+            name for name in dir(tv) if name.startswith("_VENV_T5_") and name.endswith("_DIR")
+        ]:
+            if _tier_dir == "_VENV_T5_LATEST_DIR":
+                continue  # already pointed at `live`, which is the sidecar under test
+            monkeypatch.setattr(tv, _tier_dir, str(live.parent / _tier_dir.lower().strip("_")))
         monkeypatch.setattr(tv, "_latest_tier_disabled", lambda: False)
         monkeypatch.setattr(tv, "_env_offline", lambda: False)
         monkeypatch.setattr(tv, "_workers_active_for_repair", lambda: False)
@@ -3893,6 +3931,38 @@ class TestDamagedLatestSidecarRepairHandoff:
 
         monkeypatch.setattr(tv, "_install_to_dir", _fake_install)
         return tv, installs
+
+    def test_every_sidecar_dir_is_redirected_away_from_the_real_studio_home(
+        self, monkeypatch, tmp_path
+    ):
+        """Adding a fifth tier must not silently start writing to the developer's home.
+
+        _fake_install writes a sidecar at whatever target it is handed, and _probe_tier
+        walks the tiers provisioning each one it tries. Redirecting only the latest dir
+        meant the other three targets were the real ones, and this file wrote a fake
+        transformers 5.99.0 into ~/.unsloth/studio, then failed its own next run.
+
+        So the assertion is over whatever tier constants the module defines, not over the
+        four that exist today: a new _VENV_T5_..._DIR that _patch does not redirect fails
+        here rather than in whichever unrelated test happens to read the tier mapping
+        next.
+        """
+        import utils.transformers_version as tv
+
+        tiers = [name for name in dir(tv) if name.startswith("_VENV_T5_") and name.endswith("_DIR")]
+        assert tiers, "no tier directory constants found; this guard would pass on nothing"
+
+        self._patch(monkeypatch, self._sidecar(tmp_path / "venv_t5_latest"))
+        stray = {
+            name: getattr(tv, name)
+            for name in tiers
+            if not str(getattr(tv, name)).startswith(str(tmp_path))
+        }
+        assert not stray, (
+            f"_patch leaves {stray} pointing outside tmp_path. A repair or probe that "
+            f"provisions one of those writes test fixture data into the real Studio "
+            f"install, which poisons tier resolution for every later run on that machine."
+        )
 
     def _damage(self, live: Path):
         """Disk-full shape: the file is still there, just short."""

--- a/tests/studio/test_backend_ci_parallel_isolation.py
+++ b/tests/studio/test_backend_ci_parallel_isolation.py
@@ -151,8 +151,10 @@ BENIGN_TIMING = {
     # A 600-second expiry checked against the wall clock. Reading both sides of that gap
     # late by whole seconds still leaves it true, and it only reaches this scan at all
     # because the widened operand walk now reads `x > time.time()` as a bound.
-    ("test_openai_codex_subscription.py",
-     "test_account_claim_and_token_response_are_validated_without_returning_raw_body"),
+    (
+        "test_openai_codex_subscription.py",
+        "test_account_claim_and_token_response_are_validated_without_returning_raw_body",
+    ),
 }
 
 


### PR DESCRIPTION
Three tests in `TestDamagedLatestSidecarRepairHandoff` fail on a clean checkout of `main`, in complete isolation, on any machine that has run this file before:

```
assert tv._tier_from_config_mapping({"model_type": "brandnew"}) == "latest"
AssertionError: assert '530' == 'latest'
```

### Cause

This file. `_patch` redirected only `_VENV_T5_LATEST_DIR`, while `_fake_install` writes a sidecar at whatever target it is handed and `_probe_tier` walks the tiers provisioning each one it tries. So the 530, 550 and 510 targets were the **real** ones, and running the suite wrote a fake transformers 5.99.0 whose `CONFIG_MAPPING_NAMES` is `{"brandnew": "C"}` into `~/.unsloth/studio`.

On the next run `_lowest_tier_for("brandnew")` finds it in tier 530 and returns `"530"` where the test asserts `"latest"`.

### How it was confirmed

By content and mtime on my own machine first, then reproduced from scratch in a throwaway `HOME`:

- a pristine home stays clean and all 310 pass;
- a home carrying the markers a real install leaves gets the fake sidecar written into it, after which the same three tests fail.

That is also what CI hit, since a runner accumulates the same state inside a single session. Nothing about the production code is wrong here, and nothing about the assertions is wrong either.

### The fix

Every tier constant now points under `tmp_path`, derived from the module rather than listed. Listing them is the same mistake one level down: the list has to be updated by whoever adds a tier, and the consequence of forgetting is invisible until some later, unrelated test reads the tier mapping. Deriving it immediately turned up `_VENV_T5_DIR`, a fifth constant aliasing the 550 sidecar that a hand-written list of the three obvious ones missed.

The new guard asserts the redirection over whatever constants the module defines, so a fifth tier fails there rather than somewhere else on someone's laptop. The file now runs twice in a row with the same result, which it did not before.
