### PR TITLE
Say what killed a UI wrapper script instead of reporting a bare 143

### DIFF
--- a/.github/scripts/run-studio-indicator-browser.sh
+++ b/.github/scripts/run-studio-indicator-browser.sh
@@ -34,6 +34,24 @@ cleanup() {
 }
 trap cleanup EXIT
 
+# Same signal report as run-studio-permission-browser.sh; see the comment there for the
+# failure this exists to make readable. This script has the identical shape (background
+# server, EXIT trap, suite as the last command), so it can lose a passing run to a late
+# signal the same way, and it now runs concurrently with the chat lane on Windows.
+suite_done=0
+_on_signal() {
+  name="$1"; number="$2"
+  echo "[indicator] SIG${name} received at $(date -u +%H:%M:%S) after suite_done=${suite_done}" >&2
+  # comm, not args: this lands in a public CI log, and a command line can carry a
+  # token that ::add-mask:: never saw. Process names answer "what was still alive"
+  # without quoting anyone's argv.
+  ps -o pid,ppid,comm 2>/dev/null | tail -20 >&2 || true
+  exit $((128 + number))
+}
+trap '_on_signal TERM 15' TERM
+trap '_on_signal INT 2' INT
+trap '_on_signal HUP 1' HUP
+
 healthy=0
 for _ in $(seq 1 180); do
   if curl -fs "http://127.0.0.1:$port/api/health" >/dev/null; then
@@ -70,3 +88,5 @@ else
 fi
 
 python tests/studio/playwright_loaded_models_indicator.py
+# Only after a clean return; see the permission script's comment.
+suite_done=1

--- a/.github/scripts/run-studio-permission-browser.sh
+++ b/.github/scripts/run-studio-permission-browser.sh
@@ -29,6 +29,38 @@ cleanup() {
 }
 trap cleanup EXIT
 
+# Say who died and when, for a failure mode that currently reports nothing.
+#
+# Observed on windows-latest at roughly one run in twenty-five: the suite prints
+# "permission-only run passed" and the STEP then ends with "Process completed with exit
+# code 143". 143 is 128+SIGTERM, so something signalled this script after its work had
+# already succeeded, and neither the step log nor the server log records what. The
+# server log simply stops mid-request, which is what cleanup killing it looks like, so
+# it cannot distinguish the two.
+#
+# suite_done is the fact worth capturing: it separates "signalled while driving the
+# browser" (a real timeout worth chasing) from "signalled after passing" (a teardown
+# ordering problem, and what the one observed instance was). Without it the next
+# occurrence is as unreadable as this one.
+#
+# `exit` explicitly, because the whole point is to be unambiguous about the status
+# rather than to rely on what bash would have chosen for a trapped signal.
+suite_done=0
+_on_signal() {
+  name="$1"; number="$2"
+  echo "[permissions] SIG${name} received at $(date -u +%H:%M:%S) after suite_done=${suite_done}" >&2
+  # Best effort: what was still alive. `ps` differs across MSYS and Linux and its
+  # absence must not replace the signal report with an error about ps.
+  # comm, not args: this lands in a public CI log, and a command line can carry a
+  # token that ::add-mask:: never saw. Process names answer "what was still alive"
+  # without quoting anyone's argv.
+  ps -o pid,ppid,comm 2>/dev/null | tail -20 >&2 || true
+  exit $((128 + number))
+}
+trap '_on_signal TERM 15' TERM
+trap '_on_signal INT 2' INT
+trap '_on_signal HUP 1' HUP
+
 healthy=0
 for _ in $(seq 1 180); do
   if curl -fs "http://127.0.0.1:$port/api/health" >/dev/null; then
@@ -68,3 +100,6 @@ else
 fi
 
 python tests/studio/playwright_chat_ui.py
+# Set only after the suite returns 0 (set -e means a failure never reaches here), so a
+# signal arriving during teardown is distinguishable from one that interrupted the run.
+suite_done=1

