### PR TITLE
Run two short jobs as background lanes of Lint CI, not on their own runners

### DIFF
--- a/.github/scripts/lane-load-orchestrator.sh
+++ b/.github/scripts/lane-load-orchestrator.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+#
+# The load-orchestrator freeze suite, in ONE definition.
+#
+# This used to be a whole workflow holding its own runner slot for ~33s. It now runs as a
+# background lane inside Lint CI, which was going to occupy a runner on every commit
+# anyway. studio-load-orchestrator-ci.yml still exists as a manual escape hatch and calls
+# this same script, so the two cannot drift apart.
+#
+# Deliberately installs no torch and no unsloth: that is what keeps it cheap enough to run
+# on every commit rather than only on the four paths that used to trigger it.
+#
+# Takes its venv directory as $1 so the caller decides the isolation. Inside Lint CI that
+# is a private venv, because the lane installs packages while the foreground lint steps are
+# using the job's interpreter, and two concurrent installs into one site-packages race.
+set -euo pipefail
+
+venv_dir="${1:-}"
+
+if [ -n "$venv_dir" ]; then
+    python3 -m venv "$venv_dir"
+    # shellcheck disable=SC1091
+    . "$venv_dir/bin/activate"
+fi
+
+python -m pip install --upgrade pip
+python -m pip install \
+    'pytest>=8' \
+    'httpx>=0.27,<1' \
+    'fastapi>=0.110,<1' \
+    'uvicorn>=0.30,<1' \
+    'anyio>=4'
+
+python -m pytest -v --tb=short tests/studio/load_freeze/

--- a/.github/scripts/lane-lockfile-audit.sh
+++ b/.github/scripts/lane-lockfile-audit.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+#
+# The lockfile supply-chain audit, in ONE definition.
+#
+# Ran as its own workflow on its own runner slot for ~6s of work. It now runs as a
+# background lane inside Lint CI. lockfile-audit.yml keeps its nightly `schedule` and calls
+# this same script, so the scheduled audit is unchanged and the two cannot drift apart.
+#
+# Needs no dependencies at all, which is why it needs no venv: it is stdlib Python over
+# files already in the checkout.
+set -euo pipefail
+
+# Parses before it runs, so a syntax error in the auditor is reported as a syntax error
+# rather than as an audit finding.
+python3 -c "import ast; ast.parse(open('scripts/lockfile_supply_chain_audit.py').read())"
+python3 scripts/lockfile_supply_chain_audit.py

--- a/.github/workflows/lint-ci.yml
+++ b/.github/workflows/lint-ci.yml
@@ -68,6 +68,60 @@ jobs:
       # which codespell version the runner happened to install.
       - run: pip install 'ruff==0.15.12' 'pyyaml>=6' 'codespell>=2.3,<3'
 
+      # Two short jobs that used to hold a runner slot each, absorbed onto this one.
+      #
+      #   Unsloth load-orchestrator CI :: test   33 s, its own slot
+      #   Lockfile supply-chain audit :: audit     6 s, its own slot
+      #
+      # Both are pure read-only checks: no server, no port, no install of Unsloth, no
+      # state outside the workspace. They are launched here in the BACKGROUND and
+      # collected in the last step of this job, so they overlap the ~65 s of lint below
+      # and cost no wall clock at all rather than being appended to it. ubuntu-latest has
+      # four cores and the lint steps are single-threaded, so the capacity is there.
+      #
+      # Each lane gets its own venv. That is the only isolation this needs, and it is
+      # load-bearing: the lane installs fastapi/httpx/pytest while the foreground steps
+      # are using the interpreter that `pip install` above populated, and two concurrent
+      # pip installs into one site-packages is a genuine race rather than a theoretical
+      # one. Nothing else is shared -- no ports are bound and no files are written outside
+      # each lane's own log.
+      #
+      # This job has no path filter, so it runs on every commit, which means absorbing a
+      # narrower-triggered job here can only ever REDUCE the slots a commit takes: the
+      # absorbed work now runs on commits that would not have triggered it, but on a
+      # runner that was already going to exist.
+      - name: Start the absorbed suites (background)
+        run: |
+          set -euo pipefail
+          mkdir -p logs .lanes
+
+          # Written on exit with the lane's status, and read by the collect step. A lane
+          # that dies without writing one is reported as a failure there rather than
+          # silently passing, which is the failure mode that makes backgrounding risky.
+          # `</dev/null >/dev/null 2>&1` on the SUBSHELL is not tidiness, it is what makes
+          # this step return immediately. A background child inherits the step's stdout
+          # and stderr pipes, and the runner does not consider a step finished while a
+          # writer still holds them: without this the launch blocks for as long as the
+          # lane runs, which is precisely the overlap the backgrounding exists to buy.
+          # Measured: 4.0 s to launch a 4 s lane before, 0.0 s after.
+          #
+          # The inner redirect to the log applies to the command itself and takes
+          # precedence, so nothing is lost -- the lane's output is replayed by the
+          # collect step.
+          lane() {
+            name="$1"; shift
+            (
+              rc=0
+              "$@" > "logs/lane-$name.log" 2>&1 || rc=$?
+              echo "$rc" > ".lanes/$name.rc"
+            ) < /dev/null > /dev/null 2>&1 &
+          }
+
+          lane load-orchestrator bash .github/scripts/lane-load-orchestrator.sh .lanes/venv-load-orchestrator
+          lane lockfile-audit bash .github/scripts/lane-lockfile-audit.sh
+
+          echo "launched 2 background lanes"
+
       - name: Linux deps for shellcheck
         run: sudo apt-get update -qq && sudo apt-get install -y --no-install-recommends shellcheck
 
