### PR TITLE
Print what the server said when an inference smoke request 4xx's

### DIFF
--- a/.github/workflows/studio-inference-smoke.yml
+++ b/.github/workflows/studio-inference-smoke.yml
@@ -468,7 +468,19 @@ jobs:
                       t = timeout if attempt == 0 else min(timeout, 300)
                       with urllib.request.urlopen(req, timeout = t) as resp:
                           return resp.status, json.loads(resp.read().decode())
-                  except urllib.error.HTTPError:
+                  except urllib.error.HTTPError as exc:
+                      # Say what the server said before the body is discarded. A
+                      # bare HTTPError prints only "HTTP Error 400: Bad Request",
+                      # which is what turned the #8883 Mac GGUF outage into three
+                      # red main runs whose cause had to be found by hand.
+                      try:
+                          detail = exc.read().decode("utf-8", "replace")
+                      except Exception as read_exc:
+                          detail = f"<body unreadable: {read_exc!r}>"
+                      print(
+                          f"[http] {path} -> {exc.code} {exc.reason}: {detail[:4000]}",
+                          flush = True,
+                      )
                       raise
                   except (TimeoutError, ConnectionError, urllib.error.URLError) as exc:
                       if attempt == attempts - 1:
@@ -543,7 +555,19 @@ jobs:
                                   if delta.get("content"):
                                       parts.append(delta["content"])
                       return "".join(parts), events
-                  except urllib.error.HTTPError:
+                  except urllib.error.HTTPError as exc:
+                      # Say what the server said before the body is discarded. A
+                      # bare HTTPError prints only "HTTP Error 400: Bad Request",
+                      # which is what turned the #8883 Mac GGUF outage into three
+                      # red main runs whose cause had to be found by hand.
+                      try:
+                          detail = exc.read().decode("utf-8", "replace")
+                      except Exception as read_exc:
+                          detail = f"<body unreadable: {read_exc!r}>"
+                      print(
+                          f"[http] {path} -> {exc.code} {exc.reason}: {detail[:4000]}",
+                          flush = True,
+                      )
                       raise
                   except (TimeoutError, ConnectionError, urllib.error.URLError) as exc:
                       # A stall after the tool already produced its result is
@@ -1029,7 +1053,19 @@ jobs:
                       t = timeout if attempt == 0 else min(timeout, 300)
                       with urllib.request.urlopen(req, timeout = t) as resp:
                           return resp.status, json.loads(resp.read().decode())
-                  except urllib.error.HTTPError:
+                  except urllib.error.HTTPError as exc:
+                      # Say what the server said before the body is discarded. A
+                      # bare HTTPError prints only "HTTP Error 400: Bad Request",
+                      # which is what turned the #8883 Mac GGUF outage into three
+                      # red main runs whose cause had to be found by hand.
+                      try:
+                          detail = exc.read().decode("utf-8", "replace")
+                      except Exception as read_exc:
+                          detail = f"<body unreadable: {read_exc!r}>"
+                      print(
+                          f"[http] {path} -> {exc.code} {exc.reason}: {detail[:4000]}",
+                          flush = True,
+                      )
                       raise
                   except (TimeoutError, ConnectionError, urllib.error.URLError) as exc:
                       if attempt == attempts - 1:

--- a/.github/workflows/studio-mac-ui-smoke.yml
+++ b/.github/workflows/studio-mac-ui-smoke.yml
@@ -902,7 +902,19 @@ jobs:
                       t = timeout if attempt == 0 else min(timeout, 300)
                       with urllib.request.urlopen(req, timeout = t) as resp:
                           return resp.status, json.loads(resp.read().decode())
-                  except urllib.error.HTTPError:
+                  except urllib.error.HTTPError as exc:
+                      # Say what the server said before the body is discarded. A
+                      # bare HTTPError prints only "HTTP Error 400: Bad Request",
+                      # which is what turned the #8883 Mac GGUF outage into three
+                      # red main runs whose cause had to be found by hand.
+                      try:
+                          detail = exc.read().decode("utf-8", "replace")
+                      except Exception as read_exc:
+                          detail = f"<body unreadable: {read_exc!r}>"
+                      print(
+                          f"[http] {path} -> {exc.code} {exc.reason}: {detail[:4000]}",
+                          flush = True,
+                      )
                       raise
                   except (TimeoutError, ConnectionError, urllib.error.URLError) as exc:
                       if attempt == attempts - 1:
@@ -958,7 +970,19 @@ jobs:
                                   if delta.get("content"):
                                       parts.append(delta["content"])
                       return "".join(parts)
-                  except urllib.error.HTTPError:
+                  except urllib.error.HTTPError as exc:
+                      # Say what the server said before the body is discarded. A
+                      # bare HTTPError prints only "HTTP Error 400: Bad Request",
+                      # which is what turned the #8883 Mac GGUF outage into three
+                      # red main runs whose cause had to be found by hand.
+                      try:
+                          detail = exc.read().decode("utf-8", "replace")
+                      except Exception as read_exc:
+                          detail = f"<body unreadable: {read_exc!r}>"
+                      print(
+                          f"[http] {path} -> {exc.code} {exc.reason}: {detail[:4000]}",
+                          flush = True,
+                      )
                       raise
                   except (TimeoutError, ConnectionError, urllib.error.URLError) as exc:
                       # Text already streamed is a valid signal -- keep it
@@ -1342,7 +1366,19 @@ jobs:
                       t = timeout if attempt == 0 else min(timeout, 300)
                       with urllib.request.urlopen(req, timeout = t) as resp:
                           return resp.status, json.loads(resp.read().decode())
-                  except urllib.error.HTTPError:
+                  except urllib.error.HTTPError as exc:
+                      # Say what the server said before the body is discarded. A
+                      # bare HTTPError prints only "HTTP Error 400: Bad Request",
+                      # which is what turned the #8883 Mac GGUF outage into three
+                      # red main runs whose cause had to be found by hand.
+                      try:
+                          detail = exc.read().decode("utf-8", "replace")
+                      except Exception as read_exc:
+                          detail = f"<body unreadable: {read_exc!r}>"
+                      print(
+                          f"[http] {path} -> {exc.code} {exc.reason}: {detail[:4000]}",
+                          flush = True,
+                      )
                       raise
                   except (TimeoutError, ConnectionError, urllib.error.URLError) as exc:
                       if attempt == attempts - 1:

--- a/.github/workflows/studio-windows-inference-smoke.yml
+++ b/.github/workflows/studio-windows-inference-smoke.yml
@@ -679,7 +679,19 @@ jobs:
                       t = timeout if attempt == 0 else min(timeout, 300)
                       with urllib.request.urlopen(req, timeout = t) as resp:
                           return resp.status, json.loads(resp.read().decode())
-                  except urllib.error.HTTPError:
+                  except urllib.error.HTTPError as exc:
+                      # Say what the server said before the body is discarded. A
+                      # bare HTTPError prints only "HTTP Error 400: Bad Request",
+                      # which is what turned the #8883 Mac GGUF outage into three
+                      # red main runs whose cause had to be found by hand.
+                      try:
+                          detail = exc.read().decode("utf-8", "replace")
+                      except Exception as read_exc:
+                          detail = f"<body unreadable: {read_exc!r}>"
+                      print(
+                          f"[http] {path} -> {exc.code} {exc.reason}: {detail[:4000]}",
+                          flush = True,
+                      )
                       raise
                   except (TimeoutError, ConnectionError, urllib.error.URLError) as exc:
                       if attempt == attempts - 1:
@@ -735,7 +747,19 @@ jobs:
                                   if delta.get("content"):
                                       parts.append(delta["content"])
                       return "".join(parts)
-                  except urllib.error.HTTPError:
+                  except urllib.error.HTTPError as exc:
+                      # Say what the server said before the body is discarded. A
+                      # bare HTTPError prints only "HTTP Error 400: Bad Request",
+                      # which is what turned the #8883 Mac GGUF outage into three
+                      # red main runs whose cause had to be found by hand.
+                      try:
+                          detail = exc.read().decode("utf-8", "replace")
+                      except Exception as read_exc:
+                          detail = f"<body unreadable: {read_exc!r}>"
+                      print(
+                          f"[http] {path} -> {exc.code} {exc.reason}: {detail[:4000]}",
+                          flush = True,
+                      )
                       raise
                   except (TimeoutError, ConnectionError, urllib.error.URLError) as exc:
                       # Text already streamed is a valid signal -- keep it
