### PR TITLE
Add the UEmbed unified training loss and its fine-tuning scripts

### DIFF
--- a/scripts/uembed_datasets.py
+++ b/scripts/uembed_datasets.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team.
+"""Streamed SCIENCE-TECH training pairs for the UEmbed (Qwen3.5) fine-tune example.
+
+Opt-in loader for ``scripts/uembed_finetune.py``. Nothing here touches the network at
+import time: every Hub call lives inside ``load_uembed_science_tech_dataset()``, which the
+fine-tune script only calls when ``UNSLOTH_UEMBED_TRAIN_DATASET`` is set. Importing this
+module - or importing the fine-tune script - therefore downloads nothing.
+
+What it builds
+--------------
+Two ``{anchor, positive}`` subsets, a few hundred pairs each, streamed (``streaming =
+True``), so no full dataset is ever materialised on disk:
+
+- ``"multimodal"``: ``vidore/arxivqa_test_subsampled`` - a natural-language question about
+  an arXiv page as the anchor, the rendered page image as the positive. This is the
+  screenshot-retrieval half UEmbed is built for.
+- ``"text"``: SciFact (``allenai/scifact``) - a scientific claim as the anchor, the cited
+  paper's title + abstract as the positive. The claims config carries ``cited_doc_ids``
+  and the corpus config carries the abstracts, so the pair is a two-stream join.
+
+Why a dict of two datasets and not one concatenated ``Dataset``
+---------------------------------------------------------------
+A single ``Dataset`` has a single Arrow schema, so merging the two subsets would force the
+``positive`` column to be a struct with a null ``image`` on every text row, and
+sentence-transformers reads such a dict as an image input. ``SentenceTransformerTrainer``
+accepts ``dict[str, Dataset]`` directly and never mixes two datasets inside one batch, so
+each batch stays single-modality and the in-batch negatives of
+``MultipleNegativesRankingLoss`` / ``UEmbedUnifiedLoss`` stay meaningful. Same
+``{anchor, positive}`` column shape either way, so the loss, trainer and collator are
+unchanged.
+
+Scope: this is a short domain-adaptation slice, deliberately a few hundred pairs. The real
+convergence run - loss slope, sparsity, recall@k over a few hundred steps - is Todo 11 on
+the Brev GPU box, not this file.
+
+Needs ``datasets`` (imported lazily, inside the loaders).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+# Environment variable that opts the fine-tune script into this loader.
+TRAIN_DATASET_ENV_VAR = "UNSLOTH_UEMBED_TRAIN_DATASET"
+
+# -- multimodal: text question -> arXiv page image ---------------------------------------
+ARXIVQA_REPO = "vidore/arxivqa_test_subsampled"
+ARXIVQA_SPLIT = "test"
+ARXIVQA_QUERY_COLUMN = "query"
+ARXIVQA_IMAGE_COLUMN = "image"
+
+# -- text: scientific claim -> cited abstract ---------------------------------------------
+SCIFACT_REPO = "allenai/scifact"
+SCIFACT_CLAIMS_CONFIG = "claims"
+SCIFACT_CORPUS_CONFIG = "corpus"
+SCIFACT_CLAIMS_SPLIT = "train"
+SCIFACT_CORPUS_SPLIT = "train"
+
+# Subset names of the returned mapping; they become the trainer's dataset names.
+MULTIMODAL_SUBSET = "multimodal"
+TEXT_SUBSET = "text"
+
+DEFAULT_NUM_MULTIMODAL_PAIRS = 200
+DEFAULT_NUM_TEXT_PAIRS = 200
+
+
+def _column(row: dict[str, Any], column: str, repo: str) -> Any:
+    """Read `column` off a streamed row, saying which repo drifted when it is missing."""
+    if column not in row:
+        raise KeyError(
+            f"Unsloth: `{repo}` has no `{column}` column; it exposes {sorted(row)}. The "
+            f"dataset's schema changed - update scripts/uembed_datasets.py."
+        )
+    return row[column]
+
+
+def _joined_text(value: Any) -> str:
+    """SciFact abstracts arrive as a list of sentences; titles arrive as a plain string."""
+    if isinstance(value, str):
+        return value.strip()
+    return " ".join(str(sentence).strip() for sentence in value).strip()
+
+
+def load_arxivqa_pairs(num_pairs: int = DEFAULT_NUM_MULTIMODAL_PAIRS, streaming: bool = True):
+    """`{anchor: question (str), positive: arXiv page (PIL image)}` from ViDoRe ArxivQA.
+
+    The positive column is declared as a ``datasets.Image`` feature, which is what lets
+    ``Dataset.from_list`` hold the streamed PIL pages, and what sentence-transformers reads
+    as the image modality.
+    """
+    from datasets import Dataset, Features, Image, Value, load_dataset
+
+    stream = load_dataset(ARXIVQA_REPO, split = ARXIVQA_SPLIT, streaming = streaming)
+    rows: list[dict[str, Any]] = []
+    for row in stream:
+        query = _column(row, ARXIVQA_QUERY_COLUMN, ARXIVQA_REPO)
+        image = _column(row, ARXIVQA_IMAGE_COLUMN, ARXIVQA_REPO)
+        # A handful of ViDoRe rows carry no question; they cannot form a pair.
+        if not query or image is None:
+            continue
+        rows.append({"anchor": str(query), "positive": image})
+        if len(rows) >= num_pairs:
+            break
+
+    if not rows:
+        raise RuntimeError(f"Unsloth: `{ARXIVQA_REPO}` yielded no usable (question, page) pair.")
+    features = Features({"anchor": Value("string"), "positive": Image()})
+    return Dataset.from_list(rows, features = features)
+
+
+def load_scifact_pairs(num_pairs: int = DEFAULT_NUM_TEXT_PAIRS, streaming: bool = True):
+    """`{anchor: claim, positive: title + abstract}` joined across SciFact's two configs.
+
+    Pass 1 streams the claims and collects the ``cited_doc_ids`` needed; pass 2 streams the
+    corpus and stops as soon as every wanted document has been seen. Both passes are
+    bounded by `num_pairs`, so neither config is ever fully downloaded.
+    """
+    from datasets import Dataset, load_dataset
+
+    claims = load_dataset(
+        SCIFACT_REPO, SCIFACT_CLAIMS_CONFIG, split = SCIFACT_CLAIMS_SPLIT, streaming = streaming
+    )
+    wanted: dict[str, list[str]] = {}
+    collected = 0
+    for row in claims:
+        claim = _column(row, "claim", SCIFACT_REPO)
+        cited = _column(row, "cited_doc_ids", SCIFACT_REPO)
+        # Claims without a cited document have no positive to pair with.
+        if not claim or not cited:
+            continue
+        wanted.setdefault(str(cited[0]), []).append(str(claim))
+        collected += 1
+        if collected >= num_pairs:
+            break
+
+    if not wanted:
+        raise RuntimeError(
+            f"Unsloth: `{SCIFACT_REPO}` ({SCIFACT_CLAIMS_CONFIG}) yielded no cited claim."
+        )
+
+    corpus = load_dataset(
+        SCIFACT_REPO, SCIFACT_CORPUS_CONFIG, split = SCIFACT_CORPUS_SPLIT, streaming = streaming
+    )
+    rows: list[dict[str, str]] = []
+    for document in corpus:
+        doc_id = str(_column(document, "doc_id", SCIFACT_REPO))
+        claims_for_document = wanted.pop(doc_id, None)
+        if not claims_for_document:
+            continue
+        title = _joined_text(_column(document, "title", SCIFACT_REPO))
+        abstract = _joined_text(_column(document, "abstract", SCIFACT_REPO))
+        positive = f"{title} {abstract}".strip()
+        rows.extend({"anchor": claim, "positive": positive} for claim in claims_for_document)
+        if not wanted:
+            break
+
+    if not rows:
+        raise RuntimeError(
+            f"Unsloth: no `{SCIFACT_REPO}` claim could be joined to its cited abstract."
+        )
+    return Dataset.from_list(rows[:num_pairs])
+
+
+def load_uembed_science_tech_dataset(
+    num_multimodal_pairs: int = DEFAULT_NUM_MULTIMODAL_PAIRS,
+    num_text_pairs: int = DEFAULT_NUM_TEXT_PAIRS,
+    streaming: bool = True,
+) -> dict[str, Any]:
+    """The two science-tech subsets, ready for ``SentenceTransformerTrainer``.
+
+    Args:
+        num_multimodal_pairs: ArxivQA (question -> page image) pairs; 0 skips the subset.
+        num_text_pairs: SciFact (claim -> abstract) pairs; 0 skips the subset.
+        streaming: keep the Hub streams lazy (default). ``False`` downloads the full
+            datasets and is only worth it when the same slice is reused many times.
+
+    Returns:
+        ``{"multimodal": Dataset, "text": Dataset}``, each with the ``anchor`` / ``positive``
+        columns the UEmbed losses expect. Pass it straight to the trainer's
+        ``train_dataset``. Calling this function is what triggers the download.
+    """
+    subsets: dict[str, Any] = {}
+    if num_multimodal_pairs > 0:
+        subsets[MULTIMODAL_SUBSET] = load_arxivqa_pairs(num_multimodal_pairs, streaming)
+    if num_text_pairs > 0:
+        subsets[TEXT_SUBSET] = load_scifact_pairs(num_text_pairs, streaming)
+    if not subsets:
+        raise ValueError(
+            "Unsloth: `num_multimodal_pairs` and `num_text_pairs` are both 0, so there is "
+            "nothing to train on."
+        )
+    return subsets

--- a/scripts/uembed_finetune.py
+++ b/scripts/uembed_finetune.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team.
+"""Fine-tune the UEmbed (Qwen3.5) multimodal DENSE + SPARSE embedding model with Unsloth.
+
+Target checkpoint: ``Alibaba-NLP/UEmbed-2B`` (backbone ``model_type = qwen3_5``). The script
+walks both halves of UEmbed support in order: a dense pass trained with
+``MultipleNegativesRankingLoss``, then a short unified pass trained with
+``UEmbedUnifiedLoss`` (dense InfoNCE + sparse InfoNCE + FLOPS), then an encode of the same
+query as ``dense``, ``sparse`` and ``both``.
+
+How the dense path differs from standard last-token pooling
+------------------------------------------------------------
+UEmbed does three extra things, and ``FastSentenceTransformer.from_pretrained`` wires all
+three automatically when the checkpoint ships a ``sparse_info.json`` with
+``num_eos_tokens > 0``:
+
+1. Every input is wrapped in an instruction conversation - a system message carrying
+   "Represent the user's input." plus a user message carrying ``video, image, text`` -
+   and rendered through the processor's chat template before tokenization.
+2. ``num_eos_tokens`` (16 for UEmbed) ``<|endoftext|>`` tokens are appended after the
+   content by a ``tokenizers`` post-processor, and padding moves to the right.
+3. The dense vector is pooled at ``last_index - num_eos_tokens`` instead of
+   ``last_index``, i.e. the position that precedes that EOS block. That is what
+   ``pooling_mode = "offset_lasttoken"`` selects; with ``num_eos_tokens = 0`` it is
+   byte-for-byte plain ``lasttoken`` pooling, so nothing else regresses.
+
+Pooling at the wrong offset silently returns an EOS filler position instead of the
+sentence representation, which is why the gated parity test
+(``tests/python/test_uembed_parity.py``) checks cosine >= 0.99 against the upstream
+reference rather than merely checking that ``encode()`` returns a vector.
+
+The sparse (SPLADE) path
+------------------------
+A UEmbed checkpoint ships ``sparse_weights.pt``, and ``from_pretrained`` appends the
+``SpladeHead`` to the model's module chain. That head reads the hidden states the dense
+pooling just consumed, so ONE forward pass produces ``sentence_embedding`` and
+``sparse_embedding`` side by side in the features dict - the sparse half is never a second
+forward.
+
+Two consequences the script demonstrates:
+
+- ``UEmbedUnifiedLoss`` reads both keys out of that one dict, so it can optimise the dense
+  InfoNCE, the sparse InfoNCE (temperature ``tau_s = 32.0``, not the dense scale, because
+  inner products over vocabulary space have a far wider range than cosines) and the FLOPS
+  sparsity regulariser together. ``MultipleNegativesRankingLoss`` ignores the sparse
+  vector entirely, which is why the dense-only pass leaves the SPLADE head untrained.
+- ``model.encode(..., output_mode = "sparse" | "both")`` returns the sparse vector, or
+  both vectors, from that same single forward. ``output_mode = "dense"`` (the default) is
+  a plain pass-through to sentence-transformers, so nothing existing changes shape.
+
+Backbone constraints (full list in ``unsloth/models/UEMBED_NOTES.md``)
+---------------------------------------------------------------------
+- bf16 only: ``qwen3_5`` is fp16-blocklisted, so fp16-only GPUs (e.g. T4) cannot run this.
+- ``transformers >= 5.2`` (the UEmbed model card asks for ``>= 5.4``).
+- ``trust_remote_code = True`` is required to load the checkpoint.
+- ``config.json`` has no ``auto_map``, so loading routes through ``AutoModel`` to the base
+  ``Qwen3_5Model`` (returns ``last_hidden_state``, which the pooling layer needs).
+- Packing / padding-free training is disabled for this backbone (hybrid linear-attention
+  GDN layers carry recurrent state across sequence boundaries).
+- Save scope: LoRA and merged 16-bit only. GGUF / llama.cpp export is out of scope.
+
+Also needs: a CUDA GPU with bf16 support, ``sentence-transformers >= 5.4``.
+
+Run:
+    python scripts/uembed_finetune.py
+"""
+
+from __future__ import annotations
+
+# unsloth first: it patches transformers on import.
+from unsloth import FastSentenceTransformer
+from unsloth.models.uembed_loss import UEmbedUnifiedLoss
+
+import os
+
+import torch
+from datasets import Dataset
+from sentence_transformers import (
+    SentenceTransformerTrainer,
+    SentenceTransformerTrainingArguments,
+)
+from sentence_transformers.losses import MultipleNegativesRankingLoss
+from sentence_transformers.training_args import BatchSamplers
+
+
+MODEL_ID = "Alibaba-NLP/UEmbed-2B"
+
+# Opt-in switch for the streamed science-tech slice in scripts/uembed_datasets.py. Unset
+# (the default) keeps this script a self-contained smoke that downloads no dataset.
+TRAIN_DATASET_ENV_VAR = "UNSLOTH_UEMBED_TRAIN_DATASET"
+
+# One multimodal query, reused by every encode below.
+EXAMPLE_QUERY = {
+    "image": "https://images.unsplash.com/photo-1514888286974-6c03e2ca1dba",
+    "text": "kitten close-up",
+}
+
+
+def build_dataset() -> Dataset:
+    """A tiny, self-contained (anchor, positive) contrastive dataset.
+
+    Each column value is either a plain string or a ``{"image": ..., "text": ...}`` dict;
+    ``image`` accepts a PIL image, a local path, or a URL. With
+    MultipleNegativesRankingLoss every other row's positive acts as an in-batch negative,
+    so no explicit negatives are needed. Two rows is enough to prove the multimodal path
+    trains end to end - it is a smoke run, not a convergence run.
+
+    -- SCIENCE-TECH DATASET (real convergence run) -------------------------------------
+    The domain-adaptation run swaps this inline pair for a streamed science-tech slice,
+    opt-in behind the ``UNSLOTH_UEMBED_TRAIN_DATASET`` environment variable:
+
+        multimodal: vidore/arxivqa_test_subsampled  ->  {"anchor": {"text": question},
+                                                         "positive": {"image": page_image}}
+        text:       SciFact (e.g. allenai/scifact)  ->  {"anchor": {"text": claim},
+                                                         "positive": {"text": abstract}}
+
+    Both build the same ``{anchor, positive}`` shape this function returns, so the loss,
+    trainer and collator below are unchanged. The loader lives in
+    ``scripts/uembed_datasets.py`` (``load_uembed_science_tech_dataset``) and is called
+    ONLY from ``main()``, only when that variable is set, so importing this script - or
+    that loader - downloads nothing. The few-hundred-step convergence run (loss slope,
+    sparsity, recall@k) is executed by Todo 11 on the Brev GPU box; this file deliberately
+    keeps the tiny inline dataset as its default so ``python scripts/uembed_finetune.py``
+    stays a self-contained smoke.
+    ------------------------------------------------------------------------------------
+    """
+    return Dataset.from_list(
+        [
+            {
+                "anchor": {
+                    "image": "https://images.unsplash.com/photo-1514888286974-6c03e2ca1dba",
+                    "text": "a photo of a cat",
+                },
+                "positive": {"text": "a small domesticated feline resting"},
+            },
+            {
+                "anchor": {
+                    "image": "https://images.unsplash.com/photo-1543466835-00a7907e9de1",
+                    "text": "a photo of a dog",
+                },
+                "positive": {"text": "a domesticated canine looking at the camera"},
+            },
+        ]
+    )
+
+
+def main() -> None:
+    # 1. Load UEmbed. bf16 is not a preference here - qwen3_5 is fp16-blocklisted.
+    #    pooling_mode="offset_lasttoken" selects the UEmbed dense pooling; from_pretrained
+    #    reads num_eos_tokens from the checkpoint's sparse_info.json (16 for UEmbed) and
+    #    also attaches the EOS post-processor and the instruction formatting.
+    model = FastSentenceTransformer.from_pretrained(
+        MODEL_ID,
+        load_in_16bit = True,
+        dtype = torch.bfloat16,
+        pooling_mode = "offset_lasttoken",
+        processor_kwargs = {"min_pixels": 28 * 28, "max_pixels": 600 * 600},
+        trust_remote_code = True,  # required: no auto_map in config.json
+    )
+
+    # 2. Attach LoRA to the language tower only; the vision tower stays frozen (cheap,
+    #    and the standard contrastive-tuning recipe for a VLM embedder).
+    model = FastSentenceTransformer.get_peft_model(
+        model,
+        r = 8,
+        lora_alpha = 16,
+        target_modules = None,
+        finetune_vision_layers = False,
+        finetune_language_layers = True,
+    )
+
+    # 3. Training data. The tiny inline pair is the default. The streamed science-tech
+    #    slice is opt-in and is imported HERE rather than at module import, so no dataset
+    #    is fetched unless UNSLOTH_UEMBED_TRAIN_DATASET is set. Running the file as
+    #    `python scripts/uembed_finetune.py` puts scripts/ on sys.path, which is what makes
+    #    the sibling import resolve.
+    dataset = build_dataset()
+    if os.environ.get(TRAIN_DATASET_ENV_VAR):
+        from uembed_datasets import load_uembed_science_tech_dataset
+        dataset = load_uembed_science_tech_dataset()
+        print("science-tech subsets:", {name: len(rows) for name, rows in dataset.items()})
+
+    # 4. Dense pass: MNRL == InfoNCE with in-batch negatives over the dense vectors only.
+    #    It never reads `sparse_embedding`, so the SPLADE head stays untouched here.
+    loss = MultipleNegativesRankingLoss(model)
+
+    args = SentenceTransformerTrainingArguments(
+        output_dir = "outputs/uembed-dense",
+        num_train_epochs = 1,
+        per_device_train_batch_size = 2,
+        learning_rate = 1e-4,
+        bf16 = True,  # fp16 is blocklisted for qwen3_5
+        batch_sampler = BatchSamplers.NO_DUPLICATES,  # avoid a positive as its own negative
+        logging_steps = 1,
+        report_to = "none",
+    )
+
+    trainer = SentenceTransformerTrainer(
+        model = model,
+        args = args,
+        train_dataset = dataset,
+        loss = loss,
+    )
+    trainer.train()
+
+    # 5. Unified pass: the same batches, the same single forward, but now the loss also
+    #    consumes `sparse_embedding` (dense InfoNCE + lambda * sparse InfoNCE + FLOPS).
+    #    The defaults are the paper's: scale = 20.0 (tau_dense = 0.05), tau_s = 32.0,
+    #    alpha_q = alpha_d = 0.01. Two steps is a smoke, not a convergence run - raising
+    #    lambda_sparse or the alphas is what trades retrieval quality for sparsity.
+    #    This requires a checkpoint that ships `sparse_weights.pt`; without one the loss
+    #    raises and tells you to use MultipleNegativesRankingLoss instead.
+    unified_loss = UEmbedUnifiedLoss(
+        model,
+        lambda_sparse = 1.0,
+        alpha_q = 0.01,
+        alpha_d = 0.01,
+        scale = 20.0,
+        tau_s = 32.0,
+    )
+    unified_args = SentenceTransformerTrainingArguments(
+        output_dir = "outputs/uembed-unified",
+        max_steps = 2,
+        per_device_train_batch_size = 2,
+        learning_rate = 1e-4,
+        bf16 = True,
+        batch_sampler = BatchSamplers.NO_DUPLICATES,
+        logging_steps = 1,
+        report_to = "none",
+    )
+    unified_trainer = SentenceTransformerTrainer(
+        model = model,
+        args = unified_args,
+        train_dataset = dataset,
+        loss = unified_loss,
+    )
+    unified_trainer.train()
+
+    # 6. Encode a multimodal query. The instruction conversation and the trailing EOS block
+    #    are applied inside encode(); pass raw content, not a pre-rendered prompt.
+    query = model.encode(EXAMPLE_QUERY, normalize_embeddings = True)
+    print("dense query embedding shape:", query.shape)
+
+    #    output_mode = "sparse" returns the SPLADE vector from that same forward. It lives
+    #    in vocabulary space and is non-negative, so the number that matters is how many
+    #    terms survived; it is deliberately NOT normalized, which would flatten the term
+    #    weights an inner-product retriever depends on.
+    sparse_query = model.encode(EXAMPLE_QUERY, output_mode = "sparse")
+    print(
+        "sparse query embedding shape:",
+        sparse_query.shape,
+        "non-zero terms:",
+        int((sparse_query > 0).sum()),
+    )
+
+    #    output_mode = "both" hands back both vectors of the ONE forward pass - the usual
+    #    hybrid-retrieval setup, where the sparse vector filters and the dense one reranks.
+    hybrid = model.encode(EXAMPLE_QUERY, output_mode = "both")
+    print(
+        "hybrid dense:",
+        hybrid["sentence_embedding"].shape,
+        "hybrid sparse:",
+        hybrid["sparse_embedding"].shape,
+    )
+
+    # 7. Save merged bf16 weights (LoRA and merged_16bit are the supported save scopes).
+    #    The SPLADE head is written beside them as UEmbed's `sparse_weights.pt` sidecar.
+    model.save_pretrained_merged("outputs/uembed-dense-merged", save_method = "merged_16bit")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/python/test_uembed_compile_policy.py
+++ b/tests/python/test_uembed_compile_policy.py
@@ -1,0 +1,131 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+"""CPU-safe policy tests for FastSentenceTransformer torch.compile handling.
+
+The full Unsloth package cannot import on every CPU runner, so these tests extract and
+execute the production method itself. The assertions are behavioral: fake model/config
+objects expose the same public contracts as Transformers and torch.compile is replaced
+with a call-counting seam.
+"""
+
+from __future__ import annotations
+
+import ast
+import types
+from pathlib import Path
+
+
+_SOURCE_PATH = (
+    Path(__file__).resolve().parents[2] / "unsloth" / "models" / "sentence_transformer.py"
+)
+
+
+class _CompileRecorder:
+    def __init__(self):
+        self.calls = []
+
+    def compile(self, model, *, mode):
+        compiled = types.SimpleNamespace(compiled_from = model, mode = mode)
+        self.calls.append((model, mode, compiled))
+        return compiled
+
+
+def _load_apply_torch_compile(recorder):
+    source = _SOURCE_PATH.read_text(encoding = "utf-8")
+    tree = ast.parse(source, filename = str(_SOURCE_PATH))
+    fast_class = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.ClassDef) and node.name == "FastSentenceTransformer"
+    )
+    method = next(
+        node
+        for node in fast_class.body
+        if isinstance(node, ast.FunctionDef) and node.name == "_apply_torch_compile"
+    )
+    method.decorator_list = []
+    isolated = ast.Module(body = [method], type_ignores = [])
+    ast.fix_missing_locations(isolated)
+    namespace = {"torch": recorder}
+    exec(compile(isolated, str(_SOURCE_PATH), "exec"), namespace)
+    return namespace["_apply_torch_compile"]
+
+
+class _TransformerModule:
+    def __init__(self, auto_model):
+        self.auto_model = auto_model
+
+
+class _SentenceTransformer:
+    def __init__(self, inner):
+        self.module = _TransformerModule(inner)
+
+    def __getitem__(self, index):
+        assert index == 0
+        return self.module
+
+
+def test_qwen35_config_disables_compile_for_sentence_transformer():
+    recorder = _CompileRecorder()
+    apply_compile = _load_apply_torch_compile(recorder)
+    inner = types.SimpleNamespace(config = types.SimpleNamespace(model_type = "qwen3_5"))
+    model = _SentenceTransformer(inner)
+
+    returned = apply_compile(model, mode = "default")
+
+    assert returned is model
+    assert recorder.calls == []
+    assert model[0].auto_model is inner
+    assert "_orig_mod" not in model.__dict__
+
+
+def test_qwen35_class_fallback_disables_compile_when_config_is_absent():
+    recorder = _CompileRecorder()
+    apply_compile = _load_apply_torch_compile(recorder)
+    qwen_class = type("Qwen3_5Model", (), {})
+    inner = qwen_class()
+    model = _SentenceTransformer(inner)
+
+    returned = apply_compile(model)
+
+    assert returned is model
+    assert recorder.calls == []
+    assert model[0].auto_model is inner
+
+
+def test_precompiled_qwen35_model_is_not_compiled_again():
+    recorder = _CompileRecorder()
+    apply_compile = _load_apply_torch_compile(recorder)
+    original = types.SimpleNamespace(config = types.SimpleNamespace(model_type = "qwen3_5"))
+    precompiled = types.SimpleNamespace(_orig_mod = original)
+
+    returned = apply_compile(precompiled, mode = "reduce-overhead")
+
+    assert returned is precompiled
+    assert recorder.calls == []
+
+
+def test_non_qwen_sentence_transformer_compiles_once_and_keeps_wrapper():
+    recorder = _CompileRecorder()
+    apply_compile = _load_apply_torch_compile(recorder)
+    inner = types.SimpleNamespace(config = types.SimpleNamespace(model_type = "bert"))
+    model = _SentenceTransformer(inner)
+
+    returned = apply_compile(model, mode = "default")
+
+    assert returned is model
+    assert len(recorder.calls) == 1
+    assert recorder.calls[0][:2] == (inner, "default")
+    assert model[0].auto_model is recorder.calls[0][2]
+    assert model.__dict__["_orig_mod"] is model
+
+
+def test_non_sentence_transformer_control_preserves_compiled_return_value():
+    recorder = _CompileRecorder()
+    apply_compile = _load_apply_torch_compile(recorder)
+    model = types.SimpleNamespace(config = types.SimpleNamespace(model_type = "qwen3"))
+
+    returned = apply_compile(model, mode = "max-autotune")
+
+    assert len(recorder.calls) == 1
+    assert recorder.calls[0][:2] == (model, "max-autotune")
+    assert returned is recorder.calls[0][2]

--- a/tests/python/test_uembed_inference_hub_errors.py
+++ b/tests/python/test_uembed_inference_hub_errors.py
@@ -1,0 +1,579 @@
+# Copyright 2023-present Daniel Han-Chen & the Unsloth team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+"""Regression tests for serialized UEmbed inference reload and Hub error boundaries.
+
+The package-level ``unsloth`` import requires an accelerator, so these CPU tests execute
+its torch-only UEmbed modules directly. The inference test executes the actual
+``for_inference`` branch extracted from ``FastSentenceTransformer.from_pretrained`` and
+uses a constructor that reconstructs a module chain from a serialized checkpoint file.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+import inspect
+import json
+import sys
+import types
+from collections import OrderedDict
+from pathlib import Path
+
+import huggingface_hub.errors as _native_hub_errors
+import numpy as np
+import pytest
+import torch
+import torch.nn.functional as F
+from torch import nn
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_ST_PATH = _REPO_ROOT / "unsloth" / "models" / "sentence_transformer.py"
+_POOLING_PATH = _REPO_ROOT / "unsloth" / "models" / "uembed_pooling.py"
+_SPLADE_PATH = _REPO_ROOT / "unsloth" / "models" / "uembed_splade.py"
+_WIRING_PATH = _REPO_ROOT / "unsloth" / "models" / "uembed_wiring.py"
+
+
+def _load_source(name: str, path: Path):
+    if name in sys.modules:
+        return sys.modules[name]
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope = "module")
+def pooling():
+    return _load_source("unsloth_uembed_pooling_direct", _POOLING_PATH)
+
+
+@pytest.fixture(scope = "module")
+def splade():
+    return _load_source("unsloth_uembed_splade_direct", _SPLADE_PATH)
+
+
+@pytest.fixture(scope = "module")
+def wiring():
+    return _load_source("unsloth_uembed_wiring_direct", _WIRING_PATH)
+
+
+class _Backend:
+    post_processor = None
+
+
+class _Tokenizer:
+    def __init__(self) -> None:
+        self._tokenizer = _Backend()
+        self.padding_side = "left"
+        self.unk_token_id = 0
+        self.unk_token = "<unk>"
+
+    def convert_tokens_to_ids(self, token):
+        return 1 if token == "<|endoftext|>" else self.unk_token_id
+
+
+class _Processor:
+    def __init__(self) -> None:
+        self.tokenizer = _Tokenizer()
+        self.template_calls = []
+        self.processor_calls = []
+        self.events = []
+
+    def apply_chat_template(self, conversations, **kwargs):
+        self.events.append("format")
+        self.template_calls.append((conversations, kwargs))
+        return [f"rendered-{index}" for index in range(len(conversations))]
+
+    def __call__(self, **kwargs):
+        self.events.append("tokenize")
+        self.processor_calls.append(kwargs)
+        batch = len(kwargs["text"])
+        ids = torch.arange(1, 7).repeat(batch, 1)
+        return {"input_ids": ids, "attention_mask": torch.ones_like(ids)}
+
+
+class _Transformer(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.processor = _Processor()
+        self.max_seq_length = 32
+        self.table = nn.Parameter(torch.arange(64, dtype = torch.float32).reshape(16, 4))
+        self.plain_calls = []
+        self.forward_calls = 0
+
+    def preprocess(self, inputs, **kwargs):
+        self.plain_calls.append(inputs)
+        texts = [inputs] if isinstance(inputs, str) else list(inputs)
+        return self.processor(text = [str(value) for value in texts])
+
+    def forward(self, features, **kwargs):
+        self.forward_calls += 1
+        features["token_embeddings"] = self.table[features["input_ids"]]
+        return features
+
+
+class _Pooling(nn.Module):
+    def forward(self, features, **kwargs):
+        features["sentence_embedding"] = features["token_embeddings"][:, -1]
+        return features
+
+    def get_sentence_embedding_dimension(self):
+        return 4
+
+
+class _Normalize(nn.Module):
+    def forward(self, features, **kwargs):
+        features["sentence_embedding"] = F.normalize(features["sentence_embedding"], dim = -1)
+        return features
+
+
+class _SentenceTransformer(nn.Sequential):
+    def encode(
+        self,
+        sentences,
+        output_value = "sentence_embedding",
+        convert_to_numpy = True,
+        convert_to_tensor = False,
+    ):
+        single = isinstance(sentences, (str, dict))
+        batch = [sentences] if single else list(sentences)
+        features = self[0].preprocess(batch)
+        for module in self:
+            features = module(features)
+        if output_value is None:
+            rows = [
+                {key: value[index] for key, value in features.items() if torch.is_tensor(value)}
+                for index in range(len(batch))
+            ]
+            return rows[0] if single else rows
+        result = features[output_value]
+        if not convert_to_tensor and convert_to_numpy:
+            result = result.detach().numpy()
+        return result[0] if single else result
+
+
+def _write_serialized_chain(path: Path, sparse: bool) -> None:
+    state = {"sparse": sparse}
+    if sparse:
+        generator = torch.Generator().manual_seed(17)
+        state.update(
+            heads = [torch.randn(5, 4, generator = generator), torch.randn(7, 4, generator = generator)],
+            biases = [torch.randn(5, generator = generator), torch.randn(7, generator = generator)],
+            num_eos_tokens = 2,
+        )
+    torch.save(state, path)
+
+
+def _constructor(wiring, splade):
+    def construct(model_name, **kwargs):
+        state = torch.load(model_name, map_location = "cpu", weights_only = True)
+        modules = [_Transformer(), _Pooling(), _Normalize()]
+        if state["sparse"]:
+            head = splade.SpladeHead(state["heads"], state["biases"], state["num_eos_tokens"])
+            modules.append(wiring.UEmbedSparseOutput(head))
+        return _SentenceTransformer(*modules)
+
+    return construct
+
+
+def _fresh_hf_constructor(model_name, **kwargs):
+    # Native sentence-transformers sees no modules.json in the public repository and
+    # therefore builds only its generic Transformer -> Pooling fallback.
+    return _SentenceTransformer(_Transformer(), _Pooling())
+
+
+def _load_inference_assembly(
+    wiring,
+    splade,
+    pooling,
+    read_metadata = None,
+    attach_checkpoint = None,
+):
+    tree = ast.parse(_ST_PATH.read_text(encoding = "utf-8"), filename = str(_ST_PATH))
+    functions = {
+        node.name: node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef)
+        and node.name
+        in {
+            "_ensure_uembed_offset_pooling",
+            "_assemble_uembed_inference_model",
+        }
+    }
+    if "_assemble_uembed_inference_model" not in functions:
+        return None
+
+    isolated = ast.Module(body = list(functions.values()), type_ignores = [])
+    ast.fix_missing_locations(isolated)
+
+    def read_num_eos_tokens(model_name, **kwargs):
+        state = torch.load(model_name, map_location = "cpu", weights_only = True)
+        return state.get("num_eos_tokens", 0)
+
+    def attach_sparse(model, model_name, num_eos_tokens, **kwargs):
+        state = torch.load(model_name, map_location = "cpu", weights_only = True)
+        head = splade.SpladeHead(state["heads"], state["biases"], num_eos_tokens)
+        return wiring.attach_uembed_sparse_output(model, head)
+
+    namespace = {
+        "OrderedDict": OrderedDict,
+        "OffsetLastTokenPooling": pooling.OffsetLastTokenPooling,
+        "attach_uembed_sparse_checkpoint": attach_checkpoint or attach_sparse,
+        "patch_uembed_sparse_encode": wiring.patch_uembed_sparse_encode,
+        "read_num_eos_tokens": read_metadata or read_num_eos_tokens,
+        "restore_uembed_inference_input_format": wiring.restore_uembed_inference_input_format,
+    }
+    exec(compile(isolated, str(_ST_PATH), "exec"), namespace)
+    return namespace["_assemble_uembed_inference_model"]
+
+
+def _inference_branch(
+    wiring,
+    pooling,
+    sentence_transformer,
+    checkpoint,
+    splade = None,
+):
+    """Compile and execute the production ``if for_inference`` body in isolation."""
+    tree = ast.parse(_ST_PATH.read_text(encoding = "utf-8"), filename = str(_ST_PATH))
+    from_pretrained = next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef) and node.name == "from_pretrained"
+    )
+    branch = next(
+        node
+        for node in from_pretrained.body
+        if isinstance(node, ast.If)
+        and isinstance(node.test, ast.Name)
+        and node.test.id == "for_inference"
+    )
+    function = ast.FunctionDef(
+        name = "run",
+        args = ast.arguments(posonlyargs = [], args = [], kwonlyargs = [], kw_defaults = [], defaults = []),
+        body = branch.body,
+        decorator_list = [],
+    )
+    isolated = ast.Module(body = [function], type_ignores = [])
+    ast.fix_missing_locations(isolated)
+    namespace = {
+        "SentenceTransformer": sentence_transformer,
+        "Pooling": _Pooling,
+        "Normalize": _Normalize,
+        "model_name": str(checkpoint),
+        "device_map": "cpu",
+        "dtype": torch.float32,
+        "kwargs": {},
+        "trust_remote_code": False,
+        "token": None,
+        "revision": None,
+        "patch_uembed_sparse_encode": wiring.patch_uembed_sparse_encode,
+        "restore_uembed_inference_input_format": wiring.restore_uembed_inference_input_format,
+        "_assemble_uembed_inference_model": (
+            _load_inference_assembly(wiring, splade, pooling) if splade is not None else None
+        ),
+    }
+    exec(compile(isolated, str(_ST_PATH), "exec"), namespace)
+    return namespace["run"]()
+
+
+def _assert_reference_conversation(call, expected_text):
+    conversations, kwargs = call
+    assert kwargs == {"add_generation_prompt": True, "tokenize": False}
+    assert len(conversations) == 1
+    conversation = conversations[0]
+    assert [message["role"] for message in conversation] == ["system", "user"]
+    assert conversation[0]["content"] == [{"type": "text", "text": "Represent the user's input."}]
+    assert conversation[1]["content"] == [{"type": "text", "text": expected_text}]
+
+
+def test_fresh_serialized_for_inference_restores_uembed_format_for_all_modes(
+    tmp_path, wiring, splade, pooling
+):
+    checkpoint = tmp_path / "serialized-uembed.pt"
+    _write_serialized_chain(checkpoint, sparse = True)
+
+    model = _inference_branch(
+        wiring, pooling, _constructor(wiring, splade), checkpoint, splade = splade
+    )
+    processor = model[0].processor
+
+    dense = model.encode({"text": "dense-input"}, output_mode = "dense")
+    sparse = model.encode({"text": "sparse-input"}, output_mode = "sparse")
+    both = model.encode({"text": "both-input"}, output_mode = "both")
+
+    assert dense.shape == (4,)
+    assert sparse.shape == (12,)
+    assert set(both) == {"sentence_embedding", "sparse_embedding"}
+    assert len(processor.template_calls) == 3
+    for call, expected in zip(
+        processor.template_calls,
+        ["dense-input", "sparse-input", "both-input"],
+        strict = True,
+    ):
+        _assert_reference_conversation(call, expected)
+    assert model[0].plain_calls == []
+
+    patched = model[0].preprocess
+    assert wiring.restore_uembed_inference_input_format(model) is False
+    assert model[0].preprocess is patched
+    assert len(model) == 4
+
+
+def test_fresh_public_uembed_for_inference_assembles_reference_semantics(
+    tmp_path, wiring, splade, pooling
+):
+    checkpoint = tmp_path / "fresh-public-uembed.pt"
+    _write_serialized_chain(checkpoint, sparse = True)
+
+    model = _inference_branch(wiring, pooling, _fresh_hf_constructor, checkpoint, splade = splade)
+
+    assert [type(module).__name__ for module in model] == [
+        "_Transformer",
+        "OffsetLastTokenPooling",
+        "_Normalize",
+        "UEmbedSparseOutput",
+    ]
+    assert model[1].num_eos_tokens == 2
+    assert model[0].processor.tokenizer.padding_side == "right"
+    assert model[0].processor.tokenizer._tokenizer.post_processor is not None
+    assert model[0]._unsloth_uembed_input_format is True
+
+    before = model[0].forward_calls
+    both = model.encode({"text": "fresh-hf"}, output_mode = "both")
+    assert model[0].forward_calls == before + 1
+    assert both["sentence_embedding"].shape == (4,)
+    assert both["sparse_embedding"].shape == (12,)
+    assert model[0].processor.events == ["format", "tokenize"]
+    _assert_reference_conversation(model[0].processor.template_calls[0], "fresh-hf")
+
+
+def test_dense_only_for_inference_keeps_stock_format_and_signature(
+    tmp_path, wiring, splade, pooling
+):
+    checkpoint = tmp_path / "serialized-dense.pt"
+    _write_serialized_chain(checkpoint, sparse = False)
+
+    model = _inference_branch(
+        wiring, pooling, _constructor(wiring, splade), checkpoint, splade = splade
+    )
+    signature = inspect.signature(model.encode)
+
+    dense = model.encode("plain-input")
+
+    assert dense.shape == (4,)
+    assert model[0].plain_calls == [["plain-input"]]
+    assert model[0].processor.template_calls == []
+    assert wiring.restore_uembed_inference_input_format(model) is False
+    assert inspect.signature(model.encode) == signature
+    with pytest.raises(TypeError):
+        model.encode("plain-input", output_mode = "sparse")
+
+
+_NativeEntryNotFoundError = _native_hub_errors.EntryNotFoundError
+_NativeLocalEntryNotFoundError = _native_hub_errors.LocalEntryNotFoundError
+_NativeRemoteEntryNotFoundError = getattr(
+    _native_hub_errors, "RemoteEntryNotFoundError", _NativeEntryNotFoundError
+)
+
+
+def _native_local_entry_not_found():
+    exception = _NativeLocalEntryNotFoundError("offline and not cached")
+    assert isinstance(exception, _NativeEntryNotFoundError)
+    assert not isinstance(exception, _NativeRemoteEntryNotFoundError) or (
+        _NativeRemoteEntryNotFoundError is _NativeEntryNotFoundError
+    )
+    return exception
+
+
+def _native_remote_entry_not_found():
+    if _NativeRemoteEntryNotFoundError is _NativeEntryNotFoundError:
+        exception = _NativeEntryNotFoundError("remote sidecar does not exist")
+    else:
+        import httpx
+        response = httpx.Response(
+            404,
+            request = httpx.Request("GET", "https://huggingface.co/org/model/resolve/main/sidecar"),
+        )
+        exception = _NativeRemoteEntryNotFoundError(
+            "remote sidecar does not exist", response = response
+        )
+    assert isinstance(exception, _NativeEntryNotFoundError)
+    assert not isinstance(exception, _NativeLocalEntryNotFoundError)
+    return exception
+
+
+class _GatedRepoError(Exception):
+    pass
+
+
+class _RepositoryNotFoundError(Exception):
+    pass
+
+
+@pytest.fixture
+def fake_hub(monkeypatch):
+    errors = types.ModuleType("huggingface_hub.errors")
+    errors.EntryNotFoundError = _NativeEntryNotFoundError
+    errors.LocalEntryNotFoundError = _NativeLocalEntryNotFoundError
+    if hasattr(_native_hub_errors, "RemoteEntryNotFoundError"):
+        errors.RemoteEntryNotFoundError = _NativeRemoteEntryNotFoundError
+    errors.GatedRepoError = _GatedRepoError
+    errors.RepositoryNotFoundError = _RepositoryNotFoundError
+    hub = types.ModuleType("huggingface_hub")
+    hub.errors = errors
+    monkeypatch.setitem(sys.modules, "huggingface_hub", hub)
+    monkeypatch.setitem(sys.modules, "huggingface_hub.errors", errors)
+
+    def inject(exception):
+        def download(*args, **kwargs):
+            raise exception
+
+        hub.hf_hub_download = download
+
+    return inject
+
+
+@pytest.mark.parametrize(
+    "exception_type",
+    [TimeoutError, _GatedRepoError, _RepositoryNotFoundError],
+)
+def test_metadata_hub_operational_failures_raise_unsloth(pooling, fake_hub, exception_type):
+    failure = exception_type("metadata unavailable")
+    fake_hub(failure)
+
+    with pytest.raises(RuntimeError, match = r"^Unsloth:") as error:
+        pooling.read_num_eos_tokens("org/model")
+
+    assert error.value.__cause__ is failure
+    assert "sparse_info.json" in str(error.value)
+
+
+def test_metadata_remote_entry_not_found_is_optional_absence(pooling, fake_hub):
+    fake_hub(_native_remote_entry_not_found())
+
+    assert pooling.read_num_eos_tokens("org/dense-model") == 0
+
+
+def test_fresh_inference_assembly_propagates_native_local_metadata_failure(
+    pooling, wiring, splade, fake_hub
+):
+    failure = _native_local_entry_not_found()
+    fake_hub(failure)
+    assemble = _load_inference_assembly(
+        wiring, splade, pooling, read_metadata = pooling.read_num_eos_tokens
+    )
+    model = _fresh_hf_constructor("unused")
+
+    with pytest.raises(RuntimeError, match = r"^Unsloth:.*sparse_info\.json") as error:
+        assemble(model, "org/uembed", _Pooling, _Normalize)
+
+    assert error.value.__cause__ is failure
+    assert [type(module).__name__ for module in model] == ["_Transformer", "_Pooling"]
+
+
+def test_fresh_inference_assembly_propagates_native_local_sidecar_failure(
+    pooling, wiring, splade, fake_hub
+):
+    failure = _native_local_entry_not_found()
+    fake_hub(failure)
+    assemble = _load_inference_assembly(
+        wiring,
+        splade,
+        pooling,
+        read_metadata = lambda *args, **kwargs: 2,
+        attach_checkpoint = wiring.attach_uembed_sparse_checkpoint,
+    )
+    model = _fresh_hf_constructor("unused")
+
+    with pytest.raises(RuntimeError, match = r"^Unsloth:.*sparse_weights\.pt") as error:
+        assemble(model, "org/uembed", _Pooling, _Normalize)
+
+    assert error.value.__cause__ is failure
+
+
+def test_native_local_entry_not_found_is_loud_for_metadata_and_sparse(pooling, wiring, fake_hub):
+    metadata_failure = _native_local_entry_not_found()
+    fake_hub(metadata_failure)
+    with pytest.raises(RuntimeError, match = r"^Unsloth:.*sparse_info\.json") as metadata_error:
+        pooling.read_num_eos_tokens("org/model")
+    assert metadata_error.value.__cause__ is metadata_failure
+
+    sparse_failure = _native_local_entry_not_found()
+    fake_hub(sparse_failure)
+    with pytest.raises(RuntimeError, match = r"^Unsloth:.*sparse_weights\.pt") as sparse_error:
+        wiring._resolve_sparse_weights_dir("org/model")
+    assert sparse_error.value.__cause__ is sparse_failure
+
+
+@pytest.mark.parametrize(
+    "exception_type",
+    [TimeoutError, _GatedRepoError, _RepositoryNotFoundError],
+)
+def test_sparse_weight_hub_operational_failures_raise_unsloth(wiring, fake_hub, exception_type):
+    failure = exception_type("weights unavailable")
+    fake_hub(failure)
+
+    with pytest.raises(RuntimeError, match = r"^Unsloth:") as error:
+        wiring._resolve_sparse_weights_dir("org/model")
+
+    assert error.value.__cause__ is failure
+    assert "sparse_weights.pt" in str(error.value)
+
+
+def test_sparse_weight_remote_entry_not_found_is_optional_for_dense_checkpoint(wiring, fake_hub):
+    fake_hub(_native_remote_entry_not_found())
+
+    assert wiring._resolve_sparse_weights_dir("org/dense-model") is None
+
+
+def test_positive_uembed_metadata_cannot_fall_back_to_dense_only(wiring, fake_hub):
+    fake_hub(_native_remote_entry_not_found())
+
+    with pytest.raises(RuntimeError, match = r"^Unsloth:.*sparse_weights\.pt"):
+        wiring.attach_uembed_sparse_checkpoint(nn.Sequential(), "org/uembed", num_eos_tokens = 2)
+
+
+def test_native_st_subfolder_load_contract_reconstructs_serialized_modules(
+    tmp_path, pooling, wiring, splade
+):
+    pooling_dir = tmp_path / "1_OffsetLastTokenPooling"
+    sparse_dir = tmp_path / "3_UEmbedSparseOutput"
+    expected_pooling = pooling.OffsetLastTokenPooling(4, num_eos_tokens = 2)
+    expected_sparse = wiring.UEmbedSparseOutput(
+        splade.SpladeHead(
+            [torch.ones(3, 4), torch.ones(5, 4)],
+            [torch.zeros(3), torch.zeros(5)],
+            num_eos_tokens = 2,
+        )
+    )
+    expected_pooling.save(str(pooling_dir))
+    expected_sparse.save(str(sparse_dir))
+    # A root config must never be mistaken for either module's subfolder config.
+    (tmp_path / "config.json").write_text(json.dumps({"model_type": "qwen3_5"}))
+
+    loaded_pooling = pooling.OffsetLastTokenPooling.load(str(tmp_path), subfolder = pooling_dir.name)
+    loaded_sparse = wiring.UEmbedSparseOutput.load(str(tmp_path), subfolder = sparse_dir.name)
+
+    assert loaded_pooling.get_config_dict() == expected_pooling.get_config_dict()
+    assert loaded_sparse.get_config_dict() == expected_sparse.get_config_dict()
+    assert torch.equal(
+        loaded_sparse.head.sparse_lm_heads[0], expected_sparse.head.sparse_lm_heads[0]
+    )
+
+
+def test_direct_local_checkpoint_without_optional_files_stays_absent(tmp_path, pooling, wiring):
+    assert pooling.read_num_eos_tokens(str(tmp_path)) == 0
+    assert wiring._resolve_sparse_weights_dir(str(tmp_path)) is None
+
+
+def test_positive_local_metadata_without_sparse_weights_fails_loudly(tmp_path, pooling, wiring):
+    (tmp_path / "sparse_info.json").write_text(json.dumps({"num_eos_tokens": 2}), encoding = "utf-8")
+    count = pooling.read_num_eos_tokens(str(tmp_path))
+
+    with pytest.raises(RuntimeError, match = r"^Unsloth:.*sparse_weights\.pt"):
+        wiring.attach_uembed_sparse_checkpoint(nn.Sequential(), str(tmp_path), num_eos_tokens = count)

