### PR TITLE
Studio: name the GPU agent, not the CPU, in the rocminfo probe

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -4861,12 +4861,15 @@ elif case "$TORCH_INDEX_URL" in */rocm*|*/gfx*) true ;; *) false ;; esac; then
                 | _amd_smi_hip_order "$_gpu_disp_smi_records" || true)
             _gpu_disp_smi_space=$(printf '%s\n' "$_gpu_disp_smi_out" | head -n 1)
             _gpu_disp_smi_records=$(printf '%s\n' "$_gpu_disp_smi_out" | tail -n +2)
-            # No map, and the adapters do not agree on an arch: the mask indexes HIP order
-            # and these records are in discovery order, so any ordinal is a guess. Report
-            # nothing rather than name one card and route another. Identical adapters are
-            # unaffected, since every ordinal yields the same arch either way.
+            # No map, and the adapters are not interchangeable: the mask indexes HIP order
+            # while these records are in discovery order, so any ordinal is a guess. Report
+            # nothing rather than name one card while the mask selects another. amd-smi
+            # 6.1.1 reports no TARGET_GRAPHICS_VERSION at all and the arch is then inferred
+            # from the name, so an archless record is compared on its name instead.
+            # Interchangeable adapters are unaffected: every ordinal gives the same answer.
             if [ "$_gpu_disp_smi_space" != hip ] && \
-               [ "$(printf '%s\n' "$_gpu_disp_smi_records" | awk -F'|' 'NF { print $1 }' \
+               [ "$(printf '%s\n' "$_gpu_disp_smi_records" \
+                    | awk -F'|' 'NF { print ($1 != "" ? $1 : "name:" $2) }' \
                     | sort -u | wc -l)" -gt 1 ]; then
                 _gpu_disp_smi_records=""
                 _gpu_disp_gfx_all=""

--- a/install.sh
+++ b/install.sh
@@ -4766,6 +4766,38 @@ _rocminfo_gpu_records() {
     '
 }
 
+# Same record shape for amd-smi: one `gfx|marketing name` per adapter, in `GPU: N` order.
+# Without this the arch was indexed by the visible-device mask while the name was always
+# the first adapter's, so selecting a later card paired its arch with another card's name
+# -- and on amd-smi builds predating TARGET_GRAPHICS_VERSION (present in 6.1.1's docs
+# without it) the name is what the arch is inferred from, so the wrong arch reached
+# --rocm-gfx. Keep in sync with studio/setup.sh.
+_amd_smi_gpu_records() {
+    awk '
+        function value(line,   v) {
+            v = line
+            sub(/^[^:]*:[[:space:]]*/, "", v)
+            gsub(/^[[:space:]]+|[[:space:]]+$/, "", v)
+            return v
+        }
+        function flush() {
+            if (started) print gfx "|" mkt
+            gfx = ""; mkt = ""
+        }
+        # amd-smi upper-cases every key (amdsmi_logger.py _capitalize_keys), so the real
+        # fields are MARKET_NAME and TARGET_GRAPHICS_VERSION; matched case-folded anyway.
+        /^[[:space:]]*GPU:[[:space:]]*[0-9]/ { flush(); started = 1; next }
+        !started { next }
+        tolower($0) ~ /market.?name/ { if (mkt == "") mkt = value($0); next }
+        tolower($0) ~ /target.?graphics.?version/ {
+            v = value($0)
+            if (gfx == "" && v ~ /^gfx[1-9][0-9a-z][0-9a-z][0-9a-z]?$/) gfx = v
+            next
+        }
+        END { flush() }
+    '
+}
+
 # ── GPU detection summary (mirrors install.ps1 step "gpu" block) ──
 if _has_usable_nvidia_gpu; then
     step "gpu" "NVIDIA GPU detected"
@@ -4773,6 +4805,7 @@ elif case "$TORCH_INDEX_URL" in */rocm*|*/gfx*) true ;; *) false ;; esac; then
     # Probe gfx arch for the display label, honouring HIP_VISIBLE_DEVICES
     _ensure_rocm_probe_env
     _gpu_disp_gfx_all=""
+    _gpu_disp_gfx=""
     _gpu_disp_mkt=""
     _gpu_disp_records=""
     if command -v rocminfo >/dev/null 2>&1; then
@@ -4780,11 +4813,13 @@ elif case "$TORCH_INDEX_URL" in */rocm*|*/gfx*) true ;; *) false ;; esac; then
         _gpu_disp_gfx_all=$(printf '%s\n' "$_gpu_disp_records" | awk -F'|' '$1 != "" { print $1 }')
     fi
     if [ -z "$_gpu_disp_gfx_all" ] && command -v amd-smi >/dev/null 2>&1; then
+        _gpu_disp_smi_records=$(amd-smi static --asic 2>/dev/null | _amd_smi_gpu_records || true)
         _gpu_disp_gfx_all=$(amd-smi list 2>/dev/null | grep -oE 'gfx[1-9][0-9a-z]{2,3}' || true)
         [ -z "$_gpu_disp_gfx_all" ] && \
-            _gpu_disp_gfx_all=$(amd-smi static --asic 2>/dev/null | grep -oE 'gfx[1-9][0-9a-z]{2,3}' || true)
-        # Do not let a CPU-only rocminfo record replace the amd-smi GPU arch.
-        [ -n "$_gpu_disp_gfx_all" ] && _gpu_disp_records=""
+            _gpu_disp_gfx_all=$(printf '%s\n' "$_gpu_disp_smi_records" | awk -F'|' '$1 != "" { print $1 }')
+        # Only once amd-smi actually enumerated something does it own the device list;
+        # a silent amd-smi must leave rocminfo's APU fallback record alone.
+        [ -n "$_gpu_disp_smi_records" ] && _gpu_disp_records="$_gpu_disp_smi_records"
     fi
     _gpu_vis="${HIP_VISIBLE_DEVICES:-${ROCR_VISIBLE_DEVICES:-}}"
     _gpu_vis_idx=0
@@ -4798,25 +4833,12 @@ elif case "$TORCH_INDEX_URL" in */rocm*|*/gfx*) true ;; *) false ;; esac; then
             'NF { a[n++]=$0 } END { if(idx>=n) idx=0; if(n>0) print a[idx] }')
         _gpu_disp_gfx=${_gpu_disp_record%%|*}
         _gpu_disp_mkt=${_gpu_disp_record#*|}
-    else
+    fi
+    # Only amd-smi builds old enough to predate TARGET_GRAPHICS_VERSION reach this: their
+    # records carry names but no arch, so the arch comes from the separate list probe.
+    if [ -z "$_gpu_disp_gfx" ]; then
         _gpu_disp_gfx=$(printf '%s\n' "$_gpu_disp_gfx_all" | awk -v idx="$_gpu_vis_idx" \
             'NF && !seen[$0]++ { a[n++]=$0 } END { if(idx>=n) idx=0; if(n>0) print a[idx] }')
-    fi
-    # Use the unindexed amd-smi name only when no rocminfo records are in use.
-    # amd-smi upper-cases every key in its human-readable output (amdsmi_logger.py
-    # _capitalize_keys), so the field is MARKET_NAME, which /[Mm]arket.?[Nn]ame/ could
-    # never match: the fallback printed nothing on a real host. Matched case-folded, and
-    # read past the FIRST colon only, so "MARKET_NAME: AMD Instinct MI300X OAM: 750W SKU"
-    # survives -- the same truncation the rocminfo parser above already fixed.
-    # Keep in sync with studio/setup.sh.
-    if [ -z "$_gpu_disp_mkt" ] && [ -z "$_gpu_disp_records" ] && command -v amd-smi >/dev/null 2>&1; then
-        _gpu_disp_mkt=$(amd-smi static --asic 2>/dev/null | awk \
-            'tolower($0) ~ /market.?name/ {
-                 v = $0
-                 sub(/^[^:]*:[[:space:]]*/, "", v)
-                 gsub(/^[[:space:]]+|[[:space:]]+$/, "", v)
-                 if (v != "") { print v; exit }
-             }' || true)
     fi
     # UNSLOTH_ROCM_GFX_ARCH env override (mirrors install.ps1)
     if [ -n "${UNSLOTH_ROCM_GFX_ARCH:-}" ]; then

--- a/install.sh
+++ b/install.sh
@@ -4729,6 +4729,43 @@ fi
 _TAURI_GPU_BRANCH=$(_tauri_gpu_branch "$_TAURI_TORCH_INDEX_FAMILY" "$_amd_gpu_radeon")
 tauri_diag_marker "$_TAURI_GPU_BRANCH" "$_TAURI_TORCH_INDEX_FAMILY"
 
+# Pair each rocminfo GPU gfx id with its marketing name instead of using the CPU-first
+# global name (#7307). Blank names keep device ordinals; no GPU keeps the old fallback.
+# Keep in sync with studio/setup.sh.
+_rocminfo_gpu_records() {
+    awk '
+        # Split at the first colon so embedded colons survive.
+        function value(line,   v) {
+            v = line
+            sub(/^[^:]*:[[:space:]]*/, "", v)
+            gsub(/^[[:space:]]+|[[:space:]]+$/, "", v)
+            return v
+        }
+        /^[[:space:]]*Name:/ {
+            # Keep a slot for a nameless GPU.
+            if (gfx != "" && !named) { print gfx "|"; gpus++ }
+            gfx = ""; named = 0
+            name = value($0)
+            # Accept target suffixes such as gfx90a:sramecc+, but reject ISA names.
+            if (match(name, /^gfx[1-9][0-9a-z][0-9a-z][0-9a-z]?/)) {
+                rest = substr(name, RLENGTH + 1)
+                if (rest == "" || rest ~ /^[^0-9a-z]/) gfx = substr(name, 1, RLENGTH)
+            }
+            next
+        }
+        /^[[:space:]]*Marketing Name:/ {
+            mkt = value($0)
+            if (gfx != "" && !named) { print gfx "|" mkt; gpus++; named = 1 }
+            else if (first == "") first = mkt
+            next
+        }
+        END {
+            if (gfx != "" && !named) { print gfx "|"; gpus++ }
+            if (gpus == 0 && first != "") print "|" first
+        }
+    '
+}
+
 # ── GPU detection summary (mirrors install.ps1 step "gpu" block) ──
 if _has_usable_nvidia_gpu; then
     step "gpu" "NVIDIA GPU detected"
@@ -4737,19 +4774,17 @@ elif case "$TORCH_INDEX_URL" in */rocm*|*/gfx*) true ;; *) false ;; esac; then
     _ensure_rocm_probe_env
     _gpu_disp_gfx_all=""
     _gpu_disp_mkt=""
+    _gpu_disp_records=""
     if command -v rocminfo >/dev/null 2>&1; then
-        _gpu_disp_gfx_all=$(rocminfo 2>/dev/null | grep -oE 'gfx[1-9][0-9a-z]{2,3}' || true)
-        _gpu_disp_mkt=$(rocminfo 2>/dev/null | awk -F': ' \
-            '/Marketing Name:/{gsub(/^[[:space:]]+|[[:space:]]+$/,"", $2); if($2){print $2; exit}}' || true)
+        _gpu_disp_records=$(rocminfo 2>/dev/null | _rocminfo_gpu_records || true)
+        _gpu_disp_gfx_all=$(printf '%s\n' "$_gpu_disp_records" | awk -F'|' '$1 != "" { print $1 }')
     fi
     if [ -z "$_gpu_disp_gfx_all" ] && command -v amd-smi >/dev/null 2>&1; then
         _gpu_disp_gfx_all=$(amd-smi list 2>/dev/null | grep -oE 'gfx[1-9][0-9a-z]{2,3}' || true)
         [ -z "$_gpu_disp_gfx_all" ] && \
             _gpu_disp_gfx_all=$(amd-smi static --asic 2>/dev/null | grep -oE 'gfx[1-9][0-9a-z]{2,3}' || true)
-    fi
-    if [ -z "$_gpu_disp_mkt" ] && command -v amd-smi >/dev/null 2>&1; then
-        _gpu_disp_mkt=$(amd-smi static --asic 2>/dev/null | awk -F'[:|]' \
-            '/[Mm]arket.?[Nn]ame/{gsub(/^[[:space:]]+|[[:space:]]+$/,"", $2); if($2){print $2; exit}}' || true)
+        # Do not let a CPU-only rocminfo record replace the amd-smi GPU arch.
+        [ -n "$_gpu_disp_gfx_all" ] && _gpu_disp_records=""
     fi
     _gpu_vis="${HIP_VISIBLE_DEVICES:-${ROCR_VISIBLE_DEVICES:-}}"
     _gpu_vis_idx=0
@@ -4757,8 +4792,21 @@ elif case "$TORCH_INDEX_URL" in */rocm*|*/gfx*) true ;; *) false ;; esac; then
         _gpu_first="${_gpu_vis%%,*}"
         case "$_gpu_first" in ''|*[!0-9]*) ;; *) _gpu_vis_idx=$_gpu_first ;; esac
     fi
-    _gpu_disp_gfx=$(printf '%s\n' "$_gpu_disp_gfx_all" | awk -v idx="$_gpu_vis_idx" \
-        'NF && !seen[$0]++ { a[n++]=$0 } END { if(idx>=n) idx=0; if(n>0) print a[idx] }')
+    if [ -n "$_gpu_disp_records" ]; then
+        # Records already preserve device ordinals, including duplicate arches.
+        _gpu_disp_record=$(printf '%s\n' "$_gpu_disp_records" | awk -v idx="$_gpu_vis_idx" \
+            'NF { a[n++]=$0 } END { if(idx>=n) idx=0; if(n>0) print a[idx] }')
+        _gpu_disp_gfx=${_gpu_disp_record%%|*}
+        _gpu_disp_mkt=${_gpu_disp_record#*|}
+    else
+        _gpu_disp_gfx=$(printf '%s\n' "$_gpu_disp_gfx_all" | awk -v idx="$_gpu_vis_idx" \
+            'NF && !seen[$0]++ { a[n++]=$0 } END { if(idx>=n) idx=0; if(n>0) print a[idx] }')
+    fi
+    # Use the unindexed amd-smi name only when no rocminfo records are in use.
+    if [ -z "$_gpu_disp_mkt" ] && [ -z "$_gpu_disp_records" ] && command -v amd-smi >/dev/null 2>&1; then
+        _gpu_disp_mkt=$(amd-smi static --asic 2>/dev/null | awk -F'[:|]' \
+            '/[Mm]arket.?[Nn]ame/{gsub(/^[[:space:]]+|[[:space:]]+$/,"", $2); if($2){print $2; exit}}' || true)
+    fi
     # UNSLOTH_ROCM_GFX_ARCH env override (mirrors install.ps1)
     if [ -n "${UNSLOTH_ROCM_GFX_ARCH:-}" ]; then
         _gpu_disp_gfx="${UNSLOTH_ROCM_GFX_ARCH}"

--- a/install.sh
+++ b/install.sh
@@ -4766,12 +4766,10 @@ _rocminfo_gpu_records() {
     '
 }
 
-# Same record shape for amd-smi: one `gfx|marketing name` per adapter, in `GPU: N` order.
-# Without this the arch was indexed by the visible-device mask while the name was always
-# the first adapter's, so selecting a later card paired its arch with another card's name
-# -- and on amd-smi builds predating TARGET_GRAPHICS_VERSION (present in 6.1.1's docs
-# without it) the name is what the arch is inferred from, so the wrong arch reached
-# --rocm-gfx. Keep in sync with studio/setup.sh.
+# One `gfx|marketing name` per adapter, in `GPU: N` order, so the mask picks both halves
+# of one device. Was: arch indexed, name always adapter 0's -- and on amd-smi 6.1.1, which
+# has no TARGET_GRAPHICS_VERSION, that name is what --rocm-gfx is inferred from.
+# Keep in sync with studio/setup.sh.
 _amd_smi_gpu_records() {
     awk '
         function value(line,   v) {
@@ -4784,8 +4782,8 @@ _amd_smi_gpu_records() {
             if (started) print gfx "|" mkt
             gfx = ""; mkt = ""
         }
-        # amd-smi upper-cases every key (amdsmi_logger.py _capitalize_keys), so the real
-        # fields are MARKET_NAME and TARGET_GRAPHICS_VERSION; matched case-folded anyway.
+        # amd-smi upper-cases every key (amdsmi_logger.py _capitalize_keys): MARKET_NAME,
+        # TARGET_GRAPHICS_VERSION. Matched case-folded so older spellings work too.
         /^[[:space:]]*GPU:[[:space:]]*[0-9]/ { flush(); started = 1; next }
         !started { next }
         tolower($0) ~ /market.?name/ { if (mkt == "") mkt = value($0); next }
@@ -4817,8 +4815,7 @@ elif case "$TORCH_INDEX_URL" in */rocm*|*/gfx*) true ;; *) false ;; esac; then
         _gpu_disp_gfx_all=$(amd-smi list 2>/dev/null | grep -oE 'gfx[1-9][0-9a-z]{2,3}' || true)
         [ -z "$_gpu_disp_gfx_all" ] && \
             _gpu_disp_gfx_all=$(printf '%s\n' "$_gpu_disp_smi_records" | awk -F'|' '$1 != "" { print $1 }')
-        # Only once amd-smi actually enumerated something does it own the device list;
-        # a silent amd-smi must leave rocminfo's APU fallback record alone.
+        # A silent amd-smi does not own the device list: keep rocminfo's APU fallback.
         [ -n "$_gpu_disp_smi_records" ] && _gpu_disp_records="$_gpu_disp_smi_records"
     fi
     _gpu_vis="${HIP_VISIBLE_DEVICES:-${ROCR_VISIBLE_DEVICES:-}}"
@@ -4834,8 +4831,7 @@ elif case "$TORCH_INDEX_URL" in */rocm*|*/gfx*) true ;; *) false ;; esac; then
         _gpu_disp_gfx=${_gpu_disp_record%%|*}
         _gpu_disp_mkt=${_gpu_disp_record#*|}
     fi
-    # Only amd-smi builds old enough to predate TARGET_GRAPHICS_VERSION reach this: their
-    # records carry names but no arch, so the arch comes from the separate list probe.
+    # Only pre-TARGET_GRAPHICS_VERSION amd-smi lands here: names but no arch in the record.
     if [ -z "$_gpu_disp_gfx" ]; then
         _gpu_disp_gfx=$(printf '%s\n' "$_gpu_disp_gfx_all" | awk -v idx="$_gpu_vis_idx" \
             'NF && !seen[$0]++ { a[n++]=$0 } END { if(idx>=n) idx=0; if(n>0) print a[idx] }')

--- a/install.sh
+++ b/install.sh
@@ -4803,9 +4803,20 @@ elif case "$TORCH_INDEX_URL" in */rocm*|*/gfx*) true ;; *) false ;; esac; then
             'NF && !seen[$0]++ { a[n++]=$0 } END { if(idx>=n) idx=0; if(n>0) print a[idx] }')
     fi
     # Use the unindexed amd-smi name only when no rocminfo records are in use.
+    # amd-smi upper-cases every key in its human-readable output (amdsmi_logger.py
+    # _capitalize_keys), so the field is MARKET_NAME, which /[Mm]arket.?[Nn]ame/ could
+    # never match: the fallback printed nothing on a real host. Matched case-folded, and
+    # read past the FIRST colon only, so "MARKET_NAME: AMD Instinct MI300X OAM: 750W SKU"
+    # survives -- the same truncation the rocminfo parser above already fixed.
+    # Keep in sync with studio/setup.sh.
     if [ -z "$_gpu_disp_mkt" ] && [ -z "$_gpu_disp_records" ] && command -v amd-smi >/dev/null 2>&1; then
-        _gpu_disp_mkt=$(amd-smi static --asic 2>/dev/null | awk -F'[:|]' \
-            '/[Mm]arket.?[Nn]ame/{gsub(/^[[:space:]]+|[[:space:]]+$/,"", $2); if($2){print $2; exit}}' || true)
+        _gpu_disp_mkt=$(amd-smi static --asic 2>/dev/null | awk \
+            'tolower($0) ~ /market.?name/ {
+                 v = $0
+                 sub(/^[^:]*:[[:space:]]*/, "", v)
+                 gsub(/^[[:space:]]+|[[:space:]]+$/, "", v)
+                 if (v != "") { print v; exit }
+             }' || true)
     fi
     # UNSLOTH_ROCM_GFX_ARCH env override (mirrors install.ps1)
     if [ -n "${UNSLOTH_ROCM_GFX_ARCH:-}" ]; then

--- a/install.sh
+++ b/install.sh
@@ -4766,6 +4766,46 @@ _rocminfo_gpu_records() {
     '
 }
 
+# amd-smi enumerates in discovery order over its KFD view; HIP_VISIBLE_DEVICES and
+# ROCR_VISIBLE_DEVICES index HIP/ROCr order, which the library derives from the KFD node
+# id instead. The two disagree on real hardware (MI350X SPX/NPS1), and _gfx here becomes
+# --rocm-gfx, so an untranslated ordinal can fetch a prebuilt for another card's arch.
+# `amd-smi list -e` is the map AMD publishes for this (HIP_ID, ROCm 6.4.0+); the Python
+# side reads the same field in utils/hardware/amd.py get_hip_id_by_gpu_index.
+# Keep in sync with studio/setup.sh.
+_amd_smi_hip_order() {
+    # POSIX awk forbids a physical newline in a -v value (gawk --posix makes it fatal),
+    # so the records arrive on stdin ahead of the map, separated by a sentinel.
+    { printf '%s\n' "$1"; echo "@@hip-map@@"; cat; } | awk '
+        function value(line,   v) {
+            v = line
+            sub(/^[^:]*:[[:space:]]*/, "", v)
+            gsub(/^[[:space:]]+|[[:space:]]+$/, "", v)
+            return v
+        }
+        function keep(   i) { for (i = 1; i <= r; i++) print rec[i] }
+        !split_seen && $0 == "@@hip-map@@" { split_seen = 1; next }
+        !split_seen { if ($0 != "") rec[++r] = $0; next }
+        /^[[:space:]]*GPU:[[:space:]]*[0-9]/ { n++; hip[n] = -1; next }
+        n && tolower($0) ~ /hip.?id/ {
+            if (hip[n] < 0) { v = value($0); if (v ~ /^[0-9]+$/) hip[n] = v + 0 }
+            next
+        }
+        END {
+            # All or nothing, like get_hip_id_by_gpu_index: an older CLI rejects -e, and
+            # hip_id reads N/A when the library cannot reach a KFD node. A partial or
+            # colliding map is not a 1:1 device mapping, so keep discovery order.
+            if (r == 0 || n != r) { keep(); exit }
+            for (i = 1; i <= n; i++) {
+                if (hip[i] < 0 || hip[i] >= r || (hip[i] in used)) { keep(); exit }
+                used[hip[i]] = 1
+                out[hip[i]] = rec[i]
+            }
+            for (i = 0; i < r; i++) print out[i]
+        }
+    '
+}
+
 # One `gfx|marketing name` per adapter, in `GPU: N` order, so the mask picks both halves
 # of one device. Was: arch indexed, name always adapter 0's -- and on amd-smi 6.1.1, which
 # has no TARGET_GRAPHICS_VERSION, that name is what --rocm-gfx is inferred from.
