### PR TITLE
Stop blaming the recipe for a turn that never came back

### DIFF
--- a/.github/scripts/agent-guides-drive.sh
+++ b/.github/scripts/agent-guides-drive.sh
@@ -194,7 +194,12 @@ run_timed() {  # $1=outfile, rest=command
     echo "[$AGENT] last 40 lines before timeout:"; tail -40 "$out" 2>/dev/null || true
     [ -s "$out" ] || guide_fail "invoke timed out after ${TIMEOUT}s having printed nothing (headless-TTY hang -- the recipe likely needs a non-interactive/print flag)"
     TIMED_OUT=1
-    echo "::warning::[$AGENT] the CLI printed a transcript but did not exit within ${TIMEOUT}s; judging the turn on its assertions instead of calling it guide drift."
+    # State the fact, not the verdict. Three callers (connection, resume,
+    # attribution-ab) have no assertion that can rescue a partial turn and treat
+    # a cap as fatal on purpose, so promising that the turn will be judged on its
+    # assertions was wrong for exactly the cases most likely to hit it -- and it
+    # is what a reader sees immediately above the error that contradicts it.
+    echo "::warning::[$AGENT] the CLI printed a transcript but did not exit within ${TIMEOUT}s; whether that is fatal is the caller's call."
   fi
   return "$rc"
 }
@@ -450,6 +455,17 @@ case "$MODE" in
     # report "connection OK" for a recipe that printed a banner and then blocked
     # on a headless prompt -- the exact failure this job exists to catch.
     rc=$?
+    # Two different failures, and pointing both at start.py costs an
+    # investigation. A cap means the launch command was fine and the turn never
+    # came back: on 2026-08-19 codex printed a correct banner (right provider,
+    # right model) and then sat on `ERROR: Reconnecting... 1/5` for the whole
+    # 600s. Nothing about the documented flow had drifted, and guide_fail said it
+    # had. It is still fatal -- see the note above on why a cap cannot be waived
+    # here -- but it is reported as what it is.
+    if [ "${TIMED_OUT:-0}" = 1 ]; then
+      echo "::error::[$AGENT] the documented launch command started but never completed a turn within ${TIMEOUT}s. The recipe in ${CONNECT_REF} is not implicated: the transcript above shows what the CLI was doing when the cap hit. A connection or model-server failure looks like this; so does a headless prompt, which prints nothing at all." >&2
+      exit 1
+    fi
     [ "$rc" -eq 0 ] || guide_fail "the documented launch command exited non-zero (rc=$rc) -- see the transcript above"
     assert_reply "$OUT"
     echo "[$AGENT] connection OK"

--- a/.github/workflows/workflow-trigger-lint.yml
+++ b/.github/workflows/workflow-trigger-lint.yml
@@ -110,6 +110,7 @@ jobs:
         run: |
           python3 -m pytest -q -n 4 \
             tests/studio/test_absorbed_lanes_still_run.py \
+            tests/studio/test_agent_guides_verdicts.py \
             tests/studio/test_apt_steps_are_bounded.py \
             tests/studio/test_backend_ci_matrix.py \
             tests/studio/test_backend_ci_parallel_isolation.py \

--- a/tests/sh/test_agent_guides_timeout_classification.sh
+++ b/tests/sh/test_agent_guides_timeout_classification.sh
@@ -172,11 +172,23 @@ echo "6. only file-edit turn 1 rescues a soft timeout"
 # hello.py and compares the output). Everything else -- turn 2, connection,
 # resume, attribution-ab -- has only text or a partial store to go on, so a cap
 # stays fatal there.
-# Count every waiver regardless of how the statement is wrapped: an escape
+# This heading says "only turn 1 RESCUES", so count rescues, not mentions. The
+# previous form counted every consultation of TIMED_OUT and pinned the total at
+# 3, which conflated the one waiver with the fatal checks beside it -- so adding
+# a fourth site that makes a cap MORE explicitly fatal failed a guard named for
+# waivers. Splitting them enforces the sentence above instead of a magic number,
+# and keeps the real power: a new waiver anywhere still fails.
+#
+# The waiver is the `||` form, and it is the only shape that lets execution
+# continue past a cap. Read as a whole statement, not per line: an escape
 # rewritten onto one line must still be counted, or this guard checks nothing.