--- a/tests/python/test_uembed_input_format.py
+++ b/tests/python/test_uembed_input_format.py
@@ -1,0 +1,504 @@
+# Copyright 2023-present Daniel Han-Chen & the Unsloth team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the opt-in UEmbed (Qwen3.5) instruction / chat-template input formatting.
+
+Upstream `Qwen35Embedder.format_model_input` wraps every input in a two-message
+conversation - a system message carrying the instruction ("Represent the user's input.")
+and a user message carrying the content in the order video, image, text - and renders it
+with `processor.apply_chat_template(..., add_generation_prompt = True, tokenize = False)`
+before the processor is called. Unsloth's #2 encode path does NOT wrap inputs, so dense
+parity needs this path; it must stay opt-in so existing embedders are unchanged.
+
+Everything here is CPU-only and deterministic: the processor is a synthetic stub that
+renders a minimal chat template in-process, so there is no download, no GPU and no
+network.
+
+Layers:
+- Baseline characterization: the un-wrapped ("plain #2") formatting has no instruction,
+  and a module that was never opted in keeps its own preprocess.
+- Behavioural tests: the conversation structure and the rendered prompt are asserted
+  against the reference ordering, and the processor call is asserted on its arguments.
+- Structural wiring test: proves the attachment sits behind the `num_eos_tokens > 0`
+  guard in `from_pretrained`, without importing unsloth (the package import needs an
+  accelerator + unsloth_zoo, which CPU boxes lack).
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_ST_SOURCE_PATH = _REPO_ROOT / "unsloth" / "models" / "sentence_transformer.py"
+_POOLING_SOURCE_PATH = _REPO_ROOT / "unsloth" / "models" / "uembed_pooling.py"
+
+_INSTRUCTION = "Represent the user's input."
+
+
+# --------------------------------------------------------------------------------------
+# helpers
+# --------------------------------------------------------------------------------------
+def _load_uembed_pooling():
+    """Load `unsloth.models.uembed_pooling`, falling back to a direct file load.
+
+    `import unsloth` runs the accelerator / unsloth_zoo gate, which legitimately refuses
+    to import on a CPU-only machine. The module itself only needs torch, so the fallback
+    executes the exact same source file rather than a stub.
+    """
+    try:
+        from unsloth.models import uembed_pooling  # noqa: PLC0415
+        return uembed_pooling
+    except Exception:  # accelerator gate / missing unsloth_zoo / heavy optional deps
+        pass
+
+    name = "unsloth_uembed_pooling_direct"
+    if name in sys.modules:
+        return sys.modules[name]
+    assert _POOLING_SOURCE_PATH.exists(), f"missing module file: {_POOLING_SOURCE_PATH}"
+    spec = importlib.util.spec_from_file_location(name, _POOLING_SOURCE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope = "module")
+def uembed():
+    return _load_uembed_pooling()
+
+
+class _StubImage:
+    """Stands in for a PIL image: identity matters, contents do not."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    def __repr__(self) -> str:
+        return f"_StubImage({self.name!r})"
+
+
+class _StubProcessor:
+    """A minimal chat-template renderer + processor, recording every call it receives.
+
+    `apply_chat_template` renders one line per content chunk so the ORDER of the chunks is
+    observable in the output string; `__call__` records the keyword arguments instead of
+    producing tensors, so nothing here needs a model or an accelerator.
+    """
+
+    def __init__(self) -> None:
+        self.chat_template_calls: list[dict] = []
+        self.processor_calls: list[dict] = []
+
+    def apply_chat_template(
+        self,
+        conversations,
+        add_generation_prompt: bool = False,
+        tokenize: bool = True,
+        **kwargs,
+    ):
+        self.chat_template_calls.append(
+            {
+                "conversations": conversations,
+                "add_generation_prompt": add_generation_prompt,
+                "tokenize": tokenize,
+                "kwargs": kwargs,
+            }
+        )
+        rendered = []
+        for conversation in conversations:
+            lines = []
+            for message in conversation:
+                lines.append(f"<|im_start|>{message['role']}")
+                for chunk in message["content"]:
+                    kind = chunk["type"]
+                    lines.append(chunk["text"] if kind == "text" else f"<|{kind}_pad|>")
+                lines.append("<|im_end|>")
+            if add_generation_prompt:
+                lines.append("<|im_start|>assistant")
+            rendered.append("\n".join(lines))
+        return rendered
+
+    def __call__(self, **kwargs):
+        self.processor_calls.append(kwargs)
+        return {"input_ids": [[0]] * len(kwargs.get("text", []))}
+
+
+class _StubTransformerModule:
+    """Stand-in for sentence-transformers' Transformer module (preprocess + processor)."""
+
+    def __init__(
+        self,
+        processor,
+        max_seq_length: int | None = None,
+    ) -> None:
+        self.processor = processor
+        self.max_seq_length = max_seq_length
+        self.plain_calls: list[list] = []
+
+    def preprocess(self, inputs, **kwargs):
+        self.plain_calls.append(inputs)
+        return {"plain": inputs}
+
+
+def _plain_message(model_input: dict) -> list[dict]:
+    """Independent oracle for the un-wrapped ("plain #2") sentence-transformers format.
+
+    Mirrors `sentence_transformers.base.modality.InputFormatter.to_message`: one user
+    message whose content follows the caller's own key order, and no system message.
+    """
+    return [
+        {
+            "role": "user",
+            "content": [{"type": key, key: value} for key, value in model_input.items()],
+        }
+    ]
+
+
+def _content_types(conversation: list[dict]) -> list[str]:
+    user = [message for message in conversation if message["role"] == "user"]
+    assert len(user) == 1, f"expected exactly one user message, got {conversation}"
+    return [chunk["type"] for chunk in user[0]["content"]]
+
+
+def _st_source_tree() -> ast.Module:
+    return ast.parse(_ST_SOURCE_PATH.read_text(encoding = "utf-8"))
+
+
+def _function_def(tree: ast.Module, name: str) -> ast.FunctionDef:
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == name:
+            return node
+    raise AssertionError(f"{name} not found in {_ST_SOURCE_PATH}")
+
+
+def _calls_to(node: ast.AST, func_name: str) -> list[ast.Call]:
+    calls = []
+    for child in ast.walk(node):
+        if isinstance(child, ast.Call):
+            func = child.func
+            name = func.id if isinstance(func, ast.Name) else getattr(func, "attr", None)
+            if name == func_name:
+                calls.append(child)
+    return calls
+
+
+# --------------------------------------------------------------------------------------
+# baseline characterization -- the un-wrapped formatting these tests must not change
+# --------------------------------------------------------------------------------------
+def test_baseline_plain_format_carries_no_instruction():
+    """The plain #2 conversation is a bare user message: no system role, no instruction."""
+    processor = _StubProcessor()
+    conversation = _plain_message({"text": "hello"})
+
+    (rendered,) = processor.apply_chat_template([conversation], tokenize = False)
+
+    assert "system" not in rendered
+    assert _INSTRUCTION not in rendered
+    assert [message["role"] for message in conversation] == ["user"]
+
+
+def test_baseline_module_without_optin_keeps_its_own_preprocess():
+    """A module nobody opted in stays exactly as sentence-transformers built it."""
+    module = _StubTransformerModule(_StubProcessor())
+    original = module.preprocess
+
+    assert module.preprocess(["hello"]) == {"plain": ["hello"]}
+    # Bound methods are rebuilt per access, so compare by equality (same func + instance).
+    assert module.preprocess == original
+    assert module.processor.chat_template_calls == []
+
+
+# --------------------------------------------------------------------------------------
+# behaviour -- the reference conversation structure
+# --------------------------------------------------------------------------------------
+def test_text_input_is_wrapped_in_the_reference_conversation(uembed):
+    conversation = uembed.build_uembed_conversation({"text": "hello"})
+
+    assert conversation == [
+        {"role": "system", "content": [{"type": "text", "text": _INSTRUCTION}]},
+        {"role": "user", "content": [{"type": "text", "text": "hello"}]},
+    ]
+
+
+def test_bare_string_input_is_treated_as_text(uembed):
+    assert uembed.build_uembed_conversation("hello") == uembed.build_uembed_conversation(
+        {"text": "hello"}
+    )
+
+
+def test_image_and_text_follow_the_reference_order(uembed):
+    """Upstream emits image before text regardless of the caller's dict order."""
+    image = _StubImage("a")
+
+    text_first = uembed.build_uembed_conversation({"text": "hello", "image": image})
+    image_first = uembed.build_uembed_conversation({"image": image, "text": "hello"})
+
+    assert _content_types(text_first) == ["image", "text"]
+    assert text_first == image_first
+    user_content = text_first[1]["content"]
+    assert user_content[0] == {"type": "image", "image": image}
+    assert user_content[1] == {"type": "text", "text": "hello"}
+
+
+def test_video_comes_before_image_and_text(uembed):
+    conversation = uembed.build_uembed_conversation(
+        {"text": "hello", "image": _StubImage("a"), "video": _StubImage("v")}
+    )
+
+    assert _content_types(conversation) == ["video", "image", "text"]
+
+
+def test_instruction_can_be_overridden(uembed):
+    conversation = uembed.build_uembed_conversation(
+        {"text": "hello"}, instruction = "Encode the query."
+    )
+
+    assert conversation[0] == {
+        "role": "system",
+        "content": [{"type": "text", "text": "Encode the query."}],
+    }
+
+
+# --------------------------------------------------------------------------------------
+# behaviour -- malformed / empty input falls back to NULL
+# --------------------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "model_input",
+    [None, {}, "", {"text": ""}, {"text": None}, {"image": None, "text": None}],
+    ids = ["none", "empty-dict", "empty-str", "empty-text", "none-text", "all-none"],
+)
+def test_empty_input_falls_back_to_a_single_null_text_chunk(uembed, model_input):
+    conversation = uembed.build_uembed_conversation(model_input)
+
+    assert conversation[1]["content"] == [{"type": "text", "text": "NULL"}]
+
+
+def test_a_pil_shaped_object_is_treated_as_an_image(uembed):
+    class _PILLike:
+        mode = "RGB"
+        size = (2, 2)
+
+    image = _PILLike()
+
+    conversation = uembed.build_uembed_conversation(image)
+
+    assert conversation[1]["content"] == [{"type": "image", "image": image}]
+
+
+def test_an_unsupported_input_type_is_refused(uembed):
+    with pytest.raises(ValueError, match = "UEmbed input formatting"):
+        uembed.build_uembed_conversation(object())
+
+
+def test_image_only_input_keeps_the_image_and_adds_no_null(uembed):
+    image = _StubImage("a")
+
+    conversation = uembed.build_uembed_conversation({"image": image})
+
+    assert conversation[1]["content"] == [{"type": "image", "image": image}]
+
+
+# --------------------------------------------------------------------------------------
+# behaviour -- rendering through the processor's chat template
+# --------------------------------------------------------------------------------------
+def test_rendered_prompt_contains_the_instruction_then_the_content(uembed):
+    processor = _StubProcessor()
+
+    (rendered,) = uembed.render_uembed_prompts(processor, [{"text": "hello"}])
+
+    assert _INSTRUCTION in rendered
+    assert rendered.index(_INSTRUCTION) < rendered.index("hello")
+    assert "system" in rendered
+
+
+def test_rendered_prompt_orders_image_before_text(uembed):
+    processor = _StubProcessor()
+
+    (rendered,) = uembed.render_uembed_prompts(
+        processor, [{"text": "hello", "image": _StubImage("a")}]
+    )
+
+    assert _INSTRUCTION in rendered
+    assert rendered.index("<|image_pad|>") < rendered.index("hello")
+    assert rendered.index(_INSTRUCTION) < rendered.index("<|image_pad|>")
+
+
+def test_chat_template_is_asked_for_a_generation_prompt_without_tokenizing(uembed):
+    processor = _StubProcessor()
+
+    uembed.render_uembed_prompts(processor, [{"text": "hello"}, {"text": "world"}])
+
+    assert len(processor.chat_template_calls) == 1, "one batched apply_chat_template call"
+    call = processor.chat_template_calls[0]
+    assert call["add_generation_prompt"] is True
+    assert call["tokenize"] is False
+    assert len(call["conversations"]) == 2
+
+
+def test_rendering_is_deterministic(uembed):
+    inputs = [{"text": "hello"}, {"image": _StubImage("a"), "text": "hi"}, {}]
+
+    first = uembed.render_uembed_prompts(_StubProcessor(), inputs)
+    second = uembed.render_uembed_prompts(_StubProcessor(), inputs)
+
+    assert first == second
+
+
+def test_a_string_returning_chat_template_is_normalized_to_a_list(uembed):
+    class _SingleStringProcessor(_StubProcessor):
+        def apply_chat_template(self, conversations, **kwargs):
+            return super().apply_chat_template(conversations, **kwargs)[0]
+
+    rendered = uembed.render_uembed_prompts(_SingleStringProcessor(), [{"text": "hello"}])
+
+    assert isinstance(rendered, list) and len(rendered) == 1
+    assert _INSTRUCTION in rendered[0]
+
+
+# --------------------------------------------------------------------------------------
+# behaviour -- the processor call built from the wrapped inputs
+# --------------------------------------------------------------------------------------
+def test_preprocess_sends_rendered_text_and_images_to_the_processor(uembed):
+    processor = _StubProcessor()
+    image = _StubImage("a")
+
+    uembed.uembed_preprocess_inputs(processor, [{"image": image, "text": "hello"}])
+
+    assert len(processor.processor_calls) == 1
+    call = processor.processor_calls[0]
+    assert len(call["text"]) == 1 and _INSTRUCTION in call["text"][0]
+    assert call["images"] == [image]
+    assert "videos" not in call, "no video input must not send an empty videos list"
+    assert call["padding"] is True
+    assert call["return_tensors"] == "pt"
+
+
+def test_preprocess_omits_images_for_text_only_inputs(uembed):
+    processor = _StubProcessor()
+
+    uembed.uembed_preprocess_inputs(processor, [{"text": "hello"}])
+
+    call = processor.processor_calls[0]
+    assert "images" not in call and "videos" not in call
+
+
+def test_preprocess_forwards_extra_processor_kwargs(uembed):
+    processor = _StubProcessor()
+
+    uembed.uembed_preprocess_inputs(processor, [{"text": "hello"}], truncation = True, max_length = 32)
+
+    call = processor.processor_calls[0]
+    assert call["truncation"] is True and call["max_length"] == 32
+
+
+# --------------------------------------------------------------------------------------
+# behaviour -- attaching the path to a module (opt-in) and leaving it off (default)
+# --------------------------------------------------------------------------------------
+def test_attaching_replaces_preprocess_with_the_instruction_path(uembed):
+    module = _StubTransformerModule(_StubProcessor())
+
+    uembed.attach_uembed_input_format(module)
+    module.preprocess([{"text": "hello"}])
+
+    assert module.plain_calls == [], "the un-wrapped path must not run once opted in"
+    call = module.processor.processor_calls[0]
+    assert _INSTRUCTION in call["text"][0]
+
+
+def test_attaching_threads_the_modules_max_seq_length(uembed):
+    module = _StubTransformerModule(_StubProcessor(), max_seq_length = 24)
+
+    uembed.attach_uembed_input_format(module)
+    module.preprocess([{"text": "hello"}])
+
+    call = module.processor.processor_calls[0]
+    assert call["truncation"] is True and call["max_length"] == 24
+
+
+def test_attaching_is_idempotent(uembed):
+    module = _StubTransformerModule(_StubProcessor())
+
+    assert uembed.attach_uembed_input_format(module) is True
+    patched = module.preprocess
+    assert uembed.attach_uembed_input_format(module) is False
+    assert module.preprocess is patched
+
+
+def test_attaching_keeps_the_original_preprocess_reachable(uembed):
+    module = _StubTransformerModule(_StubProcessor())
+    original = module.preprocess
+
+    uembed.attach_uembed_input_format(module)
+
+    assert module._unsloth_uembed_original_preprocess == original
+    assert original([{"text": "hello"}]) == {"plain": [{"text": "hello"}]}
+
+
+def test_attaching_refuses_a_processor_without_a_chat_template(uembed):
+    class _NoTemplate:
+        def __call__(self, **kwargs):
+            return {}
+
+    module = _StubTransformerModule(_NoTemplate())
+
+    with pytest.raises(ValueError, match = "chat template"):
+        uembed.attach_uembed_input_format(module)
+
+
+def test_a_single_input_is_accepted_as_well_as_a_list(uembed):
+    processor = _StubProcessor()
+
+    uembed.uembed_preprocess_inputs(processor, {"text": "hello"})
+
+    assert len(processor.processor_calls[0]["text"]) == 1
+
+
+# --------------------------------------------------------------------------------------
+# structural wiring -- the path is opt-in inside from_pretrained
+# --------------------------------------------------------------------------------------
+def test_input_formatting_is_attached_only_when_num_eos_tokens_is_positive():
+    from_pretrained = _function_def(_st_source_tree(), "from_pretrained")
+
+    calls = _calls_to(from_pretrained, "attach_uembed_input_format")
+    assert len(calls) == 1, "expected exactly one input-format attachment"
+
+    guarded = [
+        node
+        for node in ast.walk(from_pretrained)
+        if isinstance(node, ast.If)
+        and _calls_to(node, "attach_uembed_input_format")
+        and any(
+            isinstance(compare, ast.Compare)
+            and isinstance(compare.left, ast.Name)
+            and compare.left.id == "num_eos_tokens"
+            and isinstance(compare.ops[0], ast.Gt)
+            and isinstance(compare.comparators[0], ast.Constant)
+            and compare.comparators[0].value == 0
+            for compare in ast.walk(node.test)
+        )
+    ]
+    assert len(guarded) == 1, "attachment must sit behind `num_eos_tokens > 0`"
+
+
+def test_eos_post_processor_wiring_is_still_in_place():
+    """T2's attachment must survive: the EOS block is what the offset pooling counts back from."""
+    from_pretrained = _function_def(_st_source_tree(), "from_pretrained")
+
+    assert len(_calls_to(from_pretrained, "build_eos_post_processor")) == 1
+    assert _calls_to(from_pretrained, "read_num_eos_tokens")

