### PR TITLE
Studio: admit GGUFs that fit carved-out Vulkan UMA

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -8362,7 +8362,9 @@ class LlamaCppBackend:
         return split_library and not any(_GGML_GPU_BACKEND_RE.match(name) for name in files)
 
     def _argv_offloads_every_layer(
-        self, argv: Iterable[str], env: Optional[Mapping[str, str]] = None
+        self,
+        argv: Iterable[str],
+        env: Optional[Mapping[str, str]] = None,
     ) -> bool:
         """Whether the finished command puts every weight on the GPU.
 

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -354,7 +354,7 @@ from state.tool_approvals import (
     new_approval_id,
     wait_tool_decision,
 )
-from utils.paths.path_utils import is_appledouble_metadata
+from utils.paths.path_utils import _is_wsl, is_appledouble_metadata
 
 logger = get_logger(__name__)
 
@@ -8111,6 +8111,15 @@ class LlamaCppBackend:
             # fit stays on free*frac (the host reserve below is its
             # headroom); a discrete card passes its real total through.
             total_mib = 0 if is_igpu else row["total_mib"]
+            if is_igpu:
+                backed = LlamaCppBackend._igpu_backed_free_mib(free_mib, row["total_mib"])
+                if backed < free_mib:
+                    logger.info(
+                        f"Vulkan device VK{idx} reports {free_mib}MiB free across its "
+                        f"heaps, more than this host can back; reading it as "
+                        f"{backed}MiB (memory outside the OS pool, plus available RAM)"
+                    )
+                free_mib = backed
             capped = _apply_igpu_host_reserve_mib(free_mib, is_igpu)
             if capped < free_mib:
                 logger.info(
@@ -8125,6 +8134,42 @@ class LlamaCppBackend:
                 + ", ".join(f"VK{idx}={free}MiB" for idx, free, _total in gpus)
             )
         return gpus
+
+    @staticmethod
+    def _igpu_backed_free_mib(free_mib: int, total_mib: int) -> int:
+        """An integrated device's free reading, bounded by what the host can back.
+
+        ggml sums EVERY heap for an integrated device (ggml-vulkan.cpp skips the
+        device-local test when ``is_integrated_gpu``), so one number covers two
+        unlike pools. Part of it can be a firmware carve-out the OS never sees:
+        96 GiB of AMD Variable Graphics Memory on a Strix Halo laptop, leaving
+        Windows 31 GiB and ``MemAvailable`` around 13 GiB while Vulkan reports
+        108 GiB free (#9454). The rest is ordinary system RAM lent to the GPU,
+        and the driver prices that against its own GTT ceiling rather than
+        against what the machine has free: measured on a gfx1151 under RADV, the
+        reading sat at 97277 MiB unchanged while MemAvailable fell from 49908 to
+        662 MiB.
+
+        The split is not readable, but every heap that IS system RAM is bounded
+        by ``MemTotal``, so whatever the pool has beyond ``MemTotal`` is memory
+        the OS cannot see -- a floor on the carve-out. Credit that, plus the RAM
+        that is actually available, and never the reading itself. Only ever
+        reduces, and an unreadable host figure leaves the reading alone rather
+        than guessing it down.
+
+        That inference needs ``MemTotal`` to describe the machine the heaps live
+        on, which is exactly what WSL breaks: .wslconfig hands the VM a slice of
+        the host's RAM, and the adapter still reports a shared pool sized from
+        the whole host, so a pool larger than ``MemTotal`` there is ordinary
+        Windows RAM the VM cannot reach. No carve-out is credited under WSL, so
+        the VM cap stays the ceiling it is today.
+        """
+        available = LlamaCppBackend._available_system_memory_mib()
+        total_ram = LlamaCppBackend._total_system_memory_mib()
+        if available is None or total_ram is None:
+            return free_mib
+        unseen = 0 if _is_wsl() else max(0, total_mib - total_ram)
+        return min(free_mib, unseen + available)
 
     @staticmethod
     def _cgroup_available_memory_mib() -> Optional[int]:
@@ -8387,7 +8432,10 @@ class LlamaCppBackend:
         offload_bytes = model_bytes - free_vram_mib * 1024 * 1024
         # A carved-out UMA heap may be absent from psutil's host availability even
         # though Vulkan can hold the weights. Count that heap once, never again as RAM.
-        if offload_bytes <= shared_free_mib * 1024 * 1024:
+        # A load with nothing left to place (offload <= 0) is not that case and takes
+        # the arm below, which abstains on it: routing it here would price a negative
+        # need against a container's remaining budget and refuse a resident model.
+        if 0 < offload_bytes <= shared_free_mib * 1024 * 1024:
             # A finite cgroup remains an independent ceiling on host-backed GPU
             # allocations. Reuse the RAM check so its system headroom still applies.
             cgroup_mib = self._cgroup_available_memory_mib()

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -3009,6 +3009,7 @@ _CPU_PLACEMENT_PRESENCE_FLAGS = (_MOE_OFFLOAD_FLAGS - _CPU_MOE_COUNT_FLAGS) | fr
 )
 _CPU_PLACEMENT_FLAGS = _MOE_OFFLOAD_FLAGS | frozenset({"-ot", "--override-tensor"})
 _THREAD_OVERRIDE_FLAGS = frozenset({"-t", "--threads"})
+_TENSOR_SPLIT_FLAGS = frozenset({"--tensor-split", "-ts"})
 
 
 def _strip_flag_pairs(args: Iterable[str], flags: frozenset[str]) -> list[str]:
@@ -8436,7 +8437,17 @@ class LlamaCppBackend:
             names = {device.strip().lower() for device in str(pinned).split(",")}
             reachable = {idx for idx, _free in rows if f"vulkan{idx}" in names}
         pool = 0
-        if shared_gpu_ids and self._argv_offloads_every_layer(argv, env):
+        if (
+            shared_gpu_ids
+            and self._argv_offloads_every_layer(argv, env)
+            # An explicit per-device ratio hands out shares positionally, in llama.cpp's
+            # own enumeration order, which this cannot map onto probe indices -- the same
+            # reason --fit-target is broadcast rather than listed. A zero share for the
+            # shared device puts no weight in its heap at all, and no share is verifiable
+            # here, so any split leaves the pool uncredited.
+            and not _extra_args_set_any_flag(argv, _TENSOR_SPLIT_FLAGS)
+            and not str((env or {}).get("LLAMA_ARG_TENSOR_SPLIT") or "").strip()
+        ):
             pool = max(
                 (free for idx, free in rows if idx in shared_gpu_ids and idx in reachable),
                 default = 0,

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -8395,34 +8395,51 @@ class LlamaCppBackend:
         n_layers = self.n_layers
         return requested == -1 or (bool(n_layers) and requested > n_layers)
 
-    def _shared_heap_free_mib(
+    def _shared_heap_budget(
         self,
         gpus: Iterable[tuple],
         shared_gpu_ids: Collection[int],
+        model_bytes: int,
         argv: list[str],
         env: Optional[Mapping[str, str]] = None,
-    ) -> int:
-        """How much of a shared Vulkan pool this launch can put the weights in.
+    ) -> tuple[int, int]:
+        """The shared Vulkan pool this launch can use, and the bytes it must hold.
 
-        Every shared row reads the same host-backed pool, so the largest row is the
+        Every shared row reads the same host-backed pool, so the largest row IS the
         pool and summing them would count it twice. It counts at all only when the
-        finished command both sends every weight to a device and can reach that
+        finished command sends every weight to a device and can still reach that
         device: a zero layer count leaves the weights in host RAM, and a ``--device``
         pin naming other devices leaves the heap unreachable, so llama.cpp spills
-        them to host RAM either way. 0 hands the whole remainder back to the host-RAM
-        arm, which is what main charged for a shared device before this existed.
+        them either way.
+
+        The same pin decides the second figure. A card the pin leaves out takes none
+        of the model, so the pool has to cover everything the SELECTED cards cannot,
+        not just what the whole probed set cannot -- crediting an unselected 24 GiB
+        card left a 30 GiB model reading as a 6 GiB remainder that a 10 GiB heap
+        "held". A pool of 0 hands the remainder back to the host-RAM arm below,
+        which is what main charged for a shared device before any of this.
         """
-        if not shared_gpu_ids or not self._argv_offloads_every_layer(argv, env):
-            return 0
+        rows = [(row[0], max(0, row[1])) for row in gpus]
         pinned = _extra_args_main_device(argv)
         if pinned is None and env:
             pinned = env.get("LLAMA_ARG_DEVICE")
-        if pinned is not None:
+        if pinned is None:
+            reachable = {idx for idx, _free in rows}
+        else:
             # ggml registry names, the spelling _vulkan_pin_args emits; a shared id
             # is only ever a Vulkan iGPU, so no other backend prefix can appear.
             names = {device.strip().lower() for device in str(pinned).split(",")}
