### PR TITLE
studio: windowed message list behind a flag, defaulting off

### DIFF
--- a/studio/frontend/src/components/assistant-ui/thread-feature-flags.ts
+++ b/studio/frontend/src/components/assistant-ui/thread-feature-flags.ts
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// Thread feature flags for staged rollout. JSX/wiring stay in place so flipping
+// a flag here is the only edit needed to re-enable.
+
+// Windowed message list: mount only the messages near the viewport instead of
+// every message the thread has ever rendered. OFF until the autoscroll hook
+// follows the virtualizer's `isAtEnd()` rather than the viewport's
+// `scrollHeight`, and until select-all-copy reads the message store rather than
+// the DOM. Both are prerequisites, not polish: with this on and either missing,
+// a streaming thread stops following and a copied conversation silently loses
+// every message that happened to be unmounted.
+//
+// While this is false the thread renders the exact `<ThreadPrimitive.Messages>`
+// element it always has, so the flag-off DOM is unchanged.
+export const THREAD_MESSAGE_VIRTUALIZATION_ENABLED = false;

--- a/studio/frontend/src/components/assistant-ui/thread-message-virtualizer-policy.ts
+++ b/studio/frontend/src/components/assistant-ui/thread-message-virtualizer-policy.ts
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+/**
+ * Sizing and keying policy for the windowed message list.
+ *
+ * Split out of the component because there is no DOM in the test runner: a virtualizer needs a real
+ * scroll element and real layout, so the parts that can be asserted are the pure ones. Everything
+ * here is a value or a total function over the message array.
+ */
+
+/** The only thing the window needs from a message: something stable to key on. */
+export type VirtualizedMessage = {
+  id: string;
+};
+
+/**
+ * Estimated height of one message, before it has been measured.
+ *
+ * Measured, not guessed. Three sizes of the heavy-thread fixture (20/80/220 messages) at 1440x900
+ * give 574.2, 566.2 and 564.7 px per message, byte-identical across Chromium, Firefox and WebKit.
+ * The same fixture at 1280 wide gives 536.4, and the reduced 144-row fixture 463.1. The first-paint
+ * window (16 rows, 7,379 px) gives 461.2, because a thread opens on its short early messages.
+ *
+ * So the real range is 461 to 574 depending on viewport width and where in a thread you look. This
+ * takes 460, the bottom of that range, deliberately: `estimateSize` too LOW makes the virtualizer
+ * render more items than it needs, which costs a few extra mounts; too HIGH makes it render fewer
+ * than fill the viewport, which paints a blank gap the user sees. The failure modes are not
+ * symmetric, so the estimate is biased to the cheap one.
+ *
+ * Not derived from the studiobench film: its rungs are a handful of 300K-character documents and
+ * measure 2,438 to 14,319 px per "message", which is not the shape of a chat message.
+ */
+export const THREAD_MESSAGE_ESTIMATE_SIZE_PX = 460;
+
+/**
+ * Messages rendered beyond each edge of the viewport.
+ *
+ * Counted in items, not pixels, so it has to be read against the item size: at ~460 px a message
+ * and a ~900 px viewport only about two messages are on screen, so 8 either side is roughly 3,700 px
+ * of buffer above and below, and about 20 messages mounted in total. Generous on purpose. The whole
+ * point of this change is that a thread stops paying for thousands of standing nodes, so twenty is
+ * not a cost worth shaving, and a short overscan is what produces blank space during a fast scroll.
+ */
+export const THREAD_MESSAGE_OVERSCAN = 8;
+
+/**
+ * How close to the bottom still counts as "at the end", for `followOnAppend`.
+ *
+ * Matched to RE_ATTACH_THRESHOLD_PX in use-intent-aware-autoscroll.tsx, which is the distance at
+ * which that hook decides a user who scrolled up has come back and re-attaches. The virtualizer
+ * follows an appended message exactly when `isAtEnd(scrollEndThreshold)` holds, so giving the two
+ * the same threshold is what stops them disagreeing about whether the user is following the stream.
+ * The hook's stricter 2 px AT_BOTTOM_THRESHOLD_PX is a different question (is the viewport pinned
+ * right now), not this one.
+ */
+export const THREAD_MESSAGE_SCROLL_END_THRESHOLD_PX = 24;
+
+/**
+ * End-anchored virtualizer options.
+ *
+ * Requires @tanstack/virtual-core >= 3.16.1: `anchorTo`/`followOnAppend`/`scrollEndThreshold` do not
+ * exist before 3.16.0, and 3.16.1 is the first release carrying the eager scrollOffset adjustment on
+ * prepend. The alternative is hand-rolled scrollTop bookkeeping, which is what this replaces.
+ */
+export const THREAD_MESSAGE_ANCHORING = {
+  // A chat is read from its end. Anchoring to the start makes every measurement correction above the
+  // viewport push the content the user is reading.
+  anchorTo: "end",
+  // Follow a newly appended message, but only from the end: the library checks `isAtEnd` before it
+  // follows, so a user who scrolled up is not yanked down.
+  followOnAppend: true,
+  scrollEndThreshold: THREAD_MESSAGE_SCROLL_END_THRESHOLD_PX,
+} as const;
+
+/**
+ * The virtualizer key for the message at `index`.
+ *
+ * The message id, never the index. After a prepend (history paging, a branch switch) every existing
+ * message moves to a new index, so an index key renames every item: the virtualizer throws away its
+ * measurement cache and React unmounts and remounts every message below the insertion point. That is
+ * the same positional-keying failure that parked the block-level windowing work, where Streamdown
+ * keyed blocks as `useId()-index` and compared `e.index !== t.index`.
+ *
+ * The fallback is only reachable if `count` and the message array disagree for a render, which the
+ * component avoids by deriving both from the same array. It is deliberately not the bare index, so a
+ * transient gap cannot collide with a real message's key.
+ */
+export function messageKeyAt(
+  messages: readonly VirtualizedMessage[],
+  index: number,
+): string {
+  return messages[index]?.id ?? `aui-unresolved-message-${index}`;
+}
+
+/**
+ * Distance from the top of the scroll element to the top of the list container.
+ *
+ * The virtualizer works in scroll-element coordinates, but the list is not the first thing in the
+ * viewport: the header padding and the welcome block sit above it. Without this offset every item is
+ * positioned that many pixels too high.
+ *
+ * Clamped at 0: during a thread switch the container can be measured while detached or mid-layout,
+ * and a negative margin would push the first message off the top of the list.
+ */
+export function scrollMarginFor(
+  containerTop: number,
+  scrollElementTop: number,
+  scrollTop: number,
+): number {
+  return Math.max(0, containerTop - scrollElementTop + scrollTop);
+}

