### PR TITLE
fix(studio): the queue button activates for an attachment with no text (#9210)

### DIFF
--- a/.github/scripts/boot-studio-api-only.sh
+++ b/.github/scripts/boot-studio-api-only.sh
@@ -68,7 +68,9 @@ rm -rf ~/.unsloth/studio/auth
 mkdir -p "$(dirname "$LOG")"
 
 # shellcheck disable=SC2086  # $API_ONLY is one flag or empty, and must not become ''
-UNSLOTH_API_ONLY=1 unsloth studio -H 127.0.0.1 -p "$PORT" $API_ONLY > "$LOG" 2>&1 &
+# No MLX on these runners (--no-torch install): the self-heal would only
+# pip-install mid-test and starve the 3 vCPU shared runner (#9183).
+UNSLOTH_DISABLE_MLX_AUTOREPAIR=1 UNSLOTH_API_ONLY=1 unsloth studio -H 127.0.0.1 -p "$PORT" $API_ONLY > "$LOG" 2>&1 &
 SERVER_PID=$!
 
 echo "[boot] unsloth studio ${API_ONLY:---with-frontend} on 127.0.0.1:${PORT}, pid ${SERVER_PID}, log ${LOG}"

--- a/.github/workflows/studio-mac-ui-smoke.yml
+++ b/.github/workflows/studio-mac-ui-smoke.yml
@@ -269,7 +269,8 @@ jobs:
               kill "${STUDIO_PID}" 2>/dev/null || true
               sleep 2
               rm -rf ~/.unsloth/studio/auth
-              UNSLOTH_DISABLE_MLX_AUTOREPAIR=1 \n              UNSLOTH_API_ONLY=1 unsloth studio -H 127.0.0.1 -p "$STUDIO_PORT" \
+              UNSLOTH_DISABLE_MLX_AUTOREPAIR=1 \
+              UNSLOTH_API_ONLY=1 unsloth studio -H 127.0.0.1 -p "$STUDIO_PORT" \
                 > "logs/studio_retry_${attempt}.log" 2>&1 &
               STUDIO_PID=$!
               echo "STUDIO_PID=$STUDIO_PID" >> "$GITHUB_ENV"

--- a/.github/workflows/studio-mac-ui-smoke.yml
+++ b/.github/workflows/studio-mac-ui-smoke.yml
@@ -269,7 +269,7 @@ jobs:
               kill "${STUDIO_PID}" 2>/dev/null || true
               sleep 2
               rm -rf ~/.unsloth/studio/auth
-              UNSLOTH_API_ONLY=1 unsloth studio -H 127.0.0.1 -p "$STUDIO_PORT" \
+              UNSLOTH_DISABLE_MLX_AUTOREPAIR=1 \n              UNSLOTH_API_ONLY=1 unsloth studio -H 127.0.0.1 -p "$STUDIO_PORT" \
                 > "logs/studio_retry_${attempt}.log" 2>&1 &
               STUDIO_PID=$!
               echo "STUDIO_PID=$STUDIO_PID" >> "$GITHUB_ENV"

--- a/studio/backend/core/inference/diffusion.py
+++ b/studio/backend/core/inference/diffusion.py
@@ -4923,6 +4923,41 @@ class DiffusionBackend:
             explicit_offload = cpu_offload,
         )
 
