### PR TITLE
Repair the two studio test suites #9410 left behind

### DIFF
--- a/tests/studio/test_chat_autoload_failure_gate.py
+++ b/tests/studio/test_chat_autoload_failure_gate.py
@@ -94,6 +94,56 @@ export function sanitizeStoredExtraArgs(
   return [...tokens];
 }
 
+// The llama-server tuning group, mirroring
+// studio/frontend/src/features/chat/lib/server-tuning-fields.ts. Real logic rather
+// than a neutral stub: serverTuningLoadPayload spreads into the /load payload these
+// scenarios assert on, so a stub that always returned {} would keep passing if the
+// real one started sending a field. These are pure and import nothing, so copying
+// them costs only the drift this file already guards against by name.
+export function serverTuningLoadPayload(values: any): any {
+  return {
+    ...(values?.loadMode != null ? { load_mode: values.loadMode } : {}),
+    ...(values?.specDraftCacheDtype != null
+      ? { spec_draft_cache_type: values.specDraftCacheDtype }
+      : {}),
+    ...(values?.ctxCheckpoints != null
+      ? { ctx_checkpoints: values.ctxCheckpoints }
+      : {}),
+    ...(values?.cacheRam != null ? { cache_ram: values.cacheRam } : {}),
+  };
+}
+export function clearedServerTuningState(): any {
+  return {
+    loadMode: null,
+    loadedLoadMode: null,
+    specDraftCacheDtype: null,
+    loadedSpecDraftCacheDtype: null,
+    ctxCheckpoints: null,
+    loadedCtxCheckpoints: null,
+    cacheRam: null,
+    loadedCacheRam: null,
+  };
+}
+export function committedServerTuningState(values: any, isDiffusion = false): any {
+  if (isDiffusion) {
+    return clearedServerTuningState();
+  }
+  const loadMode = values?.loadMode ?? null;
+  const specDraftCacheDtype = values?.specDraftCacheDtype ?? null;
+  const ctxCheckpoints = values?.ctxCheckpoints ?? null;
+  const cacheRam = values?.cacheRam ?? null;
+  return {
+    loadMode,
+    loadedLoadMode: loadMode,
+    specDraftCacheDtype,
+    loadedSpecDraftCacheDtype: specDraftCacheDtype,
+    ctxCheckpoints,
+    loadedCtxCheckpoints: ctxCheckpoints,
+    cacheRam,
+    loadedCacheRam: cacheRam,
+  };
+}
+
 export const EVENTS: any[] = [];
 let SCENARIO: Scenario;
 export function setScenario(scenario: Scenario) {

--- a/tests/studio/test_model_picker_contracts.py
+++ b/tests/studio/test_model_picker_contracts.py
@@ -43,6 +43,40 @@ def _split_args(captured: str) -> list[str]:
     return args
 
 
+def _code_only(source: str) -> str:
+    """``source`` with comments removed and whitespace collapsed.
+
+    A name discussed in prose is not a call. This file's own comments name the
+    functions they explain, so a scan that skipped this would match the sentence.
+    """
+    source = re.sub(r"/\*.*?\*/", " ", source, flags = re.S)
+    source = re.sub(r"//[^\n]*", " ", source)
+    return " ".join(source.split())
+
+
+def _call_arguments(text: str, callee: str) -> list[str]:
+    """The argument text of each ``callee(...)`` call in ``text``, parens balanced.
+
+    Per call, so a contract about what every call passes cannot be satisfied by a
+    matching property somewhere else in the file, nor broken by one. An optional
+    generic parameter list is skipped, since ``f<string>(...)`` is the same call.
+    """
+    calls = []
+    for match in re.finditer(rf"\b{re.escape(callee)}\s*(?:<[^>]*>)?\s*\(", text):
+        depth, start = 0, match.end() - 1
+        for index in range(start, len(text)):
+            if text[index] == "(":
+                depth += 1
+            elif text[index] == ")":
+                depth -= 1
+                if depth == 0:
+                    calls.append(text[start + 1 : index])
+                    break
+        else:
+            raise AssertionError(f"unbalanced parentheses after {callee} at {start}")
+    return calls
+
+
 def _read_backend(rel: str) -> str:
     path = WORKDIR / "studio" / "backend" / rel
     assert path.exists(), f"missing backend source file: {path}"
@@ -2219,13 +2253,20 @@ def test_hydration_clears_the_batch_baselines_for_a_batchless_model():
     # null after it: the batch echo is the REQUESTED size, so clearing it here would also
     # discard the value just adopted from the new model and revert it on the next Reload.
     # EVERY seed is told the same thing from the same local, so none of them can drift
-    # apart. Counted against the number of resolveBatchSizeSeed call sites rather than
-    # hardcoded: the llama-server tuning knobs deliberately reuse this seed, so a fixed
-    # number here fails the next time the group grows while saying nothing about drift,
-    # which is the property actually under test.
-    seed_calls = len(re.findall(r"resolveBatchSizeSeed(?:<[^>]*>)?\(\{", status))
-    assert seed_calls >= 2, "the batch pair alone should be two seeds"
-    assert re.findall(r"modelChanged: (\w+)", status) == ["slotsModelChanged"] * seed_calls
+    # apart. Checked per call site rather than as a count: the llama-server tuning knobs
+    # deliberately reuse this seed, so a hardcoded number fails the next time the group
+    # grows while saying nothing about drift, and a whole-file count of `modelChanged`
+    # would both break on an unrelated one elsewhere and let an unrelated one stand in
+    # for a seed that omitted the property.
+    # Comments stripped first: this file discusses `resolveBatchSizeSeed (modelChanged)`
+    # in prose, and a scan that counted that sentence as a call site would fail on a
+    # wording change.
+    seed_args = _call_arguments(_code_only(src), "resolveBatchSizeSeed")
+    assert len(seed_args) >= 2, "the batch pair alone should be two seeds"
+    for args in seed_args:
+        assert "modelChanged: slotsModelChanged," in args, (
+            f"a resolveBatchSizeSeed call is not told modelChanged from slotsModelChanged: {args}"
+        )
     assert "{ nBatch: null, nUbatch: null }" not in status
     # The remembered override is re-adopted only when the echo proves it.
     assert (

--- a/tests/studio/test_model_picker_contracts.py
+++ b/tests/studio/test_model_picker_contracts.py
@@ -2264,9 +2264,9 @@ def test_hydration_clears_the_batch_baselines_for_a_batchless_model():
     seed_args = _call_arguments(_code_only(src), "resolveBatchSizeSeed")
     assert len(seed_args) >= 2, "the batch pair alone should be two seeds"
     for args in seed_args:
-        assert "modelChanged: slotsModelChanged," in args, (
-            f"a resolveBatchSizeSeed call is not told modelChanged from slotsModelChanged: {args}"
-        )
+        assert (
+            "modelChanged: slotsModelChanged," in args
+        ), f"a resolveBatchSizeSeed call is not told modelChanged from slotsModelChanged: {args}"
     assert "{ nBatch: null, nUbatch: null }" not in status
     # The remembered override is re-adopted only when the echo proves it.
     assert (

--- a/tests/studio/test_model_picker_contracts.py
+++ b/tests/studio/test_model_picker_contracts.py
@@ -2218,7 +2218,14 @@ def test_hydration_clears_the_batch_baselines_for_a_batchless_model():
     # A swap under this tab resets the controls too, but through the seed, not a blanket
     # null after it: the batch echo is the REQUESTED size, so clearing it here would also
     # discard the value just adopted from the new model and revert it on the next Reload.
-    assert status.count("modelChanged: slotsModelChanged,") == 2
+    # EVERY seed is told the same thing from the same local, so none of them can drift
+    # apart. Counted against the number of resolveBatchSizeSeed call sites rather than
+    # hardcoded: the llama-server tuning knobs deliberately reuse this seed, so a fixed
+    # number here fails the next time the group grows while saying nothing about drift,
+    # which is the property actually under test.
+    seed_calls = len(re.findall(r"resolveBatchSizeSeed(?:<[^>]*>)?\(\{", status))
+    assert seed_calls >= 2, "the batch pair alone should be two seeds"
+    assert re.findall(r"modelChanged: (\w+)", status) == ["slotsModelChanged"] * seed_calls
     assert "{ nBatch: null, nUbatch: null }" not in status
     # The remembered override is re-adopted only when the echo proves it.
     assert (


### PR DESCRIPTION
`Repo tests (CPU)` is red on `main` and has been failing every PR that runs it. On a clean checkout of `main` (`e91f9720b`):

```
71 failed
```

All 71 come from #9410 (`5786a0ead`, "Studio: add Mmap/Mlock, draft KV cache dtype, Checkpoints and Cache RAM to Run settings"). The product code from that PR is fine and is not touched here. What did not travel with it was the test-side consequences of two of its changes.

## 1. The sliced-harness stubs (70 failures)

`tests/studio/test_chat_autoload_failure_gate.py` does not import `chat-adapter.ts`. It slices a region out of it, prepends a `PREAMBLE` of stubs, writes `harness.ts` into a temp directory and runs it under node. The temp directory has no module resolution, so every name the sliced region uses has to exist in `PREAMBLE`.

#9410 added three imports to `chat-adapter.ts`:

```
clearedServerTuningState
committedServerTuningState
serverTuningLoadPayload
```

The file's own guard caught this and said exactly what to do:

> the sliced region uses ['clearedServerTuningState', 'committedServerTuningState', 'serverTuningLoadPayload'], imported by chat-adapter.ts but absent from this harness. Add a stub to PREAMBLE, or these scenarios will fail as wrong-model assertions rather than saying what is actually missing.

So the guard worked. Nobody added the stubs.

They are added here mirroring `server-tuning-fields.ts` rather than as neutral no-ops. `serverTuningLoadPayload` spreads into the `/load` payload that these scenarios assert on, so a stub that always returned `{}` would keep passing if the real one started sending a field. The three functions are pure and import nothing, so copying them is cheap, and the name-level guard above is what catches drift.

## 2. A hardcoded count that the same PR outgrew (1 failure)

`test_hydration_clears_the_batch_baselines_for_a_batchless_model` asserted:

```python
assert status.count("modelChanged: slotsModelChanged,") == 2
```

`apply-inference-status-to-store.ts` used to seed two values through `resolveBatchSizeSeed`, the batch pair. #9410 deliberately routed the four tuning knobs through the same seed, with the reasoning in the source:

> The llama-server tuning group follows the same rule, and resolveBatchSizeSeed is generic in the value type for exactly this: each one is an echo of what the load REQUESTED, which is what makes the steady-poll and dirty-control cases identical to the batch pair's.

Six call sites, so the assertion failed `6 == 2`. The code is right and the number was stale.

The assertion the test wanted, per its own comment, is that the seeds cannot drift apart ("The batch pair is told the same thing, from the same local, so the two cannot drift"). That is now what it checks:

```python
seed_calls = len(re.findall(r"resolveBatchSizeSeed(?:<[^>]*>)?\(\{", status))
assert seed_calls >= 2, "the batch pair alone should be two seeds"
assert re.findall(r"modelChanged: (\w+)", status) == ["slotsModelChanged"] * seed_calls
```

This is strictly stronger than the count it replaces. The old form only counted occurrences; this pins that every seed call site is told `modelChanged` from the same local, so one of them being wired to a different value fails even though the totals still match. It also stops being wrong the next time the group grows.

## Result

Same command, `tests/studio`, four workers:

| | result |
| --- | --- |
| `main` at `e91f9720b` | 71 failed |
| this branch | 4577 passed, 4 skipped, 0 failed |

Only the two test files change. No product code is touched.
