### PR TITLE
Run the Windows UI suites in two parallel lanes instead of five in sequence

### DIFF
--- a/.github/scripts/boot-studio-api-only.sh
+++ b/.github/scripts/boot-studio-api-only.sh
@@ -64,7 +64,15 @@ done
 
 # Wipe rather than reset: the boot below re-seeds .bootstrap_password only when
 # the directory is gone. See the header.
-rm -rf ~/.unsloth/studio/auth
+#
+# Through $UNSLOTH_STUDIO_HOME, matching run-studio-permission-browser.sh and
+# run-studio-indicator-browser.sh, which have read it since #9158. This script was
+# the odd one out, hardcoding the legacy path, and that is what forced every
+# Playwright step sharing this boot to run one after another: two concurrent lanes
+# on one home race destructively, one wiping the .bootstrap_password the other just
+# minted and is about to log in with. Unset, this is byte-for-byte the old path.
+studio_home="${UNSLOTH_STUDIO_HOME:-$HOME/.unsloth/studio}"
+rm -rf "$studio_home/auth"
 mkdir -p "$(dirname "$LOG")"
 
 # shellcheck disable=SC2086  # $API_ONLY is one flag or empty, and must not become ''

--- a/.github/scripts/run-studio-ui-lane.sh
+++ b/.github/scripts/run-studio-ui-lane.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+#
+# One lane of the Windows Chat UI Tests job, start to finish: boot a Studio on
+# this lane's own port and own UNSLOTH_STUDIO_HOME, rotate the bootstrap
+# password, drive its Playwright suites, stop the server.
+#
+# Usage:  run-studio-ui-lane.sh chat|extra
+#
+# Why this exists. The job ran five Playwright suites one after another for
+# ~788s of a 20.6 minute job, 88% of it in steps over 60s, and it was the last
+# finisher on every commit where no macOS job ran. The suites are disjoint --
+# each boots its own server and drives its own browser -- and the ports were
+# ALREADY distinct (18895/18896/18897/18899). The only thing forcing sequence
+# was shared state, exactly as #9158 found for the three Linux indicator
+# engines.
+#
+# Two lanes rather than five. windows-latest is 4 vCPU / 16 GB and these lanes
+# load a real GGUF through llama-server, whose turn latency already needed a
+# 540s budget on this image. Five concurrent servers would contend for the same
+# four cores and turn a timing-sensitive suite into a flaky one. Two splits the
+# work near evenly -- 375s against 413s -- so the lane wall is ~413s, and the
+# theoretical floor with the 287s indicator suite in it is 287s. Three lanes buy
+# ~126s for a third model-loading server; not worth it here.
+#
+#   chat  : chat UI (18896)  -> loaded-models indicator, Edge (18899)
+#   extra : Compare/Recipes/Export/Settings + update banner (18897)
+#           -> Edge permission controls (18895)
+#
+# Within a lane the order and the environment of every suite is unchanged from
+# when they were steps, including `extra` reusing one server for both of its
+# Playwright runs and passing the same STUDIO_OLD_PW / STUDIO_NEW_PW to each.
+#
+# THE STATE SPLIT. Per lane:
+#
+#   port                 -- one each, so both servers coexist. Already true.
+#   UNSLOTH_STUDIO_HOME  -- one each. boot-studio-api-only.sh wipes
+#       $home/auth so the boot mints a fresh .bootstrap_password, then this
+#       script reads that file back. On a shared home the two lanes race
+#       destructively: one wipes the password the other just minted and is
+#       about to log in with.
+#   health probe tmp     -- one each; the helper defaults to a single path.
+#   artifact + log paths -- one each, so a failure in one lane is still
+#       readable after the other has written its own.
+#
+# UNSLOTH_STUDIO_HOME is the CLI's INSTALL root, not just a data root, so a bare
+# empty directory is not usable: unsloth_cli/commands/studio.py resolves
+# $UNSLOTH_STUDIO_HOME/unsloth_studio/Scripts/python.exe and exits "Unsloth
+# Studio not set up. Run install.sh first." before binding a port. Each lane
+# home therefore links the one venv install.ps1 already built and owns only the
+# mutable state beside it.
+#
+# And one thing the Linux precedent did not have to handle. Setting the variable
+# makes the root CUSTOM, and _ensure_studio_env_exported() then points
+# UNSLOTH_LLAMA_CPP_PATH at $UNSLOTH_STUDIO_HOME/llama.cpp rather than the
+# legacy ~/.unsloth/llama.cpp (studio.py, `if _is_legacy`). These lanes load a
+# real model, so a lane whose home has no llama.cpp would fail to load rather
+# than fall back. It is set explicitly below, which the CLI honours because that
+# export is a truthy-check and not an unconditional assignment.
+
+set -euo pipefail
+
+LANE="${1:?usage: $0 chat|extra}"
+
+case "$LANE" in
+  chat)  PORT=18896 ;;
+  extra) PORT=18897 ;;
+  *) echo "run-studio-ui-lane.sh: unknown lane '$LANE'" >&2; exit 2 ;;
+esac
+
+installed_home="${UNSLOTH_INSTALLED_STUDIO_HOME:-$HOME/.unsloth/studio}"
+# Windows install; Linux path kept so the script is runnable off-CI.
+if [ -x "$installed_home/unsloth_studio/Scripts/python.exe" ]; then
+  installed_py="$installed_home/unsloth_studio/Scripts/python.exe"
+elif [ -x "$installed_home/unsloth_studio/bin/python" ]; then
+  installed_py="$installed_home/unsloth_studio/bin/python"
+else
+  echo "::error::no studio venv under $installed_home; nothing for lane $LANE to link"
+  ls -la "$installed_home" 2>/dev/null || true
+  exit 1
+fi
+echo "[lane $LANE] linking venv from $installed_py"
+
+home="${GITHUB_WORKSPACE:-$PWD}/.studio-lane-$LANE"
+mkdir -p "$home"
+
+# A junction, not `ln -s`. Under MSYS `ln -s` COPIES by default unless
+# MSYS=winsymlinks:nativestrict, and a native symlink needs Developer Mode or
+# admin; either way a per-lane copy of the venv would cost more than the
+# parallelism saves. `mklink /J` is a directory junction, needs no privilege,
+# and is what the filesystem gives you for free.
+if [ ! -e "$home/unsloth_studio" ]; then
+  if [ "${OS:-}" = "Windows_NT" ]; then
+    cmd //c mklink //J "$(cygpath -w "$home/unsloth_studio")" \
+                       "$(cygpath -w "$installed_home/unsloth_studio")" >/dev/null
+  else
+    ln -sfn "$installed_home/unsloth_studio" "$home/unsloth_studio"
+  fi
+fi
+
+export UNSLOTH_STUDIO_HOME="$home"
+# See the header: a custom root would otherwise send this to $home/llama.cpp.
+export UNSLOTH_LLAMA_CPP_PATH="${UNSLOTH_LLAMA_CPP_PATH:-$HOME/.unsloth/llama.cpp}"
+
+server_log="logs/studio-lane-$LANE.log"
+mkdir -p logs
+
+boot() {
+  local port="$1" log="$2"
+  # `env -u GITHUB_ENV` is load-bearing, not tidiness. boot-studio-api-only.sh
+  # appends the pid to $GITHUB_ENV when it is set and only falls back to stdout
+  # when it is not -- and inside a step it is always set. Two concurrent lanes
+  # would then both append LANE_PID= to the one file the runner reads after the
+  # step, which is both a lost pid and the very kind of shared mutable state
+  # this split exists to remove. Unset for this call, the pid comes back on
+  # stdout where a per-lane shell can read it. Same reason the password rotation
+  # below is inline rather than a `>> $GITHUB_ENV` step of its own.
+  env -u GITHUB_ENV bash .github/scripts/boot-studio-api-only.sh \
+    --port "$port" --log "$log" --pid-var "LANE_PID" > "logs/boot-$LANE.out" 2>&1
+  LANE_PID="$(sed -n 's/^LANE_PID=//p' "logs/boot-$LANE.out" | tail -1)"
+  cat "logs/boot-$LANE.out"
+  [ -n "$LANE_PID" ] || { echo "::error::lane $LANE: boot returned no pid"; return 1; }
+  bash .github/scripts/wait-for-health.sh --port "$port" --log "$log" \
+    --tmp "logs/health-$LANE.json"
+}
+
+stop() {
+  [ -n "${LANE_PID:-}" ] || return 0
+  kill "$LANE_PID" 2>/dev/null || true
+  sleep 2
+  LANE_PID=""
+}
+trap stop EXIT
+
+# Rotated per lane, from THIS lane's home. Every existing call site reads
+# ~/.unsloth/studio/auth/.bootstrap_password directly, which is the legacy path
+# and would hand a lane the other lane's password.
+mint() {
+  STUDIO_OLD_PW="$(cat "$home/auth/.bootstrap_password")"
+  STUDIO_NEW_PW="CIUi-$(python -c 'import secrets; print(secrets.token_urlsafe(16))')"
+  STUDIO_NEW2_PW="CIUi-$(python -c 'import secrets; print(secrets.token_urlsafe(16))')"
+  echo "::add-mask::$STUDIO_OLD_PW"
+  echo "::add-mask::$STUDIO_NEW_PW"
+  echo "::add-mask::$STUDIO_NEW2_PW"
+  export STUDIO_OLD_PW STUDIO_NEW_PW STUDIO_NEW2_PW
+}
+
+# windows-latest is 4 vCPU / 16 GB and gemma-3-270m turn latency under
+# llama-server's CPU backend already crowded the 180s default on this image
+# before anything ran beside it. Unchanged from the steps these replace.
+export STUDIO_UI_STRICT=1
+export STUDIO_UI_TURN_TIMEOUT_MS=540000
+
+if [ "$LANE" = "chat" ]; then
+  boot "$PORT" "$server_log"
+  mint
+  mkdir -p logs/playwright
+  BASE_URL="http://127.0.0.1:$PORT" PW_ART_DIR=logs/playwright \
+    python tests/studio/playwright_chat_ui.py
+  # chat-ui ends with a Shutdown click; this is belt-and-suspenders.
+  stop
+
+  # Real Edge, which is also the WebView2 the desktop app embeds on Windows.
+  bash .github/scripts/run-studio-indicator-browser.sh 18899 chromium msedge
+else
+  boot "$PORT" "$server_log"
+  mint
+  mkdir -p logs/playwright_extra
+  BASE_URL="http://127.0.0.1:$PORT" PW_ART_DIR=logs/playwright_extra \
+    python tests/studio/playwright_extra_ui.py
+
+  # The same layout regression the Linux job runs, on the platform whose
+  # scrollbars actually take width and whose font metrics are its own: the
+  # card's floor and the action row's wrap threshold are both measurements, and
+  # a measurement taken on one platform is a guess on the others. Same server
+  # and same credentials it had as a step.
+  mkdir -p logs/playwright_update_banner
+  BASE_URL="http://127.0.0.1:$PORT" PW_ART_DIR=logs/playwright_update_banner \
+    python tests/studio/playwright_update_banner_layout.py
+  stop
+
+  bash .github/scripts/run-studio-permission-browser.sh 18895 chromium msedge
+fi
+
+echo "[lane $LANE] done"

