### PR TITLE
Give each xdist worker its own torch.compile cache directory

### DIFF
--- a/studio/backend/tests/conftest.py
+++ b/studio/backend/tests/conftest.py
@@ -11,6 +11,22 @@ Model/variant for the managed mode resolve from ``--unsloth-model`` /
 ``--unsloth-gguf-variant``, then env vars, then ``test_studio_api.py`` defaults.
 """
 
+# --- torch.compile cache isolation -------------------------------------------------
+# Must run before torch is imported anywhere below, so it is here rather than in a
+# fixture. See tests/_shared/compile_cache_isolation.py for what it does and why.
+import importlib.util as _ilu  # noqa: E402
+import pathlib as _pathlib  # noqa: E402
+
+_iso = _pathlib.Path(__file__).resolve()
+for _up in _iso.parents:
+    _candidate = _up / "tests" / "_shared" / "compile_cache_isolation.py"
+    if _candidate.is_file():
+        _spec = _ilu.spec_from_file_location("_unsloth_compile_cache_isolation", _candidate)
+        _mod = _ilu.module_from_spec(_spec)
+        _spec.loader.exec_module(_mod)  # sets the env vars on import
+        break
+# -----------------------------------------------------------------------------------
+
 import contextlib
 import errno
 import itertools

--- a/tests/_shared/compile_cache_isolation.py
+++ b/tests/_shared/compile_cache_isolation.py
@@ -1,0 +1,69 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+
+"""Give every xdist worker its own torch.compile cache directory.
+
+The suites here run under `pytest -n 4`. Inductor's on-disk caches default to one
+directory per USER, not per process, so four workers on one runner share
+`/tmp/torchinductor_<user>` and its `fxgraph`, `aotautograd` and Triton subtrees. The
+upstream recipe is explicit that a common `TORCHINDUCTOR_CACHE_DIR` is what makes
+processes share compiled artifacts, so the way to stop them sharing is to give each one
+a different value.
+
+Sharing a cache between four concurrent compilers is not obviously wrong -- the entries
+are content-addressed -- but it is a write-write interaction between processes that
+nothing in this repo controls, and a cache is exactly the sort of thing that turns a
+deterministic suite into an intermittent one. Splitting it removes the interaction for
+the price of some recompilation.
+
+Measured before adding it, so nobody has to guess later what it bought: a full
+unsloth_zoo run against an empty, dedicated cache directory finished in 578s and left
+ZERO entries in it. That suite does not populate the on-disk cache at all, so for that
+step this is neither a saving nor a cost. It is insurance for the suites that do
+compile, and it is applied wherever tests run in parallel rather than only where a
+problem has already been seen.
+
+TRITON_CACHE_DIR is set explicitly rather than left to follow: it only derives from
+TORCHINDUCTOR_CACHE_DIR when it is unset, and an environment that already exports it
+would otherwise keep all four workers pointed at one Triton cache.
+
+Imported for its side effect from the conftest files, and it must run BEFORE torch is
+imported, which is why it is a module-level statement rather than a fixture.
+"""
+
+from __future__ import annotations
+
+import os
+import pathlib
+import tempfile
+
+WORKER_ENV = "PYTEST_XDIST_WORKER"
+
+
+def isolate_compile_caches() -> str | None:
+    """Point this worker's inductor and Triton caches at a directory of its own.
+
+    Returns the directory, or None when not running under xdist, where the process
+    already has the default to itself and there is nothing to separate.
+    """
+    worker = os.environ.get(WORKER_ENV)
+    if not worker:
+        return None
+
+    base = os.environ.get("TORCHINDUCTOR_CACHE_DIR")
+    if base:
+        # Respect an explicit choice of location, and split underneath it. Replacing it
+        # would move the cache somewhere the caller did not ask for, which matters when
+        # CI points it at a cached path on purpose.
+        root = pathlib.Path(base)
+    else:
+        root = pathlib.Path(tempfile.gettempdir()) / f"torchinductor_{os.environ.get('USER', 'ci')}"
+
+    mine = root / f"xdist_{worker}"
+    mine.mkdir(parents = True, exist_ok = True)
+    os.environ["TORCHINDUCTOR_CACHE_DIR"] = str(mine)
+    os.environ["TRITON_CACHE_DIR"] = str(mine / "triton")
+    return str(mine)
+
+
+isolate_compile_caches()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,22 @@ Mirrors the conftest harness in unslothai/unsloth-zoo PR #624.
 
 from __future__ import annotations
 
+# --- torch.compile cache isolation -------------------------------------------------
+# Must run before torch is imported anywhere below, so it is here rather than in a
+# fixture. See tests/_shared/compile_cache_isolation.py for what it does and why.
+import importlib.util as _ilu  # noqa: E402
+import pathlib as _pathlib  # noqa: E402
+
+_iso = _pathlib.Path(__file__).resolve()
+for _up in _iso.parents:
+    _candidate = _up / "tests" / "_shared" / "compile_cache_isolation.py"
+    if _candidate.is_file():
+        _spec = _ilu.spec_from_file_location("_unsloth_compile_cache_isolation", _candidate)
+        _mod = _ilu.module_from_spec(_spec)
+        _spec.loader.exec_module(_mod)  # sets the env vars on import
+        break
+# -----------------------------------------------------------------------------------
+
 import importlib.util
 import os
 import sys

--- a/tests/studio/test_compile_caches_are_per_worker.py
+++ b/tests/studio/test_compile_caches_are_per_worker.py
@@ -1,0 +1,104 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Parallel suites do not share one torch.compile cache directory.
+
+Inductor's on-disk caches default to one directory per USER, not per process, so four
+xdist workers on a runner would share `fxgraph`, `aotautograd` and the Triton cache
+underneath it. The upstream recipe is explicit that a common `TORCHINDUCTOR_CACHE_DIR`
+is how processes are made to SHARE compiled artifacts, so a different value per worker
+is how they are kept apart.
+
+Two things are asserted, and the second is the one that rots: that the splitting works,
+and that it is actually reached from the conftest of every suite that runs with `-n`. A
+helper nobody imports is the failure mode here, and it is silent.
+"""
+
+import importlib.util
+import os
+import re
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+HELPER = REPO / "tests" / "_shared" / "compile_cache_isolation.py"
+CONFTESTS = (REPO / "tests" / "conftest.py", REPO / "studio" / "backend" / "tests" / "conftest.py")
+WORKFLOW = REPO / ".github" / "workflows" / "studio-backend-ci.yml"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("compile_cache_isolation_under_test", HELPER)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_each_worker_gets_a_different_directory(monkeypatch, tmp_path):
+    monkeypatch.setenv("TORCHINDUCTOR_CACHE_DIR", str(tmp_path))
+    module = _load()
+
+    seen = set()
+    for worker in ("gw0", "gw1", "gw2", "gw3"):
+        monkeypatch.setenv("PYTEST_XDIST_WORKER", worker)
+        monkeypatch.setenv("TORCHINDUCTOR_CACHE_DIR", str(tmp_path))
+        module.isolate_compile_caches()
+        seen.add(os.environ["TORCHINDUCTOR_CACHE_DIR"])
+    assert len(seen) == 4, f"four workers landed on {len(seen)} directories: {sorted(seen)}"
+
+
+def test_triton_is_split_too(monkeypatch, tmp_path):
+    """It only follows TORCHINDUCTOR_CACHE_DIR when unset, so an environment that
+    exports it would otherwise keep every worker on one Triton cache."""
+    monkeypatch.setenv("TORCHINDUCTOR_CACHE_DIR", str(tmp_path))
+    monkeypatch.setenv("TRITON_CACHE_DIR", "/somewhere/shared")
+    monkeypatch.setenv("PYTEST_XDIST_WORKER", "gw1")
+    module = _load()
+    module.isolate_compile_caches()
+    assert os.environ["TRITON_CACHE_DIR"].startswith(os.environ["TORCHINDUCTOR_CACHE_DIR"]), (
+        f"TRITON_CACHE_DIR is {os.environ['TRITON_CACHE_DIR']}, outside this worker's "
+        f"inductor directory, so the Triton half is still shared"
+    )
+
+
+def test_a_single_process_run_is_left_alone(monkeypatch, tmp_path):
+    """No xdist, no split: one process already has the default to itself, and moving it
+    would drop whatever the environment deliberately pointed it at."""
+    monkeypatch.delenv("PYTEST_XDIST_WORKER", raising = False)
+    monkeypatch.setenv("TORCHINDUCTOR_CACHE_DIR", str(tmp_path))
+    module = _load()
+    assert module.isolate_compile_caches() is None
+    assert os.environ["TORCHINDUCTOR_CACHE_DIR"] == str(tmp_path)
+
+
+def test_an_explicit_location_is_split_underneath_not_replaced(monkeypatch, tmp_path):
+    """CI may point the cache at a path on purpose. The worker goes inside it."""
+    monkeypatch.setenv("TORCHINDUCTOR_CACHE_DIR", str(tmp_path / "chosen"))
+    monkeypatch.setenv("PYTEST_XDIST_WORKER", "gw0")
+    module = _load()
+    module.isolate_compile_caches()
+    assert os.environ["TORCHINDUCTOR_CACHE_DIR"].startswith(str(tmp_path / "chosen")), (
+        "an explicit TORCHINDUCTOR_CACHE_DIR was discarded rather than split underneath"
+    )
+
+
+@pytest.mark.parametrize("conftest", CONFTESTS, ids = lambda p: str(p.relative_to(REPO)))
+def test_every_parallel_suite_reaches_the_helper(conftest):
+    """The quiet failure: the helper exists, nothing imports it, and the caches merge
+    again with every test still green."""
+    assert conftest.is_file(), f"{conftest} is gone"
+    text = conftest.read_text(encoding = "utf-8")
+    assert "compile_cache_isolation" in text, (
+        f"{conftest.relative_to(REPO)} no longer loads the cache isolation helper, so its "
+        f"workers share one inductor directory again. Nothing else would report it."
+    )
+
+
+def test_the_suites_this_protects_really_do_run_in_parallel():
+    """If nothing runs with -n any more, this whole mechanism is dead weight and should
+    be deleted rather than left looking load-bearing."""
+    text = WORKFLOW.read_text(encoding = "utf-8")
+    assert re.search(r"pytest[^\n]*-n\s+\d", text), (
+        f"no parallel pytest invocation left in {WORKFLOW.name}; if the suites went back "
+        f"to one process, remove the isolation helper instead of keeping it around"
+    )


