### PR TITLE
fix(export): forward private repo flag to push_to_hub_gguf in CLI and Studio

### DIFF
--- a/studio/backend/core/export/export.py
+++ b/studio/backend/core/export/export.py
@@ -1062,6 +1062,7 @@ class ExportBackend:
         repo_id: Optional[str] = None,
         hf_token: Optional[str] = None,
         imatrix_file = None,
+        private: bool = False,
     ) -> Tuple[bool, str, Optional[str]]:
         """
         Export model in GGUF format.
@@ -1074,6 +1075,8 @@ class ExportBackend:
             push_to_hub: Whether to push to Hugging Face Hub
             repo_id: Hub repository ID
             hf_token: Hugging Face token
+            imatrix_file: Optional importance matrix file path or boolean
+            private: Whether to make the Hub repository private
 
         Returns:
             Tuple of (success: bool, message: str, output_path: Optional[str])
@@ -1265,6 +1268,7 @@ class ExportBackend:
                     self.current_tokenizer,
                     quantization_method = quant_method,
                     token = hf_token,
+                    private = private,
                     **imatrix_kw,
                 )
                 logger.info(f"GGUF model pushed successfully to {repo_id}")

--- a/studio/backend/core/export/orchestrator.py
+++ b/studio/backend/core/export/orchestrator.py
@@ -575,6 +575,7 @@ class ExportOrchestrator:
         repo_id: Optional[str] = None,
         hf_token: Optional[str] = None,
         imatrix_file = None,
+        private: bool = False,
     ) -> Tuple[bool, str, Optional[str]]:
         """Export model in GGUF format. `quantization_method` may be a single method or a list."""
         return self._run_export(
@@ -586,6 +587,7 @@ class ExportOrchestrator:
                 "repo_id": repo_id,
                 "hf_token": hf_token,
                 "imatrix_file": imatrix_file,
+                "private": private,
             },
         )
 

--- a/studio/backend/core/export/worker.py
+++ b/studio/backend/core/export/worker.py
@@ -450,6 +450,7 @@ def _handle_export(backend, cmd: dict, resp_queue: Any) -> None:
                 repo_id = cmd.get("repo_id"),
                 hf_token = cmd.get("hf_token"),
                 imatrix_file = cmd.get("imatrix_file"),
+                private = cmd.get("private", False),
             )
         elif export_type == "lora":
             success, message, output_path = backend.export_lora_adapter(

--- a/studio/backend/mcp_server.py
+++ b/studio/backend/mcp_server.py
@@ -232,6 +232,7 @@ def create_studio_mcp() -> FastMCP:
         hf_token: str | None = None,
         imatrix: bool = False,
         imatrix_path: str | None = None,
+        private: bool = False,
     ) -> dict[str, Any]:
         """Export the loaded model to GGUF using Unsloth's existing path validation.
 
@@ -251,6 +252,7 @@ def create_studio_mcp() -> FastMCP:
             hf_token = hf_token,
             imatrix = imatrix,
             imatrix_path = imatrix_path,
+            private = private,
         )
         return _dump(await export(request, current_subject = "mcp"))
 

--- a/studio/backend/models/export.py
+++ b/studio/backend/models/export.py
@@ -224,6 +224,10 @@ class ExportGGUFRequest(BaseModel):
         None,
         description = "Path to a custom imatrix file; overrides the auto-download when set.",
     )
+    private: bool = Field(
+        False,
+        description = "If True, create a private Hugging Face Hub repository",
+    )
 
 
 class ExportLoRAAdapterRequest(ExportCommonOptions):

--- a/studio/backend/routes/export.py
+++ b/studio/backend/routes/export.py
@@ -411,6 +411,7 @@ async def export_gguf(
             repo_id = request.repo_id,
             hf_token = request.hf_token,
             imatrix_file = imatrix_file,
+            private = request.private,
         )
 
         if not success:

