### PR TITLE
Make apt fail fast, so the retry has something to retry

### DIFF
--- a/.github/scripts/retry-with-apt-lock.sh
+++ b/.github/scripts/retry-with-apt-lock.sh
@@ -27,6 +27,33 @@
 #      with no output at all, which is exactly how the first version of this
 #      shipped and why it is a script now rather than eight inline copies.
 #
+#   3. apt's own timeouts, which is the part that makes the retry meaningful
+#      rather than merely survivable. Reading the logs of the four stalls above:
+#
+#        04:47:02  Get:5 https://archive.ubuntu.com/ubuntu noble-security InRelease [126 kB]
+#        05:16:29  ##[error]The operation was canceled.
+#
+#      Twenty-nine minutes of silence, mid-fetch of a 126 kB index file. Two of
+#      the four hung on that same file. What happened before it is the other half
+#      of the story: azure.archive.ubuntu.com was `Ign:`d four times over thirty
+#      seconds, so apt had already failed over through /etc/apt/apt-mirrors.txt to
+#      the public archive, which is not provisioned for this fleet.
+#
+#      apt did not consider any of that an error. `Acquire::http::Timeout`
+#      defaults to 120s AND is an idle timeout, so a connection that is open and
+#      trickling never trips it -- apt will wait out the heat death of the
+#      universe for a socket that is technically still alive. Cutting the timeout
+#      to 20s with internal retries turns a 29-minute hang into a ~1 minute
+#      failure, which matters for a reason beyond speed: the wall-clock kill below
+#      is what orphans the dpkg lock in the first place, so an apt that fails on
+#      its own is an apt we never have to kill.
+#
+#      Deliberately NOT pinning a mirror. The evidence does not support it: in one
+#      stall Azure was dead and the public archive hung, in another Azure was
+#      serving fine and the transfer stalled at a 13.6 MB package. Neither is
+#      reliably better, and the mirrorlist failover is already the right mechanism
+#      -- it just needs to be allowed to give up.
+#
 # Usage:
 #   bash .github/scripts/retry-with-apt-lock.sh apt-get update
 #   bash .github/scripts/retry-with-apt-lock.sh apt-get install -y foo bar
@@ -35,6 +62,8 @@
 # Environment:
 #   RETRY_ATTEMPTS         attempts before giving up   (default 3)
 #   RETRY_ATTEMPT_TIMEOUT  seconds per attempt         (default 480)
+#   APT_ACQUIRE_TIMEOUT    seconds apt waits on a stalled transfer (default 20)
+#   APT_ACQUIRE_RETRIES    apt's own internal retries  (default 3)
 #
 # Deliberately no `set -e`: this script reads exit codes itself, and -e would
 # abort it on the very first failing attempt -- the bug described above.
@@ -43,6 +72,9 @@ set -uo pipefail
 ATTEMPTS="${RETRY_ATTEMPTS:-3}"
 ATTEMPT_TIMEOUT="${RETRY_ATTEMPT_TIMEOUT:-480}"
 DPKG_LOCK="/var/lib/dpkg/lock-frontend"
+APT_TIMEOUT="${APT_ACQUIRE_TIMEOUT:-20}"
+APT_RETRIES="${APT_ACQUIRE_RETRIES:-3}"
+APT_CONF="/etc/apt/apt.conf.d/99-unsloth-ci-fail-fast"
 
 if [ "$#" -eq 0 ]; then
   echo "::error::retry-with-apt-lock.sh needs a command to run" >&2
@@ -53,6 +85,24 @@ fi
 # lock. Reported once rather than silently, so a retry that fails on a held lock
 # is explicable.
 have_fuser() { command -v fuser > /dev/null 2>&1; }
