### PR TITLE
Save the pip cache on main only, via a restore/save action pair

### DIFF
--- a/.github/actions/pip-cache-restore/action.yml
+++ b/.github/actions/pip-cache-restore/action.yml
@@ -1,0 +1,83 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+
+# Restore half of the pip cache, replacing `actions/setup-python`'s built-in
+# `cache: 'pip'`.
+#
+# The built-in cache is read-write and saves from its own post-step on WHATEVER
+# REF the job ran on. A cache written on a pull_request ref can only be restored
+# by re-runs of that same pull request ("caches created on the base branch are
+# available to the topic branch, but not the other way round"), so every PR
+# writes a ~700MB copy that nobody else can ever read, and that copy competes for
+# the shared 50 GiB budget against main's copy, which every PR CAN read. Measured
+# on this repo: setup-python entries were 19.45 GiB across 40 entries, 15.49 GiB
+# of it on PR refs, with four interpreter keys duplicated 4-6 times each.
+#
+# Nothing about that is visible as a failure. Over quota, GitHub evicts
+# least-recently-used, so main's copy goes, the next PR misses, downloads, and
+# writes its own copy. CI just gets slower and everyone assumes that is the cost.
+# The repo had already diagnosed and fixed this exact loop for the GGUF caches
+# (see the save step in studio-inference-smoke.yml) and for the Playwright
+# browsers; setup-python was left doing it because its built-in cache has no
+# save-gating knob. Splitting restore from save is how you get one.
+#
+# Pair this with pip-cache-save AFTER the install, passing the outputs below.
+
+name: Restore the pip cache
+description: >-
+  Restore pip's HTTP cache for this runner and interpreter, keyed on the files
+  the job actually installs from. Read-only: the save is a separate action and
+  runs on the default branch only.
+
+inputs:
+  key-files:
+    description: >-
+      Newline-separated glob(s) whose hash keys the cache. Pass the files this
+      job installs from, NOT a repo-wide pattern: the built-in cache hashed
+      dependency files across the whole repo, so an unrelated requirements edit
+      invalidated every interpreter's entry at once and orphaned the old ones.
+      Paths resolve from the workspace root, so a job that checks out into a
+      subdirectory must include it.
+    required: true
+
+outputs:
+  dir:
+    description: pip's cache directory on this runner.
+    value: ${{ steps.probe.outputs.dir }}
+  key:
+    description: The full cache key, to hand to pip-cache-save.
+    value: ${{ steps.probe.outputs.key }}
+  cache-hit:
+    description: 'true when the exact key was restored.'
+    value: ${{ steps.restore.outputs.cache-hit }}
+
+runs:
+  using: composite
+  steps:
+    # `pip cache dir` rather than a hardcoded path per OS: it differs on Linux,
+    # macOS and Windows, and pip itself is the authority on where it put things.
+    - name: Resolve the pip cache directory and key
+      id: probe
+      shell: bash
+      run: |
+        set -euo pipefail
+        dir="$(python -m pip cache dir)"
+        echo "dir=$dir" >> "$GITHUB_OUTPUT"
+        pyver="$(python -c 'import sys; print("%d.%d.%d" % sys.version_info[:3])')"
+        hash="${{ hashFiles(inputs.key-files) }}"
+        # Empty means the globs matched nothing, which would silently collapse
+        # every job onto one key. Loud here, where the cause is one line away.
+        if [ -z "$hash" ]; then
+          echo "::error::pip-cache: key-files matched no file, so the cache key would not distinguish anything. Given: ${{ inputs.key-files }}"
+          exit 1
+        fi
+        echo "key=pip-${{ runner.os }}-${{ runner.arch }}-py${pyver}-${hash}" >> "$GITHUB_OUTPUT"
+
+    - name: Restore the pip cache
+      id: restore
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+      # A cache is an optimisation; a cache service blip must not fail the job.
+      continue-on-error: true
+      with:
+        path: ${{ steps.probe.outputs.dir }}
+        key: ${{ steps.probe.outputs.key }}

--- a/.github/actions/pip-cache-save/action.yml
+++ b/.github/actions/pip-cache-save/action.yml
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+
+# Save half of the pip cache. See pip-cache-restore for why this is split out.
+#
+# Runs on the default branch ONLY. That is the whole point: an entry written on a
+# pull_request ref is restorable only by re-runs of that same PR, so it buys no
+# hit rate and evicts the copy on main that every PR can read.
+
+name: Save the pip cache
+description: Save pip's cache under the restore step's key, on the default branch only.
+
+inputs:
+  dir:
+    description: pip's cache directory, from pip-cache-restore's `dir` output.
+    required: true
+  key:
+    description: The cache key, from pip-cache-restore's `key` output.
+    required: true
+  cache-hit:
+    description: >-
+      pip-cache-restore's `cache-hit`. Skipped when it is 'true', because the key
+      is already present and re-uploading it would be pure cost.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Save the pip cache
+      # always(), so a cache earned by a successful install is not thrown away
+      # because a LATER step in the job failed. The install itself is what fills
+      # this directory, and a failed test does not make its downloads wrong.
+      if: >-
+        always() && github.ref == 'refs/heads/main'
+        && inputs.cache-hit != 'true'
+      uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+      continue-on-error: true
+      with:
+        path: ${{ inputs.dir }}
+        key: ${{ inputs.key }}

