### PR TITLE
Fix diffusion unload leaving the model in memory

### DIFF
--- a/studio/backend/core/inference/diffusion.py
+++ b/studio/backend/core/inference/diffusion.py
@@ -4545,10 +4545,11 @@ class DiffusionBackend:
             effective_tiling,
             "; ".join(plan.reasons),
         )
+        del pipe
         if "transformer" in locals():
-            del pipe, transformer, pipe_kwargs
-        else:
-            del pipe
+            del transformer
+        if "pipe_kwargs" in locals():
+            del pipe_kwargs
         return self.status()
 
     def _load_dense_quant_pipeline(

--- a/studio/backend/core/inference/diffusion.py
+++ b/studio/backend/core/inference/diffusion.py
@@ -4545,6 +4545,10 @@ class DiffusionBackend:
             effective_tiling,
             "; ".join(plan.reasons),
         )
+        if "transformer" in locals():
+            del pipe, transformer, pipe_kwargs
+        else:
+            del pipe
         return self.status()
 
     def _load_dense_quant_pipeline(

--- a/studio/backend/tests/test_diffusion_backend.py
+++ b/studio/backend/tests/test_diffusion_backend.py
@@ -2567,6 +2567,25 @@ def test_pipeline_kind_assembles_krea_and_ideogram_from_the_mirror(fake_runtime,
     assert ideogram["repo_id"] == "ideogram-ai/ideogram-4-fp8"
 
 
+def test_krea_single_file_load_reaches_cleanup_without_pipe_kwargs(fake_runtime, monkeypatch, tmp_path):
+    from core.inference import diffusion as dmod
+
+    diffusers = sys.modules["diffusers"]
+    diffusers.Krea2Pipeline = _FakePipeline
+    diffusers.Krea2Transformer2DModel = _FakeTransformer
+    monkeypatch.setattr(dmod, "load_krea2_pipeline", lambda base, dtype, **kw: _FakePipe())
+    (tmp_path / "model.safetensors").write_bytes(b"weights")
+
+    status = DiffusionBackend().load_pipeline(
+        str(tmp_path),
+        gguf_filename = "model.safetensors",
+        base_repo = "base/repo",
+        family_override = "krea-2",
+        hf_token = "hf_secret",
+    )
+    assert status["loaded"] is True
+
+
 def test_dense_quant_pulls_the_transformer_from_the_mirror(monkeypatch):
     """The dense fallback downloads the base repo's transformer/ shards. With a nonzero baked LoRA
     the GGUF fallback is refused, so a 401 here fails the load outright."""

--- a/studio/backend/tests/test_diffusion_backend.py
+++ b/studio/backend/tests/test_diffusion_backend.py
@@ -2567,7 +2567,9 @@ def test_pipeline_kind_assembles_krea_and_ideogram_from_the_mirror(fake_runtime,
     assert ideogram["repo_id"] == "ideogram-ai/ideogram-4-fp8"
 
 
-def test_krea_single_file_load_reaches_cleanup_without_pipe_kwargs(fake_runtime, monkeypatch, tmp_path):
+def test_krea_single_file_load_reaches_cleanup_without_pipe_kwargs(
+    fake_runtime, monkeypatch, tmp_path
+):
     from core.inference import diffusion as dmod
 
     diffusers = sys.modules["diffusers"]


### PR DESCRIPTION
## What this fixes

Unloading a diffusion model does not free it. The load runs on a background thread, and after the load finishes, the thread's frame chain stays alive. load_pipeline's locals (pipe, transformer, pipe_kwargs) keep the whole pipeline referenced, so unload() drops the studio's reference but the weights stay in VRAM and RAM. Switching models a few times fills both until the machine freezes.

## Why the frame survives

The worker thread is dead (is_alive() is False, not in threading.enumerate(), not in sys._current_frames()), yet gc.collect() does not collect its frames. The thread object and its frame chain form a cycle through the C thread state, which the garbage collector cannot see. Plain threads with the same pattern (bound method, daemon, kwargs) are collected normally, so this is specific to the load path.

## The fix

Clear the pipeline references before load_pipeline returns. The pipeline kind (bnb-4bit) has no transformer local, so the del is conditional.

## Verification

Measured with the studio's own DiffusionBackend (load, unload, then read torch.cuda.memory_allocated):

- Before: VRAM stays at 13591 MiB after unload
- After: VRAM drops to 8 MiB after unload

## Repro

Run this with the studio's venv python on a CUDA host with a cached GGUF model. On an unpatched install it prints the zombie frames and the retained VRAM.

```python
import gc
import sys
import threading
import time

sys.path.insert(0, "/path/to/unsloth_studio/lib/python3.13/site-packages/studio/backend")

import torch

from core.inference.diffusion import DiffusionBackend
from core.inference.diffusion_engine_router import select_and_activate_engine

backend = DiffusionBackend()
fam = backend.validate_load_request(
    "unsloth/Z-Image-Turbo-GGUF",
    gguf_filename="z-image-turbo-Q6_K.gguf",
    model_kind="gguf",
)
select_and_activate_engine(fam, model_kind="gguf")
backend.begin_load(
    "unsloth/Z-Image-Turbo-GGUF",
    gguf_filename="z-image-turbo-Q6_K.gguf",
    base_repo="Tongyi-MAI/Z-Image-Turbo",
    memory_mode="auto",
)
deadline = time.time() + 300
while time.time() < deadline:
    st = backend.status()
    if st.get("loaded"):
        break
    time.sleep(1)

vram_loaded = torch.cuda.memory_allocated() // (1024 * 1024)
backend.unload()
time.sleep(2)
gc.collect()
time.sleep(2)
vram_after = torch.cuda.memory_allocated() // (1024 * 1024)

print(f"VRAM after load:   {vram_loaded} MiB")
print(f"VRAM after unload: {vram_after} MiB")

frames = [o for o in gc.get_objects() if type(o).__name__ == "frame"]
zombies = [f for f in frames if f.f_code.co_name in ("load_pipeline", "_run_load")]
print(f"zombie worker frames alive after unload: {len(zombies)}")
for f in zombies:
    print(f"  {f.f_code.co_name} @ {f.f_code.co_filename}:{f.f_lineno}")
```
