### PR TITLE
fix(models): collapse local inventory rows that share one physical path

### DIFF
--- a/studio/backend/routes/models.py
+++ b/studio/backend/routes/models.py
@@ -1036,8 +1036,34 @@ def collect_local_models(
         if prefer_model:
             deduped[key] = model
 
-    models = sorted(
+    # A physical directory can only be one model. A custom folder pointing into
+    # a tree a native scanner already covers (LM Studio, Ollama) re-finds the
+    # same path, and the (id, source) keys above kept both rows — the same model
+    # listed twice (#9164). Collapse by canonical path; the native scanner's
+    # attribution wins, and a custom entry survives only for paths no native
+    # source already covers (the distinct-copy case the keys above protect).
+    def _canonical_model_path(model: LocalModelInfo) -> Optional[str]:
+        try:
+            return os.path.normcase(os.path.realpath(os.path.expanduser(str(model.path))))
+        except (OSError, UnicodeError, ValueError):
+            return None
+
+    seen_paths: set[str] = set()
+    collapsed: List[LocalModelInfo] = []
+    natives_first = sorted(
         deduped.values(),
+        key = lambda model: model.source == "custom",
+    )
+    for model in natives_first:
+        path_key = _canonical_model_path(model)
+        if path_key is not None:
+            if path_key in seen_paths:
+                continue
+            seen_paths.add(path_key)
+        collapsed.append(model)
+
+    models = sorted(
+        collapsed,
         key = lambda item: item.updated_at or 0,
         reverse = True,
     )

--- a/studio/backend/tests/test_cached_gguf_routes.py
+++ b/studio/backend/tests/test_cached_gguf_routes.py
@@ -161,6 +161,48 @@ def test_collect_local_models_prefers_complete_previous_copy(monkeypatch, tmp_pa
     }
 
 
+def _patch_inventory_roots(monkeypatch, tmp_path, lm_dirs, custom_folders):
+    monkeypatch.setattr(models_route, "_resolve_hf_cache_dir", lambda: tmp_path / "active")
+    monkeypatch.setattr("utils.paths.legacy_hf_cache_dir", lambda: tmp_path / "legacy")
+    monkeypatch.setattr("utils.paths.hf_default_cache_dir", lambda: tmp_path / "default")
+    monkeypatch.setattr("utils.paths.lmstudio_model_dirs", lambda: list(lm_dirs))
+    monkeypatch.setattr("utils.hf_cache_settings.known_hf_hub_caches", lambda: [])
+    monkeypatch.setattr("storage.studio_db.list_scan_folders", lambda: list(custom_folders))
+
+
+def test_collect_local_models_collapses_a_custom_folder_overlapping_lmstudio(monkeypatch, tmp_path):
+    # #9164: registering the LM Studio models tree (or a parent of it) as a custom
+    # scan folder re-found what the LM Studio scanner already listed, and the
+    # (id, source) dedup keys kept both rows: the same path twice, once as
+    # "lmstudio" and once as "custom".
+    lm_root = tmp_path / "lmstudio" / "models"
+    model_dir = lm_root / "unsloth" / "gpt-oss-20b-GGUF"
+    model_dir.mkdir(parents = True)
+    (model_dir / "model-Q4_K_M.gguf").write_bytes(b"gguf-payload")
+
+    _patch_inventory_roots(monkeypatch, tmp_path, [lm_root], [{"path": str(lm_root)}])
+
+    rows = models_route.collect_local_models(tmp_path / "models")
+
+    matches = [row for row in rows if row.path == str(model_dir)]
+    assert [(row.source, row.path) for row in matches] == [("lmstudio", str(model_dir))]
+
+
+def test_collect_local_models_keeps_custom_rows_for_distinct_paths(monkeypatch, tmp_path):
+    # The custom-source keys exist so a second physical copy of the same repo
+    # still shows; collapsing by path must not eat that row.
+    custom_root = tmp_path / "custom"
+    model_dir = custom_root / "MyModel"
+    model_dir.mkdir(parents = True)
+    (model_dir / "model.safetensors").write_bytes(b"safetensors-payload")
+
+    _patch_inventory_roots(monkeypatch, tmp_path, [], [{"path": str(custom_root)}])
+
+    rows = models_route.collect_local_models(tmp_path / "models")
+    matches = [row for row in rows if row.path == str(model_dir)]
+    assert [(row.source, row.path) for row in matches] == [("custom", str(model_dir))]
+
+
 def test_compat_local_inventory_requests_share_scan(monkeypatch, tmp_path):
     # Total and stable on hostile input is the whole contract here; the exact
     # string is platform-dependent. POSIX realpath() rejects an embedded NUL with


### PR DESCRIPTION
Fixes #9164.

## What was wrong

Registering a tree a native scanner already covers (the reporter's case: the LM Studio models directory, or a parent of it, added as a custom scan folder) made the same model appear **twice** in the model hub. The custom scan runs `_scan_models_dir` + `_scan_hf_cache` + `_scan_lmstudio_dir` over the registered folder, so it re-finds the identical directory the native LM Studio scan already listed — and the dedup keys are `id` for native sources but `id`+NUL+`custom` for custom folders, so both rows survived: same `model_id`, same `path`, sources `lmstudio` and `custom`.

## The fix

After the existing `(id, source)` dedup, rows are collapsed by **canonical path** (`normcase(realpath(expanduser))`, so case-only and symlinked duplicates count too, case-insensitively where the platform makes it matter):

- the native scanner's attribution wins a path collision (LM Studio/Ollama/HF-cache labels stay accurate);
- a custom entry survives only for paths no native source already covers — which preserves exactly the reason the custom keys exist: a **second physical copy** of the same repo under a custom folder still shows as its own row, as before.

## Verification

`tests/test_cached_gguf_routes.py` — 170 passed, 2 skipped, with two new cases:

1. `collapses_a_custom_folder_overlapping_lmstudio` — reproduces the report verbatim (same dir found by both scans) and asserts exactly one row with `lmstudio` attribution. **Fails on the pre-fix code, passes with the fix.**
2. `keeps_custom_rows_for_distinct_paths` — guards the documented distinct-copy behavior (passes before and after).