### PR TITLE
Studio: hide the Tensor Parallelism switch on diffusion models

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -15487,9 +15487,7 @@ class LlamaCppBackend:
                 # explicit request counts at all: the estimator has always charged 0,
                 # and adopting llama.cpp's default of 32 would move the fit for every
                 # model.
-                _effective_ctx_checkpoints = resolve_ctx_checkpoints(
-                    extra_args, ctx_checkpoints
-                )
+                _effective_ctx_checkpoints = resolve_ctx_checkpoints(extra_args, ctx_checkpoints)
                 # --embedding forces n_batch = n_ubatch, which aborts a load below the slots.
                 if (
                     self.is_embedding_gguf
@@ -16209,9 +16207,7 @@ class LlamaCppBackend:
                     # The control underneath them: emitted before the extras, so an
                     # extra still last-wins and the reserve prices what will run.
                     _budget_draft_cache = (
-                        spec_draft_cache_type.strip().lower()
-                        if spec_draft_cache_type
-                        else None
+                        spec_draft_cache_type.strip().lower() if spec_draft_cache_type else None
                     )
                     if _budget_draft_cache in _VALID_KV_CACHE_TYPES:
                         _mtp_draft_ck = _mtp_draft_ck or _budget_draft_cache

--- a/studio/backend/core/inference/llama_server_args.py
+++ b/studio/backend/core/inference/llama_server_args.py
@@ -721,9 +721,7 @@ def parse_ctx_checkpoints_override(args: Optional[Iterable[str]]) -> Optional[in
     return max(0, parsed)
 
 
-def resolve_ctx_checkpoints(
-    args: Optional[Iterable[str]], requested: Optional[int]
-) -> int:
+def resolve_ctx_checkpoints(args: Optional[Iterable[str]], requested: Optional[int]) -> int:
     """The checkpoint count the launch will actually run: extras beat the field."""
     override = parse_ctx_checkpoints_override(args)
     return int(override if override is not None else (requested or 0))

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -1561,7 +1561,11 @@ def _openai_llama_admission_media_tokens(payload) -> int:
 
 
 def _openai_llama_admission_tokens(
-    payload, *, budget: Optional[int], capacity: int, tool_loop: bool = False
+    payload,
+    *,
+    budget: Optional[int],
+    capacity: int,
+    tool_loop: bool = False,
 ) -> Optional[int]:
     """KV a request will occupy: what is sent, plus what it may generate.
 

--- a/studio/backend/tests/test_llama_admission_kv_budget.py
+++ b/studio/backend/tests/test_llama_admission_kv_budget.py
@@ -474,6 +474,7 @@ class TestToolLoopsReserveTheirUpperBound:
         ``enable_tools``, ``mcp_enabled``, the CLI policy and a checkpoint repair,
         none of which carry a client catalogue."""
         from types import SimpleNamespace
+
         payload = SimpleNamespace(
             messages = [{"role": "user", "content": "hi"}],
             max_tokens = 16,
@@ -524,6 +525,7 @@ class TestToolLoopsReserveTheirUpperBound:
         """The passthrough and streaming /v1/responses run ONE generation per HTTP
         call; the client sends the next round itself, with its own reservation."""
         from types import SimpleNamespace
+
         payload = SimpleNamespace(
             messages = [{"role": "user", "content": "hi"}],
             max_tokens = 16,

--- a/studio/backend/tests/test_llama_admission_kv_budget_media_and_tools.py
+++ b/studio/backend/tests/test_llama_admission_kv_budget_media_and_tools.py
@@ -81,9 +81,7 @@ class TestMediaIsCharged:
                     capacity = 4,
                     config = config,
                     budget = 2048,
-                    tokens = _openai_llama_admission_tokens(
-                        payload, budget = 2048, capacity = 4
-                    ),
+                    tokens = _openai_llama_admission_tokens(payload, budget = 2048, capacity = 4),
                 )
                 leases.append(reservation.lease_nowait())
             return leases
@@ -116,10 +114,7 @@ class TestTheToolLoopReservesTheWholeCache:
         )
         assert getattr(payload, "tools", None) is None
         assert (
-            _openai_llama_admission_tokens(
-                payload, budget = 4096, capacity = 4, tool_loop = True
-            )
-            == 4096
+            _openai_llama_admission_tokens(payload, budget = 4096, capacity = 4, tool_loop = True) == 4096
         )
 
     def test_a_passthrough_forwarding_tools_is_charged_its_own_round(self):
@@ -149,7 +144,6 @@ class TestTheBudgetIsTheWholeCacheNotOneSlot:
 
     def test_the_partitioned_total_wins_over_one_slot(self):
         from routes.inference import _openai_llama_admission_budget
-
         backend = _Payload(context_length = 4096, _kv_cache_context_total = 16384)
         assert _openai_llama_admission_budget(backend) == 16384
 
@@ -169,5 +163,4 @@ class TestTheBudgetIsTheWholeCacheNotOneSlot:
 
     def test_a_backend_that_cannot_say_keeps_slot_only_admission(self):
         from routes.inference import _openai_llama_admission_budget
-
         assert _openai_llama_admission_budget(_Payload()) is None

--- a/studio/backend/tests/test_web_page_cap_fits_window.py
+++ b/studio/backend/tests/test_web_page_cap_fits_window.py
@@ -258,16 +258,19 @@ class TestADenseResultIsSizedByWhatItCosts:
     """
 
     # One paragraph of CJK prose with the wiki-style escaped links that come with it.
-    _CJK_PAGE = ("人工智能是一门研究如何使机器具备智能行为的学科，"
-                 "涵盖[机器学习](/wiki/%E6%9C%BA%E5%99%A8%E5%AD%A6%E4%B9%A0)、"
-                 "[语言处理](/wiki/%E8%87%AA%E7%84%B6%E8%AF%AD%E8%A8%80%E5%A4%84%E7%90%86)"
-                 "和[电脑视觉](/wiki/%E8%AE%A1%E7%AE%97%E6%9C%BA%E8%A7%86%E8%A7%89)。") * 200
-    _EN_PAGE = ("Artificial intelligence is the study of machines that perceive their "
-                "environment and take actions that maximise the chance of a goal. ") * 200
+    _CJK_PAGE = (
+        "人工智能是一门研究如何使机器具备智能行为的学科，"
+        "涵盖[机器学习](/wiki/%E6%9C%BA%E5%99%A8%E5%AD%A6%E4%B9%A0)、"
+        "[语言处理](/wiki/%E8%87%AA%E7%84%B6%E8%AF%AD%E8%A8%80%E5%A4%84%E7%90%86)"
+        "和[电脑视觉](/wiki/%E8%AE%A1%E7%AE%97%E6%9C%BA%E8%A7%86%E8%A7%89)。"
+    ) * 200
+    _EN_PAGE = (
+        "Artificial intelligence is the study of machines that perceive their "
+        "environment and take actions that maximise the chance of a goal. "
+    ) * 200
 
     def _dense_tokens(self, text):
         from core.inference.context_window import estimate_messages_tokens_dense
-
         return estimate_messages_tokens_dense([{"role": "tool", "content": text}])
 
     def test_a_cjk_page_is_cut_to_the_share_it_was_promised(self, monkeypatch):
@@ -314,7 +317,9 @@ class TestADenseResultIsSizedByWhatItCosts:
 
     def test_an_unknown_window_leaves_a_dense_page_alone(self):
         """Same rule as the char budget: not knowing must never shrink a fetch."""
-        assert tools._dense_char_limit(self._CJK_PAGE, tools._MAX_PAGE_CHARS) == tools._MAX_PAGE_CHARS
+        assert (
+            tools._dense_char_limit(self._CJK_PAGE, tools._MAX_PAGE_CHARS) == tools._MAX_PAGE_CHARS
+        )
 
     def test_a_dense_terminal_result_is_sized_too(self, monkeypatch):
         """The code tools print CJK and escaped URLs as readily as a page carries them."""

--- a/studio/frontend/src/features/model-picker/components/model-config-page.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-config-page.tsx
@@ -1385,10 +1385,9 @@ function GgufAdvancedSettings({
         </div>
       )}
 
-      {/* withoutUnsupportedDiffusionSettings forces tensorParallel back to false on a
-          diffusion model and the diffusion runner never reads it, so the switch flipped
-          back under the pointer. Same gate, and the same reason, as the Vision and
-          batch rows around it. */}
+      {/* withoutUnsupportedDiffusionSettings forces tensorParallel back to false and
+          the diffusion runner never reads it, so the switch flipped back under the
+          pointer. Same gate as the Vision and batch rows around it. */}
       {!isDiffusion && (
         <div className={ROW_CLASS}>
           <div className="flex min-w-0 items-center gap-1.5">

--- a/studio/frontend/src/features/model-picker/components/model-config-page.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-config-page.tsx
@@ -1385,20 +1385,26 @@ function GgufAdvancedSettings({
         </div>
       )}
 
-      <div className={ROW_CLASS}>
-        <div className="flex min-w-0 items-center gap-1.5">
-          <span className={LABEL_CLASS}>Tensor Parallelism</span>
-          <InfoHint>
-            No effect on a single GPU. On multi-GPU setups, improves tokens/sec
-            for dense models. MoE models don't benefit.
-          </InfoHint>
+      {/* withoutUnsupportedDiffusionSettings forces tensorParallel back to false on a
+          diffusion model and the diffusion runner never reads it, so the switch flipped
+          back under the pointer. Same gate, and the same reason, as the Vision and
+          batch rows around it. */}
+      {!isDiffusion && (
+        <div className={ROW_CLASS}>
+          <div className="flex min-w-0 items-center gap-1.5">
+            <span className={LABEL_CLASS}>Tensor Parallelism</span>
+            <InfoHint>
+              No effect on a single GPU. On multi-GPU setups, improves tokens/sec
+              for dense models. MoE models don't benefit.
+            </InfoHint>
+          </div>
+          <Switch
+            className="panel-switch shrink-0"
+            checked={config.tensorParallel}
+            onCheckedChange={(checked) => update({ tensorParallel: checked })}
+          />
         </div>
-        <Switch
-          className="panel-switch shrink-0"
-          checked={config.tensorParallel}
-          onCheckedChange={(checked) => update({ tensorParallel: checked })}
-        />
-      </div>
+      )}
 
       {/* withoutUnsupportedDiffusionSettings forces disableVision back to false on a
           diffusion model and the diffusion runner never reads it, so the switch would

--- a/studio/frontend/tests/tensor-parallel-row-gating.test.ts
+++ b/studio/frontend/tests/tensor-parallel-row-gating.test.ts
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// The Tensor Parallelism row is one of the llama-server controls a diffusion model
+// cannot act on. withoutUnsupportedDiffusionSettings forces it back to false on every
+// state update and the diffusion runner never reads it, so an ungated row is a switch
+// that flips back under the pointer and would change nothing if it did not.
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const CONFIG_PAGE = readFileSync(
+  path.join(HERE, "..", "src/features/model-picker/components/model-config-page.tsx"),
+  "utf8",
+);
+
+/** The nearest JSX conditional boundary above `marker`, walking upwards. */
+function gateAbove(marker: string): string {
+  const lines = CONFIG_PAGE.split("\n");
+  const at = lines.findIndex((line) => line.includes(marker));
+  assert.notEqual(at, -1, `missing marker: ${marker}`);
+  for (let i = at; i >= 0; i--) {
+    const line = lines[i].trim();
+    if (line === "{!isDiffusion && (") return "!isDiffusion";
+    // A `)}` first means the gate closed before the row, i.e. it is not inside one.
+    if (line === ")}") return "closed";
+  }
+  return "none";
+}
+
+test("the reconciler still clears tensorParallel for a diffusion model", () => {
+  // Without this the gate below would be guarding nothing, and the test would pass
+  // while the row quietly became actionable again.
+  assert.match(CONFIG_PAGE, /tensorParallel: false,/);
+});
+
+test("the Tensor Parallelism row is gated out for diffusion models", () => {
+  assert.equal(gateAbove("checked={config.tensorParallel}"), "!isDiffusion");
+});
+
+test("the Vision row it sits beside stays gated too", () => {
+  // Both rows are unsupported for the same reason; regating one and not the other is
+  // the state this change exists to end.
+  assert.equal(gateAbove("checked={!config.disableVision}"), "!isDiffusion");
+});

--- a/tests/studio/test_ui_scripts_report_signals.py
+++ b/tests/studio/test_ui_scripts_report_signals.py
@@ -85,9 +85,9 @@ def test_the_snapshot_does_not_print_command_lines(script: str) -> None:
     """
     body = _body(script)
     assert "pid,ppid,comm" in body, f"{script}'s process snapshot is not limited to names"
-    assert not re.search(r"ps\s+-o\s+[\w,]*args", body), (
-        f"{script} snapshots full command lines into a public log"
-    )
+    assert not re.search(
+        r"ps\s+-o\s+[\w,]*args", body
+    ), f"{script} snapshots full command lines into a public log"
 
 
 def test_the_guard_reads_real_files() -> None:


### PR DESCRIPTION
Follow-up to #9383, which fixed the identical defect one row below and left this one because it was not that PR's to move.

`withoutUnsupportedDiffusionSettings` lists `tensorParallel: false` beside `disableVision: false`, `nBatch` and `nUbatch`, and `reconcileConfigGpuSelection` runs it on every state update for a diffusion target. The batch rows and, since #9383, the Vision row are gated on `!isDiffusion`. Tensor Parallelism was not, so on a diffusion GGUF it rendered as an actionable switch that flipped back under the pointer -- and the diffusion runner ignores the setting even if it stuck.

Gated the row, nothing else.

## Tests

`tensor-parallel-row-gating.test.ts` walks up from `checked={config.tensorParallel}` to the nearest JSX conditional boundary and requires it to be `{!isDiffusion && (` rather than a `)}`, so a row moved out of the gate fails rather than passing on a substring match. It also asserts `tensorParallel: false` is still in the reconciler, so the test cannot go vacuously green if the forcing is ever dropped, and re-checks the Vision row beside it, since regating one and not the other is the state this ends.

Two mutants, both killed: replacing the gate with `{true && (`, and removing the `tensorParallel: false` line.

4154 frontend tests pass, both `tsc` projects exit 0.
