### PR TITLE
Migrate Anthropic smoke probes to v1

### DIFF
--- a/.github/scripts/studio_smoke/multi_turn_chat.py
+++ b/.github/scripts/studio_smoke/multi_turn_chat.py
@@ -89,8 +89,9 @@ def run_anthropic() -> list[str]:
             model = "default",
             max_tokens = MAX_TOKENS,
             messages = history,
-            temperature = 0.0,
-            extra_body = {"seed": SEED, "enable_thinking": False},
+            # Anthropic 1.x removed sampling parameters from the typed signature;
+            # extra_body preserves the same request JSON.
+            extra_body = {"temperature": 0.0, "seed": SEED, "enable_thinking": False},
         )
         text = "".join(b.text for b in msg.content if getattr(b, "type", None) == "text")
         replies.append(text)

--- a/.github/workflows/studio-inference-smoke.yml
+++ b/.github/workflows/studio-inference-smoke.yml
@@ -194,12 +194,9 @@ jobs:
         id: sdks
         if: ${{ !cancelled() && steps.install.outcome == 'success' }}
         timeout-minutes: 10
-        # anthropic is held below 1.0: v1 removed temperature, top_p and top_k as
-        # accepted arguments on messages.create(), so the probes below, which pin
-        # temperature = 0.0 for determinism, raise TypeError against it. The v1 route
-        # is extra_body; moving to it is a deliberate change to what the probes send,
-        # not something a CI install should decide by resolving a new major.
-        run: pip install 'openai>=1.50,<4' 'anthropic>=0.40,<1'
+        # Sampling parameters use extra_body below, so exercise Anthropic 1.x while
+        # retaining a deliberate major boundary.
+        run: pip install 'openai>=1.50,<4' 'anthropic>=0.40,<2'
 
       # Phase 1's environment and model cache sit HERE, after the shared
       # preamble, not before it. They used to run before the installer, which is
