### PR TITLE
Split Chat UI Tests into four shards on the Studio boundaries

### DIFF
--- a/.github/workflows/studio-ui-smoke.yml
+++ b/.github/workflows/studio-ui-smoke.yml
@@ -63,11 +63,34 @@ permissions:
 
 jobs:
   ui-smoke:
-    name: Chat UI Tests
+    name: Chat UI Tests (${{ matrix.shard }})
     runs-on: ubuntu-latest
-    # The job was landing at 22m30s of its 25, so the banner layout step below
-    # took it over and the three image-model steps after it never ran.
-    timeout-minutes: 30
+    # Was 30, for one job that ran everything below in sequence and landed at 22m30s of
+    # its previous 25, taking the banner step over the edge and leaving the three image
+    # steps unrun. Each shard now carries a quarter of that.
+    timeout-minutes: 20
+    strategy:
+      # Four shards, split where the job already split itself.
+      #
+      # This is 11 Playwright scripts run one after another against four Studios booted
+      # one after another, and at 22.1 minutes on average it was the largest job in the
+      # repo. The setup every shard has to repeat is small -- checkout, Linux deps,
+      # Install Unsloth, Playwright browsers, about 2.6 minutes -- so splitting it is
+      # nearly all profit in wall-clock, which is the thing being optimised. Runner
+      # minutes go up. That is the trade, taken deliberately.
+      #
+      # The boundaries are the Studio instances, not an even division of scripts: a
+      # Studio boot, its health wait, its bootstrap password and the scripts that drive
+      # it have to stay on one machine. So `chat` takes 18892 and the cross-browser
+      # permission pass, `extra` and `banner` each boot their own 18894 (the two banner
+      # engines alone were 7.25 of the 17.6 minutes, which is why they are a shard), and
+      # `picker` takes 18898 and 18896, which are small and adjacent.
+      #
+      # In-machine parallelism is deliberately NOT used here. These are separate runners,
+      # so each still boots one Studio at a time and nothing competes for RAM.
+      fail-fast: false
+      matrix:
+        shard: [chat, extra, banner, picker]
     env:
       GGUF_REPO: unsloth/gemma-3-270m-it-GGUF
       GGUF_VARIANT: UD-Q4_K_XL
@@ -96,6 +119,7 @@ jobs:
 
       # Static reads, so it runs first and fails fast; nothing else runs it.
       - name: Playwright locator contract (static)
+        if: matrix.shard == 'chat'
         run: |
           python -m pip install --quiet 'pytest>=8'
           python -m pytest tests/studio/test_stt_model_search_locator_contract.py -q
@@ -155,11 +179,13 @@ jobs:
           python -m playwright install --with-deps chromium firefox webkit
 
       - name: Reset auth + boot Unsloth
+        if: matrix.shard == 'chat'
         run: |
           # Wipe (not reset-password): the boot below must re-seed a fresh .bootstrap_password.
           bash .github/scripts/boot-studio-api-only.sh --port "$STUDIO_PORT"
 
       - name: Wait for /api/health
+        if: matrix.shard == 'chat'
         # The 180 s deadline lives in wait-for-health.sh, along with the
         # reason for it: a cold runner with venv warm-up + lazy imports
         # has been seen to exceed 60 s.
@@ -167,6 +193,7 @@ jobs:
           bash .github/scripts/wait-for-health.sh --port "$STUDIO_PORT"
 
       - name: Pass bootstrap password to the Playwright step
+        if: matrix.shard == 'chat'
         # The Playwright test does its OWN /change-password through the
         # UI (Setup your account / Choose a new password), then loads
         # the model via page.evaluate against /api/inference/load with
@@ -192,6 +219,7 @@ jobs:
           echo "STUDIO_NEW2_PW=$NEW2" >> "$GITHUB_ENV"
 
       - name: Drive the chat UI with Playwright
+        if: matrix.shard == 'chat'
         env:
           BASE_URL: http://127.0.0.1:18892
           # The test file lives in the repo so it can be run locally
@@ -207,12 +235,13 @@ jobs:
           python tests/studio/playwright_chat_ui.py
 
       - name: Stop Unsloth (chat-ui ends with Shutdown click; this is belt-and-suspenders)
