### PR TITLE
fix(ci): stop the MLX self-heal storming the mac UI smoke mid-test (#9183)

### DIFF
--- a/.github/scripts/boot-studio-api-only.sh
+++ b/.github/scripts/boot-studio-api-only.sh
@@ -68,7 +68,9 @@ rm -rf ~/.unsloth/studio/auth
 mkdir -p "$(dirname "$LOG")"
 
 # shellcheck disable=SC2086  # $API_ONLY is one flag or empty, and must not become ''
-UNSLOTH_API_ONLY=1 unsloth studio -H 127.0.0.1 -p "$PORT" $API_ONLY > "$LOG" 2>&1 &
+# No MLX on these runners (--no-torch install): the self-heal would only
+# pip-install mid-test and starve the 3 vCPU shared runner (#9183).
+UNSLOTH_DISABLE_MLX_AUTOREPAIR=1 UNSLOTH_API_ONLY=1 unsloth studio -H 127.0.0.1 -p "$PORT" $API_ONLY > "$LOG" 2>&1 &
 SERVER_PID=$!
 
 echo "[boot] unsloth studio ${API_ONLY:---with-frontend} on 127.0.0.1:${PORT}, pid ${SERVER_PID}, log ${LOG}"

--- a/.github/scripts/boot-studio-api-only.sh
+++ b/.github/scripts/boot-studio-api-only.sh
@@ -70,7 +70,7 @@ mkdir -p "$(dirname "$LOG")"
 # shellcheck disable=SC2086  # $API_ONLY is one flag or empty, and must not become ''
 # No MLX on these runners (--no-torch install): the self-heal would only
 # pip-install mid-test and starve the 3 vCPU shared runner (#9183).
-UNSLOTH_DISABLE_MLX_AUTOREPAIR=1 UNSLOTH_API_ONLY=1 unsloth studio -H 127.0.0.1 -p "$PORT" $API_ONLY > "$LOG" 2>&1 &
+UNSLOTH_API_ONLY=1 unsloth studio -H 127.0.0.1 -p "$PORT" $API_ONLY > "$LOG" 2>&1 &
 SERVER_PID=$!
 
 echo "[boot] unsloth studio ${API_ONLY:---with-frontend} on 127.0.0.1:${PORT}, pid ${SERVER_PID}, log ${LOG}"

--- a/.github/workflows/studio-mac-ui-smoke.yml
+++ b/.github/workflows/studio-mac-ui-smoke.yml
@@ -234,6 +234,11 @@ jobs:
           BASE_URL: http://127.0.0.1:18896
           PW_ART_DIR: logs/playwright
           STUDIO_UI_STRICT: '1'
+          # #9183: this job's runners are --no-torch with no MLX, so the
+          # self-heal can only pip-install mid-test and starve the 3 vCPU
+          # runner. The shared boot script stays neutral: mlx-ci NEEDS the
+          # repair path.
+          UNSLOTH_DISABLE_MLX_AUTOREPAIR: '1'
           # macos-15 free runner is 3 vCPU / 7 GB / no Metal-accel
           # available to llama.cpp from CI; gemma-3-270m turn latency
           # has been observed to crowd the 180s default. Triple it.

--- a/.github/workflows/studio-mac-ui-smoke.yml
+++ b/.github/workflows/studio-mac-ui-smoke.yml
@@ -269,7 +269,8 @@ jobs:
               kill "${STUDIO_PID}" 2>/dev/null || true
               sleep 2
               rm -rf ~/.unsloth/studio/auth
-              UNSLOTH_DISABLE_MLX_AUTOREPAIR=1 \n              UNSLOTH_API_ONLY=1 unsloth studio -H 127.0.0.1 -p "$STUDIO_PORT" \
+              UNSLOTH_DISABLE_MLX_AUTOREPAIR=1 \
+              UNSLOTH_API_ONLY=1 unsloth studio -H 127.0.0.1 -p "$STUDIO_PORT" \
                 > "logs/studio_retry_${attempt}.log" 2>&1 &
               STUDIO_PID=$!
               echo "STUDIO_PID=$STUDIO_PID" >> "$GITHUB_ENV"

--- a/.github/workflows/studio-mac-ui-smoke.yml
+++ b/.github/workflows/studio-mac-ui-smoke.yml
@@ -269,7 +269,7 @@ jobs:
               kill "${STUDIO_PID}" 2>/dev/null || true
               sleep 2
               rm -rf ~/.unsloth/studio/auth
-              UNSLOTH_API_ONLY=1 unsloth studio -H 127.0.0.1 -p "$STUDIO_PORT" \
+              UNSLOTH_DISABLE_MLX_AUTOREPAIR=1 \n              UNSLOTH_API_ONLY=1 unsloth studio -H 127.0.0.1 -p "$STUDIO_PORT" \
                 > "logs/studio_retry_${attempt}.log" 2>&1 &
               STUDIO_PID=$!
               echo "STUDIO_PID=$STUDIO_PID" >> "$GITHUB_ENV"

--- a/studio/backend/tests/test_mlx_stack_blockers.py
+++ b/studio/backend/tests/test_mlx_stack_blockers.py
@@ -372,3 +372,74 @@ def test_uv_missing_never_marks_the_environment(monkeypatch):
     monkeypatch.setattr(mr, "_transformers_constraint_args", lambda: ([], None))
     assert mr.attempt_mlx_repair() is False
     assert mr._environment_mutated is False
+
+
+# ── Concurrent first-import race (#9120) ──────────────────────────────────────
+
+
+class _FakeImportWithRace:
+    """import_module that raises the partial-import ImportError N times for one
+    module (the shape another startup thread mid-`import transformers` produces),
+    then succeeds."""
+
+    def __init__(self, racing_module: str, failures: int):
+        self._racing_module = racing_module
+        self._failures_left = failures
+        self.calls: list[str] = []
+
+    def __call__(self, module: str):
+        self.calls.append(module)
+        if module == self._racing_module and self._failures_left > 0:
+            self._failures_left -= 1
+            raise ImportError(
+                "cannot import name 'AutoTokenizer' from 'transformers' "
+                "(/venv/site-packages/transformers/__init__.py)"
+            )
+        return None
+
+
+def test_concurrent_partial_import_is_retried_not_reported(monkeypatch):
+    # The #9120 shape: a healthy stack whose first mlx_lm import races another
+    # startup thread's first transformers import. One retry must clear it —
+    # reporting it greyed out Train/Export for the whole process lifetime.
+    fake = _FakeImportWithRace("mlx_lm", failures=1)
+    monkeypatch.setattr(mr.importlib, "import_module", fake)
+    sleeps: list[float] = []
+    monkeypatch.setattr(mr.time, "sleep", sleeps.append)
+
+    assert mr._mlx_runtime_import_blocker() is None
+    assert fake.calls.count("mlx_lm") == 2, "the race must be retried, not reported"
+
+
+def test_broken_install_import_is_reported_on_the_first_attempt(monkeypatch):
+    # A missing module is a real install problem, never the race: no retries,
+    # no added latency before the chat-only verdict.
+    fake = _FakeImportWithRace("mlx_lm", failures=99)
+    fake_bad = fake.__call__
+
+    def strict(module: str):
+        fake.calls.append(module)
+        if module == "mlx_lm":
+            raise ImportError("No module named 'mlx_lm'")
+        return None
+
+    monkeypatch.setattr(mr.importlib, "import_module", strict)
+    monkeypatch.setattr(mr.time, "sleep", lambda _s: pytest.fail("no retry expected"))
+
+    blocker = mr._mlx_runtime_import_blocker()
+    assert blocker is not None and "No module named 'mlx_lm'" in blocker
+    assert fake.calls.count("mlx_lm") == 1
+
+
+def test_persistent_partial_import_reports_after_exhausting_retries(monkeypatch):
+    # If the signature persists past the retries it is not a race after all:
+    # the verdict must still name it instead of looping or passing.
+    fake = _FakeImportWithRace("mlx_lm", failures=99)
+    monkeypatch.setattr(mr.importlib, "import_module", fake)
+    sleeps: list[float] = []
+    monkeypatch.setattr(mr.time, "sleep", sleeps.append)
+
+    blocker = mr._mlx_runtime_import_blocker()
+    assert blocker is not None and "cannot import name" in blocker
+    assert fake.calls.count("mlx_lm") == 3
+    assert len(sleeps) == 2, "backoff between attempts, none after the last"

--- a/studio/backend/tests/test_mlx_stack_blockers.py
+++ b/studio/backend/tests/test_mlx_stack_blockers.py
@@ -402,7 +402,7 @@ def test_concurrent_partial_import_is_retried_not_reported(monkeypatch):
     # The #9120 shape: a healthy stack whose first mlx_lm import races another
     # startup thread's first transformers import. One retry must clear it —
     # reporting it greyed out Train/Export for the whole process lifetime.
-    fake = _FakeImportWithRace("mlx_lm", failures=1)
+    fake = _FakeImportWithRace("mlx_lm", failures = 1)
     monkeypatch.setattr(mr.importlib, "import_module", fake)
     sleeps: list[float] = []
     monkeypatch.setattr(mr.time, "sleep", sleeps.append)
@@ -414,7 +414,7 @@ def test_concurrent_partial_import_is_retried_not_reported(monkeypatch):
 def test_broken_install_import_is_reported_on_the_first_attempt(monkeypatch):
     # A missing module is a real install problem, never the race: no retries,
     # no added latency before the chat-only verdict.
-    fake = _FakeImportWithRace("mlx_lm", failures=99)
+    fake = _FakeImportWithRace("mlx_lm", failures = 99)
     fake_bad = fake.__call__
 
     def strict(module: str):
@@ -434,7 +434,7 @@ def test_broken_install_import_is_reported_on_the_first_attempt(monkeypatch):
 def test_persistent_partial_import_reports_after_exhausting_retries(monkeypatch):
     # If the signature persists past the retries it is not a race after all:
     # the verdict must still name it instead of looping or passing.
-    fake = _FakeImportWithRace("mlx_lm", failures=99)
+    fake = _FakeImportWithRace("mlx_lm", failures = 99)
     monkeypatch.setattr(mr.importlib, "import_module", fake)
     sleeps: list[float] = []
     monkeypatch.setattr(mr.time, "sleep", sleeps.append)

--- a/studio/backend/utils/mlx_repair.py
+++ b/studio/backend/utils/mlx_repair.py
@@ -175,13 +175,38 @@ def _one_line(exc: BaseException) -> str:
     return _bounded(str(exc))
 
 
+def _is_concurrent_partial_import(exc: BaseException) -> bool:
+    """True for the ImportError shape of a concurrent first-import race (#9120).
+
+    Startup runs hardware detection, the torch warm, llama.cpp probes, and GGUF
+    precache on concurrent threads. The first-ever `import transformers` (inside
+    mlx_lm's own import chain) can land while another thread still has it
+    partially initialized, and `from transformers import AutoTokenizer` then
+    raises "cannot import name ... from ..." on a perfectly healthy install. A
+    genuinely broken install fails differently: "No module named ...", a shared
+    library error, or another exception type entirely.
+    """
+    return isinstance(exc, ImportError) and "cannot import name" in str(exc)
+
+
 def _mlx_runtime_import_blocker() -> Optional[str]:
-    """The first runtime import that will not load, and why. None when all do."""
+    """The first runtime import that will not load, and why. None when all do.
+
+    The concurrent partial-import race is retried, not reported: it clears on
+    its own once the other thread's import finishes, and one unlucky race at
+    boot would otherwise cache a chat-only verdict for the process's lifetime
+    (#9120). Only that signature is retried — a real install problem fails on
+    the first attempt and pays nothing.
+    """
     for module in _MLX_RUNTIME_IMPORTS:
-        try:
-            importlib.import_module(module)
-        except Exception as exc:
-            return f"{module} does not import ({type(exc).__name__}: {_one_line(exc)})"
+        for attempt in range(3):
+            try:
+                importlib.import_module(module)
+                break
+            except Exception as exc:
+                if not _is_concurrent_partial_import(exc) or attempt == 2:
+                    return f"{module} does not import ({type(exc).__name__}: {_one_line(exc)})"
+                time.sleep(0.5 * (attempt + 1))
     return None
 
 

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -483,6 +483,8 @@ function stringifyTemplateValue(value: unknown): string {
   }
 }
 
