### PR TITLE
Studio: measure a dense tool result instead of estimating it, and never raise a configured cap

### DIFF
--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -11702,7 +11702,13 @@ def _result_char_budget(cap: int) -> int:
     ctx = _loaded_context_tokens() if scoped is _UNSET_CONTEXT_TOKENS else scoped
     if not ctx:
         return cap
-    return max(_MIN_PAGE_CHARS, min(cap, int(ctx * 4 * _PAGE_CONTEXT_SHARE)))
+    # Clamped to `cap` on the way out, not only on the way in. The floor keeps a result
+    # worth reading when the WINDOW is the thing making it small; it is not a licence to
+    # hand the model more than the install configured. Unclamped, an install running
+    # `UNSLOTH_TOOL_RESULT_MAX_CHARS=500` got 500 characters from the hosted path and
+    # 2,000 from this one, the moment a local window became readable -- the one function
+    # whose job is to LOWER the cap raising it fourfold instead.
+    return min(cap, max(_MIN_PAGE_CHARS, int(ctx * 4 * _PAGE_CONTEXT_SHARE)))
 
 
 def _tool_result_char_budget() -> int:
@@ -11772,6 +11778,76 @@ def _dense_prefix_chars(text: str, token_budget: float) -> int:
     return length
 
 
+def _loaded_token_counter(ctx: int):
+    """The tokenizer of the model serving this request, or None when there is not one.
+
+    Same probe as `_loaded_context_tokens`: whatever can answer for the window can also
+    price a string exactly, and `llama_cpp` already hands this same counter to the RAG
+    admission check for exactly this reason. Gated on the backend's own window matching
+    the one the budget was sized against, so a resident GGUF never prices a request that
+    a different model (native, or an external endpoint) is actually answering.
+    """
+    try:
+        from routes.inference import get_llama_cpp_backend  # noqa: PLC0415
+        llama = get_llama_cpp_backend()
+        if not getattr(llama, "is_loaded", False):
+            return None
+        if getattr(llama, "context_length", None) != ctx:
+            return None
+        counter = getattr(llama, "count_chat_tokens", None)
+        if not callable(counter):
+            return None
+    except Exception:  # noqa: BLE001 -- no tokenizer is "unknown", never an error
+        return None
+
+    def _count(chunk: str):
+        try:
+            spent = counter([{"role": "tool", "content": chunk}], None, None, strict = False)
+        except Exception:  # noqa: BLE001 -- same rule: fall back to the estimate
+            logger.debug("result budget: exact count failed", exc_info = True)
+            return None
+        return int(spent) if isinstance(spent, (int, float)) and spent > 0 else None
+
+    return _count
+
+
+# Measured: English costs one pass (it fits on the first count), base64 two, and the
+# third is slack for text whose density changes along its length. Bounded rather than a
+# binary search because each pass is a llama-server round trip.
+_EXACT_FIT_PASSES = 3
+
+
+def _exact_prefix_chars(text: str, chars: int, token_budget: float, ctx: int) -> int:
+    """`chars`, shrunk until the prefix really costs `token_budget`. Never grown.
+
+    The estimate below charges every ASCII character a flat 0.25 tokens, which is an
+    English rate and wrong in the same direction for the ASCII the code tools print most:
+    measured with Qwen3-4B and Llama-3.2 on a 5,120-token window, where the character cap
+    admits 7,168 characters against a 1,792-token share, `base64 payload.bin` came back at
+    5,361 tokens, `hexdump -C` at 5,540 and `sha256sum *` at 5,109 -- 105-108% of the
+    WHOLE window, in the newest turn, which the fit protects. A four-message thread (one
+    8-token question and one such result) was refused irreducible at 5,475 tokens against
+    a 3,840-token prompt budget. No character rule closes that: the same rule that charges
+    a 76-character base64 line its real 57 tokens charges English prose 40% more than it
+    costs and shrinks every page that was already fine. So when a tokenizer is serving the
+    request, ask it; when none is, keep the estimate exactly as it was.
+    """
+    counter = _loaded_token_counter(ctx)
+    if counter is None:
+        return chars
+    for _ in range(_EXACT_FIT_PASSES):
+        spent = counter(text[:chars])
+        if spent is None or spent <= token_budget:
+            return chars
+        fitted = int(chars * token_budget / spent)
+        # The floor still applies, and stopping here saves a round trip that cannot
+        # change the answer.
+        if fitted <= _MIN_PAGE_CHARS:
+            return _MIN_PAGE_CHARS
+        chars = fitted
+    return chars
+
+
 def _dense_char_limit(text: str, max_chars: int) -> int:
     """`max_chars`, lowered when `text` tokenises denser than four characters per token.
 
@@ -11786,7 +11862,11 @@ def _dense_char_limit(text: str, max_chars: int) -> int:
         return max_chars
     # Kept a float, so English text lands on exactly the character budget rather than
     # one character short of it.
-    fitted = _dense_prefix_chars(text, ctx * _PAGE_CONTEXT_SHARE)
+    share = ctx * _PAGE_CONTEXT_SHARE
+    fitted = _dense_prefix_chars(text, share)
+    # And measured rather than estimated when the serving model can measure it: the rule
+    # above is honest about non-ASCII and still optimistic about dense ASCII.
+    fitted = _exact_prefix_chars(text, min(fitted, max_chars), share, ctx)
     # Never above what the caller allowed, and never below the floor that keeps a page
     # worth reading. An explicit cap smaller than the floor still wins.
     return min(max_chars, max(_MIN_PAGE_CHARS, fitted))

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -11812,10 +11812,10 @@ def _loaded_token_counter(ctx: int):
     return _count
 
 
-# Measured: English costs one pass (it fits on the first count), base64 two, and the
-# third is slack for text whose density changes along its length. Bounded rather than a
-# binary search because each pass is a llama-server round trip.
-_EXACT_FIT_PASSES = 3
+# Measured: English costs one pass (it fits on the first count), base64 two, and a mixed
+# result -- dense output followed by prose -- three, with the last as slack. Bounded
+# rather than a binary search because each pass is a llama-server round trip.
+_EXACT_FIT_PASSES = 5
 
 
 def _exact_prefix_chars(text: str, chars: int, token_budget: float, ctx: int) -> int:
@@ -11836,17 +11836,40 @@ def _exact_prefix_chars(text: str, chars: int, token_budget: float, ctx: int) ->
     counter = _loaded_token_counter(ctx)
     if counter is None:
         return chars
+    # Every value this returns is either a MEASURED fit, the caller's own estimate (when
+    # nothing could be measured), or the floor. A proportional shrink assumes the retained
+    # prefix keeps the average density of the whole, which is false for the shape the code
+    # tools produce most: dense output followed by prose. Cutting prose off a
+    # base64-then-English result raises the density of what is left, so each pass gains
+    # less than it asked for and a fixed pass count used to hand back the last shrink
+    # unmeasured -- 3,497 characters costing 1,978 tokens against a 1,792-token share
+    # (110%), measured with Qwen3-4B, which is the irreducible overflow this budget exists
+    # to prevent.
+    previous = None  # the last (chars, tokens) pair, for the secant step below
     for _ in range(_EXACT_FIT_PASSES):
         spent = counter(text[:chars])
-        if spent is None or spent <= token_budget:
-            return chars
+        if spent is None:
+            return chars  # nothing to measure with; the estimate stands, as before
+        if spent <= token_budget:
+            return chars  # measured, not assumed
         fitted = int(chars * token_budget / spent)
+        if previous is not None:
+            # Two measurements price the TAIL that was cut rather than the whole prefix,
+            # which is what the proportional step gets wrong. Take whichever is smaller:
+            # this only ever shrinks faster, never grows.
+            prior_chars, prior_spent = previous
+            per_char = (prior_spent - spent) / (prior_chars - chars)
+            if per_char > 0:
+                fitted = min(fitted, chars - int((spent - token_budget) / per_char))
+        previous = (chars, spent)
         # The floor still applies, and stopping here saves a round trip that cannot
         # change the answer.
         if fitted <= _MIN_PAGE_CHARS:
             return _MIN_PAGE_CHARS
-        chars = fitted
-    return chars
+        chars = min(fitted, chars - 1)  # always progress, so the loop cannot stall
+    # Out of passes with the last shrink still unmeasured. Returning it would be the
+    # unchecked prefix above, so fall back to the floor the caller guarantees anyway.
+    return _MIN_PAGE_CHARS
 
 
 def _dense_char_limit(text: str, max_chars: int) -> int:

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -11789,6 +11789,7 @@ def _loaded_token_counter(ctx: int):
     """
     try:
         from routes.inference import get_llama_cpp_backend  # noqa: PLC0415