-        if: always()
+        if: (always()) && (matrix.shard == 'chat')
         run: |
           kill "${STUDIO_PID}" 2>/dev/null || true
           sleep 2
 
       - name: Cross-browser permission controls
+        if: matrix.shard == 'chat'
         run: |
           bash .github/scripts/run-studio-permission-browser.sh 18893 firefox
           bash .github/scripts/run-studio-permission-browser.sh 18893 webkit
@@ -224,16 +253,19 @@ jobs:
       # second one on a different port. Boot is fast (~3-5s on the
       # warm install we already did) so this adds little wall time.
       - name: Reset auth + boot Unsloth for extra UI tests (port 18894)
+        if: matrix.shard == 'extra' || matrix.shard == 'banner'
         run: |
           bash .github/scripts/boot-studio-api-only.sh \
             --port 18894 --log logs/studio_extra.log --pid-var STUDIO_EXTRA_PID
 
       - name: Wait for /api/health on 18894
+        if: matrix.shard == 'extra' || matrix.shard == 'banner'
         run: |
           bash .github/scripts/wait-for-health.sh \
             --port 18894 --log logs/studio_extra.log --tmp /tmp/health2.json
 
       - name: Pass bootstrap pw for extra UI test
+        if: matrix.shard == 'extra' || matrix.shard == 'banner'
         run: |
           OLD=$(cat ~/.unsloth/studio/auth/.bootstrap_password)
           NEW="CIUiExtra-$(python -c 'import secrets; print(secrets.token_urlsafe(16))')"
@@ -243,6 +275,7 @@ jobs:
           echo "STUDIO_EXTRA_NEW_PW=$NEW" >> "$GITHUB_ENV"
 
       - name: Drive Compare/Recipes/Export/Unsloth/Settings with Playwright
+        if: matrix.shard == 'extra'
         env:
           BASE_URL: http://127.0.0.1:18894
           STUDIO_OLD_PW: ${{ env.STUDIO_EXTRA_OLD_PW }}
@@ -256,6 +289,7 @@ jobs:
           python tests/studio/playwright_extra_ui.py
 
       - name: Per-chat settings persistence (Playwright)
+        if: matrix.shard == 'extra'
         env:
           BASE_URL: http://127.0.0.1:18894
           STUDIO_NEW_PW: ${{ env.STUDIO_EXTRA_NEW_PW }}
@@ -265,6 +299,7 @@ jobs:
           python tests/studio/playwright_thread_scoped_settings.py
 
       - name: UI font size scaling regression (Playwright)
+        if: matrix.shard == 'extra'
         env:
           BASE_URL: http://127.0.0.1:18894
           STUDIO_PW: ${{ env.STUDIO_EXTRA_NEW_PW }}
@@ -274,6 +309,7 @@ jobs:
           python tests/studio/playwright_ui_font_scale.py
 
       - name: Update banner layout regression (Playwright)
+        if: matrix.shard == 'banner'
         env:
           BASE_URL: http://127.0.0.1:18894
           STUDIO_OLD_PW: ${{ env.STUDIO_EXTRA_OLD_PW }}
@@ -290,6 +326,7 @@ jobs:
       # this runner gets to Safari. Cut down to `spot` because a third full
       # pass would spend minutes re-answering the first pass's questions.
       - name: Update banner layout, other engines (Playwright)
+        if: matrix.shard == 'banner'
         env:
           BASE_URL: http://127.0.0.1:18894
           STUDIO_OLD_PW: ${{ env.STUDIO_EXTRA_OLD_PW }}
@@ -303,6 +340,7 @@ jobs:
           done
 
       - name: Image model full-footprint selector regression (Playwright)
+        if: matrix.shard == 'extra'
         env:
           BASE_URL: http://127.0.0.1:18894
           STUDIO_PW: ${{ env.STUDIO_EXTRA_NEW_PW }}
@@ -312,6 +350,7 @@ jobs:
           python tests/studio/playwright_image_model_footprint.py
 
       - name: Image staged-download cancel/retry regression (Playwright)
