### PR TITLE
Studio: take the three live sidebar menus off the body modal layer

### DIFF
--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -2232,7 +2232,7 @@ export function AppSidebar() {
     includeOrganize?: boolean;
   }) {
     return (
-      <DropdownMenu>
+      <DropdownMenu modal={false}>
         <DropdownMenuTrigger asChild>
           <button
             type="button"
@@ -2248,6 +2248,7 @@ export function AppSidebar() {
           sideOffset={2}
           className="unsloth-plus-menu w-56"
         >
+          <MenuDismissGuard />
           {options.includeOrganize && (
             <>
               <DropdownMenuLabel>
@@ -2576,7 +2577,7 @@ export function AppSidebar() {
                 </span>
               </button>
             )}
-            <DropdownMenu>
+            <DropdownMenu modal={false}>
               <DropdownMenuTrigger asChild>
                 <button
                   type="button"
@@ -2595,6 +2596,7 @@ export function AppSidebar() {
                 sideOffset={0}
                 className="unsloth-plus-menu menu-flat-destructive w-56"
               >
+                <MenuDismissGuard />
                 <DropdownMenuItem onSelect={() => openRenameChat(item)}>
                   <HugeiconsIcon icon={Edit03Icon} strokeWidth={1.75} className="size-icon" />
                   <span>Rename</span>

--- a/studio/frontend/src/features/chat/chat-page.tsx
+++ b/studio/frontend/src/features/chat/chat-page.tsx
@@ -77,6 +77,7 @@ import {
 } from "@/features/native-intents";
 import { GuidedTour, useGuidedTourController } from "@/features/tour";
 import { isTauri } from "@/lib/api-base";
+import { MenuDismissGuard } from "@/lib/menu-dismiss-guard";
 import { chatModelLoaded } from "./lib/chat-model-loaded";
 import { isDownloadCancelled } from "@/lib/native-files";
 import { toast } from "@/lib/toast";
@@ -1663,7 +1664,7 @@ function ProjectLanding({
                             formatProjectChatDate(item.createdAt)}
                         </span>
                       </button>
-                      <DropdownMenu>
+                      <DropdownMenu modal={false}>
                         <DropdownMenuTrigger asChild>
                           <button
                             type="button"
@@ -1684,6 +1685,7 @@ function ProjectLanding({
                           sideOffset={4}
                           className="unsloth-plus-menu menu-flat-destructive w-56"
                         >
+                          <MenuDismissGuard />
                           <DropdownMenuItem onSelect={() => openRename(item)}>
                             <HugeiconsIcon
                               icon={Edit03Icon}

--- a/studio/frontend/tests/sidebar-menu-modality.test.ts
+++ b/studio/frontend/tests/sidebar-menu-modality.test.ts
@@ -1,0 +1,232 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// The three sidebar menus a user actually opens.
+//
+// A modal Radix layer parks `pointer-events: none` on <body> for as long as it is
+// open. `pointer-events` is INHERITED, so that one write invalidates computed style
+// for the whole mounted subtree, and on a long thread that subtree is the thread.
+// Measured on one packaged production build, same 220-message thread, same run: the
+// action-bar More menu (already non-modal) opens and closes in 38.6 ms and the
+// sidebar's "Chat options" menu, identical interaction, 382.6 ms.
+//
+// Going non-modal also drops the shield that was absorbing the dismissing click, so
+// each converted menu mounts <MenuDismissGuard /> in its content. A menu that is
+// non-modal WITHOUT the guard is the dangerous half of this change, not a lesser
+// version of it: the press that dismisses the menu also fires whatever control it
+// landed on. Both halves are pinned here, per menu, so a later edit cannot drop one.
+//
+// The fourth test is the trap this change was filed for. The two menus that look
+// converted in features/chat/thread-sidebar.tsx are converted in a file NOTHING
+// imports, so vite tree-shakes it and those menus never mount. A modality pin on an
+// unreachable file is a vacuous pin, so each file checked here is required to have a
+// live importer.
+
+import assert from "node:assert/strict";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const SRC = fileURLToPath(new URL("../src/", import.meta.url));
+
+const read = (relative: string): string =>
+  readFileSync(path.join(SRC, relative), "utf8");
+
+const LINE_COMMENT = /^[ \t]*\/\/.*$/gm;
+const BLOCK_COMMENT = /\/\*[\s\S]*?\*\//g;
+const JSX_COMMENT = /\{\s*\/\*[\s\S]*?\*\/\s*\}/g;
+
+/** Strip comments so a code sample inside a rationale cannot satisfy a check. */
+function code(source: string): string {
+  return source
+    .replace(JSX_COMMENT, "")
+    .replace(BLOCK_COMMENT, "")
+    .replace(LINE_COMMENT, "");
+}
+
+/**
+ * The `<DropdownMenu ...> ... </DropdownMenu>` element whose body contains `marker`,
+ * by tag counting. `<DropdownMenuTrigger` and friends share the prefix, so the open
+ * tag is matched only when followed by whitespace or `>`.
+ *
+ * `marker` must identify exactly one menu, and that is asserted rather than assumed:
+ * a marker that matches two menus would let a check pass by reading the wrong one.
+ */
+function menuContaining(source: string, marker: string): string {
+  const OPEN_TAG = /<DropdownMenu(?=[\s>])/;
+  const CLOSE_TAG = "</DropdownMenu>";
+  /** Slice from an opening `<DropdownMenu` at `start` to its own closing tag. */
+  const element = (start: number): string => {
+    let depth = 0;
+    let i = start;
+    while (i < source.length) {
+      const rest = source.slice(i);
+      const relOpen = rest.search(OPEN_TAG);
+      const openAt = relOpen === -1 ? -1 : i + relOpen;
+      const closeAt = source.indexOf(CLOSE_TAG, i);
+      assert.notEqual(closeAt, -1, "unbalanced <DropdownMenu> in source");
+      if (openAt !== -1 && openAt < closeAt) {
+        depth++;
+        i = openAt + "<DropdownMenu".length;
+        continue;
+      }
+      depth--;
+      i = closeAt + CLOSE_TAG.length;
+      if (depth === 0) return source.slice(start, i);
+    }
+    throw new Error("unbalanced <DropdownMenu> in source");
+  };
+
+  const found: string[] = [];
+  for (const match of source.matchAll(new RegExp(OPEN_TAG.source, "g"))) {
+    const body = element(match.index);
+    if (body.includes(marker)) found.push(body);
+  }
+  // A root nested inside another would make the outer one match the inner marker as
+  // well, so keep only matches that contain no other match, and require that the
+  // marker picked out exactly one menu. A marker matching two would let a check pass
+  // by reading the wrong menu.
+  const innermost = found.filter(
+    (body) => !found.some((other) => other !== body && body.includes(other)),
+  );
+  assert.equal(
+    innermost.length,
+    1,
+    `expected exactly one <DropdownMenu> containing ${JSON.stringify(marker)}, found ${innermost.length}`,
+  );
+  return innermost[0] as string;
+}
+
+/**
+ * Body of a `function NAME(` / `const NAME = (` declaration, by brace matching, so a
+ * check reads only the function it names.
+ */
+function declaration(source: string, name: string): string {
+  const start = source.search(
+    new RegExp(`(?:export\\s+)?(?:function|const)\\s+${name}\\b`),
+  );
+  assert.notEqual(start, -1, `${name} not found`);
+  const paren = source.indexOf("(", start);
+  assert.notEqual(paren, -1, `${name} has no parameter list`);
+  let parens = 0;
+  let afterParams = -1;
+  for (let i = paren; i < source.length; i++) {
+    if (source[i] === "(") parens++;
+    else if (source[i] === ")") {
+      parens--;
+      if (parens === 0) {
+        afterParams = i;
+        break;
+      }
+    }
+  }
+  assert.notEqual(afterParams, -1, `unbalanced parentheses in ${name}`);
+  const open = source.indexOf("{", afterParams);
+  assert.notEqual(open, -1, `${name} has no body`);
+  let depth = 0;
+  for (let i = open; i < source.length; i++) {
+    if (source[i] === "{") depth++;
+    else if (source[i] === "}") {
+      depth--;
+      if (depth === 0) return source.slice(start, i + 1);
+    }
+  }
+  throw new Error(`unbalanced braces in ${name}`);
+}
+
+const NON_MODAL = /<DropdownMenu\s+modal=\{false\}/;
+const GUARD = /<MenuDismissGuard\s*\/>/;
+
+const SIDEBAR = code(read("components/app-sidebar.tsx"));
+const CHAT_PAGE = code(read("features/chat/chat-page.tsx"));
+
+/** Both halves of the conversion, named so a failure says which one went. */
+function assertConverted(menu: string, what: string): void {
+  assert.match(
+    menu,
+    NON_MODAL,
+    `${what} is back on the body modal layer; opening it invalidates computed style ` +
+      "for the whole thread subtree, which is the 382.6 ms against 38.6 ms this change removed",
+  );
+  assert.match(
+    menu,
+    GUARD,
+    `${what} is non-modal with no <MenuDismissGuard /> in its content, so the click ` +
+      "that dismisses it also fires whatever control it landed on",
+  );
+}
+
+test("the sidebar list-header menu is off the modal layer and guarded", () => {
+  assertConverted(
+    declaration(SIDEBAR, "renderSidebarHeaderMenu"),
+    'the sidebar list-header "..." menu (Organize chats / sort)',
+  );
+});
+
+test("the sidebar per-thread Chat options menu is off the modal layer and guarded", () => {
+  assertConverted(
+    menuContaining(SIDEBAR, 'aria-label="Chat options"'),
+    'the sidebar per-thread "Chat options" menu',
+  );
+});
+
+test("the project page per-chat Chat options menu is off the modal layer and guarded", () => {
+  assertConverted(
+    menuContaining(CHAT_PAGE, 'aria-label="Chat options"'),
+    'the project page per-chat "Chat options" menu',
+  );
+});
+
+/** Every .ts/.tsx under src/, so "who imports this" is asked of the whole tree. */
+function sourceFiles(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    const full = path.join(dir, entry);
+    if (statSync(full).isDirectory()) sourceFiles(full, out);
+    else if (/\.tsx?$/.test(entry)) out.push(full);
+  }
+  return out;
+}
+
+test("the pinned files are reachable, unlike thread-sidebar.tsx", () => {
+  const files = sourceFiles(SRC);
+  // A sweep that walked nothing would report every file unreachable and pass the
+  // negative half below while failing the positive half for the wrong reason.
+  assert.ok(files.length > 200, `only walked ${files.length} source files`);
+
+  const importersOf = (relative: string): string[] => {
+    const abs = path.join(SRC, relative);
+    const stem = abs.replace(/\.tsx?$/, "");
+    const aliased = `@/${path.relative(SRC, stem)}`;
+    return files.filter((file) => {
+      if (file === abs) return false;
+      const source = readFileSync(file, "utf8");
+      if (source.includes(`"${aliased}"`)) return true;
+      const rel = path.relative(path.dirname(file), stem);
+      const spec = rel.startsWith(".") ? rel : `./${rel}`;
+      return source.includes(`"${spec}"`);
+    });
+  };
+
+  for (const pinned of [
+    "components/app-sidebar.tsx",
+    "features/chat/chat-page.tsx",
+  ]) {
+    assert.ok(
+      importersOf(pinned).length > 0,
+      `${pinned} has no importer under src/, so vite drops it and the modality ` +
+        "pins above are checking a file that never mounts",
+    );
+  }
+
+  // The control. thread-sidebar.tsx carries two converted menus and NOTHING imports
+  // it, which is why the eleven-menu count in #9051 is eight live menus. If this ever
+  // gains an importer, its menus join the matrix and this test should be the thing
+  // that says so.
+  assert.deepEqual(
+    importersOf("features/chat/thread-sidebar.tsx"),
+    [],
+    "thread-sidebar.tsx has gained an importer; its two menus now mount and need " +
+      "the same dismissal matrix as the three pinned above",
+  );
+});


### PR DESCRIPTION
Follow-up to #9051, and the fix for #9168.

#9051 takes the chat menus off the body modal layer and measures a large win, but it does not
reach the sidebar. The three menus a user actually opens were still modal, and one of them is
the most expensive menu measured anywhere in this work: on one packaged production build,
same 220-message thread, same run, the action-bar More menu patched by #9051 opens and closes
in 38.6 ms and the sidebar's "Chat options" menu, identical interaction, in 382.6 ms.

This converts the three, with the guard, and measures each one.

## The change

Three `<DropdownMenu>` roots get `modal={false}`, and each one mounts `<MenuDismissGuard />`
first in its content:

| site | menu |
|---|---|
| `app-sidebar.tsx` `renderSidebarHeaderMenu` | the list-header "..." -- Organize chats, Organize projects, Sort pinned chats, all three from one function |
| `app-sidebar.tsx` per-thread trigger | "Chat options", the one opened constantly in ordinary use |
| `chat-page.tsx` project page row | "Chat options" on a project's chat list |

Six lines of source, plus `studio/frontend/tests/sidebar-menu-modality.test.ts`.

**This PR is stacked on #9051 and targets its branch.** The guard lives in
`src/lib/menu-dismiss.ts` and `src/lib/menu-dismiss-guard.tsx`, which exist only there, and it
is mounted PER MENU rather than globally, so `modal={false}` on its own is not the whole
change for these three. Merge #9051 first; GitHub will retarget this to main.

## Why the modal layer costs anything

A modal Radix layer parks `pointer-events: none` on `<body>` for as long as it is open
(`@radix-ui/react-dismissable-layer`). `pointer-events` is INHERITED, so that single write
invalidates computed style for the entire mounted subtree, which on a chat page is the thread.
The cost of opening a menu therefore scales with the thread rather than with the menu.
`modal={false}` is the upstream answer to exactly this (radix-ui/primitives discussions #2873
and #1720, shadcn-ui/ui #6908).

Read directly off the page, while each menu is open, on all three menus and all three engines:

| | base | this branch |
|---|---|---|
| `document.body.style.pointerEvents` | `none` | `""` |
| computed `pointer-events` on body | `none` | `auto` |
| `data-scroll-locked` on body | present | absent |
| `aria-hidden` body children | 3 | 1 |

## Measurement

**Every number in this section is off a PRODUCTION bundle. There is no vite dev server
anywhere in this PR's timings.** Both arms are `vite build` output with distinct
`assets/index-*.js` hashes, served as static dists. That is worth stating outright, because a
dev server does not merely scale timings: React's development-only paths cost in proportion to
elements created per frame, so the bias is correlated with a treatment that changes how much
subtree work is mounted, and it does not cancel in a base/head ratio. Taking menus off the
Radix modal layer is exactly such a treatment, so a dev-server measurement here would not have
been salvageable by ratioing.

Two Studios on ONE backend, differing only in the frontend bundle they serve
(`unsloth studio --frontend <dist>`), one dist built from #9051's head and one from this
branch. Each side has its own `UNSLOTH_STUDIO_HOME` and its own port, and each was checked to
be serving its own `assets/index-*.js` before anything was timed. Identical seeded content on
both: a project, a 220-message plain thread and a 220-message markdown thread (187,118 chars).
One shared backend is deliberate: the diff is three frontend files, so holding the backend
fixed removes it as a variable rather than duplicating it.

One press to open, Escape to close, timed from before the press to after the last `[role=menu]`
has gone. Each trial times BOTH sides back to back and the arm order alternates by trial, so
the second half is the reversed-order repeat and a drift on this shared box cannot favour
either arm. **The paired ratio is the result**; absolute milliseconds are context. A trial is
rejected outright unless both arms mounted the same amount of the page, since the cost being
removed scales with the mounted subtree.

Medians of 3 paired trials:

| engine | menu | thread | base | head | ratio | change |
|---|---|---|---:|---:|---:|---:|
| chromium | sidebar Organize chats | markdown, 12,024 nodes | 508.1 ms | 170.7 ms | 0.336 | **-66.4%** |
| chromium | sidebar Chat options | markdown, 12,024 nodes | 522.1 ms | 175.2 ms | 0.336 | **-66.4%** |
| chromium | project page Chat options | project page, 686 nodes | 191.1 ms | 174.3 ms | 0.912 | -8.8% |
| firefox | sidebar Organize chats | markdown, 12,024 nodes | 938 ms | 160 ms | 0.166 | **-83.4%** |
| firefox | sidebar Chat options | markdown, 12,024 nodes | 893 ms | 172 ms | 0.193 | **-80.7%** |
| firefox | project page Chat options | project page, 704 nodes | 214 ms | 173 ms | 0.805 | -19.5% |
| webkit | sidebar Organize chats | markdown, 12,024 nodes | 1592 ms | 197 ms | 0.123 | **-87.7%** |
| webkit | sidebar Chat options | markdown, 12,024 nodes | 1435 ms | 217 ms | 0.158 | **-84.2%** |
| webkit | project page Chat options | project page, 686 nodes | 252 ms | 162 ms | 0.644 | -35.6% |

Repeated on a plain-text thread of the same 220 messages, which mounts 2,343 nodes rather than
12,024, every cell still improves and every cell improves by less: chromium -25.6% / -28.0% /
-16.8%, firefox -59.0% / -47.4% / -25.6%, webkit -63.7% / -64.2% / -36.4%. That is the point.
**The head arm is flat at about 170 ms across both thread weights on all three engines; only
the base arm grows.** 18 cells, all 18 faster, and the per-trial ratios inside each cell agree
to within a few points.

The project page number is small on purpose and should not be read as a disappointment: that
route has no thread mounted, so there is little style to invalidate. It is the same defect,
costing less, and it costs nothing to remove.

## What was checked, per menu

Full matrix, three engines, three arms (base, this branch, and a guardless mutant), three
repeats per case, driven with `page.mouse` and `page.touchscreen` so every press is a real hit
test that honours `pointer-events`.

Two runs were thrown away rather than reconciled.

Five unrelated static servers on this box were killed at 21:27 UTC, and the firefox matrix was
mid-run on its head arm at that moment, so it was discarded and re-run clean. The re-run
reproduces the discarded one **cell for cell, across all 3 arms x 3 menus x 25 checks**, so
the contamination in fact changed nothing; it was discarded and re-run anyway rather than
reconciled after the fact. The chromium cells were re-run for a different and better reason:
they were written at 20:49:12 by a `menu3_matrix.py` that was edited at 20:55:54, so those
numbers came from a harness version that no longer exists, and nothing in the results
themselves would have revealed it.

**No timing trial was affected either way.** Every number in the Measurement section was
written between 20:04 and 20:17 UTC, over an hour before the kill, and those three Studios
stayed up throughout with unbroken request logs across 21:27.

On this branch, on all three menus:

- mouse open: 3/3, and the menu that opens has the same item count as base (5, 8 and 7)
- selecting an item reaches the item's handler and takes effect: 3/3
- a press outside dismisses it: 3/3
- ...and does NOT fire the control underneath: 3/3
- ...and the NEXT press on that same element DOES fire: 3/3, so the guard eats exactly one
  click and nothing became click-blocked
- a HELD press (700 ms) on an adjacent chat row dismisses without navigating: 3/3 on the two
  "Chat options" menus; on the list-header menu the press does not dismiss at all, see below
- dismiss-then-Space does not activate the row the swallowed press focused: 3/3
- keyboard: trigger focusable, Enter opens, ArrowDown moves, Escape closes: 3/3
- touch open: 3/3, and the tap does not fire what is underneath: 3/3. Touch dismiss is 3/3
  everywhere except one cell, called out below

Touch was run on all three engines, not just chromium and webkit: Playwright's `hasTouch`
dispatches real touch events on firefox as well, and these are real firefox measurements.

### Where this evidence is weaker than the table above looks

Three things cut against the result and are stated here rather than left in a footnote,
because each one would otherwise quietly inflate it.

**1. The kill control kills on two of the three menus, not three.** On the list-header
"Organize chats" menu, the guardless mutant scores 3/3 on `held_dismiss_did_not_navigate`,
`quick_dismiss_did_not_navigate` and `dismiss_then_space_did_not_navigate` -- the same as
head. It is not that the guard is doing its job there; it is that the harness's press never
dismisses that menu on any tree, so there is no swallowed click for the guard to be credited
with. A kill control that does not kill on a third of the surface is a weaker control than it
first appears, and the list-header menu's protection rests on the other checks
(`underlying_swallowed`, `neutral_click_after`, `touch_underlying_swallowed`, the double-click
counter) rather than on these three.

**2. The base arm's `underlying_swallowed` is not measured against the same element as head's,
and cannot be.** On base, `body { pointer-events: none }` makes `document.elementFromPoint`
return the root, so the probe attaches its click counter to `<html>`; on head and the mutant it
attaches to a `<div>`. So "0/3 on base" means `<html>` received the click, not that the control
underneath fired. The head-vs-mutant comparison is unaffected -- both are the same `<div>` --
and that is the comparison the kill control actually rests on, but the base-vs-head contrast is
softer than the bare numbers suggest.

This has a consequence worth stating in plain terms rather than leaving as a 3/3.
`underlying_swallowed` 3/3 together with `neutral_click_after` 3/3 means: **with a menu open, a
user who clicks a control must press it twice to activate it.** The first press dismisses the
menu and is eaten by the guard; the second press works normally. That is the guard's deliberate
design, inherited from #9051, and it is not new here. But whether it is an improvement on what
the modal layer did **cannot be settled from these numbers**, because the base column is the
confounded `<html>` measurement above and so the two are not comparable. It is reported as a
described behaviour, not as a pass.

**3. One touch row is chromium-only** and was previously written as if it held everywhere. See
below.

**4. Only 28 of the 77 checks in the matrix can be shown to measure anything.** **Four** separate
instrument defects were found while preparing this PR, and every one produced plausible-looking
numbers:

1. a matrix run whose harness was edited after it ran (results 20:49:12, harness 20:55:54), so
   the numbers came from a version that no longer exists;
2. a probe that targeted an inline rename which never opens a dialog, and so reported "no
   dialog" on the arm that definitely has a modal layer;
3. a probe that scrolled a thread already pinned to the bottom (`room_up` 170,256,
   `room_down` 0), so a scroll-locked arm and an out-of-room arm **both** reported 0 px moved;
4. a second overlay probe defeated by the finding itself: with a menu open the first outside
   press is always consumed, so the button it pressed never activated and it measured the
   swallow rather than the dialog.

None is visible by reading the code and none looks wrong in the output. **All four were caught
by the same signature: a check that read identically where it should have differed, or a bare
zero that could not distinguish absence from unreachability.** That is the thing to look for
when touching this harness.

So the same standard this PR applies to its assertions (a mutant must kill each one) is applied
to the probes themselves. `scripts/menu3_discrimination.py` sweeps every check and asks what it
reads on an arm where the behaviour is present against one where it is absent:

| | matrix | focus / overlay |
|---|---:|---:|
| discriminates between arms | **28** | see note |
| reads identically on base, head and mutant | 49 | see note |

The 49 split into two honest groups. Most are **regression guards that cannot discriminate by
construction**, because no arm lacks the behaviour they test: `mouse_open`, `item_count`,
`dismiss_closes`, `select_reached_item`, `select_took_effect`, all three `keyboard_*`,
`touch_open`, `dblclick_outside_closes`. They are legitimate as "nothing broke" statements and
they are reported as exactly that -- **not as evidence the change works, and with their own
instruments unvalidated**, since nothing in this experiment makes them fail. The rest are the
cases named above where the interaction never fires on any tree (the list-header menu's
held, quick and dismiss-then-Space presses; chromium's `touch_dismiss_closes` on the sidebar
"Chat options" menu), and those are stated as non-discriminating rather than as passes.

The general principle behind the scroll fix is worth stating because it applies to all of them:
**a probe must be able to distinguish "the thing did not happen" from "I could not make the
thing happen".** A bare 0 cannot.

Four rows are reported as they were observed rather than as passes:

- `touch_dismiss_closes` on the sidebar "Chat options" menu comes back 0/3 on base, head and
  the mutant alike **on chromium only**. On firefox and webkit that same cell is 3/3 on all
  three trees. A tap on the neutral spot does not close that one menu on chromium on any tree,
  so it is pre-existing and not a regression, but it is not a pass either.
- the held-press case on the list-header menu does not discriminate: 0/3 on all three trees,
  because the row the harness presses is not adjacent enough to that menu to close it. The
  same is true of the quick-press and dismiss-then-Space cases on that menu: it is not that
  the guard holds there, it is that the press never dismissed that menu to begin with.
- the probe's neutral press does not land on the same element on both arms, and it cannot.
  On base, `body { pointer-events: none }` makes `elementFromPoint` return the root, so the
  base arm's click counter is attached to `<html>` while head's and the mutant's are attached
  to a `<div>`. So `underlying_swallowed` 0/3 on base means "`<html>` received the click", not
  "the control underneath fired". The head-vs-mutant comparison is unaffected, since both are
  the same `<div>`, and that is the comparison the kill control rests on.
- on **base**, the project page menu could not be reopened after a dismissal (1/10), so the
  later rows in that column are absent. Head reopens it 10/10. I have not established whether
  that is a real base-tree defect or a harness artefact, and I am not claiming it as a fix.

## The behaviour changes, stated rather than left to be discovered

The bar for this PR is identical-except-for-performance. It does not fully meet that bar, so
the differences are listed here with their measurements rather than left to be found.

### 1. The thread scrolls behind an open menu, where before it was locked

Going non-modal drops the `react-remove-scroll` scroll lock along with the pointer-events
write. Measured, one of these menus open, a real wheel gesture over the thread:

| | base | this branch |
|---|---:|---:|
| thread `scrollTop` delta | **0 px** | **-900 px** (chromium), **-860 px** (firefox) |
| menu still open afterwards | yes | yes |
| menu moved | **no, `[0, 0]`** | **no, `[0, 0]`** |

**The menu does not close and it does not move.** That second half is what makes this benign
rather than a detached-popover bug: the menu is anchored to a trigger that lives in the
sidebar, and the sidebar is a **separate scroll container** from the thread, so scrolling the
thread cannot move the trigger the menu is attached to. Escape still closes it and scrolling
back restores the view.

An earlier version of this section, and a since-corrected comment below, said the scroll
carries the menu off screen with its trigger. That was **wrong**, and the evidence image
refutes it: **0 differing pixels for x < 402**, so the sidebar and the open menu are
byte-identical between the two sides.

The wheel-over-the-SIDEBAR case is **unmeasurable in this fixture**: the sidebar does not
overflow (`scrollHeight` 753 against `clientHeight` 753, identical), so there is nothing to
scroll. It is not claimed either way.

`app-sidebar.tsx` already ships a `modal={false}` menu with this behaviour, so it is the
existing precedent rather than a new shape.

### 2. Focus is not returned to the trigger when an outside PRESS dismisses the menu

> **Pre-existing defect, filed as #9245, extended to three more menus by this PR and not fixed
> here.** It reproduces on `main` today on the sidebar's already-non-modal "More" menu, on all
> three engines. The mechanism is established and a fix is designed in that issue; its
> recommended home is #9051, which owns the guard. This PR does not introduce it and does not
> own the file it lives in.

Escape is unaffected and is the path that matters most for keyboard and screen-reader users:
`focus_return_escape` is **3/3 on base, this branch and the mutant**, all three menus, all three
engines. Focus returns to the trigger button with its accessible name.

Dismissing with an outside press is different:

| | base | this branch | guardless mutant |
|---|---|---|---|
| focus after the press | trigger `BUTTON` | **`BODY`** | `TEXTAREA` (it navigated) |

`focus_detached` and `focus_in_menu_subtree` are both false, so it is a clean drop to `<body>`,
not focus stranded on an unmounted node.

**This is inherited from the guard, not introduced here.** The control settles it exactly as it
did for the double click: the sidebar's overflow "More" menu is ALREADY `modal={false}` with the
same guard on the base tree, untouched by this PR, and it drops focus to `<body>` **on base**,
on all three engines. So the behaviour belongs to the non-modal-plus-guard pattern and this PR
extends it to three more menus. Filed as #9245.

The mechanism, from a focus timeline sampled at every event of the gesture:

```
base   pointerdown -> menu content ... blur -> BODY ... click -> BODY
       +50ms -> BODY   then  focusin -> BUTTON[Chat options]      <- Radix restores, late
this   pointerdown -> menu content ... focusin -> BUTTON{the row} <- the press focuses the row
branch click(capture) -> the row ... blur -> BODY                 <- the guard blurs it
       +1000ms -> BODY                                            <- Radix never restores
```

Two things combine. The press focuses the row (on base it cannot, because
`pointer-events: none` sends the press to `HTML`), so Radix sees focus already outside the menu
and declines to restore it. Then `releaseFocusTakenByTheSwallowedPress` in `menu-dismiss.ts`
calls `active.blur()` to kill the pending Space activation, and nothing puts focus back.

That blur is deliberate and load-bearing: it is what makes `dismiss_then_space_did_not_navigate`
pass, one of the checks proven to discriminate. So the fix is not to remove it but to redirect
it, focusing the trigger instead of blurring to nothing, which removes the pending activation
and restores the recovery point in one move.

The comment in `menu-dismiss.ts` that chose blur over restore says *"measured on the pre-PR
shape, `document.activeElement` stays `BODY` throughout"* and *"Body is where the modal shape
left focus anyway"*. The timeline above shows why that is half right: on base focus IS `BODY`
through pointerdown, click and +50 ms, and then Radix's restore lands and it ends on the
trigger. The observation was taken at the wrong instant, and the end state is the opposite.

### 3. The shared guard's double-click over-swallow

**One defect in the shared guard comes with it, and it is not mine to claim as new.** A fast
double click outside an open menu loses its second click: the guard swallows both. Measured
10 times per arm, the three converted menus deliver 0 of 2 on this branch. The control settles
it: the sidebar's overflow "More" menu is ALREADY `modal={false}` with the same guard on the
base tree, untouched by this PR, and it delivers 0 of 2 on base as well, 10 times out of 10.
The guardless mutant delivers 2 of 2. So the over-swallow belongs to `menu-dismiss.ts` and
predates these three menus; this PR extends the guard's reach and the behaviour travels with
it. Worth fixing in the guard, not here.

### 4. A control must be pressed twice to activate it while a menu is open

`underlying_swallowed` 3/3 with `neutral_click_after` 3/3 means the first press outside an open
menu is consumed and the second lands. That is the guard's deliberate design, inherited from
#9051. As noted above, it **cannot** be compared against base from this data, because the base
column is the confounded `<html>` measurement. It is described, not scored.

## A modal dialog still shields these menus

The risk that justifies all of the above: Radix's modal layer is what normally guarantees
overlay stacking, so taking three menus off it could let them punch through a modal dialog. It
does not. A genuinely modal dialog (`open={creatingProject}`, confirmed
`getComputedStyle(document.body).pointerEvents === "none"` on every arm, including this branch)
was opened with no menu open, and the menu trigger was then pressed.

`menu_blocked_by_modal_dialog`, 3/3 in every cell, identical on chromium, firefox and webkit:

| menu | base | this branch | guardless mutant |
|---|---|---|---|
| sidebar "Chat options" | blocked | **blocked** | blocked |
| sidebar "Organize chats" | blocked | **blocked** | blocked |
| CONTROL: sidebar "More", already non-modal on base | not blocked | not blocked | not blocked |

**base equals this branch on both converted menus, so there is no regression**, and the dialog
keeps its own shield on this branch (`dialog_is_modal`, `dialog_has_focus`,
`dialog_escape_closes` and `body_restored_after_close` all true everywhere).

The control is the reason to believe the check rather than the number it produced: it reports
"not blocked" while the converted menus report "blocked", in the same run, so the check is
demonstrably able to move rather than stuck on one value.

Two things this does NOT establish. `dialog_still_open_after` is false in every cell, so the
trigger press also dismisses the dialog, and what is measured is strictly that a press at the
trigger's location does not produce a menu while a modal dialog is up. Whether that is because
the dialog refuses the press or because the hover-revealed trigger is simply unreachable under
`pointer-events: none` is **unestablished**; the verdict survives because base behaves
identically, but the mechanism does not follow from this data.

That control result is itself a pre-existing defect on `main`, filed as #9244. It is not caused
by this PR, it reproduces identically on base, and it is **deliberately not fixed here**.

## The general lesson from the evidence in this PR

Stated once rather than repeated as three separate caveats: **a check can support a comparison
between arms while being unable to support a claim about why either arm behaves as it does.**
Most of the results above are of the first kind. Where a mechanism is asserted, it is because
something independent establishes it; where it is not, that is said.

## The eleven-menu count, and the file to leave alone

`features/chat/thread-sidebar.tsx` has ZERO importers. Nothing under `src/` or `tests/`
references it and vite tree-shakes it out, so the two menus #9051 converts there never mount;
that is why its headline count of eleven is eight live menus. This PR does not touch it, and
the new test pins that fact with an importer sweep, so if it ever gains an importer the test
says so instead of the menus quietly joining the matrix unmeasured.

## Tests

`studio/frontend/tests/sidebar-menu-modality.test.ts`, four tests: each of the three menus is
pinned non-modal AND guarded, and the two pinned files are required to have live importers
while `thread-sidebar.tsx` is required not to.

Every assertion was shown to fail on a deliberately broken tree, **individually**: ten
mutations, each turning exactly one test red, with the tree checksummed between them and
green again at the end. Six flip one half of one site (modal back on, or the guard removed);
one gives `thread-sidebar.tsx` an importer; one pins a file that has none; one makes the
source walk reach nothing; one points a marker at a menu that does not exist.

The runtime assertions were shown to kill something too. A third Studio serves a mutant build
that is this branch with `modal={false}` kept and `<MenuDismissGuard />` removed.

`underlying_swallowed` is 3/3 on head and **0/3 on the mutant** on all three menus and all
three engines, and `touch_underlying_swallowed` likewise on firefox and webkit. The
double-click counter inverts just as cleanly: head delivers 0 of 2 ten times out of ten, the
mutant 2 of 2 ten times out of ten, on every menu and every engine.

`held_dismiss_did_not_navigate`, `quick_dismiss_did_not_navigate` and
`dismiss_then_space_did_not_navigate` are 3/3 on head and 0/3 on the mutant **on the two "Chat
options" menus** -- the dismissing press navigates away. On the list-header menu those three
are 3/3 on the mutant as well, so they are **not** a kill there; as noted above, the harness's
press never dismisses that menu on any tree, so there is no swallowed click for the guard to
be credited with. The list-header menu's kill rests on `underlying_swallowed`,
`neutral_click_after`, `touch_underlying_swallowed` and the double-click counter instead.

One cell does not kill and is reported rather than dropped: `touch_underlying_swallowed` on
the sidebar "Chat options" menu is 3/3 on the mutant on **chromium**, where the tap does not
close that menu at all, so it never reaches the element being counted. It kills normally on
firefox and webkit.

## Gates

`npm run typecheck` (`tsc -b` plus `tsconfig.test.json`) and `npm run build` both pass.
`npm test` is 3799/3800; the one failure is `queued-model-capabilities.test.ts`, the inherited
`ERR_MODULE_NOT_FOUND` that #9220 fixes, and it fails identically on the base worktree.

`npx eslint` on the two changed source files reports **19 problems (9 errors, 10 warnings) on
this branch and the identical 19 on base**, differing only by a two-line offset that matches
the two lines this PR adds to `chat-page.tsx`. All of them are pre-existing
`react-hooks/set-state-in-effect` and `exhaustive-deps` findings in code this PR does not
touch. The new test file lints clean.

Note `npm run typecheck` is `tsc -b`. `tsc --noEmit -p tsconfig.json` checks nothing here,
because that config is references-only.

## CI

**The four red checks on this PR are main-side and are not from this change.** `(Python 3.13)`,
`Frontend build + bundle sanity`, `Frontend unit tests (Windows)` and `Repo tests (CPU)` fail
identically on every open PR against this base, including ones that touch no frontend code at
all. They are fixed by #9220, which is green at 38/0. The other 28 checks pass here. Please do
not read this PR as red.

Fixes #9168.

