### PR TITLE
Drain the sampling suites on the store's write chains, not on node's loader

### DIFF
--- a/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
+++ b/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
@@ -1397,6 +1397,30 @@ export async function awaitThreadScopedSettingsWrite(
   return landed !== false;
 }
 
+/**
+ * Every row write that has already been started, landed.
+ *
+ * Not a flush: a debounce that has not fired yet is left where it is, so a caller cannot
+ * use this to make a write happen earlier than the store would have. It is for a caller
+ * that has just let the debounce fire and now needs the rows before it reads them back,
+ * and does not know which chats the store decided to write.
+ *
+ * The chain a write runs on ends in `await import("../utils/chat-history-storage")`. How
+ * many event-loop turns that costs is a property of the machine -- the specifier has no
+ * extension, so it resolves through a hook, which means filesystem work under a test
+ * runner and a chunk fetch in a browser. A caller that instead spins a fixed number of
+ * turns, or races the loader with an import of its own, is asserting something about the
+ * machine rather than about the store. Awaiting the chains asserts the thing itself.
+ */
+export async function awaitStartedThreadScopedSettingsWrites(): Promise<void> {
+  // A chain that settles can leave a newer one behind it for the same chat, so this
+  // repeats until the map is empty rather than awaiting one snapshot of it. Bounded, so a
+  // write that keeps rescheduling itself surfaces as a failed assertion, not as a hang.
+  for (let pass = 0; pass < 20 && threadSettingsWriteChains.size > 0; pass += 1) {
+    await Promise.allSettled([...threadSettingsWriteChains.values()]);
+  }
+}
+
 function flushThreadScopedSettingsWrite(keepalive = false): void {
   if (threadSettingsWriteTimer !== null) {
     clearTimeout(threadSettingsWriteTimer);

--- a/studio/frontend/tests/helpers/mock-timer-drain.ts
+++ b/studio/frontend/tests/helpers/mock-timer-drain.ts
@@ -64,6 +64,8 @@ const MICROTASK_TURNS = 6;
 const QUIET_ROUNDS = 3;
 /** Backstop only. Reaching it is a failure, not the normal exit. */
 const MAX_ROUNDS = 600;
+/** Which turn of a round awaits the caller's barrier, once this tick's callbacks have run. */
+const BARRIER_AFTER_TURN = 2;
 
 /** Set on the wrapper so a second enable() in the same test is not double-wrapped, and so
  * a drain can tell it is looking at a counted setTimeout rather than a raw mocked one.
@@ -168,32 +170,30 @@ export function enableCountedTimers(t: TestContext): (ms: number) => void {
   return (ms: number) => t.mock.timers.tick(ms);
 }
 
-/** Which turn of a round waits out the module loader; see probeModuleLoader. */
-const LOADER_PROBE_AFTER_TURN = 2;
-
 /**
- * Wait for the module loader to come back, so that a dynamic import the code under test
- * issued earlier in this round has settled by the time the round is judged quiet.
+ * Wait out the work that has no timer behind it.
  *
  * The store's thread-scoped write ends in `await import("../utils/chat-history-storage")`,
  * and these suites `register()` a resolver hook, which puts that import on the hooks
- * thread. That round trip is the second kind of pending work here, and unlike a debounce it
- * has no timer to count: on v24 it settles in ONE macrotask turn, but measured on v22.23.2
- * with a hook registered, three repeat imports of an already-loaded module settled in 6, 3
- * and 35 turns. That is the whole node-24-green / node-22-red split, and the reason a
- * Windows runner under load fails what the same commit passed an hour earlier: the pending
- * work is a message to another thread, so its cost is scheduling latency, not instructions.
+ * thread. That is the second kind of pending work here, and unlike a debounce it has no
+ * timer to count: on v24 it settles in ONE macrotask turn, but measured on v22.23.2 with a
+ * hook registered, three repeat imports of an already-loaded module settled in 6, 3 and 35
+ * turns. That is the whole node-24-green / node-22-red split, and the reason a Windows
+ * runner under load fails what the same commit passed an hour earlier: the pending work is
+ * a message to another thread, so its cost is scheduling latency, not instructions.
  *
- * Issuing our own import is what turns that into something to wait ON. The hooks thread
- * serves one request at a time and replies over the same port, so a reply to a request
- * issued after the store's arrives after it: when this resolves, the store's import has
- * resolved too and its continuation is at most a turn behind, which the rest of the round
- * covers. Re-importing this module rather than some marker file keeps it honest -- it is
- * certainly loaded, and it goes through the same registered hooks the store's import does.
+ * The caller supplies the wait, because only the caller knows what its subject has
+ * outstanding. For the sampling suites that is the store's own
+ * `awaitStartedThreadScopedSettingsWrites`, which awaits the write chains themselves.
+ *
+ * An earlier version of this raced the loader instead, by issuing an import of its own each
+ * round and assuming the hooks thread serves requests in order, so a reply to a later
+ * request could not arrive first. It worked, and it is still the wrong thing to assert: it
+ * is a claim about node's loader internals standing in for a claim about the store, and if
+ * that ordering ever fails it fails as a stale read again rather than as a throw. A barrier
+ * on the actual chains has no such assumption behind it.
  */
-function probeModuleLoader(): Promise<unknown> {
-  return import(import.meta.url);
-}
+export type Barrier = () => Promise<unknown>;
 
 /** Debounce timers scheduled and not yet fired or cleared. */
 export function pendingTimerCount(): number {
@@ -203,6 +203,8 @@ export function pendingTimerCount(): number {
 }
 
 export interface DrainOptions {
+  /** Awaited each round, for pending work that has no timer to count. See Barrier. */
+  barrier?: Barrier;
   /** An extra condition the caller needs true before the drain may return. Quiescence is
    * still required with it: a condition that flips mid-chain must not cut the rest off. */
   until?: () => boolean;
@@ -222,7 +224,7 @@ export async function drainMockedTimers(
   tick: (ms: number) => void,
   options: DrainOptions = {},
 ): Promise<void> {
-  const { until, label = "drain", maxRounds = MAX_ROUNDS } = options;
+  const { until, barrier, label = "drain", maxRounds = MAX_ROUNDS } = options;
   const state = counter;
   if (countedSetTimeout() === null || state === null) {
     throw new Error(
@@ -237,9 +239,9 @@ export async function drainMockedTimers(
     tick(TICK_MS);
     for (let turn = 0; turn < MICROTASK_TURNS; turn += 1) {
       await new Promise((resolve) => setImmediate(resolve));
-      // Half way through the round, once the timer callbacks fired by the tick have had a
-      // turn to issue their own import, wait out the loader with them.
-      if (turn === LOADER_PROBE_AFTER_TURN) await probeModuleLoader();
+      // After the timer callbacks fired by this tick have had a turn to start their work,
+      // wait for that work rather than for a number of turns.
+      if (turn === BARRIER_AFTER_TURN && barrier !== undefined) await barrier();
     }
     quiet =
       state.outstanding === 0 && state.activity === activityBefore

--- a/studio/frontend/tests/helpers/thread-sampling-world.ts
+++ b/studio/frontend/tests/helpers/thread-sampling-world.ts
@@ -135,20 +135,25 @@ interface StoreModule {
     };
   };
   beginThreadScopedPairing: (threadId: string) => void;
+  awaitStartedThreadScopedSettingsWrites: () => Promise<void>;
 }
 
 /** Let the debounced writers and their promise chains finish.
  *
- * On the store's own pending timers and on the module loader, not on a round count: a scenario whose write has not
- * landed yet looks exactly like one that wrote the wrong value, so an under-drain here
+ * On the store's own pending timers and its own write chains, not on a round count: a
+ * scenario whose write has not landed yet looks exactly like one that wrote the wrong
+ * value, so an under-drain here
  * surfaces as an ORDERING violation ("chat A temperature: owed 0.6, shows 1.37") and sends
  * the reader into the store instead of into the wait. drainMockedTimers throws when it
  * gives up, which is the whole point of it; see tests/helpers/mock-timer-drain.ts for the
  * measurements that killed the fixed count and for the observable NOT to drain on.
  *
  * The caller must have enabled the clock with enableCountedTimers(t). */
-async function drain(tick: (ms: number) => void): Promise<void> {
-  await drainMockedTimers(tick, { label: "runScenario drain" });
+async function drain(mod: StoreModule, tick: (ms: number) => void): Promise<void> {
+  await drainMockedTimers(tick, {
+    label: "runScenario drain",
+    barrier: () => mod.awaitStartedThreadScopedSettingsWrites(),
+  });
 }
 
 /**
@@ -421,7 +426,7 @@ export async function runScenario(
 
   for (const op of ops) {
     await perform(op);
-    await drain(tick);
+    await drain(mod, tick);
     check(op);
     if (violations.length > 0) break;
   }

--- a/studio/frontend/tests/thread-scoped-sampling-compat.test.ts
+++ b/studio/frontend/tests/thread-scoped-sampling-compat.test.ts
@@ -130,10 +130,15 @@ async function world(rows: Record<string, Record<string, unknown>> = {}) {
 // a dev box's node 24 and failed on the node 22 CI pins, and every count picked since has
 // been a guess that fails silently in one direction. See tests/helpers/mock-timer-drain.ts.
 async function settle(
+  mod: { awaitStartedThreadScopedSettingsWrites: () => Promise<void> },
   tick: (ms: number) => void,
   until?: () => boolean,
 ): Promise<void> {
-  await drainMockedTimers(tick, { until, label: "settle" });
+  await drainMockedTimers(tick, {
+    until,
+    label: "settle",
+    barrier: () => mod.awaitStartedThreadScopedSettingsWrites(),
+  });
 }
 
 function assertUsable(sampling: Record<string, unknown>, where: string): void {
@@ -158,10 +163,10 @@ function assertUsable(sampling: Record<string, unknown>, where: string): void {
 test("C1: a legacy row opens on the installation sampling, and nothing is zeroed", async (t) => {
   enableCountedTimers(t);
   const w = await world({ L: { ...LEGACY_ROW } });
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
 
   w.open("L");
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
 
   assertUsable(w.sampling(), "legacy open");
   // the installation's values, since the row says nothing about sampling
@@ -182,9 +187,9 @@ test("C1: a legacy row opens on the installation sampling, and nothing is zeroed
 test("C1b: a legacy chat follows the installation defaults, which a model load moves", async (t) => {
   enableCountedTimers(t);
   const w = await world({ L: { ...LEGACY_ROW } });
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
   w.open("L");
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
   const onFirstVisit = w.sampling();
   assert.equal(onFirstVisit.temperature, INSTALLATION.temperature);
 
@@ -198,13 +203,13 @@ test("C1b: a legacy chat follows the installation defaults, which a model load m
     },
     { fromModelDefaults: true },
   );
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
   // the chat pinned nothing, so it takes the model's values, as it did before this
   assert.equal(w.store().params.temperature, 0.31);
 
   w.open("Z");
   w.open("L");
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
   const onSecondVisit = w.sampling();
   assertUsable(onSecondVisit, "legacy reopen");
   // OBSERVED: the reopened legacy chat shows the model's sampling. It stored none, so the
@@ -218,10 +223,10 @@ test("C1b: a legacy chat follows the installation defaults, which a model load m
 test("C1c: a legacy chat that the user then edits pins the WHOLE set, not just the edit", async (t) => {
   enableCountedTimers(t);
   const w = await world({ L: { ...LEGACY_ROW } });
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
   w.open("L");
   w.store().setParams({ ...w.store().params, temperature: 1.37 });
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
 
   // The write for a chat that already had a snapshot is a full replacement built from the
   // store, so all seven other keys are pinned too and the chat stops drifting.
@@ -244,7 +249,7 @@ test("C1c: a legacy chat that the user then edits pins the WHOLE set, not just t
     },
     { fromModelDefaults: true },
   );
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
   assert.equal(w.store().params.temperature, 1.37);
 });
 
@@ -256,9 +261,9 @@ test("C2: an empty, null or absent snapshot opens on the installation settings",
   enableCountedTimers(t);
   for (const snapshot of [null, {}, undefined]) {
     const w = await world();
-    await settle((ms) => t.mock.timers.tick(ms));
+    await settle(w.mod, (ms) => t.mock.timers.tick(ms));
     w.open("E", snapshot === undefined ? null : snapshot);
-    await settle((ms) => t.mock.timers.tick(ms));
+    await settle(w.mod, (ms) => t.mock.timers.tick(ms));
     const where = `snapshot ${JSON.stringify(snapshot ?? null)}`;
     assertUsable(w.sampling(), where);
     assert.deepEqual(w.sampling(), INSTALLATION, where);
@@ -393,9 +398,9 @@ test("C3d: a NaN or Infinity in a row cannot reach the store", async (t) => {
       systemPrompt: null,
     },
   });
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
   w.open("N");
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
   assertUsable(w.sampling(), "NaN row");
   assert.deepEqual(w.sampling(), INSTALLATION);
 });
@@ -406,16 +411,16 @@ test("C3d: a NaN or Infinity in a row cannot reach the store", async (t) => {
 test("C3e: an out-of-range recommendation never reaches a chat that pinned that key", async (t) => {
   enableCountedTimers(t);
   const w = await world();
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
   w.open("A");
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
 
   w.store().setParams(
     { ...w.store().params, topP: 1.2, checkpoint: "unsloth/Llasa-3B" },
     { fromModelDefaults: true },
   );
   w.store().setParams({ ...w.store().params, temperature: 1.37 });
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
 
   // A pinned every key when it opened, so it keeps its own in-range value. Pinning on open
   // is what makes this safe: an unpinned chat has nothing to put back.
@@ -426,7 +431,7 @@ test("C3e: an out-of-range recommendation never reaches a chat that pinned that 
 
   w.open("Z");
   w.open("A");
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
   assertUsable(w.sampling(), "after an out-of-range recommendation");
   assert.equal(w.store().params.temperature, 1.37);
   assert.equal(w.store().params.topP, INSTALLATION.topP);
@@ -435,14 +440,14 @@ test("C3e: an out-of-range recommendation never reaches a chat that pinned that 
 test("C3f: an out-of-range recommendation taken with no chat open cannot be pinned", async (t) => {
   enableCountedTimers(t);
   const w = await world();
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
 
   // no chat open, so nothing puts an in-range value back
   w.store().setParams(
     { ...w.store().params, topP: 1.2, checkpoint: "unsloth/Llasa-3B" },
     { fromModelDefaults: true },
   );
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
   // OBSERVED: the live params run it, and it reaches the installation settings, which
   // have no such bound. Only the per-chat row does.
   assert.equal(w.store().params.topP, 1.2);
@@ -451,7 +456,7 @@ test("C3f: an out-of-range recommendation taken with no chat open cannot be pinn
   // a chat opened on it pins what it can, omitting topP rather than sending a body the
   // PATCH would refuse whole, which would cost the chat all seven other keys
   w.open("A");
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
   const row = threadRows.rows.get("A") as Record<string, unknown>;
   assert.equal(row.topP, undefined);
   assert.equal(row.temperature, INSTALLATION.temperature);
@@ -497,10 +502,10 @@ test("C4b: a falsy edit round-trips capture -> persist -> restore", async (t) =>
   for (const topK of [-1, 0]) {
     const edge = { ...FALSY_EDGE, topK };
     const w = await world();
-    await settle((ms) => t.mock.timers.tick(ms));
+    await settle(w.mod, (ms) => t.mock.timers.tick(ms));
     w.open("A");
     w.store().setParams({ ...w.store().params, ...edge });
-    await settle((ms) => t.mock.timers.tick(ms));
+    await settle(w.mod, (ms) => t.mock.timers.tick(ms));
 
     // captured onto the chat, whole
     const row = threadRows.rows.get("A") as Record<string, unknown>;
@@ -512,12 +517,12 @@ test("C4b: a falsy edit round-trips capture -> persist -> restore", async (t) =>
 
     // another chat opens on the installation values, untouched by any of it
     w.open("B");
-    await settle((ms) => t.mock.timers.tick(ms));
+    await settle(w.mod, (ms) => t.mock.timers.tick(ms));
     assert.deepEqual(w.sampling(), INSTALLATION, `topK ${topK}: B inherited A`);
 
     // and A gets all of it back
     w.open("A");
-    await settle((ms) => t.mock.timers.tick(ms));
+    await settle(w.mod, (ms) => t.mock.timers.tick(ms));
     assert.deepEqual(
       w.sampling(),
       edge,
@@ -529,10 +534,10 @@ test("C4b: a falsy edit round-trips capture -> persist -> restore", async (t) =>
 test("C4c: a falsy pinned value survives a model load and a model switch", async (t) => {
   enableCountedTimers(t);
   const w = await world();
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
   w.open("A");
   w.store().setParams({ ...w.store().params, ...FALSY_EDGE });
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
 
   // a load with a full, non-falsy recommendation
   w.store().setParams(
@@ -548,12 +553,12 @@ test("C4c: a falsy pinned value survives a model load and a model switch", async
     },
     { fromModelDefaults: true },
   );
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
   assert.deepEqual(w.sampling(), FALSY_EDGE, "the load overwrote a falsy pin");
 
   // and an external switch, which has no load after it to put anything back
   w.store().setCheckpoint("external::anthropic::claude-opus-5", null);
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
   assert.deepEqual(
     w.sampling(),
     FALSY_EDGE,
@@ -568,24 +573,24 @@ test("C4c: a falsy pinned value survives a model load and a model switch", async
 test("C4d: an empty system prompt is a choice, not an absent one", async (t) => {
   enableCountedTimers(t);
   const w = await world();
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
   // A is given a prompt, B is deliberately cleared
   w.open("A");
   w.store().setParams({ ...w.store().params, systemPrompt: "A's prompt" });
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
   w.open("B");
   w.store().setParams({ ...w.store().params, systemPrompt: "" });
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
 
   assert.equal(
     (threadRows.rows.get("B") as Record<string, unknown>).systemPrompt,
     "",
   );
   w.open("A");
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
   assert.equal(w.store().params.systemPrompt, "A's prompt");
   w.open("B");
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
   assert.equal(
     w.store().params.systemPrompt,
     "",
@@ -609,10 +614,10 @@ test("C5: a one-megabyte system prompt is neither truncated nor fatal", async (t
   );
 
   const w = await world();
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
   w.open("A");
   w.store().setParams({ ...w.store().params, systemPrompt: huge });
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
 
   const row = threadRows.rows.get("A") as Record<string, unknown>;
   assert.equal((row.systemPrompt as string).length, huge.length);
@@ -620,10 +625,10 @@ test("C5: a one-megabyte system prompt is neither truncated nor fatal", async (t
 
   // and back again after a visit elsewhere
   w.open("B");
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
   assert.equal(w.store().params.systemPrompt, INSTALLATION.systemPrompt);
   w.open("A");
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
   assert.equal((w.store().params.systemPrompt as string).length, huge.length);
   // and it stayed the chat's: a megabyte in the installation payload would be sent
   // on every settings write for the rest of the session

--- a/studio/frontend/tests/thread-scoped-sampling-simulation.test.ts
+++ b/studio/frontend/tests/thread-scoped-sampling-simulation.test.ts
@@ -385,10 +385,15 @@ async function raceWorld() {
 // wrong-value failure; see tests/helpers/mock-timer-drain.ts for why a count was never the
 // right bound.
 async function settle(
+  mod: { awaitStartedThreadScopedSettingsWrites: () => Promise<void> },
   tick: (ms: number) => void,
   until?: () => boolean,
 ): Promise<void> {
-  await drainMockedTimers(tick, { until, label: "settle" });
+  await drainMockedTimers(tick, {
+    until,
+    label: "settle",
+    barrier: () => mod.awaitStartedThreadScopedSettingsWrites(),
+  });
 }
 
 test("B1: a slider moved while /api/chat/settings is still in flight survives it", async (t) => {
@@ -399,7 +404,7 @@ test("B1: a slider moved while /api/chat/settings is still in flight survives it
   w.store().setParams({ ...w.store().params, temperature: 1.42 });
   settingsHttp.release?.();
   await hydrating;
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
   assert.equal(
     w.store().params.temperature,
     1.42,
@@ -413,7 +418,7 @@ test("B2: an edit made while the chat's own read is out is stored on that chat",
   enableCountedTimers(t);
   const w = await raceWorld();
   await w.store().hydratePersistedSettings();
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
   settingsHttp.puts.length = 0;
 
   w.beginOpen("A");
@@ -424,7 +429,7 @@ test("B2: an edit made while the chat's own read is out is stored on that chat",
     systemPrompt: "HELD EDIT 5f3a",
   });
   w.finishOpen("A", { temperature: 0.22, topP: 0.33, systemPrompt: "STORED" });
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
 
   // the held edit wins over what the read brought back
   assert.equal(w.store().params.temperature, 1.37);
@@ -443,7 +448,7 @@ test("B3: leaving mid-read sends the held edit to its own chat, not the next one
   enableCountedTimers(t);
   const w = await raceWorld();
   await w.store().hydratePersistedSettings();
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
   settingsHttp.puts.length = 0;
 
   w.beginOpen("A");
@@ -455,7 +460,7 @@ test("B3: leaving mid-read sends the held edit to its own chat, not the next one
   // the user gives up on A and opens B before A's read lands
   await w.mod.commitHeldThreadScopedEditsToTheirThread();
   w.open("B");
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
 
   // A's row carries the edit as a merge, leaving the rest of its snapshot alone
   const merged = threadRows
@@ -480,7 +485,7 @@ test("B4: a model load landing during the pairing window does not take the chat'
   enableCountedTimers(t);
   const w = await raceWorld();
   await w.store().hydratePersistedSettings();
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
   settingsHttp.puts.length = 0;
 
   w.beginOpen("A");
@@ -491,7 +496,7 @@ test("B4: a model load landing during the pairing window does not take the chat'
     { fromModelDefaults: true },
   );
   w.finishOpen("A", null);
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
 
   assert.equal(w.store().params.temperature, 1.37, "the load took the edit");
   // and the chat was pinned with the user's value, not the one the load published
@@ -513,7 +518,7 @@ test("B4b: the held sampling edit that survives a load is the LAST one made", as
   enableCountedTimers(t);
   const w = await raceWorld();
   await w.store().hydratePersistedSettings();
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
 
   w.beginOpen("A");
   // a slider dragged twice, then the load, then the read
@@ -524,7 +529,7 @@ test("B4b: the held sampling edit that survives a load is the LAST one made", as
     { fromModelDefaults: true },
   );
   w.finishOpen("A", null);
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
   assert.equal(w.store().params.temperature, 1.37);
 });
 
@@ -532,7 +537,7 @@ test("B4c: a falsy held edit is not treated as no edit at all", async (t) => {
   enableCountedTimers(t);
   const w = await raceWorld();
   await w.store().hydratePersistedSettings();
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
 
   w.beginOpen("A");
   // 0, "" and -1 are all deliberate choices, and all falsy or negative
@@ -548,7 +553,7 @@ test("B4c: a falsy held edit is not treated as no edit at all", async (t) => {
     { fromModelDefaults: true },
   );
   w.finishOpen("A", null);
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
 
   const params = w.store().params;
   assert.equal(params.temperature, 0);
@@ -566,20 +571,20 @@ test("B5: two rapid model switches with a pinned chat open", async (t) => {
   enableCountedTimers(t);
   const w = await raceWorld();
   await w.store().hydratePersistedSettings();
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
   w.open("A");
   w.store().setParams({
     ...w.store().params,
     temperature: 1.37,
     systemPrompt: "CHAT A ONLY 5f3a",
   });
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
   settingsHttp.puts.length = 0;
 
   // no settle between them: the second switch lands while the first is still writing
   w.store().setCheckpoint(LLAMA, null);
   w.store().setCheckpoint(EXTERNAL, null);
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
 
   assert.equal(w.store().params.temperature, 1.37);
   assert.equal(w.store().params.systemPrompt, "CHAT A ONLY 5f3a");
@@ -601,10 +606,10 @@ test("B6: a thread switch while a load is in flight keeps each chat's own values
   enableCountedTimers(t);
   const w = await raceWorld();
   await w.store().hydratePersistedSettings();
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
   w.open("A");
   w.store().setParams({ ...w.store().params, temperature: 1.37 });
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
 
   // the user opens B, and the load that was started in A finishes into B
   w.beginOpen("B");
@@ -613,7 +618,7 @@ test("B6: a thread switch while a load is in flight keeps each chat's own values
     { fromModelDefaults: true },
   );
   w.finishOpen("B", null);
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
   assert.notEqual(
     w.store().params.temperature,
     1.37,
@@ -621,7 +626,7 @@ test("B6: a thread switch while a load is in flight keeps each chat's own values
   );
 
   w.open("A");
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
   assert.equal(w.store().params.temperature, 1.37, "A lost its temperature");
 });
 
@@ -629,7 +634,7 @@ test("B7: a tab closing with a held edit beacons it to the chat it was made in",
   enableCountedTimers(t);
   const w = await raceWorld();
   await w.store().hydratePersistedSettings();
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
   settingsHttp.puts.length = 0;
 
   w.beginOpen("A");
@@ -641,7 +646,7 @@ test("B7: a tab closing with a held edit beacons it to the chat it was made in",
   // pagehide, which is what the store listens on; the read never landed
   const delivered = fireWindowEvent("pagehide", {});
   assert.ok(delivered > 0, "the store is not listening for the terminal event");
-  await settle((ms) => t.mock.timers.tick(ms));
+  await settle(w.mod, (ms) => t.mock.timers.tick(ms));
 
   // The beacon is a PATCH, so it is not in `puts`; what it queued for replay is the
   // durable record of what the closing tab tried to save, and for which chat.


### PR DESCRIPTION
Drain the sampling suites on the store's write chains, not on node's loader

#9332 fixed these suites by waiting on two observables: the mocked timers, which
it counts exactly, and the module loader, which it raced by issuing an import of
its own each round. The second one works and is still the wrong thing to assert.

The loader probe rests on an assumption about node internals that I recorded in
the comment and never verified: that the hooks thread serves requests in order
over one port, so a reply to a request issued after the store's cannot arrive
first. If that ever stops holding it fails as a stale read, which is precisely
the failure mode #9332 existed to abolish -- a wait that comes up short reports
"chat A minP: owed 0, shows 0.01" and sends the next reader into the store.

The store already tracks the thing worth waiting on. threadSettingsWriteChains
holds the live promise chain per thread, and awaitThreadScopedSettingsWrite
already awaits one of them by id. What a drain needs is all of the started ones,
without knowing which chats the store decided to write, so this adds
awaitStartedThreadScopedSettingsWrites.

It is deliberately not a flush. A debounce that has not fired yet is left alone,
so a caller cannot use it to make a write happen earlier than the store would
have; that would let a test pass against a store that never scheduled the write
at all. It is bounded at 20 passes rather than looping until the map empties, so
a write that keeps rescheduling itself surfaces as a failed assertion instead of
a hang. It repeats rather than awaiting one snapshot because a chain that settles
can leave a newer one behind it for the same chat.

drainMockedTimers now takes that as a caller-supplied `barrier` instead of
carrying its own loader probe. The timer counting is unchanged, and so is the
exhaustion throw, which is the property that keeps an under-drain from ever again
looking like a lost edit.

The approach is the one from #9352, which I opened against the same bug in
parallel and is closed in favour of this. #9332's mechanism landed first and
turned Windows green; this replaces the part of it that was a guess about the
runtime with a measurement of the subject.

Verified
------------------------------------------------------------------------
Both suites twice on v24.14.0 and twice on v22.23.2, the version setup-node 22
resolves to: compat 16 passed, simulation 18 passed, every run. Full frontend
suite 4080 passed, 0 failed.

Mutation-tested on v22.23.2, which is the only runtime where this is observable:
disabling the barrier and leaving the timer counting in place gives 8 failed, 10
passed. So the barrier is carrying the load, not decorating a wait that already
worked.
