### PR TITLE
fix(studio): refuse a hand-set context unified memory cannot hold

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -1986,11 +1986,9 @@ _CTX_FIT_VRAM_FRACTION = 0.97
 # 0.85 MLX uses in mlx_inference.py (_configure_memory_limits); not kept in sync.
 _APPLE_UNIFIED_MEMORY_FRACTION = 0.85
 
-# _fit_context_to_vram's own floor, and llama.cpp's: common_params.fit_params_min_ctx
-# is 4096, so neither Studio's fit nor "--fit on" will price a context below it. Any
-# 4096 the fit hands back is therefore that floor rather than a measurement, and the
-# Metal branch re-prices from _FIT_FLOOR_MIN_CTX (the 256 alignment step the search
-# rounds to) to find out whether anything at all fits before it trusts the number.
+# _fit_context_to_vram's floor, and llama.cpp's (common_params.fit_params_min_ctx), so a
+# 4096 from either is that floor rather than a measurement. The Metal branch re-prices
+# from _FIT_FLOOR_MIN_CTX (the search's 256 alignment step) before trusting it.
 _FIT_MIN_CTX = 4096
 _FIT_FLOOR_MIN_CTX = 256
 
@@ -7272,49 +7270,43 @@ class LlamaCppBackend:
     ) -> Optional[str]:
         """Refusal when a hand-set context exceeds what unified memory holds (else None).
 
-        The Metal branch of the placement code already works out the largest context
-        that fits, but only Auto was ever moved to it: an explicit request was passed
-        through verbatim, on the theory that "--fit on" is a backstop.
+        The Metal placement branch already works out the largest context that fits, but
+        only Auto was moved to it: an explicit request was passed through verbatim, on
+        the theory that "--fit on" is a backstop. It is one, just not a trustworthy one
+        here. llama.cpp will reduce an explicit context (common.h: fit_params_min_ctx
+        defaults to 4096, and only "-c 0" disables the reduction outright), but it
+        decides from the free memory ggml-metal reports, off the device's
+        recommendedMaxWorkingSetSize. That is a property of the machine, not the moment:
+        it knows nothing of Studio's own resident gigabyte or two, of whatever else the
+        user has open, or of the iogpu wired limit that is the figure actually being
+        blown. _apple_metal_memory_budget_bytes exists for exactly that gap, and takes
+        min(device ceiling, psutil available) instead.
 
-        It is a backstop, just not a trustworthy one here, for two reasons that compound.
-        llama.cpp will reduce an explicit context (common.h: fit_params_min_ctx defaults
-        to 4096, and only "-c 0" raises it to UINT32_MAX to disable reduction outright),
-        but it decides from the free memory ggml-metal reports, which comes off the
-        device's recommendedMaxWorkingSetSize. That is a property of the machine, not of
-        the moment: it does not know about Studio's own resident gigabyte or two, about
-        whatever else the user has open, or about the iogpu wired limit that is the
-        figure actually being blown. _apple_metal_memory_budget_bytes exists because of
-        exactly that gap, and takes min(device ceiling, psutil available) instead.
+        So an optimistic estimate leaves the request alone and the launch over-commits
+        wired memory. Wired pages are not reclaimable, so Jetsam cannot step in: the
+        driver faults and the machine panics rather than the load failing the way it
+        would on a discrete GPU (r/unsloth, M1 Max 32 GB, Qwen3.8-27B-UD-Q4_K_XL,
+        panicked twice on a hand-set context, and never on Auto).
 
-        So when llama.cpp's estimate comes out optimistic it leaves the request alone,
-        and the launch over-commits wired memory. Wired pages are not reclaimable, so
-        Jetsam cannot step in the way it would for an ordinary process: the driver
-        faults and the machine panics, rather than the load failing the way it would on
-        a discrete GPU (r/unsloth, M1 Max 32 GB, Qwen3.8-27B-UD-Q4_K_XL, panicked twice
-        on a hand-set context, and never on Auto).
-
-        Refusing rather than silently clamping to the ceiling is deliberate: the number
-        the user typed is the number they get told about, and a context that quietly
+        Refusing rather than silently clamping is deliberate: a context that quietly
         became a quarter of what was asked for is its own support thread.
 
         Unlike ``_apu_ram_shortfall_message`` this prices the context, not just the
-        weights. That helper leaves KV out because context auto-reduces on its path, so
-        counting it would refuse loads that would have succeeded. On this path the
-        explicit request is exactly what does not auto-reduce, so the KV and compute
+        weights. That helper leaves KV out because context auto-reduces on its path; here
+        the explicit request is exactly what does not auto-reduce, so the KV and compute
         buffers it implies are the bytes that do the damage.
 
-        Callers pass a ceiling they measured with a real KV estimate. The 4096 floor the
-        branch falls back to when KV cannot be sized is a guess, not a measurement, and
-        refusing against it would block contexts that load fine today.
+        Callers pass a ceiling measured with a real KV estimate. The 4096 floor the
+        branch falls back to when KV cannot be sized is a guess, and refusing against it
+        would block contexts that load fine today.
 
         UNSLOTH_ALLOW_METAL_CTX_OVERCOMMIT=1 abstains, matching the host-offload opt-out,
         though the failure mode it re-enables is the whole machine rather than one app.
         """
         if requested_ctx <= 0:
             return None
-        # nothing_fits carries its own verdict, and it is the one case with no positive
-        # ceiling to compare against: the fit priced the smallest context it will price
-        # and even that did not fit.
+        # nothing_fits carries its own verdict, and is the one case with no positive
+        # ceiling: the fit priced its smallest context and even that did not fit.
         if not nothing_fits:
             if max_available_ctx <= 0:
                 return None
@@ -14332,13 +14324,12 @@ class LlamaCppBackend:
                 # try: the launch below reads it either way.
                 _spec_dropped_no_vram = False
                 # Metal unified-memory refusal for a hand-set context, raised AFTER this
-                # block rather than inside it: the `except Exception` below swallows any
-                # raise into the placement fallback and then restores the original request,
-                # which is the very over-commit being refused. Carrying the message out
-                # survives that arm, and the ceiling it names was measured before the throw.
-                # (Worded around the handler's own log line on purpose: test_tp_vision_
-                # regression string-searches this function's source for it to check
-                # statement ordering, and quoting it here moved the match.)
+                # block: the `except Exception` below would swallow the raise into the
+                # placement fallback and restore the original request, which is the very
+                # over-commit being refused. Carrying the message out survives that arm,
+                # and the ceiling it names was measured before the throw. (Worded around
+                # the handler's own log line on purpose: test_tp_vision_regression
+                # string-searches this function's source for it to check ordering.)
                 _metal_ctx_refusal: Optional[str] = None
                 try:
                     gguf_size = self._get_gguf_size_bytes(model_path)
@@ -15616,18 +15607,17 @@ class LlamaCppBackend:
                     elif _apple_budget_mib > 0 and effective_ctx > 0:
                         # No GPU on Metal: the branches above are skipped and the context
                         # stays at native, over-committing unified memory (#5118, #6529).
-                        # Cap with the same fit math; Auto shrinks to the cap, and an
-                        # explicit request above it is refused rather than launched.
-                        # "--fit on" stays as a backstop, but not one this can lean on:
-                        # llama.cpp sizes its reduction from ggml-metal's free-memory
-                        # report, which knows nothing about Studio's own footprint or the
-                        # wired limit. See _metal_context_overcommit_message.
+                        # Cap with the same fit math; Auto shrinks to the cap, an explicit
+                        # request above it is refused. "--fit on" stays a backstop but not
+                        # one this can lean on: llama.cpp sizes its reduction from
+                        # ggml-metal's free-memory report, blind to Studio's own footprint
+                        # and the wired limit. See _metal_context_overcommit_message.
                         native_ctx_for_cap = self._context_length or effective_ctx
                         # Only a ceiling backed by a real KV estimate may refuse; the 4096
                         # fallback below is a guess and would block working loads.
                         _apple_measured_ceiling: Optional[int] = None
-                        # The other measured verdict: nothing fits at all, so there is no
-                        # ceiling to name and every explicit request over-commits.
+                        # The other measured verdict: nothing fits, so there is no ceiling
+                        # to name and every explicit request over-commits.
                         _apple_nothing_fits = False
                         # Reserve the flat MTP fraction up front like the discrete
                         # _pin_fraction, so an unsized MTP draft (e.g. Qwen3.6-MTP, #6529)
@@ -15671,50 +15661,45 @@ class LlamaCppBackend:
                                 max_available_ctx = cap
                                 _apple_measured_ceiling = cap
                             else:
-                                # Two states land here and only one of them is unmeasurable.
-                                # Weights alone over budget: the fit returned the request
-                                # untouched, priced nothing, and no context can rescue it.
-                                # Or the weights do fit and it is the helper's own 4096
-                                # floor that does not -- there 4096 is a floor, not a
-                                # measurement, so re-price under it before concluding
-                                # nothing was measured. Without that pass a Mac with room
-                                # for no tested context skipped the refusal for every
-                                # explicit request and reached llama-server, whose --fit
-                                # cannot reduce below fit_params_min_ctx (4096) either, so
-                                # the backstop had nothing left to give.
+                                # Two states land here, only one unmeasurable. Weights
+                                # alone over budget: the fit returned the request
+                                # untouched, priced nothing, and no context rescues it.
+                                # Or the weights fit and it is the helper's own 4096 floor
+                                # that does not -- a floor, not a measurement, so re-price
+                                # under it before concluding nothing was measured. Without
+                                # that pass a Mac with room for no tested context skipped
+                                # the refusal and reached llama-server, whose --fit cannot
+                                # reduce below 4096 either.
                                 _floor_cap = _apple_ctx_fit(native_ctx_for_cap, _FIT_FLOOR_MIN_CTX)
                                 # Ask the budget directly rather than inferring the
-                                # weights-only state from the two fits disagreeing. Both
-                                # calls are bounded by the same target, so on a model
-                                # whose native length is already at or under the floor
-                                # they return the same number for a reason that has
-                                # nothing to do with the weights, and the comparison read
-                                # that as "priced nothing" and refused nothing. Reachable
-                                # at native == 256, and also whenever the GGUF carries no
-                                # context length and the request itself is that small.
+                                # weights-only state from the two fits disagreeing: both
+                                # are bounded by the same target, so on a model whose
+                                # native length is at or under the floor they tie for a
+                                # reason unrelated to the weights, which read as "priced
+                                # nothing" and refused nothing. Reachable at native == 256,
+                                # and whenever the GGUF carries no context length and the
+                                # request itself is that small.
                                 _weights_over_budget = (
                                     model_size_fit / (1024 * 1024)
                                 ) > _apple_fit_budget_mib
                                 if _weights_over_budget:
-                                    # The fit priced nothing: no context can rescue a load
-                                    # whose weights alone miss the budget. A different
-                                    # failure, owned by the host-RAM guard. Floor for the
-                                    # UI, but do not refuse against a number the fit never
-                                    # vouched for.
+                                    # The fit priced nothing: no context rescues a load
+                                    # whose weights alone miss the budget, and that is the
+                                    # host-RAM guard's failure. Floor for the UI, but do
+                                    # not refuse against a number the fit never vouched for.
                                     max_available_ctx = min(4096, native_ctx_for_cap)
                                 elif _apple_footprint_mib(_floor_cap) <= _apple_fit_budget_mib:
                                     max_available_ctx = _floor_cap
                                     _apple_measured_ceiling = _floor_cap
                                 else:
-                                    # It shrank, so the weights fit, and even the smallest
-                                    # context the search will price does not. That is a
-                                    # measurement too, and the strongest one available:
-                                    # nothing fits, so there is no number to lower to and
-                                    # every explicit request over-commits. Refuse those and
-                                    # say so. Auto is untouched, as everywhere else here --
-                                    # it keeps the 4096 floor it has always launched at,
-                                    # since changing what Auto does on this host is a
-                                    # larger claim than this guard is making.
+                                    # It shrank, so the weights fit and even the smallest
+                                    # context the search prices does not. A measurement
+                                    # too, and the strongest available: nothing fits, so
+                                    # there is no number to lower to and every explicit
+                                    # request over-commits. Auto is untouched as everywhere
+                                    # else here -- it keeps the 4096 floor it has always
+                                    # launched at, since changing that is a larger claim
+                                    # than this guard makes.
                                     max_available_ctx = min(4096, native_ctx_for_cap)
                                     _apple_nothing_fits = True
                         else:
@@ -15730,45 +15715,42 @@ class LlamaCppBackend:
                         ):
                             # Exempt for the reason the other two Metal guards are: a
                             # manual load with a fixed layer count is the user taking the
-                            # memory budget over, and it is read off the request so the
-                            # paravirtual CPU pin (which rewrites Auto to manual/0) cannot
-                            # make a plain Auto load look caller-owned.
+                            # memory budget over, read off the request so the paravirtual
+                            # CPU pin (which rewrites Auto to manual/0) cannot make a plain
+                            # Auto load look caller-owned.
                             #
                             # The virtualised device is exempt for the opposite reason:
                             # that pin puts the whole load on CPU behind --device none, so
-                            # it allocates no Metal memory at all and this budget is the
-                            # wrong yardstick for it. Refusing there would break loads
-                            # that work today on a Mac VM, and the message would describe
-                            # a GPU the launch never touches. What an oversized CPU load
-                            # does risk is host RAM, which _host_offload_shortfall_message
-                            # already covers, priced against the pool it really draws on.
+                            # it allocates no Metal memory and this budget is the wrong
+                            # yardstick. Refusing would break Mac VM loads that work today,
+                            # and the message would describe a GPU the launch never
+                            # touches. Its real risk is host RAM, which
+                            # _host_offload_shortfall_message already prices.
                             #
                             # The fit above is sized through the model's native length, so
-                            # on its own it caps the ceiling there and refuses every request
-                            # past it as an over-commit -- including one this Mac has the
-                            # memory for. Nothing clamps a request to the native length on
-                            # the way in (the Extra Arguments box takes a raw "--ctx-size"
-                            # and even suggests "--rope-scaling yarn"), and llama.cpp builds
-                            # the context at the full -c, only capping the per-slot value
-                            # afterwards, so the request really is what gets allocated.
-                            # Re-price through it, and only adopt the answer when it is one
-                            # the budget vouches for.
+                            # on its own it caps the ceiling there and refuses every
+                            # request past it -- including ones this Mac has the memory
+                            # for. Nothing clamps a request to native on the way in (the
+                            # Extra Arguments box takes a raw "--ctx-size" and even
+                            # suggests "--rope-scaling yarn"), and llama.cpp builds the
+                            # context at the full -c, capping only the per-slot value
+                            # afterwards, so the request is what gets allocated. Re-price
+                            # through it, adopting the answer only when the budget
+                            # vouches for it.
                             if _apple_measured_ceiling is not None and (
                                 effective_ctx > native_ctx_for_cap
                             ):
                                 _extended_ceiling = _apple_ctx_fit(effective_ctx, _FIT_MIN_CTX)
                                 if _apple_footprint_mib(_extended_ceiling) > _apple_fit_budget_mib:
                                     # 4096 is the helper's floor, not a measurement, and
-                                    # the cap above already has to re-price under it for
-                                    # the same reason. It bites here too whenever the
-                                    # native length is below the floor: the request is
-                                    # above native and the floor is above what fits, so
-                                    # the probe hands back a non-fitting 4096, the check
-                                    # discards it, and the refusal keeps naming the
-                                    # native-sized cap. On a 2048-native model with room
-                                    # for 3072 that reads as "the largest that fits is
-                                    # 2,048" on a machine that launches 3,072 when asked
-                                    # for it directly.
+                                    # the cap above re-prices under it for the same reason.
+                                    # It bites here whenever native is below the floor: the
+                                    # request is above native and the floor above what
+                                    # fits, so the probe hands back a non-fitting 4096, the
+                                    # check discards it, and the refusal keeps naming the
+                                    # native-sized cap -- "the largest that fits is 2,048"
+                                    # on a 2048-native model whose machine launches 3,072
+                                    # when asked for it directly.
                                     _extended_ceiling = _apple_ctx_fit(
                                         effective_ctx, _FIT_FLOOR_MIN_CTX
                                     )
@@ -15778,15 +15760,14 @@ class LlamaCppBackend:
                                     <= _apple_fit_budget_mib
                                 ):
                                     _apple_measured_ceiling = _extended_ceiling
-                                    # Publish it as well. max_available_ctx becomes
+                                    # Publish it too: max_available_ctx becomes
                                     # max_context_length, which the UI reads as the
                                     # largest context that fits and both amber warnings
-                                    # compare the loaded context against. Left at the
-                                    # native length, a load this branch just measured
-                                    # and allowed arrives with a warning saying it does
-                                    # not fit in unified memory. The fit is bounded by
-                                    # the request, so this raises the bound to the
-                                    # context that actually loaded and no further.
+                                    # compare against. Left at native, a load this branch
+                                    # just measured and allowed would arrive with a
+                                    # warning saying it does not fit. The fit is bounded
+                                    # by the request, so the bound rises to the context
+                                    # that loaded and no further.
                                     max_available_ctx = max(
                                         max_available_ctx, _apple_measured_ceiling
                                     )
@@ -15895,10 +15876,9 @@ class LlamaCppBackend:
                     tp_tensor_split = None
                     effective_ctx = requested_ctx  # fall back to original
 
-                # A hand-set context unified memory cannot hold. Raised here so the
-                # handler above cannot turn it back into the launch it refuses, and
-                # ahead of the Vulkan and APU checks because those describe hardware
-                # this branch has already established is not present.
+                # A hand-set context unified memory cannot hold. Raised here so the handler
+                # above cannot turn it back into the launch it refuses, and ahead of the
+                # Vulkan and APU checks, which describe hardware this branch has ruled out.
                 if _metal_ctx_refusal:
                     raise RuntimeError(_metal_ctx_refusal)
 

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -15683,9 +15683,21 @@ class LlamaCppBackend:
                                 # cannot reduce below fit_params_min_ctx (4096) either, so
                                 # the backstop had nothing left to give.
                                 _floor_cap = _apple_ctx_fit(native_ctx_for_cap, _FIT_FLOOR_MIN_CTX)