@@ -413,3 +467,42 @@ jobs:
         continue-on-error: true
         run: |
           ruff format --check unsloth unsloth_cli studio tests cli.py unsloth-cli.py
+
+      # Collects the two lanes launched before the lint steps. This step is the whole
+      # reason the backgrounding is safe: without it a lane's failure would be invisible
+      # and the absorbed jobs would be silently deleted rather than moved.
+      #
+      # `always()` so a lane failure is still reported when a lint step above failed
+      # first, and a missing .rc file is a failure rather than a pass, which covers a
+      # lane that was killed or never started.
+      - name: Collect the absorbed suites
+        if: always()
+        run: |
+          set -uo pipefail
+          rc=0
+          for name in load-orchestrator lockfile-audit; do
+            # The lanes are children of an earlier step's shell, not of this one, so
+            # `wait` cannot see them; poll for the sentinel instead. 240s is well beyond
+            # the 33s and 6s these take, and the job timeout bounds it regardless.
+            waited=0
+            while [ ! -f ".lanes/$name.rc" ] && [ "$waited" -lt 240 ]; do
+              sleep 2
+              waited=$((waited + 2))
+            done
+            echo "::group::$name"
+            cat "logs/lane-$name.log" 2>/dev/null || echo "(no log produced)"
+            echo "::endgroup::"
+            if [ ! -f ".lanes/$name.rc" ]; then
+              echo "::error::$name never finished (no exit status after ${waited}s)"
+              rc=1
+              continue
+            fi
+            lane_rc=$(cat ".lanes/$name.rc")
+            if [ "$lane_rc" != "0" ]; then
+              echo "::error::$name failed with exit status $lane_rc"
+              rc=1
+            else
+              echo "$name passed"
+            fi
+          done
+          exit "$rc"

--- a/.github/workflows/lockfile-audit.yml
+++ b/.github/workflows/lockfile-audit.yml
@@ -24,24 +24,15 @@
 
 name: Lockfile supply-chain audit
 
+# Per-commit runs are gone: this audit now runs as a background lane inside Lint CI,
+# which already occupies a runner on every commit, so it costs a slot there instead of
+# holding one of its own for ~6s of work. Both call
+# .github/scripts/lane-lockfile-audit.sh, so there is one definition.
+#
+# The nightly schedule is deliberately KEPT. It is not the same check: it re-audits the
+# lockfiles as they stand against advisories published since the last commit, which no
+# commit-triggered run can do.
 on:
-  pull_request:
-    paths:
-      - 'studio/frontend/package-lock.json'
-      - 'studio/backend/core/data_recipe/oxc-validator/package-lock.json'
-      - 'studio/package-lock.json'
-      - 'studio/src-tauri/Cargo.lock'
-      - 'scripts/lockfile_supply_chain_audit.py'
-      - '.github/workflows/lockfile-audit.yml'
-  push:
-    branches: [main]
-    paths:
-      - 'studio/frontend/package-lock.json'
-      - 'studio/backend/core/data_recipe/oxc-validator/package-lock.json'
-      - 'studio/package-lock.json'
-      - 'studio/src-tauri/Cargo.lock'
-      - 'scripts/lockfile_supply_chain_audit.py'
-      - '.github/workflows/lockfile-audit.yml'
   schedule:
     - cron: '37 5 * * *'
   workflow_dispatch:
@@ -75,11 +66,6 @@ jobs:
         with:
           python-version: '3.12'
 
-      - name: Verify audit script parses
-        run: python3 -c "import ast; ast.parse(open('scripts/lockfile_supply_chain_audit.py').read())"
-
+      # One definition, shared with the Lint CI lane that runs this on every commit.
       - name: Run lockfile supply-chain audit
