### PR TITLE
fix(studio): the sidebar More menu no longer opens over a modal dialog (#9244)

### DIFF
--- a/studio/backend/tests/test_rag_store.py
+++ b/studio/backend/tests/test_rag_store.py
@@ -451,8 +451,12 @@ def test_a_legacy_archive_still_gets_two_different_ends(rag_home, rag_conn):
         store.add_chunks(conn, scope, document, [chunk], [[0.0, 0.0, 0.0, 0.0]])
     conn.commit()
 
-    oldest = [chunk for chunk, _ in store.search_lexical(conn, scope, "ZQXLEGACY", 3, oldest_first = True)]
-    newest = [chunk for chunk, _ in store.search_lexical(conn, scope, "ZQXLEGACY", 3, newest_first = True)]
+    oldest = [
+        chunk for chunk, _ in store.search_lexical(conn, scope, "ZQXLEGACY", 3, oldest_first = True)
+    ]
+    newest = [
+        chunk for chunk, _ in store.search_lexical(conn, scope, "ZQXLEGACY", 3, newest_first = True)
+    ]
 
     assert oldest and newest
     assert oldest != newest, "both ends of the fetch returned the same rows"

--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -121,6 +121,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { Tooltip as TooltipPrimitive } from "radix-ui";
+import { modalLayerActive } from "@/lib/modal-layer-active";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { ChevronDown, Moon } from "lucide-react";
 import {
@@ -3148,6 +3149,14 @@ export function AppSidebar() {
                             data-menu-open={moreOpen ? "true" : undefined}
                             onPointerDownCapture={(event) => {
                               if (event.button !== 0 || event.ctrlKey) return;
+                              // A modal Radix dialog sets pointer-events:none
+                              // on <body>, which shields every other trigger —
+                              // but this one drives open state in JS after
+                              // preventDefault, so the layer does not stop it
+                              // and the menu opened over the dialog (#9244).
+                              if (modalLayerActive()) {
+                                return;
+                              }
                               event.preventDefault();
                               event.stopPropagation();
                               event.currentTarget.focus({ preventScroll: true });

--- a/studio/frontend/src/lib/modal-layer-active.ts
+++ b/studio/frontend/src/lib/modal-layer-active.ts
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+
+/**
+ * True while a modal Radix layer (dialog, alert dialog) holds the page.
+ *
+ * Radix marks modalness on the body — `pointer-events: none` for the rest of
+ * the document — which is exactly what should shield off-dialog triggers. A
+ * trigger that drives its open state in JavaScript after preventDefault
+ * bypasses that shield (#9244), so it needs to consult it explicitly. Reading
+ * the style covers every modal dialog without each call site enumerating them.
+ */
+export function modalLayerActive(doc: Document = document): boolean {
+  const body = doc.body;
+  if (!body) return false;
+  return doc.defaultView?.getComputedStyle(body).pointerEvents === "none";
+}

--- a/studio/frontend/tests/modal-layer-active.test.ts
+++ b/studio/frontend/tests/modal-layer-active.test.ts
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+
+// #9244: the sidebar "More" menu's trigger drives open state in JS after
+// preventDefault, so the modal dialog's body-level pointer-events:none shield
+// never stops it. modalLayerActive() is the explicit consult of that shield.
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { modalLayerActive } from "../src/lib/modal-layer-active.ts";
+
+type FakeDoc = {
+  body: object;
+  defaultView: { getComputedStyle(body: object): { pointerEvents: string } };
+};
+
+function fakeDoc(pointerEvents: string): FakeDoc {
+  const body = {};
+  return {
+    body,
+    defaultView: { getComputedStyle: () => ({ pointerEvents }) },
+  };
+}
+
+test("detects an active modal layer (pointer-events: none)", () => {
+  assert.equal(modalLayerActive(fakeDoc("none") as unknown as Document), true);
+});
+
+test("a non-modal page reports no layer", () => {
+  assert.equal(modalLayerActive(fakeDoc("auto") as unknown as Document), false);
+  assert.equal(modalLayerActive(fakeDoc("") as unknown as Document), false);
+});
+
+test("a body-less document reports no layer rather than throwing", () => {
+  const bodyless = { body: null, defaultView: null } as unknown as Document;
+  assert.equal(modalLayerActive(bodyless), false);
+});


### PR DESCRIPTION
Closes #9244.

## The asymmetry, per the issue's measurement

A modal Radix dialog shields the page with `pointer-events: none` on `body` — every other sidebar trigger stays blocked (3/3 on chromium/firefox/webkit). But the **More** menu's trigger drives its open state **in JavaScript after `preventDefault`**, so the shield never reached it: the menu opened over the dialog while its siblings stayed blocked.

## The fix

The trigger's `onPointerDownCapture` now consults the shield explicitly via a new `modalLayerActive()` helper — `getComputedStyle(document.body).pointerEvents === "none"`. Reading the style directly covers **every** modal dialog without the sidebar having to enumerate them, which is what keeps this correct as dialogs are added. The keyboard path needs no guard: a modal dialog traps focus, so the trigger is unreachable by Tab while one is open.

The helper lives in `src/lib/` as a testable primitive; #9245's `MenuDismissGuard` work (on #9051) can reuse the same consult if it ever needs the inverse question.

## Tests

Three in `tests/modal-layer-active.test.ts`: the layer is detected at `pointer-events: none`, a non-modal page (`auto`/empty) reports no layer, and a body-less document reports no layer rather than throwing. 3/3 green; `tsc --noEmit` clean; the new files lint clean (the 3 pre-existing `app-sidebar.tsx` lint errors are byte-identical before and after — a restricted-import and two immutability findings on untouched lines).