### PR TITLE
fix(install): pair slim whisper with an external --with-llama-cpp-dir runtime (#9179)

### DIFF
--- a/.github/scripts/boot-studio-api-only.sh
+++ b/.github/scripts/boot-studio-api-only.sh
@@ -68,7 +68,9 @@ rm -rf ~/.unsloth/studio/auth
 mkdir -p "$(dirname "$LOG")"
 
 # shellcheck disable=SC2086  # $API_ONLY is one flag or empty, and must not become ''
-UNSLOTH_API_ONLY=1 unsloth studio -H 127.0.0.1 -p "$PORT" $API_ONLY > "$LOG" 2>&1 &
+# No MLX on these runners (--no-torch install): the self-heal would only
+# pip-install mid-test and starve the 3 vCPU shared runner (#9183).
+UNSLOTH_DISABLE_MLX_AUTOREPAIR=1 UNSLOTH_API_ONLY=1 unsloth studio -H 127.0.0.1 -p "$PORT" $API_ONLY > "$LOG" 2>&1 &
 SERVER_PID=$!
 
 echo "[boot] unsloth studio ${API_ONLY:---with-frontend} on 127.0.0.1:${PORT}, pid ${SERVER_PID}, log ${LOG}"

--- a/.github/workflows/studio-mac-ui-smoke.yml
+++ b/.github/workflows/studio-mac-ui-smoke.yml
@@ -269,7 +269,8 @@ jobs:
               kill "${STUDIO_PID}" 2>/dev/null || true
               sleep 2
               rm -rf ~/.unsloth/studio/auth
-              UNSLOTH_DISABLE_MLX_AUTOREPAIR=1 \n              UNSLOTH_API_ONLY=1 unsloth studio -H 127.0.0.1 -p "$STUDIO_PORT" \
+              UNSLOTH_DISABLE_MLX_AUTOREPAIR=1 \
+              UNSLOTH_API_ONLY=1 unsloth studio -H 127.0.0.1 -p "$STUDIO_PORT" \
                 > "logs/studio_retry_${attempt}.log" 2>&1 &
               STUDIO_PID=$!
               echo "STUDIO_PID=$STUDIO_PID" >> "$GITHUB_ENV"

--- a/.github/workflows/studio-mac-ui-smoke.yml
+++ b/.github/workflows/studio-mac-ui-smoke.yml
@@ -269,7 +269,7 @@ jobs:
               kill "${STUDIO_PID}" 2>/dev/null || true
               sleep 2
               rm -rf ~/.unsloth/studio/auth
-              UNSLOTH_API_ONLY=1 unsloth studio -H 127.0.0.1 -p "$STUDIO_PORT" \
+              UNSLOTH_DISABLE_MLX_AUTOREPAIR=1 \n              UNSLOTH_API_ONLY=1 unsloth studio -H 127.0.0.1 -p "$STUDIO_PORT" \
                 > "logs/studio_retry_${attempt}.log" 2>&1 &
               STUDIO_PID=$!
               echo "STUDIO_PID=$STUDIO_PID" >> "$GITHUB_ENV"

--- a/studio/backend/core/inference/diffusion.py
+++ b/studio/backend/core/inference/diffusion.py
@@ -4923,6 +4923,41 @@ class DiffusionBackend:
             explicit_offload = cpu_offload,
         )
 
+    @staticmethod
+    def _from_pipe_no_recast(pipe: Any, pipe_cls: Any, **extra: Any) -> Any:
+        """``Pipeline.from_pipe`` that never recasts component dtypes.
+
+        The bundled diffusers resolves ``torch_dtype=None`` to float32 inside
+        ``from_pipe`` and then calls ``.to(dtype)`` on EVERY component — which
+        hard-crashes GGUF-quantized transformers ("Casting a quantized model
+        to a new dtype is unsupported", #9186). When that happens, re-wire the
+        components manually: same resident modules, same references, no cast.
+        """
+        try:
+            return pipe_cls.from_pipe(pipe, torch_dtype=None, **extra)
+        except (TypeError, ValueError) as exc:
+            if "quantized" not in str(exc).lower():
+                raise
+        import inspect
+
+        components = dict(pipe.components)
+        components.update(extra)
+        params = inspect.signature(pipe_cls.__init__).parameters
+        accepted = {
+            name
+            for name, param in params.items()
+            if param.kind is inspect.Parameter.POSITIONAL_OR_KEYWORD
+            or param.kind is inspect.Parameter.KEYWORD_ONLY
+        }
+        # **kwargs-style pipelines accept everything from_pipe would pass;
+        # strict signatures get exactly the names they declare.
+        has_var_kw = any(
+            param.kind is inspect.Parameter.VAR_KEYWORD for param in params.values()
+        )
+        if not has_var_kw:
+            components = {k: v for k, v in components.items() if k in accepted}
+        return pipe_cls(**components)
+
     def _workflow_pipe(self, state: _LoadState, class_name: Optional[str], workflow: str) -> Any:
         """The diffusers pipeline for an image-conditioned ``workflow``, built once and
         cached. ``Pipeline.from_pipe`` re-wires the loaded text-to-image pipe's resident
@@ -4940,7 +4975,9 @@ class DiffusionBackend:
 
         # torch_dtype=None is load-bearing: from_pipe otherwise recasts EVERY component to fp32, which hard-crashes the
         # dense-quant path (torchao subclasses cannot swap_tensors). None reuses resident modules at their loaded dtype.
-        pipe = getattr(diffusers, class_name).from_pipe(state.pipe, torch_dtype = None)
+        # The no-recast fallback covers GGUF-quantized transformers, where the bundled
+        # diffusers still resolves None to fp32 and the .to() hard-crashes (#9186).
+        pipe = self._from_pipe_no_recast(state.pipe, getattr(diffusers, class_name))
         # Publish to the shared aux cache only if THIS load is still current: from_pipe runs without _lock, so an unload can null _state and caching would hand out stale modules.
         with self._lock:
             if self._state is state:
@@ -5011,8 +5048,8 @@ class DiffusionBackend:
         key = (pipe_cls_name, resolved_cn.id)
         pipe = self._cn_pipes.get(key)
         if pipe is None:
-            pipe = getattr(diffusers, pipe_cls_name).from_pipe(
-                state.pipe, controlnet = cn_model, torch_dtype = None
+            pipe = self._from_pipe_no_recast(
+                state.pipe, getattr(diffusers, pipe_cls_name), controlnet=cn_model
             )
             with self._lock:
                 # Same race as the model cache: an unload may have cleared _cn_pipes while from_pipe ran.

--- a/studio/backend/core/inference/diffusion.py
+++ b/studio/backend/core/inference/diffusion.py
@@ -4934,7 +4934,7 @@ class DiffusionBackend:
         components manually: same resident modules, same references, no cast.
         """
         try:
