### PR TITLE
Wait for the Compare nav instead of sampling for it

### DIFF
--- a/tests/studio/_playwright_robust.py
+++ b/tests/studio/_playwright_robust.py
@@ -423,6 +423,39 @@ BENIGN_CONSOLE_ERROR_PATTERNS: tuple[str, ...] = (
 )
 
 
+def wait_for_first(locator: Any, *, timeout_ms: int = 10_000) -> Any | None:
+    """The first match once it exists, or None once the wait expires.
+
+    `Locator.count()` does not wait. It answers about this instant, so every
+    `if locator.count() > 0:` gate is a race with rendering that reads as "the
+    feature is missing" the moment anything delays it -- and reports that as a
+    product failure rather than as a timeout.
+
+    #9251 is what this is written from. Its reload snapshot paints a cloned
+    overlay over the app and takes it down on hydration (or after 5s), which
+    opens a window where the composer is on screen but not yet in the
+    accessibility tree. The Compare step read `count() == 0` **six milliseconds**
+    after it began and reported "Compare nav not found", which is a true
+    statement about that instant and a false one about the app.
+
+    Playwright's auto-waiting covers actions and expectations, not `count()`, so
+    the wait has to be asked for. Returning None rather than raising keeps the
+    caller's existing "is this control present at all" branch, including the
+    fallbacks that legitimately expect a miss.
+    """
+    # Imported here, not at module scope. Nothing else in this file imports
+    # playwright, and the harness-contract tests import it on runners that have
+    # no browser stack -- a top-level import would turn those into collection
+    # errors instead of skips.
+    from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
+
+    try:
+        locator.first.wait_for(state = "attached", timeout = timeout_ms)
+    except PlaywrightTimeoutError:
+        return None
+    return locator.first
+
+
 def is_benign_page_error(msg: str) -> bool:
     return any(p in msg for p in BENIGN_PAGE_ERROR_PATTERNS)
 

--- a/tests/studio/playwright_extra_ui.py
+++ b/tests/studio/playwright_extra_ui.py
@@ -436,7 +436,11 @@ with sync_playwright() as p:
     if not compare_opened:
         # Which of the two was missing, because "Compare nav not found" sent the
         # last reader looking for a removed menu item that was never removed.
-        missing = "the composer's Tools and attachments button" if plus_btn is None else "the Compare chat menu item"
+        missing = (
+            "the composer's Tools and attachments button"
+            if plus_btn is None
+            else "the Compare chat menu item"
+        )
         soft_fail(f"Compare nav not found: {missing} never appeared")
     else:
         page.wait_for_timeout(1500)

--- a/tests/studio/playwright_extra_ui.py
+++ b/tests/studio/playwright_extra_ui.py
@@ -25,6 +25,7 @@ from _playwright_robust import (  # noqa: E402
     is_benign_page_error,
     recover_or_replace_page,
     robust_evaluate,
+    wait_for_first,
     wait_for_health,
 )
 
@@ -394,31 +395,49 @@ with sync_playwright() as p:
     step("Compare tab: send to two panes")
     # Compare lives in the composer "Tools and attachments" menu.
     compare_opened = False
-    plus_btn = page.get_by_role("button", name = re.compile(r"Tools and attachments", re.I)).first
-    if plus_btn.count() > 0:
+    # Waited for, not counted. This is the first step after load, so it is the one
+    # that pays for anything slowing first paint: #9251's reload snapshot overlay
+    # opened a window where the composer is on screen but not yet in the
+    # accessibility tree, and `count()` answered 0 six milliseconds in and called
+    # it "Compare nav not found". See wait_for_first().
+    plus_btn = wait_for_first(
+        page.get_by_role("button", name = re.compile(r"Tools and attachments", re.I))
+    )
+    if plus_btn is not None:
         plus_btn.click(force = True)
-        page.wait_for_timeout(400)
-        compare_item = page.get_by_role("menuitem", name = re.compile(r"Compare chat", re.I)).first
-        if compare_item.count() == 0:
+        # The menu items get a short wait rather than the full one: a miss here is
+        # a real branch (the item lives under "More"), not a slow render, and the
+        # fallbacks below must stay quick.
+        compare_item = wait_for_first(
+            page.get_by_role("menuitem", name = re.compile(r"Compare chat", re.I)),
+            timeout_ms = 2000,
+        )
+        if compare_item is None:
             # Fallback: Compare chat may be under the "More" submenu.
-            more_trigger = page.get_by_role("menuitem", name = re.compile(r"^More$", re.I)).first
-            if more_trigger.count() > 0:
+            more_trigger = wait_for_first(
+                page.get_by_role("menuitem", name = re.compile(r"^More$", re.I)),
+                timeout_ms = 2000,
+            )
+            if more_trigger is not None:
                 more_trigger.hover()
