### PR TITLE
studio: add a sampling seed to the chat run settings

### DIFF
--- a/studio/backend/routes/chat_history.py
+++ b/studio/backend/routes/chat_history.py
@@ -15,6 +15,7 @@ from typing import Annotated, Any, Literal, Optional, Union
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import (
     BaseModel,
+    BeforeValidator,
     ConfigDict,
     Field,
     ValidationError,
@@ -75,6 +76,22 @@ router = APIRouter()
 logger = get_logger(__name__)
 
 
+def _reject_boolean(value: Any) -> Any:
+    """bool subclasses int, so lax mode would take `true` for a number the user never set."""
+    if isinstance(value, bool):
+        raise ValueError("Expected a number, got a boolean.")
+    return value
+
+
+NotABoolean = Annotated[Optional[int], BeforeValidator(_reject_boolean)]
+
+# llama.cpp spends 0xFFFFFFFF on its "draw one" sentinel, so a pin stops one below it.
+MAX_SAMPLING_SEED = 2**32 - 2
+SamplingSeed = Optional[
+    Annotated[int, Field(ge = 0, le = MAX_SAMPLING_SEED), BeforeValidator(_reject_boolean)]
+]
+
+
 class ChatRagThreadSource(BaseModel):
     model_config = ConfigDict(extra = "forbid")
 
@@ -128,22 +145,11 @@ class ChatThreadSettings(BaseModel):
     minP: Optional[float] = Field(default = None, ge = 0, le = 1)
     repetitionPenalty: Optional[float] = Field(default = None, ge = 1, le = 2)
     presencePenalty: Optional[float] = Field(default = None, ge = 0, le = 2)
-    # Same ceiling as the installation-wide copy: llama.cpp reads the seed as a uint32
-    # and spends 0xFFFFFFFF on its "draw one" sentinel.
-    seed: Optional[int] = Field(default = None, ge = 0, le = 2**32 - 2)
+    seed: SamplingSeed = None
     # Not length-capped, like the installation-wide copy: truncating here would
     # silently change what the chat runs with.
     systemPrompt: Optional[str] = None
     systemVariables: Optional[str] = None
-
-    @field_validator("seed", mode = "before")
-    @classmethod
-    def _no_boolean_seed(cls, value: Any) -> Any:
-        # Same contract as ChatInferenceSettings: bool subclasses int, so lax mode
-        # would store `true` as a pin of 1 the user never set.
-        if isinstance(value, bool):
-            raise ValueError("Expected a number, got a boolean.")
-        return value
 
 
 class ChatThread(BaseModel):
@@ -396,16 +402,7 @@ class ChatInferenceSettings(BaseModel):
     systemVariables: Optional[str] = None
     trustRemoteCode: Optional[bool] = None
     fastMode: Optional[bool] = None
-    # llama.cpp reads the seed as a uint32 and spends 0xFFFFFFFF on its "draw one" sentinel.
-    seed: Optional[int] = Field(default = None, ge = 0, le = 2**32 - 2)
-
-    @field_validator("seed", mode = "before")
-    @classmethod
-    def _no_booleans(cls, value: Any) -> Any:
-        # Same contract as ChatPresetLoadConfig: bool subclasses int, so lax mode stores `true` as 1.
-        if isinstance(value, bool):
-            raise ValueError("Expected a number, got a boolean.")
-        return value
+    seed: SamplingSeed = None
 
 
 class ChatPresetLoadConfig(BaseModel):
@@ -421,21 +418,12 @@ class ChatPresetLoadConfig(BaseModel):
     # The normalizer emits both keys on every preset (null included) and this model is
     # extra="forbid", so without them PUT /api/chat/settings 400s the whole save for any
     # preset carrying a loadConfig, including one that only pinned nParallel.
-    nBatch: Optional[int] = Field(default = None, ge = BATCH_MIN, le = BATCH_MAX)
-    nUbatch: Optional[int] = Field(default = None, ge = BATCH_MIN, le = BATCH_MAX)
+    nBatch: NotABoolean = Field(default = None, ge = BATCH_MIN, le = BATCH_MAX)
+    nUbatch: NotABoolean = Field(default = None, ge = BATCH_MIN, le = BATCH_MAX)
     tensorParallel: Optional[bool] = None
     gpuMemoryMode: Optional[Literal["manual"]] = None
     gpuLayers: Optional[int] = None
     nCpuMoe: Optional[int] = Field(default = None, ge = 0)
-
-    @field_validator("nBatch", "nUbatch", mode = "before")
-    @classmethod
-    def _no_booleans(cls, value: Any) -> Any:
-        # Same contract as LoadRequest: bool subclasses int, so lax mode would store
-        # `true` as 1 here while /load 422s it.
-        if isinstance(value, bool):
-            raise ValueError("Expected a number, got a boolean.")
-        return value
 
 
 class ChatPreset(BaseModel):

--- a/studio/backend/routes/chat_history.py
+++ b/studio/backend/routes/chat_history.py
@@ -121,10 +121,22 @@ class ChatThreadSettings(BaseModel):
     minP: Optional[float] = Field(default = None, ge = 0, le = 1)
     repetitionPenalty: Optional[float] = Field(default = None, ge = 1, le = 2)
     presencePenalty: Optional[float] = Field(default = None, ge = 0, le = 2)
+    # Same ceiling as the installation-wide copy: llama.cpp reads the seed as a uint32
+    # and spends 0xFFFFFFFF on its "draw one" sentinel.
+    seed: Optional[int] = Field(default = None, ge = 0, le = 2**32 - 2)
     # Not length-capped, like the installation-wide copy: truncating here would
     # silently change what the chat runs with.
     systemPrompt: Optional[str] = None
     systemVariables: Optional[str] = None
+
+    @field_validator("seed", mode = "before")
+    @classmethod
+    def _no_boolean_seed(cls, value: Any) -> Any:
+        # Same contract as ChatInferenceSettings: bool subclasses int, so lax mode
+        # would store `true` as a pin of 1 the user never set.
+        if isinstance(value, bool):
+            raise ValueError("Expected a number, got a boolean.")
+        return value
 
 
 class ChatThread(BaseModel):

--- a/studio/backend/routes/chat_history.py
+++ b/studio/backend/routes/chat_history.py
@@ -13,7 +13,14 @@ import sqlite3
 from typing import Annotated, Any, Literal, Optional, Union
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
-from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    ValidationError,
+    field_serializer,
+    field_validator,
+)
 
 from auth.authentication import get_current_subject
 from core.inference.llama_server_args import BATCH_MAX, BATCH_MIN, PARALLEL_MAX, PARALLEL_MIN
@@ -154,6 +161,21 @@ class ChatThread(BaseModel):
     forkedFromThreadId: Optional[str] = None
     forkedFromMessageId: Optional[str] = None
     settings: Optional[ChatThreadSettings] = None
+
+    @field_serializer("settings")
+    def _only_the_keys_the_snapshot_stored(
+        self, settings: Optional[ChatThreadSettings]
+    ) -> Optional[dict]:
+        """Report a key the snapshot never held as absent rather than as null.
+
+        `seed` is the one setting whose null is a value: it means this chat draws its own
+        rather than taking the pinned one. Spelling every unset field as null, which is
+        what the default dump does, would make a snapshot written before the field existed
+        read as a chat that had cleared it.
+        """
+        if settings is None:
+            return None
+        return settings.model_dump(exclude_unset = True)
 
 
 def thread_from_row(row: dict) -> ChatThread:

--- a/studio/backend/routes/chat_history.py
+++ b/studio/backend/routes/chat_history.py
@@ -362,6 +362,16 @@ class ChatInferenceSettings(BaseModel):
     systemVariables: Optional[str] = None
     trustRemoteCode: Optional[bool] = None
     fastMode: Optional[bool] = None
+    # llama.cpp reads the seed as a uint32 and spends 0xFFFFFFFF on its "draw one" sentinel.
+    seed: Optional[int] = Field(default = None, ge = 0, le = 2**32 - 2)
+
+    @field_validator("seed", mode = "before")
+    @classmethod
+    def _no_booleans(cls, value: Any) -> Any:
+        # Same contract as ChatPresetLoadConfig: bool subclasses int, so lax mode stores `true` as 1.
+        if isinstance(value, bool):
+            raise ValueError("Expected a number, got a boolean.")
+        return value
 
 
 class ChatPresetLoadConfig(BaseModel):

--- a/studio/backend/tests/test_chat_settings_payload.py
+++ b/studio/backend/tests/test_chat_settings_payload.py
@@ -206,3 +206,42 @@ def test_the_rejection_detail_can_be_rendered_as_json():
         put_settings({"ragAutoInjectMinScore": float("nan")}, current_subject = "t")
     assert excinfo.value.status_code == 400
     json.dumps(excinfo.value.detail, allow_nan = False)
+
+
+def test_a_sampling_seed_survives_the_payload():
+    payload = ChatSettingsPayload.model_validate({"inferenceParams": {"seed": 3407}})
+    assert payload.model_dump(exclude_unset = True) == {"inferenceParams": {"seed": 3407}}
+
+
+def test_clearing_the_seed_reaches_the_merge_as_null():
+    """A cleared seed is an explicit null, not an omission: the merge overwrites per
+    key and never removes one, so an omitted seed would leave the old pin in place."""
+    payload = ChatSettingsPayload.model_validate({"inferenceParams": {"seed": None}})
+    updates = payload.model_dump(exclude_unset = True)
+    assert updates == {"inferenceParams": {"seed": None}}
+
+    merged = _deep_merge_settings({"inferenceParams": {"seed": 3407, "topP": 0.9}}, updates)
+    assert merged["inferenceParams"] == {"seed": None, "topP": 0.9}
+
+
+@pytest.mark.parametrize(
+    "seed",
+    [
+        # bool subclasses int, so lax mode would store either as a pin the user never set.
+        True,
+        False,
+        -1,
+        2**32 - 1,  # llama.cpp's "draw one" sentinel, not a value a pin can name.
+        2**32,
+        1e40,
+    ],
+)
+def test_out_of_range_seeds_are_refused(seed):
+    with pytest.raises(ValidationError):
+        ChatSettingsPayload.model_validate({"inferenceParams": {"seed": seed}})
+
+
+@pytest.mark.parametrize("seed", [0, 3407, 2**32 - 2])
+def test_the_whole_uint32_pin_range_is_accepted(seed):
+    payload = ChatSettingsPayload.model_validate({"inferenceParams": {"seed": seed}})
+    assert payload.model_dump(exclude_unset = True) == {"inferenceParams": {"seed": seed}}

--- a/studio/backend/tests/test_chat_thread_settings.py
+++ b/studio/backend/tests/test_chat_thread_settings.py
@@ -13,6 +13,8 @@ import sys
 from pathlib import Path
 
 import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
 from pydantic import ValidationError
 
 _BACKEND = Path(__file__).resolve().parents[1]
