### PR TITLE
Studio: stop docked composer from squeezing download panel

### DIFF
--- a/studio/frontend/src/features/settings/stores/monitor-frame-store.ts
+++ b/studio/frontend/src/features/settings/stores/monitor-frame-store.ts
@@ -273,6 +273,17 @@ function cardHeight(child: Element): number {
 }
 
 /**
+ * Whether the card is part of the rail's own layout. Dragged, the loaded models
+ * card pins itself `position: fixed` and is painted wherever the reader left
+ * it; `scrollHeight` has already dropped it, so the floor and the tail have to
+ * drop it too, or the rail asks for room to hold a card that is not in it.
+ */
+function inRailFlow(child: Element): boolean {
+  const { position } = getComputedStyle(child);
+  return position !== "fixed" && position !== "absolute";
+}
+
+/**
  * How short the rail can be and still show every card in it.
  *
  * Per card, never over their sum. The update banner's own min-height, 189px,
@@ -523,8 +534,10 @@ export function useStackGeometry(): StackPlacement {
       node.style.maxHeight = "none";
       const natural = node.scrollHeight;
       // Card by card as well as in total, since a card is floored against its
-      // own height rather than the rail's. Same probe, so no extra layout.
-      const grown = [...node.children].map(cardHeight);
+      // own height rather than the rail's. Same probe, so no extra layout, and
+      // one list for both readings so the two can never fall out of step.
+      const cards = [...node.children].filter(inRailFlow);
+      const grown = cards.map(cardHeight);
       // Taken here, uncapped, and not after the cap goes back on. The tail
       // panels are min-h-0 with their own scrollers, so under a tight cap they
       // measure as almost nothing, the placement reads that as a tail it can
@@ -534,10 +547,10 @@ export function useStackGeometry(): StackPlacement {
       // rail. One size that does not depend on the answer, as with the two
       // heights above.
       let tail = 0;
-      for (let i = node.children.length - 1; i >= 0; i -= 1) {
-        const child = node.children[i];
+      for (let i = cards.length - 1; i >= 0; i -= 1) {
+        const child = cards[i];
         if (child.hasAttribute("data-overlay-dismissible")) break;
-        tail += child.getBoundingClientRect().height + STACK_GAP;
+        tail += cardHeight(child) + STACK_GAP;
       }
       const persistent = Math.round(tail);
       // And the other end of the same measurement: squeezed to nothing, what is
@@ -548,7 +561,7 @@ export function useStackGeometry(): StackPlacement {
       node.style.maxHeight = "0px";
       const collapsed = node.scrollHeight;
       const floor = usableFloorRoom(
-        [...node.children].map((child, index) => ({
+        cards.map((child, index) => ({
           squeezed: cardHeight(child),
           natural: grown[index],
         })),

--- a/studio/frontend/src/features/settings/stores/monitor-frame-store.ts
+++ b/studio/frontend/src/features/settings/stores/monitor-frame-store.ts
@@ -262,6 +262,20 @@ function cardFloorRoom(squeezed: number, natural: number): number {
 }
 
 /**
+ * A card's height as the layout has it, not as it is painted.
+ *
+ * `offsetHeight` and not a bounding rect, for the reason `use-panel-anchor` has
+ * it: the update cards animate in from `scale: 0.96`, and a rect read through
+ * that transform is 4% short. Finishing a transform resizes nothing, so no
+ * observer comes back with the settled figure and the short one is the floor
+ * the placement keeps. It is also the measurement the sum is checked against,
+ * since `scrollHeight` is a layout reading too.
+ */
+function cardHeight(child: Element): number {
+  return (child as HTMLElement).offsetHeight;
+}
+
+/**
  * How short the rail can be and still show every card in it.
  *
  * Per card, never over their sum. The update banner carries a min-height of its
@@ -515,9 +529,7 @@ export function useStackGeometry(): StackPlacement {
       const natural = node.scrollHeight;
       // Card by card as well as in total, since a card is floored against its
       // own height rather than the rail's. Same probe, so no extra layout.
-      const grown = [...node.children].map(
-        (child) => child.getBoundingClientRect().height,
-      );
+      const grown = [...node.children].map(cardHeight);
       // Taken here, uncapped, and not after the cap goes back on. The tail
       // panels are min-h-0 with their own scrollers, so under a tight cap they
       // measure as almost nothing, the placement reads that as a tail it can
@@ -542,7 +554,7 @@ export function useStackGeometry(): StackPlacement {
       const collapsed = node.scrollHeight;
       const floor = usableFloorRoom(
         [...node.children].map((child, index) => ({
-          squeezed: child.getBoundingClientRect().height,
+          squeezed: cardHeight(child),
           natural: grown[index],
         })),
         natural,

--- a/studio/frontend/src/features/settings/stores/monitor-frame-store.ts
+++ b/studio/frontend/src/features/settings/stores/monitor-frame-store.ts
@@ -89,6 +89,9 @@ const STACK_GAP = 8;
 const STACK_WIDTH = 448;
 // Never lift so far that the stack itself is pushed off the top.
 const MIN_STACK_ROOM = 120;
+// Keep the download header and one row visible when collapsible cards report
+// only their borders to the squeeze probe.
+const MIN_CARD_ROOM = 128;
 // Room the stack asks for before it has been measured. Deliberately small: guessing
 // high is what parked the loaded models card mid-window with the corner underneath it
 // empty. The real height arrives from the stack's ResizeObserver on the next frame.
@@ -251,6 +254,11 @@ export function stackMaxHeight(
   }
   // At least MIN_STACK_ROOM, since anything tighter reaches at this inset.
   return Math.min(ownMargin, roomBelow(frame, viewportHeight, bottomInset));
+}
+
+/** Hold a collapsible rail to a usable floor without exceeding its full height. */
+export function usableFloorRoom(squeezed: number, natural: number): number {
+  return Math.max(squeezed, Math.min(natural, MIN_CARD_ROOM));
 }
 
 export type StackGeometry = { bottom: number; maxHeight: number };
