### PR TITLE
fix(install): restore symlink members when extracting sd.cpp prebuilts

### DIFF
--- a/studio/backend/tests/test_sd_cpp_install.py
+++ b/studio/backend/tests/test_sd_cpp_install.py
@@ -871,11 +871,14 @@ def test_safe_extractall_refuses_to_flatten_when_a_unix_host_rejects_symlinks(
 ):
     # Off Windows a refusal means this filesystem cannot hold the layout sd-cli needs. Writing
     # the link text back as a file would rebuild the "file too short" install #9268 reports,
-    # which the runtime probe then discards and reinstalls on every load.
+    # which the runtime probe then discards and reinstalls on every load. Caught before
+    # extractall, so an upgrade that cannot finish still leaves the previous install runnable.
     target = tmp_path / "install"
     target.mkdir()
+    (target / "sd-cli").write_bytes(b"\x7fELF old working")
     archive = tmp_path / "libs.zip"
     with zipfile.ZipFile(archive, "w") as zf:
+        zf.writestr("sd-cli", b"\x7fELF replacement")
         zf.writestr("libwebp.so.7.2.0", b"ELFpayload")
         _link_member(zf, "libwebp.so.7", "libwebp.so.7.2.0")
 
@@ -885,9 +888,25 @@ def test_safe_extractall_refuses_to_flatten_when_a_unix_host_rejects_symlinks(
     monkeypatch.setattr(Path, "symlink_to", _no_symlinks)
     monkeypatch.setattr(sdmod.sys, "platform", "linux")
     with zipfile.ZipFile(archive) as zf:
-        with pytest.raises(RuntimeError, match = "could not restore the symlink"):
+        with pytest.raises(RuntimeError, match = "cannot store symlinks"):
             _safe_extractall(zf, target)
     assert not (target / "libwebp.so.7").exists()
+    assert not (target / "libwebp.so.7.2.0").exists()
+    assert (target / "sd-cli").read_bytes() == b"\x7fELF old working"
+
+
+def test_safe_extractall_rejects_a_link_that_descends_through_itself(tmp_path):
+    # a -> a/x never reaches a second node, so exact-node repetition misses it, but resolving
+    # a walks a again and every load would fail with ELOOP and reinstall.
+    target = tmp_path / "install"
+    target.mkdir()
+    archive = tmp_path / "loop.zip"
+    with zipfile.ZipFile(archive, "w") as zf:
+        _link_member(zf, "libz.so", "libz.so/inner")
+    with zipfile.ZipFile(archive) as zf:
+        with pytest.raises(RuntimeError, match = "symlink cycle"):
+            _safe_extractall(zf, target)
+    assert not any(target.iterdir())
 
 
 def test_safe_extractall_extracts_normal_members(tmp_path):

--- a/studio/backend/tests/test_sd_cpp_install.py
+++ b/studio/backend/tests/test_sd_cpp_install.py
@@ -472,25 +472,29 @@ def test_safe_extractall_rejects_malformed_symlink_targets(tmp_path, link_target
 def test_safe_extractall_rejects_a_symlink_redirected_parent(tmp_path):
     if not _can_create_symlinks(tmp_path):
         pytest.skip("symlink creation needs privilege on this host (Windows non-dev-mode)")
-    # An earlier member can turn a later member's parent into a link, which the pre-extraction
-    # pass cannot see because no link exists yet. Without a re-check at creation time, the
-    # third member's unlink/symlink_to lands on a file outside the install dir.
+    # An earlier member can turn a later member's parent into a link. Preflight refuses the
+    # member under it, so nothing outside is touched and nothing inside is half replaced: the
+    # working binary an install would have overwritten is still the one that was there.
     target = tmp_path / "install"
     target.mkdir()
+    (target / "sd-cli").write_bytes(b"working binary from the previous install")
     outside = tmp_path / "outside_dir"
     outside.mkdir()
     victim = outside / "victim"
     victim.write_bytes(b"outside the install dir")
     archive = tmp_path / "evil.zip"
     with zipfile.ZipFile(archive, "w") as zf:
+        zf.writestr("sd-cli", b"replacement from the rejected archive")
         _link_member(zf, "a", ".")
         _link_member(zf, "a/out", "../outside_dir")
         _link_member(zf, "a/out/victim", "replacement")
     with zipfile.ZipFile(archive) as zf:
-        with pytest.raises(RuntimeError, match = "unsafe symlink"):
+        with pytest.raises(RuntimeError, match = "under a symlink member"):
             _safe_extractall(zf, target)
     assert not victim.is_symlink()
     assert victim.read_bytes() == b"outside the install dir"
+    assert (target / "sd-cli").read_bytes() == b"working binary from the previous install"
+    assert sorted(p.name for p in target.iterdir()) == ["sd-cli"]
 
 
 def test_the_sweep_keeps_a_binary_supplied_under_a_symlinked_directory(tmp_path):

--- a/studio/backend/tests/test_sd_cpp_install.py
+++ b/studio/backend/tests/test_sd_cpp_install.py
@@ -417,7 +417,12 @@ def _can_create_symlinks(tmp_path) -> bool:
     return True
 
 
-def _link_member(zf, name: str, link_target: str, create_system: int = 3) -> None:
+def _link_member(
+    zf,
+    name: str,
+    link_target: str,
+    create_system: int = 3,
+) -> None:
     """Write ``name`` as the symlink member CPython's zipfile produces: the Unix symlink
     mode in external_attr, the link target as the data."""
     info = zipfile.ZipInfo(name)
@@ -448,11 +453,11 @@ def test_safe_extractall_rejects_escaping_symlink(tmp_path):
 @pytest.mark.parametrize(
     "link_target",
     [
-        "/etc/passwd",          # absolute, outside
-        "C:outside.dll",        # Windows drive-relative: Win32 resolves it off that drive's cwd
-        "",                     # empty
-        "real\x00.so",          # NUL
-        "libself.so",           # self-referential, the shape the old resolve() bug produced
+        "/etc/passwd",  # absolute, outside
+        "C:outside.dll",  # Windows drive-relative: Win32 resolves it off that drive's cwd
+        "",  # empty
+        "real\x00.so",  # NUL
+        "libself.so",  # self-referential, the shape the old resolve() bug produced
     ],
 )
 def test_safe_extractall_rejects_malformed_symlink_targets(tmp_path, link_target):

--- a/studio/backend/tests/test_sd_cpp_install.py
+++ b/studio/backend/tests/test_sd_cpp_install.py
@@ -469,6 +469,30 @@ def test_safe_extractall_rejects_malformed_symlink_targets(tmp_path, link_target
     assert not any(target.iterdir())
 
 
+def test_safe_extractall_rejects_a_symlink_redirected_parent(tmp_path):
+    if not _can_create_symlinks(tmp_path):
+        pytest.skip("symlink creation needs privilege on this host (Windows non-dev-mode)")
+    # An earlier member can turn a later member's parent into a link, which the pre-extraction
+    # pass cannot see because no link exists yet. Without a re-check at creation time, the
+    # third member's unlink/symlink_to lands on a file outside the install dir.
+    target = tmp_path / "install"
+    target.mkdir()
+    outside = tmp_path / "outside_dir"
+    outside.mkdir()
+    victim = outside / "victim"
+    victim.write_bytes(b"outside the install dir")
+    archive = tmp_path / "evil.zip"
+    with zipfile.ZipFile(archive, "w") as zf:
+        _link_member(zf, "a", ".")
+        _link_member(zf, "a/out", "../outside_dir")
+        _link_member(zf, "a/out/victim", "replacement")
+    with zipfile.ZipFile(archive) as zf:
+        with pytest.raises(RuntimeError, match = "unsafe symlink"):
+            _safe_extractall(zf, target)
+    assert not victim.is_symlink()
+    assert victim.read_bytes() == b"outside the install dir"
+
+
 def test_safe_extractall_rejects_symlink_cycles(tmp_path):
     # Chains are normal, a cycle is not: it installs a library nothing can read, so the
     # loader failure would send the backend round the reinstall loop on every load.

--- a/studio/backend/tests/test_sd_cpp_install.py
+++ b/studio/backend/tests/test_sd_cpp_install.py
@@ -399,9 +399,8 @@ def test_safe_extractall_restores_symlink_members(tmp_path):
     real = target / "libwebpmux.so.3.1.2"
     assert link.is_symlink()
     assert link.readlink().name == "libwebpmux.so.3.1.2"
-    # Reads through to the real payload. The pre-fix behaviour was a 19-byte regular
-    # file holding the target text, which ldd reports as "file too short". Compare the
-    # bytes, not stat().st_size: stat() follows the link, so a size check cannot fail.
+    # Compare bytes, not stat().st_size: stat() follows the link, so a size check cannot
+    # fail. Pre-fix this was a 19-byte text file, which ldd calls "file too short".
     assert link.resolve(strict = True) == real.resolve()
     assert link.read_bytes() == b"\x7fELFpayload"
     assert not real.is_symlink()
@@ -423,8 +422,7 @@ def _link_member(
     link_target: str,
     create_system: int = 3,
 ) -> None:
-    """Write ``name`` as the symlink member CPython's zipfile produces: the Unix symlink
-    mode in external_attr, the link target as the data."""
+    """The symlink member CPython's zipfile produces: Unix link mode, target as the data."""
     info = zipfile.ZipInfo(name)
     info.create_system = create_system
     info.external_attr = (0o120777 << 16) | 0o777
@@ -432,8 +430,7 @@ def _link_member(
 
 
 def test_safe_extractall_rejects_escaping_symlink(tmp_path):
-    # Validation runs before any write, so this holds even where symlinks need
-    # privilege to create, and a rejected archive changes nothing on disk.
+    # Validation precedes every write, so this holds even where symlinks need privilege.
     target = tmp_path / "install"
     target.mkdir()
     (target / "sd-cli").write_bytes(b"working binary from the previous install")
@@ -473,9 +470,8 @@ def test_safe_extractall_rejects_malformed_symlink_targets(tmp_path, link_target
 
 
 def test_safe_extractall_rejects_symlink_cycles(tmp_path):
-    # Chains are normal (libwebp.so -> libwebp.so.7 -> libwebp.so.7.2.0), a cycle is not:
-    # it installs a library nothing can read, and the loader failure sends the backend
-    # round the discard-and-reinstall loop on every load.
+    # Chains are normal, a cycle is not: it installs a library nothing can read, so the
+    # loader failure would send the backend round the reinstall loop on every load.
     target = tmp_path / "install"
     target.mkdir()
     archive = tmp_path / "cycle.zip"
@@ -505,8 +501,7 @@ def test_safe_extractall_keeps_valid_symlink_chains(tmp_path):
 
 
 def test_safe_extractall_rejects_oversized_symlink_target(tmp_path):
-    # zf.read holds the payload in memory, so an unbounded read is a decompression bomb:
-    # a link target is a pathname and cannot legitimately exceed PATH_MAX.
+    # zf.read holds the payload in memory, and a pathname cannot exceed PATH_MAX.
     target = tmp_path / "install"
     target.mkdir()
     archive = tmp_path / "bomb.zip"
@@ -519,8 +514,7 @@ def test_safe_extractall_rejects_oversized_symlink_target(tmp_path):
 
 
 def test_safe_extractall_ignores_symlink_mode_from_non_unix_hosts(tmp_path):
-    # external_attr's high bits are only a Unix mode when a Unix host wrote the entry;
-    # for any other creator they are host-specific attributes and must not be read as one.
+    # Those high bits are a Unix mode only when a Unix host wrote the entry.
     target = tmp_path / "install"
     target.mkdir()
     archive = tmp_path / "dos.zip"
@@ -545,10 +539,8 @@ def test_safe_extractall_is_idempotent_across_reinstalls(tmp_path):
         _link_member(zf, "libwebp.so.7", "libwebp.so.7.2.0")
         _link_member(zf, "libwebp.so", "libwebp.so.7")
 
-    # install() MERGES into the managed tree, so a retry, a version bump or an accelerator
-    # switch re-extracts over the links the previous install wrote. Resolving the member
-    # path would follow them, and extraction would write the link text through them into
-    # the real library, which the restore loop then replaced with a link to itself.
+    # install() MERGES, so a retry or version bump re-extracts over the previous install's
+    # links. Resolving through them destroyed the real library they pointed at.
     for _ in range(3):
         with zipfile.ZipFile(archive) as zf:
             _safe_extractall(zf, target)
@@ -604,8 +596,8 @@ def test_safe_extractall_survives_a_hand_repaired_install(tmp_path):
 
 
 def test_safe_extractall_falls_back_when_symlinks_are_unavailable(tmp_path, monkeypatch):
-    # A Windows host outside developer mode cannot create symlinks. The install must still
-    # finish with the flattened member, exactly as it did before symlinks were restored.
+    # Windows outside developer mode cannot create symlinks. The install must still finish
+    # with the flattened member, exactly as it did before symlinks were restored.
     target = tmp_path / "install"
     target.mkdir()
     archive = tmp_path / "libs.zip"

--- a/studio/backend/tests/test_sd_cpp_install.py
+++ b/studio/backend/tests/test_sd_cpp_install.py
@@ -376,6 +376,63 @@ def test_safe_extractall_rejects_path_traversal(tmp_path):
     assert not (tmp_path / "escape.txt").exists()
 
 
+def test_safe_extractall_restores_symlink_members(tmp_path):
+    if not _can_create_symlinks(tmp_path):
+        pytest.skip("symlink creation needs privilege on this host (Windows non-dev-mode)")
+    target = tmp_path / "install"
+    target.mkdir()
+    archive = tmp_path / "libs.zip"
+    # A symlink member carries the Unix symlink mode in external_attr and the
+    # link target as its data — the shape CPython's zipfile writes when zipping
+    # a symlink, and what upstream sd.cpp release zips ship for lib*.so.
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.writestr("libwebpmux.so.3.1.2", b"ELFpayload")
+        info = zipfile.ZipInfo("libwebpmux.so.3")
+        info.create_system = 3
+        info.external_attr = (0o120777 << 16) | 0o777
+        zf.writestr(info, "libwebpmux.so.3.1.2")
+
+    with zipfile.ZipFile(archive) as zf:
+        _safe_extractall(zf, target)
+
+    link = target / "libwebpmux.so.3"
+    real = target / "libwebpmux.so.3.1.2"
+    assert link.is_symlink()
+    assert link.readlink().name == "libwebpmux.so.3.1.2"
+    # The pre-fix behaviour: a 19-byte regular file holding the target text,
+    # which ldd reports as "file too short".
+    assert link.stat().st_size == real.stat().st_size
+
+
+def _can_create_symlinks(tmp_path) -> bool:
+    probe = tmp_path / "_link_probe"
+    try:
+        probe.symlink_to("target.txt")
+    except OSError:
+        return False
+    probe.unlink(missing_ok = True)
+    return True
+
+
+def test_safe_extractall_rejects_escaping_symlink(tmp_path):
+    import stat as stat_mod
+
+    # The escape check runs before any link creation, so it must hold even
+    # where symlinks need privilege to create.
+    target = tmp_path / "install"
+    target.mkdir()
+    archive = tmp_path / "evil.zip"
+    with zipfile.ZipFile(archive, "w") as zf:
+        info = zipfile.ZipInfo("libescape.so")
+        info.create_system = 3
+        info.external_attr = (stat_mod.S_IFLNK | 0o777) << 16
+        zf.writestr(info, "../../outside.so")
+    with zipfile.ZipFile(archive) as zf:
+        with pytest.raises(RuntimeError, match = "unsafe symlink"):
+            _safe_extractall(zf, target)
+    assert not (tmp_path / "outside.so").exists()
+
+
 def test_safe_extractall_extracts_normal_members(tmp_path):
     target = tmp_path / "install"
     target.mkdir()

--- a/studio/backend/tests/test_sd_cpp_install.py
+++ b/studio/backend/tests/test_sd_cpp_install.py
@@ -520,6 +520,49 @@ def test_the_sweep_keeps_a_binary_supplied_under_a_symlinked_directory(tmp_path)
     assert (target / "real" / "sd-cli").read_bytes() == b"\x7fELF new binary"
 
 
+def test_the_sweep_keeps_a_binary_whose_parent_link_the_archive_replaces(tmp_path):
+    if not _can_create_symlinks(tmp_path):
+        pytest.skip("symlink creation needs privilege on this host (Windows non-dev-mode)")
+    # An explicit directory member replaces the previous bundle's directory symlink, so a key
+    # resolved before extraction points into a layout that no longer exists by sweep time.
+    target = tmp_path / "install"
+    target.mkdir()
+    (target / "real").mkdir()
+    (target / "build").mkdir()
+    (target / "build" / "bin").symlink_to(target / "real")
+    archive = tmp_path / "bundle.zip"
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.writestr("build/bin/", b"")
+        zf.writestr("build/bin/sd-cli", b"\x7fELF new binary")
+
+    with zipfile.ZipFile(archive) as zf:
+        supplied = sdmod._archive_binary_paths(zf, target)
+        _safe_extractall(zf, target)
+    sdmod._discard_superseded_binaries(target, supplied)
+
+    assert sdmod._locate_sd_cli(target) is not None
+
+
+def test_safe_extractall_rejects_an_existing_cycle_before_writing_anything(tmp_path):
+    if not _can_create_symlinks(tmp_path):
+        pytest.skip("symlink creation needs privilege on this host (Windows non-dev-mode)")
+    # The cycle is closed by a link the previous bundle left, so it is only visible against the
+    # tree. Deciding it up front is what keeps a refused archive from replacing the binary.
+    target = tmp_path / "install"
+    target.mkdir()
+    (target / "b").symlink_to("a")
+    (target / "sd-cli").write_bytes(b"\x7fELF working binary")
+    archive = tmp_path / "evil.zip"
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.writestr("sd-cli", b"replacement from the rejected archive")
+        _link_member(zf, "a", "b")
+    with zipfile.ZipFile(archive) as zf:
+        with pytest.raises(RuntimeError, match = "symlink cycle"):
+            _safe_extractall(zf, target)
+    assert (target / "sd-cli").read_bytes() == b"\x7fELF working binary"
+    assert not (target / "a").exists() and not (target / "a").is_symlink()
+
+
 def test_the_sweep_keeps_a_binary_the_bundle_ships_as_a_symlink(tmp_path):
     if not _can_create_symlinks(tmp_path):
         pytest.skip("symlink creation needs privilege on this host (Windows non-dev-mode)")
@@ -761,6 +804,7 @@ def test_safe_extractall_falls_back_when_symlinks_are_unavailable(tmp_path, monk
         raise OSError(1314, "A required privilege is not held by the client")
 
     monkeypatch.setattr(Path, "symlink_to", _no_symlinks)
+    monkeypatch.setattr(sdmod.sys, "platform", "win32")
     with zipfile.ZipFile(archive) as zf:
         _safe_extractall(zf, target)
 
@@ -768,6 +812,30 @@ def test_safe_extractall_falls_back_when_symlinks_are_unavailable(tmp_path, monk
     assert not flattened.is_symlink()
     assert flattened.read_bytes() == b"libwebp.so.7.2.0"
     assert (target / "libwebp.so.7.2.0").read_bytes() == b"ELFpayload"
+
+
+def test_safe_extractall_refuses_to_flatten_when_a_unix_host_rejects_symlinks(
+    tmp_path, monkeypatch
+):
+    # Off Windows a refusal means this filesystem cannot hold the layout sd-cli needs. Writing
+    # the link text back as a file would rebuild the "file too short" install #9268 reports,
+    # which the runtime probe then discards and reinstalls on every load.
+    target = tmp_path / "install"
+    target.mkdir()
+    archive = tmp_path / "libs.zip"
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.writestr("libwebp.so.7.2.0", b"ELFpayload")
+        _link_member(zf, "libwebp.so.7", "libwebp.so.7.2.0")
+
+    def _no_symlinks(self, *args, **kwargs):
+        raise OSError(1, "Operation not permitted")
+
+    monkeypatch.setattr(Path, "symlink_to", _no_symlinks)
+    monkeypatch.setattr(sdmod.sys, "platform", "linux")
+    with zipfile.ZipFile(archive) as zf:
+        with pytest.raises(RuntimeError, match = "could not restore the symlink"):
+            _safe_extractall(zf, target)
+    assert not (target / "libwebp.so.7").exists()
 
 
 def test_safe_extractall_extracts_normal_members(tmp_path):

--- a/studio/backend/tests/test_sd_cpp_install.py
+++ b/studio/backend/tests/test_sd_cpp_install.py
@@ -406,6 +406,10 @@ def test_safe_extractall_restores_symlink_members(tmp_path):
     assert not real.is_symlink()
 
 
+# The binary the sweep looks for, spelled the way this host spells it.
+_CLI = sdmod._binary_names()[0]
+
+
 def _can_create_symlinks(tmp_path) -> bool:
     probe = tmp_path / "_link_probe"
     try:
@@ -509,7 +513,7 @@ def test_the_sweep_keeps_a_binary_supplied_under_a_symlinked_directory(tmp_path)
     (target / "build" / "bin").symlink_to(target / "real")
     archive = tmp_path / "bundle.zip"
     with zipfile.ZipFile(archive, "w") as zf:
-        zf.writestr("build/bin/sd-cli", b"\x7fELF new binary")
+        zf.writestr(f"build/bin/{_CLI}", b"\x7fELF new binary")
 
     with zipfile.ZipFile(archive) as zf:
         supplied = sdmod._archive_binary_paths(zf, target)
@@ -517,7 +521,7 @@ def test_the_sweep_keeps_a_binary_supplied_under_a_symlinked_directory(tmp_path)
     sdmod._discard_superseded_binaries(target, supplied)
 
     assert sdmod._locate_sd_cli(target) is not None
-    assert (target / "real" / "sd-cli").read_bytes() == b"\x7fELF new binary"
+    assert (target / "real" / _CLI).read_bytes() == b"\x7fELF new binary"
 
 
 def test_the_sweep_keeps_a_binary_whose_parent_link_the_archive_replaces(tmp_path):
@@ -533,7 +537,7 @@ def test_the_sweep_keeps_a_binary_whose_parent_link_the_archive_replaces(tmp_pat
     archive = tmp_path / "bundle.zip"
     with zipfile.ZipFile(archive, "w") as zf:
         zf.writestr("build/bin/", b"")
-        zf.writestr("build/bin/sd-cli", b"\x7fELF new binary")
+        zf.writestr(f"build/bin/{_CLI}", b"\x7fELF new binary")
 
     with zipfile.ZipFile(archive) as zf:
         supplied = sdmod._archive_binary_paths(zf, target)
@@ -572,15 +576,15 @@ def test_the_sweep_keeps_a_binary_the_bundle_ships_as_a_symlink(tmp_path):
     target.mkdir()
     archive = tmp_path / "bundle.zip"
     with zipfile.ZipFile(archive, "w") as zf:
-        zf.writestr("build/bin/sd-cli-1.2", b"\x7fELF new binary")
-        _link_member(zf, "build/bin/sd-cli", "sd-cli-1.2")
+        zf.writestr(f"build/bin/{_CLI}-1.2", b"\x7fELF new binary")
+        _link_member(zf, f"build/bin/{_CLI}", f"{_CLI}-1.2")
 
     with zipfile.ZipFile(archive) as zf:
         supplied = sdmod._archive_binary_paths(zf, target)
         _safe_extractall(zf, target)
     sdmod._discard_superseded_binaries(target, supplied)
 
-    assert (target / "build" / "bin" / "sd-cli").is_symlink()
+    assert (target / "build" / "bin" / _CLI).is_symlink()
     assert sdmod._locate_sd_cli(target) is not None
 
 
@@ -893,6 +897,41 @@ def test_safe_extractall_refuses_to_flatten_when_a_unix_host_rejects_symlinks(
     assert not (target / "libwebp.so.7").exists()
     assert not (target / "libwebp.so.7.2.0").exists()
     assert (target / "sd-cli").read_bytes() == b"\x7fELF old working"
+
+
+def test_safe_extractall_rejects_a_member_with_a_parent_component(tmp_path):
+    # extractall drops ".." instead of cancelling the component before it, so "a/../victim"
+    # is "a/victim" to it, and an existing link at "a" lands the write outside the tree.
+    if not _can_create_symlinks(tmp_path):
+        pytest.skip("symlink creation needs privilege on this host (Windows non-dev-mode)")
+    target = tmp_path / "install"
+    target.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "victim").write_bytes(b"untouched")
+    (target / "a").symlink_to(outside)
+    archive = tmp_path / "slip.zip"
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.writestr("a/../victim", b"pwned")
+    with zipfile.ZipFile(archive) as zf:
+        with pytest.raises(RuntimeError, match = "unsafe path"):
+            _safe_extractall(zf, target)
+    assert (outside / "victim").read_bytes() == b"untouched"
+
+
+def test_safe_extractall_rejects_a_cycle_closed_through_link_parents(tmp_path):
+    # a -> b/x and b -> a/y are one cycle only once the b prefix is followed through the
+    # archive, since neither link exists on disk when the graph is built.
+    target = tmp_path / "install"
+    target.mkdir()
+    archive = tmp_path / "cycle.zip"
+    with zipfile.ZipFile(archive, "w") as zf:
+        _link_member(zf, "a", "b/x")
+        _link_member(zf, "b", "a/y")
+    with zipfile.ZipFile(archive) as zf:
+        with pytest.raises(RuntimeError, match = "symlink cycle"):
+            _safe_extractall(zf, target)
+    assert not any(target.iterdir())
 
 
 def test_safe_extractall_rejects_a_link_that_descends_through_itself(tmp_path):

--- a/studio/backend/tests/test_sd_cpp_install.py
+++ b/studio/backend/tests/test_sd_cpp_install.py
@@ -493,6 +493,30 @@ def test_safe_extractall_rejects_a_symlink_redirected_parent(tmp_path):
     assert victim.read_bytes() == b"outside the install dir"
 
 
+def test_safe_extractall_allows_a_parent_symlinked_inside_the_tree(tmp_path):
+    if not _can_create_symlinks(tmp_path):
+        pytest.skip("symlink creation needs privilege on this host (Windows non-dev-mode)")
+    # The creation-time re-check asks whether the parent still resolves INSIDE the install
+    # dir, not whether it is link-free, so a tree that symlinks one of its own subdirectories
+    # still installs. A parent pointing outside is already refused by the member-path check.
+    target = tmp_path / "install"
+    target.mkdir()
+    (target / "real_bin").mkdir()
+    (target / "build").mkdir()
+    (target / "build" / "bin").symlink_to(target / "real_bin")
+    archive = tmp_path / "libs.zip"
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.writestr("build/bin/libwebp.so.7.2.0", b"\x7fELFpayload")
+        _link_member(zf, "build/bin/libwebp.so.7", "libwebp.so.7.2.0")
+
+    with zipfile.ZipFile(archive) as zf:
+        _safe_extractall(zf, target)
+
+    link = target / "build" / "bin" / "libwebp.so.7"
+    assert link.is_symlink()
+    assert link.read_bytes() == b"\x7fELFpayload"
+
+
 def test_safe_extractall_rejects_symlink_cycles(tmp_path):
     # Chains are normal, a cycle is not: it installs a library nothing can read, so the
     # loader failure would send the backend round the reinstall loop on every load.

--- a/studio/backend/tests/test_sd_cpp_install.py
+++ b/studio/backend/tests/test_sd_cpp_install.py
@@ -668,6 +668,21 @@ def test_safe_extractall_rejects_a_symlink_at_a_reserved_installer_path(tmp_path
     assert not any(target.iterdir())
 
 
+def test_safe_extractall_rejects_a_symlink_onto_a_reserved_installer_path(tmp_path):
+    # The marker exists before extraction on any root Studio owns, so a link to it resolves
+    # to a file and _locate_sd_cli reports an empty one as the executable.
+    target = tmp_path / "install"
+    target.mkdir()
+    (target / sdmod.OWNERSHIP_MARKER).write_text("")
+    archive = tmp_path / "evil.zip"
+    with zipfile.ZipFile(archive, "w") as zf:
+        _link_member(zf, _CLI, sdmod.OWNERSHIP_MARKER)
+    with zipfile.ZipFile(archive) as zf:
+        with pytest.raises(RuntimeError, match = "onto a reserved installer path"):
+            _safe_extractall(zf, target)
+    assert sdmod._locate_sd_cli(target) is None
+
+
 def test_safe_extractall_rejects_a_reserved_path_reached_through_a_directory_alias(tmp_path):
     # A previous bundle's directory link makes alias/<record> land on the record itself, so a
     # lexical comparison misses it and _write_install_record overwrites sd-cli with JSON.

--- a/studio/backend/tests/test_sd_cpp_install.py
+++ b/studio/backend/tests/test_sd_cpp_install.py
@@ -517,6 +517,62 @@ def test_safe_extractall_allows_a_parent_symlinked_inside_the_tree(tmp_path):
     assert link.read_bytes() == b"\x7fELFpayload"
 
 
+def test_safe_extractall_drops_a_stale_link_at_a_regular_members_path(tmp_path):
+    if not _can_create_symlinks(tmp_path):
+        pytest.skip("symlink creation needs privilege on this host (Windows non-dev-mode)")
+    # An accelerator switch lands exactly here: upstream ships lib*.so as links, the mirror
+    # ships plain copies. extractall opens its destination "wb", so a leftover link would send
+    # one member's bytes into the file it points at and lose them.
+    target = tmp_path / "install"
+    target.mkdir()
+    (target / "real").write_bytes(b"old real lib")
+    (target / "name").symlink_to("real")
+    archive = tmp_path / "next.zip"
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.writestr("name", b"new name bytes")
+        zf.writestr("real", b"new real bytes")
+
+    with zipfile.ZipFile(archive) as zf:
+        _safe_extractall(zf, target)
+
+    assert not (target / "name").is_symlink()
+    assert (target / "name").read_bytes() == b"new name bytes"
+    assert (target / "real").read_bytes() == b"new real bytes"
+
+
+def test_safe_extractall_rejects_a_cycle_closed_by_an_existing_link(tmp_path):
+    if not _can_create_symlinks(tmp_path):
+        pytest.skip("symlink creation needs privilege on this host (Windows non-dev-mode)")
+    # The graph on disk also holds links a previous bundle left, so archive-to-archive edges
+    # alone cannot see a cycle. The half this archive created must not survive the rejection,
+    # or the retry meets the same loop.
+    target = tmp_path / "install"
+    target.mkdir()
+    (target / "b").symlink_to("a")
+    archive = tmp_path / "next.zip"
+    with zipfile.ZipFile(archive, "w") as zf:
+        _link_member(zf, "a", "b")
+    with zipfile.ZipFile(archive) as zf:
+        with pytest.raises(RuntimeError, match = "symlink cycle"):
+            _safe_extractall(zf, target)
+    assert not (target / "a").is_symlink()
+
+
+def test_safe_extractall_rejects_a_symlink_at_a_reserved_installer_path(tmp_path):
+    # _write_install_record opens the record with "w", which follows a link planted there and
+    # overwrites its target, while the record still reads back, so the install reports success.
+    target = tmp_path / "install"
+    target.mkdir()
+    archive = tmp_path / "evil.zip"
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.writestr("sd-cli", b"\x7fELF real binary")
+        _link_member(zf, sdmod.INSTALL_RECORD, "sd-cli")
+    with zipfile.ZipFile(archive) as zf:
+        with pytest.raises(RuntimeError, match = "reserved installer path"):
+            _safe_extractall(zf, target)
+    assert not any(target.iterdir())
+
+
 def test_safe_extractall_rejects_symlink_cycles(tmp_path):
     # Chains are normal, a cycle is not: it installs a library nothing can read, so the
     # loader failure would send the backend round the reinstall loop on every load.

--- a/studio/backend/tests/test_sd_cpp_install.py
+++ b/studio/backend/tests/test_sd_cpp_install.py
@@ -383,10 +383,10 @@ def test_safe_extractall_restores_symlink_members(tmp_path):
     target.mkdir()
     archive = tmp_path / "libs.zip"
     # A symlink member carries the Unix symlink mode in external_attr and the
-    # link target as its data — the shape CPython's zipfile writes when zipping
+    # link target as its data: the shape CPython's zipfile writes when zipping
     # a symlink, and what upstream sd.cpp release zips ship for lib*.so.
     with zipfile.ZipFile(archive, "w") as zf:
-        zf.writestr("libwebpmux.so.3.1.2", b"ELFpayload")
+        zf.writestr("libwebpmux.so.3.1.2", b"\x7fELFpayload")
         info = zipfile.ZipInfo("libwebpmux.so.3")
         info.create_system = 3
         info.external_attr = (0o120777 << 16) | 0o777
@@ -399,9 +399,12 @@ def test_safe_extractall_restores_symlink_members(tmp_path):
     real = target / "libwebpmux.so.3.1.2"
     assert link.is_symlink()
     assert link.readlink().name == "libwebpmux.so.3.1.2"
-    # The pre-fix behaviour: a 19-byte regular file holding the target text,
-    # which ldd reports as "file too short".
-    assert link.stat().st_size == real.stat().st_size
+    # Reads through to the real payload. The pre-fix behaviour was a 19-byte regular
+    # file holding the target text, which ldd reports as "file too short". Compare the
+    # bytes, not stat().st_size: stat() follows the link, so a size check cannot fail.
+    assert link.resolve(strict = True) == real.resolve()
+    assert link.read_bytes() == b"\x7fELFpayload"
+    assert not real.is_symlink()
 
 
 def _can_create_symlinks(tmp_path) -> bool:
@@ -414,23 +417,208 @@ def _can_create_symlinks(tmp_path) -> bool:
     return True
 
 
-def test_safe_extractall_rejects_escaping_symlink(tmp_path):
-    import stat as stat_mod
+def _link_member(zf, name: str, link_target: str, create_system: int = 3) -> None:
+    """Write ``name`` as the symlink member CPython's zipfile produces: the Unix symlink
+    mode in external_attr, the link target as the data."""
+    info = zipfile.ZipInfo(name)
+    info.create_system = create_system
+    info.external_attr = (0o120777 << 16) | 0o777
+    zf.writestr(info, link_target)
 
-    # The escape check runs before any link creation, so it must hold even
-    # where symlinks need privilege to create.
+
+def test_safe_extractall_rejects_escaping_symlink(tmp_path):
+    # Validation runs before any write, so this holds even where symlinks need
+    # privilege to create, and a rejected archive changes nothing on disk.
     target = tmp_path / "install"
     target.mkdir()
+    (target / "sd-cli").write_bytes(b"working binary from the previous install")
     archive = tmp_path / "evil.zip"
     with zipfile.ZipFile(archive, "w") as zf:
-        info = zipfile.ZipInfo("libescape.so")
-        info.create_system = 3
-        info.external_attr = (stat_mod.S_IFLNK | 0o777) << 16
-        zf.writestr(info, "../../outside.so")
+        zf.writestr("sd-cli", b"replacement from the rejected archive")
+        _link_member(zf, "libescape.so", "../../outside.so")
     with zipfile.ZipFile(archive) as zf:
         with pytest.raises(RuntimeError, match = "unsafe symlink"):
             _safe_extractall(zf, target)
     assert not (tmp_path / "outside.so").exists()
+    # A rejected archive must not have replaced the install it was rejected over.
+    assert (target / "sd-cli").read_bytes() == b"working binary from the previous install"
+    assert not (target / "libescape.so").exists()
+
+
+@pytest.mark.parametrize(
+    "link_target",
+    [
+        "/etc/passwd",          # absolute, outside
+        "C:outside.dll",        # Windows drive-relative: Win32 resolves it off that drive's cwd
+        "",                     # empty
+        "real\x00.so",          # NUL
+        "libself.so",           # self-referential, the shape the old resolve() bug produced
+    ],
+)
+def test_safe_extractall_rejects_malformed_symlink_targets(tmp_path, link_target):
+    target = tmp_path / "install"
+    target.mkdir()
+    archive = tmp_path / "evil.zip"
+    with zipfile.ZipFile(archive, "w") as zf:
+        _link_member(zf, "libself.so", link_target)
+    with zipfile.ZipFile(archive) as zf:
+        with pytest.raises(RuntimeError, match = "unsafe symlink"):
+            _safe_extractall(zf, target)
+    assert not any(target.iterdir())
+
+
+def test_safe_extractall_rejects_symlink_cycles(tmp_path):
+    # Chains are normal (libwebp.so -> libwebp.so.7 -> libwebp.so.7.2.0), a cycle is not:
+    # it installs a library nothing can read, and the loader failure sends the backend
+    # round the discard-and-reinstall loop on every load.
+    target = tmp_path / "install"
+    target.mkdir()
+    archive = tmp_path / "cycle.zip"
+    with zipfile.ZipFile(archive, "w") as zf:
+        _link_member(zf, "liba.so", "libb.so")
+        _link_member(zf, "libb.so", "liba.so")
+    with zipfile.ZipFile(archive) as zf:
+        with pytest.raises(RuntimeError, match = "symlink cycle"):
+            _safe_extractall(zf, target)
+    assert not any(target.iterdir())
+
+
+def test_safe_extractall_keeps_valid_symlink_chains(tmp_path):
+    if not _can_create_symlinks(tmp_path):
+        pytest.skip("symlink creation needs privilege on this host (Windows non-dev-mode)")
+    # The cycle check must not reject the chained shape upstream actually ships.
+    target = tmp_path / "install"
+    target.mkdir()
+    archive = tmp_path / "libs.zip"
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.writestr("libwebp.so.7.2.0", b"\x7fELFpayload")
+        _link_member(zf, "libwebp.so.7", "libwebp.so.7.2.0")
+        _link_member(zf, "libwebp.so", "libwebp.so.7")
+    with zipfile.ZipFile(archive) as zf:
+        _safe_extractall(zf, target)
+    assert (target / "libwebp.so").read_bytes() == b"\x7fELFpayload"
+
+
+def test_safe_extractall_rejects_oversized_symlink_target(tmp_path):
+    # zf.read holds the payload in memory, so an unbounded read is a decompression bomb:
+    # a link target is a pathname and cannot legitimately exceed PATH_MAX.
+    target = tmp_path / "install"
+    target.mkdir()
+    archive = tmp_path / "bomb.zip"
+    with zipfile.ZipFile(archive, "w", zipfile.ZIP_DEFLATED) as zf:
+        _link_member(zf, "libbomb.so", "a" * (1 << 20))
+    with zipfile.ZipFile(archive) as zf:
+        with pytest.raises(RuntimeError, match = "oversized symlink target"):
+            _safe_extractall(zf, target)
+    assert not any(target.iterdir())
+
+
+def test_safe_extractall_ignores_symlink_mode_from_non_unix_hosts(tmp_path):
+    # external_attr's high bits are only a Unix mode when a Unix host wrote the entry;
+    # for any other creator they are host-specific attributes and must not be read as one.
+    target = tmp_path / "install"
+    target.mkdir()
+    archive = tmp_path / "dos.zip"
+    with zipfile.ZipFile(archive, "w") as zf:
+        _link_member(zf, "plain.txt", "not a link", create_system = 0)
+    with zipfile.ZipFile(archive) as zf:
+        _safe_extractall(zf, target)
+    extracted = target / "plain.txt"
+    assert not extracted.is_symlink()
+    assert extracted.read_bytes() == b"not a link"
+
+
+def test_safe_extractall_is_idempotent_across_reinstalls(tmp_path):
+    if not _can_create_symlinks(tmp_path):
+        pytest.skip("symlink creation needs privilege on this host (Windows non-dev-mode)")
+    target = tmp_path / "install"
+    target.mkdir()
+    archive = tmp_path / "libs.zip"
+    # The chained shape upstream ships: libwebp.so -> libwebp.so.7 -> libwebp.so.7.2.0.
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.writestr("libwebp.so.7.2.0", b"ELFpayload")
+        _link_member(zf, "libwebp.so.7", "libwebp.so.7.2.0")
+        _link_member(zf, "libwebp.so", "libwebp.so.7")
+
+    # install() MERGES into the managed tree, so a retry, a version bump or an accelerator
+    # switch re-extracts over the links the previous install wrote. Resolving the member
+    # path would follow them, and extraction would write the link text through them into
+    # the real library, which the restore loop then replaced with a link to itself.
+    for _ in range(3):
+        with zipfile.ZipFile(archive) as zf:
+            _safe_extractall(zf, target)
+
+    real = target / "libwebp.so.7.2.0"
+    assert not real.is_symlink()
+    assert real.read_bytes() == b"ELFpayload"
+    for name in ("libwebp.so", "libwebp.so.7"):
+        assert (target / name).is_symlink()
+        assert (target / name).read_bytes() == b"ELFpayload"
+
+
+def test_safe_extractall_repairs_a_flattened_install(tmp_path):
+    if not _can_create_symlinks(tmp_path):
+        pytest.skip("symlink creation needs privilege on this host (Windows non-dev-mode)")
+    target = tmp_path / "install"
+    target.mkdir()
+    # What every pre-fix install left behind: the link flattened to its target text.
+    (target / "libwebp.so.7.2.0").write_bytes(b"ELFpayload")
+    (target / "libwebp.so.7").write_bytes(b"libwebp.so.7.2.0")
+    archive = tmp_path / "libs.zip"
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.writestr("libwebp.so.7.2.0", b"ELFpayload")
+        _link_member(zf, "libwebp.so.7", "libwebp.so.7.2.0")
+
+    with zipfile.ZipFile(archive) as zf:
+        _safe_extractall(zf, target)
+
+    assert (target / "libwebp.so.7").is_symlink()
+    assert (target / "libwebp.so.7").read_bytes() == b"ELFpayload"
+
+
+def test_safe_extractall_survives_a_hand_repaired_install(tmp_path):
+    if not _can_create_symlinks(tmp_path):
+        pytest.skip("symlink creation needs privilege on this host (Windows non-dev-mode)")
+    target = tmp_path / "install"
+    target.mkdir()
+    # The workaround #9268 tells users to apply by hand, which the next install must not undo.
+    (target / "libwebp.so.7.2.0").write_bytes(b"ELFpayload")
+    (target / "libwebp.so.7").symlink_to("libwebp.so.7.2.0")
+    archive = tmp_path / "libs.zip"
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.writestr("libwebp.so.7.2.0", b"ELFpayload")
+        _link_member(zf, "libwebp.so.7", "libwebp.so.7.2.0")
+
+    with zipfile.ZipFile(archive) as zf:
+        _safe_extractall(zf, target)
+
+    real = target / "libwebp.so.7.2.0"
+    assert not real.is_symlink()
+    assert real.read_bytes() == b"ELFpayload"
+    assert (target / "libwebp.so.7").read_bytes() == b"ELFpayload"
+
+
+def test_safe_extractall_falls_back_when_symlinks_are_unavailable(tmp_path, monkeypatch):
+    # A Windows host outside developer mode cannot create symlinks. The install must still
+    # finish with the flattened member, exactly as it did before symlinks were restored.
+    target = tmp_path / "install"
+    target.mkdir()
+    archive = tmp_path / "libs.zip"
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.writestr("libwebp.so.7.2.0", b"ELFpayload")
+        _link_member(zf, "libwebp.so.7", "libwebp.so.7.2.0")
+
+    def _no_symlinks(self, *args, **kwargs):
+        raise OSError(1314, "A required privilege is not held by the client")
+
+    monkeypatch.setattr(Path, "symlink_to", _no_symlinks)
+    with zipfile.ZipFile(archive) as zf:
+        _safe_extractall(zf, target)
+
+    flattened = target / "libwebp.so.7"
+    assert not flattened.is_symlink()
+    assert flattened.read_bytes() == b"libwebp.so.7.2.0"
+    assert (target / "libwebp.so.7.2.0").read_bytes() == b"ELFpayload"
 
 
 def test_safe_extractall_extracts_normal_members(tmp_path):

--- a/studio/backend/tests/test_sd_cpp_install.py
+++ b/studio/backend/tests/test_sd_cpp_install.py
@@ -493,6 +493,50 @@ def test_safe_extractall_rejects_a_symlink_redirected_parent(tmp_path):
     assert victim.read_bytes() == b"outside the install dir"
 
 
+def test_the_sweep_keeps_a_binary_supplied_under_a_symlinked_directory(tmp_path):
+    if not _can_create_symlinks(tmp_path):
+        pytest.skip("symlink creation needs privilege on this host (Windows non-dev-mode)")
+    # rglob reports the extracted binary under the real directory, so a lexical member path
+    # would not match and the sweep would delete the executable this bundle just supplied.
+    target = tmp_path / "install"
+    target.mkdir()
+    (target / "real").mkdir()
+    (target / "build").mkdir()
+    (target / "build" / "bin").symlink_to(target / "real")
+    archive = tmp_path / "bundle.zip"
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.writestr("build/bin/sd-cli", b"\x7fELF new binary")
+
+    with zipfile.ZipFile(archive) as zf:
+        supplied = sdmod._archive_binary_paths(zf, target)
+        _safe_extractall(zf, target)
+    sdmod._discard_superseded_binaries(target, supplied)
+
+    assert sdmod._locate_sd_cli(target) is not None
+    assert (target / "real" / "sd-cli").read_bytes() == b"\x7fELF new binary"
+
+
+def test_the_sweep_keeps_a_binary_the_bundle_ships_as_a_symlink(tmp_path):
+    if not _can_create_symlinks(tmp_path):
+        pytest.skip("symlink creation needs privilege on this host (Windows non-dev-mode)")
+    # The other half of _binary_key: resolving the final component would spell the binary as
+    # sd-cli-1.2, a name no member carries, and the sweep would take it.
+    target = tmp_path / "install"
+    target.mkdir()
+    archive = tmp_path / "bundle.zip"
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.writestr("build/bin/sd-cli-1.2", b"\x7fELF new binary")
+        _link_member(zf, "build/bin/sd-cli", "sd-cli-1.2")
+
+    with zipfile.ZipFile(archive) as zf:
+        supplied = sdmod._archive_binary_paths(zf, target)
+        _safe_extractall(zf, target)
+    sdmod._discard_superseded_binaries(target, supplied)
+
+    assert (target / "build" / "bin" / "sd-cli").is_symlink()
+    assert sdmod._locate_sd_cli(target) is not None
+
+
 def test_safe_extractall_allows_a_parent_symlinked_inside_the_tree(tmp_path):
     if not _can_create_symlinks(tmp_path):
         pytest.skip("symlink creation needs privilege on this host (Windows non-dev-mode)")

--- a/studio/backend/tests/test_sd_cpp_install.py
+++ b/studio/backend/tests/test_sd_cpp_install.py
@@ -664,6 +664,58 @@ def test_safe_extractall_rejects_a_symlink_at_a_reserved_installer_path(tmp_path
     assert not any(target.iterdir())
 
 
+def test_safe_extractall_rejects_a_reserved_path_reached_through_a_directory_alias(tmp_path):
+    # A previous bundle's directory link makes alias/<record> land on the record itself, so a
+    # lexical comparison misses it and _write_install_record overwrites sd-cli with JSON.
+    target = tmp_path / "install"
+    target.mkdir()
+    (target / "sd-cli").write_bytes(b"\x7fELF real binary")
+    (target / "alias").symlink_to(".")
+    archive = tmp_path / "evil.zip"
+    with zipfile.ZipFile(archive, "w") as zf:
+        _link_member(zf, "alias/" + sdmod.INSTALL_RECORD, "sd-cli")
+    with zipfile.ZipFile(archive) as zf:
+        with pytest.raises(RuntimeError, match = "reserved installer path"):
+            _safe_extractall(zf, target)
+    assert not (target / sdmod.INSTALL_RECORD).exists()
+    assert (target / "sd-cli").read_bytes() == b"\x7fELF real binary"
+
+
+def test_safe_extractall_rejects_a_cycle_hidden_behind_a_directory_alias(tmp_path):
+    # alias -> real means alias/a and real/b are one cycle, though the member names differ.
+    target = tmp_path / "install"
+    target.mkdir()
+    (target / "real").mkdir()
+    (target / "alias").symlink_to("real")
+    archive = tmp_path / "cycle.zip"
+    with zipfile.ZipFile(archive, "w") as zf:
+        _link_member(zf, "alias/a", "b")
+        _link_member(zf, "real/b", "a")
+    with zipfile.ZipFile(archive) as zf:
+        with pytest.raises(RuntimeError, match = "symlink cycle"):
+            _safe_extractall(zf, target)
+    assert not (target / "real" / "a").is_symlink()
+    assert not (target / "real" / "b").is_symlink()
+
+
+def test_safe_extractall_rejects_a_directory_collision_before_writing_anything(tmp_path):
+    # The collision used to be caught after extractall, so the refused archive had already
+    # replaced the working binary.
+    target = tmp_path / "install"
+    (target / "build" / "bin").mkdir(parents = True)
+    (target / "build" / "bin" / "sd-cli").write_bytes(b"\x7fELF working")
+    (target / "libz.so").mkdir()
+    archive = tmp_path / "collide.zip"
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.writestr("build/bin/sd-cli", b"\x7fELF replacement")
+        _link_member(zf, "libz.so", "libz.so.1")
+    with zipfile.ZipFile(archive) as zf:
+        with pytest.raises(RuntimeError, match = "collides with a directory"):
+            _safe_extractall(zf, target)
+    assert (target / "build" / "bin" / "sd-cli").read_bytes() == b"\x7fELF working"
+    assert (target / "libz.so").is_dir() and not (target / "libz.so").is_symlink()
+
+
 def test_safe_extractall_rejects_symlink_cycles(tmp_path):
     # Chains are normal, a cycle is not: it installs a library nothing can read, so the
     # loader failure would send the backend round the reinstall loop on every load.

--- a/studio/install_sd_cpp_prebuilt.py
+++ b/studio/install_sd_cpp_prebuilt.py
@@ -620,22 +620,20 @@ def _safe_extractall(zf: zipfile.ZipFile, target: Path) -> None:
     the ``lib*.so`` links upstream sd.cpp releases ship and leaves ``sd-cli``
     with ``file too short`` libraries (#9268)."""
     base = target.resolve()
-    # The installer writes these itself after extraction. A symlink member at one of them makes
-    # _write_install_record follow it and overwrite whatever it points at, while the record still
-    # reads back correctly, so a corrupted install reports success.
+    # The installer writes these itself. A link at one makes _write_install_record follow it and
+    # overwrite the target, while the record still reads back, so a broken install reports success.
     reserved = {base / INSTALL_RECORD, base / OWNERSHIP_MARKER}
     links: list[tuple[Path, str, zipfile.ZipInfo]] = []
     plain: list[zipfile.ZipInfo] = []
     written: list[tuple[Path, str]] = []
     for member in zf.infolist():
-        # extractall DROPS ".." components instead of cancelling the one before them, so
-        # "a/.." is "a" to it. Normalising here would compare a path it never writes to, and
-        # with a link at "a" the member lands outside base. No release ships "..", so refuse it.
+        # extractall DROPS ".." instead of cancelling the component before it, so "a/.." is "a"
+        # to it and normalising here checks a path it never writes. No release ships one.
         parts = PurePosixPath(member.filename).parts
         if ".." in parts:
             raise RuntimeError(f"unsafe path in archive: {member.filename!r}")
-        # Lexical, never resolve()d. Extraction MERGES, so resolving would follow the link the
-        # PREVIOUS install wrote and end with the real library replaced by a link to itself.
+        # Lexical, never resolve()d: extraction MERGES, and resolving would follow the previous
+        # install's link and leave the real library replaced by a link to itself.
         dest = Path(os.path.normpath(base / member.filename))
         checked = dest.resolve()
         if (dest != base and base not in dest.parents) or (
@@ -647,9 +645,8 @@ def _safe_extractall(zf: zipfile.ZipFile, target: Path) -> None:
             links.append((dest, _checked_link_target(zf, member, dest, base), member))
         else:
             plain.append(member)
-    # No member may sit under a directory this same archive turns into a link: extraction would
-    # write through the link, and the creation-time check below would only catch it once part of
-    # the tree had already been replaced. Refused here, before the first write.
+    # No member may sit under a directory this archive turns into a link: extraction would write
+    # through it, and catching that at creation time means part of the tree is already replaced.
     link_dests = {d for d, _, _ in links}
     for dest, filename in written:
         for parent in dest.parents:
@@ -659,25 +656,21 @@ def _safe_extractall(zf: zipfile.ZipFile, target: Path) -> None:
                 raise RuntimeError(
                     f"unsafe path in archive: {filename!r} is under a symlink member"
                 )
-    # Every destination this archive writes stops being whatever it is now, so a stale link at
-    # one of them must not be followed: it is about to become this archive's own member.
+    # Every destination this archive writes is about to become its own member, so a stale link
+    # at one must not be followed.
     replaced = {str(d) for d, _ in written}
     archive = {str(d): t for d, t, _ in links}
     replaced |= {str(_plan_key(d, base, replaced, archive)) for d, _ in written}
-    # A member path is not where the link lands: a directory link a PREVIOUS bundle left
-    # (alias -> .) makes alias/<record> land on the record itself, and a lexical comparison
-    # here misses it, so _write_install_record would follow the link and overwrite whatever
-    # it points at while still reading back as a valid install. Same for a directory already
-    # sitting where a link goes: checked here rather than at creation, so a refused archive
-    # has not yet replaced a working binary.
+    # A member path is not where the link lands: a previous bundle's alias -> . puts
+    # alias/<record> on the record itself, which a lexical compare misses. Same for a directory
+    # already sitting there. Checked here, so a refused archive has replaced nothing.
     keys = {str(d): _plan_key(d, base, replaced, archive) for d, _, _ in links}
     for dest, link_target, member in links:
         key = keys[str(dest)]
         if key in reserved:
             raise RuntimeError(f"symlink at a reserved installer path: {member.filename!r}")
-        # And neither may one POINT at them: the marker exists before extraction on any root
-        # Studio owns, so sd-cli -> the marker resolves to a file and _locate_sd_cli reports
-        # an empty one as the executable, with the install still claiming success.
+        # Nor may one POINT at them: the marker is already there on a root Studio owns, so
+        # sd-cli -> marker leaves _locate_sd_cli reporting an empty file as the executable.
         landing = _plan_resolve(
             Path(os.path.normpath(key.parent / link_target)), base, replaced, archive
         )
@@ -685,12 +678,10 @@ def _safe_extractall(zf: zipfile.ZipFile, target: Path) -> None:
             raise RuntimeError(f"symlink onto a reserved installer path: {member.filename!r}")
         if key.is_dir() and not key.is_symlink():
             raise RuntimeError(f"symlink member collides with a directory: {member.filename!r}")
-    # Chains are normal (libwebp.so -> libwebp.so.7 -> libwebp.so.7.2.0) but must terminate: a
-    # cycle installs a library nothing can read, so every load would reinstall it again. Walk the
-    # graph the tree will HAVE, archive edges first and then links a previous bundle left, since
-    # an archive edge can close a loop with one this archive never ships. Keyed by landing point
-    # for the same reason: alias/a and real/b are one cycle once alias -> real is followed.
-    # Done here rather than after creating the links, so a refused archive has written nothing.
+    # Chains are normal (libwebp.so -> .so.7 -> .so.7.2.0) but must terminate: a cycle installs
+    # a library nothing can read, so every load reinstalls it. Walk the graph the tree WILL have,
+    # archive edges plus links a previous bundle left, keyed by landing point so alias/a and
+    # real/b count as one cycle. Before any write, so a refused archive has written nothing.
     by_dest = {str(keys[str(d)]): t for d, t, _ in links}
     for dest, _, member in links:
         seen, cur = set(), str(keys[str(dest)])
@@ -703,16 +694,16 @@ def _safe_extractall(zf: zipfile.ZipFile, target: Path) -> None:
             else:
                 break
             nxt = Path(os.path.normpath(os.path.join(os.path.dirname(cur), nxt)))
-            # a -> a/x never reaches a second node, so exact-node repetition never catches it:
-            # every attempt to resolve a walks a again. Anything under the link is a loop.
+            # a -> a/x never reaches a second node, so repetition never fires, yet resolving a
+            # walks a again. Anything under the link is a loop.
             if Path(cur) in nxt.parents:
                 raise RuntimeError(f"symlink cycle in archive: {member.filename!r}")
             cur = str(_plan_key(nxt, base, replaced, archive))
         else:
             raise RuntimeError(f"symlink cycle in archive: {member.filename!r}")
-    # Last thing decided before the first write: whether this filesystem can hold links at all.
-    # Some mounts (exFAT, SMB without unix extensions) refuse with EPERM, and finding out at
-    # creation time means extractall has already put the new binary over the working one.
+    # Last thing decided before the first write: can this filesystem hold links at all? Some
+    # mounts (exFAT, SMB without unix extensions) refuse, and learning that at creation time
+    # means extractall has already put the new binary over the working one.
     if links:
         probe = base / f".unsloth-symlink-probe-{os.getpid()}"
         try:
@@ -723,12 +714,9 @@ def _safe_extractall(zf: zipfile.ZipFile, target: Path) -> None:
                 raise RuntimeError(f"this filesystem cannot store symlinks: {exc}") from exc
         else:
             probe.unlink()
-    # Validated before the first write, so a rejected archive leaves the install untouched.
-    #
-    # extractall opens each destination "wb", which FOLLOWS a link a previous bundle left there
-    # and writes the member into the file it points at. Drop stale links first: a name that one
-    # bundle ships as a link the next can ship as a regular file (the mirror ships plain copies
-    # where upstream ships links), and an accelerator switch lands exactly that way.
+    # extractall opens each destination "wb", which FOLLOWS a link a previous bundle left and
+    # writes the member into its target. Drop stale links first: a name one bundle ships as a
+    # link the next can ship as a file (the mirror ships copies where upstream ships links).
     for dest, _ in written:
         if dest.is_symlink():
             dest.unlink()

--- a/studio/install_sd_cpp_prebuilt.py
+++ b/studio/install_sd_cpp_prebuilt.py
@@ -522,7 +522,9 @@ def _is_symlink_member(member: zipfile.ZipInfo) -> bool:
     return member.create_system == 3 and stat.S_ISLNK(member.external_attr >> 16)
 
 
-def _checked_link_target(zf: zipfile.ZipFile, member: zipfile.ZipInfo, dest: Path, base: Path) -> str:
+def _checked_link_target(
+    zf: zipfile.ZipFile, member: zipfile.ZipInfo, dest: Path, base: Path
+) -> str:
     """A symlink member's payload, refused unless it is a relative path staying inside ``base``.
 
     Same rules as ``prebuilt_core.safe_link_target``: absolute (including Windows

--- a/studio/install_sd_cpp_prebuilt.py
+++ b/studio/install_sd_cpp_prebuilt.py
@@ -574,7 +574,11 @@ def _checked_link_target(
 
 
 def _plan_resolve(
-    path: Path, base: Path, replaced: set[str], archive: dict, depth: int = 0
+    path: Path,
+    base: Path,
+    replaced: set[str],
+    archive: dict,
+    depth: int = 0,
 ) -> Path:
     """``path`` with every component resolved as the tree will have it after extraction.
 

--- a/studio/install_sd_cpp_prebuilt.py
+++ b/studio/install_sd_cpp_prebuilt.py
@@ -36,7 +36,7 @@ import sys
 import urllib.error
 import urllib.request
 import zipfile
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Optional, Sequence
 
 # Default source: the Unsloth mirror's CPU/Apple prebuilts (override with UNSLOTH_SD_CPP_REPO). GPU hosts run diffusers, so only CPU/Apple assets are needed.
@@ -440,7 +440,9 @@ def _archive_binary_paths(zf: zipfile.ZipFile, target: Path) -> set[Path]:
     out: set[Path] = set()
     for member in zf.namelist():
         if member.rsplit("/", 1)[-1] in names:
-            out.add((target / member).resolve())
+            # Lexical, to match _discard_superseded_binaries: the tree can now hold restored
+            # symlinks, and resolving a link at a binary path yields a name no member has.
+            out.add(Path(os.path.abspath(target / member)))
     return out
 
 
@@ -470,7 +472,7 @@ def _discard_superseded_binaries(root: Path, supplied: set[Path]) -> None:
     names = _binary_names()
     for name in names:
         for found in sorted(root.rglob(name)):
-            if not found.is_file() or found.resolve() in supplied:
+            if not found.is_file() or Path(os.path.abspath(found)) in supplied:
                 continue
             try:
                 found.unlink()
@@ -509,34 +511,94 @@ def _download(
         shutil.copyfileobj(resp, f)
 
 
+# PATH_MAX. A symlink member's payload is a pathname; anything larger is malformed, and
+# ``zf.read`` holds it in memory, so an unbounded read is a decompression bomb.
+_MAX_LINK_TARGET_BYTES = 4096
+
+
+def _is_symlink_member(member: zipfile.ZipInfo) -> bool:
+    """The Unix mode in ``external_attr`` only means anything when a Unix host wrote the
+    entry; for any other creator those high bits are host-specific attributes."""
+    return member.create_system == 3 and stat.S_ISLNK(member.external_attr >> 16)
+
+
+def _checked_link_target(zf: zipfile.ZipFile, member: zipfile.ZipInfo, dest: Path, base: Path) -> str:
+    """A symlink member's payload, refused unless it is a relative path staying inside ``base``.
+
+    Same rules as ``prebuilt_core.safe_link_target``: absolute (including Windows
+    drive-relative, which Win32 resolves against that drive's cwd), empty, NUL-bearing,
+    self-referential and escaping targets are all rejected."""
+    if member.file_size > _MAX_LINK_TARGET_BYTES:
+        raise RuntimeError(f"oversized symlink target in archive: {member.filename!r}")
+    link_target = zf.read(member).decode("utf-8", "surrogateescape")
+    unsafe = (
+        # Shape first: resolve() stats the path, and a NUL in it raises ValueError.
+        not link_target
+        or "\x00" in link_target
+        or PurePosixPath(link_target).is_absolute()
+        or bool(PureWindowsPath(link_target).drive)
+    )
+    if not unsafe:
+        resolved = (dest.parent / link_target).resolve()
+        # Self-check lexically: dest may already BE a link to this target from the previous
+        # install, and resolving it would then make a correct link look self-referential.
+        unsafe = os.path.normpath(dest.parent / link_target) == os.path.normpath(dest) or (
+            resolved != base and base not in resolved.parents
+        )
+    if unsafe:
+        raise RuntimeError(f"unsafe symlink in archive: {member.filename!r} -> {link_target!r}")
+    return link_target
+
+
 def _safe_extractall(zf: zipfile.ZipFile, target: Path) -> None:
     """``extractall`` with a per-member containment check, so an archive carrying an
     absolute path or a ``..`` entry can't write outside ``target`` (Zip-Slip).
 
-    Symlink members are recreated after extraction: CPython's ``zipfile`` writes
+    Symlink members are RECREATED rather than extracted: CPython's ``zipfile`` writes
     a symlink's payload (the link target text) as a regular file, which flattens
     the ``lib*.so`` links upstream sd.cpp releases ship and leaves ``sd-cli``
     with ``file too short`` libraries (#9268)."""
-    import stat
-
     base = target.resolve()
-    links: list[tuple[Path, str, str]] = []
+    links: list[tuple[Path, str, zipfile.ZipInfo]] = []
+    plain: list[zipfile.ZipInfo] = []
     for member in zf.infolist():
-        dest = (base / member.filename).resolve()
-        if dest != base and base not in dest.parents:
+        # Lexical, never resolve()d. Extraction MERGES into the tree, so resolving would
+        # follow the link the PREVIOUS install wrote and aim every write below at the real
+        # library behind it, ending with that library replaced by a link to itself.
+        dest = base / member.filename
+        checked = dest.resolve()
+        if checked != base and base not in checked.parents:
             raise RuntimeError(f"unsafe path in archive: {member.filename!r}")
-        if stat.S_ISLNK(member.external_attr >> 16):
-            links.append(
-                (dest, zf.read(member).decode("utf-8", "surrogateescape"), member.filename)
-            )
-    zf.extractall(target)
-    for dest, link_target, filename in links:
-        resolved = (dest.parent / link_target).resolve()
-        if resolved != base and base not in resolved.parents:
-            raise RuntimeError(f"unsafe symlink in archive: {filename!r} -> {link_target!r}")
+        if _is_symlink_member(member):
+            links.append((dest, _checked_link_target(zf, member, dest, base), member))
+        else:
+            plain.append(member)
+    # Chains are normal (libwebp.so -> libwebp.so.7 -> libwebp.so.7.2.0) but must terminate:
+    # a cycle installs a library nothing can read, so every load would reinstall it again.
+    by_dest = {os.path.normpath(d): t for d, t, _ in links}
+    for dest, _, member in links:
+        seen, cur = set(), os.path.normpath(dest)
+        while cur in by_dest:
+            if cur in seen:
+                raise RuntimeError(f"symlink cycle in archive: {member.filename!r}")
+            seen.add(cur)
+            cur = os.path.normpath(os.path.join(os.path.dirname(cur), by_dest[cur]))
+    # Every member path and link target is validated above, before the first write, so a
+    # rejected archive leaves an existing install exactly as it found it.
+    zf.extractall(target, members = plain)
+    for dest, link_target, member in links:
+        if dest.is_dir() and not dest.is_symlink():
+            raise RuntimeError(f"symlink member collides with a directory: {member.filename!r}")
+        dest.parent.mkdir(parents = True, exist_ok = True)
         if dest.is_symlink() or dest.exists():
             dest.unlink()
-        dest.symlink_to(link_target)
+        try:
+            dest.symlink_to(link_target)
+        except OSError:
+            # No privilege to create one (Windows outside developer mode). Fall back to the
+            # flattened member: worse than a link, but it is what every release before this
+            # one shipped, so an install that used to finish still finishes.
+            zf.extract(member, target)
 
 
 def _maybe_fetch_windows_cudart(release: dict, chosen: str, target: Path) -> None:

--- a/studio/install_sd_cpp_prebuilt.py
+++ b/studio/install_sd_cpp_prebuilt.py
@@ -588,10 +588,12 @@ def _safe_extractall(zf: zipfile.ZipFile, target: Path) -> None:
         dest = Path(os.path.normpath(dest))
         # Re-resolved HERE, never reused from the pass above: that pass ran before a single
         # link existed, so an earlier member (a -> .) can turn a later member's parent into a
-        # link (a/out -> ../outside) and send this unlink/symlink_to outside base. A parent
-        # that no longer resolves to itself has been redirected.
+        # link (a/out -> ../outside) and send this unlink/symlink_to outside base. Both ends
+        # are checked for containment, not for being link-free, so a tree that legitimately
+        # symlinks one of its own subdirectories still installs.
+        parent = Path(os.path.realpath(dest.parent))
         resolved = (dest.parent / link_target).resolve()
-        if os.path.realpath(dest.parent) != str(dest.parent) or (
+        if (parent != base and base not in parent.parents) or (
             resolved != base and base not in resolved.parents
         ):
             raise RuntimeError(f"unsafe symlink in archive: {member.filename!r} -> {link_target!r}")

--- a/studio/install_sd_cpp_prebuilt.py
+++ b/studio/install_sd_cpp_prebuilt.py
@@ -585,13 +585,23 @@ def _safe_extractall(zf: zipfile.ZipFile, target: Path) -> None:
         checked = dest.resolve()
         if checked != base and base not in checked.parents:
             raise RuntimeError(f"unsafe path in archive: {member.filename!r}")
-        written.append(Path(os.path.normpath(dest)))
+        written.append((Path(os.path.normpath(dest)), member.filename))
         if _is_symlink_member(member):
-            if written[-1] in reserved:
+            if written[-1][0] in reserved:
                 raise RuntimeError(f"symlink at a reserved installer path: {member.filename!r}")
             links.append((dest, _checked_link_target(zf, member, dest, base), member))
         else:
             plain.append(member)
+    # No member may sit under a directory this same archive turns into a link: extraction would
+    # write through the link, and the creation-time check below would only catch it once part of
+    # the tree had already been replaced. Refused here, before the first write.
+    link_dests = {os.path.normpath(d) for d, _, _ in links}
+    for dest, filename in written:
+        parent = os.path.dirname(str(dest))
+        while parent != str(base) and parent.startswith(str(base)):
+            if parent in link_dests:
+                raise RuntimeError(f"unsafe path in archive: {filename!r} is under a symlink member")
+            parent = os.path.dirname(parent)
     # Chains are normal (libwebp.so -> libwebp.so.7 -> libwebp.so.7.2.0) but must terminate:
     # a cycle installs a library nothing can read, so every load would reinstall it again.
     by_dest = {os.path.normpath(d): t for d, t, _ in links}
@@ -608,7 +618,7 @@ def _safe_extractall(zf: zipfile.ZipFile, target: Path) -> None:
     # and writes the member into the file it points at. Drop stale links first: a name that one
     # bundle ships as a link the next can ship as a regular file (the mirror ships plain copies
     # where upstream ships links), and an accelerator switch lands exactly that way.
-    for dest in written:
+    for dest, _ in written:
         if dest.is_symlink():
             dest.unlink()
     zf.extractall(target, members = plain)

--- a/studio/install_sd_cpp_prebuilt.py
+++ b/studio/install_sd_cpp_prebuilt.py
@@ -671,10 +671,18 @@ def _safe_extractall(zf: zipfile.ZipFile, target: Path) -> None:
     # sitting where a link goes: checked here rather than at creation, so a refused archive
     # has not yet replaced a working binary.
     keys = {str(d): _plan_key(d, base, replaced, archive) for d, _, _ in links}
-    for dest, _, member in links:
+    for dest, link_target, member in links:
         key = keys[str(dest)]
         if key in reserved:
             raise RuntimeError(f"symlink at a reserved installer path: {member.filename!r}")
+        # And neither may one POINT at them: the marker exists before extraction on any root
+        # Studio owns, so sd-cli -> the marker resolves to a file and _locate_sd_cli reports
+        # an empty one as the executable, with the install still claiming success.
+        landing = _plan_resolve(
+            Path(os.path.normpath(key.parent / link_target)), base, replaced, archive
+        )
+        if landing in reserved:
+            raise RuntimeError(f"symlink onto a reserved installer path: {member.filename!r}")
         if key.is_dir() and not key.is_symlink():
             raise RuntimeError(f"symlink member collides with a directory: {member.filename!r}")
     # Chains are normal (libwebp.so -> libwebp.so.7 -> libwebp.so.7.2.0) but must terminate: a

--- a/studio/install_sd_cpp_prebuilt.py
+++ b/studio/install_sd_cpp_prebuilt.py
@@ -25,6 +25,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import errno
 import hashlib
 import json
 import os
@@ -642,20 +643,25 @@ def _safe_extractall(zf: zipfile.ZipFile, target: Path) -> None:
             dest.unlink()
         try:
             dest.symlink_to(link_target)
-            # The graph on disk also holds links a previous bundle left, so an archive edge can
-            # close a cycle with one this archive never saw. Undo ours rather than leave a pair
-            # nothing can read, which the retry would hit again.
-            try:
-                dest.resolve(strict = True)
-            except FileNotFoundError:
-                pass  # a target this bundle does not ship is still fine
-            except OSError as exc:
-                dest.unlink(missing_ok = True)
-                raise RuntimeError(f"symlink cycle in archive: {member.filename!r}") from exc
         except OSError:
             # No privilege (Windows outside developer mode). Fall back to the flattened
             # member, which is what shipped before this, so the install still finishes.
             zf.extract(member, target)
+            continue
+        # The graph on disk also holds links a previous bundle left, so an archive edge can
+        # close a cycle with one this archive never saw. Undo ours rather than leave a pair
+        # nothing can read, which the retry would hit again. os.stat, not
+        # Path.resolve(strict = True): that raises RuntimeError on a loop before 3.13 and
+        # OSError from 3.13 on, so the raw errno is the only portable signal.
+        try:
+            os.stat(dest)
+        except FileNotFoundError:
+            pass  # a target this bundle does not ship is still fine
+        except OSError as exc:
+            if exc.errno != errno.ELOOP:
+                raise
+            dest.unlink(missing_ok = True)
+            raise RuntimeError(f"symlink cycle in archive: {member.filename!r}") from exc
 
 
 def _maybe_fetch_windows_cudart(release: dict, chosen: str, target: Path) -> None:

--- a/studio/install_sd_cpp_prebuilt.py
+++ b/studio/install_sd_cpp_prebuilt.py
@@ -25,7 +25,6 @@ Usage:
 from __future__ import annotations
 
 import argparse
-import errno
 import hashlib
 import json
 import os
@@ -447,15 +446,20 @@ def _binary_key(path: Path) -> Path:
 
 
 def _archive_binary_paths(zf: zipfile.ZipFile, target: Path) -> set[Path]:
-    """Where this archive puts its executables, resolved to absolute paths under ``target``.
+    """Where this archive puts its executables, as absolute LEXICAL paths under ``target``.
 
     Read from the MEMBER LIST, never from the extracted tree: a leftover binary from an earlier
-    install looks identical on disk once extraction has run, which is the whole confusion here."""
+    install looks identical on disk once extraction has run, which is the whole confusion here.
+
+    Left unresolved on purpose. Extraction can change what the parents mean -- an explicit
+    directory member replaces a directory symlink the previous bundle left -- so resolving here
+    would key the binary off a layout that no longer exists by the time the sweep runs.
+    ``_discard_superseded_binaries`` resolves both sides once the tree is final."""
     names = _binary_names()
     out: set[Path] = set()
     for member in zf.namelist():
         if member.rsplit("/", 1)[-1] in names:
-            out.add(_binary_key(target / member))
+            out.add(Path(os.path.abspath(target / member)))
     return out
 
 
@@ -483,9 +487,12 @@ def _discard_superseded_binaries(root: Path, supplied: set[Path]) -> None:
 
     Raises when a copy cannot go, which withholds the record and makes the next load retry."""
     names = _binary_names()
+    # Resolved HERE, not when ``supplied`` was built: the tree is final only now, and extraction
+    # may have replaced a directory symlink a member path was spelled through.
+    keys = {_binary_key(p) for p in supplied}
     for name in names:
         for found in sorted(root.rglob(name)):
-            if not found.is_file() or _binary_key(found) in supplied:
+            if not found.is_file() or _binary_key(found) in keys:
                 continue
             try:
                 found.unlink()
@@ -605,16 +612,28 @@ def _safe_extractall(zf: zipfile.ZipFile, target: Path) -> None:
                 raise RuntimeError(
                     f"unsafe path in archive: {filename!r} is under a symlink member"
                 )
-    # Chains are normal (libwebp.so -> libwebp.so.7 -> libwebp.so.7.2.0) but must terminate:
-    # a cycle installs a library nothing can read, so every load would reinstall it again.
+    # Chains are normal (libwebp.so -> libwebp.so.7 -> libwebp.so.7.2.0) but must terminate: a
+    # cycle installs a library nothing can read, so every load would reinstall it again. Walk the
+    # graph the tree will HAVE, archive edges first and then links a previous bundle left, since
+    # an archive edge can close a loop with one this archive never ships. Done here rather than
+    # after creating the links, so a refused archive has still written nothing.
     by_dest = {str(d): t for d, t, _ in links}
+    # Every destination this archive writes stops being whatever it is now, so a stale link at
+    # one of them must not be followed: it is about to become this archive's own member.
+    replaced = {str(d) for d, _ in written}
     for dest, _, member in links:
         seen, cur = set(), str(dest)
-        while cur in by_dest:
-            if cur in seen:
-                raise RuntimeError(f"symlink cycle in archive: {member.filename!r}")
+        while cur not in seen:
             seen.add(cur)
-            cur = os.path.normpath(os.path.join(os.path.dirname(cur), by_dest[cur]))
+            if cur in by_dest:
+                nxt = by_dest[cur]
+            elif cur not in replaced and os.path.islink(cur):
+                nxt = os.readlink(cur)
+            else:
+                break
+            cur = os.path.normpath(os.path.join(os.path.dirname(cur), nxt))
+        else:
+            raise RuntimeError(f"symlink cycle in archive: {member.filename!r}")
     # Validated before the first write, so a rejected archive leaves the install untouched.
     #
     # extractall opens each destination "wb", which FOLLOWS a link a previous bundle left there
@@ -644,25 +663,18 @@ def _safe_extractall(zf: zipfile.ZipFile, target: Path) -> None:
             dest.unlink()
         try:
             dest.symlink_to(link_target)
-        except OSError:
-            # No privilege (Windows outside developer mode). Fall back to the flattened
-            # member, which is what shipped before this, so the install still finishes.
-            zf.extract(member, target)
-            continue
-        # The graph on disk also holds links a previous bundle left, so an archive edge can
-        # close a cycle with one this archive never saw. Undo ours rather than leave a pair
-        # nothing can read, which the retry would hit again. os.stat, not
-        # Path.resolve(strict = True): that raises RuntimeError on a loop before 3.13 and
-        # OSError from 3.13 on, so the raw errno is the only portable signal.
-        try:
-            os.stat(dest)
-        except FileNotFoundError:
-            pass  # a target this bundle does not ship is still fine
         except OSError as exc:
-            if exc.errno != errno.ELOOP:
-                raise
-            dest.unlink(missing_ok = True)
-            raise RuntimeError(f"symlink cycle in archive: {member.filename!r}") from exc
+            # Windows outside developer mode cannot create a link at all, and every Windows
+            # asset ships plain files, so flattening there costs nothing and keeps an install
+            # that used to finish finishing. Anywhere else a refusal means this filesystem
+            # cannot hold the layout sd-cli needs, and writing the link text back as a file is
+            # exactly the "file too short" install #9268 is about, which the runtime probe
+            # would then discard and reinstall on every load.
+            if sys.platform != "win32":
+                raise RuntimeError(
+                    f"could not restore the symlink {member.filename!r}: {exc}"
+                ) from exc
+            zf.extract(member, target)
 
 
 def _maybe_fetch_windows_cudart(release: dict, chosen: str, target: Path) -> None:

--- a/studio/install_sd_cpp_prebuilt.py
+++ b/studio/install_sd_cpp_prebuilt.py
@@ -66,6 +66,9 @@ _MIRROR_ONLY_TAG_RE = re.compile(r"^master-\d+-[0-9a-f]+-u[0-9a-f]+$")
 # bundle from a CUDA one instead of reusing whatever binary happens to be on disk.
 INSTALL_RECORD = ".unsloth-sd-cpp-install.json"
 
+# Marks the directory as one Studio created, so an uninstall never wipes a user's own tree.
+OWNERSHIP_MARKER = ".unsloth-studio-owned"
+
 
 def accelerator_class(accelerator: Optional[str]) -> str:
     """The accelerator an install actually serves. ``auto`` resolves to the plain build, so it and
@@ -559,8 +562,13 @@ def _safe_extractall(zf: zipfile.ZipFile, target: Path) -> None:
     the ``lib*.so`` links upstream sd.cpp releases ship and leaves ``sd-cli``
     with ``file too short`` libraries (#9268)."""
     base = target.resolve()
+    # The installer writes these itself after extraction. A symlink member at one of them makes
+    # _write_install_record follow it and overwrite whatever it points at, while the record still
+    # reads back correctly, so a corrupted install reports success.
+    reserved = {base / INSTALL_RECORD, base / OWNERSHIP_MARKER}
     links: list[tuple[Path, str, zipfile.ZipInfo]] = []
     plain: list[zipfile.ZipInfo] = []
+    written: list[Path] = []
     for member in zf.infolist():
         # Lexical, never resolve()d. Extraction MERGES, so resolving would follow the link the
         # PREVIOUS install wrote and end with the real library replaced by a link to itself.
@@ -568,7 +576,10 @@ def _safe_extractall(zf: zipfile.ZipFile, target: Path) -> None:
         checked = dest.resolve()
         if checked != base and base not in checked.parents:
             raise RuntimeError(f"unsafe path in archive: {member.filename!r}")
+        written.append(Path(os.path.normpath(dest)))
         if _is_symlink_member(member):
+            if written[-1] in reserved:
+                raise RuntimeError(f"symlink at a reserved installer path: {member.filename!r}")
             links.append((dest, _checked_link_target(zf, member, dest, base), member))
         else:
             plain.append(member)
@@ -583,6 +594,14 @@ def _safe_extractall(zf: zipfile.ZipFile, target: Path) -> None:
             seen.add(cur)
             cur = os.path.normpath(os.path.join(os.path.dirname(cur), by_dest[cur]))
     # Validated before the first write, so a rejected archive leaves the install untouched.
+    #
+    # extractall opens each destination "wb", which FOLLOWS a link a previous bundle left there
+    # and writes the member into the file it points at. Drop stale links first: a name that one
+    # bundle ships as a link the next can ship as a regular file (the mirror ships plain copies
+    # where upstream ships links), and an accelerator switch lands exactly that way.
+    for dest in written:
+        if dest.is_symlink():
+            dest.unlink()
     zf.extractall(target, members = plain)
     for dest, link_target, member in links:
         dest = Path(os.path.normpath(dest))
@@ -604,6 +623,16 @@ def _safe_extractall(zf: zipfile.ZipFile, target: Path) -> None:
             dest.unlink()
         try:
             dest.symlink_to(link_target)
+            # The graph on disk also holds links a previous bundle left, so an archive edge can
+            # close a cycle with one this archive never saw. Undo ours rather than leave a pair
+            # nothing can read, which the retry would hit again.
+            try:
+                dest.resolve(strict = True)
+            except FileNotFoundError:
+                pass                        # a target this bundle does not ship is still fine
+            except OSError as exc:
+                dest.unlink(missing_ok = True)
+                raise RuntimeError(f"symlink cycle in archive: {member.filename!r}") from exc
         except OSError:
             # No privilege (Windows outside developer mode). Fall back to the flattened
             # member, which is what shipped before this, so the install still finishes.
@@ -754,7 +783,7 @@ def install(
     """
     target = install_dir or default_install_dir()
     # Claim ownership of `target` only if we created it, it was empty, or it is already marked: adopting a user's non-empty dir would let a later uninstall wipe it.
-    marker = target / ".unsloth-studio-owned"
+    marker = target / OWNERSHIP_MARKER
     _may_own = True
     if target.exists():
         if not target.is_dir():

--- a/studio/install_sd_cpp_prebuilt.py
+++ b/studio/install_sd_cpp_prebuilt.py
@@ -629,7 +629,7 @@ def _safe_extractall(zf: zipfile.ZipFile, target: Path) -> None:
             try:
                 dest.resolve(strict = True)
             except FileNotFoundError:
-                pass                        # a target this bundle does not ship is still fine
+                pass  # a target this bundle does not ship is still fine
             except OSError as exc:
                 dest.unlink(missing_ok = True)
                 raise RuntimeError(f"symlink cycle in archive: {member.filename!r}") from exc

--- a/studio/install_sd_cpp_prebuilt.py
+++ b/studio/install_sd_cpp_prebuilt.py
@@ -434,6 +434,17 @@ def _binary_names() -> tuple[str, ...]:
     return (f"sd-cli{suffix}", f"sd-server{suffix}")
 
 
+def _binary_key(path: Path) -> Path:
+    """How a binary path is compared: parent directories resolved, final component left alone.
+
+    Both halves matter now that the tree can hold symlinks. Resolving the leaf would turn a
+    bundle that ships ``sd-cli -> sd-cli-1.2`` into a name no member has; leaving the parents
+    lexical would spell a member under a symlinked directory differently from the way ``rglob``
+    reports it, and the sweep would delete the binary this bundle just supplied."""
+    p = Path(os.path.abspath(path))
+    return Path(os.path.realpath(p.parent)) / p.name
+
+
 def _archive_binary_paths(zf: zipfile.ZipFile, target: Path) -> set[Path]:
     """Where this archive puts its executables, resolved to absolute paths under ``target``.
 
@@ -443,9 +454,7 @@ def _archive_binary_paths(zf: zipfile.ZipFile, target: Path) -> set[Path]:
     out: set[Path] = set()
     for member in zf.namelist():
         if member.rsplit("/", 1)[-1] in names:
-            # Lexical, to match _discard_superseded_binaries: the tree can now hold restored
-            # symlinks, and resolving one at a binary path yields a name no member has.
-            out.add(Path(os.path.abspath(target / member)))
+            out.add(_binary_key(target / member))
     return out
 
 
@@ -475,7 +484,7 @@ def _discard_superseded_binaries(root: Path, supplied: set[Path]) -> None:
     names = _binary_names()
     for name in names:
         for found in sorted(root.rglob(name)):
-            if not found.is_file() or Path(os.path.abspath(found)) in supplied:
+            if not found.is_file() or _binary_key(found) in supplied:
                 continue
             try:
                 found.unlink()

--- a/studio/install_sd_cpp_prebuilt.py
+++ b/studio/install_sd_cpp_prebuilt.py
@@ -663,9 +663,26 @@ def _safe_extractall(zf: zipfile.ZipFile, target: Path) -> None:
             else:
                 break
             nxt = Path(os.path.normpath(os.path.join(os.path.dirname(cur), nxt)))
+            # a -> a/x never reaches a second node, so exact-node repetition never catches it:
+            # every attempt to resolve a walks a again. Anything under the link is a loop.
+            if Path(cur) in nxt.parents:
+                raise RuntimeError(f"symlink cycle in archive: {member.filename!r}")
             cur = str(_plan_key(nxt, base, replaced))
         else:
             raise RuntimeError(f"symlink cycle in archive: {member.filename!r}")
+    # Last thing decided before the first write: whether this filesystem can hold links at all.
+    # Some mounts (exFAT, SMB without unix extensions) refuse with EPERM, and finding out at
+    # creation time means extractall has already put the new binary over the working one.
+    if links:
+        probe = base / f".unsloth-symlink-probe-{os.getpid()}"
+        try:
+            probe.symlink_to(".")
+        except OSError as exc:
+            # Windows outside developer mode is the one place flattening is right; see below.
+            if sys.platform != "win32":
+                raise RuntimeError(f"this filesystem cannot store symlinks: {exc}") from exc
+        else:
+            probe.unlink()
     # Validated before the first write, so a rejected archive leaves the install untouched.
     #
     # extractall opens each destination "wb", which FOLLOWS a link a previous bundle left there

--- a/studio/install_sd_cpp_prebuilt.py
+++ b/studio/install_sd_cpp_prebuilt.py
@@ -441,7 +441,7 @@ def _archive_binary_paths(zf: zipfile.ZipFile, target: Path) -> set[Path]:
     for member in zf.namelist():
         if member.rsplit("/", 1)[-1] in names:
             # Lexical, to match _discard_superseded_binaries: the tree can now hold restored
-            # symlinks, and resolving a link at a binary path yields a name no member has.
+            # symlinks, and resolving one at a binary path yields a name no member has.
             out.add(Path(os.path.abspath(target / member)))
     return out
 
@@ -511,21 +511,20 @@ def _download(
         shutil.copyfileobj(resp, f)
 
 
-# PATH_MAX. A symlink member's payload is a pathname; anything larger is malformed, and
-# ``zf.read`` holds it in memory, so an unbounded read is a decompression bomb.
+# PATH_MAX: a link payload is a pathname, and ``zf.read`` holds it in memory, so anything
+# larger is a decompression bomb rather than a library name.
 _MAX_LINK_TARGET_BYTES = 4096
 
 
 def _is_symlink_member(member: zipfile.ZipInfo) -> bool:
-    """The Unix mode in ``external_attr`` only means anything when a Unix host wrote the
-    entry; for any other creator those high bits are host-specific attributes."""
+    """``external_attr``'s high bits are a Unix mode only when a Unix host wrote the entry."""
     return member.create_system == 3 and stat.S_ISLNK(member.external_attr >> 16)
 
 
 def _checked_link_target(
     zf: zipfile.ZipFile, member: zipfile.ZipInfo, dest: Path, base: Path
 ) -> str:
-    """A symlink member's payload, refused unless it is a relative path staying inside ``base``.
+    """A symlink member's payload, refused unless it is relative and stays inside ``base``.
 
     Same rules as ``prebuilt_core.safe_link_target``: absolute (including Windows
     drive-relative, which Win32 resolves against that drive's cwd), empty, NUL-bearing,
@@ -542,8 +541,7 @@ def _checked_link_target(
     )
     if not unsafe:
         resolved = (dest.parent / link_target).resolve()
-        # Self-check lexically: dest may already BE a link to this target from the previous
-        # install, and resolving it would then make a correct link look self-referential.
+        # Self-check lexically: dest may already be a correct link to this very target.
         unsafe = os.path.normpath(dest.parent / link_target) == os.path.normpath(dest) or (
             resolved != base and base not in resolved.parents
         )
@@ -564,9 +562,8 @@ def _safe_extractall(zf: zipfile.ZipFile, target: Path) -> None:
     links: list[tuple[Path, str, zipfile.ZipInfo]] = []
     plain: list[zipfile.ZipInfo] = []
     for member in zf.infolist():
-        # Lexical, never resolve()d. Extraction MERGES into the tree, so resolving would
-        # follow the link the PREVIOUS install wrote and aim every write below at the real
-        # library behind it, ending with that library replaced by a link to itself.
+        # Lexical, never resolve()d. Extraction MERGES, so resolving would follow the link the
+        # PREVIOUS install wrote and end with the real library replaced by a link to itself.
         dest = base / member.filename
         checked = dest.resolve()
         if checked != base and base not in checked.parents:
@@ -585,8 +582,7 @@ def _safe_extractall(zf: zipfile.ZipFile, target: Path) -> None:
                 raise RuntimeError(f"symlink cycle in archive: {member.filename!r}")
             seen.add(cur)
             cur = os.path.normpath(os.path.join(os.path.dirname(cur), by_dest[cur]))
-    # Every member path and link target is validated above, before the first write, so a
-    # rejected archive leaves an existing install exactly as it found it.
+    # Validated before the first write, so a rejected archive leaves the install untouched.
     zf.extractall(target, members = plain)
     for dest, link_target, member in links:
         if dest.is_dir() and not dest.is_symlink():
@@ -597,9 +593,8 @@ def _safe_extractall(zf: zipfile.ZipFile, target: Path) -> None:
         try:
             dest.symlink_to(link_target)
         except OSError:
-            # No privilege to create one (Windows outside developer mode). Fall back to the
-            # flattened member: worse than a link, but it is what every release before this
-            # one shipped, so an install that used to finish still finishes.
+            # No privilege (Windows outside developer mode). Fall back to the flattened
+            # member, which is what shipped before this, so the install still finishes.
             zf.extract(member, target)
 
 

--- a/studio/install_sd_cpp_prebuilt.py
+++ b/studio/install_sd_cpp_prebuilt.py
@@ -570,6 +570,22 @@ def _checked_link_target(
     return link_target
 
 
+def _plan_key(dest: Path, base: Path, replaced: set[str]) -> Path:
+    """Where ``dest`` will really land, given the directory links the tree will have.
+
+    Parents are resolved, the final component is left alone: it is the link about to be
+    created, and following it would compare the wrong thing. Links this archive replaces
+    are not followed, since they are gone before anything is written."""
+    if dest == base or base not in dest.parents:
+        return dest
+    cur = base
+    for part in dest.relative_to(base).parts[:-1]:
+        cur = cur / part
+        if str(cur) not in replaced and cur.is_symlink():
+            cur = Path(os.path.realpath(cur))
+    return cur / dest.name
+
+
 def _safe_extractall(zf: zipfile.ZipFile, target: Path) -> None:
     """``extractall`` with a per-member containment check, so an archive carrying an
     absolute path or a ``..`` entry can't write outside ``target`` (Zip-Slip).
@@ -591,12 +607,12 @@ def _safe_extractall(zf: zipfile.ZipFile, target: Path) -> None:
         # PREVIOUS install wrote and end with the real library replaced by a link to itself.
         dest = Path(os.path.normpath(base / member.filename))
         checked = dest.resolve()
-        if checked != base and base not in checked.parents:
+        if (dest != base and base not in dest.parents) or (
+            checked != base and base not in checked.parents
+        ):
             raise RuntimeError(f"unsafe path in archive: {member.filename!r}")
         written.append((dest, member.filename))
         if _is_symlink_member(member):
-            if dest in reserved:
-                raise RuntimeError(f"symlink at a reserved installer path: {member.filename!r}")
             links.append((dest, _checked_link_target(zf, member, dest, base), member))
         else:
             plain.append(member)
@@ -612,17 +628,32 @@ def _safe_extractall(zf: zipfile.ZipFile, target: Path) -> None:
                 raise RuntimeError(
                     f"unsafe path in archive: {filename!r} is under a symlink member"
                 )
-    # Chains are normal (libwebp.so -> libwebp.so.7 -> libwebp.so.7.2.0) but must terminate: a
-    # cycle installs a library nothing can read, so every load would reinstall it again. Walk the
-    # graph the tree will HAVE, archive edges first and then links a previous bundle left, since
-    # an archive edge can close a loop with one this archive never ships. Done here rather than
-    # after creating the links, so a refused archive has still written nothing.
-    by_dest = {str(d): t for d, t, _ in links}
     # Every destination this archive writes stops being whatever it is now, so a stale link at
     # one of them must not be followed: it is about to become this archive's own member.
     replaced = {str(d) for d, _ in written}
+    replaced |= {str(_plan_key(d, base, replaced)) for d, _ in written}
+    # A member path is not where the link lands: a directory link a PREVIOUS bundle left
+    # (alias -> .) makes alias/<record> land on the record itself, and a lexical comparison
+    # here misses it, so _write_install_record would follow the link and overwrite whatever
+    # it points at while still reading back as a valid install. Same for a directory already
+    # sitting where a link goes: checked here rather than at creation, so a refused archive
+    # has not yet replaced a working binary.
+    keys = {str(d): _plan_key(d, base, replaced) for d, _, _ in links}
     for dest, _, member in links:
-        seen, cur = set(), str(dest)
+        key = keys[str(dest)]
+        if key in reserved:
+            raise RuntimeError(f"symlink at a reserved installer path: {member.filename!r}")
+        if key.is_dir() and not key.is_symlink():
+            raise RuntimeError(f"symlink member collides with a directory: {member.filename!r}")
+    # Chains are normal (libwebp.so -> libwebp.so.7 -> libwebp.so.7.2.0) but must terminate: a
+    # cycle installs a library nothing can read, so every load would reinstall it again. Walk the
+    # graph the tree will HAVE, archive edges first and then links a previous bundle left, since
+    # an archive edge can close a loop with one this archive never ships. Keyed by landing point
+    # for the same reason: alias/a and real/b are one cycle once alias -> real is followed.
+    # Done here rather than after creating the links, so a refused archive has written nothing.
+    by_dest = {str(keys[str(d)]): t for d, t, _ in links}
+    for dest, _, member in links:
+        seen, cur = set(), str(keys[str(dest)])
         while cur not in seen:
             seen.add(cur)
             if cur in by_dest:
@@ -631,7 +662,8 @@ def _safe_extractall(zf: zipfile.ZipFile, target: Path) -> None:
                 nxt = os.readlink(cur)
             else:
                 break
-            cur = os.path.normpath(os.path.join(os.path.dirname(cur), nxt))
+            nxt = Path(os.path.normpath(os.path.join(os.path.dirname(cur), nxt)))
+            cur = str(_plan_key(nxt, base, replaced))
         else:
             raise RuntimeError(f"symlink cycle in archive: {member.filename!r}")
     # Validated before the first write, so a rejected archive leaves the install untouched.

--- a/studio/install_sd_cpp_prebuilt.py
+++ b/studio/install_sd_cpp_prebuilt.py
@@ -585,6 +585,16 @@ def _safe_extractall(zf: zipfile.ZipFile, target: Path) -> None:
     # Validated before the first write, so a rejected archive leaves the install untouched.
     zf.extractall(target, members = plain)
     for dest, link_target, member in links:
+        dest = Path(os.path.normpath(dest))
+        # Re-resolved HERE, never reused from the pass above: that pass ran before a single
+        # link existed, so an earlier member (a -> .) can turn a later member's parent into a
+        # link (a/out -> ../outside) and send this unlink/symlink_to outside base. A parent
+        # that no longer resolves to itself has been redirected.
+        resolved = (dest.parent / link_target).resolve()
+        if os.path.realpath(dest.parent) != str(dest.parent) or (
+            resolved != base and base not in resolved.parents
+        ):
+            raise RuntimeError(f"unsafe symlink in archive: {member.filename!r} -> {link_target!r}")
         if dest.is_dir() and not dest.is_symlink():
             raise RuntimeError(f"symlink member collides with a directory: {member.filename!r}")
         dest.parent.mkdir(parents = True, exist_ok = True)

--- a/studio/install_sd_cpp_prebuilt.py
+++ b/studio/install_sd_cpp_prebuilt.py
@@ -578,17 +578,17 @@ def _safe_extractall(zf: zipfile.ZipFile, target: Path) -> None:
     reserved = {base / INSTALL_RECORD, base / OWNERSHIP_MARKER}
     links: list[tuple[Path, str, zipfile.ZipInfo]] = []
     plain: list[zipfile.ZipInfo] = []
-    written: list[Path] = []
+    written: list[tuple[Path, str]] = []
     for member in zf.infolist():
         # Lexical, never resolve()d. Extraction MERGES, so resolving would follow the link the
         # PREVIOUS install wrote and end with the real library replaced by a link to itself.
-        dest = base / member.filename
+        dest = Path(os.path.normpath(base / member.filename))
         checked = dest.resolve()
         if checked != base and base not in checked.parents:
             raise RuntimeError(f"unsafe path in archive: {member.filename!r}")
-        written.append((Path(os.path.normpath(dest)), member.filename))
+        written.append((dest, member.filename))
         if _is_symlink_member(member):
-            if written[-1][0] in reserved:
+            if dest in reserved:
                 raise RuntimeError(f"symlink at a reserved installer path: {member.filename!r}")
             links.append((dest, _checked_link_target(zf, member, dest, base), member))
         else:
@@ -596,20 +596,20 @@ def _safe_extractall(zf: zipfile.ZipFile, target: Path) -> None:
     # No member may sit under a directory this same archive turns into a link: extraction would
     # write through the link, and the creation-time check below would only catch it once part of
     # the tree had already been replaced. Refused here, before the first write.
-    link_dests = {os.path.normpath(d) for d, _, _ in links}
+    link_dests = {d for d, _, _ in links}
     for dest, filename in written:
-        parent = os.path.dirname(str(dest))
-        while parent != str(base) and parent.startswith(str(base)):
+        for parent in dest.parents:
+            if parent == base:
+                break
             if parent in link_dests:
                 raise RuntimeError(
                     f"unsafe path in archive: {filename!r} is under a symlink member"
                 )
-            parent = os.path.dirname(parent)
     # Chains are normal (libwebp.so -> libwebp.so.7 -> libwebp.so.7.2.0) but must terminate:
     # a cycle installs a library nothing can read, so every load would reinstall it again.
-    by_dest = {os.path.normpath(d): t for d, t, _ in links}
+    by_dest = {str(d): t for d, t, _ in links}
     for dest, _, member in links:
-        seen, cur = set(), os.path.normpath(dest)
+        seen, cur = set(), str(dest)
         while cur in by_dest:
             if cur in seen:
                 raise RuntimeError(f"symlink cycle in archive: {member.filename!r}")
@@ -626,7 +626,6 @@ def _safe_extractall(zf: zipfile.ZipFile, target: Path) -> None:
             dest.unlink()
     zf.extractall(target, members = plain)
     for dest, link_target, member in links:
-        dest = Path(os.path.normpath(dest))
         # Re-resolved HERE, never reused from the pass above: that pass ran before a single
         # link existed, so an earlier member (a -> .) can turn a later member's parent into a
         # link (a/out -> ../outside) and send this unlink/symlink_to outside base. Both ends

--- a/studio/install_sd_cpp_prebuilt.py
+++ b/studio/install_sd_cpp_prebuilt.py
@@ -535,6 +535,9 @@ def _download(
 # larger is a decompression bomb rather than a library name.
 _MAX_LINK_TARGET_BYTES = 4096
 
+# What Linux allows before ELOOP, so a layout this deep is one the loader could not read anyway.
+_MAX_LINK_DEPTH = 40
+
 
 def _is_symlink_member(member: zipfile.ZipInfo) -> bool:
     """``external_attr``'s high bits are a Unix mode only when a Unix host wrote the entry."""
@@ -570,20 +573,38 @@ def _checked_link_target(
     return link_target
 
 
-def _plan_key(dest: Path, base: Path, replaced: set[str]) -> Path:
-    """Where ``dest`` will really land, given the directory links the tree will have.
+def _plan_resolve(
+    path: Path, base: Path, replaced: set[str], archive: dict, depth: int = 0
+) -> Path:
+    """``path`` with every component resolved as the tree will have it after extraction.
 
-    Parents are resolved, the final component is left alone: it is the link about to be
-    created, and following it would compare the wrong thing. Links this archive replaces
-    are not followed, since they are gone before anything is written."""
+    Links this archive ships are followed from the archive, not from disk (they do not exist
+    yet); links it replaces are not followed at all (they are gone before the first write);
+    anything else is a link a previous bundle left. Two link members can point through each
+    other's directories, so the recursion is bounded and a runaway is the cycle it describes."""
+    if path == base or base not in path.parents:
+        return path
+    if depth > _MAX_LINK_DEPTH:
+        raise RuntimeError(f"symlink cycle in archive: {str(path.relative_to(base))!r}")
+    cur = base
+    for part in path.relative_to(base).parts:
+        cur = cur / part
+        target = archive.get(str(cur))
+        if target is not None:
+            cur = _plan_resolve(
+                Path(os.path.normpath(cur.parent / target)), base, replaced, archive, depth + 1
+            )
+        elif str(cur) not in replaced and cur.is_symlink():
+            cur = Path(os.path.realpath(cur))
+    return cur
+
+
+def _plan_key(dest: Path, base: Path, replaced: set[str], archive: dict) -> Path:
+    """Where ``dest`` will really land. Only the parents are resolved: the final component is
+    the link about to be created, and following it would compare the wrong thing."""
     if dest == base or base not in dest.parents:
         return dest
-    cur = base
-    for part in dest.relative_to(base).parts[:-1]:
-        cur = cur / part
-        if str(cur) not in replaced and cur.is_symlink():
-            cur = Path(os.path.realpath(cur))
-    return cur / dest.name
+    return _plan_resolve(dest.parent, base, replaced, archive) / dest.name
 
 
 def _safe_extractall(zf: zipfile.ZipFile, target: Path) -> None:
@@ -603,6 +624,12 @@ def _safe_extractall(zf: zipfile.ZipFile, target: Path) -> None:
     plain: list[zipfile.ZipInfo] = []
     written: list[tuple[Path, str]] = []
     for member in zf.infolist():
+        # extractall DROPS ".." components instead of cancelling the one before them, so
+        # "a/.." is "a" to it. Normalising here would compare a path it never writes to, and
+        # with a link at "a" the member lands outside base. No release ships "..", so refuse it.
+        parts = PurePosixPath(member.filename).parts
+        if ".." in parts:
+            raise RuntimeError(f"unsafe path in archive: {member.filename!r}")
         # Lexical, never resolve()d. Extraction MERGES, so resolving would follow the link the
         # PREVIOUS install wrote and end with the real library replaced by a link to itself.
         dest = Path(os.path.normpath(base / member.filename))
@@ -631,14 +658,15 @@ def _safe_extractall(zf: zipfile.ZipFile, target: Path) -> None:
     # Every destination this archive writes stops being whatever it is now, so a stale link at
     # one of them must not be followed: it is about to become this archive's own member.
     replaced = {str(d) for d, _ in written}
-    replaced |= {str(_plan_key(d, base, replaced)) for d, _ in written}
+    archive = {str(d): t for d, t, _ in links}
+    replaced |= {str(_plan_key(d, base, replaced, archive)) for d, _ in written}
     # A member path is not where the link lands: a directory link a PREVIOUS bundle left
     # (alias -> .) makes alias/<record> land on the record itself, and a lexical comparison
     # here misses it, so _write_install_record would follow the link and overwrite whatever
     # it points at while still reading back as a valid install. Same for a directory already
     # sitting where a link goes: checked here rather than at creation, so a refused archive
     # has not yet replaced a working binary.
-    keys = {str(d): _plan_key(d, base, replaced) for d, _, _ in links}
+    keys = {str(d): _plan_key(d, base, replaced, archive) for d, _, _ in links}
     for dest, _, member in links:
         key = keys[str(dest)]
         if key in reserved:
@@ -667,7 +695,7 @@ def _safe_extractall(zf: zipfile.ZipFile, target: Path) -> None:
             # every attempt to resolve a walks a again. Anything under the link is a loop.
             if Path(cur) in nxt.parents:
                 raise RuntimeError(f"symlink cycle in archive: {member.filename!r}")
-            cur = str(_plan_key(nxt, base, replaced))
+            cur = str(_plan_key(nxt, base, replaced, archive))
         else:
             raise RuntimeError(f"symlink cycle in archive: {member.filename!r}")
     # Last thing decided before the first write: whether this filesystem can hold links at all.

--- a/studio/install_sd_cpp_prebuilt.py
+++ b/studio/install_sd_cpp_prebuilt.py
@@ -511,13 +511,32 @@ def _download(
 
 def _safe_extractall(zf: zipfile.ZipFile, target: Path) -> None:
     """``extractall`` with a per-member containment check, so an archive carrying an
-    absolute path or a ``..`` entry can't write outside ``target`` (Zip-Slip)."""
+    absolute path or a ``..`` entry can't write outside ``target`` (Zip-Slip).
+
+    Symlink members are recreated after extraction: CPython's ``zipfile`` writes
+    a symlink's payload (the link target text) as a regular file, which flattens
+    the ``lib*.so`` links upstream sd.cpp releases ship and leaves ``sd-cli``
+    with ``file too short`` libraries (#9268)."""
+    import stat
+
     base = target.resolve()
+    links: list[tuple[Path, str, str]] = []
     for member in zf.infolist():
         dest = (base / member.filename).resolve()
         if dest != base and base not in dest.parents:
             raise RuntimeError(f"unsafe path in archive: {member.filename!r}")
+        if stat.S_ISLNK(member.external_attr >> 16):
+            links.append(
+                (dest, zf.read(member).decode("utf-8", "surrogateescape"), member.filename)
+            )
     zf.extractall(target)
+    for dest, link_target, filename in links:
+        resolved = (dest.parent / link_target).resolve()
+        if resolved != base and base not in resolved.parents:
+            raise RuntimeError(f"unsafe symlink in archive: {filename!r} -> {link_target!r}")
+        if dest.is_symlink() or dest.exists():
+            dest.unlink()
+        dest.symlink_to(link_target)
 
 
 def _maybe_fetch_windows_cudart(release: dict, chosen: str, target: Path) -> None:

--- a/studio/install_sd_cpp_prebuilt.py
+++ b/studio/install_sd_cpp_prebuilt.py
@@ -601,7 +601,9 @@ def _safe_extractall(zf: zipfile.ZipFile, target: Path) -> None:
         parent = os.path.dirname(str(dest))
         while parent != str(base) and parent.startswith(str(base)):
             if parent in link_dests:
-                raise RuntimeError(f"unsafe path in archive: {filename!r} is under a symlink member")
+                raise RuntimeError(
+                    f"unsafe path in archive: {filename!r} is under a symlink member"
+                )
             parent = os.path.dirname(parent)
     # Chains are normal (libwebp.so -> libwebp.so.7 -> libwebp.so.7.2.0) but must terminate:
     # a cycle installs a library nothing can read, so every load would reinstall it again.


### PR DESCRIPTION
## Summary

**What**

`_safe_extractall` in `studio/install_sd_cpp_prebuilt.py` now recreates symlink members after `zipfile.extractall`: members carrying the Unix symlink mode in `external_attr` are re-created with `symlink_to`, and the link target is resolved through the same containment guard the member paths already use — a link whose target escapes the install dir raises `unsafe symlink in archive` instead of writing outside it.

**Why**

#9268 — CPython's `zipfile.extractall` does not restore symlinks: it writes each symlink member's data (the link-target text) as a regular file. Upstream sd.cpp release zips ship `libggml*.so`, `libwebp*.so`, `libwebpmux*.so`, `libsharpyuv*.so` as symlinks, so after install `libwebpmux.so.3` is a 19-byte file containing the text `libwebpmux.so.3.1.2`, and `sd-cli` fails with `error while loading shared libraries: ... file too short`, surfacing as `video.load_failed: stable-diffusion.cpp could not be installed or started for MiniMax-H3`.

Same shape as the reporter's suggested fix, with the containment check kept in one loop and applied to both member paths and link targets.

**Testing** (`studio/backend/tests/test_sd_cpp_install.py`):

- New `test_safe_extractall_restores_symlink_members`: builds a zip with a real member plus a symlink-mode member (the exact shape CPython writes when zipping a symlink), extracts, asserts `libwebpmux.so.3` `is_symlink()`, its `readlink()` names the real library, and its size equals the real file's — the pre-fix behavior was a tiny text file. **Runs on CI's Linux runners; skips on hosts where symlink creation needs privilege** (Windows non-dev-mode — my Windows host skips it locally, the same CI-gating pattern as the whisper/llama installer suites).
- New `test_safe_extractall_rejects_escaping_symlink`: a `../../outside.so` link target raises `unsafe symlink` and nothing lands outside the install dir — this one runs everywhere (the check precedes any link creation) and **fails on the pre-fix code** (no such rejection existed).
- Existing `safe_extractall` traversal/normal-members tests unchanged: 3 passed + 1 skipped locally.

Fixes #9268