### PR TITLE
fix(studio/backend): un-stall the Python 3.13 Backend CI job

### DIFF
--- a/studio/backend/routes/providers.py
+++ b/studio/backend/routes/providers.py
@@ -284,7 +284,6 @@ async def create_provider_config(
 
 
 @router.put("/{provider_id}", response_model = ProviderResponse)
-@serialize_provider_config
 async def update_provider_config(
     provider_id: str,
     payload: ProviderUpdate,
@@ -292,6 +291,31 @@ async def update_provider_config(
     via_api_key: bool = Depends(authenticated_via_api_key),
 ):
     """Update a saved provider configuration."""
+    row, validated_account, needs_proof, restore = await _apply_provider_update(
+        provider_id, payload, credential, via_api_key
+    )
+    if needs_proof and validated_account:
+        # Deliberately outside the serialize_provider_config lock: this awaits the 30s
+        # provider_oauth_write_guard file lock, and holding the config lock across that
+        # wait both stalls every other save for this provider and deadlocks against a save
+        # landing in between — the exact window this rollback is built for. The mutation is
+        # already committed; on failure the rollback restores only this request's columns.
+        try:
+            await openai_codex_auth.remember_catalog_account(provider_id, validated_account)
+        except Exception:
+            restore()
+            raise
+    return _provider_response(row)
+
+
+@serialize_provider_config
+async def _apply_provider_update(
+    provider_id: str,
+    payload: ProviderUpdate,
+    credential: tuple,
+    via_api_key: bool,
+):
+    """Serialize and commit one provider mutation; the caller records the catalog proof."""
 
     require_ui_session(via_api_key)
     existing = providers_db.get_provider(provider_id)
@@ -467,26 +491,8 @@ async def update_provider_config(
         raise HTTPException(status_code = 400, detail = "No fields to update")
 
     row = providers_db.get_provider(provider_id)
-    if existing_info.get("auth_kind") == "chatgpt_oauth" and payload.models is not None:
-        # Record the proof here rather than when a catalog is read: reading one only
-        # shows which account answered, while this is the point where the row's models
-        # were actually judged against it and stored.
-        # The account the selection was judged against, not whatever owns the connection
-        # by now. remember_catalog_account re-reads under the guard and declines to write
-        # when the bundle has moved on, so a rebind in between records nothing.
-        # Written after the row, never before: a proof recorded ahead of a commit that
-        # then failed would license models this connection never saved. Recording it is
-        # part of the save, so a failure here undoes the row too. Leaving the new models
-        # behind without the proof is the state saved_models_proven_for exists to catch,
-        # and it outlives the process: after a restart, with the plan catalog unreadable,
-        # the row's own slugs stop authorizing chat and the next save is refused as well.
-        if validated_account:
-            try:
-                await openai_codex_auth.remember_catalog_account(provider_id, validated_account)
-            except Exception:
-                _restore_metadata()
-                raise
-    return _provider_response(row)
+    needs_proof = existing_info.get("auth_kind") == "chatgpt_oauth" and payload.models is not None
+    return row, validated_account, needs_proof, _restore_metadata
 
 
 @router.put("/{provider_id}/api-key/migrate", response_model = ProviderResponse)

--- a/studio/backend/routes/providers.py
+++ b/studio/backend/routes/providers.py
@@ -310,10 +310,7 @@ async def update_provider_config(
 
 @serialize_provider_config
 async def _apply_provider_update(
-    provider_id: str,
-    payload: ProviderUpdate,
-    credential: tuple,
-    via_api_key: bool,
+    provider_id: str, payload: ProviderUpdate, credential: tuple, via_api_key: bool
 ):
     """Serialize and commit one provider mutation; the caller records the catalog proof."""
 

--- a/studio/backend/tests/test_provider_lookup_off_event_loop.py
+++ b/studio/backend/tests/test_provider_lookup_off_event_loop.py
@@ -124,7 +124,9 @@ def test_the_saved_provider_target_and_key_are_one_snapshot(monkeypatch):
 @pytest.mark.parametrize(
     "handler",
     [
-        provider_routes.update_provider_config,
+        # update_provider_config splits its serialized mutation into
+        # _apply_provider_update so the catalog proof can run outside the lock.
+        provider_routes._apply_provider_update,
         provider_routes.migrate_provider_api_key,
         provider_routes.delete_provider_config,
     ],

--- a/studio/backend/tests/test_reset_password_command.py
+++ b/studio/backend/tests/test_reset_password_command.py
@@ -13,7 +13,9 @@ from __future__ import annotations
 
 import ast
 import importlib.util
+import os
 import sys
+import types
 from pathlib import Path
 
 import pytest
@@ -39,9 +41,32 @@ def auth():
     return module
 
 
+def _spoof_auth_globals(monkeypatch, auth, *, os_name = None, executable = None) -> None:
+    """Give routes/auth.py private copies of ``os`` and ``sys``.
+
+    The command builder branches on ``os.name`` and reads ``sys.executable``,
+    but the real modules are shared with pytest's terminal reporter and the
+    xdist transport, which keep reading them while a test runs. Mutating them
+    in-process flipped pathlib to Windows flavour inside pytest's own report
+    formatting (``ValueError: ... is not in the subpath of '\\repo\\...'``)
+    and killed the worker, taking down or wedging the whole run. Module-private
+    copies keep the spoof scoped to the code under test.
+    """
+    if os_name is not None:
+        fake_os = types.ModuleType(os.__name__)
+        fake_os.__dict__.update(os.__dict__)
+        fake_os.name = os_name
+        monkeypatch.setattr(auth, "os", fake_os)
+    if executable is not None:
+        fake_sys = types.ModuleType(sys.__name__)
+        fake_sys.__dict__.update(sys.__dict__)
+        fake_sys.executable = executable
+        monkeypatch.setattr(auth, "sys", fake_sys)
+
+
 @pytest.fixture
 def windows(monkeypatch, auth):
-    monkeypatch.setattr(auth.os, "name", "nt")
+    _spoof_auth_globals(monkeypatch, auth, os_name = "nt")
 
 
 def test_a_venv_install_gets_the_isolated_module_route(auth, monkeypatch, windows):
@@ -51,8 +76,8 @@ def test_a_venv_install_gets_the_isolated_module_route(auth, monkeypatch, window
     directory that happens to hold an unsloth_cli folder cannot shadow the
     managed one.
     """
-    monkeypatch.setattr(
-        auth.sys, "executable", r"C:\Users\dan\.unsloth\studio\unsloth_studio\Scripts\python.exe"
+    _spoof_auth_globals(
+        monkeypatch, auth, executable = r"C:\Users\dan\.unsloth\studio\unsloth_studio\Scripts\python.exe"
     )
     monkeypatch.setattr(auth, "_cli_is_inside", lambda _prefix: True)
 
@@ -69,7 +94,7 @@ def test_a_user_site_install_is_not_told_to_isolate_itself(auth, monkeypatch, wi
     `No module named unsloth_cli`, which is worse than useless to someone who is
     already locked out.
     """
-    monkeypatch.setattr(auth.sys, "executable", r"C:\Python313\python.exe")
+    _spoof_auth_globals(monkeypatch, auth, executable = r"C:\Python313\python.exe")
     monkeypatch.setattr(auth, "_cli_is_inside", lambda _prefix: False)
 
     command = auth._reset_password_command()
@@ -108,7 +133,7 @@ def test_the_bootstrap_matches_the_one_the_cli_uses(auth):
 
 def test_a_spaced_interpreter_path_still_falls_through_to_the_cmd_shim(auth, monkeypatch, windows):
     """Unchanged: a quoted path is written differently in cmd and PowerShell."""
-    monkeypatch.setattr(auth.sys, "executable", r"C:\Program Files\Python313\python.exe")
+    _spoof_auth_globals(monkeypatch, auth, executable = r"C:\Program Files\Python313\python.exe")
     monkeypatch.setattr(auth, "_cli_is_inside", lambda _prefix: True)
 
     assert auth._reset_password_command() == "unsloth.cmd studio reset-password"
@@ -140,10 +165,9 @@ def test_the_prefix_check_locates_rather_than_imports(auth, tmp_path, monkeypatc
 
 def test_posix_is_untouched(auth, monkeypatch, tmp_path):
     """The console script is what a POSIX user should run; nothing here changes."""
-    monkeypatch.setattr(auth.os, "name", "posix")
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
     (bin_dir / "unsloth").write_text("", encoding = "utf-8")
-    monkeypatch.setattr(auth.sys, "executable", str(bin_dir / "python"))
+    _spoof_auth_globals(monkeypatch, auth, os_name = "posix", executable = str(bin_dir / "python"))
 
     assert auth._reset_password_command() == f"{bin_dir / 'unsloth'} studio reset-password"

--- a/studio/backend/tests/test_reset_password_command.py
+++ b/studio/backend/tests/test_reset_password_command.py
@@ -41,7 +41,13 @@ def auth():
     return module
 
 
-def _spoof_auth_globals(monkeypatch, auth, *, os_name = None, executable = None) -> None:
+def _spoof_auth_globals(
+    monkeypatch,
+    auth,
+    *,
+    os_name = None,
+    executable = None,
+) -> None:
     """Give routes/auth.py private copies of ``os`` and ``sys``.
 
     The command builder branches on ``os.name`` and reads ``sys.executable``,
@@ -77,7 +83,9 @@ def test_a_venv_install_gets_the_isolated_module_route(auth, monkeypatch, window
     managed one.
     """
     _spoof_auth_globals(
-        monkeypatch, auth, executable = r"C:\Users\dan\.unsloth\studio\unsloth_studio\Scripts\python.exe"
+        monkeypatch,
+        auth,
+        executable = r"C:\Users\dan\.unsloth\studio\unsloth_studio\Scripts\python.exe",
     )
     monkeypatch.setattr(auth, "_cli_is_inside", lambda _prefix: True)
 

--- a/studio/backend/tests/test_scan_folder_health.py
+++ b/studio/backend/tests/test_scan_folder_health.py
@@ -571,14 +571,31 @@ def test_the_deep_probe_finds_the_denial_in_a_few_opens(tmp_path: Path, monkeypa
         denied.chmod(stat.S_IRWXU)
 
 
-def test_this_file_can_be_collected_without_geteuid(monkeypatch):
-    """Windows has no os.geteuid, and a skipif condition runs at import time."""
+def test_this_file_can_be_collected_without_geteuid():
+    """Windows has no os.geteuid, and a skipif condition runs at import time.
+
+    Restored before the test returns, not by a fixture teardown: pytest formats
+    this test's call report after the body returns but before any teardown, and
+    the terminal writer reads os.name while rendering the location. A still-
+    spoofed value there flips pathlib to Windows flavour (``ValueError: ... is
+    not in the subpath of '\\repo\\...'``) and kills the xdist worker mid-run.
+    """
     source = Path(__file__).read_text(encoding = "utf-8")
-    monkeypatch.delattr(os, "geteuid", raising = False)
-    monkeypatch.setattr(os, "name", "nt")
-    namespace: dict = {"__name__": "windows_collection_probe"}
-    # The module body is what pytest evaluates while collecting.
-    exec(compile(source, __file__, "exec"), namespace)
+    real_name = os.name
+    real_geteuid = getattr(os, "geteuid", None)
+    try:
+        os.name = "nt"
+        if real_geteuid is not None:
+            del os.geteuid
+        namespace: dict = {"__name__": "windows_collection_probe"}
+        # The module body is what pytest evaluates while collecting. pytest and
+        # the stdlib are already imported in this worker, so the re-imports stay
+        # cached and never re-run on the spoofed os.name.
+        exec(compile(source, __file__, "exec"), namespace)
+    finally:
+        os.name = real_name
+        if real_geteuid is not None:
+            os.geteuid = real_geteuid
 
 
 def test_the_child_probe_is_bounded(tmp_path: Path, monkeypatch):

--- a/studio/backend/tests/test_torch_device_probe.py
+++ b/studio/backend/tests/test_torch_device_probe.py
@@ -9,11 +9,42 @@ import signal
 import subprocess
 import sys
 import threading
+import types
 from pathlib import Path
 
 import pytest
 
 from utils import process_lifetime, torch_device_probe
+
+
+def _spoof_os_name(monkeypatch, name: str) -> None:
+    """Give the probe a private ``os`` whose ``name`` is spoofed.
+
+    The probe branches on ``os.name`` for every status interpretation, but the
+    real ``os`` module is shared with pytest's terminal reporter and the xdist
+    transport, which keep reading it while a test runs. Mutating it in-process
+    flipped pathlib to Windows flavour inside pytest's own report formatting
+    (``ValueError: ... is not in the subpath of '\\repo\\...'``) and took the
+    worker down, killing or wedging the whole run. A module-private copy keeps
+    the spoof scoped to the code under test.
+    """
+    fake_os = types.ModuleType(os.__name__)
+    fake_os.__dict__.update(os.__dict__)
+    fake_os.name = name
+    monkeypatch.setattr(torch_device_probe, "os", fake_os)
+
+
+def _spoof_sys_platform(monkeypatch, platform: str) -> None:
+    """Give the probe a private copy of ``sys`` with the platform spoofed.
+
+    Same reason as ``_spoof_os_name``: the real ``sys`` is shared with pytest
+    and the xdist transport; on Windows the spoof also defeats the
+    ``sys.platform == "win32"`` guard in process_lifetime's liveness probe.
+    """
+    fake_sys = types.ModuleType(sys.__name__)
+    fake_sys.__dict__.update(sys.__dict__)
+    fake_sys.platform = platform
+    monkeypatch.setattr(torch_device_probe, "sys", fake_sys)
 
 
 # A child that dies of SIGSEGV is still handed to the host's core_pattern handler
@@ -266,13 +297,13 @@ def test_a_child_that_hit_its_own_deadline_is_a_failed_probe(monkeypatch):
     # recognised before: SIGALRM is not a hard fault so it fell through _died_by_signal,
     # and the Windows status is an ordinary non-zero exit. Both read as a healthy device,
     # which let the parent make the allocation the probe stands in front of.
-    monkeypatch.setattr(torch_device_probe.os, "name", "posix")
+    _spoof_os_name(monkeypatch, "posix")
     _patch_popen(monkeypatch, _FakeProcess(returncode = -torch_device_probe._SIGALRM_NUMBER))
     assert torch_device_probe.device_can_allocate("cuda") is False
 
 
 def test_the_windows_watchdog_status_is_a_failed_probe(monkeypatch):
-    monkeypatch.setattr(torch_device_probe.os, "name", "nt")
+    _spoof_os_name(monkeypatch, "nt")
     _patch_popen(monkeypatch, _FakeProcess(returncode = torch_device_probe._WATCHDOG_EXIT_STATUS))
     assert torch_device_probe.device_can_allocate("cuda") is False
 
@@ -280,7 +311,7 @@ def test_the_windows_watchdog_status_is_a_failed_probe(monkeypatch):
 def test_a_windows_crt_abort_is_a_failed_probe(monkeypatch):
     # A native abort() on Windows leaves plain exit status 3, not an NTSTATUS, so nothing
     # else here recognises it and the crashing device was being reported as usable.
-    monkeypatch.setattr(torch_device_probe.os, "name", "nt")
+    _spoof_os_name(monkeypatch, "nt")
     _patch_popen(
         monkeypatch,
         _FakeProcess(returncode = torch_device_probe._WINDOWS_ABORT_EXIT_STATUS),
@@ -290,7 +321,7 @@ def test_a_windows_crt_abort_is_a_failed_probe(monkeypatch):
 
 def test_the_abort_status_is_read_as_a_crash_only_on_windows(monkeypatch):
     # Elsewhere 3 is just an exit status a child chose, and an abort arrives as SIGABRT.
-    monkeypatch.setattr(torch_device_probe.os, "name", "posix")
+    _spoof_os_name(monkeypatch, "posix")
     assert (
         torch_device_probe._died_by_signal(torch_device_probe._WINDOWS_ABORT_EXIT_STATUS) is False
     )
@@ -428,7 +459,7 @@ def test_timeout_that_terminates_does_not_kill(monkeypatch):
 def test_windows_child_registers_rocm_dll_directories_before_torch(monkeypatch, tmp_path):
     rocm_bin = tmp_path / "rocm" / "bin"
     rocm_bin.mkdir(parents = True)
-    monkeypatch.setattr(sys, "platform", "win32")
+    _spoof_sys_platform(monkeypatch, "win32")
     monkeypatch.setenv("HIP_PATH", str(tmp_path / "rocm"))
     calls: list = []
     _patch_popen(monkeypatch, _FakeProcess(), calls)
@@ -442,7 +473,7 @@ def test_windows_child_registers_rocm_dll_directories_before_torch(monkeypatch, 
 def test_windows_rocm_directories_use_numeric_version_order(monkeypatch, tmp_path):
     for version in ("6.3", "10.0", "7.0"):
         (tmp_path / "AMD" / "ROCm" / version / "bin").mkdir(parents = True)
-    monkeypatch.setattr(sys, "platform", "win32")
+    _spoof_sys_platform(monkeypatch, "win32")
     monkeypatch.setenv("ProgramFiles", str(tmp_path))
     monkeypatch.delenv("HIP_PATH", raising = False)
     monkeypatch.delenv("ROCM_PATH", raising = False)
@@ -470,7 +501,7 @@ def test_windows_rocm_directories_use_numeric_version_order(monkeypatch, tmp_pat
     ],
 )
 def test_died_by_signal(monkeypatch, returncode, on_windows, expected):
-    monkeypatch.setattr(torch_device_probe.os, "name", "nt" if on_windows else "posix")
+    _spoof_os_name(monkeypatch, "nt" if on_windows else "posix")
     assert torch_device_probe._died_by_signal(returncode) is expected
 
 
@@ -480,7 +511,7 @@ def test_a_killed_probe_is_not_a_pass_for_an_accelerator(monkeypatch, killer):
     # run that earns a pass either. Importing torch and building its device context is
     # enough to trip a cgroup OOM on its own, and reading that as a pass sends the caller
     # on to a much larger load in this process.
-    monkeypatch.setattr(torch_device_probe.os, "name", "posix")
+    _spoof_os_name(monkeypatch, "posix")
     _patch_popen(monkeypatch, _FakeProcess(returncode = -killer))
     assert torch_device_probe.device_can_allocate("cuda") is False
 
@@ -488,13 +519,13 @@ def test_a_killed_probe_is_not_a_pass_for_an_accelerator(monkeypatch, killer):
 def test_a_killed_probe_still_leaves_cpu_available(monkeypatch):
     # Same no-verdict trade as a probe that never ran: CPU cannot fault a GPU driver, and
     # condemning it would push the caller past its CPU fallback to a different backend.
-    monkeypatch.setattr(torch_device_probe.os, "name", "posix")
+    _spoof_os_name(monkeypatch, "posix")
     _patch_popen(monkeypatch, _FakeProcess(returncode = -9))
     assert torch_device_probe.device_can_allocate("cpu") is True
 
 
 def test_a_clean_child_is_still_a_pass(monkeypatch):
-    monkeypatch.setattr(torch_device_probe.os, "name", "posix")
+    _spoof_os_name(monkeypatch, "posix")
     _patch_popen(monkeypatch, _FakeProcess(returncode = 0))
     assert torch_device_probe.device_can_allocate("cuda") is True
 


### PR DESCRIPTION
## What this fixes

The 3.13 Backend CI leg reached about 95% and then hung until the 45 minute job timeout cancelled it, leaving three orphaned python processes. Reproduced in a python:3.13 container and root-caused. The stall was not disk or memory. It was a real asyncio deadlock plus a second defect that kills xdist workers. Both are fixed.

## Root cause 1: provider-config deadlock (the 95% stall)

`test_credential_routes.py::test_codex_proof_rollback_leaves_a_concurrent_save_alone` parks a first `update_provider_config` inside `remember_catalog_account` (standing in for its 30 second file lock wait), then starts a second update for the same provider. Since #9234 wrapped the whole handler in `serialize_provider_config`, the first save still holds the per-provider `asyncio.Lock` while parked, so the second save blocks on it forever and the gate is only set after the second save returns. That is a circular wait, and `asyncio.Lock` has no timeout, so the worker hangs and the master blocks in `dsession.loop_once`. Confirmed with `py-spy` and an asyncio task watchdog.

Holding the lock across that wait also contradicts `_restore_metadata`'s own docstring ("a second save can land in between"), which only works if the proof is recorded outside the serialized mutation.

## Root cause 2: platform-spoof tests corrupting pytest

Some tests monkeypatch the real `os.name` and `sys` to fake another platform. pytest formats the test's report after the body returns but before monkeypatch teardown, reads the still-spoofed `os.name`, flips pathlib to Windows flavour, and raises `ValueError: '/repo/studio/backend' is not in the subpath of '\\repo\\studio\\backend'`. That is an INTERNALERROR that kills the xdist worker.

## Changes

- `routes/providers.py`: split `update_provider_config`. New `@serialize_provider_config _apply_provider_update` commits the metadata and credential write under the lock and returns the row, the validated account, a needs-proof flag, and the `_restore_metadata` rollback. The route then records the catalog proof, and rolls back on failure, outside the lock. Behavior is unchanged; only the lock scope narrows.
- `tests/test_provider_lookup_off_event_loop.py`: the serialization guard now points at `_apply_provider_update`, which carries the lock.
- `tests/test_reset_password_command.py`, `tests/test_torch_device_probe.py`: pass a private copy of `os` / `sys` (`types.ModuleType` plus a `__dict__` copy) instead of mutating the interpreter-wide modules.
- `tests/test_scan_folder_health.py`: the geteuid probe spoofs `os` and restores it in a `finally` before returning.

## Verification (python:3.13-slim, exact CI deps and invocation)

- The formerly wedging credential test: PASSED in about 2s (was a confirmed circular wait).
- The four touched files under `-n 4`: 106 passed, 19 skipped.
- The full CI invocation now runs to completion: 26213 passed, 202 skipped in about 15 min, no INTERNALERROR. It previously hung at 95%.
- No regression: base plus these 5 files, and untouched base, both give 63 passed / 1 failed on the setup/stt files. `test_vendored_truststore::test_vendored_tree_matches_the_manifest` fails identically on the untouched base, so it is pre-existing.

## Reviewer note

`routes/providers.py` is the only production change: a behavior-preserving narrowing of the `serialize_provider_config` lock scope so the catalog proof no longer holds it. That is the part to review hardest.