@@ -496,7 +504,7 @@ export function useStackGeometry(): StackPlacement {
       // hold `natural` when it only has to hold `floor` is what made a 3px
       // shortfall at 1280x830 give up on dodging the composer entirely.
       node.style.maxHeight = "0px";
-      const floor = node.scrollHeight;
+      const floor = usableFloorRoom(node.scrollHeight, natural);
       node.style.maxHeight = capped;
       if (node.scrollTop !== scrolled) {
         node.scrollTop = scrolled;

--- a/studio/frontend/src/features/settings/stores/monitor-frame-store.ts
+++ b/studio/frontend/src/features/settings/stores/monitor-frame-store.ts
@@ -89,8 +89,8 @@ const STACK_GAP = 8;
 const STACK_WIDTH = 448;
 // Never lift so far that the stack itself is pushed off the top.
 const MIN_STACK_ROOM = 120;
-// Keep the download header and one row visible when collapsible cards report
-// only their borders to the squeeze probe.
+// Keep the download header and one row visible when a collapsible card reports
+// only its borders to the squeeze probe.
 const MIN_CARD_ROOM = 128;
 // Room the stack asks for before it has been measured. Deliberately small: guessing
 // high is what parked the loaded models card mid-window with the corner underneath it
@@ -256,9 +256,33 @@ export function stackMaxHeight(
   return Math.min(ownMargin, roomBelow(frame, viewportHeight, bottomInset));
 }
 
-/** Hold a collapsible rail to a usable floor without exceeding its full height. */
-export function usableFloorRoom(squeezed: number, natural: number): number {
+/** What one card will not give up: its own floor, or a usable slice of it. */
+function cardFloorRoom(squeezed: number, natural: number): number {
   return Math.max(squeezed, Math.min(natural, MIN_CARD_ROOM));
+}
+
+/**
+ * How short the rail can be and still show every card in it.
+ *
+ * Per card, never over their sum. The update banner carries a min-height of its
+ * own -- 189px at the default font scale -- so it answers any minimum asked of
+ * the rail as a whole while the min-h-0 download panel beside it still measures
+ * its borders. A rail floored as one number therefore accepted the 200px band
+ * the welcome composer leaves at 1366x640, and the panel came back as an 8px
+ * strip: the same hairline as the docked case below.
+ *
+ * Bounded by the rail's natural height, so a card shorter than the minimum is
+ * asked for what it has rather than for room it would not fill.
+ */
+export function usableFloorRoom(
+  cards: readonly { squeezed: number; natural: number }[],
+  natural: number,
+): number {
+  const floor = cards.reduce(
+    (total, card) => total + cardFloorRoom(card.squeezed, card.natural),
+    STACK_GAP * Math.max(0, cards.length - 1),
+  );
+  return Math.min(Math.round(floor), natural);
 }
 
 export type StackGeometry = { bottom: number; maxHeight: number };
@@ -425,11 +449,16 @@ export function useStackGeometry(): StackPlacement {
   }));
   const [neededRoom, setNeededRoom] = useState(ASSUMED_STACK_HEIGHT);
   const [floorRoom, setFloorRoom] = useState(ASSUMED_STACK_HEIGHT);
+  // How far the rail can actually be squeezed, which is not the same question as
+  // how far it may be: a card clipped inside its own min-h-0 box takes the cap
+  // without the rail overflowing, so the placement asks `floorRoom` and the
+  // scroll reading below asks this.
+  const [collapsedRoom, setCollapsedRoom] = useState(ASSUMED_STACK_HEIGHT);
   const [persistentTail, setPersistentTail] = useState(0);
   // Whether the rail is ACTUALLY scrolling, read off the node at its real cap.
   // The derived answer below is a prediction, and a prediction can be wrong: the
-  // cards are only assumed to collapse to `floorRoom`, so whenever they stop
-  // short of it the box overflows a cap that `floorRoom > maxHeight` says it
+  // cards are only assumed to collapse to `collapsedRoom`, so whenever they stop
+  // short of it the box overflows a cap that `collapsedRoom > maxHeight` says it
   // fits inside. That combination is a rail that scrolls while it is still
   // click-through, which costs it its scrollbar and strands every card above the
   // fold where no pointer can reach them.
@@ -448,6 +477,7 @@ export function useStackGeometry(): StackPlacement {
       if (node.childElementCount === 0) {
         setNeededRoom((current) => (current === 0 ? current : 0));
         setFloorRoom((current) => (current === 0 ? current : 0));
+        setCollapsedRoom((current) => (current === 0 ? current : 0));
         return;
       }
       // Drop the cap and put it back in one synchronous block, so scrollHeight
@@ -483,6 +513,11 @@ export function useStackGeometry(): StackPlacement {
       const scrolled = node.scrollTop;
       node.style.maxHeight = "none";
       const natural = node.scrollHeight;
+      // Card by card as well as in total, since a card is floored against its
+      // own height rather than the rail's. Same probe, so no extra layout.
+      const grown = [...node.children].map(
+        (child) => child.getBoundingClientRect().height,
+      );
       // Taken here, uncapped, and not after the cap goes back on. The tail
       // panels are min-h-0 with their own scrollers, so under a tight cap they
       // measure as almost nothing, the placement reads that as a tail it can
@@ -504,7 +539,14 @@ export function useStackGeometry(): StackPlacement {
       // hold `natural` when it only has to hold `floor` is what made a 3px
       // shortfall at 1280x830 give up on dodging the composer entirely.
       node.style.maxHeight = "0px";
-      const floor = usableFloorRoom(node.scrollHeight, natural);
+      const collapsed = node.scrollHeight;
+      const floor = usableFloorRoom(
+        [...node.children].map((child, index) => ({
+          squeezed: child.getBoundingClientRect().height,
+          natural: grown[index],
+        })),
+        natural,
+      );
       node.style.maxHeight = capped;
       if (node.scrollTop !== scrolled) {
         node.scrollTop = scrolled;
@@ -536,6 +578,9 @@ export function useStackGeometry(): StackPlacement {
       );
       setNeededRoom((current) => (current === natural ? current : natural));
       setFloorRoom((current) => (current === floor ? current : floor));
+      setCollapsedRoom((current) =>
+        current === collapsed ? current : collapsed,
+      );
       // How much of the stack, measured up from the corner, the reader cannot
       // dismiss. The loaded models indicator and the download panel are last,
       // so a covering placement puts them nearest the bottom edge: over Send
@@ -619,15 +664,20 @@ export function useStackGeometry(): StackPlacement {
     // latches: the stack is capped and scrolling for a frame, the placement
     // then changes to one that fits, and nothing resizes afterwards to correct
     // the flag, so a rail with nothing to scroll to keeps the pointer input it
-    // took. The cards absorb everything between their floor and their natural
-    // height, so a cap below the floor is exactly when the rail has to scroll.
-    // A pixel of slack, since the floor is a rounded scrollHeight and the cap
-    // is not.
+    // took. The cards absorb everything down to the height they collapse at, so
+    // a cap below that is exactly when the rail has to scroll. A pixel of slack,
+    // since the reading is a rounded scrollHeight and the cap is not.
+    //
+    // `collapsedRoom` and not `floorRoom`: the floor is the room the cards need
+    // to stay readable, and a card that gives up more than that is clipped
+    // rather than scrolled. Asking the floor here would hand the rail pointer
+    // input, and with it the clicks passing over its gutter, for a fold that
+    // does not exist.
     //
     // Or the box is simply scrolling, whatever the prediction says. The two
-    // agree wherever the cards do collapse to the floor they measured, so this
+    // agree wherever the cards do collapse to the height they measured, so this
     // only ever adds the case the prediction misses; it cannot take pointer
     // input away from a rail that the derived reading already claimed.
-    overflowing: floorRoom > geometry.maxHeight + 1 || domOverflowing,
+    overflowing: collapsedRoom > geometry.maxHeight + 1 || domOverflowing,
   };
 }

--- a/studio/frontend/src/features/settings/stores/monitor-frame-store.ts
+++ b/studio/frontend/src/features/settings/stores/monitor-frame-store.ts
@@ -262,14 +262,11 @@ function cardFloorRoom(squeezed: number, natural: number): number {
 }
 
 /**
- * A card's height as the layout has it, not as it is painted.
- *
- * `offsetHeight` and not a bounding rect, for the reason `use-panel-anchor` has
- * it: the update cards animate in from `scale: 0.96`, and a rect read through
- * that transform is 4% short. Finishing a transform resizes nothing, so no
- * observer comes back with the settled figure and the short one is the floor
- * the placement keeps. It is also the measurement the sum is checked against,
- * since `scrollHeight` is a layout reading too.
+ * A card's height as the layout has it, not as it is painted. `offsetHeight`
+ * and not a rect, for the reason `use-panel-anchor` has it: the update cards
+ * animate in from `scale: 0.96`, a rect is read through that transform, and
+ * finishing a transform resizes nothing, so no observer comes back with the
+ * settled figure. It also matches `scrollHeight`, the total it is summed for.
  */
 function cardHeight(child: Element): number {
   return (child as HTMLElement).offsetHeight;
@@ -278,12 +275,11 @@ function cardHeight(child: Element): number {
 /**
  * How short the rail can be and still show every card in it.
  *
- * Per card, never over their sum. The update banner carries a min-height of its
- * own -- 189px at the default font scale -- so it answers any minimum asked of
- * the rail as a whole while the min-h-0 download panel beside it still measures
- * its borders. A rail floored as one number therefore accepted the 200px band
- * the welcome composer leaves at 1366x640, and the panel came back as an 8px
- * strip: the same hairline as the docked case below.
+ * Per card, never over their sum. The update banner's own min-height, 189px,
+ * answers any minimum asked of the rail as a whole while the min-h-0 download
+ * panel beside it still measures its borders: floored as one number the rail
+ * accepted the 200px band the welcome composer leaves at 1366x640, and the
+ * panel came back an 8px strip, the same hairline as the docked case below.
  *
  * Bounded by the rail's natural height, so a card shorter than the minimum is
  * asked for what it has rather than for room it would not fill.
@@ -463,10 +459,9 @@ export function useStackGeometry(): StackPlacement {
   }));
   const [neededRoom, setNeededRoom] = useState(ASSUMED_STACK_HEIGHT);
   const [floorRoom, setFloorRoom] = useState(ASSUMED_STACK_HEIGHT);
-  // How far the rail can actually be squeezed, which is not the same question as
-  // how far it may be: a card clipped inside its own min-h-0 box takes the cap
-  // without the rail overflowing, so the placement asks `floorRoom` and the
-  // scroll reading below asks this.
+  // How far the rail can be squeezed, as opposed to how far it may be: a card
+  // clipped inside its own min-h-0 box takes the cap without the rail
+  // overflowing. The placement asks `floorRoom`, the scroll reading asks this.
   const [collapsedRoom, setCollapsedRoom] = useState(ASSUMED_STACK_HEIGHT);
   const [persistentTail, setPersistentTail] = useState(0);
   // Whether the rail is ACTUALLY scrolling, read off the node at its real cap.
@@ -680,11 +675,9 @@ export function useStackGeometry(): StackPlacement {
     // a cap below that is exactly when the rail has to scroll. A pixel of slack,
     // since the reading is a rounded scrollHeight and the cap is not.
     //
-    // `collapsedRoom` and not `floorRoom`: the floor is the room the cards need
-    // to stay readable, and a card that gives up more than that is clipped
-    // rather than scrolled. Asking the floor here would hand the rail pointer
-    // input, and with it the clicks passing over its gutter, for a fold that
-    // does not exist.
+    // `collapsedRoom` and not `floorRoom`: a card that gives up more than its
+    // floor is clipped, not scrolled, so asking the floor here would hand the
+    // rail pointer input, and the clicks crossing its gutter, for no fold.
     //
     // Or the box is simply scrolling, whatever the prediction says. The two
     // agree wherever the cards do collapse to the height they measured, so this

--- a/studio/frontend/tests/monitor-stack-inset.test.ts
+++ b/studio/frontend/tests/monitor-stack-inset.test.ts
@@ -487,6 +487,36 @@ test("the height is measured with the hook's own cap lifted", async () => {
   );
 });
 
+// The update cards animate in from scale 0.96 and a bounding rect is read
+// through that transform, 4% short. A finished transform resizes nothing, so
+// no observer comes back with the settled figure: the short reading is the
+// floor the placement keeps, and a band a few pixels under the real one is
+// accepted. The rail's own two readings are scrollHeight, a layout figure, so
+// the per-card ones have to be layout figures to be summed against them.
+test("the card floors are read off the layout box, not the painted one", async () => {
+  const source = await readFile(
+    new URL(
+      "../src/features/settings/stores/monitor-frame-store.ts",
+      import.meta.url,
+    ),
+    "utf8",
+  );
+  const measure = source.slice(
+    source.indexOf("const measure = () => {"),
+    source.indexOf("const observer = new ResizeObserver"),
+  );
+  assert.match(
+    source,
+    /function cardHeight\([\s\S]*?\)\.offsetHeight;/,
+    "a card's height is not the untransformed layout box",
+  );
+  assert.match(
+    measure,
+    /const grown = \[\.\.\.node\.children\]\.map\(cardHeight\)/,
+  );
+  assert.match(measure, /squeezed: cardHeight\(child\)/);
+});
+
 // The sweep above, re-run at the heights the stack actually takes.
 // The stack scrolls now, and an uncapped box does not, so the measurement has
 // to put scrollTop back with the cap or a resize below throws a reader of the

--- a/studio/frontend/tests/monitor-stack-inset.test.ts
+++ b/studio/frontend/tests/monitor-stack-inset.test.ts
@@ -353,6 +353,9 @@ const NOTE_DOCKED: MonitorFrame = {
 };
 // One download row under the panel's header, measured in the same window.
 const ONE_CARD = 121;
+// The download panel alone in the rail, which is what the report had.
+const alone = (squeezed: number, natural: number) =>
+  usableFloorRoom([{ squeezed, natural }], natural);
 
 test("the strip the composer's footnote leaves is not room for the rail", () => {
   const geometry = stackGeometry(
@@ -360,7 +363,7 @@ test("the strip the composer's footnote leaves is not room for the rail", () => 
     CHAT_W,
     NOTE_H,
     ONE_CARD,
-    usableFloorRoom(2, ONE_CARD),
+    alone(2, ONE_CARD),
   );
   assert.ok(geometry.bottom > 16, "5px under the note is not a placement");
   assert.ok(
@@ -371,11 +374,66 @@ test("the strip the composer's footnote leaves is not room for the rail", () => 
 });
 
 test("the floor is a card the reader can see, not what the rail can shrink to", () => {
-  assert.equal(usableFloorRoom(2, ONE_CARD), ONE_CARD);
-  assert.equal(usableFloorRoom(2, 40), 40);
-  assert.equal(usableFloorRoom(300, 480), 300);
+  assert.equal(alone(2, ONE_CARD), ONE_CARD);
+  assert.equal(alone(2, 40), 40);
+  assert.equal(alone(300, 480), 300);
   // Long lists still scroll rather than asking for their full height.
-  assert.ok(usableFloorRoom(2, 480) < 480);
+  assert.ok(alone(2, 480) < 480);
+});
+
+// The same window with the app update card up as well. Its min-height is its
+// own floor, so a rail floored as one number is already past the minimum while
+// the panel beside it is still measuring its borders.
+const BANNER_FLOOR = 189;
+const BANNER_NATURAL = 196;
+const PANEL_BORDERS = 2;
+const RAIL_CARDS = [
+  { squeezed: BANNER_FLOOR, natural: BANNER_NATURAL },
+  { squeezed: PANEL_BORDERS, natural: ONE_CARD },
+];
+const RAIL_NATURAL = BANNER_NATURAL + 8 + ONE_CARD;
+
+test("a banner's own floor does not answer for the panel beside it", () => {
+  const floor = usableFloorRoom(RAIL_CARDS, RAIL_NATURAL);
+  assert.ok(
+    floor > BANNER_FLOOR + 8 + PANEL_BORDERS,
+    "the panel is asked for as well as the banner",
+  );
+  // Shorter than the minimum, so it is asked for whole rather than for room it
+  // could not fill.
+  assert.equal(floor, BANNER_FLOOR + 8 + ONE_CARD);
+});
+
+// A 1366x768 laptop, where the browser leaves a 640px viewport: the welcome
+// composer sits with exactly 200px under it, which holds the banner and left
+// the download panel an 8px strip with no scrollbar to reach it by.
+const NOTE_W = 1366;
+const NOTE_WELCOME_H = 640;
+const NOTE_WELCOME: MonitorFrame = {
+  left: 450,
+  top: 304,
+  right: 1186,
+  bottom: 416,
+  coverable: true,
+};
+
+test("a band that only holds the banner is not room for the rail", () => {
+  const geometry = stackGeometry(
+    NOTE_WELCOME,
+    NOTE_W,
+    NOTE_WELCOME_H,
+    RAIL_NATURAL,
+    usableFloorRoom(RAIL_CARDS, RAIL_NATURAL),
+    ONE_CARD + 8,
+  );
+  assert.ok(
+    NOTE_WELCOME_H - geometry.bottom - geometry.maxHeight >= 0,
+    "the rail stays on the page",
+  );
+  assert.ok(
+    geometry.maxHeight - BANNER_FLOOR - 8 >= ONE_CARD,
+    "and the panel is more than its borders",
+  );
 });
 
 // Preserve #8462: the 163px welcome-screen band still keeps the corner.
@@ -385,7 +443,7 @@ test("the welcome band still keeps the corner under a real floor", () => {
     WIDE_W,
     WIDE_H,
     328,
-    usableFloorRoom(2, 328),
+    alone(2, 328),
   );
   assert.equal(geometry.bottom, 16, "the panel belongs in the corner");
 });

--- a/studio/frontend/tests/monitor-stack-inset.test.ts
+++ b/studio/frontend/tests/monitor-stack-inset.test.ts
@@ -9,6 +9,7 @@ import {
   type MonitorFrame,
   stackBottomInset,
   stackGeometry,
+  usableFloorRoom,
 } from "../src/features/settings/stores/monitor-frame-store.ts";
 
 const W = 1440;
@@ -338,6 +339,55 @@ test("the docked composer is dodged however little the rail insists on", () => {
       `a rail with a ${floor}px floor must still clear Send`,
     );
   }
+});
+
+// The published form leaves a 5px strip above the footnote. A border-only floor
+// used to accept that strip and clip the download panel into a hairline.
+const NOTE_H = 800;
+const NOTE_DOCKED: MonitorFrame = {
+  left: 407,
+  top: 658.53,
+  right: 1143,
+  bottom: 770.53,
+  coverable: true,
+};
+// One download row under the panel's header, measured in the same window.
+const ONE_CARD = 121;
+
+test("the strip the composer's footnote leaves is not room for the rail", () => {
+  const geometry = stackGeometry(
+    NOTE_DOCKED,
+    CHAT_W,
+    NOTE_H,
+    ONE_CARD,
+    usableFloorRoom(2, ONE_CARD),
+  );
+  assert.ok(geometry.bottom > 16, "5px under the note is not a placement");
+  assert.ok(
+    NOTE_H - geometry.bottom <= NOTE_DOCKED.top,
+    "so the rail clears the composer",
+  );
+  assert.ok(geometry.maxHeight >= ONE_CARD, "and the card fits where it lands");
+});
+
+test("the floor is a card the reader can see, not what the rail can shrink to", () => {
+  assert.equal(usableFloorRoom(2, ONE_CARD), ONE_CARD);
+  assert.equal(usableFloorRoom(2, 40), 40);
+  assert.equal(usableFloorRoom(300, 480), 300);
+  // Long lists still scroll rather than asking for their full height.
+  assert.ok(usableFloorRoom(2, 480) < 480);
+});
+
+// Preserve #8462: the 163px welcome-screen band still keeps the corner.
+test("the welcome band still keeps the corner under a real floor", () => {
+  const geometry = stackGeometry(
+    WIDE_WELCOME,
+    WIDE_W,
+    WIDE_H,
+    328,
+    usableFloorRoom(2, 328),
+  );
+  assert.equal(geometry.bottom, 16, "the panel belongs in the corner");
 });
 
 test("a docked composer is dodged whatever the stack measures", () => {

--- a/studio/frontend/tests/monitor-stack-inset.test.ts
+++ b/studio/frontend/tests/monitor-stack-inset.test.ts
@@ -381,9 +381,9 @@ test("the floor is a card the reader can see, not what the rail can shrink to", 
   assert.ok(alone(2, 480) < 480);
 });
 
-// The same window with the app update card up as well. Its min-height is its
-// own floor, so a rail floored as one number is already past the minimum while
-// the panel beside it is still measuring its borders.
+// The same window with the app update card up. Its min-height is its own floor,
+// so a rail floored as one number is already past the minimum while the panel
+// beside it is still measuring its borders.
 const BANNER_FLOOR = 189;
 const BANNER_NATURAL = 196;
 const PANEL_BORDERS = 2;
@@ -487,12 +487,9 @@ test("the height is measured with the hook's own cap lifted", async () => {
   );
 });
 
-// The update cards animate in from scale 0.96 and a bounding rect is read
-// through that transform, 4% short. A finished transform resizes nothing, so
-// no observer comes back with the settled figure: the short reading is the
-// floor the placement keeps, and a band a few pixels under the real one is
-// accepted. The rail's own two readings are scrollHeight, a layout figure, so
-// the per-card ones have to be layout figures to be summed against them.
+// A rect is read through the update cards' scale 0.96 enter transform, and a
+// finished transform resizes nothing, so the short reading is the floor the
+// placement keeps. See cardHeight.
 test("the card floors are read off the layout box, not the painted one", async () => {
   const source = await readFile(
     new URL(

--- a/studio/frontend/tests/monitor-stack-inset.test.ts
+++ b/studio/frontend/tests/monitor-stack-inset.test.ts
@@ -507,11 +507,35 @@ test("the card floors are read off the layout box, not the painted one", async (
     /function cardHeight\([\s\S]*?\)\.offsetHeight;/,
     "a card's height is not the untransformed layout box",
   );
+  assert.match(measure, /const grown = cards\.map\(cardHeight\)/);
+  assert.match(measure, /squeezed: cardHeight\(child\)/);
+  assert.match(measure, /tail \+= cardHeight\(child\) \+ STACK_GAP/);
+});
+
+// Dragged, the loaded models card pins itself `position: fixed` and leaves the
+// rail's flow. scrollHeight drops it, so a floor that still counted it asked
+// for 225px where 128 was needed and lifted the rail off a corner it fitted.
+test("a card dragged out of the rail is not floored for", async () => {
+  const source = await readFile(
+    new URL(
+      "../src/features/settings/stores/monitor-frame-store.ts",
+      import.meta.url,
+    ),
+    "utf8",
+  );
+  const measure = source.slice(
+    source.indexOf("const measure = () => {"),
+    source.indexOf("const observer = new ResizeObserver"),
+  );
+  assert.match(
+    source,
+    /function inRailFlow\([\s\S]*?position !== "fixed" && position !== "absolute";/,
+    "an out-of-flow card is not recognised",
+  );
   assert.match(
     measure,
-    /const grown = \[\.\.\.node\.children\]\.map\(cardHeight\)/,
+    /const cards = \[\.\.\.node\.children\]\.filter\(inRailFlow\)/,
   );
-  assert.match(measure, /squeezed: cardHeight\(child\)/);
 });
 
 // The sweep above, re-run at the heights the stack actually takes.

--- a/studio/frontend/tests/update-banner-flex-priority.test.ts
+++ b/studio/frontend/tests/update-banner-flex-priority.test.ts
@@ -274,10 +274,9 @@ test("a scrolling rail takes pointer input, a fitting one stays click-through", 
   // latches: the stack scrolls for a frame, the placement then changes to one
   // that fits, and nothing resizes afterwards to correct the flag, so a rail
   // with nothing to scroll to keeps the pointer input it took. Compared
-  // against the height the cards collapse to rather than their natural height,
-  // since they absorb everything in between; and not against the floor the
-  // placement asks for, which is larger wherever a card would rather be clipped
-  // than shrink, and a clipped card is not a fold to scroll to.
+  // against the height the cards collapse to, not their natural height nor the
+  // floor the placement asks for: a card clipped below its floor is not a fold
+  // to scroll to.
   assert.match(
     STORE,
     /overflowing: collapsedRoom > geometry\.maxHeight/,

--- a/studio/frontend/tests/update-banner-flex-priority.test.ts
+++ b/studio/frontend/tests/update-banner-flex-priority.test.ts
@@ -190,9 +190,11 @@ test("only the dismissible cards licence covering the composer", () => {
   );
   // Measured up from the corner, so the run that stops a cover is the one that
   // would land on the composer, not any persistent card anywhere in the stack.
+  // Over `cards`, the rail's in-flow children: a dragged loaded models card is
+  // `position: fixed` somewhere else and lands on nothing.
   assert.match(
     STORE,
-    /for \(let i = node\.children\.length - 1; i >= 0; i -= 1\)/,
+    /for \(let i = cards\.length - 1; i >= 0; i -= 1\)/,
     "the persistent run is no longer counted from the bottom of the stack",
   );
 });

--- a/studio/frontend/tests/update-banner-flex-priority.test.ts
+++ b/studio/frontend/tests/update-banner-flex-priority.test.ts
@@ -274,11 +274,13 @@ test("a scrolling rail takes pointer input, a fitting one stays click-through", 
   // latches: the stack scrolls for a frame, the placement then changes to one
   // that fits, and nothing resizes afterwards to correct the flag, so a rail
   // with nothing to scroll to keeps the pointer input it took. Compared
-  // against the floor rather than the natural height, since the cards absorb
-  // everything in between.
+  // against the height the cards collapse to rather than their natural height,
+  // since they absorb everything in between; and not against the floor the
+  // placement asks for, which is larger wherever a card would rather be clipped
+  // than shrink, and a clipped card is not a fold to scroll to.
   assert.match(
     STORE,
-    /overflowing: floorRoom > geometry\.maxHeight/,
+    /overflowing: collapsedRoom > geometry\.maxHeight/,
     "the overflow flag is not derived from the placement",
   );
   assert.ok(!/setOverflowing/.test(STORE), "a latched DOM reading is back");


### PR DESCRIPTION
## Problem

Starting a model download from a chat thread can render the download panel only 5px tall. The download continues and its progress values are correct, but the UI appears as a hairline across the "LLMs can make mistakes" note.

<table>
<tr><th width="50%">Before</th><th width="50%">After</th></tr>
<tr>
<td>
<img width="1320" height="600" alt="before-corner" src="https://github.com/user-attachments/assets/8154953f-e77d-4069-b2dc-1022b8766c74" />


</td>
<td>
<img width="1320" height="600" alt="after-corner" src="https://github.com/user-attachments/assets/ed04ef4c-7f24-45c5-8e13-e54df4a36420" />


</td>
</tr>
</table>

The overlay rail decides whether it can fit below the coverable chat composer by comparing the available band with the rail's measured floor. Its squeeze probe sets `max-height: 0` and reads `scrollHeight`, but the rail's `min-h-0` flex cards collapse to their borders. During a live download, a 121px panel therefore reported a 2px floor.

The published composer form leaves a 5.47px band above the footnote. Because that band appeared larger than the 2px floor, the rail stayed in the corner and accepted a 5.47px cap, clipping the panel almost completely.

## Fix

Floor the rail card by card rather than as one number:

```ts
const MIN_CARD_ROOM = 128;

function cardFloorRoom(squeezed: number, natural: number): number {
  return Math.max(squeezed, Math.min(natural, MIN_CARD_ROOM));
}

export function usableFloorRoom(
  cards: readonly { squeezed: number; natural: number }[],
  natural: number,
): number {
  const floor = cards.reduce(
    (total, card) => total + cardFloorRoom(card.squeezed, card.natural),
    STACK_GAP * Math.max(0, cards.length - 1),
  );
  return Math.min(Math.round(floor), natural);
}
```

Each card keeps enough room for the download header and one row, a card shorter than that is asked for what it has, and a card with a larger minimum of its own still wins. The sum is bounded by the rail's natural height.

Per card and not over the sum, because a rail floored as one number is answered by whichever card carries a `min-height`. The app update card's is 189px at the default font scale, which clears 128 on its own while the `min-h-0` download panel next to it still measures its borders. That leaves the same hairline on the welcome screen at 1366x640, where the composer's band is 200px: the rail took the corner at a 200px cap, the banner held its own minimum, and the panel came back as an 8px strip with 7px of its 41px header showing and no scrollbar to reach it by.

Two things the per-card reading needs that the aggregate one did not.

`cardHeight` reads `offsetHeight`, not a bounding rect, for the reason `use-panel-anchor.ts` already has it. The update cards animate in from `scale: 0.96` and a rect is measured through that transform: 176.64 against a layout 184 at 1366x640, still 193.71 against 196 at the last reflow. A finished transform resizes nothing, so no observer comes back with the settled figure and the short reading is the floor the placement keeps. It also matches `scrollHeight`, the total the sum is clamped against.

`inRailFlow` drops `fixed` and `absolute` children. Dragged, the loaded models card pins itself `position: fixed` and leaves the rail's flow; `scrollHeight` drops it, so a floor that still counted it asked for 225px where 128 was needed and lifted the rail off a corner it fitted in. The `persistentTail` walk had the same fault, counting a card that lands on nothing as part of the run guarding the composer, and now uses the same list.

`overflowing` moves off `floorRoom` and onto the height the cards actually collapse to. The floor is now larger than that wherever a card would rather be clipped than shrink, and a clipped card is not a fold to scroll to: reading the floor there would give the rail `pointer-events-auto`, and with it the clicks crossing its gutter, for a scrollbar it does not have.

The docked composer is still cleared instead of accepting its 5px strip. The behavior added in #8462 is preserved: a welcome-screen band that holds one usable card keeps the rail in the corner, and longer lists scroll there.

## Verification

| Layout | Window | Before | After |
| --- | --- | --- | --- |
| Chat thread | 1280x800 | `bottom 16, cap 5.47` | `bottom 149, cap 635` |
| Chat thread | 1280x520 | `bottom 16, cap 5.47` | `bottom 149, cap 355` |
| Welcome + update card | 1366x640 | `cap 200`, panel 8px | `cap 608`, panel 120.77px |
| Welcome, models card dragged out | 1366x640 | `bottom 344, cap 280` | `bottom 16, cap 200` |
| Welcome | 1280x800 | Whole card in corner | Unchanged |
| Welcome, 3 jobs | 1280x800 | 241px card in corner | Unchanged |

- `node --test tests/monitor-stack-inset.test.ts`: 66 passed, including the banner-plus-panel floor, the 1366x640 placement, the layout-box reading and the dragged card
- `node --test tests/update-banner-flex-priority.test.ts`: 15 passed
- `npm run typecheck`
- `npm run build`
- ESLint and Biome checks on the changed files
- `npm test`: 13 failures, all in `context-window-visible.test.ts` and `thread-scoped-sampling-simulation.test.ts`, reproduced on the PR's own base
- Live Chromium against a running Studio: the docked layout at 1280x800, 1280x520 and 1366x640, and the welcome layout at 1366x640, 1024x640 and 1280x800, each with and without the app update card
- The 26 viewports `tests/studio/playwright_update_banner_layout.py` sweeps, welcome and docked, with and without a download: the rail takes pointer input exactly when it scrolls in all of them, and 3 to 5 of them do scroll
- Its composer-clearance check at its own viewports (921x534, 768x500) plus 1366x640, 1024x640 and 1280x800, with the loaded models card up: `tailOverlap` is 0 in all of them
