### PR TITLE
Take two ubuntu jobs off their own runners: absorb one, delete the other

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -26,7 +26,6 @@
 #                        does not block the supply-chain pattern scan
 #                        (or vice versa).
 #   - npm-scan-packages: npm tarball content scan, no npm install.
-#   - tests-security:    pytest tests/security regression suite.
 #   - npm-provenance-and-install-scripts:
 #                        npm audit signatures + new-postinstall gate.
 #
@@ -1064,48 +1063,6 @@ jobs:
           name: scan-npm-packages-log
           path: logs-scan-npm.txt
           retention-days: 30
-
-  # ─────────────────────────────────────────────────────────────────────
-  # Regression tests: pin scanner IOC tables and pre-install fixtures.
-  # Hard gate (no continue-on-error) so future drift in the IOC tables
-  # or scanner exit semantics fails this PR at review time.
-  # ─────────────────────────────────────────────────────────────────────
-  tests-security:
-    name: pytest tests/security
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - name: Harden runner (egress block)
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920  # v2.20.0
-        with:
-          egress-policy: block
-          disable-sudo: true
-          allowed-endpoints: >
-            api.github.com:443
-            github.com:443
-            codeload.github.com:443
-            objects.githubusercontent.com:443
-            pypi.org:443
-            files.pythonhosted.org:443
-
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
-        with:
-          persist-credentials: false
-
-      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
-        with:
-          python-version: '3.12'
-
-      - name: Install pytest + PyYAML
-        # PyYAML is imported by scripts/lint_workflow_triggers.py, which the
-        # `tests/security/test_lint_workflow_triggers.py` regression suite
-        # exercises as a subprocess. Without it the lint script bails with
-        # `ERROR: PyYAML is required` (exit 2) and the 5 lint regression
-        # tests fail. Pinned the same way pytest is pinned.
-        run: pip install pytest==9.0.3 pyyaml==6.0.2
-
-      - name: Run security regression tests
-        run: python3 -m pytest tests/security -v
 
   # ─────────────────────────────────────────────────────────────────────
   # npm provenance + new install-script diff. Catches the two npm

--- a/.github/workflows/studio-export-capability-ci.yml
+++ b/.github/workflows/studio-export-capability-ci.yml
@@ -41,15 +41,28 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # No macOS leg on purpose. The only command this job runs is
-        # `pytest tests/test_export_capability.py`, and every test in that file
-        # goes through `_patch()`, which monkeypatches `_has_torch`,
-        # `get_device` and `is_apple_silicon`. Nothing in it touches Metal, MLX
-        # or any Apple binary, so a real Mac proves nothing a Linux runner does
-        # not already prove -- and studio-backend-ci.yml runs the same file on
-        # ubuntu-latest as part of `pytest tests/`. macOS concurrency is capped
-        # at 5 account-wide, so a leg that buys no signal is worth reclaiming.
-        os: [ubuntu-latest, windows-latest]
+        # Windows only, and the reason is the same one that already removed the
+        # macOS leg: the only command this job runs is `pytest
+        # tests/test_export_capability.py`, and every test in that file goes
+        # through `_patch()`, which monkeypatches `_has_torch`, `get_device` and
+        # `is_apple_silicon`. Nothing in it touches Metal, MLX or any Apple
+        # binary, so a real Mac proved nothing a Linux runner did not.
+        #
+        # That argument reaches one step further than it was taken. It rests on
+        # studio-backend-ci.yml running the same file on ubuntu-latest as part of
+        # `pytest tests/` -- which it does, the file is not in that job's
+        # --ignore list -- and if that is true then the ubuntu leg HERE is the
+        # duplicate, not just the macOS one. The import-safety test does not need
+        # a torch-free image to be honest either: it installs its own
+        # `builtins.__import__` blocker and drops preloaded torch/unsloth from
+        # sys.modules, so it proves the same thing inside Backend CI's fully
+        # installed environment.
+        #
+        # Windows stays, because nothing else in CI runs this file there and
+        # `_has_torch`'s import probe is the per-OS behaviour the job exists for.
+        # Measured 67s of execution behind a 10642s queue, so the ubuntu leg was
+        # a runner slot spent re-proving a Linux result.
+        os: [windows-latest]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
     env:

--- a/.github/workflows/workflow-trigger-lint.yml
+++ b/.github/workflows/workflow-trigger-lint.yml
@@ -68,7 +68,12 @@ jobs:
           python-version: '3.12'
 
       - name: Install PyYAML
-        run: pip install pyyaml pytest pytest-xdist vermin
+        # pytest and PyYAML are pinned to the versions security-audit.yml pinned them
+        # to when `pytest tests/security` lived there. That suite exercises
+        # scripts/lint_workflow_triggers.py as a SUBPROCESS and asserts on its exit
+        # semantics, so a pytest or PyYAML that resolves differently changes what it is
+        # asserting against. xdist and vermin stay unpinned: neither is under test.
+        run: pip install pyyaml==6.0.2 pytest==9.0.3 pytest-xdist vermin
 
       - name: Lint workflow triggers + cache keys
         run: python3 scripts/lint_workflow_triggers.py
@@ -99,6 +104,20 @@ jobs:
       # re-imports that expensive conftest. Measured on a 192-core machine: `auto` spawned
       # 192 workers and took 327s, worse than running serially. A fixed width is the same
       # everywhere and cannot be made pathological by the machine it lands on.
+      #
+      # tests/security rides along on the same invocation. It held its own ubuntu-latest
+      # runner in security-audit.yml for 72s of work behind a queue measured at 11096s,
+      # and the same argument that put the lockfile and load-orchestrator lanes into Lint
+      # CI applies: work with a narrow trigger, moved into a job that was going to occupy
+      # a runner on this commit anyway, can only reduce the slots a commit takes. Here the
+      # trigger widens too, since this workflow has no paths filter and
+      # security-audit.yml's pull_request does.
+      #
+      # This host and not Lint CI, where the other absorbed lanes went. Lint CI installs
+      # shellcheck from apt, so its harden-runner has to permit escalation and an apt
+      # mirror; a security gate moved there would run under a policy weaker than the one
+      # it has today. This workflow's harden-runner block is byte-for-byte identical to
+      # the one the job carried, so nothing about its isolation changes.
       #
       # The list grew as much as it shrank. Every module here reads a workflow file, so
       # the edit that breaks it is by definition a workflow-only edit, and this is the
@@ -132,8 +151,11 @@ jobs:
             tests/studio/test_main_runs_survive_merge_bursts.py \
             tests/studio/test_pester_bootstrap_hardening.py \
             tests/studio/test_playwright_suites_run_in_ci.py \
+            tests/studio/test_short_job_absorption.py \
             tests/studio/test_smoke_workflows_share_one_script.py \
             tests/studio/test_stt_model_search_locator_contract.py \
             tests/studio/test_uv_cache_discipline.py \
             tests/studio/test_windows_small_checks_stay_on_their_image.py \
-            tests/studio/test_workflow_guards_run_unfiltered.py
+            tests/studio/test_workflow_guards_run_unfiltered.py \
+            tests/security
+

--- a/tests/security/test_scan_packages.py
+++ b/tests/security/test_scan_packages.py
@@ -2325,8 +2325,11 @@ def test_the_toml_helpers_run_without_stdlib_tomllib(monkeypatch):
     old AND taking `tomllib` away. Doing only the second is not the same thing -- the
     guard reads sys.version_info, not the module table.
 
-    The backport is supplied rather than required. `tests-security` installs only pytest
-    and PyYAML, so a test that leaned on a real `tomli` being importable would
+    The backport is supplied rather than required. The job that runs this suite installs
+    pytest and PyYAML and nothing that provides `tomli` (it was `tests-security` in
+    security-audit.yml, and is the `Security regression tests` step in
+    workflow-trigger-lint.yml since that job was absorbed onto a shared runner). So a test
+    that leaned on a real `tomli` being importable would
     `importorskip` its way to green there and never once execute the branch it exists to
     cover. Registering the stdlib parser under the name the fallback looks for keeps this
     load-bearing on every interpreter and in CI, while still proving the fallback is what

