### PR TITLE
Get Repo tests (CPU) back to green: 113 failures from three test-harness gaps

### DIFF
--- a/tests/python/test_cross_platform_parity.py
+++ b/tests/python/test_cross_platform_parity.py
@@ -19,15 +19,34 @@ class TestNoTorchBackendAutoInInstallSh:
 
     def test_no_torch_backend_auto_outside_fallback(self):
         lines = INSTALL_SH.read_text(encoding = "utf-8").splitlines()
-        # Fallback block: from "GPU detection failed" to the next "fi".
+        # Fallback block: from "GPU detection failed" to the `fi` that closes the
+        # branch it opens. Matching the *next* `fi` is wrong as soon as the branch
+        # contains a nested `if` -- #8670 added one inside the `case` arm that picks
+        # the desktop install spec, so a plain first-`fi` scan ended the block at
+        # that inner `fi` and reported the legitimate fallback install one line
+        # below it as an out-of-block use. Track depth so only the matching `fi`
+        # closes the block; anything genuinely outside the fallback still fails.
         fallback_start = None
         fallback_end = None
+        depth = 0
         for i, line in enumerate(lines):
-            if fallback_start is None and "GPU detection failed" in line:
-                fallback_start = i
-            elif fallback_start is not None and fallback_end is None and line.strip() == "fi":
-                fallback_end = i
-                break
+            stripped = line.strip()
+            if fallback_start is None:
+                if "GPU detection failed" in line:
+                    fallback_start = i
+                continue
+            # One-line `if ...; then ...; fi` opens and closes on the same line, so
+            # count both spellings rather than treating the line as either/or.
+            if re.match(r"^if\b", stripped):
+                depth += 1
+            if re.search(r"(^|;\s*)fi\s*(;|$)", stripped):
+                if depth == 0:
+                    fallback_end = i
+                    break
+                depth -= 1
+        assert fallback_end is not None, (
+            "could not find the `fi` closing install.sh's GPU-detection fallback block"
+        )
         fallback_range = (
             range(fallback_start or 0, (fallback_end or 0) + 1) if fallback_start else range(0)
         )

--- a/tests/python/test_cross_platform_parity.py
+++ b/tests/python/test_cross_platform_parity.py
@@ -44,9 +44,9 @@ class TestNoTorchBackendAutoInInstallSh:
                     fallback_end = i
                     break
                 depth -= 1
-        assert fallback_end is not None, (
-            "could not find the `fi` closing install.sh's GPU-detection fallback block"
-        )
+        assert (
+            fallback_end is not None
+        ), "could not find the `fi` closing install.sh's GPU-detection fallback block"
         fallback_range = (
             range(fallback_start or 0, (fallback_end or 0) + 1) if fallback_start else range(0)
         )

--- a/tests/studio/test_chat_autoload_failure_gate.py
+++ b/tests/studio/test_chat_autoload_failure_gate.py
@@ -297,6 +297,15 @@ function saveSpeculativeType(_x: any) {}
 function persistGpuMemoryModeOnLoad(..._a: any[]) {}
 function reasoningCapsFromLoad(_x: any) { return {}; }
 function resolveToolsEnabledOnLoad(_x: any) { return {}; }
+// The real resolver is `storedPreserveThinking ?? preserveThinkingDefaultFromLoad(resp)`:
+// a stored answer from hydration or the composer toggle wins, and otherwise the
+// backend's family default applies. Nothing in this slice hydrates or toggles the
+// preference, so storedPreserveThinking is always null here and the stub is exactly
+// the default arm. Returning a constant instead would make these scenarios agree with
+// the harness rather than with the adapter.
+function resolvePreserveThinkingOnLoad(resp: any) {
+  return Boolean(resp?.supports_preserve_thinking && resp?.preserve_thinking_default);
+}
 function loadedGpuMemoryFields(_x: any) { return {}; }
 function resolveLoadedSpeculativeSettings(_x: any) { return {}; }
 function isMultimodalResponse(_x: any) { return false; }

--- a/tests/studio/test_new_chat_context_recount.py
+++ b/tests/studio/test_new_chat_context_recount.py
@@ -281,6 +281,13 @@ function findLatestUserAudioBase64(_messages: any): string | null {
   return null;
 }
 
