### PR TITLE
Prefer the .cmd sibling when Windows resolves an extensionless npm shim

### DIFF
--- a/unsloth_cli/claude_subagent_mcp.py
+++ b/unsloth_cli/claude_subagent_mcp.py
@@ -24,6 +24,7 @@ from unsloth_cli.commands.start import (
     _claude_flags,
     _claude_local_env,
     _prefer_windows_cmd_sibling,
+    _resolved_launch_command,
     _wsl_shim_env,
 )
 
@@ -209,8 +210,10 @@ def run_local_agent(
         popen_kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
     else:
         popen_kwargs["start_new_session"] = True
+    # --append-system-prompt and the task both span lines, and cmd.exe splits
+    # CR/LF inside `%*`, so a rescued .cmd goes through the npm parser.
     process = subprocess.Popen(
-        [executable, *command[1:]],
+        _resolved_launch_command(executable, command[1:], child_env),
         **popen_kwargs,
     )
     deadline = _timeout_seconds()

--- a/unsloth_cli/claude_subagent_mcp.py
+++ b/unsloth_cli/claude_subagent_mcp.py
@@ -210,8 +210,8 @@ def run_local_agent(
         popen_kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
     else:
         popen_kwargs["start_new_session"] = True
-    # --append-system-prompt and the task both span lines, and cmd.exe splits
-    # CR/LF inside `%*`, so a rescued .cmd goes through the npm parser.
+    # Same CR/LF hazard as the Codex bridge: --append-system-prompt and the task
+    # both span lines, so resolve npm shims rather than spawning the .cmd raw.
     process = subprocess.Popen(
         _resolved_launch_command(executable, command[1:], child_env),
         **popen_kwargs,

--- a/unsloth_cli/claude_subagent_mcp.py
+++ b/unsloth_cli/claude_subagent_mcp.py
@@ -23,6 +23,7 @@ from unsloth_cli.commands.start import (
     _SUBAGENT_PLAN_INSTRUCTIONS,
     _claude_flags,
     _claude_local_env,
+    _prefer_windows_cmd_sibling,
     _wsl_shim_env,
 )
 
@@ -144,7 +145,7 @@ def run_local_agent(
     local_env = _claude_local_env(base, key, entry)
     child_env = dict(os.environ)
 
-    executable = shutil.which("claude")
+    executable = _prefer_windows_cmd_sibling(shutil.which("claude"))
     if executable is None:
         raise RuntimeError("`claude` is not installed or is not on PATH.")
     cancel_event = cancel_event or threading.Event()

--- a/unsloth_cli/codex_subagent_mcp.py
+++ b/unsloth_cli/codex_subagent_mcp.py
@@ -136,8 +136,8 @@ def run_local_agent(task: str, cancel_event: threading.Event | None = None) -> s
         popen_kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
     else:
         popen_kwargs["start_new_session"] = True
-    # The prompt always spans lines, and cmd.exe splits CR/LF inside `%*`, so a
-    # rescued .cmd has to go through the npm parser instead of being spawned raw.
+    # cmd.exe splits CR/LF inside `%*` and the prompt always spans lines, so
+    # resolve npm shims here rather than spawning the .cmd raw.
     launch_command = _resolved_launch_command(executable, command[1:], child_env)
     process = subprocess.Popen(launch_command, **popen_kwargs)
     try:

--- a/unsloth_cli/codex_subagent_mcp.py
+++ b/unsloth_cli/codex_subagent_mcp.py
@@ -26,6 +26,7 @@ from unsloth_cli.commands.start import (
     _SUBAGENT_INSTRUCTIONS,
     _merge_wslenv,
     _prefer_windows_cmd_sibling,
+    _resolved_launch_command,
     _wsl_shim_env,
 )
 
@@ -135,7 +136,10 @@ def run_local_agent(task: str, cancel_event: threading.Event | None = None) -> s
         popen_kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
     else:
         popen_kwargs["start_new_session"] = True
-    process = subprocess.Popen([executable, *command[1:]], **popen_kwargs)
+    # The prompt always spans lines, and cmd.exe splits CR/LF inside `%*`, so a
+    # rescued .cmd has to go through the npm parser instead of being spawned raw.
+    launch_command = _resolved_launch_command(executable, command[1:], child_env)
+    process = subprocess.Popen(launch_command, **popen_kwargs)
     try:
         while True:
             try:

--- a/unsloth_cli/codex_subagent_mcp.py
+++ b/unsloth_cli/codex_subagent_mcp.py
@@ -25,6 +25,7 @@ from unsloth_cli.commands.start import (
     _CODEX_SUBAGENT_ROUTING_INSTRUCTIONS,
     _SUBAGENT_INSTRUCTIONS,
     _merge_wslenv,
+    _prefer_windows_cmd_sibling,
     _wsl_shim_env,
 )
 
@@ -82,7 +83,7 @@ def _result_text(stdout: str) -> str:
 
 def run_local_agent(task: str, cancel_event: threading.Event | None = None) -> str:
     config = _config()
-    executable = shutil.which("codex")
+    executable = _prefer_windows_cmd_sibling(shutil.which("codex"))
     if executable is None:
         raise RuntimeError("`codex` is not installed or is not on PATH.")
     cancel_event = cancel_event or threading.Event()

--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -3206,11 +3206,12 @@ def _prefer_windows_cmd_sibling(executable: Optional[str]) -> Optional[str]:
     """Prefer the sibling .cmd when Windows resolved an extensionless npm/pnpm shim.
 
     cmd-shim writes ``to``, ``to.cmd`` and ``to.ps1``, and shutil.which can return
-    the extensionless POSIX shim, which CreateProcess rejects with WinError 193:
-    CPython 3.12.0 to 3.12.9 probe the bare name before PATHEXT (gh-127001), and a
-    PATHEXT containing "." does so on any version. Substituted only when the file
-    opens with a shebang, so a real PE keeps priority over a stale wrapper beside
-    it; matched on not-a-Windows-suffix so a dotted bin name is caught too.
+    the extensionless POSIX shim, which CreateProcess rejects with WinError 193.
+    Measured on windows-latest: 3.12.0 probes the bare name before PATHEXT
+    (gh-109590), and 3.12.1 onwards do not. A PATHEXT holding "." reaches the same
+    place on any version. Substituted only when the file opens with a shebang, so a
+    real PE keeps priority over a stale wrapper beside it; matched on
+    not-a-Windows-suffix so a dotted bin name is caught too.
     """
     if executable is None or os.name != "nt":
         return executable

--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -3205,14 +3205,12 @@ def _probe_env(**extra: str) -> dict:
 def _prefer_windows_cmd_sibling(executable: Optional[str]) -> Optional[str]:
     """Prefer the sibling .cmd when Windows resolved an extensionless npm/pnpm shim.
 
-    npm's cmd-shim writes ``to``, ``to.cmd`` and ``to.ps1``; pnpm's writer does the
-    same with the .cmd casing read from PATHEXT. shutil.which can hand back the
-    extensionless POSIX shim (CPython 3.12.0 offers the bare name first; earlier
-    entries on PATH can too), which CreateProcess rejects with WinError 193.
-    Substituted only when the resolved file opens with a shebang: CreateProcess can
-    run a PE binary regardless of its name, so a real executable keeps priority
-    over a stale wrapper beside it. Matched on not-a-Windows-suffix rather than
-    no-suffix so a dotted bin name (cmd-shim writes foo.bar.cmd) is rescued too.
+    cmd-shim writes ``to``, ``to.cmd`` and ``to.ps1``, and shutil.which can return
+    the extensionless POSIX shim, which CreateProcess rejects with WinError 193:
+    CPython 3.12.0 to 3.12.9 probe the bare name before PATHEXT (gh-127001), and a
+    PATHEXT containing "." does so on any version. Substituted only when the file
+    opens with a shebang, so a real PE keeps priority over a stale wrapper beside
+    it; matched on not-a-Windows-suffix so a dotted bin name is caught too.
     """
     if executable is None or os.name != "nt":
         return executable
@@ -3221,8 +3219,7 @@ def _prefer_windows_cmd_sibling(executable: Optional[str]) -> Optional[str]:
     with contextlib.suppress(OSError):
         with open(executable, "rb") as resolved_file:
             if resolved_file.read(2) == b"#!":
-                # .CMD is only for case-sensitive volumes; neither shim writer
-                # produces a .bat sibling.
+                # .CMD only matters on case-sensitive volumes; no writer emits .bat.
                 for extension in (".cmd", ".CMD"):
                     sibling = Path(executable + extension)
                     if sibling.is_file():
@@ -3239,8 +3236,8 @@ def _which_with_install_dirs(name: str) -> Optional[str]:
     original = os.environ.get("PATH")
     _augment_path_with_install_dirs()
     try:
-        # The callers spawn or probe this result directly, so the extensionless
-        # npm-shim rescue has to happen here, not only in _resolved_launch_command.
+        # Callers spawn this result directly, so the shim rescue is needed here
+        # too, not only in _resolved_launch_command.
         return _prefer_windows_cmd_sibling(shutil.which(name))
     finally:
         if original is None:
@@ -3548,8 +3545,8 @@ def _resolved_launch_command(
     environment: Optional[dict] = None,
 ) -> list:
     """Return an argv that preserves arguments through standard Windows npm shims."""
-    # _launch resolves with raw shutil.which, so the extensionless npm-shim
-    # rescue applies here too; the sibling then enters the parser below.
+    # _launch resolves with raw shutil.which, so rescue here too; the sibling
+    # then enters the parser below.
     executable = _prefer_windows_cmd_sibling(executable)
     if os.name == "nt" and Path(executable).suffix.lower() in {".cmd", ".bat"}:
         # cmd.exe treats CR/LF inside `%*` as command separators, and Windows

--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -3518,6 +3518,24 @@ def _resolved_launch_command(
     environment: Optional[dict] = None,
 ) -> list:
     """Return an argv that preserves arguments through standard Windows npm shims."""
+    if os.name == "nt" and Path(executable).suffix.lower() not in {
+        ".exe",
+        ".com",
+        ".cmd",
+        ".bat",
+        ".ps1",
+    }:
+        # npm/pnpm install an extensionless POSIX shim next to the Windows .cmd
+        # one, and shutil.which can hand back the former. CreateProcess rejects
+        # it with WinError 193, so prefer the sibling shim the parser below
+        # already understands. Matched on not-a-Windows-suffix rather than
+        # no-suffix so a dotted bin name (cmd-shim writes foo.bar.cmd) is
+        # rescued too. .CMD is only for case-sensitive volumes.
+        for extension in (".cmd", ".CMD", ".bat"):
+            sibling = Path(executable + extension)
+            if sibling.is_file():
+                executable = str(sibling)
+                break
     if os.name == "nt" and Path(executable).suffix.lower() in {".cmd", ".bat"}:
         # cmd.exe treats CR/LF inside `%*` as command separators, and Windows
         # PowerShell's native-command bridge also rewrites embedded quotes. Match

--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -3530,12 +3530,18 @@ def _resolved_launch_command(
         # it with WinError 193, so prefer the sibling shim the parser below
         # already understands. Matched on not-a-Windows-suffix rather than
         # no-suffix so a dotted bin name (cmd-shim writes foo.bar.cmd) is
-        # rescued too. .CMD is only for case-sensitive volumes.
-        for extension in (".cmd", ".CMD", ".bat"):
-            sibling = Path(executable + extension)
-            if sibling.is_file():
-                executable = str(sibling)
-                break
+        # rescued too, and only for files opening with a shebang: CreateProcess
+        # can run a PE binary regardless of its name, so a real executable
+        # keeps priority over a stale wrapper beside it. .CMD is only for
+        # case-sensitive volumes.
+        with contextlib.suppress(OSError):
+            with open(executable, "rb") as resolved_file:
+                if resolved_file.read(2) == b"#!":
+                    for extension in (".cmd", ".CMD", ".bat"):
+                        sibling = Path(executable + extension)
+                        if sibling.is_file():
+                            executable = str(sibling)
+                            break
     if os.name == "nt" and Path(executable).suffix.lower() in {".cmd", ".bat"}:
         # cmd.exe treats CR/LF inside `%*` as command separators, and Windows
         # PowerShell's native-command bridge also rewrites embedded quotes. Match

--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -3202,6 +3202,34 @@ def _probe_env(**extra: str) -> dict:
     return env
 
 
+def _prefer_windows_cmd_sibling(executable: Optional[str]) -> Optional[str]:
+    """Prefer the sibling .cmd when Windows resolved an extensionless npm/pnpm shim.
+
+    npm's cmd-shim writes ``to``, ``to.cmd`` and ``to.ps1``; pnpm's writer does the
+    same with the .cmd casing read from PATHEXT. shutil.which can hand back the
+    extensionless POSIX shim (CPython 3.12.0 offers the bare name first; earlier
+    entries on PATH can too), which CreateProcess rejects with WinError 193.
+    Substituted only when the resolved file opens with a shebang: CreateProcess can
+    run a PE binary regardless of its name, so a real executable keeps priority
+    over a stale wrapper beside it. Matched on not-a-Windows-suffix rather than
+    no-suffix so a dotted bin name (cmd-shim writes foo.bar.cmd) is rescued too.
+    """
+    if executable is None or os.name != "nt":
+        return executable
+    if Path(executable).suffix.lower() in {".exe", ".com", ".cmd", ".bat", ".ps1"}:
+        return executable
+    with contextlib.suppress(OSError):
+        with open(executable, "rb") as resolved_file:
+            if resolved_file.read(2) == b"#!":
+                # .CMD is only for case-sensitive volumes; neither shim writer
+                # produces a .bat sibling.
+                for extension in (".cmd", ".CMD"):
+                    sibling = Path(executable + extension)
+                    if sibling.is_file():
+                        return str(sibling)
+    return executable
+
+
 def _which_with_install_dirs(name: str) -> Optional[str]:
     # shutil.which(name), but searching the known agent install dirs too, so a version probe
     # resolves the same binary _launch() will (it augments PATH before it runs). Without this an
@@ -3211,7 +3239,9 @@ def _which_with_install_dirs(name: str) -> Optional[str]:
     original = os.environ.get("PATH")
     _augment_path_with_install_dirs()
     try:
-        return shutil.which(name)
+        # The callers spawn or probe this result directly, so the extensionless
+        # npm-shim rescue has to happen here, not only in _resolved_launch_command.
+        return _prefer_windows_cmd_sibling(shutil.which(name))
     finally:
         if original is None:
             os.environ.pop("PATH", None)
@@ -3238,13 +3268,13 @@ def _pinned_raw_github_commit(source: str) -> Optional[str]:
 def _npm_executable() -> Optional[str]:
     managed_node = _managed_node_tools()
     if not (managed_node and managed_node[2]):
-        executable = shutil.which("npm")
+        executable = _prefer_windows_cmd_sibling(shutil.which("npm"))
         if executable and not _wsl_windows_executable([executable]):
             return executable
         if executable:
             # WSL inherits the Windows PATH, so the rejected shim may shadow a native npm.
             for directory in os.get_exec_path():
-                candidate = shutil.which("npm", path = directory)
+                candidate = _prefer_windows_cmd_sibling(shutil.which("npm", path = directory))
                 if candidate and not _wsl_windows_executable([candidate]):
                     return candidate
 
@@ -3518,30 +3548,9 @@ def _resolved_launch_command(
     environment: Optional[dict] = None,
 ) -> list:
     """Return an argv that preserves arguments through standard Windows npm shims."""
-    if os.name == "nt" and Path(executable).suffix.lower() not in {
-        ".exe",
-        ".com",
-        ".cmd",
-        ".bat",
-        ".ps1",
-    }:
-        # npm/pnpm install an extensionless POSIX shim next to the Windows .cmd
-        # one, and shutil.which can hand back the former. CreateProcess rejects
-        # it with WinError 193, so prefer the sibling shim the parser below
-        # already understands. Matched on not-a-Windows-suffix rather than
-        # no-suffix so a dotted bin name (cmd-shim writes foo.bar.cmd) is
-        # rescued too, and only for files opening with a shebang: CreateProcess
-        # can run a PE binary regardless of its name, so a real executable
-        # keeps priority over a stale wrapper beside it. .CMD is only for
-        # case-sensitive volumes.
-        with contextlib.suppress(OSError):
-            with open(executable, "rb") as resolved_file:
-                if resolved_file.read(2) == b"#!":
-                    for extension in (".cmd", ".CMD", ".bat"):
-                        sibling = Path(executable + extension)
-                        if sibling.is_file():
-                            executable = str(sibling)
-                            break
+    # _launch resolves with raw shutil.which, so the extensionless npm-shim
+    # rescue applies here too; the sibling then enters the parser below.
+    executable = _prefer_windows_cmd_sibling(executable)
     if os.name == "nt" and Path(executable).suffix.lower() in {".cmd", ".bat"}:
         # cmd.exe treats CR/LF inside `%*` as command separators, and Windows
         # PowerShell's native-command bridge also rewrites embedded quotes. Match

--- a/unsloth_cli/tests/test_claude_subagent_mcp.py
+++ b/unsloth_cli/tests/test_claude_subagent_mcp.py
@@ -456,9 +456,8 @@ def test_timeout_can_be_disabled(monkeypatch):
 
 
 def test_local_child_is_spawned_through_the_shim_resolver(monkeypatch, tmp_path):
-    # --append-system-prompt and the task both span lines, and cmd.exe splits
-    # CR/LF inside `%*`, so a Windows .cmd must reach the npm parser rather than
-    # Popen directly (#9167). The parser itself is covered in test_start.py.
+    # Pins the wiring: a Windows .cmd must reach the npm parser, not Popen (#9167).
+    # The parser behaviour itself is covered in test_start.py.
     _stub_env(monkeypatch, tmp_path)
     monkeypatch.setattr(bridge.shutil, "which", lambda _: r"C:\\nodejs\\claude.cmd")
     captured = {}

--- a/unsloth_cli/tests/test_claude_subagent_mcp.py
+++ b/unsloth_cli/tests/test_claude_subagent_mcp.py
@@ -463,7 +463,11 @@ def test_local_child_is_spawned_through_the_shim_resolver(monkeypatch, tmp_path)
     monkeypatch.setattr(bridge.shutil, "which", lambda _: r"C:\\nodejs\\claude.cmd")
     captured = {}
 
-    def resolver(executable, arguments, environment = None):
+    def resolver(
+        executable,
+        arguments,
+        environment = None,
+    ):
         captured["resolver"] = (executable, arguments, environment)
         return ["C:\\nodejs\\node.exe", "cli.js", *arguments]
 

--- a/unsloth_cli/tests/test_claude_subagent_mcp.py
+++ b/unsloth_cli/tests/test_claude_subagent_mcp.py
@@ -453,3 +453,43 @@ def test_timeout_can_be_disabled(monkeypatch):
         assert bridge._timeout_seconds() == bridge._DEFAULT_TIMEOUT_SECONDS
     monkeypatch.delenv("UNSLOTH_CLAUDE_SUBAGENT_TIMEOUT")
     assert bridge._timeout_seconds() == bridge._DEFAULT_TIMEOUT_SECONDS
+
+
+def test_local_child_is_spawned_through_the_shim_resolver(monkeypatch, tmp_path):
+    # --append-system-prompt and the task both span lines, and cmd.exe splits
+    # CR/LF inside `%*`, so a Windows .cmd must reach the npm parser rather than
+    # Popen directly (#9167). The parser itself is covered in test_start.py.
+    _stub_env(monkeypatch, tmp_path)
+    monkeypatch.setattr(bridge.shutil, "which", lambda _: r"C:\\nodejs\\claude.cmd")
+    captured = {}
+
+    def resolver(executable, arguments, environment = None):
+        captured["resolver"] = (executable, arguments, environment)
+        return ["C:\\nodejs\\node.exe", "cli.js", *arguments]
+
+    class Process:
+        pid = 1234
+        returncode = 0
+
+        def communicate(self, timeout):
+            return json.dumps({"is_error": False, "result": "LOCAL_OK"}), ""
+
+        def poll(self):
+            return self.returncode
+
+    def popen(command, **kwargs):
+        captured["command"] = command
+        return Process()
+
+    monkeypatch.setattr(bridge, "_resolved_launch_command", resolver)
+    monkeypatch.setattr(bridge.subprocess, "Popen", popen)
+    assert bridge.run_local_agent("multi\nline\ntask") == "LOCAL_OK"
+
+    executable, arguments, environment = captured["resolver"]
+    assert executable == r"C:\\nodejs\\claude.cmd"
+    assert arguments[0] == "--model"
+    assert any("multi\nline\ntask" in argument for argument in arguments)
+    assert environment is not None
+    # Popen spawns the resolver's argv, not the .cmd.
+    assert captured["command"][0] == "C:\\nodejs\\node.exe"
+    assert any("multi\nline\ntask" in part for part in captured["command"])

--- a/unsloth_cli/tests/test_codex_subagent_mcp.py
+++ b/unsloth_cli/tests/test_codex_subagent_mcp.py
@@ -229,9 +229,8 @@ def test_local_child_process_is_stopped_on_cancellation(monkeypatch, tmp_path):
 
 
 def test_local_child_is_spawned_through_the_shim_resolver(monkeypatch, tmp_path):
-    # The prompt always spans lines, and cmd.exe splits CR/LF inside `%*`, so a
-    # Windows .cmd must reach the npm parser rather than Popen directly (#9167).
-    # The parser itself is covered in test_start.py; this pins the wiring.
+    # Pins the wiring: a Windows .cmd must reach the npm parser, not Popen (#9167).
+    # The parser behaviour itself is covered in test_start.py.
     config = _write_config(tmp_path)
     monkeypatch.setenv(bridge._CODEX_SUBAGENT_CONFIG_ENV, str(config))
     monkeypatch.setattr(bridge.shutil, "which", lambda _: r"C:\\nodejs\\codex.cmd")

--- a/unsloth_cli/tests/test_codex_subagent_mcp.py
+++ b/unsloth_cli/tests/test_codex_subagent_mcp.py
@@ -237,7 +237,11 @@ def test_local_child_is_spawned_through_the_shim_resolver(monkeypatch, tmp_path)
     monkeypatch.setattr(bridge.shutil, "which", lambda _: r"C:\\nodejs\\codex.cmd")
     captured = {}
 
-    def resolver(executable, arguments, environment = None):
+    def resolver(
+        executable,
+        arguments,
+        environment = None,
+    ):
         captured["resolver"] = (executable, arguments, environment)
         return ["C:\\nodejs\\node.exe", "index.js", *arguments]
 

--- a/unsloth_cli/tests/test_codex_subagent_mcp.py
+++ b/unsloth_cli/tests/test_codex_subagent_mcp.py
@@ -226,3 +226,53 @@ def test_local_child_process_is_stopped_on_cancellation(monkeypatch, tmp_path):
     with pytest.raises(RuntimeError, match = "cancelled"):
         bridge.run_local_agent("wait", cancel_event)
     assert stopped == [process]
+
+
+def test_local_child_is_spawned_through_the_shim_resolver(monkeypatch, tmp_path):
+    # The prompt always spans lines, and cmd.exe splits CR/LF inside `%*`, so a
+    # Windows .cmd must reach the npm parser rather than Popen directly (#9167).
+    # The parser itself is covered in test_start.py; this pins the wiring.
+    config = _write_config(tmp_path)
+    monkeypatch.setenv(bridge._CODEX_SUBAGENT_CONFIG_ENV, str(config))
+    monkeypatch.setattr(bridge.shutil, "which", lambda _: r"C:\\nodejs\\codex.cmd")
+    captured = {}
+
+    def resolver(executable, arguments, environment = None):
+        captured["resolver"] = (executable, arguments, environment)
+        return ["C:\\nodejs\\node.exe", "index.js", *arguments]
+
+    class Process:
+        pid = 1234
+        returncode = 0
+
+        def communicate(self, timeout):
+            return (
+                json.dumps(
+                    {
+                        "type": "item.completed",
+                        "item": {"type": "agent_message", "text": "LOCAL_OK"},
+                    }
+                ),
+                "",
+            )
+
+        def poll(self):
+            return self.returncode
+
+    def popen(command, **kwargs):
+        captured["command"] = command
+        return Process()
+
+    monkeypatch.setattr(bridge, "_resolved_launch_command", resolver)
+    monkeypatch.setattr(bridge.subprocess, "Popen", popen)
+    assert bridge.run_local_agent("multi\nline\ntask") == "LOCAL_OK"
+
+    executable, arguments, environment = captured["resolver"]
+    assert executable == r"C:\\nodejs\\codex.cmd"
+    # The resolver sees the real argv and the child env, as _launch passes them.
+    assert arguments[0] == "--oss"
+    assert any("multi\nline\ntask" in argument for argument in arguments)
+    assert environment is not None and bridge._CODEX_ENV_KEY in environment
+    # Popen spawns the resolver's argv, not the .cmd.
+    assert captured["command"][0] == "C:\\nodejs\\node.exe"
+    assert any("multi\nline\ntask" in part for part in captured["command"])

--- a/unsloth_cli/tests/test_start.py
+++ b/unsloth_cli/tests/test_start.py
@@ -1740,7 +1740,9 @@ def test_prefer_cmd_sibling_leaves_an_unreadable_resolution_alone(monkeypatch, t
 
 def test_prefer_cmd_sibling_is_none_safe_and_posix_noop(monkeypatch, tmp_path):
     assert start._prefer_windows_cmd_sibling(None) is None
-    # Not simulated Windows: a POSIX host must never rewrite a which() result.
+    # Pin os.name instead of relying on the host: on a Windows runner the rescue
+    # would fire and this would assert the opposite of what it means to check.
+    monkeypatch.setattr(start.os, "name", "posix")
     shim = tmp_path / "fake-agent"
     shim.write_text("#!/bin/sh\n", encoding = "utf-8")
     (tmp_path / "fake-agent.cmd").write_text("@ECHO off\n", encoding = "utf-8")
@@ -1748,15 +1750,18 @@ def test_prefer_cmd_sibling_is_none_safe_and_posix_noop(monkeypatch, tmp_path):
 
 
 def test_resolved_launch_command_rescues_uppercase_cmd_sibling(monkeypatch, tmp_path):
-    # #9167's pnpm dir holds pi.CMD. Case-insensitive NTFS matches that on the .cmd
-    # probe, but a case-sensitive volume needs .CMD, as does this test on CI.
+    # #9167's pnpm dir holds pi.CMD. A case-sensitive volume needs the .CMD probe;
+    # a case-insensitive one answers the earlier .cmd probe with the same file, so
+    # compare identity rather than spelling or this passes only on Linux.
     _simulate_windows(monkeypatch)
     posix_shim = tmp_path / "fake-agent"
     posix_shim.write_text("#!/bin/sh\n", encoding = "utf-8")
     cmd = tmp_path / "fake-agent.CMD"
     cmd.write_text("@ECHO off\ncustom-wrapper %*\n", encoding = "utf-8")
 
-    assert start._resolved_launch_command(str(posix_shim), ["--flag"]) == [str(cmd), "--flag"]
+    resolved = start._resolved_launch_command(str(posix_shim), ["--flag"])
+    assert resolved[1:] == ["--flag"]
+    assert os.path.samefile(resolved[0], str(cmd))
 
 
 def test_which_with_install_dirs_applies_the_cmd_sibling_preference(monkeypatch, tmp_path):

--- a/unsloth_cli/tests/test_start.py
+++ b/unsloth_cli/tests/test_start.py
@@ -1748,6 +1748,19 @@ def test_prefer_cmd_sibling_is_none_safe_and_posix_noop(monkeypatch, tmp_path):
     assert start._prefer_windows_cmd_sibling(str(shim)) == str(shim)
 
 
+def test_resolved_launch_command_rescues_uppercase_cmd_sibling(monkeypatch, tmp_path):
+    # #9167's pnpm dir holds pi.CMD, not pi.cmd. Default NTFS matches either on the
+    # .cmd probe, but a case-sensitive volume (ReFS, or an fsutil-flagged dir) needs
+    # the .CMD probe -- as does this test, on a case-sensitive CI filesystem.
+    _simulate_windows(monkeypatch)
+    posix_shim = tmp_path / "fake-agent"
+    posix_shim.write_text("#!/bin/sh\n", encoding = "utf-8")
+    cmd = tmp_path / "fake-agent.CMD"
+    cmd.write_text("@ECHO off\ncustom-wrapper %*\n", encoding = "utf-8")
+
+    assert start._resolved_launch_command(str(posix_shim), ["--flag"]) == [str(cmd), "--flag"]
+
+
 def test_which_with_install_dirs_applies_the_cmd_sibling_preference(monkeypatch, tmp_path):
     # The version/capability probes spawn this result directly, without going
     # through _resolved_launch_command, so the rescue must happen here too.

--- a/unsloth_cli/tests/test_start.py
+++ b/unsloth_cli/tests/test_start.py
@@ -1693,8 +1693,8 @@ def test_resolved_launch_command_accepts_extensionless_node_target(monkeypatch, 
 
 
 def test_resolved_launch_command_prefers_cmd_sibling_of_extensionless_shim(monkeypatch, tmp_path):
-    # shutil.which can resolve npm/pnpm's extensionless POSIX shim ahead of its
-    # .cmd sibling; CreateProcess rejects the former with WinError 193 (#9167).
+    # which() can resolve the extensionless POSIX shim ahead of its .cmd sibling;
+    # CreateProcess rejects the former with WinError 193 (#9167).
     _simulate_windows(monkeypatch)
     posix_shim = tmp_path / "fake-agent"
     posix_shim.write_text("#!/bin/sh\n", encoding = "utf-8")
@@ -1713,8 +1713,7 @@ def test_resolved_launch_command_prefers_cmd_sibling_of_extensionless_shim(monke
 
 
 def test_resolved_launch_command_keeps_extensionless_shim_without_sibling(monkeypatch, tmp_path):
-    # A shebang file with no sibling exercises the probe loop itself: there is
-    # nothing to substitute, so the path passes through unchanged.
+    # Nothing to substitute, so the path passes through unchanged.
     _simulate_windows(monkeypatch)
     executable = tmp_path / "fake-agent"
     executable.write_text("#!/bin/sh\n", encoding = "utf-8")
@@ -1726,8 +1725,8 @@ def test_resolved_launch_command_keeps_extensionless_shim_without_sibling(monkey
 
 
 def test_prefer_cmd_sibling_leaves_an_unreadable_resolution_alone(monkeypatch, tmp_path):
-    # A directory (or unreadable file, or a delete between resolve and open)
-    # must fall through instead of raising out of the launch path.
+    # A directory, an unreadable file, or a delete between resolve and open must
+    # fall through instead of raising out of the launch path.
     _simulate_windows(monkeypatch)
     executable = tmp_path / "fake-agent"
     executable.mkdir()
@@ -1749,9 +1748,8 @@ def test_prefer_cmd_sibling_is_none_safe_and_posix_noop(monkeypatch, tmp_path):
 
 
 def test_resolved_launch_command_rescues_uppercase_cmd_sibling(monkeypatch, tmp_path):
-    # #9167's pnpm dir holds pi.CMD, not pi.cmd. Default NTFS matches either on the
-    # .cmd probe, but a case-sensitive volume (ReFS, or an fsutil-flagged dir) needs
-    # the .CMD probe -- as does this test, on a case-sensitive CI filesystem.
+    # #9167's pnpm dir holds pi.CMD. Case-insensitive NTFS matches that on the .cmd
+    # probe, but a case-sensitive volume needs .CMD, as does this test on CI.
     _simulate_windows(monkeypatch)
     posix_shim = tmp_path / "fake-agent"
     posix_shim.write_text("#!/bin/sh\n", encoding = "utf-8")
@@ -1762,8 +1760,8 @@ def test_resolved_launch_command_rescues_uppercase_cmd_sibling(monkeypatch, tmp_
 
 
 def test_which_with_install_dirs_applies_the_cmd_sibling_preference(monkeypatch, tmp_path):
-    # The version/capability probes spawn this result directly, without going
-    # through _resolved_launch_command, so the rescue must happen here too.
+    # The version probes spawn this result directly, bypassing
+    # _resolved_launch_command, so the rescue must happen here too.
     _simulate_windows(monkeypatch)
     posix_shim = tmp_path / "fake-agent"
     posix_shim.write_text("#!/bin/sh\n", encoding = "utf-8")
@@ -1776,8 +1774,8 @@ def test_which_with_install_dirs_applies_the_cmd_sibling_preference(monkeypatch,
 
 
 def test_resolved_launch_command_rescues_dotted_bin_name_shim(monkeypatch, tmp_path):
-    # cmd-shim appends .cmd to the whole bin name, so a dotted name pairs
-    # "foo.bar" with "foo.bar.cmd" and still needs the sibling preference.
+    # cmd-shim appends .cmd to the whole bin name, so "foo.bar" pairs with
+    # "foo.bar.cmd" and still needs the sibling preference.
     _simulate_windows(monkeypatch)
     posix_shim = tmp_path / "fake.agent"
     posix_shim.write_text("#!/bin/sh\n", encoding = "utf-8")
@@ -1798,9 +1796,8 @@ def test_resolved_launch_command_rescues_dotted_bin_name_shim(monkeypatch, tmp_p
 def test_resolved_launch_command_keeps_extensionless_pe_binary_over_stale_sibling(
     monkeypatch, tmp_path
 ):
-    # CreateProcess can run a PE binary regardless of its name, so a resolved
-    # real executable must keep priority over a stale .cmd wrapper beside it.
-    # Only files opening with a shebang are treated as unlaunchable shims.
+    # CreateProcess runs a PE regardless of its name, so a real executable keeps
+    # priority over a stale .cmd; only shebang files are treated as shims.
     _simulate_windows(monkeypatch)
     executable = tmp_path / "fake-agent"
     executable.write_bytes(b"MZ\x90\x00")
@@ -1814,8 +1811,8 @@ def test_resolved_launch_command_keeps_extensionless_pe_binary_over_stale_siblin
 
 
 def test_resolved_launch_command_falls_through_to_non_npm_cmd_sibling(monkeypatch, tmp_path):
-    # A sibling .cmd that is not an npm shim is still what cmd.exe would have
-    # picked over the extensionless file, so it is returned as-is.
+    # A non-npm .cmd sibling is still what cmd.exe would have picked, so it is
+    # returned as-is.
     _simulate_windows(monkeypatch)
     posix_shim = tmp_path / "fake-agent"
     posix_shim.write_text("#!/bin/sh\n", encoding = "utf-8")

--- a/unsloth_cli/tests/test_start.py
+++ b/unsloth_cli/tests/test_start.py
@@ -1746,6 +1746,24 @@ def test_resolved_launch_command_rescues_dotted_bin_name_shim(monkeypatch, tmp_p
     ]
 
 
+def test_resolved_launch_command_keeps_extensionless_pe_binary_over_stale_sibling(
+    monkeypatch, tmp_path
+):
+    # CreateProcess can run a PE binary regardless of its name, so a resolved
+    # real executable must keep priority over a stale .cmd wrapper beside it.
+    # Only files opening with a shebang are treated as unlaunchable shims.
+    _simulate_windows(monkeypatch)
+    executable = tmp_path / "fake-agent"
+    executable.write_bytes(b"MZ\x90\x00")
+    stale = tmp_path / "fake-agent.cmd"
+    stale.write_text("@ECHO off\nold-wrapper %*\n", encoding = "utf-8")
+
+    assert start._resolved_launch_command(str(executable), ["--flag"]) == [
+        str(executable),
+        "--flag",
+    ]
+
+
 def test_resolved_launch_command_falls_through_to_non_npm_cmd_sibling(monkeypatch, tmp_path):
     # A sibling .cmd that is not an npm shim is still what cmd.exe would have
     # picked over the extensionless file, so it is returned as-is.

--- a/unsloth_cli/tests/test_start.py
+++ b/unsloth_cli/tests/test_start.py
@@ -1712,18 +1712,54 @@ def test_resolved_launch_command_prefers_cmd_sibling_of_extensionless_shim(monke
     ]
 
 
-def test_resolved_launch_command_keeps_extensionless_executable_without_sibling(
-    monkeypatch, tmp_path
-):
-    # An extensionless path with no shim sibling may be a real PE binary; leave it alone.
+def test_resolved_launch_command_keeps_extensionless_shim_without_sibling(monkeypatch, tmp_path):
+    # A shebang file with no sibling exercises the probe loop itself: there is
+    # nothing to substitute, so the path passes through unchanged.
     _simulate_windows(monkeypatch)
     executable = tmp_path / "fake-agent"
-    executable.write_bytes(b"MZ")
+    executable.write_text("#!/bin/sh\n", encoding = "utf-8")
 
     assert start._resolved_launch_command(str(executable), ["--flag"]) == [
         str(executable),
         "--flag",
     ]
+
+
+def test_prefer_cmd_sibling_leaves_an_unreadable_resolution_alone(monkeypatch, tmp_path):
+    # A directory (or unreadable file, or a delete between resolve and open)
+    # must fall through instead of raising out of the launch path.
+    _simulate_windows(monkeypatch)
+    executable = tmp_path / "fake-agent"
+    executable.mkdir()
+    (tmp_path / "fake-agent.cmd").write_text("@ECHO off\n", encoding = "utf-8")
+
+    assert start._resolved_launch_command(str(executable), ["--flag"]) == [
+        str(executable),
+        "--flag",
+    ]
+
+
+def test_prefer_cmd_sibling_is_none_safe_and_posix_noop(monkeypatch, tmp_path):
+    assert start._prefer_windows_cmd_sibling(None) is None
+    # Not simulated Windows: a POSIX host must never rewrite a which() result.
+    shim = tmp_path / "fake-agent"
+    shim.write_text("#!/bin/sh\n", encoding = "utf-8")
+    (tmp_path / "fake-agent.cmd").write_text("@ECHO off\n", encoding = "utf-8")
+    assert start._prefer_windows_cmd_sibling(str(shim)) == str(shim)
+
+
+def test_which_with_install_dirs_applies_the_cmd_sibling_preference(monkeypatch, tmp_path):
+    # The version/capability probes spawn this result directly, without going
+    # through _resolved_launch_command, so the rescue must happen here too.
+    _simulate_windows(monkeypatch)
+    posix_shim = tmp_path / "fake-agent"
+    posix_shim.write_text("#!/bin/sh\n", encoding = "utf-8")
+    cmd = tmp_path / "fake-agent.cmd"
+    cmd.write_text("@ECHO off\n", encoding = "utf-8")
+    monkeypatch.setattr(start, "_augment_path_with_install_dirs", lambda: None)
+    monkeypatch.setattr(start.shutil, "which", lambda name: str(posix_shim))
+
+    assert start._which_with_install_dirs("fake-agent") == str(cmd)
 
 
 def test_resolved_launch_command_rescues_dotted_bin_name_shim(monkeypatch, tmp_path):

--- a/unsloth_cli/tests/test_start.py
+++ b/unsloth_cli/tests/test_start.py
@@ -1692,6 +1692,75 @@ def test_resolved_launch_command_accepts_extensionless_node_target(monkeypatch, 
     ]
 
 
+def test_resolved_launch_command_prefers_cmd_sibling_of_extensionless_shim(monkeypatch, tmp_path):
+    # shutil.which can resolve npm/pnpm's extensionless POSIX shim ahead of its
+    # .cmd sibling; CreateProcess rejects the former with WinError 193 (#9167).
+    _simulate_windows(monkeypatch)
+    posix_shim = tmp_path / "fake-agent"
+    posix_shim.write_text("#!/bin/sh\n", encoding = "utf-8")
+    cmd = tmp_path / "fake-agent.cmd"
+    target = tmp_path / "node_modules" / "fake-agent" / "index.js"
+    target.parent.mkdir(parents = True)
+    target.write_text("#!/usr/bin/env node\n", encoding = "utf-8")
+    cmd.write_bytes(_npm_node_cmd_shim(r"node_modules\fake-agent\index.js").encode())
+    monkeypatch.setattr(start.shutil, "which", lambda name: r"C:\Program Files\nodejs\node.exe")
+
+    assert start._resolved_launch_command(str(posix_shim), ["--flag"]) == [
+        r"C:\Program Files\nodejs\node.exe",
+        str(target),
+        "--flag",
+    ]
+
+
+def test_resolved_launch_command_keeps_extensionless_executable_without_sibling(
+    monkeypatch, tmp_path
+):
+    # An extensionless path with no shim sibling may be a real PE binary; leave it alone.
+    _simulate_windows(monkeypatch)
+    executable = tmp_path / "fake-agent"
+    executable.write_bytes(b"MZ")
+
+    assert start._resolved_launch_command(str(executable), ["--flag"]) == [
+        str(executable),
+        "--flag",
+    ]
+
+
+def test_resolved_launch_command_rescues_dotted_bin_name_shim(monkeypatch, tmp_path):
+    # cmd-shim appends .cmd to the whole bin name, so a dotted name pairs
+    # "foo.bar" with "foo.bar.cmd" and still needs the sibling preference.
+    _simulate_windows(monkeypatch)
+    posix_shim = tmp_path / "fake.agent"
+    posix_shim.write_text("#!/bin/sh\n", encoding = "utf-8")
+    cmd = tmp_path / "fake.agent.cmd"
+    target = tmp_path / "node_modules" / "fake-agent" / "index.js"
+    target.parent.mkdir(parents = True)
+    target.write_text("#!/usr/bin/env node\n", encoding = "utf-8")
+    cmd.write_bytes(_npm_node_cmd_shim(r"node_modules\fake-agent\index.js").encode())
+    monkeypatch.setattr(start.shutil, "which", lambda name: r"C:\Program Files\nodejs\node.exe")
+
+    assert start._resolved_launch_command(str(posix_shim), ["--flag"]) == [
+        r"C:\Program Files\nodejs\node.exe",
+        str(target),
+        "--flag",
+    ]
+
+
+def test_resolved_launch_command_falls_through_to_non_npm_cmd_sibling(monkeypatch, tmp_path):
+    # A sibling .cmd that is not an npm shim is still what cmd.exe would have
+    # picked over the extensionless file, so it is returned as-is.
+    _simulate_windows(monkeypatch)
+    posix_shim = tmp_path / "fake-agent"
+    posix_shim.write_text("#!/bin/sh\n", encoding = "utf-8")
+    cmd = tmp_path / "fake-agent.cmd"
+    cmd.write_text("@ECHO off\ncustom-wrapper %*\n", encoding = "utf-8")
+
+    assert start._resolved_launch_command(str(posix_shim), ["--flag"]) == [
+        str(cmd),
+        "--flag",
+    ]
+
+
 def test_launch_windows_npm_shim_preserves_shebang_args_and_environment(monkeypatch, tmp_path):
     _simulate_windows(monkeypatch)
     cmd = tmp_path / "fake-agent.cmd"

--- a/unsloth_cli/tests/test_start.py
+++ b/unsloth_cli/tests/test_start.py
@@ -1755,10 +1755,7 @@ def test_resolved_launch_command_falls_through_to_non_npm_cmd_sibling(monkeypatc
     cmd = tmp_path / "fake-agent.cmd"
     cmd.write_text("@ECHO off\ncustom-wrapper %*\n", encoding = "utf-8")
 
-    assert start._resolved_launch_command(str(posix_shim), ["--flag"]) == [
-        str(cmd),
-        "--flag",
-    ]
+    assert start._resolved_launch_command(str(posix_shim), ["--flag"]) == [str(cmd), "--flag"]
 
 
 def test_launch_windows_npm_shim_preserves_shebang_args_and_environment(monkeypatch, tmp_path):


### PR DESCRIPTION
## What

On Windows, `unsloth start codex` / `unsloth start pi` could die in `CreateProcess` with `WinError 193` when `shutil.which()` resolved npm/pnpm's extensionless POSIX shim ahead of the `.cmd` sibling. Fixes #9167.

## How

`_prefer_windows_cmd_sibling()`: when on Windows, the resolved path does not carry a Windows-executable suffix, **and the file opens with a shebang** (what an unlaunchable npm/pnpm POSIX shim always is), substitute a sibling `.cmd` / `.CMD` if one exists. A PE binary — which CreateProcess can run regardless of its name — keeps priority over any stale wrapper beside it.

Applied at the resolver layer, not just the launch path (per review — thanks @mahiatlinux):
- `_which_with_install_dirs` — covers the Claude/Codex/OpenCode version and capability probes that spawn the result directly, including under `--no-launch`
- `_npm_executable` — covers agent installation via PowerShell
- `codex_subagent_mcp.py` / `claude_subagent_mcp.py` — the MCP bridges that call `shutil.which` + `Popen` themselves
- `_resolved_launch_command` — covers `_launch`'s raw `shutil.which` resolver

Notes on the guard:
- Matched on not-a-Windows-suffix rather than no-suffix, so a dotted bin name (cmd-shim writes `foo.bar.cmd` next to `foo.bar`) is rescued too.
- Probes `.cmd` then `.CMD` (case-sensitive volumes) only — neither npm's cmd-shim nor pnpm's writer produces a `.bat` sibling.
- `OSError` during the peek (directory, unreadable, deleted between resolve and open) falls through to the original path.

## Reach

In the same-directory layout #9167 reports, `shutil.which` offers the bare name first on CPython 3.12.0 specifically (3.12.1+ move it last; most other versions never offer it). The rescue also applies when PATH ordering hands back an extensionless shim from an earlier directory, and is a no-op everywhere else.

## Tests

Eight tests around `_resolved_launch_command` / `_prefer_windows_cmd_sibling` / `_which_with_install_dirs`: sibling preference, dotted bin name, shebang gate (PE + stale sibling untouched), no-sibling pass-through (mutation-verified: replacing `sibling.is_file()` with `True` fails it), directory-fixture OSError suppression, None-safety, POSIX no-op, and resolver-layer application. Full `unsloth_cli/tests/test_start.py`: 508 pass (500 at merge base). Ruff clean, kwarg-spacing formatter applied.