### PR TITLE
Bundle Unsloth GGUF CI onto one runner, matching Windows and macOS

### DIFF
--- a/.github/workflows/studio-inference-smoke.yml
+++ b/.github/workflows/studio-inference-smoke.yml
@@ -87,11 +87,15 @@ jobs:
   # 18 exceeded 60s. The sequential wall time the note was trying to avoid is
   # already being paid, in the queue, plus two extra setups.
   #
-  # The honest trade, at the observed 2m30 / 6m05 / 2m50 job durations and ~1.9
-  # min of shared setup: bundled is ~7m35 every time. When all three do get
-  # slots at once that is ~1m30 slower than the 6m05 longest job; when they do
-  # not, it is 2-5 min faster. It also gives back 2 of the 60 concurrent slots,
-  # which is what makes the contended case less common for every other workflow.
+  # Measured bundled, on a staging repo with an EMPTY actions cache, so every
+  # model downloaded cold: 6m03s for all three phases. 105s of that is the now-
+  # shared setup (checkout 4s, apt 9s, node 1s, python 2s, install.sh 88s, SDKs
+  # 6s), which the three jobs each paid separately; the phases themselves are
+  # 26s / 179s / 36s. That is at or under the 6m05 the longest of the three jobs
+  # took on its own, on a third of the runners -- so this is not the "slower but
+  # cheaper" trade it looked like before it was measured. It also gives back 2 of
+  # the 60 concurrent slots, which is what makes the contended case rarer for
+  # every other workflow.
   #
   # Each phase keeps its own model cache directory, HF_HOME, port, server log,
   # uploaded artifact and step timeouts, and each is gated on the SHARED preamble

--- a/.github/workflows/studio-inference-smoke.yml
+++ b/.github/workflows/studio-inference-smoke.yml
@@ -1,31 +1,34 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
 
-# Three end-to-end smoke jobs that boot a freshly-installed Unsloth and
+# Three end-to-end smoke phases that boot a freshly-installed Unsloth and
 # exercise the surfaces real users hit through the OpenAI / Anthropic
-# SDKs and curl. Each job picks the smallest model that exercises the
-# behaviour under test, primes HF_HOME via actions/cache, and shares
-# the install.sh --local --no-torch bootstrap.
+# SDKs and curl. Each phase picks the smallest model that exercises the
+# behaviour under test and primes its own model cache via actions/cache.
+# All three run sequentially on ONE runner and share a single
+# install.sh --local --no-torch bootstrap, matching what
+# studio-windows-inference-smoke.yml already does.
 #
-#   1. OpenAI, Anthropic API tests
+#   1. OpenAI, Anthropic API tests            port 18888
 #        gemma-3-270m-it UD-Q4_K_XL (~254 MiB).
 #        Password rotation via /api/auth/change-password (old fails,
 #        new works), then OpenAI + Anthropic Python SDKs against /v1/*
 #        with temperature=0 and a fixed seed. Asserts the four-turn
 #        conversation is deterministic across two runs.
 #
-#   2. Tool calling Tests
-#        Qwen3.5-2B UD-IQ3_XXS (~890 MiB). OpenAI function calling,
+#   2. Tool calling Tests                     port 18889
+#        Qwen3.5-2B UD-Q4_K_XL (~1.28 GiB). OpenAI function calling,
 #        server-side tools (python, terminal, web_search) via
 #        enable_tools / enabled_tools, and enable_thinking on/off.
 #
-#   3. JSON, images
+#   3. JSON, images                           port 18890
 #        Qwen3-VL-2B-Instruct UD-Q4_K_XL (~1.1 GiB) + mmproj-F16 (~780 MiB).
 #        response_format JSON-schema decoding and OpenAI image_url
 #        (data URI) plus Anthropic source/base64 image inputs.
 #
-# All three jobs run in parallel. Total wall time is dominated by job 3
-# on a cold cache; warm cache cuts that to ~3 min.
+# Each phase gates on the shared install rather than on the phase before it,
+# so a phase-1 failure still lets phases 2 and 3 report. That is what the three
+# separate jobs gave for free and what the bundle has to reproduce by hand.
 
 name: Unsloth GGUF CI
 
@@ -64,23 +67,71 @@ permissions:
   contents: read
 
 jobs:
-  # ─────────────────────────────────────────────────────────────────────
-  # Job 1: OpenAI, Anthropic API tests
-  # ─────────────────────────────────────────────────────────────────────
-  openai-anthropic:
-    name: OpenAI, Anthropic API tests
+  # One job, three phases -- the Linux port of the layout Windows and macOS
+  # already use (studio-windows-inference-smoke.yml, studio-mac-inference-smoke.yml).
+  # These were three ubuntu-latest jobs differing only in model, port and test
+  # body; checkout, apt, setup-node, setup-python and `install.sh --local
+  # --no-torch` were identical in all three.
+  #
+  # This reverses the note in studio-windows-inference-smoke.yml that said the
+  # trade was not worth making on ubuntu because "setup is ~1.9 min against ~3.0
+  # min of tests" and the added sequential wall time would cost more feedback
+  # latency than the slots are worth. The arithmetic was right; its premise --
+  # that the three jobs start together -- is not what the runners actually do.
+  #
+  # Measured on main. Run 32089506294 started two jobs at 02:40:11 and the third
+  # at 02:46:52, a 6m41s wait for the third slot, and finished at 02:52:57: a
+  # 12m46s wall for ~6 min of work. Run 32089558062 staggered all three
+  # (02:47:32 / 02:50:01 / 02:54:06). Across 18 recent multi-job runs on main the
+  # median gap between a run's first and last job start was 175s, and 13 of the
+  # 18 exceeded 60s. The sequential wall time the note was trying to avoid is
+  # already being paid, in the queue, plus two extra setups.
+  #
+  # The honest trade, at the observed 2m30 / 6m05 / 2m50 job durations and ~1.9
+  # min of shared setup: bundled is ~7m35 every time. When all three do get
+  # slots at once that is ~1m30 slower than the 6m05 longest job; when they do
+  # not, it is 2-5 min faster. It also gives back 2 of the 60 concurrent slots,
+  # which is what makes the contended case less common for every other workflow.
+  #
+  # Each phase keeps its own model cache directory, HF_HOME, port, server log,
+  # uploaded artifact and step timeouts, and each is gated on the SHARED preamble
+  # rather than on the phase before it, so a failure still points at one phase,
+  # earlier phases' logs survive it, and later phases still run -- the same
+  # independence the three jobs had.
+  inference-smoke:
+    name: GGUF inference smoke (API, tools, vision)
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    # Was 25 + 25 + 30 across three runners. Sequentially they share one
+    # install, so the sum is well under 60, but a cold model cache on the
+    # vision phase is the slow case. Every step that can block also carries
+    # its own `timeout-minutes`: the job cap alone is not a substitute,
+    # because hf-download-with-retry.sh retries forever by design and named
+    # the enclosing step's timeout as its bound.
+    timeout-minutes: 60
     env:
-      GGUF_REPO: unsloth/gemma-3-270m-it-GGUF
-      GGUF_VARIANT: UD-Q4_K_XL
-      GGUF_FILE: gemma-3-270m-it-UD-Q4_K_XL.gguf
-      STUDIO_PORT: '18888'
-      HF_HOME: ${{ github.workspace }}/hf-cache
+      # Only what every phase shares. Model, GGUF file, port and HF_HOME are
+      # set per phase via $GITHUB_ENV instead of here: if a phase-specific key
+      # were also declared at job level, whether the later $GITHUB_ENV write
+      # wins is not something the Actions docs pin down, and a phase quietly
+      # talking to the previous phase's port would be a nasty way to find out.
+      #
+      # Unbuffered stdio so a phase that dies mid-step leaves its output in the
+      # log rather than in a lost 8KB pipe buffer. Three phases share one log
+      # now, so "which phase was running" has to be readable from the tail.
+      PYTHONUNBUFFERED: '1'
+      # hf-xet's chunk directory defaults to a path under HF_HOME, which is what
+      # the phase-1 and phase-3 cache entries save. Those chunks are scratch --
+      # re-derivable from the blobs sitting next to them -- so pinning them
+      # outside the workspace keeps each hf-cache* tree closer to 1:1 with the
+      # model files it holds. hf-download-with-retry.sh already sets
+      # HF_XET_CHUNK_CACHE_SIZE_BYTES=0, so this mainly covers the downloads
+      # Unsloth itself makes at load time, which do not go through that script.
+      HF_XET_CACHE: ${{ runner.temp }}/xet-scratch
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           persist-credentials: false
+
 
       - name: Linux deps for llama.cpp prebuilt
         run: |
@@ -88,9 +139,11 @@ jobs:
           sudo apt-get install -y --no-install-recommends \
             libcurl4-openssl-dev libssl-dev jq
 
+
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
           node-version: '22'
+
 
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
@@ -100,7 +153,47 @@ jobs:
       # Cross-OS shared entry. The tree under `hf-cache` is byte-identical on
       # Linux, macOS and Windows, so the key carries no `runner.os`, and
       # enableCrossOsArchive lets Windows (which tars with --force-local) join it.
+
+      # Deliberately NO `if:`, so this rides the implicit success() and a failed
+      # preamble still stops the job here, exactly as it did when this was three
+      # jobs. Every phase below gates on this step's outcome.
+      - name: Install Unsloth (--local, --no-torch)
+        id: install
+        timeout-minutes: 25
+        uses: ./.github/actions/install-unsloth-local
+        with:
+          gh-token: ${{ secrets.GITHUB_TOKEN }}
+          # Withheld on PR: this step runs checked-out PR code; public GGUF still downloads.
+          hf-token: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
+
+      # Needed by phases 1 and 3 only; the tool-calling phase drives the API
+      # with curl and never imports them, which is why phase 2 does not gate
+      # on this.
+      - name: Install OpenAI + Anthropic Python SDKs
+        id: sdks
+        if: ${{ !cancelled() && steps.install.outcome == 'success' }}
+        timeout-minutes: 10
+        run: pip install 'openai>=1.50' 'anthropic>=0.40'
+
+      # Phase 1's environment and model cache sit HERE, after the shared
+      # preamble, not before it. They used to run before the installer, which is
+      # where they sat when phase 1 was its own job -- harmless then, because a
+      # priming failure only killed that one job. Once the installer is shared,
+      # the same failure would skip it under the implicit success() and every
+      # later phase's gate would evaluate false. Ordering the shared setup first
+      # keeps a phase-1 resource failure phase-local.
+      - name: Phase 1 environment (OpenAI, Anthropic API)
+        if: ${{ !cancelled() && steps.sdks.outcome == 'success' }}
+        run: |
+          echo "GGUF_REPO=unsloth/gemma-3-270m-it-GGUF" >> "$GITHUB_ENV"
+          echo "GGUF_VARIANT=UD-Q4_K_XL" >> "$GITHUB_ENV"
+          echo "GGUF_FILE=gemma-3-270m-it-UD-Q4_K_XL.gguf" >> "$GITHUB_ENV"
+          echo "STUDIO_PORT=18888" >> "$GITHUB_ENV"
+          echo "STUDIO_LOG=logs/studio.log" >> "$GITHUB_ENV"
+          echo "HF_HOME=${{ github.workspace }}/hf-cache" >> "$GITHUB_ENV"
+
       - name: Restore HF_HOME for ${{ env.GGUF_REPO }}