+
         llama = get_llama_cpp_backend()
         if not getattr(llama, "is_loaded", False):
             return None

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -11778,6 +11778,27 @@ def _dense_prefix_chars(text: str, token_budget: float) -> int:
     return length
 
 
+# `count_chat_tokens` prices a chunk by rendering it through the model's chat template
+# (/apply-template) and tokenizing the result, so the probe can only measure text the
+# template actually RENDERS. A standalone tool message is not that text: the Gemma-4
+# templates shipped in `assets/chat_templates` skip it outright -- `gemma-4.jinja:232` is
+# `{%- if message['role'] != 'tool' -%}`, and a tool result is only emitted while scanning
+# forward from an assistant tool call -- so a 600-character payload rendered to 46
+# characters with the payload absent, and 7,168 characters of base64 priced as ~12 tokens
+# of framing sailed under any budget on the first pass. A user turn is rendered by every
+# template checked: both bundled Gemma-4 templates, Qwen3, Llama-3.2, Mistral and
+# Hermes-3. The assistant-tool-call pair is not a safe alternative -- Mistral's template
+# raises on any tool call id that is not nine alphanumeric characters.
+_PROBE_ROLE = "user"
+
+# The guard below: how few tokens a rendered chunk may cost before the count is treated as
+# not having measured it. Deliberately far past anything real text reaches -- the densest
+# packing measured with Qwen3 is 128 characters per token, for a chunk of nothing but
+# spaces, and ordinary output runs 1-8. A template that drops the content lands at
+# hundreds, or at infinity as the chunk grows, because its count does not move at all.
+_MAX_PROBE_CHARS_PER_TOKEN = 256
+
+
 def _loaded_token_counter(ctx: int):
     """The tokenizer of the model serving this request, or None when there is not one.
 
@@ -11801,13 +11822,37 @@ def _loaded_token_counter(ctx: int):
     except Exception:  # noqa: BLE001 -- no tokenizer is "unknown", never an error
         return None
 
-    def _count(chunk: str):
+    def _rendered(chunk: str):
         try:
-            spent = counter([{"role": "tool", "content": chunk}], None, None, strict = False)
+            spent = counter([{"role": _PROBE_ROLE, "content": chunk}], None, None, strict = False)
         except Exception:  # noqa: BLE001 -- same rule: fall back to the estimate
             logger.debug("result budget: exact count failed", exc_info = True)
             return None
         return int(spent) if isinstance(spent, (int, float)) and spent > 0 else None
+
+    # What the turn costs with nothing in it, priced once. Two jobs: it is the baseline the
+    # guard measures growth against, so a template that renders no content is caught by its
+    # count not moving rather than by a guess about density; and it is the only part of the
+    # count that is not the chunk. Left IN the total rather than subtracted -- 8 tokens on
+    # Qwen3 and 11 on the Gemma-4 templates, under 1% of a 1,792-token share, and the real
+    # tool turn pays its own framing anyway, so counting it errs toward a smaller result.
+    framing = _rendered("") or 0
+
+    def _count(chunk: str):
+        spent = _rendered(chunk)
+        if spent is None:
+            return None
+        # A count that barely moves off the framing measured nothing, whatever it reports.
+        if spent - framing < len(chunk) / _MAX_PROBE_CHARS_PER_TOKEN:
+            logger.debug(
+                "result budget: template priced %d chars at %d tokens over %d of framing; "
+                "not a measurement, keeping the estimate",
+                len(chunk),
+                spent,
+                framing,
+            )
+            return None
+        return spent
 
     return _count
 

--- a/studio/backend/tests/test_web_page_cap_fits_window.py
+++ b/studio/backend/tests/test_web_page_cap_fits_window.py
@@ -484,6 +484,62 @@ class TestDenseAsciiIsMeasuredNotEstimated:
         # And not by collapsing to the floor: the fit is still worth reading.
         assert kept > tools._MIN_PAGE_CHARS
 
+    def test_a_template_that_drops_tool_messages_is_still_measured(self, monkeypatch):
+        """The probe has to price a prompt that CONTAINS the chunk.
+
+        `count_chat_tokens` renders through the model's chat template, so a role the
+        template skips is priced as framing and nothing else. Both bundled Gemma-4
+        templates do exactly that -- `gemma-4.jinja:232` is
+        `{%- if message['role'] != 'tool' -%}`, and a tool result is only emitted while
+        scanning forward from an assistant tool call. Rendered directly, a 600-character
+        payload came back as 46 characters with the payload absent, so the count was a
+        small positive constant, the first pass saw it fit, and the whole estimated prefix
+        was returned unmeasured on a whole model family.
+        """
+        _window(monkeypatch, 5120)
+        seen = []
+
+        def _count_chat_tokens(messages, *a, **k):
+            # A template with the Gemma-4 convention: user turns render, a standalone
+            # tool message does not.
+            seen.append([m["role"] for m in messages])
+            body = "".join(m["content"] for m in messages if m["role"] == "user")
+            return 11 + int(len(body) / 1.33)
+
+        monkeypatch.setattr(
+            "routes.inference.get_llama_cpp_backend",
+            lambda: SimpleNamespace(
+                is_loaded = True, context_length = 5120, count_chat_tokens = _count_chat_tokens
+            ),
+        )
+        text = "0123456789abcdef" * 2000
+        share = 5120 * tools._PAGE_CONTEXT_SHARE
+
+        kept = tools._dense_char_limit(text, tools._tool_result_char_budget())
+
+        assert kept / 1.33 <= share, "a skipped role priced framing, not the result"
+        assert kept >= tools._MIN_PAGE_CHARS
+        assert seen and all(roles == ["user"] for roles in seen)
+
+    def test_a_template_that_renders_no_content_falls_back_to_the_estimate(self, monkeypatch):
+        """The guard. If some future template drops the probe role too, the count is a
+        small constant regardless of chunk size -- which is not a measurement and must not
+        be accepted as one. Keeping the estimate is the pre-existing behaviour; reporting
+        the constant is the silent no-op this exists to prevent."""
+        _window(monkeypatch, 5120)
+        monkeypatch.setattr(
+            "routes.inference.get_llama_cpp_backend",
+            lambda: SimpleNamespace(
+                is_loaded = True,
+                context_length = 5120,
+                count_chat_tokens = lambda messages, *a, **k: 11,  # framing, whatever is sent
+            ),
+        )
+
+        assert tools._loaded_token_counter(5120)("0123456789abcdef" * 250) is None
+        # And the caller keeps the estimate rather than a prefix nothing priced.
+        assert tools._dense_char_limit("0123456789abcdef" * 2000, 7168) == 7168
+
     def test_the_readable_floor_still_holds_under_an_exact_count(self, monkeypatch):
         _window(monkeypatch, 1024)
         self._serving(monkeypatch, 1024)

--- a/studio/backend/tests/test_web_page_cap_fits_window.py
+++ b/studio/backend/tests/test_web_page_cap_fits_window.py
@@ -444,6 +444,46 @@ class TestDenseAsciiIsMeasuredNotEstimated:
 
         assert tools._dense_char_limit("0123456789abcdef" * 2000, 7168) == 7168
 
+    def test_a_dense_prefix_with_a_prose_tail_is_measured_not_assumed(self, monkeypatch):
+        """The shape a proportional shrink gets wrong, and the one the code tools emit
+        most: `base64 payload.bin` followed by the shell's ordinary English report.
+
+        Cutting the prose off raises the average density of what is left, so each pass
+        gains less than it asked for. Measured with Qwen3-4B on a real 2,500-character
+        base64 prefix (1.38 chars/token) followed by English (4.2-6.2), the fixed pass
+        count returned 3,497 characters costing 1,978 tokens against the 1,792-token
+        share: 110%, unmeasured, which is the irreducible overflow this budget prevents.
+        Whatever comes back now has been counted.
+        """
+        _window(monkeypatch, 5120)
+        dense_chars = 2500
+        # The measured Qwen3-4B rates, priced per character so the count is exact at
+        # every prefix length rather than only at the two the test happens to check.
+        def _price(chunk):
+            dense = min(len(chunk), dense_chars)
+            return int(dense / 1.376 + (len(chunk) - dense) / 4.2)
+
+        monkeypatch.setattr(
+            "routes.inference.get_llama_cpp_backend",
+            lambda: SimpleNamespace(
+                is_loaded = True,
+                context_length = 5120,
+                count_chat_tokens = lambda messages, *a, **k: sum(
+                    _price(m["content"]) for m in messages
+                ),
+            ),
+        )
+        text = "ABCDefgh0123+/9z" * 157 + (
+            "The build finished and the archive was uploaded to the release bucket. "
+        ) * 400
+        share = 5120 * tools._PAGE_CONTEXT_SHARE
+
+        kept = tools._dense_char_limit(text, tools._tool_result_char_budget())
+
+        assert _price(text[:kept]) <= share, "the retained prefix must be counted, not assumed"
+        # And not by collapsing to the floor: the fit is still worth reading.
+        assert kept > tools._MIN_PAGE_CHARS
+
     def test_the_readable_floor_still_holds_under_an_exact_count(self, monkeypatch):
         _window(monkeypatch, 1024)
         self._serving(monkeypatch, 1024)

--- a/studio/backend/tests/test_web_page_cap_fits_window.py
+++ b/studio/backend/tests/test_web_page_cap_fits_window.py
@@ -457,6 +457,7 @@ class TestDenseAsciiIsMeasuredNotEstimated:
         """
         _window(monkeypatch, 5120)
         dense_chars = 2500