-            shared_gpu_ids = {idx for idx in shared_gpu_ids if f"vulkan{idx}" in names}
-        return max((max(0, row[1]) for row in gpus if row[0] in shared_gpu_ids), default = 0)
+            reachable = {idx for idx, _free in rows if f"vulkan{idx}" in names}
+        pool = 0
+        if shared_gpu_ids and self._argv_offloads_every_layer(argv, env):
+            pool = max(
+                (free for idx, free in rows if idx in shared_gpu_ids and idx in reachable),
+                default = 0,
+            )
+        on_cards = sum(
+            free for idx, free in rows if idx not in shared_gpu_ids and idx in reachable
+        )
+        return pool, model_bytes - on_cards * 1024 * 1024
 
     def _launch_host_shortfall_message(
         self,
@@ -8488,20 +8505,22 @@ class LlamaCppBackend:
             return None
         shared = set(shared_gpu_ids or ())
         free_vram_mib = sum(max(0, row[1]) for row in gpus if row[0] not in shared)
-        shared_free_mib = self._shared_heap_free_mib(gpus, shared, argv, _env)
+        heap_free_mib, heap_bytes = self._shared_heap_budget(
+            gpus, shared, model_bytes, argv, _env
+        )
         offload_bytes = model_bytes - free_vram_mib * 1024 * 1024
         # A carved-out UMA heap may be absent from psutil's host availability even
         # though Vulkan can hold the weights. Count that heap once, never again as RAM.
         # A load with nothing left to place (offload <= 0) is not that case and takes
         # the arm below, which abstains on it: routing it here would price a negative
         # need against a container's remaining budget and refuse a resident model.
-        if 0 < offload_bytes <= shared_free_mib * 1024 * 1024:
+        if 0 < offload_bytes and heap_bytes <= heap_free_mib * 1024 * 1024:
             # A finite cgroup remains an independent ceiling on host-backed GPU
             # allocations. Reuse the RAM check so its system headroom still applies.
             cgroup_mib = self._cgroup_available_memory_mib()
             if cgroup_mib is None:
                 return None
-            return self._apu_ram_shortfall_message(offload_bytes, cgroup_mib)
+            return self._apu_ram_shortfall_message(heap_bytes, cgroup_mib)
         return self._host_offload_shortfall_message(
             offload_bytes,
             self._available_system_memory_mib() if avail_mib is None else avail_mib,

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -8361,6 +8361,38 @@ class LlamaCppBackend:
         split_library = any(name.startswith((cpu_stem, base_stem)) for name in files)
         return split_library and not any(_GGML_GPU_BACKEND_RE.match(name) for name in files)
 
+    def _argv_offloads_every_layer(
+        self, argv: Iterable[str], env: Optional[Mapping[str, str]] = None
+    ) -> bool:
+        """Whether the finished command puts every weight on the GPU.
+
+        The argv-side twin of ``_offloads_every_layer``, which answers for the
+        request. ``--device none``, a zero layer count, a CPU tensor placement and
+        llama.cpp's own fitter each leave some or all of the model in host RAM, so
+        none of them reads as a full offload. Every unknown answers False too, so
+        an unreadable block count keeps the weights priced against RAM instead of
+        crediting a device pool they may never reach.
+        """
+        args = [str(a) for a in argv or ()]
+        if _device_selection_is_cpu(args, env):
+            return False
+        if _args_place_tensors_on_cpu(args) or _env_places_tensors_on_cpu(env):
+            return False
+        # The fitter owns placement while it runs and offloads whatever it cannot
+        # fit, so only an explicit "off" leaves the layer count as the last word.
+        if fit_is_effectively_on(args, env):
+            return False
+        try:
+            requested = parse_gpu_layers_override(args)
+        except ValueError:
+            return False
+        if requested is None:
+            return False
+        # -1 is llama.cpp's "every layer"; a concrete count has to clear the block
+        # count, which is what the picker's maximum (block_count + 1) sends.
+        n_layers = self.n_layers
+        return requested == -1 or (bool(n_layers) and requested > n_layers)
+
     def _launch_host_shortfall_message(
         self,
         cmd: Iterable[str],
@@ -8425,9 +8457,17 @@ class LlamaCppBackend:
             return None
         shared = set(shared_gpu_ids or ())
         free_vram_mib = sum(max(0, row[1]) for row in gpus if row[0] not in shared)
-        shared_free_mib = max(
-            (max(0, row[1]) for row in gpus if row[0] in shared),
-            default = 0,
+        # The shared heap counts only for a launch that actually sends the weights
+        # there. A zero layer count and a CPU device pin leave them in host RAM,
+        # where the arm below prices them, so crediting the heap for one of those
+        # would readmit the very paging this refusal exists to prevent.
+        shared_free_mib = (
+            max(
+                (max(0, row[1]) for row in gpus if row[0] in shared),
+                default = 0,
+            )
+            if self._argv_offloads_every_layer(argv, _env)
+            else 0
         )
         offload_bytes = model_bytes - free_vram_mib * 1024 * 1024
         # A carved-out UMA heap may be absent from psutil's host availability even

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -4064,6 +4064,24 @@ def _device_selection_is_cpu(
     return not devices or all(d in _CPU_DEVICE_VALUES for d in devices)
 
 
+def _split_mode_confines_to_one_device(
+    args: Optional[Iterable[str]], env: Optional[Mapping[str, str]] = None
+) -> bool:
+    """True when the effective split mode puts the whole model on a single device.
+
+    ``--split-mode none`` sends every weight to ``--main-gpu``, an index into
+    llama.cpp's own device enumeration. argv wins over the env twin, and an
+    unreadable value answers False like the rest of the unknowns here.
+    """
+    try:
+        mode = parse_split_mode_override(args)
+    except ValueError:
+        return False
+    if mode is None and env:
+        mode = env.get("LLAMA_ARG_SPLIT_MODE")
+    return str(mode or "").strip().lower() == "none"
+
+
 def _extra_args_draft_device(extra_args: Optional[Iterable[str]]) -> Optional[str]:
     """Return the last explicit draft-device value, if any."""
     return _extra_args_device(extra_args, {"--spec-draft-device", "-devd", "--device-draft"})
@@ -8443,6 +8461,11 @@ class LlamaCppBackend:
             # rather than listed -- so no share is verifiable here, a zero one included.
             and not _extra_args_set_any_flag(argv, _TENSOR_SPLIT_FLAGS)
             and not str((env or {}).get("LLAMA_ARG_TENSOR_SPLIT") or "").strip()
+            # --split-mode none sends the whole model to one --main-gpu index in that
+            # same enumeration, so with more than one device in play this cannot say the
+            # heap is the one receiving it. It cannot exclude a lone device, which is the
+            # #9454 shape, where the ratio above can still zero one out.
+            and not (len(reachable) > 1 and _split_mode_confines_to_one_device(argv, env))
         ):
             pool = max(
                 (free for idx, free in rows if idx in shared_gpu_ids and idx in reachable),

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -4067,12 +4067,7 @@ def _device_selection_is_cpu(
 def _split_mode_confines_to_one_device(
     args: Optional[Iterable[str]], env: Optional[Mapping[str, str]] = None
 ) -> bool:
-    """True when the effective split mode puts the whole model on a single device.
-
-    ``--split-mode none`` sends every weight to ``--main-gpu``, an index into
-    llama.cpp's own device enumeration. argv wins over the env twin, and an
-    unreadable value answers False like the rest of the unknowns here.
-    """
+    """Whether the effective split mode confines all weights to one device."""
     try:
         mode = parse_split_mode_override(args)
     except ValueError:
@@ -8156,37 +8151,12 @@ class LlamaCppBackend:
 
     @staticmethod
     def _igpu_backed_free_mib(free_mib: int) -> int:
-        """An integrated device's free reading, bounded by what the host can back.
+        """Bound iGPU free memory by host RAM plus any firmware carve-out.
 
-        ggml sums EVERY heap for an integrated device (ggml-vulkan.cpp skips the
-        device-local test when ``is_integrated_gpu``), so one number covers two
-        unlike pools. Part of it can be a firmware carve-out the OS never sees:
-        96 GiB of AMD Variable Graphics Memory on a Strix Halo laptop, leaving
-        Windows 31 GiB and ``MemAvailable`` around 13 GiB while Vulkan reports
-        108 GiB free (#9454). The rest is ordinary system RAM lent to the GPU,
-        and the driver prices that against its own GTT ceiling rather than
-        against what the machine has free: measured on a gfx1151 under RADV, the
-        reading sat at 97277 MiB unchanged while MemAvailable fell from 49908 to
-        662 MiB.
-
-        The split is not readable, but every heap that IS system RAM is bounded
-        by ``MemTotal``, so whatever the FREE reading has beyond ``MemTotal`` is
-        free memory the OS cannot see -- a floor on the carve-out still going
-        spare. Read from the free figure and not the device total: a total
-        derives the carve-out's CAPACITY, which credits the part another Vulkan
-        process is already holding, and since the driver's GTT figure stays high
-        while ``MemAvailable`` falls, the pair would then promise memory neither
-        pool can supply. Credit that floor, plus the RAM that is actually
-        available, and never the reading itself. Only ever reduces, and an
-        unreadable host figure leaves the reading alone rather than guessing it
-        down.
-
-        That inference needs ``MemTotal`` to describe the machine the heaps live
-        on, which is exactly what WSL breaks: .wslconfig hands the VM a slice of
-        the host's RAM, and the adapter still reports a shared pool sized from
-        the whole host, so a free pool larger than ``MemTotal`` there is ordinary
-        Windows RAM the VM cannot reach. No carve-out is credited under WSL, so
-        the VM cap stays the ceiling it is today.
+        Vulkan combines OS-visible RAM with carve-outs. Memory above ``MemTotal``
+        is a conservative floor for the free carve-out; add ``MemAvailable`` for
+        the host-backed share. WSL cannot use this inference because the VM and
+        adapter report different memory scopes.
         """
         available = LlamaCppBackend._available_system_memory_mib()
         total_ram = LlamaCppBackend._total_system_memory_mib()
@@ -8390,22 +8360,17 @@ class LlamaCppBackend:
         argv: Iterable[str],
         env: Optional[Mapping[str, str]] = None,
     ) -> bool:
-        """Whether the finished command puts every weight on the GPU.
+        """Whether the final command puts every model layer on a GPU.
 
-        The argv-side twin of ``_offloads_every_layer``, which answers for the
-        request. ``--device none``, a zero layer count, a CPU tensor placement and
-        llama.cpp's own fitter each leave some or all of the model in host RAM, so
-        none of them reads as a full offload. Every unknown answers False too, so
-        an unreadable block count keeps the weights priced against RAM instead of
-        crediting a device pool they may never reach.
+        Unknown placement is treated as partial offload so unverified GPU memory
+        is never credited.
         """
         args = [str(a) for a in argv or ()]
         if _device_selection_is_cpu(args, env):
             return False
         if _args_place_tensors_on_cpu(args) or _env_places_tensors_on_cpu(env):
             return False
-        # The fitter owns placement while it runs and offloads whatever it cannot
-        # fit, so only an explicit "off" leaves the layer count as the last word.
+        # The fitter owns placement unless it is explicitly disabled.
         if fit_is_effectively_on(args, env):
             return False
         try:
@@ -8414,8 +8379,7 @@ class LlamaCppBackend:
             return False
         if requested is None:
             return False
-        # -1 is llama.cpp's "every layer"; a concrete count has to clear the block
-        # count, which is what the picker's maximum (block_count + 1) sends.
+        # -1 means every layer; otherwise the count must exceed the block count.
         n_layers = self.n_layers
         return requested == -1 or (bool(n_layers) and requested > n_layers)
 
@@ -8427,19 +8391,11 @@ class LlamaCppBackend:
         argv: list[str],
         env: Optional[Mapping[str, str]] = None,
     ) -> tuple[int, int]:
-        """The shared Vulkan pool this launch can use, and the bytes it must hold.
+        """Return reachable shared Vulkan memory and the bytes it must hold.
 
-        Every shared row reads the same host-backed pool, so the largest row IS the
-        pool and summing them would count it twice. It counts at all only when the
-        command is going to put weights there: a full offload, onto a device its
-        ``--device`` pin still reaches, with no per-device ratio making the share
-        unknowable. Otherwise llama.cpp spills them to host RAM instead.
-
-        The pin decides the second figure too. A card it leaves out takes none of
-        the model, so the pool must cover what the SELECTED cards cannot: crediting
-        an unselected 24 GiB card left a 30 GiB model reading as a 6 GiB remainder
-        that a 10 GiB heap "held". A pool of 0 hands the remainder back to the
-        host-RAM arm below, which is what main charged for a shared device.
+        Shared iGPU rows overlap, so only the largest pool is credited. The pool
+        must be reachable by an unambiguous full offload, and only selected
+        discrete cards reduce the bytes assigned to it.
         """
         rows = [(row[0], max(0, row[1])) for row in gpus]
         pinned = _extra_args_main_device(argv)
@@ -8448,23 +8404,17 @@ class LlamaCppBackend:
         if pinned is None:
             reachable = {idx for idx, _free in rows}
         else:
-            # ggml registry names, the spelling _vulkan_pin_args emits; a shared id
-            # is only ever a Vulkan iGPU, so no other backend prefix can appear.
+            # Match the ggml registry names emitted by _vulkan_pin_args.
             names = {device.strip().lower() for device in str(pinned).split(",")}
             reachable = {idx for idx, _free in rows if f"vulkan{idx}" in names}
         pool = 0
         if (
             shared_gpu_ids
             and self._argv_offloads_every_layer(argv, env)
-            # Shares are positional, in llama.cpp's own enumeration order, which this
-            # cannot map onto probe indices -- the same reason --fit-target is broadcast
-            # rather than listed -- so no share is verifiable here, a zero one included.
+            # Tensor-split positions cannot be mapped reliably to probe indices.
             and not _extra_args_set_any_flag(argv, _TENSOR_SPLIT_FLAGS)
             and not str((env or {}).get("LLAMA_ARG_TENSOR_SPLIT") or "").strip()
-            # --split-mode none sends the whole model to one --main-gpu index in that
-            # same enumeration, so with more than one device in play this cannot say the
-            # heap is the one receiving it. It cannot exclude a lone device, which is the
-            # #9454 shape, where the ratio above can still zero one out.
+            # With multiple devices, split-mode none does not identify the recipient.
             and not (len(reachable) > 1 and _split_mode_confines_to_one_device(argv, env))
         ):
             pool = max(
@@ -8540,14 +8490,10 @@ class LlamaCppBackend:
         free_vram_mib = sum(max(0, row[1]) for row in gpus if row[0] not in shared)
         heap_free_mib, heap_bytes = self._shared_heap_budget(gpus, shared, model_bytes, argv, _env)
         offload_bytes = model_bytes - free_vram_mib * 1024 * 1024
-        # A carved-out UMA heap may be absent from psutil's host availability even
-        # though Vulkan can hold the weights. Count that heap once, never again as RAM.
-        # A load with nothing left to place (offload <= 0) is not that case and takes
-        # the arm below, which abstains on it: routing it here would price a negative
-        # need against a container's remaining budget and refuse a resident model.
+        # A carve-out can satisfy the dedicated-VRAM shortfall. Skip card-resident
+        # loads so a cgroup budget is never applied to a nonpositive need.
         if 0 < offload_bytes and heap_bytes <= heap_free_mib * 1024 * 1024:
-            # A finite cgroup remains an independent ceiling on host-backed GPU
-            # allocations. Reuse the RAM check so its system headroom still applies.
+            # A finite cgroup still limits host-backed GPU allocations.
             cgroup_mib = self._cgroup_available_memory_mib()
             if cgroup_mib is None:
                 return None

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -8413,17 +8413,15 @@ class LlamaCppBackend:
 
         Every shared row reads the same host-backed pool, so the largest row IS the
         pool and summing them would count it twice. It counts at all only when the
-        finished command sends every weight to a device and can still reach that
-        device: a zero layer count leaves the weights in host RAM, and a ``--device``
-        pin naming other devices leaves the heap unreachable, so llama.cpp spills
-        them either way.
+        command is going to put weights there: a full offload, onto a device its
+        ``--device`` pin still reaches, with no per-device ratio making the share
+        unknowable. Otherwise llama.cpp spills them to host RAM instead.
 
-        The same pin decides the second figure. A card the pin leaves out takes none
-        of the model, so the pool has to cover everything the SELECTED cards cannot,
-        not just what the whole probed set cannot -- crediting an unselected 24 GiB
-        card left a 30 GiB model reading as a 6 GiB remainder that a 10 GiB heap
-        "held". A pool of 0 hands the remainder back to the host-RAM arm below,
-        which is what main charged for a shared device before any of this.
+        The pin decides the second figure too. A card it leaves out takes none of
+        the model, so the pool must cover what the SELECTED cards cannot: crediting
+        an unselected 24 GiB card left a 30 GiB model reading as a 6 GiB remainder
+        that a 10 GiB heap "held". A pool of 0 hands the remainder back to the
+        host-RAM arm below, which is what main charged for a shared device.
         """
         rows = [(row[0], max(0, row[1])) for row in gpus]
         pinned = _extra_args_main_device(argv)
@@ -8440,11 +8438,9 @@ class LlamaCppBackend:
         if (
             shared_gpu_ids
             and self._argv_offloads_every_layer(argv, env)
-            # An explicit per-device ratio hands out shares positionally, in llama.cpp's
-            # own enumeration order, which this cannot map onto probe indices -- the same
-            # reason --fit-target is broadcast rather than listed. A zero share for the
-            # shared device puts no weight in its heap at all, and no share is verifiable
-            # here, so any split leaves the pool uncredited.
+            # Shares are positional, in llama.cpp's own enumeration order, which this
+            # cannot map onto probe indices -- the same reason --fit-target is broadcast
+            # rather than listed -- so no share is verifiable here, a zero one included.
             and not _extra_args_set_any_flag(argv, _TENSOR_SPLIT_FLAGS)
             and not str((env or {}).get("LLAMA_ARG_TENSOR_SPLIT") or "").strip()
         ):

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -8112,7 +8112,7 @@ class LlamaCppBackend:
             # headroom); a discrete card passes its real total through.
             total_mib = 0 if is_igpu else row["total_mib"]
             if is_igpu:
-                backed = LlamaCppBackend._igpu_backed_free_mib(free_mib, row["total_mib"])
+                backed = LlamaCppBackend._igpu_backed_free_mib(free_mib)
                 if backed < free_mib:
                     logger.info(
                         f"Vulkan device VK{idx} reports {free_mib}MiB free across its "
@@ -8136,7 +8136,7 @@ class LlamaCppBackend:
         return gpus
 
     @staticmethod
-    def _igpu_backed_free_mib(free_mib: int, total_mib: int) -> int:
+    def _igpu_backed_free_mib(free_mib: int) -> int:
         """An integrated device's free reading, bounded by what the host can back.
 
         ggml sums EVERY heap for an integrated device (ggml-vulkan.cpp skips the
@@ -8151,16 +8151,21 @@ class LlamaCppBackend:
         662 MiB.
 
         The split is not readable, but every heap that IS system RAM is bounded
-        by ``MemTotal``, so whatever the pool has beyond ``MemTotal`` is memory
-        the OS cannot see -- a floor on the carve-out. Credit that, plus the RAM
-        that is actually available, and never the reading itself. Only ever
-        reduces, and an unreadable host figure leaves the reading alone rather
-        than guessing it down.
+        by ``MemTotal``, so whatever the FREE reading has beyond ``MemTotal`` is
+        free memory the OS cannot see -- a floor on the carve-out still going
+        spare. Read from the free figure and not the device total: a total
+        derives the carve-out's CAPACITY, which credits the part another Vulkan
+        process is already holding, and since the driver's GTT figure stays high
+        while ``MemAvailable`` falls, the pair would then promise memory neither
+        pool can supply. Credit that floor, plus the RAM that is actually
+        available, and never the reading itself. Only ever reduces, and an
+        unreadable host figure leaves the reading alone rather than guessing it
+        down.
 
         That inference needs ``MemTotal`` to describe the machine the heaps live
         on, which is exactly what WSL breaks: .wslconfig hands the VM a slice of
         the host's RAM, and the adapter still reports a shared pool sized from
-        the whole host, so a pool larger than ``MemTotal`` there is ordinary
+        the whole host, so a free pool larger than ``MemTotal`` there is ordinary
         Windows RAM the VM cannot reach. No carve-out is credited under WSL, so
         the VM cap stays the ceiling it is today.
         """
@@ -8168,7 +8173,7 @@ class LlamaCppBackend:
         total_ram = LlamaCppBackend._total_system_memory_mib()
         if available is None or total_ram is None:
             return free_mib
-        unseen = 0 if _is_wsl() else max(0, total_mib - total_ram)
+        unseen = 0 if _is_wsl() else max(0, free_mib - total_ram)
         return min(free_mib, unseen + available)
 
     @staticmethod

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -8395,6 +8395,35 @@ class LlamaCppBackend:
         n_layers = self.n_layers
         return requested == -1 or (bool(n_layers) and requested > n_layers)
 
+    def _shared_heap_free_mib(
+        self,
+        gpus: Iterable[tuple],
+        shared_gpu_ids: Collection[int],
+        argv: list[str],
+        env: Optional[Mapping[str, str]] = None,
+    ) -> int:
+        """How much of a shared Vulkan pool this launch can put the weights in.
+
+        Every shared row reads the same host-backed pool, so the largest row is the
+        pool and summing them would count it twice. It counts at all only when the
+        finished command both sends every weight to a device and can reach that
+        device: a zero layer count leaves the weights in host RAM, and a ``--device``
+        pin naming other devices leaves the heap unreachable, so llama.cpp spills
+        them to host RAM either way. 0 hands the whole remainder back to the host-RAM
+        arm, which is what main charged for a shared device before this existed.
+        """
+        if not shared_gpu_ids or not self._argv_offloads_every_layer(argv, env):
+            return 0
+        pinned = _extra_args_main_device(argv)
+        if pinned is None and env:
+            pinned = env.get("LLAMA_ARG_DEVICE")
+        if pinned is not None:
+            # ggml registry names, the spelling _vulkan_pin_args emits; a shared id
+            # is only ever a Vulkan iGPU, so no other backend prefix can appear.
+            names = {device.strip().lower() for device in str(pinned).split(",")}
+            shared_gpu_ids = {idx for idx in shared_gpu_ids if f"vulkan{idx}" in names}
+        return max((max(0, row[1]) for row in gpus if row[0] in shared_gpu_ids), default = 0)
+
     def _launch_host_shortfall_message(
         self,
         cmd: Iterable[str],
@@ -8459,18 +8488,7 @@ class LlamaCppBackend:
             return None
         shared = set(shared_gpu_ids or ())
         free_vram_mib = sum(max(0, row[1]) for row in gpus if row[0] not in shared)
-        # The shared heap counts only for a launch that actually sends the weights
-        # there. A zero layer count and a CPU device pin leave them in host RAM,
-        # where the arm below prices them, so crediting the heap for one of those
-        # would readmit the very paging this refusal exists to prevent.
-        shared_free_mib = (
-            max(
-                (max(0, row[1]) for row in gpus if row[0] in shared),
-                default = 0,
-            )
-            if self._argv_offloads_every_layer(argv, _env)
-            else 0
-        )
+        shared_free_mib = self._shared_heap_free_mib(gpus, shared, argv, _env)
         offload_bytes = model_bytes - free_vram_mib * 1024 * 1024
         # A carved-out UMA heap may be absent from psutil's host availability even
         # though Vulkan can hold the weights. Count that heap once, never again as RAM.

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -8346,8 +8346,8 @@ class LlamaCppBackend:
 
         ``avail_mib`` overrides the host figure for a caller that runs before the resident
         owners are released; the launch reads what is available now. ``shared_gpu_ids``
-        names Vulkan iGPUs whose reported free memory is the same host pool, so it must
-        not also be credited as dedicated VRAM.
+        names Vulkan iGPUs whose reported free memory overlaps the host pool. Either
+        reading can hold the remaining weights, but they must never be added together.
         """
         argv = [str(a) for a in cmd or ()]
         if not argv:
@@ -8380,8 +8380,22 @@ class LlamaCppBackend:
             return None
         shared = set(shared_gpu_ids or ())
         free_vram_mib = sum(max(0, row[1]) for row in gpus if row[0] not in shared)
+        shared_free_mib = max(
+            (max(0, row[1]) for row in gpus if row[0] in shared),
+            default = 0,
+        )
+        offload_bytes = model_bytes - free_vram_mib * 1024 * 1024
+        # A carved-out UMA heap may be absent from psutil's host availability even
+        # though Vulkan can hold the weights. Count that heap once, never again as RAM.
+        if offload_bytes <= shared_free_mib * 1024 * 1024:
+            # A finite cgroup remains an independent ceiling on host-backed GPU
+            # allocations. Reuse the RAM check so its system headroom still applies.
+            cgroup_mib = self._cgroup_available_memory_mib()
+            if cgroup_mib is None:
+                return None
+            return self._apu_ram_shortfall_message(offload_bytes, cgroup_mib)
         return self._host_offload_shortfall_message(
-            model_bytes - free_vram_mib * 1024 * 1024,
+            offload_bytes,
             self._available_system_memory_mib() if avail_mib is None else avail_mib,
         )
 

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -8436,9 +8436,7 @@ class LlamaCppBackend:
                 (free for idx, free in rows if idx in shared_gpu_ids and idx in reachable),
                 default = 0,
             )
-        on_cards = sum(
-            free for idx, free in rows if idx not in shared_gpu_ids and idx in reachable
-        )
+        on_cards = sum(free for idx, free in rows if idx not in shared_gpu_ids and idx in reachable)
         return pool, model_bytes - on_cards * 1024 * 1024
 
     def _launch_host_shortfall_message(
@@ -8505,9 +8503,7 @@ class LlamaCppBackend:
             return None
         shared = set(shared_gpu_ids or ())
         free_vram_mib = sum(max(0, row[1]) for row in gpus if row[0] not in shared)
-        heap_free_mib, heap_bytes = self._shared_heap_budget(
-            gpus, shared, model_bytes, argv, _env
-        )
+        heap_free_mib, heap_bytes = self._shared_heap_budget(gpus, shared, model_bytes, argv, _env)
         offload_bytes = model_bytes - free_vram_mib * 1024 * 1024
         # A carved-out UMA heap may be absent from psutil's host availability even
         # though Vulkan can hold the weights. Count that heap once, never again as RAM.

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -8406,8 +8406,9 @@ class LlamaCppBackend:
         """Return reachable shared Vulkan memory and the bytes it must hold.
 
         Shared iGPU rows overlap, so only the largest pool is credited. The pool
-        must be reachable by an unambiguous full offload, and only selected
-        discrete cards reduce the bytes assigned to it.
+        must be reachable by an unambiguous full offload -- a device pin that
+        names it, or no pin on a host where llama.cpp finds no discrete card --
+        and only selected discrete cards reduce the bytes assigned to it.
         """
         rows = [(row[0], max(0, row[1])) for row in gpus]
         pinned = _extra_args_main_device(argv)
@@ -8415,6 +8416,11 @@ class LlamaCppBackend:
             pinned = env.get("LLAMA_ARG_DEVICE")
         if pinned is None:
             reachable = {idx for idx, _free in rows}
+            # Unpinned, llama.cpp builds the device list itself and appends
+            # integrated GPUs only when it found no discrete one, so a shared
+            # heap beside a discrete card receives nothing.
+            if any(idx not in shared_gpu_ids for idx in reachable):
+                reachable -= set(shared_gpu_ids)
         else:
             # Match the ggml registry names emitted by _vulkan_pin_args.
             names = {device.strip().lower() for device in str(pinned).split(",")}

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -4340,6 +4340,7 @@ def _report_live_llama_timings(callback, chunk) -> None:
 # margin (default 1024 MiB per device). ggml reports an iGPU's "VRAM" as shared
 # system RAM, so hold back the same margin rather than inventing a larger one.
 _IGPU_HOST_RESERVE_MIB = 1024
+_HOST_RAM_HEADROOM_MIB = 2048
 _CGROUP_ROOT = "/sys/fs/cgroup"
 _PROC_SELF_CGROUP = "/proc/self/cgroup"
 
@@ -8125,15 +8126,6 @@ class LlamaCppBackend:
             # fit stays on free*frac (the host reserve below is its
             # headroom); a discrete card passes its real total through.
             total_mib = 0 if is_igpu else row["total_mib"]
-            if is_igpu:
-                backed = LlamaCppBackend._igpu_backed_free_mib(free_mib)
-                if backed < free_mib:
-                    logger.info(
-                        f"Vulkan device VK{idx} reports {free_mib}MiB free across its "
-                        f"heaps, more than this host can back; reading it as "
-                        f"{backed}MiB (memory outside the OS pool, plus available RAM)"
-                    )
-                free_mib = backed
             capped = _apply_igpu_host_reserve_mib(free_mib, is_igpu)
             if capped < free_mib:
                 logger.info(
@@ -8150,20 +8142,40 @@ class LlamaCppBackend:
         return gpus
 
     @staticmethod
-    def _igpu_backed_free_mib(free_mib: int) -> int:
-        """Bound iGPU free memory by host RAM plus any firmware carve-out.
+    def _igpu_backed_free_mib(free_mib: int, headroom_mib: int = 0) -> int:
+        """Bound a raw iGPU free reading by host RAM plus any firmware carve-out.
 
         Vulkan combines OS-visible RAM with carve-outs. Memory above ``MemTotal``
         is a conservative floor for the free carve-out; add ``MemAvailable`` for
-        the host-backed share. WSL cannot use this inference because the VM and
-        adapter report different memory scopes.
+        the host-backed share after its required headroom. WSL cannot use this
+        inference because the VM and adapter report different memory scopes.
         """
         available = LlamaCppBackend._available_system_memory_mib()
         total_ram = LlamaCppBackend._total_system_memory_mib()
         if available is None or total_ram is None:
             return free_mib
         unseen = 0 if _is_wsl() else max(0, free_mib - total_ram)
-        return min(free_mib, unseen + available)
+        host_backed = max(0, available - max(0, headroom_mib))
+        return min(free_mib, unseen + host_backed)
+
+    @staticmethod
+    def _igpu_backed_usable_mib(usable_mib: int) -> int:
+        """Bound a post-reserve iGPU budget for shared-heap admission.
+
+        Placement keeps the Vulkan reading so an existing full-offload plan is
+        not demoted to the fitter. The host guard alone reconstructs the raw
+        reading, bounds its host-backed share with the whole-system headroom,
+        and caps that against the already-reserved placement budget. A zero
+        budget stays zero because the raw value below the reserve is no longer
+        recoverable and could not admit weights either way.
+        """
+        if usable_mib <= 0:
+            return 0
+        raw_free_mib = usable_mib + _IGPU_HOST_RESERVE_MIB
+        backed_mib = LlamaCppBackend._igpu_backed_free_mib(
+            raw_free_mib, headroom_mib = _HOST_RAM_HEADROOM_MIB
+        )
+        return min(usable_mib, backed_mib)
 
     @staticmethod
     def _cgroup_available_memory_mib() -> Optional[int]:
@@ -8417,10 +8429,18 @@ class LlamaCppBackend:
             # With multiple devices, split-mode none does not identify the recipient.
             and not (len(reachable) > 1 and _split_mode_confines_to_one_device(argv, env))
         ):
-            pool = max(
-                (free for idx, free in rows if idx in shared_gpu_ids and idx in reachable),
-                default = 0,
-            )
+            budgets = []
+            for idx, free in rows:
+                if idx not in shared_gpu_ids or idx not in reachable:
+                    continue
+                backed = self._igpu_backed_usable_mib(free)
+                if backed < free:
+                    logger.info(
+                        f"Vulkan device VK{idx} offers {free}MiB to placement; "
+                        f"host admission credits {backed}MiB"
+                    )
+                budgets.append(backed)
+            pool = max(budgets, default = 0)
         on_cards = sum(free for idx, free in rows if idx not in shared_gpu_ids and idx in reachable)
         return pool, model_bytes - on_cards * 1024 * 1024
 
@@ -8507,7 +8527,7 @@ class LlamaCppBackend:
     def _apu_ram_shortfall_message(
         model_size_bytes: int,
         avail_mib: Optional[int],
-        headroom_mib: int = 2048,
+        headroom_mib: int = _HOST_RAM_HEADROOM_MIB,
     ) -> Optional[str]:
         """On a unified-memory APU, return a user-facing refusal when the weights
         cannot fit in available system RAM (else None). Weights only: KV/context
@@ -8530,7 +8550,7 @@ class LlamaCppBackend:
     def _host_offload_shortfall_message(
         offload_bytes: int,
         avail_mib: Optional[int],
-        headroom_mib: int = 2048,
+        headroom_mib: int = _HOST_RAM_HEADROOM_MIB,
     ) -> Optional[str]:
         """On a discrete GPU, return a user-facing refusal when the part of a load
         that misses VRAM cannot fit in available system RAM (else None). The spill is

--- a/studio/backend/tests/test_llama_cpp_placement.py
+++ b/studio/backend/tests/test_llama_cpp_placement.py
@@ -1613,9 +1613,7 @@ def test_vulkan_igpu_shared_memory_is_not_counted_twice(tmp_path, monkeypatch, m
     monkeypatch.setattr(
         LlamaCppBackend, "_available_system_memory_mib", staticmethod(lambda: 14 * 1024)
     )
-    monkeypatch.setattr(
-        LlamaCppBackend, "_cgroup_available_memory_mib", staticmethod(lambda: None)
-    )
+    monkeypatch.setattr(LlamaCppBackend, "_cgroup_available_memory_mib", staticmethod(lambda: None))
 
     with pytest.raises(RuntimeError, match = "does not fit in GPU memory"):
         _launch(backend, gguf)
@@ -1636,9 +1634,7 @@ def test_vulkan_igpu_heap_can_hold_weights_missing_from_host_available(tmp_path,
     monkeypatch.setattr(
         LlamaCppBackend, "_available_system_memory_mib", staticmethod(lambda: 13 * 1024)
     )
-    monkeypatch.setattr(
-        LlamaCppBackend, "_cgroup_available_memory_mib", staticmethod(lambda: None)
-    )
+    monkeypatch.setattr(LlamaCppBackend, "_cgroup_available_memory_mib", staticmethod(lambda: None))
 
     assert _launch(backend, gguf)["cmd"]
 

--- a/studio/backend/tests/test_llama_cpp_placement.py
+++ b/studio/backend/tests/test_llama_cpp_placement.py
@@ -1590,13 +1590,22 @@ def test_free_vram_offsets_the_charge(tmp_path, monkeypatch):
     assert "--fit" in _launch(backend, gguf)["cmd"]
 
 
-def test_vulkan_igpu_shared_memory_is_not_counted_twice(tmp_path, monkeypatch):
+@pytest.mark.parametrize(
+    "memory",
+    [
+        [(0, 12 * 1024, 0)],
+        [(0, 12 * 1024, 0), (1, 12 * 1024, 0)],
+    ],
+    ids = ["one-shared-device", "two-shared-devices"],
+)
+def test_vulkan_igpu_shared_memory_is_not_counted_twice(tmp_path, monkeypatch, memory):
     """A Vulkan iGPU's free memory and MemAvailable describe the same unified pool.
-    Crediting both let a 20 GiB model through on a 14 GiB host (12 + 14 on paper)."""
+    Crediting host RAM or another iGPU again would let a 20 GiB model through on a
+    14 GiB host (12 + 14 or 12 + 12 on paper)."""
     backend, gguf = _backend(
         tmp_path,
         vulkan = True,
-        memory = [(0, 12 * 1024, 0)],
+        memory = memory,
     )
     _restore_host_guard(backend)
     backend._get_gguf_size_bytes = lambda _path: 20 * 1024**3
@@ -1604,8 +1613,55 @@ def test_vulkan_igpu_shared_memory_is_not_counted_twice(tmp_path, monkeypatch):
     monkeypatch.setattr(
         LlamaCppBackend, "_available_system_memory_mib", staticmethod(lambda: 14 * 1024)
     )
+    monkeypatch.setattr(
+        LlamaCppBackend, "_cgroup_available_memory_mib", staticmethod(lambda: None)
+    )
 
     with pytest.raises(RuntimeError, match = "does not fit in GPU memory"):
+        _launch(backend, gguf)
+
+
+def test_vulkan_igpu_heap_can_hold_weights_missing_from_host_available(tmp_path, monkeypatch):
+    """Windows can reserve most UMA for the Vulkan heap, leaving psutil with a much
+    smaller host-available figure. The heap is not added to host RAM, but it remains a
+    valid place for the weights themselves (#9454)."""
+    backend, gguf = _backend(
+        tmp_path,
+        vulkan = True,
+        # The device reported 108 GiB free; the iGPU host reserve leaves 107 GiB.
+        memory = [(0, 107 * 1024, 0)],
+    )
+    _restore_host_guard(backend)
+    backend._get_gguf_size_bytes = lambda _path: int(16.5 * 1024**3)
+    monkeypatch.setattr(
+        LlamaCppBackend, "_available_system_memory_mib", staticmethod(lambda: 13 * 1024)
+    )
+    monkeypatch.setattr(
+        LlamaCppBackend, "_cgroup_available_memory_mib", staticmethod(lambda: None)
+    )
+
+    assert _launch(backend, gguf)["cmd"]
+
+
+def test_vulkan_igpu_heap_does_not_bypass_a_cgroup_limit(tmp_path, monkeypatch):
+    """A shared Vulkan heap remains host-backed inside a constrained container, so
+    its host-wide free reading cannot override the process's cgroup ceiling."""
+    backend, gguf = _backend(
+        tmp_path,
+        vulkan = True,
+        memory = [(0, 64 * 1024, 0)],
+    )
+    _restore_host_guard(backend)
+    backend._apu_ram_shortfall_message = LlamaCppBackend._apu_ram_shortfall_message
+    backend._get_gguf_size_bytes = lambda _path: 20 * 1024**3
+    monkeypatch.setattr(
+        LlamaCppBackend, "_available_system_memory_mib", staticmethod(lambda: 64 * 1024)
+    )
+    monkeypatch.setattr(
+        LlamaCppBackend, "_cgroup_available_memory_mib", staticmethod(lambda: 8 * 1024)
+    )
+
+    with pytest.raises(RuntimeError, match = "unified-memory APU"):
         _launch(backend, gguf)
 
 

--- a/studio/backend/tests/test_llama_cpp_placement.py
+++ b/studio/backend/tests/test_llama_cpp_placement.py
@@ -1626,7 +1626,8 @@ def test_vulkan_igpu_heap_can_hold_weights_missing_from_host_available(tmp_path,
     backend, gguf = _backend(
         tmp_path,
         vulkan = True,
-        # The device reported 108 GiB free; the iGPU host reserve leaves 107 GiB.
+        # What the reader hands over once it has bounded the device's own reading
+        # against the host (_igpu_backed_free_mib) and taken the iGPU host reserve.
         memory = [(0, 107 * 1024, 0)],
     )
     _restore_host_guard(backend)
@@ -1659,6 +1660,24 @@ def test_vulkan_igpu_heap_does_not_bypass_a_cgroup_limit(tmp_path, monkeypatch):
 
     with pytest.raises(RuntimeError, match = "unified-memory APU"):
         _launch(backend, gguf)
+
+
+def test_a_card_resident_model_is_not_refused_by_a_container_ceiling(tmp_path, monkeypatch):
+    """Nothing is left to place, so no host memory is at stake and the cgroup has no
+    say. Routing this through the APU check priced a NEGATIVE need against the
+    remaining budget and refused a 23.4 GiB model on a 24 GiB card with 'needs about
+    -1 GB', on a discrete NVIDIA card at that."""
+    backend, gguf = _offload_backend(
+        tmp_path,
+        gguf_gb = 23.4,
+        free_mib = 24 * 1024,
+        avail_mib = 1024,
+        monkeypatch = monkeypatch,
+    )
+    backend._apu_ram_shortfall_message = LlamaCppBackend._apu_ram_shortfall_message
+    monkeypatch.setattr(LlamaCppBackend, "_cgroup_available_memory_mib", staticmethod(lambda: 1024))
+
+    assert _launch(backend, gguf)["cmd"]
 
 
 def test_unknown_available_ram_abstains(tmp_path, monkeypatch):

--- a/studio/backend/tests/test_llama_cpp_placement.py
+++ b/studio/backend/tests/test_llama_cpp_placement.py
@@ -1826,8 +1826,38 @@ def test_split_mode_none_leaves_a_second_device_heap_uncredited(tmp_path, monkey
     """Split mode none cannot select a shared heap among multiple devices."""
     backend, gguf = _mixed_vulkan(tmp_path, monkeypatch, [(0, 6 * 1024, 8 * 1024), (1, 94641, 0)])
 
+    # Both devices pinned, so the split mode is the only thing left to decide.
     with pytest.raises(RuntimeError, match = "does not fit in GPU memory"):
-        _launch(backend, gguf, gpu_memory_mode = "manual", gpu_layers = 33, extra_args = extras)
+        _launch(
+            backend,
+            gguf,
+            gpu_memory_mode = "manual",
+            gpu_layers = 33,
+            extra_args = ["--device", "Vulkan0,Vulkan1", *extras],
+        )
+
+
+def test_an_unpinned_launch_beside_a_discrete_card_leaves_the_heap_uncredited(
+    tmp_path, monkeypatch
+):
+    """llama.cpp drops integrated GPUs when its own device list finds a discrete one."""
+    backend, gguf = _mixed_vulkan(tmp_path, monkeypatch, [(0, 94641, 0), (1, 6 * 1024, 8 * 1024)])
+
+    with pytest.raises(RuntimeError, match = "does not fit in GPU memory"):
+        _launch(backend, gguf, gpu_memory_mode = "manual", gpu_layers = 33)
+
+
+def test_a_pin_still_reaches_the_heap_beside_a_discrete_card(tmp_path, monkeypatch):
+    """Naming the shared device puts it back in llama.cpp's list."""
+    backend, gguf = _mixed_vulkan(tmp_path, monkeypatch, [(0, 94641, 0), (1, 6 * 1024, 8 * 1024)])
+
+    assert _launch(
+        backend,
+        gguf,
+        gpu_memory_mode = "manual",
+        gpu_layers = 33,
+        extra_args = ["--device", "Vulkan0"],
+    )["cmd"]
 
 
 def test_split_mode_none_still_credits_a_lone_shared_device(tmp_path, monkeypatch):

--- a/studio/backend/tests/test_llama_cpp_placement.py
+++ b/studio/backend/tests/test_llama_cpp_placement.py
@@ -1730,15 +1730,11 @@ def test_an_unselected_card_does_not_shrink_what_the_shared_heap_must_hold(tmp_p
     [{"tensor_split": [1.0, 0.0]}, {"extra_args": ["--tensor-split", "1,0"]}],
     ids = ["picker-share", "user-flag"],
 )
-def test_an_explicit_tensor_split_leaves_the_shared_heap_uncredited(
-    tmp_path, monkeypatch, split
-):
+def test_an_explicit_tensor_split_leaves_the_shared_heap_uncredited(tmp_path, monkeypatch, split):
     """A ratio is positional in llama.cpp's enumeration, so this cannot tell which
     device a share belongs to, and 1,0 puts nothing in the iGPU's heap at all.
     Crediting it anyway admitted a 30 GiB model that has to land on a 6 GiB card."""
-    backend, gguf = _backend(
-        tmp_path, vulkan = True, memory = [(0, 6 * 1024, 8 * 1024), (1, 94641, 0)]
-    )
+    backend, gguf = _backend(tmp_path, vulkan = True, memory = [(0, 6 * 1024, 8 * 1024), (1, 94641, 0)])
     _restore_host_guard(backend)
     backend._get_gguf_size_bytes = lambda _path: 30 * 1024**3
     backend._n_layers = 32

--- a/studio/backend/tests/test_llama_cpp_placement.py
+++ b/studio/backend/tests/test_llama_cpp_placement.py
@@ -1754,6 +1754,52 @@ def test_an_explicit_tensor_split_leaves_the_shared_heap_uncredited(tmp_path, mo
         )
 
 
+def _mixed_vulkan(tmp_path, monkeypatch, memory):
+    """A 30 GiB GGUF on a host with 4 GiB of RAM left, full manual offload."""
+    backend, gguf = _backend(tmp_path, vulkan = True, memory = memory)
+    _restore_host_guard(backend)
+    backend._get_gguf_size_bytes = lambda _path: 30 * 1024**3
+    backend._n_layers = 32
+    monkeypatch.setattr(
+        LlamaCppBackend, "_available_system_memory_mib", staticmethod(lambda: 4 * 1024)
+    )
+    monkeypatch.setattr(LlamaCppBackend, "_cgroup_available_memory_mib", staticmethod(lambda: None))
+    return backend, gguf
+
+
+@pytest.mark.parametrize(
+    "extras",
+    [["--split-mode", "none", "--main-gpu", "0"], ["-sm", "none"]],
+    ids = ["with-main-gpu", "bare"],
+)
+def test_split_mode_none_leaves_a_second_device_heap_uncredited(tmp_path, monkeypatch, extras):
+    """``none`` sends the whole model to one --main-gpu index, in llama.cpp's own
+    enumeration, so beside a 6 GiB Vulkan0 this cannot claim the 94 GiB Vulkan1 heap
+    receives it. Crediting it admitted a 30 GiB model onto the 6 GiB card."""
+    backend, gguf = _mixed_vulkan(
+        tmp_path, monkeypatch, [(0, 6 * 1024, 8 * 1024), (1, 94641, 0)]
+    )
+
+    with pytest.raises(RuntimeError, match = "does not fit in GPU memory"):
+        _launch(
+            backend, gguf, gpu_memory_mode = "manual", gpu_layers = 33, extra_args = extras
+        )
+
+
+def test_split_mode_none_still_credits_a_lone_shared_device(tmp_path, monkeypatch):
+    """One device leaves ``none`` nothing to exclude, so #9454's own shape keeps
+    loading rather than being priced against the 4 GiB the host has."""
+    backend, gguf = _mixed_vulkan(tmp_path, monkeypatch, [(0, 94641, 0)])
+
+    assert _launch(
+        backend,
+        gguf,
+        gpu_memory_mode = "manual",
+        gpu_layers = 33,
+        extra_args = ["--split-mode", "none"],
+    )["cmd"]
+
+
 def test_vulkan_igpu_heap_does_not_bypass_a_cgroup_limit(tmp_path, monkeypatch):
     """A shared Vulkan heap remains host-backed inside a constrained container, so
     its host-wide free reading cannot override the process's cgroup ceiling."""

--- a/studio/backend/tests/test_llama_cpp_placement.py
+++ b/studio/backend/tests/test_llama_cpp_placement.py
@@ -1776,14 +1776,10 @@ def test_split_mode_none_leaves_a_second_device_heap_uncredited(tmp_path, monkey
     """``none`` sends the whole model to one --main-gpu index, in llama.cpp's own
     enumeration, so beside a 6 GiB Vulkan0 this cannot claim the 94 GiB Vulkan1 heap
     receives it. Crediting it admitted a 30 GiB model onto the 6 GiB card."""
-    backend, gguf = _mixed_vulkan(
-        tmp_path, monkeypatch, [(0, 6 * 1024, 8 * 1024), (1, 94641, 0)]
-    )
+    backend, gguf = _mixed_vulkan(tmp_path, monkeypatch, [(0, 6 * 1024, 8 * 1024), (1, 94641, 0)])
 
     with pytest.raises(RuntimeError, match = "does not fit in GPU memory"):
-        _launch(
-            backend, gguf, gpu_memory_mode = "manual", gpu_layers = 33, extra_args = extras
-        )
+        _launch(backend, gguf, gpu_memory_mode = "manual", gpu_layers = 33, extra_args = extras)
 
 
 def test_split_mode_none_still_credits_a_lone_shared_device(tmp_path, monkeypatch):

--- a/studio/backend/tests/test_llama_cpp_placement.py
+++ b/studio/backend/tests/test_llama_cpp_placement.py
@@ -1640,6 +1640,35 @@ def test_vulkan_igpu_heap_can_hold_weights_missing_from_host_available(tmp_path,
     assert _launch(backend, gguf)["cmd"]
 
 
+@pytest.mark.parametrize(
+    "placement",
+    [
+        {"gpu_memory_mode": "manual", "gpu_layers": 0},
+        {"gpu_memory_mode": "manual", "gpu_layers": 8},
+        {"extra_args": ["--device", "none"]},
+        {"extra_args": ["-ngl", "0"]},
+    ],
+    ids = ["manual-zero-offload", "manual-partial-offload", "device-none", "extras-zero-offload"],
+)
+def test_vulkan_igpu_heap_is_not_credited_to_a_host_resident_launch(
+    tmp_path, monkeypatch, placement
+):
+    """The heap holds only the weights the finished command sends there. A zero
+    layer count, a partial pin and a --device naming no GPU each leave the model in
+    the 13 GiB the host has, so the GGUF the full offload above admits stays
+    refused: crediting the heap for these let a 16.5 GiB model onto a 13 GiB host."""
+    backend, gguf = _backend(tmp_path, vulkan = True, memory = [(0, 107 * 1024, 0)])
+    _restore_host_guard(backend)
+    backend._get_gguf_size_bytes = lambda _path: int(16.5 * 1024**3)
+    monkeypatch.setattr(
+        LlamaCppBackend, "_available_system_memory_mib", staticmethod(lambda: 13 * 1024)
+    )
+    monkeypatch.setattr(LlamaCppBackend, "_cgroup_available_memory_mib", staticmethod(lambda: None))
+
+    with pytest.raises(RuntimeError, match = "does not fit in GPU memory"):
+        _launch(backend, gguf, **placement)
+
+
 def test_vulkan_igpu_heap_does_not_bypass_a_cgroup_limit(tmp_path, monkeypatch):
     """A shared Vulkan heap remains host-backed inside a constrained container, so
     its host-wide free reading cannot override the process's cgroup ceiling."""

--- a/studio/backend/tests/test_llama_cpp_placement.py
+++ b/studio/backend/tests/test_llama_cpp_placement.py
@@ -1700,6 +1700,31 @@ def test_a_device_pin_decides_whether_the_shared_heap_is_reachable(tmp_path, mon
     assert _launch(backend, gguf, extra_args = ["--device", "Vulkan1"], **manual)["cmd"]
 
 
+def test_an_unselected_card_does_not_shrink_what_the_shared_heap_must_hold(tmp_path, monkeypatch):
+    """Vulkan0 is a 24 GiB discrete card the pin leaves out, Vulkan1 the 10 GiB iGPU
+    heap it selects. Subtracting the unselected card first made a 30 GiB model read
+    as a 6 GiB remainder the heap could 'hold', admitting it on a 4 GiB host."""
+    backend, gguf = _backend(
+        tmp_path, vulkan = True, memory = [(0, 24 * 1024, 24 * 1024), (1, 10 * 1024, 0)]
+    )
+    _restore_host_guard(backend)
+    backend._get_gguf_size_bytes = lambda _path: 30 * 1024**3
+    backend._n_layers = 32
+    monkeypatch.setattr(
+        LlamaCppBackend, "_available_system_memory_mib", staticmethod(lambda: 4 * 1024)
+    )
+    monkeypatch.setattr(LlamaCppBackend, "_cgroup_available_memory_mib", staticmethod(lambda: None))
+
+    with pytest.raises(RuntimeError, match = "does not fit in GPU memory"):
+        _launch(
+            backend,
+            gguf,
+            gpu_memory_mode = "manual",
+            gpu_layers = 33,
+            extra_args = ["--device", "Vulkan1"],
+        )
+
+
 def test_vulkan_igpu_heap_does_not_bypass_a_cgroup_limit(tmp_path, monkeypatch):
     """A shared Vulkan heap remains host-backed inside a constrained container, so
     its host-wide free reading cannot override the process's cgroup ceiling."""

--- a/studio/backend/tests/test_llama_cpp_placement.py
+++ b/studio/backend/tests/test_llama_cpp_placement.py
@@ -1725,6 +1725,39 @@ def test_an_unselected_card_does_not_shrink_what_the_shared_heap_must_hold(tmp_p
         )
 
 
+@pytest.mark.parametrize(
+    "split",
+    [{"tensor_split": [1.0, 0.0]}, {"extra_args": ["--tensor-split", "1,0"]}],
+    ids = ["picker-share", "user-flag"],
+)
+def test_an_explicit_tensor_split_leaves_the_shared_heap_uncredited(
+    tmp_path, monkeypatch, split
+):
+    """A ratio is positional in llama.cpp's enumeration, so this cannot tell which
+    device a share belongs to, and 1,0 puts nothing in the iGPU's heap at all.
+    Crediting it anyway admitted a 30 GiB model that has to land on a 6 GiB card."""
+    backend, gguf = _backend(
+        tmp_path, vulkan = True, memory = [(0, 6 * 1024, 8 * 1024), (1, 94641, 0)]
+    )
+    _restore_host_guard(backend)
+    backend._get_gguf_size_bytes = lambda _path: 30 * 1024**3
+    backend._n_layers = 32
+    monkeypatch.setattr(
+        LlamaCppBackend, "_available_system_memory_mib", staticmethod(lambda: 4 * 1024)
+    )
+    monkeypatch.setattr(LlamaCppBackend, "_cgroup_available_memory_mib", staticmethod(lambda: None))
+
+    with pytest.raises(RuntimeError, match = "does not fit in GPU memory"):
+        _launch(
+            backend,
+            gguf,
+            gpu_memory_mode = "manual",
+            gpu_layers = 33,
+            gpu_ids = [0, 1],
+            **split,
+        )
+
+
 def test_vulkan_igpu_heap_does_not_bypass_a_cgroup_limit(tmp_path, monkeypatch):
     """A shared Vulkan heap remains host-backed inside a constrained container, so
     its host-wide free reading cannot override the process's cgroup ceiling."""

--- a/studio/backend/tests/test_llama_cpp_placement.py
+++ b/studio/backend/tests/test_llama_cpp_placement.py
@@ -1629,9 +1629,61 @@ def test_vulkan_igpu_heap_can_hold_weights_missing_from_host_available(tmp_path,
     monkeypatch.setattr(
         LlamaCppBackend, "_available_system_memory_mib", staticmethod(lambda: 13 * 1024)
     )
+    monkeypatch.setattr(
+        LlamaCppBackend, "_total_system_memory_mib", staticmethod(lambda: 32 * 1024)
+    )
     monkeypatch.setattr(LlamaCppBackend, "_cgroup_available_memory_mib", staticmethod(lambda: None))
 
     assert _launch(backend, gguf)["cmd"]
+
+
+@pytest.mark.parametrize(
+    "gguf_mib,admitted",
+    [(4096, True), (8192, True), (8256, False), (8704, False), (9216, False)],
+    ids = ["4-gib", "8-gib", "8.06-gib", "8.5-gib", "9-gib"],
+)
+def test_vulkan_igpu_backing_bound_preserves_placement_and_host_headroom(
+    tmp_path, monkeypatch, gguf_mib, admitted
+):
+    """The raw planner reading never lets host-backed credit lose system headroom."""
+    backend, gguf = _backend(tmp_path, vulkan = True, memory = [(0, 15 * 1024, 0)])
+    _restore_host_guard(backend)
+    backend._get_gpu_memory = (
+        lambda _binary = None, **_kw: LlamaCppBackend._get_gpu_free_memory_vulkan(_binary)
+    )
+    backend._get_gguf_size_bytes = lambda _path: gguf_mib * 1024**2
+    monkeypatch.setattr(
+        LlamaCppBackend,
+        "_run_vulkan_probe",
+        staticmethod(
+            lambda _binary = None: [
+                {
+                    "index": 0,
+                    "free_mib": 16 * 1024,
+                    "is_igpu": True,
+                    "total_mib": 16 * 1024,
+                    "name": "Vulkan0",
+                }
+            ]
+        ),
+    )
+    monkeypatch.setattr(
+        LlamaCppBackend, "_available_system_memory_mib", staticmethod(lambda: 10 * 1024)
+    )
+    monkeypatch.setattr(
+        LlamaCppBackend, "_total_system_memory_mib", staticmethod(lambda: 16 * 1024)
+    )
+    monkeypatch.setattr(LlamaCppBackend, "_cgroup_available_memory_mib", staticmethod(lambda: None))
+
+    if not admitted:
+        with pytest.raises(RuntimeError, match = "does not fit in GPU memory"):
+            _launch(backend, gguf)
+        return
+
+    cmd = _launch(backend, gguf)["cmd"]
+    assert cmd[cmd.index("-ngl") + 1] == "-1"
+    assert cmd[cmd.index("--fit") + 1] == "off"
+    assert cmd[cmd.index("--device") + 1] == "Vulkan0"
 
 
 @pytest.mark.parametrize(
@@ -1653,6 +1705,9 @@ def test_vulkan_igpu_heap_is_not_credited_to_a_host_resident_launch(
     backend._get_gguf_size_bytes = lambda _path: int(16.5 * 1024**3)
     monkeypatch.setattr(
         LlamaCppBackend, "_available_system_memory_mib", staticmethod(lambda: 13 * 1024)
+    )
+    monkeypatch.setattr(
+        LlamaCppBackend, "_total_system_memory_mib", staticmethod(lambda: 32 * 1024)
     )
     monkeypatch.setattr(LlamaCppBackend, "_cgroup_available_memory_mib", staticmethod(lambda: None))
 
@@ -1676,6 +1731,9 @@ def test_a_device_pin_decides_whether_the_shared_heap_is_reachable(tmp_path, mon
     monkeypatch.setattr(
         LlamaCppBackend, "_available_system_memory_mib", staticmethod(lambda: 13 * 1024)
     )
+    monkeypatch.setattr(
+        LlamaCppBackend, "_total_system_memory_mib", staticmethod(lambda: 32 * 1024)
+    )
     monkeypatch.setattr(LlamaCppBackend, "_cgroup_available_memory_mib", staticmethod(lambda: None))
     manual = {"gpu_memory_mode": "manual", "gpu_layers": 33}
 
@@ -1697,6 +1755,9 @@ def test_an_unselected_card_does_not_shrink_what_the_shared_heap_must_hold(tmp_p
     backend._n_layers = 32
     monkeypatch.setattr(
         LlamaCppBackend, "_available_system_memory_mib", staticmethod(lambda: 4 * 1024)
+    )
+    monkeypatch.setattr(
+        LlamaCppBackend, "_total_system_memory_mib", staticmethod(lambda: 32 * 1024)
     )
     monkeypatch.setattr(LlamaCppBackend, "_cgroup_available_memory_mib", staticmethod(lambda: None))
 
@@ -1724,6 +1785,9 @@ def test_an_explicit_tensor_split_leaves_the_shared_heap_uncredited(tmp_path, mo
     monkeypatch.setattr(
         LlamaCppBackend, "_available_system_memory_mib", staticmethod(lambda: 4 * 1024)
     )
+    monkeypatch.setattr(
+        LlamaCppBackend, "_total_system_memory_mib", staticmethod(lambda: 32 * 1024)
+    )
     monkeypatch.setattr(LlamaCppBackend, "_cgroup_available_memory_mib", staticmethod(lambda: None))
 
     with pytest.raises(RuntimeError, match = "does not fit in GPU memory"):
@@ -1745,6 +1809,9 @@ def _mixed_vulkan(tmp_path, monkeypatch, memory):
     backend._n_layers = 32
     monkeypatch.setattr(
         LlamaCppBackend, "_available_system_memory_mib", staticmethod(lambda: 4 * 1024)
+    )
+    monkeypatch.setattr(
+        LlamaCppBackend, "_total_system_memory_mib", staticmethod(lambda: 32 * 1024)
     )
     monkeypatch.setattr(LlamaCppBackend, "_cgroup_available_memory_mib", staticmethod(lambda: None))
     return backend, gguf

--- a/studio/backend/tests/test_llama_cpp_placement.py
+++ b/studio/backend/tests/test_llama_cpp_placement.py
@@ -1669,6 +1669,37 @@ def test_vulkan_igpu_heap_is_not_credited_to_a_host_resident_launch(
         _launch(backend, gguf, **placement)
 
 
+def test_a_device_pin_decides_whether_the_shared_heap_is_reachable(tmp_path, monkeypatch):
+    """Vulkan0 is a small discrete card here and Vulkan1 the carved-out iGPU heap. A
+    pin naming only Vulkan0 cannot place one weight in that heap, yet crediting it
+    admitted a 30 GiB model onto a 13 GiB host. The same launch pinned to the heap
+    reaches it and still loads."""
+
+    def _mixed():
+        backend, gguf = _backend(
+            tmp_path, vulkan = True, memory = [(0, 6 * 1024, 8 * 1024), (1, 94641, 0)]
+        )
+        _restore_host_guard(backend)
+        backend._get_gguf_size_bytes = lambda _path: 30 * 1024**3
+        # the block count the launch reads from the header, so gpu_layers 33 is a
+        # full offload rather than an unknown one
+        backend._n_layers = 32
+        return backend, gguf
+
+    monkeypatch.setattr(
+        LlamaCppBackend, "_available_system_memory_mib", staticmethod(lambda: 13 * 1024)
+    )
+    monkeypatch.setattr(LlamaCppBackend, "_cgroup_available_memory_mib", staticmethod(lambda: None))
+    manual = {"gpu_memory_mode": "manual", "gpu_layers": 33}
+
+    backend, gguf = _mixed()
+    with pytest.raises(RuntimeError, match = "does not fit in GPU memory"):
+        _launch(backend, gguf, extra_args = ["--device", "Vulkan0"], **manual)
+
+    backend, gguf = _mixed()
+    assert _launch(backend, gguf, extra_args = ["--device", "Vulkan1"], **manual)["cmd"]
+
+
 def test_vulkan_igpu_heap_does_not_bypass_a_cgroup_limit(tmp_path, monkeypatch):
     """A shared Vulkan heap remains host-backed inside a constrained container, so
     its host-wide free reading cannot override the process's cgroup ceiling."""

--- a/studio/backend/tests/test_llama_cpp_placement.py
+++ b/studio/backend/tests/test_llama_cpp_placement.py
@@ -1599,9 +1599,7 @@ def test_free_vram_offsets_the_charge(tmp_path, monkeypatch):
     ids = ["one-shared-device", "two-shared-devices"],
 )
 def test_vulkan_igpu_shared_memory_is_not_counted_twice(tmp_path, monkeypatch, memory):
-    """A Vulkan iGPU's free memory and MemAvailable describe the same unified pool.
-    Crediting host RAM or another iGPU again would let a 20 GiB model through on a
-    14 GiB host (12 + 14 or 12 + 12 on paper)."""
+    """Shared Vulkan rows and host RAM describe one pool."""
     backend, gguf = _backend(
         tmp_path,
         vulkan = True,
@@ -1620,14 +1618,10 @@ def test_vulkan_igpu_shared_memory_is_not_counted_twice(tmp_path, monkeypatch, m
 
 
 def test_vulkan_igpu_heap_can_hold_weights_missing_from_host_available(tmp_path, monkeypatch):
-    """Windows can reserve most UMA for the Vulkan heap, leaving psutil with a much
-    smaller host-available figure. The heap is not added to host RAM, but it remains a
-    valid place for the weights themselves (#9454)."""
+    """A firmware carve-out remains usable when host-available RAM is low."""
     backend, gguf = _backend(
         tmp_path,
         vulkan = True,
-        # What the reader hands over once it has bounded the device's own reading
-        # against the host (_igpu_backed_free_mib) and taken the iGPU host reserve.
         memory = [(0, 107 * 1024, 0)],
     )
     _restore_host_guard(backend)
@@ -1653,10 +1647,7 @@ def test_vulkan_igpu_heap_can_hold_weights_missing_from_host_available(tmp_path,
 def test_vulkan_igpu_heap_is_not_credited_to_a_host_resident_launch(
     tmp_path, monkeypatch, placement
 ):
-    """The heap holds only the weights the finished command sends there. A zero
-    layer count, a partial pin and a --device naming no GPU each leave the model in
-    the 13 GiB the host has, so the GGUF the full offload above admits stays
-    refused: crediting the heap for these let a 16.5 GiB model onto a 13 GiB host."""
+    """Only a full GPU offload may credit the shared heap."""
     backend, gguf = _backend(tmp_path, vulkan = True, memory = [(0, 107 * 1024, 0)])
     _restore_host_guard(backend)
     backend._get_gguf_size_bytes = lambda _path: int(16.5 * 1024**3)
@@ -1670,10 +1661,7 @@ def test_vulkan_igpu_heap_is_not_credited_to_a_host_resident_launch(
 
 
 def test_a_device_pin_decides_whether_the_shared_heap_is_reachable(tmp_path, monkeypatch):
-    """Vulkan0 is a small discrete card here and Vulkan1 the carved-out iGPU heap. A
-    pin naming only Vulkan0 cannot place one weight in that heap, yet crediting it
-    admitted a 30 GiB model onto a 13 GiB host. The same launch pinned to the heap
-    reaches it and still loads."""
+    """Only a selected shared device contributes its heap."""
 
     def _mixed():
         backend, gguf = _backend(
@@ -1681,8 +1669,7 @@ def test_a_device_pin_decides_whether_the_shared_heap_is_reachable(tmp_path, mon
         )
         _restore_host_guard(backend)
         backend._get_gguf_size_bytes = lambda _path: 30 * 1024**3
-        # the block count the launch reads from the header, so gpu_layers 33 is a
-        # full offload rather than an unknown one
+        # gpu_layers=33 fully offloads this 32-layer model.
         backend._n_layers = 32
         return backend, gguf
 
@@ -1701,9 +1688,7 @@ def test_a_device_pin_decides_whether_the_shared_heap_is_reachable(tmp_path, mon
 
 
 def test_an_unselected_card_does_not_shrink_what_the_shared_heap_must_hold(tmp_path, monkeypatch):
-    """Vulkan0 is a 24 GiB discrete card the pin leaves out, Vulkan1 the 10 GiB iGPU
-    heap it selects. Subtracting the unselected card first made a 30 GiB model read
-    as a 6 GiB remainder the heap could 'hold', admitting it on a 4 GiB host."""
+    """Only selected cards reduce the bytes assigned to the shared heap."""
     backend, gguf = _backend(
         tmp_path, vulkan = True, memory = [(0, 24 * 1024, 24 * 1024), (1, 10 * 1024, 0)]
     )
@@ -1731,9 +1716,7 @@ def test_an_unselected_card_does_not_shrink_what_the_shared_heap_must_hold(tmp_p
     ids = ["picker-share", "user-flag"],
 )
 def test_an_explicit_tensor_split_leaves_the_shared_heap_uncredited(tmp_path, monkeypatch, split):
-    """A ratio is positional in llama.cpp's enumeration, so this cannot tell which
-    device a share belongs to, and 1,0 puts nothing in the iGPU's heap at all.
-    Crediting it anyway admitted a 30 GiB model that has to land on a 6 GiB card."""
+    """An ambiguous tensor split must not credit a shared heap."""
     backend, gguf = _backend(tmp_path, vulkan = True, memory = [(0, 6 * 1024, 8 * 1024), (1, 94641, 0)])
     _restore_host_guard(backend)
     backend._get_gguf_size_bytes = lambda _path: 30 * 1024**3
@@ -1773,9 +1756,7 @@ def _mixed_vulkan(tmp_path, monkeypatch, memory):
     ids = ["with-main-gpu", "bare"],
 )
 def test_split_mode_none_leaves_a_second_device_heap_uncredited(tmp_path, monkeypatch, extras):
-    """``none`` sends the whole model to one --main-gpu index, in llama.cpp's own
-    enumeration, so beside a 6 GiB Vulkan0 this cannot claim the 94 GiB Vulkan1 heap
-    receives it. Crediting it admitted a 30 GiB model onto the 6 GiB card."""
+    """Split mode none cannot select a shared heap among multiple devices."""
     backend, gguf = _mixed_vulkan(tmp_path, monkeypatch, [(0, 6 * 1024, 8 * 1024), (1, 94641, 0)])
 
     with pytest.raises(RuntimeError, match = "does not fit in GPU memory"):
@@ -1783,8 +1764,7 @@ def test_split_mode_none_leaves_a_second_device_heap_uncredited(tmp_path, monkey
 
 
 def test_split_mode_none_still_credits_a_lone_shared_device(tmp_path, monkeypatch):
-    """One device leaves ``none`` nothing to exclude, so #9454's own shape keeps
-    loading rather than being priced against the 4 GiB the host has."""
+    """A lone shared device remains reachable under split mode none."""
     backend, gguf = _mixed_vulkan(tmp_path, monkeypatch, [(0, 94641, 0)])
 
     assert _launch(
@@ -1797,8 +1777,7 @@ def test_split_mode_none_still_credits_a_lone_shared_device(tmp_path, monkeypatc
 
 
 def test_vulkan_igpu_heap_does_not_bypass_a_cgroup_limit(tmp_path, monkeypatch):
-    """A shared Vulkan heap remains host-backed inside a constrained container, so
-    its host-wide free reading cannot override the process's cgroup ceiling."""
+    """A shared Vulkan heap remains subject to the process cgroup limit."""
     backend, gguf = _backend(
         tmp_path,
         vulkan = True,
@@ -1819,10 +1798,7 @@ def test_vulkan_igpu_heap_does_not_bypass_a_cgroup_limit(tmp_path, monkeypatch):
 
 
 def test_a_card_resident_model_is_not_refused_by_a_container_ceiling(tmp_path, monkeypatch):
-    """Nothing is left to place, so no host memory is at stake and the cgroup has no
-    say. Routing this through the APU check priced a NEGATIVE need against the
-    remaining budget and refused a 23.4 GiB model on a 24 GiB card with 'needs about
-    -1 GB', on a discrete NVIDIA card at that."""
+    """A card-resident model is independent of the cgroup memory budget."""
     backend, gguf = _offload_backend(
         tmp_path,
         gguf_gb = 23.4,

--- a/studio/backend/tests/test_llama_cpp_vulkan_probe.py
+++ b/studio/backend/tests/test_llama_cpp_vulkan_probe.py
@@ -127,10 +127,73 @@ def _row(
     return f"{row}\t{name}" if name is not None else row
 
 
-def test_integrated_gpu_leaves_host_margin(tmp_path):
+def _host_memory(monkeypatch, *, available_mib, total_mib):
+    """Pin the host figures the iGPU reading is bounded against, so these cases
+    describe a machine instead of whatever the runner happens to have free."""
+    monkeypatch.setattr(
+        LlamaCppBackend, "_available_system_memory_mib", staticmethod(lambda: available_mib)
+    )
+    monkeypatch.setattr(
+        LlamaCppBackend, "_total_system_memory_mib", staticmethod(lambda: total_mib)
+    )
+
+
+def test_integrated_gpu_leaves_host_margin(tmp_path, monkeypatch):
     binary = _make_vulkan_install(tmp_path)
     # iGPU with 30 GiB free; reserve a flat 1024 MiB (llama.cpp --fit-target).
     # total stays 0: shared system RAM is not a VRAM budget for the fit.
+    _host_memory(monkeypatch, available_mib = 31 * 1024, total_mib = 32 * 1024)
+    rows = [_row(0, 30 * GIB, is_igpu = 1, total_bytes = 32 * GIB)]
+    with _mock_probe(rows):
+        gpus = LlamaCppBackend._get_gpu_free_memory_vulkan(binary)
+    assert gpus == [(0, 30 * 1024 - 1024, 0)], gpus
+
+
+def test_integrated_gpu_free_is_bounded_by_what_the_host_can_back(tmp_path, monkeypatch):
+    """A stock APU's pool is all system RAM, and the driver prices it against its
+    own GTT ceiling: measured on a gfx1151 under RADV, the reading sat at 97277 MiB
+    while MemAvailable fell to 662 MiB. With nothing beyond MemTotal to credit, the
+    reading is worth no more than the RAM the host actually has."""
+    binary = _make_vulkan_install(tmp_path)
+    _host_memory(monkeypatch, available_mib = 4000, total_mib = 31000)
+    # 512 MiB of UMA plus a GTT heap half the size of RAM
+    rows = [_row(0, 15900 * MIB, is_igpu = 1, total_bytes = 16012 * MIB)]
+    with _mock_probe(rows):
+        gpus = LlamaCppBackend._get_gpu_free_memory_vulkan(binary)
+    assert gpus == [(0, 4000 - 1024, 0)], gpus
+
+
+def test_integrated_gpu_keeps_a_heap_the_os_cannot_see(tmp_path, monkeypatch):
+    """#9454: Variable Graphics Memory carves 96 GiB out before Windows boots, so
+    psutil sees 31 GiB total and 13 GiB available while Vulkan reports 108 GiB free.
+    Whatever the pool holds beyond MemTotal is memory the host figure cannot know
+    about, and the weights do fit there."""
+    binary = _make_vulkan_install(tmp_path)
+    _host_memory(monkeypatch, available_mib = 13312, total_mib = 32154)
+    rows = [_row(0, 108782 * MIB, is_igpu = 1, total_bytes = 114507 * MIB)]
+    with _mock_probe(rows):
+        gpus = LlamaCppBackend._get_gpu_free_memory_vulkan(binary)
+    assert gpus == [(0, (114507 - 32154) + 13312 - 1024, 0)], gpus
+
+
+def test_wsl_credits_no_heap_beyond_its_own_memtotal(tmp_path, monkeypatch):
+    """.wslconfig hands the VM a slice of the host's RAM while the adapter still
+    reports a pool sized from the whole machine, so 'bigger than MemTotal' proves
+    nothing there. The VM cap stays the ceiling."""
+    binary = _make_vulkan_install(tmp_path)
+    _host_memory(monkeypatch, available_mib = 6000, total_mib = 8192)
+    monkeypatch.setattr(_llama_mod, "_is_wsl", lambda: True)
+    rows = [_row(0, 11000 * MIB, is_igpu = 1, total_bytes = 12000 * MIB)]
+    with _mock_probe(rows):
+        gpus = LlamaCppBackend._get_gpu_free_memory_vulkan(binary)
+    assert gpus == [(0, 6000 - 1024, 0)], gpus
+
+
+def test_unreadable_host_memory_leaves_the_integrated_reading_alone(tmp_path, monkeypatch):
+    """No psutil and no /proc/meminfo is not evidence of a small host, so the bound
+    abstains rather than guessing the device down to nothing."""
+    binary = _make_vulkan_install(tmp_path)
+    _host_memory(monkeypatch, available_mib = None, total_mib = None)
     rows = [_row(0, 30 * GIB, is_igpu = 1, total_bytes = 32 * GIB)]
     with _mock_probe(rows):
         gpus = LlamaCppBackend._get_gpu_free_memory_vulkan(binary)

--- a/studio/backend/tests/test_llama_cpp_vulkan_probe.py
+++ b/studio/backend/tests/test_llama_cpp_vulkan_probe.py
@@ -148,15 +148,16 @@ def test_integrated_gpu_leaves_host_margin(tmp_path, monkeypatch):
     assert gpus == [(0, 30 * 1024 - 1024, 0)], gpus
 
 
-def test_integrated_gpu_free_is_bounded_by_what_the_host_can_back(tmp_path, monkeypatch):
-    """Host-backed iGPU memory cannot exceed MemAvailable."""
+def test_integrated_gpu_host_bound_does_not_replace_planner_reading(tmp_path, monkeypatch):
+    """Placement keeps Vulkan free while admission caps its host-backed share."""
     binary = _make_vulkan_install(tmp_path)
     _host_memory(monkeypatch, available_mib = 4000, total_mib = 31000)
     # 512 MiB of UMA plus a GTT heap half the size of RAM
     rows = [_row(0, 15900 * MIB, is_igpu = 1, total_bytes = 16012 * MIB)]
     with _mock_probe(rows):
         gpus = LlamaCppBackend._get_gpu_free_memory_vulkan(binary)
-    assert gpus == [(0, 4000 - 1024, 0)], gpus
+    assert gpus == [(0, 15900 - 1024, 0)], gpus
+    assert LlamaCppBackend._igpu_backed_usable_mib(gpus[0][1]) == 4000 - 2048
 
 
 def test_integrated_gpu_keeps_a_heap_the_os_cannot_see(tmp_path, monkeypatch):
@@ -166,7 +167,9 @@ def test_integrated_gpu_keeps_a_heap_the_os_cannot_see(tmp_path, monkeypatch):
     rows = [_row(0, 108782 * MIB, is_igpu = 1, total_bytes = 114507 * MIB)]
     with _mock_probe(rows):
         gpus = LlamaCppBackend._get_gpu_free_memory_vulkan(binary)
-    assert gpus == [(0, (108782 - 32154) + 13312 - 1024, 0)], gpus
+    assert gpus == [(0, 108782 - 1024, 0)], gpus
+    expected = (108782 - 32154) + 13312 - 2048
+    assert LlamaCppBackend._igpu_backed_usable_mib(gpus[0][1]) == expected
 
 
 def test_a_carve_out_another_process_holds_is_not_credited(tmp_path, monkeypatch):
@@ -177,7 +180,8 @@ def test_a_carve_out_another_process_holds_is_not_credited(tmp_path, monkeypatch
     rows = [_row(0, 22528 * MIB, is_igpu = 1, total_bytes = 114688 * MIB)]
     with _mock_probe(rows):
         gpus = LlamaCppBackend._get_gpu_free_memory_vulkan(binary)
-    assert gpus == [(0, 4096 - 1024, 0)], gpus
+    assert gpus == [(0, 22528 - 1024, 0)], gpus
+    assert LlamaCppBackend._igpu_backed_usable_mib(gpus[0][1]) == 4096 - 2048
 
 
 def test_wsl_credits_no_heap_beyond_its_own_memtotal(tmp_path, monkeypatch):
@@ -188,7 +192,8 @@ def test_wsl_credits_no_heap_beyond_its_own_memtotal(tmp_path, monkeypatch):
     rows = [_row(0, 11000 * MIB, is_igpu = 1, total_bytes = 12000 * MIB)]
     with _mock_probe(rows):
         gpus = LlamaCppBackend._get_gpu_free_memory_vulkan(binary)
-    assert gpus == [(0, 6000 - 1024, 0)], gpus
+    assert gpus == [(0, 11000 - 1024, 0)], gpus
+    assert LlamaCppBackend._igpu_backed_usable_mib(gpus[0][1]) == 6000 - 2048
 
 
 def test_unreadable_host_memory_leaves_the_integrated_reading_alone(tmp_path, monkeypatch):
@@ -199,6 +204,7 @@ def test_unreadable_host_memory_leaves_the_integrated_reading_alone(tmp_path, mo
     with _mock_probe(rows):
         gpus = LlamaCppBackend._get_gpu_free_memory_vulkan(binary)
     assert gpus == [(0, 30 * 1024 - 1024, 0)], gpus
+    assert LlamaCppBackend._igpu_backed_usable_mib(gpus[0][1]) == 30 * 1024 - 1024
 
 
 def test_discrete_gpu_free_is_untouched_and_total_passed_through(tmp_path):

--- a/studio/backend/tests/test_llama_cpp_vulkan_probe.py
+++ b/studio/backend/tests/test_llama_cpp_vulkan_probe.py
@@ -128,8 +128,7 @@ def _row(
 
 
 def _host_memory(monkeypatch, *, available_mib, total_mib):
-    """Pin the host figures the iGPU reading is bounded against, so these cases
-    describe a machine instead of whatever the runner happens to have free."""
+    """Set deterministic host-memory bounds for iGPU tests."""
     monkeypatch.setattr(
         LlamaCppBackend, "_available_system_memory_mib", staticmethod(lambda: available_mib)
     )
@@ -150,10 +149,7 @@ def test_integrated_gpu_leaves_host_margin(tmp_path, monkeypatch):
 
 
 def test_integrated_gpu_free_is_bounded_by_what_the_host_can_back(tmp_path, monkeypatch):
-    """A stock APU's pool is all system RAM, and the driver prices it against its
-    own GTT ceiling: measured on a gfx1151 under RADV, the reading sat at 97277 MiB
-    while MemAvailable fell to 662 MiB. With nothing beyond MemTotal to credit, the
-    reading is worth no more than the RAM the host actually has."""
+    """Host-backed iGPU memory cannot exceed MemAvailable."""
     binary = _make_vulkan_install(tmp_path)
     _host_memory(monkeypatch, available_mib = 4000, total_mib = 31000)
     # 512 MiB of UMA plus a GTT heap half the size of RAM
@@ -164,10 +160,7 @@ def test_integrated_gpu_free_is_bounded_by_what_the_host_can_back(tmp_path, monk
 
 
 def test_integrated_gpu_keeps_a_heap_the_os_cannot_see(tmp_path, monkeypatch):
-    """#9454: Variable Graphics Memory carves 96 GiB out before Windows boots, so
-    psutil sees 31 GiB total and 13 GiB available while Vulkan reports 108 GiB free.
-    Whatever that free reading holds beyond MemTotal is memory the host figure cannot
-    know about, and the weights do fit there."""
+    """Free memory above MemTotal is a conservative carve-out floor."""
     binary = _make_vulkan_install(tmp_path)
     _host_memory(monkeypatch, available_mib = 13312, total_mib = 32154)
     rows = [_row(0, 108782 * MIB, is_igpu = 1, total_bytes = 114507 * MIB)]
@@ -177,13 +170,10 @@ def test_integrated_gpu_keeps_a_heap_the_os_cannot_see(tmp_path, monkeypatch):
 
 
 def test_a_carve_out_another_process_holds_is_not_credited(tmp_path, monkeypatch):
-    """The floor is read from the FREE figure, so a carve-out most of which another
-    Vulkan process already holds credits what is left of it, not its capacity. Sized
-    from the device total instead, this promised 21 GiB on a host with 4 GiB free."""
+    """Use free, not total, to exclude carve-out memory held elsewhere."""
     binary = _make_vulkan_install(tmp_path)
     _host_memory(monkeypatch, available_mib = 4096, total_mib = 32768)
-    # a 96 GiB carve-out plus a 16 GiB GTT heap, with all but 6 GiB of the carve-out
-    # resident in someone else: nothing is left above MemTotal to credit
+    # The free reading does not exceed MemTotal, so no carve-out is credited.
     rows = [_row(0, 22528 * MIB, is_igpu = 1, total_bytes = 114688 * MIB)]
     with _mock_probe(rows):
         gpus = LlamaCppBackend._get_gpu_free_memory_vulkan(binary)
@@ -191,9 +181,7 @@ def test_a_carve_out_another_process_holds_is_not_credited(tmp_path, monkeypatch
 
 
 def test_wsl_credits_no_heap_beyond_its_own_memtotal(tmp_path, monkeypatch):
-    """.wslconfig hands the VM a slice of the host's RAM while the adapter still
-    reports a pool sized from the whole machine, so 'bigger than MemTotal' proves
-    nothing there. The VM cap stays the ceiling."""
+    """WSL MemTotal does not describe the adapter's host pool."""
     binary = _make_vulkan_install(tmp_path)
     _host_memory(monkeypatch, available_mib = 6000, total_mib = 8192)
     monkeypatch.setattr(_llama_mod, "_is_wsl", lambda: True)
@@ -204,8 +192,7 @@ def test_wsl_credits_no_heap_beyond_its_own_memtotal(tmp_path, monkeypatch):
 
 
 def test_unreadable_host_memory_leaves_the_integrated_reading_alone(tmp_path, monkeypatch):
-    """No psutil and no /proc/meminfo is not evidence of a small host, so the bound
-    abstains rather than guessing the device down to nothing."""
+    """Missing host readings leave the Vulkan value unchanged."""
     binary = _make_vulkan_install(tmp_path)
     _host_memory(monkeypatch, available_mib = None, total_mib = None)
     rows = [_row(0, 30 * GIB, is_igpu = 1, total_bytes = 32 * GIB)]

--- a/studio/backend/tests/test_llama_cpp_vulkan_probe.py
+++ b/studio/backend/tests/test_llama_cpp_vulkan_probe.py
@@ -166,14 +166,28 @@ def test_integrated_gpu_free_is_bounded_by_what_the_host_can_back(tmp_path, monk
 def test_integrated_gpu_keeps_a_heap_the_os_cannot_see(tmp_path, monkeypatch):
     """#9454: Variable Graphics Memory carves 96 GiB out before Windows boots, so
     psutil sees 31 GiB total and 13 GiB available while Vulkan reports 108 GiB free.
-    Whatever the pool holds beyond MemTotal is memory the host figure cannot know
-    about, and the weights do fit there."""
+    Whatever that free reading holds beyond MemTotal is memory the host figure cannot
+    know about, and the weights do fit there."""
     binary = _make_vulkan_install(tmp_path)
     _host_memory(monkeypatch, available_mib = 13312, total_mib = 32154)
     rows = [_row(0, 108782 * MIB, is_igpu = 1, total_bytes = 114507 * MIB)]
     with _mock_probe(rows):
         gpus = LlamaCppBackend._get_gpu_free_memory_vulkan(binary)
-    assert gpus == [(0, (114507 - 32154) + 13312 - 1024, 0)], gpus
+    assert gpus == [(0, (108782 - 32154) + 13312 - 1024, 0)], gpus
+
+
+def test_a_carve_out_another_process_holds_is_not_credited(tmp_path, monkeypatch):
+    """The floor is read from the FREE figure, so a carve-out most of which another
+    Vulkan process already holds credits what is left of it, not its capacity. Sized
+    from the device total instead, this promised 21 GiB on a host with 4 GiB free."""
+    binary = _make_vulkan_install(tmp_path)
+    _host_memory(monkeypatch, available_mib = 4096, total_mib = 32768)
+    # a 96 GiB carve-out plus a 16 GiB GTT heap, with all but 6 GiB of the carve-out
+    # resident in someone else: nothing is left above MemTotal to credit
+    rows = [_row(0, 22528 * MIB, is_igpu = 1, total_bytes = 114688 * MIB)]
+    with _mock_probe(rows):
+        gpus = LlamaCppBackend._get_gpu_free_memory_vulkan(binary)
+    assert gpus == [(0, 4096 - 1024, 0)], gpus
 
 
 def test_wsl_credits_no_heap_beyond_its_own_memtotal(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

- treat a Vulkan iGPU free-memory budget as an alternative view of the host-backed pool instead of discarding it
- keep shared memory from being added to host RAM or multiplied across iGPUs, while retaining finite cgroup limits
- cover the Strix Halo case where Vulkan has 107 GiB usable but Windows reports only 13 GiB host-available RAM

## Testing

- `pytest -q tests/test_llama_cpp_placement.py tests/test_host_offload_ram_guard.py tests/test_llama_cpp_vulkan_probe.py` (113 passed)
- `ruff check core/inference/llama_cpp.py tests/test_llama_cpp_placement.py`
- `python -m compileall -q core/inference/llama_cpp.py tests/test_llama_cpp_placement.py`

Fixes #9454