### PR TITLE
Update README to include Intel XPU support description for unsloth studio

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Unsloth Studio (Beta) works on **Windows, Linux, WSL** and **macOS**.
 * **NVIDIA:** Training works on RTX 30/40/50, Blackwell, DGX Spark, Station and more
 * **macOS:** Training, MLX and GGUF inference are ALL supported.
 * **AMD:** Training, RL, chat and deployment work on Windows, WSL and Linux. [Read the AMD guide](https://unsloth.ai/docs/basics/amd).
+* **Intel:** Training and GGUF inference are supported on Intel GPUs (XPU).
 * **Vulkan:** GGUF inference is supported on [compatible GPUs, including Intel GPUs](https://github.com/unslothai/unsloth/pull/5819). Vulkan accelerates GGUF inference only; training still requires a supported PyTorch or MLX backend.
 * **Multi-GPU:** Available now, with a major upgrade on the way
 


### PR DESCRIPTION
## What This PR Does

Adds Intel GPU (XPU) support to the Unsloth studio section in the README.
Depends on #9084 which enables XPU auto-detection and llama.cpp SYCL compilation, which this PR also validates it on Intel hardware, see section below.

## Validation

Tested #9084 implementation and verified its working on an Intel 4x Arc Pro B60 24GB (XPU). 
I had to explicitly source `oneapi/setvars.sh` to enable `sycl-ls` and `icpx` on `PATH` and set `UNSLOTH_LLAMA_FORCE_COMPILE=1` (from `studio/setup.sh`) to force the source build path so that llama.cpp builds on the SYCL backend rather than Vulkan backend.

Install command for Intel XPU detection:

```bash
source intel/oneapi/setvars.sh    # intel oneapi path
cd unsloth && UNSLOTH_LLAMA_FORCE_COMPILE=1 . install.sh     # with PR9084 changes
```
Note: Not sourcing `oneapi/setvars.sh` also works. When `sycl-ls`/`xpu-smi` are not on `PATH`, it fallbacks to checking for vendor `0x8086` in `/sys/bus/pci/devices` under the `_has_intel_xpu_gpu()` function.

Output:
The install detects Intel GPU (XPU) and installs `torch 2.10.0+xpu` correctly.
<img width="982" height="325" alt="image" src="https://github.com/user-attachments/assets/36c57824-d9c3-421c-9e69-db5b6db721ee" />

To confirm the llama.cpp backend is using `SYCL`:

```bash
source intel/oneapi/setvars.sh   # intel oneapi path
export LD_LIBRARY_PATH=~/.unsloth/llama.cpp/build/bin:$LD_LIBRARY_PATH   # the source build produces shared libs that need to be found
~/.unsloth/llama.cpp/build/bin/llama-server --list-devices
```

Output:
```text
Available devices:
  SYCL0: Intel(R) Arc(TM) Pro B60 Graphics (24480 MiB, 24480 MiB free)
  SYCL1: Intel(R) Arc(TM) Pro B60 Graphics (24480 MiB, 24480 MiB free)
  SYCL2: Intel(R) Arc(TM) Pro B60 Graphics (24480 MiB, 24480 MiB free)
  SYCL3: Intel(R) Arc(TM) Pro B60 Graphics (24480 MiB, 24480 MiB free)
```