### PR TITLE
Exclude the imatrix from the local models route too

### DIFF
--- a/studio/backend/core/inference/diffusion_lora.py
+++ b/studio/backend/core/inference/diffusion_lora.py
@@ -276,14 +276,7 @@ def _pick_repo_weight_file(repo_id: str, hf_token: Optional[str]) -> str:
 
     from hub.utils.gguf import drop_shadowed_appledouble_names, is_imatrix_filename
 
-    files = [
-        f
-        for f in drop_shadowed_appledouble_names(
-            list(HfApi(token = hf_token).list_repo_files(repo_id))
-        )
-        # An imatrix is not adapter weights, and it would be the fallback pick below.
-        if not is_imatrix_filename(f)
-    ]
+    files = drop_shadowed_appledouble_names(list(HfApi(token = hf_token).list_repo_files(repo_id)))
     safes = [f for f in files if f.lower().endswith(".safetensors") and "/" not in f]
     if len(safes) == 1:
         return safes[0]
@@ -293,7 +286,13 @@ def _pick_repo_weight_file(repo_id: str, hf_token: Optional[str]) -> str:
             return f
     if safes:
         return safes[0]
-    ggufs = [f for f in files if f.lower().endswith(".gguf") and "/" not in f]
+    # The gguf fallback only: an imatrix is a .gguf holding no adapter, and it would be
+    # picked here. A .safetensors is never one, so the candidates above stay untouched.
+    ggufs = [
+        f
+        for f in files
+        if f.lower().endswith(".gguf") and "/" not in f and not is_imatrix_filename(f)
+    ]
     if ggufs:
         return ggufs[0]
     raise FileNotFoundError(f"no .safetensors/.gguf LoRA file found in '{repo_id}'")

--- a/studio/backend/core/inference/diffusion_lora.py
+++ b/studio/backend/core/inference/diffusion_lora.py
@@ -286,8 +286,8 @@ def _pick_repo_weight_file(repo_id: str, hf_token: Optional[str]) -> str:
             return f
     if safes:
         return safes[0]