--- a/tests/python/test_uembed_loss.py
+++ b/tests/python/test_uembed_loss.py
@@ -1,0 +1,600 @@
+# Copyright 2023-present Daniel Han-Chen & the Unsloth team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for `UEmbedUnifiedLoss`, the UEmbed (Qwen3.5) dense + sparse + FLOPS loss.
+
+Paper arXiv:2608.02583 Eq. 5:
+
+    L = L_InfoNCE_dense + lambda * L_InfoNCE_sparse + alpha_q * L_FLOPS_q + alpha_d * L_FLOPS_d
+
+- dense InfoNCE  : cosine similarity matrix * `scale` (== MultipleNegativesRankingLoss),
+                   labels `arange(B)`, cross entropy.
+- sparse InfoNCE : inner-product similarity matrix / `tau_s`, same labels / cross entropy.
+- FLOPS          : `sum_t (mean_i W[i, t])^2`, computed separately over the query batch
+                   and the document batch.
+
+Everything here is CPU-only and deterministic: every tensor is a hand-written literal, so
+there is no seed, no clock and no download anywhere in this file. Value assertions run
+against INDEPENDENT python-loop oracles (`math.exp` / `math.log`, plain loops) built from
+the formulas above -- never against a copy of the module's own tensor expression -- so a
+mistake mirrored into both sides cannot pass. The composition test recomputes the total
+from those oracles, which is what makes it fail when any weighted term is dropped.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import math
+import sys
+from pathlib import Path
+
+import pytest
+import torch
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_LOSS_SOURCE_PATH = _REPO_ROOT / "unsloth" / "models" / "uembed_loss.py"
+
+# float64 everywhere: the composition assertion compares torch arithmetic against python
+# arithmetic, and both are IEEE doubles, so the comparison stays meaningful at 1e-12.
+_DTYPE = torch.float64
+
+
+# --------------------------------------------------------------------------------------
+# helpers
+# --------------------------------------------------------------------------------------
+def _load_uembed_loss():
+    """Load `unsloth.models.uembed_loss`, falling back to a direct file load.
+
+    `import unsloth` runs the accelerator / unsloth_zoo gate, which legitimately refuses to
+    import on a CPU-only machine. The loss module depends on torch only, so the fallback
+    executes the exact same source file -- it loads it, it does not stub it out.
+    """
+    try:
+        from unsloth.models import uembed_loss  # noqa: PLC0415
+        return uembed_loss
+    except Exception:  # accelerator gate / missing unsloth_zoo / heavy optional deps
+        pass
+
+    name = "unsloth_uembed_loss_direct"
+    if name in sys.modules:
+        return sys.modules[name]
+    assert _LOSS_SOURCE_PATH.exists(), f"missing module file: {_LOSS_SOURCE_PATH}"
+    spec = importlib.util.spec_from_file_location(name, _LOSS_SOURCE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope = "module")
+def uembed_loss():
+    return _load_uembed_loss()
+
+
+def _tensor(rows):
+    return torch.tensor(rows, dtype = _DTYPE)
+
+
+def _features(dense_anchor, dense_positive, sparse_anchor, sparse_positive):
+    """The T8 contract: one dict per column, each carrying dense AND sparse."""
+    return [
+        {"sentence_embedding": _tensor(dense_anchor), "sparse_embedding": _tensor(sparse_anchor)},
+        {
+            "sentence_embedding": _tensor(dense_positive),
+            "sparse_embedding": _tensor(sparse_positive),
+        },
+    ]
+
+
+# --- independent oracles (plain python, no torch ops) ----------------------------------
+def _flops_oracle(rows):
+    """`sum_t (mean_i W[i, t])^2` -- written as loops, not as a tensor expression."""
+    batch_size = len(rows)
+    vocab_size = len(rows[0])
+    total = 0.0
+    for term in range(vocab_size):
+        column_mean = sum(rows[row][term] for row in range(batch_size)) / batch_size
+        total += column_mean * column_mean
+    return total
+
+
+def _cross_entropy_oracle(logits):
+    """Mean `-log softmax(logits[i])[i]`, i.e. in-batch InfoNCE with labels `arange(B)`."""
+    per_row = []
+    for index, row in enumerate(logits):
+        largest = max(row)
+        denominator = sum(math.exp(value - largest) for value in row)
+        per_row.append(-(row[index] - largest - math.log(denominator)))
+    return sum(per_row) / len(per_row)
+
+
+def _dot(left, right):
+    return sum(a * b for a, b in zip(left, right))
+
+
+def _cosine_logits_oracle(anchors, candidates, scale):
+    return [
+        [
+            scale
+            * _dot(anchor, candidate)
+            / (math.sqrt(_dot(anchor, anchor)) * math.sqrt(_dot(candidate, candidate)))
+            for candidate in candidates
+        ]
+        for anchor in anchors
+    ]
+
+
+def _inner_logits_oracle(anchors, candidates, tau_s):
+    return [[_dot(anchor, candidate) / tau_s for candidate in candidates] for anchor in anchors]
+
+
+# --- fixed tiny batch shared by several tests ------------------------------------------
+_DENSE_ANCHOR = [[1.0, 0.0, 0.5], [0.0, 2.0, 1.0]]
+_DENSE_POSITIVE = [[0.5, 0.5, 0.0], [0.25, 1.0, 2.0]]
+_SPARSE_ANCHOR = [[1.5, 0.0, 0.0, 2.0], [0.0, 3.0, 0.5, 0.0]]
+_SPARSE_POSITIVE = [[2.0, 0.25, 0.0, 1.0], [0.0, 1.5, 2.5, 0.0]]
+
+
+# --------------------------------------------------------------------------------------
+# 1. FLOPS formula, pinned exactly
+# --------------------------------------------------------------------------------------
+def test_flops_matches_hand_computed_column_means(uembed_loss):
+    # column means are (2.0, 1.0, 2.0) -> 4 + 1 + 4 = 9
+    rows = [[1.0, 2.0, 3.0], [3.0, 0.0, 1.0]]
+    value = uembed_loss.flops_regularizer(_tensor(rows))
+    assert value.item() == pytest.approx(9.0, abs = 1e-12)
+    assert value.item() == pytest.approx(_flops_oracle(rows), abs = 1e-12)
+
+
+def test_flops_matches_oracle_on_the_shared_batch(uembed_loss):
+    for rows in (_SPARSE_ANCHOR, _SPARSE_POSITIVE):
+        value = uembed_loss.flops_regularizer(_tensor(rows))
+        assert value.item() == pytest.approx(_flops_oracle(rows), abs = 1e-12)
+
+
+def test_flops_is_zero_for_an_all_zero_batch(uembed_loss):
+    assert uembed_loss.flops_regularizer(torch.zeros(4, 5, dtype = _DTYPE)).item() == 0.0
+
+
+def test_flops_is_a_mean_not_a_sum_over_the_batch(uembed_loss):
+    """Duplicating every row leaves the column means -- and so the term -- unchanged."""
+    rows = [[1.0, 2.0, 3.0], [3.0, 0.0, 1.0]]
+    single = uembed_loss.flops_regularizer(_tensor(rows))
+    doubled = uembed_loss.flops_regularizer(_tensor(rows + rows))
+    assert doubled.item() == pytest.approx(single.item(), abs = 1e-12)
+
+
+def test_flops_penalises_a_denser_batch_more(uembed_loss):
+    sparse = uembed_loss.flops_regularizer(_tensor([[3.0, 0.0, 0.0], [0.0, 3.0, 0.0]]))
+    dense = uembed_loss.flops_regularizer(_tensor([[2.0, 2.0, 2.0], [2.0, 2.0, 2.0]]))
+    assert dense.item() > sparse.item()
+
+
+# --------------------------------------------------------------------------------------
+# 2. weighted composition, pinned exactly
+# --------------------------------------------------------------------------------------
+def test_total_equals_the_independently_recomputed_weighted_sum(uembed_loss):
+    lambda_sparse, alpha_q, alpha_d, scale, tau_s = 0.75, 0.03, 0.11, 20.0, 32.0
+    loss = uembed_loss.UEmbedUnifiedLoss(
+        lambda_sparse = lambda_sparse,
+        alpha_q = alpha_q,
+        alpha_d = alpha_d,
+        scale = scale,
+        tau_s = tau_s,
+    )
+    features = _features(_DENSE_ANCHOR, _DENSE_POSITIVE, _SPARSE_ANCHOR, _SPARSE_POSITIVE)
+
+    dense_expected = _cross_entropy_oracle(
+        _cosine_logits_oracle(_DENSE_ANCHOR, _DENSE_POSITIVE, scale)
+    )
+    sparse_expected = _cross_entropy_oracle(
+        _inner_logits_oracle(_SPARSE_ANCHOR, _SPARSE_POSITIVE, tau_s)
+    )
+    flops_q_expected = _flops_oracle(_SPARSE_ANCHOR)
+    flops_d_expected = _flops_oracle(_SPARSE_POSITIVE)
+    total_expected = (
+        dense_expected
+        + lambda_sparse * sparse_expected
+        + alpha_q * flops_q_expected
+        + alpha_d * flops_d_expected
+    )
+
+    components = loss.components(features)
+    assert components["dense"].item() == pytest.approx(dense_expected, abs = 1e-12)
+    assert components["sparse"].item() == pytest.approx(sparse_expected, abs = 1e-12)
+    assert components["flops_query"].item() == pytest.approx(flops_q_expected, abs = 1e-12)
+    assert components["flops_document"].item() == pytest.approx(flops_d_expected, abs = 1e-12)
+    assert components["total"].item() == pytest.approx(total_expected, abs = 1e-12)
+    assert loss(features).item() == pytest.approx(total_expected, abs = 1e-12)
+
+
+def test_every_coefficient_moves_the_total(uembed_loss):
+    """Each weight is load-bearing: zeroing it changes the total by exactly its term."""
+    features = _features(_DENSE_ANCHOR, _DENSE_POSITIVE, _SPARSE_ANCHOR, _SPARSE_POSITIVE)
+    base_kwargs = dict(lambda_sparse = 0.75, alpha_q = 0.03, alpha_d = 0.11)
+    base = uembed_loss.UEmbedUnifiedLoss(**base_kwargs)
+    components = base.components(features)
+    base_total = components["total"].item()
+
+    for coefficient, term in (
+        ("lambda_sparse", "sparse"),
+        ("alpha_q", "flops_query"),
+        ("alpha_d", "flops_document"),
+    ):
+        kwargs = dict(base_kwargs)
+        kwargs[coefficient] = 0.0
+        zeroed = uembed_loss.UEmbedUnifiedLoss(**kwargs)(features).item()
+        removed = base_kwargs[coefficient] * components[term].item()
+        assert removed > 0.0
+        assert base_total - zeroed == pytest.approx(removed, abs = 1e-12)
+
+
+def test_default_coefficients_match_the_paper_defaults(uembed_loss):
+    loss = uembed_loss.UEmbedUnifiedLoss()
+    assert loss.lambda_sparse == 1.0
+    assert loss.alpha_q == 0.01
+    assert loss.alpha_d == 0.01
+    assert loss.scale == 20.0
+    assert loss.tau_s == 32.0
+    assert loss.alpha_warmup_steps == 0
+
+
+def test_sparse_temperature_is_not_the_dense_scale(uembed_loss):
+    """Sparse logits are inner products / tau_s, dense are cosines * scale."""
+    features = _features(_DENSE_ANCHOR, _DENSE_POSITIVE, _SPARSE_ANCHOR, _SPARSE_POSITIVE)
+    default = uembed_loss.UEmbedUnifiedLoss().components(features)["sparse"].item()
+    retuned = uembed_loss.UEmbedUnifiedLoss(tau_s = 4.0).components(features)["sparse"].item()
+    assert default != pytest.approx(retuned, abs = 1e-9)
+    expected = _cross_entropy_oracle(_inner_logits_oracle(_SPARSE_ANCHOR, _SPARSE_POSITIVE, 4.0))
+    assert retuned == pytest.approx(expected, abs = 1e-12)
+
+
+def test_config_dict_reports_the_hyperparameters(uembed_loss):
+    config = uembed_loss.UEmbedUnifiedLoss(lambda_sparse = 0.5, tau_s = 64.0).get_config_dict()
+    assert config["lambda_sparse"] == 0.5
+    assert config["tau_s"] == 64.0
+    assert config["scale"] == 20.0
+
+
+# --------------------------------------------------------------------------------------
+# 3. behavioural direction (monotonicity)
+# --------------------------------------------------------------------------------------
+def test_sparse_infonce_drops_when_the_positive_inner_product_rises(uembed_loss):
+    """Disjoint supports: only the (0, 0) logit moves, so the direction is unambiguous."""
+    loss = uembed_loss.UEmbedUnifiedLoss()
+    anchor_sparse = [[1.0, 0.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0]]
+    weak = [[1.0, 0.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0]]
+    strong = [[4.0, 0.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0]]
+
+    before = loss.components(_features(_DENSE_ANCHOR, _DENSE_POSITIVE, anchor_sparse, weak))[
+        "sparse"
+    ].item()
+    after = loss.components(_features(_DENSE_ANCHOR, _DENSE_POSITIVE, anchor_sparse, strong))[
+        "sparse"
+    ].item()
+    assert after < before
+
+
+def test_dense_infonce_drops_when_the_positive_cosine_rises(uembed_loss):
+    loss = uembed_loss.UEmbedUnifiedLoss()
+    anchor_dense = [[1.0, 0.0], [0.0, 1.0]]
+    misaligned = [[1.0, 1.0], [1.0, 1.0]]
+    aligned = [[1.0, 0.0], [0.0, 1.0]]
+
+    before = loss.components(_features(anchor_dense, misaligned, _SPARSE_ANCHOR, _SPARSE_POSITIVE))[
+        "dense"
+    ].item()
+    after = loss.components(_features(anchor_dense, aligned, _SPARSE_ANCHOR, _SPARSE_POSITIVE))[
+        "dense"
+    ].item()
+    assert after < before
+
+
+def test_dense_ignores_the_magnitude_of_the_embeddings(uembed_loss):
+    """Cosine, not inner product: rescaling a row must not change the dense term."""
+    loss = uembed_loss.UEmbedUnifiedLoss()
+    scaled = [[7.0 * value for value in row] for row in _DENSE_ANCHOR]
+    plain = loss.components(
+        _features(_DENSE_ANCHOR, _DENSE_POSITIVE, _SPARSE_ANCHOR, _SPARSE_POSITIVE)
+    )["dense"].item()
+    rescaled = loss.components(
+        _features(scaled, _DENSE_POSITIVE, _SPARSE_ANCHOR, _SPARSE_POSITIVE)
+    )["dense"].item()
+    assert rescaled == pytest.approx(plain, abs = 1e-12)
+
+
+def test_gradients_reach_both_the_dense_and_the_sparse_embeddings(uembed_loss):
+    loss = uembed_loss.UEmbedUnifiedLoss()
+    features = _features(_DENSE_ANCHOR, _DENSE_POSITIVE, _SPARSE_ANCHOR, _SPARSE_POSITIVE)
+    for column in features:
+        for tensor in column.values():
+            tensor.requires_grad_(True)
+
+    loss(features).backward()
+    for column in features:
+        for key, tensor in column.items():
+            assert tensor.grad is not None, key
+            assert torch.isfinite(tensor.grad).all(), key
+            assert tensor.grad.abs().sum().item() > 0.0, key
+
+
+def test_repeated_calls_are_bit_identical(uembed_loss):
+    """No seed, no clock, no state: the same input must give the same float."""
+    loss = uembed_loss.UEmbedUnifiedLoss()
+    features = _features(_DENSE_ANCHOR, _DENSE_POSITIVE, _SPARSE_ANCHOR, _SPARSE_POSITIVE)
+    first = loss(features).item()
+    assert loss(features).item() == first
+    assert loss(features).item() == first
+
+
+# --------------------------------------------------------------------------------------
+# 4. edges + malformed input
+# --------------------------------------------------------------------------------------
+def test_missing_sparse_embedding_raises_an_unsloth_error(uembed_loss):
+    loss = uembed_loss.UEmbedUnifiedLoss()
+    for column in (0, 1):
+        features = _features(_DENSE_ANCHOR, _DENSE_POSITIVE, _SPARSE_ANCHOR, _SPARSE_POSITIVE)
+        features[column].pop("sparse_embedding")
+        with pytest.raises(KeyError) as excinfo:
+            loss(features)
+        message = str(excinfo.value)
+        assert "Unsloth:" in message
+        assert "sparse_embedding" in message
+
+
+def test_missing_sentence_embedding_raises_an_unsloth_error(uembed_loss):
+    loss = uembed_loss.UEmbedUnifiedLoss()
+    features = _features(_DENSE_ANCHOR, _DENSE_POSITIVE, _SPARSE_ANCHOR, _SPARSE_POSITIVE)
+    features[0].pop("sentence_embedding")
+    with pytest.raises(KeyError) as excinfo:
+        loss(features)
+    assert "Unsloth:" in str(excinfo.value)
+    assert "sentence_embedding" in str(excinfo.value)
+
+
+def test_a_single_column_raises_an_unsloth_error(uembed_loss):
+    loss = uembed_loss.UEmbedUnifiedLoss()
+    features = _features(_DENSE_ANCHOR, _DENSE_POSITIVE, _SPARSE_ANCHOR, _SPARSE_POSITIVE)
+    with pytest.raises(ValueError) as excinfo:
+        loss(features[:1])
+    assert "Unsloth:" in str(excinfo.value)
+
+
+def test_mismatched_batch_sizes_raise_an_unsloth_error(uembed_loss):
+    loss = uembed_loss.UEmbedUnifiedLoss()
+    features = _features(
+        _DENSE_ANCHOR,
+        _DENSE_POSITIVE[:1],
+        _SPARSE_ANCHOR,
+        _SPARSE_POSITIVE[:1],
+    )
+    with pytest.raises(ValueError) as excinfo:
+        loss(features)
+    assert "Unsloth:" in str(excinfo.value)
+    assert "batch" in str(excinfo.value).lower()
+
+
+def test_dense_and_sparse_batch_sizes_must_agree_within_a_column(uembed_loss):
+    loss = uembed_loss.UEmbedUnifiedLoss()
+    features = _features(_DENSE_ANCHOR, _DENSE_POSITIVE, _SPARSE_ANCHOR, _SPARSE_POSITIVE)
+    features[0]["sparse_embedding"] = _tensor(_SPARSE_ANCHOR[:1])
+    with pytest.raises(ValueError) as excinfo:
+        loss(features)
+    assert "Unsloth:" in str(excinfo.value)
+
+
+def test_batch_of_one_degenerates_to_the_flops_terms_only(uembed_loss):
+    """B=1 has no in-batch negatives: both cross entropies are exactly 0."""
+    loss = uembed_loss.UEmbedUnifiedLoss(lambda_sparse = 0.75, alpha_q = 0.03, alpha_d = 0.11)
+    features = _features(
+        _DENSE_ANCHOR[:1], _DENSE_POSITIVE[:1], _SPARSE_ANCHOR[:1], _SPARSE_POSITIVE[:1]
+    )
+    components = loss.components(features)
+    assert components["dense"].item() == pytest.approx(0.0, abs = 1e-12)
+    assert components["sparse"].item() == pytest.approx(0.0, abs = 1e-12)
+    expected = 0.03 * _flops_oracle(_SPARSE_ANCHOR[:1]) + 0.11 * _flops_oracle(_SPARSE_POSITIVE[:1])
+    assert components["total"].item() == pytest.approx(expected, abs = 1e-12)
+
+
+def test_labels_argument_is_accepted_and_ignored(uembed_loss):
+    """The trainer passes `labels`; in-batch InfoNCE derives its own `arange(B)`."""
+    loss = uembed_loss.UEmbedUnifiedLoss()
+    features = _features(_DENSE_ANCHOR, _DENSE_POSITIVE, _SPARSE_ANCHOR, _SPARSE_POSITIVE)
+    assert loss(features, labels = None).item() == loss(features, torch.zeros(2)).item()
+
+
+# --------------------------------------------------------------------------------------
+# 5. optional quadratic alpha warmup (default OFF)
+# --------------------------------------------------------------------------------------
+def test_alpha_warmup_is_off_by_default(uembed_loss):
+    loss = uembed_loss.UEmbedUnifiedLoss()
+    features = _features(_DENSE_ANCHOR, _DENSE_POSITIVE, _SPARSE_ANCHOR, _SPARSE_POSITIVE)
+    assert loss.alpha_scale() == 1.0
+    first = loss(features).item()
+    assert loss.alpha_step == 0
+    assert loss(features).item() == first
+
+
+def test_alpha_warmup_ramps_quadratically_then_saturates(uembed_loss):
+    loss = uembed_loss.UEmbedUnifiedLoss(alpha_warmup_steps = 4)
+    assert loss.alpha_scale() == 0.0
+    for step, expected in ((1, 0.0625), (2, 0.25), (3, 0.5625), (4, 1.0), (9, 1.0)):
+        loss.alpha_step = step
+        assert loss.alpha_scale() == pytest.approx(expected, abs = 1e-12)
+
+
+def test_alpha_warmup_scales_only_the_flops_terms(uembed_loss):
+    loss = uembed_loss.UEmbedUnifiedLoss(alpha_q = 0.03, alpha_d = 0.11, alpha_warmup_steps = 4)
+    features = _features(_DENSE_ANCHOR, _DENSE_POSITIVE, _SPARSE_ANCHOR, _SPARSE_POSITIVE)
+    loss.alpha_step = 2  # (2 / 4)^2 = 0.25
+    components = loss.components(features)
+    expected = (
+        components["dense"].item()
+        + components["sparse"].item()
+        + 0.25 * (0.03 * _flops_oracle(_SPARSE_ANCHOR) + 0.11 * _flops_oracle(_SPARSE_POSITIVE))
+    )
+    assert components["total"].item() == pytest.approx(expected, abs = 1e-12)
+
+
+def test_alpha_step_advances_only_while_training_with_warmup_enabled(uembed_loss):
+    features = _features(_DENSE_ANCHOR, _DENSE_POSITIVE, _SPARSE_ANCHOR, _SPARSE_POSITIVE)
+    loss = uembed_loss.UEmbedUnifiedLoss(alpha_warmup_steps = 4)
+    loss.train()
+    loss(features)
+    loss(features)
+    assert loss.alpha_step == 2
+    loss.eval()
+    loss(features)
+    assert loss.alpha_step == 2
+
+
+def test_negative_hyperparameters_are_rejected(uembed_loss):
+    for kwargs in (
+        {"lambda_sparse": -1.0},
+        {"alpha_q": -0.01},
+        {"alpha_d": -0.01},
+        {"scale": 0.0},
+        {"tau_s": 0.0},
+        {"alpha_warmup_steps": -1},
+    ):
+        with pytest.raises(ValueError) as excinfo:
+            uembed_loss.UEmbedUnifiedLoss(**kwargs)
+        assert "Unsloth:" in str(excinfo.value)
+
+
+# --------------------------------------------------------------------------------------
+# 6. raw trainer columns versus already-forwarded columns
+# --------------------------------------------------------------------------------------
+class _CountingFeatureModel(torch.nn.Module):
+    """A tiny trainable ST-like pipeline returning a new dual-output features dict."""
+
+    def __init__(self, *, omit_sparse = False):
+        super().__init__()
+        self.weight = torch.nn.Parameter(
+            _tensor([[1.0, -0.5, 0.25], [0.5, 1.5, -1.0], [-0.25, 0.75, 1.25]])
+        )
+        self.omit_sparse = omit_sparse
+        self.calls = 0
+
+    def forward(self, features):
+        self.calls += 1
+        dense = features["values"] @ self.weight
+        output = {"sentence_embedding": dense}
+        if not self.omit_sparse:
+            output["sparse_embedding"] = (dense + _tensor([[1.0, 0.5, 1.5]])).pow(2)
+        return output
+
+
+def _raw_features():
+    return [
+        {"values": _tensor([[1.0, 0.0, 0.5], [0.0, 2.0, 1.0]])},
+        {"values": _tensor([[0.5, 0.5, 0.0], [0.25, 1.0, 2.0]])},
+    ]
+
+
+def test_raw_trainer_columns_are_forwarded_once_each_with_gradients_and_oracle(uembed_loss):
+    model = _CountingFeatureModel()
+    loss = uembed_loss.UEmbedUnifiedLoss(
+        model,
+        lambda_sparse = 0.75,
+        alpha_q = 0.03,
+        alpha_d = 0.11,
+        scale = 20.0,
+        tau_s = 32.0,
+    )
+    raw = _raw_features()
+    original_keys = [set(column) for column in raw]
+
+    total = loss(raw)
+
+    assert model.calls == 2, "each raw column must use exactly one shared dense+sparse forward"
+    assert [set(column) for column in raw] == original_keys, "the loss mutated caller dictionaries"
+    assert all("sentence_embedding" not in column for column in raw)
+
+    # Independent scalar oracle over the model's analytically defined outputs. Do not call
+    # the loss/components again: doing so could mirror a forwarding or composition defect.
+    weight = model.weight.detach().tolist()
+    dense = []
+    sparse = []
+    for column in raw:
+        dense_column = []
+        sparse_column = []
+        for row in column["values"].tolist():
+            dense_row = [sum(row[k] * weight[k][j] for k in range(3)) for j in range(3)]
+            dense_column.append(dense_row)
+            sparse_column.append(
+                [(value + offset) ** 2 for value, offset in zip(dense_row, (1.0, 0.5, 1.5))]
+            )
+        dense.append(dense_column)
+        sparse.append(sparse_column)
+    expected = (
+        _cross_entropy_oracle(_cosine_logits_oracle(dense[0], dense[1], 20.0))
+        + 0.75 * _cross_entropy_oracle(_inner_logits_oracle(sparse[0], sparse[1], 32.0))
+        + 0.03 * _flops_oracle(sparse[0])
+        + 0.11 * _flops_oracle(sparse[1])
+    )
+    assert total.item() == pytest.approx(expected, abs = 1e-12)
+
+    total.backward()
+    assert model.weight.grad is not None
+    assert torch.isfinite(model.weight.grad).all()
+    assert model.weight.grad.abs().sum().item() > 0.0
+
+
+def test_already_forwarded_columns_never_call_the_model(uembed_loss):
+    model = _CountingFeatureModel()
+    loss = uembed_loss.UEmbedUnifiedLoss(model)
+    forwarded = _features(_DENSE_ANCHOR, _DENSE_POSITIVE, _SPARSE_ANCHOR, _SPARSE_POSITIVE)
+    # Trainer/raw keys can survive in an output dict. Presence of BOTH required output
+    # keys, rather than absence of input keys or an arbitrary flag, defines forwarded data.
+    for column in forwarded:
+        column["input_ids"] = torch.ones(2, 3, dtype = torch.long)
+    expected = uembed_loss.UEmbedUnifiedLoss()(forwarded)
+
+    actual = loss(forwarded)
+
+    assert model.calls == 0
+    assert actual.item() == expected.item()
+
+
+def test_raw_forward_missing_sparse_embedding_raises_loudly(uembed_loss):
+    model = _CountingFeatureModel(omit_sparse = True)
+    loss = uembed_loss.UEmbedUnifiedLoss(model)
+
+    with pytest.raises(KeyError) as excinfo:
+        loss(_raw_features())
+
+    assert model.calls == 2
+    assert "Unsloth:" in str(excinfo.value)
+    assert "sparse_embedding" in str(excinfo.value)
+
+
+# --------------------------------------------------------------------------------------
+# 7. sentence-transformers contract (skips when ST is not importable here)
+# --------------------------------------------------------------------------------------
+def test_dense_term_matches_multiple_negatives_ranking_loss(uembed_loss):
+    """The dense half must be MNRL exactly -- same scale, same cosine, same labels."""
+    try:
+        from sentence_transformers.losses import MultipleNegativesRankingLoss  # noqa: PLC0415
+    except Exception as error:  # ST pulls in transformers, unavailable on some CPU boxes
+        pytest.skip(f"sentence_transformers unavailable: {error}")
+
+    class _Passthrough(torch.nn.Module):
+        def forward(self, features):
+            return features
+
+    features = _features(_DENSE_ANCHOR, _DENSE_POSITIVE, _SPARSE_ANCHOR, _SPARSE_POSITIVE)
+    reference = MultipleNegativesRankingLoss(_Passthrough(), scale = 20.0)(features, None).item()
+    ours = uembed_loss.UEmbedUnifiedLoss().components(features)["dense"].item()
+    assert ours == pytest.approx(reference, abs = 1e-9)

--- a/tests/python/test_uembed_multioutput.py
+++ b/tests/python/test_uembed_multioutput.py
@@ -1,0 +1,478 @@
+# Copyright 2023-present Daniel Han-Chen & the Unsloth team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the UEmbed single-forward dense + sparse multi-output wiring.
+
+UEmbed produces its dense vector and its SPLADE sparse vector from ONE causal forward
+pass. The wiring under test puts the sparse head INTO the sentence-transformers module
+chain, so it reads the hidden state (`token_embeddings`) the transformer already emitted
+and writes `sparse_embedding` beside `sentence_embedding` in the same features dict --
+which is exactly what `UEmbedUnifiedLoss` consumes.
+
+The load-bearing assertion here is the transformer forward-call COUNT: a naive
+"encode once for dense, encode again for sparse" implementation doubles the most
+expensive part of training and fails these tests.
+
+`unsloth` and `sentence_transformers` are not importable on a CPU-only box, so the wiring
+is exercised through a stub pipeline that mimics the sentence-transformers contract
+(tokenize -> module chain over one features dict -> extract) against the REAL wiring
+module loaded from its source file. The one test that needs the genuine
+Transformer->Pooling->Normalize chain skips itself when sentence-transformers is absent.
+Everything is CPU-only, seeded and download-free.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import inspect
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+import torch.nn.functional as F
+from torch import nn
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_WIRING_SOURCE_PATH = _REPO_ROOT / "unsloth" / "models" / "uembed_wiring.py"
+_SPLADE_SOURCE_PATH = _REPO_ROOT / "unsloth" / "models" / "uembed_splade.py"
+
+_VOCAB_SIZE = 29
+_HIDDEN_DIM = 4
+_MAX_LENGTH = 8
+# Deliberately unequal per-head vocabularies: only a real `sum(V_i)` concatenation gives
+# this width, a `num_eos * V` shortcut cannot.
+_HEAD_DIMS = [3, 4, 5]
+_NUM_EOS = 3
+_SPARSE_DIM = sum(_HEAD_DIMS)
+
+# Every sentence must outlive the 3-slot EOS block the sparse head reads back through.
+_SENTENCES = ["alpha document", "beta document"]
+
+
+# --------------------------------------------------------------------------------------
+# module loading
+# --------------------------------------------------------------------------------------
+def _load_from_source(module_name: str, source_path: Path):
+    """Execute the real source file directly.
+
+    `import unsloth` runs the accelerator / unsloth_zoo gate, which legitimately refuses
+    to import on a CPU-only machine. The modules under test depend on torch only, so this
+    fallback runs the exact same source -- it loads it, it does not stub it out.
+    """
+    if module_name in sys.modules:
+        return sys.modules[module_name]
+    assert source_path.exists(), f"missing module file: {source_path}"
+    spec = importlib.util.spec_from_file_location(module_name, source_path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope = "module")
+def wiring():
+    try:
+        from unsloth.models import uembed_wiring  # noqa: PLC0415
+        return uembed_wiring
+    except Exception:  # accelerator gate / missing unsloth_zoo / heavy optional deps
+        return _load_from_source("unsloth_uembed_wiring_direct", _WIRING_SOURCE_PATH)
+
+
+@pytest.fixture(scope = "module")
+def splade():
+    try:
+        from unsloth.models import uembed_splade  # noqa: PLC0415
+        return uembed_splade
+    except Exception:
+        return _load_from_source("unsloth_uembed_splade_direct", _SPLADE_SOURCE_PATH)
+
+
+# --------------------------------------------------------------------------------------
+# stub pipeline: the sentence-transformers contract, minus sentence-transformers
+# --------------------------------------------------------------------------------------
+class _CountingTransformer(nn.Module):
+    """Stands in for the ST `Transformer` module and counts how often it runs."""
+
+    def __init__(self, seed: int = 3) -> None:
+        super().__init__()
+        generator = torch.Generator().manual_seed(seed)
+        self.table = nn.Parameter(torch.randn(_VOCAB_SIZE, _HIDDEN_DIM, generator = generator))
+        self.forward_calls = 0
+
+    def forward(self, features: dict, **kwargs) -> dict:
+        self.forward_calls += 1
+        features["token_embeddings"] = self.table[features["input_ids"]]
+        return features
+
+
+class _LastTokenPooling(nn.Module):
+    """Stands in for the ST `Pooling` module (dense vector from the last real token)."""
+
+    def forward(self, features: dict, **kwargs) -> dict:
+        mask = features["attention_mask"]
+        last = (mask.cumsum(dim = 1) * mask).argmax(dim = 1)
+        rows = torch.arange(mask.shape[0])
+        features["sentence_embedding"] = features["token_embeddings"][rows, last]
+        return features
+
+
+class _Normalize(nn.Module):
+    """Stands in for the ST `Normalize` module."""
+
+    def forward(self, features: dict, **kwargs) -> dict:
+        features["sentence_embedding"] = F.normalize(features["sentence_embedding"], p = 2, dim = -1)
+        return features
+
+
+def _tokenize(sentences: list[str]) -> dict:
+    input_ids = torch.zeros(len(sentences), _MAX_LENGTH, dtype = torch.long)
+    attention_mask = torch.zeros(len(sentences), _MAX_LENGTH, dtype = torch.long)
+    for row, sentence in enumerate(sentences):
+        codes = [ord(character) % _VOCAB_SIZE for character in sentence][:_MAX_LENGTH]
+        assert len(codes) > _NUM_EOS, f"test sentence too short for the EOS block: {sentence!r}"
+        input_ids[row, : len(codes)] = torch.tensor(codes, dtype = torch.long)
+        attention_mask[row, : len(codes)] = 1
+    return {"input_ids": input_ids, "attention_mask": attention_mask}
+
+
+class _StubSentenceTransformer(nn.Sequential):
+    """Mimics `SentenceTransformer.encode`: one tokenization, one pass over the chain.
+
+    `output_value = None` returns every feature per row, which is how sentence-transformers
+    hands back keys it does not know about.
+    """
+
+    def tokenize(self, sentences: list[str]) -> dict:
+        return _tokenize(sentences)
+
+    def encode(
+        self,
+        sentences,
+        output_value: str | None = "sentence_embedding",
+        convert_to_numpy: bool = True,
+        convert_to_tensor: bool = False,
+    ):
+        single = isinstance(sentences, str)
+        batch = [sentences] if single else list(sentences)
+
+        features = self.tokenize(batch)
+        with torch.no_grad():
+            for module in self:
+                features = module(features)
+
+        if output_value is None:
+            rows = [
+                {key: value[index] for key, value in features.items() if torch.is_tensor(value)}
+                for index in range(len(batch))
+            ]
+            return rows[0] if single else rows
+
+        embeddings = features[output_value]
+        if not convert_to_tensor and convert_to_numpy:
+            embeddings = embeddings.cpu().numpy()
+        return embeddings[0] if single else embeddings
+
+
+def _make_pipeline() -> _StubSentenceTransformer:
+    return _StubSentenceTransformer(_CountingTransformer(), _LastTokenPooling(), _Normalize())
+
+
+def _make_head(splade_module, seed: int = 11):
+    generator = torch.Generator().manual_seed(seed)
+    heads = [torch.randn(dim, _HIDDEN_DIM, generator = generator) for dim in _HEAD_DIMS]
+    biases = [torch.randn(dim, generator = generator) for dim in _HEAD_DIMS]
+    return splade_module.SpladeHead(heads, biases, num_eos_tokens = _NUM_EOS)
+
+
+@pytest.fixture
+def pipeline():
+    return _make_pipeline()
+
+
+@pytest.fixture
+def sparse_pipeline(wiring, splade):
+    model = _make_pipeline()
+    wiring.attach_uembed_sparse_output(model, _make_head(splade))
+    model[0].forward_calls = 0
+    return model
+
+
+# --------------------------------------------------------------------------------------
+# 1. no regression: the default path is untouched when sparse is not requested
+# --------------------------------------------------------------------------------------
+def test_default_encode_matches_the_pre_wiring_result(wiring, splade, pipeline):
+    """Attaching the sparse output must not change what a plain `encode()` returns."""
+    baseline = pipeline.encode(_SENTENCES)
+    baseline_single = pipeline.encode(_SENTENCES[0])
+
+    wiring.attach_uembed_sparse_output(pipeline, _make_head(splade))
+
+    after = pipeline.encode(_SENTENCES)
+    after_single = pipeline.encode(_SENTENCES[0])
+
+    assert type(after) is type(baseline) is np.ndarray
+    assert after.shape == baseline.shape == (len(_SENTENCES), _HIDDEN_DIM)
+    assert np.array_equal(after, baseline)
+    assert type(after_single) is type(baseline_single)
+    assert after_single.shape == baseline_single.shape == (_HIDDEN_DIM,)
+    assert np.array_equal(after_single, baseline_single)
+
+
+def test_default_encode_keeps_its_keyword_arguments(sparse_pipeline):
+    """The wrapped `encode` still forwards stock sentence-transformers keywords."""
+    as_tensor = sparse_pipeline.encode(_SENTENCES, convert_to_tensor = True)
+    assert torch.is_tensor(as_tensor)
+    assert as_tensor.shape == (len(_SENTENCES), _HIDDEN_DIM)
+
+    explicit_dense = sparse_pipeline.encode(_SENTENCES, output_mode = "dense")
+    assert type(explicit_dense) is np.ndarray
+    assert np.array_equal(explicit_dense, sparse_pipeline.encode(_SENTENCES))
+
+
+# --------------------------------------------------------------------------------------
+# 2. the load-bearing assertion: ONE transformer forward for BOTH outputs
+# --------------------------------------------------------------------------------------
+def test_both_outputs_come_from_a_single_transformer_forward(sparse_pipeline):
+    outputs = sparse_pipeline.encode(_SENTENCES, output_mode = "both")
+
+    assert sparse_pipeline[0].forward_calls == 1, "the transformer ran more than once"
+    assert set(outputs) == {"sentence_embedding", "sparse_embedding"}
+    assert outputs["sentence_embedding"].shape == (len(_SENTENCES), _HIDDEN_DIM)
+    assert outputs["sparse_embedding"].shape == (len(_SENTENCES), _SPARSE_DIM)
+    assert (outputs["sparse_embedding"] >= 0.0).all(), "SPLADE weights are non-negative"
+
+
+def test_sparse_only_request_also_uses_a_single_forward(sparse_pipeline):
+    sparse = sparse_pipeline.encode(_SENTENCES, output_mode = "sparse")
+
+    assert sparse_pipeline[0].forward_calls == 1
+    assert type(sparse) is np.ndarray
+    assert sparse.shape == (len(_SENTENCES), _SPARSE_DIM)
+
+
+def test_module_chain_carries_both_keys_in_one_features_dict(sparse_pipeline):
+    """The loss boundary: one forward, one dict, both embeddings."""
+    features = sparse_pipeline.tokenize(_SENTENCES)
+    for module in sparse_pipeline:
+        features = module(features)
+
+    assert sparse_pipeline[0].forward_calls == 1
+    assert "sentence_embedding" in features and "sparse_embedding" in features
+    assert features["sparse_embedding"].shape == (len(_SENTENCES), _SPARSE_DIM)
+    # The dense vector still went through Normalize, i.e. the sparse module did not
+    # displace or shadow the dense pooling it shares the forward with.
+    norms = features["sentence_embedding"].norm(dim = -1)
+    assert torch.allclose(norms, torch.ones_like(norms), atol = 1e-5)
+
+
+def test_single_string_request_returns_row_vectors(sparse_pipeline):
+    outputs = sparse_pipeline.encode(_SENTENCES[0], output_mode = "both")
+
+    assert sparse_pipeline[0].forward_calls == 1
+    assert outputs["sentence_embedding"].shape == (_HIDDEN_DIM,)
+    assert outputs["sparse_embedding"].shape == (_SPARSE_DIM,)
+
+
+def test_convert_to_tensor_applies_to_both_outputs(sparse_pipeline):
+    outputs = sparse_pipeline.encode(_SENTENCES, output_mode = "both", convert_to_tensor = True)
+
+    assert torch.is_tensor(outputs["sentence_embedding"])
+    assert torch.is_tensor(outputs["sparse_embedding"])
+    assert outputs["sparse_embedding"].shape == (len(_SENTENCES), _SPARSE_DIM)
+
+
+# --------------------------------------------------------------------------------------
+# 3. stale state: the sparse vector must come from THIS forward
+# --------------------------------------------------------------------------------------
+def test_sparse_output_tracks_the_current_input(sparse_pipeline):
+    first = sparse_pipeline.encode("alpha document", output_mode = "sparse")
+    second = sparse_pipeline.encode("zulu manuscript", output_mode = "sparse")
+    repeat = sparse_pipeline.encode("alpha document", output_mode = "sparse")
+
+    assert not np.allclose(first, second), "sparse output ignored the new input (cached?)"
+    assert np.allclose(first, repeat), "sparse output is not deterministic for one input"
+
+
+def test_dense_and_sparse_belong_to_the_same_forward(sparse_pipeline, splade):
+    """Both outputs of one call describe the same input, not a mix of two calls."""
+    together = sparse_pipeline.encode(_SENTENCES, output_mode = "both")
+    dense_alone = sparse_pipeline.encode(_SENTENCES)
+    sparse_alone = sparse_pipeline.encode(_SENTENCES, output_mode = "sparse")
+
+    assert np.allclose(together["sentence_embedding"], dense_alone)
+    assert np.allclose(together["sparse_embedding"], sparse_alone)
+
+
+# --------------------------------------------------------------------------------------
+# 4. malformed requests fail loudly
+# --------------------------------------------------------------------------------------
+def test_sparse_request_without_a_head_raises(wiring, pipeline):
+    with pytest.raises(ValueError) as error:
+        wiring.encode_uembed(pipeline, _SENTENCES, output_mode = "sparse")
+
+    message = str(error.value)
+    assert "Unsloth" in message
+    assert "sparse" in message.lower()
+
+
+def test_unknown_output_mode_raises(wiring, sparse_pipeline):
+    with pytest.raises(ValueError) as error:
+        sparse_pipeline.encode(_SENTENCES, output_mode = "splade.last")
+
+    assert "Unsloth" in str(error.value)
+
+
+def test_attaching_to_a_chain_without_encode_still_wires_the_features_dict(wiring, splade):
+    """Training only needs the features dict, so a chain with no `encode` must still wire."""
+    chain = nn.Sequential(_CountingTransformer(), _LastTokenPooling(), _Normalize())
+
+    assert wiring.attach_uembed_sparse_output(chain, _make_head(splade)) is True
+
+    features = _tokenize(_SENTENCES)
+    for module in chain:
+        features = module(features)
+    assert features["sparse_embedding"].shape == (len(_SENTENCES), _SPARSE_DIM)
+    assert chain[0].forward_calls == 1
+
+
+def test_attaching_something_other_than_a_head_raises(wiring, pipeline):
+    with pytest.raises(ValueError) as error:
+        wiring.attach_uembed_sparse_output(pipeline, nn.Linear(_HIDDEN_DIM, _HIDDEN_DIM))
+
+    assert "Unsloth" in str(error.value)
+
+
+def test_a_head_from_a_second_module_object_is_accepted(wiring, pipeline):
+    """The same source loaded twice yields two classes; a head is still a head."""
+    other_splade = _load_from_source("uembed_splade_second_load", _SPLADE_SOURCE_PATH)
+
+    assert wiring.attach_uembed_sparse_output(pipeline, _make_head(other_splade)) is True
+    assert pipeline.encode(_SENTENCES, output_mode = "sparse").shape == (
+        len(_SENTENCES),
+        _SPARSE_DIM,
+    )
+
+
+def test_serialized_sparse_chain_restores_encode_patch_idempotently(wiring, splade, pipeline):
+    """A module rebuilt from modules.json must regain the process-local encode wrapper."""
+    baseline = pipeline.encode(_SENTENCES)
+    serialized_module = wiring.UEmbedSparseOutput(_make_head(splade))
+    pipeline.add_module("3", serialized_module)
+    original_encode = pipeline.encode
+    module_count = len(pipeline)
+
+    # Attachment discovers the module reconstructed by SentenceTransformer.load instead
+    # of appending another one, but must still restore process-local method wiring.
+    assert wiring.attach_uembed_sparse_output(pipeline, _make_head(splade, seed = 99)) is False
+    patched_encode = pipeline.encode
+    assert patched_encode is not original_encode
+    assert len(pipeline) == module_count
+
+    pipeline[0].forward_calls = 0
+    sparse = pipeline.encode(_SENTENCES, output_mode = "sparse")
+    assert sparse.shape == (len(_SENTENCES), _SPARSE_DIM)
+    assert pipeline[0].forward_calls == 1
+
+    pipeline[0].forward_calls = 0
+    both = pipeline.encode(_SENTENCES, output_mode = "both")
+    assert set(both) == {"sentence_embedding", "sparse_embedding"}
+    assert pipeline[0].forward_calls == 1
+
+    # Re-running the load/attach seam must neither append nor wrap the wrapper.
+    assert wiring.attach_uembed_sparse_output(pipeline, _make_head(splade, seed = 101)) is False
+    assert pipeline.encode is patched_encode
+    pipeline[0].forward_calls = 0
+    assert np.array_equal(pipeline.encode(_SENTENCES, output_mode = "dense"), baseline)
+    assert pipeline[0].forward_calls == 1
+
+
+def test_non_uembed_chain_keeps_stock_encode_signature_and_behavior(wiring, pipeline):
+    signature = inspect.signature(pipeline.encode)
+    baseline = pipeline.encode(_SENTENCES)
+
+    # The idempotent restoration helper is intentionally a no-op without the sparse module.
+    assert wiring.patch_uembed_sparse_encode(pipeline) is False
+
+    assert inspect.signature(pipeline.encode) == signature
+    assert np.array_equal(pipeline.encode(_SENTENCES), baseline)
+    with pytest.raises(TypeError):
+        pipeline.encode(_SENTENCES, output_mode = "sparse")
+
+
+def test_attaching_twice_is_a_no_op(wiring, splade, pipeline):
+    head = _make_head(splade)
+    assert wiring.attach_uembed_sparse_output(pipeline, head) is True
+    module_count = len(pipeline)
+
+    assert wiring.attach_uembed_sparse_output(pipeline, _make_head(splade, seed = 99)) is False
+    assert len(pipeline) == module_count
+
+
+# --------------------------------------------------------------------------------------
+# 5. the sparse head trains: parameters registered, gradients arrive
+# --------------------------------------------------------------------------------------
+def test_sparse_head_parameters_are_visible_to_the_optimizer(wiring, splade, pipeline):
+    head = _make_head(splade)
+    wiring.attach_uembed_sparse_output(pipeline, head)
+
+    pipeline_parameters = {id(parameter) for parameter in pipeline.parameters()}
+    head_parameters = list(head.parameters())
+
+    assert head_parameters, "the head has no parameters"
+    for parameter in head_parameters:
+        assert parameter.requires_grad
+        assert id(parameter) in pipeline_parameters
+
+
+def test_gradients_reach_the_sparse_head_through_one_forward(wiring, splade, pipeline):
+    head = _make_head(splade)
+    wiring.attach_uembed_sparse_output(pipeline, head)
+
+    features = pipeline.tokenize(_SENTENCES)
+    for module in pipeline:
+        features = module(features)
+    (features["sparse_embedding"].sum() + features["sentence_embedding"].sum()).backward()
+
+    assert pipeline[0].forward_calls == 1
+    assert head.sparse_lm_heads[0].grad is not None
+    assert head.sparse_lm_heads[0].grad.abs().sum() > 0
+    assert head.sparse_bias[0].grad is not None
+    # The shared transformer got gradient from the same backward pass.
+    assert pipeline[0].table.grad is not None
+
+
+# --------------------------------------------------------------------------------------
+# 6. the real sentence-transformers chain must not drop the extra key
+# --------------------------------------------------------------------------------------
+def test_real_sentence_transformers_chain_preserves_sparse_embedding(wiring, splade):
+    models = pytest.importorskip("sentence_transformers.models")
+
+    head = _make_head(splade)
+    sparse_module = wiring.UEmbedSparseOutput(head)
+    pooling = models.Pooling(word_embedding_dimension = _HIDDEN_DIM, pooling_mode = "lasttoken")
+    normalize = models.Normalize()
+
+    generator = torch.Generator().manual_seed(5)
+    features = {
+        "token_embeddings": torch.randn(2, _MAX_LENGTH, _HIDDEN_DIM, generator = generator),
+        "attention_mask": torch.ones(2, _MAX_LENGTH, dtype = torch.long),
+    }
+    for module in (pooling, sparse_module, normalize):
+        features = module(features)
+
+    assert "sparse_embedding" in features, "the ST chain dropped the custom key"
+    assert features["sparse_embedding"].shape == (2, _SPARSE_DIM)
+    assert features["sentence_embedding"].shape == (2, _HIDDEN_DIM)