@@ -4812,6 +4852,8 @@ elif case "$TORCH_INDEX_URL" in */rocm*|*/gfx*) true ;; *) false ;; esac; then
     fi
     if [ -z "$_gpu_disp_gfx_all" ] && command -v amd-smi >/dev/null 2>&1; then
         _gpu_disp_smi_records=$(amd-smi static --asic 2>/dev/null | _amd_smi_gpu_records || true)
+        [ -n "$_gpu_disp_smi_records" ] && _gpu_disp_smi_records=$(amd-smi list -e 2>/dev/null \
+            | _amd_smi_hip_order "$_gpu_disp_smi_records" || true)
         _gpu_disp_gfx_all=$(amd-smi list 2>/dev/null | grep -oE 'gfx[1-9][0-9a-z]{2,3}' || true)
         [ -z "$_gpu_disp_gfx_all" ] && \
             _gpu_disp_gfx_all=$(printf '%s\n' "$_gpu_disp_smi_records" | awk -F'|' '$1 != "" { print $1 }')

--- a/install.sh
+++ b/install.sh
@@ -4868,9 +4868,9 @@ elif case "$TORCH_INDEX_URL" in */rocm*|*/gfx*) true ;; *) false ;; esac; then
             # from the name, so an archless record is compared on its name instead.
             # Interchangeable adapters are unaffected: every ordinal gives the same answer.
             if [ "$_gpu_disp_smi_space" != hip ] && \
-               [ "$(printf '%s\n' "$_gpu_disp_smi_records" \
-                    | awk -F'|' 'NF { print ($1 != "" ? $1 : "name:" $2) }' \
-                    | sort -u | wc -l)" -gt 1 ]; then
+               [ "$(printf '%s\n' "$_gpu_disp_smi_records" | awk -F'|' \
+                    'NF { k = ($1 != "" ? $1 : "name:" $2); if (!(k in seen)) { seen[k]; n++ } }
+                     END { print n + 0 }')" -gt 1 ]; then
                 _gpu_disp_smi_records=""
                 _gpu_disp_gfx_all=""
                 _gpu_disp_hip_map_missing=1

--- a/install.sh
+++ b/install.sh
@@ -4775,7 +4775,9 @@ _rocminfo_gpu_records() {
 # Keep in sync with studio/setup.sh.
 _amd_smi_hip_order() {
     # POSIX awk forbids a physical newline in a -v value (gawk --posix makes it fatal),
-    # so the records arrive on stdin ahead of the map, separated by a sentinel.
+    # so the records arrive on stdin ahead of the map, separated by a sentinel. The first
+    # output line reports which index space the records came back in; the caller needs to
+    # know, because a mask cannot be applied to an untranslated list of unlike adapters.
     { printf '%s\n' "$1"; echo "@@hip-map@@"; cat; } | awk '
         function value(line,   v) {
             v = line
@@ -4783,7 +4785,7 @@ _amd_smi_hip_order() {
             gsub(/^[[:space:]]+|[[:space:]]+$/, "", v)
             return v
         }
-        function keep(   i) { for (i = 1; i <= r; i++) print rec[i] }
+        function keep(   i) { print "discovery"; for (i = 1; i <= r; i++) print rec[i] }
         !split_seen && $0 == "@@hip-map@@" { split_seen = 1; next }
         !split_seen { if ($0 != "") rec[++r] = $0; next }
         /^[[:space:]]*GPU:[[:space:]]*[0-9]/ { n++; hip[n] = -1; next }
@@ -4801,6 +4803,7 @@ _amd_smi_hip_order() {
                 used[hip[i]] = 1
                 out[hip[i]] = rec[i]
             }
+            print "hip"
             for (i = 0; i < r; i++) print out[i]
         }
     '
@@ -4844,6 +4847,7 @@ elif case "$TORCH_INDEX_URL" in */rocm*|*/gfx*) true ;; *) false ;; esac; then
     _ensure_rocm_probe_env
     _gpu_disp_gfx_all=""
     _gpu_disp_gfx=""
+    _gpu_disp_hip_map_missing=0
     _gpu_disp_mkt=""
     _gpu_disp_records=""
     if command -v rocminfo >/dev/null 2>&1; then
@@ -4852,8 +4856,23 @@ elif case "$TORCH_INDEX_URL" in */rocm*|*/gfx*) true ;; *) false ;; esac; then
     fi
     if [ -z "$_gpu_disp_gfx_all" ] && command -v amd-smi >/dev/null 2>&1; then
         _gpu_disp_smi_records=$(amd-smi static --asic 2>/dev/null | _amd_smi_gpu_records || true)
-        [ -n "$_gpu_disp_smi_records" ] && _gpu_disp_smi_records=$(amd-smi list -e 2>/dev/null \
-            | _amd_smi_hip_order "$_gpu_disp_smi_records" || true)
+        if [ -n "$_gpu_disp_smi_records" ]; then
+            _gpu_disp_smi_out=$(amd-smi list -e 2>/dev/null \
+                | _amd_smi_hip_order "$_gpu_disp_smi_records" || true)
+            _gpu_disp_smi_space=$(printf '%s\n' "$_gpu_disp_smi_out" | head -n 1)
+            _gpu_disp_smi_records=$(printf '%s\n' "$_gpu_disp_smi_out" | tail -n +2)
+            # No map, and the adapters do not agree on an arch: the mask indexes HIP order
+            # and these records are in discovery order, so any ordinal is a guess. Report
+            # nothing rather than name one card and route another. Identical adapters are
+            # unaffected, since every ordinal yields the same arch either way.
+            if [ "$_gpu_disp_smi_space" != hip ] && \
+               [ "$(printf '%s\n' "$_gpu_disp_smi_records" | awk -F'|' 'NF { print $1 }' \
+                    | sort -u | wc -l)" -gt 1 ]; then
+                _gpu_disp_smi_records=""
+                _gpu_disp_gfx_all=""
+                _gpu_disp_hip_map_missing=1
+            fi
+        fi
         _gpu_disp_gfx_all=$(amd-smi list 2>/dev/null | grep -oE 'gfx[1-9][0-9a-z]{2,3}' || true)
         [ -z "$_gpu_disp_gfx_all" ] && \
             _gpu_disp_gfx_all=$(printf '%s\n' "$_gpu_disp_smi_records" | awk -F'|' '$1 != "" { print $1 }')

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -2160,8 +2160,19 @@ if [ "$_setup_nvidia_usable" != true ]; then
         _setup_gfx_all=$(_setup_run_smi amd-smi list 2>/dev/null | grep -oE 'gfx[1-9][0-9a-z]{2,3}' || true)
         [ -z "$_setup_gfx_all" ] && \
             _setup_gfx_all=$(_setup_run_smi amd-smi static --asic 2>/dev/null | grep -oE 'gfx[1-9][0-9a-z]{2,3}' || true)
-        _setup_mkt=$(_setup_run_smi amd-smi static --asic 2>/dev/null | awk -F'[:|]' \
-            '/[Mm]arket.?[Nn]ame/{gsub(/^[[:space:]]+|[[:space:]]+$/,"", $2); if($2){print $2; exit}}' || true)
+        # amd-smi upper-cases every key in its human-readable output (amdsmi_logger.py
+        # _capitalize_keys), so the field is MARKET_NAME, which /[Mm]arket.?[Nn]ame/ could
+        # never match: the fallback printed nothing on a real host. Matched case-folded, and
+        # read past the FIRST colon only, so "MARKET_NAME: AMD Instinct MI300X OAM: 750W SKU"
+        # survives -- the same truncation the rocminfo parser above already fixed.
+        # Keep in sync with install.sh.
+        _setup_mkt=$(_setup_run_smi amd-smi static --asic 2>/dev/null | awk \
+            'tolower($0) ~ /market.?name/ {
+                 v = $0
+                 sub(/^[^:]*:[[:space:]]*/, "", v)
+                 gsub(/^[[:space:]]+|[[:space:]]+$/, "", v)
+                 if (v != "") { print v; exit }
+             }' || true)
     elif [ -e /dev/kfd ] && \
          awk '/vendor_id/ && $2 == 4098 { found = 1 } END { exit !found }' \
              /sys/class/kfd/kfd/topology/nodes/*/properties 2>/dev/null; then

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -2041,6 +2041,45 @@ _setup_amd_detected=false
 _setup_nvidia_usable=false
 _setup_gfx_all=""
 _setup_mkt=""
+_setup_amd_records=""
+
+# Pair each rocminfo GPU gfx id with its marketing name instead of using the CPU-first
+# global name (#7307). Blank names keep device ordinals; no GPU keeps the old fallback.
+# Keep in sync with install.sh.
+_setup_rocminfo_gpu_records() {
+    awk '
+        # Split at the first colon so embedded colons survive.
+        function value(line,   v) {
+            v = line
+            sub(/^[^:]*:[[:space:]]*/, "", v)
+            gsub(/^[[:space:]]+|[[:space:]]+$/, "", v)
+            return v
+        }
+        /^[[:space:]]*Name:/ {
+            # Keep a slot for a nameless GPU.
+            if (gfx != "" && !named) { print gfx "|"; gpus++ }
+            gfx = ""; named = 0
+            name = value($0)
+            # Accept target suffixes such as gfx90a:sramecc+, but reject ISA names.
+            if (match(name, /^gfx[1-9][0-9a-z][0-9a-z][0-9a-z]?/)) {
+                rest = substr(name, RLENGTH + 1)
+                if (rest == "" || rest ~ /^[^0-9a-z]/) gfx = substr(name, 1, RLENGTH)
+            }
+            next
+        }
+        /^[[:space:]]*Marketing Name:/ {
+            mkt = value($0)
+            if (gfx != "" && !named) { print gfx "|" mkt; gpus++; named = 1 }
+            else if (first == "") first = mkt
+            next
+        }
+        END {
+            if (gfx != "" && !named) { print gfx "|"; gpus++ }
+            if (gpus == 0 && first != "") print "|" first
+        }
+    '
+}
+
 # Intel XPU. There is no vendor probe here like nvidia-smi / rocminfo -- Linux Intel support is
 # an explicit index pin, not autodetection -- so the installed runtime IS the signal. The local
 # label is read off disk first so a CPU-only host never pays for an `import torch`.
@@ -2107,15 +2146,17 @@ if _setup_has_usable_nvidia_gpu; then
     _setup_nvidia_usable=true
 fi
 if [ "$_setup_nvidia_usable" != true ]; then
-    if command -v rocminfo >/dev/null 2>&1 && \
-       _setup_run_smi rocminfo 2>/dev/null | awk '/Name:[[:space:]]*gfx[1-9][0-9]/{found=1} END{exit !found}'; then
+    if command -v rocminfo >/dev/null 2>&1; then
+        _setup_amd_records=$(_setup_run_smi rocminfo 2>/dev/null | _setup_rocminfo_gpu_records || true)
+        _setup_gfx_all=$(printf '%s\n' "$_setup_amd_records" | awk -F'|' '$1 != "" { print $1 }')
+    fi
+    if [ -n "$_setup_gfx_all" ]; then
         _setup_amd_detected=true
-        _setup_gfx_all=$(_setup_run_smi rocminfo 2>/dev/null | grep -oE 'gfx[1-9][0-9a-z]{2,3}' || true)
-        _setup_mkt=$(_setup_run_smi rocminfo 2>/dev/null | awk -F': ' \
-            '/Marketing Name:/{gsub(/^[[:space:]]+|[[:space:]]+$/,"", $2); if($2){print $2; exit}}' || true)
     elif command -v amd-smi >/dev/null 2>&1 && \
          _setup_run_smi amd-smi list 2>/dev/null | awk '/^GPU[[:space:]]*[:\[][[:space:]]*[0-9]/{ found=1 } END{ exit !found }'; then
         _setup_amd_detected=true
+        # amd-smi now owns the device list, so discard rocminfo's fallback name.
+        _setup_amd_records=""
         _setup_gfx_all=$(_setup_run_smi amd-smi list 2>/dev/null | grep -oE 'gfx[1-9][0-9a-z]{2,3}' || true)
         [ -z "$_setup_gfx_all" ] && \
             _setup_gfx_all=$(_setup_run_smi amd-smi static --asic 2>/dev/null | grep -oE 'gfx[1-9][0-9a-z]{2,3}' || true)
@@ -2131,6 +2172,7 @@ if [ "$_setup_nvidia_usable" != true ]; then
         # nor a marketing name is available from this path, so the report below
         # reads lspci rather than _setup_mkt when it needs to name the card.
         _setup_amd_detected=true
+        _setup_amd_records=""
     fi
 fi
 
@@ -2143,8 +2185,16 @@ elif [ "$_setup_amd_detected" = true ]; then
         _setup_first="${_setup_vis%%,*}"
         case "$_setup_first" in ''|*[!0-9]*) ;; *) _setup_vis_idx=$_setup_first ;; esac
     fi
