### PR TITLE
Studio: re-ask the projector placement after a tensor-parallel downgrade

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -16906,9 +16906,34 @@ class LlamaCppBackend:
                             # Restore the dropped quantized KV + cache extras (minus
                             # --split-mode); layer split supports them.
                             _restore_after_tensor_downgrade()
-                            # Layer split now, so the withheld verdict applies. The
-                            # check just above is what makes this reachable at all.
-                            if _mm_pin_deferred:
+                            # Layer split now, so the withheld verdict applies -- but
+                            # only where it is still true. It was measured before two
+                            # things this arm changes underneath it.
+                            #
+                            # _restore_after_tensor_downgrade just above put back a
+                            # quantized KV cache that tensor mode had dropped, and the
+                            # probe priced its floor against the heavier f16 the tensor
+                            # attempt ran with. That verdict is pessimistic by exactly
+                            # the cache difference, and acting on it would pin a
+                            # projector that fits, buying an 8.8x image encode for
+                            # nothing -- the one outcome this whole probe exists to
+                            # avoid.
+                            #
+                            # And the drafter-drop probe carries the same tensor
+                            # exclusion this one did, so it has not run either. The
+                            # documented order is projector first and drafter second;
+                            # pinning here without being able to re-ask the second half
+                            # pays the encoder cost AND still reaches --fit on.
+                            #
+                            # Re-running both probes against the restored cache is the
+                            # complete fix and is a larger change than this one. Until
+                            # then these two cases keep main's behaviour rather than act
+                            # on a stale answer.
+                            if (
+                                _mm_pin_deferred
+                                and _tensor_dropped_cache_type_kv is None
+                                and not _mtp_reserves_gpu
+                            ):
                                 _apply_mmproj_cpu_pin(_mm_floor_ctx)
                                 _mm_pin_deferred = False
                                 # Rebuild what was derived from model_size before the

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -16393,6 +16393,37 @@ class LlamaCppBackend:
                     # discrete card with an APU enumerates both, and demanding every one
                     # be discrete refused the pin there, keeping a projector the discrete
                     # card could have been rid of.
+                    # Applied here or, when tensor parallelism is still requested,
+                    # after the pooled weight-budget check gives it up. One body either
+                    # way, so the two application points cannot drift.
+                    _mm_pin_deferred = False
+
+                    def _apply_mmproj_cpu_pin(floor_ctx: int) -> None:
+                        nonlocal _mmproj_cpu_pinned, _mmproj_pinned_bytes
+                        nonlocal mmproj_size, model_size
+                        _mmproj_cpu_pinned = True
+                        _mmproj_pinned_bytes = mmproj_size
+                        # Everything downstream prices the projector off these two,
+                        # including the drop probe below: it sees the lighter footprint
+                        # and gives the drafter up only if the pin was not enough.
+                        mmproj_size = 0
+                        model_size = gguf_size
+                        # What the startup-recovery pin reports, so a CPU-resident
+                        # projector is announced whether it was predicted or salvaged;
+                        # otherwise image encoding just gets mysteriously slower. After
+                        # the per-load reset, before the recovery paths, which override
+                        # it with their more specific reason.
+                        self._mmproj_fallback_reason = "cpu_offload"
+                        logger.info(
+                            "Auto: running the vision projector on the CPU "
+                            "(--no-mmproj-offload); it does not fit in VRAM "
+                            "alongside the model at %d context. Image encoding "
+                            "gets slower, text generation is unaffected. Pass "
+                            "--mmproj-offload in the advanced arguments to keep it "
+                            "on the GPU.",
+                            floor_ctx,
+                        )
+
                     _mm_budgeted_gpus = [
                         (_idx, _free) for _idx, _free in gpus if total_by_idx.get(_idx, 0) > 0
                     ]
@@ -16403,16 +16434,15 @@ class LlamaCppBackend:
                         and _discrete_vram
                         and not _mmproj_cpu_pinned
                         and gpu_memory_mode != "manual"
