### PR TITLE
Run six pinned-symbol jobs on one runner instead of six

### DIFF
--- a/.github/workflows/version-compat-ci.yml
+++ b/.github/workflows/version-compat-ci.yml
@@ -56,10 +56,38 @@ permissions:
   contents: read
 
 jobs:
-  vllm-pinned-symbols:
-    name: vLLM pinned-symbol matrix (≥ 0.9.0 + main)
+  # Six jobs, one runner. Each of these suites fetches raw source from
+  # raw.githubusercontent.com and greps for symbols -- see tests/version_compat/_fetch.py,
+  # `has_def` / `first_match`. No pip install of vllm / torch / transformers is involved,
+  # which is the whole point of the canary and is also what makes co-locating them safe:
+  # there is no venv to conflict over, so "transformers 4.57.6" and "transformers main"
+  # can share one interpreter because neither is installed.
+  #
+  # They were six separate jobs costing six runner slots for 287s of combined work.
+  # Measured over a sampled main commit, each waited 23 to 31 minutes for admission to
+  # execute for 15 to 128 seconds. The queue is the cost, so the slots are the target.
+  #
+  # -n 4, deliberately, and not higher. The work is network-bound rather than CPU-bound,
+  # so more workers looks free and is not: measured locally on the full set,
+  #
+  #     serial   1606 passed, 182 skipped   182.8s
+  #     -n 4     1606 passed, 182 skipped    27.8s
+  #     -n 8     1606 passed, 182 skipped    75.2s
+  #
+  # -n 8 is 2.7x SLOWER than -n 4, which for a fetch-bound suite is upstream throttling
+  # rather than core contention. 4 also matches the hosted runner's core count and the
+  # -n 4 every other pytest job here already uses.
+  #
+  # --dist loadfile keeps each file on one worker, so a suite's tests cannot be split
+  # across workers and interleaved with another's.
+  #
+  # tests/studio/test_version_compat_bundle.py asserts every suite the six jobs named is
+  # still named here. Dropping one would not fail anything: the job would go green having
+  # tested less, which is the only way this change can go wrong.
+  pinned-symbol-matrix:
+    name: pinned-symbol matrix (vLLM, TRL, PEFT, ST, bitsandbytes, transformers)
     runs-on: ubuntu-latest
-    timeout-minutes: 12
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
@@ -68,141 +96,30 @@ jobs:
         with:
           python-version: '3.12'
       - name: Install pytest only
-        # The test fetches from raw.githubusercontent.com and greps
-        # source. No pip install of vllm / torch / transformers is
-        # needed — that's the whole point of this canary.
+        # packaging: the PEFT backfill suite loads unsloth/import_fixes.py by file path and
+        # that module imports packaging.version at the top. It pulls in nothing heavier,
+        # which is why it can run in this dependency-free job at all.
         run: |
           python -m pip install --upgrade pip
-          pip install 'pytest>=8'
-      - name: Run vllm-compat suite
+          pip install 'pytest>=8' 'pytest-xdist>=3' packaging
+      - name: Run every pinned-symbol suite
         env:
-          # Authenticated requests get a 5000-req/h quota on raw
-          # fetches; unauthenticated is 60/h and trips on the matrix.
+          # Authenticated raw fetches get 5000/h; unauthenticated is 60/h and trips on the
+          # matrix. That ceiling is why the worker count stays at 4.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          python -m pytest tests/vllm_compat/test_vllm_pinned_symbols.py -v --tb=short
-
-  trl-grpo-pinned-symbols:
-    name: TRL / GRPO pinned-symbol matrix
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
-        with:
-          persist-credentials: false
-      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
-        with:
-          python-version: '3.12'
-      - name: Install pytest only
-        run: |
-          python -m pip install --upgrade pip
-          pip install 'pytest>=8'
-      - name: Run trl-compat suite
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          # PYTHONPATH=. so `from tests.version_compat._fetch import …`
-          # works without an editable install of unsloth itself.
+          # PYTHONPATH=. so `from tests.version_compat._fetch import ...` works without an
+          # editable install of unsloth itself.
           PYTHONPATH=. python -m pytest \
+            tests/vllm_compat/test_vllm_pinned_symbols.py \
             tests/version_compat/test_trl_grpo_pinned_symbols.py \