@@ -1185,8 +1182,9 @@ jobs:
           a_msg = anthropic.messages.create(
               model       = "default",
               max_tokens  = 80,
-              temperature = 0.0,
-              extra_body  = {"seed": SEED},
+              # Anthropic 1.x removed sampling parameters from the typed signature;
+              # extra_body preserves the same request JSON.
+              extra_body  = {"temperature": 0.0, "seed": SEED},
               messages    = [{
                   "role": "user",
                   "content": [

--- a/.github/workflows/studio-inference-smoke.yml
+++ b/.github/workflows/studio-inference-smoke.yml
@@ -196,7 +196,7 @@ jobs:
         timeout-minutes: 10
         # Sampling parameters use extra_body below, so exercise Anthropic 1.x while
         # retaining a deliberate major boundary.
-        run: pip install 'openai>=1.50,<4' 'anthropic>=0.40,<2'
+        run: pip install 'openai>=1.50,<4' 'anthropic>=1,<2'
 
       # Phase 1's environment and model cache sit HERE, after the shared
       # preamble, not before it. They used to run before the installer, which is

--- a/.github/workflows/studio-mac-ui-smoke.yml
+++ b/.github/workflows/studio-mac-ui-smoke.yml
@@ -647,12 +647,9 @@ jobs:
         id: sdks-chat
         if: ${{ !cancelled() && steps.assert_llama.outcome == 'success' }}
         timeout-minutes: 5
-        # anthropic is held below 1.0: v1 removed temperature, top_p and top_k as
-        # accepted arguments on messages.create(), so the probes below, which pin
-        # temperature = 0.0 for determinism, raise TypeError against it. The v1 route
-        # is extra_body; moving to it is a deliberate change to what the probes send,
-        # not something a CI install should decide by resolving a new major.
-        run: pip install 'openai>=1.50,<4' 'anthropic>=0.40,<1'
+        # Sampling parameters use extra_body below, so exercise Anthropic 1.x while
+        # retaining a deliberate major boundary.
+        run: pip install 'openai>=1.50,<4' 'anthropic>=0.40,<2'
 
       - name: Reset auth + boot Unsloth (API-only)
         id: boot-chat
@@ -1280,12 +1277,9 @@ jobs:
         id: sdks-vision
         if: ${{ !cancelled() && steps.assert_llama.outcome == 'success' }}
         timeout-minutes: 5
-        # anthropic is held below 1.0: v1 removed temperature, top_p and top_k as
-        # accepted arguments on messages.create(), so the probes below, which pin
-        # temperature = 0.0 for determinism, raise TypeError against it. The v1 route
-        # is extra_body; moving to it is a deliberate change to what the probes send,
-        # not something a CI install should decide by resolving a new major.
-        run: pip install 'openai>=1.50,<4' 'anthropic>=0.40,<1'
+        # Sampling parameters use extra_body below, so exercise Anthropic 1.x while
+        # retaining a deliberate major boundary.
+        run: pip install 'openai>=1.50,<4' 'anthropic>=0.40,<2'
 
       - name: Reset auth + boot Unsloth (API-only)
         id: boot-vision
@@ -1553,8 +1547,9 @@ jobs:
               a_msg = anthropic.messages.create(
                   model       = "default",
                   max_tokens  = 80,
-                  temperature = TEMP,
-                  extra_body  = {"seed": SEED},
+                  # Anthropic 1.x removed sampling parameters from the typed signature;
+                  # extra_body preserves the same request JSON.
+                  extra_body  = {"temperature": TEMP, "seed": SEED},
                   messages    = [{
                       "role": "user",
                       "content": [

--- a/.github/workflows/studio-mac-ui-smoke.yml
+++ b/.github/workflows/studio-mac-ui-smoke.yml
@@ -649,7 +649,7 @@ jobs:
         timeout-minutes: 5
         # Sampling parameters use extra_body below, so exercise Anthropic 1.x while
         # retaining a deliberate major boundary.
-        run: pip install 'openai>=1.50,<4' 'anthropic>=0.40,<2'
+        run: pip install 'openai>=1.50,<4' 'anthropic>=1,<2'
 
       - name: Reset auth + boot Unsloth (API-only)
         id: boot-chat
@@ -1279,7 +1279,7 @@ jobs:
         timeout-minutes: 5
         # Sampling parameters use extra_body below, so exercise Anthropic 1.x while
         # retaining a deliberate major boundary.
-        run: pip install 'openai>=1.50,<4' 'anthropic>=0.40,<2'
+        run: pip install 'openai>=1.50,<4' 'anthropic>=1,<2'
 
       - name: Reset auth + boot Unsloth (API-only)
         id: boot-vision

--- a/.github/workflows/studio-windows-inference-smoke.yml
+++ b/.github/workflows/studio-windows-inference-smoke.yml
@@ -297,7 +297,7 @@ jobs:
         timeout-minutes: 10
         # Sampling parameters use extra_body below, so exercise Anthropic 1.x while
         # retaining a deliberate major boundary.
-        run: python -m pip install 'openai>=1.50,<4' 'anthropic>=0.40,<2'
+        run: python -m pip install 'openai>=1.50,<4' 'anthropic>=1,<2'
 
       # Phase 1's environment and model cache sit HERE, after the shared
       # preamble, not before it. They used to run before the installer, which is

--- a/.github/workflows/studio-windows-inference-smoke.yml
+++ b/.github/workflows/studio-windows-inference-smoke.yml
@@ -295,12 +295,9 @@ jobs:
         id: sdks
         if: ${{ !cancelled() && steps.assert-prebuilt.outcome == 'success' }}
         timeout-minutes: 10
-        # anthropic is held below 1.0: v1 removed temperature, top_p and top_k as
-        # accepted arguments on messages.create(), so the probes below, which pin
-        # temperature = 0.0 for determinism, raise TypeError against it. The v1 route
-        # is extra_body; moving to it is a deliberate change to what the probes send,
-        # not something a CI install should decide by resolving a new major.
-        run: python -m pip install 'openai>=1.50,<4' 'anthropic>=0.40,<1'
+        # Sampling parameters use extra_body below, so exercise Anthropic 1.x while
+        # retaining a deliberate major boundary.
+        run: python -m pip install 'openai>=1.50,<4' 'anthropic>=0.40,<2'
 
       # Phase 1's environment and model cache sit HERE, after the shared
       # preamble, not before it. They used to run before the installer, which is
@@ -1302,8 +1299,9 @@ jobs:
               a_msg = anthropic.messages.create(
                   model       = "default",
                   max_tokens  = 80,
-                  temperature = TEMP,
-                  extra_body  = {"seed": SEED},
+                  # Anthropic 1.x removed sampling parameters from the typed signature;
+                  # extra_body preserves the same request JSON.
+                  extra_body  = {"temperature": TEMP, "seed": SEED},
                   messages    = [{
                       "role": "user",
                       "content": [

--- a/tests/studio/test_sdk_installs_are_major_bounded.py
+++ b/tests/studio/test_sdk_installs_are_major_bounded.py
@@ -286,8 +286,17 @@ def test_anthropic_sampling_parameters_use_extra_body() -> None:
     blocks = _anthropic_create_blocks()
     assert len(blocks) == 4, blocks
     for path, block in blocks:
-        assert not re.search(r"^\s*temperature\s*=", block, re.MULTILINE), path
+        assert not re.search(r"\btemperature\s*=", block), path
         assert re.search(r'extra_body\s*=\s*\{[^\n]*["\']temperature["\']', block), path
+
+
+def test_anthropic_smokes_install_v1() -> None:
+    not_v1 = [
+        (path, number, spec)
+        for path, number, spec in _specs_for("anthropic")
+        if not re.search(r"(?:^|,)>=1(?:\.\d+)*(?:,|$)", spec)
+    ]
+    assert not not_v1, not_v1
 
 
 def test_a_bound_above_the_next_major_is_not_accepted() -> None:

--- a/tests/studio/test_sdk_installs_are_major_bounded.py
+++ b/tests/studio/test_sdk_installs_are_major_bounded.py
@@ -31,6 +31,12 @@ import pytest
 
 REPO = Path(__file__).resolve().parents[2]
 WORKFLOWS = REPO / ".github" / "workflows"
+ANTHROPIC_PROBES = (
+    REPO / ".github" / "scripts" / "studio_smoke" / "multi_turn_chat.py",
+    WORKFLOWS / "studio-inference-smoke.yml",
+    WORKFLOWS / "studio-mac-ui-smoke.yml",
+    WORKFLOWS / "studio-windows-inference-smoke.yml",
+)
 
 # Packages our probe code calls directly by keyword, each with the first major it must
 # NOT reach. Asserting the boundary rather than "some upper bound exists" is what makes
@@ -40,8 +46,8 @@ WORKFLOWS = REPO / ".github" / "workflows"
 # Bump a number here in the same commit that widens the pin, and only once CI has run
 # against that major.
 GUARDED = {
-    # v1 removed temperature, top_p and top_k from messages.create().
-    "anthropic": (1,),
+    # Sampling parameters moved to extra_body for v1; guard the next major now.
+    "anthropic": (2,),
     # 3.3.1 resolves today and the probes pass, so the bound sits above it, not at <2.
     "openai": (4,),
     # Still 1.x upstream.
@@ -173,6 +179,28 @@ def _specs_for(package: str) -> list[tuple[Path, int, str]]:
     return hits
 
 
+def _anthropic_create_blocks() -> list[tuple[Path, str]]:
+    blocks = []
+    for path in ANTHROPIC_PROBES:
+        lines = path.read_text(encoding = "utf-8").splitlines()
+        for index, line in enumerate(lines):
+            if ".messages.create(" not in line:
+                continue
+            indent = len(line) - len(line.lstrip())
+            block = [line]
+            for continuation in lines[index + 1 :]:
+                block.append(continuation)
+                if (
+                    continuation.strip() == ")"
+                    and len(continuation) - len(continuation.lstrip()) == indent
+                ):
+                    break
+            else:
+                raise AssertionError(f"unterminated messages.create call in {path}")
+            blocks.append((path, "\n".join(block)))
+    return blocks
+
+
 def _release(raw: str) -> tuple[int, ...]:
     """Release segment as ints, every component kept.
 
@@ -252,6 +280,14 @@ def test_the_sdk_is_pinned_below_the_next_major(package: str) -> None:
         f" anthropic 1.0.0 broke 75 jobs. Pin below {wanted}, or move the boundary in this"
         " file in the same commit once CI has run against that major."
     )
+
+
+def test_anthropic_sampling_parameters_use_extra_body() -> None:
+    blocks = _anthropic_create_blocks()
+    assert len(blocks) == 4, blocks
+    for path, block in blocks:
+        assert not re.search(r"^\s*temperature\s*=", block, re.MULTILINE), path
+        assert re.search(r'extra_body\s*=\s*\{[^\n]*["\']temperature["\']', block), path
 
 
 def test_a_bound_above_the_next_major_is_not_accepted() -> None:


### PR DESCRIPTION
## Summary

- move Anthropic sampling parameters into `extra_body` at all four smoke call sites
- test Anthropic 1.x while retaining an `<2` major boundary
- update the SDK guard and pin all four call sites against top-level `temperature`

## Validation

- 24 focused tests passed
- isolated `anthropic==1.0.0` mock transport received `temperature` and `seed` in the JSON body
- Ruff check and `py_compile` passed
- workflow trigger lint passed across 41 workflow files
- `git diff --check` passed

Fixes #9443