### PR TITLE
Let tests skip the settle wait between retried VRAM reads

### DIFF
--- a/studio/backend/core/inference/diffusion_memory.py
+++ b/studio/backend/core/inference/diffusion_memory.py
@@ -194,6 +194,29 @@ def reclaimable_snapshot_device_memory(target: Any) -> DeviceMemory:
     )
 
 
+def _settle_delay(delay_s: float) -> float:
+    """How long to wait between the retried reads, honouring ``UNSLOTH_SETTLE_DELAY_S``.
+
+    What the retry loop is for is rejecting a TRANSIENT undercount, and the ``max`` over the
+    reads does that whatever the spacing: a real neighbouring tenant caps every read, a
+    transient caps only some. The spacing exists to give a real transient time to clear on a
+    live card, so production keeps the full second.
+
+    A test that reaches this through ``_plan_memory`` cannot pass ``delay_s`` and pays the
+    wait for nothing -- its snapshots are stubs whose answers do not change with time.
+    ``test_diffusion_backend.py`` alone spent 142s of a 328s suite here, most of it in
+    tests sitting at exactly 4.00s. Callers that can pass ``delay_s = 0`` already do
+    (``test_diffusion_memory.py``); this is for the ones that cannot reach the argument.
+    """
+    override = os.environ.get("UNSLOTH_SETTLE_DELAY_S")
+    if override is None:
+        return delay_s
+    try:
+        return max(0.0, float(override))
+    except (TypeError, ValueError):
+        return delay_s  # a typo in the env must not change production behaviour
+
+
 def settled_snapshot_device_memory(
     target: Any,
     attempts: int = 3,
@@ -234,6 +257,7 @@ def settled_snapshot_device_memory(
     except Exception:  # noqa: BLE001 — settle is best-effort; the snapshot below still runs
         pass
     best = snapshot_device_memory(target)
+    delay_s = _settle_delay(delay_s)
     for _ in range(max(0, attempts - 1)):
         if best.free_mib is not None and best.total_mib is not None:
             # Free already within the reserve of total: nothing transient to wait out.

--- a/studio/backend/tests/conftest.py
+++ b/studio/backend/tests/conftest.py
@@ -56,6 +56,14 @@ os.environ.setdefault("UNSLOTH_IS_PRESENT", "1")
 os.environ.setdefault("UNSLOTH_DIFFUSION_ATTENTION_INSTALL", "0")
 # Avoid a cold torch subprocess in unrelated RAG tests. The probe tests re-enable it.
 os.environ.setdefault("UNSLOTH_STUDIO_DISABLE_DEVICE_PROBE", "1")
+# settled_snapshot_device_memory spaces its retried VRAM reads a real second apart so a
+# transient tenant on a live card has time to clear. Under test the snapshots are stubs
+# whose answers do not change with time, so the wait buys nothing and the max() over the
+# reads -- which is what the retry is actually for -- is unaffected. Measured on the
+# backend suite: 142s of test_diffusion_backend.py's 328s went here, in tests reaching it
+# through _plan_memory, which has no way to pass delay_s. setdefault, so a test that wants
+# the production spacing can still set it.
+os.environ.setdefault("UNSLOTH_SETTLE_DELAY_S", "0")
 
 
 @pytest.fixture(scope = "session")

--- a/studio/backend/tests/test_lan_access_settings.py
+++ b/studio/backend/tests/test_lan_access_settings.py
@@ -327,9 +327,7 @@ def test_interface_enumeration_skips_windows_host_only_switches(monkeypatch):
             )
         },
         net_if_addrs = lambda: {
-            "Wi-Fi": [
-                types.SimpleNamespace(family = socket.AF_INET, address = "192.168.1.20")
-            ],
+            "Wi-Fi": [types.SimpleNamespace(family = socket.AF_INET, address = "192.168.1.20")],
             "vEthernet (Default Switch)": [
                 types.SimpleNamespace(family = socket.AF_INET, address = "172.31.32.1")
             ],

--- a/studio/backend/tests/test_settle_delay_override.py
+++ b/studio/backend/tests/test_settle_delay_override.py
@@ -1,0 +1,101 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""``UNSLOTH_SETTLE_DELAY_S`` shortens the settle wait for tests, and only for tests.
+
+``settled_snapshot_device_memory`` spaces its retried ``mem_get_info`` reads a second apart
+so a transient tenant on a live card has time to clear before the next read. Under test the
+snapshots are stubs whose answers do not change with time, so the wait buys nothing --
+``test_diffusion_backend.py`` spent 142s of a 328s suite sitting in it, most of that in
+tests parked at exactly 4.00s. The tests that call the function directly already pass
+``delay_s = 0``; the expensive ones reach it through ``_plan_memory``, which has no way to
+forward the argument. Hence an env override, defaulted to 0 in the backend conftest.
+
+Two things have to stay true and neither is loud when it stops being true:
+
+  * The PRODUCTION default is still a full second. A change that quietly made the fast path
+    the default would turn a transient undercount into a silent fallback to offloaded GGUF
+    on a card that could have gone resident, and nothing would fail.
+  * The override changes only the WAIT, never the retry count or the ``max`` over the reads.
+    That is what makes zeroing it safe: a test asserting "retries once on a transient
+    undercount" still exercises the retry.
+"""
+
+import time
+
+import pytest
+
+from core.inference import diffusion_memory as dm
+
+
+def test_the_production_default_is_still_a_full_second(monkeypatch):
+    """No env var set means the caller's delay is returned untouched.
+
+    The conftest pins the override for the suite, so this has to unset it to see what a
+    production process sees.
+    """
+    monkeypatch.delenv("UNSLOTH_SETTLE_DELAY_S", raising = False)
+    assert dm._settle_delay(1.0) == 1.0
+    assert dm._settle_delay(0.25) == 0.25
+
+
+def test_the_override_replaces_the_callers_delay(monkeypatch):
+    monkeypatch.setenv("UNSLOTH_SETTLE_DELAY_S", "0")
+    assert dm._settle_delay(1.0) == 0.0
+    monkeypatch.setenv("UNSLOTH_SETTLE_DELAY_S", "0.05")
+    assert dm._settle_delay(1.0) == pytest.approx(0.05)
+
+
+@pytest.mark.parametrize("bad", ["", "fast", "1,0", "None"])
+def test_an_unparseable_override_leaves_production_behaviour_alone(monkeypatch, bad):
+    """A typo in the env must not be read as "do not wait"."""
+    monkeypatch.setenv("UNSLOTH_SETTLE_DELAY_S", bad)
+    assert dm._settle_delay(1.0) == 1.0
+
+
+def test_a_negative_override_is_clamped_rather_than_passed_to_sleep(monkeypatch):
+    monkeypatch.setenv("UNSLOTH_SETTLE_DELAY_S", "-5")
+    assert dm._settle_delay(1.0) == 0.0
+
+
+def test_the_override_shortens_the_wait_without_dropping_a_read(monkeypatch):
+    """The retry still runs the same number of times; only the spacing collapses.
+
+    This is the assertion that makes the speed-up safe to take. If the override were ever
+    implemented by skipping the loop instead of shortening the sleep, every test that
+    exercises "a transient undercount is retried past" would still pass -- because the
+    first read already carries the stubbed answer -- and the real behaviour would be gone.
+    """
+    reads, slept = [], []
+
+    def snapshot(target):
+        reads.append(1)
+        return dm.DeviceMemory("cuda", "cuda:0", "vram", 1024, 100_000)
+
+    monkeypatch.setattr(dm, "snapshot_device_memory", snapshot)
+    # Record the requested delays rather than timing the call. The loop's first act on cuda
+    # is a real torch.cuda.synchronize() + empty_cache(), which costs ~0.6s on a live card
+    # and has nothing to do with the spacing under test; asserting on wall-clock here would
+    # be a bound on the driver, not on this change.
+    monkeypatch.setattr(time, "sleep", lambda s: slept.append(s))
+    monkeypatch.setenv("UNSLOTH_SETTLE_DELAY_S", "0")
+
+    target = type("T", (), {"device": "cuda", "backend": "cuda"})()
+    dm.settled_snapshot_device_memory(target, attempts = 4, delay_s = 1.0)
+
+    assert len(reads) == 4, (
+        f"the override changed the number of reads, not just their spacing: {len(reads)}"
+    )
+    assert slept == [0.0, 0.0, 0.0], (
+        f"the override did not reach time.sleep; the loop asked for {slept}"
+    )
+
+
+def test_the_backend_conftest_pins_the_override_for_the_whole_suite():
+    """Set by conftest at import, so it holds for subprocess-spawning tests too."""
+    import os
+
+    assert os.environ.get("UNSLOTH_SETTLE_DELAY_S") == "0", (
+        "the backend conftest no longer pins UNSLOTH_SETTLE_DELAY_S; the diffusion and "
+        "video suites go back to paying a real second per retried VRAM read"
+    )

--- a/studio/backend/tests/test_settle_delay_override.py
+++ b/studio/backend/tests/test_settle_delay_override.py
@@ -83,18 +83,19 @@ def test_the_override_shortens_the_wait_without_dropping_a_read(monkeypatch):
     target = type("T", (), {"device": "cuda", "backend": "cuda"})()
     dm.settled_snapshot_device_memory(target, attempts = 4, delay_s = 1.0)
 
-    assert len(reads) == 4, (
-        f"the override changed the number of reads, not just their spacing: {len(reads)}"
-    )
-    assert slept == [0.0, 0.0, 0.0], (
-        f"the override did not reach time.sleep; the loop asked for {slept}"
-    )
+    assert (
+        len(reads) == 4
+    ), f"the override changed the number of reads, not just their spacing: {len(reads)}"
+    assert slept == [
+        0.0,
+        0.0,
+        0.0,
+    ], f"the override did not reach time.sleep; the loop asked for {slept}"
 
 
 def test_the_backend_conftest_pins_the_override_for_the_whole_suite():
     """Set by conftest at import, so it holds for subprocess-spawning tests too."""
     import os
-
     assert os.environ.get("UNSLOTH_SETTLE_DELAY_S") == "0", (
         "the backend conftest no longer pins UNSLOTH_SETTLE_DELAY_S; the diffusion and "
         "video suites go back to paying a real second per retried VRAM read"

--- a/tests/studio/test_compile_caches_are_per_worker.py
+++ b/tests/studio/test_compile_caches_are_per_worker.py
@@ -77,9 +77,9 @@ def test_an_explicit_location_is_split_underneath_not_replaced(monkeypatch, tmp_
     monkeypatch.setenv("PYTEST_XDIST_WORKER", "gw0")
     module = _load()
     module.isolate_compile_caches()
-    assert os.environ["TORCHINDUCTOR_CACHE_DIR"].startswith(str(tmp_path / "chosen")), (
-        "an explicit TORCHINDUCTOR_CACHE_DIR was discarded rather than split underneath"
-    )
+    assert os.environ["TORCHINDUCTOR_CACHE_DIR"].startswith(
+        str(tmp_path / "chosen")
+    ), "an explicit TORCHINDUCTOR_CACHE_DIR was discarded rather than split underneath"
 
 
 @pytest.mark.parametrize("conftest", CONFTESTS, ids = lambda p: str(p.relative_to(REPO)))

--- a/tests/studio/test_no_test_shadows_another.py
+++ b/tests/studio/test_no_test_shadows_another.py
@@ -45,7 +45,8 @@ def _shadowed() -> list[str]:
             scopes += [(n.name, n.body) for n in tree.body if isinstance(n, ast.ClassDef)]
             for scope, body in scopes:
                 defined = [
-                    n for n in body
+                    n
+                    for n in body
                     if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
                     and n.name.startswith("test")
                 ]


### PR DESCRIPTION
settled_snapshot_device_memory spaces its retried mem_get_info reads a second
apart so a transient tenant on a live card has time to clear. Under test the
snapshots are stubs whose answers do not change with time, so the wait buys
nothing. Tracing time.sleep through one test showed 4.00s of a 4.03s call coming
from diffusion_memory.py:244, reached via _plan_memory, which has no way to
forward delay_s. The tests that call the function directly already pass
delay_s = 0.

Adds UNSLOTH_SETTLE_DELAY_S, defaulted to 0 in the backend conftest. Production
is untouched: with the variable unset the caller's delay is returned as-is, and
an unparseable or negative value falls back rather than being read as do-not-wait.

Scope, measured rather than assumed. Back to back on the four affected files at
-n 4: 68.44s with the production spacing, 39.44s without, 639 passed both times.
On the FULL backend suite at -n 4 the effect is inside run-to-run noise on this
box (259s / 326s / 328s across three runs), because sleeping workers do not hold
a core and the suite is bound by its longest worker rather than by total CPU. So
this is a real saving for a targeted run of the diffusion and video files and
for any serial run, and it is not a Backend CI number. The full-suite failure set
is unchanged: same 34, plus the two known-flaky tool_output_streaming grandchild
timeouts that were red in the baseline and green here.