-            -v --tb=short
-
-  peft-pinned-symbols:
-    name: PEFT pinned-symbol matrix (pyproject window + main)
-    runs-on: ubuntu-latest
-    timeout-minutes: 8
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
-        with:
-          persist-credentials: false
-      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
-        with:
-          python-version: '3.12'
-      # packaging as well as pytest: the backfill suite loads unsloth/import_fixes.py by
-      # file path, and that module imports packaging.version at the top. It pulls in
-      # nothing heavier, which is why it can run in this dependency-free job at all.
-      - name: Install pytest only
-        run: |
-          python -m pip install --upgrade pip
-          pip install 'pytest>=8' packaging
-      - name: Run peft-compat suite
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          PYTHONPATH=. python -m pytest \
             tests/version_compat/test_peft_pinned_symbols.py \
             tests/version_compat/test_unsloth_zoo_save_merged_pinned_symbols.py \
             tests/version_compat/test_peft_conversion_symbol_backfill.py \
-            -v --tb=short
-
-  st-pinned-symbols:
-    name: sentence-transformers pinned-symbol matrix
-    runs-on: ubuntu-latest
-    timeout-minutes: 8
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
-        with:
-          persist-credentials: false
-      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
-        with:
-          python-version: '3.12'
-      - name: Install pytest only
-        run: |
-          python -m pip install --upgrade pip
-          pip install 'pytest>=8'
-      - name: Run sentence-transformers compat suite
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          PYTHONPATH=. python -m pytest \
             tests/version_compat/test_sentence_transformers_pinned_symbols.py \
-            -v --tb=short
-
-  bitsandbytes-pinned-symbols:
-    name: bitsandbytes pinned-symbol matrix
-    runs-on: ubuntu-latest
-    timeout-minutes: 8
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
-        with:
-          persist-credentials: false
-      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
-        with:
-          python-version: '3.12'
-      - name: Install pytest only
-        run: |
-          python -m pip install --upgrade pip
-          pip install 'pytest>=8'
-      - name: Run bitsandbytes compat suite
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          PYTHONPATH=. python -m pytest \
             tests/version_compat/test_bitsandbytes_pinned_symbols.py \
-            -v --tb=short
-
-  transformers-pinned-symbols:
-    name: transformers pinned-symbol matrix (4.57.6 + 5.x + main)
-    runs-on: ubuntu-latest
-    timeout-minutes: 12
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
-        with:
-          persist-credentials: false
-      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
-        with:
-          python-version: '3.12'
-      - name: Install pytest only
-        run: |
-          python -m pip install --upgrade pip
-          pip install 'pytest>=8'
-      - name: Run transformers compat suite
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          PYTHONPATH=. python -m pytest \
             tests/version_compat/test_transformers_pinned_symbols.py \
-            -v --tb=short
+            -n 4 --dist loadfile -v --tb=short
 
   # Optional second layer: actually `pip install` ONE representative
   # version of each package and verify unsloth + unsloth-zoo modules

--- a/.github/workflows/workflow-trigger-lint.yml
+++ b/.github/workflows/workflow-trigger-lint.yml
@@ -158,6 +158,7 @@ jobs:
             tests/studio/test_smoke_workflows_share_one_script.py \
             tests/studio/test_stt_model_search_locator_contract.py \
             tests/studio/test_uv_cache_discipline.py \
+            tests/studio/test_version_compat_bundle.py \
             tests/studio/test_windows_small_checks_stay_on_their_image.py \
             tests/studio/test_workflow_guards_run_unfiltered.py \
             tests/security