--- a/.github/workflows/studio-windows-ui-smoke.yml
+++ b/.github/workflows/studio-windows-ui-smoke.yml
@@ -25,6 +25,7 @@ on:
       # Every server boot in this workflow shells out to that script, so an edit
       # to it changes what this workflow actually runs.
       - '.github/scripts/boot-studio-api-only.sh'
+      - '.github/scripts/run-studio-ui-lane.sh'
       # Same for the /api/health wait that runs after a boot.
       - '.github/scripts/wait-for-health.sh'
   push:
@@ -58,7 +59,11 @@ jobs:
       GGUF_REPO: unsloth/gemma-3-270m-it-GGUF
       GGUF_VARIANT: UD-Q4_K_XL
       GGUF_FILE: gemma-3-270m-it-UD-Q4_K_XL.gguf
-      STUDIO_PORT: '18896'
+      # No STUDIO_PORT here any more. One job-wide port was the right shape when
+      # one server ran at a time; the lanes each need their own, so the port now
+      # belongs beside the lane that owns it in run-studio-ui-lane.sh. Leaving a
+      # job-wide knob that nothing reads only invites a future step to set it and
+      # expect the lanes to follow.
       HF_HOME: ${{ github.workspace }}/hf-cache
       # Force UTF-8 for stdio so Python tools (hf download, Unsloth
       # CLI, etc.) can print Unicode characters like the success
