### PR TITLE
Stop Codex cancelling its own first turn while llama-server reads the prompt

### DIFF
--- a/.github/workflows/local-agent-guides-ci.yml
+++ b/.github/workflows/local-agent-guides-ci.yml
@@ -123,7 +123,16 @@ env:
   # prefill-shrinking flags (minimal system prompt + restricted tools) a turn on
   # a 4B model finishes in a couple of minutes on CPU; this also caps how long a
   # still-large-prompt agent burns before failing. Well under the 6h job cap.
-  AGENT_INVOKE_TIMEOUT: '600'
+  #
+  # Raised from 600. Those flags shrink what the SERVER puts in front of the model;
+  # they do not touch a preamble the client assembles for itself, and Codex's is
+  # several thousand tokens before the prompt is appended. Measured on this image at
+  # 16.1 tok/s, that is ~460s of prompt processing to answer "pong" -- inside 600s on
+  # paper, but only just, and the leg that has to survive it is the one that was
+  # failing 88% of the time. The cap exists to stop a hang, not to enforce a
+  # performance budget, so it is sized off the slowest legitimate turn rather than
+  # the fastest. It only ever costs wall-clock on a run that was going to fail.
+  AGENT_INVOKE_TIMEOUT: '1200'
 
 jobs:
   # ═════════════════════════════════════════════════════════════════════

--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -48,6 +48,25 @@ start_app = typer.Typer(
 
 _CODEX_PROFILE = "unsloth_api"
 _CODEX_ENV_KEY = "UNSLOTH_STUDIO_AUTH_TOKEN"
+# Codex treats an SSE stream with no bytes for this long as lost, cancels it, and
+# reconnects. Its default is 300000 (5 minutes), which is measured against the WHOLE
+# quiet period -- and llama-server sends nothing at all while it processes the prompt.
+#
+# That is not a corner case on the hardware Unsloth is for. A local CPU host chews
+# through a prompt at low tens of tokens a second, and Codex's own preamble is several
+# thousand tokens before the user has typed anything: 16.1 tok/s measured on a 2-core
+# box means ~460s of silence for a ~7300-token first turn, so the default trips before
+# the first token exists. The reconnect is worse than the wait, because llama-server
+# hands the retry a different parallel slot whose KV cache shares no prefix, so each
+# attempt restarts prompt processing from zero and the five retries can never converge.
+# Observed as a request completing in exactly 300056ms with `Reconnecting... 1/5` and
+# no turn ever finishing.
+#
+# 20 minutes. Sized to be longer than a slow local first turn rather than to any
+# server-side budget: nothing here bounds generation, and a genuinely dead stream is
+# still caught, just later. Same reason the Codex docs' own local-model example raises
+# it for Ollama.
+_CODEX_STREAM_IDLE_TIMEOUT_MS = 1_200_000
 _HERMES_ENV_KEY = "UNSLOTH_API_KEY"
 _HERMES_PROVIDER = "unsloth"
 # Skip the installer's interactive setup wizard: `unsloth start hermes` runs
@@ -2475,6 +2494,7 @@ def _merge_codex_config(existing: str, base: str) -> str:
         f'env_key = "{_CODEX_ENV_KEY}"\n'
         'wire_api = "responses"\n'
         "requires_openai_auth = false\n"
+        f"stream_idle_timeout_ms = {_CODEX_STREAM_IDLE_TIMEOUT_MS}\n"
     )
 
 

--- a/unsloth_cli/tests/test_start.py
+++ b/unsloth_cli/tests/test_start.py
@@ -833,6 +833,32 @@ def test_merge_codex_config_fresh():
     assert provider["requires_openai_auth"] is False
 
 
