### PR TITLE
Format the mmproj placement policy tests so pre-commit stops failing every PR

### DIFF
--- a/studio/backend/tests/test_mmproj_placement_policy.py
+++ b/studio/backend/tests/test_mmproj_placement_policy.py
@@ -1441,13 +1441,10 @@ def test_the_extras_opt_out_moves_the_charge_to_the_inherited_projector(tmp_path
 
 def _paravirtual(monkeypatch):
     import core.inference.llama_cpp as _llama_cpp
-
     monkeypatch.setattr(_llama_cpp, "_metal_device_is_paravirtual", lambda: True)
 
 
-def test_a_virtualised_metal_device_does_not_keep_the_inherited_projector(
-    tmp_path, monkeypatch
-):
+def test_a_virtualised_metal_device_does_not_keep_the_inherited_projector(tmp_path, monkeypatch):
     """The paravirtual scrub runs after the switch's and takes BOTH projector vars
     unconditionally, so a file the switch kept is gone by launch.
 
@@ -1466,9 +1463,7 @@ def test_a_virtualised_metal_device_does_not_keep_the_inherited_projector(
     import utils.models.gguf_metadata as _meta
 
     with patch.object(_meta, "mmproj_capabilities", lambda _p: (True, False)):
-        result = _launch(
-            backend, gguf, disable_vision = True, extra_args = ["--mmproj-auto"]
-        )
+        result = _launch(backend, gguf, disable_vision = True, extra_args = ["--mmproj-auto"])
 
     assert "LLAMA_ARG_MMPROJ" not in result["env"]
     # Nothing survives to rediscover a projector with.
@@ -1477,9 +1472,7 @@ def test_a_virtualised_metal_device_does_not_keep_the_inherited_projector(
     assert backend._mmproj_has_audio is False
 
 
-def test_dropping_an_inherited_image_projector_points_at_the_switch(
-    tmp_path, monkeypatch
-):
+def test_dropping_an_inherited_image_projector_points_at_the_switch(tmp_path, monkeypatch):
     """Turning Vision back on restores an inherited image projector, so the composer
     must name the switch rather than send the user hunting for a valid mmproj."""
     ambient = tmp_path / "ambient-mmproj.gguf"


### PR DESCRIPTION
## What

Run the repo's own `ruff-format-with-kwargs` hook over
`studio/backend/tests/test_mmproj_placement_policy.py`. Formatting only: two test signatures
rejoined onto one line, one call rejoined, and one blank line after a function-local import
removed.

## Why

`pre-commit.ci` currently fails on `main`, so it fails on every open pull request whose merge
includes `main`, regardless of what that pull request changes. #9400 changes four TypeScript files
and no Python at all, and still fails this check.

The hook's failure mode is "files were modified by this hook", and one modified file is enough to
fail the whole run, so the result reads as a repo-wide formatting problem when it is a single file.

## How this was pinned down

On a clean worktree at `origin/main`, running the hook's own entry point over every Python file it
selects (`git ls-files '*.py'` minus the hook's `exclude` pattern, 3,000-odd files) leaves exactly
one file modified:

```
 M studio/backend/tests/test_mmproj_placement_policy.py
 1 file changed, 3 insertions(+), 10 deletions(-)
```

The file arrived in #9063 and was last touched by #9383.

## Checks

- `ruff check` on the file: all checks passed
- the file still parses
- no behaviour change: no statement is added, removed or reordered