-        # Blocks known-malicious versions, IOC strings, broken lockfiles,
-        # and provenance/integrity failures. Lesser anomalies stay
-        # ::warning:: unless --strict is passed.
-        run: python3 scripts/lockfile_supply_chain_audit.py
+        run: bash .github/scripts/lane-lockfile-audit.sh

--- a/.github/workflows/studio-load-orchestrator-ci.yml
+++ b/.github/workflows/studio-load-orchestrator-ci.yml
@@ -16,15 +16,15 @@
 
 name: Unsloth load-orchestrator CI
 
+# Per-commit runs are gone: this suite now runs as a background lane inside Lint CI,
+# which already occupies a runner on every commit, so it costs a slot there instead of
+# holding one of its own for ~33s. Both call .github/scripts/lane-load-orchestrator.sh,
+# so there is one definition and the two cannot drift.
+#
+# Kept dispatchable because the suite is worth being able to run on its own. Note that
+# the push trigger it used to have had no paths filter, so it ran on EVERY commit to
+# main regardless of the four paths its PR trigger listed.
 on:
-  pull_request:
-    paths:
-      - 'studio/backend/routes/inference.py'
-      - 'studio/backend/core/inference/llama_cpp.py'
-      - 'tests/studio/load_freeze/**'
-      - '.github/workflows/studio-load-orchestrator-ci.yml'
-  push:
-    branches: [main]
   workflow_dispatch:
 
 concurrency:
@@ -50,18 +50,7 @@ jobs:
         with:
           python-version: '3.12'
           cache: 'pip'
-      - name: Install minimal deps (no torch, no unsloth)
-        # The test stubs `loggers` and `structlog`, imports
-        # core.inference.llama_cpp directly, and drives a small
-        # FastAPI app. Nothing here pulls torch or any GPU code,
-        # so the entire job typically completes in well under 60 s.
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install \
-            'pytest>=8' \
-            'httpx>=0.27,<1' \
-            'fastapi>=0.110,<1' \
-            'uvicorn>=0.30,<1' \
-            'anyio>=4'
+      # One definition, shared with the Lint CI lane that runs this on every commit.
+      # No venv argument here: this job owns its interpreter.
       - name: Run load-orchestrator tests
-        run: python -m pytest -v --tb=short tests/studio/load_freeze/
+        run: bash .github/scripts/lane-load-orchestrator.sh

--- a/.github/workflows/workflow-trigger-lint.yml
+++ b/.github/workflows/workflow-trigger-lint.yml
@@ -127,3 +127,13 @@ jobs:
       # exists to reject.
       - name: The host-offload opt-out is still macOS-only
         run: python3 -m pytest tests/studio/test_mac_host_offload_optin.py -q
+
+      # Same reason. This guard covers work that was moved OFF its own runner into a
+      # background lane of Lint CI, and every way that regresses -- a lane launched but
+      # never collected, a missing exit status read as success, a launch that stops
+      # detaching -- is an edit to lint-ci.yml or to one of the two absorbed workflows.
+      # No other job's paths filter matches a workflow-only change, and the failure modes
+      # are all silent, so nothing would go red while the absorbed suites quietly stopped
+      # being able to fail anything.
+      - name: The absorbed Lint CI lanes still run and can still fail
+        run: python3 -m pytest tests/studio/test_absorbed_lanes_still_run.py -q

--- a/.github/workflows/workflow-trigger-lint.yml
+++ b/.github/workflows/workflow-trigger-lint.yml
@@ -80,60 +80,36 @@ jobs:
       - name: Backend still runs on the oldest interpreter the matrix claims
         run: python3 scripts/lint_backend_python_floor.py
 