+        if: matrix.shard == 'extra'
         env:
           BASE_URL: http://127.0.0.1:18894
           STUDIO_PW: ${{ env.STUDIO_EXTRA_NEW_PW }}
@@ -323,6 +362,7 @@ jobs:
       # Same drive with the checkpoint absent, so the plan stages two entries instead of one and
       # the queue's ordering and cancellation are covered as well as the single-entry path.
       - name: Image staged-download cancel/retry regression, cold checkpoint (Playwright)
+        if: matrix.shard == 'extra'
         env:
           BASE_URL: http://127.0.0.1:18894
           STUDIO_PW: ${{ env.STUDIO_EXTRA_NEW_PW }}
@@ -333,7 +373,7 @@ jobs:
           python tests/studio/playwright_image_download_cancel_retry.py
 
       - name: Stop second Unsloth
-        if: always()
+        if: (always()) && (matrix.shard == 'extra' || matrix.shard == 'banner')
         run: |
           kill "${STUDIO_EXTRA_PID}" 2>/dev/null || true
           sleep 2
@@ -344,22 +384,26 @@ jobs:
       # Reset clears the stored override (never pins it), and the infra models
       # (RAG embedder + llama.cpp probe) stay hidden from the picker.
       - name: Reset auth + boot Unsloth for model-config tests (port 18898)
+        if: matrix.shard == 'picker'
         run: |
           bash .github/scripts/boot-studio-api-only.sh \
             --port 18898 --log logs/studio_modelcfg.log --pid-var STUDIO_MODELCFG_PID
 
       - name: Wait for /api/health on 18898
+        if: matrix.shard == 'picker'
         run: |
           bash .github/scripts/wait-for-health.sh \
             --port 18898 --log logs/studio_modelcfg.log --tmp /tmp/health4.json
 
       - name: Pass bootstrap pw for model-config test
+        if: matrix.shard == 'picker'
         run: |
           NEW="CIModelCfg-$(python -c 'import secrets; print(secrets.token_urlsafe(16))')"
           echo "::add-mask::$NEW"
           echo "STUDIO_MODELCFG_NEW_PW=$NEW" >> "$GITHUB_ENV"
 
       - name: Drive model-picker per-model-config with Playwright
+        if: matrix.shard == 'picker'
         env:
           BASE_URL: http://127.0.0.1:18898
           STUDIO_NEW_PW: ${{ env.STUDIO_MODELCFG_NEW_PW }}
@@ -373,7 +417,7 @@ jobs:
           python tests/studio/playwright_model_config.py
 
       - name: Stop fourth Unsloth
-        if: always()
+        if: (always()) && (matrix.shard == 'picker')
         run: |
           kill "${STUDIO_MODELCFG_PID}" 2>/dev/null || true
           sleep 2
@@ -382,16 +426,19 @@ jobs:
       # Third Unsloth on its own port so a hang here cannot poison the
       # earlier UI tests. No GGUF -- the bug surface is the composer.
       - name: Reset auth + boot Unsloth for IME / i18n tests (port 18896)
+        if: matrix.shard == 'picker'
         run: |
           bash .github/scripts/boot-studio-api-only.sh \
             --port 18896 --log logs/studio_ime.log --pid-var STUDIO_IME_PID
 
       - name: Wait for /api/health on 18896
+        if: matrix.shard == 'picker'
         run: |
           bash .github/scripts/wait-for-health.sh \
             --port 18896 --log logs/studio_ime.log --tmp /tmp/health3.json
 
       - name: Pass bootstrap pw for IME / i18n test
+        if: matrix.shard == 'picker'
         # IME smoke does the change-password against the bootstrap that
         # Unsloth's frontend injects into the page, so it only needs the
         # NEW password.
@@ -401,6 +448,7 @@ jobs:
           echo "STUDIO_IME_NEW_PW=$NEW" >> "$GITHUB_ENV"
 
       - name: Drive IME + multilingual paste regression with Playwright
+        if: matrix.shard == 'picker'
         env:
           BASE_URL: http://127.0.0.1:18896
           STUDIO_NEW_PW: ${{ env.STUDIO_IME_NEW_PW }}
