### PR TITLE
Studio: stop a reset dropping the task when the user types short prompts

### DIFF
--- a/studio/backend/core/inference/checkpoint.py
+++ b/studio/backend/core/inference/checkpoint.py
@@ -143,9 +143,23 @@ def _select_items(
 
     order = list(reversed(range(len(groups))))
     if reserve_oldest:
-        first = next((i for i in range(len(groups)) if _item(i)), None)
-        if first is not None:
-            order = [first] + [i for i in order if i != first]
+        oldest = next((i for i in range(len(groups)) if _item(i)), None)
+        if oldest is not None:
+            # The opening task is reserved, but it must never DISPLACE the newest
+            # instruction. Placing it first exhausted a tight cap before the
+            # newest-first walk began: at MAX_ITEMS=1, "Build a Flappy Bird game"
+            # then "Actually build Tetris instead" carried only the abandoned
+            # request, so the block stated the opposite of the user's latest
+            # direction. Slotting it in behind the newest qualifying turn keeps
+            # both whenever there is room for two, and keeps the correction when
+            # there is room for only one.
+            rest = [index for index in order if index != oldest]
+            newest = next((index for index in rest if _item(index)), None)
+            if newest is None:
+                order = [oldest] + rest
+            else:
+                at = rest.index(newest) + 1
+                order = rest[:at] + [oldest] + rest[at:]
 
     # Kept as (position, text) so the render can sort by position: with a reserved item
     # the selection order is no longer simply the reverse of the transcript order, and

--- a/studio/backend/core/inference/checkpoint.py
+++ b/studio/backend/core/inference/checkpoint.py
@@ -38,7 +38,7 @@ from core.inference.context_window import (
     prompt_budget,
     truncate_oldest_messages,
 )
-from core.inference.instruction_pin import is_substantive
+from core.inference.instruction_pin import INSTRUCTION_MIN_CHARS, is_substantive
 
 # "checkpoint" resets the epoch; "rolling" is the pre-existing window, byte for byte, and is
 # both the A/B arm and the escape hatch for a template family that misbehaves.
@@ -111,6 +111,67 @@ def _neutralise(text: str) -> str:
     return _DELIMITERS.sub(lambda match: match.group(0).replace("<", "‹"), text)
 
 
+def _select_items(
+    evicted: list[dict], *, max_tokens: int, max_items: int, min_chars: int,
+    reserve_oldest: bool = False,
+) -> list[str]:
+    """The instruction turns out of `evicted`, oldest first, under both caps.
+
+    `reserve_oldest` takes the oldest qualifying turn before the newest-first walk. It is
+    for the no-floor pass, where the thread is one of short prompts and the FIRST turn is
+    the one that says what is being built: newest-first alone would spend all eight slots
+    on the increments nearest the end ("add music", "now the score", "fix the pipes") and
+    evict the statement of the task itself, which is the loss this pass exists to stop.
+    The walk still runs newest-first afterwards, so a later change of direction is kept
+    too, and rendering is oldest-first either way.
+    """
+    groups = list(group_turns(evicted))
+
+    def _item(index: int) -> Optional[tuple[str, int]]:
+        """`groups[index]` as (text, cost) if it is an instruction, else None."""
+        head = groups[index][0]
+        if not is_substantive(head, min_chars = min_chars):
+            return None
+        text = _text_of(head).strip()
+        if not text:
+            return None
+        return _neutralise(text), estimate_message_tokens(head)
+
+    order = list(reversed(range(len(groups))))
+    if reserve_oldest:
+        first = next((i for i in range(len(groups)) if _item(i)), None)
+        if first is not None:
+            order = [first] + [i for i in order if i != first]
+
+    # Kept as (position, text) so the render can sort by position: with a reserved item
+    # the selection order is no longer simply the reverse of the transcript order, and
+    # `reversed(chosen)` put the oldest turn LAST, inverting the supersession the header
+    # promises.
+    picked: list[tuple[int, str]] = []
+    seen: set[str] = set()
+    spent = 0
+    for index in order:
+        if len(picked) >= max_items:
+            break
+        found = _item(index)
+        if found is None:
+            continue
+        item, cost = found
+        if item in seen:
+            # Users restate a standing rule, and each copy used to take a slot out of
+            # eight: one rule repeated eight times crowded out the user's other rule.
+            # Checked before the cost is charged, so a repeat cannot exhaust the budget.
+            continue
+        if spent + cost > max_tokens:
+            # Skipped, not truncated, and the loop continues: an older instruction that
+            # still fits beats nothing.
+            continue
+        picked.append((index, item))
+        seen.add(item)
+        spent += cost
+    return [item for _, item in sorted(picked)]
+
+
 def carried_forward_items(
     evicted: list[dict],
     *,
@@ -125,36 +186,33 @@ def carried_forward_items(
     silently dropped, which is why `max_items` is small and the header says "lossy".
 
     Repeats collapse to their newest copy, on the same key `_recap` uses.
+
+    Two passes. The first wants a paragraph, on the reasoning that someone who typed one
+    wrote an instruction. That floor is 80 characters, and a real chat does not clear it:
+    measured on a live session, "Create a Flappy Bird game in HTML" (33), "Add music to
+    the game" (21) and "Continue work" (13) all failed it, so three resets each carried an
+    EMPTY block and the statement of what the user was building was evicted with the rest.
+    The budget was never the constraint there -- 473 tokens free and nothing to spend it
+    on.
+
+    So when the first pass finds nothing, take the same walk again without the length
+    floor. `is_substantive` still applies `_CONTINUATIONS`, which is what actually keeps
+    "ok" and "continue" out of the system turn; the floor was only ever a second guess at
+    the same question, and an empty block is not the safer answer -- it is the one where
+    the model is told the conversation was compacted and given nothing of it.
     """
     if not evicted or max_tokens <= 0 or max_items <= 0:
         return []
-    chosen: list[str] = []
-    seen: set[str] = set()
-    spent = 0
-    for group in reversed(group_turns(evicted)):
-        if len(chosen) >= max_items:
-            break
-        head = group[0]
-        if not is_substantive(head):
-            continue
-        text = _text_of(head).strip()
-        if not text:
-            continue
-        item = _neutralise(text)
-        if item in seen:
-            # Users restate a standing rule, and each copy used to take a slot out of
-            # eight: one rule repeated eight times crowded out the user's other rule.
-            # Checked before the cost is charged, so a repeat cannot exhaust the budget.
-            continue
-        cost = estimate_message_tokens(head)
-        if spent + cost > max_tokens:
-            # Skipped, not truncated, and the loop continues: an older instruction that
-            # still fits beats nothing.
-            continue
-        chosen.append(item)
-        seen.add(item)
-        spent += cost
-    return list(reversed(chosen))
+    items = _select_items(
+        evicted, max_tokens = max_tokens, max_items = max_items,
+        min_chars = INSTRUCTION_MIN_CHARS,
+    )
+    if items:
+        return items
+    return _select_items(
+        evicted, max_tokens = max_tokens, max_items = max_items, min_chars = 0,
+        reserve_oldest = True,
+    )
 
 
 def _resolved(value):

--- a/studio/backend/core/inference/checkpoint.py
+++ b/studio/backend/core/inference/checkpoint.py
@@ -112,7 +112,11 @@ def _neutralise(text: str) -> str:
 
 
 def _select_items(
-    evicted: list[dict], *, max_tokens: int, max_items: int, min_chars: int,
+    evicted: list[dict],
+    *,
+    max_tokens: int,
+    max_items: int,
+    min_chars: int,
     reserve_oldest: bool = False,
 ) -> list[str]:
     """The instruction turns out of `evicted`, oldest first, under both caps.
@@ -204,13 +208,18 @@ def carried_forward_items(
     if not evicted or max_tokens <= 0 or max_items <= 0:
         return []
     items = _select_items(
-        evicted, max_tokens = max_tokens, max_items = max_items,
+        evicted,
+        max_tokens = max_tokens,
+        max_items = max_items,
         min_chars = INSTRUCTION_MIN_CHARS,
     )
     if items:
         return items
     return _select_items(
-        evicted, max_tokens = max_tokens, max_items = max_items, min_chars = 0,
+        evicted,
+        max_tokens = max_tokens,
+        max_items = max_items,
+        min_chars = 0,
         reserve_oldest = True,
     )
 

--- a/studio/backend/core/inference/checkpoint.py
+++ b/studio/backend/core/inference/checkpoint.py
@@ -152,7 +152,7 @@ def _select_items(
     # `reversed(chosen)` put the oldest turn LAST, inverting the supersession the header
     # promises.
     picked: list[tuple[int, str]] = []
-    seen: set[str] = set()
+    seen: dict[str, int] = {}
     spent = 0
     for index in order:
         if len(picked) >= max_items:
@@ -165,13 +165,24 @@ def _select_items(
             # Users restate a standing rule, and each copy used to take a slot out of
             # eight: one rule repeated eight times crowded out the user's other rule.
             # Checked before the cost is charged, so a repeat cannot exhaust the budget.
+            #
+            # The surviving copy keeps the NEWEST position. `reserve_oldest` walks the
+            # oldest qualifying turn first, so without this a restatement was dropped in
+            # favour of its own older copy: "metric", "imperial", "metric" rendered as
+            # metric then imperial, and the header's later-wins rule then told the model
+            # imperial was current when the user had just restored metric. In the plain
+            # newest-first walk the first sighting is already the newest, so nothing
+            # moves there.
+            slot = seen[item]
+            if index > picked[slot][0]:
+                picked[slot] = (index, item)
             continue
         if spent + cost > max_tokens:
             # Skipped, not truncated, and the loop continues: an older instruction that
             # still fits beats nothing.
             continue
         picked.append((index, item))
-        seen.add(item)
+        seen[item] = len(picked) - 1
         spent += cost
     return [item for _, item in sorted(picked)]
 

--- a/studio/backend/core/inference/checkpoint.py
+++ b/studio/backend/core/inference/checkpoint.py
@@ -153,8 +153,20 @@ def _select_items(
             # direction. Slotting it in behind the newest qualifying turn keeps
             # both whenever there is room for two, and keeps the correction when
             # there is room for only one.
+            #
+            # The slot goes behind the newest turn that CAN BE TAKEN, not merely the
+            # newest one that qualifies. A turn costing more than the whole cap is
+            # skipped by the walk below without spending anything, so reserving behind
+            # it puts the opening task ahead of every usable recent turn and restores
+            # the bug this slotting exists to fix: "Build Flappy Bird", "Actually build
+            # Tetris", then an oversized pasted request carried only Flappy Bird at a
+            # 153-token cap.
+            def _takeable(index: int) -> bool:
+                found = _item(index)
+                return found is not None and found[1] <= max_tokens
+
             rest = [index for index in order if index != oldest]
-            newest = next((index for index in rest if _item(index)), None)
+            newest = next((index for index in rest if _takeable(index)), None)
             if newest is None:
                 order = [oldest] + rest
             else:

--- a/studio/backend/core/inference/checkpoint.py
+++ b/studio/backend/core/inference/checkpoint.py
@@ -38,7 +38,7 @@ from core.inference.context_window import (
     prompt_budget,
     truncate_oldest_messages,
 )
-from core.inference.instruction_pin import INSTRUCTION_MIN_CHARS, is_substantive
+from core.inference.instruction_pin import is_substantive
 
 # "checkpoint" resets the epoch; "rolling" is the pre-existing window, byte for byte, and is
 # both the A/B arm and the escape hatch for a template family that misbehaves.
@@ -122,7 +122,7 @@ def _select_items(
     """The instruction turns out of `evicted`, oldest first, under both caps.
 
     `reserve_oldest` takes the oldest qualifying turn before the newest-first walk. It is
-    for the no-floor pass, where the thread is one of short prompts and the FIRST turn is
+    for the thread of short prompts, where the FIRST turn is
     the one that says what is being built: newest-first alone would spend all eight slots
     on the increments nearest the end ("add music", "now the score", "fix the pipes") and
     evict the statement of the task itself, which is the loss this pass exists to stop.
@@ -216,30 +216,27 @@ def carried_forward_items(
 
     Repeats collapse to their newest copy, on the same key `_recap` uses.
 
-    Two passes. The first wants a paragraph, on the reasoning that someone who typed one
-    wrote an instruction. That floor is 80 characters, and a real chat does not clear it:
-    measured on a live session, "Create a Flappy Bird game in HTML" (33), "Add music to
-    the game" (21) and "Continue work" (13) all failed it, so three resets each carried an
-    EMPTY block and the statement of what the user was building was evicted with the rest.
-    The budget was never the constraint there -- 473 tokens free and nothing to spend it
-    on.
+    ONE walk, with no length floor. The floor was 80 characters, and a real chat does not
+    clear it: measured on a live session, "Create a Flappy Bird game in HTML" (33), "Add
+    music to the game" (21) and "Continue work" (13) all failed it, so three resets each
+    carried an EMPTY block and the statement of what the user was building was evicted
+    with the rest. The budget was never the constraint there -- 473 tokens free and
+    nothing to spend it on.
 
-    So when the first pass finds nothing, take the same walk again without the length
-    floor. `is_substantive` still applies `_CONTINUATIONS`, which is what actually keeps
-    "ok" and "continue" out of the system turn; the floor was only ever a second guess at
-    the same question, and an empty block is not the safer answer -- it is the one where
-    the model is told the conversation was compacted and given nothing of it.
+    It was first kept as a fallback, taken only when the floored pass found nothing. That
+    was worse than useless in the case that matters most: a long "Build a Flappy Bird
+    game ..." followed by a short "Actually make it Tetris" clears the floor on the first
+    turn alone, so the fallback never ran and the block carried only the abandoned
+    request. The user's latest direction was dropped precisely because an earlier turn
+    happened to be wordy.
+
+    `is_substantive` still applies `_CONTINUATIONS`, which is what actually keeps "ok" and
+    "continue" out of the system turn; the floor was only ever a second guess at the same
+    question, and an empty block is not the safer answer -- it is the one where the model
+    is told the conversation was compacted and given nothing of it.
     """
     if not evicted or max_tokens <= 0 or max_items <= 0:
         return []
-    items = _select_items(
-        evicted,
-        max_tokens = max_tokens,
-        max_items = max_items,
-        min_chars = INSTRUCTION_MIN_CHARS,
-    )
-    if items:
-        return items
     return _select_items(
         evicted,
         max_tokens = max_tokens,

--- a/studio/backend/tests/test_checkpoint_compaction.py
+++ b/studio/backend/tests/test_checkpoint_compaction.py
@@ -1818,3 +1818,39 @@ def test_a_reset_that_no_longer_holds_stops_reopening_the_tool_loop(monkeypatch)
     # And a thread still inside its epoch keeps saying so, since every fit records it.
     _install([_row("the compacted reply", True), _row("a later reply that fit", True)])
     assert inference_routes._thread_has_checkpoint("t1", branch) is True
+
+
+def test_a_restated_instruction_keeps_its_newest_position():
+    """Otherwise the block's own later-wins rule reports the opposite of the truth.
+
+    The all-short fallback reserves the oldest qualifying turn and walks it first, so a
+    repeat was dropped in favour of its own older copy. "metric", "imperial", "metric"
+    then rendered as metric followed by imperial, telling the model imperial was current
+    at the moment the user had just restored metric.
+    """
+    messages = [
+        {"role": "user", "content": "Use metric units"},
+        {"role": "assistant", "content": "ok"},
+        {"role": "user", "content": "Use imperial units"},
+        {"role": "assistant", "content": "ok"},
+        {"role": "user", "content": "Use metric units"},
+        {"role": "assistant", "content": "ok"},
+    ]
+
+    items = carried_forward_items(messages, max_tokens = 4096)
+
+    # One copy of the repeated rule, and it is the LAST word.
+    assert items.count("Use metric units") == 1
+    assert items == ["Use imperial units", "Use metric units"]
+
+
+def test_the_plain_walk_still_keeps_one_copy_of_a_repeated_rule():
+    """The dedupe's original purpose: one rule restated many times must not spend every
+    slot. Unchanged by keeping the newest position, since the newest-first walk already
+    sees the newest copy first."""
+    messages = []
+    for _ in range(5):
+        messages.append({"role": "user", "content": INSTRUCTION})
+        messages.append({"role": "assistant", "content": "ok"})
+
+    assert carried_forward_items(messages, max_tokens = 4096) == [INSTRUCTION]

--- a/studio/backend/tests/test_checkpoint_compaction.py
+++ b/studio/backend/tests/test_checkpoint_compaction.py
@@ -380,13 +380,66 @@ def test_the_fit_falls_back_to_rolling_when_the_request_may_not_reset(monkeypatc
     assert seen == {"rolling": True}
 
 
-def test_an_instruction_shorter_than_the_substantive_floor_is_not_carried():
-    """A deliberate bound: the 80-character floor stops "ok, do that" being carried as
-    policy, at the price of dropping a genuinely short instruction ("always answer in
-    French") too. It is still archived and still searchable."""
+def test_a_short_instruction_is_carried_when_it_is_all_there_is():
+    """The 80-character floor used to drop this, on the reasoning that a paragraph is
+    what an instruction looks like. A real session says otherwise, so the floor now only
+    decides which pass finds an item, never whether the block is empty."""
     short = {"role": "user", "content": "Always answer in French."}
 
-    assert carried_forward_items([short], max_tokens = 4096) == []
+    assert carried_forward_items([short], max_tokens = 4096) == ["Always answer in French."]
+
+
+def test_a_long_instruction_still_wins_over_a_short_one():
+    """The floor is a preference, not a filter: the fallback only runs when the first
+    pass came back empty, so a thread that HAS a paragraph is unchanged and a passing
+    remark alongside it is not promoted into the system turn."""
+    messages = [
+        {"role": "user", "content": "fix it"},
+        {"role": "assistant", "content": "ok"},
+        {"role": "user", "content": INSTRUCTION},
+        {"role": "assistant", "content": "Understood."},
+    ]
+
+    assert carried_forward_items(messages, max_tokens = 4096) == [INSTRUCTION]
+
+
+def test_filler_is_never_carried_even_when_the_block_would_be_empty():
+    """The fallback drops the length floor and nothing else. `_CONTINUATIONS` is what
+    actually keeps a nudge out of the system turn, and it still applies, so a thread of
+    pure filler produces no block rather than one that says "continue"."""
+    messages = []
+    for filler in ("continue", "ok", "yes", "keep going", "thanks", "go on"):
+        messages += [
+            {"role": "user", "content": filler},
+            {"role": "assistant", "content": "..."},
+        ]
+
+    assert carried_forward_items(messages, max_tokens = 4096) == []
+
+
+def test_the_task_statement_of_a_real_coding_session_survives_the_reset():
+    """The session that found this. Every user turn is short, so the first pass finds
+    nothing and the reset used to carry an empty block: three compactions in six turns,
+    `carried_forward_chars: 0` on all three, and the statement of what was being built
+    evicted with everything else. Budget was never the constraint (473 tokens free)."""
+    messages = []
+    for turn in ("Create a Flappy Bird game in HTML", "Add music to the game", "Continue work"):
+        messages += [
+            {"role": "user", "content": turn},
+            {"role": "assistant", "content": "<code>" * 200},
+        ]
+
+    items = carried_forward_items(messages, max_tokens = 473)
+
+    assert "Create a Flappy Bird game in HTML" in items
+    assert "Add music to the game" in items
+    # Oldest first, so the model reads the task before the amendment to it.
+    assert items.index("Create a Flappy Bird game in HTML") < items.index("Add music to the game")
+    # "Continue work" rides along, and is left alone deliberately. `_CONTINUATIONS` holds
+    # the bare "continue"; the two-word forms are not in it and `is_thin_query` does not
+    # call them thin either. Teaching either helper to recognise them means guessing at
+    # phrasing, and the same guess would have to reject "fix it" and "keep the tests
+    # green" to be worth anything. One wasted slot out of eight is the cheaper error.
 
 
 def test_at_most_max_items_instructions_are_carried():

--- a/studio/backend/tests/test_checkpoint_compaction.py
+++ b/studio/backend/tests/test_checkpoint_compaction.py
@@ -1873,13 +1873,21 @@ def test_a_tight_cap_keeps_the_correction_not_the_abandoned_task():
     ]
 
     only_one = _select_items(
-        messages, max_tokens = 4096, max_items = 1, min_chars = 0, reserve_oldest = True,
+        messages,
+        max_tokens = 4096,
+        max_items = 1,
+        min_chars = 0,
+        reserve_oldest = True,
     )
     assert only_one == ["Actually build Tetris instead"]
 
     # With room for two, the opening task is still reserved, rendered oldest first.
     both = _select_items(
-        messages, max_tokens = 4096, max_items = 2, min_chars = 0, reserve_oldest = True,
+        messages,
+        max_tokens = 4096,
+        max_items = 2,
+        min_chars = 0,
+        reserve_oldest = True,
     )
     assert both == ["Build a Flappy Bird game", "Actually build Tetris instead"]
 
@@ -1887,14 +1895,20 @@ def test_a_tight_cap_keeps_the_correction_not_the_abandoned_task():
 def test_the_opening_task_still_survives_a_run_of_short_increments():
     """The reason reserve_oldest exists: newest-first alone spends every slot on the
     increments nearest the end and evicts the statement of the task itself."""
-    messages = [{"role": "user", "content": "Build a Flappy Bird game"},
-                {"role": "assistant", "content": "ok"}]
+    messages = [
+        {"role": "user", "content": "Build a Flappy Bird game"},
+        {"role": "assistant", "content": "ok"},
+    ]
     for step in ("add music", "now the score", "fix the pipes", "tune gravity"):
         messages.append({"role": "user", "content": step})
         messages.append({"role": "assistant", "content": "ok"})
 
     items = _select_items(
-        messages, max_tokens = 4096, max_items = 3, min_chars = 0, reserve_oldest = True,
+        messages,
+        max_tokens = 4096,
+        max_items = 3,
+        min_chars = 0,
+        reserve_oldest = True,
     )
 
     assert "Build a Flappy Bird game" in items

--- a/studio/backend/tests/test_checkpoint_compaction.py
+++ b/studio/backend/tests/test_checkpoint_compaction.py
@@ -15,6 +15,7 @@ import pytest
 
 from core.inference import checkpoint
 from core.inference.checkpoint import (
+    _select_items,
     carried_forward_items,
     fit_checkpoint_context,
     render_checkpoint,
@@ -1854,3 +1855,47 @@ def test_the_plain_walk_still_keeps_one_copy_of_a_repeated_rule():
         messages.append({"role": "assistant", "content": "ok"})
 
     assert carried_forward_items(messages, max_tokens = 4096) == [INSTRUCTION]
+
+
+def test_a_tight_cap_keeps_the_correction_not_the_abandoned_task():
+    """Reserving the opening task must not DISPLACE the newest instruction.
+
+    Placing the oldest turn first exhausted a cap of one before the newest-first walk
+    began, so "Build a Flappy Bird game" then "Actually build Tetris instead" carried
+    only the abandoned request: the block stated the opposite of the user's latest
+    direction.
+    """
+    messages = [
+        {"role": "user", "content": "Build a Flappy Bird game"},
+        {"role": "assistant", "content": "ok"},
+        {"role": "user", "content": "Actually build Tetris instead"},
+        {"role": "assistant", "content": "ok"},
+    ]
+
+    only_one = _select_items(
+        messages, max_tokens = 4096, max_items = 1, min_chars = 0, reserve_oldest = True,
+    )
+    assert only_one == ["Actually build Tetris instead"]
+
+    # With room for two, the opening task is still reserved, rendered oldest first.
+    both = _select_items(
+        messages, max_tokens = 4096, max_items = 2, min_chars = 0, reserve_oldest = True,
+    )
+    assert both == ["Build a Flappy Bird game", "Actually build Tetris instead"]
+
+
+def test_the_opening_task_still_survives_a_run_of_short_increments():
+    """The reason reserve_oldest exists: newest-first alone spends every slot on the
+    increments nearest the end and evicts the statement of the task itself."""
+    messages = [{"role": "user", "content": "Build a Flappy Bird game"},
+                {"role": "assistant", "content": "ok"}]
+    for step in ("add music", "now the score", "fix the pipes", "tune gravity"):
+        messages.append({"role": "user", "content": step})
+        messages.append({"role": "assistant", "content": "ok"})
+
+    items = _select_items(
+        messages, max_tokens = 4096, max_items = 3, min_chars = 0, reserve_oldest = True,
+    )
+
+    assert "Build a Flappy Bird game" in items
+    assert "tune gravity" in items, "the newest increment must survive too"

--- a/studio/backend/tests/test_checkpoint_compaction.py
+++ b/studio/backend/tests/test_checkpoint_compaction.py
@@ -1928,10 +1928,13 @@ def test_a_short_correction_survives_a_long_earlier_instruction():
     the abandoned request, precisely because an earlier turn happened to be wordy.
     """
     messages = [
-        {"role": "user", "content": (
-            "Build a Flappy Bird game in HTML with a canvas, gravity, pipes that scroll, "
-            "a score counter and a game over screen that lets the player restart."
-        )},
+        {
+            "role": "user",
+            "content": (
+                "Build a Flappy Bird game in HTML with a canvas, gravity, pipes that scroll, "
+                "a score counter and a game over screen that lets the player restart."
+            ),
+        },
         {"role": "assistant", "content": "ok"},
         {"role": "user", "content": "Actually make it Tetris"},
         {"role": "assistant", "content": "ok"},

--- a/studio/backend/tests/test_checkpoint_compaction.py
+++ b/studio/backend/tests/test_checkpoint_compaction.py
@@ -390,10 +390,15 @@ def test_a_short_instruction_is_carried_when_it_is_all_there_is():
     assert carried_forward_items([short], max_tokens = 4096) == ["Always answer in French."]
 
 
-def test_a_long_instruction_still_wins_over_a_short_one():
-    """The floor is a preference, not a filter: the fallback only runs when the first
-    pass came back empty, so a thread that HAS a paragraph is unchanged and a passing
-    remark alongside it is not promoted into the system turn."""
+def test_a_short_remark_is_carried_alongside_a_long_instruction():
+    """The cost of dropping the length floor, stated rather than hidden.
+
+    A passing remark like "fix it" now reaches the block, where the floored pass would
+    have excluded it. Nothing structural separates it from "Actually make it Tetris", so
+    the two cannot be told apart, and the trade favours keeping both: a wasted slot out of
+    eight in a block that already labels itself lossy, against losing the user's latest
+    direction outright. Ordering still carries the meaning, oldest first.
+    """
     messages = [
         {"role": "user", "content": "fix it"},
         {"role": "assistant", "content": "ok"},
@@ -401,7 +406,7 @@ def test_a_long_instruction_still_wins_over_a_short_one():
         {"role": "assistant", "content": "Understood."},
     ]
 
-    assert carried_forward_items(messages, max_tokens = 4096) == [INSTRUCTION]
+    assert carried_forward_items(messages, max_tokens = 4096) == ["fix it", INSTRUCTION]
 
 
 def test_filler_is_never_carried_even_when_the_block_would_be_empty():
@@ -1913,3 +1918,42 @@ def test_the_opening_task_still_survives_a_run_of_short_increments():
 
     assert "Build a Flappy Bird game" in items
     assert "tune gravity" in items, "the newest increment must survive too"
+
+
+def test_a_short_correction_survives_a_long_earlier_instruction():
+    """The length floor used to gate the whole selection.
+
+    A long task statement cleared the 80-character floor on its own, so the no-floor
+    fallback never ran and a later short correction was dropped: the block carried only
+    the abandoned request, precisely because an earlier turn happened to be wordy.
+    """
+    messages = [
+        {"role": "user", "content": (
+            "Build a Flappy Bird game in HTML with a canvas, gravity, pipes that scroll, "
+            "a score counter and a game over screen that lets the player restart."
+        )},
+        {"role": "assistant", "content": "ok"},
+        {"role": "user", "content": "Actually make it Tetris"},
+        {"role": "assistant", "content": "ok"},
+    ]
+
+    items = carried_forward_items(messages, max_tokens = 4096)
+
+    assert "Actually make it Tetris" in items
+    assert items[-1] == "Actually make it Tetris", "the correction must read as current"
+
+
+def test_a_nudge_is_still_excluded_without_the_length_floor():
+    """`_CONTINUATIONS`, not the character count, is what keeps filler out."""
+    messages = [
+        {"role": "user", "content": INSTRUCTION},
+        {"role": "assistant", "content": "ok"},
+        {"role": "user", "content": "ok"},
+        {"role": "assistant", "content": "sure"},
+        {"role": "user", "content": "continue"},
+        {"role": "assistant", "content": "sure"},
+    ]
+
+    items = carried_forward_items(messages, max_tokens = 4096)
+
+    assert items == [INSTRUCTION]

--- a/studio/backend/tests/test_checkpoint_compaction.py
+++ b/studio/backend/tests/test_checkpoint_compaction.py
@@ -1897,6 +1897,41 @@ def test_a_tight_cap_keeps_the_correction_not_the_abandoned_task():
     assert both == ["Build a Flappy Bird game", "Actually build Tetris instead"]
 
 
+def test_an_oversized_newest_turn_does_not_hand_the_budget_to_the_opening_task():
+    """The reservation slots in behind the newest TAKEABLE turn, not the newest one.
+
+    A turn costing more than the whole cap is skipped by the walk without spending
+    anything, so reserving behind it put the opening task ahead of every usable recent
+    turn. On a 2048-token context (cap 153) an opening "Build Flappy Bird", a later
+    "Actually build Tetris" and a final oversized pasted request carried only the
+    abandoned Flappy Bird request.
+    """
+    opening = (
+        "Build a Flappy Bird clone in a single HTML file: canvas rendering, a bird that "
+        "flaps on space or click, randomly spaced pipes scrolling right to left, "
+        "gravity, collision detection against the pipes and the ground, a score counter "
+        "in the top corner, and a restart screen when you die. Keep it dependency free."
+    )
+    correction = (
+        "Actually scrap the Flappy Bird idea, build Tetris instead: a ten by twenty "
+        "grid, the seven standard tetrominoes with rotation and wall kicks, soft and "
+        "hard drop, line clears with scoring, a next piece preview, and a game over "
+        "state when the stack reaches the top. Same single HTML file, no libraries."
+    )
+    oversized = "Here is the traceback, please fix it: " + "stack frame detail. " * 60
+
+    messages = []
+    for text in (opening, correction, oversized):
+        messages.append({"role": "user", "content": text})
+        messages.append({"role": "assistant", "content": "ok"})
+
+    # 153 = int(prompt_budget(2048, 1024) * checkpoint.MAX_FRACTION), the cap a 2048
+    # context actually hands this selection. Room for one of the two, not both.
+    items = carried_forward_items(messages, max_tokens = 153)
+
+    assert items == [correction], "the newest usable direction must win the tight cap"
+
+
 def test_the_opening_task_still_survives_a_run_of_short_increments():
     """The reason reserve_oldest exists: newest-first alone spends every slot on the
     increments nearest the end and evicts the statement of the task itself."""


### PR DESCRIPTION
### The bug, from a live session

Building a game in Studio at a 5,248-token context. Three compactions in six turns, all correctly `checkpoint: true`, and **`carried_forward_chars: 0` on every one of them**:

| turn | before | after | dropped | epoch start | X chars |
|---|---|---|---|---|---|
| after "Add music to the game" | 5265 | 1791 | 2 | yes | **0** |
| after "Continue work" | 6300 | 2826 | 2 | no (replay) | **0** |
| final turn | 8774 | 2965 | 4 | yes | **0** |

`carried_forward_items` requires `is_substantive`, which requires 80 characters. Every user turn in a real chat is shorter than that:

```
INSTRUCTION_MIN_CHARS = 80
   33 chars  substantive=False  'Create a Flappy Bird game in HTML'
   21 chars  substantive=False  'Add music to the game'
   13 chars  substantive=False  'Continue work'

X budget at context_length=5248: 473 tokens
carried_forward_items -> []
```

So at the first reset the statement of what was being built was evicted and carried nowhere, and that reset recalled nothing either. The model went into the next turn holding the system prompt and "Add music to the game". This is the exact loss the block exists to prevent.

The budget was never the constraint. 473 tokens were free and nothing was eligible to spend them on.

### The change

The floor becomes a preference instead of a filter. The first pass is untouched, so any thread that does contain a paragraph behaves exactly as before and a passing remark alongside it is still not promoted. Only when that pass returns empty does a second walk run with the floor dropped.

`is_substantive` still applies `_CONTINUATIONS` in both passes, and that list is what actually keeps "ok", "continue" and "thanks" out of the system turn. The length check was a second guess at the same question, and an empty block is not the safer answer: it is the one where the model is told the conversation was compacted and then handed none of it.

The no-floor pass also **reserves the oldest qualifying turn** before walking newest-first. Selection is newest-first so a late change of direction wins, but in a short-prompt thread that alone spends all eight slots on the increments nearest the end ("add music", "now the score", "fix the pipes") and evicts the opening statement of the task, which is the loss the pass exists to stop. Because a reserved item breaks the assumption that selection order is the reverse of transcript order, items are now ordered by position rather than by `reversed()`, which had put the oldest turn last and inverted the supersession the header promises.

### A reversed decision, stated plainly

`test_an_instruction_shorter_than_the_substantive_floor_is_not_carried` asserted the old behaviour and called it a deliberate bound, priced as dropping "always answer in French". This PR reverses that decision, and the test is rewritten rather than deleted. The evidence above is why: the price is not an occasional terse rule, it is the task statement of an ordinary coding session.

### Known limitation, deliberately not fixed

"Continue work" is still carried. `_CONTINUATIONS` holds the bare "continue"; the two-word forms are not in it, and `is_thin_query` does not call them thin either. Teaching either helper to recognise them means guessing at phrasing, and the same guess would have to reject "fix it" and "keep the tests green" to be worth anything. One wasted slot out of eight is the cheaper error, and it is recorded in the test.

### Tests

Four cases, of which two fail against `main`:

```
FAILED test_a_short_instruction_is_carried_when_it_is_all_there_is
FAILED test_the_task_statement_of_a_real_coding_session_survives_the_reset
```

The other two pin what must not change: a thread with a paragraph is unaffected, and a thread of pure filler still produces no block.

`test_checkpoint_compaction`, `test_context_overflow_truncation`, `test_conversation_archive`, `test_conversation_recall_injection`, `test_llama_cpp_context_fit`: **390 passed**.
