### PR TITLE
fix(desktop): stop the llama.cpp update toast pinning when its poll dies

### DIFF
--- a/studio/frontend/src/hooks/use-llama-update-check.ts
+++ b/studio/frontend/src/hooks/use-llama-update-check.ts
@@ -8,6 +8,7 @@ import {
   subscribeToLlamaJobStarted,
 } from "@/lib/llama-job-events";
 import {
+  llamaJobPollTick,
   llamaUpdateAdoptsRunningJob,
   llamaUpdatePresentation,
 } from "@/lib/llama-job-lifecycle";
@@ -177,6 +178,8 @@ export function useLlamaUpdateCheck({
   const [visible, setVisible] = useState(false);
   const [applying, setApplying] = useState(false);
   const pollTimer = useRef<ReturnType<typeof setInterval> | null>(null);
+  // Consecutive job-poll fetches that returned nothing (see llamaJobPollTick).
+  const pollMissesRef = useRef(0);
   const snoozeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   // Read through a ref so startJobPoll stays stable (apply/surfaceIfAvailable
   // depend on it) while still calling the latest callback.
@@ -190,6 +193,9 @@ export function useLlamaUpdateCheck({
   // mount (new tab, or a page reload of a tab that already resynced) doesn't
   // replay a job some tab already handled.
   const reloadNotifiedForRef = useRef<string | null>(getHandledReloadAt());
+  // Read through a ref so the poll can re-surface after a stall without
+  // depending on surfaceIfAvailable (which depends on the poll).
+  const surfaceIfAvailableRef = useRef<((next: LlamaUpdateStatus | null) => void) | null>(null);
 
   const clearPollTimer = useCallback(() => {
     if (pollTimer.current) {
@@ -227,8 +233,31 @@ export function useLlamaUpdateCheck({
   const startJobPoll = useCallback(
     (onDone?: (result: LlamaApplyResult) => void) => {
       clearPollTimer();
+      pollMissesRef.current = 0;
       pollTimer.current = setInterval(async () => {
         const s = await fetchStatus();
+        pollMissesRef.current = s ? 0 : pollMissesRef.current + 1;
+        const tick = llamaJobPollTick(s, pollMissesRef.current);
+        if (tick.kind === "stalled") {
+          // Nothing else resets "applying" for this run, so a poll whose every
+          // fetch fails would pin the update toast forever (#9196). Drop it,
+          // hide the banner, and surface the truth once the backend answers
+          // again -- a still-running job restarts the poll from there.
+          clearPollTimer();
+          setApplying(false);
+          setVisible(false);
+          onDone?.({ ok: false, error: "update status unavailable" });
+          void recheckStatus().then((next) => surfaceIfAvailableRef.current?.(next));
+          return;
+        }
+        if (tick.kind === "polling") {
+          if (!s) return;
+          setStatus(s);
+          const presentation = llamaUpdatePresentation(s.update_available, s.job);
+          setApplying(presentation.applying);
+          setVisible(presentation.visible);
+          return;
+        }
         if (!s) return;
         setStatus(s);
         const presentation = llamaUpdatePresentation(s.update_available, s.job);
@@ -284,6 +313,10 @@ export function useLlamaUpdateCheck({
     },
     [startJobPoll, notifyReloadIfNeeded],
   );
+
+  useEffect(() => {
+    surfaceIfAvailableRef.current = surfaceIfAvailable;
+  }, [surfaceIfAvailable]);
 
   useEffect(() => {
     if (!enabled) {

--- a/studio/frontend/src/lib/llama-job-lifecycle.ts
+++ b/studio/frontend/src/lib/llama-job-lifecycle.ts
@@ -67,3 +67,38 @@ export function llamaUpdatePresentation(
     running: true,
   };
 }
+
+/** How many consecutive poll fetches may return nothing before the run is
+ * treated as stalled (500 ms apart, so 30 ≈ 15 s of dead fetches). */
+export const LLAMA_JOB_POLL_MISS_LIMIT = 30;
+
+export type LlamaJobPollTick =
+  | { kind: "polling" }
+  | { kind: "finished"; state: "success" | "error" | "idle" }
+  | { kind: "stalled" };
+
+/** One job-poll tick's decision, from the fetched status and the streak of
+ * fetches that returned nothing.
+ *
+ * The streak keeps the "applying" flag honest: the poll owns that flag for the
+ * whole run, so when every fetch starts failing — an auth token that expired,
+ * a network drop, a backend restart window — a tick that only skips leaves the
+ * update toast pinned on "Updating..." forever, with its close affordance
+ * hidden (#9196). Past the limit the tick reports `stalled`, and the caller
+ * drops applying and re-checks once instead of waiting on a backend that is
+ * not answering. A fetch that succeeds resets the streak, so a healthy run
+ * with occasional timeouts never stalls. */
+export function llamaJobPollTick(
+  status: { update_available: boolean; job: LlamaJob } | null,
+  consecutiveMisses: number,
+): LlamaJobPollTick {
+  if (status === null) {
+    return consecutiveMisses >= LLAMA_JOB_POLL_MISS_LIMIT
+      ? { kind: "stalled" }
+      : { kind: "polling" };
+  }
+  if (status.job.state === "running") {
+    return { kind: "polling" };
+  }
+  return { kind: "finished", state: status.job.state };
+}

--- a/studio/frontend/tests/llama-job-lifecycle.test.ts
+++ b/studio/frontend/tests/llama-job-lifecycle.test.ts
@@ -4,6 +4,8 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  LLAMA_JOB_POLL_MISS_LIMIT,
+  llamaJobPollTick,
   llamaUpdateAdoptsRunningJob,
   llamaUpdatePresentation,
   ownedLlamaSwitchOutcome,
@@ -102,4 +104,34 @@ test("an apply adopts an already-running update but never a switch", () => {
     }),
     false,
   );
+});
+
+test("a fetch that answers keeps the poll alive, whatever the job says", () => {
+  assert.deepEqual(
+    llamaJobPollTick({ update_available: true, job: { state: "running", operation: "update" } }, 0),
+    { kind: "polling" },
+  );
+  // A successful fetch also clears an earlier failure streak.
+  assert.deepEqual(
+    llamaJobPollTick({ update_available: false, job: { state: "running", operation: "switch" } }, 9),
+    { kind: "polling" },
+  );
+});
+
+test("a terminal job state finishes the poll", () => {
+  for (const state of ["success", "error", "idle"] as const) {
+    assert.deepEqual(
+      llamaJobPollTick({ update_available: false, job: { state, operation: "update" } }, 0),
+      { kind: "finished", state },
+    );
+  }
+});
+
+test("a sustained fetch-failure streak stalls instead of pinning the toast", () => {
+  // #9196: the poll owns the applying flag, so a run whose every fetch fails
+  // kept the update toast pinned forever; one miss short of the limit is still
+  // polling, at the limit it is stalled.
+  assert.deepEqual(llamaJobPollTick(null, LLAMA_JOB_POLL_MISS_LIMIT - 1), { kind: "polling" });
+  assert.deepEqual(llamaJobPollTick(null, LLAMA_JOB_POLL_MISS_LIMIT), { kind: "stalled" });
+  assert.deepEqual(llamaJobPollTick(null, LLAMA_JOB_POLL_MISS_LIMIT + 5), { kind: "stalled" });
 });


### PR DESCRIPTION
Fixes #9196.

## What was wrong

The job poll owns the `applying` flag for the whole update run, and a tick whose `fetchStatus()` returns `null` (auth token gone, network drop, backend restart window) only **skipped** — it kept the interval alive but did nothing. When *every* fetch fails, the poll spins forever doing nothing while `applying` stays `true`: the update toast pins on “Updating llama.cpp…” with a partially filled bar, and its close button is hidden for the applying state, so nothing can dismiss it. That is exactly the reported state — backend at `state: "success"`, `progress: 1.0`, toast stuck for minutes, cleared only by restarting the app.

(The reporter's tag-mismatch analysis is also right as a steady-state footgun — `installed_tag` (base) and `latest_tag` (full release) can legitimately differ while `update_available: false` — but the pinned card itself is this poll death: on current main the banner hides on the first terminal tick, so a card that never resolves means no terminal tick ever processed.)

## The fix

- The tick decision moves into a pure `llamaJobPollTick(status, consecutiveMisses)` in `llama-job-lifecycle.ts`: an answering fetch resets the streak, a terminal job state finishes the poll (unchanged behavior), and a streak of **30 dead fetches (~15 s)** reports `stalled`.
- On `stalled`, the poll clears its timer, drops `applying`, hides the banner, resolves the in-flight `apply()` with `"update status unavailable"`, and fires **one** re-check — so a recovered backend re-surfaces the truth: a still-running job restarts the poll from there, a finished one lands through the normal terminal path (`refreshHardwareInfo`, reload-required handling, success toast).
- A ref keeps the re-surface call stable so the poll and `surfaceIfAvailable` don't depend on each other.

Healthy runs with occasional timeouts never trip it — any successful fetch resets the streak.

## Verification

- `tests/llama-job-lifecycle.test.ts` — 9/9 (3 new: an answering fetch keeps polling and clears an earlier streak; every terminal state finishes; the streak boundary is `polling` at limit−1 and `stalled` at limit and beyond).
- `tsc --noEmit` clean; `llama-job-events` suite 1/1.

## Not addressed here (per the report's option 3)

The `installed_tag` / `latest_tag` namespace mismatch in the payload is a separate API-shape question — happy to do that rename/addition as its own change if wanted.