@@ -1121,7 +1145,19 @@ jobs:
                       t = timeout if attempt == 0 else min(timeout, 300)
                       with urllib.request.urlopen(req, timeout = t) as resp:
                           return resp.status, json.loads(resp.read().decode())
-                  except urllib.error.HTTPError:
+                  except urllib.error.HTTPError as exc:
+                      # Say what the server said before the body is discarded. A
+                      # bare HTTPError prints only "HTTP Error 400: Bad Request",
+                      # which is what turned the #8883 Mac GGUF outage into three
+                      # red main runs whose cause had to be found by hand.
+                      try:
+                          detail = exc.read().decode("utf-8", "replace")
+                      except Exception as read_exc:
+                          detail = f"<body unreadable: {read_exc!r}>"
+                      print(
+                          f"[http] {path} -> {exc.code} {exc.reason}: {detail[:4000]}",
+                          flush = True,
+                      )
                       raise
                   except (TimeoutError, ConnectionError, urllib.error.URLError) as exc:
                       if attempt == attempts - 1:

--- a/.github/workflows/workflow-trigger-lint.yml
+++ b/.github/workflows/workflow-trigger-lint.yml
@@ -120,6 +120,7 @@ jobs:
             tests/studio/test_frontend_dep_removal.py \
             tests/studio/test_gguf_smoke_phases_stay_independent.py \
             tests/studio/test_indicator_browsers_run_in_parallel.py \
+            tests/studio/test_inference_smoke_http_diagnostics.py \
             tests/studio/test_install_phase_timing.py \
             tests/studio/test_mac_bundled_job_phases.py \
             tests/studio/test_mac_host_offload_optin.py \

--- a/tests/studio/test_inference_smoke_http_diagnostics.py
+++ b/tests/studio/test_inference_smoke_http_diagnostics.py
@@ -189,7 +189,7 @@ def test_an_http_error_reports_the_response_body(name: str) -> None:
                 # it, and the status code alongside it names which request.
                 printed = "\n".join(ast.dump(call) for call in prints)
                 assert "code" in printed, (
-                    f"{name}: {helper.name}() prints on HTTPError without the " f"status code"
+                    f"{name}: {helper.name}() prints on HTTPError without the status code"
                 )
 
                 # A read can raise (a truncated or already-consumed body), and

--- a/tests/studio/test_inference_smoke_http_diagnostics.py
+++ b/tests/studio/test_inference_smoke_http_diagnostics.py
@@ -68,10 +68,7 @@ def _python_blocks(path: Path) -> list[tuple[int, str]]:
 
 def _handler_reraises_only(handler: ast.ExceptHandler) -> bool:
     """A handler whose entire body is `raise`, i.e. one that adds nothing."""
-    return all(
-        isinstance(node, ast.Raise) and node.exc is None
-        for node in handler.body
-    )
+    return all(isinstance(node, ast.Raise) and node.exc is None for node in handler.body)
 
 
 def _catches_http_error(handler: ast.ExceptHandler) -> bool:
@@ -79,10 +76,7 @@ def _catches_http_error(handler: ast.ExceptHandler) -> bool:
     if types is None:
         return False
     candidates = types.elts if isinstance(types, ast.Tuple) else [types]
-    return any(
-        isinstance(node, ast.Attribute) and node.attr == "HTTPError"
-        for node in candidates
-    )
+    return any(isinstance(node, ast.Attribute) and node.attr == "HTTPError" for node in candidates)
 
 
 def _calls(tree: ast.AST) -> list[ast.Call]:
