### PR TITLE
Studio: avoid AppImage COLRv1 font crashes

### DIFF
--- a/.github/workflows/desktop-app-clean-machine-ci.yml
+++ b/.github/workflows/desktop-app-clean-machine-ci.yml
@@ -607,7 +607,7 @@ jobs:
           RETRY_ATTEMPT_TIMEOUT: '360'
         run: |
           bash .github/scripts/retry-with-apt-lock.sh sudo sh -c \
-            'apt-get install -y -qq libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev libxdo-dev libssl-dev patchelf xdg-utils gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-libav || { apt-get update -qq && apt-get install -y -qq libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev libxdo-dev libssl-dev patchelf xdg-utils gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-libav; }'
+            'apt-get install -y -qq libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev libxdo-dev libssl-dev patchelf xdg-utils fonts-noto-color-emoji gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-libav || { apt-get update -qq && apt-get install -y -qq libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev libxdo-dev libssl-dev patchelf xdg-utils fonts-noto-color-emoji gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-libav; }'
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:

--- a/.github/workflows/desktop-app-clean-machine-ci.yml
+++ b/.github/workflows/desktop-app-clean-machine-ci.yml
@@ -862,6 +862,13 @@ jobs:
           bash .github/scripts/retry-with-apt-lock.sh sudo sh -c \
             'apt-get install -y -qq --no-install-recommends python3 xvfb xauth webkit2gtk-driver libgles2 libgl1 libegl1 libgbm1 libwayland-client0 libharfbuzz0b libnghttp2-14 fontconfig libfribidi0 libasound2 libpulse0 || { apt-get update -qq && apt-get install -y -qq --no-install-recommends python3 xvfb xauth webkit2gtk-driver libgles2 libgl1 libegl1 libgbm1 libwayland-client0 libharfbuzz0b libnghttp2-14 fontconfig libfribidi0 libasound2 libpulse0; }'
           cargo install tauri-driver --version 2.0.6 --locked
+      - name: Fetch the digest-pinned COLRv1 regression font
+        run: |
+          set -euo pipefail
+          url='https://raw.githubusercontent.com/googlefonts/noto-emoji/8998f5dd683424a73e2314a8c1f1e359c19e8742/fonts/Noto-COLRv1.ttf'
+          output="$RUNNER_TEMP/Noto-COLRv1.ttf"
+          curl -fsSL --retry 3 --retry-all-errors "$url" -o "$output"
+          echo '0ae57fe58645638523ba35f388d93739d292539a9acb84df5700c81b1e1a28d2  '"$output" | sha256sum -c -
 
       - name: Download the AppImage built from this PR
         if: github.event_name == 'pull_request'
@@ -900,6 +907,8 @@ jobs:
         env:
           APPIMAGE_PATH: ${{ github.workspace }}/dl/Unsloth.AppImage
           APPIMAGE_E2E_ART_DIR: ${{ github.workspace }}/logs/appimage-model-download
+          APPIMAGE_COLRV1_FONT: ${{ runner.temp }}/Noto-COLRv1.ttf
+          APPIMAGE_COLRV1_FONT_SHA256: 0ae57fe58645638523ba35f388d93739d292539a9acb84df5700c81b1e1a28d2
         run: |
           set -euo pipefail
           appimage="$(find dl -maxdepth 1 -type f -name '*.AppImage' -print -quit)"

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -570,7 +570,7 @@ jobs:
         run: |
           # Install the GStreamer plugins needed for H.264 playback and capture.
           bash .github/scripts/retry-with-apt-lock.sh sudo sh -c \
-            'apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev libxdo-dev libssl-dev patchelf xdg-utils gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-libav || { apt-get update && apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev libxdo-dev libssl-dev patchelf xdg-utils gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-libav; }'
+            'apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev libxdo-dev libssl-dev patchelf xdg-utils fonts-noto-color-emoji gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-libav || { apt-get update && apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev libxdo-dev libssl-dev patchelf xdg-utils fonts-noto-color-emoji gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-libav; }'
 
       # ── Node.js ──
       - name: Setup Node.js

--- a/studio/src-tauri/linux/appimage-apprun.sh
+++ b/studio/src-tauri/linux/appimage-apprun.sh
@@ -11,12 +11,17 @@ export APPDIR PATH
 
 # Keep Jammy's Skia off host COLRv1 fonts. Fontconfig 2.13 misresolves relative
 # font paths, so materialize this mount's absolute path in user-owned state.
+# The path carries the AppImage's own file name, so encode it for XML and for
+# sed on the way in; the cleanup below decodes it on the way back out.
 unsloth_fonts_template="$APPDIR/usr/etc/fonts/unsloth-appimage.conf"
 unsloth_fonts_state="${XDG_RUNTIME_DIR:-${XDG_CACHE_HOME:-${HOME:-}/.cache}}/unsloth-studio"
 FONTCONFIG_FILE="$unsloth_fonts_template"
 if [ -r "$unsloth_fonts_template" ] &&
   mkdir -p "$unsloth_fonts_state" 2>/dev/null &&
-  sed "s|@APPDIR@|$APPDIR|g" "$unsloth_fonts_template" \
+  unsloth_fonts_appdir="$(printf '%s' "$APPDIR" | sed \
+    -e 's,&,\&amp;,g' -e 's,<,\&lt;,g' -e 's,>,\&gt;,g' \
+    -e 's,\\,\\\\,g' -e 's,&,\\&,g' -e 's,|,\\|,g')" &&
+  sed "s|@APPDIR@|$unsloth_fonts_appdir|g" "$unsloth_fonts_template" \
     >"$unsloth_fonts_state/fonts-${APPDIR##*/}.conf" 2>/dev/null; then
   FONTCONFIG_FILE="$unsloth_fonts_state/fonts-${APPDIR##*/}.conf"
   # Preserve policies for live mounts and remove only departed ones.
@@ -24,13 +29,14 @@ if [ -r "$unsloth_fonts_template" ] &&
     [ -f "$unsloth_stale" ] || continue
     [ "$unsloth_stale" != "$FONTCONFIG_FILE" ] || continue
     unsloth_stale_mount="$(sed -n 's|^[[:space:]]*<dir>\(.*\)/usr/share/unsloth/fonts</dir>.*|\1|p' \
-      "$unsloth_stale" 2>/dev/null | head -1)"
+      "$unsloth_stale" 2>/dev/null | head -1 |
+      sed -e 's,&lt;,<,g' -e 's,&gt;,>,g' -e 's,&amp;,\&,g')"
     [ -n "$unsloth_stale_mount" ] && [ -d "$unsloth_stale_mount" ] || rm -f "$unsloth_stale"
   done
   unset unsloth_stale unsloth_stale_mount
 fi
 export FONTCONFIG_FILE
-unset unsloth_fonts_template unsloth_fonts_state
+unset unsloth_fonts_appdir unsloth_fonts_template unsloth_fonts_state
 
 # The loader reads LD_LIBRARY_PATH before those RUNPATHs, so an inherited value would put
 # host GLib, GTK, WebKit or GStreamer in front of the bundle. Managed children still get it;

--- a/studio/src-tauri/linux/appimage-apprun.sh
+++ b/studio/src-tauri/linux/appimage-apprun.sh
@@ -24,10 +24,19 @@ if [ -r "$unsloth_fonts_template" ] &&
   sed "s|@APPDIR@|$APPDIR|g" "$unsloth_fonts_template" \
     >"$unsloth_fonts_state/fonts-${APPDIR##*/}.conf" 2>/dev/null; then
   FONTCONFIG_FILE="$unsloth_fonts_state/fonts-${APPDIR##*/}.conf"
-  # Each mount gets its own name, so a second AppImage cannot repoint the first
-  # one's policy mid-run. Yesterday's mounts are gone; their copies can go too.
-  find "$unsloth_fonts_state" -maxdepth 1 -name 'fonts-*.conf' -mtime +1 \
-    ! -name "fonts-${APPDIR##*/}.conf" -delete 2>/dev/null || true
+  # Each mount gets its own name, so a second instance cannot repoint the first
+  # one's policy mid-run. Drop only the copies whose mount is gone: an age-based
+  # sweep would delete a live instance's copy out from under it, and its next
+  # WebKit helper would start with an unreadable FONTCONFIG_FILE, back on the
+  # host's COLRv1 font and back to the crash this file exists to prevent.
+  for unsloth_stale in "$unsloth_fonts_state"/fonts-*.conf; do
+    [ -f "$unsloth_stale" ] || continue
+    [ "$unsloth_stale" != "$FONTCONFIG_FILE" ] || continue
+    unsloth_stale_mount="$(sed -n 's|^[[:space:]]*<dir>\(.*\)/usr/share/unsloth/fonts</dir>.*|\1|p' \
+      "$unsloth_stale" 2>/dev/null | head -1)"
+    [ -n "$unsloth_stale_mount" ] && [ -d "$unsloth_stale_mount" ] || rm -f "$unsloth_stale"
+  done
+  unset unsloth_stale unsloth_stale_mount
 fi
 export FONTCONFIG_FILE
 unset unsloth_fonts_template unsloth_fonts_state

--- a/studio/src-tauri/linux/appimage-apprun.sh
+++ b/studio/src-tauri/linux/appimage-apprun.sh
@@ -9,13 +9,8 @@ APPDIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)
 PATH="$APPDIR/usr/bin:$APPDIR/usr/sbin:${PATH:-/usr/local/bin:/usr/bin:/bin}"
 export APPDIR PATH
 