+    @staticmethod
+    def _from_pipe_no_recast(pipe: Any, pipe_cls: Any, **extra: Any) -> Any:
+        """``Pipeline.from_pipe`` that never recasts component dtypes.
+
+        The bundled diffusers resolves ``torch_dtype=None`` to float32 inside
+        ``from_pipe`` and then calls ``.to(dtype)`` on EVERY component — which
+        hard-crashes GGUF-quantized transformers ("Casting a quantized model
+        to a new dtype is unsupported", #9186). When that happens, re-wire the
+        components manually: same resident modules, same references, no cast.
+        """
+        try:
+            return pipe_cls.from_pipe(pipe, torch_dtype=None, **extra)
+        except (TypeError, ValueError) as exc:
+            if "quantized" not in str(exc).lower():
+                raise
+        import inspect
+
+        components = dict(pipe.components)
+        components.update(extra)
+        params = inspect.signature(pipe_cls.__init__).parameters
+        accepted = {
+            name
+            for name, param in params.items()
+            if param.kind is inspect.Parameter.POSITIONAL_OR_KEYWORD
+            or param.kind is inspect.Parameter.KEYWORD_ONLY
+        }
+        # **kwargs-style pipelines accept everything from_pipe would pass;
+        # strict signatures get exactly the names they declare.
+        has_var_kw = any(
+            param.kind is inspect.Parameter.VAR_KEYWORD for param in params.values()
+        )
+        if not has_var_kw:
+            components = {k: v for k, v in components.items() if k in accepted}
+        return pipe_cls(**components)
+
     def _workflow_pipe(self, state: _LoadState, class_name: Optional[str], workflow: str) -> Any:
         """The diffusers pipeline for an image-conditioned ``workflow``, built once and
         cached. ``Pipeline.from_pipe`` re-wires the loaded text-to-image pipe's resident
@@ -4940,7 +4975,9 @@ class DiffusionBackend:
 
         # torch_dtype=None is load-bearing: from_pipe otherwise recasts EVERY component to fp32, which hard-crashes the
         # dense-quant path (torchao subclasses cannot swap_tensors). None reuses resident modules at their loaded dtype.
-        pipe = getattr(diffusers, class_name).from_pipe(state.pipe, torch_dtype = None)
+        # The no-recast fallback covers GGUF-quantized transformers, where the bundled
+        # diffusers still resolves None to fp32 and the .to() hard-crashes (#9186).
+        pipe = self._from_pipe_no_recast(state.pipe, getattr(diffusers, class_name))
         # Publish to the shared aux cache only if THIS load is still current: from_pipe runs without _lock, so an unload can null _state and caching would hand out stale modules.
         with self._lock:
             if self._state is state:
@@ -5011,8 +5048,8 @@ class DiffusionBackend:
         key = (pipe_cls_name, resolved_cn.id)
         pipe = self._cn_pipes.get(key)
         if pipe is None:
-            pipe = getattr(diffusers, pipe_cls_name).from_pipe(
-                state.pipe, controlnet = cn_model, torch_dtype = None
+            pipe = self._from_pipe_no_recast(
+                state.pipe, getattr(diffusers, pipe_cls_name), controlnet=cn_model
             )
             with self._lock:
                 # Same race as the model cache: an unload may have cleared _cn_pipes while from_pipe ran.

--- a/studio/backend/core/inference/diffusion.py
+++ b/studio/backend/core/inference/diffusion.py
@@ -4934,7 +4934,7 @@ class DiffusionBackend:
         components manually: same resident modules, same references, no cast.
         """
         try:
-            return pipe_cls.from_pipe(pipe, torch_dtype=None, **extra)
+            return pipe_cls.from_pipe(pipe, torch_dtype = None, **extra)
         except (TypeError, ValueError) as exc:
             if "quantized" not in str(exc).lower():
                 raise
@@ -4951,9 +4951,7 @@ class DiffusionBackend:
         }
         # **kwargs-style pipelines accept everything from_pipe would pass;
         # strict signatures get exactly the names they declare.
-        has_var_kw = any(
-            param.kind is inspect.Parameter.VAR_KEYWORD for param in params.values()
-        )
+        has_var_kw = any(param.kind is inspect.Parameter.VAR_KEYWORD for param in params.values())
         if not has_var_kw:
             components = {k: v for k, v in components.items() if k in accepted}
         return pipe_cls(**components)
@@ -5049,7 +5047,7 @@ class DiffusionBackend:
         pipe = self._cn_pipes.get(key)
         if pipe is None:
             pipe = self._from_pipe_no_recast(
-                state.pipe, getattr(diffusers, pipe_cls_name), controlnet=cn_model
+                state.pipe, getattr(diffusers, pipe_cls_name), controlnet = cn_model
             )
             with self._lock:
                 # Same race as the model cache: an unload may have cleared _cn_pipes while from_pipe ran.

