### PR TITLE
Studio: window the streaming reasoning pane's Markdown blocks

### DIFF
--- a/studio/frontend/smoke-reasoning-pane-main.tsx
+++ b/studio/frontend/smoke-reasoning-pane-main.tsx
@@ -1,0 +1,481 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// Harness page for tests/studio/playwright_reasoning_pane.py: the real Thread STREAMING a long
+// reasoning part, so what is measured is what a user watching a thinking model actually pays.
+//
+// WHY THIS EXISTS SEPARATELY FROM smoke-heavy-thread
+//
+// smoke-heavy-thread seeds a FINISHED thread through `thread.import` and its content mix is
+// text, code fences, tool calls and images. It has no reasoning part at all, and it could not
+// usefully have one: a finished reasoning group resolves to CLOSED
+// (features/chat/utils/reasoning-visibility.ts -> resolveReasoningOpen returns false when
+// `isStreaming` is false and the user has not opened it by hand), and Radix unmounts a closed
+// CollapsibleContent, so a seeded thread carries ZERO reasoning DOM. Every number that harness
+// has ever published was taken on a thread with no thinking block in it.
+//
+// The cost lives on the streaming path, so this fixture streams. The reasoning group is open
+// for the whole run because that is what `resolveReasoningOpen` returns while a group is
+// receiving deltas, which is what a user sees.
+//
+// WHAT IT REPRODUCES
+//
+// A field trace from Unsloth Desktop on Arch / Wayland / WebKitGTK 2.52.5, one long generation,
+// sampled every 5 seconds:
+//
+//     t=5s     fps 59.4   reasoningChars  2,256   reasoningCodeSpans      0   elements    578
+//     t=130s   fps 39.7   reasoningChars 45,943   reasoningCodeSpans  3,520   elements  4,755
+//     t=216s   fps 20.5   reasoningChars 73,178   reasoningCodeSpans 11,875   elements 13,688
+//     t=241s   fps 18.2   reasoningChars 80,434   reasoningCodeSpans 14,433   elements 16,513
+//     t=271s   fps 28.3   reasoningChars 90,262   reasoningCodeSpans 16,186   elements 18,536
+//     t=276s   run COMPLETED, reasoningCodeSpans 0, elements 621, fps recovers
+//
+// So the fixture's shape is fixed by the trace: ONE reasoning part reaching ~90,000 characters,
+// dense enough in fenced code to reach ~16,000 `pre code span` inside `.aui-reasoning-text`.
+// `reasoningCodeSpans` is the trace's own selector and it is reproduced verbatim below.
+//
+// The completion row is part of the fixture, not an afterthought: the drop from 18,536 elements
+// to 621 is what proves the cost is IN the reasoning pane rather than merely correlated with it.
+// So the adapter always emits a short final text answer after the reasoning, which flips
+// `message.status.type` off `running`, closes the group and unmounts its content.
+//
+// Content is UNIQUE per unit on purpose. The highlighter caches tokens keyed on the exact source
+// string, so a fixture that repeats one fence would highlight it once and hand back the cached
+// result for every copy, and the Shiki cost would vanish from the curve.
+
+import { Thread } from "@/components/assistant-ui/thread";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import {
+  AssistantRuntimeProvider,
+  type ChatModelAdapter,
+  useAui,
+  useLocalRuntime,
+} from "@assistant-ui/react";
+import {
+  RouterProvider,
+  createMemoryHistory,
+  createRootRoute,
+  createRouter,
+} from "@tanstack/react-router";
+import { type ReactElement, useEffect } from "react";
+import { createRoot } from "react-dom/client";
+import "./src/index.css";
+
+// The local runtime's thread list item reports a synthetic `__LOCALID_...` remoteId, which is
+// truthy, so the fork-count badge really does fire one GET per assistant message. Answering them
+// here, before anything mounts, keeps that off the wire entirely.
+const realFetch = window.fetch.bind(window);
+window.fetch = (input, init) => {
+  const url =
+    typeof input === "string" ? input : ((input as Request).url ?? String(input));
+  if (url.includes("/api/")) {
+    return Promise.resolve(
+      new Response("{}", {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+  }
+  return realFetch(input, init);
+};
+
+// ── the reasoning fixture ───────────────────────────────────────────
+//
+// Thinking text from a model that is working through code looks like this: a line or two of
+// deliberation, then a fence it is drafting, then more deliberation. The trace's ratio of
+// characters to highlight spans (90,262 / 16,186 = 5.6 characters per span) says the content is
+// overwhelmingly fenced code, because prose contributes characters and no spans at all. So the
+// units below are mostly fence.
+
+const DELIBERATION = [
+  "Let me reconsider the scoring step; the weighting is not obviously right yet.",
+  "Wait, that misses the empty rows, so the denominator is wrong. Try again.",
+  "I should check the boundary where the batch is smaller than the window.",
+  "That reads better. Now the client half has to agree with it exactly.",
+  "Hold on, the label filter has to run before the sum, not after.",
+  "Writing it out makes the off-by-one obvious, so let me redo the loop.",
+];
+
+/**
+ * A python fence unique to `index`, sized to about `targetChars`.
+ *
+ * Dense on purpose: identifiers, punctuation, strings and numbers are each a separate token, and
+ * the trace's span density is what the fixture has to hit.
+ */
+function pythonFence(index: number, targetChars: number): string {
+  const lines = [
+    "```python",
+    `# draft ${index}: weighted batch scorer`,
+    "from dataclasses import dataclass",
+    "",
+    "@dataclass",
+    `class Row${index}:`,
+    "    weight: float",
+    "    count: int",
+    "    label: str",
+    "",
+  ];
+  let step = 0;
+  while (lines.join("\n").length < targetChars) {
+    lines.push(
+      `def score_${index}_${step}(rows: list[Row${index}], cap: float = ${step + 1}.${(index * 7 + step) % 97}) -> float:`,
+      `    """Draft ${step} of ${index}: sum weighted counts, skip the empties."""`,
+      "    total, seen = 0.0, 0",
+      "    for row in rows:",
+      `        if row.count == 0 or row.label == "skip-${step}":`,
+      "            continue",
+      `        total += min(cap, row.weight * row.count * ${(step % 13) + 1}.${(index + step) % 89})`,
+      "        seen += 1",
+      "    return total / seen if seen else 0.0",
+      "",
+    );
+    step += 1;
+  }
+  lines.push("```");
+  return lines.join("\n");
+}
+
+function typescriptFence(index: number, targetChars: number): string {
+  const lines = [
+    "```typescript",
+    `// draft ${index}: the client half, so one grammar is not the whole story`,
+    `export interface Row${index} {`,
+    "  readonly weight: number;",
+    "  readonly count: number;",
+    "  readonly label: string;",
+    "}",
+    "",
+  ];
+  let step = 0;
+  while (lines.join("\n").length < targetChars) {
+    lines.push(
+      `export function score${index}_${step}(rows: readonly Row${index}[], cap = ${step + 1}.${(index * 5 + step) % 89}): number {`,
+      "  let total = 0, seen = 0;",
+      "  for (const row of rows) {",
+      `    if (row.count === 0 || row.label === "skip-${step}") continue;`,
+      `    total += Math.min(cap, row.weight * row.count * ${(step % 11) + 1}.${(index + step) % 73});`,
+      "    seen += 1;",
+      "  }",
+      "  return seen === 0 ? 0 : total / seen;",
+      "}",
+      "",
+    );
+    step += 1;
+  }
+  lines.push("```");
+  return lines.join("\n");
+}
+
+function jsonFence(index: number, targetChars: number): string {
+  // One very long line on purpose. A single-line document is the shape that behaves worst in a
+  // highlighter and in any code that scans for line boundaries.
+  const entries: string[] = [];
+  let step = 0;
+  let body = "";
+  while (body.length < targetChars) {
+    entries.push(
+      `{"id":"row-${index}-${step}","weight":${(step % 17) + 0.5},"count":${step * 3 + index},"label":"batch-${index}-${step}"}`,
+    );
+    body = `{"draft":${index},"rows":[${entries.join(",")}]}`;
+    step += 1;
+  }
+  return ["```json", body, "```"].join("\n");
+}
+
+const FENCES = [pythonFence, typescriptFence, pythonFence, jsonFence];
+
+/** Deliberation prose unique to `index`, about `targetChars` long. */
+function deliberation(index: number, targetChars: number): string {
+  if (targetChars <= 0) return DELIBERATION[index % DELIBERATION.length];
+  const parts: string[] = [];
+  let length = 0;
+  let cursor = index;
+  while (length < targetChars) {
+    const line = `${DELIBERATION[cursor % DELIBERATION.length]} (pass ${cursor - index + 1} of draft ${index})`;
+    parts.push(line);
+    length += line.length + 2;
+    cursor += 1;
+  }
+  return parts.join("\n\n");
+}
+
+/**
+ * The whole reasoning part, as one string of about `totalChars`.
+ *
+ * Two knobs, because length and span DENSITY are separate variables and the trace pins both.
+ * `fenceChars` sets how much fenced code each unit carries, `proseChars` how much prose sits
+ * between the fences. Prose contributes characters and no highlight spans at all, so the ratio
+ * of the two is what moves characters-per-span.
+ *
+ * The trace's 90,262 characters carried 16,186 spans, i.e. 5.6 characters per span. An earlier
+ * all-fence version of this fixture measured 3.47, which would have put ~26,000 spans on a
+ * 90,000-character run: a harder workload than the user's, which would have overstated every
+ * number taken from it. The defaults below are set from that measurement, and the driver prints
+ * the density it achieved so the calibration can be checked rather than trusted.
+ */
+export function buildReasoning(
+  totalChars: number,
+  fenceChars: number,
+  proseChars: number,
+  preambleChars: number,
+): string {
+  const parts: string[] = [];
+  let length = 0;
+  let index = 0;
+  // A stretch of thinking with NO completed fence in it, first, because that is where the
+  // measured onset is.
+  //
+  // In the field capture the page held 60.0 fps and 0 highlight spans for the first 90 seconds
+  // and 33,348 characters of reasoning, and lost a frame only once the first fence CLOSED. Prose
+  // costs 8.3 pane elements per 1000 characters; fenced code costs 169, twenty times as much. A
+  // fixture whose first unit is a fence starts on the expensive side of that step and cannot show
+  // where the step is.
+  while (length < preambleChars) {
+    const unit = `${deliberation(index, 900)}\n\n`;
+    parts.push(unit);
+    length += unit.length;
+    index += 1;
+  }
+  while (length < totalChars) {
+    const lead = deliberation(index, proseChars);
+    const fence = FENCES[index % FENCES.length](index, fenceChars);
+    const unit = `${lead}\n\n${fence}\n\n`;
+    parts.push(unit);
+    length += unit.length;
+    index += 1;
+  }
+  return parts.join("").slice(0, totalChars);
+}
+
+const ANSWER =
+  "Here is the scorer, with the empty rows skipped and the cap applied before the mean.";
+
+type RunOptions = {
+  totalChars?: number;
+  fenceChars?: number;
+  proseChars?: number;
+  preambleChars?: number;
+  chunkChars?: number;
+  gapMs?: number;
+  footnoteAtChars?: number;
+};
+
+/**
+ * A GFM footnote REFERENCE, appended once the stream passes `footnoteAtChars` and kept for the
+ * rest of the run.
+ *
+ * This is the case that closed PR #9073, reproduced live rather than argued about. A footnote
+ * reference makes this renderer treat the WHOLE document as one block, so the moment it arrives
+ * the block list collapses from hundreds of entries to one, retroactively, behind content that
+ * has already been rendered and measured. Any windowing scheme that carries a position across
+ * that moment carries it into a document that no longer has the divisions the position was
+ * expressed in.
+ */
+const LATE_FOOTNOTE = "\n\nA late reference[^z] appears.\n\n[^z]: the definition.";
+
+let config: Required<RunOptions> = {
+  totalChars: 90_000,
+  fenceChars: 1_800,
+  proseChars: 1_250,
+  // A quarter of the body, matching the field capture's 33,348 of 131,350 characters before the
+  // first fence closed.
+  preambleChars: 22_500,
+  chunkChars: 24,
+  gapMs: 2,
+  // Off by default: every measurement in the matrix runs without it, so it cannot quietly change
+  // a number that is compared against another arm.
+  footnoteAtChars: 0,
+};
+
+const stream = {
+  startedAt: 0,
+  sentChars: 0,
+  arrivals: 0,
+  reasoningEndedAtMs: null as number | null,
+  endedAtMs: null as number | null,
+  footnoteAtMs: null as number | null,
+  totalChars: 0,
+};
+
+const sleep = (ms: number) =>
+  new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
+// Stands in for the network, not the renderer: the same growing cumulative reasoning text a
+// thinking model's adapter yields, at a fixed rate.
+//
+// Cumulative, not delta: that is what assistant-ui's local runtime contract wants and what the
+// app's own adapter sends, and it is also the shape that makes a whole-subtree re-render
+// possible, which is one of the things under investigation here.
+const adapter: ChatModelAdapter = {
+  async *run() {
+    const reasoning = buildReasoning(
+      config.totalChars,
+      config.fenceChars,
+      config.proseChars,
+      config.preambleChars,
+    );
+    stream.totalChars = reasoning.length;
+    stream.startedAt = performance.now();
+    let cursor = 0;
+    while (cursor < reasoning.length) {
+      cursor = Math.min(reasoning.length, cursor + config.chunkChars);
+      stream.arrivals += 1;
+      stream.sentChars = cursor;
+      const late =
+        config.footnoteAtChars > 0 && cursor >= config.footnoteAtChars
+          ? LATE_FOOTNOTE
+          : "";
+      if (late && stream.footnoteAtMs === null) {
+        stream.footnoteAtMs = performance.now() - stream.startedAt;
+      }
+      yield {
+        content: [
+          { type: "reasoning" as const, text: reasoning.slice(0, cursor) + late },
+        ],
+      };
+      await sleep(config.gapMs);
+    }
+    stream.reasoningEndedAtMs = performance.now() - stream.startedAt;
+    // The final answer is what ends the reasoning round. Without it the group's
+    // `isReasoningStreaming` would go false only because the message stopped running, and the
+    // completion row of the trace -- the collapse and the fps recovery -- would still happen but
+    // would not be the shape a real reply has.
+    yield {
+      content: [
+        {
+          type: "reasoning" as const,
+          text: reasoning + (config.footnoteAtChars > 0 ? LATE_FOOTNOTE : ""),
+        },
+        { type: "text" as const, text: ANSWER },
+      ],
+    };
+    stream.endedAtMs = performance.now() - stream.startedAt;
+  },
+};
+
+// ── the page API ────────────────────────────────────────────────────
+
+function ReasoningPaneApi(): null {
+  const aui = useAui();
+
+  useEffect(() => {
+    const api = {
+      /** Start the generation. Returns immediately; poll `snapshot()`. */
+      run(options: RunOptions = {}): void {
+        config = { ...config, ...options };
+        stream.startedAt = 0;
+        stream.sentChars = 0;
+        stream.arrivals = 0;
+        stream.reasoningEndedAtMs = null;
+        stream.endedAtMs = null;
+        stream.footnoteAtMs = null;
+        // From a later task, so the runtime's own startup does not land inside a measurement
+        // window that the driver opened in this one.
+        setTimeout(() => {
+          void aui.thread().append({
+            role: "user",
+            content: [{ type: "text", text: "think this through and show the code" }],
+          });
+        }, 0);
+      },
+      /**
+       * The trace's columns, and nothing else in the hot path.
+       *
+       * `reasoningCodeSpans` is the trace's selector verbatim: `pre code span` scoped to
+       * `.aui-reasoning-text`. Scoping matters -- the same selector unscoped would also count the
+       * answer's fences and every other message's, and the whole point of the completion row is
+       * that the reasoning ones go to zero while the rest of the thread does not.
+       */
+      sample(): Record<string, number | boolean> {
+        const at = performance.now();
+        const pane = document.querySelector(".aui-reasoning-text");
+        const reasoningChars = pane ? (pane.textContent ?? "").length : 0;
+        const reasoningCodeSpans = document.querySelectorAll(
+          ".aui-reasoning-text pre code span",
+        ).length;
+        const totalElements = document.getElementsByTagName("*").length;
+        // The field capture reports `totalElements - reasoningElements` as a CONSTANT 578 for
+        // every sample the pane is mounted, i.e. every node the page gains is the thinking pane
+        // and nothing else in the app grows at all. Counting both is what lets that be checked
+        // here rather than assumed.
+        const reasoningElements = document.querySelectorAll(".aui-reasoning-text *").length;
+        return {
+          sampleCostMs: Math.round((performance.now() - at) * 100) / 100,
+          reasoningChars,
+          reasoningCodeSpans,
+          reasoningElements,
+          elementsOutsideReasoning: totalElements - reasoningElements,
+          reasoningPanes: document.querySelectorAll(".aui-reasoning-text").length,
+          reasoningOpen: Boolean(
+            document.querySelector('[data-slot="reasoning-root"][data-state="open"]'),
+          ),
+          totalElements,
+          allCodeSpans: document.querySelectorAll("pre code span").length,
+          sentChars: stream.sentChars,
+          arrivals: stream.arrivals,
+          streamDone: stream.endedAtMs !== null,
+        };
+      },
+      /** Stream bookkeeping the DOM cannot answer. */
+      streamState(): Record<string, number | null | boolean> {
+        return {
+          startedAt: stream.startedAt,
+          sentChars: stream.sentChars,
+          arrivals: stream.arrivals,
+          totalChars: stream.totalChars,
+          reasoningEndedAtMs: stream.reasoningEndedAtMs,
+          endedAtMs: stream.endedAtMs,
+          footnoteAtMs: stream.footnoteAtMs,
+          done: stream.endedAtMs !== null,
+        };
+      },
+      /** What the fixture would build, without building the page. Used to calibrate density. */
+      preview(
+        totalChars: number,
+        fenceChars: number,
+        proseChars: number,
+        preambleChars: number,
+      ): number {
+        return buildReasoning(totalChars, fenceChars, proseChars, preambleChars).length;
+      },
+    };
+    (window as unknown as { __reasoningPane: typeof api }).__reasoningPane = api;
+  }, [aui]);
+
+  return null;
+}
+
+function Harness(): ReactElement {
+  const runtime = useLocalRuntime(adapter);
+  return (
+    <TooltipProvider>
+      <AssistantRuntimeProvider runtime={runtime}>
+        <ReasoningPaneApi />
+        {/* Thread is flex-1 basis-0 min-h-0, so it needs a bounded flex parent to scroll. */}
+        <div
+          data-smoke="reasoning-pane"
+          style={{ display: "flex", flexDirection: "column", height: "100vh" }}
+        >
+          <Thread hideWelcome={true} />
+        </div>
+      </AssistantRuntimeProvider>
+    </TooltipProvider>
+  );
+}
+
+// Thread reaches useNavigate (the fork action, the composer tools menu). Without a router in
+// context tanstack's useRouter still works, but console.warns on every render of every action
+// bar, which scales with the thread and is serialised over the debugging channel.
+const rootRoute = createRootRoute({ component: Harness });
+const router = createRouter({
+  routeTree: rootRoute,
+  history: createMemoryHistory({ initialEntries: ["/"] }),
+});
+
+const root = document.getElementById("root");
+if (!root) {
+  throw new Error("missing #root");
+}
+createRoot(root).render(<RouterProvider router={router as unknown as never} />);

--- a/studio/frontend/smoke-reasoning-pane.html
+++ b/studio/frontend/smoke-reasoning-pane.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <script src="/crypto-boot.js"></script>
+    <title>reasoning pane smoke</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/smoke-reasoning-pane-main.tsx"></script>
+  </body>
+</html>

--- a/studio/frontend/src/components/assistant-ui/block-window-context.tsx
+++ b/studio/frontend/src/components/assistant-ui/block-window-context.tsx
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"use client";
+
+/* eslint-disable react-refresh/only-export-components */
+
+/**
+ * The DOM and React half of the streaming reasoning pane's block window. The arithmetic lives in
+ * block-window.ts, which imports neither.
+ *
+ * There are two contexts, and the split is not decorative. A reasoning GROUP can hold more than
+ * one reasoning part, and each part renders its own <MarkdownText/>, i.e. its own Streamdown
+ * document with its own block indices starting at 0. So:
+ *
+ *   BlockWindowPaneContext   supplied by ReasoningText, carries the scroll container. Present
+ *                            only while the pane is streaming, which is also the only time the
+ *                            pane is height-capped, so the window and the 256px cap are exactly
+ *                            co-extensive.
+ *   BlockWindowContext       supplied per Streamdown document by BlockWindowDocument, carries
+ *                            that document's controller. Block components read this one.
+ *
+ * Without a pane context nothing is provided, `useBlockWindowMounted` says true, and the tree
+ * is what it is today. The main answer's MarkdownText never sees a pane context.
+ */
+
+import {
+  type ReactNode,
+  type RefObject,
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useState,
+  useSyncExternalStore,
+} from "react";
+
+import { BlockWindowController } from "./block-window-controller";
+
+const NO_UNSUBSCRIBE = (): void => {};
+
+// ── contexts ────────────────────────────────────────────────────────
+
+export type BlockWindowPane = {
+  paneRef: RefObject<HTMLDivElement | null>;
+};
+
+const BlockWindowPaneContext = createContext<BlockWindowPane | null>(null);
+const BlockWindowContext = createContext<BlockWindowController | null>(null);
+
+/**
+ * Marks the subtree as a windowable pane. Rendered by ReasoningText while the group streams, and
+ * by nothing else, which is what keeps the answer text and settled panes out of scope.
+ */
+export function BlockWindowPaneProvider({
+  paneRef,
+  enabled,
+  children,
+}: {
+  paneRef: RefObject<HTMLDivElement | null>;
+  enabled: boolean;
+  children: ReactNode;
+}): ReactNode {
+  const value = useMemo(
+    () => (enabled ? { paneRef } : null),
+    [enabled, paneRef],
+  );
+  return (
+    <BlockWindowPaneContext.Provider value={value}>
+      {children}
+    </BlockWindowPaneContext.Provider>
+  );
+}
+
+/**
+ * Whether this subtree is inside a pane that windows its blocks. Read by MarkdownText to pick a
+ * block component; a document that is not windowed renders exactly the tree it renders today.
+ */
+export function useBlockWindowPaneActive(): boolean {
+  return useContext(BlockWindowPaneContext) !== null;
+}
+
+/**
+ * One Streamdown document's window: owns the controller, renders the spacer, and is where the
+ * scroll compensation runs, in a layout effect of the very commit that dropped the blocks.
+ */
+export function BlockWindowDocument({
+  children,
+}: {
+  children: ReactNode;
+}): ReactNode {
+  const pane = useContext(BlockWindowPaneContext);
+  // Lazy state rather than a ref: the controller has to survive re-renders and it is read during
+  // render (the context value), which a ref may not be.
+  const [ownController] = useState(() => new BlockWindowController());
+  const controller = pane ? ownController : null;
+
+  useEffect(() => {
+    if (!(controller && pane)) {
+      return;
+    }
+    return controller.attach(pane.paneRef.current);
+  }, [controller, pane]);
+
+  const subscribe = useMemo(
+    () => controller?.subscribeDocument ?? (() => NO_UNSUBSCRIBE),
+    [controller],
+  );
+  const getSpacerHeight = useCallback(
+    () => controller?.spacerHeight() ?? 0,
+    [controller],
+  );
+  const spacerHeight = useSyncExternalStore(
+    subscribe,
+    getSpacerHeight,
+    getSpacerHeight,
+  );
+
+  // No dependency array: this has to run on the commit that moved the window, and that commit is
+  // driven by the store subscription above rather than by a prop.
+  useLayoutEffect(() => {
+    controller?.settleAfterCommit();
+  });
+
+  if (!controller) {
+    return children;
+  }
+  return (
+    <BlockWindowContext.Provider value={controller}>
+      <div
+        aria-hidden="true"
+        data-aui-block-window-spacer=""
+        ref={controller.spacerRef}
+        style={{ height: spacerHeight }}
+      />
+      {children}
+    </BlockWindowContext.Provider>
+  );
+}
+
+/**
+ * Whether a Streamdown block belongs in the tree, and the block's report of its own content.
+ *
+ * Every block calls this, mounted or not: a withheld block still renders (it returns null), so the
+ * whole document is observed even though only a suffix of it is in the DOM, which is what lets a
+ * retroactive re-parse be noticed at all.
+ *
+ * Outside a windowed pane there is no controller and the answer is always true.
+ */
+export function useBlockWindowMounted(index: number, content: string): boolean {
+  const controller = useContext(BlockWindowContext);
+
+  const subscribe = useCallback(
+    (onChange: () => void) =>
+      controller ? controller.subscribeBlock(index, onChange) : NO_UNSUBSCRIBE,
+    [controller, index],
+  );
+  const getMounted = useCallback(
+    () => controller?.isMounted(index) ?? true,
+    [controller, index],
+  );
+  const mounted = useSyncExternalStore(subscribe, getMounted, getMounted);
+
+  useEffect(() => {
+    controller?.reportContent(index, content);
+  }, [controller, index, content]);
+
+  return mounted;
+}
+
+/**
+ * The callback ref for a mounted block's slot element.
+ *
+ * Returned rather than read: `react-hooks/refs` rejects a component that INSPECTS a ref during
+ * render, so the caller hands this straight to `ref=` and never looks at it.
+ */
+export function useBlockWindowMarker(
+  index: number,
+): ((element: HTMLElement | null) => void) | null {
+  const controller = useContext(BlockWindowContext);
+  return controller ? controller.markerRef(index) : null;
+}

--- a/studio/frontend/src/components/assistant-ui/block-window-controller.ts
+++ b/studio/frontend/src/components/assistant-ui/block-window-controller.ts
@@ -1,0 +1,415 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+/**
+ * One streaming reasoning pane document's block window, as a plain object graph.
+ *
+ * Deliberately free of React and of JSX. React reads it through a context whose value NEVER
+ * changes identity while the window is live (see block-window-context.tsx): if the window state
+ * were context state, every one of the thousands of block components would re-render on every
+ * window move, which is the cost being removed. Instead each block subscribes to its own index
+ * and only the handful whose mounted state flips is told anything.
+ *
+ * Being plain is also what makes it testable: the only browser API it needs is
+ * `getBoundingClientRect`, three observers and four numbers off the scroll container, all of
+ * which a test can supply.
+ */
+
+import { flushSync } from "react-dom";
+
+import {
+  type BlockWindowState,
+  PANE_BOTTOM_THRESHOLD_PX,
+  WINDOW_ROOT_MARGIN_PX,
+  blockWindowFlippedRange,
+  chooseBlockWindowStart,
+  createBlockWindowState,
+  isBlockMounted,
+  recordBlockContent,
+  recordBlockOffset,
+  resetBlockWindow,
+  setBlockWindowStart,
+} from "./block-window";
+
+/** How many mounted blocks at the top of the window are watched by the observer. */
+const OBSERVED_EDGE_BLOCKS = 3;
+
+const NO_UNSUBSCRIBE = (): void => {};
+
+/**
+ * One Streamdown document's window.
+ *
+ * Deliberately not a React component: the block components read it through a context whose value
+ * NEVER changes identity while the window is live. If the window state were context state, every
+ * one of the thousands of block components would re-render on every window move, which is the
+ * cost being removed. Instead each block subscribes to its own index and only the handful whose
+ * mounted state flips is told anything.
+ */
+export class BlockWindowController {
+  private readonly state: BlockWindowState = createBlockWindowState();
+  private readonly markers = new Map<number, HTMLElement>();
+  private readonly markerRefs = new Map<
+    number,
+    (element: HTMLElement | null) => void
+  >();
+  private readonly blockListeners = new Map<number, Set<() => void>>();
+  private readonly documentListeners = new Set<() => void>();
+  private readonly observedEdge = new Set<Element>();
+  private pane: HTMLElement | null = null;
+  private origin: HTMLElement | null = null;
+  private intersection: IntersectionObserver | null = null;
+  private paneWidth = 0;
+  private pendingReset = false;
+  private pendingCompensation: {
+    index: number;
+    top: number;
+    expectStart: number;
+  } | null = null;
+  /**
+   * The last residual the compensation had to correct, in CSS pixels. The spacer is sized to the
+   * exact height of the blocks it replaces, so this should be 0 and the compensation should be
+   * dead code; it is measured rather than assumed, and a test asserts the 0.
+   */
+  lastResidualPx = 0;
+
+  // ── what React reads ──────────────────────────────────────────────
+
+  isMounted(index: number): boolean {
+    return isBlockMounted(this.state, index);
+  }
+
+  spacerHeight(): number {
+    return this.state.spacerHeight;
+  }
+
+  windowStart(): number {
+    return this.state.start;
+  }
+
+  subscribeBlock(index: number, onChange: () => void): () => void {
+    let listeners = this.blockListeners.get(index);
+    if (!listeners) {
+      listeners = new Set();
+      this.blockListeners.set(index, listeners);
+    }
+    listeners.add(onChange);
+    return () => {
+      listeners.delete(onChange);
+      if (listeners.size === 0) {
+        this.blockListeners.delete(index);
+      }
+    };
+  }
+
+  subscribeDocument = (onChange: () => void): (() => void) => {
+    this.documentListeners.add(onChange);
+    return () => {
+      this.documentListeners.delete(onChange);
+    };
+  };
+
+  /** A stable ref callback per index, so a block's marker registration is not a new prop. */
+  markerRef(index: number): (element: HTMLElement | null) => void {
+    const existing = this.markerRefs.get(index);
+    if (existing) {
+      return existing;
+    }
+    const ref = (element: HTMLElement | null): void => {
+      if (element) {
+        this.markers.set(index, element);
+      } else {
+        this.markers.delete(index);
+      }
+    };
+    this.markerRefs.set(index, ref);
+    return ref;
+  }
+
+  /** The spacer, which is both the thing that replaces the dropped blocks and the measuring origin. */
+  spacerRef = (element: HTMLElement | null): void => {
+    this.origin = element;
+  };
+
+  /**
+   * Record a block's content, and reset if it shows the renderer re-segmented the document behind
+   * the live edge. Every block reports, mounted or not: a withheld block still renders (it returns
+   * null), so the whole document is observed even though only a suffix of it is in the DOM.
+   */
+  reportContent(index: number, content: string): void {
+    if (recordBlockContent(this.state, index, content)) {
+      this.invalidate();
+    }
+  }
+
+  /** Throw away every frozen height and remount the document on the next frame. */
+  invalidate(): void {
+    this.pendingReset = true;
+    this.measure();
+  }
+
+  // ── lifecycle ─────────────────────────────────────────────────────
+
+  attach(pane: HTMLElement | null): () => void {
+    this.pane = pane;
+    if (!pane) {
+      return NO_UNSUBSCRIBE;
+    }
+    this.paneWidth = pane.clientWidth;
+
+    // The window has to be re-decided on every commit that changed the pane, and the provider
+    // does not re-render when its children stream. A MutationObserver is what sees those commits.
+    // It runs in the microtask checkpoint after the commit, before paint.
+    const mutations = new MutationObserver(() => {
+      this.measure();
+    });
+    mutations.observe(pane, {
+      childList: true,
+      characterData: true,
+      subtree: true,
+    });
+
+    // A WIDTH change reflows every block, so every frozen height is wrong at once. Answer by
+    // resetting: that is what makes "a frozen height that is never revalidated" impossible here.
+    // A height change is the pane's own cap animating and means nothing.
+    const resizes = new ResizeObserver(() => {
+      if (pane.clientWidth === this.paneWidth) {
+        return;
+      }
+      this.paneWidth = pane.clientWidth;
+      this.invalidate();
+    });
+    resizes.observe(pane);
+
+    // Scrolling produces no mutations, so this is what notices a reader moving. Scroll events are
+    // deliberately not used. flushSync because an observation is delivered inside the rendering
+    // steps: without it React would commit the remount after the frame the reader already saw,
+    // and scrolling up would flash the spacer.
+    this.intersection = new IntersectionObserver(
+      () => {
+        flushSync(() => {
+          this.measure();
+        });
+      },
+      {
+        root: pane,
+        rootMargin: `${WINDOW_ROOT_MARGIN_PX}px 0px ${WINDOW_ROOT_MARGIN_PX}px 0px`,
+      },
+    );
+
+    this.measure();
+    return () => {
+      mutations.disconnect();
+      resizes.disconnect();
+      this.intersection?.disconnect();
+      this.intersection = null;
+      this.observedEdge.clear();
+      this.pane = null;
+    };
+  }
+
+  // ── the pass ──────────────────────────────────────────────────────
+
+  /**
+   * Measure what is mounted, then decide where the window starts.
+   *
+   * Order matters and is the whole trick. Offsets are recorded from the DOM as it stands NOW,
+   * before anything is dropped, so the height of the range that is about to be removed comes from
+   * a frame in which those blocks were still laid out. Nothing is derived from a scrollHeight
+   * delta, which streaming would poison.
+   */
+  private measure(): void {
+    const pane = this.pane;
+    const origin = this.origin;
+    if (!pane || !origin) {
+      return;
+    }
+
+    if (this.pendingReset) {
+      this.pendingReset = false;
+      const previousStart = this.state.start;
+      resetBlockWindow(this.state);
+      this.notifyBlocks(0, previousStart);
+      this.notifyDocument();
+      return;
+    }
+
+    const originTop = origin.getBoundingClientRect().top;
+    const paneTop = pane.getBoundingClientRect().top;
+    for (const [index, slot] of this.markers) {
+      const marker = slot.firstElementChild;
+      if (!marker) {
+        // An empty block. Streamdown's splitter emits "\n\n" blocks that render nothing, so a
+        // slot without an element child is normal and has no height to record.
+        continue;
+      }
+      recordBlockOffset(
+        this.state,
+        index,
+        marker.getBoundingClientRect().top - originTop,
+      );
+    }
+
+    // The pane's scroll position, in the same content coordinates as the offsets above.
+    const viewTop = paneTop - originTop;
+    const nextStart = chooseBlockWindowStart(this.state, viewTop);
+    this.refreshObservedEdge();
+    if (nextStart === this.state.start) {
+      return;
+    }
+
+    // The anchor has to be an element that exists on BOTH sides of the commit, because the
+    // compensation subtracts its position after from its position before.
+    //
+    // Moving the window FORWARD, the new start is already mounted and the old one is about to
+    // go, so the new start is the anchor. Moving it BACKWARD, which is what a reader scrolling
+    // up does, the new start is NOT MOUNTED YET: `markerElement(nextStart)` is null and the old
+    // code fell back to the spacer, whose top is the top of the whole content. It then compared
+    // the spacer's position before against the newly mounted BLOCK's position after, two
+    // different elements, and computed a residual the size of the spacer. Measured: a reader
+    // 1,440px up the pane was moved 8,271px down in one write, which put them at the bottom,
+    // which re-armed the pane's autoscroll, which pinned them there for the rest of the
+    // generation. Scroll-back was not degraded, it was inverted.
+    //
+    // The highest of the two starts is mounted in both states in either direction, so that is
+    // the anchor.
+    const previousStart = this.state.start;
+    const anchorIndex = Math.max(previousStart, nextStart);
+    const anchor = this.markerElement(anchorIndex) ?? origin;
+    const anchorTop = anchor.getBoundingClientRect().top - paneTop;
+    if (!setBlockWindowStart(this.state, nextStart)) {
+      return;
+    }
+    this.pendingCompensation = {
+      index: anchorIndex,
+      top: anchorTop,
+      expectStart: nextStart,
+    };
+    const flipped = blockWindowFlippedRange(previousStart, nextStart);
+    this.notifyBlocks(flipped.from, flipped.to);
+    this.notifyDocument();
+  }
+
+  /**
+   * Put the reader back where they were, explicitly, in the same layout pass as the mutation.
+   *
+   * CSS `overflow-anchor` is NOT relied on and is switched off on the pane: Playwright's WebKit
+   * implements it and real Safari does not, so the sanctioned test proxy would show scroll
+   * anchoring working while the WebKitGTK embed that ships in Tauri drifted.
+   */
+  settleAfterCommit(): void {
+    // The blocks that just entered the window registered their markers in this same commit, so
+    // this is the first moment the observer can be pointed at the new top of the window.
+    this.refreshObservedEdge();
+    const pending = this.pendingCompensation;
+    const pane = this.pane;
+    if (!pending || !pane) {
+      return;
+    }
+    // The window is decided in a MutationObserver microtask and applied by a React update, which
+    // does not have to land on the very next commit. A token arriving in between commits this
+    // component too, and answering THAT commit would compare the anchor against a DOM the drop
+    // has not reached yet and then throw the correction away. Wait until the registered markers
+    // say the drop is on screen.
+    // Wait until the DOM matches the window that was decided, in EITHER direction. The old
+    // test was "the lowest mounted index has reached the anchor", which only describes a window
+    // moving forward; a window moving backward mounts blocks BELOW the anchor, so that test
+    // never came true and the correction for a scroll-back was dropped every time.
+    if (this.lowestMarkerIndex() !== Math.max(pending.expectStart, 1)) {
+      return;
+    }
+    this.pendingCompensation = null;
+    const anchor = this.markerElement(pending.index) ?? this.origin;
+    if (!anchor) {
+      return;
+    }
+    const after =
+      anchor.getBoundingClientRect().top - pane.getBoundingClientRect().top;
+    const residual = after - pending.top;
+    this.lastResidualPx = residual;
+    if (residual === 0) {
+      return;
+    }
+    // While the pane is pinned to the bottom the autoscroll observer puts it back on this same
+    // frame, and a write here would only look like the reader scrolling up to the handler that
+    // watches for exactly that. Nothing is visible in that state either: the bottom is the bottom.
+    const distanceFromBottom =
+      pane.scrollHeight - pane.scrollTop - pane.clientHeight;
+    if (distanceFromBottom <= PANE_BOTTOM_THRESHOLD_PX) {
+      return;
+    }
+    pane.scrollTop += residual;
+  }
+
+  // ── plumbing ──────────────────────────────────────────────────────
+
+  private markerElement(index: number): Element | null {
+    return this.markers.get(index)?.firstElementChild ?? null;
+  }
+
+  /** The lowest block index currently registered, i.e. what the DOM says the window start is. */
+  private lowestMarkerIndex(): number {
+    let lowest = Number.POSITIVE_INFINITY;
+    for (const index of this.markers.keys()) {
+      if (index < lowest) {
+        lowest = index;
+      }
+    }
+    return lowest;
+  }
+
+  /**
+   * Watch the spacer and the first few mounted blocks, so a reader moving upward is noticed
+   * before the spacer can come into view.
+   */
+  private refreshObservedEdge(): void {
+    const intersection = this.intersection;
+    const origin = this.origin;
+    if (!intersection || !origin) {
+      return;
+    }
+    const wanted = new Set<Element>([origin]);
+    const edge: number[] = [];
+    for (const index of this.markers.keys()) {
+      if (index >= this.state.start) {
+        edge.push(index);
+      }
+    }
+    edge.sort((left, right) => left - right);
+    for (const index of edge.slice(0, OBSERVED_EDGE_BLOCKS)) {
+      const marker = this.markerElement(index);
+      if (marker) {
+        wanted.add(marker);
+      }
+    }
+    for (const element of this.observedEdge) {
+      if (!wanted.has(element)) {
+        intersection.unobserve(element);
+        this.observedEdge.delete(element);
+      }
+    }
+    for (const element of wanted) {
+      if (!this.observedEdge.has(element)) {
+        intersection.observe(element);
+        this.observedEdge.add(element);
+      }
+    }
+  }
+
+  private notifyBlocks(from: number, to: number): void {
+    for (let index = from; index < to; index += 1) {
+      const listeners = this.blockListeners.get(index);
+      if (!listeners) {
+        continue;
+      }
+      for (const listener of listeners) {
+        listener();
+      }
+    }
+  }
+
+  private notifyDocument(): void {
+    for (const listener of this.documentListeners) {
+      listener();
+    }
+  }
+}

--- a/studio/frontend/src/components/assistant-ui/block-window.ts
+++ b/studio/frontend/src/components/assistant-ui/block-window.ts
@@ -1,0 +1,253 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+/**
+ * The bookkeeping behind the streaming reasoning pane's block window.
+ *
+ * The pane is 256px tall while a model is thinking and it holds the WHOLE reasoning body, which
+ * on a long generation reaches tens of thousands of nodes and about 16,000 Shiki highlight spans.
+ * Only a few hundred pixels of that are ever on screen. The window renders a contiguous suffix of
+ * the block list and replaces everything above it with one spacer of exactly the height the
+ * dropped blocks had.
+ *
+ * Nothing here touches the Markdown SOURCE STRING. The window is expressed purely as block
+ * INDICES, and Streamdown decides what a block is; see block-window-context.tsx. That is the
+ * whole point: a windowing scheme that slices the source has to predict where the renderer
+ * considers the document divisible, and that judgement changes retroactively (a GFM footnote
+ * definition arriving late collapses many blocks into one).
+ *
+ * COORDINATES. Every offset here is a "content offset": the distance in CSS pixels from the top
+ * of the pane's scrollable content to the top of a block's marker element. It is derived from two
+ * rectangles read in the same frame,
+ *
+ *     contentOffset(marker) = marker.getBoundingClientRect().top - origin.getBoundingClientRect().top
+ *
+ * where `origin` is the spacer, which is always the first thing in the content. Because both
+ * rectangles come from the same frame, the value is immune to whatever else changed in that
+ * frame, including the text streaming in at the bottom. A `scrollHeight` delta could not be used
+ * for the same purpose: streaming appends at the bottom in the same commit, so the delta conflates
+ * the removed height with the appended height and the spacer inflates without bound.
+ */
+
+/**
+ * How much rendered content is kept mounted above the top of the visible pane.
+ *
+ * The pane is 256px tall, so this is six pane heights. It is the distance a reader can travel
+ * upwards between two observations before reaching content that is not mounted, and the only
+ * thing that reports a reader scrolling (an IntersectionObserver, since scroll events are not
+ * used) fires 400px before the spacer would become visible. Six pane heights is therefore about
+ * 1.1k pixels of slack beyond the observer's own warning, which no wheel or trackpad gesture
+ * covers in a single frame. A scrollbar drag can, and that case is documented in
+ * block-window-context.tsx rather than papered over.
+ */
+export const RETAIN_ABOVE_PX = 1536;
+
+/**
+ * The margin by which the observer's root is grown, so a block mounts BEFORE it enters view.
+ *
+ * 400px is about one and a half pane heights. It only has to be large enough that an observation
+ * arrives before the reader can see the spacer, and RETAIN_ABOVE_PX is already four times it.
+ */
+export const WINDOW_ROOT_MARGIN_PX = 400;
+
+/**
+ * How far behind the newest block a content change is still considered part of the live edge.
+ *
+ * Streamdown re-parses the tail of the document on every token, so the last few blocks legitimately
+ * change shape as text arrives. A change further back than this means the parse was redone behind
+ * the live edge and every frozen height is suspect. Matches ROLLBACK_BLOCKS in
+ * streaming-render-schedule.ts, which is the margin the incremental cache itself keeps.
+ */
+export const LIVE_EDGE_BLOCKS = 8;
+
+/**
+ * How close to the bottom the pane counts as pinned there.
+ *
+ * Shared with the reasoning pane's autoscroll, which uses the same number to decide whether a
+ * reader who scrolled up has come back. The window's scroll compensation has to agree with it: a
+ * correction written while the pane is pinned would read to that handler as the reader scrolling
+ * up, and would detach the autoscroll the reader never asked to detach.
+ */
+export const PANE_BOTTOM_THRESHOLD_PX = 24;
+
+export type BlockWindowState = {
+  /** Lowest block index that is rendered. Everything below it is the spacer. */
+  start: number;
+  /** Height of the spacer, in CSS pixels. Always `contentOffset(start)`. */
+  spacerHeight: number;
+  /** Content offset per block index, frozen at the last commit that measured it. */
+  readonly offsets: Map<number, number>;
+  /** Last seen block content per index, used to notice a retroactive re-parse. */
+  readonly contents: Map<number, string>;
+  /** Highest index that has ever reported content. The live edge. */
+  highestIndex: number;
+};
+
+export function createBlockWindowState(): BlockWindowState {
+  return {
+    start: 0,
+    spacerHeight: 0,
+    offsets: new Map(),
+    contents: new Map(),
+    highestIndex: -1,
+  };
+}
+
+/**
+ * Drop every frozen height and remount the whole document on the next frame.
+ *
+ * A frozen height that is never revalidated cannot exist here: the two things that can invalidate
+ * one -- the pane changing WIDTH, and the renderer re-segmenting the document behind the live edge
+ * -- both invalidate ALL of them at once, and both answer with this.
+ */
+export function resetBlockWindow(state: BlockWindowState): void {
+  state.start = 0;
+  state.spacerHeight = 0;
+  state.offsets.clear();
+  state.contents.clear();
+  state.highestIndex = -1;
+}
+
+/** Record where a block's marker sits, in content coordinates. */
+export function recordBlockOffset(
+  state: BlockWindowState,
+  index: number,
+  offset: number,
+): void {
+  state.offsets.set(index, offset);
+}
+
+/**
+ * The lowest block index that has to stay mounted for the reader.
+ *
+ * `viewTop` is the content offset of the top of the visible pane, i.e. the pane's scroll position
+ * expressed in the same coordinates as the recorded offsets. Only indices with a recorded offset
+ * are candidates, so the caller can always turn the answer into a spacer height it measured
+ * itself. Index 0 is always a candidate, with offset 0 by definition.
+ */
+export function chooseBlockWindowStart(
+  state: BlockWindowState,
+  viewTop: number,
+  retainAbovePx: number = RETAIN_ABOVE_PX,
+): number {
+  const ceiling = viewTop - retainAbovePx;
+  if (!(ceiling > 0)) {
+    return 0;
+  }
+  let start = 0;
+  for (const [index, offset] of state.offsets) {
+    if (offset <= ceiling && index > start) {
+      start = index;
+    }
+  }
+  return start;
+}
+
+/**
+ * The spacer height that goes with `start`, taken from the map as it stood BEFORE the blocks are
+ * dropped.
+ *
+ * This is the prescribed "measure then freeze", written absolutely rather than incrementally.
+ * `spacerHeight(s') - spacerHeight(s)` is exactly `offset(s') - offset(s)`, the height of the
+ * removed range including its collapsed margins, and because both come from the same
+ * pre-mutation frame the difference cannot drift. Writing it absolutely also means a window that
+ * moves back up restores the earlier height exactly instead of accumulating rounding.
+ */
+export function blockWindowSpacerHeight(
+  state: BlockWindowState,
+  start: number,
+): number {
+  return start <= 0 ? 0 : (state.offsets.get(start) ?? state.spacerHeight);
+}
+
+/** Move the window. Returns whether anything actually changed. */
+export function setBlockWindowStart(
+  state: BlockWindowState,
+  start: number,
+): boolean {
+  const spacerHeight = blockWindowSpacerHeight(state, start);
+  if (state.start === start && state.spacerHeight === spacerHeight) {
+    return false;
+  }
+  state.start = start;
+  state.spacerHeight = spacerHeight;
+  return true;
+}
+
+/** Whether a block index is inside the window. The window is a suffix, so this is a comparison. */
+export function isBlockMounted(
+  state: BlockWindowState,
+  index: number,
+): boolean {
+  return index >= state.start;
+}
+
+/**
+ * Record a block's content and report whether it proves the parse was redone behind the live edge.
+ *
+ * The window is keyed on block INDEX, so a re-segmentation moves the document under the frozen
+ * heights even though it can never corrupt the text (the source string is never touched). The
+ * signal is a block that is not near the live edge changing content. The caller answers by
+ * resetting, which revalidates every height at once.
+ */
+export function recordBlockContent(
+  state: BlockWindowState,
+  index: number,
+  content: string,
+  liveEdgeBlocks: number = LIVE_EDGE_BLOCKS,
+): boolean {
+  const previous = state.contents.get(index);
+  const wasBehindLiveEdge =
+    previous !== undefined && index < state.highestIndex - liveEdgeBlocks;
+  state.contents.set(index, content);
+  if (index > state.highestIndex) {
+    state.highestIndex = index;
+  }
+  return wasBehindLiveEdge && previous !== content;
+}
+
+/**
+ * The block indices whose mounted state differs between two window starts.
+ *
+ * Only these have to be told to re-render, which is what keeps a window move off the other
+ * thousands of block components.
+ */
+export function blockWindowFlippedRange(
+  previousStart: number,
+  nextStart: number,
+): { from: number; to: number } {
+  return {
+    from: Math.min(previousStart, nextStart),
+    to: Math.max(previousStart, nextStart),
+  };
+}
+
+/**
+ * The contents the window would mount, given the whole block list.
+ *
+ * Exported for the invariant it exists to state: what is mounted is always a contiguous SUFFIX of
+ * the block list the renderer produced, never a re-cut of the source string.
+ */
+export function mountedBlockContents(
+  blocks: readonly string[],
+  start: number,
+): string[] {
+  return blocks.slice(Math.max(0, start));
+}
+
+/** Whether `candidate` is a contiguous suffix of `blocks`. */
+export function isBlockSuffix(
+  blocks: readonly string[],
+  candidate: readonly string[],
+): boolean {
+  if (candidate.length > blocks.length) {
+    return false;
+  }
+  const offset = blocks.length - candidate.length;
+  for (let index = 0; index < candidate.length; index += 1) {
+    if (blocks[offset + index] !== candidate[index]) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/studio/frontend/src/components/assistant-ui/markdown-text.tsx
+++ b/studio/frontend/src/components/assistant-ui/markdown-text.tsx
@@ -40,6 +40,12 @@ import {
   Streamdown,
   type StreamdownProps,
 } from "streamdown";
+import {
+  BlockWindowDocument,
+  useBlockWindowMarker,
+  useBlockWindowMounted,
+  useBlockWindowPaneActive,
+} from "./block-window-context";
 import { createCodePlugin } from "./code-plugin";
 import "katex/dist/katex.min.css";
 import { AudioPlayer } from "./audio-player";
@@ -410,6 +416,47 @@ function StreamdownBlockContent(props: BlockProps) {
   return <Block {...blockProps} />;
 }
 const StreamdownBlock = memo(StreamdownBlockContent);
+
+/**
+ * The block component used while a reasoning pane streams: the same block, behind the pane's
+ * just-in-time window.
+ *
+ * A withheld block returns null and costs nothing but this function, so the heavy component above
+ * -- with its store subscription, its plugin filtering and its Shiki highlighting -- is never
+ * instantiated for a block that is not in the window. The source string handed to Streamdown is
+ * untouched; Streamdown still splits the whole document and still calls this for every index.
+ *
+ * The slot element is `display: contents` (see src/index.css) so it generates no box and margin
+ * collapsing between adjacent markdown blocks is unaffected. Its `firstElementChild` is the
+ * block's marker for geometry. Block 0 is not wrapped: nothing needs its offset, and leaving it
+ * bare keeps Streamdown's own first-child margin rule on the element it was written for.
+ */
+function WindowedStreamdownBlockContent(props: BlockProps) {
+  const mounted = useBlockWindowMounted(props.index, props.content);
+  if (!mounted) {
+    return null;
+  }
+  // Block 0 is never given a slot: nothing needs its offset, since that is 0 by definition, and
+  // leaving it bare keeps Streamdown's own `[&>*:first-child]:mt-0` on the element it was
+  // written for.
+  if (props.index === 0) {
+    return <StreamdownBlock {...props} />;
+  }
+  return <MarkedStreamdownBlock {...props} />;
+}
+
+/** A mounted block plus the slot element the window measures it by. */
+function MarkedStreamdownBlock(props: BlockProps) {
+  const attachMarker = useBlockWindowMarker(props.index);
+  return (
+    <div data-aui-block-slot="" ref={attachMarker}>
+      <StreamdownBlock {...props} />
+    </div>
+  );
+}
+
+const WindowedStreamdownBlock = memo(WindowedStreamdownBlockContent);
+
 const AUDIO_PLAYER_RE = /<audio-player\s+src="([^"]+)"\s*\/>/;
 
 // Coalesce only token events that arrive before the browser's next paint, as
@@ -507,6 +554,10 @@ const MarkdownTextImpl = () => {
     ? incrementalCache.update(processedText)
     : null;
 
+  // Only a streaming reasoning pane supplies a window. Everywhere else this is false and the
+  // block component, and therefore the whole tree below, is exactly what it is today.
+  const windowed = useBlockWindowPaneActive();
+
   const audioMatch = displayText.match(AUDIO_PLAYER_RE);
   if (audioMatch) {
     return <AudioPlayer src={audioMatch[1]} />;
@@ -517,6 +568,7 @@ const MarkdownTextImpl = () => {
       value={messageHasRenderableRenderHtmlTool}
     >
       <div data-status={status.type} className="min-w-0 max-w-full">
+        <BlockWindowDocument>
         <Streamdown
           key={`${messageId}:${incrementalCache.renderGeneration}`}
           mode="streaming"
@@ -529,10 +581,11 @@ const MarkdownTextImpl = () => {
           urlTransform={safeMarkdownUrl}
           controls={STREAMDOWN_CONTROLS}
           shikiTheme={STREAMDOWN_SHIKI_THEME}
-          BlockComponent={StreamdownBlock}
+          BlockComponent={windowed ? WindowedStreamdownBlock : StreamdownBlock}
         >
           {incrementalRender?.markdown ?? processedText}
         </Streamdown>
+        </BlockWindowDocument>
       </div>
     </RenderHtmlToolPresenceContext.Provider>
   );

--- a/studio/frontend/src/components/assistant-ui/reasoning.tsx
+++ b/studio/frontend/src/components/assistant-ui/reasoning.tsx
@@ -5,6 +5,8 @@
 
 /* eslint-disable react-refresh/only-export-components */
 
+import { PANE_BOTTOM_THRESHOLD_PX } from "@/components/assistant-ui/block-window";
+import { BlockWindowPaneProvider } from "@/components/assistant-ui/block-window-context";
 import { MarkdownText } from "@/components/assistant-ui/markdown-text";
 import {
   Collapsible,
@@ -41,7 +43,6 @@ import {
   useState,
 } from "react";
 const ANIMATION_DURATION = 200;
-const AUTO_SCROLL_THRESHOLD_PX = 24;
 
 export const reasoningVariants = cva("aui-reasoning-root mt-3 mb-4 w-full", {
   variants: {
@@ -211,7 +212,7 @@ function ReasoningText({
       const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
       if (
         detachedFromBottomRef.current &&
-        distanceFromBottom <= AUTO_SCROLL_THRESHOLD_PX
+        distanceFromBottom <= PANE_BOTTOM_THRESHOLD_PX
       ) {
         detachedFromBottomRef.current = false;
       }
@@ -250,6 +251,12 @@ function ReasoningText({
     <div
       ref={scrollRef}
       data-slot="reasoning-text"
+      // Scroll anchoring is switched off rather than depended on. The block window compensates
+      // the scroll position itself, explicitly, in the layout effect that drops the blocks:
+      // Playwright's WebKit implements `overflow-anchor` and real Safari does not, so leaving it
+      // on would let the sanctioned test proxy show anchoring working while the WebKitGTK embed
+      // that ships in Tauri drifted.
+      style={{ overflowAnchor: "none" }}
       className={cn(
         "aui-reasoning-text relative z-0 overflow-y-auto pt-2 pb-0 pl-0 leading-relaxed",
         streaming ? "max-h-64" : "",
@@ -266,7 +273,9 @@ function ReasoningText({
       )}
       {...props}
     >
-      {children}
+      <BlockWindowPaneProvider paneRef={scrollRef} enabled={Boolean(streaming)}>
+        {children}
+      </BlockWindowPaneProvider>
     </div>
   );
 }

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -2389,6 +2389,42 @@ html[data-chat-font] .aui-root {
 		}
 	}
 
+	/* The streaming reasoning pane renders only a window of Markdown blocks and wraps each mounted
+	   one in a slot element so it has something to measure (components/assistant-ui/block-window-context.tsx).
+	   `display: contents` means the slot generates no box, so margin collapsing between adjacent
+	   markdown blocks is unaffected -- but it also means the slot cannot CARRY a margin, and
+	   Streamdown spaces its blocks with three rules that all select the container's DIRECT
+	   children, which the slot has become:
+
+	       space-y-4                 :where(& > :not(:last-child)) { margin-block-end: 1rem }
+	       [&>*:first-child]:mt-0
+	       [&>*:last-child]:mb-0
+
+	   So they are restated one level down. The first is wrapped in :where() to keep Tailwind's
+	   zero specificity, which is what lets a block's own margin utility (h2's mb-2) beat it, as it
+	   does today. The other two are not, because the rules they stand in for carry class
+	   specificity and beat those utilities today. Block index 0 is never wrapped, so the plain
+	   first-child rule still applies to it directly.
+
+	   Verified rather than reasoned about: rendering seven documents twice in Chromium, once
+	   plain and once wrapped, every element's position and the pane's scrollHeight are identical
+	   with these rules and differ without them. */
+	:where([data-aui-block-slot]) {
+		display: contents;
+	}
+
+	:where([data-aui-block-slot]) > * {
+		margin-block-end: 1rem;
+	}
+
+	[data-aui-block-slot]:first-child > *:first-child {
+		margin-block-start: 0;
+	}
+
+	[data-aui-block-slot]:not(:has(~ [data-aui-block-slot] > *)) > *:last-child {
+		margin-block-end: 0;
+	}
+
 	[data-streamdown="unordered-list"] {
 		list-style-type: disc;
 		list-style-position: outside;

--- a/studio/frontend/tests/reasoning-block-window-controller.test.ts
+++ b/studio/frontend/tests/reasoning-block-window-controller.test.ts
@@ -1,0 +1,485 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// The block window driven the way a browser drives it: a commit, a measurement, a decision, a
+// second commit, a layout effect. The controller needs `getBoundingClientRect`, three observers
+// and four numbers off the scroll container and nothing else, so all of that is supplied here and
+// the real object under test is the real object.
+//
+// What this file is for is the parts that only exist once geometry is involved: that the spacer is
+// the exact height of what it replaced, that a block already on screen is not remounted when the
+// window moves, that the reader's scroll position does not move, and that the two things which can
+// invalidate a frozen height do invalidate all of them.
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { registerBundlerResolver } from "./helpers/kit.ts";
+
+registerBundlerResolver();
+
+const BLOCK_HEIGHT = 100;
+const BLOCK_COUNT = 40;
+const DOC_HEIGHT = BLOCK_COUNT * BLOCK_HEIGHT;
+const PANE_TOP = 50;
+const PANE_HEIGHT = 256;
+const PANE_WIDTH = 700;
+/** Streamdown's splitter emits blocks that render nothing. This one is ours. */
+const EMPTY_BLOCK = 7;
+
+type Observed = { callback: () => void; targets: Set<unknown> };
+
+const mutationObservers: Observed[] = [];
+const resizeObservers: Observed[] = [];
+const intersectionObservers: Observed[] = [];
+
+function installObserver(sink: Observed[]) {
+  return class {
+    private readonly entry: Observed;
+    constructor(callback: () => void) {
+      this.entry = { callback, targets: new Set() };
+      sink.push(this.entry);
+    }
+    observe(target: unknown): void {
+      this.entry.targets.add(target);
+    }
+    unobserve(target: unknown): void {
+      this.entry.targets.delete(target);
+    }
+    disconnect(): void {
+      this.entry.targets.clear();
+      const at = sink.indexOf(this.entry);
+      if (at >= 0) {
+        sink.splice(at, 1);
+      }
+    }
+    takeRecords(): unknown[] {
+      return [];
+    }
+  };
+}
+
+Object.assign(globalThis, {
+  MutationObserver: installObserver(mutationObservers),
+  ResizeObserver: installObserver(resizeObservers),
+  IntersectionObserver: installObserver(intersectionObservers),
+});
+
+class FakeElement {
+  top = 0;
+  readonly children: FakeElement[] = [];
+  get firstElementChild(): FakeElement | null {
+    return this.children[0] ?? null;
+  }
+  getBoundingClientRect() {
+    return {
+      top: this.top,
+      bottom: this.top,
+      left: 0,
+      right: 0,
+      width: 0,
+      height: 0,
+      x: 0,
+      y: this.top,
+      toJSON: () => ({}),
+    };
+  }
+}
+
+class FakePane extends FakeElement {
+  clientWidth = PANE_WIDTH;
+  clientHeight = PANE_HEIGHT;
+  scrollHeight = DOC_HEIGHT;
+  scrollTop = 0;
+  constructor() {
+    super();
+    this.top = PANE_TOP;
+  }
+}
+
+const { BlockWindowController } = await import(
+  "../src/components/assistant-ui/block-window-controller.ts"
+);
+
+type Controller = InstanceType<typeof BlockWindowController>;
+
+/**
+ * A pane holding one document of equal-height blocks, driven a frame at a time.
+ *
+ * `spacerErrorPx` is the knob that makes the scroll compensation testable: it mis-sizes the
+ * spacer on purpose so there is a residual to correct. The design says there should never be one.
+ */
+function harness(spacerErrorPx = 0) {
+  const pane = new FakePane();
+  const origin = new FakeElement();
+  const slots = new Map<number, FakeElement>();
+  const notified: number[] = [];
+  const controller: Controller = new BlockWindowController();
+
+  controller.spacerRef(origin as unknown as HTMLElement);
+  for (let index = 0; index < BLOCK_COUNT; index += 1) {
+    const at = index;
+    controller.subscribeBlock(at, () => notified.push(at));
+  }
+  const detach = controller.attach(pane as unknown as HTMLElement);
+
+  function layout(): void {
+    const shift = controller.windowStart() > 0 ? spacerErrorPx : 0;
+    origin.top = PANE_TOP - pane.scrollTop;
+    for (const [index, slot] of slots) {
+      const marker = slot.firstElementChild;
+      if (marker) {
+        marker.top = PANE_TOP + index * BLOCK_HEIGHT - pane.scrollTop + shift;
+      }
+    }
+    pane.scrollHeight = DOC_HEIGHT + shift;
+  }
+
+  /** What React does with the window's answer: mount the suffix, unmount what fell out. */
+  function commit(): void {
+    const start = controller.windowStart();
+    for (const index of [...slots.keys()]) {
+      if (index < start) {
+        controller.markerRef(index)(null);
+        slots.delete(index);
+      }
+    }
+    for (let index = Math.max(1, start); index < BLOCK_COUNT; index += 1) {
+      if (slots.has(index)) {
+        continue;
+      }
+      const slot = new FakeElement();
+      if (index !== EMPTY_BLOCK) {
+        slot.children.push(new FakeElement());
+      }
+      slots.set(index, slot);
+      controller.markerRef(index)(slot as unknown as HTMLElement);
+    }
+    layout();
+  }
+
+  /** One browser frame: the commit is measured, the window moves, the move is committed. */
+  function frame(): void {
+    for (const observer of [...mutationObservers]) {
+      observer.callback();
+    }
+    commit();
+    controller.settleAfterCommit();
+  }
+
+  function scrollTo(position: number): void {
+    pane.scrollTop = position;
+    layout();
+  }
+
+  commit();
+  return {
+    controller,
+    pane,
+    origin,
+    slots,
+    notified,
+    frame,
+    commit,
+    scrollTo,
+    detach,
+    mounted: () => [...slots.keys()].sort((a, b) => a - b),
+  };
+}
+
+test("a pane at the top mounts the whole document", () => {
+  const h = harness();
+  h.frame();
+  assert.equal(h.controller.windowStart(), 0);
+  assert.equal(h.controller.spacerHeight(), 0);
+  assert.equal(h.mounted().length, BLOCK_COUNT - 1);
+  h.detach();
+});
+
+test("scrolled to the bottom, the spacer is exactly the height of the blocks it replaced", () => {
+  const h = harness();
+  h.frame();
+  h.scrollTo(DOC_HEIGHT - PANE_HEIGHT);
+  h.notified.length = 0;
+  h.frame();
+
+  const start = h.controller.windowStart();
+  assert.equal(start, 22);
+  // Exactly the sum of the dropped blocks' heights, in the pane's own scroll coordinates.
+  assert.equal(h.controller.spacerHeight(), start * BLOCK_HEIGHT);
+  assert.deepEqual(
+    h.mounted(),
+    Array.from({ length: BLOCK_COUNT - start }, (_, i) => start + i),
+  );
+
+  // Every block that fell out was told, and no block that did not fall out was.
+  assert.deepEqual(
+    [...new Set(h.notified)].sort((a, b) => a - b),
+    Array.from({ length: start }, (_, i) => i),
+  );
+
+  // The spacer being exact is what makes the compensation dead code, so assert the 0 rather than
+  // trusting the compensation to hide a mistake.
+  assert.equal(h.controller.lastResidualPx, 0);
+  assert.equal(h.pane.scrollTop, DOC_HEIGHT - PANE_HEIGHT);
+  h.detach();
+});
+
+test("scrolling back up leaves the reader where they scrolled to", () => {
+  // The regression test for the scroll INVERSION. The compensation subtracts the anchor's
+  // position after the commit from its position before, so the anchor has to exist in BOTH
+  // states. Moving the window BACKWARD, which is what a reader scrolling up causes, the new
+  // start is not mounted yet: anchoring on it read the SPACER before and the newly mounted
+  // BLOCK after, two different elements, and produced a residual the size of the spacer. In a
+  // real browser that wrote 8,271px into a pane a reader had moved 1,440px in, which put them
+  // at the bottom, which re-armed the pane's autoscroll and pinned them there for the rest of
+  // the generation.
+  //
+  // The reader has to land on a NON-ZERO window start for this to be the case under test: a
+  // scroll back to the very top puts the start at 0, block 0 is never given a marker, and both
+  // reads fall back to the spacer and agree by accident.
+  const h = harness();
+  h.frame();
+  h.scrollTo(DOC_HEIGHT - PANE_HEIGHT);
+  h.frame();
+  const forwardStart = h.controller.windowStart();
+
+  h.scrollTo(2600);
+  h.frame();
+  const backStart = h.controller.windowStart();
+  const scrollTop = h.pane.scrollTop;
+  const residual = h.controller.lastResidualPx;
+  h.detach();
+
+  assert.equal(forwardStart, 22, "the window must have moved forward first");
+  assert.ok(
+    backStart > 0 && backStart < forwardStart,
+    `the window must come back to a non-zero start, got ${backStart}`,
+  );
+  assert.equal(scrollTop, 2600, "the reader was moved by the compensation");
+  assert.equal(residual, 0);
+});
+
+test("the correction is not switched off on the way back", () => {
+  // The second half of the fix. The gate on applying a correction used to be "the lowest mounted
+  // index has reached the anchor", which only describes a window moving FORWARD; a window moving
+  // backward mounts blocks BELOW the anchor, so on a scroll-back that test never came true and
+  // the correction was dropped every time. `lastResidualPx` is written every time the correction
+  // runs, so a stale value here means it did not run at all.
+  const h = harness(40);
+  h.frame();
+  h.scrollTo(DOC_HEIGHT - PANE_HEIGHT);
+  h.frame();
+  const forwardResidual = h.controller.lastResidualPx;
+
+  h.scrollTo(2600);
+  h.frame();
+  const backStart = h.controller.windowStart();
+  const backResidual = h.controller.lastResidualPx;
+  h.detach();
+
+  assert.notEqual(
+    forwardResidual,
+    0,
+    "the harness must actually mis-size the spacer, or this proves nothing",
+  );
+  assert.ok(backStart > 0 && backStart < 22, `start is ${backStart}`);
+  assert.equal(
+    backResidual,
+    0,
+    "the correction did not run on the way back: lastResidualPx is still the forward one",
+  );
+});
+
+test("what stays mounted is bounded by the retained band, not by the document", () => {
+  const h = harness();
+  h.frame();
+  h.scrollTo(DOC_HEIGHT - PANE_HEIGHT);
+  h.frame();
+  const mountedPx = h.mounted().length * BLOCK_HEIGHT;
+  assert.ok(mountedPx <= 1900, `mounted ${mountedPx}px`);
+  // 18 of 39, i.e. the pane holds less than half of a 4000px document and a proportionally
+  // smaller share of a longer one.
+  assert.equal(h.mounted().length, 18);
+  h.detach();
+});
+
+test("scrolling back up remounts only what re-enters, and keeps what was already there", () => {
+  const h = harness();
+  h.frame();
+  h.scrollTo(DOC_HEIGHT - PANE_HEIGHT);
+  h.frame();
+  assert.equal(h.controller.windowStart(), 22);
+  const before = new Map(h.slots);
+
+  h.scrollTo(3000);
+  h.notified.length = 0;
+  h.frame();
+
+  assert.equal(h.controller.windowStart(), 14);
+  assert.equal(h.controller.spacerHeight(), 1400);
+  // The retained half: the very same slot objects, i.e. React was never asked to remount them.
+  for (let index = 22; index < BLOCK_COUNT; index += 1) {
+    assert.equal(
+      h.slots.get(index),
+      before.get(index),
+      `block ${index} was remounted for no reason`,
+    );
+  }
+  // And only the blocks that re-entered were told anything.
+  assert.deepEqual(
+    [...new Set(h.notified)].sort((a, b) => a - b),
+    [14, 15, 16, 17, 18, 19, 20, 21],
+  );
+  h.detach();
+});
+
+test("an empty block has no marker and is simply never a window start", () => {
+  const h = harness();
+  h.frame();
+  h.scrollTo(DOC_HEIGHT - PANE_HEIGHT);
+  h.frame();
+  h.scrollTo(EMPTY_BLOCK * BLOCK_HEIGHT + 1536 + 50);
+  h.frame();
+  assert.notEqual(
+    h.controller.windowStart(),
+    EMPTY_BLOCK,
+    "a block that renders nothing has no measured height to freeze",
+  );
+  h.detach();
+});
+
+test("a mis-sized spacer is corrected explicitly, and only when the reader is not pinned", () => {
+  const wrong = harness(9);
+  wrong.frame();
+  // Away from the bottom, so the pane is not pinned and the reader's position is the thing that
+  // has to be preserved.
+  wrong.scrollTo(2600);
+  wrong.frame();
+  assert.ok(wrong.controller.windowStart() > 0);
+  assert.equal(wrong.controller.lastResidualPx, 9);
+  assert.equal(
+    wrong.pane.scrollTop,
+    2609,
+    "the reader's anchor moved 9px and was put back",
+  );
+  wrong.detach();
+
+  // Pinned to the bottom, the autoscroll owns the scroll position: writing to it here would read
+  // to the autoscroll's own handler as the reader scrolling up, and would detach it.
+  const pinned = harness(9);
+  pinned.frame();
+  pinned.scrollTo(DOC_HEIGHT - PANE_HEIGHT);
+  pinned.frame();
+  assert.equal(pinned.controller.lastResidualPx, 9);
+  assert.equal(pinned.pane.scrollTop, DOC_HEIGHT - PANE_HEIGHT);
+  pinned.detach();
+});
+
+test("a width change throws every frozen height away", () => {
+  const h = harness();
+  h.frame();
+  h.scrollTo(DOC_HEIGHT - PANE_HEIGHT);
+  h.frame();
+  assert.equal(h.controller.windowStart(), 22);
+
+  h.pane.clientHeight = 512;
+  for (const observer of [...resizeObservers]) {
+    observer.callback();
+  }
+  assert.equal(
+    h.controller.windowStart(),
+    22,
+    "a height change is the pane's own cap animating and means nothing",
+  );
+
+  h.pane.clientWidth = 420;
+  for (const observer of [...resizeObservers]) {
+    observer.callback();
+  }
+  assert.equal(h.controller.windowStart(), 0);
+  assert.equal(h.controller.spacerHeight(), 0);
+
+  // And it really does remount and re-measure rather than leaving a stale map behind.
+  h.commit();
+  assert.equal(h.mounted().length, BLOCK_COUNT - 1);
+  h.detach();
+});
+
+test("a re-parse behind the live edge throws every frozen height away", () => {
+  const h = harness();
+  h.frame();
+  h.scrollTo(DOC_HEIGHT - PANE_HEIGHT);
+  h.frame();
+  assert.equal(h.controller.windowStart(), 22);
+
+  for (let index = 0; index < BLOCK_COUNT; index += 1) {
+    h.controller.reportContent(index, `block ${index}`);
+  }
+  h.controller.reportContent(BLOCK_COUNT - 1, "block 39 with another token");
+  assert.equal(
+    h.controller.windowStart(),
+    22,
+    "the newest block growing is not a re-parse",
+  );
+
+  // A late GFM footnote definition collapsing earlier blocks looks exactly like this.
+  h.controller.reportContent(4, "blocks 4 through 9, merged");
+  assert.equal(h.controller.windowStart(), 0);
+  assert.equal(h.controller.spacerHeight(), 0);
+  h.detach();
+});
+
+test("the observer watches the spacer and the top of the window, and moves with it", () => {
+  const h = harness();
+  h.frame();
+  const [observer] = intersectionObservers;
+  assert.ok(observer, "no IntersectionObserver was created");
+  assert.ok(observer.targets.has(h.origin), "the spacer must be watched");
+
+  h.scrollTo(DOC_HEIGHT - PANE_HEIGHT);
+  h.frame();
+  const start = h.controller.windowStart();
+  const watched = [...observer.targets];
+  assert.ok(watched.includes(h.origin));
+  for (const index of [start, start + 1, start + 2]) {
+    assert.ok(
+      watched.includes(h.slots.get(index)?.firstElementChild),
+      `the observer must watch block ${index} at the top of the window`,
+    );
+  }
+  // Not every mounted block: the point is a handful at the edge, not another per-block cost.
+  assert.ok(watched.length <= 4, `watching ${watched.length} elements`);
+  h.detach();
+});
+
+test("scrolling with no DOM change still moves the window", () => {
+  const h = harness();
+  h.frame();
+  // No mutation callback at all: only the intersection observer reports this, because scroll
+  // events are deliberately not used.
+  h.scrollTo(DOC_HEIGHT - PANE_HEIGHT);
+  for (const observer of [...intersectionObservers]) {
+    observer.callback();
+  }
+  assert.equal(h.controller.windowStart(), 22);
+  h.detach();
+});
+
+test("a block's marker ref is the same function on every render", () => {
+  // React detaches and re-attaches a callback ref whose identity changed, on every render. A
+  // fresh function per render would therefore unregister and re-register every marker in the
+  // window on every token, and the measurement would be reading a map that had just been emptied.
+  const h = harness();
+  assert.equal(h.controller.markerRef(5), h.controller.markerRef(5));
+  assert.notEqual(h.controller.markerRef(5), h.controller.markerRef(6));
+  h.detach();
+});
+
+test("detaching stops the observers", () => {
+  const h = harness();
+  h.frame();
+  const before = mutationObservers.length;
+  h.detach();
+  assert.equal(mutationObservers.length, before - 1);
+});

--- a/studio/frontend/tests/reasoning-block-window-render.test.ts
+++ b/studio/frontend/tests/reasoning-block-window-render.test.ts
@@ -1,0 +1,232 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// The window against the real renderer.
+//
+// PR #9073 windowed the reasoning pane by CHARACTER BUDGET: it sliced the Markdown SOURCE STRING
+// before handing it to Streamdown. That failed repeatedly because the window had to predict where
+// the renderer considers the document divisible, and that judgement changes retroactively. This
+// window never touches the string; it withholds BLOCKS BY INDEX, and Streamdown decides what a
+// block is. These tests are the proof of that difference, taken against the three shapes that
+// broke #9073.
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { Block, type BlockProps, Streamdown } from "streamdown";
+
+import { isBlockSuffix } from "../src/components/assistant-ui/block-window.ts";
+
+/** Every `content` Streamdown handed a block component, in index order. */
+function renderWithWindow(markdown: string, start: number) {
+  const seen: string[] = [];
+  const mounted: string[] = [];
+  function Windowed(props: BlockProps) {
+    seen[props.index] = props.content;
+    if (props.index < start) {
+      return null;
+    }
+    mounted.push(props.content);
+    return createElement(Block, props);
+  }
+  const html = renderToStaticMarkup(
+    createElement(
+      Streamdown,
+      { mode: "streaming", BlockComponent: Windowed },
+      markdown,
+    ),
+  );
+  return { seen, mounted, html };
+}
+
+/** The reference #9073 could not have: the block boundaries the renderer actually chose. */
+const KILLERS: Record<string, string[]> = {
+  // A GFM footnote definition arriving late. In this renderer a footnote REFERENCE alone already
+  // makes the whole document one block, which is the 163-blocks-into-1 collapse in its purest
+  // form, and the definition arriving does not put the boundaries back.
+  "gfm footnote definition appended late": [
+    "Paragraph 0 with a ref[^a] in it.\n\nParagraph 1 with a ref[^a] in it.",
+    "Paragraph 0 with a ref[^a] in it.\n\nParagraph 1 with a ref[^a] in it.\n\nParagraph 2 with a ref[^a] in it.",
+    "Paragraph 0 with a ref[^a] in it.\n\nParagraph 1 with a ref[^a] in it.\n\nParagraph 2 with a ref[^a] in it.\n\n[^a]: the definition arrives late.",
+  ],
+  "unterminated bracket span": [
+    "Body.\n\nAn unterminated [bracket",
+    "Body.\n\nAn unterminated [bracket span",
+    "Body.\n\nAn unterminated [bracket span that never closes\n\nMore text.",
+  ],
+  "angle bracket link destination with trailing junk": [
+    "Alpha.\n\nBeta.\n\n[spec]: <https://example.com/x>",
+    "Alpha.\n\nBeta.\n\n[spec]: <https://example.com/x> junk",
+    "Alpha.\n\nBeta.\n\n[spec]: <https://example.com/x> junk\n\nGamma.",
+  ],
+};
+
+test("windowing cannot change the string the renderer is given, or how it is cut up", () => {
+  for (const [name, stages] of Object.entries(KILLERS)) {
+    for (const markdown of stages) {
+      const plain = renderWithWindow(markdown, 0);
+      for (const start of [1, 2, 3, 99]) {
+        const windowed = renderWithWindow(markdown, start);
+        // The parse is identical, block for block. Windowing is invisible to it, because the
+        // string it parses is the same object.
+        assert.deepEqual(
+          windowed.seen,
+          plain.seen,
+          `${name}: withholding blocks changed the parse`,
+        );
+      }
+      // And the blocks put back together are the same string at every window position. Streamdown
+      // repairs an incomplete tail before it splits ("[bracket" becomes a link), so this is not
+      // always the raw input; what matters is that the window cannot change it, because the
+      // window never touches the string.
+      for (const start of [0, 1, 2, 3, 99]) {
+        assert.equal(
+          renderWithWindow(markdown, start).seen.join(""),
+          plain.seen.join(""),
+          `${name}: withholding blocks changed the string that was parsed`,
+        );
+      }
+    }
+  }
+});
+
+test("a complete document's blocks are its source string, byte for byte", () => {
+  const markdown =
+    "# Heading\n\nParagraph one.\n\nParagraph two.\n\n- a\n- b\n\nDone.\n";
+  const plain = renderWithWindow(markdown, 0);
+  assert.equal(plain.seen.join(""), markdown);
+  assert.ok(plain.seen.length > 5, "the document must actually be split up");
+  for (const start of [1, 4, 7]) {
+    assert.equal(renderWithWindow(markdown, start).seen.join(""), markdown);
+  }
+});
+
+test("what is mounted is always a suffix of the renderer's block list", () => {
+  for (const [name, stages] of Object.entries(KILLERS)) {
+    for (const markdown of stages) {
+      const plain = renderWithWindow(markdown, 0);
+      for (let start = 0; start <= plain.seen.length; start += 1) {
+        const windowed = renderWithWindow(markdown, start);
+        assert.ok(
+          isBlockSuffix(plain.seen, windowed.mounted),
+          `${name}: start ${start} did not mount a suffix`,
+        );
+        assert.equal(windowed.mounted.length, plain.seen.length - start);
+      }
+    }
+  }
+});
+
+test("a withheld block removes its own markup and nothing else", () => {
+  const markdown =
+    "# Heading\n\nParagraph one.\n\nParagraph two.\n\n- a\n- b\n\nParagraph three.";
+  const plain = renderWithWindow(markdown, 0);
+  for (let start = 1; start < plain.seen.length; start += 1) {
+    const windowed = renderWithWindow(markdown, start);
+    const dropped = renderWithWindow(markdown, 0).html;
+    // Each block renders independently, so the windowed markup is the tail of the full markup.
+    const inner = (html: string) =>
+      html.slice(html.indexOf(">") + 1, html.lastIndexOf("</div>"));
+    assert.ok(
+      inner(dropped).endsWith(inner(windowed.html)),
+      `start ${start}: the windowed markup is not the tail of the full markup`,
+    );
+  }
+});
+
+test("the footnote shape leaves the window with nothing to do, rather than breaking it", () => {
+  // The honest result, and the reason this design survives the case that killed #9073: with the
+  // whole document in one block there is no index to move the window to, so it stays at 0 and the
+  // pane renders exactly what it renders today. The optimisation stops applying; nothing breaks.
+  const stages = KILLERS["gfm footnote definition appended late"];
+  for (const markdown of stages) {
+    const plain = renderWithWindow(markdown, 0);
+    assert.equal(
+      plain.seen.length,
+      1,
+      "a footnote reference is expected to collapse the document into one block",
+    );
+    // Block 0 is never given a marker, so it can never be measured, so it can never be dropped.
+    const windowed = renderWithWindow(markdown, 0);
+    assert.deepEqual(windowed.mounted, plain.seen);
+  }
+});
+
+// ── the wiring, which the SSR above cannot see ──────────────────────
+
+const read = (relative: string) =>
+  readFileSync(fileURLToPath(new URL(relative, import.meta.url)), "utf8");
+
+const MARKDOWN_TEXT = read("../src/components/assistant-ui/markdown-text.tsx");
+const REASONING = read("../src/components/assistant-ui/reasoning.tsx");
+const INDEX_CSS = read("../src/index.css");
+
+test("only a streaming reasoning pane gets the windowed block component", () => {
+  assert.match(
+    MARKDOWN_TEXT,
+    /BlockComponent=\{windowed \? WindowedStreamdownBlock : StreamdownBlock\}/,
+    "the answer text and settled panes must keep the block component they have today",
+  );
+  assert.match(
+    MARKDOWN_TEXT,
+    /const windowed = useBlockWindowPaneActive\(\)/,
+  );
+  // The pane context is supplied by ReasoningText and by nothing else, and only while streaming.
+  assert.match(
+    REASONING,
+    /<BlockWindowPaneProvider paneRef=\{scrollRef\} enabled=\{Boolean\(streaming\)\}>/,
+  );
+  const providers = [
+    ...MARKDOWN_TEXT.matchAll(/BlockWindowPaneProvider/g),
+  ].length;
+  assert.equal(providers, 0, "MarkdownText must not declare itself a pane");
+});
+
+test("scroll anchoring is switched off rather than depended on", () => {
+  // Playwright's WebKit implements overflow-anchor and real Safari does not, so leaving it on
+  // would let the sanctioned test proxy show anchoring working while the WebKitGTK embed drifted.
+  assert.match(REASONING, /style=\{\{ overflowAnchor: "none" \}\}/);
+});
+
+test("the slot restores the three Streamdown spacing rules it displaces", () => {
+  // The slot is display: contents so it generates no box and margin collapsing between adjacent
+  // markdown blocks is unaffected. That also means it cannot carry a margin, and all three of
+  // Streamdown's spacing rules select the container's DIRECT children, which the slot has become.
+  assert.match(INDEX_CSS, /:where\(\[data-aui-block-slot\]\) \{\s*display: contents;/);
+  assert.match(
+    INDEX_CSS,
+    /:where\(\[data-aui-block-slot\]\) > \* \{\s*margin-block-end: 1rem;/,
+  );
+  assert.match(
+    INDEX_CSS,
+    /\[data-aui-block-slot\]:first-child > \*:first-child \{\s*margin-block-start: 0;/,
+  );
+  assert.match(
+    INDEX_CSS,
+    /\[data-aui-block-slot\]:not\(:has\(~ \[data-aui-block-slot\] > \*\)\) > \*:last-child \{\s*margin-block-end: 0;/,
+  );
+});
+
+test("the restored gap is still the gap Streamdown asks for", () => {
+  // The 1rem above is a copy of Streamdown's own `space-y-4`. If a Streamdown upgrade changes
+  // that class, the copy is silently wrong and every block in a streaming reasoning pane moves,
+  // so read the class back off a real render rather than trusting it.
+  const html = renderToStaticMarkup(
+    createElement(Streamdown, { mode: "streaming" }, "a\n\nb"),
+  );
+  const container = html.slice(0, html.indexOf(">"));
+  assert.match(container, /class="[^"]*\bspace-y-4\b/);
+  assert.match(container, /\[&amp;&gt;\*:first-child\]:mt-0/);
+  assert.match(container, /\[&amp;&gt;\*:last-child\]:mb-0/);
+});
+
+test("block 0 is never wrapped, so the plain first-child rule still reaches it", () => {
+  assert.match(
+    MARKDOWN_TEXT,
+    /if \(props\.index === 0\) \{\s*return <StreamdownBlock \{\.\.\.props\} \/>;/,
+  );
+});

--- a/studio/frontend/tests/reasoning-block-window.test.ts
+++ b/studio/frontend/tests/reasoning-block-window.test.ts
@@ -1,0 +1,223 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// The arithmetic behind the streaming reasoning pane's block window.
+//
+// The pane holds the whole reasoning body while a model thinks, so a long generation mounts tens
+// of thousands of nodes into a 256px box. The window renders a contiguous SUFFIX of the block
+// list and replaces the rest with one spacer. Everything here is about the two numbers that makes
+// possible: where the window starts, and how tall the spacer is.
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+import {
+  PANE_BOTTOM_THRESHOLD_PX,
+  RETAIN_ABOVE_PX,
+  blockWindowFlippedRange,
+  blockWindowSpacerHeight,
+  chooseBlockWindowStart,
+  createBlockWindowState,
+  isBlockMounted,
+  isBlockSuffix,
+  mountedBlockContents,
+  recordBlockContent,
+  recordBlockOffset,
+  resetBlockWindow,
+  setBlockWindowStart,
+} from "../src/components/assistant-ui/block-window.ts";
+
+/** A document of `count` blocks, each `height` tall, already measured. */
+function measured(count: number, height: number) {
+  const state = createBlockWindowState();
+  for (let index = 1; index < count; index += 1) {
+    recordBlockOffset(state, index, index * height);
+  }
+  return state;
+}
+
+test("the window is a suffix and starts at the top until there is something to hide", () => {
+  const state = measured(40, 100);
+
+  // Nothing scrolled: RETAIN_ABOVE_PX of content has to sit above the viewport before any of it
+  // can be dropped, so the whole document is mounted.
+  assert.equal(chooseBlockWindowStart(state, 0), 0);
+  assert.equal(chooseBlockWindowStart(state, RETAIN_ABOVE_PX), 0);
+  assert.equal(blockWindowSpacerHeight(state, 0), 0);
+
+  // One block past the retained band.
+  assert.equal(chooseBlockWindowStart(state, RETAIN_ABOVE_PX + 100), 1);
+
+  // Scrolled to the bottom of a 4000px document in a 256px pane.
+  const start = chooseBlockWindowStart(state, 4000 - 256);
+  assert.equal(start, 22);
+  assert.equal(start * 100, 2200);
+  assert.ok(4000 - 256 - start * 100 >= RETAIN_ABOVE_PX);
+
+  assert.equal(isBlockMounted({ ...state, start }, 21), false);
+  assert.equal(isBlockMounted({ ...state, start }, 22), true);
+  assert.equal(isBlockMounted({ ...state, start }, 39), true);
+});
+
+test("the retained band really is what bounds the window, at any document length", () => {
+  // 400 blocks, i.e. a 40,000px document: what is mounted must not grow with it.
+  const state = measured(400, 100);
+  const start = chooseBlockWindowStart(state, 40_000 - 256);
+  const mountedPx = 40_000 - start * 100;
+  assert.ok(
+    mountedPx <= RETAIN_ABOVE_PX + 256 + 100,
+    `mounted ${mountedPx}px above the bound`,
+  );
+  // And the same fixture ten times longer picks the same bound, not ten times more.
+  const longer = measured(4000, 100);
+  const longerStart = chooseBlockWindowStart(longer, 400_000 - 256);
+  assert.equal(400_000 - longerStart * 100, mountedPx);
+});
+
+test("only indices with a measured offset can become the window start", () => {
+  const state = createBlockWindowState();
+  recordBlockOffset(state, 3, 300);
+  recordBlockOffset(state, 9, 900);
+  // 5 and 7 were never measured (empty blocks render no element), so a viewport that has passed
+  // them still stops at the last index whose height is known.
+  assert.equal(chooseBlockWindowStart(state, 900 + RETAIN_ABOVE_PX - 1), 3);
+  assert.equal(chooseBlockWindowStart(state, 900 + RETAIN_ABOVE_PX), 9);
+  assert.equal(blockWindowSpacerHeight(state, 3), 300);
+  assert.equal(blockWindowSpacerHeight(state, 9), 900);
+});
+
+test("the spacer is the height of the range it replaces, from the frame before the drop", () => {
+  const state = measured(40, 100);
+
+  // The identity the design rests on: moving the window from s to s' grows the spacer by exactly
+  // offset(s') - offset(s), which is the height of the removed blocks INCLUDING their collapsed
+  // margins, because both numbers were read in the same pre-mutation frame.
+  for (const [from, to] of [
+    [0, 5],
+    [5, 12],
+    [12, 30],
+  ] as const) {
+    const grew =
+      blockWindowSpacerHeight(state, to) - blockWindowSpacerHeight(state, from);
+    const removed =
+      (state.offsets.get(to) ?? 0) - (from === 0 ? 0 : (state.offsets.get(from) ?? 0));
+    assert.equal(grew, removed);
+  }
+
+  setBlockWindowStart(state, 12);
+  assert.equal(state.spacerHeight, 1200);
+  setBlockWindowStart(state, 30);
+  assert.equal(state.spacerHeight, 3000);
+  // Back up again: the earlier height is restored EXACTLY. An incremental spacer would have
+  // accumulated whatever the two subtractions rounded off.
+  setBlockWindowStart(state, 12);
+  assert.equal(state.spacerHeight, 1200);
+  setBlockWindowStart(state, 0);
+  assert.equal(state.spacerHeight, 0);
+});
+
+test("moving the window reports a change only when something changed", () => {
+  const state = measured(10, 100);
+  assert.equal(setBlockWindowStart(state, 4), true);
+  assert.equal(setBlockWindowStart(state, 4), false);
+  assert.equal(setBlockWindowStart(state, 0), true);
+});
+
+test("only the blocks whose mounted state flips are in the flipped range", () => {
+  assert.deepEqual(blockWindowFlippedRange(0, 22), { from: 0, to: 22 });
+  assert.deepEqual(blockWindowFlippedRange(22, 14), { from: 14, to: 22 });
+  assert.deepEqual(blockWindowFlippedRange(7, 7), { from: 7, to: 7 });
+
+  // The point of the range: for a window move from 22 to 14, blocks 14..21 flip and NOTHING else
+  // does. 22 and up were mounted before and after; 13 and down were hidden before and after.
+  const { from, to } = blockWindowFlippedRange(22, 14);
+  for (const index of [0, 13, 22, 39]) {
+    assert.ok(
+      index < from || index >= to,
+      `${index} must not be in the flipped range`,
+    );
+  }
+  for (const index of [14, 18, 21]) {
+    assert.ok(index >= from && index < to);
+  }
+});
+
+test("a width change is the thing that invalidates every frozen height at once", () => {
+  const state = measured(40, 100);
+  setBlockWindowStart(state, 22);
+  recordBlockContent(state, 22, "body");
+  assert.equal(state.offsets.size, 39);
+
+  resetBlockWindow(state);
+
+  assert.equal(state.start, 0);
+  assert.equal(state.spacerHeight, 0);
+  assert.equal(state.offsets.size, 0);
+  assert.equal(state.contents.size, 0);
+  assert.equal(state.highestIndex, -1);
+  // Which is the whole argument that a stale height cannot outlive a reflow: after a reset the
+  // window can only be 0, so every block remounts and re-measures.
+  assert.equal(chooseBlockWindowStart(state, 100_000), 0);
+});
+
+test("a re-parse behind the live edge is reported, and the live edge itself is not", () => {
+  const state = createBlockWindowState();
+  for (let index = 0; index <= 30; index += 1) {
+    assert.equal(
+      recordBlockContent(state, index, `block ${index}`),
+      false,
+      "first sight of a block is never a re-parse",
+    );
+  }
+
+  // The newest block grows with every token. That is not a re-parse.
+  assert.equal(recordBlockContent(state, 30, "block 30 and more"), false);
+  assert.equal(recordBlockContent(state, 29, "block 29 and more"), false);
+  assert.equal(recordBlockContent(state, 23, "block 23 rewritten"), false);
+
+  // Far behind it, a block that changes means the renderer re-segmented the document, which is
+  // exactly what a late GFM footnote definition does, and the frozen heights no longer describe
+  // it. The source string is never touched, so this can never corrupt the TEXT; it can only make
+  // the spacer the wrong height, and the answer is to remeasure everything.
+  assert.equal(recordBlockContent(state, 10, "block 10 rewritten"), true);
+  // Re-reporting the same content is not a change.
+  assert.equal(recordBlockContent(state, 10, "block 10 rewritten"), false);
+});
+
+test("what is mounted is always a contiguous suffix of the renderer's own block list", () => {
+  const blocks = ["a", "\n\n", "b", "\n\n", "c", "\n\n", "d"];
+  for (let start = 0; start <= blocks.length; start += 1) {
+    const mounted = mountedBlockContents(blocks, start);
+    assert.equal(mounted.length, blocks.length - start);
+    assert.ok(
+      isBlockSuffix(blocks, mounted),
+      `start ${start} did not produce a suffix`,
+    );
+    assert.equal(mounted.join(""), blocks.slice(start).join(""));
+  }
+
+  // The negative, so the check above is not vacuous.
+  assert.equal(isBlockSuffix(blocks, ["a", "\n\n", "b"]), false);
+  assert.equal(isBlockSuffix(blocks, ["c", "d"]), false);
+  assert.equal(isBlockSuffix(blocks, [...blocks, "e"]), false);
+});
+
+test("the pinned threshold is the autoscroll's own, so the two cannot drift apart", () => {
+  const reasoning = new URL(
+    "../src/components/assistant-ui/reasoning.tsx",
+    import.meta.url,
+  );
+  const source = readFileSync(reasoning, "utf8");
+  assert.match(
+    source,
+    /distanceFromBottom <= PANE_BOTTOM_THRESHOLD_PX/,
+    "the reasoning pane's autoscroll must use the shared threshold",
+  );
+  assert.doesNotMatch(
+    source,
+    /AUTO_SCROLL_THRESHOLD_PX\s*=/,
+    "a second copy of the threshold would be free to drift from the window's",
+  );
+  assert.equal(PANE_BOTTOM_THRESHOLD_PX, 24);
+});

--- a/studio/frontend/tsconfig.app.json
+++ b/studio/frontend/tsconfig.app.json
@@ -36,6 +36,7 @@
     "smoke-heavy-thread-main.tsx",
     "smoke-thread-weight-main.tsx",
     "smoke-settings-main.tsx",
-    "smoke-stream-pacing-main.tsx"
+    "smoke-stream-pacing-main.tsx",
+    "smoke-reasoning-pane-main.tsx"
   ]
 }

--- a/tests/studio/playwright_reasoning_pane.py
+++ b/tests/studio/playwright_reasoning_pane.py
@@ -921,9 +921,7 @@ def measure_cell(
     control_page_end, control_driver_end = _clock_pair(page)
     control_page_ms = control_page_end - control_page_start
     control_driver_ms = (control_driver_end - control_driver_start) * 1000
-    control_ratio = (
-        round(control_page_ms / control_driver_ms, 4) if control_driver_ms > 0 else None
-    )
+    control_ratio = round(control_page_ms / control_driver_ms, 4) if control_driver_ms > 0 else None
 
     # The completion row, and how long it took to arrive.
     #
@@ -996,9 +994,7 @@ def measure_cell(
         "collapse_ms": collapse_ms,
         "settle": settle,
         "time_to_settle_ms": (settle or {}).get("settled_ms"),
-        "rss_samples": [
-            {"t_ms": round(t), "rss_mb": v} for t, v in rss.samples
-        ],
+        "rss_samples": [{"t_ms": round(t), "rss_mb": v} for t, v in rss.samples],
         "rss_growth_mb": rss.growth_mb(),
         "rss_unavailable": rss.reason,
         "control_page_ms": round(control_page_ms),
@@ -1257,9 +1253,7 @@ def summarise(cell: dict) -> dict:
         "early_fps": rnd(early_fps, 1),
         "early_frames_over_33": round(early_over33, 1),
         "late_frames_over_33": round(late_over33, 1),
-        "frames_over_33_ratio": (
-            round(late_over33 / early_over33, 2) if early_over33 else None
-        ),
+        "frames_over_33_ratio": (round(late_over33 / early_over33, 2) if early_over33 else None),
         "early_frames_over_33_pct": rnd(early_over33_pct, 1),
         "late_frames_over_33_pct": rnd(late_over33_pct, 1),
         "frameless_early_samples": frameless_early,
@@ -1312,8 +1306,10 @@ def print_ladder(results: dict) -> None:
     """
     if not CPU_LADDER:
         return
-    print("\n=== CPU THROTTLING LADDER (CHROMIUM ONLY: CDP Emulation.setCPUThrottlingRate) ===",
-          flush = True)
+    print(
+        "\n=== CPU THROTTLING LADDER (CHROMIUM ONLY: CDP Emulation.setCPUThrottlingRate) ===",
+        flush = True,
+    )
     for engine, cells in results.items():
         arms = [c for c in cells.values() if "error" not in c]
         if not arms:
@@ -1359,9 +1355,7 @@ def print_ladder(results: dict) -> None:
                     f"{(cell.get('windows_per_wall_s') or -1):7.3f}",
                     flush = True,
                 )
-            controls = [
-                c["control_ratio"] for c in group if c.get("control_ratio") is not None
-            ]
+            controls = [c["control_ratio"] for c in group if c.get("control_ratio") is not None]
             if len(controls) < 2:
                 continue
             spread_pct = (max(controls) - min(controls)) / min(controls) * 100

--- a/tests/studio/playwright_reasoning_pane.py
+++ b/tests/studio/playwright_reasoning_pane.py
@@ -1,0 +1,1568 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""What a long THINKING block costs while it streams, sampled the way the field trace was.
+
+WHY THIS FILE EXISTS
+
+tests/studio/playwright_heavy_thread.py measures a heavy thread, and its fixture holds text,
+code fences, tool calls, artifacts and images. It holds no reasoning content, and it cannot
+usefully hold any: it seeds a FINISHED thread, a finished reasoning group resolves to closed
+(features/chat/utils/reasoning-visibility.ts), and Radix unmounts a closed CollapsibleContent.
+So a seeded reasoning part contributes zero DOM and zero cost. Every bottleneck number taken on
+that harness was taken on a thread with no thinking block in it.
+
+The field report this file answers is a single long generation on Unsloth Desktop (Arch,
+Wayland, WebKitGTK 2.52.5), sampled every 5 seconds:
+
+    t=5s     fps 59.4   reasoningChars  2,256   reasoningCodeSpans      0   elements    578
+    t=130s   fps 39.7   reasoningChars 45,943   reasoningCodeSpans  3,520   elements  4,755
+    t=216s   fps 20.5   reasoningChars 73,178   reasoningCodeSpans 11,875   elements 13,688
+    t=241s   fps 18.2   reasoningChars 80,434   reasoningCodeSpans 14,433   elements 16,513
+    t=271s   fps 28.3   reasoningChars 90,262   reasoningCodeSpans 16,186   elements 18,536
+    t=276s   COMPLETED, reasoningCodeSpans 0, elements 621, fps recovers
+
+Three things that trace establishes, which this harness therefore does not re-derive:
+
+  * It is not the forced software renderer. WEBKIT_DMABUF_RENDERER_FORCE_SHM=1 would be
+    uniformly slow from t=0. This starts at a clean 59.4 fps and degrades with content.
+  * `reasoningCodeSpans` counts `pre code span` inside `.aui-reasoning-text`, so those 16,186
+    highlight spans are inside the THINKING pane, not the answer.
+  * The collapse at completion is the proof of location: 18,536 elements become 621 and fps
+    recovers, in the same second, without the thread being unloaded.
+
+TWO PRECONDITIONS. GET EITHER WRONG AND THIS FILE MEASURES ALMOST NOTHING.
+
+1. THE ARRIVAL RATE MUST BE THE USER'S. The capture delivered ~325 characters a second, which at
+   24 characters a chunk is one chunk every 73ms, and that is the default here. The first version
+   of this file used a 2ms gap, about four times a real token rate. At 2ms the renderer is the
+   bottleneck from the very first chunk, so the run opens at 45 fps instead of 60 and there is no
+   healthy early baseline left to degrade FROM: it measured a 1.19x spread where the capture shows
+   3x. The whole shape being reproduced is "idle between chunks at the start, no longer idle at the
+   end", and a fixture that is saturated at t=0 cannot show it.
+
+2. ON AN IDLE MACHINE, FRAME RATE IS NOT SENSITIVE ENOUGH. Measured on the development box: 65%
+   main-thread IDLE at 15,000 highlight spans. The work per chunk really does grow with the
+   content, but there is so much headroom that it never crosses a frame budget, so fps sits pinned
+   at 60 for the whole run and reading fps alone calls it "no effect". The metric that moves is
+   `busy%`: main-thread blocked time per window, measured against a CALIBRATED timer clamp. To see
+   the frame-rate collapse itself rather than the cost that causes it, throttle:
+   SMOKE_RP_CPU_THROTTLE=6 on Chromium reproduced 47.1 fps -> 9.2 fps on this fixture.
+
+WHY THIS CANNOT BE A SEEDED THREAD (the trap that makes this file necessary)
+
+playwright_heavy_thread.py seeds a FINISHED thread through `thread.import`. Adding reasoning
+content to that fixture looks like the obvious way to cover this path and it would have shown
+NOTHING, convincingly: a finished reasoning group resolves to closed
+(features/chat/utils/reasoning-visibility.ts -> `resolveReasoningOpen` returns false when
+`isStreaming` is false and the user has not opened it by hand), Radix unmounts a closed
+`CollapsibleContent`, and the reasoning part therefore contributes ZERO DOM and zero cost. The
+cost exists only while the block streams. That is why this file streams.
+
+WHAT IS MEASURED, AND WHY NOT longTasks
+
+The trace's `longTasks` column read 0 in every sample. That is not an absence of jank: WebKit
+never shipped the Long Tasks API, so a `longtask` PerformanceObserver is accepted and then never
+fires. Support is read from `PerformanceObserver.supportedEntryTypes`, never from whether
+observe() throws, and the portable signal is EVENT LOOP LAG: the largest gap between ticks of a
+1ms setTimeout loop. The main thread cannot answer the timer while it is busy, so the gap is the
+block. Resolution is the timer clamp, about 4ms, far below anything a user feels.
+
+fps is counted from requestAnimationFrame ticks in the sample window, which is what the field
+sampler did.
+
+SAMPLING RUNS IN THE PAGE, NOT IN THE DRIVER
+
+`document.querySelectorAll(".aui-reasoning-text pre code span")` over 16,000 spans is not free,
+and a driver that pays a CDP round trip for it every window would put its own cost inside the
+number. The sampler is a setInterval in the page, it records its own cost as `sample_ms`, and
+that column is printed so a reader can check that the measurement is not the measured.
+
+INSTRUMENTATION (optional, SMOKE_RP_INSTRUMENT=1)
+
+ReasoningText installs a MutationObserver over its whole growing subtree and answers every
+mutation with `el.scrollTop = el.scrollHeight` (studio/frontend/src/components/assistant-ui/
+reasoning.tsx). Reading scrollHeight forces synchronous layout. To measure that directly rather
+than infer it, the optional instrumentation wraps the `scrollHeight` getter on Element.prototype
+and counts reads and the wall time inside them, split by whether the element is the reasoning
+pane. It also counts MutationObserver callback invocations.
+
+That wrapper perturbs: it adds two performance.now() calls per read. So it is OFF by default,
+and the honest way to use it is to run the same size with and without and check the uninstru-
+mented run degrades on its own. The driver prints which mode it ran in.
+
+WHAT ELSE IS MEASURED, AND WHY EACH ONE IS NOT ALREADY COVERED
+
+  * FRAMES OVER 33ms, per window, as a count and as a share of that window's frames. p95 frame
+    time says how bad a bad frame was; it does not say how many there were, and the two come
+    apart in both directions. One 400ms stall among 59 clean frames barely moves p95. Sixty
+    frames all landing at 34ms move p95 to 34ms with no single frame a user would call a stall.
+
+  * PROCESS RSS. `heapMB` is `performance.memory.usedJSHeapSize`: Chromium only, JS heap only,
+    and deliberately quantised. The 22,500-character calibration run of this file reported
+    exactly 98MB for all ten samples while the element count went from 30 to 2,747. The DOM,
+    the layout tree and the highlighter's retained strings are all outside it. So the browser
+    process AND its renderer children are sampled from the OS with psutil, and what is reported
+    as the result is `rss_growth_mb`, peak minus the first reading of the same run. Where RSS
+    cannot be read it is null with a printed reason, NEVER 0.
+
+  * TIME TO SETTLE. `collapse_ms` is a DOM predicate: it goes true when the spans reach zero,
+    which can happen while the main thread is still finishing the teardown. Settle is the wall
+    time from `streamDone` until two consecutive 250ms windows each show under 10% blocked time.
+    Null, and said out loud, if it never happens inside the collapse budget.
+
+THE CPU LADDER AND ITS CONTROL (SMOKE_RP_CPU_LADDER, CHROMIUM ONLY)
+
+SMOKE_RP_CPU_LADDER=1,2,4 runs the same cell once per CDP throttling rate. One throttled run
+answers "is this box too fast to notice". It does not answer "is the number I am reading wired
+up correctly", and a metric that is wired up wrongly is perfectly capable of producing one
+plausible figure.
+
+So the ladder carries a CONTROL that must NOT move: the page's own `Date.now()` elapsed over the
+run divided by the driver's `time.monotonic()` elapsed over the same interval. Throttling slows
+how fast V8 executes; it does not touch the wall clock, so this ratio is 1.0 at every rate.
+Arrivals per second is NOT a valid control and is not used as one -- it is paced by
+`await sleep(gapMs)` on the main thread and it already falls from 118/s to 52/s inside a single
+unthrottled run. Sampler windows per wall second is main-thread paced for the same reason and is
+printed as a diagnostic only. When the control moves by more than SMOKE_RP_CONTROL_TOLERANCE_PCT
+(10 by default) the run says loudly that the MEASUREMENT is wrong, not that the page is slow.
+
+Run:
+    python tests/studio/playwright_reasoning_pane.py
+    SMOKE_RP_CPU_LADDER=1,2,4 SMOKE_RP_ENGINES=chromium \
+      python tests/studio/playwright_reasoning_pane.py
+    SMOKE_RP_CHARS=30000,90000 SMOKE_RP_ENGINES=chromium python tests/studio/playwright_reasoning_pane.py
+    SMOKE_RP_INSTRUMENT=1 SMOKE_RP_ENGINES=chromium python tests/studio/playwright_reasoning_pane.py
+
+It starts and stops its own vite dev server. Point it at one you already have with
+SMOKE_BASE_URL, or move the port with SMOKE_PORT.
+
+RUN ONE ENGINE PER INVOCATION IN CI, UNDER AN EXTERNAL TIMEOUT, for the reason
+playwright_heavy_thread.py's docstring gives at length: Playwright's sync API blocks inside a
+greenlet, so no in-process timeout can bound a wedged engine and only the process bound works.
+
+THIS HARNESS MEASURES, IT DOES NOT GATE on timings. It exits non-zero only when it is not
+measuring what it claims: the fixture did not reach the trace's span count, the reasoning pane
+never opened, the stream did not finish, or the completion collapse did not happen.
+
+The dev server is a limitation to read the numbers against: React runs in development mode,
+nothing is minified, vite serves unbundled modules. Absolute fps is therefore lower than a
+packaged Studio's. The SHAPE across the run, and the ratio between the start and the end of the
+same run, are what this file is for.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import threading
+import time
+from pathlib import Path
+
+from playwright.sync_api import sync_playwright
+
+# Optional, and the harness stays useful without it. Everything psutil is used for here is
+# reported as null with a printed explanation when it is missing, never as zero: a zero RSS
+# reads as "the browser used no memory", which is the one thing it cannot mean.
+try:
+    import psutil
+except ImportError:  # pragma: no cover - depends on the environment, not on the code
+    psutil = None
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _playwright_robust import (  # noqa: E402
+    chromium_launch_args,
+    start_vite,
+    stop_process,
+    wait_for_smoke_page,
+)
+
+PORT = int(os.environ.get("SMOKE_PORT", "5219"))
+_EXTERNAL = os.environ.get("SMOKE_BASE_URL", "").strip().rstrip("/")
+BASE = _EXTERNAL or f"http://127.0.0.1:{PORT}"
+OWNS_SERVER = not _EXTERNAL
+LABEL = os.environ.get("SMOKE_LABEL", "tree")
+OUT = Path(os.environ.get("PW_ART_DIR", "logs/playwright-reasoning-pane"))
+OUT.mkdir(parents = True, exist_ok = True)
+
+# Characters of REASONING content. The largest is the trace's own 90,000.
+SIZES = sorted(int(n) for n in os.environ.get("SMOKE_RP_CHARS", "22500,45000,90000").split(","))
+ENGINES = [
+    e.strip() for e in os.environ.get("SMOKE_RP_ENGINES", "chromium,webkit").split(",") if e.strip()
+]
+# Characters per fence. This is the span DENSITY knob: the trace's 90,262 characters carried
+# 16,186 spans, i.e. 5.6 characters per span, which only happens if the content is nearly all
+# fenced code. The driver reports the density it achieved so this can be tuned against the trace
+# instead of guessed.
+FENCE_CHARS = int(os.environ.get("SMOKE_RP_FENCE_CHARS", "1800"))
+# Prose between the fences. Prose is characters without spans, so this is the other half of the
+# density calibration. 1,250 against a 1,800-character fence was measured to land on the trace's
+# ~5.6 characters per span; an all-fence fixture measured 3.47, i.e. half again as much work per
+# character as the user's own content.
+PROSE_CHARS = int(os.environ.get("SMOKE_RP_PROSE_CHARS", "1250"))
+# Characters of fence-free thinking before the first code fence. The field capture held a flat
+# 60.0 fps and exactly 0 highlight spans for 33,348 characters, and started losing frames at the
+# first CLOSED fence, so a fixture without this stretch cannot show where the onset is. Scaled to
+# the same quarter of the body by the driver when the size is not the capture's own.
+PREAMBLE_CHARS = int(os.environ.get("SMOKE_RP_PREAMBLE_CHARS", "0"))
+CHUNK_CHARS = int(os.environ.get("SMOKE_RP_CHUNK_CHARS", "24"))
+# THE ARRIVAL RATE IS PART OF THE FIXTURE, and getting it wrong is how the first version of this
+# file failed to reproduce anything.
+#
+# The trace delivered 90,262 characters in 276 seconds: 327 characters a second, which at 24
+# characters a chunk is one chunk every 73ms. The first run here used a 2ms gap, i.e. about four
+# times the user's token rate, and it measured a 1.19x spread on Chromium instead of the trace's
+# 3.3x. The reason is not subtle: at 2ms the renderer is the bottleneck from the very first
+# chunk, so the run opens at 45 fps rather than at 59 and there is no healthy early baseline left
+# to degrade FROM. The trace's whole shape is "idle between chunks at the start, no longer idle
+# at the end", and a fixture that is saturated at t=0 cannot show it.
+#
+# So the default is the user's own rate. It makes a 90,000-character run take about as long as
+# the user's did, which is the point.
+GAP_MS = int(os.environ.get("SMOKE_RP_GAP_MS", "73"))
+SAMPLE_MS = int(os.environ.get("SMOKE_RP_SAMPLE_MS", "1000"))
+RUN_TIMEOUT_MS = int(os.environ.get("SMOKE_RP_TIMEOUT_MS", "900000"))
+# How long the completion collapse is allowed to take before the harness calls it a failure to
+# collapse rather than a slow one.
+COLLAPSE_TIMEOUT_MS = int(os.environ.get("SMOKE_RP_COLLAPSE_TIMEOUT_MS", "60000"))
+INSTRUMENT = os.environ.get("SMOKE_RP_INSTRUMENT", "0") == "1"
+# Whether to require that the DOM ends up holding the capture's highlight spans.
+#
+# On by default, because on an unmodified tree a run that does not build them is measuring the
+# wrong content. It has to be switchable, though, and the reason is not hypothetical: a candidate
+# fix that bounds what the pane keeps mounted ends the run with 511 spans instead of 16,000, and
+# this check failed it as "the fixture is not the capture's content" when the fixture was exactly
+# right and the FIX was what removed the spans. What the fixture owes is that it SENT the content;
+# what the DOM does with it is the measurement.
+EXPECT_SPANS = os.environ.get("SMOKE_RP_EXPECT_SPANS", "1") == "1"
+# Upper bound on what the pane is allowed to keep mounted, in characters. Unset means no bound.
+#
+# The counterpart to EXPECT_SPANS, and the reason it exists: turning the span floor off to measure
+# a windowed tree removes the only check that the pane's CONTENT is what it should be, and every
+# other assertion here is satisfied by a pane holding the entire body. A run with the window
+# regressed away would then be green. This is the assertion that is false on the tree the window
+# is supposed to have fixed and true on the one it did.
+MAX_PANE_CHARS = int(os.environ.get("SMOKE_RP_MAX_PANE_CHARS", "0"))
+# Headed, under a real display, is not a nicety here.
+#
+# Headless has NO COMPOSITOR. Everything this file measures about layout and script is the same
+# either way, but the cost of PAINTING a large composited layer and getting it to a display is
+# not measured at all in headless, and on the platform the field trace came from that path is
+# deliberately the slow one: studio/src-tauri/src/linux_webkit.rs sets
+# WEBKIT_DMABUF_RENDERER_FORCE_SHM=1, which forces WebKitGTK's software transport under Wayland.
+# So a headless run that shows no degradation has NOT ruled the renderer out; it has not looked.
+#
+#     SMOKE_RP_HEADLESS=0 WEBKIT_DMABUF_RENDERER_FORCE_SHM=1 \
+#       xvfb-run -s "-screen 0 1280x900x24" python tests/studio/playwright_reasoning_pane.py
+HEADLESS = os.environ.get("SMOKE_RP_HEADLESS", "1") != "0"
+# CHROMIUM ONLY, and off by default, because it is CDP and switching it on makes the chromium
+# column incomparable with the webkit one.
+#
+# It is here because the first paced runs found 65% main-thread IDLE at 15,000 highlight spans on
+# this box: the work per chunk really does grow with the content, but there is so much headroom
+# that it never crosses a frame budget, so fps stays pinned at 60. The field trace came from a
+# machine that was also running the generation. Throttling asks the question that separates "this
+# work does not grow" from "this box is too fast to notice": at 4x or 6x, does the SAME curve
+# cross the budget and produce the trace's shape?
+CPU_THROTTLE = float(os.environ.get("SMOKE_RP_CPU_THROTTLE", "1"))
+# The ladder: the SAME cell run once per throttle rate, e.g. SMOKE_RP_CPU_LADDER=1,2,4.
+#
+# One throttled run answers "is this box too fast to notice", which is what SMOKE_RP_CPU_THROTTLE
+# is for. It does not answer "does the number I am reading respond to load the way it should",
+# and a metric that is wired up wrongly is perfectly capable of producing one plausible figure.
+# A ladder does: the arm at rate 1 is the control arm for the arms above it, and the direction
+# and rough size of the move is a prediction the harness can be checked against.
+#
+# CHROMIUM ONLY. It is CDP (Emulation.setCPUThrottlingRate); WebKit and Firefox have no
+# equivalent, and the printed output says so on every ladder run rather than silently giving a
+# non-Chromium engine one unthrottled arm that looks like a flat ladder.
+CPU_LADDER = [
+    float(r.strip()) for r in os.environ.get("SMOKE_RP_CPU_LADDER", "").split(",") if r.strip()
+]
+# How far the throttle CONTROL is allowed to move across the ladder before the run says the
+# measurement is wrong. See CONTROL in measure_cell for what the control is and why.
+CONTROL_TOLERANCE_PCT = float(os.environ.get("SMOKE_RP_CONTROL_TOLERANCE_PCT", "10"))
+
+# The trace, for the table's comparison column. Not a budget: different machine, different
+# engine, different build.
+TRACE = [
+    {"t": 5, "fps": 59.4, "chars": 2256, "spans": 0, "elements": 578},
+    {"t": 130, "fps": 39.7, "chars": 45943, "spans": 3520, "elements": 4755},
+    {"t": 216, "fps": 20.5, "chars": 73178, "spans": 11875, "elements": 13688},
+    {"t": 241, "fps": 18.2, "chars": 80434, "spans": 14433, "elements": 16513},
+    {"t": 271, "fps": 28.3, "chars": 90262, "spans": 16186, "elements": 18536},
+]
+
+
+def info(message: str) -> None:
+    print(f"[reasoning-pane] {message}", flush = True)
+
+
+# Installed before anything else runs. Counts frames and event loop lag continuously, and lets
+# the page sampler close a window and read the totals since the last one.
+#
+# The rAF wrapper COUNTS, it does not pump, so fps stays the page's own frame rate.
+RECORDER_INIT = """
+(() => {
+  const nativeRaf = window.requestAnimationFrame.bind(window);
+  window.__nativeRaf = nativeRaf;
+
+  const R = {
+    frames: 0,
+    frameGaps: [],
+    maxLagMs: 0,
+    lagTicks: 0,
+    lagSumMs: 0,
+    blockedMs: 0,
+    // The same blocked time again, but NEVER reset. `blockedMs` is drained by __rpWindow, and
+    // the settle watch below has to read blocked time on its own 250ms cadence while the 1000ms
+    // window sampler is still running. Two readers draining one accumulator would each see a
+    // fraction of the block, so the settle watch reads deltas of this monotonic total instead
+    // and disturbs the window sampler not at all.
+    blockedTotalMs: 0,
+    clampMs: 4.0,
+    longTaskSupported: Boolean(
+      (PerformanceObserver.supportedEntryTypes || []).includes("longtask"),
+    ),
+    longTasks: 0,
+    longTaskMs: 0,
+  };
+  window.__rp = R;
+
+  // ONE self-rescheduling rAF loop is the frame counter, and requestAnimationFrame is NOT
+  // wrapped. A wrapper that increments per callback counts the page's frame once for the loop
+  // and once more for every rAF the app happened to schedule in that frame, which is a frame
+  // rate that rises with how busy the app is -- the first version of this file reported 888 fps
+  // on a 60Hz page for exactly that reason.
+  let lastFrame = performance.now();
+  const frame = () => {
+    const now = performance.now();
+    R.frames += 1;
+    R.frameGaps.push(now - lastFrame);
+    lastFrame = now;
+    nativeRaf(frame);
+  };
+  nativeRaf(frame);
+
+  // 1ms setTimeout, not a MessageChannel ping-pong: the MessageChannel version ticks ~150k/s and
+  // halves Firefox's frame rate before any app code runs. This ticks ~150/s and costs nothing on
+  // any engine. The clamp puts a ~4ms floor under the resolution, far below a felt stall.
+  // The clamp is CALIBRATED, not assumed. `setTimeout(fn, 1)` is clamped to about 4ms by spec
+  // but the actual floor differs by engine and by build, and the blocked-time figure below is a
+  // subtraction against it, so a guessed 4.0 would show phantom block on one engine and hide
+  // real block on another. The first 60 gaps of an idle page ARE the floor; the median of them
+  // is taken as the clamp and reported, so a reader can see what was subtracted.
+  const CALIBRATION_TICKS = 60;
+  const calibration = [];
+  let lastTick = performance.now();
+  const tick = () => {
+    const now = performance.now();
+    const gap = now - lastTick;
+    lastTick = now;
+    if (calibration.length < CALIBRATION_TICKS) {
+      calibration.push(gap);
+      if (calibration.length === CALIBRATION_TICKS) {
+        const sorted = calibration.slice().sort((a, b) => a - b);
+        R.clampMs = sorted[Math.floor(sorted.length / 2)];
+      }
+    } else {
+      R.lagTicks += 1;
+      R.lagSumMs += gap;
+      // Everything above the clamp is time the main thread could not answer a timer it had
+      // already scheduled, i.e. time it was busy. Summed over a window this is a far more
+      // sensitive signal than frame rate: a page with 65% idle still paints every frame on time,
+      // so fps stays pinned at 60 while the work per chunk quietly triples. That is exactly the
+      // regime this harness first landed in, and reading fps alone would have called it "no
+      // effect".
+      R.blockedMs += Math.max(0, gap - R.clampMs);
+      R.blockedTotalMs += Math.max(0, gap - R.clampMs);
+      if (gap > R.maxLagMs) R.maxLagMs = gap;
+    }
+    setTimeout(tick, 1);
+  };
+  setTimeout(tick, 1);
+
+  // Recorded as a cross-check and never as the headline. Chromium alone lists `longtask` in
+  // supportedEntryTypes; on WebKit and Gecko observe() is accepted and never fires, which reads
+  // as "no jank" rather than as "no measurement". That is exactly the trap the field trace's
+  // all-zero longTasks column fell into.
+  if (R.longTaskSupported) {
+    try {
+      new PerformanceObserver((list) => {
+        for (const e of list.getEntries()) {
+          R.longTasks += 1;
+          R.longTaskMs += e.duration;
+        }
+      }).observe({ type: "longtask", buffered: false });
+    } catch (e) {
+      R.longTaskSupported = false;
+    }
+  }
+
+  window.__rpWindow = () => {
+    // Frame TIME as well as frame rate. Headless Chromium has no vsync, so it runs the rAF loop
+    // as fast as it can and an unloaded page reports far more than 60 fps; the absolute number
+    // is then not a user-visible frame rate at all. The ratio within one run still is, and p95
+    // frame time is the number that stays meaningful on an engine with no display.
+    const gaps = R.frameGaps.slice().sort((a, b) => a - b);
+    const at = (q) => (gaps.length === 0 ? null : gaps[Math.min(gaps.length - 1,
+      Math.floor(gaps.length * q))]);
+    // Frames that took longer than 33ms, i.e. longer than two frames of a 60Hz display.
+    //
+    // p95 frame time answers "how bad is a bad frame"; this answers "how many of them were
+    // there", and the two come apart. A window with one 400ms stall and 59 clean frames has a
+    // p95 barely above 16.7ms, and a window where every frame lands at 34ms has a p95 of 34ms
+    // and no single frame a user would call a stall. Both are jank and only the count separates
+    // them. The threshold is the one tests/studio/playwright_stream_pacing.py already uses
+    // (smoke-stream-pacing-main.tsx, `framesOver33ms`), so the two harnesses stay comparable.
+    let over33 = 0;
+    for (const g of gaps) if (g > 33) over33 += 1;
+    const out = {
+      frames: R.frames,
+      framesOver33: over33,
+      // As a share of the frames actually observed in the window, because the denominator is not
+      // fixed: headless Chromium has no vsync and runs the rAF loop as fast as it can, so the
+      // frame COUNT per window varies by engine and by load and a raw count alone is not
+      // comparable across throttle rates.
+      framesOver33Pct:
+        gaps.length === 0 ? null : Math.round((over33 / gaps.length) * 1000) / 10,
+      p50FrameMs: at(0.5),
+      p95FrameMs: at(0.95),
+      maxFrameMs: gaps.length === 0 ? null : gaps[gaps.length - 1],
+      maxLagMs: R.maxLagMs,
+      lagTicks: R.lagTicks,
+      lagSumMs: R.lagSumMs,
+      blockedMs: R.blockedMs,
+      clampMs: R.clampMs,
+      longTasks: R.longTasks,
+      longTaskMs: R.longTaskMs,
+    };
+    R.frames = 0;
+    R.frameGaps = [];
+    R.maxLagMs = 0;
+    R.lagTicks = 0;
+    R.lagSumMs = 0;
+    R.blockedMs = 0;
+    R.longTasks = 0;
+    R.longTaskMs = 0;
+    return out;
+  };
+
+  // TIME TO SETTLE: how long after the stream stops before the page is quiet again.
+  //
+  // The trace's completion row is not instantaneous. Unmounting ~16,000 nodes is itself a
+  // main-thread job that scales with the content, and the trace's own worst event loop lag,
+  // 576ms, is AT completion. `collapse_ms` above already measures when the spans reach zero,
+  // but that is a DOM predicate: it can go true while the main thread is still busy finishing
+  // the teardown, the highlighter is still resolving, and React is still committing. So the
+  // quiet is measured separately, from the same blocked-time signal everything else here uses.
+  //
+  // Definition, fixed by the driver's contract: two CONSECUTIVE 250ms windows each with blocked
+  // time under 10% of the window. Two, not one, because a single quiet window happens in the
+  // middle of teardown between two bursts. 250ms, because the 1000ms sampler is far too coarse
+  // for a quantity that is often under a second.
+  //
+  // The clock starts when `streamState().done` flips, polled at 25ms. Polling, not a callback,
+  // because the fixture has no completion hook; the resulting bias is at most one poll interval
+  // and it is the same bias at every throttle rate.
+  const SETTLE_WINDOW_MS = 250;
+  const SETTLE_BUSY_PCT = 10;
+  const SETTLE_CONSECUTIVE = 2;
+  window.__rpArmSettleWatch = () => {
+    const S = {
+      armedAt: performance.now(),
+      doneAt: null,
+      settledAtMs: null,
+      windows: [],
+      windowMs: SETTLE_WINDOW_MS,
+      busyPct: SETTLE_BUSY_PCT,
+      consecutive: SETTLE_CONSECUTIVE,
+    };
+    window.__rpSettle = S;
+    const startWatching = () => {
+      S.doneAt = performance.now();
+      let lastAt = S.doneAt;
+      let lastBlocked = R.blockedTotalMs;
+      let quiet = 0;
+      const watch = setInterval(() => {
+        const now = performance.now();
+        const elapsed = now - lastAt;
+        const blocked = R.blockedTotalMs - lastBlocked;
+        lastAt = now;
+        lastBlocked = R.blockedTotalMs;
+        const pct = elapsed <= 0 ? 0 : (blocked / elapsed) * 100;
+        S.windows.push({
+          at_ms: Math.round(now - S.doneAt),
+          busy_pct: Math.round(pct * 10) / 10,
+        });
+        quiet = pct < SETTLE_BUSY_PCT ? quiet + 1 : 0;
+        if (quiet >= SETTLE_CONSECUTIVE && S.settledAtMs === null) {
+          S.settledAtMs = Math.round(now - S.doneAt);
+          clearInterval(watch);
+        }
+      }, SETTLE_WINDOW_MS);
+      S.stop = () => clearInterval(watch);
+    };
+    const poll = setInterval(() => {
+      try {
+        if (window.__reasoningPane && window.__reasoningPane.streamState().done) {
+          clearInterval(poll);
+          startWatching();
+        }
+      } catch (e) {
+        /* the fixture is not up yet */
+      }
+    }, 25);
+    S.disarm = () => clearInterval(poll);
+  };
+})();
+"""
+
+# Optional and off by default, because it perturbs what it measures.
+#
+# ReasoningText answers every mutation of its subtree with `el.scrollTop = el.scrollHeight`.
+# Reading scrollHeight forces synchronous layout of everything above it. This counts those reads
+# and times them, split by whether the element IS the reasoning pane, so "the autoscroll observer
+# forces a full layout per chunk" becomes a measured number rather than a reading of the source.
+INSTRUMENT_INIT = """
+(() => {
+  const I = {
+    scrollHeightReads: 0,
+    scrollHeightMs: 0,
+    reasoningReads: 0,
+    reasoningMs: 0,
+    scrollTopWrites: 0,
+    reasoningScrollTopWrites: 0,
+    mutationCallbacks: 0,
+    mutationRecords: 0,
+  };
+  window.__rpInstr = I;
+
+  const isPane = (el) => {
+    try {
+      return Boolean(el && el.classList && el.classList.contains("aui-reasoning-text"));
+    } catch (e) {
+      return false;
+    }
+  };
+
+  const sh = Object.getOwnPropertyDescriptor(Element.prototype, "scrollHeight");
+  if (sh && sh.get) {
+    Object.defineProperty(Element.prototype, "scrollHeight", {
+      configurable: true,
+      enumerable: sh.enumerable,
+      get() {
+        const t0 = performance.now();
+        const v = sh.get.call(this);
+        const dt = performance.now() - t0;
+        I.scrollHeightReads += 1;
+        I.scrollHeightMs += dt;
+        if (isPane(this)) {
+          I.reasoningReads += 1;
+          I.reasoningMs += dt;
+        }
+        return v;
+      },
+    });
+  }
+
+  const st = Object.getOwnPropertyDescriptor(Element.prototype, "scrollTop");
+  if (st && st.set) {
+    Object.defineProperty(Element.prototype, "scrollTop", {
+      configurable: true,
+      enumerable: st.enumerable,
+      get() {
+        return st.get.call(this);
+      },
+      set(value) {
+        I.scrollTopWrites += 1;
+        if (isPane(this)) I.reasoningScrollTopWrites += 1;
+        st.set.call(this, value);
+      },
+    });
+  }
+
+  const NativeMO = window.MutationObserver;
+  if (NativeMO) {
+    window.MutationObserver = function (callback) {
+      return new NativeMO((records, observer) => {
+        I.mutationCallbacks += 1;
+        I.mutationRecords += records.length;
+        return callback(records, observer);
+      });
+    };
+    window.MutationObserver.prototype = NativeMO.prototype;
+  }
+
+  window.__rpInstrWindow = () => {
+    const out = { ...I };
+    for (const k of Object.keys(I)) I[k] = 0;
+    return out;
+  };
+})();
+"""
+
+# The in-page sampler. One setInterval, the trace's columns, and its own cost recorded so a
+# reader can rule the measurement out as the cause.
+SAMPLER = """
+(({ sampleMs }) => {
+  const rows = [];
+  window.__rpRows = rows;
+  const t0 = performance.now();
+  let lastAt = t0;
+  let seenArrivals = 0;
+  const id = setInterval(() => {
+    const at = performance.now();
+    const w = window.__rpWindow();
+    const s = window.__reasoningPane.sample();
+    const instr = window.__rpInstrWindow ? window.__rpInstrWindow() : null;
+    const elapsed = at - lastAt;
+    lastAt = at;
+    const lastArrivals = seenArrivals;
+    seenArrivals = s.arrivals;
+    rows.push({
+      t_ms: Math.round(at - t0),
+      // Absolute OS wall clock at the moment the window closed. Not a metric: it is what the
+      // driver's throttle CONTROL is computed from, see CONTROL in measure_cell.
+      wall_ms: Date.now(),
+      fps: Math.round((w.frames / (elapsed / 1000)) * 10) / 10,
+      p50_frame_ms: w.p50FrameMs === null ? null : Math.round(w.p50FrameMs * 10) / 10,
+      p95_frame_ms: w.p95FrameMs === null ? null : Math.round(w.p95FrameMs * 10) / 10,
+      max_frame_ms: w.maxFrameMs === null ? null : Math.round(w.maxFrameMs * 10) / 10,
+      frames_over_33: w.framesOver33,
+      frames_over_33_pct: w.framesOver33Pct,
+      max_lag_ms: Math.round(w.maxLagMs * 10) / 10,
+      // Percent of the window the main thread was busy, from the blocked time above. This is the
+      // column that moves when fps does not.
+      busy_pct: Math.round((w.blockedMs / elapsed) * 1000) / 10,
+      clamp_ms: Math.round(w.clampMs * 100) / 100,
+      mean_lag_ms:
+        w.lagTicks === 0 ? null : Math.round((w.lagSumMs / w.lagTicks) * 10) / 10,
+      long_tasks: w.longTasks,
+      long_task_ms: Math.round(w.longTaskMs),
+      reasoning_chars: s.reasoningChars,
+      reasoning_spans: s.reasoningCodeSpans,
+      reasoning_elements: s.reasoningElements,
+      outside_reasoning: s.elementsOutsideReasoning,
+      all_spans: s.allCodeSpans,
+      elements: s.totalElements,
+      panes: s.reasoningPanes,
+      open: s.reasoningOpen,
+      sent_chars: s.sentChars,
+      arrivals: s.arrivals,
+      // Arrivals actually delivered in this window against the arrivals the pacing asked for.
+      // When the renderer stops keeping up, the generator's own `await sleep(gapMs)` starts
+      // returning late and this falls below the target: the stream itself slows down, which is
+      // the same thing the user sees as the reply crawling.
+      arrivals_in_window: s.arrivals - lastArrivals,
+      stream_done: s.streamDone,
+      sample_ms: s.sampleCostMs,
+      heap_mb:
+        performance.memory
+          ? Math.round(performance.memory.usedJSHeapSize / 1048576)
+          : null,
+      instr,
+    });
+  }, sampleMs);
+  window.__rpStopSampler = () => clearInterval(id);
+})
+"""
+
+
+# ── process RSS ─────────────────────────────────────────────────────
+#
+# WHY heapMB IS NOT ENOUGH, AND WHY IT IS NOT RSS.
+#
+# The `heapMB` column is `performance.memory.usedJSHeapSize`. Three things are wrong with
+# reading it as the memory cost of a long thinking pane:
+#
+#   * It is Chromium only. On WebKit -- the engine the field trace came from -- the property
+#     does not exist and the column is structurally null.
+#   * It is the JS heap. The DOM, the layout tree, the render surfaces and the highlighter's
+#     retained strings live in C++ allocations that never appear in it. 18,536 elements are
+#     almost entirely outside this number.
+#   * It is deliberately quantised. Chromium buckets and delays it to defeat cross-origin
+#     side channels. The 22,500-character baseline run of this file reported exactly 98MB for
+#     all ten samples of a run whose element count went from 30 to 2,747.
+#
+# So this samples the browser's real resident set from the OS, over the browser process AND its
+# renderer children, because in Chromium the page's DOM lives in the renderer and the browser
+# process would show almost none of the growth.
+#
+# The sum double counts shared pages (renderers share the zygote's mappings), so the ABSOLUTE
+# figure is an upper bound on the tree's footprint. The quantity actually reported as a result
+# is `rss_growth_mb`, peak minus the first sample of the same run, and shared pages are common
+# to both terms of that subtraction.
+
+
+def _new_descendants(root_pid: int, before: set[int]) -> list["psutil.Process"]:
+    """Processes under `root_pid` that were not there in `before`, topmost first.
+
+    Playwright does not expose the browser's pid: the browser is launched by the node driver,
+    which is itself a child of this process, so the browser is a grandchild with an engine
+    specific name and an executable path that differs per engine and per platform. Diffing the
+    descendant set across the launch identifies it without knowing any of that.
+    """
+    if psutil is None:
+        return []
+    try:
+        after = {p.pid: p for p in psutil.Process(root_pid).children(recursive = True)}
+    except (psutil.Error, OSError):
+        return []
+    new = {pid: proc for pid, proc in after.items() if pid not in before}
+    roots = []
+    for pid, proc in new.items():
+        try:
+            if proc.ppid() not in new:
+                roots.append(proc)
+        except (psutil.Error, OSError):
+            continue
+    return roots
+
+
+def _tree_rss_mb(roots: list["psutil.Process"]) -> float | None:
+    """Summed RSS of `roots` and everything under them, or None if nothing could be read.
+
+    None, never 0.0. A renderer that has exited and a permission failure both produce no
+    reading, and reporting either as zero would put a fabricated floor into `rss_growth_mb`.
+    """
+    if psutil is None or not roots:
+        return None
+    total = 0
+    read_any = False
+    for root in roots:
+        try:
+            procs = [root, *root.children(recursive = True)]
+        except (psutil.Error, OSError):
+            continue
+        for proc in procs:
+            try:
+                total += proc.memory_info().rss
+                read_any = True
+            except (psutil.Error, OSError):
+                continue
+    return round(total / 1048576, 1) if read_any else None
+
+
+class RssSampler:
+    """Samples the browser tree's RSS on a thread, on the page sampler's own cadence.
+
+    A thread, because the driver is blocked inside Playwright's sync API for the whole run and
+    cannot sample anything itself. It touches no Playwright object, only psutil, so it is safe
+    alongside the sync API's greenlet.
+    """
+
+    def __init__(self, roots: list["psutil.Process"], period_ms: int) -> None:
+        self.roots = roots
+        self.period_s = max(0.05, period_ms / 1000)
+        self.samples: list[tuple[float, float | None]] = []
+        self.reason: str | None = None
+        if psutil is None:
+            self.reason = "psutil is not installed"
+        elif not roots:
+            self.reason = "the browser process could not be identified"
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._t0 = 0.0
+
+    def start(self) -> None:
+        self._t0 = time.monotonic()
+        if self.reason is not None:
+            return
+        self._thread = threading.Thread(target = self._loop, daemon = True)
+        self._thread.start()
+
+    def _loop(self) -> None:
+        while not self._stop.is_set():
+            at = time.monotonic()
+            self.samples.append(((at - self._t0) * 1000, _tree_rss_mb(self.roots)))
+            self._stop.wait(self.period_s)
+
+    def stop(self) -> None:
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout = 5)
+        if self.reason is None and not [s for _, s in self.samples if s is not None]:
+            self.reason = "no RSS reading succeeded for the browser tree"
+
+    def at(self, t_ms: float) -> float | None:
+        """The sample nearest `t_ms` on the page sampler's clock."""
+        usable = [(t, v) for t, v in self.samples if v is not None]
+        if not usable:
+            return None
+        return min(usable, key = lambda s: abs(s[0] - t_ms))[1]
+
+    def growth_mb(self) -> float | None:
+        """Peak minus the FIRST reading of this run, not minus zero.
+
+        A browser that is already up carries a base footprint that has nothing to do with the
+        pane, and the run before this one in the same browser leaves its own. What this file
+        claims is what the run ADDED.
+        """
+        usable = [v for _, v in self.samples if v is not None]
+        if len(usable) < 2:
+            return None
+        return round(max(usable) - usable[0], 1)
+
+
+def start_run(page, size: int) -> None:
+    page.evaluate(
+        SAMPLER,
+        {"sampleMs": SAMPLE_MS},
+    )
+    page.evaluate(
+        """(cfg) => window.__reasoningPane.run(cfg)""",
+        {
+            "totalChars": size,
+            "fenceChars": FENCE_CHARS,
+            "proseChars": PROSE_CHARS,
+            "preambleChars": PREAMBLE_CHARS or int(size * 0.25),
+            "chunkChars": CHUNK_CHARS,
+            "gapMs": GAP_MS,
+        },
+    )
+
+
+def wait_for_stream(page, timeout_ms: int) -> bool:
+    """True if the stream finished. Polls the cheap bookkeeping, never the DOM counts."""
+    try:
+        page.wait_for_function(
+            """() => window.__reasoningPane.streamState().done === true""",
+            timeout = timeout_ms,
+        )
+        return True
+    except Exception:
+        return False
+
+
+def _clock_pair(page) -> tuple[float, float]:
+    """The page's OS wall clock and the driver's monotonic clock, as close to simultaneous as a
+    CDP round trip allows.
+
+    BRACKETED, and the driver's half taken as the MIDPOINT of a read either side of the round
+    trip. The page can only answer `Date.now()` when its main thread is free, so a single driver
+    reading taken after the evaluate charges the whole of a blocked main thread to the DRIVER's
+    elapsed time. Measured: with the naive ordering the throttle control read 1.0004 at 1x and 2x
+    and 1.0251 at 4x, i.e. 2.5% of pure round-trip skew inside a quantity whose entire job is to
+    be flat. Bracketing leaves only the asymmetry of the round trip, which is sub-millisecond.
+    """
+    before = time.monotonic()
+    page_ms = page.evaluate("""() => Date.now()""")
+    after = time.monotonic()
+    return page_ms, (before + after) / 2
+
+
+def measure_cell(
+    context,
+    engine: str,
+    size: int,
+    *,
+    throttle: float = 1.0,
+    rss_roots: list["psutil.Process"] | None = None,
+) -> dict:
+    page = context.new_page()
+    errors: list[str] = []
+    page.on("pageerror", lambda e: errors.append(str(e)))
+
+    # startswith, not `"/api/" in url`: vite serves the app's own source modules from paths that
+    # contain the substring, and aborting those would blank the page.
+    page.route(
+        "**/*",
+        lambda route: (
+            route.fulfill(status = 200, content_type = "application/json", body = "{}")
+            if route.request.url.startswith(f"{BASE}/api/")
+            else route.continue_()
+        ),
+    )
+
+    page.set_viewport_size({"width": 1280, "height": 900})
+    if throttle > 1 and engine == "chromium":
+        throttle_cdp = page.context.new_cdp_session(page)
+        throttle_cdp.send("Emulation.setCPUThrottlingRate", {"rate": throttle})
+    page.goto(f"{BASE}/smoke-reasoning-pane.html", wait_until = "domcontentloaded")
+    page.wait_for_function("""() => Boolean(window.__reasoningPane)""", timeout = 120_000)
+
+    # Armed BEFORE the run, so the clock it starts is the moment the fixture reports done and
+    # not the moment the driver's wait_for_function notices.
+    page.evaluate("""() => window.__rpArmSettleWatch()""")
+
+    rss = RssSampler(rss_roots or [], SAMPLE_MS)
+
+    # CONTROL for the throttle ladder.
+    #
+    # It has to be a quantity that CANNOT move when the CPU throttle moves, so that when it does
+    # move the conclusion is "the measurement is wrong", not "the page got slower". Two
+    # candidates were rejected before this one:
+    #
+    #   * arrivals per second. It is paced by `await sleep(gapMs)` on the page's main thread, so
+    #     a throttled main thread delivers fewer of them per second. The baseline run above
+    #     already shows it falling from 118/s to 52/s WITHIN one unthrottled run as the content
+    #     grows. It measures the thing under test; it is not a control.
+    #   * completed sampler windows per wall second. Also main-thread paced: setInterval cannot
+    #     fire while the thread is blocked, and the callback itself walks the DOM. It is
+    #     reported below as a diagnostic, and it is NOT the control.
+    #
+    # What is used instead is the page's own OS wall clock against the driver's: `Date.now()`
+    # deltas inside the page divided by `time.monotonic()` deltas in this process over the same
+    # interval. Emulation.setCPUThrottlingRate slows how fast V8 executes; it does not touch the
+    # clock, so this ratio is 1.0 at every rate. If it is not, the page's timebase itself moved
+    # (virtual time, a fake timer shim, a suspended or backgrounded renderer, a CDP session left
+    # over from another cell), and in that case every per-second quantity in this file -- fps,
+    # busy%, arr/s, frames over 33ms -- is being divided by a fictional second.
+    #
+    # The one place the main thread does enter is reading Date.now() itself, which can only be
+    # answered when the thread is free. That error is bounded by one block, tens of milliseconds
+    # against a run of tens of seconds, and the 10% tolerance covers it with room to spare.
+    control_page_start, control_driver_start = _clock_pair(page)
+    rss.start()
+    start_run(page, size)
+    finished = wait_for_stream(page, RUN_TIMEOUT_MS)
+    control_page_end, control_driver_end = _clock_pair(page)
+    control_page_ms = control_page_end - control_page_start
+    control_driver_ms = (control_driver_end - control_driver_start) * 1000
+    control_ratio = (
+        round(control_page_ms / control_driver_ms, 4) if control_driver_ms > 0 else None
+    )
+
+    # The completion row, and how long it took to arrive.
+    #
+    # Not a fixed sleep. The collapse animation is 200ms and `retainStreamingHeight` releases on
+    # the same timer, so 2s looks like plenty -- and at 90,000 characters on WebKit it was not:
+    # the run reported 15,099 reasoning spans still mounted 2s after the group had already gone
+    # to `open=False`, and the harness failed itself for a collapse that had merely not finished
+    # yet. Unmounting ~16,000 nodes is itself a main-thread job that scales with the content, and
+    # how long it takes is one of the numbers worth having: the trace's own worst event loop lag,
+    # 576ms, is at completion.
+    collapse_started = time.monotonic()
+    try:
+        page.wait_for_function(
+            """() => document.querySelectorAll(".aui-reasoning-text pre code span").length === 0""",
+            timeout = COLLAPSE_TIMEOUT_MS,
+        )
+        collapse_ms = round((time.monotonic() - collapse_started) * 1000)
+    except Exception:
+        collapse_ms = None
+    after = page.evaluate("""() => window.__reasoningPane.sample()""")
+
+    # The quiet is not the collapse. The spans can already be at zero while React is still
+    # committing and the teardown is still on the thread, so this waits for the settle watch's
+    # own verdict, on the same budget the collapse gets.
+    settle_left = max(0, COLLAPSE_TIMEOUT_MS - round((time.monotonic() - collapse_started) * 1000))
+    try:
+        page.wait_for_function(
+            """() => window.__rpSettle && window.__rpSettle.settledAtMs !== null""",
+            timeout = max(1000, settle_left),
+        )
+    except Exception:
+        pass
+    settle = page.evaluate("""() => {
+      const s = window.__rpSettle;
+      if (!s) return null;
+      return {
+        settled_ms: s.settledAtMs,
+        started: s.doneAt !== null,
+        window_ms: s.windowMs,
+        busy_pct: s.busyPct,
+        consecutive: s.consecutive,
+        windows: s.windows.slice(0, 40),
+      };
+    }""")
+
+    page.evaluate("""() => window.__rpStopSampler && window.__rpStopSampler()""")
+    rows = page.evaluate("""() => window.__rpRows""")
+    state = page.evaluate("""() => window.__reasoningPane.streamState()""")
+    long_task_supported = page.evaluate("""() => window.__rp.longTaskSupported""")
+    rss.stop()
+
+    for row in rows:
+        row["rss_mb"] = rss.at(row["t_ms"])
+
+    # Completed sampler windows per wall second. A DIAGNOSTIC, not the control: see CONTROL
+    # above. It is printed next to the control because the two together separate "the page's
+    # second is not a second" from "the page's second is fine and the page is merely late".
+    windows_per_wall_s = (
+        round(len(rows) / (control_driver_ms / 1000), 3) if control_driver_ms > 0 else None
+    )
+
+    page.close()
+    return {
+        "engine": engine,
+        "size": size,
+        "throttle": throttle,
+        "finished": finished,
+        "rows": rows,
+        "after": after,
+        "collapse_ms": collapse_ms,
+        "settle": settle,
+        "time_to_settle_ms": (settle or {}).get("settled_ms"),
+        "rss_samples": [
+            {"t_ms": round(t), "rss_mb": v} for t, v in rss.samples
+        ],
+        "rss_growth_mb": rss.growth_mb(),
+        "rss_unavailable": rss.reason,
+        "control_page_ms": round(control_page_ms),
+        "control_driver_ms": round(control_driver_ms),
+        "control_ratio": control_ratio,
+        "windows_per_wall_s": windows_per_wall_s,
+        "state": state,
+        "long_task_supported": long_task_supported,
+        "errors": errors,
+    }
+
+
+def ladder_for(engine: str) -> list[float]:
+    """The throttle rates this engine will be run at.
+
+    The ladder is CDP, so it exists on Chromium and nowhere else. A non-Chromium engine under
+    SMOKE_RP_CPU_LADDER gets one arm at SMOKE_RP_CPU_THROTTLE and a printed line saying so,
+    rather than three identical arms that would read as "throttling changes nothing here".
+    """
+    if not CPU_LADDER:
+        return [CPU_THROTTLE]
+    if engine != "chromium":
+        info(
+            f"{engine}: SMOKE_RP_CPU_LADDER is CHROMIUM ONLY (CDP "
+            f"Emulation.setCPUThrottlingRate). Running one arm at {CPU_THROTTLE:g}x instead."
+        )
+        return [CPU_THROTTLE]
+    return CPU_LADDER
+
+
+def run() -> dict:
+    results: dict[str, dict] = {}
+    with sync_playwright() as p:
+        for engine in ENGINES:
+            launcher = getattr(p, engine, None)
+            if launcher is None:
+                info(f"{engine}: no such engine, skipped")
+                continue
+            kwargs: dict = {"headless": HEADLESS}
+            if engine == "chromium":
+                kwargs["args"] = chromium_launch_args()
+            before = (
+                {p.pid for p in psutil.Process(os.getpid()).children(recursive = True)}
+                if psutil is not None
+                else set()
+            )
+            try:
+                browser = launcher.launch(**kwargs)
+            except Exception as exc:
+                info(f"{engine}: launch failed ({exc}), skipped")
+                continue
+            rss_roots = _new_descendants(os.getpid(), before)
+            if psutil is None:
+                info("psutil is not installed: RSS will be reported as not measured, not as 0")
+            elif not rss_roots:
+                info(
+                    f"{engine}: the browser process could not be identified, so RSS is NOT "
+                    "measured on this engine and is reported as null rather than as 0"
+                )
+            else:
+                info(
+                    f"{engine}: RSS over pid(s) "
+                    f"{', '.join(str(p.pid) for p in rss_roots)} and their children"
+                )
+            context = browser.new_context()
+            context.add_init_script(RECORDER_INIT)
+            if INSTRUMENT:
+                context.add_init_script(INSTRUMENT_INIT)
+            rates = ladder_for(engine)
+            cells: dict[str, dict] = {}
+            for size in SIZES:
+                for rate in rates:
+                    key = str(size) if len(rates) == 1 and not CPU_LADDER else f"{size}@{rate:g}x"
+                    info(f"{engine} @ {size:,} reasoning chars, cpu throttle {rate:g}x")
+                    try:
+                        cells[key] = measure_cell(
+                            context,
+                            engine,
+                            size,
+                            throttle = rate,
+                            rss_roots = rss_roots,
+                        )
+                    except Exception as exc:
+                        info(f"{engine} @ {key}: {type(exc).__name__}: {exc}")
+                        cells[key] = {
+                            "engine": engine,
+                            "size": size,
+                            "throttle": rate,
+                            "error": str(exc),
+                        }
+            results[engine] = cells
+            context.close()
+            browser.close()
+    return results
+
+
+def print_run(cell: dict) -> None:
+    rows = cell.get("rows") or []
+    if not rows:
+        info(f"  {cell['engine']} @ {cell['size']}: no samples")
+        return
+    instrumented = any(r.get("instr") for r in rows)
+    head = (
+        f"{'t(s)':>6} {'busy%':>6} {'fps':>7} {'p50fr':>6} {'p95fr':>7} {'>33fr':>6} "
+        f"{'>33%':>6} {'maxLag':>8} "
+        f"{'arr/s':>6} {'sent':>8} {'chars':>8} {'spans':>8} {'paneEl':>8} "
+        f"{'allEl':>9} {'outside':>8} {'heapMB':>7} {'rssMB':>8} {'smpl(ms)':>9}"
+    )
+    if instrumented:
+        head += f" {'shReads':>9} {'shMs':>8} {'paneRd':>8} {'paneMs':>8} {'moCB':>7}"
+    print(head, flush = True)
+    for r in rows:
+        # Dash, not -1 and not 0: an unmeasured RSS must not be readable as a number.
+        rss_cell = "-" if r.get("rss_mb") is None else f"{r['rss_mb']:,.1f}"
+        line = (
+            f"{r['t_ms'] / 1000:6.1f} {r.get('busy_pct', -1):6.1f} {r['fps']:7.1f} "
+            f"{(r['p50_frame_ms'] if r['p50_frame_ms'] is not None else -1):6.1f} "
+            f"{(r['p95_frame_ms'] if r['p95_frame_ms'] is not None else -1):7.1f} "
+            f"{r.get('frames_over_33', -1):6,d} "
+            f"{(r['frames_over_33_pct'] if r.get('frames_over_33_pct') is not None else -1):6.1f} "
+            f"{r['max_lag_ms']:8.1f} "
+            f"{r.get('arrivals_in_window', -1) * 1000 / max(1, SAMPLE_MS):6.1f} "
+            f"{r['sent_chars']:8,d} "
+            f"{r['reasoning_chars']:8,d} {r['reasoning_spans']:8,d} "
+            f"{r.get('reasoning_elements', -1):8,d} "
+            f"{r['elements']:9,d} {r.get('outside_reasoning', -1):8,d} "
+            f"{(r['heap_mb'] if r.get('heap_mb') is not None else -1):7,d} "
+            f"{rss_cell:>8} "
+            f"{r['sample_ms']:9.2f}"
+        )
+        i = r.get("instr")
+        if instrumented and i:
+            line += (
+                f" {i['scrollHeightReads']:9,d} {i['scrollHeightMs']:8.1f} "
+                f"{i['reasoningReads']:8,d} {i['reasoningMs']:8.1f} "
+                f"{i['mutationCallbacks']:7,d}"
+            )
+        print(line, flush = True)
+    a = cell["after"]
+    c = cell.get("collapse_ms")
+    print(
+        f"  collapse took {c}ms"
+        if c is not None
+        else "  collapse did NOT complete within the timeout",
+        flush = True,
+    )
+    settled = cell.get("time_to_settle_ms")
+    settle = cell.get("settle") or {}
+    if settled is not None:
+        print(
+            f"  time to settle {settled}ms after the stream finished "
+            f"({settle.get('consecutive')} consecutive {settle.get('window_ms')}ms windows under "
+            f"{settle.get('busy_pct')}% blocked)",
+            flush = True,
+        )
+    else:
+        print(
+            f"  time to settle NOT MEASURED: the page never showed "
+            f"{settle.get('consecutive', 2)} consecutive {settle.get('window_ms', 250)}ms "
+            f"windows under {settle.get('busy_pct', 10)}% blocked within the "
+            f"{COLLAPSE_TIMEOUT_MS}ms collapse budget, so it is reported as null and not as a "
+            "number",
+            flush = True,
+        )
+    if cell.get("rss_unavailable"):
+        print(
+            f"  RSS NOT MEASURED on this engine ({cell['rss_unavailable']}); the rssMB column is "
+            "blank and rss_growth_mb is null, never 0",
+            flush = True,
+        )
+    else:
+        peak_rss = max(
+            (s["rss_mb"] for s in cell.get("rss_samples", []) if s["rss_mb"] is not None),
+            default = None,
+        )
+        first_rss = next(
+            (s["rss_mb"] for s in cell.get("rss_samples", []) if s["rss_mb"] is not None),
+            None,
+        )
+        print(
+            f"  browser tree RSS {first_rss:,.1f}MB -> peak {peak_rss:,.1f}MB "
+            f"(+{cell.get('rss_growth_mb')}MB over the run), summed over the browser process and "
+            "its renderers",
+            flush = True,
+        )
+    if cell.get("control_ratio") is not None:
+        print(
+            f"  CONTROL page wall clock / driver wall clock = {cell['control_ratio']:.4f} "
+            f"({cell['control_page_ms']:,}ms page vs {cell['control_driver_ms']:,}ms driver); "
+            f"diagnostic: {cell.get('windows_per_wall_s')} sampler windows per wall second",
+            flush = True,
+        )
+    print(
+        f"  after completion: chars {a['reasoningChars']:,} spans "
+        f"{a['reasoningCodeSpans']:,} elements {a['totalElements']:,} "
+        f"open={a['reasoningOpen']}",
+        flush = True,
+    )
+
+
+def summarise(cell: dict) -> dict:
+    """First tenth of the run against the last tenth, on the same run.
+
+    Not first sample against last sample: a single sample is one second of a loaded machine. Not
+    across sizes either, because the trace is a curve WITHIN one generation, and reproducing it
+    means showing the same run getting slower as its own content grows.
+    """
+    # The FIRST sample is dropped, always. It spans the click that starts the run, the runtime's
+    # first publish and the first Shiki highlighter load, none of which are the growth this file
+    # is about; keeping it reported a 229ms "stall" at 485 characters of content and made the
+    # early window look worse than the late one.
+    rows = [r for r in (cell.get("rows") or []) if not r.get("stream_done")][1:]
+    if len(rows) < 6:
+        return {}
+    n = max(2, len(rows) // 10)
+    early = rows[:n]
+    late = rows[-n:]
+
+    # None on an empty list, not a crash. A window in which the page produced NO frames at all
+    # has a null p95, and headless Chromium really does produce runs of them: the rAF loop does
+    # not tick before the first composite, so a slow vite start leaves the first few samples
+    # frameless. Averaging over "the frames there were" then averages over nothing. Before this
+    # guard that was a ZeroDivisionError three samples into a ladder arm, i.e. the whole run lost
+    # to an arithmetic edge rather than to anything measured.
+    def mean(xs: list[float]) -> float | None:
+        return sum(xs) / len(xs) if xs else None
+
+    def rnd(value: float | None, places: int) -> float | None:
+        return None if value is None else round(value, places)
+
+    early_fps = mean([r["fps"] for r in early])
+    late_fps = mean([r["fps"] for r in late])
+    early_busy = mean([r.get("busy_pct", 0) for r in early])
+    late_busy = mean([r.get("busy_pct", 0) for r in late])
+    early_p95 = mean([r["p95_frame_ms"] for r in early if r["p95_frame_ms"] is not None])
+    late_p95 = mean([r["p95_frame_ms"] for r in late if r["p95_frame_ms"] is not None])
+    early_over33 = mean([r.get("frames_over_33", 0) for r in early]) or 0
+    late_over33 = mean([r.get("frames_over_33", 0) for r in late]) or 0
+    early_over33_pct = mean(
+        [r["frames_over_33_pct"] for r in early if r.get("frames_over_33_pct") is not None]
+    )
+    late_over33_pct = mean(
+        [r["frames_over_33_pct"] for r in late if r.get("frames_over_33_pct") is not None]
+    )
+    # Reported, not silently averaged away. A frameless sample is not a slow one, and an early
+    # window built out of them understates the baseline this file's whole ratio is taken against.
+    frameless_early = sum(1 for r in early if r["p95_frame_ms"] is None)
+    frameless_late = sum(1 for r in late if r["p95_frame_ms"] is None)
+    rss_values = [r["rss_mb"] for r in rows if r.get("rss_mb") is not None]
+    peak = max(r["reasoning_spans"] for r in rows)
+    peak_chars = max(r["reasoning_chars"] for r in rows)
+    peak_elements = max(r["elements"] for r in rows)
+    return {
+        "label": LABEL,
+        "throttle": cell.get("throttle", CPU_THROTTLE),
+        "early_fps": rnd(early_fps, 1),
+        "early_frames_over_33": round(early_over33, 1),
+        "late_frames_over_33": round(late_over33, 1),
+        "frames_over_33_ratio": (
+            round(late_over33 / early_over33, 2) if early_over33 else None
+        ),
+        "early_frames_over_33_pct": rnd(early_over33_pct, 1),
+        "late_frames_over_33_pct": rnd(late_over33_pct, 1),
+        "frameless_early_samples": frameless_early,
+        "frameless_late_samples": frameless_late,
+        "first_rss_mb": rss_values[0] if rss_values else None,
+        "peak_rss_mb": max(rss_values) if rss_values else None,
+        "rss_growth_mb": cell.get("rss_growth_mb"),
+        "rss_unavailable": cell.get("rss_unavailable"),
+        "time_to_settle_ms": cell.get("time_to_settle_ms"),
+        "control_ratio": cell.get("control_ratio"),
+        "windows_per_wall_s": cell.get("windows_per_wall_s"),
+        "late_fps": rnd(late_fps, 1),
+        "fps_ratio": round(early_fps / late_fps, 2) if early_fps and late_fps else None,
+        "early_busy_pct": rnd(early_busy, 1),
+        "late_busy_pct": rnd(late_busy, 1),
+        "busy_ratio": round(late_busy / early_busy, 2) if early_busy and late_busy else None,
+        "early_p95_frame_ms": rnd(early_p95, 1),
+        "late_p95_frame_ms": rnd(late_p95, 1),
+        "p95_ratio": round(late_p95 / early_p95, 2) if early_p95 and late_p95 else None,
+        "early_max_lag_ms": round(max(r["max_lag_ms"] for r in early), 1),
+        "late_max_lag_ms": round(max(r["max_lag_ms"] for r in late), 1),
+        "peak_chars": peak_chars,
+        "peak_spans": peak,
+        "peak_elements": peak_elements,
+        "chars_per_span": round(peak_chars / peak, 2) if peak else None,
+        "after_spans": cell["after"]["reasoningCodeSpans"],
+        "after_elements": cell["after"]["totalElements"],
+        "collapsed": cell["after"]["reasoningCodeSpans"] == 0,
+        "collapse_ms": cell.get("collapse_ms"),
+        "peak_heap_mb": max((r["heap_mb"] for r in rows if r["heap_mb"] is not None), default = None),
+        "final_heap_mb": cell["rows"][-1]["heap_mb"] if cell.get("rows") else None,
+    }
+
+
+def _mb(value: float | None) -> str:
+    """`not measured`, never `0MB`. A missing reading and an empty one must not read alike."""
+    return "not measured" if value is None else f"{value:,.1f}MB"
+
+
+def _ms(value: float | None) -> str:
+    return "not measured" if value is None else f"{value:,.0f}ms"
+
+
+def print_ladder(results: dict) -> None:
+    """The ladder, one row per throttle rate, with the control beside the measurements.
+
+    The point of printing them together is that they are read together. A ladder where busy%
+    climbs and the control climbs with it is not a ladder that found anything: it is a ladder
+    whose seconds are not seconds.
+    """
+    if not CPU_LADDER:
+        return
+    print("\n=== CPU THROTTLING LADDER (CHROMIUM ONLY: CDP Emulation.setCPUThrottlingRate) ===",
+          flush = True)
+    for engine, cells in results.items():
+        arms = [c for c in cells.values() if "error" not in c]
+        if not arms:
+            continue
+        if engine != "chromium":
+            print(
+                f"  [{LABEL}] {engine}: no CPU throttling exists on this engine, so it has no "
+                "ladder. The rows below are Chromium's alone.",
+                flush = True,
+            )
+            continue
+        by_size: dict[int, list[dict]] = {}
+        for cell in arms:
+            by_size.setdefault(cell["size"], []).append(cell)
+        for size, group in by_size.items():
+            group = sorted(group, key = lambda c: c.get("throttle", 1))
+            print(f"  [{LABEL}] chromium @ {size:,} reasoning chars", flush = True)
+            print(
+                f"    {'rate':>6} {'busy%':>7} {'fps':>7} {'>33fr/win':>10} {'rssMB':>9} "
+                f"{'growthMB':>9} {'settle(ms)':>11} {'CONTROL':>9} {'win/s':>7}",
+                flush = True,
+            )
+            for cell in group:
+                s = summarise(cell) or {}
+                # A dash where there is no reading. -1 in a memory column has been read as a
+                # number before now.
+                peak_rss = s.get("peak_rss_mb")
+                growth = cell.get("rss_growth_mb")
+                settle = cell.get("time_to_settle_ms")
+                control = cell.get("control_ratio")
+                busy = s.get("late_busy_pct")
+                fps = s.get("late_fps")
+                over33 = s.get("late_frames_over_33")
+                print(
+                    f"    {cell.get('throttle', 1):5g}x "
+                    f"{('-' if busy is None else f'{busy:.1f}'):>7} "
+                    f"{('-' if fps is None else f'{fps:.1f}'):>7} "
+                    f"{('-' if over33 is None else f'{over33:.1f}'):>10} "
+                    f"{('-' if peak_rss is None else f'{peak_rss:,.1f}'):>9} "
+                    f"{('-' if growth is None else f'{growth:,.1f}'):>9} "
+                    f"{('-' if settle is None else f'{settle:,.0f}'):>11} "
+                    f"{('-' if control is None else f'{control:.4f}'):>9} "
+                    f"{(cell.get('windows_per_wall_s') or -1):7.3f}",
+                    flush = True,
+                )
+            controls = [
+                c["control_ratio"] for c in group if c.get("control_ratio") is not None
+            ]
+            if len(controls) < 2:
+                continue
+            spread_pct = (max(controls) - min(controls)) / min(controls) * 100
+            if spread_pct > CONTROL_TOLERANCE_PCT:
+                # Loud on purpose. This is not a slow page, it is a broken measurement: the
+                # control is a wall-clock ratio and the CPU throttle cannot touch it. If it moved,
+                # the page's own timebase moved, and every per-second column above was divided by
+                # a second that did not last a second.
+                print(
+                    f"    !!!! [{LABEL}] CONTROL MOVED {spread_pct:.1f}% ACROSS THE LADDER "
+                    f"({min(controls):.4f} .. {max(controls):.4f}, tolerance "
+                    f"{CONTROL_TOLERANCE_PCT:g}%). THE MEASUREMENT IS WRONG, NOT THE PAGE SLOW: "
+                    "the page wall clock and the driver wall clock disagree, so fps, busy%, "
+                    "arr/s and frames over 33ms on this ladder are all divided by a fictional "
+                    "second and none of the arms are comparable.",
+                    flush = True,
+                )
+            else:
+                print(
+                    f"    control flat within {spread_pct:.1f}% across the ladder (tolerance "
+                    f"{CONTROL_TOLERANCE_PCT:g}%), so the per-second columns above are on the "
+                    "same second at every rate",
+                    flush = True,
+                )
+
+
+def harness_failures(results: dict) -> list[str]:
+    """Only the ways this file could be measuring nothing. Timings never fail a run."""
+    bad: list[str] = []
+    if not results:
+        bad.append("no engine produced a cell")
+    for engine, cells in results.items():
+        for key, cell in cells.items():
+            where = f"{engine} @ {key}"
+            if "error" in cell:
+                bad.append(f"{where}: {cell['error']}")
+                continue
+            if not cell.get("finished"):
+                bad.append(f"{where}: the stream never finished")
+            rows = cell.get("rows") or []
+            if len(rows) < 5:
+                bad.append(f"{where}: {len(rows)} samples, too few to be a curve")
+                continue
+            if not any(r["open"] for r in rows):
+                bad.append(f"{where}: the reasoning group never opened, so nothing was measured")
+            peak = max(r["reasoning_spans"] for r in rows)
+            size = cell["size"]
+            # What the fixture owes, always: it sent the content it was asked for. This is the
+            # check that catches a fixture that quietly built 90,000 characters of prose, and it
+            # holds whatever the renderer under test then does with them.
+            sent = cell.get("state", {}).get("sentChars") or 0
+            if sent < size * 0.99:
+                bad.append(f"{where}: the fixture only sent {sent:,} of {size:,} characters")
+            if max(r["reasoning_chars"] for r in rows) <= 0:
+                bad.append(f"{where}: the reasoning pane never held any text")
+            # And, on an unmodified tree, that the content really did become highlight spans. At
+            # the capture's own size the floor is most of its 16,000; below that, scaled. Turn it
+            # off with SMOKE_RP_EXPECT_SPANS=0 when measuring a change whose whole purpose is to
+            # stop building them.
+            floor = int(11_000 * size / 90_000)
+            if EXPECT_SPANS and peak < floor:
+                bad.append(
+                    f"{where}: peak {peak:,} reasoning spans is below the floor {floor:,}; "
+                    "either the fixture is not the capture's content, or the tree under test "
+                    "stopped building spans and this run wanted SMOKE_RP_EXPECT_SPANS=0"
+                )
+            peak_chars = max(r["reasoning_chars"] for r in rows)
+            if MAX_PANE_CHARS and peak_chars > MAX_PANE_CHARS:
+                bad.append(
+                    f"{where}: the pane peaked at {peak_chars:,} mounted characters against a "
+                    f"bound of {MAX_PANE_CHARS:,} over {size:,} sent; the window did not bound "
+                    "what stayed mounted, so this run measured an unwindowed tree"
+                )
+            after = cell["after"]
+            if after["reasoningCodeSpans"] != 0:
+                bad.append(
+                    f"{where}: {after['reasoningCodeSpans']:,} reasoning spans survived "
+                    f"completion after {COLLAPSE_TIMEOUT_MS}ms; the collapse that localises the "
+                    "cost did not happen"
+                )
+            real_errors = [e for e in cell.get("errors", []) if "ResizeObserver" not in e]
+            if real_errors:
+                bad.append(f"{where}: page error {real_errors[0]}")
+    return bad
+
+
+def main() -> int:
+    vite = None
+    try:
+        if OWNS_SERVER:
+            info(f"starting vite dev server on port {PORT}")
+            vite = start_vite(PORT)
+            wait_for_smoke_page(
+                f"{BASE}/smoke-reasoning-pane.html",
+                "smoke-reasoning-pane-main.tsx",
+                proc = vite,
+            )
+        # The label leads the header, and it is on every summary line below as well. Several
+        # worktrees run this same file against different trees on the same box, and a table
+        # pasted into a comparison with no arm on it is a table nobody can place afterwards.
+        info(
+            f"label={LABEL} engines={','.join(ENGINES)} sizes={SIZES} fence={FENCE_CHARS} "
+            f"prose={PROSE_CHARS} "
+            f"chunk={CHUNK_CHARS} gap={GAP_MS}ms sample={SAMPLE_MS}ms "
+            f"instrument={'on' if INSTRUMENT else 'off'} "
+            f"headless={'on' if HEADLESS else 'OFF (real compositor)'} "
+            f"cpu_throttle={CPU_THROTTLE}x "
+            f"cpu_ladder={','.join(f'{r:g}' for r in CPU_LADDER) if CPU_LADDER else 'off'}"
+            f"{' (CHROMIUM ONLY)' if CPU_LADDER else ''} "
+            f"rss={'psutil' if psutil is not None else 'NOT MEASURED (psutil missing)'}"
+        )
+        results = run()
+    finally:
+        if vite is not None:
+            stop_process(vite)
+            info("vite stopped")
+
+    report: dict[str, dict] = {}
+    for engine, cells in results.items():
+        for key, cell in cells.items():
+            if "error" in cell:
+                continue
+            print(
+                f"\n=== [{LABEL}] {engine} @ {cell['size']:,} reasoning chars, "
+                f"cpu throttle {cell.get('throttle', CPU_THROTTLE):g}x ===",
+                flush = True,
+            )
+            if not cell.get("long_task_supported"):
+                print(
+                    "  longtask is NOT supported on this engine: the long-task columns are "
+                    "structurally zero and mean nothing. Read max lag.",
+                    flush = True,
+                )
+            print_run(cell)
+            s = summarise(cell)
+            report[f"{engine}@{key}"] = s
+            if s:
+                # Every summary line carries the label and the throttle rate. Same reason as the
+                # header: these lines get quoted on their own.
+                print(
+                    f"  [{LABEL}] {engine} {cell['size']:,}ch {s['throttle']:g}x: "
+                    f"main thread busy {s['early_busy_pct']}% -> {s['late_busy_pct']}% "
+                    f"({s['busy_ratio']}x), "
+                    f"early fps {s['early_fps']} -> late fps {s['late_fps']} "
+                    f"({s['fps_ratio']}x slower), p95 frame {s['early_p95_frame_ms']}ms -> "
+                    f"{s['late_p95_frame_ms']}ms ({s['p95_ratio']}x), "
+                    f"max lag {s['early_max_lag_ms']}ms -> "
+                    f"{s['late_max_lag_ms']}ms, peak {s['peak_spans']:,} spans over "
+                    f"{s['peak_chars']:,} chars ({s['chars_per_span']} chars/span), "
+                    f"elements {s['peak_elements']:,} -> {s['after_elements']:,}",
+                    flush = True,
+                )
+                print(
+                    f"  [{LABEL}] {engine} {cell['size']:,}ch {s['throttle']:g}x: "
+                    f"frames over 33ms {s['early_frames_over_33']}/window "
+                    f"({s['early_frames_over_33_pct']}%) -> {s['late_frames_over_33']}/window "
+                    f"({s['late_frames_over_33_pct']}%), "
+                    f"rss {_mb(s['first_rss_mb'])} -> peak {_mb(s['peak_rss_mb'])} "
+                    f"(growth {_mb(s['rss_growth_mb'])}), "
+                    f"time to settle {_ms(s['time_to_settle_ms'])}, "
+                    f"control {s['control_ratio']}, "
+                    f"frameless samples {s['frameless_early_samples']} early / "
+                    f"{s['frameless_late_samples']} late",
+                    flush = True,
+                )
+
+    print_ladder(results)
+
+    payload = {
+        "label": LABEL,
+        "sizes": SIZES,
+        "engines": ENGINES,
+        "fence_chars": FENCE_CHARS,
+        "prose_chars": PROSE_CHARS,
+        "chunk_chars": CHUNK_CHARS,
+        "gap_ms": GAP_MS,
+        "sample_ms": SAMPLE_MS,
+        "instrumented": INSTRUMENT,
+        "expect_spans": EXPECT_SPANS,
+        "max_pane_chars": MAX_PANE_CHARS,
+        "headless": HEADLESS,
+        "cpu_throttle": CPU_THROTTLE,
+        "cpu_ladder": CPU_LADDER,
+        "control_tolerance_pct": CONTROL_TOLERANCE_PCT,
+        "rss_backend": "psutil" if psutil is not None else None,
+        "trace": TRACE,
+        "results": results,
+        "report": report,
+    }
+    out = OUT / f"reasoning-pane-{LABEL}.json"
+    out.write_text(json.dumps(payload, indent = 2), encoding = "utf-8")
+    info(f"wrote {out}")
+
+    bad = harness_failures(results)
+    if bad:
+        print("\nHARNESS FAILURES", flush = True)
+        for b in bad:
+            print(f"  - {b}", flush = True)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/studio/test_playwright_suites_run_in_ci.py
+++ b/tests/studio/test_playwright_suites_run_in_ci.py
@@ -40,6 +40,14 @@ NOT_IN_CI = {
     # can go wrong silently, the verdict in harness_failures, is driven without a
     # browser by test_autoscroll_harness_contract.py, which CI does run.
     "playwright_thread_weight.py",
+    # The same shape as the one above, for the streaming reasoning pane. It is a
+    # measurement harness rather than a gate: it sets no budget, it has to stream a
+    # 90,000 character reply at the field trace's own 327 characters a second under
+    # 6x CPU throttling for its numbers to mean anything, and one arm of that costs
+    # ten minutes and more on a loaded runner. Run by hand when the pane's cost
+    # curve needs re-measuring. What it can get silently wrong is the same thing:
+    # its verdict, which it reports through harness_failures and a non-zero exit.
+    "playwright_reasoning_pane.py",
 }
 
 


### PR DESCRIPTION
> **DRAFT, and the performance numbers below are RETRACTED pending a retake. Do not merge.**
>
> Two things turned up after this was opened, both from running the harness against a PRODUCTION bundle instead of the vite dev server.
>
> 1. **This branch kills the renderer on a production build.** 90,000 characters, 6x throttle, paired and concurrent with a control, two trials: the control exited 0 both times, this branch was killed by its 2,400 second timeout both times, and both of its drivers died with `write EPIPE` from `PipeTransport.send` with zero page errors, zero console errors and zero unhandled rejections. The browser end of the pipe goes away and nothing in JavaScript says why. 2 of 2 against 0 of 2.
>
>    The mechanism is present in the code by construction and is not in doubt even where the crash is: when the renderer re-segments the document behind the live edge, `reportContent` calls `invalidate()`, which sets the window start to 0 and remounts the whole document, about 10,000 blocks and 15,000 elements in a single commit, waking every one of those subscribers. It runs synchronously from inside a React effect.
>
> 2. **The symptom this PR targets does not reproduce on a production bundle.** Same fixture, same throttle, control only: late frame rate 53.4 and 51.0 on production against 9.0 on the dev server; late frames over 33ms 7.2% and 15.4% against over 95%; RSS growth +428 MB and +294 MB against +1,182 MB. Peak pane elements are the same to within 0.4%, 15,181 against 15,126.
>
>    35 to 41% of late self time on the dev server is `jsxDEV` and the other development-only React paths, which a shipped Studio never runs, and that cost is proportional to elements created per frame, which is exactly the quantity the arms differ in. So it did not scale the numbers, it manufactured the symptom and biased the ranking toward whichever arm creates fewer elements.
>
> What survives: the node-count reduction, which is real on production, and the scroll-back work below. What does not: every frame rate, main-thread-busy, p95 and frames-over-33ms figure in this body, the ceiling table, the length crossover and the mount-versus-parse split, all of which were dev-server measurements and have to be retaken.

The streaming reasoning ("thinking") pane holds the whole reasoning body while a model is thinking, in a 256px tall scroller. On a long generation that reaches about 15,000 mounted elements and 14,000 Shiki highlight spans, and the frame rate collapses. A field trace from Unsloth Desktop on WebKitGTK: fps 59.4 falling to 18.2 over one generation, 18,536 elements, recovering the moment the reply completes and the group closes.

This renders only a contiguous suffix of Streamdown's block list and replaces everything above it with one spacer of exactly the height those blocks had, moving the window just in time in both directions.

## What it does to the pane

Chromium, 6x CPU throttle, the fixture pinned to the field trace's own 327 characters a second.

| | control | with the block window |
| --- | --- | --- |
| peak pane elements, 90s from the first token | 10,142 | **1,838** |
| peak pane elements, full 90,000 character run | 15,138 | 107 to a few hundred, bounded by the retained band rather than by the document |

The mounted set is bounded by `RETAIN_ABOVE_PX` plus the pane height instead of by the reply length, so it stops growing.

## The ceiling, stated as prominently as the win

This is a real improvement to the reported symptom and it is not a fix for it, and the measurement that says so is in this PR's harness.

A discriminator arm that PARSES every block and MOUNTS none isolates the two costs: it pays the full parse cost and none of the mount cost, so it is the ceiling of any mount-side change. Against a control and against an arm that keeps the pane unmounted entirely, late frame rate, chromium at 6x:

| reply length | control | parse-only ceiling | pane never mounted | share of the gap that unmounting can reach |
| --- | --- | --- | --- | --- |
| 22,500 | 18.3 / 17.7 | 50.8 / 56.5 | 60.1 / 60.0 | 78% / 92% |
| 45,000 | 10.6 / 14.6 | 46.4 / 52.7 | 60.0 / 59.9 | 72% / 84% |
| 60,000 | 8.5 / 9.8 | 27.5 / 33.2 | 59.1 / 58.7 | 38% / 48% |
| 75,000 | 11.6 | 27.1 | 59.7 | 32% |
| 90,000 | 9.0 / 10.4 / 9.9 | 27.3 / 26.4 / 25.2 | 60.0 / 59.8 / 59.8 | 36% / 32% / 29% |

So the share falls from about 85% on a short reply to about a third on a long one. The 90,000 row is three paired trials and they agree within 7 points. Unmounting is most of the answer below roughly 50,000 characters and about a third of it above.

The reason is reply LENGTH, not a per-frame blow-up. The renderer's per-chunk work is priced on the whole accumulated document, so the cost of ONE FRAME is LINEAR in reply length. The total work over a reply is quadratic only because the number of chunks grows linearly as well.

What that residual actually IS was measured rather than assumed, and it is not what I first wrote here. Instrumented inside the parse-only arm at 90,000 characters, milliseconds per chunk, early against late:

| | early | late |
| --- | --- | --- |
| markdown parsing | 0.86 / 0.89 | 0.97 / 1.01 |
| Shiki tokenization | 0.00 | 0.00 |
| React over the block list | 1.98 / 2.25 | **6.42 / 6.40** |
| length-independent floor | 6.84 / 6.51 | 6.70 / 6.54 |

Markdown parsing is 0.97 ms of a 14.09 ms per-chunk residual, and the incremental markdown cache is wired into this path and WORKING: over a 90,000 character reply it commits 679 blocks and 89,383 characters, re-repairs a 353 character tail, and records zero full-document renders, zero prefix rebuilds and zero non-monotone rewrites. So the cost is not re-parsing.

It is React creating an element for every block in the list on every chunk, and it is paid even when every one of those blocks renders `null`, which is precisely what the parse-only arm does. The block components themselves are memoised and hold: about 6 block renders per chunk against 685 blocks. The cost is element creation, memo comparison and the fibre walk, at 7.6 to 10.3 microseconds per block per chunk.

A mount-side window cannot reach that, because the window decides what a block RENDERS and the element is created before it is asked. Windowing the block LIST handed to the renderer, rather than the mounting of it, removes all of the growth in a probe. That is the follow-up, not this PR.

Independent corroboration from a different measurement track, which matters because it is not this harness: on WebKit, three arms at 0.21x, 1.00x and 0.01x of the control's element count all read 1.09x late frame rate. Node count does not explain frame rate on that engine either. Two methods, one conclusion.

Node count is the claim here. **No memory claim, and no frame-rate claim resting on memory.** The retained heap during a streaming reply is a module-level unbounded `Map` in `@streamdown/code` which no unmount touches and which nothing in this repository can reach; that is #9228's, and unmounting nodes cannot return it. #9228's own jank measurement came back NULL: reclaiming 213 MB moved no frame metric. So neither nodes nor heap is the frame-rate story, and what is left is the parse side.

## Why this shape, and not the two obvious alternatives

**Not a character budget.** A window that slices the source string has to predict where the renderer considers the document divisible, and that judgement changes retroactively: a late GFM footnote definition re-segments the whole document behind content that has already been rendered. Here the window is expressed in block INDICES and the source string is never touched, so there is no slice to carry across that moment. The harness can reproduce it on demand (`footnoteAtChars`), and sampled in a `requestAnimationFrame` callback across the collapse: window engaged beforehand at a 8,418px spacer and 35 slots, the collapse observed, **zero blank frames**, and the text intact either side, 25,595 characters at the first frame after it.

The honest cost of that choice: a footnote reference makes this renderer treat the whole document as ONE block, so on a document containing one the window has no index to move to and degrades to a no-op. It renders exactly what it renders today. A character cut would not have that hole.

**Not `content-visibility: auto`.** It keeps every block mounted, so it cannot reduce the node count, and its heights are unstable while streaming: `contain-intrinsic-size: auto` only remembers a size for an element that has been laid out at least once, and a streaming block is created and skipped before it ever is. Measured on this pane it produced 35 height decreases with a median of 255px and a maximum of 963.5px inside a 256px pane. `src/index.css` already disables it here deliberately, from #8992, for that reason. Here the height that replaces a dropped block is that block's own measured offset, read from the DOM in the frame before it was dropped.

## Scroll-back, which is the whole point, and a bug found on the way

The design is `[screen-N, screen, screen+N]` moving one way and `[screen-2N, screen-N, screen]` on the way back, with `screen-N` and `screen` already mounted so only `screen-2N` is rendered. That was measured rather than asserted, with an expando stamped on every mounted slot: an expando lives on the DOM node object, so it survives a re-render of the same element and cannot survive React creating a new one.

Building that probe found a real bug in the first version of this change, and it is called out here so a reviewer who later sees a re-pin knows it was looked at. The scroll correction subtracts an anchor's position after the commit from its position before, so the anchor has to exist in both states. Moving the window forward the new start is already mounted, which holds. Moving it BACKWARD, which is exactly what a reader scrolling up causes, the new start is not mounted yet, so it fell back to the spacer and compared the spacer's position before against the newly mounted block's position after. Traced in Chromium:

```
t=47992  wheelUp   scrollTop 11289                    detached=true auto=false
t=47996  scroll    scrollTop 11049  fromBottom 240
...      five more ticks, down to scrollTop 9849, fromBottom 1440
t=49535  move      from 258 to 250  anchorTop -9841
t=49556  comp      residual 8271    -> scrollTop 9849 becomes 11273
t=49576  scroll    fromBottom 16    reattached=TRUE
t=49635+ pin, pin, pin ... for the rest of the generation
```

Scroll-back was not degraded, it was inverted, and the pane's autoscroll then owned the scroll position for the rest of the reply. The fix anchors on the higher of the two window starts, which is mounted in both states in either direction, and gates the correction on the DOM's lowest mounted index equalling the window that was decided rather than being at or past the anchor. Two unit tests cover it and each half of the fix was reverted on its own to check that each test dies with it.

With the fix, on the real streaming fixture:

| | before the fix | after | control |
| --- | --- | --- | --- |
| scroll hold, samples detached of 60 | 0 | **52** | 59 |
| minimum distance from the bottom | 0 | **5,056** | 5,804 |

and the reversal itself: the reader climbs 8,501px clear, moves forward past a boundary and back (scroll positions 7,107 to 9,523 to 7,123), 32 slots leave the window on the way forward, 44 are mounted by the reversal, the spacer moves 5,160 to 6,970 and back to 5,176, and **99 of 99 already-mounted slots keep their DOM node identity, 0 lost**. Only `screen-2N` is rendered.

## Verification

* `npm test` 3,811 of 3,812, `tsc -b` and `tsc -p tsconfig.test.json` clean, `npm run build` clean, `npx eslint` on the changed files 0 errors. The single test failure is `tests/queued-model-capabilities.test.ts`, which is red on `main` and is fixed by #9220.
* 34 unit tests over the window: the arithmetic, the controller driven a frame at a time against a fake pane, and the window against the real renderer using the three document shapes that broke the earlier attempt.
* 26 mutations applied one at a time in a throwaway worktree, 25 killed, the one survivor found and then covered.
* Layout identity is asserted rather than assumed: the `display: contents` slot is NOT free, and without the three restated spacing rules 14 of 16 elements move by 8px. Seven documents are pixel-identical with them.

## Excluded measurements

Three 90,000 character cells of this arm were killed or starved at 23, 35 and 50 minutes against a control that finishes in 11, on a box carrying four other sessions' Playwright jobs at load average 50, and a fourth at 45,000 characters went the same way. They are excluded rather than averaged away, and the matrix above was retaken at lengths that complete. Two cells of the length sweep are missing as well, so those rows carry one trial rather than two: a control at 75,000 lost its page to an error, and a control at 90,000 found its port still held by a server left behind by a cancelled run. The wall-clock cost of the window under a 6x throttle on a loaded box is a real open question and is called out here rather than buried.




