### PR TITLE
Ask whether Playwright system libraries are missing before installing them

### DIFF
--- a/.github/workflows/studio-ui-smoke.yml
+++ b/.github/workflows/studio-ui-smoke.yml
@@ -264,6 +264,17 @@ jobs:
         env:
           RETRY_ATTEMPTS: '2'
           RETRY_ATTEMPT_TIMEOUT: '300'
+          # install-deps runs its own `apt-get update`, and that is the only apt call
+          # in this repo that cannot be restructured to try the image's lists first.
+          # The helper's 20s transfer cap was applied and confirmed in the log on
+          # 2026-08-19 and the update still burned 4m31s of a 300s attempt, twice, so
+          # the step failed having never reached the download. Four InRelease URIs
+          # stalling to the cap, repeated over apt's default 3 retries, is 4 x 4 x 20s.
+          #
+          # Zero hands resilience to the outer attempt loop, which re-runs the command
+          # under a fresh timeout and reports which way each attempt went. apt's own
+          # retries are invisible and are charged to the caller's budget.
+          APT_ACQUIRE_RETRIES: '0'
         run: |
           # The browsers first, and WITHOUT --with-deps. That flag makes playwright
           # run its own `apt-get update` internally, which is the one apt call this
@@ -801,6 +812,17 @@ jobs:
         env:
           RETRY_ATTEMPTS: '2'
           RETRY_ATTEMPT_TIMEOUT: '300'
+          # install-deps runs its own `apt-get update`, and that is the only apt call
+          # in this repo that cannot be restructured to try the image's lists first.
+          # The helper's 20s transfer cap was applied and confirmed in the log on
+          # 2026-08-19 and the update still burned 4m31s of a 300s attempt, twice, so
+          # the step failed having never reached the download. Four InRelease URIs
+          # stalling to the cap, repeated over apt's default 3 retries, is 4 x 4 x 20s.
+          #
+          # Zero hands resilience to the outer attempt loop, which re-runs the command
+          # under a fresh timeout and reports which way each attempt went. apt's own
+          # retries are invisible and are charged to the caller's budget.
+          APT_ACQUIRE_RETRIES: '0'
         run: |
           # The browsers first, and WITHOUT --with-deps. That flag makes playwright
           # run its own `apt-get update` internally, which is the one apt call this

--- a/.github/workflows/studio-ui-smoke.yml
+++ b/.github/workflows/studio-ui-smoke.yml
@@ -255,17 +255,63 @@ jobs:
         # Two attempts at 7 minutes, against a healthy ~2: worst case 14 plus the
         # lock wait, which still leaves the job's 30 room for the work it exists to
         # do. Three attempts here would not.
-        timeout-minutes: 18
+        # Two helper calls now, not one: the CDN download and the apt transaction
+        # are separated, and each carries its own retry budget. 2 x 300s plus a lock
+        # wait, twice over, is 24m of worst case against the job's 30 -- which is
+        # why the per-attempt cap comes down from 420. Healthy is ~2 minutes for the
+        # download and seconds for the probe, so 300 is still 2.5x headroom.
+        timeout-minutes: 25
         env:
           RETRY_ATTEMPTS: '2'
-          RETRY_ATTEMPT_TIMEOUT: '420'
+          RETRY_ATTEMPT_TIMEOUT: '300'
         run: |
-          if [ "${{ steps.pw-cache.outputs.cache-hit }}" = "true" ]; then
-            set -- install-deps chromium firefox webkit
-          else
-            set -- install --with-deps chromium firefox webkit
+          # The browsers first, and WITHOUT --with-deps. That flag makes playwright
+          # run its own `apt-get update` internally, which is the one apt call this
+          # repo cannot restructure: on 2026-08-19 it spent 16m14s here against a
+          # dead azure.archive.ubuntu.com while every other apt step in CI had
+          # already been taught to skip the update entirely. A CDN download and an
+          # apt transaction are two different failures and they are separated here.
+          if [ "${{ steps.pw-cache.outputs.cache-hit }}" != "true" ]; then
+            bash .github/scripts/retry-with-apt-lock.sh \
+              python -m playwright install chromium firefox webkit
           fi
