### PR TITLE
Retry the desktop ownership id read that a concurrent publish denies

### DIFF
--- a/studio/backend/tests/test_imatrix_gguf_filtering.py
+++ b/studio/backend/tests/test_imatrix_gguf_filtering.py
@@ -157,9 +157,7 @@ def test_the_models_dir_scanner_does_not_publish_an_imatrix_only_child(tmp_path)
 
     (repo / "Qwen3.8-27B-UD-Q4_K_XL.gguf").write_bytes(b"GGUF" + b"0" * 64)
     rows = _scan_models_dir(tmp_path)
-    assert [(Path(r.path).name, r.model_format) for r in rows] == [
-        ("Qwen3.8-27B-GGUF", "gguf")
-    ]
+    assert [(Path(r.path).name, r.model_format) for r in rows] == [("Qwen3.8-27B-GGUF", "gguf")]
 
 
 def test_an_mmproj_only_child_still_decides_presence(tmp_path):
@@ -217,9 +215,7 @@ def test_the_lmstudio_scanner_does_not_publish_an_imatrix_only_model_dir(tmp_pat
 
     (model_dir / "Qwen3.8-27B-UD-Q4_K_XL.gguf").write_bytes(b"GGUF" + b"0" * 64)
     rows = _scan_lmstudio_dir(tmp_path)
-    assert [(r.model_id, r.model_format) for r in rows] == [
-        ("unsloth/Qwen3.8-27B-GGUF", "gguf")
-    ]
+    assert [(r.model_id, r.model_format) for r in rows] == [("unsloth/Qwen3.8-27B-GGUF", "gguf")]
 
 
 def test_a_downloaded_imatrix_is_not_a_downloaded_gguf_repo(tmp_path):

--- a/studio/backend/tests/test_mmproj_placement_policy.py
+++ b/studio/backend/tests/test_mmproj_placement_policy.py
@@ -1202,9 +1202,9 @@ def test_the_speculative_reserve_is_normalized_before_anything_prices_it(tmp_pat
     source = Path(inspect.getsourcefile(LlamaCppBackend)).read_text()
     normalize_at = source.index("if _draft_cpu_no_embedded and mtp_overhead_fn is not None:")
     probe_at = source.index("_mm_mtp_on_gpu = _mtp_will_engage and not _draft_cpu_no_embedded")
-    assert normalize_at < probe_at, (
-        "the CPU-drafter reserve must be normalized before the projector probe prices it"
-    )
+    assert (
+        normalize_at < probe_at
+    ), "the CPU-drafter reserve must be normalized before the projector probe prices it"
 
 
 def test_a_shared_device_beside_a_discrete_one_does_not_veto_the_pin(tmp_path):

--- a/studio/src-tauri/src/desktop_backend_owner.rs
+++ b/studio/src-tauri/src/desktop_backend_owner.rs
@@ -328,8 +328,51 @@ fn is_blank_studio_root_id(raw: &str) -> bool {
     raw.trim().is_empty()
 }
 
+// Windows hands back ERROR_ACCESS_DENIED, not a sharing violation, while a delete
+// is pending on any name for a file. create_studio_root_id_file publishes by
+// hard-linking the temp file onto the real path and then removing the temp name, so
+// for the width of that remove there are two names for one file and a concurrent
+// reader of the real path can be denied. The file is fine either side of it.
+//
+// Retrying is the whole fix: the window is one unlink, and a caller that gives up
+// inside it reports a corrupt install for a file that is intact. NotFound still
+// means absent and still returns immediately -- a missing id is a normal first
+// start, not something to wait on.
+const STUDIO_ROOT_ID_READ_ATTEMPTS: usize = 5;
+const STUDIO_ROOT_ID_READ_BACKOFF: Duration = Duration::from_millis(20);
+
+fn read_studio_root_id_to_string(path: &Path) -> std::io::Result<String> {
+    read_studio_root_id_to_string_with(path, |path| std::fs::read_to_string(path))
+}
+
+fn read_studio_root_id_to_string_with(
+    path: &Path,
+    mut read: impl FnMut(&Path) -> std::io::Result<String>,
+) -> std::io::Result<String> {
+    let mut attempt = 0;
+    loop {
+        match read(path) {
+            Ok(raw) => return Ok(raw),
+            // Absent is an answer, not a transient state.
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Err(error),
+            Err(error) if is_transient_read_denial(&error) => {
+                attempt += 1;
+                if attempt >= STUDIO_ROOT_ID_READ_ATTEMPTS {
+                    return Err(error);
+                }
+                std::thread::sleep(STUDIO_ROOT_ID_READ_BACKOFF);
+            }
+            Err(error) => return Err(error),
+        }
+    }
+}
+
+fn is_transient_read_denial(error: &std::io::Error) -> bool {
+    matches!(error.kind(), std::io::ErrorKind::PermissionDenied)
+}
+
 fn read_studio_root_id_file(path: &Path) -> Result<Option<String>, String> {
-    let raw = match std::fs::read_to_string(path) {
+    let raw = match read_studio_root_id_to_string(path) {
         Ok(raw) => raw,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
         Err(error) => {
@@ -1815,6 +1858,69 @@ mod tests {
         assert_eq!(std::fs::read_to_string(&path).unwrap(), "not-a-root-id");
 
         let _ = std::fs::remove_dir_all(path.parent().unwrap().parent().unwrap());
+    }
+
+    // The retry is driven through an injected reader rather than a real race: the
+    // real one is a single unlink wide and cannot be scheduled reliably, so a test
+    // that raced for it would pass on a machine that never entered the window.
+    fn denial() -> std::io::Error {
+        std::io::Error::new(std::io::ErrorKind::PermissionDenied, "Access is denied.")
+    }
+
+    #[test]
+    fn a_reader_denied_while_the_temp_name_is_unlinked_still_gets_the_id() {
+        let mut seen = 0;
+        let raw = read_studio_root_id_to_string_with(Path::new("id"), |_| {
+            seen += 1;
+            if seen < 3 {
+                Err(denial())
+            } else {
+                Ok("an-id".to_string())
+            }
+        })
+        .unwrap();
+        assert_eq!(raw, "an-id");
+        assert_eq!(seen, 3, "the read should have been retried until it succeeded");
+    }
+
+    #[test]
+    fn a_denial_that_never_clears_is_still_reported() {
+        // Retrying must not turn a genuinely unreadable file into a hang or a
+        // silent success; it is bounded and the last error is what the caller sees.
+        let mut seen = 0;
+        let error = read_studio_root_id_to_string_with(Path::new("id"), |_| {
+            seen += 1;
+            Err(denial())
+        })
+        .unwrap_err();
+        assert_eq!(error.kind(), std::io::ErrorKind::PermissionDenied);
+        assert_eq!(seen, STUDIO_ROOT_ID_READ_ATTEMPTS);
+    }
+
+    #[test]
+    fn a_missing_id_is_answered_without_waiting() {
+        // A first start has no id file. Retrying that would add backoff to every
+        // cold launch and still return the same answer.
+        let mut seen = 0;
+        let error = read_studio_root_id_to_string_with(Path::new("id"), |_| {
+            seen += 1;
+            Err(std::io::Error::from(std::io::ErrorKind::NotFound))
+        })
+        .unwrap_err();
+        assert_eq!(error.kind(), std::io::ErrorKind::NotFound);
+        assert_eq!(seen, 1, "a missing id must not be retried");
+    }
+
+    #[test]
+    fn an_unrelated_read_error_is_not_retried() {
+        let mut seen = 0;
+        let error = read_studio_root_id_to_string_with(Path::new("id"), |_| {
+            seen += 1;
+            Err(std::io::Error::from(std::io::ErrorKind::InvalidData))
+        })
+        .unwrap_err();
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
+        assert_eq!(seen, 1, "only a denial is treated as transient");
     }
 
     #[test]

--- a/studio/src-tauri/src/desktop_backend_owner.rs
+++ b/studio/src-tauri/src/desktop_backend_owner.rs
@@ -328,16 +328,11 @@ fn is_blank_studio_root_id(raw: &str) -> bool {
     raw.trim().is_empty()
 }
 
-// Windows hands back ERROR_ACCESS_DENIED, not a sharing violation, while a delete
-// is pending on any name for a file. create_studio_root_id_file publishes by
-// hard-linking the temp file onto the real path and then removing the temp name, so
-// for the width of that remove there are two names for one file and a concurrent
-// reader of the real path can be denied. The file is fine either side of it.
-//
-// Retrying is the whole fix: the window is one unlink, and a caller that gives up
-// inside it reports a corrupt install for a file that is intact. NotFound still
-// means absent and still returns immediately -- a missing id is a normal first
-// start, not something to wait on.
+// create_studio_root_id_file hard-links the temp file onto the real path and then
+// removes the temp name, so for the width of that unlink there are two names for one
+// file. Windows denies an open of EITHER name while a delete is pending, with
+// ERROR_ACCESS_DENIED rather than a sharing violation, so a concurrent reader is turned
+// away from a file that is intact on both sides of the window.
 const STUDIO_ROOT_ID_READ_ATTEMPTS: usize = 5;
 const STUDIO_ROOT_ID_READ_BACKOFF: Duration = Duration::from_millis(20);
 
@@ -1860,9 +1855,8 @@ mod tests {
         let _ = std::fs::remove_dir_all(path.parent().unwrap().parent().unwrap());
     }
 
-    // The retry is driven through an injected reader rather than a real race: the
-    // real one is a single unlink wide and cannot be scheduled reliably, so a test
-    // that raced for it would pass on a machine that never entered the window.
+    // Injected reader, not a real race: the window is one unlink wide, so a test that
+    // raced for it would pass on any machine that never entered it.
     fn denial() -> std::io::Error {
         std::io::Error::new(std::io::ErrorKind::PermissionDenied, "Access is denied.")
     }
@@ -1885,8 +1879,8 @@ mod tests {
 
     #[test]
     fn a_denial_that_never_clears_is_still_reported() {
-        // Retrying must not turn a genuinely unreadable file into a hang or a
-        // silent success; it is bounded and the last error is what the caller sees.
+        // Bounded: a genuinely unreadable file must not become a hang or a silent
+        // success, and the last error is what the caller sees.
         let mut seen = 0;
         let error = read_studio_root_id_to_string_with(Path::new("id"), |_| {
             seen += 1;
@@ -1899,8 +1893,8 @@ mod tests {
 
     #[test]
     fn a_missing_id_is_answered_without_waiting() {
-        // A first start has no id file. Retrying that would add backoff to every
-        // cold launch and still return the same answer.
+        // A first start has no id file; retrying would add backoff to every cold
+        // launch for the same answer.
         let mut seen = 0;
         let error = read_studio_root_id_to_string_with(Path::new("id"), |_| {
             seen += 1;


### PR DESCRIPTION
`Rust unit tests (windows)` failed on `main` in [run 32439960487](https://github.com/unslothai/unsloth/actions/runs/32439960487/job/96648496983):

```
thread 'desktop_backend_owner::tests::stale_blank_observer_cannot_delete_a_competing_callers_id'
panicked at src\desktop_backend_owner.rs:1874:51:
called `Result::unwrap()` on an `Err` value: "could not read the desktop ownership id at
C:\...\share\studio_install_id: Access is denied. (os error 5)"
```

## The test is right; the read path is wrong

That test drives two threads through `ensure_studio_root_id_at` at once, which is the case it exists to cover.

`create_studio_root_id_file` publishes by hard-linking its temp file onto the real path and then removing the temp name:

```rust
let claimed = claim_private_file(&tmp, path, id.as_bytes());
let _ = std::fs::remove_file(&tmp);
```

For the width of that unlink there are two names for one file. Windows answers an open of **either** name with `ERROR_ACCESS_DENIED` while a delete is pending on the file, and `read_studio_root_id_file` treated everything except `NotFound` as fatal. A reader that landed in the window reported a corrupt install, with `delete that file and reopen Unsloth`, for a file that was intact on both sides of it.

Two Studio processes starting together reach this the same way, so this is a product race worth fixing rather than something to retry in CI.

## The change

The read retries a denial five times at 20ms. `NotFound` still returns immediately: a missing id is a normal first start, and retrying it would add backoff to every cold launch to reach the same answer. Any other error is still returned as-is.

## Why it took this long to surface

Rare, not new: `Rust unit tests (windows)` is **16 success / 0 failure** across the last 25 runs of `studio-tauri-smoke.yml`. That is also why this ships a fix for the race rather than a rerun.

## Tests

Four tests, driven through an injected reader rather than a real race. The real window is one unlink wide and cannot be scheduled reliably, so a test that raced for it would pass on any machine that never entered the window.

- a denial that clears is retried until it succeeds
- a denial that never clears is still reported, bounded, with the last error
- a missing id is answered without waiting, in one attempt
- an unrelated error is not retried

Mutation-tested: classifying a denial as non-transient fails both retry tests.

```
test result: ok. 30 passed; 0 failed  (desktop_backend_owner::tests)
```