-    _setup_gfx=$(printf '%s\n' "$_setup_gfx_all" | awk -v idx="$_setup_vis_idx" \
-        'NF && !seen[$0]++ { a[n++]=$0 } END { if(idx>=n) idx=0; if(n>0) print a[idx] }')
+    if [ -n "$_setup_amd_records" ]; then
+        # Records already preserve device ordinals, including duplicate arches.
+        _setup_amd_record=$(printf '%s\n' "$_setup_amd_records" | awk -v idx="$_setup_vis_idx" \
+            'NF { a[n++]=$0 } END { if(idx>=n) idx=0; if(n>0) print a[idx] }')
+        _setup_gfx=${_setup_amd_record%%|*}
+        _setup_mkt=${_setup_amd_record#*|}
+    else
+        _setup_gfx=$(printf '%s\n' "$_setup_gfx_all" | awk -v idx="$_setup_vis_idx" \
+            'NF && !seen[$0]++ { a[n++]=$0 } END { if(idx>=n) idx=0; if(n>0) print a[idx] }')
+    fi
     # UNSLOTH_ROCM_GFX_ARCH env override (mirrors setup.ps1)
     if [ -n "${UNSLOTH_ROCM_GFX_ARCH:-}" ]; then
         _setup_gfx="${UNSLOTH_ROCM_GFX_ARCH}"

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -2040,6 +2040,7 @@ fi
 _setup_amd_detected=false
 _setup_nvidia_usable=false
 _setup_gfx_all=""
+_setup_gfx=""
 _setup_mkt=""
 _setup_amd_records=""
 

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -2041,6 +2041,7 @@ _setup_amd_detected=false
 _setup_nvidia_usable=false
 _setup_gfx_all=""
 _setup_gfx=""
+_setup_hip_map_missing=0
 _setup_mkt=""
 _setup_amd_records=""
 
@@ -2090,7 +2091,9 @@ _setup_rocminfo_gpu_records() {
 # Keep in sync with install.sh.
 _setup_amd_smi_hip_order() {
     # POSIX awk forbids a physical newline in a -v value (gawk --posix makes it fatal),
-    # so the records arrive on stdin ahead of the map, separated by a sentinel.
+    # so the records arrive on stdin ahead of the map, separated by a sentinel. The first
+    # output line reports which index space the records came back in; the caller needs to
+    # know, because a mask cannot be applied to an untranslated list of unlike adapters.
     { printf '%s\n' "$1"; echo "@@hip-map@@"; cat; } | awk '
         function value(line,   v) {
             v = line
@@ -2098,7 +2101,7 @@ _setup_amd_smi_hip_order() {
             gsub(/^[[:space:]]+|[[:space:]]+$/, "", v)
             return v
         }
-        function keep(   i) { for (i = 1; i <= r; i++) print rec[i] }
+        function keep(   i) { print "discovery"; for (i = 1; i <= r; i++) print rec[i] }
         !split_seen && $0 == "@@hip-map@@" { split_seen = 1; next }
         !split_seen { if ($0 != "") rec[++r] = $0; next }
         /^[[:space:]]*GPU:[[:space:]]*[0-9]/ { n++; hip[n] = -1; next }
@@ -2116,6 +2119,7 @@ _setup_amd_smi_hip_order() {
                 used[hip[i]] = 1
                 out[hip[i]] = rec[i]
             }
+            print "hip"
             for (i = 0; i < r; i++) print out[i]
         }
     '
@@ -2228,8 +2232,24 @@ if [ "$_setup_nvidia_usable" != true ]; then
         _setup_amd_detected=true
         # amd-smi owns the device list here, so its indexed records replace rocminfo's.
         _setup_amd_records=$(_setup_run_smi amd-smi static --asic 2>/dev/null | _setup_amd_smi_gpu_records || true)
-        [ -n "$_setup_amd_records" ] && _setup_amd_records=$(_setup_run_smi amd-smi list -e 2>/dev/null \
-            | _setup_amd_smi_hip_order "$_setup_amd_records" || true)
+        if [ -n "$_setup_amd_records" ]; then
+            _setup_amd_smi_out=$(_setup_run_smi amd-smi list -e 2>/dev/null \
+                | _setup_amd_smi_hip_order "$_setup_amd_records" || true)
+            _setup_amd_space=$(printf '%s\n' "$_setup_amd_smi_out" | head -n 1)
+            _setup_amd_records=$(printf '%s\n' "$_setup_amd_smi_out" | tail -n +2)
+            # No map, and the adapters do not agree on an arch: the mask indexes HIP order
+            # and these records are in discovery order, so any ordinal is a guess. Decline
+            # rather than forward a guessed --rocm-gfx to the llama.cpp and whisper
+            # prebuilts. Identical adapters are unaffected, since every ordinal yields the
+            # same arch either way, and UNSLOTH_ROCM_GFX_ARCH still overrides below.
+            if [ "$_setup_amd_space" != hip ] && \
+               [ "$(printf '%s\n' "$_setup_amd_records" | awk -F'|' 'NF { print $1 }' \
+                    | sort -u | wc -l)" -gt 1 ]; then
+                _setup_amd_records=""
+                _setup_gfx_all=""
+                _setup_hip_map_missing=1
+            fi
+        fi
         _setup_gfx_all=$(_setup_run_smi amd-smi list 2>/dev/null | grep -oE 'gfx[1-9][0-9a-z]{2,3}' || true)
         [ -z "$_setup_gfx_all" ] && \
             _setup_gfx_all=$(printf '%s\n' "$_setup_amd_records" | awk -F'|' '$1 != "" { print $1 }')
@@ -2279,6 +2299,11 @@ elif [ "$_setup_amd_detected" = true ]; then
             substep "gfx arch inferred from GPU name: $_setup_gfx"
             substep "Tip: set UNSLOTH_ROCM_GFX_ARCH=$_setup_gfx to skip inference next time"
         fi
+    fi
+    # Say why the arch is missing, since the user can supply it and amd-smi cannot.
+    if [ -z "$_setup_gfx" ] && [ "$_setup_hip_map_missing" = 1 ]; then
+        substep "Unlike AMD adapters and no HIP id map (amd-smi list -e needs ROCm 6.4+):"
+        substep "cannot tell which one this session selects. Set UNSLOTH_ROCM_GFX_ARCH to pick."
     fi
     # ROCm version via hipconfig, then amd-smi
     _setup_rocm_ver=""

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -2245,9 +2245,9 @@ if [ "$_setup_nvidia_usable" != true ]; then
             # name instead. Interchangeable adapters are unaffected: every ordinal gives the
             # same answer, and UNSLOTH_ROCM_GFX_ARCH still overrides below.
             if [ "$_setup_amd_space" != hip ] && \
-               [ "$(printf '%s\n' "$_setup_amd_records" \
-                    | awk -F'|' 'NF { print ($1 != "" ? $1 : "name:" $2) }' \
-                    | sort -u | wc -l)" -gt 1 ]; then
+               [ "$(printf '%s\n' "$_setup_amd_records" | awk -F'|' \
+                    'NF { k = ($1 != "" ? $1 : "name:" $2); if (!(k in seen)) { seen[k]; n++ } }
+                     END { print n + 0 }')" -gt 1 ]; then
                 _setup_amd_records=""
                 _setup_gfx_all=""
                 _setup_hip_map_missing=1

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -2081,6 +2081,46 @@ _setup_rocminfo_gpu_records() {
     '
 }
 
+# amd-smi enumerates in discovery order over its KFD view; HIP_VISIBLE_DEVICES and
+# ROCR_VISIBLE_DEVICES index HIP/ROCr order, which the library derives from the KFD node
+# id instead. The two disagree on real hardware (MI350X SPX/NPS1), and _gfx here becomes
+# --rocm-gfx, so an untranslated ordinal can fetch a prebuilt for another card's arch.
+# `amd-smi list -e` is the map AMD publishes for this (HIP_ID, ROCm 6.4.0+); the Python
+# side reads the same field in utils/hardware/amd.py get_hip_id_by_gpu_index.
+# Keep in sync with install.sh.
+_setup_amd_smi_hip_order() {
+    # POSIX awk forbids a physical newline in a -v value (gawk --posix makes it fatal),
+    # so the records arrive on stdin ahead of the map, separated by a sentinel.
+    { printf '%s\n' "$1"; echo "@@hip-map@@"; cat; } | awk '
+        function value(line,   v) {
+            v = line
+            sub(/^[^:]*:[[:space:]]*/, "", v)
+            gsub(/^[[:space:]]+|[[:space:]]+$/, "", v)
+            return v
+        }
+        function keep(   i) { for (i = 1; i <= r; i++) print rec[i] }
+        !split_seen && $0 == "@@hip-map@@" { split_seen = 1; next }
+        !split_seen { if ($0 != "") rec[++r] = $0; next }
+        /^[[:space:]]*GPU:[[:space:]]*[0-9]/ { n++; hip[n] = -1; next }
+        n && tolower($0) ~ /hip.?id/ {
+            if (hip[n] < 0) { v = value($0); if (v ~ /^[0-9]+$/) hip[n] = v + 0 }
+            next
+        }
+        END {
+            # All or nothing, like get_hip_id_by_gpu_index: an older CLI rejects -e, and
+            # hip_id reads N/A when the library cannot reach a KFD node. A partial or
+            # colliding map is not a 1:1 device mapping, so keep discovery order.
+            if (r == 0 || n != r) { keep(); exit }
+            for (i = 1; i <= n; i++) {
+                if (hip[i] < 0 || hip[i] >= r || (hip[i] in used)) { keep(); exit }
+                used[hip[i]] = 1
+                out[hip[i]] = rec[i]
+            }
+            for (i = 0; i < r; i++) print out[i]
+        }
+    '
+}
+
 # One `gfx|marketing name` per adapter, in `GPU: N` order, so the mask picks both halves
 # of one device. Was: arch indexed, name always adapter 0's -- and on amd-smi 6.1.1, which
 # has no TARGET_GRAPHICS_VERSION, that name is what --rocm-gfx is inferred from.
@@ -2188,6 +2228,8 @@ if [ "$_setup_nvidia_usable" != true ]; then
         _setup_amd_detected=true
         # amd-smi owns the device list here, so its indexed records replace rocminfo's.
         _setup_amd_records=$(_setup_run_smi amd-smi static --asic 2>/dev/null | _setup_amd_smi_gpu_records || true)
+        [ -n "$_setup_amd_records" ] && _setup_amd_records=$(_setup_run_smi amd-smi list -e 2>/dev/null \
+            | _setup_amd_smi_hip_order "$_setup_amd_records" || true)
         _setup_gfx_all=$(_setup_run_smi amd-smi list 2>/dev/null | grep -oE 'gfx[1-9][0-9a-z]{2,3}' || true)
         [ -z "$_setup_gfx_all" ] && \
             _setup_gfx_all=$(printf '%s\n' "$_setup_amd_records" | awk -F'|' '$1 != "" { print $1 }')

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -2080,6 +2080,38 @@ _setup_rocminfo_gpu_records() {
     '
 }
 
+# Same record shape for amd-smi: one `gfx|marketing name` per adapter, in `GPU: N` order.
+# Without this the arch was indexed by the visible-device mask while the name was always
+# the first adapter's, so selecting a later card paired its arch with another card's name
+# -- and on amd-smi builds predating TARGET_GRAPHICS_VERSION (present in 6.1.1's docs
+# without it) the name is what the arch is inferred from, so the wrong arch reached
+# --rocm-gfx. Keep in sync with install.sh.
+_setup_amd_smi_gpu_records() {
+    awk '
+        function value(line,   v) {
+            v = line
+            sub(/^[^:]*:[[:space:]]*/, "", v)
+            gsub(/^[[:space:]]+|[[:space:]]+$/, "", v)
+            return v
+        }
+        function flush() {
+            if (started) print gfx "|" mkt
+            gfx = ""; mkt = ""
+        }
+        # amd-smi upper-cases every key (amdsmi_logger.py _capitalize_keys), so the real
+        # fields are MARKET_NAME and TARGET_GRAPHICS_VERSION; matched case-folded anyway.
+        /^[[:space:]]*GPU:[[:space:]]*[0-9]/ { flush(); started = 1; next }
+        !started { next }
+        tolower($0) ~ /market.?name/ { if (mkt == "") mkt = value($0); next }
+        tolower($0) ~ /target.?graphics.?version/ {
+            v = value($0)
+            if (gfx == "" && v ~ /^gfx[1-9][0-9a-z][0-9a-z][0-9a-z]?$/) gfx = v
+            next
+        }
+        END { flush() }
+    '
+}
+
 # Intel XPU. There is no vendor probe here like nvidia-smi / rocminfo -- Linux Intel support is
 # an explicit index pin, not autodetection -- so the installed runtime IS the signal. The local
 # label is read off disk first so a CPU-only host never pays for an `import torch`.
@@ -2155,24 +2187,12 @@ if [ "$_setup_nvidia_usable" != true ]; then
     elif command -v amd-smi >/dev/null 2>&1 && \
          _setup_run_smi amd-smi list 2>/dev/null | awk '/^GPU[[:space:]]*[:\[][[:space:]]*[0-9]/{ found=1 } END{ exit !found }'; then
         _setup_amd_detected=true
-        # amd-smi now owns the device list, so discard rocminfo's fallback name.
-        _setup_amd_records=""
+        # amd-smi owns the device list from here, so rocminfo's fallback name is replaced
+        # by amd-smi's own indexed records rather than left to win the selection.
+        _setup_amd_records=$(_setup_run_smi amd-smi static --asic 2>/dev/null | _setup_amd_smi_gpu_records || true)
         _setup_gfx_all=$(_setup_run_smi amd-smi list 2>/dev/null | grep -oE 'gfx[1-9][0-9a-z]{2,3}' || true)
         [ -z "$_setup_gfx_all" ] && \
-            _setup_gfx_all=$(_setup_run_smi amd-smi static --asic 2>/dev/null | grep -oE 'gfx[1-9][0-9a-z]{2,3}' || true)
-        # amd-smi upper-cases every key in its human-readable output (amdsmi_logger.py
-        # _capitalize_keys), so the field is MARKET_NAME, which /[Mm]arket.?[Nn]ame/ could
-        # never match: the fallback printed nothing on a real host. Matched case-folded, and
-        # read past the FIRST colon only, so "MARKET_NAME: AMD Instinct MI300X OAM: 750W SKU"
-        # survives -- the same truncation the rocminfo parser above already fixed.
-        # Keep in sync with install.sh.
-        _setup_mkt=$(_setup_run_smi amd-smi static --asic 2>/dev/null | awk \
-            'tolower($0) ~ /market.?name/ {
-                 v = $0
-                 sub(/^[^:]*:[[:space:]]*/, "", v)
-                 gsub(/^[[:space:]]+|[[:space:]]+$/, "", v)
-                 if (v != "") { print v; exit }
-             }' || true)
+            _setup_gfx_all=$(printf '%s\n' "$_setup_amd_records" | awk -F'|' '$1 != "" { print $1 }')
     elif [ -e /dev/kfd ] && \
          awk '/vendor_id/ && $2 == 4098 { found = 1 } END { exit !found }' \
              /sys/class/kfd/kfd/topology/nodes/*/properties 2>/dev/null; then
@@ -2202,7 +2222,10 @@ elif [ "$_setup_amd_detected" = true ]; then
             'NF { a[n++]=$0 } END { if(idx>=n) idx=0; if(n>0) print a[idx] }')
         _setup_gfx=${_setup_amd_record%%|*}
         _setup_mkt=${_setup_amd_record#*|}
-    else
+    fi
+    # Only amd-smi builds old enough to predate TARGET_GRAPHICS_VERSION reach this: their
+    # records carry names but no arch, so the arch comes from the separate list probe.
+    if [ -z "$_setup_gfx" ]; then
         _setup_gfx=$(printf '%s\n' "$_setup_gfx_all" | awk -v idx="$_setup_vis_idx" \
             'NF && !seen[$0]++ { a[n++]=$0 } END { if(idx>=n) idx=0; if(n>0) print a[idx] }')
     fi

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -2237,13 +2237,16 @@ if [ "$_setup_nvidia_usable" != true ]; then
                 | _setup_amd_smi_hip_order "$_setup_amd_records" || true)
             _setup_amd_space=$(printf '%s\n' "$_setup_amd_smi_out" | head -n 1)
             _setup_amd_records=$(printf '%s\n' "$_setup_amd_smi_out" | tail -n +2)
-            # No map, and the adapters do not agree on an arch: the mask indexes HIP order
-            # and these records are in discovery order, so any ordinal is a guess. Decline
+            # No map, and the adapters are not interchangeable: the mask indexes HIP order
+            # while these records are in discovery order, so any ordinal is a guess. Decline
             # rather than forward a guessed --rocm-gfx to the llama.cpp and whisper
-            # prebuilts. Identical adapters are unaffected, since every ordinal yields the
-            # same arch either way, and UNSLOTH_ROCM_GFX_ARCH still overrides below.
+            # prebuilts. amd-smi 6.1.1 reports no TARGET_GRAPHICS_VERSION at all and the
+            # arch is then inferred from the name, so an archless record is compared on its
+            # name instead. Interchangeable adapters are unaffected: every ordinal gives the
+            # same answer, and UNSLOTH_ROCM_GFX_ARCH still overrides below.
             if [ "$_setup_amd_space" != hip ] && \
-               [ "$(printf '%s\n' "$_setup_amd_records" | awk -F'|' 'NF { print $1 }' \
+               [ "$(printf '%s\n' "$_setup_amd_records" \
+                    | awk -F'|' 'NF { print ($1 != "" ? $1 : "name:" $2) }' \
                     | sort -u | wc -l)" -gt 1 ]; then
                 _setup_amd_records=""
                 _setup_gfx_all=""

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -2080,12 +2080,10 @@ _setup_rocminfo_gpu_records() {
     '
 }
 
-# Same record shape for amd-smi: one `gfx|marketing name` per adapter, in `GPU: N` order.
-# Without this the arch was indexed by the visible-device mask while the name was always
-# the first adapter's, so selecting a later card paired its arch with another card's name
-# -- and on amd-smi builds predating TARGET_GRAPHICS_VERSION (present in 6.1.1's docs
-# without it) the name is what the arch is inferred from, so the wrong arch reached
-# --rocm-gfx. Keep in sync with install.sh.
+# One `gfx|marketing name` per adapter, in `GPU: N` order, so the mask picks both halves
+# of one device. Was: arch indexed, name always adapter 0's -- and on amd-smi 6.1.1, which
+# has no TARGET_GRAPHICS_VERSION, that name is what --rocm-gfx is inferred from.
+# Keep in sync with install.sh.
 _setup_amd_smi_gpu_records() {
     awk '
         function value(line,   v) {
@@ -2098,8 +2096,8 @@ _setup_amd_smi_gpu_records() {
             if (started) print gfx "|" mkt
             gfx = ""; mkt = ""
         }
-        # amd-smi upper-cases every key (amdsmi_logger.py _capitalize_keys), so the real
-        # fields are MARKET_NAME and TARGET_GRAPHICS_VERSION; matched case-folded anyway.
+        # amd-smi upper-cases every key (amdsmi_logger.py _capitalize_keys): MARKET_NAME,
+        # TARGET_GRAPHICS_VERSION. Matched case-folded so older spellings work too.
         /^[[:space:]]*GPU:[[:space:]]*[0-9]/ { flush(); started = 1; next }
         !started { next }
         tolower($0) ~ /market.?name/ { if (mkt == "") mkt = value($0); next }
@@ -2187,8 +2185,7 @@ if [ "$_setup_nvidia_usable" != true ]; then
     elif command -v amd-smi >/dev/null 2>&1 && \
          _setup_run_smi amd-smi list 2>/dev/null | awk '/^GPU[[:space:]]*[:\[][[:space:]]*[0-9]/{ found=1 } END{ exit !found }'; then
         _setup_amd_detected=true
-        # amd-smi owns the device list from here, so rocminfo's fallback name is replaced
-        # by amd-smi's own indexed records rather than left to win the selection.
+        # amd-smi owns the device list here, so its indexed records replace rocminfo's.
         _setup_amd_records=$(_setup_run_smi amd-smi static --asic 2>/dev/null | _setup_amd_smi_gpu_records || true)
         _setup_gfx_all=$(_setup_run_smi amd-smi list 2>/dev/null | grep -oE 'gfx[1-9][0-9a-z]{2,3}' || true)
         [ -z "$_setup_gfx_all" ] && \
@@ -2223,8 +2220,7 @@ elif [ "$_setup_amd_detected" = true ]; then
         _setup_gfx=${_setup_amd_record%%|*}
         _setup_mkt=${_setup_amd_record#*|}
     fi
-    # Only amd-smi builds old enough to predate TARGET_GRAPHICS_VERSION reach this: their
-    # records carry names but no arch, so the arch comes from the separate list probe.
+    # Only pre-TARGET_GRAPHICS_VERSION amd-smi lands here: names but no arch in the record.
     if [ -z "$_setup_gfx" ]; then
         _setup_gfx=$(printf '%s\n' "$_setup_gfx_all" | awk -v idx="$_setup_vis_idx" \
             'NF && !seen[$0]++ { a[n++]=$0 } END { if(idx>=n) idx=0; if(n>0) print a[idx] }')

--- a/tests/sh/test_install_gpu_summary_probe_sources.sh
+++ b/tests/sh/test_install_gpu_summary_probe_sources.sh
@@ -36,10 +36,8 @@ cat > "$WORK/roc/rocminfo" <<'STUB'
 [ -s "$STUB_ROCMINFO" ] || exit 1
 cat "$STUB_ROCMINFO"
 STUB
-# `amd-smi list` prints BDF / UUID / KFD_ID / NODE_ID / PARTITION_ID and no gfx
-# token, so the arch always has to come from `static --asic`. The stub used to leak
-# TARGET_GRAPHICS_VERSION into `list`, which meant the fallthrough between the two
-# subcommands was never exercised.
+# `amd-smi list` prints BDF / UUID / KFD_ID and no gfx token, so the arch has to come
+# from `static --asic`. A stub that leaks it into `list` never tests the fallthrough.
 cat > "$WORK/smi/amd-smi" <<'STUB'
 #!/bin/sh
 [ -s "$STUB_AMDSMI" ] || exit 1
@@ -65,8 +63,7 @@ summary() {
     _path="$WORK/base"
     [ "$1" != "-" ] && _path="$WORK/roc:$_path"
     [ "$2" != "-" ] && _path="$WORK/smi:$_path"
-    # install.sh runs this block under `set -e`; match it so a guard that aborts the
-    # installer cannot pass here.
+    # install.sh runs this block under `set -e`; match it.
     env -i PATH="$_path" \
         STUB_ROCMINFO="$1" STUB_AMDSMI="$2" \
         ${3:+HIP_VISIBLE_DEVICES="$3"} \
@@ -127,9 +124,8 @@ Agent 3
   Marketing Name:          AMD Radeon RX 7900 XTX
   Device Type:             GPU
 EOF
-# amd-smi upper-cases every key in its human-readable output, so MARKET_NAME is what
-# a real host prints. The old fixture spelled it "Market Name" -- the one spelling the
-# parser happened to match -- so the naming path was green here and dead in production.
+# MARKET_NAME is what a real host prints. Spelling it "Market Name" -- the one form the
+# old parser matched -- kept this green while the naming path was dead in production.
 cat > "$WORK/smi_fixture" <<'EOF'
 GPU: 0
     ASIC:
@@ -150,8 +146,7 @@ GPU: 0
         MARKET_NAME: AMD Instinct MI300X OAM: 750W SKU
         TARGET_GRAPHICS_VERSION: gfx942
 EOF
-# Three adapters. The arch was indexed by the visible-device mask while the name was
-# always the first adapter's, so selecting a later card announced another card's name.
+# Three adapters: the arch followed the mask, the name was always adapter 0's.
 cat > "$WORK/smi_three" <<'EOF'
 GPU: 0
     ASIC:
@@ -169,8 +164,7 @@ GPU: 2
         VENDOR_ID: 0x1002
         TARGET_GRAPHICS_VERSION: gfx1201
 EOF
-# amd-smi 6.1.1 ships MARKET_NAME with no TARGET_GRAPHICS_VERSION, so the arch is
-# inferred from the name, which makes the name the thing that picks the wheel.
+# amd-smi 6.1.1 has MARKET_NAME and no TARGET_GRAPHICS_VERSION, so the name picks the wheel.
 cat > "$WORK/smi_two_nogfx" <<'EOF'
 GPU: 0
     ASIC:
@@ -181,9 +175,8 @@ GPU: 1
         MARKET_NAME: AMD Radeon AI PRO R9700
         VENDOR_ID: 0x1002
 EOF
-# The #7307 reporter's shape: a Ryzen iGPU plus two IDENTICAL R9700s. The two dGPU
-# records are byte-identical, so a selector that folds duplicate lines away resolves
-# device 2 back to ordinal 0 -- the iGPU.
+# The #7307 shape: a Ryzen iGPU plus two IDENTICAL R9700s. The two dGPU records are
+# byte-identical, so a selector that folds duplicates resolves device 2 to the iGPU.
 cat > "$WORK/roc_twins" <<'EOF'
 Agent 1
 *******
@@ -289,8 +282,7 @@ assert_eq "an ordinal past a duplicated arch still selects its own device" \
     "gfx1100|AMD Radeon PRO W7900" "$(summary "$WORK/roc_three_dup" "$WORK/empty" 2)"
 assert_eq "and the duplicate before it keeps its own name" \
     "gfx1100|AMD Radeon RX 7900 XTX" "$(summary "$WORK/roc_three_dup" "$WORK/empty" 1)"
-# Two of the same card produce two byte-identical records; the second one must still
-# be a device, not a duplicate line to be folded away.
+# The second identical card must still be a device, not a line to fold away.
 assert_eq "two identical cards are still two devices" \
     "gfx1201|AMD Radeon AI PRO R9700" "$(summary "$WORK/roc_twins" "$WORK/empty" 2)"
 

--- a/tests/sh/test_install_gpu_summary_probe_sources.sh
+++ b/tests/sh/test_install_gpu_summary_probe_sources.sh
@@ -14,6 +14,7 @@ FAIL=0
 {
     sed -n '/^_rocminfo_gpu_records()/,/^}/p' "$INSTALL_SH"
     sed -n '/^_amd_smi_gpu_records()/,/^}/p' "$INSTALL_SH"
+    sed -n '/^_amd_smi_hip_order()/,/^}/p'  "$INSTALL_SH"
     echo ""
     # Extract the probe and selection block.
     awk '/^    _gpu_disp_gfx_all=""/ {on=1}
@@ -24,6 +25,8 @@ grep -q '_gpu_disp_record=' "$WORK/block.sh" || {
     echo "FATAL: GPU summary probe block not found in $INSTALL_SH" >&2; exit 1; }
 grep -q '_amd_smi_gpu_records' "$WORK/block.sh" || {
     echo "FATAL: the amd-smi record parser is not wired into the block" >&2; exit 1; }
+grep -q '_amd_smi_hip_order' "$WORK/block.sh" || {
+    echo "FATAL: the amd-smi HIP reorder is not wired into the block" >&2; exit 1; }
 
 # Build PATH from scratch so host AMD tools cannot leak into the test.
 mkdir -p "$WORK/base" "$WORK/roc" "$WORK/smi"
@@ -41,9 +44,12 @@ STUB
 cat > "$WORK/smi/amd-smi" <<'STUB'
 #!/bin/sh
 [ -s "$STUB_AMDSMI" ] || exit 1
-case "$1" in
-    list)   sed -n 's/^\(GPU: [0-9]*\).*/\1  BDF: 0000:03:00.0  UUID: aaaa-bbbb  KFD_ID: 1/p' "$STUB_AMDSMI" ;;
-    static) cat "$STUB_AMDSMI" ;;
+case "$1 $2" in
+    # `list -e` carries HIP_ID and nothing else of interest; an older CLI rejects the
+    # flag outright, which is the STUB_AMDSMI_E="" case.
+    "list -e")  [ -z "${STUB_AMDSMI_E:-}" ] || cat "$STUB_AMDSMI_E" ;;
+    "list "*)   sed -n 's/^\(GPU: [0-9]*\).*/\1  BDF: 0000:03:00.0  UUID: aaaa-bbbb  KFD_ID: 1/p' "$STUB_AMDSMI" ;;
+    "static "*) cat "$STUB_AMDSMI" ;;
 esac
 STUB
 chmod +x "$WORK/roc/rocminfo" "$WORK/smi/amd-smi"
@@ -66,6 +72,7 @@ summary() {
     # install.sh runs this block under `set -e`; match it.
     env -i PATH="$_path" \
         STUB_ROCMINFO="$1" STUB_AMDSMI="$2" \
+        ${STUB_AMDSMI_E:+STUB_AMDSMI_E="$STUB_AMDSMI_E"} \
         ${3:+HIP_VISIBLE_DEVICES="$3"} \
         /bin/bash -c 'set -eu; . "$1"; printf "%s|%s\n" "$_gpu_disp_gfx" "$_gpu_disp_mkt"' _ "$WORK/block.sh"
 }
@@ -285,6 +292,36 @@ assert_eq "and the duplicate before it keeps its own name" \
 # The second identical card must still be a device, not a line to fold away.
 assert_eq "two identical cards are still two devices" \
     "gfx1201|AMD Radeon AI PRO R9700" "$(summary "$WORK/roc_twins" "$WORK/empty" 2)"
+
+# amd-smi discovery order is not HIP order; `amd-smi list -e` publishes HIP_ID as the map.
+# Discovery 0/1/2 is HIP 2/1/0 here, so an untranslated mask names the wrong card.
+cat > "$WORK/smi_e_reversed" <<'EOF'
+GPU: 0
+    HIP_ID: 2
+GPU: 1
+    HIP_ID: 1
+GPU: 2
+    HIP_ID: 0
+EOF
+# A partial map (hip_id reads N/A when a KFD node is unreachable) is not a mapping.
+cat > "$WORK/smi_e_partial" <<'EOF'
+GPU: 0
+    HIP_ID: 2
+GPU: 1
+    HIP_ID: N/A
+GPU: 2
+    HIP_ID: 0
+EOF
+
+echo "=== amd-smi ordinals are translated into HIP order ==="
+assert_eq "HIP 0 is discovery 2" "gfx1201|AMD Radeon AI PRO R9700" \
+    "$(STUB_AMDSMI_E="$WORK/smi_e_reversed" summary "$WORK/empty" "$WORK/smi_three" 0)"
+assert_eq "HIP 2 is discovery 0" "gfx90a|AMD Instinct MI210" \
+    "$(STUB_AMDSMI_E="$WORK/smi_e_reversed" summary "$WORK/empty" "$WORK/smi_three" 2)"
+assert_eq "an older CLI that rejects -e keeps discovery order" "gfx90a|AMD Instinct MI210" \
+    "$(summary "$WORK/empty" "$WORK/smi_three" 0)"
+assert_eq "a partial map is declined, not half-applied" "gfx90a|AMD Instinct MI210" \
+    "$(STUB_AMDSMI_E="$WORK/smi_e_partial" summary "$WORK/empty" "$WORK/smi_three" 0)"
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed"