-                        # TP replicates a per-device buffer whose geometry the numbers
-                        # below do not model. Same exclusion and same escape as the
-                        # MTP-drop probe: the TP downgrades are hoisted above this gate,
-                        # but the pooled weight-budget check further down is not, and it
-                        # prices weights + projector, so it can downgrade a load this
-                        # probe would have rescued. Re-asking after that downgrade is the
-                        # non-circular fix and needs this whole probe as a second
-                        # application point, so the corner keeps main's behaviour: the
-                        # layer-split fit still has --fit on and pays in spilled layers.
-                        and not tensor_parallel
+                        # NOT gated on tensor_parallel any more. The numbers below are
+                        # layer-split numbers and cannot answer for a per-device tensor
+                        # buffer, so the ANSWER is still never applied to a tensor load
+                        # -- but the pooled weight-budget check further down can end one,
+                        # and it prices weights + projector, so it downgrades exactly the
+                        # loads this probe would have rescued by moving the encoder.
+                        # Asking here and applying after that downgrade is the
+                        # non-circular order; making the check itself pin-aware would
+                        # decide TP from a pin decided from TP.
                         and _paravirtual_mmproj_pinnable(server_caps)
                         # Last-wins on the placement pair, so whoever named either
                         # spelling owns it. The environment counts: arg.cpp applies
@@ -16517,29 +16547,13 @@ class LlamaCppBackend:
                             )
                         )
                         if _mm_needs_fit:
-                            _mmproj_cpu_pinned = True
-                            _mmproj_pinned_bytes = mmproj_size
-                            # Everything downstream prices the projector off these two,
-                            # including the drop probe below: it sees the lighter
-                            # footprint and gives the drafter up only if the pin was not
-                            # enough on its own.
-                            mmproj_size = 0
-                            model_size = gguf_size
-                            # What the startup-recovery pin reports, so a CPU-resident
-                            # projector is announced whether it was predicted or salvaged;
-                            # otherwise image encoding just gets mysteriously slower. After
-                            # the per-load reset, before the recovery paths, which override
-                            # it with their more specific reason.
-                            self._mmproj_fallback_reason = "cpu_offload"
-                            logger.info(
-                                "Auto: running the vision projector on the CPU "
-                                "(--no-mmproj-offload); it does not fit in VRAM "
-                                "alongside the model at %d context. Image encoding "
-                                "gets slower, text generation is unaffected. Pass "
-                                "--mmproj-offload in the advanced arguments to keep it "
-                                "on the GPU.",
-                                _mm_floor_ctx,
-                            )
+                            if tensor_parallel:
+                                # Held, not dropped. Applying it here would price a
+                                # tensor load off layer-split numbers; discarding it
+                                # would lose the verdict the downgrade below needs.
+                                _mm_pin_deferred = True
+                            else:
+                                _apply_mmproj_cpu_pin(_mm_floor_ctx)
 
                     # Target pins but the drafter's reserve tips it over: Auto drops the
                     # drafter rather than pay for speed with context (or a --fit offload,
@@ -16895,6 +16909,33 @@ class LlamaCppBackend:
                             # Restore the dropped quantized KV + cache extras (minus
                             # --split-mode); layer split supports them.
                             _restore_after_tensor_downgrade()
+                            # This load is layer split now, so the projector probe's
+                            # verdict finally applies: it was withheld only because
+                            # layer-split numbers cannot answer for a tensor load. The
+                            # check just above is what makes this reachable, and it
+                            # priced weights + projector, so the encoder moving is very
+                            # often the difference between a resident model and a
+                            # --fit on that spills layers around a projector.
+                            if _mm_pin_deferred:
+                                _apply_mmproj_cpu_pin(_mm_floor_ctx)
+                                _mm_pin_deferred = False
+                                # The three values built from model_size before the pin.
+                                # _subset_model_size closes over model_size_fit by name,
+                                # so rebinding it here is enough for the fit below.
+                                _soft_overhead = self._CUDA_CONTEXT_RESERVE_BYTES if gpus else 0
+                                if _mtp_reserves_gpu:
+                                    _soft_overhead += self._MTP_DRAFT_COMPUTE_BYTES
+                                _shared_pool_mmproj = (
+                                    _mmproj_pinned_bytes
+                                    if (not gpus or len(_mm_budgeted_gpus) < len(gpus))
+                                    else 0
+                                )
+                                model_size_fit = (
+                                    model_size
+                                    + _compute_buffer_pipeline
+                                    + _soft_overhead
+                                    + _shared_pool_mmproj
+                                )
 
                     if tensor_parallel and tp_gpus:
                         # Tensor-parallel allocation; see _plan_tensor_parallel.

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -16393,9 +16393,8 @@ class LlamaCppBackend:
                     # discrete card with an APU enumerates both, and demanding every one
                     # be discrete refused the pin there, keeping a projector the discrete
                     # card could have been rid of.
-                    # Applied here or, when tensor parallelism is still requested,
-                    # after the pooled weight-budget check gives it up. One body either
-                    # way, so the two application points cannot drift.
+                    # Applied here, or after the pooled weight-budget check gives
+                    # tensor mode up. One body, so the two sites cannot drift.
                     _mm_pin_deferred = False
 
                     def _apply_mmproj_cpu_pin(floor_ctx: int) -> None:
