### PR TITLE
Point the Apertus mapper rows at the Instruct repo, not the base one

### DIFF
--- a/tests/test_mapper_instruct_drift.py
+++ b/tests/test_mapper_instruct_drift.py
@@ -1,0 +1,99 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+
+"""Guard against instruct/base drift in the ``__INT_TO_FLOAT_MAPPER`` registry.
+
+Slot 1 of each entry names the upstream repo the unsloth build mirrors, and
+``mapper.py`` turns it into two lookups: ``FLOAT_TO_INT_MAPPER[upstream] -> key``
+and ``MAP_TO_UNSLOTH_16bit[upstream] -> slot 0``. So an instruct entry whose
+upstream slot names the *base* repo silently hands anyone loading that base repo
+the instruct weights instead, and leaves the real instruct repo unmapped.
+
+Upstream cards make this easy to get wrong: an instruct model's ``base_model``
+tag points at the pretrained base, so copying it into slot 1 looks right.
+
+We inspect the source with ``ast`` so this needs no imports and no network.
+"""
+
+import ast
+import os
+import re
+
+MAPPER_PATH = os.path.join(os.path.dirname(__file__), os.pardir, "unsloth", "models", "mapper.py")
+
+# The suffixes upstreams use to mark a chat/instruction-tuned build.
+_INSTRUCT_TAG = re.compile(r"(?i)(-it\b|-it-|instruct|-chat\b|-chat-)")
+
+
+def _int_to_float_rows():
+    """Yield (line number, key, upstream repo) for every entry with an upstream."""
+    with open(MAPPER_PATH, encoding = "utf-8") as f:
+        tree = ast.parse(f.read(), MAPPER_PATH)
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign):
+            continue
+        # Private names are mangled at code generation, which ``ast.parse``
+        # never reaches, so the identifier reads exactly as written.
+        if not any(
+            isinstance(t, ast.Name) and t.id == "__INT_TO_FLOAT_MAPPER" for t in node.targets
+        ):
+            continue
+        if not isinstance(node.value, ast.Dict):
+            continue
+
+        rows = []
+        for key, value in zip(node.value.keys, node.value.values):
+            if not (isinstance(key, ast.Constant) and isinstance(key.value, str)):
+                continue
+            # Entries are either a plain tuple or a per-precision dict whose
+            # "16" tuple carries the 16bit names.
+            tuples = []
+            if isinstance(value, ast.Dict):
+                for k, v in zip(value.keys, value.values):
+                    if (
+                        isinstance(k, ast.Constant)
+                        and k.value == "16"
+                        and isinstance(v, (ast.Tuple, ast.List))
+                    ):
+                        tuples.append(v)
+            elif isinstance(value, (ast.Tuple, ast.List)):
+                tuples.append(value)
+
+            for entry in tuples:
+                names = [
+                    e.value
+                    for e in entry.elts
+                    if isinstance(e, ast.Constant) and isinstance(e.value, str)
+                ]
+                if len(names) >= 2:
+                    rows.append((entry.lineno, key.value, names[1]))
+        return rows
+    raise AssertionError("Could not find the __INT_TO_FLOAT_MAPPER dict literal in mapper.py")
+
+
+def test_instruct_entries_do_not_point_at_a_base_repo():
+    drifted = [
+        f"line {lineno}: {key} -> {upstream}"
+        for lineno, key, upstream in _int_to_float_rows()
+        if _INSTRUCT_TAG.search(key) and not _INSTRUCT_TAG.search(upstream)
+    ]
+    assert not drifted, (
+        "An instruct entry whose upstream slot names the base repo makes "
+        "`FastLanguageModel.from_pretrained(<base repo>)` load the instruct "
+        "weights, and leaves the instruct repo itself unmapped. Point slot 1 at "
+        f"the instruct repo, in mapper.py: {drifted}"
+    )
+
+
+def test_base_entries_do_not_point_at_an_instruct_repo():
+    drifted = [
+        f"line {lineno}: {key} -> {upstream}"
+        for lineno, key, upstream in _int_to_float_rows()
+        if not _INSTRUCT_TAG.search(key) and _INSTRUCT_TAG.search(upstream)
+    ]
+    assert not drifted, (
+        "A base entry whose upstream slot names the instruct repo swaps the two "
+        "the other way round, so a request for the instruct model resolves to "
+        f"base weights, in mapper.py: {drifted}"
+    )

