### PR TITLE
Say which runtime components an AppImage is missing before its env hygiene

### DIFF
--- a/studio/src-tauri/linux/verify-complete-appimage.sh
+++ b/studio/src-tauri/linux/verify-complete-appimage.sh
@@ -32,6 +32,43 @@ fi
 [[ -d "$appdir" ]] || { echo "AppDir does not exist: $appdir" >&2; exit 1; }
 [[ -x "$appdir/AppRun" ]] || { echo "Complete AppImage has no executable AppRun" >&2; exit 1; }
 
+require_basename() {
+  local pattern="$1"
+  if ! find "$appdir" \( -type f -o -type l \) -name "$pattern" -print -quit | grep -q .; then
+    echo "Complete AppImage is missing required runtime component: $pattern" >&2
+    return 1
+  fi
+}
+
+# FIRST, before the launcher-hygiene checks below. Those ask whether a bundle that
+# ships a runtime scopes it correctly; this asks whether it ships one at all, and a
+# bundle that ships none fails them too -- for a reason that reads like an env-var
+# bug. A pre-#9113 thin AppImage, which resolves webkit2gtk from the host, reported
+# "does not clear an inherited LD_LIBRARY_PATH" and sent the reader after the wrong
+# defect; the honest answer is the soname list below.
+#
+# Report every miss rather than exiting on the first: the AppRun host-preflight
+# names all four missing sonames at once, and a verifier that names one per CI run
+# turns one diagnosis into as many red runs as there are absent components.
+missing_components=()
+required_components=()
+for component in \
+  'libglib-2.0.so*' 'libgobject-2.0.so*' 'libgio-2.0.so*' \
+  'libgtk-3.so*' 'libgdk-3.so*' 'libgdk_pixbuf-2.0.so*' \
+  'libwebkit2gtk-4.1.so*' 'libjavascriptcoregtk-4.1.so*' 'libsoup-3.0.so*' \
+  'libappindicator3.so*' 'WebKitNetworkProcess' 'WebKitWebProcess' \
+  'libwebkit2gtkinjectedbundle.so' \
+  'libgiognutls.so' \
+  'libgstcoreelements.so' 'libgstplayback.so' 'libgstpulseaudio.so' \
+  'libgstisomp4.so' 'libgstvideoparsersbad.so' 'libgstlibav.so' \
+  'gst-plugin-scanner'; do
+  required_components+=("$component")
+  require_basename "$component" || missing_components+=("$component")
+done
+if ((${#missing_components[@]} > 0)); then
+  echo "Complete AppImage is missing ${#missing_components[@]} of ${#required_components[@]} required runtime components; it resolves them from the host" >&2
+  exit 1
+fi
 
 launchers=("$appdir/AppRun")
 [[ ! -e "$appdir/AppRun.wrapped" ]] || launchers+=("$appdir/AppRun.wrapped")
@@ -94,27 +131,6 @@ machine="$(readelf -h "$binary" | sed -n 's/^[[:space:]]*Machine:[[:space:]]*//p
   echo "Complete AppImage has the wrong architecture: ${machine:-unknown}" >&2
   exit 1
 }
-
-require_basename() {
-  local pattern="$1"
-  if ! find "$appdir" \( -type f -o -type l \) -name "$pattern" -print -quit | grep -q .; then
-    echo "Complete AppImage is missing required runtime component: $pattern" >&2
-    return 1
-  fi
-}
-
-for component in \
-  'libglib-2.0.so*' 'libgobject-2.0.so*' 'libgio-2.0.so*' \
-  'libgtk-3.so*' 'libgdk-3.so*' 'libgdk_pixbuf-2.0.so*' \
-  'libwebkit2gtk-4.1.so*' 'libjavascriptcoregtk-4.1.so*' 'libsoup-3.0.so*' \
-  'libappindicator3.so*' 'WebKitNetworkProcess' 'WebKitWebProcess' \
-  'libwebkit2gtkinjectedbundle.so' \
-  'libgiognutls.so' \
-  'libgstcoreelements.so' 'libgstplayback.so' 'libgstpulseaudio.so' \
-  'libgstisomp4.so' 'libgstvideoparsersbad.so' 'libgstlibav.so' \
-  'gst-plugin-scanner'; do
-  require_basename "$component"
-done
 
 # Require the media plugins that must match the bundled GStreamer core.
 gst_plugin_count="$(find "$appdir/usr/lib/gstreamer-1.0" -maxdepth 1 -type f -name '*.so' 2>/dev/null | wc -l)"


### PR DESCRIPTION
Say which runtime components an AppImage is missing before its env hygiene

`Desktop app clean machine` is red nightly on main, seven AppImage jobs, all with
the app's own preflight naming four missing sonames. The tree is not at fault and
neither is the test, so this changes only what the verifier says.

What is actually happening
------------------------------------------------------------------------
The scheduled run downloads the published release rather than building one.
`REL_TAG` is `v0.1.800-beta`, whose Linux asset was uploaded 2026-08-14T15:26Z and
never rebuilt. I extracted it: `usr/bin/unsloth-studio` and zero `.so` files, so
it resolves webkit2gtk, libsoup, javascriptcoregtk and appindicator from the host.
It is a pre-#9113 thin build, provably: the diagnostic it prints lives at line 210
of `build-thin-appimage.sh`, a script #9113 deleted, and the replacement
`appimage-apprun.sh` does not contain that string.

#9113 ("Desktop: ship a complete Linux AppImage") landed 2026-08-19T13:09Z and
also dropped the line that used to install the host runtime into the appimage row,
which is correct under a self-contained bundle and is why that row flipped on an
unchanged asset. The Aug 18 run was green, Aug 19's red was the ManagedStale
incident that #9263 fixed, and Aug 20 is the first scheduled run after #9113.

So the asset under test predates the packaging it is being tested against. The
first desktop release cut from current main will satisfy these jobs; nothing in
the tree needs changing to make that true, and until that release exists this
workflow is red for a correct reason.

Note this is invisible on a pull request by construction: on `pull_request` the
AppImage jobs consume the artifact from `appimage-pr-build`, built from the PR, so
#9113 was green when it merged. Only `schedule` and `push` reach the release.

The one real defect
------------------------------------------------------------------------
`verify-complete-appimage.sh` run against that asset reports:

    Complete AppImage does not clear an inherited LD_LIBRARY_PATH

It exits 1 correctly, but it fails at the launcher-hygiene check and never reaches
the required-component loop, so a bundle that ships NO runtime at all is reported
as an environment-variable bug. That is the difference between an hour of
diagnosis and a minute of it.

The required-component check now runs first and reports every miss instead of
exiting on the first, mirroring the AppRun preflight, which names all four sonames
at once rather than making the reader rediscover them one launch at a time. On the
published asset it now says:

    Complete AppImage is missing required runtime component: libwebkit2gtk-4.1.so*
    ... 21 lines ...
    Complete AppImage is missing 21 of 21 required runtime components; it resolves
    them from the host

Order only. No check is removed and no assertion is weakened.

Verified
------------------------------------------------------------------------
`bash -n` clean. A synthetic AppDir with all 21 components present falls through
to the launcher-hygiene check exactly as before, so the hygiene checks still run
and still fail when they should. Removing only webkit from that AppDir yields
`missing 1 of 21`, so the count is real rather than a formatting flourish.
tests/security/test_release_desktop_appimage.py: 15 passed.
