### PR TITLE
fix(studio): verify TLS against the OS trust store on Linux too

### DIFF
--- a/studio/backend/routes/providers.py
+++ b/studio/backend/routes/providers.py
@@ -55,7 +55,7 @@ from models.providers import (
     ProviderUpdate,
 )
 from storage import credential_secrets, providers_db
-from utils.utils import safe_curated_detail, log_and_http_error
+from utils.utils import is_tls_verification_error, safe_curated_detail, log_and_http_error
 
 logger = structlog.get_logger(__name__)
 
@@ -560,6 +560,20 @@ async def test_provider(
             error = str(exc),
             exc_info = True,
         )
+        if is_tls_verification_error(exc):
+            # Constant text: the raw error names neither the cause nor a next step, and
+            # anything host-specific here would leak into the response. Never point at
+            # SSL_CERT_FILE -- it replaces the bundle rather than adding to it, so it
+            # trades this failure for a Hugging Face one.
+            return ProviderTestResult(
+                success = False,
+                message = (
+                    "Connection failed: the endpoint's TLS certificate could not be verified. "
+                    "If it uses a private or self-signed CA, install that CA in the operating "
+                    "system trust store and restart Unsloth."
+                ),
+                models_count = None,
+            )
         return ProviderTestResult(
             success = False,
             message = f"Connection failed: {safe_curated_detail(exc)}",

--- a/studio/backend/tests/test_native_tls.py
+++ b/studio/backend/tests/test_native_tls.py
@@ -46,7 +46,7 @@ def _fake_truststore(monkeypatch):
 
 @pytest.mark.parametrize(
     ("platform", "expected"),
-    [("darwin", True), ("win32", True), ("linux", False)],
+    [("darwin", True), ("win32", True), ("linux", True), ("freebsd14", False)],
 )
 def test_platform_defaults(monkeypatch, platform, expected):
     monkeypatch.setattr(sys, "platform", platform)
@@ -62,7 +62,9 @@ def test_env_opt_out_wins_on_default_on_platform(monkeypatch, value):
 
 @pytest.mark.parametrize("value", ["1", "true", "YES"])
 def test_env_opt_in_wins_on_default_off_platform(monkeypatch, value):
-    monkeypatch.setattr(sys, "platform", "linux")
+    # Every platform Studio ships on is default-on, so the opt-in path needs a
+    # platform that is not, or it stops being covered at all.
+    monkeypatch.setattr(sys, "platform", "freebsd14")
     monkeypatch.setenv("UNSLOTH_STUDIO_NATIVE_TLS", value)
     assert native_tls.native_tls_enabled() is True
 
@@ -115,7 +117,7 @@ def test_activate_mirrors_legacy_uv_override(monkeypatch):
 def test_disabled_does_not_touch_uv_env(monkeypatch):
     import os
 
-    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr(sys, "platform", "freebsd14")
     _fake_truststore(monkeypatch)
 
     assert native_tls.activate_native_tls() is False
@@ -123,8 +125,27 @@ def test_disabled_does_not_touch_uv_env(monkeypatch):
     assert "UV_NATIVE_TLS" not in os.environ
 
 
-def test_activate_noop_when_disabled(monkeypatch):
+def test_linux_injects_without_exporting_uv_env(monkeypatch):
+    """The one thing Linux deliberately does not inherit from the macOS default.
+
+    Python only gains anchors here: httpx and requests load certifi themselves. uv's
+    rustls does not -- UV_SYSTEM_CERTS moves it off its bundled webpki roots, so on a
+    host with no OS store it would break installs that work today. install.sh sets it
+    on macOS only; the runtime mirror stays there too.
+    """
+    import os
+
     monkeypatch.setattr(sys, "platform", "linux")
+    calls = _fake_truststore(monkeypatch)
+
+    assert native_tls.activate_native_tls() is True
+    assert calls == ["inject"]
+    assert "UV_SYSTEM_CERTS" not in os.environ
+    assert "UV_NATIVE_TLS" not in os.environ
+
+
+def test_activate_noop_when_disabled(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "freebsd14")
     calls = _fake_truststore(monkeypatch)
 
     assert native_tls.activate_native_tls() is False

--- a/studio/backend/tests/test_tls_verification_error.py
+++ b/studio/backend/tests/test_tls_verification_error.py
@@ -1,0 +1,135 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Recognising a failed certificate verification, and what we say about it.
+
+A provider behind a private CA fails deep in the transport: httpx re-raises
+httpcore's error, which re-raises ssl's, so the type that says "certificate" is two
+``__cause__`` hops below what the route catches. These pin the walk, and pin the
+reply as constant text -- the hint is returned instead of the exception string, so
+anything interpolated into it would be new disclosure on an error response.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+import ssl
+import sys
+
+import pytest
+
+_BACKEND = pathlib.Path(__file__).resolve().parents[1]
+if str(_BACKEND) not in sys.path:
+    sys.path.insert(0, str(_BACKEND))
+
+from utils.utils import is_tls_verification_error
+
+
+def _verify_error() -> ssl.SSLCertVerificationError:
+    return ssl.SSLCertVerificationError(
+        1, "[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get "
+        "local issuer certificate (_ssl.c:1032)"
+    )
+
+
+def _chain(*errors: BaseException) -> BaseException:
+    """Link errors outermost-first, the way `raise X from Y` nests them."""
+    for outer, inner in zip(errors, errors[1:]):
+        outer.__cause__ = inner
+    return errors[0]
+
+
+def test_the_bare_ssl_error_is_recognised():
+    assert is_tls_verification_error(_verify_error()) is True
+
+
+def test_the_transport_chain_is_walked():
+    """httpx.ConnectError -> httpcore.ConnectError -> ssl.SSLCertVerificationError."""
+    outer = _chain(OSError("[Errno 1] connect failed"), OSError("connect failed"), _verify_error())
+    assert is_tls_verification_error(outer) is True
+
+
+def test_an_implicit_context_chain_is_walked():
+    """A transport that re-raises inside `except` chains via __context__, not __cause__."""
+    outer = OSError("connect failed")
+    outer.__context__ = _verify_error()
+    assert is_tls_verification_error(outer) is True
+
+
+def test_a_cyclic_chain_terminates():
+    first, second = OSError("a"), OSError("b")
+    first.__cause__ = second
+    second.__cause__ = first
+    assert is_tls_verification_error(first) is False
+
+
+def test_text_is_the_fallback_when_a_transport_stops_chaining():
+    unchained = RuntimeError(
+        "All connection attempts failed: [SSL: CERTIFICATE_VERIFY_FAILED] certificate "
+        "verify failed"
+    )
+    assert is_tls_verification_error(unchained) is True
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        TimeoutError("timed out"),
+        OSError("[Errno 111] Connection refused"),
+        ValueError("Unknown provider type: nope"),
+    ],
+)
+def test_ordinary_failures_are_not_claimed_as_tls(error):
+    assert is_tls_verification_error(error) is False
+
+
+# ── The reply ────────────────────────────────────────────────────
+
+
+def _tls_branch_messages() -> list[ast.expr]:
+    """Every `message = ...` returned under `if is_tls_verification_error(...)`.
+
+    Source-level because the route needs an authenticated app, a provider config and a
+    live endpoint to reach this line, and the property under test is what the string
+    is made of.
+    """
+    tree = ast.parse((_BACKEND / "routes" / "providers.py").read_text(encoding = "utf-8"))
+    found = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.If):
+            continue
+        test = node.test
+        if not (
+            isinstance(test, ast.Call)
+            and getattr(test.func, "id", None) == "is_tls_verification_error"
+        ):
+            continue
+        for inner in ast.walk(node):
+            if isinstance(inner, ast.keyword) and inner.arg == "message":
+                found.append(inner.value)
+    return found
+
+
+def test_the_hint_is_reachable():
+    assert _tls_branch_messages(), "no TLS branch found in routes/providers.py"
+
+
+def test_the_hint_interpolates_nothing():
+    """Constant only: no exception text, no host, no path, nothing host-specific."""
+    for message in _tls_branch_messages():
+        assert isinstance(message, ast.Constant), (
+            "the TLS hint must stay a literal; an f-string or a call would put "
+            "host-specific text on an error response"
+        )
+
+
+def test_the_hint_does_not_send_users_to_ssl_cert_file():
+    """SSL_CERT_FILE replaces the bundle rather than adding to it.
+
+    Advising it trades a provider failure for a Hugging Face one, which is exactly the
+    dead end the original report walked into.
+    """
+    for message in _tls_branch_messages():
+        assert "SSL_CERT_FILE" not in message.value
+        assert "REQUESTS_CA_BUNDLE" not in message.value

