### PR TITLE
Studio: accept .ods files from drag and drop

### DIFF
--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -2445,11 +2445,22 @@ const Composer: FC<{
         (s.pendingImageAttachments[nativeAttachmentTargetKey]?.length ?? 0) > 0,
     ),
   );
+  const hasPendingOpenDocumentAttachments = useNativeIntentStore((s) =>
+    Boolean(
+      nativeAttachmentTargetKey &&
+        (s.pendingOpenDocumentAttachments[nativeAttachmentTargetKey]?.length ??
+          0) > 0,
+    ),
+  );
   const registeringImageDrops = useNativeIntentStore(
     (s) => s.registeringImageDrops > 0,
   );
   const [materializingDroppedImages, setMaterializingDroppedImages] =
     useState(false);
+  const [
+    materializingDroppedOpenDocuments,
+    setMaterializingDroppedOpenDocuments,
+  ] = useState(false);
   const hasPendingAudioAttachments = useNativeIntentStore((s) =>
     Boolean(
       nativeAttachmentTargetKey &&
@@ -2875,10 +2886,115 @@ const Composer: FC<{
       unsubscribe();
     };
   }, [nativeAttachmentTargetKey, aui]);
+  useEffect(() => {
+    if (!nativeAttachmentTargetKey) {
+      return;
+    }
+    const targetKey = nativeAttachmentTargetKey;
+    const identityAtSetup = composerIdentityRef.current;
+    useNativeIntentStore
+      .getState()
+      .claimImageAttachments(identityAtSetup, targetKey);
+    let disposed = false;
+    let draining = false;
+
+    const stillThisComposer = () =>
+      composerIdentityRef.current === identityAtSetup;
+    const requeue = (intents: NativeIntent[]) => {
+      const key = stillThisComposer()
+        ? (nativeAttachmentTargetKeyRef.current ?? targetKey)
+        : targetKey;
+      const store = useNativeIntentStore.getState();
+      store.addOpenDocumentAttachments(key, intents);
+      store.noteImageDropOwner(key, identityAtSetup);
+    };
+
+    const drainPendingOpenDocuments = async () => {
+      if (disposed || draining) return;
+      draining = true;
+      setMaterializingDroppedOpenDocuments(true);
+      try {
+        while (!disposed) {
+          const intents = useNativeIntentStore
+            .getState()
+            .takeOpenDocumentAttachments(targetKey);
+          if (intents.length === 0) break;
+          for (const [index, intent] of intents.entries()) {
+            if (disposed) {
+              requeue(intents.slice(index));
+              return;
+            }
+            let file: File;
+            try {
+              file = await nativeAttachmentIntentToFile(intent);
+            } catch (error) {
+              toast.error("Could not attach dropped document", {
+                description:
+                  error instanceof Error ? error.message : String(error),
+              });
+              if (stillThisComposer()) cancelQueuedSendRef.current?.();
+              continue;
+            }
+            if (
+              disposed ||
+              nativeAttachmentTargetKeyRef.current !== targetKey
+            ) {
+              requeue(intents.slice(index));
+              return;
+            }
+            try {
+              await aui.composer().addAttachment(file);
+            } catch {
+              if (stillThisComposer()) cancelQueuedSendRef.current?.();
+            }
+          }
+        }
+      } finally {
+        draining = false;
+        if (!disposed) {
+          const pending =
+            useNativeIntentStore.getState().pendingOpenDocumentAttachments[
+              targetKey
+            ]?.length ?? 0;
+          if (pending > 0 && stillThisComposer()) {
+            void drainPendingOpenDocuments();
+          } else {
+            setMaterializingDroppedOpenDocuments(false);
+          }
+        }
+      }
+    };
+
+    const unsubscribe = useNativeIntentStore.subscribe((state) => {
+      const orphaned = Object.entries(state.imageDropOwners).some(
+        ([key, owner]) => owner === identityAtSetup && key !== targetKey,
+      );
+      if (orphaned) {
+        useNativeIntentStore
+          .getState()
+          .claimImageAttachments(identityAtSetup, targetKey);
+        return;
+      }
+      if (
+        (state.pendingOpenDocumentAttachments[targetKey]?.length ?? 0) > 0
+      ) {
+        void drainPendingOpenDocuments();
+      }
+    });
+    void drainPendingOpenDocuments();
+
+    return () => {
+      disposed = true;
+      setMaterializingDroppedOpenDocuments(false);
+      unsubscribe();
+    };
+  }, [nativeAttachmentTargetKey, aui]);
   const hasMaterializingImageAttachments =
     registeringImageDrops ||
     hasPendingImageAttachments ||
-    materializingDroppedImages;
+    materializingDroppedImages ||
+    hasPendingOpenDocumentAttachments ||
+    materializingDroppedOpenDocuments;
   const hasMaterializingAudioAttachments =
     registeringAudioDrops ||
     hasPendingAudioAttachments ||

--- a/studio/frontend/src/features/chat/chat-page.tsx
+++ b/studio/frontend/src/features/chat/chat-page.tsx
@@ -2764,6 +2764,14 @@ export function ChatPage({
     },
     [artifactViewKey],
   );