--- a/studio/frontend/src/components/assistant-ui/thread-message-virtualizer.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread-message-virtualizer.tsx
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"use client";
+
+/**
+ * Windowed replacement for `<ThreadPrimitive.Messages>`.
+ *
+ * `ThreadPrimitive.Messages` builds one element per message and keeps every one of them mounted for
+ * the life of the thread, so a long thread pays for every message it has ever rendered on every
+ * layout, restyle and hit test. This mounts only the messages near the viewport.
+ *
+ * Gated by THREAD_MESSAGE_VIRTUALIZATION_ENABLED, which is off. See thread-feature-flags.ts for what
+ * has to land before it goes on.
+ */
+
+import { ThreadPrimitive, useAui, useAuiState } from "@assistant-ui/react";
+import { useVirtualizer } from "@tanstack/react-virtual";
+import {
+  type ComponentProps,
+  type FC,
+  useCallback,
+  useLayoutEffect,
+  useState,
+} from "react";
+
+import {
+  THREAD_MESSAGE_ANCHORING,
+  THREAD_MESSAGE_ESTIMATE_SIZE_PX,
+  THREAD_MESSAGE_OVERSCAN,
+  messageKeyAt,
+  scrollMarginFor,
+} from "./thread-message-virtualizer-policy";
+
+type MessageComponents = ComponentProps<
+  typeof ThreadPrimitive.MessageByIndex
+>["components"];
+
+export const VirtualizedThreadMessages: FC<{
+  /** The scroll element, owned by useIntentAwareAutoScroll and mirrored by Thread. */
+  scrollElement: HTMLElement | null;
+  /**
+   * Must be hoisted by the caller. ThreadPrimitive.MessageByIndex is memoized on its index and on
+   * each component in this object, so a fresh object per render defeats the memo and re-renders
+   * every mounted message body.
+   */
+  components: MessageComponents;
+}> = ({ scrollElement, components }) => {
+  const aui = useAui();
+  // Length only, which is what ThreadPrimitive.Messages subscribes to. Subscribing to the array
+  // itself would re-render this container on every streamed token; ids are read on demand in
+  // getItemKey instead.
+  const count = useAuiState(({ thread }) => thread.messages.length);
+
+  // State, not a ref: the container is not rendered at all while the thread is empty, so the effect
+  // below has to re-run when it appears. A ref would still be null from the empty render and, with
+  // nothing in its dependencies having changed, would never be measured.
+  const [container, setContainer] = useState<HTMLDivElement | null>(null);
+  const [scrollMargin, setScrollMargin] = useState(0);
+
+  // The list is not the first thing in the viewport (header padding, welcome block), so the
+  // virtualizer needs the gap between the two. Layout effect, not effect: this has to be right in
+  // the frame the list first paints, or every item is positioned too high for a frame.
+  useLayoutEffect(() => {
+    if (!container || !scrollElement) {
+      return;
+    }
+    const measure = (): void => {
+      setScrollMargin((previous) => {
+        const next = scrollMarginFor(
+          container.getBoundingClientRect().top,
+          scrollElement.getBoundingClientRect().top,
+          scrollElement.scrollTop,
+        );
+        // Sub-pixel churn here would re-render the list on every scroll frame.
+        return Math.abs(next - previous) < 1 ? previous : next;
+      });
+    };
+    measure();
+    // Anything above the list changing height moves it: the welcome block unmounting on the first
+    // message, the chat-model notice showing, a breakpoint crossing.
+    const observer = new ResizeObserver(measure);
+    observer.observe(scrollElement);
+    observer.observe(container);
+    return () => observer.disconnect();
+  }, [scrollElement, container]);
+
+  const getItemKey = useCallback(
+    (index: number) => messageKeyAt(aui.thread().getState().messages, index),
+    [aui],
+  );
+
+  // eslint-disable-next-line react-hooks/incompatible-library
+  const virtualizer = useVirtualizer({
+    count,
+    getScrollElement: () => scrollElement,
+    estimateSize: () => THREAD_MESSAGE_ESTIMATE_SIZE_PX,
+    overscan: THREAD_MESSAGE_OVERSCAN,
+    scrollMargin,
+    getItemKey,
+    ...THREAD_MESSAGE_ANCHORING,
+  });
+
+  // Nothing to window, and no container either: an empty list must not put a 0px positioned box
+  // between the welcome block and the spacer, because that is a DOM node the unvirtualized path
+  // does not have.
+  if (count === 0) {
+    return null;
+  }
+
+  return (
+    <div
+      ref={setContainer}
+      className="relative w-full shrink-0"
+      style={{ height: virtualizer.getTotalSize() }}
+    >
+      {virtualizer.getVirtualItems().map((item) => (
+        <div
+          // The message id. See messageKeyAt: an index key remounts every message below a prepend.
+          key={item.key}
+          data-index={item.index}
+          // Measured, not fixed: messages run from about 20px to 2000px, so a fixed height would be
+          // wrong for nearly all of them.
+          ref={virtualizer.measureElement}
+          style={{
+            position: "absolute",
+            top: 0,
+            left: 0,
+            width: "100%",
+            transform: `translateY(${item.start - virtualizer.options.scrollMargin}px)`,
+          }}
+        >
+          <ThreadPrimitive.MessageByIndex
+            index={item.index}
+            components={components}
+          />
+        </div>
+      ))}
+    </div>
+  );
+};

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -27,6 +27,8 @@ import { Reasoning, ReasoningGroup } from "@/components/assistant-ui/reasoning";
 import { RagSourcesGroup } from "@/components/assistant-ui/rag-sources";
 import { researchReplyOwners } from "@/components/assistant-ui/research-reply-owners";
 import { Sources, SourcesGroup } from "@/components/assistant-ui/sources";
