### PR TITLE
Put the managed Node bin dir on PATH when spawning stdio MCP servers

### DIFF
--- a/studio/backend/core/inference/mcp_client.py
+++ b/studio/backend/core/inference/mcp_client.py
@@ -262,6 +262,16 @@ def _is_node_command(command: str) -> bool:
     return _launcher_name(command) in _NODE_COMMANDS
 
 
+def _command_selects_runtime(command: Optional[str]) -> bool:
+    """A path to a ``node`` launcher picks the runtime explicitly and runs regardless of
+    PATH, so handing its children a different Node would only split the two."""
+    return (
+        command is not None
+        and bool(os.path.dirname(command))
+        and _launcher_name(command) == "node"
+    )
+
+
 def _command_needs_npm(command: Optional[str]) -> bool:
     """A direct ``node`` server needs no npm or npx, so requiring them would shadow a
     perfectly good Node its PATH already provides."""
@@ -288,6 +298,8 @@ def _stdio_env(headers: Optional[dict], command: Optional[str] = None) -> Option
         # An explicitly empty PATH is a deliberate sandbox: hand it over untouched.
         return env
     if command is not None and not _is_node_command(command):
+        return env or None
+    if _command_selects_runtime(command):
         return env or None
     if not isinstance(base, str):
         base = os.environ.get("PATH", "")

--- a/studio/backend/core/inference/mcp_client.py
+++ b/studio/backend/core/inference/mcp_client.py
@@ -242,7 +242,22 @@ async def clear_oauth_tokens_async(url: str) -> None:
         logger.warning("Failed to clear OAuth tokens for %s: %s", url, exc)
 
 
-def _stdio_env(headers: Optional[dict]) -> Optional[dict]:
+_NODE_COMMANDS = frozenset({"node", "npm", "npx"})
+_WINDOWS_LAUNCHER_SUFFIXES = (".cmd", ".exe", ".bat", ".ps1")
+
+
+def _is_node_command(command: str) -> bool:
+    """Whether argv[0] is a Node launcher. Only those need the managed runtime, so a
+    Python or other stdio server keeps the toolchain its own env pinned."""
+    name = os.path.basename(command).lower()
+    for suffix in _WINDOWS_LAUNCHER_SUFFIXES:
+        if name.endswith(suffix):
+            name = name[: -len(suffix)]
+            break
+    return name in _NODE_COMMANDS
+
+
+def _stdio_env(headers: Optional[dict], command: Optional[str] = None) -> Optional[dict]:
     """Process env for a stdio server: its own vars, plus the managed Node bin dir
     on PATH so ``npx ...`` servers spawn on hosts with no usable system Node."""
     env = dict(headers or {})
@@ -250,6 +265,8 @@ def _stdio_env(headers: Optional[dict]) -> Optional[dict]:
     if isinstance(base, str) and not base:
         # An explicitly empty PATH is a deliberate sandbox: hand it over untouched.
         return env
+    if command is not None and not _is_node_command(command):
+        return env or None
     if not isinstance(base, str):
         base = os.environ.get("PATH", "")
     try:
@@ -294,7 +311,7 @@ def _client(
             raise ValueError(f"Empty stdio command: {url!r}")
         # env vars ride the headers field (merged over the SDK default env).
         # keep_alive=False tears the subprocess down so a one-shot call leaves no orphan.
-        env = _stdio_env(headers)
+        env = _stdio_env(headers, parts[0])
         argv = _stdio_argv(parts, env)
         return Client(
             StdioTransport(

--- a/studio/backend/core/inference/mcp_client.py
+++ b/studio/backend/core/inference/mcp_client.py
@@ -242,6 +242,7 @@ async def clear_oauth_tokens_async(url: str) -> None:
         logger.warning("Failed to clear OAuth tokens for %s: %s", url, exc)
 
 
+_IS_WINDOWS = os.name == "nt"
 _NODE_COMMANDS = frozenset({"node", "npm", "npx"})
 _WINDOWS_LAUNCHER_SUFFIXES = (".cmd", ".exe", ".bat", ".ps1")
 
@@ -257,11 +258,22 @@ def _is_node_command(command: str) -> bool:
     return name in _NODE_COMMANDS
 
 
+def _path_key(env: dict) -> str:
+    """The key holding PATH. Windows env names are case-insensitive, so a config may
+    spell it ``Path``; on POSIX only the exact name counts."""
+    if _IS_WINDOWS:
+        for key in env:
+            if key.upper() == "PATH":
+                return key
+    return "PATH"
+
+
 def _stdio_env(headers: Optional[dict], command: Optional[str] = None) -> Optional[dict]:
     """Process env for a stdio server: its own vars, plus the managed Node bin dir
     on PATH so ``npx ...`` servers spawn on hosts with no usable system Node."""
     env = dict(headers or {})
-    base = env.get("PATH")
+    key = _path_key(env)
+    base = env.get(key)
     if isinstance(base, str) and not base:
         # An explicitly empty PATH is a deliberate sandbox: hand it over untouched.
         return env
@@ -274,8 +286,8 @@ def _stdio_env(headers: Optional[dict], command: Optional[str] = None) -> Option
         patched = path_with_managed_node(base)
     except (ImportError, OSError, ValueError):
         patched = base
-    if patched and patched != env.get("PATH"):
-        env["PATH"] = patched
+    if patched and patched != env.get(key):
+        env[key] = patched
     return env or None
 
 
@@ -283,7 +295,7 @@ def _stdio_argv(parts: list, env: Optional[dict]) -> list:
     """argv with argv[0] resolved against the child's PATH. Windows resolves the
     command against the parent environment before ``env`` applies, so a managed-only
     ``npx`` has to be handed over as a full path."""
-    path = (env or {}).get("PATH")
+    path = (env or {}).get(_path_key(env or {}))
     if not isinstance(path, str):
         path = os.environ.get("PATH", "")
     try:

--- a/studio/backend/core/inference/mcp_client.py
+++ b/studio/backend/core/inference/mcp_client.py
@@ -247,15 +247,25 @@ _NODE_COMMANDS = frozenset({"node", "npm", "npx"})
 _WINDOWS_LAUNCHER_SUFFIXES = (".cmd", ".exe", ".bat", ".ps1")
 
 
-def _is_node_command(command: str) -> bool:
-    """Whether argv[0] is a Node launcher. Only those need the managed runtime, so a
-    Python or other stdio server keeps the toolchain its own env pinned."""
+def _launcher_name(command: str) -> str:
+    """argv[0] reduced to its bare launcher name, Windows suffix stripped."""
     name = os.path.basename(command).lower()
     for suffix in _WINDOWS_LAUNCHER_SUFFIXES:
         if name.endswith(suffix):
-            name = name[: -len(suffix)]
-            break
-    return name in _NODE_COMMANDS
+            return name[: -len(suffix)]
+    return name
+
+
+def _is_node_command(command: str) -> bool:
+    """Whether argv[0] is a Node launcher. Only those need the managed runtime, so a
+    Python or other stdio server keeps the toolchain its own env pinned."""
+    return _launcher_name(command) in _NODE_COMMANDS
+
+
+def _command_needs_npm(command: Optional[str]) -> bool:
+    """A direct ``node`` server needs no npm or npx, so requiring them would shadow a
+    perfectly good Node its PATH already provides."""
+    return command is None or _launcher_name(command) != "node"
 
 
 def _path_key(env: dict) -> str:
@@ -283,7 +293,7 @@ def _stdio_env(headers: Optional[dict], command: Optional[str] = None) -> Option
         base = os.environ.get("PATH", "")
     try:
         from utils.node_runtime import path_with_managed_node
-        patched = path_with_managed_node(base)
+        patched = path_with_managed_node(base, require_npm = _command_needs_npm(command))
     except (ImportError, OSError, ValueError):
         patched = base
     if patched and patched != env.get(key):

--- a/studio/backend/core/inference/mcp_client.py
+++ b/studio/backend/core/inference/mcp_client.py
@@ -271,8 +271,11 @@ def _command_selects_runtime(command: Optional[str]) -> bool:
 
 
 def _runtime_requirements(command: Optional[str]) -> tuple[bool, bool]:
-    """``(needs npm, needs npx)`` for argv[0]. node needs neither, npm needs npm, and
-    only npx needs npx, so an unrelated missing launcher cannot shadow a good runtime.
+    """``(needs npm, needs npx)`` for argv[0]. Each launcher asks only for what it runs,
+    so an unrelated missing launcher cannot shadow a good runtime: node needs neither, npm
+    needs npm, and npx needs npx alone -- npx never shells out to an ``npm`` executable,
+    its npx-cli.js delegates in-process to the npm library it ships with, so a PATH
+    exposing node and npx without a separate npm runs it fine and must be left alone.
     A pathed npm/npx is already located and only needs a node for its shebang, so it
     does not require a second copy of itself on PATH either."""
     name = _launcher_name(command) if command is not None else None
@@ -282,6 +285,8 @@ def _runtime_requirements(command: Optional[str]) -> tuple[bool, bool]:
         return False, False
     if name == "npm":
         return True, False
+    if name == "npx":
+        return False, True
     return True, True
 
 

--- a/studio/backend/core/inference/mcp_client.py
+++ b/studio/backend/core/inference/mcp_client.py
@@ -309,9 +309,7 @@ def _stdio_env(headers: Optional[dict], command: Optional[str] = None) -> Option
     try:
         from utils.node_runtime import path_with_managed_node
         require_npm, require_npx = _runtime_requirements(command)
-        patched = path_with_managed_node(
-            base, require_npm = require_npm, require_npx = require_npx
-        )
+        patched = path_with_managed_node(base, require_npm = require_npm, require_npx = require_npx)
     except (ImportError, OSError, ValueError):
         patched = base
     if patched and patched != env.get(key):

--- a/studio/backend/core/inference/mcp_client.py
+++ b/studio/backend/core/inference/mcp_client.py
@@ -263,9 +263,9 @@ def _stdio_env(headers: Optional[dict]) -> Optional[dict]:
 
 
 def _stdio_argv(parts: list, env: Optional[dict]) -> list:
-    """argv with argv[0] resolved against the child's PATH. Windows looks the command
-    up in the parent environment before ``env`` applies (and cannot run a bare ``npx``
-    that lives only in the managed Node dir), so hand it the full path."""
+    """argv with argv[0] resolved against the child's PATH. Windows resolves the
+    command against the parent environment before ``env`` applies, so a managed-only
+    ``npx`` has to be handed over as a full path."""
     path = (env or {}).get("PATH")
     if not isinstance(path, str):
         path = os.environ.get("PATH", "")

--- a/studio/backend/core/inference/mcp_client.py
+++ b/studio/backend/core/inference/mcp_client.py
@@ -270,10 +270,15 @@ def _command_selects_runtime(command: Optional[str]) -> bool:
     )
 
 
-def _command_needs_npm(command: Optional[str]) -> bool:
-    """A direct ``node`` server needs no npm or npx, so requiring them would shadow a
-    perfectly good Node its PATH already provides."""
-    return command is None or _launcher_name(command) != "node"
+def _runtime_requirements(command: Optional[str]) -> tuple[bool, bool]:
+    """``(needs npm, needs npx)`` for argv[0]. node needs neither, npm needs npm, and
+    only npx needs npx, so an unrelated missing launcher cannot shadow a good runtime."""
+    name = _launcher_name(command) if command is not None else None
+    if name == "node":
+        return False, False
+    if name == "npm":
+        return True, False
+    return True, True
 
 
 def _path_key(env: dict) -> str:
@@ -303,7 +308,10 @@ def _stdio_env(headers: Optional[dict], command: Optional[str] = None) -> Option
         base = os.environ.get("PATH", "")
     try:
         from utils.node_runtime import path_with_managed_node
-        patched = path_with_managed_node(base, require_npm = _command_needs_npm(command))
+        require_npm, require_npx = _runtime_requirements(command)
+        patched = path_with_managed_node(
+            base, require_npm = require_npm, require_npx = require_npx
+        )
     except (ImportError, OSError, ValueError):
         patched = base
     if patched and patched != env.get(key):

--- a/studio/backend/core/inference/mcp_client.py
+++ b/studio/backend/core/inference/mcp_client.py
@@ -10,6 +10,7 @@ import hashlib
 import json
 import os
 import shlex
+import shutil
 import sys
 import threading
 import time
@@ -258,6 +259,18 @@ def _stdio_env(headers: Optional[dict]) -> Optional[dict]:
     return env or None
 
 
+def _stdio_argv(parts: list, env: Optional[dict]) -> list:
+    """argv with argv[0] resolved against the child's PATH. Windows looks the command
+    up in the parent environment before ``env`` applies (and cannot run a bare ``npx``
+    that lives only in the managed Node dir), so hand it the full path."""
+    path = (env or {}).get("PATH") or os.environ.get("PATH", "")
+    try:
+        resolved = shutil.which(parts[0], path = path)
+    except OSError:
+        resolved = None
+    return [resolved or parts[0], *parts[1:]]
+
+
 def _client(
     url: str,
     headers: Optional[dict],
@@ -276,11 +289,13 @@ def _client(
             raise ValueError(f"Empty stdio command: {url!r}")
         # env vars ride the headers field (merged over the SDK default env).
         # keep_alive=False tears the subprocess down so a one-shot call leaves no orphan.
+        env = _stdio_env(headers)
+        argv = _stdio_argv(parts, env)
         return Client(
             StdioTransport(
-                command = parts[0],
-                args = parts[1:],
-                env = _stdio_env(headers),
+                command = argv[0],
+                args = argv[1:],
+                env = env,
                 keep_alive = False,
             )
         )

--- a/studio/backend/core/inference/mcp_client.py
+++ b/studio/backend/core/inference/mcp_client.py
@@ -266,9 +266,7 @@ def _command_selects_runtime(command: Optional[str]) -> bool:
     """A path to a ``node`` launcher picks the runtime explicitly and runs regardless of
     PATH, so handing its children a different Node would only split the two."""
     return (
-        command is not None
-        and bool(os.path.dirname(command))
-        and _launcher_name(command) == "node"
+        command is not None and bool(os.path.dirname(command)) and _launcher_name(command) == "node"
     )
 
 

--- a/studio/backend/core/inference/mcp_client.py
+++ b/studio/backend/core/inference/mcp_client.py
@@ -272,9 +272,13 @@ def _command_selects_runtime(command: Optional[str]) -> bool:
 
 def _runtime_requirements(command: Optional[str]) -> tuple[bool, bool]:
     """``(needs npm, needs npx)`` for argv[0]. node needs neither, npm needs npm, and
-    only npx needs npx, so an unrelated missing launcher cannot shadow a good runtime."""
+    only npx needs npx, so an unrelated missing launcher cannot shadow a good runtime.
+    A pathed npm/npx is already located and only needs a node for its shebang, so it
+    does not require a second copy of itself on PATH either."""
     name = _launcher_name(command) if command is not None else None
     if name == "node":
+        return False, False
+    if command is not None and os.path.dirname(command):
         return False, False
     if name == "npm":
         return True, False

--- a/studio/backend/core/inference/mcp_client.py
+++ b/studio/backend/core/inference/mcp_client.py
@@ -241,6 +241,23 @@ async def clear_oauth_tokens_async(url: str) -> None:
         logger.warning("Failed to clear OAuth tokens for %s: %s", url, exc)
 
 
+def _stdio_env(headers: Optional[dict]) -> Optional[dict]:
+    """Process env for a stdio server: its own vars, plus the managed Node bin dir
+    on PATH so ``npx ...`` servers spawn on hosts with no usable system Node."""
+    env = dict(headers or {})
+    base = env.get("PATH")
+    if not isinstance(base, str) or not base:
+        base = os.environ.get("PATH", "")
+    try:
+        from utils.node_runtime import path_with_managed_node
+        patched = path_with_managed_node(base)
+    except (ImportError, OSError, ValueError):
+        patched = base
+    if patched and patched != env.get("PATH"):
+        env["PATH"] = patched
+    return env or None
+
+
 def _client(
     url: str,
     headers: Optional[dict],
@@ -263,7 +280,7 @@ def _client(
             StdioTransport(
                 command = parts[0],
                 args = parts[1:],
-                env = headers or None,
+                env = _stdio_env(headers),
                 keep_alive = False,
             )
         )

--- a/studio/backend/core/inference/mcp_client.py
+++ b/studio/backend/core/inference/mcp_client.py
@@ -247,7 +247,10 @@ def _stdio_env(headers: Optional[dict]) -> Optional[dict]:
     on PATH so ``npx ...`` servers spawn on hosts with no usable system Node."""
     env = dict(headers or {})
     base = env.get("PATH")
-    if not isinstance(base, str) or not base:
+    if isinstance(base, str) and not base:
+        # An explicitly empty PATH is a deliberate sandbox: hand it over untouched.
+        return env
+    if not isinstance(base, str):
         base = os.environ.get("PATH", "")
     try:
         from utils.node_runtime import path_with_managed_node
@@ -263,7 +266,9 @@ def _stdio_argv(parts: list, env: Optional[dict]) -> list:
     """argv with argv[0] resolved against the child's PATH. Windows looks the command
     up in the parent environment before ``env`` applies (and cannot run a bare ``npx``
     that lives only in the managed Node dir), so hand it the full path."""
-    path = (env or {}).get("PATH") or os.environ.get("PATH", "")
+    path = (env or {}).get("PATH")
+    if not isinstance(path, str):
+        path = os.environ.get("PATH", "")
     try:
         resolved = shutil.which(parts[0], path = path)
     except OSError:

--- a/studio/backend/tests/test_mcp_stdio_node_path.py
+++ b/studio/backend/tests/test_mcp_stdio_node_path.py
@@ -294,3 +294,34 @@ def test_managed_dir_already_first_is_unchanged(managed_node_install, monkeypatc
     )
     configured = f"{managed_node_install}{os.pathsep}{stale}"
     assert node_runtime.path_with_managed_node(configured) == configured
+
+
+def test_non_node_command_keeps_its_configured_path(managed_node):
+    """A Python server pinning its own toolchain must not get the managed Node."""
+    env = mcp_client._stdio_env({"PATH": "/proj/node18/bin"}, "python")
+    assert env["PATH"] == "/proj/node18/bin"
+
+
+def test_non_node_command_leaves_inherited_path_alone(managed_node, monkeypatch):
+    monkeypatch.setenv("PATH", "/usr/bin")
+    assert mcp_client._stdio_env(None, "uvx") is None
+
+
+def test_node_family_commands_still_augmented(managed_node, monkeypatch):
+    monkeypatch.setenv("PATH", "/usr/bin")
+    for command in ("npx", "node", "npm", "/usr/local/bin/npx", "NPX.CMD", "node.exe"):
+        env = mcp_client._stdio_env(None, command)
+        assert env["PATH"] == f"{managed_node}{os.pathsep}/usr/bin", command
+
+
+def test_is_node_command_rejects_lookalikes():
+    assert not mcp_client._is_node_command("nodemon")
+    assert not mcp_client._is_node_command("python")
+    assert not mcp_client._is_node_command("/opt/bin/deno")
+
+
+def test_client_does_not_touch_env_for_a_python_server(managed_node, monkeypatch):
+    monkeypatch.setenv("UNSLOTH_STUDIO_ALLOW_STDIO_MCP", "1")
+    monkeypatch.setenv("PATH", "/usr/bin")
+    client = mcp_client._client("python -m my_server", {"API_KEY": "sk-1"})
+    assert client.transport.env == {"API_KEY": "sk-1"}

--- a/studio/backend/tests/test_mcp_stdio_node_path.py
+++ b/studio/backend/tests/test_mcp_stdio_node_path.py
@@ -32,6 +32,7 @@ def managed_node(tmp_path, monkeypatch):
     bin_dir.mkdir(parents = True, exist_ok = True)
     monkeypatch.setattr(node_runtime, "managed_node_bin_dir", lambda: bin_dir)
     monkeypatch.setattr(node_runtime, "managed_node_usable", lambda: True)
+    monkeypatch.setattr(node_runtime, "_path_has_usable_node", lambda path: False)
     return bin_dir
 
 
@@ -197,17 +198,62 @@ def test_absent_path_still_inherits(managed_node, monkeypatch):
 
 
 def test_path_preserves_trailing_empty_component(managed_node):
-    """An empty component means the working directory on POSIX; keep it."""
-    assert (
-        node_runtime.path_with_managed_node("/usr/bin:")
-        == f"{managed_node}{os.pathsep}/usr/bin{os.pathsep}"
-    )
+    """An empty component means the working directory on POSIX; keep it verbatim."""
+    configured = f"/usr/bin{os.pathsep}"
+    expected = f"{managed_node}{os.pathsep}{configured}"
+    assert node_runtime.path_with_managed_node(configured) == expected
 
 
 def test_path_preserves_bare_empty_components(managed_node):
-    assert node_runtime.path_with_managed_node(":") == f"{managed_node}{os.pathsep}{os.pathsep}"
+    expected = f"{managed_node}{os.pathsep}{os.pathsep}"
+    assert node_runtime.path_with_managed_node(os.pathsep) == expected
 
 
 def test_stdio_env_preserves_empty_component_from_config(managed_node):
-    env = mcp_client._stdio_env({"PATH": "/usr/bin:"})
-    assert env["PATH"] == f"{managed_node}{os.pathsep}/usr/bin{os.pathsep}"
+    configured = f"/usr/bin{os.pathsep}"
+    env = mcp_client._stdio_env({"PATH": configured})
+    assert env["PATH"] == f"{managed_node}{os.pathsep}{configured}"
+
+
+def _system_node_dir(tmp_path):
+    sysbin = tmp_path / "sysbin"
+    sysbin.mkdir()
+    _make_executable(sysbin, "node")
+    return sysbin
+
+
+def test_adequate_system_node_is_not_shadowed(managed_node_install, monkeypatch, tmp_path):
+    """A leftover managed install must not override a Node the PATH already provides."""
+    sysbin = _system_node_dir(tmp_path)
+    monkeypatch.setattr(node_runtime, "_node_version_ok", lambda executable: True)
+    assert node_runtime.path_with_managed_node(str(sysbin)) == str(sysbin)
+
+
+def test_managed_node_used_when_system_node_is_below_floor(
+    managed_node_install, monkeypatch, tmp_path
+):
+    sysbin = _system_node_dir(tmp_path)
+    monkeypatch.setattr(
+        node_runtime, "_node_version_ok", lambda executable: "sysbin" not in str(executable)
+    )
+    expected = f"{managed_node_install}{os.pathsep}{sysbin}"
+    assert node_runtime.path_with_managed_node(str(sysbin)) == expected
+
+
+def test_managed_node_used_when_path_has_no_node(managed_node_install, monkeypatch, tmp_path):
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    monkeypatch.setattr(node_runtime, "_node_version_ok", lambda executable: True)
+    expected = f"{managed_node_install}{os.pathsep}{empty}"
+    assert node_runtime.path_with_managed_node(str(empty)) == expected
+
+
+def test_system_node_probe_is_memoized(managed_node_install, monkeypatch, tmp_path):
+    sysbin = _system_node_dir(tmp_path)
+    calls = []
+    monkeypatch.setattr(
+        node_runtime, "_node_version_ok", lambda executable: calls.append(executable) or True
+    )
+    assert node_runtime.path_with_managed_node(str(sysbin)) == str(sysbin)
+    assert node_runtime.path_with_managed_node(str(sysbin)) == str(sysbin)
+    assert len(calls) == 1

--- a/studio/backend/tests/test_mcp_stdio_node_path.py
+++ b/studio/backend/tests/test_mcp_stdio_node_path.py
@@ -192,3 +192,17 @@ def test_explicit_empty_path_still_allows_absolute_command(managed_node):
 def test_absent_path_still_inherits(managed_node, monkeypatch):
     monkeypatch.setenv("PATH", "/usr/bin")
     assert mcp_client._stdio_env({"API_KEY": "sk-1"})["PATH"] == f"{managed_node}{os.pathsep}/usr/bin"
+
+
+def test_path_preserves_trailing_empty_component(managed_node):
+    """An empty component means the working directory on POSIX; keep it."""
+    assert node_runtime.path_with_managed_node("/usr/bin:") == f"{managed_node}{os.pathsep}/usr/bin{os.pathsep}"
+
+
+def test_path_preserves_bare_empty_components(managed_node):
+    assert node_runtime.path_with_managed_node(":") == f"{managed_node}{os.pathsep}{os.pathsep}"
+
+
+def test_stdio_env_preserves_empty_component_from_config(managed_node):
+    env = mcp_client._stdio_env({"PATH": "/usr/bin:"})
+    assert env["PATH"] == f"{managed_node}{os.pathsep}/usr/bin{os.pathsep}"

--- a/studio/backend/tests/test_mcp_stdio_node_path.py
+++ b/studio/backend/tests/test_mcp_stdio_node_path.py
@@ -524,9 +524,7 @@ def test_npx_server_still_needs_npx_on_a_node_only_path(
     )
 
 
-def test_npx_server_keeps_a_path_with_npx_but_no_npm(
-    managed_node_install, monkeypatch, tmp_path
-):
+def test_npx_server_keeps_a_path_with_npx_but_no_npm(managed_node_install, monkeypatch, tmp_path):
     """A curated PATH exposing node and npx without a separate npm launcher runs npx fine:
     npx-cli.js delegates in-process to the npm it ships with and never looks up an ``npm``
     executable. Demanding one would prepend the managed dir and silently swap the
@@ -538,14 +536,12 @@ def test_npx_server_keeps_a_path_with_npx_but_no_npm(
     _patch_floors(monkeypatch, lambda executable, path = None: True)
     monkeypatch.setenv("PATH", str(curated))
     assert mcp_client._stdio_env(None, "npx")["PATH"] == str(curated)
-    assert mcp_client._stdio_argv(
-        ["npx", "-y", "server"], {"PATH": str(curated)}
-    )[0].startswith(str(curated))
+    assert mcp_client._stdio_argv(["npx", "-y", "server"], {"PATH": str(curated)})[0].startswith(
+        str(curated)
+    )
 
 
-def test_npx_only_path_is_still_held_to_the_npm_floor(
-    managed_node_install, monkeypatch, tmp_path
-):
+def test_npx_only_path_is_still_held_to_the_npm_floor(managed_node_install, monkeypatch, tmp_path):
     """``npx -v`` reports the bundled npm's version, so an npx-only PATH is floor-checked
     through npx rather than waved through."""
     curated = tmp_path / "curated"

--- a/studio/backend/tests/test_mcp_stdio_node_path.py
+++ b/studio/backend/tests/test_mcp_stdio_node_path.py
@@ -15,12 +15,33 @@ from core.inference import mcp_client
 from utils import node_runtime
 
 
+@pytest.fixture(autouse = True)
+def _reset_managed_node_memo():
+    node_runtime._reset_managed_node_check()
+    yield
+    node_runtime._reset_managed_node_check()
+
+
 @pytest.fixture
 def managed_node(tmp_path, monkeypatch):
+    """A managed install that clears the version floor (the probe is stubbed: these
+    tests cover PATH assembly, not `node -v`)."""
     monkeypatch.setenv("UNSLOTH_STUDIO_HOME", str(tmp_path / "studio"))
     bin_dir = tmp_path / "studio" / "node" / ("" if os.name == "nt" else "bin")
     bin_dir.mkdir(parents = True, exist_ok = True)
     monkeypatch.setattr(node_runtime, "managed_node_bin_dir", lambda: bin_dir)
+    monkeypatch.setattr(node_runtime, "managed_node_usable", lambda: True)
+    return bin_dir
+
+
+@pytest.fixture
+def managed_node_install(tmp_path, monkeypatch):
+    """The real locator + a stub node binary, so managed_node_usable() is exercised."""
+    monkeypatch.setenv("UNSLOTH_STUDIO_HOME", str(tmp_path / "studio"))
+    bin_dir = tmp_path / "studio" / "node" / ("" if os.name == "nt" else "bin")
+    bin_dir.mkdir(parents = True, exist_ok = True)
+    binary = node_runtime.managed_node_binary()
+    binary.write_text("")
     return bin_dir
 
 
@@ -111,3 +132,32 @@ def test_client_spawns_managed_npx_by_full_path(managed_node, monkeypatch, tmp_p
     monkeypatch.setenv("UNSLOTH_STUDIO_ALLOW_STDIO_MCP", "1")
     client = mcp_client._client("npx -y @modelcontextprotocol/server-filesystem /tmp", None)
     assert os.path.samefile(client.transport.command, npx)
+
+
+def test_stale_managed_node_is_not_prepended(managed_node_install, monkeypatch):
+    """A dir left behind after the host moved to a system Node must not win the lookup."""
+    monkeypatch.setattr(node_runtime, "_node_version_ok", lambda executable: False)
+    assert node_runtime.managed_node_usable() is False
+    assert node_runtime.path_with_managed_node("/usr/bin") == "/usr/bin"
+
+
+def test_usable_managed_node_is_prepended(managed_node_install, monkeypatch):
+    monkeypatch.setattr(node_runtime, "_node_version_ok", lambda executable: True)
+    assert node_runtime.managed_node_usable() is True
+    expected = f"{managed_node_install}{os.pathsep}/usr/bin"
+    assert node_runtime.path_with_managed_node("/usr/bin") == expected
+
+
+def test_stale_managed_node_leaves_stdio_env_alone(managed_node_install, monkeypatch):
+    monkeypatch.setattr(node_runtime, "_node_version_ok", lambda executable: False)
+    monkeypatch.setenv("PATH", "/usr/bin")
+    assert mcp_client._stdio_env(None)["PATH"] == "/usr/bin"
+
+
+def test_managed_node_check_is_memoized_on_success(managed_node_install, monkeypatch):
+    """One probe per process once usable: _stdio_env runs on every client build."""
+    calls = []
+    monkeypatch.setattr(node_runtime, "_node_version_ok", lambda executable: calls.append(executable) or True)
+    assert node_runtime.managed_node_usable() is True
+    assert node_runtime.managed_node_usable() is True
+    assert len(calls) == 1

--- a/studio/backend/tests/test_mcp_stdio_node_path.py
+++ b/studio/backend/tests/test_mcp_stdio_node_path.py
@@ -562,3 +562,28 @@ def test_npm_probe_runs_with_the_candidate_path(managed_node_install, monkeypatc
     # the managed install must be usable, or the function returns before the npm probe
     monkeypatch.setattr(node_runtime, "managed_node_usable", lambda: True)
     assert node_runtime.path_with_managed_node(str(toolchain)) == str(toolchain)
+
+
+def test_windows_npm_sibling_runtime_is_validated(managed_node_install, monkeypatch, tmp_path):
+    """npm.cmd prefers the node.exe beside it just as npx.cmd does."""
+    good = tmp_path / "good"
+    good.mkdir()
+    _make_executable(good, "node")
+    old = tmp_path / "old"
+    old.mkdir()
+    _make_executable(old, "npm")
+    (old / "node.exe").write_text("")
+    monkeypatch.setattr(node_runtime, "_IS_WINDOWS", True)
+    checked = []
+
+    def _record(executable, path = None):
+        checked.append(str(executable))
+        return not str(executable).startswith(str(old))
+
+    _patch_floors(monkeypatch, lambda executable: _record(executable))
+    configured = f"{good}{os.pathsep}{old}"
+    result = node_runtime.path_with_managed_node(
+        configured, require_npm = True, require_npx = False
+    )
+    assert any(c.endswith("node.exe") for c in checked), checked
+    assert result == f"{managed_node_install}{os.pathsep}{configured}"

--- a/studio/backend/tests/test_mcp_stdio_node_path.py
+++ b/studio/backend/tests/test_mcp_stdio_node_path.py
@@ -325,3 +325,43 @@ def test_client_does_not_touch_env_for_a_python_server(managed_node, monkeypatch
     monkeypatch.setenv("PATH", "/usr/bin")
     client = mcp_client._client("python -m my_server", {"API_KEY": "sk-1"})
     assert client.transport.env == {"API_KEY": "sk-1"}
+
+
+def test_windows_npx_sibling_runtime_is_the_one_validated(
+    managed_node_install, monkeypatch, tmp_path
+):
+    """npx.cmd runs the node.exe beside it, so that runtime decides, not PATH order."""
+    good = tmp_path / "good"
+    good.mkdir()
+    _make_executable(good, "node")
+    old = tmp_path / "old"
+    old.mkdir()
+    _make_executable(old, "npx")
+    (old / "node.exe").write_text("")
+    monkeypatch.setattr(node_runtime, "_IS_WINDOWS", True)
+    checked = []
+    monkeypatch.setattr(
+        node_runtime,
+        "_node_version_ok",
+        lambda executable: checked.append(str(executable))
+        or not str(executable).startswith(str(old)),
+    )
+    configured = f"{good}{os.pathsep}{old}"
+    result = node_runtime.path_with_managed_node(configured)
+    assert any(c.endswith("node.exe") for c in checked), checked
+    assert result == f"{managed_node_install}{os.pathsep}{configured}"
+
+
+def test_posix_split_layout_still_trusts_the_path_node(
+    managed_node_install, monkeypatch, tmp_path
+):
+    """On POSIX npx is a shebang script resolving node via PATH, so a split is fine."""
+    good = tmp_path / "good"
+    good.mkdir()
+    _make_executable(good, "node")
+    other = tmp_path / "other"
+    other.mkdir()
+    _make_executable(other, "npx")
+    monkeypatch.setattr(node_runtime, "_node_version_ok", lambda executable: True)
+    configured = f"{good}{os.pathsep}{other}"
+    assert node_runtime.path_with_managed_node(configured) == configured

--- a/studio/backend/tests/test_mcp_stdio_node_path.py
+++ b/studio/backend/tests/test_mcp_stdio_node_path.py
@@ -167,6 +167,7 @@ def test_stale_managed_node_leaves_stdio_env_alone(managed_node_install, monkeyp
 def test_managed_node_check_is_memoized_on_success(managed_node_install, monkeypatch):
     """One probe per process once usable: _stdio_env runs on every client build."""
     calls = []
+
     def _record(executable, path = None):
         calls.append(executable)
         return True
@@ -238,6 +239,7 @@ def _system_node_dir(tmp_path, with_npx = True):
 
 def _patch_floors(monkeypatch, predicate):
     """Both floors move together: the installers require node AND npm to pass."""
+
     def _check(executable, path = None):
         return predicate(executable)
 
@@ -542,7 +544,7 @@ def test_npx_server_on_the_same_path_still_gets_managed(
     assert env["PATH"] == f"{managed_node_install}{os.pathsep}{nonpx}"
 
 
-@pytest.mark.skipif(os.name == "nt", reason="POSIX shebang launcher")
+@pytest.mark.skipif(os.name == "nt", reason = "POSIX shebang launcher")
 def test_npm_probe_runs_with_the_candidate_path(managed_node_install, monkeypatch, tmp_path):
     """npm is a `#!/usr/bin/env node` script, so the probe needs the candidate's node."""
     toolchain = tmp_path / "toolchain"
@@ -551,7 +553,7 @@ def test_npm_probe_runs_with_the_candidate_path(managed_node_install, monkeypatc
     node.write_text("#!/bin/sh\necho v22.12.0\n")
     node.chmod(0o755)
     npm = toolchain / "npm"
-    npm.write_text("#!/usr/bin/env node\n")       # only runs if node is on the probe PATH
+    npm.write_text("#!/usr/bin/env node\n")  # only runs if node is on the probe PATH
     npm.chmod(0o755)
     _make_executable(toolchain, "npx")
     # a backend PATH with no node at all, which is why this PR exists

--- a/studio/backend/tests/test_mcp_stdio_node_path.py
+++ b/studio/backend/tests/test_mcp_stdio_node_path.py
@@ -32,6 +32,7 @@ def managed_node(tmp_path, monkeypatch):
     bin_dir.mkdir(parents = True, exist_ok = True)
     monkeypatch.setattr(node_runtime, "managed_node_bin_dir", lambda: bin_dir)
     monkeypatch.setattr(node_runtime, "managed_node_usable", lambda: True)
+
     def _no_usable_node(path, require_npm = True):
         return False
 

--- a/studio/backend/tests/test_mcp_stdio_node_path.py
+++ b/studio/backend/tests/test_mcp_stdio_node_path.py
@@ -363,3 +363,31 @@ def test_posix_split_layout_still_trusts_the_path_node(managed_node_install, mon
     monkeypatch.setattr(node_runtime, "_node_version_ok", lambda executable: True)
     configured = f"{good}{os.pathsep}{other}"
     assert node_runtime.path_with_managed_node(configured) == configured
+
+
+@pytest.fixture
+def windows_env(monkeypatch):
+    monkeypatch.setattr(mcp_client, "_IS_WINDOWS", True)
+
+
+def test_windows_lowercase_path_key_is_recognized(managed_node, monkeypatch, windows_env):
+    monkeypatch.setenv("PATH", "/usr/bin")
+    env = mcp_client._stdio_env({"Path": "/opt/bin"}, "npx")
+    assert env["Path"] == f"{managed_node}{os.pathsep}/opt/bin"
+    assert "PATH" not in env
+
+
+def test_windows_lowercase_empty_path_is_still_a_sandbox(managed_node, monkeypatch, windows_env):
+    monkeypatch.setenv("PATH", "/usr/bin")
+    assert mcp_client._stdio_env({"Path": ""}, "npx") == {"Path": ""}
+
+
+def test_windows_lowercase_path_blocks_host_lookup(managed_node, windows_env):
+    assert mcp_client._stdio_argv(["npx"], {"Path": ""}) == ["npx"]
+
+
+def test_posix_treats_path_and_lowercase_path_as_distinct(managed_node, monkeypatch):
+    monkeypatch.setenv("PATH", "/usr/bin")
+    env = mcp_client._stdio_env({"Path": "/opt/bin"}, "npx")
+    assert env["Path"] == "/opt/bin"
+    assert env["PATH"] == f"{managed_node}{os.pathsep}/usr/bin"

--- a/studio/backend/tests/test_mcp_stdio_node_path.py
+++ b/studio/backend/tests/test_mcp_stdio_node_path.py
@@ -32,7 +32,10 @@ def managed_node(tmp_path, monkeypatch):
     bin_dir.mkdir(parents = True, exist_ok = True)
     monkeypatch.setattr(node_runtime, "managed_node_bin_dir", lambda: bin_dir)
     monkeypatch.setattr(node_runtime, "managed_node_usable", lambda: True)
-    monkeypatch.setattr(node_runtime, "_path_has_usable_node", lambda path, require_npm = True: False)
+    def _no_usable_node(path, require_npm = True):
+        return False
+
+    monkeypatch.setattr(node_runtime, "_path_has_usable_node", _no_usable_node)
     return bin_dir
 
 
@@ -472,3 +475,30 @@ def test_command_needs_npm_only_for_launchers():
     assert mcp_client._command_needs_npm("npx")
     assert mcp_client._command_needs_npm("npm.cmd")
     assert mcp_client._command_needs_npm(None)
+
+
+def test_absolute_node_launcher_keeps_its_configured_path(managed_node, monkeypatch):
+    """An explicit interpreter runs regardless of PATH; its children must match it."""
+    monkeypatch.setenv("PATH", "/usr/bin")
+    env = mcp_client._stdio_env({"API_KEY": "sk-1"}, "/opt/node/bin/node")
+    assert env == {"API_KEY": "sk-1"}
+
+
+def test_bare_node_command_is_still_helped(managed_node, monkeypatch):
+    monkeypatch.setenv("PATH", "/usr/bin")
+    env = mcp_client._stdio_env(None, "node")
+    assert env["PATH"] == f"{managed_node}{os.pathsep}/usr/bin"
+
+
+def test_absolute_npx_launcher_still_gets_the_runtime(managed_node, monkeypatch):
+    """npx needs a node on PATH to run at all, so it keeps the managed dir."""
+    monkeypatch.setenv("PATH", "/usr/bin")
+    env = mcp_client._stdio_env(None, "/opt/node/bin/npx")
+    assert env["PATH"] == f"{managed_node}{os.pathsep}/usr/bin"
+
+
+def test_command_selects_runtime_only_for_node_paths():
+    assert mcp_client._command_selects_runtime("/opt/node/bin/node")
+    assert not mcp_client._command_selects_runtime("node")
+    assert not mcp_client._command_selects_runtime("/opt/node/bin/npx")
+    assert not mcp_client._command_selects_runtime(None)

--- a/studio/backend/tests/test_mcp_stdio_node_path.py
+++ b/studio/backend/tests/test_mcp_stdio_node_path.py
@@ -306,6 +306,37 @@ def test_system_node_probe_is_memoized(managed_node_install, monkeypatch, tmp_pa
     assert len(calls) == after_first, calls
 
 
+def test_probe_memo_does_not_answer_across_paths(managed_node_install, monkeypatch, tmp_path):
+    """One npm shim, two PATHs, two different runtimes. npm and npx are
+    ``#!/usr/bin/env node`` scripts, so the shim clears the floor only under the PATH whose
+    node is adequate. The success memo must not let the passing PATH answer for the other."""
+    shim = tmp_path / "shim"
+    shim.mkdir()
+    _make_executable(shim, "npm")
+    _make_executable(shim, "npx")
+    good = tmp_path / "good"
+    good.mkdir()
+    _make_executable(good, "node")
+    old = tmp_path / "old"
+    old.mkdir()
+    _make_executable(old, "node")
+
+    # Patched directly rather than through _patch_floors: that helper drops the path
+    # argument, which is the whole dimension under test here.
+    def _npm_floor(executable, path = None):
+        # The shim runs whichever node its PATH reaches, so only the good PATH clears.
+        return path is not None and str(good) in path
+
+    monkeypatch.setattr(node_runtime, "_node_version_ok", lambda executable, path = None: True)
+    monkeypatch.setattr(node_runtime, "_npm_version_ok", _npm_floor)
+    good_path = f"{shim}{os.pathsep}{good}"
+    old_path = f"{shim}{os.pathsep}{old}"
+    assert node_runtime._path_has_usable_node(good_path) is True
+    # Same npm executable, PATH whose node is below the floor: must be re-probed, not served
+    # from the entry the good PATH cached.
+    assert node_runtime._path_has_usable_node(old_path) is False
+
+
 def test_managed_node_used_when_system_lacks_npx(managed_node_install, monkeypatch, tmp_path):
     """decide_node_source installs bundled when npm is missing, so node alone is not enough."""
     sysbin = _system_node_dir(tmp_path, with_npx = False)

--- a/studio/backend/tests/test_mcp_stdio_node_path.py
+++ b/studio/backend/tests/test_mcp_stdio_node_path.py
@@ -191,12 +191,17 @@ def test_explicit_empty_path_still_allows_absolute_command(managed_node):
 
 def test_absent_path_still_inherits(managed_node, monkeypatch):
     monkeypatch.setenv("PATH", "/usr/bin")
-    assert mcp_client._stdio_env({"API_KEY": "sk-1"})["PATH"] == f"{managed_node}{os.pathsep}/usr/bin"
+    assert (
+        mcp_client._stdio_env({"API_KEY": "sk-1"})["PATH"] == f"{managed_node}{os.pathsep}/usr/bin"
+    )
 
 
 def test_path_preserves_trailing_empty_component(managed_node):
     """An empty component means the working directory on POSIX; keep it."""
-    assert node_runtime.path_with_managed_node("/usr/bin:") == f"{managed_node}{os.pathsep}/usr/bin{os.pathsep}"
+    assert (
+        node_runtime.path_with_managed_node("/usr/bin:")
+        == f"{managed_node}{os.pathsep}/usr/bin{os.pathsep}"
+    )
 
 
 def test_path_preserves_bare_empty_components(managed_node):

--- a/studio/backend/tests/test_mcp_stdio_node_path.py
+++ b/studio/backend/tests/test_mcp_stdio_node_path.py
@@ -274,3 +274,23 @@ def test_complete_system_runtime_is_not_shadowed(managed_node_install, monkeypat
     sysbin = _system_node_dir(tmp_path)
     monkeypatch.setattr(node_runtime, "_node_version_ok", lambda executable: True)
     assert node_runtime.path_with_managed_node(str(sysbin)) == str(sysbin)
+
+
+def test_shadowed_managed_dir_moves_to_front(managed_node_install, monkeypatch, tmp_path):
+    """Already on PATH but behind a stale runtime: it has to move up, not stay put."""
+    stale = _system_node_dir(tmp_path)
+    monkeypatch.setattr(
+        node_runtime, "_node_version_ok", lambda executable: "sysbin" not in str(executable)
+    )
+    configured = f"{stale}{os.pathsep}{managed_node_install}"
+    expected = f"{managed_node_install}{os.pathsep}{stale}"
+    assert node_runtime.path_with_managed_node(configured) == expected
+
+
+def test_managed_dir_already_first_is_unchanged(managed_node_install, monkeypatch, tmp_path):
+    stale = _system_node_dir(tmp_path)
+    monkeypatch.setattr(
+        node_runtime, "_node_version_ok", lambda executable: "sysbin" not in str(executable)
+    )
+    configured = f"{managed_node_install}{os.pathsep}{stale}"
+    assert node_runtime.path_with_managed_node(configured) == configured

--- a/studio/backend/tests/test_mcp_stdio_node_path.py
+++ b/studio/backend/tests/test_mcp_stdio_node_path.py
@@ -33,7 +33,7 @@ def managed_node(tmp_path, monkeypatch):
     monkeypatch.setattr(node_runtime, "managed_node_bin_dir", lambda: bin_dir)
     monkeypatch.setattr(node_runtime, "managed_node_usable", lambda: True)
 
-    def _no_usable_node(path, require_npm = True):
+    def _no_usable_node(path, require_npm = True, require_npx = True):
         return False
 
     monkeypatch.setattr(node_runtime, "_path_has_usable_node", _no_usable_node)
@@ -438,7 +438,10 @@ def _node_only_dir(tmp_path):
 def test_direct_node_server_keeps_a_node_only_path(managed_node_install, monkeypatch, tmp_path):
     nodeonly = _node_only_dir(tmp_path)
     _patch_floors(monkeypatch, lambda executable: True)
-    assert node_runtime.path_with_managed_node(str(nodeonly), require_npm = False) == str(nodeonly)
+    unchanged = node_runtime.path_with_managed_node(
+        str(nodeonly), require_npm = False, require_npx = False
+    )
+    assert unchanged == str(nodeonly)
 
 
 def test_npx_server_still_needs_npm_on_a_node_only_path(
@@ -469,13 +472,14 @@ def test_stdio_env_still_augments_for_npx_on_a_node_only_path(
     assert env["PATH"] == f"{managed_node_install}{os.pathsep}{nodeonly}"
 
 
-def test_command_needs_npm_only_for_launchers():
-    assert not mcp_client._command_needs_npm("node")
-    assert not mcp_client._command_needs_npm("/usr/bin/node")
-    assert not mcp_client._command_needs_npm("node.exe")
-    assert mcp_client._command_needs_npm("npx")
-    assert mcp_client._command_needs_npm("npm.cmd")
-    assert mcp_client._command_needs_npm(None)
+def test_runtime_requirements_match_each_launcher():
+    assert mcp_client._runtime_requirements("node") == (False, False)
+    assert mcp_client._runtime_requirements("/usr/bin/node") == (False, False)
+    assert mcp_client._runtime_requirements("node.exe") == (False, False)
+    assert mcp_client._runtime_requirements("npm") == (True, False)
+    assert mcp_client._runtime_requirements("npm.cmd") == (True, False)
+    assert mcp_client._runtime_requirements("npx") == (True, True)
+    assert mcp_client._runtime_requirements(None) == (True, True)
 
 
 def test_absolute_node_launcher_keeps_its_configured_path(managed_node, monkeypatch):
@@ -503,3 +507,27 @@ def test_command_selects_runtime_only_for_node_paths():
     assert not mcp_client._command_selects_runtime("node")
     assert not mcp_client._command_selects_runtime("/opt/node/bin/npx")
     assert not mcp_client._command_selects_runtime(None)
+
+
+def test_direct_npm_server_does_not_need_npx(managed_node_install, monkeypatch, tmp_path):
+    """The installers gate on node and npm only, so a missing npx is irrelevant here."""
+    nonpx = tmp_path / "nonpx"
+    nonpx.mkdir()
+    _make_executable(nonpx, "node")
+    _make_executable(nonpx, "npm")
+    _patch_floors(monkeypatch, lambda executable: True)
+    monkeypatch.setenv("PATH", str(nonpx))
+    assert mcp_client._stdio_env(None, "npm")["PATH"] == str(nonpx)
+
+
+def test_npx_server_on_the_same_path_still_gets_managed(
+    managed_node_install, monkeypatch, tmp_path
+):
+    nonpx = tmp_path / "nonpx"
+    nonpx.mkdir()
+    _make_executable(nonpx, "node")
+    _make_executable(nonpx, "npm")
+    _patch_floors(monkeypatch, lambda executable: True)
+    monkeypatch.setenv("PATH", str(nonpx))
+    env = mcp_client._stdio_env(None, "npx")
+    assert env["PATH"] == f"{managed_node_install}{os.pathsep}{nonpx}"

--- a/studio/backend/tests/test_mcp_stdio_node_path.py
+++ b/studio/backend/tests/test_mcp_stdio_node_path.py
@@ -32,9 +32,7 @@ def managed_node(tmp_path, monkeypatch):
     bin_dir.mkdir(parents = True, exist_ok = True)
     monkeypatch.setattr(node_runtime, "managed_node_bin_dir", lambda: bin_dir)
     monkeypatch.setattr(node_runtime, "managed_node_usable", lambda: True)
-    monkeypatch.setattr(
-        node_runtime, "_path_has_usable_node", lambda path, require_npm = True: False
-    )
+    monkeypatch.setattr(node_runtime, "_path_has_usable_node", lambda path, require_npm = True: False)
     return bin_dir
 
 

--- a/studio/backend/tests/test_mcp_stdio_node_path.py
+++ b/studio/backend/tests/test_mcp_stdio_node_path.py
@@ -86,7 +86,9 @@ def test_stdio_argv_resolves_managed_npx(managed_node):
 
 
 def test_stdio_argv_keeps_unresolvable_command(managed_node):
-    argv = mcp_client._stdio_argv(["definitely-not-on-path-9304", "-y"], mcp_client._stdio_env(None))
+    argv = mcp_client._stdio_argv(
+        ["definitely-not-on-path-9304", "-y"], mcp_client._stdio_env(None)
+    )
     assert argv == ["definitely-not-on-path-9304", "-y"]
 
 

--- a/studio/backend/tests/test_mcp_stdio_node_path.py
+++ b/studio/backend/tests/test_mcp_stdio_node_path.py
@@ -216,19 +216,26 @@ def test_stdio_env_preserves_empty_component_from_config(managed_node):
 
 
 def _system_node_dir(tmp_path, with_npx = True):
-    """A system runtime dir; without npx it mirrors a host where setup picked bundled."""
+    """A system runtime dir; without npx/npm it mirrors a host where setup picked bundled."""
     sysbin = tmp_path / "sysbin"
     sysbin.mkdir()
     _make_executable(sysbin, "node")
     if with_npx:
+        _make_executable(sysbin, "npm")
         _make_executable(sysbin, "npx")
     return sysbin
+
+
+def _patch_floors(monkeypatch, predicate):
+    """Both floors move together: the installers require node AND npm to pass."""
+    monkeypatch.setattr(node_runtime, "_node_version_ok", predicate)
+    monkeypatch.setattr(node_runtime, "_npm_version_ok", predicate)
 
 
 def test_adequate_system_node_is_not_shadowed(managed_node_install, monkeypatch, tmp_path):
     """A leftover managed install must not override a Node the PATH already provides."""
     sysbin = _system_node_dir(tmp_path)
-    monkeypatch.setattr(node_runtime, "_node_version_ok", lambda executable: True)
+    _patch_floors(monkeypatch, lambda executable: True)
     assert node_runtime.path_with_managed_node(str(sysbin)) == str(sysbin)
 
 
@@ -236,9 +243,7 @@ def test_managed_node_used_when_system_node_is_below_floor(
     managed_node_install, monkeypatch, tmp_path
 ):
     sysbin = _system_node_dir(tmp_path)
-    monkeypatch.setattr(
-        node_runtime, "_node_version_ok", lambda executable: "sysbin" not in str(executable)
-    )
+    _patch_floors(monkeypatch, lambda executable: "sysbin" not in str(executable))
     expected = f"{managed_node_install}{os.pathsep}{sysbin}"
     assert node_runtime.path_with_managed_node(str(sysbin)) == expected
 
@@ -254,12 +259,11 @@ def test_managed_node_used_when_path_has_no_node(managed_node_install, monkeypat
 def test_system_node_probe_is_memoized(managed_node_install, monkeypatch, tmp_path):
     sysbin = _system_node_dir(tmp_path)
     calls = []
-    monkeypatch.setattr(
-        node_runtime, "_node_version_ok", lambda executable: calls.append(executable) or True
-    )
+    _patch_floors(monkeypatch, lambda executable: calls.append(executable) or True)
     assert node_runtime.path_with_managed_node(str(sysbin)) == str(sysbin)
+    after_first = len(calls)
     assert node_runtime.path_with_managed_node(str(sysbin)) == str(sysbin)
-    assert len(calls) == 1
+    assert len(calls) == after_first, calls
 
 
 def test_managed_node_used_when_system_lacks_npx(managed_node_install, monkeypatch, tmp_path):
@@ -272,16 +276,14 @@ def test_managed_node_used_when_system_lacks_npx(managed_node_install, monkeypat
 
 def test_complete_system_runtime_is_not_shadowed(managed_node_install, monkeypatch, tmp_path):
     sysbin = _system_node_dir(tmp_path)
-    monkeypatch.setattr(node_runtime, "_node_version_ok", lambda executable: True)
+    _patch_floors(monkeypatch, lambda executable: True)
     assert node_runtime.path_with_managed_node(str(sysbin)) == str(sysbin)
 
 
 def test_shadowed_managed_dir_moves_to_front(managed_node_install, monkeypatch, tmp_path):
     """Already on PATH but behind a stale runtime: it has to move up, not stay put."""
     stale = _system_node_dir(tmp_path)
-    monkeypatch.setattr(
-        node_runtime, "_node_version_ok", lambda executable: "sysbin" not in str(executable)
-    )
+    _patch_floors(monkeypatch, lambda executable: "sysbin" not in str(executable))
     configured = f"{stale}{os.pathsep}{managed_node_install}"
     expected = f"{managed_node_install}{os.pathsep}{stale}"
     assert node_runtime.path_with_managed_node(configured) == expected
@@ -289,9 +291,7 @@ def test_shadowed_managed_dir_moves_to_front(managed_node_install, monkeypatch, 
 
 def test_managed_dir_already_first_is_unchanged(managed_node_install, monkeypatch, tmp_path):
     stale = _system_node_dir(tmp_path)
-    monkeypatch.setattr(
-        node_runtime, "_node_version_ok", lambda executable: "sysbin" not in str(executable)
-    )
+    _patch_floors(monkeypatch, lambda executable: "sysbin" not in str(executable))
     configured = f"{managed_node_install}{os.pathsep}{stale}"
     assert node_runtime.path_with_managed_node(configured) == configured
 
@@ -336,13 +336,13 @@ def test_windows_npx_sibling_runtime_is_the_one_validated(
     _make_executable(good, "node")
     old = tmp_path / "old"
     old.mkdir()
+    _make_executable(old, "npm")
     _make_executable(old, "npx")
     (old / "node.exe").write_text("")
     monkeypatch.setattr(node_runtime, "_IS_WINDOWS", True)
     checked = []
-    monkeypatch.setattr(
-        node_runtime,
-        "_node_version_ok",
+    _patch_floors(
+        monkeypatch,
         lambda executable: checked.append(str(executable))
         or not str(executable).startswith(str(old)),
     )
@@ -359,8 +359,9 @@ def test_posix_split_layout_still_trusts_the_path_node(managed_node_install, mon
     _make_executable(good, "node")
     other = tmp_path / "other"
     other.mkdir()
+    _make_executable(other, "npm")
     _make_executable(other, "npx")
-    monkeypatch.setattr(node_runtime, "_node_version_ok", lambda executable: True)
+    _patch_floors(monkeypatch, lambda executable: True)
     configured = f"{good}{os.pathsep}{other}"
     assert node_runtime.path_with_managed_node(configured) == configured
 
@@ -398,3 +399,25 @@ def test_posix_treats_path_and_lowercase_path_as_distinct(managed_node, monkeypa
     env = mcp_client._stdio_env({"Path": "/opt/bin"}, "npx")
     assert env["Path"] == "/opt/bin"
     assert env["PATH"] == f"{managed_node}{os.pathsep}/usr/bin"
+
+
+def test_npm_below_installer_floor_falls_back_to_managed(
+    managed_node_install, monkeypatch, tmp_path
+):
+    """Node clears its floor but npm is 10, which is why setup installed the managed one."""
+    sysbin = _system_node_dir(tmp_path)
+    monkeypatch.setattr(node_runtime, "_node_version_ok", lambda executable: True)
+    monkeypatch.setattr(
+        node_runtime,
+        "_npm_version_ok",
+        lambda executable: not str(executable).startswith(str(sysbin)),
+    )
+    expected = f"{managed_node_install}{os.pathsep}{sysbin}"
+    assert node_runtime.path_with_managed_node(str(sysbin)) == expected
+
+
+def test_npm_floor_matches_the_installers():
+    assert node_runtime._npm_meets_floor("11.0.0")
+    assert node_runtime._npm_meets_floor("v12.1.2")
+    assert not node_runtime._npm_meets_floor("10.9.3")
+    assert not node_runtime._npm_meets_floor("")

--- a/studio/backend/tests/test_mcp_stdio_node_path.py
+++ b/studio/backend/tests/test_mcp_stdio_node_path.py
@@ -511,13 +511,61 @@ def test_direct_node_server_keeps_a_node_only_path(managed_node_install, monkeyp
     assert unchanged == str(nodeonly)
 
 
-def test_npx_server_still_needs_npm_on_a_node_only_path(
+def test_npx_server_still_needs_npx_on_a_node_only_path(
     managed_node_install, monkeypatch, tmp_path
 ):
+    """node alone cannot launch an ``npx`` server, so the managed dir still goes on."""
     nodeonly = _node_only_dir(tmp_path)
     _patch_floors(monkeypatch, lambda executable, path = None: True)
     expected = f"{managed_node_install}{os.pathsep}{nodeonly}"
-    assert node_runtime.path_with_managed_node(str(nodeonly)) == expected
+    assert (
+        node_runtime.path_with_managed_node(str(nodeonly), require_npm = False, require_npx = True)
+        == expected
+    )
+
+
+def test_npx_server_keeps_a_path_with_npx_but_no_npm(
+    managed_node_install, monkeypatch, tmp_path
+):
+    """A curated PATH exposing node and npx without a separate npm launcher runs npx fine:
+    npx-cli.js delegates in-process to the npm it ships with and never looks up an ``npm``
+    executable. Demanding one would prepend the managed dir and silently swap the
+    configured toolchain for a different npx, changing package resolution."""
+    curated = tmp_path / "curated"
+    curated.mkdir()
+    _make_executable(curated, "node")
+    _make_executable(curated, "npx")
+    _patch_floors(monkeypatch, lambda executable, path = None: True)
+    monkeypatch.setenv("PATH", str(curated))
+    assert mcp_client._stdio_env(None, "npx")["PATH"] == str(curated)
+    assert mcp_client._stdio_argv(
+        ["npx", "-y", "server"], {"PATH": str(curated)}
+    )[0].startswith(str(curated))
+
+
+def test_npx_only_path_is_still_held_to_the_npm_floor(
+    managed_node_install, monkeypatch, tmp_path
+):
+    """``npx -v`` reports the bundled npm's version, so an npx-only PATH is floor-checked
+    through npx rather than waved through."""
+    curated = tmp_path / "curated"
+    curated.mkdir()
+    _make_executable(curated, "node")
+    _make_executable(curated, "npx")
+    monkeypatch.setattr(node_runtime, "_node_version_ok", lambda executable, path = None: True)
+    probed = []
+
+    def _npm_floor(executable, path = None):
+        probed.append(str(executable))
+        return False  # the bundled npm is below the installers' floor
+
+    monkeypatch.setattr(node_runtime, "_npm_version_ok", _npm_floor)
+    expected = f"{managed_node_install}{os.pathsep}{curated}"
+    assert (
+        node_runtime.path_with_managed_node(str(curated), require_npm = False, require_npx = True)
+        == expected
+    )
+    assert any(os.path.basename(p).startswith("npx") for p in probed), probed
 
 
 def test_stdio_env_does_not_shadow_node_for_a_direct_node_server(
@@ -545,7 +593,8 @@ def test_runtime_requirements_match_each_launcher():
     assert mcp_client._runtime_requirements("node.exe") == (False, False)
     assert mcp_client._runtime_requirements("npm") == (True, False)
     assert mcp_client._runtime_requirements("npm.cmd") == (True, False)
-    assert mcp_client._runtime_requirements("npx") == (True, True)
+    assert mcp_client._runtime_requirements("npx") == (False, True)
+    assert mcp_client._runtime_requirements("npx.cmd") == (False, True)
     assert mcp_client._runtime_requirements(None) == (True, True)
 
 
@@ -687,4 +736,4 @@ def test_runtime_requirements_for_pathed_launchers():
     assert mcp_client._runtime_requirements("/opt/toolchain/npm") == (False, False)
     assert mcp_client._runtime_requirements("/opt/toolchain/npx") == (False, False)
     assert mcp_client._runtime_requirements("npm") == (True, False)
-    assert mcp_client._runtime_requirements("npx") == (True, True)
+    assert mcp_client._runtime_requirements("npx") == (False, True)

--- a/studio/backend/tests/test_mcp_stdio_node_path.py
+++ b/studio/backend/tests/test_mcp_stdio_node_path.py
@@ -582,9 +582,7 @@ def test_windows_npm_sibling_runtime_is_validated(managed_node_install, monkeypa
 
     _patch_floors(monkeypatch, lambda executable: _record(executable))
     configured = f"{good}{os.pathsep}{old}"
-    result = node_runtime.path_with_managed_node(
-        configured, require_npm = True, require_npx = False
-    )
+    result = node_runtime.path_with_managed_node(configured, require_npm = True, require_npx = False)
     assert any(c.endswith("node.exe") for c in checked), checked
     assert result == f"{managed_node_install}{os.pathsep}{configured}"
 
@@ -611,9 +609,7 @@ def test_pathed_npx_keeps_a_configured_node(managed_node_install, monkeypatch, t
     assert mcp_client._stdio_env(None, "/opt/toolchain/npx")["PATH"] == str(configured)
 
 
-def test_pathed_npm_still_gets_node_when_path_has_none(
-    managed_node_install, monkeypatch, tmp_path
-):
+def test_pathed_npm_still_gets_node_when_path_has_none(managed_node_install, monkeypatch, tmp_path):
     """With no node at all the shebang would fail, so the managed runtime still helps."""
     empty = tmp_path / "empty"
     empty.mkdir()

--- a/studio/backend/tests/test_mcp_stdio_node_path.py
+++ b/studio/backend/tests/test_mcp_stdio_node_path.py
@@ -33,7 +33,11 @@ def managed_node(tmp_path, monkeypatch):
     monkeypatch.setattr(node_runtime, "managed_node_bin_dir", lambda: bin_dir)
     monkeypatch.setattr(node_runtime, "managed_node_usable", lambda: True)
 
-    def _no_usable_node(path, require_npm = True, require_npx = True):
+    def _no_usable_node(
+        path,
+        require_npm = True,
+        require_npx = True,
+    ):
         return False
 
     monkeypatch.setattr(node_runtime, "_path_has_usable_node", _no_usable_node)

--- a/studio/backend/tests/test_mcp_stdio_node_path.py
+++ b/studio/backend/tests/test_mcp_stdio_node_path.py
@@ -146,20 +146,20 @@ def test_client_spawns_managed_npx_by_full_path(managed_node, monkeypatch, tmp_p
 
 def test_stale_managed_node_is_not_prepended(managed_node_install, monkeypatch):
     """A dir left behind after the host moved to a system Node must not win the lookup."""
-    monkeypatch.setattr(node_runtime, "_node_version_ok", lambda executable: False)
+    monkeypatch.setattr(node_runtime, "_node_version_ok", lambda executable, path = None: False)
     assert node_runtime.managed_node_usable() is False
     assert node_runtime.path_with_managed_node("/usr/bin") == "/usr/bin"
 
 
 def test_usable_managed_node_is_prepended(managed_node_install, monkeypatch):
-    monkeypatch.setattr(node_runtime, "_node_version_ok", lambda executable: True)
+    monkeypatch.setattr(node_runtime, "_node_version_ok", lambda executable, path = None: True)
     assert node_runtime.managed_node_usable() is True
     expected = f"{managed_node_install}{os.pathsep}/usr/bin"
     assert node_runtime.path_with_managed_node("/usr/bin") == expected
 
 
 def test_stale_managed_node_leaves_stdio_env_alone(managed_node_install, monkeypatch):
-    monkeypatch.setattr(node_runtime, "_node_version_ok", lambda executable: False)
+    monkeypatch.setattr(node_runtime, "_node_version_ok", lambda executable, path = None: False)
     monkeypatch.setenv("PATH", "/usr/bin")
     assert mcp_client._stdio_env(None)["PATH"] == "/usr/bin"
 
@@ -167,9 +167,11 @@ def test_stale_managed_node_leaves_stdio_env_alone(managed_node_install, monkeyp
 def test_managed_node_check_is_memoized_on_success(managed_node_install, monkeypatch):
     """One probe per process once usable: _stdio_env runs on every client build."""
     calls = []
-    monkeypatch.setattr(
-        node_runtime, "_node_version_ok", lambda executable: calls.append(executable) or True
-    )
+    def _record(executable, path = None):
+        calls.append(executable)
+        return True
+
+    monkeypatch.setattr(node_runtime, "_node_version_ok", _record)
     assert node_runtime.managed_node_usable() is True
     assert node_runtime.managed_node_usable() is True
     assert len(calls) == 1
@@ -236,14 +238,17 @@ def _system_node_dir(tmp_path, with_npx = True):
 
 def _patch_floors(monkeypatch, predicate):
     """Both floors move together: the installers require node AND npm to pass."""
-    monkeypatch.setattr(node_runtime, "_node_version_ok", predicate)
-    monkeypatch.setattr(node_runtime, "_npm_version_ok", predicate)
+    def _check(executable, path = None):
+        return predicate(executable)
+
+    monkeypatch.setattr(node_runtime, "_node_version_ok", _check)
+    monkeypatch.setattr(node_runtime, "_npm_version_ok", _check)
 
 
 def test_adequate_system_node_is_not_shadowed(managed_node_install, monkeypatch, tmp_path):
     """A leftover managed install must not override a Node the PATH already provides."""
     sysbin = _system_node_dir(tmp_path)
-    _patch_floors(monkeypatch, lambda executable: True)
+    _patch_floors(monkeypatch, lambda executable, path = None: True)
     assert node_runtime.path_with_managed_node(str(sysbin)) == str(sysbin)
 
 
@@ -251,7 +256,7 @@ def test_managed_node_used_when_system_node_is_below_floor(
     managed_node_install, monkeypatch, tmp_path
 ):
     sysbin = _system_node_dir(tmp_path)
-    _patch_floors(monkeypatch, lambda executable: "sysbin" not in str(executable))
+    _patch_floors(monkeypatch, lambda executable, path = None: "sysbin" not in str(executable))
     expected = f"{managed_node_install}{os.pathsep}{sysbin}"
     assert node_runtime.path_with_managed_node(str(sysbin)) == expected
 
@@ -259,7 +264,7 @@ def test_managed_node_used_when_system_node_is_below_floor(
 def test_managed_node_used_when_path_has_no_node(managed_node_install, monkeypatch, tmp_path):
     empty = tmp_path / "empty"
     empty.mkdir()
-    monkeypatch.setattr(node_runtime, "_node_version_ok", lambda executable: True)
+    monkeypatch.setattr(node_runtime, "_node_version_ok", lambda executable, path = None: True)
     expected = f"{managed_node_install}{os.pathsep}{empty}"
     assert node_runtime.path_with_managed_node(str(empty)) == expected
 
@@ -267,7 +272,7 @@ def test_managed_node_used_when_path_has_no_node(managed_node_install, monkeypat
 def test_system_node_probe_is_memoized(managed_node_install, monkeypatch, tmp_path):
     sysbin = _system_node_dir(tmp_path)
     calls = []
-    _patch_floors(monkeypatch, lambda executable: calls.append(executable) or True)
+    _patch_floors(monkeypatch, lambda executable, path = None: calls.append(executable) or True)
     assert node_runtime.path_with_managed_node(str(sysbin)) == str(sysbin)
     after_first = len(calls)
     assert node_runtime.path_with_managed_node(str(sysbin)) == str(sysbin)
@@ -277,21 +282,21 @@ def test_system_node_probe_is_memoized(managed_node_install, monkeypatch, tmp_pa
 def test_managed_node_used_when_system_lacks_npx(managed_node_install, monkeypatch, tmp_path):
     """decide_node_source installs bundled when npm is missing, so node alone is not enough."""
     sysbin = _system_node_dir(tmp_path, with_npx = False)
-    monkeypatch.setattr(node_runtime, "_node_version_ok", lambda executable: True)
+    monkeypatch.setattr(node_runtime, "_node_version_ok", lambda executable, path = None: True)
     expected = f"{managed_node_install}{os.pathsep}{sysbin}"
     assert node_runtime.path_with_managed_node(str(sysbin)) == expected
 
 
 def test_complete_system_runtime_is_not_shadowed(managed_node_install, monkeypatch, tmp_path):
     sysbin = _system_node_dir(tmp_path)
-    _patch_floors(monkeypatch, lambda executable: True)
+    _patch_floors(monkeypatch, lambda executable, path = None: True)
     assert node_runtime.path_with_managed_node(str(sysbin)) == str(sysbin)
 
 
 def test_shadowed_managed_dir_moves_to_front(managed_node_install, monkeypatch, tmp_path):
     """Already on PATH but behind a stale runtime: it has to move up, not stay put."""
     stale = _system_node_dir(tmp_path)
-    _patch_floors(monkeypatch, lambda executable: "sysbin" not in str(executable))
+    _patch_floors(monkeypatch, lambda executable, path = None: "sysbin" not in str(executable))
     configured = f"{stale}{os.pathsep}{managed_node_install}"
     expected = f"{managed_node_install}{os.pathsep}{stale}"
     assert node_runtime.path_with_managed_node(configured) == expected
@@ -299,7 +304,7 @@ def test_shadowed_managed_dir_moves_to_front(managed_node_install, monkeypatch, 
 
 def test_managed_dir_already_first_is_unchanged(managed_node_install, monkeypatch, tmp_path):
     stale = _system_node_dir(tmp_path)
-    _patch_floors(monkeypatch, lambda executable: "sysbin" not in str(executable))
+    _patch_floors(monkeypatch, lambda executable, path = None: "sysbin" not in str(executable))
     configured = f"{managed_node_install}{os.pathsep}{stale}"
     assert node_runtime.path_with_managed_node(configured) == configured
 
@@ -351,7 +356,7 @@ def test_windows_npx_sibling_runtime_is_the_one_validated(
     checked = []
     _patch_floors(
         monkeypatch,
-        lambda executable: checked.append(str(executable))
+        lambda executable, path = None: checked.append(str(executable))
         or not str(executable).startswith(str(old)),
     )
     configured = f"{good}{os.pathsep}{old}"
@@ -369,7 +374,7 @@ def test_posix_split_layout_still_trusts_the_path_node(managed_node_install, mon
     other.mkdir()
     _make_executable(other, "npm")
     _make_executable(other, "npx")
-    _patch_floors(monkeypatch, lambda executable: True)
+    _patch_floors(monkeypatch, lambda executable, path = None: True)
     configured = f"{good}{os.pathsep}{other}"
     assert node_runtime.path_with_managed_node(configured) == configured
 
@@ -414,11 +419,11 @@ def test_npm_below_installer_floor_falls_back_to_managed(
 ):
     """Node clears its floor but npm is 10, which is why setup installed the managed one."""
     sysbin = _system_node_dir(tmp_path)
-    monkeypatch.setattr(node_runtime, "_node_version_ok", lambda executable: True)
+    monkeypatch.setattr(node_runtime, "_node_version_ok", lambda executable, path = None: True)
     monkeypatch.setattr(
         node_runtime,
         "_npm_version_ok",
-        lambda executable: not str(executable).startswith(str(sysbin)),
+        lambda executable, path = None: not str(executable).startswith(str(sysbin)),
     )
     expected = f"{managed_node_install}{os.pathsep}{sysbin}"
     assert node_runtime.path_with_managed_node(str(sysbin)) == expected
@@ -441,7 +446,7 @@ def _node_only_dir(tmp_path):
 
 def test_direct_node_server_keeps_a_node_only_path(managed_node_install, monkeypatch, tmp_path):
     nodeonly = _node_only_dir(tmp_path)
-    _patch_floors(monkeypatch, lambda executable: True)
+    _patch_floors(monkeypatch, lambda executable, path = None: True)
     unchanged = node_runtime.path_with_managed_node(
         str(nodeonly), require_npm = False, require_npx = False
     )
@@ -452,7 +457,7 @@ def test_npx_server_still_needs_npm_on_a_node_only_path(
     managed_node_install, monkeypatch, tmp_path
 ):
     nodeonly = _node_only_dir(tmp_path)
-    _patch_floors(monkeypatch, lambda executable: True)
+    _patch_floors(monkeypatch, lambda executable, path = None: True)
     expected = f"{managed_node_install}{os.pathsep}{nodeonly}"
     assert node_runtime.path_with_managed_node(str(nodeonly)) == expected
 
@@ -461,7 +466,7 @@ def test_stdio_env_does_not_shadow_node_for_a_direct_node_server(
     managed_node_install, monkeypatch, tmp_path
 ):
     nodeonly = _node_only_dir(tmp_path)
-    _patch_floors(monkeypatch, lambda executable: True)
+    _patch_floors(monkeypatch, lambda executable, path = None: True)
     monkeypatch.setenv("PATH", str(nodeonly))
     assert mcp_client._stdio_env(None, "node")["PATH"] == str(nodeonly)
 
@@ -470,7 +475,7 @@ def test_stdio_env_still_augments_for_npx_on_a_node_only_path(
     managed_node_install, monkeypatch, tmp_path
 ):
     nodeonly = _node_only_dir(tmp_path)
-    _patch_floors(monkeypatch, lambda executable: True)
+    _patch_floors(monkeypatch, lambda executable, path = None: True)
     monkeypatch.setenv("PATH", str(nodeonly))
     env = mcp_client._stdio_env(None, "npx")
     assert env["PATH"] == f"{managed_node_install}{os.pathsep}{nodeonly}"
@@ -519,7 +524,7 @@ def test_direct_npm_server_does_not_need_npx(managed_node_install, monkeypatch, 
     nonpx.mkdir()
     _make_executable(nonpx, "node")
     _make_executable(nonpx, "npm")
-    _patch_floors(monkeypatch, lambda executable: True)
+    _patch_floors(monkeypatch, lambda executable, path = None: True)
     monkeypatch.setenv("PATH", str(nonpx))
     assert mcp_client._stdio_env(None, "npm")["PATH"] == str(nonpx)
 
@@ -531,7 +536,27 @@ def test_npx_server_on_the_same_path_still_gets_managed(
     nonpx.mkdir()
     _make_executable(nonpx, "node")
     _make_executable(nonpx, "npm")
-    _patch_floors(monkeypatch, lambda executable: True)
+    _patch_floors(monkeypatch, lambda executable, path = None: True)
     monkeypatch.setenv("PATH", str(nonpx))
     env = mcp_client._stdio_env(None, "npx")
     assert env["PATH"] == f"{managed_node_install}{os.pathsep}{nonpx}"
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX shebang launcher")
+def test_npm_probe_runs_with_the_candidate_path(managed_node_install, monkeypatch, tmp_path):
+    """npm is a `#!/usr/bin/env node` script, so the probe needs the candidate's node."""
+    toolchain = tmp_path / "toolchain"
+    toolchain.mkdir()
+    node = toolchain / "node"
+    node.write_text("#!/bin/sh\necho v22.12.0\n")
+    node.chmod(0o755)
+    npm = toolchain / "npm"
+    npm.write_text("#!/usr/bin/env node\n")       # only runs if node is on the probe PATH
+    npm.chmod(0o755)
+    _make_executable(toolchain, "npx")
+    # a backend PATH with no node at all, which is why this PR exists
+    monkeypatch.setenv("PATH", "/nonexistent-9304")
+    monkeypatch.setattr(node_runtime, "_npm_meets_floor", lambda version: True)
+    # the managed install must be usable, or the function returns before the npm probe
+    monkeypatch.setattr(node_runtime, "managed_node_usable", lambda: True)
+    assert node_runtime.path_with_managed_node(str(toolchain)) == str(toolchain)

--- a/studio/backend/tests/test_mcp_stdio_node_path.py
+++ b/studio/backend/tests/test_mcp_stdio_node_path.py
@@ -370,6 +370,13 @@ def windows_env(monkeypatch):
     monkeypatch.setattr(mcp_client, "_IS_WINDOWS", True)
 
 
+@pytest.fixture
+def posix_env(monkeypatch):
+    """Pin the platform: these assert POSIX semantics and must not follow the runner."""
+    monkeypatch.setattr(mcp_client, "_IS_WINDOWS", False)
+    monkeypatch.setattr(node_runtime, "_IS_WINDOWS", False)
+
+
 def test_windows_lowercase_path_key_is_recognized(managed_node, monkeypatch, windows_env):
     monkeypatch.setenv("PATH", "/usr/bin")
     env = mcp_client._stdio_env({"Path": "/opt/bin"}, "npx")
@@ -386,7 +393,7 @@ def test_windows_lowercase_path_blocks_host_lookup(managed_node, windows_env):
     assert mcp_client._stdio_argv(["npx"], {"Path": ""}) == ["npx"]
 
 
-def test_posix_treats_path_and_lowercase_path_as_distinct(managed_node, monkeypatch):
+def test_posix_treats_path_and_lowercase_path_as_distinct(managed_node, monkeypatch, posix_env):
     monkeypatch.setenv("PATH", "/usr/bin")
     env = mcp_client._stdio_env({"Path": "/opt/bin"}, "npx")
     assert env["Path"] == "/opt/bin"

--- a/studio/backend/tests/test_mcp_stdio_node_path.py
+++ b/studio/backend/tests/test_mcp_stdio_node_path.py
@@ -7,6 +7,7 @@ Run from studio/backend:  python -m pytest tests/test_mcp_stdio_node_path.py -q
 """
 
 import os
+import shutil
 
 import pytest
 
@@ -65,3 +66,46 @@ def test_client_passes_node_path_to_transport(managed_node, monkeypatch):
     monkeypatch.setenv("PATH", "/usr/bin")
     client = mcp_client._client("npx -y @modelcontextprotocol/server-filesystem /tmp", None)
     assert client.transport.env["PATH"].split(os.pathsep)[0] == str(managed_node)
+
+
+def _make_executable(bin_dir, name):
+    """A stub the platform's own PATH lookup will accept (.cmd via PATHEXT on Windows)."""
+    path = bin_dir / (f"{name}.cmd" if os.name == "nt" else name)
+    path.write_text("")
+    if os.name != "nt":
+        path.chmod(0o755)
+    return path
+
+
+def test_stdio_argv_resolves_managed_npx(managed_node):
+    npx = _make_executable(managed_node, "npx")
+    env = mcp_client._stdio_env(None)
+    argv = mcp_client._stdio_argv(["npx", "-y", "pkg"], env)
+    assert os.path.samefile(argv[0], npx)
+    assert argv[1:] == ["-y", "pkg"]
+
+
+def test_stdio_argv_keeps_unresolvable_command(managed_node):
+    argv = mcp_client._stdio_argv(["definitely-not-on-path-9304", "-y"], mcp_client._stdio_env(None))
+    assert argv == ["definitely-not-on-path-9304", "-y"]
+
+
+def test_stdio_argv_prefers_child_path_over_parent(managed_node, monkeypatch, tmp_path):
+    """The parent env must not decide the lookup: only the child PATH has the command."""
+    npx = _make_executable(managed_node, "npx")
+    bare = tmp_path / "empty"
+    bare.mkdir()
+    monkeypatch.setenv("PATH", str(bare))
+    assert shutil.which("npx") is None
+    argv = mcp_client._stdio_argv(["npx"], mcp_client._stdio_env(None))
+    assert os.path.samefile(argv[0], npx)
+
+
+def test_client_spawns_managed_npx_by_full_path(managed_node, monkeypatch, tmp_path):
+    npx = _make_executable(managed_node, "npx")
+    bare = tmp_path / "empty"
+    bare.mkdir()
+    monkeypatch.setenv("PATH", str(bare))
+    monkeypatch.setenv("UNSLOTH_STUDIO_ALLOW_STDIO_MCP", "1")
+    client = mcp_client._client("npx -y @modelcontextprotocol/server-filesystem /tmp", None)
+    assert os.path.samefile(client.transport.command, npx)

--- a/studio/backend/tests/test_mcp_stdio_node_path.py
+++ b/studio/backend/tests/test_mcp_stdio_node_path.py
@@ -582,6 +582,57 @@ def test_windows_npm_sibling_runtime_is_validated(managed_node_install, monkeypa
 
     _patch_floors(monkeypatch, lambda executable: _record(executable))
     configured = f"{good}{os.pathsep}{old}"
-    result = node_runtime.path_with_managed_node(configured, require_npm = True, require_npx = False)
+    result = node_runtime.path_with_managed_node(
+        configured, require_npm = True, require_npx = False
+    )
     assert any(c.endswith("node.exe") for c in checked), checked
     assert result == f"{managed_node_install}{os.pathsep}{configured}"
+
+
+def _good_node_only(tmp_path, name = "toolchain"):
+    d = tmp_path / name
+    d.mkdir()
+    _make_executable(d, "node")
+    return d
+
+
+def test_pathed_npm_keeps_a_configured_node(managed_node_install, monkeypatch, tmp_path):
+    """The pathed launcher runs either way; its shebang must keep the configured node."""
+    configured = _good_node_only(tmp_path)
+    _patch_floors(monkeypatch, lambda executable: True)
+    monkeypatch.setenv("PATH", str(configured))
+    assert mcp_client._stdio_env(None, "/opt/toolchain/npm")["PATH"] == str(configured)
+
+
+def test_pathed_npx_keeps_a_configured_node(managed_node_install, monkeypatch, tmp_path):
+    configured = _good_node_only(tmp_path)
+    _patch_floors(monkeypatch, lambda executable: True)
+    monkeypatch.setenv("PATH", str(configured))
+    assert mcp_client._stdio_env(None, "/opt/toolchain/npx")["PATH"] == str(configured)
+
+
+def test_pathed_npm_still_gets_node_when_path_has_none(
+    managed_node_install, monkeypatch, tmp_path
+):
+    """With no node at all the shebang would fail, so the managed runtime still helps."""
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    _patch_floors(monkeypatch, lambda executable: True)
+    monkeypatch.setenv("PATH", str(empty))
+    env = mcp_client._stdio_env(None, "/opt/toolchain/npm")
+    assert env["PATH"] == f"{managed_node_install}{os.pathsep}{empty}"
+
+
+def test_bare_npm_still_requires_npm_on_path(managed_node_install, monkeypatch, tmp_path):
+    configured = _good_node_only(tmp_path, "bare")
+    _patch_floors(monkeypatch, lambda executable: True)
+    monkeypatch.setenv("PATH", str(configured))
+    env = mcp_client._stdio_env(None, "npm")
+    assert env["PATH"] == f"{managed_node_install}{os.pathsep}{configured}"
+
+
+def test_runtime_requirements_for_pathed_launchers():
+    assert mcp_client._runtime_requirements("/opt/toolchain/npm") == (False, False)
+    assert mcp_client._runtime_requirements("/opt/toolchain/npx") == (False, False)
+    assert mcp_client._runtime_requirements("npm") == (True, False)
+    assert mcp_client._runtime_requirements("npx") == (True, True)

--- a/studio/backend/tests/test_mcp_stdio_node_path.py
+++ b/studio/backend/tests/test_mcp_stdio_node_path.py
@@ -8,6 +8,7 @@ Run from studio/backend:  python -m pytest tests/test_mcp_stdio_node_path.py -q
 
 import os
 import shutil
+import sys
 
 import pytest
 
@@ -163,3 +164,31 @@ def test_managed_node_check_is_memoized_on_success(managed_node_install, monkeyp
     assert node_runtime.managed_node_usable() is True
     assert node_runtime.managed_node_usable() is True
     assert len(calls) == 1
+
+
+def test_explicit_empty_path_is_preserved(managed_node, monkeypatch):
+    """PATH: "" is a deliberate sandbox; the inherited PATH must not replace it."""
+    monkeypatch.setenv("PATH", "/usr/bin")
+    env = mcp_client._stdio_env({"API_KEY": "sk-1", "PATH": ""})
+    assert env["PATH"] == ""
+    assert env["API_KEY"] == "sk-1"
+
+
+def test_explicit_empty_path_blocks_host_lookup(managed_node, monkeypatch, tmp_path):
+    """The host PATH must not resolve argv[0] once the server opted out of PATH."""
+    host = tmp_path / "hostbin"
+    host.mkdir()
+    _make_executable(host, "hostcmd")
+    monkeypatch.setenv("PATH", str(host))
+    assert shutil.which("hostcmd") is not None
+    assert mcp_client._stdio_argv(["hostcmd"], {"PATH": ""}) == ["hostcmd"]
+
+
+def test_explicit_empty_path_still_allows_absolute_command(managed_node):
+    argv = mcp_client._stdio_argv([sys.executable, "-c", "pass"], {"PATH": ""})
+    assert argv == [sys.executable, "-c", "pass"]
+
+
+def test_absent_path_still_inherits(managed_node, monkeypatch):
+    monkeypatch.setenv("PATH", "/usr/bin")
+    assert mcp_client._stdio_env({"API_KEY": "sk-1"})["PATH"] == f"{managed_node}{os.pathsep}/usr/bin"

--- a/studio/backend/tests/test_mcp_stdio_node_path.py
+++ b/studio/backend/tests/test_mcp_stdio_node_path.py
@@ -215,10 +215,13 @@ def test_stdio_env_preserves_empty_component_from_config(managed_node):
     assert env["PATH"] == f"{managed_node}{os.pathsep}{configured}"
 
 
-def _system_node_dir(tmp_path):
+def _system_node_dir(tmp_path, with_npx = True):
+    """A system runtime dir; without npx it mirrors a host where setup picked bundled."""
     sysbin = tmp_path / "sysbin"
     sysbin.mkdir()
     _make_executable(sysbin, "node")
+    if with_npx:
+        _make_executable(sysbin, "npx")
     return sysbin
 
 
@@ -257,3 +260,17 @@ def test_system_node_probe_is_memoized(managed_node_install, monkeypatch, tmp_pa
     assert node_runtime.path_with_managed_node(str(sysbin)) == str(sysbin)
     assert node_runtime.path_with_managed_node(str(sysbin)) == str(sysbin)
     assert len(calls) == 1
+
+
+def test_managed_node_used_when_system_lacks_npx(managed_node_install, monkeypatch, tmp_path):
+    """decide_node_source installs bundled when npm is missing, so node alone is not enough."""
+    sysbin = _system_node_dir(tmp_path, with_npx = False)
+    monkeypatch.setattr(node_runtime, "_node_version_ok", lambda executable: True)
+    expected = f"{managed_node_install}{os.pathsep}{sysbin}"
+    assert node_runtime.path_with_managed_node(str(sysbin)) == expected
+
+
+def test_complete_system_runtime_is_not_shadowed(managed_node_install, monkeypatch, tmp_path):
+    sysbin = _system_node_dir(tmp_path)
+    monkeypatch.setattr(node_runtime, "_node_version_ok", lambda executable: True)
+    assert node_runtime.path_with_managed_node(str(sysbin)) == str(sysbin)

--- a/studio/backend/tests/test_mcp_stdio_node_path.py
+++ b/studio/backend/tests/test_mcp_stdio_node_path.py
@@ -45,6 +45,18 @@ def managed_node(tmp_path, monkeypatch):
 
 
 @pytest.fixture
+def runtime_free_dir(tmp_path):
+    """A base PATH that resolves no runtime on every host. Real system dirs cannot be used
+    for this: a developer machine with Node in /usr/bin resolves a complete toolchain there,
+    so path_with_managed_node returns it unchanged and a prepend assertion fails, while a CI
+    image without Node passes. The empty dir makes the outcome depend on the managed install
+    under test rather than on what the host happens to ship."""
+    base = tmp_path / "runtime-free"
+    base.mkdir()
+    return base
+
+
+@pytest.fixture
 def managed_node_install(tmp_path, monkeypatch):
     """The real locator + a stub node binary, so managed_node_usable() is exercised."""
     monkeypatch.setenv("UNSLOTH_STUDIO_HOME", str(tmp_path / "studio"))
@@ -144,24 +156,37 @@ def test_client_spawns_managed_npx_by_full_path(managed_node, monkeypatch, tmp_p
     assert os.path.samefile(client.transport.command, npx)
 
 
-def test_stale_managed_node_is_not_prepended(managed_node_install, monkeypatch):
+def test_runtime_free_dir_resolves_nothing(runtime_free_dir):
+    """Pins the precondition the prepend tests below rely on. Asserting against a real
+    system dir like /usr/bin instead would make them read the host: where it ships a
+    Node the base PATH already resolves a runtime, so path_with_managed_node correctly
+    returns it unchanged and the prepend assertions flip."""
+    assert node_runtime._path_has_usable_node(str(runtime_free_dir)) is False
+    assert node_runtime._path_has_usable_node(str(runtime_free_dir), require_npm = False) is False
+
+
+def test_stale_managed_node_is_not_prepended(managed_node_install, monkeypatch, runtime_free_dir):
     """A dir left behind after the host moved to a system Node must not win the lookup."""
     monkeypatch.setattr(node_runtime, "_node_version_ok", lambda executable, path = None: False)
     assert node_runtime.managed_node_usable() is False
-    assert node_runtime.path_with_managed_node("/usr/bin") == "/usr/bin"
+    base = str(runtime_free_dir)
+    assert node_runtime.path_with_managed_node(base) == base
 
 
-def test_usable_managed_node_is_prepended(managed_node_install, monkeypatch):
+def test_usable_managed_node_is_prepended(managed_node_install, monkeypatch, runtime_free_dir):
     monkeypatch.setattr(node_runtime, "_node_version_ok", lambda executable, path = None: True)
     assert node_runtime.managed_node_usable() is True
-    expected = f"{managed_node_install}{os.pathsep}/usr/bin"
-    assert node_runtime.path_with_managed_node("/usr/bin") == expected
+    base = str(runtime_free_dir)
+    expected = f"{managed_node_install}{os.pathsep}{base}"
+    assert node_runtime.path_with_managed_node(base) == expected
 
 
-def test_stale_managed_node_leaves_stdio_env_alone(managed_node_install, monkeypatch):
+def test_stale_managed_node_leaves_stdio_env_alone(
+    managed_node_install, monkeypatch, runtime_free_dir
+):
     monkeypatch.setattr(node_runtime, "_node_version_ok", lambda executable, path = None: False)
-    monkeypatch.setenv("PATH", "/usr/bin")
-    assert mcp_client._stdio_env(None)["PATH"] == "/usr/bin"
+    monkeypatch.setenv("PATH", str(runtime_free_dir))
+    assert mcp_client._stdio_env(None)["PATH"] == str(runtime_free_dir)
 
 
 def test_managed_node_check_is_memoized_on_success(managed_node_install, monkeypatch):

--- a/studio/backend/tests/test_mcp_stdio_node_path.py
+++ b/studio/backend/tests/test_mcp_stdio_node_path.py
@@ -352,9 +352,7 @@ def test_windows_npx_sibling_runtime_is_the_one_validated(
     assert result == f"{managed_node_install}{os.pathsep}{configured}"
 
 
-def test_posix_split_layout_still_trusts_the_path_node(
-    managed_node_install, monkeypatch, tmp_path
-):
+def test_posix_split_layout_still_trusts_the_path_node(managed_node_install, monkeypatch, tmp_path):
     """On POSIX npx is a shebang script resolving node via PATH, so a split is fine."""
     good = tmp_path / "good"
     good.mkdir()

--- a/studio/backend/tests/test_mcp_stdio_node_path.py
+++ b/studio/backend/tests/test_mcp_stdio_node_path.py
@@ -582,8 +582,6 @@ def test_windows_npm_sibling_runtime_is_validated(managed_node_install, monkeypa
 
     _patch_floors(monkeypatch, lambda executable: _record(executable))
     configured = f"{good}{os.pathsep}{old}"
-    result = node_runtime.path_with_managed_node(
-        configured, require_npm = True, require_npx = False
-    )
+    result = node_runtime.path_with_managed_node(configured, require_npm = True, require_npx = False)
     assert any(c.endswith("node.exe") for c in checked), checked
     assert result == f"{managed_node_install}{os.pathsep}{configured}"

--- a/studio/backend/tests/test_mcp_stdio_node_path.py
+++ b/studio/backend/tests/test_mcp_stdio_node_path.py
@@ -157,7 +157,9 @@ def test_stale_managed_node_leaves_stdio_env_alone(managed_node_install, monkeyp
 def test_managed_node_check_is_memoized_on_success(managed_node_install, monkeypatch):
     """One probe per process once usable: _stdio_env runs on every client build."""
     calls = []
-    monkeypatch.setattr(node_runtime, "_node_version_ok", lambda executable: calls.append(executable) or True)
+    monkeypatch.setattr(
+        node_runtime, "_node_version_ok", lambda executable: calls.append(executable) or True
+    )
     assert node_runtime.managed_node_usable() is True
     assert node_runtime.managed_node_usable() is True
     assert len(calls) == 1

--- a/studio/backend/tests/test_mcp_stdio_node_path.py
+++ b/studio/backend/tests/test_mcp_stdio_node_path.py
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""stdio MCP servers get the managed Node bin dir on PATH.
+
+Run from studio/backend:  python -m pytest tests/test_mcp_stdio_node_path.py -q
+"""
+
+import os
+
+import pytest
+
+from core.inference import mcp_client
+from utils import node_runtime
+
+
+@pytest.fixture
+def managed_node(tmp_path, monkeypatch):
+    monkeypatch.setenv("UNSLOTH_STUDIO_HOME", str(tmp_path / "studio"))
+    bin_dir = tmp_path / "studio" / "node" / ("" if os.name == "nt" else "bin")
+    bin_dir.mkdir(parents = True, exist_ok = True)
+    monkeypatch.setattr(node_runtime, "managed_node_bin_dir", lambda: bin_dir)
+    return bin_dir
+
+
+def test_bin_dir_none_when_not_installed(tmp_path, monkeypatch):
+    monkeypatch.setenv("UNSLOTH_STUDIO_HOME", str(tmp_path / "studio"))
+    assert node_runtime.managed_node_bin_dir() is None
+
+
+def test_path_prepends_managed_node(managed_node):
+    assert node_runtime.path_with_managed_node("/usr/bin") == f"{managed_node}{os.pathsep}/usr/bin"
+
+
+def test_path_unchanged_when_already_present(managed_node):
+    existing = f"{managed_node}{os.pathsep}/usr/bin"
+    assert node_runtime.path_with_managed_node(existing) == existing
+
+
+def test_path_unchanged_without_managed_node(tmp_path, monkeypatch):
+    monkeypatch.setenv("UNSLOTH_STUDIO_HOME", str(tmp_path / "studio"))
+    assert node_runtime.path_with_managed_node("/usr/bin") == "/usr/bin"
+
+
+def test_stdio_env_adds_node_to_inherited_path(managed_node, monkeypatch):
+    monkeypatch.setenv("PATH", "/usr/bin")
+    env = mcp_client._stdio_env(None)
+    assert env["PATH"] == f"{managed_node}{os.pathsep}/usr/bin"
+
+
+def test_stdio_env_keeps_server_env_and_extends_its_path(managed_node):
+    env = mcp_client._stdio_env({"API_KEY": "sk-1", "PATH": "/opt/bin"})
+    assert env["API_KEY"] == "sk-1"
+    assert env["PATH"] == f"{managed_node}{os.pathsep}/opt/bin"
+
+
+def test_stdio_env_is_none_without_managed_node_or_vars(tmp_path, monkeypatch):
+    monkeypatch.setenv("UNSLOTH_STUDIO_HOME", str(tmp_path / "studio"))
+    monkeypatch.delenv("PATH", raising = False)
+    assert mcp_client._stdio_env(None) is None
+
+
+def test_client_passes_node_path_to_transport(managed_node, monkeypatch):
+    monkeypatch.setenv("UNSLOTH_STUDIO_ALLOW_STDIO_MCP", "1")
+    monkeypatch.setenv("PATH", "/usr/bin")
+    client = mcp_client._client("npx -y @modelcontextprotocol/server-filesystem /tmp", None)
+    assert client.transport.env["PATH"].split(os.pathsep)[0] == str(managed_node)

--- a/studio/backend/tests/test_mcp_stdio_node_path.py
+++ b/studio/backend/tests/test_mcp_stdio_node_path.py
@@ -32,7 +32,9 @@ def managed_node(tmp_path, monkeypatch):
     bin_dir.mkdir(parents = True, exist_ok = True)
     monkeypatch.setattr(node_runtime, "managed_node_bin_dir", lambda: bin_dir)
     monkeypatch.setattr(node_runtime, "managed_node_usable", lambda: True)
-    monkeypatch.setattr(node_runtime, "_path_has_usable_node", lambda path: False)
+    monkeypatch.setattr(
+        node_runtime, "_path_has_usable_node", lambda path, require_npm = True: False
+    )
     return bin_dir
 
 
@@ -421,3 +423,54 @@ def test_npm_floor_matches_the_installers():
     assert node_runtime._npm_meets_floor("v12.1.2")
     assert not node_runtime._npm_meets_floor("10.9.3")
     assert not node_runtime._npm_meets_floor("")
+
+
+def _node_only_dir(tmp_path):
+    """Debian/Ubuntu ship nodejs and npm as separate packages, so this is ordinary."""
+    nodeonly = tmp_path / "nodeonly"
+    nodeonly.mkdir()
+    _make_executable(nodeonly, "node")
+    return nodeonly
+
+
+def test_direct_node_server_keeps_a_node_only_path(managed_node_install, monkeypatch, tmp_path):
+    nodeonly = _node_only_dir(tmp_path)
+    _patch_floors(monkeypatch, lambda executable: True)
+    assert node_runtime.path_with_managed_node(str(nodeonly), require_npm = False) == str(nodeonly)
+
+
+def test_npx_server_still_needs_npm_on_a_node_only_path(
+    managed_node_install, monkeypatch, tmp_path
+):
+    nodeonly = _node_only_dir(tmp_path)
+    _patch_floors(monkeypatch, lambda executable: True)
+    expected = f"{managed_node_install}{os.pathsep}{nodeonly}"
+    assert node_runtime.path_with_managed_node(str(nodeonly)) == expected
+
+
+def test_stdio_env_does_not_shadow_node_for_a_direct_node_server(
+    managed_node_install, monkeypatch, tmp_path
+):
+    nodeonly = _node_only_dir(tmp_path)
+    _patch_floors(monkeypatch, lambda executable: True)
+    monkeypatch.setenv("PATH", str(nodeonly))
+    assert mcp_client._stdio_env(None, "node")["PATH"] == str(nodeonly)
+
+
+def test_stdio_env_still_augments_for_npx_on_a_node_only_path(
+    managed_node_install, monkeypatch, tmp_path
+):
+    nodeonly = _node_only_dir(tmp_path)
+    _patch_floors(monkeypatch, lambda executable: True)
+    monkeypatch.setenv("PATH", str(nodeonly))
+    env = mcp_client._stdio_env(None, "npx")
+    assert env["PATH"] == f"{managed_node_install}{os.pathsep}{nodeonly}"
+
+
+def test_command_needs_npm_only_for_launchers():
+    assert not mcp_client._command_needs_npm("node")
+    assert not mcp_client._command_needs_npm("/usr/bin/node")
+    assert not mcp_client._command_needs_npm("node.exe")
+    assert mcp_client._command_needs_npm("npx")
+    assert mcp_client._command_needs_npm("npm.cmd")
+    assert mcp_client._command_needs_npm(None)

--- a/studio/backend/utils/node_runtime.py
+++ b/studio/backend/utils/node_runtime.py
@@ -82,15 +82,43 @@ def managed_node_bin_dir() -> Path | None:
         return None
 
 
+# Memoize ONLY a usable managed Node, mirroring _resolved_node: the installer may
+# finish after the first probe, so a negative result must not stick until restart.
+_managed_node_ok: bool = False
+
+
+def _reset_managed_node_check() -> None:
+    """Clear the memoized managed-Node verdict (used by tests)."""
+    global _managed_node_ok
+    _managed_node_ok = False
+
+
+def managed_node_usable() -> bool:
+    """Whether the managed Node clears the version floor. ``decide_node_source``
+    leaves an existing install in place when it picks the system runtime, so a dir
+    left over from before a floor raise must not win the lookup over a good system
+    Node. Mirrors the managed branch of resolve_node_executable()."""
+    global _managed_node_ok
+    if _managed_node_ok:
+        return True
+    binary = managed_node_binary()
+    try:
+        present = binary.is_file()
+    except OSError:
+        return False
+    _managed_node_ok = present and _node_version_ok(str(binary))
+    return _managed_node_ok
+
+
 def path_with_managed_node(base_path: str | None = None) -> str:
     """``base_path`` (default: this process's PATH) with the managed Node bin dir
-    prepended, unchanged when there is no managed install or it is already there.
+    prepended, unchanged when there is no usable managed install or it is already there.
 
     The installer only puts the isolated Node on PATH for the setup process, so
     subprocesses that need ``node``/``npx`` must be handed it explicitly."""
     current = os.environ.get("PATH", "") if base_path is None else base_path
     bin_dir = managed_node_bin_dir()
-    if bin_dir is None:
+    if bin_dir is None or not managed_node_usable():
         return current
     bin_str = str(bin_dir)
     entries = [entry for entry in current.split(os.pathsep) if entry]

--- a/studio/backend/utils/node_runtime.py
+++ b/studio/backend/utils/node_runtime.py
@@ -132,8 +132,8 @@ def managed_node_usable() -> bool:
 
 def path_with_managed_node(base_path: str | None = None) -> str:
     """``base_path`` (default: this process's PATH) with the managed Node bin dir
-    prepended, unchanged when it is unusable or already there. The installer puts the
-    isolated Node on PATH for setup only, so subprocesses must be handed it."""
+    moved to the front, unchanged when it is unusable or the PATH already resolves a
+    runtime. The installer puts it on PATH for setup only, so subprocesses need it."""
     current = os.environ.get("PATH", "") if base_path is None else base_path
     bin_dir = managed_node_bin_dir()
     if bin_dir is None:
@@ -147,9 +147,14 @@ def path_with_managed_node(base_path: str | None = None) -> str:
     # An empty component means the working directory on POSIX; dropping it loses it.
     entries = current.split(os.pathsep) if current else []
     normalized = os.path.normcase(os.path.normpath(bin_str))
-    if any(entry and os.path.normcase(os.path.normpath(entry)) == normalized for entry in entries):
-        return current
-    return os.pathsep.join([bin_str, *entries])
+    # Drop any existing occurrence rather than keep it: we only get here when the PATH
+    # resolves no usable runtime, so a managed dir sitting behind a stale one must move up.
+    kept = [
+        entry
+        for entry in entries
+        if not (entry and os.path.normcase(os.path.normpath(entry)) == normalized)
+    ]
+    return os.pathsep.join([bin_str, *kept])
 
 
 def _node_version_ok(executable: str) -> bool:

--- a/studio/backend/utils/node_runtime.py
+++ b/studio/backend/utils/node_runtime.py
@@ -87,10 +87,31 @@ def managed_node_bin_dir() -> Path | None:
 _managed_node_ok: bool = False
 
 
+# Memoized per resolved executable, success only (same reason as _resolved_node).
+_usable_node_cache: dict[str, bool] = {}
+
+
 def _reset_managed_node_check() -> None:
-    """Clear the memoized managed-Node verdict (used by tests)."""
+    """Clear the memoized Node verdicts (used by tests)."""
     global _managed_node_ok
     _managed_node_ok = False
+    _usable_node_cache.clear()
+
+
+def _path_has_usable_node(path: str) -> bool:
+    """Whether ``path`` already resolves a ``node`` that clears the version floor."""
+    try:
+        node = shutil.which("node", path = path)
+    except OSError:
+        return False
+    if not node:
+        return False
+    if _usable_node_cache.get(node):
+        return True
+    ok = _node_version_ok(node)
+    if ok:
+        _usable_node_cache[node] = True
+    return ok
 
 
 def managed_node_usable() -> bool:
@@ -118,7 +139,13 @@ def path_with_managed_node(base_path: str | None = None) -> str:
     subprocesses that need ``node``/``npx`` must be handed it explicitly."""
     current = os.environ.get("PATH", "") if base_path is None else base_path
     bin_dir = managed_node_bin_dir()
-    if bin_dir is None or not managed_node_usable():
+    if bin_dir is None:
+        return current
+    # resolve_node_executable() prefers an adequate system Node, so a leftover managed
+    # install must not shadow one the configured PATH already reaches.
+    if _path_has_usable_node(current):
+        return current
+    if not managed_node_usable():
         return current
     bin_str = str(bin_dir)
     # Keep empty components: on POSIX one means the working directory, so dropping

--- a/studio/backend/utils/node_runtime.py
+++ b/studio/backend/utils/node_runtime.py
@@ -126,18 +126,19 @@ def _path_has_usable_node(
         return False
     if require_npm and not npm:
         return False
-    if require_npx:
-        if not npx:
+    if require_npx and not npx:
+        return False
+    launcher = npx if require_npx else npm
+    if _IS_WINDOWS and launcher:
+        # npm's generated npm.cmd and npx.cmd both run the node.exe beside them when
+        # there is one, so that is the runtime to validate, not whatever ``node``
+        # resolves to first.
+        sibling = os.path.join(os.path.dirname(launcher), "node.exe")
+        try:
+            if os.path.isfile(sibling):
+                node = sibling
+        except OSError:
             return False
-        if _IS_WINDOWS:
-            # npm's npx.cmd runs the node.exe beside it when there is one, so that is
-            # the runtime to validate, not whatever ``node`` resolves to first.
-            sibling = os.path.join(os.path.dirname(npx), "node.exe")
-            try:
-                if os.path.isfile(sibling):
-                    node = sibling
-            except OSError:
-                return False
     if not _probe_ok(node, _node_version_ok, path):
         return False
     return _probe_ok(npm, _npm_version_ok, path) if require_npm else True

--- a/studio/backend/utils/node_runtime.py
+++ b/studio/backend/utils/node_runtime.py
@@ -21,6 +21,8 @@ from pathlib import Path
 from utils.subprocess_compat import windows_hidden_subprocess_kwargs
 
 _NODE_VERSION_PROBE_TIMEOUT_SECONDS = 10
+# Module-level so the Windows-only npx branch below stays reachable from tests.
+_IS_WINDOWS = os.name == "nt"
 
 
 # Keep in sync with the setup scripts' Node floor: Get-NodeDecision (setup.ps1) /
@@ -106,6 +108,15 @@ def _path_has_usable_node(path: str) -> bool:
         return False
     if not node or not npx:
         return False
+    if _IS_WINDOWS:
+        # npm's npx.cmd runs the node.exe beside it when there is one, so that is the
+        # runtime to validate, not whatever ``node`` happens to resolve to first.
+        sibling = os.path.join(os.path.dirname(npx), "node.exe")
+        try:
+            if os.path.isfile(sibling):
+                node = sibling
+        except OSError:
+            return False
     if _usable_node_cache.get(node):
         return True
     ok = _node_version_ok(node)

--- a/studio/backend/utils/node_runtime.py
+++ b/studio/backend/utils/node_runtime.py
@@ -138,19 +138,25 @@ def _path_has_usable_node(
                     node = sibling
             except OSError:
                 return False
-    if not _probe_ok(node, _node_version_ok):
+    if not _probe_ok(node, _node_version_ok, path):
         return False
-    return _probe_ok(npm, _npm_version_ok) if require_npm else True
+    return _probe_ok(npm, _npm_version_ok, path) if require_npm else True
 
 
-def _probe_ok(executable: str, check) -> bool:
+def _probe_ok(executable: str, check, path: str | None = None) -> bool:
     """Version check for one executable, memoized on success (see _usable_node_cache)."""
     if _usable_node_cache.get(executable):
         return True
-    ok = check(executable)
+    ok = check(executable, path)
     if ok:
         _usable_node_cache[executable] = True
     return ok
+
+
+def _managed_probe_path() -> str | None:
+    """The managed bin dir itself: its npm shim needs the node sitting beside it."""
+    bin_dir = managed_node_bin_dir()
+    return str(bin_dir) if bin_dir is not None else None
 
 
 def managed_node_usable() -> bool:
@@ -165,7 +171,7 @@ def managed_node_usable() -> bool:
         present = binary.is_file()
     except OSError:
         return False
-    _managed_node_ok = present and _node_version_ok(str(binary))
+    _managed_node_ok = present and _node_version_ok(str(binary), _managed_probe_path())
     return _managed_node_ok
 
 
@@ -200,18 +206,20 @@ def path_with_managed_node(
     return os.pathsep.join([bin_str, *kept])
 
 
-def _npm_version_ok(executable: str) -> bool:
+def _npm_version_ok(executable: str, path: str | None = None) -> bool:
     """Run ``<executable> -v`` and check npm clears the installer floor."""
-    return _probe_version(executable, _npm_meets_floor)
+    return _probe_version(executable, _npm_meets_floor, path)
 
 
-def _node_version_ok(executable: str) -> bool:
+def _node_version_ok(executable: str, path: str | None = None) -> bool:
     """Run ``<executable> -v`` and check it clears the floor; False on any error."""
-    return _probe_version(executable, _version_meets_floor)
+    return _probe_version(executable, _version_meets_floor, path)
 
 
-def _probe_version(executable: str, meets_floor) -> bool:
-    """Run ``<executable> -v`` and apply ``meets_floor``; False on any error."""
+def _probe_version(executable: str, meets_floor, path: str | None = None) -> bool:
+    """Run ``<executable> -v`` and apply ``meets_floor``; False on any error. ``path`` is
+    the PATH the server would run with: npm and npx are ``#!/usr/bin/env node`` scripts,
+    so probing them under the backend's own PATH can fail to find the candidate's node."""
     try:
         result = subprocess.run(
             [executable, "-v"],
@@ -220,6 +228,7 @@ def _probe_version(executable: str, meets_floor) -> bool:
             encoding = "utf-8",
             errors = "replace",
             timeout = _NODE_VERSION_PROBE_TIMEOUT_SECONDS,
+            env = {**os.environ, "PATH": path} if path is not None else None,
             **windows_hidden_subprocess_kwargs(),
         )
     except (OSError, ValueError, subprocess.SubprocessError):

--- a/studio/backend/utils/node_runtime.py
+++ b/studio/backend/utils/node_runtime.py
@@ -121,9 +121,11 @@ def path_with_managed_node(base_path: str | None = None) -> str:
     if bin_dir is None or not managed_node_usable():
         return current
     bin_str = str(bin_dir)
-    entries = [entry for entry in current.split(os.pathsep) if entry]
+    # Keep empty components: on POSIX one means the working directory, so dropping
+    # it would silently remove a lookup location the server config asked for.
+    entries = current.split(os.pathsep) if current else []
     normalized = os.path.normcase(os.path.normpath(bin_str))
-    if any(os.path.normcase(os.path.normpath(entry)) == normalized for entry in entries):
+    if any(entry and os.path.normcase(os.path.normpath(entry)) == normalized for entry in entries):
         return current
     return os.pathsep.join([bin_str, *entries])
 

--- a/studio/backend/utils/node_runtime.py
+++ b/studio/backend/utils/node_runtime.py
@@ -108,7 +108,11 @@ def _reset_managed_node_check() -> None:
     _usable_node_cache.clear()
 
 
-def _path_has_usable_node(path: str, require_npm: bool = True, require_npx: bool = True) -> bool:
+def _path_has_usable_node(
+    path: str,
+    require_npm: bool = True,
+    require_npx: bool = True,
+) -> bool:
     """Whether ``path`` provides what a stdio command actually uses. The installers gate
     on node plus npm and never look at npx, so each launcher is checked against what it
     needs: node alone, node plus npm, or both plus the npx that launches it."""
@@ -166,7 +170,9 @@ def managed_node_usable() -> bool:
 
 
 def path_with_managed_node(
-    base_path: str | None = None, require_npm: bool = True, require_npx: bool = True
+    base_path: str | None = None,
+    require_npm: bool = True,
+    require_npx: bool = True,
 ) -> str:
     """``base_path`` (default: this process's PATH) with the managed Node bin dir
     moved to the front, unchanged when it is unusable or the PATH already resolves a

--- a/studio/backend/utils/node_runtime.py
+++ b/studio/backend/utils/node_runtime.py
@@ -115,7 +115,7 @@ def _path_has_usable_node(
 ) -> bool:
     """Whether ``path`` provides what a stdio command actually uses. The installers gate
     on node plus npm and never look at npx, so each launcher is checked against what it
-    needs: node alone, node plus npm, or both plus the npx that launches it."""
+    needs: node alone, node plus npm, or node plus the npx that launches it."""
     try:
         node = shutil.which("node", path = path)
         npm = shutil.which("npm", path = path) if require_npm else None
@@ -141,7 +141,11 @@ def _path_has_usable_node(
             return False
     if not _probe_ok(node, _node_version_ok, path):
         return False
-    return _probe_ok(npm, _npm_version_ok, path) if require_npm else True
+    # The installers' npm floor still applies to an npx-only PATH: npx-cli.js hands off to
+    # the npm library beside it, so ``npx -v`` prints that npm's version and stands in for
+    # the missing npm launcher. Falling back to it keeps the floor instead of skipping it.
+    floor_launcher = npm if require_npm else (npx if require_npx else None)
+    return _probe_ok(floor_launcher, _npm_version_ok, path) if floor_launcher else True
 
 
 def _probe_ok(

--- a/studio/backend/utils/node_runtime.py
+++ b/studio/backend/utils/node_runtime.py
@@ -108,28 +108,33 @@ def _reset_managed_node_check() -> None:
     _usable_node_cache.clear()
 
 
-def _path_has_usable_node(path: str) -> bool:
-    """Whether ``path`` provides the runtime the installers would accept: a node and an
-    npm that both clear their floors, plus an npx to launch with. decide_node_source()
-    installs the managed runtime otherwise, so a weaker test here would skip it."""
+def _path_has_usable_node(path: str, require_npm: bool = True) -> bool:
+    """Whether ``path`` provides the runtime a stdio command needs. A direct ``node``
+    server needs only a floor-clearing node; ``npm``/``npx`` also need the npm the
+    installers gate on, so the two cases cannot share one verdict."""
     try:
         node = shutil.which("node", path = path)
-        npm = shutil.which("npm", path = path)
-        npx = shutil.which("npx", path = path)
+        npm = shutil.which("npm", path = path) if require_npm else None
+        npx = shutil.which("npx", path = path) if require_npm else None
     except OSError:
         return False
-    if not node or not npm or not npx:
+    if not node:
         return False
-    if _IS_WINDOWS:
-        # npm's npx.cmd runs the node.exe beside it when there is one, so that is the
-        # runtime to validate, not whatever ``node`` happens to resolve to first.
-        sibling = os.path.join(os.path.dirname(npx), "node.exe")
-        try:
-            if os.path.isfile(sibling):
-                node = sibling
-        except OSError:
+    if require_npm:
+        if not npm or not npx:
             return False
-    return _probe_ok(node, _node_version_ok) and _probe_ok(npm, _npm_version_ok)
+        if _IS_WINDOWS:
+            # npm's npx.cmd runs the node.exe beside it when there is one, so that is
+            # the runtime to validate, not whatever ``node`` resolves to first.
+            sibling = os.path.join(os.path.dirname(npx), "node.exe")
+            try:
+                if os.path.isfile(sibling):
+                    node = sibling
+            except OSError:
+                return False
+    if not _probe_ok(node, _node_version_ok):
+        return False
+    return _probe_ok(npm, _npm_version_ok) if require_npm else True
 
 
 def _probe_ok(executable: str, check) -> bool:
@@ -158,7 +163,7 @@ def managed_node_usable() -> bool:
     return _managed_node_ok
 
 
-def path_with_managed_node(base_path: str | None = None) -> str:
+def path_with_managed_node(base_path: str | None = None, require_npm: bool = True) -> str:
     """``base_path`` (default: this process's PATH) with the managed Node bin dir
     moved to the front, unchanged when it is unusable or the PATH already resolves a
     runtime. The installer puts it on PATH for setup only, so subprocesses need it."""
@@ -167,7 +172,7 @@ def path_with_managed_node(base_path: str | None = None) -> str:
     if bin_dir is None:
         return current
     # Never shadow a runtime the PATH already reaches (resolve_node_executable order).
-    if _path_has_usable_node(current):
+    if _path_has_usable_node(current, require_npm = require_npm):
         return current
     if not managed_node_usable():
         return current

--- a/studio/backend/utils/node_runtime.py
+++ b/studio/backend/utils/node_runtime.py
@@ -143,7 +143,11 @@ def _path_has_usable_node(
     return _probe_ok(npm, _npm_version_ok, path) if require_npm else True
 
 
-def _probe_ok(executable: str, check, path: str | None = None) -> bool:
+def _probe_ok(
+    executable: str,
+    check,
+    path: str | None = None,
+) -> bool:
     """Version check for one executable, memoized on success (see _usable_node_cache)."""
     if _usable_node_cache.get(executable):
         return True
@@ -216,7 +220,11 @@ def _node_version_ok(executable: str, path: str | None = None) -> bool:
     return _probe_version(executable, _version_meets_floor, path)
 
 
-def _probe_version(executable: str, meets_floor, path: str | None = None) -> bool:
+def _probe_version(
+    executable: str,
+    meets_floor,
+    path: str | None = None,
+) -> bool:
     """Run ``<executable> -v`` and apply ``meets_floor``; False on any error. ``path`` is
     the PATH the server would run with: npm and npx are ``#!/usr/bin/env node`` scripts,
     so probing them under the backend's own PATH can fail to find the candidate's node."""

--- a/studio/backend/utils/node_runtime.py
+++ b/studio/backend/utils/node_runtime.py
@@ -108,20 +108,22 @@ def _reset_managed_node_check() -> None:
     _usable_node_cache.clear()
 
 
-def _path_has_usable_node(path: str, require_npm: bool = True) -> bool:
-    """Whether ``path`` provides the runtime a stdio command needs. A direct ``node``
-    server needs only a floor-clearing node; ``npm``/``npx`` also need the npm the
-    installers gate on, so the two cases cannot share one verdict."""
+def _path_has_usable_node(path: str, require_npm: bool = True, require_npx: bool = True) -> bool:
+    """Whether ``path`` provides what a stdio command actually uses. The installers gate
+    on node plus npm and never look at npx, so each launcher is checked against what it
+    needs: node alone, node plus npm, or both plus the npx that launches it."""
     try:
         node = shutil.which("node", path = path)
         npm = shutil.which("npm", path = path) if require_npm else None
-        npx = shutil.which("npx", path = path) if require_npm else None
+        npx = shutil.which("npx", path = path) if require_npx else None
     except OSError:
         return False
     if not node:
         return False
-    if require_npm:
-        if not npm or not npx:
+    if require_npm and not npm:
+        return False
+    if require_npx:
+        if not npx:
             return False
         if _IS_WINDOWS:
             # npm's npx.cmd runs the node.exe beside it when there is one, so that is
@@ -163,7 +165,9 @@ def managed_node_usable() -> bool:
     return _managed_node_ok
 
 
-def path_with_managed_node(base_path: str | None = None, require_npm: bool = True) -> str:
+def path_with_managed_node(
+    base_path: str | None = None, require_npm: bool = True, require_npx: bool = True
+) -> str:
     """``base_path`` (default: this process's PATH) with the managed Node bin dir
     moved to the front, unchanged when it is unusable or the PATH already resolves a
     runtime. The installer puts it on PATH for setup only, so subprocesses need it."""
@@ -172,7 +176,7 @@ def path_with_managed_node(base_path: str | None = None, require_npm: bool = Tru
     if bin_dir is None:
         return current
     # Never shadow a runtime the PATH already reaches (resolve_node_executable order).
-    if _path_has_usable_node(current, require_npm = require_npm):
+    if _path_has_usable_node(current, require_npm = require_npm, require_npx = require_npx):
         return current
     if not managed_node_usable():
         return current

--- a/studio/backend/utils/node_runtime.py
+++ b/studio/backend/utils/node_runtime.py
@@ -99,12 +99,16 @@ def _reset_managed_node_check() -> None:
 
 
 def _path_has_usable_node(path: str) -> bool:
-    """Whether ``path`` already resolves a ``node`` that clears the version floor."""
+    """Whether ``path`` already provides what stdio servers need: a ``node`` clearing
+    the version floor AND an ``npx`` to launch packaged servers. decide_node_source()
+    installs the managed runtime unless both are satisfied, so checking node alone
+    would skip a managed install a host with no npm still needs."""
     try:
         node = shutil.which("node", path = path)
+        npx = shutil.which("npx", path = path)
     except OSError:
         return False
-    if not node:
+    if not node or not npx:
         return False
     if _usable_node_cache.get(node):
         return True

--- a/studio/backend/utils/node_runtime.py
+++ b/studio/backend/utils/node_runtime.py
@@ -72,6 +72,34 @@ def managed_node_binary() -> Path:
     return node_dir / "bin" / "node"
 
 
+def managed_node_bin_dir() -> Path | None:
+    """Directory holding the isolated node/npm/npx executables, or None if not installed."""
+    node_dir = managed_node_dir()
+    bin_dir = node_dir if os.name == "nt" else node_dir / "bin"
+    try:
+        return bin_dir if bin_dir.is_dir() else None
+    except OSError:
+        return None
+
+
+def path_with_managed_node(base_path: str | None = None) -> str:
+    """``base_path`` (default: this process's PATH) with the managed Node bin dir
+    prepended, unchanged when there is no managed install or it is already there.
+
+    The installer only puts the isolated Node on PATH for the setup process, so
+    subprocesses that need ``node``/``npx`` must be handed it explicitly."""
+    current = os.environ.get("PATH", "") if base_path is None else base_path
+    bin_dir = managed_node_bin_dir()
+    if bin_dir is None:
+        return current
+    bin_str = str(bin_dir)
+    entries = [entry for entry in current.split(os.pathsep) if entry]
+    normalized = os.path.normcase(os.path.normpath(bin_str))
+    if any(os.path.normcase(os.path.normpath(entry)) == normalized for entry in entries):
+        return current
+    return os.pathsep.join([bin_str, *entries])
+
+
 def _node_version_ok(executable: str) -> bool:
     """Run ``<executable> -v`` and check it clears the floor; False on any error."""
     try:

--- a/studio/backend/utils/node_runtime.py
+++ b/studio/backend/utils/node_runtime.py
@@ -82,12 +82,9 @@ def managed_node_bin_dir() -> Path | None:
         return None
 
 
-# Memoize ONLY a usable managed Node, mirroring _resolved_node: the installer may
-# finish after the first probe, so a negative result must not stick until restart.
+# Success-only memoization, like _resolved_node: the installer may finish after the
+# first probe, so a negative verdict must not stick until restart.
 _managed_node_ok: bool = False
-
-
-# Memoized per resolved executable, success only (same reason as _resolved_node).
 _usable_node_cache: dict[str, bool] = {}
 
 
@@ -99,10 +96,9 @@ def _reset_managed_node_check() -> None:
 
 
 def _path_has_usable_node(path: str) -> bool:
-    """Whether ``path`` already provides what stdio servers need: a ``node`` clearing
-    the version floor AND an ``npx`` to launch packaged servers. decide_node_source()
-    installs the managed runtime unless both are satisfied, so checking node alone
-    would skip a managed install a host with no npm still needs."""
+    """Whether ``path`` provides both a floor-clearing ``node`` and an ``npx``.
+    decide_node_source() installs the managed runtime unless both hold, so a host
+    with node but no npm still needs it."""
     try:
         node = shutil.which("node", path = path)
         npx = shutil.which("npx", path = path)
@@ -119,10 +115,9 @@ def _path_has_usable_node(path: str) -> bool:
 
 
 def managed_node_usable() -> bool:
-    """Whether the managed Node clears the version floor. ``decide_node_source``
-    leaves an existing install in place when it picks the system runtime, so a dir
-    left over from before a floor raise must not win the lookup over a good system
-    Node. Mirrors the managed branch of resolve_node_executable()."""
+    """Whether the managed Node clears the version floor, mirroring the managed branch
+    of resolve_node_executable(). Setup leaves an install in place when it picks the
+    system runtime, so a stale dir must not win the lookup."""
     global _managed_node_ok
     if _managed_node_ok:
         return True
@@ -137,23 +132,19 @@ def managed_node_usable() -> bool:
 
 def path_with_managed_node(base_path: str | None = None) -> str:
     """``base_path`` (default: this process's PATH) with the managed Node bin dir
-    prepended, unchanged when there is no usable managed install or it is already there.
-
-    The installer only puts the isolated Node on PATH for the setup process, so
-    subprocesses that need ``node``/``npx`` must be handed it explicitly."""
+    prepended, unchanged when it is unusable or already there. The installer puts the
+    isolated Node on PATH for setup only, so subprocesses must be handed it."""
     current = os.environ.get("PATH", "") if base_path is None else base_path
     bin_dir = managed_node_bin_dir()
     if bin_dir is None:
         return current
-    # resolve_node_executable() prefers an adequate system Node, so a leftover managed
-    # install must not shadow one the configured PATH already reaches.
+    # Never shadow a runtime the PATH already reaches (resolve_node_executable order).
     if _path_has_usable_node(current):
         return current
     if not managed_node_usable():
         return current
     bin_str = str(bin_dir)
-    # Keep empty components: on POSIX one means the working directory, so dropping
-    # it would silently remove a lookup location the server config asked for.
+    # An empty component means the working directory on POSIX; dropping it loses it.
     entries = current.split(os.pathsep) if current else []
     normalized = os.path.normcase(os.path.normpath(bin_str))
     if any(entry and os.path.normcase(os.path.normpath(entry)) == normalized for entry in entries):

--- a/studio/backend/utils/node_runtime.py
+++ b/studio/backend/utils/node_runtime.py
@@ -98,7 +98,7 @@ def managed_node_bin_dir() -> Path | None:
 # Success-only memoization, like _resolved_node: the installer may finish after the
 # first probe, so a negative verdict must not stick until restart.
 _managed_node_ok: bool = False
-_usable_node_cache: dict[str, bool] = {}
+_usable_node_cache: dict[tuple[str, str | None], bool] = {}
 
 
 def _reset_managed_node_check() -> None:
@@ -149,12 +149,17 @@ def _probe_ok(
     check,
     path: str | None = None,
 ) -> bool:
-    """Version check for one executable, memoized on success (see _usable_node_cache)."""
-    if _usable_node_cache.get(executable):
+    """Version check for one executable, memoized on success (see _usable_node_cache).
+    The PATH is part of the key: npm and npx are ``#!/usr/bin/env node`` scripts, so the
+    same shim resolves a different runtime under a different PATH and can clear the floor
+    on one and fail it on another. Keying on the executable alone would let the first
+    PATH that passed answer for every later one."""
+    cache_key = (executable, path)
+    if _usable_node_cache.get(cache_key):
         return True
     ok = check(executable, path)
     if ok:
-        _usable_node_cache[executable] = True
+        _usable_node_cache[cache_key] = True
     return ok
 
 

--- a/studio/backend/utils/node_runtime.py
+++ b/studio/backend/utils/node_runtime.py
@@ -27,6 +27,17 @@ _IS_WINDOWS = os.name == "nt"
 
 # Keep in sync with the setup scripts' Node floor: Get-NodeDecision (setup.ps1) /
 # decide_node_source (setup.sh). Vite 8 needs Node ^20.19 || >=22.12 || >=23.
+# Keep in sync with decide_node_source (setup.sh) / Get-NodeDecision (setup.ps1): both
+# require npm >= 11 before accepting a system runtime.
+_NPM_MAJOR_FLOOR = 11
+
+
+def _npm_meets_floor(version: str) -> bool:
+    """True iff an ``npm -v`` string clears the installer's npm floor."""
+    match = re.match(r"v?(\d+)", version.strip())
+    return bool(match) and int(match.group(1)) >= _NPM_MAJOR_FLOOR
+
+
 def _version_meets_floor(version: str) -> bool:
     """True iff a ``node -v`` string clears the installer's version bar."""
     match = re.match(r"v?(\d+)\.(\d+)", version.strip())
@@ -98,15 +109,16 @@ def _reset_managed_node_check() -> None:
 
 
 def _path_has_usable_node(path: str) -> bool:
-    """Whether ``path`` provides both a floor-clearing ``node`` and an ``npx``.
-    decide_node_source() installs the managed runtime unless both hold, so a host
-    with node but no npm still needs it."""
+    """Whether ``path`` provides the runtime the installers would accept: a node and an
+    npm that both clear their floors, plus an npx to launch with. decide_node_source()
+    installs the managed runtime otherwise, so a weaker test here would skip it."""
     try:
         node = shutil.which("node", path = path)
+        npm = shutil.which("npm", path = path)
         npx = shutil.which("npx", path = path)
     except OSError:
         return False
-    if not node or not npx:
+    if not node or not npm or not npx:
         return False
     if _IS_WINDOWS:
         # npm's npx.cmd runs the node.exe beside it when there is one, so that is the
@@ -117,11 +129,16 @@ def _path_has_usable_node(path: str) -> bool:
                 node = sibling
         except OSError:
             return False
-    if _usable_node_cache.get(node):
+    return _probe_ok(node, _node_version_ok) and _probe_ok(npm, _npm_version_ok)
+
+
+def _probe_ok(executable: str, check) -> bool:
+    """Version check for one executable, memoized on success (see _usable_node_cache)."""
+    if _usable_node_cache.get(executable):
         return True
-    ok = _node_version_ok(node)
+    ok = check(executable)
     if ok:
-        _usable_node_cache[node] = True
+        _usable_node_cache[executable] = True
     return ok
 
 
@@ -168,8 +185,18 @@ def path_with_managed_node(base_path: str | None = None) -> str:
     return os.pathsep.join([bin_str, *kept])
 
 
+def _npm_version_ok(executable: str) -> bool:
+    """Run ``<executable> -v`` and check npm clears the installer floor."""
+    return _probe_version(executable, _npm_meets_floor)
+
+
 def _node_version_ok(executable: str) -> bool:
     """Run ``<executable> -v`` and check it clears the floor; False on any error."""
+    return _probe_version(executable, _version_meets_floor)
+
+
+def _probe_version(executable: str, meets_floor) -> bool:
+    """Run ``<executable> -v`` and apply ``meets_floor``; False on any error."""
     try:
         result = subprocess.run(
             [executable, "-v"],
@@ -184,7 +211,7 @@ def _node_version_ok(executable: str) -> bool:
         return False
     if result.returncode != 0:
         return False
-    return _version_meets_floor(result.stdout)
+    return meets_floor(result.stdout)
 
 
 # Memoize ONLY a confirmed version-adequate executable: the installer runs in a


### PR DESCRIPTION
Setup installs an isolated Node into <UNSLOTH_HOME>/node when the system Node is missing or too old, but that directory was never added to the env the backend spawns stdio MCP servers with  _client() built the StdioTransport with the
inherited env only. So on machines without a usable system Node, any `npx -y ...` MCP server failed with "Connection closed", hitting exactly the users the bundled Node exists for.

Fix: _client() now prepends the managed Node bin dir to the child's PATH when it exists, keeping any PATH the server's own env sets. New helpers in utils/node_runtime (managed_node_bin_dir, path_with_managed_node) plus tests.