--- a/studio/backend/tests/test_tls_verification_error.py
+++ b/studio/backend/tests/test_tls_verification_error.py
@@ -28,8 +28,9 @@ from utils.utils import is_tls_verification_error
 
 def _verify_error() -> ssl.SSLCertVerificationError:
     return ssl.SSLCertVerificationError(
-        1, "[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get "
-        "local issuer certificate (_ssl.c:1032)"
+        1,
+        "[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get "
+        "local issuer certificate (_ssl.c:1032)",
     )
 
 

--- a/studio/backend/utils/native_tls.py
+++ b/studio/backend/utils/native_tls.py
@@ -21,12 +21,19 @@ Studio user gains a package for a proxy they do not have; see the README there.
 Every consumer appends that directory to ``sys.path`` and imports the top-level
 name, which keeps a truststore the user installed themselves in front of ours.
 
-Defaults mirror install.sh: on for macOS and Windows, opt-in on Linux via
-``UNSLOTH_STUDIO_NATIVE_TLS=1`` (distro OpenSSL configurations vary), opt-out
-anywhere with ``0``. Explicit ``SSL_CERT_FILE``/``REQUESTS_CA_BUNDLE`` keep
-working, but become additive rather than exclusive, since truststore keeps the
-OS anchors alongside them; ``0`` is the way back to a bundle being the only
-trust root.
+On by default on macOS, Windows and Linux; opt in elsewhere with
+``UNSLOTH_STUDIO_NATIVE_TLS=1``, opt out anywhere with ``0``. Linux was opt-in while the "distro OpenSSL configurations vary" question was
+open; ``vendor/truststore/_openssl.py`` answers it with a per-distro candidate
+list, and the opt-in was unreachable anyway from a ``.deb``/AppImage launch that
+reads no shell profile. Injection is additive there: httpx and requests load
+certifi themselves and gain the OS anchors on top.
+
+``SSL_CERT_FILE``/``REQUESTS_CA_BUNDLE`` are *not* made additive by this on
+Linux. ``_configure_context`` resolves the OS store through
+``ssl.get_default_verify_paths()``, which honours those variables, so a bundle
+named in one of them becomes the only trust root -- certifi and the OS store
+included. On macOS/Windows they are additive, since those backends query the
+Keychain/CryptoAPI independently of OpenSSL's paths.
 
 Client side only: the injected class verifies a peer chain on every handshake,
 so an ``SSLContext`` built after activation cannot serve TLS. Studio serves
