### PR TITLE
Security audit: pin openai, and re-review the four digest-pinned entries

### DIFF
--- a/scripts/scan_packages_baseline.json
+++ b/scripts/scan_packages_baseline.json
@@ -1688,36 +1688,36 @@
       "file": "openai/_client.py",
       "check": "Harvests environment variables/secrets AND makes network calls",
       "severity": "CRITICAL",
-      "evidence": "Env: L210:                 api_key = os.environ.get(\"OPENAI_API_KEY\") | L220:             admin_api_key = os.environ.get(\"OPENAI_ADMIN_KEY\") | L244:             webhook_secret = os.environ.get(\"OPENAI_WEBHOOK_SECRET\") | L816:                 api_key = os.environ.get(\"OPENAI_API_KEY\") | L826:             admin_api_key = os.environ.get(\"OPENAI_ADMIN_KEY\") | L850:             webhook_secret = os.environ.get(\"OPENAI_WEBHOOK_SECRET\")\nNetwork: L147:         http_client: httpx2.Client | None = None, | L599:         http_client: httpx2.Client | None = None, | L753:         http_client: httpx2.AsyncClient | None = None, | L1216:         http_client: httpx2.AsyncClient | None = None,",
+      "evidence": "Env: L235:                 api_key = os.environ.get(\"OPENAI_API_KEY\") | L245:             admin_api_key = os.environ.get(\"OPENAI_ADMIN_KEY\") | L269:             webhook_secret = os.environ.get(\"OPENAI_WEBHOOK_SECRET\") | L908:                 api_key = os.environ.get(\"OPENAI_API_KEY\") | L918:             admin_api_key = os.environ.get(\"OPENAI_ADMIN_KEY\") | L942:             webhook_secret = os.environ.get(\"OPENAI_WEBHOOK_SECRET\")\nNetwork: L170:         http_client: httpx2.Client | None = None, | L661:         http_client: httpx2.Client | None = None, | L843:         http_client: httpx2.AsyncClient | None = None, | L1347:         http_client: httpx2.AsyncClient | None = None,",
       "evidence_hash": "ee8e7ed79d2bfe99f85f53b1bff3d0f59cfc0de3393ab31a2955ef4365005e3c",
