### PR TITLE
Cache the .deb set webkit needs, so a dead mirror costs a miss not a shard

### DIFF
--- a/.github/workflows/studio-ui-smoke.yml
+++ b/.github/workflows/studio-ui-smoke.yml
@@ -257,6 +257,32 @@ jobs:
           path: ~/.cache/ms-playwright
           key: ms-playwright-${{ runner.os }}-${{ steps.pw.outputs.version }}-${{ matrix.engine_key }}-v2
 
+      - name: Restore the apt archive cache (webkit's .deb set)
+        id: apt-cache
+        # The browser cache above holds the ENGINES. This holds the .deb files their
+        # system libraries come from, which is a different 102 MB and the one that has
+        # actually been taking jobs down:
+        #
+        #   0 upgraded, 181 newly installed
+        #   Need to get 102 MB/114 MB of archives
+        #   Get:2 .../fonts-wqy-zenhei [7472 kB]   -> 4m51s, then the attempt died
+        #
+        # #9283 removed that cost from the two chromium-only shards by not asking for
+        # webkit at all. The shards that genuinely drive webkit still pay it, so this is
+        # the other half: pay the download once on main, and let a degraded mirror cost
+        # a cache miss rather than a shard.
+        #
+        # Keyed on the runner image as well as the engine set, because which .deb
+        # versions satisfy a dependency set is a property of the image. A key that
+        # ignored it would offer noble packages to a future image; apt would reject them
+        # against its index and re-fetch, so the failure is a slow no-op rather than a
+        # wrong install -- but a silent one, and this is cheaper than finding out.
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        continue-on-error: true
+        with:
+          path: ${{ github.workspace }}/.apt-archives
+          key: apt-archives-${{ runner.os }}-${{ env.ImageOS }}-${{ env.ImageVersion }}-${{ matrix.engine_key }}-v1
+
       - name: Install Playwright browsers
         id: pw-install
         # --with-deps stays unconditional: the apt side installs system libraries OUTSIDE
@@ -347,8 +373,21 @@ jobs:
             echo "::notice::skipped playwright install-deps; the runner image already has the libraries"
           else
             echo "system libraries are missing, installing them"
+            # Hand apt last run's .debs before it goes looking for them. apt checks each
+            # file against its index and re-fetches only what does not match, so a stale
+            # cache costs a download rather than a wrong install.
+            if [ -d "${{ github.workspace }}/.apt-archives" ]; then
+              sudo cp "${{ github.workspace }}"/.apt-archives/*.deb /var/cache/apt/archives/ 2>/dev/null || true
+              echo "seeded $(ls "${{ github.workspace }}"/.apt-archives/*.deb 2>/dev/null | wc -l) cached .deb files"
+            fi
             bash .github/scripts/retry-with-apt-lock.sh \
               python -m playwright install-deps ${{ matrix.engines }}
+            # Harvest for next time. apt keeps what it installed in the archive dir until
+            # something runs `apt-get clean`, so this is exactly what it just used --
+            # seeded or downloaded, and only the packages this engine set needs.
+            mkdir -p "${{ github.workspace }}/.apt-archives"
+            sudo cp /var/cache/apt/archives/*.deb "${{ github.workspace }}/.apt-archives/" 2>/dev/null || true
+            sudo chown -R "$(id -u):$(id -g)" "${{ github.workspace }}/.apt-archives" || true
             # Fail loudly rather than proceeding into suites that cannot launch a
             # browser: without this the real error surfaces later as an opaque
             # per-test timeout in whichever suite happens to run first.
@@ -372,6 +411,19 @@ jobs:
       #
       # always() stays, so an unrelated earlier failure does not throw away browsers
       # that did download; the outcome check is what narrows it to this step.
+      - name: Save the apt archive cache
+        # main only, same rule as every other cache here: a PR-ref entry can only be
+        # restored by re-runs of that same PR while still counting against the shared
+        # budget, evicting the copy every PR can read.
+        if: >-
+          github.ref == 'refs/heads/main'
+          && steps.apt-cache.outputs.cache-hit != 'true'
+        continue-on-error: true
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: ${{ github.workspace }}/.apt-archives
+          key: ${{ steps.apt-cache.outputs.cache-primary-key }}
+
       - name: Save the Playwright browser cache
         if: >-
           always() && github.ref == 'refs/heads/main'
@@ -805,6 +857,32 @@ jobs:
           path: ~/.cache/ms-playwright
           key: ms-playwright-${{ runner.os }}-${{ steps.pw.outputs.version }}-cfw-v1
 
+      - name: Restore the apt archive cache (webkit's .deb set)
+        id: apt-cache
+        # The browser cache above holds the ENGINES. This holds the .deb files their
+        # system libraries come from, which is a different 102 MB and the one that has
+        # actually been taking jobs down:
+        #
+        #   0 upgraded, 181 newly installed
+        #   Need to get 102 MB/114 MB of archives
+        #   Get:2 .../fonts-wqy-zenhei [7472 kB]   -> 4m51s, then the attempt died
+        #
+        # #9283 removed that cost from the two chromium-only shards by not asking for
+        # webkit at all. The shards that genuinely drive webkit still pay it, so this is
+        # the other half: pay the download once on main, and let a degraded mirror cost
+        # a cache miss rather than a shard.
+        #
+        # Keyed on the runner image as well as the engine set, because which .deb
+        # versions satisfy a dependency set is a property of the image. A key that
+        # ignored it would offer noble packages to a future image; apt would reject them
+        # against its index and re-fetch, so the failure is a slow no-op rather than a
+        # wrong install -- but a silent one, and this is cheaper than finding out.
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        continue-on-error: true
+        with:
+          path: ${{ github.workspace }}/.apt-archives
+          key: apt-archives-${{ runner.os }}-${{ env.ImageOS }}-${{ env.ImageVersion }}-cfw-v1
+
       - name: Install Playwright browsers
         id: pw-install
         # --with-deps stays unconditional: the apt side installs system libraries OUTSIDE
@@ -895,8 +973,21 @@ jobs:
             echo "::notice::skipped playwright install-deps; the runner image already has the libraries"
           else
             echo "system libraries are missing, installing them"
+            # Hand apt last run's .debs before it goes looking for them. apt checks each
+            # file against its index and re-fetches only what does not match, so a stale
+            # cache costs a download rather than a wrong install.
+            if [ -d "${{ github.workspace }}/.apt-archives" ]; then
+              sudo cp "${{ github.workspace }}"/.apt-archives/*.deb /var/cache/apt/archives/ 2>/dev/null || true
+              echo "seeded $(ls "${{ github.workspace }}"/.apt-archives/*.deb 2>/dev/null | wc -l) cached .deb files"
+            fi
             bash .github/scripts/retry-with-apt-lock.sh \
               python -m playwright install-deps chromium firefox webkit
+            # Harvest for next time. apt keeps what it installed in the archive dir until
+            # something runs `apt-get clean`, so this is exactly what it just used --
+            # seeded or downloaded, and only the packages this engine set needs.
+            mkdir -p "${{ github.workspace }}/.apt-archives"
+            sudo cp /var/cache/apt/archives/*.deb "${{ github.workspace }}/.apt-archives/" 2>/dev/null || true
+            sudo chown -R "$(id -u):$(id -g)" "${{ github.workspace }}/.apt-archives" || true
             # Fail loudly rather than proceeding into suites that cannot launch a
             # browser: without this the real error surfaces later as an opaque
             # per-test timeout in whichever suite happens to run first.
@@ -920,6 +1011,19 @@ jobs:
       #
       # always() stays, so an unrelated earlier failure does not throw away browsers
       # that did download; the outcome check is what narrows it to this step.
+      - name: Save the apt archive cache
+        # main only, same rule as every other cache here: a PR-ref entry can only be
+        # restored by re-runs of that same PR while still counting against the shared
+        # budget, evicting the copy every PR can read.
+        if: >-
+          github.ref == 'refs/heads/main'
+          && steps.apt-cache.outputs.cache-hit != 'true'
+        continue-on-error: true
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: ${{ github.workspace }}/.apt-archives
+          key: ${{ steps.apt-cache.outputs.cache-primary-key }}
+
       - name: Save the Playwright browser cache
         if: >-
           always() && github.ref == 'refs/heads/main'

--- a/tests/studio/test_ui_shard_engines.py
+++ b/tests/studio/test_ui_shard_engines.py
@@ -61,6 +61,12 @@ def _engines_driven_by(shard: str) -> set[str]:
     for step in _doc()["jobs"]["ui-smoke"]["steps"]:
         run = step.get("run") or ""
         name = step.get("name") or ""
+        # Only steps that RUN something can drive a browser. A `uses:` step cannot, and
+        # reading their names produced a false positive the first time one mentioned an
+        # engine: the apt archive cache is named for the .deb set it holds, which is
+        # webkit's, and that made two chromium-only shards look like webkit users.
+        if not run:
+            continue
         if "playwright install" in run or "probe " in run:
             continue
         cond = str(step.get("if") or "")


### PR DESCRIPTION
#9283 stopped two of the four Chat UI shards asking for webkit's system
libraries at all, which is why extra and picker went from 14 minutes failing to
under 6 passing. The shards that genuinely drive webkit -- chat, banner and the
cross-browser indicator -- still pay the full price, and it is still the thing
taking them down:

  0 upgraded, 181 newly installed
  Need to get 102 MB/114 MB of archives
  Get:2 .../fonts-wqy-zenhei [7472 kB]   -> 4m51s, then the attempt died

Seen again today on a staging chat shard, after every other apt lever in this
repo had already been pulled. Bounding the wait cannot help: the work is a real
102 MB and the mirror was delivering 7 MB in five minutes.

So stop re-downloading it. apt keeps what it installed in /var/cache/apt/archives
until something runs `apt-get clean`, so the .debs are already sitting there at
the end of a good run. This copies them out, caches them on main, and copies them
back in before install-deps on later runs. apt checks each file against its index
and re-fetches only what does not match, so a stale entry costs a download rather
than a wrong install -- the failure mode is slow, not incorrect.

Keyed on the runner image as well as the engine set, because which .deb versions
satisfy a dependency set is a property of the image. Saved on main only, the same
rule as every other cache here: a PR-ref entry can only be restored by re-runs of
that same PR while still counting against the shared budget.

The engine guard from #9283 caught this change, which is the second time it has
earned its place. Its detector read step NAMES as well as run bodies, and this
step is named for the .deb set it holds -- webkit's -- so two chromium-only
shards suddenly looked like webkit users. Fixed in the detector rather than by
renaming the step: a `uses:` step cannot drive a browser, so only steps that run
something should count.