### PR TITLE
Bound every apt step in CI, and fix the retry that never ran

### DIFF
--- a/.github/scripts/retry-with-apt-lock.sh
+++ b/.github/scripts/retry-with-apt-lock.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+#
+# Run a command that talks to apt, bounded per attempt and retried.
+#
+# GitHub's Azure apt mirror stalls on these runners. Observed repeatedly in one
+# day: `playwright install --with-deps` sat in apt's download loop three times,
+# and `Linux deps` (a bare `apt-get update && apt-get install`) sat there for 28
+# minutes before anyone noticed. An unbounded apt step is not slow, it is silent:
+# it spends the job's whole timeout-minutes, GitHub scores the result as
+# "cancelled" rather than a failure, prints no reason, and skips every step after
+# it. A shard then reports nothing about its subject because a mirror hiccuped.
+#
+# Two things make the retry actually work, and both were learned the hard way:
+#
+#   1. The dpkg lock. apt runs as root, so killing the attempt leaves the
+#      apt-get child alive holding /var/lib/dpkg/lock-frontend, and the next
+#      attempt dies two seconds later with "Could not get lock". A retry that
+#      cannot succeed is worse than none: it buries the real reason under a
+#      second, different failure. So wait for the lock, then take it -- the
+#      holder is our own orphan and the runner is disposable.
+#
+#   2. `set -e`. GitHub runs `run:` blocks as `bash -e`, so a bare failing
+#      command aborts the step then and there. A retry loop written as
+#      `timeout ... ; rc=$?` never reaches its second attempt: the step exits 124
+#      with no output at all, which is exactly how the first version of this
+#      shipped and why it is a script now rather than eight inline copies.
+#
+# Usage:
+#   bash .github/scripts/retry-with-apt-lock.sh apt-get update
+#   bash .github/scripts/retry-with-apt-lock.sh apt-get install -y foo bar
+#   bash .github/scripts/retry-with-apt-lock.sh python -m playwright install --with-deps chromium
+#
+# Environment:
+#   RETRY_ATTEMPTS         attempts before giving up   (default 3)
+#   RETRY_ATTEMPT_TIMEOUT  seconds per attempt         (default 480)
+#
+# Deliberately no `set -e`: this script reads exit codes itself, and -e would
+# abort it on the very first failing attempt -- the bug described above.
+set -uo pipefail
+
+ATTEMPTS="${RETRY_ATTEMPTS:-3}"
+ATTEMPT_TIMEOUT="${RETRY_ATTEMPT_TIMEOUT:-480}"
+DPKG_LOCK="/var/lib/dpkg/lock-frontend"
+
+if [ "$#" -eq 0 ]; then
+  echo "::error::retry-with-apt-lock.sh needs a command to run" >&2
+  exit 2
+fi
+
+# Best effort: a runner without fuser still retries, it just cannot wait on the
+# lock. Reported once rather than silently, so a retry that fails on a held lock
+# is explicable.
+have_fuser() { command -v fuser > /dev/null 2>&1; }
+
+release_dpkg_lock() {
+  if ! have_fuser; then
+    echo "::warning::fuser unavailable; cannot wait on ${DPKG_LOCK}, retrying blind"
+    sleep 15
+    return 0
+  fi
+  for _ in $(seq 1 24); do
+    sudo fuser "$DPKG_LOCK" > /dev/null 2>&1 || return 0
+    sleep 5
+  done
+  echo "::warning::${DPKG_LOCK} still held after 120s; terminating the holder"
+  sudo fuser -k "$DPKG_LOCK" > /dev/null 2>&1 || true
+  sleep 5
+}
+
+for attempt in $(seq 1 "$ATTEMPTS"); do
+  rc=0
+  # `|| rc=$?` keeps this exempt from any -e a caller may have set, and records
+  # the status instead of ending the script.
+  timeout --signal=TERM --kill-after=30 "$ATTEMPT_TIMEOUT" "$@" || rc=$?
+  if [ "$rc" -eq 0 ]; then
+    [ "$attempt" -gt 1 ] && echo "::notice::succeeded on attempt ${attempt}"
+    exit 0
+  fi
+
+  # 124 is timeout's own "I killed it"; 137 is SIGKILL landing after
+  # --kill-after. Anything else is the command itself refusing, and saying "did
+  # not finish" about a two-second exit sends the next reader looking for a
+  # stall that never happened.
+  if [ "$rc" -eq 124 ] || [ "$rc" -eq 137 ]; then
+    reason="did not finish within ${ATTEMPT_TIMEOUT}s"
+  else
+    reason="exited with status ${rc}"
+  fi
+  echo "::warning::attempt ${attempt}/${ATTEMPTS} of '$*' ${reason}"
+
+  [ "$attempt" -ge "$ATTEMPTS" ] && break
+  release_dpkg_lock
+done
+
+echo "::error::'$*' failed ${ATTEMPTS} times; the attempt warnings above say which way each one went"
+exit 1

--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -41,6 +41,7 @@ on:
       - 'tests/**'
       - 'pyproject.toml'
       - '.github/workflows/consolidated-tests-ci.yml'
+      - '.github/scripts/retry-with-apt-lock.sh'
   push:
     branches: [main]
     paths:
@@ -50,6 +51,7 @@ on:
       - 'tests/**'
       - 'pyproject.toml'
       - '.github/workflows/consolidated-tests-ci.yml'
+      - '.github/scripts/retry-with-apt-lock.sh'
   workflow_dispatch:
     inputs:
       unsloth_zoo_ref:
@@ -2371,6 +2373,10 @@ jobs:
           pip show unsloth_zoo
 
       - name: llama.cpp install via unsloth_zoo.llama_cpp + CLI `--help` smoke
+        # Bounds the apt preamble below rather than leaving the job's 25m to do
+        # it: 2 x 300s of attempts plus a lock wait is 12m of the 22, and the
+        # llama.cpp build that follows has the rest.
+        timeout-minutes: 22
         # Exercise the canonical `unsloth_zoo.llama_cpp.install_llama_cpp`
         # flow that GGUF export uses at runtime: clone ggml-org/llama.cpp
         # into ~/.unsloth/llama.cpp, build the LLAMA_CPP_TARGETS list
@@ -2406,9 +2412,9 @@ jobs:
           # libssl-dev / libcurl4-openssl-dev are needed by llama.cpp's
           # cmake build for HTTPS support; install up-front so the
           # `install_llama_cpp` requirement-check is a no-op.
-          sudo apt-get update -qq
-          sudo apt-get install -y -qq build-essential cmake git curl \
-            libgomp1 libssl-dev libcurl4-openssl-dev
+          RETRY_ATTEMPTS=2 RETRY_ATTEMPT_TIMEOUT=300 \
+            bash .github/scripts/retry-with-apt-lock.sh sudo sh -c \
+            'apt-get update -qq && apt-get install -y -qq build-essential cmake git curl libgomp1 libssl-dev libcurl4-openssl-dev'
           python <<'PY'
           import os, shutil, subprocess, sys, pathlib
           # Apply the same CPU spoof the pytest shims use BEFORE any

--- a/.github/workflows/desktop-app-clean-machine-ci.yml
+++ b/.github/workflows/desktop-app-clean-machine-ci.yml
@@ -25,6 +25,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/desktop-app-clean-machine-ci.yml'
+      - '.github/scripts/retry-with-apt-lock.sh'
 
       - '.github/scripts/resolve-desktop-release.py'
       - '.github/scripts/clean-machine-env.sh'
