### PR TITLE
Studio: mount the model picker's On Device row tooltips and menus on first contact

### DIFF
--- a/.github/workflows/studio-model-picker-ci.yml
+++ b/.github/workflows/studio-model-picker-ci.yml
@@ -1,0 +1,106 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+#
+# The On Device rows mount their tooltips and their dots menu on FIRST CONTACT rather than up
+# front, which is invisible when it works and invisible when it breaks. The behaviour that can go
+# silently wrong is all pointer- and focus-shaped -- a tooltip that never opens because Radix
+# needed a pointermove, a Tab that drops focus to <body> because the focused element was replaced,
+# a click whose mousedown and mouseup land on two different nodes so the browser fires no click at
+# all -- so it needs a real browser, not a source-pinning test.
+#
+# Its own workflow rather than a step in studio-frontend-ci.yml: this is one short job with one
+# suite in it, and keeping it separate means a change to the picker cannot queue behind, or
+# conflict with, the frontend CI file every other surface also edits.
+
+name: Studio model picker
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'studio/frontend/src/features/model-picker/**'
+      - 'studio/frontend/smoke-model-picker-scale*'
+      - 'studio/frontend/package.json'
+      - 'studio/frontend/package-lock.json'
+      - 'tests/studio/playwright_model_picker_deferred.py'
+      - 'tests/studio/playwright_model_picker_scale.py'
+      - 'tests/studio/_playwright_robust.py'
+      - '.github/workflows/studio-model-picker-ci.yml'
+  pull_request:
+    paths:
+      - 'studio/frontend/src/features/model-picker/**'
+      - 'studio/frontend/smoke-model-picker-scale*'
+      - 'studio/frontend/package.json'
+      - 'studio/frontend/package-lock.json'
+      - 'tests/studio/playwright_model_picker_deferred.py'
+      - 'tests/studio/playwright_model_picker_scale.py'
+      - 'tests/studio/_playwright_robust.py'
+      - '.github/workflows/studio-model-picker-ci.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  # Per COMMIT on main, per ref elsewhere. A shared main group lets a merge burst cancel a pending
+  # run before it starts, with zero jobs recorded, so the workflow silently never reports on that
+  # commit; cancel-in-progress only spares runs already executing.
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
+  cancel-in-progress: true
+
+jobs:
+  picker-rows:
+    name: Model picker On Device rows
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
+        with:
+          node-version: '22'
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
+        with:
+          python-version: '3.12'
+
+      # node 22 bundles npm 10.x, which predates allowScripts; the frontend CI job upgrades for
+      # the same reason. --strict-allow-scripts then hard-fails on any unreviewed install script.
+      - name: Upgrade npm to 11.x (allowScripts enforcement)
+        run: |
+          npm install -g npm@^11 --no-fund --no-audit
+          V=$(npm -v)
+          case "$V" in
+            11.1[6-9].*|11.[2-9][0-9].*|1[2-9].*) echo "npm $V has allowScripts" ;;
+            *) echo "::error::npm $V lacks allowScripts (need >=11.16)"; exit 1 ;;
+          esac
+
+      - name: Install frontend dependencies
+        working-directory: studio/frontend
+        run: npm ci --strict-allow-scripts --no-fund --no-audit
+
+      - name: Install Chromium
+        run: |
+          python3 -m pip install 'playwright>=1.45,<2'
+          python3 -m playwright install --with-deps chromium
+
+      # The suite starts its own vite dev server on this port and stops it again; no dist/ is
+      # read, so nothing has to be built first.
+      - name: On Device rows defer their tooltips and menus, and still behave like rows
+        env:
+          SMOKE_PORT: '5563'
+          SMOKE_PICKER_MODELS: '200'
+        run: python3 tests/studio/playwright_model_picker_deferred.py
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v5.0.0
+        with:
+          name: studio-model-picker-artifacts
+          path: |
+            logs/playwright-model-picker-scale
+            logs/vite-*.log
+          if-no-files-found: ignore
+          retention-days: 7