+def test_merge_codex_config_raises_the_stream_idle_timeout():
+    """Codex's 300s default cancels the stream while llama-server is still reading.
+
+    llama-server emits nothing at all during prompt processing, so the whole wait counts
+    as idle. Measured on a 2-core CI host: 16.1 tok/s against Codex's several-thousand
+    token preamble is ~460s of silence before the first token exists, and the default
+    trips at 300s. The reconnect then lands on a different parallel slot whose KV cache
+    shares no prefix, so every retry restarts from zero and the turn never completes --
+    a job hung for its full 600s cap with `Reconnecting... 1/5` and one request logged at
+    exactly 300056ms.
+
+    Asserted as a floor rather than an equality: raising it further is fine, and the
+    number is not the contract. Losing it entirely is the regression.
+    """
+    provider = _parse_toml(start._merge_codex_config("", BASE))["model_providers"]["unsloth_api"]
+    assert "stream_idle_timeout_ms" in provider, (
+        "the Codex provider block no longer sets stream_idle_timeout_ms, so Codex falls "
+        "back to its 300s default and cancels any first turn whose prompt takes longer "
+        "than that to process -- which is an ordinary local CPU host, not a corner case"
+    )
+    assert provider["stream_idle_timeout_ms"] > 300_000, (
+        f"stream_idle_timeout_ms is {provider['stream_idle_timeout_ms']}, at or below "
+        f"Codex's own 300000 default, so setting it changes nothing"
+    )
+
+
 def test_merge_codex_config_replaces_stale_block():
     existing = (
         'model = "gpt-5"\n'


### PR DESCRIPTION
`connection (codex, stable)` has been failing 88% of the time (1 pass / 8 fail over the last 40 runs). Every sibling agent on the same model, server and runner is at 0%:

```
codex     1 pass /  8 fail   (88% fail)
claude, hermes, openclaw, opencode, opencode v2, pi    9-10 pass / 0 fail
```

That rules out the model server, the runner and the recipe, all of which the six passing legs share. What Codex does not share is `wire_api = "responses"` and, more to the point, the size of the preamble it sends.

## What is actually happening

From the failing run's own logs. The server records the turn as completing in `300056.15` ms, and llama-server records why:

```
llama threadpool init, n_threads = 2
task 15 | prompt processing, n_tokens = 2048, progress = 0.28, t = 126.94 s / 16.13 tok/s
task 15 | prompt processing, n_tokens = 4096, progress = 0.56, t = 259.36 s / 15.79 tok/s
srv stop: cancel task, id_task = 15
task 49 | prompt processing, n_tokens = 2048, progress = 0.28, t = 127.09 s
```

Codex's preamble is roughly 7300 tokens. At 16.1 tok/s that is about 460 seconds of prompt processing before the first token can exist, and llama-server sends nothing at all while it reads. Codex's `stream_idle_timeout_ms` defaults to **300000**, measured against exactly that quiet period, so it cancels at 300s and reconnects. `300056.15` is that default, to the millisecond.

The reconnect is what makes it unrecoverable rather than merely slow. llama-server hands the retry a different parallel slot (`task 15` on slot 2, `task 49` on slot 1), and a fresh slot's KV cache shares no prefix, so each attempt restarts prompt processing from zero. Five retries, none of which can ever finish, and the job hangs until its own cap. `ERROR: Reconnecting... 1/5` is the only thing Codex prints about it.

None of this is specific to CI. A local CPU host chewing a large first turn is the hardware Unsloth exists for, and today those users get a turn that silently never completes.

## The change

`unsloth start codex` now writes `stream_idle_timeout_ms` into the `[model_providers.unsloth_api]` block it already owns. 20 minutes, sized to be longer than a slow local first turn rather than to any server-side budget: nothing here bounds generation, and a genuinely dead stream is still caught, just later. The Codex docs' own local-model example raises the same key for Ollama.

`AGENT_INVOKE_TIMEOUT` goes 600 -> 1200. The existing comment argued 600 was enough because prefill-shrinking flags keep a 4B turn to a couple of minutes, but those flags shrink what the *server* puts in front of the model and cannot touch a preamble the *client* assembles for itself. At the measured 16.1 tok/s the honest number for this leg is ~460s, which fits inside 600s only just. The cap exists to stop a hang, not to enforce a performance budget, so it is now sized off the slowest legitimate turn. It only costs wall-clock on a run that was going to fail, and the job's own 40 minute limit is unchanged.

## Guard

`test_merge_codex_config_raises_the_stream_idle_timeout` asserts the key is present and strictly above Codex's 300000 default, so a value that silently changes nothing fails too. Mutation-tested both ways: removing the line and setting it back to 300000 are each caught.

`unsloth_cli/tests/test_start.py` is 512 passed; `tests/studio/ -q -n 4` is 4622 passed / 4 skipped; `scripts/lint_workflow_triggers.py` clean.

## Worth a separate look

Two things this deliberately does not change:

- `n_threads = 2` on a 4-vCPU runner. That is llama.cpp's physical-core default and it is the right default for token generation, but prompt processing is batch work that usually wants more. `--threads-batch` is the knob; sizing it properly needs benchmarking rather than a guess.
- Retries landing on a cold slot. Prompt-prefix reuse across a reconnect would make any future timeout recoverable instead of fatal, which is a stronger property than a longer timeout. That is a serving change, not a config one.