-      # And the test that says the step above must exist. Without this, a pull request
-      # that edits only this workflow and deletes that step passes: Backend CI's paths
-      # cover its own YAML and studio/**, not .github/workflows/**, so the assertion
-      # protecting the step is never collected for the one change it exists to reject.
-      - name: The floor lint is still wired up
-        run: python3 -m pytest tests/studio/test_backend_ci_matrix.py -q
-
-      # Runs here rather than in the Repo tests job, for this workflow's own reason:
-      # the regression it catches is a workflow or .github/scripts edit that drops a
-      # Playwright invocation, and studio-backend-ci.yml's paths do not include
-      # .github/workflows/**, .github/scripts/** or .github/actions/**, so such a PR
-      # never collected the guard and stayed green until the post-merge main run.
-      # This workflow carries no paths filter at all, by design, so it sees every PR.
-      # Same cost shape as the lint above: filesystem reads, seconds.
-      - name: Playwright suites still run somewhere
-        run: python3 -m pytest tests/studio/test_playwright_suites_run_in_ci.py -q
-
-      # Here for the same reason, one step further out: this guard reads the concurrency
-      # block of EVERY workflow, so the PR that breaks it is a PR that edits some other
-      # workflow's YAML. No workflow's paths filter contains .github/workflows/**, so a
-      # revert of, say, wheel-smoke.yml back to a shared main group never collected this
-      # test and merged green. Only this job sees such a PR.
-      - name: Main runs still survive a merge burst
-        run: python3 -m pytest tests/studio/test_main_runs_survive_merge_bursts.py -q
-
-      # And here for the same reason: this one reads the three OS smoke workflows, so
-      # the change that breaks it edits a workflow and nothing else, which no paths
-      # filter in the repo matches. Filesystem reads, seconds.
-      - name: The OS smoke legs still share one script
-        run: python3 -m pytest tests/studio/test_smoke_workflows_share_one_script.py -q
-
-      # Same reason once more, and the sharpest instance of it. This one reads
-      # studio-ui-smoke.yml to check every Playwright script still lands on some shard,
-      # so the edit it exists to catch is by definition a workflow-only edit. Backend
-      # CI's paths filter does not match one, and the UI smoke job it guards is the very
-      # thing that would silently stop running, so it cannot be the one to notice.
-      - name: Every Chat UI script still belongs to a shard
-        run: python3 -m pytest tests/studio/test_chat_ui_shards_cover_everything.py -q
-
-      # Same reason, and it is the whole point of this one. The guard exists to reject a
-      # PR that removes UNSLOTH_ALLOW_HOST_OFFLOAD from the macOS GGUF job, or adds it to
-      # the Linux or Windows one. Such a PR edits a workflow and nothing else, which
-      # Backend CI's paths filter (studio/**, tests/**, its own YAML) does not match, so
-      # the assertion protecting the guard was never collected for the exact change it
-      # exists to reject.
-      - name: The host-offload opt-out is still macOS-only
-        run: python3 -m pytest tests/studio/test_mac_host_offload_optin.py -q
-
-      # Same reason. This guard covers work that was moved OFF its own runner into a
-      # background lane of Lint CI, and every way that regresses -- a lane launched but
-      # never collected, a missing exit status read as success, a launch that stops
-      # detaching -- is an edit to lint-ci.yml or to one of the two absorbed workflows.
-      # No other job's paths filter matches a workflow-only change, and the failure modes
-      # are all silent, so nothing would go red while the absorbed suites quietly stopped
-      # being able to fail anything.
-      - name: The absorbed Lint CI lanes still run and can still fail
-        run: python3 -m pytest tests/studio/test_absorbed_lanes_still_run.py -q
+      # ONE pytest invocation, not one per file.
+      #
+      # These were 7 separate steps, each paying interpreter startup and collection to
+      # run a single module -- and each new guard added an eighth, a ninth. Collapsed
+      # into one call, which also lets pytest share collection across them.
+      #
+      # The list grew as much as it shrank. Every module here reads a workflow file, so
+      # the edit that breaks it is by definition a workflow-only edit, and this is the
+      # only job in the repo with no paths filter. Ten guards were sitting outside it,
+      # collected first by Backend CI's unfiltered push on main -- after the change had
+      # already merged. tests/studio/test_workflow_guards_run_unfiltered.py keeps the
+      # list honest so the next one is not forgotten too.
+      - name: Workflow guard suites
+        run: |
+          python3 -m pytest -q \
+            tests/studio/test_backend_ci_matrix.py \
+            tests/studio/test_backend_ci_parallel_isolation.py \
+            tests/studio/test_absorbed_lanes_still_run.py \
+            tests/studio/test_chat_ui_shards_cover_everything.py \
+            tests/studio/test_ci_shell_suite_coverage.py \
+            tests/studio/test_compile_caches_are_per_worker.py \
+            tests/studio/test_composer_rtl_bidi_attribute.py \
+            tests/studio/test_frontend_dep_removal.py \
+            tests/studio/test_gguf_smoke_phases_stay_independent.py \
+            tests/studio/test_indicator_browsers_run_in_parallel.py \
+            tests/studio/test_mac_host_offload_optin.py \
+            tests/studio/test_main_runs_survive_merge_bursts.py \
+            tests/studio/test_pester_bootstrap_hardening.py \
+            tests/studio/test_playwright_suites_run_in_ci.py \
+            tests/studio/test_smoke_workflows_share_one_script.py \
+            tests/studio/test_stt_model_search_locator_contract.py \
+            tests/studio/test_windows_small_checks_stay_on_their_image.py \
+            tests/studio/test_workflow_guards_run_unfiltered.py

