### PR TITLE
Studio: turn on the sidebar drag's scoped custom-property writes

### DIFF
--- a/studio/frontend/src/components/ui/panel-resize-recalc-flags.ts
+++ b/studio/frontend/src/components/ui/panel-resize-recalc-flags.ts
@@ -27,6 +27,35 @@
 // against `inherits: false` is 1333x on dev and 982x on prod, and elementCount
 // is a DOM property, identical on both.
 //
+// CONFIRMED ON THE REAL APP before the flag was turned on, because the numbers
+// above come off a harness whose sidebar is nearly empty and whose document is
+// a third the size of a real one. Two production builds of the same commit
+// differing only in this boolean, served by the backend, 100K rung, 42,885
+// elements, five drags of eight frames each:
+//
+//   flag off   44,141 elements restyled per frame, 1,934.87 ms per drag
+//   flag on       770 elements restyled per frame,    37.35 ms per drag
+//
+// 57x fewer elements and 52x less recalc, or 241.9 ms per frame down to 4.67 --
+// the difference between roughly 4 fps and inside the 60 fps budget. Both arms
+// were checked for potency first (40/40 samples in the expected regime: off on
+// the wrapper and <html>, on at [data-slot="sidebar"] with no <html> write), so
+// neither reading is two identical builds wearing two labels. Geometry and
+// every computed width were identical across all 40 drag positions.
+//
+// The harness's "12 elements" does NOT transfer: [data-slot="sidebar"] really
+// holds ~770 elements once the thread list is populated. The ratio is 57x, not
+// 1000x. Still worth having, but quote the 57x.
+//
+// WHAT DOES NOT MEASURE THIS. studiobench cannot see this change at all: none of
+// its actions performs a pointer drag, so the per-frame write path is never
+// entered and every timing it reports for this flag is null by construction.
+// A sweep of it (100K, n=4, concurrent in-band null) scored 0 of 36 metrics past
+// the floor, sign-consistency and scatter gates, exactly as an unexercised code
+// path should. That null is not evidence the flag is inert; the drag measurement
+// above is the evidence, and UI parity over 64 action pairs against the same
+// concurrent null found 0 stable actions rendering differently.
+//
 // WHY NOT `@property { inherits: false }`. That is right only for a property
 // whose sole consumer is the element written to (`--aui-scroll-stabilizer`).
 // Here it would silently break both: `--sidebar-width` is read by
@@ -47,4 +76,4 @@
 // 575.0 ms. It fires twice per drag rather than once per frame, so the total is
 // smaller, and it is load-bearing for cursor correctness: a separate change
 // with its own visual risk, deliberately not bundled here.
-export const PANEL_RESIZE_SCOPED_VARS_ENABLED = false;
+export const PANEL_RESIZE_SCOPED_VARS_ENABLED = true;


### PR DESCRIPTION
PR #9400 scoped the sidebar drag's custom-property writes off the chat thread's ancestors, and merged behind `PANEL_RESIZE_SCOPED_VARS_ENABLED` defaulting off. The flag has been off ever since, so nobody has been getting the improvement. This turns it on.

The mechanism was argued in #9400 but never scored on a real app. It is now.

## What exercised it

A real pointer drag of the real sidebar resize handle (`[data-slot="sidebar-resize-handle"]`), 8 frames per drag, 5 drags per arm, in headless Chromium over CDP with `UpdateLayoutTree.elementCount` read from a devtools trace.

Both arms are **production** `npm run build` bundles of the **same commit** (`20c015f29`), served by the Studio backend with `--frontend`, each with its own `UNSLOTH_STUDIO_HOME` and port. The two dists differ only in that one boolean, verified by comparing the sha256 of their concatenated JS. Thread is the studiobench 100K rung, 390,740 seeded characters, 42,885 elements in the document and 41,857 in the thread.

These are production-stylesheet numbers, so the roughly 2.7x dev inflation noted in #9400 does not apply.

## Potency, checked before anything was timed

A flag-on run whose properties are still on the wrapper and `<html>` would be two identical builds wearing two labels. Both arms were checked at every drag position, 40 samples each:

| | `--sidebar-width` on wrapper | on `[data-slot="sidebar"]` | `--studio-sidebar-live-width` on `<html>` |
|---|---|---|---|
| flag off | 40/40 | 0/40 | 40/40 |
| flag on | 0/40 | 40/40 | 0/40 |

Both landed in their expected regime. The `<html>` write disappears entirely with the flag on because this is a browser build with no custom titlebar, so `rootVarTargets()` is empty and the write is skipped, which is the documented behaviour.

## Invalidation set, off versus on

