### PR TITLE
Stub the two helpers the sliced harnesses started importing

### DIFF
--- a/tests/python/test_cross_platform_parity.py
+++ b/tests/python/test_cross_platform_parity.py
@@ -65,7 +65,7 @@ class TestNoTorchBackendAutoInInstallSh:
         """
         lines = INSTALL_SH.read_text(encoding = "utf-8").splitlines()
         block = _fallback_range(lines)
-        body = "\n".join(lines[block.start:block.stop])
+        body = "\n".join(lines[block.start : block.stop])
         # Both arms of the branch, so neither an early stop nor a runaway passes.
         assert "STUDIO_LOCAL_INSTALL" in body, "the fallback block stops before its own first if"
         assert body.count("--torch-backend=auto") == 2, (

--- a/tests/python/test_cross_platform_parity.py
+++ b/tests/python/test_cross_platform_parity.py
@@ -14,23 +14,34 @@ SETUP_PS1 = REPO_ROOT / "studio" / "setup.ps1"
 STACK_PY = REPO_ROOT / "studio" / "install_python_stack.py"
 
 
+def _fallback_range(lines):
+    """The half-open line range of install.sh's "GPU detection failed" fallback.
+
+    The end is the `fi` that closes the branch, which means counting nesting
+    rather than taking the first `fi` that appears. Any `if` inside the branch
+    contributes one, and so does a `case`: it closes with `esac`, so a version
+    that only counted `if`/`fi` would still be off by one from the `fi` of an
+    `if` nested inside a case arm.
+    """
+    start = next(i for i, line in enumerate(lines) if "GPU detection failed" in line)
+    depth = 0
+    for i in range(start, len(lines)):
+        stripped = lines[i].strip()
+        if re.match(r"^(if|case)\b", stripped):
+            depth += 1
+        elif stripped in ("fi", "esac") or stripped.startswith(("fi ", "esac ")):
+            if depth == 0:
+                return range(start, i + 1)
+            depth -= 1
+    raise AssertionError("install.sh's GPU-detection fallback branch is never closed")
+
+
 class TestNoTorchBackendAutoInInstallSh:
     """install.sh primary paths must not use --torch-backend=auto (only the fallback else-branch may)."""
 
     def test_no_torch_backend_auto_outside_fallback(self):
         lines = INSTALL_SH.read_text(encoding = "utf-8").splitlines()
-        # Fallback block: from "GPU detection failed" to the next "fi".
-        fallback_start = None
-        fallback_end = None
-        for i, line in enumerate(lines):
-            if fallback_start is None and "GPU detection failed" in line:
-                fallback_start = i
-            elif fallback_start is not None and fallback_end is None and line.strip() == "fi":
-                fallback_end = i
-                break
-        fallback_range = (
-            range(fallback_start or 0, (fallback_end or 0) + 1) if fallback_start else range(0)
-        )
+        fallback_range = _fallback_range(lines)
 
         matches = [
             (i + 1, line)
@@ -43,6 +54,26 @@ class TestNoTorchBackendAutoInInstallSh:
             f"install.sh contains --torch-backend=auto outside the fallback block at lines: "
             f"{[m[0] for m in matches]}"
         )
+
+    def test_the_fallback_range_reaches_the_end_of_the_branch(self):
+        """A range that stops early makes the assertion above fire on correct code.
+
+        It did. #8670 put a `case` with a nested `if`/`fi` in this branch to pick
+        the desktop install spec, and the previous "first `fi` after the comment"
+        scan then ended the block four lines short of the install call it exists
+        to permit -- reporting the fallback's own line as a primary path.
+        """
+        lines = INSTALL_SH.read_text(encoding = "utf-8").splitlines()
+        block = _fallback_range(lines)
+        body = "\n".join(lines[block.start:block.stop])
+        # Both arms of the branch, so neither an early stop nor a runaway passes.
+        assert "STUDIO_LOCAL_INSTALL" in body, "the fallback block stops before its own first if"
+        assert body.count("--torch-backend=auto") == 2, (
+            "the fallback runs --torch-backend=auto once per arm; the detected block "
+            f"contains {body.count('--torch-backend=auto')}"
+        )
+        # And it must not have swallowed the rest of the file.
+        assert "_installed_package_version" not in body, "the fallback block ran past its `fi`"
 
     def test_fallback_uses_torch_backend_auto(self):
         """The fallback branch should use --torch-backend=auto as recovery."""

--- a/tests/studio/test_chat_autoload_failure_gate.py
+++ b/tests/studio/test_chat_autoload_failure_gate.py
@@ -118,6 +118,17 @@ async function getInferenceStatus() {
 function isExternalModelId(value: unknown) {
   return typeof value === "string" && value.startsWith("external::");
 }
+// chat-runtime-store.ts:
+//   return storedPreserveThinking ?? preserveThinkingDefaultFromLoad(resp);
+// No scenario here sets a stored preference, so the stub is the model-family
+// default the backend resolves, verbatim from resolve-preserve-thinking-default.ts:
+//   Boolean(resp.supports_preserve_thinking && resp.preserve_thinking_default)
+// Present because the sliced region calls it; without it every scenario in this
+// file fails on the harness guard rather than on anything it means to test.
+function resolvePreserveThinkingOnLoad(resp: any) {
+  return Boolean(resp?.supports_preserve_thinking && resp?.preserve_thinking_default);
+}
+
 function resolveInferenceCheckpointId(status: any) {
   return status.active_model
     ? (status.model_identifier ?? status.active_model)

--- a/tests/studio/test_new_chat_context_recount.py
+++ b/tests/studio/test_new_chat_context_recount.py
@@ -281,6 +281,26 @@ function findLatestUserAudioBase64(_messages: any): string | null {
   return null;
 }
 
+// refresh-context-usage.ts declines to price a prompt carrying video, the same way
+// it declines audio and images. The emulator replays that module's body with its
+// imports stripped, so every name it imports has to exist here or the bail throws
+// a ReferenceError and the recount never runs -- which is what happened: adding
+// this import took `counts` to 0 and read as "the empty New Chat view must be
+// priced exactly once" failing on a pricing bug. See
+// test_the_harness_stubs_every_name_refresh_context_usage_imports.
+function findLatestUserVideoBase64(_messages: any): string | null {
+  return null;
+}
+
+// refresh-context-usage.ts declines to price a prompt carrying video, the same way
+// it declines audio and images. The emulator replays that module's body with its
+// imports stripped, so every name it imports has to exist here or the bail throws
+// a ReferenceError and the recount never runs -- which is what happened: adding
+// this import took `counts` to 0 and read as "the empty New Chat view must be
+// priced exactly once" failing on a pricing bug. See
+// test_the_harness_stubs_every_name_refresh_context_usage_imports.
+
+
 // The real predicate's rule, so a test can put an image on a branch and see it declined.
 function messagesContainImage(messages: any): boolean {
   const isImage = (p: any) => p?.type === "image" && Boolean(p?.image);
@@ -521,6 +541,45 @@ LOADED_MODEL = """
       modelLoading: false,
     });
 """
+
+
+def test_the_harness_stubs_every_name_refresh_context_usage_imports() -> None:
+    """A new import in the real module must not silently zero the recount.
+
+    `_refresh_module_body()` replays that file with its import block stripped, so
+    an imported name that this harness does not define becomes a ReferenceError
+    the moment the replayed code reaches it. The failure does not look like a
+    missing stub: the effect bails, `counts` stays 0, and the assertion reads
+    "the empty New Chat view must be priced exactly once" -- a pricing bug that
+    is not there.
+
+    That is not hypothetical. #9056 added `findLatestUserVideoBase64` to decline
+    pricing a prompt carrying video, and took 41 tests in this file red.
+    """
+    text = read(REFRESH)
+    # The single braced import list this module takes from ../api/chat-adapter.
+    block = re.search(r"import \{(.*?)\} from \"\.\./api/chat-adapter\";", text, re.S)
+    assert block, "could not find the chat-adapter import block in refresh-context-usage.ts"
+    imported = [
+        name.strip()
+        for name in block.group(1).split(",")
+        if name.strip() and not name.strip().startswith("type ")
+    ]
+    assert imported, "parsed an empty import list; this guard would check nothing"
+
+    with open(__file__, encoding = "utf-8") as handle:
+        harness = handle.read()
+    missing = [
+        name
+        for name in imported
+        if f"function {name}(" not in harness and f"const {name} =" not in harness
+    ]
+    assert not missing, (
+        f"refresh-context-usage.ts imports {missing}, which this harness does not "
+        "define. The replayed module body would throw a ReferenceError and the "
+        "recount would silently report 0. Add a stub next to "
+        "findLatestUserAudioBase64."
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Backend CI's **Repo tests (CPU)** has been red on main since `588405dce`, with **111 failures** across two files. Both are the same defect, and neither is about what the tests claim to be testing.

Bisected: `f3b042534` is the last green (124 passed), `588405dce` the first red (41 failed).

### The defect

These harnesses replay real studio source **with its import block stripped**, so every name the sliced region calls has to be defined in the harness. Two landed without one:

| module | name | from |
|---|---|---|
| `refresh-context-usage.ts` | `findLatestUserVideoBase64` | #9056, decline to price a prompt carrying video |
| `chat-runtime-store.ts` | `resolvePreserveThinkingOnLoad` | |

**Both product changes are right.** The first is the more dangerous shape: with no stub the replayed body throws a `ReferenceError`, the effect bails, `counts` stays 0, and the assertion reads

> the empty New Chat view must be priced exactly once

which is a pricing bug that does not exist. 41 tests failed that way. Bisecting main was the only way to find it, because the failure message points somewhere else entirely.

### Why one file diagnosed itself and the other did not

`test_chat_autoload_failure_gate.py` **already guards this**, and said exactly what was missing:

```
the sliced region uses ['resolvePreserveThinkingOnLoad'], imported by chat-adapter.ts
but absent from this harness. Add a stub to PREAMBLE
```

That is why its 70 failures named the cause outright while the other 41 did not. `test_new_chat_context_recount.py` had no such guard; it does now, built the same way - parse the real import list, assert the harness defines each name. Mutation-tested: dropping the video stub turns it red naming `findLatestUserVideoBase64`.

The preserve-thinking stub is the real resolver's rule verbatim (`Boolean(supports_preserve_thinking && preserve_thinking_default)`), since no scenario in that file sets a stored preference.

### Result

`tests/studio`: **0 failures, from 111.**