+        if: ${{ !cancelled() && steps.sdks.outcome == 'success' }}
         id: cache-hf
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         continue-on-error: true
@@ -111,7 +204,8 @@ jobs:
 
       - name: Prime HF_HOME with the GGUF
         id: prime-hf
-        if: steps.cache-hf.outputs.cache-hit != 'true' || steps.cache-hf.outcome != 'success'
+        timeout-minutes: 15
+        if: ${{ !cancelled() && steps.sdks.outcome == 'success' && (steps.cache-hf.outputs.cache-hit != 'true' || steps.cache-hf.outcome != 'success') }}
         env:
           # Withheld on PR: this step runs checked-out PR code; public GGUF still downloads.
           HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
@@ -139,26 +233,26 @@ jobs:
           key: hf-${{ env.GGUF_REPO }}-${{ env.GGUF_VARIANT }}-v3
           enableCrossOsArchive: true
 
-      - name: Install Unsloth (--local, --no-torch)
-        uses: ./.github/actions/install-unsloth-local
-        with:
-          gh-token: ${{ secrets.GITHUB_TOKEN }}
-          # Withheld on PR: this step runs checked-out PR code; public GGUF still downloads.
-          hf-token: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
-
-      - name: Install OpenAI + Anthropic Python SDKs
-        run: pip install 'openai>=1.50' 'anthropic>=0.40'
 
       - name: Reset auth + boot Unsloth (API-only)
+        id: boot-api
+        timeout-minutes: 5
+        if: ${{ !cancelled() && steps.sdks.outcome == 'success' && steps.prime-hf.outcome != 'failure' }}
         run: |
           # Wipe (not reset-password): the boot below must re-seed a fresh .bootstrap_password.
-          bash .github/scripts/boot-studio-api-only.sh --port "$STUDIO_PORT"
+          bash .github/scripts/boot-studio-api-only.sh --port "$STUDIO_PORT" --log "$STUDIO_LOG"
 
       - name: Wait for /api/health
+        id: ready-api
+        timeout-minutes: 10
+        if: ${{ !cancelled() && steps.sdks.outcome == 'success' && steps.boot-api.outcome == 'success' }}
         run: |
           bash .github/scripts/wait-for-health.sh --port "$STUDIO_PORT"
 
       - name: Password rotation (old must fail, new must work)
+        id: rotate-api
+        timeout-minutes: 5
+        if: ${{ !cancelled() && steps.sdks.outcome == 'success' && steps.ready-api.outcome == 'success' }}
         run: |
           OLD=$(cat ~/.unsloth/studio/auth/.bootstrap_password)
           NEW="CIRotated-$(python -c 'import secrets; print(secrets.token_urlsafe(12))')"
@@ -191,6 +285,9 @@ jobs:
           echo "password rotation OK (old=401, new=200)"
 
       - name: Load the GGUF (HF repo + variant, served from HF_HOME cache)
+        id: load-api
+        timeout-minutes: 10
+        if: ${{ !cancelled() && steps.sdks.outcome == 'success' && steps.rotate-api.outcome == 'success' }}
         run: |
           curl -fs -X POST "http://127.0.0.1:${STUDIO_PORT}/api/inference/load" \
             -H "Authorization: Bearer $TOKEN" -H 'content-type: application/json' \
@@ -199,6 +296,9 @@ jobs:
             | jq '{status, display_name, is_gguf, context_length}'
 
       - name: Multi-turn determinism via OpenAI + Anthropic SDKs
+        id: chat-api
+        timeout-minutes: 10
+        if: ${{ !cancelled() && steps.sdks.outcome == 'success' && steps.load-api.outcome == 'success' }}
         env:
           BASE_URL: http://127.0.0.1:18888
         run: |
@@ -227,55 +327,20 @@ jobs:
   # ─────────────────────────────────────────────────────────────────────
   # Job 2: Tool calling Tests
   # ─────────────────────────────────────────────────────────────────────
-  tool-calling:
-    name: Tool calling Tests
-    runs-on: ubuntu-latest
-    timeout-minutes: 25
-    env:
-      # Tool calling is the highest-volume GGUF in this workflow
-      # (Qwen3.5-2B at Q4_K_XL = ~1.28 GiB). Caching HF_HOME would
-      # store xet chunks + blobs + snapshots = ~4 GiB compressed --
-      # 4-5x file-size inflation, dominated by xet chunks. Use main's
-      # `--local-dir` pattern to cache the flat .gguf only.
-      # Unsloth's /api/inference/load accepts either a HF repo (which
-      # uses HF_HOME) or an absolute file path; passing the absolute
-      # path keeps the test off HF_HOME entirely so the cache size
-      # tracks the GGUF file 1:1. The OpenAI/Anth and JSON+images
-      # jobs still cover the gguf_variant resolution path.
-      # Q4_K_XL, not IQ3_XXS: at IQ3_XXS this model emits malformed
-      # tool calls that llama-server's peg-native parser rejects with a
-      # 500. Mac/Windows already use Q4_K_XL for the same reason.
-      GGUF_REPO: unsloth/Qwen3.5-2B-GGUF
-      GGUF_FILE: Qwen3.5-2B-UD-Q4_K_XL.gguf
-      STUDIO_PORT: '18889'
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
-        with:
-          persist-credentials: false
 
