### PR TITLE
Open the connection form when Settings > Connections has nothing to list

### DIFF
--- a/studio/frontend/src/features/chat/chat-providers-dialog.tsx
+++ b/studio/frontend/src/features/chat/chat-providers-dialog.tsx
@@ -159,6 +159,7 @@ export function ChatProvidersSettings({
 }: ChatProvidersSettingsProps) {
   const providersRef = useRef(providers);
   const seededProviderTypeRef = useRef<string | null>(null);
+  const autoOpenedAddFormRef = useRef(false);
   const [page, setPage] = useState<"list" | "form">("list");
   const [providerType, setProviderType] = useState<string>("");
   const [apiKey, setApiKey] = useState("");
@@ -350,7 +351,8 @@ export function ChatProvidersSettings({
         syncSucceeded = true;
         // Hidden entries are fetched for their capabilities only; the dropdown
         // surfaces them through CUSTOM_PROVIDER_PRESETS instead.
-        setRegistry(registryRows.filter((entry) => !entry.hidden));
+        const selectableRegistry = registryRows.filter((entry) => !entry.hidden);
+        setRegistry(selectableRegistry);
         setProviderType((current) => {
           if (
             current &&
@@ -365,6 +367,16 @@ export function ChatProvidersSettings({
         // removed (often from another tab); mirror that locally, else stale
         // entries become un-removable here until localStorage is cleared.
         onProvidersChange(syncedProviders);
+        // An empty list never says what this page is for, so open the form
+        // instead. Reads the synced response, not the local snapshot, so a
+        // stale empty list cannot flash the form at an existing user. Once
+        // only, else the focus re-sync would pull the user back here.
+        if (!autoOpenedAddFormRef.current) {
+          autoOpenedAddFormRef.current = true;
+          if (syncedProviders.length === 0 && selectableRegistry.length > 0) {
+            setPage("form");
+          }
+        }
       } catch (error) {
         // Only surface a toast for real failures, not for the silent
         // background re-sync on tab focus.

--- a/studio/frontend/src/features/chat/chat-providers-dialog.tsx
+++ b/studio/frontend/src/features/chat/chat-providers-dialog.tsx
@@ -159,6 +159,8 @@ export function ChatProvidersSettings({
 }: ChatProvidersSettingsProps) {
   const providersRef = useRef(providers);
   const seededProviderTypeRef = useRef<string | null>(null);
+  // Latches the one-shot auto-open below. Every navigation the user drives sets
+  // it too, so a slow first sync cannot pull them back into the form.
   const autoOpenedAddFormRef = useRef(false);
   const [page, setPage] = useState<"list" | "form">("list");
   const [providerType, setProviderType] = useState<string>("");
@@ -437,11 +439,13 @@ export function ChatProvidersSettings({
     if (entry?.model_list_mode === "curated") {
       setAvailableModels([...entry.default_models]);
     }
+    autoOpenedAddFormRef.current = true;
     setPage("form");
   }
 
   function closeForm() {
     resetForm();
+    autoOpenedAddFormRef.current = true;
     setPage("list");
   }
 
@@ -778,6 +782,7 @@ export function ChatProvidersSettings({
         provider,
       ]);
       resetForm();
+      autoOpenedAddFormRef.current = true;
       setPage("list");
       toast.success("Connection added.");
     } catch (error) {
@@ -927,6 +932,7 @@ export function ChatProvidersSettings({
       );
       toast.success("Connection updated.");
       resetForm();
+      autoOpenedAddFormRef.current = true;
       setPage("list");
     } catch (error) {
       const message = error instanceof Error ? error.message : "Unknown error";
@@ -938,6 +944,7 @@ export function ChatProvidersSettings({
 
   async function editProvider(provider: ExternalProviderConfig) {
     setEditingProviderId(provider.id);
+    autoOpenedAddFormRef.current = true;
     setPage("form");
     setProviderType(provider.providerType);
     setCustomProviderName(

--- a/studio/frontend/tests/connections-empty-opens-form.test.ts
+++ b/studio/frontend/tests/connections-empty-opens-form.test.ts
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// Settings > Connections used to open onto an empty list that never said what
+// the page was for. It now opens the form when the first sync comes back with
+// no connections. These pin the parts that make it land where a user expects.
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const dialog = readFileSync(
+  new URL("../src/features/chat/chat-providers-dialog.tsx", import.meta.url),
+  "utf8",
+);
+
+test("an empty connection list opens the add-connection form", () => {
+  // Both operands matter: `syncedProviders` is the backend answer, and
+  // `selectableRegistry` stops a form with an empty dropdown from opening.
+  assert.match(
+    dialog,
+    /if \(syncedProviders\.length === 0 && selectableRegistry\.length > 0\) \{\s*(?:\/\/[^\n]*\n\s*)*setPage\("form"\);/,
+  );
+  assert.match(
+    dialog,
+    /const selectableRegistry = registryRows\.filter\(\(entry\) => !entry\.hidden\);\s*setRegistry\(selectableRegistry\);/,
+  );
+
+  // Reading `providers` would decide against the previous render's props.
+  assert.doesNotMatch(
+    dialog,
+    /if \(providers\.length === 0 &&[^\n]*\)\s*\{\s*(?:\/\/[^\n]*\n\s*)*setPage\("form"\);/,
+  );
+});
+
+test("the add-connection form only opens itself once", () => {
+  // Without the latch, the focus re-sync would pull the user back to the form.
+  assert.match(
+    dialog,
+    /if \(!autoOpenedAddFormRef\.current\) \{\s*autoOpenedAddFormRef\.current = true;/,
+  );
+  assert.match(dialog, /const autoOpenedAddFormRef = useRef\(false\);/);
+
+  // Resetting it would make the latch per render instead of per visit.
+  assert.doesNotMatch(dialog, /autoOpenedAddFormRef\.current = false;/);
+});
+
+test("the form's back arrow still returns to the list", () => {
+  // A starting point, not a trap: the way back and its copy both stay.
+  assert.match(
+    dialog,
+    /function closeForm\(\) \{\s*resetForm\(\);\s*setPage\("list"\);/,
+  );
+  assert.match(dialog, /No connections yet/);
+});

--- a/studio/frontend/tests/connections-empty-opens-form.test.ts
+++ b/studio/frontend/tests/connections-empty-opens-form.test.ts
@@ -49,7 +49,22 @@ test("the form's back arrow still returns to the list", () => {
   // A starting point, not a trap: the way back and its copy both stay.
   assert.match(
     dialog,
-    /function closeForm\(\) \{\s*resetForm\(\);\s*setPage\("list"\);/,
+    /function closeForm\(\) \{\s*resetForm\(\);\s*autoOpenedAddFormRef\.current = true;\s*setPage\("list"\);/,
   );
   assert.match(dialog, /No connections yet/);
+});
+
+test("navigating before the sync lands consumes the auto-open", () => {
+  // The Add connection row stays live while the first sync runs, so a user can
+  // open the form and go back before it lands. Every path that moves the page
+  // latches the one-shot, or the sync would drag them back into the form.
+  const calls = [...dialog.matchAll(/setPage\("(?:list|form)"\)/g)];
+  assert.equal(calls.length, 6);
+  for (const call of calls) {
+    const before = dialog.slice(
+      Math.max(0, (call.index ?? 0) - 200),
+      call.index,
+    );
+    assert.match(before, /autoOpenedAddFormRef\.current = true;/);
+  }
 });


### PR DESCRIPTION
### Problem

On a fresh install, Settings > Connections opens onto a list with a single "No connections yet" row. Nothing on that screen explains what a connection is, which providers are supported, or that the small "Add connection" row at the top is the way in. The one state where the page has to teach the most is the state where it shows the least.

### Change

When the first sync returns no connections, the page opens the "New connection" form instead of the empty list. The provider dropdown, the models panel, and the explanation of which Studio tools run locally are all right there.

Three things keep it from getting in the way:

* The decision reads the synced backend response, not the local snapshot, so a stale empty list cannot flash the form at someone who already has connections.
* It waits for a loaded provider registry, so the form never opens with an empty dropdown when only that request failed. Hidden registry entries are excluded, since those are never offered in the dropdown.
* It fires once per visit. The back arrow, saving a connection, and deleting the last connection all leave the user where they navigated to, and the empty list is still there for anyone who backs out.

### Testing

* `studio/frontend/tests/connections-empty-opens-form.test.ts` covers the three points above: the check reads `syncedProviders` and the selectable registry, the latch is a ref that is never reset, and `closeForm` still returns to the list.
* Full frontend suite passes, 3681 tests.
* `tsc -b` clean, `eslint` unchanged from baseline on the touched file, and `vite build` succeeds.