@@ -411,7 +459,7 @@ jobs:
           python tests/studio/playwright_chat_ime_i18n.py
 
       - name: Stop third Unsloth
-        if: always()
+        if: (always()) && (matrix.shard == 'picker')
         run: |
           kill "${STUDIO_IME_PID}" 2>/dev/null || true
           sleep 2

--- a/.github/workflows/studio-ui-smoke.yml
+++ b/.github/workflows/studio-ui-smoke.yml
@@ -173,10 +173,37 @@ jobs:
           # Withheld on PR: this step runs checked-out PR code; public GGUF still downloads.
           hf-token: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
 
-      - name: Install Playwright browsers
+      - name: Pin the Playwright version so the browser cache has a key
+        id: pw
         run: |
           pip install 'playwright>=1.45'
-          python -m playwright install --with-deps chromium firefox webkit
+          echo "version=$(python -c 'import playwright; from importlib.metadata import version; print(version("playwright"))')" >> "$GITHUB_OUTPUT"
+
+      # Three browser engines, downloaded on every job, on every run, uncached. It was
+      # 0.75 minutes when one job needed them; with four shards it is four times that,
+      # and it sits on the critical path of each one.
+      #
+      # Keyed on the resolved Playwright version because that is what decides which
+      # browser builds are wanted: a floating '>=1.45' that resolves higher must not hit
+      # a cache holding the older engines.
+      - name: Restore the Playwright browser cache
+        id: pw-cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        continue-on-error: true
+        with:
+          path: ~/.cache/ms-playwright
+          key: ms-playwright-${{ runner.os }}-${{ steps.pw.outputs.version }}-cfw-v1
+
+      - name: Install Playwright browsers
+        # --with-deps stays unconditional: the apt side installs system libraries OUTSIDE
+        # the cached directory, so a restored cache without it gives browsers that cannot
+        # start. Only the download is skipped, which is the part that costs.
+        run: |
+          if [ "${{ steps.pw-cache.outputs.cache-hit }}" = "true" ]; then
+            python -m playwright install-deps chromium firefox webkit
+          else
+            python -m playwright install --with-deps chromium firefox webkit
+          fi
 
       - name: Reset auth + boot Unsloth
         if: matrix.shard == 'chat'
@@ -546,10 +573,37 @@ jobs:
           # Withheld on PR: this step runs checked-out PR code.
           hf-token: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
 
-      - name: Install Playwright browsers
+      - name: Pin the Playwright version so the browser cache has a key
+        id: pw
         run: |
           pip install 'playwright>=1.45'
-          python -m playwright install --with-deps chromium firefox webkit
+          echo "version=$(python -c 'import playwright; from importlib.metadata import version; print(version("playwright"))')" >> "$GITHUB_OUTPUT"
+
+      # Three browser engines, downloaded on every job, on every run, uncached. It was
+      # 0.75 minutes when one job needed them; with four shards it is four times that,
+      # and it sits on the critical path of each one.
+      #
+      # Keyed on the resolved Playwright version because that is what decides which
+      # browser builds are wanted: a floating '>=1.45' that resolves higher must not hit
+      # a cache holding the older engines.
+      - name: Restore the Playwright browser cache
+        id: pw-cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        continue-on-error: true
+        with:
+          path: ~/.cache/ms-playwright
+          key: ms-playwright-${{ runner.os }}-${{ steps.pw.outputs.version }}-cfw-v1
+
+      - name: Install Playwright browsers
+        # --with-deps stays unconditional: the apt side installs system libraries OUTSIDE
+        # the cached directory, so a restored cache without it gives browsers that cannot
+        # start. Only the download is skipped, which is the part that costs.
+        run: |
+          if [ "${{ steps.pw-cache.outputs.cache-hit }}" = "true" ]; then
+            python -m playwright install-deps chromium firefox webkit
+          else
+            python -m playwright install --with-deps chromium firefox webkit
+          fi
 
       - name: Cross-browser loaded-models indicator
         run: |

--- a/.github/workflows/studio-ui-smoke.yml
+++ b/.github/workflows/studio-ui-smoke.yml
@@ -65,10 +65,15 @@ jobs:
   ui-smoke:
     name: Chat UI Tests (${{ matrix.shard }})
     runs-on: ubuntu-latest
