### PR TITLE
studio: stop a menu dismissal deleting a chat message

### DIFF
--- a/.github/workflows/studio-frontend-ci.yml
+++ b/.github/workflows/studio-frontend-ci.yml
@@ -260,7 +260,7 @@ jobs:
           PW_ART_DIR: logs/playwright_heavy_thread
         run: python3 tests/studio/playwright_heavy_thread.py
 
-      # a failure here means one dismissal of a non-modal menu deleted a message without confirming
+      # A failure means dismissal triggered an unconfirmed delete.
       - name: Browser check for non-modal menu dismissal
         working-directory: ${{ github.workspace }}
         run: python3 tests/studio/probe_dismiss_guard.py --label ci --engine chromium
@@ -303,9 +303,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: studio-frontend-smoke-artifacts
-          # Most smokes write logs/playwright-<name>; the settings smoke writes a JSON report
-          # under its own name and the dismissal probe writes logs/pw/, so a bare playwright-*
-          # glob uploaded everything EXCEPT the report of the smoke that had just failed.
+          # Include the settings and dismissal probe reports as well as playwright-* logs.
           path: |
             logs/playwright-*
             logs/settings_tabs_report.json

--- a/.github/workflows/studio-frontend-ci.yml
+++ b/.github/workflows/studio-frontend-ci.yml
@@ -22,6 +22,7 @@ on:
       - 'tests/studio/playwright_chat_autoscroll.py'
       - 'tests/studio/playwright_research_freeze.py'
       - 'tests/studio/playwright_heavy_thread.py'
+      - 'tests/studio/probe_dismiss_guard.py'
       - 'tests/studio/playwright_settings_tabs.py'
       - 'tests/studio/playwright_stream_pacing.py'
       # Shared lifecycle helpers, and the contract tests that keep verdicts from going unread.
@@ -259,6 +260,11 @@ jobs:
           PW_ART_DIR: logs/playwright_heavy_thread
         run: python3 tests/studio/playwright_heavy_thread.py
 
+      # a failure here means one dismissal of a non-modal menu deleted a message without confirming
+      - name: Browser check for non-modal menu dismissal
+        working-directory: ${{ github.workspace }}
+        run: python3 tests/studio/probe_dismiss_guard.py --label ci --engine chromium
+
       # The settings panels are fetched on first view, so only a browser can answer whether
       # every tab renders and deep-opens land (and abandoned ones do not come back).
       - name: Browser smoke for the settings tab panels
@@ -297,13 +303,14 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: studio-frontend-smoke-artifacts
-          # Four of the five smokes write logs/playwright-<name>; the settings smoke writes a
-          # JSON report instead, under its own name, so a bare playwright-* glob uploaded
-          # everything EXCEPT the report of the smoke that had just failed.
+          # Most smokes write logs/playwright-<name>; the settings smoke writes a JSON report
+          # under its own name and the dismissal probe writes logs/pw/, so a bare playwright-*
+          # glob uploaded everything EXCEPT the report of the smoke that had just failed.
           path: |
             logs/playwright-*
             logs/settings_tabs_report.json
             logs/settings_tabs_blocked_report.json
