### PR TITLE
fix(studio): read the MLX reasoning prefill mode from the rendered generation prompt

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,6 +119,7 @@ studio = [
     "huggingface-hub>=1.23.0,<2.0 ; python_version >= '3.10'",
     "huggingface-hub==0.36.2 ; python_version < '3.10'",
     "urllib3>=2.3.0",
+    "jinja2>=3.1.0",
     "structlog>=24.1.0",
     "diceware==1.0.1",
     "ddgs==9.14.4 ; python_version >= '3.10'",

--- a/studio/backend/requirements/studio.txt
+++ b/studio/backend/requirements/studio.txt
@@ -27,13 +27,11 @@ huggingface-hub==0.36.2; python_version < "3.10"
 # below that the read is uninterruptible. The preflight abandons the reader either
 # way, so this is defence in depth, not the bound itself.
 urllib3>=2.3.0
-# The safetensors reasoning-prefill probe renders the chat template's generation prompt in a
-# Jinja sandbox to decide whether output begins inside an unclosed <think>. Transitive via
-# torch and transformers, declared here because the route imports it directly and this set is
+# The safetensors reasoning-prefill probe renders chat templates in a Jinja sandbox. Transitive
+# via torch and transformers, declared because the route imports it directly and this set is
 # installed in every mode: without it the probe cannot render, falls back to always-prefill,
-# and every reasoning model returns a blank content with the answer in reasoning_content.
-# 3.1.0 is the floor the render needs -- the |items filter arrives there, and templates that
-# use it (Hermes-3's tool_use branch) fail to compile below it.
+# and every reasoning model returns blank content. 3.1.0 is the floor -- the |items filter
+# arrives there, and Hermes-3's tool_use branch fails to compile below it.
 jinja2>=3.1.0
 structlog>=24.1.0
 diceware==1.0.1

--- a/studio/backend/requirements/studio.txt
+++ b/studio/backend/requirements/studio.txt
@@ -27,6 +27,14 @@ huggingface-hub==0.36.2; python_version < "3.10"
 # below that the read is uninterruptible. The preflight abandons the reader either
 # way, so this is defence in depth, not the bound itself.
 urllib3>=2.3.0
+# The safetensors reasoning-prefill probe renders the chat template's generation prompt in a
+# Jinja sandbox to decide whether output begins inside an unclosed <think>. Transitive via
+# torch and transformers, declared here because the route imports it directly and this set is
+# installed in every mode: without it the probe cannot render, falls back to always-prefill,
+# and every reasoning model returns a blank content with the answer in reasoning_content.
+# 3.1.0 is the floor the render needs -- the |items filter arrives there, and templates that
+# use it (Hermes-3's tool_use branch) fail to compile below it.
+jinja2>=3.1.0
 structlog>=24.1.0
 diceware==1.0.1
 ddgs==9.14.4; python_version >= "3.10"

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -2763,7 +2763,9 @@ def _generation_prompt_opens_think(
     # renders share is history. On a template that ignores the flag they match and nothing is
     # prefilled, which is the right answer for one that opens no block.
     body = _render_generation_prompt_probe(*args, messages, generation_prompt = False)
-    prefix = rendered[len(os.path.commonprefix((rendered, body))):] if body is not None else rendered
+    prefix = (
+        rendered[len(os.path.commonprefix((rendered, body))) :] if body is not None else rendered
+    )
     # ``<think>`` is not a substring of ``</think>``, so a later open tag means it stays open.
     return prefix.rfind("<think>") > prefix.rfind("</think>")
 
@@ -15415,10 +15417,13 @@ async def openai_chat_completions(
     # the backend renders (mlx_inference prepends system_prompt to chat_messages), so a
     # content-part array the probe left unflattened cannot read differently from generation.
     try:
-        _sf_probe_messages = jsonable_encoder(
-            ([{"role": "system", "content": system_prompt}] if system_prompt else [])
-            + chat_messages
-        ) or None
+        _sf_probe_messages = (
+            jsonable_encoder(
+                ([{"role": "system", "content": system_prompt}] if system_prompt else [])
+                + chat_messages
+            )
+            or None
+        )
     except Exception:
         _sf_probe_messages = None
 

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -2660,24 +2660,26 @@ def _detect_safetensors_features(
     return flags
 
 
+_PROBE_MESSAGES = ({"role": "user", "content": "hi"},)
+
+
 @functools.lru_cache(maxsize = 64)
-def _render_generation_prompt_probe(
-    template: str, enable_thinking: Optional[bool], reasoning_effort: Optional[str]
-) -> Optional[str]:
-    """Render the probe generation prompt, or None when the template cannot be rendered.
+def _compile_generation_prompt_probe(template: str):
+    """Compile the probe template, or None when it cannot be compiled.
 
-    Memoised because the render costs ~10ms and runs more than once per request; only the
-    ``<think>`` shape is read back, which no known template varies by date, so a date-stamping
-    template safely keeps its first render.
+    Compilation is the expensive half (~60ms on a production-sized template) and rendering is
+    not (~0.1ms). Memoising this half rather than the rendered string keeps that saving while
+    letting the messages vary per request, which a template that decides its ``<think>`` shape
+    from the conversation requires.
     """
-    from datetime import datetime
-
-    from jinja2.sandbox import ImmutableSandboxedEnvironment
-
-    def _raise_exception(message: str):
-        raise RuntimeError(message)
-
     try:
+        from datetime import datetime
+
+        from jinja2.sandbox import ImmutableSandboxedEnvironment
+
+        def _raise_exception(message: str):
+            raise RuntimeError(message)
+
         env = ImmutableSandboxedEnvironment(
             trim_blocks = True,
             lstrip_blocks = True,
@@ -2688,13 +2690,30 @@ def _render_generation_prompt_probe(
         # transformers exposes this to every template; without it a date-stamping one raises
         # here and the failure reads as a prefill.
         env.globals["strftime_now"] = lambda fmt: datetime.now().strftime(fmt)
-        reasoning_kwargs: dict = {}
-        if enable_thinking is not None:
-            reasoning_kwargs["enable_thinking"] = enable_thinking
-        if reasoning_effort is not None:
-            reasoning_kwargs["reasoning_effort"] = reasoning_effort
-        return env.from_string(template).render(
-            messages = [{"role": "user", "content": "hi"}],
+        return env.from_string(template)
+    except Exception:
+        return None
+
+
+def _render_generation_prompt_probe(
+    template: str,
+    enable_thinking: Optional[bool],
+    reasoning_effort: Optional[str],
+    messages: Optional[Collection] = None,
+) -> Optional[str]:
+    """Render the probe generation prompt, or None when it cannot be rendered."""
+    reasoning_kwargs: dict = {}
+    if enable_thinking is not None:
+        reasoning_kwargs["enable_thinking"] = enable_thinking
+    if reasoning_effort is not None:
+        reasoning_kwargs["reasoning_effort"] = reasoning_effort
+    try:
+        # Inside the guard: an unhashable template would raise out of the memo key otherwise.
+        compiled = _compile_generation_prompt_probe(template)
+        if compiled is None:
+            return None
+        return compiled.render(
+            messages = list(messages if messages is not None else _PROBE_MESSAGES),
             add_generation_prompt = True,
             bos_token = "",
             eos_token = "",
@@ -2708,6 +2727,7 @@ def _generation_prompt_opens_think(
     template: Optional[str],
     enable_thinking: Optional[bool] = None,
     reasoning_effort: Optional[str] = None,
+    messages: Optional[Collection] = None,
 ) -> bool:
     """True when rendering the template's generation prompt ends INSIDE an unclosed ``<think>``.
 
@@ -2717,12 +2737,21 @@ def _generation_prompt_opens_think(
     lets a template state its own default. The sandbox omits transformers' ``{% generation %}``
     extension, so a template using it joins the unrenderable ones in returning True, preserving
     the historical always-on prefill.
+
+    The request's own messages are rendered when given, because a template may decide the shape
+    from them (Nemotron opens the block only once a message says ``/think``). A history the
+    template refuses falls back to the single-user probe rather than to True, so a message the
+    probe cannot render is never itself a reason to prefill.
     """
     if not template:
         return False
     if not isinstance(template, str):
         return True
-    rendered = _render_generation_prompt_probe(template, enable_thinking, reasoning_effort)
+    rendered = _render_generation_prompt_probe(
+        template, enable_thinking, reasoning_effort, messages
+    )
+    if rendered is None and messages is not None:
+        rendered = _render_generation_prompt_probe(template, enable_thinking, reasoning_effort)
     if rendered is None:
         return True
     # ``<think>`` is not a substring of ``</think>``, so a later open tag means it stays open.
@@ -2734,6 +2763,7 @@ def _sf_reasoning_prefill_mode(
     enable_thinking: Optional[bool],
     template: Optional[str] = None,
     reasoning_effort: Optional[str] = None,
+    messages: Optional[Collection] = None,
 ) -> bool:
     """Whether a safetensors/MLX generation begins INSIDE an unclosed ``<think>``.
 
@@ -2741,7 +2771,8 @@ def _sf_reasoning_prefill_mode(
     ``<|think|>``) never emit ``</think>`` and would swallow the answer, so they, gpt-oss and
     thinking-disabled requests return False. Past the gates the generation prompt's shape
     decides rather than the capability flags, since a template free to state its own default
-    states it.
+    states it, and ``messages`` is rendered with it because a template may read the shape
+    off them.
     """
     if features.get("reasoning_style") not in ("enable_thinking", "enable_thinking_effort"):
         return False
@@ -2757,7 +2788,7 @@ def _sf_reasoning_prefill_mode(
         # template, including markup that only renders PAST assistant history (Kimi-K2-Thinking)
         # while the generation prompt opens none. Prefill only when the generation prompt opens
         # one, else the extractor captures a normal answer as reasoning_content and returns blank.
-        return _generation_prompt_opens_think(tpl)
+        return _generation_prompt_opens_think(tpl, messages = messages)
     if not features.get("supports_reasoning"):
         return False
     if enable_thinking is False:
@@ -2766,7 +2797,7 @@ def _sf_reasoning_prefill_mode(
     # so we don't prefill and capture the answer. Plain enable_thinking models ignore effort.
     if features.get("reasoning_style") == "enable_thinking_effort" and reasoning_effort == "none":
         return False
-    return _generation_prompt_opens_think(tpl, enable_thinking, reasoning_effort)
+    return _generation_prompt_opens_think(tpl, enable_thinking, reasoning_effort, messages)
 
 
 def _effective_enable_tools(payload) -> Optional[bool]:
@@ -15368,6 +15399,14 @@ async def openai_chat_completions(
     if not _sf_template_tools and _sf_server_tool_intent:
         _sf_template_tools = ({},)
 
+    # The prefill probe renders these: a template may read the shape off the conversation
+    # (Nemotron opens <think> only once a message says ``/think``), and a fixed stand-in
+    # would classify a request nobody made. Encoded once, not per protocol call.
+    try:
+        _sf_probe_messages = jsonable_encoder(getattr(payload, "messages", None)) or None
+    except Exception:
+        _sf_probe_messages = None
+
     def _sf_response_protocol(tools = None):
         features = _detect_safetensors_features(backend, _sf_tpl, tools = tools)
         parse_think = bool(
@@ -15378,6 +15417,7 @@ async def openai_chat_completions(
             payload.enable_thinking,
             _sf_tpl,
             reasoning_effort = payload.reasoning_effort,
+            messages = _sf_probe_messages,
         )
         return features, parse_think, reasoning_prefilled
 

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -2700,6 +2700,7 @@ def _render_generation_prompt_probe(
     enable_thinking: Optional[bool],
     reasoning_effort: Optional[str],
     messages: Optional[Collection] = None,
+    generation_prompt: bool = True,
 ) -> Optional[str]:
     """Render the probe generation prompt, or None when it cannot be rendered."""
     reasoning_kwargs: dict = {}
@@ -2714,7 +2715,7 @@ def _render_generation_prompt_probe(
             return None
         return compiled.render(
             messages = list(messages if messages is not None else _PROBE_MESSAGES),
-            add_generation_prompt = True,
+            add_generation_prompt = generation_prompt,
             bos_token = "",
             eos_token = "",
             **reasoning_kwargs,
@@ -2742,20 +2743,29 @@ def _generation_prompt_opens_think(
     from them (Nemotron opens the block only once a message says ``/think``). A history the
     template refuses falls back to the single-user probe rather than to True, so a message the
     probe cannot render is never itself a reason to prefill.
+
+    Only the assistant prefix is weighed, obtained by diffing the render against the same one
+    without a generation prompt. Weighing the whole prompt would let a user who merely writes
+    ``<think>`` in a message become the last opener and prefill a template that opens nothing.
     """
     if not template:
         return False
     if not isinstance(template, str):
         return True
-    rendered = _render_generation_prompt_probe(
-        template, enable_thinking, reasoning_effort, messages
-    )
+    args = (template, enable_thinking, reasoning_effort)
+    rendered = _render_generation_prompt_probe(*args, messages)
     if rendered is None and messages is not None:
-        rendered = _render_generation_prompt_probe(template, enable_thinking, reasoning_effort)
+        messages = None
+        rendered = _render_generation_prompt_probe(*args)
     if rendered is None:
         return True
+    # The generation prompt is what ``add_generation_prompt`` adds, so everything the two
+    # renders share is history. On a template that ignores the flag they match and nothing is
+    # prefilled, which is the right answer for one that opens no block.
+    body = _render_generation_prompt_probe(*args, messages, generation_prompt = False)
+    prefix = rendered[len(os.path.commonprefix((rendered, body))):] if body is not None else rendered
     # ``<think>`` is not a substring of ``</think>``, so a later open tag means it stays open.
-    return rendered.rfind("<think>") > rendered.rfind("</think>")
+    return prefix.rfind("<think>") > prefix.rfind("</think>")
 
 
 def _sf_reasoning_prefill_mode(
@@ -15400,10 +15410,15 @@ async def openai_chat_completions(
         _sf_template_tools = ({},)
 
     # The prefill probe renders these: a template may read the shape off the conversation
-    # (Nemotron opens <think> only once a message says ``/think``), and a fixed stand-in
-    # would classify a request nobody made. Encoded once, not per protocol call.
+    # (Nemotron opens <think> only once a message says ``/think``), and a fixed stand-in would
+    # classify a request nobody made. Built from the NORMALIZED conversation, the same shape
+    # the backend renders (mlx_inference prepends system_prompt to chat_messages), so a
+    # content-part array the probe left unflattened cannot read differently from generation.
     try:
-        _sf_probe_messages = jsonable_encoder(getattr(payload, "messages", None)) or None
+        _sf_probe_messages = jsonable_encoder(
+            ([{"role": "system", "content": system_prompt}] if system_prompt else [])
+            + chat_messages
+        ) or None
     except Exception:
         _sf_probe_messages = None
 

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -2733,20 +2733,19 @@ def _generation_prompt_opens_think(
     """True when rendering the template's generation prompt ends INSIDE an unclosed ``<think>``.
 
     Separates templates that prefill an open ``<think>``, where the model emits only the closing
-    tag, from those that leave the prompt open and let the model emit its own block. A ``None``
-    kwarg is omitted exactly as ``apply_chat_template_for_generation`` omits it, which is what
-    lets a template state its own default. The sandbox omits transformers' ``{% generation %}``
-    extension, so a template using it joins the unrenderable ones in returning True, preserving
-    the historical always-on prefill.
+    tag, from those that leave the prompt open and let the model emit its own block.
 
-    The request's own messages are rendered when given, because a template may decide the shape
-    from them (Nemotron opens the block only once a message says ``/think``). A history the
-    template refuses falls back to the single-user probe rather than to True, so a message the
-    probe cannot render is never itself a reason to prefill.
+    Three things keep this reading what generation reads. A ``None`` kwarg is omitted exactly as
+    ``apply_chat_template_for_generation`` omits it, so a template states its own default. The
+    request's messages are rendered when given, since a template may take the shape from them
+    (Nemotron opens the block only once a message says ``/think``). And only the assistant
+    prefix is weighed, diffed against the render without a generation prompt, so a user who
+    merely types ``<think>`` cannot become the last opener.
 
-    Only the assistant prefix is weighed, obtained by diffing the render against the same one
-    without a generation prompt. Weighing the whole prompt would let a user who merely writes
-    ``<think>`` in a message become the last opener and prefill a template that opens nothing.
+    Both fallbacks stay conservative: a history the template refuses drops back to the
+    single-user probe rather than to True, and a template the sandbox cannot render at all
+    (``{% generation %}`` is not in its extension set) returns True, the historical always-on
+    prefill.
     """
     if not template:
         return False
@@ -2759,9 +2758,8 @@ def _generation_prompt_opens_think(
         rendered = _render_generation_prompt_probe(*args)
     if rendered is None:
         return True
-    # The generation prompt is what ``add_generation_prompt`` adds, so everything the two
-    # renders share is history. On a template that ignores the flag they match and nothing is
-    # prefilled, which is the right answer for one that opens no block.
+    # Everything the two renders share is history. A template that ignores the flag yields an
+    # empty prefix and prefills nothing, right for one that opens no block.
     body = _render_generation_prompt_probe(*args, messages, generation_prompt = False)
     prefix = (
         rendered[len(os.path.commonprefix((rendered, body))) :] if body is not None else rendered
@@ -15411,16 +15409,13 @@ async def openai_chat_completions(
     if not _sf_template_tools and _sf_server_tool_intent:
         _sf_template_tools = ({},)
 
-    # The prefill probe renders these: a template may read the shape off the conversation
-    # (Nemotron opens <think> only once a message says ``/think``), and a fixed stand-in would
-    # classify a request nobody made. Built from the NORMALIZED conversation, the same shape
-    # the backend renders (mlx_inference prepends system_prompt to chat_messages), so a
-    # content-part array the probe left unflattened cannot read differently from generation.
-    # Swept the way the renderer sweeps, since apply_chat_template_for_generation neutralizes
-    # control markup before it renders: a user turn's ``<think>`` reaches the template as
-    # ``< think>``, and a template branching on that marker would otherwise pick one branch
-    # here and the other in generation. The tokenizer's markup profile is not in scope, so
-    # this uses the same default rewrite the renderer falls back to.
+    # What the prefill probe renders, built to match what generation renders: a template may
+    # read the ``<think>`` shape off the conversation (Nemotron opens it only once a message
+    # says ``/think``), so any difference here is a wrong verdict. Hence the normalized
+    # messages rather than the payload (content parts flattened, system lifted, as
+    # mlx_inference sees them) and the same sweep the renderer applies, which turns a user's
+    # ``<think>`` into ``< think>``. Markup profile is not in scope, so this takes the
+    # renderer's own default rewrite.
     try:
         from core.inference.chat_template_helpers import (
             neutralize_control_markup_in_messages as _sf_sweep,

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -28,6 +28,7 @@ from fastapi.encoders import jsonable_encoder
 from fastapi.responses import StreamingResponse, JSONResponse, PlainTextResponse, Response
 from starlette.requests import ClientDisconnect
 from typing import Any, Callable, Collection, List, NamedTuple, Optional, TYPE_CHECKING, Union
+import functools
 import json
 import httpx
 from loggers import get_logger
@@ -2659,26 +2660,24 @@ def _detect_safetensors_features(
     return flags
 
 
-def _generation_prompt_opens_think(template: Optional[str]) -> bool:
-    """True when rendering the template's generation prompt ends INSIDE an unclosed ``<think>``.
+@functools.lru_cache(maxsize = 64)
+def _render_generation_prompt_probe(
+    template: str, enable_thinking: Optional[bool], reasoning_effort: Optional[str]
+) -> Optional[str]:
+    """Render the probe generation prompt, or None when the template cannot be rendered.
 
-    Distinguishes templates that PREFILL an open ``<think>`` in the assistant generation
-    prompt (DeepSeek-R1, QwQ, Qwen3-Thinking) -- where the model emits only the closing
-    ``</think>`` and the extractor must start in reasoning mode -- from templates that merely
-    render PAST assistant ``<think>...</think>`` history while leaving the generation prompt
-    open with no ``<think>`` (e.g. Kimi-K2-Thinking), where the model self-emits its own block
-    and the extractor must start in normal mode. Renders a single-user-message probe with the
-    same sandbox transformers uses; on any failure returns True, preserving the historical
-    always-on prefill for templates that cannot be rendered here.
+    Memoised because the render costs ~10ms and runs more than once per request; only the
+    ``<think>`` shape is read back, which no known template varies by date, so a date-stamping
+    template safely keeps its first render.
     """
-    if not template:
-        return False
+    from datetime import datetime
+
+    from jinja2.sandbox import ImmutableSandboxedEnvironment
+
+    def _raise_exception(message: str):
+        raise RuntimeError(message)
+
     try:
-        from jinja2.sandbox import ImmutableSandboxedEnvironment
-
-        def _raise_exception(message: str):
-            raise RuntimeError(message)
-
         env = ImmutableSandboxedEnvironment(
             trim_blocks = True,
             lstrip_blocks = True,
@@ -2686,16 +2685,47 @@ def _generation_prompt_opens_think(template: Optional[str]) -> bool:
         )
         env.filters["tojson"] = lambda value, **kwargs: json.dumps(value, ensure_ascii = False)
         env.globals["raise_exception"] = _raise_exception
-        rendered = env.from_string(template).render(
+        # transformers exposes this to every template; without it a date-stamping one raises
+        # here and the failure reads as a prefill.
+        env.globals["strftime_now"] = lambda fmt: datetime.now().strftime(fmt)
+        reasoning_kwargs: dict = {}
+        if enable_thinking is not None:
+            reasoning_kwargs["enable_thinking"] = enable_thinking
+        if reasoning_effort is not None:
+            reasoning_kwargs["reasoning_effort"] = reasoning_effort
+        return env.from_string(template).render(
             messages = [{"role": "user", "content": "hi"}],
             add_generation_prompt = True,
             bos_token = "",
             eos_token = "",
+            **reasoning_kwargs,
         )
     except Exception:
+        return None
+
+
+def _generation_prompt_opens_think(
+    template: Optional[str],
+    enable_thinking: Optional[bool] = None,
+    reasoning_effort: Optional[str] = None,
+) -> bool:
+    """True when rendering the template's generation prompt ends INSIDE an unclosed ``<think>``.
+
+    Separates templates that prefill an open ``<think>``, where the model emits only the closing
+    tag, from those that leave the prompt open and let the model emit its own block. A ``None``
+    kwarg is omitted exactly as ``apply_chat_template_for_generation`` omits it, which is what
+    lets a template state its own default. The sandbox omits transformers' ``{% generation %}``
+    extension, so a template using it joins the unrenderable ones in returning True, preserving
+    the historical always-on prefill.
+    """
+    if not template:
+        return False
+    if not isinstance(template, str):
         return True
-    # ``<think>`` is not a substring of ``</think>`` (the ``/`` breaks it), so the last open
-    # tag sitting after the last close tag means the prompt ends inside an open block.
+    rendered = _render_generation_prompt_probe(template, enable_thinking, reasoning_effort)
+    if rendered is None:
+        return True
+    # ``<think>`` is not a substring of ``</think>``, so a later open tag means it stays open.
     return rendered.rfind("<think>") > rendered.rfind("</think>")
 
 
@@ -2707,12 +2737,11 @@ def _sf_reasoning_prefill_mode(
 ) -> bool:
     """Whether a safetensors/MLX generation begins INSIDE an unclosed ``<think>``.
 
-    ``enable_thinking`` templates (Qwen3/GLM) prefill an open ``<think>`` so the model
-    emits only the closing ``</think>``, and the extractor must start in reasoning mode.
     Gated on the STANDARD ``<think>``/``</think>`` markers: bespoke channels (gemma's
-    ``<|think|>``) never emit ``</think>`` and would swallow the answer, so they and
-    gpt-oss and thinking-disabled requests return False. ``enable_thinking`` None
-    defaults thinking ON, so a plain request still prefills.
+    ``<|think|>``) never emit ``</think>`` and would swallow the answer, so they, gpt-oss and
+    thinking-disabled requests return False. Past the gates the generation prompt's shape
+    decides rather than the capability flags, since a template free to state its own default
+    states it.
     """
     if features.get("reasoning_style") not in ("enable_thinking", "enable_thinking_effort"):
         return False
@@ -2737,7 +2766,7 @@ def _sf_reasoning_prefill_mode(
     # so we don't prefill and capture the answer. Plain enable_thinking models ignore effort.
     if features.get("reasoning_style") == "enable_thinking_effort" and reasoning_effort == "none":
         return False
-    return True
+    return _generation_prompt_opens_think(tpl, enable_thinking, reasoning_effort)
 
 
 def _effective_enable_tools(payload) -> Optional[bool]:

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -15425,7 +15425,6 @@ async def openai_chat_completions(
         from core.inference.chat_template_helpers import (
             neutralize_control_markup_in_messages as _sf_sweep,
         )
-
         _sf_probe_messages = (
             jsonable_encoder(
                 _sf_sweep(

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -15416,11 +15416,22 @@ async def openai_chat_completions(
     # classify a request nobody made. Built from the NORMALIZED conversation, the same shape
     # the backend renders (mlx_inference prepends system_prompt to chat_messages), so a
     # content-part array the probe left unflattened cannot read differently from generation.
+    # Swept the way the renderer sweeps, since apply_chat_template_for_generation neutralizes
+    # control markup before it renders: a user turn's ``<think>`` reaches the template as
+    # ``< think>``, and a template branching on that marker would otherwise pick one branch
+    # here and the other in generation. The tokenizer's markup profile is not in scope, so
+    # this uses the same default rewrite the renderer falls back to.
     try:
+        from core.inference.chat_template_helpers import (
+            neutralize_control_markup_in_messages as _sf_sweep,
+        )
+
         _sf_probe_messages = (
             jsonable_encoder(
-                ([{"role": "system", "content": system_prompt}] if system_prompt else [])
-                + chat_messages
+                _sf_sweep(
+                    ([{"role": "system", "content": system_prompt}] if system_prompt else [])
+                    + chat_messages
+                )
             )
             or None
         )

--- a/studio/backend/tests/test_chat_template_continuation.py
+++ b/studio/backend/tests/test_chat_template_continuation.py
@@ -720,7 +720,11 @@ def test_the_manual_splice_appends_the_fallback_swept_partial():
 
 # ── Non-streaming tool loop: the prefill mode belongs to the turn that produced the text ──
 
-_THINK_TEMPLATE = "{% if x %}<think>\n{% endif %}</think>"
+# R1/QwQ shape: the generation prompt opens an unclosed <think>.
+_THINK_TEMPLATE = (
+    "{% for m in messages %}<|im_start|>{{ m['role'] }}\n{{ m['content'] }}<|im_end|>\n{% endfor %}"
+    "{% if add_generation_prompt %}<|im_start|>assistant\n<think>\n{% endif %}"
+)
 # A resumed turn that calls a tool: the kept text is the POST-tool turn, which rendered
 # an ordinary generation prompt, so its output opens inside the template's <think>.
 _RESUMED_TOOL_EVENTS = [

--- a/studio/backend/tests/test_safetensors_capability_advertise.py
+++ b/studio/backend/tests/test_safetensors_capability_advertise.py
@@ -801,20 +801,29 @@ def test_detect_safetensors_features_keeps_tools_for_function_alias_bare_json():
 
 # _sf_reasoning_prefill_mode gates the prefilled-<think> extractor (GGUF reasoning parity).
 class TestSafetensorsReasoningPrefillGate:
-    # A minimal Qwen3-style template with the standard <think>/</think> markers.
-    _QWEN_TPL = "{% if enable_thinking %}<think>{% endif %}...</think>..."
+    # Qwen3.5 shape: renders a CLOSED <think></think> unless thinking is explicitly asked for.
+    _QWEN35_TPL = (
+        "{% for m in messages %}<|im_start|>{{ m['role'] }}\n{{ m['content'] }}<|im_end|>\n{% endfor %}"
+        "{% if add_generation_prompt %}<|im_start|>assistant\n"
+        "{% if enable_thinking is defined and enable_thinking is true %}<think>\n"
+        "{% else %}<think>\n\n</think>\n\n{% endif %}{% endif %}"
+    )
+    # Qwen3 shape: the model self-emits its block, so the generation prompt opens none.
+    _QWEN3_TPL = (
+        "{% for m in messages %}<|im_start|>{{ m['role'] }}\n{{ m['content'] }}<|im_end|>\n{% endfor %}"
+        "{% if add_generation_prompt %}<|im_start|>assistant\n"
+        "{% if enable_thinking is defined and enable_thinking is false %}<think>\n\n</think>\n\n{% endif %}"
+        "{% endif %}"
+    )
     # gemma-style bespoke reasoning channel -- no standard markers.
     _GEMMA_TPL = "{% if enable_thinking %}<|think|>{% endif %}<|channel>thought<channel|>"
-    # always-on template whose GENERATION PROMPT opens an unclosed <think> (DeepSeek-R1 / QwQ /
-    # Qwen3-Thinking shape): the model emits only the closing </think>, so prefill.
-    _ALWAYS_ON_OPEN_TPL = (
+    # DeepSeek-R1 / QwQ shape: the generation prompt opens an unclosed <think>.
+    _PROMPT_OPENS_THINK_TPL = (
         "{% for m in messages %}{{ m['content'] }}{% endfor %}"
         "{% if add_generation_prompt %}<|assistant|><think>\n{% endif %}"
     )
-    # always-on template that renders PAST assistant <think>...</think> history but leaves the
-    # generation prompt open with no <think> (Kimi-K2-Thinking shape): the model self-emits its
-    # own block, so prefill mode would blank a normal answer.
-    _ALWAYS_ON_HISTORY_TPL = (
+    # Kimi-K2-Thinking shape: renders past <think> history but opens none in the prompt.
+    _HISTORY_ONLY_THINK_TPL = (
         "{% for m in messages %}"
         "{% if m['role'] == 'assistant' %}<think>{{ m.get('reasoning_content', '') }}</think>"
         "{{ m['content'] }}{% endif %}"
@@ -834,41 +843,48 @@ class TestSafetensorsReasoningPrefillGate:
     def test_g1_enable_thinking_true(self):
         # G1: Qwen3.5 template + explicit enable_thinking=True -> prefilled.
         from routes.inference import _sf_reasoning_prefill_mode
-        assert _sf_reasoning_prefill_mode(self._features(), True, self._QWEN_TPL) is True
+        assert _sf_reasoning_prefill_mode(self._features(), True, self._QWEN35_TPL) is True
 
-    def test_g2_enable_thinking_none_defaults_on(self):
-        # G2: default request (None) -> prefilled (Qwen3/GLM templates default on).
+    def test_g2_enable_thinking_none_follows_template_default(self):
+        # G2: the kwarg is omitted, so the template's own default decides. Reading it as
+        # prefilled captured the whole answer as reasoning and blanked the visible content.
         from routes.inference import _sf_reasoning_prefill_mode
-        assert _sf_reasoning_prefill_mode(self._features(), None, self._QWEN_TPL) is True
+        assert _sf_reasoning_prefill_mode(self._features(), None, self._QWEN35_TPL) is False
+
+    def test_g2b_self_emitting_template_not_prefilled(self):
+        # G2b: thinking is on but the prompt opens no <think>, so the extractor starts normal.
+        from routes.inference import _sf_reasoning_prefill_mode
+        assert _sf_reasoning_prefill_mode(self._features(), None, self._QWEN3_TPL) is False
+        assert _sf_reasoning_prefill_mode(self._features(), True, self._QWEN3_TPL) is False
 
     def test_g3_enable_thinking_false(self):
         # G3: thinking explicitly off -> not prefilled.
         from routes.inference import _sf_reasoning_prefill_mode
-        assert _sf_reasoning_prefill_mode(self._features(), False, self._QWEN_TPL) is False
+        assert _sf_reasoning_prefill_mode(self._features(), False, self._QWEN35_TPL) is False
 
     def test_g4_gpt_oss_reasoning_effort_excluded(self):
         # G4: gpt-oss uses explicit tags via HarmonyTextStreamer -> normal mode.
         from routes.inference import _sf_reasoning_prefill_mode
         feats = self._features(reasoning_style = "reasoning_effort")
-        assert _sf_reasoning_prefill_mode(feats, True, self._QWEN_TPL) is False
+        assert _sf_reasoning_prefill_mode(feats, True, self._PROMPT_OPENS_THINK_TPL) is False
 
     def test_g5_enable_thinking_effort_included(self):
-        # G5: GLM-style enable_thinking_effort also prefills.
+        # G5: enable_thinking_effort is not excluded by the style gate.
         from routes.inference import _sf_reasoning_prefill_mode
         feats = self._features(reasoning_style = "enable_thinking_effort")
-        assert _sf_reasoning_prefill_mode(feats, None, self._QWEN_TPL) is True
+        assert _sf_reasoning_prefill_mode(feats, None, self._PROMPT_OPENS_THINK_TPL) is True
 
     def test_g6_non_reasoning_model(self):
         # G6: no reasoning capability -> never prefilled.
         from routes.inference import _sf_reasoning_prefill_mode
         feats = self._features(supports_reasoning = False, reasoning_style = None)
-        assert _sf_reasoning_prefill_mode(feats, True, self._QWEN_TPL) is False
+        assert _sf_reasoning_prefill_mode(feats, True, self._PROMPT_OPENS_THINK_TPL) is False
 
     def test_g7_reasoning_always_on_prompt_opens_think(self):
         # G7: always-on template whose generation prompt opens <think> -> prefilled regardless of the flag.
         from routes.inference import _sf_reasoning_prefill_mode
         feats = self._features(reasoning_always_on = True)
-        assert _sf_reasoning_prefill_mode(feats, False, self._ALWAYS_ON_OPEN_TPL) is True
+        assert _sf_reasoning_prefill_mode(feats, False, self._PROMPT_OPENS_THINK_TPL) is True
 
     def test_g7b_reasoning_always_on_history_only_not_prefilled(self):
         # G7b (#5704): always-on classification from rendered assistant HISTORY <think></think>
@@ -876,7 +892,7 @@ class TestSafetensorsReasoningPrefillGate:
         # normal answer entirely as reasoning_content and blank the visible answer, so it must be off.
         from routes.inference import _sf_reasoning_prefill_mode
         feats = self._features(reasoning_always_on = True)
-        assert _sf_reasoning_prefill_mode(feats, None, self._ALWAYS_ON_HISTORY_TPL) is False
+        assert _sf_reasoning_prefill_mode(feats, None, self._HISTORY_ONLY_THINK_TPL) is False
 
     def test_g8_gemma_bespoke_channel_excluded(self):
         # G8: gemma's <|think|>/<|channel> format has no </think> -> NOT prefilled

--- a/studio/backend/tests/test_safetensors_reasoning_stream.py
+++ b/studio/backend/tests/test_safetensors_reasoning_stream.py
@@ -126,6 +126,20 @@ _STRFTIME_TPL = (
     "{{ strftime_now('%Y') }}"
     "{% if add_generation_prompt %}<|im_start|>assistant\n<think>\n\n</think>\n\n{% endif %}"
 )
+# Nemotron shape: thinking is off until a message opts in with ``/think``.
+_MESSAGE_SHAPE_TPL = (
+    "{% set ns = namespace(think = false) %}"
+    "{% for m in messages %}{% if '/think' in m['content'] %}{% set ns.think = true %}{% endif %}"
+    "<|im_start|>{{ m['role'] }}\n{{ m['content'] }}<|im_end|>\n{% endfor %}"
+    "{% if add_generation_prompt %}<|im_start|>assistant\n"
+    "{% if ns.think %}<think>\n{% else %}<think></think>{% endif %}{% endif %}"
+)
+# Closes its block, and raises on a tool turn the way a strict template does.
+_STRICT_HISTORY_TPL = (
+    "{% for m in messages %}{% if m['role'] == 'tool' %}{{ raise_exception('no tool turns') }}"
+    "{% endif %}<|im_start|>{{ m['role'] }}\n{{ m['content'] }}<|im_end|>\n{% endfor %}"
+    "{% if add_generation_prompt %}<|im_start|>assistant\n<think>\n\n</think>\n\n{% endif %}"
+)
 _ETHINK = {"reasoning_style": "enable_thinking", "supports_reasoning": True}
 _ETHINK_EFFORT = {"reasoning_style": "enable_thinking_effort", "supports_reasoning": True}
 
@@ -171,6 +185,31 @@ def test_a_template_that_stamps_a_date_still_renders():
 
 def test_prefill_mode_off_without_think_markers():
     assert _sf_reasoning_prefill_mode(_ETHINK, None, "no markers here") is False
+
+
+def test_prefill_mode_renders_the_request_messages():
+    # The template reads the shape off the conversation, so a fixed stand-in classifies a
+    # request nobody made and the answer to the opted-in one lands in visible content.
+    plain = [{"role": "user", "content": "what is 2+2"}]
+    opted_in = [{"role": "user", "content": "/think what is 2+2"}]
+    assert _sf_reasoning_prefill_mode(_ETHINK, None, _MESSAGE_SHAPE_TPL, None, plain) is False
+    assert _sf_reasoning_prefill_mode(_ETHINK, None, _MESSAGE_SHAPE_TPL, None, opted_in) is True
+
+
+def test_messages_the_template_refuses_fall_back_to_the_single_user_probe():
+    # A history the template raises on must not itself read as a prefill: fall back to the
+    # stand-in, which is what every caller got before the messages were threaded through.
+    refused = [{"role": "user", "content": "hi"}, {"role": "tool", "content": "42"}]
+    assert _sf_reasoning_prefill_mode(_ETHINK, None, _STRICT_HISTORY_TPL, None, refused) is False
+    assert _sf_reasoning_prefill_mode(_ETHINK, None, _STRICT_HISTORY_TPL) is False
+
+
+def test_prefill_mode_without_messages_matches_the_single_user_probe():
+    # Omitting the argument keeps the pre-existing signature and verdict.
+    for tpl in (_THINK_TPL, _TEMPLATE_DEFAULT_OFF_TPL, _MESSAGE_SHAPE_TPL):
+        assert _sf_reasoning_prefill_mode(_ETHINK, None, tpl) == _sf_reasoning_prefill_mode(
+            _ETHINK, None, tpl, None, [{"role": "user", "content": "hi"}]
+        )
 
 
 def _replay_sf_reasoning_stream(events: list[dict], *, prefilled: bool) -> dict:

--- a/studio/backend/tests/test_safetensors_reasoning_stream.py
+++ b/studio/backend/tests/test_safetensors_reasoning_stream.py
@@ -204,7 +204,7 @@ def test_prefill_mode_renders_the_request_messages():
 
 def test_messages_the_template_refuses_fall_back_to_the_single_user_probe():
     # A history the template raises on must not itself read as a prefill: fall back to the
-    # stand-in, which is what every caller got before the messages were threaded through.
+    # stand-in every caller got before the messages were threaded through.
     refused = [{"role": "user", "content": "hi"}, {"role": "tool", "content": "42"}]
     assert _sf_reasoning_prefill_mode(_ETHINK, None, _STRICT_HISTORY_TPL, None, refused) is False
     assert _sf_reasoning_prefill_mode(_ETHINK, None, _STRICT_HISTORY_TPL) is False
@@ -222,9 +222,8 @@ def test_a_think_tag_the_user_typed_does_not_prefill():
 
 
 def test_content_parts_must_reach_the_probe_flattened():
-    # Pins why the route probes the normalized conversation: the two shapes disagree, so
-    # probing the raw array would test ``'/think' in <list>``, silently miss the opt-in, and
-    # classify against a prompt generation never renders.
+    # Why the route probes the normalized conversation: the shapes disagree, so a raw array
+    # would test ``'/think' in <list>``, miss the opt-in, and classify a prompt never rendered.
     flattened = [{"role": "user", "content": "/think what is 2+2"}]
     raw_parts = [{"role": "user", "content": [{"type": "text", "text": "/think what is 2+2"}]}]
     assert _sf_reasoning_prefill_mode(_ETHINK, None, _MESSAGE_SHAPE_TPL, None, flattened) is True
@@ -233,8 +232,7 @@ def test_content_parts_must_reach_the_probe_flattened():
 
 def test_control_markup_must_reach_the_probe_swept():
     # The renderer neutralizes control markup first, so a user's ``<think>`` arrives as
-    # ``< think>``. Pins the divergence the route sweeps away: a template branching on the
-    # marker would otherwise pick one branch here and the other in generation.
+    # ``< think>``. A template branching on it would otherwise split from generation.
     from core.inference.chat_template_helpers import neutralize_control_markup_in_messages
 
     raw = [{"role": "user", "content": "<think> tags"}]

--- a/studio/backend/tests/test_safetensors_reasoning_stream.py
+++ b/studio/backend/tests/test_safetensors_reasoning_stream.py
@@ -231,6 +231,20 @@ def test_content_parts_must_reach_the_probe_flattened():
     assert _sf_reasoning_prefill_mode(_ETHINK, None, _MESSAGE_SHAPE_TPL, None, raw_parts) is False
 
 
+def test_control_markup_must_reach_the_probe_swept():
+    # The renderer neutralizes control markup first, so a user's ``<think>`` arrives as
+    # ``< think>``. Pins the divergence the route sweeps away: a template branching on the
+    # marker would otherwise pick one branch here and the other in generation.
+    from core.inference.chat_template_helpers import neutralize_control_markup_in_messages
+
+    raw = [{"role": "user", "content": "<think> tags"}]
+    swept = neutralize_control_markup_in_messages([dict(m) for m in raw])
+    assert swept[0]["content"] == "< think> tags"
+    marker_tpl = _MESSAGE_SHAPE_TPL.replace("'/think' in", "'<think>' in")
+    assert _sf_reasoning_prefill_mode(_ETHINK, None, marker_tpl, None, raw) is True
+    assert _sf_reasoning_prefill_mode(_ETHINK, None, marker_tpl, None, swept) is False
+
+
 def test_prefill_mode_without_messages_matches_the_single_user_probe():
     # Omitting the argument keeps the pre-existing signature and verdict.
     for tpl in (_THINK_TPL, _TEMPLATE_DEFAULT_OFF_TPL, _MESSAGE_SHAPE_TPL):

--- a/studio/backend/tests/test_safetensors_reasoning_stream.py
+++ b/studio/backend/tests/test_safetensors_reasoning_stream.py
@@ -134,6 +134,12 @@ _MESSAGE_SHAPE_TPL = (
     "{% if add_generation_prompt %}<|im_start|>assistant\n"
     "{% if ns.think %}<think>\n{% else %}<think></think>{% endif %}{% endif %}"
 )
+# Kimi shape: renders history into the prompt but opens no block of its own.
+_HISTORY_ONLY_TPL = (
+    "{% for m in messages %}<|im_user|>{{ m['role'] }}<|im_middle|>{{ m['content'] }}<|im_end|>"
+    "{% if m['role'] == 'assistant' %}<think></think>{% endif %}{% endfor %}"
+    "{% if add_generation_prompt %}<|im_assistant|>assistant<|im_middle|>{% endif %}"
+)
 # Closes its block, and raises on a tool turn the way a strict template does.
 _STRICT_HISTORY_TPL = (
     "{% for m in messages %}{% if m['role'] == 'tool' %}{{ raise_exception('no tool turns') }}"
@@ -202,6 +208,27 @@ def test_messages_the_template_refuses_fall_back_to_the_single_user_probe():
     refused = [{"role": "user", "content": "hi"}, {"role": "tool", "content": "42"}]
     assert _sf_reasoning_prefill_mode(_ETHINK, None, _STRICT_HISTORY_TPL, None, refused) is False
     assert _sf_reasoning_prefill_mode(_ETHINK, None, _STRICT_HISTORY_TPL) is False
+
+
+def test_a_think_tag_the_user_typed_does_not_prefill():
+    # Only the assistant prefix counts. Weighing the whole prompt would let anyone asking
+    # about a <think> tag become the last opener and blank their own answer.
+    for text in ("how do I emit a <think> tag?", "use <think>x</think> tags", "plain"):
+        msgs = [{"role": "user", "content": text}]
+        assert _sf_reasoning_prefill_mode(_ETHINK, None, _HISTORY_ONLY_TPL, None, msgs) is False
+    # A template that really does open one is still read as prefilled.
+    typed = [{"role": "user", "content": "a <think> b"}]
+    assert _sf_reasoning_prefill_mode(_ETHINK, None, _THINK_TPL, None, typed) is True
+
+
+def test_content_parts_must_reach_the_probe_flattened():
+    # Pins why the route probes the normalized conversation: the two shapes disagree, so
+    # probing the raw array would test ``'/think' in <list>``, silently miss the opt-in, and
+    # classify against a prompt generation never renders.
+    flattened = [{"role": "user", "content": "/think what is 2+2"}]
+    raw_parts = [{"role": "user", "content": [{"type": "text", "text": "/think what is 2+2"}]}]
+    assert _sf_reasoning_prefill_mode(_ETHINK, None, _MESSAGE_SHAPE_TPL, None, flattened) is True
+    assert _sf_reasoning_prefill_mode(_ETHINK, None, _MESSAGE_SHAPE_TPL, None, raw_parts) is False
 
 
 def test_prefill_mode_without_messages_matches_the_single_user_probe():

--- a/studio/backend/tests/test_safetensors_reasoning_stream.py
+++ b/studio/backend/tests/test_safetensors_reasoning_stream.py
@@ -3,11 +3,13 @@
 
 """Safetensors/MLX reasoning-block parity with GGUF.
 
-enable_thinking templates (Qwen3/GLM) prefill an unclosed ``<think>`` so the model
-emits only the closing ``</think>`` then the answer; the safetensors stream must
-split the leading text into ``reasoning_content`` deltas (plain stream and tool
-loop), resetting per turn and appending only visible text to the monitor. Replays a
-copy of ``sf_tool_stream``'s reasoning loop against synthetic events.
+Some enable_thinking templates prefill an unclosed ``<think>`` so the model emits only
+the closing ``</think>`` then the answer; the safetensors stream must split the leading
+text into ``reasoning_content`` deltas (plain stream and tool loop), resetting per turn
+and appending only visible text to the monitor. Others render a closed block or none at
+all and the answer is visible from the first token, so the prefill mode is read from the
+generation prompt the request renders. Replays a copy of ``sf_tool_stream``'s reasoning
+loop against synthetic events, and covers the split through the route itself.
 """
 
 from __future__ import annotations
@@ -99,13 +101,44 @@ for _name in reversed(_STUBBED):
     sys.modules.pop(_name, None)
 
 
-_THINK_TPL = "...<think>...</think>..."
+# DeepSeek-R1 / QwQ / GLM shape: the generation prompt opens an unclosed ``<think>``.
+_THINK_TPL = (
+    "{% for m in messages %}<|user|>{{ m['content'] }}{% endfor %}"
+    "{% if add_generation_prompt %}<|assistant|>\n<think>\n{% endif %}"
+)
+# Qwen3.5 shape: a CLOSED ``<think></think>`` unless thinking is explicitly requested.
+_TEMPLATE_DEFAULT_OFF_TPL = (
+    "{% for m in messages %}<|im_start|>{{ m['role'] }}\n{{ m['content'] }}<|im_end|>\n{% endfor %}"
+    "{% if add_generation_prompt %}<|im_start|>assistant\n"
+    "{% if enable_thinking is defined and enable_thinking is true %}<think>\n"
+    "{% else %}<think>\n\n</think>\n\n{% endif %}{% endif %}"
+)
+# Opens ``<think>`` only at high effort.
+_EFFORT_SHAPE_TPL = (
+    "{% for m in messages %}<|im_start|>{{ m['role'] }}\n{{ m['content'] }}<|im_end|>\n{% endfor %}"
+    "{% if add_generation_prompt %}<|im_start|>assistant\n"
+    "{% if reasoning_effort is defined and reasoning_effort == 'high' %}<think>\n"
+    "{% else %}<think>\n\n</think>\n\n{% endif %}{% endif %}"
+)
+# Stamps a date through the ``strftime_now`` global transformers exposes to every template.
+_STRFTIME_TPL = (
+    "{% for m in messages %}<|im_start|>{{ m['role'] }}\n{{ m['content'] }}<|im_end|>\n{% endfor %}"
+    "{{ strftime_now('%Y') }}"
+    "{% if add_generation_prompt %}<|im_start|>assistant\n<think>\n\n</think>\n\n{% endif %}"
+)
 _ETHINK = {"reasoning_style": "enable_thinking", "supports_reasoning": True}
 _ETHINK_EFFORT = {"reasoning_style": "enable_thinking_effort", "supports_reasoning": True}
 
 
 def test_prefill_mode_on_for_enable_thinking_default():
     assert _sf_reasoning_prefill_mode(_ETHINK, None, _THINK_TPL) is True
+
+
+def test_prefill_mode_follows_template_default_not_the_request_flag():
+    # The kwarg is omitted when the request says nothing, so the template's own default
+    # decides. Assuming a prefill blanked ``content`` for every OpenAI client.
+    assert _sf_reasoning_prefill_mode(_ETHINK, None, _TEMPLATE_DEFAULT_OFF_TPL) is False
+    assert _sf_reasoning_prefill_mode(_ETHINK, True, _TEMPLATE_DEFAULT_OFF_TPL) is True
 
 
 def test_prefill_mode_off_when_thinking_disabled():
@@ -123,6 +156,17 @@ def test_prefill_mode_off_for_reasoning_effort_none():
         _sf_reasoning_prefill_mode(_ETHINK_EFFORT, None, _THINK_TPL, reasoning_effort = "high")
         is True
     )
+
+
+def test_prefill_mode_renders_with_the_requested_reasoning_effort():
+    # Rendering without the request's effort would report the closed shape for both.
+    assert _sf_reasoning_prefill_mode(_ETHINK_EFFORT, None, _EFFORT_SHAPE_TPL, "high") is True
+    assert _sf_reasoning_prefill_mode(_ETHINK_EFFORT, None, _EFFORT_SHAPE_TPL, "low") is False
+
+
+def test_a_template_that_stamps_a_date_still_renders():
+    # Without ``strftime_now`` the render raises and the failure reads as a prefill.
+    assert _sf_reasoning_prefill_mode(_ETHINK, None, _STRFTIME_TPL) is False
 
 
 def test_prefill_mode_off_without_think_markers():
@@ -491,3 +535,59 @@ def test_the_eager_import_under_the_stubs_actually_succeeded():
         f"not for anything transformers probes with importlib.util.find_spec)."
     )
     assert "core.inference.inference" in sys.modules
+
+
+def _sf_route_message(monkeypatch, template, snapshots, **body):
+    """POST a non-streaming safetensors chat completion and return the assistant message."""
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    import routes.inference as inference_route
+    from auth.authentication import get_current_subject
+    from utils.api_errors import install_api_error_handlers
+
+    class _NoGGUF:
+        is_loaded = False
+        supports_tools = False
+
+    class _Safetensors:
+        active_model_name = "qwen"
+        models = {"qwen": {"chat_template_info": {"template": template}}}
+
+        def generate_chat_response(self, **kwargs):
+            yield from snapshots
+
+        def reset_generation_state(self, *_args):
+            return None
+
+    monkeypatch.setattr(
+        inference_route,
+        "_detect_safetensors_features",
+        lambda backend, chat_template, tools = None: dict(_ETHINK, supports_tools = False),
+    )
+    monkeypatch.setattr(inference_route, "get_llama_cpp_backend", lambda: _NoGGUF())
+    monkeypatch.setattr(inference_route, "get_inference_backend", lambda: _Safetensors())
+
+    app = FastAPI()
+    app.include_router(inference_route.router, prefix = "/v1")
+    install_api_error_handlers(app)
+    app.dependency_overrides[get_current_subject] = lambda: "test-user"
+    resp = TestClient(app).post(
+        "/v1/chat/completions",
+        json = {
+            "messages": [{"role": "user", "content": "hi"}],
+            "stream": False,
+            **body,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()["choices"][0]["message"]
+
+
+def test_route_returns_the_answer_as_content_when_the_template_closes_its_block(monkeypatch):
+    """The user-visible symptom: a plain answer reaching ``content``, not the thinking drawer."""
+    # generate_chat_response yields cumulative text snapshots, not events.
+    snapshots = ["The capital", "The capital of Japan is Tokyo."]
+    message = _sf_route_message(monkeypatch, _TEMPLATE_DEFAULT_OFF_TPL, snapshots)
+    assert message["content"] == "The capital of Japan is Tokyo."
+    assert not message["reasoning_content"]


### PR DESCRIPTION
## The bug

A default chat completion against an MLX (safetensors) reasoning model comes back blank. `choices[0].message.content` is `""` and the entire answer sits in `reasoning_content`, so every OpenAI-compatible client — which reads `content` and nothing else — shows an empty reply.

Reproduced against a served `Qwen3.5-0.8B` on six ordinary prompts, none of which asked for reasoning:

```text
before:  6/6 requests returned content="" (answer in reasoning_content)
after:   0/6 requests returned content=""
```

## Root cause

The renderer and the reasoning extractor disagreed about the shape of the prompt.

`apply_chat_template_for_generation` omits `enable_thinking` entirely when the request does not set one, which is deliberate: it lets each chat template state its own default. Qwen3.5-0.8B's template then renders a **closed** `<think>\n\n</think>\n\n` into the generation prompt, so the model starts outside the reasoning block and never emits a `</think>`.

`_sf_reasoning_prefill_mode`, which tells the streaming extractor whether generation begins inside an unclosed `<think>`, ended in an unconditional `return True`. With no closing tag ever arriving, the extractor stayed in reasoning mode for the whole generation and captured the plain answer as reasoning.

## What changed

`_sf_reasoning_prefill_mode` now renders the template's own generation prompt — with the same reasoning kwargs the real request will render with, `None` omitted exactly as the renderer omits it — and reports whether that prompt ends inside an unclosed `<think>`. Both sides now read one source instead of one guessing about the other.

All existing gates above that decision are untouched: models whose reasoning uses bespoke markers rather than `<think>`/`</think>` (gemma's `<|think|>`), gpt-oss, and explicitly thinking-disabled requests still return `False` before the probe runs.

Two supporting details:

- The probe's Jinja sandbox exposes `strftime_now`, which transformers gives every chat template. Without it, a template that stamps a date raises inside the probe and the failure is misread as "prefilled".
- The render is memoised on the template text and reasoning kwargs. It costs ~10ms on a production-sized template and runs more than once per request. Only the `<think>` shape is read back from it, and no known template varies that by date, so a date-stamping template safely keeps its first render.

## Why it is measured rather than assumed

The template's default varies **within** a single model family, so no blanket rule is correct. Surveying 63 cached chat templates:

- `Qwen3.5-0.8B`, `Qwen3.5-2B`, MiniCPM-V — generation prompt closes the block; these were the broken ones and now return their answer as `content`.
- `Qwen3.5-4B` and larger, `Qwen3.6-*`, `Qwen3.8-*`, QwQ, the `*-Thinking-*` variants — generation prompt opens the block; these must stay prefilled and do.
- `Qwen3` — opens no block at all; the model emits its own `<think>...</think>` pair and the extractor handles it as before.

A "default thinking off" shortcut would have broken the entire second group.

## GGUF parity

The behavior was checked against the llama.cpp backend using the GGUF twin of the same model, since llama.cpp is the reference for this API surface. Streaming matched non-streaming on every row.

| request | llama.cpp (GGUF) | MLX after this change |
|---|---|---|
| default | `content` 542 chars, `reasoning_content` empty | `content` 161 chars, `reasoning_content` empty |
| thinking on, block closed | `content` 33, `reasoning_content` 637 | splits at `</think>` the same way |
| thinking on, block never closed | `content` `""`, `reasoning_content` 49922 | `content` `""`, `reasoning_content` 8142 |
| thinking on, truncated mid-block | `content` `""`, `reasoning_content` 168 | `content` `""`, `reasoning_content` 150 |

The last two rows are the reason this change does **not** promote unterminated reasoning into `content`: llama.cpp leaves `content` empty there, and matching it keeps the two backends interchangeable for clients.

## Validation

- Focused suite over the studio backend: 2889 passed, 4 skipped.
- Each added test was mutation-checked — reverting the production change fails exactly that test and no other.
- Live server, `Qwen3.5-0.8B` safetensors: 6/6 blank replies before, 0/6 after; explicit thinking-on still yields reasoning-only output; streaming, tool calls, and `/v1/models` unaffected.
