### PR TITLE
Unblock Mac Studio GGUF CI, red on every main run since #8883

### DIFF
--- a/.github/workflows/studio-mac-inference-smoke.yml
+++ b/.github/workflows/studio-mac-inference-smoke.yml
@@ -101,6 +101,30 @@ jobs:
       # something the Actions docs pin down, and a phase silently talking to the
       # previous phase's port would be a nasty way to find out.
       HF_HOME: ${{ github.workspace }}/hf-cache
+      # GitHub's macOS runners expose a PARAVIRTUAL Metal device, and Unsloth refuses to
+      # offload to it because paravirtual Apple GPUs return corrupt output. Every phase
+      # here therefore launches with `--gpu-layers 0 --device none`, which puts the WHOLE
+      # model in host RAM rather than the partial spill the host-offload guard was written
+      # for. #8883 prices that correctly and declines the load:
+      #
+      #   "About 3 GB of this model does not fit in GPU memory and would run from system
+      #    RAM. Only about 4 GB is available and 2 GB of that is kept free for the rest of
+      #    the system, leaving about 2 GB usable."
+      #
+      # The guard is right: the runner cannot host gemma-4-E2B UD-Q4_K_XL (~2.4 GB) plus
+      # mmproj-F16 (~780 MB) in 2 GB. This job ran green for weeks before the guard existed
+      # because the prompts are tiny and the mapping is paged -- which is exactly the
+      # gamble the guard stops taking on a user's machine. Here we take it knowingly. The
+      # alternative is silently swapping the model this phase covers for a smaller one,
+      # which changes what mac vision inference is tested against.
+      #
+      # Job-level, not on the vision phase alone: every phase is CPU-only for the same
+      # reason, so a runner image with a little less free RAM takes out the tool-calling
+      # phase next. Set on the job so each booted server inherits it.
+      #
+      # This removes no coverage of the guard itself, which is tested in
+      # studio/backend/tests/test_host_offload_ram_guard.py and test_llama_cpp_placement.py.
+      UNSLOTH_ALLOW_HOST_OFFLOAD: '1'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:

--- a/.github/workflows/workflow-trigger-lint.yml
+++ b/.github/workflows/workflow-trigger-lint.yml
@@ -118,3 +118,12 @@ jobs:
       # thing that would silently stop running, so it cannot be the one to notice.
       - name: Every Chat UI script still belongs to a shard
         run: python3 -m pytest tests/studio/test_chat_ui_shards_cover_everything.py -q
+
+      # Same reason, and it is the whole point of this one. The guard exists to reject a
+      # PR that removes UNSLOTH_ALLOW_HOST_OFFLOAD from the macOS GGUF job, or adds it to
+      # the Linux or Windows one. Such a PR edits a workflow and nothing else, which
+      # Backend CI's paths filter (studio/**, tests/**, its own YAML) does not match, so
+      # the assertion protecting the guard was never collected for the exact change it
+      # exists to reject.
+      - name: The host-offload opt-out is still macOS-only
+        run: python3 -m pytest tests/studio/test_mac_host_offload_optin.py -q

--- a/tests/studio/test_mac_host_offload_optin.py
+++ b/tests/studio/test_mac_host_offload_optin.py
@@ -76,6 +76,12 @@ def test_the_opt_out_explains_itself_in_place():
 def test_no_other_gguf_workflow_disables_the_guard(name):
     doc = _doc(name)
     offenders = []
+    # Workflow level first. GitHub propagates a top-level `env:` to every job, so it is
+    # the BROADEST way to set this and was the one place a job/step scan could not see:
+    # one line at the top of the Linux or Windows workflow would disable the guard across
+    # every job in it while this test, whose whole subject is blast radius, stayed green.
+    if (doc.get("env") or {}).get(ENV_VAR) is not None:
+        offenders.append("workflow env (applies to every job)")
     for jid, job in (doc.get("jobs") or {}).items():
         if not isinstance(job, dict):
             continue