-      "file_sha256": "389ea48de3b3c46a9048d6636ca19e43533bda98e4dccde2d7f96037d0c82817"
+      "file_sha256": "6303a1c4b4b01491dd6e9ef248ba74d8d7a5af5185a1d45721ab9c904dd77b42"
     },
     {
       "package": "openai",
       "file": "openai/auth/_workload.py",
       "check": "Accesses cloud metadata/IMDS AND makes network calls",
       "severity": "CRITICAL",
-      "evidence": "IMDS: L97:             url = \"http://169.254.169.254/metadata/identity/oauth2/token\" | L150:             url = \"http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/identity\"\nNetwork: L78:     http_client: httpx2.Client | None = None, | L109:                 with httpx2.Client() as client: | L134:     http_client: httpx2.Client | None = None, | L156:                 with httpx2.Client() as client:",
+      "evidence": "IMDS: L130:             url = \"http://169.254.169.254/metadata/identity/oauth2/token\" | L183:             url = \"http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/identity\"\nNetwork: L111:     http_client: httpx2.Client | None = None, | L142:                 with httpx2.Client() as client: | L167:     http_client: httpx2.Client | None = None, | L189:                 with httpx2.Client() as client:",
       "evidence_hash": "a4b0fb17867ab99605026f7d5d753ba2d3cd0a79f5fab6d77521ec251c256a4c",
-      "file_sha256": "6a01858ee5a351df969067995bde0a97d4762455468f24c116f818db3aaec95d"
+      "file_sha256": "f61ff8db00ec65d293e7cea656289ac6b0c47faa0997fa70c1731ecf57949512"
     },
     {
       "package": "openai",
       "file": "openai/lib/azure.py",
       "check": "Harvests environment variables/secrets AND makes network calls",
       "severity": "CRITICAL",
-      "evidence": "Env: L215:             api_key = os.environ.get(\"AZURE_OPENAI_API_KEY\") | L218:             azure_ad_token = os.environ.get(\"AZURE_OPENAI_AD_TOKEN\") | L539:             api_key = os.environ.get(\"AZURE_OPENAI_API_KEY\") | L542:             azure_ad_token = os.environ.get(\"AZURE_OPENAI_AD_TOKEN\")\nNetwork: L38: _HttpxClientT = TypeVar(\"_HttpxClientT\", bound=Union[httpx2.Client, httpx2.AsyncClient]) | L101: class AzureOpenAI(BaseAzureClient[httpx2.Client, Stream[Any]], OpenAI): | L120:         http_client: httpx2.Client | None = None, | L142:         http_client: httpx2.Client | None = None, | L164:         http_client: httpx2.Client | None = None, | L190:         http_client: httpx2.Client | None = None, | L298:         http_client: httpx2.Client | None = None, | L422: class AsyncAzureOpenAI(BaseAzureClient[httpx2.AsyncClient, AsyncStream[Any]], AsyncOpenAI): | L442:         http_client: httpx2.AsyncClient | None = None, | L465:         http_client: httpx2.AsyncClient | None = None, | L488:         http_client: httpx2.AsyncClient | None = None, | L514:         http_client: httpx2.AsyncClient | None = None, | L622:         http_client: httpx2.AsyncClient | None = None,",
+      "evidence": "Env: L219:             api_key = os.environ.get(\"AZURE_OPENAI_API_KEY\") | L222:             azure_ad_token = os.environ.get(\"AZURE_OPENAI_AD_TOKEN\") | L548:             api_key = os.environ.get(\"AZURE_OPENAI_API_KEY\") | L551:             azure_ad_token = os.environ.get(\"AZURE_OPENAI_AD_TOKEN\")\nNetwork: L39: _HttpxClientT = TypeVar(\"_HttpxClientT\", bound=Union[httpx2.Client, httpx2.AsyncClient]) | L102: class AzureOpenAI(BaseAzureClient[httpx2.Client, Stream[Any]], OpenAI): | L121:         http_client: httpx2.Client | None = None, | L143:         http_client: httpx2.Client | None = None, | L165:         http_client: httpx2.Client | None = None, | L191:         http_client: httpx2.Client | None = None, | L302:         http_client: httpx2.Client | None = None, | L428: class AsyncAzureOpenAI(BaseAzureClient[httpx2.AsyncClient, AsyncStream[Any]], AsyncOpenAI): | L448:         http_client: httpx2.AsyncClient | None = None, | L471:         http_client: httpx2.AsyncClient | None = None, | L494:         http_client: httpx2.AsyncClient | None = None, | L520:         http_client: httpx2.AsyncClient | None = None, | L631:         http_client: httpx2.AsyncClient | None = None,",
       "evidence_hash": "a2048fafc6303825095270dc766eb7630cdf9b0fb2e6eb0272695dbe9cd185c1",
-      "file_sha256": "b031fc8ab1d1d7865cd7f09e07a8cb08ea15b9269c710df62b1bb505d0920ed2"
+      "file_sha256": "7f6f58dd6e0068765e58af2c59acfa40504a03187953e3459ea008c263f952d7"
     },
     {
       "package": "openai",
       "file": "openai/lib/bedrock.py",
       "check": "Harvests environment variables/secrets AND makes network calls",
       "severity": "CRITICAL",
-      "evidence": "Env: L105:     token = os.environ.get(\"AWS_BEARER_TOKEN_BEDROCK\") | L150:     environment_token = os.environ.get(\"AWS_BEARER_TOKEN_BEDROCK\")\nNetwork: L415:         http_client: httpx2.Client | None = None, | L531:         http_client: httpx2.Client | None = None, | L649:         http_client: httpx2.AsyncClient | None = None, | L767:         http_client: httpx2.AsyncClient | None = None,",
+      "evidence": "Env: L117:     token = os.environ.get(\"AWS_BEARER_TOKEN_BEDROCK\") | L162:     environment_token = os.environ.get(\"AWS_BEARER_TOKEN_BEDROCK\")\nNetwork: L440:         http_client: httpx2.Client | None = None, | L554:         http_client: httpx2.Client | None = None, | L672:         http_client: httpx2.AsyncClient | None = None, | L788:         http_client: httpx2.AsyncClient | None = None,",
       "evidence_hash": "ed7177e905325f49fc00b6329c7b4c18436af60fa52a559251a3a54618715873",
-      "file_sha256": "9d38c8b3d410100ea7d63d17eac2e92d71a2916305586c244a06111e99da7704"
+      "file_sha256": "75816d2632b709d789ca5ebef43e15c3916691bb7ce9e8ed57181a2faccc667e"
     }
   ]
 }

--- a/studio/backend/requirements/extras.txt
+++ b/studio/backend/requirements/extras.txt
@@ -53,5 +53,11 @@ einops==0.8.2
 # 0.10 requires >=3.10.
 tabulate==0.10.0; python_version >= "3.10"
 tabulate==0.9.0; python_version < "3.10"
-openai>=2.7.2
+# Pinned, not floating. scan_packages_baseline.json pins four reviewed-benign
+# CRITICALs in this package to the reviewed file digests, because the evidence
+# hash records a network call but not its destination (#8104, #8565). A floating
+# spec therefore reds the security gate on whatever day upstream ships, which is
+# what openai 3.2.0 did. Bump this deliberately and re-review the four entries
+# with --write-baseline.
+openai==3.2.0
 websockets>=15.0.1

