### PR TITLE
Keep a sampler's std and uuid format across a save and reopen

### DIFF
--- a/studio/frontend/src/features/recipe-studio/utils/import/parsers/sampler-parser.ts
+++ b/studio/frontend/src/features/recipe-studio/utils/import/parsers/sampler-parser.ts
@@ -59,13 +59,21 @@ function parseCategoryConditionalParams(
   return Object.keys(conditional).length > 0 ? conditional : undefined;
 }
 
+// The words buildSamplerParams reads as a mode rather than as a prefix.
+const UUID_RESERVED_FORMATS = new Set(["uuid4", "short", "short_form", "upper", "uppercase"]);
+
 // buildSamplerParams spreads a uuid format over the three fields data_designer
 // defines, so rebuild the single UI string from those rather than from a
-// `format` key nothing writes.
+// `format` key nothing writes. A prefix whose own value is one of the reserved
+// words comes back in the builder's `prefix:` escaped form, so re-saving writes
+// the prefix again instead of turning it into a flag.
 function readUuidFormat(params: Record<string, unknown>): string {
-  const prefix = readString(params.prefix);
+  const prefix = readString(params.prefix)?.trim();
   if (prefix) {
-    return prefix;
+    const lowered = prefix.toLowerCase();
+    return UUID_RESERVED_FORMATS.has(lowered) || lowered.startsWith("prefix:")
+      ? `prefix:${prefix}`
+      : prefix;
   }
   if (params.short_form === true) {
     return "short";

--- a/studio/frontend/src/features/recipe-studio/utils/import/parsers/sampler-parser.ts
+++ b/studio/frontend/src/features/recipe-studio/utils/import/parsers/sampler-parser.ts
@@ -59,6 +59,23 @@ function parseCategoryConditionalParams(
   return Object.keys(conditional).length > 0 ? conditional : undefined;
 }
 
+// buildSamplerParams spreads a uuid format over the three fields data_designer
+// defines, so rebuild the single UI string from those rather than from a
+// `format` key nothing writes.
+function readUuidFormat(params: Record<string, unknown>): string {
+  const prefix = readString(params.prefix);
+  if (prefix) {
+    return prefix;
+  }
+  if (params.short_form === true) {
+    return "short";
+  }
+  if (params.uppercase === true) {
+    return "upper";
+  }
+  return readString(params.format) ?? "";
+}
+
 export function parseSampler(
   column: Record<string, unknown>,
   name: string,
@@ -155,7 +172,7 @@ export function parseSampler(
       // biome-ignore lint/style/useNamingConvention: api schema
       convert_to: normalizedConvertTo,
       mean: readNumberString(params.mean),
-      std: readNumberString(params.std),
+      std: readNumberString(params.stddev ?? params.std),
     };
   }
 
@@ -229,7 +246,7 @@ export function parseSampler(
       // biome-ignore lint/style/useNamingConvention: api schema
       convert_to: normalizedConvertTo,
       // biome-ignore lint/style/useNamingConvention: api schema
-      uuid_format: readString(params.format) ?? "",
+      uuid_format: readUuidFormat(params),
     };
   }
 

--- a/studio/frontend/tests/recipe-studio-sampler-round-trip.test.ts
+++ b/studio/frontend/tests/recipe-studio-sampler-round-trip.test.ts
@@ -73,6 +73,41 @@ test("a uuid sampler keeps its format across a save and reopen", () => {
   }
 });
 
