### PR TITLE
Studio: stop regrouping the whole chat history on every sidebar refresh

### DIFF
--- a/studio/frontend/src/features/chat/hooks/sidebar-thread-groups.ts
+++ b/studio/frontend/src/features/chat/hooks/sidebar-thread-groups.ts
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// The sidebar's thread grouping, kept apart from useChatSidebarItems so it can be exercised
+// without dragging in chat storage, the runtime store and the artifact store. `groupThreads` is
+// unchanged and is still re-exported from ./use-chat-sidebar-items, which is where every existing
+// caller imports it from.
+
+import { useMemo } from "react";
+import type { ThreadRecord } from "../types";
+
+export interface SidebarItem {
+  type: "single" | "compare";
+  id: string;
+  /** The pane threads behind this row id; `runningByThreadId` is keyed per pane thread. */
+  threadIds?: string[];
+  title: string;
+  createdAt: number;
+  updatedAt: number;
+  isFork?: boolean;
+  projectId?: string | null;
+}
+
+function lastActivityAt(thread: ThreadRecord): number {
+  return thread.updatedAt ?? thread.createdAt;
+}
+
+export function groupThreads(
+  threads: ThreadRecord[],
+  archived = false,
+): SidebarItem[] {
+  const items: SidebarItem[] = [];
+  const pairItems = new Map<string, SidebarItem>();
+
+  for (const t of threads) {
+    // Coerce archived to a boolean before comparing. Legacy threads (from the
+    // older browser-only Unsloth, or any record predating the archived field)
+    // can have archived === undefined or null; a raw `!== archived` comparison
+    // would drop those from BOTH the Recents (archived=false) and Archived
+    // (archived=true) lists, hiding existing chats. Treat missing as false.
+    if (Boolean(t.archived) !== archived) {
+      continue;
+    }
+    if (t.pairId) {
+      const existing = pairItems.get(t.pairId);
+      if (existing) {
+        existing.createdAt = Math.max(existing.createdAt, t.createdAt);
+        existing.updatedAt = Math.max(existing.updatedAt, lastActivityAt(t));
+        existing.threadIds?.push(t.id);
+        continue;
+      }
+      const item: SidebarItem = {
+        type: "compare",
+        id: t.pairId,
+        threadIds: [t.id],
+        title: t.title,
+        createdAt: t.createdAt,
+        updatedAt: lastActivityAt(t),
+        projectId: t.projectId ?? null,
+      };
+      pairItems.set(t.pairId, item);
+      items.push(item);
+    } else if (!t.pairId) {
+      items.push({
+        type: "single",
+        id: t.id,
+        threadIds: [t.id],
+        title: t.title,
+        createdAt: t.createdAt,
+        updatedAt: lastActivityAt(t),
+        isFork: Boolean(t.forkedFromThreadId),
+        projectId: t.projectId ?? null,
+      });
+    }
+  }
+
+  return items.sort((a, b) => b.updatedAt - a.updatedAt);
+}
+
+/**
+ * Every ThreadRecord field `groupThreads` reads, and nothing else.
+ *
+ * This list is the memo key, so it has to stay exactly the input set of `groupThreads`. A field
+ * added here that groupThreads ignores only costs a wasted regroup; a field groupThreads starts
+ * reading that is NOT here would let a changed thread keep the previous grouping, i.e. stale rows
+ * in the rail. tests/sidebar-thread-groups-memo.test.ts pins that direction: it feeds records that
+ * differ in every OTHER field and asserts the grouping is genuinely identical whenever
+ * `sameSidebarThreads` says so.
+ */
+export const SIDEBAR_THREAD_FIELDS = [
+  "id",
+  "title",
+  "archived",
+  "pairId",
+  "projectId",
+  "createdAt",
+  "updatedAt",
+  "forkedFromThreadId",
+] as const satisfies readonly (keyof ThreadRecord)[];
+
+/**
+ * Do two thread lists group into the same sidebar rows?
+ *
+ * Compared position by position with Object.is over SIDEBAR_THREAD_FIELDS. Deliberately stricter
+ * than groupThreads itself, which only reads `archived` and `forkedFromThreadId` through
+ * Boolean(): undefined and false read as different here, which can only cost a regroup that was
+ * not needed, never skip one that was.
+ *
+ * Order matters and is not normalised away. groupThreads walks the list in order and its sort is
+ * not total when two threads share an updatedAt, so two differently ordered lists with the same
+ * members can legitimately group differently.
+ */
+export function sameSidebarThreads(
+  a: readonly ThreadRecord[],
+  b: readonly ThreadRecord[],
+): boolean {
+  if (a === b) return true;
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i += 1) {
+    const left = a[i] as ThreadRecord;
+    const right = b[i] as ThreadRecord;
+    if (left === right) continue;
+    for (const field of SIDEBAR_THREAD_FIELDS) {
+      if (!Object.is(left[field], right[field])) return false;
+    }
+  }
+  return true;
+}
+
+// One shared empty list, so a hook called with no threads yet does not hand a fresh [] to the
+// memo below on every render and defeat it.
+const NO_THREADS: ThreadRecord[] = [];
+
+/**
+ * The sidebar's two grouped lists, with a stable identity while the threads have not changed.
+ *
+ * Unmemoized, `groupThreads` allocated a fresh array of fresh objects on every render of every
+ * consumer, at O(N log N) each. That is its own cost, and it also broke every downstream useMemo
+ * in app-sidebar.tsx keyed on the result (recentChatItems, pinnedChatItems, chatsByProjectId,
+ * sidebarProjectRecords, sortedRecentChatItems, recentRowIds, runningChatCount), so one useState
+ * flip in AppSidebar re-ran two sorts and seven derivations over the whole history.
+ */
+export function useSidebarThreadGroups(threads: ThreadRecord[] | undefined): {
+  items: SidebarItem[];
+  archivedItems: SidebarItem[];
+} {
+  const source = threads ?? NO_THREADS;
+  const items = useMemo(() => groupThreads(source), [source]);
+  const archivedItems = useMemo(() => groupThreads(source, true), [source]);
+  return { items, archivedItems };
+}