--- a/tests/studio/test_mac_host_offload_optin.py
+++ b/tests/studio/test_mac_host_offload_optin.py
@@ -52,7 +52,7 @@ def test_the_mac_gguf_job_opts_out_at_job_level():
     """
     jobs = _doc(MAC_GGUF)["jobs"]
     assert len(jobs) == 1, f"expected one bundled job in {MAC_GGUF}, got {list(jobs)}"
-    env = (next(iter(jobs.values())).get("env") or {})
+    env = next(iter(jobs.values())).get("env") or {}
     assert env.get(ENV_VAR) in TRUTHY, (
         f"{MAC_GGUF} no longer sets {ENV_VAR} at job level. Every phase there runs CPU-only "
         f"because the runner's Metal device is paravirtual, so the whole model sits in host "
@@ -99,6 +99,6 @@ def test_the_guard_still_has_its_own_tests():
     ]
     for path in owned:
         assert path.exists(), f"{path.name} is gone; the guard's coverage went with it"
-        assert ENV_VAR in path.read_text(encoding = "utf-8"), (
-            f"{path.name} no longer exercises {ENV_VAR}"
-        )
+        assert ENV_VAR in path.read_text(
+            encoding = "utf-8"
+        ), f"{path.name} no longer exercises {ENV_VAR}"

--- a/tests/studio/test_mac_host_offload_optin.py
+++ b/tests/studio/test_mac_host_offload_optin.py
@@ -1,0 +1,104 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Only the macOS GGUF job opts out of the host-offload guard, and only deliberately.
+
+Mac Studio GGUF CI went red on every main run from ee68d9e2a onwards, the merge of #8883
+("refuse a gguf that cannot fit in free vram plus available ram"). The chain that makes macOS
+special, from the failing run's own server log:
+
+  1. GitHub's macOS runners expose a PARAVIRTUAL Metal device.
+  2. Unsloth refuses to offload to one, because paravirtual Apple GPUs return corrupt output:
+     "Forcing gpu_layers=0 ... this Mac's Metal device is virtualised".
+  3. So the launch is `--gpu-layers 0 --device none` and the WHOLE model is a host mapping,
+     not the partial spill the new guard was written to price.
+  4. The guard then measures honestly and declines: about 3 GB wanted, about 2 GB usable.
+
+The guard is correct -- the runner really cannot hold gemma-4-E2B UD-Q4_K_XL plus mmproj-F16
+in 2 GB, and it had only been getting away with it because the prompts are tiny and the
+mapping is paged. That is precisely the gamble the guard exists to stop taking on a user's
+machine. CI takes it knowingly via UNSLOTH_ALLOW_HOST_OFFLOAD.
+
+What this file protects is the blast radius of that decision. The escape hatch disables a real
+safety net, so it belongs on the one platform whose GPU is fake and nowhere else: if it spread
+to the Linux or Windows GGUF jobs, a genuine regression that made Unsloth try to host-offload
+a model it should have declined would sail through CI green.
+"""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO = Path(__file__).resolve().parents[2]
+WORKFLOWS = REPO / ".github" / "workflows"
+ENV_VAR = "UNSLOTH_ALLOW_HOST_OFFLOAD"
+
+MAC_GGUF = "studio-mac-inference-smoke.yml"
+OTHER_GGUF = ["studio-inference-smoke.yml", "studio-windows-inference-smoke.yml"]
+
+TRUTHY = ("1", 1, "true", "True", "yes")
+
+
+def _doc(name: str) -> dict:
+    return yaml.safe_load((WORKFLOWS / name).read_text(encoding = "utf-8"))
+
+
+def test_the_mac_gguf_job_opts_out_at_job_level():
+    """Job level, so a phase added later inherits it rather than failing mysteriously.
+
+    A phase that misses it does not fail loudly: the load returns HTTP 400 and the test
+    reports an unexpected status, several layers away from the actual cause.
+    """
+    jobs = _doc(MAC_GGUF)["jobs"]
+    assert len(jobs) == 1, f"expected one bundled job in {MAC_GGUF}, got {list(jobs)}"
+    env = (next(iter(jobs.values())).get("env") or {})
+    assert env.get(ENV_VAR) in TRUTHY, (
+        f"{MAC_GGUF} no longer sets {ENV_VAR} at job level. Every phase there runs CPU-only "
+        f"because the runner's Metal device is paravirtual, so the whole model sits in host "
+        f"RAM and the #8883 guard declines the load with HTTP 400."
+    )
+
+
+def test_the_opt_out_explains_itself_in_place():
+    """A bare env var here reads like a workaround someone can tidy away."""
+    src = (WORKFLOWS / MAC_GGUF).read_text(encoding = "utf-8")
+    head = src[: src.index(ENV_VAR)]
+    comment = head[head.rindex("\n      HF_HOME") :] if "\n      HF_HOME" in head else head
+    for phrase in ("paravirtual", "8883"):
+        assert phrase.lower() in comment.lower(), (
+            f"the {ENV_VAR} block no longer explains {phrase!r}; without the reason the next "
+            f"person removes it and Mac GGUF CI goes red again"
+        )
+
+
+@pytest.mark.parametrize("name", OTHER_GGUF)
+def test_no_other_gguf_workflow_disables_the_guard(name):
+    doc = _doc(name)
+    offenders = []
+    for jid, job in (doc.get("jobs") or {}).items():
+        if not isinstance(job, dict):
+            continue
+        if (job.get("env") or {}).get(ENV_VAR) is not None:
+            offenders.append(f"{jid} (job env)")
+        for step in job.get("steps") or []:
+            if (step.get("env") or {}).get(ENV_VAR) is not None:
+                offenders.append(f"{jid}: {step.get('name')}")
+    assert not offenders, (
+        f"{name} disables the host-offload guard in {offenders}. Those runners have real "
+        f"memory and a real device; silencing the guard there means a regression that "
+        f"host-offloads a model it should decline would pass CI green."
+    )
+
+
+def test_the_guard_still_has_its_own_tests():
+    """The mac opt-out must not be mistaken for the guard being untested."""
+    owned = [
+        REPO / "studio" / "backend" / "tests" / "test_host_offload_ram_guard.py",
+        REPO / "studio" / "backend" / "tests" / "test_llama_cpp_placement.py",
+    ]
+    for path in owned:
+        assert path.exists(), f"{path.name} is gone; the guard's coverage went with it"
+        assert ENV_VAR in path.read_text(encoding = "utf-8"), (
+            f"{path.name} no longer exercises {ENV_VAR}"
+        )


