### PR TITLE
Studio: stop the KV starvation message reading as a context limit on the client

### DIFF
--- a/studio/backend/core/inference/stream_errors.py
+++ b/studio/backend/core/inference/stream_errors.py
@@ -45,11 +45,18 @@ _OVERSIZE_MARKERS = (
     "exceeds the context size",
 )
 
+# Worded around the chat client's own substring test. `chat-adapter.ts::isContextLimitError`
+# matches "context window" (among others) and shows "Context limit reached: the conversation
+# has filled the model's context window ... or start a new chat" -- the advice this message
+# exists to deny, since nothing about the conversation was too long and a new chat fails
+# identically while the other generation is still running. The backend `code` cannot rescue
+# it: `chat-api.ts` rethrows an in-band error chunk as `new Error(message)` and the text is
+# all the client has. "Context Length" names the setting and is not one of its markers.
 KV_STARVATION_MESSAGE = (
     "The model ran out of context space while generating. This happens when several "
-    "chats or research runs generate at the same time, because they share one context "
-    "window. Try again with fewer running at once, or raise the Context Length in Model "
-    "settings."
+    "chats or research runs generate at the same time, because they all draw on one "
+    "shared pool of context. Try again with fewer running at once, or raise the "
+    "Context Length in Model settings."
 )
 
 _OVERSIZE_HINT = "Raise the Context Length in Model settings, or shorten the request."
@@ -68,10 +75,11 @@ class LlamaStreamError(RuntimeError):
       swapped out on the chat path, so the cause would still never reach the user
       even though it now survives the stream loop.
     - ``_classify_llama_generation_error`` flags an overflow by substring, matching
-      "context" beside "window". The starvation text below says "context window"
-      while explaining that the window is shared, so it would be classified as
-      ``context_length_exceeded`` and set the client compacting a conversation that
-      was never too long. ``kv_starvation`` lets that path opt out explicitly.
+      "context" beside "length"/"window". The starvation text above says "context"
+      while explaining that the context is shared, and names the Context Length
+      setting as the remedy, so it would be classified as ``context_length_exceeded``
+      and set the client compacting a conversation that was never too long.
+      ``kv_starvation`` lets that path opt out explicitly.
     """
 
     def __init__(

--- a/studio/backend/tests/test_stream_errors.py
+++ b/studio/backend/tests/test_stream_errors.py
@@ -224,3 +224,45 @@ class TestTheNonStreamingPathAlsoReportsTheCause:
             == "An internal error occurred"
         )
         assert "/srv/secret" not in safe_error_detail(RuntimeError("/srv/secret/path blew up"))
+
+
+class TestTheStarvationTextDoesNotReadAsAContextLimitOnTheClient:
+    """The chat client re-classifies by substring, so the wording is load bearing.
+
+    `studio/frontend/src/features/chat/api/chat-adapter.ts::isContextLimitError` decides
+    which toast a failed generation gets from the error message alone: the backend's
+    `code` never reaches it, because `chat-api.ts` turns an in-band error chunk into
+    `new Error(parsed.error.message)` and throws only the text. Any of the substrings
+    below wins the "Context limit reached" toast, whose advice is "The conversation has
+    filled the model's context window ... or start a new chat".
+
+    That is the wrong remedy for starvation, and it is the exact claim this message was
+    written to deny: nothing about the conversation was too long, so starting a new chat
+    fails identically while the other generation is still running. Asserted here rather
+    than in the frontend because the message lives here and the wording is what breaks.
+    """
+
+    # Mirrors isContextLimitError. Keep in step with chat-adapter.ts.
+    CLIENT_CONTEXT_LIMIT_MARKERS = (
+        "context size",
+        "context shift",
+        "exceeds the available context",
+        "message too long",
+        "context window",
+    )
+
+    def test_the_curated_starvation_message_avoids_the_client_heuristic(self):
+        lowered = KV_STARVATION_MESSAGE.lower()
+        assert [m for m in self.CLIENT_CONTEXT_LIMIT_MARKERS if m in lowered] == []
+
+    def test_the_message_still_names_the_cause_and_both_remedies(self):
+        lowered = KV_STARVATION_MESSAGE.lower()
+        assert "same time" in lowered
+        assert "fewer running at once" in lowered
+        assert "context length" in lowered
+
+    def test_the_server_wording_it_replaces_would_have_hit_the_heuristic(self):
+        """Guards the test itself: the raw text is what the rewrite exists to avoid."""
+        raw = "Context size has been exceeded."
+        assert any(m in raw.lower() for m in self.CLIENT_CONTEXT_LIMIT_MARKERS)
+        assert describe_stream_error(raw) == KV_STARVATION_MESSAGE


### PR DESCRIPTION
Follow-up to #9390, which made a mid-stream llama-server failure reach the user with its real cause instead of a generic message. One of the two curated messages it added is worded in a way the chat client re-labels, so on the KV starvation path the user is now shown a confident and specific piece of wrong advice.

### What happens

`KV_STARVATION_MESSAGE` explains that several generations share one pool of KV, and said so with the phrase "because they share one context window".

`chat-adapter.ts::isContextLimitError` matches on substrings, and `"context window"` is one of them:

```ts
m.includes("context size") ||
m.includes("context shift") ||
m.includes("exceeds the available context") ||
m.includes("message too long") ||
m.includes("context window") ||
(m.includes("n_ctx") && (m.includes("exceed") || m.includes("full")))
```

So the message matches, and the client toasts **"Context limit reached"** with, in the no-truncation case that starvation always is, *"The conversation has filled the model's context window. Increase Context Length ..., or start a new chat."*

Starting a new chat is precisely the wrong move: nothing about the conversation was too long, and a new chat fails the same way for as long as the other generation is running. This is the failure #9390 exists to prevent, reintroduced one layer further out.

The error `code` cannot rescue it. `_classify_llama_generation_error` correctly returns `None` for starvation, so the chunk carries no code, and `chat-api.ts` rethrows an in-band stream error as `new Error(parsed.error.message)`. The text is all the client ever sees.

### The change

Reword the message so it stops colliding with the client heuristic while saying the same thing:

> because they all draw on one shared pool of context

"Context Length" is kept, because it names the actual UI control and is not one of the client's markers.

The `LlamaStreamError` docstring is corrected in the same commit: it cited the removed "context window" phrasing as the reason `kv_starvation` needs to opt out of `_classify_llama_generation_error`. The backend heuristic still matches on "context" beside "length", so the opt-out is still required, but the rationale as written no longer described the text.

### Tests

`TestTheStarvationTextDoesNotReadAsAContextLimitOnTheClient` in `tests/test_stream_errors.py` mirrors the client predicate's substring list and asserts the curated message hits none of it. It also asserts that the raw llama-server wording *would* have matched, so the test cannot pass vacuously if someone later empties the marker list. Fails before this commit, passes after.

`test_stream_errors`, `test_research_runs_hardening`: **193 passed**.

Backend-only, matching #9390's scope. The client predicate is left alone deliberately: it is doing its job for the cases it was written for, and loosening it would blunt the genuine oversize path.
