### PR TITLE
Fix the five ways main is red

### DIFF
--- a/studio/backend/tests/test_tp_vision_regression.py
+++ b/studio/backend/tests/test_tp_vision_regression.py
@@ -359,9 +359,36 @@ def test_tensor_split_abort_raises_early_to_layer_fallback():
     src = inspect.getsource(LlamaCppBackend.load_model)
     raise_idx = src.find("(split-axis geometry); retrying with layer split")
     assert raise_idx != -1, "the split-axis abort must raise to trigger a layer retry"
-    # raises before both the flash-attn-off retry and the text-only mmproj strip
-    assert raise_idx < src.find("_with_flash_attn_off")
-    assert raise_idx < src.find("_strip_mmproj_args(_last_spawn_cmd)")
+    # Raises before both the flash-attn-off retry and the text-only mmproj strip.
+    #
+    # Each landmark is required to exist before it is ordered. A bare
+    # `raise_idx < src.find(x)` reads as an ordering check but is really two
+    # claims, and it fails with "assert 249423 < -1" -- which says the ordering
+    # broke when what actually happened is that the landmark moved. This test
+    # went red on main that way when #9173 renamed the strip's argument from
+    # _last_spawn_cmd to _vision_gpu_cmd, a rename with no behavioural content:
+    # _vision_gpu_cmd is a snapshot of _last_spawn_cmd taken before the
+    # CPU-projector retry can mutate it, so the strip still reads the argv it
+    # always did.
+    #
+    # The strip is matched on the call, not on what is passed to it. What this
+    # test is about is that the abort raises BEFORE the projector is thrown
+    # away; which command the strip reads from is that code's own business.
+    #
+    # Wording adopted from #9189, which reached the same conclusion independently.
+    for label, needle in (
+        ("the flash-attn-off retry", "_with_flash_attn_off"),
+        ("the text-only mmproj strip", "_strip_mmproj_args("),
+    ):
+        idx = src.find(needle)
+        assert idx != -1, (
+            f"{label} is no longer in load_model, so the ordering below asserts "
+            f"nothing. If it moved, point this at where it moved to."
+        )
+        assert raise_idx < idx, (
+            f"the split-axis abort no longer raises before {label}, so the layer "
+            f"retry runs after the projector has already been discarded (#6659)"
+        )
     # gated on the marker-plus-crash helper, which also drives the record just above
     guard = src[max(0, raise_idx - 600) : raise_idx]
     assert "_should_record_tensor_split_abort" in guard

--- a/studio/frontend/smoke-heavy-thread-main.tsx
+++ b/studio/frontend/smoke-heavy-thread-main.tsx
@@ -63,10 +63,9 @@ import { createRoot } from "react-dom/client";
 import "./src/index.css";
 
 // The local runtime's thread list item reports a synthetic `__LOCALID_...` remoteId, which is
-// truthy, so the fork-count badge really does fire one GET per assistant message. Answering them
-// here, before anything mounts, keeps that off the wire entirely; answering them from the
-// Playwright side instead would put a round trip to another process inside a timed region, once
-// per assistant message.
+// truthy, so the fork-count subscription really does fire a GET for the thread. Answering it
+// here, before anything mounts, keeps that off the wire entirely; answering it from the
+// Playwright side instead would put a round trip to another process inside a timed region.
 // An explicit allowlist, never a blanket `/api/` match. A blanket match resolves EVERY request the
 // measured interactions make before Playwright emits it, so `stray_api_requests` stays at zero and
 // the fan-out this harness exists to detect becomes invisible to it. Narrowing it is what made the