+// No fixture in this file attaches a clip, and the real helper returns undefined when it
+// finds none, so this is that answer. The video decline itself is pinned by
+// studio/frontend/tests/pr9057-video-simulation.test.ts.
+function findLatestUserVideoBase64(_messages: any): string | undefined {
+  return undefined;
+}
+
 // The real predicate's rule, so a test can put an image on a branch and see it declined.
 function messagesContainImage(messages: any): boolean {
   const isImage = (p: any) => p?.type === "image" && Boolean(p?.image);
@@ -498,8 +505,53 @@ __RESTORE__
 """
 
 
+def _assert_prelude_covers_refresh_imports(prelude: str, body: str) -> None:
+    """Every name refresh-context-usage.ts imports and uses must exist in the prelude.
+
+    _refresh_module_body() drops the import block, so a name the module starts importing
+    is an unbound identifier in the harness. refreshContextUsage runs its whole body
+    inside a try whose catch is deliberately bare (background recount must not interrupt
+    chat), so the ReferenceError is swallowed, the count never happens and every
+    expectation in this file fails as `assert 0 == 1` instead of saying what is missing.
+    That is exactly how #9056 landed 41 red tests: it added a findLatestUserVideoBase64
+    bail with no stub here.
+    """
+    imported: set[str] = set()
+    for match in re.finditer(r"^import\s+(?:[A-Za-z_$][\w$]*\s*,\s*)?\{([^}]*)\}\s+from", read(REFRESH), re.M):
+        for spec in match.group(1).split(","):
+            spec = spec.strip()
+            # `import { type Foo }` is erased at runtime, so it can never be a
+            # ReferenceError and must not be demanded of the prelude.
+            if not spec or spec.startswith("type "):
+                continue
+            name = spec.split(" as ")[-1].strip()
+            if name:
+                imported.add(name)
+    for match in re.finditer(r"^import\s+(?:\*\s+as\s+)?([A-Za-z_$][\w$]*)\s*(?:,|from)", read(REFRESH), re.M):
+        imported.add(match.group(1))
+    # A name only discussed in a comment is not a use.
+    code = re.sub(r"//[^\n]*", "", re.sub(r"/\*.*?\*/", "", body, flags = re.S))
+    missing = sorted(
+        name
+        for name in imported
+        if re.search(rf"\b{re.escape(name)}\b", code)
+        and not re.search(
+            rf"^(?:export\s+)?(?:async\s+)?(?:function\s+|const\s+|let\s+|var\s+|class\s+){re.escape(name)}\b",
+            prelude,
+            re.M,
+        )
+    )
+    assert not missing, (
+        f"refresh-context-usage.ts imports {missing} and the sliced body uses them, but "
+        "HARNESS_PRELUDE does not define them. Add a stub that answers what the real "
+        "collaborator answers, or every scenario here fails as a silent zero count "
+        "instead of saying what is actually missing."
+    )
+
+
 def _harness_source() -> str:
     prelude = HARNESS_PRELUDE.replace("__STORE_REDUCERS__", _store_reducers())
+    _assert_prelude_covers_refresh_imports(prelude, _refresh_module_body())
     render = HARNESS_RENDER.replace("__EFFECTS__", _rendered_effects(_new_chat_effects())).replace(
         "__RECOUNT_EFFECTS__", _rendered_effects(_thread_recount_effects())
     )

--- a/tests/studio/test_new_chat_context_recount.py
+++ b/tests/studio/test_new_chat_context_recount.py
@@ -517,7 +517,9 @@ def _assert_prelude_covers_refresh_imports(prelude: str, body: str) -> None:
     bail with no stub here.
     """
     imported: set[str] = set()
-    for match in re.finditer(r"^import\s+(?:[A-Za-z_$][\w$]*\s*,\s*)?\{([^}]*)\}\s+from", read(REFRESH), re.M):
+    for match in re.finditer(
+        r"^import\s+(?:[A-Za-z_$][\w$]*\s*,\s*)?\{([^}]*)\}\s+from", read(REFRESH), re.M
+    ):
         for spec in match.group(1).split(","):
             spec = spec.strip()
             # `import { type Foo }` is erased at runtime, so it can never be a
@@ -527,7 +529,9 @@ def _assert_prelude_covers_refresh_imports(prelude: str, body: str) -> None:
             name = spec.split(" as ")[-1].strip()
             if name:
                 imported.add(name)
-    for match in re.finditer(r"^import\s+(?:\*\s+as\s+)?([A-Za-z_$][\w$]*)\s*(?:,|from)", read(REFRESH), re.M):
+    for match in re.finditer(
+        r"^import\s+(?:\*\s+as\s+)?([A-Za-z_$][\w$]*)\s*(?:,|from)", read(REFRESH), re.M
+    ):
         imported.add(match.group(1))
     # A name only discussed in a comment is not a use.
     code = re.sub(r"//[^\n]*", "", re.sub(r"/\*.*?\*/", "", body, flags = re.S))


### PR DESCRIPTION
Main is red. `Repo tests (CPU)` on `studio-backend-ci.yml` is at **113 failed / 8982 passed** (run 32328722463, job 96305094412), which fails the required check on every open PR in the repo. This gets that job back to green so the backlog can move.

## Before and after

| | before | after |
| --- | --- | --- |
| `tests/studio/test_chat_autoload_failure_gate.py` | 70 failed, 1 passed | 71 passed |
| `tests/studio/test_new_chat_context_recount.py` | 41 failed, 12 passed | 53 passed |
| `tests/python/test_cross_platform_parity.py` | 1 failed, 76 passed | 77 passed |
| `tests/test_python39_compatibility.py` | 1 failed | already fixed on main by #9335 |
| **total** | **113 failed** | **0 failed** |

I ran each file locally on `origin/main` and again on this branch with the same `-n 4` shape the job uses. The two studio files went from `111 failed, 13 passed` to `124 passed` together, and the parity file from `1 failed` to green.

## Root causes

Two of the three are the same failure mode. Both of those tests slice a region verbatim out of a frontend TypeScript source and run it under node against a hand-written JS preamble. The slice drops the import block, so anything the sliced source starts importing has to be re-declared in the preamble by hand. Two separate PRs added an import and did not.

### 1. `test_chat_autoload_failure_gate.py`, 70 failures

`chat-adapter.ts` now calls `resolvePreserveThinkingOnLoad` inside the auto-load region, and the harness had no stub for it. This file already has a guard that catches exactly this and it did its job, which is why all 70 said so in plain words rather than failing as wrong-model assertions.

I added the stub. The real resolver is `storedPreserveThinking ?? preserveThinkingDefaultFromLoad(resp)`: a stored answer from hydration or the composer toggle wins, otherwise the backend's family default applies. Nothing in the sliced region hydrates or toggles the preference, so `storedPreserveThinking` is always null there and the correct stub is exactly the default arm, `Boolean(resp.supports_preserve_thinking && resp.preserve_thinking_default)`. A constant would have made these scenarios agree with the harness instead of with the adapter.

### 2. `test_new_chat_context_recount.py`, 41 failures

Same shape, silent version. #9056 taught `refresh-context-usage.ts` to decline a recount on a video turn:

```
if (findLatestUserVideoBase64(runMessages)) return;
```

`findLatestUserVideoBase64` is imported from `chat-adapter.ts`, the harness slice drops imports, and the preamble had stubs for the image and audio siblings but not this one. So the line raised a bare `ReferenceError` inside `refreshContextUsage`, whose `catch` is deliberately empty because a background recount must not interrupt chat. The throw was swallowed, node exited 0, the count never happened, and every positive expectation in the file failed as `assert 0 == 1` or, in the two tests that assert usage before count, `assert None == 62`. All 41 are that one identifier. The 12 tests that stayed green are the ones asserting `counts == 0`, which bail before the new line.

The product change is right and stays: `toOpenAIMessages` has no video branch, `/chat/count_tokens` 503s on video, and hashing up to 85 MB of base64 in `branchSignature` is synchronous main-thread work. I added the stub returning `undefined`, which is what the real helper answers when no message carries a clip, and no fixture in this file attaches one. The decline itself is still pinned by `studio/frontend/tests/pr9057-video-simulation.test.ts`, which asserts the call is present in the source and that it is paid before `branchSignature`.

I also added the import-coverage guard this file was missing, modelled on the one `test_chat_autoload_failure_gate.py` already has: every name `refresh-context-usage.ts` imports and the sliced body uses must be declared in the preamble, or the harness build fails saying which name is missing. Without it this class of drift is invisible by construction, since the bare catch converts any new unbound identifier into 41 mystery zeros. I checked it by deleting the new stub again: it fails immediately and names `findLatestUserVideoBase64`.

### 3. `test_cross_platform_parity.py`, 1 failure

`install.sh contains --torch-backend=auto outside the fallback block at lines: [5280]`. The use at 5280 is legitimate: it is inside the `else` branch that runs when GPU detection produced no index URL, which is precisely the branch the guard exists to allow. The guard was wrong, not `install.sh`.

It found the fallback block by scanning from the `GPU detection failed` comment to the **next** line equal to `fi`. That worked until #8670 added a nested `if [ -n "$_unsloth_desktop_install_spec" ]` inside the `case` arm that picks the desktop install spec. Its closing `fi` at line 5276 ended the block early, so the real fallback install one line below fell outside it.

I made the scan nesting-aware: track `if`/`fi` depth and stop at the `fi` that actually closes the branch. The rule is unchanged and nothing is relaxed. I checked that by inserting a `--torch-backend=auto` line into a primary branch of `install.sh`, and the test still fails and points at it.

### 4. `tests/test_python39_compatibility.py`, 1 failure

`test_studio_evaluated_unions_do_not_grow`, 36 studio files evaluating PEP 604 unions on the 3.9 floor against a debt ceiling of 35. Already fixed on main by #9335, which put `from __future__ import annotations` back into `path_utils`. It passes on current main, so there is nothing to do here and no change in this PR for it. I am listing it so the count adds up.

## Notes

Nothing was skipped, xfailed, deleted or loosened. `install.sh` is untouched. The only changes are three test files: two missing preamble stubs whose values match what the real collaborators return, one guard taught to parse nested shell blocks, and one new assertion that makes the next missing stub fail loudly on line one instead of silently 41 times.