### PR TITLE
Studio: take the model name back off the chat rows

### DIFF
--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -168,7 +168,6 @@ import {
   CONVERSATION_MARKDOWN_LABEL,
   type ProjectRecord,
   type SidebarItem,
-  compareModelDisplayName,
 } from "@/features/chat";
 import { sandboxSessionIdFor } from "@/components/assistant-ui/sandbox-files";
 import {
@@ -2522,17 +2521,6 @@ export function AppSidebar() {
               <span className="truncate">
                 {pendingRename?.id === item.id ? pendingRename.title : item.title}
               </span>
-              {/* The model the chat was started on. Only in the quiet states: the
-                  spinner takes the same right-hand slot, and the unread dot sits
-                  over it. The title truncates first, so this never squeezes it out. */}
-              {item.modelId && !showWorkSpinner && !hasUnreadActivity && (
-                <span
-                  className="ml-auto max-w-[45%] shrink-0 truncate text-ui-10 text-muted-foreground/70"
-                  title={item.modelId}
-                >
-                  {compareModelDisplayName(item.modelId)}
-                </span>
-              )}
               {showWorkSpinner && (
                 <Spinner
                   data-testid="chat-row-spinner"

--- a/studio/frontend/src/features/chat/hooks/use-chat-sidebar-items.ts
+++ b/studio/frontend/src/features/chat/hooks/use-chat-sidebar-items.ts
@@ -36,8 +36,6 @@ export interface SidebarItem {
   updatedAt: number;
   isFork?: boolean;
   projectId?: string | null;
-  /** The model this chat was started on. Single rows only: a compare row runs two. */
-  modelId?: string;
 }
 
 function lastActivityAt(thread: ThreadRecord): number {
@@ -89,8 +87,6 @@ export function groupThreads(
         updatedAt: lastActivityAt(t),
         isFork: Boolean(t.forkedFromThreadId),
         projectId: t.projectId ?? null,
-        // Stamped at creation. Blank on a legacy row, which reads as unknown.
-        modelId: t.modelId || undefined,
       });
     }
   }

--- a/studio/frontend/tests/chat-remembers-its-model.test.ts
+++ b/studio/frontend/tests/chat-remembers-its-model.test.ts
@@ -3,9 +3,9 @@
 
 // Every thread row has carried modelId since long before this notice, so the model a chat
 // was started on is already known for chats that already exist. What was missing was
-// showing it and offering it back. The rules below are the ones that keep the offer from
-// becoming a nuisance: it never loads anything on its own, and it stays quiet whenever it
-// could not be honoured.
+// offering it back. The rules below are the ones that keep the offer from becoming a
+// nuisance: it never loads anything on its own, and it stays quiet whenever it could not
+// be honoured.
 
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
@@ -20,8 +20,6 @@ function read(path: string): string {
 
 const notice = read("../src/features/chat/components/chat-model-notice.tsx");
 const page = read("../src/features/chat/chat-page.tsx");
-const sidebar = read("../src/components/app-sidebar.tsx");
-const items = read("../src/features/chat/hooks/use-chat-sidebar-items.ts");
 const thread = read("../src/components/assistant-ui/thread.tsx");
 const researchPanel = read(
   "../src/features/chat/components/research-activity-panel.tsx",
@@ -36,26 +34,8 @@ function slice(source: string, from: string, to: string): string {
   return source.slice(start, end);
 }
 
-// Source assertions: use-chat-sidebar-items reaches chat-api, and the label helper reaches
-// external-providers, neither of which resolves in a bare node test. The sibling
-// thread-scoped suites do the same for the same reason.
-
-test("a single chat row carries the model it was started on", () => {
-  const single = slice(items, 'type: "single",', "});");
-  assert.match(single, /modelId: t\.modelId \|\| undefined,/);
-});
-
-test("a legacy row with no model reads as unknown rather than empty string", () => {
-  // db.ts backfills "" onto old records, and "" would render an empty label.
-  assert.match(items, /modelId: t\.modelId \|\| undefined,/);
-  assert.doesNotMatch(items, /modelId: t\.modelId,/);
-});
-
-test("a compare row carries no single model", () => {
-  // Two panes, two models: there is no honest one to show, so the field is absent.
-  const compare = slice(items, 'type: "compare",', "};");
-  assert.doesNotMatch(compare, /modelId/);
-});
+// Source assertions: the notice reaches external-providers, which does not resolve in a
+// bare node test. The sibling thread-scoped suites do the same for the same reason.
 
 test("the notice never switches a model on its own", () => {
   // Opening a chat must not evict what is resident: a local load is multi-gigabyte.
@@ -252,20 +232,6 @@ test("the canvas panel reserves the notice's height too", () => {
     /--studio-chat-notice-height,\s*2\.25rem/,
     "the panel must not assume a notice is present",
   );
-});
-
-test("the sidebar label cannot collide with the spinner or the unread dot", () => {
-  // Both take the same right-hand slot, and the dot is positioned over it.
-  assert.match(
-    sidebar,
-    /\{item\.modelId && !showWorkSpinner && !hasUnreadActivity && \(/,
-  );
-  // The title truncates first, so a long model name never squeezes it out.
-  const label = sidebar.slice(
-    sidebar.indexOf("{item.modelId && !showWorkSpinner"),
-  );
-  assert.match(label.slice(0, 400), /max-w-\[45%\]/);
-  assert.match(label.slice(0, 400), /compareModelDisplayName\(item\.modelId\)/);
 });
 
 test("a chat started as New Chat gets the notice once its row exists", () => {


### PR DESCRIPTION
#9081 put the model a chat was started on at the right-hand end of every sidebar
row. In practice it is the wrong trade. The label takes up to 45% of the row, and
the Recents list is mostly the same model repeated down the whole column, so it
spends a lot of width saying the same thing over and over while squeezing the one
part of the row that differs between chats: the title.

## What comes out

Just the sidebar label. The in-chat notice from #9081 is untouched, so opening a
chat started on another model still offers that model back. That was the useful
half, and it only speaks up when it has something to say.

`SidebarItem.modelId` goes with it. #9081 added that field for this label alone,
and `ChatModelNotice` reads its own value through `useChatCreatedModel(threadId)`
rather than through the sidebar item, so nothing else was consuming it.

Four tests come out with it. All four pinned the label or the plumbing feeding it:

| test | pinned |
|---|---|
| a single chat row carries the model it was started on | the field |
| a legacy row with no model reads as unknown rather than empty string | the field |
| a compare row carries no single model | the field |
| the sidebar label cannot collide with the spinner or the unread dot | the label |

The suite's header comment claimed the change was about "showing it and offering
it back", so it now says offering it back.

## Layout after

The row is title plus, when it applies, the spinner or the unread dot. Both
already carried their own `ml-auto`, so removing the label changes nothing about
where they sit. Rows never had the label when a chat was working or unread, which
is exactly the state the old code excluded.

## Verified

- `npm run typecheck` clean.
- 4083 frontend tests pass, 0 fail, including the rest of
  `chat-remembers-its-model`.
- Biome on both touched files is byte-identical to the pre-change baseline.
- 9 failures in `test_sandbox_files_and_storage_roots.py` reproduce on clean main
  and are unrelated to this change.
