### PR TITLE
Fix delegated generation flag cleanup

### DIFF
--- a/tests/test_for_training_generation_flag.py
+++ b/tests/test_for_training_generation_flag.py
@@ -1,23 +1,40 @@
 import ast
+import builtins
+import os
 from pathlib import Path
 
+import pytest
 
-def _for_training():
-    path = Path(__file__).parents[1] / "unsloth" / "models" / "llama.py"
+# Both for_training implementations must survive a PEFT wrapper that delegates the
+# read of _flag_for_generation inwards but owns no attribute to delete. See issue #2490.
+SITES = [("llama.py", "FastLlamaModel"), ("vision.py", "FastBaseModel")]
+
+
+class _Namespace(dict):
+    """Globals for a method lifted out of its module; unused module-level helpers
+    resolve to None, which is the "feature absent" branch wherever they are read."""
+
+    def __missing__(self, name):
+        return getattr(builtins, name, None)
+
+
+def _for_training(module, class_name):
+    path = Path(__file__).parents[1] / "unsloth" / "models" / module
     tree = ast.parse(path.read_text(encoding = "utf-8"))
     model_class = next(
         node
         for node in tree.body
-        if isinstance(node, ast.ClassDef) and node.name == "FastLlamaModel"
+        if isinstance(node, ast.ClassDef) and node.name == class_name
     )
     method = next(
         node
         for node in model_class.body
         if isinstance(node, ast.FunctionDef) and node.name == "for_training"
     )
-    module = ast.Module(body = [method], type_ignores = [])
-    namespace = {}
-    exec(compile(ast.fix_missing_locations(module), str(path), "exec"), namespace)
+    method.decorator_list = []
+    compiled = ast.Module(body = [method], type_ignores = [])
+    namespace = _Namespace(os = os)
+    exec(compile(ast.fix_missing_locations(compiled), str(path), "exec"), namespace)
     return namespace["for_training"]
 
 
@@ -45,7 +62,7 @@ class _PeftProxy:
         self.model = model
 
     def __getattr__(self, name):
-        return getattr(self.model, name)
+        return getattr(self.__dict__["model"], name)
 
     def parameters(self):
         return ()
@@ -57,12 +74,32 @@ class _PeftProxy:
         self.training = True
 
 
-def test_for_training_deletes_a_generation_flag_delegated_by_a_peft_wrapper():
+@pytest.mark.parametrize("module, class_name", SITES)
+def test_for_training_deletes_a_generation_flag_delegated_by_a_peft_wrapper(module, class_name):
     model = _Model()
     proxy = _PeftProxy(model)
     assert hasattr(proxy, "_flag_for_generation")
     assert "_flag_for_generation" not in vars(proxy)
 
-    _for_training()(proxy)
+    _for_training(module, class_name)(proxy)
 
     assert not hasattr(model, "_flag_for_generation")
+    assert not hasattr(proxy, "_flag_for_generation")
+
+
+@pytest.mark.parametrize("module, class_name", SITES)
+def test_for_training_does_not_swallow_unrelated_errors(module, class_name):
+    class _Exploding(_Model):
+        def __init__(self):
+            pass
+
+        @property
+        def _flag_for_generation(self):
+            return True
+
+        @_flag_for_generation.deleter
+        def _flag_for_generation(self):
+            raise RuntimeError("must propagate")
+
+    with pytest.raises(RuntimeError):
+        _for_training(module, class_name)(_Exploding())

--- a/tests/test_for_training_generation_flag.py
+++ b/tests/test_for_training_generation_flag.py
@@ -8,8 +8,7 @@ from pathlib import Path
 
 import pytest
 
-# Both for_training sites must survive a PEFT wrapper that delegates the flag read
-# but owns nothing to delete. See issue #2490.
+# Both for_training sites must survive a delegating PEFT wrapper. See issue #2490.
 SITES = [("llama.py", "FastLlamaModel"), ("vision.py", "FastBaseModel")]
 
 

--- a/tests/test_for_training_generation_flag.py
+++ b/tests/test_for_training_generation_flag.py
@@ -1,0 +1,68 @@
+import ast
+from pathlib import Path
+
+
+def _for_training():
+    path = Path(__file__).parents[1] / "unsloth" / "models" / "llama.py"
+    tree = ast.parse(path.read_text(encoding = "utf-8"))
+    model_class = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.ClassDef) and node.name == "FastLlamaModel"
+    )
+    method = next(
+        node
+        for node in model_class.body
+        if isinstance(node, ast.FunctionDef) and node.name == "for_training"
+    )
+    module = ast.Module(body = [method], type_ignores = [])
+    namespace = {}
+    exec(compile(ast.fix_missing_locations(module), str(path), "exec"), namespace)
+    return namespace["for_training"]
+
+
+class _Model:
+    training = False
+    gradient_checkpointing = False
+
+    def __init__(self):
+        self._flag_for_generation = True
+
+    def parameters(self):
+        return ()
+
+    def modules(self):
+        return ()
+
+    def train(self):
+        self.training = True
+
+
+class _PeftProxy:
+    training = False
+
+    def __init__(self, model):
+        self.model = model
+
+    def __getattr__(self, name):
+        return getattr(self.model, name)
+
+    def parameters(self):
+        return ()
+
+    def modules(self):
+        return ()
+
+    def train(self):
+        self.training = True
+
+
+def test_for_training_deletes_a_generation_flag_delegated_by_a_peft_wrapper():
+    model = _Model()
+    proxy = _PeftProxy(model)
+    assert hasattr(proxy, "_flag_for_generation")
+    assert "_flag_for_generation" not in vars(proxy)
+
+    _for_training()(proxy)
+
+    assert not hasattr(model, "_flag_for_generation")