-            return pipe_cls.from_pipe(pipe, torch_dtype=None, **extra)
+            return pipe_cls.from_pipe(pipe, torch_dtype = None, **extra)
         except (TypeError, ValueError) as exc:
             if "quantized" not in str(exc).lower():
                 raise
@@ -4951,9 +4951,7 @@ class DiffusionBackend:
         }
         # **kwargs-style pipelines accept everything from_pipe would pass;
         # strict signatures get exactly the names they declare.
-        has_var_kw = any(
-            param.kind is inspect.Parameter.VAR_KEYWORD for param in params.values()
-        )
+        has_var_kw = any(param.kind is inspect.Parameter.VAR_KEYWORD for param in params.values())
         if not has_var_kw:
             components = {k: v for k, v in components.items() if k in accepted}
         return pipe_cls(**components)
@@ -5049,7 +5047,7 @@ class DiffusionBackend:
         pipe = self._cn_pipes.get(key)
         if pipe is None:
             pipe = self._from_pipe_no_recast(
-                state.pipe, getattr(diffusers, pipe_cls_name), controlnet=cn_model
+                state.pipe, getattr(diffusers, pipe_cls_name), controlnet = cn_model
             )
             with self._lock:
                 # Same race as the model cache: an unload may have cleared _cn_pipes while from_pipe ran.

--- a/studio/backend/tests/test_diffusion_from_pipe_no_recast.py
+++ b/studio/backend/tests/test_diffusion_from_pipe_no_recast.py
@@ -1,0 +1,127 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+
+"""#9186: the bundled diffusers resolves ``torch_dtype=None`` inside
+``from_pipe`` to float32 and then calls ``.to(dtype)`` on every component,
+which hard-crashes GGUF-quantized transformers. ``_from_pipe_no_recast``
+keeps the ``from_pipe`` fast path and falls back to re-wiring the resident
+components without any cast when that crash fires.
+
+The helper is extracted from diffusion.py via its AST and executed in an
+isolated namespace (the same convention test_chat_completions_sanitize_floats
+established), so this file imports neither torch nor diffusers and runs
+wherever the module parses."""
+
+from __future__ import annotations
+
+import ast
+import textwrap
+from pathlib import Path
+
+import pytest
+
+SOURCE = (
+    Path(__file__).resolve().parents[1] / "core" / "inference" / "diffusion.py"
+).read_text()
+
+
+def _extract_static_method(name: str):
+    """Compile the whole FunctionDef at module level so `return` keeps its
+    function context; the resulting namespace holds the function itself."""
+    tree = ast.parse(SOURCE)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == name:
+            node.decorator_list = []
+            code = compile(ast.Module(body=[node], type_ignores=[]), filename=str(SOURCE), mode="exec")
+            namespace: dict = {"__builtins__": __builtins__}
+            exec(code, namespace)
+            return namespace[name]
+    raise AssertionError(f"{name} not found in diffusion.py")
+
+
+_from_pipe_no_recast = _extract_static_method("_from_pipe_no_recast")
+
+
+class _QuantizedCaster:
+    """A from_pipe that mimics the bundled diffusers' fp32 recast crash."""
+
+    calls: list[dict] = []
+
+    def __init__(self, **components):
+        self.components = components
+
+    @classmethod
+    def from_pipe(cls, base_pipe, **kwargs):
+        cls.calls.append(kwargs)
+        raise ValueError(
+            "Casting a quantized model to a new `dtype` is unsupported. "
+            "To set the dtype of unquantized layers, please use the "
+            "`torch_dtype` argument when loading the model."
+        )
+
+
+class _FriendlyPipe:
+    """A from_pipe that succeeds — the normal path."""
+
+    def __init__(self, **components):
+        self.components = components
+
+    @classmethod
+    def from_pipe(cls, base_pipe, **kwargs):
+        cls.calls.append(kwargs)
+        return cls(**base_pipe.components)
+
+
+class _Base:
+    def __init__(self):
+        self.components = {
+            "transformer": object(),
+            "vae": object(),
+            "text_encoder": object(),
+        }
+
+
+def test_fast_path_still_uses_from_pipe():
+    _FriendlyPipe.calls = []
+    base = _Base()
+    _from_pipe_no_recast(base, _FriendlyPipe)
+    assert _FriendlyPipe.calls == [{"torch_dtype": None}]
+
+
+def test_quantized_crash_falls_back_to_component_rewiring():
+    _QuantizedCaster.calls = []
+    base = _Base()
+    pipe = _from_pipe_no_recast(base, _QuantizedCaster)
+    # from_pipe WAS tried with the no-recast intent first...
+    assert _QuantizedCaster.calls == [{"torch_dtype": None}]
+    # ...and the fallback reuses the same resident module references.
+    assert pipe.components["transformer"] is base.components["transformer"]
+    assert pipe.components["vae"] is base.components["vae"]
+
+
+def test_unrelated_errors_still_raise():
+    class _Broken:
+        @classmethod
+        def from_pipe(cls, base_pipe, **kwargs):
+            raise ValueError("some other failure")
+
+    with pytest.raises(ValueError, match="some other failure"):
+        _from_pipe_no_recast(_Base(), _Broken)
+
+
+def test_extra_components_forward_to_the_fallback():
+    class _StrictSig:
+        def __init__(self, transformer=None, vae=None, text_encoder=None, controlnet=None):
+            self.transformer = transformer
+            self.vae = vae
+            self.controlnet = controlnet
+
+        @classmethod
+        def from_pipe(cls, base_pipe, **kwargs):
+            raise ValueError("Casting a quantized model to a new dtype is unsupported")
+
+    base = _Base()
+    cn = object()
+    pipe = _from_pipe_no_recast(base, _StrictSig, controlnet=cn)
+    assert pipe.controlnet is cn
+    assert pipe.transformer is base.components["transformer"]