--- a/tests/studio/test_absorbed_lanes_still_run.py
+++ b/tests/studio/test_absorbed_lanes_still_run.py
@@ -1,0 +1,171 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Work absorbed onto a shared runner still runs, and still fails its job when it fails.
+
+Two workflows each held their own runner slot on every commit for a few seconds of
+read-only checking:
+
+    Unsloth load-orchestrator CI :: test    ~33 s, its own slot
+    Lockfile supply-chain audit :: audit     ~6 s, its own slot
+
+Both now run as background lanes inside `Lint CI`, which has no path filter and was
+already going to occupy a runner on every commit. Absorbing narrower-triggered work into
+an unfiltered job can only reduce the slots a commit takes, and running the lanes in the
+background rather than as extra steps means they overlap the ~65 s of lint instead of
+being appended to it.
+
+Backgrounding is what makes this worth guarding. Three things go silently wrong with it,
+and none of them turns a job red on its own:
+
+  * the lane is launched but never collected, so a failure is invisible and the absorbed
+    job has effectively been deleted rather than moved;
+  * the lane never starts, and the collect step reads a missing exit status as success;
+  * the launch blocks on the lane's output instead of returning, so the overlap the whole
+    design buys quietly disappears and the job just gets slower.
+
+The payloads live in `.github/scripts/lane-*.sh` so the standalone workflows and the Lint
+CI lanes cannot drift apart. That single-definition property is asserted here too, since
+the obvious "fix" when a lane breaks is to inline it back into the workflow.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO = Path(__file__).resolve().parents[2]
+WORKFLOWS = REPO / ".github" / "workflows"
+SCRIPTS = REPO / ".github" / "scripts"
+
+LINT_CI = WORKFLOWS / "lint-ci.yml"
+
+# lane name -> (shared script, the workflow that keeps a standalone copy of the job)
+ABSORBED = {
+    "load-orchestrator": ("lane-load-orchestrator.sh", "studio-load-orchestrator-ci.yml"),
+    "lockfile-audit": ("lane-lockfile-audit.sh", "lockfile-audit.yml"),
+}
+
+
+def _lint_steps():
+    doc = yaml.safe_load(LINT_CI.read_text(encoding = "utf-8"))
+    return doc["jobs"]["source-lint"]["steps"]
+
+
+def _step(fragment: str) -> dict:
+    for step in _lint_steps():
+        if fragment.lower() in (step.get("name") or "").lower():
+            return step
+    raise AssertionError(f"no step in lint-ci.yml source-lint is named like {fragment!r}")
+
+
+@pytest.mark.parametrize("lane", sorted(ABSORBED))
+def test_each_absorbed_lane_is_launched(lane):
+    run = str(_step("Start the absorbed").get("run", ""))
+    script = ABSORBED[lane][0]
+    assert f"lane {lane} " in run, f"the {lane} lane is no longer launched by Lint CI"
+    assert script in run, (
+        f"the {lane} lane no longer runs {script}. The point of the shared script is that "
+        f"the standalone workflow and this lane cannot diverge."
+    )
+
+
+@pytest.mark.parametrize("lane", sorted(ABSORBED))
+def test_each_absorbed_lane_is_collected(lane):
+    """A launched-but-uncollected lane is a deleted test that looks like a passing one."""
+    run = str(_step("Collect the absorbed").get("run", ""))
+    assert lane in run, (
+        f"Lint CI launches the {lane} lane but never collects it, so nothing reads its "
+        f"exit status and a failure leaves the job green"
+    )
+
+
+def test_the_collect_step_runs_even_when_a_lint_step_failed():
+    """Without always(), a lint failure hides every lane result behind it."""
+    step = _step("Collect the absorbed")
+    assert "always()" in str(step.get("if", "")), (
+        "the collect step is not if: always(), so a lint failure above it skips the lane "
+        "results entirely and a lane regression surfaces only once the lint is fixed"
+    )
+
+
+def test_a_failing_lane_fails_the_job():
+    run = str(_step("Collect the absorbed").get("run", ""))
+    assert re.search(r"exit\s+\"?\$", run), (
+        "the collect step never propagates a non-zero lane status, so the absorbed suites "
+        "run but cannot fail anything"
+    )
+
+
+def test_a_lane_that_never_finishes_is_a_failure_not_a_pass():
+    """The sharp edge of a sentinel file: absence must not read as success."""
+    run = str(_step("Collect the absorbed").get("run", ""))
+    assert "::error::" in run and "never finished" in run, (
+        "the collect step does not treat a missing exit-status file as a failure. A lane "
+        "that was killed, or never started, would then be indistinguishable from one that "
+        "passed."
+    )
+
+
+def test_the_launch_detaches_from_the_steps_output():
+    """Measured, not theoretical: without this the launch blocks for the lane's duration.
+
+    A background child inherits the step's stdout and stderr pipes, and the step is not
+    considered finished while a writer still holds them. Locally, launching a 4 s lane
+    took 4.0 s before the redirect and 0.0 s after. The lanes would still run and still be
+    collected, so nothing would go red -- the job would just quietly stop overlapping them
+    and get slower, which is the entire benefit gone.
+    """
+    run = str(_step("Start the absorbed").get("run", ""))
+    assert re.search(r"\)\s*<\s*/dev/null\s*>\s*/dev/null\s*2>&1\s*&", run), (
+        "the background lanes are not detached from the step's stdout/stderr, so the "
+        "launch step blocks until they finish and the overlap is lost"
+    )
+
+
+@pytest.mark.parametrize("lane", sorted(ABSORBED))
+def test_the_payload_has_exactly_one_definition(lane):
+    """The standalone workflow must call the same script, not a copy of its commands."""
+    script, workflow = ABSORBED[lane]
+    assert (SCRIPTS / script).exists(), f"{script} is gone; the lane and the workflow will drift"
+    doc = yaml.safe_load((WORKFLOWS / workflow).read_text(encoding = "utf-8"))
+    runs = "\n".join(
+        str(step.get("run", ""))
+        for job in doc["jobs"].values()
+        for step in job.get("steps") or []
+        if isinstance(step, dict)
+    )
+    assert script in runs, (
+        f"{workflow} no longer calls {script}, so it has its own copy of the commands and "
+        f"the two definitions can diverge without anything noticing"
+    )
+
+
+@pytest.mark.parametrize("lane", sorted(ABSORBED))
+def test_the_absorbed_workflow_no_longer_takes_a_slot_per_commit(lane):
+    """Absorbing without removing the original trigger doubles the work instead of moving it."""
+    workflow = ABSORBED[lane][1]
+    doc = yaml.safe_load((WORKFLOWS / workflow).read_text(encoding = "utf-8"))
+    on = doc.get(True) if True in doc else doc.get("on")
+    still_per_commit = sorted(k for k in on if k in ("pull_request", "push"))
+    assert not still_per_commit, (
+        f"{workflow} still triggers on {still_per_commit} while Lint CI also runs its "
+        f"work, so the commit now pays for both. Absorbing is only a saving if the "
+        f"original per-commit trigger goes."
+    )
+
+
+def test_the_nightly_lockfile_audit_survived():
+    """The schedule is a different check from the per-commit one and must not be lost.
+
+    A commit-triggered audit reads the lockfiles against advisories known at commit time.
+    The nightly one re-reads the same lockfiles against advisories published since, which
+    no commit run can do. Removing the per-commit trigger must not take that with it.
+    """
+    doc = yaml.safe_load((WORKFLOWS / "lockfile-audit.yml").read_text(encoding = "utf-8"))
+    on = doc.get(True) if True in doc else doc.get("on")
+    assert on.get("schedule"), (
+        "lockfile-audit.yml lost its nightly schedule. That run catches advisories "
+        "published after the last commit, which the Lint CI lane cannot."
+    )

