### PR TITLE
Drop the Exa preset from the MCP menu

### DIFF
--- a/studio/frontend/src/features/chat/mcp-composer-button.tsx
+++ b/studio/frontend/src/features/chat/mcp-composer-button.tsx
@@ -72,14 +72,6 @@ const MCP_PRESETS: readonly McpPreset[] = [
     label: "Context7 (Realtime Docs)",
   },
   {
-    id: "exa",
-    displayName: "Exa",
-    url: "https://mcp.exa.ai/mcp",
-    label: "Exa (Semantic Search)",
-    hint: "Enabling Exa will disable default search",
-    disablesWebSearch: true,
-  },
-  {
     id: "huggingface",
     displayName: "Hugging Face",
     url: "https://huggingface.co/mcp",
@@ -169,7 +161,7 @@ export function McpComposerButton({
           });
         }
         setMcpEnabledForChat(true);
-        // Exa is a search server; turn off the built-in Web Search to avoid overlap.
+        // Search servers turn off the built-in Web Search to avoid overlap.
         if (args.disablesWebSearch) setToolsEnabled(false);
       } else if (args.existing) {
         await updateMcpServer(args.existing.id, { isEnabled: false });


### PR DESCRIPTION
### Change

Removes Exa from the keyless MCP presets in the composer menu. Unsloth Docs, Context7 and Hugging Face stay.

The `disablesWebSearch` plumbing stays too. It is a preset capability rather than an Exa one, so the only Exa-specific thing left was the comment naming it, which is now generic. Nothing uses the flag today, so say the word if you would rather it went as well.

### Testing

* Full frontend suite passes, 3678 tests.
* `tsc -b` clean, `eslint` unchanged from baseline on the touched file, and `vite build` succeeds.