@@ -337,109 +342,48 @@ jobs:
           python -m pip install 'playwright>=1.45'
           python -m playwright install chromium
 
-      - name: Reset auth + boot Unsloth
-        run: |
-          # Wipe (not reset-password): the boot below must re-seed a fresh .bootstrap_password.
-          bash .github/scripts/boot-studio-api-only.sh --port "$STUDIO_PORT"
-
-      - name: Wait for /api/health
-        run: |
-          bash .github/scripts/wait-for-health.sh --port "$STUDIO_PORT"
-
-      - name: Pass bootstrap password to the Playwright step
-        run: |
-          OLD=$(cat ~/.unsloth/studio/auth/.bootstrap_password)
-          NEW="CIUi-$(python -c 'import secrets; print(secrets.token_urlsafe(16))')"
-          NEW2="CIUi-$(python -c 'import secrets; print(secrets.token_urlsafe(16))')"
-          echo "::add-mask::$OLD"
-          echo "::add-mask::$NEW"
-          echo "::add-mask::$NEW2"
-          echo "STUDIO_OLD_PW=$OLD"   >> "$GITHUB_ENV"
-          echo "STUDIO_NEW_PW=$NEW"   >> "$GITHUB_ENV"
-          echo "STUDIO_NEW2_PW=$NEW2" >> "$GITHUB_ENV"
-
-      - name: Drive the chat UI with Playwright
+      # Two lanes, concurrently, on one runner.
+      #
+      # These five Playwright suites ran one after another for ~788s of a 20.6
+      # minute job, 88% of it in steps over 60s, and this job was the last
+      # finisher on every sampled commit where no macOS job ran. They are
+      # disjoint -- each boots its own server and drives its own browser -- and
+      # the ports were ALREADY distinct. The only thing forcing sequence was
+      # shared state: boot-studio-api-only.sh hardcoded ~/.unsloth/studio/auth
+      # and every "pass the bootstrap password" step read that same path back.
+      # Teaching the script to honour UNSLOTH_STUDIO_HOME, the way its two
+      # siblings have since #9158, is the whole enabling change.
+      #
+      # The lane bodies live in run-studio-ui-lane.sh, which documents the state
+      # split and why there are two lanes and not five. Wait on BOTH before
+      # failing: backgrounding defeats `set -e`, and without an explicit
+      # wait-and-collect one lane's breakage hides the other's.
+      - name: Drive the UI suites in two parallel lanes
         env:
-          BASE_URL: http://127.0.0.1:18896
-          PW_ART_DIR: logs/playwright
-          STUDIO_UI_STRICT: '1'
-          # windows-latest free runner is 4 vCPU / 16 GB; gemma-3-
-          # 270m turn latency under llama-server's CPU backend can
-          # crowd the 180s default (slower than ubuntu-latest on
-          # the same model). Keep the same generous budget the Mac
-          # job uses.
-          STUDIO_UI_TURN_TIMEOUT_MS: '540000'
-        run: |
-          mkdir -p logs/playwright
-          python tests/studio/playwright_chat_ui.py
-
-      - name: Stop Unsloth (chat-ui ends with Shutdown click; this is belt-and-suspenders)
-        if: always()
-        run: |
-          kill "${STUDIO_PID}" 2>/dev/null || true
-          sleep 2
-
-      - name: Edge permission controls
-        run: |
-          bash .github/scripts/run-studio-permission-browser.sh 18895 chromium msedge
-
-      # Real Edge, which is also the WebView2 the desktop app embeds on Windows.
-      - name: Loaded-models indicator (Edge)
-        run: |
-          bash .github/scripts/run-studio-indicator-browser.sh 18899 chromium msedge
-
-      - name: Reset auth + boot Unsloth for extra UI tests (port 18897)
-        run: |
-          bash .github/scripts/boot-studio-api-only.sh \
-            --port 18897 --log logs/studio_extra.log --pid-var STUDIO_EXTRA_PID
-
-      - name: Wait for /api/health on 18897
-        run: |
-          bash .github/scripts/wait-for-health.sh \
-            --port 18897 --log logs/studio_extra.log --tmp /tmp/health2.json
-
-      - name: Pass bootstrap pw for extra UI test
-        run: |
-          OLD=$(cat ~/.unsloth/studio/auth/.bootstrap_password)
-          NEW="CIUiExtra-$(python -c 'import secrets; print(secrets.token_urlsafe(16))')"
-          echo "::add-mask::$OLD"
-          echo "::add-mask::$NEW"
-          echo "STUDIO_EXTRA_OLD_PW=$OLD" >> "$GITHUB_ENV"
-          echo "STUDIO_EXTRA_NEW_PW=$NEW" >> "$GITHUB_ENV"
-
-      - name: Drive Compare/Recipes/Export/Unsloth/Settings with Playwright
-        env:
-          BASE_URL: http://127.0.0.1:18897
-          STUDIO_OLD_PW: ${{ env.STUDIO_EXTRA_OLD_PW }}
-          STUDIO_NEW_PW: ${{ env.STUDIO_EXTRA_NEW_PW }}
-          PW_ART_DIR: logs/playwright_extra
-          STUDIO_UI_STRICT: '1'
-          STUDIO_UI_TURN_TIMEOUT_MS: '540000'
           GGUF_REPO: ${{ env.GGUF_REPO }}
           GGUF_VARIANT: ${{ env.GGUF_VARIANT }}
         run: |