--- a/tests/studio/test_short_job_absorption.py
+++ b/tests/studio/test_short_job_absorption.py
@@ -1,0 +1,168 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Two ubuntu-latest jobs stopped taking a runner slot. Neither may stop being checked.
+
+Measured over 400 completed main push runs, both were pure slot overhead: seconds of
+execution behind a queue of about three hours.
+
+    Security audit :: pytest tests/security         72 s exec, 11096 s queue
+    Unsloth export capability :: capability (ubuntu-latest)
+                                                    67 s exec, 10642 s queue
+
+They were dealt with differently, because they are different problems.
+
+The security suite MOVED, into `Workflow trigger lint`. What makes that safe is that the
+host's harden-runner block is identical to the one the job carried, so the suite runs
+under exactly the isolation it had. The obvious alternative host, `Lint CI`, is where the
+lockfile and load-orchestrator lanes went, and it is wrong for this one: Lint CI installs
+shellcheck from apt, so its runner has to permit escalation and an apt mirror. Absorbing a
+security gate there would weaken it. That is the property asserted here, not the fact of
+the move.
+
+The capability leg was DELETED, because it was already duplicated: Backend CI runs
+`pytest tests/` without ignoring `tests/test_export_capability.py`, so the file executes
+there on ubuntu-latest either way. That justification is only true while the ignore list
+stays as it is, and adding one line to it would silently delete the coverage rather than
+turn anything red. So the ignore list is what gets asserted.
+
+Both are the same failure shape: a change that looks unrelated makes a check stop running
+without failing anything.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+
+REPO = Path(__file__).resolve().parents[2]
+WORKFLOWS = REPO / ".github" / "workflows"
+
+TRIGGER_LINT = WORKFLOWS / "workflow-trigger-lint.yml"
+SECURITY_AUDIT = WORKFLOWS / "security-audit.yml"
+CAPABILITY = WORKFLOWS / "studio-export-capability-ci.yml"
+BACKEND_CI = WORKFLOWS / "studio-backend-ci.yml"
+
+
+def _doc(path: Path) -> dict:
+    return yaml.safe_load(path.read_text(encoding = "utf-8")) or {}
+
+
+def _steps(path: Path):
+    """(job name, step dict) for every step in the workflow."""
+    for job_name, job in (_doc(path).get("jobs") or {}).items():
+        if isinstance(job, dict):
+            for step in job.get("steps") or []:
+                if isinstance(step, dict):
+                    yield job_name, step
+
+
+def _harden_runner(path: Path, job_name: str) -> dict:
+    for name, step in _steps(path):
+        if name == job_name and "harden-runner" in str(step.get("uses", "")):
+            return step.get("with") or {}
+    return {}
+
+
+def _endpoints(config: dict) -> set[str]:
+    return set(str(config.get("allowed-endpoints", "")).split())
+
+
+def _runs_security_suite(path: Path) -> list[str]:
+    return [
+        f"{job}::{step.get('name', '<unnamed>')}"
+        for job, step in _steps(path)
+        if "tests/security" in str(step.get("run", ""))
+    ]
+
+
+def test_the_security_suite_still_runs_somewhere() -> None:
+    """A move that drops the step is indistinguishable from a move that lands it."""
+    assert _runs_security_suite(TRIGGER_LINT), (
+        "no step in workflow-trigger-lint.yml runs `pytest tests/security`. It was moved "
+        "there off its own runner; if it moved again, assert it at its new home rather "
+        "than deleting this."
+    )
+
+
+def test_the_security_suite_is_not_left_running_twice() -> None:
+    """Absorbing work is only a saving if the original stops taking a slot."""
+    assert not _runs_security_suite(SECURITY_AUDIT), (
+        "security-audit.yml runs `pytest tests/security` again. It runs in "
+        "workflow-trigger-lint.yml now, so this is a second runner for the same work."
+    )
+
+
+def test_the_absorbing_job_did_not_weaken_the_isolation() -> None:
+    """The whole reason this host was chosen over Lint CI.
+
+    The suite carried `egress-policy: block`, `disable-sudo: true` and six endpoints.
+    Landing it on a runner that allows more than that is a downgrade wearing the costume
+    of a cleanup, and nothing else would report it.
+    """
+    original = {
+        "api.github.com:443",
+        "github.com:443",
+        "codeload.github.com:443",
+        "objects.githubusercontent.com:443",
+        "pypi.org:443",
+        "files.pythonhosted.org:443",
+    }
+    config = _harden_runner(TRIGGER_LINT, "workflow-trigger-lint")
+    assert config, "the absorbing job has no harden-runner step at all"
+    assert config.get("egress-policy") == "block", config.get("egress-policy")
+    assert config.get("disable-sudo") is True, config.get("disable-sudo")
+    widened = sorted(_endpoints(config) - original)
+    assert not widened, (
+        f"the job now reaches endpoints the security suite's own runner did not: {widened}. "
+        "Moving the suite here is only free while the policy matches; if this host needs "
+        "a wider allowlist, the suite has to move somewhere else, not travel with it."
+    )
+
+
+def test_the_absorbing_job_stays_unfiltered() -> None:
+    """It is also the host that makes the suite run MORE often, not less.
+
+    security-audit.yml's pull_request is path-filtered. This workflow's is not, and must
+    never be -- see its header and scripts/lint_workflow_triggers.py.
+    """
+    triggers = _doc(TRIGGER_LINT).get(True) or _doc(TRIGGER_LINT).get("on") or {}
+    pull_request = triggers.get("pull_request")
+    assert not isinstance(pull_request, dict) or not (
+        set(pull_request) & {"paths", "paths-ignore"}
+    ), (
+        "workflow-trigger-lint.yml's pull_request gained a paths filter. That is forbidden "
+        "on its own terms, and it would also make the absorbed security suite run less "
+        "often than it did in security-audit.yml."
+    )
+
+
+def test_the_capability_job_kept_the_leg_nothing_else_covers() -> None:
+    """Windows is the only platform running this file; ubuntu was the duplicate."""
+    matrix = _doc(CAPABILITY)["jobs"]["capability"]["strategy"]["matrix"]["os"]
+    assert "windows-latest" in matrix, (
+        f"the export capability job no longer runs on Windows: {matrix}. Nothing else in "
+        "CI runs tests/test_export_capability.py there, and the per-OS import probe is "
+        "what the job exists for."
+    )
+
+
+def test_backend_ci_still_runs_the_file_the_ubuntu_leg_used_to() -> None:
+    """The ubuntu leg was dropped BECAUSE Backend CI covers it. Keep that true.
+
+    One line added to that job's --ignore list would remove the coverage on every
+    platform at once, and no test would fail.
+    """
+    text = BACKEND_CI.read_text(encoding = "utf-8")
+    assert "test_export_capability" not in text, (
+        "studio-backend-ci.yml now names tests/test_export_capability.py, which almost "
+        "certainly means it is being ignored or deselected. The ubuntu leg of "
+        "studio-export-capability-ci.yml was removed because this job runs that file; "
+        "restore the leg, or the file stops being checked on Linux entirely."
+    )
+    assert "pytest tests/" in text, (
+        "studio-backend-ci.yml no longer runs the whole tests/ tree, so it can no longer "
+        "be relied on to cover tests/test_export_capability.py"
+    )