| | flag off | flag on | ratio |
|---|---|---|---|
| elements restyled per drag frame | 44,141 | 770 | 57.3x |
| recalc ms per 8-frame drag (median of 5) | 1,934.87 | 37.35 | 51.8x |
| ms per frame | 241.9 | 4.67 | |
| spread across 5 drags (min/max ms) | 1,926.19 / 2,062.19 | 37.17 / 47.21 | |
| recalc events per drag | 8 | 8 | |

Per-frame element counts were identical on all 5 drags in both arms, so the scatter is entirely in the timing.

241.9 ms per frame is about 4 fps. 4.67 ms is inside the 60 fps budget.

### The sharper version of the claim: it stops scaling

Run across three rungs spanning 40x in document size:

| rung | document elements | flag off, elements/frame | flag on, elements/frame |
|---|---|---|---|
| 1K | 1,092 | 1,080 | **770** |
| 10K | 4,869 | 4,968 | **770** |
| 100K | 42,885 | 44,141 | **770** |

Flag-off tracks the document. Flag-on is flat, and 770 is just the `[data-slot="sidebar"]` subtree (697 elements) plus pseudo-elements. This is not a percentage win, it is a change in what the cost depends on: after the flip, dragging the sidebar costs the same whether the thread is empty or a megabyte.

### The probe's own null control

Flag-off against flag-off, separate home, port and session: 44,141 vs 44,141 elements, 1,934.87 vs 1,936.21 ms. Three flag-on replicates: 37.35, 36.78, 37.13 ms. The instrument reports no difference when there is none, and the 57x is far outside its own spread.

**One correction to #9400's own numbers.** That PR reported 12,022 elements to 12. The "12" was an artefact of a harness whose sidebar was nearly empty; `[data-slot="sidebar"]` really holds about 770 elements once the thread list is populated. The ratio is 57x, not 1000x. The shape of the claim holds, the magnitude was overstated, and the comment in the flag file now says so.

## Invariance

40 drag-position pairs compared across arms:

- geometry differences: **0** out of 640 comparisons across two independent replicates
- computed-width differences: **0**. The geometry genuinely moves with the drag (sidebar-container 300 to 440px, `main` / `.aui-thread-root` / `.aui-thread-viewport` 1140 down to 1000px with x shifting 300 to 440), and it moves identically on both arms at all 8 positions. This is a real drag that really resizes, not a no-op that trivially matches.
- flag-on consumer resolution failures: **0** (`--sidebar-width` resolves to a px value at `[data-slot="sidebar"]`, `sidebar-gap` and `sidebar-container` at every position)

The custom property does stop resolving on `[data-slot="sidebar-wrapper"]` and `.aui-thread-root` with the flag on. That is the entire point: neither reads it. Every element that does read it still resolves it to the same value.

`data-resizing` moves from the wrapper to `[data-slot="sidebar"]` with the flag on. No selector anywhere reads `[data-resizing]`; the only resize selector is `html[data-panel-resizing]`, which is still written on the document element unconditionally in both arms. That relocation is inert.

## What does not measure this, and why the sweep is not evidence

studiobench cannot observe this change. None of its 16 actions performs a pointer drag; the only synthetic pointer events in the harness are a `pointerdown`/`pointerup` pair on a Radix menu trigger with no movement. The `sidebar:collapsed` surface entry clicks `button[aria-label="Close sidebar"]`, which is a plain toggle button and not the resize handle, and the surface sweep is `--surfaces`-gated, off by default and excluded from scoring. So the per-frame write path is never entered and every timing studiobench reports for this flag is null by construction.

Run anyway, for completeness and for the parity verdict. 100K rung, `fast` tier, n=4, against a **concurrent in-band** null control serving the flag-off dist on both of its sides at the same time on the same machine:

**0 of 36 metrics cleared all three gates.** Every metric VOID. Representative rows, delta / spread / floor:

| metric | base | treat | delta % | spread % | floor % | verdict |
|---|---|---|---|---|---|---|
| `stop_generation.stop_ms` | 95.6 | 109.2 | +14.4 | 29.2 | 16.7 | VOID (under floor) |
| `jank_index` | 133.4 | 130.1 | -2.4 | 9.6 | 17.4 | VOID (under floor) |
| `time_in_jank_pct` | 20.8 | 20.5 | -1.5 | 3.0 | 9.1 | VOID (under floor) |
| `max_frame_ms` | 1,667.4 | 1,645.2 | -1.3 | 6.3 | 15.0 | VOID (under floor) |
| `keystroke.p50_ms` | 24.9 | 25.3 | +1.7 | 27.3 | 21.7 | VOID (under floor) |
| `thread_reopen.reopen_ms` | 990.0 | 1,074.1 | +8.5 | 23.6 | 11.4 | VOID (under floor) |

At n=2 the individual shards each threw a couple of spurious SLOWER/faster flags that contradicted each other between shards; pooling to n=4 dissolved all of them. That is what an unexercised code path is supposed to look like, and it is not evidence the flag is inert. The drag measurement above is the evidence.