--- a/tests/python/test_uembed_pooling.py
+++ b/tests/python/test_uembed_pooling.py
@@ -1,0 +1,462 @@
+# Copyright 2023-present Daniel Han-Chen & the Unsloth team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the opt-in offset last-token pooling used by UEmbed (Qwen3.5).
+
+UEmbed appends `num_eos_tokens` `<|endoftext|>` tokens after the content and takes the
+dense vector from the hidden state that *precedes* that block, i.e. at
+`last_non_pad_index - num_eos_tokens`, not at the true last token.
+
+Three layers, all CPU-only and deterministic (synthetic tensors, no model download):
+
+- Baseline characterization: pins that the stock pooling path is untouched by this
+  feature. These pass on the pre-change tree (before any wiring exists).
+- Behavioural tests for the new module: index math is checked against an independent
+  oracle (`max(i for i where mask[i] == 1)`), never against a copy of the
+  implementation formula.
+- Structural wiring test: proves the offset module is selected only for the offset
+  mode and that stock `Pooling` remains the else-branch, without importing unsloth
+  (the package import needs an accelerator + unsloth_zoo, which CPU boxes lack).
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+import torch
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_ST_SOURCE_PATH = _REPO_ROOT / "unsloth" / "models" / "sentence_transformer.py"
+_POOLING_SOURCE_PATH = _REPO_ROOT / "unsloth" / "models" / "uembed_pooling.py"
+
+# The pooling modes sentence-transformers ships and unsloth auto-detects today. The
+# offset mode must never appear here: it is opt-in only.
+_STOCK_POOLING_MODES = frozenset(
+    {"cls", "mean", "max", "mean_sqrt_len", "weightedmean", "lasttoken"}
+)
+
+
+# --------------------------------------------------------------------------------------
+# helpers
+# --------------------------------------------------------------------------------------
+def _load_uembed_pooling():
+    """Load `unsloth.models.uembed_pooling`, falling back to a direct file load.
+
+    `import unsloth` runs the accelerator / unsloth_zoo gate, which legitimately refuses
+    to import on a CPU-only machine. The pooling module itself depends on torch only, so
+    the fallback executes the exact same source file. A broken module still fails here --
+    the fallback loads the file, it does not stub it out.
+    """
+    try:
+        from unsloth.models import uembed_pooling  # noqa: PLC0415
+        return uembed_pooling
+    except Exception:  # accelerator gate / missing unsloth_zoo / heavy optional deps
+        pass
+
+    name = "unsloth_uembed_pooling_direct"
+    if name in sys.modules:
+        return sys.modules[name]
+    assert _POOLING_SOURCE_PATH.exists(), f"missing module file: {_POOLING_SOURCE_PATH}"
+    spec = importlib.util.spec_from_file_location(name, _POOLING_SOURCE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope = "module")
+def uembed():
+    return _load_uembed_pooling()
+
+
+def _st_source_tree() -> ast.Module:
+    return ast.parse(_ST_SOURCE_PATH.read_text(encoding = "utf-8"))
+
+
+def _function_def(tree: ast.Module, name: str) -> ast.FunctionDef:
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == name:
+            return node
+    raise AssertionError(f"{name} not found in {_ST_SOURCE_PATH}")
+
+
+def _calls_to(node: ast.AST, func_name: str) -> list[ast.Call]:
+    return [
+        child
+        for child in ast.walk(node)
+        if isinstance(child, ast.Call)
+        and isinstance(child.func, ast.Name)
+        and child.func.id == func_name
+    ]
+
+
+def _hidden(batch: int, length: int, dim: int) -> torch.Tensor:
+    """Every (batch, position) row holds unique values, so a wrong index cannot pass."""
+    return torch.arange(batch * length * dim, dtype = torch.float32).reshape(batch, length, dim)
+
+
+def _last_non_pad_index(mask_row: torch.Tensor) -> int:
+    """Independent oracle: the last position that is not padding.
+
+    Deliberately NOT the implementation formula (`(cumsum * mask).argmax`) and NOT
+    `mask.sum() - 1` (which is only correct for right padding).
+    """
+    positions = [index for index, value in enumerate(mask_row.tolist()) if value]
+    assert positions, "oracle called on an all-padding row"
+    return positions[-1]
+
+
+def _mixed_layout_mask(length: int = 24) -> torch.Tensor:
+    """Right-padded rows, a fully unpadded row, a short row, and a left-padded row."""
+    mask = torch.zeros(4, length, dtype = torch.long)
+    mask[0, :20] = 1  # right padding
+    mask[1, :] = 1  # no padding at all
+    mask[2, :17] = 1  # shortest row that still survives num_eos_tokens = 16
+    mask[3, 6:] = 1  # left padding -> last index is length - 1
+    return mask
+
+
+# --------------------------------------------------------------------------------------
+# baseline characterization -- these pass BEFORE the feature exists
+# --------------------------------------------------------------------------------------
+def test_baseline_module_assembly_still_builds_stock_pooling_with_the_passed_mode():
+    """The fallback pipeline must keep building sentence-transformers' own Pooling."""
+    load_modules = _function_def(_st_source_tree(), "_load_modules")
+
+    pooling_calls = _calls_to(load_modules, "Pooling")
+    assert len(pooling_calls) == 1, "expected exactly one stock Pooling construction"
+
+    keywords = {kw.arg: kw.value for kw in pooling_calls[0].keywords}
+    assert "word_embedding_dimension" in keywords
+    mode_argument = keywords["pooling_mode"]
+    assert (
+        isinstance(mode_argument, ast.Name) and mode_argument.id == "pooling_mode"
+    ), "stock Pooling must still receive the caller's pooling_mode unchanged"
+    assert _calls_to(load_modules, "Normalize"), "Normalize must stay in the pipeline"
+
+
+def test_baseline_auto_detected_pooling_modes_stay_stock_only():
+    """Auto-detection must never hand back an offset mode: the feature is opt-in."""
+    read_pooling_mode = _function_def(_st_source_tree(), "_read_pooling_mode")
+
+    detected: set[str] = set()
+    for node in ast.walk(read_pooling_mode):
+        if isinstance(node, ast.Dict) and any(
+            isinstance(key, ast.Constant) and key.value == "pooling_mode_lasttoken"
+            for key in node.keys
+        ):
+            detected = {value.value for value in node.values if isinstance(value, ast.Constant)}
+    assert detected == _STOCK_POOLING_MODES, f"pooling auto-detection changed: {detected}"
+
+
+def test_baseline_stock_lasttoken_pools_the_last_non_pad_position():
+    """Characterizes stock sentence-transformers `lasttoken` against the oracle."""
+    pytest.importorskip("sentence_transformers", reason = "sentence-transformers not importable")
+    from sentence_transformers.models import Pooling
+
+    mask = _mixed_layout_mask()
+    hidden = _hidden(*mask.shape, 5)
+    pooling = Pooling(word_embedding_dimension = 5, pooling_mode = "lasttoken")
+
+    pooled = pooling({"token_embeddings": hidden, "attention_mask": mask})["sentence_embedding"]
+
+    for row in range(mask.shape[0]):
+        assert torch.allclose(pooled[row], hidden[row, _last_non_pad_index(mask[row])])
+
+
+def test_baseline_stock_mean_pools_the_masked_mean():
+    """Characterizes stock `mean` pooling so a regression there cannot slip through."""
+    pytest.importorskip("sentence_transformers", reason = "sentence-transformers not importable")
+    from sentence_transformers.models import Pooling
+
+    mask = _mixed_layout_mask()
+    hidden = _hidden(*mask.shape, 5)
+    pooling = Pooling(word_embedding_dimension = 5, pooling_mode = "mean")
+
+    pooled = pooling({"token_embeddings": hidden, "attention_mask": mask})["sentence_embedding"]
+
+    for row in range(mask.shape[0]):
+        keep = mask[row].bool()
+        assert torch.allclose(pooled[row], hidden[row][keep].mean(dim = 0), atol = 1e-5)
+
+
+# --------------------------------------------------------------------------------------
+# offset pooling -- index math
+# --------------------------------------------------------------------------------------
+@pytest.mark.parametrize("num_eos_tokens", [0, 1, 16])
+def test_offset_pooling_selects_last_index_minus_num_eos_tokens(uembed, num_eos_tokens):
+    mask = _mixed_layout_mask()
+    hidden = _hidden(*mask.shape, 3)
+
+    pooled = uembed.OffsetLastTokenPooling(
+        word_embedding_dimension = 3, num_eos_tokens = num_eos_tokens
+    )({"token_embeddings": hidden, "attention_mask": mask})["sentence_embedding"]
+
+    assert pooled.shape == (mask.shape[0], 3)
+    for row in range(mask.shape[0]):
+        target = _last_non_pad_index(mask[row]) - num_eos_tokens
+        assert target >= 0, "layout must keep every row valid for this offset"
+        assert torch.equal(pooled[row], hidden[row, target])
+
+
+def test_offset_zero_reproduces_plain_lasttoken_exactly(uembed):
+    mask = _mixed_layout_mask()
+    hidden = _hidden(*mask.shape, 3)
+    features = {"token_embeddings": hidden, "attention_mask": mask}
+
+    pooled = uembed.OffsetLastTokenPooling(word_embedding_dimension = 3, num_eos_tokens = 0)(
+        dict(features)
+    )["sentence_embedding"]
+    reference = torch.stack(
+        [hidden[row, _last_non_pad_index(mask[row])] for row in range(mask.shape[0])]
+    )
+
+    assert torch.allclose(pooled, reference)
+
+
+def test_offset_zero_matches_stock_lasttoken_module(uembed):
+    """The opt-in module must be a drop-in for stock `lasttoken` when the offset is 0."""
+    pytest.importorskip("sentence_transformers", reason = "sentence-transformers not importable")
+    from sentence_transformers.models import Pooling
+
+    mask = _mixed_layout_mask()
+    hidden = _hidden(*mask.shape, 5)
+    features = {"token_embeddings": hidden, "attention_mask": mask}
+
+    stock = Pooling(word_embedding_dimension = 5, pooling_mode = "lasttoken")(dict(features))
+    offset = uembed.OffsetLastTokenPooling(word_embedding_dimension = 5, num_eos_tokens = 0)(
+        dict(features)
+    )
+
+    assert torch.allclose(offset["sentence_embedding"], stock["sentence_embedding"])
+
+
+def test_neighbouring_offsets_select_different_rows(uembed):
+    """Guards the suite itself: an off-by-one implementation cannot pass silently."""
+    mask = _mixed_layout_mask()
+    hidden = _hidden(*mask.shape, 3)
+    features = {"token_embeddings": hidden, "attention_mask": mask}
+
+    pooled = [
+        uembed.OffsetLastTokenPooling(word_embedding_dimension = 3, num_eos_tokens = offset)(
+            dict(features)
+        )["sentence_embedding"]
+        for offset in (0, 1, 2)
+    ]
+
+    assert not torch.allclose(pooled[0], pooled[1])
+    assert not torch.allclose(pooled[1], pooled[2])
+
+
+def test_offset_pooling_handles_a_fully_unpadded_batch(uembed):
+    hidden = _hidden(2, 5, 4)
+    mask = torch.ones(2, 5, dtype = torch.long)
+
+    pooled = uembed.OffsetLastTokenPooling(word_embedding_dimension = 4, num_eos_tokens = 2)(
+        {"token_embeddings": hidden, "attention_mask": mask}
+    )["sentence_embedding"]
+
+    assert torch.equal(pooled, hidden[:, 2])
+
+
+def test_offset_pooling_defaults_to_all_ones_when_no_mask_is_supplied(uembed):
+    """Mirrors sentence-transformers' Pooling, which assumes no padding without a mask."""
+    hidden = _hidden(2, 5, 4)
+
+    pooled = uembed.OffsetLastTokenPooling(word_embedding_dimension = 4, num_eos_tokens = 1)(
+        {"token_embeddings": hidden}
+    )["sentence_embedding"]
+
+    assert torch.equal(pooled, hidden[:, 3])
+
+
+def test_offset_pooling_preserves_other_features_and_tensor_metadata(uembed):
+    hidden = _hidden(2, 5, 4).to(torch.float64)
+    mask = torch.ones(2, 5, dtype = torch.long)
+    features = {"token_embeddings": hidden, "attention_mask": mask, "input_ids": torch.zeros(2, 5)}
+
+    out = uembed.OffsetLastTokenPooling(word_embedding_dimension = 4, num_eos_tokens = 0)(features)
+
+    assert out is features, "sentence-transformers modules mutate and return the features dict"
+    assert "input_ids" in out and "token_embeddings" in out
+    assert out["sentence_embedding"].dtype == torch.float64
+    assert out["sentence_embedding"].device == hidden.device
+
+
+def test_offset_pooling_backpropagates_only_into_the_selected_positions(uembed):
+    hidden = _hidden(2, 6, 3).requires_grad_(True)
+    mask = torch.zeros(2, 6, dtype = torch.long)
+    mask[0, :5] = 1
+    mask[1, :] = 1
+
+    pooled = uembed.OffsetLastTokenPooling(word_embedding_dimension = 3, num_eos_tokens = 1)(
+        {"token_embeddings": hidden, "attention_mask": mask}
+    )["sentence_embedding"]
+    pooled.sum().backward()
+
+    touched = (hidden.grad.abs().sum(dim = -1) > 0).nonzero(as_tuple = False).tolist()
+    assert touched == [[0, 3], [1, 4]]
+
+
+def test_offset_pooling_reports_the_embedding_dimension(uembed):
+    pooling = uembed.OffsetLastTokenPooling(word_embedding_dimension = 7, num_eos_tokens = 16)
+
+    assert pooling.get_sentence_embedding_dimension() == 7
+    assert pooling.get_embedding_dimension() == 7
+    assert pooling.num_eos_tokens == 16
+
+
+# --------------------------------------------------------------------------------------
+# offset pooling -- malformed input
+# --------------------------------------------------------------------------------------
+def test_offset_larger_than_the_content_raises(uembed):
+    """Pinned behaviour: raise. Negative indices would silently wrap to the tail."""
+    hidden = _hidden(2, 8, 3)
+    mask = torch.zeros(2, 8, dtype = torch.long)
+    mask[0, :8] = 1
+    mask[1, :3] = 1  # only 3 real tokens, offset 4 has nothing left to point at
+
+    with pytest.raises(ValueError, match = "num_eos_tokens"):
+        uembed.OffsetLastTokenPooling(word_embedding_dimension = 3, num_eos_tokens = 4)(
+            {"token_embeddings": hidden, "attention_mask": mask}
+        )
+
+
+def test_all_padding_row_raises(uembed):
+    hidden = _hidden(2, 4, 3)
+    mask = torch.zeros(2, 4, dtype = torch.long)
+    mask[0, :4] = 1
+
+    with pytest.raises(ValueError, match = "attention_mask"):
+        uembed.OffsetLastTokenPooling(word_embedding_dimension = 3, num_eos_tokens = 0)(
+            {"token_embeddings": hidden, "attention_mask": mask}
+        )
+
+
+def test_single_position_sequence(uembed):
+    hidden = _hidden(2, 1, 3)
+    mask = torch.ones(2, 1, dtype = torch.long)
+    features = {"token_embeddings": hidden, "attention_mask": mask}
+
+    pooled = uembed.OffsetLastTokenPooling(word_embedding_dimension = 3, num_eos_tokens = 0)(
+        dict(features)
+    )["sentence_embedding"]
+    assert torch.equal(pooled, hidden[:, 0])
+
+    with pytest.raises(ValueError, match = "num_eos_tokens"):
+        uembed.OffsetLastTokenPooling(word_embedding_dimension = 3, num_eos_tokens = 1)(dict(features))
+
+
+def test_empty_batch_returns_an_empty_embedding_matrix(uembed):
+    hidden = torch.zeros(0, 5, 3)
+    mask = torch.zeros(0, 5, dtype = torch.long)
+
+    pooled = uembed.OffsetLastTokenPooling(word_embedding_dimension = 3, num_eos_tokens = 2)(
+        {"token_embeddings": hidden, "attention_mask": mask}
+    )["sentence_embedding"]
+
+    assert pooled.shape == (0, 3)
+
+
+def test_negative_num_eos_tokens_is_rejected_at_construction(uembed):
+    with pytest.raises(ValueError, match = "num_eos_tokens"):
+        uembed.OffsetLastTokenPooling(word_embedding_dimension = 3, num_eos_tokens = -1)
+
+
+# --------------------------------------------------------------------------------------
+# num_eos_tokens comes from sparse_info.json
+# --------------------------------------------------------------------------------------
+def test_num_eos_tokens_is_read_from_sparse_info_json(uembed, tmp_path):
+    (tmp_path / "sparse_info.json").write_text(
+        json.dumps({"num_eos_tokens": 16, "other": "ignored"}), encoding = "utf-8"
+    )
+
+    assert uembed.read_num_eos_tokens(str(tmp_path)) == 16
+
+
+def test_missing_sparse_info_json_defaults_to_zero(uembed, tmp_path):
+    assert uembed.read_num_eos_tokens(str(tmp_path)) == 0
+    assert uembed.read_num_eos_tokens(str(tmp_path / "does-not-exist")) == 0
+
+
+def test_sparse_info_json_without_the_key_defaults_to_zero(uembed, tmp_path):
+    (tmp_path / "sparse_info.json").write_text(json.dumps({"unrelated": 1}), encoding = "utf-8")
+
+    assert uembed.read_num_eos_tokens(str(tmp_path)) == 0
+
+
+@pytest.mark.parametrize("value", ["sixteen", -1, 1.5, None])
+def test_malformed_num_eos_tokens_raises(uembed, tmp_path, value):
+    (tmp_path / "sparse_info.json").write_text(
+        json.dumps({"num_eos_tokens": value}), encoding = "utf-8"
+    )
+
+    with pytest.raises(ValueError, match = "num_eos_tokens"):
+        uembed.read_num_eos_tokens(str(tmp_path))
+
+
+# --------------------------------------------------------------------------------------
+# opt-in wiring
+# --------------------------------------------------------------------------------------
+def test_offset_mode_is_never_a_stock_mode(uembed):
+    for mode in _STOCK_POOLING_MODES:
+        assert not uembed.is_offset_pooling_mode(mode), f"{mode} must keep stock Pooling"
+    for mode in uembed.OFFSET_POOLING_MODES:
+        assert uembed.is_offset_pooling_mode(mode)
+    assert not uembed.is_offset_pooling_mode(None)
+    assert not _STOCK_POOLING_MODES & set(uembed.OFFSET_POOLING_MODES)
+
+
+def test_offset_pooling_is_wired_as_the_opt_in_branch_of_module_assembly():
+    """`OffsetLastTokenPooling` may only replace `Pooling` behind the mode guard."""
+    load_modules = _function_def(_st_source_tree(), "_load_modules")
+
+    guards = [
+        node
+        for node in ast.walk(load_modules)
+        if isinstance(node, ast.If)
+        and _calls_to_any_attr(node.test, "is_offset_pooling_mode")
+        and _calls_to(node, "OffsetLastTokenPooling")
+    ]
+    assert len(guards) == 1, "offset pooling must sit behind exactly one mode guard"
+
+    guard = guards[0]
+    assert not any(
+        _calls_to(statement, "Pooling") for statement in guard.body
+    ), "stock Pooling must not run on the offset branch"
+    assert any(
+        _calls_to(statement, "Pooling") for statement in guard.orelse
+    ), "stock Pooling must remain the default branch"
+    assert _calls_to(guard, "read_num_eos_tokens"), "num_eos_tokens must come from the checkpoint"
+
+    for call in _calls_to(guard, "OffsetLastTokenPooling"):
+        assert not any(
+            isinstance(kw.value, ast.Constant) and kw.arg == "num_eos_tokens"
+            for kw in call.keywords
+        ), "num_eos_tokens must not be hardcoded"
+
+
+def _calls_to_any_attr(node: ast.AST, func_name: str) -> bool:
+    for child in ast.walk(node):
+        if isinstance(child, ast.Call):
+            func = child.func
+            name = func.id if isinstance(func, ast.Name) else getattr(func, "attr", None)
+            if name == func_name:
+                return True
+    return False

--- a/tests/python/test_uembed_postproc.py
+++ b/tests/python/test_uembed_postproc.py
@@ -1,0 +1,280 @@
+# Copyright 2023-present Daniel Han-Chen & the Unsloth team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the opt-in EOS post-processor used by UEmbed (Qwen3.5) embedders.
+
+UEmbed tokenizes `<content> <|endoftext|> x num_eos_tokens` and pools the position that
+precedes that block (see `uembed_pooling.OffsetLastTokenPooling`), so the tokenizer must
+actually emit the block. `build_eos_post_processor` attaches a
+`tokenizers.processors.TemplateProcessing` that does exactly that.
+
+Everything here is CPU-only and deterministic: the tokenizer is a synthetic WordLevel
+fast tokenizer built in-process, so there is no download and no model.
+
+Layers:
+- Baseline characterization: a tokenizer with `num_eos_tokens = 0` is byte-for-byte the
+  tokenizer it started as (these pass on the pre-change tree).
+- Behavioural tests: the ACTUAL token id sequence is asserted, never the template string
+  that was used to build it.
+- Structural wiring test: proves the call sits behind a `num_eos_tokens > 0` guard without
+  importing unsloth (the package import needs an accelerator + unsloth_zoo, which CPU boxes
+  lack).
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_ST_SOURCE_PATH = _REPO_ROOT / "unsloth" / "models" / "sentence_transformer.py"
+_POOLING_SOURCE_PATH = _REPO_ROOT / "unsloth" / "models" / "uembed_pooling.py"
+
+_EOS_TOKEN = "<|endoftext|>"
+_EOS_ID = 7
+_VOCAB = {"<unk>": 0, "hello": 1, "world": 2, _EOS_TOKEN: _EOS_ID}
+_CONTENT_IDS = [1, 2]  # "hello world" under _VOCAB
+
+
+# --------------------------------------------------------------------------------------
+# helpers
+# --------------------------------------------------------------------------------------
+def _load_uembed_pooling():
+    """Load `unsloth.models.uembed_pooling`, falling back to a direct file load.
+
+    `import unsloth` runs the accelerator / unsloth_zoo gate, which legitimately refuses
+    to import on a CPU-only machine. The module itself only needs torch (and, lazily,
+    tokenizers), so the fallback executes the exact same source file rather than a stub.
+    """
+    try:
+        from unsloth.models import uembed_pooling  # noqa: PLC0415
+        return uembed_pooling
+    except Exception:  # accelerator gate / missing unsloth_zoo / heavy optional deps
+        pass
+
+    name = "unsloth_uembed_pooling_direct"
+    if name in sys.modules:
+        return sys.modules[name]
+    assert _POOLING_SOURCE_PATH.exists(), f"missing module file: {_POOLING_SOURCE_PATH}"
+    spec = importlib.util.spec_from_file_location(name, _POOLING_SOURCE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope = "module")
+def uembed():
+    return _load_uembed_pooling()
+
+
+def _fast_tokenizer(vocab: dict[str, int] | None = None):
+    """A real (tiny, synthetic) `PreTrainedTokenizerFast` -- no download, no network."""
+    pytest.importorskip("tokenizers", reason = "tokenizers not importable")
+    transformers = pytest.importorskip("transformers", reason = "transformers not importable")
+    from tokenizers import Tokenizer
+    from tokenizers.models import WordLevel
+    from tokenizers.pre_tokenizers import Whitespace
+
+    backend = Tokenizer(WordLevel(dict(_VOCAB if vocab is None else vocab), unk_token = "<unk>"))
+    backend.pre_tokenizer = Whitespace()
+    return transformers.PreTrainedTokenizerFast(tokenizer_object = backend, unk_token = "<unk>")
+
+
+def _ids(tokenizer, *text: str) -> list[int]:
+    return tokenizer(*text)["input_ids"]
+
+
+def _st_source_tree() -> ast.Module:
+    return ast.parse(_ST_SOURCE_PATH.read_text(encoding = "utf-8"))
+
+
+def _function_def(tree: ast.Module, name: str) -> ast.FunctionDef:
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == name:
+            return node
+    raise AssertionError(f"{name} not found in {_ST_SOURCE_PATH}")
+
+
+def _calls_to(node: ast.AST, func_name: str) -> list[ast.Call]:
+    calls = []
+    for child in ast.walk(node):
+        if isinstance(child, ast.Call):
+            func = child.func
+            name = func.id if isinstance(func, ast.Name) else getattr(func, "attr", None)
+            if name == func_name:
+                calls.append(child)
+    return calls
+
+
+# --------------------------------------------------------------------------------------
+# baseline characterization -- these pass BEFORE the feature exists
+# --------------------------------------------------------------------------------------
+def test_baseline_untouched_tokenizer_appends_nothing():
+    tokenizer = _fast_tokenizer()
+
+    assert _ids(tokenizer, "hello world") == _CONTENT_IDS
+    assert tokenizer.backend_tokenizer.post_processor is None
+
+
+def test_num_eos_tokens_zero_leaves_the_tokenizer_byte_for_byte_unchanged(uembed):
+    """The default (non-UEmbed) path: no post-processor, no padding-side rewrite."""
+    tokenizer = _fast_tokenizer()
+    tokenizer.padding_side = "left"
+
+    result = uembed.build_eos_post_processor(tokenizer, 0)
+
+    assert result is None
+    assert tokenizer.backend_tokenizer.post_processor is None
+    assert _ids(tokenizer, "hello world") == _ids(_fast_tokenizer(), "hello world")
+    assert tokenizer.padding_side == "left", "num_eos_tokens = 0 must not touch padding_side"
+
+
+# --------------------------------------------------------------------------------------
+# behaviour -- assert the ACTUAL token ids
+# --------------------------------------------------------------------------------------
+@pytest.mark.parametrize("num_eos_tokens", [1, 16])
+def test_exactly_n_trailing_eos_ids_are_appended(uembed, num_eos_tokens):
+    tokenizer = _fast_tokenizer()
+
+    uembed.build_eos_post_processor(tokenizer, num_eos_tokens)
+    ids = _ids(tokenizer, "hello world")
+
+    assert ids[: len(_CONTENT_IDS)] == _CONTENT_IDS, "content ids must be unchanged"
+    assert ids[len(_CONTENT_IDS) :] == [_EOS_ID] * num_eos_tokens
+    assert len(ids) == len(_CONTENT_IDS) + num_eos_tokens
+    assert ids.count(_EOS_ID) == num_eos_tokens, "the block is the only source of EOS ids"
+
+
+def test_neighbouring_block_sizes_differ(uembed):
+    """Guards the suite itself: an off-by-one template cannot pass silently."""
+    lengths = []
+    for num_eos_tokens in (1, 2, 3):
+        tokenizer = _fast_tokenizer()
+        uembed.build_eos_post_processor(tokenizer, num_eos_tokens)
+        lengths.append(len(_ids(tokenizer, "hello world")))
+
+    assert lengths == [len(_CONTENT_IDS) + n for n in (1, 2, 3)]
+
+
+def test_pair_encoding_appends_the_block_after_both_segments(uembed):
+    tokenizer = _fast_tokenizer()
+
+    uembed.build_eos_post_processor(tokenizer, 3)
+    ids = _ids(tokenizer, "hello", "world")
+
+    assert ids == [1, _EOS_ID, _EOS_ID, _EOS_ID, 2, _EOS_ID, _EOS_ID, _EOS_ID]
+
+
+def test_empty_input_still_yields_exactly_the_block(uembed):
+    """Malformed/degenerate input: an empty string must not lose or duplicate the block."""
+    tokenizer = _fast_tokenizer()
+
+    uembed.build_eos_post_processor(tokenizer, 16)
+
+    assert _ids(tokenizer, "") == [_EOS_ID] * 16
+
+
+def test_padding_side_is_forced_right(uembed):
+    """Offset pooling counts back from the last real token, so padding must be on the right."""
+    tokenizer = _fast_tokenizer()
+    tokenizer.padding_side = "left"
+
+    uembed.build_eos_post_processor(tokenizer, 16)
+
+    assert tokenizer.padding_side == "right"
+
+
+def test_a_processor_is_unwrapped_to_its_inner_tokenizer(uembed):
+    """The model load path may return a processor object rather than a bare tokenizer."""
+
+    class _Processor:
+        def __init__(self, tokenizer):
+            self.tokenizer = tokenizer
+            self.image_processor = object()
+
+    tokenizer = _fast_tokenizer()
+    processor = _Processor(tokenizer)
+
+    uembed.build_eos_post_processor(processor, 16)
+
+    assert _ids(tokenizer, "hello world") == _CONTENT_IDS + [_EOS_ID] * 16
+
+
+def test_eos_token_missing_from_the_vocabulary_raises(uembed):
+    """Silently appending `unk` ids would corrupt every embedding the model produces."""
+    tokenizer = _fast_tokenizer({"<unk>": 0, "hello": 1, "world": 2})
+
+    with pytest.raises(ValueError, match = "endoftext"):
+        uembed.build_eos_post_processor(tokenizer, 16)
+
+
+def test_tokenizer_without_a_fast_backend_raises(uembed):
+    class _SlowTokenizer:
+        padding_side = "left"
+
+        def convert_tokens_to_ids(self, token):
+            return _EOS_ID
+
+    with pytest.raises(ValueError, match = "fast"):
+        uembed.build_eos_post_processor(_SlowTokenizer(), 16)
+
+
+@pytest.mark.parametrize("value", [-1, 1.5, "16", None, True])
+def test_malformed_num_eos_tokens_raises(uembed, value):
+    with pytest.raises(ValueError, match = "num_eos_tokens"):
+        uembed.build_eos_post_processor(_fast_tokenizer(), value)
+
+
+# --------------------------------------------------------------------------------------
+# opt-in wiring
+# --------------------------------------------------------------------------------------
+def test_post_processor_is_wired_behind_a_num_eos_tokens_guard():
+    """`build_eos_post_processor` may only run when the checkpoint asks for a block."""
+    from_pretrained = _function_def(_st_source_tree(), "from_pretrained")
+
+    calls = _calls_to(from_pretrained, "build_eos_post_processor")
+    assert len(calls) == 1, "expected exactly one post-processor attachment"
+
+    guards = [
+        node
+        for node in ast.walk(from_pretrained)
+        if isinstance(node, ast.If) and _calls_to(node, "build_eos_post_processor")
+    ]
+    positive_guards = [
+        node
+        for node in guards
+        if any(
+            isinstance(compare, ast.Compare)
+            and isinstance(compare.left, ast.Name)
+            and compare.left.id == "num_eos_tokens"
+            and isinstance(compare.ops[0], ast.Gt)
+            and isinstance(compare.comparators[0], ast.Constant)
+            and compare.comparators[0].value == 0
+            for compare in ast.walk(node.test)
+        )
+    ]
+    assert len(positive_guards) == 1, "attachment must sit behind `num_eos_tokens > 0`"
+
+    assert _calls_to(
+        from_pretrained, "read_num_eos_tokens"
+    ), "num_eos_tokens must come from the checkpoint's sparse_info.json"
+    for call in calls:
+        assert not any(
+            isinstance(argument, ast.Constant) for argument in call.args
+        ), "the block size must not be hardcoded"