-                                if _floor_cap >= cap:
-                                    # It could not shrink, so the weights themselves are
-                                    # over budget and the fit priced nothing. A different
+                                # Ask the budget directly rather than inferring the
+                                # weights-only state from the two fits disagreeing. Both
+                                # calls are bounded by the same target, so on a model
+                                # whose native length is already at or under the floor
+                                # they return the same number for a reason that has
+                                # nothing to do with the weights, and the comparison read
+                                # that as "priced nothing" and refused nothing. Reachable
+                                # at native == 256, and also whenever the GGUF carries no
+                                # context length and the request itself is that small.
+                                _weights_over_budget = (
+                                    model_size_fit / (1024 * 1024)
+                                ) > _apple_fit_budget_mib
+                                if _weights_over_budget:
+                                    # The fit priced nothing: no context can rescue a load
+                                    # whose weights alone miss the budget. A different
                                     # failure, owned by the host-RAM guard. Floor for the
                                     # UI, but do not refuse against a number the fit never
                                     # vouched for.

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -15758,6 +15758,24 @@ class LlamaCppBackend:
                             ):
                                 _extended_ceiling = _apple_ctx_fit(effective_ctx, _FIT_MIN_CTX)
                                 if (
+                                    _apple_footprint_mib(_extended_ceiling)
+                                    > _apple_fit_budget_mib
+                                ):
+                                    # 4096 is the helper's floor, not a measurement, and
+                                    # the cap above already has to re-price under it for
+                                    # the same reason. It bites here too whenever the
+                                    # native length is below the floor: the request is
+                                    # above native and the floor is above what fits, so
+                                    # the probe hands back a non-fitting 4096, the check
+                                    # discards it, and the refusal keeps naming the
+                                    # native-sized cap. On a 2048-native model with room
+                                    # for 3072 that reads as "the largest that fits is
+                                    # 2,048" on a machine that launches 3,072 when asked
+                                    # for it directly.
+                                    _extended_ceiling = _apple_ctx_fit(
+                                        effective_ctx, _FIT_FLOOR_MIN_CTX
+                                    )
+                                if (
                                     _extended_ceiling > _apple_measured_ceiling
                                     and _apple_footprint_mib(_extended_ceiling)
                                     <= _apple_fit_budget_mib

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -7267,6 +7267,8 @@ class LlamaCppBackend:
         requested_ctx: int,
         max_available_ctx: int,
         cache_type_kv: Optional[str] = None,
+        *,
+        nothing_fits: bool = False,
     ) -> Optional[str]:
         """Refusal when a hand-set context exceeds what unified memory holds (else None).
 
@@ -7308,10 +7310,16 @@ class LlamaCppBackend:
         UNSLOTH_ALLOW_METAL_CTX_OVERCOMMIT=1 abstains, matching the host-offload opt-out,
         though the failure mode it re-enables is the whole machine rather than one app.
         """
-        if requested_ctx <= 0 or max_available_ctx <= 0:
+        if requested_ctx <= 0:
             return None
-        if requested_ctx <= max_available_ctx:
-            return None
+        # nothing_fits carries its own verdict, and it is the one case with no positive
+        # ceiling to compare against: the fit priced the smallest context it will price
+        # and even that did not fit.
+        if not nothing_fits:
+            if max_available_ctx <= 0:
+                return None
+            if requested_ctx <= max_available_ctx:
+                return None
         # the user's own opt-out, so read the real environment, not the curated child env
         if os.environ.get(LlamaCppBackend.METAL_CTX_OVERCOMMIT_ENV, "").strip().lower() in (
             "1",
@@ -7328,6 +7336,17 @@ class LlamaCppBackend:
             if (cache_type_kv or "f16").strip().lower() in ("f16", "fp16", "")
             else ""
         )
