### PR TITLE
Studio: carry a restated instruction once, not eight times

### DIFF
--- a/studio/backend/core/inference/checkpoint.py
+++ b/studio/backend/core/inference/checkpoint.py
@@ -142,10 +142,9 @@ def carried_forward_items(
             continue
         item = _neutralise(text)
         if item in seen:
-            # Users restate a standing rule, and every copy after the first cost a slot
-            # out of eight: one rule repeated eight times carried eight copies and pushed
-            # the user's other rule out. Skipped before the cost is charged, so a repeat
-            # cannot exhaust the budget either.
+            # Users restate a standing rule, and each copy used to take a slot out of
+            # eight: one rule repeated eight times crowded out the user's other rule.
+            # Checked before the cost is charged, so a repeat cannot exhaust the budget.
             continue
         cost = estimate_message_tokens(head)
         if spent + cost > max_tokens:

--- a/studio/backend/core/inference/checkpoint.py
+++ b/studio/backend/core/inference/checkpoint.py
@@ -123,10 +123,14 @@ def carried_forward_items(
     reversed for rendering, because reading order decides which of two conflicting
     instructions the model treats as current. Instructions older than the budget are
     silently dropped, which is why `max_items` is small and the header says "lossy".
+
+    Repeats are collapsed to their newest copy, on the same rule and the same key
+    `_recap` uses for the merged list.
     """
     if not evicted or max_tokens <= 0 or max_items <= 0:
         return []
     chosen: list[str] = []
+    seen: set[str] = set()
     spent = 0
     for group in reversed(group_turns(evicted)):
         if len(chosen) >= max_items:
@@ -137,12 +141,22 @@ def carried_forward_items(
         text = _text_of(head).strip()
         if not text:
             continue
+        item = _neutralise(text)
+        if item in seen:
+            # Restating a standing rule is ordinary, and every copy after the first buys
+            # nothing while costing a slot out of eight and its tokens out of a budget
+            # that is a tenth of the prompt. Measured: a thread whose user restated one
+            # rule eight times and gave one other rule carried eight copies of the first
+            # and dropped the second entirely. Skipped BEFORE the cost is charged, so a
+            # repeat cannot exhaust the budget either.
+            continue
         cost = estimate_message_tokens(head)
         if spent + cost > max_tokens:
             # Skipped, not truncated, and the loop continues: an older instruction that
             # still fits beats nothing.
             continue
-        chosen.append(_neutralise(text))
+        chosen.append(item)
+        seen.add(item)
         spent += cost
     return list(reversed(chosen))
 

--- a/studio/backend/core/inference/checkpoint.py
+++ b/studio/backend/core/inference/checkpoint.py
@@ -124,8 +124,7 @@ def carried_forward_items(
     instructions the model treats as current. Instructions older than the budget are
     silently dropped, which is why `max_items` is small and the header says "lossy".
 
-    Repeats are collapsed to their newest copy, on the same rule and the same key
-    `_recap` uses for the merged list.
+    Repeats collapse to their newest copy, on the same key `_recap` uses.
     """
     if not evicted or max_tokens <= 0 or max_items <= 0:
         return []
@@ -143,12 +142,10 @@ def carried_forward_items(
             continue
         item = _neutralise(text)
         if item in seen:
-            # Restating a standing rule is ordinary, and every copy after the first buys
-            # nothing while costing a slot out of eight and its tokens out of a budget
-            # that is a tenth of the prompt. Measured: a thread whose user restated one
-            # rule eight times and gave one other rule carried eight copies of the first
-            # and dropped the second entirely. Skipped BEFORE the cost is charged, so a
-            # repeat cannot exhaust the budget either.
+            # Users restate a standing rule, and every copy after the first cost a slot
+            # out of eight: one rule repeated eight times carried eight copies and pushed
+            # the user's other rule out. Skipped before the cost is charged, so a repeat
+            # cannot exhaust the budget either.
             continue
         cost = estimate_message_tokens(head)
         if spent + cost > max_tokens:

--- a/studio/backend/tests/test_checkpoint_compaction.py
+++ b/studio/backend/tests/test_checkpoint_compaction.py
@@ -409,13 +409,11 @@ def test_at_most_max_items_instructions_are_carried():
 
 
 def test_a_restated_instruction_does_not_crowd_out_every_other_rule():
-    """Users restate a standing rule; each copy used to take a slot and its tokens.
+    """Users restate a standing rule, and each copy used to take a slot and its tokens.
 
-    Eight slots and a budget a tenth of the prompt is not much to spend on one rule
-    repeated, and what it costs is the OTHER rules: with the repeats counted, the second
-    instruction here fell off the end of the list entirely. `_recap` already collapsed
-    duplicates when it merged a block on the second reset, so this was the one path where
-    a duplicate survived, and the two disagreed about the same thread.
+    What that costs is the OTHER rules: with the repeats counted, the second instruction
+    here fell off the end of the list entirely. `_recap` already collapsed duplicates when
+    it merged a block on the second reset, so the two paths disagreed about one thread.
     """
     rule = (
         "Standing instruction: always end every reply with STATUS::ZQXVARA123-ALPHA "

--- a/studio/backend/tests/test_checkpoint_compaction.py
+++ b/studio/backend/tests/test_checkpoint_compaction.py
@@ -408,6 +408,36 @@ def test_at_most_max_items_instructions_are_carried():
     assert "number 19" in items[-1]
 
 
+def test_a_restated_instruction_does_not_crowd_out_every_other_rule():
+    """Users restate a standing rule; each copy used to take a slot and its tokens.
+
+    Eight slots and a budget a tenth of the prompt is not much to spend on one rule
+    repeated, and what it costs is the OTHER rules: with the repeats counted, the second
+    instruction here fell off the end of the list entirely. `_recap` already collapsed
+    duplicates when it merged a block on the second reset, so this was the one path where
+    a duplicate survived, and the two disagreed about the same thread.
+    """
+    rule = (
+        "Standing instruction: always end every reply with STATUS::ZQXVARA123-ALPHA "
+        "and report any results as a markdown table."
+    )
+    other = (
+        "Second standing rule: cite the section number in every answer, spelled out in "
+        "words rather than digits, and never abbreviate it."
+    )
+    evicted = [{"role": "user", "content": other}, {"role": "assistant", "content": "ok"}]
+    for _ in range(8):
+        evicted += [
+            {"role": "user", "content": rule},
+            {"role": "assistant", "content": "ok"},
+        ]
+
+    items = carried_forward_items(evicted, max_tokens = 1024)
+
+    assert sum(1 for item in items if item.startswith("Standing instruction")) == 1
+    assert any(item.startswith("Second standing rule") for item in items)
+
+
 def test_a_process_with_tools_disabled_never_resets(monkeypatch):
     """`supports_tools` is the TEMPLATE's capability, not "this request gets the tool".
 


### PR DESCRIPTION
### What this fixes

`carried_forward_items` builds the carried-forward block `X` that checkpoint compaction appends to the system turn after a reset. It walks the evicted turns newest-first and takes standing instructions until it hits `MAX_ITEMS` (8) or the token budget (`min(1024, 10% of the prompt budget)`), whichever comes first. It never checked whether it had already taken the same instruction.

Restating a standing rule is ordinary user behaviour, and each restatement was taking a slot and its tokens. Measured on a thread whose user restated one rule eight times and gave one other rule:

```
items carried: 8 of MAX_ITEMS 8
copies of the repeated rule: 8
distinct second rule present: False
```

The second rule falls off the end of the list entirely, so the reset carries one rule eight times and loses the other. It is still archived and still reachable through `search_conversation`, but the whole point of `X` is that the instructions in it do not need to be retrieved.

### Why it is a disagreement rather than just a miss

`_recap`, which re-applies the caps when a second reset merges an existing block with newly evicted turns, already dedupes on exactly this key with newest-wins ordering. So the two paths gave different answers for the same thread: the first reset carried the repeats and the second one silently dropped them. Feeding the eight-copy list above through `_recap` collapses it to a single item.

This change applies the same rule in the same place in the walk, using the same key (the neutralised item text). The check runs before the cost is charged, so a repeat cannot exhaust the budget on its way to being ignored either.

### Test

`test_a_restated_instruction_does_not_crowd_out_every_other_rule` fails on `main` with `assert 8 == 1` and passes here.

### Verification

`test_checkpoint_compaction`, `test_context_overflow_truncation`, `test_conversation_archive`, `test_conversation_recall_injection` and `test_llama_cpp_context_fit`: 387 passed (386 on `main`, plus the new one).

Found while re-verifying checkpoint compaction end to end on merged `main` against a live GGUF chat.
