### PR TITLE
fix(studio): rewind the MLX PRNG in the KV quantization probe without item assignment

### DIFF
--- a/studio/backend/core/inference/mlx_inference.py
+++ b/studio/backend/core/inference/mlx_inference.py
@@ -410,6 +410,34 @@ def _normalize_mlx_kv_bits(value):
     return bits
 
 
+def _mlx_rng_key_words():
+    """The MLX PRNG key as its two 32-bit words, or None if it cannot be read.
+
+    Deciding it here is what lets the rewind below stay unconditional.
+    """
+    import mlx.core as mx
+
+    try:
+        words = mx.random.state[0].tolist()
+    except Exception:
+        return None
+    return (int(words[0]), int(words[1])) if len(words) == 2 else None
+
+
+def _restore_mlx_rng_key(words):
+    """Rewind the MLX PRNG to a key captured by ``_mlx_rng_key_words``.
+
+    mlx 0.32.1 made mx.random.state a sentinel that refuses item assignment.
+    mx.random.key packs a seed as its two 32-bit halves, so reseeding with a
+    key's own words restores it exactly, over the whole unsigned 64-bit range.
+    """
+    import mlx.core as mx
+
+    if words is None:
+        return
+    mx.random.seed((words[0] << 32) | words[1])
+
+
 def _kv_quant_probe(language_model, entries, bits):
     """Attempt the conversion the runtime will perform, on a real cache.
 
@@ -438,8 +466,7 @@ def _kv_quant_probe(language_model, entries, bits):
         return 0, 0, "it uses a bounded sliding window", True
 
     # The forward pass below draws random numbers, so keep sampled output stable.
-    # mx.random.state is mutated in place, so restore element-wise, not by rebinding.
-    rng_state = list(mx.random.state)
+    rng_key = _mlx_rng_key_words()
     try:
         try:
             language_model(mx.array([[0]]), cache = entries)
@@ -465,7 +492,7 @@ def _kv_quant_probe(language_model, entries, bits):
                 retainable = False
         return converted, skipped, None, retainable
     finally:
-        mx.random.state[:] = rng_state
+        _restore_mlx_rng_key(rng_key)
 
 
 def _kv_quant_eligibility(

--- a/studio/backend/tests/test_mlx_inference_backend.py
+++ b/studio/backend/tests/test_mlx_inference_backend.py
@@ -2711,6 +2711,69 @@ def test_an_entry_the_upstream_lru_cannot_size_is_not_retainable(monkeypatch):
     assert probe(SimpleNamespace(state = (), nbytes = 128))[3] is True
 
 
+class _SentinelRandomState:
+    """``mx.random.state`` as mlx >= 0.32.1 exposes it: readable, not writable."""
+
+    def __init__(self, words):
+        self._words = list(words)
+
+    def __len__(self):
+        return 1
+
+    def __getitem__(self, index):
+        if index not in (0, -1):
+            raise IndexError("random state index out of range")
+        return SimpleNamespace(tolist = lambda: list(self._words))
+
+    def __iter__(self):
+        return iter([self[0]])
+
+
+def test_kv_quant_probe_rewinds_the_rng_without_assigning_to_the_state(monkeypatch):
+    """mlx 0.32.1 made mx.random.state a sentinel with no __setitem__, so the
+    assignment this used to do raised out of the probe's finally and failed the
+    whole model load.
+    """
+    from core.inference import mlx_inference
+
+    _install_fake_mlx(monkeypatch)
+    mx = sys.modules["mlx.core"]
+    # High word's top bit set, so a rewind that packs the seed as signed is visible.
+    words = (0xFEDCBA98, 0x76543210)
+    events = []
+    mx.random = SimpleNamespace(
+        state = _SentinelRandomState(words),
+        seed = lambda value: events.append(("seed", value)),
+    )
+    mx.array = lambda v: v
+    mx.eval = lambda *a: None
+    mx.clear_cache = lambda: None
+
+    def language_model(*args, **kwargs):
+        events.append(("forward", None))
+
+    def to_quantized(group_size, bits):
+        events.append(("convert", None))
+        return SimpleNamespace(state = (), nbytes = 128)
+
+    entry = SimpleNamespace(
+        to_quantized = to_quantized,
+        max_size = None,
+        window_size = None,
+        state = (),
+    )
+    outcome = mlx_inference._kv_quant_probe(language_model, [entry], 8)
+
+    assert outcome == (1, 0, None, True)
+    # A rewind that ran before the forward pass would leave the probe's own
+    # draws in the stream the caller goes on to sample.
+    assert events == [
+        ("forward", None),
+        ("convert", None),
+        ("seed", (words[0] << 32) | words[1]),
+    ]
+
+
 def test_a_successful_override_does_not_pin_the_tokenizer_past_load(monkeypatch):
     """The restore pairs hold the tokenizer, so unload_model cannot free it.
 


