### PR TITLE
fix(studio): coerce tool-call arguments before replaying to custom endpoints (#9039)

### DIFF
--- a/studio/backend/core/inference/external_provider.py
+++ b/studio/backend/core/inference/external_provider.py
@@ -1080,7 +1080,11 @@ class ExternalProviderClient:
                 neutralize_tool_descriptions,
                 reconciled_tool_choice,
             )
-            messages = neutralize_control_markup_in_messages(messages)
+            from core.inference.tool_loop_controller import coerce_messages_tool_calls_for_wire
+
+            messages = coerce_messages_tool_calls_for_wire(
+                neutralize_control_markup_in_messages(messages)
+            )
             if tools:
                 safe_tools = neutralize_tool_descriptions(tools)
                 # A mixed catalog keeps safe_tools non-empty while dropping the one tool the

--- a/studio/backend/core/inference/studio_tool_loop.py
+++ b/studio/backend/core/inference/studio_tool_loop.py
@@ -255,10 +255,13 @@ def _normalized_call(call: dict[str, Any], fallback_id: str = "") -> dict[str, A
         parsed = {"_raw": arguments}
     if not isinstance(parsed, dict):
         parsed = {"value": parsed}
+    from core.inference.tool_loop_controller import coerce_tool_call_replay_arguments
+
+    wire_arguments = coerce_tool_call_replay_arguments(arguments, parsed)
     normalized: dict[str, Any] = {
         "id": call_id,
         "type": "function",
-        "function": {"name": name, "arguments": arguments or "{}"},
+        "function": {"name": name, "arguments": wire_arguments},
         "arguments": parsed,
     }
     extra = call.get("extra_content")

--- a/studio/backend/core/inference/tool_loop_controller.py
+++ b/studio/backend/core/inference/tool_loop_controller.py
@@ -175,10 +175,7 @@ def canonical_tool_call_key(tool_name: str, arguments: Mapping[str, Any]) -> str
     return f"{tool_name}:{canonical_args}"
 
 
-def coerce_tool_call_replay_arguments(
-    args_text: Any,
-    structured_args: Any = None,
-) -> str:
+def coerce_tool_call_replay_arguments(args_text: Any, structured_args: Any = None) -> str:
     """Return OpenAI-wire ``function.arguments`` JSON text safe to replay upstream.
 
     Mirrors the frontend ``toolCallReplayArguments`` helper: prefer the streamed

--- a/studio/backend/core/inference/tool_loop_controller.py
+++ b/studio/backend/core/inference/tool_loop_controller.py
@@ -175,6 +175,97 @@ def canonical_tool_call_key(tool_name: str, arguments: Mapping[str, Any]) -> str
     return f"{tool_name}:{canonical_args}"
 
 
+def coerce_tool_call_replay_arguments(
+    args_text: Any,
+    structured_args: Any = None,
+) -> str:
+    """Return OpenAI-wire ``function.arguments`` JSON text safe to replay upstream.
+
+    Mirrors the frontend ``toolCallReplayArguments`` helper: prefer the streamed
+    text when it parses, otherwise fall back to the structured args the loop
+    already decoded. Unparseable wire text poisons every follow-up request on
+    strict OpenAI-compatible servers (custom vLLM / llama.cpp endpoints, #9039).
+    """
+    if isinstance(args_text, str) and args_text:
+        try:
+            json.loads(args_text)
+            return args_text
+        except (json.JSONDecodeError, ValueError, TypeError):
+            pass
+    if isinstance(args_text, Mapping):
+        return json.dumps(
+            dict(args_text),
+            ensure_ascii = False,
+            sort_keys = True,
+            separators = (",", ":"),
+            default = _json_default,
+        )
+    if structured_args is not None:
+        if isinstance(structured_args, Mapping):
+            payload: Any = dict(structured_args)
+        else:
+            payload = structured_args
+        return json.dumps(
+            payload,
+            ensure_ascii = False,
+            sort_keys = True,
+            separators = (",", ":"),
+            default = _json_default,
+        )
+    if isinstance(args_text, str) and args_text:
+        return json.dumps({"_raw": args_text}, ensure_ascii = False, separators = (",", ":"))
+    return "{}"
+
+
+def coerce_tool_call_for_wire(call: dict[str, Any]) -> dict[str, Any]:
+    """Normalize one assistant ``tool_calls[]`` entry to OpenAI wire shape."""
+    if not isinstance(call, dict):
+        return call
+    structured = call.get("arguments") if isinstance(call.get("arguments"), Mapping) else None
+    function = call.get("function")
+    if isinstance(function, dict):
+        wire_args = coerce_tool_call_replay_arguments(function.get("arguments"), structured)
+        cleaned = {key: value for key, value in call.items() if key != "arguments"}
+        if function.get("arguments") != wire_args or "arguments" in call:
+            cleaned["function"] = {**function, "arguments": wire_args}
+            return cleaned
+        return call
+    if structured is not None or "arguments" in call:
+        wire_args = coerce_tool_call_replay_arguments(call.get("arguments"), structured)
+        if call.get("arguments") != wire_args:
+            return {**call, "arguments": wire_args}
+    return call
+
+
+def coerce_messages_tool_calls_for_wire(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Ensure every replayed assistant tool call carries parseable JSON arguments."""
+    if not messages:
+        return messages
+    out: list[dict[str, Any]] = []
+    changed = False
+    for message in messages:
+        if not isinstance(message, dict):
+            out.append(message)
+            continue
+        tool_calls = message.get("tool_calls")
+        if not isinstance(tool_calls, list) or not tool_calls:
+            out.append(message)
+            continue
+        new_calls = []
+        message_changed = False
+        for call in tool_calls:
+            coerced = coerce_tool_call_for_wire(call)
+            if coerced is not call:
+                message_changed = True
+            new_calls.append(coerced)
+        if message_changed:
+            out.append({**message, "tool_calls": new_calls})
+            changed = True
+        else:
+            out.append(message)
+    return out if changed else messages
+
+
 def coerce_tool_arguments(
     raw_args: Any,
     *,

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -12285,7 +12285,9 @@ def _build_external_messages(
                 if emit_extra_content and msg.role == "assistant" and msg.extra_content:
                     entry["extra_content"] = msg.extra_content
                 result.append(entry)
-    return result
+    from core.inference.tool_loop_controller import coerce_messages_tool_calls_for_wire
+
+    return coerce_messages_tool_calls_for_wire(result)
 
 
 async def _proxy_to_external_provider(

--- a/studio/backend/tests/test_tool_call_replay_arguments.py
+++ b/studio/backend/tests/test_tool_call_replay_arguments.py
@@ -1,0 +1,120 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Regression for unslothai/unsloth#9039: malformed tool-call arguments must not
+be replayed to custom OpenAI-compatible endpoints."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+import pytest
+
+_backend = os.path.join(os.path.dirname(__file__), "..")
+sys.path.insert(0, _backend)
+
+from core.inference.tool_loop_controller import (  # noqa: E402
+    coerce_messages_tool_calls_for_wire,
+    coerce_tool_call_replay_arguments,
+)
+from routes.inference import _build_external_messages  # noqa: E402
+from models.inference import ChatMessage  # noqa: E402
+
+
+class TestCoerceToolCallReplayArguments:
+    def test_keeps_parsable_streamed_text(self):
+        assert coerce_tool_call_replay_arguments('{"query":"first"}', {"query": "first"}) == (
+            '{"query":"first"}'
+        )
+
+    def test_falls_back_to_structured_args_for_concatenated_fragments(self):
+        raw = '{"query":"first"}{"query":"second"}'
+        assert coerce_tool_call_replay_arguments(
+            raw,
+            {"_raw": raw},
+        ) == json.dumps({"_raw": raw}, separators = (",", ":"))
+
+    def test_stringifies_dict_arguments(self):
+        assert coerce_tool_call_replay_arguments({"query": "x"}) == '{"query":"x"}'
+
+    def test_empty_structured_args_becomes_empty_object(self):
+        assert coerce_tool_call_replay_arguments("", {"query": "first"}) == '{"query":"first"}'
+        assert coerce_tool_call_replay_arguments(None, None) == "{}"
+
+
+class TestCoerceMessagesToolCallsForWire:
+    def test_repairs_malformed_assistant_tool_calls(self):
+        messages = [
+            {"role": "user", "content": "hi"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_a",
+                        "type": "function",
+                        "function": {
+                            "name": "web_search",
+                            "arguments": '{"query":"first"}{"query":"second"}',
+                        },
+                        "arguments": {"_raw": '{"query":"first"}{"query":"second"}'},
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_a",
+                "content": "ok",
+            },
+        ]
+        out = coerce_messages_tool_calls_for_wire(messages)
+        wire = out[1]["tool_calls"][0]["function"]["arguments"]
+        json.loads(wire)
+        assert "arguments" not in out[1]["tool_calls"][0]
+
+    def test_stringifies_dict_function_arguments(self):
+        messages = [
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "id": "call_0",
+                        "type": "function",
+                        "function": {"name": "lookup", "arguments": {"q": "x"}},
+                    }
+                ],
+            }
+        ]
+        out = coerce_messages_tool_calls_for_wire(messages)
+        assert out[0]["tool_calls"][0]["function"]["arguments"] == '{"q":"x"}'
+
+
+class TestBuildExternalMessagesWireShape:
+    def test_custom_endpoint_messages_have_string_arguments(self):
+        built = _build_external_messages(
+            [
+                ChatMessage(
+                    role = "assistant",
+                    content = None,
+                    tool_calls = [
+                        {
+                            "id": "call_0",
+                            "type": "function",
+                            "function": {
+                                "name": "web_search",
+                                "arguments": '{"query":"first"}{"query":"second"}',
+                            },
+                        }
+                    ],
+                ),
+                ChatMessage(role = "tool", tool_call_id = "call_0", content = "ok"),
+            ],
+            supports_vision = False,
+            provider_type = "custom",
+            base_url = "http://127.0.0.1:8000/v1",
+        )
+        args = built[0]["tool_calls"][0]["function"]["arguments"]
+        assert isinstance(args, str)
+        json.loads(args)


### PR DESCRIPTION
## Summary

Fixes [#9039](https://github.com/unslothai/unsloth/issues/9039): tool calling via a custom OpenAI-compatible endpoint no longer poisons the chat history with malformed `tool_calls[].function.arguments`, which caused `invalid_request_error` on every follow-up send.

## Root cause

When Studio proxies to a custom endpoint (vLLM, llama.cpp, etc.) and runs the tool loop, assistant tool-call arguments were replayed verbatim upstream. Two common failure modes:

1. **Concatenated streaming fragments** — delta index restarts produce strings like `'{"query":"first"}{"query":"second"}'` that are not valid JSON.
2. **Dict-shaped arguments** — some clients send `function.arguments` as an object instead of the OpenAI wire-format JSON string.

Strict endpoints reject those with `invalid tool call arguments`. Once that turn is in history, every subsequent request fails and the chat freezes.

The frontend already had `toolCallReplayArguments` (#8754); the backend proxy/tool loop did not.

## Fix

- Add `coerce_tool_call_replay_arguments()` and `coerce_messages_tool_calls_for_wire()` mirroring the frontend helper.
- Apply coercion in:
  - `studio_tool_loop.py` (tool loop replay to external providers)
  - `_build_external_messages()` (outbound messages to custom endpoints)
  - `external_provider.py` (after markup neutralization for template-applying providers)

## Test plan

- [x] `pytest tests/test_tool_call_replay_arguments.py` — new regression coverage for #9039
- [x] `pytest tests/test_tool_loop_controller.py`
- [x] `pytest tests/test_external_tool_truncated_and_budget.py`
- [x] `pytest tests/test_studio_tool_loop.py`