### PR TITLE
Studio: fix two intermittently failing tests

### DIFF
--- a/studio/frontend/tests/project-source-save.test.ts
+++ b/studio/frontend/tests/project-source-save.test.ts
@@ -50,6 +50,16 @@ function json(body: unknown, status = 200): Response {
   });
 }
 
+/** Answer a job poll only when it is *this* test's job. A save leaves its
+ * ingest watcher polling for as long as 300s, and node runs the next test
+ * immediately, so without this the watcher of a finished test is answered by
+ * the handler of the running one, and toasts and announces off the back of it. */
+function jobFor(jobId: string, input: string, body: unknown): Response {
+  return input.includes(`/jobs/${jobId}`)
+    ? json(body)
+    : json({ detail: `no such job: ${input}` }, 404);
+}
+
 test.beforeEach(() => {
   recordedToasts.length = 0;
   setAuthFetchHandler(null);
@@ -90,7 +100,7 @@ test("uploads the chat under its sanitised name and reports it once", async () =
 test("a quiet save stays silent so a pair can report the count itself", async () => {
   setAuthFetchHandler((input) =>
     input.includes("/jobs/")
-      ? json({ id: "j2", documentId: "d2", status: "completed" })
+      ? jobFor("j2", input, { id: "j2", documentId: "d2", status: "completed" })
       : json({ documentId: "d2", jobId: "j2", filename: "Chat.md" }),
   );
   assert.equal(
@@ -131,31 +141,48 @@ test("a quiet save still reports its own failure", async () => {
 
 test("an ingest that fails after the upload is not left silent", async () => {
   const seen = collectUpdates();
+  // A filename of its own, so a toast can be attributed to this save and not to
+  // some other test's watcher that happens to have uploaded a "Chat.md" too.
   setAuthFetchHandler((input) => {
     if (input.includes("/jobs/")) {
-      return json({
+      return jobFor("j4", input, {
         id: "j4",
         documentId: "d4",
         status: "failed",
         error: "Could not parse the document",
       });
     }
-    return json({ documentId: "d4", jobId: "j4", filename: "Chat.md" });
+    return json({ documentId: "d4", jobId: "j4", filename: "Unparsable.md" });
   });
-  await saveMarkdownAsProjectSource("p4", "# Chat\n", "Chat");
+  await saveMarkdownAsProjectSource("p4", "# Chat\n", "Unparsable");
+  // Wait on the announce, not on the toast: the watcher toasts and *then*
+  // announces, with no await between the two, so the announce is the last
+  // thing the failed ingest does. Polling for the toast and then asserting the
+  // count reads the count in the window between them, and fails on a runner
+  // slow enough to land a poll there.
+  const announcedTwice = await waitFor(() =>
+    seen.filter((id) => id === "p4").length >= 2 || undefined,
+  );
+  assert.ok(
+    announcedTwice,
+    `the failed ingest never re-announced p4, so a chip left "pending" never resolves; saw ${JSON.stringify(seen)}`,
+  );
   // The panel hides failed documents, so the success toast would otherwise be
   // the only thing the user ever sees about a source that never arrives.
-  const failure = await waitFor(() =>
-    recordedToasts.find((t) => t.message === "Couldn't index Chat.md"),
+  const failure = recordedToasts.find(
+    (t) => t.message === "Couldn't index Unparsable.md",
   );
   assert.equal(failure?.kind, "error");
   assert.equal(failure?.description, "Could not parse the document");
-  // And the panel is told again, so a chip left "pending" resolves.
+  // Told exactly twice: once for the upload, once for the ingest that failed.
   assert.equal(seen.filter((id) => id === "p4").length, 2);
 });
 
+/** Poll `read` until it answers, for well past the 2s ingest poll. Anything
+ * asserted on the strength of it must be something the code under test does
+ * *before* what is polled for, or the wait races it. */
 async function waitFor<T>(read: () => T | undefined): Promise<T | undefined> {
-  for (let attempt = 0; attempt < 100; attempt++) {
+  for (let attempt = 0; attempt < 300; attempt++) {
     const value = read();
     if (value !== undefined) return value;
     await new Promise((resolve) => setTimeout(resolve, 100));
@@ -179,7 +206,11 @@ test("a mounted sources list refetches when a chat is saved into its project", a
   });
   setAuthFetchHandler((input) => {
     if (input.includes("/jobs/")) {
-      return json({ id: "j5", documentId: "d5", status: "completed" });
+      return jobFor("j5", input, {
+        id: "j5",
+        documentId: "d5",
+        status: "completed",
+      });
     }
     // The upload is what puts the row on the server.
     rows = ["Chat.md"];


### PR DESCRIPTION
Two tests were failing intermittently in CI. Both turned out to be faults in the tests themselves, not in the code they cover, so the implementations are unchanged here.

### Orphan cleanup test keyed on an invented pid

`test_orphan_cleanup_kills_under_real_root` never spawns a process. It invents a pid as `os.getpid() + 888`, but `_kill_orphaned_servers` gates every candidate on `_pid_parent_is_alive`, which asks the real OS. When something already occupies that pid with a live parent, the candidate is skipped and the test fails with `assert 0 == 1`. PIDs are handed out sequentially, so the allocator passes that number shortly after pytest starts, which is what makes this reachable rather than theoretical.

Reproduced by forking pytest, squatting `pytest_pid + 888` with a live process, then releasing pytest: the unmodified test fails with exactly the CI message.

The gate was added in #8498 without updating this test, so the flake has been latent since then.

The `[procfs]` parametrization was also passing for the wrong reason: its `os.kill` stub raised `ProcessLookupError` for every pid except the fake one, and `psutil.pid_exists` is `os.kill(pid, 0)` on POSIX, so every parent read as dead. That is why only `[psutil]` ever failed.

The tests now stub `_pid_parent_is_alive` for the invented pid only and delegate every other pid to the real implementation, and the procfs stub delegates too. A new test covers the ownership gate with a process the test genuinely owns, so nothing is lost by stubbing it elsewhere.

### Project source test raced its own announce

`saveMarkdownAsProjectSource` fires `watchIngestion` without awaiting it, and that watcher polls for up to 300 seconds. Watchers from earlier tests therefore outlive them and keep calling the shared fetch stub, which by then belongs to whichever test is running now. Since the stub answered any `/jobs/` URL and the uploads shared a filename, a stale watcher emitted a toast byte-identical to the one the test was waiting on, under a different project id.

The test waited on the toast and then read the announce count without polling, so a tick landing between a foreign toast and its own announce saw 1 instead of 2. The 2014 ms duration in the CI log is a stale 2 s watcher.

Each job handler now answers only its own job id and 404s anything else, so a stale watcher dies quietly instead of borrowing the running test's answers. The save under test gets its own filename, and the test polls on the announce, which the watcher does last, then asserts the toast synchronously.

Verified with a gap sweep: with a 150 ms delay inserted the old test fails 10 of 10 and the new one passes 10 of 10.

### Import resolution

`image-input-support.ts` imported `./mmproj-fallback` without an extension. CI runs Node 22 and is unaffected, but under Node 24 the package is ESM and the specifier does not resolve, which hides four tests from anyone running the suite locally. Test-reachable modules elsewhere already use the explicit `.ts` form.

### Checks

Both fixes were mutation tested to confirm they still prove what they did before: removing the parent gate from the implementation fails the new orphan test, and removing `announceProjectSourcesUpdated` fails the new source test.

- `tests/test_local_llama_cpp_link.py`: 10 passed, plus 50 sequential runs idle and 40 under CPU load with no failures
- neighbouring process-management suites: 329 passed, 4 skipped
- frontend: 3760 passed, 0 failed; `npm run typecheck` clean
