### PR TITLE
Delete a test that never ran, and stop another appearing

### DIFF
--- a/studio/backend/tests/test_safetensors_tool_loop.py
+++ b/studio/backend/tests/test_safetensors_tool_loop.py
@@ -117,19 +117,6 @@ class TestParser:
         assert result[0]["function"]["name"] == "python"
         assert "print('hi')" in result[0]["function"]["arguments"]
 
-    def test_xml_param_preserves_leading_indentation(self):
-        import json
-
-        # Only the wrapping newline is trimmed; code-argument indentation survives.
-        text = (
-            "<function=python><parameter=code>\n    indented = 1\n    more\n</parameter></function>"
-        )
-        result = parse_tool_calls_from_text(text)
-        assert len(result) == 1
-        assert json.loads(result[0]["function"]["arguments"]) == {
-            "code": "    indented = 1\n    more"
-        }
-
     def test_xml_unclosed(self):
         # Closing tags omitted; parser must still extract the value.
         text = "<function=terminal><parameter=command>ls -la"

--- a/tests/studio/test_no_test_shadows_another.py
+++ b/tests/studio/test_no_test_shadows_another.py
@@ -1,0 +1,71 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""No test function is defined twice in one scope.
+
+Python keeps the last definition. A test that shares a name with a later one in the same
+module or class is simply overwritten before pytest ever collects it: it appears in the
+file, it is maintained, it is reviewed, and it never runs. Nothing reports this. It is
+not a failure, not a skip, and not an error -- the test is absent, and absence is what
+green looks like.
+
+Found by sweeping all 23,895 test bodies in the repo for duplicates, which turned up
+exactly one: TestParser.test_xml_param_preserves_leading_indentation in
+test_safetensors_tool_loop.py, defined at lines 120 and 156, where the first was dead.
+One in the whole tree is a good result, and it is cheap to keep it at one.
+
+Scoped to module level and class level, which is where pytest collects from. A function
+nested inside another function is not collected either way, so it is not this test's
+business.
+"""
+
+import ast
+import collections
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+ROOTS = ("tests", "studio/backend/tests", "unsloth_cli/tests")
+SKIP_PARTS = ("vendor", "node_modules", "__pycache__", ".venv")
+
+
+def _shadowed() -> list[str]:
+    found = []
+    for root in ROOTS:
+        base = REPO / root
+        if not base.is_dir():
+            continue
+        for path in sorted(base.rglob("test_*.py")):
+            if any(part in SKIP_PARTS for part in path.parts):
+                continue
+            try:
+                tree = ast.parse(path.read_text(encoding = "utf-8", errors = "replace"))
+            except SyntaxError:
+                continue  # a file that does not parse is a different problem, loudly
+            scopes = [("module", tree.body)]
+            scopes += [(n.name, n.body) for n in tree.body if isinstance(n, ast.ClassDef)]
+            for scope, body in scopes:
+                defined = [
+                    n for n in body
+                    if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
+                    and n.name.startswith("test")
+                ]
+                counts = collections.Counter(n.name for n in defined)
+                for name, count in counts.items():
+                    if count > 1:
+                        lines = [n.lineno for n in defined if n.name == name]
+                        found.append(
+                            f"{path.relative_to(REPO)}::{scope}::{name} at lines {lines} "
+                            f"(only line {lines[-1]} runs)"
+                        )
+    return found
+
+
+def test_no_test_is_overwritten_by_a_later_definition():
+    offenders = _shadowed()
+    assert not offenders, (
+        "these tests are shadowed by a later definition of the same name, so every one "
+        "of them but the last is dead code that pytest never collects:\n  "
+        + "\n  ".join(offenders)
+        + "\n\nRename them if they test different things, or delete the redundant copy. "
+        "Leaving it is the worst option: it reads as coverage and provides none."
+    )


### PR DESCRIPTION
`TestParser.test_xml_param_preserves_leading_indentation` was defined **twice** in `test_safetensors_tool_loop.py`, at lines 120 and 156. Python keeps the last definition, so the first was overwritten before pytest ever collected it: present in the file, maintained, reviewed, and never run.

Nothing reports that. It is not a failure, not a skip, not an error. The test is absent, and absence is what green looks like.

The two bodies were equivalent, so no coverage is lost by removing the dead one. The surviving copy relies on the module-level `json` import rather than a local one, which is why only it works standalone.

### How it was found, and what else the sweep said

By fingerprinting all **23,895** test bodies in the repo and looking for duplicates. Exactly **one** shadowed definition in the whole tree — a good result, and cheap to keep at one, so the sweep is now a test. It looks at module and class scope, which is where pytest collects from; a function nested inside a function is not collected either way and is not its business.

Two results from the same sweep that argue *against* changes rather than for them, recorded so nobody has to redo the work:

- **72 test bodies out of 23,895 are byte-identical to another — 0.3%**, and almost all are two-statement tests applying one assertion to different subjects from different classes. There is no CI time to be had in de-duplicating them.
- The first version of the sweep ignored decorators and reported 104, including three tests in `test_control_markup_neutralize_7066.py` whose bodies are identical and whose `@pytest.mark.parametrize` supplies different schemas. Deleting two of those would have removed real coverage with every remaining test still green. The fingerprint now includes decorators.
