### PR TITLE
Studio: re-run admission when a cancelled waiter was blocking the line

### DIFF
--- a/studio/backend/core/inference/llama_admission.py
+++ b/studio/backend/core/inference/llama_admission.py
@@ -796,6 +796,11 @@ class LlamaAdmissionQueue:
                     # raising here would both mask their exception and skip the
                     # release below, stranding the slot for the process lifetime.
                     pass
+            # This waiter may have been the head the line was blocked behind: it
+            # owned no slot and no tokens, so nothing else re-runs admission for
+            # the smaller waiters it was holding back. Without this they wait for
+            # the next reserve or release, which never comes on an idle queue.
+            self._grant_waiters_locked()
         if lease_to_release is not None:
             lease_to_release.release()
 

--- a/studio/backend/core/inference/llama_admission.py
+++ b/studio/backend/core/inference/llama_admission.py
@@ -796,10 +796,8 @@ class LlamaAdmissionQueue:
                     # raising here would both mask their exception and skip the
                     # release below, stranding the slot for the process lifetime.
                     pass
-            # This waiter may have been the head the line was blocked behind: it
-            # owned no slot and no tokens, so nothing else re-runs admission for
-            # the smaller waiters it was holding back. Without this they wait for
-            # the next reserve or release, which never comes on an idle queue.
+            # A cancel frees no slot and no tokens, so nothing else re-runs
+            # admission for the waiters this one was blocking.
             self._grant_waiters_locked()
         if lease_to_release is not None:
             lease_to_release.release()

--- a/studio/backend/tests/test_llama_admission_kv_budget.py
+++ b/studio/backend/tests/test_llama_admission_kv_budget.py
@@ -549,17 +549,11 @@ class TestCancellingTheBlockingHeadReopensTheLine:
     def test_a_smaller_waiter_runs_once_the_oversized_head_is_cancelled(self):
         async def scenario():
             queue = LlamaAdmissionQueue("cancel-head")
-            head_room = await _reserve(
-                queue, capacity = 4, tokens = 1000, budget = 2048
-            )
+            head_room = await _reserve(queue, capacity = 4, tokens = 1000, budget = 2048)
             assert head_room.lease_nowait() is not None
 
-            blocked = await _reserve(
-                queue, capacity = 4, tokens = 1500, budget = 2048
-            )
-            behind = await _reserve(
-                queue, capacity = 4, tokens = 500, budget = 2048
-            )
+            blocked = await _reserve(queue, capacity = 4, tokens = 1500, budget = 2048)
+            behind = await _reserve(queue, capacity = 4, tokens = 500, budget = 2048)
             # 1000 + 1500 > 2048, and FIFO holds the 500 behind it.
             assert blocked.lease_nowait() is None
             assert behind.lease_nowait() is None

--- a/studio/backend/tests/test_llama_admission_kv_budget.py
+++ b/studio/backend/tests/test_llama_admission_kv_budget.py
@@ -532,3 +532,66 @@ class TestToolLoopsReserveTheirUpperBound:
             tools = [{"type": "function", "function": {"name": "lookup"}}],
         )
         assert self._cost(payload) < 2048
+
+
+class TestCancellingTheBlockingHeadReopensTheLine:
+    """A cancelled head owns nothing, so nothing else re-runs admission for it.
+
+    FIFO means a waiter too large for the free budget parks the whole line behind
+    it. That is deliberate, and a release re-runs admission. But a cancel is not a
+    release: it frees no slot and no tokens, so before this was fixed the smaller
+    waiters behind the cancelled head sat there with free slots and free budget in
+    front of them until some unrelated reserve or release happened to come along.
+    On a queue whose only active lease is parked awaiting tool approval, that next
+    event never arrives and the tail waits forever.
+    """
+
+    def test_a_smaller_waiter_runs_once_the_oversized_head_is_cancelled(self):
+        async def scenario():
+            queue = LlamaAdmissionQueue("cancel-head")
+            head_room = await _reserve(
+                queue, capacity = 4, tokens = 1000, budget = 2048
+            )
+            assert head_room.lease_nowait() is not None
+
+            blocked = await _reserve(
+                queue, capacity = 4, tokens = 1500, budget = 2048
+            )
+            behind = await _reserve(
+                queue, capacity = 4, tokens = 500, budget = 2048
+            )
+            # 1000 + 1500 > 2048, and FIFO holds the 500 behind it.
+            assert blocked.lease_nowait() is None
+            assert behind.lease_nowait() is None
+
+            blocked.cancel()
+            # No other queue traffic: the cancel itself must reopen the line.
+            await asyncio.sleep(0)
+            assert behind.lease_nowait() is not None
+
+            snapshot = queue.snapshot()
+            assert snapshot.queued == 0
+            assert snapshot.active == 2
+            assert snapshot.committed == 1500
+
+        _run(scenario())
+
+    def test_cancelling_a_waiter_that_is_not_the_head_admits_nobody_early(self):
+        """The line is still FIFO: losing a tail waiter must not skip the head."""
+
+        async def scenario():
+            queue = LlamaAdmissionQueue("cancel-tail")
+            active = await _reserve(queue, capacity = 4, tokens = 1000, budget = 2048)
+            assert active.lease_nowait() is not None
+
+            head = await _reserve(queue, capacity = 4, tokens = 1500, budget = 2048)
+            tail = await _reserve(queue, capacity = 4, tokens = 500, budget = 2048)
+            assert head.lease_nowait() is None
+
+            tail.cancel()
+            await asyncio.sleep(0)
+            # The oversized head is still oversized, so it stays queued.
+            assert head.lease_nowait() is None
+            assert queue.snapshot().queued == 1
+
+        _run(scenario())