-      - name: Linux deps for llama.cpp prebuilt
+      - name: Phase 2 environment (tool calling)
+        if: ${{ !cancelled() && steps.install.outcome == 'success' }}
         run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            libcurl4-openssl-dev libssl-dev jq
+          echo "GGUF_REPO=unsloth/Qwen3.5-2B-GGUF" >> "$GITHUB_ENV"
+          echo "GGUF_FILE=Qwen3.5-2B-UD-Q4_K_XL.gguf" >> "$GITHUB_ENV"
+          echo "STUDIO_PORT=18889" >> "$GITHUB_ENV"
+          echo "STUDIO_LOG=logs/studio_tools.log" >> "$GITHUB_ENV"
+          # Phase 2 passes an absolute .gguf path to /api/inference/load and
+          # never touches HF_HOME, but it must not inherit phase 1's either.
+          echo "HF_HOME=${{ github.workspace }}/hf-cache-tools" >> "$GITHUB_ENV"
 
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
-        with:
-          node-version: '22'
-
-      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
-        with:
-          python-version: '3.12'
-          cache: 'pip'
-
-      # Cross-OS shared entry with the mac and Windows tool-calling phases:
-      # same repo, same file, same flat --local-dir payload, byte-identical on
-      # all three runners. The directory is renamed gguf-cache -> gguf-cache-tools
-      # to match them, and the key version is bumped in the SAME commit because
-      # actions/cache identifies an entry by key AND a hash of `path` -- moving
-      # the path without bumping the key gives a permanent restore miss plus a
-      # refused save ("Unable to reserve cache with key ...").
       - name: Restore GGUF model file
+        if: ${{ !cancelled() && steps.install.outcome == 'success' }}
         id: cache-gguf
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         continue-on-error: true
@@ -286,7 +351,8 @@ jobs:
 
       - name: Download GGUF if cache miss
         id: download-gguf
-        if: steps.cache-gguf.outputs.cache-hit != 'true' || steps.cache-gguf.outcome != 'success'
+        timeout-minutes: 15
+        if: ${{ !cancelled() && steps.install.outcome == 'success' && (steps.cache-gguf.outputs.cache-hit != 'true' || steps.cache-gguf.outcome != 'success') }}
         env:
           # Withheld on PR: this step runs checked-out PR code; public GGUF still downloads.
           HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
@@ -303,14 +369,11 @@ jobs:
           key: gguf-unsloth/Qwen3.5-2B-GGUF-Qwen3.5-2B-UD-Q4_K_XL.gguf-v3
           enableCrossOsArchive: true
 
-      - name: Install Unsloth (--local, --no-torch)
-        uses: ./.github/actions/install-unsloth-local
-        with:
-          gh-token: ${{ secrets.GITHUB_TOKEN }}
-          # Withheld on PR: this step runs checked-out PR code; public GGUF still downloads.
-          hf-token: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
 
       - name: Reset auth + boot Unsloth (API-only, default tool policy)
+        id: boot-tools
+        timeout-minutes: 5
+        if: ${{ !cancelled() && steps.install.outcome == 'success' && steps.download-gguf.outcome != 'failure' }}
         # We deliberately use the API-only mode rather than
         # `unsloth studio run` because the latter calls
         # `set_tool_policy(...)` with a resolved bool: on loopback the
@@ -320,9 +383,12 @@ jobs:
         # tool_policy=None so each request's `enable_tools` field is
         # honoured.
         run: |
-          bash .github/scripts/boot-studio-api-only.sh --port "$STUDIO_PORT"
+          bash .github/scripts/boot-studio-api-only.sh --port "$STUDIO_PORT" --log "$STUDIO_LOG"
 
       - name: Wait for /api/health, log in, change password, load model
+        id: ready-tools
+        timeout-minutes: 15
+        if: ${{ !cancelled() && steps.install.outcome == 'success' && steps.boot-tools.outcome == 'success' }}
         run: |
           for i in $(seq 1 180); do
             if curl -fs "http://127.0.0.1:${STUDIO_PORT}/api/health" > /tmp/health.json; then
@@ -354,6 +420,9 @@ jobs:
             | jq '{status, display_name}'
 
       - name: Tool calling, server-side tools, thinking on/off
+        id: test-tools
+        timeout-minutes: 20
+        if: ${{ !cancelled() && steps.install.outcome == 'success' && steps.ready-tools.outcome == 'success' }}
         env:
           BASE_URL: http://127.0.0.1:18889
         run: |
@@ -803,7 +872,7 @@ jobs:
         with:
           name: tool-calling-log
           path: |
-            logs/studio.log
+            logs/studio_tools.log
             logs/install.log
             logs/server-logs/
           retention-days: 7
@@ -811,89 +880,67 @@ jobs:
   # ─────────────────────────────────────────────────────────────────────
   # Job 3: JSON, images
   # ─────────────────────────────────────────────────────────────────────
