### PR TITLE
Move the two version-incidental macOS jobs onto the emptier pool

### DIFF
--- a/.github/workflows/mlx-ci.yml
+++ b/.github/workflows/mlx-ci.yml
@@ -4,7 +4,7 @@
 # Focused PR gate for the MLX dispatch surface, running on a real
 # Apple Silicon runner.
 #
-# Runner: macos-15 (M1, 3 vCPU / 7 GB / Apple Silicon standard runner
+# Runner: macos-26 (Apple Silicon standard runner, 3 vCPU / 7 GB
 # -- FREE for public repositories per the GitHub Actions billing
 # reference; larger -large/-xlarge variants are paid so
 # we deliberately avoid those).
@@ -133,7 +133,34 @@ permissions:
 jobs:
   dispatch:
     name: dispatch
-    runs-on: macos-15
+    # macos-26, not macos-15, on a measurement rather than a preference. Both are
+    # free Apple Silicon standard runners, so this is the same class of machine.
+    #
+    # studio-mac-install-matrix runs both images from ONE matrix, so their queues
+    # can be compared on identical commits and identical triggers. Over 163 jobs
+    # per leg:
+    #
+    #                   exec med   exec p90   queue p90
+    #     macos-15          160s       713s      20667s
+    #     macos-26          176s       597s       3866s
+    #
+    # The medians say the two are the same machine. The queue p90 says they are
+    # not the same pool: macos-15 is 5.3x worse in the tail, five and a half hours
+    # against one. That tail is what sets this repo's wall clock -- the census
+    # behind it found every commit's last finisher to be this job, minutes of work
+    # behind hours of waiting -- and the median hides it completely, because the
+    # median wait on both images is zero.
+    #
+    # The likely cause is the macos-14 retirement (brownouts 2026-10-05, removal
+    # 2026-11-02): everything migrated onto macos-15, including this job, and
+    # macos-26 was left comparatively empty. That also means this is a fact about
+    # today's pool and not a property of the image, so it is worth re-measuring
+    # rather than assuming. The comparison above is one query against the install
+    # matrix and can be re-run whenever the queue looks wrong again.
+    #
+    # Not macos-14 for the retirement above; all three are Apple Silicon, so the
+    # arm64 paths are still what gets tested.
+    runs-on: macos-26
     # 40 min: dispatch + spoofed matrix + 7-step real LoRA training is
     # under 2 min; GGUF export builds llama.cpp via cmake on Apple
     # Silicon (~5-7 min), so we budget headroom. The capability-verdict

--- a/.github/workflows/studio-tauri-smoke.yml
+++ b/.github/workflows/studio-tauri-smoke.yml
@@ -368,10 +368,34 @@ jobs:
 
   macos-unit-tests:
     name: Rust unit tests (macos)
-    # Not macos-14: it browns out from 2026-10-05 and is removed 2026-11-02,
-    # which the other macOS workflows here have already moved off. Both are
-    # Apple Silicon, so this job keeps testing the arm64 paths.
-    runs-on: macos-15
+    # macos-26, not macos-15, on a measurement rather than a preference. Both are
+    # free Apple Silicon standard runners, so this is the same class of machine.
+    #
+    # studio-mac-install-matrix runs both images from ONE matrix, so their queues
+    # can be compared on identical commits and identical triggers. Over 163 jobs
+    # per leg:
+    #
+    #                   exec med   exec p90   queue p90
+    #     macos-15          160s       713s      20667s
+    #     macos-26          176s       597s       3866s
+    #
+    # The medians say the two are the same machine. The queue p90 says they are
+    # not the same pool: macos-15 is 5.3x worse in the tail, five and a half hours
+    # against one. That tail is what sets this repo's wall clock -- the census
+    # behind it found every commit's last finisher to be this job, minutes of work
+    # behind hours of waiting -- and the median hides it completely, because the
+    # median wait on both images is zero.
+    #
+    # The likely cause is the macos-14 retirement (brownouts 2026-10-05, removal
+    # 2026-11-02): everything migrated onto macos-15, including this job, and
+    # macos-26 was left comparatively empty. That also means this is a fact about
+    # today's pool and not a property of the image, so it is worth re-measuring
+    # rather than assuming. The comparison above is one query against the install
+    # matrix and can be re-run whenever the queue looks wrong again.
+    #
+    # Not macos-14 for the retirement above; all three are Apple Silicon, so the
+    # arm64 paths are still what gets tested.
+    runs-on: macos-26
     # A cold cache compiles both the debug and the release dependency tree.
     timeout-minutes: 45
     steps:

--- a/tests/studio/test_macos_slots_per_commit.py
+++ b/tests/studio/test_macos_slots_per_commit.py
@@ -287,3 +287,67 @@ def test_a_commit_that_touches_nothing_relevant_starts_no_macos_job():
         f"a README-only commit still starts macOS jobs: {triggered}. That was the "
         f"original symptom: seven macOS legs against a five-slot cap for a docs typo."
     )