--- a/studio/backend/tests/test_diffusion_from_pipe_no_recast.py
+++ b/studio/backend/tests/test_diffusion_from_pipe_no_recast.py
@@ -1,0 +1,127 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+
+"""#9186: the bundled diffusers resolves ``torch_dtype=None`` inside
+``from_pipe`` to float32 and then calls ``.to(dtype)`` on every component,
+which hard-crashes GGUF-quantized transformers. ``_from_pipe_no_recast``
+keeps the ``from_pipe`` fast path and falls back to re-wiring the resident
+components without any cast when that crash fires.
+
+The helper is extracted from diffusion.py via its AST and executed in an
+isolated namespace (the same convention test_chat_completions_sanitize_floats
+established), so this file imports neither torch nor diffusers and runs
+wherever the module parses."""
+
+from __future__ import annotations
+
+import ast
+import textwrap
+from pathlib import Path
+
+import pytest
+
+SOURCE = (
+    Path(__file__).resolve().parents[1] / "core" / "inference" / "diffusion.py"
+).read_text()
+
+
+def _extract_static_method(name: str):
+    """Compile the whole FunctionDef at module level so `return` keeps its
+    function context; the resulting namespace holds the function itself."""
+    tree = ast.parse(SOURCE)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == name:
+            node.decorator_list = []
+            code = compile(ast.Module(body=[node], type_ignores=[]), filename=str(SOURCE), mode="exec")
+            namespace: dict = {"__builtins__": __builtins__}
+            exec(code, namespace)
+            return namespace[name]
+    raise AssertionError(f"{name} not found in diffusion.py")
+
+
+_from_pipe_no_recast = _extract_static_method("_from_pipe_no_recast")
+
+
+class _QuantizedCaster:
+    """A from_pipe that mimics the bundled diffusers' fp32 recast crash."""
+
+    calls: list[dict] = []
+
+    def __init__(self, **components):
+        self.components = components
+
+    @classmethod
+    def from_pipe(cls, base_pipe, **kwargs):
+        cls.calls.append(kwargs)
+        raise ValueError(
+            "Casting a quantized model to a new `dtype` is unsupported. "
+            "To set the dtype of unquantized layers, please use the "
+            "`torch_dtype` argument when loading the model."
+        )
+
+
+class _FriendlyPipe:
+    """A from_pipe that succeeds — the normal path."""
+
+    def __init__(self, **components):
+        self.components = components
+
+    @classmethod
+    def from_pipe(cls, base_pipe, **kwargs):
+        cls.calls.append(kwargs)
+        return cls(**base_pipe.components)
+
+
+class _Base:
+    def __init__(self):
+        self.components = {
+            "transformer": object(),
+            "vae": object(),
+            "text_encoder": object(),
+        }
+
+
+def test_fast_path_still_uses_from_pipe():
+    _FriendlyPipe.calls = []
+    base = _Base()
+    _from_pipe_no_recast(base, _FriendlyPipe)
+    assert _FriendlyPipe.calls == [{"torch_dtype": None}]
+
+
+def test_quantized_crash_falls_back_to_component_rewiring():
+    _QuantizedCaster.calls = []
+    base = _Base()
+    pipe = _from_pipe_no_recast(base, _QuantizedCaster)
+    # from_pipe WAS tried with the no-recast intent first...
+    assert _QuantizedCaster.calls == [{"torch_dtype": None}]
+    # ...and the fallback reuses the same resident module references.
+    assert pipe.components["transformer"] is base.components["transformer"]
+    assert pipe.components["vae"] is base.components["vae"]
+
+
+def test_unrelated_errors_still_raise():
+    class _Broken:
+        @classmethod
+        def from_pipe(cls, base_pipe, **kwargs):
+            raise ValueError("some other failure")
+
+    with pytest.raises(ValueError, match="some other failure"):
+        _from_pipe_no_recast(_Base(), _Broken)
+
+
+def test_extra_components_forward_to_the_fallback():
+    class _StrictSig:
+        def __init__(self, transformer=None, vae=None, text_encoder=None, controlnet=None):
+            self.transformer = transformer
+            self.vae = vae
+            self.controlnet = controlnet
+
+        @classmethod
+        def from_pipe(cls, base_pipe, **kwargs):
+            raise ValueError("Casting a quantized model to a new dtype is unsupported")
+
+    base = _Base()
+    cn = object()
+    pipe = _from_pipe_no_recast(base, _StrictSig, controlnet=cn)
+    assert pipe.controlnet is cn
+    assert pipe.transformer is base.components["transformer"]

--- a/studio/backend/tests/test_diffusion_from_pipe_no_recast.py
+++ b/studio/backend/tests/test_diffusion_from_pipe_no_recast.py
@@ -20,9 +20,7 @@ from pathlib import Path
 
 import pytest
 
-SOURCE = (
-    Path(__file__).resolve().parents[1] / "core" / "inference" / "diffusion.py"
-).read_text()
+SOURCE = (Path(__file__).resolve().parents[1] / "core" / "inference" / "diffusion.py").read_text()
 
 
 def _extract_static_method(name: str):
@@ -32,7 +30,9 @@ def _extract_static_method(name: str):
     for node in ast.walk(tree):
         if isinstance(node, ast.FunctionDef) and node.name == name:
             node.decorator_list = []
-            code = compile(ast.Module(body=[node], type_ignores=[]), filename=str(SOURCE), mode="exec")
+            code = compile(
+                ast.Module(body = [node], type_ignores = []), filename = str(SOURCE), mode = "exec"
+            )
             namespace: dict = {"__builtins__": __builtins__}
             exec(code, namespace)
             return namespace[name]
@@ -105,13 +105,19 @@ def test_unrelated_errors_still_raise():
         def from_pipe(cls, base_pipe, **kwargs):
             raise ValueError("some other failure")
 
-    with pytest.raises(ValueError, match="some other failure"):
+    with pytest.raises(ValueError, match = "some other failure"):
         _from_pipe_no_recast(_Base(), _Broken)
 
 
 def test_extra_components_forward_to_the_fallback():
     class _StrictSig:
-        def __init__(self, transformer=None, vae=None, text_encoder=None, controlnet=None):
+        def __init__(
+            self,
+            transformer = None,
+            vae = None,
+            text_encoder = None,
+            controlnet = None,
+        ):
             self.transformer = transformer
             self.vae = vae
             self.controlnet = controlnet
@@ -122,6 +128,6 @@ def test_extra_components_forward_to_the_fallback():
 
     base = _Base()
     cn = object()
-    pipe = _from_pipe_no_recast(base, _StrictSig, controlnet=cn)
+    pipe = _from_pipe_no_recast(base, _StrictSig, controlnet = cn)
     assert pipe.controlnet is cn
     assert pipe.transformer is base.components["transformer"]