-          mkdir -p logs/playwright_extra
-          python tests/studio/playwright_extra_ui.py
+          mkdir -p logs
+          pids=""
+          for lane in chat extra; do
+            bash .github/scripts/run-studio-ui-lane.sh "$lane" \
+              >"logs/lane-$lane.out" 2>&1 &
+            pids="$pids $!:$lane"
+          done
+          rc=0
+          for entry in $pids; do
+            if ! wait "${entry%%:*}"; then
+              echo "::error::Windows UI lane ${entry##*:} failed"
+              rc=1
+            fi
+          done
+          for f in logs/lane-*.out; do
+            echo "::group::$f"
+            cat "$f"
+            echo "::endgroup::"
+          done
+          exit "$rc"
 
-      # The same layout regression the Linux job runs, on the platform whose
-      # scrollbars actually take width and whose font metrics are its own: the
-      # card's floor and the action row's wrap threshold are both measurements,
-      # and a measurement taken on one platform is a guess on the others.
-      - name: Update banner layout regression (Playwright)
-        env:
-          BASE_URL: http://127.0.0.1:18897
-          STUDIO_OLD_PW: ${{ env.STUDIO_EXTRA_OLD_PW }}
-          STUDIO_NEW_PW: ${{ env.STUDIO_EXTRA_NEW_PW }}
-          PW_ART_DIR: logs/playwright_update_banner
-        run: |
-          mkdir -p logs/playwright_update_banner
-          python tests/studio/playwright_update_banner_layout.py
-
-      - name: Stop second Unsloth
-        if: always()
-        run: |
-          kill "${STUDIO_EXTRA_PID}" 2>/dev/null || true
-          sleep 2
 
       - name: Upload Playwright artifacts
         if: always()
@@ -447,14 +391,17 @@ jobs:
         with:
           name: windows-studio-ui-smoke-artifacts
           path: |
-            logs/studio.log
-            logs/studio_extra.log
+            logs/studio-lane-*.log
+            logs/lane-*.out
+            logs/boot-*.out
             logs/install.log
             logs/playwright
             logs/playwright-permissions-*
+            logs/playwright-indicator-*
             logs/playwright_extra
             logs/playwright_update_banner
             logs/studio-permissions-*.log
+            logs/studio-indicator-*.log
           # 1 day, matching the repository-wide cap. A larger value here is
           # silently clamped to that cap today, so stating 7 only invites the
           # artifacts to re-inflate if the cap is ever raised.

--- a/.github/workflows/workflow-trigger-lint.yml
+++ b/.github/workflows/workflow-trigger-lint.yml
@@ -159,6 +159,7 @@ jobs:
             tests/studio/test_stt_model_search_locator_contract.py \
             tests/studio/test_uv_cache_discipline.py \
             tests/studio/test_windows_small_checks_stay_on_their_image.py \
+            tests/studio/test_windows_ui_lanes_are_isolated.py \
             tests/studio/test_workflow_guards_run_unfiltered.py \
             tests/security
 