-          bash .github/scripts/retry-with-apt-lock.sh python -m playwright "$@"
+
+          # Then ask whether the system libraries are actually missing, instead of
+          # assuming they are. ubuntu-latest is a browser-testing image and ships
+          # nearly all of them; when it does, `install-deps` is a full apt update
+          # and transaction to install nothing. Launching each engine is the honest
+          # test of that -- it is exactly what the suites are about to do.
+          probe() {
+            python - "$@" <<'PY'
+          import sys
+          from playwright.sync_api import sync_playwright
+
+          missing = []
+          with sync_playwright() as p:
+              for name in sys.argv[1:]:
+                  try:
+                      browser = getattr(p, name).launch()
+                      browser.close()
+                  except Exception as exc:
+                      missing.append(f"{name}: {type(exc).__name__}")
+          if missing:
+              print("engines that will not start: " + "; ".join(missing))
+              sys.exit(1)
+          print("all three engines launch; system libraries are present")
+          PY
+          }
+
+          if probe chromium firefox webkit; then
+            echo "::notice::skipped playwright install-deps; the runner image already has the libraries"
+          else
+            echo "system libraries are missing, installing them"
+            bash .github/scripts/retry-with-apt-lock.sh \
+              python -m playwright install-deps chromium firefox webkit
+            # Fail loudly rather than proceeding into suites that cannot launch a
+            # browser: without this the real error surfaces later as an opaque
+            # per-test timeout in whichever suite happens to run first.
+            probe chromium firefox webkit
+          fi
 
       # Save on main only, like every model cache in this repo. read-write
       # `actions/cache` saves from its post-step on EVERY ref, and a PR-scoped entry
@@ -746,17 +792,63 @@ jobs:
         # Two attempts at 7 minutes, against a healthy ~2: worst case 14 plus the
         # lock wait, which still leaves the job's 30 room for the work it exists to
         # do. Three attempts here would not.
-        timeout-minutes: 18
+        # Two helper calls now, not one: the CDN download and the apt transaction
+        # are separated, and each carries its own retry budget. 2 x 300s plus a lock
+        # wait, twice over, is 24m of worst case against the job's 30 -- which is
+        # why the per-attempt cap comes down from 420. Healthy is ~2 minutes for the
+        # download and seconds for the probe, so 300 is still 2.5x headroom.
+        timeout-minutes: 25
         env:
           RETRY_ATTEMPTS: '2'
-          RETRY_ATTEMPT_TIMEOUT: '420'
+          RETRY_ATTEMPT_TIMEOUT: '300'
         run: |
-          if [ "${{ steps.pw-cache.outputs.cache-hit }}" = "true" ]; then
-            set -- install-deps chromium firefox webkit
-          else
-            set -- install --with-deps chromium firefox webkit
+          # The browsers first, and WITHOUT --with-deps. That flag makes playwright
+          # run its own `apt-get update` internally, which is the one apt call this
+          # repo cannot restructure: on 2026-08-19 it spent 16m14s here against a
+          # dead azure.archive.ubuntu.com while every other apt step in CI had
+          # already been taught to skip the update entirely. A CDN download and an
+          # apt transaction are two different failures and they are separated here.
+          if [ "${{ steps.pw-cache.outputs.cache-hit }}" != "true" ]; then
+            bash .github/scripts/retry-with-apt-lock.sh \
+              python -m playwright install chromium firefox webkit
           fi
-          bash .github/scripts/retry-with-apt-lock.sh python -m playwright "$@"
+
+          # Then ask whether the system libraries are actually missing, instead of
+          # assuming they are. ubuntu-latest is a browser-testing image and ships
+          # nearly all of them; when it does, `install-deps` is a full apt update
+          # and transaction to install nothing. Launching each engine is the honest
+          # test of that -- it is exactly what the suites are about to do.
+          probe() {
+            python - "$@" <<'PY'
+          import sys
+          from playwright.sync_api import sync_playwright
+
+          missing = []
+          with sync_playwright() as p:
+              for name in sys.argv[1:]:
+                  try:
+                      browser = getattr(p, name).launch()
+                      browser.close()
+                  except Exception as exc:
+                      missing.append(f"{name}: {type(exc).__name__}")
+          if missing:
+              print("engines that will not start: " + "; ".join(missing))
+              sys.exit(1)
+          print("all three engines launch; system libraries are present")
+          PY
+          }
+
+          if probe chromium firefox webkit; then
+            echo "::notice::skipped playwright install-deps; the runner image already has the libraries"
+          else
+            echo "system libraries are missing, installing them"
+            bash .github/scripts/retry-with-apt-lock.sh \
+              python -m playwright install-deps chromium firefox webkit
+            # Fail loudly rather than proceeding into suites that cannot launch a
+            # browser: without this the real error surfaces later as an opaque
+            # per-test timeout in whichever suite happens to run first.
+            probe chromium firefox webkit
+          fi
 
       # Save on main only, like every model cache in this repo. read-write
       # `actions/cache` saves from its post-step on EVERY ref, and a PR-scoped entry

