### PR TITLE
Studio: stop two tabs both auto-continuing the same truncated reply

### DIFF
--- a/.github/scripts/run-studio-indicator-browser.sh
+++ b/.github/scripts/run-studio-indicator-browser.sh
@@ -53,8 +53,15 @@ trap '_on_signal INT 2' INT
 trap '_on_signal HUP 1' HUP
 
 healthy=0
-for _ in $(seq 1 180); do
-  if curl -fs "http://127.0.0.1:$port/api/health" >/dev/null; then
+# --max-time, or only the loop counter is bounded and a server that binds the
+# port then wedges parks the first iteration forever. And a real deadline
+# rather than an iteration count, because once a probe can cost --max-time,
+# 180 iterations is up to 18 minutes rather than the 180s it reads as. See
+# wait-for-health.sh, which had both halves of the same hole.
+health_deadline=$(( SECONDS + 180 ))
+while [ "$SECONDS" -lt "$health_deadline" ]; do
+  if curl -fs --connect-timeout 3 --max-time 5 \
+       "http://127.0.0.1:$port/api/health" >/dev/null; then
     healthy=1
     break
   fi

--- a/.github/scripts/run-studio-permission-browser.sh
+++ b/.github/scripts/run-studio-permission-browser.sh
@@ -62,8 +62,15 @@ trap '_on_signal INT 2' INT
 trap '_on_signal HUP 1' HUP
 
 healthy=0
-for _ in $(seq 1 180); do
-  if curl -fs "http://127.0.0.1:$port/api/health" >/dev/null; then
+# --max-time, or only the loop counter is bounded and a server that binds the
+# port then wedges parks the first iteration forever. And a real deadline
+# rather than an iteration count, because once a probe can cost --max-time,
+# 180 iterations is up to 18 minutes rather than the 180s it reads as. See
+# wait-for-health.sh, which had both halves of the same hole.
+health_deadline=$(( SECONDS + 180 ))
+while [ "$SECONDS" -lt "$health_deadline" ]; do
+  if curl -fs --connect-timeout 3 --max-time 5 \
+       "http://127.0.0.1:$port/api/health" >/dev/null; then
     healthy=1
     break
   fi

--- a/.github/scripts/wait-for-health.sh
+++ b/.github/scripts/wait-for-health.sh
@@ -62,8 +62,24 @@ done
 
 [ -n "$PORT" ] || { echo "wait-for-health.sh: --port is required" >&2; exit 2; }
 
-for _ in $(seq 1 "$TIMEOUT_SECONDS"); do
-  if curl -fs "http://127.0.0.1:${PORT}/api/health" > "$TMP" \
+# Two halves of one bound, and neither works without the other.
+#
+# --max-time, because curl sets no maximum transfer time by default and
+# --connect-timeout stops helping the moment the handshake completes. A Studio
+# that binds the port and then wedges its event loop -- the shape of a wedged
+# server on a 4 vCPU runner with four of them on it -- parks the FIRST
+# iteration forever, and an iteration count is not a deadline if an iteration
+# can be infinite.
+#
+# A real deadline, because once each probe can cost up to --max-time, counting
+# iterations turns "180s" into up to 180 x 6s = 18 minutes: a bound far looser
+# than the one this file advertises, and looser than the lane budget that
+# contains it. $SECONDS is the elapsed wall of this shell, so the wait is now
+# TIMEOUT_SECONDS of real time no matter what each probe costs.
+deadline=$(( SECONDS + TIMEOUT_SECONDS ))
+while [ "$SECONDS" -lt "$deadline" ]; do
+  if curl -fs --connect-timeout 3 --max-time 5 \
+       "http://127.0.0.1:${PORT}/api/health" > "$TMP" \
      && jq -e '.status == "healthy"' "$TMP" > /dev/null; then
     echo "[health] 127.0.0.1:${PORT} reported healthy"
     exit 0

--- a/.github/workflows/studio-windows-ui-smoke.yml
+++ b/.github/workflows/studio-windows-ui-smoke.yml
@@ -380,28 +380,120 @@ jobs:
       # split and why there are two lanes and not five. Wait on BOTH before
       # failing: backgrounding defeats `set -e`, and without an explicit
       # wait-and-collect one lane's breakage hides the other's.
+      #
+      # AND BOUND BOTH. Nothing here used to have a deadline shorter than the
+      # job's own 45 minutes. Every wait inside the suites is per-operation --
+      # 60s default, 540s a turn, 1080s for the rapid-submit predicate -- and
+      # five turns of a stalled model reach the job cap before any single one of
+      # them fires. On the #9425 branch this step started at 04:33:01 and never
+      # returned; the runner killed the job at its cap and GitHub recorded the
+      # result as "cancelled", which `gh pr checks` renders as a failure and
+      # which reads exactly like ordinary concurrency supersession. See
+      # studio-backend-ci.yml, wedged the same way and bounded the same way.
+      #
+      # And it left nothing to read. The lane .out files are only cat'ed after
+      # both `wait`s return, so a stalled step prints NOTHING while it stalls;
+      # the `if: always()` artifact upload does not run when the runner kills
+      # the job at its cap; and Python block-buffers stdout into a file, so the
+      # buffer went down with the process. 48 minutes, no logs, no artifacts.
+      #
+      # So: `timeout` per lane, a heartbeat while they run, unbuffered stdout so
+      # what they printed survives being killed, and the server log tailed next
+      # to the lane log because a lane killed mid-turn is usually explained by
+      # the llama-server it was driving. A lane that wedges now fails, names
+      # itself, and leaves evidence, and its sibling still reports its own
+      # result instead of being buried with it.
       - name: Drive the UI suites in two parallel lanes
+        # Bounds the whole step below the job's 45m cap even if `timeout` itself
+        # is defeated, and -- the point -- leaves room for "Upload Playwright
+        # artifacts" to actually run. ~7m of prologue precedes this step.
+        timeout-minutes: 28
         env:
           GGUF_REPO: ${{ env.GGUF_REPO }}
           GGUF_VARIANT: ${{ env.GGUF_VARIANT }}
+          # Block-buffered stdout is discarded when a wedged lane is killed,
+          # which is the one run whose output is worth having.
+          PYTHONUNBUFFERED: '1'
         run: |
           mkdir -p logs
+          # The backstop, not the first line of defence: the suites' own wall
+          # watchdogs should fire first and say which step they died on. 1500s
+          # is 3.6x the measured lane wall (375s chat, 413s extra) and 3x the
+          # slowest this step has ever been while succeeding (508s over 521
+          # runs). The failures it is here for sat at 2900s. SIGINT first so a
+          # suite can unwind and print the wait it was stuck on; SIGKILL 60s
+          # later for the native Windows processes MSYS cannot signal politely.
+          #
+          lane_timeout=1500
+
+          # Which `timeout` matters here. C:\Windows\System32\timeout.exe is on
+          # PATH too, with entirely different semantics (`timeout /t N`), and
+          # this job prepends a shim directory to GITHUB_PATH -- so the bare
+          # name is not safe to resolve. Prefer the absolute coreutils path,
+          # accept a bare one that proves itself with --version (which System32
+          # does not answer), and fail loudly rather than silently running the
+          # lanes unbounded again: MinGit trims usr/bin, so this is worth
+          # checking rather than assuming.
+          lane_timeout_bin=""
+          for candidate in /usr/bin/timeout timeout; do
+            if "$candidate" --version >/dev/null 2>&1; then
+              lane_timeout_bin="$candidate"
+              break
+            fi
+          done
+          if [ -z "$lane_timeout_bin" ]; then
+            echo "::error::no GNU coreutils timeout on this runner; the UI lanes would run unbounded and a wedge would burn the whole job again. Install coreutils or bound the lanes another way."
+            exit 1
+          fi
+          echo "[lanes] bounding each lane with $lane_timeout_bin at ${lane_timeout}s"
+
           pids=""
           for lane in chat extra; do
-            bash .github/scripts/run-studio-ui-lane.sh "$lane" \
+            "$lane_timeout_bin" --signal=INT --kill-after=60 "$lane_timeout" \
+              bash .github/scripts/run-studio-ui-lane.sh "$lane" \
               >"logs/lane-$lane.out" 2>&1 &
             pids="$pids $!:$lane"
           done
+
+          # Without this the step is silent for its entire duration, so a stall
+          # is indistinguishable from progress while it is happening.
+          (
+            while sleep 60; do
+              for lane in chat extra; do
+                [ -f "logs/lane-$lane.out" ] || continue
+                echo "[heartbeat ${SECONDS}s] $lane: $(tail -n 1 "logs/lane-$lane.out" 2>/dev/null)"
+              done
+            done
+          ) &
+          heartbeat=$!
+
           rc=0
           for entry in $pids; do
-            if ! wait "${entry%%:*}"; then
-              echo "::error::Windows UI lane ${entry##*:} failed"
-              rc=1
-            fi
+            lane="${entry##*:}"
+            status=0
+            wait "${entry%%:*}" || status=$?
+            [ "$status" -eq 0 ] && continue
+            rc=1
+            case "$status" in
+              124|137)
+                echo "::error::Windows UI lane $lane did not finish within ${lane_timeout}s and was killed. Its last output and its server log are below, and in the uploaded artifacts."
+                ;;
+              *)
+                echo "::error::Windows UI lane $lane failed (exit $status)"
+                ;;
+            esac
           done
+          kill "$heartbeat" 2>/dev/null || true
+
           for f in logs/lane-*.out; do
             echo "::group::$f"
             cat "$f"
+            echo "::endgroup::"
+          done
+          for f in logs/studio-lane-*.log; do
+            [ -f "$f" ] || continue
+            echo "::group::$f (tail)"
+            tail -n 80 "$f"
             echo "::endgroup::"
           done
           exit "$rc"

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -138,11 +138,9 @@ import {
   readTextThoughtSignature,
   claimAutoContinue,
   recordAutoContinue,
-  releaseAutoContinueLease,
-  renewAutoContinueLease,
   shouldAutoContinueMessage,
-  AUTO_CONTINUE_LEASE_RENEW_MS,
 } from "@/features/chat/utils/continuation";
+import { holdAutoContinueRun } from "@/features/chat/utils/auto-continue-run-keeper";
 import { McpComposerButton } from "@/features/chat/mcp-composer-button";
 import { getExternalReasoningCapabilities } from "@/features/chat/provider-capabilities";
 import { useRagToolDisabled } from "@/features/chat/hooks/use-rag-tool-disabled";
