### PR TITLE
Studio: keep server chats visible when legacy IndexedDB stalls

### DIFF
--- a/studio/backend/routes/chat_history.py
+++ b/studio/backend/routes/chat_history.py
@@ -41,6 +41,7 @@ from storage.studio_db import (
     get_chat_project,
     get_chat_thread,
     get_chat_message,
+    is_chat_legacy_import_complete,
     list_chat_attachments_page,
     list_chat_projects,
     list_chat_legacy_imports,
@@ -52,7 +53,7 @@ from storage.studio_db import (
     update_chat_project,
     update_chat_thread,
     upsert_chat_project,
-    upsert_chat_legacy_imports,
+    record_chat_legacy_import,
     upsert_chat_message,
     upsert_chat_settings_merge,
     write_chat_thread_settings,
@@ -294,6 +295,7 @@ class ChatProjectPatch(BaseModel):
 
 class ChatThreadListResponse(BaseModel):
     threads: list[ChatThread]
+    legacyImportComplete: bool = False
 
 
 class ChatProjectListResponse(BaseModel):
@@ -505,11 +507,13 @@ class ChatMessagesBatchResponse(BaseModel):
 
 class ChatImportLedgerResponse(BaseModel):
     threadIds: list[str]
+    complete: bool = False
 
 
 class ChatImportLedgerRecordRequest(BaseModel):
     # 10k cap bounds the request body; real users have << 1k threads.
     threadIds: list[str] = Field(default_factory = list, max_length = 10_000)
+    complete: bool = False
 
 
 class ChatImportLedgerRecordResponse(BaseModel):
@@ -517,6 +521,7 @@ class ChatImportLedgerRecordResponse(BaseModel):
     # (ON CONFLICT DO NOTHING skips already-recorded ids).
     accepted: int
     inserted: int
+    complete: bool
 
 
 @router.get("/threads", response_model = ChatThreadListResponse)
@@ -533,7 +538,10 @@ def list_threads(
         project_id = project_id,
         include_archived = include_archived,
     )
-    return ChatThreadListResponse(threads = [thread_from_row(t) for t in threads])
+    return ChatThreadListResponse(
+        threads = [thread_from_row(t) for t in threads],
+        legacyImportComplete = is_chat_legacy_import_complete(),
+    )
 
 
 def _missing_project_error(project_id: Optional[str]) -> HTTPException:
@@ -1316,7 +1324,10 @@ def get_import_ledger(current_subject: str = Depends(get_current_subject)):
 
     The frontend checks this on tab open to decide whether to re-run the Dexie -> studio.db import.
     """
-    return ChatImportLedgerResponse(threadIds = list_chat_legacy_imports())
+    return ChatImportLedgerResponse(
+        threadIds = list_chat_legacy_imports(),
+        complete = is_chat_legacy_import_complete(),
+    )
 
 
 @router.post("/import-ledger", response_model = ChatImportLedgerRecordResponse)
@@ -1324,8 +1335,12 @@ def record_import_ledger(
     payload: ChatImportLedgerRecordRequest, current_subject: str = Depends(get_current_subject)
 ):
     """Mark each legacy thread id as imported. Idempotent."""
-    accepted, inserted = upsert_chat_legacy_imports(payload.threadIds)
-    return ChatImportLedgerRecordResponse(accepted = accepted, inserted = inserted)
+    accepted, inserted, complete = record_chat_legacy_import(
+        payload.threadIds, complete = payload.complete
+    )
+    return ChatImportLedgerRecordResponse(
+        accepted = accepted, inserted = inserted, complete = complete
+    )
 
 
 @router.delete("")

--- a/studio/backend/routes/chat_history.py
+++ b/studio/backend/routes/chat_history.py
@@ -1338,9 +1338,7 @@ def record_import_ledger(
     accepted, inserted, complete = record_chat_legacy_import(
         payload.threadIds, complete = payload.complete
     )
-    return ChatImportLedgerRecordResponse(
-        accepted = accepted, inserted = inserted, complete = complete
-    )
+    return ChatImportLedgerRecordResponse(accepted = accepted, inserted = inserted, complete = complete)
 
 
 @router.delete("")

--- a/studio/backend/storage/studio_db.py
+++ b/studio/backend/storage/studio_db.py
@@ -627,13 +627,20 @@ def _ensure_schema(conn: sqlite3.Connection) -> None:
         )
         """
     )
-    # Import ledger inside studio.db (vs a localStorage boolean) so a db wipe re-triggers the
-    # legacy Dexie import instead of silently hiding threads. Keyed by legacy thread id.
+    # Keep migration state with the imported chats so a studio.db wipe retries the import.
     conn.execute(
         """
         CREATE TABLE IF NOT EXISTS chat_legacy_imports (
             legacy_thread_id TEXT NOT NULL PRIMARY KEY,
             imported_at INTEGER NOT NULL
+        ) WITHOUT ROWID
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS chat_legacy_import_state (
+            singleton INTEGER NOT NULL PRIMARY KEY CHECK(singleton = 1),
+            completed_at INTEGER NOT NULL
         ) WITHOUT ROWID
         """
     )
@@ -3943,16 +3950,26 @@ def list_chat_legacy_imports() -> list[str]:
         conn.close()
 
 
-def upsert_chat_legacy_imports(legacy_thread_ids: list[str]) -> tuple[int, int]:
-    """Mark each given legacy thread id as imported. Idempotent.
+def is_chat_legacy_import_complete() -> bool:
+    """Return whether the legacy browser database was fully imported."""
+    conn = get_connection()
+    try:
+        row = conn.execute(
+            "SELECT 1 FROM chat_legacy_import_state WHERE singleton = 1"
+        ).fetchone()
+        return row is not None
+    finally:
+        conn.close()
 
-    Returns (accepted, inserted): count of deduped non-empty input ids, and
-    count of rows actually new. RETURNING lets callers tell first-time imports
-    from idempotent re-runs without an extra SELECT.
+
+def record_chat_legacy_import(
+    legacy_thread_ids: list[str], *, complete: bool = False
+) -> tuple[int, int, bool]:
+    """Record imported thread ids and optionally complete the migration atomically.
+
+    Returns the accepted count, inserted count, and resulting completion state.
     """
     ids = list(dict.fromkeys(tid for tid in legacy_thread_ids if tid))
-    if not ids:
-        return 0, 0
     ts = int(datetime.now(timezone.utc).timestamp() * 1000)
     conn = get_connection()
     try:
@@ -3969,7 +3986,22 @@ def upsert_chat_legacy_imports(legacy_thread_ids: list[str]) -> tuple[int, int]:
             ).fetchone()
             if row is not None:
                 inserted += 1
+        if complete:
+            conn.execute(
+                """
+                INSERT INTO chat_legacy_import_state (singleton, completed_at)
+                VALUES (1, ?)
+                ON CONFLICT(singleton) DO NOTHING
+                """,
+                (ts,),
+            )
         conn.commit()
-        return len(ids), inserted
+        completed = conn.execute(
+            "SELECT 1 FROM chat_legacy_import_state WHERE singleton = 1"
+        ).fetchone()
+        return len(ids), inserted, completed is not None
+    except Exception:
+        conn.rollback()
+        raise
     finally:
         conn.close()

--- a/studio/backend/storage/studio_db.py
+++ b/studio/backend/storage/studio_db.py
@@ -3954,9 +3954,7 @@ def is_chat_legacy_import_complete() -> bool:
     """Return whether the legacy browser database was fully imported."""
     conn = get_connection()
     try:
-        row = conn.execute(
-            "SELECT 1 FROM chat_legacy_import_state WHERE singleton = 1"
-        ).fetchone()
+        row = conn.execute("SELECT 1 FROM chat_legacy_import_state WHERE singleton = 1").fetchone()
         return row is not None
     finally:
         conn.close()

--- a/studio/backend/tests/test_chat_history_routes.py
+++ b/studio/backend/tests/test_chat_history_routes.py
@@ -453,34 +453,38 @@ def test_get_import_ledger_round_trips_through_storage(monkeypatch):
         return list(seen)
 
     monkeypatch.setattr(chat_history, "list_chat_legacy_imports", fake_list)
+    monkeypatch.setattr(chat_history, "is_chat_legacy_import_complete", lambda: False)
 
     response = chat_history.get_import_ledger(current_subject = "test-user")
     assert response.threadIds == []
+    assert response.complete is False
 
     seen.extend(["legacy-a", "legacy-b"])
     response = chat_history.get_import_ledger(current_subject = "test-user")
     assert response.threadIds == ["legacy-a", "legacy-b"]
 
 
-def test_record_import_ledger_returns_accepted_and_inserted(monkeypatch):
-    captured: list[list[str]] = []
+def test_record_import_ledger_returns_completion_state(monkeypatch):
+    captured: list[tuple[list[str], bool]] = []
 
-    def fake_upsert(thread_ids):
-        captured.append(list(thread_ids))
+    def fake_record(thread_ids, *, complete = False):
+        captured.append((list(thread_ids), complete))
         # Pretend two of the three were already in the ledger.
-        return (len(thread_ids), max(0, len(thread_ids) - 2))
+        return (len(thread_ids), max(0, len(thread_ids) - 2), complete)
 
-    monkeypatch.setattr(chat_history, "upsert_chat_legacy_imports", fake_upsert)
+    monkeypatch.setattr(chat_history, "record_chat_legacy_import", fake_record)
 
     response = chat_history.record_import_ledger(
         payload = chat_history.ChatImportLedgerRecordRequest(
             threadIds = ["a", "b", "c"],
+            complete = True,
         ),
         current_subject = "test-user",
     )
     assert response.accepted == 3
     assert response.inserted == 1
-    assert captured == [["a", "b", "c"]]
+    assert response.complete is True
+    assert captured == [(["a", "b", "c"], True)]
 
 
 def test_record_import_ledger_rejects_oversize_payload():

--- a/studio/backend/tests/test_chat_history_storage.py
+++ b/studio/backend/tests/test_chat_history_storage.py
@@ -597,9 +597,11 @@ def test_legacy_import_can_complete_without_records(tmp_path, monkeypatch):
 
 def test_legacy_import_records_and_completes_atomically(tmp_path, monkeypatch):
     _reset_studio_db(tmp_path, monkeypatch)
-    assert studio_db.record_chat_legacy_import(
-        ["legacy-a", "legacy-b"], complete = True
-    ) == (2, 2, True)
+    assert studio_db.record_chat_legacy_import(["legacy-a", "legacy-b"], complete = True) == (
+        2,
+        2,
+        True,
+    )
     assert set(studio_db.list_chat_legacy_imports()) == {"legacy-a", "legacy-b"}
 
 

--- a/studio/backend/tests/test_chat_history_storage.py
+++ b/studio/backend/tests/test_chat_history_storage.py
@@ -586,24 +586,40 @@ def test_list_chat_messages_for_threads_chunks_over_900_ids(tmp_path, monkeypatc
 def test_legacy_imports_empty_by_default(tmp_path, monkeypatch):
     _reset_studio_db(tmp_path, monkeypatch)
     assert studio_db.list_chat_legacy_imports() == []
+    assert studio_db.is_chat_legacy_import_complete() is False
+
+
+def test_legacy_import_can_complete_without_records(tmp_path, monkeypatch):
+    _reset_studio_db(tmp_path, monkeypatch)
+    assert studio_db.record_chat_legacy_import([], complete = True) == (0, 0, True)
+    assert studio_db.is_chat_legacy_import_complete() is True
+
+
+def test_legacy_import_records_and_completes_atomically(tmp_path, monkeypatch):
+    _reset_studio_db(tmp_path, monkeypatch)
+    assert studio_db.record_chat_legacy_import(
+        ["legacy-a", "legacy-b"], complete = True
+    ) == (2, 2, True)
+    assert set(studio_db.list_chat_legacy_imports()) == {"legacy-a", "legacy-b"}
 
 
 def test_legacy_imports_records_and_lists(tmp_path, monkeypatch):
     _reset_studio_db(tmp_path, monkeypatch)
-    accepted, inserted = studio_db.upsert_chat_legacy_imports(
+    accepted, inserted, complete = studio_db.record_chat_legacy_import(
         ["legacy-a", "legacy-b", "legacy-c"],
     )
     assert accepted == 3
     assert inserted == 3
+    assert complete is False
     assert set(studio_db.list_chat_legacy_imports()) == {"legacy-a", "legacy-b", "legacy-c"}
 
 
 def test_legacy_imports_is_idempotent(tmp_path, monkeypatch):
     _reset_studio_db(tmp_path, monkeypatch)
-    accepted1, inserted1 = studio_db.upsert_chat_legacy_imports(
+    accepted1, inserted1, _ = studio_db.record_chat_legacy_import(
         ["legacy-a", "legacy-b"],
     )
-    accepted2, inserted2 = studio_db.upsert_chat_legacy_imports(
+    accepted2, inserted2, _ = studio_db.record_chat_legacy_import(
         ["legacy-b", "legacy-c"],
     )
     assert (accepted1, inserted1) == (2, 2)
@@ -614,7 +630,7 @@ def test_legacy_imports_is_idempotent(tmp_path, monkeypatch):
 
 def test_legacy_imports_dedups_input(tmp_path, monkeypatch):
     _reset_studio_db(tmp_path, monkeypatch)
-    accepted, inserted = studio_db.upsert_chat_legacy_imports(
+    accepted, inserted, _ = studio_db.record_chat_legacy_import(
         ["x", "x", "y", "x"],
     )
     # accepted is the deduped non-empty input size; inserted is the rows newly
@@ -626,8 +642,12 @@ def test_legacy_imports_dedups_input(tmp_path, monkeypatch):
 
 def test_legacy_imports_ignores_empty(tmp_path, monkeypatch):
     _reset_studio_db(tmp_path, monkeypatch)
-    assert studio_db.upsert_chat_legacy_imports([]) == (0, 0)
-    assert studio_db.upsert_chat_legacy_imports(["", None]) == (0, 0)  # type: ignore[list-item]
+    assert studio_db.record_chat_legacy_import([]) == (0, 0, False)
+    assert studio_db.record_chat_legacy_import(["", None]) == (  # type: ignore[list-item]
+        0,
+        0,
+        False,
+    )
     assert studio_db.list_chat_legacy_imports() == []
 
 

--- a/studio/frontend/src/features/chat/api/chat-api.ts
+++ b/studio/frontend/src/features/chat/api/chat-api.ts
@@ -688,14 +688,19 @@ export async function removeScanFolder(id: number): Promise<void> {
   await parseJsonOrThrow<unknown>(response);
 }
 
-export async function listChatThreads(
+export interface ChatThreadListResult {
+  threads: ThreadRecord[];
+  legacyImportComplete: boolean;
+}
+
+export async function listChatThreadsWithMigrationState(
   args: {
     modelType?: ModelType;
     pairId?: string;
     projectId?: string | null;
     includeArchived?: boolean;
   } = {},
-): Promise<ThreadRecord[]> {
+): Promise<ChatThreadListResult> {
   const params = new URLSearchParams();
   if (args.modelType) params.set("model_type", args.modelType);
   if (args.pairId) params.set("pair_id", args.pairId);
@@ -705,9 +710,20 @@ export async function listChatThreads(
   }
   const qs = params.toString();
   const response = await authFetch(`/api/chat/threads${qs ? `?${qs}` : ""}`);
-  const data = await parseJsonOrThrow<{ threads: ThreadRecord[] }>(response);
-  // Always hand back an array: an older or misbehaving backend may omit it or send a non-array.
-  return Array.isArray(data.threads) ? data.threads : [];
+  const data = await parseJsonOrThrow<{
+    threads: ThreadRecord[];
+    legacyImportComplete?: boolean;
+  }>(response);
+  return {
+    threads: Array.isArray(data.threads) ? data.threads : [],
+    legacyImportComplete: data.legacyImportComplete === true,
+  };
+}
+
+export async function listChatThreads(
+  args: Parameters<typeof listChatThreadsWithMigrationState>[0] = {},
+): Promise<ThreadRecord[]> {
+  return (await listChatThreadsWithMigrationState(args)).threads;
 }
 
 /** One chat message attachment, as listed for the settings uploaded-files view. */
@@ -1153,50 +1169,65 @@ export async function buildBackendChatExport(): Promise<{
   return parseJsonOrThrow(response);
 }
 
-// Legacy-Dexie import ledger: a server-side source of truth replacing the localStorage
-// sentinel, so a studio.db wipe keeps the import recoverable.
-export async function listChatImportLedger(): Promise<Set<string>> {
+// The ledger and completion state live with the imported chats in studio.db.
+export interface ChatImportLedger {
+  threadIds: Set<string>;
+  complete: boolean;
+  supported: boolean;
+}
+
+export async function listChatImportLedger(): Promise<ChatImportLedger> {
   const response = await authFetch("/api/chat/import-ledger");
   // Backends without this endpoint behave like an empty ledger -- the caller re-imports every
   // legacy thread, and syncChatMessages UPSERTs prevent duplicates.
-  if (response.status === 404 || response.status === 405) return new Set();
-  const data = await parseJsonOrThrow<{ threadIds: string[] }>(response);
-  return new Set(data.threadIds);
+  if (response.status === 404 || response.status === 405) {
+    return { threadIds: new Set(), complete: false, supported: false };
+  }
+  const data = await parseJsonOrThrow<{
+    threadIds: string[];
+    complete?: boolean;
+  }>(response);
+  return {
+    threadIds: new Set(data.threadIds),
+    complete: data.complete === true,
+    supported: true,
+  };
 }
 
 export interface RecordChatImportLedgerResult {
   accepted: number;
   inserted: number;
-  // false when the backend predates /api/chat/import-ledger, so the caller does not poison the
-  // localStorage perf hint; the next launch retries the (idempotent) import.
+  // False when the backend predates the migration endpoint.
   supported: boolean;
+  complete: boolean;
 }
 
 export async function recordChatImportLedger(
   threadIds: string[],
+  options: { complete?: boolean } = {},
 ): Promise<RecordChatImportLedgerResult> {
-  if (threadIds.length === 0) {
-    return { accepted: 0, inserted: 0, supported: true };
-  }
   const response = await authFetch("/api/chat/import-ledger", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ threadIds }),
+    body: JSON.stringify({ threadIds, complete: options.complete === true }),
   });
   if (
     response.status === 404 ||
     response.status === 405 ||
     response.status === 501
   ) {
-    return { accepted: 0, inserted: 0, supported: false };
+    return { accepted: 0, inserted: 0, supported: false, complete: false };
   }
-  const data = await parseJsonOrThrow<{ accepted: number; inserted: number }>(
-    response,
-  );
+  const data = await parseJsonOrThrow<{
+    accepted: number;
+    inserted: number;
+    complete?: boolean;
+  }>(response);
   return {
     accepted: data.accepted,
     inserted: data.inserted,
     supported: true,
+    complete: data.complete === true,
   };
 }
 

--- a/studio/frontend/src/features/chat/utils/chat-history-storage.ts
+++ b/studio/frontend/src/features/chat/utils/chat-history-storage.ts
@@ -15,6 +15,7 @@ import {
   listChatMessages,
   listChatProjects,
   listChatThreads,
+  listChatThreadsWithMigrationState,
   notifyChatHistoryUpdated,
   recordChatImportLedger,
   saveChatMessage,
@@ -37,6 +38,7 @@ import {
   markChatThreadDeleted,
   markChatThreadsDeleted,
 } from "./chat-thread-tombstones";
+import { LegacyStoreGate } from "./legacy-store-gate";
 import { ThreadRecordWriteCoordinator } from "./thread-record-write-coordinator";
 
 // Thread ids that belong to a temporary/incognito session. A thread is
@@ -66,14 +68,14 @@ type ThreadListArgs = {
   includeArchived?: boolean;
 };
 
-// localStorage perf-hint that the Dexie -> studio.db import already
-// finished. NOT the import gate -- the server-side ledger
-// (chat_legacy_imports) is the source of truth so a studio.db wipe stays
-// recoverable. The hint only short-circuits the listing paths' "also
-// surface Dexie threads?" branches once the ledger has covered everything.
-const LEGACY_CHAT_IMPORT_KEY = "unsloth_chat_legacy_imported_to_studio_db";
+const LEGACY_CHAT_FAILURE_VERSION_KEY =
+  "unsloth_chat_legacy_store_failed_app_version";
 
 let legacyChatImportPromise: Promise<void> | null = null;
+let legacyChatImportComplete = false;
+let legacyImportStatePromise: ReturnType<typeof listChatImportLedger> | null =
+  null;
+let desktopAppVersionPromise: Promise<string | null> | null = null;
 
 // Bumped whenever a backend thread row is created or backfilled, so a listing can tell whether its read raced one.
 let legacyChatImportGeneration = 0;
@@ -156,22 +158,8 @@ function hasOwn(value: object, key: string): boolean {
   return Object.prototype.hasOwnProperty.call(value, key);
 }
 
-function isLegacyChatImportDone(): boolean {
-  if (!canUseStorage()) return true;
-  try {
-    return localStorage.getItem(LEGACY_CHAT_IMPORT_KEY) === "true";
-  } catch {
-    return false;
-  }
-}
-
-function markLegacyChatImportDone(): void {
-  if (!canUseStorage()) return;
-  try {
-    localStorage.setItem(LEGACY_CHAT_IMPORT_KEY, "true");
-  } catch {
-    // ignore
-  }
+function noteLegacyChatImportComplete(complete: boolean): void {
+  if (complete) legacyChatImportComplete = true;
 }
 
 function matchesThreadListArgs(
@@ -188,17 +176,120 @@ function matchesThreadListArgs(
   );
 }
 
+// Legacy storage must never block server-backed history.
+const legacyStore = new LegacyStoreGate();
+
+// Enumeration does not open the store, so it has an independent gate.
+const legacyDatabaseList = new LegacyStoreGate();
+const legacyDatabaseDelete = new LegacyStoreGate();
+
+function isDesktopApp(): boolean {
+  return (
+    canUseStorage() &&
+    ("__TAURI__" in window ||
+      "__TAURI_INTERNALS__" in window ||
+      window.location.protocol === "tauri:")
+  );
+}
+
+async function desktopAppVersion(): Promise<string | null> {
+  if (!isDesktopApp()) return null;
+  desktopAppVersionPromise ??= import("@tauri-apps/api/app")
+    .then(({ getVersion }) => getVersion())
+    .catch(() => null);
+  return desktopAppVersionPromise;
+}
+
+async function failedForCurrentAppVersion(): Promise<boolean> {
+  const version = await desktopAppVersion();
+  if (!version) return false;
+  try {
+    return localStorage.getItem(LEGACY_CHAT_FAILURE_VERSION_KEY) === version;
+  } catch {
+    return false;
+  }
+}
+
+async function persistLegacyStoreFailure(): Promise<void> {
+  const version = await desktopAppVersion();
+  if (!version) return;
+  try {
+    localStorage.setItem(LEGACY_CHAT_FAILURE_VERSION_KEY, version);
+  } catch {
+    // Best effort. The in-memory gate still avoids repeated waits this session.
+  }
+}
+
+async function clearLegacyStoreFailure(): Promise<void> {
+  if (!canUseStorage()) return;
+  try {
+    localStorage.removeItem(LEGACY_CHAT_FAILURE_VERSION_KEY);
+  } catch {
+    // ignore
+  }
+}
+
+async function readLegacyStore<T>(
+  read: () => Promise<T>,
+  fallback: T,
+): Promise<T> {
+  if (await failedForCurrentAppVersion()) return fallback;
+  const respondedBefore = legacyStore.responds;
+  const result = await legacyStore.read(read, fallback);
+  if (respondedBefore && !legacyStore.responds) {
+    await persistLegacyStoreFailure();
+  } else if (legacyStore.responds) {
+    await clearLegacyStoreFailure();
+  }
+  return result;
+}
+
+async function getLegacyImportState() {
+  if (legacyChatImportComplete) {
+    return { threadIds: new Set<string>(), complete: true, supported: true };
+  }
+  legacyImportStatePromise ??= listChatImportLedger().then(
+    (state) => {
+      noteLegacyChatImportComplete(state.complete);
+      return state;
+    },
+    () => {
+      legacyImportStatePromise = null;
+      return {
+        threadIds: new Set<string>(),
+        complete: false,
+        supported: false,
+      };
+    },
+  );
+  return legacyImportStatePromise;
+}
+
+async function readLegacyStoreIfNeeded<T>(
+  read: () => Promise<T>,
+  fallback: T,
+): Promise<T> {
+  const state = await getLegacyImportState();
+  return state.complete ? fallback : readLegacyStore(read, fallback);
+}
+
+export function legacyChatStoreResponds(): boolean {
+  return legacyStore.responds;
+}
+
 async function listLegacyThreads(
   args: ThreadListArgs,
 ): Promise<ThreadRecord[]> {
-  const legacyQuery = args.pairId
-    ? db.threads.where("pairId").equals(args.pairId)
-    : args.modelType
-      ? db.threads.where("modelType").equals(args.modelType)
-      : db.threads.toCollection();
-  return (await legacyQuery.toArray()).filter((thread) =>
-    matchesThreadListArgs(thread, args),
-  );
+  return readLegacyStoreIfNeeded(async () => {
+    const legacyQuery = args.pairId
+      ? db.threads.where("pairId").equals(args.pairId)
+      : args.modelType
+        ? db.threads.where("modelType").equals(args.modelType)
+        : db.threads.toCollection();
+    return (await legacyQuery.toArray()).filter((thread) =>
+      matchesThreadListArgs(thread, args),
+    );
+  }, []);
 }
 
 function sortMessages(messages: MessageRecord[]): MessageRecord[] {
@@ -327,10 +418,10 @@ async function importLegacyThreadRow(
   }
   // A point lookup can import a row too, and a listing mid-flight has to re-read to see it.
   legacyChatImportGeneration += 1;
-  const legacyMessages = await db.messages
-    .where("threadId")
-    .equals(thread.id)
-    .toArray();
+  const legacyMessages = await readLegacyStoreIfNeeded(
+    () => db.messages.where("threadId").equals(thread.id).toArray(),
+    [] as MessageRecord[],
+  );
   if (legacyMessages.length > 0) {
     await syncChatMessages(thread.id, normalizeLegacyMessages(legacyMessages), {
       pruneMissing: false,
@@ -411,7 +502,10 @@ async function dexieDbAbsent(): Promise<boolean> {
   const dbs = (indexedDB as IDBFactory).databases;
   if (typeof dbs !== "function") return false;
   try {
-    const list = await dbs.call(indexedDB);
+    const list = await legacyDatabaseList.read<IDBDatabaseInfo[] | null>(
+      () => dbs.call(indexedDB),
+      null,
+    );
     if (!Array.isArray(list)) return false;
     return !list.some((entry) => entry?.name === DEXIE_DB_NAME);
   } catch {
@@ -423,10 +517,12 @@ async function dexieDbAbsent(): Promise<boolean> {
 // store metadata, not the rows -- cheap regardless of record count.
 async function dexieIsEmpty(): Promise<boolean> {
   try {
-    const [threadCount, messageCount] = await Promise.all([
-      db.threads.count(),
-      db.messages.count(),
-    ]);
+    const counts = await readLegacyStore<[number, number] | null>(
+      () => Promise.all([db.threads.count(), db.messages.count()]),
+      null,
+    );
+    if (counts === null) return false;
+    const [threadCount, messageCount] = counts;
     return threadCount === 0 && messageCount === 0;
   } catch {
     // Dexie threw (corrupt DB / version mismatch / quota). Returning
@@ -436,36 +532,49 @@ async function dexieIsEmpty(): Promise<boolean> {
   }
 }
 
+async function retireLegacyChatStore(): Promise<void> {
+  db.close();
+  await legacyDatabaseDelete.read(() => db.delete(), undefined);
+}
+
+async function completeLegacyChatImport(threadIds: string[]): Promise<boolean> {
+  const result = await recordChatImportLedger(threadIds, { complete: true });
+  if (!result.supported || !result.complete) return false;
+  noteLegacyChatImportComplete(true);
+  legacyImportStatePromise = Promise.resolve({
+    threadIds: new Set(threadIds),
+    complete: true,
+    supported: true,
+  });
+  return true;
+}
+
 async function importLegacyChatsIfNeeded(): Promise<void> {
-  // Session-level cache: repeated sidebar mounts in the same tab share
-  // one import. localStorage is NOT consulted -- the server-side ledger
-  // is the source of truth, so a studio.db wipe re-triggers the import
-  // even if the browser kept its old hint.
   if (legacyChatImportPromise) return legacyChatImportPromise;
 
   legacyChatImportPromise = (async () => {
-    // Fast-path: no Dexie DB -- new user, never had browser-only Unsloth.
+    const importState = await getLegacyImportState();
+    if (importState.complete) return;
+
     if (await dexieDbAbsent()) {
-      markLegacyChatImportDone();
+      await completeLegacyChatImport([]);
       return;
     }
 
-    // Fast-path: Dexie exists but is empty (already migrated long
-    // ago and Dexie just hasn't been GC'd, or the browser created an
-    // empty DB for some reason).
     if (await dexieIsEmpty()) {
-      markLegacyChatImportDone();
+      if (await completeLegacyChatImport([])) {
+        await retireLegacyChatStore();
+      }
       return;
     }
 
-    // Slow path: diff Dexie against the server-side ledger and import
-    // any threads not already recorded.
-    const [legacyThreads, backendThreads, importedThreadIds] =
-      await Promise.all([
-        db.threads.toArray(),
-        listChatThreads({ includeArchived: true }),
-        listChatImportLedger(),
-      ]);
+    const legacyThreads = await readLegacyStore(
+      () => db.threads.toArray(),
+      null,
+    );
+    if (legacyThreads === null) return;
+    const backendThreads = await listChatThreads({ includeArchived: true });
+    const importedThreadIds = importState.threadIds;
 
     const backendThreadsById = new Map(
       backendThreads.map((thread) => [thread.id, thread]),
@@ -484,16 +593,18 @@ async function importLegacyChatsIfNeeded(): Promise<void> {
     }
 
     if (unimportedIds.length === 0) {
-      markLegacyChatImportDone();
+      if (await completeLegacyChatImport([])) {
+        await retireLegacyChatStore();
+      }
       return;
     }
 
     // Two bulk reads instead of 2N per-thread round-trips.
-    const allLegacyMessages = await db.messages
-      .where("threadId")
-      .anyOf(unimportedIds)
-      .toArray()
-      .catch(() => [] as MessageRecord[]);
+    const allLegacyMessages = await readLegacyStore<MessageRecord[] | null>(
+      () => db.messages.where("threadId").anyOf(unimportedIds).toArray(),
+      null,
+    );
+    if (allLegacyMessages === null) return;
     const legacyByThread = new Map<string, MessageRecord[]>();
     for (const message of allLegacyMessages) {
       const arr = legacyByThread.get(message.threadId);
@@ -541,22 +652,18 @@ async function importLegacyChatsIfNeeded(): Promise<void> {
     }
 
     if (newlyImportedIds.length === 0) {
-      markLegacyChatImportDone();
+      if (await completeLegacyChatImport([])) {
+        await retireLegacyChatStore();
+      }
       return;
     }
-    let result: { supported: boolean };
     try {
-      result = await recordChatImportLedger(newlyImportedIds);
+      if (await completeLegacyChatImport(newlyImportedIds)) {
+        await retireLegacyChatStore();
+      }
     } catch {
-      // Network error: leave the perf hint alone so the next launch
-      // retries. Import is idempotent via UPSERT, so no duplicates.
+      // Import is idempotent, so a failed completion record can retry.
       return;
-    }
-    // Only flip the hint when the backend actually has the ledger. On
-    // older deployments (404/405/501) it would lie ("import done" with an
-    // empty ledger), defeating recovery after a studio.db wipe.
-    if (result.supported) {
-      markLegacyChatImportDone();
     }
   })();
 
@@ -585,23 +692,27 @@ export async function getStoredChatThreadReadResult(
   if (isChatThreadDeleted(threadId)) {
     return { thread: undefined, cacheable: true };
   }
-  const legacyThread = await db.threads.get(threadId);
-  let backendThread: ThreadRecord | null;
-  try {
+  // Start the server read without waiting for legacy IndexedDB.
+  const [legacyResult, backendResult] = await Promise.allSettled([
+    readLegacyStoreIfNeeded(() => db.threads.get(threadId), undefined),
     // Bounded for a caller that is gating the UI on this read: an unbounded GET that
     // never answers leaves the request open for the life of the page, and every retry
     // opens another.
-    backendThread = await getChatThread(threadId, {
+    getChatThread(threadId, {
       bounded: options.bounded,
       timeoutMs: options.timeoutMs,
       signal: options.signal,
-    });
-  } catch (error) {
+    }),
+  ]);
+  const legacyThread =
+    legacyResult.status === "fulfilled" ? legacyResult.value : undefined;
+  if (backendResult.status === "rejected") {
     if (legacyThread && !isChatThreadDeleted(legacyThread.id)) {
       return { thread: legacyThread, cacheable: false };
     }
-    throw error;
+    throw backendResult.reason;
   }
+  const backendThread = backendResult.value;
   if (backendThread && !isChatThreadDeleted(backendThread.id)) {
     return {
       thread: await backfillLegacyThreadFields(backendThread, legacyThread),
@@ -637,22 +748,25 @@ export async function ensureStoredChatThread(
   // Outcome ignored on purpose: adopting the failure here would skip the retryFailedThreadRecord
   // branch below for exactly the callers already waiting when the write rejected.
   await awaitStoredChatThreadWrites(threadId);
-  const legacyThread = fallback ?? (await db.threads.get(threadId));
-  let backendThread: ThreadRecord | null;
-  try {
-    // Bounded for a caller whose own request carries a deadline: this read runs BEFORE
-    // it, so an unbounded one here means neither the caller's signal nor the write
-    // timeout ever applies and the write chain behind it never settles.
-    backendThread = await getChatThread(threadId, {
+  const [legacyResult, backendResult] = await Promise.allSettled([
+    fallback === undefined
+      ? readLegacyStoreIfNeeded(() => db.threads.get(threadId), undefined)
+      : Promise.resolve(fallback),
+    // Keep this prerequisite within the caller's deadline.
+    getChatThread(threadId, {
       bounded: options.bounded,
       signal: options.signal,
-    });
-  } catch (error) {
+    }),
+  ]);
+  const legacyThread =
+    legacyResult.status === "fulfilled" ? legacyResult.value : undefined;
+  if (backendResult.status === "rejected") {
     if (!legacyThread || isChatThreadDeleted(legacyThread.id)) {
-      throw error;
+      throw backendResult.reason;
     }
     return legacyThread;
   }
+  const backendThread = backendResult.value;
   if (backendThread) {
     return backfillLegacyThreadFields(backendThread, legacyThread);
   }
@@ -687,23 +801,36 @@ export async function listStoredChatMessages(
 ): Promise<MessageRecord[]> {
   if (isThreadIncognito(threadId)) return [];
   if (isChatThreadDeleted(threadId)) return [];
-  const legacyMessages = await db.messages
-    .where("threadId")
-    .equals(threadId)
-    .toArray();
-  const [backendThread, backendMessages] = await Promise.all([
-    getChatThread(threadId).catch(() => undefined),
-    listChatMessages(threadId).catch((error) => {
-      if (legacyMessages.length > 0) {
-        return undefined;
-      }
-      throw error;
-    }),
-  ]);
+  const [legacyResult, backendThreadResult, backendMessagesResult] =
+    await Promise.allSettled([
+      readLegacyStoreIfNeeded(
+        () => db.messages.where("threadId").equals(threadId).toArray(),
+        [] as MessageRecord[],
+      ),
+      getChatThread(threadId),
+      listChatMessages(threadId),
+    ]);
+  const legacyMessages =
+    legacyResult.status === "fulfilled" ? legacyResult.value : [];
+  const backendThread =
+    backendThreadResult.status === "fulfilled"
+      ? backendThreadResult.value
+      : undefined;
+  if (
+    backendMessagesResult.status === "rejected" &&
+    legacyMessages.length === 0
+  ) {
+    throw backendMessagesResult.reason;
+  }
+  // Keep the final tombstone filter on the legacy fallback.
+  const backendMessages =
+    backendMessagesResult.status === "fulfilled"
+      ? backendMessagesResult.value
+      : undefined;
   if (backendMessages && (backendThread || backendMessages.length > 0)) {
     const merged = mergeMessages(backendMessages, legacyMessages, {
       includeLegacyOnly:
-        !isLegacyChatImportDone() ||
+        !legacyChatImportComplete ||
         (backendMessages.length === 0 && legacyMessages.length > 0),
     });
     if (legacyMessages.length > 0 && merged.shouldSync) {
@@ -715,7 +842,7 @@ export async function listStoredChatMessages(
   }
   if (
     backendMessages &&
-    isLegacyChatImportDone() &&
+    legacyChatImportComplete &&
     legacyMessages.length === 0
   ) {
     return [];
@@ -731,18 +858,21 @@ export async function getStoredChatMessage(
 ): Promise<MessageRecord | undefined> {
   if (isThreadIncognito(threadId)) return undefined;
   if (isChatThreadDeleted(threadId)) return undefined;
-  const legacyMessage = await db.messages.get(messageId);
+  const [legacyResult, backendResult] = await Promise.allSettled([
+    readLegacyStoreIfNeeded(() => db.messages.get(messageId), undefined),
+    getChatMessage(threadId, messageId),
+  ]);
+  const legacyMessage =
+    legacyResult.status === "fulfilled" ? legacyResult.value : undefined;
   const matchingLegacyMessage =
     legacyMessage?.threadId === threadId ? legacyMessage : undefined;
-  let backendMessage: MessageRecord | null;
-  try {
-    backendMessage = await getChatMessage(threadId, messageId);
-  } catch (error) {
+  if (backendResult.status === "rejected") {
     if (matchingLegacyMessage) {
       return matchingLegacyMessage;
     }
-    throw error;
+    throw backendResult.reason;
   }
+  const backendMessage = backendResult.value;
   if (backendMessage) {
     if (
       matchingLegacyMessage &&
@@ -759,25 +889,41 @@ export async function listStoredChatThreads(
   args: ThreadListArgs = {},
 ): Promise<ThreadRecord[]> {
   const importGenerationBeforeRead = legacyChatImportGeneration;
-  const legacyThreads = await listLegacyThreads(args);
-  let backendThreads = await listChatThreads(args).catch((error) => {
-    if (legacyThreads.length > 0) {
-      return undefined;
-    }
-    throw error;
-  });
+  const serverRead = listChatThreadsWithMigrationState(args);
+  const backendResult = await serverRead.then(
+    (result) => {
+      noteLegacyChatImportComplete(result.legacyImportComplete);
+      return { threads: result.threads };
+    },
+    (error: unknown) => ({ error }),
+  );
+  const legacyThreads =
+    "threads" in backendResult && legacyChatImportComplete
+      ? []
+      : await listLegacyThreads(args);
+  if ("error" in backendResult && legacyThreads.length === 0) {
+    throw backendResult.error;
+  }
+  let backendThreads =
+    "threads" in backendResult ? backendResult.threads : undefined;
   if (backendThreads) {
     await importLegacyChatsIfNeeded().catch(() => undefined);
     // a point import can commit its row before its generation bump lands, so wait on the ones
     // already in flight rather than trusting the generation alone
     await Promise.allSettled([...pendingLegacyThreadImports]);
     if (legacyChatImportGeneration !== importGenerationBeforeRead) {
-      backendThreads = await listChatThreads(args).catch(() => backendThreads);
+      backendThreads = await listChatThreadsWithMigrationState(args).then(
+        (result) => {
+          noteLegacyChatImportComplete(result.legacyImportComplete);
+          return result.threads;
+        },
+        () => backendThreads,
+      );
     }
   }
   const includeLegacyOnly =
     !backendThreads ||
-    !isLegacyChatImportDone() ||
+    !legacyChatImportComplete ||
     (backendThreads.length === 0 && legacyThreads.length > 0);
   const byId = new Map<string, ThreadRecord>();
   if (includeLegacyOnly) {
@@ -985,12 +1131,17 @@ export async function deleteStoredChatThreads(
   }
   threadRecordWrites.confirmFinalState(ids);
   if (ids.length === 0) return kept;
-  await db
-    .transaction("rw", db.threads, db.messages, async () => {
-      await db.messages.where("threadId").anyOf(ids).delete();
-      await db.threads.bulkDelete(ids);
-    })
-    .catch(() => undefined);
+  // Legacy cleanup must not block the completed server deletion.
+  await readLegacyStoreIfNeeded(
+    () =>
+      db
+        .transaction("rw", db.threads, db.messages, async () => {
+          await db.messages.where("threadId").anyOf(ids).delete();
+          await db.threads.bulkDelete(ids);
+        })
+        .catch(() => undefined),
+    undefined,
+  );
   markChatThreadsDeleted(ids);
   return kept;
 }
@@ -1037,7 +1188,10 @@ async function clearStoredChatsWithAdmissionClosed(
   // Admission is closed before this one-shot fence snapshot.
   const pendingThreadIds = threadRecordWrites.idsRequiringFence();
   const operationId = crypto.randomUUID();
-  const legacyThreads = await db.threads.toArray().catch(() => []);
+  const legacyThreads = await readLegacyStoreIfNeeded(
+    () => db.threads.toArray(),
+    [] as ThreadRecord[],
+  );
   const legacyThreadIds = new Set(legacyThreads.map((thread) => thread.id));
   const idsToFence = Array.from(
     new Set([...legacyThreadIds, ...pendingThreadIds]),
@@ -1077,15 +1231,22 @@ async function clearStoredChatsWithAdmissionClosed(
     console.error("clearStoredChats: backend clear failed", error);
   }
 
-  try {
-    await db.transaction("rw", db.threads, db.messages, async () => {
-      await db.messages.clear();
-      await db.threads.clear();
-    });
-    result.legacy = "cleared";
-  } catch (error) {
-    result.legacy = "failed";
-    console.error("clearStoredChats: legacy Dexie clear failed", error);
+  const clearLegacyChats = async () => {
+    try {
+      await db.transaction("rw", db.threads, db.messages, async () => {
+        await db.messages.clear();
+        await db.threads.clear();
+      });
+      return true;
+    } catch (error) {
+      console.error("clearStoredChats: legacy Dexie clear failed", error);
+      return false;
+    }
+  };
+  if (!legacyChatImportComplete) {
+    result.legacy = (await readLegacyStoreIfNeeded(clearLegacyChats, false))
+      ? "cleared"
+      : "failed";
   }
 
   // reported from the rows the backend says it removed, never from the fence set: an id fenced for
@@ -1113,10 +1274,9 @@ async function clearStoredChatsWithAdmissionClosed(
 
 export async function buildStoredChatExport(): Promise<ExportedChat> {
   await importLegacyChatsIfNeeded().catch(() => undefined);
-  const [legacyThreads, legacyMessages] = await Promise.all([
-    db.threads.toArray(),
-    db.messages.toArray(),
-  ]);
+  const [legacyThreads, legacyMessages] = await readLegacyStoreIfNeeded<
+    [ThreadRecord[], MessageRecord[]]
+  >(() => Promise.all([db.threads.toArray(), db.messages.toArray()]), [[], []]);
   const hasLegacyData =
     legacyThreads.some((thread) => !isChatThreadDeleted(thread.id)) ||
     legacyMessages.some((message) => !isChatThreadDeleted(message.threadId));
@@ -1139,7 +1299,7 @@ export async function buildStoredChatExport(): Promise<ExportedChat> {
     if (isChatThreadDeleted(message.threadId)) continue;
     messagesById.set(message.id, message);
   }
-  const includeLegacyOnly = backend === null || !isLegacyChatImportDone();
+  const includeLegacyOnly = backend === null || !legacyChatImportComplete;
   for (const thread of legacyThreads as ThreadRecord[]) {
     if (
       isChatThreadDeleted(thread.id) ||

--- a/studio/frontend/src/features/chat/utils/legacy-store-gate.ts
+++ b/studio/frontend/src/features/chat/utils/legacy-store-gate.ts
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+/** Bounds legacy storage access and latches to the fallback after a failure. */
+export class LegacyStoreGate {
+  responds = true;
+  timeoutMs: number;
+
+  constructor(timeoutMs = 1_000) {
+    this.timeoutMs = timeoutMs;
+  }
+
+  async read<T>(read: () => Promise<T>, fallback: T): Promise<T> {
+    if (!this.responds) return fallback;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      return await Promise.race([
+        read(),
+        new Promise<T>((resolve) => {
+          timer = setTimeout(() => {
+            this.responds = false;
+            resolve(fallback);
+          }, this.timeoutMs);
+        }),
+      ]);
+    } catch {
+      this.responds = false;
+      return fallback;
+    } finally {
+      if (timer !== undefined) clearTimeout(timer);
+    }
+  }
+}

--- a/studio/frontend/src/features/chat/utils/repair-legacy-chat-titles.ts
+++ b/studio/frontend/src/features/chat/utils/repair-legacy-chat-titles.ts
@@ -104,7 +104,8 @@ async function runRepairPass(threads: ThreadRecord[]): Promise<number> {
   if (withoutMessages.length > 0) {
     let imported = new Set<string>();
     try {
-      imported = await listChatImportLedger();
+      const ledger = await listChatImportLedger();
+      imported = ledger.complete ? new Set(ids) : ledger.threadIds;
     } catch {
       // Undecided, so keep every one of them retryable.
     }

--- a/studio/frontend/tests/legacy-chat-store-blocks-history.test.ts
+++ b/studio/frontend/tests/legacy-chat-store-blocks-history.test.ts
@@ -1,0 +1,352 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// A WebKit downgrade can leave legacy IndexedDB requests pending forever.
+// Server-backed chat history must remain usable when that happens.
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { MessageRecord, ThreadRecord } from "../src/features/chat/types";
+import { LegacyStoreGate } from "../src/features/chat/utils/legacy-store-gate.ts";
+import { loadWithStubs } from "./helpers/module-stubs.ts";
+
+type Storage = {
+  buildStoredChatExport: () => Promise<unknown>;
+  clearStoredChats: () => Promise<{ legacy: string }>;
+  deleteStoredChatThreads: (ids: string[]) => Promise<string[]>;
+  getStoredChatMessage: (
+    threadId: string,
+    messageId: string,
+  ) => Promise<MessageRecord | undefined>;
+  getStoredChatThread: (threadId: string) => Promise<ThreadRecord | undefined>;
+  legacyChatStoreResponds: () => boolean;
+  listStoredChatMessages: (threadId: string) => Promise<MessageRecord[]>;
+  listStoredChatThreads: () => Promise<ThreadRecord[]>;
+};
+
+const thread = (id: string, title: string, updatedAt: number): ThreadRecord => ({
+  id,
+  title,
+  modelType: "base",
+  archived: false,
+  createdAt: 1,
+  updatedAt,
+});
+
+const message = (id: string, threadId: string): MessageRecord => ({
+  id,
+  threadId,
+  role: "user",
+  content: [{ type: "text", text: "hi" }],
+  createdAt: 1,
+});
+
+const never = () => new Promise<never>(() => {});
+const stalledCollection = { toArray: never, count: never, delete: never };
+const stalled = {
+  get: never,
+  toArray: never,
+  count: never,
+  bulkDelete: never,
+  clear: never,
+  toCollection: () => stalledCollection,
+  where: () => ({
+    equals: () => stalledCollection,
+    anyOf: () => stalledCollection,
+  }),
+};
+
+class StubWriteCoordinator {
+  confirmFinalState() {}
+  closeAdmission() {
+    return () => {};
+  }
+  idsRequiringFence() {
+    return [] as string[];
+  }
+  settleCurrent() {
+    return Promise.resolve();
+  }
+}
+
+class PassthroughGate {
+  responds = true;
+  read<T>(read: () => Promise<T>): Promise<T> {
+    return read();
+  }
+}
+
+function loadStorage(options: {
+  db: unknown;
+  serverThreads?: ThreadRecord[];
+  serverMessages?: Map<string, MessageRecord[]>;
+  listChatThreads?: () => Promise<ThreadRecord[]>;
+  legacyImportComplete?: boolean;
+  calls?: string[];
+  gate?: unknown;
+  appVersion?: string;
+}): Storage {
+  const serverThreads = options.serverThreads ?? [];
+  const serverMessages =
+    options.serverMessages ?? new Map<string, MessageRecord[]>();
+  const record = (call: string) => options.calls?.push(call);
+  return loadWithStubs<Storage>(
+    new URL(
+      "../src/features/chat/utils/chat-history-storage.ts",
+      import.meta.url,
+    ),
+    {
+      "@tauri-apps/api/app": {
+        getVersion: async () => options.appVersion ?? "test-version",
+      },
+      "../api/chat-api": {
+        ChatThreadDeletedError: class extends Error {},
+        buildBackendChatExport: async () => ({ threads: [], messages: [] }),
+        clearBackendChats: async () => ({
+          deletedThreadIds: [],
+          sandboxesKept: [],
+        }),
+        deleteChatThreads: async (ids: string[]) => ids,
+        getChatMessage: async (threadId: string, messageId: string) => {
+          record(`getChatMessage:${threadId}:${messageId}`);
+          return (
+            (serverMessages.get(threadId) ?? []).find(
+              (candidate) => candidate.id === messageId,
+            ) ?? null
+          );
+        },
+        getChatThread: async (threadId: string) => {
+          record(`getChatThread:${threadId}`);
+          return serverThreads.find((row) => row.id === threadId) ?? null;
+        },
+        listChatImportLedger: async () => ({
+          threadIds: new Set<string>(),
+          complete: options.legacyImportComplete ?? false,
+          supported: true,
+        }),
+        listChatMessages: async (threadId: string) => {
+          record(`listChatMessages:${threadId}`);
+          return serverMessages.get(threadId) ?? [];
+        },
+        listChatThreads:
+          options.listChatThreads ??
+          (async () => {
+            record("listChatThreads");
+            return serverThreads;
+          }),
+        listChatThreadsWithMigrationState: async () => {
+          record("listChatThreads");
+          if (options.listChatThreads) {
+            return {
+              threads: await options.listChatThreads(),
+              legacyImportComplete: options.legacyImportComplete ?? false,
+            };
+          }
+          return {
+            threads: serverThreads,
+            legacyImportComplete: options.legacyImportComplete ?? false,
+          };
+        },
+        notifyChatHistoryUpdated: () => {},
+        recordChatImportLedger: async () => {
+          record("recordChatImportLedger:complete");
+          return {
+            accepted: 0,
+            inserted: 0,
+            complete: true,
+            supported: true,
+          };
+        },
+      },
+      "../db": { DEXIE_DB_NAME: "unsloth-chat", db: options.db },
+      "./chat-thread-tombstones": {
+        isChatThreadDeleted: () => false,
+        markChatThreadDeleted: () => {},
+        markChatThreadsDeleted: () => {},
+      },
+      "./legacy-store-gate": {
+        LegacyStoreGate: options.gate ?? LegacyStoreGate,
+      },
+      "./thread-record-write-coordinator": {
+        ThreadRecordWriteCoordinator: StubWriteCoordinator,
+      },
+    },
+  );
+}
+
+Object.assign(globalThis, {
+  indexedDB: { databases: async () => [{ name: "unsloth-chat" }] },
+});
+
+test("legacy storage cannot delay any server chat read", async () => {
+  const calls: string[] = [];
+  const storage = loadStorage({
+    db: { threads: stalled, messages: stalled },
+    serverThreads: [thread("t1", "yesterday", 2), thread("t2", "last week", 4)],
+    serverMessages: new Map([["t1", [message("m1", "t1")]]]),
+    calls,
+  });
+
+  const threadsPromise = storage.listStoredChatThreads();
+  const threadPromise = storage.getStoredChatThread("t1");
+  const messagesPromise = storage.listStoredChatMessages("t1");
+  const messagePromise = storage.getStoredChatMessage("t1", "m1");
+
+  // Every server read starts before the legacy timeout.
+  assert.deepEqual(calls, [
+    "listChatThreads",
+    "getChatThread:t1",
+    "getChatThread:t1",
+    "listChatMessages:t1",
+    "getChatMessage:t1:m1",
+  ]);
+
+  const [threads, one, messages, single] = await Promise.all([
+    threadsPromise,
+    threadPromise,
+    messagesPromise,
+    messagePromise,
+  ]);
+  assert.deepEqual(
+    threads.map((row) => row.id),
+    ["t2", "t1"],
+  );
+  assert.equal(one?.title, "yesterday");
+  assert.deepEqual(
+    messages.map((row) => row.id),
+    ["m1"],
+  );
+  assert.equal(single?.id, "m1");
+  assert.equal(
+    storage.legacyChatStoreResponds(),
+    false,
+    "the unreadable store should have been given up on",
+  );
+});
+
+test("a store already given up on costs the next read nothing", async () => {
+  const storage = loadStorage({ db: { threads: stalled, messages: stalled } });
+  await storage.listStoredChatThreads();
+  assert.equal(storage.legacyChatStoreResponds(), false);
+
+  const started = Date.now();
+  await storage.listStoredChatThreads();
+  assert.ok(
+    Date.now() - started < 500,
+    "later reads must not pay the timeout again",
+  );
+});
+
+test("an unreadable desktop store is retried only after the app version changes", async () => {
+  const previousWindow = globalThis.window;
+  const previousLocalStorage = globalThis.localStorage;
+  const values = new Map<string, string>();
+  Object.assign(globalThis, {
+    window: {
+      __TAURI_INTERNALS__: {},
+      location: { protocol: "tauri:" },
+    },
+    localStorage: {
+      getItem: (key: string) => values.get(key) ?? null,
+      removeItem: (key: string) => values.delete(key),
+      setItem: (key: string, value: string) => values.set(key, value),
+    },
+  });
+
+  try {
+    const firstLaunch = loadStorage({
+      db: { threads: stalled, messages: stalled },
+    });
+    await firstLaunch.listStoredChatThreads();
+    assert.equal(firstLaunch.legacyChatStoreResponds(), false);
+
+    const secondLaunch = loadStorage({
+      db: { threads: stalled, messages: stalled },
+    });
+    const started = Date.now();
+    await secondLaunch.listStoredChatThreads();
+    assert.ok(Date.now() - started < 500);
+    assert.equal(
+      secondLaunch.legacyChatStoreResponds(),
+      true,
+      "the second launch must not consult IndexedDB",
+    );
+
+    const updatedApp = loadStorage({
+      db: { threads: stalled, messages: stalled },
+      appVersion: "next-version",
+    });
+    await updatedApp.listStoredChatThreads();
+    assert.equal(updatedApp.legacyChatStoreResponds(), false);
+  } finally {
+    if (previousWindow === undefined) Reflect.deleteProperty(globalThis, "window");
+    else globalThis.window = previousWindow;
+    if (previousLocalStorage === undefined) {
+      Reflect.deleteProperty(globalThis, "localStorage");
+    }
+    else globalThis.localStorage = previousLocalStorage;
+  }
+});
+
+test("a completed migration never opens legacy storage", async () => {
+  const storage = loadStorage({
+    db: { threads: stalled, messages: stalled },
+    serverThreads: [thread("server", "saved", 2)],
+    legacyImportComplete: true,
+  });
+
+  assert.deepEqual(
+    (await storage.listStoredChatThreads()).map((row) => row.id),
+    ["server"],
+  );
+  assert.equal(storage.legacyChatStoreResponds(), true);
+});
+
+test("an empty legacy database is completed and retired", async () => {
+  const calls: string[] = [];
+  const emptyCollection = {
+    toArray: async () => [],
+    count: async () => 0,
+  };
+  const storage = loadStorage({
+    calls,
+    db: {
+      threads: { ...emptyCollection, toCollection: () => emptyCollection },
+      messages: emptyCollection,
+      close: () => calls.push("close"),
+      delete: async () => calls.push("delete"),
+    },
+  });
+
+  assert.deepEqual(await storage.listStoredChatThreads(), []);
+  assert.ok(calls.includes("recordChatImportLedger:complete"));
+  assert.ok(calls.includes("close"));
+  assert.ok(calls.includes("delete"));
+});
+
+test("deleting, clearing and exporting still finish", async () => {
+  const storage = loadStorage({
+    db: { threads: stalled, messages: stalled, transaction: never },
+  });
+  assert.deepEqual(await storage.deleteStoredChatThreads(["t1"]), ["t1"]);
+  assert.equal((await storage.clearStoredChats()).legacy, "failed");
+  assert.ok(await storage.buildStoredChatExport());
+});
+
+test("legacy-only chats remain available when the server read fails", async () => {
+  const legacyThread = thread("legacy", "before the server", 2);
+  const legacyCollection = { toArray: async () => [legacyThread] };
+  const storage = loadStorage({
+    db: {
+      threads: {
+        toCollection: () => legacyCollection,
+        where: () => ({ equals: () => legacyCollection }),
+      },
+    },
+    listChatThreads: () => Promise.reject(new Error("server unavailable")),
+    gate: PassthroughGate,
+  });
+
+  assert.deepEqual(await storage.listStoredChatThreads(), [legacyThread]);
+});

--- a/studio/frontend/tests/legacy-store-gate.test.ts
+++ b/studio/frontend/tests/legacy-store-gate.test.ts
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { LegacyStoreGate } from "../src/features/chat/utils/legacy-store-gate.ts";
+
+test("a store that answers is passed straight through", async () => {
+  const gate = new LegacyStoreGate(50);
+  assert.deepEqual(await gate.read(async () => ["thread"], []), ["thread"]);
+  assert.equal(gate.responds, true);
+});
+
+test("a store that never answers yields the fallback instead of hanging", async () => {
+  const gate = new LegacyStoreGate(20);
+  const started = Date.now();
+  const threads = await gate.read(() => new Promise<string[]>(() => {}), []);
+  assert.deepEqual(threads, []);
+  assert.ok(Date.now() - started < 1_000, "the read must not wait indefinitely");
+  assert.equal(gate.responds, false);
+});
+
+test("a store that rejects yields the fallback", async () => {
+  const gate = new LegacyStoreGate(50);
+  const threads = await gate.read(async () => {
+    throw new Error("VersionError");
+  }, []);
+  assert.deepEqual(threads, []);
+  assert.equal(gate.responds, false);
+});
+
+test("a refusal latches, so later reads cost nothing", async () => {
+  const gate = new LegacyStoreGate(20);
+  await gate.read(() => new Promise<string[]>(() => {}), []);
+  let called = false;
+  const started = Date.now();
+  const threads = await gate.read(async () => {
+    called = true;
+    return ["thread"];
+  }, []);
+  assert.equal(called, false, "the store must not be consulted again");
+  assert.deepEqual(threads, []);
+  assert.ok(Date.now() - started < 20, "a latched gate must return immediately");
+});
+
+test("a slow but healthy store keeps its answer", async () => {
+  const gate = new LegacyStoreGate(200);
+  const threads = await gate.read(
+    () => new Promise<string[]>((resolve) => setTimeout(() => resolve(["late"]), 20)),
+    [],
+  );
+  assert.deepEqual(threads, ["late"]);
+  assert.equal(gate.responds, true);
+});


### PR DESCRIPTION
Follow-up to #9113.

## Problem

The complete Linux AppImage bundles WebKitGTK 2.50.4 but reuses Studio's existing WebView profile. A profile last written by WebKitGTK 2.52.3 can leave the legacy chat IndexedDB open permanently pending under the bundled runtime.

Current chats have lived in `studio.db` since #5272, but Studio still consulted the legacy database for migration and fallback. When that open stalled, the sidebar never displayed the intact server-backed history.

In the reproduced profile, the legacy database contained zero chat records. Moving it aside removed the stalled open and allowed the chats in `studio.db` to appear.

## Fix

- Bound legacy IndexedDB access to one second so it cannot block server-backed history.
- Record migration completion in `studio.db` and skip the legacy database on all later launches.
- After a readable migration, including an empty one, delete only the `unsloth-chat` database.
- Remember unreadable stores for the current desktop version and retry after an application update.

The migration remains recoverable after a `studio.db` wipe and never touches the sibling `unsloth-data-recipes` database or the rest of the WebView profile.

## Verification

- Reproduced the empty sidebar with the affected profile under bundled WebKitGTK 2.50.4; the same `studio.db` showed its chats with a fresh profile.
- In a controlled source A/B with permanently pending IndexedDB, `origin/main` timed out while the fix returned the server chat after the one-second bound.
- Frontend suite: 4,245 passed.
- Chat history backend suites: 81 passed.
- TypeScript typecheck, ESLint, and `git diff --check` passed.