@@ -389,12 +390,18 @@ jobs:
           bash .github/scripts/clean-machine-assert.sh absent
 
       - name: Install with NO dev tooling, only runtime libs
+        # The apt preamble below is bounded by the shared helper; the `.deb` install
+        # after it deliberately is not, because whether that package resolves its own
+        # dependencies is the question this job asks. A step budget bounds it anyway,
+        # so a stall there names this step instead of cancelling the job silently.
+        timeout-minutes: 25
         run: |
           # Deliberately no build-essential/cmake/git: a user installing a .deb has none.
           # Xvfb and WebKit are runtime requirements and apt pulls the .deb's declared
           # deps, so a wrong dependency list fails here.
-          sudo apt-get update -qq
-          sudo apt-get install -y -qq --no-install-recommends xvfb
+          RETRY_ATTEMPTS=3 RETRY_ATTEMPT_TIMEOUT=150 \
+            bash .github/scripts/retry-with-apt-lock.sh sudo sh -c \
+            'apt-get update -qq && apt-get install -y -qq --no-install-recommends xvfb'
           if [ "${{ matrix.kind }}" = "deb" ]; then
             sudo apt-get install -y ./dl/*.deb || {
               echo "::error::the .deb does not declare its runtime dependencies correctly"

--- a/.github/workflows/interrupted-install-ci.yml
+++ b/.github/workflows/interrupted-install-ci.yml
@@ -46,6 +46,7 @@ on:
       - '.github/scripts/interrupt-install.ps1'
       - '.github/scripts/interrupted_install_probe.py'
       - '.github/workflows/interrupted-install-ci.yml'
+      - '.github/scripts/retry-with-apt-lock.sh'
   workflow_dispatch:
 
 concurrency:
@@ -117,9 +118,18 @@ jobs:
 
       - name: Linux system deps
         if: runner.os == 'Linux'
+        # Bounded and retried through the shared helper: an unbounded apt step does
+        # not fail, it spends the job's whole budget and is reported as "cancelled"
+        # with no reason and every later step skipped. update and install go as one
+        # unit, since retrying the install after a stalled update re-reads the same
+        # broken package list.
+        timeout-minutes: 13
+        env:
+          RETRY_ATTEMPTS: '3'
+          RETRY_ATTEMPT_TIMEOUT: '150'
         run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y -qq --no-install-recommends cmake git build-essential libcurl4-openssl-dev
+          bash .github/scripts/retry-with-apt-lock.sh sudo sh -c \
+            'apt-get update -qq && apt-get install -y -qq --no-install-recommends cmake git build-essential libcurl4-openssl-dev'
 
       - name: Install, interrupted at "${{ matrix.label }}"
         env:

--- a/.github/workflows/lint-ci.yml
+++ b/.github/workflows/lint-ci.yml
@@ -45,7 +45,12 @@ jobs:
   source-lint:
     name: Source lint (Python + shell + YAML + JSON + safety nets)
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    # Real work here is well under a minute; the budget is sized for the apt step
+    # below, which is bounded at 13 minutes of worst-case retries. Raised from 5,
+    # where the job timeout was doing the bounding -- and doing it badly, since a
+    # job that runs out of budget is reported as "cancelled" with no reason given
+    # and every remaining step skipped. The step timeout says which step and why.
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
@@ -121,8 +126,22 @@ jobs:
 
           echo "launched 2 background lanes"
 
+      # Bounded and retried, because this step is why the job's own timeout used to
+      # be the failure mechanism: on 2026-08-19 it sat in apt for 5 minutes, the job
+      # hit `timeout-minutes: 5`, and GitHub scored the result "cancelled" with no
+      # reason and skipped all fifteen checks below it. A lint run that reports
+      # nothing about lint is worse than a red one.
+      #
+      # update and install are one unit: retrying the install alone after a stalled
+      # update just re-reads the same broken package list.
       - name: Linux deps for shellcheck
-        run: sudo apt-get update -qq && sudo apt-get install -y --no-install-recommends shellcheck
+        timeout-minutes: 13
+        env:
+          RETRY_ATTEMPTS: '3'
+          RETRY_ATTEMPT_TIMEOUT: '150'
+        run: |
+          bash .github/scripts/retry-with-apt-lock.sh sudo sh -c \
+            'apt-get update -qq && apt-get install -y --no-install-recommends shellcheck'
 
       - name: Python AST/syntax check (every committed .py must compile)
         # python -m compileall uses the same parser the interpreter

--- a/.github/workflows/local-agent-guides-ci.yml
+++ b/.github/workflows/local-agent-guides-ci.yml
@@ -54,6 +54,7 @@ on:
       - 'studio/backend/models/**'
       - 'install.sh'
       - '.github/workflows/local-agent-guides-ci.yml'
+      - '.github/scripts/retry-with-apt-lock.sh'
       # The install step in this workflow is `uses:` on that composite action,
       # so an edit to the action changes what this workflow actually runs.
       - '.github/actions/install-unsloth-local/action.yml'
@@ -75,6 +76,7 @@ on:
       - 'studio/backend/models/**'
       - 'install.sh'
       - '.github/workflows/local-agent-guides-ci.yml'
+      - '.github/scripts/retry-with-apt-lock.sh'
       - '.github/actions/install-unsloth-local/action.yml'
       - '.github/scripts/serve-unsloth-run.sh'
       - '.github/scripts/assert-prompt-cache.sh'
@@ -150,10 +152,18 @@ jobs:
           persist-credentials: false
 
       - name: Linux deps for llama.cpp prebuilt
+        # Bounded and retried through the shared helper: an unbounded apt step does
+        # not fail, it spends the job's whole budget and is reported as "cancelled"
+        # with no reason and every later step skipped. update and install go as one
+        # unit, since retrying the install after a stalled update re-reads the same
+        # broken package list.
+        timeout-minutes: 13
+        env:
+          RETRY_ATTEMPTS: '3'
+          RETRY_ATTEMPT_TIMEOUT: '150'
         run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            libcurl4-openssl-dev libssl-dev jq
+          bash .github/scripts/retry-with-apt-lock.sh sudo sh -c \
+            'apt-get update && apt-get install -y --no-install-recommends libcurl4-openssl-dev libssl-dev jq'
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
@@ -373,10 +383,18 @@ jobs:
           persist-credentials: false
 
       - name: Linux deps for llama.cpp prebuilt
+        # Bounded and retried through the shared helper: an unbounded apt step does
+        # not fail, it spends the job's whole budget and is reported as "cancelled"
+        # with no reason and every later step skipped. update and install go as one
+        # unit, since retrying the install after a stalled update re-reads the same
+        # broken package list.
+        timeout-minutes: 13
+        env:
+          RETRY_ATTEMPTS: '3'
+          RETRY_ATTEMPT_TIMEOUT: '150'
         run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            libcurl4-openssl-dev libssl-dev jq
+          bash .github/scripts/retry-with-apt-lock.sh sudo sh -c \
+            'apt-get update && apt-get install -y --no-install-recommends libcurl4-openssl-dev libssl-dev jq'
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
@@ -554,10 +572,18 @@ jobs:
           persist-credentials: false
 
       - name: Linux deps for llama.cpp prebuilt
+        # Bounded and retried through the shared helper: an unbounded apt step does
+        # not fail, it spends the job's whole budget and is reported as "cancelled"
+        # with no reason and every later step skipped. update and install go as one
+        # unit, since retrying the install after a stalled update re-reads the same
+        # broken package list.
+        timeout-minutes: 13
+        env:
+          RETRY_ATTEMPTS: '3'
+          RETRY_ATTEMPT_TIMEOUT: '150'
         run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            libcurl4-openssl-dev libssl-dev jq
+          bash .github/scripts/retry-with-apt-lock.sh sudo sh -c \
+            'apt-get update && apt-get install -y --no-install-recommends libcurl4-openssl-dev libssl-dev jq'
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
@@ -712,10 +738,18 @@ jobs:
           persist-credentials: false
 
       - name: Linux deps for llama.cpp prebuilt
+        # Bounded and retried through the shared helper: an unbounded apt step does
+        # not fail, it spends the job's whole budget and is reported as "cancelled"
+        # with no reason and every later step skipped. update and install go as one
+        # unit, since retrying the install after a stalled update re-reads the same
+        # broken package list.
+        timeout-minutes: 13
+        env:
+          RETRY_ATTEMPTS: '3'
+          RETRY_ATTEMPT_TIMEOUT: '150'
         run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            libcurl4-openssl-dev libssl-dev jq
+          bash .github/scripts/retry-with-apt-lock.sh sudo sh -c \
+            'apt-get update && apt-get install -y --no-install-recommends libcurl4-openssl-dev libssl-dev jq'
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -554,9 +554,18 @@ jobs:
       # ── Linux dependencies ──
       - name: Install Linux dependencies
         if: matrix.platform == 'ubuntu-22.04'
+        # Bounded and retried through the shared helper: an unbounded apt step does
+        # not fail, it spends the job's whole budget and is reported as "cancelled"
+        # with no reason and every later step skipped. update and install go as one
+        # unit, since retrying the install after a stalled update re-reads the same
+        # broken package list.
+        timeout-minutes: 13
+        env:
+          RETRY_ATTEMPTS: '3'
+          RETRY_ATTEMPT_TIMEOUT: '150'
         run: |
-          sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev libxdo-dev libssl-dev patchelf
+          bash .github/scripts/retry-with-apt-lock.sh sudo sh -c \
+            'apt-get update && apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev libxdo-dev libssl-dev patchelf'
 
       # ── Node.js ──
       - name: Setup Node.js

--- a/.github/workflows/studio-api-smoke.yml
+++ b/.github/workflows/studio-api-smoke.yml
@@ -27,6 +27,7 @@ on:
       - 'pyproject.toml'
       - 'tests/studio/**'
       - '.github/workflows/studio-api-smoke.yml'
+      - '.github/scripts/retry-with-apt-lock.sh'
       # Every server boot in this workflow shells out to that script, so an edit
       # to it changes what this workflow actually runs.
       - '.github/scripts/boot-studio-api-only.sh'
@@ -54,7 +55,10 @@ jobs:
   api-smoke:
     name: Unsloth API & Auth Tests
     runs-on: ubuntu-latest
-    timeout-minutes: 12
+    # Sized for the apt step's bounded worst case (13m) plus the smoke itself.
+    # Raised from 12, where the job budget was smaller than the retries the step
+    # authorises, so the job timeout would have fired first and reported nothing.
+    timeout-minutes: 20
     env:
       GGUF_REPO: unsloth/gemma-3-270m-it-GGUF
       GGUF_VARIANT: UD-Q4_K_XL
@@ -67,10 +71,18 @@ jobs:
           persist-credentials: false
 
       - name: Linux deps
+        # Bounded and retried through the shared helper: an unbounded apt step does
+        # not fail, it spends the job's whole budget and is reported as "cancelled"
+        # with no reason and every later step skipped. update and install go as one
+        # unit, since retrying the install after a stalled update re-reads the same
+        # broken package list.
+        timeout-minutes: 13
+        env:
+          RETRY_ATTEMPTS: '3'
+          RETRY_ATTEMPT_TIMEOUT: '150'
         run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            libcurl4-openssl-dev libssl-dev jq
+          bash .github/scripts/retry-with-apt-lock.sh sudo sh -c \
+            'apt-get update && apt-get install -y --no-install-recommends libcurl4-openssl-dev libssl-dev jq'
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:

--- a/.github/workflows/studio-frontend-ci.yml
+++ b/.github/workflows/studio-frontend-ci.yml
@@ -34,6 +34,7 @@ on:
       - 'scripts/sync_allow_scripts_pins.py'
       - 'tests/studio/test_sync_allow_scripts_pins.py'
       - '.github/workflows/studio-frontend-ci.yml'
+      - '.github/scripts/retry-with-apt-lock.sh'
   push:
     branches: [main]
 
@@ -53,7 +54,11 @@ jobs:
     name: Frontend build + bundle sanity
     runs-on: ubuntu-latest
     # Two browser smokes (~50s) plus the Chromium install now sit inside this.
-    timeout-minutes: 20
+    # 20 was not a budget, it was the bound on the Chromium install: the step had
+    # none of its own, so the job timeout was what eventually stopped it, and it
+    # stopped everything after it too. That step is bounded at 16 now, so this can
+    # be sized for the work plus that worst case.
+    timeout-minutes: 40
     defaults:
       run:
         working-directory: studio/frontend
@@ -196,11 +201,22 @@ jobs:
       # Smokes go last: every step carries an implicit success(), so running them ahead of
       # the build gates let one red smoke skip the build and all three bundle assertions.
       # Costs nothing here, since each smoke starts its own vite server and reads no dist/.
+      # `--with-deps` shells out to apt, so this is an apt step wearing a different
+      # name and it fails the same way. On 2026-08-19 it sat here for 16m38s, the
+      # job hit `timeout-minutes: 20`, and the run was reported as "cancelled" with
+      # the browser smokes and the lifecycle tests below simply skipped. Bounded at
+      # 2 x 420s because the browser download is genuinely large; a third attempt
+      # would not fit the budget and the first two already cover a mirror hiccup.
       - name: Install Chromium for browser smokes
         working-directory: ${{ github.workspace }}
+        timeout-minutes: 17
+        env:
+          RETRY_ATTEMPTS: '2'
+          RETRY_ATTEMPT_TIMEOUT: '420'
         run: |
           python3 -m pip install 'playwright>=1.45,<2' pytest
-          python3 -m playwright install --with-deps chromium
+          bash .github/scripts/retry-with-apt-lock.sh \
+            python3 -m playwright install --with-deps chromium
 
       # Browserless, but imports the harnesses (hence playwright), so it sits after the
       # install. Covers the Windows teardown branch no runner here executes.

--- a/.github/workflows/studio-inference-smoke.yml
+++ b/.github/workflows/studio-inference-smoke.yml
@@ -41,6 +41,7 @@ on:
       - 'install.sh'
       - 'pyproject.toml'
       - '.github/workflows/studio-inference-smoke.yml'
+      - '.github/scripts/retry-with-apt-lock.sh'
       # Every server boot in this workflow shells out to that script, so an edit
       # to it changes what this workflow actually runs.
       - '.github/scripts/boot-studio-api-only.sh'
@@ -138,10 +139,18 @@ jobs:
 
 
       - name: Linux deps for llama.cpp prebuilt
+        # Bounded and retried through the shared helper: an unbounded apt step does
+        # not fail, it spends the job's whole budget and is reported as "cancelled"
+        # with no reason and every later step skipped. update and install go as one
+        # unit, since retrying the install after a stalled update re-reads the same
+        # broken package list.
+        timeout-minutes: 13
+        env:
+          RETRY_ATTEMPTS: '3'
+          RETRY_ATTEMPT_TIMEOUT: '150'
         run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            libcurl4-openssl-dev libssl-dev jq
+          bash .github/scripts/retry-with-apt-lock.sh sudo sh -c \
+            'apt-get update && apt-get install -y --no-install-recommends libcurl4-openssl-dev libssl-dev jq'
 
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0

--- a/.github/workflows/studio-tauri-smoke.yml
+++ b/.github/workflows/studio-tauri-smoke.yml
@@ -25,6 +25,7 @@ on:
       # `unsloth studio` -- include unsloth_cli in the trigger set.
       - 'unsloth_cli/**'
       - '.github/workflows/studio-tauri-smoke.yml'
+      - '.github/scripts/retry-with-apt-lock.sh'
       # The Linux job installs and runs the Tauri CLI out of the studio/ package
       # root (`npm install --prefix studio`, `npx --prefix studio`), so these
       # manifests decide what it builds with.
@@ -47,6 +48,7 @@ on:
       # `unsloth studio` -- include unsloth_cli in the trigger set.
       - 'unsloth_cli/**'
       - '.github/workflows/studio-tauri-smoke.yml'
+      - '.github/scripts/retry-with-apt-lock.sh'
       # The Linux job installs and runs the Tauri CLI out of the studio/ package
       # root (`npm install --prefix studio`, `npx --prefix studio`), so these
       # manifests decide what it builds with.
@@ -77,11 +79,18 @@ jobs:
           persist-credentials: false
 
       - name: Linux native deps for Tauri / WebKit2GTK
+        # Bounded and retried through the shared helper: an unbounded apt step does
+        # not fail, it spends the job's whole budget and is reported as "cancelled"
+        # with no reason and every later step skipped. update and install go as one
+        # unit, since retrying the install after a stalled update re-reads the same
+        # broken package list.
+        timeout-minutes: 13
+        env:
+          RETRY_ATTEMPTS: '3'
+          RETRY_ATTEMPT_TIMEOUT: '150'
         run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            libwebkit2gtk-4.1-dev libappindicator3-dev \
-            librsvg2-dev libxdo-dev libssl-dev patchelf xvfb
+          bash .github/scripts/retry-with-apt-lock.sh sudo sh -c \
+            'apt-get update && apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev libxdo-dev libssl-dev patchelf xvfb'
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:

--- a/.github/workflows/studio-ui-smoke.yml
+++ b/.github/workflows/studio-ui-smoke.yml
@@ -129,10 +129,12 @@ jobs:
         env:
           RETRY_ATTEMPTS: '3'
           RETRY_ATTEMPT_TIMEOUT: '180'
+        # One call, not two: retrying the install after a stalled update just re-reads
+        # the same broken package list, and two calls double the worst case for no
+        # extra coverage.
         run: |
-          bash .github/scripts/retry-with-apt-lock.sh sudo apt-get update
-          bash .github/scripts/retry-with-apt-lock.sh sudo apt-get install -y \
-            --no-install-recommends libcurl4-openssl-dev libssl-dev jq
+          bash .github/scripts/retry-with-apt-lock.sh sudo sh -c \
+            'apt-get update && apt-get install -y --no-install-recommends libcurl4-openssl-dev libssl-dev jq'
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
@@ -669,10 +671,12 @@ jobs:
         env:
           RETRY_ATTEMPTS: '3'
           RETRY_ATTEMPT_TIMEOUT: '180'
+        # One call, not two: retrying the install after a stalled update just re-reads
+        # the same broken package list, and two calls double the worst case for no
+        # extra coverage.
         run: |
-          bash .github/scripts/retry-with-apt-lock.sh sudo apt-get update
-          bash .github/scripts/retry-with-apt-lock.sh sudo apt-get install -y \
-            --no-install-recommends libcurl4-openssl-dev libssl-dev jq
+          bash .github/scripts/retry-with-apt-lock.sh sudo sh -c \
+            'apt-get update && apt-get install -y --no-install-recommends libcurl4-openssl-dev libssl-dev jq'
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
           node-version: '22'

--- a/.github/workflows/studio-ui-smoke.yml
+++ b/.github/workflows/studio-ui-smoke.yml
@@ -35,6 +35,9 @@ on:
       - '.github/scripts/boot-studio-api-only.sh'
       # Same for the /api/health wait that runs after a boot.
       - '.github/scripts/wait-for-health.sh'
+      # Both apt steps in this workflow shell out to it, so an edit to it changes
+      # what this workflow actually runs.
+      - '.github/scripts/retry-with-apt-lock.sh'
       # The install step in this workflow is `uses:` on that composite action,
       # so an edit to the action changes what this workflow actually runs.
       - '.github/actions/install-unsloth-local/action.yml'
@@ -108,10 +111,28 @@ jobs:
           persist-credentials: false
 
       - name: Linux deps
+        # Retried through the shared helper. Unbounded, this stalled on the Azure
+        # mirror for 28 minutes on one shard before anyone noticed, and would have
+        # spent the job's full 30: an apt stall is not slow, it is silent. Every
+        # step after it is skipped and the run reports "cancelled" with no reason,
+        # so the shard says nothing about its subject.
+        #
+        # The retry is the point, not the shorter wait. The note on this job's
+        # timeout-minutes records the last attempt at this -- cutting the JOB budget
+        # to 20 turned the same stall from a slow pass into a red build, because a
+        # single attempt had nowhere to go. Three bounded attempts do: 180s is ~14x
+        # the 13 seconds this takes healthy, so only a mirror that is genuinely gone
+        # burns all three, and that is a hang rather than a slow mean.
+        #
+        # The job's 30 stays the final backstop and is deliberately not tightened.
+        timeout-minutes: 20
+        env:
+          RETRY_ATTEMPTS: '3'
+          RETRY_ATTEMPT_TIMEOUT: '180'
         run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            libcurl4-openssl-dev libssl-dev jq
+          bash .github/scripts/retry-with-apt-lock.sh sudo apt-get update
+          bash .github/scripts/retry-with-apt-lock.sh sudo apt-get install -y \
+            --no-install-recommends libcurl4-openssl-dev libssl-dev jq
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
@@ -219,54 +240,28 @@ jobs:
         # re-run of the same commit. The healthy time is about 2 minutes, so 8 is 4x
         # headroom and a merely slow mirror will not trip it. timeout-minutes bounds the
         # pair in case `timeout` itself is outlived by an unkillable child.
-        timeout-minutes: 22
+        # Bounded and retried through the shared helper, which is where the dpkg
+        # lock wait and the exit-code reporting live. This was eight lines of
+        # inline loop and it shipped a bug that made the retry dead: GitHub runs
+        # `run:` as `bash -e`, so `timeout ...; rc=$?` aborted the step on the
+        # first stall and the second attempt never ran. The step exited 124 having
+        # printed nothing at all, which looked exactly like the unbounded stall it
+        # was supposed to replace. One definition, tested, instead of copies.
+        #
+        # Two attempts at 7 minutes, against a healthy ~2: worst case 14 plus the
+        # lock wait, which still leaves the job's 30 room for the work it exists to
+        # do. Three attempts here would not.
+        timeout-minutes: 18
+        env:
+          RETRY_ATTEMPTS: '2'
+          RETRY_ATTEMPT_TIMEOUT: '420'
         run: |
           if [ "${{ steps.pw-cache.outputs.cache-hit }}" = "true" ]; then
             set -- install-deps chromium firefox webkit
           else
             set -- install --with-deps chromium firefox webkit
           fi
-
-          # Wait for whatever the killed attempt left behind to let go of dpkg.
-          #
-          # The first version of this retry skipped this and could not recover.
-          # playwright shells out to apt-get as ROOT, so terminating the python
-          # parent leaves that child alive holding the lock, and attempt 2 died two
-          # seconds later with "Could not get lock /var/lib/dpkg/lock-frontend. It
-          # is held by process 4578 (apt-get)". A retry that cannot succeed is worse
-          # than no retry: it buries the real reason under a second, different
-          # failure.
-          release_dpkg_lock() {
-            for _ in $(seq 1 24); do
-              fuser /var/lib/dpkg/lock-frontend > /dev/null 2>&1 || return 0
-              sleep 5
-            done
-            # Still held after two minutes. It is our own orphan and this is a
-            # throwaway runner, so take the lock rather than spend the attempt.
-            echo "::warning::dpkg lock still held after 120s; terminating the holder"
-            fuser -k /var/lib/dpkg/lock-frontend > /dev/null 2>&1 || true
-            sleep 5
-          }
-
-          for attempt in 1 2; do
-            timeout --signal=TERM --kill-after=30 480 python -m playwright "$@"
-            rc=$?
-            [ "$rc" -eq 0 ] && exit 0
-            # 124 is timeout's own "I killed it"; 137 is SIGKILL landing after
-            # --kill-after. Anything else is playwright itself refusing, and saying
-            # "did not finish within 8 minutes" about a 2-second exit sends the next
-            # reader looking for a stall that never happened.
-            if [ "$rc" -eq 124 ] || [ "$rc" -eq 137 ]; then
-              reason="did not finish within 8 minutes"
-            else
-              reason="exited with status ${rc}"
-            fi
-            echo "::warning::playwright install attempt ${attempt} ${reason}"
-            [ "$attempt" -eq 2 ] && break
-            release_dpkg_lock
-          done
-          echo "::error::playwright browser install failed twice; the attempt warnings above say which way each one went"
-          exit 1
+          bash .github/scripts/retry-with-apt-lock.sh python -m playwright "$@"
 
       # Save on main only, like every model cache in this repo. read-write
       # `actions/cache` saves from its post-step on EVERY ref, and a PR-scoped entry
@@ -656,10 +651,28 @@ jobs:
           persist-credentials: false
 
       - name: Linux deps
+        # Retried through the shared helper. Unbounded, this stalled on the Azure
+        # mirror for 28 minutes on one shard before anyone noticed, and would have
+        # spent the job's full 30: an apt stall is not slow, it is silent. Every
+        # step after it is skipped and the run reports "cancelled" with no reason,
+        # so the shard says nothing about its subject.
+        #
+        # The retry is the point, not the shorter wait. The note on this job's
+        # timeout-minutes records the last attempt at this -- cutting the JOB budget
+        # to 20 turned the same stall from a slow pass into a red build, because a
+        # single attempt had nowhere to go. Three bounded attempts do: 180s is ~14x
+        # the 13 seconds this takes healthy, so only a mirror that is genuinely gone
+        # burns all three, and that is a hang rather than a slow mean.
+        #
+        # The job's 30 stays the final backstop and is deliberately not tightened.
+        timeout-minutes: 20
+        env:
+          RETRY_ATTEMPTS: '3'
+          RETRY_ATTEMPT_TIMEOUT: '180'
         run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            libcurl4-openssl-dev libssl-dev jq
+          bash .github/scripts/retry-with-apt-lock.sh sudo apt-get update
+          bash .github/scripts/retry-with-apt-lock.sh sudo apt-get install -y \
+            --no-install-recommends libcurl4-openssl-dev libssl-dev jq
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
           node-version: '22'
@@ -714,54 +727,28 @@ jobs:
         # re-run of the same commit. The healthy time is about 2 minutes, so 8 is 4x
         # headroom and a merely slow mirror will not trip it. timeout-minutes bounds the
         # pair in case `timeout` itself is outlived by an unkillable child.
-        timeout-minutes: 22
+        # Bounded and retried through the shared helper, which is where the dpkg
+        # lock wait and the exit-code reporting live. This was eight lines of
+        # inline loop and it shipped a bug that made the retry dead: GitHub runs
+        # `run:` as `bash -e`, so `timeout ...; rc=$?` aborted the step on the
+        # first stall and the second attempt never ran. The step exited 124 having
+        # printed nothing at all, which looked exactly like the unbounded stall it
+        # was supposed to replace. One definition, tested, instead of copies.
+        #
+        # Two attempts at 7 minutes, against a healthy ~2: worst case 14 plus the
+        # lock wait, which still leaves the job's 30 room for the work it exists to
+        # do. Three attempts here would not.
+        timeout-minutes: 18
+        env:
+          RETRY_ATTEMPTS: '2'
+          RETRY_ATTEMPT_TIMEOUT: '420'
         run: |
           if [ "${{ steps.pw-cache.outputs.cache-hit }}" = "true" ]; then
             set -- install-deps chromium firefox webkit
           else
             set -- install --with-deps chromium firefox webkit
           fi
-
-          # Wait for whatever the killed attempt left behind to let go of dpkg.
-          #
-          # The first version of this retry skipped this and could not recover.
-          # playwright shells out to apt-get as ROOT, so terminating the python
-          # parent leaves that child alive holding the lock, and attempt 2 died two
-          # seconds later with "Could not get lock /var/lib/dpkg/lock-frontend. It
-          # is held by process 4578 (apt-get)". A retry that cannot succeed is worse
-          # than no retry: it buries the real reason under a second, different
-          # failure.
-          release_dpkg_lock() {
-            for _ in $(seq 1 24); do
-              fuser /var/lib/dpkg/lock-frontend > /dev/null 2>&1 || return 0
-              sleep 5
-            done
-            # Still held after two minutes. It is our own orphan and this is a
-            # throwaway runner, so take the lock rather than spend the attempt.
-            echo "::warning::dpkg lock still held after 120s; terminating the holder"
-            fuser -k /var/lib/dpkg/lock-frontend > /dev/null 2>&1 || true
-            sleep 5
-          }
-
-          for attempt in 1 2; do
-            timeout --signal=TERM --kill-after=30 480 python -m playwright "$@"
-            rc=$?
-            [ "$rc" -eq 0 ] && exit 0
-            # 124 is timeout's own "I killed it"; 137 is SIGKILL landing after
-            # --kill-after. Anything else is playwright itself refusing, and saying
-            # "did not finish within 8 minutes" about a 2-second exit sends the next
-            # reader looking for a stall that never happened.
-            if [ "$rc" -eq 124 ] || [ "$rc" -eq 137 ]; then
-              reason="did not finish within 8 minutes"
-            else
-              reason="exited with status ${rc}"
-            fi
-            echo "::warning::playwright install attempt ${attempt} ${reason}"
-            [ "$attempt" -eq 2 ] && break
-            release_dpkg_lock
-          done
-          echo "::error::playwright browser install failed twice; the attempt warnings above say which way each one went"
-          exit 1
+          bash .github/scripts/retry-with-apt-lock.sh python -m playwright "$@"
 
       # Save on main only, like every model cache in this repo. read-write
       # `actions/cache` saves from its post-step on EVERY ref, and a PR-scoped entry

--- a/.github/workflows/studio-update-smoke.yml
+++ b/.github/workflows/studio-update-smoke.yml
@@ -25,6 +25,7 @@ on:
       - 'unsloth_cli/_system_dir_guard.py'
       - 'pyproject.toml'
       - '.github/workflows/studio-update-smoke.yml'
+      - '.github/scripts/retry-with-apt-lock.sh'
       # The install step in this workflow is `uses:` on that composite action,
       # so an edit to the action changes what this workflow actually runs.
       - '.github/actions/install-unsloth-local/action.yml'
@@ -54,10 +55,18 @@ jobs:
           persist-credentials: false
 
       - name: Linux deps for llama.cpp prebuilt
+        # Bounded and retried through the shared helper: an unbounded apt step does
+        # not fail, it spends the job's whole budget and is reported as "cancelled"
+        # with no reason and every later step skipped. update and install go as one
+        # unit, since retrying the install after a stalled update re-reads the same
+        # broken package list.
+        timeout-minutes: 13
+        env:
+          RETRY_ATTEMPTS: '3'
+          RETRY_ATTEMPT_TIMEOUT: '150'
         run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            libcurl4-openssl-dev libssl-dev jq
+          bash .github/scripts/retry-with-apt-lock.sh sudo sh -c \
+            'apt-get update && apt-get install -y --no-install-recommends libcurl4-openssl-dev libssl-dev jq'
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:

--- a/.github/workflows/workflow-trigger-lint.yml
+++ b/.github/workflows/workflow-trigger-lint.yml
@@ -110,6 +110,7 @@ jobs:
         run: |
           python3 -m pytest -q -n 4 \
             tests/studio/test_absorbed_lanes_still_run.py \
+            tests/studio/test_apt_steps_are_bounded.py \
             tests/studio/test_backend_ci_matrix.py \
             tests/studio/test_backend_ci_parallel_isolation.py \
             tests/studio/test_cache_budget_discipline.py \

--- a/tests/studio/test_apt_steps_are_bounded.py
+++ b/tests/studio/test_apt_steps_are_bounded.py
@@ -1,0 +1,254 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+"""
+Every apt step on a hosted runner must be bounded, retried, and paid for.
+
+An unbounded apt step is the worst failure shape CI has. It does not go red: it
+sits in apt's download loop, spends the job's entire `timeout-minutes`, and
+GitHub reports the result as **cancelled** -- no reason printed, no failing step
+named, and every step after it skipped. Three of these were caught by hand in a
+single day, on three different workflows:
+
+  Chat UI Tests (chat)        30m18s, the job's whole budget, in `Linux deps`
+  Frontend build              16m38s in `playwright install --with-deps`
+  Source lint                  5m02s in `Linux deps for shellcheck`, on a 5m job
+
+None of the three reported anything about its actual subject. The last one was
+noticed only because a human happened to look at a job that said "cancelled".
+
+So the invariant is not "apt should be retried", it is: **the step is what
+bounds itself, never the job**. A job timeout is a backstop for the unforeseen;
+using it as the bound on a known-flaky step converts a diagnosable failure into
+a silent one. These tests read the workflows and enforce that, plus the two
+things that make the bound honest -- that the retry budget actually fits inside
+the step timeout, and that the step timeout actually fits inside the job's.
+
+`--with-deps` counts as an apt step, because that is precisely what it is; it
+was excluded from the first pass by name and promptly cost a 16-minute job.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOWS = REPO_ROOT / ".github" / "workflows"
+HELPER = ".github/scripts/retry-with-apt-lock.sh"
+
+# PyYAML reads the `on:` key as the boolean True.
+ON = True
+
+# apt reached directly, or via playwright, which shells out to it. `--with-deps`
+# is qualified by `playwright install` on purpose: scan_packages.py takes a flag
+# of the same name that has nothing to do with apt.
+_APT = re.compile(r"\bapt-get\s+(?:update|install)\b|playwright\s+install\b[^\n]*--with-deps\b")
+
+# `release_dpkg_lock()` waits up to 24 * 5s for the orphaned holder, then kills it
+# and sleeps 5. It runs between attempts, so N attempts pay it N-1 times.
+LOCK_WAIT_SECONDS = 125
+
+# Workflows whose apt calls do not run on a hosted runner and cannot use the
+# helper. Each is here for a reason that would survive a rewrite, not because it
+# was inconvenient to convert.
+EXEMPT_WORKFLOWS = {
+    # Runs apt inside bare distro containers and inside WSL, as root, with no
+    # checkout (the whole point is a machine with no git). There is no repo on
+    # disk to read the helper from, and `sudo`/`fuser` are deliberately absent --
+    # one leg asserts that `sudo` does not exist on the image at all.
+    "clean-machine-install-ci.yml",
+}
+
+# Individual steps that reach apt as the thing under test rather than as setup.
+# Retrying these would retry an assertion.
+EXEMPT_STEPS = {
+    # Removes curl to construct the no-transport case. A retry loop around a
+    # removal is meaningless, and it is bounded by being a removal.
+    ("clean-machine-install-ci.yml", "Take the transport away again"),
+    # Installs the built .deb to find out whether the package declares its own
+    # runtime dependencies. A failure here is the answer, not a transport
+    # hiccup. Its apt *preamble* (update + xvfb) does go through the helper.
+    ("desktop-app-clean-machine-ci.yml", "Install with NO dev tooling, only runtime libs"),
+    # Greps the documentation for the apt line it tells users to run. It reads an
+    # apt command as data; it never executes one.
+    ("release-desktop.yml", "Verify desktop updater and Linux package config"),
+}
+
+
+def _workflows() -> list[Path]:
+    paths = sorted(WORKFLOWS.glob("*.yml"))
+    assert paths, "no workflows found; this guard would pass vacuously"
+    return paths
+
+
+def _steps(doc: dict) -> list[tuple[str, dict, dict]]:
+    """(job id, job, step) for every step with a `run:`, across every job."""
+    out = []
+    for job_id, job in (doc.get("jobs") or {}).items():
+        if not isinstance(job, dict):
+            continue
+        for step in job.get("steps") or []:
+            if isinstance(step, dict) and isinstance(step.get("run"), str):
+                out.append((job_id, job, step))
+    return out
+
+
+def _apt_steps(path: Path) -> list[tuple[str, dict, dict]]:
+    doc = yaml.safe_load(path.read_text(encoding="utf-8"))
+    return [
+        (job_id, job, step)
+        for job_id, job, step in _steps(doc)
+        if _APT.search(step["run"])
+        and (path.name, step.get("name", "")) not in EXEMPT_STEPS
+    ]
+
+
+def _int_minutes(value: object) -> int | None:
+    """A `timeout-minutes:` that is an expression is not a number we can check."""
+    return value if isinstance(value, int) else None
+
+
+def _worst_case_seconds(step: dict, run: str) -> int:
+    """Seconds the helper can burn before it gives up, from the step's own budget."""
+    env = step.get("env") or {}
+    attempts = env.get("RETRY_ATTEMPTS")
+    per_attempt = env.get("RETRY_ATTEMPT_TIMEOUT")
+
+    # A step may also set them inline, as `RETRY_ATTEMPTS=3 bash ...helper`, which
+    # is how the two steps that embed the call in a larger script pass them.
+    if attempts is None:
+        inline = re.search(r"RETRY_ATTEMPTS=(\d+)", run)
+        attempts = inline.group(1) if inline else None
+    if per_attempt is None:
+        inline = re.search(r"RETRY_ATTEMPT_TIMEOUT=(\d+)", run)
+        per_attempt = inline.group(1) if inline else None
+
+    # The helper's own defaults, kept in sync by test_helper_defaults_are_what_the_budgets_assume.
+    attempts = int(attempts) if attempts is not None else 3
+    per_attempt = int(per_attempt) if per_attempt is not None else 480
+
+    calls = run.count(HELPER)
+    return calls * (attempts * per_attempt + (attempts - 1) * LOCK_WAIT_SECONDS)
+
+
+@pytest.mark.parametrize("path", _workflows(), ids=lambda p: p.name)
+def test_every_apt_step_goes_through_the_shared_helper(path: Path) -> None:
+    if path.name in EXEMPT_WORKFLOWS:
+        return
+    for job_id, _job, step in _apt_steps(path):
+        assert HELPER in step["run"], (
+            f"{path.name}: job '{job_id}' step '{step.get('name', '<unnamed>')}' "
+            f"reaches apt without going through {HELPER}. Unbounded, it will spend "
+            f"the job's whole timeout and be reported as 'cancelled' with no reason "
+            f"and every later step skipped."
+        )
+
+
+@pytest.mark.parametrize("path", _workflows(), ids=lambda p: p.name)
+def test_every_apt_step_bounds_itself(path: Path) -> None:
+    if path.name in EXEMPT_WORKFLOWS:
+        return
+    for job_id, _job, step in _apt_steps(path):
+        assert step.get("timeout-minutes") is not None, (
+            f"{path.name}: job '{job_id}' step '{step.get('name', '<unnamed>')}' "
+            f"has no timeout-minutes, so the job timeout is what bounds it -- which "
+            f"is the failure mode this guard exists for, retry helper or not."
+        )
+
+
+@pytest.mark.parametrize("path", _workflows(), ids=lambda p: p.name)
+def test_the_retry_budget_fits_inside_the_step_timeout(path: Path) -> None:
+    """
+    A step timeout smaller than the retries it authorises silently deletes the
+    last attempt, and reports a truncated step rather than the helper's warnings.
+    """
+    if path.name in EXEMPT_WORKFLOWS:
+        return
+    for job_id, _job, step in _apt_steps(path):
+        budget = _int_minutes(step.get("timeout-minutes"))
+        if budget is None:
+            continue
+        worst = _worst_case_seconds(step, step["run"])
+        assert worst <= budget * 60, (
+            f"{path.name}: job '{job_id}' step '{step.get('name', '<unnamed>')}' "
+            f"authorises up to {worst}s of retries but is cut off at "
+            f"{budget * 60}s, so the final attempt can never finish."
+        )
+
+
+@pytest.mark.parametrize("path", _workflows(), ids=lambda p: p.name)
+def test_the_step_timeout_fits_inside_the_job_timeout(path: Path) -> None:
+    """
+    Otherwise the job timeout still fires first and the diagnosis is still lost:
+    the step's bound only helps if the job is alive to report it.
+    """
+    if path.name in EXEMPT_WORKFLOWS:
+        return
+    for job_id, job, step in _apt_steps(path):
+        step_budget = _int_minutes(step.get("timeout-minutes"))
+        job_budget = _int_minutes(job.get("timeout-minutes"))
+        if step_budget is None or job_budget is None:
+            continue
+        assert step_budget < job_budget, (
+            f"{path.name}: job '{job_id}' allows {job_budget}m but its apt step "
+            f"'{step.get('name', '<unnamed>')}' alone may take {step_budget}m, so "
+            f"the job timeout fires first and the run is reported as 'cancelled' "
+            f"with no step named."
+        )
+
+
+@pytest.mark.parametrize("path", _workflows(), ids=lambda p: p.name)
+def test_a_workflow_that_calls_the_helper_reruns_when_the_helper_changes(path: Path) -> None:
+    """
+    A paths-filtered workflow that calls the helper but does not list it is not
+    covered by an edit to it: the helper could be broken and every consumer would
+    keep showing the last green run.
+    """
+    doc = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not any(HELPER in step["run"] for _, _, step in _steps(doc)):
+        return
+    triggers = doc.get(ON) or {}
+    if not isinstance(triggers, dict):
+        return
+    for event, spec in triggers.items():
+        if not isinstance(spec, dict):
+            continue
+        paths = spec.get("paths")
+        if paths is None:
+            continue  # unfiltered: it runs for every change, helper included
+        assert HELPER in paths, (
+            f"{path.name}: the '{event}' trigger filters on paths but does not "
+            f"list {HELPER}, which its steps call. A change to the helper would "
+            f"not run this workflow."
+        )
+
+
+def test_helper_defaults_are_what_the_budgets_assume() -> None:
+    """
+    The worst-case arithmetic above falls back to the helper's own defaults for a
+    step that sets neither variable. If those defaults move and this fallback does
+    not, every such budget check silently starts measuring the wrong number.
+    """
+    source = (REPO_ROOT / HELPER).read_text(encoding="utf-8")
+    assert 'ATTEMPTS="${RETRY_ATTEMPTS:-3}"' in source
+    assert 'ATTEMPT_TIMEOUT="${RETRY_ATTEMPT_TIMEOUT:-480}"' in source
+    # 24 sleeps of 5s, then a kill and a final 5s.
+    assert "seq 1 24" in source
+    assert LOCK_WAIT_SECONDS == 24 * 5 + 5
+
+
+def test_the_guard_is_not_vacuous() -> None:
+    """
+    Every assertion above is a for-loop over steps this finds. If the detector
+    stopped matching, all of them would pass by finding nothing.
+    """
+    found = {
+        path.name: len(_apt_steps(path))
+        for path in _workflows()
+        if _apt_steps(path)
+    }
+    assert len(found) >= 10, f"only {len(found)} workflows matched; the detector looks broken: {found}"
+    assert sum(found.values()) >= 15, f"only {sum(found.values())} apt steps matched: {found}"

--- a/tests/studio/test_apt_steps_are_bounded.py
+++ b/tests/studio/test_apt_steps_are_bounded.py
@@ -97,12 +97,11 @@ def _steps(doc: dict) -> list[tuple[str, dict, dict]]:
 
 
 def _apt_steps(path: Path) -> list[tuple[str, dict, dict]]:
-    doc = yaml.safe_load(path.read_text(encoding="utf-8"))
+    doc = yaml.safe_load(path.read_text(encoding = "utf-8"))
     return [
         (job_id, job, step)
         for job_id, job, step in _steps(doc)
-        if _APT.search(step["run"])
-        and (path.name, step.get("name", "")) not in EXEMPT_STEPS
+        if _APT.search(step["run"]) and (path.name, step.get("name", "")) not in EXEMPT_STEPS
     ]
 
 
@@ -134,7 +133,7 @@ def _worst_case_seconds(step: dict, run: str) -> int:
     return calls * (attempts * per_attempt + (attempts - 1) * LOCK_WAIT_SECONDS)
 
 
-@pytest.mark.parametrize("path", _workflows(), ids=lambda p: p.name)
+@pytest.mark.parametrize("path", _workflows(), ids = lambda p: p.name)
 def test_every_apt_step_goes_through_the_shared_helper(path: Path) -> None:
     if path.name in EXEMPT_WORKFLOWS:
         return
@@ -147,7 +146,7 @@ def test_every_apt_step_goes_through_the_shared_helper(path: Path) -> None:
         )
 
 
-@pytest.mark.parametrize("path", _workflows(), ids=lambda p: p.name)
+@pytest.mark.parametrize("path", _workflows(), ids = lambda p: p.name)
 def test_every_apt_step_bounds_itself(path: Path) -> None:
     if path.name in EXEMPT_WORKFLOWS:
         return
@@ -159,7 +158,7 @@ def test_every_apt_step_bounds_itself(path: Path) -> None:
         )
 
 
-@pytest.mark.parametrize("path", _workflows(), ids=lambda p: p.name)
+@pytest.mark.parametrize("path", _workflows(), ids = lambda p: p.name)
 def test_the_retry_budget_fits_inside_the_step_timeout(path: Path) -> None:
     """
     A step timeout smaller than the retries it authorises silently deletes the
@@ -179,7 +178,7 @@ def test_the_retry_budget_fits_inside_the_step_timeout(path: Path) -> None:
         )
 
 
-@pytest.mark.parametrize("path", _workflows(), ids=lambda p: p.name)
+@pytest.mark.parametrize("path", _workflows(), ids = lambda p: p.name)
 def test_the_step_timeout_fits_inside_the_job_timeout(path: Path) -> None:
     """
     Otherwise the job timeout still fires first and the diagnosis is still lost:
@@ -200,14 +199,14 @@ def test_the_step_timeout_fits_inside_the_job_timeout(path: Path) -> None:
         )
 
 
-@pytest.mark.parametrize("path", _workflows(), ids=lambda p: p.name)
+@pytest.mark.parametrize("path", _workflows(), ids = lambda p: p.name)
 def test_a_workflow_that_calls_the_helper_reruns_when_the_helper_changes(path: Path) -> None:
     """
     A paths-filtered workflow that calls the helper but does not list it is not
     covered by an edit to it: the helper could be broken and every consumer would
     keep showing the last green run.
     """
-    doc = yaml.safe_load(path.read_text(encoding="utf-8"))
+    doc = yaml.safe_load(path.read_text(encoding = "utf-8"))
     if not any(HELPER in step["run"] for _, _, step in _steps(doc)):
         return
     triggers = doc.get(ON) or {}
@@ -232,7 +231,7 @@ def test_helper_defaults_are_what_the_budgets_assume() -> None:
     step that sets neither variable. If those defaults move and this fallback does
     not, every such budget check silently starts measuring the wrong number.
     """
-    source = (REPO_ROOT / HELPER).read_text(encoding="utf-8")
+    source = (REPO_ROOT / HELPER).read_text(encoding = "utf-8")
     assert 'ATTEMPTS="${RETRY_ATTEMPTS:-3}"' in source
     assert 'ATTEMPT_TIMEOUT="${RETRY_ATTEMPT_TIMEOUT:-480}"' in source
     # 24 sleeps of 5s, then a kill and a final 5s.
@@ -245,10 +244,8 @@ def test_the_guard_is_not_vacuous() -> None:
     Every assertion above is a for-loop over steps this finds. If the detector
     stopped matching, all of them would pass by finding nothing.
     """
-    found = {
-        path.name: len(_apt_steps(path))
-        for path in _workflows()
-        if _apt_steps(path)
-    }
-    assert len(found) >= 10, f"only {len(found)} workflows matched; the detector looks broken: {found}"
+    found = {path.name: len(_apt_steps(path)) for path in _workflows() if _apt_steps(path)}
+    assert (
+        len(found) >= 10
+    ), f"only {len(found)} workflows matched; the detector looks broken: {found}"
     assert sum(found.values()) >= 15, f"only {sum(found.values())} apt steps matched: {found}"


### PR DESCRIPTION
## Why

Three CI jobs were lost to an unbounded apt step in a single day, each in a different workflow, and each reported by GitHub as **cancelled** rather than failed:

| job | time in apt | outcome |
|---|---|---|
| `Chat UI Tests (chat)` | 30m18s | job's whole budget, everything after skipped |
| `Frontend build + bundle sanity` | 16m38s in `playwright install --with-deps` | browser smokes and lifecycle tests never ran |
| `Source lint` | 5m02s on a 5-minute job | all fifteen lint checks skipped |

This is the worst failure shape CI has. It does not go red on its subject: it spends the job's entire `timeout-minutes`, prints no reason, names no step, and skips everything downstream. The last one was noticed only because someone happened to open a job that said "cancelled".

## What this changes

**A shared entry point.** `.github/scripts/retry-with-apt-lock.sh` bounds each attempt with `timeout` and retries. Two things make the retry actually work, and both were learned the hard way:

- **The dpkg lock.** apt runs as root, so killing an attempt leaves the `apt-get` child alive holding `/var/lib/dpkg/lock-frontend`, and the next attempt dies two seconds later with "Could not get lock". A retry that cannot succeed is worse than none, because it buries the real reason under a second, different failure.
- **`set -e`.** GitHub runs `run:` blocks as `bash -e`, so a bare failing command aborts the step where it stands. A loop written as `timeout ... ; rc=$?` never reaches its second attempt: the step exits 124 with no output, indistinguishable from the original stall. That is exactly how the first version of this shipped, and why it is a script now rather than eight inline copies.

**Every on-runner apt step now goes through it**, with an explicit step timeout: `lint-ci`, `studio-api-smoke`, `studio-inference-smoke`, `studio-update-smoke`, `studio-ui-smoke`, `studio-tauri-smoke`, `studio-frontend-ci`, `interrupted-install-ci`, `consolidated-tests-ci`, `desktop-app-clean-machine-ci`, `release-desktop`, and the four copies in `local-agent-guides-ci`.

`playwright install --with-deps` counts as an apt step, because that is what it is. Excluding it by name is what cost the Frontend build job.

`update` and `install` go as one unit. Retrying the install after a stalled update just re-reads the same broken package list, and two calls double the worst case for no extra coverage.

**Job budgets raised where the step's bounded worst case no longer fits**: `source-lint` 5 to 20, `api-smoke` 12 to 20, frontend `build` 20 to 40. A job timeout is a backstop for the unforeseen; using it as the bound on a known-flaky step is what converts a diagnosable failure into a silent one.

## Guard

`tests/studio/test_apt_steps_are_bounded.py` reads the workflows and asserts:

- every apt step routes through the helper
- every apt step has its own `timeout-minutes`
- the retry budget it authorises actually fits inside that step timeout, so the last attempt is not silently deleted
- the step timeout fits inside the job timeout, so the job stays alive to report which step stalled
- a workflow that calls the helper and filters on `paths` lists the helper, so a change to it reruns its consumers
- the detector is not vacuous (it must still match at least 15 steps across at least 10 workflows)

All six corresponding mutants were reintroduced and confirmed to go red. Wired into `workflow-trigger-lint.yml`, the only job with no paths filter, since the edit that breaks it is by definition a workflow-only edit.

## Not converted, deliberately

- `clean-machine-install-ci.yml` runs apt inside bare distro containers and inside WSL, as root, with no checkout to read the helper from, and one leg asserts that `sudo` does not exist on the image at all.
- Two steps where apt is the assertion rather than the setup: removing curl to construct the no-transport case, and installing the built `.deb` to find out whether it declares its own runtime dependencies. Retrying those would retry the assertion. The `.deb` step's apt preamble does go through the helper, and the step gained a budget anyway.

## Verification

`tests/studio`: 4456 passed, 4 skipped. `actionlint` clean on every changed file (the two findings it reports are pre-existing and unrelated: a `macos-26` label and `concurrency.queue`, both newer than actionlint 1.7.7 knows).