--- a/tests/python/test_uembed_seam.py
+++ b/tests/python/test_uembed_seam.py
@@ -1,0 +1,179 @@
+# Copyright 2023-present Daniel Han-Chen & the Unsloth team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""CPU-only regression tests for the UEmbed EOS/pooling assembly seam.
+
+The production package cannot be imported on a CPU-only runner, so these tests extract
+and execute the small module-selection function from ``sentence_transformer.py``. The
+objects passed to it implement the same observable pooling contract as sentence-
+transformers modules; no model, network, accelerator, or timing is involved.
+"""
+
+from __future__ import annotations
+
+import ast
+from collections import OrderedDict
+from pathlib import Path
+
+import pytest
+
+_SOURCE_PATH = (
+    Path(__file__).resolve().parents[2] / "unsloth" / "models" / "sentence_transformer.py"
+)
+
+
+class _StockPooling:
+    def __init__(
+        self,
+        dimension: int,
+        mode: str = "lasttoken",
+    ) -> None:
+        self.dimension = dimension
+        self.mode = mode
+
+    def get_sentence_embedding_dimension(self) -> int:
+        return self.dimension
+
+
+class _OffsetPooling:
+    def __init__(self, word_embedding_dimension: int, num_eos_tokens: int) -> None:
+        self.word_embedding_dimension = word_embedding_dimension
+        self.num_eos_tokens = num_eos_tokens
+
+    def get_sentence_embedding_dimension(self) -> int:
+        return self.word_embedding_dimension
+
+
+class _Transformer:
+    pass
+
+
+class _Normalize:
+    pass
+
+
+def _load_selection_function():
+    source = _SOURCE_PATH.read_text(encoding = "utf-8")
+    tree = ast.parse(source, filename = str(_SOURCE_PATH))
+    function = next(
+        (
+            node
+            for node in tree.body
+            if isinstance(node, ast.FunctionDef) and node.name == "_ensure_uembed_offset_pooling"
+        ),
+        None,
+    )
+    assert function is not None, "UEmbed pooling assembly safeguard is missing"
+
+    isolated = ast.Module(body = [function], type_ignores = [])
+    ast.fix_missing_locations(isolated)
+    namespace = {"OffsetLastTokenPooling": _OffsetPooling}
+    exec(compile(isolated, str(_SOURCE_PATH), "exec"), namespace)
+    return namespace["_ensure_uembed_offset_pooling"]
+
+
+@pytest.fixture(scope = "module")
+def ensure_offset_pooling():
+    return _load_selection_function()
+
+
+def _stock_chain(mode: str = "lasttoken") -> OrderedDict:
+    return OrderedDict(
+        transformer = _Transformer(),
+        pooling = _StockPooling(7, mode = mode),
+        normalize = _Normalize(),
+    )
+
+
+@pytest.mark.parametrize("stock_mode", ["lasttoken", "mean"])
+def test_positive_num_eos_replaces_stock_modules_json_pooling(ensure_offset_pooling, stock_mode):
+    """A UEmbed checkpoint can never leave stock pooling in the assembled chain."""
+    modules = _stock_chain(stock_mode)
+    transformer = modules["transformer"]
+    normalize = modules["normalize"]
+
+    ensure_offset_pooling(
+        modules,
+        num_eos_tokens = 3,
+        hidden_size = 99,
+        pooling_class = _StockPooling,
+    )
+
+    assert list(modules) == ["transformer", "pooling", "normalize"]
+    assert modules["transformer"] is transformer
+    assert modules["normalize"] is normalize
+    assert isinstance(modules["pooling"], _OffsetPooling)
+    assert modules["pooling"].num_eos_tokens == 3
+    assert modules["pooling"].word_embedding_dimension == 7
+
+
+def test_positive_num_eos_refuses_an_unreplaceable_pooling_chain(ensure_offset_pooling):
+    """If safe replacement is impossible, loading fails before encode instead of mispooling."""
+    modules = OrderedDict(transformer = _Transformer(), normalize = _Normalize())
+
+    with pytest.raises(RuntimeError) as error:
+        ensure_offset_pooling(
+            modules,
+            num_eos_tokens = 2,
+            hidden_size = 7,
+            pooling_class = _StockPooling,
+        )
+
+    message = str(error.value)
+    assert "Unsloth:" in message
+    assert "OffsetLastTokenPooling" in message
+    assert "EOS" in message
+
+
+def test_zero_num_eos_preserves_stock_pooling_exactly(ensure_offset_pooling):
+    """Non-UEmbed checkpoints retain the existing stock module and chain unchanged."""
+    modules = _stock_chain("mean")
+    before_items = list(modules.items())
+
+    ensure_offset_pooling(
+        modules,
+        num_eos_tokens = 0,
+        hidden_size = 99,
+        pooling_class = _StockPooling,
+    )
+
+    assert list(modules.items()) == before_items
+    assert type(modules["pooling"]) is _StockPooling
+    assert modules["pooling"].mode == "mean"
+
+
+def test_from_pretrained_passes_the_single_resolved_eos_count_into_assembly():
+    """The metadata value driving EOS append is also the value driving pooling selection."""
+    tree = ast.parse(_SOURCE_PATH.read_text(encoding = "utf-8"), filename = str(_SOURCE_PATH))
+    class_node = next(node for node in tree.body if isinstance(node, ast.ClassDef))
+    from_pretrained = next(
+        node
+        for node in ast.walk(class_node)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and node.name == "from_pretrained"
+    )
+
+    reads = [
+        node
+        for node in ast.walk(from_pretrained)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "read_num_eos_tokens"
+    ]
+    assert len(reads) == 1, "from_pretrained must resolve sparse_info.json exactly once"
+
+    assembly_call = next(
+        node
+        for node in ast.walk(from_pretrained)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "_load_modules"
+    )
+    keyword = next((kw for kw in assembly_call.keywords if kw.arg == "num_eos_tokens"), None)
+    assert keyword is not None
+    assert isinstance(keyword.value, ast.Name) and keyword.value.id == "num_eos_tokens"

--- a/tests/python/test_uembed_sidecar.py
+++ b/tests/python/test_uembed_sidecar.py
@@ -1,0 +1,442 @@
+# Copyright 2023-present Daniel Han-Chen & the Unsloth team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the adapter-level UEmbed sparse sidecar (save next to the LoRA adapter).
+
+The SPLADE heads are trained, so they must be written out with the adapter and read back
+when the saved directory is loaded again. They stay a SIDECAR file (`sparse_weights.pt` +
+`sparse_info.json`), never folded into the merged safetensors, which is what lets them
+survive a `merged_16bit` export.
+
+Two properties carry the weight here:
+
+  * opt-in - a model with no SPLADE head writes NO sidecar and leaves the save directory
+    byte-for-byte as it was, so every existing dense embedder is unaffected;
+  * attach-aware reload - loading into a model that already carries a head REPOPULATES
+    that head instead of appending a second one, which would silently double the sparse
+    dimension and break the pipeline.
+
+`unsloth` and `sentence_transformers` are not importable on a CPU-only box, so the real
+sidecar module is loaded from its source file and exercised against a stub pipeline that
+mimics the sentence-transformers module chain. CPU-only, seeded, download-free; every save
+goes to pytest's `tmp_path`.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+import torch
+from torch import nn
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_MODELS_DIR = _REPO_ROOT / "unsloth" / "models"
+
+_HIDDEN_DIM = 4
+# Deliberately neither 16 nor uniform: the head count and every head width must come from
+# the checkpoint, not from a constant.
+_HEAD_DIMS = [3, 4, 5]
+_NUM_EOS = 3
+
+_SPARSE_WEIGHTS = "sparse_weights.pt"
+_SPARSE_INFO = "sparse_info.json"
+
+
+# --------------------------------------------------------------------------------------
+# module loading
+# --------------------------------------------------------------------------------------
+def _load_from_source(module_name: str, file_name: str):
+    """Execute the real source file directly.
+
+    `import unsloth` runs the accelerator / unsloth_zoo gate, which legitimately refuses to
+    import on a CPU-only machine. The modules under test depend on torch only, so this
+    fallback runs the exact same source -- it loads it, it does not stub it out. The module
+    names match the ones the sources themselves use, so every loader sees ONE copy of each
+    module (and `isinstance` keeps working across them).
+    """
+    if module_name in sys.modules:
+        return sys.modules[module_name]
+    source_path = _MODELS_DIR / file_name
+    assert source_path.exists(), f"missing module file: {source_path}"
+    spec = importlib.util.spec_from_file_location(module_name, source_path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope = "module")
+def splade():
+    try:
+        from unsloth.models import uembed_splade  # noqa: PLC0415
+        return uembed_splade
+    except Exception:  # accelerator gate / missing unsloth_zoo / heavy optional deps
+        return _load_from_source("unsloth_uembed_splade_direct", "uembed_splade.py")
+
+
+@pytest.fixture(scope = "module")
+def wiring():
+    try:
+        from unsloth.models import uembed_wiring  # noqa: PLC0415
+        return uembed_wiring
+    except Exception:
+        return _load_from_source("unsloth_uembed_wiring_direct", "uembed_wiring.py")
+
+
+@pytest.fixture(scope = "module")
+def sidecar():
+    try:
+        from unsloth.models import uembed_sidecar  # noqa: PLC0415
+        return uembed_sidecar
+    except Exception:
+        return _load_from_source("unsloth_uembed_sidecar_direct", "uembed_sidecar.py")
+
+
+# --------------------------------------------------------------------------------------
+# stub pipeline: the sentence-transformers module chain, minus sentence-transformers
+# --------------------------------------------------------------------------------------
+class _StubTransformer(nn.Module):
+    """Stands in for the ST `Transformer` module (the backbone that owns the dtype)."""
+
+    def __init__(self, seed: int = 5) -> None:
+        super().__init__()
+        generator = torch.Generator().manual_seed(seed)
+        self.table = nn.Parameter(torch.randn(7, _HIDDEN_DIM, generator = generator))
+
+    def forward(self, features: dict) -> dict:
+        features["token_embeddings"] = self.table[features["input_ids"]]
+        return features
+
+
+class _StubPooling(nn.Module):
+    def forward(self, features: dict) -> dict:
+        return features
+
+
+class _StubNormalize(nn.Module):
+    def forward(self, features: dict) -> dict:
+        return features
+
+
+class _StubSentenceTransformer(nn.Sequential):
+    """Minimal serialized-chain stand-in with a stock, process-local `encode` method."""
+
+    def __init__(self, *modules) -> None:
+        super().__init__(*modules)
+        self.encode_calls = 0
+
+    def encode(self, sentences):
+        self.encode_calls += 1
+        return ("stock-dense", sentences)
+
+
+def _make_pipeline() -> _StubSentenceTransformer:
+    return _StubSentenceTransformer(_StubTransformer(), _StubPooling(), _StubNormalize())
+
+
+def _make_head(splade_module, seed: int = 11):
+    generator = torch.Generator().manual_seed(seed)
+    heads = [torch.randn(dim, _HIDDEN_DIM, generator = generator) for dim in _HEAD_DIMS]
+    biases = [torch.randn(dim, generator = generator) for dim in _HEAD_DIMS]
+    return splade_module.SpladeHead(heads, biases, num_eos_tokens = _NUM_EOS)
+
+
+def _sparse_heads(model, splade_module) -> list:
+    return [module for module in model.modules() if isinstance(module, splade_module.SpladeHead)]
+
+
+def _only_head(model, splade_module):
+    heads = _sparse_heads(model, splade_module)
+    assert len(heads) == 1, f"expected exactly one SpladeHead, found {len(heads)}"
+    return heads[0]
+
+
+def _head_values(head) -> list[torch.Tensor]:
+    return [weight.detach().clone() for weight in head.sparse_lm_heads] + [
+        bias.detach().clone() for bias in head.sparse_bias
+    ]
+
+
+def _mutate(head, offset: float = 0.25) -> None:
+    """Stand in for training: move every head parameter away from its loaded value."""
+    with torch.no_grad():
+        for index, weight in enumerate(head.sparse_lm_heads):
+            weight.add_(offset * (index + 1))
+        for index, bias in enumerate(head.sparse_bias):
+            bias.add_(-offset * (index + 1))
+
+
+@pytest.fixture
+def sparse_model(wiring, splade):
+    model = _make_pipeline()
+    assert wiring.attach_uembed_sparse_output(model, _make_head(splade)) is True
+    return model
+
+
+# --------------------------------------------------------------------------------------
+# 1. opt-in: a model with no sparse head writes no sidecar and changes nothing
+# --------------------------------------------------------------------------------------
+def test_dense_only_save_writes_no_sidecar(sidecar, tmp_path):
+    save_directory = tmp_path / "dense"
+    save_directory.mkdir()
+    (save_directory / "adapter_model.safetensors").write_bytes(b"adapter")
+    before = {path.name: path.read_bytes() for path in save_directory.iterdir()}
+
+    wrote = sidecar.save_uembed_sparse_sidecar(_make_pipeline(), str(save_directory))
+
+    assert wrote is False
+    after = {path.name: path.read_bytes() for path in save_directory.iterdir()}
+    assert after == before, "a dense-only save directory must be left untouched"
+    assert not (save_directory / _SPARSE_WEIGHTS).exists()
+    assert not (save_directory / _SPARSE_INFO).exists()
+
+
+def test_dense_only_load_attaches_nothing(sidecar, splade, tmp_path):
+    save_directory = tmp_path / "dense"
+    save_directory.mkdir()
+    model = _make_pipeline()
+    module_count = len(list(model.children()))
+
+    loaded = sidecar.load_uembed_sparse_sidecar(model, str(save_directory))
+
+    assert loaded is False
+    assert len(list(model.children())) == module_count
+    assert _sparse_heads(model, splade) == []
+
+
+# --------------------------------------------------------------------------------------
+# 2. save: the sidecar carries UEmbed's own key layout
+# --------------------------------------------------------------------------------------
+def test_save_writes_sparse_weights_and_info(sidecar, splade, sparse_model, tmp_path):
+    save_directory = tmp_path / "sparse"
+    head = _only_head(sparse_model, splade)
+
+    wrote = sidecar.save_uembed_sparse_sidecar(sparse_model, str(save_directory))
+
+    assert wrote is True
+    weights_path = save_directory / _SPARSE_WEIGHTS
+    info_path = save_directory / _SPARSE_INFO
+    assert weights_path.is_file() and info_path.is_file()
+
+    state = torch.load(weights_path, map_location = "cpu", weights_only = True)
+    assert set(state) == {"sparse_lm_heads", "sparse_bias"}
+    assert len(state["sparse_lm_heads"]) == len(head.sparse_lm_heads) == len(_HEAD_DIMS)
+    assert len(state["sparse_bias"]) == len(head.sparse_bias)
+    assert [tuple(weight.shape) for weight in state["sparse_lm_heads"]] == [
+        (dim, _HIDDEN_DIM) for dim in _HEAD_DIMS
+    ]
+    assert [tuple(bias.shape) for bias in state["sparse_bias"]] == [(dim,) for dim in _HEAD_DIMS]
+
+    info = json.loads(info_path.read_text(encoding = "utf-8"))
+    assert info["num_eos_tokens"] == _NUM_EOS
+
+
+def test_save_keeps_the_merged_weights_free_of_sparse_heads(sidecar, sparse_model, tmp_path):
+    """merged_16bit round-trip: the heads land beside the export, never inside it."""
+    save_directory = tmp_path / "merged"
+    save_directory.mkdir()
+    merged = save_directory / "model.safetensors"
+    merged.write_bytes(b"merged-16bit-weights")
+
+    assert sidecar.save_uembed_sparse_sidecar(sparse_model, str(save_directory)) is True
+
+    assert merged.read_bytes() == b"merged-16bit-weights"
+    assert (save_directory / _SPARSE_WEIGHTS).is_file()
+
+
+def test_save_preserves_other_sparse_info_keys(sidecar, sparse_model, tmp_path):
+    save_directory = tmp_path / "sparse"
+    save_directory.mkdir()
+    (save_directory / _SPARSE_INFO).write_text(
+        json.dumps({"num_eos_tokens": 0, "sparse_dim": 12}), encoding = "utf-8"
+    )
+
+    assert sidecar.save_uembed_sparse_sidecar(sparse_model, str(save_directory)) is True
+
+    info = json.loads((save_directory / _SPARSE_INFO).read_text(encoding = "utf-8"))
+    assert info == {"num_eos_tokens": _NUM_EOS, "sparse_dim": 12}
+
+
+# --------------------------------------------------------------------------------------
+# 3. reload: the SAVED values come back, into a trainable head
+# --------------------------------------------------------------------------------------
+def test_reload_restores_the_saved_head_into_a_fresh_model(sidecar, splade, sparse_model, tmp_path):
+    """Stale-state probe: the head is trained (mutated) BEFORE the save."""
+    save_directory = tmp_path / "sparse"
+    trained = _only_head(sparse_model, splade)
+    _mutate(trained)
+    expected = _head_values(trained)
+    assert sidecar.save_uembed_sparse_sidecar(sparse_model, str(save_directory)) is True
+
+    fresh = _make_pipeline()
+    module_count = len(list(fresh.children()))
+
+    loaded = sidecar.load_uembed_sparse_sidecar(fresh, str(save_directory))
+
+    assert loaded is True
+    assert len(list(fresh.children())) == module_count + 1
+    reloaded = _only_head(fresh, splade)
+    assert reloaded.num_eos_tokens == _NUM_EOS
+    for saved, restored in zip(expected, _head_values(reloaded)):
+        assert torch.allclose(saved, restored)
+    assert all(weight.requires_grad for weight in reloaded.sparse_lm_heads)
+    assert all(bias.requires_grad for bias in reloaded.sparse_bias)
+
+
+def test_reload_is_attach_aware(sidecar, wiring, splade, sparse_model, tmp_path):
+    """Loading into a model that already has a head must not stack a second one."""
+    save_directory = tmp_path / "sparse"
+    trained = _only_head(sparse_model, splade)
+    _mutate(trained)
+    expected = _head_values(trained)
+    assert sidecar.save_uembed_sparse_sidecar(sparse_model, str(save_directory)) is True
+
+    # A model rebuilt from the saved directory already carries the checkpoint's head.
+    target = _make_pipeline()
+    wiring.attach_uembed_sparse_output(target, _make_head(splade, seed = 99))
+    module_count = len(list(target.children()))
+    stale = _head_values(_only_head(target, splade))
+
+    loaded = sidecar.load_uembed_sparse_sidecar(target, str(save_directory))
+
+    assert loaded is True
+    assert len(list(target.children())) == module_count, "the reload appended a second module"
+    reloaded = _only_head(target, splade)
+    for saved, restored in zip(expected, _head_values(reloaded)):
+        assert torch.allclose(saved, restored)
+    assert any(
+        not torch.allclose(old, restored) for old, restored in zip(stale, _head_values(reloaded))
+    ), "the reload kept the stale in-memory values"
+    assert all(weight.requires_grad for weight in reloaded.sparse_lm_heads)
+
+
+def test_reload_survives_a_merged_export_round_trip(sidecar, splade, sparse_model, tmp_path):
+    """Save -> merged export overwrites the weights -> reload still finds the heads."""
+    save_directory = tmp_path / "roundtrip"
+    trained = _only_head(sparse_model, splade)
+    _mutate(trained, offset = 0.5)
+    expected = _head_values(trained)
+
+    assert sidecar.save_uembed_sparse_sidecar(sparse_model, str(save_directory)) is True
+    # The merged_16bit export rewrites the backbone weights after the sidecar is written.
+    (save_directory / "model.safetensors").write_bytes(b"merged-16bit-weights")
+    (save_directory / "config.json").write_text("{}", encoding = "utf-8")
+
+    fresh = _make_pipeline()
+    assert sidecar.load_uembed_sparse_sidecar(fresh, str(save_directory)) is True
+    for saved, restored in zip(expected, _head_values(_only_head(fresh, splade))):
+        assert torch.allclose(saved, restored)
+
+
+def test_reload_reads_the_saved_num_eos_tokens(sidecar, splade, wiring, tmp_path):
+    """The EOS-block size is checkpoint data, never a constant."""
+    save_directory = tmp_path / "sparse"
+    model = _make_pipeline()
+    generator = torch.Generator().manual_seed(3)
+    heads = [torch.randn(dim, _HIDDEN_DIM, generator = generator) for dim in _HEAD_DIMS]
+    biases = [torch.randn(dim, generator = generator) for dim in _HEAD_DIMS]
+    wiring.attach_uembed_sparse_output(model, splade.SpladeHead(heads, biases, num_eos_tokens = 2))
+
+    assert sidecar.save_uembed_sparse_sidecar(model, str(save_directory)) is True
+    assert json.loads((save_directory / _SPARSE_INFO).read_text(encoding = "utf-8")) == {
+        "num_eos_tokens": 2
+    }
+
+    fresh = _make_pipeline()
+    assert sidecar.load_uembed_sparse_sidecar(fresh, str(save_directory)) is True
+    assert _only_head(fresh, splade).num_eos_tokens == 2
+
+
+def test_reload_replaces_a_head_of_a_different_shape(sidecar, wiring, splade, tmp_path):
+    """A sidecar from another checkpoint still lands as exactly one head."""
+    save_directory = tmp_path / "sparse"
+    source = _make_pipeline()
+    generator = torch.Generator().manual_seed(7)
+    heads = [torch.randn(dim, _HIDDEN_DIM, generator = generator) for dim in (2, 6)]
+    biases = [torch.randn(dim, generator = generator) for dim in (2, 6)]
+    wiring.attach_uembed_sparse_output(source, splade.SpladeHead(heads, biases, num_eos_tokens = 2))
+    expected = _head_values(_only_head(source, splade))
+    assert sidecar.save_uembed_sparse_sidecar(source, str(save_directory)) is True
+
+    target = _make_pipeline()
+    wiring.attach_uembed_sparse_output(target, _make_head(splade))
+    module_count = len(list(target.children()))
+
+    assert sidecar.load_uembed_sparse_sidecar(target, str(save_directory)) is True
+
+    assert len(list(target.children())) == module_count
+    reloaded = _only_head(target, splade)
+    assert reloaded.num_heads == 2
+    for saved, restored in zip(expected, _head_values(reloaded)):
+        assert torch.allclose(saved, restored)
+
+
+def test_reloaded_head_produces_the_saved_sparse_vector(sidecar, splade, sparse_model, tmp_path):
+    """End-to-end: same hidden states in, same sparse vector out, after a round-trip."""
+    save_directory = tmp_path / "sparse"
+    trained = _only_head(sparse_model, splade)
+    _mutate(trained)
+    generator = torch.Generator().manual_seed(23)
+    hidden = torch.randn(2, 6, _HIDDEN_DIM, generator = generator)
+    mask = torch.ones(2, 6, dtype = torch.long)
+    with torch.no_grad():
+        expected = trained(hidden, mask, splade.SPLADE_LAST)
+
+    assert sidecar.save_uembed_sparse_sidecar(sparse_model, str(save_directory)) is True
+    fresh = _make_pipeline()
+    assert sidecar.load_uembed_sparse_sidecar(fresh, str(save_directory)) is True
+    with torch.no_grad():
+        restored = _only_head(fresh, splade)(hidden, mask, splade.SPLADE_LAST)
+
+    assert torch.allclose(expected, restored)
+
+
+def test_reload_is_idempotent(sidecar, splade, sparse_model, tmp_path):
+    save_directory = tmp_path / "sparse"
+    assert sidecar.save_uembed_sparse_sidecar(sparse_model, str(save_directory)) is True
+
+    fresh = _make_pipeline()
+    module_count = len(list(fresh.children()))
+    assert sidecar.load_uembed_sparse_sidecar(fresh, str(save_directory)) is True
+    assert sidecar.load_uembed_sparse_sidecar(fresh, str(save_directory)) is True
+
+    assert len(list(fresh.children())) == module_count + 1
+    assert len(_sparse_heads(fresh, splade)) == 1
+
+
+def test_attach_aware_reload_restores_encode_patch_once(
+    sidecar, wiring, splade, sparse_model, tmp_path
+):
+    """A sparse module rebuilt by modules.json must regain its non-serialized wrapper."""
+    save_directory = tmp_path / "sparse"
+    assert sidecar.save_uembed_sparse_sidecar(sparse_model, str(save_directory)) is True
+
+    target = _make_pipeline()
+    target.add_module("3", wiring.UEmbedSparseOutput(_make_head(splade, seed = 99)))
+    baseline = target.encode("document")
+    assert not hasattr(target, "_unsloth_uembed_original_encode")
+
+    assert sidecar.load_uembed_sparse_sidecar(target, str(save_directory)) is True
+    patched_encode = target.encode
+    assert hasattr(target, "_unsloth_uembed_original_encode")
+    assert target.encode("document", output_mode = "dense") == baseline
+    assert target.encode_calls == 2
+
+    assert sidecar.load_uembed_sparse_sidecar(target, str(save_directory)) is True
+    assert target.encode is patched_encode
+    assert len(_sparse_heads(target, splade)) == 1

--- a/tests/python/test_uembed_splade.py
+++ b/tests/python/test_uembed_splade.py
@@ -1,0 +1,459 @@
+# Copyright 2023-present Daniel Han-Chen & the Unsloth team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for `SpladeHead`, the UEmbed (Qwen3.5) sparse pooling sidecar.
+
+UEmbed ships `sparse_weights.pt` next to the backbone weights: `num_eos_tokens` linear
+heads (`sparse_lm_heads` + `sparse_bias`) that project hidden states onto vocabulary
+logits. Two pooling modes build the sparse vector (paper Eq. 3-4):
+
+- `splade.last`: head `i` reads the hidden state at `last_index - ((N - 1) - i)`, i.e.
+  head 0 reads the first EOS slot and head N-1 the last one; the per-head logits are
+  concatenated and passed through `log1p(relu(.))`.
+- `splade.max`: head 0 is applied to every position, `log1p(relu(.))` is taken, padding
+  is masked out, and the maximum over the sequence wins.
+
+Everything here is CPU-only, deterministic (seeded synthetic tensors, no download) and
+torch-only. Every value assertion runs against an INDEPENDENT python-loop oracle built
+from the paper formula -- never against a copy of the module's own expression -- so a
+mistake mirrored into both sides cannot pass.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import math
+import sys
+from pathlib import Path
+
+import pytest
+import torch
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SPLADE_SOURCE_PATH = _REPO_ROOT / "unsloth" / "models" / "uembed_splade.py"
+
+_HIDDEN_DIM = 4
+# Deliberately unequal per-head vocabularies: a `16 * V` shortcut cannot pass the
+# concatenated-dimension assertion, only a real `sum(V_i)` can.
+_HEAD_DIMS = [3, 4, 5] * 5 + [3]
+_NUM_EOS = 16
+
+
+# --------------------------------------------------------------------------------------
+# helpers
+# --------------------------------------------------------------------------------------
+def _load_uembed_splade():
+    """Load `unsloth.models.uembed_splade`, falling back to a direct file load.
+
+    `import unsloth` runs the accelerator / unsloth_zoo gate, which legitimately refuses
+    to import on a CPU-only machine. The splade module depends on torch only, so the
+    fallback executes the exact same source file -- it loads it, it does not stub it out.
+    """
+    try:
+        from unsloth.models import uembed_splade  # noqa: PLC0415
+        return uembed_splade
+    except Exception:  # accelerator gate / missing unsloth_zoo / heavy optional deps
+        pass
+
+    name = "unsloth_uembed_splade_direct"
+    if name in sys.modules:
+        return sys.modules[name]
+    assert _SPLADE_SOURCE_PATH.exists(), f"missing module file: {_SPLADE_SOURCE_PATH}"
+    spec = importlib.util.spec_from_file_location(name, _SPLADE_SOURCE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope = "module")
+def splade():
+    return _load_uembed_splade()
+
+
+def _make_weights(
+    head_dims,
+    hidden_dim = _HIDDEN_DIM,
+    seed = 0,
+):
+    generator = torch.Generator().manual_seed(seed)
+    heads = [torch.randn(dim, hidden_dim, generator = generator) for dim in head_dims]
+    biases = [torch.randn(dim, generator = generator) for dim in head_dims]
+    return heads, biases
+
+
+def _write_checkpoint(
+    directory: Path,
+    head_dims = _HEAD_DIMS,
+    num_eos_tokens = _NUM_EOS,
+):
+    """Write a synthetic `sparse_weights.pt` + `sparse_info.json` UEmbed checkpoint."""
+    heads, biases = _make_weights(head_dims)
+    torch.save(
+        {"sparse_lm_heads": heads, "sparse_bias": biases},
+        directory / "sparse_weights.pt",
+    )
+    (directory / "sparse_info.json").write_text(
+        json.dumps({"num_eos_tokens": num_eos_tokens}), encoding = "utf-8"
+    )
+    return heads, biases
+
+
+@pytest.fixture
+def checkpoint(tmp_path):
+    heads, biases = _write_checkpoint(tmp_path)
+    return tmp_path, heads, biases
+
+
+def _hidden(
+    batch,
+    length,
+    dim = _HIDDEN_DIM,
+    seed = 7,
+):
+    generator = torch.Generator().manual_seed(seed)
+    return torch.randn(batch, length, dim, generator = generator)
+
+
+def _right_padded_mask(lengths, total_length):
+    mask = torch.zeros(len(lengths), total_length, dtype = torch.long)
+    for row, length in enumerate(lengths):
+        mask[row, :length] = 1
+    return mask
+
+
+def _oracle_last_index(mask_row) -> int:
+    """Independent oracle: the last non-padding position (plain python scan)."""
+    positions = [index for index, value in enumerate(mask_row.tolist()) if value]
+    assert positions, "oracle called on an all-padding row"
+    return positions[-1]
+
+
+def _oracle_linear(weight, bias, vector) -> list[float]:
+    """`F.linear` rewritten as scalar python loops: dot product per output row."""
+    return [
+        sum(float(w) * float(v) for w, v in zip(weight[row].tolist(), vector.tolist()))
+        + float(bias[row])
+        for row in range(weight.shape[0])
+    ]
+
+
+def _oracle_splade_last(hidden, mask, heads, biases, num_eos) -> torch.Tensor:
+    """Paper Eq. 3-4 by hand: per-EOS-slot head, concatenated, `log1p(relu(.))`."""
+    rows = []
+    for batch in range(hidden.shape[0]):
+        last = _oracle_last_index(mask[batch])
+        values: list[float] = []
+        for index in range(num_eos):
+            position = last - ((num_eos - 1) - index)
+            logits = _oracle_linear(heads[index], biases[index], hidden[batch, position])
+            values.extend(math.log1p(logit) if logit > 0.0 else 0.0 for logit in logits)
+        rows.append(values)
+    return torch.tensor(rows, dtype = torch.float32)
+
+
+def _oracle_splade_max(hidden, mask, head, bias) -> torch.Tensor:
+    """Masked max by hand: scan every unmasked position, keep the largest weight."""
+    rows = []
+    for batch in range(hidden.shape[0]):
+        best: list[float] | None = None
+        for position in range(hidden.shape[1]):
+            if not mask[batch, position]:
+                continue
+            logits = _oracle_linear(head, bias, hidden[batch, position])
+            weights = [math.log1p(logit) if logit > 0.0 else 0.0 for logit in logits]
+            best = weights if best is None else [max(a, b) for a, b in zip(best, weights)]
+        assert best is not None, "oracle called on an all-padding row"
+        rows.append(best)
+    return torch.tensor(rows, dtype = torch.float32)
+
+
+# --------------------------------------------------------------------------------------
+# construction / checkpoint loading
+# --------------------------------------------------------------------------------------
+def test_from_checkpoint_reads_heads_biases_and_num_eos(splade, checkpoint):
+    directory, heads, biases = checkpoint
+    head = splade.SpladeHead.from_checkpoint(str(directory))
+
+    assert head.num_heads == len(heads)
+    assert head.num_eos_tokens == _NUM_EOS
+    for loaded, expected in zip(head.sparse_lm_heads, heads):
+        assert torch.equal(loaded.detach(), expected)
+    for loaded, expected in zip(head.sparse_bias, biases):
+        assert torch.equal(loaded.detach(), expected)
+
+
+def test_loaded_heads_are_trainable_parameters(splade, checkpoint):
+    directory, heads, _ = checkpoint
+    head = splade.SpladeHead.from_checkpoint(str(directory))
+
+    assert all(isinstance(p, torch.nn.Parameter) for p in head.sparse_lm_heads)
+    assert all(p.requires_grad for p in head.sparse_lm_heads)
+    assert all(p.requires_grad for p in head.sparse_bias)
+    # Visible to an optimizer / `modules_to_save` collection: weights + biases.
+    assert len(list(head.parameters())) == 2 * len(heads)
+
+
+def test_checkpoint_loading_is_independent_of_head_count(splade, tmp_path):
+    """No hardcoded 16: a 3-head checkpoint loads and pools with 3 heads."""
+    head_dims = [2, 3, 4]
+    _write_checkpoint(tmp_path, head_dims = head_dims, num_eos_tokens = len(head_dims))
+    head = splade.SpladeHead.from_checkpoint(str(tmp_path))
+
+    hidden = _hidden(2, 6)
+    mask = _right_padded_mask([6, 5], 6)
+    output = head(hidden, mask, mode = "splade.last")
+
+    assert head.num_heads == len(head_dims)
+    assert output.shape == (2, sum(head_dims))
+
+
+# --------------------------------------------------------------------------------------
+# splade.last
+# --------------------------------------------------------------------------------------
+def test_splade_last_matches_independent_oracle(splade, checkpoint):
+    directory, heads, biases = checkpoint
+    head = splade.SpladeHead.from_checkpoint(str(directory))
+
+    hidden = _hidden(3, 20)
+    mask = _right_padded_mask([20, 18, 17], 20)
+    output = head(hidden, mask, mode = "splade.last")
+    expected = _oracle_splade_last(hidden, mask, heads, biases, _NUM_EOS)
+
+    assert output.shape == (3, sum(_HEAD_DIMS))
+    assert torch.allclose(output, expected, atol = 1e-6)
+
+
+def test_splade_last_dimension_is_the_sum_of_head_vocabularies(splade, checkpoint):
+    directory, heads, _ = checkpoint
+    head = splade.SpladeHead.from_checkpoint(str(directory))
+
+    output = head(_hidden(2, 20), _right_padded_mask([20, 16], 20), mode = "splade.last")
+
+    assert output.shape[-1] == sum(int(w.shape[0]) for w in heads)
+    assert output.shape[-1] != len(heads) * int(heads[0].shape[0])  # not `16 * V`
+
+
+def test_splade_last_is_non_negative_and_actually_clamps(splade, checkpoint):
+    """`log1p(relu(x))` floors at 0; the reversed order would produce NaN for x < -1."""
+    directory, _, _ = checkpoint
+    head = splade.SpladeHead.from_checkpoint(str(directory))
+
+    output = head(_hidden(3, 20), _right_padded_mask([20, 18, 17], 20), mode = "splade.last")
+
+    assert torch.isfinite(output).all()
+    assert float(output.min()) >= 0.0
+    assert bool((output == 0.0).any()), "relu never clamped: test inputs are too tame"
+    assert bool((output > 0.0).any())
+
+
+def test_splade_last_uses_a_distinct_head_per_eos_slot(splade, checkpoint):
+    """Head i must read `last - ((N-1) - i)`; a shared position collapses the vector."""
+    directory, heads, biases = checkpoint
+    head = splade.SpladeHead.from_checkpoint(str(directory))
+
+    hidden = _hidden(1, 20)
+    mask = _right_padded_mask([20], 20)
+    output = head(hidden, mask, mode = "splade.last")[0]
+
+    # First head's block equals head 0 applied at `last - 15`, not at `last`.
+    block = output[: _HEAD_DIMS[0]]
+    at_offset = _oracle_linear(heads[0], biases[0], hidden[0, 19 - (_NUM_EOS - 1)])
+    at_last = _oracle_linear(heads[0], biases[0], hidden[0, 19])
+    expected = torch.tensor(
+        [math.log1p(v) if v > 0.0 else 0.0 for v in at_offset], dtype = torch.float32
+    )
+    wrong = torch.tensor([math.log1p(v) if v > 0.0 else 0.0 for v in at_last], dtype = torch.float32)
+    assert torch.allclose(block, expected, atol = 1e-6)
+    assert not torch.allclose(block, wrong, atol = 1e-6)
+
+
+# --------------------------------------------------------------------------------------
+# splade.max
+# --------------------------------------------------------------------------------------
+def test_splade_max_matches_independent_masked_max_oracle(splade, checkpoint):
+    directory, heads, biases = checkpoint
+    head = splade.SpladeHead.from_checkpoint(str(directory))
+
+    hidden = _hidden(3, 12)
+    mask = _right_padded_mask([12, 9, 5], 12)
+    output = head(hidden, mask, mode = "splade.max")
+    expected = _oracle_splade_max(hidden, mask, heads[0], biases[0])
+
+    assert output.shape == (3, _HEAD_DIMS[0])
+    assert torch.allclose(output, expected, atol = 1e-6)
+    assert float(output.min()) >= 0.0
+
+
+def test_splade_max_excludes_padded_positions(splade, checkpoint):
+    """Padding carries huge activations: if it leaked into the max, the values explode."""
+    directory, heads, biases = checkpoint
+    head = splade.SpladeHead.from_checkpoint(str(directory))
+
+    hidden = _hidden(2, 10)
+    mask = _right_padded_mask([6, 4], 10)
+    # Align the padding with head 0's first row so its logit is guaranteed huge and
+    # positive (`1e6 * ||row||^2`), whatever sign the random weights happen to have.
+    pad_vector = 1e6 * heads[0][0]
+    hidden[0, 6:] = pad_vector
+    hidden[1, 4:] = pad_vector
+    leaked = math.log1p(1e6 * float(heads[0][0].dot(heads[0][0])) + float(biases[0][0]))
+    assert leaked > 12.0, "padding was not made loud enough to detect a leak"
+
+    output = head(hidden, mask, mode = "splade.max")
+    expected = _oracle_splade_max(hidden, mask, heads[0], biases[0])
+
+    assert torch.allclose(output, expected, atol = 1e-6)
+    assert float(output.max()) < 5.0  # a leaked pad position would land near `leaked`
+
+
+# --------------------------------------------------------------------------------------
+# gradients: the sidecar must actually train
+# --------------------------------------------------------------------------------------
+def test_gradients_reach_every_head_and_bias(splade, checkpoint):
+    directory, _, _ = checkpoint
+    head = splade.SpladeHead.from_checkpoint(str(directory))
+
+    output = head(_hidden(3, 20), _right_padded_mask([20, 18, 17], 20), mode = "splade.last")
+    output.sum().backward()
+
+    for index, (weight, bias) in enumerate(zip(head.sparse_lm_heads, head.sparse_bias)):
+        assert weight.grad is not None, f"head {index} received no gradient"
+        assert bias.grad is not None, f"bias {index} received no gradient"
+        assert float(weight.grad.norm()) > 0.0, f"head {index} gradient is all zero"
+
+
+def test_two_optimizer_steps_change_the_head_weights(splade, checkpoint):
+    directory, _, _ = checkpoint
+    head = splade.SpladeHead.from_checkpoint(str(directory))
+    before = [w.detach().clone() for w in head.sparse_lm_heads]
+
+    hidden = _hidden(3, 20)
+    mask = _right_padded_mask([20, 18, 17], 20)
+    optimizer = torch.optim.SGD(head.parameters(), lr = 0.1)
+    grad_norms = []
+    for _ in range(2):
+        optimizer.zero_grad()
+        loss = (head(hidden, mask, mode = "splade.last") - 1.0).pow(2).mean()
+        loss.backward()
+        grad_norms.append(float(head.sparse_lm_heads[0].grad.norm()))
+        optimizer.step()
+
+    assert all(norm > 0.0 for norm in grad_norms)
+    assert any(not torch.equal(old, new.detach()) for old, new in zip(before, head.sparse_lm_heads))
+
+
+def test_splade_max_gradients_reach_the_first_head(splade, checkpoint):
+    directory, _, _ = checkpoint
+    head = splade.SpladeHead.from_checkpoint(str(directory))
+
+    head(_hidden(2, 10), _right_padded_mask([10, 7], 10), mode = "splade.max").sum().backward()
+
+    assert head.sparse_lm_heads[0].grad is not None
+    assert float(head.sparse_lm_heads[0].grad.norm()) > 0.0
+
+
+# --------------------------------------------------------------------------------------
+# malformed input: fail loudly, never return a silently wrong vector
+# --------------------------------------------------------------------------------------
+def test_splade_last_without_eos_tokens_raises(splade, tmp_path):
+    _write_checkpoint(tmp_path, num_eos_tokens = 0)
+    head = splade.SpladeHead.from_checkpoint(str(tmp_path))
+
+    assert head.num_eos_tokens == 0
+    with pytest.raises(ValueError, match = "Unsloth"):
+        head(_hidden(2, 20), _right_padded_mask([20, 18], 20), mode = "splade.last")
+
+
+def test_splade_modes_without_loaded_heads_raise(splade):
+    head = splade.SpladeHead(sparse_lm_heads = [], sparse_bias = [], num_eos_tokens = _NUM_EOS)
+
+    assert head.num_heads == 0
+    for mode in ("splade.last", "splade.max"):
+        with pytest.raises(ValueError, match = "Unsloth"):
+            head(_hidden(2, 20), _right_padded_mask([20, 18], 20), mode = mode)
+
+
+def test_missing_sparse_weights_file_raises(splade, tmp_path):
+    (tmp_path / "sparse_info.json").write_text(
+        json.dumps({"num_eos_tokens": _NUM_EOS}), encoding = "utf-8"
+    )
+    with pytest.raises(FileNotFoundError, match = "Unsloth"):
+        splade.SpladeHead.from_checkpoint(str(tmp_path))
+
+
+def test_checkpoint_missing_keys_raises(splade, tmp_path):
+    heads, _ = _make_weights(_HEAD_DIMS)
+    torch.save({"sparse_lm_heads": heads}, tmp_path / "sparse_weights.pt")
+    with pytest.raises(ValueError, match = "Unsloth"):
+        splade.SpladeHead.from_checkpoint(str(tmp_path))
+
+
+def test_mismatched_head_and_bias_counts_raise(splade):
+    heads, biases = _make_weights(_HEAD_DIMS)
+    with pytest.raises(ValueError, match = "Unsloth"):
+        splade.SpladeHead(heads, biases[:-1], num_eos_tokens = _NUM_EOS)
+
+
+def test_more_eos_tokens_than_heads_raises(splade, tmp_path):
+    _write_checkpoint(tmp_path, head_dims = [3, 3], num_eos_tokens = 4)
+    head = splade.SpladeHead.from_checkpoint(str(tmp_path))
+    with pytest.raises(ValueError, match = "Unsloth"):
+        head(_hidden(1, 8), _right_padded_mask([8], 8), mode = "splade.last")
+
+
+def test_sequence_shorter_than_the_eos_block_raises(splade, checkpoint):
+    directory, _, _ = checkpoint
+    head = splade.SpladeHead.from_checkpoint(str(directory))
+    # last index 9 < num_eos - 1 == 15, so head 0 would index a negative position.
+    with pytest.raises(ValueError, match = "Unsloth"):
+        head(_hidden(1, 20), _right_padded_mask([10], 20), mode = "splade.last")
+
+
+def test_all_padding_row_raises(splade, checkpoint):
+    directory, _, _ = checkpoint
+    head = splade.SpladeHead.from_checkpoint(str(directory))
+    mask = _right_padded_mask([20, 0], 20)
+    for mode in ("splade.last", "splade.max"):
+        with pytest.raises(ValueError, match = "Unsloth"):
+            head(_hidden(2, 20), mask, mode = mode)
+
+
+def test_unknown_mode_raises(splade, checkpoint):
+    directory, _, _ = checkpoint
+    head = splade.SpladeHead.from_checkpoint(str(directory))
+    with pytest.raises(ValueError, match = "Unsloth"):
+        head(_hidden(1, 20), _right_padded_mask([20], 20), mode = "splade.mean")
+
+
+def test_empty_batch_returns_empty_vectors(splade, checkpoint):
+    directory, _, _ = checkpoint
+    head = splade.SpladeHead.from_checkpoint(str(directory))
+
+    hidden = torch.zeros(0, 20, _HIDDEN_DIM)
+    mask = torch.zeros(0, 20, dtype = torch.long)
+
+    assert head(hidden, mask, mode = "splade.last").shape == (0, sum(_HEAD_DIMS))
+    assert head(hidden, mask, mode = "splade.max").shape == (0, _HEAD_DIMS[0])
+
+
+# --------------------------------------------------------------------------------------
+# opt-in surface
+# --------------------------------------------------------------------------------------
+def test_only_splade_modes_are_recognised(splade):
+    assert splade.is_splade_pooling_mode("splade.last")
+    assert splade.is_splade_pooling_mode("splade.max")
+    for mode in ("mean", "cls", "lasttoken", "offset_lasttoken", None, 16):
+        assert not splade.is_splade_pooling_mode(mode)

--- a/unsloth/models/UEMBED_NOTES.md
+++ b/unsloth/models/UEMBED_NOTES.md
@@ -1,0 +1,36 @@
+# UEmbed / Qwen3.5 Backbone Constraints
+
+This note documents known constraints when using the Qwen3.5 (`qwen3_5`)
+backbone for UEmbed-style embedding fine-tuning in this repo. It is a
+standalone reference; it does not change any runtime behavior.
+
+1. bf16-only (fp16 forced off): `qwen3_5` is in the fp16 blocklist, so
+   `float16` training is forced off for this arch. This excludes fp16-only
+   GPUs such as the T4. Source: `unsloth/models/loader.py:125-140`
+   (`_FORCE_FLOAT32_FALLBACK` entry `"qwen3_5"`).
+
+2. Packing / padding-free disabled: `qwen3_5` uses hybrid linear-attention
+   (GDN) layers that carry a recurrent gated-delta state plus a causal
+   conv1d; these leak across sequence boundaries once packing flattens the
+   batch. This is detected structurally (not by model name) via
+   `_is_hybrid_linear_attention_model`. Source: `unsloth/trainer.py:100-112`.
+
+3. `transformers >= 5.2` required. The UEmbed model card asks for `>= 5.4`.
+
+4. `trust_remote_code=True` is required to load the model.
+
+5. No `auto_map` in `config.json`: the `Qwen3_5ForEmbedding` class lives
+   only in the upstream repo's source, not as a registered `AutoModel`
+   entry point. Loading therefore routes through `AutoModel` to the base
+   `Qwen3_5Model`, which returns `last_hidden_state` rather than a
+   pooled/embedding output.
+
+6. Output modes and save scope:
+   - Dense: offset-lasttoken pooling
+     (`last_index - num_eos_tokens`).
+   - Sparse: SPLADE (`splade.last` / `splade.max`, `log1p(relu(...))`).
+   - Save scope: LoRA and merged 16-bit save only.
+   - GGUF / llama.cpp export is OUT OF SCOPE.
+
+This is a documentation-only summary of currently observed constraints; it
+does not imply full or tested support for every Qwen3.5 configuration.

--- a/unsloth/models/sentence_transformer.py
+++ b/unsloth/models/sentence_transformer.py
@@ -21,6 +21,19 @@ from ._utils import (
     resolve_encoder_attention_implementation,
     maybe_prefetch_hf_snapshot,
 )
+from .uembed_pooling import (
+    OffsetLastTokenPooling,
+    attach_uembed_input_format,
+    build_eos_post_processor,
+    is_offset_pooling_mode,
+    read_num_eos_tokens,
+)
+from .uembed_sidecar import load_uembed_sparse_sidecar, save_uembed_sparse_sidecar
+from .uembed_wiring import (
+    attach_uembed_sparse_checkpoint,
+    patch_uembed_sparse_encode,
+    restore_uembed_inference_input_format,
+)
 import inspect
 import json
 import os
@@ -45,6 +58,146 @@ import shutil
 
 
 _CREATE_TRANSFORMER_MODULE_LOCK = threading.RLock()
+
+
+def _ensure_uembed_offset_pooling(modules, num_eos_tokens, hidden_size, pooling_class):
+    """Replace the assembled dense pooling module when a checkpoint appends EOS fillers.
+
+    ``sparse_info.json`` is authoritative: once its EOS count is positive, retaining
+    sentence-transformers' stock pooling would silently return an EOS filler vector.
+    The zero/absent case returns before inspecting the chain, preserving it exactly.
+    """
+    if not num_eos_tokens:
+        return
+
+    candidates = [
+        (name, module)
+        for name, module in modules.items()
+        if isinstance(module, (pooling_class, OffsetLastTokenPooling))
+    ]
+    if len(candidates) != 1:
+        raise RuntimeError(
+            "Unsloth: this UEmbed checkpoint appends an EOS filler block, but its "
+            f"module chain has {len(candidates)} replaceable pooling modules. Exactly one "
+            "sentence-transformers Pooling or OffsetLastTokenPooling module is required; "
+            "refusing to encode because stock/unknown pooling would silently select an "
+            "EOS filler token."
+        )
+
+    name, pooling = candidates[0]
+    if isinstance(pooling, OffsetLastTokenPooling) and pooling.num_eos_tokens == num_eos_tokens:
+        return
+
+    dimension = None
+    for method_name in ("get_embedding_dimension", "get_sentence_embedding_dimension"):
+        get_dimension = getattr(pooling, method_name, None)
+        if callable(get_dimension):
+            dimension = get_dimension()
+            break
+    if not isinstance(dimension, int) or isinstance(dimension, bool) or dimension <= 0:
+        dimension = hidden_size
+    if not isinstance(dimension, int) or isinstance(dimension, bool) or dimension <= 0:
+        raise RuntimeError(
+            "Unsloth: this UEmbed checkpoint requires OffsetLastTokenPooling, but the "
+            "assembled pooling module does not expose a valid embedding dimension. "
+            "Refusing to encode an EOS filler token."
+        )
+
+    modules[name] = OffsetLastTokenPooling(
+        word_embedding_dimension = dimension,
+        num_eos_tokens = num_eos_tokens,
+    )
+
+
+def _assemble_uembed_inference_model(
+    model,
+    model_name,
+    pooling_class,
+    normalize_class,
+    token = None,
+    cache_dir = None,
+    revision = None,
+):
+    """Restore or assemble UEmbed semantics on the native inference load path.
+
+    Merged SentenceTransformer exports serialize their UEmbed modules, so they only need
+    their process-local encode and input-format wrappers restored. A fresh public UEmbed
+    repository has no ``modules.json``: sentence-transformers builds a generic
+    Transformer -> Pooling chain. Positive ``sparse_info.json`` metadata is the trusted
+    opt-in signal for replacing that fallback with the same offset-pooling, normalization,
+    formatter, EOS, and sparse-output semantics used by the normal Unsloth load path.
+    """
+    if patch_uembed_sparse_encode(model):
+        restore_uembed_inference_input_format(model)
+        return True
+
+    num_eos_tokens = read_num_eos_tokens(
+        model_name,
+        token = token,
+        cache_dir = cache_dir,
+        revision = revision,
+    )
+    if num_eos_tokens <= 0:
+        return False
+
+    modules = getattr(model, "_modules", None)
+    if modules is None:
+        raise RuntimeError(
+            "Unsloth: UEmbed metadata was found, but the native SentenceTransformer "
+            "does not expose a module chain to assemble."
+        )
+
+    _ensure_uembed_offset_pooling(
+        modules,
+        num_eos_tokens = num_eos_tokens,
+        hidden_size = None,
+        pooling_class = pooling_class,
+    )
+
+    pooling_names = [
+        name for name, module in modules.items() if isinstance(module, OffsetLastTokenPooling)
+    ]
+    normalize_names = [
+        name for name, module in modules.items() if isinstance(module, normalize_class)
+    ]
+    if len(pooling_names) != 1 or len(normalize_names) > 1:
+        raise RuntimeError(
+            "Unsloth: fresh UEmbed inference assembly requires exactly one pooling "
+            f"module and at most one Normalize module; found pooling={len(pooling_names)}, "
+            f"normalize={len(normalize_names)}."
+        )
+
+    pooling_name = pooling_names[0]
+    if normalize_names:
+        names = list(modules)
+        if names.index(normalize_names[0]) < names.index(pooling_name):
+            raise RuntimeError(
+                "Unsloth: the UEmbed Normalize module appears before dense pooling; "
+                "refusing to assemble a semantically reordered inference chain."
+            )
+    else:
+        names = set(modules)
+        normalize_name = str(len(names))
+        while normalize_name in names:
+            normalize_name = str(int(normalize_name) + 1)
+        rebuilt = OrderedDict()
+        for name, module in modules.items():
+            rebuilt[name] = module
+            if name == pooling_name:
+                rebuilt[normalize_name] = normalize_class()
+        modules.clear()
+        modules.update(rebuilt)
+
+    attach_uembed_sparse_checkpoint(
+        model,
+        model_name,
+        num_eos_tokens = num_eos_tokens,
+        token = token,
+        cache_dir = cache_dir,
+        revision = revision,
+    )
+    restore_uembed_inference_input_format(model)
+    return True
 
 
 def _normalize_save_method(save_method):
@@ -1011,6 +1164,7 @@ class FastSentenceTransformer(FastModel):
         cache_dir = None,
         revision = None,
         module_subfolder = "",
+        processor_kwargs = None,
     ):
         """Helper to create and configure a Transformer module."""
         from sentence_transformers.models import Transformer
@@ -1093,10 +1247,15 @@ class FastSentenceTransformer(FastModel):
                 else:
                     transformer_kwargs["model_args"] = trust_remote_code_kwargs.copy()
                     transformer_kwargs["config_args"] = trust_remote_code_kwargs.copy()
+                extra_processor_kwargs = dict(processor_kwargs or {})
                 if "processor_kwargs" in transformer_init_params:
-                    transformer_kwargs["processor_kwargs"] = trust_remote_code_kwargs.copy()
+                    resolved_processor_kwargs = trust_remote_code_kwargs.copy()
+                    resolved_processor_kwargs.update(extra_processor_kwargs)
+                    transformer_kwargs["processor_kwargs"] = resolved_processor_kwargs
                 elif "tokenizer_args" in transformer_init_params:
-                    transformer_kwargs["tokenizer_args"] = trust_remote_code_kwargs.copy()
+                    resolved_processor_kwargs = trust_remote_code_kwargs.copy()
+                    resolved_processor_kwargs.update(extra_processor_kwargs)
+                    transformer_kwargs["tokenizer_args"] = resolved_processor_kwargs
 
                 # Build via Transformer.load so the saved modality_config is honored: plain
                 # Transformer(...) makes ST 5.x infer a "message" modality for chat-template
@@ -1221,6 +1380,8 @@ class FastSentenceTransformer(FastModel):
         trust_remote_code = False,
         cache_dir = None,
         revision = None,
+        processor_kwargs = None,
+        num_eos_tokens = None,
     ) -> tuple[OrderedDict, bool]:
         """Load modules from modules.json, else fall back to hard-coded modules.
 