--- a/tests/studio/test_version_compat_bundle.py
+++ b/tests/studio/test_version_compat_bundle.py
@@ -1,0 +1,183 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Six version-compat jobs became one. None of their suites may stop running.
+
+The six pinned-symbol jobs cost six runner slots for 287s of combined work, and on a
+sampled main commit each waited 23 to 31 minutes to be admitted in order to execute for
+15 to 128 seconds. The queue was the cost, so the slots were the target.
+
+Co-locating them is safe for a reason specific to these suites, not a general one: they
+fetch raw source from raw.githubusercontent.com and grep it for symbols (see
+tests/version_compat/_fetch.py, `has_def` / `first_match`). Nothing is pip-installed, so
+there is no venv for "transformers 4.57.6" and "transformers main" to fight over. That is
+why the two HEAVY jobs in the same workflow -- which do install, and install mutually
+exclusive TRL pins -- stay separate and must never be folded in.
+
+The failure this file exists for is the silent one. Deleting a path from the bundled
+pytest line removes a whole compat surface and turns nothing red: the job still runs, still
+passes, and simply proves less. Nothing else in CI would notice, because the suite it
+stopped running is the only thing that was checking that upstream symbol.
+
+So the assertion is coverage, derived from the filesystem: every suite that exists must be
+named by some job that actually runs on a pull request. A new suite file added and never
+wired up fails here too, which is the same bug arriving from the other direction.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+
+
+REPO = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO / ".github" / "workflows" / "version-compat-ci.yml"
+SUITE_DIRS = ("tests/version_compat", "tests/vllm_compat")
+
+# The bundled job. Named, not detected: if it is ever renamed, that should be a
+# deliberate edit here rather than this whole file quietly asserting nothing.
+BUNDLE_JOB = "pinned-symbol-matrix"
+
+# Suites with no pull_request home today. This is a RECORDED GAP, not an approval, and
+# both entries pre-date the bundling change that added this file -- they were found by
+# this test on its first run, which is the point of deriving coverage from the filesystem
+# rather than from a list someone maintains.
+#
+# Neither can join the bundle, because the bundle installs nothing but pytest:
+#
+#   test_import_leaves_torch_globals_alone.py  runs `import torch` inside a subprocess
+#       probe (_PROBE at module scope), so it needs a real torch.
+#   test_trl_vllm_generation_lora_patch.py     needs an installed TRL. It belongs with
+#       grpo-fake-run, which already installs that stack, but is not in that job's pytest
+#       list either. It was not added here because it could not be verified to pass in
+#       that environment first, and wiring an unverified suite into a heavy job would put
+#       an unrelated red on the change that noticed the gap.
+#
+# Both are swept by the cron-only `daily-fresh-fetch` job, so they are checked daily
+# rather than never. Anything added here needs the same kind of reason written down.
+CRON_ONLY = {
+    "tests/version_compat/test_import_leaves_torch_globals_alone.py",
+    "tests/version_compat/test_trl_vllm_generation_lora_patch.py",
+}
+
+
+def _doc() -> dict:
+    return yaml.safe_load(WORKFLOW.read_text(encoding = "utf-8")) or {}
+
+
+def _jobs() -> dict:
+    return _doc().get("jobs") or {}
+
+
+def _runs_on_pull_request(job: dict) -> bool:
+    """A job gated to schedule/dispatch cannot be what keeps a suite covered on a PR."""
+    cond = str(job.get("if", ""))
+    if not cond:
+        return True
+    return "pull_request" in cond or not re.search(r"schedule|workflow_dispatch", cond)
+
+
+def _named_paths(job: dict) -> set[str]:
+    named: set[str] = set()
+    for step in job.get("steps") or []:
+        body = str(step.get("run", ""))
+        for m in re.finditer(r"tests/[\w/]+\.py", body):
+            named.add(m.group(0))
+        # A bare directory sweep covers every file under it.
+        for m in re.finditer(r"(tests/(?:version_compat|vllm_compat))/(?:\s|\\|$)", body):
+            named.add(m.group(1) + "/")
+    return named
+
+
+def _covers(named: set[str], suite: str) -> bool:
+    return suite in named or any(n.endswith("/") and suite.startswith(n) for n in named)
+
+
+def _all_suites() -> set[str]:
+    found = set()
+    for d in SUITE_DIRS:
+        for p in sorted((REPO / d).glob("test_*.py")):
+            found.add(f"{d}/{p.name}")
+    return found
+
+
+def test_every_suite_still_runs_on_a_pull_request() -> None:
+    """The whole point: a path dropped from the bundle proves less and stays green."""
+    pr_named: set[str] = set()
+    for job in _jobs().values():
+        if _runs_on_pull_request(job):
+            pr_named |= _named_paths(job)
+
+    uncovered = sorted(s for s in _all_suites() - CRON_ONLY if not _covers(pr_named, s))
+    assert not uncovered, (
+        f"these version-compat suites are not run by any pull_request job: {uncovered}. "
+        f"Either a path was dropped from {BUNDLE_JOB}'s pytest line -- which removes a "
+        f"compat surface without failing anything -- or a new suite was added and never "
+        f"wired up. If a suite genuinely cannot run on a PR, add it to CRON_ONLY with the "
+        f"reason."
+    )
+
+
+def test_the_bundle_exists_and_names_suites_explicitly() -> None:
+    """A directory sweep here would silently pull in the heavy jobs' suites.
+
+    `tests/version_compat/` as a bare argument would drag in the TRL fake-run files, which
+    need an installed torch + TRL that this dependency-free job does not have. They would
+    error rather than skip, so this is a real constraint and not tidiness.
+    """
+    job = _jobs().get(BUNDLE_JOB)
+    assert job is not None, f"{BUNDLE_JOB} no longer exists; retarget or delete this file"
+    named = _named_paths(job)
+    assert named, f"{BUNDLE_JOB} names no test paths at all"
+    sweeps = sorted(n for n in named if n.endswith("/"))
+    assert not sweeps, (
+        f"{BUNDLE_JOB} sweeps {sweeps} rather than naming files. That pulls in the suites "
+        f"belonging to the install-bearing jobs, which have no torch here."
+    )
+
+
+def test_the_bundle_does_not_duplicate_the_install_bearing_jobs() -> None:
+    """Running a suite twice per commit is the waste this change exists to remove."""
+    bundle = _named_paths(_jobs()[BUNDLE_JOB])
+    for jid, job in _jobs().items():
+        if jid == BUNDLE_JOB or not _runs_on_pull_request(job):
+            continue
+        overlap = sorted(bundle & _named_paths(job))
+        assert not overlap, (
+            f"{jid} and {BUNDLE_JOB} both run {overlap} on a pull request, so every commit "
+            f"pays for it twice"
+        )
+
+
+def test_the_bundle_stays_parallel_and_file_scoped() -> None:
+    """Without -n the bundle is six jobs' work run end to end on one runner.
+
+    Measured on the full set: serial 182.8s, `-n 4` 27.8s, `-n 8` 75.2s, all three at
+    1606 passed / 182 skipped. -n 8 being 2.7x slower than -n 4 is upstream throttling of
+    a fetch-bound suite, not core contention, so the worker count is not "as high as
+    possible" -- it is pinned at the runner's core count.
+
+    --dist loadfile keeps a file on one worker so two suites cannot interleave.
+    """
+    steps = _jobs()[BUNDLE_JOB].get("steps") or []
+    body = "\n".join(str(s.get("run", "")) for s in steps)
+    assert re.search(r"-n\s+4\b", body), (
+        "the bundled job lost its `-n 4`, so six jobs' worth of suites now run one after "
+        "another on a single runner -- slower than the six jobs it replaced"
+    )
+    assert "--dist loadfile" in body, (
+        "the bundled job lost `--dist loadfile`, so one suite's tests can be split across "
+        "workers and interleaved with another's"
+    )
+
+
+def test_the_install_bearing_jobs_were_not_folded_in() -> None:
+    """They install mutually exclusive TRL pins; one venv cannot hold both."""
+    for jid in ("zoo-imports-under-spoof", "grpo-fake-run"):
+        assert jid in _jobs(), (
+            f"{jid} is gone. It installs a torch + TRL stack that conflicts with its "
+            f"sibling's pins, so it cannot have been merged into anything -- check it was "
+            f"not folded into {BUNDLE_JOB}, which has no torch at all."
+        )