--- a/tests/studio/test_ui_scripts_report_signals.py
+++ b/tests/studio/test_ui_scripts_report_signals.py
@@ -1,0 +1,96 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""The Playwright wrapper scripts must say when a signal killed them.
+
+Observed on windows-latest at roughly one run in twenty-five: the suite prints
+"permission-only run passed" and the step then ends with "Process completed with exit
+code 143". 143 is 128+SIGTERM, so the script was signalled AFTER its work succeeded, and
+nothing in either the step log or the server log records what did it. The server log just
+stops mid-request, which is exactly what the script's own cleanup killing it looks like,
+so the two cannot be told apart.
+
+This file pins the diagnostic rather than a fix, because the cause is not known yet. A
+one-in-twenty-five failure that reports nothing costs a whole run every time it lands and
+teaches nothing, and the obvious tidy-up -- deleting a signal handler that "never fires"
+-- puts it straight back. Both scripts have the same shape (background server, EXIT trap,
+suite as the last command), so both can lose a passing run the same way, and since #9391
+they run concurrently on Windows rather than one after another.
+
+`suite_done` is the fact worth capturing: it separates a signal that interrupted the
+browser run from one that arrived during teardown, which is the first thing anyone
+reading the next occurrence needs to know.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+
+REPO = Path(__file__).resolve().parents[2]
+SCRIPTS = REPO / ".github" / "scripts"
+WRAPPERS = ("run-studio-permission-browser.sh", "run-studio-indicator-browser.sh")
+
+
+def _body(name: str) -> str:
+    """Source with comments stripped: a comment must not satisfy these assertions."""
+    text = (SCRIPTS / name).read_text(encoding = "utf-8")
+    return "\n".join(re.sub(r"(^|\s)#.*$", "", line) for line in text.split("\n"))
+
+
+@pytest.mark.parametrize("script", WRAPPERS)
+def test_the_wrapper_traps_a_terminating_signal(script: str) -> None:
+    body = _body(script)
+    for signal_name in ("TERM", "INT", "HUP"):
+        assert re.search(rf"trap\s+'_on_signal {signal_name}\b", body), (
+            f"{script} no longer traps SIG{signal_name}, so a signal that kills it mid-run "
+            f"is reported only as a bare exit code with no indication of what happened"
+        )
+
+
+@pytest.mark.parametrize("script", WRAPPERS)
+def test_the_report_distinguishes_teardown_from_a_live_run(script: str) -> None:
+    """Without suite_done the report cannot answer the only question worth asking."""
+    body = _body(script)
+    assert "suite_done=0" in body, f"{script} does not initialise suite_done"
+    assert re.search(r"^suite_done=1\s*$", body, re.M), (
+        f"{script} never sets suite_done=1, so every signal report claims the suite was "
+        f"still running -- including the observed case, which was signalled after it passed"
+    )
+    assert "suite_done" in body.split("_on_signal()")[1][:400], (
+        f"{script}'s signal handler does not report suite_done, so the flag is recorded "
+        f"and never printed"
+    )
+
+
+@pytest.mark.parametrize("script", WRAPPERS)
+def test_the_handler_exits_with_the_signal_status(script: str) -> None:
+    body = _body(script)
+    assert re.search(r"exit\s+\$\(\(\s*128\s*\+\s*(number|\$?\{?number)", body), (
+        f"{script}'s handler does not exit 128+signal, so the status it reports is "
+        f"whatever bash happened to pick rather than the signal that caused it"
+    )
+
+
+@pytest.mark.parametrize("script", WRAPPERS)
+def test_the_snapshot_does_not_print_command_lines(script: str) -> None:
+    """This lands in a public CI log.
+
+    `ps -o ...,args` would quote every running command line, and one of those can carry a
+    token that ::add-mask:: never saw. Process names answer the question the snapshot is
+    there for without that risk.
+    """
+    body = _body(script)
+    assert "pid,ppid,comm" in body, f"{script}'s process snapshot is not limited to names"
+    assert not re.search(r"ps\s+-o\s+[\w,]*args", body), (
+        f"{script} snapshots full command lines into a public log"
+    )
+
+
+def test_the_guard_reads_real_files() -> None:
+    for name in WRAPPERS:
+        assert (SCRIPTS / name).is_file(), name
+        assert len(_body(name)) > 400, name


### PR DESCRIPTION
`Chat UI Tests` on windows-latest fails about one run in twenty-five like this:

```
[ui] permission-only run passed (browser=chromium, channel=msedge)
##[error]Process completed with exit code 143.
```

143 is 128+SIGTERM, and the line above it is the suite reporting success. So the script was signalled after its work had already passed, and nothing anywhere records what did it. I pulled the run's artifact: `studio-permissions-chromium-msedge.log` simply stops mid-request, which is precisely what the script's own EXIT-trap cleanup killing the server looks like, so the log cannot tell the two apart.

This does not fix that. I could not identify the sender from the evidence available, and I would rather ship a readable failure than guess at a mechanism and call it fixed.

## What changes

`run-studio-permission-browser.sh` and `run-studio-indicator-browser.sh` trap TERM / INT / HUP, print one line, and exit 128+signal explicitly rather than leaving the status to bash.

The line carries `suite_done`, which is the fact that matters. It separates a signal that interrupted the browser run -- a real timeout worth chasing -- from one that arrived during teardown, which is what the observed instance was. Without it every report claims the suite was still running, including the case that prompted this.

Both scripts get it because they have the identical shape (background server, EXIT trap, suite as the last command), so both can lose a passing run the same way. Since #9391 they also run concurrently on Windows rather than one after another, which is a reason to be able to read this failure rather than a reason to expect more of it.

## On the process snapshot

The handler also prints `ps -o pid,ppid,comm`, deliberately not `args`. This lands in a public CI log and a command line can carry a token that `::add-mask::` never saw; process names answer "what was still alive" without quoting anyone's argv. There is a test for that, because the tempting edit when the snapshot is not informative enough is to widen it.

## Verification

The trap block was extracted from the shipped script and exercised directly rather than eyeballed:

```
exit=143 (expect 143)
[permissions] SIGTERM received at 16:05:52 after suite_done=0
```

`tests/studio/test_ui_scripts_report_signals.py` is 9 tests over both scripts, comment-stripped so prose cannot satisfy them, mutation-tested 5/5: removing the TERM trap, never setting `suite_done=1`, dropping `suite_done` from the report, exiting 1 instead of 128+n, and reverting the snapshot to full argv are each caught by the intended test.

`tests/studio/ -q -n 4` is 4649 passed / 4 skipped.

## Why a guard for a diagnostic

A one-in-twenty-five failure that reports nothing costs a whole run each time it lands and teaches nothing, and the obvious tidy-up -- deleting a signal handler that appears never to fire -- puts it straight back.