### PR TITLE
Scroll into view before a forced click

### DIFF
--- a/studio/backend/tests/test_metal_explicit_context_guard.py
+++ b/studio/backend/tests/test_metal_explicit_context_guard.py
@@ -603,17 +603,13 @@ class TestAContextAboveTheModelsNativeLength:
         published = out["backend"].max_context_length
         assert published == loaded
 
-    def test_the_published_bound_never_runs_ahead_of_the_request(
-        self, tmp_path, monkeypatch
-    ):
+    def test_the_published_bound_never_runs_ahead_of_the_request(self, tmp_path, monkeypatch):
         """The fit is bounded by the request, so the bound may rise to the context that
         loaded and no further. A bound past it would invite a context nothing priced."""
         out = self._above(tmp_path, monkeypatch, n_ctx = self._ASKED, kv_per_token = 1024)
         assert out["backend"].max_context_length <= self._ASKED
 
-    def test_a_refused_request_does_not_raise_the_published_bound(
-        self, tmp_path, monkeypatch
-    ):
+    def test_a_refused_request_does_not_raise_the_published_bound(self, tmp_path, monkeypatch):
         """Only an accepted ceiling is published. A refusal measured nothing it can
         stand behind at the request, so the bound stays where the cap left it."""
         with pytest.raises(RuntimeError, match = "unified"):