### PR DESCRIPTION
Mac Studio GGUF CI has failed on every main run from ee68d9e2a onward, the merge
of #8883 (refuse a gguf that cannot fit in free vram plus available ram). Bisected
over 90 completed main runs: green through 31c42e872, red from ee68d9e2a, no
recovery since.

The guard is not wrong. From the failing run's own server log:

  Metal device looks virtualised (Apple Paravirtual device) ... GGUF inference
  will run on CPU
  Forcing gpu_layers=0 for gemma-4-E2B-it-UD-Q4_K_XL.gguf
  Error loading model: About 3 GB of this model does not fit in GPU memory and
  would run from system RAM. Only about 4 GB is available and 2 GB of that is
  kept free for the rest of the system, leaving about 2 GB usable.

GitHub's macOS runners expose a paravirtual Metal device, and Unsloth already
refuses to offload to one because paravirtual Apple GPUs return corrupt output.
So the launch is --gpu-layers 0 --device none and the WHOLE model is a host
mapping, not the partial spill the guard was written to price. It then measures
honestly: gemma-4-E2B UD-Q4_K_XL (~2.4 GB) plus mmproj-F16 (~780 MB) does not fit
in 2 GB usable. The load returns HTTP 400 and the phase fails several layers away
from the cause.

The workflow is what was wrong. It had been getting away with a model the runner
cannot hold because the prompts are tiny and the mapping is paged, which is
exactly the gamble the guard stops taking on a user's machine. CI now takes it
knowingly with UNSLOTH_ALLOW_HOST_OFFLOAD, the escape hatch the refusal names,
rather than silently swapping in a smaller model and quietly changing what mac
vision inference is tested against.

Set at job level, not on the vision phase: every phase there is CPU-only for the
same reason, so a runner image with slightly less free RAM would take out the
tool-calling phase next.

tests/studio/test_mac_host_offload_optin.py keeps the blast radius honest. The
opt-out disables a real safety net, so it asserts the reason stays written down
next to it, that the Linux and Windows GGUF workflows never acquire it -- there a
silenced guard would let a genuine host-offload regression pass green -- and that
the guard keeps its own unit tests.