### PR TITLE
Ask the repo, not sys.path, whether a stubbed name is third-party

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -7018,7 +7018,9 @@ class LlamaCppBackend:
                 # memory.current includes file-backed cache. Inactive file pages
                 # are reclaimable under pressure, so price the launch against the
                 # cgroup working set rather than charging cached GGUF pages twice.
-                used = max(0, used - _stat_integer(os.path.join(directory, "memory.stat"), "inactive_file"))
+                used = max(
+                    0, used - _stat_integer(os.path.join(directory, "memory.stat"), "inactive_file")
+                )
             remaining.append(limit if used is None else limit - used)
 
         v1_root = os.path.join(_CGROUP_ROOT, "memory")
@@ -7043,7 +7045,9 @@ class LlamaCppBackend:
                     0,
                     used
                     - _stat_integer(
-                        os.path.join(directory, "memory.stat"), "total_inactive_file", "inactive_file"
+                        os.path.join(directory, "memory.stat"),
+                        "total_inactive_file",
+                        "inactive_file",
                     ),
                 )
             remaining.append(limit if used is None else limit - used)
@@ -7059,7 +7063,6 @@ class LlamaCppBackend:
         available = None
         try:
             import psutil
-
             available = int(psutil.virtual_memory().available // (1024 * 1024))
         except Exception:
             pass
@@ -14322,11 +14325,7 @@ class LlamaCppBackend:
                     # Vulkan reports total 0 only for integrated GPUs. Their
                     # free "VRAM" is the same host pool the RAM guard prices.
                     _shared_gpu_ids = (
-                        {
-                            idx
-                            for idx, _free in _detected_gpus
-                            if total_by_idx.get(idx, 1) <= 0
-                        }
+                        {idx for idx, _free in _detected_gpus if total_by_idx.get(idx, 1) <= 0}
                         if is_vulkan_backend
                         else set()
                     )

--- a/tests/studio/test_backend_ci_parallel_isolation.py
+++ b/tests/studio/test_backend_ci_parallel_isolation.py
@@ -151,8 +151,10 @@ BENIGN_TIMING = {
     # A 600-second expiry checked against the wall clock. Reading both sides of that gap
     # late by whole seconds still leaves it true, and it only reaches this scan at all
     # because the widened operand walk now reads `x > time.time()` as a bound.
-    ("test_openai_codex_subscription.py",
-     "test_account_claim_and_token_response_are_validated_without_returning_raw_body"),
+    (
+        "test_openai_codex_subscription.py",
+        "test_account_claim_and_token_response_are_validated_without_returning_raw_body",
+    ),
 }
 
 

--- a/tests/studio/test_backend_ci_parallel_isolation.py
+++ b/tests/studio/test_backend_ci_parallel_isolation.py
@@ -569,14 +569,32 @@ def _assigned_into_sys_modules(tree: ast.AST) -> set:
     return names
 
 
-def _is_installed(name: str) -> bool:
-    """Whether a stub for this name would shadow something real.
+def _is_repo_module(name: str) -> bool:
+    """Whether studio/backend itself provides this name.
 
-    Anything the machinery cannot resolve counts as absent, including the errors it
-    raises rather than returning None for: an in-repo name such as `utils` or `loggers`
-    is importable only with studio/backend on sys.path, which this test does not have and
-    should not add.
+    `loggers`, `utils`, `routes` and friends are the backend's OWN modules. A test that
+    stands one of them up as a stub is not shadowing a third-party library, which is what
+    the check below is about; it is substituting for repo code on purpose.
     """
+    return (BACKEND_TESTS.parent / name).is_dir() or (BACKEND_TESTS.parent / f"{name}.py").is_file()
+
+
+def _is_installed(name: str) -> bool:
+    """Whether a stub for this name would shadow a real third-party library.
+
+    Asked of the REPO first, and that ordering is the whole fix. The previous version
+    asked importlib alone and reasoned that an in-repo name resolves only with
+    studio/backend on sys.path, "which this test does not have and should not add". That
+    was simply untrue in the job that runs it: under `pytest tests/ -n 4` from the repo
+    root, studio/backend does end up on sys.path, `loggers` resolved, and the guard
+    failed on main for a stub that shadows nothing. It passed locally, where the path
+    happens to differ, which is the worst shape a CI-only assertion can have.
+
+    So the question is answered from the tree, which is the same everywhere, and
+    importlib is consulted only for names the repo does not define.
+    """
+    if _is_repo_module(name):
+        return False
     try:
         return importlib.util.find_spec(name) is not None
     except (ImportError, ValueError):


### PR DESCRIPTION
The stub-shadowing guard added in #9095 is failing `Repo tests (CPU)` on `main`:

```
assert not {'test_llama_cpp_wait_for_vram_settle.py': ['loggers']}
```

`loggers` is the backend's **own** module. Stubbing it shadows nothing, and the guard exists for third-party libraries.

### The bug is the reasoning in its own docstring

It said an in-repo name resolves only with `studio/backend` on `sys.path`, "which this test does not have and should not add". That is untrue in the job that runs it: under `pytest tests/ -n 4` from the repo root, `studio/backend` does end up on `sys.path`, `find_spec("loggers")` resolves, and the guard fires on a stub doing nothing wrong.

It passed locally, where the path happens to differ. That is the worst shape a CI-only assertion can have, and it is why this reached `main`.

### The fix

Ask the tree, which is the same everywhere: if `studio/backend` defines the name, it is repo code, and a stub for it is substitution rather than shadowing. `importlib` is consulted only for names the repo does not define.

Reproduced both ways under the runner's path:

```
PYTHONPATH=studio/backend pytest ...::test_an_isolated_file_never_shadows_an_installed_library_with_a_stub
  before: AssertionError: ... {'test_llama_cpp_wait_for_vram_settle.py': ['loggers']}
  after:  1 passed
```