@@ -309,8 +307,6 @@ import {
   useCallback,
   useContext,
   useEffect,
-  useId,
-  useMemo,
   useLayoutEffect,
   useRef,
   useState,
@@ -1507,84 +1503,6 @@ const ThreadMessage: FC = () => {
 // being rebuilt, and the bail-out below it would never get to run.
 const renderThreadMessage = proplessSlot(ThreadMessage);
 
-/**
- * The runtime a continuation lease belongs to, and the way a bar hands one over to it.
- *
- * `holder` keeps two runtimes apart: compare mode mounts one per pane, and neither may
- * touch the other's leases. `adopt` is how the bar that took a lease tells its own keeper
- * which MESSAGE to hold, because the bar unmounts as soon as the continuation's sibling
- * becomes the selected branch, taking any timer of its own with it.
- *
- * Empty outside a Thread, which no continuation bar is; the lease then simply runs out its
- * TTL, which is the same thing that happens to a tab that closes mid-run.
- */
-const AutoContinueHolderContext = createContext<{
-  holder: string;
-  adopt: (messageId: string) => void;
-}>({ holder: "", adopt: () => undefined });
-
-/**
- * Hold the lease of the continuation THIS runtime is running, for as long as it runs.
- *
- * Two lists, not one. A holder is a runtime and outlives the runs inside it: when a round
- * ends on another Max Tokens cut, the bar's effect claims the next message before this
- * effect sees `isRunning` go false, because React runs child effects before parent ones.
- * A keeper that renewed or released "everything this holder owns" would settle the round
- * that just started along with the round that ended, and one settle window later another
- * tab could claim it and pay for it twice. So a claim lands in `pending`, only a run
- * starting promotes it to `active`, and only `active` is ever released. The ordering then
- * stops mattering: the next round cannot be in the list being given back, whichever effect
- * ran first and whether or not a lock manager was in the way.
- *
- * Renewed while running, and given back on the first tick that is not -- a finished run, a
- * cancelled one, or a failed one all land there. What is left over after that is a runtime
- * that stopped renewing without saying so, which is a tab that closed or crashed, and the
- * TTL is what covers it.
- */
-function useAutoContinueLeaseKeeper(holder: string): {
-  holder: string;
-  adopt: (messageId: string) => void;
-} {
-  const isRunning = useAuiState(({ thread }) => thread.isRunning);
-  /** Claimed, with no run of this thread observed for it yet. */
-  const pending = useRef<string[]>([]);
-  /** The messages the run currently live is resuming. */
-  const active = useRef<string[]>([]);
-
-  const adopt = useCallback((messageId: string) => {
-    if (messageId && !pending.current.includes(messageId)) {
-      pending.current.push(messageId);
-    }
-  }, []);
-
-  useEffect(() => {
-    if (!isRunning) {
-      // Only what this run was resuming. A message claimed for the NEXT round is still in
-      // `pending` and is not this run's to give back.
-      const finished = active.current;
-      active.current = [];
-      for (const messageId of finished) {
-        void releaseAutoContinueLease(messageId, holder);
-      }
-      return;
-    }
-    active.current = [...active.current, ...pending.current];
-    pending.current = [];
-    const renewActive = () => {
-      for (const messageId of active.current) {
-        void renewAutoContinueLease(messageId, holder);
-      }
-    };
-    renewActive();
-    const timer = setInterval(renewActive, AUTO_CONTINUE_LEASE_RENEW_MS);
-    return () => {
-      clearInterval(timer);
-    };
-  }, [isRunning, holder]);
-
-  return useMemo(() => ({ holder, adopt }), [holder, adopt]);
-}
-
 // Memoized: chat-page renders this inline in a store-subscribing component, so a parent render
 // would otherwise reconcile the whole message list.
 export const Thread: FC<{
@@ -1608,9 +1526,6 @@ export const Thread: FC<{
   const threadId = targetThreadId ?? activeThreadId ?? null;
   const aui = useAui();
   useThreadForkCounts();
-  // Stable per mounted runtime and distinct between the two compare panes, which is
-  // exactly what the leases have to be told apart by.
-  const autoContinueHolder = useAutoContinueLeaseKeeper(useId());
 
   // Measured height of the floating composer dock (null until measured).
   // Drives the bottom spacer and the scroll-to-bottom footer offset.
@@ -1815,7 +1730,6 @@ export const Thread: FC<{
   };
 
   return (
-    <AutoContinueHolderContext.Provider value={autoContinueHolder}>
     <GeneratedImageOverlayProvider key={runtimeThreadId} threadId={threadId}>
       <PageDragContext.Provider value={pageDragging}>
       <ThreadPrimitive.Root
@@ -1927,7 +1841,6 @@ export const Thread: FC<{
       <DocumentPreviewMount />
       </PageDragContext.Provider>
     </GeneratedImageOverlayProvider>
-    </AutoContinueHolderContext.Provider>
   );
 });
 Thread.displayName = "Thread";
@@ -6808,9 +6721,11 @@ const ContinueMessageBarForLastMessage: FC = () => {
   const [claimHeldElsewhere, setClaimHeldElsewhere] = useState(false);
   // The runtime this bar belongs to, so its keeper renews and releases this claim and no
   // other pane's.
-  const { holder: autoContinueHolder, adopt: adoptAutoContinue } = useContext(
-    AutoContinueHolderContext,
-  );
+  // The thread this run will file itself under, which is what the lease belongs to and
+  // what its lifetime is read from. `remoteId`, not `id`: it is the value assistant-ui
+  // passes the adapter as `unstable_threadId` and the key the run appears under in
+  // `runningByThreadId`, and an uninitialized thread has an `id` but no `remoteId`.
+  const runThreadId = useAuiState(({ threadListItem }) => threadListItem.remoteId);
   const autoContinuing =
     !claimHeldElsewhere &&
     resumable &&
@@ -6834,12 +6749,12 @@ const ContinueMessageBarForLastMessage: FC = () => {
     // and returning fired it again, creating another sibling and another paid request.
     // A module claim survived both but not a second TAB, which has its own module scope
     // and its own empty claim; the lease behind this one is shared and settles that.
-    void claimAutoContinue(messageId, autoContinueHolder).then((claim) => {
+    void claimAutoContinue(messageId, runThreadId ?? "").then((claim) => {
       if (claim === "started") {
-        // Handed to this runtime's keeper BEFORE the run starts, so the lease is held
-        // from the first tick of it. The bar cannot hold it itself: the continuation's
-        // sibling becomes the selected branch and unmounts this component almost at once.
-        adoptAutoContinue(messageId);
+        // Held for as long as THIS thread's run generates, wherever the user navigates
+        // to meanwhile. The bar cannot hold it itself: the continuation's sibling becomes
+        // the selected branch and unmounts this component almost at once.
+        holdAutoContinueRun(messageId, runThreadId);
         // Started whether or not this component is still mounted: the run belongs to the
         // thread, not to the bar, and a claim taken and then dropped would leave the
         // message continued by nobody.
@@ -6864,8 +6779,7 @@ const ContinueMessageBarForLastMessage: FC = () => {
     parentId,
     messageId,
     startContinuation,
-    autoContinueHolder,
-    adoptAutoContinue,
+    runThreadId,
   ]);
 
   // Newest turn only: appending to an older one would strand the replies after it.

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -6751,6 +6751,31 @@ const ContinueMessageBarForLastMessage: FC = () => {
     // and its own empty claim; the lease behind this one is shared and settles that.
     void claimAutoContinue(messageId, runThreadId ?? "").then((claim) => {
       if (claim === "started") {
+        // Is there still a message to resume? `aui.thread()` follows the SELECTION, not
+        // the thread this bar belongs to, so a chat or branch switch inside the window the
+        // Web Lock is pending leaves `startContinuation` looking at a different list, where
+        // it finds nothing and issues no run at all.
+        //
+        // Asked BEFORE anything is held, because a hold whose run never appears is renewed
+        // forever on purpose -- preflight has no upper bound, so no deadline can separate
+        // "never coming" from "still on its way". A hold taken for a run that was never
+        // issued therefore renews its lease for the life of the tab, and every other tab
+        // reads that lease as live and refuses the message for just as long.
+        //
+        // Not the preflight case, and it cannot become it: this is `startRun` never having
+        // been called, decided synchronously off the same store `startContinuation` reads a
+        // line later in the same tick. A run that HAS been issued and is merely slow to
+        // begin passes here and keeps its hold and its renewals.
+        const stillThere = aui
+          .thread()
+          .getState()
+          .messages.some((message) => message.id === messageId);
+        if (!stillThere) {
+          // Nothing held and nothing recorded, so the lease this claim took runs out its
+          // own TTL -- the same thing a tab that closed mid-claim leaves behind -- and the
+          // turn keeps the round no request was ever made for.
+          return;
+        }
         // Held for as long as THIS thread's run generates, wherever the user navigates
         // to meanwhile. The bar cannot hold it itself: the continuation's sibling becomes
         // the selected branch and unmounts this component almost at once.
@@ -6775,6 +6800,7 @@ const ContinueMessageBarForLastMessage: FC = () => {
       mounted = false;
     };
   }, [
+    aui,
     autoContinuing,
     parentId,
     messageId,

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -138,8 +138,8 @@ import {
   readTextThoughtSignature,
   claimAutoContinue,
   recordAutoContinue,
-  releaseAutoContinueLeases,
-  renewAutoContinueLeases,
+  releaseAutoContinueLease,
+  renewAutoContinueLease,
   shouldAutoContinueMessage,
   AUTO_CONTINUE_LEASE_RENEW_MS,
 } from "@/features/chat/utils/continuation";
@@ -310,6 +310,7 @@ import {
   useContext,
   useEffect,
   useId,
+  useMemo,
   useLayoutEffect,
   useRef,
   useState,
@@ -1507,53 +1508,81 @@ const ThreadMessage: FC = () => {
 const renderThreadMessage = proplessSlot(ThreadMessage);
 
 /**
- * Which runtime a lease belongs to, for the bar that takes it and the keeper that holds it.
+ * The runtime a continuation lease belongs to, and the way a bar hands one over to it.
  *
- * Empty outside a Thread, which no continuation bar is. Compare mode mounts a runtime per
- * pane, so this is what keeps one pane's leases apart from the other's.
+ * `holder` keeps two runtimes apart: compare mode mounts one per pane, and neither may
+ * touch the other's leases. `adopt` is how the bar that took a lease tells its own keeper
+ * which MESSAGE to hold, because the bar unmounts as soon as the continuation's sibling
+ * becomes the selected branch, taking any timer of its own with it.
+ *
+ * Empty outside a Thread, which no continuation bar is; the lease then simply runs out its
+ * TTL, which is the same thing that happens to a tab that closes mid-run.
  */
-const AutoContinueHolderContext = createContext("");
+const AutoContinueHolderContext = createContext<{
+  holder: string;
+  adopt: (messageId: string) => void;
+}>({ holder: "", adopt: () => undefined });
 
 /**
- * Hold this runtime's automatic-continuation leases for as long as ITS run is live.
+ * Hold the lease of the continuation THIS runtime is running, for as long as it runs.
  *
- * Thread level, not on the bar that took the lease: the continuation runs as a sibling and
- * becomes the selected branch, so the truncated message unmounts almost immediately and a
- * timer living there would die with it, mid-stream.
- *
- * Scoped to one holder, because thread level is not tab level. Compare mode mounts two of
- * these side by side, each with its own thread and its own run; renewing or releasing
- * every lease the tab owns would let the pane that finishes first end the hold on the pane
- * still generating, whose own renewals would then find nothing held.
+ * Two lists, not one. A holder is a runtime and outlives the runs inside it: when a round
+ * ends on another Max Tokens cut, the bar's effect claims the next message before this
+ * effect sees `isRunning` go false, because React runs child effects before parent ones.
+ * A keeper that renewed or released "everything this holder owns" would settle the round
+ * that just started along with the round that ended, and one settle window later another
+ * tab could claim it and pay for it twice. So a claim lands in `pending`, only a run
+ * starting promotes it to `active`, and only `active` is ever released. The ordering then
+ * stops mattering: the next round cannot be in the list being given back, whichever effect
+ * ran first and whether or not a lock manager was in the way.
  *
  * Renewed while running, and given back on the first tick that is not -- a finished run, a
- * cancelled one, or a failed one all land there. Only the run that follows a claim has
- * anything to renew; every other run finds nothing held and does nothing. What is left
- * over after that is a runtime that stopped renewing without saying so, which is a tab that
- * closed or crashed, and the TTL is what covers it.
+ * cancelled one, or a failed one all land there. What is left over after that is a runtime
+ * that stopped renewing without saying so, which is a tab that closed or crashed, and the
+ * TTL is what covers it.
  */
-function useAutoContinueLeaseKeeper(holder: string): void {
+function useAutoContinueLeaseKeeper(holder: string): {
+  holder: string;
+  adopt: (messageId: string) => void;
+} {
   const isRunning = useAuiState(({ thread }) => thread.isRunning);
-  const wasRunning = useRef(false);
+  /** Claimed, with no run of this thread observed for it yet. */
+  const pending = useRef<string[]>([]);
+  /** The messages the run currently live is resuming. */
+  const active = useRef<string[]>([]);
+
+  const adopt = useCallback((messageId: string) => {
+    if (messageId && !pending.current.includes(messageId)) {
+      pending.current.push(messageId);
+    }
+  }, []);
+
   useEffect(() => {
     if (!isRunning) {
-      // Only on the way down. An idle tick must not release a lease that was taken a
-      // moment ago and whose run has not turned `isRunning` on yet.
-      if (wasRunning.current) {
-        wasRunning.current = false;
-        void releaseAutoContinueLeases(holder);
+      // Only what this run was resuming. A message claimed for the NEXT round is still in
+      // `pending` and is not this run's to give back.
+      const finished = active.current;
+      active.current = [];
+      for (const messageId of finished) {
+        void releaseAutoContinueLease(messageId, holder);
       }
       return;
     }
-    wasRunning.current = true;
-    void renewAutoContinueLeases(holder);
-    const timer = setInterval(() => {
-      void renewAutoContinueLeases(holder);
-    }, AUTO_CONTINUE_LEASE_RENEW_MS);
+    active.current = [...active.current, ...pending.current];
+    pending.current = [];
+    const renewActive = () => {
+      for (const messageId of active.current) {
+        void renewAutoContinueLease(messageId, holder);
+      }
+    };
+    renewActive();
+    const timer = setInterval(renewActive, AUTO_CONTINUE_LEASE_RENEW_MS);
     return () => {
       clearInterval(timer);
     };
   }, [isRunning, holder]);
+
+  return useMemo(() => ({ holder, adopt }), [holder, adopt]);
 }
 
 // Memoized: chat-page renders this inline in a store-subscribing component, so a parent render
@@ -1581,8 +1610,7 @@ export const Thread: FC<{
   useThreadForkCounts();
   // Stable per mounted runtime and distinct between the two compare panes, which is
   // exactly what the leases have to be told apart by.
-  const autoContinueHolder = useId();
-  useAutoContinueLeaseKeeper(autoContinueHolder);
+  const autoContinueHolder = useAutoContinueLeaseKeeper(useId());
 
   // Measured height of the floating composer dock (null until measured).
   // Drives the bottom spacer and the scroll-to-bottom footer offset.
@@ -6780,7 +6808,9 @@ const ContinueMessageBarForLastMessage: FC = () => {
   const [claimHeldElsewhere, setClaimHeldElsewhere] = useState(false);
   // The runtime this bar belongs to, so its keeper renews and releases this claim and no
   // other pane's.
-  const autoContinueHolder = useContext(AutoContinueHolderContext);
+  const { holder: autoContinueHolder, adopt: adoptAutoContinue } = useContext(
+    AutoContinueHolderContext,
+  );
   const autoContinuing =
     !claimHeldElsewhere &&
     resumable &&
@@ -6806,6 +6836,10 @@ const ContinueMessageBarForLastMessage: FC = () => {
     // and its own empty claim; the lease behind this one is shared and settles that.
     void claimAutoContinue(messageId, autoContinueHolder).then((claim) => {
       if (claim === "started") {
+        // Handed to this runtime's keeper BEFORE the run starts, so the lease is held
+        // from the first tick of it. The bar cannot hold it itself: the continuation's
+        // sibling becomes the selected branch and unmounts this component almost at once.
+        adoptAutoContinue(messageId);
         // Started whether or not this component is still mounted: the run belongs to the
         // thread, not to the bar, and a claim taken and then dropped would leave the
         // message continued by nobody.
@@ -6831,6 +6865,7 @@ const ContinueMessageBarForLastMessage: FC = () => {
     messageId,
     startContinuation,
     autoContinueHolder,
+    adoptAutoContinue,
   ]);
 
   // Newest turn only: appending to an older one would strand the replies after it.

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -309,6 +309,7 @@ import {
   useCallback,
   useContext,
   useEffect,
+  useId,
   useLayoutEffect,
   useRef,
   useState,
@@ -1506,19 +1507,32 @@ const ThreadMessage: FC = () => {
 const renderThreadMessage = proplessSlot(ThreadMessage);
 
 /**
- * Hold this tab's automatic-continuation leases for as long as a run is live.
+ * Which runtime a lease belongs to, for the bar that takes it and the keeper that holds it.
+ *
+ * Empty outside a Thread, which no continuation bar is. Compare mode mounts a runtime per
+ * pane, so this is what keeps one pane's leases apart from the other's.
+ */
+const AutoContinueHolderContext = createContext("");
+
+/**
+ * Hold this runtime's automatic-continuation leases for as long as ITS run is live.
  *
  * Thread level, not on the bar that took the lease: the continuation runs as a sibling and
  * becomes the selected branch, so the truncated message unmounts almost immediately and a
  * timer living there would die with it, mid-stream.
  *
+ * Scoped to one holder, because thread level is not tab level. Compare mode mounts two of
+ * these side by side, each with its own thread and its own run; renewing or releasing
+ * every lease the tab owns would let the pane that finishes first end the hold on the pane
+ * still generating, whose own renewals would then find nothing held.
+ *
  * Renewed while running, and given back on the first tick that is not -- a finished run, a
  * cancelled one, or a failed one all land there. Only the run that follows a claim has
  * anything to renew; every other run finds nothing held and does nothing. What is left
- * over after that is a tab that stopped renewing without saying so, which is a tab that
+ * over after that is a runtime that stopped renewing without saying so, which is a tab that
  * closed or crashed, and the TTL is what covers it.
  */
-function useAutoContinueLeaseKeeper(): void {
+function useAutoContinueLeaseKeeper(holder: string): void {
   const isRunning = useAuiState(({ thread }) => thread.isRunning);
   const wasRunning = useRef(false);
   useEffect(() => {
@@ -1527,19 +1541,19 @@ function useAutoContinueLeaseKeeper(): void {
       // moment ago and whose run has not turned `isRunning` on yet.
       if (wasRunning.current) {
         wasRunning.current = false;
-        void releaseAutoContinueLeases();
+        void releaseAutoContinueLeases(holder);
       }
       return;
     }
     wasRunning.current = true;
-    void renewAutoContinueLeases();
+    void renewAutoContinueLeases(holder);
     const timer = setInterval(() => {
-      void renewAutoContinueLeases();
+      void renewAutoContinueLeases(holder);
     }, AUTO_CONTINUE_LEASE_RENEW_MS);
     return () => {
       clearInterval(timer);
     };
-  }, [isRunning]);
+  }, [isRunning, holder]);
 }
 
 // Memoized: chat-page renders this inline in a store-subscribing component, so a parent render
@@ -1565,7 +1579,10 @@ export const Thread: FC<{
   const threadId = targetThreadId ?? activeThreadId ?? null;
   const aui = useAui();
   useThreadForkCounts();
-  useAutoContinueLeaseKeeper();
+  // Stable per mounted runtime and distinct between the two compare panes, which is
+  // exactly what the leases have to be told apart by.
+  const autoContinueHolder = useId();
+  useAutoContinueLeaseKeeper(autoContinueHolder);
 
   // Measured height of the floating composer dock (null until measured).
   // Drives the bottom spacer and the scroll-to-bottom footer offset.
@@ -1770,6 +1787,7 @@ export const Thread: FC<{
   };
 
   return (
+    <AutoContinueHolderContext.Provider value={autoContinueHolder}>
     <GeneratedImageOverlayProvider key={runtimeThreadId} threadId={threadId}>
       <PageDragContext.Provider value={pageDragging}>
       <ThreadPrimitive.Root
@@ -1881,6 +1899,7 @@ export const Thread: FC<{
       <DocumentPreviewMount />
       </PageDragContext.Provider>
     </GeneratedImageOverlayProvider>
+    </AutoContinueHolderContext.Provider>
   );
 });
 Thread.displayName = "Thread";
@@ -6759,6 +6778,9 @@ const ContinueMessageBarForLastMessage: FC = () => {
   // so the answer has to come back as state: without it this tab keeps a spinner for a
   // run it never started, with the manual Continue button hidden behind it.
   const [claimHeldElsewhere, setClaimHeldElsewhere] = useState(false);
+  // The runtime this bar belongs to, so its keeper renews and releases this claim and no
+  // other pane's.
+  const autoContinueHolder = useContext(AutoContinueHolderContext);
   const autoContinuing =
     !claimHeldElsewhere &&
     resumable &&
@@ -6782,7 +6804,7 @@ const ContinueMessageBarForLastMessage: FC = () => {
     // and returning fired it again, creating another sibling and another paid request.
     // A module claim survived both but not a second TAB, which has its own module scope
     // and its own empty claim; the lease behind this one is shared and settles that.
-    void claimAutoContinue(messageId).then((claim) => {
+    void claimAutoContinue(messageId, autoContinueHolder).then((claim) => {
       if (claim === "started") {
         // Started whether or not this component is still mounted: the run belongs to the
         // thread, not to the bar, and a claim taken and then dropped would leave the
@@ -6803,7 +6825,13 @@ const ContinueMessageBarForLastMessage: FC = () => {
     return () => {
       mounted = false;
     };
-  }, [autoContinuing, parentId, messageId, startContinuation]);
+  }, [
+    autoContinuing,
+    parentId,
+    messageId,
+    startContinuation,
+    autoContinueHolder,
+  ]);
 
   // Newest turn only: appending to an older one would strand the replies after it.
   // A turn cut mid-thought has no text to resume from, so Retry stays the way out.

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -138,7 +138,10 @@ import {
   readTextThoughtSignature,
   claimAutoContinue,
   recordAutoContinue,
+  releaseAutoContinueLeases,
+  renewAutoContinueLeases,
   shouldAutoContinueMessage,
+  AUTO_CONTINUE_LEASE_RENEW_MS,
 } from "@/features/chat/utils/continuation";
 import { McpComposerButton } from "@/features/chat/mcp-composer-button";
 import { getExternalReasoningCapabilities } from "@/features/chat/provider-capabilities";
@@ -1502,6 +1505,43 @@ const ThreadMessage: FC = () => {
 // being rebuilt, and the bail-out below it would never get to run.
 const renderThreadMessage = proplessSlot(ThreadMessage);
 
+/**
+ * Hold this tab's automatic-continuation leases for as long as a run is live.
+ *
+ * Thread level, not on the bar that took the lease: the continuation runs as a sibling and
+ * becomes the selected branch, so the truncated message unmounts almost immediately and a
+ * timer living there would die with it, mid-stream.
+ *
+ * Renewed while running, and given back on the first tick that is not -- a finished run, a
+ * cancelled one, or a failed one all land there. Only the run that follows a claim has
+ * anything to renew; every other run finds nothing held and does nothing. What is left
+ * over after that is a tab that stopped renewing without saying so, which is a tab that
+ * closed or crashed, and the TTL is what covers it.
+ */
+function useAutoContinueLeaseKeeper(): void {
+  const isRunning = useAuiState(({ thread }) => thread.isRunning);
+  const wasRunning = useRef(false);
+  useEffect(() => {
+    if (!isRunning) {
+      // Only on the way down. An idle tick must not release a lease that was taken a
+      // moment ago and whose run has not turned `isRunning` on yet.
+      if (wasRunning.current) {
+        wasRunning.current = false;
+        void releaseAutoContinueLeases();
+      }
+      return;
+    }
+    wasRunning.current = true;
+    void renewAutoContinueLeases();
+    const timer = setInterval(() => {
+      void renewAutoContinueLeases();
+    }, AUTO_CONTINUE_LEASE_RENEW_MS);
+    return () => {
+      clearInterval(timer);
+    };
+  }, [isRunning]);
+}
+
 // Memoized: chat-page renders this inline in a store-subscribing component, so a parent render
 // would otherwise reconcile the whole message list.
 export const Thread: FC<{
@@ -1525,6 +1565,7 @@ export const Thread: FC<{
   const threadId = targetThreadId ?? activeThreadId ?? null;
   const aui = useAui();
   useThreadForkCounts();
+  useAutoContinueLeaseKeeper();
 
   // Measured height of the floating composer dock (null until measured).
   // Drives the bottom spacer and the scroll-to-bottom footer offset.
@@ -6712,7 +6753,14 @@ const ContinueMessageBarForLastMessage: FC = () => {
   // arriving at a message the claim below has already taken -- the branch picker back to
   // the truncated sibling, or returning to the chat -- would otherwise show a spinner for
   // a run `claimAutoContinue` refuses to start, on top of the Continue button it hides.
+  //
+  // Another tab won the message. The claim resolves after this component has already
+  // rendered off `shouldAutoContinueMessage`, which cannot see a race the lock decides,
+  // so the answer has to come back as state: without it this tab keeps a spinner for a
+  // run it never started, with the manual Continue button hidden behind it.
+  const [claimHeldElsewhere, setClaimHeldElsewhere] = useState(false);
   const autoContinuing =
+    !claimHeldElsewhere &&
     resumable &&
     shouldAutoContinueMessage(messageId, reason, parentId, {
       fits: truncation?.fits,
@@ -6725,20 +6773,36 @@ const ContinueMessageBarForLastMessage: FC = () => {
     if (!autoContinuing || !parentId) {
       return;
     }
-    // Claimed in module scope, not a ref. `<StrictMode>` in src/main.tsx replays this
-    // effect on the same fiber with the same `autoContinuing`, so nothing inside would
-    // have differed, and rechecking the round budget would not help either: one recorded
-    // round still leaves the limit unspent. A ref fixed the replay but not a real
-    // remount, so leaving the chat with a truncated branch selected and returning fired
-    // it again, creating another sibling and another paid request. The claim survives
-    // both, and is the same seam `resetAutoContinue()` clears.
-    if (!claimAutoContinue(messageId)) {
-      return;
-    }
-    // Recorded BEFORE the run, so a round that produces nothing still spends its budget
-    // instead of re-firing this effect forever.
-    recordAutoContinue(parentId);
-    startContinuation();
+    let mounted = true;
+    // Claimed in module scope, not a ref, and under a cross-tab lock. `<StrictMode>` in
+    // src/main.tsx replays this effect on the same fiber with the same `autoContinuing`,
+    // so nothing inside would have differed, and rechecking the round budget would not
+    // help either: one recorded round still leaves the limit unspent. A ref fixed the
+    // replay but not a real remount, so leaving the chat with a truncated branch selected
+    // and returning fired it again, creating another sibling and another paid request.
+    // A module claim survived both but not a second TAB, which has its own module scope
+    // and its own empty claim; the lease behind this one is shared and settles that.
+    void claimAutoContinue(messageId).then((claim) => {
+      if (claim === "started") {
+        // Started whether or not this component is still mounted: the run belongs to the
+        // thread, not to the bar, and a claim taken and then dropped would leave the
+        // message continued by nobody.
+        //
+        // Recorded BEFORE the run, so a round that produces nothing still spends its
+        // budget instead of re-firing this effect forever.
+        recordAutoContinue(parentId);
+        startContinuation();
+        return;
+      }
+      // `skipped` is this tab's own duplicate call, where the run is coming from the
+      // other one and nothing on screen should move.
+      if (claim === "held-elsewhere" && mounted) {
+        setClaimHeldElsewhere(true);
+      }
+    });
+    return () => {
+      mounted = false;
+    };
   }, [autoContinuing, parentId, messageId, startContinuation]);
 
   // Newest turn only: appending to an older one would strand the replies after it.

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -137,6 +137,7 @@ import {
   readIncompleteInfo,
   readTextThoughtSignature,
   claimAutoContinue,
+  forgetAutoContinue,
   recordAutoContinue,
   shouldAutoContinueMessage,
 } from "@/features/chat/utils/continuation";
@@ -6718,7 +6719,15 @@ const ContinueMessageBarForLastMessage: FC = () => {
   // rendered off `shouldAutoContinueMessage`, which cannot see a race the lock decides,
   // so the answer has to come back as state: without it this tab keeps a spinner for a
   // run it never started, with the manual Continue button hidden behind it.
-  const [claimHeldElsewhere, setClaimHeldElsewhere] = useState(false);
+  //
+  // Remembered as the message the answer was decided for, not as a bare flag: rows are
+  // mounted by INDEX (`<MessageByIndexProvider key={index}>` in progressive-messages.tsx),
+  // so selecting a different truncated branch at the same index re-renders THIS component
+  // instead of remounting it. A boolean survived that and suppressed the automatic
+  // continuation of a message no other tab had claimed, for as long as the row lived.
+  // Comparing ids re-answers per message while still refusing the one that really lost.
+  const [heldElsewhereFor, setHeldElsewhereFor] = useState<string | null>(null);
+  const claimHeldElsewhere = heldElsewhereFor === messageId;
   // The runtime this bar belongs to, so its keeper renews and releases this claim and no
   // other pane's.
   // The thread this run will file itself under, which is what the lease belongs to and
@@ -6774,6 +6783,13 @@ const ContinueMessageBarForLastMessage: FC = () => {
           // Nothing held and nothing recorded, so the lease this claim took runs out its
           // own TTL -- the same thing a tab that closed mid-claim leaves behind -- and the
           // turn keeps the round no request was ever made for.
+          //
+          // The claim itself is given back, and only inside this tab: it is what makes
+          // `claimAutoContinue` answer "skipped" for a message it has already continued,
+          // and a message nothing was issued for has not been continued at all. Left in,
+          // returning to this branch found the message skipped for the life of the tab.
+          // The lease stays, so no second tab may start while this one is still deciding.
+          forgetAutoContinue(messageId);
           return;
         }
         // Held for as long as THIS thread's run generates, wherever the user navigates
@@ -6793,7 +6809,7 @@ const ContinueMessageBarForLastMessage: FC = () => {
       // `skipped` is this tab's own duplicate call, where the run is coming from the
       // other one and nothing on screen should move.
       if (claim === "held-elsewhere" && mounted) {
-        setClaimHeldElsewhere(true);
+        setHeldElsewhereFor(messageId);
       }
     });
     return () => {

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -170,7 +170,10 @@ import {
   type LastLocalModelKind,
 } from "../utils/last-local-model-load";
 import { createRetryableSharedRead } from "../utils/retryable-shared-read";
-import { getImageInputUnavailableReason } from "../utils/image-input-support";
+import {
+  createImageGateRunOwner,
+  getImageInputUnavailableReason,
+} from "../utils/image-input-support";
 import { mergeContextTruncation } from "../utils/context-truncation";
 import {
   createThinkTagTracker,
@@ -4650,8 +4653,10 @@ export function createOpenAIStreamAdapter(
           // before the streaming path's setThreadRunning(true).
           const gatedThreadKey = resolvedThreadId || "__default";
           // Own token: siblings share "__default", so an ownerless clear would drop their
-          // entries while they are still generating.
-          const gateOwner = () => {};
+          // entries while they are still generating. Marked as the gate's, so a reader that
+          // means "this thread's run started" is not told one did by a pair of flags that
+          // stand for a request nobody made.
+          const gateOwner = createImageGateRunOwner();
           runtime.setThreadRunning(gatedThreadKey, true, { owner: gateOwner });
           runtime.setThreadRunning(gatedThreadKey, false, { owner: gateOwner });
           clearSelectedImageEditReference();

--- a/studio/frontend/src/features/chat/utils/auto-continue-run-keeper.ts
+++ b/studio/frontend/src/features/chat/utils/auto-continue-run-keeper.ts
@@ -16,6 +16,7 @@ import {
   AUTO_CONTINUE_LEASE_RENEW_MS,
   createAutoContinueLeaseKeeper,
 } from "./continuation";
+import { isImageGateRunOnly } from "./image-input-support";
 import {
   PROMPT_QUEUE_RUN_FAILED_EVENT,
   type PromptQueueRunFailedEventDetail,
@@ -23,8 +24,30 @@ import {
 
 const keeper = createAutoContinueLeaseKeeper({
   signal: {
-    isRunning: (threadId) =>
-      Boolean(useChatRuntimeStore.getState().runningByThreadId[threadId]),
+    /**
+     * Generating, and not the image gate settling its waiters.
+     *
+     * A continuation carrying an image that the loaded model cannot read -- a chat with a
+     * picture in it, reopened on a truncated reply with a text-only model loaded, or with
+     * Vision switched off since -- is refused before any request is made, and the gate
+     * pulses this field true and then false so compare mode's `waitForRunEnd` resolves. To
+     * a hold that is waiting for its own run to start, that pair reads as the run starting
+     * and finishing: it arms on the first and is released on the second, with the `done`
+     * marker that tells every other tab for a day that the message HAS been continued. The
+     * failure that follows cannot undo it, because a released hold is gone. So the pulse is
+     * not counted as a run, the hold never arms, and the failure discards it as it does any
+     * other run that died before it started.
+     *
+     * Only when the gate is ALL that holds the flag. A real run sharing the key -- the
+     * other compare pane, or a sibling under "__default" -- still answers yes.
+     */
+    isRunning: (threadId) => {
+      const state = useChatRuntimeStore.getState();
+      return (
+        Boolean(state.runningByThreadId[threadId]) &&
+        !isImageGateRunOnly(state.runOwnerByThreadId[threadId])
+      );
+    },
     subscribe: (onChange) => useChatRuntimeStore.subscribe(onChange),
   },
 });

--- a/studio/frontend/src/features/chat/utils/auto-continue-run-keeper.ts
+++ b/studio/frontend/src/features/chat/utils/auto-continue-run-keeper.ts
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+/**
+ * Wires the automatic-continuation lease keeper to the runs actually in flight.
+ *
+ * The keeper itself is in `continuation.ts` and knows nothing about this app; all it asks
+ * for is "is thread X generating right now", which `runningByThreadId` answers per thread
+ * and regardless of what is on screen. The same store field is what the prompt queue uses
+ * for completion detection, for the same reason: it "tracks the actual thread (not
+ * aui.thread()), so detection survives navigation".
+ */
+
+import { useChatRuntimeStore } from "../stores/chat-runtime-store";
+import {
+  AUTO_CONTINUE_LEASE_RENEW_MS,
+  createAutoContinueLeaseKeeper,
+} from "./continuation";
+
+const keeper = createAutoContinueLeaseKeeper({
+  signal: {
+    isRunning: (threadId) =>
+      Boolean(useChatRuntimeStore.getState().runningByThreadId[threadId]),
+    subscribe: (onChange) => useChatRuntimeStore.subscribe(onChange),
+  },
+});
+
+let timer: ReturnType<typeof setInterval> | null = null;
+
+function tick(): void {
+  keeper.tick();
+  if (keeper.held() === 0 && timer !== null) {
+    clearInterval(timer);
+    timer = null;
+  }
+}
+
+/**
+ * Hold `messageId`'s lease for as long as `threadId`'s own run is generating.
+ *
+ * Called by the continuation bar at the moment it starts a run, because that is the last
+ * point at which anything knows both ids: the bar unmounts as soon as the continuation's
+ * sibling becomes the selected branch, and the thread it ran on may not be the one on
+ * screen a second later.
+ *
+ * `threadId` is the key the run files itself under, which is `threadListItem.remoteId` --
+ * the same value assistant-ui passes the adapter as `unstable_threadId`. A thread with no
+ * remote id yet (the first turn of a New Chat) files its run under a shared placeholder
+ * that is not safe to watch, so nothing is held for it and its lease simply runs out its
+ * TTL. That is the same outcome as a tab closing mid-run, and it is never an early release.
+ */
+export function holdAutoContinueRun(
+  messageId: string,
+  threadId: string | undefined,
+): void {
+  if (!threadId) {
+    return;
+  }
+  keeper.hold(messageId, threadId);
+  timer ??= setInterval(tick, AUTO_CONTINUE_LEASE_RENEW_MS);
+}

--- a/studio/frontend/src/features/chat/utils/auto-continue-run-keeper.ts
+++ b/studio/frontend/src/features/chat/utils/auto-continue-run-keeper.ts
@@ -16,6 +16,10 @@ import {
   AUTO_CONTINUE_LEASE_RENEW_MS,
   createAutoContinueLeaseKeeper,
 } from "./continuation";
+import {
+  PROMPT_QUEUE_RUN_FAILED_EVENT,
+  type PromptQueueRunFailedEventDetail,
+} from "./prompt-queue-boundary";
 
 const keeper = createAutoContinueLeaseKeeper({
   signal: {
@@ -34,6 +38,30 @@ function tick(): void {
     timer = null;
   }
 }
+
+/**
+ * A run that failed before it ever reached `runningByThreadId`.
+ *
+ * The adapter wrapper catches everything `adapter.run` throws -- this chat's settings
+ * pairing running out, a model that will not load, a connection it refuses -- and announces
+ * it per thread, which is the only signal that separates a preflight that FAILED from one
+ * that is merely long. Nothing here reads a clock: a slow run emits no event and keeps its
+ * hold and its renewals, which is what the absence of an arming deadline is for.
+ */
+function onRunFailed(event: Event): void {
+  const threadId = (event as CustomEvent<PromptQueueRunFailedEventDetail>)
+    .detail?.threadId;
+  if (!threadId) {
+    return;
+  }
+  keeper.failed(threadId);
+  if (keeper.held() === 0 && timer !== null) {
+    clearInterval(timer);
+    timer = null;
+  }
+}
+
+let listening = false;
 
 /**
  * Hold `messageId`'s lease for as long as `threadId`'s own run is generating.
@@ -57,5 +85,11 @@ export function holdAutoContinueRun(
     return;
   }
   keeper.hold(messageId, threadId);
+  // Registered with the first hold rather than at import, so a module nobody continues in
+  // adds no listener. Once, and never removed: it is one handler for the tab.
+  if (!listening && typeof window !== "undefined") {
+    listening = true;
+    window.addEventListener(PROMPT_QUEUE_RUN_FAILED_EVENT, onRunFailed);
+  }
   timer ??= setInterval(tick, AUTO_CONTINUE_LEASE_RENEW_MS);
 }

--- a/studio/frontend/src/features/chat/utils/continuation.ts
+++ b/studio/frontend/src/features/chat/utils/continuation.ts
@@ -374,30 +374,244 @@ export function autoContinueCount(key: string | null | undefined): number {
 }
 
 /**
- * Messages this session has already continued automatically, by message id.
+ * How long a claim written to shared storage keeps other tabs off a message.
  *
- * Separate from `spent`, which counts rounds per logical turn and is what bounds a
- * runaway loop. This answers a different question: has THIS message already been
- * resumed once. A component-local ref cannot, because it dies with the component.
- * Leave the chat with a truncated branch selected and come back, and the ref is fresh
- * while the parent still has budget, so the effect fires again and creates another
- * sibling and another paid request. Module scope outlives the remount; the ids are
- * short and bounded by how many replies a session truncates.
+ * A lease, not a permanent flag: the tab that wins can be closed or crash mid-run, and a
+ * flag it never gets to clear would leave the message unresumable for the life of the
+ * profile. Two minutes covers a whole round -- prompt processing plus a full Max Tokens
+ * generation on a local model -- so a tab opened while the winner is still streaming stays
+ * out, while a tab that died takes the message back after one pause the user is likely
+ * still sitting through. Erring longer wedges a live message; erring shorter buys the
+ * duplicate request back.
  */
-const continued = new Set<string>();
+export const AUTO_CONTINUE_LEASE_TTL_MS = 120_000;
 
-/** Whether `messageId` still needs continuing. False once it has been claimed. */
-export function claimAutoContinue(messageId: string | null | undefined): boolean {
-  if (!messageId || continued.has(messageId)) {
-    return false;
+/** The `localStorage` key holding the leases, one record per claimed message id. */
+export const AUTO_CONTINUE_LEASE_KEY = "unsloth_chat_auto_continue_leases";
+
+/** The slice of `Storage` the lease needs. Narrow so a test can hand over a fake. */
+export type AutoContinueLeaseStorage = {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+};
+
+type Lease = { token: string; expires: number };
+
+/**
+ * The browser's own storage, or nothing when there is not one to read.
+ *
+ * Resolved per call rather than once at import: `localStorage` is absent under the test
+ * runner and in SSR, and Safari's private mode throws on the property itself, not just on
+ * a write. Every caller treats null as "no cross-tab seam" and falls back to the module
+ * claim below, which is exactly what shipped before the lease existed.
+ */
+function browserLeaseStorage(): AutoContinueLeaseStorage | null {
+  try {
+    if (typeof window === "undefined") {
+      return null;
+    }
+    return (window.localStorage as AutoContinueLeaseStorage | undefined) ?? null;
+  } catch {
+    return null;
   }
-  continued.add(messageId);
-  return true;
 }
 
-/** Whether `messageId` was already continued automatically this session. */
+function readLeases(storage: AutoContinueLeaseStorage): Record<string, Lease> {
+  const raw = storage.getItem(AUTO_CONTINUE_LEASE_KEY);
+  if (!raw) {
+    return {};
+  }
+  const parsed = JSON.parse(raw) as unknown;
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    return {};
+  }
+  const out: Record<string, Lease> = {};
+  for (const [id, value] of Object.entries(parsed as Record<string, unknown>)) {
+    const token = (value as Lease | undefined)?.token;
+    const expires = (value as Lease | undefined)?.expires;
+    if (typeof token === "string" && typeof expires === "number") {
+      out[id] = { token, expires };
+    }
+  }
+  return out;
+}
+
+function newLeaseToken(): string {
+  const uuid = (globalThis.crypto as Crypto | undefined)?.randomUUID;
+  if (typeof uuid === "function") {
+    return uuid.call(globalThis.crypto);
+  }
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+}
+
+/**
+ * One tab's view of which messages have been continued.
+ *
+ * Constructible because a second instance is precisely what a second browser tab is: its
+ * own module scope, its own empty claim set, the same saved thread and the same shared
+ * storage underneath. That is the case the lease exists for, and the only way to write it
+ * down as a test.
+ */
+export function createAutoContinueTab(
+  {
+    storage,
+  }: {
+    /** Omit for the browser's `localStorage`; pass null for a tab with no seam. */
+    storage?: AutoContinueLeaseStorage | null;
+  } = {},
+): {
+  claim: (
+    messageId: string | null | undefined,
+    options?: { now?: number },
+  ) => boolean;
+  claimed: (
+    messageId: string | null | undefined,
+    options?: { now?: number },
+  ) => boolean;
+  reset: () => void;
+} {
+  /**
+   * Messages this tab has already continued automatically, by message id.
+   *
+   * Separate from `spent`, which counts rounds per logical turn and is what bounds a
+   * runaway loop. This answers a different question: has THIS message already been
+   * resumed once. A component-local ref cannot, because it dies with the component.
+   * Leave the chat with a truncated branch selected and come back, and the ref is fresh
+   * while the parent still has budget, so the effect fires again and creates another
+   * sibling and another paid request. Module scope outlives the remount; the ids are
+   * short and bounded by how many replies a session truncates.
+   */
+  const continued = new Set<string>();
+
+  /** Lease tokens this tab wrote, so a reset clears its own and nobody else's. */
+  const ownTokens = new Map<string, string>();
+
+  const seam = (): AutoContinueLeaseStorage | null =>
+    storage === undefined ? browserLeaseStorage() : storage;
+
+  /** A lease held by ANY tab, this one included, or null. Expired reads as free. */
+  function liveLease(messageId: string, now: number): Lease | null {
+    const store = seam();
+    if (!store) {
+      return null;
+    }
+    try {
+      const lease = readLeases(store)[messageId];
+      return lease && lease.expires > now ? lease : null;
+    } catch {
+      // Unreadable storage is no worse than no storage: fall back to module scope.
+      return null;
+    }
+  }
+
+  /**
+   * Take the lease for `messageId`, or report that someone else holds it.
+   *
+   * Written then read back, because two tabs can pass the free check in the same tick;
+   * whichever `setItem` lands second is the token still in storage afterwards, so the
+   * other tab reads a token that is not its own and stands down. A storage that cannot be
+   * written is not an error: the tab keeps the module-only claim, which is what single-tab
+   * use has always relied on, rather than refusing a continuation the user is waiting for.
+   */
+  function takeLease(messageId: string, now: number): boolean {
+    const store = seam();
+    if (!store) {
+      return true;
+    }
+    try {
+      const token = newLeaseToken();
+      const leases = readLeases(store);
+      const held = leases[messageId];
+      if (held && held.expires > now && held.token !== ownTokens.get(messageId)) {
+        // Landed between the check above and this write. Never overwrite a live lease.
+        return false;
+      }
+      const next: Record<string, Lease> = {};
+      for (const [id, lease] of Object.entries(leases)) {
+        // Drop what has lapsed, so the key cannot grow with every truncated reply.
+        if (lease.expires > now) {
+          next[id] = lease;
+        }
+      }
+      next[messageId] = { token, expires: now + AUTO_CONTINUE_LEASE_TTL_MS };
+      store.setItem(AUTO_CONTINUE_LEASE_KEY, JSON.stringify(next));
+      if (readLeases(store)[messageId]?.token !== token) {
+        return false;
+      }
+      ownTokens.set(messageId, token);
+      return true;
+    } catch {
+      return true;
+    }
+  }
+
+  return {
+    claim(messageId, { now = Date.now() } = {}) {
+      if (!messageId || continued.has(messageId)) {
+        return false;
+      }
+      if (liveLease(messageId, now)) {
+        // Another tab is running this one. Not recorded locally: if that tab dies, this
+        // one takes the message back when the lease lapses.
+        return false;
+      }
+      if (!takeLease(messageId, now)) {
+        return false;
+      }
+      continued.add(messageId);
+      return true;
+    },
+    claimed(messageId, { now = Date.now() } = {}) {
+      if (!messageId) {
+        return false;
+      }
+      return continued.has(messageId) || Boolean(liveLease(messageId, now));
+    },
+    reset() {
+      continued.clear();
+      const store = seam();
+      if (!store || ownTokens.size === 0) {
+        ownTokens.clear();
+        return;
+      }
+      try {
+        const leases = readLeases(store);
+        for (const [id, token] of ownTokens) {
+          if (leases[id]?.token === token) {
+            delete leases[id];
+          }
+        }
+        store.setItem(AUTO_CONTINUE_LEASE_KEY, JSON.stringify(leases));
+      } catch {
+        // Nothing to undo: an unwritable seam held no lease of ours either.
+      }
+      ownTokens.clear();
+    },
+  };
+}
+
+/** This tab. */
+const tab = createAutoContinueTab();
+
+/**
+ * Whether `messageId` still needs continuing. False once it has been claimed, here or in
+ * another tab holding a live lease on it.
+ */
+export function claimAutoContinue(messageId: string | null | undefined): boolean {
+  return tab.claim(messageId);
+}
+
+/**
+ * Whether `messageId` is already being continued automatically -- by this tab, or by
+ * another one whose lease is still live.
+ *
+ * Asked at render time, so the answer has to match what `claimAutoContinue` will do a tick
+ * later. A tab that reported "continuing" and then found the message claimed would show a
+ * spinner nothing is going to resolve, over the manual Continue button it hides.
+ */
 export function wasAutoContinued(messageId: string | null | undefined): boolean {
-  return Boolean(messageId && continued.has(messageId));
+  return tab.claimed(messageId);
 }
 
 /**
@@ -427,11 +641,17 @@ export function shouldAutoContinueMessage(
   return shouldAutoContinue(reason, key, options);
 }
 
-/** Test seam; also lets a new thread start from zero. */
+/**
+ * Test seam; also lets a new thread start from zero.
+ *
+ * A full reset gives back the leases this tab wrote as well, so "start from zero" means
+ * the same thing it did before the lease existed. Leases other tabs hold are left alone:
+ * they are not this tab's to release, and a run they are driving is still going.
+ */
 export function resetAutoContinue(key?: string): void {
   if (key === undefined) {
     spent.clear();
-    continued.clear();
+    tab.reset();
   } else {
     spent.delete(key);
   }

--- a/studio/frontend/src/features/chat/utils/continuation.ts
+++ b/studio/frontend/src/features/chat/utils/continuation.ts
@@ -397,15 +397,22 @@ export const AUTO_CONTINUE_LEASE_TTL_MS = 180_000;
 export const AUTO_CONTINUE_LEASE_RENEW_MS = 30_000;
 
 /**
- * What a lease is cut back to when the run behind it reaches a terminal state.
+ * How long a record stays behind once the run it covered has finished.
  *
- * Released rather than held, so the TTL only ever covers a crash. Not deleted outright:
- * another tab still showing the pre-continuation branch has not seen the sibling that was
- * just written and would take the message straight back, which is the duplicate this
- * whole file exists to stop. A short settle window is long enough for that tab to pick up
- * the saved thread and short enough to be invisible otherwise.
+ * A lease answers "is somebody running this message"; this answers "has this message
+ * already been continued", which is what the per-tab claim set answers inside the tab that
+ * won and what no other tab has any way of learning. Nothing tells a second tab that the
+ * sibling was written: `notifyChatHistoryUpdated` dispatches a same-window event, no chat
+ * key has a `storage` listener, and persisted messages are re-read only by `history.load`
+ * when a thread is opened. So a tab still holding the pre-continuation branch in memory
+ * takes the message straight back the moment the record goes -- on the next remount of the
+ * bar, which leaving the chat and returning is enough to produce -- and the user pays for a
+ * second continuation from a history that is missing the first.
+ *
+ * Long enough to outlive the sitting the continuation happened in, not permanent: the ids
+ * are pruned like any other record, so the key cannot grow without bound.
  */
-export const AUTO_CONTINUE_LEASE_SETTLE_MS = 30_000;
+export const AUTO_CONTINUE_CONTINUED_TTL_MS = 86_400_000;
 
 /** The `localStorage` key holding the leases, one record per claimed message id. */
 export const AUTO_CONTINUE_LEASE_KEY = "unsloth_chat_auto_continue_leases";
@@ -437,7 +444,16 @@ export type AutoContinueLockManager = {
   request<T>(name: string, callback: () => T | Promise<T>): Promise<T>;
 };
 
-type Lease = { token: string; expires: number };
+type Lease = {
+  token: string;
+  expires: number;
+  /**
+   * The run this record covered reached a terminal state, so the message HAS been
+   * continued. A plain lease that lapses means only that its holder stopped answering and
+   * the message is free again; this one means the work is done and nobody should repeat it.
+   */
+  done?: boolean;
+};
 
 /**
  * The browser's own storage, or nothing when there is not one to read.
@@ -493,7 +509,9 @@ function readLeases(storage: AutoContinueLeaseStorage): Record<string, Lease> {
     const token = (value as Lease | undefined)?.token;
     const expires = (value as Lease | undefined)?.expires;
     if (typeof token === "string" && typeof expires === "number") {
-      out[id] = { token, expires };
+      out[id] = (value as Lease).done === true
+        ? { token, expires, done: true }
+        : { token, expires };
     }
   }
   return out;
@@ -705,6 +723,7 @@ export function createAutoContinueTab({
     holder: string,
     expires: number,
     now: number,
+    done = false,
   ): boolean {
     const held = ownTokens.get(messageId);
     if (!held || held.holder !== holder) {
@@ -721,7 +740,9 @@ export function createAutoContinueTab({
         ownTokens.delete(messageId);
         return false;
       }
-      leases[messageId] = { token: held.token, expires };
+      leases[messageId] = done
+        ? { token: held.token, expires, done: true }
+        : { token: held.token, expires };
       store.setItem(AUTO_CONTINUE_LEASE_KEY, JSON.stringify(leases));
       return true;
     } catch {
@@ -785,12 +806,20 @@ export function createAutoContinueTab({
       }
       await exclusively(
         () =>
-          restamp(messageId, holder, now + AUTO_CONTINUE_LEASE_SETTLE_MS, now),
+          restamp(
+            messageId,
+            holder,
+            now + AUTO_CONTINUE_CONTINUED_TTL_MS,
+            now,
+            true,
+          ),
         false,
       );
-      // Held no longer: nothing renews this one, and it lapses at the settle window. Only
-      // this message, so the next round of the same turn -- claimed under this same holder
-      // before this release lands -- keeps its own lease and its own renewals.
+      // Held no longer, and marked done rather than handed back: the message HAS been
+      // continued now, and the only thing that could hand it to another tab is a lease that
+      // lapses, which is reserved for a holder that stopped answering. Only this message, so
+      // the next round of the same turn -- claimed under this same holder before this
+      // release lands -- keeps its own lease and its own renewals.
       ownTokens.delete(messageId);
     },
     reset() {
@@ -889,15 +918,6 @@ export function releaseAutoContinueLease(
 }
 
 /**
- * How long a hold waits for its run to appear before it stops expecting one.
- *
- * Only ever drops the bookkeeping, never the lease: a hold that never armed has renewed
- * nothing, so what is left behind is a lease running out its own TTL, which is exactly the
- * state a tab that closed mid-claim leaves behind.
- */
-export const AUTO_CONTINUE_ARM_TIMEOUT_MS = 60_000;
-
-/**
  * Whether the thread a lease was taken for is generating right now.
  *
  * Deliberately NOT "is the thread on screen running". A run keeps streaming when the user
@@ -923,6 +943,17 @@ export type AutoContinueRunSignal = {
  * again is claimed while the finished round is still winding down, so a hold that armed on
  * "the thread is running" would arm on its predecessor's run and be released when THAT one
  * ended, mid-stream. So a hold taken while the thread is busy waits to see it idle first.
+ *
+ * A hold whose run has not appeared YET is kept and renewed, never timed out. No deadline
+ * separates "this run is never coming" from "this run is still in preflight", because the
+ * preflight has no bound: `chat-adapter.ts` awaits the thread's own settings pairing (up to
+ * 30 seconds by itself), then `waitForModelReady`, which polls every 500ms for as long as a
+ * model is loading -- minutes for a large local GGUF, and exactly the state a tab just
+ * opened on a truncated reply is in. A fixed arming timeout dropped the hold in the middle
+ * of that, its renewals stopped, and the lease lapsed under a run that had since started
+ * streaming, so another tab could claim the message and pay for the same continuation twice.
+ * Renewing instead costs only this: a claim whose run genuinely never starts holds its lease
+ * until the tab is closed, and the manual Continue button is never gated on any of it.
  */
 export function createAutoContinueLeaseKeeper({
   signal,
@@ -948,7 +979,6 @@ export function createAutoContinueLeaseKeeper({
     idle: boolean;
     /** That run has started. Only an armed hold is ever released. */
     armed: boolean;
-    takenAt: number;
   };
   const holds = new Map<string, Hold>();
   let unsubscribe: (() => void) | null = null;
@@ -972,10 +1002,10 @@ export function createAutoContinueLeaseKeeper({
         release(hold.messageId, hold.threadId, at);
         continue;
       }
-      if (at - hold.takenAt > AUTO_CONTINUE_ARM_TIMEOUT_MS) {
-        // No run ever appeared for it. Drop the bookkeeping; the lease lapses on its own.
-        holds.delete(id);
-      }
+      // Not armed yet, so its run is still in preflight, which has no upper bound (see the
+      // note above this function). Kept and renewed rather than timed out: dropping it here
+      // stopped the renewals while the run was still on its way, and the lease then lapsed
+      // under a live continuation.
     }
     if (holds.size === 0 && unsubscribe) {
       unsubscribe();
@@ -998,7 +1028,6 @@ export function createAutoContinueLeaseKeeper({
         // only fires on a reply that has finished.
         idle: !signal.isRunning(threadId),
         armed: false,
-        takenAt: now(),
       });
       unsubscribe ??= signal.subscribe(observe);
     },
@@ -1007,9 +1036,9 @@ export function createAutoContinueLeaseKeeper({
       observe();
       const at = now();
       for (const hold of holds.values()) {
-        if (hold.armed) {
-          renew(hold.messageId, hold.threadId, at);
-        }
+        // Armed or still waiting for its run: either way this tab is alive and expects to
+        // be running that message, which is the whole question the lease asks.
+        renew(hold.messageId, hold.threadId, at);
       }
     },
     held() {

--- a/studio/frontend/src/features/chat/utils/continuation.ts
+++ b/studio/frontend/src/features/chat/utils/continuation.ts
@@ -889,6 +889,141 @@ export function releaseAutoContinueLease(
 }
 
 /**
+ * How long a hold waits for its run to appear before it stops expecting one.
+ *
+ * Only ever drops the bookkeeping, never the lease: a hold that never armed has renewed
+ * nothing, so what is left behind is a lease running out its own TTL, which is exactly the
+ * state a tab that closed mid-claim leaves behind.
+ */
+export const AUTO_CONTINUE_ARM_TIMEOUT_MS = 60_000;
+
+/**
+ * Whether the thread a lease was taken for is generating right now.
+ *
+ * Deliberately NOT "is the thread on screen running". A run keeps streaming when the user
+ * opens another chat -- the chat view is keyed by project so the provider is not remounted,
+ * and the runtime just points its selection somewhere else -- so a lease whose lifetime is
+ * read off the selected thread is released the moment the user looks away, and one settle
+ * window later another tab can claim a message that is still being written. The signal has
+ * to be per thread and indifferent to selection.
+ */
+export type AutoContinueRunSignal = {
+  isRunning(threadId: string): boolean;
+  subscribe(onChange: () => void): () => void;
+};
+
+/**
+ * Holds the lease of each continuation this tab is running, for as long as its own run runs.
+ *
+ * A hold is (message, thread) and its lifetime is the run's: it arms when THAT thread starts
+ * generating and is given back when THAT thread stops, whatever is on screen meanwhile and
+ * whichever component has mounted or unmounted. Nothing here reads React state.
+ *
+ * Arming waits for a run that starts after the hold is taken. A round that hits Max Tokens
+ * again is claimed while the finished round is still winding down, so a hold that armed on
+ * "the thread is running" would arm on its predecessor's run and be released when THAT one
+ * ended, mid-stream. So a hold taken while the thread is busy waits to see it idle first.
+ */
+export function createAutoContinueLeaseKeeper({
+  signal,
+  renew = (messageId, holder, now) => tab.renew(messageId, holder, { now }),
+  release = (messageId, holder, now) => tab.release(messageId, holder, { now }),
+  now = Date.now,
+}: {
+  signal: AutoContinueRunSignal;
+  renew?: (messageId: string, holder: string, now: number) => void;
+  release?: (messageId: string, holder: string, now: number) => void;
+  now?: () => number;
+}): {
+  hold: (messageId: string, threadId: string) => void;
+  observe: () => void;
+  tick: () => void;
+  held: () => number;
+  stop: () => void;
+} {
+  type Hold = {
+    messageId: string;
+    threadId: string;
+    /** Seen idle since the hold was taken, so the next run to start is this hold's own. */
+    idle: boolean;
+    /** That run has started. Only an armed hold is ever released. */
+    armed: boolean;
+    takenAt: number;
+  };
+  const holds = new Map<string, Hold>();
+  let unsubscribe: (() => void) | null = null;
+
+  const key = (messageId: string, threadId: string) =>
+    `${threadId}\u0000${messageId}`;
+
+  /** Arm, release, or forget. No writes to storage beyond the release itself. */
+  function observe(): void {
+    const at = now();
+    for (const [id, hold] of [...holds]) {
+      if (signal.isRunning(hold.threadId)) {
+        // Only a run that started after this hold was taken can be its own.
+        hold.armed ||= hold.idle;
+        continue;
+      }
+      hold.idle = true;
+      if (hold.armed) {
+        // This hold's own run has ended: finished, cancelled or failed.
+        holds.delete(id);
+        release(hold.messageId, hold.threadId, at);
+        continue;
+      }
+      if (at - hold.takenAt > AUTO_CONTINUE_ARM_TIMEOUT_MS) {
+        // No run ever appeared for it. Drop the bookkeeping; the lease lapses on its own.
+        holds.delete(id);
+      }
+    }
+    if (holds.size === 0 && unsubscribe) {
+      unsubscribe();
+      unsubscribe = null;
+    }
+  }
+
+  return {
+    hold(messageId, threadId) {
+      if (!messageId) {
+        return;
+      }
+      if (!threadId) {
+        return;
+      }
+      holds.set(key(messageId, threadId), {
+        messageId,
+        threadId,
+        // Claimed while the thread is between runs, which is the ordinary case: the bar
+        // only fires on a reply that has finished.
+        idle: !signal.isRunning(threadId),
+        armed: false,
+        takenAt: now(),
+      });
+      unsubscribe ??= signal.subscribe(observe);
+    },
+    observe,
+    tick() {
+      observe();
+      const at = now();
+      for (const hold of holds.values()) {
+        if (hold.armed) {
+          renew(hold.messageId, hold.threadId, at);
+        }
+      }
+    },
+    held() {
+      return holds.size;
+    },
+    stop() {
+      holds.clear();
+      unsubscribe?.();
+      unsubscribe = null;
+    },
+  };
+}
+
+/**
  * Whether THIS message is the one to continue automatically.
  *
  * `shouldAutoContinue` answers about the turn: is the reason right, does the partial

--- a/studio/frontend/src/features/chat/utils/continuation.ts
+++ b/studio/frontend/src/features/chat/utils/continuation.ts
@@ -532,8 +532,16 @@ export function createAutoContinueTab({
     messageId: string | null | undefined,
     options?: { now?: number },
   ) => boolean;
-  renew: (holder: string, options?: { now?: number }) => Promise<void>;
-  release: (holder: string, options?: { now?: number }) => Promise<void>;
+  renew: (
+    messageId: string | null | undefined,
+    holder: string,
+    options?: { now?: number },
+  ) => Promise<void>;
+  release: (
+    messageId: string | null | undefined,
+    holder: string,
+    options?: { now?: number },
+  ) => Promise<void>;
   reset: () => void;
 } {
   /**
@@ -593,7 +601,14 @@ export function createAutoContinueTab({
     }
   }
 
-  /** Drop what has lapsed, so the key cannot grow with every truncated reply. */
+  /**
+   * Drop what has lapsed, so the key cannot grow with every truncated reply.
+   *
+   * The one mutation here that is deliberately not per message. It only ever removes
+   * records that are already dead by their own expiry -- `liveLease` reads them as free
+   * whether they are in the key or not -- so it cannot end anybody's hold, and it is the
+   * only thing bounding the size of a key every tab writes to.
+   */
   function prune(
     leases: Record<string, Lease>,
     now: number,
@@ -669,43 +684,49 @@ export function createAutoContinueTab({
     return "started";
   }
 
-  /** Every lease `holder` took, in the order they were taken. */
-  function heldBy(holder: string): string[] {
-    const out: string[] = [];
-    for (const [id, held] of ownTokens) {
-      if (held.holder === holder) {
-        out.push(id);
-      }
-    }
-    return out;
+  /** Whether `holder` is the one this tab took `messageId`'s lease for. */
+  function heldFor(messageId: string, holder: string): boolean {
+    return ownTokens.get(messageId)?.holder === holder;
   }
 
   /**
-   * Rewrite the leases `holder` took with a new expiry. Runs inside the lock.
+   * Rewrite ONE lease with a new expiry, if this holder is the one that took it. Runs
+   * inside the lock, and reports whether the lease is still this tab's to stamp.
    *
-   * Scoped to the holder, never to the whole map: another runtime in this same tab may be
-   * mid-run, and restamping its lease to a settle window would end its hold without its
-   * knowledge and let another tab start the duplicate.
+   * One message, never a holder's whole set. A holder is a runtime, and a runtime outlives
+   * the run inside it: rounds of the same turn are claimed one after another under the same
+   * holder, and the next round is claimed BEFORE the finished one is given back, because
+   * React runs the bar's effect before the thread's. Anything that operated on "every lease
+   * this holder owns" would settle the round that just started along with the round that
+   * ended.
    */
-  function restamp(holder: string, expires: number, now: number): void {
+  function restamp(
+    messageId: string,
+    holder: string,
+    expires: number,
+    now: number,
+  ): boolean {
+    const held = ownTokens.get(messageId);
+    if (!held || held.holder !== holder) {
+      return false;
+    }
     const store = leaseSeam();
-    const mine = heldBy(holder);
-    if (!store || mine.length === 0) {
-      return;
+    if (!store) {
+      return false;
     }
     try {
       const leases = prune(readLeases(store), now);
-      for (const id of mine) {
-        if (leases[id]?.token !== ownTokens.get(id)?.token) {
-          // Lapsed, or taken over while this tab was not looking. Not ours to stamp.
-          ownTokens.delete(id);
-          continue;
-        }
-        leases[id] = { token: leases[id].token, expires };
+      if (leases[messageId]?.token !== held.token) {
+        // Lapsed, or taken over while this tab was not looking. Not ours to stamp.
+        ownTokens.delete(messageId);
+        return false;
       }
+      leases[messageId] = { token: held.token, expires };
       store.setItem(AUTO_CONTINUE_LEASE_KEY, JSON.stringify(leases));
+      return true;
     } catch {
       // An unwritable seam holds no lease of ours to renew or release either.
+      return false;
     }
   }
 
@@ -743,29 +764,34 @@ export function createAutoContinueTab({
       // `claim` itself.
       return continued.has(messageId) || Boolean(liveLease(messageId, now));
     },
-    async renew(holder, { now = Date.now() } = {}) {
-      if (heldBy(holder).length === 0) {
+    async renew(messageId, holder, { now = Date.now() } = {}) {
+      if (!messageId) {
+        return;
+      }
+      if (!heldFor(messageId, holder)) {
         return;
       }
       await exclusively(
-        () => restamp(holder, now + AUTO_CONTINUE_LEASE_TTL_MS, now),
-        undefined,
+        () => restamp(messageId, holder, now + AUTO_CONTINUE_LEASE_TTL_MS, now),
+        false,
       );
     },
-    async release(holder, { now = Date.now() } = {}) {
-      const mine = heldBy(holder);
-      if (mine.length === 0) {
+    async release(messageId, holder, { now = Date.now() } = {}) {
+      if (!messageId) {
+        return;
+      }
+      if (!heldFor(messageId, holder)) {
         return;
       }
       await exclusively(
-        () => restamp(holder, now + AUTO_CONTINUE_LEASE_SETTLE_MS, now),
-        undefined,
+        () =>
+          restamp(messageId, holder, now + AUTO_CONTINUE_LEASE_SETTLE_MS, now),
+        false,
       );
-      // Held no longer: nothing renews these, and they lapse at the settle window. Only
-      // this holder's, so a second runtime in the same tab keeps renewing its own.
-      for (const id of mine) {
-        ownTokens.delete(id);
-      }
+      // Held no longer: nothing renews this one, and it lapses at the settle window. Only
+      // this message, so the next round of the same turn -- claimed under this same holder
+      // before this release lands -- keeps its own lease and its own renewals.
+      ownTokens.delete(messageId);
     },
     reset() {
       continued.clear();
@@ -824,33 +850,42 @@ export function wasAutoContinued(messageId: string | null | undefined): boolean 
 }
 
 /**
- * Keep `holder`'s leases alive while the run behind them is still going.
+ * Keep ONE message's lease alive while the run resuming it is still going.
  *
  * Called on a timer for as long as that runtime's thread is running. Without it the TTL
  * would have to guess the longest continuation anyone might generate, and a slow local
  * model on a big Max Tokens would outlive that guess and have its message taken by another
  * tab mid-stream.
  *
- * Per holder, because a tab can be running more than one thread: compare mode mounts a
- * runtime per pane, and each renews only what it claimed.
+ * Named by message and by holder, not by holder alone. The holder keeps two panes of
+ * compare mode apart; the message id is what keeps one round of a turn apart from the next,
+ * which the same holder claims moments later.
  */
-export function renewAutoContinueLeases(holder: string): Promise<void> {
-  return tab.renew(holder);
+export function renewAutoContinueLease(
+  messageId: string,
+  holder: string,
+): Promise<void> {
+  return tab.renew(messageId, holder);
 }
 
 /**
- * Give `holder`'s leases back when its run reaches a terminal state, cancelled included.
+ * Give ONE message's lease back when the run resuming it reaches a terminal state,
+ * cancelled included.
  *
- * They are cut to the settle window rather than deleted, so a tab still showing the
+ * It is cut to the settle window rather than deleted, so a tab still showing the
  * pre-continuation branch cannot immediately start the duplicate this file exists to
- * prevent, and the full TTL is left to mean one thing only: the holder crashed.
+ * prevent, and the full TTL is left to mean one thing only: the holder stopped answering.
  *
- * Per holder for the same reason renewal is: in compare mode the pane that finishes first
- * would otherwise release the pane still generating, whose renewals would then find
- * nothing held and whose message would be free to claim one settle window later.
+ * By message, because a holder can own two at once and they are not in the same state. A
+ * turn that hits Max Tokens again is claimed by the bar's effect before this thread's
+ * effect observes the first run ending, so a holder-wide release settles a round that has
+ * only just begun, and one settle window later another tab takes it.
  */
-export function releaseAutoContinueLeases(holder: string): Promise<void> {
-  return tab.release(holder);
+export function releaseAutoContinueLease(
+  messageId: string,
+  holder: string,
+): Promise<void> {
+  return tab.release(messageId, holder);
 }
 
 /**

--- a/studio/frontend/src/features/chat/utils/continuation.ts
+++ b/studio/frontend/src/features/chat/utils/continuation.ts
@@ -560,6 +560,7 @@ export function createAutoContinueTab({
     holder: string,
     options?: { now?: number },
   ) => Promise<void>;
+  forget: (messageId: string | null | undefined) => void;
   reset: () => void;
 } {
   /**
@@ -822,6 +823,25 @@ export function createAutoContinueTab({
       // release lands -- keeps its own lease and its own renewals.
       ownTokens.delete(messageId);
     },
+    /**
+     * Take back a claim whose run was never issued.
+     *
+     * Only this tab's own record of having continued the message. The storage lease is left
+     * exactly where it is, to run out its own TTL: that is what a tab closed mid-claim
+     * already leaves behind, and dropping it here would hand the message to a second tab
+     * while this one may still be deciding what to do with it.
+     *
+     * Without this the message stays in `continued` for the life of the tab, and every
+     * later claim of it -- the branch picker back to the truncated sibling, or returning to
+     * the chat -- answers "skipped", so the automatic continuation never runs again for a
+     * request that was never made.
+     */
+    forget(messageId) {
+      if (!messageId) {
+        return;
+      }
+      continued.delete(messageId);
+    },
     reset() {
       continued.clear();
       claiming.clear();
@@ -876,6 +896,18 @@ export function claimAutoContinue(
  */
 export function wasAutoContinued(messageId: string | null | undefined): boolean {
   return tab.claimed(messageId);
+}
+
+/**
+ * Give a claim back when the run it was taken for turned out never to be issued.
+ *
+ * The claim is what stops this tab continuing the same message twice, so it is only ever
+ * dropped where nothing was started: the caller checked, in the same tick and off the same
+ * store it starts the run from, that the message it claimed is no longer there to resume.
+ * The cross-tab lease is deliberately untouched and lapses on its own.
+ */
+export function forgetAutoContinue(messageId: string | null | undefined): void {
+  tab.forget(messageId);
 }
 
 /**
@@ -968,6 +1000,7 @@ export function createAutoContinueLeaseKeeper({
 }): {
   hold: (messageId: string, threadId: string) => void;
   observe: () => void;
+  failed: (threadId: string) => void;
   tick: () => void;
   held: () => number;
   stop: () => void;
@@ -1032,6 +1065,35 @@ export function createAutoContinueLeaseKeeper({
       unsubscribe ??= signal.subscribe(observe);
     },
     observe,
+    /**
+     * `threadId`'s run failed on its way out, before it ever reached the run signal.
+     *
+     * The one thing that can end a hold which never armed, and it is a fact rather than a
+     * deadline: the adapter threw, so this run is not slow, it is over. Not a timeout by
+     * another name -- a preflight that is merely long emits nothing here and keeps its hold
+     * and its renewals, which is the whole reason arming has no deadline.
+     *
+     * Armed holds are left alone. Their run did reach the signal, so the thread going idle
+     * is what settles them, with the `done` marker that says the message HAS been continued
+     * -- which a run that never produced a token has no right to write. This one only
+     * discards: the lease it stops renewing lapses on its own TTL and the message comes
+     * back to whoever is still looking at it, rather than being renewed for the life of the
+     * tab and refused to every other one.
+     */
+    failed(threadId) {
+      if (!threadId) {
+        return;
+      }
+      for (const [id, hold] of [...holds]) {
+        if (hold.threadId === threadId && !hold.armed) {
+          holds.delete(id);
+        }
+      }
+      if (holds.size === 0 && unsubscribe) {
+        unsubscribe();
+        unsubscribe = null;
+      }
+    },
     tick() {
       observe();
       const at = now();

--- a/studio/frontend/src/features/chat/utils/continuation.ts
+++ b/studio/frontend/src/features/chat/utils/continuation.ts
@@ -526,14 +526,14 @@ export function createAutoContinueTab({
 } = {}): {
   claim: (
     messageId: string | null | undefined,
-    options?: { now?: number },
+    options?: { now?: number; holder?: string },
   ) => Promise<AutoContinueClaim>;
   claimed: (
     messageId: string | null | undefined,
     options?: { now?: number },
   ) => boolean;
-  renew: (options?: { now?: number }) => Promise<void>;
-  release: (options?: { now?: number }) => Promise<void>;
+  renew: (holder: string, options?: { now?: number }) => Promise<void>;
+  release: (holder: string, options?: { now?: number }) => Promise<void>;
   reset: () => void;
 } {
   /**
@@ -552,8 +552,15 @@ export function createAutoContinueTab({
   /** Claims this tab has in flight. The lock is async, so a second call can arrive. */
   const claiming = new Set<string>();
 
-  /** Lease tokens this tab holds, so it renews and releases its own and nobody else's. */
-  const ownTokens = new Map<string, string>();
+  /**
+   * Lease tokens this tab holds, by message id, each tagged with the holder that took it.
+   *
+   * Tagged, because "this tab" is not one runtime. Compare mode mounts two of them side by
+   * side, each with its own thread and its own run, and either can be resuming a truncated
+   * reply while the other is idle. A holder renews and releases what IT took; the pane that
+   * finishes first must not hand the other pane's still-generating message to anyone.
+   */
+  const ownTokens = new Map<string, { token: string; holder: string }>();
 
   const leaseSeam = (): AutoContinueLeaseStorage | null =>
     storage === undefined ? browserLeaseStorage() : storage;
@@ -622,7 +629,11 @@ export function createAutoContinueTab({
    * module-only claim, which is what single-tab use has always relied on, rather than
    * refusing a continuation the user is waiting for.
    */
-  function takeLease(messageId: string, now: number): AutoContinueClaim {
+  function takeLease(
+    messageId: string,
+    now: number,
+    holder: string,
+  ): AutoContinueClaim {
     const store = leaseSeam();
     if (!store) {
       return "started";
@@ -634,7 +645,11 @@ export function createAutoContinueTab({
       return "started";
     }
     const held = leases[messageId];
-    if (held && held.expires > now && held.token !== ownTokens.get(messageId)) {
+    if (
+      held &&
+      held.expires > now &&
+      held.token !== ownTokens.get(messageId)?.token
+    ) {
       return "held-elsewhere";
     }
     const token = newLeaseToken();
@@ -650,25 +665,43 @@ export function createAutoContinueTab({
     } catch {
       return "started";
     }
-    ownTokens.set(messageId, token);
+    ownTokens.set(messageId, { token, holder });
     return "started";
   }
 
-  /** Rewrite every lease this tab holds with a new expiry. Runs inside the lock. */
-  function restamp(expires: number, now: number): void {
+  /** Every lease `holder` took, in the order they were taken. */
+  function heldBy(holder: string): string[] {
+    const out: string[] = [];
+    for (const [id, held] of ownTokens) {
+      if (held.holder === holder) {
+        out.push(id);
+      }
+    }
+    return out;
+  }
+
+  /**
+   * Rewrite the leases `holder` took with a new expiry. Runs inside the lock.
+   *
+   * Scoped to the holder, never to the whole map: another runtime in this same tab may be
+   * mid-run, and restamping its lease to a settle window would end its hold without its
+   * knowledge and let another tab start the duplicate.
+   */
+  function restamp(holder: string, expires: number, now: number): void {
     const store = leaseSeam();
-    if (!store || ownTokens.size === 0) {
+    const mine = heldBy(holder);
+    if (!store || mine.length === 0) {
       return;
     }
     try {
       const leases = prune(readLeases(store), now);
-      for (const [id, token] of [...ownTokens]) {
-        if (leases[id]?.token !== token) {
+      for (const id of mine) {
+        if (leases[id]?.token !== ownTokens.get(id)?.token) {
           // Lapsed, or taken over while this tab was not looking. Not ours to stamp.
           ownTokens.delete(id);
           continue;
         }
-        leases[id] = { token, expires };
+        leases[id] = { token: leases[id].token, expires };
       }
       store.setItem(AUTO_CONTINUE_LEASE_KEY, JSON.stringify(leases));
     } catch {
@@ -677,7 +710,7 @@ export function createAutoContinueTab({
   }
 
   return {
-    async claim(messageId, { now = Date.now() } = {}) {
+    async claim(messageId, { now = Date.now(), holder = "" } = {}) {
       if (!messageId || continued.has(messageId) || claiming.has(messageId)) {
         return "skipped";
       }
@@ -689,7 +722,7 @@ export function createAutoContinueTab({
       claiming.add(messageId);
       try {
         const outcome = await exclusively(
-          () => takeLease(messageId, now),
+          () => takeLease(messageId, now, holder),
           "held-elsewhere" as AutoContinueClaim,
         );
         if (outcome === "started") {
@@ -710,25 +743,29 @@ export function createAutoContinueTab({
       // `claim` itself.
       return continued.has(messageId) || Boolean(liveLease(messageId, now));
     },
-    async renew({ now = Date.now() } = {}) {
-      if (ownTokens.size === 0) {
+    async renew(holder, { now = Date.now() } = {}) {
+      if (heldBy(holder).length === 0) {
         return;
       }
       await exclusively(
-        () => restamp(now + AUTO_CONTINUE_LEASE_TTL_MS, now),
+        () => restamp(holder, now + AUTO_CONTINUE_LEASE_TTL_MS, now),
         undefined,
       );
     },
-    async release({ now = Date.now() } = {}) {
-      if (ownTokens.size === 0) {
+    async release(holder, { now = Date.now() } = {}) {
+      const mine = heldBy(holder);
+      if (mine.length === 0) {
         return;
       }
       await exclusively(
-        () => restamp(now + AUTO_CONTINUE_LEASE_SETTLE_MS, now),
+        () => restamp(holder, now + AUTO_CONTINUE_LEASE_SETTLE_MS, now),
         undefined,
       );
-      // Held no longer: nothing renews it, and it lapses at the settle window.
-      ownTokens.clear();
+      // Held no longer: nothing renews these, and they lapse at the settle window. Only
+      // this holder's, so a second runtime in the same tab keeps renewing its own.
+      for (const id of mine) {
+        ownTokens.delete(id);
+      }
     },
     reset() {
       continued.clear();
@@ -742,8 +779,8 @@ export function createAutoContinueTab({
       // starting from zero, neither of which races another tab for this key.
       try {
         const leases = readLeases(store);
-        for (const [id, token] of ownTokens) {
-          if (leases[id]?.token === token) {
+        for (const [id, held] of ownTokens) {
+          if (leases[id]?.token === held.token) {
             delete leases[id];
           }
         }
@@ -768,8 +805,9 @@ const tab = createAutoContinueTab();
  */
 export function claimAutoContinue(
   messageId: string | null | undefined,
+  holder: string,
 ): Promise<AutoContinueClaim> {
-  return tab.claim(messageId);
+  return tab.claim(messageId, { holder });
 }
 
 /**
@@ -786,26 +824,33 @@ export function wasAutoContinued(messageId: string | null | undefined): boolean 
 }
 
 /**
- * Keep this tab's leases alive while the run behind them is still going.
+ * Keep `holder`'s leases alive while the run behind them is still going.
  *
- * Called on a timer for as long as the thread is running. Without it the TTL would have to
- * guess the longest continuation anyone might generate, and a slow local model on a big
- * Max Tokens would outlive that guess and have its message taken by another tab mid-
- * stream.
+ * Called on a timer for as long as that runtime's thread is running. Without it the TTL
+ * would have to guess the longest continuation anyone might generate, and a slow local
+ * model on a big Max Tokens would outlive that guess and have its message taken by another
+ * tab mid-stream.
+ *
+ * Per holder, because a tab can be running more than one thread: compare mode mounts a
+ * runtime per pane, and each renews only what it claimed.
  */
-export function renewAutoContinueLeases(): Promise<void> {
-  return tab.renew();
+export function renewAutoContinueLeases(holder: string): Promise<void> {
+  return tab.renew(holder);
 }
 
 /**
- * Give the leases back when the run reaches a terminal state, cancelled included.
+ * Give `holder`'s leases back when its run reaches a terminal state, cancelled included.
  *
  * They are cut to the settle window rather than deleted, so a tab still showing the
  * pre-continuation branch cannot immediately start the duplicate this file exists to
  * prevent, and the full TTL is left to mean one thing only: the holder crashed.
+ *
+ * Per holder for the same reason renewal is: in compare mode the pane that finishes first
+ * would otherwise release the pane still generating, whose renewals would then find
+ * nothing held and whose message would be free to claim one settle window later.
  */
-export function releaseAutoContinueLeases(): Promise<void> {
-  return tab.release();
+export function releaseAutoContinueLeases(holder: string): Promise<void> {
+  return tab.release(holder);
 }
 
 /**
@@ -841,6 +886,11 @@ export function shouldAutoContinueMessage(
  * A full reset gives back the leases this tab wrote as well, so "start from zero" means
  * the same thing it did before the lease existed. Leases other tabs hold are left alone:
  * they are not this tab's to release, and a run they are driving is still going.
+ *
+ * Deliberately wholesale, unlike renewal and release, which are per holder. A run ending
+ * is one runtime saying it is finished, and says nothing about the others; a reset is the
+ * whole tab being told it has no claims at all, which is what a test between cases and a
+ * cleared history both mean. Nothing in the run lifecycle calls it.
  */
 export function resetAutoContinue(key?: string): void {
   if (key === undefined) {

--- a/studio/frontend/src/features/chat/utils/continuation.ts
+++ b/studio/frontend/src/features/chat/utils/continuation.ts
@@ -374,26 +374,67 @@ export function autoContinueCount(key: string | null | undefined): number {
 }
 
 /**
- * How long a claim written to shared storage keeps other tabs off a message.
+ * How long a lease survives without being renewed.
  *
  * A lease, not a permanent flag: the tab that wins can be closed or crash mid-run, and a
  * flag it never gets to clear would leave the message unresumable for the life of the
- * profile. Two minutes covers a whole round -- prompt processing plus a full Max Tokens
- * generation on a local model -- so a tab opened while the winner is still streaming stays
- * out, while a tab that died takes the message back after one pause the user is likely
- * still sitting through. Erring longer wedges a live message; erring shorter buys the
- * duplicate request back.
+ * profile. The winner renews for as long as its run is live (see
+ * `renewAutoContinueLeases`), so the TTL is not a guess at how long a continuation takes:
+ * it is how long a tab that stopped renewing is still believed to be alive.
+ *
+ * Three minutes because renewals are timers, and a hidden tab is throttled to roughly one
+ * timer callback a minute in Chrome. Three minutes leaves a backgrounded winner about
+ * three chances to check in before anyone else may touch its message, while a tab that
+ * really died gives the message back inside the pause a user notices anyway. The manual
+ * Continue button is never gated on any of this, so the way out is always open.
  */
-export const AUTO_CONTINUE_LEASE_TTL_MS = 120_000;
+export const AUTO_CONTINUE_LEASE_TTL_MS = 180_000;
+
+/**
+ * How often the holder renews while its run is live. Well inside the TTL even at the
+ * once-a-minute rate a hidden tab's timers are throttled to.
+ */
+export const AUTO_CONTINUE_LEASE_RENEW_MS = 30_000;
+
+/**
+ * What a lease is cut back to when the run behind it reaches a terminal state.
+ *
+ * Released rather than held, so the TTL only ever covers a crash. Not deleted outright:
+ * another tab still showing the pre-continuation branch has not seen the sibling that was
+ * just written and would take the message straight back, which is the duplicate this
+ * whole file exists to stop. A short settle window is long enough for that tab to pick up
+ * the saved thread and short enough to be invisible otherwise.
+ */
+export const AUTO_CONTINUE_LEASE_SETTLE_MS = 30_000;
 
 /** The `localStorage` key holding the leases, one record per claimed message id. */
 export const AUTO_CONTINUE_LEASE_KEY = "unsloth_chat_auto_continue_leases";
+
+/** The Web Locks name every read-modify-write of that key is taken under. */
+export const AUTO_CONTINUE_LOCK_NAME = "unsloth_chat_auto_continue_claim";
+
+/**
+ * What a claim attempt did.
+ *
+ * Three answers, not a boolean, because the two ways of not starting a run want opposite
+ * things on screen. `held-elsewhere` is another tab running this message: this one has to
+ * drop the "Continuing automatically" spinner and put its manual Continue button back, or
+ * it shows a spinner for a run it will never own. `skipped` is this tab declining its own
+ * duplicate call -- a `<StrictMode>` replay, or a claim already in flight -- where the run
+ * IS coming and changing what is on screen would be wrong.
+ */
+export type AutoContinueClaim = "started" | "skipped" | "held-elsewhere";
 
 /** The slice of `Storage` the lease needs. Narrow so a test can hand over a fake. */
 export type AutoContinueLeaseStorage = {
   getItem(key: string): string | null;
   setItem(key: string, value: string): void;
   removeItem(key: string): void;
+};
+
+/** The slice of `navigator.locks` the claim needs: an exclusive request by name. */
+export type AutoContinueLockManager = {
+  request<T>(name: string, callback: () => T | Promise<T>): Promise<T>;
 };
 
 type Lease = { token: string; expires: number };
@@ -411,7 +452,28 @@ function browserLeaseStorage(): AutoContinueLeaseStorage | null {
     if (typeof window === "undefined") {
       return null;
     }
-    return (window.localStorage as AutoContinueLeaseStorage | undefined) ?? null;
+    return (
+      (window.localStorage as AutoContinueLeaseStorage | undefined) ?? null
+    );
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The browser's lock manager, or nothing where there is not one.
+ *
+ * `navigator.locks` is what makes the claim exclusive: read, decide and write happen
+ * inside one held lock, so no other tab can be between them. localStorage alone cannot do
+ * this -- its individual operations are atomic, but a read-modify-write across three
+ * statements is not, and the storage mutex that used to serialize such sequences was
+ * dropped from the spec, so nothing holds a lock across them.
+ */
+function browserLockManager(): AutoContinueLockManager | null {
+  try {
+    const locks = (globalThis.navigator as { locks?: unknown } | undefined)
+      ?.locks as AutoContinueLockManager | undefined;
+    return typeof locks?.request === "function" ? locks : null;
   } catch {
     return null;
   }
@@ -449,26 +511,29 @@ function newLeaseToken(): string {
  * One tab's view of which messages have been continued.
  *
  * Constructible because a second instance is precisely what a second browser tab is: its
- * own module scope, its own empty claim set, the same saved thread and the same shared
- * storage underneath. That is the case the lease exists for, and the only way to write it
- * down as a test.
+ * own module scope, its own empty claim set, the same saved thread, and the same storage
+ * and lock manager underneath. That is the case the lease exists for, and the only way to
+ * write it down as a test.
  */
-export function createAutoContinueTab(
-  {
-    storage,
-  }: {
-    /** Omit for the browser's `localStorage`; pass null for a tab with no seam. */
-    storage?: AutoContinueLeaseStorage | null;
-  } = {},
-): {
+export function createAutoContinueTab({
+  storage,
+  locks,
+}: {
+  /** Omit for the browser's `localStorage`; pass null for a tab with no seam. */
+  storage?: AutoContinueLeaseStorage | null;
+  /** Omit for `navigator.locks`; pass null for a browser that has none. */
+  locks?: AutoContinueLockManager | null;
+} = {}): {
   claim: (
     messageId: string | null | undefined,
     options?: { now?: number },
-  ) => boolean;
+  ) => Promise<AutoContinueClaim>;
   claimed: (
     messageId: string | null | undefined,
     options?: { now?: number },
   ) => boolean;
+  renew: (options?: { now?: number }) => Promise<void>;
+  release: (options?: { now?: number }) => Promise<void>;
   reset: () => void;
 } {
   /**
@@ -484,15 +549,60 @@ export function createAutoContinueTab(
    */
   const continued = new Set<string>();
 
-  /** Lease tokens this tab wrote, so a reset clears its own and nobody else's. */
+  /** Claims this tab has in flight. The lock is async, so a second call can arrive. */
+  const claiming = new Set<string>();
+
+  /** Lease tokens this tab holds, so it renews and releases its own and nobody else's. */
   const ownTokens = new Map<string, string>();
 
-  const seam = (): AutoContinueLeaseStorage | null =>
+  const leaseSeam = (): AutoContinueLeaseStorage | null =>
     storage === undefined ? browserLeaseStorage() : storage;
+
+  const lockSeam = (): AutoContinueLockManager | null =>
+    locks === undefined ? browserLockManager() : locks;
+
+  /**
+   * Run `mutate` with nobody else inside it.
+   *
+   * With a lock manager this is genuinely exclusive across tabs. Without one -- an older
+   * browser, an embedded webview, the test runner -- it degrades to running the body
+   * straight through, which is the write-then-read-back below and no worse than what
+   * shipped before. A lock manager that rejects the request is treated the same way,
+   * and a body that has already run is never run twice.
+   */
+  async function exclusively<T>(mutate: () => T, fallback: T): Promise<T> {
+    const manager = lockSeam();
+    if (!manager) {
+      return mutate();
+    }
+    let ran = false;
+    try {
+      return await manager.request(AUTO_CONTINUE_LOCK_NAME, () => {
+        ran = true;
+        return mutate();
+      });
+    } catch {
+      return ran ? fallback : mutate();
+    }
+  }
+
+  /** Drop what has lapsed, so the key cannot grow with every truncated reply. */
+  function prune(
+    leases: Record<string, Lease>,
+    now: number,
+  ): Record<string, Lease> {
+    const out: Record<string, Lease> = {};
+    for (const [id, lease] of Object.entries(leases)) {
+      if (lease.expires > now) {
+        out[id] = lease;
+      }
+    }
+    return out;
+  }
 
   /** A lease held by ANY tab, this one included, or null. Expired reads as free. */
   function liveLease(messageId: string, now: number): Lease | null {
-    const store = seam();
+    const store = leaseSeam();
     if (!store) {
       return null;
     }
@@ -506,75 +616,130 @@ export function createAutoContinueTab(
   }
 
   /**
-   * Take the lease for `messageId`, or report that someone else holds it.
+   * Take the lease, or report who has it. Runs inside the lock.
    *
-   * Written then read back, because two tabs can pass the free check in the same tick;
-   * whichever `setItem` lands second is the token still in storage afterwards, so the
-   * other tab reads a token that is not its own and stands down. A storage that cannot be
-   * written is not an error: the tab keeps the module-only claim, which is what single-tab
-   * use has always relied on, rather than refusing a continuation the user is waiting for.
+   * A storage that cannot be read or written is not an error: the tab keeps the
+   * module-only claim, which is what single-tab use has always relied on, rather than
+   * refusing a continuation the user is waiting for.
    */
-  function takeLease(messageId: string, now: number): boolean {
-    const store = seam();
+  function takeLease(messageId: string, now: number): AutoContinueClaim {
+    const store = leaseSeam();
     if (!store) {
-      return true;
+      return "started";
+    }
+    let leases: Record<string, Lease>;
+    try {
+      leases = readLeases(store);
+    } catch {
+      return "started";
+    }
+    const held = leases[messageId];
+    if (held && held.expires > now && held.token !== ownTokens.get(messageId)) {
+      return "held-elsewhere";
+    }
+    const token = newLeaseToken();
+    const next = prune(leases, now);
+    next[messageId] = { token, expires: now + AUTO_CONTINUE_LEASE_TTL_MS };
+    try {
+      store.setItem(AUTO_CONTINUE_LEASE_KEY, JSON.stringify(next));
+      // Read back, which is the only defence left when there is no lock manager: whoever
+      // wrote last is the token in storage, and the other tab does not find its own.
+      if (readLeases(store)[messageId]?.token !== token) {
+        return "held-elsewhere";
+      }
+    } catch {
+      return "started";
+    }
+    ownTokens.set(messageId, token);
+    return "started";
+  }
+
+  /** Rewrite every lease this tab holds with a new expiry. Runs inside the lock. */
+  function restamp(expires: number, now: number): void {
+    const store = leaseSeam();
+    if (!store || ownTokens.size === 0) {
+      return;
     }
     try {
-      const token = newLeaseToken();
-      const leases = readLeases(store);
-      const held = leases[messageId];
-      if (held && held.expires > now && held.token !== ownTokens.get(messageId)) {
-        // Landed between the check above and this write. Never overwrite a live lease.
-        return false;
-      }
-      const next: Record<string, Lease> = {};
-      for (const [id, lease] of Object.entries(leases)) {
-        // Drop what has lapsed, so the key cannot grow with every truncated reply.
-        if (lease.expires > now) {
-          next[id] = lease;
+      const leases = prune(readLeases(store), now);
+      for (const [id, token] of [...ownTokens]) {
+        if (leases[id]?.token !== token) {
+          // Lapsed, or taken over while this tab was not looking. Not ours to stamp.
+          ownTokens.delete(id);
+          continue;
         }
+        leases[id] = { token, expires };
       }
-      next[messageId] = { token, expires: now + AUTO_CONTINUE_LEASE_TTL_MS };
-      store.setItem(AUTO_CONTINUE_LEASE_KEY, JSON.stringify(next));
-      if (readLeases(store)[messageId]?.token !== token) {
-        return false;
-      }
-      ownTokens.set(messageId, token);
-      return true;
+      store.setItem(AUTO_CONTINUE_LEASE_KEY, JSON.stringify(leases));
     } catch {
-      return true;
+      // An unwritable seam holds no lease of ours to renew or release either.
     }
   }
 
   return {
-    claim(messageId, { now = Date.now() } = {}) {
-      if (!messageId || continued.has(messageId)) {
-        return false;
+    async claim(messageId, { now = Date.now() } = {}) {
+      if (!messageId || continued.has(messageId) || claiming.has(messageId)) {
+        return "skipped";
       }
       if (liveLease(messageId, now)) {
-        // Another tab is running this one. Not recorded locally: if that tab dies, this
-        // one takes the message back when the lease lapses.
-        return false;
+        // Cheap answer before touching the lock. Not recorded locally: if the tab holding
+        // it dies, this one takes the message back when the lease lapses.
+        return "held-elsewhere";
       }
-      if (!takeLease(messageId, now)) {
-        return false;
+      claiming.add(messageId);
+      try {
+        const outcome = await exclusively(
+          () => takeLease(messageId, now),
+          "held-elsewhere" as AutoContinueClaim,
+        );
+        if (outcome === "started") {
+          continued.add(messageId);
+        }
+        return outcome;
+      } finally {
+        claiming.delete(messageId);
       }
-      continued.add(messageId);
-      return true;
     },
     claimed(messageId, { now = Date.now() } = {}) {
       if (!messageId) {
         return false;
       }
+      // A claim of this tab's own that is still in flight deliberately does NOT count: the
+      // spinner it is rendering is the right thing to show, and treating it as taken would
+      // flash the manual bar in the middle of winning. Its duplicate calls are refused by
+      // `claim` itself.
       return continued.has(messageId) || Boolean(liveLease(messageId, now));
+    },
+    async renew({ now = Date.now() } = {}) {
+      if (ownTokens.size === 0) {
+        return;
+      }
+      await exclusively(
+        () => restamp(now + AUTO_CONTINUE_LEASE_TTL_MS, now),
+        undefined,
+      );
+    },
+    async release({ now = Date.now() } = {}) {
+      if (ownTokens.size === 0) {
+        return;
+      }
+      await exclusively(
+        () => restamp(now + AUTO_CONTINUE_LEASE_SETTLE_MS, now),
+        undefined,
+      );
+      // Held no longer: nothing renews it, and it lapses at the settle window.
+      ownTokens.clear();
     },
     reset() {
       continued.clear();
-      const store = seam();
+      claiming.clear();
+      const store = leaseSeam();
       if (!store || ownTokens.size === 0) {
         ownTokens.clear();
         return;
       }
+      // Synchronous, and so outside the lock: a reset is a test seam and a new thread
+      // starting from zero, neither of which races another tab for this key.
       try {
         const leases = readLeases(store);
         for (const [id, token] of ownTokens) {
@@ -595,10 +760,15 @@ export function createAutoContinueTab(
 const tab = createAutoContinueTab();
 
 /**
- * Whether `messageId` still needs continuing. False once it has been claimed, here or in
- * another tab holding a live lease on it.
+ * Claim `messageId` for an automatic continuation, and say what happened.
+ *
+ * Asynchronous because exclusivity is: the read-decide-write is taken under a Web Lock so
+ * that two tabs cannot both come out of it believing they won. The caller starts its run
+ * on `started` and only on `started`.
  */
-export function claimAutoContinue(messageId: string | null | undefined): boolean {
+export function claimAutoContinue(
+  messageId: string | null | undefined,
+): Promise<AutoContinueClaim> {
   return tab.claim(messageId);
 }
 
@@ -607,11 +777,35 @@ export function claimAutoContinue(messageId: string | null | undefined): boolean
  * another one whose lease is still live.
  *
  * Asked at render time, so the answer has to match what `claimAutoContinue` will do a tick
- * later. A tab that reported "continuing" and then found the message claimed would show a
- * spinner nothing is going to resolve, over the manual Continue button it hides.
+ * later as closely as a synchronous read can. It cannot be exact, because the lock that
+ * decides a genuine race resolves later; the caller therefore also re-renders off the
+ * claim's own answer rather than trusting this alone.
  */
 export function wasAutoContinued(messageId: string | null | undefined): boolean {
   return tab.claimed(messageId);
+}
+
+/**
+ * Keep this tab's leases alive while the run behind them is still going.
+ *
+ * Called on a timer for as long as the thread is running. Without it the TTL would have to
+ * guess the longest continuation anyone might generate, and a slow local model on a big
+ * Max Tokens would outlive that guess and have its message taken by another tab mid-
+ * stream.
+ */
+export function renewAutoContinueLeases(): Promise<void> {
+  return tab.renew();
+}
+
+/**
+ * Give the leases back when the run reaches a terminal state, cancelled included.
+ *
+ * They are cut to the settle window rather than deleted, so a tab still showing the
+ * pre-continuation branch cannot immediately start the duplicate this file exists to
+ * prevent, and the full TTL is left to mean one thing only: the holder crashed.
+ */
+export function releaseAutoContinueLeases(): Promise<void> {
+  return tab.release();
 }
 
 /**

--- a/studio/frontend/src/features/chat/utils/continuation.ts
+++ b/studio/frontend/src/features/chat/utils/continuation.ts
@@ -379,7 +379,7 @@ export function autoContinueCount(key: string | null | undefined): number {
  * A lease, not a permanent flag: the tab that wins can be closed or crash mid-run, and a
  * flag it never gets to clear would leave the message unresumable for the life of the
  * profile. The winner renews for as long as its run is live (see
- * `renewAutoContinueLeases`), so the TTL is not a guess at how long a continuation takes:
+ * `renewAutoContinueLease`), so the TTL is not a guess at how long a continuation takes:
  * it is how long a tab that stopped renewing is still believed to be alive.
  *
  * Three minutes because renewals are timers, and a hidden tab is throttled to roughly one

--- a/studio/frontend/src/features/chat/utils/image-input-support.ts
+++ b/studio/frontend/src/features/chat/utils/image-input-support.ts
@@ -104,3 +104,44 @@ export function getImageInputUnavailableReason({
     `${label} cannot accept images. Load a vision-capable model${suffix}`
   );
 }
+
+/**
+ * The owners of the running-flag pulse the gate fires when it refuses a turn.
+ *
+ * `chat-adapter.ts` flips `runningByThreadId` on and straight back off before it throws,
+ * so compare mode's `waitForRunEnd` resolves instead of hanging on a run that never
+ * reached the streaming path. It is a settlement for waiters, not a run: nothing was
+ * requested, nothing was generated, and anything reading that field as "this thread's run
+ * started, and then it ended" is reading a request that was never issued as a finished one.
+ *
+ * A WeakSet rather than a flag on the function, because the store types an owner as a bare
+ * `() => void` and the identity is all either side needs. Fresh per pulse: siblings share
+ * the "__default" key and `setThreadRunning` clears by owner, so two gates firing on one
+ * key must not clear each other's entry.
+ */
+const imageGateRunOwners = new WeakSet<() => void>();
+
+/** A run-owner token that marks its `setThreadRunning` pair as the gate's own pulse. */
+export function createImageGateRunOwner(): () => void {
+  const owner = () => {};
+  imageGateRunOwners.add(owner);
+  return owner;
+}
+
+/**
+ * Whether everything holding this thread's running flag is a gate pulse.
+ *
+ * Asked by readers that mean "is this thread generating", so a real run sharing the key --
+ * an unresolved sibling under "__default", or a gate firing on one pane while the other
+ * streams -- still answers yes. An empty list is a run from before per-run tracking and is
+ * taken at face value.
+ */
+export function isImageGateRunOnly(
+  owners: readonly { owner: () => void }[] | undefined,
+): boolean {
+  return (
+    owners !== undefined &&
+    owners.length > 0 &&
+    owners.every((entry) => imageGateRunOwners.has(entry.owner))
+  );
+}

--- a/studio/frontend/tests/chat-continuation.test.ts
+++ b/studio/frontend/tests/chat-continuation.test.ts
@@ -818,7 +818,7 @@ test("a running continuation keeps its lease past the TTL", async () => {
   );
   // Three renewals at the interval the keeper uses, still inside the run.
   for (let tick = 1; tick <= 3; tick += 1) {
-    await running.renew(PANE, {
+    await running.renew("m1", PANE, {
       now: start + tick * AUTO_CONTINUE_LEASE_RENEW_MS,
     });
   }
@@ -841,7 +841,7 @@ test("a finished run gives its lease back, without handing over a stale branch",
     await running.claim("m1", { now: start, holder: PANE }),
     "started",
   );
-  await running.release(PANE, { now: start });
+  await running.release("m1", PANE, { now: start });
   assert.equal(
     await other.claim("m1", { now: start + AUTO_CONTINUE_LEASE_SETTLE_MS - 1 }),
     "held-elsewhere",
@@ -851,13 +851,76 @@ test("a finished run gives its lease back, without handing over a stale branch",
     "started",
   );
   // And a release holds nothing, so a later renewal cannot resurrect it.
-  await running.renew(PANE, { now: start + AUTO_CONTINUE_LEASE_SETTLE_MS + 2 });
+  await running.renew("m1", PANE, {
+    now: start + AUTO_CONTINUE_LEASE_SETTLE_MS + 2,
+  });
   assert.equal(
     await createAutoContinueTab({ storage, locks }).claim("m1", {
       now: start + AUTO_CONTINUE_LEASE_SETTLE_MS + 3,
     }),
     "held-elsewhere",
   );
+});
+
+/**
+ * Two rounds of one turn, in the order the app produces them.
+ *
+ * A round ends on another Max Tokens cut, so the bar under the new reply claims the next
+ * message while the thread is still winding the finished run down: React runs child
+ * effects before parent ones, so the claim lands before the keeper observes `isRunning`
+ * going false. `release` therefore has to name the message whose run ended, and nothing
+ * wider: the same holder owns both.
+ */
+async function sequentialRounds(
+  locks: ReturnType<typeof lockManagerFake> | null,
+) {
+  const { storage } = storageFake();
+  const tab = createAutoContinueTab({ storage, locks });
+  const otherTab = createAutoContinueTab({ storage, locks });
+  const start = 1_000;
+
+  assert.equal(
+    startedARun(await tab.claim("round-1", { now: start, holder: PANE })),
+    true,
+  );
+  // The next round, claimed before the finished one is given back.
+  assert.equal(
+    startedARun(await tab.claim("round-2", { now: start, holder: PANE })),
+    true,
+  );
+  await tab.release("round-1", PANE, { now: start });
+
+  // The second round is the live one, and its keeper is still renewing it.
+  for (let tick = 1; tick <= 3; tick += 1) {
+    await tab.renew("round-2", PANE, {
+      now: start + tick * AUTO_CONTINUE_LEASE_RENEW_MS,
+    });
+  }
+  const past =
+    start + AUTO_CONTINUE_LEASE_TTL_MS + AUTO_CONTINUE_LEASE_RENEW_MS;
+  assert.equal(
+    await otherTab.claim("round-2", { now: past }),
+    "held-elsewhere",
+    "the round that just started keeps its lease",
+  );
+  // The round that did finish settles on the usual schedule.
+  assert.equal(
+    await otherTab.claim("round-1", {
+      now: start + AUTO_CONTINUE_LEASE_SETTLE_MS + 1,
+    }),
+    "started",
+  );
+}
+
+test("the next round keeps its lease when the last one is released", async () => {
+  // No lock manager, where the claim resolves soonest and so lands earliest.
+  await sequentialRounds(null);
+});
+
+test("the next round keeps its lease with a lock manager in the way", async () => {
+  // And with one, because the effect ordering is not guaranteed in our favour there
+  // either -- the fix must not depend on which path ran.
+  await sequentialRounds(lockManagerFake());
 });
 
 test("one compare pane finishing does not release the other pane's lease", async () => {
@@ -888,11 +951,11 @@ test("one compare pane finishing does not release the other pane's lease", async
   );
 
   // The base pane finishes first. Only its own lease goes back.
-  await compareTab.release(base, { now: start });
+  await compareTab.release("base-m1", base, { now: start });
 
   // The lora pane is still generating, and its keeper is still renewing.
   for (let tick = 1; tick <= 3; tick += 1) {
-    await compareTab.renew(lora, {
+    await compareTab.renew("lora-m1", lora, {
       now: start + tick * AUTO_CONTINUE_LEASE_RENEW_MS,
     });
   }
@@ -921,7 +984,7 @@ test("a renewal touches this tab's leases and nobody else's", async () => {
 
   await mine.claim("m1", { now: start, holder: PANE });
   await theirs.claim("m2", { now: start, holder: PANE });
-  await mine.renew(PANE, { now: start + AUTO_CONTINUE_LEASE_RENEW_MS });
+  await mine.renew("m1", PANE, { now: start + AUTO_CONTINUE_LEASE_RENEW_MS });
 
   const leases = JSON.parse(store.get(AUTO_CONTINUE_LEASE_KEY) ?? "{}");
   assert.equal(

--- a/studio/frontend/tests/chat-continuation.test.ts
+++ b/studio/frontend/tests/chat-continuation.test.ts
@@ -38,6 +38,10 @@ const {
   stripContinuationOverlap,
 } = await import("../src/features/chat/utils/continuation.ts");
 
+const { createImageGateRunOwner, isImageGateRunOnly } = await import(
+  "../src/features/chat/utils/image-input-support.ts"
+);
+
 const PARTIAL =
   "There are three steps to proofing dough properly. First, warm the bowl and";
 
@@ -1684,6 +1688,229 @@ test("the keeper is wired to the failure the adapter already reports", () => {
     wiring,
     /keeper\.failed\(/,
     "the failure has to reach the keeper",
+  );
+  assert.doesNotMatch(
+    wiring,
+    /setTimeout\(/,
+    "a deadline here is the arming timeout coming back, which lapses live continuations",
+  );
+});
+
+/**
+ * The same field the keeper reads in the app, owners and all.
+ *
+ * `runSignalFake` above answers from a bare set of thread ids, which is every case where
+ * what holds the flag does not matter. Here it does: the image gate flips the flag on and
+ * off around a request it never issued, and the real signal in
+ * `auto-continue-run-keeper.ts` is what tells that pair from a run. Built on the shipped
+ * predicate rather than a copy of it, so a change to either side fails here.
+ */
+function ownedRunSignalFake() {
+  const running = new Map<string, { owner: () => void }[]>();
+  const listeners = new Set<() => void>();
+  const announce = () => {
+    for (const listener of [...listeners]) {
+      listener();
+    }
+  };
+  return {
+    signal: {
+      isRunning: (threadId: string) => {
+        const owners = running.get(threadId);
+        return Boolean(owners?.length) && !isImageGateRunOnly(owners);
+      },
+      subscribe: (onChange: () => void) => {
+        listeners.add(onChange);
+        return () => listeners.delete(onChange);
+      },
+    },
+    /** `setThreadRunning(threadId, true, { owner })`, and the notify it fires. */
+    start: (threadId: string, owner: () => void) => {
+      running.set(threadId, [...(running.get(threadId) ?? []), { owner }]);
+      announce();
+    },
+    /** `setThreadRunning(threadId, false, { owner })`, clearing that run only. */
+    end: (threadId: string, owner: () => void) => {
+      const rest = (running.get(threadId) ?? []).filter(
+        (entry) => entry.owner !== owner,
+      );
+      if (rest.length > 0) {
+        running.set(threadId, rest);
+      } else {
+        running.delete(threadId);
+      }
+      announce();
+    },
+  };
+}
+
+test("a continuation refused by the image gate is not recorded as continued", async () => {
+  // Reopen a chat containing a picture with a text-only model loaded -- or switch Vision
+  // off for the one that wrote the truncated reply -- and the automatic continuation is
+  // refused before a request is made. The gate pulses the thread's running flag true and
+  // then false first, so compare mode's `waitForRunEnd` resolves rather than hanging. Read
+  // as a run, that pair arms the hold and settles it one call later with the `done` marker
+  // that tells every other tab for a day that the message HAS been continued -- for a
+  // provider request that was never sent. The failure that follows cannot take it back: a
+  // released hold is already gone.
+  const { storage } = storageFake();
+  const locks = lockManagerFake();
+  const tab = createAutoContinueTab({ storage, locks });
+  const otherTab = createAutoContinueTab({ storage, locks });
+  const runs = ownedRunSignalFake();
+  const pending: Promise<unknown>[] = [];
+  const start = 1_000;
+  let clock = start;
+  const keeper = createAutoContinueLeaseKeeper({
+    signal: runs.signal,
+    renew: (messageId: string, holder: string, now: number) => {
+      pending.push(tab.renew(messageId, holder, { now }));
+    },
+    release: () => {
+      assert.fail(
+        "the gate issued no request, so nothing may be marked continued",
+      );
+    },
+    now: () => clock,
+  });
+
+  assert.equal(
+    await tab.claim("m1", { now: start, holder: "thread-A" }),
+    "started",
+  );
+  keeper.hold("m1", "thread-A");
+
+  // `chat-adapter.ts`: setThreadRunning(true, { owner: gateOwner }) then false, then throw.
+  const gateOwner = createImageGateRunOwner();
+  runs.start("thread-A", gateOwner);
+  assert.equal(
+    keeper.held(),
+    1,
+    "a pulse that stands for a refusal does not arm the hold",
+  );
+  runs.end("thread-A", gateOwner);
+  assert.equal(keeper.held(), 1, "and so cannot settle it either");
+
+  // The throw reaches the wrapper's catch, which is the signal that ends an unarmed hold.
+  keeper.failed("thread-A");
+  assert.equal(keeper.held(), 0);
+
+  const lapsed = clock + AUTO_CONTINUE_LEASE_TTL_MS + 1;
+  clock = lapsed;
+  keeper.tick();
+  await Promise.all(pending);
+  assert.equal(
+    await otherTab.claim("m1", { now: lapsed }),
+    "started",
+    "the message was never continued, so it comes back rather than reading done for a day",
+  );
+});
+
+test("a real run on the thread the gate refused still owns its lease", async () => {
+  // Compare mode puts two runtimes on one key, and an unresolved thread files its run under
+  // the shared "__default". A gate firing beside a run that is genuinely streaming must not
+  // make the keeper read the thread as idle: that hold would be released mid-stream, and one
+  // settle window later another tab could claim the message being written.
+  const { storage } = storageFake();
+  const locks = lockManagerFake();
+  const tab = createAutoContinueTab({ storage, locks });
+  const otherTab = createAutoContinueTab({ storage, locks });
+  const runs = ownedRunSignalFake();
+  const released: string[] = [];
+  const pending: Promise<unknown>[] = [];
+  const start = 1_000;
+  let clock = start;
+  const keeper = createAutoContinueLeaseKeeper({
+    signal: runs.signal,
+    renew: (messageId: string, holder: string, now: number) => {
+      pending.push(tab.renew(messageId, holder, { now }));
+    },
+    release: (messageId: string, holder: string, now: number) => {
+      released.push(messageId);
+      pending.push(tab.release(messageId, holder, { now }));
+    },
+    now: () => clock,
+  });
+
+  await tab.claim("m1", { now: start, holder: "__default" });
+  keeper.hold("m1", "__default");
+
+  const streamingRun = () => {};
+  runs.start("__default", streamingRun);
+  clock = start + AUTO_CONTINUE_LEASE_RENEW_MS;
+  keeper.tick();
+
+  // The sibling's image turn is refused while this one streams.
+  const gateOwner = createImageGateRunOwner();
+  runs.start("__default", gateOwner);
+  runs.end("__default", gateOwner);
+  assert.deepEqual(released, [], "the run beside it is still generating");
+  assert.equal(keeper.held(), 1);
+
+  // Its own run ending is what gives the lease back, marked continued.
+  runs.end("__default", streamingRun);
+  await Promise.all(pending);
+  assert.deepEqual(released, ["m1"]);
+  assert.equal(
+    await otherTab.claim("m1", {
+      now: clock + AUTO_CONTINUE_LEASE_TTL_MS + 1,
+    }),
+    "held-elsewhere",
+    "this one really was continued",
+  );
+});
+
+test("only the gate's own tokens are read as a refusal", () => {
+  // The predicate is asked about "is this thread generating", so anything it cannot prove
+  // is a gate pulse has to answer yes: a run from before per-run tracking carries no owner
+  // at all, and a key shared with a real run carries one of each.
+  const gateOwner = createImageGateRunOwner();
+  const runOwner = () => {};
+  assert.equal(isImageGateRunOnly([{ owner: gateOwner }]), true);
+  assert.equal(isImageGateRunOnly([{ owner: runOwner }]), false);
+  assert.equal(
+    isImageGateRunOnly([{ owner: gateOwner }, { owner: runOwner }]),
+    false,
+  );
+  assert.equal(isImageGateRunOnly([]), false, "an ownerless flag is a run");
+  assert.equal(isImageGateRunOnly(undefined), false);
+  assert.notEqual(
+    createImageGateRunOwner(),
+    gateOwner,
+    "one token per pulse, or two gates on a shared key clear each other",
+  );
+});
+
+test("the gate's pulse is tagged where it is fired and read where it matters", () => {
+  // Neither end is exercised by a unit test: the adapter's gate is deep inside a run, and
+  // the keeper's real signal reads a zustand store. Pinned at both ends instead.
+  const adapter = readFileSync(
+    new URL("../src/features/chat/api/chat-adapter.ts", import.meta.url),
+    "utf8",
+  );
+  const gate = adapter.slice(adapter.indexOf("const imageGateReason ="));
+  assert.match(
+    gate,
+    /const gateOwner = createImageGateRunOwner\(\)/,
+    "an anonymous owner is indistinguishable from a run that really started",
+  );
+  assert.match(
+    gate.slice(gate.indexOf("const gateOwner")),
+    /setThreadRunning\([\s\S]*owner: gateOwner[\s\S]*setThreadRunning\([\s\S]*owner: gateOwner/,
+    "the pulse compare mode waits on is still fired under that token",
+  );
+
+  const wiring = readFileSync(
+    new URL(
+      "../src/features/chat/utils/auto-continue-run-keeper.ts",
+      import.meta.url,
+    ),
+    "utf8",
+  );
+  assert.match(
+    wiring,
+    /isImageGateRunOnly\(state\.runOwnerByThreadId\[threadId\]\)/,
+    "the keeper is arming holds on a request the gate refused to send",
   );
   assert.doesNotMatch(
     wiring,

--- a/studio/frontend/tests/chat-continuation.test.ts
+++ b/studio/frontend/tests/chat-continuation.test.ts
@@ -2,6 +2,7 @@
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import test from "node:test";
 
 import { registerBundlerResolver } from "./helpers/kit.ts";
@@ -1326,5 +1327,113 @@ test("a malformed lease record is ignored rather than blocking", async () => {
   assert.equal(
     await createAutoContinueTab({ storage: other }).claim("m1"),
     "started",
+  );
+});
+
+test("a hold whose run never starts holds its lease for the life of the tab", async () => {
+  // Not a defect on its own: a hold that has not seen its run yet is deliberately renewed
+  // rather than timed out, because preflight has no upper bound and a deadline that fired
+  // during one lapsed the lease under a run that had since started streaming.
+  //
+  // It is the reason the bar must not take a hold for a run it never issued. This is what
+  // that mistake costs, so the guard in `ContinueMessageBarForLastMessage` below has
+  // something concrete to be measured against.
+  const { storage } = storageFake();
+  const locks = lockManagerFake();
+  const tab = createAutoContinueTab({ storage, locks });
+  const otherTab = createAutoContinueTab({ storage, locks });
+  const running = new Set<string>();
+  const pending: Promise<unknown>[] = [];
+  const start = 1_000;
+  let clock = start;
+  const keeper = createAutoContinueLeaseKeeper({
+    signal: {
+      isRunning: (threadId: string) => running.has(threadId),
+      subscribe: () => () => {},
+    },
+    renew: (messageId: string, holder: string, now: number) => {
+      pending.push(tab.renew(messageId, holder, { now }));
+    },
+    release: (messageId: string, holder: string, now: number) => {
+      pending.push(tab.release(messageId, holder, { now }));
+    },
+    now: () => clock,
+  });
+
+  assert.equal(
+    await tab.claim("m1", { now: start, holder: "thread-A" }),
+    "started",
+  );
+  keeper.hold("m1", "thread-A");
+  // `thread-A` never runs: the run this hold is waiting for was never issued.
+  for (
+    let day = 1;
+    day <= (3 * 86_400_000) / AUTO_CONTINUE_LEASE_RENEW_MS;
+    day += 1
+  ) {
+    clock = start + day * AUTO_CONTINUE_LEASE_RENEW_MS;
+    keeper.tick();
+  }
+  await Promise.all(pending);
+
+  assert.equal(keeper.held(), 1, "nothing drops a pending hold, by design");
+  assert.equal(
+    await otherTab.claim("m1", { now: clock + AUTO_CONTINUE_LEASE_TTL_MS - 1 }),
+    "held-elsewhere",
+    "three days on, every other tab is still refused this message",
+  );
+});
+
+test("a claim whose run was never issued is left to lapse, not held", async () => {
+  // The bar claims under a Web Lock, so the answer lands a tick or more after the render
+  // that asked for it, and `aui.thread()` follows the SELECTION rather than the thread the
+  // bar belongs to (`runningByThreadId` exists precisely because "detection survives
+  // navigation" and `aui.thread()` does not). Switch chats or branches inside that window
+  // and `startContinuation` searches a different thread's messages, finds nothing, and
+  // returns without calling `startRun`.
+  //
+  // Taking the hold anyway is the case above: renewed forever, and every other tab refused
+  // the message until this one closes. So the message has to still be there before anything
+  // is held. Pinned at the source, since there is no renderer here -- the same way
+  // composer-keystroke-subscription-budget.test.ts pins its seams.
+  const thread = readFileSync(
+    new URL("../src/components/assistant-ui/thread.tsx", import.meta.url),
+    "utf8",
+  );
+  const claimed = thread.indexOf(
+    'claimAutoContinue(messageId, runThreadId ?? "")',
+  );
+  assert.notEqual(claimed, -1, "the claim moved; this test needs rewriting");
+  const branch = thread.slice(
+    claimed,
+    thread.indexOf("held-elsewhere", claimed),
+  );
+
+  const guard = branch.search(/messages\.some\(/);
+  const hold = branch.indexOf("holdAutoContinueRun(");
+  const record = branch.indexOf("recordAutoContinue(");
+  const run = branch.indexOf("startContinuation()");
+  assert.notEqual(
+    guard,
+    -1,
+    "nothing checks the message is still there before holding",
+  );
+  assert.notEqual(hold, -1, "the hold is gone; this test needs rewriting");
+  assert.ok(
+    guard < hold && guard < record && guard < run,
+    "the message has to be confirmed present before the lease is held or the round spent",
+  );
+  // And the guard must leave the claim alone rather than reach for a timer: the lease
+  // lapsing on its own TTL is what a tab that closed mid-claim already produces.
+  const between = branch.slice(guard, hold);
+  assert.match(
+    between,
+    /\breturn;/,
+    "the guard has to stop before the hold, not fall through",
+  );
+  assert.doesNotMatch(
+    between,
+    /setTimeout|setInterval/,
+    "a deadline here is the arming timeout coming back, which lapses live continuations",
   );
 });

--- a/studio/frontend/tests/chat-continuation.test.ts
+++ b/studio/frontend/tests/chat-continuation.test.ts
@@ -10,6 +10,8 @@ registerBundlerResolver();
 
 const {
   AUTO_CONTINUE_LEASE_KEY,
+  AUTO_CONTINUE_LEASE_RENEW_MS,
+  AUTO_CONTINUE_LEASE_SETTLE_MS,
   AUTO_CONTINUE_LEASE_TTL_MS,
   AUTO_CONTINUE_LIMIT,
   autoContinueCount,
@@ -424,52 +426,52 @@ test("an unknown fit does not block resuming", () => {
   );
 });
 
-test("a message is claimed for automatic continuation exactly once", () => {
+test("a message is claimed for automatic continuation exactly once", async () => {
   resetAutoContinue();
-  assert.equal(claimAutoContinue("m1"), true);
-  assert.equal(claimAutoContinue("m1"), false);
-  assert.equal(claimAutoContinue("m1"), false);
+  assert.equal(await claimAutoContinue("m1"), "started");
+  assert.equal(await claimAutoContinue("m1"), "skipped");
+  assert.equal(await claimAutoContinue("m1"), "skipped");
 });
 
-test("the claim survives a remount, which a component ref did not", () => {
+test("the claim survives a remount, which a component ref did not", async () => {
   // Leave the chat with a truncated branch selected and come back: a ref was fresh
   // while the parent still had budget, so the effect fired again and created another
   // sibling and another paid provider request.
   resetAutoContinue();
-  assert.equal(claimAutoContinue("m1"), true);
+  assert.equal(await claimAutoContinue("m1"), "started");
   assert.equal(shouldAutoContinue("length", "parent-1"), true);
-  assert.equal(claimAutoContinue("m1"), false);
+  assert.equal(await claimAutoContinue("m1"), "skipped");
 });
 
-test("claims are tracked per message", () => {
+test("claims are tracked per message", async () => {
   resetAutoContinue();
-  assert.equal(claimAutoContinue("m1"), true);
-  assert.equal(claimAutoContinue("m2"), true);
-  assert.equal(claimAutoContinue("m1"), false);
+  assert.equal(await claimAutoContinue("m1"), "started");
+  assert.equal(await claimAutoContinue("m2"), "started");
+  assert.equal(await claimAutoContinue("m1"), "skipped");
 });
 
-test("a missing message id is refused rather than claimed", () => {
+test("a missing message id is refused rather than claimed", async () => {
   resetAutoContinue();
-  assert.equal(claimAutoContinue(null), false);
-  assert.equal(claimAutoContinue(undefined), false);
-  assert.equal(claimAutoContinue(""), false);
+  assert.equal(await claimAutoContinue(null), "skipped");
+  assert.equal(await claimAutoContinue(undefined), "skipped");
+  assert.equal(await claimAutoContinue(""), "skipped");
 });
 
-test("a claim is reported and cleared by a full reset", () => {
+test("a claim is reported and cleared by a full reset", async () => {
   resetAutoContinue();
   assert.equal(wasAutoContinued("m1"), false);
-  claimAutoContinue("m1");
+  await claimAutoContinue("m1");
   assert.equal(wasAutoContinued("m1"), true);
   resetAutoContinue();
   assert.equal(wasAutoContinued("m1"), false);
-  assert.equal(claimAutoContinue("m1"), true);
+  assert.equal(await claimAutoContinue("m1"), "started");
 });
 
-test("a message already claimed stops reporting itself as continuing", () => {
+test("a message already claimed stops reporting itself as continuing", async () => {
   resetAutoContinue();
   // The turn that fires it: nothing has claimed the message yet.
   assert.equal(shouldAutoContinueMessage("m1", "length", "parent-1"), true);
-  claimAutoContinue("m1");
+  await claimAutoContinue("m1");
   recordAutoContinue("parent-1");
 
   // Back on the truncated branch, whether through the branch picker or by returning to
@@ -479,9 +481,9 @@ test("a message already claimed stops reporting itself as continuing", () => {
   assert.equal(shouldAutoContinueMessage("m1", "length", "parent-1"), false);
 });
 
-test("a claim on one message does not silence another", () => {
+test("a claim on one message does not silence another", async () => {
   resetAutoContinue();
-  claimAutoContinue("m1");
+  await claimAutoContinue("m1");
   // The next round of the same turn is a new message with budget left, and continues.
   recordAutoContinue("parent-1");
   assert.equal(shouldAutoContinueMessage("m2", "length", "parent-1"), true);
@@ -501,16 +503,32 @@ test("a claimed message still honours the gates the turn itself fails", () => {
 // The module claim above is per TAB: each one loads its own copy of the module with its
 // own empty set. Open the same saved thread twice with a `length` reply last and both
 // tabs claim it, both start a run, and the user pays for two continuations and gets two
-// sibling branches. A tab here is a second `createAutoContinueTab` over one shared store,
-// which is what two browser tabs are.
+// sibling branches. A tab here is a second `createAutoContinueTab` over one shared store
+// and one shared lock manager, which is what two browser tabs are.
 
-/** An in-memory `localStorage`. `onSet` runs after a write, to interleave another tab. */
-function storageFake(onSet?: (store: Map<string, string>) => void) {
+/**
+ * An in-memory `localStorage`.
+ *
+ * `onSet` runs after a write and `onGet` after a read has taken its value, which is where
+ * another tab is interleaved: both hooks land in the middle of a read-modify-write, which
+ * is the sequence localStorage does not make atomic.
+ */
+function storageFake(
+  onSet?: (store: Map<string, string>) => void,
+  onGet?: (store: Map<string, string>) => void,
+) {
   const store = new Map<string, string>();
   return {
     store,
     storage: {
-      getItem: (key: string) => store.get(key) ?? null,
+      getItem: (key: string) => {
+        const value = store.get(key) ?? null;
+        // After the value is taken, so the caller carries on with the snapshot it read
+        // and whatever the other tab does next is invisible to it. That staleness is the
+        // whole bug.
+        onGet?.(store);
+        return value;
+      },
       setItem: (key: string, value: string) => {
         store.set(key, value);
         onSet?.(store);
@@ -522,36 +540,159 @@ function storageFake(onSet?: (store: Map<string, string>) => void) {
   };
 }
 
-test("a second tab with the same thread open does not start its own continuation", () => {
+/** A win, in the pre-fix boolean shape as well as the current one. */
+function startedARun(outcome: unknown): boolean {
+  return outcome === "started" || outcome === true;
+}
+
+/**
+ * A `navigator.locks` stand-in: one queue per name, exclusive, FIFO.
+ *
+ * The property the real API gives and a bare read-modify-write does not: a second request
+ * for a held name does not run until the first has returned.
+ */
+function lockManagerFake() {
+  const tails = new Map<string, Promise<unknown>>();
+  return {
+    request<T>(name: string, callback: () => T | Promise<T>): Promise<T> {
+      const tail = tails.get(name) ?? Promise.resolve();
+      const run = tail.then(() => callback());
+      // The queue advances on settle, so one throwing holder cannot wedge the name.
+      tails.set(
+        name,
+        run.then(
+          () => undefined,
+          () => undefined,
+        ),
+      );
+      return run;
+    },
+  };
+}
+
+test("a second tab with the same thread open does not start its own continuation", async () => {
   const { storage } = storageFake();
-  const first = createAutoContinueTab({ storage });
-  const second = createAutoContinueTab({ storage });
+  const locks = lockManagerFake();
+  const first = createAutoContinueTab({ storage, locks });
+  const second = createAutoContinueTab({ storage, locks });
   const now = 1_000;
 
-  assert.equal(first.claim("m1", { now }), true);
+  assert.equal(await first.claim("m1", { now }), "started");
   // Fresh module scope, empty claim set, same truncated reply on screen. Before the lease
-  // this said true and the second tab fired a second paid request.
-  assert.equal(second.claim("m1", { now }), false);
+  // this said yes and the second tab fired a second paid request.
+  assert.equal(await second.claim("m1", { now }), "held-elsewhere");
   // And it reports the message as being continued, so it shows no spinner of its own.
   assert.equal(second.claimed("m1", { now }), true);
 });
 
-test("a lease covers only the message it was taken for", () => {
+test("a lease covers only the message it was taken for", async () => {
   const { storage } = storageFake();
-  const first = createAutoContinueTab({ storage });
-  const second = createAutoContinueTab({ storage });
+  const locks = lockManagerFake();
+  const first = createAutoContinueTab({ storage, locks });
+  const second = createAutoContinueTab({ storage, locks });
   const now = 1_000;
 
-  assert.equal(first.claim("m1", { now }), true);
+  assert.equal(await first.claim("m1", { now }), "started");
   // The next round of the same turn is a different message and is nobody's yet.
-  assert.equal(second.claim("m2", { now }), true);
+  assert.equal(await second.claim("m2", { now }), "started");
 });
 
-test("two tabs writing in the same tick leave exactly one winner", () => {
-  // The window the free check alone cannot close: both tabs read the slot free, so both
-  // write, and the write that lands second is the one still in storage. The other tab
-  // reads its own token back, does not find it, and stands down. Written here as a tab
-  // whose record appears between this one's write and its read-back.
+test("two tabs claiming at once leave exactly one winner", async () => {
+  // ITEM A. Write-then-read-back is not a compare-and-swap: both tabs read the slot free,
+  // both write, and each verifies the token it just wrote if the two verifications happen
+  // before the two writes interleave -- so both start a run. Individual localStorage
+  // operations are atomic; a read-modify-write across statements is not, and the storage
+  // mutex that once serialized such sequences is no longer in the spec.
+  //
+  // Started together, with no await between them, which is what two tabs reaching the
+  // effect in the same instant are. The lock is what makes the second one wait for the
+  // first, see the lease it wrote, and stand down.
+  const { storage } = storageFake();
+  const locks = lockManagerFake();
+  const first = createAutoContinueTab({ storage, locks });
+  const second = createAutoContinueTab({ storage, locks });
+  const now = 1_000;
+
+  const outcomes = await Promise.all([
+    first.claim("m1", { now }),
+    second.claim("m1", { now }),
+  ]);
+  assert.equal(outcomes.filter(startedARun).length, 1);
+  assert.equal(
+    outcomes.filter((outcome) => outcome === "held-elsewhere").length,
+    1,
+  );
+});
+
+test("a tab that reads the slot free does not win it behind another tab's back", async () => {
+  // ITEM A, at the exact interleaving that survives a write-then-read-back: the second
+  // tab claims in full between the first tab READING the slot free and writing to it. The
+  // first tab then writes over a lease it never saw and reads its own token back, so both
+  // tabs believe they won and the user pays twice. Nothing about the sequence is atomic;
+  // only holding a lock across it is.
+  const now = 1_000;
+  let intruder: (() => unknown) | null = null;
+  let secondOutcome: unknown;
+  let reads = 0;
+  const { storage } = storageFake(undefined, () => {
+    reads += 1;
+    // The second read is the one the write is about to be based on: a free check, then
+    // the read-modify-write itself. Slipping the other tab in there is what leaves the
+    // first tab holding a snapshot that is already out of date.
+    if (reads !== 2) {
+      return;
+    }
+    const run = intruder;
+    intruder = null;
+    if (run) {
+      secondOutcome = run();
+    }
+  });
+  const locks = lockManagerFake();
+  const first = createAutoContinueTab({ storage, locks });
+  const second = createAutoContinueTab({ storage, locks });
+
+  intruder = () => second.claim("m1", { now });
+  const outcomes = [await first.claim("m1", { now }), await secondOutcome];
+  assert.equal(
+    outcomes.filter(startedARun).length,
+    1,
+    "exactly one tab may start the run",
+  );
+});
+
+test("a claim that loses says so, rather than just failing", async () => {
+  // ITEM B. The two ways of not starting a run need opposite things on screen, so they
+  // cannot both be a bare false. `held-elsewhere` is the loser, and is what puts this
+  // tab's manual Continue button back in place of a spinner for a run it never owned.
+  // `skipped` is this tab's own second call -- a StrictMode replay, or a claim already in
+  // flight -- where the run is coming and nothing should move.
+  const { storage } = storageFake();
+  const locks = lockManagerFake();
+  const winner = createAutoContinueTab({ storage, locks });
+  const loser = createAutoContinueTab({ storage, locks });
+  const now = 1_000;
+
+  assert.equal(startedARun(await winner.claim("m1", { now })), true);
+  const lost = await loser.claim("m1", { now });
+  // The winner's own replay is not a loss and must not repaint anything, so the two
+  // cannot be the same answer. One bare false for both is what left the losing tab
+  // spinning: its effect returned early, changed no state, and hid its own button.
+  const replay = await winner.claim("m1", { now });
+  assert.notEqual(lost, replay);
+  assert.equal(lost, "held-elsewhere");
+  assert.equal(replay, "skipped");
+  // Nor is a second call while the first is still inside the lock.
+  const inFlight = winner.claim("m2", { now });
+  assert.equal(await winner.claim("m2", { now }), "skipped");
+  assert.equal(await inFlight, "started");
+});
+
+test("two tabs writing in the same tick leave exactly one winner", async () => {
+  // The same race with no lock manager to settle it, which is what an older browser or an
+  // embedded webview gets. The write-then-read-back is all that is left: a record that
+  // appears between this tab's write and its read-back means the tab does not find its
+  // own token, and stands down.
   const now = 1_000;
   let interleave = true;
   const { storage } = storageFake((store) => {
@@ -566,27 +707,50 @@ test("two tabs writing in the same tick leave exactly one winner", () => {
       }),
     );
   });
-  const first = createAutoContinueTab({ storage });
+  const first = createAutoContinueTab({ storage, locks: null });
 
-  assert.equal(first.claim("m1", { now }), false);
+  assert.equal(await first.claim("m1", { now }), "held-elsewhere");
   // Nothing recorded locally either, so once that lease lapses this tab can take over.
   assert.equal(
-    first.claim("m1", { now: now + AUTO_CONTINUE_LEASE_TTL_MS + 1 }),
-    true,
+    await first.claim("m1", { now: now + AUTO_CONTINUE_LEASE_TTL_MS + 1 }),
+    "started",
   );
 });
 
-test("a tab with no storage keeps the claim it always had", () => {
+test("a browser with no lock manager still continues", async () => {
+  const { storage } = storageFake();
+  const only = createAutoContinueTab({ storage, locks: null });
+  assert.equal(await only.claim("m1"), "started");
+  assert.equal(await only.claim("m1"), "skipped");
+});
+
+test("a lock manager that refuses the request does not block the claim", async () => {
+  const { storage } = storageFake();
+  const angryLocks = {
+    request<T>(): Promise<T> {
+      return Promise.reject(new Error("NotSupportedError"));
+    },
+  };
+  const tab = createAutoContinueTab({ storage, locks: angryLocks });
+  // Degraded to the read-back, not to a refusal: the user is waiting for this run.
+  assert.equal(await tab.claim("m1"), "started");
+  assert.equal(
+    await createAutoContinueTab({ storage }).claim("m1"),
+    "held-elsewhere",
+  );
+});
+
+test("a tab with no storage keeps the claim it always had", async () => {
   // Private mode, an embedded webview, or the test runner: no seam to share. Falling back
   // to module scope is what shipped before the lease, and it must never refuse a
   // continuation the single tab in front of the user is waiting for.
   const only = createAutoContinueTab({ storage: null });
-  assert.equal(only.claim("m1"), true);
-  assert.equal(only.claim("m1"), false);
+  assert.equal(await only.claim("m1"), "started");
+  assert.equal(await only.claim("m1"), "skipped");
   assert.equal(only.claimed("m1"), true);
 });
 
-test("storage that throws is no worse than no storage", () => {
+test("storage that throws is no worse than no storage", async () => {
   // A quota-exceeded write, or a getItem that throws before it returns anything.
   const angry = {
     getItem(): string | null {
@@ -600,99 +764,186 @@ test("storage that throws is no worse than no storage", () => {
     },
   };
   const tab = createAutoContinueTab({ storage: angry });
-  assert.equal(tab.claim("m1"), true);
-  assert.equal(tab.claim("m1"), false);
+  assert.equal(await tab.claim("m1"), "started");
+  assert.equal(await tab.claim("m1"), "skipped");
   // A second tab cannot see through a broken seam either, so it behaves as it did before
   // the lease: module-only. Duplicates are not made worse, and nothing crashes.
-  assert.equal(createAutoContinueTab({ storage: angry }).claim("m1"), true);
+  assert.equal(
+    await createAutoContinueTab({ storage: angry }).claim("m1"),
+    "started",
+  );
 });
 
-test("a lease lapses, so a tab that died mid-run does not wedge the message", () => {
+test("a lease lapses, so a tab that died mid-run does not wedge the message", async () => {
   const { storage } = storageFake();
-  const winner = createAutoContinueTab({ storage });
-  const later = createAutoContinueTab({ storage });
+  const locks = lockManagerFake();
+  const winner = createAutoContinueTab({ storage, locks });
+  const later = createAutoContinueTab({ storage, locks });
   const start = 1_000;
 
-  assert.equal(winner.claim("m1", { now: start }), true);
-  // Still inside the lease: the run is presumed live and nobody else touches it.
+  assert.equal(await winner.claim("m1", { now: start }), "started");
+  // Still inside the lease: the holder is presumed alive and nobody else touches it.
   assert.equal(
-    later.claim("m1", { now: start + AUTO_CONTINUE_LEASE_TTL_MS - 1 }),
-    false,
+    await later.claim("m1", { now: start + AUTO_CONTINUE_LEASE_TTL_MS - 1 }),
+    "held-elsewhere",
   );
-  // Past it: a permanent flag would have left this message unresumable for the life of
-  // the profile, because the tab that owned it is gone and can never clear it.
+  // Past it, with no renewal in between: a permanent flag would have left this message
+  // unresumable for the life of the profile, because the tab that owned it is gone and
+  // can never clear it.
   assert.equal(
-    later.claim("m1", { now: start + AUTO_CONTINUE_LEASE_TTL_MS + 1 }),
-    true,
+    await later.claim("m1", { now: start + AUTO_CONTINUE_LEASE_TTL_MS + 1 }),
+    "started",
   );
 });
 
-test("lapsed leases are pruned rather than accumulating", () => {
-  const { storage, store } = storageFake();
-  const tab = createAutoContinueTab({ storage });
+test("a running continuation keeps its lease past the TTL", async () => {
+  // ITEM C. A local model on a large Max Tokens can generate for longer than the TTL, and
+  // an unrenewed lease would hand its message to the next tab to open, mid-stream. The
+  // holder renews for as long as its run is live, so the TTL only ever measures silence.
+  const { storage } = storageFake();
+  const locks = lockManagerFake();
+  const running = createAutoContinueTab({ storage, locks });
+  const other = createAutoContinueTab({ storage, locks });
   const start = 1_000;
 
-  tab.claim("m1", { now: start });
-  createAutoContinueTab({ storage }).claim("m2", {
+  assert.equal(startedARun(await running.claim("m1", { now: start })), true);
+  // Three renewals at the interval the keeper uses, still inside the run.
+  for (let tick = 1; tick <= 3; tick += 1) {
+    await running.renew({ now: start + tick * AUTO_CONTINUE_LEASE_RENEW_MS });
+  }
+  const past =
+    start + AUTO_CONTINUE_LEASE_TTL_MS + AUTO_CONTINUE_LEASE_RENEW_MS;
+  assert.equal(await other.claim("m1", { now: past }), "held-elsewhere");
+});
+
+test("a finished run gives its lease back, without handing over a stale branch", async () => {
+  // Released on any terminal state, so the full TTL is left to mean one thing: a crash.
+  // Cut to the settle window rather than deleted, because a tab still showing the
+  // pre-continuation branch has not seen the sibling yet and would start the duplicate.
+  const { storage } = storageFake();
+  const locks = lockManagerFake();
+  const running = createAutoContinueTab({ storage, locks });
+  const other = createAutoContinueTab({ storage, locks });
+  const start = 1_000;
+
+  assert.equal(await running.claim("m1", { now: start }), "started");
+  await running.release({ now: start });
+  assert.equal(
+    await other.claim("m1", { now: start + AUTO_CONTINUE_LEASE_SETTLE_MS - 1 }),
+    "held-elsewhere",
+  );
+  assert.equal(
+    await other.claim("m1", { now: start + AUTO_CONTINUE_LEASE_SETTLE_MS + 1 }),
+    "started",
+  );
+  // And a release holds nothing, so a later renewal cannot resurrect it.
+  await running.renew({ now: start + AUTO_CONTINUE_LEASE_SETTLE_MS + 2 });
+  assert.equal(
+    await createAutoContinueTab({ storage, locks }).claim("m1", {
+      now: start + AUTO_CONTINUE_LEASE_SETTLE_MS + 3,
+    }),
+    "held-elsewhere",
+  );
+});
+
+test("a renewal touches this tab's leases and nobody else's", async () => {
+  const { storage, store } = storageFake();
+  const locks = lockManagerFake();
+  const mine = createAutoContinueTab({ storage, locks });
+  const theirs = createAutoContinueTab({ storage, locks });
+  const start = 1_000;
+
+  await mine.claim("m1", { now: start });
+  await theirs.claim("m2", { now: start });
+  await mine.renew({ now: start + AUTO_CONTINUE_LEASE_RENEW_MS });
+
+  const leases = JSON.parse(store.get(AUTO_CONTINUE_LEASE_KEY) ?? "{}");
+  assert.equal(
+    leases.m1.expires,
+    start + AUTO_CONTINUE_LEASE_RENEW_MS + AUTO_CONTINUE_LEASE_TTL_MS,
+  );
+  assert.equal(leases.m2.expires, start + AUTO_CONTINUE_LEASE_TTL_MS);
+});
+
+test("lapsed leases are pruned rather than accumulating", async () => {
+  const { storage, store } = storageFake();
+  const locks = lockManagerFake();
+  const tab = createAutoContinueTab({ storage, locks });
+  const start = 1_000;
+
+  await tab.claim("m1", { now: start });
+  await createAutoContinueTab({ storage, locks }).claim("m2", {
     now: start + AUTO_CONTINUE_LEASE_TTL_MS + 1,
   });
   const leases = JSON.parse(store.get(AUTO_CONTINUE_LEASE_KEY) ?? "{}");
   assert.deepEqual(Object.keys(leases), ["m2"]);
 });
 
-test("reloading one tab does not fire a second continuation", () => {
+test("reloading one tab does not fire a second continuation", async () => {
   // What stops this today is branch selection: the continuation runs as a sibling and
   // becomes the selected branch, so the truncated reply is no longer last and the effect
   // never asks. The lease is the belt to that pair of braces -- a reload lands on the
   // truncated branch, its module scope is empty, and storage is the only thing that
   // remembers. Nothing here changes what selection already refuses.
   const { storage } = storageFake();
-  const before = createAutoContinueTab({ storage });
+  const locks = lockManagerFake();
+  const before = createAutoContinueTab({ storage, locks });
   const start = 1_000;
-  assert.equal(before.claim("m1", { now: start }), true);
+  assert.equal(await before.claim("m1", { now: start }), "started");
 
   // The reload: same tab, same profile, brand new module scope.
-  const after = createAutoContinueTab({ storage });
-  assert.equal(after.claim("m1", { now: start + 5_000 }), false);
+  const after = createAutoContinueTab({ storage, locks });
+  assert.equal(
+    await after.claim("m1", { now: start + 5_000 }),
+    "held-elsewhere",
+  );
   assert.equal(after.claimed("m1", { now: start + 5_000 }), true);
 });
 
-test("a reset gives back this tab's lease and leaves other tabs alone", () => {
+test("a reset gives back this tab's lease and leaves other tabs alone", async () => {
   const { storage } = storageFake();
-  const mine = createAutoContinueTab({ storage });
-  const theirs = createAutoContinueTab({ storage });
+  const locks = lockManagerFake();
+  const mine = createAutoContinueTab({ storage, locks });
+  const theirs = createAutoContinueTab({ storage, locks });
   const now = 1_000;
 
-  assert.equal(mine.claim("m1", { now }), true);
+  assert.equal(await mine.claim("m1", { now }), "started");
   mine.reset();
   // Cleared in both places, so "start from zero" means what it did before the lease.
-  assert.equal(mine.claim("m1", { now }), true);
+  assert.equal(await mine.claim("m1", { now }), "started");
 
-  assert.equal(theirs.claim("m2", { now }), true);
+  assert.equal(await theirs.claim("m2", { now }), "started");
   mine.reset();
   // Not mine to release: a run another tab is driving is still going.
-  assert.equal(createAutoContinueTab({ storage }).claim("m2", { now }), false);
+  assert.equal(
+    await createAutoContinueTab({ storage, locks }).claim("m2", { now }),
+    "held-elsewhere",
+  );
 });
 
-test("a stored lease survives a full reset by the module, being another tab's", () => {
+test("a stored lease survives a full reset by the module, being another tab's", async () => {
   // `resetAutoContinue()` clears the module claim and the round budget. It cannot know
   // about a lease it never wrote, and must not stamp on one.
   const { storage, store } = storageFake();
-  createAutoContinueTab({ storage }).claim("m1", { now: 1_000 });
+  const locks = lockManagerFake();
+  await createAutoContinueTab({ storage, locks }).claim("m1", { now: 1_000 });
   resetAutoContinue();
   assert.equal(
-    createAutoContinueTab({ storage }).claim("m1", { now: 1_000 }),
-    false,
+    await createAutoContinueTab({ storage, locks }).claim("m1", { now: 1_000 }),
+    "held-elsewhere",
   );
   assert.equal(store.has(AUTO_CONTINUE_LEASE_KEY), true);
 });
 
-test("a malformed lease record is ignored rather than blocking", () => {
+test("a malformed lease record is ignored rather than blocking", async () => {
   const { storage, store } = storageFake();
   store.set(AUTO_CONTINUE_LEASE_KEY, "not json at all");
-  assert.equal(createAutoContinueTab({ storage }).claim("m1"), true);
+  assert.equal(await createAutoContinueTab({ storage }).claim("m1"), "started");
 
   const { storage: other, store: otherStore } = storageFake();
   otherStore.set(AUTO_CONTINUE_LEASE_KEY, JSON.stringify({ m1: { token: 7 } }));
-  assert.equal(createAutoContinueTab({ storage: other }).claim("m1"), true);
+  assert.equal(
+    await createAutoContinueTab({ storage: other }).claim("m1"),
+    "started",
+  );
 });

--- a/studio/frontend/tests/chat-continuation.test.ts
+++ b/studio/frontend/tests/chat-continuation.test.ts
@@ -9,10 +9,9 @@ import { registerBundlerResolver } from "./helpers/kit.ts";
 registerBundlerResolver();
 
 const {
-  AUTO_CONTINUE_ARM_TIMEOUT_MS,
+  AUTO_CONTINUE_CONTINUED_TTL_MS,
   AUTO_CONTINUE_LEASE_KEY,
   AUTO_CONTINUE_LEASE_RENEW_MS,
-  AUTO_CONTINUE_LEASE_SETTLE_MS,
   AUTO_CONTINUE_LEASE_TTL_MS,
   AUTO_CONTINUE_LIMIT,
   autoContinueCount,
@@ -829,10 +828,11 @@ test("a running continuation keeps its lease past the TTL", async () => {
   assert.equal(await other.claim("m1", { now: past }), "held-elsewhere");
 });
 
-test("a finished run gives its lease back, without handing over a stale branch", async () => {
+test("a finished run leaves the message continued, not free again", async () => {
   // Released on any terminal state, so the full TTL is left to mean one thing: a crash.
-  // Cut to the settle window rather than deleted, because a tab still showing the
-  // pre-continuation branch has not seen the sibling yet and would start the duplicate.
+  // Marked done rather than handed back, because the tab that did not win never learns that
+  // the sibling was written -- no chat-history event crosses tabs -- so a record that simply
+  // lapsed handed the message to a stale tab and bought the same continuation twice.
   const { storage } = storageFake();
   const locks = lockManagerFake();
   const running = createAutoContinueTab({ storage, locks });
@@ -845,22 +845,83 @@ test("a finished run gives its lease back, without handing over a stale branch",
   );
   await running.release("m1", PANE, { now: start });
   assert.equal(
-    await other.claim("m1", { now: start + AUTO_CONTINUE_LEASE_SETTLE_MS - 1 }),
+    await other.claim("m1", { now: start + AUTO_CONTINUE_LEASE_TTL_MS + 1 }),
     "held-elsewhere",
   );
   assert.equal(
-    await other.claim("m1", { now: start + AUTO_CONTINUE_LEASE_SETTLE_MS + 1 }),
-    "started",
-  );
-  // And a release holds nothing, so a later renewal cannot resurrect it.
-  await running.renew("m1", PANE, {
-    now: start + AUTO_CONTINUE_LEASE_SETTLE_MS + 2,
-  });
-  assert.equal(
-    await createAutoContinueTab({ storage, locks }).claim("m1", {
-      now: start + AUTO_CONTINUE_LEASE_SETTLE_MS + 3,
+    await other.claim("m1", {
+      now: start + AUTO_CONTINUE_CONTINUED_TTL_MS - 1,
     }),
     "held-elsewhere",
+  );
+  // And a release holds nothing, so a later renewal cannot resurrect it as a live lease.
+  await running.renew("m1", PANE, { now: start + AUTO_CONTINUE_LEASE_TTL_MS });
+  assert.equal(
+    await createAutoContinueTab({ storage, locks }).claim("m1", {
+      now: start + AUTO_CONTINUE_LEASE_TTL_MS + 2,
+    }),
+    "held-elsewhere",
+  );
+  // Bounded, not permanent: the record is pruned like any other once it is old enough that
+  // no tab can still be holding the pre-continuation branch in memory.
+  assert.equal(
+    await createAutoContinueTab({ storage, locks }).claim("m1", {
+      now: start + AUTO_CONTINUE_CONTINUED_TTL_MS + 1,
+    }),
+    "started",
+  );
+});
+
+test("a stale tab cannot take a message back once it has been continued", async () => {
+  // The case the settle window left open. The second tab's render-time check refuses before
+  // its effect ever runs, so it records nothing locally and holds no state saying it lost;
+  // its `continued` set stays empty. Remount that bar -- leaving the chat and coming back is
+  // enough, which is the same remount the module claim exists for -- and the only thing
+  // between it and a second paid request is what storage remembers. Nothing refreshes its
+  // in-memory history in the meantime: `notifyChatHistoryUpdated` dispatches a same-window
+  // event, no chat key has a `storage` listener, and stored messages are re-read only by
+  // `history.load`.
+  const { storage } = storageFake();
+  const locks = lockManagerFake();
+  const winner = createAutoContinueTab({ storage, locks });
+  const stale = createAutoContinueTab({ storage, locks });
+  const start = 1_000;
+
+  assert.equal(await winner.claim("m1", { now: start, holder: PANE }), "started");
+  // The stale tab renders the truncated reply while the winner is running: refused, and
+  // nothing about that refusal is written down on its side.
+  assert.equal(await stale.claim("m1", { now: start + 1 }), "held-elsewhere");
+  // The winner finishes and writes the sibling. The stale tab still shows the partial.
+  await winner.release("m1", PANE, { now: start + 60_000 });
+  // Its bar remounts, long after any settle window would have passed.
+  assert.equal(
+    stale.claimed("m1", { now: start + 60_000 + AUTO_CONTINUE_LEASE_TTL_MS }),
+    true,
+  );
+  assert.equal(
+    await stale.claim("m1", {
+      now: start + 60_000 + AUTO_CONTINUE_LEASE_TTL_MS,
+    }),
+    "held-elsewhere",
+  );
+});
+
+test("a tab that died mid-run still hands the message back", async () => {
+  // The other half of the same rule, and the reason a permanent flag is wrong: a record is
+  // only marked done by a run that reached a terminal state. A tab killed without cleanup
+  // renews nothing and marks nothing, so its lease lapses and the message is claimable
+  // again. (Web Locks are released with the context too, so nothing is wedged there either.)
+  const { storage } = storageFake();
+  const locks = lockManagerFake();
+  const killed = createAutoContinueTab({ storage, locks });
+  const survivor = createAutoContinueTab({ storage, locks });
+  const start = 1_000;
+
+  assert.equal(await killed.claim("m1", { now: start, holder: PANE }), "started");
+  // No release, no renewal: the tab is gone.
+  assert.equal(
+    await survivor.claim("m1", { now: start + AUTO_CONTINUE_LEASE_TTL_MS + 1 }),
+    "started",
   );
 });
 
@@ -905,12 +966,12 @@ async function sequentialRounds(
     "held-elsewhere",
     "the round that just started keeps its lease",
   );
-  // The round that did finish settles on the usual schedule.
+  // The round that did finish is marked continued, and stays that way.
   assert.equal(
     await otherTab.claim("round-1", {
-      now: start + AUTO_CONTINUE_LEASE_SETTLE_MS + 1,
+      now: start + AUTO_CONTINUE_LEASE_TTL_MS + 1,
     }),
-    "started",
+    "held-elsewhere",
   );
 }
 
@@ -1009,9 +1070,10 @@ test("a run on a background thread keeps its lease while the user reads another 
   await Promise.all(pending);
   assert.equal(
     await otherTab.claim("a-m1", {
-      now: past + AUTO_CONTINUE_LEASE_SETTLE_MS + 1,
+      now: past + AUTO_CONTINUE_LEASE_TTL_MS + 1,
     }),
-    "started",
+    "held-elsewhere",
+    "the message was continued, so nobody continues it again",
   );
   assert.equal(keeper.held(), 0);
 });
@@ -1057,16 +1119,26 @@ test("a hold waits for its own run, not the one already in flight", async () => 
   assert.equal(await otherTab.claim("round-2", { now: past }), "held-elsewhere");
 });
 
-test("a hold whose run never appears is forgotten, and its lease simply lapses", async () => {
+test("a hold keeps its lease while its run is still in preflight", async () => {
+  // The adapter does a lot before the run reaches `runningByThreadId`: it awaits this
+  // thread's own settings pairing, which alone waits up to 30 seconds, and then
+  // `waitForModelReady`, which polls every 500ms for as long as a model is loading -- so a
+  // tab opened on a truncated reply while a large local model loads can sit in preflight for
+  // minutes. A hold dropped on a fixed arming timeout stopped renewing in the middle of
+  // that, its lease lapsed, and another tab claimed a message that was about to stream.
   const { storage } = storageFake();
   const tab = createAutoContinueTab({ storage, locks: null });
   const otherTab = createAutoContinueTab({ storage, locks: null });
   const start = 1_000;
   let clock = start;
-  const runs = runSignalFake(new Set<string>());
+  const pending: Promise<void>[] = [];
+  const running = new Set<string>();
+  const runs = runSignalFake(running);
   const keeper = createAutoContinueLeaseKeeper({
     signal: runs.signal,
-    renew: () => undefined,
+    renew: (messageId, holder, now) => {
+      pending.push(tab.renew(messageId, holder, { now }));
+    },
     release: () => {
       assert.fail("a hold that never armed has nothing to give back");
     },
@@ -1075,17 +1147,31 @@ test("a hold whose run never appears is forgotten, and its lease simply lapses",
 
   await tab.claim("a-m1", { now: start, holder: "thread-A" });
   keeper.hold("a-m1", "thread-A");
-  clock = start + AUTO_CONTINUE_ARM_TIMEOUT_MS + 1;
-  keeper.tick();
-  assert.equal(keeper.held(), 0);
-  // Untouched, so it runs out the TTL, exactly as a tab that closed mid-claim leaves it.
+
+  // Four minutes of preflight, renewed at the keeper's own interval throughout.
+  for (let tick = 1; tick <= 8; tick += 1) {
+    clock = start + tick * AUTO_CONTINUE_LEASE_RENEW_MS;
+    keeper.tick();
+  }
+  await Promise.all(pending);
+  assert.equal(keeper.held(), 1, "the hold is still expecting its run");
   assert.equal(
-    await otherTab.claim("a-m1", { now: start + AUTO_CONTINUE_LEASE_TTL_MS - 1 }),
+    await otherTab.claim("a-m1", { now: clock }),
     "held-elsewhere",
+    "nobody else may take a message this tab is still about to continue",
   );
+
+  // The run finally starts, and the hold arms on it rather than on a predecessor.
+  running.add("thread-A");
+  runs.change();
+  clock += AUTO_CONTINUE_LEASE_RENEW_MS;
+  keeper.tick();
+  await Promise.all(pending);
   assert.equal(
-    await otherTab.claim("a-m1", { now: start + AUTO_CONTINUE_LEASE_TTL_MS + 1 }),
-    "started",
+    await otherTab.claim("a-m1", {
+      now: clock + AUTO_CONTINUE_LEASE_TTL_MS - 1,
+    }),
+    "held-elsewhere",
   );
 });
 
@@ -1132,12 +1218,12 @@ test("one compare pane finishing does not release the other pane's lease", async
     "held-elsewhere",
     "the still-running pane keeps its message",
   );
-  // And the pane that did finish settles on the usual schedule.
+  // And the pane that did finish leaves its message continued.
   assert.equal(
     await otherTab.claim("base-m1", {
-      now: start + AUTO_CONTINUE_LEASE_SETTLE_MS + 1,
+      now: start + AUTO_CONTINUE_LEASE_TTL_MS + 1,
     }),
-    "started",
+    "held-elsewhere",
   );
 });
 

--- a/studio/frontend/tests/chat-continuation.test.ts
+++ b/studio/frontend/tests/chat-continuation.test.ts
@@ -39,6 +39,12 @@ const {
 const PARTIAL =
   "There are three steps to proofing dough properly. First, warm the bowl and";
 
+/**
+ * The runtime a claim belongs to. One Thread is one holder; compare mode has two, which is
+ * what the two-pane test below stands up.
+ */
+const PANE = "pane-1";
+
 test("a token-exact continuation is appended verbatim", () => {
   // A local model's prompt ended inside the partial turn, so the continuation opens
   // on the next word with nothing repeated.
@@ -428,9 +434,9 @@ test("an unknown fit does not block resuming", () => {
 
 test("a message is claimed for automatic continuation exactly once", async () => {
   resetAutoContinue();
-  assert.equal(await claimAutoContinue("m1"), "started");
-  assert.equal(await claimAutoContinue("m1"), "skipped");
-  assert.equal(await claimAutoContinue("m1"), "skipped");
+  assert.equal(await claimAutoContinue("m1", PANE), "started");
+  assert.equal(await claimAutoContinue("m1", PANE), "skipped");
+  assert.equal(await claimAutoContinue("m1", PANE), "skipped");
 });
 
 test("the claim survives a remount, which a component ref did not", async () => {
@@ -438,40 +444,40 @@ test("the claim survives a remount, which a component ref did not", async () => 
   // while the parent still had budget, so the effect fired again and created another
   // sibling and another paid provider request.
   resetAutoContinue();
-  assert.equal(await claimAutoContinue("m1"), "started");
+  assert.equal(await claimAutoContinue("m1", PANE), "started");
   assert.equal(shouldAutoContinue("length", "parent-1"), true);
-  assert.equal(await claimAutoContinue("m1"), "skipped");
+  assert.equal(await claimAutoContinue("m1", PANE), "skipped");
 });
 
 test("claims are tracked per message", async () => {
   resetAutoContinue();
-  assert.equal(await claimAutoContinue("m1"), "started");
-  assert.equal(await claimAutoContinue("m2"), "started");
-  assert.equal(await claimAutoContinue("m1"), "skipped");
+  assert.equal(await claimAutoContinue("m1", PANE), "started");
+  assert.equal(await claimAutoContinue("m2", PANE), "started");
+  assert.equal(await claimAutoContinue("m1", PANE), "skipped");
 });
 
 test("a missing message id is refused rather than claimed", async () => {
   resetAutoContinue();
-  assert.equal(await claimAutoContinue(null), "skipped");
-  assert.equal(await claimAutoContinue(undefined), "skipped");
-  assert.equal(await claimAutoContinue(""), "skipped");
+  assert.equal(await claimAutoContinue(null, PANE), "skipped");
+  assert.equal(await claimAutoContinue(undefined, PANE), "skipped");
+  assert.equal(await claimAutoContinue("", PANE), "skipped");
 });
 
 test("a claim is reported and cleared by a full reset", async () => {
   resetAutoContinue();
   assert.equal(wasAutoContinued("m1"), false);
-  await claimAutoContinue("m1");
+  await claimAutoContinue("m1", PANE);
   assert.equal(wasAutoContinued("m1"), true);
   resetAutoContinue();
   assert.equal(wasAutoContinued("m1"), false);
-  assert.equal(await claimAutoContinue("m1"), "started");
+  assert.equal(await claimAutoContinue("m1", PANE), "started");
 });
 
 test("a message already claimed stops reporting itself as continuing", async () => {
   resetAutoContinue();
   // The turn that fires it: nothing has claimed the message yet.
   assert.equal(shouldAutoContinueMessage("m1", "length", "parent-1"), true);
-  await claimAutoContinue("m1");
+  await claimAutoContinue("m1", PANE);
   recordAutoContinue("parent-1");
 
   // Back on the truncated branch, whether through the branch picker or by returning to
@@ -483,7 +489,7 @@ test("a message already claimed stops reporting itself as continuing", async () 
 
 test("a claim on one message does not silence another", async () => {
   resetAutoContinue();
-  await claimAutoContinue("m1");
+  await claimAutoContinue("m1", PANE);
   // The next round of the same turn is a new message with budget left, and continues.
   recordAutoContinue("parent-1");
   assert.equal(shouldAutoContinueMessage("m2", "length", "parent-1"), true);
@@ -806,10 +812,15 @@ test("a running continuation keeps its lease past the TTL", async () => {
   const other = createAutoContinueTab({ storage, locks });
   const start = 1_000;
 
-  assert.equal(startedARun(await running.claim("m1", { now: start })), true);
+  assert.equal(
+    startedARun(await running.claim("m1", { now: start, holder: PANE })),
+    true,
+  );
   // Three renewals at the interval the keeper uses, still inside the run.
   for (let tick = 1; tick <= 3; tick += 1) {
-    await running.renew({ now: start + tick * AUTO_CONTINUE_LEASE_RENEW_MS });
+    await running.renew(PANE, {
+      now: start + tick * AUTO_CONTINUE_LEASE_RENEW_MS,
+    });
   }
   const past =
     start + AUTO_CONTINUE_LEASE_TTL_MS + AUTO_CONTINUE_LEASE_RENEW_MS;
@@ -826,8 +837,11 @@ test("a finished run gives its lease back, without handing over a stale branch",
   const other = createAutoContinueTab({ storage, locks });
   const start = 1_000;
 
-  assert.equal(await running.claim("m1", { now: start }), "started");
-  await running.release({ now: start });
+  assert.equal(
+    await running.claim("m1", { now: start, holder: PANE }),
+    "started",
+  );
+  await running.release(PANE, { now: start });
   assert.equal(
     await other.claim("m1", { now: start + AUTO_CONTINUE_LEASE_SETTLE_MS - 1 }),
     "held-elsewhere",
@@ -837,12 +851,64 @@ test("a finished run gives its lease back, without handing over a stale branch",
     "started",
   );
   // And a release holds nothing, so a later renewal cannot resurrect it.
-  await running.renew({ now: start + AUTO_CONTINUE_LEASE_SETTLE_MS + 2 });
+  await running.renew(PANE, { now: start + AUTO_CONTINUE_LEASE_SETTLE_MS + 2 });
   assert.equal(
     await createAutoContinueTab({ storage, locks }).claim("m1", {
       now: start + AUTO_CONTINUE_LEASE_SETTLE_MS + 3,
     }),
     "held-elsewhere",
+  );
+});
+
+test("one compare pane finishing does not release the other pane's lease", async () => {
+  // Compare mode mounts two Thread runtimes in ONE tab, each with its own thread and its
+  // own run, and either can be resuming a truncated reply while the other is idle. A
+  // release that restamped every lease the tab owns and then dropped the lot would end the
+  // hold on the pane still generating: its renewals would find nothing held, and one settle
+  // window later another tab could claim its message and pay for a second run.
+  const { storage } = storageFake();
+  const locks = lockManagerFake();
+  const compareTab = createAutoContinueTab({ storage, locks });
+  const otherTab = createAutoContinueTab({ storage, locks });
+  const base = "pane-base";
+  const lora = "pane-lora";
+  const start = 1_000;
+
+  assert.equal(
+    startedARun(
+      await compareTab.claim("base-m1", { now: start, holder: base }),
+    ),
+    true,
+  );
+  assert.equal(
+    startedARun(
+      await compareTab.claim("lora-m1", { now: start, holder: lora }),
+    ),
+    true,
+  );
+
+  // The base pane finishes first. Only its own lease goes back.
+  await compareTab.release(base, { now: start });
+
+  // The lora pane is still generating, and its keeper is still renewing.
+  for (let tick = 1; tick <= 3; tick += 1) {
+    await compareTab.renew(lora, {
+      now: start + tick * AUTO_CONTINUE_LEASE_RENEW_MS,
+    });
+  }
+  const past =
+    start + AUTO_CONTINUE_LEASE_TTL_MS + AUTO_CONTINUE_LEASE_RENEW_MS;
+  assert.equal(
+    await otherTab.claim("lora-m1", { now: past }),
+    "held-elsewhere",
+    "the still-running pane keeps its message",
+  );
+  // And the pane that did finish settles on the usual schedule.
+  assert.equal(
+    await otherTab.claim("base-m1", {
+      now: start + AUTO_CONTINUE_LEASE_SETTLE_MS + 1,
+    }),
+    "started",
   );
 });
 
@@ -853,9 +919,9 @@ test("a renewal touches this tab's leases and nobody else's", async () => {
   const theirs = createAutoContinueTab({ storage, locks });
   const start = 1_000;
 
-  await mine.claim("m1", { now: start });
-  await theirs.claim("m2", { now: start });
-  await mine.renew({ now: start + AUTO_CONTINUE_LEASE_RENEW_MS });
+  await mine.claim("m1", { now: start, holder: PANE });
+  await theirs.claim("m2", { now: start, holder: PANE });
+  await mine.renew(PANE, { now: start + AUTO_CONTINUE_LEASE_RENEW_MS });
 
   const leases = JSON.parse(store.get(AUTO_CONTINUE_LEASE_KEY) ?? "{}");
   assert.equal(

--- a/studio/frontend/tests/chat-continuation.test.ts
+++ b/studio/frontend/tests/chat-continuation.test.ts
@@ -9,8 +9,11 @@ import { registerBundlerResolver } from "./helpers/kit.ts";
 registerBundlerResolver();
 
 const {
+  AUTO_CONTINUE_LEASE_KEY,
+  AUTO_CONTINUE_LEASE_TTL_MS,
   AUTO_CONTINUE_LIMIT,
   autoContinueCount,
+  createAutoContinueTab,
   budgetImpliesTruncation,
   incompleteLabel,
   isContinuableContent,
@@ -492,4 +495,204 @@ test("a claimed message still honours the gates the turn itself fails", () => {
     shouldAutoContinueMessage("m2", "length", "parent-1", { fits: false }),
     false,
   );
+});
+
+// --- cross-tab claim ------------------------------------------------------------------
+// The module claim above is per TAB: each one loads its own copy of the module with its
+// own empty set. Open the same saved thread twice with a `length` reply last and both
+// tabs claim it, both start a run, and the user pays for two continuations and gets two
+// sibling branches. A tab here is a second `createAutoContinueTab` over one shared store,
+// which is what two browser tabs are.
+
+/** An in-memory `localStorage`. `onSet` runs after a write, to interleave another tab. */
+function storageFake(onSet?: (store: Map<string, string>) => void) {
+  const store = new Map<string, string>();
+  return {
+    store,
+    storage: {
+      getItem: (key: string) => store.get(key) ?? null,
+      setItem: (key: string, value: string) => {
+        store.set(key, value);
+        onSet?.(store);
+      },
+      removeItem: (key: string) => {
+        store.delete(key);
+      },
+    },
+  };
+}
+
+test("a second tab with the same thread open does not start its own continuation", () => {
+  const { storage } = storageFake();
+  const first = createAutoContinueTab({ storage });
+  const second = createAutoContinueTab({ storage });
+  const now = 1_000;
+
+  assert.equal(first.claim("m1", { now }), true);
+  // Fresh module scope, empty claim set, same truncated reply on screen. Before the lease
+  // this said true and the second tab fired a second paid request.
+  assert.equal(second.claim("m1", { now }), false);
+  // And it reports the message as being continued, so it shows no spinner of its own.
+  assert.equal(second.claimed("m1", { now }), true);
+});
+
+test("a lease covers only the message it was taken for", () => {
+  const { storage } = storageFake();
+  const first = createAutoContinueTab({ storage });
+  const second = createAutoContinueTab({ storage });
+  const now = 1_000;
+
+  assert.equal(first.claim("m1", { now }), true);
+  // The next round of the same turn is a different message and is nobody's yet.
+  assert.equal(second.claim("m2", { now }), true);
+});
+
+test("two tabs writing in the same tick leave exactly one winner", () => {
+  // The window the free check alone cannot close: both tabs read the slot free, so both
+  // write, and the write that lands second is the one still in storage. The other tab
+  // reads its own token back, does not find it, and stands down. Written here as a tab
+  // whose record appears between this one's write and its read-back.
+  const now = 1_000;
+  let interleave = true;
+  const { storage } = storageFake((store) => {
+    if (!interleave) {
+      return;
+    }
+    interleave = false;
+    store.set(
+      AUTO_CONTINUE_LEASE_KEY,
+      JSON.stringify({
+        m1: { token: "other-tab", expires: now + AUTO_CONTINUE_LEASE_TTL_MS },
+      }),
+    );
+  });
+  const first = createAutoContinueTab({ storage });
+
+  assert.equal(first.claim("m1", { now }), false);
+  // Nothing recorded locally either, so once that lease lapses this tab can take over.
+  assert.equal(
+    first.claim("m1", { now: now + AUTO_CONTINUE_LEASE_TTL_MS + 1 }),
+    true,
+  );
+});
+
+test("a tab with no storage keeps the claim it always had", () => {
+  // Private mode, an embedded webview, or the test runner: no seam to share. Falling back
+  // to module scope is what shipped before the lease, and it must never refuse a
+  // continuation the single tab in front of the user is waiting for.
+  const only = createAutoContinueTab({ storage: null });
+  assert.equal(only.claim("m1"), true);
+  assert.equal(only.claim("m1"), false);
+  assert.equal(only.claimed("m1"), true);
+});
+
+test("storage that throws is no worse than no storage", () => {
+  // A quota-exceeded write, or a getItem that throws before it returns anything.
+  const angry = {
+    getItem(): string | null {
+      throw new Error("SecurityError");
+    },
+    setItem(): void {
+      throw new Error("QuotaExceededError");
+    },
+    removeItem(): void {
+      throw new Error("SecurityError");
+    },
+  };
+  const tab = createAutoContinueTab({ storage: angry });
+  assert.equal(tab.claim("m1"), true);
+  assert.equal(tab.claim("m1"), false);
+  // A second tab cannot see through a broken seam either, so it behaves as it did before
+  // the lease: module-only. Duplicates are not made worse, and nothing crashes.
+  assert.equal(createAutoContinueTab({ storage: angry }).claim("m1"), true);
+});
+
+test("a lease lapses, so a tab that died mid-run does not wedge the message", () => {
+  const { storage } = storageFake();
+  const winner = createAutoContinueTab({ storage });
+  const later = createAutoContinueTab({ storage });
+  const start = 1_000;
+
+  assert.equal(winner.claim("m1", { now: start }), true);
+  // Still inside the lease: the run is presumed live and nobody else touches it.
+  assert.equal(
+    later.claim("m1", { now: start + AUTO_CONTINUE_LEASE_TTL_MS - 1 }),
+    false,
+  );
+  // Past it: a permanent flag would have left this message unresumable for the life of
+  // the profile, because the tab that owned it is gone and can never clear it.
+  assert.equal(
+    later.claim("m1", { now: start + AUTO_CONTINUE_LEASE_TTL_MS + 1 }),
+    true,
+  );
+});
+
+test("lapsed leases are pruned rather than accumulating", () => {
+  const { storage, store } = storageFake();
+  const tab = createAutoContinueTab({ storage });
+  const start = 1_000;
+
+  tab.claim("m1", { now: start });
+  createAutoContinueTab({ storage }).claim("m2", {
+    now: start + AUTO_CONTINUE_LEASE_TTL_MS + 1,
+  });
+  const leases = JSON.parse(store.get(AUTO_CONTINUE_LEASE_KEY) ?? "{}");
+  assert.deepEqual(Object.keys(leases), ["m2"]);
+});
+
+test("reloading one tab does not fire a second continuation", () => {
+  // What stops this today is branch selection: the continuation runs as a sibling and
+  // becomes the selected branch, so the truncated reply is no longer last and the effect
+  // never asks. The lease is the belt to that pair of braces -- a reload lands on the
+  // truncated branch, its module scope is empty, and storage is the only thing that
+  // remembers. Nothing here changes what selection already refuses.
+  const { storage } = storageFake();
+  const before = createAutoContinueTab({ storage });
+  const start = 1_000;
+  assert.equal(before.claim("m1", { now: start }), true);
+
+  // The reload: same tab, same profile, brand new module scope.
+  const after = createAutoContinueTab({ storage });
+  assert.equal(after.claim("m1", { now: start + 5_000 }), false);
+  assert.equal(after.claimed("m1", { now: start + 5_000 }), true);
+});
+
+test("a reset gives back this tab's lease and leaves other tabs alone", () => {
+  const { storage } = storageFake();
+  const mine = createAutoContinueTab({ storage });
+  const theirs = createAutoContinueTab({ storage });
+  const now = 1_000;
+
+  assert.equal(mine.claim("m1", { now }), true);
+  mine.reset();
+  // Cleared in both places, so "start from zero" means what it did before the lease.
+  assert.equal(mine.claim("m1", { now }), true);
+
+  assert.equal(theirs.claim("m2", { now }), true);
+  mine.reset();
+  // Not mine to release: a run another tab is driving is still going.
+  assert.equal(createAutoContinueTab({ storage }).claim("m2", { now }), false);
+});
+
+test("a stored lease survives a full reset by the module, being another tab's", () => {
+  // `resetAutoContinue()` clears the module claim and the round budget. It cannot know
+  // about a lease it never wrote, and must not stamp on one.
+  const { storage, store } = storageFake();
+  createAutoContinueTab({ storage }).claim("m1", { now: 1_000 });
+  resetAutoContinue();
+  assert.equal(
+    createAutoContinueTab({ storage }).claim("m1", { now: 1_000 }),
+    false,
+  );
+  assert.equal(store.has(AUTO_CONTINUE_LEASE_KEY), true);
+});
+
+test("a malformed lease record is ignored rather than blocking", () => {
+  const { storage, store } = storageFake();
+  store.set(AUTO_CONTINUE_LEASE_KEY, "not json at all");
+  assert.equal(createAutoContinueTab({ storage }).claim("m1"), true);
+
+  const { storage: other, store: otherStore } = storageFake();
+  otherStore.set(AUTO_CONTINUE_LEASE_KEY, JSON.stringify({ m1: { token: 7 } }));
+  assert.equal(createAutoContinueTab({ storage: other }).claim("m1"), true);
 });

--- a/studio/frontend/tests/chat-continuation.test.ts
+++ b/studio/frontend/tests/chat-continuation.test.ts
@@ -1437,3 +1437,257 @@ test("a claim whose run was never issued is left to lapse, not held", async () =
     "a deadline here is the arming timeout coming back, which lapses live continuations",
   );
 });
+
+test("a losing claim does not follow the row onto the next branch", () => {
+  // The bar's "another tab has this one" answer is state, because the claim resolves after
+  // the render that asked for it. A bare boolean is wrong state to keep it in: rows are
+  // mounted by INDEX, so selecting a different truncated branch at the same index
+  // re-renders this component rather than remounting it, and the flag set for the message
+  // that lost carried over onto a message nobody has claimed at all -- no automatic
+  // continuation for it, for as long as that row lives.
+  const rows = readFileSync(
+    new URL(
+      "../src/components/assistant-ui/progressive-messages.tsx",
+      import.meta.url,
+    ),
+    "utf8",
+  );
+  assert.match(
+    rows,
+    /<MessageByIndexProvider key=\{index\}/,
+    "rows are no longer keyed by index; this test needs rewriting",
+  );
+
+  const thread = readFileSync(
+    new URL("../src/components/assistant-ui/thread.tsx", import.meta.url),
+    "utf8",
+  );
+  const start = thread.indexOf("const ContinueMessageBarForLastMessage");
+  assert.notEqual(start, -1, "the bar moved; this test needs rewriting");
+  const component = thread.slice(
+    start,
+    thread.indexOf("const WebSearchToolUIConfirmable", start),
+  );
+  const state =
+    /const \[(\w+), (set\w+)\] = useState<string \| null>\(null\)/.exec(
+      component,
+    );
+  assert.ok(
+    state,
+    "the losing answer is still a bare flag, so it outlives the message it was decided for",
+  );
+  assert.match(
+    component,
+    new RegExp(`claimHeldElsewhere =\\s*${state[1]} === messageId`),
+    "the flag has to be re-answered against the message on screen now",
+  );
+  assert.match(
+    component,
+    new RegExp(`${state[2]}\\(messageId\\)`),
+    "the message that lost is what gets remembered",
+  );
+});
+
+test("a claim taken for a run that was never issued is given back", async () => {
+  // The `stillThere` guard leaves the run unstarted, and the claim it took stays in this
+  // tab's continued set: every later claim of that message answers "skipped", so the
+  // automatic continuation never runs again for a request nobody ever made.
+  const { storage } = storageFake();
+  const locks = lockManagerFake();
+  const tab = createAutoContinueTab({ storage, locks });
+  const otherTab = createAutoContinueTab({ storage, locks });
+  const start = 1_000;
+
+  assert.equal(
+    await tab.claim("m1", { now: start, holder: "thread-A" }),
+    "started",
+  );
+  // The branch changed inside the lock's window, so nothing was issued. Roll it back.
+  tab.forget("m1");
+  // The storage lease is deliberately kept: this tab may still be deciding, and handing
+  // the message over now is how two tabs pay for the same continuation.
+  assert.equal(
+    await otherTab.claim("m1", { now: start + 1 }),
+    "held-elsewhere",
+    "the rollback must not hand the message to a second tab",
+  );
+  // Once that lease lapses -- the same record a tab that closed mid-claim leaves behind --
+  // the message is continuable again.
+  assert.equal(
+    await tab.claim("m1", {
+      now: start + AUTO_CONTINUE_LEASE_TTL_MS + 1,
+      holder: "thread-A",
+    }),
+    "started",
+    "a claim that started nothing may not wedge the message for the life of the tab",
+  );
+});
+
+test("the bar rolls its claim back when it issues no run", () => {
+  // The behaviour above, pinned where it has to be called from: the early return that
+  // decided no run would be issued.
+  const thread = readFileSync(
+    new URL("../src/components/assistant-ui/thread.tsx", import.meta.url),
+    "utf8",
+  );
+  const claimed = thread.indexOf(
+    'claimAutoContinue(messageId, runThreadId ?? "")',
+  );
+  assert.notEqual(claimed, -1, "the claim moved; this test needs rewriting");
+  const branch = thread.slice(
+    claimed,
+    thread.indexOf("held-elsewhere", claimed),
+  );
+  const guard = branch.search(/messages\.some\(/);
+  const hold = branch.indexOf("holdAutoContinueRun(");
+  const between = branch.slice(guard, hold);
+  assert.match(
+    between,
+    /forgetAutoContinue\(messageId\)/,
+    "the claim survives a run that was never issued, and skips every later one",
+  );
+});
+
+test("a hold is settled when its run fails before it ever starts", async () => {
+  // A preflight failure -- this chat's settings pairing running out, a model that will not
+  // load, a connection the adapter refuses -- throws out of `adapter.run` before anything
+  // reaches `setThreadRunning(..., true)`, so no `runningByThreadId` transition can ever
+  // identify this run as terminal. Without a signal the hold renews its cross-tab lease
+  // every 30 seconds for the life of the tab, one leaked hold per failure.
+  const { storage } = storageFake();
+  const locks = lockManagerFake();
+  const tab = createAutoContinueTab({ storage, locks });
+  const otherTab = createAutoContinueTab({ storage, locks });
+  const running = new Set<string>();
+  const runs = runSignalFake(running);
+  const pending: Promise<unknown>[] = [];
+  const start = 1_000;
+  let clock = start;
+  const keeper = createAutoContinueLeaseKeeper({
+    signal: runs.signal,
+    renew: (messageId: string, holder: string, now: number) => {
+      pending.push(tab.renew(messageId, holder, { now }));
+    },
+    release: () => {
+      assert.fail(
+        "a run that never started wrote nothing, so nothing may be marked continued",
+      );
+    },
+    now: () => clock,
+  });
+
+  assert.equal(
+    await tab.claim("m1", { now: start, holder: "thread-A" }),
+    "started",
+  );
+  keeper.hold("m1", "thread-A");
+  clock = start + AUTO_CONTINUE_LEASE_RENEW_MS;
+  keeper.tick();
+  assert.equal(keeper.held(), 1, "a slow preflight is still a live hold");
+
+  // The adapter threw. This is the run's own thread saying so.
+  keeper.failed("thread-A");
+  assert.equal(
+    keeper.held(),
+    0,
+    "nothing renews a run that failed on its way out",
+  );
+
+  const lapsed = clock + AUTO_CONTINUE_LEASE_TTL_MS + 1;
+  clock = lapsed;
+  keeper.tick();
+  await Promise.all(pending);
+  assert.equal(
+    await otherTab.claim("m1", { now: lapsed }),
+    "started",
+    "the lease lapses, so another tab can recover a message that was never continued",
+  );
+});
+
+test("a failure on a thread leaves a hold whose run is already streaming alone", async () => {
+  // The same event fires for a failure mid-stream, where the run DID reach
+  // `runningByThreadId` and the transition to idle is what settles the hold -- with the
+  // `done` marker that says the message has been continued, which a preflight failure has
+  // no right to write.
+  const { storage } = storageFake();
+  const locks = lockManagerFake();
+  const tab = createAutoContinueTab({ storage, locks });
+  const running = new Set<string>();
+  const runs = runSignalFake(running);
+  const released: string[] = [];
+  const pending: Promise<unknown>[] = [];
+  const start = 1_000;
+  let clock = start;
+  const keeper = createAutoContinueLeaseKeeper({
+    signal: runs.signal,
+    renew: (messageId: string, holder: string, now: number) => {
+      pending.push(tab.renew(messageId, holder, { now }));
+    },
+    release: (messageId: string, holder: string, now: number) => {
+      released.push(messageId);
+      pending.push(tab.release(messageId, holder, { now }));
+    },
+    now: () => clock,
+  });
+
+  await tab.claim("m1", { now: start, holder: "thread-A" });
+  keeper.hold("m1", "thread-A");
+  running.add("thread-A");
+  runs.change();
+  clock = start + AUTO_CONTINUE_LEASE_RENEW_MS;
+  keeper.tick();
+
+  // The run failed after it had started streaming. Its hold is armed, and armed holds are
+  // settled by their own thread going idle, not here.
+  keeper.failed("thread-A");
+  assert.equal(keeper.held(), 1, "an armed hold is its run's to give back");
+  assert.deepEqual(released, []);
+  running.delete("thread-A");
+  runs.change();
+  await Promise.all(pending);
+  assert.deepEqual(
+    released,
+    ["m1"],
+    "and the thread going idle is what gives it back",
+  );
+  assert.equal(keeper.held(), 0);
+});
+
+test("the keeper is wired to the failure the adapter already reports", () => {
+  // There is exactly one signal for a run that failed on its way out, and it is not a
+  // deadline: the adapter wrapper catches everything `adapter.run` throws and announces it
+  // per thread. Pinned at both ends, since neither side is exercised by a unit test.
+  const adapter = readFileSync(
+    new URL("../src/features/chat/api/chat-adapter.ts", import.meta.url),
+    "utf8",
+  );
+  const wrapper = adapter.slice(adapter.indexOf("yield* adapter.run(args)"));
+  assert.match(
+    wrapper,
+    /catch \(error\) \{[\s\S]*notifyPromptQueueRunFailed\(/,
+    "the adapter no longer reports a failed run per thread; this test needs rewriting",
+  );
+
+  const wiring = readFileSync(
+    new URL(
+      "../src/features/chat/utils/auto-continue-run-keeper.ts",
+      import.meta.url,
+    ),
+    "utf8",
+  );
+  assert.match(
+    wiring,
+    /PROMPT_QUEUE_RUN_FAILED_EVENT/,
+    "nothing settles a hold whose run failed before it started",
+  );
+  assert.match(
+    wiring,
+    /keeper\.failed\(/,
+    "the failure has to reach the keeper",
+  );
+  assert.doesNotMatch(
+    wiring,
+    /setTimeout\(/,
+    "a deadline here is the arming timeout coming back, which lapses live continuations",
+  );
+});

--- a/studio/frontend/tests/chat-continuation.test.ts
+++ b/studio/frontend/tests/chat-continuation.test.ts
@@ -9,12 +9,14 @@ import { registerBundlerResolver } from "./helpers/kit.ts";
 registerBundlerResolver();
 
 const {
+  AUTO_CONTINUE_ARM_TIMEOUT_MS,
   AUTO_CONTINUE_LEASE_KEY,
   AUTO_CONTINUE_LEASE_RENEW_MS,
   AUTO_CONTINUE_LEASE_SETTLE_MS,
   AUTO_CONTINUE_LEASE_TTL_MS,
   AUTO_CONTINUE_LIMIT,
   autoContinueCount,
+  createAutoContinueLeaseKeeper,
   createAutoContinueTab,
   budgetImpliesTruncation,
   incompleteLabel,
@@ -921,6 +923,170 @@ test("the next round keeps its lease with a lock manager in the way", async () =
   // And with one, because the effect ordering is not guaranteed in our favour there
   // either -- the fix must not depend on which path ran.
   await sequentialRounds(lockManagerFake());
+});
+
+/**
+ * The per-thread run signal the keeper reads, with no notion of what is on screen.
+ *
+ * Selection is deliberately absent: it is not an input to a lease's lifetime, and the whole
+ * point of the case below is that changing it changes nothing.
+ */
+function runSignalFake(running: Set<string>) {
+  const listeners = new Set<() => void>();
+  return {
+    signal: {
+      isRunning: (threadId: string) => running.has(threadId),
+      subscribe: (onChange: () => void) => {
+        listeners.add(onChange);
+        return () => listeners.delete(onChange);
+      },
+    },
+    /** The store told everyone something changed. */
+    change: () => {
+      for (const listener of [...listeners]) {
+        listener();
+      }
+    },
+  };
+}
+
+test("a run on a background thread keeps its lease while the user reads another chat", async () => {
+  // Switching chats does not stop a generation: the chat view is keyed by project, so the
+  // provider is not remounted and the run keeps streaming on the thread the user left. A
+  // lease whose lifetime was read off the SELECTED thread was released the moment they
+  // looked away, and one settle window later a second tab could claim a message that was
+  // still being written.
+  const { storage } = storageFake();
+  const locks = lockManagerFake();
+  const tab = createAutoContinueTab({ storage, locks });
+  const otherTab = createAutoContinueTab({ storage, locks });
+  const start = 1_000;
+  let clock = start;
+  const pending: Promise<void>[] = [];
+
+  // Thread A is generating; thread B, which the user is about to open, is idle.
+  const running = new Set<string>();
+  const runs = runSignalFake(running);
+  const keeper = createAutoContinueLeaseKeeper({
+    signal: runs.signal,
+    renew: (messageId, holder, now) => {
+      pending.push(tab.renew(messageId, holder, { now }));
+    },
+    release: (messageId, holder, now) => {
+      pending.push(tab.release(messageId, holder, { now }));
+    },
+    now: () => clock,
+  });
+
+  assert.equal(
+    startedARun(await tab.claim("a-m1", { now: start, holder: "thread-A" })),
+    true,
+  );
+  keeper.hold("a-m1", "thread-A");
+  // The continuation starts on thread A.
+  running.add("thread-A");
+  runs.change();
+
+  // The user opens idle thread B. Nothing about thread A changed, so nothing here does.
+  for (let tick = 1; tick <= 5; tick += 1) {
+    clock = start + tick * AUTO_CONTINUE_LEASE_RENEW_MS;
+    keeper.tick();
+  }
+  await Promise.all(pending);
+
+  const past =
+    start + AUTO_CONTINUE_LEASE_TTL_MS + AUTO_CONTINUE_LEASE_RENEW_MS;
+  assert.equal(
+    await otherTab.claim("a-m1", { now: past }),
+    "held-elsewhere",
+    "the background run keeps the message it is still writing",
+  );
+
+  // Thread A's own run ends. That, and only that, gives the lease back.
+  clock = past;
+  running.delete("thread-A");
+  runs.change();
+  await Promise.all(pending);
+  assert.equal(
+    await otherTab.claim("a-m1", {
+      now: past + AUTO_CONTINUE_LEASE_SETTLE_MS + 1,
+    }),
+    "started",
+  );
+  assert.equal(keeper.held(), 0);
+});
+
+test("a hold waits for its own run, not the one already in flight", async () => {
+  // The next round is claimed while the finished one is still winding down, so a hold that
+  // armed on "the thread is busy" would arm on its predecessor's run and be released the
+  // moment THAT one ended, mid-stream.
+  const { storage } = storageFake();
+  const tab = createAutoContinueTab({ storage, locks: null });
+  const otherTab = createAutoContinueTab({ storage, locks: null });
+  const start = 1_000;
+  let clock = start;
+  const pending: Promise<void>[] = [];
+  const running = new Set<string>(["thread-A"]);
+  const runs = runSignalFake(running);
+  const keeper = createAutoContinueLeaseKeeper({
+    signal: runs.signal,
+    renew: (messageId, holder, now) => {
+      pending.push(tab.renew(messageId, holder, { now }));
+    },
+    release: (messageId, holder, now) => {
+      pending.push(tab.release(messageId, holder, { now }));
+    },
+    now: () => clock,
+  });
+
+  await tab.claim("round-2", { now: start, holder: "thread-A" });
+  keeper.hold("round-2", "thread-A");
+
+  // The previous round ends, and the next one starts.
+  running.delete("thread-A");
+  runs.change();
+  running.add("thread-A");
+  runs.change();
+  for (let tick = 1; tick <= 5; tick += 1) {
+    clock = start + tick * AUTO_CONTINUE_LEASE_RENEW_MS;
+    keeper.tick();
+  }
+  await Promise.all(pending);
+  const past =
+    start + AUTO_CONTINUE_LEASE_TTL_MS + AUTO_CONTINUE_LEASE_RENEW_MS;
+  assert.equal(await otherTab.claim("round-2", { now: past }), "held-elsewhere");
+});
+
+test("a hold whose run never appears is forgotten, and its lease simply lapses", async () => {
+  const { storage } = storageFake();
+  const tab = createAutoContinueTab({ storage, locks: null });
+  const otherTab = createAutoContinueTab({ storage, locks: null });
+  const start = 1_000;
+  let clock = start;
+  const runs = runSignalFake(new Set<string>());
+  const keeper = createAutoContinueLeaseKeeper({
+    signal: runs.signal,
+    renew: () => undefined,
+    release: () => {
+      assert.fail("a hold that never armed has nothing to give back");
+    },
+    now: () => clock,
+  });
+
+  await tab.claim("a-m1", { now: start, holder: "thread-A" });
+  keeper.hold("a-m1", "thread-A");
+  clock = start + AUTO_CONTINUE_ARM_TIMEOUT_MS + 1;
+  keeper.tick();
+  assert.equal(keeper.held(), 0);
+  // Untouched, so it runs out the TTL, exactly as a tab that closed mid-claim leaves it.
+  assert.equal(
+    await otherTab.claim("a-m1", { now: start + AUTO_CONTINUE_LEASE_TTL_MS - 1 }),
+    "held-elsewhere",
+  );
+  assert.equal(
+    await otherTab.claim("a-m1", { now: start + AUTO_CONTINUE_LEASE_TTL_MS + 1 }),
+    "started",
+  );
 });
 
 test("one compare pane finishing does not release the other pane's lease", async () => {

--- a/tests/studio/playwright_loaded_models_indicator.py
+++ b/tests/studio/playwright_loaded_models_indicator.py
@@ -39,6 +39,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 from _playwright_robust import (  # noqa: E402
     chromium_launch_args,
     install_view_transition_killer,
+    install_wall_clock_watchdog,
     wait_for_health,
 )
 
@@ -50,6 +51,15 @@ ART.mkdir(parents = True, exist_ok = True)
 
 PLAYWRIGHT_BROWSER = os.environ.get("STUDIO_PLAYWRIGHT_BROWSER", "chromium").lower()
 PLAYWRIGHT_CHANNEL = os.environ.get("STUDIO_PLAYWRIGHT_CHANNEL") or None
+
+# The wall this suite did not have. Its siblings (playwright_chat_ui.py,
+# playwright_extra_ui.py) have carried one since a `page.evaluate` -- which
+# takes no `timeout=` at all -- hung a job for 27 minutes in #5387. This suite
+# has four raw `page.evaluate` calls of its own and is the LAST thing the
+# Windows chat lane runs, so a wedge here used to be indistinguishable from the
+# job simply never finishing. Same 720s default and same env knob as the
+# siblings, so a slow runner is tuned in one place.
+WALL_TIMEOUT_S = float(os.environ.get("STUDIO_UI_WALL_TIMEOUT_S", "720"))
 
 # The card polls every 5s; two ticks plus slack is enough to see a change land.
 SETTLE_MS = int(os.environ.get("STUDIO_UI_INDICATOR_SETTLE_MS", "12000"))
@@ -290,6 +300,11 @@ def main() -> int:
         return 1
 
     with sync_playwright() as p:
+        install_wall_clock_watchdog(
+            WALL_TIMEOUT_S,
+            label = "ui-indicator",
+            info = info,
+        )
         browser_type = getattr(p, PLAYWRIGHT_BROWSER)
         launch_kwargs: dict = {"headless": True}
         if PLAYWRIGHT_BROWSER == "chromium":

--- a/tests/studio/playwright_update_banner_layout.py
+++ b/tests/studio/playwright_update_banner_layout.py
@@ -35,8 +35,15 @@ from playwright.sync_api import sync_playwright
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from _playwright_robust import (  # noqa: E402
     chromium_launch_args,
+    install_wall_clock_watchdog,
     wait_for_health,
 )
+
+# The wall this suite did not have, matching playwright_chat_ui.py and
+# playwright_extra_ui.py. It has six raw `page.evaluate` calls, which take no
+# `timeout=` at all, and it runs mid-lane on Windows sharing a server with the
+# suite before it -- so a wedge here stalled the lane with nothing printed.
+WALL_TIMEOUT_S = float(os.environ.get("STUDIO_UI_WALL_TIMEOUT_S", "720"))
 
 BASE = os.environ["BASE_URL"]
 OLD = os.environ["STUDIO_OLD_PW"]
@@ -744,6 +751,11 @@ def main() -> int:
         return 1
 
     with sync_playwright() as p:
+        install_wall_clock_watchdog(
+            WALL_TIMEOUT_S,
+            label = "ui-update-banner",
+            info = info,
+        )
         launch_kwargs: dict = {"headless": True}
         if PLAYWRIGHT_BROWSER == "chromium":
             launch_kwargs["args"] = chromium_launch_args()


### PR DESCRIPTION
Follow-up to the automatic Max Tokens continuation. The claim that stops a truncated reply being resumed twice is module state, so it only covers one tab.

### The scenario

1. A reply hits Max Tokens and is saved with `reason: "length"`.
2. The same thread is open in two browser tabs, both with that reply as the last message on the selected branch.
3. Each tab loads its own copy of `continuation.ts`, so each has its own empty `continued` set. `claimAutoContinue(messageId)` returns true in both.
4. Both tabs call `startContinuation()`. Two sibling branches, two provider requests, and the user pays for both.

The effect is not tied to the end of a stream, which is what makes the second tab enough on its own. Its own comment records the earlier version of this: leaving the chat with a truncated branch selected and coming back fired it again. A second tab is that same fresh mount, with a claim set that has never seen the message.

### The mechanism

The claim is decided under a Web Lock (`navigator.locks`) and recorded as a lease in `localStorage` under `unsloth_chat_auto_continue_leases`, one record per claimed message id holding a random token and an expiry.

Both halves are needed and neither is enough alone. localStorage is the durable half: it survives the lock being released, the tab being closed, and a reload, which is what a second tab arriving later has to be able to see. The lock is the exclusive half: read, decide and write happen inside one held lock, so no other tab can be between them. localStorage cannot do that part -- its individual operations are atomic, but a read-modify-write across statements is not, and the storage mutex that once serialized such sequences was dropped from the spec. A write-then-read-back narrows that window; it does not close it, because two tabs can both read free, both write, and each verify the token it just wrote.

The read-back is kept anyway, as the only defence left where there is no lock manager.

### TTL: 3 minutes, renewed while the run is live

The lease is not a guess at how long a continuation takes. The holder renews it every 30 seconds for as long as the thread is running, and gives it back when the run reaches a terminal state, so the TTL measures one thing only: how long a tab that stopped renewing is still believed to be alive. Without renewal a local model on a large Max Tokens can out-generate any fixed TTL and have its message taken mid-stream.

Three minutes because renewals are timers and a hidden tab is throttled to roughly one timer callback a minute in Chrome, so a backgrounded winner gets about three chances to check in before anyone else may touch its message, while a tab that really died gives the message back inside a pause the user notices anyway. The manual Continue button is never gated on any of this, so the way out is always open.

The keeper lives at thread level rather than on the bar that took the lease: the continuation runs as a sibling and becomes the selected branch, so the truncated message unmounts almost immediately and a timer living there would die with it, mid-stream.

Renewal and release name one message and one thread. The thread is what keeps compare mode's two panes apart, since it mounts a runtime per pane, and it is what keeps one round of a turn apart from the next, because a round that hits Max Tokens again is claimed before the finished one is given back. Anything operating on "every lease this holder owns" settled a round that had only just started.

The lifetime of a lease is the lifetime of its run, and nothing else. It is read from `runningByThreadId`, which is per thread and indifferent to which chat is on screen: opening another saved chat does not stop a generation, because the chat view is keyed by project and the provider is not remounted, so a lease whose lifetime came from the selected thread's `isRunning` was released the moment the user looked away. The same store field is what the prompt queue already uses for completion detection, for the same stated reason, that it tracks the actual thread and so survives navigation.

The keeper that holds this lives outside React (`auto-continue-run-keeper.ts` wires it to the store; the logic itself is in `continuation.ts` and knows nothing about the app). A hold is one message on one thread; it arms on a run that starts after the hold was taken, renews while that thread generates, and is given back when that thread stops. Selection, mounting and effect ordering are not inputs to any of it. A thread with no remote id yet, the first turn of a New Chat, files its run under a shared placeholder that is not safe to watch, so nothing is held for it and its lease runs out its TTL, which is the same outcome as a tab closing mid-run and is never an early release.

`resetAutoContinue()` stays wholesale on purpose: a run ending is one run speaking for itself, while a reset is the whole tab being told it holds nothing, and nothing in the run lifecycle calls it. The only other operation that spans messages is pruning lapsed records on write, which removes nothing that was not already free by its own expiry and is what bounds the size of a key every tab shares.

A released lease is cut back to a 30 second settle window rather than deleted. A tab still showing the pre-continuation branch has not seen the sibling that was just written and, handed the message back instantly, would start the duplicate this whole change exists to stop.

### What the losing tab shows

`autoContinuing` is computed from `shouldAutoContinueMessage`, which is a synchronous read and cannot see a race the lock decides later, so both tabs can render the "Continuing automatically" spinner before either claim resolves. The claim therefore reports which of the two ways it did not start a run: `held-elsewhere` is another tab, and feeds React state that puts this tab's manual Continue button back; `skipped` is this tab's own duplicate call, a `<StrictMode>` replay or a claim already in flight, where the run is coming and nothing on screen should move. A single bare false for both left the loser holding a spinner for a run it never started, with the Continue button hidden behind it.

### Residual race

With `navigator.locks` the read-decide-write is exclusive across same-origin tabs in one profile, so two tabs cannot both come out of it as winners. What is left:

- Browsers with no lock manager, or one that rejects the request, fall back to write-then-read-back. That is strictly better than a bare check-then-act and strictly worse than a lock: the interleaving where both tabs read free, both write and each verifies before the other's write can still produce two winners. Web Locks is in current Chromium, Firefox and Safari, so this is the old-webview case.
- Two different browsers, two profiles, a private window beside a normal one, or two devices share neither storage nor locks, so nothing can coordinate them at all.
- A tab killed between taking the lease and starting the run blocks its own message until the lease lapses. That is a delay of at most one TTL, not a duplicate.
- The free check before the lock is an optimisation that can only ever refuse; a stale "free" reading of it is re-checked inside the lock.

### Degradation

No `window`, no `localStorage`, a `localStorage` property access that throws (Safari private mode), a quota-exceeded write, an unparseable value, no `navigator.locks`, or a lock request that rejects: every path falls back to the module-only claim that shipped before. The fallback is never a refusal, so a single tab with no working storage still continues exactly as it does today.

### Single-tab reload

What stops a reload double-firing today is branch selection, not the claim: the continuation runs as a sibling and becomes the selected branch, so the truncated reply is no longer last and the effect never asks. That is untouched. The lease only adds refusals on top of it, and a reload that does land back on a truncated reply within the window is now refused instead of firing a second run.

### BroadcastChannel, and why not

A channel carries no state. It does not replay, so the second tab, which by construction opens after the first has already claimed, hears nothing and would need a request/response handshake with a timeout, guessing how long to wait for silence to mean "nobody is running this". It also dies with its tab, so it cannot express "someone is running this, and here is when to stop believing that", and it is not exclusive: two tabs that broadcast at the same instant both hear the other only after they have already decided. The lock decides, the lease remembers, and the codebase already has the replay note in `rag-api.ts` for the same reason.

### Tests

Appended to `studio/frontend/tests/chat-continuation.test.ts`, in the same `node:test` style as the rest of the file. The tab is now constructible (`createAutoContinueTab`), because a second instance over one shared store and one shared lock manager is exactly what a second browser tab is, and it is the only way to write the case down. The storage fake can interleave another tab in the middle of a read-modify-write, at the read as well as at the write.

Covered: two tabs claiming at once, a tab claiming in full between another tab's read and its write, the loser being told it lost rather than just failing, renewal outliving the TTL, release and its settle window, two compare panes in one tab where the one that finishes first must leave the other's lease live and renewable, two sequential rounds of one turn where the next is claimed before the last is released (with and without a lock manager), a run left generating on a background thread while the user reads another chat, no lock manager, a lock request that rejects, no storage, storage that throws, lease expiry, pruning, a reload not double-firing, and reset releasing this tab's lease and nobody else's.

```
$ node --experimental-strip-types --test tests/chat-continuation.test.ts
ℹ tests 63
ℹ pass 63
ℹ fail 0
```

Full frontend suite (`npm test`): 4251 tests, 4251 pass, 0 fail. `npm run typecheck` clean.