### PR TITLE
Studio: show full URL in expanded web fetch cards

### DIFF
--- a/studio/frontend/src/components/assistant-ui/tool-ui-web-search.tsx
+++ b/studio/frontend/src/components/assistant-ui/tool-ui-web-search.tsx
@@ -129,6 +129,22 @@ const WebSearchToolUIImpl: ToolCallMessagePartComponent = ({
         icon={GlobeIcon}
       />
       <ToolFallbackContent>
+        {isUrlFetch ? (
+          <div
+            data-slot="tool-web-fetch-url"
+            className="flex min-w-0 items-start gap-2 text-xs"
+          >
+            <span className="shrink-0 font-medium text-muted-foreground">
+              URL:
+            </span>
+            <code
+              dir="ltr"
+              className="min-w-0 break-all text-foreground/85 [unicode-bidi:plaintext]"
+            >
+              {url}
+            </code>
+          </div>
+        ) : null}
         {isRunning ? (
           <div className="flex items-center text-sm text-muted-foreground">
             <span>

--- a/studio/frontend/tests/web-fetch-full-url.test.ts
+++ b/studio/frontend/tests/web-fetch-full-url.test.ts
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const source = readFileSync(
+  new URL(
+    "../src/components/assistant-ui/tool-ui-web-search.tsx",
+    import.meta.url,
+  ),
+  "utf8",
+);
+const EXPANDED_CONTENT_RE =
+  /<ToolFallbackContent>([\s\S]*?)<\/ToolFallbackContent>/;
+const URL_BLOCK_RE = /<div\s+data-slot="tool-web-fetch-url"[\s\S]*?<\/div>/;
+const RAW_URL_RE = /\{url\}/;
+const WRAPPING_RE = /break-all/;
+const LTR_RE = /dir="ltr"/;
+const LINK_RE = /href=/;
+
+test("expanded web fetch cards show the complete raw URL as text", () => {
+  const expandedContent = source.match(EXPANDED_CONTENT_RE)?.[1];
+  const urlBlock = expandedContent?.match(URL_BLOCK_RE)?.[0];
+
+  assert.ok(urlBlock, "missing the expanded-card URL detail");
+  assert.match(
+    urlBlock,
+    RAW_URL_RE,
+    "the detail must render the full raw argument",
+  );
+  assert.match(urlBlock, WRAPPING_RE, "long URLs must wrap inside the card");
+  assert.match(urlBlock, LTR_RE, "URLs must keep a stable reading direction");
+  assert.doesNotMatch(
+    urlBlock,
+    LINK_RE,
+    "an untrusted tool argument must not become a clickable link",
+  );
+});


### PR DESCRIPTION
## Summary

- show the complete raw URL inside expanded web-fetch tool cards
- preserve the existing collapsed hostname-only trigger
- wrap long URLs, keep left-to-right URL rendering, and avoid turning untrusted tool arguments into clickable links
- add a regression test for the expanded-card contract

## Why

Web-fetch cards previously exposed only the parsed hostname in their trigger. Even after expanding the card, users could not inspect the path, query, or fragment before approving or reviewing a fetch. This made an innocuous and a potentially sensitive URL on the same host look identical.

The URL is now rendered inside the existing expanded content rather than in the collapsed row, keeping completed chat compact while making the complete request inspectable.

## Normal chat behavior

- running and approval-gated tool calls open automatically
- completed calls collapse once assistant text begins
- clicking the tool-call trigger reopens it and reveals the full URL

## Playwright UI evidence

Scene: the same persisted web-fetch conversation loaded in the full Studio shell on isolated BEFORE and AFTER servers; Playwright clicked the completed tool-call trigger before each capture.

| Fact | BEFORE | AFTER |
| --- | ---: | ---: |
| Full-URL detail rows | 0 | 1 |
| Complete raw URL visible | no | yes |
| Links inside URL detail | 0 | 0 |
| Sidebar thread visible | yes | yes |

- Base: `bfcaea46574d63ec470ce9c7d7221471a38ea7e4`
- Head: `2453d2ee3c9df11556792aed1eb48a202ebb123c`
- Viewport: 1440×900
- The labelled full-page composite was manually inspected after capture.

## Validation

- `node --experimental-strip-types --test tests/web-fetch-full-url.test.ts`
- `npm run build`
- `git diff --check`