--- a/studio/frontend/smoke-model-picker-scale-main.tsx
+++ b/studio/frontend/smoke-model-picker-scale-main.tsx
@@ -1,0 +1,303 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// Harness page for tests/studio/playwright_model_picker_scale.py: the REAL ModelSelector holding
+// a large local model list, so what is timed is the app's own picker.
+//
+// The axis is NUMBER OF MODELS the picker is handed. ModelSelector takes `models: ModelOption[]`
+// as a prop, so the fixture is a prop and not a stubbed fetch: that is the one input the picker
+// cannot get from anywhere else, and it is the one a user with a full model cache grows.
+//
+// The Hugging Face LISTING half of the picker is deliberately not in the axis. It is paged behind
+// an IntersectionObserver sentinel (pickers.tsx:4445-4490), so its row count is bounded by how
+// far the user scrolled rather than by how much they own, and sweeping it would be measuring the
+// harness's own scrolling. The DOWNLOADED half has no such bound and that is what this varies.
+//
+// Same shape as smoke-heavy-thread.html: a vite entry, no backend, no auth.
+
+// The row type the app itself parses /api/hub/cached-models into, from the feature index. Shaping
+// the fixture against a hand-written local type instead would let it drift from what the picker
+// really reads, and the drift would show up as "the picker is empty", not as a type error.
+import type { CachedModelRepo } from "@/features/hub";
+import type { ModelOption } from "@/features/model-picker";
+import { ModelSelector } from "@/features/model-picker";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { initializeLocale } from "@/i18n";
+import {
+  RouterProvider,
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+} from "@tanstack/react-router";
+import { type ReactNode, useEffect, useState } from "react";
+import { createRoot } from "react-dom/client";
+import "./src/index.css";
+
+// Deterministic and NOT Math.random(): model name length decides how much text layout a row pays
+// for, so an unseeded fixture would hand two runs different work.
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a = (a + 0x6d2b79f5) >>> 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+const ORGS = ["unsloth", "meta-llama", "Qwen", "mistralai", "google", "deepseek-ai"];
+const FAMILIES = ["Llama", "Qwen", "Mistral", "Gemma", "Phi", "DeepSeek", "Yi", "Falcon"];
+const PARAMS = ["1B", "3B", "7B", "8B", "13B", "14B", "32B", "70B"];
+const SUFFIX = ["Instruct", "Chat", "Base", "Coder", "Math", "Vision"];
+
+function buildModels(count: number): ModelOption[] {
+  const rand = mulberry32(0x9e37_79b9);
+  const out: ModelOption[] = [];
+  for (let i = 0; i < count; i += 1) {
+    const org = ORGS[Math.floor(rand() * ORGS.length)] as string;
+    const family = FAMILIES[Math.floor(rand() * FAMILIES.length)] as string;
+    const params = PARAMS[Math.floor(rand() * PARAMS.length)] as string;
+    const suffix = SUFFIX[Math.floor(rand() * SUFFIX.length)] as string;
+    // The index is in the id so the ids are unique however the random words land; two rows with
+    // the same id would be deduped by optionById and the fixture would be smaller than it says.
+    const id = `${org}/${family}-${params}-${suffix}-${i}`;
+    const isGguf = i % 3 === 0;
+    out.push({
+      id,
+      name: id,
+      description: isGguf ? "GGUF" : "safetensors",
+      isGguf,
+      deviceQuant: isGguf ? "Q4_K_M" : undefined,
+      deviceSize: `${1 + (i % 40)}.2 GB`,
+      deviceSizeBytes: (1 + (i % 40)) * 1_000_000_000,
+      deviceLoaded: false,
+    });
+  }
+  return out;
+}
+
+// An explicit allowlist, never a blanket `/api/` match: a blanket match resolves every request the
+// measured interactions make before Playwright emits it, so the stray counter stays at zero and
+// the fan-out the harness exists to detect becomes invisible to it.
+const realFetch = window.fetch.bind(window);
+const stubbedApiCalls: string[] = [];
+
+function jsonResponse(body: string): Response {
+  return new Response(body, {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+// The DOWNLOADED half of the picker is fed by the hub INVENTORY, not by the `models` prop:
+// use-device-inventory pulls /api/hub/cached-models, /api/hub/cached-gguf and /api/hub/local, and
+// the picker's own rows come from those. Seeding the prop alone opened a panel with zero rows,
+// measured. So the size axis is served here, from the same in-memory fixture.
+let cachedRepos: CachedModelRepo[] = [];
+
+const STUBBED: ReadonlyArray<readonly [RegExp, () => string]> = [
+  // Studio polls this on a timer. Left to Playwright it is a round trip to another process
+  // landing inside a timed region, once per tick.
+  // chat_only:false and a device_type matter, not just a 200. `chatOnly` defaults TRUE until
+  // /api/health answers with a verdict, and pickers.tsx:3763 reads
+  // `chatOnly && !task ? [] : visibleCachedModels` -- so a bare {"status":"ok"} empties the whole
+  // downloaded list and the On Device tab renders zero rows however many models are seeded.
+  // Measured exactly that way: 200 models in, 0 rows out.
+  [
+    /\/api\/health$/,
+    () =>
+      JSON.stringify({
+        status: "ok",
+        version: "0.0.0-smoke",
+        device_type: "nvidia",
+        chat_only: false,
+        chat_only_reason: null,
+        hardware_detecting: false,
+      }),
+  ],
+  [/\/api\/hub\/cached-models$/, () => JSON.stringify({ cached: cachedRepos })],
+  [/\/api\/hub\/cached-gguf$/, () => '{"cached":[]}'],
+  [/\/api\/hub\/local$/, () => '{"models":[],"folders":[]}'],
+  [/\/api\/hub\/datasets\//, () => '{"datasets":[],"cached":[]}'],
+  [/\/api\/hub\/scan-folders$/, () => '{"folders":[]}'],
+  [/\/api\/hub\/hidden-models$/, () => '{"hidden":[]}'],
+  [/\/api\/hub\//, () => "{}"],
+  [/\/api\/inference\//, () => "{}"],
+  [/\/api\/models\/scan-folders$/, () => '{"folders":[]}'],
+  [/\/api\/models\/recommended-folders$/, () => '{"folders":[]}'],
+  [/\/api\/models/, () => '{"models":[]}'],
+  [/\/api\/system$/, () => "{}"],
+];
+
+window.fetch = (input, init) => {
+  const url =
+    typeof input === "string" ? input : ((input as Request).url ?? String(input));
+  const path = url.split("?")[0] ?? url;
+  for (const [pattern, body] of STUBBED) {
+    if (pattern.test(path)) {
+      stubbedApiCalls.push(url);
+      return Promise.resolve(jsonResponse(body()));
+    }
+  }
+  return realFetch(input, init);
+};
+
+declare global {
+  interface Window {
+    __pickerScale: {
+      seed: (count: number) => { models: number };
+      setOpen: (open: boolean) => void;
+      isOpen: () => boolean;
+      trigger: () => HTMLElement | null;
+      panel: () => HTMLElement | null;
+      searchInput: () => HTMLInputElement | null;
+      query: () => string;
+      counts: () => Record<string, number>;
+      onDeviceTab: () => HTMLElement | null;
+      modelCount: () => number;
+      stubbedApi: () => string[];
+    };
+    __stubbedApi: string[];
+  }
+}
+
+window.__stubbedApi = stubbedApiCalls;
+
+let externalSeed: ((models: ModelOption[]) => void) | null = null;
+let externalOpen: ((open: boolean) => void) | null = null;
+let seededCount = 0;
+let openNow = false;
+
+function Harness(): ReactNode {
+  const [models, setModels] = useState<ModelOption[]>([]);
+  const [open, setOpen] = useState(false);
+  // Published from an EFFECT, not during render. Assigning a module-level binding in the render
+  // body is a side effect and `react-hooks/globals` rejects it; more to the point, a harness whose
+  // control surface is installed by rendering is one whose control surface can be reinstalled by a
+  // re-render in the middle of a measurement.
+  useEffect(() => {
+    externalSeed = setModels;
+    externalOpen = (next: boolean) => {
+      openNow = next;
+      setOpen(next);
+    };
+    return () => {
+      externalSeed = null;
+      externalOpen = null;
+    };
+  }, []);
+  return (
+    <TooltipProvider>
+      <div data-testid="harness-root" style={{ padding: 24 }}>
+        <ModelSelector
+          models={models}
+          open={open}
+          onOpenChange={(next) => {
+            openNow = next;
+            setOpen(next);
+          }}
+        />
+      </div>
+    </TooltipProvider>
+  );
+}
+
+// The picker's own panel, portaled to document.body by Radix.
+const PANEL = ".unsloth-model-selector-menu";
+const SEARCH = "[data-model-picker-search-input]";
+
+window.__pickerScale = {
+  seed: (count: number) => {
+    const models = buildModels(count);
+    seededCount = models.length;
+    // Both halves from ONE fixture: the prop the picker takes, and the inventory rows the
+    // downloaded list is really built from. Seeding only one of them produced a panel with the
+    // right model count in its props and zero rows on screen.
+    cachedRepos = models.map((model, index) => ({
+      repo_id: model.id,
+      size_bytes: (1 + (index % 40)) * 1_000_000_000,
+      cache_path: `/models/${model.id}`,
+      last_modified: 1_700_000_000 - index * 60,
+      model_format: "safetensors",
+      partial: false,
+      tags: [],
+    })) as CachedModelRepo[];
+    externalSeed?.(models);
+    return { models: seededCount };
+  },
+  setOpen: (open: boolean) => externalOpen?.(open),
+  isOpen: () => openNow,
+  trigger: () =>
+    document.querySelector<HTMLElement>(".unsloth-model-selector-trigger"),
+  panel: () => document.querySelector<HTMLElement>(PANEL),
+  searchInput: () => document.querySelector<HTMLInputElement>(SEARCH),
+  query: () => document.querySelector<HTMLInputElement>(SEARCH)?.value ?? "",
+  counts: () => {
+    const panel = document.querySelector(PANEL);
+    return {
+      // `[data-model-picker-option]` is what a row really carries. `[role="option"]` was tried
+      // first and counted ZERO against a panel holding 200 rows, which reads as "the picker
+      // rendered nothing" rather than as "wrong selector"; the attribute census that found this
+      // also showed 604 tooltip triggers and 200 dropdown triggers for those 200 rows.
+      rows: panel ? panel.querySelectorAll("[data-model-picker-option]").length : 0,
+      rowMenuTriggers: panel
+        ? panel.querySelectorAll('[data-slot="dropdown-menu-trigger"]').length
+        : 0,
+      tooltipTriggers: panel
+        ? panel.querySelectorAll('[data-slot="tooltip-trigger"]').length
+        : 0,
+      panelNodes: panel ? panel.getElementsByTagName("*").length : 0,
+      domNodes: document.getElementsByTagName("*").length,
+      searchInputs: document.querySelectorAll(SEARCH).length,
+      panelScrollHeight: (() => {
+        const scroller = panel
+          ? panel.querySelector<HTMLElement>("[data-model-picker-option]")?.parentElement
+          : null;
+        return scroller ? scroller.scrollHeight : 0;
+      })(),
+      panels: document.querySelectorAll(PANEL).length,
+    };
+  },
+  // Found by its label text once, here, rather than in the probe: the probe then drives an
+  // element rather than a string, and a locale change breaks this one line instead of the run.
+  onDeviceTab: () => {
+    const panel = document.querySelector(PANEL);
+    if (!panel) return null;
+    for (const el of Array.from(panel.querySelectorAll<HTMLElement>("button"))) {
+      if ((el.textContent || "").trim() === "On Device") return el;
+    }
+    return null;
+  },
+  modelCount: () => seededCount,
+  stubbedApi: () => [...stubbedApiCalls],
+};
+
+// The picker navigates to the hub on "Browse", so it needs a router in scope. A memory router with
+// one route keeps the harness backend-free while those hooks resolve.
+const harnessRootRoute = createRootRoute({ component: Harness });
+const harnessIndexRoute = createRoute({
+  getParentRoute: () => harnessRootRoute,
+  path: "/",
+  component: () => null,
+});
+const harnessRouter = createRouter({
+  routeTree: harnessRootRoute.addChildren([harnessIndexRoute]),
+  history: createMemoryHistory({ initialEntries: ["/"] }),
+});
+
+const rootElement = document.getElementById("root");
+if (!rootElement) throw new Error("Root element not found");
+const root = createRoot(rootElement);
+
+function render(): void {
+  // No StrictMode: it double-invokes render, which is the quantity being measured.
+  root.render(<RouterProvider router={harnessRouter} />);
+}
+
+const localeInitialization = initializeLocale();
+if (typeof localeInitialization !== "string") {
+  void localeInitialization.then(render);
+} else {
+  render();
+}

--- a/studio/frontend/smoke-model-picker-scale.html
+++ b/studio/frontend/smoke-model-picker-scale.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <script src="/crypto-boot.js"></script>
+    <title>model picker scale smoke</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/smoke-model-picker-scale-main.tsx"></script>
+  </body>
+</html>

--- a/studio/frontend/src/features/model-picker/components/model-selector/model-load-settings-action.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector/model-load-settings-action.tsx
@@ -10,6 +10,8 @@ import { cn } from "@/lib/utils";
 import { Settings02Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 
+import { useRowActive } from "./row-activation";
+
 export function ModelLoadSettingsAction({
   ariaLabel,
   onConfigure,
@@ -19,31 +21,38 @@ export function ModelLoadSettingsAction({
   onConfigure: () => void;
   className?: string;
 }) {
+  // False only inside a `ModelRowShell` no pointer or focus has reached yet. The button below is
+  // the same element either way and carries its own click handler, so the row keeps working
+  // untouched; what is deferred is the Radix tooltip around it, which cannot be showing anything
+  // on a row the pointer has never been near.
+  const rowActive = useRowActive();
+  const button = (
+    <button
+      type="button"
+      onClick={(e) => {
+        e.stopPropagation();
+        onConfigure();
+      }}
+      aria-label={ariaLabel}
+      className={cn(
+        // Fixed box, not padding around the glyph, so this and the dots
+        // menu hover as one size. Callers can still size it up.
+        "flex size-5 shrink-0 items-center justify-center rounded-md text-muted-foreground/60 transition-colors hover:bg-black/5 hover:text-foreground dark:hover:bg-white/10",
+        className,
+      )}
+    >
+      {/* A size down from the dots: the gear fills its whole box. */}
+      <HugeiconsIcon
+        icon={Settings02Icon}
+        strokeWidth={1.75}
+        className="size-3"
+      />
+    </button>
+  );
+  if (!rowActive) return button;
   return (
     <Tooltip delayDuration={0}>
-      <TooltipTrigger asChild={true}>
-        <button
-          type="button"
-          onClick={(e) => {
-            e.stopPropagation();
-            onConfigure();
-          }}
-          aria-label={ariaLabel}
-          className={cn(
-            // Fixed box, not padding around the glyph, so this and the dots
-            // menu hover as one size. Callers can still size it up.
-            "flex size-5 shrink-0 items-center justify-center rounded-md text-muted-foreground/60 transition-colors hover:bg-black/5 hover:text-foreground dark:hover:bg-white/10",
-            className,
-          )}
-        >
-          {/* A size down from the dots: the gear fills its whole box. */}
-          <HugeiconsIcon
-            icon={Settings02Icon}
-            strokeWidth={1.75}
-            className="size-3"
-          />
-        </button>
-      </TooltipTrigger>
+      <TooltipTrigger asChild={true}>{button}</TooltipTrigger>
       <TooltipContent side="top" className="tooltip-compact">
         Configure run settings before loading model
       </TooltipContent>

--- a/studio/frontend/src/features/model-picker/components/model-selector/model-row-menu.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector/model-row-menu.tsx
@@ -42,6 +42,8 @@ import {
   useState,
 } from "react";
 
+import { useRowActive } from "./row-activation";
+
 interface ModelRowMenuPin {
   pinned: boolean;
   /** Menu item labels, e.g. "Pin quant to the top" / "Unpin quant". */
@@ -84,16 +86,7 @@ interface ModelRowMenuSettings {
   onOpen: () => void;
 }
 
-export function ModelRowMenu({
-  ariaLabel,
-  buttonClassName,
-  iconClassName,
-  cachePath,
-  settings,
-  pin,
-  update,
-  del,
-}: {
+type ModelRowMenuProps = {
   ariaLabel: string;
   buttonClassName?: string;
   iconClassName?: string;
@@ -103,20 +96,75 @@ export function ModelRowMenu({
   pin?: ModelRowMenuPin;
   update?: ModelRowMenuUpdate;
   del?: ModelRowMenuDelete;
-}) {
-  const deviceType = usePlatformStore((s) => s.deviceType);
-  const revealLabel =
-    deviceType === "mac" ? "Reveal in Finder" : "Reveal in Folder";
-  const [deleteOpen, setDeleteOpen] = useState(false);
-  const [deleting, setDeleting] = useState(false);
-  const deleteImpact = useDeleteImpact(
-    deleteOpen && Boolean(del?.impact),
-    del?.impact?.repoId ?? "",
-    del?.impact?.variant,
-  );
-  const [updateOpen, setUpdateOpen] = useState(false);
+};
 
-  // Refresh the caller when this repo+variant's managed update completes.
+/** The dots button exactly as Radix renders it, for a row nothing has reached yet.
+ *
+ *  It sits under `opacity-0` until the row is hovered or focused, so there is nothing on screen to
+ *  keep in sync; what has to match is the a11y tree and the tab order, hence the same label, the
+ *  same `aria-haspopup` / `aria-expanded` / `data-state` a closed Radix trigger carries, and a real
+ *  focusable <button> in the same slot. */
+function ModelRowMenuPlaceholder({
+  ariaLabel,
+  buttonClassName,
+  iconClassName,
+  onActivate,
+}: {
+  ariaLabel: string;
+  buttonClassName?: string;
+  iconClassName?: string;
+  onActivate: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      aria-haspopup="menu"
+      aria-expanded={false}
+      data-state="closed"
+      data-slot="dropdown-menu-trigger"
+      onPointerDown={(e) => {
+        e.stopPropagation();
+        onActivate();
+      }}
+      onClick={(e) => {
+        e.stopPropagation();
+        onActivate();
+      }}
+      aria-label={ariaLabel}
+      className={cn(
+        "flex size-5 shrink-0 items-center justify-center rounded-md text-muted-foreground/60 transition-colors hover:bg-black/5 hover:text-foreground dark:hover:bg-white/10",
+        buttonClassName,
+      )}
+    >
+      <HugeiconsIcon
+        icon={MoreVerticalIcon}
+        strokeWidth={1.75}
+        className={cn("size-3.5", iconClassName)}
+      />
+    </button>
+  );
+}
+
+/**
+ * The row's dots menu, mounted only once something has reached the row.
+ *
+ * A menu that is closed shows nothing, and on an On Device row the trigger itself is invisible
+ * until `group-hover` / `focus-within` lifts it, yet the merge base paid for a Radix root, a
+ * portal, a Presence state machine, two AlertDialogs and a platform-store subscription for every
+ * cached repo the user owns. `useRowActive()` is false only inside a `ModelRowShell` that no
+ * pointer or focus has reached; everywhere else (the Hub catalog, and any row outside a shell) it
+ * is true and this renders exactly what it always did.
+ */
+export function ModelRowMenu(props: ModelRowMenuProps) {
+  const { ariaLabel, buttonClassName, iconClassName, pin, update, cachePath, settings, del } =
+    props;
+  const rowActive = useRowActive();
+  const [open, setOpen] = useState(false);
+  const [activated, setActivated] = useState(false);
+
+  // Kept in the shell, not in the body: this is how a row learns that a managed update it started
+  // has finished, and a subscription that only exists while the menu is mounted would miss the
+  // completion of the very download it kicked off.
   const onUpdatedRef = useRef(update?.onUpdated);
   useEffect(() => {
     onUpdatedRef.current = update?.onUpdated;
@@ -134,6 +182,63 @@ export function ModelRowMenu({
       },
     });
   }, [updateRepoId, updateVariant]);
+
+  if (!pin && !update && !del && !cachePath && !settings) return null;
+
+  if (!rowActive && !activated) {
+    return (
+      <ModelRowMenuPlaceholder
+        ariaLabel={ariaLabel}
+        buttonClassName={buttonClassName}
+        iconClassName={iconClassName}
+        onActivate={() => {
+          // A press that lands on the placeholder is a press that wanted the menu: Radix's own
+          // trigger opens on pointerdown, so open on mount rather than swallowing the gesture.
+          setActivated(true);
+          setOpen(true);
+        }}
+      />
+    );
+  }
+
+  return (
+    <ModelRowMenuLive
+      {...props}
+      open={open}
+      onOpenChange={setOpen}
+      onUpdatedRef={onUpdatedRef}
+    />
+  );
+}
+
+function ModelRowMenuLive({
+  ariaLabel,
+  buttonClassName,
+  iconClassName,
+  cachePath,
+  settings,
+  pin,
+  update,
+  del,
+  open,
+  onOpenChange,
+}: ModelRowMenuProps & {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Owned by the shell so the update subscription outlives this component. */
+  onUpdatedRef: { current: (() => void) | undefined };
+}) {
+  const deviceType = usePlatformStore((s) => s.deviceType);
+  const revealLabel =
+    deviceType === "mac" ? "Reveal in Finder" : "Reveal in Folder";
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const deleteImpact = useDeleteImpact(
+    deleteOpen && Boolean(del?.impact),
+    del?.impact?.repoId ?? "",
+    del?.impact?.variant,
+  );
+  const [updateOpen, setUpdateOpen] = useState(false);
 
   const onDeleteConfirm = del?.onConfirm;
   const onDeleted = del?.onDeleted;
@@ -180,11 +285,9 @@ export function ModelRowMenu({
     });
   }, [cachePathRepoId, cachePathVariant]);
 
-  if (!pin && !update && !del && !cachePath && !settings) return null;
-
   return (
     <>
-      <DropdownMenu>
+      <DropdownMenu open={open} onOpenChange={onOpenChange}>
         <DropdownMenuTrigger asChild={true}>
           <button
             type="button"

--- a/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
@@ -144,6 +144,7 @@ import { curatedArtifactIsOfferable } from "./host-artifact-policy";
 import { ModelDeleteAction } from "./model-delete-action";
 import { ModelLoadSettingsAction } from "./model-load-settings-action";
 import { ModelRowMenu } from "./model-row-menu";
+import { ModelRowShell, useRowActive } from "./row-activation";
 import {
   type ModelLoadTimes,
   loadedAt,
@@ -281,21 +282,34 @@ function useRovingModelList({
   const listboxId = `model-picker-${rawListboxId.replace(/:/g, "")}`;
   const [rovingOptionKey, setRovingOptionKey] = useState<string | null>(null);
 
+  // One pass instead of one `indexOf` per row. Every row calls `getOptionProps` while it renders,
+  // and each of those was a linear scan of the whole key list, so a list of N rows cost O(N^2)
+  // string comparisons to draw -- 1000 downloaded models is half a million of them per render.
+  // First occurrence wins, exactly as `indexOf` resolved a duplicated key.
+  const optionIndexByKey = useMemo(() => {
+    const byKey = new Map<string, number>();
+    for (let index = 0; index < optionKeys.length; index += 1) {
+      const key = optionKeys[index];
+      if (key !== undefined && !byKey.has(key)) byKey.set(key, index);
+    }
+    return byKey;
+  }, [optionKeys]);
+
   const preferredOptionKey =
-    selectedOptionKey && optionKeys.includes(selectedOptionKey)
+    selectedOptionKey && optionIndexByKey.has(selectedOptionKey)
       ? selectedOptionKey
       : (optionKeys[0] ?? null);
   const activeOptionKey =
-    rovingOptionKey && optionKeys.includes(rovingOptionKey)
+    rovingOptionKey && optionIndexByKey.has(rovingOptionKey)
       ? rovingOptionKey
       : preferredOptionKey;
 
   const getOptionDomId = useCallback(
     (optionKey: string) => {
-      const index = optionKeys.indexOf(optionKey);
-      return index === -1 ? undefined : `${listboxId}-option-${index}`;
+      const index = optionIndexByKey.get(optionKey);
+      return index === undefined ? undefined : `${listboxId}-option-${index}`;
     },
-    [listboxId, optionKeys],
+    [listboxId, optionIndexByKey],
   );
 
   const focusOption = useCallback(
@@ -538,22 +552,55 @@ function CapabilityIcons({ caps }: { caps: ModelCapabilities }) {
   );
 }
 
+/**
+ * A row's tooltip, mounted only once the row has been reached.
+ *
+ * A closed tooltip draws nothing, so a row the pointer has never been near does not need one; what
+ * it needs is the trigger element itself, which is rendered either way. `useRowActive()` is false
+ * only inside a `ModelRowShell` (the On Device lists) that no pointer or focus has touched -- every
+ * other list in the app reads the context default and mounts the tooltip immediately, as before.
+ */
+function RowTooltip({
+  children,
+  content,
+  side,
+  className,
+  delayDuration,
+}: {
+  children: ReactNode;
+  content: ReactNode;
+  side?: "top" | "bottom" | "left" | "right";
+  className?: string;
+  delayDuration?: number;
+}) {
+  const rowActive = useRowActive();
+  if (!rowActive) return children;
+  return (
+    <Tooltip delayDuration={delayDuration}>
+      <TooltipTrigger asChild={true}>{children}</TooltipTrigger>
+      <TooltipContent side={side} className={className}>
+        {content}
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
 /** "This model reads images", from the GGUF metadata (On Device rows). */
 function VisionBadge() {
   return (
-    <Tooltip delayDuration={0}>
-      <TooltipTrigger asChild={true}>
-        <span
-          aria-label="Vision"
-          className="flex h-[18px] shrink-0 items-center justify-center rounded-md border border-border/60 px-1.5 text-indigo-700 dark:text-indigo-300"
-        >
-          <HugeiconsIcon icon={ViewIcon} className="size-3" strokeWidth={1.8} />
-        </span>
-      </TooltipTrigger>
-      <TooltipContent side="top" className="tooltip-compact">
-        This model can process image inputs
-      </TooltipContent>
-    </Tooltip>
+    <RowTooltip
+      delayDuration={0}
+      side="top"
+      className="tooltip-compact"
+      content="This model can process image inputs"
+    >
+      <span
+        aria-label="Vision"
+        className="flex h-[18px] shrink-0 items-center justify-center rounded-md border border-border/60 px-1.5 text-indigo-700 dark:text-indigo-300"
+      >
+        <HugeiconsIcon icon={ViewIcon} className="size-3" strokeWidth={1.8} />
+      </span>
+    </RowTooltip>
   );
 }
 
@@ -578,23 +625,23 @@ const FORMAT_TONE_DOT: Record<FormatTone, string> = {
  *  "Safetensors" is wide enough to shove the rest of the row around. */
 function FormatTag({ tone, label }: { tone: FormatTone; label: string }) {
   return (
-    <Tooltip delayDuration={0}>
-      <TooltipTrigger asChild={true}>
-        {/* Hit area, so hovering the dot is not a pixel hunt. */}
+    <RowTooltip
+      delayDuration={0}
+      side="top"
+      className="tooltip-compact"
+      content={label}
+    >
+      {/* Hit area, so hovering the dot is not a pixel hunt. */}
+      <span
+        aria-label={label}
+        className="flex size-[14px] shrink-0 items-center justify-center"
+      >
         <span
-          aria-label={label}
-          className="flex size-[14px] shrink-0 items-center justify-center"
-        >
-          <span
-            aria-hidden="true"
-            className={cn("size-[5px] rounded-full", FORMAT_TONE_DOT[tone])}
-          />
-        </span>
-      </TooltipTrigger>
-      <TooltipContent side="top" className="tooltip-compact">
-        {label}
-      </TooltipContent>
-    </Tooltip>
+          aria-hidden="true"
+          className={cn("size-[5px] rounded-full", FORMAT_TONE_DOT[tone])}
+        />
+      </span>
+    </RowTooltip>
   );
 }
 
@@ -864,6 +911,7 @@ function ModelRow({
   const paramLabel = parsed.param ?? extractParamLabel(name) ?? null;
   // Use the passed-in capabilities (tag-aware) or infer from the repo name.
   const caps = capabilities ?? detectCapabilities({ id: label });
+  const rowActive = useRowActive();
   const capabilityScope = useContext(CapabilityScope);
   const capabilityBadges = visibleCapabilityBadges(caps, capabilityScope);
   const showCaps = capabilityBadges.length > 0;
@@ -1041,6 +1089,13 @@ function ModelRow({
       </span>
     </button>
   );
+
+  // Nothing below this line is on screen until the row is hovered or focused, and building it is
+  // the bulk of what a row costs: the tooltip body, the Radix root, its portal and its Presence.
+  // A row inside a `ModelRowShell` that has not been reached yet stops here.
+  if (!rowActive) {
+    return content;
+  }
 
   // Optional Hugging Face address line for online/Hub rows, rendered under
   // whichever tooltip shows so the repo id / URL is always visible on hover.
@@ -4693,7 +4748,10 @@ export function HubModelPicker({
       !ggufVariantsMatchForPicker(activeGgufVariant, null) &&
       ggufVariantsMatchForPicker(activeGgufVariant, entry.quant);
     return (
-      <div key={optionKey} className={downloadedRowShellClassName(isSelected)}>
+      <ModelRowShell
+        key={optionKey}
+        className={downloadedRowShellClassName(isSelected)}
+      >
         {/* Through ModelRow, so a pinned quant lands in the same columns as
             the rows below it. */}
         <div className="min-w-0 flex-1">
@@ -4781,7 +4839,7 @@ export function HubModelPicker({
             }}
           />
         </span>
-      </div>
+      </ModelRowShell>
     );
   };
 
@@ -4817,7 +4875,10 @@ export function HubModelPicker({
       pipelineTag: c.task ?? null,
     };
     return (
-      <div key={c.repo_id} className={downloadedRowShellClassName(isSelected)}>
+      <ModelRowShell
+        key={c.repo_id}
+        className={downloadedRowShellClassName(isSelected)}
+      >
         <div className="min-w-0 flex-1">
           <ModelRow
             label={c.repo_id}
@@ -4883,7 +4944,7 @@ export function HubModelPicker({
             }}
           />
         </span>
-      </div>
+      </ModelRowShell>
     );
   };
 
@@ -4902,7 +4963,7 @@ export function HubModelPicker({
     });
     return (
       <div key={c.repo_id}>
-        <div className={downloadedRowShellClassName(isSelected)}>
+        <ModelRowShell className={downloadedRowShellClassName(isSelected)}>
           <div className="min-w-0 flex-1">
             <ModelRow
               label={c.repo_id}
@@ -4930,7 +4991,7 @@ export function HubModelPicker({
           </div>
           {/* Stands in for the other rows' buttons, so the tags line up. */}
           <span aria-hidden="true" className={cn(ROW_ACTIONS_CLASS, "h-6")} />
-        </div>
+        </ModelRowShell>
         {expanderOpen && (
           <GgufVariantExpander
             repoId={c.repo_id}
@@ -4976,7 +5037,10 @@ export function HubModelPicker({
     const optionKey = makeModelOptionKey("downloaded-model", c.repo_id);
     const isSelected = value === c.repo_id;
     return (
-      <div key={c.repo_id} className={downloadedRowShellClassName(isSelected)}>
+      <ModelRowShell
+        key={c.repo_id}
+        className={downloadedRowShellClassName(isSelected)}
+      >
         <div className="min-w-0 flex-1">
           <ModelRow
             label={c.repo_id}
@@ -5060,7 +5124,7 @@ export function HubModelPicker({
             }}
           />
         </span>
-      </div>
+      </ModelRowShell>
     );
   };
 
@@ -5072,7 +5136,10 @@ export function HubModelPicker({
     // show the name and drop the Hub link -- the raw path reads as neither.
     const isLocalPath = /^(?:[a-zA-Z]:[\\/]|[\\/]|~)/.test(model.id);
     return (
-      <div key={model.id} className={downloadedRowShellClassName(isSelected)}>
+      <ModelRowShell
+        key={model.id}
+        className={downloadedRowShellClassName(isSelected)}
+      >
         <div className="min-w-0 flex-1">
           <ModelRow
             label={isLocalPath ? model.name : model.id}
@@ -5105,7 +5172,7 @@ export function HubModelPicker({
           />
         </div>
         <span aria-hidden="true" className={cn(ROW_ACTIONS_CLASS, "h-6")} />
-      </div>
+      </ModelRowShell>
     );
   };
 

--- a/studio/frontend/src/features/model-picker/components/model-selector/row-activation.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector/row-activation.tsx
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// Per-row activation for the On Device list.
+//
+// The list renders every cached repo, and each row carried three Radix tooltips and a Radix
+// dropdown whether or not the pointer was anywhere near it. None of those four are VISIBLE until
+// the row is hovered or focused -- a tooltip has nothing on screen while it is closed, and the row
+// action buttons sit under `opacity-0` until `group-hover` / `focus-within` -- so mounting them for
+// a thousand rows buys nothing and costs a Radix Root, a Presence state machine and a portal each.
+//
+// A row wrapped in `ModelRowShell` therefore starts INACTIVE: it renders the same markup with the
+// tooltip wrappers left off and the action buttons replaced by identical, focusable placeholders.
+// The first pointer or focus that reaches the row switches it to ACTIVE, which mounts exactly what
+// the merge base always had. Everything outside such a shell reads the context default, `true`, so
+// no other list in the app changes at all.
+//
+// Two things have to survive the swap, and both are replayed in a layout effect so nothing paints
+// in between:
+//   1. FOCUS. Activating replaces the focused element (a placeholder, or the row button itself once
+//      its tooltip wrapper appears), which would otherwise drop focus to <body> mid-Tab.
+//   2. HOVER. Radix's tooltip trigger opens on `pointermove`, not on `pointerenter`. A pointer that
+//      enters a row and then holds still fires no further move, so the freshly mounted trigger
+//      would never learn the pointer is on it and the tooltip would never open. One synthetic
+//      `pointermove` at the recorded position, only if that position is still inside this row,
+//      hands it the event it missed.
+//
+// Coarse-pointer devices opt out entirely (`active` starts true). They show the row actions at all
+// times (`[@media(hover:none)]:opacity-100`), a tap is a pointerdown and a click on the SAME node,
+// and Radix's tap-to-pin tooltip behaviour has no hover to fall back on -- so the safe answer there
+// is to change nothing.
+
+import { createContext, useCallback, useContext, useLayoutEffect, useRef, useState } from "react";
+import type { PointerEvent as ReactPointerEvent, ReactNode } from "react";
+
+/** True = mount everything, which is what every row outside a shell does. */
+const RowActiveContext = createContext(true);
+
+/** Whether this row has been reached by a pointer or by focus yet. */
+export function useRowActive(): boolean {
+  return useContext(RowActiveContext);
+}
+
+/** Hover is what the deferral trades on, so a device without it keeps the merge base's tree. */
+function pointerIsCoarse(): boolean {
+  if (typeof window === "undefined" || typeof window.matchMedia !== "function") return false;
+  try {
+    return (
+      window.matchMedia("(hover: none)").matches ||
+      window.matchMedia("(pointer: coarse)").matches
+    );
+  } catch {
+    // A matchMedia that throws on an unsupported query (older WebViews) must not take the list
+    // with it; erring towards "not coarse" only costs the deferral, never correctness.
+    return false;
+  }
+}
+
+/** Child index chain from `root` down to `node`, so the same slot can be found again after the
+ *  subtree is rebuilt. The two trees are structurally identical -- `asChild` triggers add no
+ *  elements, and the placeholders are the same tags in the same order -- so the path still lands
+ *  on the element that had focus. */
+function childIndexPath(root: Element, node: Element): number[] | null {
+  const path: number[] = [];
+  let current: Element | null = node;
+  while (current && current !== root) {
+    const parent: Element | null = current.parentElement;
+    if (!parent) return null;
+    path.push(Array.prototype.indexOf.call(parent.children, current));
+    current = parent;
+  }
+  return current === root ? path.reverse() : null;
+}
+
+function elementAtPath(root: Element, path: number[]): HTMLElement | null {
+  let current: Element | undefined = root;
+  for (const index of path) {
+    current = current?.children[index];
+    if (!current) return null;
+  }
+  return current instanceof HTMLElement ? current : null;
+}
+
+type PendingReplay = {
+  focusPath: number[] | null;
+  pointer: { x: number; y: number } | null;
+};
+
+export function ModelRowShell({
+  className,
+  children,
+}: {
+  className?: string;
+  children: ReactNode;
+}) {
+  const shellRef = useRef<HTMLDivElement | null>(null);
+  // Read once per row and kept in state: a media query evaluated in the render body would be a new
+  // answer on every render, and the point of this flag is that it never changes under the row.
+  const [active, setActive] = useState(pointerIsCoarse);
+  // The state flip is async from the handler's point of view, so `active` is not readable there.
+  const activeRef = useRef(active);
+  const pending = useRef<PendingReplay | null>(null);
+
+  const activate = useCallback((pointer: { x: number; y: number } | null) => {
+    if (activeRef.current) return;
+    activeRef.current = true;
+    const shell = shellRef.current;
+    const focused = document.activeElement;
+    pending.current = {
+      focusPath:
+        shell && focused instanceof HTMLElement && focused !== shell && shell.contains(focused)
+          ? childIndexPath(shell, focused)
+          : null,
+      pointer,
+    };
+    setActive(true);
+  }, []);
+
+  const onPointerEnter = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      // A touch "enter" is the first half of a tap: swapping the subtree under the finger would
+      // move the click's target out from under it. Those devices are opted out above anyway; this
+      // is the belt for a hybrid whose primary pointer is a mouse.
+      if (event.pointerType === "touch") return;
+      activate({ x: event.clientX, y: event.clientY });
+    },
+    [activate],
+  );
+
+  const onFocusCapture = useCallback(() => {
+    activate(null);
+  }, [activate]);
+
+  useLayoutEffect(() => {
+    const replay = pending.current;
+    pending.current = null;
+    const shell = shellRef.current;
+    if (!active || !replay || !shell) return;
+    if (replay.focusPath) {
+      const target = elementAtPath(shell, replay.focusPath);
+      // Only when focus actually fell out of the row: a browser that kept it (or a user who moved
+      // it on already) must not be yanked back.
+      if (target && !shell.contains(document.activeElement)) {
+        target.focus({ preventScroll: true });
+      }
+    }
+    if (replay.pointer) {
+      const under = document.elementFromPoint(replay.pointer.x, replay.pointer.y);
+      // Stale coordinates are worse than no replay: if the pointer has already left this row, the
+      // event would announce a hover that is not happening.
+      if (under && shell.contains(under)) {
+        under.dispatchEvent(
+          new PointerEvent("pointermove", {
+            bubbles: true,
+            cancelable: true,
+            composed: true,
+            clientX: replay.pointer.x,
+            clientY: replay.pointer.y,
+            pointerType: "mouse",
+          }),
+        );
+      }
+    }
+  }, [active]);
+
+  return (
+    <div
+      ref={shellRef}
+      className={className}
+      onPointerEnter={onPointerEnter}
+      onFocusCapture={onFocusCapture}
+    >
+      <RowActiveContext.Provider value={active}>{children}</RowActiveContext.Provider>
+    </div>
+  );
+}

--- a/studio/frontend/src/features/model-picker/components/model-selector/row-activation.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector/row-activation.tsx
@@ -144,7 +144,9 @@ export function ModelRowShell({
         target.focus({ preventScroll: true });
       }
     }
-    if (replay.pointer) {
+    // No constructible PointerEvent (an old WebView) only costs the replay: the row is mounted
+    // either way and the next real move opens the tooltip.
+    if (replay.pointer && typeof PointerEvent === "function") {
       const under = document.elementFromPoint(replay.pointer.x, replay.pointer.y);
       // Stale coordinates are worse than no replay: if the pointer has already left this row, the
       // event would announce a hover that is not happening.

--- a/studio/frontend/src/features/model-picker/components/model-selector/row-activation.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector/row-activation.tsx
@@ -100,21 +100,56 @@ export function ModelRowShell({
   // The state flip is async from the handler's point of view, so `active` is not readable there.
   const activeRef = useRef(active);
   const pending = useRef<PendingReplay | null>(null);
+  // A press is in progress in this row, so the swap has to wait: see `applyPending`.
+  const pressed = useRef(false);
+  const frame = useRef(0);
 
-  const activate = useCallback((pointer: { x: number; y: number } | null) => {
-    if (activeRef.current) return;
+  const applyPending = useCallback(() => {
+    if (activeRef.current || !pending.current || pressed.current) return;
     activeRef.current = true;
-    const shell = shellRef.current;
-    const focused = document.activeElement;
-    pending.current = {
-      focusPath:
-        shell && focused instanceof HTMLElement && focused !== shell && shell.contains(focused)
-          ? childIndexPath(shell, focused)
-          : null,
-      pointer,
-    };
     setActive(true);
   }, []);
+
+  /**
+   * Record what has to be replayed, then hand the swap to the next frame.
+   *
+   * NOT immediately, and this is the whole reason this function is shaped like this. A click is
+   * one gesture -- move, down, up -- and the browser fires the click on the nearest common
+   * ancestor of the down and up targets. Activating replaces the row's button, so a swap that
+   * lands between the down and the up leaves those on two different elements and NO click is
+   * fired at all: the row silently fails to select. Measured on the smoke harness with a single
+   * `mouse.click`, which is exactly that gesture with nothing in between: the merge base selected
+   * the model and closed the panel, an eagerly swapping build did neither.
+   *
+   * `flushSync` looks like the fix and is not: `pointerenter` can be dispatched while React is
+   * already committing (the DOM moving under a still pointer is enough), and React then refuses
+   * the flush, logs, and schedules the update anyway -- so the race is still there, now with a
+   * console error. A frame is late enough to be outside the current event and early enough that
+   * nothing can be seen; if a press arrives first, the swap waits for its click.
+   */
+  const armActivation = useCallback(
+    (pointer: { x: number; y: number } | null) => {
+      if (activeRef.current || pending.current) return;
+      const shell = shellRef.current;
+      const focused = document.activeElement;
+      pending.current = {
+        focusPath:
+          shell && focused instanceof HTMLElement && focused !== shell && shell.contains(focused)
+            ? childIndexPath(shell, focused)
+            : null,
+        pointer,
+      };
+      if (pointer === null) {
+        // Focus is not a two-part gesture: a keyboard user who tabs in has already arrived, and
+        // waiting a frame would let a Tab straight through the row leave it inert.
+        applyPending();
+        return;
+      }
+      cancelAnimationFrame(frame.current);
+      frame.current = requestAnimationFrame(applyPending);
+    },
+    [applyPending],
+  );
 
   const onPointerEnter = useCallback(
     (event: ReactPointerEvent<HTMLDivElement>) => {
@@ -122,14 +157,42 @@ export function ModelRowShell({
       // move the click's target out from under it. Those devices are opted out above anyway; this
       // is the belt for a hybrid whose primary pointer is a mouse.
       if (event.pointerType === "touch") return;
-      activate({ x: event.clientX, y: event.clientY });
+      armActivation({ x: event.clientX, y: event.clientY });
     },
-    [activate],
+    [armActivation],
   );
 
+  // Capture, because the row's own action buttons stop propagation: a bubbling listener would
+  // never learn that the dots button had been pressed.
+  const onPointerDownCapture = useCallback(() => {
+    pressed.current = true;
+  }, []);
+
+  // On the NEXT frame, not from inside this handler. React collects a click's listener path once,
+  // at the start of the dispatch, and skips the ones whose instance has been unmounted by the time
+  // it gets to them -- so a swap applied in the capture phase silently eats the row button's own
+  // onClick in the bubble phase. Measured: the click landed on the row (capture saw it, the DOM
+  // swap was recorded after it) and the model was still not selected. Deferring to a frame puts
+  // the swap outside the whole dispatch.
+  const onClickCapture = useCallback(() => {
+    pressed.current = false;
+    cancelAnimationFrame(frame.current);
+    frame.current = requestAnimationFrame(applyPending);
+  }, [applyPending]);
+
+  // A press that leaves the row will not produce a click here, so release the hold: the click the
+  // browser does fire lands on a common ancestor outside this row either way.
+  const onPointerLeave = useCallback(() => {
+    pressed.current = false;
+    cancelAnimationFrame(frame.current);
+    frame.current = requestAnimationFrame(applyPending);
+  }, [applyPending]);
+
   const onFocusCapture = useCallback(() => {
-    activate(null);
-  }, [activate]);
+    armActivation(null);
+  }, [armActivation]);
+
+  useLayoutEffect(() => () => cancelAnimationFrame(frame.current), []);
 
   useLayoutEffect(() => {
     const replay = pending.current;
@@ -170,6 +233,9 @@ export function ModelRowShell({
       ref={shellRef}
       className={className}
       onPointerEnter={onPointerEnter}
+      onPointerDownCapture={onPointerDownCapture}
+      onClickCapture={onClickCapture}
+      onPointerLeave={onPointerLeave}
       onFocusCapture={onFocusCapture}
     >
       <RowActiveContext.Provider value={active}>{children}</RowActiveContext.Provider>

--- a/studio/frontend/tests/model-picker-row-activation.test.ts
+++ b/studio/frontend/tests/model-picker-row-activation.test.ts
@@ -129,6 +129,43 @@ test("activation replays the pointer move Radix needs, and only inside the row",
   assert.match(activation, /useLayoutEffect\(/);
 });
 
+test("a pointer arms the swap for the NEXT frame, never for this event", () => {
+  // A click is move, down, up, and the browser fires the click on the nearest common ancestor of
+  // the down and up targets. Swapping the row's button between them means no click is fired at
+  // all and the row silently fails to select -- measured against the merge base with a single
+  // `mouse.click`, which is that gesture with nothing in between.
+  const shell = block(activation, "export function ModelRowShell({");
+  assert.match(shell, /frame\.current = requestAnimationFrame\(applyPending\)/);
+  assert.doesNotMatch(
+    block(shell, "const onPointerEnter = useCallback(", "  );"),
+    /applyPending\(\)/,
+  );
+});
+
+test("a press in the row holds the swap until its click has been delivered", () => {
+  // The hold is what makes the frame safe: a frame boundary can fall between the down and the up.
+  const shell = block(activation, "export function ModelRowShell({");
+  assert.match(shell, /if \(activeRef\.current \|\| !pending\.current \|\| pressed\.current\) return;/);
+  assert.match(shell, /const onPointerDownCapture = useCallback\(\(\) => \{\s*\n\s*pressed\.current = true;/);
+});
+
+test("the click handler schedules the swap instead of performing it", () => {
+  // React collects a click's listener path once, at the start of the dispatch, and skips listeners
+  // whose instance has been unmounted by the time it reaches them. A swap applied from the capture
+  // phase therefore eats the row button's own onClick in the bubble phase: measured, the click
+  // landed on the row and the model was still not selected.
+  const onClick = block(activation, "const onClickCapture = useCallback(() => {", "  }, [");
+  assert.match(onClick, /requestAnimationFrame\(applyPending\)/);
+  assert.doesNotMatch(onClick, /^\s*applyPending\(\);$/m);
+});
+
+test("focus activates the row immediately, without waiting for a frame", () => {
+  // Focus is not a two-part gesture, and a Tab that passes straight through a row must not leave
+  // it inert behind the cursor.
+  const shell = block(activation, "export function ModelRowShell({");
+  assert.match(shell, /if \(pointer === null\) \{[\s\S]*?applyPending\(\);\s*\n\s*return;\s*\n\s*\}/);
+});
+
 test("coarse-pointer devices are opted out entirely", () => {
   // They show the row actions at all times and a tap is a pointerdown and a click on the same
   // node, so there is no hover to trade on and nothing to gain by swapping a subtree under a

--- a/studio/frontend/tests/model-picker-row-activation.test.ts
+++ b/studio/frontend/tests/model-picker-row-activation.test.ts
@@ -134,10 +134,25 @@ test("a pointer arms the swap for the NEXT frame, never for this event", () => {
   // the down and up targets. Swapping the row's button between them means no click is fired at
   // all and the row silently fails to select -- measured against the merge base with a single
   // `mouse.click`, which is that gesture with nothing in between.
-  const shell = block(activation, "export function ModelRowShell({");
-  assert.match(shell, /frame\.current = requestAnimationFrame\(applyPending\)/);
+  //
+  // Scoped to armActivation and counted, not matched loosely against the whole component: a
+  // `requestAnimationFrame(applyPending)` ANYWHERE in the file satisfies a loose match, and the
+  // click handler and the leave handler both contain one. Written that way this assertion stayed
+  // green against a mutant that made the pointer path apply the swap immediately, which is the
+  // whole failure it exists to catch.
+  const arm = block(activation, "const armActivation = useCallback(", "\n  );");
+  assert.equal(
+    (arm.match(/requestAnimationFrame\(applyPending\)/g) ?? []).length,
+    1,
+    "armActivation must hand the pointer swap to exactly one frame",
+  );
+  assert.equal(
+    (arm.match(/\bapplyPending\(\)/g) ?? []).length,
+    1,
+    "the only direct applyPending() in armActivation is the focus branch below",
+  );
   assert.doesNotMatch(
-    block(shell, "const onPointerEnter = useCallback(", "  );"),
+    block(activation, "const onPointerEnter = useCallback(", "\n  );"),
     /applyPending\(\)/,
   );
 });

--- a/studio/frontend/tests/model-picker-row-activation.test.ts
+++ b/studio/frontend/tests/model-picker-row-activation.test.ts
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// The On Device list renders every cached repo, and every row used to mount three Radix tooltips
+// and a Radix dropdown whether or not anything had ever pointed at it. At 1000 downloaded models
+// that was 3004 tooltip triggers and 1000 dropdown roots, and opening the picker took 5.9 s.
+//
+// The fix is invisible in the rendered output: the DOM node count is identical either way (5234
+// panel nodes at 200 models on both sides, measured), only how much React and Radix machinery hangs
+// off it differs. So, like thread-delete-render-budget.test.ts, the wiring is pinned at the source.
+// Every seam below is silently load-bearing: undo any one of them and the picker still looks and
+// behaves correctly in a hand test, and the list is slow again -- or, worse, it is fast and it has
+// quietly stopped being keyboard reachable.
+//
+// The behaviour these seams produce is asserted for real, in a browser, by
+// tests/studio/playwright_model_picker_deferred.py.
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+function source(path: string): string {
+  return readFileSync(new URL(`../src/${path}`, import.meta.url), "utf8");
+}
+
+const SELECTOR = "features/model-picker/components/model-selector";
+const pickers = source(`${SELECTOR}/pickers.tsx`);
+const activation = source(`${SELECTOR}/row-activation.tsx`);
+const rowMenu = source(`${SELECTOR}/model-row-menu.tsx`);
+const settingsAction = source(`${SELECTOR}/model-load-settings-action.tsx`);
+
+// A declaration's body ends at the first `}` in column 0. Splitting on a bare "\n}" would stop at
+// the closing brace of a destructured parameter list instead, which reads as "the seam is gone".
+function block(text: string, start: string, end = "\n}\n"): string {
+  const [, rest] = text.split(start, 2);
+  assert.ok(rest !== undefined, `the source no longer contains ${start}`);
+  const [body] = (rest ?? "").split(end, 1);
+  return body ?? "";
+}
+
+test("option ids are looked up through a map, not scanned per row", () => {
+  // getOptionProps runs once per ROW while the list renders, so an indexOf inside it is a linear
+  // scan of the whole key list per row: O(N^2) string comparisons to draw N rows, half a million
+  // of them at 1000 downloaded models.
+  const roving = block(pickers, "function useRovingModelList(");
+  assert.match(roving, /const optionIndexByKey = useMemo\(/);
+  assert.match(roving, /const index = optionIndexByKey\.get\(optionKey\)/);
+  const getOptionDomId = block(roving, "const getOptionDomId = useCallback(", "  );");
+  assert.doesNotMatch(getOptionDomId, /optionKeys\.indexOf/);
+});
+
+test("the map keeps the first occurrence of a duplicated key, as indexOf did", () => {
+  // Map.set would otherwise leave the LAST index behind and silently move a duplicated row's DOM
+  // id, which is what the roving list focuses by.
+  const roving = block(pickers, "function useRovingModelList(");
+  assert.match(roving, /if \(key !== undefined && !byKey\.has\(key\)\) byKey\.set\(key, index\)/);
+});
+
+test("an On Device row stops before its tooltip when nothing has reached it", () => {
+  // This early return is the win: the tooltip body, the Radix root, its portal and its Presence
+  // state machine are all built after this point, and none of them is on screen for a row the
+  // pointer has never been near.
+  assert.match(pickers, /const rowActive = useRowActive\(\);/);
+  assert.match(pickers, /if \(!rowActive\) \{\s*\n\s*return content;\s*\n\s*\}/);
+});
+
+test("every On Device row shell is a ModelRowShell", () => {
+  // The shell is what turns activation on. A row rendered through a bare <div> keeps the merge
+  // base's cost, so the count is pinned rather than the existence.
+  const shells = pickers.match(/<ModelRowShell[\s>]/g) ?? [];
+  assert.equal(shells.length, 5, `expected 5 On Device row shells, found ${shells.length}`);
+  assert.doesNotMatch(pickers, /<div[^>]*className=\{downloadedRowShellClassName\(/);
+});
+
+test("a row that has not been reached still renders a real, labelled dots button", () => {
+  // Same tag, same label, same aria a closed Radix trigger carries: the tab order and the
+  // accessibility tree have to be identical, because they are the two things a screen reader and a
+  // keyboard user can see that a screenshot cannot.
+  const placeholder = block(rowMenu, "function ModelRowMenuPlaceholder(");
+  assert.match(placeholder, /aria-haspopup="menu"/);
+  assert.match(placeholder, /aria-expanded=\{false\}/);
+  assert.match(placeholder, /data-state="closed"/);
+  assert.match(placeholder, /data-slot="dropdown-menu-trigger"/);
+  assert.match(placeholder, /aria-label=\{ariaLabel\}/);
+});
+
+test("pressing the placeholder opens the menu instead of swallowing the press", () => {
+  // Radix's own trigger opens on pointerdown. A placeholder that only mounted the real menu would
+  // eat the gesture that asked for it.
+  const shell = block(rowMenu, "export function ModelRowMenu(props: ModelRowMenuProps) {");
+  assert.match(shell, /setActivated\(true\);\s*\n\s*setOpen\(true\);/);
+  assert.match(rowMenu, /<DropdownMenu open=\{open\} onOpenChange=\{onOpenChange\}>/);
+});
+
+test("the update-completion subscription outlives the menu", () => {
+  // It is how a row learns that a managed update it started has finished. Moved into the lazily
+  // mounted body it would be gone by the time the download it kicked off completes.
+  const shell = block(rowMenu, "export function ModelRowMenu(props: ModelRowMenuProps) {");
+  assert.match(shell, /subscribeJobListeners\("model", updateRepoId/);
+  const live = block(rowMenu, "function ModelRowMenuLive({");
+  assert.doesNotMatch(live, /subscribeJobListeners/);
+});
+
+test("the gear keeps its own click handler while its tooltip is deferred", () => {
+  // The button is the same element either way; only the tooltip around it waits. A gear that
+  // needed activating to be clickable would break the first click on a cold row.
+  assert.match(settingsAction, /const rowActive = useRowActive\(\);/);
+  assert.match(settingsAction, /if \(!rowActive\) return button;/);
+  const button = block(settingsAction, "const button = (", "  );");
+  assert.match(button, /onClick=\{\(e\) => \{/);
+  assert.match(button, /onConfigure\(\);/);
+});
+
+test("activation replays the focus it moves", () => {
+  // Activating replaces the element that has focus. Without this, a Tab into the list drops focus
+  // to <body> and the list stops being keyboard reachable -- silently, and only for real users.
+  assert.match(activation, /childIndexPath\(shell, focused\)/);
+  assert.match(activation, /target\.focus\(\{ preventScroll: true \}\)/);
+  assert.match(activation, /!shell\.contains\(document\.activeElement\)/);
+});
+
+test("activation replays the pointer move Radix needs, and only inside the row", () => {
+  // Radix opens a tooltip on pointermove, not on pointerenter, so a pointer that enters a row and
+  // holds still would never open anything. Replaying at a point that has since left the row would
+  // announce a hover that is not happening, so the containment check is part of the seam.
+  assert.match(activation, /new PointerEvent\("pointermove"/);
+  assert.match(activation, /pointerType: "mouse"/);
+  assert.match(activation, /if \(under && shell\.contains\(under\)\)/);
+  assert.match(activation, /useLayoutEffect\(/);
+});
+
+test("coarse-pointer devices are opted out entirely", () => {
+  // They show the row actions at all times and a tap is a pointerdown and a click on the same
+  // node, so there is no hover to trade on and nothing to gain by swapping a subtree under a
+  // finger. Starting active means those devices render exactly what the merge base rendered.
+  assert.match(activation, /useState\(pointerIsCoarse\)/);
+  assert.match(activation, /matchMedia\("\(hover: none\)"\)/);
+  assert.match(activation, /matchMedia\("\(pointer: coarse\)"\)/);
+  assert.match(activation, /if \(event\.pointerType === "touch"\) return;/);
+});
+
+test("the context default mounts everything, so no other list changes", () => {
+  // Every row outside a ModelRowShell -- the Hub catalog, Recommended, the variant expander --
+  // reads the default and behaves exactly as it did.
+  assert.match(activation, /createContext\(true\)/);
+});

--- a/tests/studio/playwright_model_picker_deferred.py
+++ b/tests/studio/playwright_model_picker_deferred.py
@@ -183,9 +183,13 @@ def run(page: Page) -> None:
         page.mouse.move(*centre(dot))
         page.wait_for_timeout(400)
         texts = page.evaluate(TOOLTIP_TEXT_JS)
+        # Substring, not equality: Radix renders the label twice, once visibly and once in the
+        # visually-hidden copy screen readers announce, so `textContent` reads
+        # "SafetensorsSafetensors". An equality predicate here reported a tooltip that had opened
+        # perfectly as never having opened.
         check(
             "one mouse move opens the format tooltip",
-            any(t in ("GGUF", "Safetensors", "MLX") for t in texts),
+            any(any(f in t for f in ("GGUF", "Safetensors", "MLX")) for t in texts),
             f"tooltip contents after a single move: {texts}",
         )
         hovered = page.evaluate(ROW_FACTS_JS, 0)
@@ -277,17 +281,125 @@ def run(page: Page) -> None:
     page.keyboard.press("Escape")
     page.wait_for_timeout(300)
 
-    # 7. And a row still selects when clicked.
+    # The synthetic press above is not a gesture a user can make (the button it hits is under
+    # `opacity-0` until the row is hovered), and it leaves a dismissed menu and a moved focus
+    # behind. Reopen so the selection checks below start from a panel in a known state, and say so
+    # if that reopen did not happen: a stale panel would make the next two checks measure the
+    # leftovers of this one.
+    page.evaluate("window.__pickerScale.setOpen(false)")
+    page.wait_for_timeout(400)
+    open_on_device(page)
+    fresh = page.evaluate(ROW_FACTS_JS, 3)
+    check(
+        "the panel is open and cold before the selection checks",
+        fresh is not None and fresh["rows"] >= MODELS and fresh["rowTooltipTriggers"] == 0,
+        f"row 3 on the reopened panel: {None if fresh is None else fresh['rowTooltipTriggers']} "
+        f"tooltip triggers, {None if fresh is None else fresh['rows']} rows",
+    )
+
+    # 7. And a row still selects when clicked, in ONE gesture.
+    #
+    # `mouse.click` is move + down + up with nothing in between, which is what a real click is and
+    # what a wait between the hover and the press hides. Activating a row replaces the button, so a
+    # swap deferred to after the mousedown puts the mouseup on a different element and the browser
+    # fires no click at all. This assertion caught exactly that, and the row now activates
+    # synchronously; on the merge base it passes because nothing is ever swapped.
+    page.mouse.move(0, 0)
+    page.wait_for_timeout(300)
     target = page.evaluate(ROW_FACTS_JS, 3)
     page.mouse.click(*centre(target["optionRect"]))
+    page.wait_for_timeout(600)
+    selected = page.evaluate(
+        """() => ({
+            open: window.__pickerScale.isOpen(),
+            panel: Boolean(window.__pickerScale.panel()),
+            trigger: (window.__pickerScale.trigger()?.textContent || '').trim(),
+        })"""
+    )
+    leaf = (target["menuButtonAria"]["label"] or "").replace("More options for ", "")
+    check(
+        "clicking a row in one gesture still selects it",
+        leaf in selected["trigger"] and not selected["open"] and not selected["panel"],
+        f"after clicking {leaf!r} the picker reads {selected}",
+    )
+
+    # 8. And Enter on a focused row selects it, which is the same path with no pointer at all.
+    page.evaluate("window.__pickerScale.setOpen(false)")
     page.wait_for_timeout(400)
-    trigger_text = page.evaluate(
-        "() => (window.__pickerScale.trigger()?.textContent || '').trim()"
+    open_on_device(page)
+    page.evaluate(
+        """() => {
+            const panel = document.querySelector(".unsloth-model-selector-menu");
+            panel.querySelectorAll("[data-model-picker-option]")[7].focus();
+        }"""
+    )
+    page.wait_for_timeout(400)
+    keyboard_target = page.evaluate(ROW_FACTS_JS, 7)
+    page.keyboard.press("Enter")
+    page.wait_for_timeout(600)
+    keyboard_selected = page.evaluate(
+        """() => ({
+            open: window.__pickerScale.isOpen(),
+            trigger: (window.__pickerScale.trigger()?.textContent || '').trim(),
+        })"""
+    )
+    # The repo id from the row's own dots button, not from the option's textContent: that text runs
+    # the name straight into the param and size chips ("Yi-3B-Math-343B35GB"), so a slice of it is
+    # not a substring of anything and the check failed on a selection that had worked. It failed on
+    # the merge base too, which is what said the predicate was wrong rather than the tree.
+    keyboard_leaf = (keyboard_target["menuButtonAria"]["label"] or "").replace(
+        "More options for ", ""
     )
     check(
-        "clicking a row still selects it",
-        trigger_text != "" and trigger_text.split("/")[-1][:8] in target["optionLabel"],
-        f"picker trigger reads {trigger_text!r} after clicking {target['optionLabel']!r}",
+        "pressing Enter on a focused row still selects it",
+        keyboard_leaf in keyboard_selected["trigger"] and not keyboard_selected["open"],
+        f"after Enter on {keyboard_leaf!r} the picker reads {keyboard_selected}",
+    )
+
+
+def run_touch(page: Page) -> None:
+    """A coarse pointer opts out of the deferral entirely, so it renders the merge base's tree.
+
+    Those devices show the row actions at all times (`[@media(hover:none)]:opacity-100`), have no
+    hover to trade on, and a tap is a pointerdown and a click on the SAME node -- swapping a
+    subtree under a finger would move the click's target out from under it. So the answer there is
+    to change nothing, and this is the check that it really changed nothing.
+    """
+    coarse = page.evaluate(
+        """() => ({
+            coarse: window.matchMedia("(pointer: coarse)").matches,
+            noHover: window.matchMedia("(hover: none)").matches,
+        })"""
+    )
+    # Without this the rest of the section is vacuous: it would be asserting the desktop path twice.
+    check(
+        "the touch context really reports a coarse pointer",
+        coarse["coarse"] or coarse["noHover"],
+        f"{coarse}",
+    )
+    open_on_device(page)
+    facts = page.evaluate(ROW_FACTS_JS, 0)
+    check(
+        "a coarse pointer mounts every row's tooltips up front",
+        facts["panelTooltipTriggers"] >= facts["rows"] * 3,
+        f"{facts['panelTooltipTriggers']} tooltip triggers for {facts['rows']} rows "
+        "(three per row is the merge base's tree)",
+    )
+    check(
+        "a coarse pointer mounts every row's dots menu up front",
+        facts["rowTooltipTriggers"] >= 3,
+        f"row 0 carries {facts['rowTooltipTriggers']} tooltip triggers with no interaction at all",
+    )
+    menu_rect = facts["menuButtonAria"]["rect"]
+    page.touchscreen.tap(
+        menu_rect["x"] + menu_rect["width"] / 2, menu_rect["y"] + menu_rect["height"] / 2
+    )
+    page.wait_for_timeout(800)
+    items = page.evaluate(MENU_ITEMS_JS)
+    check(
+        "tapping the dots opens the menu on a touch device",
+        len(items) >= 2,
+        f"menu items after a tap: {items}",
     )
 
 
@@ -322,6 +434,26 @@ def main() -> int:
             page.wait_for_function("() => Boolean(window.__pickerScale)", timeout=120_000)
             run(page)
             context.close()
+
+            touch_context = browser.new_context(
+                viewport={"width": 1440, "height": 900}, has_touch=True, is_mobile=False
+            )
+            touch_page = touch_context.new_page()
+            touch_page.on("pageerror", lambda e: errors.append(f"pageerror: {e}"[:200]))
+            touch_page.on(
+                "console",
+                lambda m: errors.append(f"console error: {m.text[:160]}")
+                if m.type == "error"
+                else None,
+            )
+            touch_page.goto(
+                f"{BASE}/smoke-model-picker-scale.html", wait_until="domcontentloaded"
+            )
+            touch_page.wait_for_function(
+                "() => Boolean(window.__pickerScale)", timeout=120_000
+            )
+            run_touch(touch_page)
+            touch_context.close()
             browser.close()
     finally:
         if vite is not None:

--- a/tests/studio/playwright_model_picker_deferred.py
+++ b/tests/studio/playwright_model_picker_deferred.py
@@ -54,7 +54,7 @@ FAILURES: list[str] = []
 
 
 def info(message: str) -> None:
-    print(f"[picker-deferred] {message}", flush=True)
+    print(f"[picker-deferred] {message}", flush = True)
 
 
 def check(name: str, condition: bool, detail: str) -> None:
@@ -128,10 +128,10 @@ MENU_ITEMS_JS = """
 def open_on_device(page: Page) -> None:
     page.evaluate("(n) => window.__pickerScale.seed(n)", MODELS)
     page.evaluate("window.__pickerScale.setOpen(true)")
-    page.wait_for_function("() => window.__pickerScale.onDeviceTab() !== null", timeout=180_000)
+    page.wait_for_function("() => window.__pickerScale.onDeviceTab() !== null", timeout = 180_000)
     page.evaluate("() => window.__pickerScale.onDeviceTab().click()")
     page.wait_for_function(
-        "(n) => window.__pickerScale.counts().rows >= n", arg=MODELS, timeout=180_000
+        "(n) => window.__pickerScale.counts().rows >= n", arg = MODELS, timeout = 180_000
     )
 
 
@@ -413,15 +413,15 @@ def main() -> int:
         wait_for_smoke_page(
             f"{BASE}/smoke-model-picker-scale.html",
             "smoke-model-picker-scale-main.tsx",
-            proc=vite,
-            info=info,
+            proc = vite,
+            info = info,
         )
         with sync_playwright() as p:
             browser = p.chromium.launch(
-                headless=os.environ.get("SMOKE_HEADLESS", "1") == "1",
-                args=chromium_launch_args(),
+                headless = os.environ.get("SMOKE_HEADLESS", "1") == "1",
+                args = chromium_launch_args(),
             )
-            context = browser.new_context(viewport={"width": 1440, "height": 900})
+            context = browser.new_context(viewport = {"width": 1440, "height": 900})
             page = context.new_page()
             page.on("pageerror", lambda e: errors.append(f"pageerror: {e}"[:200]))
             page.on(
@@ -430,13 +430,13 @@ def main() -> int:
                 if m.type == "error"
                 else None,
             )
-            page.goto(f"{BASE}/smoke-model-picker-scale.html", wait_until="domcontentloaded")
-            page.wait_for_function("() => Boolean(window.__pickerScale)", timeout=120_000)
+            page.goto(f"{BASE}/smoke-model-picker-scale.html", wait_until = "domcontentloaded")
+            page.wait_for_function("() => Boolean(window.__pickerScale)", timeout = 120_000)
             run(page)
             context.close()
 
             touch_context = browser.new_context(
-                viewport={"width": 1440, "height": 900}, has_touch=True, is_mobile=False
+                viewport = {"width": 1440, "height": 900}, has_touch = True, is_mobile = False
             )
             touch_page = touch_context.new_page()
             touch_page.on("pageerror", lambda e: errors.append(f"pageerror: {e}"[:200]))
@@ -446,12 +446,8 @@ def main() -> int:
                 if m.type == "error"
                 else None,
             )
-            touch_page.goto(
-                f"{BASE}/smoke-model-picker-scale.html", wait_until="domcontentloaded"
-            )
-            touch_page.wait_for_function(
-                "() => Boolean(window.__pickerScale)", timeout=120_000
-            )
+            touch_page.goto(f"{BASE}/smoke-model-picker-scale.html", wait_until = "domcontentloaded")
+            touch_page.wait_for_function("() => Boolean(window.__pickerScale)", timeout = 120_000)
             run_touch(touch_page)
             touch_context.close()
             browser.close()

--- a/tests/studio/playwright_model_picker_deferred.py
+++ b/tests/studio/playwright_model_picker_deferred.py
@@ -1,0 +1,340 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""The On Device rows defer their tooltips and their dots menu, and still behave like rows.
+
+The picker renders every cached repo, and each row used to mount three Radix tooltips and a Radix
+dropdown whether or not anything had ever pointed at it. None of the four is on screen until the
+row is hovered or focused, so they are now mounted on first contact instead. That is invisible when
+it works and invisible when it breaks, which is what this file is for.
+
+Each check here fails on its own mutant (see logs/nextwins/picker.md for which mutant turned which
+assertion red). The interesting ones are not "the tooltip exists" but:
+
+  * ONE mouse move. Radix opens a tooltip on `pointermove`, not on `pointerenter`, so a pointer
+    that enters a row and then holds still fires nothing more. The freshly mounted trigger would
+    never learn the pointer is on it. The row replays one synthetic move; `page.mouse.move` is
+    exactly the parked-pointer case, one move and no more.
+  * FOCUS SURVIVES. Activating a row replaces the element that has focus. Without the replay, a Tab
+    into the list drops focus to <body> and the whole list stops being keyboard reachable.
+  * A COLD CLICK STILL OPENS THE MENU. The dots placeholder is a real button; a press on it has to
+    end with the menu open, not with a swallowed gesture.
+
+Run:
+    python tests/studio/playwright_model_picker_deferred.py
+    SMOKE_BASE_URL=http://127.0.0.1:5547 python tests/studio/playwright_model_picker_deferred.py
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+from playwright.sync_api import Page, sync_playwright
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _playwright_robust import (  # noqa: E402
+    chromium_launch_args,
+    start_vite,
+    stop_process,
+    wait_for_smoke_page,
+)
+
+PORT = int(os.environ.get("SMOKE_PORT", "5548"))
+_EXTERNAL = os.environ.get("SMOKE_BASE_URL", "").strip().rstrip("/")
+BASE = _EXTERNAL or f"http://127.0.0.1:{PORT}"
+OWNS_SERVER = not _EXTERNAL
+MODELS = int(os.environ.get("SMOKE_PICKER_MODELS", "200"))
+# The row tooltip opens after 700ms; give the frame budget room on a loaded host without making the
+# wait itself the assertion.
+ROW_TOOLTIP_WAIT_MS = int(os.environ.get("SMOKE_ROW_TOOLTIP_WAIT_MS", "2500"))
+
+FAILURES: list[str] = []
+
+
+def info(message: str) -> None:
+    print(f"[picker-deferred] {message}", flush=True)
+
+
+def check(name: str, condition: bool, detail: str) -> None:
+    if condition:
+        info(f"PASS {name}: {detail}")
+        return
+    FAILURES.append(f"{name}: {detail}")
+    info(f"FAIL {name}: {detail}")
+
+
+ROW_FACTS_JS = """
+(index) => {
+  const panel = document.querySelector(".unsloth-model-selector-menu");
+  if (!panel) return null;
+  const options = panel.querySelectorAll("[data-model-picker-option]");
+  const option = options[index];
+  if (!option) return null;
+  // The row shell is the option's grandparent: <shell><div.min-w-0><button option>.
+  const shell = option.closest("[data-model-picker-option]")?.parentElement?.parentElement ?? null;
+  const menuButton = shell ? shell.querySelector('[aria-label^="More options"]') : null;
+  return {
+    rows: options.length,
+    panelTooltipTriggers: panel.querySelectorAll('[data-slot="tooltip-trigger"]').length,
+    panelMenuTriggers: panel.querySelectorAll('[data-slot="dropdown-menu-trigger"]').length,
+    rowTooltipTriggers: shell
+      ? shell.querySelectorAll('[data-slot="tooltip-trigger"]').length
+      : -1,
+    optionLabel: option.textContent.trim().slice(0, 80),
+    optionRect: option.getBoundingClientRect().toJSON(),
+    formatDotRect: (() => {
+      const dot = shell ? shell.querySelector('[aria-label*="afetensors"], [aria-label="GGUF"]') : null;
+      return dot ? dot.getBoundingClientRect().toJSON() : null;
+    })(),
+    menuButtonAria: menuButton
+      ? {
+          label: menuButton.getAttribute("aria-label"),
+          haspopup: menuButton.getAttribute("aria-haspopup"),
+          expanded: menuButton.getAttribute("aria-expanded"),
+          state: menuButton.getAttribute("data-state"),
+          slot: menuButton.getAttribute("data-slot"),
+          tag: menuButton.tagName,
+          rect: menuButton.getBoundingClientRect().toJSON(),
+        }
+      : null,
+    activeElement: document.activeElement
+      ? {
+          tag: document.activeElement.tagName,
+          option: document.activeElement.hasAttribute("data-model-picker-option"),
+          label: (document.activeElement.getAttribute("aria-label") || "").slice(0, 60),
+          insideShell: shell ? shell.contains(document.activeElement) : false,
+        }
+      : null,
+  };
+}
+"""
+
+TOOLTIP_TEXT_JS = """
+() =>
+  Array.from(document.querySelectorAll('[data-slot="tooltip-content"]'))
+    .map((el) => el.textContent.trim())
+    .filter(Boolean)
+"""
+
+MENU_ITEMS_JS = """
+() =>
+  Array.from(document.querySelectorAll('[data-slot="dropdown-menu-content"] [role="menuitem"]'))
+    .map((el) => el.textContent.trim())
+"""
+
+
+def open_on_device(page: Page) -> None:
+    page.evaluate("(n) => window.__pickerScale.seed(n)", MODELS)
+    page.evaluate("window.__pickerScale.setOpen(true)")
+    page.wait_for_function("() => window.__pickerScale.onDeviceTab() !== null", timeout=180_000)
+    page.evaluate("() => window.__pickerScale.onDeviceTab().click()")
+    page.wait_for_function(
+        "(n) => window.__pickerScale.counts().rows >= n", arg=MODELS, timeout=180_000
+    )
+
+
+def centre(rect: dict) -> tuple[float, float]:
+    return rect["x"] + rect["width"] / 2, rect["y"] + rect["height"] / 2
+
+
+def run(page: Page) -> None:
+    open_on_device(page)
+
+    facts = page.evaluate(ROW_FACTS_JS, 0)
+    check(
+        "rows rendered",
+        facts is not None and facts["rows"] >= MODELS,
+        f"{facts['rows'] if facts else 'no panel'} rows for {MODELS} models",
+    )
+    # 1. The deferral is actually on. Every row still carries its dots button, so the menu trigger
+    #    count must NOT fall: what the fix removes is Radix machinery, not markup.
+    check(
+        "cold list mounts no row tooltips",
+        facts["panelTooltipTriggers"] <= 8,
+        f"{facts['panelTooltipTriggers']} tooltip triggers in a panel of {facts['rows']} rows "
+        "(the picker's own chrome only; a row that mounted its tooltips would add three each)",
+    )
+    check(
+        "cold list still renders every dots button",
+        facts["panelMenuTriggers"] >= facts["rows"],
+        f"{facts['panelMenuTriggers']} dots buttons for {facts['rows']} rows",
+    )
+    # 2. The a11y tree of a cold row is the a11y tree of a Radix trigger.
+    aria = facts["menuButtonAria"]
+    check(
+        "cold dots button is a closed menu button",
+        aria is not None
+        and aria["tag"] == "BUTTON"
+        and aria["haspopup"] == "menu"
+        and aria["expanded"] == "false"
+        and aria["state"] == "closed"
+        and (aria["label"] or "").startswith("More options"),
+        f"{aria}",
+    )
+
+    # 3. ONE mouse move onto the format dot has to open its tooltip. This is the parked-pointer
+    #    case: Playwright moves once, so a row that mounted its trigger without replaying the move
+    #    would sit there closed forever.
+    dot = facts["formatDotRect"]
+    check("row 0 has a format dot to hover", dot is not None, f"{dot}")
+    if dot:
+        page.mouse.move(*centre(dot))
+        page.wait_for_timeout(400)
+        texts = page.evaluate(TOOLTIP_TEXT_JS)
+        check(
+            "one mouse move opens the format tooltip",
+            any(t in ("GGUF", "Safetensors", "MLX") for t in texts),
+            f"tooltip contents after a single move: {texts}",
+        )
+        hovered = page.evaluate(ROW_FACTS_JS, 0)
+        check(
+            "hovering mounts the row's own tooltips",
+            hovered["rowTooltipTriggers"] >= 2,
+            f"{hovered['rowTooltipTriggers']} tooltip triggers in the hovered row",
+        )
+        check(
+            "hovering does not wake the rest of the list",
+            hovered["panelTooltipTriggers"] < facts["rows"],
+            f"{hovered['panelTooltipTriggers']} tooltip triggers in the whole panel",
+        )
+
+    # 4. And the row's own 700ms tooltip, from the same single move.
+    page.mouse.move(0, 0)
+    page.wait_for_timeout(300)
+    row1 = page.evaluate(ROW_FACTS_JS, 1)
+    page.mouse.move(*centre(row1["optionRect"]))
+    page.wait_for_timeout(ROW_TOOLTIP_WAIT_MS)
+    texts = page.evaluate(TOOLTIP_TEXT_JS)
+    check(
+        "one mouse move opens the row tooltip",
+        any(t for t in texts if "/" in t or "Local" in t),
+        f"tooltip contents after a single move onto the row: {texts}",
+    )
+
+    # 5. Keyboard: focus a cold row and keep it. Activation replaces the focused element, so
+    #    without the replay this lands on <body> and the list stops being keyboard reachable.
+    page.mouse.move(0, 0)
+    page.wait_for_timeout(200)
+    row5 = page.evaluate(ROW_FACTS_JS, 5)
+    page.evaluate(
+        """(index) => {
+            const panel = document.querySelector(".unsloth-model-selector-menu");
+            const option = panel.querySelectorAll("[data-model-picker-option]")[index];
+            option.focus();
+        }""",
+        5,
+    )
+    page.wait_for_timeout(200)
+    focused = page.evaluate(ROW_FACTS_JS, 5)
+    check(
+        "focus survives activating a row",
+        focused["activeElement"] is not None
+        and focused["activeElement"]["option"]
+        and focused["activeElement"]["insideShell"],
+        f"active element after focusing row 5: {focused['activeElement']}",
+    )
+    check(
+        "focusing a row activates it",
+        focused["rowTooltipTriggers"] >= 2 and row5["rowTooltipTriggers"] == 0,
+        f"row 5 carried {row5['rowTooltipTriggers']} tooltip triggers cold and "
+        f"{focused['rowTooltipTriggers']} once focused",
+    )
+    # Tab from the focused row must reach that row's own action buttons, in order.
+    page.keyboard.press("Tab")
+    page.wait_for_timeout(150)
+    after_tab = page.evaluate(ROW_FACTS_JS, 5)
+    check(
+        "tab from a row reaches its own action buttons",
+        after_tab["activeElement"] is not None and after_tab["activeElement"]["insideShell"],
+        f"active element after Tab: {after_tab['activeElement']}",
+    )
+
+    # 6. A cold row's dots button, pressed without ever being hovered, opens the menu.
+    cold = page.evaluate(ROW_FACTS_JS, 20)
+    check(
+        "row 20 is still cold",
+        cold["rowTooltipTriggers"] == 0,
+        f"{cold['rowTooltipTriggers']} tooltip triggers before the press",
+    )
+    page.evaluate(
+        """(index) => {
+            const panel = document.querySelector(".unsloth-model-selector-menu");
+            const option = panel.querySelectorAll("[data-model-picker-option]")[index];
+            const shell = option.parentElement.parentElement;
+            shell.querySelector('[aria-label^="More options"]').click();
+        }""",
+        20,
+    )
+    page.wait_for_timeout(600)
+    items = page.evaluate(MENU_ITEMS_JS)
+    check(
+        "a cold dots button opens the menu",
+        len(items) >= 2,
+        f"menu items after clicking a never-hovered dots button: {items}",
+    )
+    page.keyboard.press("Escape")
+    page.wait_for_timeout(300)
+
+    # 7. And a row still selects when clicked.
+    target = page.evaluate(ROW_FACTS_JS, 3)
+    page.mouse.click(*centre(target["optionRect"]))
+    page.wait_for_timeout(400)
+    trigger_text = page.evaluate(
+        "() => (window.__pickerScale.trigger()?.textContent || '').trim()"
+    )
+    check(
+        "clicking a row still selects it",
+        trigger_text != "" and trigger_text.split("/")[-1][:8] in target["optionLabel"],
+        f"picker trigger reads {trigger_text!r} after clicking {target['optionLabel']!r}",
+    )
+
+
+def main() -> int:
+    vite = None
+    if OWNS_SERVER:
+        info(f"starting vite dev server on port {PORT}")
+        vite = start_vite(PORT)
+    errors: list[str] = []
+    try:
+        wait_for_smoke_page(
+            f"{BASE}/smoke-model-picker-scale.html",
+            "smoke-model-picker-scale-main.tsx",
+            proc=vite,
+            info=info,
+        )
+        with sync_playwright() as p:
+            browser = p.chromium.launch(
+                headless=os.environ.get("SMOKE_HEADLESS", "1") == "1",
+                args=chromium_launch_args(),
+            )
+            context = browser.new_context(viewport={"width": 1440, "height": 900})
+            page = context.new_page()
+            page.on("pageerror", lambda e: errors.append(f"pageerror: {e}"[:200]))
+            page.on(
+                "console",
+                lambda m: errors.append(f"console error: {m.text[:160]}")
+                if m.type == "error"
+                else None,
+            )
+            page.goto(f"{BASE}/smoke-model-picker-scale.html", wait_until="domcontentloaded")
+            page.wait_for_function("() => Boolean(window.__pickerScale)", timeout=120_000)
+            run(page)
+            context.close()
+            browser.close()
+    finally:
+        if vite is not None:
+            stop_process(vite)
+            info("vite stopped")
+    check("no page errors", not errors, f"{errors[:3]}")
+    if FAILURES:
+        for failure in FAILURES:
+            info(f"FAILED {failure}")
+        return 1
+    info("all checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/studio/playwright_model_picker_scale.py
+++ b/tests/studio/playwright_model_picker_scale.py
@@ -495,9 +495,7 @@ def run() -> dict:
             context.add_init_script(RECORDER_INIT)
             context.route(
                 re.compile(rf"^{re.escape(BASE)}/api/"),
-                lambda route: route.fulfill(
-                    status = 200, content_type = "application/json", body = "{}"
-                ),
+                lambda route: route.fulfill(status = 200, content_type = "application/json", body = "{}"),
             )
             by_rate: dict = {}
             engine_rates = RATES if engine == "chromium" else [1.0]

--- a/tests/studio/playwright_model_picker_scale.py
+++ b/tests/studio/playwright_model_picker_scale.py
@@ -1,0 +1,863 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""What the model picker costs as a function of how many models are on the machine.
+
+The axis is the size of the ON DEVICE list. The Hugging Face half of the picker is deliberately
+not swept: it is paged behind an IntersectionObserver sentinel (pickers.tsx:4445-4490), so its row
+count is bounded by how far the user scrolled rather than by how much they own. The downloaded
+half has no such bound -- it renders every cached repo -- and that is what a user with a full
+model cache grows.
+
+studio/frontend/smoke-model-picker-scale.html mounts the REAL ModelSelector and answers
+/api/hub/cached-models from an in-memory fixture, which is where the downloaded rows really come
+from. Seeding only the `models` prop opened a panel with ZERO rows; that is in the harness's
+comments because it is the sort of thing that reads as "the picker is fast" rather than as "the
+picker is empty".
+
+WHAT IS MEASURED
+
+    open first row     setOpen(true) -> the FIRST row is in the panel.
+    open converged     the same window, stopped when all N rows are there.
+                       Both, deliberately: a change can move one and not the other, and a harness
+                       with only the convergence predicate cannot see a first-paint win at all.
+    open settle        how long after the open the panel stops moving. Three consecutive still
+                       polls over (rows, panel nodes, scrollHeight) AND no frame over 33ms,
+                       because a re-render that lands the same markup is invisible to a DOM gate.
+    keystroke          one character into the picker's search box, measured to the next paint.
+                       The query is debounced (useDebouncedValue, pickers.tsx:2430), so this is
+                       the cost of the controlled input, and `search settle` below is the cost of
+                       the filter that follows.
+    search settle      from the keystroke until the filtered list has stopped moving.
+
+CONTROLS
+
+    control sleep ms   a 200ms setTimeout. Timer-bound: MUST STAY FLAT across the throttle ladder.
+    control busy ms    a fixed integer loop. CPU-bound: MUST RISE with the rate.
+
+Ratios are the result and milliseconds are context; this host runs at load average ~60.
+
+THIS HARNESS MEASURES, IT DOES NOT GATE. It exits non-zero only when it is measuring nothing.
+
+Run:
+    python tests/studio/playwright_model_picker_scale.py
+    SMOKE_BASE_URL=http://127.0.0.1:5475 SMOKE_PICKER_MODELS=50,200 \
+        SMOKE_PICKER_RATES=1 python tests/studio/playwright_model_picker_scale.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+from playwright.sync_api import sync_playwright
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _playwright_robust import (  # noqa: E402
+    chromium_launch_args,
+    start_vite,
+    stop_process,
+    wait_for_smoke_page,
+)
+
+PORT = int(os.environ.get("SMOKE_PORT", "5475"))
+_EXTERNAL = os.environ.get("SMOKE_BASE_URL", "").strip().rstrip("/")
+BASE = _EXTERNAL or f"http://127.0.0.1:{PORT}"
+OWNS_SERVER = not _EXTERNAL
+LABEL = os.environ.get("SMOKE_LABEL", "tree")
+OUT = Path(os.environ.get("PW_ART_DIR", "logs/playwright-model-picker-scale"))
+OUT.mkdir(parents = True, exist_ok = True)
+
+# Sorted: the growth check reads the first and last as smallest and largest, so an unsorted
+# override would invert every ratio and report a good run as measuring nothing.
+SIZES = sorted(int(n) for n in os.environ.get("SMOKE_PICKER_MODELS", "50,200,1000").split(","))
+RATES = [float(r) for r in os.environ.get("SMOKE_PICKER_RATES", "1,2,4").split(",") if r.strip()]
+ENGINES = [
+    e.strip() for e in os.environ.get("SMOKE_PICKER_ENGINES", "chromium").split(",") if e.strip()
+]
+REPEATS = int(os.environ.get("SMOKE_PICKER_REPEATS", "3"))
+ACTION_TIMEOUT_MS = int(os.environ.get("SMOKE_ACTION_TIMEOUT_MS", "180000"))
+SEED_TIMEOUT_MS = int(os.environ.get("SMOKE_SEED_TIMEOUT_MS", "300000"))
+SETTLE_POLL_MS = int(os.environ.get("SMOKE_SETTLE_POLL_MS", "50"))
+STILL_POLLS = int(os.environ.get("SMOKE_STILL_POLLS", "3"))
+KEYSTROKES = int(os.environ.get("SMOKE_PICKER_KEYSTROKES", "5"))
+CONTROL_SLEEP_MS = 200
+CONTROL_BUSY_ITERS = 8_000_000
+CONTROL_FLAT_TOLERANCE = 1.25
+CONTROL_SCALE_FLOOR = 0.6
+DISCRIMINATION_RATIO = float(os.environ.get("SMOKE_DISCRIMINATION_RATIO", "1.5"))
+CONSOLE_WARNING_ALLOWANCE = int(os.environ.get("SMOKE_CONSOLE_WARNING_ALLOWANCE", "40"))
+
+ACTIONS = ("open", "search")
+
+RECORDER_INIT = """
+(() => {
+  const nativeRaf = window.requestAnimationFrame.bind(window);
+  window.__nextPaint = () =>
+    new Promise((resolve) => nativeRaf(() => nativeRaf(() => resolve())));
+  const recorder = {
+    running: false,
+    generation: 0,
+    frames: [],
+    frameAt: [],
+    startedAt: 0,
+    begin() {
+      this.running = true;
+      this.generation += 1;
+      const generation = this.generation;
+      this.frames = [];
+      this.frameAt = [];
+      this.startedAt = performance.now();
+      let lastFrame = performance.now();
+      const frame = () => {
+        // Which begin() this callback belongs to. `running` alone cannot answer that: a callback
+        // scheduled by the previous action wakes to running === true and records the whole
+        // between-action gap as a frame of the new window.
+        if (generation !== this.generation) return;
+        const now = performance.now();
+        this.frames.push(now - lastFrame);
+        this.frameAt.push(now);
+        lastFrame = now;
+        if (this.running) nativeRaf(frame);
+      };
+      nativeRaf(frame);
+    },
+    end(untilMs) {
+      this.running = false;
+      this.generation += 1;
+      const cutoff = untilMs === undefined ? Infinity : untilMs;
+      const frames = this.frames.filter((_, i) => this.frameAt[i] <= cutoff);
+      return {
+        frames: frames.length,
+        worst_frame_ms: Math.round(Math.max(0, ...frames) * 10) / 10,
+        frames_over_33: frames.filter((ms) => ms > 33).length,
+      };
+    },
+  };
+  window.__mps = recorder;
+
+  /**
+   * Three consecutive still polls, not two: a two-poll gate is a plateau detector and releases
+   * inside the lull between two React commits. Stillness is the panel signature AND the absence
+   * of any frame over 33ms since the previous poll, because a re-render that lands identical
+   * markup is invisible to a DOM-only gate. Returns the time of the LAST CHANGE, so the grace is
+   * not a constant added to both ends of every ratio.
+   */
+  window.__mpsSettle = async (timeoutMs, pollMs, stillPolls) => {
+    const api = window.__pickerScale;
+    const started = performance.now();
+    const sample = () => {
+      const c = api.counts();
+      return `${c.rows}|${c.panelNodes}|${c.panelScrollHeight}`;
+    };
+    let last = sample();
+    let lastChangeAt = performance.now();
+    let still = 0;
+    let framesSeen = window.__mps.frames.length;
+    let lastPollAt = performance.now();
+    while (performance.now() - started < timeoutMs) {
+      await new Promise((resolve) => setTimeout(resolve, pollMs));
+      const now = performance.now();
+      const next = sample();
+      const fresh = window.__mps.frames.slice(framesSeen);
+      framesSeen = window.__mps.frames.length;
+      if (next !== last || Math.max(0, ...fresh) > 33) {
+        still = 0;
+        last = next;
+        lastChangeAt = now;
+      } else {
+        still += 1;
+      }
+      lastPollAt = now;
+      if (still >= stillPolls) {
+        return { settleMs: lastChangeAt - window.__mps.startedAt, at: lastChangeAt, timedOut: false };
+      }
+    }
+    return { settleMs: null, at: lastPollAt, timedOut: true };
+  };
+})();
+"""
+
+OPEN_JS = """
+async ([want, timeoutMs, pollMs, stillPolls]) => {
+  const api = window.__pickerScale;
+  api.setOpen(false);
+  const closedStarted = performance.now();
+  while (performance.now() - closedStarted < timeoutMs) {
+    if (api.panel() === null) break;
+    await window.__nextPaint();
+  }
+  if (api.panel() !== null) return null;
+  window.__mps.begin();
+  const started = performance.now();
+  api.setOpen(true);
+  let firstRowMs = null;
+  let convergedMs = null;
+  while (performance.now() - started < timeoutMs) {
+    const rows = api.counts().rows;
+    if (firstRowMs === null && rows > 0) firstRowMs = performance.now() - started;
+    if (rows >= want) { convergedMs = performance.now() - started; break; }
+    await window.__nextPaint();
+  }
+  const settled = await window.__mpsSettle(timeoutMs, pollMs, stillPolls);
+  const metrics = window.__mps.end(settled.at);
+  const counts = api.counts();
+  return {
+    firstRowMs: firstRowMs === null ? null : Math.round(firstRowMs * 10) / 10,
+    convergedMs: convergedMs === null ? null : Math.round(convergedMs * 10) / 10,
+    settleMs: settled.settleMs === null ? null : Math.round(settled.settleMs * 10) / 10,
+    settleTimedOut: settled.timedOut,
+    rows: counts.rows,
+    panelNodes: counts.panelNodes,
+    rowMenuTriggers: counts.rowMenuTriggers,
+    tooltipTriggers: counts.tooltipTriggers,
+    metrics,
+  };
+}
+"""
+
+SEARCH_JS = """
+async ([count, timeoutMs, pollMs, stillPolls]) => {
+  const api = window.__pickerScale;
+  const input = api.searchInput();
+  if (!input) return null;
+  input.focus();
+  // The native value setter plus an input event: what the browser leaves behind after a real
+  // keypress, and what React's controlled input reacts to. input.value = x alone does not.
+  const setValue = Object.getOwnPropertyDescriptor(
+    HTMLInputElement.prototype, "value",
+  ).set;
+  const samples = [];
+  const before = api.counts().rows;
+  window.__mps.begin();
+  const typed = "llama";
+  for (let i = 0; i < count; i += 1) {
+    await window.__nextPaint();
+    const started = performance.now();
+    setValue.call(input, typed.slice(0, i + 1));
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+    await window.__nextPaint();
+    samples.push(performance.now() - started);
+  }
+  // The filter is DEBOUNCED (useDebouncedValue, pickers.tsx:2430), so for ~300ms after the last
+  // keystroke the list is still the unfiltered one and nothing in the DOM moves. A settle gate
+  // alone therefore releases INSIDE the debounce -- measured: it released after ~150ms with the
+  // row count still at its unfiltered 200, and the run's own check caught it as "the filter did
+  // not run". So wait for the row count to actually change first, and report that wait as its own
+  // number: it is what a user waits between typing and seeing the list narrow.
+  let filteredMs = null;
+  const filterStarted = performance.now();
+  while (performance.now() - filterStarted < timeoutMs) {
+    if (api.counts().rows !== before) {
+      filteredMs = performance.now() - window.__mps.startedAt;
+      break;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  const settled = await window.__mpsSettle(timeoutMs, pollMs, stillPolls);
+  const metrics = window.__mps.end(settled.at);
+  const after = api.counts().rows;
+  // Read the proofs BEFORE clearing. `domQuery` was in the returned object literal, which is
+  // evaluated after the two lines below, so it reported the CLEARED value and the run failed its
+  // own "the keystrokes never reached React" check on a keystroke that had landed perfectly well.
+  const domQuery = api.query();
+  // Clear it again so the next repetition starts from the unfiltered list.
+  setValue.call(input, "");
+  input.dispatchEvent(new Event("input", { bubbles: true }));
+  const sorted = samples.slice().sort((a, b) => a - b);
+  return {
+    samples: samples.map((s) => Math.round(s * 10) / 10),
+    // The first sample is systematically the cold one, which is why the headline is a median.
+    median_sample_ms: Math.round(sorted[Math.floor(sorted.length / 2)] * 10) / 10,
+    filteredMs: filteredMs === null ? null : Math.round(filteredMs * 10) / 10,
+    worst_sample_ms: Math.round(sorted[sorted.length - 1] * 10) / 10,
+    settleMs: settled.settleMs === null ? null : Math.round(settled.settleMs * 10) / 10,
+    settleTimedOut: settled.timedOut,
+    rowsBefore: before,
+    rowsAfter: after,
+    domQuery,
+    metrics,
+  };
+}
+"""
+
+PAINT_FLOOR_JS = """
+async (samples) => {
+  const values = [];
+  for (let i = 0; i < samples; i += 1) {
+    await window.__nextPaint();
+    const started = performance.now();
+    await window.__nextPaint();
+    values.push(performance.now() - started);
+  }
+  values.sort((a, b) => a - b);
+  return values[Math.floor(values.length / 2)];
+}
+"""
+
+CONTROLS_JS = """
+async ([sleepMs, busyIters]) => {
+  const sleeps = [];
+  const busies = [];
+  for (let i = 0; i < 3; i += 1) {
+    const t0 = performance.now();
+    await new Promise((resolve) => setTimeout(resolve, sleepMs));
+    sleeps.push(performance.now() - t0);
+    const t1 = performance.now();
+    let acc = 0;
+    for (let k = 0; k < busyIters; k += 1) acc = (acc + k) % 2147483647;
+    busies.push(performance.now() - t1);
+    if (acc === -1) console.log("unreachable");
+  }
+  const mid = (a) => a.slice().sort((x, y) => x - y)[1];
+  return {
+    control_sleep_ms: Math.round(mid(sleeps) * 10) / 10,
+    control_busy_ms: Math.round(mid(busies) * 10) / 10,
+  };
+}
+"""
+
+
+def info(message: str) -> None:
+    print(f"[model-picker-scale] {message}", flush = True)
+
+
+def median(values: list) -> float | None:
+    """None if ANY repetition failed: a null is a repetition in which the thing being timed never
+    happened, and dropping those changes the population and hides it from the failure check."""
+    if not values or any(v is None for v in values):
+        return None
+    ordered = sorted(values)
+    middle = len(ordered) // 2
+    if len(ordered) % 2:
+        return round(ordered[middle], 1)
+    return round((ordered[middle - 1] + ordered[middle]) / 2, 1)
+
+
+def measure_cell(context, engine: str, size: int, rate: float) -> dict:
+    page = context.new_page()
+    result: dict = {"models_requested": size, "engine": engine, "cpu_throttle_rate": 1.0}
+    api_prefix = f"{BASE}/api/"
+    stray: list = []
+    warnings: list = []
+    # Severity kept SEPARATE from the warnings: an application exception is not engine chatter,
+    # and folding the two into one list is how a real error sits under a warning threshold.
+    errors: list = []
+    page.on("request", lambda r: stray.append(r.url) if r.url.startswith(api_prefix) else None)
+    page.on(
+        "console",
+        lambda m: (
+            errors.append(m.text[:200])
+            if m.type == "error"
+            else warnings.append(m.text[:200])
+            if m.type == "warning"
+            else None
+        ),
+    )
+    page.on("pageerror", lambda e: errors.append(f"pageerror: {e}"[:200]))
+    cdp = None
+    try:
+        page.goto(f"{BASE}/smoke-model-picker-scale.html", wait_until = "domcontentloaded")
+        page.wait_for_function("() => Boolean(window.__pickerScale)", timeout = 120_000)
+        if engine == "chromium":
+            cdp = context.new_cdp_session(page)
+
+        # Seeding is unthrottled and untimed: this measures interaction cost at a list size, not
+        # the cost of building the fixture.
+        result["plan"] = page.evaluate("(n) => window.__pickerScale.seed(n)", size)
+        page.evaluate("window.__pickerScale.setOpen(true)")
+        page.wait_for_function(
+            "() => window.__pickerScale.panel() !== null", timeout = SEED_TIMEOUT_MS
+        )
+        # The downloaded list lives behind the On Device tab; the picker opens on Recommended,
+        # which is the Hugging Face listing and is empty here on purpose.
+        page.wait_for_function(
+            "() => window.__pickerScale.onDeviceTab() !== null", timeout = SEED_TIMEOUT_MS
+        )
+        page.evaluate("() => window.__pickerScale.onDeviceTab().click()")
+        page.wait_for_function(
+            "(n) => window.__pickerScale.counts().rows >= n", arg = size, timeout = SEED_TIMEOUT_MS
+        )
+        result["counts"] = page.evaluate("window.__pickerScale.counts()")
+        result["seed_api_requests"] = len(stray)
+        result["seed_console_errors"] = len(errors)
+        result["first_seed_error"] = errors[0] if errors else "-"
+        result["seed_console_warnings"] = len(warnings)
+        result["first_seed_warning"] = warnings[0] if warnings else "-"
+        stray.clear()
+        errors.clear()
+        warnings.clear()
+
+        if cdp is not None and rate != 1.0:
+            cdp.send("Emulation.setCPUThrottlingRate", {"rate": rate})
+            result["cpu_throttle_rate"] = rate
+        result["paint_floor_ms"] = round(page.evaluate(PAINT_FLOOR_JS, 9), 2)
+        result.update(page.evaluate(CONTROLS_JS, [CONTROL_SLEEP_MS, CONTROL_BUSY_ITERS]))
+
+        reps = []
+        for index in range(REPEATS):
+            info(f"  {engine} {size} models @{rate}x: repetition {index + 1}/{REPEATS}")
+            rep: dict = {}
+            rep["open"] = page.evaluate(
+                OPEN_JS, [size, ACTION_TIMEOUT_MS, SETTLE_POLL_MS, STILL_POLLS]
+            )
+            # OPEN_JS reopens on Recommended, so the tab has to be reselected before the search.
+            page.evaluate(
+                """() => {
+                    const tab = window.__pickerScale.onDeviceTab();
+                    if (tab) tab.click();
+                }"""
+            )
+            page.wait_for_function(
+                "(n) => window.__pickerScale.counts().rows >= n",
+                arg = size,
+                timeout = ACTION_TIMEOUT_MS,
+            )
+            rep["search"] = page.evaluate(
+                SEARCH_JS, [KEYSTROKES, ACTION_TIMEOUT_MS, SETTLE_POLL_MS, STILL_POLLS]
+            )
+            page.wait_for_function(
+                "(n) => window.__pickerScale.counts().rows >= n",
+                arg = size,
+                timeout = ACTION_TIMEOUT_MS,
+            )
+            reps.append(rep)
+        if cdp is not None and rate != 1.0:
+            cdp.send("Emulation.setCPUThrottlingRate", {"rate": 1})
+        result["raw_repetitions"] = reps
+        result["repetitions"] = REPEATS
+        result["actions"] = summarise(reps)
+        result["stray_api_requests"] = len(stray)
+        result["stray_api_urls"] = sorted({u[len(BASE) :] for u in stray})[:8]
+        result["console_errors"] = len(errors)
+        result["first_console_error"] = errors[0] if errors else "-"
+        result["console_warnings"] = len(warnings)
+        result["first_console_warning"] = warnings[0] if warnings else "-"
+    finally:
+        page.close()
+    return result
+
+
+HEADLINE = {"open": "convergedMs", "search": "median_sample_ms"}
+
+
+def summarise(reps: list) -> dict:
+    out: dict = {}
+    for action in ACTIONS:
+        rows = [r.get(action) for r in reps]
+        if any(r is None for r in rows):
+            out[action] = {"ran": False}
+            continue
+        merged: dict = {"ran": True, "repetitions": len(rows)}
+        keys = set()
+        for row in rows:
+            for key, value in row.items():
+                # `value is None` is deliberately a key too: a timing that was null in every
+                # repetition would otherwise be absent, and the failure check would KeyError
+                # instead of reporting the action that never happened.
+                if value is None or (
+                    isinstance(value, (int, float)) and not isinstance(value, bool)
+                ):
+                    keys.add(key)
+        for key in sorted(keys):
+            merged[key] = median([r.get(key) for r in rows])
+        for key, _pick in (("metrics", None),):
+            for metric in ("worst_frame_ms", "frames_over_33", "frames"):
+                merged[metric] = median([r[key][metric] for r in rows])
+        merged["settle_timed_out"] = any(bool(r.get("settleTimedOut")) for r in rows)
+        merged["domQuery"] = rows[-1].get("domQuery")
+        merged["per_repetition"] = [r.get(HEADLINE[action]) for r in rows]
+        out[action] = merged
+    return out
+
+
+def run() -> dict:
+    results: dict = {
+        "label": LABEL,
+        "base": BASE,
+        "sizes": SIZES,
+        "engines": ENGINES,
+        "rates": RATES,
+        "repetitions": REPEATS,
+        "by_engine": {},
+    }
+    with sync_playwright() as p:
+        for engine in ENGINES:
+            launcher = getattr(p, engine)
+            kwargs = {"headless": os.environ.get("SMOKE_HEADLESS", "1") == "1"}
+            if engine == "chromium":
+                kwargs["args"] = chromium_launch_args()
+            browser = launcher.launch(**kwargs)
+            context = browser.new_context(viewport = {"width": 1440, "height": 900})
+            context.add_init_script(RECORDER_INIT)
+            context.route(
+                re.compile(rf"^{re.escape(BASE)}/api/"),
+                lambda route: route.fulfill(
+                    status = 200, content_type = "application/json", body = "{}"
+                ),
+            )
+            by_rate: dict = {}
+            engine_rates = RATES if engine == "chromium" else [1.0]
+            for rate in engine_rates:
+                by_size: dict = {}
+                for size in SIZES:
+                    info(f"measuring {engine} at {size} models, cpu rate {rate}x")
+                    try:
+                        by_size[str(size)] = measure_cell(context, engine, size, rate)
+                    except Exception as exc:  # noqa: BLE001 - the message is the whole point
+                        info(f"CRASHED {engine} {size} @{rate}x: {type(exc).__name__}: {exc}")
+                        by_size[str(size)] = {
+                            "models_requested": size,
+                            "engine": engine,
+                            "crashed": f"{type(exc).__name__}: {exc}"[:400],
+                        }
+                by_rate[str(rate)] = {"by_size": by_size}
+            results["by_engine"][engine] = {"version": browser.version, "by_rate": by_rate}
+            context.close()
+            browser.close()
+    return results
+
+
+def _action(action: str, key: str):
+    return lambda r: r["actions"][action][key]
+
+
+TABLE_ROWS = (
+    ("models requested", lambda r: r["models_requested"]),
+    ("models seeded", lambda r: r["plan"]["models"]),
+    ("rows rendered", lambda r: r["counts"]["rows"]),
+    ("row menu triggers", lambda r: r["counts"]["rowMenuTriggers"]),
+    ("tooltip triggers", lambda r: r["counts"]["tooltipTriggers"]),
+    ("panel dom nodes", lambda r: r["counts"]["panelNodes"]),
+    ("document dom nodes", lambda r: r["counts"]["domNodes"]),
+    ("cpu throttle rate", lambda r: r["cpu_throttle_rate"]),
+    ("CONTROL sleep ms (flat)", lambda r: r["control_sleep_ms"]),
+    ("CONTROL busy ms (scales)", lambda r: r["control_busy_ms"]),
+    ("paint floor ms", lambda r: r["paint_floor_ms"]),
+    ("seed api requests", lambda r: r["seed_api_requests"]),
+    ("action api requests", lambda r: r["stray_api_requests"]),
+    ("action api urls", lambda r: "|".join(r["stray_api_urls"]) or "-"),
+    ("seed console errors", lambda r: r["seed_console_errors"]),
+    ("first seed error", lambda r: r["first_seed_error"]),
+    ("action console errors", lambda r: r["console_errors"]),
+    ("first action error", lambda r: r["first_console_error"]),
+    ("action console warnings", lambda r: r["console_warnings"]),
+    ("first action warning", lambda r: r["first_console_warning"]),
+    ("open ran", _action("open", "ran")),
+    ("open first row ms", _action("open", "firstRowMs")),
+    ("open converged ms", _action("open", "convergedMs")),
+    ("open settle ms", _action("open", "settleMs")),
+    ("open worst frame ms", _action("open", "worst_frame_ms")),
+    ("open frames over 33ms", _action("open", "frames_over_33")),
+    ("open rows after", _action("open", "rows")),
+    (
+        "open converged per repetition",
+        lambda r: "/".join(str(v) for v in r["actions"]["open"]["per_repetition"]),
+    ),
+    ("search ran", _action("search", "ran")),
+    ("search median keystroke ms", _action("search", "median_sample_ms")),
+    ("search worst keystroke ms", _action("search", "worst_sample_ms")),
+    ("search filtered ms", _action("search", "filteredMs")),
+    ("search settle ms", _action("search", "settleMs")),
+    ("search worst frame ms", _action("search", "worst_frame_ms")),
+    ("search frames over 33ms", _action("search", "frames_over_33")),
+    ("search rows before", _action("search", "rowsBefore")),
+    ("search rows after", _action("search", "rowsAfter")),
+    ("search dom query", _action("search", "domQuery")),
+    (
+        "search keystroke per repetition",
+        lambda r: "/".join(str(v) for v in r["actions"]["search"]["per_repetition"]),
+    ),
+)
+
+# The third field is how many double-rAF waits the metric is clocked across; each carries its own
+# ~33ms vsync floor, and left in it compresses every ratio towards 1.
+GROWTH_AXES = (
+    ("open first row ms", _action("open", "firstRowMs"), 1),
+    ("open converged ms", _action("open", "convergedMs"), 1),
+    ("open settle ms", _action("open", "settleMs"), 0),
+    ("search median keystroke ms", _action("search", "median_sample_ms"), 1),
+    ("search filtered ms", _action("search", "filteredMs"), 0),
+    ("search settle ms", _action("search", "settleMs"), 0),
+    ("open worst frame ms", _action("open", "worst_frame_ms"), 0),
+    ("search worst frame ms", _action("search", "worst_frame_ms"), 0),
+)
+
+
+def print_table(results: dict) -> None:
+    columns = [
+        (engine, rate, str(size))
+        for engine in results["engines"]
+        for rate in results["by_engine"][engine]["by_rate"]
+        for size in results["sizes"]
+    ]
+    rows = []
+    for name, pick in TABLE_ROWS:
+        cells = []
+        for engine, rate, size in columns:
+            try:
+                value = pick(results["by_engine"][engine]["by_rate"][rate]["by_size"][size])
+                cells.append("-" if value is None else str(value))
+            except (KeyError, TypeError):
+                cells.append("-")
+        rows.append((name, cells))
+    label_width = max(len(n) for n, _ in rows) + 2
+    headers = [f"{e[:4]}{float(r):g}x/{s}" for e, r, s in columns]
+    width = max([len(c) for _, cs in rows for c in cs] + [len(h) for h in headers]) + 2
+    header = "".ljust(label_width) + "".join(h.rjust(width) for h in headers)
+    info(header)
+    info("-" * len(header))
+    for name, cells in rows:
+        info(name.ljust(label_width) + "".join(c.rjust(width) for c in cells))
+
+
+def report_growth(results: dict) -> dict:
+    report: dict = {}
+    for engine in results["engines"]:
+        for rate, bucket in results["by_engine"][engine]["by_rate"].items():
+            cells = bucket["by_size"]
+            per_axis: dict = {}
+            for name, pick, floored in GROWTH_AXES:
+                try:
+                    small_row = cells[str(results["sizes"][0])]
+                    large_row = cells[str(results["sizes"][-1])]
+                    small = pick(small_row)
+                    large = pick(large_row)
+                except (KeyError, TypeError):
+                    small = large = None
+                if small is None or large is None:
+                    per_axis[name] = {
+                        "small": None,
+                        "large": None,
+                        "ratio": None,
+                        "discriminated": False,
+                        "reason": "not recorded",
+                    }
+                    continue
+                if floored:
+                    small -= floored * small_row["paint_floor_ms"]
+                    large -= floored * large_row["paint_floor_ms"]
+                small = round(small, 2)
+                large = round(large, 2)
+                if small <= 0:
+                    per_axis[name] = {
+                        "small": small,
+                        "large": large,
+                        "ratio": None,
+                        "discriminated": False,
+                        "reason": (
+                            "at or under the paint floor at the smallest size, so this axis has "
+                            "no room to move"
+                        ),
+                    }
+                    continue
+                ratio = round(large / small, 2)
+                per_axis[name] = {
+                    "small": small,
+                    "large": large,
+                    "ratio": ratio,
+                    "discriminated": ratio > DISCRIMINATION_RATIO,
+                    "reason": "-",
+                }
+            report[f"{engine}@{rate}x"] = per_axis
+    return report
+
+
+def print_growth(results: dict, report: dict) -> None:
+    for key, per_axis in report.items():
+        info("")
+        info(
+            f"growth on {key} ({results['sizes'][0]} -> {results['sizes'][-1]} models, median of "
+            f"{results['repetitions']} repetitions)"
+        )
+        for name, row in per_axis.items():
+            mark = "DISCRIMINATES" if row["discriminated"] else "flat"
+            if row["ratio"] is None:
+                info(
+                    f"  {name:<32} {row['small']!s:>10} -> {row['large']!s:>10}       -  "
+                    f"{mark} ({row['reason']})"
+                )
+                continue
+            info(
+                f"  {name:<32} {row['small']:>10} -> {row['large']:>10}  {row['ratio']:>7.2f}x  "
+                f"{mark}"
+            )
+
+
+def print_ladder(results: dict) -> None:
+    for engine in results["engines"]:
+        buckets = results["by_engine"][engine]["by_rate"]
+        base = buckets.get("1.0") or buckets.get("1")
+        if base is None or len(buckets) < 2:
+            continue
+        info("")
+        info(f"cpu throttling ladder on {engine} (ratio against each size's own 1x)")
+        for size in results["sizes"]:
+            info(f"  {size} models")
+            base_row = base["by_size"].get(str(size), {})
+            for rate, bucket in buckets.items():
+                row = bucket["by_size"].get(str(size), {})
+                if "crashed" in row or "crashed" in base_row:
+                    info(f"    {rate:>5}x  crashed")
+                    continue
+
+                def ratio(pick):
+                    try:
+                        a = pick(base_row)
+                        b = pick(row)
+                    except (KeyError, TypeError):
+                        return None
+                    if not a or b is None:
+                        return None
+                    return round(b / a, 2)
+
+                info(
+                    f"    {rate:>5}x  "
+                    f"CONTROL sleep {ratio(lambda r: r['control_sleep_ms'])}x  "
+                    f"CONTROL busy {ratio(lambda r: r['control_busy_ms'])}x  "
+                    f"open converged {ratio(_action('open', 'convergedMs'))}x  "
+                    f"search keystroke {ratio(_action('search', 'median_sample_ms'))}x  "
+                    f"search settle {ratio(_action('search', 'settleMs'))}x"
+                )
+
+
+def harness_failures(results: dict, report: dict) -> list:
+    failures: list = []
+    for engine in results["engines"]:
+        buckets = results["by_engine"][engine]["by_rate"]
+        base = buckets.get("1.0") or buckets.get("1")
+        for rate, bucket in buckets.items():
+            for size in results["sizes"]:
+                row = bucket["by_size"][str(size)]
+                where = f"{engine} at {size} models @{rate}x"
+                if "crashed" in row:
+                    failures.append(f"{where} crashed: {row['crashed']}")
+                    continue
+                if row["stray_api_requests"]:
+                    failures.append(
+                        f"{where} let {row['stray_api_requests']} /api/ request(s) reach the "
+                        f"network during the measured actions ({row['stray_api_urls']}); the "
+                        "timings include a round trip"
+                    )
+                for phase, count, first in (
+                    ("seeding", row["seed_console_errors"], row["first_seed_error"]),
+                    ("the measured actions", row["console_errors"], row["first_console_error"]),
+                ):
+                    if count:
+                        failures.append(
+                            f"{where} logged {count} console/page error(s) during {phase}, the "
+                            f"first being {first!r}; an application exception is not engine "
+                            "chatter and the timings around it are not measurements"
+                        )
+                if row["console_warnings"] > CONSOLE_WARNING_ALLOWANCE:
+                    failures.append(
+                        f"{where} logged {row['console_warnings']} console warnings during the "
+                        f"measured actions, the first being {row['first_console_warning']!r}"
+                    )
+                counts = row["counts"]
+                if counts["rows"] < size:
+                    failures.append(
+                        f"{where} rendered {counts['rows']} of {size} rows; the seed did not land"
+                    )
+                for action in ACTIONS:
+                    if not row["actions"][action].get("ran"):
+                        failures.append(f"{where} could not run the {action} action at all")
+                        continue
+                    if row["actions"][action].get("settle_timed_out"):
+                        failures.append(
+                            f"{where} ran the {action} action but it never held still, so its "
+                            "settle time is the timeout rather than a measurement"
+                        )
+                opened = row["actions"]["open"]
+                if opened.get("ran"):
+                    if opened["firstRowMs"] is None:
+                        failures.append(f"{where} opened the picker and no row ever appeared")
+                    if opened["convergedMs"] is None:
+                        failures.append(f"{where} opened the picker and it never reached {size}")
+                searched = row["actions"]["search"]
+                if searched.get("ran"):
+                    # The typed characters have to have reached the input, or the whole column is
+                    # the paint floor with a plausible-looking number on it.
+                    if not searched.get("domQuery"):
+                        failures.append(
+                            f"{where} typed into the picker search and the input stayed empty; "
+                            "the keystrokes never reached React"
+                        )
+                    # And they have to have CHANGED something, or the filter was never exercised.
+                    if searched["rowsAfter"] is not None and searched["rowsBefore"] is not None:
+                        if searched["rowsAfter"] >= searched["rowsBefore"]:
+                            failures.append(
+                                f"{where} typed a query and the row count did not fall "
+                                f"({searched['rowsBefore']} -> {searched['rowsAfter']}); the "
+                                "filter did not run, so its column is timing nothing"
+                            )
+            if base is not None and float(rate) > 1.0:
+                for size in results["sizes"]:
+                    row = bucket["by_size"][str(size)]
+                    base_row = base["by_size"][str(size)]
+                    if "crashed" in row or "crashed" in base_row:
+                        continue
+                    drift = row["control_sleep_ms"] / (base_row["control_sleep_ms"] or 1)
+                    if drift > CONTROL_FLAT_TOLERANCE or drift < 1 / CONTROL_FLAT_TOLERANCE:
+                        failures.append(
+                            f"{engine} at {size} models: the timer-bound CONTROL moved "
+                            f"{drift:.2f}x between 1x and {rate}x; it has to stay flat, so no "
+                            "ratio in this run is readable"
+                        )
+                    realised = row["control_busy_ms"] / (base_row["control_busy_ms"] or 1)
+                    if realised < float(rate) * CONTROL_SCALE_FLOOR:
+                        failures.append(
+                            f"{engine} at {size} models: the CPU-bound control only slowed "
+                            f"{realised:.2f}x at a requested {rate}x; the throttling did not land"
+                        )
+    if len(results["sizes"]) >= 2:
+        for key, per_axis in report.items():
+            if not any(row["discriminated"] for row in per_axis.values()):
+                failures.append(
+                    f"on {key} no measured axis rose by more than {DISCRIMINATION_RATIO}x from "
+                    f"{results['sizes'][0]} to {results['sizes'][-1]} models; the numbers above "
+                    "cannot size any change"
+                )
+    return failures
+
+
+def main() -> int:
+    vite = None
+    if OWNS_SERVER:
+        info(f"starting vite dev server on port {PORT}")
+        vite = start_vite(PORT)
+    try:
+        wait_for_smoke_page(
+            f"{BASE}/smoke-model-picker-scale.html",
+            "smoke-model-picker-scale-main.tsx",
+            proc = vite,
+            info = info,
+        )
+        results = run()
+    finally:
+        if vite is not None:
+            stop_process(vite)
+            info("vite stopped")
+
+    report = report_growth(results)
+    results["growth"] = report
+    out = OUT / f"{LABEL}.json"
+    out.write_text(json.dumps(results, indent = 2), encoding = "utf-8")
+    print_table(results)
+    print_growth(results, report)
+    print_ladder(results)
+    info(f"wrote {out}")
+    failures = harness_failures(results, report)
+    for problem in failures:
+        info(f"HARNESS-BROKEN {problem}")
+    if failures:
+        return 1
+    info("measurement only: no budgets are asserted here, so this exits 0 on any timing.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/studio/test_playwright_suites_run_in_ci.py
+++ b/tests/studio/test_playwright_suites_run_in_ci.py
@@ -40,6 +40,13 @@ NOT_IN_CI = {
     # can go wrong silently, the verdict in harness_failures, is driven without a
     # browser by test_autoscroll_harness_contract.py, which CI does run.
     "playwright_thread_weight.py",
+    # The same shape as playwright_thread_weight.py: a measurement harness, not a gate. It prints
+    # the per-N cost table the picker deferral was sized from and says so in its own docstring
+    # ("THIS HARNESS MEASURES, IT DOES NOT GATE"); it asserts no budget, and the sizes that make
+    # its curve mean anything (1000 models across a 1x/2x/4x CPU ladder) cost tens of minutes. The
+    # BEHAVIOUR it exists to protect is gated by playwright_model_picker_deferred.py, which
+    # studio-model-picker-ci.yml runs on every change to the picker.
+    "playwright_model_picker_scale.py",
 }
 
 


### PR DESCRIPTION
## What happens before

The model picker's "On Device" list renders every cached repo, and every row mounted three Radix
tooltips and a Radix dropdown menu whether or not anything had ever pointed at it. None of the four
is on screen until the row is hovered or focused: a closed tooltip draws nothing, and the row's
gear and dots buttons sit under `opacity-0` until `group-hover` / `focus-within` lifts them.

At 200 downloaded models that is 604 tooltip triggers and 200 dropdown roots for a panel nobody has
touched; at 1000 it is 3004 and 1000. Opening the picker costs about 1.16 s at 200 models and 6.3 s
at 1000 on a dev build, and a single keystroke in its search box costs 150 ms at 200 models.

A CPU profile of one open at 1000 models (CDP sampling profiler, 100 us, 6.8 s wall) says where it
goes, and it is not the picker's own logic:

```
  jsx / jsxDEV / ReactElement          ~31%   element creation for the rows
  react-dom client                     18.4%  mounting and committing them
  (program)                            17.1%  V8 host
  get scrollTop                         5.9%  a forced layout per updateListFades over 25,767 nodes
  getCssDimensions (floating-ui)        5.3%  the panel's popper measuring the same subtree
  radix Presence effects                5.4%  one per portal, 3004 + 1000 of them
  pickers.tsx itself                    0.5%  42.7 ms out of 7931 ms
```

## What happens after

Three changes, none of which alters what is drawn.

1. `useRovingModelList` looked its option ids up with `optionKeys.indexOf(key)` inside
   `getOptionProps`, which every row calls while it renders: a linear scan per row, so O(N^2) string
   comparisons to draw N rows. It is a `useMemo`d `Map` now, keeping the first occurrence of a
   duplicated key exactly as `indexOf` resolved it.
2. New `row-activation.tsx`: each On Device row is wrapped in a `ModelRowShell` that starts
   INACTIVE. An inactive row renders the same markup with the tooltip wrappers left off and the
   dots button rendered as an identical, focusable placeholder carrying the same `aria-haspopup`,
   `aria-expanded`, `data-state` and `data-slot` a closed Radix trigger has. The first pointer or
   focus that reaches the row activates it, which mounts exactly what the merge base always had.
   Everything outside such a shell reads the context default, `true`, so the Hub catalog,
   Recommended and every other list are untouched.
3. `model-row-menu.tsx` and `model-load-settings-action.tsx` follow that context. The menu's
   update-completion subscription stays in the always-mounted shell, so a row still learns that a
   managed update it started has finished.

Two things are replayed when a row activates, because the swap would otherwise lose them:

- FOCUS. Activating replaces the element that has focus, which would drop focus to `<body>` mid-Tab.
- HOVER. Radix opens a tooltip on `pointermove`, not on `pointerenter`, so a pointer that enters a
  row and holds still would never open anything. One synthetic `pointermove` is dispatched at the
  recorded position, and only if that position is still inside the row.

Coarse-pointer devices opt out entirely: they show the row actions at all times, a tap is a
pointerdown and a click on the same node, and there is no hover to trade on, so they render exactly
what the merge base rendered.

## Is this real or fake

Real, and it does not wash out under throttling.

`studio/frontend/smoke-model-picker-scale.html` mounts the REAL `ModelSelector` and feeds it from
one in-memory fixture; `tests/studio/playwright_model_picker_scale.py` drives it. Two dev servers,
one per tree, alternating arm by arm with the order flipped every pair, three pairs per cell.
Headline is the MEDIAN OF PAIRED RATIOS, head over base, never the ratio of two medians.

```
             open converged ms            search keystroke ms         search filtered ms
          base     head   ratio        base     head  ratio        base     head   ratio
200 @1x  1158.3    539.5  0.449       150.0     16.6  0.092*      1685.3    871.8  0.530
200 @2x  3457.5   1853.4  0.536       499.5     50.0  0.100       3589.1   1312.1  0.371
200 @4x  6704.0   4569.4  0.682       965.6    683.3  0.630       9179.8   3916.8  0.428
1000@1x  6331.0   3560.7  0.563       558.3    116.6  0.209       4171.9   1860.5  0.446
1000@2x 12106.7   7661.6  0.624      2217.1    949.9  0.416      12730.6   5936.5  0.456
1000@4x 31747.5  15318.9  0.486      4031.3   2049.7  0.496      37849.0  12869.8  0.350
```

CONTROL ARM, which is what makes the rest readable. A timer-bound 200 ms sleep must stay flat
across the CPU ladder and a fixed integer loop must scale with it:

```
                  CONTROL sleep (flat)    CONTROL busy (scales)
  base 200  1x/2x/4x   1.00 / 1.00 / 1.00      1.00 / 1.93 / 3.70
  base 1000 1x/2x/4x   1.00 / 1.00 / 1.02      1.00 / 1.90 / 3.80
  head 200  1x/2x/4x   1.00 / 1.00 / 1.00      1.00 / 1.74 / 3.54
  head 1000 1x/2x/4x   1.00 / 1.00 / 1.00      1.00 / 2.06 / 3.94
```

`*` the 200 models at 1x keystroke cell floor-subtracts to 0.092 and one of its three pairs is
exactly 0.000. That is not a zero-cost claim: it means the head's keystroke is no longer
distinguishable from a paint. RAW, unsubtracted, that cell is **183.5 -> 50.0 ms (0.231)**, and
that is the number to quote.

The table above is the ladder run against the exact commit being merged. An earlier, identical
ladder against the same change before its last two commits agreed: open converged 0.468 / 0.554 /
0.634 at 200 models and 0.622 / 0.629 / 0.491 at 1000, with the same flat timer control, and the
raw 200 models at 1x keystroke cell at 166.8 -> 33.3 ms.

Honest about the shape: this lowers the CONSTANT, it does not flatten the CURVE. Open converged
from 200 to 1000 models is 5.47x on the base and 6.60x on the head in this run (5.05x and 7.13x in
the earlier one), because N rows still cost N React mounts.

Virtualization is what would change the curve, and it is filed as #9232 rather than shipped here.
This is a list people READ rather than skim: they are looking for one model among the ones they
own, by name and by size. Windowing it puts three things at risk that a screenshot pair would not
catch. The scrollbar stops being proportional to the list unless every row is measured. Browser
find-in-page and Ctrl+F stop seeing the rows that are not mounted. And the list stops announcing
its own size to a screen reader unless the ARIA row and count attributes are set by hand, on a
roving-tabindex list whose option ids are indices into the full key list and whose `focusOption`
finds rows with `document.getElementById`, which only works while the row is in the DOM. That is a
visible, behavioural change and it deserves its own PR with its own before/after, not a paragraph
at the end of a performance one.

The measurement gates itself. Every one of the 18 pairs had to agree on the fixture after both arms
existed, and did: panel DOM nodes 5234 = 5234 at 200 models and 25767 = 25767 at 1000, dots buttons
200 = 200 and 1000 = 1000. What differs is the machinery: tooltip triggers 604 -> 4 at 200 models
and 3004 -> 4 at 1000 (the four are the picker's own chrome). A pair where those did NOT differ
would have been one tree measured twice, and the run refuses it.

## Does merging break anything

The rendered screen is the risk, so it was diffed per pixel rather than eyeballed. Both arms, same
fixture, animations and the text caret pinned off, panel element shots:

```
state       identical   differing px   max channel delta    tooltip triggers
cold          YES            0               0              604 -> 4
scrolled      YES            0               0              604 -> 4
hover         no             6               1              604 -> 7
dot           YES            0               0              604 -> 7
menu          YES            0               0              604 -> 7
focus         YES            0               0              604 -> 10
search        YES            0               0              169 -> 4
```

The `hover` pair differs by six pixels at a maximum channel delta of 1/255, which is subpixel
antialiasing on one glyph edge. Numeric identity holds in every state as well: rows, panel DOM
nodes, document DOM nodes, dots-button count, rendered text length (what find-in-page sees) and the
list's `scrollHeight` (the scrollbar proportions) are all equal between the arms, the row menu's
items are `Pin to top / Reveal in Folder / Delete` on both sides, and the focused row's
`document.activeElement` is a picker option on both.

Old pathways, checked rather than assumed, by `tests/studio/playwright_model_picker_deferred.py`
(22 checks, and each one fails on its own mutant):

- hovering a row with ONE mouse move opens the same format tooltip and the same 700 ms row tooltip;
- keyboard focus activates the row, focus stays on the option instead of falling to `<body>`, and
  Tab from the row reaches that row's own action buttons;
- the dots menu opens with the same three items, including from a press on a row that has never
  been hovered;
- a click in ONE gesture selects the model and closes the panel, and so does Enter on a focused row;
- a coarse-pointer context mounts all 604 triggers up front, i.e. it renders the merge base's tree,
  and a tap on the dots opens the menu.

That click check earned its place. The first version of this change activated the row from the
`pointerenter` handler, and a click is move-down-up in one gesture: the swap landed between the
down and the up, the browser fired the click on the nearest common ancestor instead of the row
button, and the model silently failed to select. `flushSync` does not fix it (`pointerenter` can be
dispatched while React is already committing, and React then refuses the flush and logs), and
neither does swapping from the click's capture phase (React skips listeners whose instance has been
unmounted, so it ate the row's own onClick in the bubble phase). A pointer now arms the swap for
the next frame, a press in the row holds it, and the click handler releases the hold and schedules
the swap for after the dispatch.

CI wiring, because a suite nothing runs is not a gate: the behaviour probe gets its own workflow,
`.github/workflows/studio-model-picker-ci.yml`, which runs it on any change under
`studio/frontend/src/features/model-picker/**` or to the suites themselves. Its own file rather
than a step in `studio-frontend-ci.yml` so a picker change cannot conflict with the frontend CI
file every other surface also edits. The scale harness joins `NOT_IN_CI` in
`tests/studio/test_playwright_suites_run_in_ci.py` with a reason, on the same footing as
`playwright_thread_weight.py`: it measures and sets no budget, and the sizes that make its curve
mean anything cost tens of minutes.

Gates: `npm run typecheck` clean; `npm run build` clean; `npm test` 3789 of 3790 pass, the single
failure being `tests/queued-model-capabilities.test.ts`, which fails identically on this branch's
base (pass 0 / fail 1 there too) and is not touched here; `npx eslint` on the changed files reports
0 errors and 0 new warnings, with `pickers.tsx` at exactly the 6 errors and 14 warnings it already
reports on the base.
