### PR TITLE
Fix desktop release dependency guard

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -633,7 +633,7 @@ jobs:
 
           const workflow = readFileSync('.github/workflows/release-desktop.yml', 'utf8');
           const lines = workflow.split(/\r?\n/);
-          const linuxInstallLines = lines.filter((line) => line.includes('sudo apt-get install'));
+          const linuxInstallLines = lines.filter((line) => line.includes('apt-get install'));
           const ayatanaPackage = ['libayatana', 'appindicator3-dev'].join('-');
           if (linuxInstallLines.some((line) => line.includes(ayatanaPackage))) {
             throw new Error('Desktop Linux release must not install the Ayatana appindicator dev package');


### PR DESCRIPTION
## Summary

- recognize retry-wrapped `apt-get install` commands in the desktop release validator
- keep enforcing the required `libappindicator3-dev` dependency without requiring `sudo` to directly prefix apt

## Why

The release workflow now invokes apt through the shared retry helper. The validator still searched only for `sudo apt-get install`, so every build platform failed before compilation even though the Linux dependency was installed successfully.

## Tests

- ran the exact `Verify desktop updater and Linux package config` workflow step locally
- `python3 -m pytest -q tests/security/test_release_desktop_appimage.py` (15 passed)