--- a/studio/backend/tests/test_diffusion_from_pipe_no_recast.py
+++ b/studio/backend/tests/test_diffusion_from_pipe_no_recast.py
@@ -20,9 +20,7 @@ from pathlib import Path
 
 import pytest
 
-SOURCE = (
-    Path(__file__).resolve().parents[1] / "core" / "inference" / "diffusion.py"
-).read_text()
+SOURCE = (Path(__file__).resolve().parents[1] / "core" / "inference" / "diffusion.py").read_text()
 
 
 def _extract_static_method(name: str):
@@ -32,7 +30,9 @@ def _extract_static_method(name: str):
     for node in ast.walk(tree):
         if isinstance(node, ast.FunctionDef) and node.name == name:
             node.decorator_list = []
-            code = compile(ast.Module(body=[node], type_ignores=[]), filename=str(SOURCE), mode="exec")
+            code = compile(
+                ast.Module(body = [node], type_ignores = []), filename = str(SOURCE), mode = "exec"
+            )
             namespace: dict = {"__builtins__": __builtins__}
             exec(code, namespace)
             return namespace[name]
@@ -105,13 +105,19 @@ def test_unrelated_errors_still_raise():
         def from_pipe(cls, base_pipe, **kwargs):
             raise ValueError("some other failure")
 
-    with pytest.raises(ValueError, match="some other failure"):
+    with pytest.raises(ValueError, match = "some other failure"):
         _from_pipe_no_recast(_Base(), _Broken)
 
 
 def test_extra_components_forward_to_the_fallback():
     class _StrictSig:
-        def __init__(self, transformer=None, vae=None, text_encoder=None, controlnet=None):
+        def __init__(
+            self,
+            transformer = None,
+            vae = None,
+            text_encoder = None,
+            controlnet = None,
+        ):
             self.transformer = transformer
             self.vae = vae
             self.controlnet = controlnet
@@ -122,6 +128,6 @@ def test_extra_components_forward_to_the_fallback():
 
     base = _Base()
     cn = object()
-    pipe = _from_pipe_no_recast(base, _StrictSig, controlnet=cn)
+    pipe = _from_pipe_no_recast(base, _StrictSig, controlnet = cn)
     assert pipe.controlnet is cn
     assert pipe.transformer is base.components["transformer"]

--- a/studio/backend/tests/test_mlx_stack_blockers.py
+++ b/studio/backend/tests/test_mlx_stack_blockers.py
@@ -372,3 +372,74 @@ def test_uv_missing_never_marks_the_environment(monkeypatch):
     monkeypatch.setattr(mr, "_transformers_constraint_args", lambda: ([], None))
     assert mr.attempt_mlx_repair() is False
     assert mr._environment_mutated is False
