### PR TITLE
fix(studio): resolve PowerShell by absolute path in the update gate

### DIFF
--- a/tests/test_installer_profile_hardening.py
+++ b/tests/test_installer_profile_hardening.py
@@ -196,7 +196,7 @@ def test_setup_ps1_handoff_never_inherits_the_profile():
     whole file is about ran setup.ps1 with the user's profile loaded and its bare `uv` calls
     exposed to the same alias."""
     src = STUDIO_COMMAND.read_text(encoding = "utf-8")
-    start = _locate(src, 'powershell_args = ["powershell.exe"]', "the setup.ps1 launch")
+    start = _locate(src, "powershell_args = [powershell]", "the setup.ps1 launch")
     branch = _locate(src[start:], "_should_hide_windows_subprocesses()", "the hidden-window branch")
     assert (
         '"-NoProfile"' in src[start : start + branch]
@@ -702,7 +702,7 @@ def test_the_setup_launch_reapplies_the_proxy_it_told_the_child_to_forget():
     assert "_UNSLOTH_PS_PROXY_DEFAULTS" in prelude, "the child must read it back"
 
     src = STUDIO_COMMAND.read_text(encoding = "utf-8")
-    start = _locate(src, 'powershell_args = ["powershell.exe"]', "the setup.ps1 launch")
+    start = _locate(src, "powershell_args = [powershell]", "the setup.ps1 launch")
     # The f-string itself, not the comment above it that also quotes *>&1.
     command = _locate(src[start:], 'f"', "the -Command f-string")
     assert (
@@ -865,7 +865,7 @@ def test_a_standalone_update_reconstructs_the_proxy_for_itself():
     never reach this Python process. So it is asked for, before -NoProfile drops it."""
     src = STUDIO_COMMAND.read_text(encoding = "utf-8")
     assert "_probe_profile_proxy_defaults" in src
-    start = _locate(src, 'powershell_args = ["powershell.exe"]', "the setup.ps1 launch")
+    start = _locate(src, "powershell_args = [powershell]", "the setup.ps1 launch")
     guard = _locate(src[start:], "_probe_profile_proxy_defaults(", "the probe call")
     noprofile = _locate(src[start:], '"-NoProfile"', "the -NoProfile flag")
     assert guard < noprofile, "the probe has to run while the profile is still reachable"

--- a/unsloth_cli/_studio_runtime_gate.py
+++ b/unsloth_cli/_studio_runtime_gate.py
@@ -95,7 +95,7 @@ def _canonical_windows_path(path: Path) -> str:
 
 
 def _windows_paths_equal(left: str, right: str) -> bool:
-    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error = True)
     compare = kernel32.CompareStringOrdinal
     compare.argtypes = [
         wintypes.LPCWSTR,
@@ -131,7 +131,7 @@ def runtime_mutex_name_for_studio_home(studio_home: Path) -> str:
 
 def _current_windows_user_sid() -> str:
     kernel32 = ctypes.WinDLL("kernel32", use_last_error = True)
-    advapi32 = ctypes.WinDLL("advapi32", use_last_error=True)
+    advapi32 = ctypes.WinDLL("advapi32", use_last_error = True)
 
     kernel32.GetCurrentProcess.restype = wintypes.HANDLE
     kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
@@ -199,7 +199,7 @@ def studio_runtime_launch_guard(studio_home: Path, *, inherited: bool = False) -
         yield False
         return
 
-    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error = True)
     kernel32.CreateMutexW.argtypes = [
         ctypes.c_void_p,
         wintypes.BOOL,
@@ -272,12 +272,12 @@ def ensure_managed_environment_is_idle(studio_home: Path) -> None:
     )
     result = subprocess.run(
         [_resolve_windows_powershell(), "-NoProfile", "-NonInteractive", "-Command", script],
-        capture_output=True,
-        text=True,
-        encoding="utf-8",
-        errors="replace",
-        creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
-        check=False,
+        capture_output = True,
+        text = True,
+        encoding = "utf-8",
+        errors = "replace",
+        creationflags = getattr(subprocess, "CREATE_NO_WINDOW", 0),
+        check = False,
     )
     if result.returncode != 0:
         detail = result.stderr.strip() or f"exit code {result.returncode}"

--- a/unsloth_cli/_studio_runtime_gate.py
+++ b/unsloth_cli/_studio_runtime_gate.py
@@ -74,14 +74,7 @@ def _resolved_windows_path(path: Path) -> str:
 
 
 def _resolve_windows_powershell() -> str:
-    """Absolute Windows PowerShell path that does not depend on PATH (#9440).
-
-    A GUI-launched Desktop app can run with a PATH that omits
-    ``System32\WindowsPowerSphere1.0`` (or a stripped environment), and
-    ``subprocess`` then fails with ``FileNotFoundError: [WinError 2]`` before
-    PowerShell ever starts. Prefer PATH resolution, fall back to the built-in
-    absolute location, then PowerShell 7.
-    """
+    r"""Resolve Windows PowerShell without relying solely on ``PATH`` (#9440)."""
     import shutil
 
     on_path = shutil.which("powershell.exe")

--- a/unsloth_cli/_studio_runtime_gate.py
+++ b/unsloth_cli/_studio_runtime_gate.py
@@ -73,8 +73,13 @@ def _resolved_windows_path(path: Path) -> str:
     return resolved.rstrip("\\/")
 
 
-def _resolve_windows_powershell() -> str:
-    r"""Resolve Windows PowerShell without relying solely on ``PATH`` (#9440)."""
+def resolve_windows_powershell() -> str:
+    r"""Resolve Windows PowerShell without relying solely on ``PATH`` (#9440).
+
+    Public because the install path spawns PowerShell from more than this module: powershell.exe
+    lives in a SUBDIRECTORY of System32, so ``CreateProcess``'s implicit system-directory lookup
+    never finds it and a caller whose PATH omits that entry gets ``WinError 2`` instead.
+    """
     import shutil
 
     on_path = shutil.which("powershell.exe")