--- a/tests/sh/test_install_gpu_summary_probe_sources.sh
+++ b/tests/sh/test_install_gpu_summary_probe_sources.sh
@@ -172,6 +172,22 @@ GPU: 2
         TARGET_GRAPHICS_VERSION: gfx1201
 EOF
 # amd-smi 6.1.1 has MARKET_NAME and no TARGET_GRAPHICS_VERSION, so the name picks the wheel.
+cat > "$WORK/smi_e_two_identity" <<'EOF'
+GPU: 0
+    HIP_ID: 0
+GPU: 1
+    HIP_ID: 1
+EOF
+# Two of the same card on an amd-smi with no TARGET_GRAPHICS_VERSION: the names match, so
+# whichever ordinal wins infers the same arch. Not ambiguous, so not declined.
+cat > "$WORK/smi_two_same_nogfx" <<'EOF'
+GPU: 0
+    ASIC:
+        MARKET_NAME: AMD Instinct MI300X
+GPU: 1
+    ASIC:
+        MARKET_NAME: AMD Instinct MI300X
+EOF
 cat > "$WORK/smi_two_nogfx" <<'EOF'
 GPU: 0
     ASIC:
@@ -316,7 +332,12 @@ assert_eq "an out-of-range mask falls back to adapter 0" \
     "$(STUB_AMDSMI_E="$WORK/smi_e_identity" summary "$WORK/empty" "$WORK/smi_three" 9)"
 # No gfx token anywhere: the name is all there is, so it must be the selected card's.
 assert_eq "a nameless-arch build still names the selected adapter" \
-    "|AMD Radeon AI PRO R9700" "$(summary "$WORK/empty" "$WORK/smi_two_nogfx" 1)"
+    "|AMD Radeon AI PRO R9700" \
+    "$(STUB_AMDSMI_E="$WORK/smi_e_two_identity" summary "$WORK/empty" "$WORK/smi_two_nogfx" 1)"
+assert_eq "and declines without a map, since the name is what the arch comes from" "|" \
+    "$(summary "$WORK/empty" "$WORK/smi_two_nogfx" 1)"
+assert_eq "two archless adapters of the same model are not ambiguous" \
+    "|AMD Instinct MI300X" "$(summary "$WORK/empty" "$WORK/smi_two_same_nogfx" 1)"
 assert_eq "neither tool installed reports nothing" "|" "$(summary - -)"
 assert_eq "both installed but silent reports nothing" "|" "$(summary "$WORK/empty" "$WORK/empty")"
 

--- a/tests/sh/test_install_gpu_summary_probe_sources.sh
+++ b/tests/sh/test_install_gpu_summary_probe_sources.sh
@@ -30,7 +30,7 @@ grep -q '_amd_smi_hip_order' "$WORK/block.sh" || {
 
 # Build PATH from scratch so host AMD tools cannot leak into the test.
 mkdir -p "$WORK/base" "$WORK/roc" "$WORK/smi"
-for _tool in awk grep sed cat tr; do
+for _tool in awk grep sed cat tr sort wc head tail; do
     _p=$(command -v "$_tool") || { echo "FATAL: $_tool not found" >&2; exit 1; }
     ln -sf "$_p" "$WORK/base/$_tool"
 done
@@ -256,6 +256,46 @@ echo "=== a device that reported no name of its own ==="
 assert_eq "keeps its arch and stays unnamed" \
     "gfx1030|" "$(summary "$WORK/roc_blank_name" "$WORK/smi_fixture")"
 
+# amd-smi discovery order is not HIP order; `amd-smi list -e` publishes HIP_ID as the map.
+# Discovery 0/1/2 is HIP 2/1/0 here, so an untranslated mask names the wrong card.
+cat > "$WORK/smi_e_reversed" <<'EOF'
+GPU: 0
+    HIP_ID: 2
+GPU: 1
+    HIP_ID: 1
+GPU: 2
+    HIP_ID: 0
+EOF
+# A partial map (hip_id reads N/A when a KFD node is unreachable) is not a mapping.
+cat > "$WORK/smi_e_partial" <<'EOF'
+GPU: 0
+    HIP_ID: 2
+GPU: 1
+    HIP_ID: N/A
+GPU: 2
+    HIP_ID: 0
+EOF
+
+cat > "$WORK/smi_e_identity" <<'EOF'
+GPU: 0
+    HIP_ID: 0
+GPU: 1
+    HIP_ID: 1
+GPU: 2
+    HIP_ID: 2
+EOF
+# Two of the same card: every ordinal yields the same arch, so there is nothing to decline.
+cat > "$WORK/smi_two_same" <<'EOF'
+GPU: 0
+    ASIC:
+        MARKET_NAME: AMD Instinct MI300X
+        TARGET_GRAPHICS_VERSION: gfx942
+GPU: 1
+    ASIC:
+        MARKET_NAME: AMD Instinct MI300X
+        TARGET_GRAPHICS_VERSION: gfx942
+EOF
+
 echo "=== amd-smi only ==="
 # The arch comes from `static --asic`: `amd-smi list` carries no gfx token at all.
 assert_eq "arch and name both come from amd-smi" \
@@ -265,13 +305,15 @@ assert_eq "an older title-cased Market Name still works" \
 assert_eq "an amd-smi name survives a colon in the middle" \
     "gfx942|AMD Instinct MI300X OAM: 750W SKU" "$(summary "$WORK/empty" "$WORK/smi_colon")"
 assert_eq "each adapter is announced with its own name, device 0" \
-    "gfx90a|AMD Instinct MI210" "$(summary "$WORK/empty" "$WORK/smi_three" 0)"
-assert_eq "device 1" \
-    "gfx1100|AMD Radeon RX 7900 XTX" "$(summary "$WORK/empty" "$WORK/smi_three" 1)"
-assert_eq "device 2" \
-    "gfx1201|AMD Radeon AI PRO R9700" "$(summary "$WORK/empty" "$WORK/smi_three" 2)"
+    "gfx90a|AMD Instinct MI210" \
+    "$(STUB_AMDSMI_E="$WORK/smi_e_identity" summary "$WORK/empty" "$WORK/smi_three" 0)"
+assert_eq "device 1" "gfx1100|AMD Radeon RX 7900 XTX" \
+    "$(STUB_AMDSMI_E="$WORK/smi_e_identity" summary "$WORK/empty" "$WORK/smi_three" 1)"
+assert_eq "device 2" "gfx1201|AMD Radeon AI PRO R9700" \
+    "$(STUB_AMDSMI_E="$WORK/smi_e_identity" summary "$WORK/empty" "$WORK/smi_three" 2)"
 assert_eq "an out-of-range mask falls back to adapter 0" \
-    "gfx90a|AMD Instinct MI210" "$(summary "$WORK/empty" "$WORK/smi_three" 9)"
+    "gfx90a|AMD Instinct MI210" \
+    "$(STUB_AMDSMI_E="$WORK/smi_e_identity" summary "$WORK/empty" "$WORK/smi_three" 9)"
 # No gfx token anywhere: the name is all there is, so it must be the selected card's.
 assert_eq "a nameless-arch build still names the selected adapter" \
     "|AMD Radeon AI PRO R9700" "$(summary "$WORK/empty" "$WORK/smi_two_nogfx" 1)"
@@ -293,35 +335,22 @@ assert_eq "and the duplicate before it keeps its own name" \
 assert_eq "two identical cards are still two devices" \
     "gfx1201|AMD Radeon AI PRO R9700" "$(summary "$WORK/roc_twins" "$WORK/empty" 2)"
 
-# amd-smi discovery order is not HIP order; `amd-smi list -e` publishes HIP_ID as the map.
-# Discovery 0/1/2 is HIP 2/1/0 here, so an untranslated mask names the wrong card.
-cat > "$WORK/smi_e_reversed" <<'EOF'
-GPU: 0
-    HIP_ID: 2
-GPU: 1
-    HIP_ID: 1
-GPU: 2
-    HIP_ID: 0
-EOF
-# A partial map (hip_id reads N/A when a KFD node is unreachable) is not a mapping.
-cat > "$WORK/smi_e_partial" <<'EOF'
-GPU: 0
-    HIP_ID: 2
-GPU: 1
-    HIP_ID: N/A
-GPU: 2
-    HIP_ID: 0
-EOF
-
 echo "=== amd-smi ordinals are translated into HIP order ==="
 assert_eq "HIP 0 is discovery 2" "gfx1201|AMD Radeon AI PRO R9700" \
     "$(STUB_AMDSMI_E="$WORK/smi_e_reversed" summary "$WORK/empty" "$WORK/smi_three" 0)"
 assert_eq "HIP 2 is discovery 0" "gfx90a|AMD Instinct MI210" \
     "$(STUB_AMDSMI_E="$WORK/smi_e_reversed" summary "$WORK/empty" "$WORK/smi_three" 2)"
-assert_eq "an older CLI that rejects -e keeps discovery order" "gfx90a|AMD Instinct MI210" \
+# No usable map and the adapters disagree on arch: report nothing rather than name one
+# card while the mask selects another.
+assert_eq "an older CLI that rejects -e declines on unlike adapters" "|" \
     "$(summary "$WORK/empty" "$WORK/smi_three" 0)"
-assert_eq "a partial map is declined, not half-applied" "gfx90a|AMD Instinct MI210" \
+assert_eq "a partial map is declined, not half-applied" "|" \
     "$(STUB_AMDSMI_E="$WORK/smi_e_partial" summary "$WORK/empty" "$WORK/smi_three" 0)"
+# Identical adapters, and a single adapter, are never ambiguous.
+assert_eq "identical adapters still resolve without a map" \
+    "gfx942|AMD Instinct MI300X" "$(summary "$WORK/empty" "$WORK/smi_two_same" 1)"
+assert_eq "one adapter resolves without a map" \
+    "gfx1100|AMD Radeon RX 7900 XTX" "$(summary "$WORK/empty" "$WORK/smi_fixture" 0)"
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed"

--- a/tests/sh/test_install_gpu_summary_probe_sources.sh
+++ b/tests/sh/test_install_gpu_summary_probe_sources.sh
@@ -13,6 +13,7 @@ FAIL=0
 
 {
     sed -n '/^_rocminfo_gpu_records()/,/^}/p' "$INSTALL_SH"
+    sed -n '/^_amd_smi_gpu_records()/,/^}/p' "$INSTALL_SH"
     echo ""
     # Extract the probe and selection block.
     awk '/^    _gpu_disp_gfx_all=""/ {on=1}
@@ -21,6 +22,8 @@ FAIL=0
 } > "$WORK/block.sh"
 grep -q '_gpu_disp_record=' "$WORK/block.sh" || {
     echo "FATAL: GPU summary probe block not found in $INSTALL_SH" >&2; exit 1; }
+grep -q '_amd_smi_gpu_records' "$WORK/block.sh" || {
+    echo "FATAL: the amd-smi record parser is not wired into the block" >&2; exit 1; }
 
 # Build PATH from scratch so host AMD tools cannot leak into the test.
 mkdir -p "$WORK/base" "$WORK/roc" "$WORK/smi"
@@ -147,6 +150,37 @@ GPU: 0
         MARKET_NAME: AMD Instinct MI300X OAM: 750W SKU
         TARGET_GRAPHICS_VERSION: gfx942
 EOF
+# Three adapters. The arch was indexed by the visible-device mask while the name was
+# always the first adapter's, so selecting a later card announced another card's name.
+cat > "$WORK/smi_three" <<'EOF'
+GPU: 0
+    ASIC:
+        MARKET_NAME: AMD Instinct MI210
+        VENDOR_ID: 0x1002
+        TARGET_GRAPHICS_VERSION: gfx90a
+GPU: 1
+    ASIC:
+        MARKET_NAME: AMD Radeon RX 7900 XTX
+        VENDOR_ID: 0x1002
+        TARGET_GRAPHICS_VERSION: gfx1100
+GPU: 2
+    ASIC:
+        MARKET_NAME: AMD Radeon AI PRO R9700
+        VENDOR_ID: 0x1002
+        TARGET_GRAPHICS_VERSION: gfx1201
+EOF
+# amd-smi 6.1.1 ships MARKET_NAME with no TARGET_GRAPHICS_VERSION, so the arch is
+# inferred from the name, which makes the name the thing that picks the wheel.
+cat > "$WORK/smi_two_nogfx" <<'EOF'
+GPU: 0
+    ASIC:
+        MARKET_NAME: AMD Radeon RX 7900 XTX
+        VENDOR_ID: 0x1002
+GPU: 1
+    ASIC:
+        MARKET_NAME: AMD Radeon AI PRO R9700
+        VENDOR_ID: 0x1002
+EOF
 # The #7307 reporter's shape: a Ryzen iGPU plus two IDENTICAL R9700s. The two dGPU
 # records are byte-identical, so a selector that folds duplicate lines away resolves
 # device 2 back to ordinal 0 -- the iGPU.
@@ -230,6 +264,17 @@ assert_eq "an older title-cased Market Name still works" \
     "gfx1100|AMD Radeon RX 7900 XTX" "$(summary "$WORK/empty" "$WORK/smi_titlecase")"
 assert_eq "an amd-smi name survives a colon in the middle" \
     "gfx942|AMD Instinct MI300X OAM: 750W SKU" "$(summary "$WORK/empty" "$WORK/smi_colon")"
+assert_eq "each adapter is announced with its own name, device 0" \
+    "gfx90a|AMD Instinct MI210" "$(summary "$WORK/empty" "$WORK/smi_three" 0)"
+assert_eq "device 1" \
+    "gfx1100|AMD Radeon RX 7900 XTX" "$(summary "$WORK/empty" "$WORK/smi_three" 1)"
+assert_eq "device 2" \
+    "gfx1201|AMD Radeon AI PRO R9700" "$(summary "$WORK/empty" "$WORK/smi_three" 2)"
+assert_eq "an out-of-range mask falls back to adapter 0" \
+    "gfx90a|AMD Instinct MI210" "$(summary "$WORK/empty" "$WORK/smi_three" 9)"
+# No gfx token anywhere: the name is all there is, so it must be the selected card's.
+assert_eq "a nameless-arch build still names the selected adapter" \
+    "|AMD Radeon AI PRO R9700" "$(summary "$WORK/empty" "$WORK/smi_two_nogfx" 1)"
 assert_eq "neither tool installed reports nothing" "|" "$(summary - -)"
 assert_eq "both installed but silent reports nothing" "|" "$(summary "$WORK/empty" "$WORK/empty")"
 

--- a/tests/sh/test_install_gpu_summary_probe_sources.sh
+++ b/tests/sh/test_install_gpu_summary_probe_sources.sh
@@ -33,11 +33,15 @@ cat > "$WORK/roc/rocminfo" <<'STUB'
 [ -s "$STUB_ROCMINFO" ] || exit 1
 cat "$STUB_ROCMINFO"
 STUB
+# `amd-smi list` prints BDF / UUID / KFD_ID / NODE_ID / PARTITION_ID and no gfx
+# token, so the arch always has to come from `static --asic`. The stub used to leak
+# TARGET_GRAPHICS_VERSION into `list`, which meant the fallthrough between the two
+# subcommands was never exercised.
 cat > "$WORK/smi/amd-smi" <<'STUB'
 #!/bin/sh
 [ -s "$STUB_AMDSMI" ] || exit 1
 case "$1" in
-    list)   sed -n '/^GPU/p;/TARGET_GRAPHICS_VERSION/p' "$STUB_AMDSMI" ;;
+    list)   sed -n 's/^\(GPU: [0-9]*\).*/\1  BDF: 0000:03:00.0  UUID: aaaa-bbbb  KFD_ID: 1/p' "$STUB_AMDSMI" ;;
     static) cat "$STUB_AMDSMI" ;;
 esac
 STUB
@@ -58,10 +62,12 @@ summary() {
     _path="$WORK/base"
     [ "$1" != "-" ] && _path="$WORK/roc:$_path"
     [ "$2" != "-" ] && _path="$WORK/smi:$_path"
+    # install.sh runs this block under `set -e`; match it so a guard that aborts the
+    # installer cannot pass here.
     env -i PATH="$_path" \
         STUB_ROCMINFO="$1" STUB_AMDSMI="$2" \
         ${3:+HIP_VISIBLE_DEVICES="$3"} \
-        /bin/bash -c '. "$1"; printf "%s|%s\n" "$_gpu_disp_gfx" "$_gpu_disp_mkt"' _ "$WORK/block.sh"
+        /bin/bash -c 'set -eu; . "$1"; printf "%s|%s\n" "$_gpu_disp_gfx" "$_gpu_disp_mkt"' _ "$WORK/block.sh"
 }
 
 cat > "$WORK/roc_gpu" <<'EOF'
@@ -118,12 +124,83 @@ Agent 3
   Marketing Name:          AMD Radeon RX 7900 XTX
   Device Type:             GPU
 EOF
-# "Market Name" with a space is the spelling install.sh's amd-smi parser matches.
+# amd-smi upper-cases every key in its human-readable output, so MARKET_NAME is what
+# a real host prints. The old fixture spelled it "Market Name" -- the one spelling the
+# parser happened to match -- so the naming path was green here and dead in production.
 cat > "$WORK/smi_fixture" <<'EOF'
+GPU: 0
+    ASIC:
+        MARKET_NAME: AMD Radeon RX 7900 XTX
+        TARGET_GRAPHICS_VERSION: gfx1100
+EOF
+# Older amd-smi builds print it title-cased; both spellings must still work.
+cat > "$WORK/smi_titlecase" <<'EOF'
 GPU: 0
     ASIC:
         Market Name: 		 AMD Radeon RX 7900 XTX
         TARGET_GRAPHICS_VERSION: gfx1100
+EOF
+# The Instinct OAM SKUs put ": " inside the name, which -F'[:|]' truncated.
+cat > "$WORK/smi_colon" <<'EOF'
+GPU: 0
+    ASIC:
+        MARKET_NAME: AMD Instinct MI300X OAM: 750W SKU
+        TARGET_GRAPHICS_VERSION: gfx942
+EOF
+# The #7307 reporter's shape: a Ryzen iGPU plus two IDENTICAL R9700s. The two dGPU
+# records are byte-identical, so a selector that folds duplicate lines away resolves
+# device 2 back to ordinal 0 -- the iGPU.
+cat > "$WORK/roc_twins" <<'EOF'
+Agent 1
+*******
+  Name:                    AMD Ryzen 9 9950X 16-Core Processor
+  Marketing Name:          AMD Ryzen 9 9950X 16-Core Processor
+  Device Type:             CPU
+*******
+Agent 2
+*******
+  Name:                    gfx1036
+  Marketing Name:          AMD Radeon Graphics
+  Device Type:             GPU
+*******
+Agent 3
+*******
+  Name:                    gfx1201
+  Marketing Name:          AMD Radeon AI PRO R9700
+  Device Type:             GPU
+*******
+Agent 4
+*******
+  Name:                    gfx1201
+  Marketing Name:          AMD Radeon AI PRO R9700
+  Device Type:             GPU
+EOF
+# Three devices, two sharing an arch: the ordinal past the duplicate is the one the
+# old deduplicating selector could not reach.
+cat > "$WORK/roc_three_dup" <<'EOF'
+Agent 1
+*******
+  Name:                    AMD EPYC 9654 96-Core Processor
+  Marketing Name:          AMD EPYC 9654 96-Core Processor
+  Device Type:             CPU
+*******
+Agent 2
+*******
+  Name:                    gfx90a:sramecc+:xnack-
+  Marketing Name:          AMD Instinct MI210
+  Device Type:             GPU
+*******
+Agent 3
+*******
+  Name:                    gfx1100
+  Marketing Name:          AMD Radeon RX 7900 XTX
+  Device Type:             GPU
+*******
+Agent 4
+*******
+  Name:                    gfx1100
+  Marketing Name:          AMD Radeon PRO W7900
+  Device Type:             GPU
 EOF
 : > "$WORK/empty"
 
@@ -146,8 +223,13 @@ assert_eq "keeps its arch and stays unnamed" \
     "gfx1030|" "$(summary "$WORK/roc_blank_name" "$WORK/smi_fixture")"
 
 echo "=== amd-smi only ==="
+# The arch comes from `static --asic`: `amd-smi list` carries no gfx token at all.
 assert_eq "arch and name both come from amd-smi" \
     "gfx1100|AMD Radeon RX 7900 XTX" "$(summary "$WORK/empty" "$WORK/smi_fixture")"
+assert_eq "an older title-cased Market Name still works" \
+    "gfx1100|AMD Radeon RX 7900 XTX" "$(summary "$WORK/empty" "$WORK/smi_titlecase")"
+assert_eq "an amd-smi name survives a colon in the middle" \
+    "gfx942|AMD Instinct MI300X OAM: 750W SKU" "$(summary "$WORK/empty" "$WORK/smi_colon")"
 assert_eq "neither tool installed reports nothing" "|" "$(summary - -)"
 assert_eq "both installed but silent reports nothing" "|" "$(summary "$WORK/empty" "$WORK/empty")"
 
@@ -156,6 +238,16 @@ assert_eq "device 0" \
     "gfx90a|AMD Instinct MI210" "$(summary "$WORK/roc_two_gpus" "$WORK/empty" 0)"
 assert_eq "device 1" \
     "gfx1100|AMD Radeon RX 7900 XTX" "$(summary "$WORK/roc_two_gpus" "$WORK/empty" 1)"
