### PR TITLE
Desktop: stop sending OS notifications for model loads

### DIFF
--- a/studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts
+++ b/studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts
@@ -28,12 +28,6 @@ import { consumeNativePathToken } from "@/features/native-intents/api";
 // eslint-disable-next-line no-restricted-imports -- Avoid the hub barrel's React and download-manager exports.
 import { modelDisplayName } from "@/features/hub/lib/model-identity";
 import { prepareHfTokenForUse } from "@/features/hf-auth";
-import {
-  notifyNative,
-  primeNativeNotificationPermission,
-  safeNotificationLabel,
-  sanitizeNotificationBody,
-} from "@/lib/native-notifications";
 import { ModelLoadDescription } from "../components/model-load-status";
 import {
   getDownloadProgress,
@@ -550,7 +544,6 @@ export function useChatModelRuntime() {
   const loadAbortRef = useRef<AbortController | null>(null);
   const loadingModelRef = useRef<typeof loadingModel>(null);
   const loadToastIdRef = useRef<string | number | null>(null);
-  const loadAttemptRef = useRef(0);
   const loadToastDismissedRef = useRef(false);
   const cancelUnloadPendingRef = useRef(false);
   const loadLifecycleLeaseRef = useRef<ModelLifecycleLease | null>(null);
@@ -1010,10 +1003,6 @@ export function useChatModelRuntime() {
         explicitIsLora ?? model?.isLora ?? loraIsAdapter ?? false;
       const displayName = model?.name || lora?.name || modelId;
       const toastDisplayName = shortModelLabel(displayName);
-      const loadAttemptId = ++loadAttemptRef.current;
-      primeNativeNotificationPermission().catch(() => undefined);
-      const notificationModelKey = `${modelId}:${ggufVariant ?? ""}:${loadAttemptId}`;
-      const safeModelName = safeNotificationLabel(toastDisplayName, "The model");
       const currentCheckpoint =
         useChatRuntimeStore.getState().params.checkpoint;
       const previousCheckpoint = currentCheckpoint;
@@ -2246,12 +2235,6 @@ export function useChatModelRuntime() {
                   ),
                 });
               }
-              notifyNative({
-                key: `model-downloaded:${notificationModelKey}`,
-                title: "Model downloaded",
-                body: `${safeModelName} finished downloading and is loading into memory.`,
-                requestPermission: false,
-              }).catch(() => undefined);
               // Keep polling: the mmap branch below takes over from here.
             }
           } catch {
@@ -2356,12 +2339,6 @@ export function useChatModelRuntime() {
               onDismiss: undefined,
             });
           }
-          notifyNative({
-            key: `model-loaded:${notificationModelKey}`,
-            title: "Model ready",
-            body: `${safeModelName} is loaded and ready to chat.`,
-            requestPermission: false,
-          }).catch(() => undefined);
         } catch (err) {
           if (!abortCtrl.signal.aborted) {
             const message =
@@ -2379,12 +2356,6 @@ export function useChatModelRuntime() {
                 onDismiss: undefined,
               });
             }