-                page.wait_for_timeout(400)
-                compare_item = page.get_by_role(
-                    "menuitem", name = re.compile(r"Compare chat", re.I)
-                ).first
-                if compare_item.count() == 0:
+                compare_item = wait_for_first(
+                    page.get_by_role("menuitem", name = re.compile(r"Compare chat", re.I)),
+                    timeout_ms = 2000,
+                )
+                if compare_item is None:
                     more_trigger.click(force = True)
-                    page.wait_for_timeout(400)
-                    compare_item = page.get_by_role(
-                        "menuitem", name = re.compile(r"Compare chat", re.I)
-                    ).first
-        if compare_item.count() > 0:
+                    compare_item = wait_for_first(
+                        page.get_by_role("menuitem", name = re.compile(r"Compare chat", re.I)),
+                        timeout_ms = 2000,
+                    )
+        if compare_item is not None:
             compare_item.click(force = True)
             compare_opened = True
     if not compare_opened:
-        soft_fail("Compare nav not found")
+        # Which of the two was missing, because "Compare nav not found" sent the
+        # last reader looking for a removed menu item that was never removed.
+        missing = "the composer's Tools and attachments button" if plus_btn is None else "the Compare chat menu item"
+        soft_fail(f"Compare nav not found: {missing} never appeared")
     else:
         page.wait_for_timeout(1500)
         shoot("02-compare-opened")

--- a/tests/studio/test_wait_for_first.py
+++ b/tests/studio/test_wait_for_first.py
@@ -1,0 +1,133 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+"""
+`wait_for_first` is what stops a UI probe reporting a race as a missing feature.
+
+The probes are full of `if locator.count() > 0:` gates. `count()` does not wait
+-- Playwright's auto-waiting covers actions and expectations, not counting -- so
+each of those is a sample of one instant dressed up as a question about the app.
+
+#9251 is the worked example. Its reload snapshot paints a cloned overlay over the
+app and removes it on hydration, which opens a window where the composer is on
+screen but not yet in the accessibility tree. The Compare step sampled it six
+milliseconds in, got 0, and reported "Compare nav not found" -- true about that
+instant, false about the app, and indistinguishable in CI from the menu item
+actually having been deleted.
+
+No browser here: a locator is a small protocol (`.first`, `.wait_for`), so the
+timeout, success and pass-through paths are all checkable directly. What is NOT
+checkable without a browser is that playwright's TimeoutError is the exception
+that arrives, so that import is asserted separately.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _playwright_robust import wait_for_first  # noqa: E402
+
+
+class _FakeTimeout(Exception):
+    """Stands in for playwright.sync_api.TimeoutError."""
+
+
+@pytest.fixture
+def fake_playwright(monkeypatch):
+    """A `playwright.sync_api` whose TimeoutError is one we can raise."""
+    import types
+
+    module = types.ModuleType("playwright.sync_api")
+    module.TimeoutError = _FakeTimeout
+    package = types.ModuleType("playwright")
+    package.sync_api = module
+    monkeypatch.setitem(sys.modules, "playwright", package)
+    monkeypatch.setitem(sys.modules, "playwright.sync_api", module)
+    return module
+
+
+class _Locator:
+    def __init__(self, *, raises: bool = False):
+        self._raises = raises
+        self.waited_state: str | None = None
+        self.waited_timeout: int | None = None
+
+    @property
+    def first(self):
+        return self
+
+    def wait_for(self, *, state, timeout):
+        self.waited_state = state
+        self.waited_timeout = timeout
+        if self._raises:
+            raise _FakeTimeout("timed out")
+
+
+def test_a_control_that_arrives_late_is_returned(fake_playwright):
+    locator = _Locator()
+    assert wait_for_first(locator) is locator
+    # "attached", not "visible": the callers go on to `click(force = True)`, and a
+    # control inside a just-opened menu can be attached before it has settled.
+    assert locator.waited_state == "attached"
+
+
+def test_a_control_that_never_arrives_is_none_not_an_exception(fake_playwright):
+    """
+    The callers branch on absence -- one of them legitimately expects a miss and
+    falls back to the "More" submenu. Raising would turn that branch into a crash.
+    """
+    assert wait_for_first(_Locator(raises = True)) is None
+
+
+def test_the_default_wait_is_long_enough_to_outlast_a_reload_overlay(fake_playwright):
+    """
+    #9251's overlay removes itself on hydration or after 5000ms, whichever comes
+    first. A default under that would still sample inside the window it exists to
+    outlast, so this is the one number in here that is not arbitrary.
+    """
+    locator = _Locator()
+    wait_for_first(locator)
+    assert locator.waited_timeout >= 5000
+
+
+def test_a_caller_can_ask_for_a_shorter_wait(fake_playwright):
+    """The menu-item fallbacks: a miss there is a real branch, not a slow render."""
+    locator = _Locator()
+    wait_for_first(locator, timeout_ms = 2000)
+    assert locator.waited_timeout == 2000
+
+
+def test_only_a_timeout_is_swallowed(fake_playwright):
+    """
+    A locator that raises anything else -- a closed page, a bad selector -- is a
+    real failure, and reporting it as "not present" would hide it behind a
+    soft_fail about a missing feature.
+    """
+
+    class _Broken(_Locator):
+        def wait_for(self, *, state, timeout):
+            raise RuntimeError("Target page, context or browser has been closed")
+
+    with pytest.raises(RuntimeError):
+        wait_for_first(_Broken())
+
+
+def test_the_helper_binds_playwrights_own_timeout_error() -> None:
+    """
+    The fixture above supplies a stand-in, so nothing else here would notice the
+    helper importing the wrong name. It must also be a LOCAL import: this module
+    is read by harness-contract tests on runners with no browser stack, and a
+    top-level playwright import turns those skips into collection errors.
+    """
+    source = (Path(__file__).resolve().parent / "_playwright_robust.py").read_text(encoding = "utf-8")
+    assert "from playwright.sync_api import TimeoutError as PlaywrightTimeoutError" in source
+    body = source[source.index("def wait_for_first")           :]
+    body = body[: body.index("\ndef ")]
+    assert "from playwright.sync_api import" in body, (
+        "the playwright import moved out of wait_for_first(); at module scope it "
+        "breaks every browserless importer of this file"
+    )

--- a/tests/studio/test_wait_for_first.py
+++ b/tests/studio/test_wait_for_first.py
@@ -125,7 +125,7 @@ def test_the_helper_binds_playwrights_own_timeout_error() -> None:
     """
     source = (Path(__file__).resolve().parent / "_playwright_robust.py").read_text(encoding = "utf-8")
     assert "from playwright.sync_api import TimeoutError as PlaywrightTimeoutError" in source
