### PR TITLE
Studio: overturn a chat-only MLX verdict the stack contradicts (#9120)

### DIFF
--- a/studio/backend/tests/test_mlx_repair.py
+++ b/studio/backend/tests/test_mlx_repair.py
@@ -2,13 +2,15 @@
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
 """MLX self-heal: on Apple Silicon with MLX missing, reinstall it by name on a
-background thread (off the startup critical path). No-op elsewhere / when present
-/ when disabled. Models on core.training.worker's runtime backend self-heal.
+background thread (off the startup critical path). No-op elsewhere. A present stack is
+not a no-op: it overturns a chat-only verdict that contradicts it, including for a user
+who has disabled the reinstall. Models on core.training.worker's runtime backend self-heal.
 """
 
 from __future__ import annotations
 
 import sys
+import threading
 from pathlib import Path
 
 import pytest
@@ -23,7 +25,21 @@ import utils.mlx_repair as mr  # noqa: E402
 @pytest.fixture(autouse = True)
 def _reset_attempt_guard(monkeypatch):
     monkeypatch.setattr(mr, "_attempted", False)
+    # Both halves of the repair's one-time state, or a worker started by one test reaches
+    # _run_repair_and_redetect's "the install ran" branch on a latch an earlier test left
+    # set, and re-detects for real against whatever the next test is publishing.
+    monkeypatch.setattr(mr, "_environment_mutated", False)
     monkeypatch.delenv(mr.DISABLE_ENV_VAR, raising = False)
+    yield
+    # Still inside the stubs the test installed: a daemon worker outliving its own test
+    # would otherwise run the real detect_hardware() against the next one's globals.
+    for thread in threading.enumerate():
+        if thread.name == "mlx-autorepair":
+            thread.join(timeout = 5)
+            assert not thread.is_alive(), (
+                "an mlx-autorepair worker outlived its test; once these stubs are "
+                "restored it runs the real repair and detection against another test"
+            )
 
 
 def test_uv_cmd_targets_this_interpreter_with_mlx_packages(monkeypatch):
@@ -470,3 +486,233 @@ def test_an_unresolvable_interpreter_is_diagnosed_not_retried(monkeypatch, tmp_p
     assert (
         "--target" not in flat and "--prefix" not in flat
     ), f"a corrupting install target reached the uv command line: {flat}"
+
+
+# ── Overturning a verdict a first-import race left behind (issue #9120) ───────
+
+
+def _published_verdict(monkeypatch, *, chat_only: bool, reason):
+    """Publish a settled verdict, and re-detect into a usable MLX host when forced.
+
+    Settled means a device and a set event beside the reason -- a chat-only Mac measured
+    its way to CPU, not to nothing -- or a success check that ignores the verdict itself
+    would pass. The publication state is this test's own, so nothing leaks to the next."""
+    import utils.hardware.hardware as hw
+
+    settled = threading.Event()
+    settled.set()
+    monkeypatch.setattr(hw, "DEVICE", hw.DeviceType.CPU if chat_only else hw.DeviceType.MLX)
+    monkeypatch.setattr(hw, "CHAT_ONLY", chat_only)
+    monkeypatch.setattr(hw, "CHAT_ONLY_REASON", reason)
+    monkeypatch.setattr(hw, "DETECTION_COMPLETE", settled)
+    monkeypatch.setattr(hw, "DETECTION_GENERATION", 0)
+
+    redetects = []
+
+    def _redetect():
+        redetects.append(1)
+        hw.DEVICE, hw.CHAT_ONLY, hw.CHAT_ONLY_REASON = hw.DeviceType.MLX, False, None
+        return hw.DEVICE
+
+    monkeypatch.setattr(hw, "_detect_hardware_locked", _redetect)
+    return redetects
+
+
+def _recorded_announcements(monkeypatch):
+    lines = []
+
+    class _Recorder:
+        def info(self, message, *args, **kwargs):
+            lines.append(message)
+
+        def __getattr__(self, _name):
+            return lambda *a, **k: None
+
+    monkeypatch.setattr(mr, "logger", _Recorder())
+    return lines
+
+
+def _join_the_repair_worker():
+    """A repair runs on a daemon thread; assertions about it must not race it."""
+    for thread in threading.enumerate():
+        if thread.name == "mlx-autorepair":
+            thread.join(timeout = 5)
+            assert not thread.is_alive()
+
+
+def test_a_stack_that_measures_usable_overturns_the_verdict(monkeypatch):
+    # The #9120 shape: detection lost a first-import race as the warm's first stage and
+    # cached chat-only; the stack the warm has since finished importing is fine.
+    import utils.hardware.hardware as hw
+
+    monkeypatch.setattr(mr, "is_apple_silicon", lambda: True)
+    monkeypatch.setattr(mr, "mlx_stack_available", lambda: True)
+    redetects = _published_verdict(monkeypatch, chat_only = True, reason = "mlx_unavailable")
+    announced = _recorded_announcements(monkeypatch)
+
+    assert mr.start_mlx_autorepair_if_needed() is False
+    assert len(redetects) == 1, "the verdict the stack contradicts was left published"
+    assert (hw.DEVICE, hw.CHAT_ONLY, hw.CHAT_ONLY_REASON) == (hw.DeviceType.MLX, False, None)
+    assert any("Train/Export are back" in line for line in announced)
+
+
+def test_a_stack_that_is_really_unusable_keeps_its_verdict(monkeypatch):
+    # The two agree, so there is nothing transient to overturn and the reinstall is what
+    # may still change the answer.
+    monkeypatch.setattr(mr, "is_apple_silicon", lambda: True)
+    monkeypatch.setattr(mr, "mlx_stack_available", lambda: False)
+    monkeypatch.setattr(mr, "attempt_mlx_repair", lambda **_k: False)
+    redetects = _published_verdict(monkeypatch, chat_only = True, reason = "mlx_unavailable")
+
+    assert mr.start_mlx_autorepair_if_needed() is True
+    _join_the_repair_worker()
+    assert redetects == []
+
+
+def test_a_settled_verdict_that_does_not_blame_mlx_is_left_alone(monkeypatch):
+    # A Mac that is chat-only for another reason, and a healthy boot that is not chat-only
+    # at all, were both measured by something this cannot re-run.
+    monkeypatch.setattr(mr, "is_apple_silicon", lambda: True)
+    monkeypatch.setattr(mr, "mlx_stack_available", lambda: True)
+
+    for chat_only, reason in ((True, "no_gpu"), (False, None)):
+        redetects = _published_verdict(monkeypatch, chat_only = chat_only, reason = reason)
+        assert mr.start_mlx_autorepair_if_needed() is False
+        assert redetects == [], f"re-detected over a {reason!r} verdict"
+
+
+def test_declining_the_reinstall_does_not_mean_keeping_a_wrong_verdict(monkeypatch):
+    # UNSLOTH_DISABLE_MLX_AUTOREPAIR opts out of changing the environment. Re-detecting
+    # changes nothing on disk, so the opt-out must not cost this user the fix.
+    monkeypatch.setenv(mr.DISABLE_ENV_VAR, "1")
+    monkeypatch.setattr(mr, "is_apple_silicon", lambda: True)
+    monkeypatch.setattr(mr, "mlx_stack_available", lambda: True)
+    redetects = _published_verdict(monkeypatch, chat_only = True, reason = "mlx_unavailable")
+
+    assert mr.start_mlx_autorepair_if_needed() is False
+    assert len(redetects) == 1
+
+
+@pytest.mark.parametrize("usable", (True, False))
+def test_the_stack_is_measured_once_before_the_decision(monkeypatch, usable):
+    """Two measurements would disagree with each other, not only with the verdict: a "not
+    usable" read followed by a "usable" one leaves the verdict standing with no reinstall
+    attempted and nothing left to revisit it."""
+    monkeypatch.setattr(mr, "is_apple_silicon", lambda: True)
+    monkeypatch.setattr(mr, "attempt_mlx_repair", lambda **_k: False)
+    _published_verdict(monkeypatch, chat_only = True, reason = "mlx_unavailable")
+    probes = []
+    monkeypatch.setattr(mr, "mlx_stack_available", lambda: probes.append(1) or usable)
+
+    mr.start_mlx_autorepair_if_needed()
+    _join_the_repair_worker()
+    assert probes == [1]
+
+
+def test_the_overturn_cannot_republish_into_a_stopped_lifespan(monkeypatch):
+    """detect_hardware() reads the current epoch when it owns none, so an unscoped
+    re-detect would adopt the one shutdown moved to and publish for a lifespan that had
+    ended, which the next lifespan then inherits instead of measuring for itself."""
+    import utils.hardware.hardware as hw
+
+    monkeypatch.setattr(mr, "is_apple_silicon", lambda: True)
+    _published_verdict(monkeypatch, chat_only = True, reason = "mlx_unavailable")
+    settled = (hw.DEVICE, hw.CHAT_ONLY, hw.CHAT_ONLY_REASON)
+
+    def _measure_while_shutdown_lands():
+        hw.invalidate_detection()
+        return True
+
+    monkeypatch.setattr(mr, "mlx_stack_available", _measure_while_shutdown_lands)
+
+    assert mr.start_mlx_autorepair_if_needed() is False
+    assert (
+        hw.DEVICE,
+        hw.CHAT_ONLY,
+        hw.CHAT_ONLY_REASON,
+    ) == settled, "a retired lifespan's re-detect was published"
+
+
+def test_a_redetect_that_publishes_nothing_is_not_announced(monkeypatch):
+    """Shutdown can retire the lifespan before the pass starts or under it once started;
+    either way nothing is published. Issue #9120 was diagnosed entirely from these lines,
+    so one claiming a recovery that did not happen is worse than silence."""
+    import utils.hardware.hardware as hw
+
+    monkeypatch.setattr(mr, "is_apple_silicon", lambda: True)
+    _published_verdict(monkeypatch, chat_only = True, reason = "mlx_unavailable")
+    announced = _recorded_announcements(monkeypatch)
+
+    def _measure_while_shutdown_lands():
+        hw.invalidate_detection()
+        return True
+
+    monkeypatch.setattr(mr, "mlx_stack_available", _measure_while_shutdown_lands)
+
+    assert mr.start_mlx_autorepair_if_needed() is False
+    assert announced == [], f"announced an overturn that never published: {announced}"
+
+    # Retired mid-probe instead: the pass discards the healthy answer it just produced and
+    # leaves the reason cleared, which a check phrased as "no longer the MLX verdict" reads
+    # as a win.
+    hw.DEVICE, hw.CHAT_ONLY, hw.CHAT_ONLY_REASON = None, True, "mlx_unavailable"
+    hw.DETECTION_COMPLETE.set()
+
+    def _retired_under_the_probe():
+        hw.invalidate_detection()
+        hw.DEVICE, hw.CHAT_ONLY, hw.CHAT_ONLY_REASON = hw.DeviceType.MLX, False, None
+        return hw.DEVICE
+
+    monkeypatch.setattr(hw, "_detect_hardware_locked", _retired_under_the_probe)
+
+    assert hw.overturn_the_mlx_verdict(hw.current_detection_epoch()) is False
+    assert (hw.DEVICE, hw.CHAT_ONLY) == (None, True), "the discarded pass left state behind"
+
+    # And shutdown itself clears DEVICE, then the event, then the verdict, unlocked: a read
+    # between the first two sees a set event beside a device already gone.
+    hw.DEVICE, hw.CHAT_ONLY, hw.CHAT_ONLY_REASON = None, True, "mlx_unavailable"
+    hw.DETECTION_COMPLETE.set()
+
+    def _torn_by_a_concurrent_shutdown():
+        hw.DEVICE, hw.CHAT_ONLY, hw.CHAT_ONLY_REASON = None, False, None
+        hw.DETECTION_COMPLETE.set()
+        return None
+
+    monkeypatch.setattr(hw, "_detect_hardware_locked", _torn_by_a_concurrent_shutdown)
+
+    assert hw.overturn_the_mlx_verdict(hw.current_detection_epoch()) is False
+
+
+def test_an_opted_out_host_with_nothing_to_overturn_imports_nothing(monkeypatch):
+    """Under the warm's own kill switch join_background_warm() is a no-op, so detection has
+    not run and this would be the process's first MLX import. Opting out of the reinstall
+    is what makes that import buy nothing."""
+    monkeypatch.setenv(mr.DISABLE_ENV_VAR, "1")
+    monkeypatch.setattr(mr, "is_apple_silicon", lambda: True)
+    _published_verdict(monkeypatch, chat_only = True, reason = None)
+    monkeypatch.setattr(mr, "mlx_stack_available", lambda: pytest.fail("imported MLX for no one"))
+
+    assert mr.start_mlx_autorepair_if_needed() is False
+
+
+def test_the_repair_worker_is_scoped_to_the_epoch_read_before_the_measurement(monkeypatch):
+    """The measurement imports the MLX runtime, so shutdown can land inside it: reading the
+    epoch afterwards would bind the repair to the one shutdown moved to."""
+    import utils.hardware.hardware as hw
+
+    monkeypatch.setattr(mr, "is_apple_silicon", lambda: True)
+    _published_verdict(monkeypatch, chat_only = True, reason = "mlx_unavailable")
+    before = hw.current_detection_epoch()
+
+    def _measure_while_shutdown_lands():
+        hw.invalidate_detection()
+        return False
+
+    monkeypatch.setattr(mr, "mlx_stack_available", _measure_while_shutdown_lands)
+    scoped_to = []
+    monkeypatch.setattr(mr, "_run_repair_and_redetect", lambda epoch = None: scoped_to.append(epoch))
+
+    assert mr.start_mlx_autorepair_if_needed() is True
+    _join_the_repair_worker()
+    assert scoped_to == [before]
+    assert hw.current_detection_epoch() != before, "the shutdown under test never happened"

--- a/studio/backend/utils/hardware/hardware.py
+++ b/studio/backend/utils/hardware/hardware.py
@@ -362,6 +362,36 @@ def verdict_pending_mlx_repair(chat_only: bool, reason: Optional[str]) -> bool:
         return False
 
 
+def verdict_blames_the_mlx_stack() -> bool:
+    """True while the published verdict is the chat-only one the MLX gate produced.
+
+    Unlocked deliberately: _DETECT_LOCK is held across a whole detection pass, imports
+    included, so a post-warm caller taking it would park behind an early request's first
+    import. A straddling read costs one needless measurement or one deferred overturn, and
+    the overturn re-reads under the lock."""
+    return bool(CHAT_ONLY) and CHAT_ONLY_REASON == "mlx_unavailable"
+
+
+def overturn_the_mlx_verdict(epoch: Optional[int] = None) -> bool:
+    """Re-detect while the published verdict still blames the MLX stack, for a caller that
+    has just measured it as usable.
+
+    The read and the re-detect are one locked section, or a forced pass landing between
+    them loses its fresh answer to this one. ``epoch`` is the one the caller read before
+    that measurement, so a shutdown since discards the pass rather than republishing for a
+    lifespan that has ended.
+
+    True only for a settled verdict that can now train, which asking for a re-detect
+    guarantees none of; callers announce this answer. Settled is /api/health's three-part
+    read, since shutdown clears DEVICE before the event and the verdict."""
+    with _DETECT_LOCK:
+        if not CHAT_ONLY or CHAT_ONLY_REASON != "mlx_unavailable":
+            return False
+        with owning_detection_epoch(epoch):
+            detect_hardware()
+        return DEVICE is not None and DETECTION_COMPLETE.is_set() and not CHAT_ONLY
+
+
 def _print_cuda_device_list(is_rocm: bool) -> None:
     """List every visible CUDA/ROCm GPU with its index at startup.
 

--- a/studio/backend/utils/mlx_repair.py
+++ b/studio/backend/utils/mlx_repair.py
@@ -547,17 +547,38 @@ def _run_repair_and_redetect(epoch: Optional[int] = None) -> None:
 def start_mlx_autorepair_if_needed() -> bool:
     """If this is an Apple Silicon host whose MLX stack is missing or too old,
     reinstall it on a daemon thread (off the startup critical path) and re-detect
-    on success. Returns True iff a repair thread was started. No-op (returns False)
-    off Apple Silicon, when the stack is already adequate, when already attempted
-    this process, or when disabled via UNSLOTH_DISABLE_MLX_AUTOREPAIR=1."""
+    on success. Returns True iff a repair thread was started. No-op off Apple Silicon,
+    when already attempted this process, or when disabled via
+    UNSLOTH_DISABLE_MLX_AUTOREPAIR=1. An adequate stack starts no repair but is not a
+    no-op: it overturns a published verdict that contradicts it."""
     global _attempted, _repair_thread, _repair_started_at
-    if os.environ.get(DISABLE_ENV_VAR) == "1":
-        return False
     if not is_apple_silicon():
         return False
-    if mlx_stack_available():
-        return False
     from utils.hardware import hardware as _hw
+
+    # Opting out declines a reinstall, not a correct verdict, so the overturn still runs --
+    # but with no reinstall to decide, nothing here is worth importing MLX for unless a
+    # verdict is waiting on it. Under the warm's own kill switch this would be the first.
+    opted_out = os.environ.get(DISABLE_ENV_VAR) == "1"
+    if opted_out and not _hw.verdict_blames_the_mlx_stack():
+        return False
+    # Before the measurement, so a shutdown during it discards what is published on the
+    # strength of it. The repair worker shares it rather than reading its own, later one.
+    epoch = _hw.current_detection_epoch()
+    if mlx_stack_available():
+        # Detection asks this same question as the warm's first stage, early enough to race
+        # another thread's first import of transformers: CPython hands the loser a partially
+        # initialised module rather than deadlock, so mlx_lm's import chain raises on a
+        # healthy install (issue #9120). Usable here therefore means that verdict was raced.
+        # Only the warm's is reachable; under its kill switch a later one stands unreconciled.
+        if _hw.overturn_the_mlx_verdict(epoch):
+            logger.info(
+                "MLX stack measures usable after the warm, against a chat-only verdict "
+                "from before it; re-detected. Train/Export are back (reload the page)."
+            )
+        return False
+    if opted_out:
+        return False
 
     with _attempted_lock:
         if _attempted:
@@ -567,11 +588,9 @@ def start_mlx_autorepair_if_needed() -> bool:
         # half-published: a reader landing between the two sees "attempted, nothing alive"
         # and settles the very verdict this repair is about to overturn. The worker never
         # takes this lock, so the start() handshake cannot deadlock against it.
-        # The epoch is read here rather than in the thread: it may not run for a while, and
-        # reading it there would bind the pass to a later shutdown.
         _repair_thread = threading.Thread(
             target = _run_repair_and_redetect,
-            args = (_hw.current_detection_epoch(),),
+            args = (epoch,),
             daemon = True,
             name = "mlx-autorepair",
         )


### PR DESCRIPTION
Fixes #9120.

## The bug

On Apple Silicon, Train/Export is gated on the MLX stack being usable. Hardware detection runs as the torch warm's **first** stage, early enough that another startup thread can still be part-way through the same first import of `transformers`. CPython hands the second thread a partially initialised module rather than deadlock, so `from transformers import AutoTokenizer` — reached inside `mlx_lm`'s own import chain — raises `ImportError: cannot import name ...` on a perfectly healthy install.

`detect_hardware()` caches that verdict for the process's lifetime, so one lost race at boot greys out Train/Export behind a "run `unsloth studio update`" tooltip that correctly reports nothing to fix. The reporter lost the race on 3 of 3 consecutive launches.

## Root cause, and why the fix is this small

`start_mlx_autorepair_if_needed()` **already re-measures the stack**, one statement after `join_background_warm()` in the post-warm worker, at `if mlx_stack_available(): return False`. That measurement happens once the warm has finished importing, so it is not the one that raced — and the gate was throwing it away in exactly the case where it contradicted the cached verdict. The self-heal saw a healthy stack, declined to reinstall, and left the wrong verdict latched with nothing else that would ever revisit it.

So the gate now acts on **both** answers of that single measurement rather than only one: a usable stack means the verdict was measured during the race, and it re-detects.

There are no retries, no backoff, and no classifying import errors by message. A message heuristic cannot separate this race from a genuinely incompatible mlx-vlm — `ImportError: cannot import name 'X' from 'transformers'` is also what a resolver backtrack produces, which is the failure this module exists to repair. The disagreement between two independent measurements is evidence a substring match is not.

## What changed

- `utils/hardware/hardware.py` gains `overturn_the_mlx_verdict(epoch)`, which re-detects while the published verdict still blames the MLX stack, and `verdict_blames_the_mlx_stack()`.
- `utils/mlx_repair.py` calls the overturn on the measurement it already took, and moves the `UNSLOTH_DISABLE_MLX_AUTOREPAIR` check after it.
- `main.py` is untouched.

Details worth a reviewer's attention:

- **The re-detect is epoch-scoped.** The epoch is read *before* the measurement, so a shutdown landing inside it discards the pass instead of republishing for a lifespan that has ended — the same guard `_run_repair_and_redetect` already carries, and without it the next lifespan would find `DEVICE` set and skip its own detection. The repair worker now shares that epoch instead of reading its own, later one.
- **The verdict read and the re-detect are one locked section**, so a forced pass landing between them does not lose its fresh answer to this one.
- **`UNSLOTH_DISABLE_MLX_AUTOREPAIR=1` no longer skips the overturn.** It declines a reinstall, not a correct verdict, and re-detecting mutates nothing. Such a user reaches the measurement only when a verdict is actually waiting on it, so the opt-out still imports nothing on a host with nothing to overturn — which matters because the torch warm has its own kill switch, and under it this would otherwise be the process's first MLX import.
- **The success message reflects the outcome, not the attempt.** A pass can decline on a retired epoch or be discarded under one, so the answer is the same three-part settled read `/api/health` makes.

## Cost

Nothing on a healthy boot, and nothing on a genuinely broken stack: the measurement is the one the gate already took. Where the verdict is overturned, the re-detect's own stack check is served from `sys.modules` — measured on an Apple Silicon host at 3010 ms for the first measurement and 1.3 ms for the second.

## Known limitation

The overturn reaches only a verdict published before the post-warm handoff, which is the warm's. Under the warm's own kill switch (`UNSLOTH_STUDIO_DISABLE_TORCH_WARM=1`) detection is deferred to the first request that needs it, and a verdict landing after this point stands unreconciled for the session. That is the behaviour on `main` today as well; closing it means moving where the self-heal is scheduled, which is a larger change than this bug and is left as follow-up. The limitation is stated in the code.

## Validation

```bash
python -m pytest tests/test_mlx_repair.py tests/test_startup_defers_stack_dependent_work.py \
    tests/test_warm_window_review_fixes.py tests/test_health_holds_verdict_during_mlx_repair.py \
    tests/test_mlx_stack_blockers.py -q
# 200 passed
```

A broader sweep (`-k "mlx or hardware or warm or startup or health or detect"`) gives 1654 passed with 5 failures that reproduce identically on a clean `main` checkout under the same command.

Every added test was mutation-checked: each production line was reverted in turn and exactly the intended test failed — dropping the overturn, ignoring which gate produced the verdict, checking the opt-out before the measurement, dropping the epoch scope, reading the epoch after the measurement, reading the worker's epoch at spawn, measuring the stack twice, overturning regardless of the measurement, and announcing an overturn that never published.