+
+# Make apt give up on a dead transfer instead of waiting on it forever. Written
+# before the first attempt rather than baked into the runner image so it applies
+# to `playwright install --with-deps` too, which shells out to apt without ever
+# naming it. Best effort throughout: a runner where this cannot be written still
+# runs the command, just without the fast failure.
+configure_apt_fail_fast() {
+  [ -d /etc/apt/apt.conf.d ] || return 0
+  conf="Acquire::Retries \"${APT_RETRIES}\";
+Acquire::http::Timeout \"${APT_TIMEOUT}\";
+Acquire::https::Timeout \"${APT_TIMEOUT}\";
+Acquire::ftp::Timeout \"${APT_TIMEOUT}\";"
+  if ! printf '%s\n' "$conf" | sudo tee "$APT_CONF" > /dev/null 2>&1; then
+    echo "::warning::could not write ${APT_CONF}; apt keeps its 120s idle timeout"
+    return 0
+  fi
+  echo "apt configured to fail fast: ${APT_TIMEOUT}s transfer timeout, ${APT_RETRIES} internal retries"
+}
 
 release_dpkg_lock() {
   if ! have_fuser; then
@@ -68,6 +118,8 @@ release_dpkg_lock() {
   sudo fuser -k "$DPKG_LOCK" > /dev/null 2>&1 || true
   sleep 5
 }
+
+configure_apt_fail_fast
 
 for attempt in $(seq 1 "$ATTEMPTS"); do
   rc=0

--- a/.github/scripts/retry-with-apt-lock.sh
+++ b/.github/scripts/retry-with-apt-lock.sh
@@ -14,12 +14,22 @@
 #
 # Two things make the retry actually work, and both were learned the hard way:
 #
-#   1. The dpkg lock. apt runs as root, so killing the attempt leaves the
-#      apt-get child alive holding /var/lib/dpkg/lock-frontend, and the next
-#      attempt dies two seconds later with "Could not get lock". A retry that
-#      cannot succeed is worse than none: it buries the real reason under a
-#      second, different failure. So wait for the lock, then take it -- the
-#      holder is our own orphan and the runner is disposable.
+#   1. The apt locks, PLURAL. apt runs as root, so killing the attempt leaves the
+#      apt-get child alive holding a lock, and the next attempt dies two seconds
+#      later with "Could not get lock". A retry that cannot succeed is worse than
+#      none: it buries the real reason under a second, different failure. So wait
+#      for the locks, then take them -- the holder is our own orphan and the
+#      runner is disposable.
+#
+#      There are four, and which one matters depends on what apt was doing.
+#      Waiting on only /var/lib/dpkg/lock-frontend is how the first version of
+#      this shipped, and it made the retry useless for exactly the case it was
+#      written for: `apt-get update` takes /var/lib/apt/lists/lock and nothing
+#      else, so the wait saw a free lock, retried immediately, and produced
+#
+#        E: Could not get lock /var/lib/apt/lists/lock. It is held by process 2420 (apt-get)
+#
+#      twice in a row in under two seconds. Three attempts, one real one.
 #
 #   2. `set -e`. GitHub runs `run:` blocks as `bash -e`, so a bare failing
 #      command aborts the step then and there. A retry loop written as
@@ -71,7 +81,9 @@ set -uo pipefail
 
 ATTEMPTS="${RETRY_ATTEMPTS:-3}"
 ATTEMPT_TIMEOUT="${RETRY_ATTEMPT_TIMEOUT:-480}"
-DPKG_LOCK="/var/lib/dpkg/lock-frontend"
+# Every lock apt takes. dpkg's two cover install/configure, lists covers `update`,
+# and archives covers the download cache; an orphan can be holding any of them.
+APT_LOCKS="/var/lib/dpkg/lock-frontend /var/lib/dpkg/lock /var/lib/apt/lists/lock /var/cache/apt/archives/lock"
 APT_TIMEOUT="${APT_ACQUIRE_TIMEOUT:-20}"
 APT_RETRIES="${APT_ACQUIRE_RETRIES:-3}"
 APT_CONF="/etc/apt/apt.conf.d/99-unsloth-ci-fail-fast"
@@ -104,18 +116,36 @@ Acquire::ftp::Timeout \"${APT_TIMEOUT}\";"
   echo "apt configured to fail fast: ${APT_TIMEOUT}s transfer timeout, ${APT_RETRIES} internal retries"
 }
 