-    body = source[source.index("def wait_for_first")           :]
+    body = source[source.index("def wait_for_first") :]
     body = body[: body.index("\ndef ")]
     assert "from playwright.sync_api import" in body, (
         "the playwright import moved out of wait_for_first(); at module scope it "


### PR DESCRIPTION
## The failure

`#9251`'s Windows Chat UI run:

```
05:00:27.4219  [ui-extra] STEP Compare tab: send to two panes
05:00:27.4278  [ui-extra] FAIL: Compare nav not found
```

**Six milliseconds.** That is not a probe finding a missing feature, it is a probe not looking.

`Locator.count()` does not wait. Playwright's auto-waiting covers actions and expectations, not counting, so `if plus_btn.count() > 0:` is a sample of one instant presented as a question about the app.

The instant it sampled was one where a reload snapshot overlay was still up. #9251 paints a cloned overlay over the app and removes it on hydration, or after 5000ms, whichever comes first, which opens a window where the composer is on screen but not yet in the accessibility tree.

So the report was true about that instant and false about the app. In CI it is indistinguishable from the menu item having been deleted, and that is the expensive part: it sends the next reader looking for a removed control that was never removed.

## The change

`wait_for_first()` waits and returns `None` on timeout, so the callers keep their present-or-not branch. That matters here: one of the fallbacks legitimately *expects* a miss and goes looking under the "More" submenu, so raising would turn a real branch into a crash. The menu-item lookups get a short 2s wait for the same reason; only the first-paint gate gets the full one.

Only a timeout is swallowed. A closed page or a bad selector still raises, rather than being quietly reported as a missing feature.

The message now names which of the two controls never appeared, instead of "Compare nav not found" for either.

This is the first step after load, so it is the one that pays for anything slowing first paint. It will not be the last change to do that, which is why the helper is shared rather than inlined -- there are 19 more `count()` gates in that file.

## On #9251 itself

This does not paper over a product bug, and it is worth saying why I think that. The overlay window is intended behaviour: the whole point of that PR is to keep a reload from flashing blank, and content that is painted-but-not-yet-interactive for a few hundred milliseconds is what that costs. A probe that cannot tell "not yet" from "not there" would have broken on any of several reasonable implementations.

What is worth checking on #9251 separately is whether the overlay should be `inert` / `aria-hidden` while it is up, so assistive technology and automation both see one app rather than two. That is a question about the PR, not about this helper.

## Verification

Six tests, and no browser needed -- a locator is a small protocol (`.first`, `.wait_for`), so the timeout, success, pass-through and error paths are all checkable directly.

All four mutants were reintroduced and confirmed red:

```
CAUGHT  default wait shortened below the overlay window
CAUGHT  swallows every exception, not just timeouts
CAUGHT  raises instead of returning None
CAUGHT  waits for visible instead of attached
```

The default wait is the one number here that is not arbitrary: it has to outlast the 5000ms the overlay gives itself, or it samples inside the window it exists to outlast.

The playwright import is deliberately local to the function, and a test asserts it stays there: this module is read by harness-contract tests on runners with no browser stack, where a module-scope import turns skips into collection errors.

`tests/studio`: 4462 passed, 4 skipped.
