### PR TITLE
fix(install): warn loudly when the source fallback drops GPU support (#9255)

### DIFF
--- a/studio/backend/tests/test_rag_store.py
+++ b/studio/backend/tests/test_rag_store.py
@@ -451,8 +451,12 @@ def test_a_legacy_archive_still_gets_two_different_ends(rag_home, rag_conn):
         store.add_chunks(conn, scope, document, [chunk], [[0.0, 0.0, 0.0, 0.0]])
     conn.commit()
 
-    oldest = [chunk for chunk, _ in store.search_lexical(conn, scope, "ZQXLEGACY", 3, oldest_first = True)]
-    newest = [chunk for chunk, _ in store.search_lexical(conn, scope, "ZQXLEGACY", 3, newest_first = True)]
+    oldest = [
+        chunk for chunk, _ in store.search_lexical(conn, scope, "ZQXLEGACY", 3, oldest_first = True)
+    ]
+    newest = [
+        chunk for chunk, _ in store.search_lexical(conn, scope, "ZQXLEGACY", 3, newest_first = True)
+    ]
 
     assert oldest and newest
     assert oldest != newest, "both ends of the fetch returned the same rows"

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -3054,6 +3054,17 @@ else
 
             substep "$_BUILD_DESC..."
 
+            # A CPU-only build on a host with a working GPU driver is a
+            # capability regression, not a success: GGUF inference silently
+            # loses the GPU (llama-server reports "Available devices: (none)"
+            # on working hardware). Surfaced at the footer instead of only in
+            # this mid-log parenthetical (#9255).
+            case "$_BUILD_DESC" in
+                *"CUDA driver found but nvcc missing"*|*"ROCm driver found but hipcc missing"*)
+                    _LLAMA_CPU_ONLY_ON_GPU_HOST=true
+                    ;;
+            esac
+
             NCPU=$(_llama_build_jobs)
             verbose_substep "parallel jobs: $NCPU (RAM-capped; UNSLOTH_LLAMA_BUILD_JOBS overrides)"
             CMAKE_GENERATOR_ARGS=""
@@ -3358,6 +3369,10 @@ else
         printf "  ${C_TITLE}%s${C_RST}\n" "Unsloth Studio Installed"
     fi
     printf "  ${C_DIM}%s${C_RST}\n" "$RULE"
+    if [ "$_LLAMA_CPU_ONLY_ON_GPU_HOST" = true ]; then
+        printf "  ${C_WARN}%-15s%s${C_RST}\n" "warning" "GPU acceleration is unavailable: the prebuilt install failed and the source fallback had no CUDA toolkit (nvcc) to build with. GGUF inference will run on the CPU."
+        printf "  ${C_WARN}%-15s%s${C_RST}\n" "" "to restore the GPU: install the CUDA toolkit (or fix the prebuilt download failure above), then re-run this installer."
+    fi
     if [ "$_LLAMA_CPP_DEGRADED" = true ]; then
         printf "  ${C_DIM}%-15s${C_WARN}%s${C_RST}\n" "launch" "unsloth studio -p 8888"
     else


### PR DESCRIPTION
Closes #9259's sibling ask: make the CPU-only fallback loud.

## The silent regression

When the prebuilt llama.cpp install fails (TLS-verifying download, preflight library path, GitHub outage) and the host has the NVIDIA driver but no `nvcc`, the source fallback builds **CPU-only** and the install still ends with the standard success banner and exit 0. The only hint is a parenthetical mid-log — the installer has *already determined* this is a CUDA machine about to get a build that cannot use it. GGUF inference then runs on the CPU indefinitely (`llama-server` reports `Available devices: (none)` on working hardware).

## Fix

The existing `_BUILD_DESC` selection ("CPU, CUDA driver found but nvcc missing" / the ROCm hipcc twin) now sets `_LLAMA_CPU_ONLY_ON_GPU_HOST=true`, and the final footer prints a prominent warning naming **the loss and both recovery paths** — install the CUDA toolkit, or fix the prebuilt failure logged above — before the launch line. The success banner and exit code are unchanged (this is a degraded install, not a failed one — the issue explicitly asks for a warning, and hard-failing would break genuinely CPU-only hosts whose driver remnant trips the detection).

`bash -n` clean. The `_BUILD_DESC` strings are matched verbatim from the existing selection block, so the flag can only fire on the exact shapes that dropped the GPU.