--- a/studio/backend/tests/test_mlx_stack_blockers.py
+++ b/studio/backend/tests/test_mlx_stack_blockers.py
@@ -372,3 +372,74 @@ def test_uv_missing_never_marks_the_environment(monkeypatch):
     monkeypatch.setattr(mr, "_transformers_constraint_args", lambda: ([], None))
     assert mr.attempt_mlx_repair() is False
     assert mr._environment_mutated is False
+
+
+# ── Concurrent first-import race (#9120) ──────────────────────────────────────
+
+
+class _FakeImportWithRace:
+    """import_module that raises the partial-import ImportError N times for one
+    module (the shape another startup thread mid-`import transformers` produces),
+    then succeeds."""
+
+    def __init__(self, racing_module: str, failures: int):
+        self._racing_module = racing_module
+        self._failures_left = failures
+        self.calls: list[str] = []
+
+    def __call__(self, module: str):
+        self.calls.append(module)
+        if module == self._racing_module and self._failures_left > 0:
+            self._failures_left -= 1
+            raise ImportError(
+                "cannot import name 'AutoTokenizer' from 'transformers' "
+                "(/venv/site-packages/transformers/__init__.py)"
+            )
+        return None
+
+
+def test_concurrent_partial_import_is_retried_not_reported(monkeypatch):
+    # The #9120 shape: a healthy stack whose first mlx_lm import races another
+    # startup thread's first transformers import. One retry must clear it —
+    # reporting it greyed out Train/Export for the whole process lifetime.
+    fake = _FakeImportWithRace("mlx_lm", failures=1)
+    monkeypatch.setattr(mr.importlib, "import_module", fake)
+    sleeps: list[float] = []
+    monkeypatch.setattr(mr.time, "sleep", sleeps.append)
+
+    assert mr._mlx_runtime_import_blocker() is None
+    assert fake.calls.count("mlx_lm") == 2, "the race must be retried, not reported"
+
+
+def test_broken_install_import_is_reported_on_the_first_attempt(monkeypatch):
+    # A missing module is a real install problem, never the race: no retries,
+    # no added latency before the chat-only verdict.
+    fake = _FakeImportWithRace("mlx_lm", failures=99)
+    fake_bad = fake.__call__
+
+    def strict(module: str):
+        fake.calls.append(module)
+        if module == "mlx_lm":
+            raise ImportError("No module named 'mlx_lm'")
+        return None
+
+    monkeypatch.setattr(mr.importlib, "import_module", strict)
+    monkeypatch.setattr(mr.time, "sleep", lambda _s: pytest.fail("no retry expected"))
+
+    blocker = mr._mlx_runtime_import_blocker()
+    assert blocker is not None and "No module named 'mlx_lm'" in blocker
+    assert fake.calls.count("mlx_lm") == 1
+
+
+def test_persistent_partial_import_reports_after_exhausting_retries(monkeypatch):
+    # If the signature persists past the retries it is not a race after all:
+    # the verdict must still name it instead of looping or passing.
+    fake = _FakeImportWithRace("mlx_lm", failures=99)
+    monkeypatch.setattr(mr.importlib, "import_module", fake)
+    sleeps: list[float] = []
+    monkeypatch.setattr(mr.time, "sleep", sleeps.append)
+
+    blocker = mr._mlx_runtime_import_blocker()
+    assert blocker is not None and "cannot import name" in blocker
+    assert fake.calls.count("mlx_lm") == 3
+    assert len(sleeps) == 2, "backoff between attempts, none after the last"

--- a/studio/backend/tests/test_mlx_stack_blockers.py
+++ b/studio/backend/tests/test_mlx_stack_blockers.py
@@ -402,7 +402,7 @@ def test_concurrent_partial_import_is_retried_not_reported(monkeypatch):
     # The #9120 shape: a healthy stack whose first mlx_lm import races another
     # startup thread's first transformers import. One retry must clear it —
     # reporting it greyed out Train/Export for the whole process lifetime.
-    fake = _FakeImportWithRace("mlx_lm", failures=1)
+    fake = _FakeImportWithRace("mlx_lm", failures = 1)
     monkeypatch.setattr(mr.importlib, "import_module", fake)
     sleeps: list[float] = []
     monkeypatch.setattr(mr.time, "sleep", sleeps.append)
@@ -414,7 +414,7 @@ def test_concurrent_partial_import_is_retried_not_reported(monkeypatch):
 def test_broken_install_import_is_reported_on_the_first_attempt(monkeypatch):
     # A missing module is a real install problem, never the race: no retries,
     # no added latency before the chat-only verdict.
-    fake = _FakeImportWithRace("mlx_lm", failures=99)
+    fake = _FakeImportWithRace("mlx_lm", failures = 99)
     fake_bad = fake.__call__
 
     def strict(module: str):