### PR DESCRIPTION
Inductor's on-disk caches default to one directory **per user**, not per process, so the four workers under `pytest -n 4` share `/tmp/torchinductor_<user>` and its `fxgraph`, `aotautograd` and Triton subtrees. The [upstream recipe](https://docs.pytorch.org/tutorials/recipes/torch_compile_caching_configuration_tutorial.html) is explicit that a common `TORCHINDUCTOR_CACHE_DIR` is what makes processes **share** compiled artifacts, so a different value per worker is how they are kept apart.

Sharing is not obviously wrong — the entries are content-addressed. It is still a write-write interaction between processes that nothing here controls, and a cache is exactly the sort of thing that turns a deterministic suite into an intermittent one. This removes the interaction for the price of some recompilation.

### What it buys, measured rather than assumed

A full `unsloth_zoo` run against an empty, dedicated cache directory:

```
COLD  578s   cache entries=0   size=0
WARM  503s   cache entries=0   size=0
```

That suite never populates the on-disk cache at all, so for the largest step in the Core legs this is neither a saving nor a cost — and the 75s cold/warm gap is page cache, not compilation, since there is nothing in the directory either time. Worth recording, because it also rules out persisting `TORCHINDUCTOR_CACHE_DIR` across CI runs for that suite: there is nothing to persist.

So this is insurance for the suites that *do* compile, applied wherever tests run in parallel rather than only where a problem has already been seen.

### Details that matter

- It runs as a module-level import in the two conftests, not a fixture, because it must take effect **before torch is imported**.
- `TRITON_CACHE_DIR` is set explicitly rather than left to follow: it only derives from the inductor directory when unset, and an environment that exports it would keep all four workers on one Triton cache.
- An explicit `TORCHINDUCTOR_CACHE_DIR` is split *underneath* rather than replaced, so a CI path chosen on purpose is respected.
- A single-process run is left alone entirely — it already has the default to itself.

### Verification

Under real xdist, not only unit tests: four workers report four distinct directories, and the parallel suites still pass. The guard also asserts that both conftests still reach the helper, because a helper nobody imports is the silent failure here.
