### PR TITLE
studio: settle the per-chat sampling tests on the store's own write barrier

### DIFF
--- a/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
+++ b/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
@@ -1397,6 +1397,33 @@ export async function awaitThreadScopedSettingsWrite(
   return landed !== false;
 }
 
+/**
+ * Every row write that has already been started, landed.
+ *
+ * Not a flush: a debounce that has not fired yet is left where it is, so a caller cannot
+ * use this to make a write happen earlier than the store would have made it. It is for a
+ * caller that has just let the debounce fire and now needs the row before it reads it
+ * back, and does not know which chats the store decided to write.
+ *
+ * The chain a write runs on ends in `await import("../utils/chat-history-storage")`. How
+ * many event-loop turns that costs is a property of the machine -- the specifier has no
+ * extension, so it is resolved through a hook, and that means filesystem work in a test
+ * and a chunk fetch in a browser. A caller that instead spins a fixed number of turns and
+ * then reads the row is asserting something about the machine rather than about the store.
+ */
+export async function awaitStartedThreadScopedSettingsWrites(): Promise<void> {
+  // A chain that settles can leave a newer one behind it for the same chat, so this
+  // repeats until the map is empty instead of awaiting one snapshot of it. Bounded, so a
+  // write that keeps rescheduling itself shows up as a failed assertion, not as a hang.
+  for (
+    let pass = 0;
+    pass < 20 && threadSettingsWriteChains.size > 0;
+    pass += 1
+  ) {
+    await Promise.allSettled([...threadSettingsWriteChains.values()]);
+  }
+}
+
 function flushThreadScopedSettingsWrite(keepalive = false): void {
   if (threadSettingsWriteTimer !== null) {
     clearTimeout(threadSettingsWriteTimer);

--- a/studio/frontend/tests/helpers/thread-sampling-world.ts
+++ b/studio/frontend/tests/helpers/thread-sampling-world.ts
@@ -134,15 +134,28 @@ interface StoreModule {
     };
   };
   beginThreadScopedPairing: (threadId: string) => void;
+  awaitStartedThreadScopedSettingsWrites: () => Promise<void>;
 }
 