--- a/tests/test_for_training_generation_flag.py
+++ b/tests/test_for_training_generation_flag.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+
 import ast
 import builtins
 import os
@@ -5,14 +8,13 @@ from pathlib import Path
 
 import pytest
 
-# Both for_training implementations must survive a PEFT wrapper that delegates the
-# read of _flag_for_generation inwards but owns no attribute to delete. See issue #2490.
+# Both for_training sites must survive a PEFT wrapper that delegates the flag read
+# but owns nothing to delete. See issue #2490.
 SITES = [("llama.py", "FastLlamaModel"), ("vision.py", "FastBaseModel")]
 
 
 class _Namespace(dict):
-    """Globals for a method lifted out of its module; unused module-level helpers
-    resolve to None, which is the "feature absent" branch wherever they are read."""
+    """Globals for a method lifted out of its module; unused helpers resolve to None."""
 
     def __missing__(self, name):
         return getattr(builtins, name, None)

--- a/tests/test_for_training_generation_flag.py
+++ b/tests/test_for_training_generation_flag.py
@@ -22,9 +22,7 @@ def _for_training(module, class_name):
     path = Path(__file__).parents[1] / "unsloth" / "models" / module
     tree = ast.parse(path.read_text(encoding = "utf-8"))
     model_class = next(
-        node
-        for node in tree.body
-        if isinstance(node, ast.ClassDef) and node.name == class_name
+        node for node in tree.body if isinstance(node, ast.ClassDef) and node.name == class_name
     )
     method = next(
         node

--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -3891,7 +3891,10 @@ class FastLlamaModel:
                 m._saved_temp_tokenizer.padding_side = "right"
             # Set a flag for generation!
             if hasattr(m, "_flag_for_generation"):
-                del m._flag_for_generation
+                try:
+                    del m._flag_for_generation
+                except AttributeError:
+                    pass
 
         m = model
         while hasattr(m, "model"):

--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -3892,8 +3892,7 @@ class FastLlamaModel:
             # Set a flag for generation!
             if hasattr(m, "_flag_for_generation"):
                 try:
-                    # PEFT wrappers delegate the read inwards but own no attribute
-                    # to delete, so skip them and let the walk reach the real owner
+                    # A PEFT wrapper delegates the read but owns nothing to delete
                     del m._flag_for_generation
                 except AttributeError:
                     pass

--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -3892,6 +3892,8 @@ class FastLlamaModel:
             # Set a flag for generation!
             if hasattr(m, "_flag_for_generation"):
                 try:
+                    # PEFT wrappers delegate the read inwards but own no attribute
+                    # to delete, so skip them and let the walk reach the real owner
                     del m._flag_for_generation
                 except AttributeError:
                     pass

--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -2375,8 +2375,7 @@ class FastBaseModel:
             # Set a flag for generation!
             if hasattr(m, "_flag_for_generation"):
                 try:
-                    # PEFT wrappers delegate the read inwards but own no attribute
-                    # to delete, so skip them and let the walk reach the real owner
+                    # A PEFT wrapper delegates the read but owns nothing to delete
                     del m._flag_for_generation
                 except AttributeError:
                     pass

--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -2375,9 +2375,10 @@ class FastBaseModel:
             # Set a flag for generation!
             if hasattr(m, "_flag_for_generation"):
                 try:
-                    # Weirdly sometimes cannot succeed so do a try except
+                    # PEFT wrappers delegate the read inwards but own no attribute
+                    # to delete, so skip them and let the walk reach the real owner
                     del m._flag_for_generation
-                except:
+                except AttributeError:
                     pass
 
         m = model


### PR DESCRIPTION
## Summary

`FastLlamaModel.for_training` deleted `_flag_for_generation` unconditionally. A PEFT wrapper delegates the *read* of that attribute inwards through `__getattr__` but owns nothing to delete, so `hasattr` returns True and `del` then raises. This change tolerates that failed deletion, letting the chain walk carry on to the module that actually owns the flag.

- guard the deletion in `unsloth/models/llama.py` with `except AttributeError`
- narrow the pre-existing bare `except` on the same deletion in `unsloth/models/vision.py` to `except AttributeError`, so a real failure is no longer swallowed
- add a CPU-only regression test covering both `for_training` sites

## How it happens

`for_inference` sets the flag on every level of the chain it walks. If the model is then wrapped, or re-wrapped, by `get_peft_model`, the new `PeftModelForCausalLM` sits above modules that hold the flag but does not hold it itself. The next `for_training` call raises:

```
AttributeError: 'PeftModelForCausalLM' object has no attribute '_flag_for_generation'
```

This is why the issue reports all say it only appears once inference has run. `unsloth/models/rl.py` calls `FastLanguageModel.for_inference` and then `FastLanguageModel.for_training` around every GRPO generation step, which is how the Qwen3 GRPO notebook hits it without any explicit `for_inference` in user code.

## Validation

- `python -m pytest tests/test_for_training_generation_flag.py -q` (4 passed)
- Ruff check passed
- `py_compile` passed
- `git diff --check` passed

Fixes #2490
