### PR TITLE
Reject a negative chunking stride instead of silently dropping text

### DIFF
--- a/tests/test_raw_text.py
+++ b/tests/test_raw_text.py
@@ -374,6 +374,61 @@ def test_smart_chunk_text_empty_input_returns_no_chunks():
     return True
 
 
+def test_negative_stride_is_rejected():
+    """chunk_size > 0 and stride < chunk_size both pass for a negative stride, but
+    `start_idx += chunk_size - stride` then advances by MORE than chunk_size, so the
+    tokens between one chunk's end and the next chunk's start are never emitted.
+    Nothing raises and nothing is logged, so the caller trains on a corpus with holes
+    in it: chunk_size = 10 with stride = -5 emits 70 of a 100 token document."""
+
+    class CharTokenizer:
+        def __init__(self):
+            self.eos_token = "</s>"
+            self.eos_token_id = 2
+
+        def __call__(
+            self,
+            text,
+            return_tensors = None,
+            add_special_tokens = False,
+        ):
+            token_ids = [ord(c) % 100 for c in text]
+            if return_tensors == "pt":
+                return {"input_ids": [token_ids]}
+            return {"input_ids": token_ids}
+
+        def decode(
+            self,
+            token_ids,
+            skip_special_tokens = False,
+        ):
+            return "".join(chr(32 + (t % 90)) for t in token_ids)
+
+    tokenizer = CharTokenizer()
+    text = "x" * 100
+
+    # Both entry points validate stride, so both need the lower bound.
+    try:
+        RawTextDataLoader(tokenizer, chunk_size = 10, stride = -5)
+        assert False, "the constructor should reject a negative stride"
+    except ValueError as e:
+        assert "stride" in str(e) and "non-negative" in str(e), str(e)
+
+    loader = RawTextDataLoader(tokenizer, chunk_size = 10, stride = 0)
+    try:
+        loader.smart_chunk_text(text, chunk_size = 10, stride = -5)
+        assert False, "smart_chunk_text should reject a negative stride"
+    except ValueError as e:
+        assert "stride" in str(e) and "non-negative" in str(e), str(e)
+
+    # stride = 0 stays valid: it just means the chunks do not overlap.
+    chunks = loader.smart_chunk_text(text, chunk_size = 10, stride = 0)
+    assert len(chunks) > 0, "stride = 0 should still produce chunks"
+
+    print("test_negative_stride_is_rejected passed")
+    return True
+
+
 def test_load_from_files_all_empty_raises():
     """All-empty file list must raise (like load_from_file) instead of returning
     a 0-row text-column dataset in return_tokenized mode."""
@@ -633,6 +688,7 @@ if __name__ == "__main__":
     success = test_load_from_file_skips_non_object_json_lines() and success
     success = test_smart_chunk_text_empty_input_returns_no_chunks() and success
     success = test_load_from_files_all_empty_raises() and success
+    success = test_negative_stride_is_rejected() and success
     success = test_validate_dataset_handles_tokenized_and_text_columns() and success
     success = test_validate_dataset_accepts_objects_without_column_names() and success
     success = test_validate_dataset_streams_instead_of_materialising_columns() and success

--- a/unsloth/dataprep/raw_text.py
+++ b/unsloth/dataprep/raw_text.py
@@ -44,6 +44,8 @@ class RawTextDataLoader:
     ):
         if chunk_size <= 0:
             raise ValueError(f"chunk_size must be positive, got {chunk_size}")
+        if stride < 0:
+            raise ValueError(f"stride must be non-negative, got {stride}")
         if stride >= chunk_size:
             raise ValueError(f"stride ({stride}) must be smaller than chunk_size ({chunk_size})")
         self.tokenizer = tokenizer
@@ -138,6 +140,11 @@ class RawTextDataLoader:
         """
         if chunk_size <= 0:
             raise ValueError(f"chunk_size must be positive, got {chunk_size}")
+        if stride < 0:
+            raise ValueError(
+                f"stride must be non-negative, got {stride}: a negative stride advances the loop by "
+                f"more than chunk_size and silently skips the tokens in between"
+            )
         if stride >= chunk_size:
             raise ValueError(
                 f"stride ({stride}) must be smaller than chunk_size ({chunk_size}) to progress the chunking loop"


### PR DESCRIPTION
### Motivation

`RawTextDataLoader` already guards its two chunking parameters, in the constructor and again in `smart_chunk_text` (which is public and takes them as its own arguments):

```python
if chunk_size <= 0:
    raise ValueError(f"chunk_size must be positive, got {chunk_size}")
if stride >= chunk_size:
    raise ValueError(f"stride ({stride}) must be smaller than chunk_size ({chunk_size})")
```

Neither checks the lower bound. A **negative** stride is accepted, and the loop then advances by more than a whole chunk:

```python
start_idx += chunk_size - stride    # stride = -5, chunk_size = 10  ->  += 15
```

so the tokens between one chunk's end and the next chunk's start are never emitted. Nothing raises, nothing is logged, and `load_from_file` returns a normal-looking dataset, so the caller fine-tunes on a corpus with holes in it.

This is the quiet failure of the pair. The existing `stride >= chunk_size` guard exists because that direction makes the loop stop progressing, which is loud. The negative direction loses data instead.

### Reproduction

100-token document, `chunk_size = 10`, one token per index, against `main`:

```
stride= -5:  7 chunks, 30 of 100 tokens never emitted  [10, 11, 12, 13, 14, 25, 26, 27, ...]
stride=  0: 10 chunks,  0 of 100 tokens never emitted  []
stride=  5: 19 chunks,  0 of 100 tokens never emitted  []
```

30% of the document is gone, and the missing indices are exactly the `chunk_size - stride` overshoot repeating at every step. `RawTextDataLoader(tokenizer, chunk_size=10, stride=-5)` constructs without complaint too.

### Fix

Add the matching lower-bound guard in both places the pair is already validated. `stride = 0` stays valid, which is the meaningful boundary: it simply means chunks do not overlap, and the run above confirms it emits every token.

### Tests

`test_negative_stride_is_rejected()` in `tests/test_raw_text.py`: the constructor rejects a negative stride, `smart_chunk_text` rejects it directly, and `stride = 0` still produces chunks (the control that keeps the new guard from over-reaching).

It is a standalone top-level test rather than an addition to `test_raw_text_loader()`. That function wraps its body in `except Exception: print(...); return False`, which swallows `AssertionError`, so an assertion added there passes under pytest no matter what the code does. The first version of this PR made exactly that mistake.

```
# unpatched raw_text.py + this test file
$ python3 -m pytest tests/test_raw_text.py -q
1 failed, 9 passed
FAILED tests/test_raw_text.py::test_negative_stride_is_rejected

# this branch
$ python3 -m pytest tests/test_raw_text.py -q
10 passed
```

Via the file's own `__main__` runner, `python3 tests/test_raw_text.py` exits 1 before the fix and 0 after.

Controls, same environment:

- `tests/test_raw_text.py` unmodified against unmodified `raw_text.py`: `9 passed`, so the failure above is the new test and not a pre-existing break.
- `tests/test_raw_text_json_loading.py`: `8 passed` both with and without the change.