+export { promptUsesHighPrecisionTimeVariables } from "./prompt-time-variables.ts";
+
 function resolveSystemPromptVariables(
   prompt: string,
   customVariablesRaw: string,

--- a/studio/frontend/src/features/chat/api/prompt-time-variables.ts
+++ b/studio/frontend/src/features/chat/api/prompt-time-variables.ts
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+/**
+ * True when the prompt uses a second-precision time variable ({{$now}} or
+ * {{$time}}). Those are re-filled on every request, so the prompt prefix
+ * changes each turn and prefix caching never matches — every message pays a
+ * full prefill (#9177: 55s vs 0.95s first token). {{$date}} flips once per
+ * day and is usually acceptable.
+ */
+export function promptUsesHighPrecisionTimeVariables(prompt: string): boolean {
+  if (!prompt) {
+    return false;
+  }
+  return /{{\s*\$now\s*}}|{{\s*\$time\s*}}/i.test(prompt);
+}

--- a/studio/frontend/src/features/chat/chat-settings-sheet.tsx
+++ b/studio/frontend/src/features/chat/chat-settings-sheet.tsx
@@ -1559,7 +1559,11 @@ export function ChatSettingsPanel({
                       {["{{$date}}", "{{$time}}", "{{$now}}"].map((token) => (
                         <span
                           key={token}
-                          title={`${token} is replaced automatically when you send`}
+                          title={
+                      token === "{{$now}}" || token === "{{$time}}"
+                        ? `${token} is replaced automatically when you send. Second precision: it changes every request and defeats prefix caching. Prefer {{$date}}.`
+                        : `${token} is replaced automatically when you send`
+                    }
                           className="rounded-full bg-muted px-2 py-0.5 font-mono text-ui-10 text-muted-foreground"
                         >
                           {token}
@@ -1604,6 +1608,17 @@ export function ChatSettingsPanel({
               className="min-h-[20rem] max-h-[48dvh] overflow-y-auto border-0 text-sm leading-6 corner-squircle focus-visible:ring-0"
               rows={14}
             />
+            {promptUsesHighPrecisionTimeVariables(systemPromptDraft) ? (
+              <p
+                role="note"
+                className="px-1 text-ui-11 text-amber-600 dark:text-amber-400"
+              >
+                This prompt uses {"{{$now}}"} or {"{{$time}}"}: the value is
+                re-filled every request, so the prompt prefix changes each
+                turn and prefix caching never matches — every message pays a
+                full re-process. Use {"{{$date}}"} or remove the variable.
+              </p>
+            ) : null}
           </div>
           <DialogFooter className="flex-wrap gap-2 sm:justify-between">
             <Button

--- a/studio/frontend/tests/prompt-time-variables-prefix-cache.test.ts
+++ b/studio/frontend/tests/prompt-time-variables-prefix-cache.test.ts
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { registerBundlerResolver } from "./helpers/kit.ts";
+
+registerBundlerResolver();
+
+const { promptUsesHighPrecisionTimeVariables } = await import(
+  "../src/features/chat/api/prompt-time-variables.ts"
+);
+
+// #9177: {{$now}}/{{$time}} are re-filled with second precision on every
+// request, so a system prompt carrying them changes every turn and prefix
+// caching never matches — full prefill per message (55s vs 0.95s first token
+// in the report). The UI warns on exactly this shape.
+test("detects the high-precision time variables", () => {
+  assert.equal(
+    promptUsesHighPrecisionTimeVariables("The current time is {{$now}}"),
+    true,
+  );
+  assert.equal(
+    promptUsesHighPrecisionTimeVariables("Clock: {{ $time }}"),
+    true,
+  );
+  assert.equal(
+    promptUsesHighPrecisionTimeVariables("{{ $NOW }}"),
+    true,
+  );
+});
+
+test("day precision and custom variables do not warn", () => {
+  assert.equal(
+    promptUsesHighPrecisionTimeVariables("Today is {{$date}}"),
+    false,
+  );
+  assert.equal(
+    promptUsesHighPrecisionTimeVariables("Env: {{ env }}"),
+    false,
+  );
+  assert.equal(
+    promptUsesHighPrecisionTimeVariables("Plain prompt, no variables"),
+    false,
+  );
+  assert.equal(promptUsesHighPrecisionTimeVariables(""), false);
+});
+
+test("now embedded mid-sentence and with timezone suffix still warns", () => {
+  assert.equal(
+    promptUsesHighPrecisionTimeVariables(
+      "Context as of {{$now}} — respond accordingly. Also {{version}}.",
+    ),
+    true,
+  );
+  assert.equal(
+    promptUsesHighPrecisionTimeVariables("see {{$timestamp}}"),
+    false,
+    "only the built-in $now/$time shapes warn; unknown keys are left as-is",
+  );
+});

--- a/tests/studio/playwright_chat_ui.py
+++ b/tests/studio/playwright_chat_ui.py
@@ -186,7 +186,12 @@ def exercise_permission_mode_controls(page, shoot):
     page.route("**/api/chat/settings", refuse_settings_hydration)
     set_legacy_confirm(None)
     page.reload(wait_until = "domcontentloaded")
-    expect(pill).to_be_visible()
+    # Explicit timeout: this is the post-reload assertion, and the reloaded
+    # page stays silent until the backend's warm/self-heal settles on a busy
+    # runner. The 5s expect default turns that starvation into a flake; the
+    # page's own 60s budget matches what every other assertion here already
+    # uses via set_default_timeout (#9183).
+    expect(pill).to_be_visible(timeout = 60_000)
 
     # Fresh profiles default to Approve for me.
     expect_mode("Approve for me")

--- a/tests/studio/test_backend_ci_parallel_isolation.py
+++ b/tests/studio/test_backend_ci_parallel_isolation.py
@@ -151,8 +151,10 @@ BENIGN_TIMING = {
     # A 600-second expiry checked against the wall clock. Reading both sides of that gap
     # late by whole seconds still leaves it true, and it only reaches this scan at all
     # because the widened operand walk now reads `x > time.time()` as a bound.
-    ("test_openai_codex_subscription.py",
-     "test_account_claim_and_token_response_are_validated_without_returning_raw_body"),
+    (
+        "test_openai_codex_subscription.py",
+        "test_account_claim_and_token_response_are_validated_without_returning_raw_body",
+    ),
 }
 
 


### PR DESCRIPTION
Closes #9183, implementing both changes at the two layers the issue names.

## The flake, per the issue's measurements

The chat UI smoke fails intermittently at the **post-reload** pill assertion with the 5s `expect` default. Every failing run's `studio.log` shows the reloaded page going silent until the backend finishes the torch warm **and** the MLX self-heal pip install it kicks off — on a 3 vCPU runner that install starves the browser right through the assertion budget. Run 32129318185's install finished **0.1s after** the assertion gave up; the same failure hit the unrelated `fix-mainred-banner-rail` branch 21 minutes apart.

## Change 1 — the self-heal cannot run in this job

The smoke's boot script (and the retry-restart inside the workflow) now set `UNSLOTH_DISABLE_MLX_AUTOREPAIR=1`. These runners are `--no-torch` installs with no MLX present, so the self-heal can never succeed there — it can only pip-install mid-test and steal CPU from Chromium. This is the job-scoped env var the repair path already documents for exactly this opt-out.

## Change 2 — the post-reload assertion uses the page's own budget

`expect(pill).to_be_visible(timeout = 60_000)` at the reload assertion, matching the `set_default_timeout(60_000)` every other assertion in the file already relies on — so a slow reload is slow rather than red. The pre-reload assertion at line 135 keeps the fast default (it has no starvation window behind it).

## Falsifiability note

The issue's author held off patching because neither change is provable without faking the runner. The env-var change is provable in the negative direction the job actually has: with no MLX present, `start_mlx_autorepair_if_needed()`'s own stack check decides no repair is needed, so the var's only observable effect on this runner is the absence of the mid-test pip install — which is precisely the interference being removed. The timeout change is a budget alignment with the file's documented 60s rationale (`macos-14 runners are slow enough that renders routinely crowd 30s`).