-            notifyNative({
-              key: `model-load-failed:${notificationModelKey}`,
-              title: "Model failed to load",
-              body: sanitizeNotificationBody(message, "The model failed to load."),
-              requestPermission: false,
-            }).catch(() => undefined);
           }
           throw err;
         } finally {

--- a/studio/frontend/tests/helpers/notification-resolver.mjs
+++ b/studio/frontend/tests/helpers/notification-resolver.mjs
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// The same two rules clipboard-resolver.mjs applies, for the notification plugin:
+//
+//   1. "@tauri-apps/plugin-notification" -> a local stub, because the real package
+//      only resolves inside a Tauri webview.
+//   2. A "?bust=N" query on the importer is copied onto every src module it pulls
+//      in. lib/api-base computes `isTauri` once, at module evaluation, and
+//      lib/native-notifications caches the permission grant and its sent-key set in
+//      module scope, so the only way to exercise more than one environment in a
+//      single process is to evaluate the whole subgraph again under a fresh key.
+import { existsSync } from "node:fs";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const SRC = fileURLToPath(new URL("../../src/", import.meta.url));
+const NOTIFICATION_STUB = new URL("./tauri-notification-stub.mjs", import.meta.url)
+  .href;
+
+function firstExisting(base) {
+  for (const candidate of [`${base}.ts`, `${base}/index.ts`, base]) {
+    if (existsSync(candidate)) return pathToFileURL(candidate).href;
+  }
+  return null;
+}
+
+function bustOf(parentURL) {
+  if (!parentURL) return "";
+  const bust = new URL(parentURL).searchParams.get("bust");
+  return bust ? `?bust=${bust}` : "";
+}
+
+export function resolve(specifier, context, next) {
+  const suffix = bustOf(context.parentURL);
+
+  if (specifier === "@tauri-apps/plugin-notification") {
+    return next(NOTIFICATION_STUB + suffix, context);
+  }
+  if (specifier.startsWith("@/")) {
+    const resolved = firstExisting(SRC + specifier.slice(2));
+    return next(resolved ? resolved + suffix : specifier, context);
+  }
+  if (specifier.startsWith(".") && context.parentURL?.startsWith("file:")) {
+    const parent = new URL(context.parentURL);
+    parent.search = "";
+    const resolved = firstExisting(fileURLToPath(new URL(specifier, parent)));
+    if (resolved) return next(resolved + suffix, context);
+  }
+  return next(specifier, context);
+}

--- a/studio/frontend/tests/helpers/notification-resolver.mjs
+++ b/studio/frontend/tests/helpers/notification-resolver.mjs
@@ -1,15 +1,14 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-// The same two rules clipboard-resolver.mjs applies, for the notification plugin:
+// clipboard-resolver.mjs's two rules, for the notification plugin:
 //
-//   1. "@tauri-apps/plugin-notification" -> a local stub, because the real package
-//      only resolves inside a Tauri webview.
+//   1. "@tauri-apps/plugin-notification" -> a local stub; the real package only
+//      resolves inside a Tauri webview.
 //   2. A "?bust=N" query on the importer is copied onto every src module it pulls
-//      in. lib/api-base computes `isTauri` once, at module evaluation, and
-//      lib/native-notifications caches the permission grant and its sent-key set in
-//      module scope, so the only way to exercise more than one environment in a
-//      single process is to evaluate the whole subgraph again under a fresh key.
+//      in. api-base computes `isTauri` once at module evaluation, and
+//      native-notifications caches the grant and its sent-key set in module scope,
+//      so exercising a second environment means re-evaluating the whole subgraph.
 import { existsSync } from "node:fs";
 import { fileURLToPath, pathToFileURL } from "node:url";
 

--- a/studio/frontend/tests/helpers/tauri-notification-stub.mjs
+++ b/studio/frontend/tests/helpers/tauri-notification-stub.mjs
@@ -2,14 +2,13 @@
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
 // Stands in for @tauri-apps/plugin-notification, which only resolves inside a
-// Tauri webview. State lives on globalThis, not in module scope, so it survives
-// the re-evaluation notification-resolver.mjs forces with its "?bust=N" key.
+// Tauri webview. State lives on globalThis so it survives the re-evaluation
+// notification-resolver.mjs forces with its "?bust=N" key.
 //
-//   mode "ok"             -> isPermissionGranted reports `granted`, notifications send
+//   mode "ok"             -> permission follows `granted`, notifications send
 //   mode "send-fails"     -> sendNotification throws (IPC error)
-//   mode "module-missing" -> the module throws on evaluation, which is what
-//                            `await import(...)` does when the notification
-//                            capability is absent from src-tauri/capabilities
+//   mode "module-missing" -> the module throws on evaluation, as `await import()`
+//                            does when the capability is absent from src-tauri
 
 const control = (globalThis.__TAURI_NOTIFICATION_STUB__ ??= {
   sent: [],

--- a/studio/frontend/tests/helpers/tauri-notification-stub.mjs
+++ b/studio/frontend/tests/helpers/tauri-notification-stub.mjs
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// Stands in for @tauri-apps/plugin-notification, which only resolves inside a
+// Tauri webview. State lives on globalThis, not in module scope, so it survives
+// the re-evaluation notification-resolver.mjs forces with its "?bust=N" key.
+//
+//   mode "ok"             -> isPermissionGranted reports `granted`, notifications send
+//   mode "send-fails"     -> sendNotification throws (IPC error)
+//   mode "module-missing" -> the module throws on evaluation, which is what
+//                            `await import(...)` does when the notification
+//                            capability is absent from src-tauri/capabilities
+
+const control = (globalThis.__TAURI_NOTIFICATION_STUB__ ??= {
+  sent: [],
+  granted: false,
+  mode: "ok",
+  requests: 0,
+});
+
+if (control.mode === "module-missing") {
+  throw new Error("Cannot find module '@tauri-apps/plugin-notification'");
+}
+
+export async function isPermissionGranted() {
+  return control.granted;
+}
+
+export async function requestPermission() {
+  control.requests += 1;
+  return control.granted ? "granted" : "denied";
+}
+
+export function sendNotification(payload) {
+  if (control.mode === "send-fails") {
+    throw new Error("notification: forbidden, capability not granted");
+  }
+  control.sent.push(payload);
+}

--- a/studio/frontend/tests/model-load-native-notifications.test.ts
+++ b/studio/frontend/tests/model-load-native-notifications.test.ts
@@ -1,31 +1,24 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-// Chat model loads are foreground work the user just asked for, and the load
-// toast already reports every stage of them. They send no OS notification, and
-// they do not ask for notification permission. Training is the opposite case --
-// a run that takes hours and is not watched -- so it keeps both.
-//
-// The risk in splitting them is that permission is module-global. The chat load
-// path used to hold the only primeNativeNotificationPermission() call outside
-// training, so the tests below pin the half that survived: training obtains
-// permission on its own, on a fresh install where chat never ran, in every
-// webview state the desktop app can present.
+// Chat model loads are foreground work with a toast already reporting every
+// stage, so they notify nothing and never ask for permission. Training runs for
+// hours unwatched, so it keeps both. Permission is module-global and the chat
+// path held the only prime outside training, so these pin the half that
+// survived: training grants itself permission where chat never ran.
 
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import { register } from "node:module";
 import test from "node:test";
 
-// lib/api-base derives `isTauri` once, at module evaluation, and
-// lib/native-notifications caches its permission grant in module scope.
-// notification-resolver.mjs copies a "?bust=N" key down the import chain so each
-// case gets its own evaluation, and swaps @tauri-apps/plugin-notification for a
-// stub.
+// api-base derives `isTauri` at module evaluation and native-notifications
+// caches the grant in module scope, so the resolver copies a "?bust=N" key down
+// the import chain to force a fresh evaluation per case, and stubs the plugin.
 register("./helpers/notification-resolver.mjs", import.meta.url);
 
-// A file:// URL, not a native path: `import()` rejects a "D:\..." specifier on
-// Windows, and the "?bust=N" suffix only means anything on a URL.
+// A file:// URL, not a native path: `import()` rejects "D:\..." on Windows, and
+// "?bust=N" only means anything on a URL.
 const MODULE = new URL("../src/lib/native-notifications.ts", import.meta.url).href;
 
 const CHAT_RUNTIME = new URL(
@@ -78,9 +71,8 @@ function define(name: string, value: unknown) {
 
 /**
  * Stage the globals api-base and native-notifications read, then import a fresh
- * copy of the module under test. `webviewRequests` counts the OS permission
- * prompts the webview raised, which is the thing a chat-only session must never
- * trigger.
+ * copy of the module. `webviewRequests` counts OS permission prompts, which a
+ * chat-only session must never raise.
  */
 async function load(options: EnvOptions) {
   const {
@@ -114,8 +106,7 @@ async function load(options: EnvOptions) {
   generation += 1;
   const control = ((globalThis as Record<string, unknown>).__TAURI_NOTIFICATION_STUB__ ??=
     {}) as Control;
-  // A fresh array per case, not a truncated shared one, so a late send cannot
-  // reach an earlier recorder.
+  // A fresh array per case, so a late send cannot reach an earlier recorder.
   control.sent = [];
   control.granted = pluginGranted;
   control.mode = stub;
@@ -156,9 +147,7 @@ async function trainingFinished(
     .catch(() => undefined);
 }
 
-// ---------------------------------------------------------------------------
-// The contract the chat path now holds, and the one training still holds.
-// ---------------------------------------------------------------------------
+// The contract each path now holds.
 
 test("the chat model-load path carries no native-notification dependency", async () => {
   const source = await readFile(CHAT_RUNTIME, "utf8");
@@ -182,8 +171,8 @@ test("the chat model-load path carries no native-notification dependency", async
 test("training keeps its own permission prime, which nothing else provides", async () => {
   for (const entry of TRAINING_ENTRY_POINTS) {
     const source = await readFile(entry, "utf8");
-    // The call, not the import: an unused import would still satisfy a bare
-    // name match while leaving training unable to obtain permission at all.
+    // The call, not the import: an unused import would satisfy a bare name
+    // match while leaving training unable to obtain permission.
     assert.match(
       source,
       PRIME_CALL,
@@ -199,16 +188,13 @@ test("training keeps its own permission prime, which nothing else provides", asy
   );
 });
 
-// ---------------------------------------------------------------------------
-// A chat-only session is silent, including the permission prompt.
-// ---------------------------------------------------------------------------
+// A chat-only session is silent, prompt included.
 
 test("a desktop session that only loads chat models never asks for permission", async () => {
   for (const webview of ["absent", "default", "granted"] as const) {
     const mod = await load({ tauri: true, webview, pluginGranted: true });
 
-    // Whatever the chat runtime does during a load, it no longer reaches this
-    // module, so nothing here runs and nothing prompts.
+    // A load no longer reaches this module, so nothing here runs.
     assert.equal(
       mod.webviewRequests.count,
       0,
@@ -218,9 +204,7 @@ test("a desktop session that only loads chat models never asks for permission", 
   }
 });
 
-// ---------------------------------------------------------------------------
 // Training still works on a fresh install, in every webview state.
-// ---------------------------------------------------------------------------
 
 test("training primes and notifies on a fresh install where chat never ran", async () => {
   // The webview owns the grant and the user allows it.
@@ -265,8 +249,8 @@ test("training primes and notifies on a fresh install where chat never ran", asy
 test("a training notification arrives even if the prime is still in flight", async () => {
   const mod = await load({ tauri: true, webview: "default", answer: "granted" });
 
-  // start-fresh-training-run fires the prime and does not await it. A run that
-  // fails immediately must still wait for that grant rather than race past it.
+  // start-fresh-training-run fires the prime without awaiting it, so a run that
+  // ends immediately must wait for the grant rather than race past it.
   const priming = mod.primeNativeNotificationPermission().catch(() => undefined);
   const finishing = trainingFinished(mod);
   await Promise.all([priming, finishing]);
@@ -278,9 +262,7 @@ test("a training notification arrives even if the prime is still in flight", asy
   );
 });
 
-// ---------------------------------------------------------------------------
 // Refusals and failures stay silent instead of breaking the caller.
-// ---------------------------------------------------------------------------
 
 test("a denied grant sends nothing and does not reject", async () => {
   const mod = await load({ tauri: true, webview: "denied", pluginGranted: true });
@@ -289,19 +271,12 @@ test("a denied grant sends nothing and does not reject", async () => {
   assert.deepEqual(mod.control.sent, [], "sent a notification after a denial");
 });
 
-// The desktop app registers tauri_plugin_notification, whose init script
-// replaces window.Notification with its own shim on every platform. So the
-// states below are not hypothetical browser behavior, they are what the shim
-// reports:
-//
-//   Linux, macOS -> "granted" once the shim's async bootstrap resolves, with no
-//                   OS prompt, because the plugin's desktop request_permission
-//                   is hardcoded to Granted.
-//   Windows      -> "denied", because the shim short-circuits its own bootstrap
-//                   there (tauri-apps/plugins-workspace#3512).
-//
-// Whichever state the platform lands in, moving the permission prime off the
-// chat path must not change what training does.
+// tauri_plugin_notification replaces window.Notification with its own shim, so
+// these are the shim's states, not hypothetical browser ones: Linux and macOS
+// report "granted" with no prompt (desktop request_permission is hardcoded to
+// Granted), Windows reports "denied" because the shim short-circuits its own
+// bootstrap (tauri-apps/plugins-workspace#3512). Either way, moving the prime
+// off the chat path must not change what training does.
 test("each desktop platform's shim state behaves the same with and without a chat prime", async () => {
   const platforms = [
     { name: "linux/macOS", webview: "granted" as const, expected: ["Training finished"] },
@@ -309,12 +284,12 @@ test("each desktop platform's shim state behaves the same with and without a cha
   ];
 
   for (const platform of platforms) {
-    // With a chat-side prime first, the way the app behaved before the split.
+    // A chat-side prime first, as the app behaved before the split.
     const primedByChat = await load({ tauri: true, webview: platform.webview });
     await primedByChat.primeNativeNotificationPermission();
     await trainingFinished(primedByChat);
 
-    // Training standing on its own, the way it behaves now.
+    // Training on its own, as it behaves now.
     const trainingOnly = await load({ tauri: true, webview: platform.webview });
     await trainingOnly.primeNativeNotificationPermission();
     await trainingFinished(trainingOnly);
@@ -347,9 +322,7 @@ test("a send that throws never reaches the training caller", async () => {
   await assert.doesNotReject(() => trainingFinished(mod));
 });
 
-// ---------------------------------------------------------------------------
 // Browser and LAN sessions were never in scope and still are not.
-// ---------------------------------------------------------------------------
 
 test("browser and LAN sessions send nothing and never prompt", async () => {
   for (const webview of ["absent", "default", "granted"] as const) {
@@ -366,9 +339,7 @@ test("browser and LAN sessions send nothing and never prompt", async () => {
   }
 });
 
-// ---------------------------------------------------------------------------
-// The dedupe cache and the redaction #5273 added both still hold.
-// ---------------------------------------------------------------------------
+// The dedupe cache and the redaction from #5273 both still hold.
 
 test("a repeated notification key is sent once", async () => {
   const mod = await load({ tauri: true, webview: "granted" });

--- a/studio/frontend/tests/model-load-native-notifications.test.ts
+++ b/studio/frontend/tests/model-load-native-notifications.test.ts
@@ -1,0 +1,401 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// Chat model loads are foreground work the user just asked for, and the load
+// toast already reports every stage of them. They send no OS notification, and
+// they do not ask for notification permission. Training is the opposite case --
+// a run that takes hours and is not watched -- so it keeps both.
+//
+// The risk in splitting them is that permission is module-global. The chat load
+// path used to hold the only primeNativeNotificationPermission() call outside
+// training, so the tests below pin the half that survived: training obtains
+// permission on its own, on a fresh install where chat never ran, in every
+// webview state the desktop app can present.
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { register } from "node:module";
+import test from "node:test";
+
+// lib/api-base derives `isTauri` once, at module evaluation, and
+// lib/native-notifications caches its permission grant in module scope.
+// notification-resolver.mjs copies a "?bust=N" key down the import chain so each
+// case gets its own evaluation, and swaps @tauri-apps/plugin-notification for a
+// stub.
+register("./helpers/notification-resolver.mjs", import.meta.url);
+
+// A file:// URL, not a native path: `import()` rejects a "D:\..." specifier on
+// Windows, and the "?bust=N" suffix only means anything on a URL.
+const MODULE = new URL("../src/lib/native-notifications.ts", import.meta.url).href;
+
+const CHAT_RUNTIME = new URL(
+  "../src/features/chat/hooks/use-chat-model-runtime.ts",
+  import.meta.url,
+);
+const TRAINING_LIFECYCLE = new URL(
+  "../src/features/training/hooks/use-training-runtime-lifecycle.ts",
+  import.meta.url,
+);
+const TRAINING_ENTRY_POINTS = [
+  new URL("../src/features/training/lib/start-fresh-training-run.ts", import.meta.url),
+  new URL("../src/features/training/lib/resume-training-run.ts", import.meta.url),
+];
+
+const PRIME_CALL = /primeNativeNotificationPermission\(\)/;
+const NOTIFY_CALL = /notifyNative\(\{/;
+
+type WebviewPermission = "absent" | "default" | "granted" | "denied";
+
+type StubMode = "ok" | "send-fails" | "module-missing";
+
+type EnvOptions = {
+  tauri: boolean;
+  /** What the webview's own Notification API reports, or "absent" if it has none. */
+  webview?: WebviewPermission;
+  /** What the Tauri plugin reports when the webview API cannot answer. */
+  pluginGranted?: boolean;
+  /** What Notification.requestPermission() resolves to once the user answers. */
+  answer?: "granted" | "denied";
+  stub?: StubMode;
+};
+
+type Control = {
+  sent: { title: string; body?: string }[];
+  granted: boolean;
+  mode: StubMode;
+  requests: number;
+};
+
+let generation = 0;
+
+function define(name: string, value: unknown) {
+  Object.defineProperty(globalThis, name, {
+    value,
+    configurable: true,
+    writable: true,
+  });
+}
+
+/**
+ * Stage the globals api-base and native-notifications read, then import a fresh
+ * copy of the module under test. `webviewRequests` counts the OS permission
+ * prompts the webview raised, which is the thing a chat-only session must never
+ * trigger.
+ */
+async function load(options: EnvOptions) {
+  const {
+    tauri,
+    webview = "absent",
+    pluginGranted = false,
+    answer = "granted",
+    stub = "ok",
+  } = options;
+
+  const webviewRequests = { count: 0 };
+
+  const windowStub: Record<string, unknown> = {
+    location: { protocol: tauri ? "tauri:" : "https:" },
+  };
+  if (tauri) {
+    windowStub.__TAURI_INTERNALS__ = {};
+  }
+  if (webview !== "absent") {
+    windowStub.Notification = {
+      permission: webview,
+      async requestPermission() {
+        webviewRequests.count += 1;
+        (windowStub.Notification as { permission: string }).permission = answer;
+        return answer;
+      },
+    };
+  }
+  define("window", windowStub);
+
+  generation += 1;
+  const control = ((globalThis as Record<string, unknown>).__TAURI_NOTIFICATION_STUB__ ??=
+    {}) as Control;
+  // A fresh array per case, not a truncated shared one, so a late send cannot
+  // reach an earlier recorder.
+  control.sent = [];
+  control.granted = pluginGranted;
+  control.mode = stub;
+  control.requests = 0;
+
+  const mod = (await import(`${MODULE}?bust=${generation}`)) as {
+    notifyNative: (options: {
+      key: string;
+      title: string;
+      body?: string;
+      requestPermission?: boolean;
+    }) => Promise<void>;
+    primeNativeNotificationPermission: () => Promise<void>;
+    sanitizeNotificationBody: (input: string | null, fallback: string) => string;
+    safeNotificationLabel: (input: string | null, fallback: string) => string;
+  };
+
+  const api = (await import(
+    `${new URL("../src/lib/api-base.ts", import.meta.url).href}?bust=${generation}`
+  )) as { isTauri: boolean };
+  assert.equal(api.isTauri, tauri, "isTauri did not match the staged environment");
+
+  return { ...mod, control, webviewRequests };
+}
+
+/** The training runtime's two terminal notifications, as it sends them. */
+async function trainingFinished(
+  mod: Awaited<ReturnType<typeof load>>,
+  jobId = "job-1",
+) {
+  await mod
+    .notifyNative({
+      key: `training-completed:${jobId}`,
+      title: "Training finished",
+      body: "Your training run is complete.",
+      requestPermission: false,
+    })
+    .catch(() => undefined);
+}
+
+// ---------------------------------------------------------------------------
+// The contract the chat path now holds, and the one training still holds.
+// ---------------------------------------------------------------------------
+
+test("the chat model-load path carries no native-notification dependency", async () => {
+  const source = await readFile(CHAT_RUNTIME, "utf8");
+
+  assert.ok(
+    !source.includes("native-notifications"),
+    "use-chat-model-runtime imports the native notification helper again",
+  );
+  for (const symbol of [
+    "notifyNative",
+    "primeNativeNotificationPermission",
+    "safeNotificationLabel",
+  ]) {
+    assert.ok(
+      !source.includes(symbol),
+      `use-chat-model-runtime calls ${symbol} again; the load toast already reports this`,
+    );
+  }
+});
+
+test("training keeps its own permission prime, which nothing else provides", async () => {
+  for (const entry of TRAINING_ENTRY_POINTS) {
+    const source = await readFile(entry, "utf8");
+    // The call, not the import: an unused import would still satisfy a bare
+    // name match while leaving training unable to obtain permission at all.
+    assert.match(
+      source,
+      PRIME_CALL,
+      `${entry.href} dropped its prime; training would never obtain permission`,
+    );
+  }
+
+  const lifecycle = await readFile(TRAINING_LIFECYCLE, "utf8");
+  assert.match(
+    lifecycle,
+    NOTIFY_CALL,
+    "the training lifecycle stopped sending native notifications",
+  );
+});
+
+// ---------------------------------------------------------------------------
+// A chat-only session is silent, including the permission prompt.
+// ---------------------------------------------------------------------------
+
+test("a desktop session that only loads chat models never asks for permission", async () => {
+  for (const webview of ["absent", "default", "granted"] as const) {
+    const mod = await load({ tauri: true, webview, pluginGranted: true });
+
+    // Whatever the chat runtime does during a load, it no longer reaches this
+    // module, so nothing here runs and nothing prompts.
+    assert.equal(
+      mod.webviewRequests.count,
+      0,
+      `loading a chat model prompted for notification permission [webview=${webview}]`,
+    );
+    assert.deepEqual(mod.control.sent, [], "a chat model load sent a notification");
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Training still works on a fresh install, in every webview state.
+// ---------------------------------------------------------------------------
+
+test("training primes and notifies on a fresh install where chat never ran", async () => {
+  // The webview owns the grant and the user allows it.
+  const prompted = await load({
+    tauri: true,
+    webview: "default",
+    answer: "granted",
+  });
+  await prompted.primeNativeNotificationPermission();
+  await trainingFinished(prompted);
+  assert.equal(prompted.webviewRequests.count, 1, "training did not prompt");
+  assert.deepEqual(
+    prompted.control.sent.map((n) => n.title),
+    ["Training finished"],
+  );
+
+  // No Notification API in the webview, so the grant comes from the plugin.
+  const viaPlugin = await load({
+    tauri: true,
+    webview: "absent",
+    pluginGranted: true,
+  });
+  await viaPlugin.primeNativeNotificationPermission();
+  await trainingFinished(viaPlugin);
+  assert.deepEqual(
+    viaPlugin.control.sent.map((n) => n.title),
+    ["Training finished"],
+    "training lost its notification on the plugin permission path",
+  );
+
+  // Already granted from an earlier session: no prompt, still delivered.
+  const already = await load({ tauri: true, webview: "granted" });
+  await already.primeNativeNotificationPermission();
+  await trainingFinished(already);
+  assert.equal(already.webviewRequests.count, 0, "re-prompted an existing grant");
+  assert.deepEqual(
+    already.control.sent.map((n) => n.title),
+    ["Training finished"],
+  );
+});
+
+test("a training notification arrives even if the prime is still in flight", async () => {
+  const mod = await load({ tauri: true, webview: "default", answer: "granted" });
+
+  // start-fresh-training-run fires the prime and does not await it. A run that
+  // fails immediately must still wait for that grant rather than race past it.
+  const priming = mod.primeNativeNotificationPermission().catch(() => undefined);
+  const finishing = trainingFinished(mod);
+  await Promise.all([priming, finishing]);
+
+  assert.deepEqual(
+    mod.control.sent.map((n) => n.title),
+    ["Training finished"],
+    "a terminal event during the prime lost its notification",
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Refusals and failures stay silent instead of breaking the caller.
+// ---------------------------------------------------------------------------
+
+test("a denied grant sends nothing and does not reject", async () => {
+  const mod = await load({ tauri: true, webview: "denied", pluginGranted: true });
+  await mod.primeNativeNotificationPermission();
+  await assert.doesNotReject(() => trainingFinished(mod));
+  assert.deepEqual(mod.control.sent, [], "sent a notification after a denial");
+});
+
+// The desktop app registers tauri_plugin_notification, whose init script
+// replaces window.Notification with its own shim on every platform. So the
+// states below are not hypothetical browser behavior, they are what the shim
+// reports:
+//
+//   Linux, macOS -> "granted" once the shim's async bootstrap resolves, with no
+//                   OS prompt, because the plugin's desktop request_permission
+//                   is hardcoded to Granted.
+//   Windows      -> "denied", because the shim short-circuits its own bootstrap
+//                   there (tauri-apps/plugins-workspace#3512).
+//
+// Whichever state the platform lands in, moving the permission prime off the
+// chat path must not change what training does.
+test("each desktop platform's shim state behaves the same with and without a chat prime", async () => {
+  const platforms = [
+    { name: "linux/macOS", webview: "granted" as const, expected: ["Training finished"] },
+    { name: "windows", webview: "denied" as const, expected: [] },
+  ];
+
+  for (const platform of platforms) {
+    // With a chat-side prime first, the way the app behaved before the split.
+    const primedByChat = await load({ tauri: true, webview: platform.webview });
+    await primedByChat.primeNativeNotificationPermission();
+    await trainingFinished(primedByChat);
+
+    // Training standing on its own, the way it behaves now.
+    const trainingOnly = await load({ tauri: true, webview: platform.webview });
+    await trainingOnly.primeNativeNotificationPermission();
+    await trainingFinished(trainingOnly);
+
+    assert.deepEqual(
+      trainingOnly.control.sent.map((n) => n.title),
+      primedByChat.control.sent.map((n) => n.title),
+      `${platform.name}: an earlier chat prime changed the training outcome`,
+    );
+    assert.deepEqual(
+      trainingOnly.control.sent.map((n) => n.title),
+      platform.expected,
+      `${platform.name}: unexpected training notification set`,
+    );
+  }
+});
+
+test("a missing notification plugin degrades quietly", async () => {
+  const mod = await load({
+    tauri: true,
+    webview: "granted",
+    stub: "module-missing",
+  });
+  await assert.doesNotReject(() => mod.primeNativeNotificationPermission());
+  await assert.doesNotReject(() => trainingFinished(mod));
+});
+
+test("a send that throws never reaches the training caller", async () => {
+  const mod = await load({ tauri: true, webview: "granted", stub: "send-fails" });
+  await assert.doesNotReject(() => trainingFinished(mod));
+});
+
+// ---------------------------------------------------------------------------
+// Browser and LAN sessions were never in scope and still are not.
+// ---------------------------------------------------------------------------
+
+test("browser and LAN sessions send nothing and never prompt", async () => {
+  for (const webview of ["absent", "default", "granted"] as const) {
+    const mod = await load({ tauri: false, webview, pluginGranted: true });
+    await mod.primeNativeNotificationPermission();
+    await trainingFinished(mod);
+
+    assert.deepEqual(mod.control.sent, [], `a browser session notified [${webview}]`);
+    assert.equal(
+      mod.webviewRequests.count,
+      0,
+      `a browser session prompted for permission [${webview}]`,
+    );
+  }
+});
+
+// ---------------------------------------------------------------------------
+// The dedupe cache and the redaction #5273 added both still hold.
+// ---------------------------------------------------------------------------
+
+test("a repeated notification key is sent once", async () => {
+  const mod = await load({ tauri: true, webview: "granted" });
+  await trainingFinished(mod, "job-7");
+  await trainingFinished(mod, "job-7");
+
+  assert.equal(mod.control.sent.length, 1, "the same job notified twice");
+});
+
+test("notification bodies still redact tokens and local paths", async () => {
+  const mod = await load({ tauri: true, webview: "granted" });
+
+  await mod
+    .notifyNative({
+      key: "training-error:job-9",
+      title: "Training failed",
+      body: "run died at /home/ada/models/run.gguf using hf_abcdefghijklmnopqrstuvwxyz012345",
+      requestPermission: false,
+    })
+    .catch(() => undefined);
+
+  const body = mod.control.sent.at(-1)?.body ?? "";
+  assert.ok(!body.includes("/home/ada"), `a local path reached the OS: ${body}`);
+  assert.ok(
+    !body.includes("hf_abcdefghijklmnopqrstuvwxyz012345"),
+    `a token reached the OS: ${body}`,
+  );
+  assert.ok(body.includes("[path]"), body);
+  assert.ok(body.includes("hf_[redacted]"), body);
+});


### PR DESCRIPTION
## Problem

#5273 added native OS notifications to the chat model load lifecycle: `Model downloaded`, `Model ready`, and `Model failed to load`. All three fire during a foreground load the user started themselves, on top of the in-app load toast that already reports the same thing. On Linux each one plays the desktop notification sound, so switching models is audible and repeats on every switch.

The first load in a session also triggers the OS notification permission prompt, because the load path primes the permission before the toast appears.

## Change

Remove the three `notifyNative` calls from `use-chat-model-runtime.ts`, along with the permission prime and the per-attempt notification key that only fed them. The load toast, its download and memory progress, the fallback notice, and the error toast are unchanged.

## Scope

Training notifications stay. `Training finished` and `Training failed` fire from `use-training-runtime-lifecycle.ts` for runs that take hours and are not watched, which is the case native notifications were for. The shared `native-notifications` helper, the Tauri notification plugin, and its capability entry are still used by that path, so nothing is removed from `src-tauri`.

The notifications were gated on `isTauri`, so this only changes the desktop app. Browser and LAN sessions never sent them.

## Verification

- Frontend suite: 4,259 passed, 3 failed. Two are in `context-window-visible.test.ts` and reproduce on the commit this branch is based on. The third, in `code-plugin-tokenization-work.test.ts`, is timing sensitive and passes when the file is run on its own.
- `tsc -b` and `tsc -p tsconfig.test.json` passed.
- ESLint and Biome on the changed file report the same errors and warnings as the base commit.
- Production `vite build` passed.
