### PR TITLE
Stop the orphan-scan tests asking the host whether an invented PID is alive

### DIFF
--- a/studio/backend/tests/test_local_llama_cpp_link.py
+++ b/studio/backend/tests/test_local_llama_cpp_link.py
@@ -156,9 +156,7 @@ def _run_orphan_scan(
     # whatever else happens to be running. test_llama_cpp_wait_for_vram_settle.py
     # stubs this at every one of its call sites for the same reason; this harness
     # stubbed the sibling _reap_recorded_pid and missed this one.
-    monkeypatch.setattr(
-        LlamaCppBackend, "_pid_parent_is_alive", staticmethod(lambda pid: False)
-    )
+    monkeypatch.setattr(LlamaCppBackend, "_pid_parent_is_alive", staticmethod(lambda pid: False))
 
     if scan == "procfs":
         # Linux reads /proc directly. Point it at a fixture tree and intercept the

--- a/studio/backend/tests/test_local_llama_cpp_link.py
+++ b/studio/backend/tests/test_local_llama_cpp_link.py
@@ -138,6 +138,28 @@ def _run_orphan_scan(
     )
     monkeypatch.setattr(LlamaCppBackend, "_reap_recorded_pid", staticmethod(lambda: 0))
 
+    # The fake is an orphan by construction, so say so instead of letting the host
+    # decide. _kill_orphaned_servers skips any candidate whose parent is alive, and
+    # _pid_parent_is_alive answers that by looking the PID up for real:
+    # psutil.Process(pid).ppid() then psutil.pid_exists(ppid). Nothing here stubs
+    # psutil.Process -- only process_iter -- so the lookup hits the actual machine.
+    #
+    # The PID is os.getpid() + 888, invented on the assumption that nothing owns it.
+    # On a quiet runner nothing does, NoSuchProcess comes back, the candidate is
+    # treated as an orphan and killed. On a busier one that PID is a real process
+    # with a real live parent, the candidate is skipped, and the test reports
+    # `assert 0 == 1` having exercised the ownership logic correctly. That is what
+    # it did on a staging runner while passing on the org queue for the same commit.
+    #
+    # These two tests are about OWNERSHIP -- link tree spared, real root reaped --
+    # and parent liveness is incidental to both, so it is pinned rather than left to
+    # whatever else happens to be running. test_llama_cpp_wait_for_vram_settle.py
+    # stubs this at every one of its call sites for the same reason; this harness
+    # stubbed the sibling _reap_recorded_pid and missed this one.
+    monkeypatch.setattr(
+        LlamaCppBackend, "_pid_parent_is_alive", staticmethod(lambda pid: False)
+    )
+
     if scan == "procfs":
         # Linux reads /proc directly. Point it at a fixture tree and intercept the
         # signal, since the fixture's pid is not a real process.


### PR DESCRIPTION
test_orphan_cleanup_kills_under_real_root[psutil] failed on a staging runner
while passing on the org queue for the same commit, on two unrelated PRs
neither of which touches this code.

The harness builds its fake process with os.getpid() + 888, a PID invented on
the assumption that nothing owns it. _kill_orphaned_servers skips any candidate
whose parent is alive, and _pid_parent_is_alive answers that by looking the PID
up for real -- psutil.Process(pid).ppid(), then psutil.pid_exists(ppid). The
harness stubs psutil.process_iter and nothing else, so that lookup goes to the
actual machine.

On a quiet runner nothing owns the PID, NoSuchProcess comes back, the candidate
is an orphan and gets killed. On a busier one it is a real process with a real
live parent, the candidate is skipped, and the test reports `assert 0 == 1`
having exercised the ownership logic perfectly correctly. The pass was the
accident, not the failure.

Reproduced by keeping the original harness and forcing the answer a busy host
gives, which yields `assert 0 == 1` -- the staging failure exactly.

Both tests in this pair are about OWNERSHIP: the link tree is spared, the real
root is reaped. Parent liveness is incidental to both, so it is pinned rather
than left to whatever else is running on the box. The fake is an orphan by
construction and the harness now says so.

This is the established pattern here rather than a new one:
test_llama_cpp_wait_for_vram_settle.py stubs _pid_parent_is_alive at every one
of its ten call sites. This harness stubbed the sibling _reap_recorded_pid and
missed this one, so the coverage it loses is coverage it never had -- parent
liveness has its own tests in that file.