### PR TITLE
Studio: turn LoRA finetune targets on by default

### DIFF
--- a/studio/backend/core/training/worker.py
+++ b/studio/backend/core/training/worker.py
@@ -735,6 +735,34 @@ def _pre_detect_training_model(
         local_files_only = local_files_only,
         model_revision = model_revision,
     )
+    _check_finetune_targets_after_detect(trainer, config)
+
+
+def _check_finetune_targets_after_detect(trainer, config: dict) -> None:
+    """Reject a LoRA run that selects no adapter layers, once detection has settled which
+    branch it takes. models/training.py gates the image case from the request alone, but an
+    audio request is ambiguous there: is_audio_vlm reads all four selectors while the
+    codec/ASR branches (csm, snac, whisper, bicodec, dac) ignore them, and only the probe in
+    pre_detect tells them apart. Running here keeps the error early -- pre_detect is
+    config/tokenizer only, so this still fires before any weights load, instead of surfacing
+    as get_peft_regex's "No layers to finetune" after the model is in memory."""
+    if config.get("training_type", "LoRA/QLoRA") != "LoRA/QLoRA":
+        return  # Full Finetuning / CPT build adapters from target_modules alone
+    if not (getattr(trainer, "is_vlm", False) or getattr(trainer, "is_audio_vlm", False)):
+        return
+    if any(
+        config.get(key, True)
+        for key in (
+            "finetune_language_layers",
+            "finetune_attention_modules",
+            "finetune_mlp_modules",
+        )
+    ) or config.get("finetune_vision_layers", False):
+        return
+    raise ValueError(
+        "Nothing to train: enable at least one of finetune_language_layers, "
+        "finetune_attention_modules, finetune_mlp_modules, or finetune_vision_layers."
+    )
 
 
 def _reload_dataset_with_remote_model_tokenizer(

--- a/studio/backend/core/training/worker.py
+++ b/studio/backend/core/training/worker.py
@@ -857,10 +857,7 @@ def _check_mlx_finetune_targets(config: dict) -> None:
 
 
 def _check_mlx_effective_targets(
-    config: dict,
-    *,
-    finetune_language: bool,
-    finetune_vision: bool,
+    config: dict, *, finetune_language: bool, finetune_vision: bool
 ) -> None:
     """The same refusal, re-asked with the values get_peft_model will actually receive.
 

--- a/studio/backend/core/training/worker.py
+++ b/studio/backend/core/training/worker.py
@@ -796,6 +796,21 @@ def _check_finetune_targets_after_detect(trainer, config: dict) -> None:
         raise ValueError(_NOTHING_TO_TRAIN)
 
 
+# Targets the MLX loader trains regardless of the layer-family flags: embed_tokens becomes a
+# full trainable module and lm_head its own adapter, both on the CPT path.
+_CPT_TARGET_NAMES = frozenset({"embed_tokens", "lm_head"})
+
+
+def _names_a_cpt_target(target_modules) -> bool:
+    """Whether an explicit target list names something that trains on its own."""
+    if isinstance(target_modules, str):
+        return target_modules in _CPT_TARGET_NAMES
+    try:
+        return any(name in _CPT_TARGET_NAMES for name in target_modules)
+    except TypeError:  # not iterable -> not a list of names, so nothing is guaranteed
+        return False
+
+
 def _check_mlx_finetune_targets(config: dict) -> None:
     """MLX equivalent, called from the LoRA branch of the MLX worker.
 
@@ -804,13 +819,29 @@ def _check_mlx_finetune_targets(config: dict) -> None:
     finetune_language_layers whenever a module type is on, so only an empty module selection
     can survive here.
 
-    The filter only drops names it recognises as attention or MLP leaves, so a request naming
-    anything else (lm_head, embed_tokens, a fused qkv, all-linear) still has targets left with
-    both module types off, and trains. Only the default seven leaves are wholly attention and
-    MLP, so refuse just the runs that let the default stand; an explicit list that does filter
-    down to nothing still gets the loader's own message, which names the two flags."""
-    if config.get("target_modules"):
-        return
+    Surviving the module-type filter is NOT enough to train. get_peft_model drops only the
+    names it recognises as attention or MLP leaves, so a fused qkv, a c_fc or an expanded
+    all-linear does come out the other side with both module types off -- but the text branch
+    then gates the LoRA application itself on finetune_language_layers, and with all four
+    selectors off the caller's back-fill never fires. Those runs apply no adapters at all:
+    the model warns and trains nothing, and a VLM raises only once the weights are loaded.
+
+    The exception is a target the loader handles independently of the layer families. Naming
+    embed_tokens or lm_head puts it on the CPT path, where the full module or the head adapter
+    trains whatever the flags say, so such a request is left alone.
+
+    An explicit list that merely filters down to nothing still gets the loader's own message,
+    which names the two flags."""
+    targets = config.get("target_modules")
+    if targets:
+        if _names_a_cpt_target(targets):
+            return
+        vision, language, attention, mlp = _finetune_selectors(config)
+        # Any one of them leaves something that can train, or leaves the loader to say so
+        # with a better message than this one.
+        if attention or mlp or language or vision:
+            return
+        raise ValueError(_NOTHING_TO_TRAIN)
     _, _, attention, mlp = _finetune_selectors(config)
     if not (attention or mlp):
         raise ValueError(_NOTHING_TO_TRAIN)

--- a/studio/backend/core/training/worker.py
+++ b/studio/backend/core/training/worker.py
@@ -738,31 +738,52 @@ def _pre_detect_training_model(
     _check_finetune_targets_after_detect(trainer, config)
 
 
+_NOTHING_TO_TRAIN = (
+    "Nothing to train: select at least one layer family (finetune_language_layers or "
+    "finetune_vision_layers) and at least one module type (finetune_attention_modules or "
+    "finetune_mlp_modules)."
+)
+
+
+def _finetune_selectors(config: dict) -> tuple[bool, bool, bool, bool]:
+    """(vision, language, attention, mlp), with the request model's own defaults."""
+    return (
+        bool(config.get("finetune_vision_layers", False)),
+        bool(config.get("finetune_language_layers", True)),
+        bool(config.get("finetune_attention_modules", True)),
+        bool(config.get("finetune_mlp_modules", True)),
+    )
+
+
 def _check_finetune_targets_after_detect(trainer, config: dict) -> None:
     """Reject a LoRA run that selects no adapter layers, once detection has settled which
-    branch it takes. models/training.py gates the image case from the request alone, but an
-    audio request is ambiguous there: is_audio_vlm reads all four selectors while the
-    codec/ASR branches (csm, snac, whisper, bicodec, dac) ignore them, and only the probe in
-    pre_detect tells them apart. Running here keeps the error early -- pre_detect is
+    branch it takes. The request model cannot decide this: is_audio_vlm reads all four
+    selectors while the codec/ASR branches (csm, snac, whisper, bicodec, dac) ignore them,
+    is_vlm needs a vision-capable model and not just an image-tagged dataset, and only the
+    probe in pre_detect separates those. Running here keeps the error early -- pre_detect is
     config/tokenizer only, so this still fires before any weights load, instead of surfacing
-    as get_peft_regex's "No layers to finetune" after the model is in memory."""
+    as get_peft_regex's "No layers to finetune" with the model already in memory."""
     if config.get("training_type", "LoRA/QLoRA") != "LoRA/QLoRA":
         return  # Full Finetuning / CPT build adapters from target_modules alone
     if not (getattr(trainer, "is_vlm", False) or getattr(trainer, "is_audio_vlm", False)):
-        return
-    if any(
-        config.get(key, True)
-        for key in (
-            "finetune_language_layers",
-            "finetune_attention_modules",
-            "finetune_mlp_modules",
-        )
-    ) or config.get("finetune_vision_layers", False):
-        return
-    raise ValueError(
-        "Nothing to train: enable at least one of finetune_language_layers, "
-        "finetune_attention_modules, finetune_mlp_modules, or finetune_vision_layers."
-    )
+        return  # the text branch ignores these four
+    vision, language, attention, mlp = _finetune_selectors(config)
+    # Mirror get_peft_regex's two guards: one layer family AND one module type.
+    if not (vision or language) or not (attention or mlp):
+        raise ValueError(_NOTHING_TO_TRAIN)
+
+
+def _check_mlx_finetune_targets(config: dict) -> None:
+    """MLX equivalent, called from the LoRA branch of the MLX worker.
+
+    Two things differ from the CUDA path. FastMLXModel.get_peft_model is handed these
+    selectors for text models too, not only VLMs, so there is no is_vlm gate here. And the
+    caller back-fills finetune_language_layers whenever a module type is on, so an empty
+    layer family cannot survive -- only an empty module selection can, which leaves
+    target_modules empty after filtering ("target_modules became empty after filtering")."""
+    _, _, attention, mlp = _finetune_selectors(config)
+    if not (attention or mlp):
+        raise ValueError(_NOTHING_TO_TRAIN)
 
 
 def _reload_dataset_with_remote_model_tokenizer(
@@ -2697,6 +2718,10 @@ def _run_mlx_training(event_queue, stop_queue, config):
     is_dataset_image = bool(config.get("is_dataset_image", False))
     training_type = config.get("training_type", "LoRA/QLoRA")
     use_lora = training_type == "LoRA/QLoRA"
+    # Before the download/load below: this needs none of the model, unlike the CUDA path's
+    # equivalent, which has to wait for pre_detect to say which branch the run takes.
+    if use_lora:
+        _check_mlx_finetune_targets(config)
     # Normalize seed; explicit None must not reach the seed chain.
     _raw_seed = config.get("random_seed", 3407)
     random_seed = 3407 if _raw_seed is None else int(_raw_seed)

--- a/studio/backend/core/training/worker.py
+++ b/studio/backend/core/training/worker.py
@@ -796,8 +796,8 @@ def _check_finetune_targets_after_detect(trainer, config: dict) -> None:
         raise ValueError(_NOTHING_TO_TRAIN)
 
 
-# Targets the MLX loader trains regardless of the layer-family flags: embed_tokens becomes a
-# full trainable module and lm_head its own adapter, both on the CPT path.
+# Targets the MLX loader trains regardless of the layer-family flags: on the CPT path
+# embed_tokens becomes a full trainable module and lm_head its own adapter.
 _CPT_TARGET_NAMES = frozenset({"embed_tokens", "lm_head"})
 
 
@@ -821,14 +821,13 @@ def _check_mlx_finetune_targets(config: dict) -> None:
 
     Surviving the module-type filter is NOT enough to train. get_peft_model drops only the
     names it recognises as attention or MLP leaves, so a fused qkv, a c_fc or an expanded
-    all-linear does come out the other side with both module types off -- but the text branch
-    then gates the LoRA application itself on finetune_language_layers, and with all four
-    selectors off the caller's back-fill never fires. Those runs apply no adapters at all:
-    the model warns and trains nothing, and a VLM raises only once the weights are loaded.
+    all-linear survives with both module types off -- but the text branch then gates the LoRA
+    application on finetune_language_layers, and with all four selectors off the caller's
+    back-fill never fires. Those runs apply no adapters at all: the model warns and trains
+    nothing, and a VLM raises only once the weights are loaded.
 
-    The exception is a target the loader handles independently of the layer families. Naming
-    embed_tokens or lm_head puts it on the CPT path, where the full module or the head adapter
-    trains whatever the flags say, so such a request is left alone.
+    The exception is a target the loader handles independently of the layer families: naming
+    embed_tokens or lm_head puts it on the CPT path, which trains whatever the flags say.
 
     An explicit list that merely filters down to nothing still gets the loader's own message,
     which names the two flags."""
@@ -839,15 +838,14 @@ def _check_mlx_finetune_targets(config: dict) -> None:
         _, language, attention, mlp = _finetune_selectors(config)
         # Vision read the way the MLX call site reads it, NOT the way _finetune_selectors
         # does: that helper carries the CUDA consumer's defaults, where an omitted vision
-        # selector means True, while MLX defaults it False and forces it False outright for
-        # a text model. Taking True from an omitted key here would wave through every legacy
-        # config that never sent the selectors at all.
+        # selector means True, while MLX defaults it False and forces it False for a text
+        # model. Taking True from an omitted key would wave through every legacy config
+        # that never sent the selectors at all.
         vision = bool(config.get("finetune_vision_layers", False))
         # Any one of them leaves something that can train, or leaves the loader to say so
-        # with a better message than this one. Vision counts because this runs BEFORE
-        # detection, so a VLM whose vision tower is the only thing selected must not be
-        # refused here; _check_mlx_effective_targets catches the text case once is_vlm is
-        # known, which is the earliest it can be told apart.
+        # with a better message. Vision counts because this runs BEFORE detection, so a VLM
+        # whose vision tower is the only selection must not be refused here;
+        # _check_mlx_effective_targets catches the text case once is_vlm is known.
         if attention or mlp or language or vision:
             return
         raise ValueError(_NOTHING_TO_TRAIN)
@@ -865,10 +863,10 @@ def _check_mlx_effective_targets(
     from a text model and has to let a vision-only selection through. The call site can: it
     has forced vision to False for a text model and applied the language back-fill, so if
     both layer families are still off here, no adapter is coming and the run would train
-    nothing but its own warning. Raise instead, with the message that names the four fields.
+    nothing but its own warning.
 
-    Later than the preflight, and deliberately so -- this is the first point the answer is
-    knowable. It is still before the trainer is built and before a single step runs."""
+    Later than the preflight deliberately: this is the first point the answer is knowable,
+    and it is still before the trainer is built and before a single step runs."""
     if finetune_language or finetune_vision:
         return
     if _names_a_cpt_target(config.get("target_modules") or ()):
@@ -2945,8 +2943,7 @@ def _run_mlx_training(event_queue, stop_queue, config):
         if (finetune_attention or finetune_mlp) and not finetune_language and not finetune_vision:
             finetune_language = True
 
-        # is_vlm is known now, and so is the back-fill's outcome, which is what the preflight
-        # could only guess at.
+        # is_vlm and the back-fill's outcome are known now; the preflight could only guess.
         _check_mlx_effective_targets(
             config,
             finetune_language = finetune_language,

--- a/studio/backend/core/training/worker.py
+++ b/studio/backend/core/training/worker.py
@@ -836,15 +836,47 @@ def _check_mlx_finetune_targets(config: dict) -> None:
     if targets:
         if _names_a_cpt_target(targets):
             return
-        vision, language, attention, mlp = _finetune_selectors(config)
+        _, language, attention, mlp = _finetune_selectors(config)
+        # Vision read the way the MLX call site reads it, NOT the way _finetune_selectors
+        # does: that helper carries the CUDA consumer's defaults, where an omitted vision
+        # selector means True, while MLX defaults it False and forces it False outright for
+        # a text model. Taking True from an omitted key here would wave through every legacy
+        # config that never sent the selectors at all.
+        vision = bool(config.get("finetune_vision_layers", False))
         # Any one of them leaves something that can train, or leaves the loader to say so
-        # with a better message than this one.
+        # with a better message than this one. Vision counts because this runs BEFORE
+        # detection, so a VLM whose vision tower is the only thing selected must not be
+        # refused here; _check_mlx_effective_targets catches the text case once is_vlm is
+        # known, which is the earliest it can be told apart.
         if attention or mlp or language or vision:
             return
         raise ValueError(_NOTHING_TO_TRAIN)
     _, _, attention, mlp = _finetune_selectors(config)
     if not (attention or mlp):
         raise ValueError(_NOTHING_TO_TRAIN)
+
+
+def _check_mlx_effective_targets(
+    config: dict,
+    *,
+    finetune_language: bool,
+    finetune_vision: bool,
+) -> None:
+    """The same refusal, re-asked with the values get_peft_model will actually receive.
+
+    ``_check_mlx_finetune_targets`` runs before the model is loaded, so it cannot tell a VLM
+    from a text model and has to let a vision-only selection through. The call site can: it
+    has forced vision to False for a text model and applied the language back-fill, so if
+    both layer families are still off here, no adapter is coming and the run would train
+    nothing but its own warning. Raise instead, with the message that names the four fields.
+
+    Later than the preflight, and deliberately so -- this is the first point the answer is
+    knowable. It is still before the trainer is built and before a single step runs."""
+    if finetune_language or finetune_vision:
+        return
+    if _names_a_cpt_target(config.get("target_modules") or ()):
+        return
+    raise ValueError(_NOTHING_TO_TRAIN)
 
 
 def _reload_dataset_with_remote_model_tokenizer(
@@ -2915,6 +2947,14 @@ def _run_mlx_training(event_queue, stop_queue, config):
 
         if (finetune_attention or finetune_mlp) and not finetune_language and not finetune_vision:
             finetune_language = True
+
+        # is_vlm is known now, and so is the back-fill's outcome, which is what the preflight
+        # could only guess at.
+        _check_mlx_effective_targets(
+            config,
+            finetune_language = finetune_language,
+            finetune_vision = finetune_vision,
+        )
 
         peft_kwargs["finetune_language_layers"] = finetune_language
         peft_kwargs["finetune_attention_modules"] = finetune_attention

--- a/studio/backend/core/training/worker.py
+++ b/studio/backend/core/training/worker.py
@@ -749,10 +749,9 @@ def _finetune_selectors(config: dict) -> tuple[bool, bool, bool, bool]:
     """(vision, language, attention, mlp), read exactly the way the consumers read them.
 
     A guard that models the run differently from the code it guards rejects runs that would
-    have trained. Every default here is the CUDA consumer's own default for a config that
-    omits the key -- 4d passes finetune_vision_layers through config.get(..., True), and
-    _build_training_worker_config fills the same True. Only the MLX consumer defaults vision
-    False, and _check_mlx_finetune_targets discards the vision element, so True is safe there.
+    have trained, so every default here is the CUDA consumer's own default for an omitted key.
+    Only the MLX consumer defaults vision False, and _check_mlx_finetune_targets discards the
+    vision element, so True is safe there too.
     """
     return (
         bool(config.get("finetune_vision_layers", True)),
@@ -765,12 +764,10 @@ def _finetune_selectors(config: dict) -> tuple[bool, bool, bool, bool]:
 def _requests_all_linear(config: dict) -> bool:
     """Whether target_modules is PEFT's bare "all-linear" keyword rather than a leaf list.
 
-    prepare_model_for_training collapses a lone "all-linear" entry to the bare string before
-    calling get_peft_model, which then forces every selector True for it, so a run that asks
-    for all-linear with the selectors off trains every linear layer today. Rejecting it would
-    break exactly the requests the four selectors are not consulted for. A list that names
-    all-linear alongside other leaves is not the keyword -- the caller strips it and the
-    remaining names go through the normal scoped path, where the selectors do apply.
+    get_peft_model forces every selector True for the keyword, so all-linear with the
+    selectors off trains every linear layer today and rejecting it would break the very
+    requests the selectors are not consulted for. A list naming all-linear alongside other
+    leaves is not the keyword: the caller strips it and the rest take the scoped path.
     """
     target_modules = config.get("target_modules")
     if isinstance(target_modules, str):
@@ -782,10 +779,9 @@ def _requests_all_linear(config: dict) -> bool:
 
 def _check_finetune_targets_after_detect(trainer, config: dict) -> None:
     """Reject a LoRA run that selects no adapter layers, once detection has settled which
-    branch it takes. The request model cannot decide this: is_audio_vlm reads all four
-    selectors while the codec/ASR branches (csm, snac, whisper, bicodec, dac) ignore them,
-    is_vlm needs a vision-capable model and not just an image-tagged dataset, and only the
-    probe in pre_detect separates those. Running here keeps the error early -- pre_detect is
+    branch it takes. The request model cannot decide this: the codec/ASR branches ignore the
+    selectors that is_audio_vlm reads, is_vlm needs a vision-capable model and not just an
+    image-tagged dataset, and only the probe in pre_detect separates those. pre_detect is
     config/tokenizer only, so this still fires before any weights load, instead of surfacing
     as get_peft_regex's "No layers to finetune" with the model already in memory."""
     if config.get("training_type", "LoRA/QLoRA") != "LoRA/QLoRA":
@@ -804,17 +800,15 @@ def _check_mlx_finetune_targets(config: dict) -> None:
     """MLX equivalent, called from the LoRA branch of the MLX worker.
 
     Two things differ from the CUDA path. FastMLXModel.get_peft_model is handed these
-    selectors for text models too, not only VLMs, so there is no is_vlm gate here. And the
-    caller back-fills finetune_language_layers whenever a module type is on, so an empty
-    layer family cannot survive -- only an empty module selection can, which leaves
-    target_modules empty after filtering ("target_modules became empty after filtering").
+    selectors for text models too, so there is no is_vlm gate. And the caller back-fills
+    finetune_language_layers whenever a module type is on, so only an empty module selection
+    can survive here.
 
-    The filter only drops names it recognises as attention or MLP leaves, so a request that
-    names anything else -- lm_head, embed_tokens, a fused qkv under an architecture-specific
-    name, all-linear -- still has targets left with both module types off, and trains. Only
-    the default seven leaves are wholly attention and MLP, so refuse just the runs that let
-    the default stand. An explicit list that does filter down to nothing still gets the
-    loader's own message, which names the two flags."""
+    The filter only drops names it recognises as attention or MLP leaves, so a request naming
+    anything else (lm_head, embed_tokens, a fused qkv, all-linear) still has targets left with
+    both module types off, and trains. Only the default seven leaves are wholly attention and
+    MLP, so refuse just the runs that let the default stand; an explicit list that does filter
+    down to nothing still gets the loader's own message, which names the two flags."""
     if config.get("target_modules"):
         return
     _, _, attention, mlp = _finetune_selectors(config)
@@ -2754,8 +2748,7 @@ def _run_mlx_training(event_queue, stop_queue, config):
     is_dataset_image = bool(config.get("is_dataset_image", False))
     training_type = config.get("training_type", "LoRA/QLoRA")
     use_lora = training_type == "LoRA/QLoRA"
-    # Before the download/load below: this needs none of the model, unlike the CUDA path's
-    # equivalent, which has to wait for pre_detect to say which branch the run takes.
+    # Before the download/load below: unlike the CUDA path, this needs none of the model.
     if use_lora:
         _check_mlx_finetune_targets(config)
     # Normalize seed; explicit None must not reach the seed chain.

--- a/studio/backend/core/training/worker.py
+++ b/studio/backend/core/training/worker.py
@@ -746,13 +746,38 @@ _NOTHING_TO_TRAIN = (
 
 
 def _finetune_selectors(config: dict) -> tuple[bool, bool, bool, bool]:
-    """(vision, language, attention, mlp), with the request model's own defaults."""
+    """(vision, language, attention, mlp), read exactly the way the consumers read them.
+
+    A guard that models the run differently from the code it guards rejects runs that would
+    have trained. Every default here is the CUDA consumer's own default for a config that
+    omits the key -- 4d passes finetune_vision_layers through config.get(..., True), and
+    _build_training_worker_config fills the same True. Only the MLX consumer defaults vision
+    False, and _check_mlx_finetune_targets discards the vision element, so True is safe there.
+    """
     return (
-        bool(config.get("finetune_vision_layers", False)),
+        bool(config.get("finetune_vision_layers", True)),
         bool(config.get("finetune_language_layers", True)),
         bool(config.get("finetune_attention_modules", True)),
         bool(config.get("finetune_mlp_modules", True)),
     )
+
+
+def _requests_all_linear(config: dict) -> bool:
+    """Whether target_modules is PEFT's bare "all-linear" keyword rather than a leaf list.
+
+    prepare_model_for_training collapses a lone "all-linear" entry to the bare string before
+    calling get_peft_model, which then forces every selector True for it, so a run that asks
+    for all-linear with the selectors off trains every linear layer today. Rejecting it would
+    break exactly the requests the four selectors are not consulted for. A list that names
+    all-linear alongside other leaves is not the keyword -- the caller strips it and the
+    remaining names go through the normal scoped path, where the selectors do apply.
+    """
+    target_modules = config.get("target_modules")
+    if isinstance(target_modules, str):
+        return target_modules == "all-linear"
+    if isinstance(target_modules, (list, tuple)):
+        return list(target_modules) == ["all-linear"]
+    return False
 
 
 def _check_finetune_targets_after_detect(trainer, config: dict) -> None:
@@ -767,6 +792,8 @@ def _check_finetune_targets_after_detect(trainer, config: dict) -> None:
         return  # Full Finetuning / CPT build adapters from target_modules alone
     if not (getattr(trainer, "is_vlm", False) or getattr(trainer, "is_audio_vlm", False)):
         return  # the text branch ignores these four
+    if _requests_all_linear(config):
+        return  # get_peft_model turns all five selectors on for the keyword; see below
     vision, language, attention, mlp = _finetune_selectors(config)
     # Mirror get_peft_regex's two guards: one layer family AND one module type.
     if not (vision or language) or not (attention or mlp):
@@ -780,7 +807,16 @@ def _check_mlx_finetune_targets(config: dict) -> None:
     selectors for text models too, not only VLMs, so there is no is_vlm gate here. And the
     caller back-fills finetune_language_layers whenever a module type is on, so an empty
     layer family cannot survive -- only an empty module selection can, which leaves
-    target_modules empty after filtering ("target_modules became empty after filtering")."""
+    target_modules empty after filtering ("target_modules became empty after filtering").
+
+    The filter only drops names it recognises as attention or MLP leaves, so a request that
+    names anything else -- lm_head, embed_tokens, a fused qkv under an architecture-specific
+    name, all-linear -- still has targets left with both module types off, and trains. Only
+    the default seven leaves are wholly attention and MLP, so refuse just the runs that let
+    the default stand. An explicit list that does filter down to nothing still gets the
+    loader's own message, which names the two flags."""
+    if config.get("target_modules"):
+        return
     _, _, attention, mlp = _finetune_selectors(config)
     if not (attention or mlp):
         raise ValueError(_NOTHING_TO_TRAIN)

--- a/studio/backend/models/training.py
+++ b/studio/backend/models/training.py
@@ -538,9 +538,9 @@ class TrainingStartRequest(BaseModel):
 
     # Vision-specific LoRA parameters
     finetune_vision_layers: bool = Field(False, description = "Finetune vision layers")
-    finetune_language_layers: bool = Field(False, description = "Finetune language layers")
-    finetune_attention_modules: bool = Field(False, description = "Finetune attention modules")
-    finetune_mlp_modules: bool = Field(False, description = "Finetune MLP modules")
+    finetune_language_layers: bool = Field(True, description = "Finetune language layers")
+    finetune_attention_modules: bool = Field(True, description = "Finetune attention modules")
+    finetune_mlp_modules: bool = Field(True, description = "Finetune MLP modules")
     is_dataset_image: bool = Field(False, description = "Whether the dataset contains image data")
     is_dataset_audio: bool = Field(False, description = "Whether the dataset contains audio data")
     is_embedding: bool = Field(
@@ -628,6 +628,22 @@ class TrainingStartRequest(BaseModel):
             raise ValueError(
                 f"{active[0]} requires an adapter method (LoRA/QLoRA or "
                 "Continued Pretraining); it has no effect under Full Finetuning."
+            )
+        return self
+
+    @model_validator(mode = "after")
+    def _check_finetune_targets(self) -> "TrainingStartRequest":
+        if getattr(self, "training_type", None) == "Full Finetuning":
+            return self
+        if not (
+            self.finetune_vision_layers
+            or self.finetune_language_layers
+            or self.finetune_attention_modules
+            or self.finetune_mlp_modules
+        ):
+            raise ValueError(
+                "Nothing to train: enable at least one of finetune_language_layers, "
+                "finetune_attention_modules, finetune_mlp_modules, or finetune_vision_layers."
             )
         return self
 

--- a/studio/backend/models/training.py
+++ b/studio/backend/models/training.py
@@ -633,15 +633,24 @@ class TrainingStartRequest(BaseModel):
 
     @model_validator(mode = "after")
     def _check_finetune_targets(self) -> "TrainingStartRequest":
-        if getattr(self, "training_type", None) == "Full Finetuning":
-            return self
         # Only the vision (VLM) LoRA path feeds these four selectors to
         # FastVisionModel.get_peft_model. Text runs, the audio paths and Continued
         # Pretraining build adapters from target_modules alone (trainer.py's else /
         # snac branches, worker.py's is_cpt branch), so all-false is a valid request
-        # there and rejecting it broke working configs. trainer.is_vlm is
-        # `not is_audio_vlm and vision and is_dataset_image`, so a run that did not
-        # declare an image dataset can never reach the branch that reads these.
+        # there and rejecting it broke working configs.
+        #
+        # Full Finetuning and CPT are exempt on training_type alone, NOT via the
+        # is_dataset_image gate below: worker.py takes its `if is_cpt` branch before the
+        # LoRA one and passes only target_modules, so a CPT run never reads these four
+        # however its dataset is tagged. Gating CPT on the image flag still rejected
+        # is_dataset_image=true + all-false, a config the worker runs fine.
+        if getattr(self, "training_type", None) in (
+            "Full Finetuning",
+            "Continued Pretraining",
+        ):
+            return self
+        # trainer.is_vlm is `not is_audio_vlm and vision and is_dataset_image`, so a run
+        # that did not declare an image dataset can never reach the branch that reads these.
         if not self.is_dataset_image:
             return self
         if not (

--- a/studio/backend/models/training.py
+++ b/studio/backend/models/training.py
@@ -649,14 +649,14 @@ class TrainingStartRequest(BaseModel):
             "Continued Pretraining",
         ):
             return self
-        # is_vlm is `not is_audio_vlm and vision and is_dataset_image` and is_audio_vlm is
-        # `is_dataset_audio` on an audio-VLM model -- it never consults is_dataset_image --
-        # so audio has to gate this too or an all-false Gemma-3N-style run slips through and
-        # dies in get_peft_regex ("No layers to finetune") after the model is loaded. Which
-        # audio model it is only becomes known after that load, so a codec/TTS run (csm,
-        # snac, whisper, bicodec, dac), whose branch ignores these flags, is also asked to
-        # turn one on; that is a no-op there and costs nothing.
-        if not (self.is_dataset_image or self.is_dataset_audio):
+        # Image-tagged runs are gated here because is_dataset_image is a necessary condition
+        # for trainer.is_vlm, so the request alone settles it. Audio is NOT gated here: the
+        # audio-VLM branch does read these four, but the codec/ASR branches (csm, snac,
+        # whisper, bicodec, dac) ignore them, and only a config/tokenizer probe tells the two
+        # apart -- so an is_dataset_audio gate would reject valid codec runs. That case is
+        # checked in worker.py's _pre_detect_training_model, after detection and still before
+        # any weights load.
+        if not self.is_dataset_image:
             return self
         if not (
             self.finetune_vision_layers

--- a/studio/backend/models/training.py
+++ b/studio/backend/models/training.py
@@ -631,45 +631,6 @@ class TrainingStartRequest(BaseModel):
             )
         return self
 
-    @model_validator(mode = "after")
-    def _check_finetune_targets(self) -> "TrainingStartRequest":
-        # Two LoRA branches feed these four selectors to get_peft_model: the vision one
-        # (trainer.is_vlm) and the audio-VLM one (trainer.is_audio_vlm). Text runs and
-        # Continued Pretraining build adapters from target_modules alone (trainer.py's
-        # else branch, worker.py's is_cpt branch), so all-false is a valid request there
-        # and rejecting it broke working configs.
-        #
-        # Full Finetuning and CPT are exempt on training_type alone, NOT via the dataset
-        # gate below: worker.py takes its `if is_cpt` branch before the LoRA one and
-        # passes only target_modules, so a CPT run never reads these four however its
-        # dataset is tagged. Gating CPT on the image flag still rejected
-        # is_dataset_image=true + all-false, a config the worker runs fine.
-        if getattr(self, "training_type", None) in (
-            "Full Finetuning",
-            "Continued Pretraining",
-        ):
-            return self
-        # Image-tagged runs are gated here because is_dataset_image is a necessary condition
-        # for trainer.is_vlm, so the request alone settles it. Audio is NOT gated here: the
-        # audio-VLM branch does read these four, but the codec/ASR branches (csm, snac,
-        # whisper, bicodec, dac) ignore them, and only a config/tokenizer probe tells the two
-        # apart -- so an is_dataset_audio gate would reject valid codec runs. That case is
-        # checked in worker.py's _pre_detect_training_model, after detection and still before
-        # any weights load.
-        if not self.is_dataset_image:
-            return self
-        if not (
-            self.finetune_vision_layers
-            or self.finetune_language_layers
-            or self.finetune_attention_modules
-            or self.finetune_mlp_modules
-        ):
-            raise ValueError(
-                "Nothing to train: enable at least one of finetune_language_layers, "
-                "finetune_attention_modules, finetune_mlp_modules, or finetune_vision_layers."
-            )
-        return self
-
 
 class TrainingJobResponse(BaseModel):
     """Immediate response when training is initiated"""

--- a/studio/backend/models/training.py
+++ b/studio/backend/models/training.py
@@ -633,25 +633,30 @@ class TrainingStartRequest(BaseModel):
 
     @model_validator(mode = "after")
     def _check_finetune_targets(self) -> "TrainingStartRequest":
-        # Only the vision (VLM) LoRA path feeds these four selectors to
-        # FastVisionModel.get_peft_model. Text runs, the audio paths and Continued
-        # Pretraining build adapters from target_modules alone (trainer.py's else /
-        # snac branches, worker.py's is_cpt branch), so all-false is a valid request
-        # there and rejecting it broke working configs.
+        # Two LoRA branches feed these four selectors to get_peft_model: the vision one
+        # (trainer.is_vlm) and the audio-VLM one (trainer.is_audio_vlm). Text runs and
+        # Continued Pretraining build adapters from target_modules alone (trainer.py's
+        # else branch, worker.py's is_cpt branch), so all-false is a valid request there
+        # and rejecting it broke working configs.
         #
-        # Full Finetuning and CPT are exempt on training_type alone, NOT via the
-        # is_dataset_image gate below: worker.py takes its `if is_cpt` branch before the
-        # LoRA one and passes only target_modules, so a CPT run never reads these four
-        # however its dataset is tagged. Gating CPT on the image flag still rejected
+        # Full Finetuning and CPT are exempt on training_type alone, NOT via the dataset
+        # gate below: worker.py takes its `if is_cpt` branch before the LoRA one and
+        # passes only target_modules, so a CPT run never reads these four however its
+        # dataset is tagged. Gating CPT on the image flag still rejected
         # is_dataset_image=true + all-false, a config the worker runs fine.
         if getattr(self, "training_type", None) in (
             "Full Finetuning",
             "Continued Pretraining",
         ):
             return self
-        # trainer.is_vlm is `not is_audio_vlm and vision and is_dataset_image`, so a run
-        # that did not declare an image dataset can never reach the branch that reads these.
-        if not self.is_dataset_image:
+        # is_vlm is `not is_audio_vlm and vision and is_dataset_image` and is_audio_vlm is
+        # `is_dataset_audio` on an audio-VLM model -- it never consults is_dataset_image --
+        # so audio has to gate this too or an all-false Gemma-3N-style run slips through and
+        # dies in get_peft_regex ("No layers to finetune") after the model is loaded. Which
+        # audio model it is only becomes known after that load, so a codec/TTS run (csm,
+        # snac, whisper, bicodec, dac), whose branch ignores these flags, is also asked to
+        # turn one on; that is a no-op there and costs nothing.
+        if not (self.is_dataset_image or self.is_dataset_audio):
             return self
         if not (
             self.finetune_vision_layers

--- a/studio/backend/models/training.py
+++ b/studio/backend/models/training.py
@@ -635,6 +635,15 @@ class TrainingStartRequest(BaseModel):
     def _check_finetune_targets(self) -> "TrainingStartRequest":
         if getattr(self, "training_type", None) == "Full Finetuning":
             return self
+        # Only the vision (VLM) LoRA path feeds these four selectors to
+        # FastVisionModel.get_peft_model. Text runs, the audio paths and Continued
+        # Pretraining build adapters from target_modules alone (trainer.py's else /
+        # snac branches, worker.py's is_cpt branch), so all-false is a valid request
+        # there and rejecting it broke working configs. trainer.is_vlm is
+        # `not is_audio_vlm and vision and is_dataset_image`, so a run that did not
+        # declare an image dataset can never reach the branch that reads these.
+        if not self.is_dataset_image:
+            return self
         if not (
             self.finetune_vision_layers
             or self.finetune_language_layers

--- a/studio/backend/tests/test_training_finetune_targets.py
+++ b/studio/backend/tests/test_training_finetune_targets.py
@@ -2,7 +2,6 @@
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
 import pytest
-from pydantic import ValidationError
 
 from models import TrainingStartRequest
 
@@ -26,122 +25,28 @@ def test_lora_targets_default_on():
     assert request.finetune_vision_layers is False
 
 
-def test_vision_lora_with_no_targets_is_rejected():
-    with pytest.raises(ValidationError, match = "Nothing to train"):
-        _request(
-            is_dataset_image = True,
+def test_request_layer_does_not_guess_the_branch():
+    # Whether these four are read at all depends on the model, which the request cannot see:
+    # a vision-capable model makes it a VLM run, a plain text model does not, and an audio
+    # dataset may be an audio VLM or a codec. Every combination is accepted here and settled
+    # in the worker once detection has run (tests below).
+    for flags in (
+        {},
+        {"is_dataset_image": True},
+        {"is_dataset_audio": True},
+        {"is_dataset_image": True, "is_dataset_audio": True},
+        {"training_type": "Continued Pretraining", "is_dataset_image": True},
+        {"training_type": "Full Finetuning"},
+    ):
+        request = _request(
             finetune_vision_layers = False,
             finetune_language_layers = False,
             finetune_attention_modules = False,
             finetune_mlp_modules = False,
+            **flags,
         )
 
-
-def test_text_lora_with_no_targets_is_allowed():
-    # Only the VLM path reads these four selectors; a text LoRA run builds its
-    # adapters from target_modules, so an all-false request still trains.
-    request = _request(
-        finetune_vision_layers = False,
-        finetune_language_layers = False,
-        finetune_attention_modules = False,
-        finetune_mlp_modules = False,
-    )
-
-    assert request.finetune_language_layers is False
-
-
-def test_continued_pretraining_with_no_targets_is_allowed():
-    request = _request(
-        training_type = "Continued Pretraining",
-        finetune_vision_layers = False,
-        finetune_language_layers = False,
-        finetune_attention_modules = False,
-        finetune_mlp_modules = False,
-    )
-
-    assert request.training_type == "Continued Pretraining"
-
-
-def test_image_tagged_continued_pretraining_with_no_targets_is_allowed():
-    # worker.py takes its `if is_cpt` branch BEFORE the LoRA one and passes only
-    # target_modules, so a CPT run never reads these four however its dataset is
-    # tagged. Gating the exemption on is_dataset_image rejected this valid config;
-    # the case above leaves the flag at its default, so it never covered this.
-    request = _request(
-        training_type = "Continued Pretraining",
-        is_dataset_image = True,
-        finetune_vision_layers = False,
-        finetune_language_layers = False,
-        finetune_attention_modules = False,
-        finetune_mlp_modules = False,
-    )
-
-    assert request.training_type == "Continued Pretraining"
-    assert request.is_dataset_image is True
-
-
-def test_audio_lora_with_no_targets_passes_request_validation():
-    # An audio request is ambiguous at this layer: the audio-VLM branch reads all four
-    # selectors, the codec/ASR branches ignore them, and only pre_detect's probe separates
-    # them. So the request is accepted here and settled in the worker (tests below).
-    request = _request(
-        is_dataset_audio = True,
-        finetune_vision_layers = False,
-        finetune_language_layers = False,
-        finetune_attention_modules = False,
-        finetune_mlp_modules = False,
-    )
-
-    assert request.is_dataset_audio is True
-
-
-def test_audio_lora_with_one_target_is_allowed():
-    request = _request(
-        is_dataset_audio = True,
-        finetune_vision_layers = False,
-        finetune_language_layers = True,
-        finetune_attention_modules = False,
-        finetune_mlp_modules = True,
-    )
-
-    assert request.is_dataset_audio is True
-
-
-def test_audio_tagged_continued_pretraining_with_no_targets_is_allowed():
-    # training_type exempts CPT before the dataset gate, for audio as for image.
-    request = _request(
-        training_type = "Continued Pretraining",
-        is_dataset_audio = True,
-        finetune_vision_layers = False,
-        finetune_language_layers = False,
-        finetune_attention_modules = False,
-        finetune_mlp_modules = False,
-    )
-
-    assert request.is_dataset_audio is True
-
-
-def test_vision_only_target_is_enough():
-    request = _request(
-        is_dataset_image = True,
-        finetune_vision_layers = True,
-        finetune_language_layers = False,
-        finetune_attention_modules = False,
-        finetune_mlp_modules = False,
-    )
-
-    assert request.finetune_vision_layers is True
-
-
-def test_full_finetuning_ignores_targets():
-    request = _request(
-        training_type = "Full Finetuning",
-        finetune_language_layers = False,
-        finetune_attention_modules = False,
-        finetune_mlp_modules = False,
-    )
-
-    assert request.training_type == "Full Finetuning"
+        assert request.finetune_language_layers is False
 
 
 # --- worker-level check, after detection has settled which branch the run takes ---
@@ -190,15 +95,40 @@ def test_worker_rejects_vision_vlm_with_no_targets():
         _check_finetune_targets_after_detect(_Trainer(is_vlm = True), _config(**_ALL_OFF))
 
 
-def test_worker_allows_audio_vlm_with_one_target():
+def test_worker_rejects_audio_vlm_with_a_module_type_but_no_layer_family():
+    # get_peft_regex's first guard: mlp alone is not enough, some family must be on.
     from core.training.worker import _check_finetune_targets_after_detect
     config = _config(**{**_ALL_OFF, "finetune_mlp_modules": True})
+
+    with pytest.raises(ValueError, match = "Nothing to train"):
+        _check_finetune_targets_after_detect(_Trainer(is_audio_vlm = True), config)
+
+
+def test_worker_allows_audio_vlm_with_a_family_and_a_module_type():
+    from core.training.worker import _check_finetune_targets_after_detect
+
+    config = _config(
+        **{**_ALL_OFF, "finetune_language_layers": True, "finetune_mlp_modules": True}
+    )
     _check_finetune_targets_after_detect(_Trainer(is_audio_vlm = True), config)
 
 
-def test_worker_allows_vision_only_target():
+def test_worker_rejects_vision_family_with_no_module_type():
+    # get_peft_regex's second guard: a family with neither attention nor mlp still raises,
+    # so "at least one of the four" would have been too loose a rule here.
     from core.training.worker import _check_finetune_targets_after_detect
     config = _config(**{**_ALL_OFF, "finetune_vision_layers": True})
+
+    with pytest.raises(ValueError, match = "Nothing to train"):
+        _check_finetune_targets_after_detect(_Trainer(is_vlm = True), config)
+
+
+def test_worker_allows_vision_family_with_a_module_type():
+    from core.training.worker import _check_finetune_targets_after_detect
+
+    config = _config(
+        **{**_ALL_OFF, "finetune_vision_layers": True, "finetune_attention_modules": True}
+    )
     _check_finetune_targets_after_detect(_Trainer(is_vlm = True), config)
 
 
@@ -227,8 +157,61 @@ def test_worker_rejection_is_not_mistaken_for_a_cache_problem():
     # error, or a nothing-to-train run would be retried as a corrupt-download instead.
     from core.training.worker import _is_model_cache_artifact_error
     error = ValueError(
-        "Nothing to train: enable at least one of finetune_language_layers, "
-        "finetune_attention_modules, finetune_mlp_modules, or finetune_vision_layers."
+        "Nothing to train: select at least one layer family (finetune_language_layers or "
+        "finetune_vision_layers) and at least one module type (finetune_attention_modules "
+        "or finetune_mlp_modules)."
     )
 
     assert _is_model_cache_artifact_error(error) is False
+
+
+# --- MLX path: selectors are read for text models too, and before any model load ---
+
+
+def test_mlx_rejects_no_module_types():
+    from core.training.worker import _check_mlx_finetune_targets
+
+    with pytest.raises(ValueError, match = "Nothing to train"):
+        _check_mlx_finetune_targets(_config(**_ALL_OFF))
+
+
+def test_mlx_rejects_text_run_with_no_module_types():
+    # No is_vlm gate on this path: FastMLXModel.get_peft_model is handed the selectors for
+    # text models too, so an all-false text run fails there where CUDA would ignore them.
+    from core.training.worker import _check_mlx_finetune_targets
+
+    config = _config(**{**_ALL_OFF, "finetune_language_layers": True})
+
+    with pytest.raises(ValueError, match = "Nothing to train"):
+        _check_mlx_finetune_targets(config)
+
+
+def test_mlx_allows_empty_layer_family_when_a_module_type_is_on():
+    # The caller back-fills finetune_language_layers when a module type is selected, so this
+    # trains fine and must not be rejected -- the CUDA guard would reject the same config.
+    from core.training.worker import _check_mlx_finetune_targets
+
+    config = _config(**{**_ALL_OFF, "finetune_attention_modules": True})
+    _check_mlx_finetune_targets(config)
+
+
+def test_mlx_allows_defaults():
+    from core.training.worker import _check_mlx_finetune_targets
+
+    _check_mlx_finetune_targets(_config())
+
+
+def test_cuda_rejects_empty_layer_family():
+    # get_peft_regex's first guard, which the MLX back-fill makes unreachable there.
+    from core.training.worker import _check_finetune_targets_after_detect
+
+    config = _config(**{**_ALL_OFF, "finetune_attention_modules": True})
+
+    with pytest.raises(ValueError, match = "Nothing to train"):
+        _check_finetune_targets_after_detect(_Trainer(is_vlm = True), config)
+
+
+def test_cuda_text_run_is_untouched_by_either_guard():
+    from core.training.worker import _check_finetune_targets_after_detect
+
+    _check_finetune_targets_after_detect(_Trainer(), _config(**_ALL_OFF))

--- a/studio/backend/tests/test_training_finetune_targets.py
+++ b/studio/backend/tests/test_training_finetune_targets.py
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import pytest
+from pydantic import ValidationError
+
+from models import TrainingStartRequest
+
+
+def _request(**overrides):
+    fields = {
+        "model_name": "unsloth/Llama-3.2-1B-Instruct",
+        "training_type": "LoRA/QLoRA",
+        "format_type": "alpaca",
+    }
+    fields.update(overrides)
+    return TrainingStartRequest(**fields)
+
+
+def test_lora_targets_default_on():
+    request = _request()
+
+    assert request.finetune_language_layers is True
+    assert request.finetune_attention_modules is True
+    assert request.finetune_mlp_modules is True
+    assert request.finetune_vision_layers is False
+
+
+def test_lora_with_no_targets_is_rejected():
+    with pytest.raises(ValidationError, match = "Nothing to train"):
+        _request(
+            finetune_vision_layers = False,
+            finetune_language_layers = False,
+            finetune_attention_modules = False,
+            finetune_mlp_modules = False,
+        )
+
+
+def test_vision_only_target_is_enough():
+    request = _request(
+        finetune_vision_layers = True,
+        finetune_language_layers = False,
+        finetune_attention_modules = False,
+        finetune_mlp_modules = False,
+    )
+
+    assert request.finetune_vision_layers is True
+
+
+def test_full_finetuning_ignores_targets():
+    request = _request(
+        training_type = "Full Finetuning",
+        finetune_language_layers = False,
+        finetune_attention_modules = False,
+        finetune_mlp_modules = False,
+    )
+
+    assert request.training_type == "Full Finetuning"

--- a/studio/backend/tests/test_training_finetune_targets.py
+++ b/studio/backend/tests/test_training_finetune_targets.py
@@ -62,6 +62,24 @@ def test_continued_pretraining_with_no_targets_is_allowed():
     assert request.training_type == "Continued Pretraining"
 
 
+def test_image_tagged_continued_pretraining_with_no_targets_is_allowed():
+    # worker.py takes its `if is_cpt` branch BEFORE the LoRA one and passes only
+    # target_modules, so a CPT run never reads these four however its dataset is
+    # tagged. Gating the exemption on is_dataset_image rejected this valid config;
+    # the case above leaves the flag at its default, so it never covered this.
+    request = _request(
+        training_type = "Continued Pretraining",
+        is_dataset_image = True,
+        finetune_vision_layers = False,
+        finetune_language_layers = False,
+        finetune_attention_modules = False,
+        finetune_mlp_modules = False,
+    )
+
+    assert request.training_type == "Continued Pretraining"
+    assert request.is_dataset_image is True
+
+
 def test_vision_only_target_is_enough():
     request = _request(
         is_dataset_image = True,

--- a/studio/backend/tests/test_training_finetune_targets.py
+++ b/studio/backend/tests/test_training_finetune_targets.py
@@ -80,18 +80,19 @@ def test_image_tagged_continued_pretraining_with_no_targets_is_allowed():
     assert request.is_dataset_image is True
 
 
-def test_audio_vlm_with_no_targets_is_rejected():
-    # trainer.is_audio_vlm is set from is_dataset_audio alone and its branch forwards all
-    # four selectors to FastModel.get_peft_model, so an audio run with none enabled must be
-    # rejected here rather than crashing in get_peft_regex after the model is loaded.
-    with pytest.raises(ValidationError, match = "Nothing to train"):
-        _request(
-            is_dataset_audio = True,
-            finetune_vision_layers = False,
-            finetune_language_layers = False,
-            finetune_attention_modules = False,
-            finetune_mlp_modules = False,
-        )
+def test_audio_lora_with_no_targets_passes_request_validation():
+    # An audio request is ambiguous at this layer: the audio-VLM branch reads all four
+    # selectors, the codec/ASR branches ignore them, and only pre_detect's probe separates
+    # them. So the request is accepted here and settled in the worker (tests below).
+    request = _request(
+        is_dataset_audio = True,
+        finetune_vision_layers = False,
+        finetune_language_layers = False,
+        finetune_attention_modules = False,
+        finetune_mlp_modules = False,
+    )
+
+    assert request.is_dataset_audio is True
 
 
 def test_audio_lora_with_one_target_is_allowed():
@@ -141,3 +142,100 @@ def test_full_finetuning_ignores_targets():
     )
 
     assert request.training_type == "Full Finetuning"
+
+
+# --- worker-level check, after detection has settled which branch the run takes ---
+
+
+class _Trainer:
+    def __init__(self, is_vlm = False, is_audio_vlm = False):
+        self.is_vlm = is_vlm
+        self.is_audio_vlm = is_audio_vlm
+
+
+def _config(**overrides):
+    config = {"training_type": "LoRA/QLoRA"}
+    config.update(overrides)
+    return config
+
+
+_ALL_OFF = {
+    "finetune_vision_layers": False,
+    "finetune_language_layers": False,
+    "finetune_attention_modules": False,
+    "finetune_mlp_modules": False,
+}
+
+
+def test_worker_rejects_audio_vlm_with_no_targets():
+    from core.training.worker import _check_finetune_targets_after_detect
+
+    with pytest.raises(ValueError, match = "Nothing to train"):
+        _check_finetune_targets_after_detect(
+            _Trainer(is_audio_vlm = True), _config(**_ALL_OFF)
+        )
+
+
+def test_worker_allows_codec_audio_with_no_targets():
+    # csm / snac / whisper / bicodec / dac leave is_audio_vlm False and build adapters from
+    # target_modules, so an all-false request is valid and must not be rejected.
+    from core.training.worker import _check_finetune_targets_after_detect
+
+    _check_finetune_targets_after_detect(_Trainer(), _config(**_ALL_OFF))
+
+
+def test_worker_rejects_vision_vlm_with_no_targets():
+    from core.training.worker import _check_finetune_targets_after_detect
+
+    with pytest.raises(ValueError, match = "Nothing to train"):
+        _check_finetune_targets_after_detect(_Trainer(is_vlm = True), _config(**_ALL_OFF))
+
+
+def test_worker_allows_audio_vlm_with_one_target():
+    from core.training.worker import _check_finetune_targets_after_detect
+
+    config = _config(**{**_ALL_OFF, "finetune_mlp_modules": True})
+    _check_finetune_targets_after_detect(_Trainer(is_audio_vlm = True), config)
+
+
+def test_worker_allows_vision_only_target():
+    from core.training.worker import _check_finetune_targets_after_detect
+
+    config = _config(**{**_ALL_OFF, "finetune_vision_layers": True})
+    _check_finetune_targets_after_detect(_Trainer(is_vlm = True), config)
+
+
+def test_worker_defaults_count_as_selected():
+    # An omitted selector defaults on for the three language-side flags, so a config that
+    # simply does not mention them must not be read as "nothing selected".
+    from core.training.worker import _check_finetune_targets_after_detect
+
+    _check_finetune_targets_after_detect(_Trainer(is_audio_vlm = True), _config())
+
+
+def test_worker_exempts_continued_pretraining():
+    from core.training.worker import _check_finetune_targets_after_detect
+
+    config = _config(training_type = "Continued Pretraining", **_ALL_OFF)
+    _check_finetune_targets_after_detect(_Trainer(is_audio_vlm = True), config)
+
+
+def test_worker_exempts_full_finetuning():
+    from core.training.worker import _check_finetune_targets_after_detect
+
+    config = _config(training_type = "Full Finetuning", **_ALL_OFF)
+    _check_finetune_targets_after_detect(_Trainer(is_vlm = True), config)
+
+
+def test_worker_rejection_is_not_mistaken_for_a_cache_problem():
+    # _pre_detect_training_model's caller funnels exceptions through the incomplete-cache
+    # fallback when the model is local-only. This error must not look like a cache artifact
+    # error, or a nothing-to-train run would be retried as a corrupt-download instead.
+    from core.training.worker import _is_model_cache_artifact_error
+
+    error = ValueError(
+        "Nothing to train: enable at least one of finetune_language_layers, "
+        "finetune_attention_modules, finetune_mlp_modules, or finetune_vision_layers."
+    )
+
+    assert _is_model_cache_artifact_error(error) is False

--- a/studio/backend/tests/test_training_finetune_targets.py
+++ b/studio/backend/tests/test_training_finetune_targets.py
@@ -106,10 +106,7 @@ def test_worker_rejects_audio_vlm_with_a_module_type_but_no_layer_family():
 
 def test_worker_allows_audio_vlm_with_a_family_and_a_module_type():
     from core.training.worker import _check_finetune_targets_after_detect
-
-    config = _config(
-        **{**_ALL_OFF, "finetune_language_layers": True, "finetune_mlp_modules": True}
-    )
+    config = _config(**{**_ALL_OFF, "finetune_language_layers": True, "finetune_mlp_modules": True})
     _check_finetune_targets_after_detect(_Trainer(is_audio_vlm = True), config)
 
 
@@ -125,7 +122,6 @@ def test_worker_rejects_vision_family_with_no_module_type():
 
 def test_worker_allows_vision_family_with_a_module_type():
     from core.training.worker import _check_finetune_targets_after_detect
-
     config = _config(
         **{**_ALL_OFF, "finetune_vision_layers": True, "finetune_attention_modules": True}
     )
@@ -170,7 +166,6 @@ def test_worker_rejection_is_not_mistaken_for_a_cache_problem():
 
 def test_mlx_rejects_no_module_types():
     from core.training.worker import _check_mlx_finetune_targets
-
     with pytest.raises(ValueError, match = "Nothing to train"):
         _check_mlx_finetune_targets(_config(**_ALL_OFF))
 
@@ -179,7 +174,6 @@ def test_mlx_rejects_text_run_with_no_module_types():
     # No is_vlm gate on this path: FastMLXModel.get_peft_model is handed the selectors for
     # text models too, so an all-false text run fails there where CUDA would ignore them.
     from core.training.worker import _check_mlx_finetune_targets
-
     config = _config(**{**_ALL_OFF, "finetune_language_layers": True})
 
     with pytest.raises(ValueError, match = "Nothing to train"):
@@ -190,21 +184,18 @@ def test_mlx_allows_empty_layer_family_when_a_module_type_is_on():
     # The caller back-fills finetune_language_layers when a module type is selected, so this
     # trains fine and must not be rejected -- the CUDA guard would reject the same config.
     from core.training.worker import _check_mlx_finetune_targets
-
     config = _config(**{**_ALL_OFF, "finetune_attention_modules": True})
     _check_mlx_finetune_targets(config)
 
 
 def test_mlx_allows_defaults():
     from core.training.worker import _check_mlx_finetune_targets
-
     _check_mlx_finetune_targets(_config())
 
 
 def test_cuda_rejects_empty_layer_family():
     # get_peft_regex's first guard, which the MLX back-fill makes unreachable there.
     from core.training.worker import _check_finetune_targets_after_detect
-
     config = _config(**{**_ALL_OFF, "finetune_attention_modules": True})
 
     with pytest.raises(ValueError, match = "Nothing to train"):
@@ -213,5 +204,4 @@ def test_cuda_rejects_empty_layer_family():
 
 def test_cuda_text_run_is_untouched_by_either_guard():
     from core.training.worker import _check_finetune_targets_after_detect
-
     _check_finetune_targets_after_detect(_Trainer(), _config(**_ALL_OFF))

--- a/studio/backend/tests/test_training_finetune_targets.py
+++ b/studio/backend/tests/test_training_finetune_targets.py
@@ -26,9 +26,10 @@ def test_lora_targets_default_on():
     assert request.finetune_vision_layers is False
 
 
-def test_lora_with_no_targets_is_rejected():
+def test_vision_lora_with_no_targets_is_rejected():
     with pytest.raises(ValidationError, match = "Nothing to train"):
         _request(
+            is_dataset_image = True,
             finetune_vision_layers = False,
             finetune_language_layers = False,
             finetune_attention_modules = False,
@@ -36,8 +37,34 @@ def test_lora_with_no_targets_is_rejected():
         )
 
 
+def test_text_lora_with_no_targets_is_allowed():
+    # Only the VLM path reads these four selectors; a text LoRA run builds its
+    # adapters from target_modules, so an all-false request still trains.
+    request = _request(
+        finetune_vision_layers = False,
+        finetune_language_layers = False,
+        finetune_attention_modules = False,
+        finetune_mlp_modules = False,
+    )
+
+    assert request.finetune_language_layers is False
+
+
+def test_continued_pretraining_with_no_targets_is_allowed():
+    request = _request(
+        training_type = "Continued Pretraining",
+        finetune_vision_layers = False,
+        finetune_language_layers = False,
+        finetune_attention_modules = False,
+        finetune_mlp_modules = False,
+    )
+
+    assert request.training_type == "Continued Pretraining"
+
+
 def test_vision_only_target_is_enough():
     request = _request(
+        is_dataset_image = True,
         finetune_vision_layers = True,
         finetune_language_layers = False,
         finetune_attention_modules = False,

--- a/studio/backend/tests/test_training_finetune_targets.py
+++ b/studio/backend/tests/test_training_finetune_targets.py
@@ -26,10 +26,8 @@ def test_lora_targets_default_on():
 
 
 def test_request_layer_does_not_guess_the_branch():
-    # Whether these four are read at all depends on the model, which the request cannot see:
-    # a vision-capable model makes it a VLM run, a plain text model does not, and an audio
-    # dataset may be an audio VLM or a codec. Every combination is accepted here and settled
-    # in the worker once detection has run (tests below).
+    # Whether these four are read at all depends on the model, which the request cannot see,
+    # so every combination is accepted here and settled in the worker after detection.
     for flags in (
         {},
         {"is_dataset_image": True},
@@ -148,9 +146,8 @@ def test_worker_exempts_full_finetuning():
 
 
 def test_worker_rejection_is_not_mistaken_for_a_cache_problem():
-    # _pre_detect_training_model's caller funnels exceptions through the incomplete-cache
-    # fallback when the model is local-only. This error must not look like a cache artifact
-    # error, or a nothing-to-train run would be retried as a corrupt-download instead.
+    # The caller funnels exceptions through the incomplete-cache fallback for a local-only
+    # model, so a nothing-to-train run must not read as a corrupt download and get retried.
     from core.training.worker import _is_model_cache_artifact_error
     error = ValueError(
         "Nothing to train: select at least one layer family (finetune_language_layers or "

--- a/studio/backend/tests/test_training_finetune_targets.py
+++ b/studio/backend/tests/test_training_finetune_targets.py
@@ -80,6 +80,46 @@ def test_image_tagged_continued_pretraining_with_no_targets_is_allowed():
     assert request.is_dataset_image is True
 
 
+def test_audio_vlm_with_no_targets_is_rejected():
+    # trainer.is_audio_vlm is set from is_dataset_audio alone and its branch forwards all
+    # four selectors to FastModel.get_peft_model, so an audio run with none enabled must be
+    # rejected here rather than crashing in get_peft_regex after the model is loaded.
+    with pytest.raises(ValidationError, match = "Nothing to train"):
+        _request(
+            is_dataset_audio = True,
+            finetune_vision_layers = False,
+            finetune_language_layers = False,
+            finetune_attention_modules = False,
+            finetune_mlp_modules = False,
+        )
+
+
+def test_audio_lora_with_one_target_is_allowed():
+    request = _request(
+        is_dataset_audio = True,
+        finetune_vision_layers = False,
+        finetune_language_layers = True,
+        finetune_attention_modules = False,
+        finetune_mlp_modules = True,
+    )
+
+    assert request.is_dataset_audio is True
+
+
+def test_audio_tagged_continued_pretraining_with_no_targets_is_allowed():
+    # training_type exempts CPT before the dataset gate, for audio as for image.
+    request = _request(
+        training_type = "Continued Pretraining",
+        is_dataset_audio = True,
+        finetune_vision_layers = False,
+        finetune_language_layers = False,
+        finetune_attention_modules = False,
+        finetune_mlp_modules = False,
+    )
+
+    assert request.is_dataset_audio is True
+
+
 def test_vision_only_target_is_enough():
     request = _request(
         is_dataset_image = True,

--- a/studio/backend/tests/test_training_finetune_targets.py
+++ b/studio/backend/tests/test_training_finetune_targets.py
@@ -148,7 +148,11 @@ def test_full_finetuning_ignores_targets():
 
 
 class _Trainer:
-    def __init__(self, is_vlm = False, is_audio_vlm = False):
+    def __init__(
+        self,
+        is_vlm = False,
+        is_audio_vlm = False,
+    ):
         self.is_vlm = is_vlm
         self.is_audio_vlm = is_audio_vlm
 
@@ -169,38 +173,31 @@ _ALL_OFF = {
 
 def test_worker_rejects_audio_vlm_with_no_targets():
     from core.training.worker import _check_finetune_targets_after_detect
-
     with pytest.raises(ValueError, match = "Nothing to train"):
-        _check_finetune_targets_after_detect(
-            _Trainer(is_audio_vlm = True), _config(**_ALL_OFF)
-        )
+        _check_finetune_targets_after_detect(_Trainer(is_audio_vlm = True), _config(**_ALL_OFF))
 
 
 def test_worker_allows_codec_audio_with_no_targets():
     # csm / snac / whisper / bicodec / dac leave is_audio_vlm False and build adapters from
     # target_modules, so an all-false request is valid and must not be rejected.
     from core.training.worker import _check_finetune_targets_after_detect
-
     _check_finetune_targets_after_detect(_Trainer(), _config(**_ALL_OFF))
 
 
 def test_worker_rejects_vision_vlm_with_no_targets():
     from core.training.worker import _check_finetune_targets_after_detect
-
     with pytest.raises(ValueError, match = "Nothing to train"):
         _check_finetune_targets_after_detect(_Trainer(is_vlm = True), _config(**_ALL_OFF))
 
 
 def test_worker_allows_audio_vlm_with_one_target():
     from core.training.worker import _check_finetune_targets_after_detect
-
     config = _config(**{**_ALL_OFF, "finetune_mlp_modules": True})
     _check_finetune_targets_after_detect(_Trainer(is_audio_vlm = True), config)
 
 
 def test_worker_allows_vision_only_target():
     from core.training.worker import _check_finetune_targets_after_detect
-
     config = _config(**{**_ALL_OFF, "finetune_vision_layers": True})
     _check_finetune_targets_after_detect(_Trainer(is_vlm = True), config)
 
@@ -209,20 +206,17 @@ def test_worker_defaults_count_as_selected():
     # An omitted selector defaults on for the three language-side flags, so a config that
     # simply does not mention them must not be read as "nothing selected".
     from core.training.worker import _check_finetune_targets_after_detect
-
     _check_finetune_targets_after_detect(_Trainer(is_audio_vlm = True), _config())
 
 
 def test_worker_exempts_continued_pretraining():
     from core.training.worker import _check_finetune_targets_after_detect
-
     config = _config(training_type = "Continued Pretraining", **_ALL_OFF)
     _check_finetune_targets_after_detect(_Trainer(is_audio_vlm = True), config)
 
 
 def test_worker_exempts_full_finetuning():
     from core.training.worker import _check_finetune_targets_after_detect
-
     config = _config(training_type = "Full Finetuning", **_ALL_OFF)
     _check_finetune_targets_after_detect(_Trainer(is_vlm = True), config)
 
@@ -232,7 +226,6 @@ def test_worker_rejection_is_not_mistaken_for_a_cache_problem():
     # fallback when the model is local-only. This error must not look like a cache artifact
     # error, or a nothing-to-train run would be retried as a corrupt-download instead.
     from core.training.worker import _is_model_cache_artifact_error
-
     error = ValueError(
         "Nothing to train: enable at least one of finetune_language_layers, "
         "finetune_attention_modules, finetune_mlp_modules, or finetune_vision_layers."

--- a/studio/backend/tests/test_training_finetune_targets_matrix.py
+++ b/studio/backend/tests/test_training_finetune_targets_matrix.py
@@ -30,8 +30,7 @@ from models import TrainingStartRequest
 TRAINING_TYPES = ("LoRA/QLoRA", "Full Finetuning", "Continued Pretraining")
 
 # The branch pre_detect settles on. Only "vlm" and "audio_vlm" forward the selectors on CUDA;
-# see trainer.prepare_model_for_training, whose codec/whisper/snac/text arms pass target_modules
-# and never the four.
+# prepare_model_for_training's other arms pass target_modules and never the four.
 BRANCHES = ("text", "vlm", "audio_vlm", "codec", "whisper", "snac")
 _CUDA_BRANCHES_READING_SELECTORS = ("vlm", "audio_vlm")
 

--- a/studio/backend/tests/test_training_finetune_targets_matrix.py
+++ b/studio/backend/tests/test_training_finetune_targets_matrix.py
@@ -19,6 +19,7 @@ import pytest
 from core.training.worker import (
     _check_finetune_targets_after_detect,
     _check_mlx_finetune_targets,
+    _check_mlx_effective_targets,
     _names_a_cpt_target,
     _finetune_selectors,
     _pre_detect_training_model,
@@ -509,3 +510,89 @@ def test_the_error_names_every_field_the_caller_has_to_set():
     for field in TrainingStartRequest.model_fields:
         if field.startswith("finetune_"):
             assert field in message
+
+
+def test_mlx_reads_the_vision_selector_with_the_mlx_default_not_the_cuda_one():
+    """A config that never carried the selectors at all must not be waved through.
+
+    `_finetune_selectors` answers an omitted key with the CUDA consumer's default, and for
+    vision that is True. The MLX call site defaults it False and forces it False outright
+    for a text model, so taking True from a missing key would let every legacy config -- the
+    ones written before these fields existed -- past the guard with nothing to train.
+    """
+    config = {
+        "training_type": "LoRA/QLoRA",
+        "target_modules": ["Wqkv"],
+        "finetune_language_layers": False,
+        "finetune_attention_modules": False,
+        "finetune_mlp_modules": False,
+        # finetune_vision_layers deliberately absent.
+    }
+    assert _finetune_selectors(config)[0] is True, "the helper still reports the CUDA default"
+
+    with pytest.raises(ValueError, match = "Nothing to train"):
+        _check_mlx_finetune_targets(config)
+
+
+def test_the_preflight_still_lets_a_vision_only_selection_through():
+    """It runs before detection, so it cannot tell a VLM from a text model. A VLM whose
+    vision tower is the only thing selected does train, and refusing it here would turn a
+    working run away; `_check_mlx_effective_targets` settles it once is_vlm is known."""
+    config = {
+        "training_type": "LoRA/QLoRA",
+        "target_modules": ["Wqkv"],
+        "finetune_vision_layers": True,
+        "finetune_language_layers": False,
+        "finetune_attention_modules": False,
+        "finetune_mlp_modules": False,
+    }
+
+    _check_mlx_finetune_targets(config)
+
+
+def test_the_effective_check_refuses_a_text_run_whose_only_selection_was_vision():
+    """The call site has already forced vision False for a text model and run the language
+    back-fill, so both layer families are off and get_peft_model would apply no adapter at
+    all -- a warning, and a model with no trainable parameters."""
+    config = {"training_type": "LoRA/QLoRA", "target_modules": ["Wqkv"]}
+
+    with pytest.raises(ValueError, match = "Nothing to train"):
+        _check_mlx_effective_targets(
+            config, finetune_language = False, finetune_vision = False
+        )
+
+
+@pytest.mark.parametrize(
+    "language, vision", [(True, False), (False, True), (True, True)]
+)
+def test_the_effective_check_passes_whenever_a_layer_family_survives(language, vision):
+    config = {"training_type": "LoRA/QLoRA", "target_modules": ["Wqkv"]}
+
+    _check_mlx_effective_targets(
+        config, finetune_language = language, finetune_vision = vision
+    )
+
+
+@pytest.mark.parametrize("target_modules", [["lm_head"], ["embed_tokens"], ["all-linear", "lm_head"]])
+def test_the_effective_check_still_spares_a_cpt_target(target_modules):
+    """embed_tokens and lm_head train on the CPT path with both layer families off."""
+    config = {"training_type": "LoRA/QLoRA", "target_modules": target_modules}
+
+    _check_mlx_effective_targets(config, finetune_language = False, finetune_vision = False)
+
+
+def test_the_effective_check_runs_after_the_back_fill_at_the_mlx_call_site():
+    """Structural. Asked before the back-fill it would refuse runs that go on to train, and
+    asked before `finetune_vision` is narrowed by is_vlm it is just the preflight again."""
+    import inspect
+
+    from core.training import worker
+
+    source = inspect.getsource(worker)
+    call = source.index("_check_mlx_effective_targets(\n            config,")
+    backfill = source.index("            finetune_language = True")
+    forced = source.index('config.get("finetune_vision_layers", False) if is_vlm else False')
+    assert forced < backfill < call, (
+        "the effective check must follow both the is_vlm narrowing and the back-fill"
+    )
+    assert call < source.index("FastMLXModel.get_peft_model("), "and precede the loader"

--- a/studio/backend/tests/test_training_finetune_targets_matrix.py
+++ b/studio/backend/tests/test_training_finetune_targets_matrix.py
@@ -1,0 +1,480 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Full [training type] x [model branch] x [worker] x [selector combination] sweep.
+
+The four finetune_* selectors are read by exactly two branches on CUDA (vision VLM and audio
+VLM) and by every LoRA branch on MLX, and every other branch builds its adapter from
+target_modules alone. This file pins that map so a guard cannot start firing on a branch that
+never read the selectors, which would turn a previously working run into a hard error.
+"""
+
+import ast
+import inspect
+import itertools
+import textwrap
+
+import pytest
+
+from core.training.worker import (
+    _check_finetune_targets_after_detect,
+    _check_mlx_finetune_targets,
+    _finetune_selectors,
+    _pre_detect_training_model,
+    _requests_all_linear,
+    _run_mlx_training,
+)
+from models import TrainingStartRequest
+
+
+TRAINING_TYPES = ("LoRA/QLoRA", "Full Finetuning", "Continued Pretraining")
+
+# The branch pre_detect settles on. Only "vlm" and "audio_vlm" forward the selectors on CUDA;
+# see trainer.prepare_model_for_training, whose codec/whisper/snac/text arms pass target_modules
+# and never the four.
+BRANCHES = ("text", "vlm", "audio_vlm", "codec", "whisper", "snac")
+_CUDA_BRANCHES_READING_SELECTORS = ("vlm", "audio_vlm")
+
+SELECTOR_CASES = {
+    "omitted": {},
+    "all_false": {
+        "finetune_vision_layers": False,
+        "finetune_language_layers": False,
+        "finetune_attention_modules": False,
+        "finetune_mlp_modules": False,
+    },
+    "all_true": {
+        "finetune_vision_layers": True,
+        "finetune_language_layers": True,
+        "finetune_attention_modules": True,
+        "finetune_mlp_modules": True,
+    },
+    "mlp_only": {
+        "finetune_vision_layers": False,
+        "finetune_language_layers": False,
+        "finetune_attention_modules": False,
+        "finetune_mlp_modules": True,
+    },
+    "vision_only": {
+        "finetune_vision_layers": True,
+        "finetune_language_layers": False,
+        "finetune_attention_modules": False,
+        "finetune_mlp_modules": False,
+    },
+    "vision_and_attention": {
+        "finetune_vision_layers": True,
+        "finetune_language_layers": False,
+        "finetune_attention_modules": True,
+        "finetune_mlp_modules": False,
+    },
+    "language_and_mlp": {
+        "finetune_vision_layers": False,
+        "finetune_language_layers": True,
+        "finetune_attention_modules": False,
+        "finetune_mlp_modules": True,
+    },
+}
+
+
+_DEFAULT_LEAVES = ["q_proj", "k_proj", "v_proj", "o_proj", "gate_proj", "up_proj", "down_proj"]
+
+# target_modules changes which guard applies at all: "all-linear" turns every selector on
+# inside get_peft_model, and MLX's filter only strips names it recognises as attention or MLP.
+TARGET_MODULE_CASES = {
+    "unset": None,
+    "empty": [],
+    "all_linear": ["all-linear"],
+    "all_linear_plus_lm_head": ["all-linear", "lm_head"],
+    "lm_head": ["lm_head"],
+    "embed_tokens": ["embed_tokens"],
+    "fused_qkv": ["Wqkv"],
+    "architecture_specific": ["c_fc"],
+    "defaults": list(_DEFAULT_LEAVES),
+}
+
+
+class _Trainer:
+    """Stands in for the detection result pre_detect leaves on the trainer."""
+
+    def __init__(self, branch: str):
+        self.is_vlm = branch == "vlm"
+        self.is_audio_vlm = branch == "audio_vlm"
+        self._audio_type = {
+            "codec": "csm",
+            "whisper": "whisper",
+            "snac": "snac",
+        }.get(branch)
+
+
+def _request_config(
+    training_type: str, branch: str, selectors: dict, target_modules = None
+) -> dict:
+    """Build the worker config the way /training/start does: through the request model, so
+    an omitted field arrives as the request model's default rather than as a missing key."""
+    request = TrainingStartRequest(
+        model_name = "unsloth/Llama-3.2-1B-Instruct",
+        training_type = training_type,
+        format_type = "alpaca",
+        target_modules = target_modules,
+        **selectors,
+    )
+    # The route sends an empty list through as None, so the worker never sees a falsy list.
+    config = {
+        "training_type": training_type,
+        "target_modules": request.target_modules if request.target_modules else None,
+    }
+    for field in (
+        "finetune_vision_layers",
+        "finetune_language_layers",
+        "finetune_attention_modules",
+        "finetune_mlp_modules",
+    ):
+        config[field] = getattr(request, field)
+    if branch == "vlm":
+        config["is_dataset_image"] = True
+    if branch in ("audio_vlm", "codec", "whisper", "snac"):
+        config["is_dataset_audio"] = True
+    return config
+
+
+def _cuda_guard_fires(config: dict, branch: str) -> bool:
+    try:
+        _check_finetune_targets_after_detect(_Trainer(branch), config)
+    except ValueError:
+        return True
+    return False
+
+
+def _mlx_guard_fires(config: dict) -> bool:
+    if config.get("training_type", "LoRA/QLoRA") != "LoRA/QLoRA":
+        return False  # the call site at _run_mlx_training sits under `if use_lora`
+    try:
+        _check_mlx_finetune_targets(config)
+    except ValueError:
+        return True
+    return False
+
+
+def _cuda_targets(config: dict, branch: str) -> str:
+    """The adapter target set the CUDA worker ends up with, once the guard has passed."""
+    training_type = config["training_type"]
+    if training_type == "Full Finetuning":
+        return "no adapter (full finetuning)"
+    if training_type == "Continued Pretraining":
+        return "target_modules only (q,k,v,o,gate,up,down,lm_head)"
+    if branch not in _CUDA_BRANCHES_READING_SELECTORS:
+        return "target_modules only (selectors ignored)"
+    if _requests_all_linear(config):
+        return "every linear layer (all-linear forces the selectors on)"
+    vision, language, attention, mlp = _finetune_selectors(config)
+    families = [name for name, on in (("vision", vision), ("language", language)) if on]
+    modules = [name for name, on in (("attention", attention), ("mlp", mlp)) if on]
+    return f"regex over {'+'.join(families)} x {'+'.join(modules)}"
+
+
+def _mlx_targets(config: dict) -> str:
+    training_type = config["training_type"]
+    if training_type != "LoRA/QLoRA":
+        return "no adapter (MLX applies LoRA only for LoRA/QLoRA)"
+    is_vlm = bool(config.get("is_dataset_image", False))
+    _, language, attention, mlp = _finetune_selectors(config)
+    explicit = config.get("target_modules")
+    if explicit and not (attention or mlp):
+        # The filter drops only recognised attention and MLP leaves; whatever is left trains.
+        return f"whatever survives the filter of {list(explicit)}"
+    vision = bool(config.get("finetune_vision_layers", False)) if is_vlm else False
+    if (attention or mlp) and not language and not vision:
+        language = True  # the back-fill at the MLX LoRA branch
+    families = [name for name, on in (("vision", vision), ("language", language)) if on]
+    modules = [name for name, on in (("attention", attention), ("mlp", mlp)) if on]
+    return f"{'+'.join(families)} x {'+'.join(modules)}"
+
+
+@pytest.mark.parametrize("training_type", TRAINING_TYPES)
+@pytest.mark.parametrize("branch", BRANCHES)
+@pytest.mark.parametrize("selector_case", sorted(SELECTOR_CASES))
+@pytest.mark.parametrize("targets_case", sorted(TARGET_MODULE_CASES))
+def test_cuda_guard_only_fires_where_the_selectors_are_read(
+    training_type, branch, selector_case, targets_case
+):
+    config = _request_config(
+        training_type,
+        branch,
+        SELECTOR_CASES[selector_case],
+        TARGET_MODULE_CASES[targets_case],
+    )
+    vision, language, attention, mlp = _finetune_selectors(config)
+
+    expected = (
+        training_type == "LoRA/QLoRA"
+        and branch in _CUDA_BRANCHES_READING_SELECTORS
+        and not _requests_all_linear(config)
+        and (not (vision or language) or not (attention or mlp))
+    )
+
+    assert _cuda_guard_fires(config, branch) is expected
+    if not expected:
+        assert _cuda_targets(config, branch)
+
+
+@pytest.mark.parametrize("training_type", TRAINING_TYPES)
+@pytest.mark.parametrize("branch", BRANCHES)
+@pytest.mark.parametrize("selector_case", sorted(SELECTOR_CASES))
+@pytest.mark.parametrize("targets_case", sorted(TARGET_MODULE_CASES))
+def test_mlx_guard_only_fires_on_an_empty_module_selection(
+    training_type, branch, selector_case, targets_case
+):
+    config = _request_config(
+        training_type,
+        branch,
+        SELECTOR_CASES[selector_case],
+        TARGET_MODULE_CASES[targets_case],
+    )
+    _, _, attention, mlp = _finetune_selectors(config)
+
+    expected = (
+        training_type == "LoRA/QLoRA"
+        and not config.get("target_modules")
+        and not (attention or mlp)
+    )
+
+    assert _mlx_guard_fires(config) is expected
+
+
+@pytest.mark.parametrize("branch", BRANCHES)
+def test_omitted_selectors_never_trip_either_guard(branch):
+    """The headline of the default flip: a caller that sends none of the four now trains
+    the language attention and MLP modules on every branch instead of failing."""
+    for training_type in TRAINING_TYPES:
+        config = _request_config(training_type, branch, {})
+
+        assert _cuda_guard_fires(config, branch) is False
+        assert _mlx_guard_fires(config) is False
+
+    lora = _request_config("LoRA/QLoRA", branch, {})
+    if branch in _CUDA_BRANCHES_READING_SELECTORS:
+        assert _cuda_targets(lora, branch) == "regex over language x attention+mlp"
+    else:
+        assert _cuda_targets(lora, branch) == "target_modules only (selectors ignored)"
+    assert _mlx_targets(lora) == "language x attention+mlp"
+
+
+def test_pre_pr_omitted_selectors_would_have_been_rejected_on_a_vlm():
+    """What the flip fixes. Before it, the request model defaulted all three language-side
+    selectors False, so an API caller that omitted them reached get_peft_regex with nothing
+    selected and got "No layers to finetune" only after the weights were resident."""
+    pre_pr = {
+        "training_type": "LoRA/QLoRA",
+        "finetune_vision_layers": False,
+        "finetune_language_layers": False,
+        "finetune_attention_modules": False,
+        "finetune_mlp_modules": False,
+    }
+
+    assert _cuda_guard_fires(pre_pr, "vlm") is True
+    assert _cuda_guard_fires(pre_pr, "audio_vlm") is True
+    assert _cuda_guard_fires(pre_pr, "text") is False
+
+
+def test_every_selector_combination_is_covered_by_a_named_case():
+    covered = {
+        tuple(
+            case.get(field, None)
+            for field in (
+                "finetune_vision_layers",
+                "finetune_language_layers",
+                "finetune_attention_modules",
+                "finetune_mlp_modules",
+            )
+        )
+        for name, case in SELECTOR_CASES.items()
+        if name != "omitted"
+    }
+    all_combinations = set(itertools.product((False, True), repeat = 4))
+
+    assert covered <= all_combinations
+
+
+@pytest.mark.parametrize("flags", list(itertools.product((False, True), repeat = 4)))
+def test_cuda_guard_matches_get_peft_regex_for_the_whole_product(flags):
+    """Exhaustive 2^4. get_peft_regex raises unless a layer family AND a module type is on
+    (unsloth_zoo/peft_utils.py: "No layers to finetune" / "No modules to finetune"), and the
+    guard must fire on exactly that set, never wider."""
+    vision, language, attention, mlp = flags
+    config = {
+        "training_type": "LoRA/QLoRA",
+        "finetune_vision_layers": vision,
+        "finetune_language_layers": language,
+        "finetune_attention_modules": attention,
+        "finetune_mlp_modules": mlp,
+    }
+    get_peft_regex_would_raise = not (vision or language) or not (attention or mlp)
+
+    assert _cuda_guard_fires(config, "vlm") is get_peft_regex_would_raise
+
+
+# --- defaults for a config that never went through the request model ---
+
+
+def test_selector_defaults_match_the_cuda_consumer():
+    """A config assembled outside the request model (an old job record, the CLI adapter)
+    can omit the keys entirely. 4d reads all four with config.get(..., True), so a guard that
+    read finetune_vision_layers as False would reject a vision-only run that trains fine."""
+    assert _finetune_selectors({}) == (True, True, True, True)
+
+
+def test_vision_only_run_with_missing_keys_is_not_rejected():
+    config = {
+        "training_type": "LoRA/QLoRA",
+        "finetune_language_layers": False,
+        "finetune_attention_modules": True,
+        "finetune_mlp_modules": False,
+    }
+
+    _check_finetune_targets_after_detect(_Trainer("vlm"), config)
+
+
+# --- call sites, so deleting the wiring fails a test ---
+
+
+def _fake_trainer_with_detect(branch: str):
+    trainer = _Trainer(branch)
+    trainer.pre_detect_calls = []
+
+    def pre_detect_and_load_tokenizer(**kwargs):
+        trainer.pre_detect_calls.append(kwargs)
+
+    trainer.pre_detect_and_load_tokenizer = pre_detect_and_load_tokenizer
+    return trainer
+
+
+def test_pre_detect_training_model_runs_the_guard():
+    trainer = _fake_trainer_with_detect("vlm")
+    config = {
+        "training_type": "LoRA/QLoRA",
+        "max_seq_length": 2048,
+        **SELECTOR_CASES["all_false"],
+    }
+
+    with pytest.raises(ValueError, match = "Nothing to train"):
+        _pre_detect_training_model(trainer, config, "model", None, "model", False)
+
+    # Detection still ran first: the guard needs the branch it settles.
+    assert len(trainer.pre_detect_calls) == 1
+
+
+def test_pre_detect_training_model_leaves_a_valid_run_alone():
+    trainer = _fake_trainer_with_detect("vlm")
+    config = {"training_type": "LoRA/QLoRA", "max_seq_length": 2048}
+
+    _pre_detect_training_model(trainer, config, "model", None, "model", False)
+
+    assert len(trainer.pre_detect_calls) == 1
+
+
+def test_mlx_worker_calls_the_guard_in_its_lora_branch():
+    """_run_mlx_training imports mlx, so it cannot be invoked off Apple Silicon. Pin the call
+    site structurally instead: inside `if use_lora:` and above the from_pretrained below it."""
+    source = textwrap.dedent(inspect.getsource(_run_mlx_training))
+    tree = ast.parse(source)
+    calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "_check_mlx_finetune_targets"
+    ]
+
+    assert len(calls) == 1
+
+    guarded = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.If)
+        and isinstance(node.test, ast.Name)
+        and node.test.id == "use_lora"
+        and any(call in ast.walk(node) for call in calls)
+    ]
+
+    assert guarded, "_check_mlx_finetune_targets must sit under `if use_lora:`"
+
+    from_pretrained_lines = [
+        node.lineno
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "from_pretrained"
+    ]
+
+    assert from_pretrained_lines
+    assert calls[0].lineno < min(from_pretrained_lines)
+
+
+# --- the guard must never be stricter than the code it guards ---
+
+
+def test_all_linear_vlm_run_with_the_selectors_off_is_not_rejected():
+    """prepare_model_for_training collapses ["all-linear"] to the bare keyword, and
+    get_peft_model forces all five selectors True for it, so this trains every linear layer.
+    Rejecting it would break a working request, and a resumed run can carry it: target_modules
+    is one of the resume structure fields restored from the stored config."""
+    for branch in _CUDA_BRANCHES_READING_SELECTORS:
+        config = _request_config("LoRA/QLoRA", branch, SELECTOR_CASES["all_false"], ["all-linear"])
+
+        _check_finetune_targets_after_detect(_Trainer(branch), config)
+
+
+def test_all_linear_as_a_bare_string_is_recognised_too():
+    config = {
+        "training_type": "LoRA/QLoRA",
+        "target_modules": "all-linear",
+        **SELECTOR_CASES["all_false"],
+    }
+
+    _check_finetune_targets_after_detect(_Trainer("vlm"), config)
+
+
+def test_all_linear_alongside_other_leaves_is_not_the_keyword():
+    """The caller strips "all-linear" out of a longer list and keeps the rest, so the
+    selectors do apply and an empty selection is still nothing to train."""
+    config = _request_config(
+        "LoRA/QLoRA", "vlm", SELECTOR_CASES["all_false"], ["all-linear", "lm_head"]
+    )
+
+    assert _requests_all_linear(config) is False
+    with pytest.raises(ValueError, match = "Nothing to train"):
+        _check_finetune_targets_after_detect(_Trainer("vlm"), config)
+
+
+@pytest.mark.parametrize(
+    "target_modules",
+    [["lm_head"], ["embed_tokens"], ["Wqkv"], ["c_fc"], ["all-linear"], ["lm_head", "Wqkv"]],
+)
+def test_mlx_keeps_targets_outside_the_attention_and_mlp_sets(target_modules):
+    """FastMLXModel filters target_modules by the two module flags, but only drops names it
+    recognises as attention or MLP leaves. Anything else survives with both flags off and
+    trains, so the preflight must not refuse it."""
+    config = _request_config("LoRA/QLoRA", "text", SELECTOR_CASES["all_false"], target_modules)
+
+    _check_mlx_finetune_targets(config)
+
+
+def test_mlx_still_rejects_an_empty_module_selection_on_the_defaults():
+    config = _request_config("LoRA/QLoRA", "text", SELECTOR_CASES["all_false"], None)
+
+    with pytest.raises(ValueError, match = "Nothing to train"):
+        _check_mlx_finetune_targets(config)
+
+
+def test_the_error_names_every_field_the_caller_has_to_set():
+    """An all-false request has to be actionable: the message must name the four request
+    fields, not the internal flag names, so an API caller can fix it without reading source."""
+    config = _request_config("LoRA/QLoRA", "vlm", SELECTOR_CASES["all_false"], None)
+
+    with pytest.raises(ValueError) as excinfo:
+        _check_finetune_targets_after_detect(_Trainer("vlm"), config)
+
+    message = str(excinfo.value)
+    for field in TrainingStartRequest.model_fields:
+        if field.startswith("finetune_"):
+            assert field in message

--- a/studio/backend/tests/test_training_finetune_targets_matrix.py
+++ b/studio/backend/tests/test_training_finetune_targets_matrix.py
@@ -243,9 +243,7 @@ def test_mlx_guard_only_fires_on_an_empty_module_selection(
     if not targets:
         empty = not (attention or mlp)
     else:
-        empty = not _names_a_cpt_target(targets) and not (
-            attention or mlp or language or vision
-        )
+        empty = not _names_a_cpt_target(targets) and not (attention or mlp or language or vision)
     expected = training_type == "LoRA/QLoRA" and empty
 
     assert _mlx_guard_fires(config) is expected
@@ -456,9 +454,7 @@ def test_all_linear_alongside_other_leaves_is_not_the_keyword():
         _check_finetune_targets_after_detect(_Trainer("vlm"), config)
 
 
-@pytest.mark.parametrize(
-    "target_modules", [["lm_head"], ["embed_tokens"], ["lm_head", "Wqkv"]]
-)
+@pytest.mark.parametrize("target_modules", [["lm_head"], ["embed_tokens"], ["lm_head", "Wqkv"]])
 def test_mlx_keeps_a_target_the_loader_trains_whatever_the_flags_say(target_modules):
     """embed_tokens and lm_head go down get_peft_model's CPT path, where the full module and
     the head adapter are applied without consulting the layer families. Something trains, so

--- a/studio/backend/tests/test_training_finetune_targets_matrix.py
+++ b/studio/backend/tests/test_training_finetune_targets_matrix.py
@@ -557,23 +557,19 @@ def test_the_effective_check_refuses_a_text_run_whose_only_selection_was_vision(
     config = {"training_type": "LoRA/QLoRA", "target_modules": ["Wqkv"]}
 
     with pytest.raises(ValueError, match = "Nothing to train"):
-        _check_mlx_effective_targets(
-            config, finetune_language = False, finetune_vision = False
-        )
+        _check_mlx_effective_targets(config, finetune_language = False, finetune_vision = False)
 
 
-@pytest.mark.parametrize(
-    "language, vision", [(True, False), (False, True), (True, True)]
-)
+@pytest.mark.parametrize("language, vision", [(True, False), (False, True), (True, True)])
 def test_the_effective_check_passes_whenever_a_layer_family_survives(language, vision):
     config = {"training_type": "LoRA/QLoRA", "target_modules": ["Wqkv"]}
 
-    _check_mlx_effective_targets(
-        config, finetune_language = language, finetune_vision = vision
-    )
+    _check_mlx_effective_targets(config, finetune_language = language, finetune_vision = vision)
 
 
-@pytest.mark.parametrize("target_modules", [["lm_head"], ["embed_tokens"], ["all-linear", "lm_head"]])
+@pytest.mark.parametrize(
+    "target_modules", [["lm_head"], ["embed_tokens"], ["all-linear", "lm_head"]]
+)
 def test_the_effective_check_still_spares_a_cpt_target(target_modules):
     """embed_tokens and lm_head train on the CPT path with both layer families off."""
     config = {"training_type": "LoRA/QLoRA", "target_modules": target_modules}
@@ -592,7 +588,7 @@ def test_the_effective_check_runs_after_the_back_fill_at_the_mlx_call_site():
     call = source.index("_check_mlx_effective_targets(\n            config,")
     backfill = source.index("            finetune_language = True")
     forced = source.index('config.get("finetune_vision_layers", False) if is_vlm else False')
-    assert forced < backfill < call, (
-        "the effective check must follow both the is_vlm narrowing and the back-fill"
-    )
+    assert (
+        forced < backfill < call
+    ), "the effective check must follow both the is_vlm narrowing and the back-fill"
     assert call < source.index("FastMLXModel.get_peft_model("), "and precede the loader"

--- a/studio/backend/tests/test_training_finetune_targets_matrix.py
+++ b/studio/backend/tests/test_training_finetune_targets_matrix.py
@@ -19,6 +19,7 @@ import pytest
 from core.training.worker import (
     _check_finetune_targets_after_detect,
     _check_mlx_finetune_targets,
+    _names_a_cpt_target,
     _finetune_selectors,
     _pre_detect_training_model,
     _requests_all_linear,
@@ -232,13 +233,20 @@ def test_mlx_guard_only_fires_on_an_empty_module_selection(
         SELECTOR_CASES[selector_case],
         TARGET_MODULE_CASES[targets_case],
     )
-    _, _, attention, mlp = _finetune_selectors(config)
+    vision, language, attention, mlp = _finetune_selectors(config)
+    targets = config.get("target_modules")
 
-    expected = (
-        training_type == "LoRA/QLoRA"
-        and not config.get("target_modules")
-        and not (attention or mlp)
-    )
+    # Two rules, because the loader has two. With no explicit list the default seven are
+    # wholly attention and MLP, so an empty module selection leaves nothing. With one, the
+    # module-type filter is not the only gate: the text branch also needs a layer family,
+    # and only a CPT target (embed_tokens / lm_head) trains without one.
+    if not targets:
+        empty = not (attention or mlp)
+    else:
+        empty = not _names_a_cpt_target(targets) and not (
+            attention or mlp or language or vision
+        )
+    expected = training_type == "LoRA/QLoRA" and empty
 
     assert _mlx_guard_fires(config) is expected
 
@@ -449,14 +457,39 @@ def test_all_linear_alongside_other_leaves_is_not_the_keyword():
 
 
 @pytest.mark.parametrize(
-    "target_modules",
-    [["lm_head"], ["embed_tokens"], ["Wqkv"], ["c_fc"], ["all-linear"], ["lm_head", "Wqkv"]],
+    "target_modules", [["lm_head"], ["embed_tokens"], ["lm_head", "Wqkv"]]
 )
-def test_mlx_keeps_targets_outside_the_attention_and_mlp_sets(target_modules):
-    """FastMLXModel filters target_modules by the two module flags, but only drops names it
-    recognises as attention or MLP leaves. Anything else survives with both flags off and
-    trains, so the preflight must not refuse it."""
+def test_mlx_keeps_a_target_the_loader_trains_whatever_the_flags_say(target_modules):
+    """embed_tokens and lm_head go down get_peft_model's CPT path, where the full module and
+    the head adapter are applied without consulting the layer families. Something trains, so
+    the preflight must not refuse these however the four selectors are set."""
     config = _request_config("LoRA/QLoRA", "text", SELECTOR_CASES["all_false"], target_modules)
+
+    _check_mlx_finetune_targets(config)
+
+
+@pytest.mark.parametrize("target_modules", [["Wqkv"], ["c_fc"], ["all-linear"]])
+def test_mlx_refuses_an_all_false_request_whose_targets_need_a_layer_family(target_modules):
+    """Surviving the module-type filter is not the same as training.
+
+    These names are not attention or MLP leaves, so get_peft_model's filter keeps them -- but
+    the text branch then gates the LoRA application on finetune_language_layers, and with all
+    four selectors off the worker's back-fill (which only fires when a module type is on)
+    never turns it back on. The run applies no adapters at all: a warning, and a model with
+    no trainable parameters. A VLM raises, but only after the weights are loaded."""
+    config = _request_config("LoRA/QLoRA", "text", SELECTOR_CASES["all_false"], target_modules)
+
+    with pytest.raises(ValueError, match = "Nothing to train"):
+        _check_mlx_finetune_targets(config)
+
+
+@pytest.mark.parametrize("target_modules", [["Wqkv"], ["c_fc"], ["all-linear"]])
+def test_mlx_keeps_those_same_targets_once_a_layer_family_is_on(target_modules):
+    """The refusal above is about the layer families, not the names. With
+    finetune_language_layers on, the filter keeps these and they train, so refusing here
+    would turn a working run away."""
+    selectors = {**SELECTOR_CASES["all_false"], "finetune_language_layers": True}
+    config = _request_config("LoRA/QLoRA", "text", selectors, target_modules)
 
     _check_mlx_finetune_targets(config)
 

--- a/studio/backend/tests/test_training_finetune_targets_matrix.py
+++ b/studio/backend/tests/test_training_finetune_targets_matrix.py
@@ -107,7 +107,10 @@ class _Trainer:
 
 
 def _request_config(
-    training_type: str, branch: str, selectors: dict, target_modules = None
+    training_type: str,
+    branch: str,
+    selectors: dict,
+    target_modules = None,
 ) -> dict:
     """Build the worker config the way /training/start does: through the request model, so
     an omitted field arrives as the request model's default rather than as a missing key."""

--- a/studio/backend/tests/test_training_finetune_targets_matrix.py
+++ b/studio/backend/tests/test_training_finetune_targets_matrix.py
@@ -239,8 +239,7 @@ def test_mlx_guard_only_fires_on_an_empty_module_selection(
 
     # Two rules, because the loader has two. With no explicit list the default seven are
     # wholly attention and MLP, so an empty module selection leaves nothing. With one, the
-    # module-type filter is not the only gate: the text branch also needs a layer family,
-    # and only a CPT target (embed_tokens / lm_head) trains without one.
+    # text branch also needs a layer family, and only a CPT target trains without one.
     if not targets:
         empty = not (attention or mlp)
     else:
@@ -457,9 +456,9 @@ def test_all_linear_alongside_other_leaves_is_not_the_keyword():
 
 @pytest.mark.parametrize("target_modules", [["lm_head"], ["embed_tokens"], ["lm_head", "Wqkv"]])
 def test_mlx_keeps_a_target_the_loader_trains_whatever_the_flags_say(target_modules):
-    """embed_tokens and lm_head go down get_peft_model's CPT path, where the full module and
-    the head adapter are applied without consulting the layer families. Something trains, so
-    the preflight must not refuse these however the four selectors are set."""
+    """embed_tokens and lm_head go down get_peft_model's CPT path, applied without consulting
+    the layer families. Something trains, so the preflight must not refuse these however the
+    four selectors are set."""
     config = _request_config("LoRA/QLoRA", "text", SELECTOR_CASES["all_false"], target_modules)
 
     _check_mlx_finetune_targets(config)
@@ -516,9 +515,9 @@ def test_mlx_reads_the_vision_selector_with_the_mlx_default_not_the_cuda_one():
     """A config that never carried the selectors at all must not be waved through.
 
     `_finetune_selectors` answers an omitted key with the CUDA consumer's default, and for
-    vision that is True. The MLX call site defaults it False and forces it False outright
-    for a text model, so taking True from a missing key would let every legacy config -- the
-    ones written before these fields existed -- past the guard with nothing to train.
+    vision that is True. The MLX call site defaults it False and forces it False for a text
+    model, so taking True from a missing key would let every config written before these
+    fields existed past the guard with nothing to train.
     """
     config = {
         "training_type": "LoRA/QLoRA",


### PR DESCRIPTION
finetune_language_layers, finetune_attention_modules, and finetune_mlp_modules default to False on TrainingStartRequest. The UI always sends them as True, so nobody hits this. Any API or MCP caller that leaves them out gets a LoRA attached to nothing, even with target_modules set, since these flags pick which modules get adapted.

The rest of the stack already defaults them to True (core/training/trainer.py, core/training/training.py). Only the request model didn't. This matches it, and adds a check that rejects an adapter run with all four turned off. Full Finetuning is unaffected.