--- a/tests/studio/test_workflow_guards_run_unfiltered.py
+++ b/tests/studio/test_workflow_guards_run_unfiltered.py
@@ -1,0 +1,134 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""A test that reads a workflow file must run on a PR that only edits workflow files.
+
+`workflow-trigger-lint.yml` is the one job in this repo with no `paths:` filter, which
+makes it the only job a workflow-only PR is guaranteed to start. Every other job filters on
+source paths: Backend CI matches `studio/**`, `tests/**`, `scripts/**` and its own YAML, but
+not arbitrary workflow files.
+
+So a guard that reads `.github/workflows` and is not run by that job has a specific,
+silent hole: the edit it exists to reject is by definition a workflow-only edit, and on
+such a PR the guard is never collected. It is collected later, by Backend CI's unfiltered
+push on main -- after the change has merged. The guard still works; it just stops being
+able to block anything.
+
+That went unnoticed for ten modules at once, which is why this is asserted from the
+workflow rather than maintained by hand. Three separate review rounds reported one instance
+each of it before the pattern was recognised.
+
+The list is also deliberately ONE pytest invocation rather than one step per module. At 17
+modules that is 53.9s against 300.8s measured locally, because this repo's conftest is
+expensive to import and a step per module pays it every time.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO = Path(__file__).resolve().parents[2]
+TESTS = REPO / "tests" / "studio"
+LINT = REPO / ".github" / "workflows" / "workflow-trigger-lint.yml"
+
+# Modules that read a workflow file but cannot run in that job, each with the reason.
+# Shrinking this is the point; growing it needs a reason written here.
+EXEMPT = {
+    # Imports PIL, which that job does not install (it installs pyyaml, pytest and vermin
+    # only, deliberately, so the lint stays seconds rather than minutes).
+    "test_tauri_branding_contract.py",
+    # Imports a local `utils` helper that resolves only under the full test environment.
+    "test_update_release_notes.py",
+}
+
+
+def _guard_step() -> dict:
+    doc = yaml.safe_load(LINT.read_text(encoding = "utf-8"))
+    for step in doc["jobs"]["workflow-trigger-lint"]["steps"]:
+        if "pytest" in str(step.get("run", "")):
+            return step
+    raise AssertionError("workflow-trigger-lint.yml no longer runs pytest at all")
+
+
+def _modules_run_by_the_lint_job() -> set:
+    doc = yaml.safe_load(LINT.read_text(encoding = "utf-8"))
+    runs = "\n".join(
+        str(step.get("run", "")) for step in doc["jobs"]["workflow-trigger-lint"]["steps"]
+    )
+    return set(re.findall(r"tests/studio/(test_[\w]+\.py)", runs))
+
+
+def _modules_that_read_a_workflow() -> set:
+    """Test modules that reach into `.github/workflows`.
+
+    Matched on the directory path as it appears in the source, either as a literal or as
+    the `"workflows"` component of a `Path` join, which are the only two forms in use.
+    """
+    found = set()
+    for path in sorted(TESTS.glob("test_*.py")):
+        src = path.read_text(encoding = "utf-8", errors = "replace")
+        if ".github/workflows" in src or re.search(r'"\.github"\s*/\s*"workflows"', src):
+            found.add(path.name)
+    return found
+
+
+def test_the_scan_finds_the_guards_it_claims_to():
+    """A scan that matched nothing would pass the check below on an empty set."""
+    found = _modules_that_read_a_workflow()
+    assert len(found) >= 10, f"only found {len(found)} workflow-reading guards; scan is wrong"
+    for expected in ("test_playwright_suites_run_in_ci.py", "test_backend_ci_matrix.py"):
+        assert expected in found, f"{expected} reads a workflow but the scan missed it"
+
+
+def test_every_workflow_reading_guard_runs_in_the_unfiltered_job():
+    uncovered = sorted(_modules_that_read_a_workflow() - _modules_run_by_the_lint_job() - EXEMPT)
+    assert not uncovered, (
+        f"these guards read a workflow file but are not run by workflow-trigger-lint, the "
+        f"only job with no paths filter: {uncovered}. A PR that edits only workflow files "
+        f"-- which is exactly the change each of them exists to reject -- never collects "
+        f"them, so they cannot block it. Add them to the guard step, or to EXEMPT with a "
+        f"reason."
+    )
+
+
+@pytest.mark.parametrize("name", sorted(EXEMPT))
+def test_the_exemptions_still_exist_and_are_still_needed(name):
+    """An exemption that outlives its file, or its reason, quietly shrinks the check."""
+    assert (TESTS / name).is_file(), f"EXEMPT names {name}, which no longer exists"
+    assert name not in _modules_run_by_the_lint_job(), (
+        f"{name} is exempted from the unfiltered job but that job now runs it. Remove it "
+        f"from EXEMPT so the check keeps covering it."
+    )
+
+
+def test_the_guards_run_in_one_pytest_invocation():
+    """One step per module pays this repo's conftest import cost once per module.
+
+    Measured over these 17 modules: 53.9s as a single invocation, 300.8s as one each. The
+    shape regresses naturally, because the obvious way to add a guard is to add a step.
+    """
+    doc = yaml.safe_load(LINT.read_text(encoding = "utf-8"))
+    steps = doc["jobs"]["workflow-trigger-lint"]["steps"]
+    invocations = [s for s in steps if "-m pytest" in str(s.get("run", ""))]
+    assert len(invocations) == 1, (
+        f"workflow-trigger-lint runs pytest in {len(invocations)} separate steps. Add the "
+        f"module to the existing invocation instead: one step per module costs about 15s "
+        f"of interpreter and conftest startup each."
+    )
+
+
+def test_the_job_that_runs_them_has_no_paths_filter():
+    """The entire premise. If this job gains a filter, every guard above loses its point."""
+    doc = yaml.safe_load(LINT.read_text(encoding = "utf-8"))
+    on = doc.get(True) if True in doc else doc.get("on")
+    for trigger in ("pull_request", "push"):
+        config = on.get(trigger)
+        if not isinstance(config, dict):
+            continue
+        assert not config.get("paths") and not config.get("paths-ignore"), (
+            f"workflow-trigger-lint now filters its {trigger} trigger on paths. It is the "
+            f"only job a workflow-only PR is guaranteed to start, and every guard it runs "
+            f"depends on that."
+        )


