### PR TITLE
Bound the SDK majors CI installs, and guard the ones the probes call

### DIFF
--- a/.github/workflows/studio-inference-smoke.yml
+++ b/.github/workflows/studio-inference-smoke.yml
@@ -199,7 +199,7 @@ jobs:
         # temperature = 0.0 for determinism, raise TypeError against it. The v1 route
         # is extra_body; moving to it is a deliberate change to what the probes send,
         # not something a CI install should decide by resolving a new major.
-        run: pip install 'openai>=1.50' 'anthropic>=0.40,<1'
+        run: pip install 'openai>=1.50,<4' 'anthropic>=0.40,<1'
 
       # Phase 1's environment and model cache sit HERE, after the shared
       # preamble, not before it. They used to run before the installer, which is

--- a/.github/workflows/studio-mac-ui-smoke.yml
+++ b/.github/workflows/studio-mac-ui-smoke.yml
@@ -652,7 +652,7 @@ jobs:
         # temperature = 0.0 for determinism, raise TypeError against it. The v1 route
         # is extra_body; moving to it is a deliberate change to what the probes send,
         # not something a CI install should decide by resolving a new major.
-        run: pip install 'openai>=1.50' 'anthropic>=0.40,<1'
+        run: pip install 'openai>=1.50,<4' 'anthropic>=0.40,<1'
 
       - name: Reset auth + boot Unsloth (API-only)
         id: boot-chat
@@ -1285,7 +1285,7 @@ jobs:
         # temperature = 0.0 for determinism, raise TypeError against it. The v1 route
         # is extra_body; moving to it is a deliberate change to what the probes send,
         # not something a CI install should decide by resolving a new major.
-        run: pip install 'openai>=1.50' 'anthropic>=0.40,<1'
+        run: pip install 'openai>=1.50,<4' 'anthropic>=0.40,<1'
 
       - name: Reset auth + boot Unsloth (API-only)
         id: boot-vision

--- a/.github/workflows/studio-ui-smoke.yml
+++ b/.github/workflows/studio-ui-smoke.yml
@@ -244,7 +244,7 @@ jobs:
       - name: Pin the Playwright version so the browser cache has a key
         id: pw
         run: |
-          pip install 'playwright>=1.45'
+          pip install 'playwright>=1.45,<2'
           echo "version=$(python -c 'import playwright; from importlib.metadata import version; print(version("playwright"))')" >> "$GITHUB_OUTPUT"
 
       # Three browser engines, downloaded on every job, on every run, uncached. It was
@@ -844,7 +844,7 @@ jobs:
       - name: Pin the Playwright version so the browser cache has a key
         id: pw
         run: |
-          pip install 'playwright>=1.45'
+          pip install 'playwright>=1.45,<2'
           echo "version=$(python -c 'import playwright; from importlib.metadata import version; print(version("playwright"))')" >> "$GITHUB_OUTPUT"
 
       # Three browser engines, downloaded on every job, on every run, uncached. It was

--- a/.github/workflows/studio-windows-inference-smoke.yml
+++ b/.github/workflows/studio-windows-inference-smoke.yml
@@ -300,7 +300,7 @@ jobs:
         # temperature = 0.0 for determinism, raise TypeError against it. The v1 route
         # is extra_body; moving to it is a deliberate change to what the probes send,
         # not something a CI install should decide by resolving a new major.
-        run: python -m pip install 'openai>=1.50' 'anthropic>=0.40,<1'
+        run: python -m pip install 'openai>=1.50,<4' 'anthropic>=0.40,<1'
 
       # Phase 1's environment and model cache sit HERE, after the shared
       # preamble, not before it. They used to run before the installer, which is

--- a/.github/workflows/studio-windows-ui-smoke.yml
+++ b/.github/workflows/studio-windows-ui-smoke.yml
@@ -361,7 +361,7 @@ jobs:
         # packages. windows-latest ships the system frameworks
         # Chromium needs (Edge / WebView2) already.
         run: |
-          python -m pip install 'playwright>=1.45'
+          python -m pip install 'playwright>=1.45,<2'
           python -m playwright install chromium
 
       # Two lanes, concurrently, on one runner.

--- a/.github/workflows/workflow-trigger-lint.yml
+++ b/.github/workflows/workflow-trigger-lint.yml
@@ -154,6 +154,7 @@ jobs:
             tests/studio/test_main_runs_survive_merge_bursts.py \
             tests/studio/test_pester_bootstrap_hardening.py \
             tests/studio/test_playwright_suites_run_in_ci.py \
+            tests/studio/test_sdk_installs_are_major_bounded.py \
             tests/studio/test_short_job_absorption.py \
             tests/studio/test_smoke_workflows_share_one_script.py \
             tests/studio/test_stt_model_search_locator_contract.py \

--- a/tests/studio/test_sdk_installs_are_major_bounded.py
+++ b/tests/studio/test_sdk_installs_are_major_bounded.py
@@ -23,6 +23,7 @@ remove. Adding to this set needs that property; removing from it needs a reason.
 from __future__ import annotations
 
 import re
+import shlex
 from pathlib import Path
 
 import pytest
@@ -50,13 +51,17 @@ GUARDED = {
     "playwright": (2,),
 }
 