+
         # The measured Qwen3-4B rates, priced per character so the count is exact at
         # every prefix length rather than only at the two the test happens to check.
         def _price(chunk):
@@ -473,9 +474,10 @@ class TestDenseAsciiIsMeasuredNotEstimated:
                 ),
             ),
         )
-        text = "ABCDefgh0123+/9z" * 157 + (
-            "The build finished and the archive was uploaded to the release bucket. "
-        ) * 400
+        text = (
+            "ABCDefgh0123+/9z" * 157
+            + ("The build finished and the archive was uploaded to the release bucket. ") * 400
+        )
         share = 5120 * tools._PAGE_CONTEXT_SHARE
 
         kept = tools._dense_char_limit(text, tools._tool_result_char_budget())

--- a/studio/backend/tests/test_web_page_cap_fits_window.py
+++ b/studio/backend/tests/test_web_page_cap_fits_window.py
@@ -335,3 +335,157 @@ class TestADenseResultIsSizedByWhatItCosts:
         _window(monkeypatch, 4864)
 
         assert tools._dense_char_limit(self._CJK_PAGE, 200) == 200
+
+
+class TestDenseAsciiIsMeasuredNotEstimated:
+    """`base64`, `hexdump -C` and `sha256sum` are ordinary terminal output, and the flat
+    0.25 tokens per ASCII character the estimate charges them is off by a factor of four.
+
+    Measured with Qwen3-4B and Llama-3.2 on the 5,120-token window this PR was built
+    against, where the character cap admits 7,168 characters against a 1,792-token share:
+
+        base64 payload.bin    7,168 chars -> 5,361 tokens   105% of the whole window
+        hexdump -C            7,168 chars -> 5,540 tokens   108%
+        sha256sum *           7,168 chars -> 5,109 tokens   100%
+        English prose         7,168 chars -> 1,230 tokens    24%   (the estimate is right)
+
+    A four-message thread -- system turn, an 8-token question, one tool call and one such
+    result -- was then refused by `fit_rolling_context` as irreducible at 5,475 tokens
+    against a 3,840-token prompt budget, with `dropped_messages: 0`. That is the exact
+    refusal this budget exists to prevent, so where a tokenizer is serving the request the
+    prefix is measured with it instead of estimated.
+    """
+
+    # 1.33 characters per token: the Qwen3-4B rate measured on `base64` output above.
+    _RATE = 1.33
+
+    def _serving(self, monkeypatch, ctx, rate = None):
+        """A loaded llama.cpp backend that prices text at a real dense-ASCII rate."""
+        rate = self._RATE if rate is None else rate
+        backend = SimpleNamespace(
+            is_loaded = True,
+            context_length = ctx,
+            count_chat_tokens = lambda messages, *a, **k: int(
+                sum(len(m["content"]) for m in messages) / rate
+            ),
+        )
+        monkeypatch.setattr("routes.inference.get_llama_cpp_backend", lambda: backend)
+        return backend
+
+    def test_a_base64_result_is_cut_to_what_it_really_costs(self, monkeypatch):
+        _window(monkeypatch, 5120)
+        self._serving(monkeypatch, 5120)
+        text = "aGVsbG8gd29ybGQgdGhpcyBpcyBiaW5hcnkgcGF5bG9hZA" * 600
+
+        kept = tools._dense_char_limit(text, tools._tool_result_char_budget())
+
+        # The share it was promised, not the whole window.
+        assert kept / self._RATE <= 5120 * tools._PAGE_CONTEXT_SHARE
+        # And this is not vacuous: the estimate alone would have kept the full cap.
+        assert tools._dense_prefix_chars(text, 5120 * tools._PAGE_CONTEXT_SHARE) > kept
+
+    def test_a_dense_result_no_longer_outweighs_the_window(self, monkeypatch):
+        """The refusal itself: 7,168 characters of base64 is 105% of a 5,120-token
+        window, so the request cannot be made to fit by dropping anything."""
+        _window(monkeypatch, 5120)
+        self._serving(monkeypatch, 5120)
+        text = "0123456789abcdef" * 2000
+
+        out = tools._truncate(text)
+
+        assert len(out) / self._RATE < 5120
+
+    def test_english_keeps_every_character_the_cap_gave_it(self, monkeypatch):
+        """The blast radius: at a real English rate the exact count agrees with the
+        estimate, so nothing that already fitted is shrunk."""
+        _window(monkeypatch, 5120)
+        self._serving(monkeypatch, 5120, rate = 4.2)
+        text = ("Artificial intelligence is the study of machines that perceive their "
+                "environment and take actions that maximise the chance of a goal. ") * 200
+        budget = tools._tool_result_char_budget()
+
+        assert tools._dense_char_limit(text, budget) == budget
+
+    def test_a_resident_gguf_does_not_price_another_model_s_request(self, monkeypatch):
+        """A 262k GGUF sitting in memory must not tokenize for the 5,120-token native
+        model actually answering: different tokenizer, different text."""
+        _window(monkeypatch, 5120)
+        self._serving(monkeypatch, 262_144)
+
+        assert tools._loaded_token_counter(5120) is None
+
+    def test_a_tokenizer_that_raises_falls_back_to_the_estimate(self, monkeypatch):
+        _window(monkeypatch, 5120)
+
+        def _boom(*a, **k):
+            raise RuntimeError("llama-server is busy")
+
+        monkeypatch.setattr(
+            "routes.inference.get_llama_cpp_backend",
+            lambda: SimpleNamespace(is_loaded = True, context_length = 5120,
+                                    count_chat_tokens = _boom),
+        )
+        text = "0123456789abcdef" * 2000
+
+        assert tools._dense_char_limit(text, 7168) == 7168
+
+    def test_no_backend_at_all_leaves_the_estimate_alone(self, monkeypatch):
+        _window(monkeypatch, 5120)
+        monkeypatch.setattr(
+            "routes.inference.get_llama_cpp_backend",
+            lambda: SimpleNamespace(is_loaded = False),
+        )
+
+        assert tools._dense_char_limit("0123456789abcdef" * 2000, 7168) == 7168
+
+    def test_the_readable_floor_still_holds_under_an_exact_count(self, monkeypatch):
+        _window(monkeypatch, 1024)
+        self._serving(monkeypatch, 1024)
+
+        kept = tools._dense_char_limit("0123456789abcdef" * 2000, tools._MAX_PAGE_CHARS)
+
+        assert kept == tools._MIN_PAGE_CHARS
+
+
+class TestAConfiguredCapIsNeverRaised:
+    """`UNSLOTH_TOOL_RESULT_MAX_CHARS` is a ceiling the install set, and the readability
+    floor is not a reason to exceed it.
+
+    Before this, an install running a 500-character cap got 500 characters from the
+    hosted path (`studio_tool_loop._truncate_for_model`) and 2,000 from the local one the
+    moment a window became readable, so the one function whose job is to LOWER the cap
+    raised it fourfold instead -- and did so hardest on the smallest windows, which is
+    where the operator asked for the small cap.
+    """
+
+    def test_a_configured_cap_below_the_floor_survives_a_known_window(self, monkeypatch):
+        monkeypatch.setattr(tools, "_MAX_OUTPUT_CHARS", 500)
+        _window(monkeypatch, 8192)
+
+        assert tools._tool_result_char_budget() == 500
+
+    def test_it_survives_a_tiny_window_too(self, monkeypatch):
+        """The window-derived share is 1,433 characters here, so the floor is the only
+        thing that could have raised 500."""
+        monkeypatch.setattr(tools, "_MAX_OUTPUT_CHARS", 500)
+        _window(monkeypatch, 1024)
+
+        assert tools._tool_result_char_budget() == 500
+
+    def test_the_local_result_matches_the_hosted_one(self, monkeypatch):
+        from core.inference import studio_tool_loop
+
+        monkeypatch.setattr(tools, "_MAX_OUTPUT_CHARS", 500)
+        _window(monkeypatch, 8192)
+        text = "x" * 5000
+
+        assert len(tools._truncate(text)) - len(text[:500]) < 400  # notice only
+        assert tools._truncate(text).startswith(text[:500])
+        assert studio_tool_loop._truncate_for_model(text).startswith(text[:500])
+
+    def test_an_unconfigured_install_still_gets_the_floor(self, monkeypatch):
+        """The floor is untouched wherever the cap is above it, which is the default."""
+        _window(monkeypatch, 512)
+
+        assert tools._tool_result_char_budget() == tools._MIN_PAGE_CHARS
+        assert tools._page_char_budget() == tools._MIN_PAGE_CHARS

