### PR TITLE
Studio: render code blocks far from the viewport as plain text, behind a flag defaulting off

### DIFF
--- a/studio/frontend/src/components/assistant-ui/code-highlight-gate.ts
+++ b/studio/frontend/src/components/assistant-ui/code-highlight-gate.ts
@@ -1,0 +1,217 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// Which code blocks are allowed to carry Shiki tokens, and which render plain.
+//
+// WHY THERE IS A DECISION HERE AT ALL. At the 100K rung the thread is 63,180 elements and 42,077
+// of them are Shiki highlight spans: 67% of the whole document, from 57 code blocks. Interactions
+// against that standing DOM collapse to 2.7 fps (reasoning_toggle) and 5.6 fps
+// (select_all_copy), while streaming stays at ~60 fps. The cost tracks the standing PRESENCE of
+// those nodes, not the work of creating them -- its correlation with mutation count is r = -0.88,
+// the wrong sign for creation being the cost. So the lever is how many highlight spans are
+// STANDING in the document, and the blocks a user cannot see are the ones that can give them up.
+//
+// This module is only the decision. It holds no DOM, no React and no timers: geometry is pushed
+// in, `now` is passed in, and every transition is observable. That is deliberate -- the rule below
+// is the part that decides whether a user ever sees uncoloured code, so it is the part that has to
+// be testable without a browser.
+
+/**
+ * How far outside the viewport a code block still renders with full Shiki tokens.
+ *
+ * This is THE knob: it buys the time a block needs to be re-highlighted between entering the
+ * buffer and reaching the user's eye. Sized from the measured re-highlight latency rather than
+ * chosen round.
+ *
+ * Re-highlighting one fence of the studiobench corpus from a cold fence cache, with grammars
+ * already loaded (the state a scrolling thread is actually in), measured over all 57 content
+ * fences at the 100K rung: median 12.7 ms, p90 28.5 ms, max 39.4 ms, at a median 1,783 characters
+ * and 25 lines per fence.
+ *
+ * A fence that size occupies roughly 570 px once rendered (25 lines at ~20 px, plus 32 px of
+ * padding, borders and the wrapper's `my-4`), so 2,000 px of buffer holds about 3.5 blocks, and
+ * refilling all of them costs about 100 ms at p90. Crossing 2,000 px takes 400 ms at 5,000 px/s,
+ * which is a hard trackpad flick. That is a 4x margin. It narrows to parity only around
+ * 20,000 px/s, which is a scrollbar drag -- a jump, where a repaint is expected anyway.
+ *
+ * Raising this hides uncoloured code under faster scrolling and stands more spans in the
+ * document; lowering it does the reverse. Nothing else in the mechanism trades those two off.
+ */
+export const CODE_HIGHLIGHT_BUFFER_PX = 2000;
+
+/**
+ * How long after a block last grew it still counts as streaming.
+ *
+ * A streaming fence re-enters `highlight()` every frame with the whole block, and the plugin
+ * throttles its re-tokenization to one refresh per `REFRESH_MS` (250 ms). Four refresh windows is
+ * long enough that an ordinary gap between chunks never reads as "finished", and short enough
+ * that a finished block becomes eligible for gating well within a second.
+ */
+export const CODE_HIGHLIGHT_STREAMING_GRACE_MS = 1000;
+
+/** Full Shiki tokens, or one token per line with no colours. */
+export type HighlightMode = "highlighted" | "plain";
+
+/** A block's position in the scroll container, in the same coordinates as the viewport height. */
+export type BlockGeometry = {
+  /** Distance from the top of the viewport to the top of the block. Negative when scrolled past. */
+  top: number;
+  /** Distance from the top of the viewport to the bottom of the block. */
+  bottom: number;
+};
+
+export type HighlightDecision = {
+  /** `null` means nothing has located this block yet. */
+  geometry: BlockGeometry | null;
+  viewportHeight: number;
+  bufferPx: number;
+  /** True while the block is still being streamed into. */
+  streaming: boolean;
+};
+
+/**
+ * The whole rule, in one pure function.
+ *
+ * Both early returns FAIL OPEN, towards colour. Getting this backwards is the only way this
+ * mechanism can produce a visibly wrong thread rather than a merely slow one, so neither is an
+ * optimisation to be tightened later.
+ */
+export const decideHighlightMode = ({
+  geometry,
+  viewportHeight,
+  bufferPx,
+  streaming,
+}: HighlightDecision): HighlightMode => {
+  // The block being streamed is in view by definition -- it is the reply the user is waiting on.
+  // It also owns the plugin's incremental caches, which a downgrade mid-stream would be fighting.
+  if (streaming) return "highlighted";
+  // A block nothing has measured yet is not a block known to be far away. On first render the
+  // element does not exist, so there is no geometry to have; serving plain here would decolour
+  // every block for the frame before it is located, including the ones on screen.
+  if (geometry === null) return "highlighted";
+  return geometry.bottom >= -bufferPx &&
+    geometry.top <= viewportHeight + bufferPx
+    ? "highlighted"
+    : "plain";
+};
+
+export type CodeHighlightGate = {
+  /** The mode a block should render in right now. Unknown ids read as `highlighted`. */
+  mode: (id: string, now?: number) => HighlightMode;
+  /** Record where a block is, or `null` to forget its position without forgetting the block. */
+  place: (id: string, geometry: BlockGeometry | null) => void;
+  /** Record that a block grew at `now`, which holds it highlighted for the grace window. */
+  markStreaming: (id: string, now?: number) => void;
+  setViewportHeight: (height: number) => void;
+  /** Called with each block id whose mode may have changed. */
+  subscribe: (listener: (id: string) => void) => () => void;
+  /** Called when the plugin first produces a result for a block, so a binder can go find it. */
+  onAnnounce: (listener: (id: string) => void) => () => void;
+  announce: (id: string) => void;
+  forget: (id: string) => void;
+  readonly bufferPx: number;
+};
+
+type Entry = {
+  geometry: BlockGeometry | null;
+  lastGrowthAt: number;
+  mode: HighlightMode;
+};
+
+export type GateOptions = {
+  bufferPx?: number;
+  streamingGraceMs?: number;
+  viewportHeight?: number;
+  now?: () => number;
+};
+
+export const createCodeHighlightGate = ({
+  bufferPx = CODE_HIGHLIGHT_BUFFER_PX,
+  streamingGraceMs = CODE_HIGHLIGHT_STREAMING_GRACE_MS,
+  viewportHeight = 0,
+  now = () =>
+    typeof performance !== "undefined" && typeof performance.now === "function"
+      ? performance.now()
+      : Date.now(),
+}: GateOptions = {}): CodeHighlightGate => {
+  const entries = new Map<string, Entry>();
+  const listeners = new Set<(id: string) => void>();
+  const announcements = new Set<(id: string) => void>();
+  let viewport = viewportHeight;
+
+  const decide = (entry: Entry, at: number): HighlightMode =>
+    decideHighlightMode({
+      geometry: entry.geometry,
+      viewportHeight: viewport,
+      bufferPx,
+      streaming: at - entry.lastGrowthAt < streamingGraceMs,
+    });
+
+  // Notify on the TRANSITION only. The plugin turns each notification into a re-render of that
+  // block, so a gate that republished the current mode on every scroll event would re-render
+  // every mounted code block on every frame -- the cost this exists to remove.
+  const settle = (id: string, entry: Entry, at: number): void => {
+    const next = decide(entry, at);
+    if (next === entry.mode) return;
+    entry.mode = next;
+    for (const listener of listeners) listener(id);
+  };
+
+  const entryFor = (id: string): Entry => {
+    let entry = entries.get(id);
+    if (entry === undefined) {
+      // Negative infinity, not 0: a block registered by `place` on a page that has been open for
+      // a while must not read as having grown at time zero and so be inside the grace window.
+      entry = {
+        geometry: null,
+        lastGrowthAt: Number.NEGATIVE_INFINITY,
+        mode: "highlighted",
+      };
+      entries.set(id, entry);
+    }
+    return entry;
+  };
+
+  return {
+    bufferPx,
+    mode: (id, at = now()) => {
+      const entry = entries.get(id);
+      if (entry === undefined) return "highlighted";
+      // Read through `decide` rather than the cached mode: the grace window expires on the clock,
+      // with no event to settle it.
+      entry.mode = decide(entry, at);
+      return entry.mode;
+    },
+    place: (id, geometry) => {
+      const entry = entryFor(id);
+      entry.geometry = geometry;
+      settle(id, entry, now());
+    },
+    markStreaming: (id, at = now()) => {
+      const entry = entryFor(id);
+      entry.lastGrowthAt = at;
+      settle(id, entry, at);
+    },
+    setViewportHeight: (height) => {
+      if (height === viewport) return;
+      viewport = height;
+      const at = now();
+      for (const [id, entry] of entries) settle(id, entry, at);
+    },
+    subscribe: (listener) => {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+    onAnnounce: (listener) => {
+      announcements.add(listener);
+      return () => announcements.delete(listener);
+    },
+    announce: (id) => {
+      entryFor(id);
+      for (const listener of announcements) listener(id);
+    },
+    forget: (id) => {
+      entries.delete(id);
+    },
+  };
+};

--- a/studio/frontend/src/components/assistant-ui/code-highlight-viewport.ts
+++ b/studio/frontend/src/components/assistant-ui/code-highlight-viewport.ts
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// The DOM half of viewport-gated highlighting: find each gated code block and tell the gate where
+// it is. Every decision lives in `code-highlight-gate.ts`; this file only measures.
+
+import type { CodeHighlightGate } from "./code-highlight-gate";
+import { CODE_FENCE_ATTRIBUTE } from "./code-plugin";
+
+/** The element whose height a block's rendering actually costs, not the token span carrying the id. */
+const BLOCK_SELECTOR = '[data-streamdown="code-block"]';
+
+export type ViewportBinding = { dispose: () => void };
+
+export const bindCodeHighlightViewport = (
+  gate: CodeHighlightGate,
+  scope: { document: Document; window: Window } = {
+    document: globalThis.document,
+    window: globalThis.window,
+  },
+): ViewportBinding => {
+  const { document: doc, window: view } = scope;
+  const bound = new Map<string, Element>();
+  // The id is held beside the element rather than written onto it. Writing an attribute onto a
+  // React-owned node works until React re-renders that node and drops it, and a block whose id had
+  // been quietly erased would stop being reported and silently stay highlighted forever.
+  const idOf = new WeakMap<Element, string>();
+
+  // `rootMargin` expands the observer's box to the gate's own buffer, so a crossing is reported
+  // exactly when the gate's answer can change. The gate still decides -- this only says when to
+  // ask it -- so the two cannot drift into disagreeing about where the band is.
+  const observer = new IntersectionObserver(
+    (entries) => {
+      for (const entry of entries) {
+        const id = idOf.get(entry.target);
+        if (id === undefined) continue;
+        const box = entry.boundingClientRect;
+        gate.place(id, { top: box.top, bottom: box.bottom });
+      }
+    },
+    { root: null, rootMargin: `${gate.bufferPx}px 0px`, threshold: 0 },
+  );
+
+  // Announcements arrive from inside the plugin's return path, one frame BEFORE React has
+  // committed that result, so the element cannot be queried yet. Batch to the next frame.
+  const waiting = new Set<string>();
+  let frame: number | null = null;
+
+  const sweep = (): void => {
+    frame = null;
+    for (const id of waiting) {
+      const token = doc.querySelector(
+        `[${CODE_FENCE_ATTRIBUTE}="${CSS.escape(id)}"]`,
+      );
+      const block = token?.closest(BLOCK_SELECTOR);
+      if (!block) continue;
+      waiting.delete(id);
+      const previous = bound.get(id);
+      if (previous === block) continue;
+      if (previous) observer.unobserve(previous);
+      idOf.set(block, id);
+      bound.set(id, block);
+      observer.observe(block);
+    }
+  };
+
+  const unannounce = gate.onAnnounce((id) => {
+    waiting.add(id);
+    if (frame === null) frame = view.requestAnimationFrame(sweep);
+  });
+
+  const measureViewport = () => gate.setViewportHeight(view.innerHeight);
+  measureViewport();
+  view.addEventListener("resize", measureViewport);
+
+  return {
+    dispose: () => {
+      unannounce();
+      observer.disconnect();
+      view.removeEventListener("resize", measureViewport);
+      if (frame !== null) view.cancelAnimationFrame(frame);
+      bound.clear();
+      waiting.clear();
+    },
+  };
+};

--- a/studio/frontend/src/components/assistant-ui/code-plugin.ts
+++ b/studio/frontend/src/components/assistant-ui/code-plugin.ts
@@ -10,13 +10,28 @@ import type {
 } from "@streamdown/code";
 import {
   type BundledLanguage,
+  type GrammarState,
+  type ThemedToken,
   bundledLanguages,
   bundledLanguagesInfo,
   createHighlighter,
-  type GrammarState,
-  type ThemedToken,
 } from "shiki";
 import { createJavaScriptRegexEngine } from "shiki/engine/javascript";
+import type { CodeHighlightGate } from "./code-highlight-gate";
+
+/**
+ * The attribute the plugin stamps on a gated block's first token span.
+ *
+ * The plugin is handed `{code, language, themes}` and nothing else -- no element, no ref, no key --
+ * so it cannot ask where a block is, and a viewport gate has to be told. Streamdown spreads a
+ * token's `htmlAttrs` onto the span it renders, which is the one channel from this layer into the
+ * DOM, so the block's gate id rides out on its first token and a binder can find the element by
+ * `[data-code-fence="..."]`. Only stamped when a gate is present: with the flag off no attribute
+ * is emitted at all.
+ */
+export const CODE_FENCE_ATTRIBUTE = "data-code-fence";
+
+let nextFenceId = 0;
 
 // Common fence tags shiki doesn't expose as aliases.
 // Keys: lower-cased input; values: canonical shiki language ids.
@@ -92,9 +107,30 @@ type ThemeNames = { light: string; dark: string };
 type HighlightCallback = (result: HighlightResult) => void;
 type Pending = { code: string; callbacks: Set<HighlightCallback> };
 
+type FenceContext = {
+  language: BundledLanguage;
+  themes: ThemeNames;
+};
+
 type Fence = {
   key: string;
   code: string;
+  /** Gate id, assigned on the first gated call. Empty while ungated. */
+  id: string;
+  /**
+   * Callbacks retained past the call that supplied them.
+   *
+   * Streamdown calls `highlight()` from an effect keyed on the code string, so a block that has
+   * stopped streaming calls in exactly ONCE and never again. Its `useState` setter is then the
+   * only way to change what it shows, which is what makes a later downgrade or re-highlight
+   * possible at all. The setter is referentially stable per mounted component, so this holds one
+   * entry per mounted block and is cleared when the fence is dropped.
+   */
+  subscribers: Set<HighlightCallback>;
+  /** The most recent code seen for this fence, which may be ahead of `code` while gated plain. */
+  live: string | null;
+  /** What a later re-highlight needs to call the tokenizer with. */
+  context: FenceContext | null;
   result: HighlightResult | null;
   meta: ResultMeta | null;
   /** Absolute-offset tokens for completed lines. */
@@ -111,6 +147,44 @@ type Fence = {
 // Tokens without colors preserve the previous plain-tail rendering.
 const plainLine = (content: string): TokenLine =>
   [{ content, offset: 0 } as unknown as ThemedToken] as TokenLine;
+
+/** The source text of one tokenized line. Shiki splits a line into runs, it does not alter it. */
+const lineText = (line: TokenLine): string =>
+  line.length === 1
+    ? line[0].content
+    : line.map((token) => token.content).join("");
+
+/**
+ * The same lines, with the colours taken off.
+ *
+ * Derived from the tokenized result rather than re-split from the source, so the plain rendering
+ * has the same NUMBER of lines and the same TEXT on each line as the highlighted one by
+ * construction. That is what makes the swap layout-neutral: `<pre>` does not wrap, so a block's
+ * height is its line count times its line height, and neither changes here.
+ */
+const plainTokens = (tokens: TokenLine[]): TokenLine[] =>
+  tokens.map((line) => plainLine(lineText(line)));
+
+/**
+ * Put `id` on the block's first rendered token.
+ *
+ * Skips lines the renderer turns into a bare newline (empty, or a single empty token), because
+ * those emit no span to carry it. A block with no such line -- an empty fence -- goes unstamped
+ * and is never located, which the gate reads as "not measured" and leaves highlighted.
+ */
+const stampFence = (result: HighlightResult, id: string): HighlightResult => {
+  const index = result.tokens.findIndex(
+    (line) => line.length > 0 && !(line.length === 1 && line[0].content === ""),
+  );
+  if (index < 0) return result;
+  const [first, ...rest] = result.tokens[index];
+  const tokens = [...result.tokens];
+  tokens[index] = [
+    { ...first, htmlAttrs: { ...first.htmlAttrs, [CODE_FENCE_ATTRIBUTE]: id } },
+    ...rest,
+  ] as TokenLine;
+  return { ...result, tokens };
+};
 
 const themeName = (theme: ThemeInput): string =>
   typeof theme === "string" ? theme : (theme.name ?? "custom");
@@ -161,19 +235,37 @@ const shedsClosingRun = (shorter: string, longer: string): boolean =>
   longer.startsWith(shorter) &&
   CLOSING_FENCE.test(longer.slice(shorter.length));
 
+export type StudioCodePluginOptions = CodePluginOptions & {
+  /**
+   * When supplied, blocks the gate reports as far from the viewport render plain.
+   *
+   * Optional on purpose: with no gate the plugin takes the exact path it always has, every return
+   * below is the object it always returned, and no attribute is stamped. That is the flag-off
+   * build.
+   */
+  gate?: CodeHighlightGate;
+};
+
 export function createCodePlugin(
-  options: CodePluginOptions = {},
+  options: StudioCodePluginOptions = {},
 ): CodeHighlighterPlugin {
   const defaultThemes: [ThemeInput, ThemeInput] = options.themes ?? [
     "github-light",
     "github-dark",
   ];
+  const gate = options.gate;
   const engine = createJavaScriptRegexEngine({ forgiving: true });
   const highlighters = new Map<string, { highlighter: Highlighter | null }>();
   // Most recently used first.
   const fences: Fence[] = [];
   // Avoid scanning every fence for exact cache hits.
   const fencesByCode = new Map<string, Fence>();
+  // Gated fences only, so a gate notification can find the block it names.
+  const fencesById = new Map<string, Fence>();
+  // Which fence currently owns each retained callback. A block whose code changes enough to start
+  // a new fence must not be left subscribed to the old one, or a stale result can arrive last and
+  // overwrite a newer one -- streamdown does no cancellation of its own.
+  const subscriberOwners = new Map<HighlightCallback, Fence>();
   let cachedCharacters = 0;
 
   // Avoid hashing the whole source on each update; verify compact-key hits.
@@ -203,11 +295,26 @@ export function createCodePlugin(
     if (callback) fence.pending.callbacks.add(callback);
   };
 
+  // Every result that leaves the plugin has to carry the stamp, not just the ones returned
+  // synchronously: a block whose grammar arrived late is delivered through here, and an unstamped
+  // delivery would erase the attribute that is how it gets located.
+  const deliver = (fence: Fence, result: HighlightResult): HighlightResult =>
+    gate === undefined || fence.id === ""
+      ? result
+      : stampFence(result, fence.id);
+
   const notifyPending = (
+    fence: Fence,
     pending: Pending,
     result: HighlightResult,
   ): void => {
-    for (const callback of pending.callbacks) callback(result);
+    for (const callback of pending.callbacks) callback(deliver(fence, result));
+  };
+
+  /** Push a result to every block that has this fence's content mounted. */
+  const publish = (fence: Fence, result: HighlightResult): void => {
+    for (const subscriber of fence.subscribers)
+      subscriber(deliver(fence, result));
   };
 
   const dropFence = (fence: Fence): void => {
@@ -217,6 +324,14 @@ export function createCodePlugin(
     cachedCharacters -= fence.code.length;
     dropCodeIndex(fence);
     clearTrailing(fence);
+    // Retained callbacks hold their component alive, so a dropped fence must let go of them.
+    for (const subscriber of fence.subscribers)
+      subscriberOwners.delete(subscriber);
+    fence.subscribers.clear();
+    if (fence.id !== "") {
+      fencesById.delete(fence.id);
+      gate?.forget(fence.id);
+    }
   };
 
   const evict = (): void => {
@@ -271,6 +386,10 @@ export function createCodePlugin(
     const fence: Fence = {
       key,
       code: "",
+      id: "",
+      subscribers: new Set(),
+      live: null,
+      context: null,
       result: null,
       meta: null,
       lines: [],
@@ -394,7 +513,7 @@ export function createCodePlugin(
       language,
       themes,
     );
-    if (refreshed) notifyPending(pending, refreshed);
+    if (refreshed) notifyPending(fence, pending, refreshed);
   };
 
   const loadHighlighter = (
@@ -428,31 +547,22 @@ export function createCodePlugin(
     return null;
   };
 
-  return {
-    name: "shiki",
-    type: "code-highlighter",
-    getSupportedLanguages: () => SUPPORTED_LANGUAGE_LIST,
-    getThemes: () => defaultThemes,
-    supportsLanguage: (language) =>
-      SUPPORTED_LANGUAGES.has(normalizeLanguage(language)),
-    highlight: (
-      opts: HighlightOptions,
-      callback?: (result: HighlightResult) => void,
-    ): HighlightResult | null => {
-      const language = normalizeLanguage(opts.language);
-      const themes: ThemeNames = {
-        light: themeName(opts.themes[0]),
-        dark: themeName(opts.themes[1]),
-      };
-      const key = `${language} ${themeKey(opts.themes[0])} ${themeKey(opts.themes[1])}`;
-      const fence = findFence(key, opts.code);
-
+  /**
+   * The plugin's own path, unchanged. Everything the gate does happens around this, never inside
+   * it: with no gate, `highlight()` is this function and nothing else.
+   */
+  const resolve = (
+    fence: Fence,
+    opts: HighlightOptions,
+    callback: HighlightCallback | undefined,
+    key: string,
+    language: BundledLanguage,
+    themes: ThemeNames,
+  ): HighlightResult | null => {
+    {
       if (fence.result && fence.code === opts.code) {
         const pending = fence.pending;
-        if (
-          pending !== null &&
-          shedsClosingRun(opts.code, pending.code)
-        ) {
+        if (pending !== null && shedsClosingRun(opts.code, pending.code)) {
           // This may be one fence shedding its closing run or a shorter sibling
           // reusing the same entry. Settle the queued body before serving the
           // shorter exact hit so neither caller loses its final highlighted state.
@@ -466,16 +576,27 @@ export function createCodePlugin(
         return fence.result;
       }
 
-      const highlighter = loadHighlighter(key, language, opts.themes, (ready) => {
-        // Use a stable, oldest-first snapshot because updates can evict fences.
-        for (const waiting of [...fences].reverse()) {
-          const pending = waiting.pending;
-          if (waiting.key !== key || !pending) continue;
-          clearTrailing(waiting);
-          const resumed = update(waiting, ready, pending.code, language, themes);
-          if (resumed) notifyPending(pending, resumed);
-        }
-      });
+      const highlighter = loadHighlighter(
+        key,
+        language,
+        opts.themes,
+        (ready) => {
+          // Use a stable, oldest-first snapshot because updates can evict fences.
+          for (const waiting of [...fences].reverse()) {
+            const pending = waiting.pending;
+            if (waiting.key !== key || !pending) continue;
+            clearTrailing(waiting);
+            const resumed = update(
+              waiting,
+              ready,
+              pending.code,
+              language,
+              themes,
+            );
+            if (resumed) notifyPending(waiting, pending, resumed);
+          }
+        },
+      );
       if (!highlighter) {
         queuePending(fence, opts.code, callback);
         evict();
@@ -509,13 +630,111 @@ export function createCodePlugin(
               language,
               themes,
             );
-            if (refreshed) notifyPending(pending, refreshed);
+            if (refreshed) notifyPending(fence, pending, refreshed);
           },
           Math.max(0, REFRESH_MS - elapsed),
         );
         return result;
       }
       return update(fence, highlighter, opts.code, language, themes);
+    }
+  };
+
+  // A gate notification names one block. Turn it into that block's new rendering.
+  gate?.subscribe((id) => {
+    const fence = fencesById.get(id);
+    const code = fence?.live;
+    if (!fence || code === null || code === undefined) return;
+    if (fence.subscribers.size === 0) return;
+    if (gate.mode(id) === "plain") {
+      // Downgrade only a block that HAS a highlighted result: `plainTokens` reads its line
+      // structure off that result, which is what guarantees the two renderings are the same
+      // height. Until then the block is highlighted, which is also what the gate reports for a
+      // block it has never located.
+      const exact = fence.result;
+      if (exact === null || fence.code !== code) return;
+      publish(fence, { ...exact, tokens: plainTokens(exact.tokens) });
+      return;
+    }
+    const context = fence.context;
+    const highlighter = highlighters.get(fence.key)?.highlighter;
+    if (!context || !highlighter) return;
+    // Back inside the buffer. `update` tokenizes from `committedLength`, so a block that grew
+    // while it was plain costs only its uncommitted tail, and the incremental caches that the
+    // streaming path depends on are the ones being reused here.
+    const refreshed = update(
+      fence,
+      highlighter,
+      code,
+      context.language,
+      context.themes,
+    );
+    if (refreshed) publish(fence, refreshed);
+  });
+
+  return {
+    name: "shiki",
+    type: "code-highlighter",
+    getSupportedLanguages: () => SUPPORTED_LANGUAGE_LIST,
+    getThemes: () => defaultThemes,
+    supportsLanguage: (language) =>
+      SUPPORTED_LANGUAGES.has(normalizeLanguage(language)),
+    highlight: (
+      opts: HighlightOptions,
+      callback?: (result: HighlightResult) => void,
+    ): HighlightResult | null => {
+      const language = normalizeLanguage(opts.language);
+      const themes: ThemeNames = {
+        light: themeName(opts.themes[0]),
+        dark: themeName(opts.themes[1]),
+      };
+      const key = `${language} ${themeKey(opts.themes[0])} ${themeKey(opts.themes[1])}`;
+      const fence = findFence(key, opts.code);
+      if (gate === undefined)
+        return resolve(fence, opts, callback, key, language, themes);
+
+      if (fence.id === "") {
+        fence.id = `sf${nextFenceId++}`;
+        fencesById.set(fence.id, fence);
+      }
+      if (callback) {
+        const previous = subscriberOwners.get(callback);
+        if (previous !== fence) {
+          previous?.subscribers.delete(callback);
+          subscriberOwners.set(callback, fence);
+          fence.subscribers.add(callback);
+        }
+      }
+      fence.context = { language, themes };
+      // Growth from code this fence has ALREADY seen is the only streaming signal available here,
+      // and it has to be recorded before the mode is read: a block still being streamed into is in
+      // view by definition and must not be handed a plain rendering on the frame its next chunk
+      // lands. A block arriving complete is not a stream -- treating a first sighting as growth
+      // would hold every block in a freshly mounted thread highlighted for the whole grace window,
+      // which is exactly the thread this mechanism is for.
+      const streamed =
+        fence.live !== null && opts.code.length > fence.live.length;
+      fence.live = opts.code;
+      if (streamed) gate.markStreaming(fence.id);
+
+      if (
+        gate.mode(fence.id) === "plain" &&
+        fence.result !== null &&
+        fence.code === opts.code
+      ) {
+        return deliver(fence, {
+          ...fence.result,
+          tokens: plainTokens(fence.result.tokens),
+        });
+      }
+      const result = resolve(fence, opts, callback, key, language, themes);
+      if (result === null) return null;
+      // The element does not exist until this result has been rendered, so this is the earliest
+      // anything can go and measure it. Every block is therefore highlighted once and downgraded
+      // afterwards, never plain on arrival -- which is the right trade here, because the cost
+      // being removed is the standing presence of the spans and not the work of building them.
+      gate.announce(fence.id);
+      return deliver(fence, result);
     },
   };
 }

--- a/studio/frontend/src/components/assistant-ui/markdown-text.tsx
+++ b/studio/frontend/src/components/assistant-ui/markdown-text.tsx
@@ -40,7 +40,10 @@ import {
   Streamdown,
   type StreamdownProps,
 } from "streamdown";
+import { createCodeHighlightGate } from "./code-highlight-gate";
+import { bindCodeHighlightViewport } from "./code-highlight-viewport";
 import { createCodePlugin } from "./code-plugin";
+import { VIEWPORT_GATED_CODE_HIGHLIGHTING_ENABLED } from "./thread-feature-flags";
 import "katex/dist/katex.min.css";
 import { AudioPlayer } from "./audio-player";
 import { unslothDarkTheme, unslothLightTheme } from "./code-themes";
@@ -51,8 +54,17 @@ import {
 } from "./streaming-render-schedule";
 
 const math = createMathPlugin({ singleDollarTextMath: true });
+// Off by default. With the flag false no gate is built, so `createCodePlugin` takes the exact
+// path it always has and nothing is stamped into the DOM.
+const codeHighlightGate = VIEWPORT_GATED_CODE_HIGHLIGHTING_ENABLED
+  ? createCodeHighlightGate()
+  : undefined;
+if (codeHighlightGate && typeof document !== "undefined") {
+  bindCodeHighlightViewport(codeHighlightGate);
+}
 const code = createCodePlugin({
   themes: [unslothLightTheme, unslothDarkTheme],
+  gate: codeHighlightGate,
 });
 const STREAMDOWN_PLUGINS = { code, math, mermaid } satisfies NonNullable<
   StreamdownProps["plugins"]

--- a/studio/frontend/src/components/assistant-ui/thread-feature-flags.ts
+++ b/studio/frontend/src/components/assistant-ui/thread-feature-flags.ts
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// Thread feature flags for staged rollout. The wiring stays in place so flipping a flag here is
+// the only edit needed to re-enable.
+
+// Viewport-gated syntax highlighting: a code block far from the viewport renders as PLAIN text
+// (one token per line) instead of carrying its full set of Shiki spans, and is re-highlighted when
+// it comes back within `CODE_HIGHLIGHT_BUFFER_PX`. At the 100K rung, 42,134 of the thread's
+// standing spans come from 57 code blocks; all-plain is 2,850, a 93.2% reduction in the nodes this
+// mechanism can reach.
+//
+// OFF until the A/B has run: the mechanism is measured layout-neutral and the plugin's incremental
+// streaming path is unchanged, but no floor-cleared interaction result has been taken yet, and
+// CONTRIBUTING-perf.md is explicit that a direction is not a result.
+//
+// While this is false `createCodePlugin` is called with no gate at all, so the plugin takes the
+// exact code path it always has and the flag-off DOM is unchanged -- there is not even an
+// attribute stamped on a token.
+export const VIEWPORT_GATED_CODE_HIGHLIGHTING_ENABLED = false;

--- a/studio/frontend/tests/code-highlight-gate.test.ts
+++ b/studio/frontend/tests/code-highlight-gate.test.ts
@@ -1,0 +1,219 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// When a code block is allowed to give up its Shiki spans.
+//
+// The rule the gate enforces is that a block renders plain only when something has MEASURED it
+// outside the viewport plus the buffer, and it is not being streamed into. Both escape hatches
+// point the same way, towards colour, because the failure they prevent -- a visibly uncoloured
+// block, or worse a block decoloured under a scrolling user -- is far worse than the slow standing
+// DOM this exists to shrink. Every test below is written against a way of getting that backwards
+// that was reachable while this was built.
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  CODE_HIGHLIGHT_BUFFER_PX,
+  CODE_HIGHLIGHT_STREAMING_GRACE_MS,
+  createCodeHighlightGate,
+  decideHighlightMode,
+} from "../src/components/assistant-ui/code-highlight-gate.ts";
+
+const VIEWPORT = 900;
+
+/** A gate on a hand-cranked clock, so the tests assert on ORDER rather than on wall time. */
+function build(options: { bufferPx?: number; graceMs?: number } = {}) {
+  let clock = 10_000;
+  const seen: string[] = [];
+  const gate = createCodeHighlightGate({
+    bufferPx: options.bufferPx ?? 100,
+    streamingGraceMs: options.graceMs ?? CODE_HIGHLIGHT_STREAMING_GRACE_MS,
+    viewportHeight: VIEWPORT,
+    now: () => clock,
+  });
+  gate.subscribe((id) => seen.push(id));
+  return {
+    gate,
+    seen,
+    tick: (ms: number) => {
+      clock += ms;
+    },
+    at: () => clock,
+  };
+}
+
+test("a block nobody has located yet is highlighted, not plain", () => {
+  // This is the case the whole mechanism passes through on first render: the element does not
+  // exist until a result has been rendered, so there is no geometry to have. A gate that defaulted
+  // to plain would decolour every block in the thread for the frame before it was measured,
+  // including the ones the user is looking at.
+  assert.equal(
+    decideHighlightMode({
+      geometry: null,
+      viewportHeight: VIEWPORT,
+      bufferPx: CODE_HIGHLIGHT_BUFFER_PX,
+      streaming: false,
+    }),
+    "highlighted",
+  );
+  const { gate } = build();
+  assert.equal(gate.mode("never-seen"), "highlighted");
+});
+
+test("the band is the viewport plus the buffer on BOTH sides, and its edges are inclusive", () => {
+  const decide = (top: number, bottom: number) =>
+    decideHighlightMode({
+      geometry: { top, bottom },
+      viewportHeight: VIEWPORT,
+      bufferPx: 100,
+      streaming: false,
+    });
+
+  assert.equal(decide(10, 200), "highlighted", "plainly on screen");
+  // Above: a block ends exactly at the top edge of the buffer.
+  assert.equal(
+    decide(-300, -100),
+    "highlighted",
+    "touching the top edge is inside",
+  );
+  assert.equal(decide(-300, -101), "plain", "one pixel past it is outside");
+  // Below: a block starts exactly at the bottom edge of the buffer.
+  assert.equal(
+    decide(VIEWPORT + 100, VIEWPORT + 400),
+    "highlighted",
+    "touching the bottom edge",
+  );
+  assert.equal(
+    decide(VIEWPORT + 101, VIEWPORT + 400),
+    "plain",
+    "one pixel past it",
+  );
+  // A block taller than the viewport, scrolled so neither end is in it, is still on screen.
+  assert.equal(
+    decide(-5000, 5000),
+    "highlighted",
+    "a block spanning the viewport is in view",
+  );
+});
+
+test("a streaming block stays highlighted wherever it is measured to be", () => {
+  // The block being streamed is the reply the user is waiting on, and it owns the plugin's
+  // incremental caches. A gate that could take its colours off mid-stream would be fighting the
+  // one path in the plugin that is already fast.
+  assert.equal(
+    decideHighlightMode({
+      geometry: { top: 99_999, bottom: 100_999 },
+      viewportHeight: VIEWPORT,
+      bufferPx: CODE_HIGHLIGHT_BUFFER_PX,
+      streaming: true,
+    }),
+    "highlighted",
+  );
+});
+
+test("the streaming hold expires on the clock, with no event to expire it", () => {
+  // Nothing calls back into the gate when a stream ENDS -- the last chunk is just the last call.
+  // A hold that needed an event to clear it would pin every block that ever streamed.
+  const { gate, tick } = build({ graceMs: 1000 });
+  gate.place("a", { top: 99_999, bottom: 100_999 });
+  assert.equal(gate.mode("a"), "plain", "far away and not streaming");
+
+  gate.markStreaming("a");
+  assert.equal(gate.mode("a"), "highlighted", "held by the stream");
+  tick(999);
+  assert.equal(gate.mode("a"), "highlighted", "still inside the grace window");
+  tick(2);
+  assert.equal(
+    gate.mode("a"),
+    "plain",
+    "the window passed, with no event to say so",
+  );
+});
+
+test("a block registered by place() is not treated as having streamed at time zero", () => {
+  // `lastGrowthAt` starting at 0 rather than -Infinity reads as "grew at the epoch", which is
+  // inside the grace window for the first second of a page's life and nowhere near it afterwards.
+  // That is a gate whose behaviour depends on how long the app has been open.
+  const gate = createCodeHighlightGate({
+    bufferPx: 100,
+    viewportHeight: VIEWPORT,
+    now: () => 5, // 5ms after start, well inside any grace window
+  });
+  gate.place("a", { top: 99_999, bottom: 100_999 });
+  assert.equal(gate.mode("a"), "plain");
+});
+
+test("listeners fire on the transition only, never on a repeat", () => {
+  // The plugin turns each notification into a re-render of that block. A gate that republished the
+  // current mode on every scroll event would re-render every mounted code block on every frame,
+  // which is the cost this exists to remove.
+  const { gate, seen } = build();
+  gate.place("a", { top: 10, bottom: 200 });
+  assert.deepEqual(seen, [], "already highlighted, so nothing changed");
+
+  gate.place("a", { top: 5000, bottom: 5200 });
+  assert.deepEqual(seen, ["a"], "highlighted -> plain");
+
+  gate.place("a", { top: 5100, bottom: 5300 });
+  assert.deepEqual(seen, ["a"], "still plain, still one notification");
+
+  gate.place("a", { top: 20, bottom: 220 });
+  assert.deepEqual(seen, ["a", "a"], "plain -> highlighted");
+});
+
+test("forgetting a position is not the same as reporting it far away", () => {
+  // The plugin calls `forget` when it drops a fence. That must not be a downgrade: it means the
+  // gate no longer knows anything about the block, which reads as highlighted.
+  const { gate } = build();
+  gate.place("a", { top: 5000, bottom: 5200 });
+  assert.equal(gate.mode("a"), "plain");
+  gate.forget("a");
+  assert.equal(gate.mode("a"), "highlighted");
+});
+
+test("a shorter viewport re-settles every block it already knows about", () => {
+  // The band is measured from the viewport height, so a window resize moves it for blocks that
+  // have not moved and will not fire an intersection of their own.
+  const { gate, seen } = build();
+  gate.place("a", { top: 880, bottom: 990 });
+  assert.equal(gate.mode("a"), "highlighted", "inside 900 + 100");
+  gate.setViewportHeight(400);
+  assert.equal(gate.mode("a"), "plain", "outside 400 + 100");
+  assert.deepEqual(seen, ["a"]);
+});
+
+test("setting the same viewport height again re-settles nothing", () => {
+  const { gate, seen } = build();
+  gate.place("a", { top: 10, bottom: 200 });
+  gate.setViewportHeight(VIEWPORT);
+  assert.deepEqual(seen, []);
+});
+
+test("announcing is how a block gets found, and it does not decide anything", () => {
+  // The plugin announces from inside its return path, before React has committed the result. The
+  // block is therefore still unmeasured at that moment, and must read as highlighted.
+  const { gate } = build();
+  const announced: string[] = [];
+  gate.onAnnounce((id) => announced.push(id));
+  gate.announce("a");
+  assert.deepEqual(announced, ["a"]);
+  assert.equal(gate.mode("a"), "highlighted");
+});
+
+test("the shipped buffer covers a hard flick at the measured re-highlight latency", () => {
+  // Re-highlighting one fence of the 100K-rung corpus from a cold fence cache, grammars already
+  // loaded, measured over all 57 content fences: median 12.7ms, p90 28.5ms, max 39.4ms, at a
+  // median 1,783 characters. Such a fence renders at roughly 570px, so the buffer holds about
+  // `bufferPx / 570` of them and refilling them costs that many times the p90.
+  const fencePx = 570;
+  const p90Ms = 28.5;
+  const flickPxPerS = 5000;
+  const refillMs = (CODE_HIGHLIGHT_BUFFER_PX / fencePx) * p90Ms;
+  const crossingMs = (CODE_HIGHLIGHT_BUFFER_PX / flickPxPerS) * 1000;
+  assert.ok(
+    crossingMs > refillMs * 2,
+    `buffer ${CODE_HIGHLIGHT_BUFFER_PX}px is crossed in ${crossingMs.toFixed(0)}ms at ` +
+      `${flickPxPerS}px/s but needs ${refillMs.toFixed(0)}ms to refill`,
+  );
+});

--- a/studio/frontend/tests/code-plugin-viewport-gating.test.ts
+++ b/studio/frontend/tests/code-plugin-viewport-gating.test.ts
@@ -1,0 +1,344 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+/**
+ * What the gate does to the plugin, as opposed to what the gate decides.
+ *
+ * Streamdown calls `highlight()` from an effect keyed on the code string, so a block that has
+ * stopped streaming calls in exactly ONCE and never again. Everything here therefore turns on the
+ * retained callback: it is the only way a settled block's rendering can change afterwards, and it
+ * is the only way this mechanism can be wrong at runtime after passing the decision tests.
+ *
+ * The claim these tests exist to protect is that PLAIN and HIGHLIGHTED are the same text laid out
+ * the same way. The line count and the per-line text are asserted equal on every swap, because
+ * that equality is what makes the swap layout-neutral, and a block that changed height under a
+ * scrolling user would be a worse bug than the slow DOM this removes.
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import type {
+  HighlightOptions,
+  HighlightResult,
+  ThemeInput,
+} from "@streamdown/code";
+
+import {
+  type CodeHighlightGate,
+  createCodeHighlightGate,
+} from "../src/components/assistant-ui/code-highlight-gate.ts";
+import {
+  CODE_FENCE_ATTRIBUTE,
+  MIN_INCREMENTAL_CHARS,
+  createCodePlugin,
+} from "../src/components/assistant-ui/code-plugin.ts";
+
+const THEMES: [ThemeInput, ThemeInput] = ["github-light", "github-dark"];
+const LANGUAGE = "typescript" as HighlightOptions["language"];
+
+const SOURCE = `${Array.from({ length: 120 }, (index_) => index_)
+  .map(
+    (_, index) =>
+      `export const value_${index} = { id: ${index}, label: "row ${index}" };`,
+  )
+  .join("\n")}\n`.trimEnd();
+
+// Long enough to take the incremental path, which is the one a stream depends on.
+assert.ok(SOURCE.length > MIN_INCREMENTAL_CHARS);
+
+type Plugin = ReturnType<typeof createCodePlugin>;
+
+/** One block, rendering into a slot the way `HighlightedCodeBlockBody`'s `useState` does. */
+class Block {
+  latest: HighlightResult | null = null;
+  updates = 0;
+  readonly receive = (result: HighlightResult): void => {
+    this.latest = result;
+    this.updates += 1;
+  };
+}
+
+/** Drive one `highlight()` call and settle whatever it produces, sync or async. */
+const render = async (
+  plugin: Plugin,
+  block: Block,
+  code: string,
+): Promise<void> => {
+  const sync = plugin.highlight(
+    { code, language: LANGUAGE, themes: THEMES } as HighlightOptions,
+    block.receive,
+  );
+  if (sync) block.receive(sync);
+  // The highlighter loads asynchronously on the first call for a key; a few turns of the
+  // microtask queue plus a macrotask is enough for it to resolve and notify.
+  await new Promise((resolve) => setTimeout(resolve, 0));
+};
+
+const lines = (result: HighlightResult): string[] =>
+  result.tokens.map((line) => line.map((token) => token.content).join(""));
+
+const spanCount = (result: HighlightResult): number =>
+  result.tokens.reduce((total, line) => total + line.length, 0);
+
+const fenceId = (result: HighlightResult): string => {
+  for (const line of result.tokens) {
+    for (const token of line) {
+      const id = token.htmlAttrs?.[CODE_FENCE_ATTRIBUTE];
+      if (id !== undefined) return id;
+    }
+  }
+  throw new Error("no fence id was stamped on this result");
+};
+
+const gateOn = (): { gate: CodeHighlightGate; tick: (ms: number) => void } => {
+  let clock = 1_000_000;
+  const gate = createCodeHighlightGate({
+    bufferPx: 100,
+    viewportHeight: 900,
+    now: () => clock,
+  });
+  return {
+    gate,
+    tick: (ms) => {
+      clock += ms;
+    },
+  };
+};
+
+const FAR = { top: 90_000, bottom: 92_000 };
+const NEAR = { top: 20, bottom: 400 };
+
+test("with no gate the plugin returns exactly what it always returned", async () => {
+  // The flag-off build. Not "similar output" -- the same tokens, and no attribute anywhere, so a
+  // parity digest taken on a flag-off build cannot see this change at all.
+  const plain = createCodePlugin({ themes: THEMES });
+  const a = new Block();
+  await render(plain, a, SOURCE);
+  assert.ok(a.latest);
+  assert.equal(
+    JSON.stringify(a.latest).includes(CODE_FENCE_ATTRIBUTE),
+    false,
+    "an ungated result must carry no fence attribute",
+  );
+
+  const reference = createCodePlugin({ themes: THEMES });
+  const b = new Block();
+  await render(reference, b, SOURCE);
+  assert.deepEqual(a.latest, b.latest);
+});
+
+test("a settled block that scrolls far away is served plain, one span per line", async () => {
+  const { gate } = gateOn();
+  const plugin = createCodePlugin({ themes: THEMES, gate });
+  const block = new Block();
+  await render(plugin, block, SOURCE);
+
+  const highlighted = block.latest as HighlightResult;
+  const id = fenceId(highlighted);
+  assert.ok(
+    spanCount(highlighted) > highlighted.tokens.length,
+    "the block starts out with more spans than it has lines",
+  );
+
+  const before = block.updates;
+  gate.place(id, FAR);
+  assert.ok(
+    block.updates > before,
+    "the retained callback re-rendered the block",
+  );
+
+  const served = block.latest as HighlightResult;
+  assert.equal(
+    spanCount(served),
+    served.tokens.length,
+    "plain is exactly one token per line",
+  );
+  assert.deepEqual(
+    lines(served),
+    lines(highlighted),
+    "the same lines, with the same text on each",
+  );
+  assert.equal(
+    served.tokens.length,
+    highlighted.tokens.length,
+    "and the same NUMBER of lines, which is the block's height",
+  );
+});
+
+test("the plain rendering has byte-identical text, so copy and find-in-page cannot notice", () => {
+  // The text is what a selection, a clipboard write and a find-in-page all read. Asserting the
+  // whole concatenation rather than per line catches a swap that moved a newline.
+  const { gate } = gateOn();
+  const plugin = createCodePlugin({ themes: THEMES, gate });
+  const block = new Block();
+  return render(plugin, block, SOURCE).then(() => {
+    const highlighted = block.latest as HighlightResult;
+    gate.place(fenceId(highlighted), FAR);
+    const served = block.latest as HighlightResult;
+    assert.equal(lines(served).join("\n"), lines(highlighted).join("\n"));
+    assert.equal(lines(served).join("\n"), SOURCE);
+  });
+});
+
+test("scrolling back re-highlights it, to the tokens it had before", async () => {
+  const { gate } = gateOn();
+  const plugin = createCodePlugin({ themes: THEMES, gate });
+  const block = new Block();
+  await render(plugin, block, SOURCE);
+  const highlighted = block.latest as HighlightResult;
+  const id = fenceId(highlighted);
+
+  gate.place(id, FAR);
+  assert.equal(
+    spanCount(block.latest as HighlightResult),
+    highlighted.tokens.length,
+  );
+
+  gate.place(id, NEAR);
+  const restored = block.latest as HighlightResult;
+  assert.equal(
+    spanCount(restored),
+    spanCount(highlighted),
+    "every span came back",
+  );
+  assert.deepEqual(lines(restored), lines(highlighted));
+  assert.deepEqual(
+    restored.tokens.map((line) => line.map((token) => token.color)),
+    highlighted.tokens.map((line) => line.map((token) => token.color)),
+    "with the colours they had, not a re-tokenization that drifted",
+  );
+});
+
+test("a block still streaming is not downgraded, however far away it is measured", async () => {
+  // A streaming fence re-enters highlight() with the whole block every frame. Serving it plain
+  // would both fight the incremental path and take the colours off the one block the user is
+  // certainly looking at.
+  const { gate, tick } = gateOn();
+  const plugin = createCodePlugin({ themes: THEMES, gate });
+  const block = new Block();
+
+  await render(plugin, block, SOURCE.slice(0, 1500));
+  const id = fenceId(block.latest as HighlightResult);
+  // A second, longer chunk: growth from code this fence has already seen is what a stream is.
+  await render(plugin, block, SOURCE.slice(0, 2500));
+
+  gate.place(id, FAR);
+  assert.ok(
+    spanCount(block.latest as HighlightResult) >
+      (block.latest as HighlightResult).tokens.length,
+    "held highlighted while the stream is live",
+  );
+
+  // The stream ends. Nothing calls back to say so, so the hold lapses on the clock and the next
+  // measurement is what downgrades it.
+  tick(5000);
+  gate.place(id, FAR);
+  assert.equal(
+    spanCount(block.latest as HighlightResult),
+    (block.latest as HighlightResult).tokens.length,
+    "and downgraded once it is quiet",
+  );
+});
+
+test("a block that arrives complete is not mistaken for a stream", async () => {
+  // Every block in a SEEDED thread calls highlight() once with its whole body, which is growth
+  // from nothing. Counting that as streaming would hold all 57 blocks at the 100K rung highlighted
+  // for the whole grace window on every mount -- the case this exists for, opted out of itself.
+  const { gate } = gateOn();
+  const plugin = createCodePlugin({ themes: THEMES, gate });
+  const block = new Block();
+  await render(plugin, block, SOURCE);
+
+  gate.place(fenceId(block.latest as HighlightResult), FAR);
+  const served = block.latest as HighlightResult;
+  assert.equal(
+    spanCount(served),
+    served.tokens.length,
+    "downgraded on the first measurement, with no clock to wait for",
+  );
+});
+
+test("a fence that streamed while gated plain comes back with the whole block, not a stale prefix", async () => {
+  // The gated path deliberately does NOT advance `fence.code`, so the plugin's cached result can
+  // fall behind the code it has been shown. A re-highlight that tokenized the cached prefix would
+  // restore a block missing everything that arrived while it was plain.
+  const { gate, tick } = gateOn();
+  const plugin = createCodePlugin({ themes: THEMES, gate });
+  const block = new Block();
+
+  const half = SOURCE.slice(0, SOURCE.lastIndexOf("\n", SOURCE.length / 2));
+  await render(plugin, block, half);
+  const id = fenceId(block.latest as HighlightResult);
+
+  gate.place(id, FAR);
+  tick(5000);
+  assert.equal(
+    spanCount(block.latest as HighlightResult),
+    (block.latest as HighlightResult).tokens.length,
+    "plain",
+  );
+
+  // More of the block arrives while it is off screen.
+  await render(plugin, block, SOURCE);
+  gate.place(id, NEAR);
+
+  const restored = block.latest as HighlightResult;
+  assert.equal(lines(restored).join("\n"), SOURCE);
+
+  const reference = createCodePlugin({ themes: THEMES });
+  const control = new Block();
+  await render(reference, control, SOURCE);
+  assert.deepEqual(
+    lines(restored),
+    lines(control.latest as HighlightResult),
+    "the same text the ungated plugin produces for the whole block",
+  );
+});
+
+test("the fence id rides out on the first token that is actually rendered", async () => {
+  // Streamdown renders an empty line as a bare newline with no span at all, so an id put on one
+  // would never reach the DOM and the block would never be located.
+  const { gate } = gateOn();
+  const plugin = createCodePlugin({ themes: THEMES, gate });
+  const block = new Block();
+  await render(plugin, block, `\n\n${SOURCE}`);
+
+  const result = block.latest as HighlightResult;
+  const stamped = result.tokens.findIndex((line) =>
+    line.some((token) => token.htmlAttrs?.[CODE_FENCE_ATTRIBUTE] !== undefined),
+  );
+  const rendered = result.tokens.findIndex(
+    (line) => line.length > 0 && !(line.length === 1 && line[0].content === ""),
+  );
+  assert.equal(stamped, rendered);
+  assert.ok(stamped > 0, "this fixture starts with lines that render no span");
+});
+
+test("two blocks sharing one fence are both told, because the fence is keyed on content", async () => {
+  // Identical code in two places is one fence, so the gate's answer is per CONTENT and not per
+  // element. Both mounted blocks have to be updated together or one keeps a rendering the gate
+  // has already retired.
+  const { gate } = gateOn();
+  const plugin = createCodePlugin({ themes: THEMES, gate });
+  const first = new Block();
+  const second = new Block();
+  await render(plugin, first, SOURCE);
+  await render(plugin, second, SOURCE);
+
+  const id = fenceId(first.latest as HighlightResult);
+  gate.place(id, FAR);
+
+  for (const block of [first, second]) {
+    const served = block.latest as HighlightResult;
+    assert.equal(spanCount(served), served.tokens.length);
+  }
+});
+
+test("a gate notification for a block with nothing mounted does no work", () => {
+  // `forget` and eviction both leave ids the gate may still name. Publishing to an empty
+  // subscriber set has to be a no-op rather than a throw.
+  const { gate } = gateOn();
+  createCodePlugin({ themes: THEMES, gate });
+  gate.place("sf-nonexistent", FAR);
+  gate.place("sf-nonexistent", NEAR);
+});


### PR DESCRIPTION
### What is actually in the DOM

At the 100K rung a Studio thread is **63,180 elements**, and **42,077 of them are Shiki syntax-highlight token spans**. That is 67% of the whole document, produced by only **57 code blocks**, at **4.69 characters per span**.

Interactions against that standing DOM collapse:

| Interaction | fps |
| --- | --- |
| `reasoning_toggle` | 2.7 |
| `select_all_copy` | 5.6 |
| streaming | ~60 |

Streaming is fine. It is the standing document that is slow, and two thirds of it is colour on code the user is not looking at.

### The change

A code block far from the viewport renders as **plain text, one token per line**. A block inside the viewport plus a 2,000 px buffer gets its full set of Shiki tokens, and a block that comes back into that band is re-highlighted.

Plain is not a new render mode. `plainLine` was already in `code-plugin.ts`, already used for the tail of a streaming fence, so this reuses the drawing path the plugin has always had for uncoloured code.

Three new files, all under `studio/frontend/src/components/assistant-ui/`:

- `code-highlight-gate.ts`, the decision, pure. No DOM, no React, no timers: geometry is pushed in, `now` is passed in. Both early returns fail open towards colour, so a block that is streaming or that nothing has measured yet stays highlighted.
- `code-highlight-viewport.ts`, the DOM half. It only measures and reports positions.
- `thread-feature-flags.ts`, the flag.

`code-plugin.ts` gains an optional `gate` option. With no gate it takes the exact path it always had, every return is the object it always returned, and no attribute is stamped on any token.

### Layout neutrality, measured

Measured on the real 57-fence corpus in Chromium at 1280x900, swapping every block to plain:

| | Highlighted | Plain |
| --- | --- | --- |
| Token spans | 42,134 | 2,793 (**-93.4%**) |
| Document height | 30,650 px | 30,650 px (delta **0**) |
| Max block height delta | | **0.0 px** |
| Max block top delta | | **0 px** |
| Blocks moved or resized | | **0 of 57** |

Line element counts identical, code text identical. This holds by construction rather than by luck: the plain lines are derived from the tokenized result, not re-split from the source, so the line count and the per-line text are equal, and `<pre>` does not wrap, so a block's height is its line count times its line height.

Selection text is byte-identical across both arms: **102,394 characters, sha `3050450b0f4c82eb`** on each side. `window.find` returns exactly 1 hit on both arms for five needles, including ones Shiki splits across several coloured spans.

### Why the buffer is 2,000 px

Sized from the measured re-highlight latency rather than picked round. Re-highlighting one fence, over all 57 content fences at the 100K rung:

```
median   12.65 ms
p90      28.54 ms
max      39.39 ms
```

2,000 px holds about 3.5 blocks, so refilling the buffer costs about 100 ms at p90. Crossing 2,000 px takes 400 ms at 5,000 px/s, a hard trackpad flick. Raising the buffer hides uncoloured code under faster scrolling and stands more spans in the document. Lowering it does the reverse. Nothing else in the mechanism trades those two against each other.

### Limitations, stated plainly

**Every block is highlighted once before it can be downgraded.** `highlight()` receives only `{code, language, themes}`, and the element has to exist before its position can be measured. So this removes **standing spans** and saves **no tokenization work**. If the cost you care about is the tokenizer, this is not the change for it.

**Fence identity is per content, not per element.** Two identical code blocks share one fence and are therefore gated together.

**No A/B has been run yet.** There is no interaction-timing result here and this PR does not claim one. Every number above is a DOM and geometry measurement. The A/B is running separately and will be posted as a follow-up comment on this PR.

That last point is why the flag ships **off**:

```ts
export const VIEWPORT_GATED_CODE_HIGHLIGHTING_ENABLED = false;
```

While it is false no gate is built, `createCodePlugin` is called with no gate at all, and the flag-off DOM is unchanged down to the absence of a single attribute. Flipping that one constant is the only edit needed to enable it.

### Tests

`npm test` in `studio/frontend`: **4,108 pass, 0 fail, 0 skipped**. That includes 21 new tests (11 in `tests/code-highlight-gate.test.ts`, 10 in `tests/code-plugin-viewport-gating.test.ts`) and all 39 pre-existing code-plugin tests, unchanged.

The new decision tests are written against ways of getting the rule backwards that were reachable while this was built, since a block decoloured under a scrolling user would be a worse bug than the slow DOM this exists to shrink. The plugin tests assert line count and per-line text equal on every swap, which is the property that makes the swap layout-neutral.

`npm run typecheck` and `npm run build` are green on this branch.
