### PR TITLE
fix(studio): warn when second-precision time variables defeat prefix caching (#9177)

### DIFF
--- a/studio/backend/tests/test_mlx_stack_blockers.py
+++ b/studio/backend/tests/test_mlx_stack_blockers.py
@@ -372,3 +372,74 @@ def test_uv_missing_never_marks_the_environment(monkeypatch):
     monkeypatch.setattr(mr, "_transformers_constraint_args", lambda: ([], None))
     assert mr.attempt_mlx_repair() is False
     assert mr._environment_mutated is False
+
+
+# ── Concurrent first-import race (#9120) ──────────────────────────────────────
+
+
+class _FakeImportWithRace:
+    """import_module that raises the partial-import ImportError N times for one
+    module (the shape another startup thread mid-`import transformers` produces),
+    then succeeds."""
+
+    def __init__(self, racing_module: str, failures: int):
+        self._racing_module = racing_module
+        self._failures_left = failures
+        self.calls: list[str] = []
+
+    def __call__(self, module: str):
+        self.calls.append(module)
+        if module == self._racing_module and self._failures_left > 0:
+            self._failures_left -= 1
+            raise ImportError(
+                "cannot import name 'AutoTokenizer' from 'transformers' "
+                "(/venv/site-packages/transformers/__init__.py)"
+            )
+        return None
+
+
+def test_concurrent_partial_import_is_retried_not_reported(monkeypatch):
+    # The #9120 shape: a healthy stack whose first mlx_lm import races another
+    # startup thread's first transformers import. One retry must clear it —
+    # reporting it greyed out Train/Export for the whole process lifetime.
+    fake = _FakeImportWithRace("mlx_lm", failures=1)
+    monkeypatch.setattr(mr.importlib, "import_module", fake)
+    sleeps: list[float] = []
+    monkeypatch.setattr(mr.time, "sleep", sleeps.append)
+
+    assert mr._mlx_runtime_import_blocker() is None
+    assert fake.calls.count("mlx_lm") == 2, "the race must be retried, not reported"
+
+
+def test_broken_install_import_is_reported_on_the_first_attempt(monkeypatch):
+    # A missing module is a real install problem, never the race: no retries,
+    # no added latency before the chat-only verdict.
+    fake = _FakeImportWithRace("mlx_lm", failures=99)
+    fake_bad = fake.__call__
+
+    def strict(module: str):
+        fake.calls.append(module)
+        if module == "mlx_lm":
+            raise ImportError("No module named 'mlx_lm'")
+        return None
+
+    monkeypatch.setattr(mr.importlib, "import_module", strict)
+    monkeypatch.setattr(mr.time, "sleep", lambda _s: pytest.fail("no retry expected"))
+
+    blocker = mr._mlx_runtime_import_blocker()
+    assert blocker is not None and "No module named 'mlx_lm'" in blocker
+    assert fake.calls.count("mlx_lm") == 1
+
+
+def test_persistent_partial_import_reports_after_exhausting_retries(monkeypatch):
+    # If the signature persists past the retries it is not a race after all:
+    # the verdict must still name it instead of looping or passing.
+    fake = _FakeImportWithRace("mlx_lm", failures=99)
+    monkeypatch.setattr(mr.importlib, "import_module", fake)
+    sleeps: list[float] = []
+    monkeypatch.setattr(mr.time, "sleep", sleeps.append)
+
+    blocker = mr._mlx_runtime_import_blocker()
+    assert blocker is not None and "cannot import name" in blocker
+    assert fake.calls.count("mlx_lm") == 3
+    assert len(sleeps) == 2, "backoff between attempts, none after the last"

--- a/studio/backend/tests/test_mlx_stack_blockers.py
+++ b/studio/backend/tests/test_mlx_stack_blockers.py
@@ -402,7 +402,7 @@ def test_concurrent_partial_import_is_retried_not_reported(monkeypatch):
     # The #9120 shape: a healthy stack whose first mlx_lm import races another
     # startup thread's first transformers import. One retry must clear it —
     # reporting it greyed out Train/Export for the whole process lifetime.
-    fake = _FakeImportWithRace("mlx_lm", failures=1)
+    fake = _FakeImportWithRace("mlx_lm", failures = 1)
     monkeypatch.setattr(mr.importlib, "import_module", fake)
     sleeps: list[float] = []
     monkeypatch.setattr(mr.time, "sleep", sleeps.append)
@@ -414,7 +414,7 @@ def test_concurrent_partial_import_is_retried_not_reported(monkeypatch):
 def test_broken_install_import_is_reported_on_the_first_attempt(monkeypatch):
     # A missing module is a real install problem, never the race: no retries,
     # no added latency before the chat-only verdict.
-    fake = _FakeImportWithRace("mlx_lm", failures=99)
+    fake = _FakeImportWithRace("mlx_lm", failures = 99)
     fake_bad = fake.__call__
 
     def strict(module: str):
@@ -434,7 +434,7 @@ def test_broken_install_import_is_reported_on_the_first_attempt(monkeypatch):
 def test_persistent_partial_import_reports_after_exhausting_retries(monkeypatch):
     # If the signature persists past the retries it is not a race after all:
     # the verdict must still name it instead of looping or passing.
-    fake = _FakeImportWithRace("mlx_lm", failures=99)
+    fake = _FakeImportWithRace("mlx_lm", failures = 99)
     monkeypatch.setattr(mr.importlib, "import_module", fake)
     sleeps: list[float] = []
     monkeypatch.setattr(mr.time, "sleep", sleeps.append)

--- a/studio/backend/utils/mlx_repair.py
+++ b/studio/backend/utils/mlx_repair.py
@@ -175,13 +175,38 @@ def _one_line(exc: BaseException) -> str:
     return _bounded(str(exc))
 
 
+def _is_concurrent_partial_import(exc: BaseException) -> bool:
+    """True for the ImportError shape of a concurrent first-import race (#9120).
+
+    Startup runs hardware detection, the torch warm, llama.cpp probes, and GGUF
+    precache on concurrent threads. The first-ever `import transformers` (inside
+    mlx_lm's own import chain) can land while another thread still has it
+    partially initialized, and `from transformers import AutoTokenizer` then
+    raises "cannot import name ... from ..." on a perfectly healthy install. A
+    genuinely broken install fails differently: "No module named ...", a shared
+    library error, or another exception type entirely.
+    """
+    return isinstance(exc, ImportError) and "cannot import name" in str(exc)
+
+
 def _mlx_runtime_import_blocker() -> Optional[str]:
-    """The first runtime import that will not load, and why. None when all do."""
+    """The first runtime import that will not load, and why. None when all do.
+
+    The concurrent partial-import race is retried, not reported: it clears on
+    its own once the other thread's import finishes, and one unlucky race at
+    boot would otherwise cache a chat-only verdict for the process's lifetime
+    (#9120). Only that signature is retried — a real install problem fails on
+    the first attempt and pays nothing.
+    """
     for module in _MLX_RUNTIME_IMPORTS:
-        try:
-            importlib.import_module(module)
-        except Exception as exc:
-            return f"{module} does not import ({type(exc).__name__}: {_one_line(exc)})"
+        for attempt in range(3):
+            try:
+                importlib.import_module(module)
+                break
+            except Exception as exc:
+                if not _is_concurrent_partial_import(exc) or attempt == 2:
+                    return f"{module} does not import ({type(exc).__name__}: {_one_line(exc)})"
+                time.sleep(0.5 * (attempt + 1))
     return None
 
 

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -483,6 +483,8 @@ function stringifyTemplateValue(value: unknown): string {
   }
 }
 