+# Driven through the real block, not a restated selector: a deduplicating selector
+# resolves both gfx1100 slots to one entry and sends device 2 back to device 0.
+assert_eq "an ordinal past a duplicated arch still selects its own device" \
+    "gfx1100|AMD Radeon PRO W7900" "$(summary "$WORK/roc_three_dup" "$WORK/empty" 2)"
+assert_eq "and the duplicate before it keeps its own name" \
+    "gfx1100|AMD Radeon RX 7900 XTX" "$(summary "$WORK/roc_three_dup" "$WORK/empty" 1)"
+# Two of the same card produce two byte-identical records; the second one must still
+# be a device, not a duplicate line to be folded away.
+assert_eq "two identical cards are still two devices" \
+    "gfx1201|AMD Radeon AI PRO R9700" "$(summary "$WORK/roc_twins" "$WORK/empty" 2)"
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed"

--- a/tests/sh/test_install_gpu_summary_probe_sources.sh
+++ b/tests/sh/test_install_gpu_summary_probe_sources.sh
@@ -1,0 +1,162 @@
+#!/bin/bash
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+# Drive install.sh's AMD summary with stub rocminfo and amd-smi outputs.
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INSTALL_SH="$SCRIPT_DIR/../../install.sh"
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+PASS=0
+FAIL=0
+
+{
+    sed -n '/^_rocminfo_gpu_records()/,/^}/p' "$INSTALL_SH"
+    echo ""
+    # Extract the probe and selection block.
+    awk '/^    _gpu_disp_gfx_all=""/ {on=1}
+         on && /UNSLOTH_ROCM_GFX_ARCH env override/ {exit}
+         on {print}' "$INSTALL_SH"
+} > "$WORK/block.sh"
+grep -q '_gpu_disp_record=' "$WORK/block.sh" || {
+    echo "FATAL: GPU summary probe block not found in $INSTALL_SH" >&2; exit 1; }
+
+# Build PATH from scratch so host AMD tools cannot leak into the test.
+mkdir -p "$WORK/base" "$WORK/roc" "$WORK/smi"
+for _tool in awk grep sed cat tr; do
+    _p=$(command -v "$_tool") || { echo "FATAL: $_tool not found" >&2; exit 1; }
+    ln -sf "$_p" "$WORK/base/$_tool"
+done
+cat > "$WORK/roc/rocminfo" <<'STUB'
+#!/bin/sh
+[ -s "$STUB_ROCMINFO" ] || exit 1
+cat "$STUB_ROCMINFO"
+STUB
+cat > "$WORK/smi/amd-smi" <<'STUB'
+#!/bin/sh
+[ -s "$STUB_AMDSMI" ] || exit 1
+case "$1" in
+    list)   sed -n '/^GPU/p;/TARGET_GRAPHICS_VERSION/p' "$STUB_AMDSMI" ;;
+    static) cat "$STUB_AMDSMI" ;;
+esac
+STUB
+chmod +x "$WORK/roc/rocminfo" "$WORK/smi/amd-smi"
+
+assert_eq() {
+    _label="$1"; _expected="$2"; _actual="$3"
+    if [ "$_actual" = "$_expected" ]; then
+        echo "  PASS: $_label"; PASS=$((PASS + 1))
+    else
+        echo "  FAIL: $_label (expected '$_expected', got '$_actual')"; FAIL=$((FAIL + 1))
+    fi
+}
+
+# $1 rocminfo fixture ("-" = the tool is not installed, empty file = installed but silent)
+# $2 amd-smi fixture, same convention. $3 visible-device mask. Prints "gfx|name".
+summary() {
+    _path="$WORK/base"
+    [ "$1" != "-" ] && _path="$WORK/roc:$_path"
+    [ "$2" != "-" ] && _path="$WORK/smi:$_path"
+    env -i PATH="$_path" \
+        STUB_ROCMINFO="$1" STUB_AMDSMI="$2" \
+        ${3:+HIP_VISIBLE_DEVICES="$3"} \
+        /bin/bash -c '. "$1"; printf "%s|%s\n" "$_gpu_disp_gfx" "$_gpu_disp_mkt"' _ "$WORK/block.sh"
+}
+
+cat > "$WORK/roc_gpu" <<'EOF'
+Agent 1
+*******
+  Name:                    AMD Ryzen 9 5950X 16-Core Processor
+  Marketing Name:          AMD Ryzen 9 5950X 16-Core Processor
+  Vendor Name:             CPU
+  Device Type:             CPU
+*******
+Agent 2
+*******
+  Name:                    gfx1151
+  Marketing Name:          AMD Radeon Graphics
+  Vendor Name:             AMD
+  Device Type:             GPU
+EOF
+cat > "$WORK/roc_cpu_only" <<'EOF'
+Agent 1
+*******
+  Name:                    AMD Ryzen 9 5950X 16-Core Processor
+  Marketing Name:          AMD Ryzen 9 5950X 16-Core Processor
+  Vendor Name:             CPU
+  Device Type:             CPU
+EOF
+cat > "$WORK/roc_blank_name" <<'EOF'
+Agent 1
+*******
+  Name:                    AMD Ryzen 9 5950X 16-Core Processor
+  Marketing Name:          AMD Ryzen 9 5950X 16-Core Processor
+  Device Type:             CPU
+*******
+Agent 2
+*******
+  Name:                    gfx1030
+  Device Type:             GPU
+EOF
+cat > "$WORK/roc_two_gpus" <<'EOF'
+Agent 1
+*******
+  Name:                    AMD EPYC 7763 64-Core Processor
+  Marketing Name:          AMD EPYC 7763 64-Core Processor
+  Device Type:             CPU
+*******
+Agent 2
+*******
+  Name:                    gfx90a
+  Marketing Name:          AMD Instinct MI210
+  Device Type:             GPU
+*******
+Agent 3
+*******
+  Name:                    gfx1100
+  Marketing Name:          AMD Radeon RX 7900 XTX
+  Device Type:             GPU
+EOF
+# "Market Name" with a space is the spelling install.sh's amd-smi parser matches.
+cat > "$WORK/smi_fixture" <<'EOF'
+GPU: 0
+    ASIC:
+        Market Name: 		 AMD Radeon RX 7900 XTX
+        TARGET_GRAPHICS_VERSION: gfx1100
+EOF
+: > "$WORK/empty"
+
+echo "=== rocminfo enumerates the device ==="
+assert_eq "its arch and its own name are used" \
+    "gfx1151|AMD Radeon Graphics" "$(summary "$WORK/roc_gpu" "$WORK/smi_fixture")"
+assert_eq "and amd-smi is not consulted for the name" \
+    "gfx1151|AMD Radeon Graphics" "$(summary "$WORK/roc_gpu" "$WORK/empty")"
+
+echo "=== rocminfo names something but enumerates no device ==="
+# The CPU-only record must not survive to beat the arch amd-smi found.
+assert_eq "amd-smi supplies the arch" \
+    "gfx1100|AMD Radeon RX 7900 XTX" "$(summary "$WORK/roc_cpu_only" "$WORK/smi_fixture")"
+assert_eq "with no amd-smi, the APU fallback name still shows" \
+    "|AMD Ryzen 9 5950X 16-Core Processor" "$(summary "$WORK/roc_cpu_only" "$WORK/empty")"
+
+echo "=== a device that reported no name of its own ==="
+# Borrowing amd-smi's unindexed first row would label this card as another one.
+assert_eq "keeps its arch and stays unnamed" \
+    "gfx1030|" "$(summary "$WORK/roc_blank_name" "$WORK/smi_fixture")"
+
+echo "=== amd-smi only ==="
+assert_eq "arch and name both come from amd-smi" \
+    "gfx1100|AMD Radeon RX 7900 XTX" "$(summary "$WORK/empty" "$WORK/smi_fixture")"
+assert_eq "neither tool installed reports nothing" "|" "$(summary - -)"
+assert_eq "both installed but silent reports nothing" "|" "$(summary "$WORK/empty" "$WORK/empty")"
+
+echo "=== the mask selects a device, and its name follows ==="
+assert_eq "device 0" \
+    "gfx90a|AMD Instinct MI210" "$(summary "$WORK/roc_two_gpus" "$WORK/empty" 0)"
+assert_eq "device 1" \
+    "gfx1100|AMD Radeon RX 7900 XTX" "$(summary "$WORK/roc_two_gpus" "$WORK/empty" 1)"
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/tests/sh/test_rocminfo_gpu_name_7307.sh
+++ b/tests/sh/test_rocminfo_gpu_name_7307.sh
@@ -20,8 +20,20 @@ _FUNC_FILE=$(mktemp)
 . "$_FUNC_FILE"
 rm -f "$_FUNC_FILE"
 
