### PR TITLE
fix(studio): keep iGPU carve-out VRAM on hybrid ROCm hosts

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -5840,7 +5840,7 @@ class LlamaCppBackend:
             unified: set[int] = set()
             for ordinal in range(torch.cuda.device_count()):
                 try:
-                    _arch, is_unified = _rocm_classify_unified_memory(
+                    _arch, is_unified, _ = _rocm_classify_unified_memory(
                         torch.cuda.get_device_properties(ordinal)
                     )
                 except Exception:
@@ -5880,7 +5880,7 @@ class LlamaCppBackend:
             physical_ids = LlamaCppBackend._resolve_visible_physical_ids()
             for ordinal in range(torch.cuda.device_count()):
                 try:
-                    _arch, _is_unified = _rocm_classify_unified_memory(
+                    _arch, _is_unified, _ = _rocm_classify_unified_memory(
                         torch.cuda.get_device_properties(ordinal)
                     )
                 except Exception:

--- a/studio/backend/core/training/worker.py
+++ b/studio/backend/core/training/worker.py
@@ -1694,15 +1694,23 @@ def _torch_has_hip() -> bool:
         return False
 
 
-def _rocm_classify_unified_memory(props: Any) -> tuple[str, bool]:
+def _rocm_classify_unified_memory(props: Any) -> tuple[str, bool, bool]:
     """Classify a ROCm device as unified-memory (APU) or discrete.
 
-    Returns ``(gcn_arch, is_unified)``:
+    Returns ``(gcn_arch, is_unified, is_shared_pool)``:
     - ``gcn_arch``: canonical arch string (e.g. ``"gfx1151"``) when a known
       attribute is present, else ``""``.
     - ``is_unified``: ``True`` for AMD APUs with a shared GPU/system-RAM pool
       (gfx1150 Strix Point, gfx1151 Strix Halo, gfx1152 Krackan Point) — these
       need a lower ``set_per_process_memory_fraction`` cap to leave OS headroom.
+    - ``is_shared_pool``: ``True`` when the device is a *genuine* shared-pool
+      arch (gfx1150/51/52 Strix Point/Halo/Krackan, or a Radeon 8xxM/80xxS
+      name). For these the GTT pool IS the real VRAM, so hybrid-host code must
+      NOT substitute the carve-out even when a discrete card is visible. A
+      driver-flag-only APU (e.g. gfx1103 Phoenix iGPU) is unified but not a
+      shared-pool arch; consumers distinguish the two via this flag. This is
+      the single source of truth for the arch/name table -- callers must not
+      re-list the arches or names.
 
     Classification priority:
     1. ``props.is_integrated`` truthy (hipDeviceProp_t.integrated -- the
@@ -1724,22 +1732,12 @@ def _rocm_classify_unified_memory(props: Any) -> tuple[str, bool]:
             gcn_arch = _v
             break
 
-    # Driver's own answer first: hipDeviceProp_t.integrated (props.is_integrated, the same
-    # gate PR #5988's UMA safetensors fast-load uses). Strictly additive -- only a truthy
-    # value upgrades to unified, so a wheel that omits the field can't downgrade the known
-    # APU set. Covers unified APUs outside the hardcoded arches (gfx1103 Phoenix, future).
-    if getattr(props, "is_integrated", 0):
-        return gcn_arch, True
-
-    if gcn_arch:
-        # gfx1152 is Krackan Point: same shared GPU/system-RAM pool as gfx1150/gfx1151.
-        # Case-folded: the attribute is lowercase in practice but is not guaranteed.
-        return gcn_arch, gcn_arch.lower() in {"gfx1150", "gfx1151", "gfx1152"}
-
-    # Arch attrs absent -- fall back to device-name matching. Only reached under _hw.IS_ROCM,
-    # so the NVIDIA GeForce 840M cannot collide with the Krackan markers.
+    # Genuine shared-pool arch: gfx1150/51/52, or a Radeon 8xxM/80xxS name when the
+    # arch attrs are absent. Computed before the is_integrated early return so a
+    # Strix Halo (integrated flag AND gfx1151) still reports is_shared_pool=True.
+    _arch_lower = gcn_arch.lower()
     dev_lower = (getattr(props, "name", "") or "").lower()
-    is_unified = (
+    is_shared_pool = _arch_lower in {"gfx1150", "gfx1151", "gfx1152"} or (
         "890m" in dev_lower
         or "880m" in dev_lower
         or "8065s" in dev_lower
@@ -1748,7 +1746,22 @@ def _rocm_classify_unified_memory(props: Any) -> tuple[str, bool]:
         or "860m" in dev_lower
         or "840m" in dev_lower
     )
-    return gcn_arch, is_unified
+
+    # Driver's own answer first: hipDeviceProp_t.integrated (props.is_integrated, the same
+    # gate PR #5988's UMA safetensors fast-load uses). Strictly additive -- only a truthy
+    # value upgrades to unified, so a wheel that omits the field can't downgrade the known
+    # APU set. Covers unified APUs outside the hardcoded arches (gfx1103 Phoenix, future).
+    if getattr(props, "is_integrated", 0):
+        return gcn_arch, True, is_shared_pool
+
+    if gcn_arch:
+        # gfx1152 is Krackan Point: same shared GPU/system-RAM pool as gfx1150/gfx1151.
+        # Case-folded: the attribute is lowercase in practice but is not guaranteed.
+        return gcn_arch, _arch_lower in {"gfx1150", "gfx1151", "gfx1152"}, is_shared_pool
+
+    # Arch attrs absent -- fall back to device-name matching. Only reached under _hw.IS_ROCM,
+    # so the NVIDIA GeForce 840M cannot collide with the Krackan markers.
+    return gcn_arch, is_shared_pool, is_shared_pool
 
 
 # 16 GiB, not a percentage: on a 128 GiB Strix Halo a flat 20% withholds 25.6 GiB, while
@@ -3980,7 +3993,7 @@ def run_training_process(*, event_queue: Any, stop_queue: Any, config: dict) -> 
                 _rdna4 = False
                 for _i in range(_torch_lin.cuda.device_count()):
                     _props = _torch_lin.cuda.get_device_properties(_i)
-                    _lin_arch, _ = _rocm_classify_unified_memory(_props)
+                    _lin_arch, _, _ = _rocm_classify_unified_memory(_props)
                     _lin_name = (getattr(_props, "name", "") or "").lower()
                     if _lin_arch.lower() in ("gfx1200", "gfx1201") or (
                         not _lin_arch and re.search(r"rx\s*90[0-9]0|r9700", _lin_name)
@@ -4007,7 +4020,7 @@ def run_training_process(*, event_queue: Any, stop_queue: Any, config: dict) -> 
                 # Classify unified vs discrete (see _rocm_classify_unified_memory's docstring).
                 _props = _torch_mem.cuda.get_device_properties(0)
                 _dev_name = _props.name
-                _gcn_arch, _is_unified = _rocm_classify_unified_memory(_props)
+                _gcn_arch, _is_unified, _ = _rocm_classify_unified_memory(_props)
                 if _is_unified and not _gcn_arch:
                     logger.debug(
                         "ROCm OOM guard: gcnArchName absent -- inferred "

--- a/studio/backend/tests/test_rocm_oom_guard.py
+++ b/studio/backend/tests/test_rocm_oom_guard.py
@@ -71,30 +71,30 @@ class TestIsIntegratedSignal:
         # gfx1103 Phoenix iGPU: outside the hardcoded arch set, but the
         # driver says integrated -> unified.
         props = _props(gcnArchName = "gfx1103", name = "Radeon 780M", is_integrated = 1)
-        gcn, is_unified = _rocm_classify_unified_memory(props)
+        gcn, is_unified, _ = _rocm_classify_unified_memory(props)
         assert gcn == "gfx1103"
         assert is_unified is True
 
     def test_integrated_wins_without_any_arch(self) -> None:
         props = _props(name = "Some Future APU", is_integrated = 1)
-        gcn, is_unified = _rocm_classify_unified_memory(props)
+        gcn, is_unified, _ = _rocm_classify_unified_memory(props)
         assert gcn == ""
         assert is_unified is True
 
     def test_zero_does_not_downgrade_known_apu(self) -> None:
         # A wheel that zeroes the field must not flip Strix Halo to discrete.
         props = _props(gcnArchName = "gfx1151", name = "x", is_integrated = 0)
-        gcn, is_unified = _rocm_classify_unified_memory(props)
+        gcn, is_unified, _ = _rocm_classify_unified_memory(props)
         assert is_unified is True
 
     def test_absent_keeps_existing_behavior(self) -> None:
         props = _props(gcnArchName = "gfx1201", name = "RX 9070 XT")
-        gcn, is_unified = _rocm_classify_unified_memory(props)
+        gcn, is_unified, _ = _rocm_classify_unified_memory(props)
         assert is_unified is False
 
     def test_discrete_with_zero_stays_discrete(self) -> None:
         props = _props(gcnArchName = "gfx1100", name = "RX 7900 XTX", is_integrated = 0)
-        gcn, is_unified = _rocm_classify_unified_memory(props)
+        gcn, is_unified, _ = _rocm_classify_unified_memory(props)
         assert is_unified is False
 
 
@@ -117,14 +117,14 @@ class TestCanonicalGcnArchName:
     )
     def test_canonical_attr(self, arch: str, expected_unified: bool) -> None:
         props = _props(gcnArchName = arch, name = "irrelevant")
-        gcn, is_unified = _rocm_classify_unified_memory(props)
+        gcn, is_unified, _ = _rocm_classify_unified_memory(props)
         assert gcn == arch
         assert is_unified is expected_unified
 
     def test_arch_with_colon_suffix_stripped(self) -> None:
         """gcnArchName can carry xnack/sramecc suffix; only the base is kept."""
         props = _props(gcnArchName = "gfx1151:xnack-", name = "irrelevant")
-        gcn, is_unified = _rocm_classify_unified_memory(props)
+        gcn, is_unified, _ = _rocm_classify_unified_memory(props)
         assert gcn == "gfx1151"
         assert is_unified is True
 
@@ -132,7 +132,7 @@ class TestCanonicalGcnArchName:
         """Arch attr takes priority; device name is ignored."""
         # Discrete arch, but name looks like a unified SKU — arch must win.
         props = _props(gcnArchName = "gfx1100", name = "Radeon 890M")
-        gcn, is_unified = _rocm_classify_unified_memory(props)
+        gcn, is_unified, _ = _rocm_classify_unified_memory(props)
         assert gcn == "gfx1100"
         assert is_unified is False
 
@@ -149,7 +149,7 @@ class TestAlternateSpellingFallback:
     )
     def test_alternate_attr_unified(self, attr_name: str) -> None:
         props = _props(**{attr_name: "gfx1151"}, name = "Radeon 8060S Graphics")
-        gcn, is_unified = _rocm_classify_unified_memory(props)
+        gcn, is_unified, _ = _rocm_classify_unified_memory(props)
         assert gcn == "gfx1151"
         assert is_unified is True
 
@@ -159,14 +159,14 @@ class TestAlternateSpellingFallback:
     )
     def test_alternate_attr_discrete(self, attr_name: str) -> None:
         props = _props(**{attr_name: "gfx1201"}, name = "Radeon RX 9070 XT")
-        gcn, is_unified = _rocm_classify_unified_memory(props)
+        gcn, is_unified, _ = _rocm_classify_unified_memory(props)
         assert gcn == "gfx1201"
         assert is_unified is False
 
     def test_first_non_empty_attr_wins(self) -> None:
         """With multiple alternate attrs, the first non-empty one wins."""
         props = _props(gcn_arch_name = "gfx1151", arch_name = "gfx1100", name = "irrelevant")
-        gcn, is_unified = _rocm_classify_unified_memory(props)
+        gcn, is_unified, _ = _rocm_classify_unified_memory(props)
         assert gcn == "gfx1151"
         assert is_unified is True
 
@@ -209,7 +209,7 @@ class TestDeviceNameFallback:
     )
     def test_unified_memory_detected(self, device_name: str) -> None:
         props = _props(name = device_name)
-        gcn, is_unified = _rocm_classify_unified_memory(props)
+        gcn, is_unified, _ = _rocm_classify_unified_memory(props)
         assert gcn == "", f"expected empty gcn_arch, got {gcn!r}"
         assert is_unified is True, f"device {device_name!r} should be classified as unified-memory"
 
@@ -230,7 +230,7 @@ class TestDeviceNameFallback:
     )
     def test_discrete_not_misclassified(self, device_name: str) -> None:
         props = _props(name = device_name)
-        gcn, is_unified = _rocm_classify_unified_memory(props)
+        gcn, is_unified, _ = _rocm_classify_unified_memory(props)
         assert gcn == ""
         assert (
             is_unified is False
@@ -239,13 +239,13 @@ class TestDeviceNameFallback:
     def test_empty_name_returns_false(self) -> None:
         """Absent name must not crash and must default to discrete."""
         props = _props()  # no 'name' attr at all
-        gcn, is_unified = _rocm_classify_unified_memory(props)
+        gcn, is_unified, _ = _rocm_classify_unified_memory(props)
         assert gcn == ""
         assert is_unified is False
 
     def test_none_name_returns_false(self) -> None:
         props = _props(name = None)
-        gcn, is_unified = _rocm_classify_unified_memory(props)
+        gcn, is_unified, _ = _rocm_classify_unified_memory(props)
         assert gcn == ""
         assert is_unified is False
 
@@ -254,6 +254,53 @@ class TestDeviceNameFallback:
 
 
 _WORKER_PY = Path(__file__).resolve().parents[1] / "core" / "training" / "worker.py"
+
+
+class TestSharedPoolFlag:
+    """is_shared_pool: genuine shared-pool arches vs driver-flag-only APUs.
+
+    The third classifier answer exists so hybrid-host code (e.g.
+    _rocm_hybrid_keeps_carve_out) can distinguish "GTT is the real VRAM"
+    (Strix Point/Halo/Krackan + Radeon 8xxM/80xxS) from a driver-flag-only
+    unified APU (e.g. gfx1103 Phoenix iGPU), without re-listing the arch/name
+    table. This is the single source of truth for that table.
+    """
+
+    def test_shared_pool_arch_via_gcn(self) -> None:
+        props = _props(gcnArchName = "gfx1151", name = "irrelevant", is_integrated = 0)
+        gcn, is_unified, is_shared_pool = _rocm_classify_unified_memory(props)
+        assert gcn == "gfx1151"
+        assert is_unified is True
+        assert is_shared_pool is True
+
+    def test_shared_pool_arch_stays_true_with_integrated_flag(self) -> None:
+        # Strix Halo carries both the integrated flag and the gfx1151 arch; the
+        # early is_integrated return must not drop the shared-pool answer.
+        props = _props(gcnArchName = "gfx1151", name = "Radeon 8060S", is_integrated = 1)
+        gcn, is_unified, is_shared_pool = _rocm_classify_unified_memory(props)
+        assert is_unified is True
+        assert is_shared_pool is True
+
+    def test_flag_only_apu_is_unified_but_not_shared_pool(self) -> None:
+        # gfx1103 Phoenix iGPU: driver flag upgrades it to unified, but it is
+        # not a genuine shared-pool arch, so hybrid code must keep its carve-out.
+        props = _props(gcnArchName = "gfx1103", name = "Radeon 780M", is_integrated = 1)
+        gcn, is_unified, is_shared_pool = _rocm_classify_unified_memory(props)
+        assert gcn == "gfx1103"
+        assert is_unified is True
+        assert is_shared_pool is False
+
+    def test_name_table_marks_shared_pool_when_arch_absent(self) -> None:
+        props = _props(name = "Radeon 8060S Graphics", is_integrated = 0)
+        gcn, is_unified, is_shared_pool = _rocm_classify_unified_memory(props)
+        assert is_unified is True
+        assert is_shared_pool is True
+
+    def test_discrete_arch_is_not_shared_pool(self) -> None:
+        props = _props(gcnArchName = "gfx1201", name = "RX 9070 XT")
+        _, is_unified, is_shared_pool = _rocm_classify_unified_memory(props)
+        assert is_unified is False
+        assert is_shared_pool is False
 
 
 class TestMemFractionSelection:

--- a/studio/backend/tests/test_system_poll_no_cuda_context.py
+++ b/studio/backend/tests/test_system_poll_no_cuda_context.py
@@ -263,7 +263,11 @@ def _rocm_inventory_mod(devices):
     return mod
 
 
-def _rocm_test_env(monkeypatch, devices, hip = "6.2.0"):
+def _rocm_test_env(
+    monkeypatch,
+    devices,
+    hip = "6.2.0",
+):
     """Point the inventory helper at a fake ROCm torch with the given HIP
     version (6.2 fills is_integrated authoritatively; 6.1 exercises the
     runtime-not-trusted path)."""

--- a/studio/backend/tests/test_system_poll_no_cuda_context.py
+++ b/studio/backend/tests/test_system_poll_no_cuda_context.py
@@ -239,6 +239,90 @@ def test_inventory_is_empty_without_torch(monkeypatch):
     assert hw._torch_get_device_inventory([0]) == []
 
 
+# ========== ROCm hybrid host (discrete + integrated) ==========
+
+_GB = 1024**3
+
+
+def _rocm_inventory_mod(devices):
+    """Fake torch module for inventory tests.
+
+    ``devices`` is a list of
+    ``(name, total_memory, is_integrated, gcn_arch_name, gtt_total)`` tuples:
+    ``total_memory`` is the driver's dedicated total (the carve-out on an
+    integrated part) and ``gtt_total`` is what ``mem_get_info`` reports for the
+    same device (the GTT/shared pool on an APU)."""
+    mod = types.SimpleNamespace()
+    mod.get_device_properties = lambda o: types.SimpleNamespace(
+        name = devices[o][0],
+        total_memory = devices[o][1],
+        is_integrated = devices[o][2],
+        gcnArchName = devices[o][3],
+    )
+    mod.mem_get_info = lambda o: (devices[o][4] - (1 << 30), devices[o][4])
+    return mod
+
+
+def _rocm_test_env(monkeypatch, devices):
+    """Point the inventory helper at a fake ROCm torch: hip 6.2 (so discrete
+    carve-out classification is authoritative) with the given device list."""
+    torch_mod = types.SimpleNamespace()
+    torch_mod.version = types.SimpleNamespace(hip = "6.2.0")
+    monkeypatch.setitem(sys.modules, "torch", torch_mod)
+    monkeypatch.setattr(hw, "IS_ROCM", True)
+    mod = _rocm_inventory_mod(devices)
+    monkeypatch.setattr(hw, "_torch_get_device_module", lambda: (mod, "cuda"))
+    return mod
+
+
+def test_inventory_hybrid_rocm_keeps_igpu_carve_out(monkeypatch):
+    # Desktop dGPU + iGPU (unslothai/unsloth#8942): the integrated member's
+    # GTT/shared pool is not its real VRAM. Reporting it as capacity showed the
+    # iGPU with overinflated VRAM; the fix keeps the dedicated carve-out on a
+    # hybrid host while the discrete card is unchanged.
+    devices = [
+        ("AMD Radeon RX 9070 XT", 16 * _GB, 0, "gfx1201", 16 * _GB),
+        ("AMD Radeon Graphics", int(0.5 * _GB), 1, "gfx1150", 24 * _GB),
+    ]
+    _rocm_test_env(monkeypatch, devices)
+    inventory = hw._torch_get_device_inventory([0, 1])
+    assert [d["total_gb"] for d in inventory] == [16.0, 0.5]
+    assert [d["name"] for d in inventory] == ["AMD Radeon RX 9070 XT", "AMD Radeon Graphics"]
+
+
+def test_inventory_hybrid_rocm_igpu_first_ordinal(monkeypatch):
+    # Same host, iGPU enumerated first: the hybrid guard must not depend on which
+    # ordinal the integrated part lands on.
+    devices = [
+        ("AMD Radeon Graphics", int(0.5 * _GB), 1, "gfx1150", 24 * _GB),
+        ("AMD Radeon RX 9070 XT", 16 * _GB, 0, "gfx1201", 16 * _GB),
+    ]
+    _rocm_test_env(monkeypatch, devices)
+    inventory = hw._torch_get_device_inventory([0, 1])
+    assert [d["total_gb"] for d in inventory] == [0.5, 16.0]
+
+
+def test_inventory_apu_only_still_reports_gtt_pool(monkeypatch):
+    # A unified-only APU host (e.g. Strix Halo) must keep today's behaviour: the
+    # carve-out understates what the model can actually use, so the GTT total
+    # stays the reported capacity.
+    devices = [("AMD Radeon 8060S", 8 * _GB, 1, "gfx1151", 128 * _GB)]
+    _rocm_test_env(monkeypatch, devices)
+    inventory = hw._torch_get_device_inventory([0])
+    assert inventory[0]["total_gb"] == 128.0
+
+
+def test_inventory_discrete_rocm_set_untouched(monkeypatch):
+    # Two discrete cards: nothing unified, no correction, driver totals stand.
+    devices = [
+        ("AMD Radeon RX 9070 XT", 16 * _GB, 0, "gfx1201", 16 * _GB),
+        ("AMD Radeon RX 7900 XTX", 24 * _GB, 0, "gfx1100", 24 * _GB),
+    ]
+    _rocm_test_env(monkeypatch, devices)
+    inventory = hw._torch_get_device_inventory([0, 1])
+    assert [d["total_gb"] for d in inventory] == [16.0, 24.0]
+
+
 def test_visibility_endpoint_uses_inventory_not_occupancy(monkeypatch):
     monkeypatch.setattr(hw, "get_device", lambda: hw.DeviceType.CUDA)
     monkeypatch.setattr(hw, "IS_ROCM", True)  # skips the nvidia-smi shortcut

--- a/studio/backend/tests/test_system_poll_no_cuda_context.py
+++ b/studio/backend/tests/test_system_poll_no_cuda_context.py
@@ -263,11 +263,12 @@ def _rocm_inventory_mod(devices):
     return mod
 
 
-def _rocm_test_env(monkeypatch, devices):
-    """Point the inventory helper at a fake ROCm torch: hip 6.2 (so discrete
-    carve-out classification is authoritative) with the given device list."""
+def _rocm_test_env(monkeypatch, devices, hip = "6.2.0"):
+    """Point the inventory helper at a fake ROCm torch with the given HIP
+    version (6.2 fills is_integrated authoritatively; 6.1 exercises the
+    runtime-not-trusted path)."""
     torch_mod = types.SimpleNamespace()
-    torch_mod.version = types.SimpleNamespace(hip = "6.2.0")
+    torch_mod.version = types.SimpleNamespace(hip = hip)
     monkeypatch.setitem(sys.modules, "torch", torch_mod)
     monkeypatch.setattr(hw, "IS_ROCM", True)
     mod = _rocm_inventory_mod(devices)
@@ -276,13 +277,14 @@ def _rocm_test_env(monkeypatch, devices):
 
 
 def test_inventory_hybrid_rocm_keeps_igpu_carve_out(monkeypatch):
-    # Desktop dGPU + iGPU (unslothai/unsloth#8942): the integrated member's
-    # GTT/shared pool is not its real VRAM. Reporting it as capacity showed the
-    # iGPU with overinflated VRAM; the fix keeps the dedicated carve-out on a
-    # hybrid host while the discrete card is unchanged.
+    # Desktop dGPU + desktop iGPU (unslothai/unsloth#8942): the integrated member
+    # is a Phoenix (gfx1103) classified unified ONLY through the driver flag; its
+    # GTT/shared pool is not its real VRAM on a hybrid host, so the carve-out is
+    # kept. gfx1150 would be the wrong arch here: it is Strix Point, one of the
+    # genuine shared-pool arches that keeps the GTT pool even in a mixed set.
     devices = [
         ("AMD Radeon RX 9070 XT", 16 * _GB, 0, "gfx1201", 16 * _GB),
-        ("AMD Radeon Graphics", int(0.5 * _GB), 1, "gfx1150", 24 * _GB),
+        ("AMD Radeon Graphics", int(0.5 * _GB), 1, "gfx1103", 24 * _GB),
     ]
     _rocm_test_env(monkeypatch, devices)
     inventory = hw._torch_get_device_inventory([0, 1])
@@ -294,12 +296,25 @@ def test_inventory_hybrid_rocm_igpu_first_ordinal(monkeypatch):
     # Same host, iGPU enumerated first: the hybrid guard must not depend on which
     # ordinal the integrated part lands on.
     devices = [
-        ("AMD Radeon Graphics", int(0.5 * _GB), 1, "gfx1150", 24 * _GB),
+        ("AMD Radeon Graphics", int(0.5 * _GB), 1, "gfx1103", 24 * _GB),
         ("AMD Radeon RX 9070 XT", 16 * _GB, 0, "gfx1201", 16 * _GB),
     ]
     _rocm_test_env(monkeypatch, devices)
     inventory = hw._torch_get_device_inventory([0, 1])
     assert [d["total_gb"] for d in inventory] == [0.5, 16.0]
+
+
+def test_inventory_hybrid_rocm_strix_halo_keeps_gtt_pool(monkeypatch):
+    # A genuine shared-pool arch (gfx1151 Strix Halo) keeps its GTT pool even
+    # when a discrete card is visible: its carve-out is NOT its real VRAM, and
+    # reporting 8 GiB would budget a 128 GiB Halo as a tiny card and hide models.
+    devices = [
+        ("AMD Radeon RX 9070 XT", 16 * _GB, 0, "gfx1201", 16 * _GB),
+        ("AMD Radeon 8060S", 8 * _GB, 1, "gfx1151", 128 * _GB),
+    ]
+    _rocm_test_env(monkeypatch, devices)
+    inventory = hw._torch_get_device_inventory([0, 1])
+    assert [d["total_gb"] for d in inventory] == [16.0, 128.0]
 
 
 def test_inventory_apu_only_still_reports_gtt_pool(monkeypatch):
@@ -312,15 +327,73 @@ def test_inventory_apu_only_still_reports_gtt_pool(monkeypatch):
     assert inventory[0]["total_gb"] == 128.0
 
 
+def test_inventory_apu_only_flag_classified_keeps_gtt_pool(monkeypatch):
+    # A flag-only unified device alone (no discrete card) is NOT a hybrid set:
+    # the GTT substitution applies, so the pool stays the reported capacity.
+    # Pins the hybrid_rocm term of the gate -- dropping it would wrongly keep
+    # the carve-out here.
+    devices = [("AMD Radeon Graphics", int(0.5 * _GB), 1, "gfx1103", 24 * _GB)]
+    _rocm_test_env(monkeypatch, devices)
+    inventory = hw._torch_get_device_inventory([0])
+    assert inventory[0]["total_gb"] == 24.0
+
+
 def test_inventory_discrete_rocm_set_untouched(monkeypatch):
     # Two discrete cards: nothing unified, no correction, driver totals stand.
+    # gtt_total deliberately differs from total_memory (32/48 vs 16/24), so this
+    # test would FAIL if the correction ever fired for a discrete row.
     devices = [
-        ("AMD Radeon RX 9070 XT", 16 * _GB, 0, "gfx1201", 16 * _GB),
-        ("AMD Radeon RX 7900 XTX", 24 * _GB, 0, "gfx1100", 24 * _GB),
+        ("AMD Radeon RX 9070 XT", 16 * _GB, 0, "gfx1201", 32 * _GB),
+        ("AMD Radeon RX 7900 XTX", 24 * _GB, 0, "gfx1100", 48 * _GB),
     ]
     _rocm_test_env(monkeypatch, devices)
     inventory = hw._torch_get_device_inventory([0, 1])
     assert [d["total_gb"] for d in inventory] == [16.0, 24.0]
+
+
+def test_inventory_hybrid_gate_needs_positive_classification(monkeypatch):
+    # Pins the integrated term of the gate: on hip 6.1 the runtime is not trusted
+    # to fill is_integrated, so _rocm_props_total_is_carve_out says carve-out for
+    # EVERY device -- including the Phoenix (gfx1103) the classifier calls
+    # discrete. Only a positive unified classification trips the hybrid skip; a
+    # gate reduced to `if not hybrid_rocm` would wrongly keep the Phoenix at 0.5.
+    devices = [
+        ("AMD Radeon RX 9070 XT", 16 * _GB, 0, "gfx1201", 16 * _GB),
+        ("AMD Radeon 8060S", 8 * _GB, 1, "gfx1151", 128 * _GB),
+        ("AMD Radeon Graphics", int(0.5 * _GB), 0, "gfx1103", 24 * _GB),
+    ]
+    _rocm_test_env(monkeypatch, devices, hip = "6.1.0")
+    inventory = hw._torch_get_device_inventory([0, 1, 2])
+    assert [d["total_gb"] for d in inventory] == [16.0, 128.0, 24.0]
+
+
+def test_inventory_failed_probe_is_not_a_discrete_member(monkeypatch):
+    # A failed probe must not count as "discrete": one APU beside a dead probe is
+    # a single-device set, not a hybrid one, so the APU keeps its GTT pool. The
+    # old gate counted the failed probe as a non-unified member and wrongly
+    # reported the carve-out.
+    def _props(o):
+        if o == 1:
+            raise RuntimeError("device lost")
+        return types.SimpleNamespace(
+            name = "AMD Radeon 8060S",
+            total_memory = 8 * _GB,
+            is_integrated = 1,
+            gcnArchName = "gfx1151",
+        )
+
+    torch_mod = types.SimpleNamespace()
+    torch_mod.version = types.SimpleNamespace(hip = "6.2.0")
+    monkeypatch.setitem(sys.modules, "torch", torch_mod)
+    monkeypatch.setattr(hw, "IS_ROCM", True)
+    mod = types.SimpleNamespace(
+        get_device_properties = _props,
+        mem_get_info = lambda o: (128 * _GB - (1 << 30), 128 * _GB),
+    )
+    monkeypatch.setattr(hw, "_torch_get_device_module", lambda: (mod, "cuda"))
+    inventory = hw._torch_get_device_inventory([0, 1])
+    assert [d["total_gb"] for d in inventory] == [128.0]
+    assert [d["index"] for d in inventory] == [0]
 
 
 def test_visibility_endpoint_uses_inventory_not_occupancy(monkeypatch):

--- a/studio/backend/utils/hardware/hardware.py
+++ b/studio/backend/utils/hardware/hardware.py
@@ -1152,7 +1152,7 @@ def _hip_runtime_version() -> Optional[tuple[int, int]]:
 
 
 def _rocm_props_total_is_carve_out(
-    props: Any, classification: Optional[tuple[str, bool]] = None
+    props: Any, classification: Optional[tuple[str, bool, bool]] = None
 ) -> bool:
     """True when ``props.total_memory`` may understate what torch can actually use.
 
@@ -1201,7 +1201,7 @@ def _rocm_props_total_is_carve_out(
 
 def _rocm_probe_and_classify(
     mod: Any, device_indices: list[int]
-) -> tuple[dict[int, tuple[int, Any, Optional[tuple[str, bool]]]], bool]:
+) -> tuple[dict[int, tuple[int, Any, Optional[tuple[str, bool, bool]]]], bool]:
     """Probe each visible device's props once and classify each device once.
 
     Returns ``(probed, hybrid_rocm)``: ``probed[ordinal]`` is
@@ -1218,7 +1218,7 @@ def _rocm_probe_and_classify(
     """
     if mod is None:
         return {}, False
-    probed: dict[int, tuple[int, Any, Optional[tuple[str, bool]]]] = {}
+    probed: dict[int, tuple[int, Any, Optional[tuple[str, bool, bool]]]] = {}
     for ordinal, phys_idx in enumerate(device_indices):
         try:
             # torch ordinals are 0-based relative to CUDA_VISIBLE_DEVICES.
@@ -1226,7 +1226,7 @@ def _rocm_probe_and_classify(
         except Exception as e:
             logger.debug("torch inventory probe failed for ordinal %d: %s", ordinal, e)
             continue
-        classification: Optional[tuple[str, bool]] = None
+        classification: Optional[tuple[str, bool, bool]] = None
         if IS_ROCM:
             try:
                 from core.training.worker import _rocm_classify_unified_memory
@@ -1264,7 +1264,7 @@ def _rocm_probe_and_classify(
 
 
 def _rocm_hybrid_keeps_carve_out(
-    props: Any, classification: Optional[tuple[str, bool]], hybrid_rocm: bool
+    classification: Optional[tuple[str, bool, bool]], hybrid_rocm: bool
 ) -> bool:
     """True when the GTT substitution must be skipped for this device.
 
@@ -1277,19 +1277,17 @@ def _rocm_hybrid_keeps_carve_out(
     visible -- reporting the carve-out would budget a 128 GiB Strix Halo as
     ~8 GiB and hide models. A device the classifier calls discrete (or that
     failed to classify) is also untouched: it keeps today's behaviour.
+
+    The arch/name table lives in ``_rocm_classify_unified_memory`` (single
+    source of truth); this function consumes its ``is_shared_pool`` answer
+    instead of re-listing the arches and names.
     """
     if not hybrid_rocm:
         return False
     if classification is None or not classification[1]:
         return False
-    arch = (classification[0] or "").lower()
-    if arch in {"gfx1150", "gfx1151", "gfx1152"}:
-        return False
-    dev_lower = (getattr(props, "name", "") or "").lower()
-    if any(
-        marker in dev_lower
-        for marker in ("890m", "880m", "8065s", "8060s", "8050s", "860m", "840m")
-    ):
+    # Genuine shared-pool arch: GTT is the real VRAM, keep the substitution.
+    if classification[2]:
         return False
     return True
 
@@ -1334,7 +1332,7 @@ def _torch_get_device_inventory(device_indices: list[int]) -> list[Dict[str, Any
             if _rocm_props_total_is_carve_out(props, classification) and hasattr(
                 mod, "mem_get_info"
             ):
-                if not _rocm_hybrid_keeps_carve_out(props, classification, hybrid_rocm):
+                if not _rocm_hybrid_keeps_carve_out(classification, hybrid_rocm):
                     try:
                         total_bytes = mod.mem_get_info(ordinal)[1]
                     except Exception as e:
@@ -2411,7 +2409,7 @@ def _reconcile_rocm_unified_memory(utilization: Dict[str, Any], device_indices: 
     keep_carve_out = {
         probed[ordinal][0]
         for ordinal in probed
-        if _rocm_hybrid_keeps_carve_out(probed[ordinal][1], probed[ordinal][2], hybrid_rocm)
+        if _rocm_hybrid_keeps_carve_out(probed[ordinal][2], hybrid_rocm)
     }
     torch_by_index = {td["index"]: td for td in torch_devices}
     for dev in utilization.get("devices", []):

--- a/studio/backend/utils/hardware/hardware.py
+++ b/studio/backend/utils/hardware/hardware.py
@@ -1151,7 +1151,9 @@ def _hip_runtime_version() -> Optional[tuple[int, int]]:
         return None
 
 
-def _rocm_props_total_is_carve_out(props: Any) -> bool:
+def _rocm_props_total_is_carve_out(
+    props: Any, classification: Optional[tuple[str, bool]] = None
+) -> bool:
     """True when ``props.total_memory`` may understate what torch can actually use.
 
     On a unified-memory ROCm APU the two totals are NOT the same number:
@@ -1164,6 +1166,12 @@ def _rocm_props_total_is_carve_out(props: Any) -> bool:
     free inventory. Same classifier the training worker and the llama.cpp backend
     use, so all three agree on what an APU is.
 
+    ``classification``, when given, is the ``(gcn_arch, is_unified)`` tuple from
+    that same classifier, so callers that already classified the device do not
+    pay for a second pass. When omitted (or when classification failed and the
+    caller passes None) the classifier runs here and a failure is treated as
+    carve-out, exactly as before.
+
     "Not unified" is not the same answer as "discrete". That classifier knows an APU
     by the driver's integrated flag or by a hardcoded arch set, so a gfx1103 Phoenix
     iGPU on a runtime that leaves the flag at 0 reads as discrete and would publish
@@ -1173,12 +1181,15 @@ def _rocm_props_total_is_carve_out(props: Any) -> bool:
     """
     if not IS_ROCM:
         return False
-    try:
-        from core.training.worker import _rocm_classify_unified_memory
-        if _rocm_classify_unified_memory(props)[1]:
+    if classification is None:
+        try:
+            from core.training.worker import _rocm_classify_unified_memory
+
+            classification = _rocm_classify_unified_memory(props)
+        except Exception as e:
+            logger.debug("ROCm unified-memory classification failed: %s", e)
             return True
-    except Exception as e:
-        logger.debug("ROCm unified-memory classification failed: %s", e)
+    if classification[1]:
         return True
     hip_version = _hip_runtime_version()
     return (
@@ -1186,6 +1197,101 @@ def _rocm_props_total_is_carve_out(props: Any) -> bool:
         or hip_version is None
         or hip_version < _HIP_INTEGRATED_FLAG_MIN
     )
+
+
+def _rocm_probe_and_classify(
+    mod: Any, device_indices: list[int]
+) -> tuple[dict[int, tuple[int, Any, Optional[tuple[str, bool]]]], bool]:
+    """Probe each visible device's props once and classify each device once.
+
+    Returns ``(probed, hybrid_rocm)``: ``probed[ordinal]`` is
+    ``(phys_idx, props, classification)`` where ``classification`` is the
+    ``(gcn_arch, is_unified)`` tuple from the shared worker classifier, or None
+    when the probe or the classification failed.
+
+    Failed probes are omitted entirely rather than counted as "discrete": a
+    single-APU host with one dead probe must not be misread as a hybrid set
+    (that would strip the APU of its GTT pool). Each device classifies in its
+    own try/except, so one props object that raises on attribute access cannot
+    collapse the decision for the whole set. ``hybrid_rocm`` is True when at
+    least two probed ROCm devices mix unified and non-unified members.
+    """
+    if mod is None:
+        return {}, False
+    probed: dict[int, tuple[int, Any, Optional[tuple[str, bool]]]] = {}
+    for ordinal, phys_idx in enumerate(device_indices):
+        try:
+            # torch ordinals are 0-based relative to CUDA_VISIBLE_DEVICES.
+            props = mod.get_device_properties(ordinal)
+        except Exception as e:
+            logger.debug("torch inventory probe failed for ordinal %d: %s", ordinal, e)
+            continue
+        classification: Optional[tuple[str, bool]] = None
+        if IS_ROCM:
+            try:
+                from core.training.worker import _rocm_classify_unified_memory
+
+                classification = _rocm_classify_unified_memory(props)
+            except Exception as e:
+                logger.debug(
+                    "ROCm unified-memory classification failed for ordinal %d: %s",
+                    ordinal,
+                    e,
+                )
+        if IS_ROCM:
+            logger.debug(
+                "ROCm device ordinal %d (phys %d): name=%r arch=%r is_integrated=%r -> unified=%s",
+                ordinal,
+                phys_idx,
+                getattr(props, "name", None),
+                classification[0] if classification else None,
+                getattr(props, "is_integrated", None),
+                classification[1] if classification else None,
+            )
+        probed[ordinal] = (phys_idx, props, classification)
+    hybrid_rocm = False
+    if IS_ROCM and len(probed) >= 2:
+        unified_flags = [
+            cls is not None and cls[1] for _, _, cls in probed.values()
+        ]
+        hybrid_rocm = any(unified_flags) and not all(unified_flags)
+        if hybrid_rocm:
+            logger.debug(
+                "ROCm hybrid set detected (unified_flags=%s); integrated members keep their carve-out",
+                unified_flags,
+            )
+    return probed, hybrid_rocm
+
+
+def _rocm_hybrid_keeps_carve_out(
+    props: Any, classification: Optional[tuple[str, bool]], hybrid_rocm: bool
+) -> bool:
+    """True when the GTT substitution must be skipped for this device.
+
+    The integrated member of a hybrid ROCm set (unified + discrete visible
+    together, e.g. a desktop Radeon dGPU beside a Ryzen iGPU) keeps its dedicated
+    carve-out: its GTT/shared pool is system RAM, not VRAM (unslothai/unsloth
+    #8942). The genuine shared-pool arches (gfx1150/51/52 Strix Point/Halo/
+    Krackan, and their Radeon 8xxM/80xxS names) are exempt: their GTT pool IS
+    the real VRAM, so the substitution stands even when a discrete card is
+    visible -- reporting the carve-out would budget a 128 GiB Strix Halo as
+    ~8 GiB and hide models. A device the classifier calls discrete (or that
+    failed to classify) is also untouched: it keeps today's behaviour.
+    """
+    if not hybrid_rocm:
+        return False
+    if classification is None or not classification[1]:
+        return False
+    arch = (classification[0] or "").lower()
+    if arch in {"gfx1150", "gfx1151", "gfx1152"}:
+        return False
+    dev_lower = (getattr(props, "name", "") or "").lower()
+    if any(
+        marker in dev_lower
+        for marker in ("890m", "880m", "8065s", "8060s", "8050s", "860m", "840m")
+    ):
+        return False
+    return True
 
 
 def _torch_get_device_inventory(device_indices: list[int]) -> list[Dict[str, Any]]:
@@ -1198,63 +1304,45 @@ def _torch_get_device_inventory(device_indices: list[int]) -> list[Dict[str, Any
     not be what pins that, so callers that need name and capacity but not live
     occupancy come here instead of _torch_get_per_device_info.
 
-    ``props.total_memory`` is the same number ``mem_get_info`` returns as its total
-    half everywhere except a ROCm APU (see _rocm_props_total_is_carve_out), so
-    totals are unchanged. ``used_gb`` is always None, the value this module already
-    uses for "telemetry unavailable".
+    ``props.total_memory`` is the same number ``mem_get_info`` returns as its
+    total half everywhere except a ROCm APU (see _rocm_props_total_is_carve_out)
+    and except the integrated member of a hybrid ROCm set, which keeps its
+    carve-out (see _rocm_hybrid_keeps_carve_out); both endpoints decide the
+    same way, so the rows /api/system merges stay self-consistent.
+    ``used_gb`` is always None, the value this module already uses for
+    "telemetry unavailable".
     """
     mod, _ = _torch_get_device_module()
     if mod is None:
         return []
 
-    # Fetch every device's props once: on a hybrid ROCm host (integrated + discrete
-    # visible together, e.g. a desktop Radeon dGPU beside a Ryzen iGPU) the
-    # integrated member's GTT/shared pool is NOT its real VRAM. The carve-out→GTT
+    # Fetch every device's props once, classify each once, and detect a hybrid
+    # ROCm set (integrated + discrete visible together, e.g. a desktop Radeon
+    # dGPU beside a Ryzen iGPU) up front. On a hybrid host the integrated
+    # member's GTT/shared pool is NOT its real VRAM: the carve-out→GTT
     # correction below exists so unified-only APU hosts budget their whole pool;
     # applying it to the iGPU of a hybrid host reports a system-RAM share as the
     # card's capacity (unslothai/unsloth#8942). Skip the correction for the
-    # integrated member of a hybrid set; every other case keeps today's behaviour.
-    props_list: list[tuple[int, int, Any]] = []
-    for ordinal, phys_idx in enumerate(device_indices):
-        try:
-            # torch ordinals are 0-based relative to CUDA_VISIBLE_DEVICES.
-            props_list.append((ordinal, phys_idx, mod.get_device_properties(ordinal)))
-        except Exception as e:
-            logger.debug("torch inventory probe failed for ordinal %d: %s", ordinal, e)
-            props_list.append((ordinal, phys_idx, None))
-
-    hybrid_rocm = False
-    if IS_ROCM and len(props_list) >= 2:
-        try:
-            from core.training.worker import _rocm_classify_unified_memory
-            unified_flags = [
-                props is not None and bool(_rocm_classify_unified_memory(props)[1])
-                for _, _, props in props_list
-            ]
-            hybrid_rocm = any(unified_flags) and not all(unified_flags)
-        except Exception as e:
-            logger.debug("ROCm hybrid-set classification failed: %s", e)
+    # integrated member of a hybrid set only; every other case keeps today's
+    # behaviour.
+    probed, hybrid_rocm = _rocm_probe_and_classify(mod, device_indices)
 
     devices = []
-    for ordinal, phys_idx, props in props_list:
-        if props is None:
-            continue
+    for ordinal, (phys_idx, props, classification) in probed.items():
         try:
             total_bytes = props.total_memory
-            if _rocm_props_total_is_carve_out(props) and hasattr(mod, "mem_get_info"):
-                integrated = False
-                try:
-                    from core.training.worker import _rocm_classify_unified_memory
-                    integrated = bool(_rocm_classify_unified_memory(props)[1])
-                except Exception:
-                    pass
-                if not (hybrid_rocm and integrated):
+            if _rocm_props_total_is_carve_out(props, classification) and hasattr(
+                mod, "mem_get_info"
+            ):
+                if not _rocm_hybrid_keeps_carve_out(props, classification, hybrid_rocm):
                     try:
                         total_bytes = mod.mem_get_info(ordinal)[1]
                     except Exception as e:
                         # Keep the carve-out rather than dropping the device: an
                         # understated total still beats no device at all.
-                        logger.debug("ROCm APU driver total failed for ordinal %d: %s", ordinal, e)
+                        logger.debug(
+                            "ROCm APU driver total failed for ordinal %d: %s", ordinal, e
+                        )
             devices.append(
                 {
                     "index": phys_idx,
@@ -2311,14 +2399,24 @@ def _reconcile_rocm_unified_memory(utilization: Dict[str, Any], device_indices: 
 
     amd-smi reports only the dedicated slice; torch sees the full GTT pool. When
     torch total > smi total, overwrite per-device VRAM fields with the real value.
+    On a hybrid ROCm host the integrated member keeps its carve-out here too
+    (mirrors _torch_get_device_inventory): both endpoints must decide the same
+    way, or /api/system rows contradict themselves (a device whose free exceeds
+    its total) and the reported capacity flips with amd-smi availability.
     """
     torch_devices = _torch_get_per_device_info(device_indices)
     if not torch_devices:
         return
+    probed, hybrid_rocm = _rocm_probe_and_classify(_torch_get_device_module()[0], device_indices)
+    keep_carve_out = {
+        probed[ordinal][0]
+        for ordinal in probed
+        if _rocm_hybrid_keeps_carve_out(probed[ordinal][1], probed[ordinal][2], hybrid_rocm)
+    }
     torch_by_index = {td["index"]: td for td in torch_devices}
     for dev in utilization.get("devices", []):
         td = torch_by_index.get(dev.get("index"))
-        if td is None:
+        if td is None or dev.get("index") in keep_carve_out:
             continue
         _apply_unified_memory_correction(dev, td)
 

--- a/studio/backend/utils/hardware/hardware.py
+++ b/studio/backend/utils/hardware/hardware.py
@@ -1184,7 +1184,6 @@ def _rocm_props_total_is_carve_out(
     if classification is None:
         try:
             from core.training.worker import _rocm_classify_unified_memory
-
             classification = _rocm_classify_unified_memory(props)
         except Exception as e:
             logger.debug("ROCm unified-memory classification failed: %s", e)
@@ -1230,7 +1229,6 @@ def _rocm_probe_and_classify(
         if IS_ROCM:
             try:
                 from core.training.worker import _rocm_classify_unified_memory
-
                 classification = _rocm_classify_unified_memory(props)
             except Exception as e:
                 logger.debug(
@@ -1251,9 +1249,7 @@ def _rocm_probe_and_classify(
         probed[ordinal] = (phys_idx, props, classification)
     hybrid_rocm = False
     if IS_ROCM and len(probed) >= 2:
-        unified_flags = [
-            cls is not None and cls[1] for _, _, cls in probed.values()
-        ]
+        unified_flags = [cls is not None and cls[1] for _, _, cls in probed.values()]
         hybrid_rocm = any(unified_flags) and not all(unified_flags)
         if hybrid_rocm:
             logger.debug(
@@ -1338,9 +1334,7 @@ def _torch_get_device_inventory(device_indices: list[int]) -> list[Dict[str, Any
                     except Exception as e:
                         # Keep the carve-out rather than dropping the device: an
                         # understated total still beats no device at all.
-                        logger.debug(
-                            "ROCm APU driver total failed for ordinal %d: %s", ordinal, e
-                        )
+                        logger.debug("ROCm APU driver total failed for ordinal %d: %s", ordinal, e)
             devices.append(
                 {
                     "index": phys_idx,

--- a/studio/backend/utils/hardware/hardware.py
+++ b/studio/backend/utils/hardware/hardware.py
@@ -1207,19 +1207,58 @@ def _torch_get_device_inventory(device_indices: list[int]) -> list[Dict[str, Any
     if mod is None:
         return []
 
-    devices = []
+    # Fetch every device's props once: on a hybrid ROCm host (integrated + discrete
+    # visible together, e.g. a desktop Radeon dGPU beside a Ryzen iGPU) the
+    # integrated member's GTT/shared pool is NOT its real VRAM. The carve-out→GTT
+    # correction below exists so unified-only APU hosts budget their whole pool;
+    # applying it to the iGPU of a hybrid host reports a system-RAM share as the
+    # card's capacity (unslothai/unsloth#8942). Skip the correction for the
+    # integrated member of a hybrid set; every other case keeps today's behaviour.
+    props_list: list[tuple[int, int, Any]] = []
     for ordinal, phys_idx in enumerate(device_indices):
         try:
             # torch ordinals are 0-based relative to CUDA_VISIBLE_DEVICES.
-            props = mod.get_device_properties(ordinal)
+            props_list.append((ordinal, phys_idx, mod.get_device_properties(ordinal)))
+        except Exception as e:
+            logger.debug("torch inventory probe failed for ordinal %d: %s", ordinal, e)
+            props_list.append((ordinal, phys_idx, None))
+
+    hybrid_rocm = False
+    if IS_ROCM and len(props_list) >= 2:
+        try:
+            from core.training.worker import _rocm_classify_unified_memory
+
+            unified_flags = [
+                props is not None and bool(_rocm_classify_unified_memory(props)[1])
+                for _, _, props in props_list
+            ]
+            hybrid_rocm = any(unified_flags) and not all(unified_flags)
+        except Exception as e:
+            logger.debug("ROCm hybrid-set classification failed: %s", e)
+
+    devices = []
+    for ordinal, phys_idx, props in props_list:
+        if props is None:
+            continue
+        try:
             total_bytes = props.total_memory
             if _rocm_props_total_is_carve_out(props) and hasattr(mod, "mem_get_info"):
+                integrated = False
                 try:
-                    total_bytes = mod.mem_get_info(ordinal)[1]
-                except Exception as e:
-                    # Keep the carve-out rather than dropping the device: an
-                    # understated total still beats no device at all.
-                    logger.debug("ROCm APU driver total failed for ordinal %d: %s", ordinal, e)
+                    from core.training.worker import _rocm_classify_unified_memory
+
+                    integrated = bool(_rocm_classify_unified_memory(props)[1])
+                except Exception:
+                    pass
+                if not (hybrid_rocm and integrated):
+                    try:
+                        total_bytes = mod.mem_get_info(ordinal)[1]
+                    except Exception as e:
+                        # Keep the carve-out rather than dropping the device: an
+                        # understated total still beats no device at all.
+                        logger.debug(
+                            "ROCm APU driver total failed for ordinal %d: %s", ordinal, e
+                        )
             devices.append(
                 {
                     "index": phys_idx,

--- a/studio/backend/utils/hardware/hardware.py
+++ b/studio/backend/utils/hardware/hardware.py
@@ -1227,7 +1227,6 @@ def _torch_get_device_inventory(device_indices: list[int]) -> list[Dict[str, Any
     if IS_ROCM and len(props_list) >= 2:
         try:
             from core.training.worker import _rocm_classify_unified_memory
-
             unified_flags = [
                 props is not None and bool(_rocm_classify_unified_memory(props)[1])
                 for _, _, props in props_list
@@ -1246,7 +1245,6 @@ def _torch_get_device_inventory(device_indices: list[int]) -> list[Dict[str, Any
                 integrated = False
                 try:
                     from core.training.worker import _rocm_classify_unified_memory
-
                     integrated = bool(_rocm_classify_unified_memory(props)[1])
                 except Exception:
                     pass
@@ -1256,9 +1254,7 @@ def _torch_get_device_inventory(device_indices: list[int]) -> list[Dict[str, Any
                     except Exception as e:
                         # Keep the carve-out rather than dropping the device: an
                         # understated total still beats no device at all.
-                        logger.debug(
-                            "ROCm APU driver total failed for ordinal %d: %s", ordinal, e
-                        )
+                        logger.debug("ROCm APU driver total failed for ordinal %d: %s", ordinal, e)
             devices.append(
                 {
                     "index": phys_idx,


### PR DESCRIPTION
Fixes #8942

## Problem

On hosts where an integrated Radeon and a discrete Radeon are both visible to ROCm (e.g. a Ryzen iGPU beside a desktop dGPU), `_torch_get_device_inventory` replaced the integrated part's **carve-out** total with the `mem_get_info` **GTT/shared pool**, so Studio's About page / hardware specs reported system RAM (e.g. 24 GB) as the iGPU's VRAM capacity.

## Root cause

The carve-out→GTT correction exists so unified-only APU hosts (Strix Halo etc.) budget their whole usable pool. It was applied unconditionally to every carve-out device, including the integrated member of a hybrid set, where the GTT pool is not the card's real VRAM.

## Fix

- Probe every visible device's props once up front, then detect a **hybrid ROCm set** (`IS_ROCM` + ≥2 devices + mixed unified/discrete classification via the existing `_rocm_classify_unified_memory`).
- Only in that case, keep the integrated member's dedicated carve-out total instead of substituting the GTT pool.
- APU-only hosts and all-discrete sets keep today's behaviour byte-for-byte, pinned by 4 new tests (hybrid dGPU+iGPU, iGPU-first ordinal, APU-only GTT, all-discrete untouched). 32 passed / 3 skipped in `test_system_poll_no_cuda_context.py`.

## Scope

Both memory-reporting endpoints now apply the same hybrid gate, so `/api/system` device rows stay self-consistent (used/free never exceed total):

- Inventory path: `_torch_get_device_inventory` (via `_rocm_props_total_is_carve_out` + `_rocm_hybrid_keeps_carve_out`)
- Occupancy path: `_apply_unified_memory_correction` → `_reconcile_rocm_unified_memory` now skips the GTT adoption for the hybrid integrated member, so the two endpoints agree on the same carve-out total

The shared-pool arches (Strix Point gfx1150/51/52, Radeon 8xxM/80xxS) are exempted from the carve-out skip, so a Strix Halo beside a discrete card keeps its GTT pool.

Not touched: `amd-smi` polling, llama.cpp backend, telemetry (`_torch_get_per_device_info`) — those keep GTT semantics on real APU machines.