### PR DESCRIPTION
## What this does

Two workflows each held a runner slot on every commit for a few seconds of read-only checking:

| workflow | exec | slots |
|---|---:|---:|
| `Unsloth load-orchestrator CI :: test` | ~33s | 1 |
| `Lockfile supply-chain audit :: audit` | ~6s | 1 |

Both now run as **background lanes inside `Lint CI`**, which has no path filter and was already going to occupy a runner on every commit. Three slots become one.

They are backgrounded rather than appended as steps, so they overlap the ~65s of lint instead of adding to it. `ubuntu-latest` has four cores and the lint steps are single-threaded, so the capacity was already there and idle. Measured locally on the real step bodies: a 5s lane alongside 5s of foreground work took 7s total, not 10s.

## Why this cannot cost more than it saves

`Lint CI` has no path filter, so absorbing a narrower-triggered job into it can only **reduce** the slots a commit takes. The absorbed work now runs on commits that would not have triggered it, but on a runner that was going to exist regardless.

`studio-load-orchestrator-ci.yml` is worth calling out separately: its `push` trigger had no `paths:` filter at all, so it already ran on every commit to main regardless of the four paths its `pull_request` trigger listed.

## Three things that were not obvious

- **Each lane needs its own venv.** The load-orchestrator lane installs fastapi and friends while the foreground steps are using the interpreter `Lint CI`'s own `pip install` populated. Two concurrent installs into one `site-packages` is a real race, not a theoretical one.
- **The launch has to detach from the step's stdout and stderr.** A background child inherits those pipes, and the step is not considered finished while a writer still holds them. Launching a 4s lane took **4.0s before the redirect and 0.0s after**. Nothing would have gone red; the overlap the whole design buys would just have silently disappeared and the job would have got slower.
- **A missing exit-status file has to be a failure.** A lane that was killed, or never started, is otherwise indistinguishable from one that passed.