--- a/studio/backend/requirements/extras.txt
+++ b/studio/backend/requirements/extras.txt
@@ -59,5 +59,12 @@ tabulate==0.9.0; python_version < "3.10"
 # spec therefore reds the security gate on whatever day upstream ships, which is
 # what openai 3.2.0 did. Bump this deliberately and re-review the four entries
 # with --write-baseline.
-openai==3.2.0
+#
+# Split on 3.10 because openai 3.x requires it and this file still supports 3.9
+# (pyproject requires-python is >=3.9). A single `openai==3.2.0` would not resolve
+# at all there, where `>=2.7.2` had quietly been picking 2.48.0; that is the last
+# release accepting 3.9, so the pin keeps what 3.9 was already getting. Only the
+# 3.10 branch is what the security audit scans, since that job runs on 3.12.
+openai==3.2.0; python_version >= "3.10"
+openai==2.48.0; python_version < "3.10"
 websockets>=15.0.1

--- a/tests/security/test_scan_packages.py
+++ b/tests/security/test_scan_packages.py
@@ -2189,9 +2189,7 @@ def test_digest_pinned_packages_are_pinned_on_every_supported_python():
         "publishes: " + "; ".join(floating)
     )
     gaps = {
-        pkg: sorted(
-            set(pythons) - covered.get(pkg, set()), key = lambda v: int(v.split(".")[1])
-        )
+        pkg: sorted(set(pythons) - covered.get(pkg, set()), key = lambda v: int(v.split(".")[1]))
         for pkg in sorted(present)
     }
     gaps = {pkg: missing for pkg, missing in gaps.items() if missing}

--- a/tests/security/test_scan_packages.py
+++ b/tests/security/test_scan_packages.py
@@ -2063,7 +2063,6 @@ def _tomllib():
     """
     if sys.version_info >= (3, 11):
         import tomllib
-
         return tomllib
     return pytest.importorskip("tomli")
 

--- a/tests/security/test_scan_packages.py
+++ b/tests/security/test_scan_packages.py
@@ -2050,11 +2050,29 @@ def test_a_stalled_pool_exits_2_not_1(tmp_path, monkeypatch, capsys):
     assert "scan stalled" in captured.err
 
 
+def _tomllib():
+    """`tomllib` is stdlib only on 3.11+ (PEP 680); below that, the tomli backport.
+
+    pyproject's requires-python is >=3.9 and testpaths is ["tests/security"], so a bare
+    `pytest` from the repo root collects this file on 3.9 and 3.10, where a plain
+    `import tomllib` is a ModuleNotFoundError rather than a test result. tomli is already
+    a declared dependency there (extras-no-deps.txt pins it for python_version < "3.11"),
+    and this is the same shape the rest of the suite already uses -- see
+    tests/python/test_windows_xformers_wheel_match.py and
+    tests/studio/install/test_install_node_prebuilt_logic.py.
+    """
+    if sys.version_info >= (3, 11):
+        import tomllib
+
+        return tomllib
+    return pytest.importorskip("tomli")
+
+
 def _supported_python_versions(root):
     """Every `python_version` marker value pyproject's requires-python admits."""
     import re
-    import tomllib
 
+    tomllib = _tomllib()
     with open(root / "pyproject.toml", "rb") as fh:
         spec = tomllib.load(fh)["project"]["requires-python"]
     lo = re.search(r">=\s*3\.(\d+)", spec)
