### PR TITLE
Studio: stop the overlay rail going click-through while it is scrolling

### DIFF
--- a/studio/frontend/src/features/settings/stores/monitor-frame-store.ts
+++ b/studio/frontend/src/features/settings/stores/monitor-frame-store.ts
@@ -418,6 +418,14 @@ export function useStackGeometry(): StackPlacement {
   const [neededRoom, setNeededRoom] = useState(ASSUMED_STACK_HEIGHT);
   const [floorRoom, setFloorRoom] = useState(ASSUMED_STACK_HEIGHT);
   const [persistentTail, setPersistentTail] = useState(0);
+  // Whether the rail is ACTUALLY scrolling, read off the node at its real cap.
+  // The derived answer below is a prediction, and a prediction can be wrong: the
+  // cards are only assumed to collapse to `floorRoom`, so whenever they stop
+  // short of it the box overflows a cap that `floorRoom > maxHeight` says it
+  // fits inside. That combination is a rail that scrolls while it is still
+  // click-through, which costs it its scrollbar and strands every card above the
+  // fold where no pointer can reach them.
+  const [domOverflowing, setDomOverflowing] = useState(false);
   useEffect(() => {
     const onResize = () =>
       setViewport({ width: window.innerWidth, height: window.innerHeight });
@@ -501,6 +509,15 @@ export function useStackGeometry(): StackPlacement {
       // Flush the restore under the suppression, or putting `transition` back
       // hands the pending max-height change to a transition after all.
       void node.scrollHeight;
+      // Taken here, with the real cap back on and the layout just flushed, so it
+      // describes the box the reader has rather than either probe above. Read
+      // every time this runs, never latched: the observers below watch the rail
+      // AND every descendant, and a placement change moves the rail's own border
+      // box, so a cap that grows to fit clears this on the same pass that applied
+      // it. That is what the derived value was protecting against, and it is
+      // still true when the reading is refreshed rather than remembered.
+      const overflows = node.scrollHeight > node.clientHeight;
+      setDomOverflowing((current) => (current === overflows ? current : overflows));
       node.style.transition = eased;
       setNeededRoom((current) => (current === natural ? current : natural));
       setFloorRoom((current) => (current === floor ? current : floor));
@@ -591,6 +608,11 @@ export function useStackGeometry(): StackPlacement {
     // height, so a cap below the floor is exactly when the rail has to scroll.
     // A pixel of slack, since the floor is a rounded scrollHeight and the cap
     // is not.
-    overflowing: floorRoom > geometry.maxHeight + 1,
+    //
+    // Or the box is simply scrolling, whatever the prediction says. The two
+    // agree wherever the cards do collapse to the floor they measured, so this
+    // only ever adds the case the prediction misses; it cannot take pointer
+    // input away from a rail that the derived reading already claimed.
+    overflowing: floorRoom > geometry.maxHeight + 1 || domOverflowing,
   };
 }

--- a/studio/frontend/src/features/settings/stores/monitor-frame-store.ts
+++ b/studio/frontend/src/features/settings/stores/monitor-frame-store.ts
@@ -509,16 +509,23 @@ export function useStackGeometry(): StackPlacement {
       // Flush the restore under the suppression, or putting `transition` back
       // hands the pending max-height change to a transition after all.
       void node.scrollHeight;
-      // Taken here, with the real cap back on and the layout just flushed, so it
-      // describes the box the reader has rather than either probe above. Read
-      // every time this runs, never latched: the observers below watch the rail
-      // AND every descendant, and a placement change moves the rail's own border
-      // box, so a cap that grows to fit clears this on the same pass that applied
-      // it. That is what the derived value was protecting against, and it is
-      // still true when the reading is refreshed rather than remembered.
-      const overflows = node.scrollHeight > node.clientHeight;
-      setDomOverflowing((current) => (current === overflows ? current : overflows));
       node.style.transition = eased;
+      // Taken here, with the real cap back on and the layout already flushed by
+      // the line above, so it describes the box the reader has rather than
+      // either probe. After the `transition` restore, not between it and the
+      // flush: the cap change is already committed under the suppression, and
+      // `transition` is not itself a transitionable property, so no reflow this
+      // read forces can hand that cap to an animation.
+      //
+      // Read every time this runs, never latched: the observers below watch the
+      // rail AND every descendant, and a placement change moves the rail's own
+      // border box, so a cap that grows to fit clears this on the same pass that
+      // applied it. That is what the derived value was protecting against, and
+      // it is still true when the reading is refreshed rather than remembered.
+      const overflows = node.scrollHeight > node.clientHeight;
+      setDomOverflowing((current) =>
+        current === overflows ? current : overflows,
+      );
       setNeededRoom((current) => (current === natural ? current : natural));
       setFloorRoom((current) => (current === floor ? current : floor));
       // How much of the stack, measured up from the corner, the reader cannot

--- a/tests/studio/playwright_update_banner_layout.py
+++ b/tests/studio/playwright_update_banner_layout.py
@@ -434,6 +434,30 @@ MEASURE = """
     railGutterPx: rail ? Math.round(rail.offsetWidth - rail.clientWidth) : null,
     cardWidth: card ? Math.round(card.getBoundingClientRect().width) : null,
     railPointerEvents: rail ? getComputedStyle(rail).pointerEvents : null,
+    // Everything needed to say WHY a card came out narrow, reported with the
+    // failure instead of being guessed at afterwards from two numbers. A card
+    // that lost width to a scrollbar and a card that lost it to an unfinished
+    // transform read identically as `cardWidth`, and the engine that reports
+    // offsetWidth === clientWidth while still taking the width out of the
+    // content box (Playwright WebKit on Linux) makes railGutterPx no help on
+    // its own. `borderBox` is the layout width with no transform applied.
+    widthWhy: card && rail ? {
+      transform: getComputedStyle(card).transform,
+      borderBox: card.offsetWidth,
+      cssWidth: getComputedStyle(card).width,
+      maxWidth: getComputedStyle(card).maxWidth,
+      innerWidth: innerWidth,
+      docClientWidth: document.documentElement.clientWidth,
+      railOffsetW: rail.offsetWidth,
+      railClientW: rail.clientWidth,
+      railContentW: rail.clientWidth
+        - parseFloat(getComputedStyle(rail).paddingLeft || '0')
+        - parseFloat(getComputedStyle(rail).paddingRight || '0'),
+      railScrollH: rail.scrollHeight,
+      railClientH: rail.clientHeight,
+      railMaxHeight: getComputedStyle(rail).maxHeight,
+      kids: [...rail.children].map((c) => Math.round(c.getBoundingClientRect().height)),
+    } : null,
     // What a click on the rail's own gutter lands on when it is click-through.
     gutterIsRail: rail ? (() => {
       const r = rail.getBoundingClientRect();
@@ -555,14 +579,16 @@ def measure(page, label: str) -> dict:
             f"{label}: the card keeps its full width whatever the scrollbar does",
             abs(facts["cardWidth"] - want) <= 1,
             f"cardWidth={facts['cardWidth']} want={want} "
-            f"railGutter={facts['railGutterPx']} scrolls={facts['railScrolls']}",
+            f"railGutter={facts['railGutterPx']} scrolls={facts['railScrolls']} "
+            f"why={json.dumps(facts['widthWhy'], sort_keys = True)}",
         )
     if facts["railScrolls"] is not None:
         scrolls = facts["railScrolls"]
         check(
             f"{label}: the rail takes pointer input exactly when it scrolls",
             facts["railPointerEvents"] == ("auto" if scrolls else "none"),
-            f"scrolls={scrolls} pointerEvents={facts['railPointerEvents']}",
+            f"scrolls={scrolls} pointerEvents={facts['railPointerEvents']} "
+            f"why={json.dumps(facts['widthWhy'], sort_keys = True)}",
         )
         # Click-through is what pointer-events-none is for, and the gutter is
         # the widest part of the rail that no card covers.

--- a/tests/studio/playwright_update_banner_layout.py
+++ b/tests/studio/playwright_update_banner_layout.py
@@ -433,6 +433,12 @@ MEASURE = """
     // on which platform it is or on whether the rail happens to be scrolling.
     railGutterPx: rail ? Math.round(rail.offsetWidth - rail.clientWidth) : null,
     cardWidth: card ? Math.round(card.getBoundingClientRect().width) : null,
+    // The same card, measured off the LAYOUT box instead of the painted one.
+    // offsetWidth is the border box with no transform applied (CSSOM-View), so
+    // it answers the scrollbar question the assertion below is actually asking
+    // and cannot be moved by the card's enter animation. `cardWidth` stays,
+    // reported alongside, because the gap between the two is the diagnosis.
+    cardLayoutWidth: card ? card.offsetWidth : null,
     railPointerEvents: rail ? getComputedStyle(rail).pointerEvents : null,
     // Everything needed to say WHY a card came out narrow, reported with the
     // failure instead of being guessed at afterwards from two numbers. A card
@@ -572,13 +578,22 @@ def measure(page, label: str) -> dict:
             reached and not seen["offscreen"],
             f"{name}={seen}",
         )
-    if facts["cardWidth"] is not None:
+    if facts["cardLayoutWidth"] is not None:
         # 448px is the card's max width and 2rem the viewport inset it keeps.
         want = min(448, view["width"] - 32)
+        # Asked of the layout box, not the painted one. A scrollbar that takes
+        # its width out of the rail's content box shrinks the card's layout
+        # width, which is the whole subject here; the card's enter animation
+        # (opacity 0, y 12, scale .96 -- see components/*/update-banner.tsx)
+        # shrinks only the painted one, and measuring that raced the animation
+        # rather than the scrollbar. 448 * 0.96 = 430.08, which is exactly the
+        # 430 this reported on the WebKit leg while its own borderBox read 448
+        # and railGutter read 0.
         check(
             f"{label}: the card keeps its full width whatever the scrollbar does",
-            abs(facts["cardWidth"] - want) <= 1,
-            f"cardWidth={facts['cardWidth']} want={want} "
+            abs(facts["cardLayoutWidth"] - want) <= 1,
+            f"cardLayoutWidth={facts['cardLayoutWidth']} want={want} "
+            f"cardPaintedWidth={facts['cardWidth']} "
             f"railGutter={facts['railGutterPx']} scrolls={facts['railScrolls']} "
             f"why={json.dumps(facts['widthWhy'], sort_keys = True)}",
         )


### PR DESCRIPTION
`Chat UI Tests (banner)` has been red on main since #9132, on the WebKit leg of
"Update banner layout, other engines", at 921x534 on New chat:

    FAIL the card keeps its full width whatever the scrollbar does
         cardWidth=430 want=448 railGutter=0 scrolls=True
    FAIL the rail takes pointer input exactly when it scrolls
         scrolls=True pointerEvents=none

Both assertions are from #8367 and both are right. The second one describes a
state a user can actually be in, and the shard's own screenshot shows it: the
rail is capped, the llama.cpp card is sliced off at the fold, the Unsloth update
card is entirely above it, and the rail is `pointer-events: none`, so there is no
scrollbar and no drag that brings it back. The suite's reachability checks pass
because they call scrollIntoView, which a reader has no way to do.

What #9132 changed is not the product, it is the state the suite finds. The
banner scripts used to run on the machine and the Studio home the chat and extra
shards had already been through; they now get their own runner and a pristine
`~/.unsloth/studio`, since boot-studio-api-only.sh wipes only `auth`. The last
green artifact is dark-themed with "Chat C" and "Chat B" in Recents; the first
red one is default-themed with "No chats yet". Same commit range, different
starting state, so the rail is capped now where it was not before. #9132 is
correct; it exposed this rather than caused it, and the same failure reproduces
on unrelated PR branches.

The defect is that `overflowing` is a prediction. `floorRoom > maxHeight` asks
whether the cards WOULD fit if they collapsed to the floor that was measured for
them under a max-height of 0. When they stop short of that floor the box
overflows a cap the prediction says it fits inside, and the rail is left
click-through while it scrolls, which is the failing pair exactly.

So the reading is kept and the actual state is or-ed into it, taken off the node
in the same synchronous block that already lifts and restores the cap, with the
real cap back on and the layout just flushed. It is re-read on every pass and
never remembered, which is what the derived value was there to protect against:
the observers watch the rail and every descendant, so a placement that grows to
fit clears the flag on the same pass that applied it. Being an `||`, it can only
add the case the prediction misses and can never take pointer input away from a
rail that already had it.

Verified on this box, WebKit and Chromium, against a build actually served from
this tree (`unsloth studio --frontend`; the venv's installed copy is what gets
served otherwise, which is worth knowing before trusting a local Studio run):

  - Broken deliberately, `overflowing` forced false: the full Chromium suite is
    1433 checks, 1 failed, and the one is
    `320x480 at 20px: the rail takes pointer input exactly when it scrolls
     scrolls=True pointerEvents=none`.
  - Fixed: 1433 checks, 0 failed. Firefox and WebKit spot: 221, 0 failed each.
  - Unchanged where the prediction was already right. Sweeping WebKit down the
    height axis at 921 wide, the rail and the flag agree at every step both
    before and after: no scroll and `none` at 534 through 364, scroll and `auto`
    from 360 down, card 448 throughout.

The width half is not fixed here, because I could not reproduce it and will not
guess at it. 448 - 430 is 18px of scrollbar, but `offsetWidth - clientWidth`
reports 0 in the same breath, so on that runner the bar takes width out of the
content box without showing up in the gutter the assertion reads. This box never
reproduces it: WebKit here keeps the card at 448 whether the rail scrolls or not.
`scrollbar-gutter: stable` is the obvious candidate and is deliberately not taken
on a guess, since it reserves the gutter permanently and would shift the cards
left by the scrollbar width on Chromium, where the card is already correct.

Instead both failing assertions now print the measurements that would settle it:
the card's transform and border box, its computed and max width, innerWidth and
documentElement.clientWidth, the rail's offset, client and content widths, its
scroll and client heights, its cap, and the children's heights. Nothing is
relaxed; the same two checks fail on the same conditions, with enough attached to
say which of the two mechanisms it is. That output is what the next run of this
shard is for.