### PR TITLE
Studio: tray toggle reflects server state

### DIFF
--- a/studio/frontend/src/hooks/use-tauri-backend.ts
+++ b/studio/frontend/src/hooks/use-tauri-backend.ts
@@ -51,6 +51,13 @@ export type BackendStatus =
   | "stopped"
   | "error";
 
+function syncTrayStatus(status: BackendStatus) {
+  if (!isTauri) return;
+  import("@tauri-apps/api/core")
+    .then(({ invoke }) => invoke("set_tray_server_status", { status }))
+    .catch(() => {});
+}
+
 type DesktopPreflightDisposition =
   | "not_installed"
   | "managed_ready"
@@ -166,6 +173,7 @@ export function useTauriBackend() {
     if (authFailureRef.current) return;
     statusRef.current = nextStatus;
     setStatus(nextStatus);
+    syncTrayStatus(nextStatus);
   }
 
   function setBackendError(
@@ -176,6 +184,7 @@ export function useTauriBackend() {
     statusRef.current = nextStatus;
     setStatus(nextStatus);
     setError(nextError);
+    syncTrayStatus(nextStatus);
   }
 
   function clearBackendError() {

--- a/studio/frontend/src/hooks/use-tauri-backend.ts
+++ b/studio/frontend/src/hooks/use-tauri-backend.ts
@@ -201,6 +201,7 @@ export function useTauriBackend() {
     statusRef.current = "error";
     setStatus("error");
     setError(detail);
+    syncTrayStatus("error");
   }
 
   function clearAuthFailure() {

--- a/studio/frontend/tests/desktop-stop-intent.test.ts
+++ b/studio/frontend/tests/desktop-stop-intent.test.ts
@@ -231,8 +231,9 @@ test("stopping records the intent before the shutdown it can outlive", async () 
 test("a second stop cannot run while the first is in flight", async () => {
   const hook = await hookSource();
 
-  // The tray item is never disabled and the toggle branches on statusRef, which stays
-  // "running" for the whole invoke, so two Stop clicks reach stopServer concurrently.
+  // The tray item stays enabled while the server runs and the toggle branches on
+  // statusRef, which stays "running" for the whole invoke, so two Stop clicks reach
+  // stopServer concurrently.
   const tray = hook.slice(hook.indexOf('register<void>("tray-toggle-server"'));
   assert.match(
     tray.slice(0, tray.indexOf("});")),

--- a/studio/frontend/tests/tray-server-status.test.ts
+++ b/studio/frontend/tests/tray-server-status.test.ts
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+// The tray label is settled across two languages: the hook pushes a BackendStatus over
+// the IPC and main.rs turns it into a label and an enabled flag. Neither half can be
+// rendered here, so both are asserted against source, the way the rest of the desktop
+// startup tests do it. tray_toggle_label's own table is covered by the Rust unit tests
+// in main.rs; what is left, and what only a test spanning both files can hold, is that
+// the two halves still agree on the set of statuses.
+
+function hookSource(): Promise<string> {
+  return readFile(
+    new URL("../src/hooks/use-tauri-backend.ts", import.meta.url),
+    "utf8",
+  );
+}
+
+function tauriSource(): Promise<string> {
+  return readFile(
+    new URL("../../src-tauri/src/main.rs", import.meta.url),
+    "utf8",
+  );
+}
+
+/**
+ * The body of a `function name(...)` in the hook, to its closing brace. syncTrayStatus
+ * sits at module scope and the status committers sit inside the hook, so the indent the
+ * declaration and its brace share is whatever precedes the keyword.
+ */
+function hookFunction(hook: string, name: string): string {
+  const declaration = hook.match(
+    new RegExp(`^([ ]*)function ${name}\\(`, "m"),
+  );
+  if (!declaration || declaration.index === undefined) {
+    throw new Error(`${name} is gone from use-tauri-backend.ts`);
+  }
+  const close = `\n${declaration[1]}}\n`;
+  return hook.slice(declaration.index, hook.indexOf(close, declaration.index));
+}
+
+/** The `fn tray_toggle_label` body in main.rs. */
+function trayToggleLabel(rust: string): string {
+  const start = rust.indexOf("fn tray_toggle_label(");
+  if (start < 0) {
+    throw new Error("tray_toggle_label is gone from main.rs");
+  }
+  return rust.slice(start, rust.indexOf("\n}\n", start));
+}
+
+/** Every status string tray_toggle_label reports as clickable. */
+function enabledStatuses(rust: string): string[] {
+  const table = trayToggleLabel(rust);
+  const enabled: string[] = [];
+  for (const arm of table.matchAll(/^\s*(.+?)\s*=>\s*\([^)]*,\s*(true|false)\)/gm)) {
+    if (arm[2] !== "true" || arm[1] === "_") continue;
+    for (const status of arm[1].matchAll(/"([^"]*)"/g)) enabled.push(status[1]);
+  }
+  return enabled.sort();
+}
+
+/** Every status the tray-toggle-server listener branches on. */
+function actionableStatuses(hook: string): string[] {
+  const start = hook.indexOf('register<void>("tray-toggle-server"');
+  if (start < 0) {
+    throw new Error("the tray-toggle-server listener is gone");
+  }
+  const listener = hook.slice(start, hook.indexOf("});", start));
+  return [
+    ...new Set(
+      [...listener.matchAll(/statusRef\.current === "([^"]*)"/g)].map(
+        (match) => match[1],
+      ),
+    ),
+  ].sort();
+}
+
+test("every status the hook commits is also pushed to the tray", async () => {
+  const hook = await hookSource();
+
+  // setStatus is reached through these three and nowhere else, so covering them
+  // covers every transition the tray can be told about.
+  const committers = ["setBackendStatus", "setBackendError", "setAuthFailure"];
+  const setStatusCalls = [...hook.matchAll(/(?<!\w)setStatus\(/g)].length;
+  assert.equal(
+    setStatusCalls,
+    committers.length,
+    "a status is now committed somewhere the tray sync does not run",
+  );
+
+  for (const name of committers) {
+    assert.match(
+      hookFunction(hook, name),
+      /syncTrayStatus\(/,
+      `${name} leaves the tray showing the previous state`,
+    );
+  }
+});
+
+test("a tray sync never surfaces on the web build or on a binary without the command", async () => {
+  const hook = await hookSource();
+  const sync = hookFunction(hook, "syncTrayStatus");
+
+  // The browser build has no IPC at all, so the import must not even be attempted.
+  assert.match(
+    sync,
+    /if \(!isTauri\) return;/,
+    "syncTrayStatus reaches for the Tauri IPC outside the desktop app",
+  );
+  // A frontend bundle can be newer than the binary serving it, in which case
+  // set_tray_server_status is not registered and the invoke rejects. That leaves the
+  // tray on its build-time label, which is the pre-existing behaviour, and must not
+  // raise an unhandled rejection over a running app.
+  assert.match(
+    sync,
+    /\.catch\(\(\) => \{\}\)/,
+    "a rejected tray sync escapes as an unhandled rejection",
+  );
+});
+
+test("the tray offers a click exactly when the listener would act on it", async () => {
+  const [hook, rust] = await Promise.all([hookSource(), tauriSource()]);
+
+  assert.deepEqual(
+    enabledStatuses(rust),
+    actionableStatuses(hook),
+    "a tray toggle is clickable for a status the renderer silently drops, or greyed for one it would have handled",
+  );
+});
+
+test("an unlisted status falls through rather than going unhandled", async () => {
+  const rust = await tauriSource();
+  const table = trayToggleLabel(rust);
+
+  // BackendStatus grows; the command takes a bare String. A wildcard arm keeps a new
+  // status greyed instead of leaving the label on whatever the last transition set.
+  assert.match(
+    table,
+    /^\s*_ => \(/m,
+    "tray_toggle_label has no wildcard arm for an unknown status",
+  );
+
+  const hook = await hookSource();
+  const union = hook.slice(
+    hook.indexOf("export type BackendStatus ="),
+    hook.indexOf(";", hook.indexOf("export type BackendStatus =")),
+  );
+  const statuses = [...union.matchAll(/"([^"]*)"/g)].map((match) => match[1]);
+  assert.ok(statuses.length >= 11, "the BackendStatus union did not parse");
+  for (const status of enabledStatuses(rust)) {
+    assert.ok(
+      statuses.includes(status),
+      `main.rs enables the tray for "${status}", which is not a BackendStatus`,
+    );
+  }
+});
+
+test("set_tray_server_status is registered, so the invoke can be answered", async () => {
+  const rust = await tauriSource();
+  const handler = rust.slice(
+    rust.indexOf("invoke_handler(tauri::generate_handler!["),
+    rust.indexOf("])", rust.indexOf("invoke_handler(tauri::generate_handler![")),
+  );
+  assert.match(
+    handler,
+    /(?<!\w)set_tray_server_status(?!\w)/,
+    "the tray sync command is defined but not registered, so every invoke rejects",
+  );
+});
+
+test("the tray toggle starts clickable, for a frontend older than this binary", async () => {
+  const rust = await tauriSource();
+  const built = rust.match(
+    /MenuItemBuilder::with_id\("toggle", "([^"]*)"\)([\s\S]{0,40}?)\.build\(app\)/,
+  );
+  assert.ok(built, "the toggle item is no longer built with a literal label");
+  // A bundle predating set_tray_server_status never calls it, so whatever is set here
+  // is what that user sees for the whole session. Seeding it disabled would strand
+  // them with a tray toggle they can never click.
+  assert.doesNotMatch(
+    built[2],
+    /\.enabled\(false\)/,
+    "an old frontend bundle would leave this tray toggle permanently disabled",
+  );
+});

--- a/studio/frontend/tests/tray-server-status.test.ts
+++ b/studio/frontend/tests/tray-server-status.test.ts
@@ -5,12 +5,11 @@ import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import test from "node:test";
 
-// The tray label is settled across two languages: the hook pushes a BackendStatus over
-// the IPC and main.rs turns it into a label and an enabled flag. Neither half can be
-// rendered here, so both are asserted against source, the way the rest of the desktop
-// startup tests do it. tray_toggle_label's own table is covered by the Rust unit tests
-// in main.rs; what is left, and what only a test spanning both files can hold, is that
-// the two halves still agree on the set of statuses.
+// The tray label is settled across two languages: the hook pushes a BackendStatus over the
+// IPC and main.rs turns it into a label and an enabled flag. Neither half can be rendered
+// here, so both are asserted against source, as the rest of the desktop startup tests do.
+// tray_toggle_label's own table is covered by the Rust unit tests in main.rs; only a test
+// spanning both files can hold that the two halves still agree on the set of statuses.
 
 function hookSource(): Promise<string> {
   return readFile(
@@ -110,10 +109,8 @@ test("a tray sync never surfaces on the web build or on a binary without the com
     /if \(!isTauri\) return;/,
     "syncTrayStatus reaches for the Tauri IPC outside the desktop app",
   );
-  // A frontend bundle can be newer than the binary serving it, in which case
-  // set_tray_server_status is not registered and the invoke rejects. That leaves the
-  // tray on its build-time label, which is the pre-existing behaviour, and must not
-  // raise an unhandled rejection over a running app.
+  // Against an older binary the command is unregistered and the invoke rejects, leaving
+  // the tray on its build-time label. That must not raise an unhandled rejection.
   assert.match(
     sync,
     /\.catch\(\(\) => \{\}\)/,
@@ -177,9 +174,8 @@ test("the tray toggle starts clickable, for a frontend older than this binary", 
     /MenuItemBuilder::with_id\("toggle", "([^"]*)"\)([\s\S]{0,40}?)\.build\(app\)/,
   );
   assert.ok(built, "the toggle item is no longer built with a literal label");
-  // A bundle predating set_tray_server_status never calls it, so whatever is set here
-  // is what that user sees for the whole session. Seeding it disabled would strand
-  // them with a tray toggle they can never click.
+  // A bundle predating set_tray_server_status never calls it, so seeding it disabled
+  // would strand that user with a tray toggle they can never click.
   assert.doesNotMatch(
     built[2],
     /\.enabled\(false\)/,

--- a/studio/src-tauri/src/main.rs
+++ b/studio/src-tauri/src/main.rs
@@ -36,7 +36,7 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Mutex, MutexGuard, OnceLock};
-use tauri::menu::{MenuBuilder, MenuItemBuilder};
+use tauri::menu::{MenuBuilder, MenuItem, MenuItemBuilder};
 use tauri::tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent};
 use tauri::{Emitter, Manager};
 use tauri_plugin_window_state::{AppHandleExt, StateFlags};
@@ -1680,13 +1680,36 @@ fn setup_terminate_interception(app: &tauri::App) {
     }
 }
 
+struct TrayServerToggle(MenuItem<tauri::Wry>);
+
+fn tray_toggle_label(status: &str) -> (&'static str, bool) {
+    match status {
+        "running" => ("Stop Server", true),
+        "stopped" | "error" => ("Start Server", true),
+        "starting" => ("Starting\u{2026}", false),
+        _ => ("Start Server", false),
+    }
+}
+
+#[tauri::command]
+fn set_tray_server_status(app: tauri::AppHandle, status: String) {
+    if let Some(toggle) = app.try_state::<TrayServerToggle>() {
+        let (text, enabled) = tray_toggle_label(&status);
+        let _ = toggle.0.set_text(text);
+        let _ = toggle.0.set_enabled(enabled);
+    }
+}
+
 fn setup_tray(app: &tauri::App) -> Result<(), Box<dyn std::error::Error>> {
     let open = MenuItemBuilder::with_id("open", "Open Unsloth").build(app)?;
-    let toggle = MenuItemBuilder::with_id("toggle", "Start/Stop Server").build(app)?;
+    let toggle = MenuItemBuilder::with_id("toggle", "Starting\u{2026}")
+        .enabled(false)
+        .build(app)?;
     let quit = MenuItemBuilder::with_id("quit", "Quit").build(app)?;
     let menu = MenuBuilder::new(app)
         .items(&[&open, &toggle, &quit])
         .build()?;
+    app.manage(TrayServerToggle(toggle));
 
     TrayIconBuilder::new()
         .menu(&menu)
@@ -1913,6 +1936,7 @@ fn main() {
             set_close_to_tray,
             get_launch_at_login,
             set_launch_at_login,
+            set_tray_server_status,
         ])
         .setup(|app| {
             // Resolve here, before any window path can ask: this consumes the relaunch marker.

--- a/studio/src-tauri/src/main.rs
+++ b/studio/src-tauri/src/main.rs
@@ -2780,9 +2780,9 @@ mod tests {
         assert_eq!(tray_toggle_label("starting"), ("Starting\u{2026}", false));
     }
 
-    /// Every remaining BackendStatus the hook can report. The listener does nothing for
-    /// any of them, so the item is greyed rather than offering a click that would be a
-    /// silent no-op. Keep this list in step with the union in use-tauri-backend.ts.
+    /// Every remaining BackendStatus: the listener acts on none of them, so the item is
+    /// greyed rather than offering a click that would be a silent no-op. Keep this list in
+    /// step with the union in use-tauri-backend.ts.
     #[test]
     fn a_status_the_tray_cannot_act_on_greys_the_toggle() {
         for status in [
@@ -2802,10 +2802,9 @@ mod tests {
         }
     }
 
-    /// The status arrives as whatever string the webview sent, so a frontend bundle
-    /// older or newer than this binary can reach the command with something that is not
-    /// a status at all. Match the whole string: a prefix or a case fold would let
-    /// "run" read as an offer to stop a server that is not running.
+    /// The status is whatever string the webview sent, so a mismatched bundle can pass
+    /// something that is not a status at all. Match the whole string: a prefix or a case
+    /// fold would let "run" read as an offer to stop a server that is not running.
     #[test]
     fn an_unrecognised_status_greys_the_toggle_rather_than_guessing() {
         for status in ["", " ", "Running", "RUNNING", "running ", "run", "{}"] {

--- a/studio/src-tauri/src/main.rs
+++ b/studio/src-tauri/src/main.rs
@@ -2769,4 +2769,51 @@ mod tests {
         apply_renderer_activity(&state, "Downloads", true);
         assert_eq!(renderer_activity(&state), (false, true));
     }
+
+    /// The three states the tray-toggle-server listener in use-tauri-backend.ts acts
+    /// on, plus the one the tray reports progress for.
+    #[test]
+    fn the_tray_toggle_names_the_action_a_click_would_take() {
+        assert_eq!(tray_toggle_label("running"), ("Stop Server", true));
+        assert_eq!(tray_toggle_label("stopped"), ("Start Server", true));
+        assert_eq!(tray_toggle_label("error"), ("Start Server", true));
+        assert_eq!(tray_toggle_label("starting"), ("Starting\u{2026}", false));
+    }
+
+    /// Every remaining BackendStatus the hook can report. The listener does nothing for
+    /// any of them, so the item is greyed rather than offering a click that would be a
+    /// silent no-op. Keep this list in step with the union in use-tauri-backend.ts.
+    #[test]
+    fn a_status_the_tray_cannot_act_on_greys_the_toggle() {
+        for status in [
+            "checking",
+            "not-installed",
+            "installing",
+            "install-error",
+            "needs-elevation",
+            "repairing",
+            "repair-error",
+        ] {
+            assert_eq!(
+                tray_toggle_label(status),
+                ("Start Server", false),
+                "{status} offered a click the renderer would drop"
+            );
+        }
+    }
+
+    /// The status arrives as whatever string the webview sent, so a frontend bundle
+    /// older or newer than this binary can reach the command with something that is not
+    /// a status at all. Match the whole string: a prefix or a case fold would let
+    /// "run" read as an offer to stop a server that is not running.
+    #[test]
+    fn an_unrecognised_status_greys_the_toggle_rather_than_guessing() {
+        for status in ["", " ", "Running", "RUNNING", "running ", "run", "{}"] {
+            assert_eq!(
+                tray_toggle_label(status),
+                ("Start Server", false),
+                "{status:?} was read as a known status"
+            );
+        }
+    }
 }

--- a/studio/src-tauri/src/main.rs
+++ b/studio/src-tauri/src/main.rs
@@ -1702,9 +1702,7 @@ fn set_tray_server_status(app: tauri::AppHandle, status: String) {
 
 fn setup_tray(app: &tauri::App) -> Result<(), Box<dyn std::error::Error>> {
     let open = MenuItemBuilder::with_id("open", "Open Unsloth").build(app)?;
-    let toggle = MenuItemBuilder::with_id("toggle", "Starting\u{2026}")
-        .enabled(false)
-        .build(app)?;
+    let toggle = MenuItemBuilder::with_id("toggle", "Start/Stop Server").build(app)?;
     let quit = MenuItemBuilder::with_id("quit", "Quit").build(app)?;
     let menu = MenuBuilder::new(app)
         .items(&[&open, &toggle, &quit])


### PR DESCRIPTION
The tray's "Start/Stop Server" item now shows the actual backend state: "Stop Server" while running, "Start Server" when stopped or errored, and a disabled "Starting..." during startup. The frontend calls a small set_tray_server_status command whenever backend status changes.