+import { THREAD_MESSAGE_VIRTUALIZATION_ENABLED } from "@/components/assistant-ui/thread-feature-flags";
+import { VirtualizedThreadMessages } from "@/components/assistant-ui/thread-message-virtualizer";
 import {
   proplessSlot,
   threadMessageKind,
@@ -1495,6 +1497,14 @@ const ThreadMessage: FC = () => {
 // being rebuilt, and the bail-out below it would never get to run.
 const renderThreadMessage = proplessSlot(ThreadMessage);
 
+// The same component, for the windowed path. ThreadPrimitive.MessageByIndex only takes the map
+// form, but supplying `Message` alone resolves to ThreadMessage for every role and edit state
+// through assistant-ui's fallback chain (UserMessage ?? Message, AssistantMessage ?? Message, and
+// every *EditComposer ?? EditComposer ?? *Message ?? Message), so both paths render the same
+// component and ThreadMessage keeps making the choice. Hoisted for the same reason as the slot
+// above: MessageByIndex is memoized on the identity of each component in this object.
+const virtualizedThreadMessageComponents = { Message: ThreadMessage };
+
 // Memoized: chat-page renders this inline in a store-subscribing component, so a parent render
 // would otherwise reconcile the whole message list.
 export const Thread: FC<{
@@ -1731,6 +1741,11 @@ export const Thread: FC<{
             scrollToBottomOnThreadSwitch={false}
             className={cn(
               "aui-thread-viewport aui-stream-viewport relative flex min-h-0 min-w-0 flex-1 basis-0 flex-col overflow-x-auto overflow-y-auto scroll-smooth px-5",
+              // Disables browser scroll anchoring, but only where the
+              // virtualizer owns scroll position. See the rule in index.css for
+              // why this is not unconditional.
+              THREAD_MESSAGE_VIRTUALIZATION_ENABLED &&
+                "aui-stream-viewport-virtualized",
               hideComposer
                 ? "pt-4"
                 : // + the chat-model notice, which is an opaque absolute bar
@@ -1747,9 +1762,16 @@ export const Thread: FC<{
               </AuiIf>
             )}
 
-            <ThreadPrimitive.Messages>
-              {renderThreadMessage}
-            </ThreadPrimitive.Messages>
+            {THREAD_MESSAGE_VIRTUALIZATION_ENABLED ? (
+              <VirtualizedThreadMessages
+                scrollElement={viewportEl}
+                components={virtualizedThreadMessageComponents}
+              />
+            ) : (
+              <ThreadPrimitive.Messages>
+                {renderThreadMessage}
+              </ThreadPrimitive.Messages>
+            )}
 
             {/* Bottom slack so the last message has room above the sticky
             scroll-to-bottom button (and floating composer in single mode),

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -2859,6 +2859,27 @@ html[data-chat-font] .aui-root {
 	padding-bottom: var(--aui-scroll-stabilizer, 0px);
 }
 
+/* Applied to the same viewport only while the message list is windowed
+   (THREAD_MESSAGE_VIRTUALIZATION_ENABLED, see
+   components/assistant-ui/thread-feature-flags.ts).
+
+   A virtualizer positions items itself and corrects scrollOffset itself, so it
+   has to be the only thing moving scrollTop. Chromium's CSS scroll anchoring
+   moves scrollTop too, and correcting an anchor shift in document space on top
+   of that double-corrects, which is where the anchoring bugs in the progressive
+   mount work came from.
+
+   Deliberately NOT unconditional. The unwindowed path currently DEPENDS on
+   browser scroll anchoring: useIntentAwareAutoScroll's upward-intent test
+   measures growth in distance-from-bottom rather than raw scrollTop delta
+   precisely because a browser scroll-anchors when content above collapses, so
+   scrollTop and scrollHeight drop together and the distance is unchanged.
+   Turning anchoring off for everyone would make a reasoning-pane collapse read
+   as a deliberate scroll up and detach the user from a live stream. */
+.aui-stream-viewport-virtualized {
+	overflow-anchor: none;
+}
+
 .dark .aui-thread-viewport {
 	scrollbar-color: oklch(0.72 0 0 / 0.25) #23252a;
 }

--- a/studio/frontend/tests/thread-message-virtualization.test.ts
+++ b/studio/frontend/tests/thread-message-virtualization.test.ts
@@ -1,0 +1,270 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// The windowed message list, in the two halves that can be asserted without a DOM.
+//
+// There is no jsdom here and a virtualizer needs a real scroll element and real layout, so the
+// mechanism itself is not mountable. What IS assertable, and is what actually goes wrong:
+//   - the keying property, because keying on the index is the failure that parked the block-level
+//     windowing work and is invisible until something prepends;
+//   - that the flag is off and the flag-off path is still the element it always was, which is the
+//     whole claim of this stage.
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import ts from "typescript";
+
+import { THREAD_MESSAGE_VIRTUALIZATION_ENABLED } from "../src/components/assistant-ui/thread-feature-flags.ts";
+import {
+  THREAD_MESSAGE_ANCHORING,
+  THREAD_MESSAGE_ESTIMATE_SIZE_PX,
+  THREAD_MESSAGE_OVERSCAN,
+  THREAD_MESSAGE_SCROLL_END_THRESHOLD_PX,
+  type VirtualizedMessage,
+  messageKeyAt,
+  scrollMarginFor,
+} from "../src/components/assistant-ui/thread-message-virtualizer-policy.ts";
+import { cn } from "../src/lib/utils.ts";
+import { openingTag } from "./helpers/tsx-ast.ts";
+
+const read = (relative: string): string =>
+  readFileSync(fileURLToPath(new URL(relative, import.meta.url)), "utf8");
+
+const sourceFile = (relative: string): ts.SourceFile => {
+  const path = fileURLToPath(new URL(relative, import.meta.url));
+  return ts.createSourceFile(
+    path,
+    readFileSync(path, "utf8"),
+    ts.ScriptTarget.ESNext,
+    true,
+    ts.ScriptKind.TSX,
+  );
+};
+
+const THREAD = "../src/components/assistant-ui/thread.tsx";
+const AUTOSCROLL =
+  "../src/components/assistant-ui/use-intent-aware-autoscroll.tsx";
+
+const messages = (...ids: string[]): VirtualizedMessage[] =>
+  ids.map((id) => ({ id }));
+
+// ---------------------------------------------------------------------------
+// The flag, and the path it leaves alone
+// ---------------------------------------------------------------------------
+
+test("the windowed message list is off", () => {
+  // The point of the flag is that the mechanism is exercisable and revertible by config before
+  // anything user-visible changes. Turning it on is a separate, measured step.
+  assert.equal(THREAD_MESSAGE_VIRTUALIZATION_ENABLED, false);
+});
+
+test("the unwindowed path still renders the shared propless slot", () => {
+  const source = read(THREAD);
+  // Byte-for-byte the element the thread has always rendered, indentation aside. If this ever needs
+  // updating, the flag-off DOM has changed and the claim of this stage is void.
+  assert.match(
+    source,
+    /<ThreadPrimitive\.Messages>\s*\{renderThreadMessage\}\s*<\/ThreadPrimitive\.Messages>/,
+  );
+});
+
+test("the windowed list is the only thing behind the flag in the message slot", () => {
+  const source = read(THREAD);
+  // The conditional has to be an expression around the two lists, not a mutation of the surrounding
+  // JSX: anything else and "off is unchanged" stops being checkable by reading the ternary.
+  assert.match(
+    source,
+    /\{THREAD_MESSAGE_VIRTUALIZATION_ENABLED \? \(\s*<VirtualizedThreadMessages/,
+  );
+});
+
+test("the anchoring class is applied only under the flag", () => {
+  const source = read(THREAD);
+  // `cn` drops falsy entries, so with the flag off the viewport's className string is the one it
+  // already had. Unconditional `overflow-anchor: none` would change the unwindowed path, which the
+  // autoscroll hook is written against; see the rule in index.css.
+  assert.match(
+    source,
+    /THREAD_MESSAGE_VIRTUALIZATION_ENABLED &&\s*"aui-stream-viewport-virtualized"/,
+  );
+  assert.doesNotMatch(
+    read("../src/index.css"),
+    /\.aui-stream-viewport\s*\{[^}]*overflow-anchor/,
+  );
+});
+
+test("with the flag off the viewport's class string is the one it already had", () => {
+  // The class list is built with `cn`, and `false && "..."` is dropped by clsx before twMerge sees
+  // it. Asserted against the real `cn` and the real base class string lifted out of the source,
+  // rather than argued from how clsx ought to behave.
+  const source = read(THREAD);
+  const base = /"(aui-thread-viewport aui-stream-viewport[^"]*)"/.exec(
+    source,
+  )?.[1];
+  assert.ok(base, "viewport base class string not found in the thread");
+
+  const withFlagOff = cn(
+    base,
+    THREAD_MESSAGE_VIRTUALIZATION_ENABLED && "aui-stream-viewport-virtualized",
+    "pt-4",
+  );
+  assert.equal(withFlagOff, cn(base, "pt-4"));
+  assert.doesNotMatch(withFlagOff, /aui-stream-viewport-virtualized/);
+});
+
+test("the message components map is hoisted, not built per render", () => {
+  const source = sourceFile(THREAD);
+  let componentsProp: string | null = null;
+  const visit = (node: ts.Node): void => {
+    const opening = openingTag(node);
+    if (opening?.tagName.getText() === "VirtualizedThreadMessages") {
+      for (const property of opening.attributes.properties) {
+        if (
+          ts.isJsxAttribute(property) &&
+          property.name.getText() === "components"
+        ) {
+          componentsProp = property.initializer?.getText() ?? null;
+        }
+      }
+    }
+    node.forEachChild(visit);
+  };
+  source.forEachChild(visit);
+
+  assert.ok(
+    componentsProp,
+    "<VirtualizedThreadMessages> has no components prop",
+  );
+  // An inline object literal would allocate a fresh map every render, and MessageByIndex is
+  // memoized on the identity of each component in it, so every mounted message body would
+  // re-render on every Thread render. Same reason renderThreadMessage is hoisted.
+  assert.doesNotMatch(componentsProp, /\{\s*\{/);
+  assert.match(componentsProp, /^\{virtualizedThreadMessageComponents\}$/);
+});
+
+// ---------------------------------------------------------------------------
+// Keying: the property that breaks silently
+// ---------------------------------------------------------------------------
+
+test("a message is keyed by its id", () => {
+  const list = messages("m-a", "m-b", "m-c");
+  assert.equal(messageKeyAt(list, 0), "m-a");
+  assert.equal(messageKeyAt(list, 1), "m-b");
+  assert.equal(messageKeyAt(list, 2), "m-c");
+});
+
+test("prepending leaves every existing message's key alone", () => {
+  const before = messages("m-a", "m-b", "m-c");
+  const keysBefore = new Map(
+    before.map((message, index) => [message.id, messageKeyAt(before, index)]),
+  );
+
+  // History paging, or a branch switch that reveals earlier turns: every old message moves to a new
+  // index. An index key would rename all three, dropping the virtualizer's measurement cache and
+  // remounting every message below the insertion point.
+  const after = messages("m-x", "m-y", "m-a", "m-b", "m-c");
+  for (const [id, key] of keysBefore) {
+    const index = after.findIndex((message) => message.id === id);
+    assert.equal(messageKeyAt(after, index), key);
+  }
+});
+
+test("keys are not positional", () => {
+  const list = messages("m-a", "m-b", "m-c");
+  // Stated directly, because the prepend test above would still pass if keys happened to be
+  // stringified indices in a list whose ids were also "0", "1", "2".
+  for (let index = 0; index < list.length; index++) {
+    assert.notEqual(messageKeyAt(list, index), String(index));
+  }
+});
+
+test("keys are unique across the thread", () => {
+  const list = messages("m-a", "m-b", "m-c", "m-d");
+  const keys = list.map((_, index) => messageKeyAt(list, index));
+  assert.equal(new Set(keys).size, keys.length);
+});
+
+test("an empty thread has no keys to resolve", () => {
+  const list = messages();
+  assert.equal(list.length, 0);
+  // Reached only if count and the array disagree for a render. It must not collide with a real id,
+  // so it is not the bare index.
+  assert.equal(messageKeyAt(list, 0), "aui-unresolved-message-0");
+  assert.notEqual(messageKeyAt(list, 0), "0");
+});
+
+test("a single-message thread keys that one message", () => {
+  const list = messages("m-only");
+  assert.equal(messageKeyAt(list, 0), "m-only");
+  assert.equal(messageKeyAt(list, 1), "aui-unresolved-message-1");
+});
+
+test("a long thread keys every message by id", () => {
+  const list = messages(...Array.from({ length: 5000 }, (_, i) => `m-${i}`));
+  assert.equal(messageKeyAt(list, 0), "m-0");
+  assert.equal(messageKeyAt(list, 2499), "m-2499");
+  assert.equal(messageKeyAt(list, 4999), "m-4999");
+  assert.equal(new Set(list.map((_, i) => messageKeyAt(list, i))).size, 5000);
+});
+
+// ---------------------------------------------------------------------------
+// Sizing policy
+// ---------------------------------------------------------------------------
+
+test("the size estimate sits at the low end of the measured range", () => {
+  // Measured per-message heights: 574.2 / 566.2 / 564.7 px at 1440x900 across three thread sizes,
+  // 536.4 at 1280 wide, 463.1 on the reduced fixture, 461.2 over a first-paint window. Under-
+  // estimating makes the virtualizer render more items than it needs; over-estimating paints a
+  // blank gap. The failure modes are not symmetric.
+  assert.ok(THREAD_MESSAGE_ESTIMATE_SIZE_PX <= 463);
+  assert.ok(THREAD_MESSAGE_ESTIMATE_SIZE_PX >= 300);
+});
+
+test("the overscan buffers several viewports", () => {
+  // At the estimated size, on the 900px-tall viewport the benchmarks use.
+  const bufferPx = THREAD_MESSAGE_OVERSCAN * THREAD_MESSAGE_ESTIMATE_SIZE_PX;
+  assert.ok(bufferPx >= 3 * 900);
+});
+
+test("the end threshold matches the hook's re-attach distance", () => {
+  // The virtualizer follows an appended message exactly when isAtEnd(scrollEndThreshold) holds, and
+  // the hook re-attaches a scrolled-up user at RE_ATTACH_THRESHOLD_PX. Different numbers means the
+  // two disagree about whether the user is following the stream. Read from the source so the pair
+  // cannot drift apart unnoticed.
+  const match = /RE_ATTACH_THRESHOLD_PX = (\d+)/.exec(read(AUTOSCROLL));
+  assert.ok(match, "RE_ATTACH_THRESHOLD_PX not found in the autoscroll hook");
+  assert.equal(THREAD_MESSAGE_SCROLL_END_THRESHOLD_PX, Number(match[1]));
+});
+
+test("the list anchors to the end and follows appends", () => {
+  // virtual-core defaults are anchorTo "start" and followOnAppend false, which is a document, not a
+  // chat. Both need >= 3.16.1 to exist at all.
+  assert.equal(THREAD_MESSAGE_ANCHORING.anchorTo, "end");
+  assert.equal(THREAD_MESSAGE_ANCHORING.followOnAppend, true);
+  assert.equal(
+    THREAD_MESSAGE_ANCHORING.scrollEndThreshold,
+    THREAD_MESSAGE_SCROLL_END_THRESHOLD_PX,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Scroll margin
+// ---------------------------------------------------------------------------
+
+test("the scroll margin is the list's offset inside the scroll element", () => {
+  // Viewport top at 100 on screen, scrolled down 500, list starting 260 below the viewport top:
+  // the list begins 660px into the scrollable content.
+  assert.equal(scrollMarginFor(360, 100, 500), 760);
+  // Unscrolled, list flush with the top of the viewport.
+  assert.equal(scrollMarginFor(100, 100, 0), 0);
+});
+
+test("the scroll margin never goes negative", () => {
+  // A thread switch can measure the container while it is detached or mid-layout. A negative margin
+  // would push the first message off the top of the list.
+  assert.equal(scrollMarginFor(0, 100, 0), 0);
+  assert.equal(scrollMarginFor(-5000, 100, 0), 0);
+});


### PR DESCRIPTION
Stacked on #9336, which is the dependency bump this needs. Review that one first.

## The problem

`studio/frontend/src/components/assistant-ui/thread.tsx` renders a bare `<ThreadPrimitive.Messages>`, so **every message ever rendered stays mounted and in layout for the life of the thread**. That is the structural reason a long thread degrades: the cost is paid on every layout, restyle and hit test, whether or not anything changed.

The cost is the standing presence of those nodes, not the work of creating them. Across the heavy-thread fixtures, 63 mutations over 5 s at 16,958 elements gave 18.9 fps and 49 mutations at 22,789 elements gave 14.6, a correlation with mutation count of **r = -0.88**, the wrong sign for creation being the expense. `content-visibility: auto` measured as nothing here, 60.2 percent against 64.8 percent busy: skipping paint does not help, removing nodes from layout does.

Two cheaper dodges were tried and measured out. Windowing the block list inside a message is flat, 0.822 to 0.780 ms per chunk between 45k and 90k characters, so it buys a constant rather than bending the curve. Block-level windowing inside one streaming message did work, 17,487 elements to 3,203 and late busy 64.8 to 39.1 percent, but was parked on boundary correctness because Streamdown keys blocks positionally, which does not apply at the message level.

## What this PR is

The mechanism, off.

`THREAD_MESSAGE_VIRTUALIZATION_ENABLED` is `false`, so the thread renders the exact `<ThreadPrimitive.Messages>` element it always has and the DOM is unchanged. Flipping the flag is the only edit needed to exercise it, which is the point: this is meant to be measurable and revertible by config before any default changes.

## The parts worth reviewing closely

**Keying is on `message.id`, never the index.** After a prepend, history paging or a branch switch, every existing message moves to a new index, so an index key renames every item: the virtualizer discards its measurement cache and React unmounts and remounts everything below the insertion point. This is the same positional-keying failure that parked the block-level work.

**`overflow-anchor: none` is scoped to the flag, not applied unconditionally.** This is a deliberate deviation from the obvious thing. The unwindowed path *depends* on browser scroll anchoring: `use-intent-aware-autoscroll.tsx` measures upward intent as growth in distance-from-bottom precisely because a browser anchors when content above collapses, so `scrollTop` and `scrollHeight` fall together and the distance is unchanged. Turning anchoring off for everyone would make a reasoning-pane collapse read as a deliberate scroll up and detach the user from a live stream.

**Sizing is measured, not guessed.** Real messages run 461 to 574 px per message across the fixtures and viewport widths. `estimateSize` takes 460, the bottom of that range, on purpose: too low over-renders by a few mounts, too high paints a blank gap the user sees, and the failure modes are not symmetric. `overscan: 8` puts about 20 messages mounted at once, roughly 3,700 px of buffer at each edge.

## Verification

19 new tests. There is no DOM in the test runner and a virtualizer needs a real scroll element and real layout, so what is asserted is the keying property, the sizing policy, and, through the TSX AST, that the flag-off path is still the element and the class string it already was. That is a structural proof, not a pixel one, and it is stated as such in the file.

Full frontend suite 4099 passed, 0 failed. `npm run typecheck` and `npm run build` exit 0. `npm run lint` and biome report nothing on the new files.

## What has to land before the default can flip

Both are prerequisites rather than polish, and both are named in the flag's own comment so nobody flips it by accident.

1. The autoscroll hook has to follow the virtualizer's `isAtEnd()` rather than the viewport's `scrollHeight`, which under windowing is an estimate rather than real content.
2. Select-all-copy has to read the message store rather than the DOM. The selection is taken over the viewport DOM and the harness assertion is only that the character count is above zero, so unmounting silently truncates a copied conversation from roughly 400,000 characters to a few thousand **while every timing improves**. That is why `tests/studio/studiobench` now scores `select_all_copy.count.selected_chars` as a correctness invariant rather than a timing, so a fall reads `LOST (invariant fell)` instead of `faster`. The store-backed path already exists and is DOM-free, so this is extending an established pattern.

There is also an exposure list for what unmounting destroys in per-message state: audio playback stops and rewinds, an in-progress assistant-message edit is silently reverted because the textarea is uncontrolled while `editingMessageId` survives in the store, an edit-during-run never resends because the latch is a `useRef`, and a settled tool confirmation can re-arm because `decided` is local state. None of those are reachable with the flag off. All of them have to be answered before it goes on.

## Measurement

The flag has never been switched on, so the windowed path is verified as code, not as behaviour. The configuration is reasoned from measured heights and from replaying the virtualizer's arithmetic offline. The first real run is the first real test of it, and the numbers will be posted here rather than assumed.

Note for anyone measuring this themselves: the parity digest in `tests/studio/studiobench/sweep/ui_parity.py` **cannot** judge this change. It compares structural DOM digests and virtualization changes what is mounted by design, so it will report differences everywhere and prove nothing. Parity for this change means screenshots at matched scroll positions plus the behavioural invariants: `select_all_copy`, `select_text`, `copy_markdown`, `thread_reopen`, `scroll_after`.