@@ -271,7 +276,7 @@ def ensure_managed_environment_is_idle(studio_home: Path) -> None:
         "[Console]::Out.Write(($items|ConvertTo-Json -Compress))"
     )
     result = subprocess.run(
-        [_resolve_windows_powershell(), "-NoProfile", "-NonInteractive", "-Command", script],
+        [resolve_windows_powershell(), "-NoProfile", "-NonInteractive", "-Command", script],
         capture_output = True,
         text = True,
         encoding = "utf-8",

--- a/unsloth_cli/_studio_runtime_gate.py
+++ b/unsloth_cli/_studio_runtime_gate.py
@@ -88,9 +88,7 @@ def _resolve_windows_powershell() -> str:
     if on_path:
         return on_path
     system_root = os.environ.get("SystemRoot") or r"C:\Windows"
-    builtin = ntpath.join(
-        system_root, "System32", "WindowsPowerShell", "v1.0", "powershell.exe"
-    )
+    builtin = ntpath.join(system_root, "System32", "WindowsPowerShell", "v1.0", "powershell.exe")
     if os.path.isfile(builtin):
         return builtin
     pwsh = shutil.which("pwsh.exe")
@@ -104,7 +102,7 @@ def _canonical_windows_path(path: Path) -> str:
 
 
 def _windows_paths_equal(left: str, right: str) -> bool:
-    kernel32 = ctypes.WinDLL("kernel32", use_last_error = True)
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
     compare = kernel32.CompareStringOrdinal
     compare.argtypes = [
         wintypes.LPCWSTR,
@@ -140,7 +138,7 @@ def runtime_mutex_name_for_studio_home(studio_home: Path) -> str:
 
 def _current_windows_user_sid() -> str:
     kernel32 = ctypes.WinDLL("kernel32", use_last_error = True)
-    advapi32 = ctypes.WinDLL("advapi32", use_last_error = True)
+    advapi32 = ctypes.WinDLL("advapi32", use_last_error=True)
 
     kernel32.GetCurrentProcess.restype = wintypes.HANDLE
     kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
@@ -208,7 +206,7 @@ def studio_runtime_launch_guard(studio_home: Path, *, inherited: bool = False) -
         yield False
         return
 
-    kernel32 = ctypes.WinDLL("kernel32", use_last_error = True)
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
     kernel32.CreateMutexW.argtypes = [
         ctypes.c_void_p,
         wintypes.BOOL,
@@ -281,12 +279,12 @@ def ensure_managed_environment_is_idle(studio_home: Path) -> None:
     )
     result = subprocess.run(
         [_resolve_windows_powershell(), "-NoProfile", "-NonInteractive", "-Command", script],
-        capture_output = True,
-        text = True,
-        encoding = "utf-8",
-        errors = "replace",
-        creationflags = getattr(subprocess, "CREATE_NO_WINDOW", 0),
-        check = False,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
+        check=False,
     )
     if result.returncode != 0:
         detail = result.stderr.strip() or f"exit code {result.returncode}"

--- a/unsloth_cli/_studio_runtime_gate.py
+++ b/unsloth_cli/_studio_runtime_gate.py
@@ -73,6 +73,32 @@ def _resolved_windows_path(path: Path) -> str:
     return resolved.rstrip("\\/")
 
 
+def _resolve_windows_powershell() -> str:
+    """Absolute Windows PowerShell path that does not depend on PATH (#9440).
+
+    A GUI-launched Desktop app can run with a PATH that omits
+    ``System32\WindowsPowerSphere1.0`` (or a stripped environment), and
+    ``subprocess`` then fails with ``FileNotFoundError: [WinError 2]`` before
+    PowerShell ever starts. Prefer PATH resolution, fall back to the built-in
+    absolute location, then PowerShell 7.
+    """
+    import shutil
+
+    on_path = shutil.which("powershell.exe")
+    if on_path:
+        return on_path
+    system_root = os.environ.get("SystemRoot") or r"C:\Windows"
+    builtin = ntpath.join(
+        system_root, "System32", "WindowsPowerShell", "v1.0", "powershell.exe"
+    )
+    if os.path.isfile(builtin):
+        return builtin
+    pwsh = shutil.which("pwsh.exe")
+    if pwsh:
+        return pwsh
+    return "powershell.exe"
+
+
 def _canonical_windows_path(path: Path) -> str:
     return _resolved_windows_path(path).replace("/", "\\")
 
@@ -254,7 +280,7 @@ def ensure_managed_environment_is_idle(studio_home: Path) -> None:
         "[Console]::Out.Write(($items|ConvertTo-Json -Compress))"
     )
     result = subprocess.run(
-        ["powershell.exe", "-NoProfile", "-NonInteractive", "-Command", script],
+        [_resolve_windows_powershell(), "-NoProfile", "-NonInteractive", "-Command", script],
         capture_output = True,
         text = True,
         encoding = "utf-8",

--- a/unsloth_cli/commands/studio.py
+++ b/unsloth_cli/commands/studio.py
@@ -3551,12 +3551,16 @@ def _run_setup_script(*, verbose: bool = False, repo_root: Optional[Path] = None
     env = {**os.environ, "UNSLOTH_VERBOSE": "1"} if verbose else None
 
     if platform.system() == "Windows":
-        powershell_args = ["powershell.exe"]
+        # Resolved, not bare: the gate that runs immediately before this in setup() and update()
+        # had to stop trusting PATH for exactly this reason (#9440), and the Popen below has no
+        # OSError handler, so a bare name here just moves the same WinError 2 one frame later.
+        powershell = _studio_runtime_gate.resolve_windows_powershell()
+        powershell_args = [powershell]
         # PRESENCE, not truthiness: install.ps1 publishes this around the handoff and sets it to
         # "{}" when it found no proxy, so treating that as "nobody handed anything over" would
         # send an installer launch off to reload the profiles it deliberately discarded.
         if os.environ.get("_UNSLOTH_PS_PROXY_DEFAULTS") is None:
-            probed = _probe_profile_proxy_defaults(_profile_probe_hosts() or ["powershell.exe"])
+            probed = _probe_profile_proxy_defaults(_profile_probe_hosts() or [powershell])
             if probed:
                 env = {**(env or os.environ), "_UNSLOTH_PS_PROXY_DEFAULTS": probed}
         # -NoProfile unconditionally, not just on the hidden branch: install.ps1 hands off to
@@ -3758,7 +3762,7 @@ def _refresh_desktop_shortcuts(*, verbose: bool = False) -> None:
     checkouts = _installers_on_disk(_installer_script_candidates(installer_name))
 
     if is_windows:
-        ps_argv: List[str] = ["powershell.exe"]
+        ps_argv: List[str] = [_studio_runtime_gate.resolve_windows_powershell()]
         # -NoProfile unconditionally, as in _run_setup_script above: gating it on the hidden
         # branch left the visible console path, where a profile is exactly what IS loaded.
         ps_argv.append("-NoProfile")

--- a/unsloth_cli/tests/test_studio_runtime_gate_powershell.py
+++ b/unsloth_cli/tests/test_studio_runtime_gate_powershell.py
@@ -1,10 +1,7 @@
-"""The Studio-update gate must find PowerShell without PATH help (#9440).
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-A GUI-launched Desktop app can run with a PATH that omits
-``System32\\WindowsPowerShell\\v1.0``; the gate's ``subprocess`` call then died
-with ``FileNotFoundError: [WinError 2]`` during ``unsloth studio setup`` before
-PowerShell ever started.
-"""
+"""Regression coverage for Studio's PowerShell resolution (#9440)."""
 
 import ntpath
 import os
@@ -18,18 +15,16 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 from unsloth_cli._studio_runtime_gate import _resolve_windows_powershell  # noqa: E402
 
 
+@pytest.mark.skipif(sys.platform != "win32", reason="requires Windows PowerShell")
 def test_resolves_through_path_when_available(monkeypatch):
     monkeypatch.setenv("SystemRoot", os.environ.get("SystemRoot", r"C:\Windows"))
     resolved = _resolve_windows_powershell()
-    # Either a PATH hit or the builtin absolute location — never a bare name that
-    # depends on the caller's PATH again.
     assert ntpath.isabs(resolved)
     assert os.path.isfile(resolved)
 
 
 def test_falls_back_to_the_builtin_location_when_path_lacks_powershell(monkeypatch, tmp_path):
-    # A PATH with no PowerShell (a stripped GUI environment) must still resolve:
-    # the builtin System32 location is absolute and does not depend on PATH.
+    # Simulate the stripped PATH from a GUI launch.
     monkeypatch.setenv("PATH", str(tmp_path))
     monkeypatch.setenv("SystemRoot", os.environ.get("SystemRoot", r"C:\Windows"))
 
@@ -51,7 +46,5 @@ def test_returns_the_bare_name_as_a_last_resort(monkeypatch, tmp_path):
     monkeypatch.setenv("SystemRoot", str(tmp_path))
     monkeypatch.delenv("ProgramFiles", raising = False)
 
-    # No PATH hit, no builtin under the (faked) SystemRoot, no pwsh: return the
-    # bare name so the subprocess error stays the familiar WinError 2 rather
-    # than a new failure mode.
+    # Preserve the familiar subprocess error when no host exists.
     assert _resolve_windows_powershell() == "powershell.exe"

--- a/unsloth_cli/tests/test_studio_runtime_gate_powershell.py
+++ b/unsloth_cli/tests/test_studio_runtime_gate_powershell.py
@@ -15,7 +15,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 from unsloth_cli._studio_runtime_gate import _resolve_windows_powershell  # noqa: E402
 
 
-@pytest.mark.skipif(sys.platform != "win32", reason="requires Windows PowerShell")
+@pytest.mark.skipif(sys.platform != "win32", reason = "requires Windows PowerShell")
 def test_resolves_through_path_when_available(monkeypatch):
     monkeypatch.setenv("SystemRoot", os.environ.get("SystemRoot", r"C:\Windows"))
     resolved = _resolve_windows_powershell()

--- a/unsloth_cli/tests/test_studio_runtime_gate_powershell.py
+++ b/unsloth_cli/tests/test_studio_runtime_gate_powershell.py
@@ -12,13 +12,13 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
-from unsloth_cli._studio_runtime_gate import _resolve_windows_powershell  # noqa: E402
+from unsloth_cli._studio_runtime_gate import resolve_windows_powershell  # noqa: E402
 
 
 @pytest.mark.skipif(sys.platform != "win32", reason = "requires Windows PowerShell")
 def test_resolves_through_path_when_available(monkeypatch):
     monkeypatch.setenv("SystemRoot", os.environ.get("SystemRoot", r"C:\Windows"))
-    resolved = _resolve_windows_powershell()
+    resolved = resolve_windows_powershell()
     assert ntpath.isabs(resolved)
     assert os.path.isfile(resolved)
 
@@ -28,7 +28,7 @@ def test_falls_back_to_the_builtin_location_when_path_lacks_powershell(monkeypat
     monkeypatch.setenv("PATH", str(tmp_path))
     monkeypatch.setenv("SystemRoot", os.environ.get("SystemRoot", r"C:\Windows"))
 
-    resolved = _resolve_windows_powershell()
+    resolved = resolve_windows_powershell()
 
     expected_root = os.environ.get("SystemRoot", r"C:\Windows")
     if os.path.isfile(
@@ -47,4 +47,94 @@ def test_returns_the_bare_name_as_a_last_resort(monkeypatch, tmp_path):
     monkeypatch.delenv("ProgramFiles", raising = False)
 
     # Preserve the familiar subprocess error when no host exists.
-    assert _resolve_windows_powershell() == "powershell.exe"
+    assert resolve_windows_powershell() == "powershell.exe"
+
+
+# ── the callers ────────────────────────────────────────────────────────────────────
+#
+# Resolving in the gate alone does not fix #9440: setup() and update() both run the gate and
+# then hand off to PowerShell again, so every spawn on that path has to use the resolver or the
+# install dies at the next one with the same WinError 2.
+
+_RESOLVED = ntpath.join(r"C:\Windows", "System32", "WindowsPowerShell", "v1.0", "powershell.exe")
+
+
+def _windows_studio(monkeypatch):
+    from unsloth_cli.commands import studio
+
+    monkeypatch.setattr(studio.platform, "system", lambda: "Windows")
+    monkeypatch.setattr(
+        studio._studio_runtime_gate, "resolve_windows_powershell", lambda: _RESOLVED
+    )
+    return studio
+
+
+class _Process:
+    def wait(self):
+        return 0
+
+
+def test_the_setup_handoff_spawns_the_resolved_interpreter(monkeypatch, tmp_path):
+    """_run_setup_script is the gate's own next line, and its Popen has no OSError handler."""
+    studio = _windows_studio(monkeypatch)
+    monkeypatch.setattr(studio, "_probe_profile_proxy_defaults", lambda hosts: None)
+    repo_root = tmp_path / "repo"
+    (repo_root / "studio").mkdir(parents = True)
+    (repo_root / "studio" / "setup.ps1").write_text("")
+
+    spawned = []
+    monkeypatch.setattr(
+        studio.subprocess, "Popen", lambda argv, **kw: spawned.append(list(argv)) or _Process()
+    )
+
+    studio._run_setup_script(repo_root = repo_root)
+
+    assert spawned and spawned[0][0] == _RESOLVED, spawned
+
+
+def test_the_profile_probe_falls_back_to_the_resolved_interpreter(monkeypatch, tmp_path):
+    """_profile_probe_hosts() keeps only hosts shutil.which finds, so the PATH that broke the
+    gate empties it and the fallback is the only host the proxy probe gets."""
+    studio = _windows_studio(monkeypatch)
+    monkeypatch.setattr(studio, "_profile_probe_hosts", list)
+    monkeypatch.delenv("_UNSLOTH_PS_PROXY_DEFAULTS", raising = False)
+    repo_root = tmp_path / "repo"
+    (repo_root / "studio").mkdir(parents = True)
+    (repo_root / "studio" / "setup.ps1").write_text("")
+
+    probed = []
+    monkeypatch.setattr(
+        studio, "_probe_profile_proxy_defaults", lambda hosts: probed.append(list(hosts))
+    )
+    monkeypatch.setattr(studio.subprocess, "Popen", lambda argv, **kw: _Process())
+
+    studio._run_setup_script(repo_root = repo_root)
+
+    assert probed == [[_RESOLVED]], probed
+
+
+def test_the_launcher_refresh_spawns_the_resolved_interpreter(monkeypatch, tmp_path):
+    """update() ends in _refresh_desktop_shortcuts. It degrades instead of crashing, so a bare
+    name silently drops the refresh -- after fetching an installer it cannot launch either."""
+    studio = _windows_studio(monkeypatch)
+    installer = tmp_path / "install.ps1"
+    installer.write_text("")
+    monkeypatch.setattr(studio, "_installers_on_disk", lambda candidates: [installer])
+    monkeypatch.setattr(
+        studio,
+        "_fetch_installer",
+        lambda *a, **k: pytest.fail("a launchable installer was on disk"),
+    )
+
+    spawned = []
+
+    class _Result:
+        returncode = 0
+
+    monkeypatch.setattr(
+        studio.subprocess, "run", lambda argv, **kw: spawned.append(list(argv)) or _Result()
+    )
+
+    studio._refresh_desktop_shortcuts()
+
+    assert spawned and spawned[0][0] == _RESOLVED, spawned

--- a/unsloth_cli/tests/test_studio_runtime_gate_powershell.py
+++ b/unsloth_cli/tests/test_studio_runtime_gate_powershell.py
@@ -1,0 +1,57 @@
+"""The Studio-update gate must find PowerShell without PATH help (#9440).
+
+A GUI-launched Desktop app can run with a PATH that omits
+``System32\\WindowsPowerShell\\v1.0``; the gate's ``subprocess`` call then died
+with ``FileNotFoundError: [WinError 2]`` during ``unsloth studio setup`` before
+PowerShell ever started.
+"""
+
+import ntpath
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from unsloth_cli._studio_runtime_gate import _resolve_windows_powershell  # noqa: E402
+
+
+def test_resolves_through_path_when_available(monkeypatch):
+    monkeypatch.setenv("SystemRoot", os.environ.get("SystemRoot", r"C:\Windows"))
+    resolved = _resolve_windows_powershell()
+    # Either a PATH hit or the builtin absolute location — never a bare name that
+    # depends on the caller's PATH again.
+    assert ntpath.isabs(resolved)
+    assert os.path.isfile(resolved)
+
+
+def test_falls_back_to_the_builtin_location_when_path_lacks_powershell(monkeypatch, tmp_path):
+    # A PATH with no PowerShell (a stripped GUI environment) must still resolve:
+    # the builtin System32 location is absolute and does not depend on PATH.
+    monkeypatch.setenv("PATH", str(tmp_path))
+    monkeypatch.setenv("SystemRoot", os.environ.get("SystemRoot", r"C:\Windows"))
+
+    resolved = _resolve_windows_powershell()
+
+    expected_root = os.environ.get("SystemRoot", r"C:\Windows")
+    if os.path.isfile(
+        ntpath.join(expected_root, "System32", "WindowsPowerShell", "v1.0", "powershell.exe")
+    ):
+        assert resolved == ntpath.join(
+            expected_root, "System32", "WindowsPowerShell", "v1.0", "powershell.exe"
+        )
+    else:
+        pytest.skip("builtin Windows PowerShell not present on this host")
+
+
+def test_returns_the_bare_name_as_a_last_resort(monkeypatch, tmp_path):
+    monkeypatch.setenv("PATH", str(tmp_path))
+    monkeypatch.setenv("SystemRoot", str(tmp_path))
+    monkeypatch.delenv("ProgramFiles", raising = False)
+
+    # No PATH hit, no builtin under the (faked) SystemRoot, no pwsh: return the
+    # bare name so the subprocess error stays the familiar WinError 2 rather
+    # than a new failure mode.
+    assert _resolve_windows_powershell() == "powershell.exe"


### PR DESCRIPTION
## Summary

**What**

`ensure_managed_environment_is_idle` now resolves the PowerShell executable instead of spawning `"powershell.exe"` by bare name: `shutil.which` first, then the builtin absolute location under `%SystemRoot%\System32\WindowsPowerShell1.0`, then `pwsh.exe`, and only when none exists the bare name (keeping the familiar error rather than a new failure mode).

**Why**

#9440 — Unsloth Studio's Windows installation fails at the final step, "Running studio setup", with `FileNotFoundError: [WinError 2]`. The traceback lands in `_studio_runtime_gate.py`'s `subprocess.run(["powershell.exe", ...])`: a GUI-launched Desktop app can carry a PATH that omits `System32\WindowsPowerShell1.0`, and `CreateProcess` then fails before PowerShell ever starts. Everything before the gate (Python, uv, venv, PyTorch, unsloth, xFormers) had installed successfully, so the entire installation was lost to a PATH lookup.

The builtin absolute path exists on every Windows install since forever and does not depend on the caller's environment, which is exactly the property the gate needs.

**Scope**: only the crashing site. The other bare `powershell.exe` invocations in the tree (e.g. the GPU-name WMI probe in `install_python_stack.py`) are explicitly best-effort with `stderr=DEVNULL` degradation and cannot crash a flow.

**Testing**

New `unsloth_cli/tests/test_studio_runtime_gate_powershell.py`, 3/3 on this Windows host:

- resolves to an absolute, existing path with a normal environment;
- with a PATH stripped of PowerShell, falls back to the builtin `SystemRoot` location (the #9440 environment);
- with PATH, SystemRoot, and pwsh all unavailable, returns the bare name (documented last resort).

`python -m pytest unsloth_cli/tests` on this host has 63 pre-existing environment-dependent failures on `main` — verified identical with this change stashed, so they are unrelated.

Fixes #9440