### PR TITLE
[CHORE] Comment out dead LoRA/GELU code paths

### DIFF
--- a/unsloth/kernels/__init__.py
+++ b/unsloth/kernels/__init__.py
@@ -29,8 +29,9 @@ from .layernorm import (
 from .rope_embedding import fast_rope_embedding, inplace_rope_embedding
 from .swiglu import swiglu_fg_kernel, swiglu_DWf_DW_dfg_kernel
 from .geglu import (
-    geglu_exact_forward_kernel,
-    geglu_exact_backward_kernel,
+    # DEAD CODE : exact-GELU kernels are no longer defined.
+    # geglu_exact_forward_kernel,
+    # geglu_exact_backward_kernel,
     geglu_approx_forward_kernel,
     geglu_approx_backward_kernel,
 )
@@ -38,7 +39,8 @@ from .fast_lora import (
     get_lora_parameters,
     get_lora_parameters_bias,
     apply_lora_mlp_swiglu,
-    apply_lora_mlp_geglu_exact,
+    # DEAD CODE : apply_lora_mlp_geglu_exact is no longer defined.
+    # apply_lora_mlp_geglu_exact,
     apply_lora_mlp_geglu_approx,
     apply_lora_qkv,
     apply_lora_o,

--- a/unsloth/kernels/fast_lora.py
+++ b/unsloth/kernels/fast_lora.py
@@ -265,40 +265,44 @@ def apply_lora_mlp_swiglu(
     return out
 
 
-from .geglu import geglu_exact_forward_kernel, geglu_exact_backward_kernel
-
-
-def apply_lora_mlp_geglu_exact(
-    self,
-    X,
-    inplace = True,
-):
-    X = _maybe_fake_quantize_activations(X, self.gate_proj)
-    gateW, gateW_quant, gateA, gateB, gateS = get_lora_parameters(self.gate_proj)
-    upW, upW_quant, upA, upB, upS = get_lora_parameters(self.up_proj)
-    downW, downW_quant, downA, downB, downS = get_lora_parameters(self.down_proj)
-    out = LoRA_MLP.apply(
-        X,
-        gateW,
-        gateW_quant,
-        gateA,
-        gateB,
-        gateS,
-        upW,
-        upW_quant,
-        upA,
-        upB,
-        upS,
-        downW,
-        downW_quant,
-        downA,
-        downB,
-        downS,
-        geglu_exact_forward_kernel,
-        geglu_exact_backward_kernel,
-        inplace,
-    )
-    return out
+# DEAD CODE : apply_lora_mlp_geglu_exact was never dispatched;
+# the MLP dispatch table (unsloth/models/llama.py) selects swiglu or
+# geglu_approx only. Its kernels are commented out in kernels/geglu.py. Keep for
+# reference / re-enable if an exact-erf path is ever wired in.
+# from .geglu import geglu_exact_forward_kernel, geglu_exact_backward_kernel
+#
+#
+# def apply_lora_mlp_geglu_exact(
+#     self,
+#     X,
+#     inplace = True,
+# ):
+#     X = _maybe_fake_quantize_activations(X, self.gate_proj)
+#     gateW, gateW_quant, gateA, gateB, gateS = get_lora_parameters(self.gate_proj)
+#     upW, upW_quant, upA, upB, upS = get_lora_parameters(self.up_proj)
+#     downW, downW_quant, downA, downB, downS = get_lora_parameters(self.down_proj)
+#     out = LoRA_MLP.apply(
+#         X,
+#         gateW,
+#         gateW_quant,
+#         gateA,
+#         gateB,
+#         gateS,
+#         upW,
+#         upW_quant,
+#         upA,
+#         upB,
+#         upS,
+#         downW,
+#         downW_quant,
+#         downA,
+#         downB,
+#         downS,
+#         geglu_exact_forward_kernel,
+#         geglu_exact_backward_kernel,
+#         inplace,
+#     )
+#     return out
 
 
 from .geglu import geglu_approx_forward_kernel, geglu_approx_backward_kernel

--- a/unsloth/kernels/geglu.py
+++ b/unsloth/kernels/geglu.py
@@ -28,115 +28,119 @@ BLOCK_SIZE = 1024
 INT32_SAFETY_BUFFER = NUM_INT32_ELEMENTS - BLOCK_SIZE * SAFE_INT32_BUFFER_MULTIPLIER
 
 
-@triton.jit
-def _exact_forward_kernel(
-    e, g, h, n_elements, BLOCK_SIZE: tl.constexpr, LONG_INDEXING: tl.constexpr
-):
-    block_idx = tl.program_id(0)
-    if LONG_INDEXING:
-        offsets = block_idx.to(tl.int64) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE).to(tl.int64)
-        n_elements = tl.cast(n_elements, tl.int64)
-    else:
-        offsets = block_idx * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
-    mask = offsets < n_elements
-
-    # f = 1/2 * e * (1 + erf(1/sqrt(2) * e))
-    # h = f * up
-    e_row = tl.load(e + offsets, mask = mask, other = 0).to(tl.float32)
-    g_row = tl.load(g + offsets, mask = mask, other = 0)  # .to(tl.float32)
-
-    f_row = 0.5 * e_row * (tl.math.erf(tl.math.rsqrt(2.0) * e_row) + 1.0)
-    f_row = f_row.to(g_row.dtype)  # Exact copy from HF
-    h_row = f_row * g_row
-
-    # Store h
-    tl.store(h + offsets, h_row, mask = mask)
-
-
-def geglu_exact_forward_kernel(gate, up):
-    batch, seq_len, hd = gate.shape
-    n_elements = gate.numel()
-    device = gate.device
-    out = torch.empty((batch, seq_len, hd), dtype = gate.dtype, device = device)
-    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
-    with torch_gpu_device(device):
-        _exact_forward_kernel[grid](
-            gate,
-            up,
-            out,
-            n_elements,
-            BLOCK_SIZE = BLOCK_SIZE,
-            LONG_INDEXING = 0 if n_elements <= INT32_SAFETY_BUFFER else 1,
-        )
-    return out
-
-
-@triton.jit
-def _exact_backward_kernel(
-    DW, e, g, n_elements, BLOCK_SIZE: tl.constexpr, LONG_INDEXING: tl.constexpr
-):
-    """
-    f = 1/2 * e * (1 + erf(1/sqrt(2) * e))
-    h = f * up
-
-    df/de (with help of Wolfram :)
-    df/de = 1/2 * (1 + erf(1/sqrt(2) * e)) + 1/sqrt(2*pi) * e * exp(-1/2 * e^2)
-
-    Reuse via
-    f =        1/2 * (1 + erf(1/sqrt(2) * e)) * e
-    """
-    block_idx = tl.program_id(0)
-    if LONG_INDEXING:
-        offsets = block_idx.to(tl.int64) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE).to(tl.int64)
-        n_elements = tl.cast(n_elements, tl.int64)
-    else:
-        offsets = block_idx * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
-    mask = offsets < n_elements
-
-    DW_row = tl.load(DW + offsets, mask = mask, other = 0)  # .to(tl.float32)
-    e_row = tl.load(e + offsets, mask = mask, other = 0).to(tl.float32)
-    g_row = tl.load(g + offsets, mask = mask, other = 0)  # .to(tl.float32)
-
-    # Break e_row away for reuse
-    # f = 1/2 * e * (1 + erf(1/sqrt(2) * e))
-    f_partial_row = 0.5 * (tl.math.erf(tl.math.rsqrt(2.0) * e_row) + 1.0)
-    f_row = f_partial_row * e_row
-
-    f_row = f_row.to(DW_row.dtype)
-    # h = f * g
-    h_row = f_row * g_row
-    # df = DW * f
-    df_row = DW_row * f_row
-    # dg = DW * g
-    dg_row = DW_row * g_row
-
-    # df/de = 1/2 * (1 + erf(1/sqrt(2) * e)) + 1/sqrt(2*pi) * e * exp(-1/2 * e^2)
-    t = 0.3989422804014327  # 1/sqrt(2*pi)
-    df_de = f_partial_row + t * e_row * tl.exp(-0.5 * e_row * e_row)
-
-    de_row = dg_row.to(tl.float32) * df_de
-    de_row = de_row.to(DW_row.dtype)
-
-    # Store derivatives in buffers
-    tl.store(DW + offsets, h_row, mask = mask)  # h  = f * g
-    tl.store(e + offsets, df_row, mask = mask)  # df = DW * f
-    tl.store(g + offsets, de_row, mask = mask)  # de
-
-
-def geglu_exact_backward_kernel(DW, e, g):
-    batch_seq_len, hd = e.shape
-    n_elements = e.numel()
-    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
-    with torch_gpu_device(e.device):
-        _exact_backward_kernel[grid](
-            DW,
-            e,
-            g,
-            n_elements,
-            BLOCK_SIZE = BLOCK_SIZE,
-            LONG_INDEXING = 0 if n_elements <= INT32_SAFETY_BUFFER else 1,
-        )
-    return DW, e, g
+# DEAD CODE : the exact-GELU kernels and wrappers have no live
+# caller. The MLP dispatch table (unsloth/models/llama.py) selects swiglu or
+# geglu_approx only; apply_lora_mlp_geglu_exact was never wired in. Keep for
+# reference / re-enable if an exact-erf path is ever dispatched.
+# @triton.jit
+# def _exact_forward_kernel(
+#     e, g, h, n_elements, BLOCK_SIZE: tl.constexpr, LONG_INDEXING: tl.constexpr
+# ):
+#     block_idx = tl.program_id(0)
+#     if LONG_INDEXING:
+#         offsets = block_idx.to(tl.int64) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE).to(tl.int64)
+#         n_elements = tl.cast(n_elements, tl.int64)
+#     else:
+#         offsets = block_idx * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+#     mask = offsets < n_elements
+#
+#     # f = 1/2 * e * (1 + erf(1/sqrt(2) * e))
+#     # h = f * up
+#     e_row = tl.load(e + offsets, mask = mask, other = 0).to(tl.float32)
+#     g_row = tl.load(g + offsets, mask = mask, other = 0)  # .to(tl.float32)
+#
+#     f_row = 0.5 * e_row * (tl.math.erf(tl.math.rsqrt(2.0) * e_row) + 1.0)
+#     f_row = f_row.to(g_row.dtype)  # Exact copy from HF
+#     h_row = f_row * g_row
+#
+#     # Store h
+#     tl.store(h + offsets, h_row, mask = mask)
+#
+#
+# def geglu_exact_forward_kernel(gate, up):
+#     batch, seq_len, hd = gate.shape
+#     n_elements = gate.numel()
+#     device = gate.device
+#     out = torch.empty((batch, seq_len, hd), dtype = gate.dtype, device = device)
+#     grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+#     with torch_gpu_device(device):
+#         _exact_forward_kernel[grid](
+#             gate,
+#             up,
+#             out,
+#             n_elements,
+#             BLOCK_SIZE = BLOCK_SIZE,
+#             LONG_INDEXING = 0 if n_elements <= INT32_SAFETY_BUFFER else 1,
+#         )
+#     return out
+#
+#
+# @triton.jit
+# def _exact_backward_kernel(
+#     DW, e, g, n_elements, BLOCK_SIZE: tl.constexpr, LONG_INDEXING: tl.constexpr
+# ):
+#     """
+#     f = 1/2 * e * (1 + erf(1/sqrt(2) * e))
+#     h = f * up
+#
+#     df/de (with help of Wolfram :)
+#     df/de = 1/2 * (1 + erf(1/sqrt(2) * e)) + 1/sqrt(2*pi) * e * exp(-1/2 * e^2)
+#
+#     Reuse via
+#     f =        1/2 * (1 + erf(1/sqrt(2) * e)) * e
+#     """
+#     block_idx = tl.program_id(0)
+#     if LONG_INDEXING:
+#         offsets = block_idx.to(tl.int64) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE).to(tl.int64)
+#         n_elements = tl.cast(n_elements, tl.int64)
+#     else:
+#         offsets = block_idx * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+#     mask = offsets < n_elements
+#
+#     DW_row = tl.load(DW + offsets, mask = mask, other = 0)  # .to(tl.float32)
+#     e_row = tl.load(e + offsets, mask = mask, other = 0).to(tl.float32)
+#     g_row = tl.load(g + offsets, mask = mask, other = 0)  # .to(tl.float32)
+#
+#     # Break e_row away for reuse
+#     # f = 1/2 * e * (1 + erf(1/sqrt(2) * e))
+#     f_partial_row = 0.5 * (tl.math.erf(tl.math.rsqrt(2.0) * e_row) + 1.0)
+#     f_row = f_partial_row * e_row
+#
+#     f_row = f_row.to(DW_row.dtype)
+#     # h = f * g
+#     h_row = f_row * g_row
+#     # df = DW * f
+#     df_row = DW_row * f_row
+#     # dg = DW * g
+#     dg_row = DW_row * g_row
+#
+#     # df/de = 1/2 * (1 + erf(1/sqrt(2) * e)) + 1/sqrt(2*pi) * e * exp(-1/2 * e^2)
+#     t = 0.3989422804014327  # 1/sqrt(2*pi)
+#     df_de = f_partial_row + t * e_row * tl.exp(-0.5 * e_row * e_row)
+#
+#     de_row = dg_row.to(tl.float32) * df_de
+#     de_row = de_row.to(DW_row.dtype)
+#
+#     # Store derivatives in buffers
+#     tl.store(DW + offsets, h_row, mask = mask)  # h  = f * g
+#     tl.store(e + offsets, df_row, mask = mask)  # df = DW * f
+#     tl.store(g + offsets, de_row, mask = mask)  # de
+#
+#
+# def geglu_exact_backward_kernel(DW, e, g):
+#     batch_seq_len, hd = e.shape
+#     n_elements = e.numel()
+#     grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+#     with torch_gpu_device(e.device):
+#         _exact_backward_kernel[grid](
+#             DW,
+#             e,
+#             g,
+#             n_elements,
+#             BLOCK_SIZE = BLOCK_SIZE,
+#             LONG_INDEXING = 0 if n_elements <= INT32_SAFETY_BUFFER else 1,
+#         )
+#     return DW, e, g
 
 
 @triton.jit

--- a/unsloth/models/_utils.py
+++ b/unsloth/models/_utils.py
@@ -75,7 +75,7 @@ __all__ = [
     "resolve_encoder_attention_implementation",
     "_set_attn_impl",
     "set_task_config_attr",
-    "patch_fast_lora",
+    # "patch_fast_lora",  # DEAD CODE: function is commented out (orphaned / superseded by unsloth_zoo)
     "validate_loftq_config",
     "RaiseUninitialized",
     "fast_inference_setup",
@@ -3466,10 +3466,14 @@ def patch_tokenizer(model, tokenizer):
     return model, tokenizer
 
 
-def patch_fast_lora():
-    import peft.tuners.lora.bnb
-    from ..kernels.fast_lora import fast_lora_forward
-    peft.tuners.lora.bnb.Linear4bit.forward = fast_lora_forward
+# DEAD CODE : patch_fast_lora is orphaned - nothing calls it. The
+# real LoRA fast-path patching is done by unsloth_zoo.compiler.patch_lora_forwards
+# (driven by the fast_lora_forwards flag). Re-enable only if a local
+# Linear4bit.forward override is ever needed.
+# def patch_fast_lora():
+#     import peft.tuners.lora.bnb
+#     from ..kernels.fast_lora import fast_lora_forward
+#     peft.tuners.lora.bnb.Linear4bit.forward = fast_lora_forward
 
 
 def unsloth_compile_transformers(


### PR DESCRIPTION
## Summary
Comments out dead code in the LoRA/GELU hot path, keeping it recoverable.

## What's dead
- `patch_fast_lora` (`unsloth/models/_utils.py`) orphaned, zero callers. The real fast-LoRA patching is `unsloth_zoo.compiler.patch_lora_forwards`, driven by the `fast_lora_forwards` flag. The repo's own CI notes this function would raise `NameError` if ever invoked.
- `apply_lora_mlp_geglu_exact` + its `geglu_exact_forward/backward_kernel` (`unsloth/kernels/fast_lora.py`, `unsloth/kernels/geglu.py`) never dispatched. The MLP dispatch table (`unsloth/models/llama.py`) selects `swiglu` or `geglu_approx` only.

## Verification
- `py_compile` passes on all 4 changed files.
- Zero live references to the commented-out symbols (grep).
- CPU-runnable tests touching these modules pass: `test_get_lora_parameters_fp8_block_size.py`, `test_get_lora_parameters_bias_fp8_block_size.py`, `test_import_without_bitsandbytes.py` (12 passed), plus `test_mlx_public_trainer_api.py` / `test_revision_forwarding.py` / `test_pad_token_fix.py` (64 passed, 50 skipped).
- GPU/import-heavy tests (need torch) are covered by CI.

## Files changed
- `unsloth/kernels/__init__.py`
- `unsloth/kernels/fast_lora.py`
- `unsloth/kernels/geglu.py`
- `unsloth/models/_utils.py`