### PR TITLE
Allow multiple images in the Image Generator's Edit workflow

### DIFF
--- a/studio/backend/core/inference/diffusion.py
+++ b/studio/backend/core/inference/diffusion.py
@@ -5485,7 +5485,8 @@ class DiffusionBackend:
                     if reference_images:
                         raise ValueError("reference_images require an input image (init_image).")
                 if reference_images and not (
-                    getattr(state.family, "reference", False) or getattr(state.family, "edit", False)
+                    getattr(state.family, "reference", False)
+                    or getattr(state.family, "edit", False)
                 ):
                     raise ValueError(
                         f"Reference images are not supported for the '{state.family.name}' "

--- a/studio/backend/core/inference/diffusion.py
+++ b/studio/backend/core/inference/diffusion.py
@@ -5406,7 +5406,8 @@ class DiffusionBackend:
         strength: Optional[float] = None,
         # Upscale (hires fix): factor > 1 with an init image enlarges then re-denoises at low strength.
         upscale: Optional[float] = None,
-        # Reference (FLUX.2): additional reference images beyond init_image (a list). Ignored elsewhere.
+        # Additional images beyond init_image (a list): FLUX.2 reference conditioning, or extra
+        # source images for an edit-family model (e.g. Qwen-Image-Edit-Plus, FLUX Kontext). Ignored elsewhere.
         reference_images: Optional[list[str]] = None,
         # LoRA (id, weight) pairs; loaded non-fused and activated for this generation. None/empty clears.
         loras: Optional[list[tuple[str, float]]] = None,
@@ -5483,7 +5484,9 @@ class DiffusionBackend:
                         raise ValueError("upscale requires an input image (init_image).")
                     if reference_images:
                         raise ValueError("reference_images require an input image (init_image).")
-                if reference_images and not getattr(state.family, "reference", False):
+                if reference_images and not (
+                    getattr(state.family, "reference", False) or getattr(state.family, "edit", False)
+                ):
                     raise ValueError(
                         f"Reference images are not supported for the '{state.family.name}' "
                         "model family."
@@ -5502,6 +5505,10 @@ class DiffusionBackend:
                         )
                     workflow = "edit"
                     init_pil = decode_b64_image(init_image, mode = "RGB")
+                    # Additional edit-reference images (e.g. Qwen-Image-Edit-Plus, FLUX Kontext multi-image); capped to bound VRAM.
+                    ref_extra = [
+                        decode_b64_image(x, mode = "RGB") for x in (reference_images or [])[:3]
+                    ]
                 elif mask_image is not None and init_image is not None:
                     workflow = "inpaint"
                     pipe = self._workflow_pipe(state, state.family.inpaint_pipeline_class, workflow)

--- a/studio/backend/core/inference/diffusion.py
+++ b/studio/backend/core/inference/diffusion.py
@@ -5506,10 +5506,19 @@ class DiffusionBackend:
                         )
                     workflow = "edit"
                     init_pil = decode_b64_image(init_image, mode = "RGB")
-                    # Additional edit-reference images (e.g. Qwen-Image-Edit-Plus, FLUX Kontext multi-image); capped to bound VRAM.
-                    ref_extra = [
-                        decode_b64_image(x, mode = "RGB") for x in (reference_images or [])[:3]
-                    ]
+                    # Additional edit-reference images (e.g. Qwen-Image-Edit-Plus): capped to bound VRAM.
+                    # Only for families whose pipeline treats a list as multiple conditioning sources -
+                    # FluxKontextPipeline instead treats `image: list[...]` as an image batch, so extra
+                    # images there would silently misbehave rather than combine into one edit.
+                    if reference_images and not getattr(state.family, "edit_multi_image", False):
+                        raise ValueError(
+                            f"{state.family.name} does not support multiple reference_images "
+                            "for edits; provide a single init_image."
+                        )
+                    if getattr(state.family, "edit_multi_image", False):
+                        ref_extra = [
+                            decode_b64_image(x, mode = "RGB") for x in (reference_images or [])[:3]
+                        ]
                 elif mask_image is not None and init_image is not None:
                     workflow = "inpaint"
                     pipe = self._workflow_pipe(state, state.family.inpaint_pipeline_class, workflow)