@@ -128,11 +122,7 @@ def test_every_request_helper_has_an_http_error_handler(name: str) -> None:
     whole timeout budget re-asking a question the server already refused.
     """
     path = WORKFLOWS / name
-    helpers = [
-        helper
-        for _, source in _python_blocks(path)
-        for helper in _request_helpers(source)
-    ]
+    helpers = [helper for _, source in _python_blocks(path) for helper in _request_helpers(source)]
     assert helpers, f"{name}: no request helper found"
     for helper in helpers:
         handlers = [
@@ -199,16 +189,12 @@ def test_an_http_error_reports_the_response_body(name: str) -> None:
                 # it, and the status code alongside it names which request.
                 printed = "\n".join(ast.dump(call) for call in prints)
                 assert "code" in printed, (
-                    f"{name}: {helper.name}() prints on HTTPError without the "
-                    f"status code"
+                    f"{name}: {helper.name}() prints on HTTPError without the " f"status code"
                 )
 
                 # A read can raise (a truncated or already-consumed body), and
                 # that must not replace the real HTTPError with a confusing one.
-                guarded = any(
-                    isinstance(node, ast.Try)
-                    for node in ast.walk(handler)
-                )
+                guarded = any(isinstance(node, ast.Try) for node in ast.walk(handler))
                 assert guarded, (
                     f"{name}: {helper.name}() reads the HTTPError body "
                     f"unguarded, so a failed read masks the real status"
@@ -216,9 +202,7 @@ def test_an_http_error_reports_the_response_body(name: str) -> None:
 
                 # And the original error must still propagate: reporting is not
                 # the same as tolerating.
-                assert any(
-                    isinstance(node, ast.Raise) for node in handler.body
-                ), (
+                assert any(isinstance(node, ast.Raise) for node in handler.body), (
                     f"{name}: {helper.name}() reports the HTTPError but does "
                     f"not re-raise it, so a 4xx would pass as success"
                 )

--- a/tests/studio/test_inference_smoke_http_diagnostics.py
+++ b/tests/studio/test_inference_smoke_http_diagnostics.py
@@ -1,0 +1,224 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+"""
+The inference smoke probes must say what the server said when a request 4xx's.
+
+#8883 broke the Mac GGUF job's `/v1/chat/completions` call and stayed broken for
+three main runs. The only thing CI printed was:
+
+    urllib.error.HTTPError: HTTP Error 400: Bad Request
+
+The server's own explanation went out with the unread response body, so the cause
+had to be reconstructed by hand from the workflow source. These probes are the
+only place a real llama-server answers a real request, so their diagnostics are
+the whole value of a red run; a status line with no body is a red run that costs
+an investigation instead of paying for one.
+
+The tests parse the Python actually embedded in the workflows rather than
+matching text, so a rewrite that keeps the behaviour keeps passing and a rewrite
+that drops it fails.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+import textwrap
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOWS = REPO_ROOT / ".github" / "workflows"
+
+SMOKE_WORKFLOWS = (
+    "studio-inference-smoke.yml",
+    "studio-mac-ui-smoke.yml",
+    "studio-windows-inference-smoke.yml",
+)
+
+_HEREDOC_START = re.compile(r"^(\s*)python3? - <<'PY'\s*$")
+
+
+def _python_blocks(path: Path) -> list[tuple[int, str]]:
+    """Every `python - <<'PY' ... PY` block, as (1-based start line, source)."""
+    blocks: list[tuple[int, str]] = []
+    lines = path.read_text(encoding = "utf-8").splitlines()
+    i = 0
+    while i < len(lines):
+        match = _HEREDOC_START.match(lines[i])
+        if match is None:
+            i += 1
+            continue
+        indent = match.group(1)
+        start = i + 1
+        body: list[str] = []
+        i += 1
+        while i < len(lines) and lines[i].strip() != "PY":
+            body.append(lines[i])
+            i += 1
+        assert i < len(lines), f"{path.name}:{start} heredoc never closed"
+        blocks.append((start + 1, textwrap.dedent("\n".join(body)) + "\n"))
+        i += 1
+    # The indent is stripped by textwrap, so a block whose lines are indented
+    # inconsistently would fail to parse below rather than pass silently.
+    del indent
+    return blocks
+
+
+def _handler_reraises_only(handler: ast.ExceptHandler) -> bool:
+    """A handler whose entire body is `raise`, i.e. one that adds nothing."""
+    return all(
+        isinstance(node, ast.Raise) and node.exc is None
+        for node in handler.body
+    )
+
+
+def _catches_http_error(handler: ast.ExceptHandler) -> bool:
+    types = handler.type
+    if types is None:
+        return False
+    candidates = types.elts if isinstance(types, ast.Tuple) else [types]
+    return any(
+        isinstance(node, ast.Attribute) and node.attr == "HTTPError"
+        for node in candidates
+    )
+
+
+def _calls(tree: ast.AST) -> list[ast.Call]:
+    return [node for node in ast.walk(tree) if isinstance(node, ast.Call)]
+
+
+def _sends_a_request(func: ast.FunctionDef) -> bool:
+    """A helper that actually opens the URL, as opposed to one of its callers."""
+    for call in _calls(func):
+        target = call.func
+        if isinstance(target, ast.Attribute) and target.attr == "urlopen":
+            return True
+    return False
+
+
+def _request_helpers(source: str) -> list[ast.FunctionDef]:
+    tree = ast.parse(source)
+    return [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef) and _sends_a_request(node)
+    ]
+
+
+@pytest.mark.parametrize("name", SMOKE_WORKFLOWS)
+def test_every_embedded_probe_is_valid_python(name: str) -> None:
+    """The heredocs are shell text to YAML, so nothing else checks they parse."""
+    path = WORKFLOWS / name
+    blocks = _python_blocks(path)
+    assert blocks, f"{name}: no embedded python probe found"
+    for line, source in blocks:
+        try:
+            ast.parse(source)
+        except SyntaxError as exc:
+            pytest.fail(f"{name}:{line} embedded python does not parse: {exc}")
+
+
+@pytest.mark.parametrize("name", SMOKE_WORKFLOWS)
+def test_every_request_helper_has_an_http_error_handler(name: str) -> None:
+    """
+    Without a dedicated handler an HTTPError falls into the URLError branch it
+    subclasses and gets retried as a transport stall, which spends the job's
+    whole timeout budget re-asking a question the server already refused.
+    """
+    path = WORKFLOWS / name
+    helpers = [
+        helper
+        for _, source in _python_blocks(path)
+        for helper in _request_helpers(source)
+    ]
+    assert helpers, f"{name}: no request helper found"
+    for helper in helpers:
+        handlers = [
+            node
+            for node in ast.walk(helper)
+            if isinstance(node, ast.ExceptHandler) and _catches_http_error(node)
+        ]
+        assert handlers, (
+            f"{name}: {helper.name}() opens a URL but does not handle "
+            f"urllib.error.HTTPError, so a 4xx is retried as a transport stall"
+        )
+
+
+@pytest.mark.parametrize("name", SMOKE_WORKFLOWS)
+def test_an_http_error_reports_the_response_body(name: str) -> None:
+    """
+    The regression this guards: a handler that is a bare `raise`. CI then prints
+    the status line and nothing else, and the server's explanation is lost with
+    the unread body.
+    """
+    path = WORKFLOWS / name
+    for _, source in _python_blocks(path):
+        for helper in _request_helpers(source):
+            for handler in ast.walk(helper):
+                if not isinstance(handler, ast.ExceptHandler):
+                    continue
+                if not _catches_http_error(handler):
+                    continue
+
+                assert not _handler_reraises_only(handler), (
+                    f"{name}: {helper.name}() re-raises HTTPError without "
+                    f"reporting the response body, so a failure prints only "
+                    f"'HTTP Error 400: Bad Request'"
+                )
+                assert handler.name, (
+                    f"{name}: {helper.name}() does not bind the HTTPError, so "
+                    f"it cannot report the body"
+                )
+
+                bound = handler.name
+                reads = any(
+                    isinstance(call.func, ast.Attribute)
+                    and call.func.attr == "read"
+                    and isinstance(call.func.value, ast.Name)
+                    and call.func.value.id == bound
+                    for call in _calls(handler)
+                )
+                assert reads, (
+                    f"{name}: {helper.name}() does not call {bound}.read(), so "
+                    f"the server's explanation is discarded"
+                )
+
+                prints = [
+                    call
+                    for call in _calls(handler)
+                    if isinstance(call.func, ast.Name) and call.func.id == "print"
+                ]
+                assert prints, (
+                    f"{name}: {helper.name}() reads the body but never prints "
+                    f"it, so the diagnosis never reaches the CI log"
+                )
+
+                # Reading the body is only useful if the printed text carries
+                # it, and the status code alongside it names which request.
+                printed = "\n".join(ast.dump(call) for call in prints)
+                assert "code" in printed, (
+                    f"{name}: {helper.name}() prints on HTTPError without the "
+                    f"status code"
+                )
+
+                # A read can raise (a truncated or already-consumed body), and
+                # that must not replace the real HTTPError with a confusing one.
+                guarded = any(
+                    isinstance(node, ast.Try)
+                    for node in ast.walk(handler)
+                )
+                assert guarded, (
+                    f"{name}: {helper.name}() reads the HTTPError body "
+                    f"unguarded, so a failed read masks the real status"
+                )
+
+                # And the original error must still propagate: reporting is not
+                # the same as tolerating.
+                assert any(
+                    isinstance(node, ast.Raise) for node in handler.body
+                ), (
+                    f"{name}: {helper.name}() reports the HTTPError but does "
+                    f"not re-raise it, so a 4xx would pass as success"
+                )