@@ -43,7 +50,13 @@ import sys
 from pathlib import Path
 
 _NATIVE_TLS_ENV = "UNSLOTH_STUDIO_NATIVE_TLS"
-_DEFAULT_ON_PLATFORMS = ("darwin", "win32")
+_DEFAULT_ON_PLATFORMS = ("darwin", "win32", "linux")
+# uv's rustls takes its own opt-in, and install.sh sets it on macOS only. Keep the
+# runtime mirror on the platforms that already had it: on a host whose OS store is
+# empty (a slim container without ca-certificates), exporting it moves uv off its
+# bundled webpki roots and turns a working install into a TLS error. Python pays no
+# such cost, which is why injection itself is not restricted this way.
+_UV_SYSTEM_CERTS_PLATFORMS = ("darwin", "win32")
 _TRUTHY = ("1", "true", "yes")
 _FALSEY = ("0", "false", "no")
 
@@ -116,8 +129,9 @@ def activate_native_tls() -> bool:
     # uv's rustls ignores in-process injection (uv >= 0.11 reads UV_SYSTEM_CERTS,
     # older reads UV_NATIVE_TLS). Mirror one value across both: uv takes either as
     # an opt-in, so an opt-out in one spelling must carry to the other.
-    os.environ.setdefault("UV_SYSTEM_CERTS", os.environ.get("UV_NATIVE_TLS", "1"))
-    os.environ.setdefault("UV_NATIVE_TLS", os.environ["UV_SYSTEM_CERTS"])
+    if sys.platform in _UV_SYSTEM_CERTS_PLATFORMS:
+        os.environ.setdefault("UV_SYSTEM_CERTS", os.environ.get("UV_NATIVE_TLS", "1"))
+        os.environ.setdefault("UV_NATIVE_TLS", os.environ["UV_SYSTEM_CERTS"])
     # append, not insert(0): a user-installed truststore must win over the vendored copy.
     if _VENDOR_DIR not in sys.path:
         sys.path.append(_VENDOR_DIR)
