### PR TITLE
Studio: size a large tool result to the window the model is running with

### DIFF
--- a/studio/backend/core/inference/studio_tool_loop.py
+++ b/studio/backend/core/inference/studio_tool_loop.py
@@ -1233,6 +1233,11 @@ async def stream_with_studio_tools(
                 # an external model's window, and a custom OpenAI-compatible endpoint can
                 # be a small local server, so a model-chosen 8 chunks is roughly 4K tokens
                 # replayed on every later call. Unmeasurable means one recall's worth.
+                # Explicitly unknowable, not absent: this request is served by an
+                # external provider, so the resident GGUF's window says nothing about
+                # what it can hold. 0 keeps the default page cap instead of inheriting it.
+                if accepts_kwarg(execute_tool, "context_tokens"):
+                    kwargs["context_tokens"] = 0
                 if accepts_kwarg(execute_tool, "conversation_budget_tokens"):
                     try:
                         from core.rag import config as rag_config

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -39,7 +39,8 @@ from contextvars import ContextVar
 # model hand the full 16,000 characters to a small OpenAI-compatible endpoint.
 _UNSET_CONTEXT_TOKENS = object()
 _REQUEST_CONTEXT_TOKENS: ContextVar = ContextVar(
-    "unsloth_request_context_tokens", default = _UNSET_CONTEXT_TOKENS,
+    "unsloth_request_context_tokens",
+    default = _UNSET_CONTEXT_TOKENS,
 )
 
 import uuid

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -10831,6 +10831,12 @@ def build_rag_autoinject(conversation: list[dict], rag_scope: dict | None) -> di
 
 
 _MAX_PAGE_CHARS = 16000  # cap fetched page text (after HTML-to-MD conversion)
+# Share of the loaded window one fetched page may claim. The same window also has to hold
+# the system prompt, the carried-forward block, the user's turn, the call itself and room
+# to answer, so a third is already generous.
+_PAGE_CONTEXT_SHARE = 0.35
+# Below this a page is too clipped to answer from, so the fetch is not worth making small.
+_MIN_PAGE_CHARS = 2000
 # Raw download cap > _MAX_PAGE_CHARS since SSR pages embed large <head> sections
 # stripped during conversion; 512 KB still reaches article content.
 _MAX_FETCH_BYTES = 512 * 1024
@@ -11615,6 +11621,47 @@ def _looks_like_html_document(body: str) -> bool:
     return bool(_HTML_DOCUMENT_RE.match(probe))
 
 
+def _loaded_context_tokens() -> int | None:
+    """The active model's context window, or None when it cannot be read.
+
+    Mirrors `research_runs._loaded_context_length`: the ML backends live in a worker
+    subprocess, so the in-process singleton is unpopulated here and importing it pulls in
+    the ML stack. Read the orchestrator the routes use instead, and treat every failure as
+    "unknown" so a fetch is never blocked by not knowing.
+    """
+    try:
+        from routes.inference import get_llama_cpp_backend  # noqa: PLC0415
+
+        llama = get_llama_cpp_backend()
+        if getattr(llama, "is_loaded", False):
+            ctx = getattr(llama, "context_length", None)
+            if isinstance(ctx, int) and ctx > 0:
+                return ctx
+    except Exception:  # noqa: BLE001 -- an unreadable window is "unknown", never an error
+        return None
+    return None
+
+
+def _page_char_budget() -> int:
+    """`_MAX_PAGE_CHARS`, lowered to what the loaded window can actually hold.
+
+    16,000 characters is roughly 4,000 tokens: fine on a 128k model, nonsensical on a
+    4,864-token one. Measured there, a single fetched page came back at 12,295 characters,
+    the request went irreducible at 8,995 tokens against a 3,648-token budget with
+    `latest_turn_role: "tool"`, and the user was advised to shorten a conversation
+    consisting of one 11-token question. Nothing downstream can recover from it either:
+    the fit protects the newest turn, so compaction may not drop the very result that does
+    not fit.
+
+    Above roughly an 11k window this returns the old constant unchanged, so only the models
+    that cannot afford a whole page are affected.
+    """
+    ctx = _loaded_context_tokens()
+    if not ctx:
+        return _MAX_PAGE_CHARS
+    return max(_MIN_PAGE_CHARS, min(_MAX_PAGE_CHARS, int(ctx * 4 * _PAGE_CONTEXT_SHARE)))
+
+
 def _truncate_page_text(text: str, max_chars: int) -> str:
     if not text:
         return "(page returned no readable text)"
@@ -11625,7 +11672,9 @@ def _truncate_page_text(text: str, max_chars: int) -> str:
 
 def _fetch_page_text(
     url: str,
-    max_chars: int = _MAX_PAGE_CHARS,
+    # Resolved per call rather than bound at import: the default would freeze the constant
+    # before any model is loaded, which is exactly when the window is still unknown.
+    max_chars: int | None = None,
     timeout: int = 30,
     cancel_event = None,
     website_policy: dict | None = None,
@@ -11639,6 +11688,8 @@ def _fetch_page_text(
     instead of the repo page's UI chrome. Blocks private/loopback/link-local
     targets (SSRF protection) and caps the download size.
     """
+    if max_chars is None:
+        max_chars = _page_char_budget()
     # One wall-clock budget for the whole fetch. The README API attempt and its
     # HTML fallback both draw from it, so a slow/failed API call cannot hand the
     # fallback a fresh full timeout and double the worst case.

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -29,6 +29,19 @@ import sys
 import tempfile
 import contextlib
 import threading
+from contextvars import ContextVar
+
+# The window of the model THIS request is served by, set by execute_tool for the call's
+# duration. Left unset, the budget falls back to the process-global probe, which is right
+# for the local loops and wrong for anything else: an external-provider request runs
+# Studio's tool loop without touching a resident GGUF, so inheriting that GGUF's window
+# let a small resident model truncate pages for a large cloud model, and a large resident
+# model hand the full 16,000 characters to a small OpenAI-compatible endpoint.
+_UNSET_CONTEXT_TOKENS = object()
+_REQUEST_CONTEXT_TOKENS: ContextVar = ContextVar(
+    "unsloth_request_context_tokens", default = _UNSET_CONTEXT_TOKENS,
+)
+
 import uuid
 import time
 import urllib.parse
@@ -10007,6 +10020,7 @@ def execute_tool(
     conversation_branch: list[dict] | None = None,
     conversation_budget_tokens: int | None = None,
     conversation_token_counter = None,
+    context_tokens = _UNSET_CONTEXT_TOKENS,
 ) -> str:
     """Execute a tool by name with the given arguments; returns a string.
 
@@ -10026,6 +10040,9 @@ def execute_tool(
     ``website_policy``: hidden server-validated domain limits for web_search.
     """
     logger.info(f"execute_tool: name={name}, session_id={session_id}, timeout={timeout}")
+    # Set unconditionally, so a value from an earlier call on this thread can never be
+    # read by a later one. That is what makes a try/finally reset unnecessary here.
+    _REQUEST_CONTEXT_TOKENS.set(context_tokens)
     effective_timeout = _EXEC_TIMEOUT if timeout is _TIMEOUT_UNSET else timeout
     if name == "search_knowledge_base":
         return _search_knowledge_base_with_budget(
@@ -10831,6 +10848,7 @@ def build_rag_autoinject(conversation: list[dict], rag_scope: dict | None) -> di
 
 
 _MAX_PAGE_CHARS = 16000  # cap fetched page text (after HTML-to-MD conversion)
+
 # Share of the loaded window one fetched page may claim. The same window also has to hold
 # the system prompt, the carried-forward block, the user's turn, the call itself and room
 # to answer, so a third is already generous.
@@ -11624,10 +11642,17 @@ def _looks_like_html_document(body: str) -> bool:
 def _loaded_context_tokens() -> int | None:
     """The active model's context window, or None when it cannot be read.
 
-    Mirrors `research_runs._loaded_context_length`: the ML backends live in a worker
-    subprocess, so the in-process singleton is unpopulated here and importing it pulls in
-    the ML stack. Read the orchestrator the routes use instead, and treat every failure as
-    "unknown" so a fetch is never blocked by not knowing.
+    Mirrors `research_runs._loaded_context_length` and `routes.inference.
+    _monitor_context_length`: llama.cpp first, then the orchestrator the API layer reads.
+    Both branches are needed. A native/Transformers chat leaves `is_loaded` false, and
+    stopping at that probe reported "unknown", which kept the full 16,000-character cap
+    and reproduced on small native models exactly the overflow this budget exists to
+    prevent.
+
+    The ML backends live in a worker subprocess, so the in-process singleton is
+    unpopulated here and importing it pulls in the ML stack; peek at the orchestrator
+    instead of constructing one. Every failure is "unknown" so a fetch is never blocked by
+    not knowing.
     """
     try:
         from routes.inference import get_llama_cpp_backend  # noqa: PLC0415
@@ -11637,12 +11662,28 @@ def _loaded_context_tokens() -> int | None:
             if isinstance(ctx, int) and ctx > 0:
                 return ctx
     except Exception:  # noqa: BLE001 -- an unreadable window is "unknown", never an error
+        pass
+    try:
+        from core.research_runs import _peek_inference_backend  # noqa: PLC0415
+
+        backend = _peek_inference_backend()
+        name = getattr(backend, "active_model_name", None)
+        models = getattr(backend, "models", {}) or {}
+        info = models.get(name) if (name and isinstance(models, dict)) else None
+        for candidate in (
+            (info or {}).get("context_length"),
+            getattr(backend, "context_length", None),
+            getattr(backend, "max_seq_length", None),
+        ):
+            if isinstance(candidate, int) and candidate > 0:
+                return candidate
+    except Exception:  # noqa: BLE001 -- same rule: unknown, never an error
         return None
     return None
 
 
 def _page_char_budget() -> int:
-    """`_MAX_PAGE_CHARS`, lowered to what the loaded window can actually hold.
+    """`_MAX_PAGE_CHARS`, lowered to what the serving window can actually hold.
 
     16,000 characters is roughly 4,000 tokens: fine on a 128k model, nonsensical on a
     4,864-token one. Measured there, a single fetched page came back at 12,295 characters,
@@ -11655,7 +11696,10 @@ def _page_char_budget() -> int:
     Above roughly an 11k window this returns the old constant unchanged, so only the models
     that cannot afford a whole page are affected.
     """
-    ctx = _loaded_context_tokens()
+    scoped = _REQUEST_CONTEXT_TOKENS.get()
+    # An explicit 0/None means "asked, and unknowable" (external provider), and must NOT
+    # fall through to the probe. Only an absent value keeps the process-global read.
+    ctx = _loaded_context_tokens() if scoped is _UNSET_CONTEXT_TOKENS else scoped
     if not ctx:
         return _MAX_PAGE_CHARS
     return max(_MIN_PAGE_CHARS, min(_MAX_PAGE_CHARS, int(ctx * 4 * _PAGE_CONTEXT_SHARE)))

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -11683,6 +11683,31 @@ def _loaded_context_tokens() -> int | None:
     return None
 
 
+def _result_char_budget(cap: int) -> int:
+    """`cap`, lowered to what the serving window can actually hold.
+
+    Shared by fetched pages and by terminal/python results, because the failure is the
+    same: a fixed character cap has no relation to the loaded context, so on a small
+    window one result fills most of it. That result lands in the NEWEST turn, which the
+    fit protects, so compaction cannot drop the very thing that does not fit and the
+    request goes irreducible. Measured live on a 5120-token window: 7043 and 6684 token
+    requests refused, both on the code tools, whose 16,000-character cap is about 4,000
+    tokens on its own.
+    """
+    scoped = _REQUEST_CONTEXT_TOKENS.get()
+    # An explicit 0/None means "asked, and unknowable" (external provider), and must NOT
+    # fall through to the probe. Only an absent value keeps the process-global read.
+    ctx = _loaded_context_tokens() if scoped is _UNSET_CONTEXT_TOKENS else scoped
+    if not ctx:
+        return cap
+    return max(_MIN_PAGE_CHARS, min(cap, int(ctx * 4 * _PAGE_CONTEXT_SHARE)))
+
+
+def _tool_result_char_budget() -> int:
+    """The terminal/python cap, sized to the window. See `_result_char_budget`."""
+    return _result_char_budget(_MAX_OUTPUT_CHARS)
+
+
 def _page_char_budget() -> int:
     """`_MAX_PAGE_CHARS`, lowered to what the serving window can actually hold.
 
@@ -13163,7 +13188,11 @@ def _cancel_watcher(
         cancel_event.wait(poll_interval) if cancel_event else None
 
 
-def _truncate(text: str, limit: int = _MAX_OUTPUT_CHARS) -> str:
+def _truncate(text: str, limit: int | None = None) -> str:
+    # Resolved per call, not bound at import: the default would freeze the constant
+    # before any model is loaded, which is exactly when the window is still unknown.
+    if limit is None:
+        limit = _tool_result_char_budget()
     # Mode-neutral notice: this result serves both the streaming UI and
     # non-streaming callers and must stay byte-identical with and without an
     # output_callback (a regression-tested invariant), so it can't claim the

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -11631,7 +11631,6 @@ def _loaded_context_tokens() -> int | None:
     """
     try:
         from routes.inference import get_llama_cpp_backend  # noqa: PLC0415
-
         llama = get_llama_cpp_backend()
         if getattr(llama, "is_loaded", False):
             ctx = getattr(llama, "context_length", None)

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -10856,6 +10856,8 @@ _MAX_PAGE_CHARS = 16000  # cap fetched page text (after HTML-to-MD conversion)
 _PAGE_CONTEXT_SHARE = 0.35
 # Below this a page is too clipped to answer from, so the fetch is not worth making small.
 _MIN_PAGE_CHARS = 2000
+# A percent-escape is one non-ASCII byte written in ASCII, and tokenises like one.
+_HEX_PAIR_RE = re.compile(r"[0-9A-Fa-f]{2}")
 # Raw download cap > _MAX_PAGE_CHARS since SSR pages embed large <head> sections
 # stripped during conversion; 512 KB still reaches article content.
 _MAX_FETCH_BYTES = 512 * 1024
@@ -11731,9 +11733,69 @@ def _page_char_budget() -> int:
     return max(_MIN_PAGE_CHARS, min(_MAX_PAGE_CHARS, int(ctx * 4 * _PAGE_CONTEXT_SHARE)))
 
 
+def _window_context_tokens() -> int | None:
+    """The window this request is served by, or None when it cannot be read."""
+    scoped = _REQUEST_CONTEXT_TOKENS.get()
+    # An explicit 0/None means "asked, and unknowable" (external provider), and must NOT
+    # fall through to the probe. Only an absent value keeps the process-global read.
+    ctx = _loaded_context_tokens() if scoped is _UNSET_CONTEXT_TOKENS else scoped
+    return ctx if ctx else None
+
+
+def _dense_prefix_chars(text: str, token_budget: float) -> int:
+    """How many leading characters of `text` cost at most `token_budget` tokens.
+
+    Four characters per token is an English rate. Measured with Qwen3, Llama 3.2 and
+    tiktoken on real fetched pages, CJK prose runs 1.3-1.6 characters per token, and the
+    percent-escaped links a CJK page is full of (`%E7%9F%A5`) run 1.3-1.5: both are the
+    same non-ASCII bytes, one spelled in ASCII. Charging them a token each, the rule
+    `context_window.estimate_messages_tokens_dense` already uses, keeps the share the
+    caller asked to reserve a share instead of the whole budget.
+
+    One pass, so it costs nothing next to the fetch it sizes.
+    """
+    spent = 0.0
+    index = 0
+    length = len(text)
+    while index < length:
+        start = index
+        if text[index] == "%" and _HEX_PAIR_RE.match(text, index + 1):
+            spent += 3.0  # a non-ASCII byte spelled in ASCII; charge it like one
+            index += 3
+        else:
+            spent += 1.0 if ord(text[index]) > 127 else 0.25
+            index += 1
+        # Cut on whole characters (and whole escapes), so the tail is never half a
+        # percent-escape the model has to guess at.
+        if spent > token_budget:
+            return start
+    return length
+
+
+def _dense_char_limit(text: str, max_chars: int) -> int:
+    """`max_chars`, lowered when `text` tokenises denser than four characters per token.
+
+    Without this the window-derived caps above reserve their share only for English. On
+    the 4,864-token window this PR was measured against, the 6,809-character page budget
+    is 35% of the window in English and 3,800-4,500 real tokens of a Chinese or Japanese
+    page: 80-95% of the whole prompt budget, in the newest turn, which the fit protects.
+    That is the same irreducible refusal the budget exists to prevent.
+    """
+    ctx = _window_context_tokens()
+    if not ctx or len(text) <= _MIN_PAGE_CHARS:
+        return max_chars
+    # Kept a float, so English text lands on exactly the character budget rather than
+    # one character short of it.
+    fitted = _dense_prefix_chars(text, ctx * _PAGE_CONTEXT_SHARE)
+    # Never above what the caller allowed, and never below the floor that keeps a page
+    # worth reading. An explicit cap smaller than the floor still wins.
+    return min(max_chars, max(_MIN_PAGE_CHARS, fitted))
+
+
 def _truncate_page_text(text: str, max_chars: int) -> str:
     if not text:
         return "(page returned no readable text)"
+    max_chars = _dense_char_limit(text, max_chars)
     if len(text) > max_chars:
         return text[:max_chars] + f"\n\n... (truncated, {len(text)} chars total)"
     return text
@@ -13193,6 +13255,10 @@ def _truncate(text: str, limit: int | None = None) -> str:
     # before any model is loaded, which is exactly when the window is still unknown.
     if limit is None:
         limit = _tool_result_char_budget()
+    # Same correction as a fetched page: a character cap reserves its share of the window
+    # only for English, and a command that prints CJK or percent-escaped text costs two to
+    # three times what the cap assumed.
+    limit = _dense_char_limit(text, limit)
     # Mode-neutral notice: this result serves both the streaming UI and
     # non-streaming callers and must stay byte-identical with and without an
     # output_callback (a regression-tested invariant), so it can't claim the

--- a/studio/backend/tests/test_web_page_cap_fits_window.py
+++ b/studio/backend/tests/test_web_page_cap_fits_window.py
@@ -1,0 +1,110 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""A fetched page has to fit the window the model is actually running with.
+
+The flat 16,000-character cap is roughly 4,000 tokens. On a 128k model that is nothing;
+on the 4,864-token model this was measured against it is larger than the entire prompt
+budget, and nothing downstream can recover: the fit protects the newest turn, so
+compaction may not drop the oversized tool result, and the request is refused outright.
+
+Measured, from a two-message thread (one 11-token question, one assistant turn with two
+web_search calls):
+
+    latest_turn_role   = "tool"
+    latest_turn_tokens = 8154
+    irreducible_tokens = 8389
+    prompt_target      = 3648
+    dropped_messages   = 0      nothing to evict; the thread IS the tool result
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from core.inference import tools
+
+
+@pytest.fixture(autouse = True)
+def _unknown_window(monkeypatch):
+    """Default to "no model loaded" so each test states the window it means."""
+    monkeypatch.setattr(tools, "_loaded_context_tokens", lambda: None)
+
+
+def _window(monkeypatch, ctx):
+    monkeypatch.setattr(tools, "_loaded_context_tokens", lambda: ctx)
+
+
+def test_a_small_window_gets_a_page_it_can_hold(monkeypatch):
+    """The case that failed. 4,864 tokens leaves 3,648 for the prompt, and the page that
+    broke it was 12,295 characters, roughly 3,073 tokens: 84% of the budget for one
+    search, before the system turn, the question or room to answer."""
+    _window(monkeypatch, 4864)
+
+    budget = tools._page_char_budget()
+
+    assert budget < 12_295, "the page that caused the refusal must no longer fit"
+    # And still worth reading rather than a stub.
+    assert budget >= tools._MIN_PAGE_CHARS
+
+
+def test_a_large_window_is_left_exactly_as_it_was(monkeypatch):
+    """The blast radius. Above roughly an 11k window the old constant is returned
+    unchanged, so no model that could already afford a whole page sees any difference."""
+    for ctx in (16_384, 32_768, 131_072):
+        _window(monkeypatch, ctx)
+        assert tools._page_char_budget() == tools._MAX_PAGE_CHARS
+
+
+def test_an_unknown_window_keeps_the_old_constant():
+    """Not knowing the window must never shrink a fetch: that would silently degrade
+    every provider path where the local backend is not the one answering."""
+    assert tools._page_char_budget() == tools._MAX_PAGE_CHARS
+
+
+def test_a_tiny_window_still_returns_a_readable_page(monkeypatch):
+    """A floor, not a proportion all the way down. Below it the fetch would return a
+    fragment too clipped to answer from, which is worse than a truncated page: the model
+    cannot tell a short page from a cut one without the notice."""
+    _window(monkeypatch, 512)
+
+    assert tools._page_char_budget() == tools._MIN_PAGE_CHARS
+
+
+def test_the_budget_never_exceeds_the_absolute_cap(monkeypatch):
+    """The window only ever LOWERS the cap. A 1M-token model does not get a 1.4MB page."""
+    _window(monkeypatch, 1_000_000)
+
+    assert tools._page_char_budget() == tools._MAX_PAGE_CHARS
+
+
+def test_an_unreadable_backend_is_unknown_rather_than_an_error(monkeypatch):
+    """Every failure reading the window is "unknown", so a fetch is never blocked by the
+    orchestrator being unavailable. Exercises the REAL reader, not a stub of it: stubbing
+    `_loaded_context_tokens` would step over the very try/except under test."""
+    import routes.inference as routes_inference
+
+    def _boom():
+        raise RuntimeError("backend gone")
+
+    monkeypatch.undo()  # drop the autouse stub; this test owns the reader
+    monkeypatch.setattr(routes_inference, "get_llama_cpp_backend", _boom)
+
+    assert tools._loaded_context_tokens() is None
+    assert tools._page_char_budget() == tools._MAX_PAGE_CHARS
+
+
+def test_the_caller_can_still_pin_a_size(monkeypatch):
+    """An explicit `max_chars` wins over the window, so callers that size their own budget
+    and the extraction tests that pin exact output are unaffected."""
+    _window(monkeypatch, 4864)
+    captured = {}
+
+    def _fake_truncate(text, max_chars):
+        captured["max_chars"] = max_chars
+        return text[:max_chars]
+
+    monkeypatch.setattr(tools, "_truncate_page_text", _fake_truncate)
+    # The signature default is None, so an explicit value must survive to the truncation.
+    assert tools._truncate_page_text("x" * 50_000, 200) == "x" * 200
+    assert captured["max_chars"] == 200

--- a/studio/backend/tests/test_web_page_cap_fits_window.py
+++ b/studio/backend/tests/test_web_page_cap_fits_window.py
@@ -31,6 +31,11 @@ from core.inference import tools
 def _unknown_window(monkeypatch):
     """Default to "no model loaded" so each test states the window it means."""
     monkeypatch.setattr(tools, "_loaded_context_tokens", lambda: None)
+    # The request-scoped window is module state that outlives a test, and execute_tool
+    # sets it deliberately. Restore it so one test cannot decide another's budget.
+    token = tools._REQUEST_CONTEXT_TOKENS.set(tools._UNSET_CONTEXT_TOKENS)
+    yield
+    tools._REQUEST_CONTEXT_TOKENS.reset(token)
 
 
 def _window(monkeypatch, ctx):
@@ -178,3 +183,63 @@ class TestTheWindowIsReadPerRequest:
     def test_execute_tool_scopes_the_window_for_the_call(self):
         tools.execute_tool("render_html", {"html": "<p>x</p>"}, context_tokens = 4864)
         assert tools._REQUEST_CONTEXT_TOKENS.get() == 4864
+
+
+class TestToolResultsAlsoFitTheWindow:
+    """The code tools had the same fixed-cap defect as fetched pages.
+
+    Observed live on a 5120-token window: two requests refused at 7043 and 6684 tokens,
+    both on the terminal/python tools, whose 16,000-character cap is about 4,000 tokens
+    on its own. The result lands in the NEWEST turn, which the fit protects, so
+    compaction cannot drop the one thing that does not fit and the request is
+    irreducible rather than merely large.
+    """
+
+    def test_a_small_window_shrinks_the_tool_result_cap(self, monkeypatch):
+        _window(monkeypatch, 5120)
+
+        budget = tools._tool_result_char_budget()
+
+        assert budget < tools._MAX_OUTPUT_CHARS
+        # Roughly 1,800 tokens rather than 4,000, which is what brought the live
+        # 7,043-token request back under a 5,120-token window.
+        assert budget <= 5120 * 4 * tools._PAGE_CONTEXT_SHARE
+
+    def test_a_large_window_keeps_the_full_cap(self, monkeypatch):
+        for ctx in (32_768, 131_072, 262_144):
+            _window(monkeypatch, ctx)
+            assert tools._tool_result_char_budget() == tools._MAX_OUTPUT_CHARS
+
+    def test_an_unknown_window_keeps_the_full_cap(self):
+        # Not knowing must never shrink a result: that would silently degrade every
+        # provider path where the local backend is not the one answering.
+        assert tools._tool_result_char_budget() == tools._MAX_OUTPUT_CHARS
+
+    def test_an_external_request_keeps_the_full_cap(self, monkeypatch):
+        _window(monkeypatch, 5120)
+        token = tools._REQUEST_CONTEXT_TOKENS.set(0)
+        try:
+            assert tools._tool_result_char_budget() == tools._MAX_OUTPUT_CHARS
+        finally:
+            tools._REQUEST_CONTEXT_TOKENS.reset(token)
+
+    def test_truncate_resolves_its_limit_per_call(self, monkeypatch):
+        """Bound at import, the default would freeze before any model is loaded."""
+        _window(monkeypatch, 5120)
+        text = "x" * 20_000
+
+        out = tools._truncate(text)
+
+        assert len(out) < len(text)
+        assert "truncated to" in out
+
+    def test_an_explicit_limit_still_wins(self, monkeypatch):
+        _window(monkeypatch, 5120)
+
+        assert tools._truncate("x" * 500, limit = 100).startswith("x" * 100)
+        assert tools._truncate("x" * 50, limit = 100) == "x" * 50
+
+    def test_a_result_that_fits_is_returned_untouched(self, monkeypatch):
+        _window(monkeypatch, 262_144)
+
+        assert tools._truncate("all good") == "all good"

--- a/studio/backend/tests/test_web_page_cap_fits_window.py
+++ b/studio/backend/tests/test_web_page_cap_fits_window.py
@@ -243,3 +243,90 @@ class TestToolResultsAlsoFitTheWindow:
         _window(monkeypatch, 262_144)
 
         assert tools._truncate("all good") == "all good"
+
+
+class TestADenseResultIsSizedByWhatItCosts:
+    """A character cap reserves its share of the window only for English.
+
+    Measured with Qwen3-4B, Llama-3.2 and tiktoken on the real pages the tool fetches:
+    English markdown runs 4.1 characters per token, so 35% of the window is 35%. Chinese
+    and Japanese prose run 1.3-1.6, and the percent-escaped links a CJK page is full of
+    (`/wiki/%E7%9F%A5%E8%AF%86`) run 1.3-1.5. Before this correction, zh.wikipedia and
+    ja.wikipedia articles cut to the 4,864-token budget came back at 3,558-4,511 real
+    tokens: 79-95% of the WHOLE prompt budget, in the newest turn, which the fit protects.
+    That is the irreducible refusal this budget exists to prevent, reproduced.
+    """
+
+    # One paragraph of CJK prose with the wiki-style escaped links that come with it.
+    _CJK_PAGE = ("人工智能是一门研究如何使机器具备智能行为的学科，"
+                 "涵盖[机器学习](/wiki/%E6%9C%BA%E5%99%A8%E5%AD%A6%E4%B9%A0)、"
+                 "[语言处理](/wiki/%E8%87%AA%E7%84%B6%E8%AF%AD%E8%A8%80%E5%A4%84%E7%90%86)"
+                 "和[电脑视觉](/wiki/%E8%AE%A1%E7%AE%97%E6%9C%BA%E8%A7%86%E8%A7%89)。") * 200
+    _EN_PAGE = ("Artificial intelligence is the study of machines that perceive their "
+                "environment and take actions that maximise the chance of a goal. ") * 200
+
+    def _dense_tokens(self, text):
+        from core.inference.context_window import estimate_messages_tokens_dense
+
+        return estimate_messages_tokens_dense([{"role": "tool", "content": text}])
+
+    def test_a_cjk_page_is_cut_to_the_share_it_was_promised(self, monkeypatch):
+        _window(monkeypatch, 4864)
+
+        out = tools._truncate_page_text(self._CJK_PAGE, tools._page_char_budget())
+
+        # The whole point: what lands in the turn costs about the share reserved for it,
+        # not the entire window. A little over for the truncation notice itself.
+        assert self._dense_tokens(out) <= int(4864 * tools._PAGE_CONTEXT_SHARE) + 64
+        # And this is not a no-op: the characters the flat budget would have admitted
+        # do not fit the share by either measure, the repo's dense estimate or the rule
+        # here (which the real tokenizers above put at 79-95% of the prompt budget).
+        flat = self._CJK_PAGE[: tools._page_char_budget()]
+        assert self._dense_tokens(flat) > int(4864 * tools._PAGE_CONTEXT_SHARE)
+        assert tools._dense_prefix_chars(flat, 4864 * tools._PAGE_CONTEXT_SHARE) < len(flat)
+
+    def test_an_english_page_is_left_exactly_as_it_was(self, monkeypatch):
+        """The blast radius: text that really does run four characters per token keeps
+        every character the character budget gave it."""
+        _window(monkeypatch, 4864)
+        budget = tools._page_char_budget()
+
+        assert tools._dense_char_limit(self._EN_PAGE, budget) == budget
+
+    def test_percent_escaped_links_are_charged_like_the_bytes_they_encode(self):
+        """`%E7%9F%A5` is three non-ASCII bytes spelled in ASCII and tokenises like them,
+        so charging it four characters per token undercounts it three-fold."""
+        escaped = "%E7%9F%A5" * 100
+
+        # 300 escapes, a token each for the three bytes they spell: 900 tokens, where
+        # four characters per token would have called the same text 225.
+        assert tools._dense_prefix_chars(escaped, 900) == len(escaped)
+        assert tools._dense_prefix_chars(escaped, 450) == len(escaped) // 2
+        # Cut on a whole escape, never halfway through one.
+        assert tools._dense_prefix_chars(escaped, 451) % 3 == 0
+
+    def test_a_dense_result_never_falls_below_the_readable_floor(self, monkeypatch):
+        _window(monkeypatch, 1024)
+
+        out = tools._truncate_page_text(self._CJK_PAGE, tools._page_char_budget())
+
+        assert len(out) >= tools._MIN_PAGE_CHARS
+
+    def test_an_unknown_window_leaves_a_dense_page_alone(self):
+        """Same rule as the char budget: not knowing must never shrink a fetch."""
+        assert tools._dense_char_limit(self._CJK_PAGE, tools._MAX_PAGE_CHARS) == tools._MAX_PAGE_CHARS
+
+    def test_a_dense_terminal_result_is_sized_too(self, monkeypatch):
+        """The code tools print CJK and escaped URLs as readily as a page carries them."""
+        _window(monkeypatch, 5120)
+
+        out = tools._truncate(self._CJK_PAGE)
+
+        assert self._dense_tokens(out) <= int(5120 * tools._PAGE_CONTEXT_SHARE) + 64
+        assert "truncated to" in out
+
+    def test_an_explicit_limit_is_still_a_ceiling_not_a_floor(self, monkeypatch):
+        """A caller that pins a size smaller than the floor keeps it."""
+        _window(monkeypatch, 4864)
+
+        assert tools._dense_char_limit(self._CJK_PAGE, 200) == 200

--- a/studio/backend/tests/test_web_page_cap_fits_window.py
+++ b/studio/backend/tests/test_web_page_cap_fits_window.py
@@ -20,6 +20,8 @@ web_search calls):
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
 
 from core.inference import tools
@@ -108,3 +110,71 @@ def test_the_caller_can_still_pin_a_size(monkeypatch):
     # The signature default is None, so an explicit value must survive to the truncation.
     assert tools._truncate_page_text("x" * 50_000, 200) == "x" * 200
     assert captured["max_chars"] == 200
+
+
+class TestTheWindowIsReadPerRequest:
+    """Two ways the budget read the wrong window, both found in review.
+
+    The reader stopped at the llama.cpp probe, so a native/Transformers chat left
+    `is_loaded` false and reported "unknown", which kept the full 16,000-character
+    cap on exactly the small models that cannot hold it. And the budget consulted
+    process-global state, so an external-provider request, which never touches a
+    resident GGUF, inherited that GGUF's window in both directions.
+    """
+
+    def test_a_native_model_window_is_read_when_no_gguf_is_loaded(self, monkeypatch):
+        # The autouse fixture stubs the reader out; these exercise the real one.
+        monkeypatch.undo()
+        monkeypatch.setattr(
+            "routes.inference.get_llama_cpp_backend",
+            lambda: SimpleNamespace(is_loaded = False, context_length = None),
+        )
+        monkeypatch.setattr(
+            "core.research_runs._peek_inference_backend",
+            lambda: SimpleNamespace(
+                active_model_name = "native/model",
+                models = {"native/model": {"context_length": 4864}},
+            ),
+        )
+        assert tools._loaded_context_tokens() == 4864
+
+    def test_a_native_window_is_read_even_if_the_gguf_probe_raises(self, monkeypatch):
+        # The llama.cpp branch must fall through, not return None: swallowing the
+        # native answer is what made the reader report "unknown" here.
+        monkeypatch.undo()
+
+        def _boom():
+            raise RuntimeError("no backend")
+
+        monkeypatch.setattr("routes.inference.get_llama_cpp_backend", _boom)
+        monkeypatch.setattr(
+            "core.research_runs._peek_inference_backend",
+            lambda: SimpleNamespace(active_model_name = None, models = {}, max_seq_length = 8192),
+        )
+        assert tools._loaded_context_tokens() == 8192
+
+    def test_an_external_request_does_not_inherit_the_resident_gguf_window(self, monkeypatch):
+        # A large resident GGUF must not hand its budget to a small external endpoint.
+        _window(monkeypatch, 262_144)
+        token = tools._REQUEST_CONTEXT_TOKENS.set(0)
+        try:
+            assert tools._page_char_budget() == tools._MAX_PAGE_CHARS
+        finally:
+            tools._REQUEST_CONTEXT_TOKENS.reset(token)
+
+    def test_a_local_request_still_uses_the_probe_when_nothing_is_scoped(self, monkeypatch):
+        _window(monkeypatch, 4864)
+        assert tools._REQUEST_CONTEXT_TOKENS.get() is tools._UNSET_CONTEXT_TOKENS
+        assert tools._page_char_budget() == 6809
+
+    def test_a_scoped_window_beats_the_probe(self, monkeypatch):
+        _window(monkeypatch, 262_144)
+        token = tools._REQUEST_CONTEXT_TOKENS.set(4864)
+        try:
+            assert tools._page_char_budget() == 6809
+        finally:
+            tools._REQUEST_CONTEXT_TOKENS.reset(token)
+
+    def test_execute_tool_scopes_the_window_for_the_call(self):
+        tools.execute_tool("render_html", {"html": "<p>x</p>"}, context_tokens = 4864)
+        assert tools._REQUEST_CONTEXT_TOKENS.get() == 4864


### PR DESCRIPTION
### What happened

A two-message thread on a 4,864-token model:

1. "Search for the highest grossing film this year" (11 tokens)
2. One assistant turn that called `web_search` twice

Both searches succeeded. The first returned snippets and ended with the tool's own advice:

> IMPORTANT: These are only short snippets. To get the full page content, call web_search with the url parameter.

The model did exactly that, and the fetched page came back at **12,295 characters, roughly 3,073 tokens**, against a **3,648-token prompt budget**. The request was then refused:

```
latest_turn_role   = "tool"     the oversized turn is output the user never wrote
latest_turn_tokens = 8154
irreducible_tokens = 8389
prompt_target      = 3648       (4,864-token window)
dropped_messages   = 0
```

Nothing downstream could recover from it. The fit protects the newest turn, so compaction may not drop the very result that does not fit, and there was nothing else to drop: the whole conversation *was* the tool call. What the user saw was `Message too long: 8995 tokens exceeds the 4864-token context window. Try increasing the Context Length in Model settings, or shorten the conversation` on a thread containing one 11-token question.

The same shape then showed up without any page fetch at all: 7,043- and 6,684-token requests refused on a 5,120-token window, because a **16,000-character terminal result** landed in the protected newest turn. The cap is the same constant, so the fix has to be the same fix.

### The cause

```python
_MAX_PAGE_CHARS = 16000  # cap fetched page text (after HTML-to-MD conversion)
```

A flat constant, independent of the model. 16,000 characters is about 4,000 tokens: negligible on a 128k model, and 110% of the entire window here. The cap never fired for the page, because 12,295 < 16,000, so a result that could not possibly fit was passed through untouched.

### The change

**Every large tool result is sized to the window the model is actually running with** rather than to a fixed constant. Fetched pages, terminal output and python output all resolve to `min(constant, 35% of the window)` with a floor (`_MIN_PAGE_CHARS`) so a result never comes back too clipped to answer from. A third-ish share because the same window also has to hold the system prompt, the carried-forward block, the user's turn, the call itself and room to reply.

The window is read **per request**: a `ContextVar` set by `execute_tool` wins, and otherwise a probe tries llama.cpp first and then the orchestrator, so native and Transformers chats are covered too. The external-provider tool loop passes `context_tokens=0`, meaning "asked, and unknowable", so a cloud request neither inherits nor is throttled by whatever GGUF happens to be resident.

**A character cap only reserves its share for English.** Four characters per token is an English rate; measured with Qwen3, Llama 3.2 and tiktoken against real fetched pages, CJK prose runs 1.3 to 1.6 characters per token, and so do the percent-escaped links a CJK page is full of (`%E7%9F%A5%E8%AF%86`), which are the same non-ASCII bytes spelled in ASCII. On a real `zh.wikipedia.org` article the "35%" budget measured **4,070 tokens against a 4,864-token window, 84% of it** - the same irreducible refusal, reached by a page that is entirely ordinary to fetch. So the char budget is now also capped by a single linear pass charging non-ASCII characters and percent-escapes a token each, the rule `estimate_messages_tokens_dense` already documents. Same page after: **1,473 tokens, 30%**. English is unchanged to within the truncation notice.

Deliberately narrow:

- **Above roughly an 11k window the old constant is returned unchanged** for English, so no model that could already afford a whole page sees a difference.
- **An unreadable window is "unknown" and keeps the constant**, so not knowing never silently shrinks a result.
- **An explicit `max_chars` still wins**, so callers sizing their own budget and the extraction tests that pin exact output are unaffected.
- **The dense correction is a ceiling, never a floor** - it can only lower a budget, and never below the readable floor.

The parameter default moves from `_MAX_PAGE_CHARS` to `None` and resolves per call. Bound at import it would freeze the constant before any model is loaded, which is exactly when the window is not yet known.

### Tests

`tests/test_web_page_cap_fits_window.py`: the 4,864-token window no longer admits the page that caused the refusal; 16k/32k/128k windows are unchanged; an unknown window keeps the constant; a tiny window still returns a readable result; the budget never exceeds the absolute cap; an unreadable backend reads as unknown rather than raising (exercising the real reader, not a stub of it); an explicit size still wins; the terminal and python caps follow the window; and for the dense case, a CJK page is cut to the share it was promised, an English page is left exactly as it was, percent-escapes are charged like the bytes they encode, the readable floor still holds, an unknown window leaves a dense page alone, and a dense terminal result is sized too.

`test_web_page_cap_fits_window`, `test_web_fetch_extraction`, `test_web_access_policy`, `test_web_fetch_binary_guard`, `test_external_tool_truncated_and_budget`, `test_context_overflow_truncation`: **1304 passed**.

### Not fixed here

The same session hit `Research could not be completed: Local model report reached its output limit before completion` on a Deep Research run asking for a 356-day itinerary. That message is accurate rather than a bug: `_completion_hit_context_wall` was false, so the report genuinely exhausted its output budget rather than the window. A 356-day plan does not fit in one response at any small context. Worth a separate look is that the sibling error string for the context-wall case names a remedy ("Increase Context Length in chat settings or reduce the research evidence size") while this one names none.
