### PR TITLE
Studio: never offer a calibration imatrix as a GGUF variant

### DIFF
--- a/studio/backend/core/inference/diffusion_lora.py
+++ b/studio/backend/core/inference/diffusion_lora.py
@@ -281,8 +281,7 @@ def _pick_repo_weight_file(repo_id: str, hf_token: Optional[str]) -> str:
         for f in drop_shadowed_appledouble_names(
             list(HfApi(token = hf_token).list_repo_files(repo_id))
         )
-        # A repo that ships a calibration imatrix beside the adapter offers no LoRA
-        # weights in it, and it would be the fallback pick below.
+        # An imatrix is not adapter weights, and it would be the fallback pick below.
         if not is_imatrix_filename(f)
     ]
     safes = [f for f in files if f.lower().endswith(".safetensors") and "/" not in f]

--- a/studio/backend/core/inference/diffusion_lora.py
+++ b/studio/backend/core/inference/diffusion_lora.py
@@ -274,9 +274,17 @@ def _pick_repo_weight_file(repo_id: str, hf_token: Optional[str]) -> str:
     """Pick the single LoRA weight file in an HF repo (prefer safetensors)."""
     from huggingface_hub import HfApi
 
-    from hub.utils.gguf import drop_shadowed_appledouble_names
+    from hub.utils.gguf import drop_shadowed_appledouble_names, is_imatrix_filename
 
-    files = drop_shadowed_appledouble_names(list(HfApi(token = hf_token).list_repo_files(repo_id)))
+    files = [
+        f
+        for f in drop_shadowed_appledouble_names(
+            list(HfApi(token = hf_token).list_repo_files(repo_id))
+        )
+        # A repo that ships a calibration imatrix beside the adapter offers no LoRA
+        # weights in it, and it would be the fallback pick below.
+        if not is_imatrix_filename(f)
+    ]
     safes = [f for f in files if f.lower().endswith(".safetensors") and "/" not in f]
     if len(safes) == 1:
         return safes[0]

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -1958,8 +1958,11 @@ def _drafter_path_kind(path: str) -> Optional[str]:
     return None
 
 
+_IMATRIX_TOKEN_RE = re.compile(r"^imatrix(?:[._\-]|$)|[._\-]imatrix$", re.IGNORECASE)
+
+
 def _is_companion_gguf_path(path: str) -> bool:
-    """True for a non-main GGUF: vision mmproj, or a separate drafter (repo-root
+    """True for a non-main GGUF: vision mmproj, a calibration imatrix, or a separate drafter (repo-root
     ``mtp-*.gguf``, the ``MTP/`` subdir copies for Gemma 4, the ``dspark/``
     drafters for DeepSeek V4 Flash). Mirrors hub.utils.gguf so variant resolution
     never picks a companion as the main model -- a Gemma ``Q8_0`` request must not
@@ -1971,6 +1974,10 @@ def _is_companion_gguf_path(path: str) -> bool:
     if not p.endswith(".gguf"):
         return False
     if "mmproj" in p:
+        return True
+    # Mirrors hub.utils.gguf.is_imatrix_filename: an imatrix_unsloth.gguf is a valid
+    # GGUF container holding calibration statistics, so only the name rules it out.
+    if _IMATRIX_TOKEN_RE.search(Path(p).stem):
         return True
     return _drafter_path_kind(path) is not None
 

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -1962,8 +1962,8 @@ _IMATRIX_TOKEN_RE = re.compile(r"^imatrix(?:[._\-]|$)|[._\-]imatrix$", re.IGNORE
 
 
 def _is_companion_gguf_path(path: str) -> bool:
-    """True for a non-main GGUF: vision mmproj, a calibration imatrix, or a separate drafter (repo-root
-    ``mtp-*.gguf``, the ``MTP/`` subdir copies for Gemma 4, the ``dspark/``
+    """True for a non-main GGUF: vision mmproj, a calibration imatrix, or a separate
+    drafter (repo-root ``mtp-*.gguf``, the ``MTP/`` subdir copies for Gemma 4, the ``dspark/``
     drafters for DeepSeek V4 Flash). Mirrors hub.utils.gguf so variant resolution
     never picks a companion as the main model -- a Gemma ``Q8_0`` request must not
     resolve to ``MTP/...-Q8_0-MTP.gguf``, which sorts ahead of the real weight.
@@ -1975,8 +1975,8 @@ def _is_companion_gguf_path(path: str) -> bool:
         return False
     if "mmproj" in p:
         return True
-    # Mirrors hub.utils.gguf.is_imatrix_filename: an imatrix_unsloth.gguf is a valid
-    # GGUF container holding calibration statistics, so only the name rules it out.
+    # Mirrors hub.utils.gguf.is_imatrix_filename: an imatrix is a valid GGUF container
+    # holding calibration statistics, so only the name rules it out.
     if _IMATRIX_TOKEN_RE.search(Path(p).stem):
         return True
     return _drafter_path_kind(path) is not None

--- a/studio/backend/core/inference/openai_auto_download.py
+++ b/studio/backend/core/inference/openai_auto_download.py
@@ -258,8 +258,8 @@ def _auth_denied(repo_id: str, hf_token: Optional[str]) -> bool:
 def _gguf_variants(siblings, repo_id: str = "") -> dict[str, int]:
     """Quant label -> bytes the download will actually fetch.
 
-    Mirrors list_gguf_variants for the selectable labels: companions (mmproj/MTP)
-    and big-endian builds are not quants, and sharded quants sum across shards.
+    Mirrors list_gguf_variants for the selectable labels: companions (mmproj/MTP),
+    calibration imatrices and big-endian builds are not quants, and sharded quants sum across shards.
     Bytes come from the download plan, which folds companions back into every
     quant, so the disk reserve is measured against what the worker fetches.
     """
@@ -269,6 +269,7 @@ def _gguf_variants(siblings, repo_id: str = "") -> dict[str, int]:
     from utils.models.model_config import (
         _extract_quant_label,
         _is_big_endian_gguf_path,
+        _is_imatrix_path,
         _is_mmproj,
         _is_mtp_drafter,
     )
@@ -298,7 +299,12 @@ def _gguf_variants(siblings, repo_id: str = "") -> dict[str, int]:
             # key the whole stem, so advertising ours dispatches an unresolvable variant.
             quant = canonical_quant_label(name) or quant
         # The endian test reads a quant TOKEN, so it gets the label, not the path-qualified key.
-        if _is_mmproj(name) or _is_mtp_drafter(name) or _is_big_endian_gguf_path(name, label):
+        if (
+            _is_mmproj(name)
+            or _is_mtp_drafter(name)
+            or _is_imatrix_path(name)
+            or _is_big_endian_gguf_path(name, label)
+        ):
             continue
         plan = plans.get(quant.lower())
         if plan is not None:

--- a/studio/backend/hub/services/models/common.py
+++ b/studio/backend/hub/services/models/common.py
@@ -20,6 +20,7 @@ from hub.schemas.inventory import (
 from hub.utils.gguf import (
     gguf_variant_key,
     is_gguf_filename as _is_gguf_filename,
+    is_imatrix_filename as _is_imatrix_filename,
     is_mmproj_filename as _is_mmproj_filename,
     is_mtp_drafter_path as _is_mtp_drafter_path,
 )
@@ -66,7 +67,7 @@ _HF_CACHE_MODEL_FILE_PROBE_LIMIT = 2000
 
 
 def _is_model_directory(d: Path) -> bool:
-    """True when *d* has a config plus real weights; excludes mmproj GGUFs and non-weight ``.bin`` files (``tokenizer.bin``) to avoid false positives."""
+    """True when *d* has a config plus real weights; excludes mmproj GGUFs, calibration imatrices and non-weight ``.bin`` files (``tokenizer.bin``) to avoid false positives."""
 
     def _is_weight_file(f: Path) -> bool:
         if is_appledouble_metadata(f):
@@ -75,7 +76,11 @@ def _is_model_directory(d: Path) -> bool:
         if suffix == ".safetensors":
             return True
         if suffix == ".gguf":
-            return "mmproj" not in f.name.lower() and not _is_mtp_drafter_path(f.name)
+            return (
+                "mmproj" not in f.name.lower()
+                and not _is_mtp_drafter_path(f.name)
+                and not _is_imatrix_filename(f.name)
+            )
         if suffix == ".bin":
             name = f.name.lower()
             return (
@@ -550,7 +555,10 @@ def _classify_non_gguf_model_format(
 
 def _is_main_gguf_filename(name: str) -> bool:
     return (
-        _is_gguf_filename(name) and not _is_mmproj_filename(name) and not _is_mtp_drafter_path(name)
+        _is_gguf_filename(name)
+        and not _is_mmproj_filename(name)
+        and not _is_mtp_drafter_path(name)
+        and not _is_imatrix_filename(name)
     )
 
 

--- a/studio/backend/hub/services/models/deletion.py
+++ b/studio/backend/hub/services/models/deletion.py
@@ -298,8 +298,8 @@ def _delete_gguf_variant_from_repos(
                 # Companions: mmproj and the drafters Studio downloads (MTP with
                 # every variant, DSpark on opt-in). No main GGUF is left, so they
                 # cannot be launched; reclaim them with the last variant. An imatrix
-                # joins them: it is no longer offered as a variant, so a copy an older
-                # build fetched as one would otherwise be unreachable from the UI.
+                # joins them: no longer offered as a variant, so a copy an older build
+                # fetched as one would be unreachable from the UI.
                 lambda name: _is_gguf_filename(name)
                 and (
                     _is_mmproj_filename(name)

--- a/studio/backend/hub/services/models/deletion.py
+++ b/studio/backend/hub/services/models/deletion.py
@@ -41,6 +41,7 @@ from hub.services import resolve_destructive_repo_ids
 from hub.services.models import cache_inventory, downloads, gguf_variants
 from hub.services.models.common import (
     _is_gguf_filename,
+    _is_imatrix_filename,
     _is_main_gguf_filename,
     _is_mmproj_filename,
 )
@@ -296,9 +297,15 @@ def _delete_gguf_variant_from_repos(
                 target_repo,
                 # Companions: mmproj and the drafters Studio downloads (MTP with
                 # every variant, DSpark on opt-in). No main GGUF is left, so they
-                # cannot be launched; reclaim them with the last variant.
+                # cannot be launched; reclaim them with the last variant. An imatrix
+                # joins them: it is no longer offered as a variant, so a copy an older
+                # build fetched as one would otherwise be unreachable from the UI.
                 lambda name: _is_gguf_filename(name)
-                and (_is_mmproj_filename(name) or _is_reclaimable_drafter_path(name)),
+                and (
+                    _is_mmproj_filename(name)
+                    or _is_reclaimable_drafter_path(name)
+                    or _is_imatrix_filename(name)
+                ),
             )
             for snap, _blob, name in companion_matches:
                 try:

--- a/studio/backend/hub/services/models/gguf_variants.py
+++ b/studio/backend/hub/services/models/gguf_variants.py
@@ -50,6 +50,7 @@ from hub.utils.paths import (
 # Loader's normalizer, not the hub's: they disagree on WSL, and only it names what the load opens.
 from utils.paths import normalize_path as _loader_normalize_path
 from hub.services.models.common import (
+    _is_imatrix_filename,
     _is_mmproj_filename,
     _is_mtp_drafter_path,
     _iter_gguf_paths,
@@ -516,6 +517,10 @@ def _local_main_gguf_blobs_by_quant(
                 normalized = str(path).replace("\\", "/")
                 if not hashes:
                     continue
+                if _is_imatrix_filename(normalized):
+                    # Not a companion either: nothing plans or fetches an imatrix, so a
+                    # stale copy on disk must not vouch for a variant's blobs.
+                    continue
                 if _is_mmproj_filename(normalized) or _is_mtp_drafter_path(normalized):
                     companion_blobs.setdefault(normalized, set()).update(
                         str(blob) for blob in hashes if blob
@@ -724,6 +729,7 @@ def _direct_gguf_loads(path: Path) -> bool:
     return not (
         _is_mmproj_filename(path.name)
         or _is_mtp_drafter_path(context)
+        or _is_imatrix_filename(path.name)
         or is_big_endian_gguf_path(context, _extract_quant_label(context))
         or is_appledouble_metadata(path)
     )
@@ -1399,7 +1405,11 @@ async def get_gguf_variants_answer(
                         continue
                     key = rel.lower()
                     by_filename[key] = max(by_filename.get(key, 0), size)
-                    if _is_mmproj_filename(f.name) or _is_mtp_drafter_path(rel):
+                    if (
+                        _is_mmproj_filename(f.name)
+                        or _is_mtp_drafter_path(rel)
+                        or _is_imatrix_filename(f.name)
+                    ):
                         continue
                     q = gguf_variant_key(rel)
                     if is_big_endian_gguf_path(rel, extract_quant_label(rel)):

--- a/studio/backend/hub/services/models/gguf_variants.py
+++ b/studio/backend/hub/services/models/gguf_variants.py
@@ -518,8 +518,8 @@ def _local_main_gguf_blobs_by_quant(
                 if not hashes:
                     continue
                 if _is_imatrix_filename(normalized):
-                    # Not a companion either: nothing plans or fetches an imatrix, so a
-                    # stale copy on disk must not vouch for a variant's blobs.
+                    # Not a companion either: nothing fetches an imatrix, so a stale copy
+                    # on disk must not vouch for a variant's blobs.
                     continue
                 if _is_mmproj_filename(normalized) or _is_mtp_drafter_path(normalized):
                     companion_blobs.setdefault(normalized, set()).update(

--- a/studio/backend/hub/utils/gguf.py
+++ b/studio/backend/hub/utils/gguf.py
@@ -877,6 +877,7 @@ def list_partial_gguf_variants_from_state(
         main_filename: Optional[str] = None
         size_bytes = 0
         companion_bytes = 0
+        imatrix_only = False
         if manifest is not None:
             for expected in manifest.expected_files:
                 if not is_gguf_filename(expected.path):
@@ -884,6 +885,7 @@ def list_partial_gguf_variants_from_state(
                 if is_imatrix_filename(expected.path):
                     # A manifest predating this filtering can still name one; it is
                     # neither weights nor a companion, so it counts towards neither size.
+                    imatrix_only = True
                     continue
                 if is_mtp_drafter_path(expected.path):
                     # Downloaded with every variant (like mmproj) but not a
@@ -899,6 +901,13 @@ def list_partial_gguf_variants_from_state(
                     main_filename = expected.path
                 size_bytes += max(0, int(expected.size or 0))
         if main_filename is None:
+            # An older build could download the imatrix as a variant of its own, so its
+            # interrupted state is still on disk. Naming the synthetic file after the
+            # variant would put that row back in the menu, at zero bytes, on exactly the
+            # offline path this listing serves. Only when NOTHING eligible was found:
+            # a marker-only quant keeps its synthetic row so it can be resumed or deleted.
+            if imatrix_only or is_imatrix_filename(variant):
+                continue
             main_filename = f"{variant}.gguf"
         variants.append(
             GgufVariantInfo(

--- a/studio/backend/hub/utils/gguf.py
+++ b/studio/backend/hub/utils/gguf.py
@@ -89,6 +89,41 @@ def is_mmproj_filename(filename: str) -> bool:
     return "mmproj" in filename.lower()
 
 
+# Calibration importance matrices published beside the weights. Unsloth ships
+# imatrix_unsloth.dat and imatrix_unsloth.gguf_file, whose suffixes keep them out
+# of a GGUF listing, but some repos publish the same file as imatrix_unsloth.gguf
+# (unsloth/Qwen3.8-27B-GGUF) and it then reaches every GGUF path as if it were
+# weights: the variant menu grew a ~13 MB row labelled "GGUF", since the quant
+# extractor finds no token in the name.
+#
+# An imatrix holds per-tensor activation statistics, not a model. llama-quantize
+# reads one at QUANTIZE time and llama-server never opens it, so it is neither a
+# selectable variant nor a companion to fetch -- unlike mmproj and the MTP
+# drafter, it is excluded outright.
+#
+# Anchored at an END of the stem, never a substring, for the reason
+# is_mtp_drafter_path documents: a name that merely contains the word (a
+# hypothetical ``Qwen3-Imatrix-Tuned-Q4_K_M.gguf``) is a real model, while every
+# published imatrix leads or closes with it -- ``imatrix.gguf``,
+# ``imatrix_unsloth.gguf``, ``<model>-imatrix.gguf``, ``<model>.imatrix``.
+_IMATRIX_TOKEN_RE = re.compile(r"^imatrix(?:[._\-]|$)|[._\-]imatrix$", re.IGNORECASE)
+
+
+def is_imatrix_filename(path: str) -> bool:
+    """True for a calibration imatrix, in any of the suffixes repos publish it under.
+
+    Must be excluded everywhere mmproj is, or the imatrix is advertised as a quant,
+    downloaded as weights and, being a valid GGUF container, handed to the loader.
+
+    CANONICAL COPY. Two mirrors must change in lockstep:
+    utils/models/model_config.py ``_is_imatrix_path`` (utils cannot import hub) and
+    core/inference/llama_cpp.py ``_is_companion_gguf_path`` (core avoids hub imports).
+    """
+    name = path.replace("\\", "/").rsplit("/", 1)[-1]
+    stem = name.rsplit(".", 1)[0] if "." in name else name
+    return bool(_IMATRIX_TOKEN_RE.search(stem)) or name.lower().endswith(".imatrix")
+
+
 # Separate-file drafter kinds. dspark and dflash are the same DeepSeek V4 Flash
 # drafter: the folder it ships in and the architecture it reports.
 _DRAFTER_KINDS = ("mtp", "dspark", "dflash")
@@ -289,6 +324,7 @@ def pick_best_gguf(filenames: list[str]) -> Optional[str]:
         if is_gguf_filename(name)
         and not is_mmproj_filename(name)
         and not is_mtp_drafter_path(name)
+        and not is_imatrix_filename(name)
         and not is_big_endian_gguf_path(name, extract_quant_label(name))
     ]
     if not gguf_files:
@@ -853,6 +889,11 @@ def list_partial_gguf_variants_from_state(
             for expected in manifest.expected_files:
                 if not is_gguf_filename(expected.path):
                     continue
+                if is_imatrix_filename(expected.path):
+                    # A manifest written before imatrix filtering can still name one;
+                    # it is neither the variant's weights nor a companion fetched with
+                    # them, so it counts towards neither size.
+                    continue
                 if is_mtp_drafter_path(expected.path):
                     # Downloaded with every variant (like mmproj) but not a
                     # selectable quant; count it so the shown download size
@@ -972,7 +1013,7 @@ def list_gguf_variants(
             continue
         if not _is_selectable_repo_gguf(repo_id, filename):
             continue
-        if is_mtp_drafter_path(filename):
+        if is_mtp_drafter_path(filename) or is_imatrix_filename(filename):
             continue
         if is_mmproj_filename(filename):
             has_vision = True
@@ -1037,6 +1078,8 @@ def list_local_gguf_variants(
 
     for file in sorted(iter_gguf_files(root, recursive = True)):
         if h3_bundle_repo and not _is_selectable_repo_gguf(h3_bundle_repo, file.name):
+            continue
+        if is_imatrix_filename(file.name):
             continue
         if is_mmproj_filename(file.name):
             # An empty projector is an interrupted download; an audio-only one is not vision.

--- a/studio/backend/hub/utils/gguf.py
+++ b/studio/backend/hub/utils/gguf.py
@@ -89,31 +89,23 @@ def is_mmproj_filename(filename: str) -> bool:
     return "mmproj" in filename.lower()
 
 
-# Calibration importance matrices published beside the weights. Unsloth ships
-# imatrix_unsloth.dat and imatrix_unsloth.gguf_file, whose suffixes keep them out
-# of a GGUF listing, but some repos publish the same file as imatrix_unsloth.gguf
-# (unsloth/Qwen3.8-27B-GGUF) and it then reaches every GGUF path as if it were
-# weights: the variant menu grew a ~13 MB row labelled "GGUF", since the quant
-# extractor finds no token in the name.
-#
-# An imatrix holds per-tensor activation statistics, not a model. llama-quantize
-# reads one at QUANTIZE time and llama-server never opens it, so it is neither a
-# selectable variant nor a companion to fetch -- unlike mmproj and the MTP
-# drafter, it is excluded outright.
-#
 # Anchored at an END of the stem, never a substring, for the reason
-# is_mtp_drafter_path documents: a name that merely contains the word (a
-# hypothetical ``Qwen3-Imatrix-Tuned-Q4_K_M.gguf``) is a real model, while every
-# published imatrix leads or closes with it -- ``imatrix.gguf``,
-# ``imatrix_unsloth.gguf``, ``<model>-imatrix.gguf``, ``<model>.imatrix``.
+# is_mtp_drafter_path documents: a name that merely contains the word
+# (``Qwen3-Imatrix-Tuned-Q4_K_M.gguf``) is a real model, while every published
+# imatrix leads or closes with it.
 _IMATRIX_TOKEN_RE = re.compile(r"^imatrix(?:[._\-]|$)|[._\-]imatrix$", re.IGNORECASE)
 
 
 def is_imatrix_filename(path: str) -> bool:
-    """True for a calibration imatrix, in any of the suffixes repos publish it under.
+    """True for a calibration imatrix: ``imatrix.gguf``, ``imatrix_unsloth.gguf``,
+    ``imatrix_unsloth.dat``, ``<model>-imatrix.gguf``, ``<model>.imatrix``.
 
-    Must be excluded everywhere mmproj is, or the imatrix is advertised as a quant,
-    downloaded as weights and, being a valid GGUF container, handed to the loader.
+    It holds activation statistics for llama-quantize, not a model, and llama-server
+    never opens one, so it is neither a selectable variant nor a companion to fetch:
+    unlike mmproj and the MTP drafter it is excluded outright, everywhere they are.
+    Most repos spell it .dat or .gguf_file, which no GGUF listing sees; the ones that
+    publish imatrix_unsloth.gguf (unsloth/Qwen3.8-27B-GGUF) put a valid GGUF container
+    carrying no model in front of the variant menu, download and loader.
 
     CANONICAL COPY. Two mirrors must change in lockstep:
     utils/models/model_config.py ``_is_imatrix_path`` (utils cannot import hub) and
@@ -890,9 +882,8 @@ def list_partial_gguf_variants_from_state(
                 if not is_gguf_filename(expected.path):
                     continue
                 if is_imatrix_filename(expected.path):
-                    # A manifest written before imatrix filtering can still name one;
-                    # it is neither the variant's weights nor a companion fetched with
-                    # them, so it counts towards neither size.
+                    # A manifest predating this filtering can still name one; it is
+                    # neither weights nor a companion, so it counts towards neither size.
                     continue
                 if is_mtp_drafter_path(expected.path):
                     # Downloaded with every variant (like mmproj) but not a

--- a/studio/backend/hub/utils/gguf_plan.py
+++ b/studio/backend/hub/utils/gguf_plan.py
@@ -15,6 +15,7 @@ from hub.utils.gguf import (
     is_big_endian_gguf_path,
     drop_shadowed_appledouble_siblings,
     is_gguf_filename,
+    is_imatrix_filename,
     is_mmproj_filename,
     is_mtp_drafter_path,
 )
@@ -82,6 +83,7 @@ def is_main_gguf_variant_path(path: str, variant: str) -> bool:
         is_gguf_filename(path)
         and not is_mmproj_filename(path)
         and not is_mtp_drafter_path(path)
+        and not is_imatrix_filename(path)
         # The endian predicate reads a quant TOKEN, so it gets the label: handed the qualified key
         # it cannot see a parent-only quant and drops the file, leaving the plan with no main
         # files at all and an interrupted download with no hashes to resume against.
@@ -243,7 +245,9 @@ def build_gguf_variant_plans(siblings: Sequence) -> dict[str, GgufVariantPlan]:
         # Companions are folded into every plan below; keep them out of the
         # quant grouping so a drafter never lands in a variant's main files
         # (the root mtp-*.gguf carries a quant label, e.g. Q8_0).
-        if is_mmproj_filename(name) or is_mtp_drafter_path(name):
+        # An imatrix leaves entirely rather than joining companions_expected: it is
+        # calibration data for llama-quantize, so no variant needs it downloaded.
+        if is_mmproj_filename(name) or is_mtp_drafter_path(name) or is_imatrix_filename(name):
             continue
         quant = gguf_variant_key(name).lower()
         # The endian predicate reads a quant TOKEN -- it decides whether the quant came from the

--- a/studio/backend/hub/utils/gguf_plan.py
+++ b/studio/backend/hub/utils/gguf_plan.py
@@ -245,8 +245,8 @@ def build_gguf_variant_plans(siblings: Sequence) -> dict[str, GgufVariantPlan]:
         # Companions are folded into every plan below; keep them out of the
         # quant grouping so a drafter never lands in a variant's main files
         # (the root mtp-*.gguf carries a quant label, e.g. Q8_0).
-        # An imatrix leaves entirely rather than joining companions_expected: it is
-        # calibration data for llama-quantize, so no variant needs it downloaded.
+        # An imatrix leaves entirely rather than joining companions_expected: no
+        # variant needs llama-quantize's calibration data downloaded.
         if is_mmproj_filename(name) or is_mtp_drafter_path(name) or is_imatrix_filename(name):
             continue
         quant = gguf_variant_key(name).lower()

--- a/studio/backend/hub/utils/inventory_scan.py
+++ b/studio/backend/hub/utils/inventory_scan.py
@@ -32,6 +32,7 @@ from hub.utils.gguf import (
     gguf_variant_key,
     is_big_endian_gguf_path,
     is_gguf_filename,
+    is_imatrix_filename,
     is_mmproj_filename,
     is_mtp_drafter_path,
 )
@@ -783,7 +784,12 @@ def _completed_gguf_variants(snapshot_dir: Optional[Path]) -> set[str]:
         except OSError:
             continue
         rel = path.relative_to(snapshot_dir).as_posix()
-        if not is_gguf_filename(rel) or is_mmproj_filename(rel) or is_mtp_drafter_path(rel):
+        if (
+            not is_gguf_filename(rel)
+            or is_mmproj_filename(rel)
+            or is_mtp_drafter_path(rel)
+            or is_imatrix_filename(rel)
+        ):
             continue
         # Metadata vouching for a quant marks a torn snapshot ready: a set whose sidecars are
         # all present but whose weights are not answers the shard count exactly as the real

--- a/studio/backend/tests/test_imatrix_gguf_filtering.py
+++ b/studio/backend/tests/test_imatrix_gguf_filtering.py
@@ -27,6 +27,7 @@ from hub.utils.gguf import (
     is_imatrix_filename,
     list_gguf_variants,
     list_local_gguf_variants,
+    list_partial_gguf_variants_from_state,
     pick_best_gguf,
 )
 from hub.utils.gguf_plan import build_gguf_variant_plans, is_main_gguf_variant_path
@@ -121,6 +122,59 @@ def test_local_listing_and_load_path_skip_the_imatrix(tmp_path):
     assert detect_gguf_model(os.fspath(tmp_path)) == os.fspath(
         tmp_path / "Qwen3.8-27B-UD-Q4_K_XL.gguf"
     )
+
+
+def _state_sources(monkeypatch, manifests, markers, manifest_for):
+    from hub.utils import download_manifest
+
+    monkeypatch.setattr(
+        download_manifest,
+        "iter_variant_manifests",
+        lambda *_a, **_k: iter([(v, Path(f"{v}.json")) for v in manifests]),
+    )
+    monkeypatch.setattr(
+        download_manifest,
+        "iter_variant_markers",
+        lambda *_a, **_k: iter([(v, Path(f"{v}.marker")) for v in markers]),
+    )
+    monkeypatch.setattr(
+        download_manifest, "read_manifest", lambda _t, _r, variant, **_k: manifest_for(variant)
+    )
+
+
+def test_interrupted_imatrix_state_does_not_come_back_as_a_row(monkeypatch):
+    # An older build offered the imatrix as a variant, so a cancelled download of it can
+    # still be on disk. Skipping only its expected file left main_filename unset, and the
+    # synthetic "<variant>.gguf" fallback put the row back at zero bytes on exactly the
+    # offline path this listing serves.
+    manifest = SimpleNamespace(
+        expected_files = [SimpleNamespace(path = "imatrix_unsloth.gguf", size = 13_642_656)]
+    )
+    _state_sources(
+        monkeypatch,
+        manifests = ["imatrix_unsloth"],
+        markers = [],
+        manifest_for = lambda _variant: manifest,
+    )
+
+    variants, _has_vision = list_partial_gguf_variants_from_state("unsloth/Qwen3.8-27B-GGUF")
+    assert variants == []
+
+
+def test_a_marker_only_imatrix_variant_is_dropped_but_a_real_quant_survives(monkeypatch):
+    # A cancel marker carries no manifest at all, so the filtered-file check above cannot
+    # see it; the stored variant key is the only evidence. A real quant in the same state
+    # must keep its synthetic row, or an interrupted download becomes unresumable.
+    _state_sources(
+        monkeypatch,
+        manifests = [],
+        markers = ["imatrix_unsloth", "UD-Q4_K_XL"],
+        manifest_for = lambda _variant: None,
+    )
+
+    variants, _has_vision = list_partial_gguf_variants_from_state("unsloth/Qwen3.8-27B-GGUF")
+    assert [v.quant for v in variants] == ["UD-Q4_K_XL"]
+    assert variants[0].filename == "UD-Q4_K_XL.gguf"
 
 
 def test_an_imatrix_only_folder_offers_no_model(tmp_path):

--- a/studio/backend/tests/test_imatrix_gguf_filtering.py
+++ b/studio/backend/tests/test_imatrix_gguf_filtering.py
@@ -1,0 +1,130 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""A calibration imatrix is not a model, so no GGUF surface may offer one.
+
+unsloth/Qwen3.8-27B-GGUF publishes imatrix_unsloth.gguf beside the weights (most
+repos use the .dat / .gguf_file spellings the Hub does not list as GGUF). Carrying
+a real .gguf suffix, it reached the chat model picker as an unlabelled ~13 MB row
+called "GGUF", downloadable and then unloadable.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+_BACKEND_DIR = str(Path(__file__).resolve().parent.parent)
+if _BACKEND_DIR not in sys.path:
+    sys.path.insert(0, _BACKEND_DIR)
+
+from core.inference.llama_cpp import _is_companion_gguf_path
+from hub.utils.gguf import (
+    is_imatrix_filename,
+    list_gguf_variants,
+    list_local_gguf_variants,
+    pick_best_gguf,
+)
+from hub.utils.gguf_plan import build_gguf_variant_plans, is_main_gguf_variant_path
+from utils.models.model_config import _is_imatrix_path, detect_gguf_model
+
+IMATRIX_NAMES = [
+    "imatrix_unsloth.gguf",
+    "imatrix_unsloth.dat",
+    "imatrix_unsloth.gguf_file",
+    "imatrix.gguf",
+    "IMATRIX_UNSLOTH.GGUF",
+    "Qwen3.8-27B.imatrix",
+    "Qwen3.8-27B-imatrix.gguf",
+    "quants/imatrix_unsloth.gguf",
+]
+
+MODEL_NAMES = [
+    "Qwen3.8-27B-UD-Q4_K_XL.gguf",
+    "BF16/Qwen3.8-27B-BF16-00001-of-00002.gguf",
+    # The word inside a name is not the file: only a leading or trailing token is.
+    "Qwen3-Imatrix-Tuned-Q4_K_M.gguf",
+    "imatrixed-model-Q8_0.gguf",
+]
+
+
+@pytest.mark.parametrize("name", IMATRIX_NAMES)
+def test_every_published_imatrix_spelling_is_recognized(name):
+    assert is_imatrix_filename(name)
+    assert _is_imatrix_path(name)
+
+
+@pytest.mark.parametrize("name", MODEL_NAMES)
+def test_real_weights_are_not_mistaken_for_an_imatrix(name):
+    assert not is_imatrix_filename(name)
+    assert not _is_imatrix_path(name)
+
+
+@pytest.mark.parametrize("name", IMATRIX_NAMES + MODEL_NAMES)
+def test_the_three_copies_of_the_predicate_agree(name):
+    # hub cannot be imported from utils and core avoids importing it, so the rule is
+    # spelled three times; a drift here is a file one surface hides and another loads.
+    expected = is_imatrix_filename(name)
+    assert _is_imatrix_path(name) is expected
+    if name.lower().endswith(".gguf"):
+        assert _is_companion_gguf_path(name) is expected
+
+
+def test_remote_listing_drops_the_imatrix_row(monkeypatch):
+    info = SimpleNamespace(
+        siblings = [
+            SimpleNamespace(rfilename = "Qwen3.8-27B-UD-Q4_K_XL.gguf", size = 17_559_178_144),
+            SimpleNamespace(rfilename = "imatrix_unsloth.gguf", size = 13_642_656),
+        ]
+    )
+    api = SimpleNamespace(model_info = lambda *a, **k: info)
+    monkeypatch.setattr("huggingface_hub.HfApi", lambda token = None: api)
+
+    variants, _has_vision, _siblings = list_gguf_variants("unsloth/Qwen3.8-27B-GGUF")
+    assert [v.quant for v in variants] == ["UD-Q4_K_XL"]
+
+
+def test_the_imatrix_is_neither_planned_nor_downloaded():
+    siblings = [
+        SimpleNamespace(rfilename = "Qwen3.8-27B-UD-Q4_K_XL.gguf", size = 17_559_178_144),
+        SimpleNamespace(rfilename = "imatrix_unsloth.gguf", size = 13_642_656),
+    ]
+    plans = build_gguf_variant_plans(siblings)
+
+    assert list(plans) == ["ud-q4_k_xl"]
+    plan = plans["ud-q4_k_xl"]
+    # Not a main file and not a companion folded into the plan: llama-quantize reads an
+    # imatrix, llama-server never does, so no variant needs it on disk.
+    assert plan.target_filenames == ("Qwen3.8-27B-UD-Q4_K_XL.gguf",)
+    assert plan.download_size_bytes == 17_559_178_144
+    assert not is_main_gguf_variant_path("imatrix_unsloth.gguf", "ud-q4_k_xl")
+
+
+def test_local_listing_and_load_path_skip_the_imatrix(tmp_path):
+    (tmp_path / "Qwen3.8-27B-UD-Q4_K_XL.gguf").write_bytes(b"GGUF" + b"0" * 64)
+    imatrix = tmp_path / "imatrix_unsloth.gguf"
+    imatrix.write_bytes(b"GGUF" + b"0" * 8)
+    (tmp_path / "config.json").write_text("{}", encoding = "utf-8")
+
+    variants, _has_vision = list_local_gguf_variants(os.fspath(tmp_path))
+    assert [v.quant for v in variants] == ["UD-Q4_K_XL"]
+
+    assert pick_best_gguf(["imatrix_unsloth.gguf", "Qwen3.8-27B-UD-Q4_K_XL.gguf"]) == (
+        "Qwen3.8-27B-UD-Q4_K_XL.gguf"
+    )
+    # Pointed at directly it is not a model either, so a folder scan cannot route it.
+    assert detect_gguf_model(os.fspath(imatrix)) is None
+    assert detect_gguf_model(os.fspath(tmp_path)) == os.fspath(
+        tmp_path / "Qwen3.8-27B-UD-Q4_K_XL.gguf"
+    )
+
+
+def test_an_imatrix_only_folder_offers_no_model(tmp_path):
+    (tmp_path / "imatrix_unsloth.gguf").write_bytes(b"GGUF" + b"0" * 8)
+
+    assert list_local_gguf_variants(os.fspath(tmp_path)) == ([], False)
+    assert detect_gguf_model(os.fspath(tmp_path)) is None

--- a/studio/backend/utils/models/model_config.py
+++ b/studio/backend/utils/models/model_config.py
@@ -1482,13 +1482,11 @@ def _is_imatrix_path(path: str) -> bool:
     """True for a calibration imatrix published beside the weights
     (``imatrix_unsloth.gguf``, ``imatrix.gguf``, ``<model>.imatrix``).
 
-    It holds activation statistics for llama-quantize, not a model, so it must be
-    excluded everywhere mmproj is: a GGUF-suffixed one is a valid container that
-    a size-ranked scan would otherwise hand to llama-server.
+    Activation statistics for llama-quantize, not a model, so it is excluded
+    everywhere mmproj is: a GGUF-suffixed one is a valid container that a
+    size-ranked scan would otherwise hand to llama-server.
 
-    Mirrors hub.utils.gguf.is_imatrix_filename. Anchored at an end of the stem,
-    never a substring, so a real model whose name contains the word stays
-    selectable.
+    Mirrors hub.utils.gguf.is_imatrix_filename.
     """
     name = path.replace("\\", "/").rsplit("/", 1)[-1]
     stem = name.rsplit(".", 1)[0] if "." in name else name

--- a/studio/backend/utils/models/model_config.py
+++ b/studio/backend/utils/models/model_config.py
@@ -1474,6 +1474,27 @@ def _is_mmproj(filename: str) -> bool:
     return "mmproj" in filename.lower()
 
 
+# Mirrors hub.utils.gguf._IMATRIX_TOKEN_RE (utils cannot import hub).
+_IMATRIX_TOKEN_RE = re.compile(r"^imatrix(?:[._\-]|$)|[._\-]imatrix$", re.IGNORECASE)
+
+
+def _is_imatrix_path(path: str) -> bool:
+    """True for a calibration imatrix published beside the weights
+    (``imatrix_unsloth.gguf``, ``imatrix.gguf``, ``<model>.imatrix``).
+
+    It holds activation statistics for llama-quantize, not a model, so it must be
+    excluded everywhere mmproj is: a GGUF-suffixed one is a valid container that
+    a size-ranked scan would otherwise hand to llama-server.
+
+    Mirrors hub.utils.gguf.is_imatrix_filename. Anchored at an end of the stem,
+    never a substring, so a real model whose name contains the word stays
+    selectable.
+    """
+    name = path.replace("\\", "/").rsplit("/", 1)[-1]
+    stem = name.rsplit(".", 1)[0] if "." in name else name
+    return bool(_IMATRIX_TOKEN_RE.search(stem)) or name.lower().endswith(".imatrix")
+
+
 # Mirrors hub.utils.gguf._DRAFTER_KINDS. dflash/ holds real weights, so it is a drafter by prefix only.
 _DRAFTER_KINDS = ("mtp", "dspark", "dflash")
 _DRAFTER_DIR_KINDS = ("mtp", "dspark")
@@ -2207,6 +2228,7 @@ def detect_gguf_model(path: str, model_root: Optional[str] = None) -> Optional[s
         if (
             _is_mmproj(p.name)
             or _is_local_mtp_drafter(p, root, rel)
+            or _is_imatrix_path(p.name)
             or _is_big_endian_gguf_path(rel, quant)
             # Pointed at directly, a sidecar bypasses the scan that would have skipped it.
             # Identified positively so an unreadable file still reaches the lock window below.
@@ -2231,6 +2253,7 @@ def detect_gguf_model(path: str, model_root: Optional[str] = None) -> Optional[s
             if (
                 _is_mmproj(f.name)
                 or _is_local_mtp_drafter(f, root, context_rel)
+                or _is_imatrix_path(f.name)
                 or _is_big_endian_gguf_path(context_rel, quant)
             ):
                 continue
@@ -2734,6 +2757,10 @@ def list_gguf_variants(
         # MTP drafters are speculative-decoding companions, not quants.
         if _is_mtp_drafter(fname):
             continue
+        # An imatrix is calibration data, not a quant: listed, it becomes an
+        # unlabelled ~13 MB row (unsloth/Qwen3.8-27B-GGUF ships imatrix_unsloth.gguf).
+        if _is_imatrix_path(fname):
+            continue
 
         label = _extract_quant_label(fname)
         if _is_big_endian_gguf_path(fname, label):
@@ -2825,6 +2852,8 @@ def list_local_gguf_variants(
     # Recurse so variant-specific subdirs (``BF16/...gguf``) are picked up. Result filenames
     # keep the relative subpath so ``_find_local_gguf_by_variant`` can locate the file again.
     for f in sorted(_iter_gguf_files(p, recursive = True)):
+        if _is_imatrix_path(f.name):
+            continue
         if _is_mmproj(f.name):
             has_vision = True
             continue
@@ -2924,7 +2953,7 @@ def _find_local_gguf_by_variant(
     owned = []
     for f in _iter_gguf_files(p, recursive = True):
         rel = f.relative_to(p).as_posix()
-        if _is_mmproj(f.name) or _is_local_mtp_drafter(f, root, rel):
+        if _is_mmproj(f.name) or _is_local_mtp_drafter(f, root, rel) or _is_imatrix_path(f.name):
             continue
         quant = _extract_quant_label(rel)
         fallback_variant = re.sub(r"-\d{3,}-of-\d{3,}$", "", rel.rsplit(".", 1)[0])
@@ -2966,7 +2995,12 @@ def _detect_gguf_from_hf_cache(repo_id: str) -> Optional[str]:
         for f in _iter_gguf_files(snap, recursive = True):
             rel = f.relative_to(snap).as_posix()
             quant = _extract_quant_label(rel)
-            if _is_mmproj(f.name) or _is_mtp_drafter(rel) or _is_big_endian_gguf_path(rel, quant):
+            if (
+                _is_mmproj(f.name)
+                or _is_mtp_drafter(rel)
+                or _is_imatrix_path(f.name)
+                or _is_big_endian_gguf_path(rel, quant)
+            ):
                 continue
             rel_files.append(rel)
         if rel_files:
@@ -3000,6 +3034,7 @@ def detect_gguf_model_remote(repo_id: str, hf_token: Optional[str] = None) -> Op
                 if (
                     _is_mmproj(fname)
                     or _is_mtp_drafter(fname)
+                    or _is_imatrix_path(fname)
                     or _is_big_endian_gguf_path(fname, quant)
                 ):
                     continue
@@ -3249,8 +3284,13 @@ def scan_exported_models(
             if not run_dir.is_dir():
                 continue
 
-            # Flat GGUF export (exports/...-gguf/); mmproj files aren't loadable as main models.
-            gguf_files = [f for f in _iter_gguf_files(run_dir) if not _is_mmproj(f.name)]
+            # Flat GGUF export (exports/...-gguf/); neither mmproj files nor the imatrix an
+            # imatrix export leaves beside the weights are loadable as main models.
+            gguf_files = [
+                f
+                for f in _iter_gguf_files(run_dir)
+                if not _is_mmproj(f.name) and not _is_imatrix_path(f.name)
+            ]
             if gguf_files:
                 base_model = None
                 export_meta = run_dir / "export_metadata.json"


### PR DESCRIPTION
### The bug

Searching the chat model picker for `https://huggingface.co/unsloth/Qwen3.8-27B-GGUF/tree/main` returns one row that is not a model: a ~13 MB entry labelled just **GGUF**. It is [`imatrix_unsloth.gguf`](https://huggingface.co/unsloth/Qwen3.8-27B-GGUF/blob/main/imatrix_unsloth.gguf), the repo's calibration importance matrix.

Most of our GGUF repos publish it as `imatrix_unsloth.dat` or `imatrix_unsloth.gguf_file`, and neither suffix reaches a GGUF listing. Some repos publish the same file as a plain `.gguf` (`unsloth/Qwen3.8-27B-GGUF`, `unsloth/Qwen3.5-122B-A10B-GGUF`), and there it flowed through every GGUF surface as if it were weights. The quant extractor finds no quant token in `imatrix_unsloth`, so the row falls back to the bare "GGUF" label, and it is offered for download and then fails to load.

Reproduced before the fix:

```
GgufVariantInfo(filename='Qwen3.8-27B-UD-IQ1_S.gguf',  quant='UD-IQ1_S',        size_bytes=6192222208)
GgufVariantInfo(filename='imatrix_unsloth.gguf',       quant='imatrix_unsloth', size_bytes=13642656, display_label='GGUF')
```

### The fix

An imatrix holds per-tensor activation statistics for `llama-quantize`. `llama-server` never opens one, so it is not a selectable variant and, unlike mmproj or the MTP drafter, not a companion worth fetching either: it is excluded outright.

`is_imatrix_filename` joins `is_mmproj_filename` / `is_mtp_drafter_path` in `hub/utils/gguf.py` and is applied everywhere they are:

- remote and local variant listings, `pick_best_gguf`, and the manifest-based partial listing
- download plans (`build_gguf_variant_plans`, `is_main_gguf_variant_path`), so no plan fetches one and the advertised download size does not include it
- the HF cache blob map, inventory scan and snapshot readiness checks
- `detect_gguf_model` and the local/remote best-GGUF picks in `model_config.py`, so a folder holding one cannot route it as the main model, including the copy an imatrix export leaves in `exports/`
- the diffusion LoRA file pick, where a `.gguf` was the last-resort candidate
- deletion: a copy an older build already fetched as a variant is reclaimed with the repo's last variant, since nothing can reach it from the UI any more

The rule is spelled three times (hub, `utils/models/model_config.py`, `core/inference/llama_cpp.py`) because utils cannot import hub and core avoids it, matching how the mmproj and MTP predicates are already mirrored. A test asserts the three copies agree on every name.

Matching is anchored at a leading or trailing stem token, never a substring, so every published spelling is caught (`imatrix.gguf`, `imatrix_unsloth.gguf`, `imatrix_unsloth.gguf_file`, `<model>-imatrix.gguf`, `<model>.imatrix`) while a real model whose name happens to contain the word (`Qwen3-Imatrix-Tuned-Q4_K_M.gguf`) stays selectable.

After the fix the same repo lists 25 rows, all of them real quants, with no imatrix entry.

### Tests

New `studio/backend/tests/test_imatrix_gguf_filtering.py` (28 cases): every published spelling recognised, real weights untouched, the three predicate copies in agreement, and the imatrix absent from the remote listing, the local listing, the download plan and `detect_gguf_model`.

`ruff check studio` passes. The GGUF, model, inventory, download, deletion, variant, quant, export, MTP, mmproj and LoRA suites run 4306 passed; the 12 remaining failures are pre-existing torchao/diffusers environment mismatches on this box and fail identically on `main`.
