### PR TITLE
CI: hold the Anthropic SDK below 1.0 in the inference smoke workflows

### DIFF
--- a/.github/workflows/studio-inference-smoke.yml
+++ b/.github/workflows/studio-inference-smoke.yml
@@ -194,7 +194,12 @@ jobs:
         id: sdks
         if: ${{ !cancelled() && steps.install.outcome == 'success' }}
         timeout-minutes: 10
-        run: pip install 'openai>=1.50' 'anthropic>=0.40'
+        # anthropic is held below 1.0: v1 removed temperature, top_p and top_k as
+        # accepted arguments on messages.create(), so the probes below, which pin
+        # temperature = 0.0 for determinism, raise TypeError against it. The v1 route
+        # is extra_body; moving to it is a deliberate change to what the probes send,
+        # not something a CI install should decide by resolving a new major.
+        run: pip install 'openai>=1.50' 'anthropic>=0.40,<1'
 
       # Phase 1's environment and model cache sit HERE, after the shared
       # preamble, not before it. They used to run before the installer, which is

--- a/.github/workflows/studio-mac-ui-smoke.yml
+++ b/.github/workflows/studio-mac-ui-smoke.yml
@@ -647,7 +647,12 @@ jobs:
         id: sdks-chat
         if: ${{ !cancelled() && steps.assert_llama.outcome == 'success' }}
         timeout-minutes: 5
-        run: pip install 'openai>=1.50' 'anthropic>=0.40'
+        # anthropic is held below 1.0: v1 removed temperature, top_p and top_k as
+        # accepted arguments on messages.create(), so the probes below, which pin
+        # temperature = 0.0 for determinism, raise TypeError against it. The v1 route
+        # is extra_body; moving to it is a deliberate change to what the probes send,
+        # not something a CI install should decide by resolving a new major.
+        run: pip install 'openai>=1.50' 'anthropic>=0.40,<1'
 
       - name: Reset auth + boot Unsloth (API-only)
         id: boot-chat
@@ -1275,7 +1280,12 @@ jobs:
         id: sdks-vision
         if: ${{ !cancelled() && steps.assert_llama.outcome == 'success' }}
         timeout-minutes: 5
-        run: pip install 'openai>=1.50' 'anthropic>=0.40'
+        # anthropic is held below 1.0: v1 removed temperature, top_p and top_k as
+        # accepted arguments on messages.create(), so the probes below, which pin
+        # temperature = 0.0 for determinism, raise TypeError against it. The v1 route
+        # is extra_body; moving to it is a deliberate change to what the probes send,
+        # not something a CI install should decide by resolving a new major.
+        run: pip install 'openai>=1.50' 'anthropic>=0.40,<1'
 
       - name: Reset auth + boot Unsloth (API-only)
         id: boot-vision

--- a/.github/workflows/studio-windows-inference-smoke.yml
+++ b/.github/workflows/studio-windows-inference-smoke.yml
@@ -295,7 +295,12 @@ jobs:
         id: sdks
         if: ${{ !cancelled() && steps.assert-prebuilt.outcome == 'success' }}
         timeout-minutes: 10
-        run: python -m pip install 'openai>=1.50' 'anthropic>=0.40'
+        # anthropic is held below 1.0: v1 removed temperature, top_p and top_k as
+        # accepted arguments on messages.create(), so the probes below, which pin
+        # temperature = 0.0 for determinism, raise TypeError against it. The v1 route
+        # is extra_body; moving to it is a deliberate change to what the probes send,
+        # not something a CI install should decide by resolving a new major.
+        run: python -m pip install 'openai>=1.50' 'anthropic>=0.40,<1'
 
       # Phase 1's environment and model cache sit HERE, after the shared
       # preamble, not before it. They used to run before the installer, which is

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -15487,9 +15487,7 @@ class LlamaCppBackend:
                 # explicit request counts at all: the estimator has always charged 0,
                 # and adopting llama.cpp's default of 32 would move the fit for every
                 # model.