+  const handleNativeOpenDocumentDrop = useCallback(
+    (intents: NativeIntent[]) => {
+      useNativeIntentStore
+        .getState()
+        .addOpenDocumentAttachments(artifactViewKey, intents);
+    },
+    [artifactViewKey],
+  );
   const handleNativeAudioDrop = useCallback(
     (intents: NativeIntent[]) => {
       useNativeIntentStore.getState().addAudioAttachments(artifactViewKey, intents);
@@ -2793,6 +2801,7 @@ export function ChatPage({
     onAutoLoad: handleNativeModelDropAutoLoad,
     onAttach: handleNativeAttachmentDrop,
     onAttachImages: handleNativeImageDrop,
+    onAttachOpenDocuments: handleNativeOpenDocumentDrop,
     onAttachAudio: handleNativeAudioDrop,
     onAttachVideo: handleNativeVideoDrop,
   });

--- a/studio/frontend/src/features/chat/open-document-accept.ts
+++ b/studio/frontend/src/features/chat/open-document-accept.ts
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+export const OPEN_DOCUMENT_SPREADSHEET_MIME =
+  "application/vnd.oasis.opendocument.spreadsheet";
+export const OPEN_DOCUMENT_TEXT_MIME =
+  "application/vnd.oasis.opendocument.text";
+export const OPEN_DOCUMENT_ATTACHMENT_EXTENSIONS = ".ods,.odt";
+export const OPEN_DOCUMENT_ATTACHMENT_ACCEPT = [
+  OPEN_DOCUMENT_ATTACHMENT_EXTENSIONS,
+  OPEN_DOCUMENT_SPREADSHEET_MIME,
+  OPEN_DOCUMENT_TEXT_MIME,
+].join(",");
+
+export function isOpenDocumentAttachmentName(filename: string): boolean {
+  const lower = filename.toLowerCase();
+  return OPEN_DOCUMENT_ATTACHMENT_EXTENSIONS.split(",").some((extension) =>
+    lower.endsWith(extension),
+  );
+}

--- a/studio/frontend/src/features/chat/open-document.ts
+++ b/studio/frontend/src/features/chat/open-document.ts
@@ -2,11 +2,7 @@
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
 import { strFromU8, unzipSync } from "fflate";
-
-export const OPEN_DOCUMENT_SPREADSHEET_MIME =
-  "application/vnd.oasis.opendocument.spreadsheet";
-export const OPEN_DOCUMENT_TEXT_MIME =
-  "application/vnd.oasis.opendocument.text";
+import { OPEN_DOCUMENT_SPREADSHEET_MIME } from "./open-document-accept";
 const OFFICE_NAMESPACE = "urn:oasis:names:tc:opendocument:xmlns:office:1.0";
 const STYLE_NAMESPACE = "urn:oasis:names:tc:opendocument:xmlns:style:1.0";
 const TABLE_NAMESPACE = "urn:oasis:names:tc:opendocument:xmlns:table:1.0";

--- a/studio/frontend/src/features/chat/runtime-provider.tsx
+++ b/studio/frontend/src/features/chat/runtime-provider.tsx
@@ -55,8 +55,11 @@ import {
   providerModelSupportsVision,
 } from "./external-providers";
 import {
+  OPEN_DOCUMENT_ATTACHMENT_ACCEPT,
   OPEN_DOCUMENT_SPREADSHEET_MIME,
   OPEN_DOCUMENT_TEXT_MIME,
+} from "./open-document-accept";
+import {
   type OpenDocumentAttachmentContent,
   readActiveOpenDocumentAttachmentContent,
   readOpenDocumentAttachmentContent,
@@ -442,12 +445,7 @@ class OpenDocumentAttachmentAdapter implements AttachmentAdapter {
     Promise<OpenDocumentAttachmentContent | null>
   >();
 
-  accept = [
-    ".ods",
-    ".odt",
-    OPEN_DOCUMENT_SPREADSHEET_MIME,
-    OPEN_DOCUMENT_TEXT_MIME,
-  ].join(",");
+  accept = OPEN_DOCUMENT_ATTACHMENT_ACCEPT;
 
   async *add({
     file,

--- a/studio/frontend/src/features/native-intents/drop-paths.ts
+++ b/studio/frontend/src/features/native-intents/drop-paths.ts
@@ -1,6 +1,10 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
+import {
+  OPEN_DOCUMENT_ATTACHMENT_EXTENSIONS,
+  isOpenDocumentAttachmentName,
+} from "../chat/open-document-accept.ts";
 import { RAG_UPLOAD_ACCEPT } from "../rag/types/rag.ts";
 
 const DOC_EXTS = RAG_UPLOAD_ACCEPT.split(",").map((ext) => ext.trim().toLowerCase());
@@ -23,7 +27,7 @@ export const CHAT_VIDEO_DROP_ACCEPT = ".mp4,.mov,.webm,.mkv,.avi";
 const VIDEO_EXTS = CHAT_VIDEO_DROP_ACCEPT.split(",").map((ext) => ext.trim().toLowerCase());
 
 /** What the window actually takes, for the rejection toast and the overlay. */
-export const SUPPORTED_DROP_HINT = `Supported files: ${RAG_UPLOAD_ACCEPT}, ${CHAT_IMAGE_DROP_ACCEPT}, one of ${CHAT_AUDIO_DROP_ACCEPT}, one of ${CHAT_VIDEO_DROP_ACCEPT}, or a single .gguf model.`;
+export const SUPPORTED_DROP_HINT = `Supported files: ${RAG_UPLOAD_ACCEPT}, ${OPEN_DOCUMENT_ATTACHMENT_EXTENSIONS}, ${CHAT_IMAGE_DROP_ACCEPT}, one of ${CHAT_AUDIO_DROP_ACCEPT}, one of ${CHAT_VIDEO_DROP_ACCEPT}, or a single .gguf model.`;
 
 /** Last path segment of a native path, for display and extension checks. */
 export function nativeFileName(path: string): string {
@@ -61,7 +65,11 @@ export function classifyDropPaths(paths: string[]): NativeDropClass {
       ? { kind: "model", path: ggufs[0] }
       : { kind: "unsupported" };
   }
-  const docs = paths.filter((path) => DOC_EXTS.some((ext) => hasExt(path, ext)));
+  const docs = paths.filter(
+    (path) =>
+      DOC_EXTS.some((ext) => hasExt(path, ext)) ||
+      isOpenDocumentAttachmentName(path),
+  );
   const images = paths.filter((path) =>
     IMAGE_EXTS.some((ext) => hasExt(path, ext)),
   );

--- a/studio/frontend/src/features/native-intents/store.ts
+++ b/studio/frontend/src/features/native-intents/store.ts
@@ -6,12 +6,32 @@ import {
 } from "./attachment-queue";
 import type { NativeIntent } from "./types";
 
+function moveQueuedAttachments(
+  queues: PendingNativeAttachments,
+  staleKeys: string[],
+  targetKey: string,
+): PendingNativeAttachments {
+  let pending = queues;
+  for (const key of staleKeys) {
+    const queued = queues[key] ?? [];
+    if (queued.length > 0) {
+      pending = enqueueNativeAttachments(pending, targetKey, queued);
+    }
+    if (key in pending) {
+      pending = { ...pending };
+      delete pending[key];
+    }
+  }
+  return pending;
+}
+
 interface NativeIntentState {
   pendingModelIntent: NativeIntent | null;
   // Key each batch to the chat that received the OS drop. Registration crosses an
   // async Rust boundary, so the active chat may change before these arrive.
   pendingAttachments: PendingNativeAttachments;
   pendingImageAttachments: PendingNativeAttachments;
+  pendingOpenDocumentAttachments: PendingNativeAttachments;
   pendingAudioAttachments: PendingNativeAttachments;
   pendingVideoAttachments: PendingNativeAttachments;
   // Image drops registering with Rust, before they have a queue to sit in. Not
@@ -29,8 +49,8 @@ interface NativeIntentState {
   imageDropFailures: Record<string, number>;
   audioDropFailures: Record<string, number>;
   videoDropFailures: Record<string, number>;
-  // Owner of a queued image batch, by composer identity. A remount means the
-  // outgoing instance cannot hand the batch over itself, so it leaves a note.
+  // Owner of queued composer-file batches, by composer identity. A remount means
+  // the outgoing instance cannot hand the batches over itself, so it leaves a note.
   imageDropOwners: Record<string, string>;
   // Same for audio: a new chat re-keys mid-read, so the clip needs a note
   // to follow the composer.
@@ -39,10 +59,12 @@ interface NativeIntentState {
   addIntent: (intent: NativeIntent) => void;
   addAttachments: (targetKey: string, intents: NativeIntent[]) => void;
   addImageAttachments: (targetKey: string, intents: NativeIntent[]) => void;
+  addOpenDocumentAttachments: (targetKey: string, intents: NativeIntent[]) => void;
   addAudioAttachments: (targetKey: string, intents: NativeIntent[]) => void;
   addVideoAttachments: (targetKey: string, intents: NativeIntent[]) => void;
   takeAttachments: (targetKey: string) => NativeIntent[];
   takeImageAttachments: (targetKey: string) => NativeIntent[];
+  takeOpenDocumentAttachments: (targetKey: string) => NativeIntent[];
   takeAudioAttachments: (targetKey: string) => NativeIntent[];
   takeVideoAttachments: (targetKey: string) => NativeIntent[];
   beginImageDropRegistration: () => void;
@@ -67,6 +89,7 @@ export const useNativeIntentStore = create<NativeIntentState>((set, get) => ({
   pendingModelIntent: null,
   pendingAttachments: {},
   pendingImageAttachments: {},
+  pendingOpenDocumentAttachments: {},
   pendingAudioAttachments: {},
   pendingVideoAttachments: {},
   registeringImageDrops: 0,
@@ -98,6 +121,17 @@ export const useNativeIntentStore = create<NativeIntentState>((set, get) => ({
     );
     if (pendingImageAttachments !== current) {
       set({ pendingImageAttachments });
+    }
+  },
+  addOpenDocumentAttachments: (targetKey, intents) => {
+    const current = get().pendingOpenDocumentAttachments;
+    const pendingOpenDocumentAttachments = enqueueNativeAttachments(
+      current,
+      targetKey,
+      intents,
+    );
+    if (pendingOpenDocumentAttachments !== current) {
+      set({ pendingOpenDocumentAttachments });
     }
   },
   addAudioAttachments: (targetKey, intents) => {
@@ -144,6 +178,17 @@ export const useNativeIntentStore = create<NativeIntentState>((set, get) => ({
     }
     return queued;
   },
+  takeOpenDocumentAttachments: (targetKey) => {
+    const current = get().pendingOpenDocumentAttachments;
+    const [queued, pendingOpenDocumentAttachments] = dequeueNativeAttachments(
+      current,
+      targetKey,
+    );
+    if (pendingOpenDocumentAttachments !== current) {
+      set({ pendingOpenDocumentAttachments });
+    }
+    return queued;
+  },
   beginImageDropRegistration: () => {
     set({ registeringImageDrops: get().registeringImageDrops + 1 });
   },
@@ -185,25 +230,23 @@ export const useNativeIntentStore = create<NativeIntentState>((set, get) => ({
       (key) => owners[key] === identity && key !== targetKey,
     );
     if (stale.length === 0) return;
-    const queues = get().pendingImageAttachments;
-    let pendingImageAttachments = queues;
-    for (const key of stale) {
-      const queued = queues[key] ?? [];
-      if (queued.length > 0) {
-        pendingImageAttachments = enqueueNativeAttachments(
-          pendingImageAttachments,
-          targetKey,
-          queued,
-        );
-      }
-      if (key in pendingImageAttachments) {
-        pendingImageAttachments = { ...pendingImageAttachments };
-        delete pendingImageAttachments[key];
-      }
-    }
+    const pendingImageAttachments = moveQueuedAttachments(
+      get().pendingImageAttachments,
+      stale,
+      targetKey,
+    );
+    const pendingOpenDocumentAttachments = moveQueuedAttachments(
+      get().pendingOpenDocumentAttachments,
+      stale,
+      targetKey,
+    );
     const nextOwners = { ...owners };
     for (const key of stale) delete nextOwners[key];
-    set({ pendingImageAttachments, imageDropOwners: nextOwners });
+    set({
+      pendingImageAttachments,
+      pendingOpenDocumentAttachments,
+      imageDropOwners: nextOwners,
+    });
   },
   noteAudioDropOwner: (targetKey, identity) => {
     if (!identity) return;

--- a/studio/frontend/src/features/native-intents/use-native-drop.ts
+++ b/studio/frontend/src/features/native-intents/use-native-drop.ts
@@ -152,6 +152,7 @@ function dropStateForPaths(
 
 interface RegisteredDrop {
   docs: NativeIntent[];
+  openDocuments: NativeIntent[];
   images: NativeIntent[];
   audio: NativeIntent[];
   video: NativeIntent[];
@@ -196,6 +197,10 @@ async function registerDroppedAttachments(
       : dropped.kind === "attach"
         ? dropped.docs
         : [];
+  const openDocumentPaths = docPaths.filter(isOpenDocumentAttachmentName);
+  const ragDocumentPaths = docPaths.filter(
+    (path) => !isOpenDocumentAttachmentName(path),
+  );
   const imagePaths =
     dropped.kind === "images"
       ? dropped.paths
@@ -214,22 +219,29 @@ async function registerDroppedAttachments(
       : dropped.kind === "attach"
         ? dropped.video
         : [];
-  const [docs, images, audio, video] = await Promise.all([
-    registerEach(docPaths),
+  const [docs, openDocuments, images, audio, video] = await Promise.all([
+    registerEach(ragDocumentPaths),
+    registerEach(openDocumentPaths),
     registerEach(imagePaths),
     registerEach(audioPaths),
     registerEach(videoPaths),
   ]);
   return {
     docs: docs.intents,
+    openDocuments: openDocuments.intents,
     images: images.intents,
     audio: audio.intents,
     video: video.intents,
-    docsFailed: docs.failed,
+    docsFailed: docs.failed + openDocuments.failed,
     imagesFailed: images.failed,
     audioFailed: audio.failed,
     videoFailed: video.failed,
-    error: docs.error ?? images.error ?? audio.error ?? video.error,
+    error:
+      docs.error ??
+      openDocuments.error ??
+      images.error ??
+      audio.error ??
+      video.error,
   };
 }
 
@@ -373,18 +385,12 @@ export function useNativeModelDrop(options: NativeModelDropOptions): NativeModel
               latestOptions.attachmentScope === currentOptions.attachmentScope
                 ? latestOptions
                 : currentOptions;
-            const openDocuments = registered.docs.filter((intent) =>
-              isOpenDocumentAttachmentName(intent.displayLabel),
-            );
-            const ragDocuments = registered.docs.filter(
-              (intent) => !isOpenDocumentAttachmentName(intent.displayLabel),
-            );
-            if (ragDocuments.length > 0) {
-              await attachOptions.onAttach?.(ragDocuments);
+            if (registered.docs.length > 0) {
+              await attachOptions.onAttach?.(registered.docs);
             }
             const composerAttachments = [
               ...registered.images,
-              ...openDocuments,
+              ...registered.openDocuments,
             ];
             if (composerAttachments.length > 0) {
               await attachOptions.onAttachImages?.(composerAttachments);

--- a/studio/frontend/src/features/native-intents/use-native-drop.ts
+++ b/studio/frontend/src/features/native-intents/use-native-drop.ts
@@ -1,6 +1,7 @@
 import { isTauri } from "@/lib/api-base";
 import { useEffect, useRef, useState } from "react";
 import { toast } from "@/lib/toast";
+import { isOpenDocumentAttachmentName } from "../chat/open-document-accept";
 import { registerNativeAttachmentPath, registerNativeModelPath } from "./api";
 import { classifyDropPaths, SUPPORTED_DROP_HINT } from "./drop-paths";
 import { nativeDropTargetAt } from "./native-drop-targets";
@@ -303,6 +304,14 @@ export function useNativeModelDrop(options: NativeModelDropOptions): NativeModel
           const needsImages =
             dropped.kind === "images" ||
             (dropped.kind === "attach" && dropped.images.length > 0);
+          const openDocumentPaths =
+            dropped.kind === "docs"
+              ? dropped.paths.filter(isOpenDocumentAttachmentName)
+              : dropped.kind === "attach"
+                ? dropped.docs.filter(isOpenDocumentAttachmentName)
+                : [];
+          const needsOpenDocuments = openDocumentPaths.length > 0;
+          const needsComposerAttachments = needsImages || needsOpenDocuments;
           const needsAudio =
             dropped.kind === "audio" ||
             (dropped.kind === "attach" && dropped.audio.length > 0);
@@ -315,7 +324,7 @@ export function useNativeModelDrop(options: NativeModelDropOptions): NativeModel
             });
             return;
           }
-          if (needsImages && !canAttachImages(currentOptions)) {
+          if (needsComposerAttachments && !canAttachImages(currentOptions)) {
             toast.error("Attaching images is unavailable right now", {
               description: "Retry once this chat is ready for attachments.",
             });
@@ -337,7 +346,7 @@ export function useNativeModelDrop(options: NativeModelDropOptions): NativeModel
           // intents reaching the queue there is nothing for the composer to see,
           // so an Enter in that window would send the text without the image.
           const store = useNativeIntentStore.getState();
-          if (needsImages) store.beginImageDropRegistration();
+          if (needsComposerAttachments) store.beginImageDropRegistration();
           if (needsAudio) store.beginAudioDropRegistration();
           if (needsVideo) store.beginVideoDropRegistration();
           try {
@@ -350,11 +359,21 @@ export function useNativeModelDrop(options: NativeModelDropOptions): NativeModel
               latestOptions.attachmentScope === currentOptions.attachmentScope
                 ? latestOptions
                 : currentOptions;
-            if (registered.docs.length > 0) {
-              await attachOptions.onAttach?.(registered.docs);
+            const openDocuments = registered.docs.filter((intent) =>
+              isOpenDocumentAttachmentName(intent.displayLabel),
+            );
+            const ragDocuments = registered.docs.filter(
+              (intent) => !isOpenDocumentAttachmentName(intent.displayLabel),
+            );
+            if (ragDocuments.length > 0) {
+              await attachOptions.onAttach?.(ragDocuments);
             }
-            if (registered.images.length > 0) {
-              await attachOptions.onAttachImages?.(registered.images);
+            const composerAttachments = [
+              ...registered.images,
+              ...openDocuments,
+            ];
+            if (composerAttachments.length > 0) {
+              await attachOptions.onAttachImages?.(composerAttachments);
             }
             const failureKey = attachOptions.attachmentTargetKey;
             if (registered.imagesFailed > 0 && failureKey) {
@@ -369,7 +388,9 @@ export function useNativeModelDrop(options: NativeModelDropOptions): NativeModel
             // A failed document cancels a send parked behind the image, audio or
             // video gate too, or the draft goes out with only what survived.
             if (registered.docsFailed > 0 && failureKey) {
-              if (needsImages) store.failImageDropRegistration(failureKey);
+              if (needsComposerAttachments) {
+                store.failImageDropRegistration(failureKey);
+              }
               if (needsAudio) store.failAudioDropRegistration(failureKey);
               if (needsVideo) store.failVideoDropRegistration(failureKey);
             }
@@ -392,7 +413,7 @@ export function useNativeModelDrop(options: NativeModelDropOptions): NativeModel
             }
           } catch (error) {
             const failureKey = currentOptions.attachmentTargetKey;
-            if (needsImages && failureKey) {
+            if (needsComposerAttachments && failureKey) {
               store.failImageDropRegistration(failureKey);
             }
             if (needsAudio && failureKey) {
@@ -405,7 +426,7 @@ export function useNativeModelDrop(options: NativeModelDropOptions): NativeModel
               description: error instanceof Error ? error.message : String(error),
             });
           } finally {
-            if (needsImages) store.endImageDropRegistration();
+            if (needsComposerAttachments) store.endImageDropRegistration();
             if (needsAudio) store.endAudioDropRegistration();
             if (needsVideo) store.endVideoDropRegistration();
           }

--- a/studio/frontend/src/features/native-intents/use-native-drop.ts
+++ b/studio/frontend/src/features/native-intents/use-native-drop.ts
@@ -34,6 +34,7 @@ interface NativeModelDropOptions {
   onAutoLoad?: (intent: NativeIntent) => Promise<void> | void;
   onAttach?: (intents: NativeIntent[]) => Promise<void> | void;
   onAttachImages?: (intents: NativeIntent[]) => Promise<void> | void;
+  onAttachOpenDocuments?: (intents: NativeIntent[]) => Promise<void> | void;
   onAttachAudio?: (intents: NativeIntent[]) => Promise<void> | void;
   onAttachVideo?: (intents: NativeIntent[]) => Promise<void> | void;
 }
@@ -46,13 +47,17 @@ function canAttachImages(options: NativeModelDropOptions): boolean {
   return Boolean(options.onAttachImages);
 }
 
+function canAttachOpenDocuments(options: NativeModelDropOptions): boolean {
+  return Boolean(options.onAttachOpenDocuments);
+}
+
 function canAttachDocumentPaths(
   paths: string[],
   options: NativeModelDropOptions,
 ): boolean {
   return paths.every((path) =>
     isOpenDocumentAttachmentName(path)
-      ? canAttachImages(options)
+      ? canAttachOpenDocuments(options)
       : canAttachDocs(options),
   );
 }
@@ -350,8 +355,17 @@ export function useNativeModelDrop(options: NativeModelDropOptions): NativeModel
             });
             return;
           }
-          if (needsComposerAttachments && !canAttachImages(currentOptions)) {
+          if (needsImages && !canAttachImages(currentOptions)) {
             toast.error("Attaching images is unavailable right now", {
+              description: "Retry once this chat is ready for attachments.",
+            });
+            return;
+          }
+          if (
+            needsOpenDocuments &&
+            !canAttachOpenDocuments(currentOptions)
+          ) {
+            toast.error("Attaching files is unavailable right now", {
               description: "Retry once this chat is ready for attachments.",
             });
             return;
@@ -388,12 +402,13 @@ export function useNativeModelDrop(options: NativeModelDropOptions): NativeModel
             if (registered.docs.length > 0) {
               await attachOptions.onAttach?.(registered.docs);
             }
-            const composerAttachments = [
-              ...registered.images,
-              ...registered.openDocuments,
-            ];
-            if (composerAttachments.length > 0) {
-              await attachOptions.onAttachImages?.(composerAttachments);
+            if (registered.images.length > 0) {
+              await attachOptions.onAttachImages?.(registered.images);
+            }
+            if (registered.openDocuments.length > 0) {
+              await attachOptions.onAttachOpenDocuments?.(
+                registered.openDocuments,
+              );
             }
             const failureKey = attachOptions.attachmentTargetKey;
             if (registered.imagesFailed > 0 && failureKey) {

--- a/studio/frontend/src/features/native-intents/use-native-drop.ts
+++ b/studio/frontend/src/features/native-intents/use-native-drop.ts
@@ -384,7 +384,7 @@ export function useNativeModelDrop(options: NativeModelDropOptions): NativeModel
           }
           // Hold the send gate across registration too. Between the drop and the
           // intents reaching the queue there is nothing for the composer to see,
-          // so an Enter in that window would send the text without the image.
+          // so an Enter in that window would send the text without the attachment.
           const store = useNativeIntentStore.getState();
           if (needsComposerAttachments) store.beginImageDropRegistration();
           if (needsAudio) store.beginAudioDropRegistration();
@@ -420,8 +420,8 @@ export function useNativeModelDrop(options: NativeModelDropOptions): NativeModel
             if (registered.videoFailed > 0 && failureKey) {
               store.failVideoDropRegistration(failureKey);
             }
-            // A failed document cancels a send parked behind the image, audio or
-            // video gate too, or the draft goes out with only what survived.
+            // A failed document cancels a send parked behind the attachment, audio
+            // or video gates too, or the draft goes out with only what survived.
             if (registered.docsFailed > 0 && failureKey) {
               if (needsComposerAttachments) {
                 store.failImageDropRegistration(failureKey);

--- a/studio/frontend/src/features/native-intents/use-native-drop.ts
+++ b/studio/frontend/src/features/native-intents/use-native-drop.ts
@@ -46,6 +46,17 @@ function canAttachImages(options: NativeModelDropOptions): boolean {
   return Boolean(options.onAttachImages);
 }
 
+function canAttachDocumentPaths(
+  paths: string[],
+  options: NativeModelDropOptions,
+): boolean {
+  return paths.every((path) =>
+    isOpenDocumentAttachmentName(path)
+      ? canAttachImages(options)
+      : canAttachDocs(options),
+  );
+}
+
 function canAttachAudio(options: NativeModelDropOptions): boolean {
   return Boolean(options.onAttachAudio);
 }
@@ -100,7 +111,7 @@ function dropStateForPaths(
     return { status: "invalid", reason: options.dropsUnsupportedReason };
   }
   if (dropped.kind === "docs") {
-    return canAttachDocs(options)
+    return canAttachDocumentPaths(dropped.paths, options)
       ? { status: "attach", count: dropped.paths.length, kind: "docs" }
       : { status: "invalid" };
   }
@@ -120,7 +131,7 @@ function dropStateForPaths(
       : { status: "invalid" };
   }
   if (dropped.kind === "attach") {
-    const docsSupported = dropped.docs.length === 0 || canAttachDocs(options);
+    const docsSupported = canAttachDocumentPaths(dropped.docs, options);
     const imagesSupported =
       dropped.images.length === 0 || canAttachImages(options);
     const audioSupported = dropped.audio.length === 0 || canAttachAudio(options);
@@ -298,18 +309,21 @@ export function useNativeModelDrop(options: NativeModelDropOptions): NativeModel
           dropped.kind === "video" ||
           dropped.kind === "attach"
         ) {
-          const needsDocs =
-            dropped.kind === "docs" ||
-            (dropped.kind === "attach" && dropped.docs.length > 0);
           const needsImages =
             dropped.kind === "images" ||
             (dropped.kind === "attach" && dropped.images.length > 0);
-          const openDocumentPaths =
+          const documentPaths =
             dropped.kind === "docs"
-              ? dropped.paths.filter(isOpenDocumentAttachmentName)
+              ? dropped.paths
               : dropped.kind === "attach"
-                ? dropped.docs.filter(isOpenDocumentAttachmentName)
+                ? dropped.docs
                 : [];
+          const openDocumentPaths = documentPaths.filter(
+            isOpenDocumentAttachmentName,
+          );
+          const needsRagDocuments = documentPaths.some(
+            (path) => !isOpenDocumentAttachmentName(path),
+          );
           const needsOpenDocuments = openDocumentPaths.length > 0;
           const needsComposerAttachments = needsImages || needsOpenDocuments;
           const needsAudio =
@@ -318,7 +332,7 @@ export function useNativeModelDrop(options: NativeModelDropOptions): NativeModel
           const needsVideo =
             dropped.kind === "video" ||
             (dropped.kind === "attach" && dropped.video.length > 0);
-          if (needsDocs && !canAttachDocs(currentOptions)) {
+          if (needsRagDocuments && !canAttachDocs(currentOptions)) {
             toast.error("Attaching files needs the desktop backend", {
               description: "Retry once Studio has finished starting up.",
             });

--- a/studio/frontend/src/features/rag/components/thread-documents-bar.tsx
+++ b/studio/frontend/src/features/rag/components/thread-documents-bar.tsx
@@ -25,12 +25,9 @@ import {
   isThreadIncognito,
 } from "@/features/chat";
 import {
-  nativeAttachmentIntentToFile,
-  type NativeIntent,
   useNativeAttachmentTargetKey,
   useNativeIntentStore,
 } from "@/features/native-intents";
-import { isOpenDocumentAttachmentName } from "@/features/chat/open-document-accept";
 import { toast } from "@/lib/toast";
 import {
   DropdownMenu,
@@ -548,22 +545,6 @@ export function ThreadDocumentsBar({
         (s.pendingAttachments[nativeAttachmentTargetKey]?.length ?? 0) > 0,
     ),
   );
-  const attachOpenDocuments = useCallback(
-    async (intents: NativeIntent[]) => {
-      for (const intent of intents) {
-        try {
-          const file = await nativeAttachmentIntentToFile(intent);
-          await aui.composer().addAttachment(file);
-        } catch (error) {
-          toast.error(`Couldn't attach ${intent.displayLabel}`, {
-            description:
-              error instanceof Error ? error.message : String(error),
-          });
-        }
-      }
-    },
-    [aui],
-  );
   useEffect(() => {
     if (!hasPendingAttachments || !nativeAttachmentTargetKey) {
       return;
@@ -575,18 +556,6 @@ export function ThreadDocumentsBar({
     const store = useNativeIntentStore.getState();
     const intents = store.takeAttachments(nativeAttachmentTargetKey);
     if (intents.length === 0) {
-      return;
-    }
-    const openDocuments = intents.filter((intent) =>
-      isOpenDocumentAttachmentName(intent.displayLabel),
-    );
-    const ragDocuments = intents.filter(
-      (intent) => !isOpenDocumentAttachmentName(intent.displayLabel),
-    );
-    if (openDocuments.length > 0) {
-      void attachOpenDocuments(openDocuments);
-    }
-    if (ragDocuments.length === 0) {
       return;
     }
     // A KB-scoped chat uploads through the KB dialog, so a thread upload here would
@@ -603,7 +572,7 @@ export function ThreadDocumentsBar({
       setRagEnabled(true);
     }
     attach(
-      ragDocuments.map((intent) => ({
+      intents.map((intent) => ({
         kind: "native" as const,
         token: intent.path.token,
         name: intent.displayLabel,
@@ -616,7 +585,6 @@ export function ThreadDocumentsBar({
     projectUnresolved,
     nativeAttachmentTargetKey,
     attach,
-    attachOpenDocuments,
     ragEnabled,
     ragSource,
     setRagSource,

--- a/studio/frontend/src/features/rag/components/thread-documents-bar.tsx
+++ b/studio/frontend/src/features/rag/components/thread-documents-bar.tsx
@@ -568,6 +568,10 @@ export function ThreadDocumentsBar({
     if (!hasPendingAttachments || !nativeAttachmentTargetKey) {
       return;
     }
+    // Hold the batch rather than draining it before the chat's project scope is known.
+    if (projectUnresolved) {
+      return;
+    }
     const store = useNativeIntentStore.getState();
     const intents = store.takeAttachments(nativeAttachmentTargetKey);
     if (intents.length === 0) {
@@ -583,12 +587,6 @@ export function ThreadDocumentsBar({
       void attachOpenDocuments(openDocuments);
     }
     if (ragDocuments.length === 0) {
-      return;
-    }
-    // Hold RAG files rather than uploading them into an unresolved project
-    // scope. OpenDocument files above go through the composer, like the picker.
-    if (projectUnresolved) {
-      store.addAttachments(nativeAttachmentTargetKey, ragDocuments);
       return;
     }
     // A KB-scoped chat uploads through the KB dialog, so a thread upload here would

--- a/studio/frontend/src/features/rag/components/thread-documents-bar.tsx
+++ b/studio/frontend/src/features/rag/components/thread-documents-bar.tsx
@@ -25,9 +25,12 @@ import {
   isThreadIncognito,
 } from "@/features/chat";
 import {
+  nativeAttachmentIntentToFile,
+  type NativeIntent,
   useNativeAttachmentTargetKey,
   useNativeIntentStore,
 } from "@/features/native-intents";
+import { isOpenDocumentAttachmentName } from "@/features/chat/open-document-accept";
 import { toast } from "@/lib/toast";
 import {
   DropdownMenu,
@@ -545,35 +548,64 @@ export function ThreadDocumentsBar({
         (s.pendingAttachments[nativeAttachmentTargetKey]?.length ?? 0) > 0,
     ),
   );
+  const attachOpenDocuments = useCallback(
+    async (intents: NativeIntent[]) => {
+      for (const intent of intents) {
+        try {
+          const file = await nativeAttachmentIntentToFile(intent);
+          await aui.composer().addAttachment(file);
+        } catch (error) {
+          toast.error(`Couldn't attach ${intent.displayLabel}`, {
+            description:
+              error instanceof Error ? error.message : String(error),
+          });
+        }
+      }
+    },
+    [aui],
+  );
   useEffect(() => {
     if (!hasPendingAttachments || !nativeAttachmentTargetKey) {
       return;
     }
-    // Hold the batch rather than draining it into the wrong scope. The intents
-    // stay in the store, so this runs again once the row has been read.
+    const store = useNativeIntentStore.getState();
+    const intents = store.takeAttachments(nativeAttachmentTargetKey);
+    if (intents.length === 0) {
+      return;
+    }
+    const openDocuments = intents.filter((intent) =>
+      isOpenDocumentAttachmentName(intent.displayLabel),
+    );
+    const ragDocuments = intents.filter(
+      (intent) => !isOpenDocumentAttachmentName(intent.displayLabel),
+    );
+    if (openDocuments.length > 0) {
+      void attachOpenDocuments(openDocuments);
+    }
+    if (ragDocuments.length === 0) {
+      return;
+    }
+    // Hold RAG files rather than uploading them into an unresolved project
+    // scope. OpenDocument files above go through the composer, like the picker.
     if (projectUnresolved) {
+      store.addAttachments(nativeAttachmentTargetKey, ragDocuments);
       return;
     }
     // A KB-scoped chat uploads through the KB dialog, so a thread upload here would
     // index into something this bar never shows.
     if (ragEnabled && ragSource.type === "kb") {
-      useNativeIntentStore.getState().takeAttachments(nativeAttachmentTargetKey);
       toast.error("This chat retrieves from a knowledge base", {
         description: "Add these files to the knowledge base instead.",
       });
       return;
     }
-    const intents = useNativeIntentStore
-      .getState()
-      .takeAttachments(nativeAttachmentTargetKey);
-    if (intents.length === 0) return;
     // A stale KB preference is inactive while RAG is off; use thread retrieval.
     if (!ragEnabled) {
       setRagSource({ type: "thread" });
       setRagEnabled(true);
     }
     attach(
-      intents.map((intent) => ({
+      ragDocuments.map((intent) => ({
         kind: "native" as const,
         token: intent.path.token,
         name: intent.displayLabel,
@@ -586,6 +618,7 @@ export function ThreadDocumentsBar({
     projectUnresolved,
     nativeAttachmentTargetKey,
     attach,
+    attachOpenDocuments,
     ragEnabled,
     ragSource,
     setRagSource,

--- a/studio/frontend/tests/native-drop-paths.test.ts
+++ b/studio/frontend/tests/native-drop-paths.test.ts
@@ -57,6 +57,8 @@ const OPEN_DOCUMENT_DROP_TO_COMPOSER_RE =
   /const openDocuments = registered\.docs\.filter[\s\S]*?const composerAttachments = \[[\s\S]*?\.\.\.registered\.images,[\s\S]*?\.\.\.openDocuments,[\s\S]*?await attachOptions\.onAttachImages\?\.\(composerAttachments\)/;
 const OPEN_DOCUMENT_IMAGE_REGISTRATION_RE =
   /const needsOpenDocuments = openDocumentPaths\.length > 0;[\s\S]*?const needsComposerAttachments = needsImages \|\| needsOpenDocuments;[\s\S]*?if \(needsComposerAttachments\) store\.beginImageDropRegistration\(\);[\s\S]*?finally \{[\s\S]*?if \(needsComposerAttachments\) store\.endImageDropRegistration\(\)/;
+const OPEN_DOCUMENT_BACKEND_GATE_RE =
+  /function canAttachDocumentPaths[\s\S]*?isOpenDocumentAttachmentName\(path\)[\s\S]*?\? canAttachImages\(options\)[\s\S]*?: canAttachDocs\(options\)[\s\S]*?const needsRagDocuments = documentPaths\.some[\s\S]*?if \(needsRagDocuments && !canAttachDocs\(currentOptions\)\)/;
 
 function attachmentIntent(id: string): NativeIntent {
   return {
@@ -116,6 +118,7 @@ test("OpenDocument picker types are accepted by native drops", () => {
   );
   assert.match(nativeDropSource, OPEN_DOCUMENT_DROP_TO_COMPOSER_RE);
   assert.match(nativeDropSource, OPEN_DOCUMENT_IMAGE_REGISTRATION_RE);
+  assert.match(nativeDropSource, OPEN_DOCUMENT_BACKEND_GATE_RE);
 
   const rustSource = readFileSync(
     new URL("../../src-tauri/src/native_path_policy.rs", import.meta.url),

--- a/studio/frontend/tests/native-drop-paths.test.ts
+++ b/studio/frontend/tests/native-drop-paths.test.ts
@@ -6,15 +6,25 @@ import { readFileSync } from "node:fs";
 import test from "node:test";
 
 import {
+  OPEN_DOCUMENT_ATTACHMENT_ACCEPT,
+  OPEN_DOCUMENT_ATTACHMENT_EXTENSIONS,
+} from "../src/features/chat/open-document-accept.ts";
+import {
   dequeueNativeAttachments,
   enqueueNativeAttachments,
 } from "../src/features/native-intents/attachment-queue.ts";
-import { classifyDropPaths, CHAT_AUDIO_DROP_ACCEPT, CHAT_IMAGE_DROP_ACCEPT, CHAT_VIDEO_DROP_ACCEPT, SUPPORTED_DROP_HINT } from "../src/features/native-intents/drop-paths.ts";
+import {
+  CHAT_AUDIO_DROP_ACCEPT,
+  CHAT_IMAGE_DROP_ACCEPT,
+  CHAT_VIDEO_DROP_ACCEPT,
+  SUPPORTED_DROP_HINT,
+  classifyDropPaths,
+} from "../src/features/native-intents/drop-paths.ts";
 import type { NativeIntent } from "../src/features/native-intents/types.ts";
-import { AUDIO_ACCEPT } from "../src/lib/audio-utils.ts";
-import { MAX_REFERENCE_BYTES } from "../src/features/video/reference-budget.ts";
-import { VIDEO_ACCEPT } from "../src/lib/video-utils.ts";
 import { RAG_UPLOAD_ACCEPT } from "../src/features/rag/types/rag.ts";
+import { MAX_REFERENCE_BYTES } from "../src/features/video/reference-budget.ts";
+import { AUDIO_ACCEPT } from "../src/lib/audio-utils.ts";
+import { VIDEO_ACCEPT } from "../src/lib/video-utils.ts";
 import { registerBundlerResolver } from "./helpers/kit.ts";
 
 registerBundlerResolver();
@@ -25,6 +35,8 @@ const { useNativeIntentStore } = await import(
 
 const BACKEND_UPLOAD_EXTS_RE = /UPLOAD_EXTS\s*=\s*\{([^}]+)\}/s;
 const RUST_ATTACHMENT_EXTS_RE = /ATTACHMENT_EXTS[^=]*=\s*&\[([^\]]+)\]/s;
+const RUST_OPEN_DOCUMENT_ATTACHMENT_EXTS_RE =
+  /OPEN_DOCUMENT_ATTACHMENT_EXTS[^=]*=\s*&\[([^\]]+)\]/s;
 const RUST_IMAGE_ATTACHMENT_EXTS_RE = /IMAGE_ATTACHMENT_EXTS[^=]*=\s*&\[([^\]]+)\]/s;
 const RUST_AUDIO_ATTACHMENT_EXTS_RE = /AUDIO_ATTACHMENT_EXTS[^=]*=\s*&\[([^\]]+)\]/s;
 const RUST_AUDIO_MIME_RE = /Some\("(audio\/[^"]+)"\)/g;
@@ -38,6 +50,11 @@ const MIME_ARM_EXTENSION_RE = /^\s*((?:"[^"]+"\s*\|?\s*)+)=>\s*Some\("image\//gm
 const COMPOSER_IMAGE_ACCEPT_RE = /const IMAGE_ACCEPT\s*=\s*"([^"]+)"/;
 const VISION_ADAPTER_ACCEPT_RE =
   /class VisionImageAdapter[^{]*\{\s*accept\s*=\s*"([^"]+)"/s;
+const OPEN_DOCUMENT_EXTENSION_RE = /\.ods/;
+const OPEN_DOCUMENT_ADAPTER_ACCEPT_RE =
+  /class OpenDocumentAttachmentAdapter[^{]*\{[\s\S]*?accept = OPEN_DOCUMENT_ATTACHMENT_ACCEPT;/;
+const OPEN_DOCUMENT_DROP_TO_COMPOSER_RE =
+  /attachOpenDocuments[\s\S]*?nativeAttachmentIntentToFile\(intent\)[\s\S]*?aui\.composer\(\)\.addAttachment\(file\)/;
 
 function attachmentIntent(id: string): NativeIntent {
   return {
@@ -72,6 +89,44 @@ test("documents are an attachment drop, one or many", () => {
   ]);
   assert.equal(dropped.kind, "docs");
   assert.equal(dropped.kind === "docs" ? dropped.paths.length : 0, 3);
+});
+
+test("OpenDocument picker types are accepted by native drops", () => {
+  assert.match(OPEN_DOCUMENT_ATTACHMENT_ACCEPT, OPEN_DOCUMENT_EXTENSION_RE);
+  for (const extension of OPEN_DOCUMENT_ATTACHMENT_EXTENSIONS.split(",")) {
+    const path = `/docs/file${extension.toUpperCase()}`;
+    assert.equal(classifyDropPaths([path]).kind, "docs", path);
+    assert.ok(SUPPORTED_DROP_HINT.includes(extension));
+  }
+
+  const providerSource = readFileSync(
+    new URL("../src/features/chat/runtime-provider.tsx", import.meta.url),
+    "utf8",
+  );
+  assert.match(providerSource, OPEN_DOCUMENT_ADAPTER_ACCEPT_RE);
+
+  const threadDocumentsSource = readFileSync(
+    new URL(
+      "../src/features/rag/components/thread-documents-bar.tsx",
+      import.meta.url,
+    ),
+    "utf8",
+  );
+  assert.match(threadDocumentsSource, OPEN_DOCUMENT_DROP_TO_COMPOSER_RE);
+
+  const rustSource = readFileSync(
+    new URL("../../src-tauri/src/native_path_policy.rs", import.meta.url),
+    "utf8",
+  );
+  const rust = [
+    ...(rustSource
+      .match(RUST_OPEN_DOCUMENT_ATTACHMENT_EXTS_RE)?.[1]
+      .matchAll(RUST_EXTENSION_RE) ?? []),
+  ]
+    .map((match) => `.${match[1]}`)
+    .sort();
+  const frontend = OPEN_DOCUMENT_ATTACHMENT_EXTENSIONS.split(",").sort();
+  assert.deepEqual(rust, frontend);
 });
 
 test("images route to chat vision attachments, one or many", () => {

--- a/studio/frontend/tests/native-drop-paths.test.ts
+++ b/studio/frontend/tests/native-drop-paths.test.ts
@@ -54,7 +54,9 @@ const OPEN_DOCUMENT_EXTENSION_RE = /\.ods/;
 const OPEN_DOCUMENT_ADAPTER_ACCEPT_RE =
   /class OpenDocumentAttachmentAdapter[^{]*\{[\s\S]*?accept = OPEN_DOCUMENT_ATTACHMENT_ACCEPT;/;
 const OPEN_DOCUMENT_DROP_TO_COMPOSER_RE =
-  /attachOpenDocuments[\s\S]*?nativeAttachmentIntentToFile\(intent\)[\s\S]*?aui\.composer\(\)\.addAttachment\(file\)/;
+  /const openDocuments = registered\.docs\.filter[\s\S]*?const composerAttachments = \[[\s\S]*?\.\.\.registered\.images,[\s\S]*?\.\.\.openDocuments,[\s\S]*?await attachOptions\.onAttachImages\?\.\(composerAttachments\)/;
+const OPEN_DOCUMENT_IMAGE_REGISTRATION_RE =
+  /const needsOpenDocuments = openDocumentPaths\.length > 0;[\s\S]*?const needsComposerAttachments = needsImages \|\| needsOpenDocuments;[\s\S]*?if \(needsComposerAttachments\) store\.beginImageDropRegistration\(\);[\s\S]*?finally \{[\s\S]*?if \(needsComposerAttachments\) store\.endImageDropRegistration\(\)/;
 
 function attachmentIntent(id: string): NativeIntent {
   return {
@@ -105,14 +107,15 @@ test("OpenDocument picker types are accepted by native drops", () => {
   );
   assert.match(providerSource, OPEN_DOCUMENT_ADAPTER_ACCEPT_RE);
 
-  const threadDocumentsSource = readFileSync(
+  const nativeDropSource = readFileSync(
     new URL(
-      "../src/features/rag/components/thread-documents-bar.tsx",
+      "../src/features/native-intents/use-native-drop.ts",
       import.meta.url,
     ),
     "utf8",
   );
-  assert.match(threadDocumentsSource, OPEN_DOCUMENT_DROP_TO_COMPOSER_RE);
+  assert.match(nativeDropSource, OPEN_DOCUMENT_DROP_TO_COMPOSER_RE);
+  assert.match(nativeDropSource, OPEN_DOCUMENT_IMAGE_REGISTRATION_RE);
 
   const rustSource = readFileSync(
     new URL("../../src-tauri/src/native_path_policy.rs", import.meta.url),

--- a/studio/frontend/tests/native-drop-paths.test.ts
+++ b/studio/frontend/tests/native-drop-paths.test.ts
@@ -54,7 +54,9 @@ const OPEN_DOCUMENT_EXTENSION_RE = /\.ods/;
 const OPEN_DOCUMENT_ADAPTER_ACCEPT_RE =
   /class OpenDocumentAttachmentAdapter[^{]*\{[\s\S]*?accept = OPEN_DOCUMENT_ATTACHMENT_ACCEPT;/;
 const OPEN_DOCUMENT_DROP_TO_COMPOSER_RE =
-  /const openDocuments = registered\.docs\.filter[\s\S]*?const composerAttachments = \[[\s\S]*?\.\.\.registered\.images,[\s\S]*?\.\.\.openDocuments,[\s\S]*?await attachOptions\.onAttachImages\?\.\(composerAttachments\)/;
+  /const composerAttachments = \[[\s\S]*?\.\.\.registered\.images,[\s\S]*?\.\.\.registered\.openDocuments,[\s\S]*?await attachOptions\.onAttachImages\?\.\(composerAttachments\)/;
+const OPEN_DOCUMENT_REGISTRATION_CLASS_RE =
+  /const openDocumentPaths = docPaths\.filter\(isOpenDocumentAttachmentName\);[\s\S]*?const ragDocumentPaths = docPaths\.filter[\s\S]*?registerEach\(ragDocumentPaths\),[\s\S]*?registerEach\(openDocumentPaths\),[\s\S]*?openDocuments: openDocuments\.intents/;
 const OPEN_DOCUMENT_IMAGE_REGISTRATION_RE =
   /const needsOpenDocuments = openDocumentPaths\.length > 0;[\s\S]*?const needsComposerAttachments = needsImages \|\| needsOpenDocuments;[\s\S]*?if \(needsComposerAttachments\) store\.beginImageDropRegistration\(\);[\s\S]*?finally \{[\s\S]*?if \(needsComposerAttachments\) store\.endImageDropRegistration\(\)/;
 const OPEN_DOCUMENT_BACKEND_GATE_RE =
@@ -117,6 +119,7 @@ test("OpenDocument picker types are accepted by native drops", () => {
     "utf8",
   );
   assert.match(nativeDropSource, OPEN_DOCUMENT_DROP_TO_COMPOSER_RE);
+  assert.match(nativeDropSource, OPEN_DOCUMENT_REGISTRATION_CLASS_RE);
   assert.match(nativeDropSource, OPEN_DOCUMENT_IMAGE_REGISTRATION_RE);
   assert.match(nativeDropSource, OPEN_DOCUMENT_BACKEND_GATE_RE);
 

--- a/studio/frontend/tests/native-drop-paths.test.ts
+++ b/studio/frontend/tests/native-drop-paths.test.ts
@@ -54,13 +54,17 @@ const OPEN_DOCUMENT_EXTENSION_RE = /\.ods/;
 const OPEN_DOCUMENT_ADAPTER_ACCEPT_RE =
   /class OpenDocumentAttachmentAdapter[^{]*\{[\s\S]*?accept = OPEN_DOCUMENT_ATTACHMENT_ACCEPT;/;
 const OPEN_DOCUMENT_DROP_TO_COMPOSER_RE =
-  /const composerAttachments = \[[\s\S]*?\.\.\.registered\.images,[\s\S]*?\.\.\.registered\.openDocuments,[\s\S]*?await attachOptions\.onAttachImages\?\.\(composerAttachments\)/;
+  /await attachOptions\.onAttachImages\?\.\(registered\.images\)[\s\S]*?await attachOptions\.onAttachOpenDocuments\?\.\([\s\S]*?registered\.openDocuments/;
 const OPEN_DOCUMENT_REGISTRATION_CLASS_RE =
   /const openDocumentPaths = docPaths\.filter\(isOpenDocumentAttachmentName\);[\s\S]*?const ragDocumentPaths = docPaths\.filter[\s\S]*?registerEach\(ragDocumentPaths\),[\s\S]*?registerEach\(openDocumentPaths\),[\s\S]*?openDocuments: openDocuments\.intents/;
 const OPEN_DOCUMENT_IMAGE_REGISTRATION_RE =
   /const needsOpenDocuments = openDocumentPaths\.length > 0;[\s\S]*?const needsComposerAttachments = needsImages \|\| needsOpenDocuments;[\s\S]*?if \(needsComposerAttachments\) store\.beginImageDropRegistration\(\);[\s\S]*?finally \{[\s\S]*?if \(needsComposerAttachments\) store\.endImageDropRegistration\(\)/;
 const OPEN_DOCUMENT_BACKEND_GATE_RE =
-  /function canAttachDocumentPaths[\s\S]*?isOpenDocumentAttachmentName\(path\)[\s\S]*?\? canAttachImages\(options\)[\s\S]*?: canAttachDocs\(options\)[\s\S]*?const needsRagDocuments = documentPaths\.some[\s\S]*?if \(needsRagDocuments && !canAttachDocs\(currentOptions\)\)/;
+  /function canAttachDocumentPaths[\s\S]*?isOpenDocumentAttachmentName\(path\)[\s\S]*?\? canAttachOpenDocuments\(options\)[\s\S]*?: canAttachDocs\(options\)[\s\S]*?const needsRagDocuments = documentPaths\.some[\s\S]*?if \(needsRagDocuments && !canAttachDocs\(currentOptions\)\)/;
+const OPEN_DOCUMENT_CHAT_QUEUE_RE =
+  /const handleNativeOpenDocumentDrop = useCallback\([\s\S]*?addOpenDocumentAttachments\(artifactViewKey, intents\)[\s\S]*?onAttachOpenDocuments: handleNativeOpenDocumentDrop/;
+const OPEN_DOCUMENT_DRAIN_RE =
+  /takeOpenDocumentAttachments\(targetKey\)[\s\S]*?nativeAttachmentIntentToFile\(intent\)[\s\S]*?await aui\.composer\(\)\.addAttachment\(file\)/;
 
 function attachmentIntent(id: string): NativeIntent {
   return {
@@ -122,6 +126,18 @@ test("OpenDocument picker types are accepted by native drops", () => {
   assert.match(nativeDropSource, OPEN_DOCUMENT_REGISTRATION_CLASS_RE);
   assert.match(nativeDropSource, OPEN_DOCUMENT_IMAGE_REGISTRATION_RE);
   assert.match(nativeDropSource, OPEN_DOCUMENT_BACKEND_GATE_RE);
+
+  const chatPageSource = readFileSync(
+    new URL("../src/features/chat/chat-page.tsx", import.meta.url),
+    "utf8",
+  );
+  assert.match(chatPageSource, OPEN_DOCUMENT_CHAT_QUEUE_RE);
+
+  const threadSource = readFileSync(
+    new URL("../src/components/assistant-ui/thread.tsx", import.meta.url),
+    "utf8",
+  );
+  assert.match(threadSource, OPEN_DOCUMENT_DRAIN_RE);
 
   const rustSource = readFileSync(
     new URL("../../src-tauri/src/native_path_policy.rs", import.meta.url),
@@ -354,7 +370,7 @@ test("the drop image list matches the composer's file picker", () => {
 });
 
 // A remount means the instance that queued the batch cannot hand it over.
-test("a remounted composer claims the batch its predecessor left behind", () => {
+test("a remounted composer claims image and OpenDocument batches", () => {
   const store = useNativeIntentStore.getState();
   const intent = {
     id: "i1",
@@ -367,8 +383,10 @@ test("a remounted composer claims the batch its predecessor left behind", () => 
       expiresAtMs: Date.now() + 60_000,
     },
   } as unknown as NativeIntent;
+  const openDocument = attachmentIntent("remounted-sheet");
 
   store.addImageAttachments("single:new", [intent]);
+  store.addOpenDocumentAttachments("single:new", [openDocument]);
   store.noteImageDropOwner("single:new", "composer-1");
 
   // A different composer must not take it.
@@ -382,6 +400,11 @@ test("a remounted composer claims the batch its predecessor left behind", () => 
   const after = useNativeIntentStore.getState();
   assert.equal(after.pendingImageAttachments["single:new"], undefined);
   assert.deepEqual(after.pendingImageAttachments["single:thread-7"], [intent]);
+  assert.equal(after.pendingOpenDocumentAttachments["single:new"], undefined);
+  assert.deepEqual(
+    after.pendingOpenDocumentAttachments["single:thread-7"],
+    [openDocument],
+  );
   assert.deepEqual(after.imageDropOwners, {});
 });
 
@@ -413,6 +436,20 @@ test("ownership recorded after a claim is still picked up", () => {
   const after = useNativeIntentStore.getState();
   assert.equal(after.pendingImageAttachments["single:new"], undefined);
   assert.deepEqual(after.pendingImageAttachments["single:thread-9"], [intent]);
+});
+
+test("image failures cannot consume queued OpenDocuments", () => {
+  const store = useNativeIntentStore.getState();
+  const image = attachmentIntent("mixed-image");
+  const openDocument = attachmentIntent("mixed-sheet");
+
+  store.addImageAttachments("single:mixed", [image]);
+  store.addOpenDocumentAttachments("single:mixed", [openDocument]);
+
+  assert.deepEqual(store.takeImageAttachments("single:mixed"), [image]);
+  assert.deepEqual(store.takeOpenDocumentAttachments("single:mixed"), [
+    openDocument,
+  ]);
 });
 
 test("document, image and audio drop extensions stay disjoint", () => {

--- a/studio/src-tauri/src/native_intents.rs
+++ b/studio/src-tauri/src/native_intents.rs
@@ -635,6 +635,8 @@ fn attachment_mime_type(path: &Path) -> Option<&'static str> {
         "webm" => Some("video/webm"),
         "mkv" => Some("video/x-matroska"),
         "avi" => Some("video/x-msvideo"),
+        "ods" => Some("application/vnd.oasis.opendocument.spreadsheet"),
+        "odt" => Some("application/vnd.oasis.opendocument.text"),
         _ => None,
     }
 }
@@ -807,6 +809,23 @@ mod tests {
         assert_eq!(BASE64.decode(payload.base64).unwrap(), b"\x89PNG\r\n\x1a\n");
         assert!(payload.name.ends_with(".png"));
         let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    fn open_document_read_round_trips_with_its_mime_type() {
+        for (ext, mime) in [
+            ("ods", "application/vnd.oasis.opendocument.spreadsheet"),
+            ("odt", "application/vnd.oasis.opendocument.text"),
+        ] {
+            let path = temp_path("open-document").with_extension(ext);
+            fs::write(&path, b"open-document").unwrap();
+            let (_state, entry) = attachment_entry(&path);
+            let payload = read_attachment_payload(&entry)
+                .unwrap_or_else(|error| panic!(".{ext} was unreadable: {error}"));
+            assert_eq!(payload.mime_type, mime);
+            assert_eq!(BASE64.decode(payload.base64).unwrap(), b"open-document");
+            let _ = fs::remove_file(path);
+        }
     }
 
     #[test]

--- a/studio/src-tauri/src/native_intents.rs
+++ b/studio/src-tauri/src/native_intents.rs
@@ -599,8 +599,10 @@ pub fn open_path_token(
     crate::process::open_detached(entry.canonical_path).map_err(|e| format!("Failed to open path: {e}"))
 }
 
-// Covers the largest client-side limit (audio, 25 MB).
+// Covers the generic client-side limit (audio, 25 MB).
 const MAX_NATIVE_ATTACHMENT_BYTES: u64 = 25 * 1024 * 1024;
+// OpenDocument archives use the composer's larger archive limit.
+const MAX_NATIVE_OPEN_DOCUMENT_BYTES: u64 = 50 * 1024 * 1024;
 // Images stop lower: the composer throws over 20 MB without a toast and the
 // drain swallows it, so a larger read loses them silently.
 const MAX_NATIVE_IMAGE_BYTES: u64 = 20 * 1024 * 1024;
@@ -691,6 +693,8 @@ fn read_attachment_payload(entry: &NativePathEntry) -> Result<NativeAttachmentFi
         MAX_NATIVE_IMAGE_BYTES
     } else if mime_type.starts_with("video/") {
         MAX_NATIVE_VIDEO_BYTES
+    } else if mime_type.starts_with("application/vnd.oasis.opendocument.") {
+        MAX_NATIVE_OPEN_DOCUMENT_BYTES
     } else {
         MAX_NATIVE_ATTACHMENT_BYTES
     };
@@ -887,6 +891,20 @@ mod tests {
             panic!("expected the read to be refused");
         };
         assert!(err.contains("too large"), "unexpected error: {err}");
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    fn open_document_read_allows_more_than_the_generic_cap() {
+        let path = temp_path("spreadsheet").with_extension("ods");
+        fs::write(&path, vec![0u8; MAX_NATIVE_ATTACHMENT_BYTES as usize + 1]).unwrap();
+        let (_state, entry) = attachment_entry(&path);
+        let payload =
+            read_attachment_payload(&entry).expect("OpenDocument archive under 50 MiB reads");
+        assert_eq!(
+            payload.mime_type,
+            "application/vnd.oasis.opendocument.spreadsheet"
+        );
         let _ = fs::remove_file(path);
     }
 

--- a/studio/src-tauri/src/native_path_policy.rs
+++ b/studio/src-tauri/src/native_path_policy.rs
@@ -48,6 +48,8 @@ pub fn classify_native_model_path(path: &Path) -> Result<ClassifiedPath, String>
 
 /// Document types the RAG ingest accepts; keep in sync with `config.UPLOAD_EXTS`.
 pub const ATTACHMENT_EXTS: &[&str] = &["pdf", "txt", "md", "markdown", "docx", "html", "htm"];
+/// OpenDocument files the chat composer parses directly rather than indexing as RAG sources.
+pub const OPEN_DOCUMENT_ATTACHMENT_EXTS: &[&str] = &["ods", "odt"];
 pub const TRAINING_DATASET_EXTS: &[&str] = &["csv", "json", "jsonl", "parquet"];
 
 /// Vision chat image attachments; keep in sync with `drop-paths.ts` `CHAT_IMAGE_DROP_ACCEPT`.
@@ -64,6 +66,7 @@ pub const VIDEO_ATTACHMENT_EXTS: &[&str] = &["mp4", "mov", "webm", "mkv", "avi"]
 fn accepted_attachment_exts() -> impl Iterator<Item = &'static &'static str> {
     ATTACHMENT_EXTS
         .iter()
+        .chain(OPEN_DOCUMENT_ATTACHMENT_EXTS.iter())
         .chain(IMAGE_ATTACHMENT_EXTS.iter())
         .chain(AUDIO_ATTACHMENT_EXTS.iter())
         .chain(VIDEO_ATTACHMENT_EXTS.iter())


### PR DESCRIPTION

### Summary

Dragging an `.ods` file into Studio was rejected even though **Files -> + -> Add files** accepted the same file. Desktop drag and drop derived document support from the narrower RAG allowlist and a separate native policy, while the picker used the OpenDocument composer adapter. The initial native route also bypassed the composer's keyed attachment lifecycle and kept a 25 MiB reader ceiling instead of the picker's 50 MiB OpenDocument limit.

The change shares the OpenDocument accept definition, permits `.ods` and `.odt` through the native bridge, routes those drops through the existing keyed composer attachment queue rather than RAG, and aligns the native reader with the adapter's 50 MiB archive limit. Other RAG and media upload types keep their existing paths.

### How to test

1. Drag `test_upload_ods.ods` onto a Studio chat and confirm it is accepted and processed as an attachment.
2. Select the same file through **Files -> + -> Add files** and confirm it still works.
3. Drop a supported RAG document such as `.pdf` and an unsupported file such as `.zip`; confirm their behavior is unchanged.
4. Start a send immediately after dropping an `.ods`, then switch chats during another drop; confirm the send waits and the attachment stays with its original chat.
5. Run:

```text
node --experimental-strip-types --test tests/native-drop-paths.test.ts
npm run typecheck
npm run build
cargo test --manifest-path studio/src-tauri/Cargo.toml native_intents
```
