### PR TITLE
Re-type the native default, not whatever the input happens to show

### DIFF
--- a/tests/studio/playwright_model_config.py
+++ b/tests/studio/playwright_model_config.py
@@ -883,7 +883,8 @@ with sync_playwright() as p:
         # closed popover from the Reset step and silently skipped until #7760 made it own
         # its state; the first time it actually ran, it failed.
         expected_pin = [
-            e for e in pinned
+            e
+            for e in pinned
             if e.get("gpuMemoryMode") == "manual"
             and isinstance(e.get("gpuLayers"), int)
             and e.get("gpuLayers") >= 0

--- a/tests/studio/playwright_model_config.py
+++ b/tests/studio/playwright_model_config.py
@@ -861,13 +861,43 @@ with sync_playwright() as p:
             btn.click()
             page.wait_for_timeout(1500)
         cfg = read_configs()
-        pinned = any(
-            _as_int(e.get("customContextLength")) == native_default for e in entries_for_model(cfg)
-        )
-        if pinned:
+        entries = entries_for_model(cfg)
+        pinned = [e for e in entries if _as_int(e.get("customContextLength")) == native_default]
+
+        # Not every stored context here is a phantom pin. model-config-page.tsx pins the
+        # active context ON PURPOSE when the placement is fixed:
+        #
+        #   const pinFixedLayerContext =
+        #     target.isGguf && loadableConfig.gpuMemoryMode === "manual" &&
+        #     loadableConfig.gpuLayers != null && loadableConfig.gpuLayers >= 0 &&
+        #     loadableConfig.customContextLength == null && activeLoadedContext != null;
+        #
+        # with the reason stated above it: "If the user fixes GPU Layers (Manual) and
+        # remembers, pin that shown context so a later fresh load keeps the fitted
+        # placement instead of sending native/0 and recreating the OOM." Storing the
+        # context is the feature; not storing it is the bug it was written to prevent.
+        #
+        # This step could not tell the two apart, so on a runner where the placement IS
+        # manual -- which is every CPU-only CI runner, gpuLayers 0 -- it reported the
+        # documented behaviour as a regression. It went unnoticed because it inherited a
+        # closed popover from the Reset step and silently skipped until #7760 made it own
+        # its state; the first time it actually ran, it failed.
+        expected_pin = [
+            e for e in pinned
+            if e.get("gpuMemoryMode") == "manual"
+            and isinstance(e.get("gpuLayers"), int)
+            and e.get("gpuLayers") >= 0
+        ]
+        if pinned and len(expected_pin) == len(pinned):
+            info(
+                f"OK re-type-shown: context {native_default} is stored, and every entry "
+                f"storing it has the fixed-layer placement that pins it deliberately"
+            )
+        elif pinned:
             fail(
                 "re-typing the shown context pinned it as an override "
-                f"(customContextLength={native_default})"
+                f"(customContextLength={native_default}) with no fixed-layer placement to "
+                f"justify it; entries={[{k: e.get(k) for k in ('gpuMemoryMode', 'gpuLayers', 'customContextLength')} for e in pinned]}"
             )
         else:
             info("OK re-type-shown: shown context not stored as an override")


### PR DESCRIPTION
"re-typing the shown context does not pin an override" failed on a staging
runner and passed on the org queue for the same commit, on a PR touching one
backend test file:

  STEP reset clears the per-model override
    reset: Context Length input now shows '4096'
  STEP re-typing the shown context does not pin an override
    FAIL: re-typing the shown context pinned it as an override (4096)

The step read its target value out of the input, calling it "the currently
displayed native/default context". Those are two different things, and the
Reset step immediately above already says so in its own comment: "a live-loaded
model can still echo its context even with the stored override gone."

After Reset the model is still live at DISTINCT_CTX, so the input echoes 4096
while the native default is 2048. The step then ticked "Remember for this
model", typed 4096, and called the resulting override a phantom pin. That
override is correct -- the value differs from the default and the user asked
for it to be remembered. The step was asserting the opposite of its subject,
and only passed when timing happened to leave the native default showing.

So it now re-types default_ctx, captured at the top of the suite before any
override existed, and checks that the input actually shows it before asserting
anything. The precondition IS the subject here: the regression being guarded is
that entering an unchanged value replays a cached blur value into a stored
override, and "unchanged" has to be true for that to mean anything. When it is
not, the step says which way it went instead of testing something else.

That stays a soft_fail rather than a silent skip, for the reason the existing
comment gives: this step is the only guard on the phantom-pin regression, so a
run where it did not execute must not read as a run where it passed.

default_ctx is bound before the step that assigns it, because both assigning
branches sit inside failure guards -- otherwise a run that failed early would
raise NameError here and bury the step that actually broke.