### PR DESCRIPTION
The Mac GGUF probe was red on three consecutive main runs after #8883. Everything CI printed about it was this:

```
urllib.error.HTTPError: HTTP Error 400: Bad Request
```

llama-server's own explanation of the 400 is in the response body, and the body went out unread. Finding the cause meant pulling the raw job log, counting lines into a heredoc to work out which call had failed, and reasoning about the request from the workflow source. #9155 fixed the regression itself; this is so the next one does not cost the same dig.

These probes are the only place in CI where a real llama-server answers a real request, so their diagnostics are most of the value of a red run.

## The change

The `HTTPError` branch of every request helper in the three inference smoke workflows (nine sites, identical) now prints the status, the reason and the body before re-raising:

```python
except urllib.error.HTTPError as exc:
    try:
        detail = exc.read().decode("utf-8", "replace")
    except Exception as read_exc:
        detail = f"<body unreadable: {read_exc!r}>"
    print(
        f"[http] {path} -> {exc.code} {exc.reason}: {detail[:4000]}",
        flush = True,
    )
    raise
```

The read is guarded because a truncated or already-consumed body must not replace the real status with a confusing one, and the original error still propagates: reporting is not tolerating.

A tenth `except urllib.error.HTTPError` exists, in the tool-probe seed loop of `studio-inference-smoke.yml`. It is a caller, not a helper. `post_sse` has already printed the body by the time it re-raises there, so it is left alone.

## The guard

`tests/studio/test_inference_smoke_http_diagnostics.py` extracts the `python - <<'PY'` blocks and parses them with `ast`, so it checks behaviour rather than text and a rewrite that keeps the reporting keeps passing. Three properties:

- every embedded probe parses as Python. Nothing else in the repo checks this: the heredocs are shell text inside YAML, invisible to actionlint, ruff and every YAML linter.
- every helper that calls `urlopen` handles `HTTPError` separately. Without that it falls into the `URLError` branch it subclasses and gets retried as a transport stall, spending the job's timeout budget re-asking a question the server already refused.
- that handler binds the error, reads the body under a `try`, prints it with the status code, and re-raises.

Seven mutations confirmed red: revert the change, drop the re-raise, drop the print, drop the status code from the print, unguard the read, delete the handler, break the embedded syntax.

Listed in `workflow-trigger-lint` because it reads workflow files, so the edit that breaks it is workflow-only and no paths filter would collect it. Confirmed by removing the line and watching `test_workflow_guards_run_unfiltered` name the module.

## Verification

`pytest tests/studio/ -q -n 16`: 71 failures, all of them the two chat auto-load modules that are red on main today and are fixed in #9189. No module touched by this branch fails.
