### PR TITLE
Studio: scope the sidebar drag's custom-property writes off the thread's ancestors

### DIFF
--- a/studio/frontend/src/components/tauri/window-titlebar.tsx
+++ b/studio/frontend/src/components/tauri/window-titlebar.tsx
@@ -350,12 +350,10 @@ export function WindowTitlebar({
       {showSidebarSurface && (
         <div
           data-slot="window-titlebar-decoration"
-          // Marks a consumer of --studio-sidebar-live-width. Only this
-          // fragment and the titlebar element below read it, so
-          // PANEL_RESIZE_SCOPED_VARS_ENABLED writes the live width here rather
-          // than on the document element, where an unregistered custom
-          // property invalidates inherited style for the whole document once
-          // per animation frame of a sidebar drag.
+          // Marks a consumer of --studio-sidebar-live-width. Only this and the
+          // header below read it, so PANEL_RESIZE_SCOPED_VARS_ENABLED writes
+          // the live width here instead of on the document element, where it
+          // would restyle the whole document once per drag frame.
           data-titlebar-live-width-scope=""
           aria-hidden="true"
           className="pointer-events-none absolute inset-x-0 top-[var(--studio-custom-titlebar-height)] z-[45] h-3"

--- a/studio/frontend/src/components/tauri/window-titlebar.tsx
+++ b/studio/frontend/src/components/tauri/window-titlebar.tsx
@@ -350,6 +350,13 @@ export function WindowTitlebar({
       {showSidebarSurface && (
         <div
           data-slot="window-titlebar-decoration"
+          // Marks a consumer of --studio-sidebar-live-width. Only this
+          // fragment and the titlebar element below read it, so
+          // PANEL_RESIZE_SCOPED_VARS_ENABLED writes the live width here rather
+          // than on the document element, where an unregistered custom
+          // property invalidates inherited style for the whole document once
+          // per animation frame of a sidebar drag.
+          data-titlebar-live-width-scope=""
           aria-hidden="true"
           className="pointer-events-none absolute inset-x-0 top-[var(--studio-custom-titlebar-height)] z-[45] h-3"
         >
@@ -376,6 +383,7 @@ export function WindowTitlebar({
           "pointer-events-none absolute inset-x-0 top-0 z-[70] h-[var(--studio-custom-titlebar-height)] select-none text-foreground",
           showSidebarSurface && "bg-sidebar text-sidebar-foreground",
         )}
+        data-titlebar-live-width-scope=""
         aria-label="Window titlebar"
       >
         {showSidebarSurface && (

--- a/studio/frontend/src/components/ui/panel-resize-handle.tsx
+++ b/studio/frontend/src/components/ui/panel-resize-handle.tsx
@@ -58,16 +58,15 @@ export type PanelResizeHandleProps = {
   /** Mirrors the live width onto :root for chrome outside the panel. */
   rootVar?: string
   /**
-   * Narrower element to paint `cssVar` onto, used instead of `target()` when
-   * PANEL_RESIZE_SCOPED_VARS_ENABLED is on. Must contain every consumer of
-   * `cssVar` and nothing else, because an unregistered custom property
-   * invalidates inherited style for the whole subtree below wherever it lands.
+   * Narrower element for `cssVar`, replacing `target()` under
+   * PANEL_RESIZE_SCOPED_VARS_ENABLED. Must hold every consumer and nothing
+   * else: the write invalidates inherited style for everything below it.
    */
   scopedTarget?: () => HTMLElement | null
   /**
-   * The elements that actually read `rootVar`, used instead of
-   * `document.documentElement` when PANEL_RESIZE_SCOPED_VARS_ENABLED is on.
-   * An empty list means nothing consumes it and the write is skipped.
+   * The elements that actually read `rootVar`, replacing
+   * `document.documentElement` under PANEL_RESIZE_SCOPED_VARS_ENABLED. Empty
+   * means no consumer, so the write is skipped.
    */
   rootVarTargets?: () => HTMLElement[]
 }
@@ -128,8 +127,8 @@ export function PanelResizeHandle({
     committedRef.current = width
   }, [width])
 
-  // Where `rootVar` is painted, resolved once on pointer down. With the flag
-  // off this is always [document.documentElement], which is what shipped.
+  // Where `rootVar` is painted, resolved once on pointer down. Always
+  // [document.documentElement] with the flag off, which is what shipped.
   const rootTargetsRef = React.useRef<HTMLElement[]>([])
 
   const paint = React.useCallback(
@@ -186,8 +185,8 @@ export function PanelResizeHandle({
     if (event.button !== 0) return
     event.preventDefault()
     event.currentTarget.setPointerCapture(event.pointerId)
-    // Resolved once per drag, never per frame: the write itself is what costs,
-    // and a DOM walk here is already how `target()` worked.
+    // Resolved once per drag, never per frame: the write is what costs, and a
+    // DOM walk here is already how `target()` worked.
     targetRef.current =
       (PANEL_RESIZE_SCOPED_VARS_ENABLED && scopedTarget?.()) || target()
     rootTargetsRef.current = !rootVar

--- a/studio/frontend/src/components/ui/panel-resize-handle.tsx
+++ b/studio/frontend/src/components/ui/panel-resize-handle.tsx
@@ -12,6 +12,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip"
 import { getClientPlatform } from "@/components/tauri/window-titlebar"
+import { PANEL_RESIZE_SCOPED_VARS_ENABLED } from "@/components/ui/panel-resize-recalc-flags"
 
 /** Pointer travel (px) below which a drag counts as a plain click. */
 const DRAG_SLOP = 4
@@ -56,6 +57,19 @@ export type PanelResizeHandleProps = {
   className?: string
   /** Mirrors the live width onto :root for chrome outside the panel. */
   rootVar?: string
+  /**
+   * Narrower element to paint `cssVar` onto, used instead of `target()` when
+   * PANEL_RESIZE_SCOPED_VARS_ENABLED is on. Must contain every consumer of
+   * `cssVar` and nothing else, because an unregistered custom property
+   * invalidates inherited style for the whole subtree below wherever it lands.
+   */
+  scopedTarget?: () => HTMLElement | null
+  /**
+   * The elements that actually read `rootVar`, used instead of
+   * `document.documentElement` when PANEL_RESIZE_SCOPED_VARS_ENABLED is on.
+   * An empty list means nothing consumes it and the write is skipped.
+   */
+  rootVarTargets?: () => HTMLElement[]
 }
 
 /**
@@ -86,6 +100,8 @@ export function PanelResizeHandle({
   dataSlot = "panel-resize-handle",
   className,
   rootVar,
+  scopedTarget,
+  rootVarTargets,
 }: PanelResizeHandleProps) {
   const ref = React.useRef<HTMLButtonElement>(null)
   const dragRef = React.useRef<DragState | null>(null)
@@ -112,11 +128,17 @@ export function PanelResizeHandle({
     committedRef.current = width
   }, [width])
 
+  // Where `rootVar` is painted, resolved once on pointer down. With the flag
+  // off this is always [document.documentElement], which is what shipped.
+  const rootTargetsRef = React.useRef<HTMLElement[]>([])
+
   const paint = React.useCallback(
     (value: string) => {
       targetRef.current?.style.setProperty(cssVar, value)
       if (rootVar) {
-        document.documentElement.style.setProperty(rootVar, value)
+        for (const el of rootTargetsRef.current) {
+          el.style.setProperty(rootVar, value)
+        }
       }
     },
     [cssVar, rootVar],
@@ -148,7 +170,10 @@ export function PanelResizeHandle({
     // Hand the property back to the committed value. A commit re-renders with
     // the new width; a cancel or a no-commit drag keeps DOM and store in step.
     paint(`${committedRef.current}px`)
-    if (rootVar) document.documentElement.style.removeProperty(rootVar)
+    if (rootVar) {
+      for (const el of rootTargetsRef.current) el.style.removeProperty(rootVar)
+    }
+    rootTargetsRef.current = []
     targetRef.current?.removeAttribute("data-resizing")
     document.documentElement.removeAttribute("data-panel-resizing")
     targetRef.current = null
@@ -161,7 +186,15 @@ export function PanelResizeHandle({
     if (event.button !== 0) return
     event.preventDefault()
     event.currentTarget.setPointerCapture(event.pointerId)
-    targetRef.current = target()
+    // Resolved once per drag, never per frame: the write itself is what costs,
+    // and a DOM walk here is already how `target()` worked.
+    targetRef.current =
+      (PANEL_RESIZE_SCOPED_VARS_ENABLED && scopedTarget?.()) || target()
+    rootTargetsRef.current = !rootVar
+      ? []
+      : PANEL_RESIZE_SCOPED_VARS_ENABLED
+        ? (rootVarTargets?.() ?? [])
+        : [document.documentElement]
     // Collapsed: grow from the rendered size so the edge tracks the pointer.
     const start = open ? width : measure()
     dragRef.current = { startX: event.clientX, startWidth: start, moved: false }

--- a/studio/frontend/src/components/ui/panel-resize-recalc-flags.ts
+++ b/studio/frontend/src/components/ui/panel-resize-recalc-flags.ts
@@ -1,80 +1,50 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-// Panel-resize style-recalc flags, for staged rollout. Wiring stays in place so
-// flipping a flag here is the only edit needed.
+// Panel-resize style-recalc flags, for staged rollout. The wiring stays in
+// place, so flipping a flag here is the only edit needed.
 //
-// WHY THIS EXISTS
+// WHY. An unregistered CSS custom property inherits, so writing one marks
+// inherited style dirty for every descendant. `PanelResizeHandle` writes two of
+// them on every animation frame of a sidebar drag -- `--sidebar-width` on
+// `[data-slot="sidebar-wrapper"]` and `--studio-sidebar-live-width` on
+// `document.documentElement` -- and both are ancestors of the chat thread, so
+// each one restyles the whole document.
 //
-// An UNREGISTERED CSS custom property inherits. Writing one on an element marks
-// inherited style dirty for every descendant of that element, so a write on
-// `<html>` restyles the whole document and a write on the sidebar wrapper
-// restyles everything the wrapper contains -- which, on the chat route, is the
-// thread and all of its Shiki token spans.
-//
-// `PanelResizeHandle` writes TWO such properties on every animation frame of a
-// sidebar drag: `--sidebar-width` on `[data-slot="sidebar-wrapper"]`, and
-// `--studio-sidebar-live-width` on `document.documentElement`. Both are
-// ancestors of the thread. Measured on the heavy-thread harness (Chromium,
-// `UpdateLayoutTree.elementCount` from a devtools trace, median of 10 writes):
-//
-//   thread          elements   --sidebar-width on wrapper   scoped (this flag)
-//   27,873 chars       4,000    4,286 restyled /  67.9 ms    1 restyled / 0.02 ms
-//   84,407 chars      11,805   12,693 restyled / 193.2 ms    1 restyled / 0.02 ms
-//  140,987 chars      19,576   21,065 restyled / 335.0 ms    1 restyled / 0.02 ms
-//  253,791 chars      35,119   37,811 restyled / 576.6 ms    1 restyled / 0.02 ms
-//
-// The unscoped write is linear in thread size (8.54x over an 8.78x growth in
-// elements); the scoped write is flat. Two of them per frame at 60fps is not a
-// slow drag, it is a stalled one.
-//
-// Those numbers come off the vite DEV server. Repeating the decisive pair with
-// the built production stylesheet swapped in over the same DOM costs 49.1 ms
-// rather than 133.3 ms for the same 12,026 elements, so read the milliseconds
-// above as roughly 2.7x high. The mechanism is not a dev artefact: the ratio
-// between an unregistered write and an `inherits: false` one is 1333x on dev
-// and 982x on prod, and `elementCount` is a property of the DOM and identical
-// on both.
-//
+// Measured on the heavy-thread harness (Chromium, `UpdateLayoutTree.elementCount`
+// from a devtools trace, median of 10 writes): the unscoped write is linear in
+// thread size, 4,286 elements / 67.9 ms at a 4,000-element thread up to 37,811 /
+// 576.6 ms at 35,119, while the scoped write is flat at 1 element / 0.02 ms.
 // End to end, driving the real handle through a real pointer drag over a
-// 12,026-element document (8 drag frames):
+// 12,026-element document (8 frames), 12,022 elements restyled per frame and
+// 1,088.25 ms total become 12 per frame and 3.76 ms, with identical rendered
+// geometry at all 8 positions and --sidebar-width resolving the same at every
+// consumer.
 //
-//   flag off   12,022 elements restyled per frame, 1,088.25 ms total
-//   flag on        12 elements restyled per frame,     3.76 ms total
+// Read those milliseconds as roughly 2.7x high: they come off the vite DEV
+// server, and the built production stylesheet costs 49.1 ms against 133.3 ms
+// over the same DOM. The mechanism is not a dev artefact -- unregistered
+// against `inherits: false` is 1333x on dev and 982x on prod, and elementCount
+// is a DOM property, identical on both.
 //
-// 12,022 of 12,026 is 99.97% of the document restyled to move one panel edge.
-// Rendered geometry is identical at all 8 drag positions in both states, and
-// --sidebar-width resolves to the same value at every consumer.
+// WHY NOT `@property { inherits: false }`. That is right only for a property
+// whose sole consumer is the element written to (`--aui-scroll-stabilizer`).
+// Here it would silently break both: `--sidebar-width` is read by
+// `[data-slot="sidebar"]`, `sidebar-gap` and `sidebar-container`, and
+// `--studio-sidebar-live-width` by `window-titlebar.tsx`, all descendants of
+// the element written to, so they would resolve the initial value instead.
+// Registration is not the mechanism, INHERITANCE is: the same probe registered
+// `inherits: true` restyled all 37,817 elements in 576 ms, `inherits: false`
+// restyled 1 in 0.08 ms. So the fix moves each write DOWN into a subtree that
+// consumes it -- `--sidebar-width` to `[data-slot="sidebar"]`, which holds
+// every consumer and not the thread, and `--studio-sidebar-live-width` to the
+// titlebar roots, which do not exist on a build without a custom titlebar,
+// where the write is skipped entirely.
 //
-// WHY NOT `@property { inherits: false }`
-//
-// That is the right fix for a property whose only consumer is the element it is
-// written to, which is why it works for `--aui-scroll-stabilizer`. It is the
-// WRONG fix for both of these, and would silently break them:
-//
-//   * `--sidebar-width` is read by `[data-slot="sidebar"]`, `sidebar-gap` and
-//     `sidebar-container` -- descendants. With `inherits: false` they would all
-//     resolve it to the initial value and the sidebar would lose its width.
-//   * `--studio-sidebar-live-width` is read by `window-titlebar.tsx`, also a
-//     descendant of the `<html>` it is written on.
-//
-// Registration is not the mechanism. INHERITANCE is: a probe registered with
-// `inherits: true` restyled all 37,817 elements in 576 ms, exactly like the
-// unregistered one, while the same probe registered `inherits: false` restyled
-// 1 element in 0.08 ms. So the fix here is to move each write DOWN to a subtree
-// that actually consumes it, which is what this flag does:
-//
-//   * `--sidebar-width` -> `[data-slot="sidebar"]`, which contains every
-//     consumer and does not contain the thread.
-//   * `--studio-sidebar-live-width` -> the titlebar roots themselves. When no
-//     custom titlebar is mounted (every non-Tauri build) there is no consumer
-//     at all and the write is skipped entirely.
-//
-// NOT ADDRESSED BY THIS FLAG, and measured so the next person does not have to:
-// `html[data-panel-resizing] *` (index.css:1604-1605) is a universal descendant selector
-// on `<html>`, and toggling that attribute restyles the whole document too --
-// 37,818 elements / 575.0 ms at 253,791 chars, indistinguishable from the
-// custom-property write. It fires twice per drag rather than once per frame, so
-// it is a smaller total, and it is load-bearing for cursor correctness. It is a
-// separate change with its own visual risk, deliberately not bundled here.
+// NOT ADDRESSED BY THIS FLAG, measured so the next person need not:
+// `html[data-panel-resizing] *` (index.css:1604-1605) is a universal descendant
+// selector on `<html>` and restyles the whole document too, 37,818 elements /
+// 575.0 ms. It fires twice per drag rather than once per frame, so the total is
+// smaller, and it is load-bearing for cursor correctness: a separate change
+// with its own visual risk, deliberately not bundled here.
 export const PANEL_RESIZE_SCOPED_VARS_ENABLED = false;

--- a/studio/frontend/src/components/ui/panel-resize-recalc-flags.ts
+++ b/studio/frontend/src/components/ui/panel-resize-recalc-flags.ts
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// Panel-resize style-recalc flags, for staged rollout. Wiring stays in place so
+// flipping a flag here is the only edit needed.
+//
+// WHY THIS EXISTS
+//
+// An UNREGISTERED CSS custom property inherits. Writing one on an element marks
+// inherited style dirty for every descendant of that element, so a write on
+// `<html>` restyles the whole document and a write on the sidebar wrapper
+// restyles everything the wrapper contains -- which, on the chat route, is the
+// thread and all of its Shiki token spans.
+//
+// `PanelResizeHandle` writes TWO such properties on every animation frame of a
+// sidebar drag: `--sidebar-width` on `[data-slot="sidebar-wrapper"]`, and
+// `--studio-sidebar-live-width` on `document.documentElement`. Both are
+// ancestors of the thread. Measured on the heavy-thread harness (Chromium,
+// `UpdateLayoutTree.elementCount` from a devtools trace, median of 10 writes):
+//
+//   thread          elements   --sidebar-width on wrapper   scoped (this flag)
+//   27,873 chars       4,000    4,286 restyled /  67.9 ms    1 restyled / 0.02 ms
+//   84,407 chars      11,805   12,693 restyled / 193.2 ms    1 restyled / 0.02 ms
+//  140,987 chars      19,576   21,065 restyled / 335.0 ms    1 restyled / 0.02 ms
+//  253,791 chars      35,119   37,811 restyled / 576.6 ms    1 restyled / 0.02 ms
+//
+// The unscoped write is linear in thread size (8.54x over an 8.78x growth in
+// elements); the scoped write is flat. Two of them per frame at 60fps is not a
+// slow drag, it is a stalled one.
+//
+// Those numbers come off the vite DEV server. Repeating the decisive pair with
+// the built production stylesheet swapped in over the same DOM costs 49.1 ms
+// rather than 133.3 ms for the same 12,026 elements, so read the milliseconds
+// above as roughly 2.7x high. The mechanism is not a dev artefact: the ratio
+// between an unregistered write and an `inherits: false` one is 1333x on dev
+// and 982x on prod, and `elementCount` is a property of the DOM and identical
+// on both.
+//
+// End to end, driving the real handle through a real pointer drag over a
+// 12,026-element document (8 drag frames):
+//
+//   flag off   12,022 elements restyled per frame, 1,088.25 ms total
+//   flag on        12 elements restyled per frame,     3.76 ms total
+//
+// 12,022 of 12,026 is 99.97% of the document restyled to move one panel edge.
+// Rendered geometry is identical at all 8 drag positions in both states, and
+// --sidebar-width resolves to the same value at every consumer.
+//
+// WHY NOT `@property { inherits: false }`
+//
+// That is the right fix for a property whose only consumer is the element it is
+// written to, which is why it works for `--aui-scroll-stabilizer`. It is the
+// WRONG fix for both of these, and would silently break them:
+//
+//   * `--sidebar-width` is read by `[data-slot="sidebar"]`, `sidebar-gap` and
+//     `sidebar-container` -- descendants. With `inherits: false` they would all
+//     resolve it to the initial value and the sidebar would lose its width.
+//   * `--studio-sidebar-live-width` is read by `window-titlebar.tsx`, also a
+//     descendant of the `<html>` it is written on.
+//
+// Registration is not the mechanism. INHERITANCE is: a probe registered with
+// `inherits: true` restyled all 37,817 elements in 576 ms, exactly like the
+// unregistered one, while the same probe registered `inherits: false` restyled
+// 1 element in 0.08 ms. So the fix here is to move each write DOWN to a subtree
+// that actually consumes it, which is what this flag does:
+//
+//   * `--sidebar-width` -> `[data-slot="sidebar"]`, which contains every
+//     consumer and does not contain the thread.
+//   * `--studio-sidebar-live-width` -> the titlebar roots themselves. When no
+//     custom titlebar is mounted (every non-Tauri build) there is no consumer
+//     at all and the write is skipped entirely.
+//
+// NOT ADDRESSED BY THIS FLAG, and measured so the next person does not have to:
+// `html[data-panel-resizing] *` (index.css:1604-1605) is a universal descendant selector
+// on `<html>`, and toggling that attribute restyles the whole document too --
+// 37,818 elements / 575.0 ms at 253,791 chars, indistinguishable from the
+// custom-property write. It fires twice per drag rather than once per frame, so
+// it is a smaller total, and it is load-bearing for cursor correctness. It is a
+// separate change with its own visual risk, deliberately not bundled here.
+export const PANEL_RESIZE_SCOPED_VARS_ENABLED = false;

--- a/studio/frontend/src/components/ui/sidebar.tsx
+++ b/studio/frontend/src/components/ui/sidebar.tsx
@@ -28,6 +28,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip"
 import { PanelResizeHandle } from "@/components/ui/panel-resize-handle"
+import { PANEL_RESIZE_SCOPED_VARS_ENABLED } from "@/components/ui/panel-resize-recalc-flags"
 import { useT } from "@/i18n"
 import { useIsMobile } from "@/hooks/use-mobile"
 import {
@@ -189,7 +190,17 @@ function SidebarProvider({
         style={
           {
             // The drag handle writes this same property live while resizing.
-            "--sidebar-width": `${width}px`,
+            //
+            // With PANEL_RESIZE_SCOPED_VARS_ENABLED the declaration moves DOWN
+            // to [data-slot="sidebar"], which holds every consumer. It cannot
+            // stay here as well: this wrapper is an ancestor of the chat
+            // thread, so a write here marks inherited style dirty for every
+            // element in the thread, and leaving a second declaration behind
+            // would keep the render-time write on the expensive element even
+            // though the drag-time write had moved.
+            ...(PANEL_RESIZE_SCOPED_VARS_ENABLED
+              ? null
+              : { "--sidebar-width": `${width}px` }),
             "--sidebar-width-icon": SIDEBAR_WIDTH_ICON,
             ...style,
           } as React.CSSProperties
@@ -221,12 +232,22 @@ function Sidebar({
   collapsible?: "offcanvas" | "icon" | "none"
   collapseToZero?: boolean
 }) {
-  const { isMobile, state, openMobile, setOpenMobile, hasPinMode, pinned } = useSidebar()
+  const { isMobile, state, openMobile, setOpenMobile, hasPinMode, pinned, width } =
+    useSidebar()
+
+  // The scoped home for --sidebar-width. Every consumer -- this element,
+  // sidebar-gap and sidebar-container -- is inside it, and the chat thread is
+  // not, so a write here cannot invalidate inherited style for the thread.
+  // Empty with the flag off, where the wrapper keeps the declaration.
+  const scopedWidthStyle = (
+    PANEL_RESIZE_SCOPED_VARS_ENABLED ? { "--sidebar-width": `${width}px` } : {}
+  ) as React.CSSProperties
 
   if (collapsible === "none") {
     return (
       <div
         data-slot="sidebar"
+        style={scopedWidthStyle}
         className={cn(
           "bg-sidebar text-sidebar-foreground flex h-full w-(--sidebar-width) flex-col",
           className
@@ -281,6 +302,7 @@ function Sidebar({
       data-variant={variant}
       data-side={side}
       data-slot="sidebar"
+      style={scopedWidthStyle}
       aria-hidden={(hasPinMode && !pinned && collapseToZero) || undefined}
       inert={(hasPinMode && !pinned && collapseToZero) || undefined}
     >
@@ -387,6 +409,19 @@ function SidebarResizeHandle({
         cssVar="--sidebar-width"
         // The custom titlebar renders outside the wrapper and cannot inherit it.
         rootVar="--studio-sidebar-live-width"
+        // Both used only when PANEL_RESIZE_SCOPED_VARS_ENABLED is on.
+        // The rail sits inside sidebar-container, so [data-slot="sidebar"] is
+        // always an ancestor of it.
+        scopedTarget={() =>
+          ref.current?.closest<HTMLElement>('[data-slot="sidebar"]') ?? null
+        }
+        // Empty on every build without a custom titlebar, which is the honest
+        // answer there: nothing reads the property, so nothing needs writing.
+        rootVarTargets={() =>
+          Array.from(
+            document.querySelectorAll<HTMLElement>("[data-titlebar-live-width-scope]"),
+          )
+        }
         measure={() =>
           ref.current
             ?.closest<HTMLElement>('[data-slot="sidebar-container"]')

--- a/studio/frontend/src/components/ui/sidebar.tsx
+++ b/studio/frontend/src/components/ui/sidebar.tsx
@@ -190,14 +190,11 @@ function SidebarProvider({
         style={
           {
             // The drag handle writes this same property live while resizing.
-            //
-            // With PANEL_RESIZE_SCOPED_VARS_ENABLED the declaration moves DOWN
-            // to [data-slot="sidebar"], which holds every consumer. It cannot
-            // stay here as well: this wrapper is an ancestor of the chat
-            // thread, so a write here marks inherited style dirty for every
-            // element in the thread, and leaving a second declaration behind
-            // would keep the render-time write on the expensive element even
-            // though the drag-time write had moved.
+            // Under PANEL_RESIZE_SCOPED_VARS_ENABLED it moves DOWN to
+            // [data-slot="sidebar"], which holds every consumer, and cannot
+            // also stay here: this wrapper is an ancestor of the chat thread,
+            // so a declaration left behind would keep restyling the thread on
+            // every render even once the drag-time write had moved.
             ...(PANEL_RESIZE_SCOPED_VARS_ENABLED
               ? null
               : { "--sidebar-width": `${width}px` }),
@@ -235,9 +232,8 @@ function Sidebar({
   const { isMobile, state, openMobile, setOpenMobile, hasPinMode, pinned, width } =
     useSidebar()
 
-  // The scoped home for --sidebar-width. Every consumer -- this element,
-  // sidebar-gap and sidebar-container -- is inside it, and the chat thread is
-  // not, so a write here cannot invalidate inherited style for the thread.
+  // The scoped home for --sidebar-width: every consumer (this element,
+  // sidebar-gap, sidebar-container) is inside it and the chat thread is not.
   // Empty with the flag off, where the wrapper keeps the declaration.
   const scopedWidthStyle = (
     PANEL_RESIZE_SCOPED_VARS_ENABLED ? { "--sidebar-width": `${width}px` } : {}
@@ -409,14 +405,13 @@ function SidebarResizeHandle({
         cssVar="--sidebar-width"
         // The custom titlebar renders outside the wrapper and cannot inherit it.
         rootVar="--studio-sidebar-live-width"
-        // Both used only when PANEL_RESIZE_SCOPED_VARS_ENABLED is on.
-        // The rail sits inside sidebar-container, so [data-slot="sidebar"] is
-        // always an ancestor of it.
+        // Both used only under PANEL_RESIZE_SCOPED_VARS_ENABLED. The rail sits
+        // inside sidebar-container, so [data-slot="sidebar"] always encloses it.
         scopedTarget={() =>
           ref.current?.closest<HTMLElement>('[data-slot="sidebar"]') ?? null
         }
-        // Empty on every build without a custom titlebar, which is the honest
-        // answer there: nothing reads the property, so nothing needs writing.
+        // Empty on every build without a custom titlebar: nothing reads the
+        // property there, so nothing needs writing.
         rootVarTargets={() =>
           Array.from(
             document.querySelectorAll<HTMLElement>("[data-titlebar-live-width-scope]"),


### PR DESCRIPTION
Dragging the sidebar edge restyles essentially the entire document, twice per animation frame. This scopes both writes down to the subtrees that actually consume them, behind `PANEL_RESIZE_SCOPED_VARS_ENABLED`, which **defaults to off**.

## The mechanism

CSS custom properties inherit by default, so a write high in the tree invalidates style for every descendant. `PanelResizeHandle` makes two such writes on every animation frame of a sidebar drag:

| Property | Written on | Relationship to the chat thread |
| --- | --- | --- |
| `--sidebar-width` | `[data-slot="sidebar-wrapper"]` | ancestor |
| `--studio-sidebar-live-width` | `document.documentElement` | ancestor |

Both land above the thread, so each one is a full-document style recalc. Two of them, once per frame, for the whole drag.

## Dose-response

Four document sizes, using the engine's own `UpdateLayoutTree.elementCount` from a devtools trace:

| Property variant | Recalc time | Elements restyled |
| --- | --- | --- |
| unregistered, on `<html>` | 67.5 -> 576.9 ms | 4,292 -> 37,817 |
| registered `inherits: true` | 68.9 -> 576.5 ms | 4,292 -> 37,817 |
| registered `inherits: false` | 0.09 -> 0.08 ms | 1 -> 1 |

`inherits: true` costs exactly what unregistered costs. Registration is not the mechanism, **inheritance is**. Blink also invalidates blindly: a property nothing reads costs the same as `--sdm-c`, which every one of 28,732 Shiki token spans reads.

## Why the obvious fix is wrong

Neither variable can simply be typed `inherits: false`, because both are read by descendants of the element they are written on:

- `--sidebar-width` is read by `[data-slot="sidebar"]`, `sidebar-gap` and `sidebar-container`, all descendants of the wrapper.
- `--studio-sidebar-live-width` is read by `window-titlebar.tsx` (around line 212), a descendant of `<html>`.

Typing either one non-inheriting would make those consumers resolve the initial value and would silently break them. So the fix instead moves each write **down** to a subtree that consumes it and does not contain the chat thread:

- `--sidebar-width` -> `[data-slot="sidebar"]`, which holds every consumer and not the thread.
- `--studio-sidebar-live-width` -> the titlebar roots themselves. On every build without a custom titlebar there is no consumer at all, and the write is skipped entirely.

## Ablation

A real handle driven by a real pointer drag over a 12,026-element document, 8 frames:

| | Flag off | Flag on |
| --- | --- | --- |
| Elements restyled per frame | 12,022 (99.97% of the document) | 12 |
| Total recalc | 1,088.25 ms | 3.76 ms |

**Potency**, three witnesses flipped:

- `--sidebar-width` moved off the wrapper (`"440px"` -> `null`) onto `[data-slot="sidebar"]` (`null` -> `"440px"`).
- `--studio-sidebar-live-width` left `<html>` (`"440px"` -> `null`).
- The thread stand-in stopped resolving `--sidebar-width` at all (`"440px"` -> `""`).

**Invariance**: rendered geometry is identical at all 8 drag positions and before and after (280 to 440 px; sidebar, gap, container and inner all match), and `--sidebar-width` resolves identically at every real consumer.

## Limitations

Stating these plainly rather than burying them.

1. **The absolute milliseconds came off a vite dev server.** Read them as roughly 2.7x high: the same DOM with the built production stylesheet gave 49.1 ms against 133.3 ms. The mechanism is not a dev artefact, though. Unregistered versus `inherits: false` is 1333x on dev and 982x on production, and `elementCount` is a DOM property that is identical on both.
2. **No studiobench A/B has been run for this**, because the benchmark scene has no sidebar-drag action. The evidence here is the targeted ablation above, not an A/B.
3. **There is a second instance of the same bug shape that this PR does not fix.** `html[data-panel-resizing] *` at `studio/frontend/src/index.css:1604-1605` is a universal descendant selector and produces an indistinguishable full-document restyle, 37,818 elements and 575.0 ms. It fires twice per drag rather than once per frame, so its total is smaller, and it is load-bearing for cursor correctness. Left as follow-up work with its own visual risk rather than bundled here.

## Rollout

`PANEL_RESIZE_SCOPED_VARS_ENABLED` is `false` in this PR. With the flag off the behaviour is byte-for-byte what ships today: the wrapper keeps the `--sidebar-width` declaration and `rootVar` is painted on `document.documentElement`. All the wiring lands now so that flipping the one constant is the only edit needed later.

## Verification

Run in `studio/frontend` on this branch:

| Command | Result |
| --- | --- |
| `npm run typecheck` | pass |
| `npm run build` | pass, 8164 modules transformed |
| `npm test` | pass, 4109/4109, 0 failed |