@@ -126,7 +140,10 @@ def activate_native_tls() -> bool:
         truststore.inject_into_ssl()
     except Exception as exc:  # noqa: BLE001
         # Warn, no traceback: a silent certifi fallback is what this exists to prevent.
-        _logger.warning("native TLS unavailable (%s); TLS keeps certifi defaults", exc)
+        # Below 3.10 there is nothing to warn about: the vendored truststore evaluates
+        # PEP 604 unions at import, so the failure is the interpreter, not the host.
+        log = _logger.debug if sys.version_info < (3, 10) else _logger.warning
+        log("native TLS unavailable (%s); TLS keeps certifi defaults", exc)
         return False
     _activated = True
     return True

--- a/studio/backend/utils/utils.py
+++ b/studio/backend/utils/utils.py
@@ -620,6 +620,26 @@ def safe_curated_detail(error: Exception, fallback: str = "An internal error occ
     return msg or fallback
 
 
+def is_tls_verification_error(error: BaseException) -> bool:
+    """True when ``error``, or anything it wraps, is a failed certificate verification.
+
+    httpx re-raises httpcore's error, which re-raises ssl's, so the type is two
+    ``__cause__`` hops down from what a caller catches. Type first, text second: the
+    string is the only signal left if a transport stops chaining, and OpenSSL's wording
+    is stable enough to fall back on.
+    """
+    import ssl
+
+    seen: set[int] = set()
+    current: Optional[BaseException] = error
+    while current is not None and id(current) not in seen:
+        if isinstance(current, ssl.SSLCertVerificationError):
+            return True
+        seen.add(id(current))
+        current = current.__cause__ or current.__context__
+    return "CERTIFICATE_VERIFY_FAILED" in str(error)
+
+
 def log_and_http_error(
     error: Exception,
     status_code: int,

--- a/studio/prebuilt_core.py
+++ b/studio/prebuilt_core.py
@@ -62,7 +62,7 @@ except ImportError:
 _TRUSTSTORE_VENDOR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "backend", "vendor")
 _flag = os.environ.get("UNSLOTH_STUDIO_NATIVE_TLS", "").strip().lower()
 if _flag in ("1", "true", "yes") or (
-    _flag not in ("0", "false", "no") and sys.platform in ("darwin", "win32")
+    _flag not in ("0", "false", "no") and sys.platform in ("darwin", "win32", "linux")
 ):
     try:
         if _TRUSTSTORE_VENDOR not in sys.path:


### PR DESCRIPTION
## The bug

Adding a provider whose TLS certificate is signed by a CA the OS trusts — a self-hosted LLM gateway, a corporate TLS-inspecting proxy — fails on Linux with `CERTIFICATE_VERIFY_FAILED`, both when pulling the model list and on the connectivity check.

`utils/native_tls.py` listed Linux as opt-in, so `activate_native_tls()` returned early at `main.py:185` and httpx kept certifi as its only anchor (it builds its default context as `create_default_context(cafile = certifi.where())`). The opt-in was unreachable exactly where it was needed: a `.deb`/AppImage launch reads no shell profile.

Both documented workarounds make it worse. `SSL_CERT_FILE` / `REQUESTS_CA_BUNDLE` *replace* the bundle rather than adding to it, so the private CA becomes the entire trust set and Hugging Face stops verifying. `UV_SYSTEM_CERTS` only reaches uv.

## Evidence

Two local CAs, two loopback HTTPS servers, this repo's vendored truststore 0.10.4, CA-A reachable through OpenSSL's default verify paths (what `/etc/ssl/certs` gives on Ubuntu), CA-B standing in for certifi's public roots:

| Client context | Server | Result |
|---|---|---|
| `cafile = certifi` (what httpx does today) | CA-A "gateway" | **FAIL** ← the bug |
| same + truststore injected | CA-A "gateway" | **PASS** ← the fix |
| same + truststore injected | CA-B "huggingface" | **PASS** ← additive, nothing lost |
| `cafile = private CA` (the `SSL_CERT_FILE` workaround) + injected | CA-B "huggingface" | **FAIL** ← workaround still breaks the Hub |
| bare `create_default_context()`, **no** injection | CA-A "gateway" | **PASS** ← OS paths already trusted today |

Re-run end to end against the patched `activate_native_tls()` on Ubuntu: fails before, passes after, still fails under `UNSLOTH_STUDIO_NATIVE_TLS=0`, and no `UV_SYSTEM_CERTS` appears in the environment.

## The change

**Linux joins `_DEFAULT_ON_PLATFORMS`.** `vendor/truststore/_openssl.py` carries the per-distro candidate list that the original "distro OpenSSL configurations vary" hedge in #8108 was waiting for, which is also why the uv-managed CPython in the `.deb`/AppImage resolves the store when its own OpenSSL defaults do not match the distro's. The gate paste in `prebuilt_core.py` moves with it, as `test_prebuilt_core_gate_matches_the_generated_source` requires.

**The uv export deliberately stays where `install.sh` puts it.** `activate_native_tls()` also sets `UV_SYSTEM_CERTS`/`UV_NATIVE_TLS`; on a host whose OS store is empty (a slim container without `ca-certificates`) that moves uv off its bundled webpki roots and turns a working install into a TLS error. Python pays no such cost, because httpx and requests load certifi themselves and only gain the OS anchors on top. So this PR changes exactly one thing on Linux — in-process Python trust — and a new test pins that scope limit. Extending uv to Linux can follow if anyone reports install-time proxy failures.

**A docstring correction.** It claimed `SSL_CERT_FILE` becomes "additive rather than exclusive" under truststore. True on macOS/Windows; false on Linux, where `_configure_context` resolves the store through `ssl.get_default_verify_paths()` — which honours that variable and loads only it. Row 4 above is that claim failing.

**`POST /providers/test` now says why.** It returned the raw `SSLCertVerificationError`, naming neither cause nor next step. It now returns constant text pointing at the OS trust store, via a `is_tls_verification_error()` helper that walks the `__cause__`/`__context__` chain (httpx re-raises httpcore's error, which re-raises ssl's, so the informative type is two hops down) with the OpenSSL wording as fallback.

## Why the security delta is zero

Not "acceptable" — zero, in capability terms:

1. **No new trust source.** A bare `ssl.create_default_context()` already loads OpenSSL's default paths on Linux, and Studio already ships one at `core/inference/tools.py` for the web-fetch tool (row 5). The change makes the certifi-loaded contexts agree with a store this process already trusts.
2. **No trust removed.** `vendor/truststore/_openssl.py` only ever *adds* to a context httpx and requests already filled with certifi — row 3 is the same context still verifying a public root.
3. **No unprivileged write path on Linux.** truststore's OpenSSL backend reads only OpenSSL's default paths (root-owned) and `SSL_CERT_FILE`/`SSL_CERT_DIR` from the environment, which belongs to the user already running Studio. It never reads a per-user NSS store, so unlike the macOS login Keychain and Windows `CurrentUser\Root` — both already default-on, both writable without admin — the only party who can add an anchor here is root, who can already overwrite certifi's PEM inside the venv, swap the interpreter, or read provider keys out of the SQLite DB.
4. **The new hint adds no dynamic content** to a response that already returned `safe_curated_detail(exc)`. A test asserts it stays a literal, and that it never advises `SSL_CERT_FILE`.

Stated plainly: an already-compromised OS store is now honoured for provider and Hub traffic (see 3), and `test_backend_serves_no_tls_in_process` must keep passing, since a future in-process HTTPS listener would now break on one more platform.

One unrelated nicety: below 3.10 the truststore import failure now logs at debug rather than warning — the vendored copy evaluates PEP 604 unions at import, so on 3.9 the failure is the interpreter, not the host, and there is nothing the user could act on.

## Not fixed here

`SSL_CERT_FILE` stays exclusive on Linux, so a CA that is *not* in the OS store still forces the all-or-nothing choice; node-based MCP stdio servers read only `NODE_EXTRA_CA_CERTS`; `hf_xet` is Rust and may honour none of it. Each wants an additive merged-bundle seam — larger, and worth its own discussion.

## Tests

`studio/backend/tests/test_native_tls.py` — Linux default-on; default-off coverage retargeted at a platform that still is (`freebsd14`) so the opt-in path does not go untested; **Linux exports no `UV_SYSTEM_CERTS`/`UV_NATIVE_TLS`**.

`studio/backend/tests/test_tls_verification_error.py` (new) — the chain walk (two-hop `__cause__`, `__context__`, cycle safety, text fallback, no false positives on ordinary failures), plus source-level assertions that the hint interpolates nothing and never names `SSL_CERT_FILE`.

Unchanged and green: `test_prebuilt_core_gate_matches_the_generated_source`, `test_backend_serves_no_tls_in_process`, `test_vendored_truststore.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
