### PR TITLE
Give the Colab freeze a pip cache, like the job beside it already has

### DIFF
--- a/.github/workflows/notebooks-ci.yml
+++ b/.github/workflows/notebooks-ci.yml
@@ -421,6 +421,25 @@ jobs:
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with: { python-version: '3.12' }
 
+      - name: Restore the pip cache
+        id: pip-cache
+        # ./ resolves from GITHUB_WORKSPACE, and this job checks the repo out
+        # under `unsloth/`, so the unprefixed path is a directory that does not
+        # exist and the step fails with "Can't find 'action.yml'".
+        uses: ./unsloth/.github/actions/pip-cache-restore
+        with:
+          # The freeze is the pin set, so it is what the downloads depend on. The
+          # workflow comes too because the seed step rewrites those pins in place
+          # -- CPU index mapping, skips, spoofs -- so an edit there changes what
+          # gets installed without touching the freeze.
+          #
+          # api-introspect above keys on the workflow alone because it pins inline.
+          # This job does not, and keying it on the workflow alone would rebuild
+          # 709 downloads for an unrelated edit to any other job in this file.
+          key-files: |
+            unsloth/scripts/data/colab_pip_freeze.gpu.txt
+            unsloth/.github/workflows/notebooks-ci.yml
+
       - name: Seed Colab-shaped venv from pip-freeze (CPU-mapped)
         run: |
           # Strip cu128 local versions, route torch/torchvision to the CPU
@@ -478,6 +497,17 @@ jobs:
                 echo "::warning::pin failed: $spec"
             done < /tmp/seed_pins.txt
           fi
+
+      - name: Save the pip cache
+        if: always()
+        # always(), because the fallback path is exactly when the cache is worth
+        # most: it installs 709 pins one at a time, and a partial download set is
+        # still a head start on the next run.
+        uses: ./unsloth/.github/actions/pip-cache-save
+        with:
+          dir: ${{ steps.pip-cache.outputs.dir }}
+          key: ${{ steps.pip-cache.outputs.key }}
+          cache-hit: ${{ steps.pip-cache.outputs.cache-hit }}
 
       - name: Run install cell
         run: |

--- a/tests/studio/test_cache_budget_discipline.py
+++ b/tests/studio/test_cache_budget_discipline.py
@@ -66,6 +66,11 @@ PIP_CACHE_JOBS = {
     ("consolidated-tests-ci.yml", "llama-cpp-smoke"),
     ("mlx-ci.yml", "dispatch"),
     ("notebooks-ci.yml", "api-introspect"),
+    # Installs a 709-line Colab pip-freeze, eight matrix legs at once, and each leg
+    # downloads the identical set. It is cron and dispatch only, so none of that is
+    # on a pull request's critical path -- but eight ubuntu runners holding a 25
+    # minute cap contend for the same pool every other job queues against.
+    ("notebooks-ci.yml", "smoke-install"),
     ("studio-backend-ci.yml", "pytest"),
     ("studio-backend-ci.yml", "repo-cpu-tests"),
     ("studio-export-capability-ci.yml", "capability"),


### PR DESCRIPTION
smoke-install downloads a 709-line pip-freeze on eight matrix legs at once and
keeps none of it. api-introspect, two jobs up in the same file, already restores
and saves through the action pair; this one was left on a bare setup-python.

Keyed on the freeze plus the workflow. The freeze is the pin set, so it is what
the downloads depend on, and the workflow comes too because the seed step
rewrites those pins in place -- CPU index mapping, skips, spoofs -- so an edit
there changes what gets installed without touching the freeze. api-introspect
keys on the workflow alone because it pins its dependencies inline; keying this
job the same way would rebuild 709 downloads whenever any other job in the file
is edited.

Saved with always(), because the failure path is when the cache is worth most:
if the freeze does not resolve as a set the job falls back to installing 709
pins one at a time, and a partial download set is still a head start.

Correcting something I have been assuming about this job: it is `schedule` and
`workflow_dispatch` only, so it never runs on a pull request and none of this is
on a PR's critical path. It is still worth doing, for a different reason than I
had -- eight ubuntu runners holding a 25 minute cap contend for the same pool
every PR job queues against, and the queue is repo-wide.

The allowlist in test_cache_budget_discipline caught the new entry, which is what
it is for: a cache is a claim on a shared 50 GiB budget and a job has to earn it.
Listing it there also enrolls it in the checks that were already running for the
other nine, so the key scoping, the restore-to-save wiring and the main-only save
gate are all now enforced on this job rather than trusted.