### PR DESCRIPTION
Fixes https://github.com/unslothai/unsloth/issues/9466.

## Behaviour

On mlx 0.32.1, loading any MLX model with **KV Cache Dtype set to anything other than Auto** fails with:

```text
Failed to load model: This model is not supported yet.
Original error: 'mlx.core.random._RandomState' object does not support item assignment
```

The weights are already resident when this raises, so the worker also holds that memory until it is killed. The reporter confirmed that setting KV Cache Dtype back to Auto is a complete workaround, which matches the diagnosis below: Auto skips the probe entirely.

The message is doubly misleading. Nothing about the checkpoint is unsupported — an internal `TypeError` is being rewritten into a verdict about the user's model.

## Root cause

mlx 0.32.1 replaced `mx.random.state` — previously a plain list — with a `mlx.core.random._RandomState` sentinel exposing `__len__`, `__getitem__` and `__iter__` but no `__setitem__` ([ml-explore/mlx#3828](https://github.com/ml-explore/mlx/pull/3828), on PyPI 2026-08-18).

`_kv_quant_probe` runs a forward pass to decide whether a model's KV cache can be quantized, and restored the pre-probe PRNG key from a `finally` with `mx.random.state[:] = rng_state`. On 0.32.1 that assignment raises, the `TypeError` escapes the `finally`, and it fails the entire load. The probe only runs when a bit width was requested, which is why Auto is unaffected.

The probe itself was added recently, so the two halves arrived within two weeks of each other: this code shipped 2026-08-07, mlx 0.32.1 landed 2026-08-18. Either alone is harmless.

## What changed

`_kv_quant_probe` captures the key as its two 32-bit words and rewinds with `mx.random.seed`. `mx.random.key(seed)` builds `array([seed >> 32, seed & 0xFFFFFFFF], uint32)`, so key packing is exactly invertible and reseeding with a captured key's own words restores that key on every mlx version.

Capture returns `None` when the state cannot be read, so the rewind in the `finally` is unconditional and cannot raise a second error over the probe's own outcome — which is the failure shape being fixed.

The rewind is deliberately duplicated here rather than imported from `unsloth-zoo`, which carries the same fix for its own call sites. The two components release independently, so a shared symbol would have to be imported defensively — more code than the six lines it would save, and it would couple this fix to a zoo release.

## Why reseeding is equivalent, not approximate

- On mlx 0.32.0 the seed round-trip and the previous item assignment produce **bit-identical** subsequent draws.
- `mx.random.seed` accepts and exactly round-trips the **full unsigned 64-bit range**, including `0x8000000000000000` and `0xFFFFFFFFFFFFFFFF`. Keys with the high bit set are half of all real keys, so this was measured rather than assumed.

## Not in scope

Two adjacent defects this incident exposed are left for follow-ups, to keep the fix reviewable:

- `_NOT_SUPPORTED_HINTS` in `studio/backend/routes/inference.py` matches the bare substring `"does not support"`, so any internal `TypeError` of that shape becomes "This model is not supported yet". That is what sent the reporter looking at their checkpoint.
- `load_model` leaves the weights resident when it raises after loading them, so a failed load holds memory until the worker is killed.

The issue thread also contains a second, unrelated failure during generation. That one is an upstream bug in mlx-vlm ≤ 0.6.8 (`BPEStreamingDetokenizer.add_token` flushing its byte buffer with a strict `.decode("utf-8")`), fixed upstream in mlx-vlm 0.6.9, so the issue is linked here rather than closed.

## Validation

```bash
cd studio/backend && python -m pytest tests/test_mlx_inference_backend.py -q
```

91 passed.

The added test was mutation-checked twice against the production change:

- restoring by item assignment fails it with `TypeError: '_SentinelRandomState' object does not support item assignment`, mirroring the reported error, because the stand-in state has no `__setitem__` just as the real one does not;
- moving the rewind ahead of the forward pass also fails it, since the test asserts event order across the forward pass, the conversion and the rewind — proving the rewind still happens in the `finally` and not merely that it happens.