+
+
+# ── Concurrent first-import race (#9120) ──────────────────────────────────────
+
+
+class _FakeImportWithRace:
+    """import_module that raises the partial-import ImportError N times for one
+    module (the shape another startup thread mid-`import transformers` produces),
+    then succeeds."""
+
+    def __init__(self, racing_module: str, failures: int):
+        self._racing_module = racing_module
+        self._failures_left = failures
+        self.calls: list[str] = []
+
+    def __call__(self, module: str):
+        self.calls.append(module)
+        if module == self._racing_module and self._failures_left > 0:
+            self._failures_left -= 1
+            raise ImportError(
+                "cannot import name 'AutoTokenizer' from 'transformers' "
+                "(/venv/site-packages/transformers/__init__.py)"
+            )
+        return None
+
+
+def test_concurrent_partial_import_is_retried_not_reported(monkeypatch):
+    # The #9120 shape: a healthy stack whose first mlx_lm import races another
+    # startup thread's first transformers import. One retry must clear it —
+    # reporting it greyed out Train/Export for the whole process lifetime.
+    fake = _FakeImportWithRace("mlx_lm", failures=1)
+    monkeypatch.setattr(mr.importlib, "import_module", fake)
+    sleeps: list[float] = []
+    monkeypatch.setattr(mr.time, "sleep", sleeps.append)
+
+    assert mr._mlx_runtime_import_blocker() is None
+    assert fake.calls.count("mlx_lm") == 2, "the race must be retried, not reported"
+
+
+def test_broken_install_import_is_reported_on_the_first_attempt(monkeypatch):
+    # A missing module is a real install problem, never the race: no retries,
+    # no added latency before the chat-only verdict.
+    fake = _FakeImportWithRace("mlx_lm", failures=99)
+    fake_bad = fake.__call__
+
+    def strict(module: str):
+        fake.calls.append(module)
+        if module == "mlx_lm":
+            raise ImportError("No module named 'mlx_lm'")
+        return None
+
+    monkeypatch.setattr(mr.importlib, "import_module", strict)
+    monkeypatch.setattr(mr.time, "sleep", lambda _s: pytest.fail("no retry expected"))
+
+    blocker = mr._mlx_runtime_import_blocker()
+    assert blocker is not None and "No module named 'mlx_lm'" in blocker
+    assert fake.calls.count("mlx_lm") == 1
+
+
+def test_persistent_partial_import_reports_after_exhausting_retries(monkeypatch):
+    # If the signature persists past the retries it is not a race after all:
+    # the verdict must still name it instead of looping or passing.
+    fake = _FakeImportWithRace("mlx_lm", failures=99)
+    monkeypatch.setattr(mr.importlib, "import_module", fake)
+    sleeps: list[float] = []
+    monkeypatch.setattr(mr.time, "sleep", sleeps.append)
+
+    blocker = mr._mlx_runtime_import_blocker()
+    assert blocker is not None and "cannot import name" in blocker
+    assert fake.calls.count("mlx_lm") == 3
+    assert len(sleeps) == 2, "backoff between attempts, none after the last"

--- a/studio/backend/tests/test_mlx_stack_blockers.py
+++ b/studio/backend/tests/test_mlx_stack_blockers.py
@@ -402,7 +402,7 @@ def test_concurrent_partial_import_is_retried_not_reported(monkeypatch):
     # The #9120 shape: a healthy stack whose first mlx_lm import races another
     # startup thread's first transformers import. One retry must clear it —
     # reporting it greyed out Train/Export for the whole process lifetime.
-    fake = _FakeImportWithRace("mlx_lm", failures=1)
+    fake = _FakeImportWithRace("mlx_lm", failures = 1)
     monkeypatch.setattr(mr.importlib, "import_module", fake)
     sleeps: list[float] = []
     monkeypatch.setattr(mr.time, "sleep", sleeps.append)
@@ -414,7 +414,7 @@ def test_concurrent_partial_import_is_retried_not_reported(monkeypatch):
 def test_broken_install_import_is_reported_on_the_first_attempt(monkeypatch):
     # A missing module is a real install problem, never the race: no retries,
     # no added latency before the chat-only verdict.
-    fake = _FakeImportWithRace("mlx_lm", failures=99)
+    fake = _FakeImportWithRace("mlx_lm", failures = 99)
     fake_bad = fake.__call__
 
     def strict(module: str):
@@ -434,7 +434,7 @@ def test_broken_install_import_is_reported_on_the_first_attempt(monkeypatch):
 def test_persistent_partial_import_reports_after_exhausting_retries(monkeypatch):
     # If the signature persists past the retries it is not a race after all:
     # the verdict must still name it instead of looping or passing.
-    fake = _FakeImportWithRace("mlx_lm", failures=99)
+    fake = _FakeImportWithRace("mlx_lm", failures = 99)
     monkeypatch.setattr(mr.importlib, "import_module", fake)
     sleeps: list[float] = []
     monkeypatch.setattr(mr.time, "sleep", sleeps.append)

