### PR TITLE
fix(install): pair slim whisper with a --with-llama-cpp-dir runtime

### DIFF
--- a/studio/backend/tests/test_whisper_slim_local_llama.py
+++ b/studio/backend/tests/test_whisper_slim_local_llama.py
@@ -1,0 +1,131 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Slim whisper pairing against an unmanaged local llama.cpp runtime.
+
+--with-llama-cpp-dir links a user-built llama tree into the canonical install
+location with no managed prebuilt marker, which used to make every slim
+whisper artifact skip pairing ("no managed llama.cpp prebuilt install") and
+the install fail outright. The runtime is now accepted with no release tag,
+with the per-file ABI gates (requires_ggml_sonames, backend module glob)
+deciding -- these tests pin that contract.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+_studio = Path(__file__).resolve().parent.parent.parent
+if str(_studio) not in sys.path:
+    sys.path.insert(0, str(_studio))
+
+iwp = importlib.import_module("install_whisper_prebuilt")
+
+if not hasattr(iwp, "_local_unmanaged_llama_runtime"):
+    pytest.skip("unmanaged-runtime fallback not present - check branch", allow_module_level = True)
+
+
+def _host(**overrides) -> iwp.HostInfo:
+    info = iwp.HostInfo(
+        system = "Linux",
+        machine = "x86_64",
+        whisper_os = "linux",
+        whisper_arch = "x64",
+        archive_ext = ".tar.gz",
+        is_windows = False,
+        is_macos = False,
+        is_apple_silicon = False,
+    )
+    for key, value in overrides.items():
+        setattr(info, key, value)
+    return info
+
+
+def _artifact(**overrides) -> dict:
+    payload = {
+        "asset": "whisper-v1.9.2-unsloth.10-linux-x64-slim.tar.gz",
+        "requires_llama_tag": "b10360-mix-87da1a2",
+        "requires_ggml_tree": "abc123",
+        "requires_ggml_sonames": ["libggml.so", "libggml-base.so", "libggml-cpu.so"],
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _link_local_tree(monkeypatch, tmp_path, files):
+    bin_dir = tmp_path / "llama.cpp" / "build" / "bin"
+    if os.name == "nt":
+        bin_dir = bin_dir / "Release"
+    bin_dir.mkdir(parents = True)
+    for name in files:
+        (bin_dir / name).write_bytes(b"")
+    monkeypatch.setattr(iwp.llama, "default_managed_llama_dir", lambda: tmp_path / "llama.cpp")
+    monkeypatch.setattr(iwp, "installed_llama_runtime", lambda *a, **k: None)
+    monkeypatch.setattr(iwp, "installed_llama_ggml_tree", lambda *a, **k: None)
+    return bin_dir
+
+
+def test_local_llama_without_marker_pairs_via_abi_gates(monkeypatch, tmp_path):
+    bin_dir = _link_local_tree(
+        monkeypatch,
+        tmp_path,
+        ["libggml.so", "libggml-base.so", "libggml-cpu.so", "llama-server"],
+    )
+
+    runtime = iwp._local_unmanaged_llama_runtime()
+    assert runtime == (bin_dir, "", "")
+
+    paired = iwp.slim_pairing_for_artifact(_artifact(), _host(), "cpu")
+    assert paired == (bin_dir, "")
+    # The tag heuristic alone would have refused: the required tag pairs with
+    # nothing a source build can report.
+    assert not iwp.llama_runtime_pairs("", _artifact()["requires_llama_tag"])
+
+
+def test_local_llama_missing_soname_still_rejects(monkeypatch, tmp_path):
+    _link_local_tree(monkeypatch, tmp_path, ["libggml.so", "llama-server"])
+
+    assert iwp.slim_pairing_for_artifact(_artifact(), _host(), "cpu") is None
+
+
+def test_local_llama_missing_backend_module_still_rejects(monkeypatch, tmp_path):
+    # All sonames present, but the cuda module glob finds nothing: a cpu-only
+    # source build cannot back the cuda pairing.
+    _link_local_tree(
+        monkeypatch, tmp_path, ["libggml.so", "libggml-base.so", "libggml-cpu.so"]
+    )
+
+    assert iwp.slim_pairing_for_artifact(_artifact(), _host(), "cuda") is None
+
+
+def test_no_llama_tree_at_all_still_reports_no_managed_install(monkeypatch, tmp_path):
+    monkeypatch.setattr(iwp.llama, "default_managed_llama_dir", lambda: tmp_path / "llama.cpp")
+    monkeypatch.setattr(iwp, "installed_llama_runtime", lambda *a, **k: None)
+    monkeypatch.setattr(iwp, "installed_llama_ggml_tree", lambda *a, **k: None)
+
+    assert iwp._local_unmanaged_llama_runtime() is None
+    assert iwp.slim_pairing_for_artifact(_artifact(), _host(), "cpu") is None
+
+
+def test_managed_runtime_still_wins_over_the_local_tree(monkeypatch, tmp_path):
+    bin_dir = _link_local_tree(monkeypatch, tmp_path, ["libggml.so", "llama-server"])
+    managed_bin = tmp_path / "managed" / "build" / "bin"
+    if os.name == "nt":
+        managed_bin = managed_bin / "Release"
+    managed_bin.mkdir(parents = True)
+    for name in ("libggml.so", "libggml-base.so", "libggml-cpu.so"):
+        (managed_bin / name).write_bytes(b"")
+    monkeypatch.setattr(
+        iwp,
+        "installed_llama_runtime",
+        lambda *a, **k: (managed_bin, "b10360-mix-87da1a2", "cuda13-newer"),
+    )
+
+    paired = iwp.slim_pairing_for_artifact(_artifact(), _host(), "cpu")
+    assert paired is not None and paired[0] != bin_dir

--- a/studio/backend/tests/test_whisper_slim_local_llama.py
+++ b/studio/backend/tests/test_whisper_slim_local_llama.py
@@ -97,9 +97,7 @@ def test_local_llama_missing_soname_still_rejects(monkeypatch, tmp_path):
 def test_local_llama_missing_backend_module_still_rejects(monkeypatch, tmp_path):
     # All sonames present, but the cuda module glob finds nothing: a cpu-only
     # source build cannot back the cuda pairing.
-    _link_local_tree(
-        monkeypatch, tmp_path, ["libggml.so", "libggml-base.so", "libggml-cpu.so"]
-    )
+    _link_local_tree(monkeypatch, tmp_path, ["libggml.so", "libggml-base.so", "libggml-cpu.so"])
 
     assert iwp.slim_pairing_for_artifact(_artifact(), _host(), "cuda") is None
 

--- a/studio/install_whisper_prebuilt.py
+++ b/studio/install_whisper_prebuilt.py
@@ -411,6 +411,25 @@ def _ships_windows_gpu_ggml_module(llama_bin_dir: Path) -> bool:
     return False
 
 
+def _local_unmanaged_llama_runtime() -> tuple[Path, str, str] | None:
+    """A llama runtime sitting at the canonical install location WITHOUT the
+    managed prebuilt marker: the --with-llama-cpp-dir shape, where setup links
+    a user-built tree into $UNSLOTH_HOME/llama.cpp. The tag is empty on
+    purpose — a source build carries no release tag — so tag-based pairing
+    refuses and callers must fall back to the per-file ABI gates
+    (requires_ggml_sonames, backend module glob), which is exactly what
+    slim_pairing_for_artifact does with it.
+    """
+    root = llama.default_managed_llama_dir()
+    bin_dir = root / "build" / "bin"
+    if os.name == "nt":
+        bin_dir = bin_dir / "Release"
+    if not bin_dir.is_dir():
+        return None
+    has_runtime = any(bin_dir.glob("libggml*")) or any(bin_dir.glob("ggml*.dll"))
+    return (bin_dir, "", "") if has_runtime else None
+
+
 def slim_pairing_for_artifact(
     artifact: dict[str, Any], host: HostInfo, backend: str
 ) -> tuple[Path, str] | None:
@@ -419,12 +438,23 @@ def slim_pairing_for_artifact(
     then retries via CPU or reports the prebuilt unavailable."""
     asset = artifact.get("asset")
     runtime = installed_llama_runtime()
+    unmanaged = False
+    if runtime is None:
+        runtime = _local_unmanaged_llama_runtime()
+        if runtime is not None:
+            # A --with-llama-cpp-dir tree: no release tag exists, so the tag
+            # heuristic cannot speak; the per-file ABI gates below decide.
+            unmanaged = True
+            log(
+                f"slim_selection: {asset}: no managed llama.cpp prebuilt marker; "
+                "pairing with the local llama.cpp runtime via the per-file ABI gates"
+            )
     if runtime is None:
         log(f"slim_selection: {asset} skipped: no managed llama.cpp prebuilt install")
         return None
     llama_bin_dir, llama_tag, _profile = runtime
     requires_tag = artifact.get("requires_llama_tag")
-    if not llama_runtime_pairs(
+    if not unmanaged and not llama_runtime_pairs(
         llama_tag,
         requires_tag,
         installed_ggml_tree = installed_llama_ggml_tree(),
@@ -937,11 +967,16 @@ def selection_from_artifact(
     # A slim selection carries its pairing so the install wiring and marker know
     # which llama runtime provides the ggml libraries.
     runtime = installed_llama_runtime()
-    if runtime is None or not llama_runtime_pairs(
-        runtime[1],
-        artifact.get("requires_llama_tag"),
-        installed_ggml_tree = installed_llama_ggml_tree(),
-        required_ggml_tree = artifact.get("requires_ggml_tree"),
+    if runtime is None:
+        runtime = _local_unmanaged_llama_runtime()
+    if runtime is None or (
+        runtime[1]
+        and not llama_runtime_pairs(
+            runtime[1],
+            artifact.get("requires_llama_tag"),
+            installed_ggml_tree = installed_llama_ggml_tree(),
+            required_ggml_tree = artifact.get("requires_ggml_tree"),
+        )
     ):
         raise PrebuiltFallback(
             "the paired llama.cpp runtime changed underneath the slim whisper selection"


### PR DESCRIPTION
Fixes #9179.

## What happened

`--with-llama-cpp-dir` links a user-built llama.cpp tree into the canonical install location **without** the managed prebuilt marker, so `installed_llama_runtime()` returned `None` and every slim whisper artifact skipped pairing — `slim_selection: ... skipped: no managed llama.cpp prebuilt install`. Current releases publish **slim bundles only** (the fat selection chain was deleted with the fat bundles), so there was no fallback asset and whisper.cpp failed to install outright: `prebuilt install failed: no whisper.cpp prebuilt asset`.

## The fix

A llama runtime found at the canonical location (`build/bin`, `build/bin/Release` on Windows, with ggml libraries present) but **without** the marker — exactly the `--with-llama-cpp-dir` shape — is now accepted for pairing with an empty release tag. A source build carries no tag, so the tag heuristic cannot speak; the per-file ABI gates the module already documents as authoritative decide:

- `requires_ggml_sonames` presence (a missing soname still rejects),
- the backend module glob (a cpu-only tree still cannot back a cuda pairing; the existing cpu-retry path applies),
- the Windows libomp filter unchanged.

The managed marker keeps priority when both exist, and the finalize gate re-validates the same way at install time (empty tag → ABI gates only).

## Testing

New `tests/test_whisper_slim_local_llama.py` (5 cases): unmanaged tree pairs via the ABI gates while the tag heuristic alone refuses; missing soname rejects; missing backend module rejects; no tree at all still reports no managed install; managed runtime wins over a coexisting local tree. 5/5 plus the whisper regression suites (`checksums`, `freshness`, `combined_update`) 45/45 locally.