-# Keep WebKitGTK on the bundled CBDT emoji font. Jammy's Skia can abort when a
-# newer host FreeType selects a COLRv1 font, while host text fonts remain usable.
-# The policy carries this mount's AppDir because Fontconfig has no portable way
-# to name a directory relative to the config file: prefix="relative" arrived in
-# 2.14, and 2.13 hosts such as Ubuntu 22.04 anchor such a path at the host root.
-# Materialize it in a directory this user owns; a shared /tmp path would let
-# anyone else on the machine choose what this process treats as a font policy.
+# Keep Jammy's Skia off host COLRv1 fonts. Fontconfig 2.13 misresolves relative
+# font paths, so materialize this mount's absolute path in user-owned state.
 unsloth_fonts_template="$APPDIR/usr/etc/fonts/unsloth-appimage.conf"
 unsloth_fonts_state="${XDG_RUNTIME_DIR:-${XDG_CACHE_HOME:-${HOME:-}/.cache}}/unsloth-studio"
 FONTCONFIG_FILE="$unsloth_fonts_template"
@@ -24,11 +19,7 @@ if [ -r "$unsloth_fonts_template" ] &&
   sed "s|@APPDIR@|$APPDIR|g" "$unsloth_fonts_template" \
     >"$unsloth_fonts_state/fonts-${APPDIR##*/}.conf" 2>/dev/null; then
   FONTCONFIG_FILE="$unsloth_fonts_state/fonts-${APPDIR##*/}.conf"
-  # Each mount gets its own name, so a second instance cannot repoint the first
-  # one's policy mid-run. Drop only the copies whose mount is gone: an age-based
-  # sweep would delete a live instance's copy out from under it, and its next
-  # WebKit helper would start with an unreadable FONTCONFIG_FILE, back on the
-  # host's COLRv1 font and back to the crash this file exists to prevent.
+  # Preserve policies for live mounts and remove only departed ones.
   for unsloth_stale in "$unsloth_fonts_state"/fonts-*.conf; do
     [ -f "$unsloth_stale" ] || continue
     [ "$unsloth_stale" != "$FONTCONFIG_FILE" ] || continue

--- a/studio/src-tauri/linux/appimage-apprun.sh
+++ b/studio/src-tauri/linux/appimage-apprun.sh
@@ -11,8 +11,26 @@ export APPDIR PATH
 
 # Keep WebKitGTK on the bundled CBDT emoji font. Jammy's Skia can abort when a
 # newer host FreeType selects a COLRv1 font, while host text fonts remain usable.
-FONTCONFIG_FILE="$APPDIR/usr/etc/fonts/unsloth-appimage.conf"
+# The policy carries this mount's AppDir because Fontconfig has no portable way
+# to name a directory relative to the config file: prefix="relative" arrived in
+# 2.14, and 2.13 hosts such as Ubuntu 22.04 anchor such a path at the host root.
+# Materialize it in a directory this user owns; a shared /tmp path would let
+# anyone else on the machine choose what this process treats as a font policy.
+unsloth_fonts_template="$APPDIR/usr/etc/fonts/unsloth-appimage.conf"
+unsloth_fonts_state="${XDG_RUNTIME_DIR:-${XDG_CACHE_HOME:-${HOME:-}/.cache}}/unsloth-studio"
+FONTCONFIG_FILE="$unsloth_fonts_template"
+if [ -r "$unsloth_fonts_template" ] &&
+  mkdir -p "$unsloth_fonts_state" 2>/dev/null &&
+  sed "s|@APPDIR@|$APPDIR|g" "$unsloth_fonts_template" \
+    >"$unsloth_fonts_state/fonts-${APPDIR##*/}.conf" 2>/dev/null; then
+  FONTCONFIG_FILE="$unsloth_fonts_state/fonts-${APPDIR##*/}.conf"
+  # Each mount gets its own name, so a second AppImage cannot repoint the first
+  # one's policy mid-run. Yesterday's mounts are gone; their copies can go too.
+  find "$unsloth_fonts_state" -maxdepth 1 -name 'fonts-*.conf' -mtime +1 \
+    ! -name "fonts-${APPDIR##*/}.conf" -delete 2>/dev/null || true
+fi
 export FONTCONFIG_FILE
+unset unsloth_fonts_template unsloth_fonts_state
 
 # The loader reads LD_LIBRARY_PATH before those RUNPATHs, so an inherited value would put
 # host GLib, GTK, WebKit or GStreamer in front of the bundle. Managed children still get it;

--- a/studio/src-tauri/linux/appimage-apprun.sh
+++ b/studio/src-tauri/linux/appimage-apprun.sh
@@ -9,6 +9,11 @@ APPDIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)
 PATH="$APPDIR/usr/bin:$APPDIR/usr/sbin:${PATH:-/usr/local/bin:/usr/bin:/bin}"
 export APPDIR PATH
 
+# Keep WebKitGTK on the bundled CBDT emoji font. Jammy's Skia can abort when a
+# newer host FreeType selects a COLRv1 font, while host text fonts remain usable.
+FONTCONFIG_FILE="$APPDIR/usr/etc/fonts/unsloth-appimage.conf"
+export FONTCONFIG_FILE
+
 # The loader reads LD_LIBRARY_PATH before those RUNPATHs, so an inherited value would put
 # host GLib, GTK, WebKit or GStreamer in front of the bundle. Managed children still get it;
 # the guard keeps a restart of an already-cleared process from erasing the saved value.

--- a/studio/src-tauri/linux/appimage-fonts.conf
+++ b/studio/src-tauri/linux/appimage-fonts.conf
@@ -13,7 +13,22 @@
     <edit name="family" mode="assign">
       <string>Unsloth Safe Emoji</string>
     </edit>
+
+    <!-- Keep this vetted CBDT font available while the filter below removes
+         every host-provided color font, including incompatible COLRv1 fonts. -->
+    <edit name="color" mode="assign">
+      <bool>false</bool>
+    </edit>
   </match>
+
+
+  <selectfont>
+    <rejectfont>
+      <pattern>
+        <patelt name="color"><bool>true</bool></patelt>
+      </pattern>
+    </rejectfont>
+  </selectfont>
 
   <!-- The Jammy WebKitGTK/Skia build can abort when a newer host FreeType picks
        a COLRv1 emoji font. Prefer the bundled CBDT font for every glyph it has;

--- a/studio/src-tauri/linux/appimage-fonts.conf
+++ b/studio/src-tauri/linux/appimage-fonts.conf
@@ -3,10 +3,7 @@
 <fontconfig>
   <include ignore_missing="yes">/etc/fonts/fonts.conf</include>
 
-  <!-- AppRun substitutes this mount's AppDir before pointing FONTCONFIG_FILE
-       here. A prefix="relative" path would look right and silently miss:
-       Fontconfig before 2.14 ignores that attribute and anchors the path at
-       the host root, so Jammy-era hosts would scan /share/unsloth/fonts. -->
+  <!-- AppRun replaces @APPDIR@ because Fontconfig 2.13 misresolves relative paths. -->
   <dir>@APPDIR@/usr/share/unsloth/fonts</dir>
 
   <!-- Give the AppImage-owned CBDT font a private family name. Host fonts with
@@ -20,10 +17,7 @@
     </edit>
   </match>
 
-  <!-- Drop every host color font, COLRv1 ones included, and keep this vetted
-       CBDT font. acceptfont outranks rejectfont, so the bundled font keeps its
-       real color=true and still answers the color-emoji queries WebKitGTK and
-       Fontconfig's own und-zsye rules make. -->
+  <!-- Keep bundled CBDT emoji while rejecting host color fonts, including COLRv1. -->
   <selectfont>
     <acceptfont>
       <pattern>
@@ -37,11 +31,7 @@
     </rejectfont>
   </selectfont>
 
-  <!-- The Jammy WebKitGTK/Skia build can abort when a newer host FreeType picks
-       a COLRv1 emoji font. The filter above already leaves the bundled CBDT font
-       as the only color font, so these rules only have to route emoji to it.
-       und-zsye is the emoji script tag Fontconfig and toolkits tag such runs
-       with; emoji is the generic family they resolve. -->
+  <!-- Route emoji-family and und-zsye requests to the safe font. -->
   <match target="pattern">
     <test name="lang">
       <string>und-zsye</string>
@@ -59,10 +49,7 @@
     </edit>
   </match>
 
-  <!-- Back the text families up without displacing them. An unconditional
-       strong prepend would win FcFontMatch for every request, and WebKitGTK
-       would then draw ordinary text out of the emoji font, spaces and digits
-       included, since a CBDT emoji font covers both. -->
+  <!-- Add emoji fallback without displacing host text fonts. -->
   <match target="pattern">
     <test name="family">
       <string>sans-serif</string>

--- a/studio/src-tauri/linux/appimage-fonts.conf
+++ b/studio/src-tauri/linux/appimage-fonts.conf
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<!DOCTYPE fontconfig SYSTEM "urn:fontconfig:fonts.dtd">
+<fontconfig>
+  <include ignore_missing="yes">/etc/fonts/fonts.conf</include>
+  <dir prefix="relative">../../share/unsloth/fonts</dir>
+
+  <!-- Give the AppImage-owned CBDT font a private family name. Host fonts with
+       the same upstream family can then never win this preference. -->
+  <match target="scan">
+    <test name="file" compare="contains">
+      <string>/share/unsloth/fonts/</string>
+    </test>
+    <edit name="family" mode="assign">
+      <string>Unsloth Safe Emoji</string>
+    </edit>
+  </match>
+
+  <!-- The Jammy WebKitGTK/Skia build can abort when a newer host FreeType picks
+       a COLRv1 emoji font. Prefer the bundled CBDT font for every glyph it has;
+       normal text falls through to the user's configured fonts. -->
+  <match target="pattern">
+    <edit name="family" mode="prepend" binding="strong">
+      <string>Unsloth Safe Emoji</string>
+    </edit>
+  </match>
+</fontconfig>

--- a/studio/src-tauri/linux/appimage-fonts.conf
+++ b/studio/src-tauri/linux/appimage-fonts.conf
@@ -2,7 +2,12 @@
 <!DOCTYPE fontconfig SYSTEM "urn:fontconfig:fonts.dtd">
 <fontconfig>
   <include ignore_missing="yes">/etc/fonts/fonts.conf</include>