+            logs/pw/
           retention-days: 3
           if-no-files-found: ignore
 

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -7201,7 +7201,7 @@ const AssistantActionBar: FC = () => {
             onCloseAutoFocus={(e) => e.preventDefault()}
             className="aui-action-bar-more-content z-50 min-w-32 overflow-hidden rounded-[21px] bg-popover px-[9px] py-2 text-popover-foreground shadow-[0_2px_8px_-2px_rgba(0,0,0,0.16)] dark:shadow-none"
           >
-            {/* non-modal no longer absorbs the dismissing press, and an unconfirmed delete sits two buttons away */}
+            {/* Prevent an outside dismissal from triggering Delete. */}
             <MenuDismissGuard />
             <ActionBarMorePrimitive.Item
               disabled={forkDisabled}

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -219,6 +219,7 @@ import { useVoiceSettingsStore } from "@/features/settings/stores/voice-settings
 import { applyQwenThinkingParams } from "@/features/chat/utils/qwen-params";
 import { isTauri } from "@/lib/api-base";
 import { copyToClipboard } from "@/lib/copy-to-clipboard";
+import { MenuDismissGuard } from "@/lib/menu-dismiss-guard";
 import { MicIcon } from "@/lib/mic-icon";
 import { downloadFile, isDownloadCancelled } from "@/lib/native-files";
 import { toast } from "@/lib/toast";
@@ -7200,6 +7201,8 @@ const AssistantActionBar: FC = () => {
             onCloseAutoFocus={(e) => e.preventDefault()}
             className="aui-action-bar-more-content z-50 min-w-32 overflow-hidden rounded-[21px] bg-popover px-[9px] py-2 text-popover-foreground shadow-[0_2px_8px_-2px_rgba(0,0,0,0.16)] dark:shadow-none"
           >
+            {/* non-modal no longer absorbs the dismissing press, and an unconfirmed delete sits two buttons away */}
+            <MenuDismissGuard />
             <ActionBarMorePrimitive.Item
               disabled={forkDisabled}
               onSelect={() => void forkMessage()}

--- a/studio/frontend/src/lib/menu-dismiss-guard.tsx
+++ b/studio/frontend/src/lib/menu-dismiss-guard.tsx
@@ -6,17 +6,8 @@ import type { FC } from "react";
 import { useDismissingClickGuard } from "@/lib/menu-dismiss";
 
 /**
- * Renders nothing; its only job is to be mounted for exactly as long as a non-modal menu's
- * content is. Radix mounts content on open and unmounts it on close, so a child of the content
- * is the cheapest correct signal for "a menu is open", and it needs no `onOpenChange` wiring at
- * the call sites.
- *
- * See menu-dismiss.ts for why the guard has to watch `pointerdown` rather than take Radix's
- * `onPointerDownOutside`.
- *
- * The lifetime is the content's MOUNT, not its open state, so a content that animates out keeps
- * the guard armed for the length of that animation, when no menu is open to dismiss. The menus
- * mounting this today unmount on close; one with an exit animation needs an open check first.
+ * Marker mounted inside non-modal menu content. The lifetime is mount-scoped: exit-animated
+ * content can outlive the open state, so animated menus must add explicit open-state gating.
  */
 export const MenuDismissGuard: FC = () => {
   useDismissingClickGuard();

--- a/studio/frontend/src/lib/menu-dismiss-guard.tsx
+++ b/studio/frontend/src/lib/menu-dismiss-guard.tsx
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import type { FC } from "react";
+
+import { useDismissingClickGuard } from "@/lib/menu-dismiss";
+
+/**
+ * Renders nothing; its only job is to be mounted for exactly as long as a non-modal menu's
+ * content is. Radix mounts content on open and unmounts it on close, so a child of the content
+ * is the cheapest correct signal for "a menu is open", and it needs no `onOpenChange` wiring at
+ * the call sites.
+ *
+ * See menu-dismiss.ts for why the guard has to watch `pointerdown` rather than take Radix's
+ * `onPointerDownOutside`.
+ *
+ * The lifetime is the content's MOUNT, not its open state, so a content that animates out keeps
+ * the guard armed for the length of that animation, when no menu is open to dismiss. The menus
+ * mounting this today unmount on close; one with an exit animation needs an open check first.
+ */
+export const MenuDismissGuard: FC = () => {
+  useDismissingClickGuard();
+  return null;
+};

--- a/studio/frontend/src/lib/menu-dismiss.ts
+++ b/studio/frontend/src/lib/menu-dismiss.ts
@@ -196,6 +196,7 @@ const disarm = (): void => {
   keyboardOnly = false;
   armedPressTarget = undefined;
   focusBeforePress = null;
+  document.removeEventListener("pointerdown", disarmOnNewPointerDown, true);
   document.removeEventListener("click", swallowClick, true);
   document.removeEventListener("pointerup", startGrace, true);
   document.removeEventListener("pointercancel", disarmOnPointerCancel, true);
@@ -266,6 +267,12 @@ function releaseFocusTakenByTheGuardedPress(): void {
 function disarmAndReleaseFocus(): void {
   releaseFocusTakenByTheGuardedPress();
   disarm();
+}
+
+/** Keep watching for the gesture that supersedes this one after the menu has unmounted. */
+function disarmOnNewPointerDown(event: PointerEvent): void {
+  if (pointerIsDown && isAnotherPointer(event)) return;
+  disarmAndReleaseFocus();
 }
 
 function swallowClick(event: Event): void {
@@ -347,6 +354,10 @@ const arm = (touch: boolean, pointerId: number, pressTarget: Node): void => {
   keyboardOnly = false;
   armedPressTarget = pressTarget;
   focusBeforePress = document.activeElement;
+  // The menu content unmounts as soon as this outside press dismisses it, but a no-click
+  // gesture can leave the module-level swallower armed. Its next pointerdown watcher therefore
+  // belongs to the armed gesture, not to the menu content's lifetime.
+  document.addEventListener("pointerdown", disarmOnNewPointerDown, true);
   // Capture, so this runs before React's root-container delegation reaches any control.
   document.addEventListener("click", swallowClick, true);
   // A gesture that never becomes a click must not leave the swallower waiting for an unrelated

--- a/studio/frontend/src/lib/menu-dismiss.ts
+++ b/studio/frontend/src/lib/menu-dismiss.ts
@@ -1,0 +1,391 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import { useEffect } from "react";
+
+/**
+ * Swallow the single click that dismisses an open non-modal Radix menu.
+ *
+ * WHY THESE MENUS ARE `modal={false}` AT ALL
+ *
+ * A modal Radix layer parks `pointer-events: none` on `<body>` for as long as it is open.
+ * `pointer-events` is an INHERITED property, so that one write invalidates computed style
+ * for the entire mounted subtree underneath it. On a long chat thread that subtree is the
+ * thread, and opening a menu turns into a full-document style recalculation whose cost
+ * scales with the thread rather than with the menu. tests/action-menu-modal-layer.test.ts
+ * pins the message action menu non-modal for that reason and carries the measurements.
+ *
+ * WHAT THE SHIELD WAS ALSO DOING
+ *
+ * Absorbing the click that dismisses the menu, so the first click outside only ever closed
+ * it. Dropping the shield brings back a real footgun: Radix's outside handler dismisses but
+ * never cancels the event, so one click on a control next to the menu both closes the menu
+ * and fires that control. In the assistant action bar the neighbours are "Refresh" and an
+ * unconfirmed "Delete message", two buttons from the trigger.
+ *
+ * WHY THIS IS ARMED FROM `pointerdown` AND NOT FROM RADIX'S CALLBACK
+ *
+ * The obvious place to restore the swallow is `onPointerDownOutside`, and it is wrong in two
+ * ways that a quick press hides. Measured on the heavy-thread smoke page, chromium, by
+ * pressing the adjacent unconfirmed "Delete message" button with the menu open:
+ *
+ *     press and release in the same tick   menu closed, nothing deleted
+ *     press held 600 ms                    menu closed, MESSAGE DELETED
+ *     press with the main thread busy      menu closed, MESSAGE DELETED
+ *     touch tap                            menu closed, MESSAGE DELETED
+ *
+ * The first two are the timer: a listener armed by `onPointerDownOutside` and disarmed by a
+ * fixed deadline is gone before the browser synthesises `click` on release, and a person can
+ * hold a button down for as long as they like. Blocking the main thread reproduces the same
+ * outcome from a normal-length press, which is the version a heavy thread produces on its own.
+ *
+ * The third is ordering. `usePointerDownOutside` in @radix-ui/react-dismissable-layer 1.1.11
+ * defers to the resulting `click` when `pointerType === "touch"`, and listens on
+ * `ownerDocument` in the BUBBLE phase. React 19 delegates to the root container, which is
+ * inside document, so the control's own `onClick` has already run by the time Radix calls us.
+ * A guard armed there cannot swallow the click that armed it, and no amount of fixing the
+ * timer changes that.
+ *
+ * So the guard watches `pointerdown` itself, on `document`, in the CAPTURE phase, which is
+ * ahead of React's delegation and ahead of Radix's own listener for both pointer types. It is
+ * disarmed by the click it was armed for, or by the next gesture, never by a deadline anchored
+ * at the press.
+ *
+ * THE UPPER BOUND, AND WHY IT IS ANCHORED AT RELEASE
+ *
+ * Plenty of dismissing gestures never become a click at all: a press that turns into a drag or a
+ * scroll, a press on an element the menu's own close unmounts before release, a window that
+ * loses focus mid-gesture. With no upper bound the swallower survives all of those and eats an
+ * unrelated click an arbitrary time later, which the user experiences as the app ignoring a
+ * click for no reason and cannot report usefully. So the window opens at `pointerup` rather than
+ * at `pointerdown`: a press held for a minute is still covered, and a gesture that produces no
+ * click is still bounded.
+ *
+ * A bound is not a substitute for not arming, though. A right click raises `contextmenu` and
+ * never a `click`, and measured on all three engines it ate the user's next left click; the
+ * bound only shortened that to 500 ms. The primary-button check below is the real answer, and
+ * the bound is what catches the cases nobody has enumerated.
+ *
+ * WHY THE ARM STATE OUTLIVES THE COMPONENT
+ *
+ * The dismissing `pointerdown` unmounts the menu content synchronously, so anything torn down
+ * in this effect's cleanup would be gone before the `click` arrives. The arm state is
+ * therefore module-level and self-disarming; the effect owns only the `pointerdown` watcher.
+ *
+ * WHAT THIS DOES NOT COVER
+ *
+ * Controls that commit on `pointerdown` rather than on `click` have already acted by the time
+ * the swallow runs: Radix Slider commits in `onSlideStart` and Radix Select opens in
+ * `onPointerDown`. Taking those out of the hit test while a menu is open is a separate shield,
+ * because the same move also takes away the drag that starts on them, and it is not in here.
+ */
+
+/**
+ * Anything a pointer can land on that belongs to an open overlay: a menu, a menu item, or the
+ * wrapper Radix positions any popper content in. A press in there is a selection rather than a
+ * dismissal, so it must reach its handler untouched.
+ */
+const MENU_SURFACE =
+  '[role="menu"],[role="menuitem"],[data-radix-popper-content-wrapper]';
+
+/**
+ * At most one dismissing gesture is ever in flight, so one module-level flag serves every menu
+ * and two menus open at once cannot leave a second listener armed behind the first.
+ */
+let armed = false;
+let graceTimer: number | undefined;
+/**
+ * Whether the armed gesture came from a finger. Radix dismisses on the `pointerdown` itself for
+ * a mouse, but for touch it defers to the resulting `click`, which the swallow below denies it.
+ */
+let armedByTouch = false;
+/**
+ * Whether the gesture that armed the guard is still pressed. A keydown only means "the user has
+ * moved on" once the pointer is up; while it is still down, releasing over the same element will
+ * still synthesise the click the guard exists to eat.
+ */
+let pointerIsDown = false;
+/**
+ * Which pointer the guarded gesture belongs to. Two pointers can be down at once -- a second
+ * finger, or a mouse on a touchscreen laptop -- and only one of them owes the click this guard
+ * exists to eat. Measured on chromium with real CDP touch: press and HOLD the unconfirmed
+ * "Delete message" button with a finger while the menu is open, which Radix leaves open because
+ * it defers a touch dismissal to the resulting click, then press inside the menu with the mouse,
+ * then lift the finger, and the message is gone. Without this id the second press disarmed the
+ * first gesture's swallower and the menu surface check returned without rearming.
+ *
+ * Two FINGERS cannot reach that: with two active touch points the engine suppresses every
+ * compatibility mouse event for the rest of the gesture, so the held finger's release delivers
+ * no click at all. The hybrid touch-and-mouse case is the one that lands.
+ */
+let armedPointerId: number | undefined;
+/**
+ * Whether an activation key is held down during the guarded gesture. Space is the whole set: a
+ * button activates on Space's KEYUP and on Enter's keydown, so Enter has always fired before the
+ * pointer's own click and is covered by the `pointerIsDown` branch in `swallowClick`, while Space
+ * still owes a click after the pointer is long gone.
+ *
+ * The engines split on whether that late click survives an intervening mouse release, and the
+ * split is in their source rather than in anything we do. Gecko tracks the pending activation on
+ * its own `HTML_ELEMENT_ACTIVE_FOR_KEYBOARD` flag, set on keydown and unset only on keyup
+ * (`nsGenericHTMLElement::HandleKeyboardActivation`), so the release does not touch it. Blink and
+ * WebKit gate the same activation on the shared `:active` state (`HTMLElement::
+ * HandleKeyboardActivation`: `if (IsActive()) DispatchSimulatedClick`), which the release clears,
+ * so they never fire it. Measured on all three: the message is deleted on firefox and not on
+ * chromium or webkit.
+ */
+let activationKeyIsDown = false;
+/**
+ * Armed for a KEYBOARD-generated click only. Entered when the pointer's own click was swallowed
+ * with Space still held: the release is accounted for, the Space keyup click is not. Any real
+ * click in this state is a new gesture and must land.
+ */
+let keyboardOnly = false;
+
+/** How long after the pointer is RELEASED a click may still arrive. */
+const CLICK_GRACE_MS = 500;
+
+/** A key that fires the focused control's click on its KEYUP. Enter fires on keydown instead. */
+const isActivationKey = (event: KeyboardEvent): boolean =>
+  event.key === " " || event.key === "Spacebar";
+
+const disarmOnKey = (event: KeyboardEvent): void => {
+  // Space has not activated anything yet -- that happens on its keyup -- so it cannot mean "the
+  // user has moved on", whatever the pointer does next. Auto-repeat re-sets this, which is what
+  // recovers the flag if a disarm cleared it while the key was still physically down.
+  if (isActivationKey(event)) {
+    activationKeyIsDown = true;
+    return;
+  }
+  // Shift, Ctrl and friends get pressed mid-gesture constantly. Disarming on one while the button
+  // is still held meant a press on the unconfirmed "Delete message" button, then a modifier, then
+  // a release, deleted the message: measured on chromium, and safe once this returns early.
+  if (pointerIsDown) return;
+  disarm();
+};
+
+const disarmOnActivationKeyUp = (event: KeyboardEvent): void => {
+  if (!isActivationKey(event)) return;
+  activationKeyIsDown = false;
+  // The pointer is still down, so its release still owes a click and the bound belongs to that.
+  if (pointerIsDown) return;
+  // The activation click is dispatched by THIS keyup's own default action, so it lands before a
+  // zero-delay timeout runs; anything later than that is not this gesture's. Capture phase runs
+  // ahead of the default action, which is why the timeout is scheduled here rather than after.
+  if (graceTimer !== undefined) window.clearTimeout(graceTimer);
+  graceTimer = window.setTimeout(disarm, 0);
+};
+
+const disarm = (): void => {
+  if (graceTimer !== undefined) {
+    window.clearTimeout(graceTimer);
+    graceTimer = undefined;
+  }
+  if (!armed) return;
+  armed = false;
+  pointerIsDown = false;
+  armedPointerId = undefined;
+  activationKeyIsDown = false;
+  keyboardOnly = false;
+  document.removeEventListener("click", swallowClick, true);
+  document.removeEventListener("pointerup", startGrace, true);
+  document.removeEventListener("pointercancel", disarmOnPointerCancel, true);
+  document.removeEventListener("keydown", disarmOnKey, true);
+  document.removeEventListener("keyup", disarmOnActivationKeyUp, true);
+  window.removeEventListener("blur", disarm);
+};
+
+/** The release or cancel of a pointer that is not the one the guard armed for. */
+const isAnotherPointer = (event: PointerEvent): boolean =>
+  armedPointerId !== undefined && event.pointerId !== armedPointerId;
+
+const disarmOnPointerCancel = (event: PointerEvent): void => {
+  // Same filter, same reason as `startGrace`: a second pointer's cancel is not the guarded
+  // gesture ending, and disarming on it leaves the click the guarded pointer still owes to
+  // land on whatever it was pressing.
+  if (isAnotherPointer(event)) return;
+  disarm();
+};
+
+function startGrace(event: PointerEvent): void {
+  // Only the ARMED pointer's release retires its gesture. `installDismissingClickGuard`'s
+  // `pointerdown` handler already filters a second pointer, but this listener took no event and
+  // so could not: a mouse pressed and RELEASED inside the menu while a finger is still holding
+  // the unconfirmed "Delete message" button started the 500 ms bound on the FINGER's behalf, and
+  // once that expired the finger's own compatibility click reached the button. Measured on
+  // chromium with real CDP touch: message deleted.
+  if (isAnotherPointer(event)) return;
+  pointerIsDown = false;
+  if (graceTimer !== undefined) window.clearTimeout(graceTimer);
+  // A release-anchored bound cannot retire the guard while Space is still down: the click that
+  // key fires on its own keyup is still to come, and on Gecko it comes however long the key is
+  // held. `disarmOnActivationKeyUp` re-imposes the bound the moment it is released, and `blur`
+  // and `pointercancel` still cover a gesture that never gets that far.
+  if (activationKeyIsDown) {
+    graceTimer = undefined;
+    return;
+  }
+  graceTimer = window.setTimeout(disarm, CLICK_GRACE_MS);
+}
+
+/** Anything the user types into. Dismissing a menu by clicking into it must leave the caret. */
+const TEXT_ENTRY = "input,textarea,select";
+
+function releaseFocusTakenByTheSwallowedPress(event: Event): void {
+  // Throwing the click away is only half of undoing the press. The press also FOCUSED what it
+  // landed on, and a focused button is one Space away from firing: measured on chromium, firefox
+  // and webkit, click the unconfirmed "Delete message" button to dismiss the menu, then press
+  // Space -- the key a reader uses to scroll -- and the message is gone, with no click involved
+  // for the guard to swallow. The modal shield never left this behind, because with
+  // `pointer-events: none` on the body the press landed on `HTML` and the button was never
+  // focused: measured on the pre-#8992 shape, `document.activeElement` stays `BODY` throughout.
+  //
+  // Blur rather than restore: what was focused when the guard armed is the menu content, and the
+  // dismissal has already unmounted it. Body is where the modal shape left focus anyway.
+  const active = document.activeElement;
+  if (!(active instanceof HTMLElement)) return;
+  if (active.isContentEditable || active.matches(TEXT_ENTRY)) return;
+  // Only focus the swallowed press itself moved. Anything else is the app's own, and taking it
+  // would be a second unasked-for effect in place of the first.
+  if (!(event.target instanceof Node)) return;
+  if (!active.contains(event.target)) return;
+  active.blur();
+}
+
+function swallowClick(event: Event): void {
+  const keyboardGenerated = (event as MouseEvent).detail === 0;
+  if (keyboardOnly) {
+    // Everything the pointer owed has been paid; the only click left to eat is the one a held
+    // Space fires on its keyup. A real click here is a NEW gesture and must land -- eating it is
+    // the "swallowed too much" failure `second_click` and `rightclick_then_click` exist to catch.
+    disarm();
+    if (!keyboardGenerated) return;
+    event.stopPropagation();
+    event.preventDefault();
+    return;
+  }
+  // A KEYBOARD-generated click carries no click count, and one that arrives while the guarded
+  // pointer is still down is not the click this guard was armed for. Pressing a control focuses
+  // it, so Enter or Space mid-gesture activates it, and treating that as the awaited click
+  // leaves nothing armed for the one the RELEASE still synthesises. Measured on chromium: press
+  // and hold the unconfirmed "Delete message" button with the menu open, press Enter, release,
+  // and the message is gone. Swallow it and stay armed.
+  if (pointerIsDown && keyboardGenerated) {
+    event.stopPropagation();
+    event.preventDefault();
+    return;
+  }
+  if (activationKeyIsDown && !keyboardGenerated && !armedByTouch) {
+    // The pointer's own click, with Space still held. On Gecko the control's activation click is
+    // still to come on that key's keyup, so disarming here leaves nothing to eat it: measured on
+    // firefox, press and hold the unconfirmed "Delete message" button with the menu open, hold
+    // Space, release the pointer, release Space, and the message is gone. Swallow this one and
+    // stay armed for exactly one keyboard-generated click. Mouse only: a touch tap has no key in
+    // flight, and the branch below owes Radix a re-raised click that this path does not send.
+    keyboardOnly = true;
+    event.stopPropagation();
+    event.preventDefault();
+    // Throwing the click away is only half of undoing the press here too. Without this the
+    // button the press landed on keeps focus for the whole of the held key and after it, so an
+    // ordinary Space later activates it and deletes the message this guard just saved. Measured
+    // on chromium, firefox and webkit. Blurring also removes the pending activation at its
+    // source on Gecko, whose keyup handler returns early when the element is no longer the
+    // focused one (`nsGenericHTMLElement::HandleKeyboardActivation`), so the swallow below is
+    // belt and braces on the engines that would still fire one.
+    releaseFocusTakenByTheSwallowedPress(event);
+    return;
+  }
+  const touch = armedByTouch;
+  disarm();
+  event.stopPropagation();
+  event.preventDefault();
+  releaseFocusTakenByTheSwallowedPress(event);
+  if (!touch) return;
+  // On touch, Radix's dismissal is a `once` CLICK listener on `document` in the bubble phase,
+  // and the `stopPropagation` above is what it would otherwise have been woken by. Measured:
+  // without this, a tap on non-focusable thread background leaves the menu open on chromium and
+  // webkit. A tap on a focusable control happened to still close it, via `useFocusOutside`,
+  // which is why the first version of this looked fine.
+  //
+  // Radix's deferred handler takes no arguments and ignores the click entirely -- it only
+  // re-raises the pointerdown it already captured -- so a bare click dispatched at `document`
+  // is enough to release it. `bubbles: false` keeps it to listeners on `document` itself, and
+  // `disarm()` above has already removed ours, so this cannot re-enter.
+  //
+  // Two properties of this worth knowing before reusing it. It wakes EVERY listener on
+  // `document`, not just Radix's, so it releases every dismissable layer that is currently
+  // deferring, and compare mode does put a second thread and a second action-bar menu on
+  // screen. Releasing both is what is wanted for a dismissal; a layer deferring for another
+  // reason would go with them. And `isTrusted` is false on a synthetic event, so anything that
+  // gates on trusted input will ignore it -- Radix does not, which is what makes this work.
+  document.dispatchEvent(new MouseEvent("click", { bubbles: false }));
+}
+
+const arm = (touch: boolean, pointerId: number): void => {
+  if (armed) return;
+  armed = true;
+  armedByTouch = touch;
+  pointerIsDown = true;
+  armedPointerId = pointerId;
+  activationKeyIsDown = false;
+  keyboardOnly = false;
+  // Capture, so this runs before React's root-container delegation reaches any control.
+  document.addEventListener("click", swallowClick, true);
+  // A gesture that never becomes a click must not leave the swallower waiting for an unrelated
+  // one: bound it at release, and drop it outright on a cancel, a key, or losing the window.
+  document.addEventListener("pointerup", startGrace, true);
+  document.addEventListener("pointercancel", disarmOnPointerCancel, true);
+  document.addEventListener("keydown", disarmOnKey, true);
+  document.addEventListener("keyup", disarmOnActivationKeyUp, true);
+  window.addEventListener("blur", disarm);
+};
+
+/**
+ * Install the document watcher for one open menu, and return the removal.
+ *
+ * Exported because the arm/disarm state machine above is the part with the sharp edges, and it
+ * can be driven end to end against a fake document without a renderer. Application code mounts
+ * `<MenuDismissGuard />`; nothing else should call this.
+ */
+export function installDismissingClickGuard(): () => void {
+  const onPointerDown = (event: PointerEvent): void => {
+    // A SECOND pointer is not a new gesture while the guarded one is still pressed. Radix
+    // defers a touch dismissal to the resulting click, so a finger held on a control outside
+    // an open menu leaves that menu usable by a second pointer, and every early return below
+    // gives up the guard without rearming it. Measured on chromium with real CDP touch: a
+    // finger holding the unconfirmed "Delete message" button, a mouse press inside the menu,
+    // then lifting the finger, deleted the message.
+    if (armed && pointerIsDown && event.pointerId !== armedPointerId) return;
+    // A new gesture always supersedes the last one, so a press that never produced a click
+    // cannot leave the swallower armed.
+    disarm();
+    // Only the primary button ever synthesises the click this exists to eat. A right or
+    // middle press raises `contextmenu` or `auxclick` instead, so arming for one can only eat
+    // the user's NEXT left click: measured on all three engines, the click after a right-click
+    // dismissal was suppressed. The release-anchored bound caps that at 500 ms rather than
+    // forever, but not arming at all is the actual answer.
+    //
+    // `button` is the whole test on purpose. macOS spells its secondary click ctrl+left, which
+    // arrives as button 0 with `ctrlKey`, and the engines disagree about what follows it:
+    // Blink raises `contextmenu` and no `click`, WebKit sends both. Skipping those would drop
+    // the swallow on WebKit, which is the engine Desktop ships on macOS, and on every ctrl+left
+    // elsewhere, where it is an ordinary primary click. So that one is left to the bound.
+    if (event.button !== 0) return;
+    const target = event.target;
+    if (!(target instanceof Element)) return;
+    if (target.closest(MENU_SURFACE)) return;
+    arm(event.pointerType === "touch", event.pointerId);
+  };
+  document.addEventListener("pointerdown", onPointerDown, true);
+  return () => {
+    document.removeEventListener("pointerdown", onPointerDown, true);
+  };
+}
+
+/**
+ * Call from inside an open non-modal menu's content. Mount it via `<MenuDismissGuard />`
+ * rather than calling it directly, so the guard's lifetime is exactly the content's.
+ */
+export function useDismissingClickGuard(): void {
+  useEffect(installDismissingClickGuard, []);
+}

--- a/studio/frontend/src/lib/menu-dismiss.ts
+++ b/studio/frontend/src/lib/menu-dismiss.ts
@@ -141,6 +141,13 @@ let activationKeyIsDown = false;
  * click in this state is a new gesture and must land.
  */
 let keyboardOnly = false;
+/**
+ * The node hit by the pointerdown that armed the guard, and the element focused before that
+ * press. Browsers may retarget the eventual click to a common ancestor after a drag, so the
+ * click target cannot identify which control the swallowed press focused.
+ */
+let armedPressTarget: Node | undefined;
+let focusBeforePress: Element | null = null;
 
 /** How long after the pointer is RELEASED a click may still arrive. */
 const CLICK_GRACE_MS = 500;
@@ -161,7 +168,7 @@ const disarmOnKey = (event: KeyboardEvent): void => {
   // is still held meant a press on the unconfirmed "Delete message" button, then a modifier, then
   // a release, deleted the message: measured on chromium, and safe once this returns early.
   if (pointerIsDown) return;
-  disarm();
+  disarmAndReleaseFocus();
 };
 
 const disarmOnActivationKeyUp = (event: KeyboardEvent): void => {
@@ -173,7 +180,7 @@ const disarmOnActivationKeyUp = (event: KeyboardEvent): void => {
   // zero-delay timeout runs; anything later than that is not this gesture's. Capture phase runs
   // ahead of the default action, which is why the timeout is scheduled here rather than after.
   if (graceTimer !== undefined) window.clearTimeout(graceTimer);
-  graceTimer = window.setTimeout(disarm, 0);
+  graceTimer = window.setTimeout(disarmAndReleaseFocus, 0);
 };
 
 const disarm = (): void => {
@@ -187,12 +194,14 @@ const disarm = (): void => {
   armedPointerId = undefined;
   activationKeyIsDown = false;
   keyboardOnly = false;
+  armedPressTarget = undefined;
+  focusBeforePress = null;
   document.removeEventListener("click", swallowClick, true);
   document.removeEventListener("pointerup", startGrace, true);
   document.removeEventListener("pointercancel", disarmOnPointerCancel, true);
   document.removeEventListener("keydown", disarmOnKey, true);
   document.removeEventListener("keyup", disarmOnActivationKeyUp, true);
-  window.removeEventListener("blur", disarm);
+  window.removeEventListener("blur", disarmAndReleaseFocus);
 };
 
 /** The release or cancel of a pointer that is not the one the guard armed for. */
@@ -204,7 +213,7 @@ const disarmOnPointerCancel = (event: PointerEvent): void => {
   // gesture ending, and disarming on it leaves the click the guarded pointer still owes to
   // land on whatever it was pressing.
   if (isAnotherPointer(event)) return;
-  disarm();
+  disarmAndReleaseFocus();
 };
 
 function startGrace(event: PointerEvent): void {
@@ -225,13 +234,13 @@ function startGrace(event: PointerEvent): void {
     graceTimer = undefined;
     return;
   }
-  graceTimer = window.setTimeout(disarm, CLICK_GRACE_MS);
+  graceTimer = window.setTimeout(disarmAndReleaseFocus, CLICK_GRACE_MS);
 }
 
 /** Anything the user types into. Dismissing a menu by clicking into it must leave the caret. */
 const TEXT_ENTRY = "input,textarea,select";
 
-function releaseFocusTakenByTheSwallowedPress(event: Event): void {
+function releaseFocusTakenByTheGuardedPress(): void {
   // Throwing the click away is only half of undoing the press. The press also FOCUSED what it
   // landed on, and a focused button is one Space away from firing: measured on chromium, firefox
   // and webkit, click the unconfirmed "Delete message" button to dismiss the menu, then press
@@ -244,12 +253,19 @@ function releaseFocusTakenByTheSwallowedPress(event: Event): void {
   // dismissal has already unmounted it. Body is where the modal shape left focus anyway.
   const active = document.activeElement;
   if (!(active instanceof HTMLElement)) return;
+  if (active === focusBeforePress) return;
   if (active.isContentEditable || active.matches(TEXT_ENTRY)) return;
   // Only focus the swallowed press itself moved. Anything else is the app's own, and taking it
   // would be a second unasked-for effect in place of the first.
-  if (!(event.target instanceof Node)) return;
-  if (!active.contains(event.target)) return;
+  if (!(armedPressTarget instanceof Node)) return;
+  if (!active.contains(armedPressTarget)) return;
   active.blur();
+}
+
+/** Retire a gesture that produced no click without leaving its pressed control focused. */
+function disarmAndReleaseFocus(): void {
+  releaseFocusTakenByTheGuardedPress();
+  disarm();
 }
 
 function swallowClick(event: Event): void {
@@ -292,14 +308,14 @@ function swallowClick(event: Event): void {
     // source on Gecko, whose keyup handler returns early when the element is no longer the
     // focused one (`nsGenericHTMLElement::HandleKeyboardActivation`), so the swallow below is
     // belt and braces on the engines that would still fire one.
-    releaseFocusTakenByTheSwallowedPress(event);
+    releaseFocusTakenByTheGuardedPress();
     return;
   }
   const touch = armedByTouch;
-  disarm();
   event.stopPropagation();
   event.preventDefault();
-  releaseFocusTakenByTheSwallowedPress(event);
+  releaseFocusTakenByTheGuardedPress();
+  disarm();
   if (!touch) return;
   // On touch, Radix's dismissal is a `once` CLICK listener on `document` in the bubble phase,
   // and the `stopPropagation` above is what it would otherwise have been woken by. Measured:
@@ -321,7 +337,7 @@ function swallowClick(event: Event): void {
   document.dispatchEvent(new MouseEvent("click", { bubbles: false }));
 }
 
-const arm = (touch: boolean, pointerId: number): void => {
+const arm = (touch: boolean, pointerId: number, pressTarget: Node): void => {
   if (armed) return;
   armed = true;
   armedByTouch = touch;
@@ -329,15 +345,17 @@ const arm = (touch: boolean, pointerId: number): void => {
   armedPointerId = pointerId;
   activationKeyIsDown = false;
   keyboardOnly = false;
+  armedPressTarget = pressTarget;
+  focusBeforePress = document.activeElement;
   // Capture, so this runs before React's root-container delegation reaches any control.
   document.addEventListener("click", swallowClick, true);
   // A gesture that never becomes a click must not leave the swallower waiting for an unrelated
-  // one: bound it at release, and drop it outright on a cancel, a key, or losing the window.
+  // one: bound it at release, and retire it on a cancel, a key, or losing the window.
   document.addEventListener("pointerup", startGrace, true);
   document.addEventListener("pointercancel", disarmOnPointerCancel, true);
   document.addEventListener("keydown", disarmOnKey, true);
   document.addEventListener("keyup", disarmOnActivationKeyUp, true);
-  window.addEventListener("blur", disarm);
+  window.addEventListener("blur", disarmAndReleaseFocus);
 };
 
 /**
@@ -358,7 +376,7 @@ export function installDismissingClickGuard(): () => void {
     if (armed && pointerIsDown && event.pointerId !== armedPointerId) return;
     // A new gesture always supersedes the last one, so a press that never produced a click
     // cannot leave the swallower armed.
-    disarm();
+    disarmAndReleaseFocus();
     // Only the primary button ever synthesises the click this exists to eat. A right or
     // middle press raises `contextmenu` or `auxclick` instead, so arming for one can only eat
     // the user's NEXT left click: measured on all three engines, the click after a right-click
@@ -374,7 +392,7 @@ export function installDismissingClickGuard(): () => void {
     const target = event.target;
     if (!(target instanceof Element)) return;
     if (target.closest(MENU_SURFACE)) return;
-    arm(event.pointerType === "touch", event.pointerId);
+    arm(event.pointerType === "touch", event.pointerId, target);
   };
   document.addEventListener("pointerdown", onPointerDown, true);
   return () => {

--- a/studio/frontend/src/lib/menu-dismiss.ts
+++ b/studio/frontend/src/lib/menu-dismiss.ts
@@ -4,169 +4,45 @@
 import { useEffect } from "react";
 
 /**
- * Swallow the single click that dismisses an open non-modal Radix menu.
- *
- * WHY THESE MENUS ARE `modal={false}` AT ALL
- *
- * A modal Radix layer parks `pointer-events: none` on `<body>` for as long as it is open.
- * `pointer-events` is an INHERITED property, so that one write invalidates computed style
- * for the entire mounted subtree underneath it. On a long chat thread that subtree is the
- * thread, and opening a menu turns into a full-document style recalculation whose cost
- * scales with the thread rather than with the menu. tests/action-menu-modal-layer.test.ts
- * pins the message action menu non-modal for that reason and carries the measurements.
- *
- * WHAT THE SHIELD WAS ALSO DOING
- *
- * Absorbing the click that dismisses the menu, so the first click outside only ever closed
- * it. Dropping the shield brings back a real footgun: Radix's outside handler dismisses but
- * never cancels the event, so one click on a control next to the menu both closes the menu
- * and fires that control. In the assistant action bar the neighbours are "Refresh" and an
- * unconfirmed "Delete message", two buttons from the trigger.
- *
- * WHY THIS IS ARMED FROM `pointerdown` AND NOT FROM RADIX'S CALLBACK
- *
- * The obvious place to restore the swallow is `onPointerDownOutside`, and it is wrong in two
- * ways that a quick press hides. Measured on the heavy-thread smoke page, chromium, by
- * pressing the adjacent unconfirmed "Delete message" button with the menu open:
- *
- *     press and release in the same tick   menu closed, nothing deleted
- *     press held 600 ms                    menu closed, MESSAGE DELETED
- *     press with the main thread busy      menu closed, MESSAGE DELETED
- *     touch tap                            menu closed, MESSAGE DELETED
- *
- * The first two are the timer: a listener armed by `onPointerDownOutside` and disarmed by a
- * fixed deadline is gone before the browser synthesises `click` on release, and a person can
- * hold a button down for as long as they like. Blocking the main thread reproduces the same
- * outcome from a normal-length press, which is the version a heavy thread produces on its own.
- *
- * The third is ordering. `usePointerDownOutside` in @radix-ui/react-dismissable-layer 1.1.11
- * defers to the resulting `click` when `pointerType === "touch"`, and listens on
- * `ownerDocument` in the BUBBLE phase. React 19 delegates to the root container, which is
- * inside document, so the control's own `onClick` has already run by the time Radix calls us.
- * A guard armed there cannot swallow the click that armed it, and no amount of fixing the
- * timer changes that.
- *
- * So the guard watches `pointerdown` itself, on `document`, in the CAPTURE phase, which is
- * ahead of React's delegation and ahead of Radix's own listener for both pointer types. It is
- * disarmed by the click it was armed for, or by the next gesture, never by a deadline anchored
- * at the press.
- *
- * THE UPPER BOUND, AND WHY IT IS ANCHORED AT RELEASE
- *
- * Plenty of dismissing gestures never become a click at all: a press that turns into a drag or a
- * scroll, a press on an element the menu's own close unmounts before release, a window that
- * loses focus mid-gesture. With no upper bound the swallower survives all of those and eats an
- * unrelated click an arbitrary time later, which the user experiences as the app ignoring a
- * click for no reason and cannot report usefully. So the window opens at `pointerup` rather than
- * at `pointerdown`: a press held for a minute is still covered, and a gesture that produces no
- * click is still bounded.
- *
- * A bound is not a substitute for not arming, though. A right click raises `contextmenu` and
- * never a `click`, and measured on all three engines it ate the user's next left click; the
- * bound only shortened that to 500 ms. The primary-button check below is the real answer, and
- * the bound is what catches the cases nobody has enumerated.
- *
- * WHY THE ARM STATE OUTLIVES THE COMPONENT
- *
- * The dismissing `pointerdown` unmounts the menu content synchronously, so anything torn down
- * in this effect's cleanup would be gone before the `click` arrives. The arm state is
- * therefore module-level and self-disarming; the effect owns only the `pointerdown` watcher.
- *
- * WHAT THIS DOES NOT COVER
- *
- * Controls that commit on `pointerdown` rather than on `click` have already acted by the time
- * the swallow runs: Radix Slider commits in `onSlideStart` and Radix Select opens in
- * `onPointerDown`. Taking those out of the hit test while a menu is open is a separate shield,
- * because the same move also takes away the drag that starts on them, and it is not in here.
+ * Swallow the outside click that dismisses a non-modal menu before it activates an adjacent
+ * control. Capture on `document` precedes React and Radix; module state survives content unmount
+ * until the owed click, cancel, blur, new gesture, or release grace. Pointer identity, keyboard
+ * activation, and focus are tracked, and touch dismissal is re-raised after the swallowed click.
  */
 
-/**
- * Anything a pointer can land on that belongs to an open overlay: a menu, a menu item, or the
- * wrapper Radix positions any popper content in. A press in there is a selection rather than a
- * dismissal, so it must reach its handler untouched.
- */
+/** Menu and popper surfaces are selections, not dismissals. */
 const MENU_SURFACE =
   '[role="menu"],[role="menuitem"],[data-radix-popper-content-wrapper]';
 
-/**
- * At most one dismissing gesture is ever in flight, so one module-level flag serves every menu
- * and two menus open at once cannot leave a second listener armed behind the first.
- */
+/** Shared state survives menu-content unmount during dismissal. */
 let armed = false;
 let graceTimer: number | undefined;
-/**
- * Whether the armed gesture came from a finger. Radix dismisses on the `pointerdown` itself for
- * a mouse, but for touch it defers to the resulting `click`, which the swallow below denies it.
- */
+/** Touch dismissal is deferred by Radix until the resulting click. */
 let armedByTouch = false;
-/**
- * Whether the gesture that armed the guard is still pressed. A keydown only means "the user has
- * moved on" once the pointer is up; while it is still down, releasing over the same element will
- * still synthesise the click the guard exists to eat.
- */
+/** Tracks whether the guarded pointer still owes a click. */
 let pointerIsDown = false;
-/**
- * Which pointer the guarded gesture belongs to. Two pointers can be down at once -- a second
- * finger, or a mouse on a touchscreen laptop -- and only one of them owes the click this guard
- * exists to eat. Measured on chromium with real CDP touch: press and HOLD the unconfirmed
- * "Delete message" button with a finger while the menu is open, which Radix leaves open because
- * it defers a touch dismissal to the resulting click, then press inside the menu with the mouse,
- * then lift the finger, and the message is gone. Without this id the second press disarmed the
- * first gesture's swallower and the menu surface check returned without rearming.
- *
- * Two FINGERS cannot reach that: with two active touch points the engine suppresses every
- * compatibility mouse event for the rest of the gesture, so the held finger's release delivers
- * no click at all. The hybrid touch-and-mouse case is the one that lands.
- */
+/** Only the armed pointer may end the guarded gesture. */
 let armedPointerId: number | undefined;
-/**
- * Whether an activation key is held down during the guarded gesture. Space is the whole set: a
- * button activates on Space's KEYUP and on Enter's keydown, so Enter has always fired before the
- * pointer's own click and is covered by the `pointerIsDown` branch in `swallowClick`, while Space
- * still owes a click after the pointer is long gone.
- *
- * The engines split on whether that late click survives an intervening mouse release, and the
- * split is in their source rather than in anything we do. Gecko tracks the pending activation on
- * its own `HTML_ELEMENT_ACTIVE_FOR_KEYBOARD` flag, set on keydown and unset only on keyup
- * (`nsGenericHTMLElement::HandleKeyboardActivation`), so the release does not touch it. Blink and
- * WebKit gate the same activation on the shared `:active` state (`HTMLElement::
- * HandleKeyboardActivation`: `if (IsActive()) DispatchSimulatedClick`), which the release clears,
- * so they never fire it. Measured on all three: the message is deleted on firefox and not on
- * chromium or webkit.
- */
+/** Space activates on keyup; Enter activates on keydown. */
 let activationKeyIsDown = false;
-/**
- * Armed for a KEYBOARD-generated click only. Entered when the pointer's own click was swallowed
- * with Space still held: the release is accounted for, the Space keyup click is not. Any real
- * click in this state is a new gesture and must land.
- */
+/** The pointer click was handled; a held Space keyup still owes one click. */
 let keyboardOnly = false;
-/**
- * The node hit by the pointerdown that armed the guard, and the element focused before that
- * press. Browsers may retarget the eventual click to a common ancestor after a drag, so the
- * click target cannot identify which control the swallowed press focused.
- */
+/** Used to undo focus taken by the swallowed press. */
 let armedPressTarget: Node | undefined;
 let focusBeforePress: Element | null = null;
 
-/** How long after the pointer is RELEASED a click may still arrive. */
+/** Maximum post-release click delay. */
 const CLICK_GRACE_MS = 500;
 
-/** A key that fires the focused control's click on its KEYUP. Enter fires on keydown instead. */
+/** Keys that activate on keyup. */
 const isActivationKey = (event: KeyboardEvent): boolean =>
   event.key === " " || event.key === "Spacebar";
 
 const disarmOnKey = (event: KeyboardEvent): void => {
-  // Space has not activated anything yet -- that happens on its keyup -- so it cannot mean "the
-  // user has moved on", whatever the pointer does next. Auto-repeat re-sets this, which is what
-  // recovers the flag if a disarm cleared it while the key was still physically down.
   if (isActivationKey(event)) {
     activationKeyIsDown = true;
     return;
   }
-  // Shift, Ctrl and friends get pressed mid-gesture constantly. Disarming on one while the button
-  // is still held meant a press on the unconfirmed "Delete message" button, then a modifier, then
-  // a release, deleted the message: measured on chromium, and safe once this returns early.
   if (pointerIsDown) return;
   disarmAndReleaseFocus();
 };
@@ -174,11 +50,7 @@ const disarmOnKey = (event: KeyboardEvent): void => {
 const disarmOnActivationKeyUp = (event: KeyboardEvent): void => {
   if (!isActivationKey(event)) return;
   activationKeyIsDown = false;
-  // The pointer is still down, so its release still owes a click and the bound belongs to that.
   if (pointerIsDown) return;
-  // The activation click is dispatched by THIS keyup's own default action, so it lands before a
-  // zero-delay timeout runs; anything later than that is not this gesture's. Capture phase runs
-  // ahead of the default action, which is why the timeout is scheduled here rather than after.
   if (graceTimer !== undefined) window.clearTimeout(graceTimer);
   graceTimer = window.setTimeout(disarmAndReleaseFocus, 0);
 };
@@ -210,27 +82,14 @@ const isAnotherPointer = (event: PointerEvent): boolean =>
   armedPointerId !== undefined && event.pointerId !== armedPointerId;
 
 const disarmOnPointerCancel = (event: PointerEvent): void => {
-  // Same filter, same reason as `startGrace`: a second pointer's cancel is not the guarded
-  // gesture ending, and disarming on it leaves the click the guarded pointer still owes to
-  // land on whatever it was pressing.
   if (isAnotherPointer(event)) return;
   disarmAndReleaseFocus();
 };
 
 function startGrace(event: PointerEvent): void {
-  // Only the ARMED pointer's release retires its gesture. `installDismissingClickGuard`'s
-  // `pointerdown` handler already filters a second pointer, but this listener took no event and
-  // so could not: a mouse pressed and RELEASED inside the menu while a finger is still holding
-  // the unconfirmed "Delete message" button started the 500 ms bound on the FINGER's behalf, and
-  // once that expired the finger's own compatibility click reached the button. Measured on
-  // chromium with real CDP touch: message deleted.
   if (isAnotherPointer(event)) return;
   pointerIsDown = false;
   if (graceTimer !== undefined) window.clearTimeout(graceTimer);
-  // A release-anchored bound cannot retire the guard while Space is still down: the click that
-  // key fires on its own keyup is still to come, and on Gecko it comes however long the key is
-  // held. `disarmOnActivationKeyUp` re-imposes the bound the moment it is released, and `blur`
-  // and `pointercancel` still cover a gesture that never gets that far.
   if (activationKeyIsDown) {
     graceTimer = undefined;
     return;
@@ -242,22 +101,12 @@ function startGrace(event: PointerEvent): void {
 const TEXT_ENTRY = "input,textarea,select";
 
 function releaseFocusTakenByTheGuardedPress(): void {
-  // Throwing the click away is only half of undoing the press. The press also FOCUSED what it
-  // landed on, and a focused button is one Space away from firing: measured on chromium, firefox
-  // and webkit, click the unconfirmed "Delete message" button to dismiss the menu, then press
-  // Space -- the key a reader uses to scroll -- and the message is gone, with no click involved
-  // for the guard to swallow. The modal shield never left this behind, because with
-  // `pointer-events: none` on the body the press landed on `HTML` and the button was never
-  // focused: measured on the pre-#8992 shape, `document.activeElement` stays `BODY` throughout.
-  //
-  // Blur rather than restore: what was focused when the guard armed is the menu content, and the
-  // dismissal has already unmounted it. Body is where the modal shape left focus anyway.
+  // Swallowing the click is not enough: blur only focus acquired by this guarded press, so a
+  // later Space key cannot activate the dismissed control.
   const active = document.activeElement;
   if (!(active instanceof HTMLElement)) return;
   if (active === focusBeforePress) return;
   if (active.isContentEditable || active.matches(TEXT_ENTRY)) return;
-  // Only focus the swallowed press itself moved. Anything else is the app's own, and taking it
-  // would be a second unasked-for effect in place of the first.
   if (!(armedPressTarget instanceof Node)) return;
   if (!active.contains(armedPressTarget)) return;
   active.blur();
@@ -269,7 +118,7 @@ function disarmAndReleaseFocus(): void {
   disarm();
 }
 
-/** Keep watching for the gesture that supersedes this one after the menu has unmounted. */
+/** A new pointer supersedes an uncompleted gesture. */
 function disarmOnNewPointerDown(event: PointerEvent): void {
   if (pointerIsDown && isAnotherPointer(event)) return;
   disarmAndReleaseFocus();
@@ -278,43 +127,21 @@ function disarmOnNewPointerDown(event: PointerEvent): void {
 function swallowClick(event: Event): void {
   const keyboardGenerated = (event as MouseEvent).detail === 0;
   if (keyboardOnly) {
-    // Everything the pointer owed has been paid; the only click left to eat is the one a held
-    // Space fires on its keyup. A real click here is a NEW gesture and must land -- eating it is
-    // the "swallowed too much" failure `second_click` and `rightclick_then_click` exist to catch.
     disarm();
     if (!keyboardGenerated) return;
     event.stopPropagation();
     event.preventDefault();
     return;
   }
-  // A KEYBOARD-generated click carries no click count, and one that arrives while the guarded
-  // pointer is still down is not the click this guard was armed for. Pressing a control focuses
-  // it, so Enter or Space mid-gesture activates it, and treating that as the awaited click
-  // leaves nothing armed for the one the RELEASE still synthesises. Measured on chromium: press
-  // and hold the unconfirmed "Delete message" button with the menu open, press Enter, release,
-  // and the message is gone. Swallow it and stay armed.
   if (pointerIsDown && keyboardGenerated) {
     event.stopPropagation();
     event.preventDefault();
     return;
   }
   if (activationKeyIsDown && !keyboardGenerated && !armedByTouch) {
-    // The pointer's own click, with Space still held. On Gecko the control's activation click is
-    // still to come on that key's keyup, so disarming here leaves nothing to eat it: measured on
-    // firefox, press and hold the unconfirmed "Delete message" button with the menu open, hold
-    // Space, release the pointer, release Space, and the message is gone. Swallow this one and
-    // stay armed for exactly one keyboard-generated click. Mouse only: a touch tap has no key in
-    // flight, and the branch below owes Radix a re-raised click that this path does not send.
     keyboardOnly = true;
     event.stopPropagation();
     event.preventDefault();
-    // Throwing the click away is only half of undoing the press here too. Without this the
-    // button the press landed on keeps focus for the whole of the held key and after it, so an
-    // ordinary Space later activates it and deletes the message this guard just saved. Measured
-    // on chromium, firefox and webkit. Blurring also removes the pending activation at its
-    // source on Gecko, whose keyup handler returns early when the element is no longer the
-    // focused one (`nsGenericHTMLElement::HandleKeyboardActivation`), so the swallow below is
-    // belt and braces on the engines that would still fire one.
     releaseFocusTakenByTheGuardedPress();
     return;
   }
@@ -324,23 +151,8 @@ function swallowClick(event: Event): void {
   releaseFocusTakenByTheGuardedPress();
   disarm();
   if (!touch) return;
-  // On touch, Radix's dismissal is a `once` CLICK listener on `document` in the bubble phase,
-  // and the `stopPropagation` above is what it would otherwise have been woken by. Measured:
-  // without this, a tap on non-focusable thread background leaves the menu open on chromium and
-  // webkit. A tap on a focusable control happened to still close it, via `useFocusOutside`,
-  // which is why the first version of this looked fine.
-  //
-  // Radix's deferred handler takes no arguments and ignores the click entirely -- it only
-  // re-raises the pointerdown it already captured -- so a bare click dispatched at `document`
-  // is enough to release it. `bubbles: false` keeps it to listeners on `document` itself, and
-  // `disarm()` above has already removed ours, so this cannot re-enter.
-  //
-  // Two properties of this worth knowing before reusing it. It wakes EVERY listener on
-  // `document`, not just Radix's, so it releases every dismissable layer that is currently
-  // deferring, and compare mode does put a second thread and a second action-bar menu on
-  // screen. Releasing both is what is wanted for a dismissal; a layer deferring for another
-  // reason would go with them. And `isTrusted` is false on a synthetic event, so anything that
-  // gates on trusted input will ignore it -- Radix does not, which is what makes this work.
+  // Radix defers touch dismissal to a document click. Re-raise a non-bubbling synthetic click
+  // after removing this guard so Radix can close the menu without re-entering the swallower.
   document.dispatchEvent(new MouseEvent("click", { bubbles: false }));
 }
 
@@ -354,14 +166,8 @@ const arm = (touch: boolean, pointerId: number, pressTarget: Node): void => {
   keyboardOnly = false;
   armedPressTarget = pressTarget;
   focusBeforePress = document.activeElement;
-  // The menu content unmounts as soon as this outside press dismisses it, but a no-click
-  // gesture can leave the module-level swallower armed. Its next pointerdown watcher therefore
-  // belongs to the armed gesture, not to the menu content's lifetime.
   document.addEventListener("pointerdown", disarmOnNewPointerDown, true);
-  // Capture, so this runs before React's root-container delegation reaches any control.
   document.addEventListener("click", swallowClick, true);
-  // A gesture that never becomes a click must not leave the swallower waiting for an unrelated
-  // one: bound it at release, and retire it on a cancel, a key, or losing the window.
   document.addEventListener("pointerup", startGrace, true);
   document.addEventListener("pointercancel", disarmOnPointerCancel, true);
   document.addEventListener("keydown", disarmOnKey, true);
@@ -369,36 +175,11 @@ const arm = (touch: boolean, pointerId: number, pressTarget: Node): void => {
   window.addEventListener("blur", disarmAndReleaseFocus);
 };
 
-/**
- * Install the document watcher for one open menu, and return the removal.
- *
- * Exported because the arm/disarm state machine above is the part with the sharp edges, and it
- * can be driven end to end against a fake document without a renderer. Application code mounts
- * `<MenuDismissGuard />`; nothing else should call this.
- */
+/** Install the watcher for one open menu. */
 export function installDismissingClickGuard(): () => void {
   const onPointerDown = (event: PointerEvent): void => {
-    // A SECOND pointer is not a new gesture while the guarded one is still pressed. Radix
-    // defers a touch dismissal to the resulting click, so a finger held on a control outside
-    // an open menu leaves that menu usable by a second pointer, and every early return below
-    // gives up the guard without rearming it. Measured on chromium with real CDP touch: a
-    // finger holding the unconfirmed "Delete message" button, a mouse press inside the menu,
-    // then lifting the finger, deleted the message.
     if (armed && pointerIsDown && event.pointerId !== armedPointerId) return;
-    // A new gesture always supersedes the last one, so a press that never produced a click
-    // cannot leave the swallower armed.
     disarmAndReleaseFocus();
-    // Only the primary button ever synthesises the click this exists to eat. A right or
-    // middle press raises `contextmenu` or `auxclick` instead, so arming for one can only eat
-    // the user's NEXT left click: measured on all three engines, the click after a right-click
-    // dismissal was suppressed. The release-anchored bound caps that at 500 ms rather than
-    // forever, but not arming at all is the actual answer.
-    //
-    // `button` is the whole test on purpose. macOS spells its secondary click ctrl+left, which
-    // arrives as button 0 with `ctrlKey`, and the engines disagree about what follows it:
-    // Blink raises `contextmenu` and no `click`, WebKit sends both. Skipping those would drop
-    // the swallow on WebKit, which is the engine Desktop ships on macOS, and on every ctrl+left
-    // elsewhere, where it is an ordinary primary click. So that one is left to the bound.
     if (event.button !== 0) return;
     const target = event.target;
     if (!(target instanceof Element)) return;
@@ -411,10 +192,7 @@ export function installDismissingClickGuard(): () => void {
   };
 }
 
-/**
- * Call from inside an open non-modal menu's content. Mount it via `<MenuDismissGuard />`
- * rather than calling it directly, so the guard's lifetime is exactly the content's.
- */
+/** Mount the guard inside an open non-modal menu's content. */
 export function useDismissingClickGuard(): void {
   useEffect(installDismissingClickGuard, []);
 }

--- a/studio/frontend/tests/nonmodal-menu-dismiss-guard.test.ts
+++ b/studio/frontend/tests/nonmodal-menu-dismiss-guard.test.ts
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// A modal Radix menu absorbs the press that dismisses it, because `pointer-events: none` on
+// <body> takes everything underneath out of the hit test. `modal={false}` removes that write --
+// which is the point, since it is an inherited property and invalidates style for the whole
+// thread -- and it removes the absorption with it. Radix's outside handler dismisses the menu
+// but never cancels the event, so one press on a control beside the menu both closes it and
+// fires that control. In the assistant action bar that control is an unconfirmed
+// "Delete message" two buttons from the trigger: measured on the heavy-thread smoke page,
+// eleven separate dismissal gestures each removed a message on chromium and nine on webkit.
+//
+// lib/menu-dismiss.ts restores the absorption by swallowing exactly that click. It only helps a
+// menu that mounts it, so this sweeps the tree for every layer that opts OUT of the modal one
+// with `modal={false}`, and one added tomorrow has to be decided about rather than defaulting to
+// unguarded. Radix Popover is non-modal by DEFAULT and carries no such prop, so it is outside
+// this sweep and outside this change.
+//
+// tests/studio/probe_dismiss_guard.py carries the same question against a real engine with real
+// input, and is the gate in CI.
+
+import assert from "node:assert/strict";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const SRC = fileURLToPath(new URL("../src/", import.meta.url));
+
+const TAG_NAME = /^<([A-Za-z0-9_.]+)/;
+const GUARD = /<MenuDismissGuard\s*\/>/;
+
+/**
+ * Non-modal menus that deliberately do not swallow their dismissing click, and why. Swallowing
+ * costs the user a click, so a menu that can open without being asked for cannot afford it.
+ */
+const UNGUARDED = new Map<string, string>([
+  [
+    "components/app-sidebar.tsx <DropdownMenu>",
+    "the sidebar's More flyout opens on POINTER ENTER and stays open for 180ms after the pointer " +
+      "leaves, so an unconditional swallow eats an ordinary click on the nav row the pointer was " +
+      "heading for. A press pins it open too, and that path could take one, but the flyout has " +
+      "been non-modal since #6763 rather than since #8992, so it is a defect of its own.",
+  ],
+]);
+
+/** Every .tsx under src/, so a new non-modal menu anywhere is covered without a list. */
+function sources(dir: string, found: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    const full = path.join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      sources(full, found);
+    } else if (entry.endsWith(".tsx")) {
+      found.push(full);
+    }
+  }
+  return found;
+}
+
+/**
+ * Where `<tag` opens an element of exactly that name rather than one whose name merely starts
+ * with it. `<DropdownMenu` is a prefix of `<DropdownMenuTrigger`, which never closes as
+ * `</DropdownMenu>`, so counting prefixes leaves the depth permanently unbalanced and the body
+ * below runs to end of file.
+ */
+function openingTagAt(source: string, tag: string, from: number): number {
+  let at = source.indexOf(`<${tag}`, from);
+  while (at !== -1) {
+    const next = source[at + tag.length + 1] ?? "";
+    if (next === "" || !/[A-Za-z0-9_.]/.test(next)) return at;
+    at = source.indexOf(`<${tag}`, at + 1);
+  }
+  return -1;
+}
+
+/**
+ * The JSX element that carries `modal={false}` at `at`, by counting its own opening and closing
+ * tags. A file-level "as many guards as menus" count would pass a file where one menu mounts two.
+ */
+function element(source: string, at: number): { tag: string; body: string } {
+  const open = source.lastIndexOf("<", at);
+  if (open === -1) {
+    throw new Error("modal={false} outside any element");
+  }
+  const tag = TAG_NAME.exec(source.slice(open))?.[1];
+  if (!tag) {
+    throw new Error("no tag name at the element carrying modal={false}");
+  }
+  let depth = 0;
+  let i = open;
+  while (i < source.length) {
+    const nextOpen = openingTagAt(source, tag, i + 1);
+    const nextClose = source.indexOf(`</${tag}>`, i + 1);
+    if (nextClose === -1) {
+      break;
+    }
+    if (nextOpen !== -1 && nextOpen < nextClose) {
+      depth++;
+      i = nextOpen;
+      continue;
+    }
+    if (depth === 0) {
+      return { tag, body: source.slice(open, nextClose) };
+    }
+    depth--;
+    i = nextClose;
+  }
+  throw new Error(`unbalanced <${tag}> around the menu at offset ${at}`);
+}
+
+/** Every `modal={false}` menu in the tree, as `relative/path.tsx <Tag>`, with its own body. */
+function nonModalMenus(): { id: string; body: string }[] {
+  const menus: { id: string; body: string }[] = [];
+  for (const file of sources(SRC)) {
+    const source = readFileSync(file, "utf8");
+    let at = source.indexOf("modal={false}");
+    while (at !== -1) {
+      const { tag, body } = element(source, at);
+      menus.push({ id: `${path.relative(SRC, file)} <${tag}>`, body });
+      at = source.indexOf("modal={false}", at + 1);
+    }
+  }
+  return menus;
+}
+
+test("every non-modal menu either mounts MenuDismissGuard or is a listed exception", () => {
+  const menus = nonModalMenus();
+  // A sweep that resolves nothing would pass without checking anything.
+  assert.ok(
+    menus.length >= 2,
+    `only found ${menus.length} non-modal menus; the sweep is not reaching the tree`,
+  );
+  const offenders = menus
+    .filter(({ id, body }) => !GUARD.test(body) && !UNGUARDED.has(id))
+    .map(({ id }) => id);
+  assert.deepEqual(
+    offenders,
+    [],
+    `a non-modal menu with no guard lets the press that dismisses it fire whatever is underneath. Add the guard, or list it in UNGUARDED with the reason. Offenders: ${offenders.join(", ")}`,
+  );
+});
+
+test("the exception list does not outlive the menus it excuses", () => {
+  const ids = new Set(nonModalMenus().map(({ id }) => id));
+  for (const id of UNGUARDED.keys()) {
+    assert.ok(
+      ids.has(id),
+      `${id} is excused from the guard but is no longer a non-modal menu; drop the entry`,
+    );
+  }
+});
+
+test("the element scan does not confuse a tag with one that merely starts the same", () => {
+  // `<DropdownMenu>` against `<DropdownMenuTrigger>`: the real shape in app-sidebar.tsx, and the
+  // one that silently returned the rest of the file as the menu's body.
+  const source = [
+    "<DropdownMenu modal={false}>",
+    "  <DropdownMenuTrigger />",
+    "</DropdownMenu>",
+    "<MenuDismissGuard />",
+  ].join("\n");
+  const { tag, body } = element(source, source.indexOf("modal={false}"));
+  assert.equal(tag, "DropdownMenu");
+  assert.ok(
+    !GUARD.test(body),
+    "the scan ran past the menu's own closing tag and swallowed the next element",
+  );
+});
+
+test("the guard component is what mounts the watcher", () => {
+  const guard = readFileSync(
+    path.join(SRC, "lib/menu-dismiss-guard.tsx"),
+    "utf8",
+  );
+  assert.match(
+    guard,
+    /useDismissingClickGuard\(\)/,
+    "MenuDismissGuard must install the document watcher, or every mount above is decoration",
+  );
+});

--- a/studio/frontend/tests/nonmodal-menu-dismiss-guard.test.ts
+++ b/studio/frontend/tests/nonmodal-menu-dismiss-guard.test.ts
@@ -1,23 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-// A modal Radix menu absorbs the press that dismisses it, because `pointer-events: none` on
-// <body> takes everything underneath out of the hit test. `modal={false}` removes that write --
-// which is the point, since it is an inherited property and invalidates style for the whole
-// thread -- and it removes the absorption with it. Radix's outside handler dismisses the menu
-// but never cancels the event, so one press on a control beside the menu both closes it and
-// fires that control. In the assistant action bar that control is an unconfirmed
-// "Delete message" two buttons from the trigger: measured on the heavy-thread smoke page,
-// eleven separate dismissal gestures each removed a message on chromium and nine on webkit.
-//
-// lib/menu-dismiss.ts restores the absorption by swallowing exactly that click. It only helps a
-// menu that mounts it, so this sweeps the tree for every layer that opts OUT of the modal one
-// with `modal={false}`, and one added tomorrow has to be decided about rather than defaulting to
-// unguarded. Radix Popover is non-modal by DEFAULT and carries no such prop, so it is outside
-// this sweep and outside this change.
-//
-// tests/studio/probe_dismiss_guard.py carries the same question against a real engine with real
-// input, and is the gate in CI.
+// Verify that every explicit non-modal menu is guarded or documented as exempt.
 
 import assert from "node:assert/strict";
 import { readFileSync, readdirSync, statSync } from "node:fs";
@@ -30,10 +14,7 @@ const SRC = fileURLToPath(new URL("../src/", import.meta.url));
 const TAG_NAME = /^<([A-Za-z0-9_.]+)/;
 const GUARD = /<MenuDismissGuard\s*\/>/;
 
-/**
- * Non-modal menus that deliberately do not swallow their dismissing click, and why. Swallowing
- * costs the user a click, so a menu that can open without being asked for cannot afford it.
- */
+/** Explicit non-modal menus that intentionally remain unguarded. */
 const UNGUARDED = new Map<string, string>([
   [
     "components/app-sidebar.tsx <DropdownMenu>",
@@ -44,7 +25,7 @@ const UNGUARDED = new Map<string, string>([
   ],
 ]);
 
-/** Every .tsx under src/, so a new non-modal menu anywhere is covered without a list. */
+/** Find all TSX sources. */
 function sources(dir: string, found: string[] = []): string[] {
   for (const entry of readdirSync(dir)) {
     const full = path.join(dir, entry);
@@ -57,12 +38,7 @@ function sources(dir: string, found: string[] = []): string[] {
   return found;
 }
 
-/**
- * Where `<tag` opens an element of exactly that name rather than one whose name merely starts
- * with it. `<DropdownMenu` is a prefix of `<DropdownMenuTrigger`, which never closes as
- * `</DropdownMenu>`, so counting prefixes leaves the depth permanently unbalanced and the body
- * below runs to end of file.
- */
+/** Find an opening tag with an exact name. */
 function openingTagAt(source: string, tag: string, from: number): number {
   let at = source.indexOf(`<${tag}`, from);
   while (at !== -1) {
@@ -73,10 +49,7 @@ function openingTagAt(source: string, tag: string, from: number): number {
   return -1;
 }
 
-/**
- * The JSX element that carries `modal={false}` at `at`, by counting its own opening and closing
- * tags. A file-level "as many guards as menus" count would pass a file where one menu mounts two.
- */
+/** Return the element carrying `modal={false}`. */
 function element(source: string, at: number): { tag: string; body: string } {
   const open = source.lastIndexOf("<", at);
   if (open === -1) {
@@ -108,11 +81,11 @@ function element(source: string, at: number): { tag: string; body: string } {
   throw new Error(`unbalanced <${tag}> around the menu at offset ${at}`);
 }
 
-/** Posix separators whatever the host uses, so the UNGUARDED keys match on Windows too. */
+/** Normalize separators for stable exemption keys. */
 const relativeId = (file: string): string =>
   path.relative(SRC, file).split(path.sep).join("/");
 
-/** Every `modal={false}` menu in the tree, as `relative/path.tsx <Tag>`, with its own body. */
+/** Collect each explicit non-modal menu and its body. */
 function nonModalMenus(): { id: string; body: string }[] {
   const menus: { id: string; body: string }[] = [];
   for (const file of sources(SRC)) {
@@ -129,7 +102,7 @@ function nonModalMenus(): { id: string; body: string }[] {
 
 test("every non-modal menu either mounts MenuDismissGuard or is a listed exception", () => {
   const menus = nonModalMenus();
-  // A sweep that resolves nothing would pass without checking anything.
+  // Require at least one menu so an empty sweep cannot pass.
   assert.ok(
     menus.length >= 2,
     `only found ${menus.length} non-modal menus; the sweep is not reaching the tree`,
@@ -155,8 +128,7 @@ test("the exception list does not outlive the menus it excuses", () => {
 });
 
 test("the element scan does not confuse a tag with one that merely starts the same", () => {
-  // `<DropdownMenu>` against `<DropdownMenuTrigger>`: the real shape in app-sidebar.tsx, and the
-  // one that silently returned the rest of the file as the menu's body.
+  // Exact tag matching prevents trigger prefixes from unbalancing the scan.
   const source = [
     "<DropdownMenu modal={false}>",
     "  <DropdownMenuTrigger />",
@@ -172,8 +144,7 @@ test("the element scan does not confuse a tag with one that merely starts the sa
 });
 
 test("menu ids are separator-independent", () => {
-  // `path.relative` yields backslashes on Windows, and an id built from those matches no
-  // UNGUARDED key, so every listed exception reads as an offender on that runner alone.
+  // Normalize Windows paths before matching exemptions.
   for (const { id } of nonModalMenus()) {
     assert.ok(!id.includes("\\"), `${id} carries a host separator`);
   }

--- a/studio/frontend/tests/nonmodal-menu-dismiss-guard.test.ts
+++ b/studio/frontend/tests/nonmodal-menu-dismiss-guard.test.ts
@@ -108,6 +108,10 @@ function element(source: string, at: number): { tag: string; body: string } {
   throw new Error(`unbalanced <${tag}> around the menu at offset ${at}`);
 }
 
+/** Posix separators whatever the host uses, so the UNGUARDED keys match on Windows too. */
+const relativeId = (file: string): string =>
+  path.relative(SRC, file).split(path.sep).join("/");
+
 /** Every `modal={false}` menu in the tree, as `relative/path.tsx <Tag>`, with its own body. */
 function nonModalMenus(): { id: string; body: string }[] {
   const menus: { id: string; body: string }[] = [];
@@ -116,7 +120,7 @@ function nonModalMenus(): { id: string; body: string }[] {
     let at = source.indexOf("modal={false}");
     while (at !== -1) {
       const { tag, body } = element(source, at);
-      menus.push({ id: `${path.relative(SRC, file)} <${tag}>`, body });
+      menus.push({ id: `${relativeId(file)} <${tag}>`, body });
       at = source.indexOf("modal={false}", at + 1);
     }
   }
@@ -165,6 +169,14 @@ test("the element scan does not confuse a tag with one that merely starts the sa
     !GUARD.test(body),
     "the scan ran past the menu's own closing tag and swallowed the next element",
   );
+});
+
+test("menu ids are separator-independent", () => {
+  // `path.relative` yields backslashes on Windows, and an id built from those matches no
+  // UNGUARDED key, so every listed exception reads as an offender on that runner alone.
+  for (const { id } of nonModalMenus()) {
+    assert.ok(!id.includes("\\"), `${id} carries a host separator`);
+  }
 });
 
 test("the guard component is what mounts the watcher", () => {

--- a/studio/frontend/tests/nonmodal-menu-second-pointer.test.ts
+++ b/studio/frontend/tests/nonmodal-menu-second-pointer.test.ts
@@ -1,0 +1,321 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// Two pointers can be down at once -- a finger and a mouse on a touchscreen laptop -- and only
+// one of them owes the click `swallowClick` exists to eat. `installDismissingClickGuard`'s
+// `pointerdown` handler already filters a second pointer's PRESS. Its release was not filtered,
+// and the release is the half that retires the guard: `startGrace` took no event, so a second
+// pointer's `pointerup` marked the FIRST pointer's gesture as released and started its 500 ms
+// bound. Measured on chromium with real CDP touch, hold the unconfirmed "Delete message" button
+// with a finger while the action-bar menu is open, press and release inside the menu with the
+// mouse, wait past the bound and lift the finger: the message was deleted.
+//
+// The state machine is driven here against a fake document rather than through a browser,
+// because the ordering that produces the bug is a handful of events and a clock, and a test that
+// can advance the clock by hand pins the bound itself rather than a sleep that happens to be
+// longer than it. tests/studio/probe_dismiss_guard.py carries the same case against real
+// engines with real input.
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+// ---------------------------------------------------------------------------
+// The smallest document that answers every question menu-dismiss.ts asks of one.
+// ---------------------------------------------------------------------------
+
+type Listener = (event: FakeEvent) => void;
+
+interface FakeEvent {
+  type: string;
+  target?: unknown;
+  detail?: number;
+  button?: number;
+  pointerId?: number;
+  pointerType?: string;
+  key?: string;
+  stopped?: boolean;
+  prevented?: boolean;
+  stopPropagation?: () => void;
+  preventDefault?: () => void;
+}
+
+class FakeNode {}
+
+/** `closest` answers the one selector the guard uses: is this inside a menu surface. */
+class FakeElement extends FakeNode {
+  inMenu: boolean;
+  constructor(inMenu: boolean) {
+    super();
+    this.inMenu = inMenu;
+  }
+  closest(): FakeElement | null {
+    return this.inMenu ? this : null;
+  }
+  contains(): boolean {
+    return false;
+  }
+  matches(): boolean {
+    return false;
+  }
+}
+
+class FakeHTMLElement extends FakeElement {
+  isContentEditable = false;
+  blur(): void {}
+}
+
+class FakeMouseEvent implements FakeEvent {
+  detail = 0;
+  type: string;
+  constructor(type: string) {
+    this.type = type;
+  }
+}
+
+class FakeDocument {
+  private readonly capturing = new Map<string, Listener[]>();
+  private readonly bubbling = new Map<string, Listener[]>();
+  activeElement: unknown = null;
+
+  addEventListener(type: string, fn: Listener, capture?: boolean): void {
+    const bucket = capture ? this.capturing : this.bubbling;
+    const list = bucket.get(type) ?? [];
+    if (!list.includes(fn)) list.push(fn);
+    bucket.set(type, list);
+  }
+
+  removeEventListener(type: string, fn: Listener, capture?: boolean): void {
+    const bucket = capture ? this.capturing : this.bubbling;
+    const list = bucket.get(type);
+    if (!list) return;
+    const at = list.indexOf(fn);
+    if (at >= 0) list.splice(at, 1);
+  }
+
+  /** Capture first, then bubble, and `stopPropagation` in capture ends the dispatch. */
+  dispatchEvent(event: FakeEvent): void {
+    event.stopped = false;
+    event.prevented = false;
+    event.stopPropagation = () => {
+      event.stopped = true;
+    };
+    event.preventDefault = () => {
+      event.prevented = true;
+    };
+    for (const phase of [this.capturing, this.bubbling]) {
+      for (const fn of [...(phase.get(event.type) ?? [])]) {
+        if (event.stopped) return;
+        fn(event);
+      }
+      if (event.stopped) return;
+    }
+  }
+}
+
+/** A clock the test advances by hand, so the 500 ms bound is pinned rather than slept through. */
+class FakeWindow {
+  private next = 1;
+  private readonly timers = new Map<number, { at: number; fn: () => void }>();
+  private now = 0;
+  private readonly windowListeners = new Map<string, Listener[]>();
+
+  setTimeout(fn: () => void, ms: number): number {
+    const id = this.next++;
+    this.timers.set(id, { at: this.now + ms, fn });
+    return id;
+  }
+  clearTimeout(id: number | undefined): void {
+    if (id !== undefined) this.timers.delete(id);
+  }
+  addEventListener(type: string, fn: Listener): void {
+    const list = this.windowListeners.get(type) ?? [];
+    if (!list.includes(fn)) list.push(fn);
+    this.windowListeners.set(type, list);
+  }
+  removeEventListener(type: string, fn: Listener): void {
+    const list = this.windowListeners.get(type);
+    if (!list) return;
+    const at = list.indexOf(fn);
+    if (at >= 0) list.splice(at, 1);
+  }
+  advance(ms: number): void {
+    this.now += ms;
+    for (const [id, timer] of [...this.timers]) {
+      if (timer.at <= this.now) {
+        this.timers.delete(id);
+        timer.fn();
+      }
+    }
+  }
+}
+
+const fakeDocument = new FakeDocument();
+const fakeWindow = new FakeWindow();
+
+const globals = globalThis as unknown as Record<string, unknown>;
+globals.document = fakeDocument;
+globals.window = fakeWindow;
+globals.Node = FakeNode;
+globals.Element = FakeElement;
+globals.HTMLElement = FakeHTMLElement;
+globals.MouseEvent = FakeMouseEvent;
+
+const { installDismissingClickGuard } = await import(
+  "../src/lib/menu-dismiss.ts"
+);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const OUTSIDE = new FakeHTMLElement(false);
+const INSIDE_MENU = new FakeHTMLElement(true);
+
+const down = (
+  pointerId: number,
+  pointerType: string,
+  target: unknown,
+): void => {
+  fakeDocument.dispatchEvent({
+    type: "pointerdown",
+    pointerId,
+    pointerType,
+    button: 0,
+    target,
+  });
+};
+const up = (pointerId: number, pointerType: string): void => {
+  fakeDocument.dispatchEvent({ type: "pointerup", pointerId, pointerType });
+};
+
+/**
+ * Dispatch the compatibility click a pointer's release synthesises, and answer whether it
+ * survived to the bubble phase. The guard's whole job is that it does not.
+ *
+ * Matched on TARGET, not on "a click arrived": when the swallowed gesture was a touch the guard
+ * re-raises a bare `click` at `document` to release Radix's deferred touch dismissal, and
+ * counting that one would report every touch case as delivered on a tree that swallowed
+ * correctly.
+ */
+function clickReachedTheControl(target: unknown): boolean {
+  let delivered = false;
+  const watch = (event: FakeEvent): void => {
+    if (event.target === target) delivered = true;
+  };
+  fakeDocument.addEventListener("click", watch, false);
+  try {
+    fakeDocument.dispatchEvent({ type: "click", detail: 1, target });
+  } finally {
+    fakeDocument.removeEventListener("click", watch, false);
+  }
+  return delivered;
+}
+
+/** A guard for exactly one test, always removed, so no test inherits another's arm state. */
+function withOpenMenu(body: () => void): void {
+  const remove = installDismissingClickGuard();
+  try {
+    body();
+  } finally {
+    remove();
+    // Whatever state the body left, end the gesture: a new press supersedes any arm, and the
+    // release plus the bound retires it, so the next test starts from a disarmed module.
+    down(999, "mouse", INSIDE_MENU);
+    up(999, "mouse");
+    fakeWindow.advance(5000);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// The bug
+// ---------------------------------------------------------------------------
+
+test("a second pointer's release does not retire the gesture that armed the guard", () => {
+  withOpenMenu(() => {
+    // A finger presses and HOLDS a control outside the menu. Radix defers a touch dismissal to
+    // the resulting click, so the menu is still open underneath.
+    down(11, "touch", OUTSIDE);
+    // A mouse presses INSIDE the still-open menu and releases there. Its press is already
+    // filtered; its release is the one that was not.
+    down(22, "mouse", INSIDE_MENU);
+    up(22, "mouse");
+    // Past CLICK_GRACE_MS. If that release started the bound on the FINGER's behalf, the guard
+    // is gone by now and the finger is still down.
+    fakeWindow.advance(900);
+    assert.equal(
+      clickReachedTheControl(OUTSIDE),
+      false,
+      "the held finger's compatibility click reached the control underneath: a second " +
+        "pointer's pointerup retired a gesture that was never released",
+    );
+  });
+});
+
+test("a second pointer's cancel does not retire it either", () => {
+  withOpenMenu(() => {
+    down(11, "touch", OUTSIDE);
+    down(22, "mouse", INSIDE_MENU);
+    fakeDocument.dispatchEvent({
+      type: "pointercancel",
+      pointerId: 22,
+      pointerType: "mouse",
+    });
+    fakeWindow.advance(900);
+    assert.equal(
+      clickReachedTheControl(OUTSIDE),
+      false,
+      "a second pointer being cancelled disarmed a guard whose own pointer was still down",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// and the other direction, which is just as broken and looks identical from outside
+// ---------------------------------------------------------------------------
+
+test("the armed pointer's OWN release still starts the bound", () => {
+  withOpenMenu(() => {
+    down(11, "mouse", OUTSIDE);
+    up(11, "mouse");
+    fakeWindow.advance(900);
+    assert.equal(
+      clickReachedTheControl(OUTSIDE),
+      true,
+      "a gesture that produced no click must not leave the swallower armed for an unrelated " +
+        "one; filtering by pointer id must not cost the bound its own release",
+    );
+  });
+});
+
+test("the armed pointer's own click is still swallowed, once", () => {
+  withOpenMenu(() => {
+    down(11, "mouse", OUTSIDE);
+    up(11, "mouse");
+    assert.equal(
+      clickReachedTheControl(OUTSIDE),
+      false,
+      "the dismissing click is the one click this guard exists to eat",
+    );
+    assert.equal(
+      clickReachedTheControl(OUTSIDE),
+      true,
+      "and exactly one: the click after it is the user's",
+    );
+  });
+});
+
+test("the armed pointer's own cancel still disarms", () => {
+  withOpenMenu(() => {
+    down(11, "touch", OUTSIDE);
+    fakeDocument.dispatchEvent({
+      type: "pointercancel",
+      pointerId: 11,
+      pointerType: "touch",
+    });
+    assert.equal(
+      clickReachedTheControl(OUTSIDE),
+      true,
+      "a cancelled gesture produces no click of its own, so the guard must not survive it",
+    );
+  });
+});

--- a/studio/frontend/tests/nonmodal-menu-second-pointer.test.ts
+++ b/studio/frontend/tests/nonmodal-menu-second-pointer.test.ts
@@ -326,6 +326,28 @@ test("the armed pointer's own click is still swallowed, once", () => {
   });
 });
 
+test("a new gesture supersedes an armed no-click gesture after menu cleanup", () => {
+  const remove = installDismissingClickGuard();
+  try {
+    down(11, "mouse", OUTSIDE);
+    up(11, "mouse");
+    // Radix unmounts the menu content after the outside press. The first gesture pressed a
+    // disabled native button, so it produced no click, but the swallower remains armed in grace.
+    remove();
+
+    down(12, "mouse", OUTSIDE);
+    up(12, "mouse");
+    assert.equal(
+      clickReachedTheControl(OUTSIDE),
+      true,
+      "the first click of a new gesture was swallowed after the menu's watcher unmounted",
+    );
+  } finally {
+    remove();
+    fakeWindow.advance(5000);
+  }
+});
+
 test("the armed pointer's own cancel still disarms", () => {
   withOpenMenu(() => {
     down(11, "touch", OUTSIDE);

--- a/studio/frontend/tests/nonmodal-menu-second-pointer.test.ts
+++ b/studio/frontend/tests/nonmodal-menu-second-pointer.test.ts
@@ -44,24 +44,43 @@ class FakeNode {}
 /** `closest` answers the one selector the guard uses: is this inside a menu surface. */
 class FakeElement extends FakeNode {
   inMenu: boolean;
-  constructor(inMenu: boolean) {
+  readonly parent?: FakeElement;
+  readonly textEntry: boolean;
+  constructor(inMenu: boolean, parent?: FakeElement, textEntry = false) {
     super();
     this.inMenu = inMenu;
+    this.parent = parent;
+    this.textEntry = textEntry;
   }
   closest(): FakeElement | null {
-    return this.inMenu ? this : null;
+    if (this.inMenu) return this;
+    for (let node = this.parent; node; node = node.parent) {
+      if (node.inMenu) return node;
+    }
+    return null;
   }
-  contains(): boolean {
+  contains(candidate: unknown): boolean {
+    for (
+      let node = candidate instanceof FakeElement ? candidate : undefined;
+      node;
+      node = node.parent
+    ) {
+      if (node === this) return true;
+    }
     return false;
   }
   matches(): boolean {
-    return false;
+    return this.textEntry;
   }
 }
 
 class FakeHTMLElement extends FakeElement {
   isContentEditable = false;
-  blur(): void {}
+  blurCount = 0;
+  blur(): void {
+    this.blurCount += 1;
+    if (fakeDocument.activeElement === this) fakeDocument.activeElement = null;
+  }
 }
 
 class FakeMouseEvent implements FakeEvent {
@@ -137,6 +156,9 @@ class FakeWindow {
     if (!list) return;
     const at = list.indexOf(fn);
     if (at >= 0) list.splice(at, 1);
+  }
+  dispatchEvent(event: FakeEvent): void {
+    for (const fn of [...(this.windowListeners.get(event.type) ?? [])]) fn(event);
   }
   advance(ms: number): void {
     this.now += ms;
@@ -317,5 +339,117 @@ test("the armed pointer's own cancel still disarms", () => {
       true,
       "a cancelled gesture produces no click of its own, so the guard must not survive it",
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Focus acquired by a guarded press
+// ---------------------------------------------------------------------------
+
+test("a drag-retargeted click releases the control focused by the guarded press", () => {
+  withOpenMenu(() => {
+    const clickAncestor = new FakeHTMLElement(false);
+    const button = new FakeHTMLElement(false, clickAncestor);
+    const icon = new FakeElement(false, button);
+    fakeDocument.activeElement = INSIDE_MENU;
+
+    down(11, "mouse", icon);
+    // Pointerdown's default action runs after the capture listener and focuses the button.
+    fakeDocument.activeElement = button;
+    up(11, "mouse");
+
+    assert.equal(
+      clickReachedTheControl(clickAncestor),
+      false,
+      "the drag-retargeted click must still be swallowed",
+    );
+    assert.equal(
+      button.blurCount,
+      1,
+      "focus cleanup must use the original press target, not the retargeted click ancestor",
+    );
+  });
+});
+
+test("focus moved elsewhere during the gesture is preserved", () => {
+  withOpenMenu(() => {
+    const clickAncestor = new FakeHTMLElement(false);
+    const pressedButton = new FakeHTMLElement(false, clickAncestor);
+    const icon = new FakeElement(false, pressedButton);
+    const appFocusedControl = new FakeHTMLElement(false);
+    fakeDocument.activeElement = INSIDE_MENU;
+
+    down(11, "mouse", icon);
+    fakeDocument.activeElement = appFocusedControl;
+    up(11, "mouse");
+    clickReachedTheControl(clickAncestor);
+
+    assert.equal(
+      appFocusedControl.blurCount,
+      0,
+      "the guard must not blur focus the app moved away from the pressed control",
+    );
+  });
+});
+
+test("a control focused before the guarded press is preserved", () => {
+  withOpenMenu(() => {
+    const button = new FakeHTMLElement(false);
+    fakeDocument.activeElement = button;
+
+    down(11, "mouse", button);
+    up(11, "mouse");
+    assert.equal(clickReachedTheControl(button), false);
+
+    assert.equal(button.blurCount, 0, "the press did not acquire this existing focus");
+    assert.equal(fakeDocument.activeElement, button);
+  });
+});
+
+test("window blur retires the guard and releases press-acquired focus", () => {
+  withOpenMenu(() => {
+    const button = new FakeHTMLElement(false);
+    fakeDocument.activeElement = INSIDE_MENU;
+
+    down(11, "mouse", button);
+    fakeDocument.activeElement = button;
+    fakeWindow.dispatchEvent({ type: "blur" });
+
+    assert.equal(button.blurCount, 1);
+    assert.equal(
+      clickReachedTheControl(button),
+      true,
+      "a guard retired on window blur must not swallow a later click",
+    );
+  });
+});
+
+test("a no-click grace timeout also releases press-acquired focus", () => {
+  withOpenMenu(() => {
+    const button = new FakeHTMLElement(false);
+    fakeDocument.activeElement = INSIDE_MENU;
+
+    down(11, "mouse", button);
+    fakeDocument.activeElement = button;
+    up(11, "mouse");
+    fakeWindow.advance(900);
+
+    assert.equal(button.blurCount, 1);
+    assert.equal(clickReachedTheControl(button), true);
+  });
+});
+
+test("text-entry focus acquired by the guarded press is preserved", () => {
+  withOpenMenu(() => {
+    const input = new FakeHTMLElement(false, undefined, true);
+    fakeDocument.activeElement = INSIDE_MENU;
+
+    down(11, "mouse", input);
+    fakeDocument.activeElement = input;
+    up(11, "mouse");
+    assert.equal(clickReachedTheControl(input), false);
+
+    assert.equal(input.blurCount, 0, "typing focus must keep its caret");
+    assert.equal(fakeDocument.activeElement, input);
   });
 });

--- a/studio/frontend/tests/nonmodal-menu-second-pointer.test.ts
+++ b/studio/frontend/tests/nonmodal-menu-second-pointer.test.ts
@@ -1,27 +1,10 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-// Two pointers can be down at once -- a finger and a mouse on a touchscreen laptop -- and only
-// one of them owes the click `swallowClick` exists to eat. `installDismissingClickGuard`'s
-// `pointerdown` handler already filters a second pointer's PRESS. Its release was not filtered,
-// and the release is the half that retires the guard: `startGrace` took no event, so a second
-// pointer's `pointerup` marked the FIRST pointer's gesture as released and started its 500 ms
-// bound. Measured on chromium with real CDP touch, hold the unconfirmed "Delete message" button
-// with a finger while the action-bar menu is open, press and release inside the menu with the
-// mouse, wait past the bound and lift the finger: the message was deleted.
-//
-// The state machine is driven here against a fake document rather than through a browser,
-// because the ordering that produces the bug is a handful of events and a clock, and a test that
-// can advance the clock by hand pins the bound itself rather than a sleep that happens to be
-// longer than it. tests/studio/probe_dismiss_guard.py carries the same case against real
-// engines with real input.
+// Pin the multi-pointer ordering and release grace period with a deterministic fake DOM.
 
 import assert from "node:assert/strict";
 import test from "node:test";
-
-// ---------------------------------------------------------------------------
-// The smallest document that answers every question menu-dismiss.ts asks of one.
-// ---------------------------------------------------------------------------
 
 type Listener = (event: FakeEvent) => void;
 
@@ -41,7 +24,7 @@ interface FakeEvent {
 
 class FakeNode {}
 
-/** `closest` answers the one selector the guard uses: is this inside a menu surface. */
+/** Minimal `closest` implementation for the guard's menu check. */
 class FakeElement extends FakeNode {
   inMenu: boolean;
   readonly parent?: FakeElement;
@@ -111,7 +94,7 @@ class FakeDocument {
     if (at >= 0) list.splice(at, 1);
   }
 
-  /** Capture first, then bubble, and `stopPropagation` in capture ends the dispatch. */
+  /** Dispatch capture then bubble listeners. */
   dispatchEvent(event: FakeEvent): void {
     event.stopped = false;
     event.prevented = false;
@@ -131,7 +114,7 @@ class FakeDocument {
   }
 }
 
-/** A clock the test advances by hand, so the 500 ms bound is pinned rather than slept through. */
+/** Deterministic timer clock. */
 class FakeWindow {
   private next = 1;
   private readonly timers = new Map<number, { at: number; fn: () => void }>();
@@ -186,10 +169,6 @@ const { installDismissingClickGuard } = await import(
   "../src/lib/menu-dismiss.ts"
 );
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
 const OUTSIDE = new FakeHTMLElement(false);
 const INSIDE_MENU = new FakeHTMLElement(true);
 
@@ -210,15 +189,7 @@ const up = (pointerId: number, pointerType: string): void => {
   fakeDocument.dispatchEvent({ type: "pointerup", pointerId, pointerType });
 };
 
-/**
- * Dispatch the compatibility click a pointer's release synthesises, and answer whether it
- * survived to the bubble phase. The guard's whole job is that it does not.
- *
- * Matched on TARGET, not on "a click arrived": when the swallowed gesture was a touch the guard
- * re-raises a bare `click` at `document` to release Radix's deferred touch dismissal, and
- * counting that one would report every touch case as delivered on a tree that swallowed
- * correctly.
- */
+/** Dispatch a target click and report whether it reached bubble listeners. */
 function clickReachedTheControl(target: unknown): boolean {
   let delivered = false;
   const watch = (event: FakeEvent): void => {
@@ -233,36 +204,27 @@ function clickReachedTheControl(target: unknown): boolean {
   return delivered;
 }
 
-/** A guard for exactly one test, always removed, so no test inherits another's arm state. */
+/** Install a guard for one isolated test. */
 function withOpenMenu(body: () => void): void {
   const remove = installDismissingClickGuard();
   try {
     body();
   } finally {
     remove();
-    // Whatever state the body left, end the gesture: a new press supersedes any arm, and the
-    // release plus the bound retires it, so the next test starts from a disarmed module.
     down(999, "mouse", INSIDE_MENU);
     up(999, "mouse");
     fakeWindow.advance(5000);
   }
 }
 
-// ---------------------------------------------------------------------------
-// The bug
-// ---------------------------------------------------------------------------
-
 test("a second pointer's release does not retire the gesture that armed the guard", () => {
   withOpenMenu(() => {
-    // A finger presses and HOLDS a control outside the menu. Radix defers a touch dismissal to
-    // the resulting click, so the menu is still open underneath.
+    // A finger holds a control outside the menu; touch dismissal is deferred to its click.
     down(11, "touch", OUTSIDE);
-    // A mouse presses INSIDE the still-open menu and releases there. Its press is already
-    // filtered; its release is the one that was not.
+    // A mouse presses and releases inside the still-open menu.
     down(22, "mouse", INSIDE_MENU);
     up(22, "mouse");
-    // Past CLICK_GRACE_MS. If that release started the bound on the FINGER's behalf, the guard
-    // is gone by now and the finger is still down.
+    // Advance beyond CLICK_GRACE_MS while the finger remains down.
     fakeWindow.advance(900);
     assert.equal(
       clickReachedTheControl(OUTSIDE),
@@ -331,8 +293,7 @@ test("a new gesture supersedes an armed no-click gesture after menu cleanup", ()
   try {
     down(11, "mouse", OUTSIDE);
     up(11, "mouse");
-    // Radix unmounts the menu content after the outside press. The first gesture pressed a
-    // disabled native button, so it produced no click, but the swallower remains armed in grace.
+    // The first gesture produced no click, but the swallower remains armed during grace.
     remove();
 
     down(12, "mouse", OUTSIDE);
@@ -363,10 +324,6 @@ test("the armed pointer's own cancel still disarms", () => {
     );
   });
 });
-
-// ---------------------------------------------------------------------------
-// Focus acquired by a guarded press
-// ---------------------------------------------------------------------------
 
 test("a drag-retargeted click releases the control focused by the guarded press", () => {
   withOpenMenu(() => {

--- a/tests/studio/probe_dismiss_guard.py
+++ b/tests/studio/probe_dismiss_guard.py
@@ -562,6 +562,15 @@ async def one_case(
         if not spot:
             return {"case": case, "error": "no qualifying neutral spot in the viewport"}
         if case == "rightclick_then_click":
+            # Keep WebKit's native context-menu UI from consuming the next automated mouse input.
+            # The contextmenu event still fires, so this isolates the page-level guard behavior
+            # the case is meant to test instead of mistaking browser chrome for a swallowed click.
+            await page.evaluate(
+                """() => document.addEventListener(
+                    "contextmenu", (event) => event.preventDefault(),
+                    { capture: true, once: true }
+                )"""
+            )
             await page.mouse.click(spot["x"], spot["y"], button = "right")
         else:
             await page.mouse.move(spot["x"], spot["y"])

--- a/tests/studio/probe_dismiss_guard.py
+++ b/tests/studio/probe_dismiss_guard.py
@@ -629,7 +629,7 @@ def main() -> int:
     out = Path("logs/pw") / f"dismiss_guard_{args.label}_{args.engine}.json"
     out.parent.mkdir(parents = True, exist_ok = True)
     out.write_text(json.dumps(result, indent = 2), encoding = "utf-8")
-    print(json.dumps(result, indent=2))
+    print(json.dumps(result, indent = 2))
     print(f"[probe] wrote {out}", flush = True)
 
     skipped = [(c["case"], c["skipped"]) for c in result["cases"] if c.get("skipped")]

--- a/tests/studio/probe_dismiss_guard.py
+++ b/tests/studio/probe_dismiss_guard.py
@@ -161,7 +161,11 @@ BLOCK_JS = """
 # clicks that MUST still land.
 WATCH_ITEM_JS = """
 () => {
-  const item = document.querySelector(".aui-action-bar-more-item");
+  // The first item forks into a new chat, so a fast runner can navigate before this probe reads
+  // its counter. Export closes the same Radix menu without replacing the page under the probe.
+  const item = [...document.querySelectorAll(".aui-action-bar-more-item")].find(
+    (candidate) => candidate.textContent?.includes("Export as markdown")
+  );
   if (!item) return null;
   window.__dismissProbe = { itemClicks: 0 };
   item.addEventListener("click", () => { window.__dismissProbe.itemClicks += 1; });

--- a/tests/studio/probe_dismiss_guard.py
+++ b/tests/studio/probe_dismiss_guard.py
@@ -379,6 +379,24 @@ async def one_case(
         await page.mouse.click(x, y)
         await page.wait_for_timeout(300)
         await page.keyboard.press("Space")
+    elif case in ("drag_then_space", "blur_then_space"):
+        # The pointerdown focuses Delete, but a drag can retarget the compatibility click to a
+        # common ancestor. Cleanup based on that click target therefore misses the focused
+        # button. The blur variant retires the guard before any click and pins the same cleanup
+        # requirement on the production window-blur handler. It dispatches the exact event
+        # directly because Playwright cannot reliably make a headless page lose OS focus.
+        spot = await page.evaluate(WATCH_NEUTRAL_JS, False)
+        if not spot:
+            return {"case": case, "error": "no qualifying neutral spot in the viewport"}
+        await page.mouse.move(x, y)
+        await page.mouse.down()
+        await page.wait_for_timeout(120)
+        if case == "blur_then_space":
+            await page.evaluate("() => window.dispatchEvent(new Event('blur'))")
+        await page.mouse.move(spot["x"], spot["y"])
+        await page.mouse.up()
+        await page.wait_for_timeout(700)
+        await page.keyboard.press("Space")
     elif case == "dismiss_on_composer":
         # The other half of releasing the focus a swallowed press took: dismissing a menu by
         # clicking INTO the composer must leave the caret there, or the guard has answered one
@@ -660,7 +678,7 @@ def main() -> int:
     ap.add_argument("--engine", default = "chromium", choices = ("chromium", "webkit", "firefox"))
     ap.add_argument(
         "--cases",
-        default = "quick,held,busy,held_modifier,held_enter,held_space,held_space_then_space,dismiss_then_space,dismiss_on_composer,touch,touch_hold_second_pointer,touch_hold_second_pointer_grace,select,select_then_quick_click,second_click,rightclick_then_click,dragoff_then_click,touch_neutral,touch_trigger",
+        default = "quick,held,busy,held_modifier,held_enter,held_space,held_space_then_space,dismiss_then_space,drag_then_space,blur_then_space,dismiss_on_composer,touch,touch_hold_second_pointer,touch_hold_second_pointer_grace,select,select_then_quick_click,second_click,rightclick_then_click,dragoff_then_click,touch_neutral,touch_trigger",
     )
     args = ap.parse_args()
     cases = [c.strip() for c in args.cases.split(",") if c.strip()]

--- a/tests/studio/probe_dismiss_guard.py
+++ b/tests/studio/probe_dismiss_guard.py
@@ -1,0 +1,728 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Does the non-modal menu dismissal guard stop exactly the right click, and only that one?
+
+The easy case is one `page.mouse.click`, a press and a release in the same tick, and every
+version of the guard passes it. These are the cases that separate them. Each was checked against a DELIBERATELY BROKEN tree
+before its green was trusted; where a case does not discriminate, that is said here rather than
+left to be assumed.
+
+The guard must swallow too little nowhere:
+
+  quick          press and release in one tick. Control case.
+  held           press, wait past any fixed deadline, release. A guard armed from Radix's
+                 `onPointerDownOutside` and disarmed by a 300 ms timer is gone by the time the
+                 browser synthesises `click`. Discriminates: chromium, webkit, firefox.
+  busy           press, block the main thread, release. The same outcome from a normal-length
+                 press, which is what a heavy thread produces on its own. Flaky as a detector:
+                 it reproduced on one chromium run and not the next, so `held` is the reliable
+                 one and this is kept only as a second look.
+  touch          tap. `usePointerDownOutside` in react-dismissable-layer 1.1.11 defers to the
+                 resulting `click` when `pointerType === "touch"`, on `ownerDocument`, bubble
+                 phase, and React 19 delegates to the root container inside document, so the
+                 control's `onClick` has already run. Discriminates: chromium, webkit.
+  held_enter     press, press Enter while still holding, release. The press focuses the button,
+                 so Enter activates it and the browser fires a keyboard-generated click with the
+                 pointer still down. A guard that spends itself on that has nothing left for the
+                 click the release synthesises. Discriminates: chromium.
+  held_space     press, hold Space, RELEASE THE POINTER, then release Space. Space activates a
+                 focused control on its keyup, so its click arrives after the pointer's own, on a
+                 guard that has already spent itself. Discriminates: FIREFOX ONLY, and that is a
+                 property of the engines rather than of the harness. Gecko tracks the pending
+                 activation on its own `HTML_ELEMENT_ACTIVE_FOR_KEYBOARD` flag, which the mouse
+                 release does not clear, so the click still fires; Blink and WebKit gate it on the
+                 shared `:active` state, which the release does clear, so no click is ever
+                 dispatched and the case cannot fail there however broken the guard is.
+  touch_hold_    a finger presses and HOLDS the unconfirmed "Delete message" button, a MOUSE
+    second_      press lands inside the still-open menu, then the finger lifts. Radix defers a
+    pointer      touch dismissal to the resulting click, so the menu is still there for a second
+                 pointer to land in, and every early return in the guard's `pointerdown` handler
+                 gave the guard up without rearming it. Discriminates: chromium. Needs two
+                 pointers alive at once, so it is CDP-only and reports itself skipped elsewhere
+                 rather than passing vacuously; it asserts both pointers were live before it
+                 trusts any verdict. TWO FINGERS cannot reach this and the case does not try:
+                 measured with real CDP multi-touch, two active touch points suppress every
+                 compatibility mouse event for the rest of the gesture, so the held finger's
+                 release delivers no click to swallow in the first place. This case watches the
+                 swallow-too-little direction only: the second pointer's own press raises no
+                 `click` while a touch point is live, on either tree, so it cannot also stand in
+                 for the swallow-too-much direction.
+  dismiss_then_  click the button to dismiss, then press Space, the key a reader uses to scroll.
+    space        No click is involved for the guard to swallow: the press it DID swallow left the
+                 button focused, and a focused button activates on Space. Discriminates on
+                 chromium, firefox and webkit. The modal shape cannot reach it, because with
+                 `pointer-events: none` on the body the press lands on `HTML` and focus never
+                 moves off `BODY`.
+
+and too much nowhere:
+
+  dismiss_on_    dismiss the menu by clicking INTO the composer, then type. Releasing the focus a
+    composer     swallowed press took must not take the caret with it. Discriminates against a
+                 guard that blurs unconditionally.
+
+  select         a click INSIDE the menu must still reach its item.
+  second_click   dismiss on neutral ground, then click again. Exactly one click is the menu's.
+  rightclick_    a right click raises `contextmenu` and no `click`, so a guard with no upper
+    then_click   bound stays armed and eats the user's next real click. Discriminates.
+  dragoff_       press, drag out, release. Does NOT discriminate today: a click still fires at
+    then_click   the common ancestor, so this passes with and without the bound. Kept as a
+                 cheap watch on a different shape, not offered as evidence.
+  touch_neutral  a tap on a spot that CANNOT take focus, with the menu open. The capture-phase
+                 swallow denies Radix its deferred touch dismissal, and when the tapped element
+                 is focusable `useFocusOutside` closes the menu anyway, which is exactly how an
+                 earlier version of the guard looked correct while leaving the menu open on
+                 plain background. The neutral spot is grid-searched for a genuinely
+                 non-focusable element and the probe FAILS rather than falling back if none
+                 exists, because a probe that cannot tell you it missed is worse than none.
+
+Every verdict is a DOM fact: did the assistant message count go down, did the menu close, did
+the watched click land. Clicks go through `page.mouse` / `page.touchscreen`, real hit tests that
+honour pointer-events. `locator.click()` throws on interception and `element.click()` skips hit
+testing, and each would lie in a different direction.
+
+Run against the PR head AND the merge base. On the merge base these menus are modal, the body
+carries `pointer-events: none`, and no variant reaches the control at all.
+
+Usage:  python tests/studio/probe_dismiss_guard.py --label head --engine chromium
+Exits non-zero on any failure, so it is a gate rather than a report.
+Writes logs/pw/dismiss_guard_<label>_<engine>.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from playwright_heavy_thread import (  # noqa: E402
+    BASE,
+    OWNS_SERVER,
+    PORT,
+    start_vite,
+    stop_process,
+    wait_for_smoke_page,
+)
+
+CHARS = int(os.environ.get("PROBE_CHARS", "25000"))
+HOLD_MS = int(os.environ.get("PROBE_HOLD_MS", "600"))
+# Past CLICK_GRACE_MS (500) in src/lib/menu-dismiss.ts, deliberately: the bound is the thing
+# `touch_hold_second_pointer_grace` is waiting out.
+GRACE_HOLD_MS = int(os.environ.get("PROBE_GRACE_HOLD_MS", "900"))
+
+OPEN_MENU_JS = """
+async () => {
+  const api = window.__heavyThread;
+  const trigger = api.actionButton("More");
+  if (!trigger) return { ok: false, why: "no More trigger" };
+  const pointer = {
+    bubbles: true, cancelable: true, composed: true,
+    button: 0, pointerId: 1, pointerType: "mouse", isPrimary: true,
+  };
+  trigger.dispatchEvent(new PointerEvent("pointerdown", { ...pointer, buttons: 1 }));
+  trigger.dispatchEvent(new PointerEvent("pointerup", { ...pointer, buttons: 0 }));
+  const deadline = performance.now() + 15000;
+  while (performance.now() < deadline) {
+    if (document.querySelector(".aui-action-bar-more-content")) break;
+    await new Promise((r) => requestAnimationFrame(r));
+  }
+  return { ok: Boolean(document.querySelector(".aui-action-bar-more-content")) };
+}
+"""
+
+FACTS_JS = """
+() => {
+  const api = window.__heavyThread;
+  const del = api.actionButton("Delete message");
+  const r = del ? del.getBoundingClientRect() : null;
+  return {
+    menuOpen: Boolean(document.querySelector(".aui-action-bar-more-content")),
+    bodyPointerEvents: getComputedStyle(document.body).pointerEvents,
+    deleteRect: r ? { x: r.x + r.width / 2, y: r.y + r.height / 2 } : null,
+    assistantMessages: document.querySelectorAll('[data-role="assistant"]').length,
+  };
+}
+"""
+
+# Occupy the main thread so the guard's 300 ms timer expires between pointerdown and the
+# click the browser will synthesise on release. This is a stand-in for the style recalc
+# and React commit a real heavy thread does on the same press.
+BLOCK_JS = """
+(ms) => { const end = Date.now() + ms; while (Date.now() < end) {} }
+"""
+
+# A guard that swallows too much is as broken as one that swallows too little, and the two
+# failures look identical from the outside (the menu closes either way). These two watch the
+# clicks that MUST still land.
+WATCH_ITEM_JS = """
+() => {
+  const item = document.querySelector(".aui-action-bar-more-item");
+  if (!item) return null;
+  window.__dismissProbe = { itemClicks: 0 };
+  item.addEventListener("click", () => { window.__dismissProbe.itemClicks += 1; });
+  const r = item.getBoundingClientRect();
+  return { x: r.x + r.width / 2, y: r.y + r.height / 2 };
+}
+"""
+
+# Somewhere in the thread that is neither the menu nor the action bar. The listener goes on
+# whatever is ACTUALLY at the point, via elementFromPoint, rather than on an element chosen by
+# selector: the first `[data-role="user"]` in a seeded thread is scrolled far above the
+# viewport, so a rect-derived point lands somewhere else entirely and the probe reports zero
+# clicks on every tree, fixed or broken, which is a false alarm rather than a measurement.
+WATCH_NEUTRAL_JS = """
+(wantUnfocusable) => {
+  const v = window.__heavyThread.viewport();
+  if (!v) return null;
+  const r = v.getBoundingClientRect();
+  const FOCUSABLE = 'button,a[href],input,textarea,select,[tabindex],[contenteditable]';
+  // Grid-search rather than pick one point. The obvious choice lands on a BUTTON often enough
+  // that a run can silently test the focusable case while claiming to test the other one, and
+  // a probe that cannot tell you it missed is worse than no probe. If no qualifying point
+  // exists in the viewport, say so instead of falling back to whatever was there.
+  for (let fy = 0.9; fy > 0.05; fy -= 0.05) {
+    for (let fx = 0.1; fx < 0.95; fx += 0.05) {
+      const x = Math.round(r.x + r.width * fx);
+      const y = Math.round(r.y + r.height * fy);
+      const el = document.elementFromPoint(x, y);
+      if (!el) continue;
+      if (el.closest('[role="menu"],[data-radix-popper-content-wrapper]')) continue;
+      const focusable = Boolean(el.closest(FOCUSABLE));
+      if (wantUnfocusable && focusable) continue;
+      window.__dismissProbe = { neutralClicks: 0 };
+      el.addEventListener("click", () => { window.__dismissProbe.neutralClicks += 1; });
+      return { x, y, tag: el.tagName, focusable };
+    }
+  }
+  return null;
+}
+"""
+
+
+# Two pointers alive at once is the whole premise of `touch_hold_second_pointer`, and a run that
+# silently delivered only one would report a confident false negative. This records every
+# pointerdown the document sees, so the case can assert the overlap happened before it trusts a
+# verdict, and it counts the clicks the SECOND pointer's press must still deliver.
+MULTI_POINTER_INIT = """
+(() => {
+  const st = { live: [], maxLive: 0, concurrentTypes: [], downs: [] };
+  window.__multiPointer = st;
+  const typeOf = {};
+  document.addEventListener("pointerdown", (e) => {
+    st.live.push(e.pointerId);
+    typeOf[e.pointerId] = e.pointerType;
+    if (st.live.length > st.maxLive) {
+      st.maxLive = st.live.length;
+      st.concurrentTypes = st.live.map((id) => typeOf[id]);
+    }
+    st.downs.push({ id: e.pointerId, type: e.pointerType, primary: e.isPrimary });
+  }, true);
+  const drop = (e) => {
+    const i = st.live.indexOf(e.pointerId);
+    if (i >= 0) st.live.splice(i, 1);
+  };
+  document.addEventListener("pointerup", drop, true);
+  document.addEventListener("pointercancel", drop, true);
+  const inMenu = (el) => Boolean(el && el.closest && el.closest(
+    '[role="menu"],[role="menuitem"],[data-radix-popper-content-wrapper]'
+  ));
+  const seen = (e) => ({ tag: e.target && e.target.tagName, detail: e.detail,
+    inMenu: inMenu(e.target) });
+  st.clicks = [];
+  st.delivered = [];
+  document.addEventListener("click", (e) => { st.clicks.push(seen(e)); }, true);
+  // Bubble phase on `document`: the guard stops propagation in CAPTURE at `document`, so a click
+  // it swallowed can never reach this. Node identity is not usable here -- the menu re-renders
+  // between the setup read and the press -- so delivery is read off the event's own target.
+  document.addEventListener("click", (e) => { st.delivered.push(seen(e)); }, false);
+})()
+"""
+
+# A point INSIDE the guard's own MENU_SURFACE that is not a selectable item, so the second
+# pointer's press is "inside the menu" and changes nothing by itself. Grid-searched rather than
+# guessed, and null rather than a fallback if the menu has no such point, so a run that could not
+# set the case up says so instead of testing something else.
+MENU_BLANK_JS = """
+() => {
+  const menu = document.querySelector('[role="menu"]');
+  if (!menu) return null;
+  const r = menu.getBoundingClientRect();
+  for (let y = Math.round(r.y) + 1; y < r.bottom - 1; y += 1) {
+    for (let x = Math.round(r.x) + 1; x < r.right - 1; x += 2) {
+      const el = document.elementFromPoint(x, y);
+      if (!el) continue;
+      const surface = el.closest(
+        '[role="menu"],[role="menuitem"],[data-radix-popper-content-wrapper]'
+      );
+      if (!surface) continue;
+      if (el.closest('[role="menuitem"]')) continue;
+      return { x, y, tag: el.tagName };
+    }
+  }
+  return null;
+}
+"""
+
+
+async def hover_last_assistant(page) -> None:
+    await page.evaluate(
+        "() => window.__heavyThread.lastAssistantMessage()?.scrollIntoView({ block: 'center' })"
+    )
+    box = await page.evaluate(
+        "() => { const m = window.__heavyThread.lastAssistantMessage();"
+        "if (!m) return null; const r = m.getBoundingClientRect();"
+        "return { x: r.x + r.width / 2, y: r.y + r.height / 2 }; }"
+    )
+    if box:
+        await page.mouse.move(box["x"], box["y"])
+        await page.wait_for_timeout(600)
+
+
+async def one_case(
+    page,
+    case: str,
+    engine: str = "chromium",
+    context = None,
+) -> dict:
+    """Open the menu, attack the Delete button one way, report whether it fired."""
+    await hover_last_assistant(page)
+    opened = await page.evaluate(OPEN_MENU_JS)
+    if not opened.get("ok"):
+        return {"case": case, "error": "menu never opened"}
+    before = await page.evaluate(FACTS_JS)
+    rect = before["deleteRect"]
+    if not rect:
+        return {"case": case, "error": "no Delete button"}
+    x, y = rect["x"], rect["y"]
+
+    if case == "quick":
+        await page.mouse.move(x, y)
+        await page.mouse.down()
+        await page.mouse.up()
+    elif case == "held":
+        await page.mouse.move(x, y)
+        await page.mouse.down()
+        await page.wait_for_timeout(HOLD_MS)
+        await page.mouse.up()
+    elif case == "busy":
+        await page.mouse.move(x, y)
+        await page.mouse.down()
+        # Not `wait_for_timeout`: the point is that the page is BUSY, not idle, so the
+        # press itself is a normal length and only the main thread is late.
+        await page.evaluate(BLOCK_JS, HOLD_MS)
+        await page.mouse.up()
+    elif case == "held_modifier":
+        # Press, then press a modifier while still held, then release. Modifiers get pressed
+        # mid-gesture constantly. A guard that treats any keydown as "the user moved on" disarms
+        # here, and the release still synthesises the click, so the press lands on Delete.
+        await page.mouse.move(x, y)
+        await page.mouse.down()
+        await page.wait_for_timeout(120)
+        await page.keyboard.down("Shift")
+        await page.wait_for_timeout(120)
+        await page.mouse.up()
+        await page.keyboard.up("Shift")
+    elif case == "held_enter":
+        # Press and hold, then press Enter. A press on a button focuses it on Linux and Windows,
+        # so Enter activates the focused control and the browser fires a KEYBOARD-generated click
+        # while the pointer is still down. A guard that treats any click as the one it was armed
+        # for disarms on that, and the click the RELEASE synthesises then lands on Delete.
+        await page.mouse.move(x, y)
+        await page.mouse.down()
+        await page.wait_for_timeout(120)
+        await page.keyboard.press("Enter")
+        await page.wait_for_timeout(120)
+        await page.mouse.up()
+    elif case == "held_space":
+        # The same shape as `held_enter` with the one key that activates on KEYUP rather than
+        # keydown. Press and hold, hold Space down, RELEASE THE POINTER, then release Space. The
+        # pointer's own click arrives with the pointer already up, so a guard keyed on
+        # `pointerIsDown` spends itself on it, and the activation click Space fires on its keyup
+        # lands afterwards on a disarmed document. HTML spec: Space activates a button on keyup,
+        # Enter on keydown, which is why `held_enter` cannot cover this ordering.
+        await page.mouse.move(x, y)
+        await page.mouse.down()
+        await page.wait_for_timeout(120)
+        await page.keyboard.down("Space")
+        await page.wait_for_timeout(120)
+        await page.mouse.up()
+        await page.wait_for_timeout(120)
+        await page.keyboard.up("Space")
+    elif case == "held_space_then_space":
+        # `held_space` leaves the guard correct about the CLICK and wrong about the FOCUS. The
+        # press focuses the button; the held-Space branch swallows the pointer click and returns
+        # early, so nothing releases that focus. The gesture then ends with the button still
+        # focused, and the next ordinary Space -- the key a reader uses to scroll -- activates it
+        # and deletes the message. Same failure as `dismiss_then_space`, reached down the one
+        # path that skipped the blur.
+        await page.mouse.move(x, y)
+        await page.mouse.down()
+        await page.wait_for_timeout(120)
+        await page.keyboard.down("Space")
+        await page.wait_for_timeout(120)
+        await page.mouse.up()
+        await page.wait_for_timeout(120)
+        await page.keyboard.up("Space")
+        await page.wait_for_timeout(300)
+        await page.keyboard.press("Space")
+    elif case == "dismiss_then_space":
+        # Dismiss the menu with an ordinary click on the unconfirmed "Delete message" button, which
+        # the guard swallows, and then press Space -- the key a reader uses to scroll a thread. The
+        # press that was thrown away still FOCUSED that button, so the keystroke activates it. The
+        # modal shield never left this behind: with `pointer-events: none` on the body the press
+        # landed on `HTML` and the button was never focused.
+        await page.mouse.click(x, y)
+        await page.wait_for_timeout(300)
+        await page.keyboard.press("Space")
+    elif case == "dismiss_on_composer":
+        # The other half of releasing the focus a swallowed press took: dismissing a menu by
+        # clicking INTO the composer must leave the caret there, or the guard has answered one
+        # unasked-for effect with another. Typing is the only honest test of that.
+        spot = await page.evaluate(
+            "() => { const c = window.__heavyThread.composer(); if (!c) return null;"
+            "const r = c.getBoundingClientRect();"
+            "return { x: r.x + r.width / 2, y: r.y + r.height / 2 }; }"
+        )
+        if not spot:
+            return {"case": case, "error": "no composer"}
+        await page.mouse.click(spot["x"], spot["y"])
+        await page.wait_for_timeout(300)
+        await page.keyboard.type("zz")
+        await page.wait_for_timeout(400)
+        after = await page.evaluate(FACTS_JS)
+        typed = await page.evaluate(
+            "() => { const c = window.__heavyThread.composer(); return c ? c.value : ''; }"
+        )
+        return {
+            "case": case,
+            "composerText": typed[-8:],
+            "menuClosed": not after["menuOpen"],
+            "lostComposerFocus": not typed.endswith("zz"),
+            "deleted": after["assistantMessages"] < before["assistantMessages"],
+        }
+    elif case == "touch":
+        await page.touchscreen.tap(x, y)
+    elif case in ("touch_hold_second_pointer", "touch_hold_second_pointer_grace"):
+        # A finger holds the unconfirmed "Delete message" button with the menu open, a MOUSE
+        # press lands inside the menu, then the finger lifts. Radix defers a touch dismissal to
+        # the resulting click, so the menu is still open under the second pointer, and a guard
+        # that lets any pointerdown disarm it has nothing left for the click the finger's release
+        # synthesises. Playwright's Touchscreen only exposes an atomic `tap()`, so holding a
+        # finger down needs CDP and this case runs on chromium alone.
+        if engine != "chromium" or context is None:
+            return {
+                "case": case,
+                "skipped": f"{engine} has no API for a held touch alongside a second pointer",
+            }
+        blank = await page.evaluate(MENU_BLANK_JS)
+        if not blank:
+            return {"case": case, "error": "no non-item spot inside the menu"}
+        cdp = await context.new_cdp_session(page)
+        finger = [{"x": x, "y": y, "id": 1, "radiusX": 1, "radiusY": 1, "force": 1}]
+        await cdp.send("Input.dispatchTouchEvent", {"type": "touchStart", "touchPoints": finger})
+        await page.wait_for_timeout(150)
+        held = await page.evaluate(FACTS_JS)
+        await page.mouse.move(blank["x"], blank["y"])
+        await page.mouse.down()
+        await page.wait_for_timeout(80)
+        live = await page.evaluate("() => window.__multiPointer.live.length")
+        await page.mouse.up()
+        # The _grace variant waits out the release-anchored bound with the FINGER STILL DOWN.
+        # `startGrace` is reached by the second pointer's own `pointerup`, and if it cannot tell
+        # that release from the guarded one it retires a gesture nobody has let go of; 500 ms
+        # later the guard is gone and the finger's own compatibility click lands on Delete.
+        # Measured on chromium: message deleted. The plain variant lifts INSIDE the window and
+        # therefore cannot see this at all, which is why both are kept.
+        await page.wait_for_timeout(GRACE_HOLD_MS if case.endswith("_grace") else 150)
+        if case.endswith("_grace"):
+            still_down = await page.evaluate("() => window.__multiPointer.live.length")
+            if still_down < 1:
+                return {
+                    "case": case,
+                    "error": "the finger was no longer down when the bound expired, so the "
+                    "case tested nothing",
+                }
+        await cdp.send("Input.dispatchTouchEvent", {"type": "touchEnd", "touchPoints": finger})
+        await page.wait_for_timeout(1500)
+        after = await page.evaluate(FACTS_JS)
+        state = await page.evaluate("() => window.__multiPointer")
+        # Every one of these is a way the case could look green while having tested nothing: the
+        # finger's press never reaching the document, the menu closing on the touch after all, or
+        # only one of the two pointers ever being alive. An unmet premise is a FAILURE here, not
+        # a pass, because a probe that cannot tell you it missed is worse than no probe.
+        if not held["menuOpen"]:
+            return {
+                "case": case,
+                "error": "the held touch dismissed the menu, so there was no "
+                "open menu for a second pointer to land in",
+            }
+        if state["maxLive"] < 2 or live < 2:
+            return {
+                "case": case,
+                "error": f"the two pointers never coexisted: maxLive="
+                f"{state['maxLive']}, live at the second press={live}",
+            }
+        if sorted(state["concurrentTypes"]) != ["mouse", "touch"]:
+            return {"case": case, "error": f"wrong pointer types: {state['concurrentTypes']}"}
+        return {
+            "case": case,
+            "concurrentPointers": state["downs"],
+            "menuOpenUnderSecondPointer": held["menuOpen"],
+            "assistantMessagesBefore": before["assistantMessages"],
+            "assistantMessagesAfter": after["assistantMessages"],
+            "deleted": after["assistantMessages"] < before["assistantMessages"],
+            "menuClosed": not after["menuOpen"],
+            "clicksSeen": state["clicks"],
+            "clicksDelivered": state["delivered"],
+            # Recorded, not asserted on. The second pointer's own press produces no `click` at
+            # all while a touch point is live -- measured as zero on the fixed AND the unfixed
+            # tree -- so a "the menu press must still land" assertion here would fail on both and
+            # would be measuring the engine rather than the guard.
+        }
+    elif case == "select":
+        # Not a dismissal at all: a click INSIDE the menu, which must still reach its item.
+        spot = await page.evaluate(WATCH_ITEM_JS)
+        if not spot:
+            return {"case": case, "error": "no menu item to select"}
+        await page.mouse.click(spot["x"], spot["y"])
+        await page.wait_for_timeout(800)
+        return {
+            "case": case,
+            "itemClicks": await page.evaluate("() => window.__dismissProbe.itemClicks"),
+            "swallowedSelection": (
+                await page.evaluate("() => window.__dismissProbe.itemClicks") == 0
+            ),
+        }
+    elif case == "touch_neutral":
+        # A touch tap on a spot that CANNOT take focus. Radix defers its touch dismissal to the
+        # resulting click, and this guard swallows that click in the capture phase, so the
+        # deferred handler never runs. When the tapped element is focusable, `useFocusOutside`
+        # dismisses instead and the menu closes anyway. Plain thread background is not focusable,
+        # so this is the case where nothing else can cover for it.
+        spot = await page.evaluate(WATCH_NEUTRAL_JS, case == "touch_neutral")
+        if not spot:
+            return {"case": case, "error": "no qualifying neutral spot in the viewport"}
+        await page.touchscreen.tap(spot["x"], spot["y"])
+        await page.wait_for_timeout(1200)
+        after = await page.evaluate(FACTS_JS)
+        return {
+            "case": case,
+            "tappedTag": spot.get("tag"),
+            "menuClosed": not after["menuOpen"],
+            "deleted": after["assistantMessages"] < before["assistantMessages"],
+        }
+    elif case == "touch_trigger":
+        # Tap the trigger itself to close. The trigger is OUTSIDE the content, so the guard arms
+        # for it and swallows its click; if that were the only thing closing the menu, a touch
+        # user would be unable to cancel one of these menus without picking an item.
+        trigger = await page.evaluate(
+            "() => { const t = window.__heavyThread.actionButton('More');"
+            "if (!t) return null; const r = t.getBoundingClientRect();"
+            "return { x: r.x + r.width / 2, y: r.y + r.height / 2 }; }"
+        )
+        if not trigger:
+            return {"case": case, "error": "no More trigger"}
+        await page.touchscreen.tap(trigger["x"], trigger["y"])
+        await page.wait_for_timeout(1200)
+        after = await page.evaluate(FACTS_JS)
+        return {
+            "case": case,
+            "menuClosed": not after["menuOpen"],
+            "deleted": after["assistantMessages"] < before["assistantMessages"],
+        }
+    elif case in ("rightclick_then_click", "dragoff_then_click"):
+        # Two ways a dismissing gesture produces NO click at all: a right click raises
+        # contextmenu instead, and a press that leaves the window is released elsewhere. Either
+        # one leaves a guard with no upper bound armed indefinitely, so the user's next real
+        # click is eaten with nothing to associate it with.
+        spot = await page.evaluate(WATCH_NEUTRAL_JS, False)
+        if not spot:
+            return {"case": case, "error": "no qualifying neutral spot in the viewport"}
+        if case == "rightclick_then_click":
+            await page.mouse.click(spot["x"], spot["y"], button = "right")
+        else:
+            await page.mouse.move(spot["x"], spot["y"])
+            await page.mouse.down()
+            await page.mouse.move(4, 4)
+            await page.mouse.up()
+        # INSIDE the release-anchored grace window on purpose. Waiting it out was the first
+        # version of this case and it passed on a tree that was still eating the click, because
+        # it only ever asked whether the bound existed, not whether the guard should have armed
+        # for a gesture that cannot produce a click at all.
+        await page.wait_for_timeout(150)
+        await page.mouse.click(spot["x"], spot["y"])
+        await page.wait_for_timeout(600)
+        clicks = await page.evaluate("() => window.__dismissProbe.neutralClicks")
+        return {
+            "case": case,
+            "neutralClicks": clicks,
+            "swallowedLaterClick": clicks < 1,
+        }
+    elif case == "select_then_quick_click":
+        # The guard is mounted INSIDE the menu content, and Radix Presence keeps that content
+        # mounted for the 100ms `data-closed:animate-out` exit. So for that window after the menu
+        # has visibly closed, the document pointerdown listener is still installed and can arm on
+        # a press that has nothing to do with any menu. `second_click` cannot see this: it waits
+        # 200ms between clicks, which is outside the window. This one lands inside it.
+        item = await page.evaluate(WATCH_ITEM_JS)
+        if not item:
+            return {"case": case, "error": "no menu item to select"}
+        spot = await page.evaluate(WATCH_NEUTRAL_JS, False)
+        if not spot:
+            return {"case": case, "error": "no qualifying neutral spot in the viewport"}
+        await page.evaluate("() => { window.__dismissProbe.neutralClicks = 0; }")
+        await page.mouse.click(item["x"], item["y"])
+        # Inside the exit animation, deliberately. The content and its guard stay mounted
+        # for ~126ms after the item click, measured, so this press happens while the document
+        # listener is still installed. Sweepable to show the whole window, not one point.
+        await page.wait_for_timeout(int(os.environ.get("PROBE_EXIT_DELAY_MS", "40")))
+        await page.mouse.click(spot["x"], spot["y"])
+        await page.wait_for_timeout(600)
+        clicks = await page.evaluate("() => window.__dismissProbe.neutralClicks")
+        return {
+            "case": case,
+            "neutralClicks": clicks,
+            "swallowedLaterClick": clicks == 0,
+        }
+    elif case == "second_click":
+        # Dismiss on neutral ground, then click a real control. Only the FIRST click is the
+        # menu's to eat; a guard that stays armed would eat this one too.
+        spot = await page.evaluate(WATCH_NEUTRAL_JS, False)
+        if not spot:
+            return {"case": case, "error": "no qualifying neutral spot in the viewport"}
+        await page.mouse.click(spot["x"], spot["y"])
+        await page.wait_for_timeout(200)
+        await page.mouse.click(spot["x"], spot["y"])
+        await page.wait_for_timeout(600)
+        clicks = await page.evaluate("() => window.__dismissProbe.neutralClicks")
+        return {
+            "case": case,
+            "neutralClicks": clicks,
+            # One swallowed (the dismissal) and one delivered is the whole contract.
+            "swallowedSecondClick": clicks < 1,
+        }
+    else:
+        return {"case": case, "error": f"unknown case {case}"}
+
+    await page.wait_for_timeout(1500)
+    after = await page.evaluate(FACTS_JS)
+    return {
+        "case": case,
+        "bodyPointerEvents": before["bodyPointerEvents"],
+        "assistantMessagesBefore": before["assistantMessages"],
+        "assistantMessagesAfter": after["assistantMessages"],
+        # The whole question: did one dismissing interaction also delete a message.
+        "deleted": after["assistantMessages"] < before["assistantMessages"],
+        "menuClosed": not after["menuOpen"],
+    }
+
+
+async def run(engine: str, cases: list[str]) -> dict:
+    from playwright.async_api import async_playwright
+
+    out: dict = {"engine": engine, "chars": CHARS, "hold_ms": HOLD_MS, "cases": []}
+    async with async_playwright() as pw:
+        browser = await getattr(pw, engine).launch(headless = True)
+        for case in cases:
+            # A fresh context per case: a deleted message stays deleted, and a guard left
+            # armed by one case must not be inherited by the next.
+            context = await browser.new_context(
+                viewport = {"width": 1280, "height": 900},
+                has_touch = case.startswith("touch"),
+            )
+            page = await context.new_page()
+            await page.add_init_script(MULTI_POINTER_INIT)
+            await page.goto(f"{BASE}/smoke-heavy-thread.html", wait_until = "domcontentloaded")
+            await page.wait_for_function("() => Boolean(window.__heavyThread)", timeout = 60_000)
+            plan = await page.evaluate("(n) => window.__heavyThread.seed(n)", CHARS)
+            await page.wait_for_function(
+                "(n) => window.__heavyThread.messageCount() >= n",
+                arg = plan["messages"],
+                timeout = 300_000,
+            )
+            try:
+                out["cases"].append(await one_case(page, case, engine, context))
+            except Exception as exc:  # a failed case is a result, not a crash
+                out["cases"].append({"case": case, "error": repr(exc)})
+            await context.close()
+        await browser.close()
+    return out
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--label", default = "run")
+    ap.add_argument("--engine", default = "chromium", choices = ("chromium", "webkit", "firefox"))
+    ap.add_argument(
+        "--cases",
+        default = "quick,held,busy,held_modifier,held_enter,held_space,held_space_then_space,dismiss_then_space,dismiss_on_composer,touch,touch_hold_second_pointer,touch_hold_second_pointer_grace,select,select_then_quick_click,second_click,rightclick_then_click,dragoff_then_click,touch_neutral,touch_trigger",
+    )
+    args = ap.parse_args()
+    cases = [c.strip() for c in args.cases.split(",") if c.strip()]
+
+    vite = start_vite(PORT) if OWNS_SERVER else None
+    try:
+        wait_for_smoke_page(
+            f"{BASE}/smoke-heavy-thread.html",
+            "smoke-heavy-thread-main.tsx",
+            proc = vite,
+            info = lambda m: print(f"[probe] {m}", flush = True),
+        )
+        result = asyncio.run(run(args.engine, cases))
+    finally:
+        if vite is not None:
+            stop_process(vite)
+
+    out = Path("logs/pw") / f"dismiss_guard_{args.label}_{args.engine}.json"
+    out.parent.mkdir(parents = True, exist_ok = True)
+    out.write_text(json.dumps(result, indent = 2), encoding = "utf-8")
+    print(json.dumps(result, indent = 2))
+    print(f"[probe] wrote {out}", flush = True)
+
+    # A verdict nobody reads is not a gate. Deleting a message is the failure this exists to
+    # catch, and a case that could not run is a failure too, or a broken fixture would report
+    # a clean sheet.
+    # A case the engine cannot present is reported rather than counted either way. Reading it as
+    # a pass would let an engine with no multi-pointer input silently certify a guard nobody
+    # tested there.
+    skipped = [(c["case"], c["skipped"]) for c in result["cases"] if c.get("skipped")]
+    for case, why in skipped:
+        print(f"[probe] SKIPPED {case}: {why}", flush = True)
+    deleted = [c["case"] for c in result["cases"] if c.get("deleted")]
+    # A guard that swallows the dismissing click so thoroughly that Radix never sees it would
+    # leave the menu OPEN, which is its own bug and one this probe used to record and ignore.
+    stuck = [c["case"] for c in result["cases"] if "menuClosed" in c and not c["menuClosed"]]
+    broken = [c["case"] for c in result["cases"] if c.get("error")]
+    over = [
+        c["case"]
+        for c in result["cases"]
+        if c.get("swallowedSelection")
+        or c.get("swallowedSecondClick")
+        or c.get("swallowedLaterClick")
+        or c.get("lostComposerFocus")
+    ]
+    if over:
+        print(f"[probe] FAIL: the guard swallowed a click it should not have: {over}", flush = True)
+        broken = broken + over
+    if deleted:
+        print(
+            f"[probe] FAIL: dismissing the menu also deleted a message via {deleted}",
+            flush = True,
+        )
+    if broken:
+        print(f"[probe] FAIL: cases did not run: {broken}", flush = True)
+    if stuck:
+        print(f"[probe] FAIL: the menu did not close on {stuck}", flush = True)
+    if deleted or broken or stuck:
+        return 1
+    print("[probe] PASS: no dismissal variant reached the control underneath", flush = True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/studio/probe_dismiss_guard.py
+++ b/tests/studio/probe_dismiss_guard.py
@@ -111,8 +111,7 @@ from playwright_heavy_thread import (  # noqa: E402
 
 CHARS = int(os.environ.get("PROBE_CHARS", "25000"))
 HOLD_MS = int(os.environ.get("PROBE_HOLD_MS", "600"))
-# Past CLICK_GRACE_MS (500) in src/lib/menu-dismiss.ts, deliberately: the bound is the thing
-# `touch_hold_second_pointer_grace` is waiting out.
+# Deliberately beyond CLICK_GRACE_MS (500).
 GRACE_HOLD_MS = int(os.environ.get("PROBE_GRACE_HOLD_MS", "900"))
 
 OPEN_MENU_JS = """
@@ -149,16 +148,12 @@ FACTS_JS = """
 }
 """
 
-# Occupy the main thread so the guard's 300 ms timer expires between pointerdown and the
-# click the browser will synthesise on release. This is a stand-in for the style recalc
-# and React commit a real heavy thread does on the same press.
+# Simulate main-thread work between pointerdown and the synthesized click.
 BLOCK_JS = """
 (ms) => { const end = Date.now() + ms; while (Date.now() < end) {} }
 """
 
-# A guard that swallows too much is as broken as one that swallows too little, and the two
-# failures look identical from the outside (the menu closes either way). These two watch the
-# clicks that MUST still land.
+# Watch clicks that must still land.
 WATCH_ITEM_JS = """
 () => {
   // The first item forks into a new chat, so a fast runner can navigate before this probe reads
@@ -174,11 +169,7 @@ WATCH_ITEM_JS = """
 }
 """
 
-# Somewhere in the thread that is neither the menu nor the action bar. The listener goes on
-# whatever is ACTUALLY at the point, via elementFromPoint, rather than on an element chosen by
-# selector: the first `[data-role="user"]` in a seeded thread is scrolled far above the
-# viewport, so a rect-derived point lands somewhere else entirely and the probe reports zero
-# clicks on every tree, fixed or broken, which is a false alarm rather than a measurement.
+# Find a real neutral target in the visible thread.
 WATCH_NEUTRAL_JS = """
 (wantUnfocusable) => {
   const v = window.__heavyThread.viewport();
@@ -208,10 +199,7 @@ WATCH_NEUTRAL_JS = """
 """
 
 
-# Two pointers alive at once is the whole premise of `touch_hold_second_pointer`, and a run that
-# silently delivered only one would report a confident false negative. This records every
-# pointerdown the document sees, so the case can assert the overlap happened before it trusts a
-# verdict, and it counts the clicks the SECOND pointer's press must still deliver.
+# Record concurrent pointers and clicks for multi-pointer cases.
 MULTI_POINTER_INIT = """
 (() => {
   const st = { live: [], maxLive: 0, concurrentTypes: [], downs: [] };
@@ -247,10 +235,7 @@ MULTI_POINTER_INIT = """
 })()
 """
 
-# A point INSIDE the guard's own MENU_SURFACE that is not a selectable item, so the second
-# pointer's press is "inside the menu" and changes nothing by itself. Grid-searched rather than
-# guessed, and null rather than a fallback if the menu has no such point, so a run that could not
-# set the case up says so instead of testing something else.
+# Find a non-item point inside the menu for the second pointer.
 MENU_BLANK_JS = """
 () => {
   const menu = document.querySelector('[role="menu"]');
@@ -316,14 +301,11 @@ async def one_case(
     elif case == "busy":
         await page.mouse.move(x, y)
         await page.mouse.down()
-        # Not `wait_for_timeout`: the point is that the page is BUSY, not idle, so the
-        # press itself is a normal length and only the main thread is late.
+        # Keep the press normal-length while blocking the page.
         await page.evaluate(BLOCK_JS, HOLD_MS)
         await page.mouse.up()
     elif case == "held_modifier":
-        # Press, then press a modifier while still held, then release. Modifiers get pressed
-        # mid-gesture constantly. A guard that treats any keydown as "the user moved on" disarms
-        # here, and the release still synthesises the click, so the press lands on Delete.
+        # Modifiers may be pressed during a held gesture.
         await page.mouse.move(x, y)
         await page.mouse.down()
         await page.wait_for_timeout(120)
@@ -332,10 +314,7 @@ async def one_case(
         await page.mouse.up()
         await page.keyboard.up("Shift")
     elif case == "held_enter":
-        # Press and hold, then press Enter. A press on a button focuses it on Linux and Windows,
-        # so Enter activates the focused control and the browser fires a KEYBOARD-generated click
-        # while the pointer is still down. A guard that treats any click as the one it was armed
-        # for disarms on that, and the click the RELEASE synthesises then lands on Delete.
+        # Enter activates the focused button while the pointer remains down.
         await page.mouse.move(x, y)
         await page.mouse.down()
         await page.wait_for_timeout(120)
@@ -343,12 +322,7 @@ async def one_case(
         await page.wait_for_timeout(120)
         await page.mouse.up()
     elif case == "held_space":
-        # The same shape as `held_enter` with the one key that activates on KEYUP rather than
-        # keydown. Press and hold, hold Space down, RELEASE THE POINTER, then release Space. The
-        # pointer's own click arrives with the pointer already up, so a guard keyed on
-        # `pointerIsDown` spends itself on it, and the activation click Space fires on its keyup
-        # lands afterwards on a disarmed document. HTML spec: Space activates a button on keyup,
-        # Enter on keydown, which is why `held_enter` cannot cover this ordering.
+        # Space activates on keyup, after the pointer click.
         await page.mouse.move(x, y)
         await page.mouse.down()
         await page.wait_for_timeout(120)
@@ -358,12 +332,7 @@ async def one_case(
         await page.wait_for_timeout(120)
         await page.keyboard.up("Space")
     elif case == "held_space_then_space":
-        # `held_space` leaves the guard correct about the CLICK and wrong about the FOCUS. The
-        # press focuses the button; the held-Space branch swallows the pointer click and returns
-        # early, so nothing releases that focus. The gesture then ends with the button still
-        # focused, and the next ordinary Space -- the key a reader uses to scroll -- activates it
-        # and deletes the message. Same failure as `dismiss_then_space`, reached down the one
-        # path that skipped the blur.
+        # Ensure the swallowed press does not leave the button focused.
         await page.mouse.move(x, y)
         await page.mouse.down()
         await page.wait_for_timeout(120)
@@ -375,20 +344,12 @@ async def one_case(
         await page.wait_for_timeout(300)
         await page.keyboard.press("Space")
     elif case == "dismiss_then_space":
-        # Dismiss the menu with an ordinary click on the unconfirmed "Delete message" button, which
-        # the guard swallows, and then press Space -- the key a reader uses to scroll a thread. The
-        # press that was thrown away still FOCUSED that button, so the keystroke activates it. The
-        # modal shield never left this behind: with `pointer-events: none` on the body the press
-        # landed on `HTML` and the button was never focused.
+        # A swallowed dismissal must not leave Delete focused for Space activation.
         await page.mouse.click(x, y)
         await page.wait_for_timeout(300)
         await page.keyboard.press("Space")
     elif case in ("drag_then_space", "blur_then_space"):
-        # The pointerdown focuses Delete, but a drag can retarget the compatibility click to a
-        # common ancestor. Cleanup based on that click target therefore misses the focused
-        # button. The blur variant retires the guard before any click and pins the same cleanup
-        # requirement on the production window-blur handler. It dispatches the exact event
-        # directly because Playwright cannot reliably make a headless page lose OS focus.
+        # A drag may retarget the click; blur exercises the no-click cleanup path.
         spot = await page.evaluate(WATCH_NEUTRAL_JS, False)
         if not spot:
             return {"case": case, "error": "no qualifying neutral spot in the viewport"}
@@ -402,9 +363,7 @@ async def one_case(
         await page.wait_for_timeout(700)
         await page.keyboard.press("Space")
     elif case == "dismiss_on_composer":
-        # The other half of releasing the focus a swallowed press took: dismissing a menu by
-        # clicking INTO the composer must leave the caret there, or the guard has answered one
-        # unasked-for effect with another. Typing is the only honest test of that.
+        # Dismissing into the composer must preserve its caret.
         spot = await page.evaluate(
             "() => { const c = window.__heavyThread.composer(); if (!c) return null;"
             "const r = c.getBoundingClientRect();"
@@ -430,12 +389,7 @@ async def one_case(
     elif case == "touch":
         await page.touchscreen.tap(x, y)
     elif case in ("touch_hold_second_pointer", "touch_hold_second_pointer_grace"):
-        # A finger holds the unconfirmed "Delete message" button with the menu open, a MOUSE
-        # press lands inside the menu, then the finger lifts. Radix defers a touch dismissal to
-        # the resulting click, so the menu is still open under the second pointer, and a guard
-        # that lets any pointerdown disarm it has nothing left for the click the finger's release
-        # synthesises. Playwright's Touchscreen only exposes an atomic `tap()`, so holding a
-        # finger down needs CDP and this case runs on chromium alone.
+        # Hold touch while a mouse interacts with the open menu.
         if engine != "chromium" or context is None:
             return {
                 "case": case,
@@ -454,12 +408,6 @@ async def one_case(
         await page.wait_for_timeout(80)
         live = await page.evaluate("() => window.__multiPointer.live.length")
         await page.mouse.up()
-        # The _grace variant waits out the release-anchored bound with the FINGER STILL DOWN.
-        # `startGrace` is reached by the second pointer's own `pointerup`, and if it cannot tell
-        # that release from the guarded one it retires a gesture nobody has let go of; 500 ms
-        # later the guard is gone and the finger's own compatibility click lands on Delete.
-        # Measured on chromium: message deleted. The plain variant lifts INSIDE the window and
-        # therefore cannot see this at all, which is why both are kept.
         await page.wait_for_timeout(GRACE_HOLD_MS if case.endswith("_grace") else 150)
         if case.endswith("_grace"):
             still_down = await page.evaluate("() => window.__multiPointer.live.length")
@@ -473,10 +421,6 @@ async def one_case(
         await page.wait_for_timeout(1500)
         after = await page.evaluate(FACTS_JS)
         state = await page.evaluate("() => window.__multiPointer")
-        # Every one of these is a way the case could look green while having tested nothing: the
-        # finger's press never reaching the document, the menu closing on the touch after all, or
-        # only one of the two pointers ever being alive. An unmet premise is a FAILURE here, not
-        # a pass, because a probe that cannot tell you it missed is worse than no probe.
         if not held["menuOpen"]:
             return {
                 "case": case,
@@ -501,13 +445,9 @@ async def one_case(
             "menuClosed": not after["menuOpen"],
             "clicksSeen": state["clicks"],
             "clicksDelivered": state["delivered"],
-            # Recorded, not asserted on. The second pointer's own press produces no `click` at
-            # all while a touch point is live -- measured as zero on the fixed AND the unfixed
-            # tree -- so a "the menu press must still land" assertion here would fail on both and
-            # would be measuring the engine rather than the guard.
         }
     elif case == "select":
-        # Not a dismissal at all: a click INSIDE the menu, which must still reach its item.
+        # Selection inside the menu must reach its item.
         spot = await page.evaluate(WATCH_ITEM_JS)
         if not spot:
             return {"case": case, "error": "no menu item to select"}
@@ -521,11 +461,7 @@ async def one_case(
             ),
         }
     elif case == "touch_neutral":
-        # A touch tap on a spot that CANNOT take focus. Radix defers its touch dismissal to the
-        # resulting click, and this guard swallows that click in the capture phase, so the
-        # deferred handler never runs. When the tapped element is focusable, `useFocusOutside`
-        # dismisses instead and the menu closes anyway. Plain thread background is not focusable,
-        # so this is the case where nothing else can cover for it.
+        # A non-focusable touch target exercises Radix's deferred dismissal.
         spot = await page.evaluate(WATCH_NEUTRAL_JS, case == "touch_neutral")
         if not spot:
             return {"case": case, "error": "no qualifying neutral spot in the viewport"}
@@ -539,9 +475,7 @@ async def one_case(
             "deleted": after["assistantMessages"] < before["assistantMessages"],
         }
     elif case == "touch_trigger":
-        # Tap the trigger itself to close. The trigger is OUTSIDE the content, so the guard arms
-        # for it and swallows its click; if that were the only thing closing the menu, a touch
-        # user would be unable to cancel one of these menus without picking an item.
+        # Tapping the trigger must still close the menu.
         trigger = await page.evaluate(
             "() => { const t = window.__heavyThread.actionButton('More');"
             "if (!t) return null; const r = t.getBoundingClientRect();"
@@ -558,17 +492,12 @@ async def one_case(
             "deleted": after["assistantMessages"] < before["assistantMessages"],
         }
     elif case in ("rightclick_then_click", "dragoff_then_click"):
-        # Two ways a dismissing gesture produces NO click at all: a right click raises
-        # contextmenu instead, and a press that leaves the window is released elsewhere. Either
-        # one leaves a guard with no upper bound armed indefinitely, so the user's next real
-        # click is eaten with nothing to associate it with.
+        # These dismissing gestures may produce no click.
         spot = await page.evaluate(WATCH_NEUTRAL_JS, False)
         if not spot:
             return {"case": case, "error": "no qualifying neutral spot in the viewport"}
         if case == "rightclick_then_click":
-            # Keep WebKit's native context-menu UI from consuming the next automated mouse input.
-            # The contextmenu event still fires, so this isolates the page-level guard behavior
-            # the case is meant to test instead of mistaking browser chrome for a swallowed click.
+            # Prevent browser chrome from consuming the next automated click.
             await page.evaluate(
                 """() => document.addEventListener(
                     "contextmenu", (event) => event.preventDefault(),
@@ -595,11 +524,7 @@ async def one_case(
             "swallowedLaterClick": clicks < 1,
         }
     elif case == "select_then_quick_click":
-        # The guard is mounted INSIDE the menu content, and Radix Presence keeps that content
-        # mounted for the 100ms `data-closed:animate-out` exit. So for that window after the menu
-        # has visibly closed, the document pointerdown listener is still installed and can arm on
-        # a press that has nothing to do with any menu. `second_click` cannot see this: it waits
-        # 200ms between clicks, which is outside the window. This one lands inside it.
+        # Exercise a click during the menu's exit animation.
         item = await page.evaluate(WATCH_ITEM_JS)
         if not item:
             return {"case": case, "error": "no menu item to select"}
@@ -608,9 +533,6 @@ async def one_case(
             return {"case": case, "error": "no qualifying neutral spot in the viewport"}
         await page.evaluate("() => { window.__dismissProbe.neutralClicks = 0; }")
         await page.mouse.click(item["x"], item["y"])
-        # Inside the exit animation, deliberately. The content and its guard stay mounted
-        # for ~126ms after the item click, measured, so this press happens while the document
-        # listener is still installed. Sweepable to show the whole window, not one point.
         await page.wait_for_timeout(int(os.environ.get("PROBE_EXIT_DELAY_MS", "40")))
         await page.mouse.click(spot["x"], spot["y"])
         await page.wait_for_timeout(600)
@@ -621,8 +543,7 @@ async def one_case(
             "swallowedLaterClick": clicks == 0,
         }
     elif case == "second_click":
-        # Dismiss on neutral ground, then click a real control. Only the FIRST click is the
-        # menu's to eat; a guard that stays armed would eat this one too.
+        # Only the dismissing click may be swallowed.
         spot = await page.evaluate(WATCH_NEUTRAL_JS, False)
         if not spot:
             return {"case": case, "error": "no qualifying neutral spot in the viewport"}
@@ -634,7 +555,6 @@ async def one_case(
         return {
             "case": case,
             "neutralClicks": clicks,
-            # One swallowed (the dismissal) and one delivered is the whole contract.
             "swallowedSecondClick": clicks < 1,
         }
     else:
@@ -647,7 +567,6 @@ async def one_case(
         "bodyPointerEvents": before["bodyPointerEvents"],
         "assistantMessagesBefore": before["assistantMessages"],
         "assistantMessagesAfter": after["assistantMessages"],
-        # The whole question: did one dismissing interaction also delete a message.
         "deleted": after["assistantMessages"] < before["assistantMessages"],
         "menuClosed": not after["menuOpen"],
     }
@@ -660,8 +579,6 @@ async def run(engine: str, cases: list[str]) -> dict:
     async with async_playwright() as pw:
         browser = await getattr(pw, engine).launch(headless = True)
         for case in cases:
-            # A fresh context per case: a deleted message stays deleted, and a guard left
-            # armed by one case must not be inherited by the next.
             context = await browser.new_context(
                 viewport = {"width": 1280, "height": 900},
                 has_touch = case.startswith("touch"),
@@ -712,21 +629,13 @@ def main() -> int:
     out = Path("logs/pw") / f"dismiss_guard_{args.label}_{args.engine}.json"
     out.parent.mkdir(parents = True, exist_ok = True)
     out.write_text(json.dumps(result, indent = 2), encoding = "utf-8")
-    print(json.dumps(result, indent = 2))
+    print(json.dumps(result, indent=2))
     print(f"[probe] wrote {out}", flush = True)
 
-    # A verdict nobody reads is not a gate. Deleting a message is the failure this exists to
-    # catch, and a case that could not run is a failure too, or a broken fixture would report
-    # a clean sheet.
-    # A case the engine cannot present is reported rather than counted either way. Reading it as
-    # a pass would let an engine with no multi-pointer input silently certify a guard nobody
-    # tested there.
     skipped = [(c["case"], c["skipped"]) for c in result["cases"] if c.get("skipped")]
     for case, why in skipped:
         print(f"[probe] SKIPPED {case}: {why}", flush = True)
     deleted = [c["case"] for c in result["cases"] if c.get("deleted")]
-    # A guard that swallows the dismissing click so thoroughly that Radix never sees it would
-    # leave the menu OPEN, which is its own bug and one this probe used to record and ignore.
     stuck = [c["case"] for c in result["cases"] if "menuClosed" in c and not c["menuClosed"]]
     broken = [c["case"] for c in result["cases"] if c.get("error")]
     over = [


### PR DESCRIPTION
## The bug

Dismissing the chat action bar's "More" menu can delete a message, with no confirmation.

#8992 set `modal={false}` on `ActionBarMorePrimitive.Root` in `studio/frontend/src/components/assistant-ui/thread.tsx`. That was the right call and this PR keeps it: a modal Radix layer parks `pointer-events: none` on `<body>`, which is an inherited property, so every open invalidates computed style for the whole thread. `studio/frontend/tests/action-menu-modal-layer.test.ts` pins the menu non-modal and carries the numbers.

What that shield was also doing is absorbing the press that dismisses the menu. Radix's outside handler closes the layer but never cancels the event, so one press on a control beside the menu both closes it and fires that control. Two buttons from the trigger sits `DeleteMessageButton` (`thread.tsx:7033`), which deletes on `onClick` with no confirmation.

Measured with `tests/studio/probe_dismiss_guard.py` against a seeded thread of 10 assistant messages:

| tree | chromium | webkit |
|---|---|---|
| `origin/main` (6e5360ca9) | 11 gestures deleted a message | 9 gestures deleted a message |
| this branch | none | none |

The gestures that reach it include a quick click, a press held past any fixed deadline, a press while the main thread is busy, a touch tap, a press with a modifier, Enter or Space pressed mid-press, and Space pressed after the menu was already dismissed.

## The fix

`studio/frontend/src/lib/menu-dismiss.ts` swallows exactly the click that dismissed the menu.

It arms from `pointerdown` on `document` in the **capture** phase, not from Radix's `onPointerDownOutside`. Two reasons, both measured rather than assumed. A guard armed from that callback and retired by a fixed timer is gone before the browser synthesises `click` on release, and a press can be held for as long as the user likes. And `usePointerDownOutside` in `@radix-ui/react-dismissable-layer` 1.1.11 defers to the resulting `click` for `pointerType === "touch"`, listening on `ownerDocument` in the bubble phase, while React 19 delegates to the root container inside `document`, so the control's own `onClick` has already run by the time Radix calls back.

The upper bound is anchored at `pointerup`, not at the press, so a gesture that never becomes a click cannot leave the swallower waiting for an unrelated one. A non-primary button never arms it at all, since a right click raises `contextmenu` and no `click`.

Throwing the click away is only half of undoing the press. The press also focuses what it landed on, and a focused button is one Space away from firing, so the swallow releases the focus it took unless the target takes text.

`studio/frontend/src/lib/menu-dismiss-guard.tsx` exposes `<MenuDismissGuard />`, mounted inside `ActionBarMorePrimitive.Content`. Radix mounts content on open and unmounts it on close, so the guard's lifetime is the menu's with no `onOpenChange` wiring.

The sidebar's "More" destinations flyout stays non-modal and unguarded. It opens on pointer enter, so an unconditional swallow there would eat an ordinary click on the nav row the pointer was heading for. `nonmodal-menu-dismiss-guard.test.ts` records that as an explicit exception and fails on any other unguarded `modal={false}` menu.

## Before and after

Same fixture, same viewport, same gesture: open the last reply's "More" menu, press and hold its "Delete message" button for 600ms, release. Captured at 6e5360ca9 and at this branch's head.

On `main`, reply 9 is gone and the thread ends at the prompt that produced it:

![one dismissing press on main deletes the reply](https://raw.githubusercontent.com/mahiatlinux/unsloth/pr-assets-action-bar-dismiss-delete/before-main.png)

On this branch the menu closes and the reply is still there:

![the same press on this branch only closes the menu](https://raw.githubusercontent.com/mahiatlinux/unsloth/pr-assets-action-bar-dismiss-delete/after-fix.png)

## Tests

`tests/studio/probe_dismiss_guard.py` drives the real menu on the heavy-thread smoke page through 19 cases and is wired into `studio-frontend-ci.yml` as a gate. It watches both directions: the dismissing press must not reach the control underneath, and a click inside the menu, a second click after a dismissal, and the click after a right-click dismissal must all still land.

`nonmodal-menu-second-pointer.test.ts` drives the arm/disarm state machine against a fake document, where the clock can be advanced by hand rather than slept through.

`nonmodal-menu-dismiss-guard.test.ts` sweeps every `.tsx` under `src/` for `modal={false}` and requires the guard or a listed exception.

## Checks

- `probe_dismiss_guard.py`: passes on chromium and webkit, fails on both at the merge base
- `npm test`: 3800 of 3801. The one failure, `queued-model-capabilities.test.ts`, is pre-existing on `main` (`image-input-support.ts:7` imports `./mmproj-fallback` without an extension)
- `npm run typecheck`, `npm run build`, `npm run bundle:check`: clean, and the bundle stays within budget
- `eslint`: no new findings, the 55 in `thread.tsx` and `app-sidebar.tsx` are unchanged from `main`
- `ruff check`, `ruff format`, `biome check` on the new files: clean
- six mutations applied to the fix: five caught by the node tests, and removing the branch that handles a keyboard-generated click mid-press is caught by the probe's `held_enter` case