--- a/studio/frontend/src/features/chat/hooks/use-chat-sidebar-items.ts
+++ b/studio/frontend/src/features/chat/hooks/use-chat-sidebar-items.ts
@@ -25,74 +25,16 @@ import {
 } from "../utils/chat-thread-tombstones";
 import { requestPromptQueueStop } from "../utils/prompt-queue-boundary";
 import { repairLegacyChatTitles } from "../utils/repair-legacy-chat-titles";
+import {
+  groupThreads,
+  sameSidebarThreads,
+  useSidebarThreadGroups,
+  type SidebarItem,
+} from "./sidebar-thread-groups";
 
-export interface SidebarItem {
-  type: "single" | "compare";
-  id: string;
-  /** The pane threads behind this row id; `runningByThreadId` is keyed per pane thread. */
-  threadIds?: string[];
-  title: string;
-  createdAt: number;
-  updatedAt: number;
-  isFork?: boolean;
-  projectId?: string | null;
-}
-
-function lastActivityAt(thread: ThreadRecord): number {
-  return thread.updatedAt ?? thread.createdAt;
-}
-
-export function groupThreads(
-  threads: ThreadRecord[],
-  archived = false,
-): SidebarItem[] {
-  const items: SidebarItem[] = [];
-  const pairItems = new Map<string, SidebarItem>();
-
-  for (const t of threads) {
-    // Coerce archived to a boolean before comparing. Legacy threads (from the
-    // older browser-only Unsloth, or any record predating the archived field)
-    // can have archived === undefined or null; a raw `!== archived` comparison
-    // would drop those from BOTH the Recents (archived=false) and Archived
-    // (archived=true) lists, hiding existing chats. Treat missing as false.
-    if (Boolean(t.archived) !== archived) {
-      continue;
-    }
-    if (t.pairId) {
-      const existing = pairItems.get(t.pairId);
-      if (existing) {
-        existing.createdAt = Math.max(existing.createdAt, t.createdAt);
-        existing.updatedAt = Math.max(existing.updatedAt, lastActivityAt(t));
-        existing.threadIds?.push(t.id);
-        continue;
-      }
-      const item: SidebarItem = {
-        type: "compare",
-        id: t.pairId,
-        threadIds: [t.id],
-        title: t.title,
-        createdAt: t.createdAt,
-        updatedAt: lastActivityAt(t),
-        projectId: t.projectId ?? null,
-      };
-      pairItems.set(t.pairId, item);
-      items.push(item);
-    } else if (!t.pairId) {
-      items.push({
-        type: "single",
-        id: t.id,
-        threadIds: [t.id],
-        title: t.title,
-        createdAt: t.createdAt,
-        updatedAt: lastActivityAt(t),
-        isFork: Boolean(t.forkedFromThreadId),
-        projectId: t.projectId ?? null,
-      });
-    }
-  }
-
-  return items.sort((a, b) => b.updatedAt - a.updatedAt);
-}
+// Re-exported, not moved: every caller in the tree imports these from here.
+export { groupThreads } from "./sidebar-thread-groups";
+export type { SidebarItem } from "./sidebar-thread-groups";
 
 // Streaming fires CHAT_HISTORY_UPDATED_EVENT per chunk. Debounce so each quiet
 // window produces at most one O(N) fetch; requestSeq discards stale responses.
@@ -131,7 +73,15 @@ export function useChatSidebarItems(options?: {
         // Discard the response if a newer request was scheduled while we
         // were in flight, or if the effect was torn down.
         if (cancelled || seq !== requestSeq) return;
-        setAllThreads(threads);
+        // Keep the previous array when the refetch changed nothing the sidebar
+        // reads. Every CHAT_HISTORY_UPDATED_EVENT refetches the WHOLE list and
+        // streaming fires that event per chunk, so without this a quiet refresh
+        // handed React a brand new array, re-rendered the rail and regrouped
+        // the entire history for no visible difference. Object.is on the state
+        // makes an unchanged refresh a genuine no-op instead.
+        setAllThreads((previous) =>
+          sameSidebarThreads(previous, threads) ? previous : threads,
+        );
         setLoaded(true);
         // Pre-cut legacy titles cannot grow with the sidebar. The repair reads
         // its own messages, as late as it can, not this list's.
@@ -165,8 +115,7 @@ export function useChatSidebarItems(options?: {
     };
   }, [enabled, options?.projectId, requireMessages]);
 
-  const items = groupThreads(allThreads ?? []);
-  const archivedItems = groupThreads(allThreads ?? [], true);
+  const { items, archivedItems } = useSidebarThreadGroups(allThreads);
   const canCompare = useChatRuntimeStore((s) => Boolean(s.params.checkpoint));
 
   return { items, archivedItems, canCompare, loaded };

--- a/studio/frontend/tests/sidebar-thread-groups-memo.test.ts
+++ b/studio/frontend/tests/sidebar-thread-groups-memo.test.ts
@@ -349,6 +349,40 @@ test("useSidebarThreadGroups regroups when the threads actually change", () => {
   );
 });
 