### PR DESCRIPTION
Take two ubuntu jobs off their own runners: absorb one, delete the other

Over 400 completed main push runs, 25 of 96 job types execute in under 120s:
1116s of work spread across 25 runners, each queuing for about three hours. Two
of them are dealt with here.

  Security audit :: pytest tests/security                72s exec, 11096s queue
  Unsloth export capability :: capability (ubuntu-latest) 67s exec, 10642s queue

Different problems, so different treatments.

The security suite MOVED, onto the Workflow trigger lint runner
------------------------------------------------------------------------
Same argument that put the lockfile and load-orchestrator lanes into Lint CI in
#9176: work with a narrow trigger, moved into a job that was going to occupy a
runner on this commit anyway, can only reduce the slots a commit takes. Here the
trigger widens too, since this host has no paths filter and security-audit.yml's
pull_request does, so the suite now runs on every pull request rather than on the
ones that touch its paths.

This host and NOT Lint CI, where the other lanes went, and that is the whole
decision. Lint CI installs shellcheck from apt, so its harden-runner has to
permit escalation and an apt mirror; a security gate moved there would run under
a policy weaker than the one it has today. Workflow trigger lint's harden-runner
block is byte-for-byte identical to the one the job carried in security-audit.yml
(block, disable-sudo, the same six endpoints), so nothing about its isolation
changes. harden-runner binds per runner, not per step, which is what makes that
the deciding constraint rather than a detail.