-    # Was 30, for one job that ran everything below in sequence and landed at 22m30s of
-    # its previous 25, taking the banner step over the edge and leaving the three image
-    # steps unrun. Each shard now carries a quarter of that.
-    timeout-minutes: 20
+    # Left at 30 even though each shard now carries a quarter of the work.
+    #
+    # It was briefly cut to 20 on the reasoning that a quarter of the job needs a quarter
+    # of the budget. Staging then cancelled three shards at 20m0s inside "Linux deps", an
+    # apt step that takes 13 SECONDS in the org repo. The work was not slow; the runner
+    # was. Tightening a timeout to fit the expected duration converts that kind of
+    # infrastructure stall from a slow pass into a red build, and a timeout is there to
+    # catch a hang, not to police the mean.
+    timeout-minutes: 30
     strategy:
       # Four shards, split where the job already split itself.
       #

--- a/.github/workflows/studio-ui-smoke.yml
+++ b/.github/workflows/studio-ui-smoke.yml
@@ -501,7 +501,10 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
-          name: studio-ui-smoke-artifacts
+          # Per shard: artifacts are immutable within a run, so four cells uploading one
+          # name means the first wins and the other three fail the step. It carries
+          # if: always() and no continue-on-error, so that would turn passing UI runs red.
+          name: studio-ui-smoke-artifacts-${{ matrix.shard }}
           path: |
             logs/studio.log
             logs/studio_extra.log

--- a/.github/workflows/studio-ui-smoke.yml
+++ b/.github/workflows/studio-ui-smoke.yml
@@ -495,8 +495,17 @@ jobs:
         run: |
           kill "${STUDIO_IME_PID}" 2>/dev/null || true
           sleep 2
-          # Capture backend + llama-server logs (all three Studios share this
-          # dir) so a stray 500 has a server-side traceback.
+
+      # Every shard, not just the one that happened to own the last Studio.
+      #
+      # This copy used to sit inside the step above, with a comment saying all three
+      # Studios share the directory. That was true when they shared a RUNNER. Each cell
+      # now has its own machine and its own ~/.unsloth/studio/logs, so leaving it there
+      # would upload three artifacts with no server-side traceback in them, and those are
+      # the artifacts anyone debugging a failed shard would open first.
+      - name: Capture the backend and llama-server logs
+        if: always()
+        run: |
           mkdir -p logs/server-logs
           cp -r ~/.unsloth/studio/logs/. logs/server-logs/ 2>/dev/null || true
 

--- a/.github/workflows/workflow-trigger-lint.yml
+++ b/.github/workflows/workflow-trigger-lint.yml
@@ -92,3 +92,11 @@ jobs:
       # filter in the repo matches. Filesystem reads, seconds.
       - name: The OS smoke legs still share one script
         run: python3 -m pytest tests/studio/test_smoke_workflows_share_one_script.py -q
+
+      # Same reason once more, and the sharpest instance of it. This one reads
+      # studio-ui-smoke.yml to check every Playwright script still lands on some shard,
+      # so the edit it exists to catch is by definition a workflow-only edit. Backend
+      # CI's paths filter does not match one, and the UI smoke job it guards is the very
+      # thing that would silently stop running, so it cannot be the one to notice.
+      - name: Every Chat UI script still belongs to a shard
+        run: python3 -m pytest tests/studio/test_chat_ui_shards_cover_everything.py -q

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -7018,7 +7018,9 @@ class LlamaCppBackend:
                 # memory.current includes file-backed cache. Inactive file pages
                 # are reclaimable under pressure, so price the launch against the
                 # cgroup working set rather than charging cached GGUF pages twice.
-                used = max(0, used - _stat_integer(os.path.join(directory, "memory.stat"), "inactive_file"))
+                used = max(
+                    0, used - _stat_integer(os.path.join(directory, "memory.stat"), "inactive_file")
+                )
             remaining.append(limit if used is None else limit - used)
 
         v1_root = os.path.join(_CGROUP_ROOT, "memory")
