### PR TITLE
Stop the pip cache key duplicating itself on every Python patch bump

### DIFF
--- a/.github/actions/pip-cache-restore/action.yml
+++ b/.github/actions/pip-cache-restore/action.yml
@@ -63,7 +63,20 @@ runs:
         set -euo pipefail
         dir="$(python -m pip cache dir)"
         echo "dir=$dir" >> "$GITHUB_OUTPUT"
-        pyver="$(python -c 'import sys; print("%d.%d.%d" % sys.version_info[:3])')"
+        # Minor, deliberately not patch. Nothing in this repo pins a patch version:
+        # 53 steps ask for '3.12' and the one matrix offers '3.11' and '3.13', so the
+        # patch is whatever the hosted image happens to ship that week. Carrying it in
+        # the key duplicated the WHOLE cache every time GitHub bumped it, which is not
+        # a hypothetical -- measured 2026-08-20, two entries differing in nothing but
+        # 3.12.13 vs 3.12.14 held 10.85 and 11.21 GiB, 44% of the repo's 50 GiB budget
+        # between them, against a total that had climbed back to 99.1% full. The same
+        # pairing showed up in 10 of the 12 pip entries.
+        #
+        # Safe because of WHAT is cached, the same argument the uv cache rests on: pip
+        # stores downloaded wheels, tagged cp312 and so ABI-compatible across every
+        # 3.12.x, behind an HTTP cache addressed by URL and hash. A stale entry cannot
+        # serve wrong content; the worst it can do is miss.
+        pyver="$(python -c 'import sys; print("%d.%d" % sys.version_info[:2])')"
         hash="${{ hashFiles(inputs.key-files) }}"
         # Empty means the globs matched nothing, which would silently collapse
         # every job onto one key. Loud here, where the cause is one line away.

--- a/tests/studio/test_cache_budget_discipline.py
+++ b/tests/studio/test_cache_budget_discipline.py
@@ -372,6 +372,35 @@ def test_the_pip_cache_save_action_is_gated_on_the_default_branch():
         )
 
 
+def test_the_pip_cache_key_carries_the_interpreter_minor_not_its_patch():
+    """
+    A key field more specific than anything the workflows request is pure churn.
+
+    No step in this repo pins a patch version: 53 ask for '3.12' and the one matrix
+    offers '3.11' and '3.13'. So the patch is whatever the hosted image ships that
+    week, and putting it in the key duplicates the ENTIRE cache each time GitHub
+    bumps it. Measured 2026-08-20: two entries alike in everything but 3.12.13 vs
+    3.12.14 held 10.85 and 11.21 GiB, 44% of the 50 GiB budget between them, with the
+    same pairing in 10 of the 12 pip entries.
+
+    Nothing goes red when that happens. The cache simply sits at 99% full and evicts
+    entries someone else was about to read, which is the failure this whole file is
+    about.
+    """
+    body = (REPO / ".github" / "actions" / "pip-cache-restore" / "action.yml").read_text(
+        encoding = "utf-8"
+    )
+    assert 'print("%d.%d" % sys.version_info[:2])' in body, (
+        "the pip cache key no longer derives the interpreter version as a minor. If it "
+        "went back to sys.version_info[:3], every runner-image patch bump silently "
+        "doubles the largest family in the cache."
+    )
+    assert "sys.version_info[:3]" not in body, (
+        "the pip cache key is back to the full patch version, which duplicated 22.06 "
+        "GiB across two otherwise identical entries the last time it was measured"
+    )
+
+
 def _workflows_by_name():
     return dict(_workflows())
 


### PR DESCRIPTION
The Actions cache budget is back to **49.55 GiB of 50, 99.1% full**, and 26.82 GiB of it is a single family. Two entries account for most of that:

| size | ref | key |
|---|---|---|
| 10.85 GiB | refs/heads/main | `pip-Linux-X64-py3.12.13-8a6adb0c...` |
| 11.21 GiB | refs/heads/main | `pip-Linux-X64-py3.12.14-8a6adb0c...` |

Alike in every field except the Python patch. That is **44% of the repo's entire budget held in two copies of the same thing**.

## Cause

`pip-cache-restore` built its key from `sys.version_info[:3]`, putting the interpreter **patch** in the key. Nothing in this repo pins a patch: 53 `setup-python` steps ask for `'3.12'`, and the single matrix offers `'3.11'` and `'3.13'`. The patch is whatever the hosted image ships that week, so each time GitHub bumps it the whole cache is rewritten under a new key while the old one still counts against the budget until LRU reaches it.

The same pairing appears in **10 of the 12** pip entries (3.12.13/3.12.14, 3.11.15/3.11.16), so this has recurred rather than happened once.

## Why keying on the minor is safe

The same argument the uv cache rests on, and a property of what is stored rather than a judgement about it: pip keeps downloaded wheels, tagged `cp312` and so ABI-compatible across every 3.12.x, behind an HTTP cache addressed by URL and hash. **A stale entry cannot serve wrong content; the worst it can do is miss.**

## Expected recovery

About **12.5 GiB, a quarter of the budget**, as the duplicate halves stop being written: 10.85 + 0.33 + 0.52 + 0.52 + 0.29 across the five pairs currently present.

## One honest caveat

The first run after this lands misses under the new key, so it re-downloads and saves a fresh entry while the old patch-keyed entries are still resident. At 99.1% full that pushes slightly harder on LRU before it gets better. Purging the stale patch-keyed entries once this is in makes the recovery immediate rather than gradual.

## Verified

- Guarded in `test_cache_budget_discipline.py`, the file that exists for exactly this class of silent waste.
- Mutation-tested: restoring `sys.version_info[:3]` fails that test and nothing else.
- 67 passed across `test_cache_budget_discipline`, `test_uv_cache_discipline`, `test_frontend_dist_cache`.
- The action still parses; steps unchanged in order and count.