--- a/tests/studio/test_version_compat_bundle.py
+++ b/tests/studio/test_version_compat_bundle.py
@@ -154,10 +154,18 @@ def test_the_bundle_does_not_duplicate_the_install_bearing_jobs() -> None:
 def test_the_bundle_stays_parallel_and_file_scoped() -> None:
     """Without -n the bundle is six jobs' work run end to end on one runner.
 
-    Measured on the full set: serial 182.8s, `-n 4` 27.8s, `-n 8` 75.2s, all three at
-    1606 passed / 182 skipped. -n 8 being 2.7x slower than -n 4 is upstream throttling of
-    a fetch-bound suite, not core contention, so the worker count is not "as high as
+    Measured on the full set: serial 182.8s, `-n 4` 27.8s, `-n 8` 75.2s, all three at the
+    same 1788 collected. -n 8 being 2.7x slower than -n 4 is upstream throttling of a
+    fetch-bound suite, not core contention, so the worker count is not "as high as
     possible" -- it is pinned at the runner's core count.
+
+    The pass/skip SPLIT of those 1788 is environment-dependent, so do not pin a number to
+    it. On CI the job is 1604 passed / 184 skipped; on a developer box with transformers
+    and unsloth_zoo already installed it is 1606 / 182, because
+    test_peft_conversion_symbol_backfill.py::test_the_moe_snapshot_matches_the_installed_transformers
+    and test_vllm_pinned_symbols.py::test_unsloth_zoo_standby_guards_present both skip
+    when their package is absent. The six jobs this replaced installed pytest and nothing
+    else, so they skipped those two as well -- the split is unchanged by the bundling.
 
     --dist loadfile keeps a file on one worker so two suites cannot interleave.
     """