--- a/studio/backend/core/inference/diffusion_families.py
+++ b/studio/backend/core/inference/diffusion_families.py
@@ -54,6 +54,10 @@ class DiffusionFamily:
     # True for instruction-editing families (Qwen-Image-Edit / FLUX Kontext): the pipeline IS the edit pipeline (image +
     # instruction, no plain text-to-image). ``base_repo`` supplies the VAE / text-encoder / processor / scheduler.
     edit: bool = False
+    # True for edit families whose pipeline treats `image: list[...]` as multiple conditioning sources
+    # (QwenImageEditPlusPipeline). False (default) for families like FluxKontextPipeline, where a list is
+    # instead treated as an image batch, so extra reference_images must be rejected rather than combined.
+    edit_multi_image: bool = False
     # True for families whose text-to-image pipeline ALSO accepts reference image(s) (FLUX.2 ``image``): no ``strength``, size from width/height.
     reference: bool = False
     # Extra lowercased substrings (besides ``name``) that map a repo id here.
@@ -241,6 +245,7 @@ _FAMILIES: tuple[DiffusionFamily, ...] = (
             "qwenimageedit",
         ),
         edit = True,
+        edit_multi_image = True,
     ),
     DiffusionFamily(
         name = "qwen-image",

--- a/studio/backend/models/inference.py
+++ b/studio/backend/models/inference.py
@@ -3120,8 +3120,9 @@ class DiffusionGenerateRequest(BaseModel):
     reference_images: Optional[list[str]] = Field(
         None,
         max_length = 3,
-        description = "Additional reference images (base64/data-URL) for the FLUX.2 reference "
-        "workflow, combined with init_image. Up to 3; ignored by other workflows.",
+        description = "Additional images (base64/data-URL) combined with init_image: for the "
+        "FLUX.2 reference workflow, or extra source images for an edit-family model "
+        "(e.g. Qwen-Image-Edit-Plus, FLUX Kontext). Up to 3; ignored by other workflows.",
     )
     loras: Optional[list[LoraSpec]] = Field(
         None,

--- a/studio/backend/tests/test_diffusion_backend.py
+++ b/studio/backend/tests/test_diffusion_backend.py
@@ -1577,6 +1577,52 @@ def test_edit_family_uses_own_pipeline_and_requires_image(fake_runtime, tmp_path
         backend.generate(prompt = "make it night", steps = 8)
 
 
+def test_edit_family_supports_multiple_images(fake_runtime, tmp_path):
+    """An instruction-editing family accepts extra source images via ``reference_images``
+    (e.g. Qwen-Image-Edit-Plus, FLUX Kontext multi-image editing) and passes the primary
+    image plus every extra as a list to the pipeline's ``image`` kwarg."""
+    (tmp_path / "model.gguf").write_bytes(b"x")
+    backend = DiffusionBackend()
+    backend.load_pipeline(
+        str(tmp_path),
+        gguf_filename = "model.gguf",
+        base_repo = "Qwen/Qwen-Image-Edit-2511",
+        family_override = "qwen-image-edit",
+    )
+    loaded_pipe = backend._state.pipe
+
+    backend.generate(
+        prompt = "combine these into one scene",
+        steps = 8,
+        guidance = 4.0,
+        seed = 1,
+        init_image = _tiny_png_b64(),
+        reference_images = [_tiny_png_b64(), _tiny_png_b64()],
+    )
+    img_arg = loaded_pipe.last_kwargs["image"]
+    assert isinstance(img_arg, list) and len(img_arg) == 3  # primary + 2 extras
+
+    # More than 3 extras is silently capped, same as the reference workflow.
+    backend.generate(
+        prompt = "combine these into one scene",
+        steps = 8,
+        guidance = 4.0,
+        seed = 1,
+        init_image = _tiny_png_b64(),
+        reference_images = [_tiny_png_b64()] * 5,
+    )
+    img_arg = loaded_pipe.last_kwargs["image"]
+    assert isinstance(img_arg, list) and len(img_arg) == 4  # primary + capped 3 extras
+
+    # reference_images still requires an init_image, same as every other conditioned workflow.
+    with pytest.raises(ValueError, match = "reference_images"):
+        backend.generate(
+            prompt = "combine these into one scene",
+            steps = 8,
+            reference_images = [_tiny_png_b64()],
+        )
+
+
 def test_load_pipeline_kind_uses_from_pretrained(fake_runtime):
     """A full-pipeline (no single-file) load on an unsloth/* repo builds the pipe with
     pipeline_cls.from_pretrained(repo_id) -- NO single-file transformer build, NO GGUF

--- a/studio/backend/tests/test_diffusion_backend.py
+++ b/studio/backend/tests/test_diffusion_backend.py
@@ -705,6 +705,10 @@ def fake_runtime(monkeypatch):
     diffusers.QwenImageInpaintPipeline = _FakeInpaintPipeline
     # Qwen-Image-Edit: its own pipeline is the loaded one.
     diffusers.QwenImageEditPlusPipeline = _FakePipeline
+    # FLUX Kontext: another edit-family pipeline, whose `image` kwarg is a batch not a
+    # multi-conditioning list -- used to exercise the reference_images rejection.
+    diffusers.FluxKontextPipeline = _FakePipeline
+    diffusers.FluxTransformer2DModel = _FakeTransformer
     # Ideogram 4, for its guidance_scale/guidance_schedule pairing. It loads only as a full pipeline (two DiTs), so stub the assembly.
     diffusers.Ideogram4Pipeline = _FakePipeline
     diffusers.Ideogram4Transformer2DModel = _FakeTransformer

--- a/studio/backend/tests/test_diffusion_backend.py
+++ b/studio/backend/tests/test_diffusion_backend.py
@@ -1578,9 +1578,9 @@ def test_edit_family_uses_own_pipeline_and_requires_image(fake_runtime, tmp_path
 
 
 def test_edit_family_supports_multiple_images(fake_runtime, tmp_path):
-    """An instruction-editing family accepts extra source images via ``reference_images``
-    (e.g. Qwen-Image-Edit-Plus, FLUX Kontext multi-image editing) and passes the primary
-    image plus every extra as a list to the pipeline's ``image`` kwarg."""
+    """An instruction-editing family whose pipeline treats a list as multiple conditioning
+    sources (Qwen-Image-Edit-Plus) accepts extra source images via ``reference_images`` and
+    passes the primary image plus every extra as a list to the pipeline's ``image`` kwarg."""
     (tmp_path / "model.gguf").write_bytes(b"x")
     backend = DiffusionBackend()
     backend.load_pipeline(
@@ -1620,6 +1620,28 @@ def test_edit_family_supports_multiple_images(fake_runtime, tmp_path):
             prompt = "combine these into one scene",
             steps = 8,
             reference_images = [_tiny_png_b64()],
+        )
+
+
+def test_edit_family_rejects_multiple_images_for_kontext(fake_runtime, tmp_path):
+    """FLUX Kontext's pipeline treats `image: list[...]` as an image batch, not multiple
+    conditioning sources, so extra reference_images must be rejected rather than combined."""
+    (tmp_path / "model.gguf").write_bytes(b"x")
+    backend = DiffusionBackend()
+    backend.load_pipeline(
+        str(tmp_path),
+        gguf_filename = "model.gguf",
+        base_repo = "black-forest-labs/FLUX.1-Kontext-dev",
+        family_override = "flux.1-kontext",
+    )
+    with pytest.raises(ValueError, match = "does not support multiple reference_images"):
+        backend.generate(
+            prompt = "combine these into one scene",
+            steps = 8,
+            guidance = 4.0,
+            seed = 1,
+            init_image = _tiny_png_b64(),
+            reference_images = [_tiny_png_b64(), _tiny_png_b64()],
         )
 
 

--- a/studio/frontend/src/features/images/api.ts
+++ b/studio/frontend/src/features/images/api.ts
@@ -124,7 +124,8 @@ export interface DiffusionGenerateRequest {
   strength?: number;
   // Upscale (hires fix): factor > 1 with an init_image enlarges the source and re-denoises at low strength.
   upscale?: number;
-  // Additional reference images for the FLUX.2 reference workflow, combined with init_image.
+  // Additional images combined with init_image: for the FLUX.2 reference workflow, or extra
+  // source images for an edit-family model (e.g. Qwen-Image-Edit-Plus, FLUX Kontext).
   reference_images?: string[];
   // LoRA adapters for this generation (discovery id + weight, 0..2). Rejected (400) when the loaded model cannot apply LoRA.
   loras?: LoraSpecInput[];

--- a/studio/frontend/src/features/images/images-page.tsx
+++ b/studio/frontend/src/features/images/images-page.tsx
@@ -3202,9 +3202,12 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
         if (extras.length) condRefImages = extras;
       } else if (isEdit) {
         // Instruction editing: send the source image, plus any extra source images; the prompt IS the instruction. No mask, no strength.
+        // FLUX Kontext only supports one source image (its pipeline treats a list as a batch, not multiple conditioning sources).
         condInit = initImage ?? undefined;
-        const extras = referenceImages.filter(Boolean);
-        if (extras.length) condRefImages = extras;
+        if (status?.family !== "flux.1-kontext") {
+          const extras = referenceImages.filter(Boolean);
+          if (extras.length) condRefImages = extras;
+        }
       }
     } catch {
       toast.error("Could not prepare the source image");
@@ -3984,7 +3987,9 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
                 >
                   <ImageDropzone value={initImage} onChange={handleInitChange} />
                 </Field>
-                {referenceImages.map((img, i) => (
+                {/* FLUX Kontext's pipeline treats a list of images as a batch, not multiple
+                    conditioning sources, so it only supports a single source image. */}
+                {status?.family !== "flux.1-kontext" && referenceImages.map((img, i) => (
                   <Field
                     key={i}
                     label={`Source image ${i + 2}`}
@@ -4013,7 +4018,7 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
                     </div>
                   </Field>
                 ))}
-                {referenceImages.length < 3 && (
+                {status?.family !== "flux.1-kontext" && referenceImages.length < 3 && (
                   <Button
                     type="button"
                     variant="secondary"

--- a/studio/frontend/src/features/images/images-page.tsx
+++ b/studio/frontend/src/features/images/images-page.tsx
@@ -186,7 +186,7 @@ const CONDITIONED_WORKFLOW_INPUTS: Record<string, string> = {
   img2img: "the source image",
   inpaint: "the source image and mask",
   upscale: "the source image",
-  edit: "the source image",
+  edit: "the source image(s)",
   reference: "the source and reference images",
   controlnet: "the control image",
 };
@@ -3201,8 +3201,10 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
         const extras = referenceImages.filter(Boolean);
         if (extras.length) condRefImages = extras;
       } else if (isEdit) {
-        // Instruction editing: send the source image; the prompt IS the instruction. No mask, no strength.
+        // Instruction editing: send the source image, plus any extra source images; the prompt IS the instruction. No mask, no strength.
         condInit = initImage ?? undefined;
+        const extras = referenceImages.filter(Boolean);
+        if (extras.length) condRefImages = extras;
       }
     } catch {
       toast.error("Could not prepare the source image");
@@ -3975,12 +3977,56 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
             )}
 
             {workflow === "edit" && (
-              <Field
-                label="Source image"
-                hint="The image to edit. Describe the change in the prompt below (e.g. 'make it night', 'add a red hat', 'change the background to a beach')."
-              >
-                <ImageDropzone value={initImage} onChange={handleInitChange} />
-              </Field>
+              <>
+                <Field
+                  label="Source image"
+                  hint="The image to edit. Describe the change in the prompt below (e.g. 'make it night', 'add a red hat', 'change the background to a beach')."
+                >
+                  <ImageDropzone value={initImage} onChange={handleInitChange} />
+                </Field>
+                {referenceImages.map((img, i) => (
+                  <Field
+                    key={i}
+                    label={`Source image ${i + 2}`}
+                    hint="An extra image combined with the others (e.g. two photos to merge, or a subject plus a style reference)."
+                  >
+                    <div className="space-y-1.5">
+                      <ImageDropzone
+                        value={img}
+                        onChange={(v) =>
+                          // Keep the slot in place (empty string when cleared) so other slots do not renumber mid-edit; empty slots are dropped at send time.
+                          setReferenceImages((prev) =>
+                            prev.map((p, j) => (j === i ? (v ?? "") : p)),
+                          )
+                        }
+                      />
+                      <Button
+                        type="button"
+                        variant="secondary"
+                        size="sm"
+                        className="w-full"
+                        onClick={() => setReferenceImages((prev) => prev.filter((_, j) => j !== i))}
+                      >
+                        <HugeiconsIcon icon={Delete02Icon} className="size-3.5" />
+                        Remove source image {i + 2}
+                      </Button>
+                    </div>
+                  </Field>
+                ))}
+                {referenceImages.length < 3 && (
+                  <Button
+                    type="button"
+                    variant="secondary"
+                    size="sm"
+                    className="w-full"
+                    disabled={!initImage}
+                    onClick={() => setReferenceImages((prev) => [...prev, ""])}
+                  >
+                    <HugeiconsIcon icon={ImageAdd02Icon} className="size-3.5" />
+                    Add another source image
+                  </Button>
+                )}
+              </>
             )}
 
             <Field label={workflow === "edit" ? "Instruction" : "Prompt"}>


### PR DESCRIPTION
## Summary
Closes #8987 — the Image Generator's Edit mode only accepted a single source image, even though the underlying edit-family pipelines (`QwenImageEditPlusPipeline`, `FluxKontextPipeline`) natively accept a list of images. This reuses the multi-image plumbing already built for the Reference (FLUX.2) workflow, end-to-end:

- **Frontend** (`studio/frontend/src/features/images/images-page.tsx`, `api.ts`): Edit now renders the same "add another image" / per-slot remove UI as Reference, backed by the existing `referenceImages` state, and sends the extra images through the already-generic `reference_images` payload field.
- **Backend** (`studio/backend/core/inference/diffusion.py`): the `reference_images` validation guard now also permits edit-family models (previously it only allowed `family.reference`), and the `edit` branch builds `ref_extra` (capped at 3, matching the Reference workflow) so the pipeline receives `[init_pil, *ref_extra]` as a list — the existing line that assembles `kwargs["image"]` already handled this generically.
- **Docs**: updated the `reference_images` field descriptions in `models/inference.py` and `api.ts` to reflect that it now also applies to edit-family models.
- **Tests** (`studio/backend/tests/test_diffusion_backend.py`): added `test_edit_family_supports_multiple_images`, covering multi-image edit generation, the pre-existing 3-image cap, and the pre-existing "`reference_images` requires an `init_image`" validation — modeled directly on the existing `test_generate_reference_uses_loaded_pipe_at_slider_size` / `test_edit_family_uses_own_pipeline_and_requires_image` tests.

## Test plan
- [x] `python3 -m py_compile` on all edited Python files
- [ ] `pytest studio/backend/tests/test_diffusion_backend.py -k edit_family` (could not run locally — the backend's heavy ML deps, torch/diffusers/structlog/fastapi, aren't installed in this sandbox; the new test closely mirrors the existing passing `test_edit_family_uses_own_pipeline_and_requires_image` and `test_generate_reference_uses_loaded_pipe_at_slider_size` tests in structure and fixtures)
- [ ] Manual UI check of the Edit tab's new multi-image upload/remove flow (no dev environment available in this sandbox)

## AI Usage Disclaimer
- [x] AI assistance (Claude Code) was used for this change.