--- a/tests/studio/_playwright_robust.py
+++ b/tests/studio/_playwright_robust.py
@@ -760,3 +760,35 @@ def install_wall_clock_watchdog(
     if info is not None:
         info(f"watchdog armed: hard-exit at {deadline_s:.0f}s")
     return timer
+
+
+def click_forced(locator: Any, *, timeout_ms: int = 5_000, **click_kwargs: Any) -> None:
+    """Scroll into view, then click with actionability checks off.
+
+    `click(force = True)` skips Playwright's actionability checks, which is what you
+    want against a menu whose overlay would otherwise intercept the click. It also
+    skips the part that scrolls the element into view, and Playwright will not click
+    a point it cannot reach:
+
+        playwright._impl._errors.Error: Locator.click: Element is outside of the viewport
+
+    That is what took down `Compare tab: send to two panes` on macOS. The menu item
+    existed, was found, and was off-screen, because a Mac runner's window is shorter
+    than a Linux one and the item sits at the bottom of a long menu. On Linux the same
+    code has always worked, which is why three forced clicks sat here unnoticed since
+    the composer redesign.
+
+    Scrolling first keeps the reason force was used -- the overlay is still ignored --
+    and removes the assumption that the element happens to be on screen.
+
+    The scroll is best-effort: an element that cannot be scrolled (fixed position, zero
+    size) should still reach the click, and fail there with Playwright's own message
+    rather than here with a scrolling one.
+    """
+    try:
+        locator.scroll_into_view_if_needed(timeout = timeout_ms)
+    except Exception:
+        pass
+    # Callers pass their own `timeout` through: several of these clicks wait longer
+    # than the default because the tab they open is doing work behind the overlay.
+    locator.click(force = True, **click_kwargs)

--- a/tests/studio/_playwright_robust.py
+++ b/tests/studio/_playwright_robust.py
@@ -762,7 +762,12 @@ def install_wall_clock_watchdog(
     return timer
 
 
-def click_forced(locator: Any, *, timeout_ms: int = 5_000, **click_kwargs: Any) -> None:
+def click_forced(
+    locator: Any,
+    *,
+    timeout_ms: int = 5_000,
+    **click_kwargs: Any,
+) -> None:
     """Scroll into view, then click with actionability checks off.
 
     `click(force = True)` skips Playwright's actionability checks, which is what you

--- a/tests/studio/playwright_chat_ui.py
+++ b/tests/studio/playwright_chat_ui.py
@@ -29,6 +29,7 @@ from _playwright_robust import (  # noqa: E402
     recover_or_replace_page,
     robust_evaluate,
     wait_for_health,
+    click_forced,
 )
 
 BASE = os.environ["BASE_URL"]
@@ -1607,7 +1608,7 @@ with sync_playwright() as p:
             opened = False
             for attempt in range(2):
                 try:
-                    acct.click(force = True)
+                    click_forced(acct)
                 except Exception as exc:
                     if attempt == 1:
                         soft_fail(f"theme cycle {cycle + 1}: account-menu click failed ({exc!r})")
@@ -1641,10 +1642,10 @@ with sync_playwright() as p:
             for click_attempt in range(3):
                 try:
                     if click_attempt == 0:
-                        theme_item.click(force = True, timeout = 3_000)
+                        click_forced(theme_item, timeout = 3_000)
                     elif click_attempt == 1:
                         theme_item.scroll_into_view_if_needed(timeout = 2_000)
-                        theme_item.click(force = True, timeout = 3_000)
+                        click_forced(theme_item, timeout = 3_000)
                     else:
                         theme_item.evaluate("el => el.click()")
                     click_err = None
@@ -1739,7 +1740,7 @@ with sync_playwright() as p:
                 page.wait_for_timeout(500)
                 item = page.get_by_role("menuitem", name = re.compile(label, re.I)).first
                 if item.count() == 0:
-                    more_btn.click(force = True)
+                    click_forced(more_btn)
                     page.wait_for_timeout(500)
                     item = page.get_by_role("menuitem", name = re.compile(label, re.I)).first
                 if item.count() > 0:
@@ -1752,7 +1753,7 @@ with sync_playwright() as p:
         # though the button is visible + enabled (belt-and-suspenders
         # atop the startViewTransition neutraliser).
         try:
-            btn.click(force = True, timeout = 5_000)
+            click_forced(btn, timeout = 5_000)
         except Exception as exc:
             soft_fail(f"nav '{label}' click failed: {exc!r}")
             return False
@@ -1770,7 +1771,7 @@ with sync_playwright() as p:
     # Compare moved into the composer "Tools and attachments" menu.
     plus_btn = page.get_by_role("button", name = re.compile(r"Tools and attachments", re.I)).first
     if plus_btn.count() > 0:
-        plus_btn.click(force = True)
+        click_forced(plus_btn)
         page.wait_for_timeout(400)
         compare_item = page.get_by_role("menuitem", name = re.compile(r"Compare chat", re.I)).first
         if compare_item.count() == 0:
@@ -1784,13 +1785,13 @@ with sync_playwright() as p:
                     "menuitem", name = re.compile(r"Compare chat", re.I)
                 ).first
                 if compare_item.count() == 0:
-                    more_trigger.click(force = True)
+                    click_forced(more_trigger)
                     page.wait_for_timeout(400)
                     compare_item = page.get_by_role(
                         "menuitem", name = re.compile(r"Compare chat", re.I)
                     ).first
         if compare_item.count() > 0:
-            compare_item.click(force = True)
+            click_forced(compare_item)
             page.wait_for_timeout(800)
             if not re.search(r"/chat\?", page.url):
                 soft_fail(f"'Compare chat' didn't open compare; current: {page.url}")

--- a/tests/studio/playwright_extra_ui.py
+++ b/tests/studio/playwright_extra_ui.py
@@ -27,6 +27,7 @@ from _playwright_robust import (  # noqa: E402
     robust_evaluate,
     wait_for_first,
     wait_for_health,
+    click_forced,
 )
 
 BASE = os.environ["BASE_URL"]
@@ -404,7 +405,7 @@ with sync_playwright() as p:
         page.get_by_role("button", name = re.compile(r"Tools and attachments", re.I))
     )
     if plus_btn is not None:
-        plus_btn.click(force = True)
+        click_forced(plus_btn)
         # The menu items get a short wait rather than the full one: a miss here is
         # a real branch (the item lives under "More"), not a slow render, and the
         # fallbacks below must stay quick.
@@ -425,13 +426,13 @@ with sync_playwright() as p:
                     timeout_ms = 2000,
                 )
                 if compare_item is None:
-                    more_trigger.click(force = True)
+                    click_forced(more_trigger)
                     compare_item = wait_for_first(
                         page.get_by_role("menuitem", name = re.compile(r"Compare chat", re.I)),
                         timeout_ms = 2000,
                     )
         if compare_item is not None:
-            compare_item.click(force = True)
+            click_forced(compare_item)
             compare_opened = True
     if not compare_opened:
         # Which of the two was missing, because "Compare nav not found" sent the

--- a/tests/studio/playwright_settings_tabs.py
+++ b/tests/studio/playwright_settings_tabs.py
@@ -27,6 +27,7 @@ from _playwright_robust import (  # noqa: E402
     chromium_launch_args,
     start_vite,
     stop_process,
+    click_forced,
 )
 
 TABS = [
@@ -134,7 +135,7 @@ def settle_panel(page, timeout_s: float = SETTLE_TIMEOUT_S) -> dict:
 def click_tab_and_observe(page, tab: str) -> dict:
     """Click a tab; record how long the panel keeps the old content and whether it blanks."""
     before = snapshot(page)
-    page.locator(f'[data-testid="settings-tab-{tab}"]').click(force = True, timeout = 15000)
+    click_forced(page.locator(f'[data-testid="settings-tab-{tab}"]'), timeout = 15000)
     started = time.time()
     changed_ms = None
     blank_frames = 0
@@ -272,9 +273,9 @@ def run_chunk_fail(page) -> None:
     """One panel's module is blocked. The dialog must survive it, and so must the app."""
     open_dialog(page)
     settle_panel(page)
-    page.locator('[data-testid="settings-tab-general"]').click(force = True, timeout = 15000)
+    click_forced(page.locator('[data-testid="settings-tab-general"]'), timeout = 15000)
     settle_panel(page)
-    page.locator(f'[data-testid="settings-tab-{CHUNK_FAIL}"]').click(force = True, timeout = 15000)
+    click_forced(page.locator(f'[data-testid="settings-tab-{CHUNK_FAIL}"]'), timeout = 15000)
     page.wait_for_timeout(3000)
     state = page.evaluate(
         """() => ({
@@ -309,7 +310,7 @@ def run_chunk_fail(page) -> None:
     else:
         log("the dialog and its twelve nav entries survived")
     # Another tab must still work.
-    page.locator('[data-testid="settings-tab-about"]').click(force = True, timeout = 15000)
+    click_forced(page.locator('[data-testid="settings-tab-about"]'), timeout = 15000)
     after = settle_panel(page)
     report["chunk_fail_recovery"] = after
     if not after.get("present") or after.get("elements", 0) < 5:
@@ -329,7 +330,7 @@ def run(page) -> None:
     open_dialog(page)
     settle_panel(page)
     # Start off the persisted tab, so the first iteration is a real switch.
-    page.locator('[data-testid="settings-tab-about"]').click(force = True, timeout = 15000)
+    click_forced(page.locator('[data-testid="settings-tab-about"]'), timeout = 15000)
     settle_panel(page)
     for tab in TABS:
         obs = click_tab_and_observe(page, tab)
@@ -390,7 +391,7 @@ def run(page) -> None:
     if index is None:
         fail(f"search '{query}': '{target_label}' not among results {texts}")
     else:
-        entries.nth(index).click(force = True)
+        click_forced(entries.nth(index))
         flashed = None
         deadline = time.time() + 15
         while time.time() < deadline:

--- a/tests/studio/test_click_forced.py
+++ b/tests/studio/test_click_forced.py
@@ -1,0 +1,111 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+"""
+A forced click has to scroll first, or it clicks a point that is not on screen.
+
+`click(force = True)` turns off actionability checks, which is the point when a menu
+overlay would otherwise intercept the click. It also turns off the scroll that puts
+the element in the viewport, and Playwright refuses a point it cannot reach:
+
+    Locator.click: Element is outside of the viewport
+
+That failed `Compare tab: send to two panes` on macOS. The menu item existed and was
+found; it was simply below the fold, because a Mac runner's window is shorter than a
+Linux one and the item sits at the bottom of a long menu. The same three forced
+clicks have been in playwright_extra_ui.py since the composer redesign and have
+always worked on Linux, which is why nothing caught it until the Compare nav started
+being found reliably enough for the click to run at all.
+
+Driven against a fake locator rather than a browser: these run on browserless CI
+lanes, and the ordering is the whole contract, so a stand-in that records call order
+tests it exactly.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _playwright_robust import click_forced  # noqa: E402
+
+
+class _FakeLocator:
+    def __init__(self, *, scroll_raises: Exception | None = None):
+        self.calls: list[str] = []
+        self._scroll_raises = scroll_raises
+        self.click_kwargs: dict | None = None
+
+    def scroll_into_view_if_needed(self, timeout = None):
+        self.calls.append("scroll")
+        if self._scroll_raises is not None:
+            raise self._scroll_raises
+
+    def click(self, **kwargs):
+        self.calls.append("click")
+        self.click_kwargs = kwargs
+
+
+def test_it_scrolls_before_clicking() -> None:
+    loc = _FakeLocator()
+    click_forced(loc)
+    assert loc.calls == ["scroll", "click"], (
+        f"expected a scroll then a click, got {loc.calls}. Clicking first is the bug: "
+        f"the element is off-screen at that moment."
+    )
+
+
+def test_the_click_is_still_forced() -> None:
+    """Dropping force would reintroduce the overlay interception it was added for."""
+    loc = _FakeLocator()
+    click_forced(loc)
+    assert loc.click_kwargs == {"force": True}, (
+        f"click was called with {loc.click_kwargs}; force must stay, because the menu "
+        f"overlay is why these call sites bypass actionability in the first place"
+    )
+
+
+def test_a_scroll_that_fails_does_not_stop_the_click() -> None:
+    """
+    An element that cannot be scrolled -- fixed position, zero size -- should still
+    reach the click and fail there with Playwright's own message, rather than here
+    with a scrolling one that names the wrong problem.
+    """
+    loc = _FakeLocator(scroll_raises = RuntimeError("no scrollable ancestor"))
+    click_forced(loc)
+    assert loc.calls == ["scroll", "click"]
+
+
+def test_a_failing_click_still_propagates() -> None:
+    """The helper must not swallow the thing it exists to report."""
+
+    class _Boom(_FakeLocator):
+        def click(self, **kwargs):
+            self.calls.append("click")
+            raise RuntimeError("Element is outside of the viewport")
+
+    loc = _Boom()
+    with pytest.raises(RuntimeError, match = "outside of the viewport"):
+        click_forced(loc)
+
+
+def test_every_forced_click_in_the_suite_goes_through_the_helper() -> None:
+    """
+    The helper is only worth having if nothing bypasses it. A bare
+    `click(force = True)` is the exact shape that broke, so it fails here rather than
+    on a Mac runner twenty minutes into a job.
+    """
+    here = Path(__file__).resolve().parent
+    offenders = []
+    for path in sorted(here.glob("playwright_*.py")):
+        for i, line in enumerate(path.read_text(encoding = "utf-8").splitlines(), 1):
+            if "click(force" in line and "def " not in line:
+                offenders.append(f"{path.name}:{i}")
+    assert not offenders, (
+        f"these call sites force a click without scrolling into view first: {offenders}. "
+        f"Use click_forced from _playwright_robust, which keeps force and adds the "
+        f"scroll that force turns off."
+    )


### PR DESCRIPTION
`Compare tab: send to two panes` failed on a macOS runner with

    Locator.click: Element is outside of the viewport

then a cascade of TargetClosedError as the browser came down behind it. The menu
item existed and was found. It was simply below the fold: a Mac runner's window
is shorter than a Linux one and Compare sits at the bottom of a long menu.

`click(force = True)` turns off actionability checks, which is exactly what these
call sites want against a menu whose overlay would otherwise intercept the click.
It also turns off the scroll that brings the element into the viewport, and
Playwright will not click a point it cannot reach. So the flag was doing two
things and only one of them was wanted.

The forced clicks are not new -- they arrived with the composer redesign in #5891
and have always worked on Linux. What changed is #9264, which made the Compare nav
be found reliably instead of sampled for: before that the step often gave up
earlier with "Compare nav not found" and never reached the click. That PR is
correct; it surfaced this rather than causing it, the same way #9283 was going to
surface the picker's context-pin assertion once the shard stopped dying in apt.

click_forced keeps force and adds the scroll back. The scroll is best effort: an
element that cannot be scrolled -- fixed position, zero size -- should still reach
the click and fail there with Playwright's own message, rather than here with a
scrolling one that names the wrong problem.

Applied to all 17 forced clicks across the three drivers, not just the one that
failed. They are the same hazard on the same runners, and the guard would be
worth little if the file it was written for were the only one obeying it. The
guard is a source scan for the bare shape, so a new one fails here rather than
twenty minutes into a Mac job.

Driven against a fake locator: these tests run on browserless lanes, and the
ordering is the whole contract, so a stand-in that records call order tests it
exactly -- scroll before click, force preserved, a failing scroll not swallowing
the click, and a failing click still propagating.