Folded into the existing pytest invocation rather than added as a step of its
own. I wrote it as a separate step first, so a security regression would not be
reported as a workflow-guard failure, and
test_the_guards_run_in_one_pytest_invocation rejected it: one step per module
costs about 15s of interpreter and conftest startup, measured in this repo at
53.9s as one invocation against 300.8s as one each. The guard is right and the
attribution preference is not worth 15s.

pytest and PyYAML are now pinned here to the versions security-audit.yml pinned
them to. That suite runs scripts/lint_workflow_triggers.py as a SUBPROCESS and
asserts on its exit semantics, so a pytest or PyYAML that resolves differently
changes what it is asserting against.

The capability ubuntu leg was DELETED, because it was already duplicated
------------------------------------------------------------------------
That workflow's own comment already explains why it has no macOS leg: every test
in tests/test_export_capability.py goes through _patch(), which monkeypatches
_has_torch, get_device and is_apple_silicon, so a real Mac proves nothing a Linux
runner does not -- and studio-backend-ci.yml runs the same file on ubuntu-latest
as part of `pytest tests/`.

That argument reaches one step further than it was taken. If Backend CI covers
the file on Linux, the ubuntu leg HERE is the duplicate too. Checked: the file is
not in that job's --ignore list. The import-safety test does not need a
torch-free image either; it installs its own builtins.__import__ blocker and
drops preloaded torch/unsloth from sys.modules, so it proves the same thing
inside Backend CI's fully installed environment.

Windows stays. Nothing else in CI runs that file there, and _has_torch's import
probe is the per-OS behaviour the job exists for.

The guard
------------------------------------------------------------------------
tests/studio/test_short_job_absorption.py, wired into the unfiltered job. Both
changes fail silently rather than loudly if they regress, which is what it is
for:

  - the suite still runs somewhere, and no longer runs twice
  - the absorbing job's harden-runner has not widened past the six endpoints the
    suite came with, since "the policy is identical" is the entire justification
    for this host
  - the absorbing job has not gained a paths filter
  - capability still has its Windows leg
  - studio-backend-ci.yml still runs the whole tests/ tree and does not name
    test_export_capability.py, because one line added to that --ignore list
    would remove the coverage the ubuntu leg was deleted for, and nothing would
    turn red

Mutation-tested, each failing exactly one test: drop tests/security from the
invocation; add one endpoint to the allowlist; add
--ignore=tests/test_export_capability.py to Backend CI; remove the Windows leg.

Also corrected a docstring in tests/security/test_scan_packages.py that named
tests-security and what it installs. It was about to become false.

Verification
------------------------------------------------------------------------
tests/security under the host's own -n 4: 409 passed, 6 skipped.
scripts/lint_workflow_triggers.py: OK across 41 workflow files.
All three workflows still parse; security-audit.yml keeps its other 4 jobs.

Net: 7 short ubuntu slots per commit, down to 5.

A note for whoever extends this. The census that found these 15 candidates was
partly stale and I nearly acted on it: the lockfile and load-orchestrator rows
were already absorbed by #9176 and their samples were pre-merge tails, and the
two Local Agent Guides rows show ~0s because they are if-gated to schedule and
dispatch, which is a skip and not a fast job. Read the trigger before ranking by
duration. Of the remaining candidates, Scorecard is blocked by its job-level
id-token: write, the Kaggle gate by a downstream needs:, npm-provenance by an
audit egress policy plus registry.npmjs.org, and the notransport clean-install
lane by a container that asserts several common tools are absent.