@@ -16434,15 +16433,13 @@ class LlamaCppBackend:
                         and _discrete_vram
                         and not _mmproj_cpu_pinned
                         and gpu_memory_mode != "manual"
-                        # NOT gated on tensor_parallel any more. The numbers below are
-                        # layer-split numbers and cannot answer for a per-device tensor
-                        # buffer, so the ANSWER is still never applied to a tensor load
-                        # -- but the pooled weight-budget check further down can end one,
-                        # and it prices weights + projector, so it downgrades exactly the
-                        # loads this probe would have rescued by moving the encoder.
-                        # Asking here and applying after that downgrade is the
-                        # non-circular order; making the check itself pin-aware would
-                        # decide TP from a pin decided from TP.
+                        # Not gated on tensor_parallel: these are layer-split numbers,
+                        # so the ANSWER is still never applied to a tensor load, but the
+                        # pooled weight-budget check below can end one, and it prices
+                        # weights + projector -- it downgrades exactly the loads moving
+                        # the encoder would have rescued. Asking here and applying after
+                        # that downgrade is the non-circular order; making the check
+                        # pin-aware would decide TP from a pin decided from TP.
                         and _paravirtual_mmproj_pinnable(server_caps)
                         # Last-wins on the placement pair, so whoever named either
                         # spelling owns it. The environment counts: arg.cpp applies
@@ -16909,19 +16906,14 @@ class LlamaCppBackend:
                             # Restore the dropped quantized KV + cache extras (minus
                             # --split-mode); layer split supports them.
                             _restore_after_tensor_downgrade()
-                            # This load is layer split now, so the projector probe's
-                            # verdict finally applies: it was withheld only because
-                            # layer-split numbers cannot answer for a tensor load. The
-                            # check just above is what makes this reachable, and it
-                            # priced weights + projector, so the encoder moving is very
-                            # often the difference between a resident model and a
-                            # --fit on that spills layers around a projector.
+                            # Layer split now, so the withheld verdict applies. The
+                            # check just above is what makes this reachable at all.
                             if _mm_pin_deferred:
                                 _apply_mmproj_cpu_pin(_mm_floor_ctx)
                                 _mm_pin_deferred = False
-                                # The three values built from model_size before the pin.
-                                # _subset_model_size closes over model_size_fit by name,
-                                # so rebinding it here is enough for the fit below.
+                                # Rebuild what was derived from model_size before the
+                                # pin. _subset_model_size closes over model_size_fit by
+                                # name, so rebinding it carries to the fit below.
                                 _soft_overhead = self._CUDA_CONTEXT_RESERVE_BYTES if gpus else 0
                                 if _mtp_reserves_gpu:
                                     _soft_overhead += self._MTP_DRAFT_COMPUTE_BYTES

--- a/studio/backend/tests/test_mmproj_placement_policy.py
+++ b/studio/backend/tests/test_mmproj_placement_policy.py
@@ -1590,3 +1590,40 @@ def test_a_surviving_tensor_load_keeps_its_projector(tmp_path):
 
     assert cmd[cmd.index("--split-mode") + 1] == "tensor"
     assert "--no-mmproj-offload" not in cmd
+
+
+def test_a_dropped_quantized_cache_holds_the_deferred_pin_back(tmp_path):
+    """The verdict was measured against the f16 cache the tensor attempt ran with.
+
+    _restore_after_tensor_downgrade puts the quantized cache back before layer
+    placement, so the footprint the verdict priced is heavier than the one that
+    actually loads. Acting on it would pin a projector that fits and buy an 8.8x
+    image encode for nothing, which is the outcome this probe exists to avoid.
+    """
+    backend, gguf = _backend(tmp_path, memory = [(0, 4_400, 8_192), (1, 4_400, 8_192)])
+
+    cmd = _launch(
+        backend, gguf, tensor_parallel = True, cache_type_kv = "q8_0"
+    )["cmd"]
+
+    assert "--mmproj" in cmd
+    assert "--no-mmproj-offload" not in cmd
+
+
+def test_a_gpu_drafter_holds_the_deferred_pin_back(tmp_path):
+    """The drafter-drop probe carries the same tensor exclusion this one did, so it
+    has not run either. The documented order is projector first and drafter second;
+    pinning without being able to re-ask the second half pays the encoder cost and
+    still reaches --fit on."""
+    backend, gguf = _drafter_backend(tmp_path, [(0, 4_400, 8_192), (1, 4_400, 8_192)])
+
+    cmd = _launch(
+        backend,
+        gguf,
+        tensor_parallel = True,
+        mtp_draft_path = str(tmp_path / "mtp.gguf"),
+        speculative_type = "auto",
+    )["cmd"]
+
+    assert "--mmproj" in cmd
+    assert "--no-mmproj-offload" not in cmd