@@ -1234,6 +1395,7 @@ class FastSentenceTransformer(FastModel):
         modules_json_path = FastSentenceTransformer._module_path(
             model_name, token, cache_dir = cache_dir, revision = revision
         )
+        hidden_size = getattr(model.config, "hidden_size", 768)
 
         if modules_json_path:
             with open(modules_json_path, encoding = "utf8") as f:
@@ -1254,6 +1416,7 @@ class FastSentenceTransformer(FastModel):
                         cache_dir,
                         revision,
                         module_subfolder = module_config.get("path") or "",
+                        processor_kwargs = processor_kwargs,
                     )
                     modules[name] = transformer_module
                 else:
@@ -1281,6 +1444,12 @@ class FastSentenceTransformer(FastModel):
                     except Exception as e:
                         print(f"Unsloth Warning: Failed to load module {name} ({class_ref}): {e}")
 
+            _ensure_uembed_offset_pooling(
+                modules,
+                num_eos_tokens = num_eos_tokens,
+                hidden_size = hidden_size,
+                pooling_class = Pooling,
+            )
             return modules, False
 
         # fallback if no modules.json (non sentence-transformers models)
@@ -1297,18 +1466,33 @@ class FastSentenceTransformer(FastModel):
             token,
             cache_dir,
             revision,
+            processor_kwargs = processor_kwargs,
         )
         modules["0"] = transformer_module
-
-        hidden_size = getattr(model.config, "hidden_size", 768)
 
         if pooling_mode == "mean":
             pooling_mode = FastSentenceTransformer._read_pooling_mode(
                 model_name, token, cache_dir = cache_dir, revision = revision
             )
 
-        modules["1"] = Pooling(word_embedding_dimension = hidden_size, pooling_mode = pooling_mode)
+        if is_offset_pooling_mode(pooling_mode):
+            if num_eos_tokens is None:
+                num_eos_tokens = read_num_eos_tokens(
+                    model_name, token = token, cache_dir = cache_dir, revision = revision
+                )
+            modules["1"] = OffsetLastTokenPooling(
+                word_embedding_dimension = hidden_size,
+                num_eos_tokens = num_eos_tokens,
+            )
+        else:
+            modules["1"] = Pooling(word_embedding_dimension = hidden_size, pooling_mode = pooling_mode)
         modules["2"] = Normalize()
+        _ensure_uembed_offset_pooling(
+            modules,
+            num_eos_tokens = num_eos_tokens,
+            hidden_size = hidden_size,
+            pooling_class = Pooling,
+        )
 
         return modules, True
 
@@ -1439,8 +1623,29 @@ class FastSentenceTransformer(FastModel):
     def _apply_torch_compile(model, mode = "default"):
         """Apply torch.compile to a SentenceTransformer model (with an
         accelerate unwrap_model bug workaround)."""
+        inner_model = model[0].auto_model if hasattr(model, "__getitem__") else model
+
+        # Qwen3.5's hybrid GDN/FLA backbone currently produces deterministic but
+        # materially different embeddings under torch.compile. Prefer eager execution.
+        compile_candidate = inner_model
+        while compile_candidate is not None:
+            config = getattr(compile_candidate, "config", None)
+            model_type = getattr(config, "model_type", None)
+            is_qwen3_5 = isinstance(model_type, str) and (
+                model_type == "qwen3_5" or model_type.startswith("qwen3_5_")
+            )
+            if config is None:
+                class_name = type(compile_candidate).__name__
+                is_qwen3_5 = class_name == "Qwen3_5Model" or class_name.startswith("Qwen3_5For")
+            if is_qwen3_5:
+                print(
+                    "Unsloth: torch.compile disabled for Qwen3.5 because compiled "
+                    "embeddings can differ materially from eager results."
+                )
+                return model
+            compile_candidate = getattr(compile_candidate, "_orig_mod", None)
+
         if hasattr(model, "__getitem__"):
-            inner_model = model[0].auto_model
             compiled = torch.compile(inner_model, mode = mode)
             if isinstance(getattr(type(model[0]), "auto_model", None), property):
                 model[0].model = compiled
@@ -1482,6 +1687,7 @@ class FastSentenceTransformer(FastModel):
         unsloth_tiled_mlp = False,
         pooling_mode = "mean",
         for_inference = False,
+        processor_kwargs = None,
         **kwargs,
     ):
         try:
@@ -1569,6 +1775,15 @@ class FastSentenceTransformer(FastModel):
                 st_kwargs["cache_folder"] = _st_cache
 
             st_model = SentenceTransformer(model_name, **st_kwargs)
+            _assemble_uembed_inference_model(
+                st_model,
+                model_name,
+                pooling_class = Pooling,
+                normalize_class = Normalize,
+                token = token,
+                cache_dir = _st_cache,
+                revision = revision,
+            )
             return st_model
 
         # Load-mode validation already ran before the prefetch above.
@@ -1679,6 +1894,7 @@ class FastSentenceTransformer(FastModel):
                 model_kwargs = model_kwargs,
                 cache_folder = kwargs.get("cache_dir") or kwargs.get("cache_folder"),
             )
+            patch_uembed_sparse_encode(st_model)
 
             # Store metadata for get_peft_model
             st_model._unsloth_fast_encoder = True
@@ -1729,6 +1945,7 @@ class FastSentenceTransformer(FastModel):
                         inner.save_pretrained(save_directory)
                 if tokenizer is not None:
                     tokenizer.save_pretrained(save_directory)
+                save_uembed_sparse_sidecar(self, save_directory)
                 FastSentenceTransformer._add_unsloth_branding(save_directory)
 
             st_model.save_pretrained_merged = types.MethodType(_save_pretrained_merged, st_model)
@@ -1864,6 +2081,19 @@ class FastSentenceTransformer(FastModel):
         finally:
             os.environ["UNSLOTH_WARN_UNINITIALIZED"] = old_environ
 
+        # UEmbed metadata is the sole opt-in signal. The generic model loader above
+        # already returns the checkpoint's processor when one is required.
+        num_eos_tokens = read_num_eos_tokens(
+            model_name,
+            token = token,
+            cache_dir = kwargs.get("cache_dir")
+            or kwargs.get("cache_folder")
+            or os.environ.get("SENTENCE_TRANSFORMERS_HOME"),
+            revision = revision,
+        )
+        if num_eos_tokens > 0:
+            build_eos_post_processor(tokenizer, num_eos_tokens)
+
         from sentence_transformers import SentenceTransformer
 
         modules, no_modules = FastSentenceTransformer._load_modules(
@@ -1880,6 +2110,8 @@ class FastSentenceTransformer(FastModel):
             or os.environ.get("SENTENCE_TRANSFORMERS_HOME"),
             # Same revision as the weight load so modules hit the warm (None = default branch).
             revision = revision,
+            processor_kwargs = processor_kwargs,
+            num_eos_tokens = num_eos_tokens,
         )
 
         st_device = device_map
@@ -1889,7 +2121,23 @@ class FastSentenceTransformer(FastModel):
             st_device = None
 
         st_model = SentenceTransformer(modules = modules, device = st_device)
+        patch_uembed_sparse_encode(st_model)
         st_model.no_modules = no_modules