-  json-images:
-    name: JSON, images
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    env:
-      GGUF_REPO: unsloth/Qwen3-VL-2B-Instruct-GGUF
-      # UD-Q4_K_XL, not UD-IQ2_XXS: at 2-bit the temp-0 answer to the JSON
-      # step's capital-of-France probe flips with the host's SIMD kernels
-      # (GitHub runners deterministically answered France while other CPUs
-      # answer Paris; seeds do not rescue it, 1/5 Paris at temp 0.7). The
-      # Q4 quant answered Paris 13/13 across temps and seeds on the same
-      # runners, so the hard Paris assertion below stays reliable.
-      GGUF_VARIANT: UD-Q4_K_XL
-      GGUF_FILE: Qwen3-VL-2B-Instruct-UD-Q4_K_XL.gguf
-      MMPROJ_FILE: mmproj-F16.gguf
-      STUDIO_PORT: '18890'
-      HF_HOME: ${{ github.workspace }}/hf-cache
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
-        with:
-          persist-credentials: false
 
-      - name: Linux deps for llama.cpp prebuilt
+      - name: Phase 3 environment (JSON, images)
+        if: ${{ !cancelled() && steps.sdks.outcome == 'success' }}
         run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            libcurl4-openssl-dev libssl-dev jq
-
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
-        with:
-          node-version: '22'
-
-      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
-        with:
-          python-version: '3.12'
-          cache: 'pip'
+          echo "GGUF_REPO=unsloth/Qwen3-VL-2B-Instruct-GGUF" >> "$GITHUB_ENV"
+          echo "GGUF_VARIANT=UD-Q4_K_XL" >> "$GITHUB_ENV"
+          echo "GGUF_FILE=Qwen3-VL-2B-Instruct-UD-Q4_K_XL.gguf" >> "$GITHUB_ENV"
+          echo "MMPROJ_FILE=mmproj-F16.gguf" >> "$GITHUB_ENV"
+          echo "STUDIO_PORT=18890" >> "$GITHUB_ENV"
+          echo "STUDIO_LOG=logs/studio_vision.log" >> "$GITHUB_ENV"
+          # Its own directory, not phase 1's `hf-cache`. Phase 1's entry is
+          # byte-shared with the macOS and Windows gemma phases under a key with
+          # no `runner.os`, and actions/cache identifies an entry by key AND a
+          # hash of `path`, so phase 1 keeps `hf-cache` untouched and the vision
+          # phase (whose key is already Linux-scoped) is the one that moves.
+          echo "HF_HOME=${{ github.workspace }}/hf-cache-vision" >> "$GITHUB_ENV"
 
       - name: Restore HF_HOME for ${{ env.GGUF_REPO }} (model + mmproj)
-        id: cache-hf
+        if: ${{ !cancelled() && steps.sdks.outcome == 'success' }}
+        id: cache-hf-vision
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         continue-on-error: true
         with:
-          path: hf-cache
-          key: ${{ runner.os }}-hf-${{ env.GGUF_REPO }}-${{ env.GGUF_VARIANT }}-${{ env.MMPROJ_FILE }}-v2
+          path: hf-cache-vision
+          key: ${{ runner.os }}-hf-${{ env.GGUF_REPO }}-${{ env.GGUF_VARIANT }}-${{ env.MMPROJ_FILE }}-v3
 
       - name: Prime HF_HOME with the GGUF + mmproj
-        id: prime-hf
-        if: steps.cache-hf.outputs.cache-hit != 'true' || steps.cache-hf.outcome != 'success'
+        id: prime-hf-vision
+        timeout-minutes: 20
+        if: ${{ !cancelled() && steps.sdks.outcome == 'success' && (steps.cache-hf-vision.outputs.cache-hit != 'true' || steps.cache-hf-vision.outcome != 'success') }}
         env:
           # Withheld on PR: this step runs checked-out PR code; public GGUF still downloads.
           HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
         run: |
           python -m pip install --upgrade huggingface_hub
-          mkdir -p hf-cache
+          mkdir -p hf-cache-vision
           bash .github/scripts/hf-download-with-retry.sh "$GGUF_REPO" "$GGUF_FILE"
           bash .github/scripts/hf-download-with-retry.sh "$GGUF_REPO" "$MMPROJ_FILE"
           bash .github/scripts/hf-download-with-retry.sh ggml-org/models tinyllamas/stories260K.gguf
 
       - name: Save HF_HOME for ${{ env.GGUF_REPO }} (model + mmproj)
-        if: always() && github.ref == 'refs/heads/main' && steps.prime-hf.outcome == 'success'
+        if: always() && github.ref == 'refs/heads/main' && steps.prime-hf-vision.outcome == 'success'
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
-          path: hf-cache
-          key: ${{ runner.os }}-hf-${{ env.GGUF_REPO }}-${{ env.GGUF_VARIANT }}-${{ env.MMPROJ_FILE }}-v2
-
-      - name: Install Unsloth (--local, --no-torch)
-        uses: ./.github/actions/install-unsloth-local
-        with:
-          gh-token: ${{ secrets.GITHUB_TOKEN }}
-          # Withheld on PR: this step runs checked-out PR code; public GGUF still downloads.
-          hf-token: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
-
-      - name: Install OpenAI + Anthropic Python SDKs
-        run: pip install 'openai>=1.50' 'anthropic>=0.40'
+          path: hf-cache-vision
+          key: ${{ runner.os }}-hf-${{ env.GGUF_REPO }}-${{ env.GGUF_VARIANT }}-${{ env.MMPROJ_FILE }}-v3
 
       - name: Reset auth + boot Unsloth (API-only)