--- a/unsloth/models/mapper.py
+++ b/unsloth/models/mapper.py
@@ -1118,12 +1118,12 @@ __INT_TO_FLOAT_MAPPER = \
     },
     "unsloth/Apertus-70B-Instruct-2509-unsloth-bnb-4bit" : (
         "unsloth/Apertus-70B-Instruct-2509",
-        "swiss-ai/Apertus-70B-2509",
+        "swiss-ai/Apertus-70B-Instruct-2509",
         "unsloth/Apertus-70B-Instruct-2509-unsloth-bnb-4bit",
     ),
     "unsloth/Apertus-8B-Instruct-2509-unsloth-bnb-4bit" : (
         "unsloth/Apertus-8B-Instruct-2509",
-        "swiss-ai/Apertus-8B-2509",
+        "swiss-ai/Apertus-8B-Instruct-2509",
         "unsloth/Apertus-8B-Instruct-2509-unsloth-bnb-4bit",
     ),
     "unsloth/granite-4.0-micro-unsloth-bnb-4bit" : (


### PR DESCRIPTION
### Motivation

Slot 1 of an `__INT_TO_FLOAT_MAPPER` entry names the upstream repo the unsloth build mirrors, and `mapper.py` turns it into two lookups:

```python
FLOAT_TO_INT_MAPPER[values[1]]  = key        # -> the 4bit build
MAP_TO_UNSLOTH_16bit[values[1]] = values[0]  # -> the 16bit build
```

Both Apertus rows put the **pretrained base** repo there:

```python
"unsloth/Apertus-8B-Instruct-2509-unsloth-bnb-4bit" : (
    "unsloth/Apertus-8B-Instruct-2509",
    "swiss-ai/Apertus-8B-2509",              # <- the base model, not the Instruct one
    "unsloth/Apertus-8B-Instruct-2509-unsloth-bnb-4bit",
),
```

So `__get_model_name` resolves the base repo to the instruct build, and the instruct repo to nothing at all. Built straight from `mapper.py` on `main`:

```
model_name passed by the user            load_in_4bit=False resolves to                load_in_4bit=True resolves to
swiss-ai/Apertus-8B-2509                 unsloth/Apertus-8B-Instruct-2509              unsloth/apertus-8b-instruct-2509-unsloth-bnb-4bit
swiss-ai/Apertus-8B-Instruct-2509        None                                          None
swiss-ai/Apertus-70B-2509                unsloth/Apertus-70B-Instruct-2509             unsloth/apertus-70b-instruct-2509-unsloth-bnb-4bit
swiss-ai/Apertus-70B-Instruct-2509       None                                          None
```

Two consequences, both silent:

- `FastLanguageModel.from_pretrained("swiss-ai/Apertus-8B-2509")` loads instruct weights, complete with a chat template, for someone who asked for the base model to continue-pretrain or fine-tune from scratch.
- Someone who asks for `swiss-ai/Apertus-8B-Instruct-2509` matches nothing and downloads the upstream repo, missing the unsloth build entirely.

### Which repo is which

`swiss-ai` ships `chat_template.jinja` only in the `-Instruct` repos:

| repo | `chat_template.jinja` |
| --- | --- |
| `swiss-ai/Apertus-8B-Instruct-2509` | yes |
| `swiss-ai/Apertus-8B-2509` | no |
| `swiss-ai/Apertus-70B-Instruct-2509` | yes |
| `swiss-ai/Apertus-70B-2509` | no |

and `unsloth/Apertus-8B-Instruct-2509` carries that template inline in `tokenizer_config.json`, so the unsloth mirrors are of the Instruct models.

The base repo most likely landed in slot 1 because an instruct model's HuggingFace `base_model` card tag names the pretrained base: `swiss-ai/Apertus-8B-Instruct-2509` itself declares `base_model: ['swiss-ai/Apertus-8B-2509']`, which reads like the upstream name when filling the row in.

### Fix

Two lines: slot 1 becomes `swiss-ai/Apertus-{8B,70B}-Instruct-2509`. After it:

```
model_name passed by the user            load_in_4bit=False resolves to                load_in_4bit=True resolves to
swiss-ai/Apertus-8B-2509                 None                                          None
swiss-ai/Apertus-8B-Instruct-2509        unsloth/Apertus-8B-Instruct-2509              unsloth/apertus-8b-instruct-2509-unsloth-bnb-4bit
swiss-ai/Apertus-70B-2509                None                                          None
swiss-ai/Apertus-70B-Instruct-2509       unsloth/Apertus-70B-Instruct-2509             unsloth/apertus-70b-instruct-2509-unsloth-bnb-4bit
```

`None` for the base repos is correct: there is no unsloth Apertus base build, so those fall through to the ordinary HuggingFace path instead of being handed the wrong weights.

### Tests

`tests/test_mapper_instruct_drift.py`, an `ast` check in the same shape as the existing `test_mapper_no_duplicate_keys.py`, so it needs no imports and no network. It asserts no entry crosses the instruct/base line in either direction.

```
# on main
$ python3 -m pytest tests/test_mapper_instruct_drift.py -q
1 failed, 1 passed
FAILED tests/test_mapper_instruct_drift.py::test_instruct_entries_do_not_point_at_a_base_repo
E   AssertionError: ... ['line 1119: unsloth/Apertus-70B-Instruct-2509-unsloth-bnb-4bit -> swiss-ai/Apertus-70B-2509',
                         'line 1124: unsloth/Apertus-8B-Instruct-2509-unsloth-bnb-4bit -> swiss-ai/Apertus-8B-2509']

# this branch
$ python3 -m pytest tests/test_mapper_instruct_drift.py -q
2 passed
```

`test_base_entries_do_not_point_at_an_instruct_repo` is the other direction and passes on `main` too, so it is a control rather than a second bug report: the rest of the table has no crossing either way, which is why the guard can be strict.

The mapper suite around it, same environment:

```
$ python3 -m pytest tests/test_mapper_no_duplicate_keys.py tests/test_gemma_2b_mapper_key.py \
    tests/test_new_mapper_fetched_fp8.py tests/test_new_mapper_no_global_leak.py -q
4 failed, 4 passed    # main
4 failed, 6 passed    # this branch, plus tests/test_mapper_instruct_drift.py
```

The 4 are the same `test_new_mapper_fetched_fp8.py` failures on both sides, pre-existing in my environment and untouched here; the delta is exactly the 2 tests added.

`ruff check` passes on the new file, and `scripts/run_ruff_format.py` leaves it unchanged on a second pass. `mapper.py` is in ruff's `extend-exclude` and in the kwarg hook's exclude, so its two edited lines are not formatter-affected.
