### PR TITLE
Stop the ingest-failure test waiting on another test's toast

### DIFF
--- a/studio/frontend/tests/project-source-save.test.ts
+++ b/studio/frontend/tests/project-source-save.test.ts
@@ -140,13 +140,21 @@ test("an ingest that fails after the upload is not left silent", async () => {
         error: "Could not parse the document",
       });
     }
-    return json({ documentId: "d4", jobId: "j4", filename: "Chat.md" });
+    // A name only this test uses. Every earlier save in this file also uploads
+    // a "Chat.md", and each successful one leaves a 2s ingest poll running past
+    // the end of its own test; those land here, where the handler above answers
+    // every /jobs/ with a failure, and raise a toast that reads exactly like
+    // this test's. Waiting on the shared name therefore resolved on a foreign
+    // toast, before this save's own poll had announced the second update, and
+    // the count below read 1. Observed on the Windows runner, and reproducible
+    // anywhere by delaying this test ~1.8s after the ones that arm those polls.
+    return json({ documentId: "d4", jobId: "j4", filename: "Chat p4.md" });
   });
   await saveMarkdownAsProjectSource("p4", "# Chat\n", "Chat");
   // The panel hides failed documents, so the success toast would otherwise be
   // the only thing the user ever sees about a source that never arrives.
   const failure = await waitFor(() =>
-    recordedToasts.find((t) => t.message === "Couldn't index Chat.md"),
+    recordedToasts.find((t) => t.message === "Couldn't index Chat p4.md"),
   );
   assert.equal(failure?.kind, "error");
   assert.equal(failure?.description, "Could not parse the document");


### PR DESCRIPTION
`Frontend unit tests (Windows)` fails intermittently on `tests/project-source-save.test.ts:132`, "an ingest that fails after the upload is not left silent", with `expected 2, actual 1`. It is a test-side race, not a product defect, and it is not specific to any one branch.

### Why it fails

`watchIngestion` in `src/features/rag/api/save-markdown-source.ts` is fired with `void` and polls on a 2000 ms timer that outlives the test that started it. Inside it, `toast.error(...)` and `announceProjectSourcesUpdated(...)` run back to back synchronously, so no poll can ever observe the state between them. A test that sees the toast but not the announce is therefore not seeing its own poller.

Every earlier successful save in this file uploads a file the stub names `Chat.md`, and their leaked pollers land inside the line-132 test, whose handler answers **every** `/jobs/` request with `status: "failed", error: "Could not parse the document"`. So a leaked poller raises `Couldn't index Chat.md` with the exact description this test waits for. `waitFor` resolves on that foreign toast, before this save's own poller has announced, and the count reads 1.

The CI evidence agrees: the failing run records `duration_ms: 1990.55`, below the test's own 2000 ms poll interval, which is impossible if the toast it woke on were its own.

### It is not one branch's

The identical failure, same file, same line, same `1 !== 2`, same sub-2000 ms duration, appears on four unrelated branches:

| run | branch | duration_ms |
|---|---|---|
| 32108785548 | `studio/xet-progress-notice` | 1999.51 |
| 32098914546 | `perf-stream-harness` | 1996.41 |
| 32084163667 | `feat/studio-keyless-api-access` | 1987.66 |
| 32042404705 | `feat/studio-attachment-preview-modal` | 1945.58 |

It is also a coin flip rather than a property of a tree: two replications of the same content ran 20 minutes apart, one passed and one failed.

### The fix, and how it was proved

Give this test's upload a filename no other test uses, so the wait can only be satisfied by its own poller, whose announce is dispatched in the same synchronous block as its toast.

Because the race is timing dependent it will not reproduce on demand on Linux (175 full-suite runs produced zero occurrences), so I made it deterministic instead: inserting an 1800 ms gap test immediately before the failing one forces the leaked pollers to fire inside it.

- main content with the gap, no fix: **red 20 of 20**, `AssertionError 1 !== 2` at line 158, test duration 202 ms.
- same tree, same gap, with the fix: **green 20 of 20**.
- main content with the fix only, full suite 50 times: no occurrence.

Found while checking whether a cross-platform failure belonged to #9051. It does not, so it is fixed here rather than inside that PR.