+
+
+# Images GitHub still schedules. macos-14 is absent deliberately: brownouts from
+# 2026-10-05, removal 2026-11-02. Add to this set when GitHub ships an image, and
+# remove from it when GitHub announces a retirement -- the removal is the point,
+# because that is when this guard starts naming the jobs that have to move.
+LIVE_MACOS_IMAGES = {
+    "macos-15",
+    "macos-15-intel",
+    "macos-26",
+    "macos-26-intel",
+    "macos-latest",
+}
+
+
+def _macos_labels():
+    """Every concrete macOS image any job can be scheduled onto, with its origin."""
+    found = []
+    for path in sorted(WORKFLOWS.glob("*.yml")):
+        doc = yaml.safe_load(path.read_text(encoding = "utf-8"))
+        if not isinstance(doc, dict) or not isinstance(doc.get("jobs"), dict):
+            continue
+        for jid, job in doc["jobs"].items():
+            if not isinstance(job, dict):
+                continue
+            # runs-on plus the matrix it may select from: a retired image hides in
+            # an `include:` list just as easily as in a literal runs-on.
+            blob = str(job.get("runs-on", ""))
+            strategy = job.get("strategy") or {}
+            blob += str((strategy.get("matrix") or {}) if isinstance(strategy, dict) else "")
+            # Only things shaped like a GitHub image name. The loose MACOS pattern
+            # used elsewhere in this file also matches build targets that merely
+            # contain "macos" -- release-desktop's matrix carries `macos-aarch64`,
+            # which is a Rust triple's nickname and never a runner label. Every
+            # real macOS image is macos-latest or macos-<version>[-intel].
+            for label in re.findall(r"\bmacos-(?:latest|\d+(?:-intel)?)\b", blob, re.I):
+                found.append((path.name, jid, label.lower()))
+    return found
+
+
+def test_no_job_targets_a_retired_macos_image() -> None:
+    """
+    macos-14's retirement is already written into three comments in this repo, each
+    explaining why some job moved off it. Comments do not fail, so the next
+    retirement will be discovered the same way this one was: by a job that stops
+    being scheduled, on a runner pool nobody is watching.
+
+    This is the cheap version of that discovery. It cannot know GitHub's roadmap,
+    but it does force the retirement to be recorded in one place, and it names
+    every job that has to move on the day someone records it.
+    """
+    labels = _macos_labels()
+    assert labels, "no macOS labels found at all; this guard would pass vacuously"
+
+    retired = sorted(
+        f"{name}:{jid} -> {label}"
+        for name, jid, label in labels
+        if label not in LIVE_MACOS_IMAGES
+    )
+    assert not retired, (
+        f"these jobs target a macOS image not in LIVE_MACOS_IMAGES: {retired}. Either "
+        f"GitHub ships it and it belongs in the set, or it is retired and these jobs "
+        f"need moving before they stop being scheduled."
+    )

--- a/tests/studio/test_macos_slots_per_commit.py
+++ b/tests/studio/test_macos_slots_per_commit.py
@@ -342,9 +342,7 @@ def test_no_job_targets_a_retired_macos_image() -> None:
     assert labels, "no macOS labels found at all; this guard would pass vacuously"
 
     retired = sorted(
-        f"{name}:{jid} -> {label}"
-        for name, jid, label in labels
-        if label not in LIVE_MACOS_IMAGES
+        f"{name}:{jid} -> {label}" for name, jid, label in labels if label not in LIVE_MACOS_IMAGES
     )
     assert not retired, (
         f"these jobs target a macOS image not in LIVE_MACOS_IMAGES: {retired}. Either "


### PR DESCRIPTION
Rust unit tests (macos) is this repo's last finisher. The census behind that
found minutes of work sitting behind hours of queue, and no execution-time work
touches it, so the runner pool is the only lever left.

studio-mac-install-matrix runs macos-15 and macos-26 from ONE matrix, which
makes them comparable on identical commits and identical triggers rather than
across different jobs at different times. Over 163 jobs per leg:

                  exec med   exec p90   queue p90
    macos-15          160s       713s      20667s
    macos-26          176s       597s       3866s

The medians say these are the same class of machine, which they are: both free
Apple Silicon standard runners. The queue p90 says they are not the same pool.
macos-15 is 5.3x worse in the tail, five and a half hours against one.

Worth being precise about what the tail means here, because the median is zero
on both images and hides all of it. macOS queueing is not slow on average; it
is occasionally catastrophic, and the occasional case is what sets the wall
clock for the commit it lands on.

The likely cause is the macos-14 retirement. Everything migrated onto macos-15,
this job included, and macos-26 was left comparatively empty. That makes this a
fact about today's pool rather than a property of the image, so the comment
records the query as much as the result: it is one read of the install matrix
and can be re-run whenever the queue looks wrong again.

Two jobs, not all of them. These two test our Rust crate and our MLX dispatch,
where the OS version is incidental. The install matrices are deliberately
testing across OS versions and are left alone, and studio-mac-ui-smoke stays
too: it documents a dependency on the frameworks the image ships for Chromium,
which is a claim about macos-15 specifically and wants checking before it moves.

The guard is for the next retirement rather than this one. macos-14's is
recorded in three comments in this repo, each explaining why some job moved off
it, and comments do not fail -- so the next one gets discovered the way this one
was, by a pool nobody is watching. LIVE_MACOS_IMAGES cannot know GitHub's
roadmap, but it forces the retirement to be written down once and then names
every job that has to move. Mutation-tested by putting macos-14 back.