### PR DESCRIPTION
Version Compat CI spent **six runner slots on 287s of combined work**. On a sampled main commit each of the six waited **23 to 31 minutes** to be admitted, in order to execute for 15 to 128 seconds. The queue is the cost, so the slots are the target.

```
 15s bitsandbytes | 128s TRL/GRPO | 38s vLLM | 52s transformers
 21s sentence-transformers | 33s PEFT
```

## Why these six can share a runner

Not a general claim about the suite, a specific one about these tests: they fetch raw source from `raw.githubusercontent.com` and grep it for symbols (`tests/version_compat/_fetch.py`, `has_def` / `first_match`). **Nothing is pip-installed** — that is the whole point of the canary, and it is also what makes co-location safe: there is no venv for "transformers 4.57.6" and "transformers main" to fight over, because neither is installed.

The repo had already proved the shape: `daily-fresh-fetch` runs all of these in one process on cron. This makes the PR path do the same, in parallel.

## Measured

| mode | result | wall |
|---|---|---|
| serial | 1606 passed, 182 skipped | 182.8s |
| **-n 4** | **1606 passed, 182 skipped** | **27.8s** |
| -n 8 | 1606 passed, 182 skipped | 75.2s |

The pass counts are identical in all three, which is the number that matters: the bundle tests exactly what the six jobs tested.

**`-n 4`, not higher.** `-n 8` is 2.7x *slower*, which for a fetch-bound suite is upstream throttling rather than core contention — the job's own comment already notes the 5000/h authenticated raw-fetch ceiling. 4 also matches the hosted runner's core count and the `-n 4` every other pytest job here uses. `--dist loadfile` keeps a suite on one worker.

## Deliberately NOT folded in

`zoo-imports-under-spoof` and `grpo-fake-run` stay separate. Both install a torch stack, and they install **mutually exclusive TRL pins** (`'trl>=0.22,<0.26'` against `pip install --upgrade trl`), so one venv cannot hold both. A guard asserts they still exist, because folding them into a job with no torch at all is the plausible next step and it would not fail loudly.

## Two pre-existing gaps this found

The new guard derives coverage from the filesystem rather than from a list, and on its first run reported two suites that **no pull_request job runs at all**:

| suite | why it cannot join the bundle |
|---|---|
| `test_import_leaves_torch_globals_alone.py` | `import torch` inside a subprocess probe |
| `test_trl_vllm_generation_lora_patch.py` | needs an installed TRL |

Both pre-date this change and both are swept daily by the cron job, so they are checked daily rather than never. The second belongs with `grpo-fake-run`, which already has that stack, but is not in that job's list either. I left it alone rather than wiring it in blind: I could not verify it passes in that environment first, and an unverified suite would have put an unrelated red on the change that noticed the gap. Recorded in `CRON_ONLY` with the reasons.

## Check names

Six checks become one. **Branch protection naming any of the six needs updating.**

| removed |
|---|
| vLLM pinned-symbol matrix (>= 0.9.0 + main) |
| TRL / GRPO pinned-symbol matrix |
| PEFT pinned-symbol matrix (pyproject window + main) |
| sentence-transformers pinned-symbol matrix |
| bitsandbytes pinned-symbol matrix |
| transformers pinned-symbol matrix (4.57.6 + 5.x + main) |

Added: `pinned-symbol matrix (vLLM, TRL, PEFT, ST, bitsandbytes, transformers)`

## Verified

- Mutation-tested, each failing exactly one guard: drop a suite from the bundle; remove `-n 4`; remove `--dist loadfile`; sweep the directory instead of naming files.
- `tests/studio` 4584 passed.
- `lint_workflow_triggers.py` OK across 41 files.
- No dangling references to the six removed job ids anywhere in the tree.