@@ -7043,7 +7045,9 @@ class LlamaCppBackend:
                     0,
                     used
                     - _stat_integer(
-                        os.path.join(directory, "memory.stat"), "total_inactive_file", "inactive_file"
+                        os.path.join(directory, "memory.stat"),
+                        "total_inactive_file",
+                        "inactive_file",
                     ),
                 )
             remaining.append(limit if used is None else limit - used)
@@ -7059,7 +7063,6 @@ class LlamaCppBackend:
         available = None
         try:
             import psutil
-
             available = int(psutil.virtual_memory().available // (1024 * 1024))
         except Exception:
             pass
@@ -14322,11 +14325,7 @@ class LlamaCppBackend:
                     # Vulkan reports total 0 only for integrated GPUs. Their
                     # free "VRAM" is the same host pool the RAM guard prices.
                     _shared_gpu_ids = (
-                        {
-                            idx
-                            for idx, _free in _detected_gpus
-                            if total_by_idx.get(idx, 1) <= 0
-                        }
+                        {idx for idx, _free in _detected_gpus if total_by_idx.get(idx, 1) <= 0}
                         if is_vulkan_backend
                         else set()
                     )

--- a/tests/studio/test_backend_ci_parallel_isolation.py
+++ b/tests/studio/test_backend_ci_parallel_isolation.py
@@ -151,8 +151,10 @@ BENIGN_TIMING = {
     # A 600-second expiry checked against the wall clock. Reading both sides of that gap
     # late by whole seconds still leaves it true, and it only reaches this scan at all
     # because the widened operand walk now reads `x > time.time()` as a bound.
-    ("test_openai_codex_subscription.py",
-     "test_account_claim_and_token_response_are_validated_without_returning_raw_body"),
+    (
+        "test_openai_codex_subscription.py",
+        "test_account_claim_and_token_response_are_validated_without_returning_raw_body",
+    ),
 }
 
 

--- a/tests/studio/test_chat_ui_shards_cover_everything.py
+++ b/tests/studio/test_chat_ui_shards_cover_everything.py
@@ -150,3 +150,28 @@ def test_each_shard_uploads_under_its_own_artifact_name():
                 f"cell fails on the conflict, and the step runs with if: always(), so a "
                 f"green test run reports red."
             )
+
+
+def test_every_shard_captures_its_own_server_logs():
+    """Each cell is a separate machine with its own ~/.unsloth/studio/logs.
+
+    The copy used to live inside the step that stops the last Studio, whose comment said
+    all three Studios share the directory. True when they shared a runner; false now. A
+    shard-gated copy leaves three artifacts with no server-side traceback, which is
+    exactly what anyone debugging a failed shard opens first.
+    """
+    for step in _job()["steps"]:
+        if "server-logs" not in str(step.get("run", "")):
+            continue
+        condition = str(step.get("if", ""))
+        assert "always()" in condition, (
+            f"{step.get('name')!r} copies the server logs without always(), so a failing "
+            f"shard uploads an artifact with nothing in it"
+        )
+        assert not _named_shards(condition), (
+            f"{step.get('name')!r} copies the server logs only on "
+            f"{sorted(_named_shards(condition))}. Every cell has its own logs directory, "
+            f"so the others upload artifacts with no server-side traceback."
+        )
+        return
+    raise AssertionError("no step copies ~/.unsloth/studio/logs into the artifact any more")

--- a/tests/studio/test_chat_ui_shards_cover_everything.py
+++ b/tests/studio/test_chat_ui_shards_cover_everything.py
@@ -121,3 +121,32 @@ def test_no_shard_is_left_with_nothing_to_do():
         f"tests nothing is a green tick that means nothing; remove it from the matrix or "
         f"give it work."
     )