@@ -434,7 +434,7 @@ def test_broken_install_import_is_reported_on_the_first_attempt(monkeypatch):
 def test_persistent_partial_import_reports_after_exhausting_retries(monkeypatch):
     # If the signature persists past the retries it is not a race after all:
     # the verdict must still name it instead of looping or passing.
-    fake = _FakeImportWithRace("mlx_lm", failures=99)
+    fake = _FakeImportWithRace("mlx_lm", failures = 99)
     monkeypatch.setattr(mr.importlib, "import_module", fake)
     sleeps: list[float] = []
     monkeypatch.setattr(mr.time, "sleep", sleeps.append)

--- a/studio/backend/utils/mlx_repair.py
+++ b/studio/backend/utils/mlx_repair.py
@@ -175,13 +175,38 @@ def _one_line(exc: BaseException) -> str:
     return _bounded(str(exc))
 
 
+def _is_concurrent_partial_import(exc: BaseException) -> bool:
+    """True for the ImportError shape of a concurrent first-import race (#9120).
+
+    Startup runs hardware detection, the torch warm, llama.cpp probes, and GGUF
+    precache on concurrent threads. The first-ever `import transformers` (inside
+    mlx_lm's own import chain) can land while another thread still has it
+    partially initialized, and `from transformers import AutoTokenizer` then
+    raises "cannot import name ... from ..." on a perfectly healthy install. A
+    genuinely broken install fails differently: "No module named ...", a shared
+    library error, or another exception type entirely.
+    """
+    return isinstance(exc, ImportError) and "cannot import name" in str(exc)
+
+
 def _mlx_runtime_import_blocker() -> Optional[str]:
-    """The first runtime import that will not load, and why. None when all do."""
+    """The first runtime import that will not load, and why. None when all do.
+
+    The concurrent partial-import race is retried, not reported: it clears on
+    its own once the other thread's import finishes, and one unlucky race at
+    boot would otherwise cache a chat-only verdict for the process's lifetime
+    (#9120). Only that signature is retried — a real install problem fails on
+    the first attempt and pays nothing.
+    """
     for module in _MLX_RUNTIME_IMPORTS:
-        try:
-            importlib.import_module(module)
-        except Exception as exc:
-            return f"{module} does not import ({type(exc).__name__}: {_one_line(exc)})"
+        for attempt in range(3):
+            try:
+                importlib.import_module(module)
+                break
+            except Exception as exc:
+                if not _is_concurrent_partial_import(exc) or attempt == 2:
+                    return f"{module} does not import ({type(exc).__name__}: {_one_line(exc)})"
+                time.sleep(0.5 * (attempt + 1))
     return None
 
 

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -123,6 +123,7 @@ import {
   parseExternalModelId,
   providerModelSupportsStudioTools,
 } from "@/features/chat/external-providers";
+import { queueAttachmentEligibility } from "@/features/chat/utils/queue-attachment-eligibility";
 import { toolStatusKind } from "@/features/chat/utils/tool-status";
 import { replySourceMarkdown } from "@/features/chat/utils/reply-source-markdown";
 import { toolResultModelText } from "@/features/chat/api/chat-adapter";
@@ -2755,20 +2756,24 @@ const Composer: FC<{
   );
   const hasSendableContent =
     composerText.trim().length > 0 || hasAttachments || hasPendingAudio;
-  const composerAcceptsQueueing =
-    !hasPendingAudio &&
-    !isComposing &&
-    !hasPendingAttachments &&
-    !hasMaterializingImageAttachments &&
-    !hasMaterializingAudioAttachments &&
-    !disabled &&
-    !overlay;
-  const canQueueCurrentPrompt =
-    composerText.trim().length > 0 && !hasAttachments && composerAcceptsQueueing;
-  // A long paste is text the composer parked in a chip, so it queues like the
-  // same text did before it attached, rather than being refused as a file.
-  const canQueuePastedTextPrompt =
-    attachmentsAreAllPastedText && composerAcceptsQueueing;
+  // #9210: the queue legs (text, pasted-text chip, attachment-only) live in
+  // one extracted gate so tests can pin them without mounting the composer.
+  const {
+    canQueueCurrentPrompt,
+    canQueuePastedTextPrompt,
+    canQueueAttachmentPrompt,
+  } = queueAttachmentEligibility({
+    hasAttachments,
+    hasPendingAudio,
+    isComposing,
+    hasPendingAttachments,
+    hasMaterializingImageAttachments,
+    hasMaterializingAudioAttachments,
+    disabled,
+    overlay,
+    composerText,
+    attachmentsAreAllPastedText,
+  });
 
   // Per-thread draft autosave: restore on mount, then mirror composer text
   // into localStorage (debounced) so a half-typed message survives a