-# 'name>=1.2' / "name>=1.2,<2" / bare name>=1.2, as they appear inside a `pip install`.
-_SPEC = re.compile(
-    r"""(?P<quote>['"]?)(?P<name>[A-Za-z0-9][A-Za-z0-9._-]*)"""
-    r"""(?P<spec>(?:[<>=!~]=?[^,'"\s]+)(?:,[<>=!~]=?[^,'"\s]+)*)(?P=quote)"""
+# One `pip install` argument: name, optional [extras], optional specifier. The specifier
+# is optional on purpose -- a bare `pip install openai` resolves whatever major is current,
+# which is the exact thing this file exists to prevent, and a pattern that required a
+# specifier could not see it at all.
+_REQUIREMENT = re.compile(
+    r"""^(?P<name>[A-Za-z0-9][A-Za-z0-9._-]*)(?:\[[^\]]*\])?(?P<spec>.*)$"""
 )
 
 _UPPER = re.compile(r"(?P<op><=|<)(?P<version>[0-9][0-9.]*)")
+_EXACT = re.compile(r"===?(?P<version>[0-9][0-9.]*)")
+_COMPATIBLE = re.compile(r"~=(?P<version>[0-9][0-9.]*)")
 
 
 def _install_commands_in(text: str) -> list[tuple[int, str]]:
@@ -102,12 +107,37 @@ def _install_lines() -> list[tuple[Path, int, str]]:
     return found
 
 
+def _requirements_in(command: str, package: str) -> list[str]:
+    """Every requirement for `package` in one pip command, as its raw specifier.
+
+    Returns "" for a bare `pip install openai`, which is a requirement with no
+    constraint at all, and is distinct from the package not appearing.
+
+    Tokenized rather than pattern-matched across the whole command so that a package
+    name inside a URL or a `-r` path cannot be mistaken for an install of it.
+    """
+    try:
+        tokens = shlex.split(command, posix = True)
+    except ValueError:
+        tokens = command.split()
+    found = []
+    for token in tokens:
+        if token.startswith("-") or "/" in token:
+            continue
+        match = _REQUIREMENT.match(token)
+        if not match:
+            continue
+        if match.group("name").lower().replace("_", "-") != package:
+            continue
+        found.append(match.group("spec"))
+    return found
+
+
 def _specs_for(package: str) -> list[tuple[Path, int, str]]:
     hits = []
-    for path, number, line in _install_lines():
-        for match in _SPEC.finditer(line):
-            if match.group("name").lower().replace("_", "-") == package:
-                hits.append((path, number, match.group("spec")))
+    for path, number, command in _install_lines():
+        for spec in _requirements_in(command, package):
+            hits.append((path, number, spec))
     return hits
 
 
@@ -116,12 +146,33 @@ def _version(raw: str) -> tuple[int, ...]:
 
 
 def _excludes(spec: str, major: tuple[int, ...]) -> bool:
-    """Does this specifier keep `major` out?
+    """Does this requirement keep `major` out?
 
-    `<2` and `<1.58` both exclude 2.x; `<=2` does not, since it admits 2.0 itself.
+    - no specifier at all resolves whatever is current, so it excludes nothing
+    - `<2` and `<1.58` both exclude 2.x; `<=2` does not, since it admits 2.0 itself
+    - `==3.0.0` cannot drift anywhere, so an exact pin below the major is safe
+    - `~=1.4` means `>=1.4,<2`, so it carries an upper bound of its own
+
     Compared as integer tuples rather than through `packaging`, which the
     workflow-trigger-lint job does not install.
     """
+    if not spec.strip():
+        return False
+    for match in _EXACT.finditer(spec):
+        pinned = _version(match.group("version"))
+        if pinned and pinned < major:
+            return True
+    for match in _COMPATIBLE.finditer(spec):
+        release = _version(match.group("version"))
+        # ~=X.Y means >=X.Y,<X+1; ~=X.Y.Z means >=X.Y.Z,<X.Y+1.
+        if len(release) == 2:
+            implied = (release[0] + 1,)
+        elif len(release) > 2:
+            implied = (release[0], release[1] + 1)
+        else:
+            continue
+        if implied <= major:
+            return True
     for match in _UPPER.finditer(spec):
         bound = _version(match.group("version"))
         if not bound:
@@ -164,6 +215,39 @@ def test_a_bound_above_the_next_major_is_not_accepted() -> None:
     # A narrower window than the boundary is stricter, and still fine.
     assert _excludes(">=1.55,<1.58", GUARDED["playwright"])
     assert _excludes(">=1.45,<2", GUARDED["playwright"])
+
+
+def test_a_pin_that_cannot_drift_is_accepted() -> None:
+    """An exact or compatible-release pin already excludes the major.
+
+    Rejecting these would be a false positive that pushes people to add a redundant
+    `<N` beside an `==`, so the rule is about what the requirement can RESOLVE to, not
+    about which operator was typed.
+    """
+    assert _excludes("==3.0.0", GUARDED["openai"])
+    assert _excludes("===3.0.0", GUARDED["openai"])
+    assert not _excludes("==4.1.0", GUARDED["openai"])
+    # ~=1.4 is >=1.4,<2, so it keeps 2.x out.
+    assert _excludes("~=1.4", GUARDED["playwright"])
+    # ~=1.4.5 is >=1.4.5,<1.5, narrower still.
+    assert _excludes("~=1.4.5", GUARDED["playwright"])
+
+
+def test_a_bare_or_extras_install_is_not_invisible() -> None:
+    """`pip install openai` resolves whatever major is current.
+
+    A pattern that required a version specifier matched nothing here, so the package
+    was neither bounded nor reported, while the anti-vacuity test stayed satisfied by
+    the other pins. Extras are the same shape.
+    """
+    assert _requirements_in("pip install openai", "openai") == [""]
+    assert _requirements_in("pip install 'openai[datalib]>=1.50'", "openai") == [">=1.50"]
+    assert not _excludes("", GUARDED["openai"]), "a bare install constrains nothing"
+    # A name inside a URL or a requirements path is not an install of that package.
+    assert _requirements_in("pip install -r reqs/openai.txt", "openai") == []
+    assert _requirements_in(
+        "pip install --index-url https://example.test/openai/simple pytest", "openai"
+    ) == []
 
 
 def test_a_pin_on_a_continuation_line_is_still_seen() -> None:

--- a/tests/studio/test_sdk_installs_are_major_bounded.py
+++ b/tests/studio/test_sdk_installs_are_major_bounded.py
@@ -56,7 +56,12 @@ _REQUIREMENT = re.compile(r"""^(?P<name>[A-Za-z0-9][A-Za-z0-9._-]*)(?:\[[^\]]*\]
 
 # `pip install`, but also `pip3 install` and `"$VENV/bin/pip" install`, which
 # mlx-ci.yml:439 already uses. Matching the literal text `pip install` missed both.
-_PIP_INSTALL = re.compile(r"""(?:^|[\s"'/])pip[0-9.]*["']?\s+install(?:\s|$)""")
+# pip, pip3, pip3.12, pip.exe, and any of those behind a path with either separator,
+# quoted or not. mlx-ci.yml:439 uses "$STUDIO_VENV/bin/pip"; the Windows workflows can
+# use pip.exe, which neither a `/`-only separator nor a digits-only suffix would match.
+_PIP_INSTALL = re.compile(
+    r"""(?:^|[\s"'/\\])pip[0-9]*(?:\.[0-9]+)*(?:\.exe)?["']?\s+install(?:\s|$)"""
+)
 
 # The whole version token, suffix included. Capturing only the numeric prefix silently
 # turned `<4.post1` into `<4`, and a post-release or local-version bound is LOOSER than
@@ -65,6 +70,27 @@ _UPPER = re.compile(r"(?P<op><=|<)(?P<version>[^,\s'\"]+)")
 _NUMERIC = re.compile(r"^[0-9][0-9.]*$")
 _EXACT = re.compile(r"===?(?P<version>[0-9][0-9.]*)")
 _COMPATIBLE = re.compile(r"~=(?P<version>[0-9][0-9.]*)")
+
+
+def _strip_inline_comment(line: str) -> str:
+    """Drop a trailing shell comment, respecting quotes.
+
+    Only whole-line comments were dropped before, so `run: echo ok  # pip install
+    'openai<4'` was scanned as a real install: commented text could satisfy the bound
+    and anti-vacuity checks, and merely naming a bare guarded package after a `#` could
+    fail CI. A `#` only opens a comment at the start of a word, so `git+https://x#egg=y`
+    survives.
+    """
+    quote = ""
+    for index, char in enumerate(line):
+        if quote:
+            if char == quote:
+                quote = ""
+        elif char in "'\"":
+            quote = char
+        elif char == "#" and (index == 0 or line[index - 1].isspace()):
+            return line[:index]
+    return line
 
 
 def _install_commands_in(text: str) -> list[tuple[int, str]]:
@@ -81,7 +107,8 @@ def _install_commands_in(text: str) -> list[tuple[int, str]]:
     pending: list[str] = []
     start = 0
     for number, line in enumerate(text.splitlines(), 1):
-        if line.lstrip().startswith("#"):
+        line = _strip_inline_comment(line)
+        if not line.strip():
             continue
         if not pending:
             start = number
@@ -128,7 +155,7 @@ def _requirements_in(command: str, package: str) -> list[str]:
         tokens = command.split()
     found = []
     for token in tokens:
-        if token.startswith("-") or "/" in token:
+        if token.startswith("-") or "/" in token or "\\" in token:
             continue
         match = _REQUIREMENT.match(token)
         if not match:
@@ -370,3 +397,32 @@ def test_a_compatible_pin_keeps_its_written_precision() -> None:
     assert _excludes("~=3.0.0", GUARDED["openai"])
     assert _release("3.0.0") == (3, 0, 0)
     assert _version("3.0.0") == (3,)
+
+
+def test_a_trailing_comment_is_not_an_install() -> None:
+    """Only whole-line comments were dropped, which cut both ways.
+
+    Commented text could satisfy the bound and anti-vacuity checks after the real
+    installs were gone, and merely naming a bare guarded package after a `#` could fail
+    CI. A `#` only opens a comment at the start of a word, so a URL fragment survives.
+    """
+    assert _install_commands_in("      - run: echo ok  # pip install 'openai<4'\n") == []
+    assert _install_commands_in("          pip install 'openai>=1.50,<4'  # below 4\n")
+    assert _strip_inline_comment("pip install 'git+https://x#egg=y'") == (
+        "pip install 'git+https://x#egg=y'"
+    )
+    assert _strip_inline_comment("pip install git+https://x#egg=y") == (
+        "pip install git+https://x#egg=y"
+    )
+
+
+def test_a_windows_pip_executable_is_recognized() -> None:
+    """`pip.exe` matched neither the digits-only suffix nor the `/`-only separator."""
+    for command in (
+        "pip.exe install openai",
+        '"$VENV\\Scripts\\pip.exe" install openai',
+        "pip3.12.exe install openai",
+    ):
+        assert _PIP_INSTALL.search(command), command
+    assert not _PIP_INSTALL.search("npm install openai")
+    assert not _PIP_INSTALL.search("pip download openai")

--- a/tests/studio/test_sdk_installs_are_major_bounded.py
+++ b/tests/studio/test_sdk_installs_are_major_bounded.py
@@ -52,9 +52,7 @@ GUARDED = {
 # is optional on purpose -- a bare `pip install openai` resolves whatever major is current,
 # which is the exact thing this file exists to prevent, and a pattern that required a
 # specifier could not see it at all.
-_REQUIREMENT = re.compile(
-    r"""^(?P<name>[A-Za-z0-9][A-Za-z0-9._-]*)(?:\[[^\]]*\])?(?P<spec>.*)$"""
-)
+_REQUIREMENT = re.compile(r"""^(?P<name>[A-Za-z0-9][A-Za-z0-9._-]*)(?:\[[^\]]*\])?(?P<spec>.*)$""")
 
 # `pip install`, but also `pip3 install` and `"$VENV/bin/pip" install`, which
 # mlx-ci.yml:439 already uses. Matching the literal text `pip install` missed both.
@@ -273,9 +271,12 @@ def test_a_bare_or_extras_install_is_not_invisible() -> None:
     assert not _excludes("", GUARDED["openai"]), "a bare install constrains nothing"
     # A name inside a URL or a requirements path is not an install of that package.
     assert _requirements_in("pip install -r reqs/openai.txt", "openai") == []
-    assert _requirements_in(
-        "pip install --index-url https://example.test/openai/simple pytest", "openai"
-    ) == []
+    assert (
+        _requirements_in(
+            "pip install --index-url https://example.test/openai/simple pytest", "openai"
+        )
+        == []
+    )
 
 
 def test_a_pin_on_a_continuation_line_is_still_seen() -> None:

--- a/tests/studio/test_sdk_installs_are_major_bounded.py
+++ b/tests/studio/test_sdk_installs_are_major_bounded.py
@@ -1,0 +1,102 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""SDKs the probes call by name must not float across a major.
+
+On 2026-08-20 `anthropic` 1.0.0 was published. The inference smoke workflows installed
+`anthropic>=0.40` with no upper bound, pip resolved the new major, and v1 had removed
+`temperature`, `top_p` and `top_k` as accepted arguments on `messages.create()`. Every
+probe that pins `temperature = 0.0` for determinism started raising:
+
+    TypeError: Messages.create() got an unexpected keyword argument 'temperature'
+
+75 job failures in about four hours, across every PR that ran those workflows, none of
+them caused by the PR they were reported against. #9432 pinned `<1` to stop it.
+
+This guard is deliberately NOT "every `>=` needs an upper bound". Most pins here are
+libraries whose majors do not reach our code, and asserting on all of them would be noise
+that gets suppressed. It covers the packages whose *call surface* our own probe scripts
+use directly with keyword arguments, which is exactly the surface a major is allowed to
+remove. Adding to this set needs that property; removing from it needs a reason.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+
+REPO = Path(__file__).resolve().parents[2]
+WORKFLOWS = REPO / ".github" / "workflows"
+
+# Packages our probe code calls directly by keyword. A new major may drop a keyword
+# without any change on our side, so the version we test against has to be a decision.
+GUARDED = ("anthropic", "openai", "playwright")
+
+# 'name>=1.2' / "name>=1.2,<2" / bare name>=1.2, as they appear inside a `pip install`.
+_SPEC = re.compile(
+    r"""(?P<quote>['"]?)(?P<name>[A-Za-z0-9][A-Za-z0-9._-]*)"""
+    r"""(?P<spec>(?:[<>=!~]=?[^,'"\s]+)(?:,[<>=!~]=?[^,'"\s]+)*)(?P=quote)"""
+)
+
+
+def _install_lines() -> list[tuple[Path, int, str]]:
+    """Every `pip install` line in every workflow, minus commented-out ones.
+
+    A YAML/shell comment that merely mentions a package must not be able to satisfy or
+    trip this guard -- #9432 added comments naming `anthropic` right beside the pins.
+    """
+    found = []
+    for path in sorted(WORKFLOWS.glob("*.yml")):
+        for number, line in enumerate(path.read_text(encoding = "utf-8").splitlines(), 1):
+            if line.lstrip().startswith("#"):
+                continue
+            if "pip install" in line:
+                found.append((path, number, line))
+    return found
+
+
+def _specs_for(package: str) -> list[tuple[Path, int, str]]:
+    hits = []
+    for path, number, line in _install_lines():
+        for match in _SPEC.finditer(line):
+            if match.group("name").lower().replace("_", "-") == package:
+                hits.append((path, number, match.group("spec")))
+    return hits
+
+
+@pytest.mark.parametrize("package", GUARDED)
+def test_the_sdk_is_pinned_below_the_next_major(package: str) -> None:
+    unbounded = [
+        (path, number, spec)
+        for path, number, spec in _specs_for(package)
+        if "<" not in spec
+    ]
+    assert not unbounded, (
+        f"{package} is installed without an upper bound at "
+        + ", ".join(f"{p.name}:{n} ({s})" for p, n, s in unbounded)
+        + f". A new {package} major would reach CI with no change on our side; that is how"
+        " anthropic 1.0.0 broke 75 jobs. Pin the major you mean to test against."
+    )
+
+
+def test_the_guard_is_reading_real_pins() -> None:
+    """An empty scan would make every assertion above pass silently.
+
+    If the workflows stop installing these, this test is the one that says so, rather
+    than the suite going quietly green while it checks nothing.
+    """
+    for package in GUARDED:
+        assert _specs_for(package), (
+            f"no `pip install` line in .github/workflows pins {package} any more; either"
+            " the probes moved or the regex stopped matching, and the guard above is now"
+            " vacuous"
+        )
+
+
+def test_a_commented_out_pin_is_not_mistaken_for_an_install() -> None:
+    lines = _install_lines()
+    assert lines, "no pip install lines found at all"
+    assert all(not line.lstrip().startswith("#") for _, _, line in lines)

--- a/tests/studio/test_sdk_installs_are_major_bounded.py
+++ b/tests/studio/test_sdk_installs_are_major_bounded.py
@@ -70,9 +70,7 @@ def _specs_for(package: str) -> list[tuple[Path, int, str]]:
 @pytest.mark.parametrize("package", GUARDED)
 def test_the_sdk_is_pinned_below_the_next_major(package: str) -> None:
     unbounded = [
-        (path, number, spec)
-        for path, number, spec in _specs_for(package)
-        if "<" not in spec
+        (path, number, spec) for path, number, spec in _specs_for(package) if "<" not in spec
     ]
     assert not unbounded, (
         f"{package} is installed without an upper bound at "

--- a/tests/studio/test_sdk_installs_are_major_bounded.py
+++ b/tests/studio/test_sdk_installs_are_major_bounded.py
@@ -33,15 +33,12 @@ REPO = Path(__file__).resolve().parents[2]
 WORKFLOWS = REPO / ".github" / "workflows"
 
 # Packages our probe code calls directly by keyword, each with the first major it must
-# NOT reach. A pin has to exclude that major; anything at or below it is fine, so the
-# narrower `playwright>=1.55,<1.58` window in one workflow still satisfies this.
+# NOT reach. Asserting the boundary rather than "some upper bound exists" is what makes
+# this mean anything: `openai>=1.50,<999` contains a `<` and admits every major it is
+# meant to keep out. Anything stricter than the boundary is fine.
 #
-# Asserting the boundary rather than "some upper bound exists" is what makes the guard
-# mean anything: `openai>=1.50,<999` contains a `<` and still admits every major this
-# exists to keep out.
-#
-# Moving one of these is a deliberate act. Bump the number here in the same commit that
-# widens the pin, and only after CI has actually run against that major.
+# Bump a number here in the same commit that widens the pin, and only once CI has run
+# against that major.
 GUARDED = {
     # v1 removed temperature, top_p and top_k from messages.create().
     "anthropic": (1,),
@@ -65,15 +62,14 @@ _COMPATIBLE = re.compile(r"~=(?P<version>[0-9][0-9.]*)")
 
 
 def _install_commands_in(text: str) -> list[tuple[int, str]]:
-    """Every `pip install` COMMAND in a workflow, continuations joined, comments dropped.
+    """Every `pip install` COMMAND, continuations joined, comment lines dropped.
 
-    Joining matters: `pip install \\` over several lines is the house style at 19 sites
-    here, and a line-at-a-time scan sees only the first one. A guarded SDK added on a
-    continuation line would then be invisible while the anti-vacuity test below stayed
-    satisfied by the single-line pins -- the guard would pass and check nothing.
+    `pip install \\` over several lines is the house style at 19 sites here, and a
+    line-at-a-time scan sees only the first, so a guarded SDK below it would be
+    unchecked while the anti-vacuity test stayed satisfied by the single-line pins.
 
-    Comments are dropped because #9432 added comments naming `anthropic` right beside
-    the pins, and a comment must not be able to satisfy or trip this either way.
+    Comments go because #9432 put comments naming `anthropic` beside the pins, and one
+    must not be able to satisfy or trip this.
     """
     commands = []
     pending: list[str] = []
@@ -110,11 +106,9 @@ def _install_lines() -> list[tuple[Path, int, str]]:
 def _requirements_in(command: str, package: str) -> list[str]:
     """Every requirement for `package` in one pip command, as its raw specifier.
 
-    Returns "" for a bare `pip install openai`, which is a requirement with no
-    constraint at all, and is distinct from the package not appearing.
-
-    Tokenized rather than pattern-matched across the whole command so that a package
-    name inside a URL or a `-r` path cannot be mistaken for an install of it.
+    "" means a bare `pip install openai`: a requirement with no constraint, which is
+    not the same as the package being absent. Tokenized so a name inside a URL or a
+    `-r` path is not mistaken for an install of it.
     """
     try:
         tokens = shlex.split(command, posix = True)
@@ -220,9 +214,8 @@ def test_a_bound_above_the_next_major_is_not_accepted() -> None:
 def test_a_pin_that_cannot_drift_is_accepted() -> None:
     """An exact or compatible-release pin already excludes the major.
 
-    Rejecting these would be a false positive that pushes people to add a redundant
-    `<N` beside an `==`, so the rule is about what the requirement can RESOLVE to, not
-    about which operator was typed.
+    Rejecting them would push people to add a redundant `<N` beside an `==`, so the
+    rule is what the requirement can RESOLVE to, not which operator was typed.
     """
     assert _excludes("==3.0.0", GUARDED["openai"])
     assert _excludes("===3.0.0", GUARDED["openai"])
@@ -236,9 +229,8 @@ def test_a_pin_that_cannot_drift_is_accepted() -> None:
 def test_a_bare_or_extras_install_is_not_invisible() -> None:
     """`pip install openai` resolves whatever major is current.
 
-    A pattern that required a version specifier matched nothing here, so the package
-    was neither bounded nor reported, while the anti-vacuity test stayed satisfied by
-    the other pins. Extras are the same shape.
+    Requiring a version specifier matched nothing here, so the package was neither
+    bounded nor reported. Extras are the same shape.
     """
     assert _requirements_in("pip install openai", "openai") == [""]
     assert _requirements_in("pip install 'openai[datalib]>=1.50'", "openai") == [">=1.50"]
@@ -271,11 +263,7 @@ def test_a_pin_on_a_continuation_line_is_still_seen() -> None:
 
 
 def test_the_guard_is_reading_real_pins() -> None:
-    """An empty scan would make every assertion above pass silently.
-
-    If the workflows stop installing these, this test is the one that says so, rather
-    than the suite going quietly green while it checks nothing.
-    """
+    """An empty scan would make every assertion above pass silently."""
     for package in GUARDED:
         assert _specs_for(package), (
             f"no `pip install` line in .github/workflows pins {package} any more; either"

--- a/tests/studio/test_sdk_installs_are_major_bounded.py
+++ b/tests/studio/test_sdk_installs_are_major_bounded.py
@@ -56,6 +56,10 @@ _REQUIREMENT = re.compile(
     r"""^(?P<name>[A-Za-z0-9][A-Za-z0-9._-]*)(?:\[[^\]]*\])?(?P<spec>.*)$"""
 )
 
+# `pip install`, but also `pip3 install` and `"$VENV/bin/pip" install`, which
+# mlx-ci.yml:439 already uses. Matching the literal text `pip install` missed both.
+_PIP_INSTALL = re.compile(r"""(?:^|[\s"'/])pip[0-9.]*["']?\s+install(?:\s|$)""")
+
 _UPPER = re.compile(r"(?P<op><=|<)(?P<version>[0-9][0-9.]*)")
 _EXACT = re.compile(r"===?(?P<version>[0-9][0-9.]*)")
 _COMPATIBLE = re.compile(r"~=(?P<version>[0-9][0-9.]*)")
@@ -86,18 +90,24 @@ def _install_commands_in(text: str) -> list[tuple[int, str]]:
         pending.append(stripped)
         joined = " ".join(pending)
         pending = []
-        if "pip install" in joined:
+        if _PIP_INSTALL.search(joined):
             commands.append((start, joined))
     if pending:
         joined = " ".join(pending)
-        if "pip install" in joined:
+        if _PIP_INSTALL.search(joined):
             commands.append((start, joined))
     return commands
 
 
+def _workflow_files(root: Path = WORKFLOWS) -> list[Path]:
+    """Both extensions: GitHub accepts .yaml, and scanning only .yml would leave one
+    silently unchecked while the .yml pins kept the anti-vacuity test satisfied."""
+    return sorted(list(root.glob("*.yml")) + list(root.glob("*.yaml")))
+
+
 def _install_lines() -> list[tuple[Path, int, str]]:
     found = []
-    for path in sorted(WORKFLOWS.glob("*.yml")):
+    for path in _workflow_files():
         for number, command in _install_commands_in(path.read_text(encoding = "utf-8")):
             found.append((path, number, command))
     return found
@@ -136,7 +146,15 @@ def _specs_for(package: str) -> list[tuple[Path, int, str]]:
 
 
 def _version(raw: str) -> tuple[int, ...]:
-    return tuple(int(part) for part in raw.strip(".").split(".") if part.isdigit())
+    """Version as ints, trailing zeros dropped so 4.0 and 4 compare equal.
+
+    Without this, `<4.0` was rejected against a boundary of `(4,)`: the tuples differ
+    even though the two bounds are the same release.
+    """
+    parts = [int(part) for part in raw.strip(".").split(".") if part.isdigit()]
+    while len(parts) > 1 and parts[-1] == 0:
+        parts.pop()
+    return tuple(parts)
 
 
 def _excludes(spec: str, major: tuple[int, ...]) -> bool:
@@ -276,3 +294,37 @@ def test_a_commented_out_pin_is_not_mistaken_for_an_install() -> None:
     lines = _install_lines()
     assert lines, "no pip install lines found at all"
     assert all(not line.lstrip().startswith("#") for _, _, line in lines)
+
+
+def test_a_yaml_workflow_is_scanned_too(tmp_path) -> None:
+    """GitHub accepts .yaml. Scanning one extension leaves the other unchecked."""
+    (tmp_path / "a.yml").write_text("x", encoding = "utf-8")
+    (tmp_path / "b.yaml").write_text("x", encoding = "utf-8")
+    assert [p.name for p in _workflow_files(tmp_path)] == ["a.yml", "b.yaml"]
+
+
+def test_pip_is_recognized_beyond_the_bare_command() -> None:
+    """`"$STUDIO_VENV/bin/pip" install` is already used at mlx-ci.yml:439.
+
+    Matching the literal text `pip install` missed it and `pip3` alike, so a guarded
+    SDK installed either way was never inspected.
+    """
+    for command in (
+        "pip install openai",
+        "pip3 install openai",
+        '"$STUDIO_VENV/bin/pip" install openai',
+        "python -m pip install openai",
+    ):
+        assert _PIP_INSTALL.search(command), command
+    assert not _PIP_INSTALL.search("npm install openai")
+    assert not _PIP_INSTALL.search("pip download openai")
+
+
+def test_equivalent_bounds_compare_equal() -> None:
+    """`<4.0` and `<4` are the same boundary; only tuple length differed."""
+    assert _version("4.0") == _version("4") == (4,)
+    assert _version("1.58") == (1, 58)
+    assert _excludes(">=1.50,<4.0", GUARDED["openai"])
+    assert _excludes(">=1.50,<4.0.0", GUARDED["openai"])
+    # <4.0.1 still admits 4.0, so it does not exclude the 4 series.
+    assert not _excludes(">=1.50,<4.0.1", GUARDED["openai"])

--- a/tests/studio/test_sdk_installs_are_major_bounded.py
+++ b/tests/studio/test_sdk_installs_are_major_bounded.py
@@ -113,7 +113,10 @@ def _install_commands_in(text: str) -> list[tuple[int, str]]:
         if not pending:
             start = number
         stripped = line.rstrip()
-        if stripped.endswith("\\"):
+        # Backslash for sh, backtick for PowerShell. 92 pwsh steps live here, 9 of them
+        # around a pip install, so the backtick form is one long install list away even
+        # though nothing uses it yet.
+        if stripped.endswith("\\") or stripped.endswith("`"):
             pending.append(stripped[:-1])
             continue
         pending.append(stripped)
@@ -426,3 +429,21 @@ def test_a_windows_pip_executable_is_recognized() -> None:
         assert _PIP_INSTALL.search(command), command
     assert not _PIP_INSTALL.search("npm install openai")
     assert not _PIP_INSTALL.search("pip download openai")
+
+
+def test_a_powershell_continuation_is_joined() -> None:
+    """PowerShell continues with a backtick, not a backslash.
+
+    Nothing here uses the form yet, but 92 pwsh steps live in these workflows and 9 sit
+    around a pip install, so it is one long install list away.
+    """
+    text = (
+        "        shell: pwsh\n"
+        "        run: |\n"
+        "          python -m pip install `\n"
+        "            openai\n"
+    )
+    commands = _install_commands_in(text)
+    assert len(commands) == 1, commands
+    assert "openai" in commands[0][1]
+    assert _requirements_in(commands[0][1], "openai") == [""]

--- a/tests/studio/test_sdk_installs_are_major_bounded.py
+++ b/tests/studio/test_sdk_installs_are_major_bounded.py
@@ -31,9 +31,24 @@ import pytest
 REPO = Path(__file__).resolve().parents[2]
 WORKFLOWS = REPO / ".github" / "workflows"
 
-# Packages our probe code calls directly by keyword. A new major may drop a keyword
-# without any change on our side, so the version we test against has to be a decision.
-GUARDED = ("anthropic", "openai", "playwright")
+# Packages our probe code calls directly by keyword, each with the first major it must
+# NOT reach. A pin has to exclude that major; anything at or below it is fine, so the
+# narrower `playwright>=1.55,<1.58` window in one workflow still satisfies this.
+#
+# Asserting the boundary rather than "some upper bound exists" is what makes the guard
+# mean anything: `openai>=1.50,<999` contains a `<` and still admits every major this
+# exists to keep out.
+#
+# Moving one of these is a deliberate act. Bump the number here in the same commit that
+# widens the pin, and only after CI has actually run against that major.
+GUARDED = {
+    # v1 removed temperature, top_p and top_k from messages.create().
+    "anthropic": (1,),
+    # 3.3.1 resolves today and the probes pass, so the bound sits above it, not at <2.
+    "openai": (4,),
+    # Still 1.x upstream.
+    "playwright": (2,),
+}
 
 # 'name>=1.2' / "name>=1.2,<2" / bare name>=1.2, as they appear inside a `pip install`.
 _SPEC = re.compile(
@@ -41,20 +56,49 @@ _SPEC = re.compile(
     r"""(?P<spec>(?:[<>=!~]=?[^,'"\s]+)(?:,[<>=!~]=?[^,'"\s]+)*)(?P=quote)"""
 )
 
+_UPPER = re.compile(r"(?P<op><=|<)(?P<version>[0-9][0-9.]*)")
+
+
+def _install_commands_in(text: str) -> list[tuple[int, str]]:
+    """Every `pip install` COMMAND in a workflow, continuations joined, comments dropped.
+
+    Joining matters: `pip install \\` over several lines is the house style at 19 sites
+    here, and a line-at-a-time scan sees only the first one. A guarded SDK added on a
+    continuation line would then be invisible while the anti-vacuity test below stayed
+    satisfied by the single-line pins -- the guard would pass and check nothing.
+
+    Comments are dropped because #9432 added comments naming `anthropic` right beside
+    the pins, and a comment must not be able to satisfy or trip this either way.
+    """
+    commands = []
+    pending: list[str] = []
+    start = 0
+    for number, line in enumerate(text.splitlines(), 1):
+        if line.lstrip().startswith("#"):
+            continue
+        if not pending:
+            start = number
+        stripped = line.rstrip()
+        if stripped.endswith("\\"):
+            pending.append(stripped[:-1])
+            continue
+        pending.append(stripped)
+        joined = " ".join(pending)
+        pending = []
+        if "pip install" in joined:
+            commands.append((start, joined))
+    if pending:
+        joined = " ".join(pending)
+        if "pip install" in joined:
+            commands.append((start, joined))
+    return commands
+
 
 def _install_lines() -> list[tuple[Path, int, str]]:
-    """Every `pip install` line in every workflow, minus commented-out ones.
-
-    A YAML/shell comment that merely mentions a package must not be able to satisfy or
-    trip this guard -- #9432 added comments naming `anthropic` right beside the pins.
-    """
     found = []
     for path in sorted(WORKFLOWS.glob("*.yml")):
-        for number, line in enumerate(path.read_text(encoding = "utf-8").splitlines(), 1):
-            if line.lstrip().startswith("#"):
-                continue
-            if "pip install" in line:
-                found.append((path, number, line))
+        for number, command in _install_commands_in(path.read_text(encoding = "utf-8")):
+            found.append((path, number, command))
     return found
 
 
@@ -67,17 +111,79 @@ def _specs_for(package: str) -> list[tuple[Path, int, str]]:
     return hits
 
 
+def _version(raw: str) -> tuple[int, ...]:
+    return tuple(int(part) for part in raw.strip(".").split(".") if part.isdigit())
+
+
+def _excludes(spec: str, major: tuple[int, ...]) -> bool:
+    """Does this specifier keep `major` out?
+
+    `<2` and `<1.58` both exclude 2.x; `<=2` does not, since it admits 2.0 itself.
+    Compared as integer tuples rather than through `packaging`, which the
+    workflow-trigger-lint job does not install.
+    """
+    for match in _UPPER.finditer(spec):
+        bound = _version(match.group("version"))
+        if not bound:
+            continue
+        if bound <= major if match.group("op") == "<" else bound < major:
+            return True
+    return False
+
+
 @pytest.mark.parametrize("package", GUARDED)
 def test_the_sdk_is_pinned_below_the_next_major(package: str) -> None:
-    unbounded = [
-        (path, number, spec) for path, number, spec in _specs_for(package) if "<" not in spec
+    major = GUARDED[package]
+    wanted = ".".join(str(part) for part in major)
+    admits = [
+        (path, number, spec)
+        for path, number, spec in _specs_for(package)
+        if not _excludes(spec, major)
     ]
-    assert not unbounded, (
-        f"{package} is installed without an upper bound at "
-        + ", ".join(f"{p.name}:{n} ({s})" for p, n, s in unbounded)
+    assert not admits, (
+        f"{package} is installed in a way that admits {wanted} at "
+        + ", ".join(f"{p.name}:{n} ({s})" for p, n, s in admits)
         + f". A new {package} major would reach CI with no change on our side; that is how"
-        " anthropic 1.0.0 broke 75 jobs. Pin the major you mean to test against."
+        f" anthropic 1.0.0 broke 75 jobs. Pin below {wanted}, or move the boundary in this"
+        " file in the same commit once CI has run against that major."
     )
+
+
+def test_a_bound_above_the_next_major_is_not_accepted() -> None:
+    """`<` alone is not the property; keeping the major out is.
+
+    Checking only for the presence of an upper bound let `openai>=1.50,<999` through,
+    which admits every major the pin exists to exclude.
+    """
+    assert not _excludes(">=1.50,<999", GUARDED["openai"])
+    assert not _excludes(">=1.50,<5", GUARDED["openai"])
+    assert not _excludes(">=1.50", GUARDED["openai"])
+    # <=4 admits 4.0 itself, so it does not exclude the 4 series.
+    assert not _excludes(">=1.50,<=4", GUARDED["openai"])
+    assert _excludes(">=1.50,<4", GUARDED["openai"])
+    # A narrower window than the boundary is stricter, and still fine.
+    assert _excludes(">=1.55,<1.58", GUARDED["playwright"])
+    assert _excludes(">=1.45,<2", GUARDED["playwright"])
+
+
+def test_a_pin_on_a_continuation_line_is_still_seen() -> None:
+    """`pip install \\` over several lines is the house style at 19 sites here.
+
+    A line-at-a-time scan sees only the first line, so a guarded SDK added below it would
+    be invisible while the anti-vacuity test stayed satisfied by the single-line pins.
+    """
+    text = (
+        "      - name: Install\n"
+        "        run: |\n"
+        "          pip install 'pytest>=8' \\\n"
+        "            'openai>=1.50' \\\n"
+        "            'anthropic>=0.40,<1'\n"
+    )
+    commands = _install_commands_in(text)
+    assert len(commands) == 1, commands
+    number, command = commands[0]
+    assert number == 3, "the command should be reported at the line it starts on"
+    assert "openai>=1.50" in command and "anthropic>=0.40,<1" in command
 
 
 def test_the_guard_is_reading_real_pins() -> None:

--- a/tests/studio/test_sdk_installs_are_major_bounded.py
+++ b/tests/studio/test_sdk_installs_are_major_bounded.py
@@ -48,24 +48,20 @@ GUARDED = {
     "playwright": (2,),
 }
 
-# One `pip install` argument: name, optional [extras], optional specifier. The specifier
-# is optional on purpose -- a bare `pip install openai` resolves whatever major is current,
-# which is the exact thing this file exists to prevent, and a pattern that required a
-# specifier could not see it at all.
+# One `pip install` argument: name, optional [extras], optional specifier. Optional on
+# purpose: a bare `pip install openai` resolves whatever major is current, and a pattern
+# that required a specifier could not see it at all.
 _REQUIREMENT = re.compile(r"""^(?P<name>[A-Za-z0-9][A-Za-z0-9._-]*)(?:\[[^\]]*\])?(?P<spec>.*)$""")
 
-# `pip install`, but also `pip3 install` and `"$VENV/bin/pip" install`, which
-# mlx-ci.yml:439 already uses. Matching the literal text `pip install` missed both.
 # pip, pip3, pip3.12, pip.exe, and any of those behind a path with either separator,
-# quoted or not. mlx-ci.yml:439 uses "$STUDIO_VENV/bin/pip"; the Windows workflows can
-# use pip.exe, which neither a `/`-only separator nor a digits-only suffix would match.
+# quoted or not. mlx-ci.yml:439 uses "$STUDIO_VENV/bin/pip", and the Windows workflows
+# can use pip.exe; matching the literal text `pip install` saw neither.
 _PIP_INSTALL = re.compile(
     r"""(?:^|[\s"'/\\])pip[0-9]*(?:\.[0-9]+)*(?:\.exe)?["']?\s+install(?:\s|$)"""
 )
 
-# The whole version token, suffix included. Capturing only the numeric prefix silently
-# turned `<4.post1` into `<4`, and a post-release or local-version bound is LOOSER than
-# its numeric prefix: `<4.post1` admits 4.0.
+# The whole version token, suffix included. Capturing only the numeric prefix turned
+# `<4.post1` into `<4`, and such a bound is LOOSER than its digits: `<4.post1` admits 4.0.
 _UPPER = re.compile(r"(?P<op><=|<)(?P<version>[^,\s'\"]+)")
 _NUMERIC = re.compile(r"^[0-9][0-9.]*$")
 _EXACT = re.compile(r"===?(?P<version>[0-9][0-9.]*)")

--- a/tests/studio/test_sdk_installs_are_major_bounded.py
+++ b/tests/studio/test_sdk_installs_are_major_bounded.py
@@ -60,7 +60,11 @@ _REQUIREMENT = re.compile(
 # mlx-ci.yml:439 already uses. Matching the literal text `pip install` missed both.
 _PIP_INSTALL = re.compile(r"""(?:^|[\s"'/])pip[0-9.]*["']?\s+install(?:\s|$)""")
 
-_UPPER = re.compile(r"(?P<op><=|<)(?P<version>[0-9][0-9.]*)")
+# The whole version token, suffix included. Capturing only the numeric prefix silently
+# turned `<4.post1` into `<4`, and a post-release or local-version bound is LOOSER than
+# its numeric prefix: `<4.post1` admits 4.0.
+_UPPER = re.compile(r"(?P<op><=|<)(?P<version>[^,\s'\"]+)")
+_NUMERIC = re.compile(r"^[0-9][0-9.]*$")
 _EXACT = re.compile(r"===?(?P<version>[0-9][0-9.]*)")
 _COMPATIBLE = re.compile(r"~=(?P<version>[0-9][0-9.]*)")
 
@@ -145,13 +149,22 @@ def _specs_for(package: str) -> list[tuple[Path, int, str]]:
     return hits
 
 
+def _release(raw: str) -> tuple[int, ...]:
+    """Release segment as ints, every component kept.
+
+    `~=` semantics depend on how many components were written -- `~=3.0` implies <4
+    and `~=3.0.0` implies <3.1 -- so it needs this rather than the normalized form.
+    """
+    return tuple(int(part) for part in raw.strip(".").split(".") if part.isdigit())
+
+
 def _version(raw: str) -> tuple[int, ...]:
-    """Version as ints, trailing zeros dropped so 4.0 and 4 compare equal.
+    """Release with trailing zeros dropped, so 4.0 and 4 compare equal.
 
     Without this, `<4.0` was rejected against a boundary of `(4,)`: the tuples differ
     even though the two bounds are the same release.
     """
-    parts = [int(part) for part in raw.strip(".").split(".") if part.isdigit()]
+    parts = list(_release(raw))
     while len(parts) > 1 and parts[-1] == 0:
         parts.pop()
     return tuple(parts)
@@ -175,7 +188,7 @@ def _excludes(spec: str, major: tuple[int, ...]) -> bool:
         if pinned and pinned < major:
             return True
     for match in _COMPATIBLE.finditer(spec):
-        release = _version(match.group("version"))
+        release = _release(match.group("version"))
         # ~=X.Y means >=X.Y,<X+1; ~=X.Y.Z means >=X.Y.Z,<X.Y+1.
         if len(release) == 2:
             implied = (release[0] + 1,)
@@ -186,7 +199,12 @@ def _excludes(spec: str, major: tuple[int, ...]) -> bool:
         if implied <= major:
             return True
     for match in _UPPER.finditer(spec):
-        bound = _version(match.group("version"))
+        raw = match.group("version")
+        # Fail closed on anything that is not a plain release. A suffix can make the
+        # bound looser than its digits suggest, and guessing is how `<4.post1` passed.
+        if not _NUMERIC.match(raw):
+            continue
+        bound = _version(raw)
         if not bound:
             continue
         if bound <= major if match.group("op") == "<" else bound < major:
@@ -328,3 +346,26 @@ def test_equivalent_bounds_compare_equal() -> None:
     assert _excludes(">=1.50,<4.0.0", GUARDED["openai"])
     # <4.0.1 still admits 4.0, so it does not exclude the 4 series.
     assert not _excludes(">=1.50,<4.0.1", GUARDED["openai"])
+
+
+def test_a_bound_with_a_suffix_is_not_read_as_its_digits() -> None:
+    """`<4.post1` admits 4.0, so it must not be read as `<4`.
+
+    The regex used to capture only the numeric prefix, which quietly turned a looser
+    bound into a passing one. Anything that is not a plain release now fails closed.
+    """
+    assert not _excludes(">=1.50,<4.post1", GUARDED["openai"])
+    assert not _excludes(">=1.50,<4+local", GUARDED["openai"])
+    assert _excludes(">=1.50,<4", GUARDED["openai"])
+
+
+def test_a_compatible_pin_keeps_its_written_precision() -> None:
+    """`~=3.0` implies <4 and `~=3.0.0` implies <3.1, so the component count matters.
+
+    Normalizing trailing zeros before this branch collapsed both to `(3,)` and made the
+    guard reject two valid pins.
+    """
+    assert _excludes("~=3.0", GUARDED["openai"])
+    assert _excludes("~=3.0.0", GUARDED["openai"])
+    assert _release("3.0.0") == (3, 0, 0)
+    assert _version("3.0.0") == (3,)


### PR DESCRIPTION
`anthropic` 1.0.0 was published `2026-08-20T19:58:58Z`. The inference smoke workflows installed `anthropic>=0.40` with no upper bound, pip resolved the new major, and v1 removed `temperature`, `top_p` and `top_k` as accepted arguments on `messages.create()`:

```
TypeError: Messages.create() got an unexpected keyword argument 'temperature'
```

**75 job failures in about four hours**, across every PR that ran those workflows, none of them caused by the PR they were reported against. #9432 pinned `<1` to stop it.

This is the guard that would have caught it while the pin was being written.

## It found two more of the same thing

`openai>=1.50` and `playwright>=1.45`, both unbounded, in four workflows each.

| package | latest on PyPI | before | after | why |
| --- | --- | --- | --- | --- |
| `anthropic` | 1.0.0 | `>=0.40,<1` | unchanged | #9432 |
| `openai` | 3.3.1 | `>=1.50` | `>=1.50,<4` | already resolves to 3.x and passes |
| `playwright` | 1.62.0 | `>=1.45` | `>=1.45,<2` | matches `studio-frontend-ci.yml` |

`openai>=1.50` resolving to 3.3.1 today matters: openai's majors have **not** broken us, so bounding to `<2` would silently downgrade what CI tests. The bound goes below the *next* major, which keeps today's behaviour and makes the next one a decision instead of a surprise.

## Scope

Deliberately not "every `>=` needs an upper bound". Most pins here are libraries whose majors never reach our code, and asserting on all of them would be noise that gets suppressed. The guarded set is the packages whose **call surface our own probe scripts use directly with keyword arguments**, which is exactly what a major is allowed to remove. Adding to the set needs that property; removing needs a reason.

## Two ways this guard could have been useless

- **A comment satisfying it.** #9432 added comments naming `anthropic` directly beside the pins. The scan skips commented-out lines, and a test asserts that.
- **Scanning nothing.** If the workflows stop installing these, every assertion would pass vacuously. A separate test fails in that case instead.

Mutation-tested: removing `,<4` from one `openai` pin fails the `openai` case and names `studio-inference-smoke.yml:202`.

Registered in `workflow-trigger-lint.yml`, the one job with no `paths` filter, so a workflow-only edit still runs it. `tests/studio/test_workflow_guards_run_unfiltered.py` passes.

```
11 passed   (this guard + the meta-guard)
OK: scanned 41 workflow file(s)   (scripts/lint_workflow_triggers.py)
```
