### PR TITLE
feat(api): list every on-disk quant in /v1/models

### DIFF
--- a/studio/backend/core/inference/local_model_resolver.py
+++ b/studio/backend/core/inference/local_model_resolver.py
@@ -539,6 +539,24 @@ def _resolve_from_index(
         return None
 
 
+def local_gguf_variants_for(requested: str) -> Optional[tuple[str, ...]]:
+    """On-disk quant labels an advertised id (``repo`` or ``repo:VARIANT``) can
+    pin, or None when the resolver does not list it.
+
+    Reads only the last published index: callers that must prove freshness warm
+    it first. The order is the entry's own — preferred quant first, matching
+    what a bare id serves — so ``[0]`` agrees with the ``quant`` field
+    /v1/models reports."""
+    try:
+        resolved = _resolve_from_index(requested, _scan[1])
+    except Exception:
+        return None
+    if resolved is None:
+        return None
+    entry = _scan[1].get(resolved[2].lower())
+    return tuple(entry.variants) if entry else None
+
+
 MISS_MODEL_NOT_FOUND = "model_not_found"
 MISS_VARIANT_NOT_FOUND = "variant_not_found"
 

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -16703,6 +16703,11 @@ def _openai_model_objects() -> list[dict]:
         _quant = getattr(llama_backend, "hf_variant", None)
         if _quant and _quant_reference_resolves(entry["id"], _quant):
             entry["quant"] = _quant
+        # Every on-disk sibling quant, so a client can append ":<quant>" to pin
+        # any of them even while another one is resident (#9340).
+        _variants = _on_disk_quants_for(entry["id"])
+        if _variants:
+            entry["quants"] = list(_variants)
         _ctx = _positive_int_or_none(getattr(llama_backend, "context_length", None))
         if _ctx is not None:
             entry["context_length"] = _ctx
@@ -16745,6 +16750,24 @@ def _openai_model_objects() -> list[dict]:
 _CATALOG_CACHE: dict = {"at": 0.0, "models": []}
 # Ids the last catalog scan listed, rebuilt only when that scan is replaced.
 _ADVERTISED_CACHE: dict = {"at": None, "paths": {}}
+
+
+def _on_disk_quants_for(model_id: Optional[str]) -> tuple[str, ...]:
+    """On-disk quants advertised for *model_id*, from the resolver's index.
+
+    Same proof rule as the resident ``quant``: a cold index proves nothing, so
+    warm it and let the next response carry the list (#9340 — a client holding
+    several quants of one repo could not discover the others while one was
+    loaded, because the loaded entry replaced the catalog's row)."""
+    from core.inference.local_model_resolver import (
+        local_gguf_variants_for,
+        warm_index_soon,
+    )
+
+    if not model_id:
+        return ()
+    warm_index_soon()
+    return local_gguf_variants_for(model_id) or ()
 
 
 def _quant_reference_resolves(model_id: Optional[str], quant: str) -> bool:
@@ -16886,6 +16909,10 @@ async def _openai_catalog_objects() -> list[dict]:
             obj["quant"] = resident_quant
         elif quants:
             obj["quant"] = quants[0]
+        # All on-disk quants, preferred first; a client appends any of them to
+        # the id ("<id>:<quant>") to pin that variant (#9340).
+        if quants:
+            obj["quants"] = list(quants)
         display = getattr(info, "display_name", None)
         if display:
             obj["display_name"] = display

--- a/studio/backend/tests/test_openai_catalog.py
+++ b/studio/backend/tests/test_openai_catalog.py
@@ -326,11 +326,20 @@ def test_a_loaded_entry_still_lists_its_sibling_quants(monkeypatch):
     from core.inference.local_model_resolver import _LocalGgufEntry
 
     monkeypatch.setattr(inf, "get_inference_backend", lambda: _FakeUnsloth())
-    monkeypatch.setattr(resolver, "_scan", (1.0, {
-        "publisher/qwen3": _LocalGgufEntry(
-            "publisher/Qwen3", "/hf/models--publisher--Qwen3/snapshots/a", ("Q4_K_M", "Q8_0")
-        )
-    }))
+    monkeypatch.setattr(
+        resolver,
+        "_scan",
+        (
+            1.0,
+            {
+                "publisher/qwen3": _LocalGgufEntry(
+                    "publisher/Qwen3",
+                    "/hf/models--publisher--Qwen3/snapshots/a",
+                    ("Q4_K_M", "Q8_0"),
+                )
+            },
+        ),
+    )
     monkeypatch.setattr(resolver, "warm_index_soon", lambda: None)
 
     llama = _FakeLlama()
@@ -346,9 +355,11 @@ def test_a_loaded_entry_still_lists_its_sibling_quants(monkeypatch):
 def test_a_standalone_gguf_lists_no_quants_field(monkeypatch):
     from core.inference.local_model_resolver import _LocalGgufEntry
 
-    monkeypatch.setattr(resolver, "_scan", (1.0, {
-        "qwen3-q4": _LocalGgufEntry("Qwen3-Q4", "/srv/models/Qwen3-Q4.gguf", ())
-    }))
+    monkeypatch.setattr(
+        resolver,
+        "_scan",
+        (1.0, {"qwen3-q4": _LocalGgufEntry("Qwen3-Q4", "/srv/models/Qwen3-Q4.gguf", ())}),
+    )
     monkeypatch.setattr(inf, "get_inference_backend", lambda: _FakeUnsloth())
     monkeypatch.setattr(resolver, "warm_index_soon", lambda: None)
 

--- a/studio/backend/tests/test_openai_catalog.py
+++ b/studio/backend/tests/test_openai_catalog.py
@@ -300,6 +300,67 @@ def test_a_loaded_alias_advertises_the_quant_that_is_actually_loaded(monkeypatch
     assert ids["publisher/Qwen3"]["quant"] == "Q8_0"
 
 
+def test_catalog_lists_every_on_disk_quant_so_a_client_can_pin_one(monkeypatch):
+    # #9340: two quants of one repo are on disk, but the listing named only one
+    # (the preferred or the resident), so an API client could not discover the
+    # other, let alone know "<id>:<quant>" is how you select it.
+    monkeypatch.setattr(inf, "get_llama_cpp_backend", lambda: _FakeLlama(loaded = False))
+    monkeypatch.setattr(inf, "get_inference_backend", lambda: _FakeUnsloth())
+
+    async def _fake_catalog():
+        return [_Info("/data/models/Qwen3", "Qwen3", model_id = "publisher/Qwen3")]
+
+    monkeypatch.setattr(inf, "_cached_local_catalog", _fake_catalog)
+    monkeypatch.setattr(resolver, "local_gguf_quants", lambda info: ("Q8_0", "Q4_K_M"))
+
+    ids = {m["id"]: m for m in asyncio.run(inf._openai_catalog_objects())}
+    entry = ids["publisher/Qwen3"]
+    assert entry["quants"] == ["Q8_0", "Q4_K_M"]
+    # The head is the one a bare id serves, so quant and quants cannot disagree.
+    assert entry["quant"] == entry["quants"][0]
+
+
+def test_a_loaded_entry_still_lists_its_sibling_quants(monkeypatch):
+    # While one quant is resident the loaded row replaces the catalog row, so
+    # without this the other on-disk quant disappears from /v1/models entirely.
+    from core.inference.local_model_resolver import _LocalGgufEntry
+
+    monkeypatch.setattr(inf, "get_inference_backend", lambda: _FakeUnsloth())
+    monkeypatch.setattr(resolver, "_scan", (1.0, {
+        "publisher/qwen3": _LocalGgufEntry(
+            "publisher/Qwen3", "/hf/models--publisher--Qwen3/snapshots/a", ("Q4_K_M", "Q8_0")
+        )
+    }))
+    monkeypatch.setattr(resolver, "warm_index_soon", lambda: None)
+
+    llama = _FakeLlama()
+    llama.hf_variant = "Q8_0"
+    monkeypatch.setattr(inf, "get_llama_cpp_backend", lambda: llama)
+    llama.model_identifier = "publisher/Qwen3"
+
+    entry = inf._openai_model_objects()[0]
+    assert entry["quant"] == "Q8_0"
+    assert entry["quants"] == ["Q4_K_M", "Q8_0"]
+
+
+def test_a_standalone_gguf_lists_no_quants_field(monkeypatch):
+    from core.inference.local_model_resolver import _LocalGgufEntry
+
+    monkeypatch.setattr(resolver, "_scan", (1.0, {
+        "qwen3-q4": _LocalGgufEntry("Qwen3-Q4", "/srv/models/Qwen3-Q4.gguf", ())
+    }))
+    monkeypatch.setattr(inf, "get_inference_backend", lambda: _FakeUnsloth())
+    monkeypatch.setattr(resolver, "warm_index_soon", lambda: None)
+
+    llama = _FakeLlama()
+    llama.hf_variant = "Q4_K_M"
+    monkeypatch.setattr(inf, "get_llama_cpp_backend", lambda: llama)
+
+    entry = inf._openai_model_objects()[0]
+    assert "quant" not in entry
+    assert "quants" not in entry
+
+
 def test_a_nested_model_directory_is_not_the_resident_one(monkeypatch):
     # Two indexed models can nest (/models/A holding A, /models/A/sub/B holding B). A
     # plain prefix test made loading B mark A resident, so a request for A was answered


### PR DESCRIPTION
Fixes #9340.

## What was wrong

A model with several downloaded quants (the reporter's case: Q8_0 + Q4_K_M of one repo) appeared in `GET /v1/models` once, carrying a single `quant` — the preferred one on disk, or the resident one while that model is loaded. An API client therefore could not discover the other variants, and nothing in the response says that appending `:<quant>` to the id is how you pin one (the backend's `resolve_local_gguf` already fully supports `repo:QUANT`). LM Studio's `model@quant`-style listing is what users compare against.

While one quant is resident the problem is worse: the loaded row **replaces** the catalog row, so the sibling quants disappeared from the listing entirely.

## The change

- Every catalog entry for a multi-quant model now also carries `quants`: all on-disk quants, ordered preferred-first, so `quants[0]` always agrees with the existing `quant` field (a bare id keeps serving that one).
- The loaded GGUF entry gets `quants` too, read from the resolver's published index under the same cold-index proof rule as the resident `quant` (warm, then read; publish nothing unprovable).
- New resolver helper `local_gguf_variants_for(requested)` returns the entry's variant tuple without re-scanning.

`quant` semantics, the bare id (OpenAI compat), and standalone-`.gguf` behavior (neither field) are unchanged.

## Verification

- `tests/test_openai_catalog.py` — 18/18, with three new cases: the catalog lists every on-disk quant with `quants[0] == quant`; a loaded entry still lists its sibling quants while advertising the resident one; a standalone `.gguf` lists neither field.
- `tests/test_openai_auto_switch.py` — 482 passed, 1 skipped (the resolver and switching paths this touches).