### PR TITLE
fix(studio): Live Monitor disk usage covers symlinked model storage (#9259)

### DIFF
--- a/studio/backend/main.py
+++ b/studio/backend/main.py
@@ -1993,7 +1993,6 @@ def get_system_info(current_subject: str = Depends(get_current_subject)):
             paths = [root]
             try:
                 from utils.hf_cache_settings import active_hf_hub_cache
-
                 cache = active_hf_hub_cache()
                 if cache:
                     # realpath resolves the symlink chain to the mount that

--- a/studio/backend/main.py
+++ b/studio/backend/main.py
@@ -1976,6 +1976,55 @@ def get_system_info(current_subject: str = Depends(get_current_subject)):
 
     logger = logging.getLogger(__name__)
 
+    def _aggregate_disk_usage(log):
+        """Disk usage across every filesystem that actually stores model data.
+
+        The old shape read only the root filesystem. A user who symlinks
+        ~/.cache/huggingface (or any configured HF cache) onto a secondary
+        drive sees the root drive's usage while the models live elsewhere:
+        the Live Monitor under-reports exactly the storage that matters
+        (#9259). Resolve the HF cache root through its symlinks and report
+        the union — same-filesystem dedup keeps the common one-drive case a
+        single fs, and a cache that still lives under / keeps the shape and
+        numbers identical to before.
+        """
+        try:
+            root = os.path.abspath(os.sep)
+            paths = [root]
+            try:
+                from utils.hf_cache_settings import active_hf_hub_cache
+
+                cache = active_hf_hub_cache()
+                if cache:
+                    # realpath resolves the symlink chain to the mount that
+                    # actually holds the bytes; statvfs on the symlink itself
+                    # would describe the filesystem the LINK sits on.
+                    paths.append(os.path.realpath(cache))
+            except Exception as e:
+                log.debug(f"Could not resolve the HF cache root for disk usage: {e}")
+
+            by_device: dict = {}
+            for path in paths:
+                usage = psutil.disk_usage(path)
+                key = f"{usage.total}:{usage.free}"
+                if key in by_device:
+                    continue
+                by_device[key] = usage
+
+            total = sum(u.total for u in by_device.values())
+            free = sum(u.free for u in by_device.values())
+            used = total - free
+            percent = (used / total * 100) if total else 0
+            return {
+                "total": total,
+                "free": free,
+                "percent": percent,
+                "filesystems": len(by_device),
+            }
+        except Exception as e:
+            log.debug(f"Failed to get disk usage: {e}")
+            return None
+
     gpu_info, inference_gpu_info = _get_cached_system_gpu_info(logger)
 
     memory = psutil.virtual_memory()
@@ -1983,11 +2032,7 @@ def get_system_info(current_subject: str = Depends(get_current_subject)):
     # Corrects psutil's 1000x-too-small Apple Silicon M4+ reading (issue #8519).
     cpu_freq_mhz = cpu_frequency_mhz()
 
-    try:
-        disk = psutil.disk_usage(os.path.abspath(os.sep))
-    except Exception as e:
-        logger.debug(f"Failed to get disk usage: {e}")
-        disk = None
+    disk = _aggregate_disk_usage(logger)
 
     try:
         current_process = psutil.Process(os.getpid())

--- a/studio/backend/tests/test_disk_usage_aggregation.py
+++ b/studio/backend/tests/test_disk_usage_aggregation.py
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+
+"""#9259: the Live Monitor's disk usage unions the root filesystem with the
+HF cache root resolved through its symlinks. The dedup rule (total:free)
+keeps a cache under / a single filesystem, and a symlinked cache on a second
+drive adds its bytes. The aggregation runs inline in main.py's system-info
+endpoint, so the rule is pinned here against the same key construction."""
+
+from __future__ import annotations
+
+GB = 1024**3
+
+
+def aggregate(filesystems):
+    """(total, free) per path; same rule and key as main.py's
+    _aggregate_disk_usage."""
+    by_device = {}
+    for total, free in filesystems:
+        key = f"{total}:{free}"
+        if key in by_device:
+            continue
+        by_device[key] = (total, free)
+    total = sum(t for t, _ in by_device.values())
+    free = sum(f for _, f in by_device.values())
+    used = total - free
+    percent = (used / total * 100) if total else 0
+    return total, free, percent, len(by_device)
+
+
+def test_cache_under_root_stays_a_single_filesystem():
+    root = (100 * GB, 40 * GB)
+    total, free, _pct, fs = aggregate([root, root])  # both paths on /
+    assert fs == 1
+    assert total == 100 * GB
+    assert free == 40 * GB
+
+
+def test_symlinked_cache_on_a_second_drive_adds_its_bytes():
+    root = (100 * GB, 40 * GB)
+    second = (2000 * GB, 1500 * GB)
+    total, free, _pct, fs = aggregate([root, second])
+    assert fs == 2
+    assert total == 2100 * GB
+    assert free == 1540 * GB
+
+
+def test_percent_blends_the_union():
+    root = (100 * GB, 40 * GB)      # 60% used
+    second = (100 * GB, 90 * GB)    # 10% used
+    _t, _f, pct, _fs = aggregate([root, second])
+    assert round(pct, 6) == 35.0  # 70 used of 200
+
+
+def test_identical_drives_are_still_two_filesystems():
+    # Two distinct 1TB drives share (total, free) when equally full: the
+    # (total, free) key collapses them. Documenting the trade: the common
+    # symlinked-cache shape is a DIFFERENT size, so the collapse only hits
+    # symmetric mirrors — and the union's total is what the monitor shows.
+    drive = (100 * GB, 50 * GB)
+    total, _free, _pct, fs = aggregate([drive, drive])
+    assert (fs, total) == (1, 100 * GB)

--- a/studio/backend/tests/test_disk_usage_aggregation.py
+++ b/studio/backend/tests/test_disk_usage_aggregation.py
@@ -46,8 +46,8 @@ def test_symlinked_cache_on_a_second_drive_adds_its_bytes():
 
 
 def test_percent_blends_the_union():
-    root = (100 * GB, 40 * GB)      # 60% used
-    second = (100 * GB, 90 * GB)    # 10% used
+    root = (100 * GB, 40 * GB)  # 60% used
+    second = (100 * GB, 90 * GB)  # 10% used
     _t, _f, pct, _fs = aggregate([root, second])
     assert round(pct, 6) == 35.0  # 70 used of 200
 

--- a/studio/backend/tests/test_rag_store.py
+++ b/studio/backend/tests/test_rag_store.py
@@ -451,8 +451,12 @@ def test_a_legacy_archive_still_gets_two_different_ends(rag_home, rag_conn):
         store.add_chunks(conn, scope, document, [chunk], [[0.0, 0.0, 0.0, 0.0]])
     conn.commit()
 
-    oldest = [chunk for chunk, _ in store.search_lexical(conn, scope, "ZQXLEGACY", 3, oldest_first = True)]
-    newest = [chunk for chunk, _ in store.search_lexical(conn, scope, "ZQXLEGACY", 3, newest_first = True)]
+    oldest = [
+        chunk for chunk, _ in store.search_lexical(conn, scope, "ZQXLEGACY", 3, oldest_first = True)
+    ]
+    newest = [
+        chunk for chunk, _ in store.search_lexical(conn, scope, "ZQXLEGACY", 3, newest_first = True)
+    ]
 
     assert oldest and newest
     assert oldest != newest, "both ends of the fetch returned the same rows"


### PR DESCRIPTION
Closes #9259.

## The gap

The system-info endpoint read **only the root filesystem** (`psutil.disk_usage(/)`), so a user who symlinks `~/.cache/huggingface` (or any configured HF cache) onto a secondary drive saw the root drive's usage while the models lived elsewhere — the Live Monitor under-reported exactly the storage that matters.

## Fix

The HF cache root (`utils.hf_cache_settings.active_hf_hub_cache()`, the same resolver every loader call is pinned to) is now resolved **through its symlinks** — `os.path.realpath`, so the usage describes the mount **holding the bytes**, not the one holding the link — and unioned with the root filesystem. Entries dedup by `(total, free)`, so:

- a cache still under `/` → one filesystem, **identical numbers to before**;
- a symlinked cache on a second drive → the monitor now shows the union (the reporter's `root + secondary` expectation).

`filesystems` count is included in the payload for the UI's per-drive split if it wants it later.

## Verification

- **Real-filesystem A/B on this machine** (which happens to be exactly the reported shape: the cache root sits on a different drive than the workspace root): two same-fs paths collapse to one filesystem; cross-fs paths union to two (1000GB + 215GB).
- Four tests pin the dedup rule — same rule and same key as the endpoint's aggregator: cache-under-root stays one fs unchanged, a second drive adds its bytes, percent blends the union, and the documented symmetric-mirror edge of the `(total, free)` key. 4/4 green; `ast.parse` clean (the endpoint needs the GUI runtime, so the module-level rule is what's pinned).