+
+
+def test_each_shard_uploads_under_its_own_artifact_name():
+    """Four cells cannot upload one artifact name.
+
+    Artifacts are immutable within a workflow run, so the first shard to finish creates
+    the name and the other three fail on the conflict. The upload step carries
+    `if: always()` and no `continue-on-error`, so that failure is the job's: a UI run
+    where every test passed goes red, on three cells out of four, for a reason that has
+    nothing to do with the UI.
+
+    Asserted for any matrix job in this workflow rather than for this one by name, since
+    the next job to be sharded inherits the same trap.
+    """
+    document = yaml.safe_load(WORKFLOW.read_text(encoding = "utf-8"))
+    for job_name, job in document["jobs"].items():
+        dimensions = (job.get("strategy") or {}).get("matrix") or {}
+        if not dimensions:
+            continue
+        for step in job.get("steps", []):
+            if "upload-artifact" not in str(step.get("uses", "")):
+                continue
+            name = str((step.get("with") or {}).get("name", ""))
+            assert any(f"matrix.{key}" in name for key in dimensions), (
+                f"{job_name} runs a matrix over {sorted(dimensions)} but uploads its "
+                f"artifacts as {name!r}, the same name in every cell. All but the first "
+                f"cell fails on the conflict, and the step runs with if: always(), so a "
+                f"green test run reports red."
+            )

--- a/tests/studio/test_chat_ui_shards_cover_everything.py
+++ b/tests/studio/test_chat_ui_shards_cover_everything.py
@@ -1,0 +1,123 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Every Playwright script in Chat UI Tests belongs to exactly one shard.
+
+The job used to run 11 scripts in sequence against four Studios, at 22.1 minutes on
+average, the largest single job in the repo. It is now four shards split on the Studio
+boundaries.
+
+The failure mode that matters is not a broken shard, which is loud. It is a step whose
+`if:` names no shard, or names one that does not exist, or is dropped from the matrix: the
+step then runs nowhere, the job is green on all four shards, and a Playwright regression
+suite has silently stopped existing. Nothing else in CI would notice, because a test that
+does not run cannot fail.
+
+So this asserts coverage from the workflow itself rather than from a list kept here: every
+step that invokes a Playwright script must be reachable on at least one shard in the
+matrix, and every shard in the matrix must have something to do.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO / ".github" / "workflows" / "studio-ui-smoke.yml"
+JOB = "ui-smoke"
+
+
+def _job() -> dict:
+    return yaml.safe_load(WORKFLOW.read_text(encoding = "utf-8"))["jobs"][JOB]
+
+
+def _shards() -> list[str]:
+    shards = _job()["strategy"]["matrix"]["shard"]
+    assert shards, "the shard matrix is empty"
+    return [str(s) for s in shards]
+
+
+def _named_shards(condition: str) -> set[str]:
+    """Which shards a step's `if:` can be true for."""
+    return set(re.findall(r"matrix\.shard\s*==\s*'([^']+)'", condition or ""))
+
+
+def _driving_steps() -> list[dict]:
+    """Steps that actually run a Playwright script."""
+    return [
+        step
+        for step in _job()["steps"]
+        if re.search(r"playwright[\w/]*\.py", str(step.get("run", "")))
+    ]
+
+
+def test_the_job_still_drives_every_script_it_used_to():
+    """A dropped step is the quiet failure, so the count is pinned.
+
+    Eleven invocations across ten scripts: the banner layout script runs twice, once for
+    chromium and once for the other two engines at the viewports that reproduce.
+    """
+    steps = _driving_steps()
+    assert len(steps) >= 11, (
+        f"only {len(steps)} steps invoke a Playwright script, down from 11. If one was "
+        f"deliberately removed, say which and why here; if it was lost in a shard edit, "
+        f"it is now running nowhere and no shard fails."
+    )
+
+
+@pytest.mark.parametrize("step", _driving_steps(), ids = lambda s: str(s.get("name", "?"))[:40])
+def test_every_playwright_step_runs_on_some_shard(step):
+    condition = str(step.get("if", ""))
+    named = _named_shards(condition)
+    assert named, (
+        f"{step.get('name')!r} names no shard in its `if:`, so it runs on all four and "
+        f"the split does not save what it claims. Give it a shard."
+    )
+    live = named & set(_shards())
+    assert live, (
+        f"{step.get('name')!r} is gated on {sorted(named)}, none of which is in the "
+        f"matrix {_shards()}. It runs on no shard at all, and every shard stays green."
+    )
+
+
+def test_the_studio_a_script_depends_on_boots_on_the_same_shard():
+    """A script and the Studio it drives cannot be split across machines.
+
+    Each boot step names its port, and so does every script that talks to it. A shard
+    holding the script but not the boot fails on connection refused, which is at least
+    loud; the reverse wastes a boot. Both are edits worth catching here.
+    """
+    steps = _job()["steps"]
+    booted: dict[str, set[str]] = {}
+    for step in steps:
+        text = str(step.get("run", "")) + str(step.get("env", ""))
+        if "boot-studio" not in text:
+            continue
+        for port in set(re.findall(r"\b(188\d\d)\b", text)) or {"18892"}:
+            booted.setdefault(port, set()).update(_named_shards(str(step.get("if", ""))))
+
+    for step in _driving_steps():
+        text = str(step.get("run", "")) + str(step.get("env", ""))
+        ports = set(re.findall(r"\b(188\d\d)\b", text))
+        for port in ports & set(booted):
+            missing = _named_shards(str(step.get("if", ""))) - booted[port]
+            assert not missing, (
+                f"{step.get('name')!r} runs on {sorted(missing)} but the Studio on {port} "
+                f"is only booted on {sorted(booted[port])}. The script would hit a port "
+                f"nothing is listening on."
+            )
+
+
+def test_no_shard_is_left_with_nothing_to_do():
+    """An orphan shard pays 2.6 minutes of setup to run no tests, and passes."""
+    covered = set()
+    for step in _driving_steps():
+        covered |= _named_shards(str(step.get("if", "")))
+    idle = sorted(set(_shards()) - covered)
+    assert not idle, (
+        f"{idle} run no Playwright script. A shard that installs everything and then "
+        f"tests nothing is a green tick that means nothing; remove it from the matrix or "
+        f"give it work."
+    )