-                _effective_ctx_checkpoints = resolve_ctx_checkpoints(
-                    extra_args, ctx_checkpoints
-                )
+                _effective_ctx_checkpoints = resolve_ctx_checkpoints(extra_args, ctx_checkpoints)
                 # --embedding forces n_batch = n_ubatch, which aborts a load below the slots.
                 if (
                     self.is_embedding_gguf
@@ -16209,9 +16207,7 @@ class LlamaCppBackend:
                     # The control underneath them: emitted before the extras, so an
                     # extra still last-wins and the reserve prices what will run.
                     _budget_draft_cache = (
-                        spec_draft_cache_type.strip().lower()
-                        if spec_draft_cache_type
-                        else None
+                        spec_draft_cache_type.strip().lower() if spec_draft_cache_type else None
                     )
                     if _budget_draft_cache in _VALID_KV_CACHE_TYPES:
                         _mtp_draft_ck = _mtp_draft_ck or _budget_draft_cache

--- a/studio/backend/core/inference/llama_server_args.py
+++ b/studio/backend/core/inference/llama_server_args.py
@@ -721,9 +721,7 @@ def parse_ctx_checkpoints_override(args: Optional[Iterable[str]]) -> Optional[in
     return max(0, parsed)
 
 
-def resolve_ctx_checkpoints(
-    args: Optional[Iterable[str]], requested: Optional[int]
-) -> int:
+def resolve_ctx_checkpoints(args: Optional[Iterable[str]], requested: Optional[int]) -> int:
     """The checkpoint count the launch will actually run: extras beat the field."""
     override = parse_ctx_checkpoints_override(args)
     return int(override if override is not None else (requested or 0))

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -1561,7 +1561,11 @@ def _openai_llama_admission_media_tokens(payload) -> int:
 
 
 def _openai_llama_admission_tokens(
-    payload, *, budget: Optional[int], capacity: int, tool_loop: bool = False
+    payload,
+    *,
+    budget: Optional[int],
+    capacity: int,
+    tool_loop: bool = False,
 ) -> Optional[int]:
     """KV a request will occupy: what is sent, plus what it may generate.
 

--- a/studio/backend/tests/test_llama_admission_kv_budget.py
+++ b/studio/backend/tests/test_llama_admission_kv_budget.py
@@ -474,6 +474,7 @@ class TestToolLoopsReserveTheirUpperBound:
         ``enable_tools``, ``mcp_enabled``, the CLI policy and a checkpoint repair,
         none of which carry a client catalogue."""
         from types import SimpleNamespace
+
         payload = SimpleNamespace(
             messages = [{"role": "user", "content": "hi"}],
             max_tokens = 16,
@@ -524,6 +525,7 @@ class TestToolLoopsReserveTheirUpperBound:
         """The passthrough and streaming /v1/responses run ONE generation per HTTP
         call; the client sends the next round itself, with its own reservation."""
         from types import SimpleNamespace
+
         payload = SimpleNamespace(
             messages = [{"role": "user", "content": "hi"}],
             max_tokens = 16,

--- a/studio/backend/tests/test_llama_admission_kv_budget_media_and_tools.py
+++ b/studio/backend/tests/test_llama_admission_kv_budget_media_and_tools.py
@@ -81,9 +81,7 @@ class TestMediaIsCharged:
                     capacity = 4,
                     config = config,
                     budget = 2048,
-                    tokens = _openai_llama_admission_tokens(
-                        payload, budget = 2048, capacity = 4
-                    ),
+                    tokens = _openai_llama_admission_tokens(payload, budget = 2048, capacity = 4),
                 )
                 leases.append(reservation.lease_nowait())
             return leases
@@ -116,10 +114,7 @@ class TestTheToolLoopReservesTheWholeCache:
         )
         assert getattr(payload, "tools", None) is None
         assert (
-            _openai_llama_admission_tokens(
-                payload, budget = 4096, capacity = 4, tool_loop = True
-            )
-            == 4096
+            _openai_llama_admission_tokens(payload, budget = 4096, capacity = 4, tool_loop = True) == 4096
         )
 
     def test_a_passthrough_forwarding_tools_is_charged_its_own_round(self):
@@ -149,7 +144,6 @@ class TestTheBudgetIsTheWholeCacheNotOneSlot:
 
     def test_the_partitioned_total_wins_over_one_slot(self):
         from routes.inference import _openai_llama_admission_budget
-
         backend = _Payload(context_length = 4096, _kv_cache_context_total = 16384)
         assert _openai_llama_admission_budget(backend) == 16384
 
@@ -169,5 +163,4 @@ class TestTheBudgetIsTheWholeCacheNotOneSlot:
 
     def test_a_backend_that_cannot_say_keeps_slot_only_admission(self):
         from routes.inference import _openai_llama_admission_budget
-
         assert _openai_llama_admission_budget(_Payload()) is None

--- a/studio/backend/tests/test_web_page_cap_fits_window.py
+++ b/studio/backend/tests/test_web_page_cap_fits_window.py
@@ -258,16 +258,19 @@ class TestADenseResultIsSizedByWhatItCosts:
     """
 
     # One paragraph of CJK prose with the wiki-style escaped links that come with it.
-    _CJK_PAGE = ("人工智能是一门研究如何使机器具备智能行为的学科，"
-                 "涵盖[机器学习](/wiki/%E6%9C%BA%E5%99%A8%E5%AD%A6%E4%B9%A0)、"
-                 "[语言处理](/wiki/%E8%87%AA%E7%84%B6%E8%AF%AD%E8%A8%80%E5%A4%84%E7%90%86)"
-                 "和[电脑视觉](/wiki/%E8%AE%A1%E7%AE%97%E6%9C%BA%E8%A7%86%E8%A7%89)。") * 200
-    _EN_PAGE = ("Artificial intelligence is the study of machines that perceive their "
-                "environment and take actions that maximise the chance of a goal. ") * 200
+    _CJK_PAGE = (
+        "人工智能是一门研究如何使机器具备智能行为的学科，"
+        "涵盖[机器学习](/wiki/%E6%9C%BA%E5%99%A8%E5%AD%A6%E4%B9%A0)、"
+        "[语言处理](/wiki/%E8%87%AA%E7%84%B6%E8%AF%AD%E8%A8%80%E5%A4%84%E7%90%86)"
+        "和[电脑视觉](/wiki/%E8%AE%A1%E7%AE%97%E6%9C%BA%E8%A7%86%E8%A7%89)。"
+    ) * 200
+    _EN_PAGE = (
+        "Artificial intelligence is the study of machines that perceive their "
+        "environment and take actions that maximise the chance of a goal. "
+    ) * 200
 
     def _dense_tokens(self, text):
         from core.inference.context_window import estimate_messages_tokens_dense
-
         return estimate_messages_tokens_dense([{"role": "tool", "content": text}])
 
     def test_a_cjk_page_is_cut_to_the_share_it_was_promised(self, monkeypatch):
@@ -314,7 +317,9 @@ class TestADenseResultIsSizedByWhatItCosts:
 
     def test_an_unknown_window_leaves_a_dense_page_alone(self):
         """Same rule as the char budget: not knowing must never shrink a fetch."""
-        assert tools._dense_char_limit(self._CJK_PAGE, tools._MAX_PAGE_CHARS) == tools._MAX_PAGE_CHARS
+        assert (
+            tools._dense_char_limit(self._CJK_PAGE, tools._MAX_PAGE_CHARS) == tools._MAX_PAGE_CHARS
+        )
 
     def test_a_dense_terminal_result_is_sized_too(self, monkeypatch):
         """The code tools print CJK and escaped URLs as readily as a page carries them."""

--- a/tests/studio/test_ui_scripts_report_signals.py
+++ b/tests/studio/test_ui_scripts_report_signals.py
@@ -85,9 +85,9 @@ def test_the_snapshot_does_not_print_command_lines(script: str) -> None:
     """
     body = _body(script)
     assert "pid,ppid,comm" in body, f"{script}'s process snapshot is not limited to names"
-    assert not re.search(r"ps\s+-o\s+[\w,]*args", body), (
-        f"{script} snapshots full command lines into a public log"
-    )
+    assert not re.search(
+        r"ps\s+-o\s+[\w,]*args", body
+    ), f"{script} snapshots full command lines into a public log"
 
 
 def test_the_guard_reads_real_files() -> None:


### PR DESCRIPTION
The inference smoke workflows install the Anthropic SDK as `anthropic>=0.40`, with no upper bound. `anthropic` published 1.0.0, the resolver picked it up, and the OpenAI + Anthropic determinism and image probes started failing on every PR that runs them.

## What breaks

```
TypeError: Messages.create() got an unexpected keyword argument 'temperature'
```

raised from the "Multi-turn determinism via OpenAI + Anthropic SDKs" and "JSON schema decoding + image input" steps.

## What actually changed

v1.0 removed `temperature`, `top_p` and `top_k` as accepted arguments on `messages.create()`. From the SDK's own [MIGRATION.md](https://github.com/anthropics/anthropic-sdk-python/blob/main/MIGRATION.md):

> `messages.create()`, `messages.stream()`, `messages.parse()` and their `beta.messages` counterparts ... `temperature`, `top_p`, `top_k` | Remove them.

and

> passing them is a `TypeError`, and a type checker flags it

The stated reason is that current models do not use these sampling parameters. The documented route for callers that still want them is `extra_body`, which is merged into the request JSON as-is.

The probes pass `temperature = 0.0` deliberately, for determinism, so they land exactly on this.

Worth noting the 1.0.0 CHANGELOG entry alone does not say this. It reads only "upgrade to httpx2 and some minor breaking changes. See MIGRATION.md for details", so the parameter removal is only visible in the migration guide.

## Evidence that this is the version and not the code

Same workflow, same step, same call site, different resolved SDK:

| run | resolved | result |
| --- | --- | --- |
| #9425 | `anthropic-0.125.0` | pass |
| #9423 | `anthropic-1.0.0` | fail |

It survived a re-run, so it is not a flake. Checking the signature directly on a 0.x install agrees:

```
installed anthropic: 0.122.0
  temperature: PRESENT
  top_p: PRESENT
  top_k: PRESENT
  extra_body: PRESENT
```

## The change

`'anthropic>=0.40'` becomes `'anthropic>=0.40,<1'` at the four install sites:

- `.github/workflows/studio-inference-smoke.yml`
- `.github/workflows/studio-windows-inference-smoke.yml`
- `.github/workflows/studio-mac-ui-smoke.yml` (two steps)

A major-version bound rather than an exact pin, so patch and minor fixes still arrive but a major cannot land under us again without a decision. `>=0.40,<1` currently resolves to 0.125.0, which is the version the last green runs used.

## What this deliberately does not do

It does not migrate the call sites to `extra_body`. That changes what the probes send to the backend, and the determinism probes exist precisely to pin what is sent, so it is worth doing as its own change with its own reasoning rather than as a side effect of unbreaking CI. This PR restores the known-good major and leaves that door open.
