### PR TITLE
Studio: do not call the host CPU-only before the System tab has read anything

### DIFF
--- a/studio/frontend/src/features/settings/tabs/resources-tab.tsx
+++ b/studio/frontend/src/features/settings/tabs/resources-tab.tsx
@@ -142,8 +142,7 @@ function MetricTile({
           {percentKnown ? formatPercent(safePercent) : "--"}
         </span>
       </div>
-      {/* Both lines truncate in a half-width tile, so carry the full text as a title:
-          a sentence-length detail (the GPU states) is otherwise unrecoverable. */}
+      {/* Both lines truncate, so carry the full text: the GPU states are sentences. */}
       <div className="min-w-0">
         <div
           title={value}
@@ -349,18 +348,15 @@ export function ResourcesTab() {
   const cpuFrequencyLabel = formatFrequency(systemInfo.cpu?.frequency_mhz);
   const hasGpu =
     (displayedGpu?.available ?? false) && metrics.devices.length > 0;
-  // The placeholder reads as a CPU-only host with no GPU. Rendering that verdict
-  // tells an AMD/ROCm user their card is unused, so until the host has actually
-  // been read, report which of the two non-answers it is: still checking, or
-  // asked and got nothing back.
+  // The placeholder reads as a CPU-only host, so rendering it tells an AMD/ROCm user their
+  // card is unused. Until the host is read, say which non-answer it is: checking, or empty.
   const hostUnread = systemInfo.status !== "ready";
   const gpuUnknown = hostUnread && !hasGpu;
   const gpuUnknownLabel =
     systemInfo.status === "unavailable"
       ? t("settings.resources.gpu.unreadable")
       : t("settings.resources.gpu.detecting");
-  // The same two non-answers for the tiles that are not about the GPU. The failure
-  // wording already speaks of the whole host; only "checking for GPUs" does not.
+  // "Checking for GPUs" is the wrong sentence beside a RAM tile; the failure wording fits.
   const hostUnreadDetail =
     systemInfo.status === "unavailable"
       ? t("settings.resources.gpu.unreadable")
@@ -392,8 +388,7 @@ export function ResourcesTab() {
           .join(" · ")
     : null;
   const unknownLabel = t("settings.resources.environment.unknown");
-  // Same rule as the GPU sections: the placeholder's cpu backend and empty package list
-  // are not facts about the host either, so the Environment rows wait for the read too.
+  // The placeholder's cpu backend and empty package list are not facts about the host either.
   const hostReading = (value: string) => (hostUnread ? unknownLabel : value);
 
   return (
@@ -433,8 +428,7 @@ export function ResourcesTab() {
 
       <SettingsSection title={t("settings.resources.liveMonitor.title")}>
         <div className="grid gap-2 py-3 sm:grid-cols-2">
-          {/* An unread host is not an idle one with no capacity: percent null is what
-              MetricTile already has for a usage it must not fabricate. */}
+          {/* An unread host is not an idle one: percent null is MetricTile's "unknown". */}
           <MetricTile
             label={t("settings.resources.liveMonitor.cpu")}
             value={hostReading(cpuFrequencyLabel ?? cpuCoresLabel)}

--- a/studio/frontend/src/features/settings/tabs/resources-tab.tsx
+++ b/studio/frontend/src/features/settings/tabs/resources-tab.tsx
@@ -142,11 +142,16 @@ function MetricTile({
           {percentKnown ? formatPercent(safePercent) : "--"}
         </span>
       </div>
+      {/* Both lines truncate in a half-width tile, so carry the full text as a title:
+          a sentence-length detail (the GPU states) is otherwise unrecoverable. */}
       <div className="min-w-0">
-        <div className="truncate font-mono text-sm tabular-nums text-foreground">
+        <div
+          title={value}
+          className="truncate font-mono text-sm tabular-nums text-foreground"
+        >
           {value}
         </div>
-        <div className="mt-0.5 truncate text-xs text-muted-foreground">
+        <div title={detail} className="mt-0.5 truncate text-xs text-muted-foreground">
           {detail}
         </div>
       </div>
@@ -348,7 +353,8 @@ export function ResourcesTab() {
   // tells an AMD/ROCm user their card is unused, so until the host has actually
   // been read, report which of the two non-answers it is: still checking, or
   // asked and got nothing back.
-  const gpuUnknown = systemInfo.status !== "ready" && !hasGpu;
+  const hostUnread = systemInfo.status !== "ready";
+  const gpuUnknown = hostUnread && !hasGpu;
   const gpuUnknownLabel =
     systemInfo.status === "unavailable"
       ? t("settings.resources.gpu.unreadable")
@@ -380,6 +386,9 @@ export function ResourcesTab() {
           .join(" · ")
     : null;
   const unknownLabel = t("settings.resources.environment.unknown");
+  // Same rule as the GPU sections: the placeholder's cpu backend and empty package list
+  // are not facts about the host either, so the Environment rows wait for the read too.
+  const hostReading = (value: string) => (hostUnread ? unknownLabel : value);
 
   return (
     <div className="flex flex-col gap-6">
@@ -692,7 +701,7 @@ export function ResourcesTab() {
       <SettingsSection title={t("settings.resources.environment.title")}>
         <InfoRow
           label={t("settings.resources.environment.backend")}
-          value={backendLabel}
+          value={hostReading(backendLabel)}
         />
         <InfoRow
           label={t("settings.resources.environment.python")}
@@ -700,25 +709,25 @@ export function ResourcesTab() {
         />
         <InfoRow
           label={t("settings.resources.environment.torch")}
-          value={
+          value={hostReading(
             systemInfo.ml_packages.torch ??
-            t("settings.resources.environment.notInstalled")
-          }
+              t("settings.resources.environment.notInstalled"),
+          )}
         />
         <InfoRow
           label={t("settings.resources.environment.transformers")}
-          value={
+          value={hostReading(
             systemInfo.ml_packages.transformers ??
-            t("settings.resources.environment.notInstalled")
-          }
+              t("settings.resources.environment.notInstalled"),
+          )}
         />
         <InfoRow
           label={t("settings.resources.environment.uptime")}
-          value={formatUptime(systemInfo.uptime_seconds)}
+          value={hostReading(formatUptime(systemInfo.uptime_seconds))}
         />
         <InfoRow
           label={t("settings.resources.environment.processMemory")}
-          value={formatMb(systemInfo.memory?.process_used_mb)}
+          value={hostReading(formatMb(systemInfo.memory?.process_used_mb))}
         />
       </SettingsSection>
     </div>

--- a/studio/frontend/src/features/settings/tabs/resources-tab.tsx
+++ b/studio/frontend/src/features/settings/tabs/resources-tab.tsx
@@ -359,6 +359,12 @@ export function ResourcesTab() {
     systemInfo.status === "unavailable"
       ? t("settings.resources.gpu.unreadable")
       : t("settings.resources.gpu.detecting");
+  // The same two non-answers for the tiles that are not about the GPU. The failure
+  // wording already speaks of the whole host; only "checking for GPUs" does not.
+  const hostUnreadDetail =
+    systemInfo.status === "unavailable"
+      ? t("settings.resources.gpu.unreadable")
+      : t("common.loading");
   const backendLabel = (
     displayedGpu?.backend ??
     systemInfo.device_backend ??
@@ -427,31 +433,47 @@ export function ResourcesTab() {
 
       <SettingsSection title={t("settings.resources.liveMonitor.title")}>
         <div className="grid gap-2 py-3 sm:grid-cols-2">
+          {/* An unread host is not an idle one with no capacity: percent null is what
+              MetricTile already has for a usage it must not fabricate. */}
           <MetricTile
             label={t("settings.resources.liveMonitor.cpu")}
-            value={cpuFrequencyLabel ?? cpuCoresLabel}
+            value={hostReading(cpuFrequencyLabel ?? cpuCoresLabel)}
             detail={
-              cpuFrequencyLabel
-                ? cpuCoresLabel
-                : t("settings.resources.liveMonitor.currentLoad")
+              hostUnread
+                ? hostUnreadDetail
+                : cpuFrequencyLabel
+                  ? cpuCoresLabel
+                  : t("settings.resources.liveMonitor.currentLoad")
             }
-            percent={systemInfo.cpu?.usage_percent ?? 0}
+            percent={hostUnread ? null : (systemInfo.cpu?.usage_percent ?? 0)}
           />
           <MetricTile
             label={t("settings.resources.liveMonitor.ram")}
-            value={`${formatGiB(metrics.ramUsed)} / ${formatGiB(metrics.ramTotal)}`}
-            detail={t("settings.resources.liveMonitor.free", {
-              value: formatGiB(systemInfo.memory?.available_gb),
-            })}
-            percent={systemInfo.memory?.percent_used ?? 0}
+            value={hostReading(
+              `${formatGiB(metrics.ramUsed)} / ${formatGiB(metrics.ramTotal)}`,
+            )}
+            detail={
+              hostUnread
+                ? hostUnreadDetail
+                : t("settings.resources.liveMonitor.free", {
+                    value: formatGiB(systemInfo.memory?.available_gb),
+                  })
+            }
+            percent={hostUnread ? null : (systemInfo.memory?.percent_used ?? 0)}
           />
           <MetricTile
             label={t("settings.resources.liveMonitor.disk")}
-            value={`${formatGb(metrics.diskUsed)} / ${formatGb(metrics.diskTotal)}`}
-            detail={t("settings.resources.liveMonitor.free", {
-              value: formatGb(metrics.diskFree),
-            })}
-            percent={metrics.diskPercent}
+            value={hostReading(
+              `${formatGb(metrics.diskUsed)} / ${formatGb(metrics.diskTotal)}`,
+            )}
+            detail={
+              hostUnread
+                ? hostUnreadDetail
+                : t("settings.resources.liveMonitor.free", {
+                    value: formatGb(metrics.diskFree),
+                  })
+            }
+            percent={hostUnread ? null : metrics.diskPercent}
           />
           <MetricTile
             label={t("settings.resources.liveMonitor.vram")}

--- a/studio/frontend/src/features/settings/tabs/resources-tab.tsx
+++ b/studio/frontend/src/features/settings/tabs/resources-tab.tsx
@@ -344,6 +344,10 @@ export function ResourcesTab() {
   const cpuFrequencyLabel = formatFrequency(systemInfo.cpu?.frequency_mhz);
   const hasGpu =
     (displayedGpu?.available ?? false) && metrics.devices.length > 0;
+  // Until /api/system answers, the placeholder reads as a CPU-only host with no
+  // GPU. Rendering that verdict tells an AMD/ROCm user their card is unused, so
+  // say the check is still running instead.
+  const gpuUnknown = !systemInfo.loaded && !hasGpu;
   const backendLabel = (
     displayedGpu?.backend ??
     systemInfo.device_backend ??
@@ -438,20 +442,24 @@ export function ResourcesTab() {
           <MetricTile
             label={t("settings.resources.liveMonitor.vram")}
             value={
-              hasGpu
-                ? metrics.vramUsageKnown
-                  ? `${formatGiB(metrics.vramUsed)} / ${formatGiB(metrics.vramTotal)}`
-                  : `${unknownLabel} / ${formatGiB(metrics.vramTotal)}`
-                : t("settings.resources.liveMonitor.noGpu")
+              gpuUnknown
+                ? t("common.loading")
+                : hasGpu
+                  ? metrics.vramUsageKnown
+                    ? `${formatGiB(metrics.vramUsed)} / ${formatGiB(metrics.vramTotal)}`
+                    : `${unknownLabel} / ${formatGiB(metrics.vramTotal)}`
+                  : t("settings.resources.liveMonitor.noGpu")
             }
             detail={
-              hasGpu
-                ? metrics.vramUsageKnown
-                  ? t("settings.resources.liveMonitor.free", {
-                      value: formatGiB(metrics.vramFree),
-                    })
-                  : unknownLabel
-                : backendLabel
+              gpuUnknown
+                ? t("settings.resources.gpu.detecting")
+                : hasGpu
+                  ? metrics.vramUsageKnown
+                    ? t("settings.resources.liveMonitor.free", {
+                        value: formatGiB(metrics.vramFree),
+                      })
+                    : unknownLabel
+                  : backendLabel
             }
             percent={metrics.vramUsageKnown ? metrics.vramPercent : null}
           />
@@ -570,7 +578,9 @@ export function ResourcesTab() {
           })
         ) : (
           <div className="py-3 text-sm text-muted-foreground">
-            {t("settings.resources.gpu.noGpu")}
+            {gpuUnknown
+              ? t("settings.resources.gpu.detecting")
+              : t("settings.resources.gpu.noGpu")}
           </div>
         )}
       </SettingsSection>

--- a/studio/frontend/src/features/settings/tabs/resources-tab.tsx
+++ b/studio/frontend/src/features/settings/tabs/resources-tab.tsx
@@ -344,10 +344,15 @@ export function ResourcesTab() {
   const cpuFrequencyLabel = formatFrequency(systemInfo.cpu?.frequency_mhz);
   const hasGpu =
     (displayedGpu?.available ?? false) && metrics.devices.length > 0;
-  // Until /api/system answers, the placeholder reads as a CPU-only host with no
-  // GPU. Rendering that verdict tells an AMD/ROCm user their card is unused, so
-  // say the check is still running instead.
-  const gpuUnknown = !systemInfo.loaded && !hasGpu;
+  // The placeholder reads as a CPU-only host with no GPU. Rendering that verdict
+  // tells an AMD/ROCm user their card is unused, so until the host has actually
+  // been read, report which of the two non-answers it is: still checking, or
+  // asked and got nothing back.
+  const gpuUnknown = systemInfo.status !== "ready" && !hasGpu;
+  const gpuUnknownLabel =
+    systemInfo.status === "unavailable"
+      ? t("settings.resources.gpu.unreadable")
+      : t("settings.resources.gpu.detecting");
   const backendLabel = (
     displayedGpu?.backend ??
     systemInfo.device_backend ??
@@ -443,7 +448,7 @@ export function ResourcesTab() {
             label={t("settings.resources.liveMonitor.vram")}
             value={
               gpuUnknown
-                ? t("common.loading")
+                ? unknownLabel
                 : hasGpu
                   ? metrics.vramUsageKnown
                     ? `${formatGiB(metrics.vramUsed)} / ${formatGiB(metrics.vramTotal)}`
@@ -452,7 +457,7 @@ export function ResourcesTab() {
             }
             detail={
               gpuUnknown
-                ? t("settings.resources.gpu.detecting")
+                ? gpuUnknownLabel
                 : hasGpu
                   ? metrics.vramUsageKnown
                     ? t("settings.resources.liveMonitor.free", {
@@ -578,9 +583,7 @@ export function ResourcesTab() {
           })
         ) : (
           <div className="py-3 text-sm text-muted-foreground">
-            {gpuUnknown
-              ? t("settings.resources.gpu.detecting")
-              : t("settings.resources.gpu.noGpu")}
+            {gpuUnknown ? gpuUnknownLabel : t("settings.resources.gpu.noGpu")}
           </div>
         )}
       </SettingsSection>

--- a/studio/frontend/src/hooks/system-discovery.ts
+++ b/studio/frontend/src/hooks/system-discovery.ts
@@ -1,6 +1,22 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
+/** How far the host description has got: "pending" until the first request
+ * settles, "ready" once real data arrives, "unavailable" when it settled with
+ * none. Callers rendering a verdict about the host must not draw one from
+ * anything but "ready". */
+export type SystemInfoStatus = "pending" | "ready" | "unavailable";
+
+/** The status after a request settles empty. Data already on screen stays, so a
+ * failed poll cannot blank a good reading; only a placeholder moves, off
+ * "pending", because with polling off nothing retries and "still checking"
+ * would outlive the check. */
+export function settledFailureStatus(
+  previous: SystemInfoStatus,
+): SystemInfoStatus {
+  return previous === "ready" ? "ready" : "unavailable";
+}
+
 interface InferenceGpuDiscovery {
   available: boolean;
   backend?: string;

--- a/studio/frontend/src/hooks/system-discovery.ts
+++ b/studio/frontend/src/hooks/system-discovery.ts
@@ -1,16 +1,12 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-/** How far the host description has got: "pending" until the first request
- * settles, "ready" once real data arrives, "unavailable" when it settled with
- * none. Callers rendering a verdict about the host must not draw one from
- * anything but "ready". */
+/** How far host discovery has got: "pending" until the first request settles, "ready" on
+ * real data, "unavailable" when it settled with none. Render a verdict only from "ready". */
 export type SystemInfoStatus = "pending" | "ready" | "unavailable";
 
-/** The status after a request settles empty. Data already on screen stays, so a
- * failed poll cannot blank a good reading; only a placeholder moves, off
- * "pending", because with polling off nothing retries and "still checking"
- * would outlive the check. */
+/** The status after a request settles empty. A reading on screen stays; only a placeholder
+ * moves off "pending", since with polling off nothing retries and "checking" would outlive it. */
 export function settledFailureStatus(
   previous: SystemInfoStatus,
 ): SystemInfoStatus {

--- a/studio/frontend/src/hooks/use-system.ts
+++ b/studio/frontend/src/hooks/use-system.ts
@@ -3,7 +3,11 @@
 
 import { authFetch } from "@/features/auth";
 import { useEffect, useState } from "react";
-import { shouldRetrySystemDiscovery } from "./system-discovery";
+import {
+  settledFailureStatus,
+  shouldRetrySystemDiscovery,
+  type SystemInfoStatus,
+} from "./system-discovery";
 
 export interface GpuDevice {
   index?: number;
@@ -38,11 +42,10 @@ export interface SystemGpuInfo {
 export { aggregateGpuMemoryTotalGb } from "./gpu-vram";
 
 export interface SystemInfoResponse {
-  /** Client-side, not sent by the backend: false on the placeholder below until
-   * /api/system answers. Readers that render a verdict about the host -- "no
-   * GPU", "CPU only" -- must check it, or they state it as fact before anything
-   * has been read. */
-  loaded: boolean;
+  /** Client-side, not sent by the backend. Readers that render a verdict about
+   * the host -- "no GPU", "CPU only" -- must check it, or they state the
+   * placeholder below as fact. */
+  status: SystemInfoStatus;
   platform: string;
   python_version: string;
   device_backend: "cuda" | "rocm" | "cpu" | "mlx" | "xpu";
@@ -80,7 +83,7 @@ let vulkanRetrySubscribers = 0;
 let vulkanRetryId: number | null = null;
 
 const DEFAULT_SYSTEM: SystemInfoResponse = {
-  loaded: false,
+  status: "pending",
   platform: "Unknown",
   python_version: "Unknown",
   device_backend: "cpu",
@@ -155,7 +158,7 @@ export async function fetchSystemInfo({
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const data = await res.json();
 
-      cachedSystem = { ...(data as SystemInfoResponse), loaded: true };
+      cachedSystem = { ...(data as SystemInfoResponse), status: "ready" };
       systemSubscribers.forEach((subscriber) => subscriber(cachedSystem!));
       return cachedSystem;
     } catch {
@@ -189,7 +192,17 @@ export function useSystemInfo({
     const update = (force: boolean) => {
       void fetchSystemInfo({ force })
         .then((info) => {
-          if (!cancelled && info) setSystemInfo(info);
+          if (cancelled) return;
+          if (info) {
+            setSystemInfo(info);
+            return;
+          }
+          setSystemInfo((previous) => {
+            const status = settledFailureStatus(previous.status);
+            return status === previous.status
+              ? previous
+              : { ...DEFAULT_SYSTEM, status };
+          });
         })
         .finally(() => {
           if (cancelled || !pollMs) return;

--- a/studio/frontend/src/hooks/use-system.ts
+++ b/studio/frontend/src/hooks/use-system.ts
@@ -42,9 +42,8 @@ export interface SystemGpuInfo {
 export { aggregateGpuMemoryTotalGb } from "./gpu-vram";
 
 export interface SystemInfoResponse {
-  /** Client-side, not sent by the backend. Readers that render a verdict about
-   * the host -- "no GPU", "CPU only" -- must check it, or they state the
-   * placeholder below as fact. */
+  /** Client-side, not sent by the backend. Readers rendering a host verdict -- "no GPU",
+   * "CPU only" -- must check it, or they state the placeholder below as fact. */
   status: SystemInfoStatus;
   platform: string;
   python_version: string;
@@ -189,9 +188,8 @@ export function useSystemInfo({
     let cancelled = false;
     let timeoutId: number | null = null;
 
-    // Every successful read is published here. A placeholder has nothing to retry it
-    // once its own request settled, so it takes the shared snapshot; a reading already
-    // on screen is left to this hook's poll, which the live-updates switch governs.
+    // A placeholder has nothing to retry it once its own request settled, so it takes any
+    // published read; a reading on screen is left to this hook's poll (the live-updates switch).
     const unsubscribe = subscribeSystemInfo((info) => {
       if (cancelled) return;
       setSystemInfo((previous) => (previous.status === "ready" ? previous : info));

--- a/studio/frontend/src/hooks/use-system.ts
+++ b/studio/frontend/src/hooks/use-system.ts
@@ -189,6 +189,14 @@ export function useSystemInfo({
     let cancelled = false;
     let timeoutId: number | null = null;
 
+    // Every successful read is published here. A placeholder has nothing to retry it
+    // once its own request settled, so it takes the shared snapshot; a reading already
+    // on screen is left to this hook's poll, which the live-updates switch governs.
+    const unsubscribe = subscribeSystemInfo((info) => {
+      if (cancelled) return;
+      setSystemInfo((previous) => (previous.status === "ready" ? previous : info));
+    });
+
     const update = (force: boolean) => {
       void fetchSystemInfo({ force })
         .then((info) => {
@@ -213,6 +221,7 @@ export function useSystemInfo({
     update(Boolean(pollMs));
     return () => {
       cancelled = true;
+      unsubscribe();
       if (timeoutId !== null) window.clearTimeout(timeoutId);
     };
   }, [enabled, pollMs]);

--- a/studio/frontend/src/hooks/use-system.ts
+++ b/studio/frontend/src/hooks/use-system.ts
@@ -38,6 +38,11 @@ export interface SystemGpuInfo {
 export { aggregateGpuMemoryTotalGb } from "./gpu-vram";
 
 export interface SystemInfoResponse {
+  /** Client-side, not sent by the backend: false on the placeholder below until
+   * /api/system answers. Readers that render a verdict about the host -- "no
+   * GPU", "CPU only" -- must check it, or they state it as fact before anything
+   * has been read. */
+  loaded: boolean;
   platform: string;
   python_version: string;
   device_backend: "cuda" | "rocm" | "cpu" | "mlx" | "xpu";
@@ -75,6 +80,7 @@ let vulkanRetrySubscribers = 0;
 let vulkanRetryId: number | null = null;
 
 const DEFAULT_SYSTEM: SystemInfoResponse = {
+  loaded: false,
   platform: "Unknown",
   python_version: "Unknown",
   device_backend: "cpu",
@@ -149,7 +155,7 @@ export async function fetchSystemInfo({
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const data = await res.json();
 
-      cachedSystem = data as SystemInfoResponse;
+      cachedSystem = { ...(data as SystemInfoResponse), loaded: true };
       systemSubscribers.forEach((subscriber) => subscriber(cachedSystem!));
       return cachedSystem;
     } catch {

--- a/studio/frontend/src/i18n/locales/ar.ts
+++ b/studio/frontend/src/i18n/locales/ar.ts
@@ -837,6 +837,8 @@ export const ar = {
         title: "أجهزة GPU",
         ggufInference: "استدلال GGUF",
         unavailable: "غير متاح",
+        detecting: "جارٍ البحث عن وحدات GPU...",
+        unreadable: "تعذّرت قراءة عتاد هذا الخادم.",
         noGpu: "لم يُكتشف أي GPU مرئي. تُعرض موارد CPU فقط أعلاه.",
         unknownDevice: "GPU غير معروف",
         deviceWithIndex: "GPU {index}",

--- a/studio/frontend/src/i18n/locales/de.ts
+++ b/studio/frontend/src/i18n/locales/de.ts
@@ -862,6 +862,8 @@ export const de = {
         title: "GPU-Geräte",
         ggufInference: "GGUF-Inferenz",
         unavailable: "nicht verfügbar",
+        detecting: "Suche nach GPUs...",
+        unreadable: "Die Hardware dieses Servers konnte nicht gelesen werden.",
         noGpu:
           "Keine sichtbare GPU erkannt. Oben werden nur die CPU-Ressourcen angezeigt.",
         unknownDevice: "Unbekannte GPU",

--- a/studio/frontend/src/i18n/locales/en.ts
+++ b/studio/frontend/src/i18n/locales/en.ts
@@ -833,6 +833,7 @@ export const en = {
         title: "GPU devices",
         ggufInference: "GGUF inference",
         unavailable: "unavailable",
+        detecting: "Checking for GPUs...",
         noGpu: "No visible GPU detected. CPU-only resources are shown above.",
         unknownDevice: "Unknown GPU",
         deviceWithIndex: "GPU {index}",

--- a/studio/frontend/src/i18n/locales/en.ts
+++ b/studio/frontend/src/i18n/locales/en.ts
@@ -834,6 +834,7 @@ export const en = {
         ggufInference: "GGUF inference",
         unavailable: "unavailable",
         detecting: "Checking for GPUs...",
+        unreadable: "Could not read this server's hardware.",
         noGpu: "No visible GPU detected. CPU-only resources are shown above.",
         unknownDevice: "Unknown GPU",
         deviceWithIndex: "GPU {index}",

--- a/studio/frontend/src/i18n/locales/es.ts
+++ b/studio/frontend/src/i18n/locales/es.ts
@@ -857,6 +857,8 @@ export const es = {
         title: "Dispositivos GPU",
         ggufInference: "Inferencia GGUF",
         unavailable: "No disponible",
+        detecting: "Buscando GPU...",
+        unreadable: "No se pudo leer el hardware de este servidor.",
         noGpu:
           "No se detectó ninguna GPU visible. Arriba se muestran los recursos solo de CPU.",
         unknownDevice: "GPU desconocida",

--- a/studio/frontend/src/i18n/locales/fr.ts
+++ b/studio/frontend/src/i18n/locales/fr.ts
@@ -861,6 +861,8 @@ export const fr = {
         title: "Périphériques GPU",
         ggufInference: "Inférence GGUF",
         unavailable: "indisponible",
+        detecting: "Recherche de GPU...",
+        unreadable: "Impossible de lire le matériel de ce serveur.",
         noGpu:
           "Aucun GPU visible n'a été détecté. Seules les ressources du CPU sont affichées ci-dessus.",
         unknownDevice: "GPU inconnu",

--- a/studio/frontend/src/i18n/locales/hi.ts
+++ b/studio/frontend/src/i18n/locales/hi.ts
@@ -840,6 +840,8 @@ export const hi = {
         title: "GPU डिवाइस",
         ggufInference: "GGUF इन्फ़रेंस",
         unavailable: "उपलब्ध नहीं",
+        detecting: "GPU खोजे जा रहे हैं...",
+        unreadable: "इस सर्वर का हार्डवेयर नहीं पढ़ा जा सका।",
         noGpu: "कोई दृश्यमान GPU नहीं मिला। केवल-CPU संसाधन ऊपर दिखाए गए हैं।",
         unknownDevice: "अज्ञात GPU",
         deviceWithIndex: "GPU {index}",

--- a/studio/frontend/src/i18n/locales/it.ts
+++ b/studio/frontend/src/i18n/locales/it.ts
@@ -828,6 +828,8 @@ export const it = {
         title: "Dispositivi GPU",
         ggufInference: "Inferenza GGUF",
         unavailable: "non disponibile",
+        detecting: "Ricerca di GPU...",
+        unreadable: "Impossibile leggere l'hardware di questo server.",
         noGpu:
           "Nessuna GPU visibile rilevata. Sopra sono mostrate le risorse della sola CPU.",
         unknownDevice: "GPU sconosciuta",

--- a/studio/frontend/src/i18n/locales/ja.ts
+++ b/studio/frontend/src/i18n/locales/ja.ts
@@ -819,6 +819,8 @@ export const ja = {
         title: "GPU デバイス",
         ggufInference: "GGUF 推論",
         unavailable: "利用不可",
+        detecting: "GPU を確認しています...",
+        unreadable: "このサーバーのハードウェアを読み取れませんでした。",
         noGpu:
           "利用可能な GPU が検出されませんでした。CPU のみの環境向けのリソース情報は上に表示されています。",
         unknownDevice: "不明な GPU",

--- a/studio/frontend/src/i18n/locales/ko.ts
+++ b/studio/frontend/src/i18n/locales/ko.ts
@@ -834,6 +834,8 @@ export const ko = {
         title: "GPU 장치",
         ggufInference: "GGUF 추론",
         unavailable: "사용할 수 없음",
+        detecting: "GPU를 확인하는 중...",
+        unreadable: "이 서버의 하드웨어를 읽을 수 없습니다.",
         noGpu: "인식되는 GPU가 없습니다. 위에는 CPU 관련 리소스만 표시됩니다.",
         unknownDevice: "알 수 없는 GPU",
         deviceWithIndex: "GPU {index}",

--- a/studio/frontend/src/i18n/locales/pt-br.ts
+++ b/studio/frontend/src/i18n/locales/pt-br.ts
@@ -846,6 +846,8 @@ export const ptBR = {
         title: "Dispositivos de GPU",
         ggufInference: "Inferência com GGUF",
         unavailable: "indisponível",
+        detecting: "Procurando GPUs...",
+        unreadable: "Não foi possível ler o hardware deste servidor.",
         noGpu: "Nenhuma GPU visível detectada. Os recursos somente CPU aparecem acima.",
         unknownDevice: "GPU desconhecida",
         deviceWithIndex: "GPU {index}",

--- a/studio/frontend/src/i18n/locales/ru.ts
+++ b/studio/frontend/src/i18n/locales/ru.ts
@@ -841,6 +841,8 @@ export const ru = {
         title: "Устройства GPU",
         ggufInference: "Инференс GGUF",
         unavailable: "недоступно",
+        detecting: "Поиск GPU...",
+        unreadable: "Не удалось прочитать оборудование этого сервера.",
         noGpu:
           "Доступные GPU не обнаружены. Выше показаны ресурсы только для CPU.",
         unknownDevice: "Неизвестный GPU",

--- a/studio/frontend/src/i18n/locales/zh-CN.ts
+++ b/studio/frontend/src/i18n/locales/zh-CN.ts
@@ -816,6 +816,8 @@ export const zhCN = {
         title: "GPU 设备",
         ggufInference: "GGUF 推理",
         unavailable: "不可用",
+        detecting: "正在检查 GPU...",
+        unreadable: "无法读取此服务器的硬件信息。",
         noGpu: "未检测到可见 GPU。上方仅显示 CPU 资源。",
         unknownDevice: "未知 GPU",
         deviceWithIndex: "GPU {index}",

--- a/studio/frontend/tests/system-discovery.test.ts
+++ b/studio/frontend/tests/system-discovery.test.ts
@@ -39,8 +39,7 @@ test("retries only an unavailable Vulkan inventory after discovery", () => {
 });
 
 test("a settled failure leaves the placeholder, not a live check", () => {
-  // Polling off means nothing retries, so "pending" would outlive the check and
-  // the System tab would claim to be looking for a GPU forever.
+  // Polling off means nothing retries, so "pending" would outlive the check.
   assert.equal(settledFailureStatus("pending"), "unavailable");
   assert.equal(settledFailureStatus("unavailable"), "unavailable");
 });

--- a/studio/frontend/tests/system-discovery.test.ts
+++ b/studio/frontend/tests/system-discovery.test.ts
@@ -4,7 +4,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { shouldRetrySystemDiscovery } from "../src/hooks/system-discovery.ts";
+import {
+  settledFailureStatus,
+  shouldRetrySystemDiscovery,
+} from "../src/hooks/system-discovery.ts";
 
 test("retries a cold system cache while an interested subscriber exists", () => {
   assert.equal(shouldRetrySystemDiscovery(true, undefined, 1), true);
@@ -33,4 +36,15 @@ test("retries only an unavailable Vulkan inventory after discovery", () => {
     false,
   );
   assert.equal(shouldRetrySystemDiscovery(false, undefined, 1), false);
+});
+
+test("a settled failure leaves the placeholder, not a live check", () => {
+  // Polling off means nothing retries, so "pending" would outlive the check and
+  // the System tab would claim to be looking for a GPU forever.
+  assert.equal(settledFailureStatus("pending"), "unavailable");
+  assert.equal(settledFailureStatus("unavailable"), "unavailable");
+});
+
+test("a settled failure does not blank a reading already on screen", () => {
+  assert.equal(settledFailureStatus("ready"), "ready");
 });

--- a/studio/frontend/tests/system-status-verdict.test.ts
+++ b/studio/frontend/tests/system-status-verdict.test.ts
@@ -150,6 +150,34 @@ test("the Environment rows wait for the same read", () => {
   }
 });
 
+test("no tile fabricates a usage percentage for a host it has not read", () => {
+  // MetricTile takes percent null for "unknown" and draws a dash and an empty bar. An
+  // unread host is not an idle one with no capacity, so every tile must reach for that
+  // rather than pass 0. Asserted on the source: percent is a prop, not a derivation.
+  const tiles = tabSrc.match(/<MetricTile\b[\s\S]*?\/>/g) ?? [];
+  assert.equal(tiles.length, 4, "the Live monitor's four tiles");
+  for (const tile of tiles) {
+    const label = /label=\{t\("([^"]+)"\)\}/.exec(tile)?.[1] ?? "?";
+    const percent = /percent=\{([^}]*)\}/.exec(tile)?.[1] ?? "";
+    assert.match(
+      percent,
+      /hostUnread \? null :|vramUsageKnown \? metrics\.vramPercent : null/,
+      `${label} gates its percentage`,
+    );
+  }
+});
+
+test("the two non-answers are worded for the whole host, not just its GPUs", () => {
+  // "Checking for GPUs..." beside a RAM reading would be the wrong sentence, so the
+  // non-GPU tiles take common.loading; the failure wording already speaks of the host.
+  const detail = lift(tabSrc, /const hostUnreadDetail =\n?[\s\S]*?;/, "hostUnreadDetail", "resources-tab.tsx");
+  const forStatus = (status: string) =>
+    new Function("systemInfo", "t", `${detail}\nreturn hostUnreadDetail;`)({ status }, t);
+  assert.equal(forStatus("unavailable"), UNREADABLE);
+  assert.equal(forStatus("pending"), "common.loading");
+  assert.notEqual(forStatus("pending"), DETECTING, "which is about GPUs specifically");
+});
+
 test("a host that really has no GPU still gets the CPU-only verdict, and its real rows", () => {
   const out = verdictFor(cpuShaped("ready"));
   assert.equal(out.gpuUnknown, false);

--- a/studio/frontend/tests/system-status-verdict.test.ts
+++ b/studio/frontend/tests/system-status-verdict.test.ts
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// The System tab's host verdict, run rather than pattern-matched.
+//
+// settledFailureStatus is three lines and has its own cases in system-discovery.test.ts.
+// Those cannot fail for the bug this guards: the verdict lives in resources-tab.tsx as
+// `hostUnread && !hasGpu`, and the preservation rule lives in the callbacks useSystemInfo
+// hands to setSystemInfo. Delete either and the helper's cases still pass. So lift both out
+// of their sources and evaluate them, the way chat-only-route-guard.test.ts lifts the route
+// guard out of __root.tsx (resources-tab is .tsx and pulls in the whole app, so it cannot be
+// imported here).
+//
+// The case this exists for: DEFAULT_SYSTEM describes a cpu backend with no GPU and zero
+// everything. Rendered before /api/system answers, it told an AMD/ROCm user "No visible GPU
+// detected. CPU-only resources are shown above."
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const tabSrc = await readFile(
+  new URL("../src/features/settings/tabs/resources-tab.tsx", import.meta.url),
+  "utf8",
+);
+const hookSrc = await readFile(
+  new URL("../src/hooks/use-system.ts", import.meta.url),
+  "utf8",
+);
+
+function lift(src: string, pattern: RegExp, what: string, where: string): string {
+  const found = pattern.exec(src);
+  assert.ok(found, `could not find ${what} in ${where}`);
+  return found[0];
+}
+
+// The one annotation in the lifted block is hostReading's parameter; dropping it by hand
+// keeps this a plain-node test. A changed shape fails loudly, when lift finds nothing.
+const verdict = [
+  lift(tabSrc, /const hasGpu =\n?[\s\S]*?;/, "hasGpu", "resources-tab.tsx"),
+  lift(tabSrc, /const hostUnread = [\s\S]*?;/, "hostUnread", "resources-tab.tsx"),
+  lift(tabSrc, /const gpuUnknown = [\s\S]*?;/, "gpuUnknown", "resources-tab.tsx"),
+  lift(tabSrc, /const gpuUnknownLabel =\n?[\s\S]*?;/, "gpuUnknownLabel", "resources-tab.tsx"),
+  lift(tabSrc, /const backendLabel = \([\s\S]*?\)\.toUpperCase\(\);/, "backendLabel", "resources-tab.tsx"),
+  lift(tabSrc, /const hostReading = [\s\S]*?;/, "hostReading", "resources-tab.tsx").replace(
+    "(value: string)",
+    "(value)",
+  ),
+].join("\n");
+
+// The GPU-devices section's fallback, which is what a host with no device rows reads.
+const gpuSection = lift(
+  tabSrc,
+  /gpuUnknown \? gpuUnknownLabel : t\("settings\.resources\.gpu\.noGpu"\)/,
+  "the GPU section fallback",
+  "resources-tab.tsx",
+);
+
+// t() returns its key, so a failure names the string the user would have seen.
+const t = (key: string) => key;
+
+interface Snapshot {
+  status: string;
+  device_backend: string;
+  gpu: { available: boolean; backend?: string; devices: unknown[] };
+  ml_packages?: { torch?: string };
+}
+
+function verdictFor(systemInfo: Snapshot) {
+  const run = new Function(
+    "systemInfo",
+    "displayedGpu",
+    "metrics",
+    "t",
+    "unknownLabel",
+    `${verdict}
+     return {
+       gpuUnknown,
+       hasGpu,
+       gpuSection: hasGpu ? "<device rows>" : (${gpuSection}),
+       backendRow: hostReading(backendLabel),
+       torchRow: hostReading(
+         systemInfo.ml_packages?.torch ?? "settings.resources.environment.notInstalled",
+       ),
+     };`,
+  );
+  return run(
+    systemInfo,
+    systemInfo.gpu,
+    { devices: systemInfo.gpu.devices },
+    t,
+    "settings.resources.environment.unknown",
+  ) as {
+    gpuUnknown: boolean;
+    hasGpu: boolean;
+    gpuSection: string;
+    backendRow: string;
+    torchRow: string;
+  };
+}
+
+const NO_GPU = "settings.resources.gpu.noGpu";
+const DETECTING = "settings.resources.gpu.detecting";
+const UNREADABLE = "settings.resources.gpu.unreadable";
+const UNKNOWN = "settings.resources.environment.unknown";
+const NOT_INSTALLED = "settings.resources.environment.notInstalled";
+
+const cpuShaped = (status: string): Snapshot => ({
+  status,
+  device_backend: "cpu",
+  gpu: { available: false, devices: [] },
+});
+
+test("the placeholder is shaped exactly like a CPU-only host, which is why this gate exists", () => {
+  const placeholder = lift(
+    hookSrc,
+    /const DEFAULT_SYSTEM: SystemInfoResponse = \{[\s\S]*?\n\};/,
+    "DEFAULT_SYSTEM",
+    "use-system.ts",
+  );
+  assert.match(placeholder, /status: "pending"/);
+  assert.match(placeholder, /device_backend: "cpu"/);
+  assert.match(placeholder, /gpu: \{ available: false, devices: \[\] \}/);
+});
+
+test("before the host has been read, the tab says it is checking, not that there is no GPU", () => {
+  const out = verdictFor(cpuShaped("pending"));
+  assert.equal(out.gpuUnknown, true);
+  assert.equal(out.gpuSection, DETECTING);
+  assert.notEqual(out.gpuSection, NO_GPU);
+});
+
+test("after the read settles empty, the tab says so, and still does not claim there is no GPU", () => {
+  // Distinct from "checking": with live updates off nothing retries, so a check that never
+  // ends would outlive the check.
+  const out = verdictFor(cpuShaped("unavailable"));
+  assert.equal(out.gpuUnknown, true);
+  assert.equal(out.gpuSection, UNREADABLE);
+  assert.notEqual(out.gpuSection, NO_GPU);
+  assert.notEqual(out.gpuSection, DETECTING);
+});
+
+test("the Environment rows wait for the same read", () => {
+  // The placeholder's backend is "cpu" and its package list is empty. Rendered, that is the
+  // same false verdict the GPU sections above refuse, two sections further down.
+  for (const status of ["pending", "unavailable"]) {
+    const out = verdictFor(cpuShaped(status));
+    assert.equal(out.backendRow, UNKNOWN, `backend row on a ${status} host`);
+    assert.equal(out.torchRow, UNKNOWN, `torch row on a ${status} host`);
+  }
+});
+
+test("a host that really has no GPU still gets the CPU-only verdict, and its real rows", () => {
+  const out = verdictFor(cpuShaped("ready"));
+  assert.equal(out.gpuUnknown, false);
+  assert.equal(out.gpuSection, NO_GPU);
+  assert.equal(out.backendRow, "CPU");
+  assert.equal(out.torchRow, NOT_INSTALLED);
+});
+
+test("a host with a GPU gets none of the three fallbacks", () => {
+  const out = verdictFor({
+    status: "ready",
+    device_backend: "rocm",
+    gpu: { available: true, backend: "rocm", devices: [{ name: "Radeon RX 9060 XT" }] },
+    ml_packages: { torch: "2.11.0+rocm7.13.0" },
+  });
+  assert.equal(out.gpuUnknown, false);
+  assert.equal(out.hasGpu, true);
+  assert.equal(out.gpuSection, "<device rows>");
+  assert.equal(out.backendRow, "ROCM");
+  assert.equal(out.torchRow, "2.11.0+rocm7.13.0");
+  for (const forbidden of [NO_GPU, DETECTING, UNREADABLE, UNKNOWN]) {
+    assert.notEqual(out.gpuSection, forbidden);
+    assert.notEqual(out.backendRow, forbidden);
+  }
+});
+
+// The two rules useSystemInfo applies to its own state, lifted out of the hook.
+
+test("a failed poll preserves the whole reading on screen, not just its status", () => {
+  // settledFailureStatus("ready") === "ready" does not prove this. The branch acting on it
+  // rebuilds from DEFAULT_SYSTEM, and only the identity short-circuit keeps the reading.
+  const branch = lift(
+    hookSrc,
+    /\(previous\) => \{\n\s*const status = settledFailureStatus\([\s\S]*?\n\s*\}/,
+    "the setSystemInfo failure callback",
+    "use-system.ts",
+  );
+  const DEFAULT_SYSTEM = { status: "pending", device_backend: "cpu" };
+  const settledFailureStatus = (previous: string) =>
+    previous === "ready" ? "ready" : "unavailable";
+  const onFailure = new Function(
+    "DEFAULT_SYSTEM",
+    "settledFailureStatus",
+    `return ${branch};`,
+  )(DEFAULT_SYSTEM, settledFailureStatus) as (previous: unknown) => { status: string };
+
+  const reading = { status: "ready", device_backend: "rocm" };
+  assert.equal(onFailure(reading), reading, "the same object, so React does not re-render");
+
+  const settled = onFailure({ ...DEFAULT_SYSTEM });
+  assert.equal(settled.status, "unavailable", "a placeholder does move, once, off pending");
+  assert.equal(onFailure(settled), settled, "and does not churn on every later failure");
+});
+
+test("a success published by another consumer clears a placeholder but not a reading", () => {
+  // Nothing retries a settled placeholder while polling is off, so without this the tab
+  // keeps saying the hardware is unreadable after the shared cache has recovered.
+  const rule = lift(
+    hookSrc,
+    /\(previous\) => \(previous\.status === "ready" \? previous : info\)/,
+    "the subscribeSystemInfo callback",
+    "use-system.ts",
+  );
+  const info = { status: "ready", device_backend: "rocm" };
+  const onPublish = new Function("info", `return ${rule};`)(info) as (
+    previous: unknown,
+  ) => unknown;
+
+  for (const status of ["pending", "unavailable"]) {
+    assert.equal(onPublish({ status }), info, `a ${status} placeholder takes the snapshot`);
+  }
+  const mine = { status: "ready", device_backend: "cuda" };
+  assert.equal(onPublish(mine), mine, "a reading already on screen is left to its own poll");
+});

--- a/studio/frontend/tests/system-status-verdict.test.ts
+++ b/studio/frontend/tests/system-status-verdict.test.ts
@@ -3,17 +3,12 @@
 
 // The System tab's host verdict, run rather than pattern-matched.
 //
-// settledFailureStatus is three lines and has its own cases in system-discovery.test.ts.
-// Those cannot fail for the bug this guards: the verdict lives in resources-tab.tsx as
-// `hostUnread && !hasGpu`, and the preservation rule lives in the callbacks useSystemInfo
-// hands to setSystemInfo. Delete either and the helper's cases still pass. So lift both out
-// of their sources and evaluate them, the way chat-only-route-guard.test.ts lifts the route
-// guard out of __root.tsx (resources-tab is .tsx and pulls in the whole app, so it cannot be
-// imported here).
-//
-// The case this exists for: DEFAULT_SYSTEM describes a cpu backend with no GPU and zero
-// everything. Rendered before /api/system answers, it told an AMD/ROCm user "No visible GPU
-// detected. CPU-only resources are shown above."
+// The verdict lives in resources-tab.tsx as `hostUnread && !hasGpu` and the preservation rule
+// in the callbacks useSystemInfo hands to setSystemInfo; delete either and the existing
+// settledFailureStatus cases still pass. So lift both and evaluate them, the way
+// chat-only-route-guard.test.ts lifts the route guard out of __root.tsx (a .tsx pulls in the
+// whole app and cannot be imported here). DEFAULT_SYSTEM is shaped like a CPU-only host, so
+// rendering it told an AMD/ROCm user "No visible GPU detected".
 
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
@@ -34,8 +29,7 @@ function lift(src: string, pattern: RegExp, what: string, where: string): string
   return found[0];
 }
 
-// The one annotation in the lifted block is hostReading's parameter; dropping it by hand
-// keeps this a plain-node test. A changed shape fails loudly, when lift finds nothing.
+// hostReading's parameter is the block's only annotation; dropping it keeps this plain node.
 const verdict = [
   lift(tabSrc, /const hasGpu =\n?[\s\S]*?;/, "hasGpu", "resources-tab.tsx"),
   lift(tabSrc, /const hostUnread = [\s\S]*?;/, "hostUnread", "resources-tab.tsx"),
@@ -48,7 +42,7 @@ const verdict = [
   ),
 ].join("\n");
 
-// The GPU-devices section's fallback, which is what a host with no device rows reads.
+// The GPU-devices section's fallback: what a host with no device rows reads.
 const gpuSection = lift(
   tabSrc,
   /gpuUnknown \? gpuUnknownLabel : t\("settings\.resources\.gpu\.noGpu"\)/,
@@ -131,8 +125,7 @@ test("before the host has been read, the tab says it is checking, not that there
 });
 
 test("after the read settles empty, the tab says so, and still does not claim there is no GPU", () => {
-  // Distinct from "checking": with live updates off nothing retries, so a check that never
-  // ends would outlive the check.
+  // Distinct from "checking": with live updates off nothing retries.
   const out = verdictFor(cpuShaped("unavailable"));
   assert.equal(out.gpuUnknown, true);
   assert.equal(out.gpuSection, UNREADABLE);
@@ -141,8 +134,7 @@ test("after the read settles empty, the tab says so, and still does not claim th
 });
 
 test("the Environment rows wait for the same read", () => {
-  // The placeholder's backend is "cpu" and its package list is empty. Rendered, that is the
-  // same false verdict the GPU sections above refuse, two sections further down.
+  // Its backend is "cpu" and its package list empty: the verdict the GPU sections refuse.
   for (const status of ["pending", "unavailable"]) {
     const out = verdictFor(cpuShaped(status));
     assert.equal(out.backendRow, UNKNOWN, `backend row on a ${status} host`);
@@ -151,9 +143,8 @@ test("the Environment rows wait for the same read", () => {
 });
 
 test("no tile fabricates a usage percentage for a host it has not read", () => {
-  // MetricTile takes percent null for "unknown" and draws a dash and an empty bar. An
-  // unread host is not an idle one with no capacity, so every tile must reach for that
-  // rather than pass 0. Asserted on the source: percent is a prop, not a derivation.
+  // percent null draws a dash and an empty bar. An unread host is not an idle one, so no
+  // tile may pass 0. Asserted on the source, since percent is a prop, not a derivation.
   const tiles = tabSrc.match(/<MetricTile\b[\s\S]*?\/>/g) ?? [];
   assert.equal(tiles.length, 4, "the Live monitor's four tiles");
   for (const tile of tiles) {
@@ -168,8 +159,7 @@ test("no tile fabricates a usage percentage for a host it has not read", () => {
 });
 
 test("the two non-answers are worded for the whole host, not just its GPUs", () => {
-  // "Checking for GPUs..." beside a RAM reading would be the wrong sentence, so the
-  // non-GPU tiles take common.loading; the failure wording already speaks of the host.
+  // "Checking for GPUs..." is wrong beside a RAM reading, so those tiles take common.loading.
   const detail = lift(tabSrc, /const hostUnreadDetail =\n?[\s\S]*?;/, "hostUnreadDetail", "resources-tab.tsx");
   const forStatus = (status: string) =>
     new Function("systemInfo", "t", `${detail}\nreturn hostUnreadDetail;`)({ status }, t);
@@ -204,11 +194,11 @@ test("a host with a GPU gets none of the three fallbacks", () => {
   }
 });
 
-// The two rules useSystemInfo applies to its own state, lifted out of the hook.
+// The two rules useSystemInfo applies to its own state.
 
 test("a failed poll preserves the whole reading on screen, not just its status", () => {
-  // settledFailureStatus("ready") === "ready" does not prove this. The branch acting on it
-  // rebuilds from DEFAULT_SYSTEM, and only the identity short-circuit keeps the reading.
+  // settledFailureStatus("ready") does not prove this: the branch acting on it rebuilds from
+  // DEFAULT_SYSTEM, and only the identity short-circuit keeps the reading.
   const branch = lift(
     hookSrc,
     /\(previous\) => \{\n\s*const status = settledFailureStatus\([\s\S]*?\n\s*\}/,
@@ -233,8 +223,8 @@ test("a failed poll preserves the whole reading on screen, not just its status",
 });
 
 test("a success published by another consumer clears a placeholder but not a reading", () => {
-  // Nothing retries a settled placeholder while polling is off, so without this the tab
-  // keeps saying the hardware is unreadable after the shared cache has recovered.
+  // Nothing retries a settled placeholder while polling is off, so without this the tab keeps
+  // saying the hardware is unreadable after the shared cache has recovered.
   const rule = lift(
     hookSrc,
     /\(previous\) => \(previous\.status === "ready" \? previous : info\)/,


### PR DESCRIPTION
`useSystemInfo`'s placeholder says cpu backend, no GPU, zero everything, and the System tab rendered it as "No visible GPU detected. CPU-only resources are shown above." Opening Settings before `/api/system` answered told an AMD user their card was unused.

A client-side status gates that verdict behind having read something, and distinguishes the two non-answers: still checking, or asked and got nothing back. The second matters because with polling off nothing retries, so "still checking" would outlive the check. Data already on screen is never blanked by a failed poll; only a placeholder moves, off "pending".

The two new strings are in every locale overlay, so the strict parity gate passes.

## Tests

Two cases added to `system-discovery.test.ts`: a settled failure leaves the placeholder rather than a live check, and a settled failure does not blank a reading already on screen. Locale parity clean.

Split out of #8863 at review request. Pure frontend, independent of the other three.
