### PR TITLE
feat: expose UNSLOTH_API_MAX_CONCURRENCY onto existing admission capacity

### DIFF
--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -1400,6 +1400,26 @@ _TEARDOWN_TASK_STOP_TIMEOUT_S = 5.0
 _LOCAL_TOOL_STREAM_STALL_KEEPALIVE_S = 15.0
 
 
+_API_MAX_CONCURRENCY_ENV = "UNSLOTH_API_MAX_CONCURRENCY"
+
+
+def _api_max_concurrency_override() -> Optional[int]:
+    """UNSLOTH_API_MAX_CONCURRENCY overrides the admission slot capacity.
+
+    When set, this caps the number of concurrent inference requests regardless
+    of the ``--parallel`` value. Takes the minimum of the override and the
+    backend's own slot count so it never exceeds what llama-server can serve.
+    """
+    raw = os.environ.get(_API_MAX_CONCURRENCY_ENV)
+    if raw is None or not raw.strip():
+        return None
+    try:
+        value = int(raw.strip())
+    except ValueError:
+        return None
+    return value if value > 0 else None
+
+
 def _openai_llama_admission_capacity(request: Optional[Request], llama_backend = None) -> int:
     """Serving slots available for one local llama-server backend.
 
@@ -1407,15 +1427,25 @@ def _openai_llama_admission_capacity(request: Optional[Request], llama_backend =
     ``--parallel`` at load time to keep the model on GPU. The app state is a
     launch-intent fallback for tests and for the short window before a backend
     reports its committed runtime slots.
+
+    UNSLOTH_API_MAX_CONCURRENCY (or --api-max-concurrency) caps the admission
+    capacity independently of --parallel, letting operators control API
+    concurrency without changing the llama-server decode slot count.
     """
     slots = _positive_int_or_none(getattr(llama_backend, "effective_parallel_slots", None))
     if slots is not None:
-        return slots
-    try:
-        slots = getattr(request.app.state, "llama_parallel_slots", None)
-    except Exception:
-        slots = None
-    return _positive_int_or_none(slots) or 1
+        backend_slots = slots
+    else:
+        try:
+            slots = getattr(request.app.state, "llama_parallel_slots", None)
+        except Exception:
+            slots = None
+        backend_slots = _positive_int_or_none(slots) or 1
+
+    override = _api_max_concurrency_override()
+    if override is not None:
+        return min(override, backend_slots)
+    return backend_slots
 
 
 def _openai_llama_admission_reserve(

--- a/studio/backend/run.py
+++ b/studio/backend/run.py
@@ -2897,6 +2897,17 @@ def _build_arg_parser():
             "(Parallel Slots) override it per load."
         ),
     )
+    parser.add_argument(
+        "--api-max-concurrency",
+        type = int,
+        default = None,
+        help = (
+            "Cap the number of concurrent inference API requests (admission "
+            "slots) independently of --parallel. Takes the minimum of this "
+            "value and the backend's slot count. Also reads "
+            "UNSLOTH_API_MAX_CONCURRENCY."
+        ),
+    )
     return parser
 
 
@@ -2930,6 +2941,11 @@ if __name__ == "__main__":
         os.environ["UNSLOTH_STUDIO_DISABLE_DNS_PINNING"] = "1"
     else:
         os.environ.setdefault("UNSLOTH_STUDIO_DISABLE_DNS_PINNING", "0")
+
+    if args.api_max_concurrency is not None:
+        if args.api_max_concurrency < 1:
+            parser.error("--api-max-concurrency must be at least 1")
+        os.environ["UNSLOTH_API_MAX_CONCURRENCY"] = str(args.api_max_concurrency)
 
     kwargs = dict(
         host = args.host,

--- a/unsloth_cli/commands/studio.py
+++ b/unsloth_cli/commands/studio.py
@@ -1726,12 +1726,24 @@ def studio_default(
             "(Parallel Slots) override it per load."
         ),
     ),
+    api_max_concurrency: Optional[int] = typer.Option(
+        None,
+        "--api-max-concurrency",
+        min = _PARALLEL_MIN,
+        max = _PARALLEL_MAX,
+        help = (
+            "Cap concurrent inference API requests (admission slots) "
+            "independently of --parallel. Takes the minimum of this value "
+            "and the backend's slot count. Also reads "
+            "UNSLOTH_API_MAX_CONCURRENCY."
+        ),
+    ),
     cloudflare: Optional[bool] = typer.Option(
         None,
         "--cloudflare/--no-cloudflare",
         help = "Expose Unsloth on a PUBLIC internet URL via a free Cloudflare HTTPS "
         "tunnel, for non-api-only wildcard binds (0.0.0.0 or ::). Off by default; "
-        "pass --cloudflare to enable it (--secure implies it). --no-cloudflare forces "
+        "pass --cloudflare to enable it (--secure implies it), --no-cloudflare forces "
         "it off but does not change a raw wildcard bind.",
     ),
     secure: bool = typer.Option(
@@ -2056,6 +2068,9 @@ def studio_default(
     if not silent:
         display_host = _display_host_for_bind(run_mod, host)
         typer.echo(f"Starting Unsloth Studio on http://{_url_host(display_host)}:{port}")
+
+    if api_max_concurrency is not None:
+        os.environ["UNSLOTH_API_MAX_CONCURRENCY"] = str(api_max_concurrency)
 
     run_kwargs = dict(
         host = host,
@@ -2387,6 +2402,19 @@ def run(
             "loaded model; each slot gets ctx/N KV cache. Default "
             f"{_PARALLEL_DEFAULT_RUN} (pre-PR hardcoded value). The Studio "
             "run settings (Parallel Slots) can override it per load."
+        ),
+    ),
+    api_max_concurrency: Optional[int] = typer.Option(
+        None,
+        "--api-max-concurrency",
+        min = _PARALLEL_MIN,
+        max = _PARALLEL_MAX,
+        rich_help_panel = _RUN_PANEL_SERVER,
+        help = (
+            "Cap concurrent inference API requests (admission slots) "
+            "independently of --parallel. Takes the minimum of this value "
+            "and the backend's slot count. Also reads "
+            "UNSLOTH_API_MAX_CONCURRENCY."
         ),
     ),
     cloudflare: Optional[bool] = typer.Option(
@@ -2765,6 +2793,9 @@ def run(
 
     set_tool_policy_default(True)
     set_tool_policy(enable_tools)
+
+    if api_max_concurrency is not None:
+        os.environ["UNSLOTH_API_MAX_CONCURRENCY"] = str(api_max_concurrency)
 
     run_kwargs = dict(
         host = host,


### PR DESCRIPTION
Addresses [danielhanchen's feedback](https://github.com/unslothai/unsloth/pull/5482#issuecomment-5340452757) on #5482.

## What changed

Instead of a separate  middleware (second gate), this exposes  and  directly onto the existing admission slot pool in .

**Single gate, no disagreement:**  now returns  when the env var is set, so the concurrency limit and the decode slot pool are always consistent.

## Files

| File | Change |
|------|--------|
|  |  + modified  |
|  |  CLI flag, wired to env var |
|  |  on  and  |

## Usage



## Test plan

- `python -m py_compile studio/backend/routes/inference.py studio/backend/run.py unsloth_cli/commands/studio.py`

Closes #5481