--- a/studio/backend/tests/test_export_gguf_discovery.py
+++ b/studio/backend/tests/test_export_gguf_discovery.py
@@ -452,8 +452,14 @@ def _imatrix_model(accepts_token: bool, calls: dict):
             quantization_method = None,
             token = None,
             imatrix_file = None,
+            private = False,
         ):
-            calls["push"] = {"repo_id": repo_id, "token": token, "imatrix_file": imatrix_file}
+            calls["push"] = {
+                "repo_id": repo_id,
+                "token": token,
+                "imatrix_file": imatrix_file,
+                "private": private,
+            }
 
     class _WithoutToken:
         def save_pretrained_gguf(
@@ -496,7 +502,29 @@ def test_hub_push_with_an_imatrix_passes_the_token_exactly_once(monkeypatch, tmp
     )
 
     assert success is True, message
-    assert calls["push"] == {"repo_id": "org/model", "token": "hf_secret", "imatrix_file": True}
+    assert calls["push"] == {"repo_id": "org/model", "token": "hf_secret", "imatrix_file": True, "private": False}
+
+
+@pytest.mark.parametrize("imatrix_file", [None, False, True])
+@pytest.mark.parametrize("private", [True, False])
+def test_hub_push_gguf_forwards_private_flag(monkeypatch, tmp_path, imatrix_file, private):
+    """push_to_hub_gguf receives the requested private flag for both standard and imatrix exports."""
+    calls: dict = {}
+    _m, backend, save_dir, _cwd = _backend(monkeypatch, tmp_path, _imatrix_model(True, calls))
+
+    success, message, _p = backend.export_gguf(
+        str(save_dir),
+        "q4_k_m" if not imatrix_file else "iq2_xxs",
+        push_to_hub = True,
+        repo_id = "org/model",
+        hf_token = "hf_secret",
+        imatrix_file = imatrix_file,
+        private = private,
+    )
+
+    assert success is True, message
+    assert calls["push"]["private"] is private
+
 
 
 def test_gguf_export_without_an_imatrix_does_not_forward_the_token(monkeypatch, tmp_path):

--- a/studio/backend/tests/test_export_gguf_discovery.py
+++ b/studio/backend/tests/test_export_gguf_discovery.py
@@ -502,7 +502,12 @@ def test_hub_push_with_an_imatrix_passes_the_token_exactly_once(monkeypatch, tmp
     )
 
     assert success is True, message
-    assert calls["push"] == {"repo_id": "org/model", "token": "hf_secret", "imatrix_file": True, "private": False}
+    assert calls["push"] == {
+        "repo_id": "org/model",
+        "token": "hf_secret",
+        "imatrix_file": True,
+        "private": False,
+    }
 
 
 @pytest.mark.parametrize("imatrix_file", [None, False, True])
@@ -524,7 +529,6 @@ def test_hub_push_gguf_forwards_private_flag(monkeypatch, tmp_path, imatrix_file
 
     assert success is True, message
     assert calls["push"]["private"] is private
-
 
 
 def test_gguf_export_without_an_imatrix_does_not_forward_the_token(monkeypatch, tmp_path):

--- a/studio/backend/tests/test_export_imatrix_compressed.py
+++ b/studio/backend/tests/test_export_imatrix_compressed.py
@@ -25,7 +25,9 @@ def _src(rel):
 def _func_src(rel, name):
     src = _src(rel)
     node = next(
-        n for n in ast.walk(ast.parse(src)) if isinstance(n, ast.FunctionDef) and n.name == name
+        n
+        for n in ast.walk(ast.parse(src))
+        if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef)) and n.name == name
     )
     return ast.get_source_segment(src, node)
 
@@ -38,6 +40,12 @@ def test_gguf_request_imatrix_defaults_and_set():
     assert ExportGGUFRequest(save_directory = "/tmp/x").imatrix_path is None
     r = ExportGGUFRequest(save_directory = "/tmp/x", imatrix = True, imatrix_path = "/i.dat")
     assert r.imatrix is True and r.imatrix_path == "/i.dat"
