### PR TITLE
studio: bump @tanstack/react-virtual to 3.14.10

### DIFF
--- a/studio/backend/tests/test_rag_store.py
+++ b/studio/backend/tests/test_rag_store.py
@@ -451,8 +451,12 @@ def test_a_legacy_archive_still_gets_two_different_ends(rag_home, rag_conn):
         store.add_chunks(conn, scope, document, [chunk], [[0.0, 0.0, 0.0, 0.0]])
     conn.commit()
 
-    oldest = [chunk for chunk, _ in store.search_lexical(conn, scope, "ZQXLEGACY", 3, oldest_first = True)]
-    newest = [chunk for chunk, _ in store.search_lexical(conn, scope, "ZQXLEGACY", 3, newest_first = True)]
+    oldest = [
+        chunk for chunk, _ in store.search_lexical(conn, scope, "ZQXLEGACY", 3, oldest_first = True)
+    ]
+    newest = [
+        chunk for chunk, _ in store.search_lexical(conn, scope, "ZQXLEGACY", 3, newest_first = True)
+    ]
 
     assert oldest and newest
     assert oldest != newest, "both ends of the fetch returned the same rows"

--- a/studio/frontend/package-lock.json
+++ b/studio/frontend/package-lock.json
@@ -31,7 +31,7 @@
         "@tailwindcss/vite": "^4.2.2",
         "@tanstack/react-router": "1.169.2",
         "@tanstack/react-table": "^8.21.3",
-        "@tanstack/react-virtual": "3.13.25",
+        "@tanstack/react-virtual": "3.14.10",
         "@tauri-apps/api": "^2.10.1",
         "@tauri-apps/plugin-clipboard-manager": "^2.3.2",
         "@tauri-apps/plugin-deep-link": "2.4.9",
@@ -6406,12 +6406,12 @@
       }
     },
     "node_modules/@tanstack/react-virtual": {
-      "version": "3.13.25",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.25.tgz",
-      "integrity": "sha512-bmNoqMu6gcAW9JGrKVB0Q1tN1i5RONZF8r1fW0bbE4Oyf3DwEGnzzQJ2OW+Ozg1P4s8PyugkHg2ULZoFQN+cqw==",
+      "version": "3.14.10",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.14.10.tgz",
+      "integrity": "sha512-SRyoUbdFMRHuYXMijV5H4ZarQWpXkj3iANq8OFre+pybeVap8ZJjZ3Nz9bVjx4d8PfobVUQUdKyyyHYk3E+djw==",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/virtual-core": "3.15.0"
+        "@tanstack/virtual-core": "3.17.8"
       },
       "funding": {
         "type": "github",
@@ -6465,9 +6465,9 @@
       }
     },
     "node_modules/@tanstack/virtual-core": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.15.0.tgz",
-      "integrity": "sha512-0AwPGx0I8QxPYjAxShT/+z+ZOe9u8mW5rsXvivCTjRfRmz9a43+3mRyi4wwlyoUqOC56q/jatKa0Bh9M99BEHQ==",
+      "version": "3.17.8",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.17.8.tgz",
+      "integrity": "sha512-BfEvehNpOT75r5Ksc5xW6NZuXujTfb7nlSEyVu4XHG3gdxNg1KqXruWbDewXOUaUYIo4oRbSfkjIajz4MAT8tA==",
       "license": "MIT",
       "funding": {
         "type": "github",

--- a/studio/frontend/package.json
+++ b/studio/frontend/package.json
@@ -45,7 +45,7 @@
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/react-router": "1.169.2",
     "@tanstack/react-table": "^8.21.3",
-    "@tanstack/react-virtual": "3.13.25",
+    "@tanstack/react-virtual": "3.14.10",
     "@tauri-apps/api": "^2.10.1",
     "@tauri-apps/plugin-clipboard-manager": "^2.3.2",
     "@tauri-apps/plugin-deep-link": "2.4.9",


### PR DESCRIPTION
## Why

`studio/frontend/package.json` pinned `@tanstack/react-virtual` at exactly `3.13.25`, which resolves `@tanstack/virtual-core` `3.15.0`. The end-anchored virtualizer options a chat list needs, `anchorTo`, `followOnAppend`, `isAtEnd` and `scrollEndThreshold`, do not exist in `3.15.0`. They first appear in `virtual-core` `3.16.0`, one patch above what we were pinned to.

Without them the alternative is manual `scrollTop` bookkeeping, which is exactly what the library's chat mode exists to replace, and exactly the kind of code that has already produced scroll anchoring bugs in this codebase.

`3.14.10` resolves `virtual-core` `3.17.8`, which is at or after the follow-up fix in [TanStack/virtual#1176](https://github.com/TanStack/virtual/pull/1176), eagerly adjusting `scrollOffset` on prepend to prevent a jump. That fix shipped in core `3.16.1`, so taking `3.16.0` alone would not have been enough.

## What this PR is

The bump on its own. Nothing in the app uses the new options yet.

## Evidence it is a null

The only `useVirtualizer` call site in the app today is the model catalogue, `studio/frontend/src/features/hub/catalog/models-catalog-rows.tsx`. Replaying its exact config through both core versions at seven scroll offsets and two scroll margins gives **14 of 14 identical windows**: same index range, same count, same total size.

That is expected rather than lucky. The new options default to `anchorTo: "start"`, `followOnAppend: false` and `scrollEndThreshold: 1`, so nothing changes for a caller that does not pass them. The React wrapper diff is purely additive, one new `directDomUpdates` option defaulting to `false`.

Frontend suite is unmoved by the bump: 4083 passed, 0 failed, identical to the count taken immediately before it. `npm run typecheck` and `npm run build` both exit 0.

## Follow-up

The mechanism that uses these options lands separately, behind a flag defaulting off, so it can be exercised and reverted by config before any default changes.