### PR TITLE
Studio: follow up #9201 across non-streaming sibling paths

### DIFF
--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -3172,14 +3172,13 @@ async def _stop_local_disconnect_cancel_watcher(
 
 
 async def _drain_pending_next_task(task, cancel_event) -> None:
-    """Wait for a pending ``asyncio.to_thread(next, gen, ...)`` task to finish
-    before its generator is closed.
+    """Wait for a pending blocking worker before its resources are released.
 
-    On disconnect a ``next(gen)`` call may still run in a worker thread;
-    cancelling the awaiting task does NOT stop it, and ``gen.close()`` mid-
-    ``next(gen)`` raises ``ValueError: generator already executing``, leaking the
-    generator's cleanup. So re-set the cancel flag (the generator polls it) and
-    shield the task until the worker returns. No-op when there is no pending task.
+    On disconnect a worker may still be inside ``next(gen)`` or draining a whole
+    non-streaming generation. Cancelling the awaiting task does NOT stop that
+    worker. Re-set the cancel flag (the generator polls it) and shield the task
+    until the worker returns, so admission and generation tracking still cover
+    its real lifetime. No-op when there is no pending task.
     """
     if task is None:
         return
@@ -3199,6 +3198,73 @@ async def _drain_pending_next_task(task, cancel_event) -> None:
             task.exception()
         except (asyncio.CancelledError, Exception):
             pass
+
+
+def _settle_daemon_worker(future: "asyncio.Future", succeeded: bool, value) -> None:
+    """Publish a daemon worker outcome unless its event loop has moved on."""
+    if future.done():
+        return
+    if succeeded:
+        future.set_result(value)
+    else:
+        future.set_exception(value)
+
+
+def _start_daemon_worker(fn, *, name: str) -> "asyncio.Future":
+    """Start blocking request work without adding an interpreter-exit join.
+
+    ``asyncio.to_thread`` uses the loop's non-daemon default executor. A local
+    generation can be inside a cancellation-ignoring tool for its full timeout,
+    so that executor would defeat the launcher's bounded server-thread join and
+    keep the process alive. The request still awaits this future during ordinary
+    cancellation; daemon status only preserves the process shutdown boundary.
+    """
+    loop = asyncio.get_running_loop()
+    future = loop.create_future()
+    context = contextvars.copy_context()
+
+    def _run() -> None:
+        try:
+            value = context.run(fn)
+        except BaseException as exc:  # noqa: BLE001 - delivered to the awaiting request
+            outcome = (False, exc)
+        else:
+            outcome = (True, value)
+        try:
+            loop.call_soon_threadsafe(_settle_daemon_worker, future, *outcome)
+        except RuntimeError:
+            pass  # the daemon may finish after process shutdown closed the loop
+
+    try:
+        threading.Thread(target = _run, name = name, daemon = True).start()
+    except BaseException as exc:  # noqa: BLE001 - mirror executor submission failures
+        future.set_exception(exc)
+    return future
+
+
+async def _run_blocking_generation(
+    fn,
+    cancel_event,
+    *,
+    name: str,
+    daemon: bool = False,
+):
+    """Run one synchronous generation unit without blocking the event loop.
+
+    Shield the worker so task cancellation cannot shorten the tracker or
+    admission-lease lifetime. Use a daemon only for server-tool loops that may
+    ignore cancellation; ordinary generation stays on the bounded default pool.
+    """
+    worker = (
+        _start_daemon_worker(fn, name = name)
+        if daemon
+        else asyncio.create_task(asyncio.to_thread(fn))
+    )
+    try:
+        return await asyncio.shield(worker)
+    except asyncio.CancelledError:
+        await _drain_pending_next_task(worker, cancel_event)
+        raise
 
 
 # Centralized local/server tool nudge. Keep render_html guidance gated to turns
@@ -13672,13 +13738,28 @@ async def openai_chat_completions(
                 _tracker = _TrackedCancel.for_payload(cancel_event, payload, *_cancel_keys)
                 _tracker.__enter__()
                 try:
-                    full_text = ""
-                    for chunk_text in audio_input_generate():
-                        if isinstance(chunk_text, GenStreamError):
-                            _msg = _friendly_gen_stream_error(chunk_text)
-                            api_monitor.fail(monitor_id, _msg)
-                            raise HTTPException(status_code = 500, detail = _msg)
-                        full_text += chunk_text
+
+                    def _drain_audio_input():
+                        text_parts = []
+                        for chunk_text in audio_input_generate():
+                            if isinstance(chunk_text, GenStreamError):
+                                return chunk_text
+                            text_parts.append(chunk_text)
+                        return "".join(text_parts)
+
+                    full_text = await _run_blocking_generation(
+                        _drain_audio_input,
+                        cancel_event,
+                        name = "openai-audio-input-nonstream",
+                    )
+                    if isinstance(full_text, GenStreamError):
+                        _msg = _friendly_gen_stream_error(full_text)
+                        api_monitor.fail(monitor_id, _msg)
+                        raise HTTPException(status_code = 500, detail = _msg)
+                except asyncio.CancelledError:
+                    cancel_event.set()
+                    api_monitor.finish(monitor_id, "cancelled")
+                    raise
                 except HTTPException:
                     raise
                 except Exception as e:
@@ -16346,14 +16427,25 @@ async def openai_chat_completions(
         _tracker = _TrackedCancel.for_payload(cancel_event, payload, *_cancel_keys)
         _tracker.__enter__()
         try:
-            full_text = ""
-            for token in generate():
-                if isinstance(token, GenStreamError):
-                    backend.reset_generation_state(cancel_event)
-                    _msg = _friendly_gen_stream_error(token)
-                    api_monitor.fail(monitor_id, _msg)
-                    raise HTTPException(status_code = 500, detail = _msg)
-                full_text = token
+
+            def _drain_generate(messages_override = None):
+                final = ""
+                for token in generate(messages_override):
+                    if isinstance(token, GenStreamError):
+                        return token
+                    final = token
+                return final
+
+            full_text = await _run_blocking_generation(
+                _drain_generate,
+                cancel_event,
+                name = "openai-chat-nonstream",
+            )
+            if isinstance(full_text, GenStreamError):
+                backend.reset_generation_state(cancel_event)
+                _msg = _friendly_gen_stream_error(full_text)
+                api_monitor.fail(monitor_id, _msg)
+                raise HTTPException(status_code = 500, detail = _msg)
 
             # Split prefilled <think> reasoning (GGUF parity); also covers MLX via
             # the shared generate(). Client-tool healing then runs on the visible
@@ -16387,11 +16479,15 @@ async def openai_chat_completions(
                         # and restore them if the retry is discarded.
                         _first_stats = stats_holder.get("stats")
                         try:
-                            retry_text = ""
-                            for token in generate(
-                                [*gen_kwargs["messages"], *nudge_messages(_data, _sf_heal)]
-                            ):
-                                retry_text = token
+                            retry_messages = [
+                                *gen_kwargs["messages"],
+                                *nudge_messages(_data, _sf_heal),
+                            ]
+                            retry_text = await _run_blocking_generation(
+                                lambda: _drain_generate(retry_messages),
+                                cancel_event,
+                                name = "openai-chat-nudge-nonstream",
+                            )
                             # Re-split reasoning on the retry so its visible text is
                             # what heals into a call (and reaches the monitor).
                             # The nudge retry appends messages, so it is not a
@@ -16464,6 +16560,11 @@ async def openai_chat_completions(
             api_monitor.finish(monitor_id)
             return _model_json_response(response)
 
+        except asyncio.CancelledError:
+            cancel_event.set()
+            backend.reset_generation_state(cancel_event)
+            api_monitor.finish(monitor_id, "cancelled")
+            raise
         except HTTPException:
             raise
         except GenStreamErrorRaised as exc:
@@ -20844,19 +20945,12 @@ def _anthropic_map_generation_error(e: Exception) -> HTTPException:
     return HTTPException(status_code = 500, detail = _friendly_error(e))
 
 
-async def _collect_anthropic_events(run_gen, cancel_event = None) -> list:
+def _collect_anthropic_events(run_gen) -> list:
     """Drain the generator into a list, mapping an upstream 4xx / context
     overflow to a clean Anthropic 400 instead of leaking a 500."""
 
-    def _drain():
-        return list(run_gen())
-
-    drain_task = asyncio.create_task(asyncio.to_thread(_drain))
     try:
-        return await asyncio.shield(drain_task)
-    except asyncio.CancelledError:
-        await _drain_pending_next_task(drain_task, cancel_event)
-        raise
+        return list(run_gen())
     except HTTPException:
         raise
     except Exception as e:
@@ -20882,15 +20976,14 @@ def _anthropic_message_json_response(
     )
 
 
-async def _anthropic_tool_non_streaming(
-    run_gen,
+def _anthropic_tool_response_from_events(
+    events,
     message_id,
     model_name,
     disable_parallel_tool_use = False,
     openai_tools = None,
-    cancel_event = None,
 ):
-    """Non-streaming response for the tool-calling path.
+    """Reduce collected tool events into one non-streaming response.
 
     Builds ``content_blocks`` in generation order (text → tool_use → text →
     tool_use → ...), mirroring the streaming emitter. Deltas within one
@@ -20913,8 +21006,6 @@ async def _anthropic_tool_non_streaming(
     # Pending client tool_use; cleared by tool_end (server execution) or
     # trailing text. See the stop_reason mapping below.
     ends_on_tool_use = False
-
-    events = await _collect_anthropic_events(run_gen, cancel_event)
 
     for event in events:
         etype = event.get("type", "")
@@ -20986,19 +21077,39 @@ async def _anthropic_tool_non_streaming(
     )
 
 
-async def _anthropic_plain_non_streaming(
+async def _anthropic_tool_non_streaming(
     run_gen,
     message_id,
     model_name,
+    disable_parallel_tool_use = False,
+    openai_tools = None,
     cancel_event = None,
 ):
-    """Non-streaming response for the no-tool path."""
+    """Generate and reduce a tool response entirely off the event loop."""
+
+    def _drain_and_build():
+        return _anthropic_tool_response_from_events(
+            _collect_anthropic_events(run_gen),
+            message_id,
+            model_name,
+            disable_parallel_tool_use = disable_parallel_tool_use,
+            openai_tools = openai_tools,
+        )
+
+    return await _run_blocking_generation(
+        _drain_and_build,
+        cancel_event,
+        name = "anthropic-tool-nonstream",
+        daemon = True,
+    )
+
+
+def _anthropic_plain_response_from_events(events, message_id, model_name):
+    """Reduce collected plain events into one non-streaming response."""
     text_parts = []
     usage = {}
     prev_text = ""
     captured_finish_reason = None
-
-    events = await _collect_anthropic_events(run_gen, cancel_event)
 
     for cumulative in events:
         if isinstance(cumulative, dict):
@@ -21022,6 +21133,28 @@ async def _anthropic_plain_non_streaming(
 
     return _anthropic_message_json_response(
         message_id, model_name, content_blocks, stop_reason, usage
+    )
+
+
+async def _anthropic_plain_non_streaming(
+    run_gen,
+    message_id,
+    model_name,
+    cancel_event = None,
+):
+    """Generate and reduce a plain response entirely off the event loop."""
+
+    def _drain_and_build():
+        return _anthropic_plain_response_from_events(
+            _collect_anthropic_events(run_gen),
+            message_id,
+            model_name,
+        )
+
+    return await _run_blocking_generation(
+        _drain_and_build,
+        cancel_event,
+        name = "anthropic-plain-nonstream",
     )
 
 

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -3171,31 +3171,32 @@ async def _stop_local_disconnect_cancel_watcher(
         pass
 
 
-async def _drain_pending_next_task(task, cancel_event) -> None:
+async def _drain_pending_worker(worker, cancel_event) -> None:
     """Wait for a pending blocking worker before its resources are released.
 
-    On disconnect a worker may still be inside ``next(gen)`` or draining a whole
-    non-streaming generation. Cancelling the awaiting task does NOT stop that
-    worker. Re-set the cancel flag (the generator polls it) and shield the task
-    until the worker returns, so admission and generation tracking still cover
-    its real lifetime. No-op when there is no pending task.
+    ``worker`` is the task or future the request awaits: a streaming
+    ``next(gen)`` step, or a whole non-streaming generation. Cancelling it does
+    NOT stop the thread behind it. Re-set the cancel flag (the generator polls
+    it) and shield the worker until it returns, so admission and generation
+    tracking still cover its real lifetime. No-op when there is no pending
+    worker.
     """
-    if task is None:
+    if worker is None:
         return
     if cancel_event is not None:
         cancel_event.set()
-    while not task.done():
+    while not worker.done():
         try:
-            await asyncio.shield(task)
+            await asyncio.shield(worker)
         except asyncio.CancelledError:
             if cancel_event is not None:
                 cancel_event.set()
             continue
         except Exception:
             break
-    if task.done():
+    if worker.done():
         try:
-            task.exception()
+            worker.exception()
         except (asyncio.CancelledError, Exception):
             pass
 
@@ -3254,6 +3255,10 @@ async def _run_blocking_generation(
     Shield the worker so task cancellation cannot shorten the tracker or
     admission-lease lifetime. Use a daemon only for server-tool loops that may
     ignore cancellation; ordinary generation stays on the bounded default pool.
+
+    Unlike the streaming paths, which release their default-executor thread
+    between tokens, a non-daemon unit holds one for the whole generation. Keep
+    unrelated blocking work off that pool (see _STATUS_PROBE_EXECUTOR).
     """
     worker = (
         _start_daemon_worker(fn, name = name)
@@ -3263,7 +3268,7 @@ async def _run_blocking_generation(
     try:
         return await asyncio.shield(worker)
     except asyncio.CancelledError:
-        await _drain_pending_next_task(worker, cancel_event)
+        await _drain_pending_worker(worker, cancel_event)
         raise
 
 
@@ -15919,7 +15924,7 @@ async def openai_chat_completions(
                 # Drain a still-running next(gen) worker before closing: closing
                 # mid-next(gen) raises ValueError('generator already executing') and
                 # skips the generator's cleanup finally. Matches the GGUF tool stream.
-                await _drain_pending_next_task(_sf_next_task, cancel_event)
+                await _drain_pending_worker(_sf_next_task, cancel_event)
                 if gen is not None:
                     try:
                         # Offload the close so the generator's cleanup runs off the event
@@ -16397,7 +16402,7 @@ async def openai_chat_completions(
                 # Drain a still-running next(gen) worker before closing: closing
                 # mid-next(gen) raises ValueError('generator already executing') and
                 # skips the generator's cleanup finally. Matches the safetensors stream.
-                await _drain_pending_next_task(_next_task, cancel_event)
+                await _drain_pending_worker(_next_task, cancel_event)
                 if gen is not None:
                     try:
                         # Offload the close so the generator's cleanup runs off the event
@@ -20814,7 +20819,7 @@ async def _anthropic_tool_stream(
                 await _stop_local_disconnect_cancel_watcher(disconnect_watcher)
                 # Drain a still-running next(gen) worker first, so a mid-prefill disconnect releases
                 # its resources; closing first races into 'already executing'.
-                await _drain_pending_next_task(_next_task, cancel_event)
+                await _drain_pending_worker(_next_task, cancel_event)
                 if gen is not None:
                     try:
                         await asyncio.to_thread(gen.close)
@@ -20912,7 +20917,7 @@ async def _anthropic_plain_stream(
                 await _stop_local_disconnect_cancel_watcher(disconnect_watcher)
                 # Drain a still-running next(gen) worker first, so a mid-prefill disconnect releases
                 # its resources; closing first races into 'already executing'.
-                await _drain_pending_next_task(_next_task, cancel_event)
+                await _drain_pending_worker(_next_task, cancel_event)
                 if gen is not None:
                     try:
                         await asyncio.to_thread(gen.close)

--- a/studio/backend/tests/test_anthropic_messages.py
+++ b/studio/backend/tests/test_anthropic_messages.py
@@ -7,6 +7,7 @@ import sys
 import os
 import json
 import threading
+import time
 
 import httpx
 import pytest
@@ -948,19 +949,63 @@ class TestAnthropicToolNonStreaming:
             pytest.param(_anthropic_plain_non_streaming, "ok", id = "plain"),
         ],
     )
-    def test_generator_is_drained_off_the_event_loop(self, helper, event):
+    def test_complete_response_build_keeps_event_loop_responsive(self, helper, event):
         loop_thread = threading.current_thread()
         generator_threads = []
 
         def _run_gen():
             generator_threads.append(threading.current_thread())
+            time.sleep(0.08)
             yield event
 
-        response = asyncio.run(helper(_run_gen, "msg_1", "m"))
+        async def _run():
+            task = asyncio.create_task(helper(_run_gen, "msg_1", "m"))
+            await asyncio.sleep(0)
+            heartbeat_ticks = 0
+            while not task.done():
+                heartbeat_ticks += 1
+                await asyncio.sleep(0.005)
+            return await task, heartbeat_ticks
+
+        response, heartbeat_ticks = asyncio.run(_run())
 
         assert response.status_code == 200
+        assert heartbeat_ticks > 0
         assert len(generator_threads) == 1
         assert generator_threads[0] is not loop_thread
+
+    def test_tool_event_reduction_keeps_event_loop_responsive(self, monkeypatch):
+        import routes.inference as inf_mod
+
+        reduction_threads = []
+        real_strip = inf_mod._strip_tool_xml_for_display
+
+        def _slow_strip(*args, **kwargs):
+            reduction_threads.append(threading.current_thread())
+            time.sleep(0.08)
+            return real_strip(*args, **kwargs)
+
+        monkeypatch.setattr(inf_mod, "_strip_tool_xml_for_display", _slow_strip)
+
+        def _run_gen():
+            yield {"type": "content", "text": "ok"}
+
+        async def _run():
+            task = asyncio.create_task(_anthropic_tool_non_streaming(_run_gen, "msg_1", "m"))
+            await asyncio.sleep(0)
+            heartbeat_ticks = 0
+            while not task.done():
+                heartbeat_ticks += 1
+                await asyncio.sleep(0.005)
+            return await task, heartbeat_ticks
+
+        response, heartbeat_ticks = asyncio.run(_run())
+
+        assert response.status_code == 200
+        assert heartbeat_ticks > 0
+        assert len(reduction_threads) == 1
+        assert reduction_threads[0] is not threading.current_thread()
+        assert reduction_threads[0].daemon is True
 
     @pytest.mark.parametrize(
         ("helper", "event"),

--- a/studio/backend/tests/test_openai_tool_passthrough.py
+++ b/studio/backend/tests/test_openai_tool_passthrough.py
@@ -6715,6 +6715,75 @@ class TestApiMonitorSafetensorsUsage:
         url = SimpleNamespace(path = "/v1/chat/completions")
         method = "POST"
 
+    def test_non_streaming_safetensors_keeps_event_loop_responsive(self, monkeypatch):
+        async def _run():
+            import routes.inference as inf_mod
+
+            generation_started = threading.Event()
+            generation_finished = threading.Event()
+            generation_threads = []
+
+            class DummyBackend:
+                active_model_name = "safe-model"
+                models = {"safe-model": {"context_length": 2048}}
+
+                def generate_chat_response(self, **_kwargs):
+                    generation_threads.append(threading.current_thread())
+                    generation_started.set()
+                    try:
+                        time.sleep(0.08)
+                        yield "safe reply"
+                    finally:
+                        generation_finished.set()
+
+                def reset_generation_state(self, caller_cancel_event = None):
+                    pass
+
+            monkeypatch.setattr(
+                inf_mod,
+                "get_llama_cpp_backend",
+                lambda: SimpleNamespace(
+                    is_loaded = False,
+                    supports_tools = False,
+                    is_vision = False,
+                    context_length = None,
+                ),
+            )
+            monkeypatch.setattr(inf_mod, "get_inference_backend", lambda: DummyBackend())
+            monkeypatch.setattr(
+                inf_mod,
+                "_detect_safetensors_features",
+                lambda *_args, **_kwargs: {"supports_tools": False},
+            )
+            monkeypatch.setattr(inf_mod, "api_monitor", ApiMonitor(max_entries = 3))
+            payload = ChatCompletionRequest(
+                model = "default",
+                messages = [ChatMessage(role = "user", content = "hi")],
+            )
+            heartbeat_ticks = 0
+
+            async def _heartbeat():
+                nonlocal heartbeat_ticks
+                while not generation_finished.is_set():
+                    await asyncio.sleep(0.005)
+                    if generation_started.is_set() and not generation_finished.is_set():
+                        heartbeat_ticks += 1
+
+            heartbeat = asyncio.create_task(_heartbeat())
+            response = await openai_chat_completions(
+                payload,
+                request = self._Request(),
+                current_subject = "test",
+            )
+            await heartbeat
+
+            assert response.status_code == 200
+            assert heartbeat_ticks > 0
+            assert len(generation_threads) == 1
+            assert generation_threads[0] is not threading.current_thread()
+
+        asyncio.run(_run())
+
     def test_non_streaming_safetensors_records_usage(self, monkeypatch):
         async def _run():
             import routes.inference as inf_mod
@@ -6987,6 +7056,57 @@ class TestApiMonitorAudioInput:
             assert entry["status"] == "completed"
             assert entry["reply"] == "hello world"
             assert monitor.active_count() == 0
+
+        asyncio.run(_run())
+
+    def test_audio_input_non_streaming_keeps_event_loop_responsive(self, monkeypatch):
+        async def _run():
+            generation_started = threading.Event()
+            generation_finished = threading.Event()
+            generation_threads = []
+
+            def _chunks():
+                generation_threads.append(threading.current_thread())
+                generation_started.set()
+                try:
+                    time.sleep(0.08)
+                    yield "hello"
+                finally:
+                    generation_finished.set()
+
+            inf_mod = self._patch_audio_backend(monkeypatch, _chunks())
+            monkeypatch.setattr(inf_mod, "api_monitor", ApiMonitor(max_entries = 3))
+            payload = ChatCompletionRequest(
+                model = "default",
+                messages = [ChatMessage(role = "user", content = "describe this audio")],
+                audio_base64 = "ZmFrZQ==",
+            )
+            request = SimpleNamespace(
+                state = SimpleNamespace(),
+                url = SimpleNamespace(path = "/v1/chat/completions"),
+                method = "POST",
+            )
+            heartbeat_ticks = 0
+
+            async def _heartbeat():
+                nonlocal heartbeat_ticks
+                while not generation_finished.is_set():
+                    await asyncio.sleep(0.005)
+                    if generation_started.is_set() and not generation_finished.is_set():
+                        heartbeat_ticks += 1
+
+            heartbeat = asyncio.create_task(_heartbeat())
+            response = await openai_chat_completions(
+                payload,
+                request = request,
+                current_subject = "test",
+            )
+            await heartbeat
+
+            assert response.status_code == 200
+            assert heartbeat_ticks > 0
+            assert len(generation_threads) == 1
+            assert generation_threads[0] is not threading.current_thread()
 
         asyncio.run(_run())
 

--- a/studio/backend/tests/test_tool_stream_generator_drain.py
+++ b/studio/backend/tests/test_tool_stream_generator_drain.py
@@ -6,7 +6,7 @@
 Tool streams run ``next(gen)`` in an ``asyncio.to_thread`` worker. Closing the
 generator while that worker is still inside ``next`` raises ``ValueError:
 generator already executing`` and skips the generator's ``finally`` (tool
-cleanup); the routes drain the pending task first (``_drain_pending_next_task``),
+cleanup); the routes drain the pending task first (``_drain_pending_worker``),
 which these tests exercise.
 """
 
@@ -17,7 +17,7 @@ import threading
 
 import pytest
 
-from routes.inference import _drain_pending_next_task
+from routes.inference import _drain_pending_worker
 
 
 def test_drain_before_close_avoids_generator_already_executing():
@@ -46,7 +46,7 @@ def test_drain_before_close_avoids_generator_already_executing():
 
         # Draining sets the cancel flag so the worker returns; then close is
         # clean and the generator's finally runs.
-        await _drain_pending_next_task(next_task, cancel_event)
+        await _drain_pending_worker(next_task, cancel_event)
         gen.close()
         return
 
@@ -54,15 +54,15 @@ def test_drain_before_close_avoids_generator_already_executing():
     assert finally_ran.is_set()
 
 
-def test_drain_pending_next_task_is_noop_without_task():
+def test_drain_pending_worker_is_noop_without_task():
     # None (task already consumed): draining is a no-op, cancel flag untouched.
     cancel_event = threading.Event()
 
-    asyncio.run(_drain_pending_next_task(None, cancel_event))
+    asyncio.run(_drain_pending_worker(None, cancel_event))
     assert not cancel_event.is_set()
 
 
-def test_drain_pending_next_task_returns_when_worker_finishes():
+def test_drain_pending_worker_returns_when_worker_finishes():
     # A worker finishing on its own drains without error; the cancel flag stays
     # set (the caller is tearing the stream down).
     cancel_event = threading.Event()
@@ -76,7 +76,7 @@ def test_drain_pending_next_task_returns_when_worker_finishes():
         g = gen()
         task = asyncio.create_task(asyncio.to_thread(next, g, object()))
         release.set()  # let the worker complete before draining
-        await _drain_pending_next_task(task, cancel_event)
+        await _drain_pending_worker(task, cancel_event)
         assert task.done()
 
     asyncio.run(scenario())


### PR DESCRIPTION
Follow-up to #9201.

## Problem

#9201 moves non-streaming Anthropic generation off the event loop, fixing the watchdog failure in #8916. Two related blocking paths remain:

- The Anthropic server-tool path collects events in a worker but reduces them on the event loop. Its cumulative tool-call sanitization becomes quadratic on long responses.
- OpenAI safetensors and MLX generation, its tool-nudge retry, and audio-input generation still drain synchronous generators on the event loop.

Both can block health checks, disconnect handling, and unrelated API work during a long non-streaming request.

## Fix

- Run Anthropic collection and reduction as one worker unit.
- Drain the OpenAI and audio-input generators in workers.
- On cancellation, wait for the real worker before releasing generation tracking or llama admission.
- Use a daemon worker for Anthropic server tools so a cancellation-resistant tool cannot extend process shutdown.
- Rename the shared cleanup helper to `_drain_pending_worker`.

Streaming behavior is unchanged. Response content, error mapping, usage, nudge fallback, monitor state, and tool behavior are preserved.

## Validation

- `python3 -m pytest -q studio/backend/tests/test_anthropic_messages.py studio/backend/tests/test_openai_tool_passthrough.py studio/backend/tests/test_tool_stream_generator_drain.py` (`409 passed`)
- `python3 -m ruff check studio/backend/routes/inference.py studio/backend/tests/test_anthropic_messages.py studio/backend/tests/test_openai_tool_passthrough.py studio/backend/tests/test_tool_stream_generator_drain.py`
- `python3 -m py_compile studio/backend/routes/inference.py studio/backend/tests/test_anthropic_messages.py studio/backend/tests/test_openai_tool_passthrough.py studio/backend/tests/test_tool_stream_generator_drain.py`