@@ -2073,8 +2091,7 @@ def _audited_requirements(root):
     copied through a `git+` filter. Reading only the second half is how a pinned
     package declared in pyproject goes unchecked.
     """
-    import tomllib
-
+    tomllib = _tomllib()
     for req in sorted((root / "studio" / "backend" / "requirements").glob("*.txt")):
         for lineno, raw in enumerate(req.read_text(encoding = "utf-8").splitlines(), 1):
             spec = raw.split("#", 1)[0].strip()
@@ -2198,3 +2215,50 @@ def test_digest_pinned_packages_are_pinned_on_every_supported_python():
         "installing there resolves to nothing at all: "
         + "; ".join(f"{pkg} uncovered on {', '.join(missing)}" for pkg, missing in gaps.items())
     )
+
+
+def test_the_toml_helpers_run_without_stdlib_tomllib(monkeypatch):
+    """The helpers above must work on 3.9/3.10, where `tomllib` does not exist.
+
+    pyproject declares requires-python >=3.9 and testpaths ["tests/security"], so a bare
+    `pytest` from the repo root runs this module on 3.9 and 3.10. `tomllib` landed in 3.11
+    (PEP 680), so an unguarded `import tomllib` there is a collection-time
+    ModuleNotFoundError, not a verdict.
+
+    Simulated rather than skipped: the interpreter running the suite is whatever CI picked
+    (3.12 today), so the below-3.11 branch is only ever reached by making the version look
+    old AND taking `tomllib` away. Doing only the second is not the same thing -- the
+    guard reads sys.version_info, not the module table.
+
+    The backport is supplied rather than required. `tests-security` installs only pytest
+    and PyYAML, so a test that leaned on a real `tomli` being importable would
+    `importorskip` its way to green there and never once execute the branch it exists to
+    cover. Registering the stdlib parser under the name the fallback looks for keeps this
+    load-bearing on every interpreter and in CI, while still proving the fallback is what
+    gets consulted, because `import tomllib` is made to fail for the duration.
+    """
+    import builtins
+    import importlib
+
+    # Read the REAL version before it is patched, and take whichever parser this
+    # interpreter genuinely has. On 3.11+ that is stdlib tomllib, which is always
+    # there, so the branch runs in CI; on a real 3.9/3.10 it is the tomli the
+    # requirements already pin, and only a machine missing both ever skips.
+    parser = (
+        importlib.import_module("tomllib")
+        if sys.version_info >= (3, 11)
+        else pytest.importorskip("tomli")
+    )
+    monkeypatch.setattr(sys, "version_info", (3, 10, 0, "final", 0))
+    monkeypatch.setitem(sys.modules, "tomli", parser)
+    real_import = builtins.__import__
+
+    def without_tomllib(name, *args, **kwargs):
+        if name == "tomllib":
+            raise ModuleNotFoundError("No module named 'tomllib'", name = "tomllib")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", without_tomllib)
+
+    assert _supported_python_versions(REPO_ROOT)[0] == "3.9"
+    assert any(source == "pyproject.toml" for source, _ in _audited_requirements(REPO_ROOT))

--- a/tests/security/test_scan_packages.py
+++ b/tests/security/test_scan_packages.py
@@ -2048,3 +2048,57 @@ def test_a_stalled_pool_exits_2_not_1(tmp_path, monkeypatch, capsys):
     assert rc == 2, f"a stalled scan must exit 2 (incomplete), got {rc}"
     assert "SCAN INCOMPLETE" in captured.err
     assert "scan stalled" in captured.err
+
+
+def test_digest_pinned_packages_are_version_pinned():
+    """A package whose baseline entries pin a file digest must not float in requirements.
+
+    The two mechanisms are only coherent together. `file_sha256` deliberately reopens a
+    reviewed CRITICAL on ANY edit to the file, because the evidence records a network
+    call and not its destination, so nothing weaker can tell a benign refactor from an
+    added credential send. A `>=` spec then hands the choice of file bytes to whatever
+    upstream published most recently, so the gate turns red on release day rather than
+    on a change anyone here made.
+
+    That is not hypothetical: `openai>=2.7.2` floated onto 3.2.0, which touched all four
+    pinned files, and the extras shard of the security audit went red on main with four
+    non-baselined CRITICALs that were the same reviewed-benign patterns as before.
+
+    Pinning the spec makes the bump deliberate, which is the point: the reviewer who
+    raises the version is the one who re-runs --write-baseline and re-reads the diff.
+    """
+    import json
+    import pathlib
+    import re
+
+    root = pathlib.Path(__file__).resolve().parents[2]
+    baseline = json.loads(
+        (root / "scripts" / "scan_packages_baseline.json").read_text(encoding = "utf-8")
+    )
+    pinned_packages = {
+        sp._norm_pkg(e["package"])
+        for e in baseline["entries"]
+        if e.get("file_sha256")
+    }
+    assert pinned_packages, "no digest-pinned entries; this guard would be vacuous"
+
+    req_dir = root / "studio" / "backend" / "requirements"
+    offenders = []
+    for req in sorted(req_dir.glob("*.txt")):
+        for lineno, raw in enumerate(req.read_text(encoding = "utf-8").splitlines(), 1):
+            spec = raw.split("#", 1)[0].strip()
+            if not spec or spec.startswith("-") or "git+" in spec:
+                continue
+            # Name is everything before the first comparator / marker / extra.
+            name = re.split(r"[<>=!~;\[]", spec, maxsplit = 1)[0].strip()
+            if sp._norm_pkg(name) not in pinned_packages:
+                continue
+            # `==` on the bare name, not `>=`, `~=` or a bare requirement.
+            if not re.search(rf"^{re.escape(name)}\s*==", spec):
+                offenders.append(f"{req.name}:{lineno}: {spec}")
+
+    assert not offenders, (
+        "these packages carry digest-pinned baseline entries but float in requirements, "
+        "so the security audit goes red whenever upstream publishes: "
+        + "; ".join(offenders)
+    )

--- a/tests/security/test_scan_packages.py
+++ b/tests/security/test_scan_packages.py
@@ -2050,26 +2050,52 @@ def test_a_stalled_pool_exits_2_not_1(tmp_path, monkeypatch, capsys):
     assert "scan stalled" in captured.err
 
 
-def test_digest_pinned_packages_are_version_pinned():
-    """A package whose baseline entries pin a file digest must not float in requirements.
+def _supported_python_versions(root):
+    """Every `python_version` marker value pyproject's requires-python admits."""
+    import re
+    import tomllib
+
+    with open(root / "pyproject.toml", "rb") as fh:
+        spec = tomllib.load(fh)["project"]["requires-python"]
+    lo = re.search(r">=\s*3\.(\d+)", spec)
+    hi = re.search(r"<\s*3\.(\d+)", spec)
+    assert lo, f"cannot read a floor out of requires-python {spec!r}"
+    last = int(hi.group(1)) - 1 if hi else int(lo.group(1))
+    return [f"3.{minor}" for minor in range(int(lo.group(1)), last + 1)]
+
+
+def test_digest_pinned_packages_are_pinned_on_every_supported_python():
+    """A digest-pinned package must be `==` pinned, and pinned for every Python we support.
 
     The two mechanisms are only coherent together. `file_sha256` deliberately reopens a
     reviewed CRITICAL on ANY edit to the file, because the evidence records a network
     call and not its destination, so nothing weaker can tell a benign refactor from an
     added credential send. A `>=` spec then hands the choice of file bytes to whatever
     upstream published most recently, so the gate turns red on release day rather than
-    on a change anyone here made.
+    on a change anyone here made. That is not hypothetical: `openai>=2.7.2` floated onto
+    3.2.0, which touched all four pinned files, and the extras shard went red on main.
 
-    That is not hypothetical: `openai>=2.7.2` floated onto 3.2.0, which touched all four
-    pinned files, and the extras shard of the security audit went red on main with four
-    non-baselined CRITICALs that were the same reviewed-benign patterns as before.
+    The second half of the assertion is the trap the first half walks into. `==` is
+    strictly narrower than `>=`, so pinning the newest release silently drops every
+    interpreter that release does not support: openai 3.x needs 3.10, this project
+    supports 3.9 back to pyproject's requires-python, and a bare `openai==3.2.0` does
+    not resolve there AT ALL, where `>=2.7.2` had been quietly picking 2.48.0. A pin
+    that fixes CI by breaking an install is not a fix, so the markers on the pinned
+    lines have to cover the whole supported range between them.
 
-    Pinning the spec makes the bump deliberate, which is the point: the reviewer who
-    raises the version is the one who re-runs --write-baseline and re-reads the diff.
+    Marker-only, so it stays offline and deterministic. That bounds what the second
+    half can see: it catches a marker partition with a hole in it (a `>= "3.11"` beside
+    a `< "3.10"` leaves 3.10 resolving to nothing), but it cannot catch a single
+    unmarked pin whose version happens not to support 3.9, because knowing that means
+    asking PyPI for the release's requires-python. Resolving extras.txt on each
+    supported interpreter is what covers that, and it is done as a resolution
+    simulation rather than from here, so this module stays network-free.
     """
     import json
     import pathlib
     import re