## One definition, not a copy

The payloads live in `.github/scripts/lane-load-orchestrator.sh` and `.github/scripts/lane-lockfile-audit.sh`. Both the Lint CI lane and the standalone workflow call them, so the two cannot drift apart. The obvious thing to do when a lane breaks is to inline it back into the workflow, so a test asserts against that too.

What the standalone workflows keep:

- `studio-load-orchestrator-ci.yml` keeps `workflow_dispatch`, so the suite can still be run on its own.
- `lockfile-audit.yml` keeps its **nightly schedule**, which is deliberately not the same check: it re-reads the lockfiles against advisories published since the last commit, which no commit-triggered run can do.

## Tests

`tests/studio/test_absorbed_lanes_still_run.py`. Backgrounding is what makes this worth guarding, because its failure modes are all silent. Eight mutations verified red:

| mutation | caught by |
|---|---|
| a lane launched but never collected | `test_each_absorbed_lane_is_collected` |
| collect step loses `always()` | `test_the_collect_step_runs_even_when_a_lint_step_failed` |
| a failing lane no longer fails the job | `test_a_failing_lane_fails_the_job` |
| a missing sentinel read as a pass | `test_a_lane_that_never_finishes_is_a_failure_not_a_pass` |
| launch stops detaching (overlap silently lost) | `test_the_launch_detaches_from_the_steps_output` |
| absorbed workflow keeps its per-commit trigger | `test_the_absorbed_workflow_no_longer_takes_a_slot_per_commit` |
| nightly lockfile schedule deleted | `test_the_nightly_lockfile_audit_survived` |
| standalone workflow inlines its own copy | `test_the_payload_has_exactly_one_definition` |

## Verification

- 4037 passed, 4 skipped.
- `actionlint` clean on all three edited workflows.
- The lane/collect machinery was extracted from the YAML and **executed**, in both the passing and failing cases, confirming that a lane exiting 4 makes the collect step exit 1, that the launch returns in 0.0s, and that the two overlap.
- Both lane scripts were run end to end for real: the lockfile audit passes, and the load-orchestrator suite is 23 passed in 22.6s inside its own venv.

## Note for whoever merges this

Two check names disappear (`Unsloth load-orchestrator CI` and `Lockfile supply-chain audit` on PR events). If either is configured as a required status check, that setting needs updating, since I cannot see branch protection from here.