--- a/studio/backend/tests/test_whisper_slim_external_llama.py
+++ b/studio/backend/tests/test_whisper_slim_external_llama.py
@@ -1,0 +1,122 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+
+"""#9179: slim whisper pairing falls back to an external --with-llama-cpp-dir
+runtime when the managed-installer metadata is absent."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+_studio = Path(__file__).resolve().parent.parent.parent
+if str(_studio) not in sys.path:
+    sys.path.insert(0, str(_studio))
+
+iwp = importlib.import_module("install_whisper_prebuilt")
+
+
+class _Proc:
+    def __init__(self, out: str = "", err: str = ""):
+        self.stdout = out
+        self.stderr = err
+
+
+@pytest.mark.p1
+def test_fallback_parses_llama_server_version(monkeypatch, tmp_path):
+    server = tmp_path / "llama-server"
+    server.write_text("#!/bin/sh\n", encoding="utf-8")
+
+    monkeypatch.setenv("LLAMA_SERVER_PATH", str(server))
+    monkeypatch.setattr(
+        iwp.subprocess,
+        "run",
+        lambda *a, **k: _Proc(err="llama-server\nversion: 10360 (87da1a2)\nbuilt with ...\n"),
+    )
+
+    runtime = iwp._external_llama_runtime_fallback()
+    assert runtime is not None
+    bin_dir, tag, profile = runtime
+    assert tag == "b10360"
+    assert bin_dir == server.resolve().parent
+    assert profile == ""
+
+
+@pytest.mark.p1
+def test_fallback_rejects_unknown_source_build_version(monkeypatch, tmp_path):
+    server = tmp_path / "llama-server"
+    server.write_text("#!/bin/sh\n", encoding="utf-8")
+
+    monkeypatch.setenv("LLAMA_SERVER_PATH", str(server))
+    monkeypatch.setattr(
+        iwp.subprocess, "run", lambda *a, **k: _Proc(err="version: 1 (no tags)")
+    )
+
+    assert iwp._external_llama_runtime_fallback() is None
+
+
+@pytest.mark.p1
+def test_fallback_none_without_a_llama_server(monkeypatch):
+    monkeypatch.delenv("LLAMA_SERVER_PATH", raising=False)
+    monkeypatch.setattr(iwp.shutil, "which", lambda name: None)
+
+    assert iwp._external_llama_runtime_fallback() is None
+
+
+@pytest.mark.p1
+def test_slim_pairing_uses_fallback_when_no_managed_install(monkeypatch, tmp_path):
+    artifact = {
+        "asset": "whisper-linux-x64-slim.tar.gz",
+        "requires_llama_tag": "b10360",
+        "requires_ggml_sonames": ["libggml.so", "libggml-base.so"],
+    }
+    for soname in artifact["requires_ggml_sonames"]:
+        (tmp_path / soname).write_bytes(b"")
+    (tmp_path / "libggml-cuda.so").write_bytes(b"")
+
+    server = tmp_path / "llama-server"
+    server.write_text("#!/bin/sh\n", encoding="utf-8")
+
+    monkeypatch.setattr(iwp, "installed_llama_runtime", lambda *a, **k: None)
+    monkeypatch.setenv("LLAMA_SERVER_PATH", str(server))
+    monkeypatch.setattr(
+        iwp.subprocess,
+        "run",
+        lambda *a, **k: _Proc(err="version: 10360 (87da1a2)"),
+    )
+
+    host = MagicMock()
+    host.is_macos = False
+    host.is_windows = False
+    host.whisper_os = "linux"
+
+    monkeypatch.setattr(iwp, "installed_llama_ggml_tree", lambda *a, **k: None)
+
+    pairing = iwp.slim_pairing_for_artifact(artifact, host, "cuda")
+    assert pairing is not None
+    bin_dir, tag = pairing
+    assert tag == "b10360"
+    assert bin_dir == server.resolve().parent
+
+
+@pytest.mark.p1
+def test_slim_pairing_still_refuses_without_any_runtime(monkeypatch):
+    artifact = {
+        "asset": "whisper-linux-x64-slim.tar.gz",
+        "requires_llama_tag": "b10360",
+        "requires_ggml_sonames": ["libggml.so"],
+    }
+    monkeypatch.setattr(iwp, "installed_llama_runtime", lambda *a, **k: None)
+    monkeypatch.delenv("LLAMA_SERVER_PATH", raising=False)
+    monkeypatch.setattr(iwp.shutil, "which", lambda name: None)
+
+    host = MagicMock()
+    host.is_macos = False
+    host.is_windows = False
+    host.whisper_os = "linux"
+
+    assert iwp.slim_pairing_for_artifact(artifact, host, "cuda") is None

--- a/studio/backend/tests/test_whisper_slim_external_llama.py
+++ b/studio/backend/tests/test_whisper_slim_external_llama.py
@@ -21,7 +21,11 @@ iwp = importlib.import_module("install_whisper_prebuilt")
 
 
 class _Proc:
-    def __init__(self, out: str = "", err: str = ""):
+    def __init__(
+        self,
+        out: str = "",
+        err: str = "",
+    ):
         self.stdout = out
         self.stderr = err
 
@@ -29,13 +33,13 @@ class _Proc:
 @pytest.mark.p1
 def test_fallback_parses_llama_server_version(monkeypatch, tmp_path):
     server = tmp_path / "llama-server"
-    server.write_text("#!/bin/sh\n", encoding="utf-8")
+    server.write_text("#!/bin/sh\n", encoding = "utf-8")
 
     monkeypatch.setenv("LLAMA_SERVER_PATH", str(server))
     monkeypatch.setattr(
         iwp.subprocess,
         "run",
-        lambda *a, **k: _Proc(err="llama-server\nversion: 10360 (87da1a2)\nbuilt with ...\n"),
+        lambda *a, **k: _Proc(err = "llama-server\nversion: 10360 (87da1a2)\nbuilt with ...\n"),
     )
 
     runtime = iwp._external_llama_runtime_fallback()
@@ -49,19 +53,17 @@ def test_fallback_parses_llama_server_version(monkeypatch, tmp_path):
 @pytest.mark.p1
 def test_fallback_rejects_unknown_source_build_version(monkeypatch, tmp_path):
     server = tmp_path / "llama-server"
-    server.write_text("#!/bin/sh\n", encoding="utf-8")
+    server.write_text("#!/bin/sh\n", encoding = "utf-8")
 
     monkeypatch.setenv("LLAMA_SERVER_PATH", str(server))
-    monkeypatch.setattr(
-        iwp.subprocess, "run", lambda *a, **k: _Proc(err="version: 1 (no tags)")
-    )
+    monkeypatch.setattr(iwp.subprocess, "run", lambda *a, **k: _Proc(err = "version: 1 (no tags)"))
 
     assert iwp._external_llama_runtime_fallback() is None
 
 
 @pytest.mark.p1
 def test_fallback_none_without_a_llama_server(monkeypatch):
-    monkeypatch.delenv("LLAMA_SERVER_PATH", raising=False)
+    monkeypatch.delenv("LLAMA_SERVER_PATH", raising = False)
     monkeypatch.setattr(iwp.shutil, "which", lambda name: None)
 
     assert iwp._external_llama_runtime_fallback() is None
@@ -79,14 +81,14 @@ def test_slim_pairing_uses_fallback_when_no_managed_install(monkeypatch, tmp_pat
     (tmp_path / "libggml-cuda.so").write_bytes(b"")
 
     server = tmp_path / "llama-server"
-    server.write_text("#!/bin/sh\n", encoding="utf-8")
+    server.write_text("#!/bin/sh\n", encoding = "utf-8")
 
     monkeypatch.setattr(iwp, "installed_llama_runtime", lambda *a, **k: None)
     monkeypatch.setenv("LLAMA_SERVER_PATH", str(server))
     monkeypatch.setattr(
         iwp.subprocess,
         "run",
-        lambda *a, **k: _Proc(err="version: 10360 (87da1a2)"),
+        lambda *a, **k: _Proc(err = "version: 10360 (87da1a2)"),
     )
 
     host = MagicMock()
@@ -111,7 +113,7 @@ def test_slim_pairing_still_refuses_without_any_runtime(monkeypatch):
         "requires_ggml_sonames": ["libggml.so"],
     }
     monkeypatch.setattr(iwp, "installed_llama_runtime", lambda *a, **k: None)
-    monkeypatch.delenv("LLAMA_SERVER_PATH", raising=False)
+    monkeypatch.delenv("LLAMA_SERVER_PATH", raising = False)
     monkeypatch.setattr(iwp.shutil, "which", lambda name: None)
 
     host = MagicMock()

--- a/studio/backend/utils/mlx_repair.py
+++ b/studio/backend/utils/mlx_repair.py
@@ -175,13 +175,38 @@ def _one_line(exc: BaseException) -> str:
     return _bounded(str(exc))
 
 
+def _is_concurrent_partial_import(exc: BaseException) -> bool:
+    """True for the ImportError shape of a concurrent first-import race (#9120).
+
+    Startup runs hardware detection, the torch warm, llama.cpp probes, and GGUF
+    precache on concurrent threads. The first-ever `import transformers` (inside
+    mlx_lm's own import chain) can land while another thread still has it
+    partially initialized, and `from transformers import AutoTokenizer` then
+    raises "cannot import name ... from ..." on a perfectly healthy install. A
+    genuinely broken install fails differently: "No module named ...", a shared
+    library error, or another exception type entirely.
+    """
+    return isinstance(exc, ImportError) and "cannot import name" in str(exc)
+
+
 def _mlx_runtime_import_blocker() -> Optional[str]:
-    """The first runtime import that will not load, and why. None when all do."""
+    """The first runtime import that will not load, and why. None when all do.
+
+    The concurrent partial-import race is retried, not reported: it clears on
+    its own once the other thread's import finishes, and one unlucky race at
+    boot would otherwise cache a chat-only verdict for the process's lifetime
+    (#9120). Only that signature is retried — a real install problem fails on
+    the first attempt and pays nothing.
+    """
     for module in _MLX_RUNTIME_IMPORTS:
-        try:
-            importlib.import_module(module)
-        except Exception as exc:
-            return f"{module} does not import ({type(exc).__name__}: {_one_line(exc)})"
+        for attempt in range(3):
+            try:
+                importlib.import_module(module)
+                break
+            except Exception as exc:
+                if not _is_concurrent_partial_import(exc) or attempt == 2:
+                    return f"{module} does not import ({type(exc).__name__}: {_one_line(exc)})"
+                time.sleep(0.5 * (attempt + 1))
     return None
 
 

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -483,6 +483,8 @@ function stringifyTemplateValue(value: unknown): string {
   }
 }
 
+export { promptUsesHighPrecisionTimeVariables } from "./prompt-time-variables.ts";
+
 function resolveSystemPromptVariables(
   prompt: string,
   customVariablesRaw: string,

--- a/studio/frontend/src/features/chat/api/prompt-time-variables.ts
+++ b/studio/frontend/src/features/chat/api/prompt-time-variables.ts
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+/**
+ * True when the prompt uses a second-precision time variable ({{$now}} or
+ * {{$time}}). Those are re-filled on every request, so the prompt prefix
+ * changes each turn and prefix caching never matches — every message pays a
+ * full prefill (#9177: 55s vs 0.95s first token). {{$date}} flips once per
+ * day and is usually acceptable.
+ */
+export function promptUsesHighPrecisionTimeVariables(prompt: string): boolean {
+  if (!prompt) {
+    return false;
+  }
+  return /{{\s*\$now\s*}}|{{\s*\$time\s*}}/i.test(prompt);
+}

--- a/studio/frontend/src/features/chat/chat-settings-sheet.tsx
+++ b/studio/frontend/src/features/chat/chat-settings-sheet.tsx
@@ -1559,7 +1559,11 @@ export function ChatSettingsPanel({
                       {["{{$date}}", "{{$time}}", "{{$now}}"].map((token) => (
                         <span
                           key={token}
-                          title={`${token} is replaced automatically when you send`}
+                          title={
+                      token === "{{$now}}" || token === "{{$time}}"
+                        ? `${token} is replaced automatically when you send. Second precision: it changes every request and defeats prefix caching. Prefer {{$date}}.`
+                        : `${token} is replaced automatically when you send`
+                    }
                           className="rounded-full bg-muted px-2 py-0.5 font-mono text-ui-10 text-muted-foreground"
                         >
                           {token}
@@ -1604,6 +1608,17 @@ export function ChatSettingsPanel({
               className="min-h-[20rem] max-h-[48dvh] overflow-y-auto border-0 text-sm leading-6 corner-squircle focus-visible:ring-0"
               rows={14}
             />
+            {promptUsesHighPrecisionTimeVariables(systemPromptDraft) ? (
+              <p
+                role="note"
+                className="px-1 text-ui-11 text-amber-600 dark:text-amber-400"
+              >
+                This prompt uses {"{{$now}}"} or {"{{$time}}"}: the value is
+                re-filled every request, so the prompt prefix changes each
+                turn and prefix caching never matches — every message pays a
+                full re-process. Use {"{{$date}}"} or remove the variable.
+              </p>
+            ) : null}
           </div>
           <DialogFooter className="flex-wrap gap-2 sm:justify-between">
             <Button

--- a/studio/frontend/tests/prompt-time-variables-prefix-cache.test.ts
+++ b/studio/frontend/tests/prompt-time-variables-prefix-cache.test.ts
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { registerBundlerResolver } from "./helpers/kit.ts";
+
+registerBundlerResolver();
+
+const { promptUsesHighPrecisionTimeVariables } = await import(
+  "../src/features/chat/api/prompt-time-variables.ts"
+);
+
+// #9177: {{$now}}/{{$time}} are re-filled with second precision on every
+// request, so a system prompt carrying them changes every turn and prefix
+// caching never matches — full prefill per message (55s vs 0.95s first token
+// in the report). The UI warns on exactly this shape.
+test("detects the high-precision time variables", () => {
+  assert.equal(
+    promptUsesHighPrecisionTimeVariables("The current time is {{$now}}"),
+    true,
+  );
+  assert.equal(
+    promptUsesHighPrecisionTimeVariables("Clock: {{ $time }}"),
+    true,
+  );
+  assert.equal(
+    promptUsesHighPrecisionTimeVariables("{{ $NOW }}"),
+    true,
+  );
+});
+
+test("day precision and custom variables do not warn", () => {
+  assert.equal(
+    promptUsesHighPrecisionTimeVariables("Today is {{$date}}"),
+    false,
+  );
+  assert.equal(
+    promptUsesHighPrecisionTimeVariables("Env: {{ env }}"),
+    false,
+  );
+  assert.equal(
+    promptUsesHighPrecisionTimeVariables("Plain prompt, no variables"),
+    false,
+  );
+  assert.equal(promptUsesHighPrecisionTimeVariables(""), false);
+});
+
+test("now embedded mid-sentence and with timezone suffix still warns", () => {
+  assert.equal(
+    promptUsesHighPrecisionTimeVariables(
+      "Context as of {{$now}} — respond accordingly. Also {{version}}.",
+    ),
+    true,
+  );
+  assert.equal(
+    promptUsesHighPrecisionTimeVariables("see {{$timestamp}}"),
+    false,
+    "only the built-in $now/$time shapes warn; unknown keys are left as-is",
+  );
+});

--- a/studio/install_whisper_prebuilt.py
+++ b/studio/install_whisper_prebuilt.py
@@ -411,6 +411,58 @@ def _ships_windows_gpu_ggml_module(llama_bin_dir: Path) -> bool:
     return False
 
 
+def _external_llama_runtime_fallback() -> tuple[Path, str, str] | None:
+    """A --with-llama-cpp-dir runtime the managed-installer metadata never
+    covers (#9179).
+
+    ``installed_llama_runtime()`` only recognizes a completed managed prebuilt
+    install (UNSLOTH_PREBUILT_INFO.json under the managed root). A
+    --with-llama-cpp-dir checkout — the user's own build, symlinked into the
+    canonical llama.cpp slot — carries no such marker, so slim whisper pairing
+    answered None and the prebuilt install failed with "no managed llama.cpp
+    prebuilt install", exactly as reported.
+
+    This fallback resolves the ACTIVE llama-server through the same
+    environment the runtime uses, runs ``--version`` for its tag, and returns
+    the directory holding the binary's sibling ggml libraries. The per-file
+    sonames and backend-module gates in slim_pairing_for_artifact still
+    verify everything this probe cannot promise; an unparseable version or a
+    binary-less tree simply keeps the old behavior.
+    """
+    try:
+        import shutil
+        import subprocess
+
+        binary = (
+            os.environ.get("LLAMA_SERVER_PATH")
+            or shutil.which("llama-server")
+        )
+        if not binary:
+            return None
+        proc = subprocess.run(
+            [binary, "--version"],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=20,
+        )
+        match = re.search(r"version:\s*(\d+)", (proc.stderr or "") + (proc.stdout or ""))
+        if not match:
+            return None
+        build = int(match.group(1))
+        if build <= 1:
+            # A source build with no git tags reports 1: unknown, not a tag.
+            return None
+        bin_dir = Path(binary).resolve().parent
+        if not bin_dir.is_dir():
+            return None
+        return bin_dir, f"b{build}", ""
+    except Exception as exc:
+        log(f"external_llama_runtime: probe failed: {exc}")
+        return None
+
+
 def slim_pairing_for_artifact(
     artifact: dict[str, Any], host: HostInfo, backend: str
 ) -> tuple[Path, str] | None:
@@ -419,6 +471,13 @@ def slim_pairing_for_artifact(
     then retries via CPU or reports the prebuilt unavailable."""
     asset = artifact.get("asset")
     runtime = installed_llama_runtime()
+    if runtime is None:
+        runtime = _external_llama_runtime_fallback()
+        if runtime is not None:
+            log(
+                f"slim_selection: {asset}: pairing with external llama.cpp at "
+                f"{runtime[0]} ({runtime[1]}) — not a managed prebuilt install"
+            )
     if runtime is None:
         log(f"slim_selection: {asset} skipped: no managed llama.cpp prebuilt install")
         return None

--- a/studio/install_whisper_prebuilt.py
+++ b/studio/install_whisper_prebuilt.py
@@ -433,19 +433,16 @@ def _external_llama_runtime_fallback() -> tuple[Path, str, str] | None:
         import shutil
         import subprocess
 
-        binary = (
-            os.environ.get("LLAMA_SERVER_PATH")
-            or shutil.which("llama-server")
-        )
+        binary = os.environ.get("LLAMA_SERVER_PATH") or shutil.which("llama-server")
         if not binary:
             return None
         proc = subprocess.run(
             [binary, "--version"],
-            capture_output=True,
-            text=True,
-            encoding="utf-8",
-            errors="replace",
-            timeout=20,
+            capture_output = True,
+            text = True,
+            encoding = "utf-8",
+            errors = "replace",
+            timeout = 20,
         )
         match = re.search(r"version:\s*(\d+)", (proc.stderr or "") + (proc.stdout or ""))
         if not match:

--- a/tests/studio/playwright_chat_ui.py
+++ b/tests/studio/playwright_chat_ui.py
@@ -186,7 +186,12 @@ def exercise_permission_mode_controls(page, shoot):
     page.route("**/api/chat/settings", refuse_settings_hydration)
     set_legacy_confirm(None)
     page.reload(wait_until = "domcontentloaded")
-    expect(pill).to_be_visible()
+    # Explicit timeout: this is the post-reload assertion, and the reloaded
+    # page stays silent until the backend's warm/self-heal settles on a busy
+    # runner. The 5s expect default turns that starvation into a flake; the
+    # page's own 60s budget matches what every other assertion here already
+    # uses via set_default_timeout (#9183).
+    expect(pill).to_be_visible(timeout = 60_000)
 
     # Fresh profiles default to Approve for me.
     expect_mode("Approve for me")

--- a/tests/studio/test_backend_ci_parallel_isolation.py
+++ b/tests/studio/test_backend_ci_parallel_isolation.py
@@ -151,8 +151,10 @@ BENIGN_TIMING = {
     # A 600-second expiry checked against the wall clock. Reading both sides of that gap
     # late by whole seconds still leaves it true, and it only reaches this scan at all
     # because the widened operand walk now reads `x > time.time()` as a bound.
-    ("test_openai_codex_subscription.py",
-     "test_account_claim_and_token_response_are_validated_without_returning_raw_body"),
+    (
+        "test_openai_codex_subscription.py",
+        "test_account_claim_and_token_response_are_validated_without_returning_raw_body",
+    ),
 }
 
 


### PR DESCRIPTION
Closes #9179.

## The failure, from the report's log

`--with-llama-cpp-dir` installs failed the whisper.cpp prebuilt step with:

```
slim_selection: ... skipped: no managed llama.cpp prebuilt install
slim bundle requires llama.cpp b10360-mix-87da1a2; install or update llama.cpp first
prebuilt install failed: no whisper.cpp prebuilt asset for linux-x64 (backend 'cuda')
```

## Root cause

Slim whisper bundles pair with the **installed llama.cpp runtime** via `installed_llama_runtime()`, which only recognizes a completed **managed** prebuilt install — `UNSLOTH_PREBUILT_INFO.json` under the managed root. A `--with-llama-cpp-dir` checkout is the user's own build, symlinked into the canonical `llama.cpp` slot the runtime already uses for inference; it carries no installer marker, so pairing answered `None` and the whisper install failed — even though a perfectly good ggml runtime was sitting right there.

## Fix

When the managed-install lookup misses, `slim_pairing_for_artifact` now falls back to probing the **active** llama-server (`LLAMA_SERVER_PATH`, else `PATH`), parsing its `--version` build tag, and returning the binary's directory as the runtime. Everything the probe cannot promise is still verified downstream by the existing per-file `requires_ggml_sonames` and backend-module gates; an unparseable version (source builds with no tags report `version: 1`) or a binary-less tree keeps the previous behavior.

## Tests

Five in `tests/test_whisper_slim_external_llama.py`, importing the real installer the same way `test_install_whisper_prebuilt_checksums.py` does:

1. the fallback parses a real `--version` line and returns `(dir, b-tag, profile)`;
2. `version: 1` (source build) is rejected as unknown;
3. no llama-server anywhere → `None`;
4. slim pairing **selects** through the fallback when no managed install exists, with the sonames present beside the probed binary;
5. with no runtime at all, the refusal is unchanged.

Both suites green locally (5/5 new + 12/12 existing checksums = 17/17).