@@ -76,11 +75,19 @@ import "./src/index.css";
 // returns, so no round trip lands inside a timed region. Anything NOT listed here goes to the
 // network and trips the stray counter, which is the point.
 const STUBBED_API: ReadonlyArray<readonly [RegExp, string]> = [
-  // One GET per assistant message: the synthetic `__LOCALID_...` remoteId is truthy, so the badge
-  // really does ask. `{ count: 0 }`, not `{}`: getForkCount returns `data.count`, and
-  // `undefined <= 0` is false, so an empty body renders a badge reading "undefined forks" on every
-  // assistant message and adds DOM in proportion to thread size, the axis being measured.
-  [/\/api\/chat\/threads\/[^/]+\/messages\/[^/]+\/forks$/, '{"count":0}'],
+  // One GET per thread, not per message: fork-count-store.ts holds a single subscription for the
+  // rendered thread and every badge reads from it, so the whole-thread endpoint is what fires.
+  // The synthetic `__LOCALID_...` remoteId is truthy, so it really does ask -- once while seeding,
+  // once after the delete's `notifyChatHistoryUpdated`, and once when the reopened thread
+  // resubscribes. This entry used to name the OLD per-message endpoint
+  // (`/threads/{id}/messages/{mid}/forks`), which nothing has called since fork counts were
+  // batched; the per-thread GET it was replaced by matched nothing here and went to the network,
+  // putting two round trips inside the measured actions.
+  //
+  // `{"counts":{}}`, not `{}`: that is the body the endpoint really returns, and the shape
+  // getThreadForkCounts parses. Every badge then reads 0 and renders nothing, so the fixture does
+  // not grow DOM in proportion to thread size, the axis being measured.
+  [/\/api\/chat\/threads\/[^/]+\/forks$/, '{"counts":{}}'],
   // The delete action's own persistence. deleteThreadMessage syncs the exported repository
   // whenever remoteId is truthy, which the synthetic id always is, so this is the fixture
   // maintaining itself rather than app fan-out. Left on the wire it is 3 round trips inside the

--- a/studio/frontend/src/features/chat/utils/image-input-support.ts
+++ b/studio/frontend/src/features/chat/utils/image-input-support.ts
@@ -4,7 +4,7 @@
 import type { ChatModelSummary } from "../types/runtime";
 
 import type { MmprojFallbackReason } from "../types/api";
-import { isTextOnlyMmprojFallback } from "./mmproj-fallback";
+import { isTextOnlyMmprojFallback } from "./mmproj-fallback.ts";
 
 function textOnlyMmprojUnavailableReason(
   activeModel: ChatModelSummary | undefined,

--- a/tests/studio/test_chat_autoload_failure_gate.py
+++ b/tests/studio/test_chat_autoload_failure_gate.py
@@ -182,6 +182,16 @@ async function prepareHfTokenForUse(token: any) {
   if (SCENARIO.tokenDecision === "anonymous") return { proceed: true, token: null };
   return { proceed: true, token };
 }
+// Imported by chat-adapter.ts from ../utils/mmproj-fallback, and called by
+// showAutoLoadSuccess whenever /load reports the vision projector was moved or
+// dropped. A marker rather than the real prose on purpose: the copy itself is
+// pinned by studio/frontend/tests/mmproj-fallback.test.ts, and duplicating it
+// here would only rot. What these scenarios need to prove is the wiring -- that
+// the toast description comes from this function, called with the reason the
+// backend actually reported.
+function mmprojFallbackMessage(reason: string) {
+  return `mmproj:${reason}`;
+}
 async function fetchGgufStagedMetadata(_req: any) {
   // camelCase, matching chat-api.ts: the call site reads `.isDiffusion`, so a
   // snake_case key here would be silently undefined.
@@ -235,7 +245,15 @@ const toast: any = Object.assign(
       if (opts?.action?.onClick) CANCEL_TOAST_ACTION = opts.action.onClick;
       return "toast-id";
     },
-    success: (msg: string) => EVENTS.push({ kind: "toast.success", msg }),
+    success: (msg: string, opts?: any) =>
+      EVENTS.push({ kind: "toast.success", msg, description: opts?.description }),
+    // A degraded load (no GPU, no vision projector) is a warning, not a
+    // success. Missing here it was a TypeError inside the sliced region, which
+    // the retry loop catches and scores as a failed load -- the same
+    // wrong-model failure mode the import check above exists to prevent, but
+    // for a member rather than a bare name, so that check cannot see it.
+    warning: (msg: string, opts?: any) =>
+      EVENTS.push({ kind: "toast.warning", msg, description: opts?.description }),
     error: (msg: string, opts?: any) =>
       EVENTS.push({ kind: "toast.error", msg, description: opts?.description }),
     dismiss: () => EVENTS.push({ kind: "toast.dismiss" }),
@@ -1451,6 +1469,50 @@ def test_a_legacy_gguf_row_without_model_format_loads_as_gguf():
     assert _loaded_paths(out) == [LOCAL_GGUF_PATH]
     remembered = [e for e in out["events"] if e["kind"] == "recordLastLocal"]
     assert remembered and remembered[0]["modelKind"] == "gguf", remembered
+
+
+# --- #9173: an auto-load that lost its vision projector says so ---
+
+
+@pytest.mark.parametrize(
+    "reason,suffix",
+    [
+        ("cpu_offload", "with vision on CPU"),
+        ("projector_incompatible", "without vision"),
+        ("projector_startup_failure", "without vision"),
+    ],
+)
+def test_an_mmproj_fallback_auto_load_warns_rather_than_reporting_a_plain_success(reason, suffix):
+    """A model that came back text-only, or with its projector on the CPU, is not
+    the model the user asked for. Reporting it as a plain success is how a
+    silently degraded load reaches the composer and the first image fails."""
+    out = _run(
+        "scenario({ localModels: [LOCAL_GGUF],"
+        f" load: (p) => ({{ ...LOADED(p), mmproj_fallback_reason: '{reason}' }}) }})"
+    )
+
+    assert _loaded_paths(out) == [LOCAL_GGUF_PATH]
+    assert out["result"]["loaded"] is True
+    assert _toasts(out, "toast.success") == []
+    [warning] = _toasts(out, "toast.warning")
+    assert warning["msg"].endswith(suffix), warning
+    # The reason reaches mmprojFallbackMessage unchanged: the whole point of the
+    # per-reason copy is that "moved to system memory" and "reload to restore
+    # image input" are different instructions.
+    assert warning["description"] == f"mmproj:{reason}", warning
+
+
+def test_an_undegraded_auto_load_is_still_a_plain_success():
+    """Control for the warnings above, so they cannot be met by warning on every
+    load: no fallback reason means no description and no warning."""
+    out = _run("scenario({ localModels: [LOCAL_GGUF] })")
+
+    assert _toasts(out, "toast.warning") == []
+    [success] = _toasts(out, "toast.success")
+    # `.get`, not `[...]`: JSON.stringify drops an undefined value entirely, so
+    # the absent key IS the "no description" the ordinary path is supposed to
+    # send.
+    assert success.get("description") is None, success
 
 
 @pytest.mark.parametrize("fmt", ["'unknown'", "undefined"])

--- a/tests/studio/test_heavy_thread_harness_contract.py
+++ b/tests/studio/test_heavy_thread_harness_contract.py
@@ -212,7 +212,7 @@ def test_the_fork_count_stub_matches_the_url_the_app_actually_requests() -> None
     # parseable zero. That is DOM in proportion to thread size, on the axis this harness measures.
     # getThreadForkCounts reads `data.counts`, so that is the key that has to be there.
     assert isinstance(json.loads(body).get("counts"), dict), (
-        "the fork-count stub must answer with the {\"counts\": {...}} body getThreadForkCounts "
+        'the fork-count stub must answer with the {"counts": {...}} body getThreadForkCounts '
         f"parses, so every badge reads a real zero. Got: {body!r}"
     )
 

--- a/tests/studio/test_heavy_thread_harness_contract.py
+++ b/tests/studio/test_heavy_thread_harness_contract.py
@@ -14,6 +14,8 @@ CDP counter and the Long Tasks API are Chromium-only, and the failure mode is si
 as "no measurement". So no growth axis and no pass/fail decision may rest on one.
 """
 
+import json
+import re
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -177,24 +179,41 @@ def test_the_smoke_page_is_served_and_owns_its_dev_server() -> None:
     assert "stop_process(vite)" in text
 
 
-def test_the_fork_count_stub_answers_with_a_real_zero() -> None:
-    # `getForkCount` returns `data.count`, and the badge's guard is `count <= 0`. `undefined <= 0`
-    # is false, so a `{}` body renders a badge reading "undefined forks from this message" on every
-    # assistant message. Measured at 25000 chars: 10 badges and 4031 DOM nodes with `{}`, 0 badges
-    # and 3981 with `{"count":0}`. That is DOM in proportion to thread size, on the axis this
-    # harness measures.
+def test_the_fork_count_stub_matches_the_url_the_app_actually_requests() -> None:
+    # Pinning the BODY alone is what let this rot. The entry used to name the per-message endpoint
+    # `/threads/{id}/messages/{mid}/forks`, and when fork counts were batched into one whole-thread
+    # GET the pattern stopped matching anything: the stub still looked present and correct, the new
+    # URL went to the network, and the harness failed with two stray requests inside its measured
+    # actions instead of failing here, in a browserless test that costs a second.
+    #
+    # So the check is the one that catches a rename: build the URL the app builds and require the
+    # allowlist pattern to match it. The JS regex source is reused verbatim -- `\/` is a valid
+    # escape for `/` in Python's `re` too.
+    api = (FRONTEND / "src/features/chat/api/chat-api.ts").read_text(encoding = "utf-8")
+    assert (
+        "`/api/chat/threads/${encodeURIComponent(threadId)}/forks`" in api
+    ), "getThreadForkCounts no longer requests /api/chat/threads/{id}/forks; update the stub too"
+    requested = "/api/chat/threads/__LOCALID_AbC123/forks"
+
     page = (FRONTEND / "smoke-heavy-thread-main.tsx").read_text(encoding = "utf-8")
     # Pin the fork-count entry to its own body rather than scanning the whole file: other
     # endpoints in the allowlist legitimately answer "{}", so a bare file-wide check for it
     # would fail on them and tell us nothing about this one.
-    forks = next(
-        (line for line in page.splitlines() if "forks$/" in line),
-        "",
+    entry = next((line for line in page.splitlines() if "/forks" in line and "[/" in line), "")
+    assert entry, "the fork-count endpoint is no longer in the stub allowlist"
+    pattern, body = re.fullmatch(r"\s*\[/(.+)/,\s*'(.+)'\],\s*", entry).groups()
+    assert re.search(pattern, requested), (
+        f"the fork-count stub pattern /{pattern}/ does not match {requested}, the URL "
+        "getThreadForkCounts requests, so that GET reaches the network inside a measured action"
     )
-    assert forks, "the fork-count endpoint is no longer in the stub allowlist"
-    assert '{"count":0}' in forks, (
-        "the fork-count stub must answer with a numeric count; an empty object makes the parsed "
-        f"count undefined and renders a badge on every assistant message. Got: {forks.strip()!r}"
+    # `undefined <= 0` is false, so a body the store cannot parse renders a badge reading
+    # "undefined forks from this message" on every assistant message. Measured at 25000 chars when
+    # the badge was per-message: 10 badges and 4031 DOM nodes with `{}`, 0 badges and 3981 with a
+    # parseable zero. That is DOM in proportion to thread size, on the axis this harness measures.
+    # getThreadForkCounts reads `data.counts`, so that is the key that has to be there.
+    assert isinstance(json.loads(body).get("counts"), dict), (
+        "the fork-count stub must answer with the {\"counts\": {...}} body getThreadForkCounts "
+        f"parses, so every badge reads a real zero. Got: {body!r}"
     )
 
 

--- a/tests/studio/test_heavy_thread_measurement_integrity.py
+++ b/tests/studio/test_heavy_thread_measurement_integrity.py
@@ -57,8 +57,24 @@ def _load_harness():
     this file calls. Stubbing it keeps these tests runnable in the CPU test job, where the
     Playwright package is not installed, rather than skipping the arithmetic along with the
     browser.
+
+    The stub is torn down again the moment that one import is done, and that is not tidiness.
+    `sys.modules` is process-wide, so a stub left in it is every later test's `playwright` too,
+    and it is a `playwright` that exists and is empty -- the worst of both answers. On the CPU
+    job that is exactly what happened: `pytest.importorskip("playwright")` in
+    test_playwright_server_lifecycle.py and test_autoscroll_harness_contract.py found a module,
+    stopped skipping, and the browser harnesses they then imported died on
+    `from playwright.sync_api import Page, expect, sync_playwright` with "cannot import name
+    'Page' from 'playwright.sync_api' (unknown location)" -- a ModuleType has no `__file__`,
+    which is where the "unknown location" comes from. The harnesses that import only
+    `sync_playwright` were worse than red: they imported clean against a fake and passed.
+
+    Whatever was there before is put back, rather than the keys being popped, so a partially
+    imported real playwright is not damaged either.
     """
     os.environ.setdefault("PW_ART_DIR", str(TEMP_ROOT / "artifacts"))
+    stubbed = False
+    saved = {name: sys.modules.get(name) for name in ("playwright", "playwright.sync_api")}
     if "playwright.sync_api" not in sys.modules:
         try:
             import playwright.sync_api  # noqa: F401
@@ -69,12 +85,39 @@ def _load_harness():
             package.sync_api = module
             sys.modules["playwright"] = package
             sys.modules["playwright.sync_api"] = module
-    import playwright_heavy_thread
+            stubbed = True
+    try:
+        # The names the harness binds at import time survive the teardown below: it is the
+        # module object that keeps them, not the sys.modules entry.
+        import playwright_heavy_thread
+    finally:
+        if stubbed:
+            for name, previous in saved.items():
+                if previous is None:
+                    sys.modules.pop(name, None)
+                else:
+                    sys.modules[name] = previous
 
     return playwright_heavy_thread
 
 
 HARNESS = _load_harness()
+
+
+def test_importing_this_file_leaves_no_playwright_stub_behind() -> None:
+    """The blast radius is the whole worker, so it is worth one test of its own.
+
+    A real `playwright.sync_api` is a file on disk and has a `__file__`; the stub above is a
+    bare ModuleType and has none. Anything sitting under that name without one is a fake that
+    outlived the import it was built for, and every `pytest.importorskip("playwright")` in the
+    suite will believe it.
+    """
+    for name in ("playwright", "playwright.sync_api"):
+        module = sys.modules.get(name)
+        assert module is None or getattr(module, "__file__", None) is not None, (
+            f"a stub {name} is still in sys.modules, so every later test in this worker sees a "
+            "playwright that exists and is empty"
+        )
 
 
 # ── the node side: the harness's own JS on a virtual clock ────────────

--- a/tests/studio/test_model_picker_contracts.py
+++ b/tests/studio/test_model_picker_contracts.py
@@ -170,10 +170,21 @@ def test_chat_autoload_toast_is_persistent_and_dismissible():
     # No description on the ordinary path. It stopped being the literal
     # `description: undefined` when the CPU-fallback branch was added, so pin the
     # branch and its undefined arm rather than one spelling of the old constant.
+    #
+    # `description: cpuFallbackReason` was still one spelling of the head of that
+    # chain, which is why this went red again when the mmproj text-only fallback
+    # added a branch ABOVE the CPU one -- a change to which degraded loads get a
+    # description, not to the contract this test exists to hold. What actually
+    # matters is unchanged and is what is asserted now: the description is
+    # conditional on a degraded-load reason, the CPU one is still among them, and
+    # the arm for a load with nothing wrong is `undefined`. Another reason can be
+    # added tomorrow without touching this.
     success_toast = auto_load.split("const showAutoLoadSuccess", 1)[1]
     success_toast = success_toast.split("};", 1)[0]
-    assert "description: cpuFallbackReason" in success_toast
-    assert ": undefined," in success_toast
+    assert "description:" in success_toast, success_toast
+    description = success_toast.split("description:", 1)[1].split("duration:", 1)[0]
+    assert "cpuFallbackReason" in description, description
+    assert description.rstrip().rstrip(",").endswith("undefined"), description
     assert "icon: undefined" in auto_load
     assert "duration: 5000" in auto_load
     assert "duration: 30000" not in auto_load


### PR DESCRIPTION
`main` is red in five distinct ways and every open PR is blocked behind it. This PR started as the one-line import fix and now carries all five, because fixing the first one is what made the rest visible.

The same four checks fail identically on #9051, #9058, #9062, #9068, #8935 and this branch. Failing on six independent branches is what says main-side rather than PR-side.

## The five failures

### 1. `Frontend build + bundle sanity` and `Frontend unit tests (Windows)`, at `Unit tests`

`npm test` is `node --experimental-strip-types --test`, so modules are resolved by node, not vite. Node's ESM resolver does not guess extensions. `src/features/chat/utils/image-input-support.ts` imported `./mmproj-fallback` without one, and `tests/queued-model-capabilities.test.ts` reaches it:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module
  '.../src/features/chat/utils/mmproj-fallback' imported from
  '.../src/features/chat/utils/image-input-support.ts'
```

Reproduced on a clean `origin/main` worktree: `pass 0, fail 1`. After: `pass 3781, fail 0`.

Nothing caught it at authoring time, and that is worth stating: the import is valid TypeScript, vite resolves it, typecheck and lint both pass.

**A judgement call worth recording.** `src/` has 2319 extensionless relative imports against 55 with `.ts`, and the test suite already has a sanctioned mechanism for this exact case, `registerBundlerResolver()`, used by 61 of its 392 test files. So extensionless is the convention here and the `.ts` extension is the minority style. #9189 fixes this by registering the resolver in the test instead, which is arguably the more idiomatic answer. I kept the one-line version because it is the smaller blast radius while `main` is red. That was a call about risk, not a verdict that the other approach is wrong, and a proper fix for the class is still worth doing. I would rather this be on the record than have someone later find 2319 extensionless imports and conclude we did not look.

### 2. `(Python 3.13)`: `test_tensor_split_abort_raises_early_to_layer_fallback`

```
assert raise_idx < src.find("_strip_mmproj_args(_last_spawn_cmd)")
E   AssertionError: assert 249423 < -1
```

**The test was stale, not the product.** #9173 renamed the strip's argument from `_last_spawn_cmd` to `_vision_gpu_cmd`. I checked the product side directly before touching the test: `_vision_gpu_cmd = list(_last_spawn_cmd)` is a snapshot taken *before* the CPU-projector retry can mutate it, so the strip still reads the argv it always did. Nothing was dropped, and the call is still there.

The anchor now matches the call rather than its argument, and each landmark must be found before it is ordered, so the next rename fails saying a landmark moved instead of `assert 249423 < -1`. Wording adopted from #9189, which reached this independently, as did #9192. Three-way agreement, nobody found a dropped call.

Before: 1 failed. After: 42 passed.

### 3. `Repo tests (CPU)`, three separate symptoms

**A.** `test_chat_autoload_failure_gate.py` names its own fix: the sliced region gained a `mmprojFallbackMessage` import with no stub behind it, so add one to `PREAMBLE`.

**B.** `assert "description: cpuFallbackReason" in success_toast` pinned the head of a conditional chain, and the mmproj fallback added a branch above the CPU one. That changes which degraded loads get a description, not the contract the test exists to hold. It now asserts the contract: description conditional on a degraded-load reason, CPU still among them, undefined for a load with nothing wrong. Product correct, test pinned too tightly.

**C.** `ImportError: cannot import name 'Page' from 'playwright.sync_api' (unknown location)`. **This one is pre-existing and unrelated to the mmproj merge** - it reproduces at `077593612^`. `_load_harness()` in `test_heavy_thread_measurement_integrity.py` builds a fake `playwright.sync_api` and left it in `sys.modules`, which is process-wide. `importorskip("playwright")` then found a module, declined to skip, and the real harness import died on `Page`. `(unknown location)` is the tell: a hand-built `ModuleType` has no `__file__`.

The two red tests are the smaller half. **Six false greens** were the larger one: harnesses importing only `sync_playwright` imported clean against the fake and passed while testing nothing. They now skip correctly. The stub is torn down after the one import it exists for, restoring whatever was there before rather than popping the keys, and a new test fails if a `__file__`-less stub is ever left behind again.

### 4. `Browser smoke for heavy-thread interaction cost` - masked behind failure 1

```
[heavy-thread] HARNESS-BROKEN chromium at 25000 chars let 2 /api/ requests reach
the network during the measured actions; the timings include a round trip per request
```

**This was masked on `main`.** The job aborts at `Unit tests`, which is failure 1, so it never reached this step. Fixing the import is what revealed it.

I identified the leaker by URL before changing anything: `/api/chat/threads/__LOCALID_G0w1QWF/forks`. The stub allowlist named the *old* per-message endpoint `/threads/{id}/messages/{mid}/forks`. Fork counts were since batched into one whole-thread GET, so the pattern matched nothing - the stub looked present and correct while the real request went to the network, inside the measured actions.

The request legitimately fires, so this is a stale allowlist entry rather than app fan-out, and the fix belongs in the harness, not the product. The guard that should have caught it pinned only the response body, which is why it rotted silently; it now builds the URL the app builds and requires the pattern to match, so the next rename fails in a browserless test that costs a second.

**The `HARNESS-BROKEN` guard itself is untouched.** It was right, and it exists to stop timings being reported that include network round trips.

Verified at the full CI configuration (`SMOKE_HEAVY_CHARS='25000,100000'`): before, exit 1 with `HARNESS-BROKEN`; after, exit 0, zero strays.

### 5. `Frontend unit tests (Windows)`

Failure 1 on another OS. That job's only test step is `npm test`. No separate cause.

## Verification

| check | result |
|---|---|
| `npm test` | 3781 passed, 0 failed |
| `npm run typecheck` | clean |
| `npm run build` | built |
| `test_tp_vision_regression.py` | 42 passed |
| heavy-thread smoke, `25000,100000` | exit 0, no `HARNESS-BROKEN` |
| `Repo tests (CPU)` | 0 failures under `tests/studio/` |

Two notes on honest gaps. `Repo tests (CPU)` shows 84 failures locally outside `tests/studio/`, and the full backend suite shows more; both reproduce identically on a clean `origin/main` and are local environment (bitsandbytes CUDA detection, missing `av`, `fastmcp`, `ddgs`, `sqlite_vec`). They are not related to these changes and I have not tried to fix them. `npx vitest run` reporting "No test suite found" for `node:test` files is a false red, not a failure.

## Relationship to the other open PRs

#9181 was byte-identical on the import and is closed as subsumed, with the reasoning recorded there.

#9200 stays open. Only its import hunk overlaps; it carries two unrelated flake fixes nothing else has, including a real bug where `test_orphan_cleanup_kills_under_real_root[psutil]` asked the real OS about an invented pid, so an unrelated process decided the assertion. I hit that failure independently. Its hunk is byte-identical to this one and git will resolve it.

#9189 overlaps on failures 1, 2 and 3 and is the better answer on failure 2, which I have taken. Its failure-3C fix does not work - `importorskip("playwright.sync_api")` finds the leaked stub and declines to skip, so the same two tests still fail on its branch (`2 failed, 104 passed` there against `98 passed, 9 skipped, 0 failed` here, same command, same environment). Detail and evidence are in a comment on that PR. It also improves failure 4's diagnostic by naming the offending endpoints, which is how I confirmed the leaker; that is worth landing whichever way the rest goes.
