### PR TITLE
Record the venv own requirement digests, not the installers

### DIFF
--- a/.github/workflows/desktop-app-clean-machine-ci.yml
+++ b/.github/workflows/desktop-app-clean-machine-ci.yml
@@ -276,7 +276,14 @@ jobs:
             cp "$f" logs/ 2>/dev/null || true
             tail -60 "$f"
             # The two fields the bug report turned on.
-            grep -E "disposition=|can_auto_repair=|Xcode Command Line|ModuleNotFoundError" "$f" || true
+            # "Managed preflight" is not decoration. The disposition is the symptom;
+            # the reason is the diagnosis, and it is logged on a separate line that
+            # `tail -60` above scrolls away the moment the backend starts chattering.
+            # On 2026-08-19 this went red on all four platforms and printed nothing
+            # but "saw: ManagedStale"; the reason that actually explained it,
+            # studio_install_requirements_changed, had to be recovered by hand from
+            # the uploaded artifact.
+            grep -E "disposition=|can_auto_repair=|Managed preflight|Xcode Command Line|ModuleNotFoundError" "$f" || true
             found=1
             if grep -qE "desktop_preflight completed disposition=" "$f"; then disposition=1; fi
             dispositions="${dispositions:-} $(grep -oE 'desktop_preflight completed disposition=[A-Za-z]+' "$f" | sed 's/.*disposition=//' | tr '\n' ' ')"
@@ -520,7 +527,14 @@ jobs:
           for f in "$UNSLOTH_STUDIO_HOME/tauri.log" "$HOME/.unsloth/studio/tauri.log"; do
             [ -f "$f" ] || continue
             echo "=== $f ==="; cp "$f" logs/ 2>/dev/null || true; tail -60 "$f"
-            grep -E "disposition=|can_auto_repair=|ModuleNotFoundError" "$f" || true
+            # "Managed preflight" is not decoration. The disposition is the symptom;
+            # the reason is the diagnosis, and it is logged on a separate line that
+            # `tail -60` above scrolls away the moment the backend starts chattering.
+            # On 2026-08-19 this went red on all four platforms and printed nothing
+            # but "saw: ManagedStale"; the reason that actually explained it,
+            # studio_install_requirements_changed, had to be recovered by hand from
+            # the uploaded artifact.
+            grep -E "disposition=|can_auto_repair=|Managed preflight|ModuleNotFoundError" "$f" || true
             found=1
             if grep -qE "desktop_preflight completed disposition=" "$f"; then disposition=1; fi
             dispositions="${dispositions:-} $(grep -oE 'desktop_preflight completed disposition=[A-Za-z]+' "$f" | sed 's/.*disposition=//' | tr '\n' ' ')"
@@ -801,7 +815,9 @@ jobs:
               Write-Host "=== $f ==="
               Copy-Item $f logs/ -ErrorAction SilentlyContinue
               Get-Content $f -Tail 60
-              Select-String -Path $f -Pattern 'disposition=|can_auto_repair=|ModuleNotFoundError' `
+              # See the Linux job: the reason line is what explains a disposition,
+              # and Get-Content -Tail 60 above scrolls it away.
+              Select-String -Path $f -Pattern 'disposition=|can_auto_repair=|Managed preflight|ModuleNotFoundError' `
                 -ErrorAction SilentlyContinue
               $found = $true
               $hits = @(Select-String -Path $f -Pattern 'desktop_preflight completed disposition=(\w+)')

--- a/studio/install_manifest.py
+++ b/studio/install_manifest.py
@@ -77,6 +77,32 @@ def _sha256(path: Path) -> Optional[str]:
         return None
 
 
+def installed_requirements_root(root: Optional[Path] = None) -> Optional[Path]:
+    """The requirements the venv's *installed* package ships, if it has them.
+
+    The digests must describe the files `verify_install` will later read, and
+    that is always the installed package's copy: at verify time this module is
+    imported out of the venv, so `requirements_root()` resolves there, and
+    unsloth_cli/_studio_deps.py looks in the same place for a foreign venv.
+
+    The installer is a different tree. A desktop bundle carries its own
+    `studio/install_python_stack.py`, and its requirements are whatever they were
+    when that bundle was cut -- so recording the installer's digests makes every
+    install stale the moment a tracked requirement file changes upstream. That is
+    not hypothetical: v0.1.800-beta (2026-08-14) installed unsloth 2026.8.18,
+    #9148 had pinned openai in extras.txt in between, and every fresh Linux and
+    macOS desktop install came up `studio_install_requirements_changed` and paid
+    an immediate repair pass before it would run.
+    """
+    prefix = root or venv_root()
+    for pattern in ("lib/python*/site-packages", "Lib/site-packages"):
+        for site in sorted(prefix.glob(pattern)):
+            reqs = site / "studio" / "backend" / "requirements"
+            if reqs.is_dir():
+                return reqs
+    return None
+
+
 def requirement_digests(req_root: Optional[Path] = None) -> Dict[str, str]:
     """sha256 of every tracked requirement file that exists."""
     root = req_root or requirements_root()