+test("a uuid prefix survives even when its value is a reserved word", () => {
+  // buildSamplerParams reads "short" / "upper" / "uuid4" as modes, so a prefix whose
+  // own value is one of those has to come back escaped or the next save turns the
+  // prefix into a flag. Checked as payload stability over two save/reopen cycles,
+  // which is what a user actually does.
+  for (const uuidFormat of [
+    "MY-",
+    "short",
+    "upper",
+    "uuid4",
+    "prefix:short",
+    "prefix:upper",
+    "prefix:uuid4",
+    "prefix:prefix:x",
+    "",
+  ] as const) {
+    const config: SamplerConfig = {
+      id: "uuid-1",
+      kind: "sampler",
+      sampler_type: "uuid",
+      name: "row_id",
+      uuid_format: uuidFormat,
+    };
+    const firstSave = buildSamplerColumn(config, []);
+    const reopened = roundTrip(config);
+    const secondSave = buildSamplerColumn(reopened, []);
+
+    assert.deepEqual(
+      secondSave.params,
+      firstSave.params,
+      `uuid_format ${JSON.stringify(uuidFormat)} should re-save to the same params`,
+    );
+  }
+});
+
 test("a gaussian sampler still reads a hand-written std key", () => {
   const parseErrors: string[] = [];
   const parsed = parseSampler(

--- a/studio/frontend/tests/recipe-studio-sampler-round-trip.test.ts
+++ b/studio/frontend/tests/recipe-studio-sampler-round-trip.test.ts
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { registerBundlerResolver } from "./helpers/kit.ts";
+
+registerBundlerResolver();
+
+const { buildSamplerColumn } = await import(
+  "../src/features/recipe-studio/utils/payload/builders-sampler.ts"
+);
+const { parseSampler } = await import(
+  "../src/features/recipe-studio/utils/import/parsers/sampler-parser.ts"
+);
+
+type SamplerConfig = Parameters<typeof buildSamplerColumn>[0];
+
+// Saving writes the payload, reopening re-imports that same payload
+// (use-recipe-persistence re-imports the stored payload on load), so whatever
+// survives this is what the user still sees after a reopen.
+function roundTrip(config: SamplerConfig): SamplerConfig {
+  const buildErrors: string[] = [];
+  const column = buildSamplerColumn(config, buildErrors);
+  assert.deepEqual(buildErrors, [], "the config should build without errors");
+
+  const parseErrors: string[] = [];
+  const parsed = parseSampler(column, config.name, config.id, parseErrors);
+  assert.deepEqual(
+    parseErrors,
+    [],
+    "the built column should parse without errors",
+  );
+  assert.ok(parsed, "the built column should parse back to a sampler");
+  return parsed;
+}
+
+test("a gaussian sampler keeps its standard deviation across a save and reopen", () => {
+  const parsed = roundTrip({
+    id: "gaussian-1",
+    kind: "sampler",
+    sampler_type: "gaussian",
+    name: "score",
+    mean: "10",
+    std: "2.5",
+  });
+
+  assert.equal(parsed.mean, "10");
+  assert.equal(parsed.std, "2.5");
+});
+
+test("a uuid sampler keeps its format across a save and reopen", () => {
+  for (const [uuidFormat, expected] of [
+    ["MY-", "MY-"],
+    ["short", "short"],
+    ["upper", "upper"],
+    ["", ""],
+  ] as const) {
+    const parsed = roundTrip({
+      id: "uuid-1",
+      kind: "sampler",
+      sampler_type: "uuid",
+      name: "row_id",
+      uuid_format: uuidFormat,
+    });
+
+    assert.equal(
+      parsed.uuid_format,
+      expected,
+      `uuid_format ${uuidFormat} should survive`,
+    );
+  }
+});
+
+test("a gaussian sampler still reads a hand-written std key", () => {
+  const parseErrors: string[] = [];
+  const parsed = parseSampler(
+    {
+      column_type: "sampler",
+      sampler_type: "gaussian",
+      name: "score",
+      params: { mean: 1, std: 3 },
+    },
+    "score",
+    "gaussian-legacy",
+    parseErrors,
+  );
+
+  assert.deepEqual(parseErrors, []);
+  assert.equal(parsed?.std, "3");
+});


### PR DESCRIPTION
### Motivation

A Data Recipe loses two sampler settings on every save and reopen, silently, with no import error.

- **Gaussian:** set a standard deviation, save, reopen. The std box is blank and the node reports `Gaussian mean/std must be numbers.` Saving again writes `stddev: null`, which the Data Designer schema marks required on `GaussianSamplerParams`.
- **UUID:** type a format (a prefix like `MY-`, or `short`, or `upper`), save, reopen. The box is empty, and saving again writes the column back with empty `params`, so the generated column reverts to a plain uuid4.

### Root cause

The writer and the reader disagree on the key names.

`utils/payload/builders-sampler.ts` writes what the Data Designer API defines:

```ts
if (config.sampler_type === "gaussian") {
  return {
    mean: parseNumber(config.mean),
    // data_designer expects `stddev`
    stddev: parseNumber(config.std),
  };
}
```

and for uuid it spreads the single UI string over `prefix` / `short_form` / `uppercase`.

`utils/import/parsers/sampler-parser.ts` reads keys nothing produces:

```ts
std: readNumberString(params.std),          // params.std is never written
uuid_format: readString(params.format) ?? "",  // params.format is never written
```

A repo-wide grep shows `builders-sampler.ts` is the only writer of `stddev` and the parser is its only reader, so no other code path supplies `std` or `format`.

This is reached by the app's own reload path, not just by importing a foreign file: `hooks/use-recipe-persistence.ts` calls `importRecipePayload(JSON.stringify(initialPayload))` when a saved recipe is opened.

### Fix

Read the keys the builder and the API actually use, and keep the old spellings as a fallback so a hand-written config still loads:

- gaussian: `readNumberString(params.stddev ?? params.std)`
- uuid: rebuild the single UI string from `prefix` / `short_form` / `uppercase`, falling back to `params.format`. The spellings chosen (`short`, `upper`, and the bare prefix) are ones `buildSamplerParams` already round-trips, so a reopened recipe re-saves to the same payload.

### Tests

New `studio/frontend/tests/recipe-studio-sampler-round-trip.test.ts` drives the real round trip: `buildSamplerColumn` then `parseSampler`, which is what save-then-reopen does.

```
$ node --experimental-strip-types --test tests/recipe-studio-sampler-round-trip.test.ts

# before the fix
✖ a gaussian sampler keeps its standard deviation across a save and reopen
    '' !== '2.5'
✖ a uuid sampler keeps its format across a save and reopen
    '' !== 'MY-'
✔ a gaussian sampler still reads a hand-written std key
  pass 1  fail 2

# after the fix
✔ a gaussian sampler keeps its standard deviation across a save and reopen
✔ a uuid sampler keeps its format across a save and reopen
✔ a gaussian sampler still reads a hand-written std key
  pass 3  fail 0
```

Full frontend suite after `npm ci` in `studio/frontend`:

```
$ npm test
ℹ tests 3781
ℹ pass 3780
ℹ fail 1
```

The single failure is `tests/queued-model-capabilities.test.ts` (`Cannot find module .../chat/utils/mmproj-fallback`). It fails identically on a pristine tree with this change reverted, so it is pre-existing and unrelated.

```
$ npm run typecheck    # clean
$ npx biome check studio/frontend/tests/recipe-studio-sampler-round-trip.test.ts   # no errors
```

`biome check` on the parser reports the same two findings before and after the change (`useSimplifiedLogicExpression`, `noExcessiveCognitiveComplexity`, both pre-existing on lines this PR does not touch).