+
+
+def test_gguf_request_private_defaults_and_set():
+    assert ExportGGUFRequest(save_directory = "/tmp/x").private is False
+    r = ExportGGUFRequest(save_directory = "/tmp/x", private = True)
+    assert r.private is True
 
 
 def test_merged_request_accepts_compressed_formats():
@@ -282,3 +290,81 @@ def test_orchestrator_and_worker_pass_compressed_method():
 
 def test_route_passes_compressed_method():
     assert "compressed_method = request.compressed_method" in _src("routes/export.py")
+
+
+def test_export_gguf_threads_private_to_push_to_hub():
+    g = _func_src("core/export/export.py", "export_gguf")
+    assert "private: bool = False" in g
+    assert "private = private" in g
+
+
+def test_route_passes_gguf_private():
+    src = _func_src("routes/export.py", "export_gguf")
+    assert "private = request.private" in src
+
+
+def test_route_export_gguf_forwards_private(monkeypatch):
+    import asyncio
+    from routes import export as export_route
+
+    captured = {}
+
+    class FakeBackend:
+        def export_gguf(self, **kwargs):
+            captured.update(kwargs)
+            return True, "ok", "/tmp/out"
+
+    async def _mock_supported():
+        return None
+
+    monkeypatch.setattr(export_route, "_ensure_export_supported", _mock_supported)
+    monkeypatch.setattr(export_route, "get_export_backend", lambda: FakeBackend())
+    monkeypatch.setattr(export_route, "_export_details", lambda *args, **kwargs: {})
+
+    req = ExportGGUFRequest(save_directory = "/tmp/out", private = True)
+    res = asyncio.run(export_route.export_gguf(req, current_subject = "test"))
+    assert res.success is True
+    assert captured.get("private") is True
+
+    captured.clear()
+    req_default = ExportGGUFRequest(save_directory = "/tmp/out")
+    res_default = asyncio.run(export_route.export_gguf(req_default, current_subject = "test"))
+    assert res_default.success is True
+    assert captured.get("private") is False
+
+
+def test_orchestrator_passes_gguf_private():
+    o = _func_src("core/export/orchestrator.py", "export_gguf")
+    assert "private: bool = False" in o and '"private": private' in o
+
+
+def test_worker_passes_gguf_private():
+    import queue
+    from core.export.worker import _handle_export
+
+    captured = {}
+
+    class FakeBackend:
+        def export_gguf(self, **kwargs):
+            captured.update(kwargs)
+            return True, "ok", "/out"
+
+    q = queue.Queue()
+    _handle_export(
+        FakeBackend(),
+        {"export_type": "gguf", "save_directory": "/tmp/out", "private": True},
+        q,
+    )
+    assert captured.get("private") is True
+
+    captured.clear()
+    _handle_export(
+        FakeBackend(),
+        {"export_type": "gguf", "save_directory": "/tmp/out"},
+        q,
+    )
+    assert captured.get("private") is False
+
+
+
+

--- a/studio/backend/tests/test_export_imatrix_compressed.py
+++ b/studio/backend/tests/test_export_imatrix_compressed.py
@@ -364,7 +364,3 @@ def test_worker_passes_gguf_private():
         q,
     )
     assert captured.get("private") is False
-
-
-
-

--- a/studio/backend/tests/test_mcp_server.py
+++ b/studio/backend/tests/test_mcp_server.py
@@ -176,7 +176,7 @@ def test_clamp_restricts_to_inclusive_bounds():
 
 def test_export_and_checkpoint_tools_expose_forwarded_fields():
     export_props = set(_get_tool("export_gguf").parameters["properties"])
-    assert {"hf_token", "imatrix", "imatrix_path"} <= export_props
+    assert {"hf_token", "imatrix", "imatrix_path", "private"} <= export_props
 
     checkpoint_props = set(_get_tool("load_checkpoint").parameters["properties"])
     assert {"hf_token", "approved_remote_code_fingerprint"} <= checkpoint_props