@@ -139,7 +165,12 @@ def write_manifest(
         "platform": f"{sys.platform}-{platform.machine()}",
         "prefix": str(venv_root()),
         "steps_total": steps_total,
-        "requirement_files": requirement_digests(req_root),
+        # The venv's own copy wins over the caller's. `verify_install` reads the
+        # installed package's requirements, so recording the installer's would
+        # compare two different trees and call a finished install stale. An
+        # editable / source install has no copy under site-packages, and there
+        # the caller's root is already the tree both sides read.
+        "requirement_files": requirement_digests(installed_requirements_root(root) or req_root),
     }
     # Additive, so MANIFEST_SCHEMA does not move and every existing manifest stays
     # valid. Absent means "unknown", which is NOT False: only a manifest written by

--- a/tests/studio/install/test_install_manifest.py
+++ b/tests/studio/install/test_install_manifest.py
@@ -304,7 +304,9 @@ def test_the_manifest_records_the_venvs_own_requirements_not_the_installers(inst
     So the two roots are made deliberately different here, and the manifest must
     describe the one the verifier will read.
     """
-    installed = _fake_venv(install_root, {"studio.txt": "pytest\n", "extras.txt": "openai==3.2.0\n"})
+    installed = _fake_venv(
+        install_root, {"studio.txt": "pytest\n", "extras.txt": "openai==3.2.0\n"}
+    )
     # The installer's tree, as an older bundle would carry it.
     (req_root / "studio.txt").write_text("pytest\n", encoding = "utf-8")
     (req_root / "extras.txt").write_text("openai>=2.7.2\n", encoding = "utf-8")

--- a/tests/studio/install/test_install_manifest.py
+++ b/tests/studio/install/test_install_manifest.py
@@ -278,3 +278,67 @@ def test_set_no_torch_marker_clears_itself_and_never_raises(install_root):
 
     # Absent directory: must degrade quietly, it runs mid-install.
     im.set_no_torch_marker(True, root = install_root / "does" / "not" / "exist")
+
+
+def _fake_venv(root, files):
+    """A venv-shaped tree whose installed package ships its own requirements."""
+    site = root / "lib" / "python3.12" / "site-packages"
+    reqs = site / "studio" / "backend" / "requirements"
+    (reqs / "single-env").mkdir(parents = True, exist_ok = True)
+    for name, body in files.items():
+        (reqs / name).write_text(body, encoding = "utf-8")
+    return reqs
+
+
+def test_the_manifest_records_the_venvs_own_requirements_not_the_installers(install_root, req_root):
+    """
+    The regression that broke every fresh desktop install on 2026-08-19.
+
+    A desktop bundle carries its own `studio/install_python_stack.py`, so the
+    digests used to come from whatever that bundle shipped. Verification reads
+    the *installed* package's copy. v0.1.800-beta (2026-08-14) installed unsloth
+    2026.8.18, #9148 had pinned openai in extras.txt in between, and the two
+    trees disagreed: every install came up `studio_install_requirements_changed`
+    and repaired itself before it would run.
+
+    So the two roots are made deliberately different here, and the manifest must
+    describe the one the verifier will read.
+    """
+    installed = _fake_venv(install_root, {"studio.txt": "pytest\n", "extras.txt": "openai==3.2.0\n"})
+    # The installer's tree, as an older bundle would carry it.
+    (req_root / "studio.txt").write_text("pytest\n", encoding = "utf-8")
+    (req_root / "extras.txt").write_text("openai>=2.7.2\n", encoding = "utf-8")
+
+    im.write_manifest(root = install_root, req_root = req_root, package_name = "pytest")
+
+    recorded = json.loads((install_root / im.MANIFEST_NAME).read_text(encoding = "utf-8"))
+    assert recorded["requirement_files"] == im.requirement_digests(installed), (
+        "the manifest recorded the installer's requirement digests; verification "
+        "reads the installed package's, so a bundle even one commit behind marks "
+        "every install it performs as stale"
+    )
+
+    # And the whole point: the install it just described reads as finished.
+    state = im.verify_install(root = install_root, req_root = installed, package_name = "pytest")
+    assert state["manifest_ok"] is True, state["reason"]
+
+
+def test_a_source_install_still_uses_the_root_it_was_given(install_root, req_root):
+    """
+    An editable / `--local` install has no copy under site-packages, and there the
+    caller's root is already the tree both sides read. Falling back to it is what
+    keeps test_edited_requirements_invalidate_the_manifest meaningful.
+    """
+    assert im.installed_requirements_root(install_root) is None
+    im.write_manifest(root = install_root, req_root = req_root, package_name = "pytest")
+    recorded = json.loads((install_root / im.MANIFEST_NAME).read_text(encoding = "utf-8"))
+    assert recorded["requirement_files"] == im.requirement_digests(req_root)
+
+
+def test_the_venv_resolver_finds_both_layouts(tmp_path):
+    """posix `lib/python3.x/site-packages` and Windows `Lib/site-packages`."""
+    for layout in ("lib/python3.12/site-packages", "Lib/site-packages"):
+        root = tmp_path / layout.replace("/", "_")
+        reqs = root / layout / "studio" / "backend" / "requirements"
+        reqs.mkdir(parents = True)
+        assert im.installed_requirements_root(root) == reqs


### PR DESCRIPTION
## What was happening

`desktop-app-clean-machine-ci` went red on main on all four platforms after four green days. The error said only:

```
preflight never reported a ready disposition (saw:  ManagedStale )
```

The app's own log says what actually happened:

```
05:44:22  Managed preflight: install probe result Stale { reason: "studio_install_requirements_changed" }
05:44:22  desktop_preflight completed disposition=ManagedStale
05:44:22  start_managed_repair command called
05:44:24  studio install incomplete -- forcing dependency pass to repair...
05:44:32  Managed preflight: install probe result Ready
```

**Every fresh desktop install was coming up stale and repairing itself before it would run.** Ten seconds, on every new user's first launch. Everything after that is healthy in the log, which is why the failure looked inscrutable rather than serious.

## Root cause

The manifest records digests from `REQ_ROOT`, which is `studio/backend/requirements/` next to **whichever `install_python_stack.py` ran**. A desktop bundle carries its own copy.

`verify_install` reads the **installed package's** copy, because at verify time `install_manifest.py` is imported out of the venv, so `requirements_root()` resolves there. `unsloth_cli/_studio_deps.py` looks in the same place for a foreign venv.

Two different trees, compared against each other. They agree right up until a tracked requirement file changes upstream, and then every install that bundle performs is stale for ever:

| | |
|---|---|
| app under test | `v0.1.800-beta`, cut **2026-08-14** |
| backend it installs | `unsloth` **2026.8.18** |
| what changed in between | [#9148](https://github.com/unslothai/unsloth/pull/9148) pinned `openai` in `extras.txt` |

Windows was unaffected, but only by luck of layout, and it would have followed on the next release.

## The fix

The digests now describe the tree the verifier will read. `installed_requirements_root()` resolves the venv's own `site-packages/studio/backend/requirements` (both the posix and Windows layouts), and `write_manifest` prefers it.

A source or `--local` editable install has no copy under `site-packages` and still uses the root it was given. That fallback is load-bearing: it is what keeps an edited `studio.txt` invalidating the manifest on the dev path, which `test_edited_requirements_invalidate_the_manifest` covers.

## The diagnostic gap, which is the reason this took so long

The gate printed `saw: ManagedStale` and nothing else. The reason is logged on its own line, and the `tail -60` in the same step scrolls it away the moment the backend starts logging. The one fact that explained the whole failure had to be recovered by hand from an uploaded artifact.

All three log dumps (macOS, Linux, Windows) now grep for `Managed preflight` alongside `disposition=`.

I deliberately did **not** relax the "must reach a READY disposition" requirement, even though the app does recover. Accepting the recovery would have made this go green while every user still paid the repair, which is precisely the regression the gate exists to catch. It caught a real one.

## Verification

Three new tests, and the central one was mutation-tested: reverting the one-line fix turns `test_the_manifest_records_the_venvs_own_requirements_not_the_installers` red.

- the two roots are made deliberately different (installer on `openai>=2.7.2`, installed package on `openai==3.2.0`, exactly the #9148 delta) and the manifest must describe the installed one, and the install it just described must read as finished
- a source install with no `site-packages` copy still uses the root it was given
- the resolver finds both `lib/python3.x/site-packages` and `Lib/site-packages`

`tests/studio` + `tests/studio/install`: 4459 passed, 4 skipped.