-# The visible-device pick both scripts apply to the record list.
-_pick() { awk -v idx="$1" 'NF { a[n++]=$0 } END { if(idx>=n) idx=0; if(n>0) print a[idx] }'; }
+# The visible-device pick both scripts apply to the record list, read OUT OF the
+# scripts rather than restated here: a restated copy cannot fail when the real one
+# changes, and re-adding the old `!seen[$0]++` dedup to production used to leave
+# this file green while collapsing duplicate-arch ordinals.
+_extract_pick() { awk '/_[a-z_]*record=\$\(printf/ {
+                           getline
+                           sub(/^[[:space:]]*'"'"'/, "")
+                           sub(/'"'"'\)$/, "")
+                           print; exit
+                       }' "$1"; }
+_PICK_PROG=$(_extract_pick "$INSTALL_SH")
+_PICK_PROG_SETUP=$(_extract_pick "$SETUP_SH")
+[ -n "$_PICK_PROG" ] || { echo "FATAL: no record selector found in $INSTALL_SH" >&2; exit 1; }
+_pick() { awk -v idx="$1" "$_PICK_PROG"; }
 
 assert_eq() {
     _label="$1"; _expected="$2"; _actual="$3"
@@ -36,6 +48,10 @@ assert_eq() {
 _body_install=$(sed -n '/^_rocminfo_gpu_records()/,/^}/p' "$INSTALL_SH" | tail -n +2)
 _body_setup=$(sed -n '/^_setup_rocminfo_gpu_records()/,/^}/p' "$SETUP_SH" | tail -n +2)
 assert_eq "install.sh and setup.sh parsers are identical" "$_body_install" "$_body_setup"
+# The parser is only half the contract: the two scripts must also select the same
+# record from it, or one names the card the other does not.
+assert_eq "install.sh and setup.sh record selectors are identical" \
+    "$_PICK_PROG" "$_PICK_PROG_SETUP"
 
 # Strix Halo lists the misleading CPU marketing name first.
 STRIX=$(cat <<'EOF'
@@ -195,6 +211,70 @@ Agent 1
   Device Type:             CPU
 EOF
 )
+# The ISA section repeats the agent's target id verbatim. Rejecting it is what the
+# leading ^ in the gfx match does; without the anchor, `match` would find gfx90a at
+# offset 20 of "amdgcn-amd-amdhsa--gfx90a:sramecc+:xnack-" while substr() still cuts
+# from RLENGTH+1, emitting a bogus "amdgcn" device and shifting every later ordinal.
+ISA_TARGET_ID=$(cat <<'EOF'
+Agent 1
+*******
+  Name:                    AMD EPYC 9654 96-Core Processor
+  Marketing Name:          AMD EPYC 9654 96-Core Processor
+  Vendor Name:             CPU
+  Device Type:             CPU
+*******
+Agent 2
+*******
+  Name:                    gfx90a:sramecc+:xnack-
+  Marketing Name:          AMD Instinct MI210
+  Vendor Name:             AMD
+  Device Type:             GPU
+  ISA Info:
+    ISA 1
+      Name:                    amdgcn-amd-amdhsa--gfx90a:sramecc+:xnack-
+*******
+Agent 3
+*******
+  Name:                    gfx1100
+  Marketing Name:          AMD Radeon RX 7900 XTX
+  Vendor Name:             AMD
+  Device Type:             GPU
+  ISA Info:
+    ISA 1
+      Name:                    amdgcn-amd-amdhsa--gfx1100
+EOF
+)
+echo "=== ISA lines repeating a target id ==="
+assert_eq "an ISA target id adds no device" \
+    "gfx90a|AMD Instinct MI210 gfx1100|AMD Radeon RX 7900 XTX" \
+    "$(printf '%s\n' "$ISA_TARGET_ID" | _rocminfo_gpu_records | tr '\n' ' ' | sed 's/ $//')"
+assert_eq "so device 1 is still the second card" \
+    "gfx1100|AMD Radeon RX 7900 XTX" \
+    "$(printf '%s\n' "$ISA_TARGET_ID" | _rocminfo_gpu_records | _pick 1)"
+
+# Every ISA ROCr can report today has at most four characters after "gfx"
+# (ROCR-Runtime's processor table tops out at gfx1201 / gfx1310), so the width cap
+# costs nothing now. If AMD ever ships a longer one, the trailing-character guard
+# must drop the device rather than report a silently truncated arch that would route
+# the wrong wheel.
+WIDE=$(cat <<'EOF'
+Agent 1
+*******
+  Name:                    AMD EPYC 9654 96-Core Processor
+  Marketing Name:          AMD EPYC 9654 96-Core Processor
+  Device Type:             CPU
+*******
+Agent 2
+*******
+  Name:                    gfx12500
+  Marketing Name:          AMD Future Accelerator
+  Device Type:             GPU
+EOF
+)
+echo "=== arch wider than the cap ==="
+assert_eq "an over-long gfx token is dropped, not truncated" \
+    "|AMD EPYC 9654 96-Core Processor" "$(printf '%s\n' "$WIDE" | _rocminfo_gpu_records)"
+
 echo "=== no GPU agent ==="
 assert_eq "falls back to the first marketing name with no arch" \
     "|AMD Ryzen 7 5700U with Radeon Graphics" "$(printf '%s\n' "$APU" | _rocminfo_gpu_records)"

--- a/tests/sh/test_rocminfo_gpu_name_7307.sh
+++ b/tests/sh/test_rocminfo_gpu_name_7307.sh
@@ -53,6 +53,37 @@ assert_eq "install.sh and setup.sh record selectors are identical" \
 _smi_install=$(sed -n '/^_amd_smi_gpu_records()/,/^}/p' "$INSTALL_SH" | tail -n +2)
 _smi_setup=$(sed -n '/^_setup_amd_smi_gpu_records()/,/^}/p' "$SETUP_SH" | tail -n +2)
 assert_eq "install.sh and setup.sh amd-smi parsers are identical" "$_smi_install" "$_smi_setup"
+# So does the amd-smi-to-HIP reorder: it decides which record the mask lands on.
+_hip_install=$(sed -n '/^_amd_smi_hip_order()/,/^}/p' "$INSTALL_SH" | tail -n +2)
+_hip_setup=$(sed -n '/^_setup_amd_smi_hip_order()/,/^}/p' "$SETUP_SH" | tail -n +2)
+assert_eq "install.sh and setup.sh amd-smi HIP reorders are identical" "$_hip_install" "$_hip_setup"
+[ -n "$_hip_install" ] || { echo "FATAL: no amd-smi HIP reorder found" >&2; exit 1; }
+
+# POSIX awk forbids a physical newline in a -v value, and gawk --posix makes it fatal, so
+# the multi-line record list has to reach awk some other way. Run the real helper under a
+# strict awk when the host has one; a host without it records a skip rather than a pass.
+if gawk --posix 'BEGIN { exit 0 }' >/dev/null 2>&1; then
+    _POSIX_AWK_DIR=$(mktemp -d)
+    printf '#!/bin/sh\nexec %s --posix "$@"\n' "$(command -v gawk)" > "$_POSIX_AWK_DIR/awk"
+    chmod +x "$_POSIX_AWK_DIR/awk"
+    _HIP_FILE=$(mktemp)
+    sed -n '/^_amd_smi_hip_order()/,/^}/p' "$INSTALL_SH" > "$_HIP_FILE"
+    # shellcheck disable=SC1090
+    . "$_HIP_FILE"
+    _RECS="gfx90a|AMD Instinct MI210
+gfx1100|AMD Radeon RX 7900 XTX"
+    echo "=== strict awk ==="
+    assert_eq "the HIP reorder runs under a POSIX awk" \
+        "gfx1100|AMD Radeon RX 7900 XTX gfx90a|AMD Instinct MI210" \
+        "$(printf 'GPU: 0\n    HIP_ID: 1\nGPU: 1\n    HIP_ID: 0\n' \
+           | PATH="$_POSIX_AWK_DIR:$PATH" _amd_smi_hip_order "$_RECS" | tr '\n' ' ' | sed 's/ $//')"
+    assert_eq "and declines cleanly there too, rather than dying" \
+        "gfx90a|AMD Instinct MI210 gfx1100|AMD Radeon RX 7900 XTX" \
+        "$(printf '' | PATH="$_POSIX_AWK_DIR:$PATH" _amd_smi_hip_order "$_RECS" | tr '\n' ' ' | sed 's/ $//')"
+    rm -rf "$_POSIX_AWK_DIR" "$_HIP_FILE"
+else
+    echo "  SKIP: no gawk --posix on this host, strict-awk check not run"
+fi
 [ -n "$_smi_install" ] || { echo "FATAL: no amd-smi record parser found" >&2; exit 1; }
 
 # Strix Halo lists the misleading CPU marketing name first.

--- a/tests/sh/test_rocminfo_gpu_name_7307.sh
+++ b/tests/sh/test_rocminfo_gpu_name_7307.sh
@@ -20,10 +20,8 @@ _FUNC_FILE=$(mktemp)
 . "$_FUNC_FILE"
 rm -f "$_FUNC_FILE"
 
-# The visible-device pick both scripts apply to the record list, read OUT OF the
-# scripts rather than restated here: a restated copy cannot fail when the real one
-# changes, and re-adding the old `!seen[$0]++` dedup to production used to leave
-# this file green while collapsing duplicate-arch ordinals.
+# The visible-device pick, read OUT OF the scripts: a restated copy cannot fail when
+# the real one changes (re-adding `!seen[$0]++` to production left this file green).
 _extract_pick() { awk '/_[a-z_]*record=\$\(printf/ {
                            getline
                            sub(/^[[:space:]]*'"'"'/, "")
@@ -48,8 +46,7 @@ assert_eq() {
 _body_install=$(sed -n '/^_rocminfo_gpu_records()/,/^}/p' "$INSTALL_SH" | tail -n +2)
 _body_setup=$(sed -n '/^_setup_rocminfo_gpu_records()/,/^}/p' "$SETUP_SH" | tail -n +2)
 assert_eq "install.sh and setup.sh parsers are identical" "$_body_install" "$_body_setup"
-# The parser is only half the contract: the two scripts must also select the same
-# record from it, or one names the card the other does not.
+# The scripts must also select the same record, or one names a card the other does not.
 assert_eq "install.sh and setup.sh record selectors are identical" \
     "$_PICK_PROG" "$_PICK_PROG_SETUP"
 # The amd-smi side emits the same record shape and must not drift either.
@@ -216,10 +213,9 @@ Agent 1
   Device Type:             CPU
 EOF
 )
-# The ISA section repeats the agent's target id verbatim. Rejecting it is what the
-# leading ^ in the gfx match does; without the anchor, `match` would find gfx90a at
-# offset 20 of "amdgcn-amd-amdhsa--gfx90a:sramecc+:xnack-" while substr() still cuts
-# from RLENGTH+1, emitting a bogus "amdgcn" device and shifting every later ordinal.
+# The ISA section repeats the target id verbatim; the leading ^ is what rejects it.
+# Unanchored, match() finds gfx90a at offset 20 while substr() still cuts from
+# RLENGTH+1, emitting a bogus "amdgcn" device and shifting every later ordinal.
 ISA_TARGET_ID=$(cat <<'EOF'
 Agent 1
 *******
@@ -257,11 +253,8 @@ assert_eq "so device 1 is still the second card" \
     "gfx1100|AMD Radeon RX 7900 XTX" \
     "$(printf '%s\n' "$ISA_TARGET_ID" | _rocminfo_gpu_records | _pick 1)"
 
-# Every ISA ROCr can report today has at most four characters after "gfx"
-# (ROCR-Runtime's processor table tops out at gfx1201 / gfx1310), so the width cap
-# costs nothing now. If AMD ever ships a longer one, the trailing-character guard
-# must drop the device rather than report a silently truncated arch that would route
-# the wrong wheel.
+# ROCr's processor table tops out at four characters after "gfx", so the cap costs
+# nothing today. A longer one must drop the device, not report a truncated arch.
 WIDE=$(cat <<'EOF'
 Agent 1
 *******

--- a/tests/sh/test_rocminfo_gpu_name_7307.sh
+++ b/tests/sh/test_rocminfo_gpu_name_7307.sh
@@ -52,6 +52,11 @@ assert_eq "install.sh and setup.sh parsers are identical" "$_body_install" "$_bo
 # record from it, or one names the card the other does not.
 assert_eq "install.sh and setup.sh record selectors are identical" \
     "$_PICK_PROG" "$_PICK_PROG_SETUP"
+# The amd-smi side emits the same record shape and must not drift either.
+_smi_install=$(sed -n '/^_amd_smi_gpu_records()/,/^}/p' "$INSTALL_SH" | tail -n +2)
+_smi_setup=$(sed -n '/^_setup_amd_smi_gpu_records()/,/^}/p' "$SETUP_SH" | tail -n +2)
+assert_eq "install.sh and setup.sh amd-smi parsers are identical" "$_smi_install" "$_smi_setup"
+[ -n "$_smi_install" ] || { echo "FATAL: no amd-smi record parser found" >&2; exit 1; }
 
 # Strix Halo lists the misleading CPU marketing name first.
 STRIX=$(cat <<'EOF'

--- a/tests/sh/test_rocminfo_gpu_name_7307.sh
+++ b/tests/sh/test_rocminfo_gpu_name_7307.sh
@@ -1,0 +1,205 @@
+#!/bin/bash
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+# Test both rocminfo parsers against CPU-first and multi-GPU outputs (#7307).
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INSTALL_SH="$SCRIPT_DIR/../../install.sh"
+SETUP_SH="$SCRIPT_DIR/../../studio/setup.sh"
+PASS=0
+FAIL=0
+
+_FUNC_FILE=$(mktemp)
+{
+    sed -n '/^_rocminfo_gpu_records()/,/^}/p' "$INSTALL_SH"
+    echo ""
+    sed -n '/^_setup_rocminfo_gpu_records()/,/^}/p' "$SETUP_SH"
+} > "$_FUNC_FILE"
+# shellcheck disable=SC1090
+. "$_FUNC_FILE"
+rm -f "$_FUNC_FILE"
+
+# The visible-device pick both scripts apply to the record list.
+_pick() { awk -v idx="$1" 'NF { a[n++]=$0 } END { if(idx>=n) idx=0; if(n>0) print a[idx] }'; }
+
+assert_eq() {
+    _label="$1"; _expected="$2"; _actual="$3"
+    if [ "$_actual" = "$_expected" ]; then
+        echo "  PASS: $_label"; PASS=$((PASS + 1))
+    else
+        echo "  FAIL: $_label (expected '$_expected', got '$_actual')"; FAIL=$((FAIL + 1))
+    fi
+}
+
+# Installer and updater must use the same parser.
+_body_install=$(sed -n '/^_rocminfo_gpu_records()/,/^}/p' "$INSTALL_SH" | tail -n +2)
+_body_setup=$(sed -n '/^_setup_rocminfo_gpu_records()/,/^}/p' "$SETUP_SH" | tail -n +2)
+assert_eq "install.sh and setup.sh parsers are identical" "$_body_install" "$_body_setup"
+
+# Strix Halo lists the misleading CPU marketing name first.
+STRIX=$(cat <<'EOF'
+Agent 1
+*******
+  Name:                    AMD RYZEN AI MAX+ 395 w/ Radeon 8060S
+  Marketing Name:          AMD RYZEN AI MAX+ 395 w/ Radeon 8060S
+  Vendor Name:             CPU
+  Device Type:             CPU
+*******
+Agent 2
+*******
+  Name:                    gfx1151
+  Marketing Name:          AMD Radeon Graphics
+  Vendor Name:             AMD
+  Device Type:             GPU
+  ISA Info:
+    ISA 1
+      Name:                    amdgcn-amd-amdhsa--gfx1151
+      Name:                    amdgcn-amd-amdhsa--gfx11-generic
+*******
+Agent 3
+*******
+  Name:                    aie2p
+  Marketing Name:          NPU Strix Halo
+  Vendor Name:             AMD
+  Device Type:             DSP
+EOF
+)
+echo "=== CPU agent first ==="
+assert_eq "the GPU agent names the GPU, not the processor" \
+    "gfx1151|AMD Radeon Graphics" "$(printf '%s\n' "$STRIX" | _rocminfo_gpu_records)"
+assert_eq "setup.sh copy agrees" \
+    "gfx1151|AMD Radeon Graphics" "$(printf '%s\n' "$STRIX" | _setup_rocminfo_gpu_records)"
+assert_eq "the ISA section and a non-GPU agent add no records" \
+    "1" "$(printf '%s\n' "$STRIX" | _rocminfo_gpu_records | wc -l | tr -d ' ')"
+
+# Two discrete cards behind the same CPU agent.
+DUAL=$(cat <<'EOF'
+Agent 1
+*******
+  Name:                    AMD EPYC 7763 64-Core Processor
+  Marketing Name:          AMD EPYC 7763 64-Core Processor
+  Vendor Name:             CPU
+  Device Type:             CPU
+*******
+Agent 2
+*******
+  Name:                    gfx90a:sramecc+:xnack-
+  Marketing Name:          AMD Instinct MI210
+  Vendor Name:             AMD
+  Device Type:             GPU
+*******
+Agent 3
+*******
+  Name:                    gfx1100
+  Marketing Name:          AMD Radeon RX 7900 XTX
+  Vendor Name:             AMD
+  Device Type:             GPU
+EOF
+)
+echo "=== multi-GPU ==="
+assert_eq "one record per device, in agent order" \
+    "gfx90a|AMD Instinct MI210 gfx1100|AMD Radeon RX 7900 XTX" \
+    "$(printf '%s\n' "$DUAL" | _rocminfo_gpu_records | tr '\n' ' ' | sed 's/ $//')"
+assert_eq "a target id still registers as its arch" \
+    "gfx90a|AMD Instinct MI210" "$(printf '%s\n' "$DUAL" | _rocminfo_gpu_records | _pick 0)"
+assert_eq "index 1 selects the second card and its own name" \
+    "gfx1100|AMD Radeon RX 7900 XTX" "$(printf '%s\n' "$DUAL" | _rocminfo_gpu_records | _pick 1)"
+assert_eq "an out-of-range index falls back to device 0" \
+    "gfx90a|AMD Instinct MI210" "$(printf '%s\n' "$DUAL" | _rocminfo_gpu_records | _pick 9)"
+
+# Two cards of the same arch: the ordinals must not collapse.
+SAME=$(cat <<'EOF'
+Agent 1
+*******
+  Name:                    Intel(R) Xeon(R) Gold 6338
+  Marketing Name:          Intel(R) Xeon(R) Gold 6338
+  Vendor Name:             CPU
+  Device Type:             CPU
+*******
+Agent 2
+*******
+  Name:                    gfx1100
+  Marketing Name:          AMD Radeon RX 7900 XTX
+  Device Type:             GPU
+*******
+Agent 3
+*******
+  Name:                    gfx1100
+  Marketing Name:          AMD Radeon PRO W7900
+  Device Type:             GPU
+EOF
+)
+assert_eq "identical arches keep separate ordinals" \
+    "gfx1100|AMD Radeon PRO W7900" "$(printf '%s\n' "$SAME" | _rocminfo_gpu_records | _pick 1)"
+
+# A GPU agent that reports no marketing name.
+BLANK=$(cat <<'EOF'
+Agent 1
+*******
+  Name:                    AMD Ryzen 9 5950X 16-Core Processor
+  Marketing Name:          AMD Ryzen 9 5950X 16-Core Processor
+  Vendor Name:             CPU
+  Device Type:             CPU
+*******
+Agent 2
+*******
+  Name:                    gfx1030
+  Vendor Name:             AMD
+  Device Type:             GPU
+*******
+Agent 3
+*******
+  Name:                    gfx1100
+  Marketing Name:          AMD Radeon RX 7900 XTX
+  Device Type:             GPU
+EOF
+)
+echo "=== blank marketing name ==="
+assert_eq "a nameless GPU keeps its arch and an empty name" \
+    "gfx1030|" "$(printf '%s\n' "$BLANK" | _rocminfo_gpu_records | _pick 0)"
+assert_eq "and keeps its slot, so device 1 is still device 1" \
+    "gfx1100|AMD Radeon RX 7900 XTX" "$(printf '%s\n' "$BLANK" | _rocminfo_gpu_records | _pick 1)"
+assert_eq "a nameless GPU does not borrow the processor name" \
+    "" "$(printf '%s\n' "$BLANK" | _rocminfo_gpu_records | _pick 0 | cut -d'|' -f2-)"
+
+# Marketing names contain ": " on the Instinct OAM SKUs, which -F": " truncated.
+COLON=$(cat <<'EOF'
+Agent 1
+*******
+  Name:                    AMD EPYC 9654 96-Core Processor
+  Marketing Name:          AMD EPYC 9654 96-Core Processor
+  Vendor Name:             CPU
+  Device Type:             CPU
+*******
+Agent 2
+*******
+  Name:                    gfx942
+  Marketing Name:          AMD Instinct MI300X OAM: 750W SKU
+  Vendor Name:             AMD
+  Device Type:             GPU
+EOF
+)
+echo "=== embedded colon ==="
+assert_eq "the name survives the colon in the middle" \
+    "gfx942|AMD Instinct MI300X OAM: 750W SKU" "$(printf '%s\n' "$COLON" | _rocminfo_gpu_records)"
+
+# No gfx agent at all: unchanged from before, the first marketing name is reported
+# with an empty arch so the APU still gets named.
+APU=$(cat <<'EOF'
+Agent 1
+*******
+  Name:                    AMD Ryzen 7 5700U with Radeon Graphics
+  Marketing Name:          AMD Ryzen 7 5700U with Radeon Graphics
+  Vendor Name:             CPU
+  Device Type:             CPU
+EOF
+)
+echo "=== no GPU agent ==="
+assert_eq "falls back to the first marketing name with no arch" \
+    "|AMD Ryzen 7 5700U with Radeon Graphics" "$(printf '%s\n' "$APU" | _rocminfo_gpu_records)"
+assert_eq "empty input yields nothing" "" "$(printf '' | _rocminfo_gpu_records)"
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/tests/sh/test_rocminfo_gpu_name_7307.sh
+++ b/tests/sh/test_rocminfo_gpu_name_7307.sh
@@ -73,12 +73,13 @@ if gawk --posix 'BEGIN { exit 0 }' >/dev/null 2>&1; then
     _RECS="gfx90a|AMD Instinct MI210
 gfx1100|AMD Radeon RX 7900 XTX"
     echo "=== strict awk ==="
+    # The first line is the index space the records came back in, then the records.
     assert_eq "the HIP reorder runs under a POSIX awk" \
-        "gfx1100|AMD Radeon RX 7900 XTX gfx90a|AMD Instinct MI210" \
+        "hip gfx1100|AMD Radeon RX 7900 XTX gfx90a|AMD Instinct MI210" \
         "$(printf 'GPU: 0\n    HIP_ID: 1\nGPU: 1\n    HIP_ID: 0\n' \
            | PATH="$_POSIX_AWK_DIR:$PATH" _amd_smi_hip_order "$_RECS" | tr '\n' ' ' | sed 's/ $//')"
     assert_eq "and declines cleanly there too, rather than dying" \
-        "gfx90a|AMD Instinct MI210 gfx1100|AMD Radeon RX 7900 XTX" \
+        "discovery gfx90a|AMD Instinct MI210 gfx1100|AMD Radeon RX 7900 XTX" \
         "$(printf '' | PATH="$_POSIX_AWK_DIR:$PATH" _amd_smi_hip_order "$_RECS" | tr '\n' ' ' | sed 's/ $//')"
     rm -rf "$_POSIX_AWK_DIR" "$_HIP_FILE"
 else

--- a/tests/sh/test_setup_gpu_summary_probe_sources.sh
+++ b/tests/sh/test_setup_gpu_summary_probe_sources.sh
@@ -3,10 +3,9 @@
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 # Drive studio/setup.sh's AMD detection and selection with stub rocminfo and amd-smi.
 #
-# The sibling test_install_gpu_summary_probe_sources.sh covers install.sh, where the
-# result is a display label. Here it is not: $_setup_gfx is forwarded as --rocm-gfx to
-# install_llama_prebuilt.py and to the whisper installer, so a wrong ordinal picks the
-# wrong binary. This file drives the real block rather than the parser alone.
+# install.sh's value is a display label; this one is not. $_setup_gfx is forwarded as
+# --rocm-gfx to install_llama_prebuilt.py and the whisper installer, so a wrong ordinal
+# picks the wrong binary. Drives the real block, not the parser alone.
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -24,8 +23,8 @@ SKIP=0
     echo '_setup_amd_detected=false'
     echo '_setup_nvidia_usable=false'
     echo '_setup_gfx_all=""; _setup_mkt=""; _setup_amd_records=""; _setup_gfx=""'
-    # Detection through selection. NVIDIA is classified above this point and pinned
-    # false here: this file is about which AMD device gets picked, not about priority.
+    # Detection through selection. NVIDIA is pinned false: this is about which AMD
+    # device gets picked, not about vendor priority.
     awk '/^if \[ "\$_setup_nvidia_usable" != true \]; then/ {on=1}
          on && /UNSLOTH_ROCM_GFX_ARCH env override/ {exit}
          on {print}' "$SETUP_SH"
@@ -49,8 +48,7 @@ echo "rocminfo" >> "$PROBE_LOG"
 [ -s "$STUB_ROCMINFO" ] || exit 1
 cat "$STUB_ROCMINFO"
 STUB
-# `amd-smi list` prints BDF / UUID / KFD_ID and no gfx token, so the arch has to come
-# from `static --asic`; keeping the two subcommands distinct is what tests that.
+# `amd-smi list` carries no gfx token; keeping the subcommands distinct tests that.
 cat > "$WORK/smi/amd-smi" <<'STUB'
 #!/bin/sh
 echo "amd-smi $1" >> "$PROBE_LOG"
@@ -78,8 +76,7 @@ summary() {
     [ "$1" != "-" ] && _path="$WORK/roc:$_path"
     [ "$2" != "-" ] && _path="$WORK/smi:$_path"
     : > "$WORK/probes"
-    # setup.sh runs under `set -euo pipefail`; match it so a guard that would abort
-    # `unsloth studio update` cannot pass here.
+    # setup.sh runs under `set -euo pipefail`; match it.
     env -i PATH="$_path" PROBE_LOG="$WORK/probes" \
         STUB_ROCMINFO="$1" STUB_AMDSMI="$2" \
         ${3:+HIP_VISIBLE_DEVICES="$3"} \
@@ -181,8 +178,7 @@ GPU: 0
         MARKET_NAME: AMD Radeon RX 7900 XTX
         TARGET_GRAPHICS_VERSION: gfx1100
 EOF
-# Three adapters: the arch was indexed by the mask while the name was always the first
-# adapter's, so a later card was announced with another card's name.
+# Three adapters: the arch followed the mask, the name was always adapter 0's.
 cat > "$WORK/smi_three" <<'EOF'
 GPU: 0
     ASIC:
@@ -197,8 +193,7 @@ GPU: 2
         MARKET_NAME: AMD Radeon AI PRO R9700
         TARGET_GRAPHICS_VERSION: gfx1201
 EOF
-# amd-smi 6.1.1 ships MARKET_NAME with no TARGET_GRAPHICS_VERSION, so the arch is
-# inferred from the name and $_setup_gfx -- hence --rocm-gfx -- follows the name.
+# amd-smi 6.1.1 has no TARGET_GRAPHICS_VERSION, so --rocm-gfx follows the name.
 cat > "$WORK/smi_two_nogfx" <<'EOF'
 GPU: 0
     ASIC:
@@ -222,15 +217,13 @@ assert_eq "device 0" \
     "gfx90a|AMD Instinct MI210" "$(summary "$WORK/roc_three_dup" "$WORK/empty" 0)"
 assert_eq "device 1" \
     "gfx1100|AMD Radeon RX 7900 XTX" "$(summary "$WORK/roc_three_dup" "$WORK/empty" 1)"
-# This is the ordinal that decides --rocm-gfx on a duplicate-arch host: a selector
-# that collapses the two gfx1100 slots sends device 2 back to device 0's arch.
+# The ordinal that decides --rocm-gfx: collapsing the gfx1100 slots sends it to device 0.
 assert_eq "device 2, past a duplicated arch, keeps its own arch and name" \
     "gfx1100|AMD Radeon PRO W7900" "$(summary "$WORK/roc_three_dup" "$WORK/empty" 2)"
 assert_eq "an out-of-range mask falls back to device 0" \
     "gfx90a|AMD Instinct MI210" "$(summary "$WORK/roc_three_dup" "$WORK/empty" 9)"
-# Two of the same card produce two byte-identical records. A selector that folds
-# duplicate lines away resolves device 2 to the iGPU at ordinal 0, and --rocm-gfx
-# then carries gfx1036 for a host whose selected card is gfx1201.
+# Byte-identical records: folding them resolves device 2 to the iGPU, so --rocm-gfx
+# carries gfx1036 on a host whose selected card is gfx1201.
 assert_eq "two identical cards are still two devices" \
     "gfx1201|AMD Radeon AI PRO R9700" "$(summary "$WORK/roc_twins" "$WORK/empty" 2)"
 
@@ -239,11 +232,9 @@ echo "=== rocminfo names something but enumerates no device ==="
 # rather than win the selection and discard amd-smi's arch.
 assert_eq "amd-smi supplies both the arch and the name" \
     "gfx1100|AMD Radeon RX 7900 XTX" "$(summary "$WORK/roc_cpu_only" "$WORK/smi_fixture")"
-# `list` runs twice: once to detect the GPU, once to look for a gfx token it does not
-# carry. `static --asic` runs ONCE and yields both fields, because they now come from
-# one record parse instead of two independent greps. Pinned rather than tidied: this
-# file is a regression net, and the counts are what would change if an arm were
-# reordered or the parse were split again.
+# `list` runs twice (detect, then look for a gfx token it does not carry); one
+# `static --asic` parse yields both fields. Pinned: the counts move if an arm is
+# reordered or the parse is split again.
 assert_eq "list is asked first, and carries no gfx" 2 "$(probe_count 'amd-smi list')"
 assert_eq "one static --asic parse supplies both the arch and the name" \
     1 "$(probe_count 'amd-smi static')"
@@ -261,14 +252,12 @@ assert_eq "device 2" \
     "gfx1201|AMD Radeon AI PRO R9700" "$(summary "$WORK/empty" "$WORK/smi_three" 2)"
 assert_eq "an out-of-range mask falls back to adapter 0" \
     "gfx90a|AMD Instinct MI210" "$(summary "$WORK/empty" "$WORK/smi_three" 9)"
-# No gfx token anywhere, so the name is what --rocm-gfx is inferred from: it has to be
-# the selected adapter's, not the first one's.
+# With no gfx token the name is what --rocm-gfx comes from: it must be the selected one's.
 assert_eq "a nameless-arch build still names the selected adapter" \
     "|AMD Radeon AI PRO R9700" "$(summary "$WORK/empty" "$WORK/smi_two_nogfx" 1)"
 
 echo "=== neither tool reports a device ==="
-# The KFD sysfs arm below these two would also fire on a host that really has an AMD
-# GPU, which is where this suite is most likely to be run by hand.
+# The KFD arm below would fire on a host that really has an AMD GPU.
 if [ -e /dev/kfd ]; then
     echo "  SKIP: /dev/kfd exists on this host, so the KFD arm is reachable"; SKIP=$((SKIP + 1))
 else

--- a/tests/sh/test_setup_gpu_summary_probe_sources.sh
+++ b/tests/sh/test_setup_gpu_summary_probe_sources.sh
@@ -20,9 +20,10 @@ SKIP=0
     sed -n '/^_setup_run_smi()/,/^}/p'              "$SETUP_SH"
     sed -n '/^_setup_rocminfo_gpu_records()/,/^}/p' "$SETUP_SH"
     sed -n '/^_setup_amd_smi_gpu_records()/,/^}/p'  "$SETUP_SH"
-    echo '_setup_amd_detected=false'
-    echo '_setup_nvidia_usable=false'
-    echo '_setup_gfx_all=""; _setup_mkt=""; _setup_amd_records=""; _setup_gfx=""'
+    # The real initialiser group, not a restated one. Seeding these here would hide the
+    # thing that matters under `set -u`: a variable the selection block reads but no arm
+    # assigns aborts `unsloth studio update` outright.
+    sed -n '/^_setup_amd_detected=false$/,/^_setup_amd_records=""$/p' "$SETUP_SH"
     # Detection through selection. NVIDIA is pinned false: this is about which AMD
     # device gets picked, not about vendor priority.
     awk '/^if \[ "\$_setup_nvidia_usable" != true \]; then/ {on=1}
@@ -35,6 +36,21 @@ grep -q '_setup_amd_record=' "$WORK/block.sh" || {
 grep -q '_setup_amd_smi_gpu_records' "$WORK/block.sh" || {
     echo "FATAL: the amd-smi record parser is not wired into the block" >&2; exit 1; }
 bash -n "$WORK/block.sh" || { echo "FATAL: extracted block does not parse" >&2; exit 1; }
+
+# The same two halves, split, for the arms that reach selection without probing anything.
+sed -n '/^_setup_amd_detected=false$/,/^_setup_amd_records=""$/p' "$SETUP_SH" > "$WORK/init.sh"
+{
+    awk '/^if \[ "\$_setup_nvidia_usable" = true \]; then/ {on=1}
+         on && /UNSLOTH_ROCM_GFX_ARCH env override/ {exit}
+         on {print}' "$SETUP_SH"
+    echo 'fi'
+} > "$WORK/select.sh"
+grep -q '_setup_nvidia_usable=false' "$WORK/init.sh" || {
+    echo "FATAL: initialiser group not found in $SETUP_SH" >&2; exit 1; }
+grep -q '_setup_amd_record=' "$WORK/select.sh" || {
+    echo "FATAL: selection block not found in $SETUP_SH" >&2; exit 1; }
+bash -n "$WORK/init.sh" && bash -n "$WORK/select.sh" || {
+    echo "FATAL: extracted halves do not parse" >&2; exit 1; }
 
 # PATH from scratch: the host running this may itself have a real rocminfo/amd-smi.
 mkdir -p "$WORK/base" "$WORK/roc" "$WORK/smi"
@@ -55,7 +71,8 @@ echo "amd-smi $1" >> "$PROBE_LOG"
 [ -s "$STUB_AMDSMI" ] || exit 1
 case "$1" in
     list)   sed -n 's/^\(GPU: [0-9]*\).*/\1  BDF: 0000:03:00.0  UUID: aaaa-bbbb  KFD_ID: 1/p' "$STUB_AMDSMI" ;;
-    static) cat "$STUB_AMDSMI" ;;
+    # A driver that answers `list` but not `static --asic`: detected, zero records.
+    static) [ -n "${STUB_AMDSMI_MUTE_STATIC:-}" ] || cat "$STUB_AMDSMI" ;;
 esac
 STUB
 chmod +x "$WORK/roc/rocminfo" "$WORK/smi/amd-smi"
@@ -79,9 +96,24 @@ summary() {
     # setup.sh runs under `set -euo pipefail`; match it.
     env -i PATH="$_path" PROBE_LOG="$WORK/probes" \
         STUB_ROCMINFO="$1" STUB_AMDSMI="$2" \
+        ${STUB_AMDSMI_MUTE_STATIC:+STUB_AMDSMI_MUTE_STATIC=1} \
         ${3:+HIP_VISIBLE_DEVICES="$3"} \
         /bin/bash -c 'set -euo pipefail; . "$1"; printf "%s|%s\n" "$_setup_gfx" "$_setup_mkt"' \
         _ "$WORK/block.sh"
+}
+
+# The KFD sysfs arm sets _setup_amd_detected=true and nothing else, so it reaches the
+# selection block with no records and no gfx list. That arm needs a real /dev/kfd, so
+# drive the selection block directly from the same starting state.
+kfd_shape_summary() {
+    env -i PATH="$WORK/base" \
+        /bin/bash -c 'set -euo pipefail
+                      step() { :; }
+                      . "$1"
+                      _setup_amd_detected=true
+                      . "$2"
+                      printf "%s|%s\n" "$_setup_gfx" "$_setup_mkt"' \
+        _ "$WORK/init.sh" "$WORK/select.sh" 2>&1
 }
 # grep -c prints 0 and exits 1 when there is no match, so the status is discarded.
 probe_count() { _n=$(grep -c "^$1" "$WORK/probes" 2>/dev/null) || true; echo "${_n:-0}"; }
@@ -264,6 +296,18 @@ else
     assert_eq "neither tool installed reports nothing" "|" "$(summary - -)"
     assert_eq "both installed but silent reports nothing" "|" "$(summary "$WORK/empty" "$WORK/empty")"
 fi
+
+echo "=== detected, but no arm produced a record ==="
+# Under `set -euo pipefail` an unassigned variable is not an empty string, it is a fatal
+# error: `unsloth studio update` dies here instead of falling through to a source build.
+assert_eq "the KFD-shaped path reaches the end instead of aborting on set -u" \
+    "|" "$(kfd_shape_summary)"
+assert_eq "every variable the selection block reads is initialised up front" \
+    "" "$(grep -oE '\$\{?_setup_(gfx|gfx_all|mkt|amd_records|amd_detected|nvidia_usable)\b' \
+              "$WORK/select.sh" | tr -d '${' | sort -u \
+          | while read -r _v; do grep -q "^$_v=" "$WORK/init.sh" || echo "$_v"; done | tr '\n' ' ' | sed 's/ $//')"
+assert_eq "amd-smi answers list but not static --asic" \
+    "|" "$(STUB_AMDSMI_MUTE_STATIC=1 summary "$WORK/empty" "$WORK/smi_three")"
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed, $SKIP skipped"

--- a/tests/sh/test_setup_gpu_summary_probe_sources.sh
+++ b/tests/sh/test_setup_gpu_summary_probe_sources.sh
@@ -1,0 +1,239 @@
+#!/bin/bash
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+# Drive studio/setup.sh's AMD detection and selection with stub rocminfo and amd-smi.
+#
+# The sibling test_install_gpu_summary_probe_sources.sh covers install.sh, where the
+# result is a display label. Here it is not: $_setup_gfx is forwarded as --rocm-gfx to
+# install_llama_prebuilt.py and to the whisper installer, so a wrong ordinal picks the
+# wrong binary. This file drives the real block rather than the parser alone.
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SETUP_SH="$SCRIPT_DIR/../../studio/setup.sh"
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+PASS=0
+FAIL=0
+SKIP=0
+
+{
+    sed -n '/^_setup_run_smi()/,/^}/p'              "$SETUP_SH"
+    sed -n '/^_setup_rocminfo_gpu_records()/,/^}/p' "$SETUP_SH"
+    echo '_setup_amd_detected=false'
+    echo '_setup_nvidia_usable=false'
+    echo '_setup_gfx_all=""; _setup_mkt=""; _setup_amd_records=""; _setup_gfx=""'
+    # Detection through selection. NVIDIA is classified above this point and pinned
+    # false here: this file is about which AMD device gets picked, not about priority.
+    awk '/^if \[ "\$_setup_nvidia_usable" != true \]; then/ {on=1}
+         on && /UNSLOTH_ROCM_GFX_ARCH env override/ {exit}
+         on {print}' "$SETUP_SH"
+    echo 'fi'
+} > "$WORK/block.sh"
+grep -q '_setup_amd_record=' "$WORK/block.sh" || {
+    echo "FATAL: AMD detection/selection block not found in $SETUP_SH" >&2; exit 1; }
+grep -q '_setup_amd_records=""' "$WORK/block.sh" || {
+    echo "FATAL: the amd-smi record-clearing arm is missing from the extracted block" >&2; exit 1; }
+bash -n "$WORK/block.sh" || { echo "FATAL: extracted block does not parse" >&2; exit 1; }
+
+# PATH from scratch: the host running this may itself have a real rocminfo/amd-smi.
+mkdir -p "$WORK/base" "$WORK/roc" "$WORK/smi"
+for _tool in awk grep sed cat tr timeout; do
+    _p=$(command -v "$_tool") || { echo "FATAL: $_tool not found" >&2; exit 1; }
+    ln -sf "$_p" "$WORK/base/$_tool"
+done
+cat > "$WORK/roc/rocminfo" <<'STUB'
+#!/bin/sh
+echo "rocminfo" >> "$PROBE_LOG"
+[ -s "$STUB_ROCMINFO" ] || exit 1
+cat "$STUB_ROCMINFO"
+STUB
+# `amd-smi list` prints BDF / UUID / KFD_ID and no gfx token, so the arch has to come
+# from `static --asic`; keeping the two subcommands distinct is what tests that.
+cat > "$WORK/smi/amd-smi" <<'STUB'
+#!/bin/sh
+echo "amd-smi $1" >> "$PROBE_LOG"
+[ -s "$STUB_AMDSMI" ] || exit 1
+case "$1" in
+    list)   sed -n 's/^\(GPU: [0-9]*\).*/\1  BDF: 0000:03:00.0  UUID: aaaa-bbbb  KFD_ID: 1/p' "$STUB_AMDSMI" ;;
+    static) cat "$STUB_AMDSMI" ;;
+esac
+STUB
+chmod +x "$WORK/roc/rocminfo" "$WORK/smi/amd-smi"
+
+assert_eq() {
+    _label="$1"; _expected="$2"; _actual="$3"
+    if [ "$_actual" = "$_expected" ]; then
+        echo "  PASS: $_label"; PASS=$((PASS + 1))
+    else
+        echo "  FAIL: $_label (expected '$_expected', got '$_actual')"; FAIL=$((FAIL + 1))
+    fi
+}
+
+# $1 rocminfo fixture ("-" = not installed), $2 amd-smi fixture, $3 visible-device mask.
+# Prints "gfx|name". The probe log is left in $WORK/probes for the call-count asserts.
+summary() {
+    _path="$WORK/base"
+    [ "$1" != "-" ] && _path="$WORK/roc:$_path"
+    [ "$2" != "-" ] && _path="$WORK/smi:$_path"
+    : > "$WORK/probes"
+    # setup.sh runs under `set -euo pipefail`; match it so a guard that would abort
+    # `unsloth studio update` cannot pass here.
+    env -i PATH="$_path" PROBE_LOG="$WORK/probes" \
+        STUB_ROCMINFO="$1" STUB_AMDSMI="$2" \
+        ${3:+HIP_VISIBLE_DEVICES="$3"} \
+        /bin/bash -c 'set -euo pipefail; . "$1"; printf "%s|%s\n" "$_setup_gfx" "$_setup_mkt"' \
+        _ "$WORK/block.sh"
+}
+# grep -c prints 0 and exits 1 when there is no match, so the status is discarded.
+probe_count() { _n=$(grep -c "^$1" "$WORK/probes" 2>/dev/null) || true; echo "${_n:-0}"; }
+
+cat > "$WORK/roc_gpu" <<'EOF'
+Agent 1
+*******
+  Name:                    AMD RYZEN AI MAX+ 395 w/ Radeon 8060S
+  Marketing Name:          AMD RYZEN AI MAX+ 395 w/ Radeon 8060S
+  Vendor Name:             CPU
+  Device Type:             CPU
+*******
+Agent 2
+*******
+  Name:                    gfx1151
+  Marketing Name:          AMD Radeon Graphics
+  Vendor Name:             AMD
+  Device Type:             GPU
+EOF
+cat > "$WORK/roc_three_dup" <<'EOF'
+Agent 1
+*******
+  Name:                    AMD EPYC 9654 96-Core Processor
+  Marketing Name:          AMD EPYC 9654 96-Core Processor
+  Device Type:             CPU
+*******
+Agent 2
+*******
+  Name:                    gfx90a:sramecc+:xnack-
+  Marketing Name:          AMD Instinct MI210
+  Device Type:             GPU
+*******
+Agent 3
+*******
+  Name:                    gfx1100
+  Marketing Name:          AMD Radeon RX 7900 XTX
+  Device Type:             GPU
+*******
+Agent 4
+*******
+  Name:                    gfx1100
+  Marketing Name:          AMD Radeon PRO W7900
+  Device Type:             GPU
+EOF
+# The #7307 reporter's shape: a Ryzen iGPU plus two IDENTICAL R9700s.
+cat > "$WORK/roc_twins" <<'EOF'
+Agent 1
+*******
+  Name:                    AMD Ryzen 9 9950X 16-Core Processor
+  Marketing Name:          AMD Ryzen 9 9950X 16-Core Processor
+  Device Type:             CPU
+*******
+Agent 2
+*******
+  Name:                    gfx1036
+  Marketing Name:          AMD Radeon Graphics
+  Device Type:             GPU
+*******
+Agent 3
+*******
+  Name:                    gfx1201
+  Marketing Name:          AMD Radeon AI PRO R9700
+  Device Type:             GPU
+*******
+Agent 4
+*******
+  Name:                    gfx1201
+  Marketing Name:          AMD Radeon AI PRO R9700
+  Device Type:             GPU
+EOF
+cat > "$WORK/roc_cpu_only" <<'EOF'
+Agent 1
+*******
+  Name:                    AMD Ryzen 9 5950X 16-Core Processor
+  Marketing Name:          AMD Ryzen 9 5950X 16-Core Processor
+  Vendor Name:             CPU
+  Device Type:             CPU
+EOF
+cat > "$WORK/roc_blank_name" <<'EOF'
+Agent 1
+*******
+  Name:                    AMD Ryzen 9 5950X 16-Core Processor
+  Marketing Name:          AMD Ryzen 9 5950X 16-Core Processor
+  Device Type:             CPU
+*******
+Agent 2
+*******
+  Name:                    gfx1030
+  Device Type:             GPU
+EOF
+cat > "$WORK/smi_fixture" <<'EOF'
+GPU: 0
+    ASIC:
+        MARKET_NAME: AMD Radeon RX 7900 XTX
+        TARGET_GRAPHICS_VERSION: gfx1100
+EOF
+: > "$WORK/empty"
+
+echo "=== rocminfo enumerates the device ==="
+assert_eq "the GPU agent names the GPU, not the processor" \
+    "gfx1151|AMD Radeon Graphics" "$(summary "$WORK/roc_gpu" "$WORK/empty")"
+assert_eq "rocminfo is run once, not once per field" 1 "$(probe_count rocminfo)"
+assert_eq "and amd-smi is not consulted at all" 0 "$(probe_count amd-smi)"
+assert_eq "the same answer with amd-smi installed and disagreeing" \
+    "gfx1151|AMD Radeon Graphics" "$(summary "$WORK/roc_gpu" "$WORK/smi_fixture")"
+
+echo "=== the mask selects a device, and its name follows ==="
+assert_eq "device 0" \
+    "gfx90a|AMD Instinct MI210" "$(summary "$WORK/roc_three_dup" "$WORK/empty" 0)"
+assert_eq "device 1" \
+    "gfx1100|AMD Radeon RX 7900 XTX" "$(summary "$WORK/roc_three_dup" "$WORK/empty" 1)"
+# This is the ordinal that decides --rocm-gfx on a duplicate-arch host: a selector
+# that collapses the two gfx1100 slots sends device 2 back to device 0's arch.
+assert_eq "device 2, past a duplicated arch, keeps its own arch and name" \
+    "gfx1100|AMD Radeon PRO W7900" "$(summary "$WORK/roc_three_dup" "$WORK/empty" 2)"
+assert_eq "an out-of-range mask falls back to device 0" \
+    "gfx90a|AMD Instinct MI210" "$(summary "$WORK/roc_three_dup" "$WORK/empty" 9)"
+# Two of the same card produce two byte-identical records. A selector that folds
+# duplicate lines away resolves device 2 to the iGPU at ordinal 0, and --rocm-gfx
+# then carries gfx1036 for a host whose selected card is gfx1201.
+assert_eq "two identical cards are still two devices" \
+    "gfx1201|AMD Radeon AI PRO R9700" "$(summary "$WORK/roc_twins" "$WORK/empty" 2)"
+
+echo "=== rocminfo names something but enumerates no device ==="
+# amd-smi owns the device list here, so the leftover CPU-only record must be dropped
+# rather than win the selection and discard amd-smi's arch.
+assert_eq "amd-smi supplies both the arch and the name" \
+    "gfx1100|AMD Radeon RX 7900 XTX" "$(summary "$WORK/roc_cpu_only" "$WORK/smi_fixture")"
+# `list` runs twice (once to detect the GPU, once to look for a gfx token it does not
+# carry), so `static --asic` is reached twice too: once for the arch, once for the
+# name. Pinned rather than tidied here: this file is a regression net, and the counts
+# are what would change if an arm were reordered.
+assert_eq "list is asked first, and carries no gfx" 2 "$(probe_count 'amd-smi list')"
+assert_eq "so static --asic supplies both the arch and the name" \
+    2 "$(probe_count 'amd-smi static')"
+
+echo "=== a device that reported no name of its own ==="
+assert_eq "keeps its arch and stays unnamed" \
+    "gfx1030|" "$(summary "$WORK/roc_blank_name" "$WORK/smi_fixture")"
+
+echo "=== neither tool reports a device ==="
+# The KFD sysfs arm below these two would also fire on a host that really has an AMD
+# GPU, which is where this suite is most likely to be run by hand.
+if [ -e /dev/kfd ]; then
+    echo "  SKIP: /dev/kfd exists on this host, so the KFD arm is reachable"; SKIP=$((SKIP + 1))
+else
+    assert_eq "neither tool installed reports nothing" "|" "$(summary - -)"
+    assert_eq "both installed but silent reports nothing" "|" "$(summary "$WORK/empty" "$WORK/empty")"
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed, $SKIP skipped"
+[ "$FAIL" -eq 0 ]

--- a/tests/sh/test_setup_gpu_summary_probe_sources.sh
+++ b/tests/sh/test_setup_gpu_summary_probe_sources.sh
@@ -57,7 +57,7 @@ bash -n "$WORK/init.sh" && bash -n "$WORK/select.sh" || {
 
 # PATH from scratch: the host running this may itself have a real rocminfo/amd-smi.
 mkdir -p "$WORK/base" "$WORK/roc" "$WORK/smi"
-for _tool in awk grep sed cat tr timeout; do
+for _tool in awk grep sed cat tr timeout sort wc head tail; do
     _p=$(command -v "$_tool") || { echo "FATAL: $_tool not found" >&2; exit 1; }
     ln -sf "$_p" "$WORK/base/$_tool"
 done
@@ -286,28 +286,6 @@ echo "=== a device that reported no name of its own ==="
 assert_eq "keeps its arch and stays unnamed" \
     "gfx1030|" "$(summary "$WORK/roc_blank_name" "$WORK/smi_fixture")"
 
-echo "=== amd-smi owns the device list ==="
-assert_eq "each adapter is announced with its own name, device 0" \
-    "gfx90a|AMD Instinct MI210" "$(summary "$WORK/empty" "$WORK/smi_three" 0)"
-assert_eq "device 1" \
-    "gfx1100|AMD Radeon RX 7900 XTX" "$(summary "$WORK/empty" "$WORK/smi_three" 1)"
-assert_eq "device 2" \
-    "gfx1201|AMD Radeon AI PRO R9700" "$(summary "$WORK/empty" "$WORK/smi_three" 2)"
-assert_eq "an out-of-range mask falls back to adapter 0" \
-    "gfx90a|AMD Instinct MI210" "$(summary "$WORK/empty" "$WORK/smi_three" 9)"
-# With no gfx token the name is what --rocm-gfx comes from: it must be the selected one's.
-assert_eq "a nameless-arch build still names the selected adapter" \
-    "|AMD Radeon AI PRO R9700" "$(summary "$WORK/empty" "$WORK/smi_two_nogfx" 1)"
-
-echo "=== neither tool reports a device ==="
-# The KFD arm below would fire on a host that really has an AMD GPU.
-if [ -e /dev/kfd ]; then
-    echo "  SKIP: /dev/kfd exists on this host, so the KFD arm is reachable"; SKIP=$((SKIP + 1))
-else
-    assert_eq "neither tool installed reports nothing" "|" "$(summary - -)"
-    assert_eq "both installed but silent reports nothing" "|" "$(summary "$WORK/empty" "$WORK/empty")"
-fi
-
 # amd-smi discovery order is not HIP order; `amd-smi list -e` publishes HIP_ID as the map.
 # On this host discovery 0/1/2 is HIP 2/1/0, so an untranslated mask picks the wrong arch,
 # and _setup_gfx is what becomes --rocm-gfx.
@@ -347,6 +325,44 @@ GPU: 2
     HIP_ID: 0
 EOF
 
+# Two of the same card. Discovery order and HIP order may disagree here too, but every
+# ordinal yields the same arch either way, so there is nothing to decline.
+cat > "$WORK/smi_two_same" <<'EOF'
+GPU: 0
+    ASIC:
+        MARKET_NAME: AMD Instinct MI300X
+        TARGET_GRAPHICS_VERSION: gfx942
+GPU: 1
+    ASIC:
+        MARKET_NAME: AMD Instinct MI300X
+        TARGET_GRAPHICS_VERSION: gfx942
+EOF
+
+echo "=== amd-smi owns the device list ==="
+# With the map present each adapter is announced with its own name.
+assert_eq "each adapter is announced with its own name, device 0" \
+    "gfx90a|AMD Instinct MI210" \
+    "$(STUB_AMDSMI_E="$WORK/smi_e_identity" summary "$WORK/empty" "$WORK/smi_three" 0)"
+assert_eq "device 1" "gfx1100|AMD Radeon RX 7900 XTX" \
+    "$(STUB_AMDSMI_E="$WORK/smi_e_identity" summary "$WORK/empty" "$WORK/smi_three" 1)"
+assert_eq "device 2" "gfx1201|AMD Radeon AI PRO R9700" \
+    "$(STUB_AMDSMI_E="$WORK/smi_e_identity" summary "$WORK/empty" "$WORK/smi_three" 2)"
+assert_eq "an out-of-range mask falls back to adapter 0" \
+    "gfx90a|AMD Instinct MI210" \
+    "$(STUB_AMDSMI_E="$WORK/smi_e_identity" summary "$WORK/empty" "$WORK/smi_three" 9)"
+# With no gfx token the name is what --rocm-gfx comes from: it must be the selected one's.
+assert_eq "a nameless-arch build still names the selected adapter" \
+    "|AMD Radeon AI PRO R9700" "$(summary "$WORK/empty" "$WORK/smi_two_nogfx" 1)"
+
+echo "=== neither tool reports a device ==="
+# The KFD arm below would fire on a host that really has an AMD GPU.
+if [ -e /dev/kfd ]; then
+    echo "  SKIP: /dev/kfd exists on this host, so the KFD arm is reachable"; SKIP=$((SKIP + 1))
+else
+    assert_eq "neither tool installed reports nothing" "|" "$(summary - -)"
+    assert_eq "both installed but silent reports nothing" "|" "$(summary "$WORK/empty" "$WORK/empty")"
+fi
+
 echo "=== amd-smi ordinals are translated into HIP order ==="
 assert_eq "HIP 0 is discovery 2" "gfx1201|AMD Radeon AI PRO R9700" \
     "$(STUB_AMDSMI_E="$WORK/smi_e_reversed" summary "$WORK/empty" "$WORK/smi_three" 0)"
@@ -356,12 +372,22 @@ assert_eq "the middle device is unmoved" "gfx1100|AMD Radeon RX 7900 XTX" \
     "$(STUB_AMDSMI_E="$WORK/smi_e_reversed" summary "$WORK/empty" "$WORK/smi_three" 1)"
 assert_eq "an identity map changes nothing" "gfx90a|AMD Instinct MI210" \
     "$(STUB_AMDSMI_E="$WORK/smi_e_identity" summary "$WORK/empty" "$WORK/smi_three" 0)"
-assert_eq "an older CLI that rejects -e keeps discovery order" "gfx90a|AMD Instinct MI210" \
+# No usable map and the adapters disagree on arch: any ordinal would be a guess, and the
+# guess becomes --rocm-gfx, so nothing is reported rather than the wrong thing.
+assert_eq "an older CLI that rejects -e declines on unlike adapters" "|" \
     "$(summary "$WORK/empty" "$WORK/smi_three" 0)"
-assert_eq "a partial map is declined, not half-applied" "gfx90a|AMD Instinct MI210" \
+assert_eq "a partial map is declined, not half-applied" "|" \
     "$(STUB_AMDSMI_E="$WORK/smi_e_partial" summary "$WORK/empty" "$WORK/smi_three" 0)"
-assert_eq "colliding hip ids are declined" "gfx90a|AMD Instinct MI210" \
+assert_eq "colliding hip ids are declined" "|" \
     "$(STUB_AMDSMI_E="$WORK/smi_e_collide" summary "$WORK/empty" "$WORK/smi_three" 0)"
+# Identical adapters are not ambiguous, so the absent map costs nothing.
+assert_eq "identical adapters still resolve without a map, device 0" \
+    "gfx942|AMD Instinct MI300X" "$(summary "$WORK/empty" "$WORK/smi_two_same" 0)"
+assert_eq "and device 1" \
+    "gfx942|AMD Instinct MI300X" "$(summary "$WORK/empty" "$WORK/smi_two_same" 1)"
+# A single adapter can never be ambiguous either.
+assert_eq "one adapter resolves without a map" \
+    "gfx1100|AMD Radeon RX 7900 XTX" "$(summary "$WORK/empty" "$WORK/smi_fixture" 0)"
 # rocminfo is an HSA client, so its agent list is already in ROCr order.
 assert_eq "the rocminfo path is not reordered by a HIP map" "gfx1100|AMD Radeon RX 7900 XTX" \
     "$(STUB_AMDSMI_E="$WORK/smi_e_reversed" summary "$WORK/roc_three_dup" "$WORK/empty" 1)"

--- a/tests/sh/test_setup_gpu_summary_probe_sources.sh
+++ b/tests/sh/test_setup_gpu_summary_probe_sources.sh
@@ -235,6 +235,22 @@ GPU: 2
         TARGET_GRAPHICS_VERSION: gfx1201
 EOF
 # amd-smi 6.1.1 has no TARGET_GRAPHICS_VERSION, so --rocm-gfx follows the name.
+cat > "$WORK/smi_e_two_identity" <<'EOF'
+GPU: 0
+    HIP_ID: 0
+GPU: 1
+    HIP_ID: 1
+EOF
+# Two of the same card on an amd-smi with no TARGET_GRAPHICS_VERSION: the names match, so
+# whichever ordinal wins infers the same arch. Not ambiguous, so not declined.
+cat > "$WORK/smi_two_same_nogfx" <<'EOF'
+GPU: 0
+    ASIC:
+        MARKET_NAME: AMD Instinct MI300X
+GPU: 1
+    ASIC:
+        MARKET_NAME: AMD Instinct MI300X
+EOF
 cat > "$WORK/smi_two_nogfx" <<'EOF'
 GPU: 0
     ASIC:
@@ -350,9 +366,15 @@ assert_eq "device 2" "gfx1201|AMD Radeon AI PRO R9700" \
 assert_eq "an out-of-range mask falls back to adapter 0" \
     "gfx90a|AMD Instinct MI210" \
     "$(STUB_AMDSMI_E="$WORK/smi_e_identity" summary "$WORK/empty" "$WORK/smi_three" 9)"
-# With no gfx token the name is what --rocm-gfx comes from: it must be the selected one's.
+# With no gfx token the name is what --rocm-gfx comes from, so it must be the selected
+# adapter's. With the map present that is answerable; without it, it is not.
 assert_eq "a nameless-arch build still names the selected adapter" \
-    "|AMD Radeon AI PRO R9700" "$(summary "$WORK/empty" "$WORK/smi_two_nogfx" 1)"
+    "|AMD Radeon AI PRO R9700" \
+    "$(STUB_AMDSMI_E="$WORK/smi_e_two_identity" summary "$WORK/empty" "$WORK/smi_two_nogfx" 1)"
+assert_eq "and declines without a map, since the name is what the arch comes from" "|" \
+    "$(summary "$WORK/empty" "$WORK/smi_two_nogfx" 1)"
+assert_eq "two archless adapters of the same model are not ambiguous" \
+    "|AMD Instinct MI300X" "$(summary "$WORK/empty" "$WORK/smi_two_same_nogfx" 1)"
 
 echo "=== neither tool reports a device ==="
 # The KFD arm below would fire on a host that really has an AMD GPU.

--- a/tests/sh/test_setup_gpu_summary_probe_sources.sh
+++ b/tests/sh/test_setup_gpu_summary_probe_sources.sh
@@ -20,6 +20,7 @@ SKIP=0
 {
     sed -n '/^_setup_run_smi()/,/^}/p'              "$SETUP_SH"
     sed -n '/^_setup_rocminfo_gpu_records()/,/^}/p' "$SETUP_SH"
+    sed -n '/^_setup_amd_smi_gpu_records()/,/^}/p'  "$SETUP_SH"
     echo '_setup_amd_detected=false'
     echo '_setup_nvidia_usable=false'
     echo '_setup_gfx_all=""; _setup_mkt=""; _setup_amd_records=""; _setup_gfx=""'
@@ -32,8 +33,8 @@ SKIP=0
 } > "$WORK/block.sh"
 grep -q '_setup_amd_record=' "$WORK/block.sh" || {
     echo "FATAL: AMD detection/selection block not found in $SETUP_SH" >&2; exit 1; }
-grep -q '_setup_amd_records=""' "$WORK/block.sh" || {
-    echo "FATAL: the amd-smi record-clearing arm is missing from the extracted block" >&2; exit 1; }
+grep -q '_setup_amd_smi_gpu_records' "$WORK/block.sh" || {
+    echo "FATAL: the amd-smi record parser is not wired into the block" >&2; exit 1; }
 bash -n "$WORK/block.sh" || { echo "FATAL: extracted block does not parse" >&2; exit 1; }
 
 # PATH from scratch: the host running this may itself have a real rocminfo/amd-smi.
@@ -180,6 +181,32 @@ GPU: 0
         MARKET_NAME: AMD Radeon RX 7900 XTX
         TARGET_GRAPHICS_VERSION: gfx1100
 EOF
+# Three adapters: the arch was indexed by the mask while the name was always the first
+# adapter's, so a later card was announced with another card's name.
+cat > "$WORK/smi_three" <<'EOF'
+GPU: 0
+    ASIC:
+        MARKET_NAME: AMD Instinct MI210
+        TARGET_GRAPHICS_VERSION: gfx90a
+GPU: 1
+    ASIC:
+        MARKET_NAME: AMD Radeon RX 7900 XTX
+        TARGET_GRAPHICS_VERSION: gfx1100
+GPU: 2
+    ASIC:
+        MARKET_NAME: AMD Radeon AI PRO R9700
+        TARGET_GRAPHICS_VERSION: gfx1201
+EOF
+# amd-smi 6.1.1 ships MARKET_NAME with no TARGET_GRAPHICS_VERSION, so the arch is
+# inferred from the name and $_setup_gfx -- hence --rocm-gfx -- follows the name.
+cat > "$WORK/smi_two_nogfx" <<'EOF'
+GPU: 0
+    ASIC:
+        MARKET_NAME: AMD Radeon RX 7900 XTX
+GPU: 1
+    ASIC:
+        MARKET_NAME: AMD Radeon AI PRO R9700
+EOF
 : > "$WORK/empty"
 
 echo "=== rocminfo enumerates the device ==="
@@ -212,17 +239,32 @@ echo "=== rocminfo names something but enumerates no device ==="
 # rather than win the selection and discard amd-smi's arch.
 assert_eq "amd-smi supplies both the arch and the name" \
     "gfx1100|AMD Radeon RX 7900 XTX" "$(summary "$WORK/roc_cpu_only" "$WORK/smi_fixture")"
-# `list` runs twice (once to detect the GPU, once to look for a gfx token it does not
-# carry), so `static --asic` is reached twice too: once for the arch, once for the
-# name. Pinned rather than tidied here: this file is a regression net, and the counts
-# are what would change if an arm were reordered.
+# `list` runs twice: once to detect the GPU, once to look for a gfx token it does not
+# carry. `static --asic` runs ONCE and yields both fields, because they now come from
+# one record parse instead of two independent greps. Pinned rather than tidied: this
+# file is a regression net, and the counts are what would change if an arm were
+# reordered or the parse were split again.
 assert_eq "list is asked first, and carries no gfx" 2 "$(probe_count 'amd-smi list')"
-assert_eq "so static --asic supplies both the arch and the name" \
-    2 "$(probe_count 'amd-smi static')"
+assert_eq "one static --asic parse supplies both the arch and the name" \
+    1 "$(probe_count 'amd-smi static')"
 
 echo "=== a device that reported no name of its own ==="
 assert_eq "keeps its arch and stays unnamed" \
     "gfx1030|" "$(summary "$WORK/roc_blank_name" "$WORK/smi_fixture")"
+
+echo "=== amd-smi owns the device list ==="
+assert_eq "each adapter is announced with its own name, device 0" \
+    "gfx90a|AMD Instinct MI210" "$(summary "$WORK/empty" "$WORK/smi_three" 0)"
+assert_eq "device 1" \
+    "gfx1100|AMD Radeon RX 7900 XTX" "$(summary "$WORK/empty" "$WORK/smi_three" 1)"
+assert_eq "device 2" \
+    "gfx1201|AMD Radeon AI PRO R9700" "$(summary "$WORK/empty" "$WORK/smi_three" 2)"
+assert_eq "an out-of-range mask falls back to adapter 0" \
+    "gfx90a|AMD Instinct MI210" "$(summary "$WORK/empty" "$WORK/smi_three" 9)"
+# No gfx token anywhere, so the name is what --rocm-gfx is inferred from: it has to be
+# the selected adapter's, not the first one's.
+assert_eq "a nameless-arch build still names the selected adapter" \
+    "|AMD Radeon AI PRO R9700" "$(summary "$WORK/empty" "$WORK/smi_two_nogfx" 1)"
 
 echo "=== neither tool reports a device ==="
 # The KFD sysfs arm below these two would also fire on a host that really has an AMD

--- a/tests/sh/test_setup_gpu_summary_probe_sources.sh
+++ b/tests/sh/test_setup_gpu_summary_probe_sources.sh
@@ -20,6 +20,7 @@ SKIP=0
     sed -n '/^_setup_run_smi()/,/^}/p'              "$SETUP_SH"
     sed -n '/^_setup_rocminfo_gpu_records()/,/^}/p' "$SETUP_SH"
     sed -n '/^_setup_amd_smi_gpu_records()/,/^}/p'  "$SETUP_SH"
+    sed -n '/^_setup_amd_smi_hip_order()/,/^}/p'  "$SETUP_SH"
     # The real initialiser group, not a restated one. Seeding these here would hide the
     # thing that matters under `set -u`: a variable the selection block reads but no arm
     # assigns aborts `unsloth studio update` outright.
@@ -35,6 +36,8 @@ grep -q '_setup_amd_record=' "$WORK/block.sh" || {
     echo "FATAL: AMD detection/selection block not found in $SETUP_SH" >&2; exit 1; }
 grep -q '_setup_amd_smi_gpu_records' "$WORK/block.sh" || {
     echo "FATAL: the amd-smi record parser is not wired into the block" >&2; exit 1; }
+grep -q '_setup_amd_smi_hip_order' "$WORK/block.sh" || {
+    echo "FATAL: the amd-smi HIP reorder is not wired into the block" >&2; exit 1; }
 bash -n "$WORK/block.sh" || { echo "FATAL: extracted block does not parse" >&2; exit 1; }
 
 # The same two halves, split, for the arms that reach selection without probing anything.
@@ -65,14 +68,17 @@ echo "rocminfo" >> "$PROBE_LOG"
 cat "$STUB_ROCMINFO"
 STUB
 # `amd-smi list` carries no gfx token; keeping the subcommands distinct tests that.
+# `list -e` is a third answer again: it carries HIP_ID and nothing else of interest, and
+# an older CLI rejects the flag outright, which is the STUB_AMDSMI_E="" case.
 cat > "$WORK/smi/amd-smi" <<'STUB'
 #!/bin/sh
-echo "amd-smi $1" >> "$PROBE_LOG"
+echo "amd-smi $*" >> "$PROBE_LOG"
 [ -s "$STUB_AMDSMI" ] || exit 1
-case "$1" in
-    list)   sed -n 's/^\(GPU: [0-9]*\).*/\1  BDF: 0000:03:00.0  UUID: aaaa-bbbb  KFD_ID: 1/p' "$STUB_AMDSMI" ;;
+case "$1 $2" in
+    "list -e") [ -z "${STUB_AMDSMI_E:-}" ] || cat "$STUB_AMDSMI_E" ;;
+    "list "*)  sed -n 's/^\(GPU: [0-9]*\).*/\1  BDF: 0000:03:00.0  UUID: aaaa-bbbb  KFD_ID: 1/p' "$STUB_AMDSMI" ;;
     # A driver that answers `list` but not `static --asic`: detected, zero records.
-    static) [ -n "${STUB_AMDSMI_MUTE_STATIC:-}" ] || cat "$STUB_AMDSMI" ;;
+    "static "*) [ -n "${STUB_AMDSMI_MUTE_STATIC:-}" ] || cat "$STUB_AMDSMI" ;;
 esac
 STUB
 chmod +x "$WORK/roc/rocminfo" "$WORK/smi/amd-smi"
@@ -97,6 +103,7 @@ summary() {
     env -i PATH="$_path" PROBE_LOG="$WORK/probes" \
         STUB_ROCMINFO="$1" STUB_AMDSMI="$2" \
         ${STUB_AMDSMI_MUTE_STATIC:+STUB_AMDSMI_MUTE_STATIC=1} \
+        ${STUB_AMDSMI_E:+STUB_AMDSMI_E="$STUB_AMDSMI_E"} \
         ${3:+HIP_VISIBLE_DEVICES="$3"} \
         /bin/bash -c 'set -euo pipefail; . "$1"; printf "%s|%s\n" "$_setup_gfx" "$_setup_mkt"' \
         _ "$WORK/block.sh"
@@ -116,7 +123,9 @@ kfd_shape_summary() {
         _ "$WORK/init.sh" "$WORK/select.sh" 2>&1
 }
 # grep -c prints 0 and exits 1 when there is no match, so the status is discarded.
-probe_count() { _n=$(grep -c "^$1" "$WORK/probes" 2>/dev/null) || true; echo "${_n:-0}"; }
+# Anchored at both ends: `amd-smi list` must not also count `amd-smi list -e`.
+probe_count() { _n=$(grep -c "^$1\$" "$WORK/probes" 2>/dev/null) || true; echo "${_n:-0}"; }
+probe_prefix_count() { _n=$(grep -c "^$1" "$WORK/probes" 2>/dev/null) || true; echo "${_n:-0}"; }
 
 cat > "$WORK/roc_gpu" <<'EOF'
 Agent 1
@@ -240,7 +249,7 @@ echo "=== rocminfo enumerates the device ==="
 assert_eq "the GPU agent names the GPU, not the processor" \
     "gfx1151|AMD Radeon Graphics" "$(summary "$WORK/roc_gpu" "$WORK/empty")"
 assert_eq "rocminfo is run once, not once per field" 1 "$(probe_count rocminfo)"
-assert_eq "and amd-smi is not consulted at all" 0 "$(probe_count amd-smi)"
+assert_eq "and amd-smi is not consulted at all" 0 "$(probe_prefix_count amd-smi)"
 assert_eq "the same answer with amd-smi installed and disagreeing" \
     "gfx1151|AMD Radeon Graphics" "$(summary "$WORK/roc_gpu" "$WORK/smi_fixture")"
 
@@ -268,8 +277,10 @@ assert_eq "amd-smi supplies both the arch and the name" \
 # `static --asic` parse yields both fields. Pinned: the counts move if an arm is
 # reordered or the parse is split again.
 assert_eq "list is asked first, and carries no gfx" 2 "$(probe_count 'amd-smi list')"
+assert_eq "and list -e is asked once, for the HIP mapping" \
+    1 "$(probe_count 'amd-smi list -e')"
 assert_eq "one static --asic parse supplies both the arch and the name" \
-    1 "$(probe_count 'amd-smi static')"
+    1 "$(probe_count 'amd-smi static --asic')"
 
 echo "=== a device that reported no name of its own ==="
 assert_eq "keeps its arch and stays unnamed" \
@@ -296,6 +307,64 @@ else
     assert_eq "neither tool installed reports nothing" "|" "$(summary - -)"
     assert_eq "both installed but silent reports nothing" "|" "$(summary "$WORK/empty" "$WORK/empty")"
 fi
+
+# amd-smi discovery order is not HIP order; `amd-smi list -e` publishes HIP_ID as the map.
+# On this host discovery 0/1/2 is HIP 2/1/0, so an untranslated mask picks the wrong arch,
+# and _setup_gfx is what becomes --rocm-gfx.
+cat > "$WORK/smi_e_reversed" <<'EOF'
+GPU: 0
+    HIP_ID: 2
+GPU: 1
+    HIP_ID: 1
+GPU: 2
+    HIP_ID: 0
+EOF
+cat > "$WORK/smi_e_identity" <<'EOF'
+GPU: 0
+    HIP_ID: 0
+GPU: 1
+    HIP_ID: 1
+GPU: 2
+    HIP_ID: 2
+EOF
+# hip_id reads N/A when the library cannot reach a device's KFD node. A partial map is
+# not a mapping, so discovery order is kept rather than half-translated.
+cat > "$WORK/smi_e_partial" <<'EOF'
+GPU: 0
+    HIP_ID: 2
+GPU: 1
+    HIP_ID: N/A
+GPU: 2
+    HIP_ID: 0
+EOF
+# Two devices claiming one HIP id describe something other than a 1:1 device mapping.
+cat > "$WORK/smi_e_collide" <<'EOF'
+GPU: 0
+    HIP_ID: 1
+GPU: 1
+    HIP_ID: 1
+GPU: 2
+    HIP_ID: 0
+EOF
+
+echo "=== amd-smi ordinals are translated into HIP order ==="
+assert_eq "HIP 0 is discovery 2" "gfx1201|AMD Radeon AI PRO R9700" \
+    "$(STUB_AMDSMI_E="$WORK/smi_e_reversed" summary "$WORK/empty" "$WORK/smi_three" 0)"
+assert_eq "HIP 2 is discovery 0" "gfx90a|AMD Instinct MI210" \
+    "$(STUB_AMDSMI_E="$WORK/smi_e_reversed" summary "$WORK/empty" "$WORK/smi_three" 2)"
+assert_eq "the middle device is unmoved" "gfx1100|AMD Radeon RX 7900 XTX" \
+    "$(STUB_AMDSMI_E="$WORK/smi_e_reversed" summary "$WORK/empty" "$WORK/smi_three" 1)"
+assert_eq "an identity map changes nothing" "gfx90a|AMD Instinct MI210" \
+    "$(STUB_AMDSMI_E="$WORK/smi_e_identity" summary "$WORK/empty" "$WORK/smi_three" 0)"
+assert_eq "an older CLI that rejects -e keeps discovery order" "gfx90a|AMD Instinct MI210" \
+    "$(summary "$WORK/empty" "$WORK/smi_three" 0)"
+assert_eq "a partial map is declined, not half-applied" "gfx90a|AMD Instinct MI210" \
+    "$(STUB_AMDSMI_E="$WORK/smi_e_partial" summary "$WORK/empty" "$WORK/smi_three" 0)"
+assert_eq "colliding hip ids are declined" "gfx90a|AMD Instinct MI210" \
+    "$(STUB_AMDSMI_E="$WORK/smi_e_collide" summary "$WORK/empty" "$WORK/smi_three" 0)"
+# rocminfo is an HSA client, so its agent list is already in ROCr order.
+assert_eq "the rocminfo path is not reordered by a HIP map" "gfx1100|AMD Radeon RX 7900 XTX" \
+    "$(STUB_AMDSMI_E="$WORK/smi_e_reversed" summary "$WORK/roc_three_dup" "$WORK/empty" 1)"
 
 echo "=== detected, but no arm produced a record ==="
 # Under `set -euo pipefail` an unassigned variable is not an empty string, it is a fatal


### PR DESCRIPTION
## Problem

On an AMD host both the installer and `unsloth studio update` reported the processor as the GPU. On a Ryzen AI MAX+ 395 (gfx1151):

```
gpu            AMD ROCm (gfx1151)
               GPU: AMD RYZEN AI MAX+ 395 w/ Radeon 8060S
```

rocminfo lists the CPU agent before the GPU agents, and both scripts took the first `Marketing Name:` line in the whole output:

```sh
awk -F': ' '/Marketing Name:/{...; if($2){print $2; exit}}'
```

On a real gfx1151 runner that parser prints `AMD RYZEN AI MAX+ 395 w/ Radeon 8060S`. The arch shown next to it came from a separate grep, so the two halves of the line could describe different devices.

## Change

`_rocminfo_gpu_records` emits one `gfx|marketing name` record per rocminfo GPU agent, in agent order, and the summary selects a record with the same visible-device index that already picked the arch. Identical awk in `install.sh` and `studio/setup.sh`, with a test asserting the two copies stay byte-identical, since the installer and the updater must not name different cards on the same host.

Details the parser has to get right:

- The value is everything after the first colon rather than `-F': '`, so `AMD Instinct MI300X OAM: 750W SKU` survives intact.
- A GPU agent that reports no marketing name still emits its slot (`gfx1030|`), or every later device shifts down one ordinal.
- The agent name is matched as a leading gfx token followed by something that cannot extend it, so a target id (`gfx90a:sramecc+:xnack-`) still registers while the ISA section's `Name: amdgcn-amd-amdhsa--gfx1151` does not.
- With no GPU agent at all, the first marketing name is reported with an empty arch. That is what an APU without a gfx token showed before, so the fallback path is unchanged.
- The rocminfo arch list is no longer deduplicated, because there is now one record per device: two cards of the same arch are two ordinals, and collapsing them resolved every mask past 0 to card 0.

The two probes have different shapes, so `install.sh` now follows the division of labour `studio/setup.sh` already had:

- When rocminfo names something but enumerates no device and amd-smi then supplies an arch, the leftover record is dropped. Kept, it would win the selection and discard that arch.
- The amd-smi name is read only when rocminfo produced no records. Its rows are not indexed here, so a device that reported no name of its own must stay unnamed rather than borrow another device's.

Deliberately unchanged: visibility-mask handling, the amd-smi and KFD detection fallbacks, the name-based arch inference table, and the ordering of the arms in the summary. `setup.sh` calls rocminfo once instead of three times, which follows from building the records rather than being a separate goal.

## Verification

- `tests/sh/test_rocminfo_gpu_name_7307.sh`: 15 assertions on the parser, covering the CPU-first host, two discrete cards with index selection, two cards of one arch, a blank marketing name keeping its slot, an embedded colon, a target-id agent name, and the no-GPU-agent fallback.
- `tests/sh/test_install_gpu_summary_probe_sources.sh`: 10 assertions driving the real probe-and-select block out of `install.sh` with stub probes, pinning down which source wins in each combination. It builds its `PATH` from scratch, because the host running it may itself have a real rocminfo and amd-smi.
- On an AMD DevLab gfx1151 host with real `rocminfo` output: the previous parser prints `AMD RYZEN AI MAX+ 395 w/ Radeon 8060S`, both patched copies print `gfx1151|AMD Radeon Graphics`. The NPU agent (`aie2p`, Device Type DSP) and both ISA `Name:` lines produce no records. Both new test files pass in full on that host.
- Parser output is identical under GNU awk 5.2, mawk and busybox awk.
- Locally: `tests/sh` 52/52; `tests/studio/install/` plus `tests/python/test_cross_platform_parity.py` and `tests/python/test_windows_no_torch_setup.py` at 2574 passed, 118 skipped.
- On the AMD host, `tests/studio/install/` fails the same 6 tests with and without the change (3 in `test_managed_node_runtime.py`, 1 in `test_rocm_gfx_spoof_7331.py`, 2 in `test_unsupported_arch_routing_guards_8529.py`), and `tests/sh` the same 1 (`test_install_rollback_lifecycle.sh`, which needs signal traps the runner does not allow). That baseline was measured with this change and #9499 both applied.
- `bash -n` and `dash -n` on `install.sh`, `bash -n` on `studio/setup.sh`, `git diff --check`.

Related: #7307. Replaces the reporting half of #8606.
