### PR TITLE
Studio: put Remote and LAN access on their own settings tab

### DIFF
--- a/studio/backend/startup_banner.py
+++ b/studio/backend/startup_banner.py
@@ -172,7 +172,7 @@ def print_studio_access_banner(
                 style("  LAN access is on -- also reachable on your network at:", secondary)
             )
             lines.extend(style(f"    http://{a}:{port}", secondary) for a in lan_addresses)
-            lines.append(style("  Turn it off in Settings > API keys > LAN access.", secondary))
+            lines.append(style("  Turn it off in Settings > Remote & LAN > LAN access.", secondary))
         else:
             lines.extend(
                 [
@@ -182,7 +182,7 @@ def print_studio_access_banner(
                         secondary,
                     ),
                     style(
-                        "  To expose it, turn on Settings > API keys > LAN access, or "
+                        "  To expose it, turn on Settings > Remote & LAN > LAN access, or "
                         f"relaunch with:  unsloth studio -H 0.0.0.0 -p {port}",
                         secondary,
                     ),

--- a/studio/frontend/src/features/settings/settings-dialog.tsx
+++ b/studio/frontend/src/features/settings/settings-dialog.tsx
@@ -18,13 +18,13 @@ import { scheduleIdleTask } from "@/lib/schedule-idle-task";
 import {
   BotIcon,
   Cancel01Icon,
-  CellularNetworkIcon,
   CloudIcon,
   ComputerTerminal01Icon,
   CpuIcon,
   DatabaseSettingIcon,
   Globe02Icon,
   HelpCircleIcon,
+  HomeWifiIcon,
   KeyboardIcon,
   Message01Icon,
   PaintBrush02Icon,
@@ -192,7 +192,7 @@ const TABS: TabDef[] = [
   {
     id: "remote-lan",
     labelKey: "settings.tabs.remoteLan",
-    icon: CellularNetworkIcon,
+    icon: HomeWifiIcon,
   },
   {
     id: "connections",

--- a/studio/frontend/src/features/settings/settings-dialog.tsx
+++ b/studio/frontend/src/features/settings/settings-dialog.tsx
@@ -18,6 +18,7 @@ import { scheduleIdleTask } from "@/lib/schedule-idle-task";
 import {
   BotIcon,
   Cancel01Icon,
+  CellularNetworkIcon,
   CloudIcon,
   ComputerTerminal01Icon,
   CpuIcon,
@@ -73,6 +74,8 @@ const TAB_LOADERS = {
       default: m.KeyboardShortcutsTab,
     })),
   "api-keys": () => import("./tabs/api-keys-tab").then((m) => ({ default: m.ApiKeysTab })),
+  "remote-lan": () =>
+    import("./tabs/remote-lan-tab").then((m) => ({ default: m.RemoteLanTab })),
   agents: () => import("./tabs/agents-tab").then((m) => ({ default: m.AgentsTab })),
   debugging: () =>
     import("./tabs/debugging-tab").then((m) => ({ default: m.DebuggingTab })),
@@ -185,6 +188,11 @@ const TABS: TabDef[] = [
     id: "api-keys",
     labelKey: "settings.tabs.apiKeys",
     icon: Globe02Icon,
+  },
+  {
+    id: "remote-lan",
+    labelKey: "settings.tabs.remoteLan",
+    icon: CellularNetworkIcon,
   },
   {
     id: "connections",
@@ -357,6 +365,7 @@ export function SettingsDialog() {
     "keyboard-shortcuts": null,
     data: null,
     "api-keys": null,
+    "remote-lan": null,
     agents: null,
     debugging: null,
     about: null,

--- a/studio/frontend/src/features/settings/settings-search.ts
+++ b/studio/frontend/src/features/settings/settings-search.ts
@@ -119,14 +119,9 @@ export const SETTINGS_SEARCH_INDEX: Record<SettingsTab, TranslationKey[]> = {
     "settings.apiKeys.description",
     "settings.apiKeys.accessTokens",
   ],
-  // Both section headings carry a matching data-settings-label, so a hit scrolls
-  // to the card rather than only opening the tab.
-  "remote-lan": [
-    "settings.remoteLan.title",
-    "settings.remoteLan.description",
-    "settings.remoteLan.remoteAccess",
-    "settings.remoteLan.lanAccess",
-  ],
+  // The two cards label themselves in English in every locale, so keys naming them
+  // would never match their own anchor. The header carries both entries instead.
+  "remote-lan": ["settings.remoteLan.title", "settings.remoteLan.description"],
   agents: [
     // Every key needs a rendered data-settings-label, or a hit has nothing to scroll to.
     "settings.agents.title",

--- a/studio/frontend/src/features/settings/settings-search.ts
+++ b/studio/frontend/src/features/settings/settings-search.ts
@@ -119,6 +119,14 @@ export const SETTINGS_SEARCH_INDEX: Record<SettingsTab, TranslationKey[]> = {
     "settings.apiKeys.description",
     "settings.apiKeys.accessTokens",
   ],
+  // Both section headings carry a matching data-settings-label, so a hit scrolls
+  // to the card rather than only opening the tab.
+  "remote-lan": [
+    "settings.remoteLan.title",
+    "settings.remoteLan.description",
+    "settings.remoteLan.remoteAccess",
+    "settings.remoteLan.lanAccess",
+  ],
   agents: [
     // Every key needs a rendered data-settings-label, or a hit has nothing to scroll to.
     "settings.agents.title",

--- a/studio/frontend/src/features/settings/stores/settings-dialog-store.ts
+++ b/studio/frontend/src/features/settings/stores/settings-dialog-store.ts
@@ -17,6 +17,7 @@ export const SETTINGS_TABS = [
   "connections",
   "data",
   "api-keys",
+  "remote-lan",
   "agents",
   "keyboard-shortcuts",
   "debugging",

--- a/studio/frontend/src/features/settings/tabs/api-keys-tab.tsx
+++ b/studio/frontend/src/features/settings/tabs/api-keys-tab.tsx
@@ -174,6 +174,7 @@ export function ApiKeysTab() {
 
       <MonitorLink />
 
+      {/* Also on the Remote & LAN tab. One panel mounts at a time, so only one polls. */}
       <RemoteAccessSection />
 
       <LanAccessSection />

--- a/studio/frontend/src/features/settings/tabs/remote-lan-tab.tsx
+++ b/studio/frontend/src/features/settings/tabs/remote-lan-tab.tsx
@@ -11,11 +11,18 @@ export function RemoteLanTab() {
 
   return (
     <div className="flex min-w-0 max-w-full flex-col gap-6">
+      {/* data-settings-label lets indexed settings search scroll to these. */}
       <header className="flex min-w-0 flex-col gap-1">
-        <h1 className="text-xl font-semibold font-heading">
+        <h1
+          data-settings-label={t("settings.remoteLan.title")}
+          className="text-xl font-semibold font-heading"
+        >
           {t("settings.remoteLan.title")}
         </h1>
-        <p className="text-xs text-muted-foreground">
+        <p
+          data-settings-label={t("settings.remoteLan.description")}
+          className="text-xs text-muted-foreground"
+        >
           {t("settings.remoteLan.description")}
         </p>
       </header>

--- a/studio/frontend/src/features/settings/tabs/remote-lan-tab.tsx
+++ b/studio/frontend/src/features/settings/tabs/remote-lan-tab.tsx
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import { useT } from "@/i18n";
+import { LanAccessSection } from "../components/lan-access-section";
+import { RemoteAccessSection } from "../components/remote-access-section";
+
+/** Reaching Studio from another device, without the API token list in the way. */
+export function RemoteLanTab() {
+  const t = useT();
+
+  return (
+    <div className="flex min-w-0 max-w-full flex-col gap-6">
+      <header className="flex min-w-0 flex-col gap-1">
+        <h1 className="text-xl font-semibold font-heading">
+          {t("settings.remoteLan.title")}
+        </h1>
+        <p className="text-xs text-muted-foreground">
+          {t("settings.remoteLan.description")}
+        </p>
+      </header>
+
+      <RemoteAccessSection />
+
+      <LanAccessSection />
+    </div>
+  );
+}

--- a/studio/frontend/src/i18n/locales/ar.ts
+++ b/studio/frontend/src/i18n/locales/ar.ts
@@ -193,6 +193,7 @@ export const ar = {
       chat: "المحادثة",
       connections: "الاتصالات",
       apiKeys: "API",
+      remoteLan: "الوصول عن بُعد والشبكة المحلية",
       about: "حول",
       data: "البيانات",
       agents: "الوكلاء",
@@ -1226,6 +1227,13 @@ export const ar = {
     connections: {
       title: "الاتصالات",
       description: "إدارة المزوّدين والاتصالات الخارجية.",
+    },
+    remoteLan: {
+      title: "الوصول عن بُعد والشبكة المحلية",
+      description:
+        "الوصول إلى Unsloth من أجهزتك الأخرى عبر شبكتك المحلية أو عنوان URL عام مؤقت.",
+      remoteAccess: "الوصول عن بُعد",
+      lanAccess: "وصول الشبكة المحلية",
     },
     apiKeys: {
       title: "API",

--- a/studio/frontend/src/i18n/locales/ar.ts
+++ b/studio/frontend/src/i18n/locales/ar.ts
@@ -1232,8 +1232,6 @@ export const ar = {
       title: "الوصول عن بُعد والشبكة المحلية",
       description:
         "الوصول إلى Unsloth من أجهزتك الأخرى عبر شبكتك المحلية أو عنوان URL عام مؤقت.",
-      remoteAccess: "الوصول عن بُعد",
-      lanAccess: "وصول الشبكة المحلية",
     },
     apiKeys: {
       title: "API",

--- a/studio/frontend/src/i18n/locales/de.ts
+++ b/studio/frontend/src/i18n/locales/de.ts
@@ -1272,8 +1272,6 @@ export const de = {
       title: "Remote & LAN",
       description:
         "Erreiche dieses Unsloth von deinen anderen Geräten über dein lokales Netzwerk oder eine temporäre öffentliche URL.",
-      remoteAccess: "Fernzugriff",
-      lanAccess: "LAN-Zugriff",
     },
     apiKeys: {
       title: "API",

--- a/studio/frontend/src/i18n/locales/de.ts
+++ b/studio/frontend/src/i18n/locales/de.ts
@@ -197,6 +197,7 @@ export const de = {
       chat: "Chat",
       connections: "Verbindungen",
       apiKeys: "API",
+      remoteLan: "Remote & LAN",
       about: "Info",
       data: "Daten",
       agents: "Agenten",
@@ -1266,6 +1267,13 @@ export const de = {
     connections: {
       title: "Verbindungen",
       description: "Verwalten Sie Anbieter und externe Verbindungen.",
+    },
+    remoteLan: {
+      title: "Remote & LAN",
+      description:
+        "Erreiche dieses Unsloth von deinen anderen Geräten über dein lokales Netzwerk oder eine temporäre öffentliche URL.",
+      remoteAccess: "Fernzugriff",
+      lanAccess: "LAN-Zugriff",
     },
     apiKeys: {
       title: "API",

--- a/studio/frontend/src/i18n/locales/en.ts
+++ b/studio/frontend/src/i18n/locales/en.ts
@@ -195,6 +195,7 @@ export const en = {
       connections: "Connections",
       data: "Data",
       apiKeys: "API",
+      remoteLan: "Remote & LAN",
       agents: "Agents",
       keyboardShortcuts: "Shortcuts",
       debugging: "Logs",
@@ -1220,6 +1221,13 @@ export const en = {
     connections: {
       title: "Connections",
       description: "Manage providers and external connections.",
+    },
+    remoteLan: {
+      title: "Remote & LAN",
+      description:
+        "Reach this Unsloth from your other devices, over your local network or a temporary public URL.",
+      remoteAccess: "Remote access",
+      lanAccess: "LAN access",
     },
     apiKeys: {
       title: "API",

--- a/studio/frontend/src/i18n/locales/en.ts
+++ b/studio/frontend/src/i18n/locales/en.ts
@@ -1226,8 +1226,6 @@ export const en = {
       title: "Remote & LAN",
       description:
         "Reach this Unsloth from your other devices, over your local network or a temporary public URL.",
-      remoteAccess: "Remote access",
-      lanAccess: "LAN access",
     },
     apiKeys: {
       title: "API",

--- a/studio/frontend/src/i18n/locales/es.ts
+++ b/studio/frontend/src/i18n/locales/es.ts
@@ -1263,8 +1263,6 @@ export const es = {
       title: "Remoto y LAN",
       description:
         "Accede a este Unsloth desde tus otros dispositivos, por tu red local o mediante una URL pública temporal.",
-      remoteAccess: "Acceso remoto",
-      lanAccess: "Acceso LAN",
     },
     apiKeys: {
       title: "API",

--- a/studio/frontend/src/i18n/locales/es.ts
+++ b/studio/frontend/src/i18n/locales/es.ts
@@ -196,6 +196,7 @@ export const es = {
       chat: "Chat",
       connections: "Conexiones",
       apiKeys: "API",
+      remoteLan: "Remoto y LAN",
       about: "Acerca de",
       data: "Datos",
       agents: "Agentes",
@@ -1257,6 +1258,13 @@ export const es = {
     connections: {
       title: "Conexiones",
       description: "Gestiona proveedores y conexiones externas.",
+    },
+    remoteLan: {
+      title: "Remoto y LAN",
+      description:
+        "Accede a este Unsloth desde tus otros dispositivos, por tu red local o mediante una URL pública temporal.",
+      remoteAccess: "Acceso remoto",
+      lanAccess: "Acceso LAN",
     },
     apiKeys: {
       title: "API",

--- a/studio/frontend/src/i18n/locales/fr.ts
+++ b/studio/frontend/src/i18n/locales/fr.ts
@@ -1271,8 +1271,6 @@ export const fr = {
       title: "Accès distant et LAN",
       description:
         "Accédez à cet Unsloth depuis vos autres appareils, via votre réseau local ou une URL publique temporaire.",
-      remoteAccess: "Accès distant",
-      lanAccess: "Accès LAN",
     },
     apiKeys: {
       title: "API",

--- a/studio/frontend/src/i18n/locales/fr.ts
+++ b/studio/frontend/src/i18n/locales/fr.ts
@@ -197,6 +197,7 @@ export const fr = {
       chat: "Discussion",
       connections: "Connexions",
       apiKeys: "API",
+      remoteLan: "Accès distant et LAN",
       about: "À propos",
       data: "Données",
       agents: "Agents",
@@ -1265,6 +1266,13 @@ export const fr = {
     connections: {
       title: "Connexions",
       description: "Gérez les fournisseurs et les connexions externes.",
+    },
+    remoteLan: {
+      title: "Accès distant et LAN",
+      description:
+        "Accédez à cet Unsloth depuis vos autres appareils, via votre réseau local ou une URL publique temporaire.",
+      remoteAccess: "Accès distant",
+      lanAccess: "Accès LAN",
     },
     apiKeys: {
       title: "API",

--- a/studio/frontend/src/i18n/locales/hi.ts
+++ b/studio/frontend/src/i18n/locales/hi.ts
@@ -196,6 +196,7 @@ export const hi = {
       chat: "चैट",
       connections: "कनेक्शन",
       apiKeys: "API",
+      remoteLan: "रिमोट और LAN",
       about: "परिचय",
       data: "डेटा",
       agents: "एजेंट",
@@ -1232,6 +1233,13 @@ export const hi = {
     connections: {
       title: "कनेक्शन",
       description: "प्रदाता और बाहरी कनेक्शन प्रबंधित करें।",
+    },
+    remoteLan: {
+      title: "रिमोट और LAN",
+      description:
+        "इस Unsloth तक अपने दूसरे डिवाइस से पहुँचें, अपने लोकल नेटवर्क या एक अस्थायी सार्वजनिक URL से।",
+      remoteAccess: "रिमोट पहुँच",
+      lanAccess: "LAN पहुँच",
     },
     apiKeys: {
       title: "API",

--- a/studio/frontend/src/i18n/locales/hi.ts
+++ b/studio/frontend/src/i18n/locales/hi.ts
@@ -1238,8 +1238,6 @@ export const hi = {
       title: "रिमोट और LAN",
       description:
         "इस Unsloth तक अपने दूसरे डिवाइस से पहुँचें, अपने लोकल नेटवर्क या एक अस्थायी सार्वजनिक URL से।",
-      remoteAccess: "रिमोट पहुँच",
-      lanAccess: "LAN पहुँच",
     },
     apiKeys: {
       title: "API",

--- a/studio/frontend/src/i18n/locales/it.ts
+++ b/studio/frontend/src/i18n/locales/it.ts
@@ -1236,8 +1236,6 @@ export const it = {
       title: "Remoto e LAN",
       description:
         "Raggiungi questo Unsloth dagli altri tuoi dispositivi, tramite la rete locale o un URL pubblico temporaneo.",
-      remoteAccess: "Accesso remoto",
-      lanAccess: "Accesso LAN",
     },
     apiKeys: {
       title: "API",

--- a/studio/frontend/src/i18n/locales/it.ts
+++ b/studio/frontend/src/i18n/locales/it.ts
@@ -163,6 +163,7 @@ export const it = {
       connections: "Connessioni",
       data: "Dati",
       apiKeys: "API",
+      remoteLan: "Remoto e LAN",
       agents: "Agenti",
       debugging: "Log",
       about: "Informazioni",
@@ -1230,6 +1231,13 @@ export const it = {
     connections: {
       title: "Connessioni",
       description: "Gestisci provider e connessioni esterne.",
+    },
+    remoteLan: {
+      title: "Remoto e LAN",
+      description:
+        "Raggiungi questo Unsloth dagli altri tuoi dispositivi, tramite la rete locale o un URL pubblico temporaneo.",
+      remoteAccess: "Accesso remoto",
+      lanAccess: "Accesso LAN",
     },
     apiKeys: {
       title: "API",

--- a/studio/frontend/src/i18n/locales/ja.ts
+++ b/studio/frontend/src/i18n/locales/ja.ts
@@ -1211,8 +1211,6 @@ export const ja = {
       title: "リモートとLAN",
       description:
         "ローカルネットワークまたは一時的な公開URLを介して、他のデバイスからこのUnslothにアクセスできます。",
-      remoteAccess: "リモートアクセス",
-      lanAccess: "LANアクセス",
     },
     apiKeys: {
       title: "API",

--- a/studio/frontend/src/i18n/locales/ja.ts
+++ b/studio/frontend/src/i18n/locales/ja.ts
@@ -195,6 +195,7 @@ export const ja = {
       chat: "チャット",
       connections: "接続",
       apiKeys: "API",
+      remoteLan: "リモートとLAN",
       about: "情報",
       voice: "音声",
       data: "データ",
@@ -1205,6 +1206,13 @@ export const ja = {
     connections: {
       title: "接続",
       description: "プロバイダーと外部接続を管理します。",
+    },
+    remoteLan: {
+      title: "リモートとLAN",
+      description:
+        "ローカルネットワークまたは一時的な公開URLを介して、他のデバイスからこのUnslothにアクセスできます。",
+      remoteAccess: "リモートアクセス",
+      lanAccess: "LANアクセス",
     },
     apiKeys: {
       title: "API",

--- a/studio/frontend/src/i18n/locales/ko.ts
+++ b/studio/frontend/src/i18n/locales/ko.ts
@@ -1230,8 +1230,6 @@ export const ko = {
       title: "원격 및 LAN",
       description:
         "로컬 네트워크나 임시 공개 URL을 통해 다른 기기에서 이 Unsloth에 접속합니다.",
-      remoteAccess: "원격 접근",
-      lanAccess: "LAN 접근",
     },
     apiKeys: {
       title: "API",

--- a/studio/frontend/src/i18n/locales/ko.ts
+++ b/studio/frontend/src/i18n/locales/ko.ts
@@ -193,6 +193,7 @@ export const ko = {
       chat: "채팅",
       connections: "연결",
       apiKeys: "API",
+      remoteLan: "원격 및 LAN",
       about: "정보",
       data: "데이터",
       agents: "에이전트",
@@ -1224,6 +1225,13 @@ export const ko = {
     connections: {
       title: "연결",
       description: "제공자 및 외부 연결을 관리합니다.",
+    },
+    remoteLan: {
+      title: "원격 및 LAN",
+      description:
+        "로컬 네트워크나 임시 공개 URL을 통해 다른 기기에서 이 Unsloth에 접속합니다.",
+      remoteAccess: "원격 접근",
+      lanAccess: "LAN 접근",
     },
     apiKeys: {
       title: "API",

--- a/studio/frontend/src/i18n/locales/pt-br.ts
+++ b/studio/frontend/src/i18n/locales/pt-br.ts
@@ -1245,8 +1245,6 @@ export const ptBR = {
       title: "Remoto e LAN",
       description:
         "Acesse este Unsloth dos seus outros dispositivos, pela rede local ou por uma URL pública temporária.",
-      remoteAccess: "Acesso remoto",
-      lanAccess: "Acesso LAN",
     },
     apiKeys: {
       title: "API",

--- a/studio/frontend/src/i18n/locales/pt-br.ts
+++ b/studio/frontend/src/i18n/locales/pt-br.ts
@@ -195,6 +195,7 @@ export const ptBR = {
       chat: "Chat",
       connections: "Conexões",
       apiKeys: "API",
+      remoteLan: "Remoto e LAN",
       about: "Sobre",
       voice: "Voz",
       data: "Dados",
@@ -1239,6 +1240,13 @@ export const ptBR = {
     connections: {
       title: "Conexões",
       description: "Gerencie provedores e conexões externas.",
+    },
+    remoteLan: {
+      title: "Remoto e LAN",
+      description:
+        "Acesse este Unsloth dos seus outros dispositivos, pela rede local ou por uma URL pública temporária.",
+      remoteAccess: "Acesso remoto",
+      lanAccess: "Acesso LAN",
     },
     apiKeys: {
       title: "API",

--- a/studio/frontend/src/i18n/locales/ru.ts
+++ b/studio/frontend/src/i18n/locales/ru.ts
@@ -1243,8 +1243,6 @@ export const ru = {
       title: "Удалённый доступ и LAN",
       description:
         "Откройте этот Unsloth с других устройств: через локальную сеть или временный публичный URL.",
-      remoteAccess: "Удалённый доступ",
-      lanAccess: "Доступ по LAN",
     },
     apiKeys: {
       title: "API",

--- a/studio/frontend/src/i18n/locales/ru.ts
+++ b/studio/frontend/src/i18n/locales/ru.ts
@@ -195,6 +195,7 @@ export const ru = {
       chat: "Чат",
       connections: "Подключения",
       apiKeys: "API",
+      remoteLan: "Удалённый доступ и LAN",
       about: "О программе",
       data: "Данные",
       agents: "Агенты",
@@ -1237,6 +1238,13 @@ export const ru = {
     connections: {
       title: "Подключения",
       description: "Управление провайдерами и внешними подключениями.",
+    },
+    remoteLan: {
+      title: "Удалённый доступ и LAN",
+      description:
+        "Откройте этот Unsloth с других устройств: через локальную сеть или временный публичный URL.",
+      remoteAccess: "Удалённый доступ",
+      lanAccess: "Доступ по LAN",
     },
     apiKeys: {
       title: "API",

--- a/studio/frontend/src/i18n/locales/zh-CN.ts
+++ b/studio/frontend/src/i18n/locales/zh-CN.ts
@@ -191,6 +191,7 @@ export const zhCN = {
       chat: "聊天",
       connections: "连接",
       apiKeys: "API",
+      remoteLan: "远程与局域网",
       about: "关于",
       voice: "语音",
       data: "数据",
@@ -1193,6 +1194,13 @@ export const zhCN = {
     connections: {
       title: "连接",
       description: "管理提供方和外部服务的连接。",
+    },
+    remoteLan: {
+      title: "远程与局域网",
+      description:
+        "通过局域网或临时公开 URL，从其他设备访问此 Unsloth。",
+      remoteAccess: "远程访问",
+      lanAccess: "局域网访问",
     },
     apiKeys: {
       title: "API",

--- a/studio/frontend/src/i18n/locales/zh-CN.ts
+++ b/studio/frontend/src/i18n/locales/zh-CN.ts
@@ -1199,8 +1199,6 @@ export const zhCN = {
       title: "远程与局域网",
       description:
         "通过局域网或临时公开 URL，从其他设备访问此 Unsloth。",
-      remoteAccess: "远程访问",
-      lanAccess: "局域网访问",
     },
     apiKeys: {
       title: "API",

--- a/tests/studio/playwright_settings_tabs.py
+++ b/tests/studio/playwright_settings_tabs.py
@@ -40,6 +40,7 @@ TABS = [
     "connections",
     "data",
     "api-keys",
+    "remote-lan",
     "agents",
     "keyboard-shortcuts",
     "debugging",


### PR DESCRIPTION
Turning on LAN access means opening **Settings > API**, scrolling past the token
creation form, the access token list and the API monitor, and finding the card
below all of it. Nothing about reaching Studio from a phone on the same Wi-Fi is
an API-key concern, and the launch banner has been telling people to go there
since LAN access landed:

```
To expose it, turn on Settings > API keys > LAN access, or
relaunch with:  unsloth studio -H 0.0.0.0 -p 8931
```

## What this does

Adds a **Remote & LAN** tab directly under API, holding the remote access and LAN
access cards and nothing else. Both cards stay on the API tab too, so anyone who
knows where they are today loses nothing.

The two mounts share one chunk rather than duplicating the component:

```
api-keys-tab-DvrXpWnt.js   ->  remote-access-section-DGep6x6a.js
remote-lan-tab-BpHoo_Io.js ->  remote-access-section-DGep6x6a.js
```

Both sections poll while mounted, so a copy on each tab could mean two pollers on
one status endpoint. It does not: panels render from `panelTab`, one at a time, so
only the visible copy is ever mounted.

## Registration

A tab id has four places to land and they drift apart quietly, which is what
`test_settings_smoke_covers_every_tab` exists to catch. All four are updated:

| where | why it matters if missed |
|---|---|
| `SETTINGS_TABS` in the store | persisted tab rejected on reload, silently falls back to General |
| `TAB_LOADERS` and `TABS` | the panel has no chunk and no nav row |
| `tabButtonRefs` | focus restore on open misses the row |
| smoke `TABS` list | page ships with no browser coverage, smoke still green |

Search is wired through `SETTINGS_SEARCH_INDEX`. The two entries beyond the title
and description are deliberate: `settings.remoteLan.remoteAccess` and
`.lanAccess` render as the existing `data-settings-label` on each card, so
searching "LAN" scrolls to the card instead of only opening the tab.

## Icon

`HomeWifiIcon`. The house plus wifi arcs is the clearest silhouette of the
candidates at the 18px nav size, and it reads as "my own network" without
competing with the globe on the API row above it.

## Also

Both banner strings in `startup_banner.py` now name **Settings > Remote & LAN >
LAN access**, since the old path was about to be one hop stale.

Full locale coverage: `settings.tabs.remoteLan` plus the tab title, description
and the two search labels across all 12 locales, not just en.

## Verified

- `npm run typecheck` and `npm run i18n:check:strict` clean.
- 62 passed across `test_settings_smoke_covers_every_tab`,
  `test_usage_examples_model_source_contract`,
  `test_desktop_reliability_frontend_contract`,
  `test_settings_compact_overflow_contract`.
- 12 passed in the startup banner suites.
- API tab ordering unchanged: monitor, then remote, then LAN, then auto-switch,
  then usage examples.