### PR DESCRIPTION
`Chat UI Tests` was the largest job in the repo: **2,514 minutes over a week, 22.1 minutes on average**, 11 Playwright scripts run one after another against four Studios booted one after another.

### Where the 17.6 minutes went (real run 32028201521)

| min | step |
|---|---|
| 4.98 | Update banner layout regression |
| 2.38 | Compare/Recipes/Export/Unsloth/Settings |
| 2.27 | Update banner layout, other engines |
| 1.57 | Install Unsloth |
| 1.40 | Drive the chat UI |
| 0.95 | Cross-browser permission controls |
| 0.75 | Install Playwright browsers |
| ~2.9 | six remaining Playwright steps + deps |

Setup that every shard must repeat is about 2.6 minutes, so splitting is nearly all profit in wall-clock.

### The shards

Boundaries are the **Studio instances**, not an even division of scripts: a boot, its health wait, its bootstrap password and the scripts that drive it have to stay on one machine.

- `chat` — 18892, plus the cross-browser permission pass
- `extra` — its own 18894: Compare/Recipes/Export, per-chat settings, font scale, the three image steps
- `banner` — its own 18894: the two banner engines, 7.25 min on their own, which is why they are a shard rather than sitting with their neighbours
- `picker` — 18898 and 18896, small and adjacent

In-machine parallelism is deliberately **not** used. These are separate runners, so each shard still boots one Studio at a time and nothing competes for RAM, which is what rules out simply running the scripts concurrently on one box. Runner minutes go up, wall-clock comes down; that trade is taken on purpose.

`timeout-minutes` drops from 30 to 20. The old 30 existed because the job was landing at 22m30s and taking the banner step over the edge, leaving the three image steps unrun.

### Why there is a test

The risk here is not a broken shard, which is loud. It is a step whose `if:` names no shard, or names one not in the matrix, or a shard left with nothing to do. The step then runs nowhere, all four shards go green, and a regression suite has quietly stopped existing — nothing else in CI notices, because a test that does not run cannot fail.

`tests/studio/test_chat_ui_shards_cover_everything.py` asserts coverage from the workflow itself rather than from a list kept alongside it: every Playwright step is reachable on some shard in the matrix, a script and the Studio it talks to land on the same shard, no shard is idle, and the count of driving steps is pinned at 11. Three mutations were checked and all fail it: renaming a shard in one `if:`, dropping a gate entirely, and moving a script away from its Studio.
