### PR TITLE
Put back the AppleDouble GGUF filters #9074 reverted, and guard them

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -351,6 +351,7 @@ from state.tool_approvals import (
     new_approval_id,
     wait_tool_decision,
 )
+from utils.paths.path_utils import is_appledouble_metadata
 
 logger = get_logger(__name__)
 
@@ -2065,7 +2066,7 @@ def _gguf_snapshot_files(snapshot: Path) -> list[str]:
     return [
         p.relative_to(snapshot).as_posix()
         for p in snapshot.rglob("*")
-        if p.is_file() and p.name.lower().endswith(".gguf")
+        if p.is_file() and p.name.lower().endswith(".gguf") and not is_appledouble_metadata(p)
     ]
 
 
@@ -2402,7 +2403,29 @@ def _companion_snapshot_sibling(
     return str(candidate) if _drafter_split_is_complete(candidate) else None
 
 
+def _pick_dspark(candidates: list[str]) -> Optional[str]:
+    """The DSpark drafter a listing offers, or None. Module level for the same reason
+    ``_pick_mmproj`` is: both are handed a live repo listing as well as a snapshot."""
+    from hub.utils.gguf import drop_shadowed_appledouble_names
+    from utils.models.model_config import dspark_preference_key
+
+    # Every GGUF under dspark/ qualifies, so a sidecar ranks equal to its sibling and sorts first.
+    files = sorted(
+        (
+            name
+            for name in drop_shadowed_appledouble_names(list(candidates))
+            if _is_dspark_drafter_path(name)
+        ),
+        key = dspark_preference_key,
+    )
+    return files[0] if files else None
+
+
 def _pick_mmproj(candidates: list[str]) -> Optional[str]:
+    from hub.utils.gguf import drop_shadowed_appledouble_names
+
+    # "._mmproj-F16.gguf" satisfies the F16 preference and sorts ahead of the real adapter.
+    candidates = drop_shadowed_appledouble_names(list(candidates))
     mmproj_files = sorted(
         f for f in candidates if f.lower().endswith(".gguf") and "mmproj" in Path(f).name.lower()
     )
@@ -2611,10 +2634,13 @@ def _gguf_files_for_variant(files: Iterable[str], variant: str) -> list[str]:
     Prefer exact quant-label matches over loose substring matches so a request
     for ``stories260K`` does not resolve to ``stories260K-be.gguf``.
     """
+    from hub.utils.gguf import drop_shadowed_appledouble_names
+
     variant_key = variant.strip().lower()
+    # A repo listing has no bytes to read; a local one arrives already filtered on its headers.
     main_files = [
         f
-        for f in files
+        for f in drop_shadowed_appledouble_names(list(files))
         if f.lower().endswith(".gguf")
         and not _is_companion_gguf_path(f)
         # The endian predicate reads a quant TOKEN -- it decides whether the quant came from the
@@ -9645,9 +9671,11 @@ class LlamaCppBackend:
             from huggingface_hub import get_paths_info, list_repo_files
 
             files = list_repo_files(hf_repo, token = hf_token)
+            from hub.utils.gguf import drop_shadowed_appledouble_names
+
             gguf_files = [
                 f
-                for f in files
+                for f in drop_shadowed_appledouble_names(list(files))
                 if f.lower().endswith(".gguf")
                 and not _is_companion_gguf_path(f)
                 and not _is_big_endian_gguf_path(f)
@@ -11376,14 +11404,6 @@ class LlamaCppBackend:
         if caps_probe is None:
             caps_probe = self.probe_server_capabilities
 
-        def _pick_dspark(candidates: list[str]) -> Optional[str]:
-            from utils.models.model_config import dspark_preference_key
-            files = sorted(
-                (name for name in candidates if _is_dspark_drafter_path(name)),
-                key = dspark_preference_key,
-            )
-            return files[0] if files else None
-
         cached = _companion_snapshot_sibling(near_path, _pick_dspark) if near_path else None
         if not cached and _hf_env_offline():
             cached = self._cached_repo_dspark_drafter(
@@ -12693,6 +12713,30 @@ class LlamaCppBackend:
                 "Tensor parallelism is not supported for this model's "
                 "architecture. Turn off Tensor Parallelism in the model "
                 "settings and reload."
+            )
+
+        # llama.cpp prints the four bytes it found with %c, so a binary header arrives as
+        # unprintable characters; the generic fallback then blamed the user's memory (#8566).
+        if "invalid magic characters" in lowered:
+            # Not necessarily the main model: the projector and drafter report this too.
+            base = os.path.basename(gguf_path) if gguf_path else ""
+            named = f", loading {base}" if base else ""
+            # A "._" model path proves the volume keeps xattrs in companions, whichever file
+            # llama-server actually opened, and dot_clean is the remedy for the volume.
+            remedy = (
+                'This volume has no native extended attributes, so macOS keeps them in "._" '
+                'companions: run "dot_clean -m" on the folder to remove them, or keep models '
+                "on an APFS disk."
+                if base.startswith("._")
+                else "Re-download the model, or pick a different file."
+            )
+            return LlamaCppBackend._with_startup_diagnostics(
+                f"llama-server opened a file that is not a GGUF{named}: it does not start with "
+                "the GGUF magic. It may be that file or a companion loaded with it, such as a "
+                f"vision projector or a drafter, which llama-server does not always name. {remedy}",
+                output,
+                log_path,
+                secrets,
             )
 
         # Detect Ollama source up front so the arch branch can keep the

--- a/studio/backend/tests/data/refactor_guard/ast_inventory.json
+++ b/studio/backend/tests/data/refactor_guard/ast_inventory.json
@@ -852,6 +852,9 @@
       "RAG_SEARCH_CAP_NUDGE": {
         "kind": "assign"
       },
+      "RAG_SEARCH_TOOLS": {
+        "kind": "assign"
+      },
       "RENDER_HTML_REPEAT_NUDGE": {
         "kind": "assign"
       },

--- a/studio/backend/tests/data/refactor_guard/runtime_inventory.json
+++ b/studio/backend/tests/data/refactor_guard/runtime_inventory.json
@@ -10,6 +10,7 @@
       "Optional",
       "RAG_MAX_SEARCHES_PER_TURN",
       "RAG_SEARCH_CAP_NUDGE",
+      "RAG_SEARCH_TOOLS",
       "RENDER_HTML_REPEAT_NUDGE",
       "REPROMPT_MAX_CHARS",
       "StreamingMarkupStripper",

--- a/studio/backend/tests/test_appledouble_guards.py
+++ b/studio/backend/tests/test_appledouble_guards.py
@@ -210,3 +210,60 @@ def test_consolidated_weights_are_not_hidden_by_their_companion():
         is False
     )
     assert repo_ships_transformers_weights(["model.safetensors"]) is True
+
+
+# ---------------------------------------------------------------------------
+# The GGUF selection sites in core/inference/llama_cpp.py.
+#
+# Every one of these was filtered by #8919 and every one was silently reverted by
+# #9074's whole-file merge resolution. Only one of the five had a test, so CI
+# reported a lost error message and said nothing at all about the four selection
+# sites, which is the half that actually loads the wrong file. These cover the
+# selection behaviour directly, so a revert cannot come back quiet again.
+# ---------------------------------------------------------------------------
+
+
+def test_a_sidecar_never_wins_the_mmproj_preference():
+    """"._mmproj-F16.gguf" satisfies the F16 preference and sorts ahead of the real adapter."""
+    from core.inference.llama_cpp import _pick_mmproj
+
+    assert _pick_mmproj(["._mmproj-F16.gguf", "mmproj-F16.gguf"]) == "mmproj-F16.gguf"
+    # A file a user genuinely named "._..." with no sibling to shadow still resolves.
+    assert _pick_mmproj(["._mmproj-F16.gguf"]) == "._mmproj-F16.gguf"
+
+
+def test_a_sidecar_never_wins_the_dspark_preference():
+    """Every GGUF under dspark/ qualifies, so a sidecar ranks equal to its sibling and sorts first."""
+    from core.inference.llama_cpp import _pick_dspark
+
+    picked = _pick_dspark(["dspark/._drafter-Q4_K_M.gguf", "dspark/drafter-Q4_K_M.gguf"])
+    assert picked == "dspark/drafter-Q4_K_M.gguf"
+
+
+def test_pick_dspark_stays_reachable_from_module_scope():
+    """It is handed a live repo listing as well as a snapshot, the same as _pick_mmproj.
+
+    Nesting it back inside the method is how #9074 reverted it, and nothing noticed.
+    """
+    import core.inference.llama_cpp as llama_cpp
+
+    assert callable(getattr(llama_cpp, "_pick_dspark", None))
+
+
+def test_a_sidecar_is_not_offered_as_a_variant():
+    from core.inference.llama_cpp import _gguf_files_for_variant
+
+    files = ["._model-Q4_K_M.gguf", "model-Q4_K_M.gguf"]
+    assert _gguf_files_for_variant(files, "Q4_K_M") == ["model-Q4_K_M.gguf"]
+
+
+def test_a_snapshot_walk_skips_the_companion_by_its_bytes(tmp_path):
+    from core.inference.llama_cpp import _gguf_snapshot_files
+
+    (tmp_path / "model-Q4_K_M.gguf").write_bytes(b"GGUF" + b"\x00" * 32)
+    (tmp_path / "._model-Q4_K_M.gguf").write_bytes(_AD)
+    # A real GGUF a user named "._..." is decided on its bytes, so it survives.
+    (tmp_path / "._mine.gguf").write_bytes(b"GGUF" + b"\x00" * 32)
+
+    found = sorted(_gguf_snapshot_files(tmp_path))
+    assert found == ["._mine.gguf", "model-Q4_K_M.gguf"]

--- a/studio/backend/tests/test_appledouble_guards.py
+++ b/studio/backend/tests/test_appledouble_guards.py
@@ -224,7 +224,7 @@ def test_consolidated_weights_are_not_hidden_by_their_companion():
 
 
 def test_a_sidecar_never_wins_the_mmproj_preference():
-    """"._mmproj-F16.gguf" satisfies the F16 preference and sorts ahead of the real adapter."""
+    """ "._mmproj-F16.gguf" satisfies the F16 preference and sorts ahead of the real adapter."""
     from core.inference.llama_cpp import _pick_mmproj
 
     assert _pick_mmproj(["._mmproj-F16.gguf", "mmproj-F16.gguf"]) == "mmproj-F16.gguf"
@@ -246,13 +246,11 @@ def test_pick_dspark_stays_reachable_from_module_scope():
     Nesting it back inside the method is how #9074 reverted it, and nothing noticed.
     """
     import core.inference.llama_cpp as llama_cpp
-
     assert callable(getattr(llama_cpp, "_pick_dspark", None))
 
 
 def test_a_sidecar_is_not_offered_as_a_variant():
     from core.inference.llama_cpp import _gguf_files_for_variant
-
     files = ["._model-Q4_K_M.gguf", "model-Q4_K_M.gguf"]
     assert _gguf_files_for_variant(files, "Q4_K_M") == ["model-Q4_K_M.gguf"]
 

--- a/studio/backend/tests/test_research_internal_call_tool_gate.py
+++ b/studio/backend/tests/test_research_internal_call_tool_gate.py
@@ -101,7 +101,10 @@ def test_the_research_payload_never_enters_the_tool_loop(monkeypatch, policy):
 @pytest.mark.parametrize("policy", [None, False])
 def test_the_opt_out_changes_nothing_a_default_install_does(monkeypatch, policy):
     # Without --enable-tools the hop was already tool-free, so the two fields must not
-    # perturb what the model is handed: same entry point, same generation kwargs.
+    # perturb what the model is handed: same entry point, same generation kwargs, and in
+    # particular no tool catalogue on either side. The one kwarg that may differ is
+    # `tools_withheld` (#9162), which is not handed to the model at all; it is pinned
+    # explicitly below rather than excluded, so a regression either way still fails here.
     before_entry, before_kwargs = _entry_point(monkeypatch, policy = policy, opt_out = False)
     reset_tool_policy()
     after_entry, after_kwargs = _entry_point(monkeypatch, policy = policy, opt_out = True)
@@ -109,12 +112,22 @@ def test_the_opt_out_changes_nothing_a_default_install_does(monkeypatch, policy)
     assert (before_entry, after_entry) == ("plain", "plain")
     # Both are fresh per request (a new Event, and the monitor's per-request tok/s closure), so
     # comparing them by identity would fail for any pair of requests.
-    drop = {"cancel_event", "perf_callback"}
+    drop = {"cancel_event", "perf_callback", "tools_withheld"}
     # But dropping perf_callback outright would also pass if the opt-out stopped supplying it at
     # all, silently costing that path its tok/s readout. Compare presence first, then exclude.
     assert callable(before_kwargs.get("perf_callback")) == callable(
         after_kwargs.get("perf_callback")
     ), "the opt-out must not decide whether llama.cpp timings are collected"
+    # `tools_withheld` reaches the compaction gate, never the prompt: it tells
+    # `_can_reset_epoch` that THIS request withdrew the tool loop, which the process-wide
+    # policy cannot see. A default install can still re-admit `search_conversation` alone
+    # through the checkpoint repair, so resetting the epoch there is safe; under the opt-out
+    # that repair is closed on this turn and on every identical turn after it, so a reset
+    # would strand the epoch behind a tool that never arrives. It MUST differ, in this
+    # direction, and the two must never both be False.
+    assert (before_kwargs["tools_withheld"], after_kwargs["tools_withheld"]) == (False, True)
+    # Nothing that reaches the model may differ, tool catalogue included.
+    assert not before_kwargs.get("tools") and not after_kwargs.get("tools")
     assert {k: v for k, v in before_kwargs.items() if k not in drop} == {
         k: v for k, v in after_kwargs.items() if k not in drop
     }


### PR DESCRIPTION
Put back the AppleDouble GGUF filters #9074 reverted, and guard them

Backend CI's 3.13 leg has six failures on main beyond the two in #9348. Three
separate causes, all of them in the tests or in a merge resolution rather than
in anything a PR meant to change.

1. llama_cpp.py lost every line of #8919
------------------------------------------------------------------------
#8919, "never pick a macOS AppleDouble sidecar as a GGUF", touched 49 files.
18b97f8b7 ("keep and search the turns rolling context evicts", #9074) reverted
all five of its hunks in core/inference/llama_cpp.py and nothing else. That is
the signature of a branch cut before #8919 landed and merged whole-file: #9074
is a rolling-context PR, its diff carries no replacement for any of this, and it
did not revert the tests, which is the only reason CI said anything at all.

Checked the rest of #8919 line by line against main: of the 49 files it changed,
llama_cpp.py is the only one that lost anything. All five hunks are restored
here, and the file now contains every line #8919 added.

Four of the five are the selection sites, and they are the half that was silent:

  _gguf_snapshot_files      a local walk now skips the companion on its bytes
  _pick_mmproj              "._mmproj-F16.gguf" satisfied the F16 preference and
                            sorted ahead of the real adapter
  _pick_dspark              every GGUF under dspark/ qualifies, so a sidecar
                            ranked equal to its sibling and sorted first; also
                            back at module level, where #8919 put it because it
                            is handed a live repo listing as well as a snapshot
  the HF list_repo_files    a repo listing has no bytes to read

The fifth is the one CI caught: the "invalid magic characters" branch in
_classify_llama_start_failure. Without it a user who points llama-server at a
"._model.gguf" sidecar gets "Check that the GGUF file is valid and you have
enough memory" and goes off to free memory they already have, which is issue
#8566 exactly. Restored verbatim at its original anchor, below the dyld branch
so test_a_dyld_failure_still_outranks_it keeps holding.

Five new tests in test_appledouble_guards.py cover the four selection sites
behaviourally, including that _pick_dspark is reachable from module scope, since
nesting it back inside the method is how it was reverted. Each also pins that a
file a user genuinely named "._something" still resolves: nothing may be refused
for its name alone.

Mutation-tested by restoring llama_cpp.py to its current main state: 7 failed,
all five new guards plus the two that were already red.

2. The refactor guard baseline
------------------------------------------------------------------------
#9074 added RAG_SEARCH_TOOLS to core/inference/tool_call_parser, which is one of
the two strict modules the guard runs with additions_matter, so a new public name
there is a deliberate re-baseline by design. The symbol is correct: three modules
import it, and test_conversation_recall_injection.py already pins its value.

Re-baselined through the tool's own `snapshot`, then trimmed to just this entry.
The full snapshot also absorbed 52 unreviewed new names in core.inference.llama_cpp,
3 in safetensors_agentic and 151 lines of patch_targets churn. Those are additive
drift the guard tolerates on purpose, so recording them fixes nothing and pins
symbols nobody looked at.

Mutation-tested: an added throwaway public symbol still turns both tests red, so
the strict-addition behaviour survived the re-baseline.

3. The research opt-out payload
------------------------------------------------------------------------
28b888046 ("compact a chat by resetting the epoch", #9162) added tools_withheld
to the generation kwargs. test_the_opt_out_changes_nothing_a_default_install_does
compared the two payloads whole, which was right when every kwarg was
model-facing.

tools_withheld is not. Its only consumer is _can_reset_epoch, which picks a
compaction strategy; it never reaches the prompt, the sampling params or the tool
catalogue. And it has to differ: without the opt-out a compacted thread can still
re-admit search_conversation through the checkpoint-repair branch, so resetting
the epoch is safe, while with the opt-out that repair is closed on this turn and
every identical turn after it, so a reset would strand the epoch behind a tool
that never arrives. Forcing the two equal is what would break Deep Research,
which sends a real thread_id.

The 17 model-facing fields are identical and neither side carries a `tools` key,
so the asymmetry this test exists to catch is not present. Rather than just
excluding the key, it is now pinned in both directions plus an explicit
no-tool-catalogue assertion, so the file catches more than before.

Mutation-tested: pinning tools_withheld = False in routes/inference.py fails the
new assertion for both parameters.

Verification
------------------------------------------------------------------------
test_appledouble_guards.py, test_llama_cpp_start_failure_classification.py,
test_refactor_guard.py, test_research_internal_call_tool_gate.py and
hub/tests/test_model_services.py: 508 passed, from 6 failed.
Wider sweep over tests/test_llama*.py and the hub model services: no collateral.
