### PR TITLE
Install the browser engines each Chat UI shard actually drives

### DIFF
--- a/.github/workflows/studio-ui-smoke.yml
+++ b/.github/workflows/studio-ui-smoke.yml
@@ -98,7 +98,38 @@ jobs:
       # so each still boots one Studio at a time and nothing competes for RAM.
       fail-fast: false
       matrix:
+        # The shard list stays a list: test_chat_ui_shards_cover_everything reads it
+        # to prove every Playwright step lands on some shard, and an include-only
+        # matrix hides it from that guard.
         shard: [chat, extra, banner, picker]
+        # include: entries that match an existing combination ADD fields to it rather
+        # than creating new jobs, which is how each shard gets the engines it drives
+        # without changing the shard set.
+        #
+        # `extra` and `picker` name no engine but chromium anywhere in their steps.
+        # Installing webkit's system libraries for them is 181 packages and 102 MB of
+        # apt, which is what timed this job out on 2026-08-19:
+        #
+        #   0 upgraded, 181 newly installed
+        #   Need to get 102 MB/114 MB of archives
+        #   Get:2 .../fonts-wqy-zenhei [7472 kB]   -> 4m51s, then the attempt died
+        #
+        # Fonts, X fonts and a soundfont, fetched so that two shards which never
+        # launch webkit could fail to fetch them. test_ui_shard_engines.py keeps this
+        # honest against the steps rather than against this comment.
+        include:
+          - shard: chat      # Cross-browser permission controls drives all three
+            engines: chromium firefox webkit
+            engine_key: cfw
+          - shard: banner    # "other engines" step drives firefox and webkit
+            engines: chromium firefox webkit
+            engine_key: cfw
+          - shard: extra
+            engines: chromium
+            engine_key: c
+          - shard: picker
+            engines: chromium
+            engine_key: c
     env:
       GGUF_REPO: unsloth/gemma-3-270m-it-GGUF
       GGUF_VARIANT: UD-Q4_K_XL
@@ -224,7 +255,7 @@ jobs:
         continue-on-error: true
         with:
           path: ~/.cache/ms-playwright
-          key: ms-playwright-${{ runner.os }}-${{ steps.pw.outputs.version }}-cfw-v1
+          key: ms-playwright-${{ runner.os }}-${{ steps.pw.outputs.version }}-${{ matrix.engine_key }}-v2
 
       - name: Install Playwright browsers
         id: pw-install
@@ -284,7 +315,7 @@ jobs:
           # apt transaction are two different failures and they are separated here.
           if [ "${{ steps.pw-cache.outputs.cache-hit }}" != "true" ]; then
             bash .github/scripts/retry-with-apt-lock.sh \
-              python -m playwright install chromium firefox webkit
+              python -m playwright install ${{ matrix.engines }}
           fi
 
           # Then ask whether the system libraries are actually missing, instead of
@@ -312,16 +343,16 @@ jobs:
           PY
           }
 
-          if probe chromium firefox webkit; then
+          if probe ${{ matrix.engines }}; then
             echo "::notice::skipped playwright install-deps; the runner image already has the libraries"
           else
             echo "system libraries are missing, installing them"
             bash .github/scripts/retry-with-apt-lock.sh \
-              python -m playwright install-deps chromium firefox webkit
+              python -m playwright install-deps ${{ matrix.engines }}
             # Fail loudly rather than proceeding into suites that cannot launch a
             # browser: without this the real error surfaces later as an opaque
             # per-test timeout in whichever suite happens to run first.
-            probe chromium firefox webkit
+            probe ${{ matrix.engines }}
           fi
 
       # Save on main only, like every model cache in this repo. read-write
@@ -350,7 +381,7 @@ jobs:
         continue-on-error: true
         with:
           path: ~/.cache/ms-playwright
-          key: ms-playwright-${{ runner.os }}-${{ steps.pw.outputs.version }}-cfw-v1
+          key: ms-playwright-${{ runner.os }}-${{ steps.pw.outputs.version }}-${{ matrix.engine_key }}-v2
 
       - name: Reset auth + boot Unsloth
         if: matrix.shard == 'chat'