+
+    from packaging.markers import Marker
 
     root = pathlib.Path(__file__).resolve().parents[2]
     baseline = json.loads(
@@ -2080,22 +2106,45 @@ def test_digest_pinned_packages_are_version_pinned():
     }
     assert pinned_packages, "no digest-pinned entries; this guard would be vacuous"
 
+    pythons = _supported_python_versions(root)
+    assert pythons, "no supported python versions parsed out of requires-python"
+
     req_dir = root / "studio" / "backend" / "requirements"
-    offenders = []
+    floating = []
+    # package -> the python_version values some `==` line claims
+    covered: dict[str, set[str]] = {}
+    present: set[str] = set()
     for req in sorted(req_dir.glob("*.txt")):
         for lineno, raw in enumerate(req.read_text(encoding = "utf-8").splitlines(), 1):
             spec = raw.split("#", 1)[0].strip()
             if not spec or spec.startswith("-") or "git+" in spec:
                 continue
-            # Name is everything before the first comparator / marker / extra.
-            name = re.split(r"[<>=!~;\[]", spec, maxsplit = 1)[0].strip()
-            if sp._norm_pkg(name) not in pinned_packages:
+            requirement, _, marker_text = spec.partition(";")
+            name = re.split(r"[<>=!~\[]", requirement, maxsplit = 1)[0].strip()
+            pkg = sp._norm_pkg(name)
+            if pkg not in pinned_packages:
                 continue
-            # `==` on the bare name, not `>=`, `~=` or a bare requirement.
-            if not re.search(rf"^{re.escape(name)}\s*==", spec):
-                offenders.append(f"{req.name}:{lineno}: {spec}")
+            present.add(pkg)
+            if not re.search(rf"^{re.escape(name)}\s*==", requirement.strip()):
+                floating.append(f"{req.name}:{lineno}: {spec}")
+                continue
+            marker = Marker(marker_text.strip()) if marker_text.strip() else None
+            for python in pythons:
+                if marker is None or marker.evaluate({"python_version": python}):
+                    covered.setdefault(pkg, set()).add(python)
 