-/** Let the debounced writers and their promise chains finish. */
-async function drain(tick: (ms: number) => void): Promise<void> {
+/**
+ * Let the debounced writers and their promise chains finish.
+ *
+ * The turns let whatever the tick started get going; the store's own barrier is what says
+ * it finished. Counting turns alone does not: a row write ends in a dynamic import, so the
+ * number of turns between the timer firing and the row being written is a property of the
+ * machine the suite runs on, and an ordering whose write had not landed yet is checked
+ * against a row the next ordering then resets.
+ */
+async function drain(
+  mod: StoreModule,
+  tick: (ms: number) => void,
+): Promise<void> {
   for (let round = 0; round < 3; round += 1) {
     tick(1000);
     for (let i = 0; i < 6; i += 1) {
       await new Promise((resolve) => setImmediate(resolve));
     }
+    await mod.awaitStartedThreadScopedSettingsWrites();
   }
 }
 
@@ -416,7 +429,7 @@ export async function runScenario(
 
   for (const op of ops) {
     await perform(op);
-    await drain(tick);
+    await drain(mod, tick);
     check(op);
     if (violations.length > 0) break;
   }

--- a/studio/frontend/tests/thread-scoped-sampling-compat.test.ts
+++ b/studio/frontend/tests/thread-scoped-sampling-compat.test.ts
@@ -121,12 +121,23 @@ async function world(rows: Record<string, Record<string, unknown>> = {}) {
   };
 }
 
-async function settle(tick: (ms: number) => void): Promise<void> {
+interface Settleable {
+  awaitStartedThreadScopedSettingsWrites: () => Promise<void>;
+}
+
+// The turns let whatever the tick started get going; the store's own barrier is what says
+// it finished. Counting turns alone does not: the row write ends in a dynamic import, and
+// how many turns that takes is a property of the machine the suite happens to run on.
+async function settle(
+  mod: Settleable,
+  tick: (ms: number) => void,
+): Promise<void> {
   for (let round = 0; round < 3; round += 1) {
     tick(1000);
     for (let i = 0; i < 6; i += 1) {
       await new Promise((resolve) => setImmediate(resolve));
     }
+    await mod.awaitStartedThreadScopedSettingsWrites();
   }
 }
 
@@ -152,10 +163,10 @@ function assertUsable(sampling: Record<string, unknown>, where: string): void {
 test("C1: a legacy row opens on the installation sampling, and nothing is zeroed", async (t) => {
   t.mock.timers.enable({ apis: ["setTimeout"] });
   const w = await world({ L: { ...LEGACY_ROW } });
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
 
   w.open("L");
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
 
   assertUsable(w.sampling(), "legacy open");
   // the installation's values, since the row says nothing about sampling
@@ -176,9 +187,9 @@ test("C1: a legacy row opens on the installation sampling, and nothing is zeroed
 test("C1b: a legacy chat follows the installation defaults, which a model load moves", async (t) => {
   t.mock.timers.enable({ apis: ["setTimeout"] });
   const w = await world({ L: { ...LEGACY_ROW } });
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
   w.open("L");
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
   const onFirstVisit = w.sampling();
   assert.equal(onFirstVisit.temperature, INSTALLATION.temperature);
 
@@ -192,13 +203,13 @@ test("C1b: a legacy chat follows the installation defaults, which a model load m
     },
     { fromModelDefaults: true },
   );
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
   // the chat pinned nothing, so it takes the model's values, as it did before this
   assert.equal(w.store().params.temperature, 0.31);
 
   w.open("Z");
   w.open("L");
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
   const onSecondVisit = w.sampling();
   assertUsable(onSecondVisit, "legacy reopen");
   // OBSERVED: the reopened legacy chat shows the model's sampling. It stored none, so the
@@ -212,10 +223,10 @@ test("C1b: a legacy chat follows the installation defaults, which a model load m
 test("C1c: a legacy chat that the user then edits pins the WHOLE set, not just the edit", async (t) => {
   t.mock.timers.enable({ apis: ["setTimeout"] });
   const w = await world({ L: { ...LEGACY_ROW } });
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
   w.open("L");
   w.store().setParams({ ...w.store().params, temperature: 1.37 });
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
 
   // The write for a chat that already had a snapshot is a full replacement built from the
   // store, so all seven other keys are pinned too and the chat stops drifting.
@@ -238,7 +249,7 @@ test("C1c: a legacy chat that the user then edits pins the WHOLE set, not just t
     },
     { fromModelDefaults: true },
   );
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
   assert.equal(w.store().params.temperature, 1.37);
 });
 
@@ -250,9 +261,9 @@ test("C2: an empty, null or absent snapshot opens on the installation settings",
   t.mock.timers.enable({ apis: ["setTimeout"] });
   for (const snapshot of [null, {}, undefined]) {
     const w = await world();
-    await settle((ms) => t.mock.timers.tick(ms));
+    await settle(w.mod, (ms) => t.mock.timers.tick(ms));
     w.open("E", snapshot === undefined ? null : snapshot);
-    await settle((ms) => t.mock.timers.tick(ms));
+    await settle(w.mod, (ms) => t.mock.timers.tick(ms));
     const where = `snapshot ${JSON.stringify(snapshot ?? null)}`;
     assertUsable(w.sampling(), where);
     assert.deepEqual(w.sampling(), INSTALLATION, where);
@@ -387,9 +398,9 @@ test("C3d: a NaN or Infinity in a row cannot reach the store", async (t) => {
       systemPrompt: null,
     },
   });
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
   w.open("N");
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
   assertUsable(w.sampling(), "NaN row");
   assert.deepEqual(w.sampling(), INSTALLATION);
 });
@@ -400,16 +411,16 @@ test("C3d: a NaN or Infinity in a row cannot reach the store", async (t) => {
 test("C3e: an out-of-range recommendation never reaches a chat that pinned that key", async (t) => {
   t.mock.timers.enable({ apis: ["setTimeout"] });
   const w = await world();
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
   w.open("A");
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
 
   w.store().setParams(
     { ...w.store().params, topP: 1.2, checkpoint: "unsloth/Llasa-3B" },
     { fromModelDefaults: true },
   );
   w.store().setParams({ ...w.store().params, temperature: 1.37 });
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
 
   // A pinned every key when it opened, so it keeps its own in-range value. Pinning on open
   // is what makes this safe: an unpinned chat has nothing to put back.
@@ -420,7 +431,7 @@ test("C3e: an out-of-range recommendation never reaches a chat that pinned that 
 
   w.open("Z");
   w.open("A");
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
   assertUsable(w.sampling(), "after an out-of-range recommendation");
   assert.equal(w.store().params.temperature, 1.37);
   assert.equal(w.store().params.topP, INSTALLATION.topP);
@@ -429,14 +440,14 @@ test("C3e: an out-of-range recommendation never reaches a chat that pinned that 
 test("C3f: an out-of-range recommendation taken with no chat open cannot be pinned", async (t) => {
   t.mock.timers.enable({ apis: ["setTimeout"] });
   const w = await world();
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
 
   // no chat open, so nothing puts an in-range value back
   w.store().setParams(
     { ...w.store().params, topP: 1.2, checkpoint: "unsloth/Llasa-3B" },
     { fromModelDefaults: true },
   );
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
   // OBSERVED: the live params run it, and it reaches the installation settings, which
   // have no such bound. Only the per-chat row does.
   assert.equal(w.store().params.topP, 1.2);
@@ -445,7 +456,7 @@ test("C3f: an out-of-range recommendation taken with no chat open cannot be pinn
   // a chat opened on it pins what it can, omitting topP rather than sending a body the
   // PATCH would refuse whole, which would cost the chat all seven other keys
   w.open("A");
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
   const row = threadRows.rows.get("A") as Record<string, unknown>;
   assert.equal(row.topP, undefined);
   assert.equal(row.temperature, INSTALLATION.temperature);
@@ -491,10 +502,10 @@ test("C4b: a falsy edit round-trips capture -> persist -> restore", async (t) =>
   for (const topK of [-1, 0]) {
     const edge = { ...FALSY_EDGE, topK };
     const w = await world();
-    await settle((ms) => t.mock.timers.tick(ms));
+    await settle(w.mod, (ms) => t.mock.timers.tick(ms));
     w.open("A");
     w.store().setParams({ ...w.store().params, ...edge });
-    await settle((ms) => t.mock.timers.tick(ms));
+    await settle(w.mod, (ms) => t.mock.timers.tick(ms));
 
     // captured onto the chat, whole
     const row = threadRows.rows.get("A") as Record<string, unknown>;
@@ -506,12 +517,12 @@ test("C4b: a falsy edit round-trips capture -> persist -> restore", async (t) =>
 
     // another chat opens on the installation values, untouched by any of it
     w.open("B");
-    await settle((ms) => t.mock.timers.tick(ms));
+    await settle(w.mod, (ms) => t.mock.timers.tick(ms));
     assert.deepEqual(w.sampling(), INSTALLATION, `topK ${topK}: B inherited A`);
 
     // and A gets all of it back
     w.open("A");
-    await settle((ms) => t.mock.timers.tick(ms));
+    await settle(w.mod, (ms) => t.mock.timers.tick(ms));
     assert.deepEqual(
       w.sampling(),
       edge,
@@ -523,10 +534,10 @@ test("C4b: a falsy edit round-trips capture -> persist -> restore", async (t) =>
 test("C4c: a falsy pinned value survives a model load and a model switch", async (t) => {
   t.mock.timers.enable({ apis: ["setTimeout"] });
   const w = await world();
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
   w.open("A");
   w.store().setParams({ ...w.store().params, ...FALSY_EDGE });
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
 
   // a load with a full, non-falsy recommendation
   w.store().setParams(
@@ -542,12 +553,12 @@ test("C4c: a falsy pinned value survives a model load and a model switch", async
     },
     { fromModelDefaults: true },
   );
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
   assert.deepEqual(w.sampling(), FALSY_EDGE, "the load overwrote a falsy pin");
 
   // and an external switch, which has no load after it to put anything back
   w.store().setCheckpoint("external::anthropic::claude-opus-5", null);
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
   assert.deepEqual(
     w.sampling(),
     FALSY_EDGE,
@@ -562,24 +573,24 @@ test("C4c: a falsy pinned value survives a model load and a model switch", async
 test("C4d: an empty system prompt is a choice, not an absent one", async (t) => {
   t.mock.timers.enable({ apis: ["setTimeout"] });
   const w = await world();
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
   // A is given a prompt, B is deliberately cleared
   w.open("A");
   w.store().setParams({ ...w.store().params, systemPrompt: "A's prompt" });
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
   w.open("B");
   w.store().setParams({ ...w.store().params, systemPrompt: "" });
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
 
   assert.equal(
     (threadRows.rows.get("B") as Record<string, unknown>).systemPrompt,
     "",
   );
   w.open("A");
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
   assert.equal(w.store().params.systemPrompt, "A's prompt");
   w.open("B");
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
   assert.equal(
     w.store().params.systemPrompt,
     "",
@@ -603,10 +614,10 @@ test("C5: a one-megabyte system prompt is neither truncated nor fatal", async (t
   );
 
   const w = await world();
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
   w.open("A");
   w.store().setParams({ ...w.store().params, systemPrompt: huge });
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
 
   const row = threadRows.rows.get("A") as Record<string, unknown>;
   assert.equal((row.systemPrompt as string).length, huge.length);
@@ -614,10 +625,10 @@ test("C5: a one-megabyte system prompt is neither truncated nor fatal", async (t
 
   // and back again after a visit elsewhere
   w.open("B");
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
   assert.equal(w.store().params.systemPrompt, INSTALLATION.systemPrompt);
   w.open("A");
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
   assert.equal((w.store().params.systemPrompt as string).length, huge.length);
   // and it stayed the chat's: a megabyte in the installation payload would be sent
   // on every settings write for the rest of the session

--- a/studio/frontend/tests/thread-scoped-sampling-simulation.test.ts
+++ b/studio/frontend/tests/thread-scoped-sampling-simulation.test.ts
@@ -375,12 +375,23 @@ async function raceWorld() {
   };
 }
 
-async function settle(tick: (ms: number) => void): Promise<void> {
+interface Settleable {
+  awaitStartedThreadScopedSettingsWrites: () => Promise<void>;
+}
+
+// The turns let whatever the tick started get going; the store's own barrier is what says
+// it finished. Counting turns alone does not: the row write ends in a dynamic import, and
+// how many turns that takes is a property of the machine the suite happens to run on.
+async function settle(
+  mod: Settleable,
+  tick: (ms: number) => void,
+): Promise<void> {
   for (let round = 0; round < 3; round += 1) {
     tick(1000);
     for (let i = 0; i < 6; i += 1) {
       await new Promise((resolve) => setImmediate(resolve));
     }
+    await mod.awaitStartedThreadScopedSettingsWrites();
   }
 }
 
@@ -392,7 +403,7 @@ test("B1: a slider moved while /api/chat/settings is still in flight survives it
   w.store().setParams({ ...w.store().params, temperature: 1.42 });
   settingsHttp.release?.();
   await hydrating;
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
   assert.equal(
     w.store().params.temperature,
     1.42,
@@ -406,7 +417,7 @@ test("B2: an edit made while the chat's own read is out is stored on that chat",
   t.mock.timers.enable({ apis: ["setTimeout"] });
   const w = await raceWorld();
   await w.store().hydratePersistedSettings();
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
   settingsHttp.puts.length = 0;
 
   w.beginOpen("A");
@@ -417,7 +428,7 @@ test("B2: an edit made while the chat's own read is out is stored on that chat",
     systemPrompt: "HELD EDIT 5f3a",
   });
   w.finishOpen("A", { temperature: 0.22, topP: 0.33, systemPrompt: "STORED" });
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
 
   // the held edit wins over what the read brought back
   assert.equal(w.store().params.temperature, 1.37);
@@ -436,7 +447,7 @@ test("B3: leaving mid-read sends the held edit to its own chat, not the next one
   t.mock.timers.enable({ apis: ["setTimeout"] });
   const w = await raceWorld();
   await w.store().hydratePersistedSettings();
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
   settingsHttp.puts.length = 0;
 
   w.beginOpen("A");
@@ -448,7 +459,7 @@ test("B3: leaving mid-read sends the held edit to its own chat, not the next one
   // the user gives up on A and opens B before A's read lands
   await w.mod.commitHeldThreadScopedEditsToTheirThread();
   w.open("B");
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
 
   // A's row carries the edit as a merge, leaving the rest of its snapshot alone
   const merged = threadRows
@@ -473,7 +484,7 @@ test("B4: a model load landing during the pairing window does not take the chat'
   t.mock.timers.enable({ apis: ["setTimeout"] });
   const w = await raceWorld();
   await w.store().hydratePersistedSettings();
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
   settingsHttp.puts.length = 0;
 
   w.beginOpen("A");
@@ -484,7 +495,7 @@ test("B4: a model load landing during the pairing window does not take the chat'
     { fromModelDefaults: true },
   );
   w.finishOpen("A", null);
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
 
   assert.equal(w.store().params.temperature, 1.37, "the load took the edit");
   // and the chat was pinned with the user's value, not the one the load published
@@ -506,7 +517,7 @@ test("B4b: the held sampling edit that survives a load is the LAST one made", as
   t.mock.timers.enable({ apis: ["setTimeout"] });
   const w = await raceWorld();
   await w.store().hydratePersistedSettings();
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
 
   w.beginOpen("A");
   // a slider dragged twice, then the load, then the read
@@ -517,7 +528,7 @@ test("B4b: the held sampling edit that survives a load is the LAST one made", as
     { fromModelDefaults: true },
   );
   w.finishOpen("A", null);
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
   assert.equal(w.store().params.temperature, 1.37);
 });
 
@@ -525,7 +536,7 @@ test("B4c: a falsy held edit is not treated as no edit at all", async (t) => {
   t.mock.timers.enable({ apis: ["setTimeout"] });
   const w = await raceWorld();
   await w.store().hydratePersistedSettings();
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
 
   w.beginOpen("A");
   // 0, "" and -1 are all deliberate choices, and all falsy or negative
@@ -541,7 +552,7 @@ test("B4c: a falsy held edit is not treated as no edit at all", async (t) => {
     { fromModelDefaults: true },
   );
   w.finishOpen("A", null);
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
 
   const params = w.store().params;
   assert.equal(params.temperature, 0);
@@ -559,20 +570,20 @@ test("B5: two rapid model switches with a pinned chat open", async (t) => {
   t.mock.timers.enable({ apis: ["setTimeout"] });
   const w = await raceWorld();
   await w.store().hydratePersistedSettings();
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
   w.open("A");
   w.store().setParams({
     ...w.store().params,
     temperature: 1.37,
     systemPrompt: "CHAT A ONLY 5f3a",
   });
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
   settingsHttp.puts.length = 0;
 
   // no settle between them: the second switch lands while the first is still writing
   w.store().setCheckpoint(LLAMA, null);
   w.store().setCheckpoint(EXTERNAL, null);
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
 
   assert.equal(w.store().params.temperature, 1.37);
   assert.equal(w.store().params.systemPrompt, "CHAT A ONLY 5f3a");
@@ -594,10 +605,10 @@ test("B6: a thread switch while a load is in flight keeps each chat's own values
   t.mock.timers.enable({ apis: ["setTimeout"] });
   const w = await raceWorld();
   await w.store().hydratePersistedSettings();
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
   w.open("A");
   w.store().setParams({ ...w.store().params, temperature: 1.37 });
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
 
   // the user opens B, and the load that was started in A finishes into B
   w.beginOpen("B");
@@ -606,7 +617,7 @@ test("B6: a thread switch while a load is in flight keeps each chat's own values
     { fromModelDefaults: true },
   );
   w.finishOpen("B", null);
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
   assert.notEqual(
     w.store().params.temperature,
     1.37,
@@ -614,7 +625,7 @@ test("B6: a thread switch while a load is in flight keeps each chat's own values
   );
 
   w.open("A");
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
   assert.equal(w.store().params.temperature, 1.37, "A lost its temperature");
 });
 
@@ -622,7 +633,7 @@ test("B7: a tab closing with a held edit beacons it to the chat it was made in",
   t.mock.timers.enable({ apis: ["setTimeout"] });
   const w = await raceWorld();
   await w.store().hydratePersistedSettings();
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
   settingsHttp.puts.length = 0;
 
   w.beginOpen("A");
@@ -634,7 +645,7 @@ test("B7: a tab closing with a held edit beacons it to the chat it was made in",
   // pagehide, which is what the store listens on; the read never landed
   const delivered = fireWindowEvent("pagehide", {});
   assert.ok(delivered > 0, "the store is not listening for the terminal event");
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
 
   // The beacon is a PATCH, so it is not in `puts`; what it queued for replay is the
   // durable record of what the closing tab tried to save, and for which chat.


### PR DESCRIPTION
Main is red on `Frontend unit tests (Windows)` and on `Frontend build + bundle sanity`, and it blocks every open PR. Same bug in both, different severity.

## What actually happens

A per-chat sampling edit is written like this: `setParams` captures the edit, a 400ms debounce fires, and the write runs on a promise chain that ends in

```ts
const { updateStoredChatThread } = await import("../utils/chat-history-storage");
```

That specifier has no extension, so it is resolved through a hook, and in the tests it is resolved through `tests/thread-sampling-resolver.mjs`, which is registered with `module.register` and therefore runs off-thread with `existsSync` probes behind it. The import is real work on a real event-loop turn, not a microtask.

The three drains that these tests run on did not wait for that. They gave it a fixed number of turns:

```ts
for (let round = 0; round < 3; round += 1) {
  tick(1000);
  for (let i = 0; i < 6; i += 1) {
    await new Promise((resolve) => setImmediate(resolve));
  }
}
```

18 turns, then read the row back. `tick` is a mocked clock, so it costs no real time at all: those 18 turns go by in microseconds on an otherwise empty loop, and nothing in them is tied to the import finishing.

When the import has not finished, two things follow, and both are in the CI logs:

- the row is simply not there yet. That is `TypeError: Cannot read properties of undefined (reading 'temperature')` at `thread-scoped-sampling-compat.test.ts:264`, where `threadRows.rows.get("E")` came back undefined.
- the write lands later, after the test has moved on, into the shared `threadRows` that the next scenario has just `reset()`. That is `B4c` asserting `1.37 !== 0`: 1.37 is the temperature an earlier test wrote, arriving after the fact. `A1` reporting both "owed 0.6, shows 1.37" and "owed 1.37, shows 0.6" in the same sweep is the same thing across 120 orderings.

## Why it is red in CI and green locally

Node version. Both jobs pin `node-version: '22'`; I had been running 24.

I instrumented the write path to count how many `setImmediate` turns pass between the debounce firing and the row being written, on the same checkout and the same machine:

| Node | turns needed (3 runs) | budget |
| --- | --- | --- |
| 24.14.0 | 1, 1, 1 | 18 |
| 22.22.0 | 2, 61, 34 | 18 |

Node 24 collapses that dynamic import to a single turn, so the budget is never close to being spent and the suite is green. On Node 22 it is variable and routinely well past 18.

Severity then tracks how fast the machine is, which is why the two jobs fail different subsets of the same set: ubuntu fails 9, Windows fails 12, and Node 22 on my box, unloaded, fails 15. It is one bug, not two, and it is not Windows-specific.

## Before and after, Node 22, Linux

Full `tests/**/*.test.ts`, `node-v22.22.0`:

```
before   tests 4080   pass 4065   fail 15
after    tests 4080   pass 4080   fail 0
```

The 15 before are a superset of the 12 the Windows job fails and of the 9 the ubuntu job fails.

## The change

`awaitStartedThreadScopedSettingsWrites()` on the store returns when the row writes it has already started have landed. It is not a flush: a debounce that has not fired is left alone, so a caller cannot use it to make a write happen earlier than the store would have made it. The three drains call it after their turns instead of assuming the turns were enough.

That removes the dependency on how long module resolution takes on the machine, rather than widening the window. Nothing is skipped, retried or given more time.

## The tests still bite

To check the barrier is not hiding the behaviour it is supposed to observe, I put a one-line regression into the write path (`delete settings.temperature` in `writeThreadScopedSettings`) and ran the two files on Node 22 with the fix in place: 18 failures, including all of the ones this PR turns green. Reverted afterwards.

## Counts

`studio/frontend`, Node 24 (the local default), before and after are the same because 24 was never affected:

```
npm test        tests 4080   pass 4080   fail 0
npm run typecheck   clean, exit 0
npm run lint    735 problems (577 errors, 158 warnings)
```

The lint total is identical to `origin/main` at `78a3587`, which I ran in a separate clean worktree to compare. Those are pre-existing and none of them are in the files this PR touches.

## One thing I did not change

`tests/thread-scoped-commit-restores-defaults.test.ts` and `tests/thread-scoped-pairing-default-refresh.test.ts` settle with `await new Promise((resolve) => setTimeout(resolve, 900))` on the real clock. That is the same assumption in a different form, but it does have 500ms of real slack past the debounce and it is green on Node 22 on both jobs, so I left it alone rather than widen this PR.
