### PR TITLE
Studio: keep every cached revision's quants on the on-device card

### DIFF
--- a/studio/backend/hub/services/models/gguf_variants.py
+++ b/studio/backend/hub/services/models/gguf_variants.py
@@ -39,6 +39,7 @@ from hub.utils.gguf import (
     list_local_gguf_variants,
     list_partial_gguf_variants_from_state,
     pick_best_gguf,
+    merge_sibling_snapshot_variants,
     select_gguf_cache_snapshot,
 )
 from hub.utils.paths import (
@@ -1053,6 +1054,31 @@ async def get_gguf_variants_answer(
         hub_cache = repo_cache_dir.parent if repo_cache_dir is not None else None
         snapshot_scope = _snapshot_scope_for_request(repo_id, local_path)
 
+        def _merge_when_the_repo_id_loads(response_repo_id, cached, root):
+            """*cached* widened, but only where the repo id is the load target.
+
+            ``cached_gguf_for_load`` searches the revisions only for such a row; one naming a
+            snapshot dir loads from it alone. Sufficient, not complete -- other shapes load by id
+            and keep listing one revision, since reconstructing the inventory's answer here from
+            less than it uses would offer quants the row cannot resolve.
+            """
+            variants, has_vision, complete, snapshot = cached
+            if not complete:
+                return cached
+            try:
+                from hub.utils.hf_cache_state import same_existing_path
+                from utils.hf_cache_settings import get_hf_cache_paths
+
+                repo_dir = snapshot.parent.parent
+                if not same_existing_path(repo_dir.parent, get_hf_cache_paths().hub_cache):
+                    return cached
+                default_snapshot = hf_cache_scan.default_ref_snapshot(repo_dir)
+                if default_snapshot is None or not same_existing_path(default_snapshot, snapshot):
+                    return cached
+            except (OSError, RuntimeError, ValueError):
+                return cached
+            return merge_sibling_snapshot_variants(response_repo_id, cached, root = root)
+
         def _local_response(
             response_repo_id: str,
             variants,
@@ -1264,7 +1290,9 @@ async def get_gguf_variants_answer(
                 return scoped_response
             cached = select_gguf_cache_snapshot(repo_id, root = hub_cache)
             if cached is not None:
-                variants, has_vision, complete, snapshot = cached
+                variants, has_vision, complete, snapshot = _merge_when_the_repo_id_loads(
+                    repo_id, cached, hub_cache
+                )
                 # Name the answering snapshot: a repo-wide walk could read a different cache's
                 # context length, and a repo-dir walk a sibling revision's.
                 answered_from[0] = str(snapshot)
@@ -1308,7 +1336,9 @@ async def get_gguf_variants_answer(
                 return scoped_response
             cached = select_gguf_cache_snapshot(repo_id, root = hub_cache)
             if cached is not None:
-                variants, has_vision, complete, snapshot = cached
+                variants, has_vision, complete, snapshot = _merge_when_the_repo_id_loads(
+                    repo_id, cached, hub_cache
+                )
                 answered_from[0] = str(snapshot)
                 # Same reason as the local_only branch above, state partials included:
                 # an unreachable Hub is exactly when a resume has nowhere else to surface.

--- a/studio/backend/hub/utils/gguf.py
+++ b/studio/backend/hub/utils/gguf.py
@@ -699,6 +699,65 @@ def select_gguf_cache_snapshot(
     return fallback
 
 
+def merge_sibling_snapshot_variants(
+    repo_id: str,
+    selected: tuple[list[GgufVariantInfo], bool, set, Path],
+    root: Optional[Path] = None,
+) -> tuple[list[GgufVariantInfo], bool, set, Path]:
+    """*selected* widened with the quants the repo dir's other revisions hold.
+
+    The selector names one directory, so an inventory built on it drops what an upstream re-upload
+    left elsewhere. Only safe for a row loading by repo id, which the caller establishes. One repo
+    dir only: a cache can hold two differing in case, and the row owns one.
+    """
+    from hub.utils.hf_cache_state import same_existing_path
+    from hub.utils.inventory_scan import complete_snapshot_variants
+
+    variants, has_vision, complete, snapshot = selected
+    merged = list(variants)
+    merged_complete = set(complete)
+    whole = {quant.lower() for quant in merged_complete}
+    held: dict[str, int] = {}
+    for index, variant in enumerate(merged):
+        if variant.quant:
+            held.setdefault(variant.quant.lower(), index)
+    # Per row, so a projector cannot outlive the row it arrived with.
+    merged_vision: dict[str, bool] = {}
+    changed = False
+    for other in iter_hf_cache_snapshots(repo_id, root = root):
+        if other.parent != snapshot.parent:
+            continue
+        if other == snapshot or same_existing_path(other, snapshot):
+            continue
+        extra, extra_vision = list_local_gguf_variants(str(other))
+        candidates = [v for v in extra if v.quant and v.quant.lower() not in whole]
+        if not candidates:
+            continue
+        other_complete = complete_snapshot_variants(str(other)) or set()
+        for variant in candidates:
+            key = variant.quant.lower()
+            index = held.get(key)
+            is_whole = variant.quant in other_complete
+            if index is None:
+                held[key] = len(merged)
+                merged.append(variant)
+            elif is_whole:
+                # A load skips the torn copy for this one, so the row describes this one.
+                merged[index] = variant
+            else:
+                continue
+            changed = True
+            merged_vision[key] = extra_vision
+            if is_whole:
+                merged_complete.add(variant.quant)
+                whole.add(key)
+    if changed:
+        # Labels disambiguate within a revision, so a merged set can hold names only the
+        # merge brings together.
+        _apply_gguf_display_labels(merged)
+    return merged, has_vision or any(merged_vision.values()), merged_complete, snapshot
+
+
 def list_gguf_variants_from_hf_cache(
     repo_id: str, root: Optional[Path] = None
 ) -> Optional[tuple[list[GgufVariantInfo], bool, set]]:

--- a/studio/backend/tests/test_cached_gguf_routes.py
+++ b/studio/backend/tests/test_cached_gguf_routes.py
@@ -4220,14 +4220,16 @@ def _write_cached_gguf(
     filename: str,
     mtime: float | None = None,
     revision: str = "rev",
+    size: int = 36,
 ) -> Path:
-    """One real snapshot under *hub_cache*; *mtime* pins which one a repo-wide walk picks."""
+    """One real snapshot under *hub_cache*; *mtime* pins which one a repo-wide walk picks,
+    *size* tells two revisions' copies of one filename apart."""
     import os
 
     repo_dir = hub_cache / ("models--" + repo_id.replace("/", "--"))
     snapshot = repo_dir / "snapshots" / revision
     snapshot.mkdir(parents = True, exist_ok = True)
-    (snapshot / filename).write_bytes(b"GGUF" + b"\0" * 32)
+    (snapshot / filename).write_bytes(b"GGUF" + b"\0" * (size - 4))
     if mtime is not None:
         os.utime(snapshot, (mtime, mtime))
     return repo_dir
@@ -4404,6 +4406,275 @@ def test_context_follows_the_answering_revision_not_a_sibling(monkeypatch, tmp_p
     )
     assert [v.quant for v in response.variants] == ["Q8_0"]
     assert context_calls == [(str(repo_dir / "snapshots" / "newer"), True)]
+
+
+def _point_ref_at(repo_dir: Path, revision: str) -> None:
+    """Widening needs this ref to name the answering revision."""
+    refs = repo_dir / "refs"
+    refs.mkdir(parents = True, exist_ok = True)
+    (refs / "main").write_text(revision)
+
+
+def _cached_repo_variants(
+    monkeypatch,
+    hub_cache,
+    repo_dir,
+    *,
+    local_path = None,
+    active = None,
+    prefer_local_cache = True,
+):
+    _pin_caches(monkeypatch, active or hub_cache, [active, hub_cache] if active else [hub_cache])
+    _unreachable_hub(monkeypatch)
+    monkeypatch.setattr(GV, "list_partial_gguf_variants_from_state", lambda *a, **k: None)
+    monkeypatch.setattr(
+        models_route, "_read_native_context_length", lambda model, *, is_local: None
+    )
+    return asyncio.run(
+        models_route.get_gguf_variants(
+            repo_id = "org/repo",
+            # True is what the on-device card sends; False falls back through the dead Hub.
+            prefer_local_cache = prefer_local_cache,
+            local_path = str(local_path or repo_dir),
+            hf_token = None,
+            current_subject = "test-user",
+        )
+    )
+
+
+def test_a_quant_only_an_older_revision_holds_is_still_listed(monkeypatch, tmp_path):
+    """The hidden quant is still cached and still loadable."""
+    hub_cache = tmp_path / "hub"
+    hub_cache.mkdir()
+    repo_dir = _write_cached_gguf(
+        hub_cache, "org/repo", "m-Q4_K_M.gguf", mtime = 1_000_000_000, revision = "older"
+    )
+    _write_cached_gguf(hub_cache, "org/repo", "m-Q8_0.gguf", mtime = 2_000_000_000, revision = "newer")
+    _point_ref_at(repo_dir, "newer")
+
+    response = _cached_repo_variants(monkeypatch, hub_cache, repo_dir)
+
+    assert [v.quant for v in response.variants] == ["Q8_0", "Q4_K_M"]
+    assert all(v.downloaded for v in response.variants)
+
+
+def test_merged_unlabelled_quants_are_told_apart(monkeypatch, tmp_path):
+    """Two revisions each hold the only unnamed quant they can see."""
+    hub_cache = tmp_path / "hub"
+    hub_cache.mkdir()
+    repo_dir = _write_cached_gguf(
+        hub_cache, "org/repo", "foo.gguf", mtime = 1_000_000_000, revision = "older"
+    )
+    _write_cached_gguf(hub_cache, "org/repo", "bar.gguf", mtime = 2_000_000_000, revision = "newer")
+    _point_ref_at(repo_dir, "newer")
+
+    response = _cached_repo_variants(monkeypatch, hub_cache, repo_dir)
+
+    assert sorted(v.quant for v in response.variants) == ["bar", "foo"]
+    labels = [v.display_label for v in response.variants]
+    assert labels == ["GGUF \u00b7 bar.gguf", "GGUF \u00b7 foo.gguf"]
+
+
+def test_a_quant_cached_twice_is_listed_once(monkeypatch, tmp_path):
+    """Described by the answering revision, the copy a load opens."""
+    hub_cache = tmp_path / "hub"
+    hub_cache.mkdir()
+    repo_dir = _write_cached_gguf(
+        hub_cache,
+        "org/repo",
+        "m-Q4_K_M.gguf",
+        mtime = 1_000_000_000,
+        revision = "older",
+        size = 128,
+    )
+    _write_cached_gguf(
+        hub_cache,
+        "org/repo",
+        "m-Q4_K_M.gguf",
+        mtime = 2_000_000_000,
+        revision = "newer",
+        size = 64,
+    )
+    _point_ref_at(repo_dir, "newer")
+
+    response = _cached_repo_variants(monkeypatch, hub_cache, repo_dir)
+
+    assert [v.quant for v in response.variants] == ["Q4_K_M"]
+    # The answering revision's copy, not the sibling's, so the row matches what a load opens.
+    assert response.variants[0].size_bytes == 64
+
+
+def test_a_sibling_revisions_torn_quant_is_listed_but_not_ready(monkeypatch, tmp_path):
+    hub_cache = tmp_path / "hub"
+    hub_cache.mkdir()
+    repo_dir = _write_cached_gguf(
+        hub_cache,
+        "org/repo",
+        "m-Q4_K_M-00001-of-00002.gguf",
+        mtime = 1_000_000_000,
+        revision = "older",
+    )
+    _write_cached_gguf(hub_cache, "org/repo", "m-Q8_0.gguf", mtime = 2_000_000_000, revision = "newer")
+    _point_ref_at(repo_dir, "newer")
+
+    response = _cached_repo_variants(monkeypatch, hub_cache, repo_dir)
+
+    by_quant = {v.quant: v for v in response.variants}
+    assert set(by_quant) == {"Q8_0", "Q4_K_M"}
+    assert by_quant["Q8_0"].downloaded is True
+    assert by_quant["Q4_K_M"].downloaded is False
+
+
+def test_a_whole_sibling_copy_replaces_a_torn_one(monkeypatch, tmp_path):
+    """A load skips the shard-short copy for the whole one, so the row must too."""
+    hub_cache = tmp_path / "hub"
+    hub_cache.mkdir()
+    repo_dir = _write_cached_gguf(
+        hub_cache, "org/repo", "m-Q4_K_M.gguf", mtime = 1_000_000_000, revision = "older"
+    )
+    _write_cached_gguf(hub_cache, "org/repo", "m-Q8_0.gguf", mtime = 2_000_000_000, revision = "newer")
+    _write_cached_gguf(
+        hub_cache,
+        "org/repo",
+        "m-Q4_K_M-00001-of-00002.gguf",
+        mtime = 2_000_000_000,
+        revision = "newer",
+    )
+    _point_ref_at(repo_dir, "newer")
+
+    response = _cached_repo_variants(monkeypatch, hub_cache, repo_dir)
+
+    by_quant = {v.quant: v for v in response.variants}
+    assert by_quant["Q4_K_M"].downloaded is True
+    assert by_quant["Q4_K_M"].filename == "m-Q4_K_M.gguf"
+
+
+def test_a_projector_alone_in_a_sibling_does_not_claim_vision(monkeypatch, tmp_path):
+    """A projector serves only its own revision's quants, and this sibling merges none."""
+    hub_cache = tmp_path / "hub"
+    hub_cache.mkdir()
+    repo_dir = _write_cached_gguf(
+        hub_cache, "org/repo", "m-Q8_0.gguf", mtime = 2_000_000_000, revision = "newer"
+    )
+    _write_cached_gguf(
+        hub_cache,
+        "org/repo",
+        "m-Q4_K_M-00001-of-00002.gguf",
+        mtime = 2_000_000_000,
+        revision = "newer",
+    )
+    _write_cached_gguf(
+        hub_cache,
+        "org/repo",
+        "m-Q4_K_M-00001-of-00002.gguf",
+        mtime = 1_000_000_000,
+        revision = "older",
+    )
+    _write_cached_gguf(
+        hub_cache, "org/repo", "mmproj-F16.gguf", mtime = 1_000_000_000, revision = "older"
+    )
+    _point_ref_at(repo_dir, "newer")
+
+    response = _cached_repo_variants(monkeypatch, hub_cache, repo_dir)
+
+    assert response.has_vision is False
+
+
+def test_a_merged_rows_projector_still_flags_vision(monkeypatch, tmp_path):
+    hub_cache = tmp_path / "hub"
+    hub_cache.mkdir()
+    repo_dir = _write_cached_gguf(
+        hub_cache, "org/repo", "m-Q8_0.gguf", mtime = 2_000_000_000, revision = "newer"
+    )
+    _write_cached_gguf(
+        hub_cache, "org/repo", "m-Q4_K_M.gguf", mtime = 1_000_000_000, revision = "older"
+    )
+    _write_cached_gguf(
+        hub_cache, "org/repo", "mmproj-F16.gguf", mtime = 1_000_000_000, revision = "older"
+    )
+    _point_ref_at(repo_dir, "newer")
+
+    response = _cached_repo_variants(monkeypatch, hub_cache, repo_dir)
+
+    assert [v.quant for v in response.variants] == ["Q8_0", "Q4_K_M"]
+    assert response.has_vision is True
+
+
+def test_a_replaced_row_does_not_keep_its_donors_vision(monkeypatch, tmp_path):
+    """Its revision is superseded by a whole copy with no projector, so the flag goes too."""
+    hub_cache = tmp_path / "hub"
+    hub_cache.mkdir()
+    repo_dir = _write_cached_gguf(
+        hub_cache, "org/repo", "m-Q8_0.gguf", mtime = 3_000_000_000, revision = "newest"
+    )
+    _write_cached_gguf(
+        hub_cache,
+        "org/repo",
+        "m-Q4_K_M-00001-of-00002.gguf",
+        mtime = 2_000_000_000,
+        revision = "middle",
+    )
+    _write_cached_gguf(
+        hub_cache, "org/repo", "mmproj-F16.gguf", mtime = 2_000_000_000, revision = "middle"
+    )
+    _write_cached_gguf(
+        hub_cache, "org/repo", "m-Q4_K_M.gguf", mtime = 1_000_000_000, revision = "oldest"
+    )
+    _point_ref_at(repo_dir, "newest")
+
+    response = _cached_repo_variants(monkeypatch, hub_cache, repo_dir)
+
+    by_quant = {v.quant: v for v in response.variants}
+    assert by_quant["Q4_K_M"].downloaded is True
+    assert response.has_vision is False
+
+
+def test_the_unreachable_hub_fallback_also_unions(monkeypatch, tmp_path):
+    hub_cache = tmp_path / "hub"
+    hub_cache.mkdir()
+    repo_dir = _write_cached_gguf(
+        hub_cache, "org/repo", "m-Q4_K_M.gguf", mtime = 1_000_000_000, revision = "older"
+    )
+    _write_cached_gguf(hub_cache, "org/repo", "m-Q8_0.gguf", mtime = 2_000_000_000, revision = "newer")
+    _point_ref_at(repo_dir, "newer")
+
+    response = _cached_repo_variants(monkeypatch, hub_cache, repo_dir, prefer_local_cache = False)
+
+    assert [v.quant for v in response.variants] == ["Q8_0", "Q4_K_M"]
+
+
+def test_a_repo_outside_the_active_cache_gains_no_siblings(monkeypatch, tmp_path):
+    """Such a row loads by the directory it names, not by id."""
+    active = tmp_path / "active"
+    other = tmp_path / "other"
+    active.mkdir()
+    other.mkdir()
+    repo_dir = _write_cached_gguf(
+        other, "org/repo", "m-Q4_K_M.gguf", mtime = 1_000_000_000, revision = "older"
+    )
+    _write_cached_gguf(other, "org/repo", "m-Q8_0.gguf", mtime = 2_000_000_000, revision = "newer")
+    _point_ref_at(repo_dir, "newer")
+
+    response = _cached_repo_variants(monkeypatch, other, repo_dir, active = active)
+
+    assert [v.quant for v in response.variants] == ["Q8_0"]
+
+
+def test_a_row_pinned_to_one_revision_gains_no_siblings(monkeypatch, tmp_path):
+    """A pinned row loads out of that directory alone, so nothing else may be offered on it."""
+    hub_cache = tmp_path / "hub"
+    hub_cache.mkdir()
+    repo_dir = _write_cached_gguf(
+        hub_cache, "org/repo", "m-Q4_K_M.gguf", mtime = 1_000_000_000, revision = "older"
+    )
+    _write_cached_gguf(hub_cache, "org/repo", "m-Q8_0.gguf", mtime = 2_000_000_000, revision = "newer")
+    _point_ref_at(repo_dir, "newer")
+
+    response = _cached_repo_variants(
+        monkeypatch, hub_cache, repo_dir, local_path = repo_dir / "snapshots" / "newer"
+    )
+
+    assert [v.quant for v in response.variants] == ["Q8_0"]
 
 
 def test_a_case_variant_repo_dir_still_names_its_snapshot(monkeypatch, tmp_path):


### PR DESCRIPTION
## Behavior

A GGUF repo that upstream re-uploads leaves the user's quants spread across two cache revisions. Studio's On-device card lists the quants of **one** of them, so a quant held only in the other disappears from the model list while its files stay on disk. It cannot be selected, run, updated or deleted from the row that owns it, and the row's size counts bytes it will not account for. Because the "Update available" cue is attached to a listed row, that quant never gets one either.

Reproduced on a real cache: `unsloth/Qwen3.8-27B-GGUF` downloaded at `UD-Q2_K_XL` before the 2026-08-19 re-upload, then `UD-IQ1_S` from the new revision. The row reports 16,868,645,952 bytes and offers one 6.19 GB quant.

### Before / After
<img width="1278" height="1300" alt="图片" src="https://github.com/user-attachments/assets/6995e52c-9356-4f0c-8677-412736a19135" />


## Root cause

The local listing calls `select_gguf_cache_snapshot`, which answers "which directory would a load resolve to". That question is genuinely single-valued and the selector is right about it, but the inventory is asking a different one — "what does this user have" — which is a union over the repo's revisions. The selected revision is the last-written one holding a whole quant, chosen by directory mtime rather than by commit recency, so this is not "the new revision hides the old" but "the last-written revision hides every other".

## What changed

`merge_sibling_snapshot_variants` widens the selector's answer with the quants the repo directory's other revisions hold. A quant whole in some revision is described by that copy, which is the one a load opens; a quant torn everywhere keeps a torn row so it can still be resumed or deleted. The vision flag follows the copies finally listed, so a projector cannot outlive the row it arrived with. Both local-answer paths use it — the `prefer_local_cache` branch the On-device card and chat auto-load call, and the fallback taken when the Hub is unreachable.

Display labels are recomputed over the merged list, and only when a revision actually contributed. The per-revision scan disambiguates colliding names within the revision it scanned, so two revisions each holding their own unnamed GGUF would otherwise produce two rows named `GGUF` with different quant keys.

`select_gguf_cache_snapshot` is unchanged, so the answering revision, the context-length read and every load-side caller resolve against the same directory as before.

## Reviewer-relevant constraints

**Widening is gated on the row loading by repo id.** `cached_gguf_for_load` searches the revisions for a requested quant only for such a row; a row whose `load_id` is a snapshot directory loads out of that directory alone, and offering it a sibling's quant would produce a row that cannot resolve. Existing tests in `tests/test_hf_cache_dangling_refs.py` assert `offered ⊆ resolvable-from-load_id` and fail without the gate.

**The gate is a sufficient condition, not the inventory's own decision**: the repo in the active cache, `refs/main` resolving to the revision that answered, and that revision holding a whole quant. Other shapes also load by id — a ref naming a different complete revision, or a repo whose revisions are all torn — and keep listing a single revision, exactly as they do today. Recognising them means reconstructing the inventory's load decision from less information than the inventory uses, which is how a row ends up offered a quant it cannot resolve. Closing that remainder belongs in the inventory layer, where the decision already lives, not here.

**Merging stays inside one repo cache directory.** A cache can hold two that differ only in case; the inventory row owns one of them, so merging across them could describe a row with files it does not own.

## Validation

Focused suites across the GGUF listing, cache-scan, offline-fallback, auto-switch and hub service tests:

```
1979 passed, 2 failed
```

Both failures reproduce unchanged on `main` and are unrelated (`test_every_shipped_video_family_resolves_on_this_diffusers`, a diffusers version check; `test_the_sweep_will_not_cross_a_case_variant_directory`, which needs a case-sensitive filesystem). No existing assertion was changed or weakened.

Ten mutations were run against the new code, each killing exactly the intended tests and nothing else: the merge forced to a no-op; a whole sibling copy never replacing a torn one; merged quants forced ready; the duplicate filter removed; the vision flag never propagated; the vision flag propagated unconditionally; the vision flag made sticky across a replacement; each half of the gate removed; the merged-list relabel removed. Removing the gate kills three pre-existing tests in `tests/test_hf_cache_dangling_refs.py`, which is how it is shown to be load-bearing.

End-to-end against live Hub metadata with both files hash-verified against the revisions upstream publishes for them, the local listing goes from one quant to two with both ready, and the single-revision case is unchanged.