-        # See Job 2's comment: API-only mode keeps tool_policy=None so
+        id: boot-vision
+        timeout-minutes: 5
+        if: ${{ !cancelled() && steps.sdks.outcome == 'success' && steps.prime-hf-vision.outcome != 'failure' }}
+        # See phase 2's comment: API-only mode keeps tool_policy=None so
         # response_format requests aren't routed through the agentic
         # tool loop.
         run: |
-          bash .github/scripts/boot-studio-api-only.sh --port "$STUDIO_PORT"
+          bash .github/scripts/boot-studio-api-only.sh --port "$STUDIO_PORT" --log "$STUDIO_LOG"
 
       - name: Wait for /api/health, log in, change password, load model
+        id: ready-vision
+        timeout-minutes: 15
+        if: ${{ !cancelled() && steps.sdks.outcome == 'success' && steps.prime-hf-vision.outcome != 'failure' }}
         run: |
           for i in $(seq 1 180); do
             if curl -fs "http://127.0.0.1:${STUDIO_PORT}/api/health" > /tmp/health.json; then
@@ -935,6 +982,9 @@ jobs:
           jq '{status, display_name, is_vision}' /tmp/load.json
 
       - name: JSON schema decoding + image input
+        id: test-vision
+        timeout-minutes: 20
+        if: ${{ !cancelled() && steps.sdks.outcome == 'success' && steps.ready-vision.outcome == 'success' }}
         env:
           BASE_URL: http://127.0.0.1:18890
         run: |
@@ -1109,6 +1159,6 @@ jobs:
         with:
           name: json-images-log
           path: |
-            logs/studio.log
+            logs/studio_vision.log
             logs/install.log
           retention-days: 7

--- a/.github/workflows/studio-inference-smoke.yml
+++ b/.github/workflows/studio-inference-smoke.yml
@@ -126,7 +126,7 @@ jobs:
       # model files it holds. hf-download-with-retry.sh already sets
       # HF_XET_CHUNK_CACHE_SIZE_BYTES=0, so this mainly covers the downloads
       # Unsloth itself makes at load time, which do not go through that script.
-      HF_XET_CACHE: ${{ runner.temp }}/xet-scratch
+      HF_XET_CACHE: ${{ github.workspace }}/xet-scratch
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:

--- a/.github/workflows/studio-windows-inference-smoke.yml
+++ b/.github/workflows/studio-windows-inference-smoke.yml
@@ -68,8 +68,10 @@ jobs:
   # ~3.8 min of tests, so setup dominates and sharing it once saves ~14
   # runner-minutes and 2 of the 60 concurrent-job slots. The same trade is NOT
   # worth making on ubuntu (studio-inference-smoke.yml), where setup is ~1.9 min
-  # against ~3.0 min of tests: there the added sequential wall time costs more
-  # feedback latency than the slots are worth.
+  # against ~3.0 min of tests. That last claim no longer holds and ubuntu is now
+  # bundled too: it assumed the three jobs start together, and measured on main
+  # they usually do not (median 175s between a run's first and last job start
+  # across 18 recent multi-job runs). See that file's header for the numbers.
   #
   # Each phase keeps its own model cache directory, HF_HOME, server port, server
   # log, uploaded artifact and step timeouts, and each is gated on the SHARED