## UI parity

`tests/studio/studiobench/sweep/ui_parity.py --null`, reading the `scene/parity.js` DOM digest taken at the close of every action window on both arms of the same session. Verdict **PARITY OK**, with its concurrent in-band null scored on the same run beside it:

| | action pairs | matched | **stable differing** | unstable differing | NOT COMPARABLE | NOT EXERCISED | style probe |
|---|---|---|---|---|---|---|---|
| **PR arm** (off vs on) | 64 | 54 | **0** | 6 | 0 | 4 | 0 |
| **null** (off vs off) | 64 | 56 | **0** | 4 | 0 | 4 | 0 |

Both read 0 stable breaks, so the arm's 0 is against a clean floor rather than a broken instrument. The matched-count gap (54 vs 56) is entirely in the declared-unstable bucket: `keystroke`, `scroll_during_generation` and `composer_fill` differ by streaming length between two runs of any build, which is why they are declared unstable and are not a verdict. `NOT EXERCISED` is `image_upload` on both arms, whose attachments button has a zero-size box in this configuration; that surface is unchecked rather than unchanged, and it is unrelated to the sidebar.

**What this pass does not cover, stated plainly.** Two blind spots, both of which matter for this specific change:

1. **It never drags.** No studiobench action performs a pointer drag, so this pass exercises only the flag's always-on side effect, the static relocation of the inline `--sidebar-width` declaration from `[data-slot="sidebar-wrapper"]` to `[data-slot="sidebar"]` on every render. It says nothing about the per-frame write path.
2. **The digest is sidebar-blind and layout-blind.** `scene/parity.js` states its own limits: it does not see anything outside the thread root and overlay selectors, specifically naming the sidebar and header, and it does not see computed layout, geometry, sizes or positions, or CSS arriving from a stylesheet. For a change whose whole subject is the sidebar's width, that is the wrong blind spot to leave uncovered.

So the digest alone is not the load-bearing invariance evidence here. Both blind spots are closed below.

## Drag-time parity, with its own null

A dedicated pass that captures state at **every drag position** and sees what the shipped digest cannot. It injects `scene/dom.js` then `scene/parity.js` as context init scripts in the order `__main__.py` uses and calls `window.__sb.parity.capture()` exactly as `scene/schedule.py` does, so the thread digest is the shipped one and not a lookalike. Three arms, run sequentially: **A** = flag off, **B** = flag on, **N** = flag off again on its own home, port and session, as the null. 34 position-pairs per arm. Handle started at x=280.0 on all three, so the drag geometry is identical.

| capture | B (on) vs A (off) | **N (off) vs A (off)** |
|---|---|---|
| shipped `parity.js` thread digest | **0 / 34** | **0 / 34** |
| computed layout and geometry | **0 / 34** | **0 / 34** |
| sidebar-inclusive structure | 34 / 34 | **0 / 34** |
| sidebar inline style | 34 / 34 (intended 102, **unexpected 0**) | **0 / 34** |
| custom-property reach | 34 / 34 | **0 / 34** |
| scroll (diagnostic) | 0 / 34 | 0 / 34 |

**The null is zero in every category**, so the instrument has a genuine floor of zero and B-vs-A is readable rather than being noise wearing a verdict.

The three non-zero buckets are each the change itself, and were run down individually rather than waved through:

- **Inline style.** The walk covers the whole document: **39,226 elements carry a style attribute, and exactly 2 differ**, at every position, both the intended relocation with the same value. `--sidebar-width: 380px` leaves the wrapper and appears on `[data-slot="sidebar"]`. `--sidebar-width-icon: 3rem` stays on the wrapper in both arms. Unexpected differences: **0**.
- **Structure.** 204 of 204 signature pairs become **character-identical** once ` data-resizing=true` is removed from both sides. The entire structural difference is that `PanelResizeHandle` sets `data-resizing` on its drag target, which the flag redirects from the wrapper to `[data-slot="sidebar"]`. That is an undocumented side effect of the flag, so it was checked rather than assumed: in both dists, **0 CSS files mention `data-resizing`, 0 occurrences of `[data-resizing` as a selector, and exactly 2 occurrences in JS** (one `setAttribute`, one `removeAttribute`). It is write-only in both builds. Inert.
- **Custom-property reach.** `--sidebar-width` stops resolving on wrapper, inset, `main`, `.aui-thread-root`, `.aui-thread-viewport` and `.aui-composer-root`. That is the entire point of the change. It still resolves **identically** on sidebar, gap, container and inner, which never appear in the diff. A stylesheet scan gated on a positive control (807 rules reading `var(--spacing)`) found that the only rule reading `--sidebar-width` which matches anything is `.w-\(--sidebar-width\)`, matching **3 elements, all inside `[data-slot="sidebar"]`, 0 outside**. Everything else reads `--sidebar-width-icon`, which did not move.