--- a/studio/backend/tests/test_llama_admission_kv_budget.py
+++ b/studio/backend/tests/test_llama_admission_kv_budget.py
@@ -537,13 +537,10 @@ class TestToolLoopsReserveTheirUpperBound:
 class TestCancellingTheBlockingHeadReopensTheLine:
     """A cancelled head owns nothing, so nothing else re-runs admission for it.
 
-    FIFO means a waiter too large for the free budget parks the whole line behind
-    it. That is deliberate, and a release re-runs admission. But a cancel is not a
-    release: it frees no slot and no tokens, so before this was fixed the smaller
-    waiters behind the cancelled head sat there with free slots and free budget in
-    front of them until some unrelated reserve or release happened to come along.
-    On a queue whose only active lease is parked awaiting tool approval, that next
-    event never arrives and the tail waits forever.
+    FIFO parks the line behind an oversized waiter, and a release re-runs
+    admission. A cancel frees no slot and no tokens, so the waiters behind it sat
+    on a free budget until unrelated traffic arrived, which never happens on a
+    queue whose only lease is parked awaiting tool approval.
     """
 
     def test_a_smaller_waiter_runs_once_the_oversized_head_is_cancelled(self):


### PR DESCRIPTION
Follow-up to #9392, which added the KV budget to llama admission. Reviewing that PR turned up a deadlock in `LlamaAdmissionQueue.cancel()` that the budget makes reachable, and I got the diagnosis wrong the first time, so this fixes the mechanism that is actually live.

### The bug

Every path that frees capacity ends by re-running admission. `cancel()` did not:

```
release()                   :706-718   -> self._grant_waiters_locked()
try_park()                  :720-731   -> self._grant_waiters_locked()
acquire_parked_slot() finally :772-778 -> self._grant_waiters_locked()
cancel()                    :780-800   -> nothing
```

A cancelled waiter owns no slot and no tokens, so on the face of it there is nothing to hand back and nothing to re-run. That is true for a waiter in the middle of the line. It is not true for the **head**, because `_grant_waiters_locked` tests the head's own cost against the remaining budget and stops there:

```python
while self._waiters and self._can_admit_locked(
    len(self._unpark_tickets), self._waiters[0].tokens
):
```

That head-of-line rule is deliberate (granting past a large waiter whenever a small one fits would starve it). But it means a large head blocks smaller waiters behind it, and when that head cancels, nothing re-opens the line.

### Reproduction

Capacity 4, budget 2048. A=1000 admitted. B=1500 queued, blocking on budget. C=500 queued behind it. Cancel B through the ordinary public path, `reservation.cancel()`:

```
A lease: True
B granted immediately? False
C granted immediately? False
C after b.cancel(): STILL QUEUED
snapshot: capacity=4, active=1, queued=1, free=3, committed=1000, budget=2048
```

C wants 500 tokens with three free slots and 1048 free budget, and stays queued. It is only reconsidered on the next reserve or release. When the one active lease is parked waiting on a tool approval prompt, that never arrives.

### The fix

One call, inside `cancel()`, still under `_lock`:

```python
self._grant_waiters_locked()
```

The cancelled waiter is already off `_waiters`, so the loop sees the new head. In the `granted_lease` branch those tokens are still in `_committed` at that point, so granting here is conservative and the `lease_to_release.release()` below re-grants anyway. `_grant_waiters_locked` only does `call_soon_threadsafe`, so there is no re-entrant lock acquisition. FIFO is unchanged.

### Tests

`TestCancellingTheBlockingHeadReopensTheLine` in `tests/test_llama_admission_kv_budget.py`:

- `test_a_smaller_waiter_runs_once_the_oversized_head_is_cancelled` reproduces the deadlock. Fails before this commit, passes after.
- `test_cancelling_a_waiter_that_is_not_the_head_admits_nobody_early` guards the head-of-line trade in the other direction: cancelling a tail waiter must not let anyone skip the oversized head. Passes before and after, so the fix does not quietly turn FIFO into best-fit.

`test_llama_admission_kv_budget`, `test_llama_admission_kv_budget_media_and_tools`, `test_llama_admission`, `test_anthropic_admission`: **130 passed**.

### Note on the review of #9392

An earlier revision of this was raised there and I turned it down, on the grounds that a cancelled waiter can never be left at the head because `cancel()` removes it under the lock before cancelling its future. That part is correct and still is. It was the wrong thing to check: the bug is not a dead waiter sitting at the head, it is a live head being removed with nothing re-running admission behind it. I claimed a control run through `cancel()` granted the waiter immediately. It does not, and re-running it cleanly is what turned this up.