+test("useSidebarThreadGroups regroups on an edit that leaves the list the same length", () => {
+  // A rename, an archive and a bumped activity time all keep the count identical. A memo keyed on
+  // anything as coarse as the length would serve the old rows here and the rail would lie.
+  const runner = createHookRunner(useSidebarThreadGroups);
+  const before = [thread({ id: "a", title: "old name" }), thread({ id: "b" })];
+  const renamed = [
+    thread({ id: "a", title: "new name" }),
+    thread({ id: "b" }),
+  ];
+  const archived = [
+    thread({ id: "a", title: "new name" }),
+    thread({ id: "b", archived: true }),
+  ];
+  const first = runner.render(before);
+  const second = runner.render(renamed);
+  const third = runner.render(archived);
+
+  assert.notEqual(first.items, second.items);
+  assert.equal(
+    second.items.find((item) => item.id === "a")?.title,
+    "new name",
+    "a renamed chat kept its old title in the rail",
+  );
+  assert.notEqual(second.items, third.items);
+  assert.deepEqual(
+    third.items.map((item) => item.id),
+    ["a"],
+  );
+  assert.deepEqual(
+    third.archivedItems.map((item) => item.id),
+    ["b"],
+  );
+});
+
 test("useSidebarThreadGroups does not conflate the archived list with the live one", () => {
   const runner = createHookRunner(useSidebarThreadGroups);
   const threads = [

--- a/studio/frontend/tests/sidebar-thread-groups-memo.test.ts
+++ b/studio/frontend/tests/sidebar-thread-groups-memo.test.ts
@@ -1,0 +1,408 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// The sidebar's chat rows are derived from the whole thread list by groupThreads, which sorts and
+// allocates a fresh array of fresh objects. Unmemoized that ran on every render of every consumer,
+// and because the identity changed each time it also broke every downstream useMemo in
+// app-sidebar.tsx that is keyed on the result. These tests pin the two halves of the fix:
+//
+//   1. the grouping itself is unchanged (it moved file, so every branch of it is re-pinned here),
+//   2. the derived lists keep a STABLE IDENTITY while the threads have not changed, and a FRESH
+//      identity the moment they have. Only asserting the first half would bless a stale rail.
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+import React from "react";
+
+import {
+  SIDEBAR_THREAD_FIELDS,
+  groupThreads,
+  sameSidebarThreads,
+  useSidebarThreadGroups,
+} from "../src/features/chat/hooks/sidebar-thread-groups.ts";
+import type { ThreadRecord } from "../src/features/chat/types.ts";
+
+// ── a minimal hook runner ────────────────────────────────────────────────────
+//
+// There is no DOM and no renderer in this test suite, so hooks are driven through React's own
+// dispatcher slot: React.useMemo resolves the dispatcher on every call, so installing one here
+// runs the REAL React entry point against hook slots this file owns. Deps are compared the way
+// React compares them (Object.is, elementwise), so a hook that memoizes on a value it rebuilds
+// every render fails here exactly as it would in the browser.
+
+interface MemoSlot {
+  deps: unknown[] | undefined;
+  value: unknown;
+}
+
+const reactInternals = (
+  React as unknown as {
+    __CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE?: {
+      H: unknown;
+    };
+  }
+).__CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE;
+
+function depsEqual(
+  previous: unknown[] | undefined,
+  next: unknown[] | undefined,
+): boolean {
+  if (previous === undefined || next === undefined) return false;
+  if (previous.length !== next.length) return false;
+  for (let i = 0; i < previous.length; i += 1) {
+    if (!Object.is(previous[i], next[i])) return false;
+  }
+  return true;
+}
+
+function createHookRunner<A, R>(hook: (arg: A) => R) {
+  const slots: MemoSlot[] = [];
+  let cursor = 0;
+  let memoCalls = 0;
+  const dispatcher = {
+    useMemo<T>(create: () => T, deps: unknown[] | undefined): T {
+      memoCalls += 1;
+      const slot = slots[cursor];
+      if (slot && depsEqual(slot.deps, deps)) {
+        cursor += 1;
+        return slot.value as T;
+      }
+      const value = create();
+      slots[cursor] = { deps, value };
+      cursor += 1;
+      return value;
+    },
+  };
+  return {
+    render(arg: A): R {
+      // Missing internals is a hard failure, never a skip: a runner that silently stopped driving
+      // React would let every identity assertion below pass without testing anything.
+      assert.ok(
+        reactInternals,
+        "React client internals are missing; the hook runner cannot drive useMemo",
+      );
+      cursor = 0;
+      const previous = reactInternals.H;
+      reactInternals.H = dispatcher;
+      try {
+        return hook(arg);
+      } finally {
+        reactInternals.H = previous;
+      }
+    },
+    memoCalls: () => memoCalls,
+  };
+}
+
+// ── fixtures ─────────────────────────────────────────────────────────────────
+
+const EPOCH = 1_700_000_000_000;
+
+function thread(overrides: Partial<ThreadRecord> & { id: string }): ThreadRecord {
+  return {
+    title: `chat ${overrides.id}`,
+    modelType: "base",
+    archived: false,
+    createdAt: EPOCH,
+    updatedAt: EPOCH,
+    ...overrides,
+  } as ThreadRecord;
+}
+
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a = (a + 0x6d2b79f5) >>> 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+// ── 1. the grouping is unchanged ─────────────────────────────────────────────
+
+test("groupThreads on an empty history returns empty lists for both flags", () => {
+  assert.deepEqual(groupThreads([]), []);
+  assert.deepEqual(groupThreads([], true), []);
+});
+
+test("groupThreads treats a legacy record with no archived field as not archived", () => {
+  const legacy = [
+    thread({ id: "no-field" }),
+    thread({ id: "explicit-false", archived: false }),
+    thread({ id: "explicit-true", archived: true }),
+  ];
+  // Legacy rows predating the archived column: undefined and null, not false.
+  delete (legacy[0] as { archived?: boolean }).archived;
+  (legacy[1] as { archived: unknown }).archived = null;
+
+  assert.deepEqual(
+    groupThreads(legacy).map((item) => item.id).sort(),
+    ["explicit-false", "no-field"],
+  );
+  assert.deepEqual(
+    groupThreads(legacy, true).map((item) => item.id),
+    ["explicit-true"],
+  );
+});
+
+test("groupThreads collapses a compare pair into one row keyed by pairId", () => {
+  const items = groupThreads([
+    thread({ id: "left", pairId: "pair-1", createdAt: EPOCH, updatedAt: EPOCH }),
+    thread({
+      id: "right",
+      pairId: "pair-1",
+      createdAt: EPOCH + 10,
+      updatedAt: EPOCH + 20,
+    }),
+  ]);
+  assert.equal(items.length, 1);
+  assert.equal(items[0]?.type, "compare");
+  assert.equal(items[0]?.id, "pair-1");
+  assert.deepEqual(items[0]?.threadIds, ["left", "right"]);
+  assert.equal(items[0]?.createdAt, EPOCH + 10);
+  assert.equal(items[0]?.updatedAt, EPOCH + 20);
+});
+
+test("groupThreads sorts newest activity first and falls back to createdAt", () => {
+  const withoutUpdatedAt = thread({ id: "middle", createdAt: EPOCH + 50 });
+  delete (withoutUpdatedAt as { updatedAt?: number }).updatedAt;
+  const items = groupThreads([
+    thread({ id: "oldest", createdAt: EPOCH, updatedAt: EPOCH }),
+    withoutUpdatedAt,
+    thread({ id: "newest", createdAt: EPOCH, updatedAt: EPOCH + 100 }),
+  ]);
+  assert.deepEqual(
+    items.map((item) => item.id),
+    ["newest", "middle", "oldest"],
+  );
+  assert.equal(items[1]?.updatedAt, EPOCH + 50);
+});
+
+test("groupThreads carries the fork flag and the project id onto single rows", () => {
+  const items = groupThreads([
+    thread({ id: "forked", forkedFromThreadId: "parent", projectId: "proj-1" }),
+    thread({ id: "plain" }),
+  ]);
+  const forked = items.find((item) => item.id === "forked");
+  const plain = items.find((item) => item.id === "plain");
+  assert.equal(forked?.isFork, true);
+  assert.equal(forked?.projectId, "proj-1");
+  assert.equal(plain?.isFork, false);
+  assert.equal(plain?.projectId, null);
+  assert.deepEqual(plain?.threadIds, ["plain"]);
+});
+
+// ── 2. the memo key ──────────────────────────────────────────────────────────
+
+test("sameSidebarThreads accepts two distinct arrays holding equal records", () => {
+  const a = [thread({ id: "a" }), thread({ id: "b", pairId: "p" })];
+  const b = a.map((record) => ({ ...record }));
+  assert.notEqual(a, b);
+  assert.notEqual(a[0], b[0]);
+  assert.equal(sameSidebarThreads(a, b), true);
+});
+
+test("sameSidebarThreads rejects a list that gained or lost a thread", () => {
+  const a = [thread({ id: "a" })];
+  assert.equal(sameSidebarThreads(a, [...a, thread({ id: "b" })]), false);
+  assert.equal(sameSidebarThreads([...a, thread({ id: "b" })], a), false);
+});
+
+test("sameSidebarThreads rejects a reordered list", () => {
+  const a = [thread({ id: "a" }), thread({ id: "b" })];
+  assert.equal(sameSidebarThreads(a, [a[1] as ThreadRecord, a[0] as ThreadRecord]), false);
+});
+
+test("sameSidebarThreads rejects a change to every field the grouping reads", () => {
+  const changes: Record<(typeof SIDEBAR_THREAD_FIELDS)[number], unknown> = {
+    id: "changed-id",
+    title: "changed title",
+    archived: true,
+    pairId: "changed-pair",
+    projectId: "changed-project",
+    createdAt: EPOCH + 1,
+    updatedAt: EPOCH + 2,
+    forkedFromThreadId: "changed-parent",
+  };
+  // Every field in the key gets its own turn. A field dropped from
+  // SIDEBAR_THREAD_FIELDS leaves its entry here unvisited and the count fails.
+  let visited = 0;
+  for (const field of SIDEBAR_THREAD_FIELDS) {
+    const base = [thread({ id: "a", pairId: "p", projectId: null })];
+    const changed = [{ ...(base[0] as ThreadRecord), [field]: changes[field] }];
+    assert.equal(
+      sameSidebarThreads(base, changed as ThreadRecord[]),
+      false,
+      `a change to ${field} must invalidate the memo`,
+    );
+    visited += 1;
+  }
+  assert.equal(visited, Object.keys(changes).length);
+});
+
+test("sameSidebarThreads only says yes when the grouping really is identical", () => {
+  // The direction that matters. If groupThreads ever starts reading a field the key does not
+  // compare, this finds it: the pairs below differ in EVERY other ThreadRecord field.
+  const rand = mulberry32(0x5f_1d_eb_a1);
+  const pick = <T,>(values: T[]): T =>
+    values[Math.floor(rand() * values.length)] as T;
+  const ignored = (): Partial<ThreadRecord> => ({
+    modelType: pick(["base", "lora", "model1", "model2"] as const),
+    modelId: pick(["m-1", "m-2", undefined]),
+    openaiCodeExecContainerId: pick(["c-1", null, undefined]),
+    anthropicCodeExecContainerId: pick(["c-2", null, undefined]),
+    forkedFromMessageId: pick(["msg-1", null, undefined]),
+  });
+  const keyed = (index: number): Partial<ThreadRecord> => ({
+    id: `t-${pick([index, index + 1, index + 2])}`,
+    title: pick(["alpha", "beta", "gamma"]),
+    archived: pick([true, false]),
+    pairId: pick(["pair-a", "pair-b", undefined]),
+    projectId: pick(["proj-a", null, undefined]),
+    createdAt: EPOCH + pick([0, 10, 20]),
+    updatedAt: EPOCH + pick([0, 10, 20]),
+    forkedFromThreadId: pick(["parent", null, undefined]),
+  });
+
+  let agreed = 0;
+  for (let trial = 0; trial < 400; trial += 1) {
+    const size = 1 + Math.floor(rand() * 5);
+    const left: ThreadRecord[] = [];
+    const right: ThreadRecord[] = [];
+    for (let i = 0; i < size; i += 1) {
+      const key = keyed(i);
+      const clone = rand() < 0.5;
+      left.push(thread({ ...ignored(), ...key } as ThreadRecord & { id: string }));
+      right.push(
+        thread({
+          ...ignored(),
+          ...(clone ? key : keyed(i)),
+        } as ThreadRecord & { id: string }),
+      );
+    }
+    if (!sameSidebarThreads(left, right)) continue;
+    agreed += 1;
+    assert.deepEqual(groupThreads(left), groupThreads(right));
+    assert.deepEqual(groupThreads(left, true), groupThreads(right, true));
+  }
+  // Guards the guard: a key that never agrees would make every assertion above unreachable.
+  assert.ok(agreed > 20, `expected the key to agree sometimes, agreed ${agreed} times`);
+});
+
+// ── 3. identity across renders ───────────────────────────────────────────────
+
+test("useSidebarThreadGroups keeps both lists identical across a re-render", () => {
+  const runner = createHookRunner(useSidebarThreadGroups);
+  const threads = [
+    thread({ id: "a" }),
+    thread({ id: "b", archived: true }),
+    thread({ id: "c", updatedAt: EPOCH + 5 }),
+  ];
+  const first = runner.render(threads);
+  const second = runner.render(threads);
+  const third = runner.render(threads);
+
+  assert.ok(runner.memoCalls() >= 6, "the hook must derive both lists through useMemo");
+  assert.equal(
+    first.items,
+    second.items,
+    "items got a new identity from a render that changed nothing",
+  );
+  assert.equal(second.items, third.items);
+  assert.equal(
+    first.archivedItems,
+    second.archivedItems,
+    "archivedItems got a new identity from a render that changed nothing",
+  );
+  assert.equal(second.archivedItems, third.archivedItems);
+});
+
+test("useSidebarThreadGroups keeps the empty case stable too", () => {
+  const runner = createHookRunner(useSidebarThreadGroups);
+  const first = runner.render(undefined);
+  const second = runner.render(undefined);
+  assert.deepEqual(first.items, []);
+  assert.deepEqual(first.archivedItems, []);
+  assert.equal(first.items, second.items);
+  assert.equal(first.archivedItems, second.archivedItems);
+});
+
+test("useSidebarThreadGroups regroups when the threads actually change", () => {
+  const runner = createHookRunner(useSidebarThreadGroups);
+  const before = [thread({ id: "a" })];
+  const after = [thread({ id: "a" }), thread({ id: "b", updatedAt: EPOCH + 9 })];
+  const first = runner.render(before);
+  const second = runner.render(after);
+
+  assert.notEqual(
+    first.items,
+    second.items,
+    "a changed thread list must produce a new items identity, or the rail shows stale rows",
+  );
+  assert.notEqual(first.archivedItems, second.archivedItems);
+  assert.deepEqual(
+    second.items.map((item) => item.id),
+    ["b", "a"],
+  );
+});
+
+test("useSidebarThreadGroups does not conflate the archived list with the live one", () => {
+  const runner = createHookRunner(useSidebarThreadGroups);
+  const threads = [
+    thread({ id: "live" }),
+    thread({ id: "gone", archived: true }),
+  ];
+  const rendered = runner.render(threads);
+  assert.deepEqual(
+    rendered.items.map((item) => item.id),
+    ["live"],
+  );
+  assert.deepEqual(
+    rendered.archivedItems.map((item) => item.id),
+    ["gone"],
+  );
+  assert.notEqual(rendered.items, rendered.archivedItems);
+});
+
+// ── 4. the wiring in useChatSidebarItems ─────────────────────────────────────
+
+test("useChatSidebarItems derives its lists through the memo, not per render", async () => {
+  const source = await readFile(
+    new URL(
+      "../src/features/chat/hooks/use-chat-sidebar-items.ts",
+      import.meta.url,
+    ),
+    "utf8",
+  );
+  const body = source.slice(source.indexOf("export function useChatSidebarItems"));
+  assert.match(body, /useSidebarThreadGroups\(allThreads\)/);
+  assert.doesNotMatch(
+    body,
+    /const\s+(items|archivedItems)\s*=\s*groupThreads\(/,
+    "the render body regrouped the whole history again",
+  );
+  // The refetch bail-out: without it every debounced refresh hands React a new array and the
+  // memo above cannot hold, however well it is keyed.
+  assert.match(body, /setAllThreads\(\s*\(previous\)\s*=>[\s\S]{0,120}sameSidebarThreads\(/);
+  // The other groupThreads caller in the file is archiveAllChatItems, which counts rows once per
+  // click and is not on a render path. It is expected to stay a direct call.
+  assert.match(source, /return groupThreads\(toArchive\)\.length;/);
+});
+
+test("groupThreads is still exported from its original module path", async () => {
+  const source = await readFile(
+    new URL(
+      "../src/features/chat/hooks/use-chat-sidebar-items.ts",
+      import.meta.url,
+    ),
+    "utf8",
+  );
+  assert.match(source, /export \{ groupThreads \} from "\.\/sidebar-thread-groups";/);
+  assert.match(
+    source,
+    /export type \{ SidebarItem \} from "\.\/sidebar-thread-groups";/,
+  );
+});


### PR DESCRIPTION
## What happens today

`useChatSidebarItems` derives the sidebar's two chat lists like this:

```ts
const items = groupThreads(allThreads ?? []);
const archivedItems = groupThreads(allThreads ?? [], true);
```

Unmemoized. `groupThreads` walks the whole history, allocates a fresh object per row and ends in a
`.sort()`, so both calls run on every render of every consumer and both hand back a new array
identity every time. That identity is the input to seven `useMemo`s in `app-sidebar.tsx`
(`recentChatItems`, `pinnedChatItems`, `chatsByProjectId`, `sidebarProjectRecords`,
`sortedRecentChatItems`, `recentRowIds`, `runningChatCount`), so none of them could ever hold.

The path where that costs the most is not the one it looks like. `allThreads` is a `useState`, so
its identity is already stable across a plain re-render. What was never stable is the array the
refresh path installs. Every `CHAT_HISTORY_UPDATED_EVENT` refetches the WHOLE thread list behind a
300 ms debounce and calls `setAllThreads(threads)` with a brand new array even when the list that
came back is identical to the one already on screen. Streaming fires that event per chunk, which
is what the comment above `SIDEBAR_REFRESH_DEBOUNCE_MS` in this same file says, and the backend's
`_bump_chat_thread_updated_at` is a `MAX()` ratchet against the message's own `createdAt`, so
re-saving the same streaming message leaves `chat_threads.updated_at` exactly where it already
was. The refetch comes back identical, and the rail was regrouping and re-rendering the entire
history for it anyway, several times a second, for as long as a reply was being written.

## What this changes

Two things, both inside `use-chat-sidebar-items.ts`:

1. `groupThreads` now runs inside `useMemo` keyed on the thread array, through a small
   `useSidebarThreadGroups` hook.
2. A refetch that changed nothing the sidebar reads keeps the previous array:
   `setAllThreads((previous) => sameSidebarThreads(previous, threads) ? previous : threads)`.
   `Object.is` on the state turns that into a React bail-out, so the render never happens.

`groupThreads` itself is unchanged, character for character. It moved into a new
`hooks/sidebar-thread-groups.ts` so it can be unit tested without dragging in chat storage, the
runtime store and the artifact store, and it is re-exported from its old path, so every existing
caller, including `groupThreads(toArchive).length` in `archiveAllChatItems`, is untouched.

`app-sidebar.tsx` is not modified. The point of the change is that the seven memos over there
start holding on their own once the identity upstream of them is stable.

## The memo key, and why it is enough

`SIDEBAR_THREAD_FIELDS` is `id, title, archived, pairId, projectId, createdAt, updatedAt,
forkedFromThreadId`, compared position by position with `Object.is`. That is exactly the set of
fields `groupThreads` reads, and nothing else in the hook reads the `allThreads` state at all (the
legacy title repair reads the freshly fetched list, not the state). Order is not normalised away:
`groupThreads` walks the list in order and its sort is not total when two threads share an
`updatedAt`, so two differently ordered lists with the same members can legitimately group
differently.

The comparison is deliberately stricter than `groupThreads`, which reads `archived` and
`forkedFromThreadId` only through `Boolean()`. Here `undefined` and `false` count as different,
which can cost a regroup that was not needed but can never skip one that was.

The direction that would actually hurt is a field `groupThreads` reads that the key does not
compare, because that ships stale rows. A property test pins it: 400 randomized pairs whose
`modelType`, `modelId`, both code-exec container ids and `forkedFromMessageId` all vary,
asserting that whenever `sameSidebarThreads` says yes, both groupings are deep equal. Teaching
`groupThreads` to read a new field without adding it to the key turns that test red.

## Measurement

Two worktrees, `origin/main` and this branch, each behind its own vite dev server, both serving
the same harness (hashed before the run; the probe refuses to start if the two copies differ).
Arms are interleaved base, head, base, head with the order flipped every pair, and the headline is
the MEDIAN OF PAIRED RATIOS, never the ratio of two medians. Row count, DOM node count and scroll
height are read from both arms after both are seeded and have to agree or the pair is not
measured. Chromium, dev server, host at load average around 45 on 192 cores, so the ratios are the
result and the milliseconds are context.

Ratios are main / branch, so above 1 means this branch is faster.

### By history size, CPU 1x, 5 interleaved pairs per cell

```
                                          100 threads    1000 threads    5000 threads
refresh that changed nothing
  settle ms            main -> branch    625.6 -> 311.5  1136.3 -> 311.9  2709.2 -> 326.0
  paired ratio                                   2.01x           3.64x            8.31x
  main-thread script ms                 332.0 ->  12.9   841.7 ->  18.3  2430.3 ->  48.5
  paired ratio                                  25.09x          46.00x           50.11x
  long-task total ms                      315 ->     0     822 ->     0    2371 ->     0
refresh that changed a thread                    0.97x           0.96x            0.96x
scroll re-render (paint)                         0.96x           1.04x            1.04x
mount converged                                  0.93x           0.96x            1.06x
row kebab open                                   0.89x           1.00x            1.02x
row kebab close                                  1.01x           1.01x            1.00x
CONTROL busy loop, main/branch                   0.99x           0.93x            1.03x
```

The last row is the noise floor and it is there to be read against the rest. It is the same fixed
integer loop on both arms, so it should sit at 1.00; it drifts by up to 7% between the two arms
inside one cell. Everything except the first block is inside that band. Only the refresh that
changed nothing is outside it, and it is outside it by an order of magnitude.

First paint and convergence are reported separately by the harness. On this rail they are the same
number at every size, because React commits all N rows in one commit, so there is no progressive
first paint and no first-paint win is claimed.

### CPU throttling ladder, 5000 threads, 3 interleaved pairs per rung

Each column is normalised against that arm's own 1x rung, so the two control rows say whether the
instrument is honest before any of the others are read.

```
                              main                       this branch
                        1x      2x      4x           1x      2x      4x
CONTROL sleep         1.00x   1.00x   1.00x        1.00x   1.00x   1.00x
CONTROL busy          1.00x   2.12x   4.02x        1.00x   2.08x   4.60x
mount converged       1.00x   1.93x   4.05x        1.00x   1.81x   3.89x
scroll re-render      1.00x   2.01x   3.90x        1.00x   1.78x   3.83x
refresh, nothing new  1.00x   2.06x   4.12x        1.00x   1.03x   1.36x
refresh, thread moved 1.00x   2.03x   4.02x        1.00x   2.00x   4.07x
row kebab open        1.00x   1.99x   4.18x        1.00x   2.05x   4.32x
```

The timer-bound control stays flat at every rung on both arms, so the clock is not being scaled.
The CPU-bound control rises with the rate, so the throttling landed. Every row on `main` tracks
the CPU-bound control, which is what says this is main-thread script and not layout or network.

The one row that stops tracking it is the one this PR is about: on this branch a refresh that
changed nothing barely responds to CPU throttling at all, 1.00 / 1.03 / 1.36, because what is left
of it is the 300 ms debounce and not script. Same rungs as paired ratios: 8.02x at 1x, 15.87x at
2x, 24.44x at 4x, with the long-task total going 2293 -> 0, 4957 -> 0 and 10320 -> 0 ms.

## Is this real, or is it a fake win

Real, and smaller than it first looked. Two things were checked before publishing any of it.

The first run of the scroll re-render said 350.8 ms on `main` against 68.3 ms here at 100 threads,
a 9x win. It was false. A CPU sampling profile of the same action put the two arms at 354.1 ms and
344.7 ms. The probe's drain between actions was 150 ms, shorter than the hook's own 300 ms refresh
debounce, so whichever arm finished its mount early was paying for the mount's own refetch
re-render inside its next timed window. With the drain raised past the debounce the phantom
disappeared and the scroll path reads as a wash, which is what is in the table.

That is also why no re-render win is claimed. The profile says what the scroll actually costs at
1000 threads: `jsxDEV` self time 835.7 ms on `main` and 831.0 ms here, which is rebuilding 1000
rows' element trees, and no memo upstream of the JSX can avoid that. The grouping is a few percent
of it.

What is real is the refresh path, and it is not a small number. At 5000 threads a refresh that
changed nothing went from 2.4 s of main-thread script to 26 ms of it, and from a 2371 ms long-task
total to zero. There is no long task left because there is no render left.

## Limits of the measurement, stated rather than rounded up

- No measurable win on the scroll re-render or on mount. Both sit inside the plus or minus 7% band
  the CPU-bound control itself drifts by between the two arms in one cell, so they are reported as
  a wash and not as a win.
- That streaming fires the refresh event per chunk is argued, not reproduced here. It comes from
  the comment above `SIDEBAR_REFRESH_DEBOUNCE_MS` in this same file plus the backend's `MAX()`
  ratchet in `_bump_chat_thread_updated_at`, which is what makes the repeated save of one streaming
  message come back as an identical list. It was not measured against a live model stream.
- Dev-server numbers, not a packaged build: React runs in development mode and vite serves
  unbundled modules, so the absolute milliseconds sit above a shipped Studio's. The ratios across
  sizes and the ladder are what these are for.
- Chromium only. The mechanism was already shown not to be engine specific (mount growth from 100
  to 1000 threads converged at 4.99x chromium, 5.19x webkit, 6.77x firefox), but every ratio above
  is Chromium.
- The first full sweep lost its 5000-thread 4x cell to a dead renderer. The probe now records a
  crashed cell instead of losing the run, and the ladder above is a second, self-consistent pass
  over 1x, 2x and 4x.

## Does merging break anything

The screen has to be identical, and it is. Five scenes (freshly mounted, after a refresh that
changed nothing, after a refresh that moved a thread, scrolled, row kebab open) driven against
both arms at 100 and 1000 threads: the sidebar's serialized DOM is identical in all ten, and with
CSS animations frozen the screenshots are 100.00% pixel identical in all ten. Before freezing them
the only differing pixels anywhere were a spinner caught at a different rotation angle, 0.1% of
the frame. The comparison discriminates: the same comparator puts the mounted rail against the
scrolled rail at 79.10% and against the kebab-open rail at 98.13%, and the scene set has its own
gate that refuses to publish if a scene renders the same DOM as the freshly mounted rail.

Making an identity stable is only safe if every consumer's dependency array is complete, so they
were all read rather than assumed. In `app-sidebar.tsx`: `recentChatItems`, `pinnedChatItems`,
`chatsByProjectId`, `sidebarProjectRecords`, `runningChatCount`, `runningTarget`,
`activeVisibleThreadIds`, `selectedChatItems`, `sortedRecentChatItems` (through the `sortChatItems`
and `chatPriorityRank` callbacks) and `recentRowIds` each list exactly what they read. The one
effect keyed on the list, the one that clears the optimistic rename title once the refreshed list
carries it, also lists `pendingRename`, so setting a pending rename still runs it on that same
render, and a rename that changes a title necessarily changes the list. The other consumers
(`thread-sidebar.tsx`, `data-tab.tsx`, `archived-chats-dialog.tsx`, `chat-page.tsx`) only read the
lists during render.

Older pathways specifically:

- Legacy records with `archived` `undefined` or `null` still count as not archived, in both lists.
  Pinned as a test.
- Compare pairs still collapse to one row keyed on `pairId`, keeping both `threadIds` and the max
  of the two timestamps.
- A thread with no `updatedAt` still sorts on its `createdAt`.
- Deleting a chat writes a tombstone and the storage layer filters tombstoned threads out of the
  list, so the refetch is shorter and the bail-out cannot fire on it.
- Archive, unarchive, rename, fork and project moves all change a compared field, so they all
  re-render exactly as they did before. Measured as the "refresh that changed a thread" row above,
  which is a wash at every size and every CPU rate.
- `groupThreads` and the `SidebarItem` type are still exported from
  `features/chat/hooks/use-chat-sidebar-items`, and `features/chat/index.ts` re-exports them
  unchanged.

## What is deliberately not in this PR

The other half of this is the rail itself. `app-sidebar.tsx:3542` maps `sortedRecentChatItems`
straight into rows with no window and no cap, and every row is a `ContextMenu` around a
`SidebarMenuButton` plus a per-row `DropdownMenu` whose items are rebuilt on each render. That is
what the profile above is pointing at, and it is where the remaining scroll and mount cost lives.
`@tanstack/react-virtual` is already a dependency and is already used by
`features/hub/catalog/models-catalog-rows.tsx`. It is not here because #9051 has open hunks in
`app-sidebar.tsx`, and this change does not need that file at all. Follow-up.

## Tests

`studio/frontend/tests/sidebar-thread-groups-memo.test.ts`, 17 tests: the grouping's own branches,
the memo key with one case per field, the property above, and identity across renders in both
directions, stable when the threads have not changed and fresh when they have, including an edit
that leaves the list the same length so a length-keyed memo cannot slip through.

Every assertion was checked against a deliberately broken tree, one mutant per assertion, 27 in
all, each confirmed to turn its own assertion red. Two worth naming: keying the memo on
`source.length` is caught only by the same-length edit test, and teaching `groupThreads` to read
`modelId` is caught only by the property test.

`npm test`: 3794 pass, 1 fail. `origin/main` at the same base commit: 3777 pass, 1 fail. It is the
same failure on both sides, `tests/queued-model-capabilities.test.ts`, pre-existing and untouched
here. `npm run typecheck`, `npm run build`, and `npx eslint` on the three changed files are clean.