-    assert not offenders, (
+    assert not floating, (
         "these packages carry digest-pinned baseline entries but float in requirements, "
-        "so the security audit goes red whenever upstream publishes: " + "; ".join(offenders)
+        "so the security audit goes red whenever upstream publishes: "
+        + "; ".join(floating)
+    )
+    gaps = {
+        pkg: sorted(set(pythons) - covered.get(pkg, set()), key = lambda v: int(v.split(".")[1]))
+        for pkg in sorted(present)
+    }
+    gaps = {pkg: missing for pkg, missing in gaps.items() if missing}
+    assert not gaps, (
+        "a digest-pinned package has no exact pin on some supported Python, so "
+        "installing there resolves to nothing at all: "
+        + "; ".join(f"{pkg} uncovered on {', '.join(missing)}" for pkg, missing in gaps.items())
     )

--- a/tests/security/test_scan_packages.py
+++ b/tests/security/test_scan_packages.py
@@ -2064,8 +2064,47 @@ def _supported_python_versions(root):
     return [f"3.{minor}" for minor in range(int(lo.group(1)), last + 1)]
 
 
+def _audited_requirements(root):
+    """(source, spec) for everything security-audit.yml feeds to the scanner.
+
+    Both halves, because the workflow has two. `audit-reqs/unsloth-deps.txt` is
+    generated from pyproject's `project.dependencies` plus the
+    `huggingfacenotorch` extra, and the rest are the studio requirement files
+    copied through a `git+` filter. Reading only the second half is how a pinned
+    package declared in pyproject goes unchecked.
+    """
+    import tomllib
+
+    for req in sorted((root / "studio" / "backend" / "requirements").glob("*.txt")):
+        for lineno, raw in enumerate(req.read_text(encoding = "utf-8").splitlines(), 1):
+            spec = raw.split("#", 1)[0].strip()
+            if spec and not spec.startswith("-") and "git+" not in spec:
+                yield f"{req.name}:{lineno}", spec
+    with open(root / "pyproject.toml", "rb") as fh:
+        project = tomllib.load(fh)["project"]
+    declared = list(project["dependencies"])
+    declared += list(project["optional-dependencies"]["huggingfacenotorch"])
+    for spec in declared:
+        if "git+" not in spec:
+            yield "pyproject.toml", spec
+
+
+# unsloth_zoo is digest-pinned and deliberately NOT version-pinned, so it is named
+# here rather than quietly skipped. The recurrence this guard exists to stop is an
+# upstream release we do not control changing the bytes and reddening main on a day
+# nobody touched the repo. unsloth_zoo is our own, released in lockstep with this
+# package, and pinning it exactly would break that; when its digest reopens, the
+# change is one of ours and re-reviewing it is the point of the pin (#8104, and that
+# entry is the credential send itself). Third-party packages get no such licence, so
+# the test asserts this list holds only first-party names.
+# Exactly the first-party packages that ARE digest-pinned today, asserted below to
+# be exactly that, so a name added here without an entry, or a third-party name
+# added at all, fails rather than silently widening the exemption.
+FIRST_PARTY_DIGEST_PINNED = {"unsloth-zoo"}
+
+
 def test_digest_pinned_packages_are_pinned_on_every_supported_python():
-    """A digest-pinned package must be `==` pinned, and pinned for every Python we support.
+    """A digest-pinned third-party package must be `==` pinned on every Python we support.
 
     The two mechanisms are only coherent together. `file_sha256` deliberately reopens a
     reviewed CRITICAL on ANY edit to the file, because the evidence records a network
@@ -2075,27 +2114,30 @@ def test_digest_pinned_packages_are_pinned_on_every_supported_python():
     on a change anyone here made. That is not hypothetical: `openai>=2.7.2` floated onto
     3.2.0, which touched all four pinned files, and the extras shard went red on main.
 
-    The second half of the assertion is the trap the first half walks into. `==` is
-    strictly narrower than `>=`, so pinning the newest release silently drops every
-    interpreter that release does not support: openai 3.x needs 3.10, this project
-    supports 3.9 back to pyproject's requires-python, and a bare `openai==3.2.0` does
-    not resolve there AT ALL, where `>=2.7.2` had been quietly picking 2.48.0. A pin
-    that fixes CI by breaking an install is not a fix, so the markers on the pinned
-    lines have to cover the whole supported range between them.
+    `==` has to mean one version. `openai==3.*` satisfies a naive prefix test and is a
+    floating prefix match to pip, which recreates the same failure, so the specifier is
+    parsed rather than pattern-matched and a wildcard is rejected.
 
-    Marker-only, so it stays offline and deterministic. That bounds what the second
+    And `==` is strictly narrower than `>=`, so pinning the newest release silently
+    drops every interpreter that release does not support: openai 3.x needs 3.10, this
+    project supports 3.9 back to pyproject's requires-python, and a bare
+    `openai==3.2.0` does not resolve there AT ALL, where `>=2.7.2` had been quietly
+    picking 2.48.0. A pin that fixes CI by breaking an install is not a fix, so the
+    markers on the pinned lines have to cover the whole supported range between them.
+
+    Marker-only, so it stays offline and deterministic. That bounds what the coverage
     half can see: it catches a marker partition with a hole in it (a `>= "3.11"` beside
     a `< "3.10"` leaves 3.10 resolving to nothing), but it cannot catch a single
     unmarked pin whose version happens not to support 3.9, because knowing that means
-    asking PyPI for the release's requires-python. Resolving extras.txt on each
+    asking PyPI for the release's requires-python. Resolving the requirements on each
     supported interpreter is what covers that, and it is done as a resolution
     simulation rather than from here, so this module stays network-free.
     """
     import json
     import pathlib
-    import re
 
     from packaging.markers import Marker
+    from packaging.requirements import Requirement
 
     root = pathlib.Path(__file__).resolve().parents[2]
     baseline = json.loads(
@@ -2105,40 +2147,51 @@ def test_digest_pinned_packages_are_pinned_on_every_supported_python():
         sp._norm_pkg(e["package"]) for e in baseline["entries"] if e.get("file_sha256")
     }
     assert pinned_packages, "no digest-pinned entries; this guard would be vacuous"
+    stray = FIRST_PARTY_DIGEST_PINNED - pinned_packages
+    assert not stray, f"exemption names a package with no digest-pinned entry: {sorted(stray)}"
+    third_party = pinned_packages - FIRST_PARTY_DIGEST_PINNED
+    assert third_party, "every digest-pinned package is exempt; this guard would be vacuous"
 
     pythons = _supported_python_versions(root)
     assert pythons, "no supported python versions parsed out of requires-python"
 
-    req_dir = root / "studio" / "backend" / "requirements"
     floating = []
-    # package -> the python_version values some `==` line claims
     covered: dict[str, set[str]] = {}
     present: set[str] = set()
-    for req in sorted(req_dir.glob("*.txt")):
-        for lineno, raw in enumerate(req.read_text(encoding = "utf-8").splitlines(), 1):
-            spec = raw.split("#", 1)[0].strip()
-            if not spec or spec.startswith("-") or "git+" in spec:
-                continue
-            requirement, _, marker_text = spec.partition(";")
-            name = re.split(r"[<>=!~\[]", requirement, maxsplit = 1)[0].strip()
-            pkg = sp._norm_pkg(name)
-            if pkg not in pinned_packages:
-                continue
-            present.add(pkg)
-            if not re.search(rf"^{re.escape(name)}\s*==", requirement.strip()):
-                floating.append(f"{req.name}:{lineno}: {spec}")
-                continue
-            marker = Marker(marker_text.strip()) if marker_text.strip() else None
-            for python in pythons:
-                if marker is None or marker.evaluate({"python_version": python}):
-                    covered.setdefault(pkg, set()).add(python)
+    for source, spec in _audited_requirements(root):
+        try:
+            requirement = Requirement(spec)
+        except Exception:
+            continue
+        pkg = sp._norm_pkg(requirement.name)
+        if pkg not in third_party:
+            continue
+        present.add(pkg)
+        specifiers = list(requirement.specifier)
+        exact = (
+            len(specifiers) == 1
+            and specifiers[0].operator == "=="
+            # `==3.*` is a prefix match, not a pin, and pip resolves it to
+            # whatever 3.x is newest.
+            and not specifiers[0].version.endswith(".*")
+        )
+        if not exact:
+            floating.append(f"{source}: {spec}")
+            continue
+        marker = requirement.marker
+        for python in pythons:
+            if marker is None or marker.evaluate({"python_version": python}):
+                covered.setdefault(pkg, set()).add(python)
 
     assert not floating, (
-        "these packages carry digest-pinned baseline entries but float in requirements, "
-        "so the security audit goes red whenever upstream publishes: " + "; ".join(floating)
+        "these packages carry digest-pinned baseline entries but are not pinned to one "
+        "version in what the security audit scans, so it goes red whenever upstream "
+        "publishes: " + "; ".join(floating)
     )
     gaps = {
-        pkg: sorted(set(pythons) - covered.get(pkg, set()), key = lambda v: int(v.split(".")[1]))
+        pkg: sorted(
+            set(pythons) - covered.get(pkg, set()), key = lambda v: int(v.split(".")[1])
+        )
         for pkg in sorted(present)
     }
     gaps = {pkg: missing for pkg, missing in gaps.items() if missing}

--- a/tests/security/test_scan_packages.py
+++ b/tests/security/test_scan_packages.py
@@ -2135,8 +2135,7 @@ def test_digest_pinned_packages_are_pinned_on_every_supported_python():
 
     assert not floating, (
         "these packages carry digest-pinned baseline entries but float in requirements, "
-        "so the security audit goes red whenever upstream publishes: "
-        + "; ".join(floating)
+        "so the security audit goes red whenever upstream publishes: " + "; ".join(floating)
     )
     gaps = {
         pkg: sorted(set(pythons) - covered.get(pkg, set()), key = lambda v: int(v.split(".")[1]))

--- a/tests/security/test_scan_packages.py
+++ b/tests/security/test_scan_packages.py
@@ -2076,9 +2076,7 @@ def test_digest_pinned_packages_are_version_pinned():
         (root / "scripts" / "scan_packages_baseline.json").read_text(encoding = "utf-8")
     )
     pinned_packages = {
-        sp._norm_pkg(e["package"])
-        for e in baseline["entries"]
-        if e.get("file_sha256")
+        sp._norm_pkg(e["package"]) for e in baseline["entries"] if e.get("file_sha256")
     }
     assert pinned_packages, "no digest-pinned entries; this guard would be vacuous"
 
@@ -2099,6 +2097,5 @@ def test_digest_pinned_packages_are_version_pinned():
 
     assert not offenders, (
         "these packages carry digest-pinned baseline entries but float in requirements, "
-        "so the security audit goes red whenever upstream publishes: "
-        + "; ".join(offenders)
+        "so the security audit goes red whenever upstream publishes: " + "; ".join(offenders)
     )


### PR DESCRIPTION
The extras shard of the security audit has been red on main since 2026-08-17
19:14Z with four non-baselined CRITICALs, all in `openai`:

    Harvests environment variables/secrets AND makes network calls
      openai/_client.py, openai/lib/azure.py, openai/lib/bedrock.py
    Accesses cloud metadata/IMDS AND makes network calls
      openai/auth/_workload.py

It is not a code change here. The last green run was 18:23Z and every run after
18:40Z failed on the same four findings, on main and on unrelated PR branches
alike, which is upstream drift rather than anything in the tree.

`openai>=2.7.2` is the only floating spec in extras.txt that carries digest-pinned
baseline entries. openai 3.2.0 published at 19:14Z and changed all four files.
Confirmed by digest: the four `file_sha256` values in the baseline match openai
3.0.0 and 3.1.0 exactly and none of 3.2.0's.

The pin is deliberate and correct (#8104, #8565): the evidence for these entries
records that a network call exists but not where it goes, so `client.post(...,
data=api_key)` appended to one of these files would leave the evidence hash
untouched. Only the file digest can reopen that, so any edit upstream makes must
red the gate until someone re-reads it.

Which is the review, done here. Every destination in the four files at 3.2.0 is
first-party or a documented cloud metadata endpoint: api.openai.com,
auth.openai.com, 169.254.169.254 (Azure IMDS), metadata.google.internal,
management.azure.com, and bedrock-mantle.{region}.api.aws. The one instance-level
POST is the workload-identity token exchange, which defaults to
https://auth.openai.com/oauth/token and sets follow_redirects=False. The env reads
are OPENAI_API_KEY, OPENAI_ADMIN_KEY, OPENAI_WEBHOOK_SECRET,
AZURE_OPENAI_API_KEY, AZURE_OPENAI_AD_TOKEN and AWS_BEARER_TOKEN_BEDROCK, each
used to authenticate to its own service. Same benign patterns as the reviewed
3.0.0, so the four entries are re-pinned to 3.2.0's digests and nothing else in
the 214-entry baseline is touched.

Re-baselining alone would only buy time until the next release, so the spec is
pinned too. Every other requirement in extras.txt is already an exact pin (#8408
pinned the bare ones and skipped this one because it had a specifier). Pinning
makes the bump deliberate: whoever raises the version is the one who re-runs
--write-baseline and re-reads the diff, instead of the gate going red on release
day for a change nobody here made.

The new test asserts that invariant directly, since it is the part that will be
got wrong again: a package with digest-pinned baseline entries must not float in
studio/backend/requirements. Reverting the spec to `openai>=2.7.2` fails it and
names extras.txt:62.

Verified:
  - `scan_packages.py 'openai==3.2.0'` exits 0; on 3.1.0 it exits 1, so the pin
    still bites and the entries were not widened.
  - The whole extras shard (`--with-deps -r extras.txt`, 128 archives) exits 0
    with 0 active CRITICAL/HIGH, against 4 CRITICAL and exit 1 before.
  - tests/security/test_scan_packages.py: 121 passed.

Unrelated, and not a defect: the `openai-whisper==20250625` line in the same log
is an INFO, not the failure. That version is on PyPI as an sdist only, and the
bulk resolve runs `--only-binary :all:` so it never executes a setup.py, which is
the scanner's whole security model. "from versions: none" is what pip says about
an sdist-only package under that flag, and the per-spec fallback plus the direct
sdist fetch that follow are the designed path working. The scipy
`assert_raises(ValueError, CubicSpline, ...)` evidence quoted alongside it is a
MEDIUM and cannot fail the gate; it is a false positive on `bc1`, a boundary
condition variable in scipy's own test file that looks like a bech32 address.