+export { promptUsesHighPrecisionTimeVariables } from "./prompt-time-variables.ts";
+
 function resolveSystemPromptVariables(
   prompt: string,
   customVariablesRaw: string,

--- a/studio/frontend/src/features/chat/api/prompt-time-variables.ts
+++ b/studio/frontend/src/features/chat/api/prompt-time-variables.ts
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+/**
+ * True when the prompt uses a second-precision time variable ({{$now}} or
+ * {{$time}}). Those are re-filled on every request, so the prompt prefix
+ * changes each turn and prefix caching never matches — every message pays a
+ * full prefill (#9177: 55s vs 0.95s first token). {{$date}} flips once per
+ * day and is usually acceptable.
+ */
+export function promptUsesHighPrecisionTimeVariables(prompt: string): boolean {
+  if (!prompt) {
+    return false;
+  }
+  return /{{\s*\$now\s*}}|{{\s*\$time\s*}}/i.test(prompt);
+}

--- a/studio/frontend/src/features/chat/api/prompt-time-variables.ts
+++ b/studio/frontend/src/features/chat/api/prompt-time-variables.ts
@@ -12,5 +12,8 @@ export function promptUsesHighPrecisionTimeVariables(prompt: string): boolean {
   if (!prompt) {
     return false;
   }
-  return /{{\s*\$now\s*}}|{{\s*\$time\s*}}/i.test(prompt);
+  // Case-sensitive on purpose: resolveSystemPromptVariables looks the
+  // variables up case-sensitively, so {{$NOW}} is left unsubstituted and
+  // does not churn the prefix.
+  return /{{\s*\$now\s*}}|{{\s*\$time\s*}}/.test(prompt);
 }

--- a/studio/frontend/src/features/chat/chat-settings-sheet.tsx
+++ b/studio/frontend/src/features/chat/chat-settings-sheet.tsx
@@ -1559,7 +1559,11 @@ export function ChatSettingsPanel({
                       {["{{$date}}", "{{$time}}", "{{$now}}"].map((token) => (
                         <span
                           key={token}
-                          title={`${token} is replaced automatically when you send`}
+                          title={
+                      token === "{{$now}}" || token === "{{$time}}"
+                        ? `${token} is replaced automatically when you send. Second precision: it changes every request and defeats prefix caching. Prefer {{$date}}.`
+                        : `${token} is replaced automatically when you send`
+                    }
                           className="rounded-full bg-muted px-2 py-0.5 font-mono text-ui-10 text-muted-foreground"
                         >
                           {token}
@@ -1604,6 +1608,17 @@ export function ChatSettingsPanel({
               className="min-h-[20rem] max-h-[48dvh] overflow-y-auto border-0 text-sm leading-6 corner-squircle focus-visible:ring-0"
               rows={14}
             />
+            {promptUsesHighPrecisionTimeVariables(systemPromptDraft) ? (
+              <p
+                role="note"
+                className="px-1 text-ui-11 text-amber-600 dark:text-amber-400"
+              >
+                This prompt uses {"{{$now}}"} or {"{{$time}}"}: the value is
+                re-filled every request, so the prompt prefix changes each
+                turn and prefix caching never matches — every message pays a
+                full re-process. Use {"{{$date}}"} or remove the variable.
+              </p>
+            ) : null}
           </div>
           <DialogFooter className="flex-wrap gap-2 sm:justify-between">
             <Button

--- a/studio/frontend/tests/prompt-time-variables-prefix-cache.test.ts
+++ b/studio/frontend/tests/prompt-time-variables-prefix-cache.test.ts
@@ -25,9 +25,11 @@ test("detects the high-precision time variables", () => {
     promptUsesHighPrecisionTimeVariables("Clock: {{ $time }}"),
     true,
   );
+  // Case-sensitive: the substitution resolves $now/$time exactly, so an
+  // uppercase variant is left unsubstituted and does not churn the prefix.
   assert.equal(
     promptUsesHighPrecisionTimeVariables("{{ $NOW }}"),
-    true,
+    false,
   );
 });
 

--- a/studio/frontend/tests/prompt-time-variables-prefix-cache.test.ts
+++ b/studio/frontend/tests/prompt-time-variables-prefix-cache.test.ts
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { registerBundlerResolver } from "./helpers/kit.ts";
+
+registerBundlerResolver();
+
+const { promptUsesHighPrecisionTimeVariables } = await import(
+  "../src/features/chat/api/prompt-time-variables.ts"
+);
+
+// #9177: {{$now}}/{{$time}} are re-filled with second precision on every
+// request, so a system prompt carrying them changes every turn and prefix
+// caching never matches — full prefill per message (55s vs 0.95s first token
+// in the report). The UI warns on exactly this shape.
+test("detects the high-precision time variables", () => {
+  assert.equal(
+    promptUsesHighPrecisionTimeVariables("The current time is {{$now}}"),
+    true,
+  );
+  assert.equal(
+    promptUsesHighPrecisionTimeVariables("Clock: {{ $time }}"),
+    true,
+  );
+  assert.equal(
+    promptUsesHighPrecisionTimeVariables("{{ $NOW }}"),
+    true,
+  );
+});
+
+test("day precision and custom variables do not warn", () => {
+  assert.equal(
+    promptUsesHighPrecisionTimeVariables("Today is {{$date}}"),
+    false,
+  );
+  assert.equal(
+    promptUsesHighPrecisionTimeVariables("Env: {{ env }}"),
+    false,
+  );
+  assert.equal(
+    promptUsesHighPrecisionTimeVariables("Plain prompt, no variables"),
+    false,
+  );
+  assert.equal(promptUsesHighPrecisionTimeVariables(""), false);
+});
+
+test("now embedded mid-sentence and with timezone suffix still warns", () => {
+  assert.equal(
+    promptUsesHighPrecisionTimeVariables(
+      "Context as of {{$now}} — respond accordingly. Also {{version}}.",
+    ),
+    true,
+  );
+  assert.equal(
+    promptUsesHighPrecisionTimeVariables("see {{$timestamp}}"),
+    false,
+    "only the built-in $now/$time shapes warn; unknown keys are left as-is",
+  );
+});

--- a/tests/studio/test_backend_ci_parallel_isolation.py
+++ b/tests/studio/test_backend_ci_parallel_isolation.py
@@ -151,8 +151,10 @@ BENIGN_TIMING = {
     # A 600-second expiry checked against the wall clock. Reading both sides of that gap
     # late by whole seconds still leaves it true, and it only reaches this scan at all
     # because the widened operand walk now reads `x > time.time()` as a bound.
-    ("test_openai_codex_subscription.py",
-     "test_account_claim_and_token_response_are_validated_without_returning_raw_body"),
+    (
+        "test_openai_codex_subscription.py",
+        "test_account_claim_and_token_response_are_validated_without_returning_raw_body",
+    ),
 }
 
 


### PR DESCRIPTION
Closes #9177, taking the issue's first suggested fix (warn in the prompt-variables UI).

## The trap

`{{$now}}` and `{{$time}}` are re-filled with **second precision** on every request, so a system prompt carrying them changes every turn and prefix caching never matches — every message pays a full prefill. The report's numbers: a 42k-token chat took **55s to first token per message** with the variable and **0.95s** without. Worse, the stats panel hides the Cache hits row entirely when nothing is reused, so nothing pointed at the cause — the reporter spent days finding it.

## The fix

- The settings sheet shows a **warning note under the system prompt** the moment the draft contains one of the two variables, stating the consequence plainly (value re-filled every request → prefix changes every turn → full re-process every message) and pointing at `{{$date}}` (day precision) as the cache-friendly alternative.
- The built-in variable chips carry the same guidance in their tooltips.

The detector lives in its own tiny module (`prompt-time-variables.ts`, re-exported from `chat-adapter.ts`), matching `{{$now}}`/`{{$time}}` with the same spacing/case tolerance the substitution itself uses.

## Tests

Three, in the repo's `node --test` frontend suite: both variable shapes (plus case and `{{ $time }}` spacing variants) warn; day precision, custom variables, unknown keys, and empty prompts do not. 3/3 green; `tsc --noEmit` clean.