### PR TITLE
Correct root license map

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -660,5 +660,11 @@ if any, to sign a "copyright disclaimer" for the program, if necessary.
 For more information on this, and how to apply and follow the GNU AGPL, see
 <https://www.gnu.org/licenses/>.
 
-Files under unsloth/*, tests/*, scripts/* are Apache 2.0 licensed.
-Files under studio/*, unsloth_cli/* which is optional to install are AGPLv3 licensed.
+Files under unsloth/*, tests/*, scripts/* are Apache 2.0 licensed where they
+do not carry a more-specific license notice.
+Files under studio/* and unsloth_cli/* are AGPL-3.0-only licensed; see
+studio/LICENSE.AGPL-3.0.
+The unsloth_cli and studio package trees are included in the base Python wheel;
+the full Studio server dependency set is provided by the optional studio extra.
+File-specific notices and the nearest nested LICENSE file take precedence over
+this path-level summary, including bundled third-party components.

--- a/COPYING
+++ b/COPYING
@@ -666,5 +666,6 @@ Files under studio/* and unsloth_cli/* are AGPL-3.0-only licensed; see
 studio/LICENSE.AGPL-3.0.
 The unsloth_cli and studio package trees are included in the base Python wheel;
 the full Studio server dependency set is provided by the optional studio extra.
-Applicable file-specific and nested license or notice files govern their
-covered components, including bundled third-party components.
+Applicable file-specific or nested license terms govern their covered
+components, including bundled third-party components; applicable notices
+remain in effect.

--- a/COPYING
+++ b/COPYING
@@ -666,5 +666,5 @@ Files under studio/* and unsloth_cli/* are AGPL-3.0-only licensed; see
 studio/LICENSE.AGPL-3.0.
 The unsloth_cli and studio package trees are included in the base Python wheel;
 the full Studio server dependency set is provided by the optional studio extra.
-File-specific notices and the nearest nested LICENSE file take precedence over
-this path-level summary, including bundled third-party components.
+Applicable file-specific and nested license or notice files govern their
+covered components, including bundled third-party components.

--- a/LICENSE
+++ b/LICENSE
@@ -193,8 +193,8 @@
    and studio/LICENSE.AGPL-3.0.
    The unsloth_cli and studio package trees are included in the base Python wheel;
    the full Studio server dependency set is provided by the optional studio extra.
-   File-specific notices and the nearest nested LICENSE file take precedence over
-   this path-level summary, including bundled third-party components.
+   Applicable file-specific and nested license or notice files govern their
+   covered components, including bundled third-party components.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/LICENSE
+++ b/LICENSE
@@ -193,8 +193,9 @@
    and studio/LICENSE.AGPL-3.0.
    The unsloth_cli and studio package trees are included in the base Python wheel;
    the full Studio server dependency set is provided by the optional studio extra.
-   Applicable file-specific and nested license or notice files govern their
-   covered components, including bundled third-party components.
+   Applicable file-specific or nested license terms govern their covered
+   components, including bundled third-party components; applicable notices
+   remain in effect.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/LICENSE
+++ b/LICENSE
@@ -187,8 +187,14 @@
       identification within third-party archives.
 
    Copyright [2024-] [Unsloth AI. Inc team, Daniel Han-Chen & Michael Han-Chen]
-   Files under unsloth/*, tests/*, scripts/* are Apache 2.0 licensed.
-   Files under studio/*, unsloth_cli/* which is optional to install are AGPLv3 licensed.
+   Files under unsloth/*, tests/*, scripts/* are Apache 2.0 licensed where they
+   do not carry a more-specific license notice.
+   Files under studio/* and unsloth_cli/* are AGPL-3.0-only licensed; see COPYING
+   and studio/LICENSE.AGPL-3.0.
+   The unsloth_cli and studio package trees are included in the base Python wheel;
+   the full Studio server dependency set is provided by the optional studio extra.
+   File-specific notices and the nearest nested LICENSE file take precedence over
+   this path-level summary, including bundled third-party components.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Summary

- make the Apache path map explicitly defer to more-specific file and nested license notices
- remove the inaccurate claim that `unsloth_cli` is optional and document that both package trees ship in the base wheel
- distinguish shipped Studio code from its optional full server dependency set
- point the AGPL paths to the repository's full AGPL license texts

## Validation

- built a fresh wheel from this branch
- verified the wheel contains `unsloth_cli`, `studio`, the `unsloth = unsloth_cli:app` entry point, and both nested MoE license files
- parsed `pyproject.toml` to verify package discovery and the `studio` optional dependency group
- `git diff --check` passed

This changes only the path-level summary; it does not change any license terms.

Fixes #8902