@@ -701,3 +703,31 @@ def test_a_cleared_seed_stays_in_the_stored_snapshot():
     come back for the one chat the user deliberately unpinned."""
     assert readable_thread_settings({"seed": None}) == {"seed": None}
     assert ChatThreadSettings.model_validate({"seed": None}).seed is None
+
+
+def _thread_row(settings):
+    row = {"id": "thread-1", "modelType": "base", "createdAt": 0}
+    return row if settings is None else {**row, "settings": settings}
+
+
+@pytest.mark.parametrize(
+    "stored, expected",
+    [
+        # Written before the seed existed. Absent, so the chat takes the pin it inherits.
+        ({"temperature": 0.3}, {"temperature": 0.3}),
+        # Written by a build that has it, with the pin cleared. null is the chat's choice.
+        ({"temperature": 0.3, "seed": None}, {"temperature": 0.3, "seed": None}),
+        ({"temperature": 0.3, "seed": 3407}, {"temperature": 0.3, "seed": 3407}),
+    ],
+)
+def test_the_response_says_absent_for_a_key_the_snapshot_never_held(stored, expected):
+    """The default dump spells every unset field as null, and the client drops those, so
+    a pre-seed snapshot would read as a chat that had cleared the pin."""
+    app = FastAPI()
+
+    @app.get("/thread", response_model = ChatThread)
+    def _read():
+        return thread_from_row(_thread_row(stored))
+
+    with TestClient(app) as client:
+        assert client.get("/thread").json()["settings"] == expected

--- a/studio/backend/tests/test_chat_thread_settings.py
+++ b/studio/backend/tests/test_chat_thread_settings.py
@@ -24,6 +24,7 @@ from routes.chat_history import (  # noqa: E402
     ChatThreadPatch,
     ChatThreadSettings,
     _settings_write_from_patch,
+    readable_thread_settings,
     thread_from_row,
 )
 from storage import studio_db  # noqa: E402
@@ -668,3 +669,35 @@ def test_an_older_build_drops_only_the_sampling_it_cannot_read():
         {"toolsEnabled": True, "temperature": 0.3, "somethingNewer": "?"}
     )
     assert kept == {"toolsEnabled": True, "temperature": 0.3}
+
+
+def test_a_chat_carries_its_own_sampling_seed():
+    """The seed sits with the sliders the snapshot already carries, so without it a pin
+    taken in one chat fixes the draw for every other chat on the same model."""
+    assert ChatThreadSettings.model_validate({"seed": 3407}).seed == 3407
+    assert ChatThreadSettings.model_validate({"seed": 0}).seed == 0
+    assert ChatThreadSettings.model_validate({"seed": 2**32 - 2}).seed == 2**32 - 2
+
+
+@pytest.mark.parametrize(
+    "seed",
+    [
+        # bool subclasses int, so lax mode would store either as a pin the user never set.
+        True,
+        False,
+        -1,
+        2**32 - 1,  # llama.cpp's "draw one" sentinel, not a value a pin can name.
+        2**32,
+        1.5,
+    ],
+)
+def test_a_thread_seed_takes_the_same_range_as_the_installation_copy(seed):
+    with pytest.raises(ValidationError):
+        ChatThreadSettings.model_validate({"seed": seed})
+
+
+def test_a_cleared_seed_stays_in_the_stored_snapshot():
+    """null is the clear, not an absence: dropping the key would let the installation pin
+    come back for the one chat the user deliberately unpinned."""
+    assert readable_thread_settings({"seed": None}) == {"seed": None}
+    assert ChatThreadSettings.model_validate({"seed": None}).seed is None

--- a/studio/backend/tests/test_health_answers_within_probe_budget.py
+++ b/studio/backend/tests/test_health_answers_within_probe_budget.py
@@ -560,9 +560,9 @@ def test_a_cold_health_call_answers_inside_the_launcher_deadline():
     probe_timeout = _desktop_probe_timeout_s()
     result = _probe(_SLOW_DETECT_S)
 
-    assert result["cold_hardware_detecting"] is True, (
-        "the cold call got a settled reply, so it never exercised the wait this bound is about"
-    )
+    assert (
+        result["cold_hardware_detecting"] is True
+    ), "the cold call got a settled reply, so it never exercised the wait this bound is about"
     assert result["cold_elapsed"] < probe_timeout, (
         f"the first /api/health call took {result['cold_elapsed']:.2f}s, past the "
         f"{probe_timeout}s the desktop probe allows before it gives up and dead-ends "

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -5737,14 +5737,10 @@ export function createOpenAIStreamAdapter(
             min_p: params.minP,
             repetition_penalty: params.repetitionPenalty,
             presence_penalty: params.presencePenalty,
-            // Omitted when unset so llama-server keeps drawing a fresh seed, and when the
-            // model does not reach it, so a pin left over from a GGUF is not sent invisibly.
-            ...(params.seed == null ||
-            !modelReadsSamplingSeed(
-              runtime.activeGgufVariant,
-              runtime.ggufContextLength,
-              params.checkpoint,
-            )
+            // Omitted when unset so the server keeps drawing a fresh seed, and when the
+            // backend does not read one, so a pin left over from a GGUF is not sent
+            // invisibly after a switch to transformers.
+            ...(params.seed == null || !modelReadsSamplingSeed(activeModel)
               ? {}
               : { seed: params.seed }),
             image_base64: imageBase64,

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -166,7 +166,7 @@ import type {
   OpenAIMessageContent,
   OpenAIReasoningContentPart,
 } from "../types/api";
-import type { ChatModelSummary } from "../types/runtime";
+import { modelReadsSamplingSeed, type ChatModelSummary } from "../types/runtime";
 import { loadFallbackNotice } from "../utils/mmproj-fallback";
 import {
   getStoredChatThread,
@@ -5737,6 +5737,16 @@ export function createOpenAIStreamAdapter(
             min_p: params.minP,
             repetition_penalty: params.repetitionPenalty,
             presence_penalty: params.presencePenalty,
+            // Omitted when unset so llama-server keeps drawing a fresh seed, and when the
+            // model does not reach it, so a pin left over from a GGUF is not sent invisibly.
+            ...(params.seed == null ||
+            !modelReadsSamplingSeed(
+              runtime.activeGgufVariant,
+              runtime.ggufContextLength,
+              params.checkpoint,
+            )
+              ? {}
+              : { seed: params.seed }),
             image_base64: imageBase64,
             audio_base64: audioBase64,
             video_base64: videoBase64,

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -166,7 +166,7 @@ import type {
   OpenAIMessageContent,
   OpenAIReasoningContentPart,
 } from "../types/api";
-import { modelReadsSamplingSeed, type ChatModelSummary } from "../types/runtime";
+import { modelReadsSamplingSeed, type ChatModelRow } from "../types/runtime";
 import { loadFallbackNotice } from "../utils/mmproj-fallback";
 import {
   getStoredChatThread,
@@ -3673,12 +3673,15 @@ async function autoLoadSmallestModel(options?: AutoLoadOptions): Promise<{
             maxTokensCap: loadResp.context_length ?? undefined,
           },
         );
-        const defaultModel: ChatModelSummary = {
+        const defaultModel: ChatModelRow = {
           id: DEFAULT_CHAT_MODEL_REPO,
           name: loadResp.display_name ?? DEFAULT_CHAT_MODEL_LABEL,
           isVision: loadResp.is_vision ?? false,
           isLora: false,
           isGguf: true,
+          isMlx: false,
+          isAudio: false,
+          hasAudioInput: false,
         };
         if (!store.models.some((m) => m.id === DEFAULT_CHAT_MODEL_REPO)) {
           store.setModels([...store.models, defaultModel]);

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -2308,6 +2308,9 @@ function queuedResolvedModelFromStore(
       ? {
           isVision: activeModel.isVision,
           isGguf: activeModel.isGguf,
+          // The queued run mints its own summary for a model with no catalog row, and
+          // the sampling seed is gated on this.
+          isMlx: activeModel.isMlx,
           isAudio: activeModel.isAudio,
           audioType: activeModel.audioType,
           hasAudioInput: activeModel.hasAudioInput,
@@ -3803,6 +3806,7 @@ async function resolveQueuedEmptyLocalModel(
             modelCapabilities: {
               isVision: status.is_vision ?? false,
               isGguf: status.is_gguf ?? false,
+              isMlx: status.is_mlx ?? false,
               isAudio: status.is_audio ?? false,
               audioType: status.audio_type ?? null,
               hasAudioInput: status.has_audio_input ?? false,

--- a/studio/frontend/src/features/chat/chat-settings-sheet.tsx
+++ b/studio/frontend/src/features/chat/chat-settings-sheet.tsx
@@ -633,6 +633,27 @@ export function ChatSettingsPanel({
   // Clamping straight into params would rewrite the box mid-entry, so the commit
   // waits for blur the way NumericValueInput's does.
   const [seedDraft, setSeedDraft] = useState<string | null>(null);
+  // What blur would commit, available before it runs. Clicking Save blurs the box during
+  // mousedown, but React has not re-rendered by the time that button's onClick fires, so
+  // a handler reading `params` there still sees the seed from before the entry.
+  // NumericValueInput bridges the same gap with its imperative commit().
+  const committedSeed = useMemo<number | null>(() => {
+    if (seedDraft === null) return params.seed ?? null;
+    // Measured after the padding: a zero-padded seed is short enough to keep, and
+    // truncating instead of clamping would rewrite it.
+    const digits = seedDraft.replace(/^0+(?=\d)/, "");
+    if (digits === "") return null;
+    return digits.length > 10
+      ? MAX_SAMPLING_SEED
+      : Math.min(Number(digits), MAX_SAMPLING_SEED);
+  }, [params.seed, seedDraft]);
+  const paramsWithCommittedSeed = useMemo(
+    () =>
+      committedSeed === (params.seed ?? null)
+        ? params
+        : { ...params, seed: committedSeed },
+    [committedSeed, params],
+  );
   // When the prompt overflows the inline box, clicking opens the popup editor.
   const systemPromptBoxRef = useRef<HTMLTextAreaElement>(null);
   const [systemPromptOverflows, setSystemPromptOverflows] = useState(false);
@@ -676,8 +697,12 @@ export function ChatSettingsPanel({
       }
       const samplingChanged =
         activePresetDefinition.name === "Default"
-          ? activePresetSource === "modified"
-          : !isSamePresetConfig(activePresetDefinition.params, params);
+          ? activePresetSource === "modified" ||
+            committedSeed !== (params.seed ?? null)
+          : !isSamePresetConfig(
+              activePresetDefinition.params,
+              paramsWithCommittedSeed,
+            );
       const currentLoadConfig = capturePresetLoadConfig();
       const loadChanged = !isSamePresetLoadConfig(
         activePresetDefinition.loadConfig,
@@ -688,6 +713,8 @@ export function ChatSettingsPanel({
     activePresetDefinition,
     activePresetSource,
     params,
+    committedSeed,
+    paramsWithCommittedSeed,
     customContextLength,
     ggufContextLength,
     kvCacheDtype,
@@ -883,7 +910,7 @@ export function ChatSettingsPanel({
       ...next,
       {
         name: saveName,
-        params: toPresetParams(params),
+        params: toPresetParams(paramsWithCommittedSeed),
         ...(loadConfig ? { loadConfig } : {}),
       },
     ];
@@ -1542,17 +1569,8 @@ export function ChatSettingsPanel({
                     }
                     onBlur={() => {
                       if (seedDraft === null) return;
-                      // Measured after the padding: a zero-padded seed is short enough
-                      // to keep, and truncating instead of clamping would rewrite it.
-                      const digits = seedDraft.replace(/^0+(?=\d)/, "");
                       setSeedDraft(null);
-                      setSeed(
-                        digits === ""
-                          ? null
-                          : digits.length > 10
-                            ? MAX_SAMPLING_SEED
-                            : Math.min(Number(digits), MAX_SAMPLING_SEED),
-                      );
+                      setSeed(committedSeed);
                     }}
                     onKeyDown={(e) => {
                       // Blur is the only commit, so Enter has to reach it.

--- a/studio/frontend/src/features/chat/chat-settings-sheet.tsx
+++ b/studio/frontend/src/features/chat/chat-settings-sheet.tsx
@@ -654,6 +654,11 @@ export function ChatSettingsPanel({
         : { ...params, seed: committedSeed },
     [committedSeed, params],
   );
+  // Removing a focused element fires no blur, so a draft the user walked away from
+  // would keep reporting through committedSeed with the field gone.
+  useEffect(() => {
+    setSeedDraft(null);
+  }, [currentCheckpoint, showSeed]);
   // When the prompt overflows the inline box, clicking opens the popup editor.
   const systemPromptBoxRef = useRef<HTMLTextAreaElement>(null);
   const [systemPromptOverflows, setSystemPromptOverflows] = useState(false);

--- a/studio/frontend/src/features/chat/chat-settings-sheet.tsx
+++ b/studio/frontend/src/features/chat/chat-settings-sheet.tsx
@@ -505,7 +505,7 @@ export function ChatSettingsPanel({
   const showPresencePenalty =
     !isExternalModel || Boolean(providerCapabilities?.presencePenalty);
   const isMobile = useIsMobile();
-  const activeGgufVariant = useChatRuntimeStore((s) => s.activeGgufVariant);
+  const isLoadedGguf = useChatRuntimeStore((s) => s.activeGgufVariant) != null;
   const currentCheckpoint = params.checkpoint;
   const activeModelIsLocal = useChatRuntimeStore(
     (s) => s.activeModelIsLocal,
@@ -516,21 +516,16 @@ export function ChatSettingsPanel({
   // suffix too (mirrors the chat page's activeModelIsGguf). Otherwise Max Tokens
   // would fall back to params.maxSeqLength instead of the loaded GGUF context.
   const isGguf =
-    activeGgufVariant != null ||
+    isLoadedGguf ||
     ggufContextLength != null ||
     (currentCheckpoint?.toLowerCase().endsWith(".gguf") ?? false);
-  const activeModelSummary = useChatRuntimeStore(
+  const activeModel = useChatRuntimeStore(
     (s) => s.models.find((m) => m.id === currentCheckpoint) ?? null,
   );
-  // The predicate the request body gates on too, so the panel cannot offer a seed it drops.
-  const showSeed =
-    !isExternalModel &&
-    modelReadsSamplingSeed(
-      activeGgufVariant,
-      ggufContextLength,
-      currentCheckpoint,
-      activeModelSummary,
-    );
+  // Same call the request body makes, on the same summary, so the panel cannot offer a
+  // seed the body drops. An external selection carries an `external::` id that no local
+  // entry matches, so the summary answers that case without a separate guard.
+  const showSeed = modelReadsSamplingSeed(activeModel);
   const platformDeviceType = usePlatformStore((s) => s.deviceType);
   // Unified memory, not just Darwin: an Intel Mac spills to system RAM like a PC.
   const isUnifiedMemory = usePlatformStore((s) => s.appleSilicon);
@@ -634,6 +629,10 @@ export function ChatSettingsPanel({
   const [systemPromptDraft, setSystemPromptDraft] = useState("");
   const [systemVariablesDraft, setSystemVariablesDraft] = useState("");
   const [systemVariablesOpen, setSystemVariablesOpen] = useState(false);
+  // Raw keystrokes while the Seed box is being typed into, null once committed.
+  // Clamping straight into params would rewrite the box mid-entry, so the commit
+  // waits for blur the way NumericValueInput's does.
+  const [seedDraft, setSeedDraft] = useState<string | null>(null);
   // When the prompt overflows the inline box, clicking opens the popup editor.
   const systemPromptBoxRef = useRef<HTMLTextAreaElement>(null);
   const [systemPromptOverflows, setSystemPromptOverflows] = useState(false);
@@ -1520,7 +1519,10 @@ export function ChatSettingsPanel({
                     reproduce the same reply. Leave blank to draw a fresh seed
                     each request. It only fixes the draw, so the other sampling
                     settings have to stay put as well; at Temperature 0 decoding
-                    is already greedy and a seed changes nothing.
+                    is already greedy and a seed changes nothing. Matching a
+                    reply also needs the model loaded with Parallel Slots at 1
+                    and Speculative Decoding off, since both change how tokens
+                    are batched and that moves the result.
                   </InfoHint>
                 </div>
                 <InputGroup className="panel-input-group w-[8.5rem] shrink-0">
@@ -1531,13 +1533,19 @@ export function ChatSettingsPanel({
                     inputMode="numeric"
                     autoComplete="off"
                     spellCheck={false}
-                    value={params.seed == null ? "" : String(params.seed)}
-                    onChange={(e) => {
-                      const digits = e.target.value
-                        .replace(/\D/g, "")
-                        // Measured after the padding: a zero-padded seed is short enough
-                        // to keep, and truncating instead of clamping would rewrite it.
-                        .replace(/^0+(?=\d)/, "");
+                    value={
+                      seedDraft ??
+                      (params.seed == null ? "" : String(params.seed))
+                    }
+                    onChange={(e) =>
+                      setSeedDraft(e.target.value.replace(/\D/g, ""))
+                    }
+                    onBlur={() => {
+                      if (seedDraft === null) return;
+                      // Measured after the padding: a zero-padded seed is short enough
+                      // to keep, and truncating instead of clamping would rewrite it.
+                      const digits = seedDraft.replace(/^0+(?=\d)/, "");
+                      setSeedDraft(null);
                       setSeed(
                         digits === ""
                           ? null
@@ -1545,6 +1553,10 @@ export function ChatSettingsPanel({
                             ? MAX_SAMPLING_SEED
                             : Math.min(Number(digits), MAX_SAMPLING_SEED),
                       );
+                    }}
+                    onKeyDown={(e) => {
+                      // Blur is the only commit, so Enter has to reach it.
+                      if (e.key === "Enter") e.currentTarget.blur();
                     }}
                     placeholder="Random"
                     aria-label="Seed"

--- a/studio/frontend/src/features/chat/chat-settings-sheet.tsx
+++ b/studio/frontend/src/features/chat/chat-settings-sheet.tsx
@@ -519,6 +519,9 @@ export function ChatSettingsPanel({
     activeGgufVariant != null ||
     ggufContextLength != null ||
     (currentCheckpoint?.toLowerCase().endsWith(".gguf") ?? false);
+  const activeModelSummary = useChatRuntimeStore(
+    (s) => s.models.find((m) => m.id === currentCheckpoint) ?? null,
+  );
   // The predicate the request body gates on too, so the panel cannot offer a seed it drops.
   const showSeed =
     !isExternalModel &&
@@ -526,6 +529,7 @@ export function ChatSettingsPanel({
       activeGgufVariant,
       ggufContextLength,
       currentCheckpoint,
+      activeModelSummary,
     );
   const platformDeviceType = usePlatformStore((s) => s.deviceType);
   // Unified memory, not just Darwin: an Intel Mac spills to system RAM like a PC.

--- a/studio/frontend/src/features/chat/chat-settings-sheet.tsx
+++ b/studio/frontend/src/features/chat/chat-settings-sheet.tsx
@@ -105,7 +105,11 @@ import {
   isLocalModelPath,
   useChatRuntimeStore,
 } from "./stores/chat-runtime-store";
-import type { InferenceParams } from "./types/runtime";
+import {
+  MAX_SAMPLING_SEED,
+  modelReadsSamplingSeed,
+  type InferenceParams,
+} from "./types/runtime";
 
 export { defaultInferenceParams, type Preset } from "./presets/preset-policy";
 export type { InferenceParams } from "./types/runtime";
@@ -501,7 +505,7 @@ export function ChatSettingsPanel({
   const showPresencePenalty =
     !isExternalModel || Boolean(providerCapabilities?.presencePenalty);
   const isMobile = useIsMobile();
-  const isLoadedGguf = useChatRuntimeStore((s) => s.activeGgufVariant) != null;
+  const activeGgufVariant = useChatRuntimeStore((s) => s.activeGgufVariant);
   const currentCheckpoint = params.checkpoint;
   const activeModelIsLocal = useChatRuntimeStore(
     (s) => s.activeModelIsLocal,
@@ -512,9 +516,17 @@ export function ChatSettingsPanel({
   // suffix too (mirrors the chat page's activeModelIsGguf). Otherwise Max Tokens
   // would fall back to params.maxSeqLength instead of the loaded GGUF context.
   const isGguf =
-    isLoadedGguf ||
+    activeGgufVariant != null ||
     ggufContextLength != null ||
     (currentCheckpoint?.toLowerCase().endsWith(".gguf") ?? false);
+  // The predicate the request body gates on too, so the panel cannot offer a seed it drops.
+  const showSeed =
+    !isExternalModel &&
+    modelReadsSamplingSeed(
+      activeGgufVariant,
+      ggufContextLength,
+      currentCheckpoint,
+    );
   const platformDeviceType = usePlatformStore((s) => s.deviceType);
   // Unified memory, not just Darwin: an Intel Mac spills to system RAM like a PC.
   const isUnifiedMemory = usePlatformStore((s) => s.appleSilicon);
@@ -780,6 +792,8 @@ export function ChatSettingsPanel({
       onParamsChange(nextParams);
     };
   }
+
+  const setSeed = set("seed");
 
   // Lower a live Max Tokens that no longer fits the connection's cap.
   // `resolveExternalMaxTokensClamp` documents why an unresolved provider must not be
@@ -1491,6 +1505,50 @@ export function ChatSettingsPanel({
               }
               info="Maximum number of tokens to generate per response. Generation stops at this limit or when the model emits an end-of-sequence token."
             />
+            {showSeed ? (
+              <div className="flex items-center justify-between gap-3">
+                <div className="flex min-w-0 items-center gap-1.5">
+                  <span className="min-w-0 text-ui-13 font-medium leading-[1.25] tracking-nav text-nav-fg">
+                    Seed
+                  </span>
+                  <InfoHint>
+                    Pins the sampling draw so the same prompt and settings can
+                    reproduce the same reply. Leave blank to draw a fresh seed
+                    each request. It only fixes the draw, so the other sampling
+                    settings have to stay put as well; at Temperature 0 decoding
+                    is already greedy and a seed changes nothing.
+                  </InfoHint>
+                </div>
+                <InputGroup className="panel-input-group w-[8.5rem] shrink-0">
+                  <InputGroupInput
+                    id="inference-seed"
+                    // A TEXT input: type="number" reports an unreadable entry as "", clearing the pin.
+                    type="text"
+                    inputMode="numeric"
+                    autoComplete="off"
+                    spellCheck={false}
+                    value={params.seed == null ? "" : String(params.seed)}
+                    onChange={(e) => {
+                      const digits = e.target.value
+                        .replace(/\D/g, "")
+                        // Measured after the padding: a zero-padded seed is short enough
+                        // to keep, and truncating instead of clamping would rewrite it.
+                        .replace(/^0+(?=\d)/, "");
+                      setSeed(
+                        digits === ""
+                          ? null
+                          : digits.length > 10
+                            ? MAX_SAMPLING_SEED
+                            : Math.min(Number(digits), MAX_SAMPLING_SEED),
+                      );
+                    }}
+                    placeholder="Random"
+                    aria-label="Seed"
+                    className="!h-9 min-h-0 min-w-0 self-stretch !px-3 py-0 text-ui-13 font-medium leading-9 text-nav-fg md:text-ui-13"
+                  />
+                </InputGroup>
+              </div>
+            ) : null}
           </div>
         </CollapsibleSection>
 

--- a/studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts
+++ b/studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts
@@ -109,7 +109,7 @@ import {
 } from "@/features/model-picker/api/llama-flags";
 import type {
   ChatLoraSummary,
-  ChatModelSummary,
+  ChatModelRow,
 } from "../types/runtime";
 
 export type SelectedModelInput = {
@@ -249,7 +249,7 @@ function describeModel(model: {
   return tags.join(" · ");
 }
 
-function toChatModelSummary(model: {
+function toChatModelRow(model: {
   id: string;
   name?: string | null;
   is_lora?: boolean;
@@ -260,7 +260,7 @@ function toChatModelSummary(model: {
   audio_type?: string | null;
   has_audio_input?: boolean;
   has_video_input?: boolean;
-}): ChatModelSummary {
+}): ChatModelRow {
   return {
     id: model.id,
     name: model.name || model.id,
@@ -402,7 +402,7 @@ async function syncInferenceStatusToStore(options?: {
     // describes a moment that has passed.
     if (signal?.aborted || superseded()) return;
 
-    setModels(listRes.models.map(toChatModelSummary));
+    setModels(listRes.models.map(toChatModelRow));
     if (lorasRes) {
       setLoras(lorasRes.loras.map(toLoraSummary));
     }

--- a/studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts
+++ b/studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts
@@ -288,6 +288,7 @@ export function syncModelCapabilities(
     is_vision?: boolean;
     is_lora?: boolean;
     is_gguf?: boolean;
+    is_mlx?: boolean;
     is_audio?: boolean;
     audio_type?: string | null;
     has_audio_input?: boolean;
@@ -299,6 +300,9 @@ export function syncModelCapabilities(
   const synced = {
     isVision: Boolean(resp.is_vision),
     isGguf: Boolean(resp.is_gguf),
+    // A locally scanned model is in no /api/models/list row, so this is the only place
+    // its summary learns it is served by MLX, and the seed gate reads that.
+    isMlx: Boolean(resp.is_mlx),
     isAudio: Boolean(resp.is_audio),
     audioType: resp.audio_type ?? null,
     hasAudioInput: Boolean(resp.has_audio_input),

--- a/studio/frontend/src/features/chat/lib/apply-inference-status-to-store.ts
+++ b/studio/frontend/src/features/chat/lib/apply-inference-status-to-store.ts
@@ -99,8 +99,7 @@ function ensureActiveModelInStoreList(
 ): void {
   const store = useChatRuntimeStore.getState();
   const caps = {
-    // Adopting a model the backend already had is one of the ways a row is minted
-    // without a catalog entry, and the seed gate reads this off the row.
+    // Adopting a model the backend already had mints a row with no catalog entry behind it.
     isMlx: status.is_mlx ?? false,
     isAudio: status.is_audio ?? false,
     audioType: status.audio_type ?? null,

--- a/studio/frontend/src/features/chat/lib/apply-inference-status-to-store.ts
+++ b/studio/frontend/src/features/chat/lib/apply-inference-status-to-store.ts
@@ -99,13 +99,13 @@ function ensureActiveModelInStoreList(
 ): void {
   const store = useChatRuntimeStore.getState();
   const caps = {
+    // Adopting a model the backend already had is one of the ways a row is minted
+    // without a catalog entry, and the seed gate reads this off the row.
+    isMlx: status.is_mlx ?? false,
     isAudio: status.is_audio ?? false,
     audioType: status.audio_type ?? null,
     hasAudioInput: status.has_audio_input ?? false,
     hasVideoInput: status.has_video_input ?? false,
-    // Adopting a model the backend already had is the other way a row is minted
-    // without a catalog entry, and the seed gate reads this off the row.
-    isMlx: status.is_mlx ?? false,
   };
   const existing = store.models.find((model) => model.id === checkpointId);
   if (existing) {

--- a/studio/frontend/src/features/chat/lib/apply-inference-status-to-store.ts
+++ b/studio/frontend/src/features/chat/lib/apply-inference-status-to-store.ts
@@ -27,7 +27,7 @@ import {
   type InferenceStatusResponse,
   isMultimodalResponse,
 } from "../types/api";
-import type { ChatModelSummary } from "../types/runtime";
+import type { ChatModelRow } from "../types/runtime";
 import { resolveQwenThinkingParams } from "../utils/qwen-params";
 import { sameGpuSelection } from "@/hooks/gpu-selection";
 import { resolveBatchSizeSeed } from "./resolve-batch-size-seed";
@@ -118,7 +118,7 @@ function ensureActiveModelInStoreList(
     }
     return;
   }
-  const summary: ChatModelSummary = {
+  const summary: ChatModelRow = {
     id: checkpointId,
     // active_model is already the clean public id; its leaf matches the catalog rows,
     // and the fallback keeps a snapshot path out of the trigger.

--- a/studio/frontend/src/features/chat/lib/apply-inference-status-to-store.ts
+++ b/studio/frontend/src/features/chat/lib/apply-inference-status-to-store.ts
@@ -103,6 +103,9 @@ function ensureActiveModelInStoreList(
     audioType: status.audio_type ?? null,
     hasAudioInput: status.has_audio_input ?? false,
     hasVideoInput: status.has_video_input ?? false,
+    // Adopting a model the backend already had is the other way a row is minted
+    // without a catalog entry, and the seed gate reads this off the row.
+    isMlx: status.is_mlx ?? false,
   };
   const existing = store.models.find((model) => model.id === checkpointId);
   if (existing) {

--- a/studio/frontend/src/features/chat/lib/per-model-params.ts
+++ b/studio/frontend/src/features/chat/lib/per-model-params.ts
@@ -26,6 +26,7 @@ export const PERSISTED_INFERENCE_PARAM_KEYS = [
   "systemVariables",
   "trustRemoteCode",
   "fastMode",
+  "seed",
 ] as const satisfies readonly PersistedInferenceParamKey[];
 
 /** What the memory records. `maxSeqLength` is left out: the context belongs to

--- a/studio/frontend/src/features/chat/presets/preset-policy.ts
+++ b/studio/frontend/src/features/chat/presets/preset-policy.ts
@@ -27,6 +27,7 @@ export type PresetOwnedParams = Pick<
   | "maxTokens"
   | "systemPrompt"
   | "systemVariables"
+  | "seed"
 >;
 
 export const BUILTIN_PRESETS: Preset[] = [
@@ -111,6 +112,8 @@ export function getPresetOwnedParams(
     maxTokens: params.maxTokens,
     systemPrompt: params.systemPrompt ?? "",
     systemVariables: params.systemVariables ?? "",
+    // The seed sits with the sampling knobs in the panel, so a preset captures it there too.
+    seed: params.seed ?? null,
   };
 }
 
@@ -129,7 +132,8 @@ export function isSamePresetConfig(
     left.presencePenalty === right.presencePenalty &&
     left.maxTokens === right.maxTokens &&
     left.systemPrompt === right.systemPrompt &&
-    left.systemVariables === right.systemVariables
+    left.systemVariables === right.systemVariables &&
+    left.seed === right.seed
   );
 }
 

--- a/studio/frontend/src/features/chat/presets/preset-policy.ts
+++ b/studio/frontend/src/features/chat/presets/preset-policy.ts
@@ -112,7 +112,7 @@ export function getPresetOwnedParams(
     maxTokens: params.maxTokens,
     systemPrompt: params.systemPrompt ?? "",
     systemVariables: params.systemVariables ?? "",
-    // The seed sits with the sampling knobs in the panel, so a preset captures it there too.
+    // Normalised, so a preset saved before the field existed never reads as modified.
     seed: params.seed ?? null,
   };
 }

--- a/studio/frontend/src/features/chat/shared-composer.tsx
+++ b/studio/frontend/src/features/chat/shared-composer.tsx
@@ -1732,6 +1732,7 @@ export function SharedComposer({
         const synced = {
           isVision: Boolean(resp.is_vision),
           isGguf: Boolean(resp.is_gguf),
+          isMlx: Boolean(resp.is_mlx),
           isAudio: Boolean(resp.is_audio),
           audioType: resp.audio_type ?? null,
           hasAudioInput: Boolean(resp.has_audio_input),

--- a/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
+++ b/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
@@ -959,6 +959,14 @@ function heldThreadScopedParamValue(key: string): unknown {
 }
 
 /**
+ * The first value that is actually set. `??` cannot do this any more: `seed` is null when
+ * the pin is cleared, and null there is the chat's own choice rather than a missing key.
+ */
+function firstSetThreadScopedValue(...values: unknown[]): unknown {
+  return values.find((value) => value !== undefined);
+}
+
+/**
  * Put back the sampling keys the open chat owns, so a model load or status poll applying
  * that model's recommendation leaves the chat running on what it stored. Only an unpinned
  * chat falls through to the model's values.
@@ -966,8 +974,12 @@ function heldThreadScopedParamValue(key: string): unknown {
 function restoreThreadScopedParams(params: InferenceParams): InferenceParams {
   const kept: Record<string, unknown> = {};
   for (const key of THREAD_SCOPED_PARAM_KEYS) {
-    // ?? and not ||: 0, "" and -1 are all values a user sets on purpose here.
-    const held = heldThreadScopedParamValue(key) ?? threadScopedOverride(key);
+    // Not ||, and not ?? either: 0, "", -1 and a cleared seed's null are all values a
+    // user sets on purpose here.
+    const held = firstSetThreadScopedValue(
+      heldThreadScopedParamValue(key),
+      threadScopedOverride(key),
+    );
     if (held === undefined || isSameThreadScopedValue(held, params[key])) {
       continue;
     }
@@ -1005,10 +1017,11 @@ function withoutActiveThreadParams(
     if (held === undefined && threadScopedOverride(key) === undefined) continue;
     // For a held key the installation copy can still be null and the store no longer
     // holds the pre-edit value; the sample taken when the window opened is that value.
-    const own =
-      remembered?.[key] ??
-      globalThreadScopedDefaults?.[key] ??
-      (held !== undefined ? pairingWindowDefaults?.[key] : undefined);
+    const own = firstSetThreadScopedValue(
+      remembered?.[key],
+      globalThreadScopedDefaults?.[key],
+      held !== undefined ? pairingWindowDefaults?.[key] : undefined,
+    );
     if (own === undefined || isSameThreadScopedValue(own, params[key])) {
       continue;
     }
@@ -4433,7 +4446,10 @@ export const useChatRuntimeStore = create<ChatRuntimeStore>((set, get) => ({
           continue;
         }
         // a key the snapshot omits falls back to the defaults, not to the outgoing chat's value.
-        const value = stored?.[key] ?? globalThreadScopedDefaults?.[key];
+        const value = firstSetThreadScopedValue(
+          stored?.[key],
+          globalThreadScopedDefaults?.[key],
+        );
         if (value === undefined) continue;
         applied[key] = value;
         if (isSameThreadScopedValue(value, readThreadScopedValue(state, key))) {

--- a/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
+++ b/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
@@ -47,7 +47,7 @@ import {
 } from "../lib/per-model-params";
 import {
   type ChatLoraSummary,
-  type ChatModelSummary,
+  type ChatModelRow,
   DEFAULT_INFERENCE_PARAMS,
   type InferenceParams,
 } from "../types/runtime";
@@ -2457,7 +2457,7 @@ type ChatRuntimeStore = {
   customPresets: Preset[];
   activePreset: string;
   activePresetSource: ChatPresetSource;
-  models: ChatModelSummary[];
+  models: ChatModelRow[];
   loras: ChatLoraSummary[];
   runningByThreadId: Record<string, boolean>;
   /**
@@ -2833,7 +2833,7 @@ type ChatRuntimeStore = {
   setCustomPresets: (presets: Preset[]) => void;
   setActivePreset: (name: string) => void;
   setActivePresetSource: (source: ChatPresetSource) => void;
-  setModels: (models: ChatModelSummary[]) => void;
+  setModels: (models: ChatModelRow[]) => void;
   setLoras: (loras: ChatLoraSummary[]) => void;
   /**
      * `local` defaults to true, so an unqualified caller still counts for the model-swap gate.

--- a/studio/frontend/src/features/chat/types/api.ts
+++ b/studio/frontend/src/features/chat/types/api.ts
@@ -608,6 +608,8 @@ export interface OpenAIChatCompletionsRequest {
   min_p?: number;
   repetition_penalty?: number;
   presence_penalty?: number;
+  /** Omitted when unset, which leaves the server to draw its own seed. */
+  seed?: number;
   image_base64?: string;
   audio_base64?: string;
   video_base64?: string;

--- a/studio/frontend/src/features/chat/types/runtime.ts
+++ b/studio/frontend/src/features/chat/types/runtime.ts
@@ -32,14 +32,19 @@ export interface InferenceParams {
  *  its "draw one" sentinel, so a pin can name every value below that and no other. */
 export const MAX_SAMPLING_SEED = 4_294_967_294;
 
+/** An absent flag reads as false, so a row that omits one makes the gate answer wrong. */
+export type SeedGateFlags = Required<
+  Pick<ChatModelSummary, "isGguf" | "isMlx" | "isAudio" | "hasAudioInput">
+>;
+
+/** What the store holds, so every place that mints a row has to state those flags. */
+export type ChatModelRow = ChatModelSummary & SeedGateFlags;
+
 /** Whether the loaded model's backend reads a sampling seed. Shared so the panel cannot
  *  offer the field where the request would drop it, and takes the same `models[]` summary
  *  the request body already reads `isGguf` from, so the two cannot answer differently. */
 export function modelReadsSamplingSeed(
-  activeModel:
-    | Pick<ChatModelSummary, "isGguf" | "isMlx" | "isAudio" | "hasAudioInput">
-    | null
-    | undefined,
+  activeModel: SeedGateFlags | null | undefined,
 ): boolean {
   // An audio-output model answers through generateAudio, whose request carries no seed.
   if (activeModel?.isAudio && !activeModel.hasAudioInput) {

--- a/studio/frontend/src/features/chat/types/runtime.ts
+++ b/studio/frontend/src/features/chat/types/runtime.ts
@@ -21,6 +21,29 @@ export interface InferenceParams {
    * https://platform.claude.com/docs/en/build-with-claude/fast-mode
    */
   fastMode?: boolean;
+  /**
+   * Sampling seed forwarded to llama-server so a generation can be reproduced.
+   * `null` is unset, which leaves the server to draw its own seed per request.
+   */
+  seed?: number | null;
+}
+
+/** llama.cpp reads the seed as a uint32 and spends 0xFFFFFFFF on LLAMA_DEFAULT_SEED,
+ *  its "draw one" sentinel, so a pin can name every value below that and no other. */
+export const MAX_SAMPLING_SEED = 4_294_967_294;
+
+/** Whether the loaded model decodes through llama-server, the only backend that reads
+ *  a seed. Shared so the panel cannot offer the field where the request would drop it. */
+export function modelReadsSamplingSeed(
+  activeGgufVariant: string | null | undefined,
+  ggufContextLength: number | null | undefined,
+  checkpoint: string | null | undefined,
+): boolean {
+  return (
+    activeGgufVariant != null ||
+    ggufContextLength != null ||
+    (checkpoint?.toLowerCase().endsWith(".gguf") ?? false)
+  );
 }
 
 /** The params that survive a reload. `checkpoint` names the model rather than
@@ -43,6 +66,7 @@ export const DEFAULT_INFERENCE_PARAMS: InferenceParams = {
   checkpoint: "",
   trustRemoteCode: false,
   fastMode: false,
+  seed: null,
 };
 
 export interface ChatModelSummary {

--- a/studio/frontend/src/features/chat/types/runtime.ts
+++ b/studio/frontend/src/features/chat/types/runtime.ts
@@ -38,7 +38,12 @@ export function modelReadsSamplingSeed(
   activeGgufVariant: string | null | undefined,
   ggufContextLength: number | null | undefined,
   checkpoint: string | null | undefined,
+  activeModel?: Pick<ChatModelSummary, "isAudio" | "hasAudioInput"> | null,
 ): boolean {
+  // An audio-output model answers through generateAudio, whose request carries no seed.
+  if (activeModel?.isAudio && !activeModel.hasAudioInput) {
+    return false;
+  }
   return (
     activeGgufVariant != null ||
     ggufContextLength != null ||

--- a/studio/frontend/src/features/chat/types/runtime.ts
+++ b/studio/frontend/src/features/chat/types/runtime.ts
@@ -22,8 +22,8 @@ export interface InferenceParams {
    */
   fastMode?: boolean;
   /**
-   * Sampling seed forwarded to llama-server so a generation can be reproduced.
-   * `null` is unset, which leaves the server to draw its own seed per request.
+   * Sampling seed forwarded to the backends that read one so a generation can be
+   * reproduced. `null` is unset, which leaves the backend to draw its own per request.
    */
   seed?: number | null;
 }
@@ -32,23 +32,22 @@ export interface InferenceParams {
  *  its "draw one" sentinel, so a pin can name every value below that and no other. */
 export const MAX_SAMPLING_SEED = 4_294_967_294;
 
-/** Whether the loaded model decodes through llama-server, the only backend that reads
- *  a seed. Shared so the panel cannot offer the field where the request would drop it. */
+/** Whether the loaded model's backend reads a sampling seed. Shared so the panel cannot
+ *  offer the field where the request would drop it, and takes the same `models[]` summary
+ *  the request body already reads `isGguf` from, so the two cannot answer differently. */
 export function modelReadsSamplingSeed(
-  activeGgufVariant: string | null | undefined,
-  ggufContextLength: number | null | undefined,
-  checkpoint: string | null | undefined,
-  activeModel?: Pick<ChatModelSummary, "isAudio" | "hasAudioInput"> | null,
+  activeModel:
+    | Pick<ChatModelSummary, "isGguf" | "isMlx" | "isAudio" | "hasAudioInput">
+    | null
+    | undefined,
 ): boolean {
   // An audio-output model answers through generateAudio, whose request carries no seed.
   if (activeModel?.isAudio && !activeModel.hasAudioInput) {
     return false;
   }
-  return (
-    activeGgufVariant != null ||
-    ggufContextLength != null ||
-    (checkpoint?.toLowerCase().endsWith(".gguf") ?? false)
-  );
+  // llama-server takes a seed, and so does MLX. The transformers backend declares no
+  // `seed` kwarg, so worker.py's `_backend_declares` gate drops it before generation.
+  return activeModel?.isGguf === true || activeModel?.isMlx === true;
 }
 
 /** The params that survive a reload. `checkpoint` names the model rather than

--- a/studio/frontend/src/features/chat/utils/chat-settings-storage.ts
+++ b/studio/frontend/src/features/chat/utils/chat-settings-storage.ts
@@ -156,7 +156,7 @@ function sanitizeInferenceParams(
   }
   // Bounded here as well as in the panel: this gates the hydration read and the outgoing PUT alike.
   if (value.seed === null) {
-    // null IS the clear, and the server merge only overwrites the keys it receives.
+    // Kept, not dropped: the server merge overwrites the keys it receives and removes none.
     params.seed = null;
   } else if (
     typeof value.seed === "number" &&

--- a/studio/frontend/src/features/chat/utils/chat-settings-storage.ts
+++ b/studio/frontend/src/features/chat/utils/chat-settings-storage.ts
@@ -19,6 +19,7 @@ import {
   type Preset,
 } from "../presets/preset-policy";
 import type { ReasoningEffort } from "../stores/chat-runtime-store";
+import { MAX_SAMPLING_SEED } from "../types/runtime";
 import {
   assignSanitizedMirroredSettings,
   hasNoMirroredSettings,
@@ -152,6 +153,18 @@ function sanitizeInferenceParams(
   // trustRemoteCode is no longer persisted: custom code is consented per model via the dialog.
   if (typeof value.fastMode === "boolean") {
     params.fastMode = value.fastMode;
+  }
+  // Bounded here as well as in the panel: this gates the hydration read and the outgoing PUT alike.
+  if (value.seed === null) {
+    // null IS the clear, and the server merge only overwrites the keys it receives.
+    params.seed = null;
+  } else if (
+    typeof value.seed === "number" &&
+    Number.isInteger(value.seed) &&
+    value.seed >= 0 &&
+    value.seed <= MAX_SAMPLING_SEED
+  ) {
+    params.seed = value.seed;
   }
   return hasKeys(params) ? params : undefined;
 }

--- a/studio/frontend/src/features/chat/utils/queued-model-capabilities.ts
+++ b/studio/frontend/src/features/chat/utils/queued-model-capabilities.ts
@@ -4,6 +4,7 @@ export type QueuedModelCapabilities = Pick<
   ChatModelSummary,
   | "isVision"
   | "isGguf"
+  | "isMlx"
   | "isAudio"
   | "audioType"
   | "hasAudioInput"

--- a/studio/frontend/src/features/chat/utils/queued-model-capabilities.ts
+++ b/studio/frontend/src/features/chat/utils/queued-model-capabilities.ts
@@ -1,7 +1,7 @@
-import type { ChatModelSummary } from "../types/runtime";
+import type { ChatModelRow } from "../types/runtime";
 
 export type QueuedModelCapabilities = Pick<
-  ChatModelSummary,
+  ChatModelRow,
   | "isVision"
   | "isGguf"
   | "isMlx"
@@ -17,10 +17,10 @@ export type QueuedModelCapabilities = Pick<
  * catalog values, and a model loaded outside Studio gets a minimal entry.
  */
 export function mergeQueuedModelCapabilities(
-  models: ChatModelSummary[],
+  models: ChatModelRow[],
   checkpoint: string,
   capabilities: QueuedModelCapabilities | null,
-): ChatModelSummary[] {
+): ChatModelRow[] {
   if (!capabilities) {
     return models;
   }

--- a/studio/frontend/src/features/chat/utils/thread-scoped-settings.ts
+++ b/studio/frontend/src/features/chat/utils/thread-scoped-settings.ts
@@ -109,8 +109,6 @@ const THREAD_SCOPED_NUMBER_BOUNDS = {
   minP: { min: 0, max: 1, integer: false },
   repetitionPenalty: { min: 1, max: 2, integer: false },
   presencePenalty: { min: 0, max: 2, integer: false },
-  // Same ceiling as the panel and the installation copy: llama.cpp keeps 0xFFFFFFFF
-  // for its draw-one sentinel, so a pin stops one below it.
   seed: { min: 0, max: MAX_SAMPLING_SEED, integer: true },
 } as const satisfies Partial<
   Record<

--- a/studio/frontend/src/features/chat/utils/thread-scoped-settings.ts
+++ b/studio/frontend/src/features/chat/utils/thread-scoped-settings.ts
@@ -12,6 +12,7 @@ import type {
   RagSource,
   ReasoningEffort,
 } from "../stores/chat-runtime-store";
+import { MAX_SAMPLING_SEED } from "../types/runtime.ts";
 import {
   isRecord,
   sanitizeBoundedNumber,
@@ -44,6 +45,8 @@ export interface ThreadScopedSettings {
   minP?: number;
   repetitionPenalty?: number;
   presencePenalty?: number;
+  /** null is the cleared pin, and is the only thread-scoped value that is not undefined. */
+  seed?: number | null;
   systemPrompt?: string;
   systemVariables?: string;
 }
@@ -56,6 +59,7 @@ export const THREAD_SCOPED_PARAM_KEYS = [
   "minP",
   "repetitionPenalty",
   "presencePenalty",
+  "seed",
   "systemPrompt",
   "systemVariables",
 ] as const satisfies readonly (keyof ThreadScopedSettings)[];
@@ -105,6 +109,9 @@ const THREAD_SCOPED_NUMBER_BOUNDS = {
   minP: { min: 0, max: 1, integer: false },
   repetitionPenalty: { min: 1, max: 2, integer: false },
   presencePenalty: { min: 0, max: 2, integer: false },
+  // Same ceiling as the panel and the installation copy: llama.cpp keeps 0xFFFFFFFF
+  // for its draw-one sentinel, so a pin stops one below it.
+  seed: { min: 0, max: MAX_SAMPLING_SEED, integer: true },
 } as const satisfies Partial<
   Record<
     keyof ThreadScopedSettings,
@@ -183,6 +190,8 @@ export function sanitizeThreadScopedSettings(
   for (const key of THREAD_SCOPED_STRING_KEYS) {
     if (typeof value[key] === "string") target[key] = value[key];
   }
+  // null is a value here, not an absence, and sanitizeBoundedNumber reads it as one.
+  if (value.seed === null) settings.seed = null;
   const ragSource = sanitizeRagSource(value.ragSource);
   if (ragSource) settings.ragSource = ragSource;
   return settings;

--- a/studio/frontend/tests/chat-sampling-seed.test.ts
+++ b/studio/frontend/tests/chat-sampling-seed.test.ts
@@ -289,6 +289,10 @@ test("the seed belongs to the chat, not the installation", () => {
 
 test("a chat stores a cleared seed rather than dropping the key", () => {
   assert.deepEqual(sanitizeThreadScopedSettings({ seed: null }), { seed: null });
+  // The other half of that: a snapshot written before the field existed carries no seed,
+  // and the thread response now says so rather than spelling it null, so the chat falls
+  // through to the pin it inherits instead of reading as one that cleared it.
+  assert.deepEqual(sanitizeThreadScopedSettings({ topK: 40 }), { topK: 40 });
   assert.deepEqual(sanitizeThreadScopedSettings({ seed: 3407 }), { seed: 3407 });
   // The bound the panel and the installation copy already share, applied to the snapshot
   // a chat writes: a row from another client meets only this.

--- a/studio/frontend/tests/chat-sampling-seed.test.ts
+++ b/studio/frontend/tests/chat-sampling-seed.test.ts
@@ -133,44 +133,43 @@ test("the request omits the seed when it is unset", () => {
 
 test("the pin covers llama.cpp's whole uint32 range bar the sentinel", () => {
   // 0xFFFFFFFF is LLAMA_DEFAULT_SEED, llama.cpp's "draw one" value, so it is the one
-  // number a pin cannot name. Stopping at int32 max instead would put every seed above
-  // 2^31-1 out of reach, and a run whose server-drawn seed landed there could not be replayed.
+  // number a pin cannot name. llama-server parses the field as a uint32, so stopping at
+  // int32 max instead would refuse half the seeds it accepts for no reason.
   assert.equal(MAX_SAMPLING_SEED, 0xffffffff - 1);
 });
 
-test("a seed reaches only the backend that reads one", () => {
-  // A loaded variant, a GGUF context, or a direct .gguf file each mean llama-server.
-  assert.ok(modelReadsSamplingSeed("Q4_K_M", null, "unsloth/Qwen3.5-9B-GGUF"));
-  assert.ok(modelReadsSamplingSeed(null, 8192, "unsloth/Qwen3.5-9B"));
-  assert.ok(modelReadsSamplingSeed(null, null, "/models/local-file.GGUF"));
-  // Transformers and MLX take the field and ignore it, so neither is offered one.
-  assert.ok(!modelReadsSamplingSeed(null, null, "unsloth/Llama-4-8B"));
-  assert.ok(!modelReadsSamplingSeed(null, null, undefined));
-  // An audio-output GGUF answers through generateAudio, whose request carries no seed, so
+test("a seed reaches only the backends that read one", () => {
+  // llama-server reads the seed, and so does MLX: generate_chat_response takes it and
+  // builds _make_seeded_mlx_sampler, and worker.py's _backend_declares lets it through.
+  assert.ok(modelReadsSamplingSeed({ isGguf: true }));
+  assert.ok(modelReadsSamplingSeed({ isMlx: true }));
+  // The transformers backend declares no seed kwarg, so the same gate drops it there.
+  assert.ok(!modelReadsSamplingSeed({ isGguf: false, isMlx: false }));
+  // No summary at all is a model the panel knows nothing about, so it is offered nothing.
+  assert.ok(!modelReadsSamplingSeed(null));
+  assert.ok(!modelReadsSamplingSeed(undefined));
+  // An audio-output model answers through generateAudio, whose request carries no seed, so
   // the control would promise a reproducibility it cannot deliver on that path.
   assert.ok(
-    !modelReadsSamplingSeed("Q4_K_M", 8192, "unsloth/TTS-GGUF", {
+    !modelReadsSamplingSeed({
+      isGguf: true,
       isAudio: true,
       hasAudioInput: false,
     }),
   );
   // A model that takes audio IN still decodes through llama-server, so it keeps the field.
   assert.ok(
-    modelReadsSamplingSeed("Q4_K_M", 8192, "unsloth/Voxtral-GGUF", {
+    modelReadsSamplingSeed({
+      isGguf: true,
       isAudio: true,
       hasAudioInput: true,
     }),
   );
 });
 
-test("the panel offers the seed only where llama-server reads it", () => {
+test("the panel offers the seed only where the backend reads it", () => {
   const sheet = read("../src/features/chat/chat-settings-sheet.tsx");
-  assert.match(
-    sheet,
-    /const showSeed =\s*!isExternalModel &&\s*modelReadsSamplingSeed\(/,
-  );
-  // The panel passes the active model, or the audio-output exclusion never fires for it.
-  assert.match(sheet, /activeModelSummary,\s*\);/);
+  assert.match(sheet, /const showSeed = modelReadsSamplingSeed\(/);
   // type="number" reports an entry the engine cannot parse as "", which would clear
   // the pin with no error. chat-providers-dialog documents the same trap.
   const field = slice(sheet, "{showSeed ? (", 'aria-label="Seed"');
@@ -180,22 +179,51 @@ test("the panel offers the seed only where llama-server reads it", () => {
     .filter((line) => !line.startsWith("//"));
   assert.ok(props.includes('type="text"'));
   assert.ok(!props.includes('type="number"'));
-  // The panel and the request body answer "reaches llama-server" with the same helper, so
-  // neither can drift into hiding the field while the wire still carries a pin. isGguf is
-  // deliberately not that helper: it also caps Max Tokens, and the two must stay separable.
-  assert.match(sheet, /modelReadsSamplingSeed\(/);
+  // isGguf is deliberately not this helper: it also caps Max Tokens, and the two
+  // questions must stay separable even though both read the same summary today.
   assert.doesNotMatch(sheet, /const isGguf = modelReadsSamplingSeed\(/);
 });
 
-test("an over-long paste clamps rather than becoming another number", () => {
+test("the panel and the request body gate on the same argument", () => {
+  // A regex on the call name alone cannot see a call site passing an extra argument,
+  // which is how the panel and the body drifted apart the first time. Compare the
+  // argument text so an added or dropped signal at one site fails here.
+  const gateArguments = (source: string): string[] =>
+    [...source.matchAll(/modelReadsSamplingSeed\(([^)]*)\)/g)].map((match) =>
+      match[1].replace(/\s+/g, " ").trim(),
+    );
+  assert.deepEqual(
+    gateArguments(read("../src/features/chat/chat-settings-sheet.tsx")),
+    ["activeModel"],
+  );
+  assert.deepEqual(
+    gateArguments(read("../src/features/chat/api/chat-adapter.ts")),
+    ["activeModel"],
+  );
+});
+
+test("an over-long entry clamps rather than becoming another number", () => {
   const sheet = read("../src/features/chat/chat-settings-sheet.tsx");
-  const handler = slice(sheet, "onChange={(e) => {", 'placeholder="Random"');
+  const handler = slice(sheet, "onBlur={() => {", "onKeyDown={(e) => {");
   // Truncating to 10 digits before clamping turned 12345678901234 into 1234567890.
   assert.doesNotMatch(handler, /\.slice\(0, ?10\)/);
   assert.match(handler, /digits\.length > 10\s*\?\s*MAX_SAMPLING_SEED/);
   // And the length is measured after the padding, so a pasted 0000000003407 stays 3407
   // instead of reading as 13 digits and clamping to the maximum.
   assert.match(handler, /\^0\+\(\?=\\d\)/);
+});
+
+test("typing is not rewritten before the entry is finished", () => {
+  const sheet = read("../src/features/chat/chat-settings-sheet.tsx");
+  const field = slice(sheet, "{showSeed ? (", "placeholder=\"Random\"");
+  // The box shows the raw draft while it is being typed into, so a clamp cannot
+  // rewrite it mid-entry. NumericValueInput keeps a draft for the same reason.
+  assert.match(field, /value=\{\s*seedDraft \?\?/);
+  assert.match(field, /onChange=\{\(e\) =>\s*setSeedDraft\(/);
+  // Blur is the only commit, so it must not fire for a field nobody typed into,
+  // and Enter has to reach it.
+  assert.match(field, /if \(seedDraft === null\) return;/);
+  assert.match(field, /if \(e\.key === "Enter"\) e\.currentTarget\.blur\(\);/);
 });
 
 test("a preset carries the seed it was saved with", () => {
@@ -236,8 +264,10 @@ test("the stored seed is range-checked, not just the keystroke", () => {
 
 test("the request drops a seed the loaded model cannot use", () => {
   const adapter = read("../src/features/chat/api/chat-adapter.ts");
-  // A pin set on a GGUF outlives a switch to safetensors, where the panel hides the
+  // A pin set on a GGUF outlives a switch to transformers, where the panel hides the
   // field: without this the user would keep sending a seed they can no longer see.
   assert.match(adapter, /!modelReadsSamplingSeed\(/);
-  assert.match(adapter, /runtime\.activeGgufVariant,/);
+  // The same summary the body already reads isGguf from for context_overflow, so
+  // "is this a GGUF" cannot be answered two ways inside one request.
+  assert.match(adapter, /activeModel\?\.isGguf === true/);
 });

--- a/studio/frontend/tests/chat-sampling-seed.test.ts
+++ b/studio/frontend/tests/chat-sampling-seed.test.ts
@@ -245,6 +245,7 @@ test("typing is not rewritten before the entry is finished", () => {
 test("an abandoned entry does not outlive the box it was typed into", () => {
   // Blur is the only commit and removing a focused element fires none, so both keys
   // matter: a model switch and the field going away each strand a draft in committedSeed.
+  // Shape only: there is no DOM here, so the no-blur premise was measured in a browser.
   const sheet = read("../src/features/chat/chat-settings-sheet.tsx");
   const reset = slice(sheet, "useEffect(() => {\n    setSeedDraft(null);", ");");
   assert.match(reset, /\[currentCheckpoint, showSeed\]/);

--- a/studio/frontend/tests/chat-sampling-seed.test.ts
+++ b/studio/frontend/tests/chat-sampling-seed.test.ts
@@ -209,7 +209,9 @@ test("the panel and the request body gate on the same argument", () => {
 
 test("an over-long entry clamps rather than becoming another number", () => {
   const sheet = read("../src/features/chat/chat-settings-sheet.tsx");
-  const handler = slice(sheet, "onBlur={() => {", "onKeyDown={(e) => {");
+  // The clamp lives in committedSeed now, so a click on Save reads the same value blur
+  // would have written rather than the one from before the entry.
+  const handler = slice(sheet, "const committedSeed = useMemo", "const paramsWithCommittedSeed");
   // Truncating to 10 digits before clamping turned 12345678901234 into 1234567890.
   assert.doesNotMatch(handler, /\.slice\(0, ?10\)/);
   assert.match(handler, /digits\.length > 10\s*\?\s*MAX_SAMPLING_SEED/);
@@ -301,4 +303,35 @@ test("a cleared seed is not read as a missing key", () => {
   // `??` would fall through a cleared seed's null to the installation default, putting
   // the pin back on the one chat that dropped it. Only undefined means "not set".
   assert.match(helper, /values\.find\(\(value\) => value !== undefined\)/);
+});
+
+test("a model with no catalog row still learns it is served by MLX", () => {
+  // A locally scanned model is in neither /api/models/list nor the external ids, so its
+  // models[] summary is minted from the load or status response. Both hops that mint one
+  // have to carry is_mlx or the gate hides the field for a backend that reads the seed.
+  const runtime = read("../src/features/chat/hooks/use-chat-model-runtime.ts");
+  const synced = slice(runtime, "  const synced = {", "  const idx =");
+  assert.match(synced, /isMlx: Boolean\(resp\.is_mlx\)/);
+  const adoption = read(
+    "../src/features/chat/lib/apply-inference-status-to-store.ts",
+  );
+  const caps = slice(
+    adoption,
+    "function ensureActiveModelInStoreList",
+    "const existing = store.models.find",
+  );
+  assert.match(caps, /isMlx: status\.is_mlx \?\? false/);
+});
+
+test("saving a preset takes the seed being typed, not the one before it", () => {
+  const panel = read("../src/features/chat/chat-settings-sheet.tsx");
+  // Clicking Save blurs the box during mousedown, but React has not re-rendered by the
+  // time onClick runs, so a save reading `params` writes the pre-entry seed and, over an
+  // otherwise-unmodified preset, the button is still disabled and the click does nothing.
+  assert.match(panel, /params: toPresetParams\(paramsWithCommittedSeed\)/);
+  const unsaved = slice(panel, "const hasUnsavedPresetChanges", "const presetSaveState");
+  assert.match(unsaved, /isSamePresetConfig\(\s*activePresetDefinition\.params,\s*paramsWithCommittedSeed,/);
+  assert.match(unsaved, /committedSeed !== \(params\.seed \?\? null\)/);
+  // and blur commits the same value, so the two cannot answer differently
+  assert.match(panel, /setSeedDraft\(null\);\s*setSeed\(committedSeed\);/);
 });

--- a/studio/frontend/tests/chat-sampling-seed.test.ts
+++ b/studio/frontend/tests/chat-sampling-seed.test.ts
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// The sampling seed is the one inference param whose unset state is a value, not an
+// absence: null means "let the server draw one". Every layer it crosses tests presence
+// with `!== undefined`, so these pin the places a truthiness check or an omission would
+// quietly drop a seed of 0 or a deliberate clear.
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+import { registerBundlerResolver } from "./helpers/kit.ts";
+
+registerBundlerResolver();
+
+import {
+  PERSISTED_INFERENCE_PARAM_KEYS,
+  REMEMBERED_INFERENCE_PARAM_KEYS,
+  getReplayedParams,
+  pickRememberedParams,
+} from "../src/features/chat/lib/per-model-params.ts";
+import {
+  DEFAULT_INFERENCE_PARAMS,
+  type InferenceParams,
+  MAX_SAMPLING_SEED,
+  modelReadsSamplingSeed,
+} from "../src/features/chat/types/runtime.ts";
+
+// Dynamic, unlike the two above: preset-policy value-imports ../types/runtime without an
+// extension, and a static import resolves before registerBundlerResolver's hook is live.
+const { applyPresetParams, getPresetOwnedParams, isSamePresetConfig } =
+  await import("../src/features/chat/presets/preset-policy.ts");
+
+const GGUF = "unsloth/Qwen3.5-9B-GGUF";
+
+function params(overrides: Partial<InferenceParams> = {}): InferenceParams {
+  return { ...DEFAULT_INFERENCE_PARAMS, checkpoint: GGUF, ...overrides };
+}
+
+function read(path: string): string {
+  return readFileSync(new URL(path, import.meta.url), "utf8");
+}
+
+function slice(source: string, from: string, to: string): string {
+  const start = source.indexOf(from);
+  const end = source.indexOf(to, start + from.length);
+  assert.ok(start !== -1, `not found: ${from}`);
+  assert.ok(end !== -1, `not found: ${to}`);
+  return source.slice(start, end);
+}
+
+test("an untouched install sends no seed", () => {
+  // Blank is the shipped state, so nothing changes for a user who never opens the field.
+  assert.equal(DEFAULT_INFERENCE_PARAMS.seed, null);
+});
+
+test("the seed persists and is remembered per model", () => {
+  assert.ok(PERSISTED_INFERENCE_PARAM_KEYS.includes("seed"));
+  // Derived from the persisted list by dropping maxSeqLength; a seed belongs to the
+  // sampling config, not the load, so it must survive that filter.
+  assert.ok(REMEMBERED_INFERENCE_PARAM_KEYS.includes("seed"));
+});
+
+test("a seed of 0 is remembered rather than read as unset", () => {
+  const picked = pickRememberedParams(params({ seed: 0 }));
+  assert.equal(picked.seed, 0);
+});
+
+test("a cleared seed is remembered as the clear", () => {
+  const picked = pickRememberedParams(params({ seed: null }));
+  assert.ok("seed" in picked);
+  assert.equal(picked.seed, null);
+});
+
+test("switching models replays each model's own seed", () => {
+  const replayed = getReplayedParams(
+    true,
+    { [GGUF]: { seed: 3407 } },
+    params({ seed: 11 }),
+    GGUF,
+    true,
+  );
+  assert.equal(replayed.seed, 3407);
+});
+
+test("a model whose row cleared the seed replays the clear", () => {
+  // An explicit null, so the switch does not inherit whichever seed was last on screen.
+  const replayed = getReplayedParams(
+    true,
+    { [GGUF]: { seed: null } },
+    params({ seed: 3407 }),
+    GGUF,
+    true,
+  );
+  assert.equal(replayed.seed, null);
+});
+
+test("a row written before the seed existed keeps what is on screen", () => {
+  // A gap is not a clear: the memory stores rows as written and invents nothing, so a
+  // pre-feature row leaves the seed alone rather than replaying a value it never held.
+  const replayed = getReplayedParams(
+    true,
+    { [GGUF]: { temperature: 0.7 } },
+    params({ seed: 3407 }),
+    GGUF,
+    true,
+  );
+  assert.equal(replayed.seed, 3407);
+});
+
+// The storage module, the adapter and the panel all pull a .tsx barrel into their
+// graph, so pin their source the way the sibling settings tests do.
+
+test("the settings sanitizer lets a cleared seed through", () => {
+  const storage = read("../src/features/chat/utils/chat-settings-storage.ts");
+  const body = slice(
+    storage,
+    "function sanitizeInferenceParams(",
+    "\nfunction sanitizeInferenceParamsByModel(",
+  );
+  // It gates both the read and the outgoing PUT, so a branch that only accepts numbers
+  // would drop the clear and leave the server's old pin in place.
+  assert.match(body, /value\.seed === null/);
+  assert.match(body, /Number\.isInteger\(value\.seed\)/);
+});
+
+test("the request omits the seed when it is unset", () => {
+  const adapter = read("../src/features/chat/api/chat-adapter.ts");
+  assert.match(adapter, /params\.seed == null \|\|/);
+  assert.match(adapter, /\{ seed: params\.seed \}/);
+});
+
+test("the pin covers llama.cpp's whole uint32 range bar the sentinel", () => {
+  // 0xFFFFFFFF is LLAMA_DEFAULT_SEED, llama.cpp's "draw one" value, so it is the one
+  // number a pin cannot name. Stopping at int32 max instead would put every seed above
+  // 2^31-1 out of reach, and a run whose server-drawn seed landed there could not be replayed.
+  assert.equal(MAX_SAMPLING_SEED, 0xffffffff - 1);
+});
+
+test("a seed reaches only the backend that reads one", () => {
+  // A loaded variant, a GGUF context, or a direct .gguf file each mean llama-server.
+  assert.ok(modelReadsSamplingSeed("Q4_K_M", null, "unsloth/Qwen3.5-9B-GGUF"));
+  assert.ok(modelReadsSamplingSeed(null, 8192, "unsloth/Qwen3.5-9B"));
+  assert.ok(modelReadsSamplingSeed(null, null, "/models/local-file.GGUF"));
+  // Transformers and MLX take the field and ignore it, so neither is offered one.
+  assert.ok(!modelReadsSamplingSeed(null, null, "unsloth/Llama-4-8B"));
+  assert.ok(!modelReadsSamplingSeed(null, null, undefined));
+});
+
+test("the panel offers the seed only where llama-server reads it", () => {
+  const sheet = read("../src/features/chat/chat-settings-sheet.tsx");
+  assert.match(
+    sheet,
+    /const showSeed =\s*!isExternalModel &&\s*modelReadsSamplingSeed\(/,
+  );
+  // type="number" reports an entry the engine cannot parse as "", which would clear
+  // the pin with no error. chat-providers-dialog documents the same trap.
+  const field = slice(sheet, "{showSeed ? (", 'aria-label="Seed"');
+  const props = field
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => !line.startsWith("//"));
+  assert.ok(props.includes('type="text"'));
+  assert.ok(!props.includes('type="number"'));
+  // The panel and the request body answer "reaches llama-server" with the same helper, so
+  // neither can drift into hiding the field while the wire still carries a pin. isGguf is
+  // deliberately not that helper: it also caps Max Tokens, and the two must stay separable.
+  assert.match(sheet, /modelReadsSamplingSeed\(/);
+  assert.doesNotMatch(sheet, /const isGguf = modelReadsSamplingSeed\(/);
+});
+
+test("an over-long paste clamps rather than becoming another number", () => {
+  const sheet = read("../src/features/chat/chat-settings-sheet.tsx");
+  const handler = slice(sheet, "onChange={(e) => {", 'placeholder="Random"');
+  // Truncating to 10 digits before clamping turned 12345678901234 into 1234567890.
+  assert.doesNotMatch(handler, /\.slice\(0, ?10\)/);
+  assert.match(handler, /digits\.length > 10\s*\?\s*MAX_SAMPLING_SEED/);
+  // And the length is measured after the padding, so a pasted 0000000003407 stays 3407
+  // instead of reading as 13 digits and clamping to the maximum.
+  assert.match(handler, /\^0\+\(\?=\\d\)/);
+});
+
+test("a preset carries the seed it was saved with", () => {
+  // The field sits with Temperature through Max Tokens, all preset-owned, so saving a
+  // preset while a seed is pinned has to capture it rather than quietly drop it.
+  const saved = getPresetOwnedParams(params({ seed: 3407 }));
+  assert.equal(saved.seed, 3407);
+  const applied = applyPresetParams(
+    params({ seed: 11 }),
+    params({ seed: 3407 }),
+  );
+  assert.equal(applied.seed, 3407);
+  // And a preset saved with no pin clears one left on screen, so "Default" means default.
+  assert.equal(
+    applyPresetParams(params({ seed: 3407 }), params({ seed: null })).seed,
+    null,
+  );
+});
+
+test("moving the seed marks the preset modified", () => {
+  // Without this the panel would show a saved preset while sampling no longer matches it.
+  assert.ok(!isSamePresetConfig(params({ seed: 3407 }), params({ seed: 11 })));
+  assert.ok(isSamePresetConfig(params({ seed: 3407 }), params({ seed: 3407 })));
+});
+
+test("the stored seed is range-checked, not just the keystroke", () => {
+  const storage = read("../src/features/chat/utils/chat-settings-storage.ts");
+  const body = slice(
+    storage,
+    "function sanitizeInferenceParams(",
+    "\nfunction sanitizeInferenceParamsByModel(",
+  );
+  // The panel clamps what the user types; a row from another client or a hand-edited
+  // studio.db meets only this, and it feeds the request body straight through.
+  assert.match(body, /value\.seed >= 0/);
+  assert.match(body, /value\.seed <= MAX_SAMPLING_SEED/);
+});
+
+test("the request drops a seed the loaded model cannot use", () => {
+  const adapter = read("../src/features/chat/api/chat-adapter.ts");
+  // A pin set on a GGUF outlives a switch to safetensors, where the panel hides the
+  // field: without this the user would keep sending a seed they can no longer see.
+  assert.match(adapter, /!modelReadsSamplingSeed\(/);
+  assert.match(adapter, /runtime\.activeGgufVariant,/);
+});

--- a/studio/frontend/tests/chat-sampling-seed.test.ts
+++ b/studio/frontend/tests/chat-sampling-seed.test.ts
@@ -7,7 +7,7 @@
 // quietly drop a seed of 0 or a deliberate clear.
 
 import assert from "node:assert/strict";
-import { readFileSync, readdirSync } from "node:fs";
+import { readFileSync } from "node:fs";
 import test from "node:test";
 
 import { registerBundlerResolver } from "./helpers/kit.ts";
@@ -21,6 +21,7 @@ import {
   pickRememberedParams,
 } from "../src/features/chat/lib/per-model-params.ts";
 import {
+  type ChatModelRow,
   DEFAULT_INFERENCE_PARAMS,
   type InferenceParams,
   MAX_SAMPLING_SEED,
@@ -143,32 +144,40 @@ test("the pin covers llama.cpp's whole uint32 range bar the sentinel", () => {
   assert.equal(MAX_SAMPLING_SEED, 0xffffffff - 1);
 });
 
+function row(
+  overrides: Partial<Parameters<typeof modelReadsSamplingSeed>[0] & object>,
+) {
+  return {
+    isGguf: false,
+    isMlx: false,
+    isAudio: false,
+    hasAudioInput: false,
+    ...overrides,
+  };
+}
+
 test("a seed reaches only the backends that read one", () => {
   // llama-server reads the seed, and so does MLX: generate_chat_response takes it and
   // builds _make_seeded_mlx_sampler, and worker.py's _backend_declares lets it through.
-  assert.ok(modelReadsSamplingSeed({ isGguf: true }));
-  assert.ok(modelReadsSamplingSeed({ isMlx: true }));
+  assert.ok(modelReadsSamplingSeed(row({ isGguf: true })));
+  assert.ok(modelReadsSamplingSeed(row({ isMlx: true })));
   // The transformers backend declares no seed kwarg, so the same gate drops it there.
-  assert.ok(!modelReadsSamplingSeed({ isGguf: false, isMlx: false }));
+  assert.ok(!modelReadsSamplingSeed(row({})));
   // No summary at all is a model the panel knows nothing about, so it is offered nothing.
   assert.ok(!modelReadsSamplingSeed(null));
   assert.ok(!modelReadsSamplingSeed(undefined));
   // An audio-output model answers through generateAudio, whose request carries no seed, so
   // the control would promise a reproducibility it cannot deliver on that path.
   assert.ok(
-    !modelReadsSamplingSeed({
-      isGguf: true,
-      isAudio: true,
-      hasAudioInput: false,
-    }),
+    !modelReadsSamplingSeed(
+      row({ isGguf: true, isAudio: true, hasAudioInput: false }),
+    ),
   );
   // A model that takes audio IN still decodes through llama-server, so it keeps the field.
   assert.ok(
-    modelReadsSamplingSeed({
-      isGguf: true,
-      isAudio: true,
-      hasAudioInput: true,
-    }),
+    modelReadsSamplingSeed(
+      row({ isGguf: true, isAudio: true, hasAudioInput: true }),
+    ),
   );
 });
 
@@ -321,32 +330,31 @@ test("a cleared seed is not read as a missing key", () => {
 // status response, and the seed gate reads isMlx off that summary. Four separate places
 // mint or refresh one, and three of them were each missing the flag, so this is a rule
 // over the capability cluster rather than a spot check per place.
-test("every capability set that reaches a model summary carries isMlx", () => {
-  const SRC = new URL("../src/", import.meta.url);
-  const files: URL[] = [];
-  const walk = (dir: URL) => {
-    for (const entry of readdirSync(dir, { withFileTypes: true })) {
-      if (entry.name === "node_modules") continue;
-      if (entry.isDirectory()) walk(new URL(`${entry.name}/`, dir));
-      else if (/\.tsx?$/.test(entry.name)) files.push(new URL(entry.name, dir));
-    }
-  };
-  walk(SRC);
+// Compile-time, not runtime: a row omitting one of the four fails to build at the site
+// that mints it, including sites no test knows about. ChatModelSummary keeps them optional.
+type RequiredKeys<T> = {
+  [K in keyof T]-?: object extends Pick<T, K> ? never : K;
+}[keyof T];
+type Assert<T extends true> = T;
+type _EveryFlagTheSeedGateReadsIsRequired = Assert<
+  "isGguf" | "isMlx" | "isAudio" | "hasAudioInput" extends
+    RequiredKeys<ChatModelRow>
+    ? true
+    : false
+>;
 
-  const dropped: string[] = [];
-  for (const file of files) {
-    const source = readFileSync(file, "utf8");
-    // hasVideoInput is the last field of the cluster every summary-shaped literal writes,
-    // and `:` is the write; `.hasVideoInput` is a read.
-    for (const match of source.matchAll(/\bhasVideoInput\s*:/g)) {
-      const cluster = source.slice(Math.max(0, match.index - 400), match.index);
-      if (!/\bisMlx\s*:/.test(cluster)) {
-        const line = source.slice(0, match.index).split("\n").length;
-        dropped.push(`${file.pathname.split("/src/")[1]}:${line}`);
-      }
-    }
-  }
-  assert.deepEqual(dropped, []);
+test("a models[] row states every flag the seed gate reads", () => {
+  const row: ChatModelRow = {
+    id: "m",
+    name: "m",
+    isVision: false,
+    isLora: false,
+    isGguf: true,
+    isMlx: false,
+    isAudio: false,
+    hasAudioInput: false,
+  };
+  assert.ok(modelReadsSamplingSeed(row));
 });
 
 test("saving a preset takes the seed being typed, not the one before it", () => {

--- a/studio/frontend/tests/chat-sampling-seed.test.ts
+++ b/studio/frontend/tests/chat-sampling-seed.test.ts
@@ -146,6 +146,21 @@ test("a seed reaches only the backend that reads one", () => {
   // Transformers and MLX take the field and ignore it, so neither is offered one.
   assert.ok(!modelReadsSamplingSeed(null, null, "unsloth/Llama-4-8B"));
   assert.ok(!modelReadsSamplingSeed(null, null, undefined));
+  // An audio-output GGUF answers through generateAudio, whose request carries no seed, so
+  // the control would promise a reproducibility it cannot deliver on that path.
+  assert.ok(
+    !modelReadsSamplingSeed("Q4_K_M", 8192, "unsloth/TTS-GGUF", {
+      isAudio: true,
+      hasAudioInput: false,
+    }),
+  );
+  // A model that takes audio IN still decodes through llama-server, so it keeps the field.
+  assert.ok(
+    modelReadsSamplingSeed("Q4_K_M", 8192, "unsloth/Voxtral-GGUF", {
+      isAudio: true,
+      hasAudioInput: true,
+    }),
+  );
 });
 
 test("the panel offers the seed only where llama-server reads it", () => {
@@ -154,6 +169,8 @@ test("the panel offers the seed only where llama-server reads it", () => {
     sheet,
     /const showSeed =\s*!isExternalModel &&\s*modelReadsSamplingSeed\(/,
   );
+  // The panel passes the active model, or the audio-output exclusion never fires for it.
+  assert.match(sheet, /activeModelSummary,\s*\);/);
   // type="number" reports an entry the engine cannot parse as "", which would clear
   // the pin with no error. chat-providers-dialog documents the same trap.
   const field = slice(sheet, "{showSeed ? (", 'aria-label="Seed"');

--- a/studio/frontend/tests/chat-sampling-seed.test.ts
+++ b/studio/frontend/tests/chat-sampling-seed.test.ts
@@ -26,6 +26,11 @@ import {
   MAX_SAMPLING_SEED,
   modelReadsSamplingSeed,
 } from "../src/features/chat/types/runtime.ts";
+import {
+  THREAD_SCOPED_PARAM_KEYS,
+  isThreadScopedSettingKey,
+  sanitizeThreadScopedSettings,
+} from "../src/features/chat/utils/thread-scoped-settings.ts";
 
 // Dynamic, unlike the two above: preset-policy value-imports ../types/runtime without an
 // extension, and a static import resolves before registerBundlerResolver's hook is live.
@@ -270,4 +275,30 @@ test("the request drops a seed the loaded model cannot use", () => {
   // The same summary the body already reads isGguf from for context_overflow, so
   // "is this a GGUF" cannot be answered two ways inside one request.
   assert.match(adapter, /activeModel\?\.isGguf === true/);
+});
+
+test("the seed belongs to the chat, not the installation", () => {
+  // Every other per-turn sampling control travels with the conversation. Left out, a pin
+  // taken in one chat would fix the draw for every other chat opened on the same model,
+  // and reopening the first could not bring its own value back.
+  assert.ok(THREAD_SCOPED_PARAM_KEYS.includes("seed"));
+  assert.equal(isThreadScopedSettingKey("seed"), true);
+});
+
+test("a chat stores a cleared seed rather than dropping the key", () => {
+  assert.deepEqual(sanitizeThreadScopedSettings({ seed: null }), { seed: null });
+  assert.deepEqual(sanitizeThreadScopedSettings({ seed: 3407 }), { seed: 3407 });
+  // The bound the panel and the installation copy already share, applied to the snapshot
+  // a chat writes: a row from another client meets only this.
+  for (const bad of [-1, 1.5, MAX_SAMPLING_SEED + 1, true, "3407"]) {
+    assert.deepEqual(sanitizeThreadScopedSettings({ seed: bad }), {}, String(bad));
+  }
+});
+
+test("a cleared seed is not read as a missing key", () => {
+  const store = read("../src/features/chat/stores/chat-runtime-store.ts");
+  const helper = slice(store, "function firstSetThreadScopedValue", "\n}");
+  // `??` would fall through a cleared seed's null to the installation default, putting
+  // the pin back on the one chat that dropped it. Only undefined means "not set".
+  assert.match(helper, /values\.find\(\(value\) => value !== undefined\)/);
 });

--- a/studio/frontend/tests/chat-sampling-seed.test.ts
+++ b/studio/frontend/tests/chat-sampling-seed.test.ts
@@ -233,6 +233,14 @@ test("typing is not rewritten before the entry is finished", () => {
   assert.match(field, /if \(e\.key === "Enter"\) e\.currentTarget\.blur\(\);/);
 });
 
+test("an abandoned entry does not outlive the box it was typed into", () => {
+  // Blur is the only commit and removing a focused element fires none, so both keys
+  // matter: a model switch and the field going away each strand a draft in committedSeed.
+  const sheet = read("../src/features/chat/chat-settings-sheet.tsx");
+  const reset = slice(sheet, "useEffect(() => {\n    setSeedDraft(null);", ");");
+  assert.match(reset, /\[currentCheckpoint, showSeed\]/);
+});
+
 test("a preset carries the seed it was saved with", () => {
   // The field sits with Temperature through Max Tokens, all preset-owned, so saving a
   // preset while a seed is pinned has to capture it rather than quietly drop it.

--- a/studio/frontend/tests/chat-sampling-seed.test.ts
+++ b/studio/frontend/tests/chat-sampling-seed.test.ts
@@ -7,7 +7,7 @@
 // quietly drop a seed of 0 or a deliberate clear.
 
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
+import { readFileSync, readdirSync } from "node:fs";
 import test from "node:test";
 
 import { registerBundlerResolver } from "./helpers/kit.ts";
@@ -309,22 +309,36 @@ test("a cleared seed is not read as a missing key", () => {
   assert.match(helper, /values\.find\(\(value\) => value !== undefined\)/);
 });
 
-test("a model with no catalog row still learns it is served by MLX", () => {
-  // A locally scanned model is in neither /api/models/list nor the external ids, so its
-  // models[] summary is minted from the load or status response. Both hops that mint one
-  // have to carry is_mlx or the gate hides the field for a backend that reads the seed.
-  const runtime = read("../src/features/chat/hooks/use-chat-model-runtime.ts");
-  const synced = slice(runtime, "  const synced = {", "  const idx =");
-  assert.match(synced, /isMlx: Boolean\(resp\.is_mlx\)/);
-  const adoption = read(
-    "../src/features/chat/lib/apply-inference-status-to-store.ts",
-  );
-  const caps = slice(
-    adoption,
-    "function ensureActiveModelInStoreList",
-    "const existing = store.models.find",
-  );
-  assert.match(caps, /isMlx: status\.is_mlx \?\? false/);
+// A model outside /api/models/list gets its models[] summary minted from a load or
+// status response, and the seed gate reads isMlx off that summary. Four separate places
+// mint or refresh one, and three of them were each missing the flag, so this is a rule
+// over the capability cluster rather than a spot check per place.
+test("every capability set that reaches a model summary carries isMlx", () => {
+  const SRC = new URL("../src/", import.meta.url);
+  const files: URL[] = [];
+  const walk = (dir: URL) => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      if (entry.name === "node_modules") continue;
+      if (entry.isDirectory()) walk(new URL(`${entry.name}/`, dir));
+      else if (/\.tsx?$/.test(entry.name)) files.push(new URL(entry.name, dir));
+    }
+  };
+  walk(SRC);
+
+  const dropped: string[] = [];
+  for (const file of files) {
+    const source = readFileSync(file, "utf8");
+    // hasVideoInput is the last field of the cluster every summary-shaped literal writes,
+    // and `:` is the write; `.hasVideoInput` is a read.
+    for (const match of source.matchAll(/\bhasVideoInput\s*:/g)) {
+      const cluster = source.slice(Math.max(0, match.index - 400), match.index);
+      if (!/\bisMlx\s*:/.test(cluster)) {
+        const line = source.slice(0, match.index).split("\n").length;
+        dropped.push(`${file.pathname.split("/src/")[1]}:${line}`);
+      }
+    }
+  }
+  assert.deepEqual(dropped, []);
 });
 
 test("saving a preset takes the seed being typed, not the one before it", () => {

--- a/studio/frontend/tests/queued-model-capabilities.test.ts
+++ b/studio/frontend/tests/queued-model-capabilities.test.ts
@@ -22,6 +22,7 @@ test("status capabilities synthesize an audio model missing from the catalog", (
     mergeQueuedModelCapabilities([], "local/audio-model", {
       isVision: false,
       isGguf: false,
+      isMlx: false,
       isAudio: true,
       audioType: "tts",
       hasAudioInput: false,
@@ -33,6 +34,7 @@ test("status capabilities synthesize an audio model missing from the catalog", (
         isLora: false,
         isVision: false,
         isGguf: false,
+        isMlx: false,
         isAudio: true,
         audioType: "tts",
         hasAudioInput: false,
@@ -51,6 +53,7 @@ test("status capabilities override stale catalog flags", () => {
           isVision: true,
           isLora: true,
           isGguf: true,
+          isMlx: false,
           isAudio: false,
           audioType: null,
           hasAudioInput: true,
@@ -60,6 +63,7 @@ test("status capabilities override stale catalog flags", () => {
       {
         isVision: false,
         isGguf: false,
+        isMlx: false,
         isAudio: true,
         audioType: "tts",
         hasAudioInput: false,
@@ -72,6 +76,7 @@ test("status capabilities override stale catalog flags", () => {
         isVision: false,
         isLora: true,
         isGguf: false,
+        isMlx: false,
         isAudio: true,
         audioType: "tts",
         hasAudioInput: false,
@@ -84,6 +89,7 @@ test("audio-input capability keeps the synthesized model off the output-only pat
   const [model] = mergeQueuedModelCapabilities([], "local/audio-vlm", {
     isVision: false,
     isGguf: false,
+    isMlx: false,
     isAudio: true,
     audioType: "audio_vlm",
     hasAudioInput: true,
@@ -96,6 +102,7 @@ test("synthesized audio-only capability reaches image validation", () => {
   const [model] = mergeQueuedModelCapabilities([], "local/audio-model", {
     isVision: false,
     isGguf: false,
+    isMlx: false,
     isAudio: true,
     audioType: "tts",
     hasAudioInput: false,

--- a/studio/frontend/tests/thread-scoped-pairing-invariants.test.ts
+++ b/studio/frontend/tests/thread-scoped-pairing-invariants.test.ts
@@ -687,8 +687,12 @@ test("the in-memory defaults follow the model defaults that were just written", 
     note,
     /if \(isHeldThreadScopedField\(key\)\) \{\s*hydratedDefaultsByHeldField\.set\(key, value\);/,
   );
-  // and it is the fallback apply() actually reads
-  assert.match(store, /stored\?\.\[key\] \?\? globalThreadScopedDefaults\?\.\[key\]/);
+  // and it is the fallback apply() actually reads. Not ??: a cleared seed is stored as
+  // null, and ?? would read that as a missing key and hand back the installation pin.
+  assert.match(
+    store,
+    /firstSetThreadScopedValue\(\s*stored\?\.\[key\],\s*globalThreadScopedDefaults\?\.\[key\],/,
+  );
 });
 
 // setCheckpoint replays the destination model's remembered params without going through
@@ -730,7 +734,7 @@ test("the model being left does not remember the open chat's values", () => {
   );
   assert.match(
     strip,
-    /remembered\?\.\[key\] \?\?\s*globalThreadScopedDefaults\?\.\[key\]/,
+    /firstSetThreadScopedValue\(\s*remembered\?\.\[key\],\s*globalThreadScopedDefaults\?\.\[key\],/,
   );
   // and for a held key neither of those may exist yet, so the sample taken when the
   // window opened is the pre-edit value.


### PR DESCRIPTION
Studio has no way to pin a sampling seed, so a generation cannot be reproduced. The backend already accepted one: `ChatCompletionRequest.seed` in `studio/backend/models/inference.py` reaches llama-server through `routes/inference.py` and `core/inference/llama_cpp.py`. The gap was the frontend's parameter set, so this adds the field and the control rather than any new server plumbing.

Fixes #9090.

The issue's own evidence points at the `seed` key in `inference_defaults.json`, which is `families.seed`, a model-family sampling block rather than a seed parameter. `ChatCompletionRequest.seed` is the field that actually carries the pin.

## What changed

`InferenceParams` in `studio/frontend/src/features/chat/types/runtime.ts` gains `seed?: number | null`, defaulting to `null`. A blank field is unset, so nothing changes for anyone who does not touch it.

The run settings panel renders a Seed box in the Sampling section, below Max Tokens. It is a text input rather than `type="number"`: the HTML value sanitization algorithm reports an entry the engine cannot parse as the empty string, which would silently clear the pin. `chat-providers-dialog.tsx` documents the same trap for the provider Max Tokens field. The box keeps the raw keystrokes in `seedDraft` and clamps on blur, so an entry past the maximum is not rewritten while it is still being typed. `committedSeed` is that clamp as a value rather than a side effect, so a click on Save, which blurs the box during mousedown but runs its `onClick` before React re-renders, saves the seed that was typed instead of the one before it. `NumericValueInput` cannot be reused here (`value: number`, no unset state) but its blur commit exists for that reason.

`chat-adapter.ts` sends `seed` on the local chat body only when it is set and when the loaded model's backend reads one. `modelReadsSamplingSeed` in `types/runtime.ts` answers that for both the panel and the request body, from the same `models[]` summary the body already reads `isGguf` from for `context_overflow`, so the two cannot drift and a pin left over from a GGUF is not sent invisibly.

llama-server reads the seed, and so does MLX since #9262: `generate_chat_response` takes it and builds `_make_seeded_mlx_sampler`, and `worker.py`'s `_backend_declares` gate lets it through. The transformers backend declares no `seed` kwarg, so it is the one that drops it, and the one the control stays hidden for. An audio-output model is excluded too, since it answers through `generateAudio`, whose request carries no seed.

The flag has to reach the summary for that to work. A locally scanned model is in no `/api/models/list` row, so its `models[]` entry is minted from the load or status response, and both hops that mint one, `syncModelCapabilities` and `ensureActiveModelInStoreList`, now carry `is_mlx` the way they already carry `has_video_input`.

The pin covers 0 to 4294967294. llama.cpp reads the seed as a `uint32_t` and spends `0xFFFFFFFF` on `LLAMA_DEFAULT_SEED`, its draw-one sentinel, so that value is the one a pin cannot name.

The hint says a matching reply also needs Parallel Slots at 1 and Speculative Decoding off. #9090's table shows seed plus temperature 0 plus top_k 1 still producing 3,960 against 150 characters without them.

## Persistence

`seed` joins `PERSISTED_INFERENCE_PARAM_KEYS`, so it survives a reload and is remembered per model. Three places needed it:

- `utils/chat-settings-storage.ts` gates both the hydration read and the outgoing PUT, so `sanitizeInferenceParams` now range-checks the seed and lets an explicit `null` through. Without the null the server merge, which only overwrites the keys it receives, would leave an old pin in place after the user cleared it.
- `ChatInferenceSettings` in `studio/backend/routes/chat_history.py` is `extra="forbid"`, so an unknown key would 400 the whole settings save. It bounds the seed and rejects booleans, matching the `_no_booleans` guard `ChatPresetLoadConfig` already applies to `nBatch` and `nUbatch` for the same reason: `bool` subclasses `int`, so lax mode would store `true` as a pin of 1.
- `presets/preset-policy.ts` adds `seed` to `PresetOwnedParams`. The control sits with Temperature through Max Tokens, all preset-owned, so saving a preset captures the pin and applying one restores it.
- `utils/thread-scoped-settings.ts` and `ChatThreadSettings` add it to the per-chat snapshot, so a pin belongs to the conversation it was taken in. Every other per-turn sampling control already travels that way; `maxTokens` is the one left out, and the reason `thread-scoped-settings.test.ts` gives is that the context belongs to the model that loaded, which does not cover a seed. It is also the first thread-scoped value whose cleared state is `null` rather than absent, so the three snapshot fallbacks in `chat-runtime-store.ts` go through `firstSetThreadScopedValue` instead of `??`: coalescing would read a cleared seed as a missing key and hand back the installation pin.

## Checks

Run on the rebase.

- `npm run typecheck` clean
- `npm test` 5161 passed, 0 failed, including 24 in `tests/chat-sampling-seed.test.ts`
- `pytest tests/test_chat_settings_payload.py tests/test_chat_history_routes.py tests/test_chat_thread_settings.py tests/test_chat_history_storage.py` 195 passed, 0 failed
- `ruff check` clean on both backend files


