### PR TITLE
Studio: settings nav badges and the Shortcuts icon

### DIFF
--- a/studio/frontend/src/features/settings/settings-dialog.tsx
+++ b/studio/frontend/src/features/settings/settings-dialog.tsx
@@ -167,7 +167,6 @@ const TABS: TabDef[] = [
     id: "profile",
     labelKey: "settings.tabs.profile",
     icon: UserIcon,
-    badgeKey: "common.new",
   },
   {
     id: "appearance",
@@ -193,6 +192,7 @@ const TABS: TabDef[] = [
     id: "remote-lan",
     labelKey: "settings.tabs.remoteLan",
     icon: HomeWifiIcon,
+    badgeKey: "common.new",
   },
   {
     id: "connections",
@@ -203,24 +203,22 @@ const TABS: TabDef[] = [
     id: "agents",
     labelKey: "settings.tabs.agents",
     icon: BotIcon,
-    badgeKey: "common.new",
   },
   {
     id: "voice",
     labelKey: "settings.tabs.voice",
     iconComponent: MicIcon,
-    badgeKey: "common.new",
   },
   {
     id: "data",
     labelKey: "settings.tabs.data",
     icon: DatabaseSettingIcon,
-    badgeKey: "common.new",
   },
   {
     id: "keyboard-shortcuts",
     labelKey: "settings.tabs.keyboardShortcuts",
     icon: KeyboardIcon,
+    badgeKey: "common.new",
   },
   {
     id: "debugging",

--- a/studio/frontend/src/features/settings/settings-dialog.tsx
+++ b/studio/frontend/src/features/settings/settings-dialog.tsx
@@ -22,10 +22,10 @@ import {
   ComputerTerminal01Icon,
   CpuIcon,
   DatabaseSettingIcon,
+  EnergyRectangleIcon,
   Globe02Icon,
   HelpCircleIcon,
   HomeWifiIcon,
-  KeyboardIcon,
   Message01Icon,
   PaintBrush02Icon,
   Search01Icon,
@@ -217,7 +217,7 @@ const TABS: TabDef[] = [
   {
     id: "keyboard-shortcuts",
     labelKey: "settings.tabs.keyboardShortcuts",
-    icon: KeyboardIcon,
+    icon: EnergyRectangleIcon,
     badgeKey: "common.new",
   },
   {


### PR DESCRIPTION
Two small passes on the Settings sidebar.

**New badges.** Profile, Agents, Voice and Data have carried a New pill for a while now and are no longer new to anyone. Shortcuts and Remote & LAN are the two worth pointing people at, so the badge moves to them.

**Shortcuts icon.** Swapped for [energy-rectangle](https://hugeicons.com/icon/energy-rectangle), which reads better next to the rest of the nav than the keyboard did.

No behaviour change either way, just which tabs carry `badgeKey` and which icon the Shortcuts row uses.