+
+        st_model._unsloth_uembed_instruction = num_eos_tokens > 0
+        if num_eos_tokens > 0:
+            attach_uembed_input_format(st_model[0])
+            attach_uembed_sparse_checkpoint(
+                st_model,
+                model_name,
+                num_eos_tokens = num_eos_tokens,
+                token = token,
+                cache_dir = kwargs.get("cache_dir")
+                or kwargs.get("cache_folder")
+                or os.environ.get("SENTENCE_TRANSFORMERS_HOME"),
+                revision = revision,
+            )
+            load_uembed_sparse_sidecar(st_model, model_name)
 
         def _save_pretrained_merged(
             self,
@@ -1957,6 +2205,8 @@ class FastSentenceTransformer(FastModel):
                 self[0].auto_model.save_pretrained_merged(
                     save_directory, tokenizer = tokenizer, **kwargs
                 )
+
+            save_uembed_sparse_sidecar(self, save_directory)
 
             # add Unsloth branding to the generated README
             try:

--- a/unsloth/models/uembed_loss.py
+++ b/unsloth/models/uembed_loss.py
@@ -1,0 +1,270 @@
+# Copyright 2023-present Daniel Han-Chen & the Unsloth team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unified dense + sparse + FLOPS training loss for UEmbed (Qwen3.5) embedders.
+
+Paper arXiv:2608.02583 Eq. 5:
+
+    L = L_InfoNCE_dense + lambda * L_InfoNCE_sparse + alpha_q * L_FLOPS_q + alpha_d * L_FLOPS_d
+
+- dense InfoNCE  : cosine similarity between the anchor and candidate dense vectors, scaled
+                   by `scale` (= 1 / tau_dense, default 20.0 <=> tau_dense = 0.05), labels
+                   `arange(B)`, cross entropy. This is exactly sentence-transformers'
+                   `MultipleNegativesRankingLoss` (in-batch negatives).
+- sparse InfoNCE : inner product between the non-negative SPLADE vectors divided by the
+                   sparse temperature `tau_s` (default 32.0, paper section 5.1). Sparse
+                   scores have a far wider dynamic range than cosines, so the sparse
+                   temperature is deliberately NOT the dense scale.
+- FLOPS          : `sum_t (mean_i W[i, t])^2` (Paria et al. / SPLADE-v2), computed
+                   separately over the query batch and the document batch so queries and
+                   documents can be sparsified at different strengths.
+
+The loss accepts both sentence-transformers contracts. Trainer batches contain raw tokenized
+feature dictionaries, so each column is passed through the model exactly once; the UEmbed
+pipeline produces `sentence_embedding` + `sparse_embedding` together in that one forward.
+Already-forwarded dictionaries carrying both keys are consumed directly without another model
+call. Non-negativity of the sparse vectors is guaranteed upstream by `SpladeHead`'s
+`log1p(relu(.))`, so it is assumed, not re-clamped.
+
+Torch-only, so it imports without an accelerator and without importing `unsloth`.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Iterable
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+
+
+# Keys in the sentence-transformers features dict. `sentence_embedding` is the stock ST
+# key; `sparse_embedding` is what the UEmbed single-forward wiring adds beside it.
+SENTENCE_EMBEDDING_KEY = "sentence_embedding"
+SPARSE_EMBEDDING_KEY = "sparse_embedding"
+
+# Paper-grounded defaults: tau_dense = 0.05 (scale = 20.0), tau_s = 32.0, equal query and
+# document FLOPS weights. `alpha_warmup_steps = 0` keeps the regulariser constant.
+DEFAULT_SCALE = 20.0
+DEFAULT_TAU_SPARSE = 32.0
+DEFAULT_LAMBDA_SPARSE = 1.0
+DEFAULT_ALPHA = 0.01
+
+
+def flops_regularizer(sparse_embeddings: torch.Tensor) -> torch.Tensor:
+    """`sum_t (mean_i W[i, t])^2` for a `(batch, vocab)` batch of sparse vectors."""
+    return sparse_embeddings.mean(dim = 0).pow(2).sum()
+
+
+def _positive(name: str, value: Any) -> float:
+    number = float(value)
+    if not number > 0.0:
+        raise ValueError(f"Unsloth: `{name}` must be > 0, got {value!r}.")
+    return number
+
+
+def _non_negative(name: str, value: Any) -> float:
+    number = float(value)
+    if number < 0.0:
+        raise ValueError(f"Unsloth: `{name}` must be >= 0, got {value!r}.")
+    return number
+
+
+class UEmbedUnifiedLoss(nn.Module):
+    """Dense InfoNCE + sparse InfoNCE + FLOPS, the UEmbed unified objective.
+
+    Usage mirrors any sentence-transformers loss::
+
+        loss = UEmbedUnifiedLoss(model)
+        SentenceTransformerTrainer(model = model, loss = loss, ...)
+
+    Raw tokenized columns from `SentenceTransformerTrainer` are forwarded through `model`
+    once each. Columns that already carry both required embedding keys are not forwarded
+    again, preserving the direct/precomputed contract used outside the trainer.
+
+    Each column of the batch arrives as one features dict; column 0 is the anchors
+    (queries) and every later column is a candidate (positives first, then optional hard
+    negatives, which become extra in-batch candidates exactly as MNRL treats them).
+
+    `alpha_warmup_steps > 0` enables the optional quadratic ramp described in the SPLADE
+    literature: the FLOPS weights grow as `(step / warmup)^2` and then stay at full
+    strength. It is off by default, i.e. the weights are constant.
+    """
+
+    def __init__(
+        self,
+        model: Any = None,
+        lambda_sparse: float = DEFAULT_LAMBDA_SPARSE,
+        alpha_q: float = DEFAULT_ALPHA,
+        alpha_d: float = DEFAULT_ALPHA,
+        scale: float = DEFAULT_SCALE,
+        tau_s: float = DEFAULT_TAU_SPARSE,
+        alpha_warmup_steps: int = 0,
+    ) -> None:
+        super().__init__()
+        self.model = model
+        self.lambda_sparse = _non_negative("lambda_sparse", lambda_sparse)
+        self.alpha_q = _non_negative("alpha_q", alpha_q)
+        self.alpha_d = _non_negative("alpha_d", alpha_d)
+        self.scale = _positive("scale", scale)
+        self.tau_s = _positive("tau_s", tau_s)
+        is_integer = isinstance(alpha_warmup_steps, int) and not isinstance(
+            alpha_warmup_steps, bool
+        )
+        if not is_integer or alpha_warmup_steps < 0:
+            raise ValueError(
+                f"Unsloth: `alpha_warmup_steps` must be a non-negative integer, "
+                f"got {alpha_warmup_steps!r}."
+            )
+        self.alpha_warmup_steps = alpha_warmup_steps
+        self.alpha_step = 0
+
+    # -- FLOPS ramp ---------------------------------------------------------------------
+    def alpha_scale(self) -> float:
+        """Multiplier applied to both FLOPS weights; always 1.0 when warmup is off."""
+        if self.alpha_warmup_steps <= 0:
+            return 1.0
+        progress = min(1.0, self.alpha_step / self.alpha_warmup_steps)
+        return progress * progress
+
+    # -- feature extraction -------------------------------------------------------------
+    @staticmethod
+    def _embedding(column: Any, key: str, index: int) -> torch.Tensor:
+        if not isinstance(column, dict) or key not in column:
+            if key == SPARSE_EMBEDDING_KEY:
+                raise KeyError(
+                    f"Unsloth: column {index} of the batch has no `{SPARSE_EMBEDDING_KEY}`. "
+                    f"UEmbedUnifiedLoss needs the dense AND sparse outputs of a single model "
+                    f"forward, which the UEmbed multi-output wiring adds beside "
+                    f"`{SENTENCE_EMBEDDING_KEY}`. Load the model with a SPLADE pooling mode "
+                    f"so the SpladeHead is attached, or use "
+                    f"MultipleNegativesRankingLoss for dense-only training."
+                )
+            raise KeyError(
+                f"Unsloth: column {index} of the batch has no `{key}`; every sentence "
+                f"feature must carry the pooled dense embedding."
+            )
+        embedding = column[key]
+        if embedding.dim() != 2:
+            raise ValueError(
+                f"Unsloth: `{key}` of column {index} must be a (batch, dim) matrix, got "
+                f"shape {tuple(embedding.shape)}."
+            )
+        return embedding
+
+    def _columns(
+        self, sentence_features: Iterable[Any]
+    ) -> tuple[list[torch.Tensor], list[torch.Tensor]]:
+        columns = list(sentence_features)
+        if len(columns) < 2:
+            raise ValueError(
+                f"Unsloth: UEmbedUnifiedLoss needs at least 2 columns (anchor + positive), "
+                f"got {len(columns)}."
+            )
+
+        forwarded = []
+        for column in columns:
+            has_outputs = isinstance(column, dict) and all(
+                key in column for key in (SENTENCE_EMBEDDING_KEY, SPARSE_EMBEDDING_KEY)
+            )
+            if has_outputs or self.model is None or not isinstance(column, dict):
+                forwarded.append(column)
+            else:
+                # ST modules mutate their working features dict as it moves through the
+                # pipeline. A shallow copy protects the caller's dictionary while keeping
+                # its tensors (and their gradient graph) intact.
+                forwarded.append(self.model(dict(column)))
+
+        dense = [self._embedding(c, SENTENCE_EMBEDDING_KEY, i) for i, c in enumerate(forwarded)]
+        sparse = [self._embedding(c, SPARSE_EMBEDDING_KEY, i) for i, c in enumerate(forwarded)]
+
+        batch_size = dense[0].shape[0]
+        for index, (dense_column, sparse_column) in enumerate(zip(dense, sparse)):
+            sizes = (dense_column.shape[0], sparse_column.shape[0])
+            if sizes != (batch_size, batch_size):
+                raise ValueError(
+                    f"Unsloth: every column must share one batch size; column 0 has "
+                    f"{batch_size} rows but column {index} has dense {sizes[0]} / sparse "
+                    f"{sizes[1]}. In-batch InfoNCE pairs row i with row i."
+                )
+        return dense, sparse
+
+    # -- loss terms ---------------------------------------------------------------------
+    @staticmethod
+    def _in_batch_cross_entropy(logits: torch.Tensor) -> torch.Tensor:
+        """Cross entropy against `arange(B)`: candidate i is the positive of anchor i."""
+        labels = torch.arange(logits.shape[0], device = logits.device)
+        return F.cross_entropy(logits, labels)
+
+    def _dense_infonce(self, anchors: torch.Tensor, candidates: torch.Tensor) -> torch.Tensor:
+        similarity = F.normalize(anchors, p = 2, dim = -1) @ F.normalize(
+            candidates, p = 2, dim = -1
+        ).transpose(0, 1)
+        return self._in_batch_cross_entropy(similarity * self.scale)
+
+    def _sparse_infonce(self, anchors: torch.Tensor, candidates: torch.Tensor) -> torch.Tensor:
+        similarity = anchors @ candidates.transpose(0, 1)
+        return self._in_batch_cross_entropy(similarity / self.tau_s)
+
+    def components(self, sentence_features: Iterable[Any]) -> dict[str, torch.Tensor]:
+        """Every term of Eq. 5 plus the weighted `total`; leaves the warmup step alone."""
+        dense, sparse = self._columns(sentence_features)
+        dense_candidates = torch.cat(dense[1:], dim = 0)
+        sparse_candidates = torch.cat(sparse[1:], dim = 0)
+
+        dense_loss = self._dense_infonce(dense[0], dense_candidates)
+        sparse_loss = self._sparse_infonce(sparse[0], sparse_candidates)
+        flops_query = flops_regularizer(sparse[0])
+        flops_document = flops_regularizer(sparse_candidates)
+
+        regulariser = self.alpha_q * flops_query + self.alpha_d * flops_document
+        total = dense_loss + self.lambda_sparse * sparse_loss + self.alpha_scale() * regulariser
+        return {
+            "dense": dense_loss,
+            "sparse": sparse_loss,
+            "flops_query": flops_query,
+            "flops_document": flops_document,
+            "total": total,
+        }
+
+    def forward(
+        self,
+        sentence_features: Iterable[Any],
+        labels: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """`labels` is ignored: in-batch InfoNCE derives its own `arange(B)` targets."""
+        total = self.components(sentence_features)["total"]
+        if self.alpha_warmup_steps > 0 and self.training:
+            self.alpha_step += 1
+        return total
+
+    def get_config_dict(self) -> dict[str, float | int]:
+        return {
+            "lambda_sparse": self.lambda_sparse,
+            "alpha_q": self.alpha_q,
+            "alpha_d": self.alpha_d,
+            "scale": self.scale,
+            "tau_s": self.tau_s,
+            "alpha_warmup_steps": self.alpha_warmup_steps,
+        }
+
+    @property
+    def citation(self) -> str:
+        return (
+            "@misc{uembed2026,\n"
+            "    title={UEmbed: Unified Dense and Sparse Multimodal Embeddings},\n"
+            "    eprint={2608.02583},\n"
+            "    archivePrefix={arXiv},\n"
+            "}"
+        )

--- a/unsloth/models/uembed_pooling.py
+++ b/unsloth/models/uembed_pooling.py
@@ -1,0 +1,634 @@
+# Copyright 2023-present Daniel Han-Chen & the Unsloth team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""`num_eos_tokens` handling for UEmbed (Qwen3.5) style embedding checkpoints.
+
+UEmbed appends `num_eos_tokens` `<|endoftext|>` tokens after the content and reads the
+dense vector from the hidden state that *precedes* that block, so plain last-token
+pooling would pool an EOS filler position instead of the sentence representation:
+
+    last_index = (attention_mask.cumsum(dim = 1) * attention_mask).argmax(dim = 1)
+    target     = last_index - num_eos_tokens
+    dense      = hidden_state[batch_arange, target]
+
+`num_eos_tokens` is read from the checkpoint's `sparse_info.json`; when that file is
+absent it defaults to 0, which makes this module behave exactly like sentence-
+transformers' `lasttoken` pooling. The module is opt-in: `_load_modules` only selects it
+for the pooling modes in `OFFSET_POOLING_MODES`, every other mode keeps stock `Pooling`.
+
+The same number drives the tokenizer: `build_eos_post_processor` attaches a `tokenizers`
+post-processor that emits the trailing `<|endoftext|>` block which the pooling above then
+skips. Both sides are opt-in and are no-ops at `num_eos_tokens = 0`.
+
+The same checkpoints also wrap every input in an instruction conversation before
+tokenization -- system instruction "Represent the user's input." plus a user message
+carrying `video, image, text` -- rendered through the processor's chat template
+(`build_uembed_conversation` / `attach_uembed_input_format`). That path is opt-in behind
+the same `num_eos_tokens > 0` signal, so existing embedders keep their formatting.
+
+Depends on torch only (`tokenizers` is imported lazily), so it stays importable without an
+accelerator.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+
+import torch
+
+
+# Sidecar file UEmbed ships next to the weights, and the key holding the EOS block size.
+SPARSE_INFO_FILENAME = "sparse_info.json"
+NUM_EOS_TOKENS_KEY = "num_eos_tokens"
+
+# The token UEmbed repeats `num_eos_tokens` times after the content.
+EOS_TOKEN = "<|endoftext|>"
+
+# Pooling modes that select this module instead of sentence-transformers' `Pooling`.
+# Deliberately disjoint from the stock modes so existing embedders are untouched.
+OFFSET_POOLING_MODES = frozenset({"offset_lasttoken"})
+
+
+def is_offset_pooling_mode(pooling_mode: Any) -> bool:
+    """True when the caller explicitly asked for UEmbed-style offset pooling."""
+    return isinstance(pooling_mode, str) and pooling_mode in OFFSET_POOLING_MODES
+
+
+def _local_sparse_info_path(model_name_or_path: str) -> str | None:
+    if not isinstance(model_name_or_path, str) or not os.path.isdir(model_name_or_path):
+        return None
+    candidate = os.path.join(model_name_or_path, SPARSE_INFO_FILENAME)
+    return candidate if os.path.isfile(candidate) else None
+
+
+def _hub_sparse_info_path(
+    model_name_or_path: str,
+    token: str | bool | None = None,
+    cache_dir: str | None = None,
+    revision: str | None = None,
+) -> str | None:
+    """Download `sparse_info.json` from the Hub, or None when the repo has no such file.
+
+    A missing file is the documented "not a UEmbed checkpoint" case and stays silent.
+    Anything else (network / auth failure) is reported so a misconfigured run does not
+    quietly fall back to `num_eos_tokens = 0` and pool the wrong position.
+    """
+    try:
+        from huggingface_hub import hf_hub_download
+        from huggingface_hub.errors import EntryNotFoundError, LocalEntryNotFoundError
+        try:
+            from huggingface_hub.errors import RemoteEntryNotFoundError
+        except ImportError:
+            # huggingface_hub < 1 uses EntryNotFoundError for remote 404s. Its
+            # LocalEntryNotFoundError subclass is excluded explicitly below.
+            RemoteEntryNotFoundError = EntryNotFoundError
+    except ImportError as exception:
+        raise RuntimeError(
+            f"Unsloth: cannot resolve optional `{SPARSE_INFO_FILENAME}` for "
+            f"`{model_name_or_path}` because `huggingface_hub` is unavailable. Install "
+            f"`huggingface_hub` or load from a complete local checkpoint."
+        ) from exception
+
+    try:
+        return hf_hub_download(
+            model_name_or_path,
+            SPARSE_INFO_FILENAME,
+            token = token,
+            cache_dir = cache_dir,
+            revision = revision,
+        )
+    except Exception as exception:
+        if isinstance(exception, RemoteEntryNotFoundError) and not isinstance(
+            exception, LocalEntryNotFoundError
+        ):
+            return None
+        raise RuntimeError(
+            f"Unsloth: failed to resolve `{SPARSE_INFO_FILENAME}` for "
+            f"`{model_name_or_path}`. Only a confirmed missing file is treated as an "
+            f"optional dense-only checkpoint; this failure may be caused by the network, "
+            f"an invalid repository/revision, authentication, or gated-repository access. "
+            f"Check connectivity and pass a token with access. Original error: {exception}"
+        ) from exception
+
+
+def read_num_eos_tokens(
+    model_name_or_path: str,
+    token: str | bool | None = None,
+    cache_dir: str | None = None,
+    revision: str | None = None,
+) -> int:
+    """Read `num_eos_tokens` from the checkpoint's `sparse_info.json`, else 0.
+
+    0 is the "no EOS block" default and makes offset pooling identical to `lasttoken`.
+    A present-but-malformed value is an error: silently pooling the wrong position would
+    corrupt every embedding the model produces.
+    """
+    path = _local_sparse_info_path(model_name_or_path)
+    if path is None:
+        # A real local directory without the optional sidecar is a confirmed absence, not
+        # a malformed Hub repo id. Absolute nonexistent paths retain the same local
+        # checkpoint semantics for callers probing a not-yet-created directory.
+        is_local = isinstance(model_name_or_path, str) and (
+            os.path.isdir(model_name_or_path) or os.path.isabs(model_name_or_path)
+        )
+        if is_local:
+            return 0
+        path = _hub_sparse_info_path(
+            model_name_or_path, token = token, cache_dir = cache_dir, revision = revision
+        )
+    if path is None:
+        return 0
+
+    with open(path, encoding = "utf-8") as file:
+        sparse_info = json.load(file)
+
+    if not isinstance(sparse_info, dict) or NUM_EOS_TOKENS_KEY not in sparse_info:
+        return 0
+
+    value = sparse_info[NUM_EOS_TOKENS_KEY]
+    _validate_num_eos_tokens(value, source = path)
+    return int(value)
+
+
+def _validate_num_eos_tokens(value: Any, source: str | None = None) -> None:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        location = f" in {source}" if source else ""
+        raise ValueError(
+            f"Unsloth: `{NUM_EOS_TOKENS_KEY}`{location} must be a non-negative integer, "
+            f"got {value!r}."
+        )
+
+
+def _resolve_fast_tokenizer(tokenizer: Any) -> Any:
+    """Unwrap a processor to the tokenizer that actually encodes text."""
+    inner = getattr(tokenizer, "tokenizer", None)
+    return tokenizer if inner is None else inner
+
+
+def _backend_tokenizer(tokenizer: Any) -> Any:
+    """The `tokenizers.Tokenizer` behind a fast tokenizer; slow tokenizers have none."""
+    for attribute in ("_tokenizer", "backend_tokenizer"):
+        backend = getattr(tokenizer, attribute, None)
+        if backend is not None and hasattr(backend, "post_processor"):
+            return backend
+    raise ValueError(
+        f"Unsloth: {type(tokenizer).__name__} has no fast (`tokenizers`) backend, so the "
+        f"UEmbed `{EOS_TOKEN}` block cannot be appended. Load the checkpoint with a fast "
+        f"tokenizer / processor."
+    )
+
+
+def _eos_token_id(tokenizer: Any, eos_token: str) -> int:
+    """The vocabulary id of `eos_token`, refusing an unknown-token fallback."""
+    token_id = tokenizer.convert_tokens_to_ids(eos_token)
+    maps_to_unknown = token_id == getattr(tokenizer, "unk_token_id", None) and eos_token != getattr(
+        tokenizer, "unk_token", None
+    )
+    if token_id is None or maps_to_unknown:
+        raise ValueError(
+            f"Unsloth: `{eos_token}` is not in this tokenizer's vocabulary (id {token_id!r}), so "
+            f"the UEmbed EOS block would be appended as unknown tokens. This checkpoint does not "
+            f"look like a UEmbed model."
+        )
+    return int(token_id)
+
+
+def build_eos_post_processor(
+    tokenizer: Any,
+    num_eos_tokens: int,
+    eos_token: str = EOS_TOKEN,
+) -> Any:
+    """Make `tokenizer` append `num_eos_tokens` x `eos_token` after every encoded input.
+
+    Mirrors upstream `Qwen35Embedder.update_processor()`: a `TemplateProcessing`
+    post-processor appends the block to a single sequence and to both halves of a pair,
+    and padding moves to the right so the block stays at the end of the real tokens --
+    that is the position `offset_last_token_pool` counts back from.
+
+    Opt-in: `num_eos_tokens = 0` (i.e. every checkpoint without a `sparse_info.json`)
+    attaches nothing and leaves the tokenizer exactly as it was.
+
+    Args:
+        tokenizer: a fast tokenizer, or a processor owning one as `.tokenizer`.
+        num_eos_tokens: size of the EOS block; 0 disables the post-processor entirely.
+        eos_token: the token to repeat, `<|endoftext|>` for UEmbed.
+
+    Returns:
+        The attached `TemplateProcessing`, or None when nothing was attached.
+
+    Raises:
+        ValueError: if `num_eos_tokens` is not a non-negative integer, if the tokenizer
+            has no fast backend, or if `eos_token` is missing from the vocabulary.
+    """
+    _validate_num_eos_tokens(num_eos_tokens)
+    if num_eos_tokens == 0:
+        return None
+
+    from tokenizers.processors import TemplateProcessing
+
+    fast_tokenizer = _resolve_fast_tokenizer(tokenizer)
+    backend = _backend_tokenizer(fast_tokenizer)
+    eos_token_id = _eos_token_id(fast_tokenizer, eos_token)
+
+    block = " ".join([eos_token] * num_eos_tokens)
+    template = TemplateProcessing(
+        single = f"$A {block}",
+        pair = f"$A {block} $B {block}",
+        special_tokens = [(eos_token, eos_token_id)],
+    )
+    backend.post_processor = template
+    fast_tokenizer.padding_side = "right"
+    return template
+
+
+# The instruction the reference wraps every input in, the placeholder it emits when an
+# input carries no content at all, and the order it emits the content chunks in.
+DEFAULT_INSTRUCTION = "Represent the user's input."
+NULL_CONTENT_TEXT = "NULL"
+CONTENT_ORDER = ("video", "image", "text")
+
+
+def _content_value(field: str, value: Any) -> Any | None:
+    """The chunk value for `field`, or None when the caller supplied nothing usable."""
+    if value is None:
+        return None
+    if isinstance(value, str) and value.strip() == "":
+        return None
+    return value
+
+
+def _input_fields(model_input: Any) -> dict[str, Any]:
+    """Normalise one `encode()` item into `{modality: value}`.
+
+    A bare string is text and a PIL-shaped object is an image, matching what the existing
+    embedding path already accepts. Anything else is refused rather than guessed at:
+    silently filing a video tensor under `image` would corrupt every embedding.
+    """
+    if model_input is None:
+        return {}
+    if isinstance(model_input, str):
+        return {"text": model_input}
+    if isinstance(model_input, dict):
+        return dict(model_input)
+    if hasattr(model_input, "mode") and hasattr(model_input, "size"):  # PIL.Image.Image
+        return {"image": model_input}
+    raise ValueError(
+        f"Unsloth: UEmbed input formatting expects a string, a PIL image, or a dict of "
+        f"{list(CONTENT_ORDER)} entries, got {type(model_input).__name__}. Pass e.g. "
+        f"`{{'image': image, 'text': 'a caption'}}`."
+    )
+
+
+def _as_input_list(model_inputs: Any) -> list[Any]:
+    """A batch of one when the caller passed a single item (a dict is one item, not many)."""
+    if isinstance(model_inputs, (list, tuple)):
+        return list(model_inputs)
+    return [model_inputs]
+
+
+def build_uembed_conversation(
+    model_input: Any, instruction: str | None = None
+) -> list[dict[str, Any]]:
+    """Wrap one input in the reference instruction conversation.
+
+    Mirrors upstream `Qwen35Embedder.format_model_input`: a system message carrying the
+    instruction, then a user message carrying the content as `video, image, text` -- the
+    reference order, not the caller's dict order, because the rendered prompt is what the
+    model was trained on. An input with no usable content becomes a single `NULL` text
+    chunk so the conversation is never empty.
+
+    Args:
+        model_input: a dict of `{"text": ..., "image": ..., "video": ...}` entries, a bare
+            string (text), a PIL image, or None.
+        instruction: overrides `DEFAULT_INSTRUCTION` for this input.
+
+    Returns:
+        `[{"role": "system", ...}, {"role": "user", ...}]` in the reference content order.
+    """
+    fields = _input_fields(model_input)
+    content = []
+    for field in CONTENT_ORDER:
+        value = _content_value(field, fields.get(field))
+        if value is not None:
+            content.append({"type": field, field: value})
+    if not content:
+        content = [{"type": "text", "text": NULL_CONTENT_TEXT}]
+
+    return [
+        {
+            "role": "system",
+            "content": [
+                {
+                    "type": "text",
+                    "text": DEFAULT_INSTRUCTION if instruction is None else instruction,
+                }
+            ],
+        },
+        {"role": "user", "content": content},
+    ]
+
+
+def _render_conversations(processor: Any, conversations: list[list[dict[str, Any]]]) -> list[str]:
+    """Render whole conversations to prompt strings via the processor's chat template."""
+    rendered = processor.apply_chat_template(
+        conversations,
+        add_generation_prompt = True,
+        tokenize = False,
+    )
+    if isinstance(rendered, str):
+        # Some processors collapse a single conversation to one string.
+        return [rendered]
+    return list(rendered)
+
+
+def render_uembed_prompts(
+    processor: Any,
+    model_inputs: Any,
+    instruction: str | None = None,
+) -> list[str]:
+    """The instruction-wrapped prompt string for every input, ready for tokenization."""
+    conversations = [
+        build_uembed_conversation(model_input, instruction)
+        for model_input in _as_input_list(model_inputs)
+    ]
+    return _render_conversations(processor, conversations)
+
+
+def _collect_vision_inputs(
+    conversations: list[list[dict[str, Any]]],
+) -> tuple[list[Any], list[Any]]:
+    """The images and videos referenced by `conversations`, in prompt order."""
+    images, videos = [], []
+    for conversation in conversations:
+        for message in conversation:
+            for chunk in message["content"]:
+                if chunk["type"] == "image":
+                    images.append(chunk["image"])
+                elif chunk["type"] == "video":
+                    videos.append(chunk["video"])
+    return images, videos
+
+
+def uembed_preprocess_inputs(
+    processor: Any,
+    model_inputs: Any,
+    instruction: str | None = None,
+    **processor_kwargs: Any,
+) -> Any:
+    """Tokenize `model_inputs` the way the reference does: wrap, render, then process.
+
+    Mirrors upstream `Qwen35Embedder._preprocess_inputs`: the rendered prompts go to the
+    processor as `text`, with the images / videos they reference alongside. Modality
+    arguments are omitted entirely when the batch has none, since processors reject an
+    empty list for a modality they were not given.
+
+    Args:
+        processor: the multimodal processor (must own a chat template).
+        model_inputs: one input or a list of them (see `build_uembed_conversation`).
+        instruction: overrides `DEFAULT_INSTRUCTION` for the whole batch.
+        **processor_kwargs: merged over `padding` / `return_tensors` on the processor call.
+
+    Returns:
+        Whatever the processor returns (a `BatchFeature` of model-ready tensors).
+    """
+    conversations = [
+        build_uembed_conversation(model_input, instruction)
+        for model_input in _as_input_list(model_inputs)
+    ]
+    texts = _render_conversations(processor, conversations)
+    images, videos = _collect_vision_inputs(conversations)
+
+    call_kwargs: dict[str, Any] = {"text": texts, "padding": True, "return_tensors": "pt"}
+    if images:
+        call_kwargs["images"] = images
+    if videos:
+        call_kwargs["videos"] = videos
+    call_kwargs.update(processor_kwargs)
+    return processor(**call_kwargs)
+
+
+def _module_processor(transformer_module: Any) -> Any:
+    """The processor a sentence-transformers Transformer module encodes with."""
+    processor = getattr(transformer_module, "processor", None)
+    if processor is None:
+        processor = getattr(transformer_module, "tokenizer", None)
+    if processor is None:
+        raise ValueError(
+            f"Unsloth: {type(transformer_module).__name__} exposes neither `processor` nor "
+            f"`tokenizer`, so UEmbed input formatting has nothing to tokenize with."
+        )
+    return processor
+
+
+def attach_uembed_input_format(transformer_module: Any, instruction: str | None = None) -> bool:
+    """Make `transformer_module` wrap every input in the reference instruction conversation.
+
+    Replaces the module's input-preparation method (`preprocess`, or `tokenize` on older
+    sentence-transformers) with the reference path, because the stock one applies the
+    processor's chat template itself -- letting it also see a pre-rendered prompt would
+    wrap the input twice. The original method stays reachable as
+    `_unsloth_uembed_original_preprocess`.
+
+    Opt-in: only `from_pretrained` calls this, and only for a checkpoint that asks for the
+    trailing EOS block (`num_eos_tokens > 0`). Every other embedder keeps the stock path.
+
+    Args:
+        transformer_module: the first module of the SentenceTransformer.
+        instruction: overrides `DEFAULT_INSTRUCTION` for this model.
+
+    Returns:
+        True when the path was attached, False when it already was (idempotent).
+
+    Raises:
+        ValueError: if the module has no input-preparation method, or its processor has no
+            chat template to render the conversation with.
+    """
+    if getattr(transformer_module, "_unsloth_uembed_input_format", False):
+        return False
+
+    method_name = "preprocess" if hasattr(transformer_module, "preprocess") else "tokenize"
+    original = getattr(transformer_module, method_name, None)
+    if original is None:
+        raise ValueError(
+            f"Unsloth: {type(transformer_module).__name__} has neither `preprocess` nor "
+            f"`tokenize`, so UEmbed input formatting cannot be attached to it."
+        )
+
+    processor = _module_processor(transformer_module)
+    if not hasattr(processor, "apply_chat_template"):
+        raise ValueError(
+            f"Unsloth: {type(processor).__name__} has no chat template "
+            f"(`apply_chat_template`), so the UEmbed instruction conversation cannot be "
+            f"rendered. This checkpoint does not look like a UEmbed model."
+        )
+
+    def preprocess_with_instruction(
+        inputs: Any,
+        prompt: Any = None,
+        **kwargs: Any,
+    ) -> Any:
+        if prompt is not None:
+            # The instruction IS this path's system prompt; accepting a second one would
+            # silently drop one of the two.
+            raise ValueError(
+                "Unsloth: this UEmbed embedder already wraps inputs in its own system "
+                "instruction, so `prompt` cannot be used. Pass `instruction` to "
+                "`attach_uembed_input_format` instead."
+            )
+        # Remaining kwargs are sentence-transformers plumbing (e.g. `processing_kwargs`),
+        # not processor arguments; the reference call below owns the processor kwargs.
+        extra_kwargs: dict[str, Any] = {}
+        max_length = getattr(transformer_module, "max_seq_length", None)
+        if isinstance(max_length, int) and not isinstance(max_length, bool) and max_length > 0:
+            extra_kwargs["truncation"] = True
+            extra_kwargs["max_length"] = max_length
+        return uembed_preprocess_inputs(
+            _module_processor(transformer_module),
+            inputs,
+            instruction = instruction,
+            **extra_kwargs,
+        )
+
+    setattr(transformer_module, method_name, preprocess_with_instruction)
+    transformer_module._unsloth_uembed_original_preprocess = original
+    transformer_module._unsloth_uembed_input_format = True
+    return True
+
+
+def offset_last_token_pool(
+    hidden_state: torch.Tensor, attention_mask: torch.Tensor, num_eos_tokens: int
+) -> torch.Tensor:
+    """Pool `hidden_state` at `last_non_pad_index - num_eos_tokens` for every row.
+
+    Args:
+        hidden_state: `(batch, sequence, hidden)` transformer output.
+        attention_mask: `(batch, sequence)` mask, 1 for real tokens and 0 for padding.
+            Left, right and interior padding all resolve to the last unmasked position.
+        num_eos_tokens: size of the trailing EOS block to skip; 0 = plain last token.
+
+    Raises:
+        ValueError: if a row is entirely padding, or if `num_eos_tokens` reaches past the
+            start of the sequence. Both would otherwise index backwards from the end and
+            return a silently wrong vector.
+    """
+    _validate_num_eos_tokens(num_eos_tokens)
+    if hidden_state.dim() != 3:
+        raise ValueError(
+            f"Unsloth: offset pooling expects a (batch, sequence, hidden) hidden state, "
+            f"got shape {tuple(hidden_state.shape)}."
+        )
+
+    mask = attention_mask.to(device = hidden_state.device, dtype = torch.long)
+    empty_rows = (mask.sum(dim = 1) == 0).nonzero(as_tuple = False).flatten()
+    if empty_rows.numel():
+        raise ValueError(
+            f"Unsloth: attention_mask has no unmasked position for batch row(s) "
+            f"{empty_rows.tolist()}; offset pooling has nothing to pool there."
+        )
+
+    # Last unmasked position: cumsum peaks at the final real token, and multiplying by
+    # the mask keeps padding from tying that peak.
+    last_indices = (mask.cumsum(dim = 1) * mask).argmax(dim = 1)
+    target_indices = last_indices - num_eos_tokens
+
+    short_rows = (target_indices < 0).nonzero(as_tuple = False).flatten()
+    if short_rows.numel():
+        raise ValueError(
+            f"Unsloth: num_eos_tokens = {num_eos_tokens} exceeds the content length of "
+            f"batch row(s) {short_rows.tolist()} (last unmasked index "
+            f"{last_indices[short_rows].tolist()}). Every sequence must be longer than "
+            f"the trailing EOS block."
+        )
+
+    batch_indices = torch.arange(hidden_state.shape[0], device = hidden_state.device)
+    return hidden_state[batch_indices, target_indices]
+
+
+class OffsetLastTokenPooling(torch.nn.Module):
+    """sentence-transformers pooling module for UEmbed-style dense vectors.
+
+    Drop-in replacement for `Pooling(pooling_mode = "lasttoken")` that skips the trailing
+    `num_eos_tokens` positions. With `num_eos_tokens = 0` it is exactly `lasttoken`.
+    """
+
+    config_keys = ["word_embedding_dimension", "num_eos_tokens"]
+
+    def __init__(
+        self,
+        word_embedding_dimension: int,
+        num_eos_tokens: int = 0,
+    ) -> None:
+        super().__init__()
+        _validate_num_eos_tokens(num_eos_tokens)
+        self.word_embedding_dimension = int(word_embedding_dimension)
+        self.num_eos_tokens = int(num_eos_tokens)
+
+    def forward(self, features: dict[str, Any], **kwargs: Any) -> dict[str, Any]:
+        token_embeddings = features["token_embeddings"]
+        attention_mask = features.get("attention_mask")
+        if attention_mask is None or attention_mask.size(-1) != token_embeddings.size(1):
+            # Same fallback as sentence-transformers' Pooling: no mask means no padding.
+            attention_mask = torch.ones(
+                token_embeddings.shape[:-1], device = token_embeddings.device, dtype = torch.long
+            )
+
+        features["sentence_embedding"] = offset_last_token_pool(
+            token_embeddings, attention_mask, self.num_eos_tokens
+        )
+        return features
+
+    def get_embedding_dimension(self) -> int:
+        return self.word_embedding_dimension
+
+    def get_sentence_embedding_dimension(self) -> int:
+        return self.word_embedding_dimension
+
+    def get_config_dict(self) -> dict[str, Any]:
+        return {key: getattr(self, key) for key in self.config_keys}
+
+    def save(self, output_path: str, *args: Any, **kwargs: Any) -> None:
+        os.makedirs(output_path, exist_ok = True)
+        with open(os.path.join(output_path, "config.json"), "w", encoding = "utf-8") as file:
+            json.dump(self.get_config_dict(), file, indent = 2)
+
+    @classmethod
+    def load(cls, input_path: str, *args: Any, **kwargs: Any) -> OffsetLastTokenPooling:
+        subfolder = kwargs.get("subfolder", "")
+        if subfolder:
+            if os.path.isdir(input_path):
+                input_path = os.path.join(input_path, subfolder)
+            else:
+                try:
+                    from sentence_transformers.util import load_dir_path
+                except ImportError as exception:
+                    raise RuntimeError(
+                        "Unsloth: sentence-transformers is required to resolve a remote "
+                        "serialized OffsetLastTokenPooling module."
+                    ) from exception
+                input_path = load_dir_path(
+                    model_name_or_path = input_path,
+                    subfolder = subfolder,
+                    token = kwargs.get("token"),
+                    cache_folder = kwargs.get("cache_folder"),
+                    revision = kwargs.get("revision"),
+                    local_files_only = kwargs.get("local_files_only", False),
+                )
+        with open(os.path.join(input_path, "config.json"), encoding = "utf-8") as file:
+            config = json.load(file)
+        return cls(**{key: config[key] for key in cls.config_keys if key in config})
+
+    def __repr__(self) -> str:
+        return f"OffsetLastTokenPooling({self.get_config_dict()})"

--- a/unsloth/models/uembed_sidecar.py
+++ b/unsloth/models/uembed_sidecar.py
@@ -1,0 +1,221 @@
+# Copyright 2023-present Daniel Han-Chen & the Unsloth team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Adapter-level sidecar for UEmbed's trainable SPLADE heads.
+
+The sparse heads are trained alongside the LoRA adapter, so they are part of the result of
+a fine-tune and have to be written out with it. They are kept as a SIDECAR pair -
+`sparse_weights.pt` (UEmbed's own `sparse_lm_heads` / `sparse_bias` layout) plus
+`sparse_info.json` (`num_eos_tokens`) - written next to the adapter rather than folded into
+the model's safetensors. That is what lets them survive a `merged_16bit` export: the merge
+rewrites the backbone weights and never touches these two files, and the saved directory
+then loads back as a UEmbed checkpoint through the very same path as the original.
+
+Both halves are opt-in: `save_uembed_sparse_sidecar` returns False (writing nothing) for a
+model without a SPLADE head, and `load_uembed_sparse_sidecar` returns False for a directory
+without the sidecar, so plain dense embedders are untouched.
+
+The reload is attach-AWARE. A directory saved from sentence-transformers may already
+rebuild the sparse module from its own subfolder, so blindly attaching again would leave
+the pipeline with two heads and a doubled sparse dimension. When a head is already present
+this repopulates it from the sidecar (which holds the newest, trained values) instead.
+
+Torch-only, so it imports without an accelerator and without importing `unsloth`.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+from typing import Any
+
+import torch
+
+
+def _sibling(module_name: str, standalone_name: str):
+    """Import a sibling `uembed_*` module, by package or (standalone) by file path.
+
+    The standalone names match the ones the siblings use for each other, so every entry
+    point ends up sharing ONE copy of each module and `isinstance` keeps working.
+    """
+    if __package__:
+        try:
+            return importlib.import_module(f".{module_name}", __package__)
+        except ImportError:
+            pass
+
+    if standalone_name in sys.modules:
+        return sys.modules[standalone_name]
+    path = os.path.join(os.path.dirname(os.path.abspath(__file__)), f"{module_name}.py")
+    spec = importlib.util.spec_from_file_location(standalone_name, path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[standalone_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _uembed_splade():
+    return _sibling("uembed_splade", "unsloth_uembed_splade_direct")
+
+
+def _uembed_wiring():
+    return _sibling("uembed_wiring", "unsloth_uembed_wiring_direct")
+
+
+def _uembed_pooling():
+    return _sibling("uembed_pooling", "unsloth_uembed_pooling_direct")
+
+
+def _sidecar_weights_path(directory: Any) -> str | None:
+    """Path of the directory's `sparse_weights.pt`, or None when it has none."""
+    if not isinstance(directory, str) or not os.path.isdir(directory):
+        return None
+    path = os.path.join(directory, _uembed_splade().SPARSE_WEIGHTS_FILENAME)
+    return path if os.path.isfile(path) else None
+
+
+def _saved_num_eos_tokens(directory: str) -> int | None:
+    """`num_eos_tokens` from the directory's own `sparse_info.json`, else None.
+
+    None means "the directory does not say", which leaves an already-loaded head's value
+    alone rather than resetting it to 0 and disabling `splade.last`.
+    """
+    pooling = _uembed_pooling()
+    if not os.path.isfile(os.path.join(directory, pooling.SPARSE_INFO_FILENAME)):
+        return None
+    return pooling.read_num_eos_tokens(directory)
+
+
+def _write_sparse_info(directory: str, num_eos_tokens: int) -> None:
+    """Emit `sparse_info.json`, keeping any other keys the checkpoint already carried."""
+    pooling = _uembed_pooling()
+    path = os.path.join(directory, pooling.SPARSE_INFO_FILENAME)
+    sparse_info: dict[str, Any] = {}
+    if os.path.isfile(path):
+        with open(path, encoding = "utf-8") as file:
+            existing = json.load(file)
+        if isinstance(existing, dict):
+            sparse_info = existing
+    sparse_info[pooling.NUM_EOS_TOKENS_KEY] = int(num_eos_tokens)
+    with open(path, "w", encoding = "utf-8") as file:
+        json.dump(sparse_info, file, indent = 2)
+
+
+def save_uembed_sparse_sidecar(model: Any, save_directory: str) -> bool:
+    """Write the model's trained SPLADE heads next to the adapter in `save_directory`.
+
+    Returns False without writing anything when the model carries no sparse head, which is
+    every non-UEmbed embedder.
+    """
+    module = _uembed_wiring().find_uembed_sparse_output(model)
+    if module is None:
+        return False
+
+    splade = _uembed_splade()
+    head = module.head
+    os.makedirs(save_directory, exist_ok = True)
+    torch.save(
+        {
+            splade.SPARSE_LM_HEADS_KEY: [
+                weight.detach().cpu().clone() for weight in head.sparse_lm_heads
+            ],
+            splade.SPARSE_BIAS_KEY: [bias.detach().cpu().clone() for bias in head.sparse_bias],
+        },
+        os.path.join(save_directory, splade.SPARSE_WEIGHTS_FILENAME),
+    )
+    _write_sparse_info(save_directory, head.num_eos_tokens)
+    return True
+
+
+def _restore_in_place(head: Any, path: str, num_eos_tokens: int | None) -> bool:
+    """Copy the sidecar's tensors into an existing head; False when the layout differs.
+
+    Nothing is written until every shape has been checked, so a mismatched sidecar leaves
+    the head as it was instead of half-overwritten.
+    """
+    splade = _uembed_splade()
+    state = torch.load(path, map_location = "cpu", weights_only = True)
+    missing = [
+        key
+        for key in (splade.SPARSE_LM_HEADS_KEY, splade.SPARSE_BIAS_KEY)
+        if not isinstance(state, dict) or key not in state
+    ]
+    if missing:
+        raise ValueError(
+            f"Unsloth: `{path}` is missing the key(s) {missing}; expected a dict with "
+            f"`{splade.SPARSE_LM_HEADS_KEY}` and `{splade.SPARSE_BIAS_KEY}`."
+        )
+
+    saved = list(state[splade.SPARSE_LM_HEADS_KEY]) + list(state[splade.SPARSE_BIAS_KEY])
+    current = list(head.sparse_lm_heads) + list(head.sparse_bias)
+    if len(saved) != len(current):
+        return False
+    if any(tuple(a.shape) != tuple(b.shape) for a, b in zip(current, saved)):
+        return False
+
+    with torch.no_grad():
+        for parameter, value in zip(current, saved):
+            parameter.copy_(value.to(device = parameter.device, dtype = parameter.dtype))
+    if num_eos_tokens is not None:
+        head.num_eos_tokens = int(num_eos_tokens)
+    return True
+
+
+def load_uembed_sparse_sidecar(
+    model: Any,
+    model_dir: str,
+    mode: str | None = None,
+    num_eos_tokens: int | None = None,
+) -> bool:
+    """Reload `model_dir`'s sparse sidecar into `model`'s pipeline.
+
+    Attach-aware: a model that already carries a sparse head has that head repopulated from
+    the sidecar, so a reload can never stack a second one. Returns False when the directory
+    ships no `sparse_weights.pt`.
+    """
+    path = _sidecar_weights_path(model_dir)
+    if path is None:
+        return False
+
+    splade = _uembed_splade()
+    wiring = _uembed_wiring()
+    if num_eos_tokens is None:
+        num_eos_tokens = _saved_num_eos_tokens(model_dir)
+
+    existing = wiring.find_uembed_sparse_output(model)
+    if existing is None:
+        head = splade.SpladeHead.from_checkpoint(model_dir, num_eos_tokens = num_eos_tokens)
+        return wiring.attach_uembed_sparse_output(model, head, mode)
+
+    # A module reconstructed from modules.json has no process-local encode wrapper.
+    # Restore it before repopulating the existing head; the helper is idempotent.
+    wiring.patch_uembed_sparse_encode(model)
+    if mode is not None:
+        existing.set_mode(mode)
+    if _restore_in_place(existing.head, path, num_eos_tokens):
+        return True
+
+    # A sidecar from a differently shaped checkpoint: swap the head rather than append a
+    # second module, keeping the pipeline at exactly one sparse head.
+    head = splade.SpladeHead.from_checkpoint(model_dir, num_eos_tokens = num_eos_tokens)
+    reference = next(iter(existing.head.parameters()), None)
+    if reference is not None:
+        if reference.is_floating_point():
+            head.to(device = reference.device, dtype = reference.dtype)
+        else:
+            head.to(device = reference.device)
+    existing.head = head
+    return True

--- a/unsloth/models/uembed_splade.py
+++ b/unsloth/models/uembed_splade.py
@@ -1,0 +1,248 @@
+# Copyright 2023-present Daniel Han-Chen & the Unsloth team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""SPLADE sparse pooling head for UEmbed (Qwen3.5) style embedding checkpoints.
+
+UEmbed ships a `sparse_weights.pt` sidecar holding `num_eos_tokens` linear heads
+(`sparse_lm_heads` + `sparse_bias`) that project hidden states onto vocabulary logits.
+Two modes build the sparse vector (paper Eq. 3-4, arXiv:2608.02583):
+
+    splade.last : head i reads `last_index - ((N - 1) - i)`, so head 0 pools the first
+                  EOS slot and head N-1 the last; logits concatenated, `log1p(relu(.))`.
+    splade.max  : head 0 runs over every position, `log1p(relu(.))`, padding masked out,
+                  per-dimension max over the sequence.
+
+The heads are trainable `nn.Parameter`s so the trainer can fine-tune them alongside the
+LoRA adapter. Opt-in: constructed only when a SPLADE mode is requested, so dense
+embedders are untouched. Torch-only, so it imports without an accelerator.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+from typing import Any, Sequence
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+
+
+# Sidecar file UEmbed ships next to the weights, and the keys it stores.
+SPARSE_WEIGHTS_FILENAME = "sparse_weights.pt"
+SPARSE_LM_HEADS_KEY = "sparse_lm_heads"
+SPARSE_BIAS_KEY = "sparse_bias"
+
+# Pooling modes that select this module. Deliberately disjoint from the stock
+# sentence-transformers modes so existing dense embedders never reach this code.
+SPLADE_LAST = "splade.last"
+SPLADE_MAX = "splade.max"
+SPLADE_POOLING_MODES = frozenset({SPLADE_LAST, SPLADE_MAX})
+
+
+def is_splade_pooling_mode(pooling_mode: Any) -> bool:
+    """True when the caller explicitly asked for a SPLADE sparse pooling mode."""
+    return isinstance(pooling_mode, str) and pooling_mode in SPLADE_POOLING_MODES
+
+
+def _uembed_pooling():
+    """Import the sibling pooling module, by package or (standalone) by file path.
+
+    The file-path branch keeps this usable without importing all of `unsloth`.
+    """
+    try:
+        from . import uembed_pooling  # noqa: PLC0415
+        return uembed_pooling
+    except ImportError:
+        pass
+
+    name = "unsloth_uembed_pooling_direct"
+    if name in sys.modules:
+        return sys.modules[name]
+    path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "uembed_pooling.py")
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class SpladeHead(nn.Module):
+    """Trainable SPLADE sparse pooling heads loaded from UEmbed's `sparse_weights.pt`.
+
+    `sparse_lm_heads` are `(vocab_i, hidden)` matrices and `sparse_bias` the matching
+    `(vocab_i,)` vectors, one pair per EOS slot. `num_eos_tokens` (from `sparse_info.json`)
+    is how many heads `splade.last` consumes; 0 means no EOS block, so `splade.last` is
+    unavailable. An empty head list is the "sidecar not loaded" state: construction
+    succeeds so the module can be wired before weights arrive, but pooling then raises
+    instead of returning a wrong-shaped vector.
+    """
+
+    def __init__(
+        self,
+        sparse_lm_heads: Sequence[torch.Tensor],
+        sparse_bias: Sequence[torch.Tensor],
+        num_eos_tokens: int = 0,
+    ) -> None:
+        super().__init__()
+        heads, biases = list(sparse_lm_heads), list(sparse_bias)
+        if len(heads) != len(biases):
+            raise ValueError(
+                f"Unsloth: `{SPARSE_LM_HEADS_KEY}` has {len(heads)} entries but "
+                f"`{SPARSE_BIAS_KEY}` has {len(biases)}; they must match one-to-one."
+            )
+        for index, (weight, bias) in enumerate(zip(heads, biases)):
+            if weight.dim() != 2 or bias.dim() != 1 or bias.shape[0] != weight.shape[0]:
+                raise ValueError(
+                    f"Unsloth: sparse head {index} must be a (vocab, hidden) matrix with a "
+                    f"(vocab,) bias, got {tuple(weight.shape)} and {tuple(bias.shape)}."
+                )
+            if weight.shape[1] != heads[0].shape[1]:
+                raise ValueError(
+                    f"Unsloth: sparse head {index} expects hidden size {weight.shape[1]}, but "
+                    f"head 0 expects {heads[0].shape[1]}."
+                )
+        is_integer = isinstance(num_eos_tokens, int) and not isinstance(num_eos_tokens, bool)
+        if not is_integer or num_eos_tokens < 0:
+            raise ValueError(
+                f"Unsloth: num_eos_tokens must be a non-negative integer, got {num_eos_tokens!r}."
+            )
+
+        self.num_eos_tokens = int(num_eos_tokens)
+        self.sparse_lm_heads = nn.ParameterList(
+            [nn.Parameter(weight.detach().clone(), requires_grad = True) for weight in heads]
+        )
+        self.sparse_bias = nn.ParameterList(
+            [nn.Parameter(bias.detach().clone(), requires_grad = True) for bias in biases]
+        )
+
+    @property
+    def num_heads(self) -> int:
+        return len(self.sparse_lm_heads)
+
+    def _require_heads(self, mode: str) -> None:
+        if self.num_heads == 0:
+            raise ValueError(
+                f"Unsloth: `{mode}` pooling needs the sparse heads, but none are loaded. "
+                f"Load `{SPARSE_WEIGHTS_FILENAME}` via `SpladeHead.from_checkpoint(...)`."
+            )
+
+    def _masked_last_indices(
+        self, hidden_state: torch.Tensor, attention_mask: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if hidden_state.dim() != 3:
+            raise ValueError(
+                f"Unsloth: SPLADE pooling expects a (batch, sequence, hidden) hidden state, "
+                f"got shape {tuple(hidden_state.shape)}."
+            )
+        mask = attention_mask.to(device = hidden_state.device, dtype = torch.long)
+        empty_rows = (mask.sum(dim = 1) == 0).nonzero(as_tuple = False).flatten()
+        if empty_rows.numel():
+            raise ValueError(
+                f"Unsloth: attention_mask has no unmasked position for batch row(s) "
+                f"{empty_rows.tolist()}; SPLADE pooling has nothing to pool there."
+            )
+        # Last unmasked position: cumsum peaks at the final real token, mask breaks ties.
+        return mask, (mask.cumsum(dim = 1) * mask).argmax(dim = 1)
+
+    def splade_last(self, hidden_state: torch.Tensor, attn_mask: torch.Tensor) -> torch.Tensor:
+        """Concatenate one head per EOS slot, then `log1p(relu(.))` (paper Eq. 3-4)."""
+        self._require_heads(SPLADE_LAST)
+        num_eos = self.num_eos_tokens
+        if num_eos == 0:
+            raise ValueError(
+                f"Unsloth: `{SPLADE_LAST}` pooling needs num_eos_tokens > 0, but the "
+                f"checkpoint reports 0 (no trailing EOS block). Use `{SPLADE_MAX}` instead."
+            )
+        if num_eos > self.num_heads:
+            raise ValueError(
+                f"Unsloth: `{SPLADE_LAST}` pooling needs {num_eos} sparse heads "
+                f"(num_eos_tokens), but only {self.num_heads} were loaded."
+            )
+
+        _, last_indices = self._masked_last_indices(hidden_state, attn_mask)
+        # Head 0 reaches furthest back, so it alone bounds how long a sequence must be.
+        short_rows = (last_indices - (num_eos - 1) < 0).nonzero(as_tuple = False).flatten()
+        if short_rows.numel():
+            raise ValueError(
+                f"Unsloth: batch row(s) {short_rows.tolist()} are shorter than the "
+                f"{num_eos}-token EOS block (last unmasked index "
+                f"{last_indices[short_rows].tolist()}); `{SPLADE_LAST}` cannot pool them."
+            )
+
+        batch_indices = torch.arange(hidden_state.shape[0], device = hidden_state.device)
+        logits = []
+        for index in range(num_eos):
+            offset = (num_eos - 1) - index
+            pooled = hidden_state[batch_indices, last_indices - offset]
+            logits.append(F.linear(pooled, self.sparse_lm_heads[index], self.sparse_bias[index]))
+        return torch.log1p(torch.relu(torch.cat(logits, dim = -1)))
+
+    def splade_max(self, hidden_state: torch.Tensor, attn_mask: torch.Tensor) -> torch.Tensor:
+        """Head 0 over every position, `log1p(relu(.))`, max over the unmasked sequence."""
+        self._require_heads(SPLADE_MAX)
+        mask, _ = self._masked_last_indices(hidden_state, attn_mask)
+        logits = F.linear(hidden_state, self.sparse_lm_heads[0], self.sparse_bias[0])
+        weights = torch.log1p(torch.relu(logits))
+        weights = weights.masked_fill(~mask.unsqueeze(-1).bool(), torch.finfo(weights.dtype).min)
+        return weights.max(dim = 1).values
+
+    def forward(
+        self,
+        hidden_state: torch.Tensor,
+        attention_mask: torch.Tensor,
+        mode: str = SPLADE_LAST,
+    ) -> torch.Tensor:
+        if mode == SPLADE_LAST:
+            return self.splade_last(hidden_state, attention_mask)
+        if mode == SPLADE_MAX:
+            return self.splade_max(hidden_state, attention_mask)
+        raise ValueError(
+            f"Unsloth: unknown SPLADE pooling mode {mode!r}; expected one of "
+            f"{sorted(SPLADE_POOLING_MODES)}."
+        )
+
+    @classmethod
+    def from_checkpoint(
+        cls,
+        model_dir: str,
+        num_eos_tokens: int | None = None,
+        token: str | bool | None = None,
+        cache_dir: str | None = None,
+        revision: str | None = None,
+    ) -> SpladeHead:
+        """Load `sparse_weights.pt`; `num_eos_tokens` defaults to `sparse_info.json`."""
+        path = os.path.join(model_dir, SPARSE_WEIGHTS_FILENAME)
+        if not os.path.isfile(path):
+            raise FileNotFoundError(
+                f"Unsloth: `{SPARSE_WEIGHTS_FILENAME}` not found in `{model_dir}`; this "
+                f"checkpoint carries no SPLADE sparse heads."
+            )
+        state = torch.load(path, map_location = "cpu", weights_only = True)
+        keys = (SPARSE_LM_HEADS_KEY, SPARSE_BIAS_KEY)
+        missing = [key for key in keys if not isinstance(state, dict) or key not in state]
+        if missing:
+            raise ValueError(
+                f"Unsloth: `{path}` is missing the key(s) {missing}; expected a dict with "
+                f"`{SPARSE_LM_HEADS_KEY}` and `{SPARSE_BIAS_KEY}`."
+            )
+        if num_eos_tokens is None:
+            num_eos_tokens = _uembed_pooling().read_num_eos_tokens(
+                model_dir, token = token, cache_dir = cache_dir, revision = revision
+            )
+        return cls(state[SPARSE_LM_HEADS_KEY], state[SPARSE_BIAS_KEY], num_eos_tokens)
+
+    def extra_repr(self) -> str:
+        return f"num_heads={self.num_heads}, num_eos_tokens={self.num_eos_tokens}"

--- a/unsloth/models/uembed_wiring.py
+++ b/unsloth/models/uembed_wiring.py
@@ -1,0 +1,551 @@
+# Copyright 2023-present Daniel Han-Chen & the Unsloth team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Single-forward dense + sparse output wiring for UEmbed (Qwen3.5) embedders.
+
+UEmbed derives BOTH of its vectors from one causal forward pass: the dense vector is the
+hidden state preceding the trailing EOS block, and the sparse (SPLADE) vector is produced
+by `SpladeHead` from the very same hidden states. Running the transformer twice - once per
+output - would double the cost of every training step and every encode.
+
+`UEmbedSparseOutput` is therefore a sentence-transformers module, appended after the dense
+pooling: it reads `token_embeddings` + `attention_mask` (already in the features dict, so
+the transformer is not touched again) and writes `sparse_embedding` beside
+`sentence_embedding`. That single dict is what `SentenceTransformerTrainer` hands to
+`UEmbedUnifiedLoss`, which needs both keys.
+
+`encode()` is wrapped so callers can ask for `output_mode = "dense" | "sparse" | "both"`.
+The default, `"dense"`, delegates straight to the untouched sentence-transformers
+implementation, so existing embedders keep their exact return object. The wrapper is only
+installed on models that actually carry a `SpladeHead`, i.e. UEmbed checkpoints shipping
+`sparse_weights.pt`.
+
+Torch-only, so it imports without an accelerator and without importing `unsloth`.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+from typing import Any
+
+import torch
+from torch import nn
+
+
+# Features-dict keys of the sentence-transformers pipeline. `sparse_embedding` is the one
+# this module adds; the rest are produced upstream by the Transformer / Pooling modules.
+TOKEN_EMBEDDINGS_KEY = "token_embeddings"
+ATTENTION_MASK_KEY = "attention_mask"
+SENTENCE_EMBEDDING_KEY = "sentence_embedding"
+SPARSE_EMBEDDING_KEY = "sparse_embedding"
+
+# `encode(output_mode = ...)` values. "dense" is the default and is a pass-through.
+OUTPUT_MODE_DENSE = "dense"
+OUTPUT_MODE_SPARSE = "sparse"
+OUTPUT_MODE_BOTH = "both"
+OUTPUT_MODES = (OUTPUT_MODE_DENSE, OUTPUT_MODE_SPARSE, OUTPUT_MODE_BOTH)
+
+_CONFIG_FILENAME = "config.json"
+
+
+def _load_sibling(module_name: str, filename: str):
+    """Import a sibling by package or directly, without importing all of `unsloth`."""
+    try:
+        return __import__(f"{__package__}.{module_name}", fromlist = [module_name])
+    except (ImportError, TypeError):
+        pass
+
+    name = f"unsloth_{module_name}_direct"
+    if name in sys.modules:
+        return sys.modules[name]
+    path = os.path.join(os.path.dirname(os.path.abspath(__file__)), filename)
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _uembed_splade():
+    return _load_sibling("uembed_splade", "uembed_splade.py")
+
+
+def _uembed_pooling():
+    return _load_sibling("uembed_pooling", "uembed_pooling.py")
+
+
+class UEmbedSparseOutput(nn.Module):
+    """sentence-transformers module that adds UEmbed's sparse vector to the features dict.
+
+    It consumes the hidden states the transformer already emitted, so it costs one head
+    projection, never a second forward. The wrapped `SpladeHead` is a submodule, which is
+    what puts its parameters in `model.parameters()` (and therefore in the optimizer) and
+    keeps them trainable next to the LoRA adapter.
+    """
+
+    config_keys = ["mode", "num_eos_tokens"]
+
+    def __init__(
+        self,
+        head: nn.Module,
+        mode: str | None = None,
+    ) -> None:
+        super().__init__()
+        splade = _uembed_splade()
+        # Duck-typed on purpose: `SpladeHead` can legitimately be reached through more
+        # than one module object (package import vs the standalone file-path load), and an
+        # identity check would then reject a perfectly valid head.
+        if not isinstance(head, nn.Module) or not hasattr(head, "num_eos_tokens"):
+            raise ValueError(
+                f"Unsloth: UEmbedSparseOutput needs a SpladeHead, got " f"{type(head).__name__}."
+            )
+        if mode is None:
+            # `splade.last` reads the trailing EOS block; without one, only `splade.max`
+            # is defined for the checkpoint.
+            mode = splade.SPLADE_LAST if head.num_eos_tokens > 0 else splade.SPLADE_MAX
+        if not splade.is_splade_pooling_mode(mode):
+            raise ValueError(
+                f"Unsloth: unknown SPLADE pooling mode {mode!r}; expected one of "
+                f"{sorted(splade.SPLADE_POOLING_MODES)}."
+            )
+        self.head = head
+        self.mode = mode
+
+    @property
+    def num_eos_tokens(self) -> int:
+        return self.head.num_eos_tokens
+
+    def set_mode(self, mode: str) -> None:
+        """Switch between `splade.last` and `splade.max` without rebuilding the head."""
+        splade = _uembed_splade()
+        if not splade.is_splade_pooling_mode(mode):
+            raise ValueError(
+                f"Unsloth: unknown SPLADE pooling mode {mode!r}; expected one of "
+                f"{sorted(splade.SPLADE_POOLING_MODES)}."
+            )
+        self.mode = mode
+
+    def forward(self, features: dict[str, Any], **kwargs: Any) -> dict[str, Any]:
+        if TOKEN_EMBEDDINGS_KEY not in features:
+            raise KeyError(
+                f"Unsloth: the features dict has no `{TOKEN_EMBEDDINGS_KEY}`, so the "
+                f"UEmbed sparse head has no hidden states to pool. It must run after the "
+                f"Transformer module of the SentenceTransformer."
+            )
+        token_embeddings = features[TOKEN_EMBEDDINGS_KEY]
+        attention_mask = features.get(ATTENTION_MASK_KEY)
+        if attention_mask is None or attention_mask.size(-1) != token_embeddings.size(1):
+            # Same fallback as sentence-transformers' Pooling: no mask means no padding.
+            attention_mask = torch.ones(
+                token_embeddings.shape[:-1],
+                device = token_embeddings.device,
+                dtype = torch.long,
+            )
+        features[SPARSE_EMBEDDING_KEY] = self.head(token_embeddings, attention_mask, self.mode)
+        return features
+
+    def get_config_dict(self) -> dict[str, Any]:
+        return {"mode": self.mode, "num_eos_tokens": self.head.num_eos_tokens}
+
+    def save(self, output_path: str, *args: Any, **kwargs: Any) -> None:
+        """Write the module config plus the sparse heads in UEmbed's sidecar layout."""
+        splade = _uembed_splade()
+        os.makedirs(output_path, exist_ok = True)
+        with open(os.path.join(output_path, _CONFIG_FILENAME), "w", encoding = "utf-8") as file:
+            json.dump(self.get_config_dict(), file, indent = 2)
+        torch.save(
+            {
+                splade.SPARSE_LM_HEADS_KEY: [
+                    weight.detach().cpu() for weight in self.head.sparse_lm_heads
+                ],
+                splade.SPARSE_BIAS_KEY: [bias.detach().cpu() for bias in self.head.sparse_bias],
+            },
+            os.path.join(output_path, splade.SPARSE_WEIGHTS_FILENAME),
+        )
+
+    @classmethod
+    def load(cls, input_path: str, *args: Any, **kwargs: Any) -> UEmbedSparseOutput:
+        subfolder = kwargs.get("subfolder", "")
+        if subfolder:
+            if os.path.isdir(input_path):
+                input_path = os.path.join(input_path, subfolder)
+            else:
+                try:
+                    from sentence_transformers.util import load_dir_path
+                except ImportError as exception:
+                    raise RuntimeError(
+                        "Unsloth: sentence-transformers is required to resolve a remote "
+                        "serialized UEmbedSparseOutput module."
+                    ) from exception
+                input_path = load_dir_path(
+                    model_name_or_path = input_path,
+                    subfolder = subfolder,
+                    token = kwargs.get("token"),
+                    cache_folder = kwargs.get("cache_folder"),
+                    revision = kwargs.get("revision"),
+                    local_files_only = kwargs.get("local_files_only", False),
+                )
+
+        splade = _uembed_splade()
+        config: dict[str, Any] = {}
+        config_path = os.path.join(input_path, _CONFIG_FILENAME)
+        if os.path.isfile(config_path):
+            with open(config_path, encoding = "utf-8") as file:
+                config = json.load(file)
+        head = splade.SpladeHead.from_checkpoint(
+            input_path, num_eos_tokens = config.get("num_eos_tokens")
+        )
+        return cls(head, config.get("mode"))
+
+    def extra_repr(self) -> str:
+        return f"mode={self.mode}"
+
+
+# -- pipeline wiring --------------------------------------------------------------------
+def find_uembed_sparse_output(model: Any) -> UEmbedSparseOutput | None:
+    """The model's sparse output module, or None for a plain dense embedder."""
+    children = getattr(model, "children", None)
+    if children is None:
+        return None
+    for module in children():
+        if isinstance(module, UEmbedSparseOutput):
+            return module
+    return None
+
+
+def require_uembed_sparse_output(model: Any) -> UEmbedSparseOutput:
+    """Same as `find_uembed_sparse_output`, but says what is wrong instead of None."""
+    module = find_uembed_sparse_output(model)
+    if module is None:
+        raise ValueError(
+            "Unsloth: this model has no UEmbed sparse head, so it cannot produce a "
+            "`sparse_embedding`. Sparse output needs a checkpoint that ships "
+            "`sparse_weights.pt` (a UEmbed model); load one with "
+            "`FastSentenceTransformer.from_pretrained(...)`, or ask for the dense "
+            "output only."
+        )
+    return module
+
+
+def _match_dtype_and_device(module: nn.Module, model: Any) -> None:
+    """Move the head onto the backbone's device (and float dtype, when it has one)."""
+    parameters = getattr(model, "parameters", None)
+    if parameters is None:
+        return
+    reference = next(iter(parameters()), None)
+    if reference is None:
+        return
+    if reference.is_floating_point():
+        # Quantized backbones expose integer parameters; casting to those would destroy
+        # the head, so only a real float dtype is copied.
+        module.to(device = reference.device, dtype = reference.dtype)
+    else:
+        module.to(device = reference.device)
+
+
+def _append_module(model: Any, module: nn.Module) -> None:
+    names = {name for name, _ in model.named_children()}
+    index = len(names)
+    while str(index) in names:
+        index += 1
+    model.add_module(str(index), module)
+
+
+def _patch_encode(model: Any) -> None:
+    """Give `encode` an `output_mode`; the default delegates to the original untouched."""
+    if getattr(model, "_unsloth_uembed_original_encode", None) is not None:
+        return
+    original_encode = getattr(model, "encode", None)
+    if original_encode is None:
+        # A bare module chain (no `encode`) is still perfectly trainable: the loss reads
+        # the features dict, not `encode`. Nothing to wrap, so leave it alone.
+        return
+
+    def encode(
+        sentences,
+        *args: Any,
+        output_mode: str = OUTPUT_MODE_DENSE,
+        **kwargs: Any,
+    ):
+        if output_mode == OUTPUT_MODE_DENSE:
+            return original_encode(sentences, *args, **kwargs)
+        return encode_uembed(
+            model,
+            sentences,
+            *args,
+            output_mode = output_mode,
+            encode_fn = original_encode,
+            **kwargs,
+        )
+
+    model.encode = encode
+    model._unsloth_uembed_original_encode = original_encode
+
+
+def patch_uembed_sparse_encode(model: Any) -> bool:
+    """Restore UEmbed's process-local encode wrapper for a loaded sparse module chain.
+
+    Sentence-transformers serializes modules, not instance method wrappers. This is a
+    no-op for dense-only chains and is idempotent when attachment or sidecar reload runs
+    more than once.
+    """
+    if find_uembed_sparse_output(model) is None:
+        return False
+    _patch_encode(model)
+    return True
+
+
+def restore_uembed_inference_input_format(model: Any) -> bool:
+    """Restore process-local UEmbed formatting from a serialized sparse module chain.
+
+    ``UEmbedSparseOutput`` and its positive ``num_eos_tokens`` are serialized in
+    ``modules.json`` and the module config, unlike the replaced Transformer preprocess
+    method. Their presence is therefore the trusted opt-in signal on the native
+    sentence-transformers inference path; dense-only models are never modified.
+    """
+    sparse_output = find_uembed_sparse_output(model)
+    if sparse_output is None or sparse_output.num_eos_tokens <= 0:
+        return False
+
+    try:
+        transformer_module = model[0]
+    except (KeyError, IndexError, TypeError) as exception:
+        raise RuntimeError(
+            "Unsloth: serialized UEmbed sparse metadata was found, but the "
+            "SentenceTransformer has no first Transformer module to restore input "
+            "formatting on."
+        ) from exception
+
+    pooling = _uembed_pooling()
+    processor = pooling._module_processor(transformer_module)
+    # Assignment replaces any serialized TemplateProcessing rather than stacking EOS
+    # blocks, while the input formatter itself has an explicit idempotence marker.
+    pooling.build_eos_post_processor(processor, sparse_output.num_eos_tokens)
+    attached = pooling.attach_uembed_input_format(transformer_module)
+    model._unsloth_uembed_instruction = True
+    return attached
+
+
+def attach_uembed_sparse_output(
+    model: Any,
+    head: nn.Module,
+    mode: str | None = None,
+) -> bool:
+    """Append the sparse head to `model`'s module chain and teach `encode` about it.
+
+    Args:
+        model: the SentenceTransformer (its module chain must already end in the dense
+            pooling, so `token_embeddings` is still in the features dict).
+        head: a `SpladeHead`, or an already-built `UEmbedSparseOutput`.
+        mode: `splade.last` (default when the checkpoint has an EOS block) or `splade.max`.
+
+    Returns:
+        True when the sparse output was attached, False when the model already had one
+        (idempotent, so a reload cannot stack two heads).
+    """
+    if find_uembed_sparse_output(model) is not None:
+        patch_uembed_sparse_encode(model)
+        return False
+
+    module = head if isinstance(head, UEmbedSparseOutput) else UEmbedSparseOutput(head, mode)
+    _match_dtype_and_device(module, model)
+    _append_module(model, module)
+    patch_uembed_sparse_encode(model)
+    return True
+
+
+def _resolve_sparse_weights_dir(
+    model_name_or_path: str,
+    token: str | bool | None = None,
+    cache_dir: str | None = None,
+    revision: str | None = None,
+) -> str | None:
+    """Directory holding `sparse_weights.pt`, or None when the checkpoint has none.
+
+    A missing file is the documented "not a sparse checkpoint" case and stays silent.
+    Anything else (network / auth failure) is reported rather than silently dropping the
+    sparse half of a UEmbed model.
+    """
+    splade = _uembed_splade()
+    filename = splade.SPARSE_WEIGHTS_FILENAME
+
+    if isinstance(model_name_or_path, str) and os.path.isdir(model_name_or_path):
+        local = os.path.join(model_name_or_path, filename)
+        return model_name_or_path if os.path.isfile(local) else None
+
+    try:
+        from huggingface_hub import hf_hub_download
+        from huggingface_hub.errors import EntryNotFoundError, LocalEntryNotFoundError
+        try:
+            from huggingface_hub.errors import RemoteEntryNotFoundError
+        except ImportError:
+            # huggingface_hub < 1 uses EntryNotFoundError for remote 404s. Its
+            # LocalEntryNotFoundError subclass is excluded explicitly below.
+            RemoteEntryNotFoundError = EntryNotFoundError
+    except ImportError as exception:
+        raise RuntimeError(
+            f"Unsloth: cannot resolve optional `{filename}` for `{model_name_or_path}` "
+            f"because `huggingface_hub` is unavailable. Install `huggingface_hub` or "
+            f"load from a complete local checkpoint."
+        ) from exception
+
+    try:
+        path = hf_hub_download(
+            model_name_or_path,
+            filename,
+            token = token,
+            cache_dir = cache_dir,
+            revision = revision,
+        )
+    except Exception as exception:
+        if isinstance(exception, RemoteEntryNotFoundError) and not isinstance(
+            exception, LocalEntryNotFoundError
+        ):
+            return None
+        raise RuntimeError(
+            f"Unsloth: failed to resolve `{filename}` for `{model_name_or_path}`. Only a "
+            f"confirmed missing file is treated as an optional dense-only checkpoint; "
+            f"this failure may be caused by the network, an invalid repository/revision, "
+            f"authentication, or gated-repository access. Check connectivity and pass a "
+            f"token with access. Original error: {exception}"
+        ) from exception
+    return os.path.dirname(path)
+
+
+def attach_uembed_sparse_checkpoint(
+    model: Any,
+    model_name_or_path: str,
+    num_eos_tokens: int | None = None,
+    token: str | bool | None = None,
+    cache_dir: str | None = None,
+    revision: str | None = None,
+    mode: str | None = None,
+) -> bool:
+    """Attach the checkpoint's `sparse_weights.pt` heads, if it ships any.
+
+    Returns False (leaving the model dense-only) when the checkpoint carries no sparse
+    sidecar, so non-UEmbed embedders are unaffected.
+    """
+    directory = _resolve_sparse_weights_dir(
+        model_name_or_path, token = token, cache_dir = cache_dir, revision = revision
+    )
+    if directory is None:
+        if num_eos_tokens is not None and num_eos_tokens > 0:
+            raise RuntimeError(
+                f"Unsloth: `{model_name_or_path}` declares num_eos_tokens = "
+                f"{num_eos_tokens}, so it is a UEmbed checkpoint, but its required "
+                f"`sparse_weights.pt` is missing. Restore the complete checkpoint or "
+                f"select a revision that contains the sparse heads; refusing to silently "
+                f"return a dense-only model."
+            )
+        return False
+
+    splade = _uembed_splade()
+    head = splade.SpladeHead.from_checkpoint(
+        directory,
+        num_eos_tokens = num_eos_tokens,
+        token = token,
+        cache_dir = cache_dir,
+        revision = revision,
+    )
+    return attach_uembed_sparse_output(model, head, mode)
+
+
+# -- encode -----------------------------------------------------------------------------
+def _stack(rows: list[Any], key: str) -> torch.Tensor:
+    values = []
+    for index, row in enumerate(rows):
+        if not isinstance(row, dict) or key not in row:
+            raise KeyError(
+                f"Unsloth: row {index} of the encode output has no `{key}`. The UEmbed "
+                f"sparse module must stay in the model's module chain for `encode` to "
+                f"return sparse vectors."
+            )
+        values.append(row[key])
+    return torch.stack(values) if values else torch.empty(0)
+
+
+def _finalize(
+    embeddings: torch.Tensor, single: bool, convert_to_tensor: bool, convert_to_numpy: bool
+) -> Any:
+    if single and embeddings.shape[0] > 0:
+        embeddings = embeddings[0]
+    if convert_to_tensor:
+        return embeddings
+    if convert_to_numpy:
+        embeddings = embeddings.detach().cpu()
+        if embeddings.dtype in (torch.bfloat16, torch.float16):
+            embeddings = embeddings.float()
+        return embeddings.numpy()
+    return embeddings
+
+
+def encode_uembed(
+    model: Any,
+    sentences: Any,
+    *args: Any,
+    output_mode: str = OUTPUT_MODE_BOTH,
+    encode_fn: Any = None,
+    **kwargs: Any,
+):
+    """Encode once and return the dense vector, the sparse vector, or both.
+
+    `"both"` and `"sparse"` run the model's own `encode` a SINGLE time asking for every
+    feature it produced, which is where `sparse_embedding` rides along - there is no
+    second forward pass. `"dense"` is a plain pass-through.
+    """
+    if output_mode not in OUTPUT_MODES:
+        raise ValueError(
+            f"Unsloth: unknown `output_mode` {output_mode!r}; expected one of "
+            f"{list(OUTPUT_MODES)}."
+        )
+    if encode_fn is None:
+        encode_fn = getattr(model, "_unsloth_uembed_original_encode", None) or model.encode
+    if output_mode == OUTPUT_MODE_DENSE:
+        return encode_fn(sentences, *args, **kwargs)
+
+    require_uembed_sparse_output(model)
+    if kwargs.get("output_value", None) is not None:
+        raise ValueError(
+            f"Unsloth: `output_value = {kwargs['output_value']!r}` cannot be combined with "
+            f"`output_mode = {output_mode!r}`; the sparse path already reads every output "
+            f"of the single forward pass."
+        )
+    kwargs.pop("output_value", None)
+    convert_to_tensor = bool(kwargs.pop("convert_to_tensor", False))
+    convert_to_numpy = bool(kwargs.pop("convert_to_numpy", True))
+
+    rows = encode_fn(
+        sentences,
+        *args,
+        output_value = None,
+        convert_to_numpy = False,
+        convert_to_tensor = False,
+        **kwargs,
+    )
+    single = isinstance(rows, dict)
+    row_list = [rows] if single else list(rows)
+
+    sparse = _finalize(
+        _stack(row_list, SPARSE_EMBEDDING_KEY), single, convert_to_tensor, convert_to_numpy
+    )
+    if output_mode == OUTPUT_MODE_SPARSE:
+        return sparse
+    dense = _finalize(
+        _stack(row_list, SENTENCE_EMBEDDING_KEY), single, convert_to_tensor, convert_to_numpy
+    )
+    return {SENTENCE_EMBEDDING_KEY: dense, SPARSE_EMBEDDING_KEY: sparse}


### PR DESCRIPTION
Part 2 of 3 splitting #8712, as requested in [this review comment](https://github.com/unslothai/unsloth/pull/8712#issuecomment-5339573677).

> **Stacked on #9322.** This PR's own contribution is the 4 files in the table below; the rest of the diff is #9322's commit and will disappear once that merges. Please review #9322 first.

## What this PR adds

| File | Role |
|---|---|
| `unsloth/models/uembed_loss.py` | `UEmbedUnifiedLoss` — dense InfoNCE + sparse InfoNCE + FLOPS regulariser |
| `scripts/uembed_datasets.py` | builds the contrastive dataset |
| `scripts/uembed_finetune.py` | runnable end-to-end fine-tune example |
| `tests/python/test_uembed_loss.py` | 30 CPU tests for the loss |

The sparse InfoNCE runs at the SPLADE temperature (`tau_s = 32.0`), not the dense scale, and carries the FLOPS sparsity regulariser alongside it. `MultipleNegativesRankingLoss` ignores the sparse half entirely, which is why a dedicated loss exists.

`uembed_loss.py` is torch-only — it imports without an accelerator and without importing `unsloth`, so the test file runs on a CPU runner in ~0.1s.

## Why it depends on #9322

The loss reads `sparse_embedding` out of the features dict, and that key only exists because #9322's multi-output wiring puts it there. `scripts/uembed_finetune.py` likewise assumes `from_pretrained` has already wired offset pooling and the SPLADE head. Merging this alone would ship a loss with nothing to consume.

## Verification

Local run of the CI gates on this branch:

```
compileall    PASS
ruff 0.15.12  PASS
```

`pytest tests/python -m 'not server and not e2e'`, this branch vs. `main`:

```
main         10 failed, 681 passed, 242 skipped, 56 errors
this branch  10 failed, 869 passed, 247 skipped, 56 errors
```

FAILED/ERROR set byte-identical to `main`'s — no new failures. `+30 passed` over #9322 is exactly `test_uembed_loss.py`.