--- a/tests/studio/test_apt_steps_are_bounded.py
+++ b/tests/studio/test_apt_steps_are_bounded.py
@@ -305,3 +305,48 @@ def test_the_guard_is_not_vacuous() -> None:
         len(found) >= 10
     ), f"only {len(found)} workflows matched; the detector looks broken: {found}"
     assert sum(found.values()) >= 15, f"only {sum(found.values())} apt steps matched: {found}"
+
+
+def test_install_deps_does_not_let_apt_retry_inside_the_attempt() -> None:
+    """
+    `playwright install-deps` runs its own `apt-get update`, and that is the one apt
+    call in this repo that cannot be restructured to try the image's lists first.
+    So it is the one step where a stalled mirror is still paid in full, and the only
+    lever left is how many times apt repeats the stall before giving up.
+
+    On 2026-08-19 the helper's 20s transfer cap was applied and confirmed in the log
+    -- "apt configured to fail fast: 20s transfer timeout" -- and the update still
+    burned 4m31s of a 300s attempt, twice, so the step failed having never reached
+    the download. Four InRelease URIs stalling to the cap, repeated over apt's
+    default `Acquire::Retries "3"`, is 4 x 4 x 20s, which is what was measured.
+
+    Retrying belongs in the outer loop, not inside apt: the outer loop re-runs the
+    command under a fresh timeout and prints which way each attempt went, whereas
+    apt's internal retries are invisible and are charged to the caller's budget.
+
+    This is a guard rather than a comment because reverting it looks harmless. The
+    value would go back to apt's default, the step would still be "bounded and
+    retried" by every other assertion in this file, and the symptom would return as
+    a step that fails slowly against a mirror -- which reads as bad luck, not as a
+    setting someone changed.
+    """
+    steps = [
+        (f"{path.name}: {step.get('name', '<unnamed>')}", step)
+        for path in _workflows()
+        for _job_id, _job, step in _steps(yaml.safe_load(path.read_text(encoding = "utf-8")))
+        if "install-deps" in step["run"]
+    ]
+    assert steps, "no step runs `playwright install-deps`; this guard checks nothing"
+
+    for name, step in steps:
+        retries = (step.get("env") or {}).get("APT_ACQUIRE_RETRIES")
+        assert retries is not None, (
+            f"step '{name}' runs `playwright install-deps` without setting "
+            f"APT_ACQUIRE_RETRIES, so apt falls back to 3 internal retries and a "
+            f"stalled mirror costs roughly four times the per-URI timeout"
+        )
+        assert str(retries) == "0", (
+            f"step '{name}' sets APT_ACQUIRE_RETRIES={retries!r}; anything above 0 "
+            f"spends the attempt budget inside apt, where the retries are invisible "
+            f"and the outer attempt loop cannot see or report them"
+        )


### PR DESCRIPTION
Ask whether Playwright's system libraries are missing before installing them

`--with-deps` makes playwright run its own `apt-get update` internally.
That is the one apt call in this repo that could not be restructured: every
other one now tries the image's package lists first and only refreshes them
on a miss, but this update happens inside playwright and there is no flag
for it.

So it still pays full price for a dead mirror. On this branch's own base,
2026-08-19:

  07:42:09 Installing dependencies... Switching to root user...
  07:42:29 Ign:2 http://azure.archive.ubuntu.com/ubuntu noble InRelease
  07:58:22 (step fails, 16m14s)

three shards at once, on the critical path of each.

Two changes, both of the same shape as the apt work: separate the failures,
then ask whether the work is needed.

The browser download is a CDN fetch and has nothing to do with apt, so it
is its own call now. A stalled mirror can no longer stop browsers being
downloaded, and a CDN failure no longer reads as an apt problem.

The apt transaction runs only when the libraries are actually missing.
ubuntu-latest is a browser-testing image and ships nearly all of them; when
it does, `install-deps` is a full apt update and transaction to install
nothing. The honest test of that is launching each engine, which is exactly
what the suites are about to do -- so the probe is the same question the
job asks two steps later, asked cheaply and first.

When the probe fails, install-deps runs and the probe runs AGAIN. Without
that second check a missing library surfaces later as an opaque per-test
timeout in whichever suite happens to run first, which is a much more
expensive way to learn the same fact.

Rebudgeted for two helper calls rather than one: 2 x 300s plus a lock wait,
twice over, is 24m of worst case against the job's 30, so the per-attempt
cap comes down from 420 and the step timeout goes 18 to 25.
test_apt_steps_are_bounded caught that arithmetic when I first got it
wrong -- the two calls doubled the authorised retries past the step's own
cut-off.

The probe's logic is exercised against a stubbed playwright: exits 0 when
all three engines launch, and 1 naming each engine that does not, for one
broken engine and for two. The embedded Python is parsed with ast and the
surrounding shell with bash -n, in both shards.
