### PR TITLE
Keep path_utils off PEP 604, which the 3.9 floor gate rejects

### DIFF
--- a/studio/backend/tests/test_rag_store.py
+++ b/studio/backend/tests/test_rag_store.py
@@ -451,8 +451,12 @@ def test_a_legacy_archive_still_gets_two_different_ends(rag_home, rag_conn):
         store.add_chunks(conn, scope, document, [chunk], [[0.0, 0.0, 0.0, 0.0]])
     conn.commit()
 
-    oldest = [chunk for chunk, _ in store.search_lexical(conn, scope, "ZQXLEGACY", 3, oldest_first = True)]
-    newest = [chunk for chunk, _ in store.search_lexical(conn, scope, "ZQXLEGACY", 3, newest_first = True)]
+    oldest = [
+        chunk for chunk, _ in store.search_lexical(conn, scope, "ZQXLEGACY", 3, oldest_first = True)
+    ]
+    newest = [
+        chunk for chunk, _ in store.search_lexical(conn, scope, "ZQXLEGACY", 3, newest_first = True)
+    ]
 
     assert oldest and newest
     assert oldest != newest, "both ends of the fetch returned the same rows"

--- a/studio/backend/utils/paths/path_utils.py
+++ b/studio/backend/utils/paths/path_utils.py
@@ -69,7 +69,10 @@ def _shadowed_name(path: str) -> str:
 
 
 def drop_shadowed_appledouble_names(
-    files: list[str], *, subject_key: Callable[[str], object] | None = None
+    # Optional[...] rather than `| None`: this module has no `from __future__ import
+    # annotations`, so its annotations are evaluated at import, and PEP 604 unions are a
+    # TypeError on the declared 3.9 floor. tests/test_python39_compatibility.py gates it.
+    files: list[str], *, subject_key: Optional[Callable[[str], object]] = None
 ) -> list[str]:
     """*files* without the ``._`` entries whose subject is present in the same listing.
 

--- a/studio/backend/utils/paths/path_utils.py
+++ b/studio/backend/utils/paths/path_utils.py
@@ -72,7 +72,9 @@ def drop_shadowed_appledouble_names(
     # Optional[...] rather than `| None`: this module has no `from __future__ import
     # annotations`, so its annotations are evaluated at import, and PEP 604 unions are a
     # TypeError on the declared 3.9 floor. tests/test_python39_compatibility.py gates it.
-    files: list[str], *, subject_key: Optional[Callable[[str], object]] = None
+    files: list[str],
+    *,
+    subject_key: Optional[Callable[[str], object]] = None,
 ) -> list[str]:
     """*files* without the ``._`` entries whose subject is present in the same listing.
 


### PR DESCRIPTION
`Core` is failing on main at **python floor compatibility (HARD GATE)**, on all three HF/TRL cells:

```
36 studio files now evaluate PEP 604 unions on the floor, up from 35
```

The 36th is `studio/backend/utils/paths/path_utils.py`, from #8919. That change is right - it just added

```python
subject_key: Callable[[str], object] | None = None
```

to a module with no `from __future__ import annotations`, so the annotation is **evaluated at import** and `X | None` is a `TypeError` on the declared 3.9 floor.

### Why Optional[...] and not the future import

The ratchet's message suggests adding `from __future__ import annotations`, and that would work, but it is the wider change: five other modules import this one, and the ratchet's own docstring warns that converting a file wants Studio booted, because FastAPI resolves annotations when it builds each endpoint. `Optional` is already imported in this file, so this touches one annotation and nothing else.

### Verified on main

| | |
|---|---|
| offenders | back to 35, against a debt of 35 |
| `tests/test_python39_compatibility.py` | 8 passed |
| `studio/backend/tests/test_appledouble_guards.py` | 9 passed - the behaviour #8919 added is unchanged |
| ruff | clean |

Reproduced locally before fixing: a checkout of `origin/main` counts 36, my branch point counted 35, and the diff is exactly this one file.