-  <dir prefix="relative">../../share/unsloth/fonts</dir>
+
+  <!-- AppRun substitutes this mount's AppDir before pointing FONTCONFIG_FILE
+       here. A prefix="relative" path would look right and silently miss:
+       Fontconfig before 2.14 ignores that attribute and anchors the path at
+       the host root, so Jammy-era hosts would scan /share/unsloth/fonts. -->
+  <dir>@APPDIR@/usr/share/unsloth/fonts</dir>
 
   <!-- Give the AppImage-owned CBDT font a private family name. Host fonts with
        the same upstream family can then never win this preference. -->
@@ -13,16 +18,18 @@
     <edit name="family" mode="assign">
       <string>Unsloth Safe Emoji</string>
     </edit>
-
-    <!-- Keep this vetted CBDT font available while the filter below removes
-         every host-provided color font, including incompatible COLRv1 fonts. -->
-    <edit name="color" mode="assign">
-      <bool>false</bool>
-    </edit>
   </match>
 
-
+  <!-- Drop every host color font, COLRv1 ones included, and keep this vetted
+       CBDT font. acceptfont outranks rejectfont, so the bundled font keeps its
+       real color=true and still answers the color-emoji queries WebKitGTK and
+       Fontconfig's own und-zsye rules make. -->
   <selectfont>
+    <acceptfont>
+      <pattern>
+        <patelt name="family"><string>Unsloth Safe Emoji</string></patelt>
+      </pattern>
+    </acceptfont>
     <rejectfont>
       <pattern>
         <patelt name="color"><bool>true</bool></patelt>
@@ -31,10 +38,52 @@
   </selectfont>
 
   <!-- The Jammy WebKitGTK/Skia build can abort when a newer host FreeType picks
-       a COLRv1 emoji font. Prefer the bundled CBDT font for every glyph it has;
-       normal text falls through to the user's configured fonts. -->
+       a COLRv1 emoji font. The filter above already leaves the bundled CBDT font
+       as the only color font, so these rules only have to route emoji to it.
+       und-zsye is the emoji script tag Fontconfig and toolkits tag such runs
+       with; emoji is the generic family they resolve. -->
   <match target="pattern">
+    <test name="lang">
+      <string>und-zsye</string>
+    </test>
     <edit name="family" mode="prepend" binding="strong">
+      <string>Unsloth Safe Emoji</string>
+    </edit>
+  </match>
+  <match target="pattern">
+    <test name="family">
+      <string>emoji</string>
+    </test>
+    <edit name="family" mode="prepend" binding="strong">
+      <string>Unsloth Safe Emoji</string>
+    </edit>
+  </match>
+
+  <!-- Back the text families up without displacing them. An unconditional
+       strong prepend would win FcFontMatch for every request, and WebKitGTK
+       would then draw ordinary text out of the emoji font, spaces and digits
+       included, since a CBDT emoji font covers both. -->
+  <match target="pattern">
+    <test name="family">
+      <string>sans-serif</string>
+    </test>
+    <edit name="family" mode="append" binding="weak">
+      <string>Unsloth Safe Emoji</string>
+    </edit>
+  </match>
+  <match target="pattern">
+    <test name="family">
+      <string>serif</string>
+    </test>
+    <edit name="family" mode="append" binding="weak">
+      <string>Unsloth Safe Emoji</string>
+    </edit>
+  </match>
+  <match target="pattern">
+    <test name="family">
+      <string>monospace</string>
+    </test>
+    <edit name="family" mode="append" binding="weak">
       <string>Unsloth Safe Emoji</string>
     </edit>
   </match>

--- a/studio/src-tauri/linux/finalize-complete-appimage.sh
+++ b/studio/src-tauri/linux/finalize-complete-appimage.sh
@@ -17,6 +17,23 @@ libdir="$appdir/usr/lib"
 [[ -d "$libdir" ]] || { echo "AppDir has no usr/lib: $appdir" >&2; exit 1; }
 command -v patchelf >/dev/null || { echo "patchelf is required" >&2; exit 1; }
 
+asset_dir="$(cd -- "$(dirname -- "$0")" && pwd -P)"
+for asset in UnslothSafeEmoji.ttf UnslothSafeEmoji.LICENSE unsloth-appimage-fonts.conf; do
+  [[ -f "$asset_dir/$asset" ]] || {
+    echo "Complete AppImage asset is missing: $asset_dir/$asset" >&2
+    exit 1
+  }
+done
+install -D -m 644 \
+  "$asset_dir/UnslothSafeEmoji.ttf" \
+  "$appdir/usr/share/unsloth/fonts/UnslothSafeEmoji.ttf"
+install -D -m 644 \
+  "$asset_dir/UnslothSafeEmoji.LICENSE" \
+  "$appdir/usr/share/doc/unsloth-safe-emoji/copyright"
+install -D -m 644 \
+  "$asset_dir/unsloth-appimage-fonts.conf" \
+  "$appdir/usr/etc/fonts/unsloth-appimage.conf"
+
 # Remove host-coupled libraries after all input plugins deploy their dependencies.
 host_patterns=(
   'ld-linux*.so*' 'libc.so*' 'libm.so*' 'libdl.so*' 'libpthread.so*'

--- a/studio/src-tauri/linux/prepare-complete-appimage-tools.sh
+++ b/studio/src-tauri/linux/prepare-complete-appimage-tools.sh
@@ -13,6 +13,17 @@ tools_dir="$1"
 mkdir -p "$tools_dir"
 
 script_dir="$(cd -- "$(dirname -- "$0")" && pwd -P)"
+
+safe_emoji_font="/usr/share/fonts/truetype/noto/NotoColorEmoji.ttf"
+safe_emoji_license="/usr/share/doc/fonts-noto-color-emoji/copyright"
+[[ -f "$safe_emoji_font" ]] || {
+  echo "fonts-noto-color-emoji is required: $safe_emoji_font" >&2
+  exit 1
+}
+[[ -f "$safe_emoji_license" ]] || {
+  echo "fonts-noto-color-emoji license is required: $safe_emoji_license" >&2
+  exit 1
+}
 LINUXDEPLOY_URL="https://github.com/tauri-apps/binary-releases/releases/download/linuxdeploy/linuxdeploy-x86_64.AppImage"
 LINUXDEPLOY_SHA256="e762bea85c8eb0d4b3508d46e5c1f037f717d0f9303ae3b4aafc8b04991fa1ef"
 GTK_PLUGIN_URL="https://raw.githubusercontent.com/tauri-apps/linuxdeploy-plugin-gtk/b5eb8d05b4c0ed40107fe2158c5d8527f94568ef/linuxdeploy-plugin-gtk.sh"
@@ -43,6 +54,9 @@ install -m 755 \
   "$script_dir/finalize-complete-appimage.sh" \
   "$tools_dir/finalize-complete-appimage.sh"
 
+install -m 644 "$script_dir/appimage-fonts.conf" "$tools_dir/unsloth-appimage-fonts.conf"
+install -m 644 "$safe_emoji_font" "$tools_dir/UnslothSafeEmoji.ttf"
+install -m 644 "$safe_emoji_license" "$tools_dir/UnslothSafeEmoji.LICENSE"
 
 # Let GTK select X11 or Wayland instead of forcing X11.
 sed -i '/export GDK_BACKEND=x11/d' "$tools_dir/linuxdeploy-plugin-gtk.sh"

--- a/studio/src-tauri/linux/verify-complete-appimage.sh
+++ b/studio/src-tauri/linux/verify-complete-appimage.sh
@@ -118,9 +118,7 @@ grep -Fq 'sed "s|@APPDIR@|$APPDIR|g" "$unsloth_fonts_template"' "${launchers[@]}
   exit 1
 }
 
-# Prove the policy under the fontconfig this machine runs, not by reading it.
-# The Jammy build host and the portability images span 2.13 to 2.15, and the
-# 2.13 behavior above is invisible to any text search of the config.
+# Exercise the policy with the host Fontconfig, including version 2.13.
 if command -v fc-match >/dev/null && command -v fc-query >/dev/null &&
   fc-query "$safe_emoji_font" >/dev/null 2>&1; then
   fc_root="$(mktemp -d "${RUNNER_TEMP:-/tmp}/unsloth-appimage-fc.XXXXXX")"

--- a/studio/src-tauri/linux/verify-complete-appimage.sh
+++ b/studio/src-tauri/linux/verify-complete-appimage.sh
@@ -109,10 +109,46 @@ grep -Fq 'Unsloth Safe Emoji' "$fontconfig_file" || {
   echo "Complete AppImage fontconfig does not prefer its safe emoji family" >&2
   exit 1
 }