--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -138,14 +138,12 @@ jobs:
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: '3.12'
-          cache: 'pip'
-          # Without this, setup-python's default glob resolves to the repo's only
-          # requirements.txt, unsloth/kernels/moe/requirements.txt: five lines that have
-          # nothing to do with what this job installs. Every job in the repo therefore
-          # shared one cache slot keyed on an unrelated file, so a "hit" restored a few MB
-          # and the install still downloaded the whole tree. Key on what this job actually
-          # reads instead.
-          cache-dependency-path: |
+
+      - name: Restore the pip cache
+        id: pip-cache
+        uses: ./.github/actions/pip-cache-restore
+        with:
+          key-files: |
             pyproject.toml
             studio/backend/requirements/*.txt
 
@@ -2271,6 +2269,14 @@ jobs:
           echo "  - unsloth_zoo @ ${UNSLOTH_ZOO_REF} pytest tests/ (5 GPU cases deselected)"
           echo "  - unsloth_zoo.compiler.test_apply_fused_lm_head"
 
+      - name: Save the pip cache
+        if: always()
+        uses: ./.github/actions/pip-cache-save
+        with:
+          dir: ${{ steps.pip-cache.outputs.dir }}
+          key: ${{ steps.pip-cache.outputs.key }}
+          cache-hit: ${{ steps.pip-cache.outputs.cache-hit }}
+
   llama-cpp-smoke:
     # Standalone llama.cpp build + smoke. Earlier this lived inside every
     # consolidated matrix cell and re-cmake'd llama.cpp ~5 min per cell --
@@ -2300,14 +2306,12 @@ jobs:
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: '3.12'
-          cache: 'pip'
-          # Without this, setup-python's default glob resolves to the repo's only
-          # requirements.txt, unsloth/kernels/moe/requirements.txt: five lines that have
-          # nothing to do with what this job installs. Every job in the repo therefore
-          # shared one cache slot keyed on an unrelated file, so a "hit" restored a few MB
-          # and the install still downloaded the whole tree. Key on what this job actually
-          # reads instead.
-          cache-dependency-path: |
+
+      - name: Restore the pip cache
+        id: pip-cache
+        uses: ./.github/actions/pip-cache-restore
+        with:
+          key-files: |
             pyproject.toml
             studio/backend/requirements/*.txt
 
@@ -2505,3 +2509,12 @@ jobs:
               f"and llama-quantize at {quantizer}."
           )
           PY
+
+      - name: Save the pip cache
+        if: always()
+        uses: ./.github/actions/pip-cache-save
+        with:
+          dir: ${{ steps.pip-cache.outputs.dir }}
+          key: ${{ steps.pip-cache.outputs.key }}
+          cache-hit: ${{ steps.pip-cache.outputs.cache-hit }}
+

--- a/.github/workflows/mlx-ci.yml
+++ b/.github/workflows/mlx-ci.yml
@@ -158,11 +158,12 @@ jobs:
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: '3.12'
-          cache: 'pip'
-          # Scope the key to the files this job installs from. Unscoped,
-          # setup-python hashes dependency files repo-wide, so one edit anywhere
-          # invalidates ~700MB x 4 interpreters and orphans the old entries.
-          cache-dependency-path: |
+
+      - name: Restore the pip cache
+        id: pip-cache
+        uses: ./.github/actions/pip-cache-restore
+        with:
+          key-files: |
             pyproject.toml
             studio/backend/requirements/*.txt
 
@@ -540,3 +541,12 @@ jobs:
             exit 1
           fi
           echo "OK: Unsloth prebuilt llama.cpp on Mac M1 + GGUF /completion works"
+
+      - name: Save the pip cache
+        if: always()
+        uses: ./.github/actions/pip-cache-save
+        with:
+          dir: ${{ steps.pip-cache.outputs.dir }}
+          key: ${{ steps.pip-cache.outputs.key }}
+          cache-hit: ${{ steps.pip-cache.outputs.cache-hit }}
+

--- a/.github/workflows/notebooks-ci.yml
+++ b/.github/workflows/notebooks-ci.yml
@@ -285,12 +285,12 @@ jobs:
         # repo-wide, so one unrelated edit invalidates ~700MB per interpreter.
         with:
           python-version: '3.12'
-          cache: 'pip'
-          # Nested: this job checks the repo out under `unsloth/`, so the workflow
-          # file is at unsloth/.github/... . setup-python FAILS the job outright
-          # when cache-dependency-path matches nothing ("No file in ... matched"),
-          # rather than skipping the cache.
-          cache-dependency-path: |
+
+      - name: Restore the pip cache
+        id: pip-cache
+        uses: ./.github/actions/pip-cache-restore
+        with:
+          key-files: |
             unsloth/.github/workflows/notebooks-ci.yml
 
       - name: Install CPU torch + pinned unsloth + trl + converter deps
@@ -364,6 +364,14 @@ jobs:
           python unsloth/scripts/notebook_validator.py api \
               --converted-dir _converted \
               --surface _api_surface.json
+
+      - name: Save the pip cache
+        if: always()
+        uses: ./.github/actions/pip-cache-save
+        with:
+          dir: ${{ steps.pip-cache.outputs.dir }}
+          key: ${{ steps.pip-cache.outputs.key }}
+          cache-hit: ${{ steps.pip-cache.outputs.cache-hit }}
 
   smoke-install:
     name: smoke install (Colab-shaped venv, opt-in)

--- a/.github/workflows/notebooks-ci.yml
+++ b/.github/workflows/notebooks-ci.yml
@@ -288,7 +288,10 @@ jobs:
 
       - name: Restore the pip cache
         id: pip-cache
-        uses: ./.github/actions/pip-cache-restore
+        # ./ resolves from GITHUB_WORKSPACE, and this job checks the repo out
+        # under `unsloth/`, so the unprefixed path is a directory that does not
+        # exist and the step fails with "Can't find 'action.yml'".
+        uses: ./unsloth/.github/actions/pip-cache-restore
         with:
           key-files: |
             unsloth/.github/workflows/notebooks-ci.yml
@@ -367,7 +370,10 @@ jobs:
 
       - name: Save the pip cache
         if: always()
-        uses: ./.github/actions/pip-cache-save
+        # ./ resolves from GITHUB_WORKSPACE, and this job checks the repo out
+        # under `unsloth/`, so the unprefixed path is a directory that does not
+        # exist and the step fails with "Can't find 'action.yml'".
+        uses: ./unsloth/.github/actions/pip-cache-save
         with:
           dir: ${{ steps.pip-cache.outputs.dir }}
           key: ${{ steps.pip-cache.outputs.key }}

--- a/.github/workflows/studio-backend-ci.yml
+++ b/.github/workflows/studio-backend-ci.yml
@@ -146,8 +146,12 @@ jobs:
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: '${{ matrix.python }}'
-          cache: 'pip'
-          cache-dependency-path: |
+
+      - name: Restore the pip cache
+        id: pip-cache
+        uses: ./.github/actions/pip-cache-restore
+        with:
+          key-files: |
             pyproject.toml
             studio/backend/requirements/*.txt
 
@@ -291,6 +295,14 @@ jobs:
             tests/test_recommended_folders_permission.py \
             tests/test_hf_cache_settings.py
 
+      - name: Save the pip cache
+        if: always()
+        uses: ./.github/actions/pip-cache-save
+        with:
+          dir: ${{ steps.pip-cache.outputs.dir }}
+          key: ${{ steps.pip-cache.outputs.key }}
+          cache-hit: ${{ steps.pip-cache.outputs.cache-hit }}
+
   repo-cpu-tests:
     # Auto-discover everything under tests/ that is not GPU-bound by
     # design. New tests added in covered directories are picked up
@@ -311,8 +323,12 @@ jobs:
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: '3.12'
-          cache: 'pip'
-          cache-dependency-path: |
+
+      - name: Restore the pip cache
+        id: pip-cache
+        uses: ./.github/actions/pip-cache-restore
+        with:
+          key-files: |
             pyproject.toml
             studio/backend/requirements/*.txt
 
@@ -476,4 +492,12 @@ jobs:
           done
           [ "$found" -gt 0 ] || { echo "::error::no shell tests discovered under tests/sh"; exit 1; }
           echo "ran $found shell installer test files"
+
+      - name: Save the pip cache
+        if: always()
+        uses: ./.github/actions/pip-cache-save
+        with:
+          dir: ${{ steps.pip-cache.outputs.dir }}
+          key: ${{ steps.pip-cache.outputs.key }}
+          cache-hit: ${{ steps.pip-cache.outputs.cache-hit }}
 

--- a/.github/workflows/studio-export-capability-ci.yml
+++ b/.github/workflows/studio-export-capability-ci.yml
@@ -66,9 +66,14 @@ jobs:
         # repo-wide, so one unrelated edit invalidates ~700MB per interpreter.
         with:
           python-version: '3.12'
-          cache: 'pip'
-          cache-dependency-path: |
+
+      - name: Restore the pip cache
+        id: pip-cache
+        uses: ./.github/actions/pip-cache-restore
+        with:
+          key-files: |
             .github/workflows/studio-export-capability-ci.yml
+
       - name: Upgrade pip
         run: python -m pip install --upgrade pip
       - name: Install CPU PyTorch
@@ -85,3 +90,12 @@ jobs:
       - name: Export capability + import-safety tests
         working-directory: studio/backend
         run: python -m pytest tests/test_export_capability.py -q
+
+      - name: Save the pip cache
+        if: always()
+        uses: ./.github/actions/pip-cache-save
+        with:
+          dir: ${{ steps.pip-cache.outputs.dir }}
+          key: ${{ steps.pip-cache.outputs.key }}
+          cache-hit: ${{ steps.pip-cache.outputs.cache-hit }}
+

--- a/.github/workflows/version-compat-ci.yml
+++ b/.github/workflows/version-compat-ci.yml
@@ -243,13 +243,14 @@ jobs:
         # repo-wide, so one unrelated edit invalidates ~700MB per interpreter.
         with:
           python-version: '3.12'
-          cache: 'pip'
-          # Nested: this job checks the repo out under `unsloth/`, so the workflow
-          # file is at unsloth/.github/... . setup-python FAILS the job outright
-          # when cache-dependency-path matches nothing ("No file in ... matched"),
-          # rather than skipping the cache.
-          cache-dependency-path: |
+
+      - name: Restore the pip cache
+        id: pip-cache
+        uses: ./.github/actions/pip-cache-restore
+        with:
+          key-files: |
             unsloth/.github/workflows/version-compat-ci.yml
+
       - name: Install CPU torch + supported pkg pins
         run: |
           python -m pip install --upgrade pip
@@ -297,6 +298,14 @@ jobs:
             tests/vllm_compat/test_extended_module_imports.py \
             -v --tb=short
 
+      - name: Save the pip cache
+        if: always()
+        uses: ./.github/actions/pip-cache-save
+        with:
+          dir: ${{ steps.pip-cache.outputs.dir }}
+          key: ${{ steps.pip-cache.outputs.key }}
+          cache-hit: ${{ steps.pip-cache.outputs.cache-hit }}
+
   # Fake-CUDA GRPO/SFT/DPO patch run against REAL TRL (latest + main). Unlike
   # the static symbol/source greps above, this drives unsloth's actual
   # source-transform patchers (models/rl.py + rl_replacements.py) on a CPU-only
@@ -336,13 +345,14 @@ jobs:
         # repo-wide, so one unrelated edit invalidates ~700MB per interpreter.
         with:
           python-version: '3.12'
-          cache: 'pip'
-          # Nested: this job checks the repo out under `unsloth/`, so the workflow
-          # file is at unsloth/.github/... . setup-python FAILS the job outright
-          # when cache-dependency-path matches nothing ("No file in ... matched"),
-          # rather than skipping the cache.
-          cache-dependency-path: |
+
+      - name: Restore the pip cache
+        id: pip-cache
+        uses: ./.github/actions/pip-cache-restore
+        with:
+          key-files: |
             unsloth/.github/workflows/version-compat-ci.yml
+
       - name: Install CPU torch + ecosystem + TRL latest
         run: |
           python -m pip install --upgrade pip
@@ -396,6 +406,14 @@ jobs:
             tests/version_compat/test_trl_padding_free_max_length.py \
             tests/version_compat/test_trl_loss_normalization_contract.py \
             -v --tb=short
+
+      - name: Save the pip cache
+        if: always()
+        uses: ./.github/actions/pip-cache-save
+        with:
+          dir: ${{ steps.pip-cache.outputs.dir }}
+          key: ${{ steps.pip-cache.outputs.key }}
+          cache-hit: ${{ steps.pip-cache.outputs.cache-hit }}
 
   # Daily-only: same suites but with --strict on importable upstream
   # tags. Schedule-only so PR jobs stay fast; cron tolerates a flake.

--- a/.github/workflows/version-compat-ci.yml
+++ b/.github/workflows/version-compat-ci.yml
@@ -246,7 +246,10 @@ jobs:
 
       - name: Restore the pip cache
         id: pip-cache
-        uses: ./.github/actions/pip-cache-restore
+        # ./ resolves from GITHUB_WORKSPACE, and this job checks the repo out
+        # under `unsloth/`, so the unprefixed path is a directory that does not
+        # exist and the step fails with "Can't find 'action.yml'".
+        uses: ./unsloth/.github/actions/pip-cache-restore
         with:
           key-files: |
             unsloth/.github/workflows/version-compat-ci.yml
@@ -300,7 +303,10 @@ jobs:
 
       - name: Save the pip cache
         if: always()
-        uses: ./.github/actions/pip-cache-save
+        # ./ resolves from GITHUB_WORKSPACE, and this job checks the repo out
+        # under `unsloth/`, so the unprefixed path is a directory that does not
+        # exist and the step fails with "Can't find 'action.yml'".
+        uses: ./unsloth/.github/actions/pip-cache-save
         with:
           dir: ${{ steps.pip-cache.outputs.dir }}
           key: ${{ steps.pip-cache.outputs.key }}
@@ -348,7 +354,10 @@ jobs:
 
       - name: Restore the pip cache
         id: pip-cache
-        uses: ./.github/actions/pip-cache-restore
+        # ./ resolves from GITHUB_WORKSPACE, and this job checks the repo out
+        # under `unsloth/`, so the unprefixed path is a directory that does not
+        # exist and the step fails with "Can't find 'action.yml'".
+        uses: ./unsloth/.github/actions/pip-cache-restore
         with:
           key-files: |
             unsloth/.github/workflows/version-compat-ci.yml
@@ -409,7 +418,10 @@ jobs:
 
       - name: Save the pip cache
         if: always()
-        uses: ./.github/actions/pip-cache-save
+        # ./ resolves from GITHUB_WORKSPACE, and this job checks the repo out
+        # under `unsloth/`, so the unprefixed path is a directory that does not
+        # exist and the step fails with "Can't find 'action.yml'".
+        uses: ./unsloth/.github/actions/pip-cache-save
         with:
           dir: ${{ steps.pip-cache.outputs.dir }}
           key: ${{ steps.pip-cache.outputs.key }}

--- a/tests/studio/test_cache_budget_discipline.py
+++ b/tests/studio/test_cache_budget_discipline.py
@@ -174,6 +174,7 @@ def test_the_main_only_expression_check_reads_the_expression(expr, restricted):
     """The guard below is only as good as this predicate, so the predicate is tested too."""
     assert _restricted_to_main(expr) is restricted, expr
 
+
 def _composite_actions():
     """(name, steps) for every composite action in the repo.
 
@@ -291,8 +292,7 @@ def test_every_pip_cache_user_actually_installs_something_heavy():
         if not HEAVY.search(body):
             thin.append(f"{name}:{jid}")
     assert not thin, (
-        f"these jobs hold a pip cache but no longer install anything that justifies it: "
-        f"{thin}"
+        f"these jobs hold a pip cache but no longer install anything that justifies it: " f"{thin}"
     )
 
 

--- a/tests/studio/test_cache_budget_discipline.py
+++ b/tests/studio/test_cache_budget_discipline.py
@@ -242,6 +242,60 @@ def test_no_job_uses_setup_pythons_built_in_pip_cache():
     )
 
 
+def _pip_cache_users():
+    """Every job that touches either half of the pip-cache action pair, discovered."""
+    return {
+        (name, jid)
+        for name, jid, job in _jobs()
+        for step in job.get("steps") or []
+        if "pip-cache-restore" in str(step.get("uses", ""))
+        or "pip-cache-save" in str(step.get("uses", ""))
+    }
+
+
+def test_only_the_allowlisted_jobs_use_the_pip_cache_actions():
+    """The allowlist has to be enforced against what the workflows DO, not iterated over.
+
+    Every other check in this file is parametrized over PIP_CACHE_JOBS, which means a new
+    job that adds the restore/save pair is simply never visited: it gets a ~700MB entry
+    with no scoping check, no wiring check and no justification, and this file stays green.
+
+    That hole opened when the built-in `cache: 'pip'` went away. The previous guard
+    discovered claimants by scanning for setup-python's `cache:` key, so replacing that
+    mechanism removed the discovery along with it, leaving nine hardcoded names and nothing
+    watching for a tenth.
+    """
+    extra = _pip_cache_users() - PIP_CACHE_JOBS
+    assert not extra, (
+        f"these jobs use the pip cache without being listed in PIP_CACHE_JOBS: "
+        f"{sorted(extra)}. Every entry competes for the shared 50 GiB budget, so a job "
+        f"earns one by installing a torch/transformers-class dependency set where the "
+        f"download dominates. Add it to the allowlist with that justification, or drop the "
+        f"cache."
+    )
+
+
+def test_every_pip_cache_user_actually_installs_something_heavy():
+    """The allowlist records a judgement; this checks the judgement still matches the job.
+
+    A job whose heavy install is later moved elsewhere keeps its cache entry, and nothing
+    else in this file would notice: the name stays in the list and every parametrized check
+    still passes.
+    """
+    thin = []
+    for name, jid in sorted(_pip_cache_users()):
+        job = dict(_workflows())[name]["jobs"][jid]
+        body = "\n".join(
+            str(step.get("run", "")) + str(step.get("with", "")) for step in job.get("steps") or []
+        )
+        if not HEAVY.search(body):
+            thin.append(f"{name}:{jid}")
+    assert not thin, (
+        f"these jobs hold a pip cache but no longer install anything that justifies it: "
+        f"{thin}"
+    )
+
+
 def _pip_cache_steps(name, jid):
     """(restore step, save step) for a job, either of which may be None."""
     job = dict(_workflows())[name]["jobs"][jid]

--- a/tests/studio/test_cache_budget_discipline.py
+++ b/tests/studio/test_cache_budget_discipline.py
@@ -234,8 +234,7 @@ def test_no_job_uses_setup_pythons_built_in_pip_cache():
         f"{name}:{jid}"
         for name, jid, job in _jobs()
         for step in job.get("steps") or []
-        if "setup-python" in str(step.get("uses", ""))
-        and (step.get("with") or {}).get("cache")
+        if "setup-python" in str(step.get("uses", "")) and (step.get("with") or {}).get("cache")
     ]
     assert not offenders, (
         f"these jobs use setup-python's built-in cache, which saves on every ref with no "
@@ -268,7 +267,11 @@ def test_every_pip_cache_scopes_its_key_to_what_it_installs(name, jid):
     """
     restore, _ = _pip_cache_steps(name, jid)
     assert restore is not None, f"{name}:{jid} no longer restores a pip cache"
-    files = [l.strip() for l in str((restore.get("with") or {}).get("key-files") or "").splitlines() if l.strip()]
+    files = [
+        l.strip()
+        for l in str((restore.get("with") or {}).get("key-files") or "").splitlines()
+        if l.strip()
+    ]
     assert files, f"{name}:{jid} passes no key-files, so the key describes nothing"
 
 
@@ -289,9 +292,9 @@ def test_every_restored_pip_cache_is_also_saved_and_wired_to_its_restore(name, j
     assert ident, f"{name}:{jid}'s restore step has no id, so the save cannot read its outputs"
     with_ = save.get("with") or {}
     for field in ("dir", "key", "cache-hit"):
-        assert f"steps.{ident}.outputs.{field}" in str(with_.get(field, "")), (
-            f"{name}:{jid}'s save does not take {field} from steps.{ident}.outputs"
-        )
+        assert f"steps.{ident}.outputs.{field}" in str(
+            with_.get(field, "")
+        ), f"{name}:{jid}'s save does not take {field} from steps.{ident}.outputs"
 
 
 def test_the_pip_cache_save_action_is_gated_on_the_default_branch():

--- a/tests/studio/test_cache_budget_discipline.py
+++ b/tests/studio/test_cache_budget_discipline.py
@@ -54,12 +54,14 @@ WORKFLOWS = REPO / ".github" / "workflows"
 
 # Jobs whose pip cache earns its place: they install a torch/transformers-class dependency
 # set, where the download genuinely dominates. Anything not listed here must not ask for it.
-# The jobs that still use setup-python's built-in cache, and therefore still save on
-# every ref. Listed rather than skipped silently: the check above would otherwise report
-# a clean bill while nine jobs did exactly the thing it exists to prohibit, and a tenth
-# could join them unnoticed. The follow-up converts these to an explicit
-# restore + main-only save pair and empties this set.
-PIP_CACHE_JOBS_PENDING_CONVERSION = {
+#
+# These nine no longer use setup-python's built-in `cache: 'pip'`. That form is read-write
+# and saves from its post-step on whatever ref the job ran on, with no knob to gate it, so
+# every PR wrote a ~700MB entry only its own re-runs could ever restore while evicting the
+# copy on main that all PRs share. Measured at 19.45 GiB across 40 entries, 15.49 GiB of it
+# on PR refs. They use the pip-cache-restore / pip-cache-save action pair instead, which
+# splits the halves so the save can be gated on the default branch.
+PIP_CACHE_JOBS = {
     ("consolidated-tests-ci.yml", "consolidated"),
     ("consolidated-tests-ci.yml", "llama-cpp-smoke"),
     ("mlx-ci.yml", "dispatch"),
@@ -172,20 +174,39 @@ def test_the_main_only_expression_check_reads_the_expression(expr, restricted):
     """The guard below is only as good as this predicate, so the predicate is tested too."""
     assert _restricted_to_main(expr) is restricted, expr
 
+def _composite_actions():
+    """(name, steps) for every composite action in the repo.
+
+    Scanned because the pip cache save now lives in one. A guard that reads only workflow
+    steps would have gone blind to it the moment the logic was factored out, which is the
+    failure mode where a rule quietly stops applying to the thing it was written for.
+    """
+    for f in sorted((REPO / ".github" / "actions").rglob("action.yml")):
+        doc = yaml.safe_load(f.read_text(encoding = "utf-8"))
+        if isinstance(doc, dict):
+            yield f.parent.name, ((doc.get("runs") or {}).get("steps") or [])
+
 
 def test_no_workflow_saves_a_cache_on_a_pull_request_ref():
     offenders = []
+    for name, steps in _composite_actions():
+        for step in steps:
+            uses = str(step.get("uses", ""))
+            if "actions/cache" not in uses or "/restore@" in uses:
+                continue
+            if "refs/heads/main" not in str(step.get("if", "")):
+                offenders.append(f"action {name}: {step.get('name') or uses}")
     for name, jid, job in _jobs():
         for step in job.get("steps") or []:
             uses = str(step.get("uses", ""))
             # setup-python's `cache:` is a save too, and an invisible one: the action
             # registers a post-step (`post: dist/cache-save/index.js` in its own
             # action.yml) that runs after the job on whatever ref it ran on, with no
-            # condition to gate it. A scan that only looked for `actions/cache` steps read
-            # as green while nine jobs wrote PR-scoped entries every run.
+            # condition to gate it. A scan that only looked for `actions/cache` steps
+            # read as green while nine jobs wrote PR-scoped entries every run. Nothing
+            # is exempt now that all nine are converted.
             if "setup-python" in uses and (step.get("with") or {}).get("cache"):
-                if (name, jid) not in PIP_CACHE_JOBS_PENDING_CONVERSION:
-                    offenders.append(f"{name}:{jid}: setup-python implicit post-step save")
+                offenders.append(f"{name}:{jid}: setup-python implicit post-step save")
                 continue
             if "actions/cache" not in uses:
                 continue
@@ -200,41 +221,92 @@ def test_no_workflow_saves_a_cache_on_a_pull_request_ref():
     )
 
 
-def test_only_jobs_that_install_heavy_dependencies_ask_for_the_pip_cache():
-    asking = {
-        (name, jid)
+def test_no_job_uses_setup_pythons_built_in_pip_cache():
+    """The built-in cache cannot be gated, so it is not used here at all any more.
+
+    `actions/setup-python`'s `cache: 'pip'` is the read-write form: it restores in the step
+    and saves from its own post-step, on whatever ref the job ran on, and exposes no
+    condition to stop that. A PR-ref entry is restorable only by re-runs of that same PR, so
+    it buys no hit rate while competing for the shared 50 GiB budget against main's copy,
+    which every PR can read. Use pip-cache-restore plus pip-cache-save instead.
+    """
+    offenders = [
+        f"{name}:{jid}"
         for name, jid, job in _jobs()
         for step in job.get("steps") or []
         if "setup-python" in str(step.get("uses", ""))
-        and (step.get("with") or {}).get("cache") == "pip"
-    }
-    extra = asking - PIP_CACHE_JOBS_PENDING_CONVERSION
-    assert not extra, (
-        f"these jobs ask for the shared pip cache without installing anything that justifies "
-        f"a ~700MB entry: {sorted(extra)}. The setup-python pip key is one per interpreter "
-        f"across the whole repo, so every extra claimant is another racer saving under it."
+        and (step.get("with") or {}).get("cache")
+    ]
+    assert not offenders, (
+        f"these jobs use setup-python's built-in cache, which saves on every ref with no "
+        f"way to gate it: {offenders}. Swap to the pip-cache-restore / pip-cache-save pair."
     )
 
 
-@pytest.mark.parametrize("name,jid", sorted(PIP_CACHE_JOBS_PENDING_CONVERSION))
-def test_every_allowed_pip_cache_scopes_its_key_to_what_it_installs(name, jid):
-    """Without `cache-dependency-path`, setup-python hashes dependency files repo-wide.
+def _pip_cache_steps(name, jid):
+    """(restore step, save step) for a job, either of which may be None."""
+    job = dict(_workflows())[name]["jobs"][jid]
+    restore = save = None
+    for step in job.get("steps") or []:
+        uses = str(step.get("uses", ""))
+        if "pip-cache-restore" in uses:
+            restore = step
+        elif "pip-cache-save" in uses:
+            save = step
+    return restore, save
 
-    That is the second multiplier behind the 27.05 GiB: 16 distinct keys appeared in a
+
+@pytest.mark.parametrize("name,jid", sorted(PIP_CACHE_JOBS))
+def test_every_pip_cache_scopes_its_key_to_what_it_installs(name, jid):
+    """Without scoping, the key is a hash of dependency files repo-wide.
+
+    That is the second multiplier behind the 19.45 GiB: 16 distinct keys appeared in a
     week, because any requirements edit anywhere invalidates every interpreter's entry at
     once and orphans the old ones. Scoping the key to the files a job actually installs
     from -- or, for the jobs that pin their dependencies inline, to the workflow file that
     IS the dependency spec -- keeps an unrelated edit from costing ~700MB per interpreter.
     """
-    job = _workflows_by_name()[name]["jobs"][jid]
-    for step in job.get("steps") or []:
-        with_ = step.get("with") or {}
-        if "setup-python" not in str(step.get("uses", "")) or with_.get("cache") != "pip":
-            continue
-        assert with_.get("cache-dependency-path"), (
-            f"{name}:{jid} caches pip without a cache-dependency-path, so its key is a hash "
-            f"of dependency files across the whole repo and moves for reasons that have "
-            f"nothing to do with what this job installs"
+    restore, _ = _pip_cache_steps(name, jid)
+    assert restore is not None, f"{name}:{jid} no longer restores a pip cache"
+    files = [l.strip() for l in str((restore.get("with") or {}).get("key-files") or "").splitlines() if l.strip()]
+    assert files, f"{name}:{jid} passes no key-files, so the key describes nothing"
+
+
+@pytest.mark.parametrize("name,jid", sorted(PIP_CACHE_JOBS))
+def test_every_restored_pip_cache_is_also_saved_and_wired_to_its_restore(name, jid):
+    """A restore with no save fills nothing; a save reading the wrong ids saves nothing.
+
+    Both halves are silent when wrong. The save takes the directory, the key and the
+    hit flag from the restore step's outputs, so a renamed or missing id yields empty
+    inputs and an entry that is never written, with a green job either way.
+    """
+    restore, save = _pip_cache_steps(name, jid)
+    assert restore is not None and save is not None, (
+        f"{name}:{jid} has restore={restore is not None}, save={save is not None}; the "
+        f"pair has to stay together or the cache is never populated"
+    )
+    ident = restore.get("id")
+    assert ident, f"{name}:{jid}'s restore step has no id, so the save cannot read its outputs"
+    with_ = save.get("with") or {}
+    for field in ("dir", "key", "cache-hit"):
+        assert f"steps.{ident}.outputs.{field}" in str(with_.get(field, "")), (
+            f"{name}:{jid}'s save does not take {field} from steps.{ident}.outputs"
+        )
+
+
+def test_the_pip_cache_save_action_is_gated_on_the_default_branch():
+    """The one place the gate lives, now that nine call sites share it."""
+    doc = yaml.safe_load(
+        (REPO / ".github" / "actions" / "pip-cache-save" / "action.yml").read_text(encoding = "utf-8")
+    )
+    steps = (doc.get("runs") or {}).get("steps") or []
+    saves = [s for s in steps if "actions/cache" in str(s.get("uses", ""))]
+    assert saves, "pip-cache-save no longer saves anything"
+    for s in saves:
+        cond = str(s.get("if", ""))
+        assert "refs/heads/main" in cond, (
+            "the pip cache save is no longer gated on the default branch, so all nine call "
+            "sites went back to writing PR-scoped entries at once"
         )
 
 
@@ -242,17 +314,13 @@ def _workflows_by_name():
     return dict(_workflows())
 
 
-@pytest.mark.parametrize("name,jid", sorted(PIP_CACHE_JOBS_PENDING_CONVERSION))
+@pytest.mark.parametrize("name,jid", sorted(PIP_CACHE_JOBS))
 def test_every_allowed_pip_cache_job_still_exists_and_still_earns_it(name, jid):
-    """The allowlist must not outlive the jobs, or it silently permits nothing."""
+    """The list must not outlive the jobs, or it silently permits nothing."""
     doc = dict(_workflows()).get(name)
-    assert (
-        doc is not None
-    ), f"{name} no longer exists; drop it from PIP_CACHE_JOBS_PENDING_CONVERSION"
+    assert doc is not None, f"{name} no longer exists; drop it from PIP_CACHE_JOBS"
     job = doc["jobs"].get(jid)
-    assert (
-        job is not None
-    ), f"{name} no longer has job {jid}; drop it from PIP_CACHE_JOBS_PENDING_CONVERSION"
+    assert job is not None, f"{name} no longer has job {jid}; drop it from PIP_CACHE_JOBS"
     body = "\n".join(str(s.get("run", "")) for s in job.get("steps") or [])
     assert HEAVY.search(body), (
         f"{name}:{jid} is allowed a pip cache but no longer installs anything heavy; it "
@@ -340,25 +408,20 @@ def test_a_cache_save_of_downloaded_artifacts_waits_for_the_download_to_succeed(
     )
 
 
-def test_every_cache_dependency_path_resolves_where_the_job_checked_out():
-    """setup-python FAILS the job when the path matches nothing; it does not skip the cache.
+def test_every_cache_key_path_resolves_where_the_job_checked_out():
+    """A key-files glob that matches nothing collapses every job onto one key.
 
-    "Error: No file in <workspace> matched to [...], make sure you have checked out the
-    target repository" -- actions/setup-python#807 is an open request to downgrade that to
-    a warning, so today it is fatal. Three jobs here check the repo out under `unsloth/`
-    (notebooks-ci api-introspect, version-compat-ci zoo-imports-under-spoof and
-    grpo-fake-run) because they need a second repo beside it. A key written as if the
-    checkout were at the workspace root therefore does not merely miss the cache, it stops
-    the job before it installs anything.
-
-    Scoping the keys is what introduced this, which is why it is asserted rather than
-    remembered: the failure is loud, but only once it reaches CI.
+    Three jobs check the repo out under `unsloth/` because they need a second repo beside
+    it (notebooks-ci api-introspect, version-compat-ci zoo-imports-under-spoof and
+    grpo-fake-run), so a path written as if the checkout were at the workspace root
+    resolves to nothing. Under setup-python's built-in cache that was fatal outright
+    ("No file in ... matched to ..."); hashFiles is quieter and simply returns empty, which
+    is why pip-cache-restore fails loudly on an empty hash and why this stays asserted.
 
     Each entry is resolved against the checkout it belongs to and then globbed, rather than
     prefix-matched. A prefix check calls `unsloth/.github/workflows/typo.yml` correct
     because it starts with `unsloth/`, and a job checked out at the workspace root was
-    skipped entirely, so a misspelling there was never examined at all. Both fail the job
-    exactly as hard as the wrong prefix does.
+    skipped entirely, so a misspelling there was never examined at all.
     """
     offenders = []
     for name, jid, job in _jobs():
@@ -382,9 +445,10 @@ def test_every_cache_dependency_path_resolves_where_the_job_checked_out():
 
         for step in steps:
             with_ = step.get("with") or {}
-            if "setup-python" not in str(step.get("uses", "")):
-                continue
-            for line in str(with_.get("cache-dependency-path") or "").splitlines():
+            paths = with_.get("cache-dependency-path") or (
+                with_.get("key-files") if "pip-cache-restore" in str(step.get("uses", "")) else None
+            )
+            for line in str(paths or "").splitlines():
                 line = line.strip()
                 if not line:
                     continue
@@ -413,8 +477,8 @@ def test_every_cache_dependency_path_resolves_where_the_job_checked_out():
                         f"(resolved to {relative!r})"
                     )
     assert not offenders, (
-        "setup-python fails a job outright when cache-dependency-path matches nothing, so "
-        "each of these stops its job before it installs anything:\n  " + "\n  ".join(offenders)
+        "these cache key paths are workspace-root-relative in a job that checks the repo "
+        "out into a subdirectory, so they match no file:\n  " + "\n  ".join(offenders)
     )
 
 

--- a/tests/studio/test_cache_budget_discipline.py
+++ b/tests/studio/test_cache_budget_discipline.py
@@ -504,3 +504,36 @@ def test_no_setup_python_step_declares_a_cache_path_without_a_cache():
         f"these steps declare cache-dependency-path but no cache, so the key is never "
         f"used and the config only misleads: {offenders}"
     )
+
+
+def test_local_action_references_use_the_nested_checkout_path():
+    """`uses: ./...` resolves from GITHUB_WORKSPACE, not from the workflow file.
+
+    GitHub's own docs put it plainly: if the action checks the repository out to a
+    different location than the workflow, the relative path for a local action has to be
+    updated. Three jobs here check out under `unsloth/` because they need a second repo
+    beside it, so an unprefixed `./.github/actions/...` points at a directory that does not
+    exist and the step fails with "Can't find 'action.yml', 'action.yaml' or 'Dockerfile'".
+
+    Same root cause as the cache-key path check above, one level out: the key paths were
+    fixed for these jobs and the action paths were not.
+    """
+    offenders = []
+    for name, jid, job in _jobs():
+        steps = job.get("steps") or []
+        checkout_dirs = [
+            str((s.get("with") or {}).get("path")).rstrip("/")
+            for s in steps
+            if "actions/checkout" in str(s.get("uses", "")) and (s.get("with") or {}).get("path")
+        ]
+        if not checkout_dirs:
+            continue
+        for step in steps:
+            uses = str(step.get("uses", ""))
+            if uses.startswith("./") and not any(uses.startswith(f"./{d}/") for d in checkout_dirs):
+                offenders.append(f"{name}:{jid}: {uses} (checkouts: {checkout_dirs})")
+    assert not offenders, (
+        "these local action references are workspace-root-relative in a job that checks "
+        "the repo out into a subdirectory, so the runner cannot find the action:\n  "
+        + "\n  ".join(offenders)
+    )


### PR DESCRIPTION
`actions/setup-python`'s `cache: 'pip'` is the read-write form: it restores in the step and saves from its own post-step, on **whatever ref the job ran on**, and exposes no condition to stop that. An entry written on a `pull_request` ref can only be restored by re-runs of that same pull request, so it buys no hit rate while competing for the shared 50 GiB budget against the copy on `main` that every PR *can* read.

### What it was costing

Measured across all 173 cache entries before this change:

```
19.45 GiB  40 entries  setup-python pip        <- 49% of everything in the cache
15.49 GiB  28 entries    ... of that, on PR refs, restorable only by that PR's own re-runs
 9.60 GiB              pure duplicate: 4 interpreter keys held 4-6 copies each
```

None of it surfaces as a failure. Over quota, GitHub evicts least-recently-used, so `main`'s copy goes, the next PR misses, downloads, and writes its own copy, which evicts something else. CI just gets slower and everyone assumes that is what it costs.

This repo had already diagnosed and fixed exactly that loop twice, for the GGUF model caches and for the Playwright browsers. `setup-python` was left doing it because the built-in cache has no save-gating knob.

### The change

Splitting restore from save is how you get one. The nine jobs that genuinely install a torch/transformers-class dependency set now use a composite pair:

- `.github/actions/pip-cache-restore` resolves pip's cache directory, builds a key from `runner.os`, `runner.arch`, the resolved interpreter version and a hash of the files the job installs from, and restores read-only.
- `.github/actions/pip-cache-save` saves under that key, gated on `github.ref == 'refs/heads/main'`.

Defined once rather than inlined nine times, following `install-unsloth-local`: the ref gate is the entire point of the change, and nine copies of a one-line condition drift.

Two details worth calling out. The directory comes from `pip cache dir` rather than a hardcoded path, because it differs on Linux, macOS and Windows and this set spans all three (`mlx-ci` is macOS, `studio-export-capability-ci` is an ubuntu + windows matrix). And the restore fails loudly when `key-files` matches nothing: `hashFiles` returns an empty string there rather than erroring, which would silently collapse every job onto one key. The built-in cache was at least loud about this; the replacement has to be too.

Jobs converted:

| workflow | job |
|---|---|
| consolidated-tests-ci.yml | consolidated, llama-cpp-smoke |
| mlx-ci.yml | dispatch |
| notebooks-ci.yml | api-introspect |
| studio-backend-ci.yml | pytest, repo-cpu-tests |
| studio-export-capability-ci.yml | capability |
| version-compat-ci.yml | zoo-imports-under-spoof, grpo-fake-run |

### Guards

The existing discipline tests had to move with the architecture, or they would have kept passing while guarding nothing:

- The save scan now reads composite actions as well as workflow steps. The save moved into an action, so a scan that only walked workflows would have gone blind to it the moment the logic was factored out. Verified by ungating the action's save: both that scan and the dedicated gate test go red.
- Using the built-in cache at all is now a failure rather than an allowlist question.
- Each of the nine is checked to restore *and* save as a wired pair, taking `dir`, `key` and `cache-hit` from the restore step's outputs, since a renamed id yields empty inputs and an entry that is never written, with a green job either way. Verified by deleting one job's save step.
- The key-path check covers `key-files` as well as `cache-dependency-path`, so the three jobs that check out under `unsloth/` stay covered.

`tests/studio/` is green at 4035 passed, and `actionlint` is clean on every workflow touched.

### Base

Stacked on `cache-budget` (#9151), which is where the nine keys were scoped and the allowlist introduced. GitHub will retarget this to `main` when that merges.