-RESCUERS="$(grep -c 'TIMED_OUT:-0}" = 1 \]' "$DRIVE_SH" || true)"
-# Only turn 1's guard, plus the resume and attribution-ab fatal checks.
-assert_eq "exactly the expected TIMED_OUT sites" "$RESCUERS" 3
+WAIVERS="$(grep -c '|| \[ "${TIMED_OUT:-0}" = 1 \]' "$DRIVE_SH" || true)"
+assert_eq "exactly one TIMED_OUT waiver (file-edit turn 1)" "$WAIVERS" 1
+
+# The rest must consult it only to STOP: resume, attribution-ab and connection.
+# Counted separately so a waiver can never masquerade as one of them.
+TOTAL_SITES="$(grep -c 'TIMED_OUT:-0}" = 1 \]' "$DRIVE_SH" || true)"
+assert_eq "every other TIMED_OUT site is a fatal check" "$((TOTAL_SITES - WAIVERS))" 3
 assert_eq "resume keeps a hang fatal" \
     "$(grep -c 'a resume pass cannot be judged from a partial turn' "$DRIVE_SH" || true)" 1
 assert_eq "attribution-ab keeps a hang fatal" \

--- a/tests/studio/test_agent_guides_verdicts.py
+++ b/tests/studio/test_agent_guides_verdicts.py
@@ -1,0 +1,119 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+"""
+agent-guides-drive.sh must not blame the recipe for a failure that is not the
+recipe's.
+
+The whole value of this job is the sentence it prints when it goes red. It exists
+to catch "guide drift" -- the documented flow in `unsloth start` no longer works
+-- and a red run that says "drift" costs whoever reads it a trip through
+start.py. So a wrong attribution is not cosmetic here, it is the entire output.
+
+Two of those were live on 2026-08-19, in one 13-minute failure:
+
+  ##[warning] ... judging the turn on its assertions instead of calling it guide drift.
+  ##[error]  [guide drift] agent=codex: the documented launch command exited
+             non-zero (rc=124) ... so the documented flow in start.py drifted.
+
+The warning promised something the next line contradicted, because run_timed
+spoke for callers that treat a cap as fatal on purpose. And the error blamed
+start.py for a turn whose transcript showed the CLI launching perfectly (correct
+provider, correct model) and then sitting on `ERROR: Reconnecting... 1/5` for the
+full 600s. Nothing had drifted; the model server never answered.
+
+These are static checks. The script needs five agent CLIs and a live model server
+to run, so what can be pinned without them is the shape of what it says.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / ".github" / "scripts" / "agent-guides-drive.sh"
+
+
+def _source() -> str:
+    return SCRIPT.read_text(encoding = "utf-8")
+
+
+def _block(name: str) -> str:
+    """A shell function's body, by brace depth."""
+    source = _source()
+    start = source.index(f"{name}() {{")
+    depth, i = 0, start
+    while i < len(source):
+        if source[i] == "{":
+            depth += 1
+        elif source[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return source[start : i + 1]
+        i += 1
+    raise AssertionError(f"{name}() never closes")
+
+
+def test_run_timed_does_not_speak_for_its_callers() -> None:
+    """
+    `connection`, `resume` and `attribution-ab` have no assertion that can rescue
+    a partial turn and treat a cap as fatal, deliberately. A blanket "judging the
+    turn on its assertions" from inside run_timed is therefore false for exactly
+    the callers most likely to hit it, and it is printed immediately above the
+    error that contradicts it.
+    """
+    body = _block("run_timed")
+    assert "judging the turn on its assertions" not in body, (
+        "run_timed still promises the caller will judge on assertions; three "
+        "callers treat a timeout as fatal instead, and the reader sees both"
+    )
+    # It must still say the cap was hit -- silence here is how a stall reads as
+    # an ordinary non-zero exit.
+    assert "did not exit within" in body
+
+
+def test_a_timed_out_connection_is_not_reported_as_recipe_drift() -> None:
+    """
+    A cap means the launch command was fine and the turn never came back. The
+    recipe is the one thing that is NOT implicated, so `guide_fail` (which
+    asserts the documented flow drifted) is the wrong reporter for it.
+    """
+    source = _source()
+    connection = source[source.index("\n  connection)") :]
+    connection = connection[: connection.index("\n  file-edit)")]
+
+    timed_out = re.search(r'if \[ "\$\{TIMED_OUT:-0\}" = 1 \]; then(.*?)\n    fi', connection, re.DOTALL)
+    assert timed_out, "the connection case no longer distinguishes a timeout from a non-zero exit"
+    branch = timed_out.group(1)
+
+    assert "guide_fail" not in branch, (
+        "a timed-out connection still goes through guide_fail, which states that "
+        "the documented flow drifted -- the one thing a cap does not show"
+    )
+    assert "not implicated" in branch, "the message does not clear the recipe it used to blame"
+    # Still fatal. Waiving a cap here would report "connection OK" for a recipe
+    # that printed a banner and then blocked on a headless prompt, which is the
+    # failure this job exists to catch.
+    assert "exit 1" in branch, (
+        "a timed-out connection must stay fatal; assert_reply cannot tell a "
+        "finished reply from a startup banner"
+    )
+
+
+def test_a_non_zero_exit_is_still_drift() -> None:
+    """
+    The narrowing must not swallow the case guide_fail is right about: a launch
+    command that exits non-zero on its own really is the documented flow failing.
+    """
+    source = _source()
+    connection = source[source.index("\n  connection)") :]
+    connection = connection[: connection.index("\n  file-edit)")]
+    assert re.search(r'\[ "\$rc" -eq 0 \] \|\| guide_fail', connection), (
+        "a non-zero exit from the launch command no longer reports drift"
+    )
+
+
+def test_guide_fail_still_names_the_recipe() -> None:
+    """It is the right message for the case it is now reserved for."""
+    body = _block("guide_fail")
+    assert "guide drift" in body and "CONNECT_REF" in body

--- a/tests/studio/test_agent_guides_verdicts.py
+++ b/tests/studio/test_agent_guides_verdicts.py
@@ -82,7 +82,9 @@ def test_a_timed_out_connection_is_not_reported_as_recipe_drift() -> None:
     connection = source[source.index("\n  connection)") :]
     connection = connection[: connection.index("\n  file-edit)")]
 
-    timed_out = re.search(r'if \[ "\$\{TIMED_OUT:-0\}" = 1 \]; then(.*?)\n    fi', connection, re.DOTALL)
+    timed_out = re.search(
+        r'if \[ "\$\{TIMED_OUT:-0\}" = 1 \]; then(.*?)\n    fi', connection, re.DOTALL
+    )
     assert timed_out, "the connection case no longer distinguishes a timeout from a non-zero exit"
     branch = timed_out.group(1)
 
@@ -108,9 +110,9 @@ def test_a_non_zero_exit_is_still_drift() -> None:
     source = _source()
     connection = source[source.index("\n  connection)") :]
     connection = connection[: connection.index("\n  file-edit)")]
-    assert re.search(r'\[ "\$rc" -eq 0 \] \|\| guide_fail', connection), (
-        "a non-zero exit from the launch command no longer reports drift"
-    )
+    assert re.search(
+        r'\[ "\$rc" -eq 0 \] \|\| guide_fail', connection
+    ), "a non-zero exit from the launch command no longer reports drift"
 
 
 def test_guide_fail_still_names_the_recipe() -> None:


### PR DESCRIPTION
## The two lines it prints contradict each other

`connection (codex)` fails on main and on unrelated branches (`fix/amd-aotriton-library-gate` among them), so it is not any one PR. What it says is:

```
##[warning] ... judging the turn on its assertions instead of calling it guide drift.
##[error]  [guide drift] agent=codex: the documented launch command exited
           non-zero (rc=124) ... so the documented flow in start.py drifted.
```

Neither is right, and I believed the first one for a while before checking.

**The warning.** `run_timed` printed it unconditionally, but three callers (`connection`, `resume`, `attribution-ab`) have no assertion that can rescue a partial turn and treat a cap as fatal *on purpose*, which the script documents a few lines above. So it promised the opposite of what was about to happen, for exactly the callers most likely to hit it, immediately above the error that contradicts it. It now states the fact and leaves the verdict to the caller, which is the only thing it is in a position to know.

**The error is worse**, because it sends the reader to the one file that is not implicated. The transcript shows codex launching perfectly:

```
model: gemma-4-E4B-it-UD-Q4_K_XL
provider: unsloth_api
approval: never
user
Reply with exactly the single word: pong
ERROR: Reconnecting... 1/5
```

Correct provider, correct model, correct profile, and then 600 seconds of reconnecting. Nothing about the documented flow had drifted; the model server never answered. A cap means the launch command was fine and the turn never came back, which is a different failure with a different owner.

## What does not change

**Still fatal.** Waiving a cap here would report "connection OK" for a recipe that printed a banner and then blocked on a headless prompt, which is the failure this job exists to catch, and `assert_reply` cannot tell a finished reply from a startup banner. Only the attribution changes.

**A non-zero exit is still drift.** That is the case `guide_fail` is right about, and narrowing must not swallow it.

## On the underlying stall

I am not claiming to have fixed `Reconnecting... 1/5`. It reproduces across unrelated branches, and the script already carries a note about opencode doing the same thing on 2026-08-03 with llama-server serving nothing, described there as intermittent rather than a one-way regression. This makes the red run say what actually happened, so the next person does not spend the time I did in `start.py`.

## Verification

Four static guards. The script needs five agent CLIs and a live model server to run, so what can be pinned without them is the shape of what it says. All four mutants reintroduced and confirmed red:

```
CAUGHT  run_timed goes back to speaking for its callers
CAUGHT  timed-out connection routed back through guide_fail
CAUGHT  timeout waived instead of fatal
CAUGHT  non-zero exit no longer reports drift
```

Wired into `workflow-trigger-lint`, the only job with no paths filter, since the edit that breaks it is a scripts or workflow edit.

`tests/studio`: 4460 passed, 4 skipped.