--- a/.github/workflows/workflow-trigger-lint.yml
+++ b/.github/workflows/workflow-trigger-lint.yml
@@ -116,6 +116,7 @@ jobs:
             tests/studio/test_backend_ci_parallel_isolation.py \
             tests/studio/test_cache_budget_discipline.py \
             tests/studio/test_chat_ui_shards_cover_everything.py \
+            tests/studio/test_ui_shard_engines.py \
             tests/studio/test_ci_shell_suite_coverage.py \
             tests/studio/test_compile_caches_are_per_worker.py \
             tests/studio/test_composer_rtl_bidi_attribute.py \

--- a/tests/studio/test_ui_shard_engines.py
+++ b/tests/studio/test_ui_shard_engines.py
@@ -1,0 +1,140 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+"""
+Each Chat UI shard must install exactly the browser engines its own steps drive.
+
+The four shards used to install all three engines each. Two of them -- `extra` and
+`picker` -- never open anything but chromium, and installing webkit's system
+libraries for them is an apt transaction of 181 packages and 102 MB:
+
+    0 upgraded, 181 newly installed, 0 to remove
+    Need to get 102 MB/114 MB of archives
+    Get:2 .../noble/universe amd64 fonts-wqy-zenhei all 0.9.45-8 [7472 kB]
+    -> 4m51s later: attempt 2/2 did not finish within 300s
+
+Fonts, X fonts and a soundfont, fetched so that two shards which never launch webkit
+could time out fetching them. That is what this file exists to stop coming back.
+
+It is enforced in BOTH directions, and the second one is the dangerous one:
+
+  * installing an engine no step drives is waste, and waste on a degraded mirror is
+    an outage;
+  * driving an engine the shard did not install is a broken run. Playwright reports
+    it as a launch failure deep inside a suite, minutes after the install step went
+    green, which reads as a flaky test rather than a missing package.
+
+Derived from the workflow, never from a hardcoded list: the whole point is that
+adding a webkit step to `picker` fails HERE, at the edit, rather than in CI.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO / ".github" / "workflows" / "studio-ui-smoke.yml"
+
+ENGINES = ("chromium", "firefox", "webkit")
+
+
+def _doc() -> dict:
+    return yaml.safe_load(WORKFLOW.read_text(encoding = "utf-8"))
+
+
+def _shards() -> list[dict]:
+    include = _doc()["jobs"]["ui-smoke"]["strategy"]["matrix"]["include"]
+    assert include, "the ui-smoke matrix has no include list; this guard checks nothing"
+    return include
+
+
+def _engines_driven_by(shard: str) -> set[str]:
+    """Engines the steps that RUN for ``shard`` actually name.
+
+    The install step itself is excluded: it names engines because it installs them,
+    so counting it would make every shard trivially consistent with itself.
+    """
+    driven: set[str] = set()
+    for step in _doc()["jobs"]["ui-smoke"]["steps"]:
+        run = step.get("run") or ""
+        name = step.get("name") or ""
+        if "playwright install" in run or "probe " in run:
+            continue
+        cond = str(step.get("if") or "")
+        # A step gated on another shard does not run for this one. Anything ungated
+        # runs for every shard.
+        others = re.findall(r"matrix\.shard\s*==\s*'([a-z]+)'", cond)
+        if others and shard not in others:
+            continue
+        for engine in ENGINES:
+            if re.search(rf"\b{engine}\b", run) or re.search(rf"\b{engine}\b", name):
+                driven.add(engine)
+    return driven
+
+
+def test_every_shard_declares_engines_and_a_key() -> None:
+    for cell in _shards():
+        assert cell.get("engines"), f"shard {cell.get('shard')!r} declares no engines"
+        assert cell.get("engine_key"), (
+            f"shard {cell.get('shard')!r} has no engine_key, so its browser cache would "
+            f"share a key with a shard that installs a different engine set"
+        )
+
+
+def test_the_engine_key_distinguishes_the_engine_set() -> None:
+    """
+    The cache holds the downloaded browsers. Two shards installing different engine
+    sets under one key means the smaller set gets saved, the larger one restores it,
+    reports a hit, skips the download, and then cannot launch what it did not get.
+    """
+    by_key: dict[str, set[str]] = {}
+    for cell in _shards():
+        by_key.setdefault(cell["engine_key"], set()).add(cell["engines"])
+    for key, sets in by_key.items():
+        assert len(sets) == 1, (
+            f"engine_key {key!r} is used for different engine sets {sorted(sets)}; the "
+            f"browser cache would serve one shard's browsers to another"
+        )
+
+
+@pytest.mark.parametrize("cell", _shards(), ids = lambda c: c["shard"])
+def test_shard_installs_every_engine_it_drives(cell: dict) -> None:
+    installed = set(cell["engines"].split())
+    driven = _engines_driven_by(cell["shard"])
+    missing = driven - installed
+    assert not missing, (
+        f"shard {cell['shard']!r} drives {sorted(missing)} but installs only "
+        f"{sorted(installed)}. Playwright will fail to launch mid-suite, minutes after "
+        f"the install step went green. Add the engine to this shard's `engines`."
+    )
+
+
+@pytest.mark.parametrize("cell", _shards(), ids = lambda c: c["shard"])
+def test_shard_installs_nothing_it_never_drives(cell: dict) -> None:
+    installed = set(cell["engines"].split())
+    driven = _engines_driven_by(cell["shard"])
+    # chromium is the default engine for every suite here, so it is legitimately
+    # installed whether or not a step names it out loud.
+    extra = installed - driven - {"chromium"}
+    assert not extra, (
+        f"shard {cell['shard']!r} installs {sorted(extra)} but no step drives them. "
+        f"webkit alone is 181 packages and 102 MB of apt on a mirror that has already "
+        f"timed this job out; drop it or point at the step that needs it."
+    )
+
+
+def test_the_detector_sees_the_cross_browser_steps() -> None:
+    """Otherwise both directions above pass by finding nothing driven anywhere."""
+    chat = _engines_driven_by("chat")
+    assert {"firefox", "webkit"} <= chat, (
+        f"the chat shard drives {sorted(chat)}; it runs Cross-browser permission "
+        f"controls, so the step scan is not seeing engine names any more"
+    )
+    picker = _engines_driven_by("picker")
+    assert "webkit" not in picker, (
+        f"the picker shard now appears to drive {sorted(picker)}; if that is real the "
+        f"matrix needs updating, and if it is not the scan is over-matching"
+    )


### PR DESCRIPTION
The four shards install all three engines each. Two of them never open anything
but chromium: nothing in `extra` or `picker` names firefox or webkit at all.

Installing webkit's system libraries for them is not a rounding error. On
2026-08-19, in the extra shard:

  0 upgraded, 181 newly installed, 0 to remove
  Need to get 102 MB/114 MB of archives
  Get:2 .../noble/universe amd64 fonts-wqy-zenhei all 0.9.45-8 [7472 kB]
  -> 4m51s later, attempt 2/2 did not finish within 300s

Fonts, X fonts and a soundfont, fetched so that a shard which never launches
webkit could time out fetching them. Both attempts died there and the shard
reported nothing about the UI it exists to test.

That is the last apt exposure in this job, and unlike the previous two rounds it
cannot be fixed by bounding anything. Making the index refresh cheap (the
retries change) left the download, and no timeout survives a mirror moving 7 MB
in five minutes. The fix is to stop asking for 102 MB that nothing uses.

chat keeps all three for Cross-browser permission controls, banner keeps all
three for its "other engines" step, and the browser cache key carries the engine
set: without that the chromium-only cache would be restored by a three-engine
shard, report a hit, skip the download, and fail to launch what it never got.

The matrix keeps `shard:` as a list and augments it through `include:`, because
test_chat_ui_shards_cover_everything reads that list to prove every Playwright
step lands on some shard. An include-only matrix passes YAML and silently hides
the shards from that guard, which I did first and it caught.

test_ui_shard_engines enforces both directions against the steps, never against
the comment above. Installing an unused engine is waste; driving an uninstalled
one is worse, because Playwright reports it as a launch failure deep inside a
suite, minutes after the install step went green, which reads as a flaky test
rather than a missing package. Mutation-tested three ways: adding webkit to
picker, removing webkit from chat, and collapsing two engine sets onto one cache
key. It is listed in workflow-trigger-lint because it reads a workflow, so a
workflow-only PR -- exactly the change it exists to reject -- would otherwise
never collect it. That guard caught this too.