-grep -Fq 'FONTCONFIG_FILE="$APPDIR/usr/etc/fonts/unsloth-appimage.conf"' "${launchers[@]}" || {
+grep -Fq '@APPDIR@/usr/share/unsloth/fonts' "$fontconfig_file" || {
+  echo "Complete AppImage fontconfig does not name its font directory absolutely" >&2
+  exit 1
+}
+grep -Fq 'sed "s|@APPDIR@|$APPDIR|g" "$unsloth_fonts_template"' "${launchers[@]}" || {
   echo "Complete AppImage does not pin fontconfig to its safe emoji policy" >&2
   exit 1
 }
+
+# Prove the policy under the fontconfig this machine runs, not by reading it.
+# The Jammy build host and the portability images span 2.13 to 2.15, and the
+# 2.13 behavior above is invisible to any text search of the config.
+if command -v fc-match >/dev/null && command -v fc-query >/dev/null &&
+  fc-query "$safe_emoji_font" >/dev/null 2>&1; then
+  fc_root="$(mktemp -d "${RUNNER_TEMP:-/tmp}/unsloth-appimage-fc.XXXXXX")"
+  sed "s|@APPDIR@|$appdir|g" "$fontconfig_file" >"$fc_root/fonts.conf"
+  selected="$(FONTCONFIG_FILE="$fc_root/fonts.conf" XDG_CACHE_HOME="$fc_root" \
+    fc-match -f '%{file}' 'sans-serif:charset=1f680')"
+  if [[ "$selected" != "$safe_emoji_font" ]]; then
+    echo "Complete AppImage fontconfig picks ${selected:-nothing} for U+1F680," \
+      "not its bundled safe emoji font" >&2
+    rm -rf -- "$fc_root"
+    exit 1
+  fi
+  # Emoji coverage must not cost the host's text fonts their own requests.
+  text_font="$(FONTCONFIG_FILE="$fc_root/fonts.conf" XDG_CACHE_HOME="$fc_root" \
+    fc-match -f '%{file}' 'sans-serif:charset=41')"
+  if [[ -n "$text_font" && "$text_font" != "$safe_emoji_font" ]]; then
+    for family in sans-serif serif monospace; do
+      chosen="$(FONTCONFIG_FILE="$fc_root/fonts.conf" XDG_CACHE_HOME="$fc_root" \
+        fc-match -f '%{file}' "$family")"
+      [[ "$chosen" != "$safe_emoji_font" ]] || {
+        echo "Complete AppImage fontconfig hands $family to the emoji font" >&2
+        rm -rf -- "$fc_root"
+        exit 1
+      }
+    done
+  fi
+  rm -rf -- "$fc_root"
+fi
 
 if ! grep -Rqs 'GIO_MODULE_DIR=' \
   "$appdir/AppRun" "$appdir/apprun-hooks" "$appdir/usr/lib" 2>/dev/null; then

--- a/studio/src-tauri/linux/verify-complete-appimage.sh
+++ b/studio/src-tauri/linux/verify-complete-appimage.sh
@@ -86,6 +86,34 @@ if ! grep -aEq '^[[:space:]]*unset[[:space:]]+LD_LIBRARY_PATH([[:space:]]|$)' \
   exit 1
 fi
 
+safe_emoji_font="$appdir/usr/share/unsloth/fonts/UnslothSafeEmoji.ttf"
+safe_emoji_license="$appdir/usr/share/doc/unsloth-safe-emoji/copyright"
+fontconfig_file="$appdir/usr/etc/fonts/unsloth-appimage.conf"
+for required_file in "$safe_emoji_font" "$safe_emoji_license" "$fontconfig_file"; do
+  [[ -f "$required_file" ]] || {
+    echo "Complete AppImage is missing safe emoji runtime file: $required_file" >&2
+    exit 1
+  }
+done
+for table in CBDT CBLC; do
+  grep -aFq "$table" "$safe_emoji_font" || {
+    echo "Complete AppImage safe emoji font has no $table bitmap table" >&2
+    exit 1
+  }
+done
+if grep -aFq 'COLR' "$safe_emoji_font"; then
+  echo "Complete AppImage safe emoji font unexpectedly contains a COLR table" >&2
+  exit 1
+fi
+grep -Fq 'Unsloth Safe Emoji' "$fontconfig_file" || {
+  echo "Complete AppImage fontconfig does not prefer its safe emoji family" >&2
+  exit 1
+}
+grep -Fq 'FONTCONFIG_FILE="$APPDIR/usr/etc/fonts/unsloth-appimage.conf"' "${launchers[@]}" || {
+  echo "Complete AppImage does not pin fontconfig to its safe emoji policy" >&2
+  exit 1
+}
+
 if ! grep -Rqs 'GIO_MODULE_DIR=' \
   "$appdir/AppRun" "$appdir/apprun-hooks" "$appdir/usr/lib" 2>/dev/null; then
   echo "Complete AppImage does not isolate bundled GIO modules" >&2

--- a/studio/src-tauri/linux/verify-complete-appimage.sh
+++ b/studio/src-tauri/linux/verify-complete-appimage.sh
@@ -113,8 +113,13 @@ grep -Fq '@APPDIR@/usr/share/unsloth/fonts' "$fontconfig_file" || {
   echo "Complete AppImage fontconfig does not name its font directory absolutely" >&2
   exit 1
 }
-grep -Fq 'sed "s|@APPDIR@|$APPDIR|g" "$unsloth_fonts_template"' "${launchers[@]}" || {
+grep -Fq 'sed "s|@APPDIR@|$unsloth_fonts_appdir|g" "$unsloth_fonts_template"' "${launchers[@]}" || {
   echo "Complete AppImage does not pin fontconfig to its safe emoji policy" >&2
+  exit 1
+}
+# A mount path carries the AppImage's own file name, so it reaches the policy encoded.
+grep -Fq "s,&,\\&amp;,g" "${launchers[@]}" || {
+  echo "Complete AppImage does not encode its mount path for the fontconfig policy" >&2
   exit 1
 }
 
@@ -122,7 +127,11 @@ grep -Fq 'sed "s|@APPDIR@|$APPDIR|g" "$unsloth_fonts_template"' "${launchers[@]}
 if command -v fc-match >/dev/null && command -v fc-query >/dev/null &&
   fc-query "$safe_emoji_font" >/dev/null 2>&1; then
   fc_root="$(mktemp -d "${RUNNER_TEMP:-/tmp}/unsloth-appimage-fc.XXXXXX")"
-  sed "s|@APPDIR@|$appdir|g" "$fontconfig_file" >"$fc_root/fonts.conf"
+  # Encode the AppDir exactly as AppRun does, so this exercises the shipped policy.
+  fc_appdir="$(printf '%s' "$appdir" | sed \
+    -e 's,&,\&amp;,g' -e 's,<,\&lt;,g' -e 's,>,\&gt;,g' \
+    -e 's,\\,\\\\,g' -e 's,&,\\&,g' -e 's,|,\\|,g')"
+  sed "s|@APPDIR@|$fc_appdir|g" "$fontconfig_file" >"$fc_root/fonts.conf"
   selected="$(FONTCONFIG_FILE="$fc_root/fonts.conf" XDG_CACHE_HOME="$fc_root" \
     fc-match -f '%{file}' 'sans-serif:charset=1f680')"
   if [[ "$selected" != "$safe_emoji_font" ]]; then

--- a/studio/src-tauri/src/process.rs
+++ b/studio/src-tauri/src/process.rs
@@ -64,6 +64,7 @@ pub(crate) fn scrub_appimage_python_env(cmd: &mut Command) {
 // Restore a host-safe environment before launching browsers and file managers.
 #[cfg(target_os = "linux")]
 const APPIMAGE_GUI_ONLY_VARS: &[&str] = &[
+    "FONTCONFIG_FILE",
     "GIO_MODULE_DIR",
     "GIO_EXTRA_MODULES",
     "GTK_PATH",
@@ -313,7 +314,8 @@ mod appimage_environment_tests {
         );
         std::env::set_var("PATH", "/tmp/.mount_Unsloth/usr/bin:/usr/bin:/bin");
         let mut cmd = Command::new("/usr/bin/env");
-        cmd.env("GTK_PATH", "/tmp/.mount_Unsloth/usr/lib/gtk-3.0")
+        cmd.env("FONTCONFIG_FILE", "/tmp/.mount_Unsloth/usr/etc/fonts/fonts.conf")
+            .env("GTK_PATH", "/tmp/.mount_Unsloth/usr/lib/gtk-3.0")
             .env("QT_PLUGIN_PATH", "/tmp/.mount_Unsloth/usr/lib/qt5/plugins")
             .env("PYTHONPATH", "/tmp/.mount_Unsloth/usr/share/pyshared");
         scrub_appimage_launcher_env(&mut cmd);
@@ -322,6 +324,7 @@ mod appimage_environment_tests {
         // The host's own GLib binaries must win, and the bundled tools stay last.
         assert!(env.contains("LD_LIBRARY_PATH=/opt/cuda/lib64"));
         assert!(env.contains("PATH=/usr/bin:/bin:/tmp/.mount_Unsloth/usr/bin"));
+        assert!(!env.contains("FONTCONFIG_FILE="));
         assert!(!env.contains("GTK_PATH="));
         assert!(!env.contains("QT_PLUGIN_PATH="));
         assert!(!env.contains("PYTHONPATH="));

--- a/tests/security/test_release_desktop_appimage.py
+++ b/tests/security/test_release_desktop_appimage.py
@@ -2,6 +2,7 @@
 
 import json
 import re
+import shutil
 import subprocess
 from pathlib import Path
 from xml.etree import ElementTree
@@ -477,10 +478,10 @@ def test_complete_appimage_verifier_rejects_global_library_path_and_missing_orig
     assert "$ORIGIN-relative RUNPATH" in result.stderr
 
 
-def test_apprun_hands_an_inherited_library_path_to_children_only(tmp_path):
-    """The loader reads LD_LIBRARY_PATH before the bundle's own $ORIGIN RUNPATHs."""
+def _apprun_mount(tmp_path: Path, name: str = "AppDir") -> Path:
+    """An AppDir holding just what AppRun itself touches."""
 
-    appdir = tmp_path / "AppDir"
+    appdir = tmp_path / name
     binary = appdir / "usr/bin/unsloth-studio"
     binary.parent.mkdir(parents = True)
     binary.write_text("#!/bin/sh\nexec /usr/bin/env\n", encoding = "utf-8")
@@ -491,6 +492,15 @@ def test_apprun_hands_an_inherited_library_path_to_children_only(tmp_path):
     template = appdir / "usr/etc/fonts/unsloth-appimage.conf"
     template.parent.mkdir(parents = True)
     template.write_bytes(FONTCONFIG.read_bytes())
+    return appdir
+
+
+def test_apprun_hands_an_inherited_library_path_to_children_only(tmp_path):
+    """The loader reads LD_LIBRARY_PATH before the bundle's own $ORIGIN RUNPATHs."""
+
+    appdir = _apprun_mount(tmp_path)
+    apprun = appdir / "AppRun"
+    template = appdir / "usr/etc/fonts/unsloth-appimage.conf"
     state = tmp_path / "state"
 
     result = subprocess.run(
@@ -518,20 +528,44 @@ def test_apprun_hands_an_inherited_library_path_to_children_only(tmp_path):
     assert "@APPDIR@" not in materialized.read_text(encoding = "utf-8")
 
 
+def test_apprun_retires_only_the_font_policies_whose_mount_is_gone(tmp_path):
+    """A second launch must not pull the policy out from under a running one.
+
+    The survivor's next WebKit helper would start with an unreadable
+    FONTCONFIG_FILE, fall back to the host config, and pick the COLRv1 font
+    the policy exists to keep away from Jammy's Skia.
+    """
+
+    state = tmp_path / "state"
+    env = {"PATH": "/usr/bin:/bin", "XDG_RUNTIME_DIR": str(state)}
+    live = _apprun_mount(tmp_path, "mount-live")
+    subprocess.run([live / "AppRun"], check = True, capture_output = True, env = env)
+    live_policy = state / "unsloth-studio/fonts-mount-live.conf"
+    assert live_policy.is_file()
+
+    # A mount that exited: same shape, but its AppDir is no longer on disk.
+    dead = _apprun_mount(tmp_path, "mount-dead")
+    subprocess.run([dead / "AppRun"], check = True, capture_output = True, env = env)
+    dead_policy = state / "unsloth-studio/fonts-mount-dead.conf"
+    assert dead_policy.is_file()
+    shutil.rmtree(dead)
+
+    later = _apprun_mount(tmp_path, "mount-later")
+    result = subprocess.run([later / "AppRun"], check = True, capture_output = True, text = True, env = env)
+
+    assert live_policy.is_file(), "a running instance lost its font policy"
+    assert not dead_policy.exists(), "a departed mount's font policy was kept"
+    later_policy = state / "unsloth-studio/fonts-mount-later.conf"
+    assert f"FONTCONFIG_FILE={later_policy}" in result.stdout.splitlines()
+    assert later_policy.is_file()
+
+
 def test_apprun_falls_back_to_the_shipped_font_policy_when_it_cannot_write(tmp_path):
     """A policy that rejects host color fonts still beats no policy at all."""
 
-    appdir = tmp_path / "AppDir"
-    binary = appdir / "usr/bin/unsloth-studio"
-    binary.parent.mkdir(parents = True)
-    binary.write_text("#!/bin/sh\nexec /usr/bin/env\n", encoding = "utf-8")
-    binary.chmod(0o755)
+    appdir = _apprun_mount(tmp_path)
     apprun = appdir / "AppRun"
-    apprun.write_bytes(APPRUN.read_bytes())
-    apprun.chmod(0o755)
     template = appdir / "usr/etc/fonts/unsloth-appimage.conf"
-    template.parent.mkdir(parents = True)
-    template.write_bytes(FONTCONFIG.read_bytes())
     unwritable = tmp_path / "unwritable"
     unwritable.mkdir(mode = 0o500)
 

--- a/tests/security/test_release_desktop_appimage.py
+++ b/tests/security/test_release_desktop_appimage.py
@@ -67,6 +67,18 @@ def test_tauri_builds_and_signs_deb_and_complete_appimage_together():
     assert "tauri-driver --version 2.0.6 --locked" in webdriver_install["run"]
     assert "appimage_model_download_webdriver.py" in e2e_source
 
+    colrv1_sha = "0ae57fe58645638523ba35f388d93739d292539a9acb84df5700c81b1e1a28d2"
+    assert "googlefonts/noto-emoji/8998f5dd683424a73e2314a8c1f1e359c19e8742" in e2e_source
+    assert e2e_source.count(colrv1_sha) >= 2
+    assert "APPIMAGE_COLRV1_FONT" in e2e_source
+    webdriver_script = (
+        REPO_ROOT / "tests/studio/appimage_model_download_webdriver.py"
+    ).read_text(encoding = "utf-8")
+    assert "Unsloth Test COLRv1" in webdriver_script
+    assert '"route": "/hub"' in webdriver_script
+    assert '"survived_seconds": 0' in webdriver_script
+    assert "colrv1-model-hub.json" in webdriver_script
+
 
 def test_appimage_pr_build_is_unsigned_and_feeds_every_artifact_test():
     workflow = yaml.safe_load(CLEAN_MACHINE_WORKFLOW.read_text(encoding = "utf-8"))

--- a/tests/security/test_release_desktop_appimage.py
+++ b/tests/security/test_release_desktop_appimage.py
@@ -227,6 +227,11 @@ def test_release_preseeds_every_tauri_appimage_tool_with_a_digest():
     assert 'prefix="relative">../../share/unsloth/fonts' in fontconfig_source
     assert '<match target="scan">' in fontconfig_source
     assert "Unsloth Safe Emoji" in fontconfig_source
+
+    assert '<edit name="color" mode="assign">' in fontconfig_source
+    assert "<selectfont>" in fontconfig_source
+    assert "<rejectfont>" in fontconfig_source
+    assert '<patelt name="color"><bool>true</bool></patelt>' in fontconfig_source
     assert 'case "${APPDIR:-}" in' in tool_script
     assert 'APPDIR="$(dirname "$(realpath "$0")")"' in tool_script
     for host_library in (

--- a/tests/security/test_release_desktop_appimage.py
+++ b/tests/security/test_release_desktop_appimage.py
@@ -309,7 +309,8 @@ def _fake_complete_appdir(tmp_path: Path) -> Path:
         "#!/bin/sh\n"
         '. "$APPDIR/apprun-hooks/linuxdeploy-plugin-gtk.sh"\n'
         "unset LD_LIBRARY_PATH\n"
-        'sed "s|@APPDIR@|$APPDIR|g" "$unsloth_fonts_template"\n'
+        "sed -e 's,&,\\&amp;,g'\n"
+        'sed "s|@APPDIR@|$unsloth_fonts_appdir|g" "$unsloth_fonts_template"\n'
         "exit 0\n",
         encoding = "utf-8",
     )
@@ -547,6 +548,50 @@ def test_apprun_retires_only_the_font_policies_whose_mount_is_gone(tmp_path):
     later_policy = state / "unsloth-studio/fonts-mount-later.conf"
     assert f"FONTCONFIG_FILE={later_policy}" in result.stdout.splitlines()
     assert later_policy.is_file()
+
+
+def test_apprun_encodes_a_mount_path_carrying_xml_and_sed_metacharacters(tmp_path):
+    """The AppImage runtime copies the file's own name into the mount path."""
+
+    # An AppImage named "R&D<x>.AppImage" mounts under /tmp/.mount_R&D<x>XXXXXX.
+    appdir = _apprun_mount(tmp_path, "mount-R&D<x>|y\\z")
+    state = tmp_path / "state"
+
+    result = subprocess.run(
+        [appdir / "AppRun"],
+        check = True,
+        capture_output = True,
+        text = True,
+        env = {"PATH": "/usr/bin:/bin", "XDG_RUNTIME_DIR": str(state)},
+    )
+
+    materialized = state / f"unsloth-studio/fonts-{appdir.name}.conf"
+    assert f"FONTCONFIG_FILE={materialized}" in result.stdout.splitlines()
+    policy = materialized.read_text(encoding = "utf-8")
+    assert "@APPDIR@" not in policy
+
+    # Fontconfig drops a whole policy it cannot parse, which puts host COLRv1
+    # fonts back in front of Skia.
+    root = ElementTree.fromstring(policy)
+    directories = [element.text for element in root.findall("dir")]
+    assert directories == [f"{appdir}/usr/share/unsloth/fonts"]
+    assert root.find("selectfont/rejectfont") is not None
+
+
+def test_apprun_keeps_a_live_policy_whose_mount_path_needed_encoding(tmp_path):
+    """Cleanup compares mounts on disk, so it has to decode what it wrote."""
+
+    state = tmp_path / "state"
+    env = {"PATH": "/usr/bin:/bin", "XDG_RUNTIME_DIR": str(state)}
+    live = _apprun_mount(tmp_path, "mount-R&D<x>")
+    subprocess.run([live / "AppRun"], check = True, capture_output = True, env = env)
+    live_policy = state / f"unsloth-studio/fonts-{live.name}.conf"
+    assert live_policy.is_file()
+
+    later = _apprun_mount(tmp_path, "mount-later")
+    subprocess.run([later / "AppRun"], check = True, capture_output = True, env = env)
+
+    assert live_policy.is_file(), "a running instance lost its font policy"
 
 
 def test_apprun_falls_back_to_the_shipped_font_policy_when_it_cannot_write(tmp_path):

--- a/tests/security/test_release_desktop_appimage.py
+++ b/tests/security/test_release_desktop_appimage.py
@@ -4,6 +4,7 @@ import json
 import re
 import subprocess
 from pathlib import Path
+from xml.etree import ElementTree
 
 import yaml
 
@@ -224,14 +225,40 @@ def test_release_preseeds_every_tauri_appimage_tool_with_a_digest():
         assert asset in tool_script
         assert asset in finalizer_source
     fontconfig_source = FONTCONFIG.read_text(encoding = "utf-8")
-    assert 'prefix="relative">../../share/unsloth/fonts' in fontconfig_source
+    # Fontconfig skips a malformed file wholesale and logs to stderr the app
+    # never shows, which reads exactly like the policy not applying.
+    ElementTree.fromstring(fontconfig_source)
+    # Fontconfig 2.13, which Ubuntu 22.04 still ships, ignores prefix="relative"
+    # and anchors the path at the host root, so AppRun fills in the real AppDir.
+    assert "<dir>@APPDIR@/usr/share/unsloth/fonts</dir>" in fontconfig_source
+    assert "<dir prefix=" not in fontconfig_source
     assert '<match target="scan">' in fontconfig_source
     assert "Unsloth Safe Emoji" in fontconfig_source
 
-    assert '<edit name="color" mode="assign">' in fontconfig_source
     assert "<selectfont>" in fontconfig_source
     assert "<rejectfont>" in fontconfig_source
     assert '<patelt name="color"><bool>true</bool></patelt>' in fontconfig_source
+    # The bundled font keeps its real color=true, so the color-emoji queries
+    # WebKitGTK makes still reach it; acceptfont is what spares it the filter.
+    assert "<acceptfont>" in fontconfig_source
+    assert '<patelt name="family"><string>Unsloth Safe Emoji</string></patelt>' in fontconfig_source
+    assert fontconfig_source.index("<acceptfont>") < fontconfig_source.index("<rejectfont>")
+
+    # Every pattern rule must be guarded by what it answers for. An unguarded
+    # prepend wins FcFontMatch outright, and WebKitGTK then draws spaces and
+    # digits, which a CBDT emoji font covers, out of that font.
+    pattern_rules = re.findall(
+        r'<match target="pattern">(.*?)</match>', fontconfig_source, re.DOTALL
+    )
+    assert pattern_rules
+    for rule in pattern_rules:
+        assert '<test name="family">' in rule or '<test name="lang">' in rule
+        if 'mode="prepend"' in rule:
+            assert "<string>emoji</string>" in rule or "<string>und-zsye</string>" in rule
+        else:
+            assert 'mode="append" binding="weak"' in rule
+    for guard in ("und-zsye", "emoji", "sans-serif", "serif", "monospace"):
+        assert any(f"<string>{guard}</string>" in rule for rule in pattern_rules)
     assert 'case "${APPDIR:-}" in' in tool_script
     assert 'APPDIR="$(dirname "$(realpath "$0")")"' in tool_script
     for host_library in (
@@ -286,7 +313,7 @@ def _fake_complete_appdir(tmp_path: Path) -> Path:
         "#!/bin/sh\n"
         '. "$APPDIR/apprun-hooks/linuxdeploy-plugin-gtk.sh"\n'
         "unset LD_LIBRARY_PATH\n"
-        'FONTCONFIG_FILE="$APPDIR/usr/etc/fonts/unsloth-appimage.conf"\n'
+        'sed "s|@APPDIR@|$APPDIR|g" "$unsloth_fonts_template"\n'
         "exit 0\n",
         encoding = "utf-8",
     )
@@ -348,7 +375,10 @@ def _fake_complete_appdir(tmp_path: Path) -> Path:
     safe_license.write_text("fixture OFL license\n", encoding = "utf-8")
     fontconfig = appdir / "usr/etc/fonts/unsloth-appimage.conf"
     fontconfig.parent.mkdir(parents = True)
-    fontconfig.write_text("Unsloth Safe Emoji\n", encoding = "utf-8")
+    fontconfig.write_text(
+        "Unsloth Safe Emoji\n<dir>@APPDIR@/usr/share/unsloth/fonts</dir>\n",
+        encoding = "utf-8",
+    )
 
     return appdir
 
@@ -458,19 +488,61 @@ def test_apprun_hands_an_inherited_library_path_to_children_only(tmp_path):
     apprun = appdir / "AppRun"
     apprun.write_bytes(APPRUN.read_bytes())
     apprun.chmod(0o755)
+    template = appdir / "usr/etc/fonts/unsloth-appimage.conf"
+    template.parent.mkdir(parents = True)
+    template.write_bytes(FONTCONFIG.read_bytes())
+    state = tmp_path / "state"
 
     result = subprocess.run(
         [apprun],
         check = True,
         capture_output = True,
         text = True,
-        env = {"PATH": "/usr/bin:/bin", "LD_LIBRARY_PATH": "/opt/conda/lib:/opt/rocm/lib"},
+        env = {
+            "PATH": "/usr/bin:/bin",
+            "LD_LIBRARY_PATH": "/opt/conda/lib:/opt/rocm/lib",
+            "XDG_RUNTIME_DIR": str(state),
+        },
     )
     printed = result.stdout.splitlines()
     assert not [line for line in printed if line.startswith("LD_LIBRARY_PATH=")]
     assert "UNSLOTH_HOST_LD_LIBRARY_PATH=/opt/conda/lib:/opt/rocm/lib" in printed
 
-    assert f"FONTCONFIG_FILE={appdir}/usr/etc/fonts/unsloth-appimage.conf" in printed
+    # The shipped policy names its font directory as @APPDIR@; a mount-specific
+    # copy is what fontconfig actually reads, on every version.
+    materialized = state / "unsloth-studio/fonts-AppDir.conf"
+    assert f"FONTCONFIG_FILE={materialized}" in printed
+    assert f"<dir>{appdir}/usr/share/unsloth/fonts</dir>" in materialized.read_text(
+        encoding = "utf-8"
+    )
+    assert "@APPDIR@" not in materialized.read_text(encoding = "utf-8")
+
+
+def test_apprun_falls_back_to_the_shipped_font_policy_when_it_cannot_write(tmp_path):
+    """A policy that rejects host color fonts still beats no policy at all."""
+
+    appdir = tmp_path / "AppDir"
+    binary = appdir / "usr/bin/unsloth-studio"
+    binary.parent.mkdir(parents = True)
+    binary.write_text("#!/bin/sh\nexec /usr/bin/env\n", encoding = "utf-8")
+    binary.chmod(0o755)
+    apprun = appdir / "AppRun"
+    apprun.write_bytes(APPRUN.read_bytes())
+    apprun.chmod(0o755)
+    template = appdir / "usr/etc/fonts/unsloth-appimage.conf"
+    template.parent.mkdir(parents = True)
+    template.write_bytes(FONTCONFIG.read_bytes())
+    unwritable = tmp_path / "unwritable"
+    unwritable.mkdir(mode = 0o500)
+
+    result = subprocess.run(
+        [apprun],
+        check = True,
+        capture_output = True,
+        text = True,
+        env = {"PATH": "/usr/bin:/bin", "XDG_RUNTIME_DIR": str(unwritable / "state")},
+    )
+    assert f"FONTCONFIG_FILE={template}" in result.stdout.splitlines()
 
 
 def test_complete_appimage_verifier_rejects_a_launcher_that_keeps_the_host_library_path(tmp_path):

--- a/tests/security/test_release_desktop_appimage.py
+++ b/tests/security/test_release_desktop_appimage.py
@@ -226,11 +226,9 @@ def test_release_preseeds_every_tauri_appimage_tool_with_a_digest():
         assert asset in tool_script
         assert asset in finalizer_source
     fontconfig_source = FONTCONFIG.read_text(encoding = "utf-8")
-    # Fontconfig skips a malformed file wholesale and logs to stderr the app
-    # never shows, which reads exactly like the policy not applying.
+    # Fontconfig silently ignores malformed policies.
     ElementTree.fromstring(fontconfig_source)
-    # Fontconfig 2.13, which Ubuntu 22.04 still ships, ignores prefix="relative"
-    # and anchors the path at the host root, so AppRun fills in the real AppDir.
+    # AppRun replaces @APPDIR@ because Fontconfig 2.13 misresolves relative paths.
     assert "<dir>@APPDIR@/usr/share/unsloth/fonts</dir>" in fontconfig_source
     assert "<dir prefix=" not in fontconfig_source
     assert '<match target="scan">' in fontconfig_source
@@ -239,15 +237,12 @@ def test_release_preseeds_every_tauri_appimage_tool_with_a_digest():
     assert "<selectfont>" in fontconfig_source
     assert "<rejectfont>" in fontconfig_source
     assert '<patelt name="color"><bool>true</bool></patelt>' in fontconfig_source
-    # The bundled font keeps its real color=true, so the color-emoji queries
-    # WebKitGTK makes still reach it; acceptfont is what spares it the filter.
+    # Spare the bundled color font from the host-color rejection.
     assert "<acceptfont>" in fontconfig_source
     assert '<patelt name="family"><string>Unsloth Safe Emoji</string></patelt>' in fontconfig_source
     assert fontconfig_source.index("<acceptfont>") < fontconfig_source.index("<rejectfont>")
 
-    # Every pattern rule must be guarded by what it answers for. An unguarded
-    # prepend wins FcFontMatch outright, and WebKitGTK then draws spaces and
-    # digits, which a CBDT emoji font covers, out of that font.
+    # Only emoji requests may strongly prefer the bundled font.
     pattern_rules = re.findall(
         r'<match target="pattern">(.*?)</match>', fontconfig_source, re.DOTALL
     )
@@ -518,8 +513,7 @@ def test_apprun_hands_an_inherited_library_path_to_children_only(tmp_path):
     assert not [line for line in printed if line.startswith("LD_LIBRARY_PATH=")]
     assert "UNSLOTH_HOST_LD_LIBRARY_PATH=/opt/conda/lib:/opt/rocm/lib" in printed
 
-    # The shipped policy names its font directory as @APPDIR@; a mount-specific
-    # copy is what fontconfig actually reads, on every version.
+    # AppRun materializes the mount-specific font path.
     materialized = state / "unsloth-studio/fonts-AppDir.conf"
     assert f"FONTCONFIG_FILE={materialized}" in printed
     assert f"<dir>{appdir}/usr/share/unsloth/fonts</dir>" in materialized.read_text(
@@ -529,12 +523,7 @@ def test_apprun_hands_an_inherited_library_path_to_children_only(tmp_path):
 
 
 def test_apprun_retires_only_the_font_policies_whose_mount_is_gone(tmp_path):
-    """A second launch must not pull the policy out from under a running one.
-
-    The survivor's next WebKit helper would start with an unreadable
-    FONTCONFIG_FILE, fall back to the host config, and pick the COLRv1 font
-    the policy exists to keep away from Jammy's Skia.
-    """
+    """A later launch preserves live-mount policies and removes departed ones."""
 
     state = tmp_path / "state"
     env = {"PATH": "/usr/bin:/bin", "XDG_RUNTIME_DIR": str(state)}
@@ -543,7 +532,7 @@ def test_apprun_retires_only_the_font_policies_whose_mount_is_gone(tmp_path):
     live_policy = state / "unsloth-studio/fonts-mount-live.conf"
     assert live_policy.is_file()
 
-    # A mount that exited: same shape, but its AppDir is no longer on disk.
+    # Simulate an unmounted AppImage.
     dead = _apprun_mount(tmp_path, "mount-dead")
     subprocess.run([dead / "AppRun"], check = True, capture_output = True, env = env)
     dead_policy = state / "unsloth-studio/fonts-mount-dead.conf"

--- a/tests/security/test_release_desktop_appimage.py
+++ b/tests/security/test_release_desktop_appimage.py
@@ -333,7 +333,6 @@ def _fake_complete_appdir(tmp_path: Path) -> Path:
     fontconfig.parent.mkdir(parents = True)
     fontconfig.write_text("Unsloth Safe Emoji\n", encoding = "utf-8")
 
-
     return appdir
 
 

--- a/tests/security/test_release_desktop_appimage.py
+++ b/tests/security/test_release_desktop_appimage.py
@@ -71,9 +71,9 @@ def test_tauri_builds_and_signs_deb_and_complete_appimage_together():
     assert "googlefonts/noto-emoji/8998f5dd683424a73e2314a8c1f1e359c19e8742" in e2e_source
     assert e2e_source.count(colrv1_sha) >= 2
     assert "APPIMAGE_COLRV1_FONT" in e2e_source
-    webdriver_script = (
-        REPO_ROOT / "tests/studio/appimage_model_download_webdriver.py"
-    ).read_text(encoding = "utf-8")
+    webdriver_script = (REPO_ROOT / "tests/studio/appimage_model_download_webdriver.py").read_text(
+        encoding = "utf-8"
+    )
     assert "Unsloth Test COLRv1" in webdriver_script
     assert '"route": "/hub"' in webdriver_script
     assert '"survived_seconds": 0' in webdriver_script

--- a/tests/security/test_release_desktop_appimage.py
+++ b/tests/security/test_release_desktop_appimage.py
@@ -18,6 +18,8 @@ FINALIZER = REPO_ROOT / "studio" / "src-tauri" / "linux" / "finalize-complete-ap
 
 APPRUN = REPO_ROOT / "studio" / "src-tauri" / "linux" / "appimage-apprun.sh"
 
+FONTCONFIG = REPO_ROOT / "studio" / "src-tauri" / "linux" / "appimage-fonts.conf"
+
 
 def _workflow():
     return yaml.safe_load(WORKFLOW.read_text(encoding = "utf-8"))
@@ -38,7 +40,12 @@ def test_tauri_builds_and_signs_deb_and_complete_appimage_together():
 
     # Require plugins compatible with the bundled GStreamer core.
     dependencies = _step("Install Linux dependencies")["run"]
-    for package in ("gstreamer1.0-plugins-good", "gstreamer1.0-plugins-bad", "gstreamer1.0-libav"):
+    for package in (
+        "fonts-noto-color-emoji",
+        "gstreamer1.0-plugins-good",
+        "gstreamer1.0-plugins-bad",
+        "gstreamer1.0-libav",
+    ):
         assert package in dependencies
 
     build = _step("Build Linux bundles")
@@ -78,7 +85,12 @@ def test_appimage_pr_build_is_unsigned_and_feeds_every_artifact_test():
     build = jobs["appimage-pr-build"]
     build_source = yaml.safe_dump(build)
     assert "github.event_name == 'pull_request'" in build["if"]
-    for package in ("gstreamer1.0-plugins-good", "gstreamer1.0-plugins-bad", "gstreamer1.0-libav"):
+    for package in (
+        "fonts-noto-color-emoji",
+        "gstreamer1.0-plugins-good",
+        "gstreamer1.0-plugins-bad",
+        "gstreamer1.0-libav",
+    ):
         assert package in build_source
     assert "TAURI_SIGNING_PRIVATE_KEY" not in build_source
     assert "createUpdaterArtifacts" in build_source
@@ -182,11 +194,27 @@ def test_release_preseeds_every_tauri_appimage_tool_with_a_digest():
     assert tool_script.index("sha256sum -c") < tool_script.index("chmod +x")
 
     assert "apprun-old" not in tool_script
-    for local_tool in ("appimage-apprun.sh", "finalize-complete-appimage.sh"):
+    for local_tool in (
+        "appimage-apprun.sh",
+        "appimage-fonts.conf",
+        "finalize-complete-appimage.sh",
+    ):
         assert local_tool in tool_script
 
     assert "patchelf --set-rpath" in finalizer_source
     assert "$ORIGIN" in finalizer_source
+
+    for asset in (
+        "UnslothSafeEmoji.ttf",
+        "UnslothSafeEmoji.LICENSE",
+        "unsloth-appimage-fonts.conf",
+    ):
+        assert asset in tool_script
+        assert asset in finalizer_source
+    fontconfig_source = FONTCONFIG.read_text(encoding = "utf-8")
+    assert 'prefix="relative">../../share/unsloth/fonts' in fontconfig_source
+    assert '<match target="scan">' in fontconfig_source
+    assert "Unsloth Safe Emoji" in fontconfig_source
     assert 'case "${APPDIR:-}" in' in tool_script
     assert 'APPDIR="$(dirname "$(realpath "$0")")"' in tool_script
     for host_library in (
@@ -241,6 +269,7 @@ def _fake_complete_appdir(tmp_path: Path) -> Path:
         "#!/bin/sh\n"
         '. "$APPDIR/apprun-hooks/linuxdeploy-plugin-gtk.sh"\n'
         "unset LD_LIBRARY_PATH\n"
+        'FONTCONFIG_FILE="$APPDIR/usr/etc/fonts/unsloth-appimage.conf"\n'
         "exit 0\n",
         encoding = "utf-8",
     )
@@ -294,6 +323,17 @@ def _fake_complete_appdir(tmp_path: Path) -> Path:
     scanner = runtime / "gstreamer1.0/gstreamer-1.0/gst-plugin-scanner"
     scanner.parent.mkdir(parents = True)
     scanner.touch()
+    safe_font = appdir / "usr/share/unsloth/fonts/UnslothSafeEmoji.ttf"
+    safe_font.parent.mkdir(parents = True)
+    safe_font.write_bytes(b"fixture CBDT CBLC bitmap font tables")
+    safe_license = appdir / "usr/share/doc/unsloth-safe-emoji/copyright"
+    safe_license.parent.mkdir(parents = True)
+    safe_license.write_text("fixture OFL license\n", encoding = "utf-8")
+    fontconfig = appdir / "usr/etc/fonts/unsloth-appimage.conf"
+    fontconfig.parent.mkdir(parents = True)
+    fontconfig.write_text("Unsloth Safe Emoji\n", encoding = "utf-8")
+
+
     return appdir
 
 
@@ -413,6 +453,8 @@ def test_apprun_hands_an_inherited_library_path_to_children_only(tmp_path):
     printed = result.stdout.splitlines()
     assert not [line for line in printed if line.startswith("LD_LIBRARY_PATH=")]
     assert "UNSLOTH_HOST_LD_LIBRARY_PATH=/opt/conda/lib:/opt/rocm/lib" in printed
+
+    assert f"FONTCONFIG_FILE={appdir}/usr/etc/fonts/unsloth-appimage.conf" in printed
 
 
 def test_complete_appimage_verifier_rejects_a_launcher_that_keeps_the_host_library_path(tmp_path):

--- a/tests/studio/appimage_model_download_webdriver.py
+++ b/tests/studio/appimage_model_download_webdriver.py
@@ -423,14 +423,24 @@ def _install_colrv1_probe_font(config_dir: Path, data_dir: Path) -> dict[str, st
         env = font_env,
         stdout = subprocess.DEVNULL,
     )
-    selected = subprocess.check_output(
-        ["fc-match", "-f", "%{file}\t%{family}\n", "sans-serif:charset=1f680"],
-        env = font_env,
-        text = True,
-    ).strip()
-    if str(installed) not in selected:
-        raise RuntimeError(f"Host Fontconfig did not select the COLRv1 fixture: {selected}")
-    result = {"path": str(installed), "sha256": actual_sha, "host_fc_match": selected}
+    selected_by_charset = {}
+    for charset in ("1f680", "1faea"):
+        selected = subprocess.check_output(
+            ["fc-match", "-f", "%{file}\t%{family}\t%{color}\n", f"sans-serif:charset={charset}"],
+            env = font_env,
+            text = True,
+        ).strip()
+        if str(installed) not in selected:
+            raise RuntimeError(
+                f"Host Fontconfig did not select the COLRv1 fixture for U+{charset.upper()}: "
+                f"{selected}"
+            )
+        selected_by_charset[charset] = selected
+    result = {
+        "path": str(installed),
+        "sha256": actual_sha,
+        "host_fc_match": selected_by_charset,
+    }
     (ART_DIR / "colrv1-host-font.json").write_text(json.dumps(result, indent = 2), encoding = "utf-8")
     return result
 
@@ -556,7 +566,7 @@ def main() -> None:
             inserted = _execute(
                 base,
                 session_id,
-                "const d=document.createElement('div');d.id='appimage-colrv1-probe';d.textContent='🚀 🇬🇧 👨‍👩‍👧 ⭐ ✅';d.style.cssText=\"position:fixed;z-index:2147483647;left:320px;top:90px;padding:16px;background:white;color:black;font-size:48px;font-family:'Unsloth Test COLRv1'\";document.body.appendChild(d);return d.textContent;",
+                "const d=document.createElement('div');d.id='appimage-colrv1-probe';d.textContent='🚀 🇬🇧 👨‍👩‍👧 ⭐ ✅ 🫪 🫯';d.style.cssText=\"position:fixed;z-index:2147483647;left:320px;top:90px;padding:16px;background:white;color:black;font-size:48px;font-family:'Unsloth Test COLRv1',sans-serif\";document.body.appendChild(d);return d.textContent;",
             )
             assert inserted, "Could not inject the COLRv1 renderer probe"
             evidence = {**colrv1_font, "route": "/hub", "survived_seconds": 0}

--- a/tests/studio/appimage_model_download_webdriver.py
+++ b/tests/studio/appimage_model_download_webdriver.py
@@ -371,6 +371,73 @@ def _request_log_contains(request_log: Path, path: str) -> bool:
     )
 
 
+def _install_colrv1_probe_font(config_dir: Path, data_dir: Path) -> dict[str, str] | None:
+    source_value = os.environ.get("APPIMAGE_COLRV1_FONT", "")
+    if not source_value:
+        return None
+
+    source = Path(source_value).resolve()
+    expected_sha = os.environ.get("APPIMAGE_COLRV1_FONT_SHA256", "").lower()
+    if not source.is_file() or not expected_sha:
+        raise RuntimeError("APPIMAGE_COLRV1_FONT and its SHA-256 are required together")
+    actual_sha = hashlib.sha256(source.read_bytes()).hexdigest()
+    if actual_sha != expected_sha:
+        raise RuntimeError(f"COLRv1 font digest mismatch: {actual_sha} != {expected_sha}")
+    font_bytes = source.read_bytes()
+    for table in (b"COLR", b"CPAL"):
+        if table not in font_bytes:
+            raise RuntimeError(f"COLRv1 regression font has no {table.decode()} table")
+
+    font_dir = data_dir / "fonts"
+    font_dir.mkdir(parents = True, exist_ok = True)
+    installed = font_dir / "Noto-COLRv1.ttf"
+    shutil.copy2(source, installed)
+    fontconfig_dir = config_dir / "fontconfig/conf.d"
+    fontconfig_dir.mkdir(parents = True, exist_ok = True)
+    (fontconfig_dir / "10-unsloth-colrv1-regression.conf").write_text(
+        """<?xml version="1.0"?>
+<!DOCTYPE fontconfig SYSTEM "urn:fontconfig:fonts.dtd">
+<fontconfig>
+  <match target="scan">
+    <test name="file" compare="contains"><string>Noto-COLRv1.ttf</string></test>
+    <edit name="family" mode="assign"><string>Unsloth Test COLRv1</string></edit>
+  </match>
+  <match target="pattern">
+    <edit name="family" mode="prepend" binding="strong">
+      <string>Unsloth Test COLRv1</string>
+    </edit>
+  </match>
+</fontconfig>
+""",
+        encoding = "utf-8",
+    )
+    font_env = {
+        **os.environ,
+        "HOME": str(data_dir.parents[1]),
+        "XDG_CONFIG_HOME": str(config_dir),
+        "XDG_DATA_HOME": str(data_dir),
+    }
+    subprocess.run(
+        ["fc-cache", "-f", str(font_dir)],
+        check = True,
+        env = font_env,
+        stdout = subprocess.DEVNULL,
+    )
+    selected = subprocess.check_output(
+        ["fc-match", "-f", "%{file}\t%{family}\n", "sans-serif:charset=1f680"],
+        env = font_env,
+        text = True,
+    ).strip()
+    if str(installed) not in selected:
+        raise RuntimeError(f"Host Fontconfig did not select the COLRv1 fixture: {selected}")
+    result = {"path": str(installed), "sha256": actual_sha, "host_fc_match": selected}
+    (ART_DIR / "colrv1-host-font.json").write_text(
+        json.dumps(result, indent = 2), encoding = "utf-8"
+    )
+    return result
+
+
+
 def main() -> None:
     appimage_value = os.environ.get("APPIMAGE_PATH", "")
     if not appimage_value:
@@ -397,6 +464,8 @@ def main() -> None:
     data_dir.mkdir(parents = True)
     cache_dir.mkdir(parents = True)
     state_dir.mkdir(parents = True)
+
+    colrv1_font = _install_colrv1_probe_font(config_dir, data_dir)
     request_log = ART_DIR.resolve() / "backend-requests.jsonl"
     _write_backend_fixture(home, request_log)
 
@@ -470,6 +539,49 @@ def main() -> None:
             "return document.body && !document.body.innerText.includes('Starting Unsloth')",
             "the deterministic desktop backend handoff",
         )
+
+        if colrv1_font is not None:
+            clicked = _wait_for(
+                base,
+                session_id,
+                "const b=document.querySelector('[data-testid=\"nav-row-hub\"]')||[...document.querySelectorAll('button')].find((e)=>(e.innerText||'').trim()==='Model hub');if(b){b.click();return true;}return false;",
+                "the Model hub sidebar destination",
+                timeout = 30,
+            )
+            assert clicked, "Could not click the Model hub sidebar destination"
+            _wait_for(
+                base,
+                session_id,
+                "return location.pathname==='/hub'&&document.body?.innerText.includes('Model hub')",
+                "the Model hub route",
+                timeout = 60,
+            )
+            inserted = _execute(
+                base,
+                session_id,
+                "const d=document.createElement('div');d.id='appimage-colrv1-probe';d.textContent='🚀 🇬🇧 👨‍👩‍👧 ⭐ ✅';d.style.cssText=\"position:fixed;z-index:2147483647;left:320px;top:90px;padding:16px;background:white;color:black;font-size:48px;font-family:'Unsloth Test COLRv1'\";document.body.appendChild(d);return d.textContent;",
+            )
+            assert inserted, "Could not inject the COLRv1 renderer probe"
+            evidence = {**colrv1_font, "route": "/hub", "survived_seconds": 0}
+            for elapsed in range(1, 31):
+                time.sleep(1)
+                state = _execute(
+                    base,
+                    session_id,
+                    "return {path:location.pathname,probe:document.getElementById('appimage-colrv1-probe')?.textContent||false,body:(document.body?.innerText||'').slice(0,12000)};",
+                )
+                assert state["path"] == "/hub", f"Left Model hub during COLRv1 probe: {state}"
+                assert state["probe"], f"COLRv1 probe disappeared or renderer stopped: {state}"
+                evidence["survived_seconds"] = elapsed
+            evidence["result"] = "PASS"
+            (ART_DIR / "colrv1-model-hub.json").write_text(
+                json.dumps(evidence, indent = 2, ensure_ascii = False), encoding = "utf-8"
+            )
+            _execute(
+                base,
+                session_id,
+                "document.getElementById('appimage-colrv1-probe')?.remove();return true;",
+            )
         clicked = _wait_for(
             base,
             session_id,
@@ -611,7 +723,10 @@ def main() -> None:
             home / ".unsloth/studio/tauri.log",
         )
 
-        print("PASS packaged AppImage model picker sent download, rendered progress, and cancelled")
+        print(
+            "PASS packaged AppImage survived the COLRv1 Model hub probe, "
+            "then sent, rendered, and cancelled a model download"
+        )
     except Exception:
         if session_id:
             try:

--- a/tests/studio/appimage_model_download_webdriver.py
+++ b/tests/studio/appimage_model_download_webdriver.py
@@ -431,11 +431,8 @@ def _install_colrv1_probe_font(config_dir: Path, data_dir: Path) -> dict[str, st
     if str(installed) not in selected:
         raise RuntimeError(f"Host Fontconfig did not select the COLRv1 fixture: {selected}")
     result = {"path": str(installed), "sha256": actual_sha, "host_fc_match": selected}
-    (ART_DIR / "colrv1-host-font.json").write_text(
-        json.dumps(result, indent = 2), encoding = "utf-8"
-    )
+    (ART_DIR / "colrv1-host-font.json").write_text(json.dumps(result, indent = 2), encoding = "utf-8")
     return result
-
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary

- bundle a known CBDT Noto emoji font only in the Linux AppImage
- give that bundled file a private Fontconfig family and prefer it for glyphs it covers
- keep normal host fonts available while preventing Jammy WebKitGTK/Skia from selecting host COLRv1 emoji fonts
- verify the safe font, license, policy, and AppRun wiring in the complete-AppImage contract

## Why

The fat AppImage bundles Ubuntu 22.04 WebKitGTK/Skia but intentionally uses the host FreeType runtime. On systems where Fontconfig selects a COLRv1 emoji font, this combination can abort in `colrv1_configure_skpaint` with `std::vector::operator[]: Assertion '__n < this->size()' failed`. Model Hub cards are one trigger.

Bundling an older FreeType made font rendering hang, and README-only sanitization does not cover every renderer path. The AppImage-scoped CBDT fallback avoids the incompatible COLRv1 path without changing `.deb` behavior or hiding README content.

## Verification

- `15 passed`: `tests/security/test_release_desktop_appimage.py`
- exact released v0.1.801 AppImage + pinned Noto COLRv1 font: **FAIL**, renderer session deleted and `colrv1_configure_skpaint` assertion observed
- same v0.1.801 payload repacked with this runtime policy + same font/probe: **PASS**, Model Hub survived 30s and the explicit emoji/flag renderer probe survived 10s, no crash assertion
- exact built-head negative: U+1FAEA is absent from the bundled CBDT font, so `fda1fa05` selected the hostile host `Noto-COLRv1.ttf`; `61cb9f758` keeps the vetted bundled font and rejects every other `color=true` font, removing that fallback path
- PR-head GitHub Actions: **PASS** on [`61cb9f758`](https://github.com/unslothai/unsloth/commit/61cb9f7582c47b37dc662b1cc1a63309d3fd24f3) — [run 32497188126](https://github.com/unslothai/unsloth/actions/runs/32497188126) built the AppImage, proved the host selected the exact digest-pinned COLRv1 fixture for both U+1F680 and uncovered U+1FAEA, kept `/hub` alive for 30s while rendering the probe, and passed Ubuntu 22.04, Ubuntu 22.04 without GLES, Ubuntu 24.04 Wayland, Debian 12, and Fedora 44 portability lanes
- independent review found one host-launcher environment leak; `fda1fa05` scrubs `FONTCONFIG_FILE` before opening host browsers/file managers, with a focused Rust regression test
- Codex found the uncovered-glyph fallback; fixed in `61cb9f758`, re-reviewed on that exact head, and approved with no remaining major issues

Closes #9453.


