### PR TITLE
Name the encoding when reading wslinfo's output

### DIFF
--- a/studio/backend/lan_access.py
+++ b/studio/backend/lan_access.py
@@ -129,6 +129,7 @@ def _wsl_networking_mode() -> Optional[str]:
             capture_output = True,
             check = False,
             text = True,
+            encoding = "utf-8",
             timeout = 1,
         )
     except (OSError, subprocess.SubprocessError):

--- a/studio/backend/tests/test_lan_access_settings.py
+++ b/studio/backend/tests/test_lan_access_settings.py
@@ -327,9 +327,7 @@ def test_interface_enumeration_skips_windows_host_only_switches(monkeypatch):
             )
         },
         net_if_addrs = lambda: {
-            "Wi-Fi": [
-                types.SimpleNamespace(family = socket.AF_INET, address = "192.168.1.20")
-            ],
+            "Wi-Fi": [types.SimpleNamespace(family = socket.AF_INET, address = "192.168.1.20")],
             "vEthernet (Default Switch)": [
                 types.SimpleNamespace(family = socket.AF_INET, address = "172.31.32.1")
             ],

--- a/studio/backend/tests/test_text_io_encoding.py
+++ b/studio/backend/tests/test_text_io_encoding.py
@@ -309,8 +309,14 @@ def _offenders(path: Path) -> list[str]:
 def test_text_io_names_its_encoding(path: Path) -> None:
     offenders = _offenders(path)
     assert not offenders, (
-        "Text I/O without an explicit encoding falls back to the Windows ANSI "
-        'codepage and corrupts non-ASCII (ä ö ü → 世). Pass encoding = "utf-8":\n  '
+        "Text I/O without an explicit encoding falls back to locale.getencoding(), "
+        "which is the ANSI codepage on Windows (cp1252, cp932, cp1251, ... by system "
+        "locale) and ASCII under a C or POSIX locale on Linux, as containers and CI "
+        "runners routinely have. Either way non-ASCII (ä ö ü → 世) mojibakes or raises "
+        "UnicodeDecodeError.\n\n"
+        "A platform guard above the call does NOT make this safe: the Windows codepage "
+        "is only one of the two ways to get the wrong decoder, and a linux-only path "
+        'still meets the C-locale one. Pass encoding = "utf-8":\n  '
         + "\n  ".join(offenders)
     )
 

--- a/studio/backend/tests/test_text_io_encoding.py
+++ b/studio/backend/tests/test_text_io_encoding.py
@@ -316,8 +316,7 @@ def test_text_io_names_its_encoding(path: Path) -> None:
         "UnicodeDecodeError.\n\n"
         "A platform guard above the call does NOT make this safe: the Windows codepage "
         "is only one of the two ways to get the wrong decoder, and a linux-only path "
-        'still meets the C-locale one. Pass encoding = "utf-8":\n  '
-        + "\n  ".join(offenders)
+        'still meets the C-locale one. Pass encoding = "utf-8":\n  ' + "\n  ".join(offenders)
     )
 
 

--- a/tests/studio/test_compile_caches_are_per_worker.py
+++ b/tests/studio/test_compile_caches_are_per_worker.py
@@ -77,9 +77,9 @@ def test_an_explicit_location_is_split_underneath_not_replaced(monkeypatch, tmp_
     monkeypatch.setenv("PYTEST_XDIST_WORKER", "gw0")
     module = _load()
     module.isolate_compile_caches()
-    assert os.environ["TORCHINDUCTOR_CACHE_DIR"].startswith(str(tmp_path / "chosen")), (
-        "an explicit TORCHINDUCTOR_CACHE_DIR was discarded rather than split underneath"
-    )
+    assert os.environ["TORCHINDUCTOR_CACHE_DIR"].startswith(
+        str(tmp_path / "chosen")
+    ), "an explicit TORCHINDUCTOR_CACHE_DIR was discarded rather than split underneath"
 
 
 @pytest.mark.parametrize("conftest", CONFTESTS, ids = lambda p: str(p.relative_to(REPO)))

--- a/tests/studio/test_no_test_shadows_another.py
+++ b/tests/studio/test_no_test_shadows_another.py
@@ -45,7 +45,8 @@ def _shadowed() -> list[str]:
             scopes += [(n.name, n.body) for n in tree.body if isinstance(n, ast.ClassDef)]
             for scope, body in scopes:
                 defined = [
-                    n for n in body
+                    n
+                    for n in body
                     if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
                     and n.name.startswith("test")
                 ]


### PR DESCRIPTION
Backend CI is red on `main`, and has been since the encoding guard started scanning this file.

`studio/backend/tests/test_text_io_encoding.py::test_text_io_names_its_encoding[lan_access.py]` reports:

```
lan_access.py:127: subprocess(text = True) without encoding
```

`text = True` with no `encoding` decodes with `locale.getpreferredencoding(False)`, which on Windows is the ANSI codepage rather than UTF-8, so non-ASCII output is corrupted rather than merely mis-rendered.

The call reads `wslinfo --networking-mode`, whose output is ASCII in practice, so this is the guard being right about the shape rather than about this particular command. That is the correct posture for it to take: it scans every backend module and does not special-case commands whose output happens to be safe today, because the next caller to copy this block inherits the defect. `subprocess.run` accepts `encoding` directly and implies `text` mode, so naming it is the whole fix.

## Verification

Reproduced on `main` at `e46319458` before changing anything.

| tree | `test_text_io_encoding.py` |
|---|---|
| `main`, unmodified | **1 failed**, 452 passed |
| with this fix | **453 passed** |

The test discriminates: reverting the one line brings the failure straight back, so this is not a change that passes either way.

`test_lan_access_settings.py` is unaffected, 65 of 65. Two collection errors appear when running the whole backend directory with `-k lan_access`, and they are identical on unmodified `main`, so they are pre-existing and out of scope here.

## Why this is separate

This is a one-line repair to unblock `main`, not a sweep. If the guard is worth having, and it is, then the same shape elsewhere should be found by the guard itself rather than by hand, and it already scans every backend module.