@@ -219,6 +219,7 @@ def test_export_gguf_forwards_hf_token_and_imatrix(monkeypatch):
             hf_token = "hf_secret",
             imatrix = True,
             imatrix_path = "/tmp/imatrix.dat",
+            private = True,
         )
     )
 
@@ -226,6 +227,7 @@ def test_export_gguf_forwards_hf_token_and_imatrix(monkeypatch):
     assert captured["imatrix"] is True
     assert captured["imatrix_path"] == "/tmp/imatrix.dat"
     assert captured["quantization_method"] == ["Q4_K_M", "Q8_0"]
+    assert captured["private"] is True
     assert result["current_subject"] == "mcp"
 
 

--- a/studio/frontend/src/features/export/api/export-api.ts
+++ b/studio/frontend/src/features/export/api/export-api.ts
@@ -168,6 +168,7 @@ export async function exportGGUF(params: {
   hf_token?: string | null;
   imatrix?: boolean;
   imatrix_path?: string | null;
+  private?: boolean;
 }): Promise<ExportOperationResponse> {
   const response = await authFetch("/api/export/export/gguf", {
     method: "POST",

--- a/studio/frontend/src/features/export/stores/export-runtime-store.ts
+++ b/studio/frontend/src/features/export/stores/export-runtime-store.ts
@@ -495,6 +495,7 @@ export const useExportRuntimeStore = create<ExportRuntimeStore>()((set, get) => 
             // token when there is no hub-upload token (both are the same HF token).
             hf_token: params.token ?? params.loadToken ?? null,
             imatrix: params.useImatrix,
+            private: params.privateRepo,
           }),
         );
         if (outputPath) outputs.push({ label: "GGUF", path: outputPath });

--- a/tests/test_cli_export_unpacking.py
+++ b/tests/test_cli_export_unpacking.py
@@ -161,5 +161,3 @@ def test_cli_export_forwards_private_flag(
     assert result.exit_code == 0, f"CLI error:\n{result.output}"
     assert _FakeExportBackend.last_call.get("method") == expected_method
     assert _FakeExportBackend.last_call.get("kwargs", {}).get("private") is True
-
-

--- a/tests/test_cli_export_unpacking.py
+++ b/tests/test_cli_export_unpacking.py
@@ -17,6 +17,8 @@ from typer.testing import CliRunner
 class _FakeExportBackend:
     """Stand-in for ExportBackend: export_* return the 3-tuple, load_checkpoint stays a 2-tuple."""
 
+    last_call: dict = {}
+
     def __init__(self) -> None:
         self.loaded: str | None = None
 
@@ -28,15 +30,19 @@ class _FakeExportBackend:
         return []
 
     def export_merged_model(self, **kwargs):
+        _FakeExportBackend.last_call = {"method": "export_merged_model", "kwargs": kwargs}
         return True, "merged ok", str(Path(kwargs["save_directory"]).resolve())
 
     def export_base_model(self, **kwargs):
+        _FakeExportBackend.last_call = {"method": "export_base_model", "kwargs": kwargs}
         return True, "base ok", str(Path(kwargs["save_directory"]).resolve())
 
     def export_gguf(self, **kwargs):
+        _FakeExportBackend.last_call = {"method": "export_gguf", "kwargs": kwargs}
         return True, "gguf ok", str(Path(kwargs["save_directory"]).resolve())
 
     def export_lora_adapter(self, **kwargs):
+        _FakeExportBackend.last_call = {"method": "export_lora_adapter", "kwargs": kwargs}
         return True, "lora ok", str(Path(kwargs["save_directory"]).resolve())
 
 
@@ -56,6 +62,7 @@ def _install_fake_studio_backend(monkeypatch: pytest.MonkeyPatch) -> None:
 @pytest.fixture
 def cli_app(monkeypatch: pytest.MonkeyPatch) -> typer.Typer:
     """Typer app wrapping unsloth_cli.commands.export.export."""
+    _FakeExportBackend.last_call = {}
     _install_fake_studio_backend(monkeypatch)
     from unsloth_cli.commands import export as export_cmd
 
@@ -111,3 +118,48 @@ def test_cli_export_unpacks_three_tuple(
     # Fake backend's success message should reach stdout.
     expected_prefix = format_flag.split("-")[0]
     assert f"{expected_prefix} ok" in result.output
+
+
+@pytest.mark.parametrize(
+    "format_flag,quant_flag,expected_method",
+    [
+        ("merged-16bit", None, "export_merged_model"),
+        ("merged-4bit", None, "export_merged_model"),
+        ("gguf", "q4_k_m", "export_gguf"),
+        ("lora", None, "export_lora_adapter"),
+    ],
+)
+def test_cli_export_forwards_private_flag(
+    cli_app: typer.Typer,
+    runner: CliRunner,
+    tmp_path: Path,
+    format_flag: str,
+    quant_flag: str | None,
+    expected_method: str,
+) -> None:
+    """--private flag is forwarded as private=True to backend.export_* for every format."""
+    ckpt = tmp_path / "ckpt"
+    ckpt.mkdir()
+    out = tmp_path / "out"
+
+    cli_args = [
+        "export",
+        str(ckpt),
+        str(out),
+        "--format",
+        format_flag,
+        "--push-to-hub",
+        "--repo-id",
+        "test/repo",
+        "--private",
+    ]
+    if quant_flag is not None:
+        cli_args += ["--quantization", quant_flag]
+
+    result = runner.invoke(cli_app, cli_args)
+
+    assert result.exit_code == 0, f"CLI error:\n{result.output}"
+    assert _FakeExportBackend.last_call.get("method") == expected_method
+    assert _FakeExportBackend.last_call.get("kwargs", {}).get("private") is True
+
+

--- a/unsloth_cli/commands/export.py
+++ b/unsloth_cli/commands/export.py
@@ -118,6 +118,7 @@ def export(
             push_to_hub = push_to_hub,
             repo_id = repo_id,
             hf_token = hf_token,
+            private = private,
         )
     elif format == "lora":
         success, message, output_path = backend.export_lora_adapter(


### PR DESCRIPTION
## Problem & Motivation

When exporting fine-tuned models and pushing them to Hugging Face Hub, the `private` flag is critical for ensuring user checkpoints and proprietary weights are not inadvertently published to public repositories.

While `merged`, `base`, and `lora` export pathways correctly honor the `private` parameter, **GGUF exports were silently dropping it across the entire stack**. As a result:
- Running `unsloth export <ckpt> <out> --format gguf --push-to-hub --repo-id <id> --private` ignored the `--private` flag and created a public repository on the Hub.
- Toggling "Private" in the Studio UI or setting `private=True` via the backend API / MCP server did not propagate to `current_model.push_to_hub_gguf()`.

This PR fixes the parameter omission across all layers, establishing parity between GGUF and the other export formats.

---

## Changes

### 1. CLI (`unsloth_cli`)
* [`unsloth_cli/commands/export.py`](file:///c:/Users/pc/Desktop/Contributions-%20Github/unsloth/unsloth_cli/commands/export.py): Forwarded `private = private` to `backend.export_gguf(...)` in the `format == "gguf"` branch.

### 2. Studio Backend & Process Architecture (`studio/backend`)
* **Pydantic Schema**: Added `private: bool = Field(False, description = "If True, create a private Hugging Face Hub repository")` to `ExportGGUFRequest` in [`studio/backend/models/export.py`](file:///c:/Users/pc/Desktop/Contributions-%20Github/unsloth/studio/backend/models/export.py).
* **FastAPI Route**: Forwarded `private = request.private` to `backend.export_gguf` in [`studio/backend/routes/export.py`](file:///c:/Users/pc/Desktop/Contributions-%20Github/unsloth/studio/backend/routes/export.py).
* **Core Engine**: Added `private: bool = False` to `ExportBackend.export_gguf(...)` and forwarded it to `self.current_model.push_to_hub_gguf(...)` in [`studio/backend/core/export/export.py`](file:///c:/Users/pc/Desktop/Contributions-%20Github/unsloth/studio/backend/core/export/export.py).
* **Process Orchestration & Worker**:
  * Updated `ExportOrchestrator.export_gguf` in [`studio/backend/core/export/orchestrator.py`](file:///c:/Users/pc/Desktop/Contributions-%20Github/unsloth/studio/backend/core/export/orchestrator.py) to accept `private: bool = False` and embed `"private": private` in the IPC payload.
  * Updated `_handle_export_command` in [`studio/backend/core/export/worker.py`](file:///c:/Users/pc/Desktop/Contributions-%20Github/unsloth/studio/backend/core/export/worker.py) to forward `private = cmd.get("private", False)` for GGUF exports.
* **MCP Server**: Added `private: bool = False` parameter to the `export_gguf` MCP tool in [`studio/backend/mcp_server.py`](file:///c:/Users/pc/Desktop/Contributions-%20Github/unsloth/studio/backend/mcp_server.py).

### 3. Frontend Store & API Client (`studio/frontend`)
* [`studio/frontend/src/features/export/api/export-api.ts`](file:///c:/Users/pc/Desktop/Contributions-%20Github/unsloth/studio/frontend/src/features/export/api/export-api.ts): Added optional `private?: boolean` field to `exportGGUF` request parameters.
* [`studio/frontend/src/features/export/stores/export-runtime-store.ts`](file:///c:/Users/pc/Desktop/Contributions-%20Github/unsloth/studio/frontend/src/features/export/stores/export-runtime-store.ts): Forwarded `private: params.privateRepo` to `exportGGUF(...)`.

---

## Testing & Verification

Added unit and regression tests covering all affected modules:

1. **CLI Tests** ([`tests/test_cli_export_unpacking.py`](file:///c:/Users/pc/Desktop/Contributions-%20Github/unsloth/tests/test_cli_export_unpacking.py)):
   - Parametrized `test_cli_export_forwards_private_flag` to verify `--private` is forwarded to `backend.export_*` across `merged-16bit`, `merged-4bit`, `gguf`, and `lora`.
2. **Backend Engine Tests** ([`studio/backend/tests/test_export_gguf_discovery.py`](file:///c:/Users/pc/Desktop/Contributions-%20Github/unsloth/studio/backend/tests/test_export_gguf_discovery.py)):
   - Added `test_hub_push_gguf_forwards_private_flag` to verify `push_to_hub_gguf` receives `private=True`.
3. **IPC & Schema Tests** ([`studio/backend/tests/test_export_imatrix_compressed.py`](file:///c:/Users/pc/Desktop/Contributions-%20Github/unsloth/studio/backend/tests/test_export_imatrix_compressed.py)):
   - Added `test_gguf_request_private_defaults_and_set`, `test_export_gguf_threads_private_to_push_to_hub`, `test_route_passes_gguf_private`, and `test_orchestrator_and_worker_pass_gguf_private`.
4. **MCP Server Tests** ([`studio/backend/tests/test_mcp_server.py`](file:///c:/Users/pc/Desktop/Contributions-%20Github/unsloth/studio/backend/tests/test_mcp_server.py)):
   - Verified that `export_gguf` MCP tool schema advertises and forwards `private`.

```bash
pytest studio/backend/tests/test_export_absolute_paths.py \
       studio/backend/tests/test_mcp_server.py \
       studio/backend/tests/test_export_gguf_discovery.py \
       studio/backend/tests/test_export_imatrix_compressed.py \
       tests/test_cli_export_unpacking.py