--- a/tests/studio/test_windows_ui_lanes_are_isolated.py
+++ b/tests/studio/test_windows_ui_lanes_are_isolated.py
@@ -1,0 +1,187 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""The two Windows UI lanes must not share the state that used to serialise them.
+
+Five Playwright suites ran end to end for ~788s of a 20.6 minute job. They are
+disjoint and their ports were already distinct; what forced the sequence was shared
+auth state, because boot-studio-api-only.sh hardcoded ~/.unsloth/studio/auth and every
+"pass the bootstrap password" step read that same file back.
+
+Every failure this file guards against LOOKS LIKE SUCCESS, which is why they are worth
+pinning:
+
+  * A lane losing its own UNSLOTH_STUDIO_HOME. Both lanes then wipe and re-seed one
+    auth directory while the other is logging in with the password it just read. That
+    is a race, so it fails intermittently and on someone else's PR.
+  * Backgrounding without wait-and-collect. `&` defeats `set -e`; the step exits 0 and
+    the job goes green having run neither suite to completion.
+  * Waiting on only the first lane. The second lane's failure is then invisible, which
+    is the specific regression #9158 called out for the Linux indicator engines.
+  * A lane home with no venv link. UNSLOTH_STUDIO_HOME is the CLI's INSTALL root, so a
+    bare directory makes `unsloth studio` exit "Unsloth Studio not set up" before it
+    binds a port.
+  * A lane home with no llama.cpp path. Setting the variable makes the root custom, and
+    unsloth_cli/commands/studio.py then resolves UNSLOTH_LLAMA_CPP_PATH under it rather
+    than the legacy ~/.unsloth/llama.cpp. These lanes load a real GGUF, so the model
+    load fails rather than falling back.
+
+The assertions read the script and the workflow rather than a list written here, so a
+list cannot agree with itself while the scripts move.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+
+
+REPO = Path(__file__).resolve().parents[2]
+LANE = REPO / ".github" / "scripts" / "run-studio-ui-lane.sh"
+BOOT = REPO / ".github" / "scripts" / "boot-studio-api-only.sh"
+WORKFLOW = REPO / ".github" / "workflows" / "studio-windows-ui-smoke.yml"
+
+LANES = ("chat", "extra")
+
+
+def _strip_comments(text: str) -> str:
+    """Assertions must not be satisfied by the prose that explains them.
+
+    Every one of these scripts documents the thing being asserted in a comment
+    directly above it, so a substring check against the raw file passes even after the
+    code it describes is deleted. This has already bitten this repo once.
+    """
+    out = []
+    for line in text.split("\n"):
+        stripped = re.sub(r"(^|\s)#.*$", "", line)
+        out.append(stripped)
+    return "\n".join(out)
+
+
+def _lane_body() -> str:
+    return _strip_comments(LANE.read_text(encoding = "utf-8"))
+
+
+def _step() -> dict:
+    doc = yaml.safe_load(WORKFLOW.read_text(encoding = "utf-8")) or {}
+    for step in doc["jobs"]["ui-smoke"]["steps"]:
+        if "lane" in str(step.get("name", "")).lower():
+            return step
+    raise AssertionError(
+        "no step in ui-smoke runs the UI lanes. If they were deliberately put back in "
+        "sequence, delete this file; if the step was renamed, retarget it."
+    )
+
+
+def _step_body() -> str:
+    return _strip_comments(str(_step().get("run", "")))
+
+
+def test_the_boot_script_honours_a_per_lane_studio_home() -> None:
+    """The enabling change. Without it the lanes share one auth directory."""
+    body = _strip_comments(BOOT.read_text(encoding = "utf-8"))
+    assert "UNSLOTH_STUDIO_HOME" in body, (
+        "boot-studio-api-only.sh no longer reads UNSLOTH_STUDIO_HOME, so it is back to "
+        "wiping the one legacy auth directory. Two concurrent lanes then race: one wipes "
+        "the .bootstrap_password the other just minted and is about to log in with, and "
+        "it fails intermittently rather than every time."
+    )
+    assert not re.search(r"rm -rf\s+~?/?\.unsloth/studio/auth", body), (
+        "boot-studio-api-only.sh wipes a hardcoded auth path again; it must go through "
+        "the resolved per-lane home"
+    )
+
+
+def test_each_lane_gets_its_own_port_and_studio_home() -> None:
+    body = _lane_body()
+    ports = set(re.findall(r"PORT=(\d{4,5})", body))
+    assert len(ports) >= len(LANES), (
+        f"the lanes do not have distinct boot ports: {sorted(ports)}. Two servers on one "
+        f"port means the second never binds."
+    )
+    assert re.search(r'home=.*\$\{?LANE', body) or re.search(r'\.studio-lane-\$LANE', body), (
+        "the lane home does not vary by lane, so both lanes share one UNSLOTH_STUDIO_HOME "
+        "and the auth wipe races"
+    )
+    assert re.search(r"export\s+UNSLOTH_STUDIO_HOME=", body), (
+        "the lane never exports UNSLOTH_STUDIO_HOME, so the boot script and the two "
+        "browser scripts all fall back to the shared legacy home"
+    )
+
+
+def test_each_lane_links_the_installed_venv_and_pins_llama_cpp() -> None:
+    """A bare per-lane home is not a usable Studio root; see the module docstring."""
+    body = _lane_body()
+    assert "unsloth_studio" in body and re.search(r"mklink|ln -sfn", body), (
+        "the lane home does not link the installed venv. UNSLOTH_STUDIO_HOME is the "
+        "CLI's install root, so `unsloth studio` exits 'Unsloth Studio not set up' "
+        "before binding a port."
+    )
+    assert re.search(r"export\s+UNSLOTH_LLAMA_CPP_PATH=", body), (
+        "the lane does not pin UNSLOTH_LLAMA_CPP_PATH. A custom UNSLOTH_STUDIO_HOME "
+        "makes the CLI resolve llama.cpp UNDER that home instead of ~/.unsloth/llama.cpp "
+        "(unsloth_cli/commands/studio.py), and these lanes load a real GGUF."
+    )
+
+
+def test_the_lane_boot_does_not_write_the_shared_github_env() -> None:
+    """Concurrent lanes appending one file is the shared state this change removes."""
+    body = _lane_body()
+    assert "env -u GITHUB_ENV" in body, (
+        "the lane boots without unsetting GITHUB_ENV. boot-studio-api-only.sh appends "
+        "the pid there whenever it is set, and inside a step it always is, so both lanes "
+        "would append to the one file the runner reads back -- a lost pid and exactly the "
+        "kind of shared mutable state the lanes exist to avoid."
+    )
+
+
+def test_the_step_runs_the_lanes_concurrently() -> None:
+    body = _step_body()
+    assert re.search(r"run-studio-ui-lane\.sh.*&\s*$", body, re.M) or re.search(
+        r"run-studio-ui-lane\.sh[^\n]*\n[^\n]*&\s*$", body, re.M
+    ), (
+        "the lanes are not backgrounded, so they run one after another and the change "
+        "buys nothing"
+    )
+
+
+def test_the_step_waits_on_every_lane_and_propagates_failure() -> None:
+    """`&` defeats set -e: without this the step exits 0 having run nothing."""
+    body = _step_body()
+    assert "wait " in body, "the step never waits on the lanes, so it cannot see them fail"
+    assert re.search(r"rc=1", body) and re.search(r'exit\s+"?\$\{?rc', body), (
+        "the step does not collect a failing lane into its own exit status. Backgrounded "
+        "work does not trip `set -e`, so the job would go green with a failed lane."
+    )
+    waits = len(re.findall(r"\bwait\b", body))
+    loops = len(re.findall(r"\bfor\s+\w+\s+in\s+\$pids", body))
+    assert loops >= 1 or waits >= len(LANES), (
+        "the step waits on fewer lanes than it starts, so one lane's breakage hides "
+        "another's -- the regression #9158 called out for the Linux indicator engines"
+    )
+
+
+def test_every_suite_that_used_to_be_a_step_still_runs() -> None:
+    """The silent failure: a lane that quietly drops a suite still goes green."""
+    body = _lane_body()
+    for suite in (
+        "tests/studio/playwright_chat_ui.py",
+        "tests/studio/playwright_extra_ui.py",
+        "tests/studio/playwright_update_banner_layout.py",
+        "run-studio-indicator-browser.sh",
+        "run-studio-permission-browser.sh",
+    ):
+        assert suite in body, (
+            f"{suite} ran as a step before the lanes and is not run by any lane now. "
+            f"Nothing else in CI covers it, so dropping it turns nothing red."
+        )
+
+
+def test_the_guard_is_reading_real_files() -> None:
+    """Every assertion above passes vacuously if these stop being found."""
+    for path in (LANE, BOOT, WORKFLOW):
+        assert path.is_file(), path
+    assert len(_lane_body()) > 500, "lane script body looks empty after comment stripping"
+    assert len(_step_body()) > 100, "workflow step body looks empty after comment stripping"