-    # The gguf fallback only: an imatrix is a .gguf holding no adapter, and it would be
-    # picked here. A .safetensors is never one, so the candidates above stay untouched.
+    # The gguf fallback only: an imatrix is a .gguf holding no adapter and would be picked
+    # here, while a .safetensors is never one, so the candidates above stay untouched.
     ggufs = [
         f
         for f in files

--- a/studio/backend/routes/models.py
+++ b/studio/backend/routes/models.py
@@ -1365,7 +1365,12 @@ def _dir_has_downloaded_model(directory: Path, max_entries: int = 4000) -> bool:
                     low = entry.name.lower()
                     if is_appledouble_metadata(entry):
                         continue
-                    if low.endswith((".gguf", ".safetensors")):
+                    # An imatrix is calibration data, and the scanners no longer surface a
+                    # folder holding only that, so counting it here would advertise a chip
+                    # whose folder opens an empty picker -- the mirror this helper keeps.
+                    if low.endswith(".gguf") and not _is_imatrix_path(entry.name):
+                        return True
+                    if low.endswith(".safetensors"):
                         return True
                     # PyTorch checkpoints; gate by name so tokenizer.bin and friends don't count as weights.
                     if _is_weight_bin(entry.name):

--- a/studio/backend/routes/models.py
+++ b/studio/backend/routes/models.py
@@ -323,10 +323,9 @@ def _local_pipeline_index(d: Path) -> bool:
 def _servable_gguf_names(directory: Path) -> list[str]:
     """The ``.gguf`` names in *directory* that count as a model being present there.
 
-    An imatrix is calibration data for llama-quantize, not a model artifact, so it must
-    not make an otherwise empty folder look like one. mmproj and MTP drafters DO count:
-    they are real companions of a model, and the scanners let them decide presence but
-    never format (``model_format`` still asks ``_is_main_gguf_filename``).
+    An imatrix is calibration data, not a model artifact, so it must not make an empty
+    folder look like one. mmproj and MTP drafters DO count: they are companions of a real
+    model, and presence is all they decide (format still asks _is_main_gguf_filename).
     """
     return [
         p.name
@@ -1365,9 +1364,8 @@ def _dir_has_downloaded_model(directory: Path, max_entries: int = 4000) -> bool:
                     low = entry.name.lower()
                     if is_appledouble_metadata(entry):
                         continue
-                    # An imatrix is calibration data, and the scanners no longer surface a
-                    # folder holding only that, so counting it here would advertise a chip
-                    # whose folder opens an empty picker -- the mirror this helper keeps.
+                    # The scanners no longer surface an imatrix-only folder, so counting
+                    # one here would advertise a chip that opens an empty picker.
                     if low.endswith(".gguf") and not _is_imatrix_path(entry.name):
                         return True
                     if low.endswith(".safetensors"):

--- a/studio/backend/routes/models.py
+++ b/studio/backend/routes/models.py
@@ -145,6 +145,7 @@ try:
     from utils.models.model_config import (
         _extract_quant_label,
         _is_big_endian_gguf_path,
+        _is_imatrix_path,
         _is_mtp_drafter,
         is_audio_input_type,
     )
@@ -177,6 +178,7 @@ except ImportError:
     from utils.models.model_config import (
         _extract_quant_label,
         _is_big_endian_gguf_path,
+        _is_imatrix_path,
         _is_mtp_drafter,
         is_audio_input_type,
     )
@@ -248,9 +250,9 @@ def _is_model_directory(d: Path) -> bool:
     """Return ``True`` when *d* looks like a model directory.
 
     Requires both a config (``config.json``/``adapter_config.json``) and
-    weight files. Excludes ``mmproj`` GGUFs (vision projectors) and
-    non-weight ``.bin`` files (``tokenizer.bin`` etc.) to avoid false
-    positives.
+    weight files. Excludes ``mmproj`` GGUFs (vision projectors), calibration
+    imatrices and non-weight ``.bin`` files (``tokenizer.bin`` etc.) to avoid
+    false positives.
     """
 
     def _is_weight_file(f: Path) -> bool:
@@ -260,7 +262,7 @@ def _is_model_directory(d: Path) -> bool:
         if suffix == ".safetensors":
             return True
         if suffix == ".gguf":
-            return "mmproj" not in f.name.lower()
+            return "mmproj" not in f.name.lower() and not _is_imatrix_path(f.name)
         if suffix == ".bin":
             name = f.name.lower()
             return (
@@ -3760,9 +3762,15 @@ def _is_mmproj_filename(name: str) -> bool:
 
 
 def _is_main_gguf_filename(name: str) -> bool:
-    """A primary GGUF weight, not an mmproj vision adapter or an MTP drafter. Same rule as
-    ``hub.services.models.common``; pass a snapshot-relative path to catch ``MTP/`` copies too."""
-    return _is_gguf_filename(name) and not _is_mmproj_filename(name) and not _is_mtp_drafter(name)
+    """A primary GGUF weight, not an mmproj vision adapter, an MTP drafter or a calibration
+    imatrix. Same rule as ``hub.services.models.common``; pass a snapshot-relative path to
+    catch ``MTP/`` copies too."""
+    return (
+        _is_gguf_filename(name)
+        and not _is_mmproj_filename(name)
+        and not _is_mtp_drafter(name)
+        and not _is_imatrix_path(name)
+    )
 
 
 def _recovered_repo_is_unusable_by_repo_id(repo_info) -> bool:

--- a/studio/backend/routes/models.py
+++ b/studio/backend/routes/models.py
@@ -320,6 +320,21 @@ def _local_pipeline_index(d: Path) -> bool:
         return False
 
 
+def _servable_gguf_names(directory: Path) -> list[str]:
+    """The ``.gguf`` names in *directory* that count as a model being present there.
+
+    An imatrix is calibration data for llama-quantize, not a model artifact, so it must
+    not make an otherwise empty folder look like one. mmproj and MTP drafters DO count:
+    they are real companions of a model, and the scanners let them decide presence but
+    never format (``model_format`` still asks ``_is_main_gguf_filename``).
+    """
+    return [
+        p.name
+        for p in directory.glob("*.gguf")
+        if not is_appledouble_metadata(p) and not _is_imatrix_path(p.name)
+    ]
+
+
 def _is_gguf_companion_only_dir(path: Path) -> bool:
     """True for a folder whose entire content is GGUF companions -- a lone mmproj adapter, an
     MTP drafter, or both -- with nothing servable beside them.
@@ -370,7 +385,7 @@ def _scan_models_dir(models_dir: Path, *, limit: int | None = None) -> List[Loca
             if not child.is_dir():
                 continue
 
-            gguf_names = [p.name for p in child.glob("*.gguf") if not is_appledouble_metadata(p)]
+            gguf_names = _servable_gguf_names(child)
             has_gguf = bool(gguf_names)
             # mmproj alone is a vision adapter, not servable weights: decides presence, never format.
             has_main_gguf = any(_is_main_gguf_filename(n) for n in gguf_names)
@@ -621,7 +636,7 @@ def _scan_lmstudio_dir(lm_dir: Path) -> List[LocalModelInfo]:
                 try:
                     if model_dir.is_dir():
                         has_model = (
-                            any(not is_appledouble_metadata(p) for p in model_dir.glob("*.gguf"))
+                            bool(_servable_gguf_names(model_dir))
                             or (model_dir / "config.json").exists()
                             or any(
                                 not is_appledouble_metadata(p)

--- a/studio/backend/tests/test_imatrix_gguf_filtering.py
+++ b/studio/backend/tests/test_imatrix_gguf_filtering.py
@@ -143,6 +143,35 @@ def test_the_local_models_route_does_not_list_an_imatrix(tmp_path):
     assert _dir_model_format(tmp_path) == "gguf"
 
 
+def test_a_downloaded_imatrix_is_not_a_downloaded_gguf_repo(tmp_path):
+    # The surface a user who already clicked the old phantom row lands on: the imatrix is
+    # in the HF cache, and the Downloaded list sizes a repo with the same routes/models.py
+    # predicate, so the repo came back as a ~13 MB GGUF download it could not load.
+    from huggingface_hub import scan_cache_dir
+
+    from routes.models import _repo_gguf_size_bytes, _repo_has_gguf_files
+
+    repo_id = "unsloth/Qwen3.8-27B-GGUF"
+    sha = "a" * 40
+    repo_dir = tmp_path / f"models--{repo_id.replace('/', '--')}"
+    blobs = repo_dir / "blobs"
+    blobs.mkdir(parents = True)
+    (repo_dir / "refs").mkdir(parents = True)
+    (repo_dir / "refs" / "main").write_text(sha, encoding = "utf-8")
+    snapshot = repo_dir / "snapshots" / sha
+    snapshot.mkdir(parents = True)
+    blob = blobs / ("0" * 40)
+    blob.write_bytes(b"GGUF" + b"\0" * 13_642_656)
+    try:
+        (snapshot / "imatrix_unsloth.gguf").symlink_to(blob)
+    except OSError as exc:
+        pytest.skip(f"symlinks unavailable: {exc}")
+
+    cached = next(r for r in scan_cache_dir(tmp_path).repos if r.repo_id == repo_id)
+    assert _repo_gguf_size_bytes(cached) == 0
+    assert _repo_has_gguf_files(cached) is False
+
+
 def test_a_lora_repo_weight_named_like_an_imatrix_is_still_picked(monkeypatch):
     # The exclusion belongs to the .gguf fallback: an imatrix is a GGUF holding no
     # adapter. Applied to the whole listing it also dropped .safetensors candidates,

--- a/studio/backend/tests/test_imatrix_gguf_filtering.py
+++ b/studio/backend/tests/test_imatrix_gguf_filtering.py
@@ -143,6 +143,54 @@ def test_the_local_models_route_does_not_list_an_imatrix(tmp_path):
     assert _dir_model_format(tmp_path) == "gguf"
 
 
+def test_the_models_dir_scanner_does_not_publish_an_imatrix_only_child(tmp_path):
+    # The predicates are not what gates a CHILD folder: _scan_models_dir decides presence
+    # from any .gguf, so an interrupted download that landed only the repo's smallest file
+    # published the folder as a local model. mmproj and MTP still decide presence, as they
+    # are companions of a real model; an imatrix is not a model artifact at all.
+    from routes.models import _scan_models_dir
+
+    repo = tmp_path / "Qwen3.8-27B-GGUF"
+    repo.mkdir()
+    (repo / "imatrix_unsloth.gguf").write_bytes(b"GGUF" + b"0" * 8)
+    assert _scan_models_dir(tmp_path) == []
+
+    (repo / "Qwen3.8-27B-UD-Q4_K_XL.gguf").write_bytes(b"GGUF" + b"0" * 64)
+    rows = _scan_models_dir(tmp_path)
+    assert [(Path(r.path).name, r.model_format) for r in rows] == [
+        ("Qwen3.8-27B-GGUF", "gguf")
+    ]
+
+
+def test_an_mmproj_only_child_still_decides_presence(tmp_path):
+    # Guard the line this change must not cross: a lone vision projector keeps its row
+    # (format None), which is what the scanner has always reported for a companion.
+    from routes.models import _scan_models_dir
+
+    repo = tmp_path / "gemma-4-GGUF"
+    repo.mkdir()
+    (repo / "mmproj-F16.gguf").write_bytes(b"GGUF" + b"0" * 8)
+
+    rows = _scan_models_dir(tmp_path)
+    assert [(Path(r.path).name, r.model_format) for r in rows] == [("gemma-4-GGUF", None)]
+
+
+def test_the_lmstudio_scanner_does_not_publish_an_imatrix_only_model_dir(tmp_path):
+    # Same presence test in the nested publisher/model layout.
+    from routes.models import _scan_lmstudio_dir
+
+    model_dir = tmp_path / "unsloth" / "Qwen3.8-27B-GGUF"
+    model_dir.mkdir(parents = True)
+    (model_dir / "imatrix_unsloth.gguf").write_bytes(b"GGUF" + b"0" * 8)
+    assert _scan_lmstudio_dir(tmp_path) == []
+
+    (model_dir / "Qwen3.8-27B-UD-Q4_K_XL.gguf").write_bytes(b"GGUF" + b"0" * 64)
+    rows = _scan_lmstudio_dir(tmp_path)
+    assert [(r.model_id, r.model_format) for r in rows] == [
+        ("unsloth/Qwen3.8-27B-GGUF", "gguf")
+    ]
+
+
 def test_a_downloaded_imatrix_is_not_a_downloaded_gguf_repo(tmp_path):
     # The surface a user who already clicked the old phantom row lands on: the imatrix is
     # in the HF cache, and the Downloaded list sizes a repo with the same routes/models.py

--- a/studio/backend/tests/test_imatrix_gguf_filtering.py
+++ b/studio/backend/tests/test_imatrix_gguf_filtering.py
@@ -175,6 +175,23 @@ def test_an_mmproj_only_child_still_decides_presence(tmp_path):
     assert [(Path(r.path).name, r.model_format) for r in rows] == [("gemma-4-GGUF", None)]
 
 
+def test_a_config_beside_an_imatrix_lists_for_the_reason_a_lone_config_does(tmp_path):
+    # The boundary of this change, asserted so it reads as deliberate. A folder holding a
+    # config and nothing loadable has always been listed (format None) -- that is how a
+    # checkpoint still downloading its weights stays visible -- and it lists whether or not
+    # an imatrix sits beside it. So the config disjunct is not an imatrix filter to bypass:
+    # suppressing it would hide in-flight downloads, which is a different change.
+    from routes.models import _scan_models_dir
+
+    for name in ("config-only", "config-and-imatrix"):
+        (tmp_path / name).mkdir()
+        (tmp_path / name / "config.json").write_text("{}", encoding = "utf-8")
+    (tmp_path / "config-and-imatrix" / "imatrix_unsloth.gguf").write_bytes(b"GGUF" + b"0" * 8)
+
+    rows = {Path(r.path).name: r.model_format for r in _scan_models_dir(tmp_path)}
+    assert rows == {"config-only": None, "config-and-imatrix": None}
+
+
 def test_the_lmstudio_scanner_does_not_publish_an_imatrix_only_model_dir(tmp_path):
     # Same presence test in the nested publisher/model layout.
     from routes.models import _scan_lmstudio_dir

--- a/studio/backend/tests/test_imatrix_gguf_filtering.py
+++ b/studio/backend/tests/test_imatrix_gguf_filtering.py
@@ -151,10 +151,11 @@ def test_a_lora_repo_weight_named_like_an_imatrix_is_still_picked(monkeypatch):
 
     files = ["imatrix-tuned.safetensors", "imatrix_unsloth.gguf", "README.md"]
     monkeypatch.setitem(
-        sys.modules, "huggingface_hub",
-        SimpleNamespace(HfApi = lambda token = None: SimpleNamespace(
-            list_repo_files = lambda _repo: list(files)
-        )),
+        sys.modules,
+        "huggingface_hub",
+        SimpleNamespace(
+            HfApi = lambda token = None: SimpleNamespace(list_repo_files = lambda _repo: list(files))
+        ),
     )
 
     assert diffusion_lora._pick_repo_weight_file("owner/lora", None) == "imatrix-tuned.safetensors"
@@ -163,10 +164,11 @@ def test_a_lora_repo_weight_named_like_an_imatrix_is_still_picked(monkeypatch):
 def test_an_imatrix_is_never_the_lora_gguf_fallback(monkeypatch):
     files = ["imatrix_unsloth.gguf", "pytorch_lora_weights.gguf"]
     monkeypatch.setitem(
-        sys.modules, "huggingface_hub",
-        SimpleNamespace(HfApi = lambda token = None: SimpleNamespace(
-            list_repo_files = lambda _repo: list(files)
-        )),
+        sys.modules,
+        "huggingface_hub",
+        SimpleNamespace(
+            HfApi = lambda token = None: SimpleNamespace(list_repo_files = lambda _repo: list(files))
+        ),
     )
     from core.inference import diffusion_lora
 

--- a/studio/backend/tests/test_imatrix_gguf_filtering.py
+++ b/studio/backend/tests/test_imatrix_gguf_filtering.py
@@ -175,6 +175,20 @@ def test_an_mmproj_only_child_still_decides_presence(tmp_path):
     assert [(Path(r.path).name, r.model_format) for r in rows] == [("gemma-4-GGUF", None)]
 
 
+def test_a_recommended_folder_chip_matches_what_the_picker_would_show(tmp_path):
+    # _dir_has_downloaded_model mirrors the scanners on purpose, so that a chip never leads
+    # to an empty picker. Once the scanners stopped surfacing an imatrix-only folder, an
+    # unfiltered probe here would have advertised exactly that.
+    from routes.models import _dir_has_downloaded_model, _scan_models_dir
+
+    (tmp_path / "imatrix_unsloth.gguf").write_bytes(b"GGUF" + b"0" * 8)
+    assert _dir_has_downloaded_model(tmp_path) is False
+    assert _scan_models_dir(tmp_path) == []
+
+    (tmp_path / "Qwen3.8-27B-UD-Q4_K_XL.gguf").write_bytes(b"GGUF" + b"0" * 64)
+    assert _dir_has_downloaded_model(tmp_path) is True
+
+
 def test_a_config_beside_an_imatrix_lists_for_the_reason_a_lone_config_does(tmp_path):
     # The boundary of this change, asserted so it reads as deliberate. A folder holding a
     # config and nothing loadable has always been listed (format None) -- that is how a

--- a/studio/backend/tests/test_imatrix_gguf_filtering.py
+++ b/studio/backend/tests/test_imatrix_gguf_filtering.py
@@ -124,6 +124,57 @@ def test_local_listing_and_load_path_skip_the_imatrix(tmp_path):
     )
 
 
+def test_the_local_models_route_does_not_list_an_imatrix(tmp_path):
+    # routes/models.py keeps its own copies of these predicates, and GET /models/local
+    # (the picker) reads them, so the hub-side exclusion alone left a standalone imatrix
+    # and an imatrix-only folder still offered there as loadable GGUF models.
+    from routes.models import _dir_model_format, _is_main_gguf_filename, _is_model_directory
+
+    assert _is_main_gguf_filename("Qwen3.8-27B-UD-Q4_K_XL.gguf")
+    assert not _is_main_gguf_filename("imatrix_unsloth.gguf")
+
+    (tmp_path / "imatrix_unsloth.gguf").write_bytes(b"GGUF" + b"0" * 8)
+    (tmp_path / "config.json").write_text("{}", encoding = "utf-8")
+    assert not _is_model_directory(tmp_path)
+    assert _dir_model_format(tmp_path) is None
+
+    (tmp_path / "Qwen3.8-27B-UD-Q4_K_XL.gguf").write_bytes(b"GGUF" + b"0" * 64)
+    assert _is_model_directory(tmp_path)
+    assert _dir_model_format(tmp_path) == "gguf"
+
+
+def test_a_lora_repo_weight_named_like_an_imatrix_is_still_picked(monkeypatch):
+    # The exclusion belongs to the .gguf fallback: an imatrix is a GGUF holding no
+    # adapter. Applied to the whole listing it also dropped .safetensors candidates,
+    # and a repo whose only weight leads with the token raised FileNotFoundError.
+    from core.inference import diffusion_lora
+
+    files = ["imatrix-tuned.safetensors", "imatrix_unsloth.gguf", "README.md"]
+    monkeypatch.setitem(
+        sys.modules, "huggingface_hub",
+        SimpleNamespace(HfApi = lambda token = None: SimpleNamespace(
+            list_repo_files = lambda _repo: list(files)
+        )),
+    )
+
+    assert diffusion_lora._pick_repo_weight_file("owner/lora", None) == "imatrix-tuned.safetensors"
+
+
+def test_an_imatrix_is_never_the_lora_gguf_fallback(monkeypatch):
+    files = ["imatrix_unsloth.gguf", "pytorch_lora_weights.gguf"]
+    monkeypatch.setitem(
+        sys.modules, "huggingface_hub",
+        SimpleNamespace(HfApi = lambda token = None: SimpleNamespace(
+            list_repo_files = lambda _repo: list(files)
+        )),
+    )
+    from core.inference import diffusion_lora
+
+    assert diffusion_lora._pick_repo_weight_file("owner/lora", None) == (
+        "pytorch_lora_weights.gguf"
+    )
+
+
 def _state_sources(monkeypatch, manifests, markers, manifest_for):
     from hub.utils import download_manifest
 

--- a/studio/backend/tests/test_mmproj_placement_policy.py
+++ b/studio/backend/tests/test_mmproj_placement_policy.py
@@ -1441,13 +1441,10 @@ def test_the_extras_opt_out_moves_the_charge_to_the_inherited_projector(tmp_path
 
 def _paravirtual(monkeypatch):
     import core.inference.llama_cpp as _llama_cpp
-
     monkeypatch.setattr(_llama_cpp, "_metal_device_is_paravirtual", lambda: True)
 
 
-def test_a_virtualised_metal_device_does_not_keep_the_inherited_projector(
-    tmp_path, monkeypatch
-):
+def test_a_virtualised_metal_device_does_not_keep_the_inherited_projector(tmp_path, monkeypatch):
     """The paravirtual scrub runs after the switch's and takes BOTH projector vars
     unconditionally, so a file the switch kept is gone by launch.
 
@@ -1466,9 +1463,7 @@ def test_a_virtualised_metal_device_does_not_keep_the_inherited_projector(
     import utils.models.gguf_metadata as _meta
 
     with patch.object(_meta, "mmproj_capabilities", lambda _p: (True, False)):
-        result = _launch(
-            backend, gguf, disable_vision = True, extra_args = ["--mmproj-auto"]
-        )
+        result = _launch(backend, gguf, disable_vision = True, extra_args = ["--mmproj-auto"])
 
     assert "LLAMA_ARG_MMPROJ" not in result["env"]
     # Nothing survives to rediscover a projector with.
@@ -1477,9 +1472,7 @@ def test_a_virtualised_metal_device_does_not_keep_the_inherited_projector(
     assert backend._mmproj_has_audio is False
 
 
-def test_dropping_an_inherited_image_projector_points_at_the_switch(
-    tmp_path, monkeypatch
-):
+def test_dropping_an_inherited_image_projector_points_at_the_switch(tmp_path, monkeypatch):
     """Turning Vision back on restores an inherited image projector, so the composer
     must name the switch rather than send the user hunting for a valid mmproj."""
     ambient = tmp_path / "ambient-mmproj.gguf"


### PR DESCRIPTION
Follow-up to #9409, which is merged. Two Codex items on that PR landed after the merge; both are real and are fixed here.

### `GET /models/local` kept its own copy of the rule

`routes/models.py` defines its own `_is_main_gguf_filename` and `_is_model_directory`. Its docstring says "Same rule as `hub.services.models.common`", but the hub-side exclusion in #9409 did not reach it, so the model picker (`GET /models/local` -> `collect_local_models` -> `_scan_models_dir` / `_dir_model_format`) still surfaced a standalone `imatrix_unsloth.gguf`, or an imatrix-only folder, as a loadable GGUF model. Reachable whenever a `unsloth/*-GGUF` repo is fetched outside Studio into the models dir, since those repos ship the imatrix beside the weights.

Both now take the loader's `_is_imatrix_path` rather than a fourth spelling of the rule, matching how they already import `_is_mtp_drafter`.

### The diffusion LoRA filter was wider than its purpose

The exclusion belongs to the `.gguf` fallback pick: an imatrix is a GGUF holding no adapter. #9409 applied it to the whole repo listing, which also filtered `.safetensors` candidates, so a LoRA repo whose only weight leads with the token (`imatrix-tuned.safetensors`) resolved to `FileNotFoundError`. A `.safetensors` is never an imatrix, so the candidate list is left alone and only the fallback is filtered.

### Tests

Three cases added to `studio/backend/tests/test_imatrix_gguf_filtering.py`. The two bug cases fail without this change and pass with it; the third pins the behaviour that must not regress (an imatrix is still never the LoRA `.gguf` fallback).

`ruff check studio` passes; `tests/test_imatrix_gguf_filtering.py` and `tests/test_diffusion_lora.py` are green (57 passed).