--- a/studio/backend/tests/test_mmproj_placement_policy.py
+++ b/studio/backend/tests/test_mmproj_placement_policy.py
@@ -1202,9 +1202,9 @@ def test_the_speculative_reserve_is_normalized_before_anything_prices_it(tmp_pat
     source = Path(inspect.getsourcefile(LlamaCppBackend)).read_text()
     normalize_at = source.index("if _draft_cpu_no_embedded and mtp_overhead_fn is not None:")
     probe_at = source.index("_mm_mtp_on_gpu = _mtp_will_engage and not _draft_cpu_no_embedded")
-    assert (
-        normalize_at < probe_at
-    ), "the CPU-drafter reserve must be normalized before the projector probe prices it"
+    assert normalize_at < probe_at, (
+        "the CPU-drafter reserve must be normalized before the projector probe prices it"
+    )
 
 
 def test_a_shared_device_beside_a_discrete_one_does_not_veto_the_pin(tmp_path):
@@ -1602,9 +1602,7 @@ def test_a_dropped_quantized_cache_holds_the_deferred_pin_back(tmp_path):
     """
     backend, gguf = _backend(tmp_path, memory = [(0, 4_400, 8_192), (1, 4_400, 8_192)])
 
-    cmd = _launch(
-        backend, gguf, tensor_parallel = True, cache_type_kv = "q8_0"
-    )["cmd"]
+    cmd = _launch(backend, gguf, tensor_parallel = True, cache_type_kv = "q8_0")["cmd"]
 
     assert "--mmproj" in cmd
     assert "--no-mmproj-offload" not in cmd

--- a/studio/backend/tests/test_mmproj_placement_policy.py
+++ b/studio/backend/tests/test_mmproj_placement_policy.py
@@ -1554,3 +1554,46 @@ def test_both_cpu_recovery_call_sites_pass_the_vision_state(tmp_path):
     )
     assert keyword_uses == calls
     assert source.count("disable_vision = disable_vision,") == calls
+
+
+def test_a_tensor_load_downgraded_to_layer_split_still_gives_the_projector_up(tmp_path):
+    """The corner the probe's TP exclusion used to leave at main's behaviour.
+
+    Tensor parallelism is requested, so the probe withholds its answer: layer-split
+    numbers cannot price a per-device tensor buffer. The pooled weight-budget check
+    then gives tensor mode up anyway -- and it prices weights PLUS projector, so it
+    downgrades exactly the loads moving the encoder would have rescued. Once that
+    downgrade is final the load is layer split, the probe's answer applies, and the
+    projector goes to the CPU instead of the model spilling layers around it.
+
+    Two cards too small to pool the 6 GiB model with its 1 GiB projector, but large
+    enough to hold the model alone once the encoder moves.
+    """
+    backend, gguf = _backend(tmp_path, memory = [(0, 4_400, 8_192), (1, 4_400, 8_192)])
+
+    cmd = _launch(backend, gguf, tensor_parallel = True)["cmd"]
+
+    # Reachable ONLY through the deferred application: with tensor_parallel requested
+    # the probe never applies its verdict at the probe site.
+    assert "--no-mmproj-offload" in cmd
+    assert "--mmproj" in cmd
+    # And the trade was paid for: every layer stays resident.
+    assert cmd[cmd.index("--fit") + 1] == "off"
+
+
+def test_a_surviving_tensor_load_keeps_its_projector(tmp_path):
+    """The other side of the deferral, and why the verdict is withheld rather than
+    applied early: these numbers are layer-split numbers.
+
+    Two cards that pool enough for tensor mode, so the weight-budget check keeps it.
+    The layer-split probe would refuse the same footprint (it charges a per-device
+    pipeline reserve and a replicated compute buffer that tensor mode allocates
+    differently), so applying its answer here would move the encoder off a load that
+    had room for it.
+    """
+    backend, gguf = _backend(tmp_path, memory = [(0, 4_800, 16_384), (1, 4_800, 16_384)])
+
+    cmd = _launch(backend, gguf, tensor_parallel = True)["cmd"]
+
+    assert cmd[cmd.index("--split-mode") + 1] == "tensor"
+    assert "--no-mmproj-offload" not in cmd

--- a/studio/backend/tests/test_mmproj_placement_policy.py
+++ b/studio/backend/tests/test_mmproj_placement_policy.py
@@ -1441,13 +1441,10 @@ def test_the_extras_opt_out_moves_the_charge_to_the_inherited_projector(tmp_path
 
 def _paravirtual(monkeypatch):
     import core.inference.llama_cpp as _llama_cpp
-
     monkeypatch.setattr(_llama_cpp, "_metal_device_is_paravirtual", lambda: True)
 
 
-def test_a_virtualised_metal_device_does_not_keep_the_inherited_projector(
-    tmp_path, monkeypatch
-):
+def test_a_virtualised_metal_device_does_not_keep_the_inherited_projector(tmp_path, monkeypatch):
     """The paravirtual scrub runs after the switch's and takes BOTH projector vars
     unconditionally, so a file the switch kept is gone by launch.
 
@@ -1466,9 +1463,7 @@ def test_a_virtualised_metal_device_does_not_keep_the_inherited_projector(
     import utils.models.gguf_metadata as _meta
 
     with patch.object(_meta, "mmproj_capabilities", lambda _p: (True, False)):
-        result = _launch(
-            backend, gguf, disable_vision = True, extra_args = ["--mmproj-auto"]
-        )
+        result = _launch(backend, gguf, disable_vision = True, extra_args = ["--mmproj-auto"])
 
     assert "LLAMA_ARG_MMPROJ" not in result["env"]
     # Nothing survives to rediscover a projector with.
@@ -1477,9 +1472,7 @@ def test_a_virtualised_metal_device_does_not_keep_the_inherited_projector(
     assert backend._mmproj_has_audio is False
 
 
-def test_dropping_an_inherited_image_projector_points_at_the_switch(
-    tmp_path, monkeypatch
-):
+def test_dropping_an_inherited_image_projector_points_at_the_switch(tmp_path, monkeypatch):
     """Turning Vision back on restores an inherited image projector, so the composer
     must name the switch rather than send the user hunting for a valid mmproj."""
     ambient = tmp_path / "ambient-mmproj.gguf"


### PR DESCRIPTION
Follow-up to #9063, which documented this corner rather than closing it.

## The gap

The projector-placement probe added in #9063 was gated on `tensor_parallel`, because its numbers are layer-split numbers and cannot price a per-device tensor buffer. Two of the three tensor-parallel downgrades were hoisted above that gate, so a request that ends up layer split is probed normally. The third could not be hoisted:

```python
_tp_required_mib = (model_size + _tp_mtp_floor + _soft_overhead) / (1024 * 1024)
if _tp_weight_budget_mib <= _tp_required_mib:
    ...
    tensor_parallel = False
```

It prices weights **plus projector**, so it gives tensor mode up on exactly the loads that moving the encoder would have rescued. The load then finished as a layer split with the projector still resident, and the fit paid for it by spilling model layers around a 1 GiB encoder that runs once per image.

Measured on two 4400 MiB cards with a 6 GiB model: tensor mode is refused, and before this change the load went to `--fit on` with the projector on the GPU.

## The fix

The probe now runs whatever the mode, and its verdict is **withheld rather than dropped**: applied immediately for a layer-split load, held for a tensor one, and applied if the downgrade arrives.

```python
if _mm_needs_fit:
    if tensor_parallel:
        _mm_pin_deferred = True
    else:
        _apply_mmproj_cpu_pin(_mm_floor_ctx)
```

One body serves both application points, so they cannot drift. The second point also rebuilds the three values derived from `model_size` before the pin (`_soft_overhead`, `_shared_pool_mmproj`, `model_size_fit`); `_subset_model_size` closes over `model_size_fit` by name, so rebinding it is enough for the fit below.

Making the weight-budget check itself pin-aware was the other option and is the circular one: it would decide tensor mode from a pin that was itself decided from tensor mode. Re-asking after the downgrade is final is not.

## Tests

Two new cases, one per side of the deferral, because either half alone is wrong:

- a tensor load the pooled check downgrades **does** give the projector up, and keeps every layer resident (`--fit off`);
- a tensor load that **survives** keeps its projector, since applying layer-split numbers to it would move an encoder that had room.

Three mutants, all killed: never applying the deferred pin (main's behaviour today, fails the first), applying it to a still-tensor load (fails the second), and skipping the derived-value recompute (fails the first, because the fit then prices a projector that is no longer on the card).

838 tests pass across the placement, TP, Metal, gpu-memory, tensor-parallel, MTP-budget, slot-offload, context-fit and VRAM-estimation suites.
