### PR TITLE
Stub all three fields the snapshot reads, not two of them

### DIFF
--- a/studio/backend/tests/test_warm_window_review_fixes.py
+++ b/studio/backend/tests/test_warm_window_review_fixes.py
@@ -671,7 +671,9 @@ def test_health_snapshot_returns_a_settled_verdict(monkeypatch):
     # for, and stubbing it to None above would hide a snapshot that dropped it.
     monkeypatch.setattr(hw_mod, "CHAT_ONLY_DETAIL", "mlx-vlm 0.4.3 (needs >=0.4.4)", raising = False)
     assert main_mod._hardware_snapshot() == (
-        True, "mlx_unavailable", "mlx-vlm 0.4.3 (needs >=0.4.4)",
+        True,
+        "mlx_unavailable",
+        "mlx-vlm 0.4.3 (needs >=0.4.4)",
     )
 
 

--- a/studio/backend/tests/test_warm_window_review_fixes.py
+++ b/studio/backend/tests/test_warm_window_review_fixes.py
@@ -655,10 +655,24 @@ def test_health_snapshot_returns_a_settled_verdict(monkeypatch):
     monkeypatch.setattr(hw_mod, "DEVICE", hw_mod.DeviceType.CPU, raising = False)
     monkeypatch.setattr(hw_mod, "CHAT_ONLY", True, raising = False)
     monkeypatch.setattr(hw_mod, "CHAT_ONLY_REASON", "mlx_unavailable", raising = False)
+    # The detail too. _hardware_snapshot reads three fields and this pinned all
+    # three while stubbing only two, so the assertion held on whatever the real
+    # module happened to be carrying. It stopped holding on 2026-08-19 when an
+    # mlx-vlm bump left a live "(needs >=0.4.4)" detail behind, and the failure
+    # read as a snapshot bug rather than as an unstubbed field.
+    monkeypatch.setattr(hw_mod, "CHAT_ONLY_DETAIL", None, raising = False)
     hw_mod.DETECTION_COMPLETE.set()
     # Three items: the detail travels with the reason it explains, out of the same
     # guarded read, so the two can never be paired across different detection passes.
     assert main_mod._hardware_snapshot() == (True, "mlx_unavailable", None)
+
+    # And the detail is genuinely read rather than hardcoded to None: pairing it
+    # with its reason out of one guarded read is the property this test is named
+    # for, and stubbing it to None above would hide a snapshot that dropped it.
+    monkeypatch.setattr(hw_mod, "CHAT_ONLY_DETAIL", "mlx-vlm 0.4.3 (needs >=0.4.4)", raising = False)
+    assert main_mod._hardware_snapshot() == (
+        True, "mlx_unavailable", "mlx-vlm 0.4.3 (needs >=0.4.4)",
+    )
 
 
 def test_health_rereads_the_verdict_after_authentication():


### PR DESCRIPTION
## What broke

Backend CI (Python 3.13) went red across several open PRs on:

```
assert (True, 'mlx_u...eds >=0.4.4)') == (True, 'mlx_u...ilable', None)
FAILED tests/test_warm_window_review_fixes.py::test_health_snapshot_returns_a_settled_verdict
```

None of those PRs touch this code, and main was green at 07:19 and red by 07:45, so nothing in the repo changed either.

## Why

`_hardware_snapshot()` reads **three** fields. The test pinned all three while monkeypatching only two:

```python
monkeypatch.setattr(hw_mod, "CHAT_ONLY", True, raising = False)
monkeypatch.setattr(hw_mod, "CHAT_ONLY_REASON", "mlx_unavailable", raising = False)
assert main_mod._hardware_snapshot() == (True, "mlx_unavailable", None)
```

`CHAT_ONLY_DETAIL` was never stubbed, so the third element asserted whatever the real hardware module happened to be carrying. That was `None` until an mlx-vlm bump left a live `(needs >=0.4.4)` detail behind.

The expensive part is not the red run, it is where it points: the failure reads as a snapshot bug and sends the next person into `main.py`'s seqlock, which is fine.

## The fix

Stub the third field too.

Stubbing it to `None` alone would swap one under-specification for another -- it would equally pass against a snapshot that had stopped reading the detail at all. So the test now also pins a **non-None** detail and asserts it travels with its reason, which is the property the test is named for.

## Verification

Mutation-tested against `main.py`, both directions:

```
CAUGHT  snapshot drops the detail (returns None)
CAUGHT  snapshot pairs the reason with a stale detail
```

`studio/backend`: 100 passed.