--- a/tests/studio/test_windows_ui_lanes_are_isolated.py
+++ b/tests/studio/test_windows_ui_lanes_are_isolated.py
@@ -101,7 +101,7 @@ def test_each_lane_gets_its_own_port_and_studio_home() -> None:
         f"the lanes do not have distinct boot ports: {sorted(ports)}. Two servers on one "
         f"port means the second never binds."
     )
-    assert re.search(r'home=.*\$\{?LANE', body) or re.search(r'\.studio-lane-\$LANE', body), (
+    assert re.search(r"home=.*\$\{?LANE", body) or re.search(r"\.studio-lane-\$LANE", body), (
         "the lane home does not vary by lane, so both lanes share one UNSLOTH_STUDIO_HOME "
         "and the auth wipe races"
     )


### PR DESCRIPTION
`Windows Unsloth UI CI :: Chat UI Tests` is the last finisher on every sampled commit where no macOS job runs. Measured on `2043c734c`: 36 jobs, 20.7 minute wall, and this job alone was 20.6 minutes of execution with 88% of it in steps over 60 seconds.

Five of those steps are Playwright suites that ran one after another for about 788 seconds:

```
287s Loaded-models indicator (Edge)      167s Update banner
144s Compare/Recipes/Export/Settings     102s Edge permission        88s chat UI
```

They are disjoint. Each boots its own Studio and drives its own browser, and the ports were **already** distinct (18895/18896/18897/18899). The only thing forcing the sequence was shared state, which is the same finding #9158 made for the three Linux indicator engines.

## The enabling change

`.github/scripts/boot-studio-api-only.sh` hardcoded `rm -rf ~/.unsloth/studio/auth`. Its two siblings, `run-studio-permission-browser.sh` and `run-studio-indicator-browser.sh`, have read `${UNSLOTH_STUDIO_HOME:-$HOME/.unsloth/studio}` since #9158; this one was the odd one out. Every "pass the bootstrap password" step then read that same legacy path back. Two concurrent lanes on one home race destructively: one wipes the `.bootstrap_password` the other just minted and is about to log in with.

With the variable honoured, the lane bodies move into `run-studio-ui-lane.sh` and run two at a time:

```
chat  : chat UI (18896)  -> loaded-models indicator, Edge (18899)     375s
extra : Compare/Recipes/Export/Settings + update banner (18897)
        -> Edge permission controls (18895)                           413s
```

Expected lane wall about 413s against 788s, so roughly 375s off a 20.6 minute job. Within a lane the order and the environment of every suite is unchanged, including `extra` reusing one server for both of its Playwright runs and passing it the same credentials it had as a step.

Two lanes rather than five is deliberate. windows-latest is 4 vCPU / 16 GB and these lanes load a real GGUF through llama-server, whose turn latency already needed a 540s budget on this image before anything ran beside it. Five concurrent servers would contend for the same four cores and turn a timing-sensitive suite into a flaky one. The floor with the 287s indicator suite in it is 287s, so a third lane buys about 126s for a third model-loading server.

## What each lane owns

Port, `UNSLOTH_STUDIO_HOME`, health-probe temp file, and log/artifact paths. Two further points are specific to this job and are not in the Linux precedent:

- `UNSLOTH_STUDIO_HOME` is the CLI's **install** root, not a data root. A bare per-lane directory makes `unsloth studio` exit "Unsloth Studio not set up" before it binds a port, so each lane links the one venv `install.ps1` already built. It is a directory junction rather than `ln -s`, because under MSYS `ln -s` copies unless `winsymlinks:nativestrict` and a native symlink needs Developer Mode; a per-lane copy of the venv would cost more than the parallelism saves.
- Setting the variable makes the root **custom**, and `unsloth_cli/commands/studio.py` then resolves `UNSLOTH_LLAMA_CPP_PATH` under that home instead of `~/.unsloth/llama.cpp`. These lanes load a real model, so it is pinned explicitly.

`env -u GITHUB_ENV` on the boot call is load-bearing: the boot script appends the pid to `$GITHUB_ENV` whenever it is set, and inside a step it always is, so both lanes would append to the one file the runner reads back.

## Guard

`tests/studio/test_windows_ui_lanes_are_isolated.py`, 8 tests, added to the unfiltered `workflow-trigger-lint` list so a workflow-only PR still collects it. Every failure it covers looks like success: a shared home races intermittently, a lost `&` silently serialises, a missing wait-and-collect exits 0 with a failed lane, and a dropped suite turns nothing red.

Mutation-tested by reintroducing each bug, 11/11 caught by the intended test, including reverting the boot script to the hardcoded path and the case where the code is deleted but the words survive in the comment above it.

`pytest tests/studio/ -q -n 4` is 4590 passed / 4 skipped, and `scripts/lint_workflow_triggers.py` is clean.

## Check names

No check name changes. This is one job's internal restructuring; `Chat UI Tests` keeps its name.