### PR TITLE
Pass temperature through extra_body for anthropic 1.0.0

### DIFF
--- a/.github/scripts/studio_smoke/multi_turn_chat.py
+++ b/.github/scripts/studio_smoke/multi_turn_chat.py
@@ -125,9 +125,9 @@ def check(label: str, first: list[str], second: list[str]) -> None:
     # Lower-cased substring checks, so formatting jitter is not a failure.
     joined = " ".join(first).lower()
     assert "1" in first[0], f"{label}: turn-1 answer should contain '1', got {first[0]!r}"
-    assert (
-        "paris" in joined
-    ), f"{label}: expected 'paris' somewhere in the four-turn transcript: {first}"
+    assert "paris" in joined, (
+        f"{label}: expected 'paris' somewhere in the four-turn transcript: {first}"
+    )
     print(f"[{label}] OK -- 4 turns, run1 == run2, history grounded")
 
 

--- a/.github/scripts/studio_smoke/multi_turn_chat.py
+++ b/.github/scripts/studio_smoke/multi_turn_chat.py
@@ -89,8 +89,11 @@ def run_anthropic() -> list[str]:
             model = "default",
             max_tokens = MAX_TOKENS,
             messages = history,
-            temperature = 0.0,
-            extra_body = {"seed": SEED, "enable_thinking": False},
+            # temperature goes in extra_body, not the signature: anthropic 1.0.0
+            # dropped the sampling parameters from messages.create() and raises a
+            # TypeError on them. The wire format is unchanged, and this smoke needs
+            # the greedy setting to compare two runs for equality.
+            extra_body = {"temperature": 0.0, "seed": SEED, "enable_thinking": False},
         )
         text = "".join(b.text for b in msg.content if getattr(b, "type", None) == "text")
         replies.append(text)

--- a/.github/workflows/studio-inference-smoke.yml
+++ b/.github/workflows/studio-inference-smoke.yml
@@ -1180,8 +1180,9 @@ jobs:
           a_msg = anthropic.messages.create(
               model       = "default",
               max_tokens  = 80,
-              temperature = 0.0,
-              extra_body  = {"seed": SEED},
+              # anthropic 1.0.0 dropped the sampling parameters from the
+              # messages.create() signature. extra_body still reaches the wire.
+              extra_body  = {"temperature": 0.0, "seed": SEED},
               messages    = [{
                   "role": "user",
                   "content": [

--- a/.github/workflows/studio-mac-ui-smoke.yml
+++ b/.github/workflows/studio-mac-ui-smoke.yml
@@ -1543,8 +1543,9 @@ jobs:
               a_msg = anthropic.messages.create(
                   model       = "default",
                   max_tokens  = 80,
-                  temperature = TEMP,
-                  extra_body  = {"seed": SEED},
+                  # anthropic 1.0.0 dropped the sampling parameters from the
+                  # messages.create() signature. extra_body still reaches the wire.
+                  extra_body  = {"temperature": TEMP, "seed": SEED},
                   messages    = [{
                       "role": "user",
                       "content": [

--- a/.github/workflows/studio-windows-inference-smoke.yml
+++ b/.github/workflows/studio-windows-inference-smoke.yml
@@ -1297,8 +1297,9 @@ jobs:
               a_msg = anthropic.messages.create(
                   model       = "default",
                   max_tokens  = 80,
-                  temperature = TEMP,
-                  extra_body  = {"seed": SEED},
+                  # anthropic 1.0.0 dropped the sampling parameters from the
+                  # messages.create() signature. extra_body still reaches the wire.
+                  extra_body  = {"temperature": TEMP, "seed": SEED},
                   messages    = [{
                       "role": "user",
                       "content": [


### PR DESCRIPTION
`anthropic` 1.0.0 landed and removed the sampling parameters from `messages.create()`, so the multi-turn determinism smoke now dies before it sends a single Anthropic turn:

```
TypeError: Messages.create() got an unexpected keyword argument 'temperature'
```

The job installs the SDK unpinned, so this fails on every PR and on main. The OpenAI half of the same script is unaffected and still passes all four turns.

The parameter is only gone from the typed signature, not from the API. The SDK's own migration guide says to pass it through `extra_body`, which is merged into the request JSON as-is, so the wire format is unchanged and the smoke keeps the greedy setting it needs to compare two runs for equality.

The script already sent `seed` and `enable_thinking` that way, so this just moves `temperature` in beside them.

The same call appears three more times inline in the smoke workflows (`studio-inference-smoke.yml`, `studio-mac-ui-smoke.yml`, `studio-windows-inference-smoke.yml`), which is the `GGUF inference smoke (API, tools, vision)` failure. All three already passed `extra_body = {"seed": SEED}`, so `temperature` moves in beside it there too. The OpenAI `chat.completions.create` calls in the same scripts are untouched: `openai` 3.3.1 still takes `temperature` in the signature, and the OpenAI halves of these smokes pass.