### PR TITLE
Fix stale libappindicator3-dev guard blocking desktop releases

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -633,7 +633,11 @@ jobs:
 
           const workflow = readFileSync('.github/workflows/release-desktop.yml', 'utf8');
           const lines = workflow.split(/\r?\n/);
-          const linuxInstallLines = lines.filter((line) => line.includes('sudo apt-get install'));
+          // The needle is assembled rather than written as a literal: this file is
+          // what gets scanned, so a literal would match this very line and let a
+          // genuinely missing install slip through.
+          const aptInstallNeedle = ['apt-get', 'install'].join(' ');
+          const linuxInstallLines = lines.filter((line) => line.includes(aptInstallNeedle));
           const ayatanaPackage = ['libayatana', 'appindicator3-dev'].join('-');
           if (linuxInstallLines.some((line) => line.includes(ayatanaPackage))) {
             throw new Error('Desktop Linux release must not install the Ayatana appindicator dev package');


### PR DESCRIPTION
## Summary

The `v0.1.801-beta` desktop release ([run 32396441114](https://github.com/unslothai/unsloth/actions/runs/32396441114)) failed on all three platforms in `Verify desktop updater and Linux package config`, before any binary was built:

```
Error: Desktop Linux release must install libappindicator3-dev
```

The dependency is in fact installed. The guard is what is stale.

It collects candidate lines with:

```js
const linuxInstallLines = lines.filter((line) => line.includes('sudo apt-get install'));
```

but the install step no longer contains that literal. It runs through the apt-lock retry helper, so `sudo` and `apt-get` are separated:

```
bash .github/scripts/retry-with-apt-lock.sh sudo sh -c \
  'apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev ...'
```

No line in the workflow matches `sudo apt-get install` any more except the JavaScript line performing the search, which does not mention `libappindicator3-dev`, so the assertion always throws. The neighbouring Ayatana check already avoids this trap by assembling its needle with `join`; this one was written as a literal and drifted.

## Fix

Match on `apt-get install`, with the needle assembled rather than written as a literal so it cannot match its own source line and mask a genuinely missing install.

## Test plan

Extracted the verification block and ran it against a clean `v0.1.801-beta` checkout, which is what the release job checks out:

- Current guard against the tag: fails with the exact CI error.
- Fixed guard against the tag: exits 0, whole block passes.
- Fixed guard against `main`: exits 0.
- Negative test, `libappindicator3-dev` stripped from the install line: still fails with `Desktop Linux release must install libappindicator3-dev`, so the check has not been weakened into a no-op.

Nothing was published by the failed run. `Publish desktop release` refused with `refusing to publish, these build jobs did not succeed`, so the `v0.1.801-beta` release assets are untouched and the release can be re-dispatched once this lands.