--- a/studio/backend/tests/test_lan_access_settings.py
+++ b/studio/backend/tests/test_lan_access_settings.py
@@ -327,9 +327,7 @@ def test_interface_enumeration_skips_windows_host_only_switches(monkeypatch):
             )
         },
         net_if_addrs = lambda: {
-            "Wi-Fi": [
-                types.SimpleNamespace(family = socket.AF_INET, address = "192.168.1.20")
-            ],
+            "Wi-Fi": [types.SimpleNamespace(family = socket.AF_INET, address = "192.168.1.20")],
             "vEthernet (Default Switch)": [
                 types.SimpleNamespace(family = socket.AF_INET, address = "172.31.32.1")
             ],

--- a/tests/studio/test_compile_caches_are_per_worker.py
+++ b/tests/studio/test_compile_caches_are_per_worker.py
@@ -77,9 +77,9 @@ def test_an_explicit_location_is_split_underneath_not_replaced(monkeypatch, tmp_
     monkeypatch.setenv("PYTEST_XDIST_WORKER", "gw0")
     module = _load()
     module.isolate_compile_caches()
-    assert os.environ["TORCHINDUCTOR_CACHE_DIR"].startswith(str(tmp_path / "chosen")), (
-        "an explicit TORCHINDUCTOR_CACHE_DIR was discarded rather than split underneath"
-    )
+    assert os.environ["TORCHINDUCTOR_CACHE_DIR"].startswith(
+        str(tmp_path / "chosen")
+    ), "an explicit TORCHINDUCTOR_CACHE_DIR was discarded rather than split underneath"
 
 
 @pytest.mark.parametrize("conftest", CONFTESTS, ids = lambda p: str(p.relative_to(REPO)))

--- a/tests/studio/test_gguf_smoke_phases_stay_independent.py
+++ b/tests/studio/test_gguf_smoke_phases_stay_independent.py
@@ -86,11 +86,7 @@ def test_no_two_phases_share_a(key):
 
 
 def test_every_phase_uploads_under_its_own_artifact_name():
-    names = [
-        s["with"]["name"]
-        for s in _steps()
-        if "upload-artifact" in str(s.get("uses", ""))
-    ]
+    names = [s["with"]["name"] for s in _steps() if "upload-artifact" in str(s.get("uses", ""))]
     assert len(names) == 3, names
     assert len(set(names)) == 3, f"artifact names collide: {names}"
 
@@ -186,7 +182,7 @@ def test_the_cross_os_gemma_cache_entry_is_left_alone():
         if "actions/cache" in str(s.get("uses", ""))
     }
     assert entries.get("hf-cache", "").endswith("-v3"), entries
-    assert "runner.os" not in entries.get("hf-cache", ""), (
-        "phase 1's key gained a runner.os scope, which un-shares it from macOS and Windows"
-    )
+    assert "runner.os" not in entries.get(
+        "hf-cache", ""
+    ), "phase 1's key gained a runner.os scope, which un-shares it from macOS and Windows"
     assert len(entries) == 3, f"expected one cache path per phase, got {entries}"

--- a/tests/studio/test_gguf_smoke_phases_stay_independent.py
+++ b/tests/studio/test_gguf_smoke_phases_stay_independent.py
@@ -1,0 +1,192 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""The three GGUF smoke phases share a runner without sharing anything else.
+
+Unsloth GGUF CI used to be three ubuntu-latest jobs. It is now one job with three
+sequential phases, matching what Windows and macOS already do. Three jobs gave a few
+properties for free that a single job has to reproduce by hand, and each of them fails
+silently rather than loudly:
+
+  * A phase-1 failure must not skip phases 2 and 3. A step with no `if:` rides the
+    implicit `success()`, which is exactly that skip -- and the run stays green-looking
+    because skipped steps are not failures.
+  * Two phases must not share a port, an HF_HOME, a server log or an artifact name. The
+    symptom of a shared port is phase 2 asserting against phase 1's still-running server;
+    the symptom of a shared log is an artifact that describes the wrong phase.
+  * A step that can block must carry its own `timeout-minutes`. The job cap is not a
+    substitute: `hf-download-with-retry.sh` retries forever by design and names the
+    enclosing step's timeout as its only bound, so one stalled download would eat the
+    whole job and take the other two phases' results with it.
+
+Every assertion below reads the workflow rather than a list kept here, so adding a fourth
+phase is caught by the same checks that guard the three.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO / ".github" / "workflows" / "studio-inference-smoke.yml"
+JOB = "inference-smoke"
+
+# The step that every phase gates on, directly or through the SDK install that follows it.
+SHARED = ("steps.install", "steps.sdks")
+
+
+def _steps() -> list[dict]:
+    job = yaml.safe_load(WORKFLOW.read_text(encoding = "utf-8"))["jobs"][JOB]
+    return job["steps"]
+
+
+def _phase_env() -> list[dict]:
+    return [s for s in _steps() if str(s.get("name", "")).startswith("Phase ")]
+
+
+def _phase_of(index: int, steps: list[dict]) -> int:
+    """0 for the shared preamble, else the 1-based number of the phase in force."""
+    phase = 0
+    for i, step in enumerate(steps):
+        name = str(step.get("name", ""))
+        if name.startswith("Phase "):
+            phase = int(name.split()[1])
+        if i == index:
+            return phase
+    raise AssertionError(index)
+
+
+def _exports(step: dict) -> dict[str, str]:
+    """The KEY=VALUE pairs a `Phase N environment` step writes to $GITHUB_ENV."""
+    found = re.findall(r'echo "([A-Z_]+)=(.*?)" >> "\$GITHUB_ENV"', step.get("run", ""))
+    return dict(found)
+
+
+def test_the_workflow_is_a_single_job():
+    jobs = yaml.safe_load(WORKFLOW.read_text(encoding = "utf-8"))["jobs"]
+    assert list(jobs) == [JOB], (
+        f"Unsloth GGUF CI is meant to be one bundled job; found {list(jobs)}. Splitting it "
+        f"back out returns two of the 60 concurrent slots to a pool that was measured "
+        f"handing out staggered starts (median 175s between a run's first and last job)."
+    )
+
+
+def test_there_are_three_phases():
+    names = [s["name"] for s in _phase_env()]
+    assert len(names) == 3, names
+
+
+@pytest.mark.parametrize("key", ["STUDIO_PORT", "HF_HOME", "STUDIO_LOG"])
+def test_no_two_phases_share_a(key):
+    values = [_exports(s).get(key) for s in _phase_env()]
+    assert all(values), f"a phase never sets {key}: {values}"
+    assert len(set(values)) == len(values), f"phases collide on {key}: {values}"
+
+
+def test_every_phase_uploads_under_its_own_artifact_name():
+    names = [
+        s["with"]["name"]
+        for s in _steps()
+        if "upload-artifact" in str(s.get("uses", ""))
+    ]
+    assert len(names) == 3, names
+    assert len(set(names)) == 3, f"artifact names collide: {names}"
+
+
+def test_every_phase_uploads_the_log_that_phase_actually_wrote():
+    steps = _steps()
+    logs = {
+        _phase_of(i, steps): _exports(s)["STUDIO_LOG"]
+        for i, s in enumerate(steps)
+        if str(s.get("name", "")).startswith("Phase ")
+    }
+    for i, step in enumerate(steps):
+        if "upload-artifact" not in str(step.get("uses", "")):
+            continue
+        phase = _phase_of(i, steps)
+        want = logs[phase]
+        paths = str(step["with"]["path"])
+        assert want in paths, (
+            f"phase {phase} boots its server with --log {want} but its artifact uploads "
+            f"{paths!r}. The upload would carry another phase's log."
+        )
+
+
+def test_no_step_rides_the_implicit_success_into_skipping_a_later_phase():
+    steps = _steps()
+    offenders = []
+    for i, step in enumerate(steps):
+        if _phase_of(i, steps) == 0:
+            continue  # the shared preamble is meant to fail-fast
+        if "if" not in step:
+            offenders.append(step.get("name") or step.get("uses"))
+    assert not offenders, (
+        "these phase steps carry no `if:`, so they inherit the implicit success() and a "
+        f"failure in an earlier phase silently skips them: {offenders}"
+    )
+
+
+def test_every_phase_gates_on_the_shared_preamble_not_on_the_phase_before_it():
+    steps = _steps()
+    for i, step in enumerate(steps):
+        phase = _phase_of(i, steps)
+        cond = str(step.get("if", ""))
+        if phase == 0 or "always()" in cond:
+            continue
+        assert any(s in cond for s in SHARED), (
+            f"{step.get('name')!r} (phase {phase}) does not gate on the shared install: "
+            f"{cond!r}"
+        )
+
+
+def test_step_ids_are_unique_and_every_reference_resolves():
+    steps = _steps()
+    ids = [s["id"] for s in steps if "id" in s]
+    duplicates = sorted({i for i in ids if ids.count(i) > 1})
+    assert not duplicates, (
+        f"duplicate step ids {duplicates}: `steps.<id>.outcome` then silently reads "
+        f"whichever one Actions picked, and a phase gate can be answered by another "
+        f"phase's step."
+    )
+    referenced = set(re.findall(r"steps\.([A-Za-z0-9_-]+)\.", yaml.dump(steps)))
+    assert not referenced - set(ids), f"dangling step references: {referenced - set(ids)}"
+
+
+def test_every_step_that_can_block_carries_its_own_timeout():
+    steps = _steps()
+    # A step is "blocking" if it downloads a model, waits on the server, or drives it.
+    blocking = re.compile(r"hf-download-with-retry|wait-for-health|curl |seq 1 ")
+    offenders = [
+        step.get("name")
+        for i, step in enumerate(steps)
+        if _phase_of(i, steps) > 0
+        and blocking.search(str(step.get("run", "")))
+        and "timeout-minutes" not in step
+        and "always()" not in str(step.get("if", ""))
+    ]
+    assert not offenders, (
+        "hf-download-with-retry.sh retries forever and names the enclosing step's "
+        f"timeout as its bound, so these need a `timeout-minutes:`: {offenders}"
+    )
+
+
+def test_the_cross_os_gemma_cache_entry_is_left_alone():
+    """Phase 1's cache is byte-shared with the macOS and Windows gemma phases.
+
+    actions/cache identifies an entry by key AND a hash of `path`, so renaming the
+    directory on Linux alone would give a permanent restore miss on all three platforms
+    without any of them failing -- they would just quietly re-download every run.
+    """
+    steps = _steps()
+    entries = {
+        str(s["with"]["path"]): str(s["with"]["key"])
+        for s in steps
+        if "actions/cache" in str(s.get("uses", ""))
+    }
+    assert entries.get("hf-cache", "").endswith("-v3"), entries
+    assert "runner.os" not in entries.get("hf-cache", ""), (
+        "phase 1's key gained a runner.os scope, which un-shares it from macOS and Windows"
+    )
+    assert len(entries) == 3, f"expected one cache path per phase, got {entries}"

--- a/tests/studio/test_no_test_shadows_another.py
+++ b/tests/studio/test_no_test_shadows_another.py
@@ -45,7 +45,8 @@ def _shadowed() -> list[str]:
             scopes += [(n.name, n.body) for n in tree.body if isinstance(n, ast.ClassDef)]
             for scope, body in scopes:
                 defined = [
-                    n for n in body
+                    n
+                    for n in body
                     if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
                     and n.name.startswith("test")
                 ]


### PR DESCRIPTION
The three ubuntu-latest jobs differed only in model, port and test body;
checkout, apt, setup-node, setup-python and install.sh --local --no-torch were
identical in all three. Windows and macOS already run these three phases in a
single job. This is the Linux port of that layout, step bodies unchanged.

studio-windows-inference-smoke.yml carried a note saying the trade was not worth
making on ubuntu, because setup there is ~1.9 min against ~3.0 min of tests and
the sequential wall time would cost more than the slots are worth. The
arithmetic was right; the premise that the three jobs start together is not what
the runners do. Run 32089506294 started two jobs at 02:40:11 and the third at
02:46:52, then finished at 02:52:57: a 12m46s wall for about 6 min of work. Run
32089558062 staggered all three. Across 18 recent multi-job runs on main the
median gap between a run's first and last job start was 175s, and 13 of the 18
exceeded 60s.

Bundled is about 7m35 every time. When all three do get slots at once that is
~1m30 slower than the 6m05 longest job; when they do not it is 2-5 min faster.
It also returns 2 of the 60 concurrent slots, which is what makes the contended
case rarer for every other workflow.

Each phase keeps its own model cache directory, HF_HOME, port, server log,
artifact and step timeouts, and gates on the shared preamble rather than on the
phase before it, so a phase-1 failure still lets phases 2 and 3 report. Phase 3
moves to hf-cache-vision with a key bump because phase 1 keeps hf-cache, whose
key is byte-shared with the macOS and Windows gemma phases.

tests/studio/test_gguf_smoke_phases_stay_independent.py asserts all of that from
the workflow rather than from a list, since every one of these regressions is
silent rather than red.