### Nothing in a browser build reads `--studio-sidebar-live-width`

Worth stating because with the flag on the browser arm never writes it. 6,451 CSS rules scanned, 0 unreadable sheets, positive control 807: **0 stylesheet rules read it and 0 inline styles read it.** `[data-titlebar-live-width-scope]` and `[data-slot="window-titlebar-decoration"]` both match **0 elements**, because `WindowTitlebar` returns `null` when `shouldUseCustomWindowTitlebar` is false, and its only consumers live inside that component. Mid-drag with the flag off, 4,000 of 4,001 walked elements inherit a value nobody reads; with it on, 0 of 4,001. So the flag-off build was paying whole-document invalidation to publish a property with no readers.

One caution on the scan: the first version of it reported zero readers for the wrong reason. In Chrome every `CSSStyleRule` has a truthy but empty `cssRules` because of CSS nesting, so treating it as a grouping rule skipped every declaration in the document. That was a bug in the probe, not a result. It was fixed and then gated on the positive control above, and a run whose control comes back low is marked untrustworthy rather than reported.

## Relationship to #9328

No overlap. #9328 registered `--aui-scroll-stabilizer` with `inherits: false`, one `@property` block in `index.css`. This is four TS/TSX files and no CSS. Different property, different element, different event: the stabilizer is written on the thread scroll viewport during streaming, these two on the sidebar wrapper and `<html>` during a drag. The viewport is a descendant of the wrapper, so the invalidation cones point in opposite directions. #9328 does not capture any part of this and does not subsume it.

`inherits: false` is also not transferable here, for the reason #9400 gave: both of these properties have descendant consumers and would resolve to their initial value.

## Still not addressed

`html[data-panel-resizing] *` (index.css:1604) is a universal descendant selector that restyles the whole document during a drag. It fires twice per drag, on pointer-down and on release, rather than once per frame, so it sets a fixed floor under the drag's total cost rather than scaling with frame count. It is load-bearing for cursor correctness and is left alone here deliberately, as #9400 said.

## What this measurement does not cover

Stated so nobody reads the numbers above as broader than they are.

### The Tauri titlebar substitution was never executed. Read this before approving.

Concretely, and a reviewer can act on this:

- With the flag **off**, `--studio-sidebar-live-width` is written to `document.documentElement` on every drag frame.
- With the flag **on**, it is written to whatever `[data-titlebar-live-width-scope]` matches instead.
- **In a browser build that selector matches nothing, so the property is not written at all.** The flag-on browser arm I measured is therefore literally "do not write this property", not "write it somewhere narrower". That is what the 57x was measured on.
- **On desktop the selector does match**, because `window-titlebar.tsx` renders those scope elements, and the titlebar reads `var(--studio-sidebar-live-width, ...)`. So on desktop the write must actually land on the titlebar elements and drive them correctly.

**No measurement in this PR executed that desktop path.** It is the single most plausible place for a flag-on regression to hide: if the write fails to reach the titlebar elements, the custom titlebar stops tracking the sidebar during a drag.

The staging matrix includes an `Unsloth Tauri CI` job. That is the only coverage this change has for the desktop path, and **a CI job passing is not a substitute for a measurement**. If someone wants this de-risked properly, the thing to do is run the same drag probe inside a Tauri build and check that the titlebar tracks. I did not do that.

There is also a narrow behavioural difference on that path that no probe here can see. `rootVarTargets()` is resolved **once, at pointerdown**, and the resulting list is held for the rest of the drag. The old code wrote to `document.documentElement` every frame, and that cannot go stale. If a titlebar decoration were to unmount mid-drag, the flag-on build would keep writing to a detached node. Narrow, and only reachable on desktop, but it is a real difference in kind and not just in scope, so it should be looked at by someone who can run a Tauri build.

Related, and untested for the same reason: `collapseToZero={isTauri}`, so on desktop the resize handle only renders when the sidebar is pinned. The collapsed desktop case is unexercised.

`collapsible="offcanvas"` is also unexercised. The two rules that read `calc(var(--sidebar-width)*-1)` match 0 elements in this shell, which uses `collapsible="icon"`, so the offcanvas path is unverified by any of the above.

### Other limits

- Headless Chromium, not the WebKitGTK webview Studio uses on Linux. `elementCount` is a Blink counter.
- The millisecond figures were taken while another sweep was running on the same machine. `elementCount` is load-independent, which is why the element counts carry the argument and the timings are quoted with their spread beside them.

## Reproducing

```
scripts/r9400_build.sh              two dists from one commit, sha-verified distinct
scripts/r9400_realapp_probe.py      potency, invalidation counts, invariance
scripts/r9400_parity_sweep.py       studiobench arm + concurrent in-band null
```