+        if nothing_fits:
+            return (
+                "No context fits in this Mac's unified memory with this model. The weights "
+                "fit, but they leave too little for even the smallest context, so a load at "
+                f"any length would over-commit. The GPU and the rest of the system share one "
+                f"pool here, so there is nothing to offload to, and the load would bring the "
+                f"machine down instead of reporting an error. Use a smaller or more quantized "
+                f"GGUF, or free memory."
+                f"{kv_hint} Set "
+                f"{LlamaCppBackend.METAL_CTX_OVERCOMMIT_ENV}=1 to load it anyway."
+            )
         return (
             f"A context of {requested_ctx:,} tokens does not fit in this Mac's unified "
             f"memory with this model. The largest that fits is {max_available_ctx:,} "
@@ -15607,6 +15626,9 @@ class LlamaCppBackend:
                         # Only a ceiling backed by a real KV estimate may refuse; the 4096
                         # fallback below is a guess and would block working loads.
                         _apple_measured_ceiling: Optional[int] = None
+                        # The other measured verdict: nothing fits at all, so there is no
+                        # ceiling to name and every explicit request over-commits.
+                        _apple_nothing_fits = False
                         # Reserve the flat MTP fraction up front like the discrete
                         # _pin_fraction, so an unsized MTP draft (e.g. Qwen3.6-MTP, #6529)
                         # can't over-commit. No-op when MTP is off; exclusive with the
@@ -15661,16 +15683,28 @@ class LlamaCppBackend:
                                 # cannot reduce below fit_params_min_ctx (4096) either, so
                                 # the backstop had nothing left to give.
                                 _floor_cap = _apple_ctx_fit(native_ctx_for_cap, _FIT_FLOOR_MIN_CTX)
-                                if (
-                                    _floor_cap < cap
-                                    and _apple_footprint_mib(_floor_cap) <= _apple_fit_budget_mib
-                                ):
+                                if _floor_cap >= cap:
+                                    # It could not shrink, so the weights themselves are
+                                    # over budget and the fit priced nothing. A different
+                                    # failure, owned by the host-RAM guard. Floor for the
+                                    # UI, but do not refuse against a number the fit never
+                                    # vouched for.
+                                    max_available_ctx = min(4096, native_ctx_for_cap)
+                                elif _apple_footprint_mib(_floor_cap) <= _apple_fit_budget_mib:
                                     max_available_ctx = _floor_cap
                                     _apple_measured_ceiling = _floor_cap
                                 else:
-                                    # Floor for the UI, but do not refuse against a number
-                                    # the fit never vouched for.
+                                    # It shrank, so the weights fit, and even the smallest
+                                    # context the search will price does not. That is a
+                                    # measurement too, and the strongest one available:
+                                    # nothing fits, so there is no number to lower to and
+                                    # every explicit request over-commits. Refuse those and
+                                    # say so. Auto is untouched, as everywhere else here --
+                                    # it keeps the 4096 floor it has always launched at,
+                                    # since changing what Auto does on this host is a
+                                    # larger claim than this guard is making.
                                     max_available_ctx = min(4096, native_ctx_for_cap)
+                                    _apple_nothing_fits = True
                         else:
                             # No KV estimate: mirror the discrete file-size-only fallback
                             # and floor to 4096 rather than launch at native and over-commit.
@@ -15678,7 +15712,7 @@ class LlamaCppBackend:
                         if not explicit_ctx:
                             effective_ctx = max_available_ctx
                         elif (
-                            _apple_measured_ceiling is not None
+                            (_apple_measured_ceiling is not None or _apple_nothing_fits)
                             and not _caller_owns_budget
                             and not _paravirtual_cpu_forced
                         ):
@@ -15707,7 +15741,9 @@ class LlamaCppBackend:
                             # afterwards, so the request really is what gets allocated.
                             # Re-price through it, and only adopt the answer when it is one
                             # the budget vouches for.
-                            if effective_ctx > native_ctx_for_cap:
+                            if _apple_measured_ceiling is not None and (
+                                effective_ctx > native_ctx_for_cap
+                            ):
                                 _extended_ceiling = _apple_ctx_fit(effective_ctx, _FIT_MIN_CTX)
                                 if (
                                     _extended_ceiling > _apple_measured_ceiling
@@ -15717,8 +15753,9 @@ class LlamaCppBackend:
                                     _apple_measured_ceiling = _extended_ceiling
                             _metal_ctx_refusal = self._metal_context_overcommit_message(
                                 effective_ctx,
-                                _apple_measured_ceiling,
+                                _apple_measured_ceiling or 0,
                                 cache_type_kv,
+                                nothing_fits = _apple_nothing_fits,
                             )
 
                     # Prefer fewer serving slots on GPU over --fit on offload: when the extra

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -15778,6 +15778,18 @@ class LlamaCppBackend:
                                     <= _apple_fit_budget_mib
                                 ):
                                     _apple_measured_ceiling = _extended_ceiling
+                                    # Publish it as well. max_available_ctx becomes
+                                    # max_context_length, which the UI reads as the
+                                    # largest context that fits and both amber warnings
+                                    # compare the loaded context against. Left at the
+                                    # native length, a load this branch just measured
+                                    # and allowed arrives with a warning saying it does
+                                    # not fit in unified memory. The fit is bounded by
+                                    # the request, so this raises the bound to the
+                                    # context that actually loaded and no further.
+                                    max_available_ctx = max(
+                                        max_available_ctx, _apple_measured_ceiling
+                                    )
                             _metal_ctx_refusal = self._metal_context_overcommit_message(
                                 effective_ctx,
                                 _apple_measured_ceiling or 0,

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -7264,12 +7264,28 @@ class LlamaCppBackend:
 
         The Metal branch of the placement code already works out the largest context
         that fits, but only Auto was ever moved to it: an explicit request was passed
-        through verbatim on the theory that "--fit on" is a backstop. It is not one
-        here. --fit flexes -ngl to spill layers to the host, and on unified memory the
-        host is the same pool, so the spill frees nothing. The launch over-commits, and
-        because a Mac has nothing to fall back on it takes the system down with a kernel
-        panic rather than returning an out-of-memory error the way a discrete GPU does
-        (r/unsloth, M1 Max 32 GB, Qwen3.8-27B-UD-Q4_K_XL at a hand-set context).
+        through verbatim, on the theory that "--fit on" is a backstop.
+
+        It is a backstop, just not a trustworthy one here, for two reasons that compound.
+        llama.cpp will reduce an explicit context (common.h: fit_params_min_ctx defaults
+        to 4096, and only "-c 0" raises it to UINT32_MAX to disable reduction outright),
+        but it decides from the free memory ggml-metal reports, which comes off the
+        device's recommendedMaxWorkingSetSize. That is a property of the machine, not of
+        the moment: it does not know about Studio's own resident gigabyte or two, about
+        whatever else the user has open, or about the iogpu wired limit that is the
+        figure actually being blown. _apple_metal_memory_budget_bytes exists because of
+        exactly that gap, and takes min(device ceiling, psutil available) instead.
+
+        So when llama.cpp's estimate comes out optimistic it leaves the request alone,
+        and the launch over-commits wired memory. Wired pages are not reclaimable, so
+        Jetsam cannot step in the way it would for an ordinary process: the driver
+        faults and the machine panics, rather than the load failing the way it would on
+        a discrete GPU (r/unsloth, M1 Max 32 GB, Qwen3.8-27B-UD-Q4_K_XL, panicked twice
+        on a hand-set context, and never on Auto).
+
+        Refusing rather than silently clamping to the ceiling is deliberate: the number
+        the user typed is the number they get told about, and a context that quietly
+        became a quarter of what was asked for is its own support thread.
 
         Unlike ``_apu_ram_shortfall_message`` this prices the context, not just the
         weights. That helper leaves KV out because context auto-reduces on its path, so
@@ -15571,10 +15587,11 @@ class LlamaCppBackend:
                         # No GPU on Metal: the branches above are skipped and the context
                         # stays at native, over-committing unified memory (#5118, #6529).
                         # Cap with the same fit math; Auto shrinks to the cap, and an
-                        # explicit request above it is refused rather than launched. --fit
-                        # is no backstop on this path: it spills layers to the host, which
-                        # is the same pool, so the over-commit survives it and takes the
-                        # machine down. See _metal_context_overcommit_message.
+                        # explicit request above it is refused rather than launched.
+                        # "--fit on" stays as a backstop, but not one this can lean on:
+                        # llama.cpp sizes its reduction from ggml-metal's free-memory
+                        # report, which knows nothing about Studio's own footprint or the
+                        # wired limit. See _metal_context_overcommit_message.
                         native_ctx_for_cap = self._context_length or effective_ctx
                         # Only a ceiling backed by a real KV estimate may refuse; the 4096
                         # fallback below is a guess and would block working loads.
@@ -15624,12 +15641,25 @@ class LlamaCppBackend:
                             max_available_ctx = min(4096, native_ctx_for_cap)
                         if not explicit_ctx:
                             effective_ctx = max_available_ctx
-                        elif _apple_measured_ceiling is not None and not _caller_owns_budget:
+                        elif (
+                            _apple_measured_ceiling is not None
+                            and not _caller_owns_budget
+                            and not _paravirtual_cpu_forced
+                        ):
                             # Exempt for the reason the other two Metal guards are: a
                             # manual load with a fixed layer count is the user taking the
                             # memory budget over, and it is read off the request so the
                             # paravirtual CPU pin (which rewrites Auto to manual/0) cannot
                             # make a plain Auto load look caller-owned.
+                            #
+                            # The virtualised device is exempt for the opposite reason:
+                            # that pin puts the whole load on CPU behind --device none, so
+                            # it allocates no Metal memory at all and this budget is the
+                            # wrong yardstick for it. Refusing there would break loads
+                            # that work today on a Mac VM, and the message would describe
+                            # a GPU the launch never touches. What an oversized CPU load
+                            # does risk is host RAM, which _host_offload_shortfall_message
+                            # already covers, priced against the pool it really draws on.
                             _metal_ctx_refusal = self._metal_context_overcommit_message(
                                 effective_ctx,
                                 _apple_measured_ceiling,

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -7252,6 +7252,69 @@ class LlamaCppBackend:
             "UNSLOTH_ALLOW_HOST_OFFLOAD=1 to load it anyway."
         )
 
+    METAL_CTX_OVERCOMMIT_ENV = "UNSLOTH_ALLOW_METAL_CTX_OVERCOMMIT"
+
+    @staticmethod
+    def _metal_context_overcommit_message(
+        requested_ctx: int,
+        max_available_ctx: int,
+        cache_type_kv: Optional[str] = None,
+    ) -> Optional[str]:
+        """Refusal when a hand-set context exceeds what unified memory holds (else None).
+
+        The Metal branch of the placement code already works out the largest context
+        that fits, but only Auto was ever moved to it: an explicit request was passed
+        through verbatim on the theory that "--fit on" is a backstop. It is not one
+        here. --fit flexes -ngl to spill layers to the host, and on unified memory the
+        host is the same pool, so the spill frees nothing. The launch over-commits, and
+        because a Mac has nothing to fall back on it takes the system down with a kernel
+        panic rather than returning an out-of-memory error the way a discrete GPU does
+        (r/unsloth, M1 Max 32 GB, Qwen3.8-27B-UD-Q4_K_XL at a hand-set context).
+
+        Unlike ``_apu_ram_shortfall_message`` this prices the context, not just the
+        weights. That helper leaves KV out because context auto-reduces on its path, so
+        counting it would refuse loads that would have succeeded. On this path the
+        explicit request is exactly what does not auto-reduce, so the KV and compute
+        buffers it implies are the bytes that do the damage.
+
+        Callers pass a ceiling they measured with a real KV estimate. The 4096 floor the
+        branch falls back to when KV cannot be sized is a guess, not a measurement, and
+        refusing against it would block contexts that load fine today.
+
+        UNSLOTH_ALLOW_METAL_CTX_OVERCOMMIT=1 abstains, matching the host-offload opt-out,
+        though the failure mode it re-enables is the whole machine rather than one app.
+        """
+        if requested_ctx <= 0 or max_available_ctx <= 0:
+            return None
+        if requested_ctx <= max_available_ctx:
+            return None
+        # the user's own opt-out, so read the real environment, not the curated child env
+        if os.environ.get(LlamaCppBackend.METAL_CTX_OVERCOMMIT_ENV, "").strip().lower() in (
+            "1",
+            "true",
+            "yes",
+        ):
+            logger.info(
+                "%s set: launching at a context unified memory is not sized for.",
+                LlamaCppBackend.METAL_CTX_OVERCOMMIT_ENV,
+            )
+            return None
+        kv_hint = (
+            " Setting the KV cache to q8_0 roughly halves what the context costs."
+            if (cache_type_kv or "f16").strip().lower() in ("f16", "fp16", "")
+            else ""
+        )
+        return (
+            f"A context of {requested_ctx:,} tokens does not fit in this Mac's unified "
+            f"memory with this model. The largest that fits is {max_available_ctx:,} "
+            "tokens. The GPU and the rest of the system share one pool here, so there is "
+            "nothing to offload to, and the load would bring the machine down instead of "
+            f"reporting an error. Lower the context to {max_available_ctx:,} or less, "
+            "leave it on Auto, or use a more quantized GGUF."
+            f"{kv_hint} Set "
+            f"{LlamaCppBackend.METAL_CTX_OVERCOMMIT_ENV}=1 to load it anyway."
+        )
+
     # Skip the wait when the last kill is older than this; the driver has
     # already reclaimed the prior process's allocations.
     _VRAM_SETTLE_WINDOW_S: float = 15.0
@@ -13341,7 +13404,7 @@ class LlamaCppBackend:
 
             # Read before the pin below rewrites every placement, Auto included, to
             # manual/0. Owning the memory budget is a property of what was asked for,
-            # and the two Metal context guards further down skip themselves on it.
+            # and the three Metal context guards further down skip themselves on it.
             _caller_owns_budget = gpu_memory_mode == "manual" and gpu_layers >= 0
 
             # A virtualised Apple GPU corrupts every offloaded layer, so pin GGUF
@@ -14225,6 +14288,12 @@ class LlamaCppBackend:
                 # Auto dropped the drafter because only the target fit. Bound before the
                 # try: the launch below reads it either way.
                 _spec_dropped_no_vram = False
+                # Metal unified-memory refusal for a hand-set context, raised AFTER this
+                # block rather than inside it: the `except Exception` below turns any raise
+                # into "GPU selection failed" and then restores the original request, which
+                # is the very over-commit being refused. Carrying the message out survives
+                # that arm, and the ceiling it names was measured before the throw.
+                _metal_ctx_refusal: Optional[str] = None
                 try:
                     gguf_size = self._get_gguf_size_bytes(model_path)
                     # Include GPU-loaded mmproj in the fit budget (#5825).
@@ -15501,9 +15570,15 @@ class LlamaCppBackend:
                     elif _apple_budget_mib > 0 and effective_ctx > 0:
                         # No GPU on Metal: the branches above are skipped and the context
                         # stays at native, over-committing unified memory (#5118, #6529).
-                        # Cap with the same fit math (--fit on stays as a backstop); only
-                        # auto context shrinks, explicit is honored.
+                        # Cap with the same fit math; Auto shrinks to the cap, and an
+                        # explicit request above it is refused rather than launched. --fit
+                        # is no backstop on this path: it spills layers to the host, which
+                        # is the same pool, so the over-commit survives it and takes the
+                        # machine down. See _metal_context_overcommit_message.
                         native_ctx_for_cap = self._context_length or effective_ctx
+                        # Only a ceiling backed by a real KV estimate may refuse; the 4096
+                        # fallback below is a guess and would block working loads.
+                        _apple_measured_ceiling: Optional[int] = None
                         # Reserve the flat MTP fraction up front like the discrete
                         # _pin_fraction, so an unsized MTP draft (e.g. Qwen3.6-MTP, #6529)
                         # can't over-commit. No-op when MTP is off; exclusive with the
@@ -15534,17 +15609,32 @@ class LlamaCppBackend:
                             ) / (1024 * 1024)
                             # Fit returns the request unchanged when it fits OR weights
                             # exceed budget; only the latter over-commits, so floor to 4096.
-                            max_available_ctx = (
-                                cap
-                                if _cap_footprint_mib <= _apple_fit_budget_mib
-                                else min(4096, native_ctx_for_cap)
-                            )
+                            if _cap_footprint_mib <= _apple_fit_budget_mib:
+                                max_available_ctx = cap
+                                _apple_measured_ceiling = cap
+                            else:
+                                # Weights alone exceed the budget, so the fit returned the
+                                # request untouched and no context is really available.
+                                # Floor for the UI, but do not refuse against a number the
+                                # fit never vouched for.
+                                max_available_ctx = min(4096, native_ctx_for_cap)
                         else:
                             # No KV estimate: mirror the discrete file-size-only fallback
                             # and floor to 4096 rather than launch at native and over-commit.
                             max_available_ctx = min(4096, native_ctx_for_cap)
                         if not explicit_ctx:
                             effective_ctx = max_available_ctx
+                        elif _apple_measured_ceiling is not None and not _caller_owns_budget:
+                            # Exempt for the reason the other two Metal guards are: a
+                            # manual load with a fixed layer count is the user taking the
+                            # memory budget over, and it is read off the request so the
+                            # paravirtual CPU pin (which rewrites Auto to manual/0) cannot
+                            # make a plain Auto load look caller-owned.
+                            _metal_ctx_refusal = self._metal_context_overcommit_message(
+                                effective_ctx,
+                                _apple_measured_ceiling,
+                                cache_type_kv,
+                            )
 
                     # Prefer fewer serving slots on GPU over --fit on offload: when the extra
                     # --parallel slots push the footprint past the pin budget, llama-server
@@ -15643,6 +15733,13 @@ class LlamaCppBackend:
                     _placement_verdict_partial = False
                     tp_tensor_split = None
                     effective_ctx = requested_ctx  # fall back to original
+
+                # A hand-set context unified memory cannot hold. Raised here so the
+                # handler above cannot turn it back into the launch it refuses, and
+                # ahead of the Vulkan and APU checks because those describe hardware
+                # this branch has already established is not present.
+                if _metal_ctx_refusal:
+                    raise RuntimeError(_metal_ctx_refusal)
 
                 # An unenumerated explicit Vulkan ordinal can't be pinned; fail loudly
                 # instead of fitting onto an unselected device. Clear the raw selection

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -14313,10 +14313,13 @@ class LlamaCppBackend:
                 # try: the launch below reads it either way.
                 _spec_dropped_no_vram = False
                 # Metal unified-memory refusal for a hand-set context, raised AFTER this
-                # block rather than inside it: the `except Exception` below turns any raise
-                # into "GPU selection failed" and then restores the original request, which
-                # is the very over-commit being refused. Carrying the message out survives
-                # that arm, and the ceiling it names was measured before the throw.
+                # block rather than inside it: the `except Exception` below swallows any
+                # raise into the placement fallback and then restores the original request,
+                # which is the very over-commit being refused. Carrying the message out
+                # survives that arm, and the ceiling it names was measured before the throw.
+                # (Worded around the handler's own log line on purpose: test_tp_vision_
+                # regression string-searches this function's source for it to check
+                # statement ordering, and quoting it here moved the match.)
                 _metal_ctx_refusal: Optional[str] = None
                 try:
                     gguf_size = self._get_gguf_size_bytes(model_path)

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -1986,6 +1986,14 @@ _CTX_FIT_VRAM_FRACTION = 0.97
 # 0.85 MLX uses in mlx_inference.py (_configure_memory_limits); not kept in sync.
 _APPLE_UNIFIED_MEMORY_FRACTION = 0.85
 
+# _fit_context_to_vram's own floor, and llama.cpp's: common_params.fit_params_min_ctx
+# is 4096, so neither Studio's fit nor "--fit on" will price a context below it. Any
+# 4096 the fit hands back is therefore that floor rather than a measurement, and the
+# Metal branch re-prices from _FIT_FLOOR_MIN_CTX (the 256 alignment step the search
+# rounds to) to find out whether anything at all fits before it trusts the number.
+_FIT_MIN_CTX = 4096
+_FIT_FLOOR_MIN_CTX = 256
+
 # How far amd-smi's total VRAM may sit from HIP's before the two are reporting
 # different memory scopes rather than one pool (an APU carve-out against the GTT
 # pool, a partition against the whole card). Same 10% margin
@@ -15603,12 +15611,14 @@ class LlamaCppBackend:
                         _apple_fit_budget_mib = int(
                             _apple_budget_mib * max(0.0, 1.0 - _flat_mtp_reserve)
                         )
-                        if self._can_estimate_kv():
-                            cap = self._fit_context_to_vram(
-                                native_ctx_for_cap,
+
+                        def _apple_ctx_fit(target: int, min_ctx: int) -> int:
+                            return self._fit_context_to_vram(
+                                target,
                                 _apple_fit_budget_mib,
                                 model_size_fit,
                                 cache_type_kv,
+                                min_ctx = min_ctx,
                                 swa_full = swa_full,
                                 n_parallel = n_parallel,
                                 kv_unified = planned_kv_unified,
@@ -15621,20 +15631,43 @@ class LlamaCppBackend:
                                 pooled = True,
                                 total_mib = None,
                             )
-                            _cap_footprint_mib = (
-                                model_size_fit + _kv_bytes(cap) + _mtp_bytes(cap) + _cc_bytes(cap)
+
+                        def _apple_footprint_mib(ctx: int) -> float:
+                            return (
+                                model_size_fit + _kv_bytes(ctx) + _mtp_bytes(ctx) + _cc_bytes(ctx)
                             ) / (1024 * 1024)
+
+                        if self._can_estimate_kv():
+                            cap = _apple_ctx_fit(native_ctx_for_cap, _FIT_MIN_CTX)
+                            _cap_footprint_mib = _apple_footprint_mib(cap)
                             # Fit returns the request unchanged when it fits OR weights
                             # exceed budget; only the latter over-commits, so floor to 4096.
                             if _cap_footprint_mib <= _apple_fit_budget_mib:
                                 max_available_ctx = cap
                                 _apple_measured_ceiling = cap
                             else:
-                                # Weights alone exceed the budget, so the fit returned the
-                                # request untouched and no context is really available.
-                                # Floor for the UI, but do not refuse against a number the
-                                # fit never vouched for.
-                                max_available_ctx = min(4096, native_ctx_for_cap)
+                                # Two states land here and only one of them is unmeasurable.
+                                # Weights alone over budget: the fit returned the request
+                                # untouched, priced nothing, and no context can rescue it.
+                                # Or the weights do fit and it is the helper's own 4096
+                                # floor that does not -- there 4096 is a floor, not a
+                                # measurement, so re-price under it before concluding
+                                # nothing was measured. Without that pass a Mac with room
+                                # for no tested context skipped the refusal for every
+                                # explicit request and reached llama-server, whose --fit
+                                # cannot reduce below fit_params_min_ctx (4096) either, so
+                                # the backstop had nothing left to give.
+                                _floor_cap = _apple_ctx_fit(native_ctx_for_cap, _FIT_FLOOR_MIN_CTX)
+                                if (
+                                    _floor_cap < cap
+                                    and _apple_footprint_mib(_floor_cap) <= _apple_fit_budget_mib
+                                ):
+                                    max_available_ctx = _floor_cap
+                                    _apple_measured_ceiling = _floor_cap
+                                else:
+                                    # Floor for the UI, but do not refuse against a number
+                                    # the fit never vouched for.
+                                    max_available_ctx = min(4096, native_ctx_for_cap)
                         else:
                             # No KV estimate: mirror the discrete file-size-only fallback
                             # and floor to 4096 rather than launch at native and over-commit.
@@ -15660,6 +15693,25 @@ class LlamaCppBackend:
                             # a GPU the launch never touches. What an oversized CPU load
                             # does risk is host RAM, which _host_offload_shortfall_message
                             # already covers, priced against the pool it really draws on.
+                            #
+                            # The fit above is sized through the model's native length, so
+                            # on its own it caps the ceiling there and refuses every request
+                            # past it as an over-commit -- including one this Mac has the
+                            # memory for. Nothing clamps a request to the native length on
+                            # the way in (the Extra Arguments box takes a raw "--ctx-size"
+                            # and even suggests "--rope-scaling yarn"), and llama.cpp builds
+                            # the context at the full -c, only capping the per-slot value
+                            # afterwards, so the request really is what gets allocated.
+                            # Re-price through it, and only adopt the answer when it is one
+                            # the budget vouches for.
+                            if effective_ctx > native_ctx_for_cap:
+                                _extended_ceiling = _apple_ctx_fit(effective_ctx, _FIT_MIN_CTX)
+                                if (
+                                    _extended_ceiling > _apple_measured_ceiling
+                                    and _apple_footprint_mib(_extended_ceiling)
+                                    <= _apple_fit_budget_mib
+                                ):
+                                    _apple_measured_ceiling = _extended_ceiling
                             _metal_ctx_refusal = self._metal_context_overcommit_message(
                                 effective_ctx,
                                 _apple_measured_ceiling,

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -15757,10 +15757,7 @@ class LlamaCppBackend:
                                 effective_ctx > native_ctx_for_cap
                             ):
                                 _extended_ceiling = _apple_ctx_fit(effective_ctx, _FIT_MIN_CTX)
-                                if (
-                                    _apple_footprint_mib(_extended_ceiling)
-                                    > _apple_fit_budget_mib
-                                ):
+                                if _apple_footprint_mib(_extended_ceiling) > _apple_fit_budget_mib:
                                     # 4096 is the helper's floor, not a measurement, and
                                     # the cap above already has to re-price under it for
                                     # the same reason. It bites here too whenever the

--- a/studio/backend/main.py
+++ b/studio/backend/main.py
@@ -1683,6 +1683,13 @@ async def health_check(request: Request):
 
     platform_map = {"darwin": "mac", "win32": "windows", "linux": "linux"}
     device_type = platform_map.get(sys.platform, sys.platform)
+    # Reported alongside device_type, not folded into it: "mac" is every Darwin host,
+    # and an Intel Mac with a discrete GPU spills to system RAM like a PC, while on
+    # Apple Silicon there is one pool and nowhere to spill. The UI words its memory
+    # warnings from this. Same gate the Metal context budget uses, and a pure platform
+    # check, so it costs nothing on a health poll.
+    from utils.hardware import is_apple_silicon
+
     authed = {
         **base,
         "version": UNSLOTH_VERSION,
@@ -1703,6 +1710,7 @@ async def health_check(request: Request):
         # cannot come from a different detection pass than the reason beside it.
         authed["chat_only_detail"] = snapshot[2]
         authed["device_type"] = device_type
+        authed["apple_silicon"] = is_apple_silicon()
         # base predates the bearer await; never ship "detecting" beside a measurement.
         authed.pop("hardware_detecting", None)
         # Same for the deferred marker: the client reads it first and would keep the old reason.

--- a/studio/backend/main.py
+++ b/studio/backend/main.py
@@ -1683,11 +1683,10 @@ async def health_check(request: Request):
 
     platform_map = {"darwin": "mac", "win32": "windows", "linux": "linux"}
     device_type = platform_map.get(sys.platform, sys.platform)
-    # Reported alongside device_type, not folded into it: "mac" is every Darwin host,
-    # and an Intel Mac with a discrete GPU spills to system RAM like a PC, while on
-    # Apple Silicon there is one pool and nowhere to spill. The UI words its memory
-    # warnings from this. Same gate the Metal context budget uses, and a pure platform
-    # check, so it costs nothing on a health poll.
+    # Alongside device_type, not folded into it: "mac" is every Darwin host, and an Intel
+    # Mac with a discrete GPU spills to system RAM like a PC while Apple Silicon has one
+    # pool and nowhere to spill. The UI words its memory warnings from this. Same gate the
+    # Metal context budget uses, and a pure platform check, so a health poll pays nothing.
     from utils.hardware import is_apple_silicon
 
     authed = {

--- a/studio/backend/tests/test_health_reports_unified_memory.py
+++ b/studio/backend/tests/test_health_reports_unified_memory.py
@@ -1,0 +1,117 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""/api/health reports unified memory separately from the platform.
+
+`device_type` is "mac" for every Darwin host, which is not the question the chat and
+model-picker context warnings need answered. An Intel Mac with a discrete GPU spills an
+oversized context to system RAM like any PC; on Apple Silicon there is one pool and
+nowhere to spill, so the same over-commit takes the machine down. Wording both from
+`device_type === "mac"` told Intel Mac users the opposite of what happens to them.
+
+So the payload carries `apple_silicon` alongside `device_type`, gated on the same
+`is_apple_silicon()` the Metal context budget uses, and the UI words the warning from
+it. It rides with `device_type` because the frontend treats that field as the marker of
+an authoritative reply: a provisional or unauthenticated response carries neither, and
+absent reads as false, which is the PC wording that was already correct there.
+
+CPU-only, no network, no GPU, no weights.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_BACKEND = Path(__file__).resolve().parent.parent
+if str(_BACKEND) not in sys.path:
+    sys.path.insert(0, str(_BACKEND))
+
+import utils.hardware as hardware_pkg  # noqa: E402
+
+
+def _health(
+    monkeypatch,
+    *,
+    apple_silicon: bool,
+    authed: bool = True,
+) -> dict:
+    """Drive /api/health and return the body."""
+    import auth.authentication as _authmod
+    import main as main_mod
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    # health_check does `from utils.hardware import is_apple_silicon` at call time, so
+    # the package attribute is the one it reads.
+    monkeypatch.setattr(hardware_pkg, "is_apple_silicon", lambda: apple_silicon)
+
+    hw_mod = main_mod._hw_module
+    monkeypatch.setattr(hw_mod, "DEVICE", hw_mod.DeviceType.CPU, raising = False)
+    monkeypatch.setattr(hw_mod, "CHAT_ONLY", False, raising = False)
+    monkeypatch.setattr(hw_mod, "CHAT_ONLY_REASON", None, raising = False)
+    monkeypatch.setattr(main_mod, "_torch_warm_in_progress", lambda: False)
+    was_complete = hw_mod.DETECTION_COMPLETE.is_set()
+    hw_mod.DETECTION_COMPLETE.set()
+
+    async def _subject(_creds):
+        if not authed:
+            from fastapi import HTTPException
+            raise HTTPException(status_code = 401, detail = "no")
+        return "tester"
+
+    monkeypatch.setattr(_authmod, "get_current_subject", _subject)
+    app = FastAPI()
+    app.add_api_route("/api/health", main_mod.health_check, methods = ["GET"])
+    try:
+        with TestClient(app) as client:
+            headers = {"Authorization": "Bearer probe"} if authed else {}
+            return client.get("/api/health", headers = headers).json()
+    finally:
+        if not was_complete:
+            hw_mod.DETECTION_COMPLETE.clear()
+
+
+def test_apple_silicon_is_reported(monkeypatch):
+    body = _health(monkeypatch, apple_silicon = True)
+    assert body["apple_silicon"] is True
+    assert body["device_type"]
+
+
+def test_every_other_host_reports_false(monkeypatch):
+    """Including an Intel Mac, which is the case device_type cannot distinguish and the
+    one the old wording was already right about."""
+    body = _health(monkeypatch, apple_silicon = False)
+    assert body["apple_silicon"] is False
+
+
+def test_it_rides_with_device_type(monkeypatch):
+    """Both are authed-only. The frontend keys `fetched` on device_type and reads
+    apple_silicon on the same terms, so a reply may not carry one without the other or
+    the store caches a verdict it was never told."""
+    for apple in (True, False):
+        body = _health(monkeypatch, apple_silicon = apple)
+        assert ("apple_silicon" in body) == ("device_type" in body)
+
+
+def test_an_unauthenticated_reply_carries_neither(monkeypatch):
+    """It fingerprints the host, like device_type, so it stays behind the bearer."""
+    body = _health(monkeypatch, apple_silicon = True, authed = False)
+    assert "device_type" not in body
+    assert "apple_silicon" not in body
+
+
+def test_the_gate_is_the_one_the_metal_budget_uses(monkeypatch):
+    """Not a second definition of Apple Silicon. If these ever diverge, the UI starts
+    describing a memory model the loader is not enforcing."""
+    import inspect
+
+    import main as main_mod
+    from core.inference.llama_cpp import LlamaCppBackend
+
+    assert "from utils.hardware import is_apple_silicon" in inspect.getsource(main_mod.health_check)
+    assert "from utils.hardware import is_apple_silicon" in inspect.getsource(
+        LlamaCppBackend._apple_metal_memory_budget_bytes
+    )

--- a/studio/backend/tests/test_health_reports_unified_memory.py
+++ b/studio/backend/tests/test_health_reports_unified_memory.py
@@ -10,10 +10,10 @@ nowhere to spill, so the same over-commit takes the machine down. Wording both f
 `device_type === "mac"` told Intel Mac users the opposite of what happens to them.
 
 So the payload carries `apple_silicon` alongside `device_type`, gated on the same
-`is_apple_silicon()` the Metal context budget uses, and the UI words the warning from
-it. It rides with `device_type` because the frontend treats that field as the marker of
-an authoritative reply: a provisional or unauthenticated response carries neither, and
-absent reads as false, which is the PC wording that was already correct there.
+`is_apple_silicon()` the Metal context budget uses. It rides with `device_type` because
+the frontend treats that field as the marker of an authoritative reply: a provisional or
+unauthenticated response carries neither, and absent reads as false, the PC wording that
+was already correct there.
 
 CPU-only, no network, no GPU, no weights.
 """
@@ -35,18 +35,18 @@ import utils.hardware as hardware_pkg  # noqa: E402
 def _restore_real_logging_modules() -> dict:
     """Undo the stubs other test files install, so `main` can be imported.
 
-    Several files in this tree put a plain module named `loggers` and a minimal
-    `structlog` into sys.modules to avoid the real dependency, and pytest runs the whole
-    tree in one process. `main` does `from loggers.config import LogConfig`, and that
-    module needs both the real package (a plain module cannot satisfy `loggers.config`)
-    and real structlog (it annotates with `structlog.BoundLogger`). So whichever file
-    sorts first decides whether this one can import main at all. Predates this change:
-    the existing MLX-repair health test hits the same wall in a full-suite run.
+    Several files in this tree put a plain `loggers` module and a minimal `structlog` into
+    sys.modules to avoid the real dependency, and pytest runs the whole tree in one
+    process. `main` does `from loggers.config import LogConfig`, which needs both the real
+    package (a plain module cannot satisfy `loggers.config`) and real structlog (it
+    annotates with `structlog.BoundLogger`), so whichever file sorts first decides whether
+    this one can import main at all. Predates this change: the existing MLX-repair health
+    test hits the same wall in a full-suite run.
 
-    Dropping the stubs is safe in both directions. The real `loggers` package sits in
-    this backend and exports the same `get_logger`, so a later test expecting the stub
-    gets a working superset. If real structlog is genuinely absent the caller skips
-    rather than failing, since that is an environment gap and not a defect here.
+    Dropping the stubs is safe both ways: the real `loggers` package sits in this backend
+    and exports the same `get_logger`, so a later test expecting the stub gets a working
+    superset. If real structlog is genuinely absent the caller skips, since that is an
+    environment gap and not a defect here.
     """
     removed = {}
     stub = sys.modules.get("loggers")
@@ -124,8 +124,8 @@ def test_every_other_host_reports_false(monkeypatch):
 
 def test_it_rides_with_device_type(monkeypatch):
     """Both are authed-only. The frontend keys `fetched` on device_type and reads
-    apple_silicon on the same terms, so a reply may not carry one without the other or
-    the store caches a verdict it was never told."""
+    apple_silicon on the same terms, so a reply carrying one without the other would make
+    the store cache a verdict it was never told."""
     for apple in (True, False):
         body = _health(monkeypatch, apple_silicon = apple)
         assert ("apple_silicon" in body) == ("device_type" in body)

--- a/studio/backend/tests/test_health_reports_unified_memory.py
+++ b/studio/backend/tests/test_health_reports_unified_memory.py
@@ -32,6 +32,35 @@ if str(_BACKEND) not in sys.path:
 import utils.hardware as hardware_pkg  # noqa: E402
 
 
+def _restore_real_logging_modules() -> None:
+    """Undo the stubs other test files install, so `main` can be imported.
+
+    Several files in this tree put a plain module named `loggers` and a minimal
+    `structlog` into sys.modules to avoid the real dependency, and pytest runs the whole
+    tree in one process. `main` does `from loggers.config import LogConfig`, and that
+    module needs both the real package (a plain module cannot satisfy `loggers.config`)
+    and real structlog (it annotates with `structlog.BoundLogger`). So whichever file
+    sorts first decides whether this one can import main at all. Predates this change:
+    the existing MLX-repair health test hits the same wall in a full-suite run.
+
+    Dropping the stubs is safe in both directions. The real `loggers` package sits in
+    this backend and exports the same `get_logger`, so a later test expecting the stub
+    gets a working superset. If real structlog is genuinely absent the caller skips
+    rather than failing, since that is an environment gap and not a defect here.
+    """
+    stub = sys.modules.get("loggers")
+    if stub is not None and not hasattr(stub, "__path__"):
+        for name in [n for n in sys.modules if n == "loggers" or n.startswith("loggers.")]:
+            del sys.modules[name]
+    stub = sys.modules.get("structlog")
+    if stub is not None and not hasattr(stub, "BoundLogger"):
+        del sys.modules["structlog"]
+    try:
+        import structlog  # noqa: F401
+    except Exception:
+        pytest.skip("real structlog is required to import main")
+
+
 def _health(
     monkeypatch,
     *,
@@ -39,6 +68,7 @@ def _health(
     authed: bool = True,
 ) -> dict:
     """Drive /api/health and return the body."""
+    _restore_real_logging_modules()
     import auth.authentication as _authmod
     import main as main_mod
     from fastapi import FastAPI

--- a/studio/backend/tests/test_health_reports_unified_memory.py
+++ b/studio/backend/tests/test_health_reports_unified_memory.py
@@ -32,7 +32,7 @@ if str(_BACKEND) not in sys.path:
 import utils.hardware as hardware_pkg  # noqa: E402
 
 
-def _restore_real_logging_modules() -> None:
+def _restore_real_logging_modules() -> dict:
     """Undo the stubs other test files install, so `main` can be imported.
 
     Several files in this tree put a plain module named `loggers` and a minimal
@@ -48,17 +48,20 @@ def _restore_real_logging_modules() -> None:
     gets a working superset. If real structlog is genuinely absent the caller skips
     rather than failing, since that is an environment gap and not a defect here.
     """
+    removed = {}
     stub = sys.modules.get("loggers")
     if stub is not None and not hasattr(stub, "__path__"):
         for name in [n for n in sys.modules if n == "loggers" or n.startswith("loggers.")]:
-            del sys.modules[name]
+            removed[name] = sys.modules.pop(name)
     stub = sys.modules.get("structlog")
     if stub is not None and not hasattr(stub, "BoundLogger"):
-        del sys.modules["structlog"]
+        removed["structlog"] = sys.modules.pop("structlog")
     try:
         import structlog  # noqa: F401
     except Exception:
+        sys.modules.update(removed)
         pytest.skip("real structlog is required to import main")
+    return removed
 
 
 def _health(
@@ -68,7 +71,7 @@ def _health(
     authed: bool = True,
 ) -> dict:
     """Drive /api/health and return the body."""
-    _restore_real_logging_modules()
+    _swapped_modules = _restore_real_logging_modules()
     import auth.authentication as _authmod
     import main as main_mod
     from fastapi import FastAPI
@@ -102,6 +105,8 @@ def _health(
     finally:
         if not was_complete:
             hw_mod.DETECTION_COMPLETE.clear()
+        # Put back exactly what was displaced, so nothing downstream inherits this.
+        sys.modules.update(_swapped_modules)
 
 
 def test_apple_silicon_is_reported(monkeypatch):

--- a/studio/backend/tests/test_metal_explicit_context_guard.py
+++ b/studio/backend/tests/test_metal_explicit_context_guard.py
@@ -1,0 +1,287 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""A hand-set context above what unified memory holds must be refused, not launched.
+
+The Metal branch of load_model already works out the largest context that fits, but
+only Auto was ever moved to it: an explicit request was passed through verbatim on the
+theory that "--fit on" is a backstop. It is not one here. --fit flexes -ngl to spill
+layers to the host, and on unified memory the host is the same pool, so the spill frees
+nothing and the launch over-commits. A discrete GPU answers that with an out-of-memory
+error; a Mac has nothing to fall back on and panics the whole machine, which is what an
+M1 Max 32 GB hit on Qwen3.8-27B-UD-Q4_K_XL as soon as the context was set by hand.
+
+So the ceiling the branch computes now gates the explicit request too, and the refusal
+names it. Two things it deliberately does not do: refuse against the 4096 fallback the
+branch uses when KV cannot be sized (a guess, not a measurement, and refusing on it
+would block contexts that load fine today), and refuse a manual load with a fixed layer
+count, which is the user taking the memory budget over, as the other two Metal guards
+already treat it.
+"""
+
+from __future__ import annotations
+
+import struct
+import subprocess
+import sys
+import types as _types
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+_BACKEND_DIR = str(Path(__file__).resolve().parent.parent)
+if _BACKEND_DIR not in sys.path:
+    sys.path.insert(0, _BACKEND_DIR)
+
+_loggers_stub = _types.ModuleType("loggers")
+_loggers_stub.get_logger = lambda name: __import__("logging").getLogger(name)
+sys.modules.setdefault("loggers", _loggers_stub)
+_structlog_stub = _types.ModuleType("structlog")
+_structlog_stub.get_logger = lambda *a, **k: __import__("logging").getLogger("structlog")
+sys.modules.setdefault("structlog", _structlog_stub)
+if not hasattr(sys.modules["structlog"], "get_logger"):
+    sys.modules["structlog"].get_logger = _structlog_stub.get_logger
+
+if "jwt" not in sys.modules:
+    try:
+        import jwt  # noqa: F401
+    except Exception:
+        _jwt_stub = _types.ModuleType("jwt")
+        _jwt_stub.decode = lambda *a, **k: {}
+        _jwt_stub.ExpiredSignatureError = type("ExpiredSignatureError", (Exception,), {})
+        _jwt_stub.InvalidTokenError = type("InvalidTokenError", (Exception,), {})
+        sys.modules["jwt"] = _jwt_stub
+
+from core.inference.llama_cpp import GgufLoadIntent, LlamaCppBackend  # noqa: E402
+
+_message = LlamaCppBackend._metal_context_overcommit_message
+_ENV = LlamaCppBackend.METAL_CTX_OVERCOMMIT_ENV
+_REAL_POPEN = subprocess.Popen
+
+# What the stubbed fit reports as the largest context that fits, and the native length
+# of the GGUF under test. Anything between them is a context the user can type into the
+# box today and the machine cannot hold.
+CEILING = 8192
+NATIVE = 262144
+
+
+@pytest.fixture(autouse = True)
+def _no_opt_out(monkeypatch):
+    """The opt-out is a real environment read, so a host that has it set must not
+    silently turn every refusal test green."""
+    monkeypatch.delenv(_ENV, raising = False)
+
+
+def _write_gguf(path: Path) -> Path:
+    """The smallest header load_model will parse."""
+
+    def string(value: str) -> bytes:
+        data = value.encode()
+        return struct.pack("<Q", len(data)) + data
+
+    metadata = string("general.architecture") + struct.pack("<I", 8) + string("llama")
+    path.write_bytes(struct.pack("<IIQQ", 0x46554747, 3, 0, 1) + metadata)
+    return path
+
+
+def _ctx_values(cmd) -> list[str]:
+    """Every context value in argv, in order. llama.cpp takes the last."""
+    values = []
+    for i, token in enumerate(cmd):
+        if token in ("-c", "--ctx-size"):
+            values.append(cmd[i + 1] if i + 1 < len(cmd) else None)
+        elif token.startswith("-c=") or token.startswith("--ctx-size="):
+            values.append(token.split("=", 1)[1])
+    return values
+
+
+def _launch(
+    tmp_path,
+    monkeypatch,
+    *,
+    n_ctx,
+    metal = True,
+    can_estimate_kv = True,
+    gpu_memory_mode = "auto",
+    gpu_layers = -1,
+    extra_args = None,
+):
+    """Drive the real load_model with no GPU enumerated (the Metal condition).
+
+    The KV estimate is a flat 1 KiB per token and the compute buffer is zeroed, so the
+    footprint check the branch runs before trusting its own ceiling passes on the tiny
+    stub GGUF and the ceiling under test is the one the fit returns.
+    """
+    monkeypatch.setattr(
+        LlamaCppBackend,
+        "_apple_metal_memory_budget_bytes",
+        staticmethod(lambda: 9 * 1024**3 if metal else 0),
+    )
+    backend = LlamaCppBackend()
+    backend._get_gpu_memory = lambda _binary = None, **_kw: []
+    backend._get_gpu_free_memory = lambda _binary = None, **_kw: []
+    backend._read_gguf_metadata = lambda _path: None
+    backend._can_estimate_kv = lambda: can_estimate_kv
+    backend._estimate_kv_cache_bytes = lambda ctx, *a, **k: int(ctx) * 1024
+    backend._compute_buffer_ctx_bytes = lambda *a, **k: 0
+    backend._fit_context_to_vram = lambda native, *a, **k: min(int(native), CEILING)
+    backend._get_gguf_size_bytes = lambda _path: 1024
+    backend._mmproj_vram_bytes = lambda _path: 0
+    backend._resolve_launch_mmproj_path = lambda **kwargs: None
+    backend._apu_ram_shortfall_message = lambda *a, **k: None
+    backend._amd_apu_wants_unified_memory = lambda *a, **k: False
+    backend._find_llama_server_binary = lambda include_denied = False: "/fake/llama-server"
+    backend._is_vulkan_backend = lambda _binary = None: False
+    backend._wait_for_health = lambda timeout: True
+    backend._detect_audio_type_strict = lambda: None
+    backend._apply_detected_audio = lambda _detected: True
+    backend._context_length = NATIVE
+
+    captured = {}
+
+    def fake_popen(cmd, **kwargs):
+        if not cmd or str(cmd[0]) != "/fake/llama-server":
+            return _REAL_POPEN(cmd, **kwargs)
+        captured["cmd"] = list(cmd)
+        return type(
+            "Process",
+            (),
+            {
+                "pid": 123,
+                "stdout": (),
+                "poll": lambda self: None,
+                "terminate": lambda self: None,
+                "wait": lambda self, timeout = None: 0,
+                "kill": lambda self: None,
+            },
+        )()
+
+    with patch.object(subprocess, "Popen", side_effect = fake_popen):
+        backend.load_model(
+            GgufLoadIntent(
+                gguf_path = str(_write_gguf(tmp_path / "model.gguf")),
+                model_identifier = "test",
+                n_ctx = n_ctx,
+                gpu_memory_mode = gpu_memory_mode,
+                gpu_layers = gpu_layers,
+                extra_args = extra_args,
+            )
+        )
+    return captured
+
+
+class TestTheRefusalItself:
+    """The message, in isolation from where it is raised."""
+
+    def test_a_context_above_the_ceiling_is_refused(self):
+        msg = _message(32768, CEILING)
+        assert msg is not None
+        # Both numbers, so the user can act on it without a second round trip.
+        assert "32,768" in msg and "8,192" in msg
+
+    def test_it_names_the_opt_out(self):
+        assert _ENV in _message(32768, CEILING)
+
+    def test_it_does_not_blame_system_ram(self):
+        """The PC advice. There is no system RAM to spill to on unified memory, and
+        saying so is what made the old warning read as survivable."""
+        assert "system RAM" not in _message(32768, CEILING)
+
+    @pytest.mark.parametrize("requested", [1, CEILING - 1, CEILING])
+    def test_a_context_that_fits_is_allowed(self, requested):
+        assert _message(requested, CEILING) is None
+
+    @pytest.mark.parametrize("requested,ceiling", [(0, CEILING), (32768, 0), (-1, CEILING)])
+    def test_an_unusable_pair_abstains(self, requested, ceiling):
+        """No request, or no ceiling to measure against, is not a refusal."""
+        assert _message(requested, ceiling) is None
+
+    @pytest.mark.parametrize("value", ["1", "true", "yes", "TRUE", " 1 "])
+    def test_the_opt_out_abstains(self, monkeypatch, value):
+        monkeypatch.setenv(_ENV, value)
+        assert _message(32768, CEILING) is None
+
+    @pytest.mark.parametrize("value", ["0", "no", "", "maybe"])
+    def test_anything_else_still_refuses(self, monkeypatch, value):
+        monkeypatch.setenv(_ENV, value)
+        assert _message(32768, CEILING) is not None
+
+    @pytest.mark.parametrize("cache_type", [None, "", "f16", "fp16"])
+    def test_the_kv_hint_is_offered_on_an_unquantized_cache(self, cache_type):
+        assert "q8_0" in _message(32768, CEILING, cache_type)
+
+    @pytest.mark.parametrize("cache_type", ["q8_0", "q4_0"])
+    def test_it_is_not_offered_once_the_cache_is_already_quantized(self, cache_type):
+        """Advice the user has already taken reads as the refusal not having noticed."""
+        assert "q8_0" not in _message(32768, CEILING, cache_type)
+
+
+class TestWhatLoadModelDoes:
+    def test_a_context_above_the_ceiling_never_reaches_llama_server(
+        self, tmp_path, monkeypatch
+    ):
+        with pytest.raises(RuntimeError, match = "unified"):
+            _launch(tmp_path, monkeypatch, n_ctx = 32768)
+
+    def test_the_refusal_names_the_ceiling(self, tmp_path, monkeypatch):
+        with pytest.raises(RuntimeError, match = "8,192"):
+            _launch(tmp_path, monkeypatch, n_ctx = 32768)
+
+    def test_a_context_that_fits_still_launches(self, tmp_path, monkeypatch):
+        captured = _launch(tmp_path, monkeypatch, n_ctx = 4096)
+        assert _ctx_values(captured["cmd"])[-1] == "4096"
+
+    def test_the_ceiling_itself_is_allowed(self, tmp_path, monkeypatch):
+        """Off-by-one on the boundary would refuse the number the message tells the
+        user to type."""
+        captured = _launch(tmp_path, monkeypatch, n_ctx = CEILING)
+        assert _ctx_values(captured["cmd"])[-1] == str(CEILING)
+
+    def test_auto_is_untouched(self, tmp_path, monkeypatch):
+        """The path that already worked: shrink to the ceiling, never refuse."""
+        captured = _launch(tmp_path, monkeypatch, n_ctx = 0)
+        assert _ctx_values(captured["cmd"])[-1] == str(CEILING)
+
+    def test_the_opt_out_loads_it_anyway(self, tmp_path, monkeypatch):
+        monkeypatch.setenv(_ENV, "1")
+        captured = _launch(tmp_path, monkeypatch, n_ctx = 32768)
+        assert _ctx_values(captured["cmd"])[-1] == "32768"
+
+    def test_a_fixed_manual_layer_count_is_the_callers_budget(self, tmp_path, monkeypatch):
+        """Same exemption the floor and the zero-context drop already make."""
+        captured = _launch(
+            tmp_path, monkeypatch, n_ctx = 32768, gpu_memory_mode = "manual", gpu_layers = 20
+        )
+        assert _ctx_values(captured["cmd"])[-1] == "32768"
+
+    def test_an_unsizeable_kv_cache_does_not_refuse(self, tmp_path, monkeypatch):
+        """The branch falls back to a flat 4096 there. It is a guess, and refusing
+        against it would block contexts that load fine today."""
+        captured = _launch(tmp_path, monkeypatch, n_ctx = 32768, can_estimate_kv = False)
+        assert _ctx_values(captured["cmd"])[-1] == "32768"
+
+    def test_off_metal_nothing_is_refused(self, tmp_path, monkeypatch):
+        """Linux and Windows spill to system RAM and report an error; not this guard's
+        problem, and the budget reads 0 there so the branch is never entered."""
+        captured = _launch(tmp_path, monkeypatch, n_ctx = 32768, metal = False)
+        assert _ctx_values(captured["cmd"])[-1] == "32768"
+
+
+def test_the_refusal_is_raised_outside_the_placement_handler():
+    """Structural, because the failure it guards against is silent.
+
+    The `except Exception` around GPU selection turns any raise inside it into
+    "GPU selection failed", then restores the original request, which is exactly the
+    over-commit being refused. So the branch records the message and load_model raises
+    it after that handler. Raising in place would leave every test above passing on a
+    guard that does nothing.
+    """
+    import inspect
+
+    src = inspect.getsource(LlamaCppBackend.load_model)
+    assigned = src.find("_metal_ctx_refusal = self._metal_context_overcommit_message(")
+    handler = src.find("using --fit on")
+    raised = src.find("raise RuntimeError(_metal_ctx_refusal)")
+    assert assigned != -1 and handler != -1 and raised != -1
+    assert assigned < handler < raised

--- a/studio/backend/tests/test_metal_explicit_context_guard.py
+++ b/studio/backend/tests/test_metal_explicit_context_guard.py
@@ -599,6 +599,35 @@ class TestAContextAboveTheModelsNativeLength:
         cmd = self._above(tmp_path, monkeypatch, n_ctx = self._ASKED, kv_per_token = 1024)["cmd"]
         assert _ctx_values(cmd)[-1] == str(self._ASKED)
 
+    def test_the_load_does_not_arrive_carrying_a_warning_against_itself(
+        self, tmp_path, monkeypatch
+    ):
+        """max_available_ctx is published as max_context_length, and both amber warnings
+        fire when the loaded context exceeds it. Left at the native length, a load this
+        branch measured and allowed reaches the user as "context length exceeds what
+        fits in unified memory", naming a number smaller than the one running.
+        """
+        out = self._above(tmp_path, monkeypatch, n_ctx = self._ASKED, kv_per_token = 1024)
+        loaded = int(_ctx_values(out["cmd"])[-1])
+        published = out["backend"].max_context_length
+        assert published == loaded
+
+    def test_the_published_bound_never_runs_ahead_of_the_request(
+        self, tmp_path, monkeypatch
+    ):
+        """The fit is bounded by the request, so the bound may rise to the context that
+        loaded and no further. A bound past it would invite a context nothing priced."""
+        out = self._above(tmp_path, monkeypatch, n_ctx = self._ASKED, kv_per_token = 1024)
+        assert out["backend"].max_context_length <= self._ASKED
+
+    def test_a_refused_request_does_not_raise_the_published_bound(
+        self, tmp_path, monkeypatch
+    ):
+        """Only an accepted ceiling is published. A refusal measured nothing it can
+        stand behind at the request, so the bound stays where the cap left it."""
+        with pytest.raises(RuntimeError, match = "unified"):
+            self._above(tmp_path, monkeypatch, n_ctx = self._ASKED, kv_per_token = _FAT_KV)
+
     def test_the_pass_through_spelling_launches_too(self, tmp_path, monkeypatch):
         """The spelling a RoPE-scaled request actually arrives in."""
         cmd = self._above(

--- a/studio/backend/tests/test_metal_explicit_context_guard.py
+++ b/studio/backend/tests/test_metal_explicit_context_guard.py
@@ -218,9 +218,7 @@ class TestTheRefusalItself:
 
 
 class TestWhatLoadModelDoes:
-    def test_a_context_above_the_ceiling_never_reaches_llama_server(
-        self, tmp_path, monkeypatch
-    ):
+    def test_a_context_above_the_ceiling_never_reaches_llama_server(self, tmp_path, monkeypatch):
         with pytest.raises(RuntimeError, match = "unified"):
             _launch(tmp_path, monkeypatch, n_ctx = 32768)
 

--- a/studio/backend/tests/test_metal_explicit_context_guard.py
+++ b/studio/backend/tests/test_metal_explicit_context_guard.py
@@ -638,6 +638,67 @@ class TestAContextAboveTheModelsNativeLength:
         assert _named_ceiling(message) > 4096
 
 
+class TestAnAboveNativeRequestOnAShortNativeModel:
+    """Native below 4096, so the extension probe's own floor is above what fits.
+
+    The probe re-prices the request through the fit to find a ceiling the native-sized
+    cap could never reach. Its floor is 4096, which is a floor and not a measurement,
+    and on a model trained at 2048 an above-native request can have room for something
+    between the two. The floored result does not fit, the footprint check discards it,
+    and the refusal falls back to naming the native-sized cap -- on a machine that
+    launches the intermediate context when asked for it directly.
+
+    Budget 9216 MiB against 5916 MiB of weights leaves 3300 MiB, so at 1 MiB per token
+    the real ceiling is 3072 and 4096 misses by ~800 MiB.
+    """
+
+    _NATIVE = 2048
+    _FITS = 3072
+    _ASKED = 8192
+
+    def _short(self, tmp_path, monkeypatch, **kw):
+        return _launch(
+            tmp_path,
+            monkeypatch,
+            real_fit = True,
+            budget_bytes = 9216 * 1024**2,
+            weights_bytes = 796 * 1024**2,
+            kv_per_token = _FAT_KV,
+            native = self._NATIVE,
+            **kw,
+        )
+
+    def test_the_intermediate_context_launches(self, tmp_path, monkeypatch):
+        """The other half of the contradiction, and what makes the number in the
+        refusal checkable: this same load is one the guard already allows."""
+        cmd = self._short(tmp_path, monkeypatch, n_ctx = self._FITS)["cmd"]
+        assert _ctx_values(cmd)[-1] == str(self._FITS)
+
+    def test_the_refusal_names_it_rather_than_the_native_length(self, tmp_path, monkeypatch):
+        with pytest.raises(RuntimeError) as excinfo:
+            self._short(tmp_path, monkeypatch, n_ctx = self._ASKED)
+        message = str(excinfo.value)
+        assert _named_ceiling(message) == self._FITS
+        # Naming 2,048 here sends the user to less than the machine holds.
+        assert f"{self._NATIVE:,}" not in message
+
+    def test_the_re_probe_only_ever_raises_the_ceiling(self, tmp_path, monkeypatch):
+        """It runs on every above-native request, including ones where the floored
+        probe already fits, so it must not talk a working ceiling back down."""
+        with pytest.raises(RuntimeError) as excinfo:
+            _launch(
+                tmp_path,
+                monkeypatch,
+                real_fit = True,
+                budget_bytes = _BUDGET,
+                weights_bytes = _TIGHT_WEIGHTS,
+                kv_per_token = _FAT_KV,
+                native = 262144,
+                n_ctx = 1048576,
+            )
+        assert _named_ceiling(str(excinfo.value)) >= _TIGHT_CEILING
+
+
 class TestWhenNothingFitsAtAll:
     """Weights fit, and even the smallest context the search prices does not.
 

--- a/studio/backend/tests/test_metal_explicit_context_guard.py
+++ b/studio/backend/tests/test_metal_explicit_context_guard.py
@@ -3,24 +3,22 @@
 
 """A hand-set context above what unified memory holds must be refused, not launched.
 
-The Metal branch of load_model already works out the largest context that fits, but
-only Auto was ever moved to it: an explicit request was passed through verbatim, on the
-theory that "--fit on" is a backstop. It is one, but not a trustworthy one here.
-llama.cpp will reduce an explicit context (fit_params_min_ctx defaults to 4096; only
-"-c 0" disables the reduction), but it decides from ggml-metal's free-memory report,
-which comes off the device's recommendedMaxWorkingSetSize and knows nothing about
-Studio's own resident gigabyte or two, other running apps, or the iogpu wired limit
-that is the figure actually being blown. When that estimate is optimistic the request
-stands and the launch over-commits wired memory, which Jetsam cannot reclaim, so the
-machine panics instead of the load failing. An M1 Max 32 GB hit exactly that on
+The Metal branch of load_model already works out the largest context that fits, but only
+Auto was moved to it: an explicit request was passed through verbatim, on the theory that
+"--fit on" is a backstop. It is one, but not a trustworthy one here. llama.cpp will reduce
+an explicit context (fit_params_min_ctx defaults to 4096; only "-c 0" disables it), but it
+decides from ggml-metal's free-memory report, off the device's recommendedMaxWorkingSetSize,
+which knows nothing of Studio's own resident gigabyte or two, other running apps, or the
+iogpu wired limit actually being blown. When that estimate is optimistic the request stands
+and the launch over-commits wired memory, which Jetsam cannot reclaim, so the machine
+panics instead of the load failing. An M1 Max 32 GB hit exactly that on
 Qwen3.8-27B-UD-Q4_K_XL, twice, as soon as the context was set by hand.
 
 So the ceiling the branch computes now gates the explicit request too, and the refusal
-names it. Two things it deliberately does not do: refuse against the 4096 fallback the
-branch uses when KV cannot be sized (a guess, not a measurement, and refusing on it
-would block contexts that load fine today), and refuse a manual load with a fixed layer
-count, which is the user taking the memory budget over, as the other two Metal guards
-already treat it.
+names it. Two things it deliberately does not do: refuse against the 4096 fallback used
+when KV cannot be sized (a guess, and refusing on it would block contexts that load fine
+today), and refuse a manual load with a fixed layer count, which is the user taking the
+memory budget over, as the other two Metal guards already treat it.
 """
 
 from __future__ import annotations
@@ -63,17 +61,17 @@ _message = LlamaCppBackend._metal_context_overcommit_message
 _ENV = LlamaCppBackend.METAL_CTX_OVERCOMMIT_ENV
 _REAL_POPEN = subprocess.Popen
 
-# What the stubbed fit reports as the largest context that fits, and the native length
-# of the GGUF under test. Anything between them is a context the user can type into the
-# box today and the machine cannot hold.
+# What the stubbed fit reports as the largest context that fits, and the GGUF's native
+# length. Anything between them is a context the user can type today and the machine
+# cannot hold.
 CEILING = 8192
 NATIVE = 262144
 
 
 @pytest.fixture(autouse = True)
 def _no_opt_out(monkeypatch):
-    """The opt-out is a real environment read, so a host that has it set must not
-    silently turn every refusal test green."""
+    """A real environment read, so a host that has it set must not turn every refusal
+    test silently green."""
     monkeypatch.delenv(_ENV, raising = False)
 
 
@@ -126,14 +124,13 @@ def _launch(
     stub GGUF and the ceiling under test is the one the fit returns.
 
     Returns the launch capture ({"cmd": argv}, empty when nothing launched). Pass
-    ``backend`` to drive a second load through the same instance, which is the only way
-    to observe what a refusal does to state a previous load left behind.
+    ``backend`` to drive a second load through the same instance, the only way to observe
+    what a refusal does to state a previous load left behind.
 
     ``real_fit`` leaves _fit_context_to_vram unstubbed so the branch runs against the
     helper's actual return contract -- its 4096 floor, and its habit of handing the
     request straight back. ``budget_bytes`` / ``weights_bytes`` / ``kv_per_token`` /
-    ``native`` then place the model against the budget; the stubbed ceiling ignores all
-    four, so they only matter with ``real_fit``.
+    ``native`` then place the model against the budget, and only matter with ``real_fit``.
     """
     monkeypatch.setattr(
         LlamaCppBackend,
@@ -156,14 +153,13 @@ def _launch(
     backend._mmproj_vram_bytes = lambda _path: 0
     backend._resolve_launch_mmproj_path = lambda **kwargs: None
     backend._apu_ram_shortfall_message = lambda *a, **k: None
-    # This harness does not model host RAM, and None is the documented way to say so:
-    # both _apu_ram_shortfall_message and _host_offload_shortfall_message treat unknown
+    # This harness does not model host RAM, and None is the documented way to say so: both
+    # _apu_ram_shortfall_message and _host_offload_shortfall_message treat unknown
     # available memory as "never refuse". Without it the sibling host-RAM guard fires on
-    # the paravirtual path, which is the one placement here that reports
-    # child_has_no_gpu and so gets past that guard's empty-pool early return. It then
-    # prices the model against the REAL machine, so the virtualised-device tests passed
-    # on a 16 GB runner and failed on a 7 GB macos-14 one. Host-memory dependent, not
-    # OS dependent: a real 8 GB Mac would have failed the same way.
+    # the paravirtual path (the one placement here that reports child_has_no_gpu and so
+    # gets past that guard's empty-pool early return) and prices the model against the
+    # REAL machine, so the virtualised-device tests passed on a 16 GB runner and failed on
+    # a 7 GB one. Host-memory dependent, not OS dependent.
     backend._available_system_memory_mib = lambda *a, **k: None
     backend._amd_apu_wants_unified_memory = lambda *a, **k: False
     backend._find_llama_server_binary = lambda include_denied = False: "/fake/llama-server"
@@ -183,11 +179,10 @@ def _launch(
             "Process",
             (),
             {
-                # One below pid_max: validly shaped, but names no process, so the
-                # lifetime registry's identity check drops it and it can never be
-                # signalled. A low pid here is not inert decoration -- load_model
-                # adopts whatever it is given and teardown signals that process
-                # group, and killpg(1) is kill(-1), i.e. everything the user owns.
+                # One below pid_max: validly shaped but names no process, so the
+                # lifetime registry's identity check drops it. Not inert decoration
+                # -- load_model adopts whatever pid it is given and teardown signals
+                # that process group, and killpg(1) is kill(-1), everything the user owns.
                 "pid": 4194303,
                 "stdout": (),
                 "poll": lambda self: None,
@@ -311,11 +306,10 @@ class TestWhatLoadModelDoes:
 def test_the_refusal_is_raised_outside_the_placement_handler():
     """Structural, because the failure it guards against is silent.
 
-    The `except Exception` around GPU selection turns any raise inside it into
-    "GPU selection failed", then restores the original request, which is exactly the
-    over-commit being refused. So the branch records the message and load_model raises
-    it after that handler. Raising in place would leave every test above passing on a
-    guard that does nothing.
+    The `except Exception` around GPU selection swallows any raise inside it and restores
+    the original request, which is exactly the over-commit being refused. So the branch
+    records the message and load_model raises it after that handler. Raising in place
+    would leave every test above passing on a guard that does nothing.
     """
     import inspect
 
@@ -331,17 +325,17 @@ class TestAVirtualisedMetalDevice:
     """A Mac VM runs GGUF entirely on CPU, so this budget is the wrong yardstick.
 
     The paravirtual pin rewrites every placement to manual/0 and launches behind
-    --device none, because offloaded layers on a virtualised Metal device produce
-    corrupt output. Nothing is allocated on the GPU, so refusing against a GPU
-    working-set budget would break loads that work today on a Mac VM (and on the
-    macOS GitHub Actions runners, which report exactly this device), and the message
-    would describe hardware the launch never touches. Host RAM is the real limit
-    there, and _host_offload_shortfall_message already prices that.
+    --device none, because offloaded layers on a virtualised Metal device produce corrupt
+    output. Nothing is allocated on the GPU, so refusing against a GPU working-set budget
+    would break loads that work today on a Mac VM (and on the macOS GitHub Actions
+    runners, which report exactly this device), and the message would describe hardware
+    the launch never touches. Host RAM is the real limit, and
+    _host_offload_shortfall_message already prices it.
 
     Caught by the pre-merge OS x GPU simulation, not by review: the exemption reads
-    _paravirtual_cpu_forced, which is set from the hardware, while the neighbouring
-    _caller_owns_budget is read off the REQUEST and so stays False for the Auto load
-    the pin rewrote.
+    _paravirtual_cpu_forced, set from the hardware, while the neighbouring
+    _caller_owns_budget is read off the REQUEST and stays False for the Auto load the
+    pin rewrote.
     """
 
     def test_it_is_not_refused(self, tmp_path, monkeypatch):
@@ -364,10 +358,10 @@ class TestAVirtualisedMetalDevice:
 class TestTheMessageSurvivesTheRoute:
     """load_model raises; the route rewrites the text twice before the user reads it.
 
-    It is caught by the broad handler in _load_model_impl, which redacts native paths
-    and then runs _maybe_unsupported_message over the result, exactly as the existing
-    APU and host-offload refusals are. Both rewrites have to leave this message alone
-    or the user is told something false about a fixable mistake.
+    The broad handler in _load_model_impl redacts native paths and then runs
+    _maybe_unsupported_message over the result, exactly as for the existing APU and
+    host-offload refusals. Both rewrites have to leave this message alone or the user is
+    told something false about a fixable mistake.
     """
 
     def _message(self, tmp_path, monkeypatch) -> str:
@@ -376,13 +370,12 @@ class TestTheMessageSurvivesTheRoute:
         return str(excinfo.value)
 
     def test_it_is_not_relabelled_as_an_unsupported_model(self, tmp_path, monkeypatch):
-        """_maybe_unsupported_message rewrites any error carrying one of these into
-        "This model is not supported yet. Try a different model.", which would send
-        the user off to change models over a context they can simply lower.
+        """_maybe_unsupported_message rewrites any error carrying one of these into "This
+        model is not supported yet. Try a different model.", sending the user off to
+        change models over a context they can simply lower.
 
         Read out of the route source rather than imported: the phrase list is the
-        contract, and importing routes.inference would drag FastAPI into a test that
-        only needs four strings.
+        contract, and importing routes.inference would drag FastAPI in for four strings.
         """
         import ast
         import re
@@ -416,15 +409,15 @@ class TestTheMessageSurvivesTheRoute:
 class TestWhatARefusedReloadCosts:
     """A refused reload ends with no model loaded, and that is the existing contract.
 
-    load_model kills the resident server in its Phase 1, long before the placement
-    block that computes the ceiling. Every refusal raised from that block behaves this
-    way already: the APU RAM shortfall, the unpinnable Vulkan ordinal. Refusing earlier
-    would mean re-deriving the fit outside the one place that owns it, which is the
-    drift _apu_ram_shortfall_message explicitly avoids.
+    load_model kills the resident server in Phase 1, long before the placement block that
+    computes the ceiling, so every refusal raised from that block already behaves this way
+    (the APU RAM shortfall, the unpinnable Vulkan ordinal). Refusing earlier would mean
+    re-deriving the fit outside the one place that owns it, the drift
+    _apu_ram_shortfall_message explicitly avoids.
 
-    So this is pinned rather than fixed, and it is still the better end state: before
-    this guard the same click took the whole machine down. The recovery path is what
-    has to work, and the next test covers it.
+    So this is pinned rather than fixed, and still the better end state: before this guard
+    the same click took the whole machine down. The recovery path is what has to work, and
+    the next test covers it.
     """
 
     def test_the_refused_reload_leaves_nothing_running(self, tmp_path, monkeypatch):
@@ -450,9 +443,9 @@ class TestWhatARefusedReloadCosts:
 class TestTheContextCanArriveByAnotherDoor:
     """requested_ctx folds in a -c from extra args, so every spelling is covered.
 
-    Worth pinning: if the guard read intent.n_ctx directly it would sit one text box
-    away from being bypassed, and the pass-through spelling is the one a user reaches
-    for after being refused.
+    Worth pinning: reading intent.n_ctx directly would leave the guard one text box away
+    from being bypassed, and the pass-through spelling is the one a user reaches for
+    after being refused.
     """
 
     @pytest.mark.parametrize(
@@ -483,8 +476,8 @@ class TestTheContextCanArriveByAnotherDoor:
 _FAT_KV = 1024 * 1024
 _BUDGET = 9 * 1024**3
 # load_model folds a flat compute-buffer reserve into the weights before the fit sees
-# them, so what is left of a 9 GiB budget for weights + KV is well under 9 GiB. Sized
-# so the weights fit with room for a few hundred tokens and nothing like 4096.
+# them, so a 9 GiB budget leaves well under 9 GiB for weights + KV. Sized so the weights
+# fit with room for a few hundred tokens and nothing like 4096.
 _TIGHT_WEIGHTS = 3300 * 1024**2
 _TIGHT_CEILING = 768
 
@@ -498,16 +491,14 @@ class TestWhenEvenTheFitsOwnMinimumDoesNotFit:
     """The fit floors at ``min_ctx`` (4096), so a 4096 coming back means either "4096
     fits" or "nothing fits, here is the floor". Reading the second as "the weights alone
     are over budget" skipped the refusal on exactly the machine that needs it: llama.cpp
-    will not reduce below fit_params_min_ctx (4096) either, so "--fit on" has nothing
-    left to give and the launch over-commits wired memory.
+    will not reduce below 4096 either, so "--fit on" has nothing left to give and the
+    launch over-commits wired memory.
     """
 
     def test_the_premise_the_fit_hands_back_its_own_floor(self):
         """Not a behaviour assertion -- a guard on the return contract the branch reads.
-
-        998 MiB of weights against a 1000 MiB budget leaves room for 2048 tokens at
-        1 KiB each, yet asking with the default floor still answers 4096.
-        """
+        998 MiB of weights against a 1000 MiB budget leaves room for 2048 tokens at 1 KiB
+        each, yet asking with the default floor still answers 4096."""
         backend = LlamaCppBackend()
         backend._can_estimate_kv = lambda: True
         backend._estimate_kv_cache_bytes = lambda ctx, *a, **k: int(ctx) * 1024
@@ -573,12 +564,12 @@ class TestWhenEvenTheFitsOwnMinimumDoesNotFit:
 
 
 class TestAContextAboveTheModelsNativeLength:
-    """The fit is sized through the native length, so its ceiling can never exceed it
-    and every request past it read as an over-commit whatever the machine had spare.
-    Nothing clamps a request to the native length on the way in (the Extra Arguments box
-    takes a raw --ctx-size and its placeholder suggests --rope-scaling yarn), and
-    llama.cpp builds the context at the full -c, capping only the per-slot value
-    afterwards, so the request is what actually gets allocated.
+    """The fit is sized through the native length, so its ceiling can never exceed it and
+    every request past it read as an over-commit whatever the machine had spare. Nothing
+    clamps a request to native on the way in (the Extra Arguments box takes a raw
+    --ctx-size and its placeholder suggests --rope-scaling yarn), and llama.cpp builds the
+    context at the full -c, capping only the per-slot value afterwards, so the request is
+    what actually gets allocated.
     """
 
     _NATIVE = 32768
@@ -603,9 +594,9 @@ class TestAContextAboveTheModelsNativeLength:
         self, tmp_path, monkeypatch
     ):
         """max_available_ctx is published as max_context_length, and both amber warnings
-        fire when the loaded context exceeds it. Left at the native length, a load this
-        branch measured and allowed reaches the user as "context length exceeds what
-        fits in unified memory", naming a number smaller than the one running.
+        fire when the loaded context exceeds it. Left at native, a load this branch
+        measured and allowed reaches the user as "context length exceeds what fits in
+        unified memory", naming a number smaller than the one running.
         """
         out = self._above(tmp_path, monkeypatch, n_ctx = self._ASKED, kv_per_token = 1024)
         loaded = int(_ctx_values(out["cmd"])[-1])
@@ -646,10 +637,9 @@ class TestAContextAboveTheModelsNativeLength:
     def test_the_refusal_names_the_measured_ceiling_not_the_native_length(
         self, tmp_path, monkeypatch
     ):
-        """A refusal that names the native length is reporting the wrong limit: here
-        memory holds sixteen times it, so "lower the context to 4,096" throws away a
-        context that would have loaded.
-        """
+        """A refusal that names the native length reports the wrong limit: memory holds
+        sixteen times it here, so "lower the context to 4,096" throws away a context that
+        would have loaded."""
         # 64 KiB per token against ~4 GiB of headroom: tens of thousands of tokens fit,
         # far past the 4096 this GGUF was trained at.
         with pytest.raises(RuntimeError) as excinfo:
@@ -670,12 +660,12 @@ class TestAContextAboveTheModelsNativeLength:
 class TestAnAboveNativeRequestOnAShortNativeModel:
     """Native below 4096, so the extension probe's own floor is above what fits.
 
-    The probe re-prices the request through the fit to find a ceiling the native-sized
-    cap could never reach. Its floor is 4096, which is a floor and not a measurement,
-    and on a model trained at 2048 an above-native request can have room for something
-    between the two. The floored result does not fit, the footprint check discards it,
-    and the refusal falls back to naming the native-sized cap -- on a machine that
-    launches the intermediate context when asked for it directly.
+    The probe re-prices the request through the fit to find a ceiling the native-sized cap
+    could never reach. Its floor is 4096, a floor and not a measurement, and on a model
+    trained at 2048 an above-native request can have room for something between the two.
+    The floored result does not fit, the footprint check discards it, and the refusal
+    falls back to naming the native-sized cap -- on a machine that launches the
+    intermediate context when asked for it directly.
 
     Budget 9216 MiB against 5916 MiB of weights leaves 3300 MiB, so at 1 MiB per token
     the real ceiling is 3072 and 4096 misses by ~800 MiB.
@@ -731,22 +721,20 @@ class TestAnAboveNativeRequestOnAShortNativeModel:
 class TestWhenNothingFitsAtAll:
     """Weights fit, and even the smallest context the search prices does not.
 
-    The narrowest of the three states the over-budget arm has to tell apart, and the
-    one with no number to lower to. It is a measurement, not an absence of one: the fit
-    shrank, which is what says the weights themselves fit, and then the floor it shrank
-    to did not fit either. Leaving it unmeasured let every explicit context through on a
-    host where all of them over-commit, which is the crash this guard exists to stop.
+    The narrowest of the three states the over-budget arm has to tell apart, and the one
+    with no number to lower to. It is a measurement, not an absence of one: the fit
+    shrank, which is what says the weights themselves fit, and then the floor it shrank to
+    did not fit either. Leaving it unmeasured let every explicit context through on a host
+    where all of them over-commit, the crash this guard exists to stop.
 
-    Told apart from weights-alone-over-budget by whether the re-priced answer is
-    smaller. That arm returns the request untouched for any min_ctx, so it cannot
-    shrink; this one always does.
+    Told apart from weights-alone-over-budget by whether the re-priced answer is smaller:
+    that arm returns the request untouched for any min_ctx, so it cannot shrink.
     """
 
     # Weights heavy enough that the budget cannot afford 256 tokens on top of them at
-    # 1 MiB each, but still light enough that the fit can shrink at all -- which is the
-    # signal that separates this state from weights-alone-over-budget. Measured window
-    # for this harness: ~3850 to ~4050 MiB, with 3300 leaving room for 768 tokens and
-    # 4100 tipping into weights-over-budget.
+    # 1 MiB each, but light enough that the fit can shrink at all, the signal that
+    # separates this state from weights-alone-over-budget. Measured window for this
+    # harness: ~3850 to ~4050 MiB (3300 leaves room for 768 tokens, 4100 tips over).
     NOTHING_FITS = dict(
         real_fit = True,
         budget_bytes = _BUDGET,
@@ -836,12 +824,12 @@ class TestWhenNothingFitsAtAll:
 class TestAModelWhoseNativeLengthIsAtTheFloor:
     """The weights-only state has to be read off the budget, not off two fits agreeing.
 
-    Both probes are bounded by the same target, so on a model whose native length is
-    already at or under the search's 256 alignment step they return the same number for
-    a reason that has nothing to do with the weights. Inferring "the fit priced nothing"
-    from that agreement left both verdicts unset and let every explicit context through
-    on a host where none of them fit. Reachable at native == 256 exactly, and also
-    whenever the GGUF carries no context length so the request itself becomes the target.
+    Both probes are bounded by the same target, so on a model whose native length is at or
+    under the search's 256 alignment step they return the same number for a reason
+    unrelated to the weights. Inferring "the fit priced nothing" from that agreement left
+    both verdicts unset and let every explicit context through on a host where none of
+    them fit. Reachable at native == 256 exactly, and whenever the GGUF carries no context
+    length so the request itself becomes the target.
     """
 
     TIGHT = dict(

--- a/studio/backend/tests/test_metal_explicit_context_guard.py
+++ b/studio/backend/tests/test_metal_explicit_context_guard.py
@@ -741,3 +741,58 @@ class TestWhenNothingFitsAtAll:
                 weights_bytes = _TIGHT_WEIGHTS,
                 kv_per_token = _FAT_KV,
             )
+
+
+class TestAModelWhoseNativeLengthIsAtTheFloor:
+    """The weights-only state has to be read off the budget, not off two fits agreeing.
+
+    Both probes are bounded by the same target, so on a model whose native length is
+    already at or under the search's 256 alignment step they return the same number for
+    a reason that has nothing to do with the weights. Inferring "the fit priced nothing"
+    from that agreement left both verdicts unset and let every explicit context through
+    on a host where none of them fit. Reachable at native == 256 exactly, and also
+    whenever the GGUF carries no context length so the request itself becomes the target.
+    """
+
+    TIGHT = dict(
+        real_fit = True,
+        budget_bytes = _BUDGET,
+        weights_bytes = 3950 * 1024**2,
+        kv_per_token = _FAT_KV,
+    )
+
+    @pytest.mark.parametrize("native", [128, 256, 512, 4096])
+    def test_an_explicit_context_is_refused_at_every_native_length(
+        self, tmp_path, monkeypatch, native
+    ):
+        with pytest.raises(RuntimeError, match = "unified memory"):
+            _launch(tmp_path, monkeypatch, n_ctx = 8192, native = native, **self.TIGHT)
+
+    def test_weights_over_budget_is_still_not_refused_at_the_floor(self, tmp_path, monkeypatch):
+        """The state the old comparison was trying to detect still has to pass through,
+        and now it is detected by asking the budget rather than by the two fits tying."""
+        cmd = _launch(
+            tmp_path,
+            monkeypatch,
+            n_ctx = 8192,
+            native = 256,
+            real_fit = True,
+            budget_bytes = _BUDGET,
+            weights_bytes = 12 * 1024**3,
+            kv_per_token = _FAT_KV,
+        )["cmd"]
+        assert _ctx_values(cmd)[-1] == "8192"
+
+    def test_a_roomy_host_still_launches_at_a_tiny_native_length(self, tmp_path, monkeypatch):
+        """Nothing about a small native length should refuse on its own."""
+        cmd = _launch(
+            tmp_path,
+            monkeypatch,
+            n_ctx = 256,
+            native = 256,
+            real_fit = True,
+            budget_bytes = _BUDGET,
+            weights_bytes = 100 * 1024**2,
+            kv_per_token = _FAT_KV,
+        )["cmd"]
+        assert _ctx_values(cmd)[-1] == "256"

--- a/studio/backend/tests/test_metal_explicit_context_guard.py
+++ b/studio/backend/tests/test_metal_explicit_context_guard.py
@@ -156,6 +156,15 @@ def _launch(
     backend._mmproj_vram_bytes = lambda _path: 0
     backend._resolve_launch_mmproj_path = lambda **kwargs: None
     backend._apu_ram_shortfall_message = lambda *a, **k: None
+    # This harness does not model host RAM, and None is the documented way to say so:
+    # both _apu_ram_shortfall_message and _host_offload_shortfall_message treat unknown
+    # available memory as "never refuse". Without it the sibling host-RAM guard fires on
+    # the paravirtual path, which is the one placement here that reports
+    # child_has_no_gpu and so gets past that guard's empty-pool early return. It then
+    # prices the model against the REAL machine, so the virtualised-device tests passed
+    # on a 16 GB runner and failed on a 7 GB macos-14 one. Host-memory dependent, not
+    # OS dependent: a real 8 GB Mac would have failed the same way.
+    backend._available_system_memory_mib = lambda *a, **k: None
     backend._amd_apu_wants_unified_memory = lambda *a, **k: False
     backend._find_llama_server_binary = lambda include_denied = False: "/fake/llama-server"
     backend._is_vulkan_backend = lambda _binary = None: False

--- a/studio/backend/tests/test_metal_explicit_context_guard.py
+++ b/studio/backend/tests/test_metal_explicit_context_guard.py
@@ -183,7 +183,12 @@ def _launch(
             "Process",
             (),
             {
-                "pid": 123,
+                # One below pid_max: validly shaped, but names no process, so the
+                # lifetime registry's identity check drops it and it can never be
+                # signalled. A low pid here is not inert decoration -- load_model
+                # adopts whatever it is given and teardown signals that process
+                # group, and killpg(1) is kill(-1), i.e. everything the user owns.
+                "pid": 4194303,
                 "stdout": (),
                 "poll": lambda self: None,
                 "terminate": lambda self: None,

--- a/studio/backend/tests/test_metal_explicit_context_guard.py
+++ b/studio/backend/tests/test_metal_explicit_context_guard.py
@@ -373,7 +373,11 @@ class TestTheMessageSurvivesTheRoute:
         import ast
         import re
 
-        route_src = (Path(__file__).resolve().parent.parent / "routes" / "inference.py").read_text()
+        # encoding is not optional: routes/inference.py carries non-ASCII (the DeepSeek
+        # tool-call tokens), and read_text() defaults to cp1252 on Windows.
+        route_src = (Path(__file__).resolve().parent.parent / "routes" / "inference.py").read_text(
+            encoding = "utf-8"
+        )
         hints = ast.literal_eval(
             re.search(r"_NOT_SUPPORTED_HINTS = (\(.*?\))", route_src, re.S).group(1)
         )

--- a/studio/backend/tests/test_metal_explicit_context_guard.py
+++ b/studio/backend/tests/test_metal_explicit_context_guard.py
@@ -113,6 +113,11 @@ def _launch(
     paravirtual = False,
     cache_type_kv = None,
     backend = None,
+    real_fit = False,
+    budget_bytes = 9 * 1024**3,
+    weights_bytes = 1024,
+    kv_per_token = 1024,
+    native = NATIVE,
 ):
     """Drive the real load_model with no GPU enumerated (the Metal condition).
 
@@ -123,11 +128,17 @@ def _launch(
     Returns the launch capture ({"cmd": argv}, empty when nothing launched). Pass
     ``backend`` to drive a second load through the same instance, which is the only way
     to observe what a refusal does to state a previous load left behind.
+
+    ``real_fit`` leaves _fit_context_to_vram unstubbed so the branch runs against the
+    helper's actual return contract -- its 4096 floor, and its habit of handing the
+    request straight back. ``budget_bytes`` / ``weights_bytes`` / ``kv_per_token`` /
+    ``native`` then place the model against the budget; the stubbed ceiling ignores all
+    four, so they only matter with ``real_fit``.
     """
     monkeypatch.setattr(
         LlamaCppBackend,
         "_apple_metal_memory_budget_bytes",
-        staticmethod(lambda: 9 * 1024**3 if metal else 0),
+        staticmethod(lambda: budget_bytes if metal else 0),
     )
     if paravirtual:
         import core.inference.llama_cpp as _llama_cpp
@@ -137,10 +148,11 @@ def _launch(
     backend._get_gpu_free_memory = lambda _binary = None, **_kw: []
     backend._read_gguf_metadata = lambda _path: None
     backend._can_estimate_kv = lambda: can_estimate_kv
-    backend._estimate_kv_cache_bytes = lambda ctx, *a, **k: int(ctx) * 1024
+    backend._estimate_kv_cache_bytes = lambda ctx, *a, **k: int(ctx) * kv_per_token
     backend._compute_buffer_ctx_bytes = lambda *a, **k: 0
-    backend._fit_context_to_vram = lambda native, *a, **k: min(int(native), CEILING)
-    backend._get_gguf_size_bytes = lambda _path: 1024
+    if not real_fit:
+        backend._fit_context_to_vram = lambda target, *a, **k: min(int(target), CEILING)
+    backend._get_gguf_size_bytes = lambda _path: weights_bytes
     backend._mmproj_vram_bytes = lambda _path: 0
     backend._resolve_launch_mmproj_path = lambda **kwargs: None
     backend._apu_ram_shortfall_message = lambda *a, **k: None
@@ -150,7 +162,7 @@ def _launch(
     backend._wait_for_health = lambda timeout: True
     backend._detect_audio_type_strict = lambda: None
     backend._apply_detected_audio = lambda _detected: True
-    backend._context_length = NATIVE
+    backend._context_length = native
 
     captured = {}
 
@@ -446,3 +458,163 @@ class TestTheContextCanArriveByAnotherDoor:
         so it must not turn into a refusal."""
         cmd = _launch(tmp_path, monkeypatch, n_ctx = 0, extra_args = ["-c", "0"])["cmd"]
         assert _ctx_values(cmd) and _ctx_values(cmd)[-1] != "0"
+
+
+# 1 MiB of KV per token, so a handful of thousand tokens is worth gigabytes and the
+# fit's own 4096 floor can be pushed past the budget on a stub model.
+_FAT_KV = 1024 * 1024
+_BUDGET = 9 * 1024**3
+# load_model folds a flat compute-buffer reserve into the weights before the fit sees
+# them, so what is left of a 9 GiB budget for weights + KV is well under 9 GiB. Sized
+# so the weights fit with room for a few hundred tokens and nothing like 4096.
+_TIGHT_WEIGHTS = 3300 * 1024**2
+_TIGHT_CEILING = 768
+
+
+def _named_ceiling(message: str) -> int:
+    """The ceiling the refusal quotes back, so a test can assert about it directly."""
+    return int(message.split("The largest that fits is ")[1].split(" ")[0].replace(",", ""))
+
+
+class TestWhenEvenTheFitsOwnMinimumDoesNotFit:
+    """The fit floors at ``min_ctx`` (4096), so a 4096 coming back means either "4096
+    fits" or "nothing fits, here is the floor". Reading the second as "the weights alone
+    are over budget" skipped the refusal on exactly the machine that needs it: llama.cpp
+    will not reduce below fit_params_min_ctx (4096) either, so "--fit on" has nothing
+    left to give and the launch over-commits wired memory.
+    """
+
+    def test_the_premise_the_fit_hands_back_its_own_floor(self):
+        """Not a behaviour assertion -- a guard on the return contract the branch reads.
+
+        998 MiB of weights against a 1000 MiB budget leaves room for 2048 tokens at
+        1 KiB each, yet asking with the default floor still answers 4096.
+        """
+        backend = LlamaCppBackend()
+        backend._can_estimate_kv = lambda: True
+        backend._estimate_kv_cache_bytes = lambda ctx, *a, **k: int(ctx) * 1024
+
+        def fit(min_ctx):
+            return backend._fit_context_to_vram(
+                NATIVE,
+                1000,
+                998 * 1024**2,
+                None,
+                min_ctx = min_ctx,
+                budget_frac = 1.0,
+                pooled = True,
+                total_mib = None,
+                compute_ctx_bytes_fn = lambda _ctx: 0,
+            )
+
+        assert fit(4096) == 4096  # the floor, not a measurement
+        assert fit(256) == 2048  # what actually fits
+
+    def _tight(self, tmp_path, monkeypatch, **kw):
+        return _launch(
+            tmp_path,
+            monkeypatch,
+            real_fit = True,
+            budget_bytes = _BUDGET,
+            weights_bytes = _TIGHT_WEIGHTS,
+            kv_per_token = _FAT_KV,
+            **kw,
+        )
+
+    def test_an_explicit_context_is_refused(self, tmp_path, monkeypatch):
+        with pytest.raises(RuntimeError, match = "unified"):
+            self._tight(tmp_path, monkeypatch, n_ctx = 4096)
+
+    def test_the_refusal_names_what_actually_fits(self, tmp_path, monkeypatch):
+        with pytest.raises(RuntimeError, match = f"{_TIGHT_CEILING:,}"):
+            self._tight(tmp_path, monkeypatch, n_ctx = 8192)
+
+    def test_auto_starts_at_what_fits_not_at_the_floor(self, tmp_path, monkeypatch):
+        """The same number the refusal names, or the UI advertises as its maximum a
+        context that is itself the over-commit."""
+        cmd = self._tight(tmp_path, monkeypatch, n_ctx = 0)["cmd"]
+        assert _ctx_values(cmd)[-1] == str(_TIGHT_CEILING)
+
+    def test_a_context_that_does_fit_still_launches(self, tmp_path, monkeypatch):
+        cmd = self._tight(tmp_path, monkeypatch, n_ctx = 512)["cmd"]
+        assert _ctx_values(cmd)[-1] == "512"
+
+    def test_weights_over_budget_is_still_never_refused(self, tmp_path, monkeypatch):
+        """The exemption the guard shipped with: nothing was measured there, so refusing
+        would block loads that work today."""
+        cmd = _launch(
+            tmp_path,
+            monkeypatch,
+            real_fit = True,
+            budget_bytes = _BUDGET,
+            weights_bytes = 10 * 1024**3,
+            kv_per_token = _FAT_KV,
+            n_ctx = 32768,
+        )["cmd"]
+        assert _ctx_values(cmd)[-1] == "32768"
+
+
+class TestAContextAboveTheModelsNativeLength:
+    """The fit is sized through the native length, so its ceiling can never exceed it
+    and every request past it read as an over-commit whatever the machine had spare.
+    Nothing clamps a request to the native length on the way in (the Extra Arguments box
+    takes a raw --ctx-size and its placeholder suggests --rope-scaling yarn), and
+    llama.cpp builds the context at the full -c, capping only the per-slot value
+    afterwards, so the request is what actually gets allocated.
+    """
+
+    _NATIVE = 32768
+    _ASKED = 131072
+
+    def _above(self, tmp_path, monkeypatch, **kw):
+        return _launch(
+            tmp_path,
+            monkeypatch,
+            real_fit = True,
+            budget_bytes = _BUDGET,
+            native = self._NATIVE,
+            **kw,
+        )
+
+    def test_it_launches_when_unified_memory_holds_it(self, tmp_path, monkeypatch):
+        # 1 KiB per token: 131,072 tokens is 128 MiB against a 9 GiB budget.
+        cmd = self._above(tmp_path, monkeypatch, n_ctx = self._ASKED, kv_per_token = 1024)["cmd"]
+        assert _ctx_values(cmd)[-1] == str(self._ASKED)
+
+    def test_the_pass_through_spelling_launches_too(self, tmp_path, monkeypatch):
+        """The spelling a RoPE-scaled request actually arrives in."""
+        cmd = self._above(
+            tmp_path,
+            monkeypatch,
+            n_ctx = 0,
+            kv_per_token = 1024,
+            extra_args = ["--rope-scaling", "yarn", "--ctx-size", str(self._ASKED)],
+        )["cmd"]
+        assert _ctx_values(cmd)[-1] == str(self._ASKED)
+
+    def test_it_is_still_refused_when_the_memory_is_not_there(self, tmp_path, monkeypatch):
+        with pytest.raises(RuntimeError, match = "unified"):
+            self._above(tmp_path, monkeypatch, n_ctx = self._ASKED, kv_per_token = _FAT_KV)
+
+    def test_the_refusal_names_the_measured_ceiling_not_the_native_length(
+        self, tmp_path, monkeypatch
+    ):
+        """A refusal that names the native length is reporting the wrong limit: here
+        memory holds sixteen times it, so "lower the context to 4,096" throws away a
+        context that would have loaded.
+        """
+        # 64 KiB per token against ~4 GiB of headroom: tens of thousands of tokens fit,
+        # far past the 4096 this GGUF was trained at.
+        with pytest.raises(RuntimeError) as excinfo:
+            _launch(
+                tmp_path,
+                monkeypatch,
+                real_fit = True,
+                budget_bytes = _BUDGET,
+                native = 4096,
+                kv_per_token = 64 * 1024,
+                n_ctx = self._ASKED,
+            )
+        message = str(excinfo.value)
+        assert "4,096" not in message
+        assert _named_ceiling(message) > 4096

--- a/studio/backend/tests/test_metal_explicit_context_guard.py
+++ b/studio/backend/tests/test_metal_explicit_context_guard.py
@@ -622,3 +622,108 @@ class TestAContextAboveTheModelsNativeLength:
         message = str(excinfo.value)
         assert "4,096" not in message
         assert _named_ceiling(message) > 4096
+
+
+class TestWhenNothingFitsAtAll:
+    """Weights fit, and even the smallest context the search prices does not.
+
+    The narrowest of the three states the over-budget arm has to tell apart, and the
+    one with no number to lower to. It is a measurement, not an absence of one: the fit
+    shrank, which is what says the weights themselves fit, and then the floor it shrank
+    to did not fit either. Leaving it unmeasured let every explicit context through on a
+    host where all of them over-commit, which is the crash this guard exists to stop.
+
+    Told apart from weights-alone-over-budget by whether the re-priced answer is
+    smaller. That arm returns the request untouched for any min_ctx, so it cannot
+    shrink; this one always does.
+    """
+
+    # Weights heavy enough that the budget cannot afford 256 tokens on top of them at
+    # 1 MiB each, but still light enough that the fit can shrink at all -- which is the
+    # signal that separates this state from weights-alone-over-budget. Measured window
+    # for this harness: ~3850 to ~4050 MiB, with 3300 leaving room for 768 tokens and
+    # 4100 tipping into weights-over-budget.
+    NOTHING_FITS = dict(
+        real_fit = True,
+        budget_bytes = _BUDGET,
+        weights_bytes = 3950 * 1024**2,
+        kv_per_token = _FAT_KV,
+    )
+
+    def test_an_explicit_context_is_refused(self, tmp_path, monkeypatch):
+        with pytest.raises(RuntimeError, match = "No context fits"):
+            _launch(tmp_path, monkeypatch, n_ctx = 8192, **self.NOTHING_FITS)
+
+    def test_even_a_tiny_explicit_context_is_refused(self, tmp_path, monkeypatch):
+        """There is no floor to fall back to: 512 over-commits the same as 32768."""
+        with pytest.raises(RuntimeError, match = "No context fits"):
+            _launch(tmp_path, monkeypatch, n_ctx = 512, **self.NOTHING_FITS)
+
+    def test_the_refusal_names_no_ceiling(self, tmp_path, monkeypatch):
+        """Naming one would be inventing a number the fit never vouched for, and the
+        user would lower to it and hit the same wall."""
+        with pytest.raises(RuntimeError) as excinfo:
+            _launch(tmp_path, monkeypatch, n_ctx = 8192, **self.NOTHING_FITS)
+        message = str(excinfo.value)
+        assert "The largest that fits" not in message
+        assert "smaller or more quantized GGUF" in message
+
+    def test_it_still_names_the_opt_out(self, tmp_path, monkeypatch):
+        with pytest.raises(RuntimeError, match = _ENV):
+            _launch(tmp_path, monkeypatch, n_ctx = 8192, **self.NOTHING_FITS)
+
+    def test_the_opt_out_loads_it_anyway(self, tmp_path, monkeypatch):
+        monkeypatch.setenv(_ENV, "1")
+        cmd = _launch(tmp_path, monkeypatch, n_ctx = 8192, **self.NOTHING_FITS)["cmd"]
+        assert _ctx_values(cmd)[-1] == "8192"
+
+    def test_auto_is_untouched(self, tmp_path, monkeypatch):
+        """Auto has always launched at the 4096 floor on this host. Changing that is a
+        larger claim than this guard makes, and it is not what was reported."""
+        cmd = _launch(tmp_path, monkeypatch, n_ctx = 0, **self.NOTHING_FITS)["cmd"]
+        assert _ctx_values(cmd)[-1] == "4096"
+
+    def test_a_fixed_manual_layer_count_is_still_exempt(self, tmp_path, monkeypatch):
+        cmd = _launch(
+            tmp_path,
+            monkeypatch,
+            n_ctx = 8192,
+            gpu_memory_mode = "manual",
+            gpu_layers = 20,
+            **self.NOTHING_FITS,
+        )["cmd"]
+        assert _ctx_values(cmd)[-1] == "8192"
+
+    def test_a_virtualised_device_is_still_exempt(self, tmp_path, monkeypatch):
+        cmd = _launch(tmp_path, monkeypatch, n_ctx = 8192, paravirtual = True, **self.NOTHING_FITS)[
+            "cmd"
+        ]
+        assert _ctx_values(cmd)[-1] == "8192"
+
+    def test_weights_over_budget_is_still_not_refused(self, tmp_path, monkeypatch):
+        """The neighbouring state, and the discriminator between them. Here the fit
+        cannot shrink, so nothing was measured and the host-RAM guard owns the failure."""
+        cmd = _launch(
+            tmp_path,
+            monkeypatch,
+            n_ctx = 8192,
+            real_fit = True,
+            budget_bytes = _BUDGET,
+            weights_bytes = 4100 * 1024**2,
+            kv_per_token = _FAT_KV,
+        )["cmd"]
+        assert _ctx_values(cmd)[-1] == "8192"
+
+    def test_a_host_with_room_for_a_small_context_names_it(self, tmp_path, monkeypatch):
+        """The third state, so all three arms are pinned against the real helper: the
+        floor re-price finds something, and that something is what gets named."""
+        with pytest.raises(RuntimeError, match = "The largest that fits"):
+            _launch(
+                tmp_path,
+                monkeypatch,
+                n_ctx = 32768,
+                real_fit = True,
+                budget_bytes = _BUDGET,
+                weights_bytes = _TIGHT_WEIGHTS,
+                kv_per_token = _FAT_KV,
+            )

--- a/studio/backend/tests/test_metal_explicit_context_guard.py
+++ b/studio/backend/tests/test_metal_explicit_context_guard.py
@@ -4,12 +4,16 @@
 """A hand-set context above what unified memory holds must be refused, not launched.
 
 The Metal branch of load_model already works out the largest context that fits, but
-only Auto was ever moved to it: an explicit request was passed through verbatim on the
-theory that "--fit on" is a backstop. It is not one here. --fit flexes -ngl to spill
-layers to the host, and on unified memory the host is the same pool, so the spill frees
-nothing and the launch over-commits. A discrete GPU answers that with an out-of-memory
-error; a Mac has nothing to fall back on and panics the whole machine, which is what an
-M1 Max 32 GB hit on Qwen3.8-27B-UD-Q4_K_XL as soon as the context was set by hand.
+only Auto was ever moved to it: an explicit request was passed through verbatim, on the
+theory that "--fit on" is a backstop. It is one, but not a trustworthy one here.
+llama.cpp will reduce an explicit context (fit_params_min_ctx defaults to 4096; only
+"-c 0" disables the reduction), but it decides from ggml-metal's free-memory report,
+which comes off the device's recommendedMaxWorkingSetSize and knows nothing about
+Studio's own resident gigabyte or two, other running apps, or the iogpu wired limit
+that is the figure actually being blown. When that estimate is optimistic the request
+stands and the launch over-commits wired memory, which Jetsam cannot reclaim, so the
+machine panics instead of the load failing. An M1 Max 32 GB hit exactly that on
+Qwen3.8-27B-UD-Q4_K_XL, twice, as soon as the context was set by hand.
 
 So the ceiling the branch computes now gates the explicit request too, and the refusal
 names it. Two things it deliberately does not do: refuse against the 4096 fallback the
@@ -106,19 +110,29 @@ def _launch(
     gpu_memory_mode = "auto",
     gpu_layers = -1,
     extra_args = None,
+    paravirtual = False,
+    cache_type_kv = None,
+    backend = None,
 ):
     """Drive the real load_model with no GPU enumerated (the Metal condition).
 
     The KV estimate is a flat 1 KiB per token and the compute buffer is zeroed, so the
     footprint check the branch runs before trusting its own ceiling passes on the tiny
     stub GGUF and the ceiling under test is the one the fit returns.
+
+    Returns the launch capture ({"cmd": argv}, empty when nothing launched). Pass
+    ``backend`` to drive a second load through the same instance, which is the only way
+    to observe what a refusal does to state a previous load left behind.
     """
     monkeypatch.setattr(
         LlamaCppBackend,
         "_apple_metal_memory_budget_bytes",
         staticmethod(lambda: 9 * 1024**3 if metal else 0),
     )
-    backend = LlamaCppBackend()
+    if paravirtual:
+        import core.inference.llama_cpp as _llama_cpp
+        monkeypatch.setattr(_llama_cpp, "_metal_device_is_paravirtual", lambda: True)
+    backend = backend if backend is not None else LlamaCppBackend()
     backend._get_gpu_memory = lambda _binary = None, **_kw: []
     backend._get_gpu_free_memory = lambda _binary = None, **_kw: []
     backend._read_gguf_metadata = lambda _path: None
@@ -166,8 +180,10 @@ def _launch(
                 gpu_memory_mode = gpu_memory_mode,
                 gpu_layers = gpu_layers,
                 extra_args = extra_args,
+                cache_type_kv = cache_type_kv,
             )
         )
+    captured["backend"] = backend
     return captured
 
 
@@ -283,3 +299,152 @@ def test_the_refusal_is_raised_outside_the_placement_handler():
     raised = src.find("raise RuntimeError(_metal_ctx_refusal)")
     assert assigned != -1 and handler != -1 and raised != -1
     assert assigned < handler < raised
+
+
+class TestAVirtualisedMetalDevice:
+    """A Mac VM runs GGUF entirely on CPU, so this budget is the wrong yardstick.
+
+    The paravirtual pin rewrites every placement to manual/0 and launches behind
+    --device none, because offloaded layers on a virtualised Metal device produce
+    corrupt output. Nothing is allocated on the GPU, so refusing against a GPU
+    working-set budget would break loads that work today on a Mac VM (and on the
+    macOS GitHub Actions runners, which report exactly this device), and the message
+    would describe hardware the launch never touches. Host RAM is the real limit
+    there, and _host_offload_shortfall_message already prices that.
+
+    Caught by the pre-merge OS x GPU simulation, not by review: the exemption reads
+    _paravirtual_cpu_forced, which is set from the hardware, while the neighbouring
+    _caller_owns_budget is read off the REQUEST and so stays False for the Auto load
+    the pin rewrote.
+    """
+
+    def test_it_is_not_refused(self, tmp_path, monkeypatch):
+        cmd = _launch(tmp_path, monkeypatch, n_ctx = 32768, paravirtual = True)["cmd"]
+        assert _ctx_values(cmd)[-1] == "32768"
+
+    def test_a_physical_mac_in_the_same_shape_is_still_refused(self, tmp_path, monkeypatch):
+        """Pins that the exemption is the virtualised device, not the CPU placement
+        it happens to produce."""
+        with pytest.raises(RuntimeError, match = "unified"):
+            _launch(tmp_path, monkeypatch, n_ctx = 32768, paravirtual = False)
+
+    def test_auto_is_still_capped_there(self, tmp_path, monkeypatch):
+        """The exemption is from the refusal only. Auto still shrinks to the ceiling,
+        which is what keeps a virtualised Mac off its native context."""
+        cmd = _launch(tmp_path, monkeypatch, n_ctx = 0, paravirtual = True)["cmd"]
+        assert _ctx_values(cmd)[-1] == str(CEILING)
+
+
+class TestTheMessageSurvivesTheRoute:
+    """load_model raises; the route rewrites the text twice before the user reads it.
+
+    It is caught by the broad handler in _load_model_impl, which redacts native paths
+    and then runs _maybe_unsupported_message over the result, exactly as the existing
+    APU and host-offload refusals are. Both rewrites have to leave this message alone
+    or the user is told something false about a fixable mistake.
+    """
+
+    def _message(self, tmp_path, monkeypatch) -> str:
+        with pytest.raises(RuntimeError) as excinfo:
+            _launch(tmp_path, monkeypatch, n_ctx = 32768)
+        return str(excinfo.value)
+
+    def test_it_is_not_relabelled_as_an_unsupported_model(self, tmp_path, monkeypatch):
+        """_maybe_unsupported_message rewrites any error carrying one of these into
+        "This model is not supported yet. Try a different model.", which would send
+        the user off to change models over a context they can simply lower.
+
+        Read out of the route source rather than imported: the phrase list is the
+        contract, and importing routes.inference would drag FastAPI into a test that
+        only needs four strings.
+        """
+        import ast
+        import re
+
+        route_src = (Path(__file__).resolve().parent.parent / "routes" / "inference.py").read_text()
+        hints = ast.literal_eval(
+            re.search(r"_NOT_SUPPORTED_HINTS = (\(.*?\))", route_src, re.S).group(1)
+        )
+        # The list is only a contract if it is the real one.
+        assert "is not supported" in hints
+        message = self._message(tmp_path, monkeypatch).lower()
+        assert [h for h in hints if h.lower() in message] == []
+
+    def test_it_carries_nothing_for_the_path_redactor_to_eat(self, tmp_path, monkeypatch):
+        """redact_native_paths replaces any leased path with <native_path>. A message
+        with no path in it cannot be cut in half by that."""
+        message = self._message(tmp_path, monkeypatch)
+        assert "/" not in message.replace("q8_0", "")
+
+    def test_it_is_a_single_line_of_plain_text(self, tmp_path, monkeypatch):
+        """The route prefixes it ("Failed to load model: ...") and the UI renders the
+        detail as one string."""
+        message = self._message(tmp_path, monkeypatch)
+        assert "\n" not in message
+
+
+class TestWhatARefusedReloadCosts:
+    """A refused reload ends with no model loaded, and that is the existing contract.
+
+    load_model kills the resident server in its Phase 1, long before the placement
+    block that computes the ceiling. Every refusal raised from that block behaves this
+    way already: the APU RAM shortfall, the unpinnable Vulkan ordinal. Refusing earlier
+    would mean re-deriving the fit outside the one place that owns it, which is the
+    drift _apu_ram_shortfall_message explicitly avoids.
+
+    So this is pinned rather than fixed, and it is still the better end state: before
+    this guard the same click took the whole machine down. The recovery path is what
+    has to work, and the next test covers it.
+    """
+
+    def test_the_refused_reload_leaves_nothing_running(self, tmp_path, monkeypatch):
+        # is_active, not is_loaded: this asks whether a child process exists, and
+        # health is a separate signal the stubbed launch does not model.
+        backend = _launch(tmp_path, monkeypatch, n_ctx = 4096)["backend"]
+        assert backend.is_active
+        with pytest.raises(RuntimeError, match = "unified"):
+            _launch(tmp_path, monkeypatch, n_ctx = 32768, backend = backend)
+        assert not backend.is_active
+
+    def test_a_smaller_retry_after_a_refusal_succeeds(self, tmp_path, monkeypatch):
+        """Nothing about the refusal is sticky: no half-written request state, and no
+        dedupe that would read the retry as already loaded."""
+        backend = LlamaCppBackend()
+        with pytest.raises(RuntimeError, match = "unified"):
+            _launch(tmp_path, monkeypatch, n_ctx = 32768, backend = backend)
+        assert not backend.is_active
+        cmd = _launch(tmp_path, monkeypatch, n_ctx = 4096, backend = backend)["cmd"]
+        assert _ctx_values(cmd)[-1] == "4096"
+
+
+class TestTheContextCanArriveByAnotherDoor:
+    """requested_ctx folds in a -c from extra args, so every spelling is covered.
+
+    Worth pinning: if the guard read intent.n_ctx directly it would sit one text box
+    away from being bypassed, and the pass-through spelling is the one a user reaches
+    for after being refused.
+    """
+
+    @pytest.mark.parametrize(
+        "extra",
+        [
+            ("-c", "32768"),
+            ("--ctx-size", "32768"),
+            ("--ctx-size=32768",),
+        ],
+    )
+    def test_a_pass_through_context_is_refused_too(self, tmp_path, monkeypatch, extra):
+        with pytest.raises(RuntimeError, match = "unified"):
+            _launch(tmp_path, monkeypatch, n_ctx = 0, extra_args = list(extra))
+
+    def test_a_pass_through_context_under_the_ceiling_still_launches(
+        self, tmp_path, monkeypatch
+    ):
+        cmd = _launch(tmp_path, monkeypatch, n_ctx = 0, extra_args = ["-c", "4096"])["cmd"]
+        assert _ctx_values(cmd)[-1] == "4096"
+
+    def test_a_zero_pass_through_is_floored_not_refused(self, tmp_path, monkeypatch):
+        """"-c 0" is read as non-explicit and handled by the existing floor (#5118),
+        so it must not turn into a refusal."""
+        cmd = _launch(tmp_path, monkeypatch, n_ctx = 0, extra_args = ["-c", "0"])["cmd"]
+        assert _ctx_values(cmd) and _ctx_values(cmd)[-1] != "0"

--- a/studio/backend/tests/test_metal_explicit_context_guard.py
+++ b/studio/backend/tests/test_metal_explicit_context_guard.py
@@ -437,14 +437,12 @@ class TestTheContextCanArriveByAnotherDoor:
         with pytest.raises(RuntimeError, match = "unified"):
             _launch(tmp_path, monkeypatch, n_ctx = 0, extra_args = list(extra))
 
-    def test_a_pass_through_context_under_the_ceiling_still_launches(
-        self, tmp_path, monkeypatch
-    ):
+    def test_a_pass_through_context_under_the_ceiling_still_launches(self, tmp_path, monkeypatch):
         cmd = _launch(tmp_path, monkeypatch, n_ctx = 0, extra_args = ["-c", "4096"])["cmd"]
         assert _ctx_values(cmd)[-1] == "4096"
 
     def test_a_zero_pass_through_is_floored_not_refused(self, tmp_path, monkeypatch):
-        """"-c 0" is read as non-explicit and handled by the existing floor (#5118),
+        """ "-c 0" is read as non-explicit and handled by the existing floor (#5118),
         so it must not turn into a refusal."""
         cmd = _launch(tmp_path, monkeypatch, n_ctx = 0, extra_args = ["-c", "0"])["cmd"]
         assert _ctx_values(cmd) and _ctx_values(cmd)[-1] != "0"

--- a/studio/frontend/src/config/env.ts
+++ b/studio/frontend/src/config/env.ts
@@ -22,6 +22,12 @@ export type DeviceType = "mac" | "windows" | "linux" | string;
 
 interface PlatformState {
   deviceType: DeviceType;
+  // Unified memory: the GPU and the rest of the system draw on one pool, so an
+  // over-committed load has nowhere to spill and takes the machine down rather than
+  // failing. Narrower than deviceType === "mac", which is every Darwin host including
+  // an Intel Mac with a discrete GPU, where spilling to system RAM is exactly what
+  // happens. Mirrors the backend's own is_apple_silicon gate on the Metal budget.
+  appleSilicon: boolean;
   chatOnly: boolean;
   // Why chatOnly is set (null when training is enabled), from /api/health.
   // e.g. "mlx_unavailable" on Apple Silicon -> the UI explains the greyed-out
@@ -62,6 +68,7 @@ const localDeviceType = detectLocalPlatform();
 
 export const usePlatformStore = create<PlatformState>()((_, get) => ({
   deviceType: localDeviceType,
+  appleSilicon: false,
   // A guess from the user agent, kept only as the pre-measurement fallback for the redirects
   // that must decide something before /api/health answers. Capability gating must read
   // capabilitiesUnknown() first and hold, not gray a tab out on this.
@@ -153,6 +160,7 @@ export async function fetchDeviceType(options?: {
     if (res.ok) {
       const data = (await res.json()) as {
         device_type?: string;
+        apple_silicon?: boolean;
         chat_only?: boolean;
         chat_only_reason?: string | null;
         hardware_detecting?: boolean;
@@ -176,6 +184,13 @@ export async function fetchDeviceType(options?: {
       const keepPlatform = data.device_type === undefined && previous.fetched;
       const deviceType =
         data.device_type ?? (keepPlatform ? previous.deviceType : detectLocalPlatform());
+      // Rides with device_type, and is kept on the same terms: a provisional or
+      // unauthenticated reply carries neither, and a browser guess cannot tell an Apple
+      // Silicon Mac from an Intel one. Absent means false, which is the pre-Apple-Silicon
+      // wording everywhere -- correct on an Intel Mac, and on a Mac browser pointed at a
+      // Linux host.
+      const appleSilicon =
+        data.apple_silicon ?? (keepPlatform ? previous.appleSilicon : false);
       // A still-provisional reply keeps the stored verdict: see resolveVerdict.
       const { chatOnly, chatOnlyReason, chatOnlyDetail } = resolveVerdict(
         data,
@@ -186,6 +201,7 @@ export async function fetchDeviceType(options?: {
       // SSH); keeping fetched=false retries once a token exists.
       usePlatformStore.setState({
         deviceType,
+        appleSilicon,
         chatOnly,
         chatOnlyReason,
         chatOnlyDetail,

--- a/studio/frontend/src/config/env.ts
+++ b/studio/frontend/src/config/env.ts
@@ -22,11 +22,10 @@ export type DeviceType = "mac" | "windows" | "linux" | string;
 
 interface PlatformState {
   deviceType: DeviceType;
-  // Unified memory: the GPU and the rest of the system draw on one pool, so an
-  // over-committed load has nowhere to spill and takes the machine down rather than
-  // failing. Narrower than deviceType === "mac", which is every Darwin host including
-  // an Intel Mac with a discrete GPU, where spilling to system RAM is exactly what
-  // happens. Mirrors the backend's own is_apple_silicon gate on the Metal budget.
+  // Unified memory: GPU and system draw on one pool, so an over-committed load has
+  // nowhere to spill and takes the machine down rather than failing. Narrower than
+  // deviceType === "mac", which includes Intel Macs with a discrete GPU, where spilling
+  // to system RAM is exactly what happens. Mirrors the backend's is_apple_silicon gate.
   appleSilicon: boolean;
   chatOnly: boolean;
   // Why chatOnly is set (null when training is enabled), from /api/health.
@@ -184,11 +183,10 @@ export async function fetchDeviceType(options?: {
       const keepPlatform = data.device_type === undefined && previous.fetched;
       const deviceType =
         data.device_type ?? (keepPlatform ? previous.deviceType : detectLocalPlatform());
-      // Rides with device_type, and is kept on the same terms: a provisional or
-      // unauthenticated reply carries neither, and a browser guess cannot tell an Apple
-      // Silicon Mac from an Intel one. Absent means false, which is the pre-Apple-Silicon
-      // wording everywhere -- correct on an Intel Mac, and on a Mac browser pointed at a
-      // Linux host.
+      // Rides with device_type and is kept on the same terms: a provisional or
+      // unauthenticated reply carries neither, and a browser guess cannot tell Apple
+      // Silicon from Intel. Absent means false, the pre-Apple-Silicon wording -- correct
+      // on an Intel Mac, and on a Mac browser pointed at a Linux host.
       const appleSilicon =
         data.apple_silicon ?? (keepPlatform ? previous.appleSilicon : false);
       // A still-provisional reply keeps the stored verdict: see resolveVerdict.

--- a/studio/frontend/src/features/chat/chat-settings-sheet.tsx
+++ b/studio/frontend/src/features/chat/chat-settings-sheet.tsx
@@ -1067,9 +1067,8 @@ export function ChatSettingsPanel({
                       Context length exceeds what fits in unified memory (
                       {ggufMaxContextLength?.toLocaleString()} tokens). The GPU
                       and the rest of the system share one pool here, so there
-                      is nothing to offload to and the load is refused. Lower
-                      the context, leave it on Auto, or set the KV cache to
-                      q8_0.
+                      is nothing to offload to. Lower the context, leave it on
+                      Auto, or set the KV cache to q8_0.
                     </>
                   ) : (
                     <>

--- a/studio/frontend/src/features/chat/chat-settings-sheet.tsx
+++ b/studio/frontend/src/features/chat/chat-settings-sheet.tsx
@@ -516,6 +516,8 @@ export function ChatSettingsPanel({
     ggufContextLength != null ||
     (currentCheckpoint?.toLowerCase().endsWith(".gguf") ?? false);
   const platformDeviceType = usePlatformStore((s) => s.deviceType);
+  // Unified memory, not just Darwin: an Intel Mac spills to system RAM like a PC.
+  const isUnifiedMemory = usePlatformStore((s) => s.appleSilicon);
   const platformChatOnlyReason = usePlatformStore((s) => s.chatOnlyReason);
   const loadSettingNames = presetLoadSettingNames(
     isGguf,
@@ -1062,7 +1064,7 @@ export function ChatSettingsPanel({
               )}
               {showContextVramWarning && (
                 <p className="text-ui-11 text-amber-500">
-                  {platformDeviceType === "mac" ? (
+                  {isUnifiedMemory ? (
                     <>
                       Context length exceeds what fits in unified memory (
                       {ggufMaxContextLength?.toLocaleString()} tokens). The GPU

--- a/studio/frontend/src/features/chat/chat-settings-sheet.tsx
+++ b/studio/frontend/src/features/chat/chat-settings-sheet.tsx
@@ -1062,9 +1062,22 @@ export function ChatSettingsPanel({
               )}
               {showContextVramWarning && (
                 <p className="text-ui-11 text-amber-500">
-                  Context length exceeds the estimated VRAM capacity (
+                  {platformDeviceType === "mac" ? (
+                    <>
+                      Context length exceeds what fits in unified memory (
+                      {ggufMaxContextLength?.toLocaleString()} tokens). The GPU
+                      and the rest of the system share one pool here, so there
+                      is nothing to offload to and the load is refused. Lower
+                      the context, leave it on Auto, or set the KV cache to
+                      q8_0.
+                    </>
+                  ) : (
+                    <>
+                      Context length exceeds the estimated VRAM capacity (
                       {ggufMaxContextLength?.toLocaleString()} tokens). The
                       model may use system RAM.
+                    </>
+                  )}
                 </p>
               )}
             </div>

--- a/studio/frontend/src/features/model-picker/components/model-config-page.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-config-page.tsx
@@ -2320,9 +2320,20 @@ export function ModelConfigPage({
                 loadedMaxContextLength != null &&
                 contextValue > loadedMaxContextLength && (
                   <p className="text-ui-11 text-amber-500">
-                    Exceeds estimated VRAM capacity (
-                    {loadedMaxContextLength.toLocaleString()} tokens). The model
-                    may use system RAM.
+                    {platformDeviceType === "mac" ? (
+                      <>
+                        Exceeds what fits in unified memory (
+                        {loadedMaxContextLength.toLocaleString()} tokens). The
+                        GPU and the rest of the system share one pool here, so
+                        there is nothing to offload to and the load is refused.
+                      </>
+                    ) : (
+                      <>
+                        Exceeds estimated VRAM capacity (
+                        {loadedMaxContextLength.toLocaleString()} tokens). The
+                        model may use system RAM.
+                      </>
+                    )}
                   </p>
                 )}
             </div>

--- a/studio/frontend/src/features/model-picker/components/model-config-page.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-config-page.tsx
@@ -2325,7 +2325,7 @@ export function ModelConfigPage({
                         Exceeds what fits in unified memory (
                         {loadedMaxContextLength.toLocaleString()} tokens). The
                         GPU and the rest of the system share one pool here, so
-                        there is nothing to offload to and the load is refused.
+                        there is nothing to offload to.
                       </>
                     ) : (
                       <>

--- a/studio/frontend/src/features/model-picker/components/model-config-page.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-config-page.tsx
@@ -1452,6 +1452,8 @@ export function ModelConfigPage({
 }: ModelConfigPageProps) {
   const rememberId = useId();
   const platformDeviceType = usePlatformStore((s) => s.deviceType);
+  // Unified memory, not just Darwin: an Intel Mac spills to system RAM like a PC.
+  const isUnifiedMemory = usePlatformStore((s) => s.appleSilicon);
   const platformChatOnlyReason = usePlatformStore((s) => s.chatOnlyReason);
   const mlxKvQuantReason = useChatRuntimeStore((s) => s.mlxKvQuantReason);
   const chatTemplateOverrideReason = useChatRuntimeStore(
@@ -2320,7 +2322,7 @@ export function ModelConfigPage({
                 loadedMaxContextLength != null &&
                 contextValue > loadedMaxContextLength && (
                   <p className="text-ui-11 text-amber-500">
-                    {platformDeviceType === "mac" ? (
+                    {isUnifiedMemory ? (
                       <>
                         Exceeds what fits in unified memory (
                         {loadedMaxContextLength.toLocaleString()} tokens). The


### PR DESCRIPTION
Reported on r/unsloth: on an M1 Max (32 GB), adjusting the context length by hand on `Qwen3.8-27B-UD-Q4_K_XL.gguf` kernel panics the machine. Twice. It does not happen on `Q3_K_XL`, and it does not happen with the context left on Auto.

### What is happening

The Metal branch of `load_model` already works out the largest context that fits in unified memory. It only ever applied that answer to Auto:

```python
if not explicit_ctx:
    effective_ctx = max_available_ctx
```

An explicit context was passed through verbatim, on the theory that `--fit on` is a backstop. It is a backstop, just not one worth leaning on here, for two reasons that compound.

llama.cpp will reduce an explicit context: `fit_params_min_ctx` defaults to 4096 in `common.h`, and only `-c 0` raises it to `UINT32_MAX` to disable the reduction outright. But it decides from the free memory ggml-metal reports, which comes off the device's `recommendedMaxWorkingSetSize`. That is a property of the machine, not of the moment. It knows nothing about Studio's own resident gigabyte or two, about whatever else the user has open, or about the `iogpu` wired limit that is the figure actually being blown. `_apple_metal_memory_budget_bytes` exists because of exactly that gap, and already takes `min(device ceiling, psutil available)` instead.

When llama.cpp's estimate comes out optimistic it leaves the request alone and the launch over-commits wired memory. Wired pages are not reclaimable, so Jetsam cannot step in the way it would for an ordinary process: the driver faults and the machine panics, rather than the load failing the way it would on a discrete GPU. Q3_K_XL surviving the same edit is the size difference: roughly 12.5 GB of weights against 16.7 GB, out of the 21 to 22 GB the GPU is allowed on a 32 GB machine, so Q3 has headroom for a manual bump and Q4 does not.

There is already a refusal helper for this shape of problem, `_apu_ram_shortfall_message`, but it is gated on AMD APUs and prices the weights only. Its docstring says why it leaves the context out: "KV/context auto-reduce, so counting them too would refuse loads that would succeed". True on the path it guards. On this path the explicit context is exactly what does not reliably auto-reduce, so the KV and compute buffers are the bytes that do the damage.

### The fix

Gate the explicit request on the ceiling the branch already computes, and refuse above it rather than launching. The message names the largest context that fits, so the answer is actionable without a second round trip:

```
A context of 32,768 tokens does not fit in this Mac's unified memory with this model.
The largest that fits is 8,192 tokens. The GPU and the rest of the system share one
pool here, so there is nothing to offload to, and the load would bring the machine
down instead of reporting an error. Lower the context to 8,192 or less, leave it on
Auto, or use a more quantized GGUF. Setting the KV cache to q8_0 roughly halves what
the context costs. Set UNSLOTH_ALLOW_METAL_CTX_OVERCOMMIT=1 to load it anyway.
```

Refusing rather than silently clamping to the ceiling is deliberate. The number the user typed is the number they get told about, and a context that quietly became a quarter of what was asked for is its own support thread.

Three things it deliberately does not refuse:

- The 4096 the branch falls back to when KV cannot be sized. That is a guess, not a measurement, and refusing against it would block contexts that load fine today. Only a ceiling backed by a real KV estimate can refuse.
- A manual load with a fixed layer count. That is the user taking the memory budget over, and it is the same exemption the other Metal context guards already make. It is read off the request, so the paravirtual CPU pin cannot make a plain Auto load look caller owned.
- A virtualised Metal device. Studio pins that whole load to CPU behind `--device none`, because offloaded layers there produce corrupt output, so it allocates no GPU memory at all and this budget is the wrong yardstick for it. Host RAM is the real limit and `_host_offload_shortfall_message` already prices it.

`UNSLOTH_ALLOW_METAL_CTX_OVERCOMMIT=1` abstains outright, matching the `UNSLOTH_ALLOW_HOST_OFFLOAD` opt-out, with the caveat that the failure mode it re-enables is the whole machine rather than one app.

One structural detail worth flagging for review. The refusal is raised after the placement block, not inside it. The broad `except Exception` around GPU selection turns any raise into "GPU selection failed, using --fit on" and then does `effective_ctx = requested_ctx`, which is precisely the over-commit being refused. Raising in place would have left a guard that looks correct, tests green, and does nothing. The branch records the message and `load_model` raises it once past that handler. A test pins the ordering, because that failure would be silent.

### The UI warning was also wrong on Mac

Both context sliders warned that the model "may use system RAM". Sound advice on a PC, and a description of something that does not exist on unified memory, which is what made the state read as survivable. On Mac they now say what is actually true there.

### What a refused reload costs

`load_model` kills the resident server in its Phase 1, long before the placement block that computes the ceiling, so a refused reload ends with no model loaded. That is the existing contract for every refusal raised from that block (the APU RAM shortfall, the unpinnable Vulkan ordinal), and refusing earlier would mean re-deriving the fit outside the one place that owns it. It is pinned in a test rather than fixed, and it is still the better end state: before this guard, the same click took the whole machine down.

### Verification

Simulated across `[Windows, Linux, WSL, macOS Apple Silicon, macOS paravirtual, macOS Intel] x [NVIDIA, AMD, CPU only]`, driving the real `load_model` against a fake llama-server with the platform probes swapped out. 191 cases, run on Python 3.10, 3.12 and 3.13. The budget helper itself is left real in that harness, so its Apple Silicon gate is exercised rather than bypassed, and it is asserted to return 0 on every non-Apple cell.

The simulation is what caught the virtualised-Metal exemption above. Review did not: the neighbouring `_caller_owns_budget` is read off the request, so it stays False for the Auto load the paravirtual pin rewrote to manual/0, and the guard fired on a load that never touches the GPU. That would have broken Mac VMs and the macOS Actions runners.

Also covered: every `-c` spelling in extra args (`-c N`, `--ctx-size N`, `--ctx-size=N`) is refused too, since `resolve_requested_ctx` folds them into `requested_ctx`; `-c 0` stays on the existing floor path rather than becoming a refusal; both route rewrites leave the message intact, in particular `_maybe_unsupported_message`, which would otherwise relabel a fixable context mistake as "This model is not supported yet"; and a refused load leaves no state that breaks the next one.

`studio/backend/tests/test_metal_explicit_context_guard.py` carries the distilled 47 cases. Existing suites re-run green: 839 across `test_metal_never_starts_at_native_context`, `test_metal_paravirtual_guard`, `test_llama_cpp_max_context_threshold`, `test_gpu_memory_mode`, `test_amd_apu_unified_memory`, `test_host_offload_ram_guard`, `test_llama_cpp_placement`, `test_compute_buffer`, `test_vram_budget_settings`, `test_llama_cpp_props_readback`, `test_batch_sizes_per_load`.

Frontend: `npm run typecheck` clean, `npm test` 3713 passing, `i18n:check` parity clean, and `biome check` on the two touched files reports the same 8 errors and 29 warnings before and after, so the change adds none. The wording branches on `platformDeviceType`, which is the server-reported platform, not a user-agent guess, so it stays correct when a Mac browser drives a Linux Studio over a tunnel, and it uses no browser-specific API.

### Not covered here

Showing the ceiling on the slider before you load, rather than at load time, is the better version of this and a larger change. The refusal is the part that stops the panics, so it goes first.