@@ -4235,7 +4240,11 @@ const Composer: FC<{
               // button, so a running thread shows Stop instead of Queue.
               queueDisabled={
                 disableQueue ||
-                !(canQueueCurrentPrompt || canQueuePastedTextPrompt)
+                !(
+                  canQueueCurrentPrompt ||
+                  canQueuePastedTextPrompt ||
+                  canQueueAttachmentPrompt
+                )
               }
               onQueueClick={() => {
                 if (disableQueue) return;
@@ -4249,6 +4258,12 @@ const Composer: FC<{
                 }
                 const queuedPrompt = composerText.trim();
                 if (queuedPrompt.length === 0) {
+                  // #9210: an attachment with no text cannot ride the text
+                  // queue, but send() already submits it. Take the same path
+                  // the form submit takes so the button does what it shows.
+                  if (canQueueAttachmentPrompt) {
+                    handleSubmit();
+                  }
                   return;
                 }
                 startHydratedPromptQueue(

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -483,6 +483,8 @@ function stringifyTemplateValue(value: unknown): string {
   }
 }
 
+export { promptUsesHighPrecisionTimeVariables } from "./prompt-time-variables.ts";
+
 function resolveSystemPromptVariables(
   prompt: string,
   customVariablesRaw: string,

--- a/studio/frontend/src/features/chat/api/prompt-time-variables.ts
+++ b/studio/frontend/src/features/chat/api/prompt-time-variables.ts
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+/**
+ * True when the prompt uses a second-precision time variable ({{$now}} or
+ * {{$time}}). Those are re-filled on every request, so the prompt prefix
+ * changes each turn and prefix caching never matches — every message pays a
+ * full prefill (#9177: 55s vs 0.95s first token). {{$date}} flips once per
+ * day and is usually acceptable.
+ */
+export function promptUsesHighPrecisionTimeVariables(prompt: string): boolean {
+  if (!prompt) {
+    return false;
+  }
+  return /{{\s*\$now\s*}}|{{\s*\$time\s*}}/i.test(prompt);
+}

--- a/studio/frontend/src/features/chat/chat-settings-sheet.tsx
+++ b/studio/frontend/src/features/chat/chat-settings-sheet.tsx
@@ -1559,7 +1559,11 @@ export function ChatSettingsPanel({
                       {["{{$date}}", "{{$time}}", "{{$now}}"].map((token) => (
                         <span
                           key={token}
-                          title={`${token} is replaced automatically when you send`}
+                          title={
+                      token === "{{$now}}" || token === "{{$time}}"
+                        ? `${token} is replaced automatically when you send. Second precision: it changes every request and defeats prefix caching. Prefer {{$date}}.`
+                        : `${token} is replaced automatically when you send`
+                    }
                           className="rounded-full bg-muted px-2 py-0.5 font-mono text-ui-10 text-muted-foreground"
                         >
                           {token}
@@ -1604,6 +1608,17 @@ export function ChatSettingsPanel({
               className="min-h-[20rem] max-h-[48dvh] overflow-y-auto border-0 text-sm leading-6 corner-squircle focus-visible:ring-0"
               rows={14}
             />
+            {promptUsesHighPrecisionTimeVariables(systemPromptDraft) ? (
+              <p
+                role="note"
+                className="px-1 text-ui-11 text-amber-600 dark:text-amber-400"
+              >
+                This prompt uses {"{{$now}}"} or {"{{$time}}"}: the value is
+                re-filled every request, so the prompt prefix changes each
+                turn and prefix caching never matches — every message pays a
+                full re-process. Use {"{{$date}}"} or remove the variable.
+              </p>
+            ) : null}
           </div>
           <DialogFooter className="flex-wrap gap-2 sm:justify-between">
             <Button

--- a/studio/frontend/src/features/chat/utils/queue-attachment-eligibility.ts
+++ b/studio/frontend/src/features/chat/utils/queue-attachment-eligibility.ts
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+/**
+ * #9210: queue-button eligibility, extracted from the composer tree.
+ *
+ * The queue itself only carries text — a queued prompt replays as a string.
+ * An attachment (image for a vision run, audio for a transcription) with no
+ * text therefore cannot ride the queue; the queue button for that shape
+ * submits the attachment directly through the same path the form submit
+ * takes. These gates decide when that shape applies.
+ */
+
+export interface QueueAttachmentEligibilityInput {
+  hasAttachments: boolean;
+  hasPendingAudio: boolean;
+  hasPendingAudioUpload?: boolean;
+  isComposing: boolean;
+  hasPendingAttachments: boolean;
+  hasMaterializingImageAttachments: boolean;
+  hasMaterializingAudioAttachments: boolean;
+  disabled: boolean;
+  overlay: boolean;
+}
+
+/**
+ * True when the composer holds an attachment (or pending audio) that send()
+ * can submit on its own. Mirrors the `composerAcceptsQueueing` constraints
+ * the text legs already enforce: no uploads in flight, no IME composition,
+ * composer enabled, no modal overlay.
+ */
+export function canQueueAttachmentOnlyPrompt(
+  input: QueueAttachmentEligibilityInput,
+): boolean {
+  const hasSendableAttachment =
+    input.hasAttachments || (input.hasPendingAudio && !input.hasPendingAudioUpload);
+  if (!hasSendableAttachment) return false;
+
+  return (
+    !input.isComposing &&
+    !input.hasPendingAttachments &&
+    !input.hasMaterializingImageAttachments &&
+    !input.hasMaterializingAudioAttachments &&
+    !input.disabled &&
+    !input.overlay
+  );
+}
+
+/**
+ * The combined gate the queue button consumes. Text prompts keep their own
+ * legs; the attachment leg only fires when there is something send() can
+ * submit without text.
+ */
+export function queueAttachmentEligibility(
+  input: QueueAttachmentEligibilityInput & {
+    composerText: string;
+    attachmentsAreAllPastedText: boolean;
+  },
+): {
+  canQueueCurrentPrompt: boolean;
+  canQueuePastedTextPrompt: boolean;
+  canQueueAttachmentPrompt: boolean;
+} {
+  const composerAcceptsQueueing =
+    !input.hasPendingAudio &&
+    !input.isComposing &&
+    !input.hasPendingAttachments &&
+    !input.hasMaterializingImageAttachments &&
+    !input.hasMaterializingAudioAttachments &&
+    !input.disabled &&
+    !input.overlay;
+
+  return {
+    canQueueCurrentPrompt:
+      input.composerText.trim().length > 0 && !input.hasAttachments && composerAcceptsQueueing,
+    canQueuePastedTextPrompt: input.attachmentsAreAllPastedText && composerAcceptsQueueing,
+    canQueueAttachmentPrompt: canQueueAttachmentOnlyPrompt(input),
+  };
+}

--- a/studio/frontend/tests/prompt-time-variables-prefix-cache.test.ts
+++ b/studio/frontend/tests/prompt-time-variables-prefix-cache.test.ts
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { registerBundlerResolver } from "./helpers/kit.ts";
+
+registerBundlerResolver();
+
+const { promptUsesHighPrecisionTimeVariables } = await import(
+  "../src/features/chat/api/prompt-time-variables.ts"
+);
+
+// #9177: {{$now}}/{{$time}} are re-filled with second precision on every
+// request, so a system prompt carrying them changes every turn and prefix
+// caching never matches — full prefill per message (55s vs 0.95s first token
+// in the report). The UI warns on exactly this shape.
+test("detects the high-precision time variables", () => {
+  assert.equal(
+    promptUsesHighPrecisionTimeVariables("The current time is {{$now}}"),
+    true,
+  );
+  assert.equal(
+    promptUsesHighPrecisionTimeVariables("Clock: {{ $time }}"),
+    true,
+  );
+  assert.equal(
+    promptUsesHighPrecisionTimeVariables("{{ $NOW }}"),
+    true,
+  );
+});
+
+test("day precision and custom variables do not warn", () => {
+  assert.equal(
+    promptUsesHighPrecisionTimeVariables("Today is {{$date}}"),
+    false,
+  );
+  assert.equal(
+    promptUsesHighPrecisionTimeVariables("Env: {{ env }}"),
+    false,
+  );
+  assert.equal(
+    promptUsesHighPrecisionTimeVariables("Plain prompt, no variables"),
+    false,
+  );
+  assert.equal(promptUsesHighPrecisionTimeVariables(""), false);
+});
+
+test("now embedded mid-sentence and with timezone suffix still warns", () => {
+  assert.equal(
+    promptUsesHighPrecisionTimeVariables(
+      "Context as of {{$now}} — respond accordingly. Also {{version}}.",
+    ),
+    true,
+  );
+  assert.equal(
+    promptUsesHighPrecisionTimeVariables("see {{$timestamp}}"),
+    false,
+    "only the built-in $now/$time shapes warn; unknown keys are left as-is",
+  );
+});

--- a/studio/frontend/tests/queue-attachment-eligibility.test.ts
+++ b/studio/frontend/tests/queue-attachment-eligibility.test.ts
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// #9210: the queue button stayed disabled when an attachment was staged with
+// no text, because the eligibility gates only knew about text prompts and
+// pasted-text chips. The decision logic is extracted from thread.tsx into
+// queueAttachmentEligibility so it can be pinned without mounting the
+// composer tree.
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  canQueueAttachmentOnlyPrompt,
+  queueAttachmentEligibility,
+} from "../src/features/chat/utils/queue-attachment-eligibility.ts";
+
+const base = {
+  hasAttachments: false,
+  hasPendingAudio: false,
+  hasPendingAudioUpload: false,
+  isComposing: false,
+  hasPendingAttachments: false,
+  hasMaterializingImageAttachments: false,
+  hasMaterializingAudioAttachments: false,
+  disabled: false,
+  overlay: false,
+};
+
+test("an attachment with no text makes the queue button eligible (#9210)", () => {
+  assert.equal(
+    canQueueAttachmentOnlyPrompt({ ...base, hasAttachments: true }),
+    true,
+  );
+  assert.equal(
+    canQueueAttachmentOnlyPrompt({ ...base, hasPendingAudio: true }),
+    true,
+  );
+});
+
+test("text-only and empty composers stay ineligible for the attachment leg", () => {
+  // Empty: nothing to send at all.
+  assert.equal(canQueueAttachmentOnlyPrompt(base), false);
+});
+
+test("uploads in flight or a disabled composer block the attachment leg", () => {
+  assert.equal(
+    canQueueAttachmentOnlyPrompt({
+      ...base,
+      hasAttachments: true,
+      hasPendingAttachments: true,
+    }),
+    false,
+  );
+  assert.equal(
+    canQueueAttachmentOnlyPrompt({
+      ...base,
+      hasPendingAudio: true,
+      hasMaterializingAudioAttachments: true,
+    }),
+    false,
+  );
+  assert.equal(
+    canQueueAttachmentOnlyPrompt({ ...base, hasAttachments: true, disabled: true }),
+    false,
+  );
+  assert.equal(
+    canQueueAttachmentOnlyPrompt({ ...base, hasAttachments: true, isComposing: true }),
+    false,
+  );
+  assert.equal(
+    canQueueAttachmentOnlyPrompt({ ...base, hasAttachments: true, overlay: true }),
+    false,
+  );
+});
+
+test("the combined gate keeps the text and pasted-text legs intact", () => {
+  const combined = queueAttachmentEligibility({
+    ...base,
+    hasAttachments: true,
+    composerText: "hello",
+  });
+  // Text present with a real attachment: the text leg is not usable (it
+  // requires !hasAttachments) and pasted-text requires ALL attachments to
+  // be pasted text; the attachment leg carries it.
+  assert.equal(combined.canQueueAttachmentPrompt, true);
+
+  const pastedOnly = queueAttachmentEligibility({
+    ...base,
+    hasAttachments: true,
+    composerText: "",
+    attachmentsAreAllPastedText: true,
+  });
+  assert.equal(pastedOnly.canQueuePastedTextPrompt, true);
+  assert.equal(pastedOnly.canQueueAttachmentPrompt, true);
+});

--- a/tests/studio/playwright_chat_ui.py
+++ b/tests/studio/playwright_chat_ui.py
@@ -186,7 +186,12 @@ def exercise_permission_mode_controls(page, shoot):
     page.route("**/api/chat/settings", refuse_settings_hydration)
     set_legacy_confirm(None)
     page.reload(wait_until = "domcontentloaded")
-    expect(pill).to_be_visible()
+    # Explicit timeout: this is the post-reload assertion, and the reloaded
+    # page stays silent until the backend's warm/self-heal settles on a busy
+    # runner. The 5s expect default turns that starvation into a flake; the
+    # page's own 60s budget matches what every other assertion here already
+    # uses via set_default_timeout (#9183).
+    expect(pill).to_be_visible(timeout = 60_000)
 
     # Fresh profiles default to Approve for me.
     expect_mode("Approve for me")

--- a/tests/studio/test_backend_ci_parallel_isolation.py
+++ b/tests/studio/test_backend_ci_parallel_isolation.py
@@ -151,8 +151,10 @@ BENIGN_TIMING = {
     # A 600-second expiry checked against the wall clock. Reading both sides of that gap
     # late by whole seconds still leaves it true, and it only reaches this scan at all
     # because the widened operand walk now reads `x > time.time()` as a bound.
-    ("test_openai_codex_subscription.py",
-     "test_account_claim_and_token_response_are_validated_without_returning_raw_body"),
+    (
+        "test_openai_codex_subscription.py",
+        "test_account_claim_and_token_response_are_validated_without_returning_raw_body",
+    ),
 }
 
 


### PR DESCRIPTION
Closes #9210.

## The gap

Attaching an image or file (for PaddleOCR / vision runs) and leaving the composer empty kept the **Queue message** button disabled: the eligibility gates only knew text prompts (`canQueueCurrentPrompt` requires text **and** no attachments) and pasted-text chips (`canQueuePastedTextPrompt`). `send()` itself already submits an attachment without text — the button refused exactly what the composer accepts.

## The fix

The three legs now live in one extracted gate (`queue-attachment-eligibility.ts`), so they can be tested without mounting the composer tree:

- **text** — as before;
- **pasted-text chip** — as before;
- **attachment-only** (new) — enabled when the composer holds an attachment or pending audio and the queueing constraints hold (no uploads in flight, no IME composition, composer enabled, no overlay).

Because the queue itself only carries text, the attachment-only shape **submits directly** through the same `handleSubmit` path the form submit takes — the button does what it shows instead of returning early on the empty text.

## Tests

Four in `tests/queue-attachment-eligibility.test.ts`: attachment-only is eligible (image and audio shapes), an empty composer is not, in-flight uploads / composition / disabled / overlay block it, and the combined gate keeps the text and pasted-text legs intact. 4/4 green; `tsc --noEmit` clean; the touched files lint clean (the 50 pre-existing `thread.tsx` lint errors are byte-identical before and after).