### PR TITLE
Studio: fall back to the legacy --swa-checkpoints spelling

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -6342,10 +6342,10 @@ class LlamaCppBackend:
             supports_fit_ctx = _is_real("--fit-ctx")
             supports_fit_target = _is_real("--fit-target")
             supports_cache_ram = _is_real("--cache-ram")
-            # --swa-checkpoints is the older spelling of the same option, kept as an
-            # alias on builds new enough to have both. Probing only the modern name
-            # drops the Checkpoints control on a build that carries just the old one,
-            # so record WHICH name this build has, like the draft-cache pair below.
+            # --swa-checkpoints is the older spelling, kept as an alias on newer
+            # builds. Probing the modern name alone drops the Checkpoints control on
+            # a build carrying only the old one, so record WHICH name this build has,
+            # like the draft-cache pair below.
             for _alias in ("--ctx-checkpoints", "--swa-checkpoints"):
                 if _is_real(_alias):
                     ctx_checkpoints_flag = _alias

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -6092,6 +6092,7 @@ class LlamaCppBackend:
                 "supports_fit_target": False,
                 "supports_cache_ram": False,
                 "supports_ctx_checkpoints": False,
+                "ctx_checkpoints_flag": None,
                 "supports_no_cache_prompt": False,
                 "supports_metrics": False,
                 "supports_slot_save": False,
@@ -6138,6 +6139,7 @@ class LlamaCppBackend:
         supports_fit_target = False
         supports_cache_ram = False
         supports_ctx_checkpoints = False
+        ctx_checkpoints_flag = None
         supports_no_cache_prompt = False
         supports_metrics = False
         supports_slot_save = False
@@ -6340,7 +6342,15 @@ class LlamaCppBackend:
             supports_fit_ctx = _is_real("--fit-ctx")
             supports_fit_target = _is_real("--fit-target")
             supports_cache_ram = _is_real("--cache-ram")
-            supports_ctx_checkpoints = _is_real("--ctx-checkpoints")
+            # --swa-checkpoints is the older spelling of the same option, kept as an
+            # alias on builds new enough to have both. Probing only the modern name
+            # drops the Checkpoints control on a build that carries just the old one,
+            # so record WHICH name this build has, like the draft-cache pair below.
+            for _alias in ("--ctx-checkpoints", "--swa-checkpoints"):
+                if _is_real(_alias):
+                    ctx_checkpoints_flag = _alias
+                    break
+            supports_ctx_checkpoints = ctx_checkpoints_flag is not None
             supports_no_cache_prompt = _is_real("--no-cache-prompt")
             supports_metrics = _is_real("--metrics")
             supports_slot_save = _is_real("--slot-save-path")
@@ -6423,6 +6433,7 @@ class LlamaCppBackend:
             "supports_fit_target": supports_fit_target,
             "supports_cache_ram": supports_cache_ram,
             "supports_ctx_checkpoints": supports_ctx_checkpoints,
+            "ctx_checkpoints_flag": ctx_checkpoints_flag,
             "supports_no_cache_prompt": supports_no_cache_prompt,
             "supports_metrics": supports_metrics,
             "supports_slot_save": supports_slot_save,
@@ -17869,8 +17880,9 @@ class LlamaCppBackend:
                 # last-wins over the control. Each is gated on the capability
                 # probe, because a build that predates the flag exits on it.
                 if ctx_checkpoints is not None:
-                    if server_caps.get("supports_ctx_checkpoints"):
-                        cmd.extend(["--ctx-checkpoints", str(int(ctx_checkpoints))])
+                    _ctxcp_flag = server_caps.get("ctx_checkpoints_flag")
+                    if _ctxcp_flag:
+                        cmd.extend([str(_ctxcp_flag), str(int(ctx_checkpoints))])
                     else:
                         logger.info(
                             "llama-server has no --ctx-checkpoints; skipping the requested %s.",
@@ -18475,8 +18487,8 @@ class LlamaCppBackend:
                         unsupported_cache_flags.append("--cache-ram")
                     if ctx_checkpoints is not None:
                         pass
-                    elif server_caps.get("supports_ctx_checkpoints"):
-                        cmd.extend(["--ctx-checkpoints", "0"])
+                    elif server_caps.get("ctx_checkpoints_flag"):
+                        cmd.extend([str(server_caps["ctx_checkpoints_flag"]), "0"])
                     else:
                         unsupported_cache_flags.append("--ctx-checkpoints")
                     if unsupported_cache_flags:

--- a/studio/backend/tests/test_server_tuning_flags.py
+++ b/studio/backend/tests/test_server_tuning_flags.py
@@ -281,6 +281,28 @@ def test_the_effective_checkpoint_count_comes_from_the_extras():
     assert resolve_ctx_checkpoints([], None) == 0
 
 
+def test_the_checkpoint_flag_falls_back_to_the_legacy_spelling():
+    """A build carrying only --swa-checkpoints must still get the control's value.
+
+    Upstream renamed --swa-checkpoints to --ctx-checkpoints and kept the old name
+    as an alias, so a build older than the rename exposes only the old one.
+    Probing the modern name alone dropped the Checkpoints pick there in silence.
+    """
+    import inspect
+
+    from core.inference import llama_cpp
+
+    probe = inspect.getsource(llama_cpp.LlamaCppBackend.probe_server_capabilities)
+    # both spellings probed, most modern first, and WHICH one is recorded
+    assert 'for _alias in ("--ctx-checkpoints", "--swa-checkpoints")' in probe
+    assert "ctx_checkpoints_flag = _alias" in probe
+    assert "supports_ctx_checkpoints = ctx_checkpoints_flag is not None" in probe
+    # and the emission uses the recorded name, not a hard-coded one
+    load = inspect.getsource(llama_cpp.LlamaCppBackend.load_model)
+    assert 'cmd.extend([str(_ctxcp_flag), str(int(ctx_checkpoints))])' in load
+    assert 'cmd.extend([str(server_caps["ctx_checkpoints_flag"]), "0"])' in load
+
+
 def test_an_unsupported_draft_cache_dtype_is_dropped_not_launched():
     """llama-server exits on a dtype it cannot map, and by then the old model is gone."""
     import inspect

--- a/studio/backend/tests/test_server_tuning_flags.py
+++ b/studio/backend/tests/test_server_tuning_flags.py
@@ -299,7 +299,7 @@ def test_the_checkpoint_flag_falls_back_to_the_legacy_spelling():
     assert "supports_ctx_checkpoints = ctx_checkpoints_flag is not None" in probe
     # and the emission uses the recorded name, not a hard-coded one
     load = inspect.getsource(llama_cpp.LlamaCppBackend.load_model)
-    assert 'cmd.extend([str(_ctxcp_flag), str(int(ctx_checkpoints))])' in load
+    assert "cmd.extend([str(_ctxcp_flag), str(int(ctx_checkpoints))])" in load
     assert 'cmd.extend([str(server_caps["ctx_checkpoints_flag"]), "0"])' in load
 
 


### PR DESCRIPTION
Follow-up to #9410.

The capability probe looked for `--ctx-checkpoints` only. `--swa-checkpoints` is the older spelling of the same option, and a build carries either one or both, so on a build that ships only the old name the probe reported no support and the Checkpoints control silently did nothing. The probe now records which of the two names the build has, the same way the draft cache pair already did, and the launch emits that name. The Windows full-offload path that forces the value to 0 uses the recorded name too.

## Verification

- `studio/backend/tests/test_server_tuning_flags.py`: 41 passed, including the new `test_the_checkpoint_flag_falls_back_to_the_legacy_spelling`.
- Cross-platform staging CI green on ubuntu-latest, macos-14 and windows-latest, plus the live Studio Playwright pass.

Rebased onto main. The two test fixes this branch also carried, the auto-load harness stubs and the seed-count contract, have since landed on main independently, so they are no longer part of this diff.