-release_dpkg_lock() {
+# Held locks, as a single string. Absent files are not locks, and `fuser` on one
+# is an error rather than an answer, so they are skipped rather than waited on.
+held_apt_locks() {
+  held=""
+  for lock in $APT_LOCKS; do
+    [ -e "$lock" ] || continue
+    if sudo fuser "$lock" > /dev/null 2>&1; then
+      held="$held $lock"
+    fi
+  done
+  printf '%s' "$held"
+}
+
+release_apt_locks() {
   if ! have_fuser; then
-    echo "::warning::fuser unavailable; cannot wait on ${DPKG_LOCK}, retrying blind"
+    echo "::warning::fuser unavailable; cannot wait on the apt locks, retrying blind"
     sleep 15
     return 0
   fi
   for _ in $(seq 1 24); do
-    sudo fuser "$DPKG_LOCK" > /dev/null 2>&1 || return 0
+    holding="$(held_apt_locks)"
+    [ -n "$holding" ] || return 0
     sleep 5
   done
-  echo "::warning::${DPKG_LOCK} still held after 120s; terminating the holder"
-  sudo fuser -k "$DPKG_LOCK" > /dev/null 2>&1 || true
+  holding="$(held_apt_locks)"
+  [ -n "$holding" ] || return 0
+  echo "::warning::still held after 120s, terminating the holders:${holding}"
+  for lock in $holding; do
+    sudo fuser -k "$lock" > /dev/null 2>&1 || true
+  done
   sleep 5
 }
 
@@ -143,7 +173,7 @@ for attempt in $(seq 1 "$ATTEMPTS"); do
   echo "::warning::attempt ${attempt}/${ATTEMPTS} of '$*' ${reason}"
 
   [ "$attempt" -ge "$ATTEMPTS" ] && break
-  release_dpkg_lock
+  release_apt_locks
 done
 
 echo "::error::'$*' failed ${ATTEMPTS} times; the attempt warnings above say which way each one went"

--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -2414,7 +2414,7 @@ jobs:
           # `install_llama_cpp` requirement-check is a no-op.
           RETRY_ATTEMPTS=2 RETRY_ATTEMPT_TIMEOUT=300 \
             bash .github/scripts/retry-with-apt-lock.sh sudo sh -c \
-            'apt-get update -qq && apt-get install -y -qq build-essential cmake git curl libgomp1 libssl-dev libcurl4-openssl-dev'
+            'apt-get install -y -qq build-essential cmake git curl libgomp1 libssl-dev libcurl4-openssl-dev || { apt-get update -qq && apt-get install -y -qq build-essential cmake git curl libgomp1 libssl-dev libcurl4-openssl-dev; }'
           python <<'PY'
           import os, shutil, subprocess, sys, pathlib
           # Apply the same CPU spoof the pytest shims use BEFORE any

--- a/.github/workflows/desktop-app-clean-machine-ci.yml
+++ b/.github/workflows/desktop-app-clean-machine-ci.yml
@@ -399,7 +399,7 @@ jobs:
           # Deliberately no build-essential/cmake/git: a user installing a .deb has none.
           # Xvfb and WebKit are runtime requirements and apt pulls the .deb's declared
           # deps, so a wrong dependency list fails here.
-          RETRY_ATTEMPTS=3 RETRY_ATTEMPT_TIMEOUT=150 \
+          RETRY_ATTEMPTS=2 RETRY_ATTEMPT_TIMEOUT=360 \
             bash .github/scripts/retry-with-apt-lock.sh sudo sh -c \
             'apt-get update -qq && apt-get install -y -qq --no-install-recommends xvfb'
           if [ "${{ matrix.kind }}" = "deb" ]; then

--- a/.github/workflows/desktop-app-clean-machine-ci.yml
+++ b/.github/workflows/desktop-app-clean-machine-ci.yml
@@ -401,7 +401,7 @@ jobs:
           # deps, so a wrong dependency list fails here.
           RETRY_ATTEMPTS=2 RETRY_ATTEMPT_TIMEOUT=360 \
             bash .github/scripts/retry-with-apt-lock.sh sudo sh -c \
-            'apt-get update -qq && apt-get install -y -qq --no-install-recommends xvfb'
+            'apt-get install -y -qq --no-install-recommends xvfb || { apt-get update -qq && apt-get install -y -qq --no-install-recommends xvfb; }'
           if [ "${{ matrix.kind }}" = "deb" ]; then
             sudo apt-get install -y ./dl/*.deb || {
               echo "::error::the .deb does not declare its runtime dependencies correctly"

--- a/.github/workflows/interrupted-install-ci.yml
+++ b/.github/workflows/interrupted-install-ci.yml
@@ -133,7 +133,7 @@ jobs:
           RETRY_ATTEMPT_TIMEOUT: '360'
         run: |
           bash .github/scripts/retry-with-apt-lock.sh sudo sh -c \
-            'apt-get update -qq && apt-get install -y -qq --no-install-recommends cmake git build-essential libcurl4-openssl-dev'
+            'apt-get install -y -qq --no-install-recommends cmake git build-essential libcurl4-openssl-dev || { apt-get update -qq && apt-get install -y -qq --no-install-recommends cmake git build-essential libcurl4-openssl-dev; }'
 
       - name: Install, interrupted at "${{ matrix.label }}"
         env:

--- a/.github/workflows/interrupted-install-ci.yml
+++ b/.github/workflows/interrupted-install-ci.yml
@@ -123,10 +123,14 @@ jobs:
         # with no reason and every later step skipped. update and install go as one
         # unit, since retrying the install after a stalled update re-reads the same
         # broken package list.
-        timeout-minutes: 13
+        # Two long attempts, not three short ones. 150s killed apt mid-`update`
+        # against a mirror that was degraded rather than dead, and every attempt
+        # then hit the same wall -- three kills and no result. The bound exists to
+        # stop an infinite hang, not to race a slow mirror.
+        timeout-minutes: 15
         env:
-          RETRY_ATTEMPTS: '3'
-          RETRY_ATTEMPT_TIMEOUT: '150'
+          RETRY_ATTEMPTS: '2'
+          RETRY_ATTEMPT_TIMEOUT: '360'
         run: |
           bash .github/scripts/retry-with-apt-lock.sh sudo sh -c \
             'apt-get update -qq && apt-get install -y -qq --no-install-recommends cmake git build-essential libcurl4-openssl-dev'

--- a/.github/workflows/lint-ci.yml
+++ b/.github/workflows/lint-ci.yml
@@ -135,10 +135,14 @@ jobs:
       # update and install are one unit: retrying the install alone after a stalled
       # update just re-reads the same broken package list.
       - name: Linux deps for shellcheck
-        timeout-minutes: 13
+        # Two long attempts, not three short ones. 150s killed apt mid-`update`
+        # against a mirror that was degraded rather than dead, and every attempt
+        # then hit the same wall -- three kills and no result. The bound exists to
+        # stop an infinite hang, not to race a slow mirror.
+        timeout-minutes: 15
         env:
-          RETRY_ATTEMPTS: '3'
-          RETRY_ATTEMPT_TIMEOUT: '150'
+          RETRY_ATTEMPTS: '2'
+          RETRY_ATTEMPT_TIMEOUT: '360'
         run: |
           bash .github/scripts/retry-with-apt-lock.sh sudo sh -c \
             'apt-get update -qq && apt-get install -y --no-install-recommends shellcheck'

--- a/.github/workflows/lint-ci.yml
+++ b/.github/workflows/lint-ci.yml
@@ -145,7 +145,7 @@ jobs:
           RETRY_ATTEMPT_TIMEOUT: '360'
         run: |
           bash .github/scripts/retry-with-apt-lock.sh sudo sh -c \
-            'apt-get update -qq && apt-get install -y --no-install-recommends shellcheck'
+            'apt-get install -y --no-install-recommends shellcheck || { apt-get update -qq && apt-get install -y --no-install-recommends shellcheck; }'
 
       - name: Python AST/syntax check (every committed .py must compile)
         # python -m compileall uses the same parser the interpreter

--- a/.github/workflows/local-agent-guides-ci.yml
+++ b/.github/workflows/local-agent-guides-ci.yml
@@ -157,10 +157,14 @@ jobs:
         # with no reason and every later step skipped. update and install go as one
         # unit, since retrying the install after a stalled update re-reads the same
         # broken package list.
-        timeout-minutes: 13
+        # Two long attempts, not three short ones. 150s killed apt mid-`update`
+        # against a mirror that was degraded rather than dead, and every attempt
+        # then hit the same wall -- three kills and no result. The bound exists to
+        # stop an infinite hang, not to race a slow mirror.
+        timeout-minutes: 15
         env:
-          RETRY_ATTEMPTS: '3'
-          RETRY_ATTEMPT_TIMEOUT: '150'
+          RETRY_ATTEMPTS: '2'
+          RETRY_ATTEMPT_TIMEOUT: '360'
         run: |
           bash .github/scripts/retry-with-apt-lock.sh sudo sh -c \
             'apt-get update && apt-get install -y --no-install-recommends libcurl4-openssl-dev libssl-dev jq'
@@ -388,10 +392,14 @@ jobs:
         # with no reason and every later step skipped. update and install go as one
         # unit, since retrying the install after a stalled update re-reads the same
         # broken package list.
-        timeout-minutes: 13
+        # Two long attempts, not three short ones. 150s killed apt mid-`update`
+        # against a mirror that was degraded rather than dead, and every attempt
+        # then hit the same wall -- three kills and no result. The bound exists to
+        # stop an infinite hang, not to race a slow mirror.
+        timeout-minutes: 15
         env:
-          RETRY_ATTEMPTS: '3'
-          RETRY_ATTEMPT_TIMEOUT: '150'
+          RETRY_ATTEMPTS: '2'
+          RETRY_ATTEMPT_TIMEOUT: '360'
         run: |
           bash .github/scripts/retry-with-apt-lock.sh sudo sh -c \
             'apt-get update && apt-get install -y --no-install-recommends libcurl4-openssl-dev libssl-dev jq'
@@ -577,10 +585,14 @@ jobs:
         # with no reason and every later step skipped. update and install go as one
         # unit, since retrying the install after a stalled update re-reads the same
         # broken package list.
-        timeout-minutes: 13
+        # Two long attempts, not three short ones. 150s killed apt mid-`update`
+        # against a mirror that was degraded rather than dead, and every attempt
+        # then hit the same wall -- three kills and no result. The bound exists to
+        # stop an infinite hang, not to race a slow mirror.
+        timeout-minutes: 15
         env:
-          RETRY_ATTEMPTS: '3'
-          RETRY_ATTEMPT_TIMEOUT: '150'
+          RETRY_ATTEMPTS: '2'
+          RETRY_ATTEMPT_TIMEOUT: '360'
         run: |
           bash .github/scripts/retry-with-apt-lock.sh sudo sh -c \
             'apt-get update && apt-get install -y --no-install-recommends libcurl4-openssl-dev libssl-dev jq'
@@ -743,10 +755,14 @@ jobs:
         # with no reason and every later step skipped. update and install go as one
         # unit, since retrying the install after a stalled update re-reads the same
         # broken package list.
-        timeout-minutes: 13
+        # Two long attempts, not three short ones. 150s killed apt mid-`update`
+        # against a mirror that was degraded rather than dead, and every attempt
+        # then hit the same wall -- three kills and no result. The bound exists to
+        # stop an infinite hang, not to race a slow mirror.
+        timeout-minutes: 15
         env:
-          RETRY_ATTEMPTS: '3'
-          RETRY_ATTEMPT_TIMEOUT: '150'
+          RETRY_ATTEMPTS: '2'
+          RETRY_ATTEMPT_TIMEOUT: '360'
         run: |
           bash .github/scripts/retry-with-apt-lock.sh sudo sh -c \
             'apt-get update && apt-get install -y --no-install-recommends libcurl4-openssl-dev libssl-dev jq'

--- a/.github/workflows/local-agent-guides-ci.yml
+++ b/.github/workflows/local-agent-guides-ci.yml
@@ -167,7 +167,7 @@ jobs:
           RETRY_ATTEMPT_TIMEOUT: '360'
         run: |
           bash .github/scripts/retry-with-apt-lock.sh sudo sh -c \
-            'apt-get update && apt-get install -y --no-install-recommends libcurl4-openssl-dev libssl-dev jq'
+            'apt-get install -y --no-install-recommends libcurl4-openssl-dev libssl-dev jq || { apt-get update && apt-get install -y --no-install-recommends libcurl4-openssl-dev libssl-dev jq; }'
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
@@ -402,7 +402,7 @@ jobs:
           RETRY_ATTEMPT_TIMEOUT: '360'
         run: |
           bash .github/scripts/retry-with-apt-lock.sh sudo sh -c \
-            'apt-get update && apt-get install -y --no-install-recommends libcurl4-openssl-dev libssl-dev jq'
+            'apt-get install -y --no-install-recommends libcurl4-openssl-dev libssl-dev jq || { apt-get update && apt-get install -y --no-install-recommends libcurl4-openssl-dev libssl-dev jq; }'
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
@@ -595,7 +595,7 @@ jobs:
           RETRY_ATTEMPT_TIMEOUT: '360'
         run: |
           bash .github/scripts/retry-with-apt-lock.sh sudo sh -c \
-            'apt-get update && apt-get install -y --no-install-recommends libcurl4-openssl-dev libssl-dev jq'
+            'apt-get install -y --no-install-recommends libcurl4-openssl-dev libssl-dev jq || { apt-get update && apt-get install -y --no-install-recommends libcurl4-openssl-dev libssl-dev jq; }'
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
@@ -765,7 +765,7 @@ jobs:
           RETRY_ATTEMPT_TIMEOUT: '360'
         run: |
           bash .github/scripts/retry-with-apt-lock.sh sudo sh -c \
-            'apt-get update && apt-get install -y --no-install-recommends libcurl4-openssl-dev libssl-dev jq'
+            'apt-get install -y --no-install-recommends libcurl4-openssl-dev libssl-dev jq || { apt-get update && apt-get install -y --no-install-recommends libcurl4-openssl-dev libssl-dev jq; }'
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -559,10 +559,14 @@ jobs:
         # with no reason and every later step skipped. update and install go as one
         # unit, since retrying the install after a stalled update re-reads the same
         # broken package list.
-        timeout-minutes: 13
+        # Two long attempts, not three short ones. 150s killed apt mid-`update`
+        # against a mirror that was degraded rather than dead, and every attempt
+        # then hit the same wall -- three kills and no result. The bound exists to
+        # stop an infinite hang, not to race a slow mirror.
+        timeout-minutes: 15
         env:
-          RETRY_ATTEMPTS: '3'
-          RETRY_ATTEMPT_TIMEOUT: '150'
+          RETRY_ATTEMPTS: '2'
+          RETRY_ATTEMPT_TIMEOUT: '360'
         run: |
           bash .github/scripts/retry-with-apt-lock.sh sudo sh -c \
             'apt-get update && apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev libxdo-dev libssl-dev patchelf'

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -569,7 +569,7 @@ jobs:
           RETRY_ATTEMPT_TIMEOUT: '360'
         run: |
           bash .github/scripts/retry-with-apt-lock.sh sudo sh -c \
-            'apt-get update && apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev libxdo-dev libssl-dev patchelf'
+            'apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev libxdo-dev libssl-dev patchelf || { apt-get update && apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev libxdo-dev libssl-dev patchelf; }'
 
       # ── Node.js ──
       - name: Setup Node.js

--- a/.github/workflows/studio-api-smoke.yml
+++ b/.github/workflows/studio-api-smoke.yml
@@ -86,7 +86,7 @@ jobs:
           RETRY_ATTEMPT_TIMEOUT: '360'
         run: |
           bash .github/scripts/retry-with-apt-lock.sh sudo sh -c \
-            'apt-get update && apt-get install -y --no-install-recommends libcurl4-openssl-dev libssl-dev jq'
+            'apt-get install -y --no-install-recommends libcurl4-openssl-dev libssl-dev jq || { apt-get update && apt-get install -y --no-install-recommends libcurl4-openssl-dev libssl-dev jq; }'
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:

--- a/.github/workflows/studio-api-smoke.yml
+++ b/.github/workflows/studio-api-smoke.yml
@@ -76,10 +76,14 @@ jobs:
         # with no reason and every later step skipped. update and install go as one
         # unit, since retrying the install after a stalled update re-reads the same
         # broken package list.
-        timeout-minutes: 13
+        # Two long attempts, not three short ones. 150s killed apt mid-`update`
+        # against a mirror that was degraded rather than dead, and every attempt
+        # then hit the same wall -- three kills and no result. The bound exists to
+        # stop an infinite hang, not to race a slow mirror.
+        timeout-minutes: 15
         env:
-          RETRY_ATTEMPTS: '3'
-          RETRY_ATTEMPT_TIMEOUT: '150'
+          RETRY_ATTEMPTS: '2'
+          RETRY_ATTEMPT_TIMEOUT: '360'
         run: |
           bash .github/scripts/retry-with-apt-lock.sh sudo sh -c \
             'apt-get update && apt-get install -y --no-install-recommends libcurl4-openssl-dev libssl-dev jq'

--- a/.github/workflows/studio-inference-smoke.yml
+++ b/.github/workflows/studio-inference-smoke.yml
@@ -144,10 +144,14 @@ jobs:
         # with no reason and every later step skipped. update and install go as one
         # unit, since retrying the install after a stalled update re-reads the same
         # broken package list.
-        timeout-minutes: 13
+        # Two long attempts, not three short ones. 150s killed apt mid-`update`
+        # against a mirror that was degraded rather than dead, and every attempt
+        # then hit the same wall -- three kills and no result. The bound exists to
+        # stop an infinite hang, not to race a slow mirror.
+        timeout-minutes: 15
         env:
-          RETRY_ATTEMPTS: '3'
-          RETRY_ATTEMPT_TIMEOUT: '150'
+          RETRY_ATTEMPTS: '2'
+          RETRY_ATTEMPT_TIMEOUT: '360'
         run: |
           bash .github/scripts/retry-with-apt-lock.sh sudo sh -c \
             'apt-get update && apt-get install -y --no-install-recommends libcurl4-openssl-dev libssl-dev jq'

--- a/.github/workflows/studio-inference-smoke.yml
+++ b/.github/workflows/studio-inference-smoke.yml
@@ -154,7 +154,7 @@ jobs:
           RETRY_ATTEMPT_TIMEOUT: '360'
         run: |
           bash .github/scripts/retry-with-apt-lock.sh sudo sh -c \
-            'apt-get update && apt-get install -y --no-install-recommends libcurl4-openssl-dev libssl-dev jq'
+            'apt-get install -y --no-install-recommends libcurl4-openssl-dev libssl-dev jq || { apt-get update && apt-get install -y --no-install-recommends libcurl4-openssl-dev libssl-dev jq; }'
 
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0

--- a/.github/workflows/studio-tauri-smoke.yml
+++ b/.github/workflows/studio-tauri-smoke.yml
@@ -84,10 +84,14 @@ jobs:
         # with no reason and every later step skipped. update and install go as one
         # unit, since retrying the install after a stalled update re-reads the same
         # broken package list.
-        timeout-minutes: 13
+        # Two long attempts, not three short ones. 150s killed apt mid-`update`
+        # against a mirror that was degraded rather than dead, and every attempt
+        # then hit the same wall -- three kills and no result. The bound exists to
+        # stop an infinite hang, not to race a slow mirror.
+        timeout-minutes: 15
         env:
-          RETRY_ATTEMPTS: '3'
-          RETRY_ATTEMPT_TIMEOUT: '150'
+          RETRY_ATTEMPTS: '2'
+          RETRY_ATTEMPT_TIMEOUT: '360'
         run: |
           bash .github/scripts/retry-with-apt-lock.sh sudo sh -c \
             'apt-get update && apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev libxdo-dev libssl-dev patchelf xvfb'

--- a/.github/workflows/studio-tauri-smoke.yml
+++ b/.github/workflows/studio-tauri-smoke.yml
@@ -94,7 +94,7 @@ jobs:
           RETRY_ATTEMPT_TIMEOUT: '360'
         run: |
           bash .github/scripts/retry-with-apt-lock.sh sudo sh -c \
-            'apt-get update && apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev libxdo-dev libssl-dev patchelf xvfb'
+            'apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev libxdo-dev libssl-dev patchelf xvfb || { apt-get update && apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev libxdo-dev libssl-dev patchelf xvfb; }'
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:

--- a/.github/workflows/studio-ui-smoke.yml
+++ b/.github/workflows/studio-ui-smoke.yml
@@ -127,8 +127,10 @@ jobs:
         # The job's 30 stays the final backstop and is deliberately not tightened.
         timeout-minutes: 20
         env:
-          RETRY_ATTEMPTS: '3'
-          RETRY_ATTEMPT_TIMEOUT: '180'
+          # See the note above: two long attempts beat three short ones against a
+          # mirror that is slow rather than gone.
+          RETRY_ATTEMPTS: '2'
+          RETRY_ATTEMPT_TIMEOUT: '360'
         # One call, not two: retrying the install after a stalled update just re-reads
         # the same broken package list, and two calls double the worst case for no
         # extra coverage.
@@ -669,8 +671,10 @@ jobs:
         # The job's 30 stays the final backstop and is deliberately not tightened.
         timeout-minutes: 20
         env:
-          RETRY_ATTEMPTS: '3'
-          RETRY_ATTEMPT_TIMEOUT: '180'
+          # See the note above: two long attempts beat three short ones against a
+          # mirror that is slow rather than gone.
+          RETRY_ATTEMPTS: '2'
+          RETRY_ATTEMPT_TIMEOUT: '360'
         # One call, not two: retrying the install after a stalled update just re-reads
         # the same broken package list, and two calls double the worst case for no
         # extra coverage.

--- a/.github/workflows/studio-ui-smoke.yml
+++ b/.github/workflows/studio-ui-smoke.yml
@@ -136,7 +136,7 @@ jobs:
         # extra coverage.
         run: |
           bash .github/scripts/retry-with-apt-lock.sh sudo sh -c \
-            'apt-get update && apt-get install -y --no-install-recommends libcurl4-openssl-dev libssl-dev jq'
+            'apt-get install -y --no-install-recommends libcurl4-openssl-dev libssl-dev jq || { apt-get update && apt-get install -y --no-install-recommends libcurl4-openssl-dev libssl-dev jq; }'
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
@@ -680,7 +680,7 @@ jobs:
         # extra coverage.
         run: |
           bash .github/scripts/retry-with-apt-lock.sh sudo sh -c \
-            'apt-get update && apt-get install -y --no-install-recommends libcurl4-openssl-dev libssl-dev jq'
+            'apt-get install -y --no-install-recommends libcurl4-openssl-dev libssl-dev jq || { apt-get update && apt-get install -y --no-install-recommends libcurl4-openssl-dev libssl-dev jq; }'
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
           node-version: '22'

--- a/.github/workflows/studio-update-smoke.yml
+++ b/.github/workflows/studio-update-smoke.yml
@@ -71,7 +71,7 @@ jobs:
           RETRY_ATTEMPT_TIMEOUT: '360'
         run: |
           bash .github/scripts/retry-with-apt-lock.sh sudo sh -c \
-            'apt-get update && apt-get install -y --no-install-recommends libcurl4-openssl-dev libssl-dev jq'
+            'apt-get install -y --no-install-recommends libcurl4-openssl-dev libssl-dev jq || { apt-get update && apt-get install -y --no-install-recommends libcurl4-openssl-dev libssl-dev jq; }'
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:

--- a/.github/workflows/studio-update-smoke.yml
+++ b/.github/workflows/studio-update-smoke.yml
@@ -48,7 +48,8 @@ jobs:
   update-idempotency:
     name: Unsloth Updating Tests
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # Sized for the apt step's bounded worst case (15m) plus the smoke itself.
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
@@ -60,10 +61,14 @@ jobs:
         # with no reason and every later step skipped. update and install go as one
         # unit, since retrying the install after a stalled update re-reads the same
         # broken package list.
-        timeout-minutes: 13
+        # Two long attempts, not three short ones. 150s killed apt mid-`update`
+        # against a mirror that was degraded rather than dead, and every attempt
+        # then hit the same wall -- three kills and no result. The bound exists to
+        # stop an infinite hang, not to race a slow mirror.
+        timeout-minutes: 15
         env:
-          RETRY_ATTEMPTS: '3'
-          RETRY_ATTEMPT_TIMEOUT: '150'
+          RETRY_ATTEMPTS: '2'
+          RETRY_ATTEMPT_TIMEOUT: '360'
         run: |
           bash .github/scripts/retry-with-apt-lock.sh sudo sh -c \
             'apt-get update && apt-get install -y --no-install-recommends libcurl4-openssl-dev libssl-dev jq'

--- a/tests/studio/test_apt_steps_are_bounded.py
+++ b/tests/studio/test_apt_steps_are_bounded.py
@@ -239,6 +239,62 @@ def test_helper_defaults_are_what_the_budgets_assume() -> None:
     assert LOCK_WAIT_SECONDS == 24 * 5 + 5
 
 
+def test_the_helper_makes_apt_fail_fast() -> None:
+    """
+    The bound is the backstop; this is the part that stops the stall happening.
+
+    apt's `Acquire::http::Timeout` defaults to 120s and is an *idle* timeout, so a
+    socket that is open and trickling never trips it. That is how a 126 kB index
+    file cost 29 minutes: apt did not consider waiting on it an error at all.
+    Without these four options the helper still works, but every stall costs the
+    full step budget and ends in a kill -- and the kill is what orphans the dpkg
+    lock, so an apt that gives up on its own is one we never have to kill.
+    """
+    source = (REPO_ROOT / HELPER).read_text(encoding = "utf-8")
+
+    # The generated config only, not the whole file. Searching the file matches the
+    # header comment, which names these options while explaining them -- so deleting
+    # the line that actually sets one would have gone unnoticed. It did, on the
+    # first version of this test.
+    written = re.search(r'conf="(.*?)"\n', source, re.DOTALL)
+    assert written, f"{HELPER} no longer builds an apt config to write"
+    conf = written.group(1)
+
+    for option in (
+        "Acquire::Retries",
+        "Acquire::http::Timeout",
+        "Acquire::https::Timeout",
+        "Acquire::ftp::Timeout",
+    ):
+        assert option in conf, f"{HELPER} no longer sets {option}; it writes: {conf!r}"
+
+    # Well under apt's 120s default, or it buys nothing. The whole point is that a
+    # dead transfer is abandoned in seconds rather than minutes.
+    match = re.search(r'APT_TIMEOUT="\$\{APT_ACQUIRE_TIMEOUT:-(\d+)\}"', source)
+    assert match, f"{HELPER} does not define a default transfer timeout"
+    assert int(match.group(1)) <= 30, (
+        f"a {match.group(1)}s transfer timeout is close enough to apt's 120s "
+        f"default that a stalled mirror still eats the step budget"
+    )
+
+    # Ordering is the whole value: configured inside or after the retry loop, the
+    # first attempt -- the one that actually stalls -- runs unconfigured.
+    configure = source.index("configure_apt_fail_fast\n\nfor attempt")
+    loop = source.index('for attempt in $(seq 1 "$ATTEMPTS")')
+    assert configure < loop, (
+        f"{HELPER} configures apt at or after the retry loop, so the first "
+        f"attempt runs with apt's 120s idle timeout"
+    )
+
+    # Best effort: a runner that cannot write the file must still run the command.
+    # `set -e` is absent here by design, but a bare failing `tee` would still leave
+    # the function returning non-zero into a caller that may have it set.
+    assert "could not write" in source, (
+        f"{HELPER} does not handle an unwritable apt config, so a runner that "
+        f"refuses the write would fail before running the command at all"
+    )
+
+
 def test_the_guard_is_not_vacuous() -> None:
     """
     Every assertion above is a for-loop over steps this finds. If the detector


### PR DESCRIPTION
## The answer to "is installing packages broken?"

No. Nothing about this repo's dependencies. GitHub's Azure Ubuntu mirror was degraded, and **apt has no timeout that stops it waiting on a dead connection.**

Every one of the four stalled jobs ends the same way:

```
04:47:02  Get:5 https://archive.ubuntu.com/ubuntu noble-security InRelease [126 kB]
05:16:29  ##[error]The operation was canceled.
```

Twenty-nine minutes and twenty-seven seconds of total silence, mid-fetch of a 126 kB index file. Two of the four hung on that exact file. What comes immediately before it is the other half of the story:

```
04:46:54  Ign:2 http://azure.archive.ubuntu.com/ubuntu noble InRelease
04:46:55  Ign:2 http://azure.archive.ubuntu.com/ubuntu noble InRelease
04:46:57  Ign:2 http://azure.archive.ubuntu.com/ubuntu noble InRelease
04:47:01  Ign:2 http://azure.archive.ubuntu.com/ubuntu noble InRelease
04:47:01  Hit:2 https://archive.ubuntu.com/ubuntu noble InRelease
```

The Azure mirror was already gone, so apt failed over through `/etc/apt/apt-mirrors.txt` to the public archive, which is not provisioned for this fleet.

apt did not consider any of that an error. `Acquire::http::Timeout` defaults to 120s **and is an idle timeout**, so a socket that is open and trickling never trips it. This is a long-running, well-documented condition on GitHub's runners, tracked upstream in [actions/runner-images#675](https://github.com/actions/virtual-environments/issues/675), [#6486](https://github.com/actions/runner-images/issues/6486), [#6894](https://github.com/actions/runner-images/issues/6894) and [#7048](https://github.com/actions/runner-images/issues/7048).

## What this changes

The helper now writes `/etc/apt/apt.conf.d/99-unsloth-ci-fail-fast` before its first attempt:

```
Acquire::Retries "3";
Acquire::http::Timeout "20";
Acquire::https::Timeout "20";
Acquire::ftp::Timeout "20";
```

A 29-minute hang becomes a ~1 minute failure. That matters for a reason beyond speed: **the wall-clock kill is what orphans the dpkg lock**, so an apt that gives up on its own is an apt we never have to kill, and the retry is retrying a failed command rather than resuming a half-killed one.

It is written by the helper rather than assumed of the runner image so that it also covers `playwright install --with-deps`, which shells out to apt without ever naming it.

**Not pinning a mirror**, and the evidence is why: in one stall Azure was dead and the public archive hung; in another Azure was serving fine and the transfer stalled partway through a 13.6 MB package. Neither is reliably better. The mirrorlist failover is already the right mechanism, it just needed to be allowed to give up.

## Verification

The generated config is validated **against apt itself**, not by eye. `apt-config dump` round-trips all four options:

```
$ APT_CONFIG=apt-fail-fast.conf apt-config dump | grep -i acquire
Acquire::Retries "3";
Acquire::http::Timeout "20";
Acquire::https::Timeout "20";
Acquire::ftp::Timeout "20";
```

The helper's behaviour is exercised end to end with shims for `sudo` and `fuser`, so the best-effort fallbacks are covered rather than assumed: success on the first attempt, a command that always fails (3 attempts, all reported as "exited with status 1" rather than as a stall), a command that hangs (killed and reported as "did not finish within 2s"), recovery on attempt 2, the no-command case, and an unwritable config warning and continuing rather than aborting. All as expected.

Guard: `test_the_helper_makes_apt_fail_fast` asserts the four options are in the config **the helper actually writes**, that the timeout stays well under apt's useless 120s default, that it is applied *before* the retry loop (configured inside or after it, the first attempt is the one that stalls and it would run unconfigured), and that an unwritable config does not abort. Four mutants reintroduced and confirmed red.

One of those mutants initially survived, which is worth recording: the first version of the test searched the whole file, so it matched the option names in the header comment that explains them, and deleting the line that actually set one went unnoticed. It now parses the generated config.

`tests/studio`: 4457 passed, 4 skipped.