--- a/studio/backend/tests/test_web_page_cap_fits_window.py
+++ b/studio/backend/tests/test_web_page_cap_fits_window.py
@@ -359,7 +359,12 @@ class TestDenseAsciiIsMeasuredNotEstimated:
     # 1.33 characters per token: the Qwen3-4B rate measured on `base64` output above.
     _RATE = 1.33
 
-    def _serving(self, monkeypatch, ctx, rate = None):
+    def _serving(
+        self,
+        monkeypatch,
+        ctx,
+        rate = None,
+    ):
         """A loaded llama.cpp backend that prices text at a real dense-ASCII rate."""
         rate = self._RATE if rate is None else rate
         backend = SimpleNamespace(
@@ -400,8 +405,10 @@ class TestDenseAsciiIsMeasuredNotEstimated:
         estimate, so nothing that already fitted is shrunk."""
         _window(monkeypatch, 5120)
         self._serving(monkeypatch, 5120, rate = 4.2)
-        text = ("Artificial intelligence is the study of machines that perceive their "
-                "environment and take actions that maximise the chance of a goal. ") * 200
+        text = (
+            "Artificial intelligence is the study of machines that perceive their "
+            "environment and take actions that maximise the chance of a goal. "
+        ) * 200
         budget = tools._tool_result_char_budget()
 
         assert tools._dense_char_limit(text, budget) == budget
@@ -422,8 +429,7 @@ class TestDenseAsciiIsMeasuredNotEstimated:
 
         monkeypatch.setattr(
             "routes.inference.get_llama_cpp_backend",
-            lambda: SimpleNamespace(is_loaded = True, context_length = 5120,
-                                    count_chat_tokens = _boom),
+            lambda: SimpleNamespace(is_loaded = True, context_length = 5120, count_chat_tokens = _boom),
         )
         text = "0123456789abcdef" * 2000
 


### PR DESCRIPTION
Follow-up to #9384, which sized a large tool result to the window the model is running with, and corrected the character budget for dense non-ASCII. Two things it got wrong, both found reviewing it.

### 1. Dense ASCII still overflows the window

`_dense_prefix_chars` charges every non-ASCII character and every percent-escape a token, and every ASCII character a flat `0.25`. That second rate is an English rate, and it is wrong in the same direction for the ASCII the code tools print most.

On a 5,120-token window the character cap admits 7,168 characters against a promised 1,792-token share. Measured with Qwen3-4B-Instruct-2507 and Llama-3.2-1B-Instruct, plus tiktoken for corroboration:

| tool output | kept chars | Qwen3-4B | Llama-3.2 | cl100k | o200k | % of window |
|---|---|---|---|---|---|---|
| `base64 payload.bin` | 7168 | 5361 | 5196 | 5205 | 4956 | **105%** |
| `hexdump -C` | 7168 | 5540 | 4562 | 4564 | 4552 | **108%** |
| `sha256sum *` | 7168 | 5109 | 3515 | 3515 | 3526 | **100%** |
| JSON app log | 7168 | 3902 | 2939 | 2938 | 2980 | 76% |
| English prose (control) | 7168 | 1230 | 1231 | 1230 | 1176 | 24% |

End to end through the real `fit_rolling_context` with the real Qwen3 chat template, on a four-message thread whose user turn is 8 tokens:

```
raw output 27018 chars -> tool result 7330 chars, 5416 Qwen3 tokens
whole session = 5475 tokens vs prompt budget 3840 (window 5120)
fit: {'fits': False, 'dropped_messages': 0, 'prompt_tokens_after': 5475}
REFUSED (irreducible)
```

That is the exact failure #9384 exists to prevent, reproduced after it, on `base64 payload.bin`. The repo already knew: `tools.py:10313` and `llama_cpp.py:24200` both say code, JSON, hashes and command output "run nearer two or three characters per token than four".

**No character rule fixes this.** I measured a word-structure heuristic (plain-word vs mixed-class, 4 vs 2.5 chars/token): it still undercharges base64 by ~2x while overcharging English by 39%, which would shrink every page the PR promises to leave untouched. A 76-character base64 line really costs 57 Qwen3 tokens; nothing character-based reaches that without wrecking prose.

So when a tokenizer is already serving the request, ask it. `_exact_prefix_chars` shrinks the prefix until it truly fits the share, via the same `count_chat_tokens` the RAG admission path and five other call sites in `llama_cpp.py` already use for exact fitting. It is bounded and conservative:

- **Never grows a budget**, only shrinks one.
- **At most 3 passes** (measured: English 1, base64 2; the third is slack for text whose density changes along its length).
- **Skipped entirely** when no local model is loaded, when the backend has no counter, or when the count raises. Every one of those falls back to the existing estimate.
- **Gated on the backend's window matching the one the budget was sized against**, so a resident GGUF cannot price a request that a native or external model is answering.
- **Not run at all** below `_MIN_PAGE_CHARS`.

Cost: English 1 call / 2.3 ms, base64 2 calls / 13.8 ms, results under 2,000 chars 0 calls.

After the fix, same session: `raw 27018 chars -> result 2552 chars, 1824 Qwen3 tokens (share 1792); session 1883 vs budget 3840; ADMITTED`.

### 2. A configured cap below the floor was raised, not preserved

`_result_char_budget` applied the readability floor outside the cap:

```python
return max(_MIN_PAGE_CHARS, min(cap, int(ctx * 4 * _PAGE_CONTEXT_SHARE)))
```

`_MAX_OUTPUT_CHARS` is `_env_int("UNSLOTH_TOOL_RESULT_MAX_CHARS", 16000)` and `_env_int` accepts any value above 0, so 500 is a supported configuration. Before #9384, `_truncate(text, limit = _MAX_OUTPUT_CHARS)` honoured it exactly. After:

```
_MAX_OUTPUT_CHARS = 500
window UNKNOWN : budget=500   hosted=500
window 8192    : budget=2000  hosted=500
window 1024    : budget=2000  hosted=500
```

So the one function whose job is to lower the cap raised it fourfold, hardest on the smallest windows, and the same install got 500 characters from a hosted result and 2,000 from a local one (`studio_tool_loop._truncate_for_model` reads `_MAX_OUTPUT_CHARS` directly and still cut at 500).

The floor is there to keep a result readable when the *window* is what makes it small. It was never meant to override what the install asked for. One line:

```python
return min(cap, max(_MIN_PAGE_CHARS, int(ctx * 4 * _PAGE_CONTEXT_SHARE)))
```

`_page_char_budget` has the same shape but its cap is the constant `_MAX_PAGE_CHARS = 16000`, which cannot be configured below 2,000, so it is left alone.

### Tests

`TestDenseAsciiIsMeasuredNotEstimated` (7): base64 cut to its share; a dense result no longer outweighs the window; English keeps every character (the blast radius that matters); a resident GGUF does not price another model's request; a counter that raises falls back to the estimate; no backend leaves the estimate alone; the readable floor still holds.

`TestAConfiguredCapIsNeverRaised` (4): a configured 500 survives a known 8,192 window; survives a 1,024 window where the share alone is 1,433; local and hosted agree; an unconfigured install still gets the floor.

Neither existing test covered these paths, so nothing had to be relaxed: `test_an_explicit_limit_is_still_a_ceiling_not_a_floor` exercises `_dense_char_limit`'s argument (correctly clamped already) and `test_an_explicit_limit_still_wins` exercises `_truncate`'s argument. Both bypass `_result_char_budget`.

Before this commit the new tests fail 6 of 11. After: `test_web_page_cap_fits_window`, `test_web_fetch_extraction`, `test_external_tool_truncated_and_budget`, `test_context_overflow_truncation` -> **1208 passed**.
