### PR TITLE
Installer: replace an existing venv whose interpreter is gone

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -3946,16 +3946,15 @@ exit 0
         }
     }
 
-    # uv refuses to create a venv in an occupied directory. The .NET API counts
-    # hidden entries and treats wildcard characters in the path literally.
+    # uv creates only into a path that is absent or an empty directory. The .NET
+    # API counts hidden entries and reads wildcards in the path literally.
     function Test-DirectoryHasEntries {
         param([Parameter(Mandatory = $true)][string]$Path)
         if (-not (Test-Path -LiteralPath $Path -PathType Container)) {
-            # Not a directory, but still something: a file, a link to one, or a
-            # link whose target is gone. CreateDirectory answers
-            # ERROR_ALREADY_EXISTS for all three, so uv cannot create here either
-            # and the path has to be moved aside. -PathType Container follows the
-            # link and reports false, so ask Get-Item, which sees the link itself.
+            # Still an existing path to CreateDirectory, which answers
+            # ERROR_ALREADY_EXISTS for a file or a link whose target is gone, so
+            # uv refuses it too. -PathType Container follows the link and cannot
+            # see a dangling one; Get-Item sees the link itself.
             return ($null -ne (Get-Item -LiteralPath $Path -Force -ErrorAction SilentlyContinue))
         }
         try {
@@ -3969,12 +3968,10 @@ exit 0
         return $false
     }
 
-    # Move-Item into a directory that already exists nests the source inside it
-    # rather than renaming it, and uv then refuses the occupied target with the
-    # same error as #9479. Reaching a migration branch already means $VenvDir is
-    # absent or empty, so clear it first. Directory.Delete is non-recursive, so it
-    # cannot take a directory that gained an entry since the check, and on a
-    # reparse point it removes the link without following it to the target.
+    # Move-Item into an existing directory nests the source inside it rather than
+    # renaming it, and uv then refuses that target as in #9479. A migration branch
+    # already means $VenvDir is absent or empty, so clear it: Directory.Delete is
+    # non-recursive, and on a reparse point it unlinks without following.
     function Clear-MigrationTargetDirectory {
         param([Parameter(Mandatory = $true)][string]$Path)
         if (-not (Test-Path -LiteralPath $Path)) { return }
@@ -3982,9 +3979,8 @@ exit 0
         if ($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) {
             # Not Remove-Item: on Windows PowerShell 5.1 it trips a reparse-tag
             # mismatch on a directory symlink (PowerShell/PowerShell#621).
-            # Directory.Delete unlinks without following the link, but throws
-            # DirectoryNotFoundException when the link points at a file or is
-            # dangling, so fall back to File.Delete for those two shapes.
+            # Directory.Delete throws on a link to a file or a dangling one,
+            # hence the File.Delete fallback.
             try { [System.IO.Directory]::Delete($Path) }
             catch {
                 try { [System.IO.File]::Delete($Path) }

--- a/install.ps1
+++ b/install.ps1
@@ -4013,6 +4013,15 @@ exit 0
         return $null
     }
 
+    # Test-Path follows a link, so a dangling one reads as absent. A rollback can
+    # hold any shape Test-DirectoryHasEntries called occupied, a dangling link and
+    # a plain file included, so existence has to be asked of the path itself.
+    function Test-StudioPathPresent {
+        param([Parameter(Mandatory = $true)][AllowEmptyString()][string]$Path)
+        if (-not $Path) { return $false }
+        return ($null -ne (Get-Item -LiteralPath $Path -Force -ErrorAction SilentlyContinue))
+    }
+
     function Start-StudioVenvRollback {
         param([Parameter(Mandatory = $true)][string]$ExistingDir)
         $stamp = Get-Date -Format "yyyyMMddHHmmss"
@@ -4172,7 +4181,7 @@ exit 0
         if (-not $script:StudioVenvRollbackActive) { return }
         $backup = $script:StudioVenvRollbackDir
         $target = $script:StudioVenvRollbackTarget
-        if (-not $backup -or -not (Test-Path -LiteralPath $backup)) {
+        if (-not (Test-StudioPathPresent -Path $backup)) {
             $script:StudioVenvRollbackActive = $false
             $script:StudioVenvRollbackPartial = $false
             return
@@ -4227,7 +4236,7 @@ exit 0
         $script:StudioVenvRollbackActive = $false
         $script:StudioVenvRollbackDir = $null
         $script:StudioVenvRollbackPartial = $false
-        if ($backup -and (Test-Path -LiteralPath $backup)) {
+        if (Test-StudioPathPresent -Path $backup) {
             Remove-StudioVenvTreeWithRetry -Path $backup -Label "environment rollback" | Out-Null
         }
     }

--- a/install.ps1
+++ b/install.ps1
@@ -4013,9 +4013,8 @@ exit 0
         return $null
     }
 
-    # Test-Path follows a link, so a dangling one reads as absent. A rollback can
-    # hold any shape Test-DirectoryHasEntries called occupied, a dangling link and
-    # a plain file included, so existence has to be asked of the path itself.
+    # Test-Path follows a link, so a dangling one reads as absent. A rollback holds
+    # whatever Test-DirectoryHasEntries called occupied, so ask the path itself.
     function Test-StudioPathPresent {
         param([Parameter(Mandatory = $true)][AllowEmptyString()][string]$Path)
         if (-not $Path) { return $false }

--- a/install.ps1
+++ b/install.ps1
@@ -3946,6 +3946,22 @@ exit 0
         }
     }
 
+    # uv refuses to create a venv in an occupied directory. The .NET API counts
+    # hidden entries and treats wildcard characters in the path literally.
+    function Test-DirectoryHasEntries {
+        param([Parameter(Mandatory = $true)][string]$Path)
+        if (-not (Test-Path -LiteralPath $Path -PathType Container)) { return $false }
+        try {
+            foreach ($entry in [System.IO.Directory]::EnumerateFileSystemEntries($Path)) {
+                if ($entry) { return $true }
+            }
+        } catch {
+            # Present but unreadable: report it occupied rather than let uv fail on it.
+            return $true
+        }
+        return $false
+    }
+
     function Get-VenvBaseHome {
         param([Parameter(Mandatory = $true)][string]$VenvRoot)
         $configPath = Join-Path $VenvRoot "pyvenv.cfg"
@@ -4182,7 +4198,8 @@ exit 0
 
     $studioVenvReplacementCommitted = $false
     try {
-    if (Test-Path -LiteralPath $VenvPython) {
+    # Replace occupied venvs even when python.exe is missing, as in #9479.
+    if ((Test-Path -LiteralPath $VenvPython) -or (Test-DirectoryHasEntries -Path $VenvDir)) {
         # why: matching guard to the .venv branch below -- in env-mode
         # $StudioHome is a user-chosen workspace, so refuse to nuke an
         # existing $StudioHome\unsloth_studio that lacks Unsloth sentinels.
@@ -4278,7 +4295,7 @@ exit 0
         Write-StudioLine "        Managed Python: $VenvPython" -ForegroundColor Yellow
         if (-not $recordedBaseHome) { $recordedBaseHome = "unavailable" }
         Write-StudioLine "        Recorded base Python home: $recordedBaseHome" -ForegroundColor Yellow
-        # The ownership marker is written above, so a plain re-run replaces this venv.
+        # The occupied-directory branch makes this venv replaceable on a plain re-run.
         Write-StudioLine "        Restore that Python installation, or just re-run install.ps1." -ForegroundColor Yellow
         return (Exit-InstallFailure "Managed Python is unavailable at $VenvPython (recorded base home: $recordedBaseHome)")
     }

--- a/install.ps1
+++ b/install.ps1
@@ -3962,6 +3962,39 @@ exit 0
         return $false
     }
 
+    # Move-Item into a directory that already exists nests the source inside it
+    # rather than renaming it, and uv then refuses the occupied target with the
+    # same error as #9479. Reaching a migration branch already means $VenvDir is
+    # absent or empty, so clear it first. Directory.Delete is non-recursive, so it
+    # cannot take a directory that gained an entry since the check, and on a
+    # reparse point it removes the link without following it to the target.
+    function Clear-MigrationTargetDirectory {
+        param([Parameter(Mandatory = $true)][string]$Path)
+        if (-not (Test-Path -LiteralPath $Path)) { return }
+        $item = Get-Item -LiteralPath $Path -Force
+        if ($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) {
+            # Not Remove-Item: on Windows PowerShell 5.1 it trips a reparse-tag
+            # mismatch on a directory symlink (PowerShell/PowerShell#621).
+            # Directory.Delete unlinks without following the link, but throws
+            # DirectoryNotFoundException when the link points at a file or is
+            # dangling, so fall back to File.Delete for those two shapes.
+            try { [System.IO.Directory]::Delete($Path) }
+            catch {
+                try { [System.IO.File]::Delete($Path) }
+                catch { throw "$Path is in the way of the environment migration. Move it aside and re-run." }
+            }
+            return
+        }
+        if (-not $item.PSIsContainer) {
+            throw "$Path is a file and is in the way of the environment migration. Move it aside and re-run."
+        }
+        try {
+            [System.IO.Directory]::Delete($Path)
+        } catch {
+            throw "$Path is in the way of the environment migration. Move it aside and re-run."
+        }
+    }
+
     function Get-VenvBaseHome {
         param([Parameter(Mandatory = $true)][string]$VenvRoot)
         $configPath = Join-Path $VenvRoot "pyvenv.cfg"
@@ -4250,6 +4283,12 @@ exit 0
         $ErrorActionPreference = $prevEAP2
         if ($legacyOk) {
             substep "legacy environment is healthy -- migrating..."
+            try {
+                Clear-MigrationTargetDirectory -Path $VenvDir
+            } catch {
+                Write-StudioLine "[ERROR] $($_.Exception.Message)" -ForegroundColor Red
+                return (Exit-InstallFailure "Could not clear $VenvDir for the environment migration")
+            }
             Move-Item -LiteralPath $OldVenv -Destination $VenvDir -Force
             substep "moved .venv -> unsloth_studio"
             $_Migrated = $true
@@ -4266,6 +4305,12 @@ exit 0
         # Skip custom-root env-mode so it is not relocated into a workspace root.
         $CwdVenv = Join-Path $env:USERPROFILE "unsloth_studio"
         substep "found CWD-relative Unsloth environment, migrating to $VenvDir..."
+        try {
+            Clear-MigrationTargetDirectory -Path $VenvDir
+        } catch {
+            Write-StudioLine "[ERROR] $($_.Exception.Message)" -ForegroundColor Red
+            return (Exit-InstallFailure "Could not clear $VenvDir for the environment migration")
+        }
         Move-Item -LiteralPath $CwdVenv -Destination $VenvDir -Force
         substep "moved ~/unsloth_studio -> ~/.unsloth/studio/unsloth_studio"
         $_Migrated = $true

--- a/install.ps1
+++ b/install.ps1
@@ -3950,7 +3950,14 @@ exit 0
     # hidden entries and treats wildcard characters in the path literally.
     function Test-DirectoryHasEntries {
         param([Parameter(Mandatory = $true)][string]$Path)
-        if (-not (Test-Path -LiteralPath $Path -PathType Container)) { return $false }
+        if (-not (Test-Path -LiteralPath $Path -PathType Container)) {
+            # Not a directory, but still something: a file, a link to one, or a
+            # link whose target is gone. CreateDirectory answers
+            # ERROR_ALREADY_EXISTS for all three, so uv cannot create here either
+            # and the path has to be moved aside. -PathType Container follows the
+            # link and reports false, so ask Get-Item, which sees the link itself.
+            return ($null -ne (Get-Item -LiteralPath $Path -Force -ErrorAction SilentlyContinue))
+        }
         try {
             foreach ($entry in [System.IO.Directory]::EnumerateFileSystemEntries($Path)) {
                 if ($entry) { return $true }

--- a/install.sh
+++ b/install.sh
@@ -681,6 +681,18 @@ _start_studio_venv_replacement() {
     substep "previous environment preserved for rollback"
 }
 
+# uv refuses to create a venv in an occupied directory. Include hidden entries
+# and dangling symlinks in that check.
+_dir_has_entries() {  # dir
+    [ -d "$1" ] || return 1
+    for _dhe_entry in "$1"/* "$1"/.[!.]* "$1"/..?*; do
+        if [ -e "$_dhe_entry" ] || [ -L "$_dhe_entry" ]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
 # Clear $VENV_DIR for a recreate without ever destroying the only copy. The
 # legacy-layout migration below moves $STUDIO_HOME/.venv straight into $VENV_DIR
 # without going through _start_studio_venv_replacement, so a plain `rm -rf` there
@@ -2747,7 +2759,9 @@ _MIGRATED=false
 # Empty so an inherited value can never masquerade as a probed torch version.
 _PREV_TORCH_VER=""
 
-if [ -x "$VENV_DIR/bin/python" ]; then
+# Replace occupied venvs even when bin/python is missing or dangling, as in
+# the repair loop reported in #9479.
+if [ -x "$VENV_DIR/bin/python" ] || _dir_has_entries "$VENV_DIR"; then
     # why: matching guard to the .venv branch below -- in env-mode
     # $STUDIO_HOME is a user-chosen workspace, so refuse to nuke an
     # existing $STUDIO_HOME/unsloth_studio that lacks Unsloth sentinels.

--- a/install.sh
+++ b/install.sh
@@ -685,12 +685,27 @@ _start_studio_venv_replacement() {
 # and dangling symlinks in that check.
 _dir_has_entries() {  # dir
     [ -d "$1" ] || return 1
+    # Not enumerable: without read the globs cannot expand, and without search
+    # the -e/-L tests below fail on every name, so either way the directory would
+    # be reported empty and handed to uv to fail on. Call it occupied instead,
+    # which is what install.ps1's enumeration catch does, and let the move repair
+    # it: rename needs write on the parent, not on the directory itself.
+    { [ -r "$1" ] && [ -x "$1" ]; } || return 0
+    # The globs below are the whole check, so pathname expansion has to be on for
+    # them; a caller that set -f would otherwise make every directory look empty.
+    # Mirrors _path_has_dir, which saves and restores the flag the other way.
+    _dhe_glob=on
+    case $- in *f*) _dhe_glob=off ;; esac
+    set +f
+    _dhe_found=1
     for _dhe_entry in "$1"/* "$1"/.[!.]* "$1"/..?*; do
         if [ -e "$_dhe_entry" ] || [ -L "$_dhe_entry" ]; then
-            return 0
+            _dhe_found=0
+            break
         fi
     done
-    return 1
+    [ "$_dhe_glob" = off ] && set -f
+    return "$_dhe_found"
 }
 
 # Clear $VENV_DIR for a recreate without ever destroying the only copy. The
@@ -2794,7 +2809,15 @@ if [ -x "$VENV_DIR/bin/python" ] || _dir_has_entries "$VENV_DIR"; then
         "import torch; print(torch.__version__)" 2>/dev/null | tail -n 1 || true)
     # New layout already exists — replace only after preserving rollback copy.
     substep "preserving existing environment for rollback..."
-    _start_studio_venv_replacement "$VENV_DIR"
+    # why: the bare call would still abort under `set -e`, but with nothing on
+    # screen except mv's own stderr. install.ps1 already reports this failure
+    # (Exit-InstallFailure "Could not prepare existing environment for reinstall");
+    # say the same thing here, and name the directory that has to be writable.
+    if ! _start_studio_venv_replacement "$VENV_DIR"; then
+        echo "ERROR: could not move $VENV_DIR aside to reinstall." >&2
+        echo "       Check that $STUDIO_HOME is writable, or move $VENV_DIR yourself and re-run." >&2
+        exit 1
+    fi
 elif [ "$_STUDIO_HOME_REDIRECT" != "env" ] && [ -x "$STUDIO_HOME/.venv/bin/python" ]; then
     # Old layout exists — validate before migrating.
     # Skip in env-mode so we don't rm -rf an unrelated .venv at the
@@ -2820,6 +2843,19 @@ torch.testing.assert_close(torch.unique(E), torch.tensor((20,), device=E.device,
     fi
     if [ "$_legacy_ok" = true ]; then
         echo "✅ Legacy environment is healthy — migrating..."
+        # `mv` into a directory that already exists nests the environment inside
+        # it ($VENV_DIR/.venv) instead of renaming it, and `uv venv` then refuses
+        # the occupied target with the same error as #9479. Reaching this branch
+        # already means $VENV_DIR is absent or empty, so clear it first.
+        # rmdir, never rm -rf: it cannot take a directory that gained an entry
+        # since the check. Unlinking a symlink never touches its target.
+        if [ -L "$VENV_DIR" ]; then
+            rm -f "$VENV_DIR"
+        elif [ -d "$VENV_DIR" ] && ! rmdir "$VENV_DIR" 2>/dev/null; then
+            echo "ERROR: $VENV_DIR is in the way of the legacy migration." >&2
+            echo "       Move it aside and re-run." >&2
+            exit 1
+        fi
         mv "$STUDIO_HOME/.venv" "$VENV_DIR"
         echo "   Moved ~/.unsloth/studio/.venv → $VENV_DIR"
         _MIGRATED=true

--- a/install.sh
+++ b/install.sh
@@ -684,7 +684,16 @@ _start_studio_venv_replacement() {
 # uv refuses to create a venv in an occupied directory. Include hidden entries
 # and dangling symlinks in that check.
 _dir_has_entries() {  # dir
-    [ -d "$1" ] || return 1
+    if [ ! -d "$1" ]; then
+        # Not a directory, but still something: a regular file, a symlink to one,
+        # or a symlink whose target is gone. mkdir(2) answers EEXIST for all three
+        # -- "pathname already exists (not necessarily as a directory)", which the
+        # man page states covers a symbolic link "dangling or not" -- so uv cannot
+        # create here either and the path has to be moved aside. -d follows the
+        # link, and -e alone misses a dangling one, hence the -L.
+        { [ -e "$1" ] || [ -L "$1" ]; } && return 0
+        return 1
+    fi
     # Not enumerable: without read the globs cannot expand, and without search
     # the -e/-L tests below fail on every name, so either way the directory would
     # be reported empty and handed to uv to fail on. Call it occupied instead,

--- a/install.sh
+++ b/install.sh
@@ -730,9 +730,8 @@ _discard_venv_for_recreate() {  # venv dir
 
 _restore_studio_venv_replacement() {
     [ "$_VENV_ROLLBACK_ACTIVE" = true ] || return 0
-    # -e/-L, not -d: what was moved aside is whatever _dir_has_entries called
-    # occupied, which includes a regular file and a symlink with no target. -d
-    # would drop those, deactivate the rollback, and strand the original.
+    # -e/-L, not -d: a rollback holds whatever _dir_has_entries called occupied,
+    # and -d would drop a file or a dangling link and strand the original.
     [ -n "$_VENV_ROLLBACK_DIR" ] \
         && { [ -e "$_VENV_ROLLBACK_DIR" ] || [ -L "$_VENV_ROLLBACK_DIR" ]; } || {
         _VENV_ROLLBACK_ACTIVE=false
@@ -797,8 +796,7 @@ _commit_studio_venv_replacement() {
         # before deletion so an interrupt cannot replace it with a half-deleted backup.
         _VENV_ROLLBACK_ACTIVE=false
         _VENV_ROLLBACK_DIR=""
-        # Same shapes as the restore above, or a file/dangling-link backup is
-        # never cleaned up and litters $STUDIO_HOME after a successful install.
+        # Same shapes as the restore, or such a backup is never cleaned up.
         if [ -n "$_rollback_to_remove" ] \
            && { [ -e "$_rollback_to_remove" ] || [ -L "$_rollback_to_remove" ]; }; then
             if ! rm -rf "$_rollback_to_remove"; then

--- a/install.sh
+++ b/install.sh
@@ -730,7 +730,11 @@ _discard_venv_for_recreate() {  # venv dir
 
 _restore_studio_venv_replacement() {
     [ "$_VENV_ROLLBACK_ACTIVE" = true ] || return 0
-    [ -n "$_VENV_ROLLBACK_DIR" ] && [ -d "$_VENV_ROLLBACK_DIR" ] || {
+    # -e/-L, not -d: what was moved aside is whatever _dir_has_entries called
+    # occupied, which includes a regular file and a symlink with no target. -d
+    # would drop those, deactivate the rollback, and strand the original.
+    [ -n "$_VENV_ROLLBACK_DIR" ] \
+        && { [ -e "$_VENV_ROLLBACK_DIR" ] || [ -L "$_VENV_ROLLBACK_DIR" ]; } || {
         _VENV_ROLLBACK_ACTIVE=false
         return 0
     }
@@ -793,7 +797,10 @@ _commit_studio_venv_replacement() {
         # before deletion so an interrupt cannot replace it with a half-deleted backup.
         _VENV_ROLLBACK_ACTIVE=false
         _VENV_ROLLBACK_DIR=""
-        if [ -n "$_rollback_to_remove" ] && [ -d "$_rollback_to_remove" ]; then
+        # Same shapes as the restore above, or a file/dangling-link backup is
+        # never cleaned up and litters $STUDIO_HOME after a successful install.
+        if [ -n "$_rollback_to_remove" ] \
+           && { [ -e "$_rollback_to_remove" ] || [ -L "$_rollback_to_remove" ]; }; then
             if ! rm -rf "$_rollback_to_remove"; then
                 echo "⚠️  Could not remove environment rollback $_rollback_to_remove" >&2
             fi

--- a/install.sh
+++ b/install.sh
@@ -681,28 +681,22 @@ _start_studio_venv_replacement() {
     substep "previous environment preserved for rollback"
 }
 
-# uv refuses to create a venv in an occupied directory. Include hidden entries
-# and dangling symlinks in that check.
+# uv creates only into a path that is absent or an empty directory. Everything
+# else is occupied, hidden entries and non-resolving symlinks included.
 _dir_has_entries() {  # dir
     if [ ! -d "$1" ]; then
-        # Not a directory, but still something: a regular file, a symlink to one,
-        # or a symlink whose target is gone. mkdir(2) answers EEXIST for all three
-        # -- "pathname already exists (not necessarily as a directory)", which the
-        # man page states covers a symbolic link "dangling or not" -- so uv cannot
-        # create here either and the path has to be moved aside. -d follows the
-        # link, and -e alone misses a dangling one, hence the -L.
+        # Still an existing path to mkdir(2), which answers EEXIST for a file or
+        # for a symlink "dangling or not", so uv refuses it too. -d follows the
+        # link and -e misses a dangling one, hence the -L.
         { [ -e "$1" ] || [ -L "$1" ]; } && return 0
         return 1
     fi
-    # Not enumerable: without read the globs cannot expand, and without search
-    # the -e/-L tests below fail on every name, so either way the directory would
-    # be reported empty and handed to uv to fail on. Call it occupied instead,
-    # which is what install.ps1's enumeration catch does, and let the move repair
-    # it: rename needs write on the parent, not on the directory itself.
+    # Not enumerable: the globs cannot expand without read, and the tests below
+    # fail on every name without search, so it would read as empty. Fail closed
+    # like install.ps1's catch; the rename only needs write on the parent.
     { [ -r "$1" ] && [ -x "$1" ]; } || return 0
-    # The globs below are the whole check, so pathname expansion has to be on for
-    # them; a caller that set -f would otherwise make every directory look empty.
-    # Mirrors _path_has_dir, which saves and restores the flag the other way.
+    # The globs are the whole check, so a caller's set -f would make every
+    # directory look empty. Mirrors _path_has_dir, which saves the flag too.
     _dhe_glob=on
     case $- in *f*) _dhe_glob=off ;; esac
     set +f
@@ -2818,10 +2812,8 @@ if [ -x "$VENV_DIR/bin/python" ] || _dir_has_entries "$VENV_DIR"; then
         "import torch; print(torch.__version__)" 2>/dev/null | tail -n 1 || true)
     # New layout already exists — replace only after preserving rollback copy.
     substep "preserving existing environment for rollback..."
-    # why: the bare call would still abort under `set -e`, but with nothing on
-    # screen except mv's own stderr. install.ps1 already reports this failure
-    # (Exit-InstallFailure "Could not prepare existing environment for reinstall");
-    # say the same thing here, and name the directory that has to be writable.
+    # A bare call still aborts under `set -e`, but shows only mv's own stderr.
+    # install.ps1 reports this step; say the same here and name the directory.
     if ! _start_studio_venv_replacement "$VENV_DIR"; then
         echo "ERROR: could not move $VENV_DIR aside to reinstall." >&2
         echo "       Check that $STUDIO_HOME is writable, or move $VENV_DIR yourself and re-run." >&2
@@ -2852,12 +2844,11 @@ torch.testing.assert_close(torch.unique(E), torch.tensor((20,), device=E.device,
     fi
     if [ "$_legacy_ok" = true ]; then
         echo "✅ Legacy environment is healthy — migrating..."
-        # `mv` into a directory that already exists nests the environment inside
-        # it ($VENV_DIR/.venv) instead of renaming it, and `uv venv` then refuses
-        # the occupied target with the same error as #9479. Reaching this branch
-        # already means $VENV_DIR is absent or empty, so clear it first.
-        # rmdir, never rm -rf: it cannot take a directory that gained an entry
-        # since the check. Unlinking a symlink never touches its target.
+        # `mv` into an existing directory nests the environment inside it
+        # ($VENV_DIR/.venv) rather than renaming it, and uv then refuses that
+        # target as in #9479. This branch already means $VENV_DIR is absent or
+        # empty, so clear it: rmdir cannot take one that gained an entry since
+        # the check, and unlinking a symlink never touches its target.
         if [ -L "$VENV_DIR" ]; then
             rm -f "$VENV_DIR"
         elif [ -d "$VENV_DIR" ] && ! rmdir "$VENV_DIR" 2>/dev/null; then

--- a/tests/python/test_windows_python_venv_hardening.py
+++ b/tests/python/test_windows_python_venv_hardening.py
@@ -224,6 +224,7 @@ def test_restoring_a_split_move_never_deletes_the_half_left_behind(tmp_path: Pat
     blocks = "".join(
         _extract(rf"    function {name} \{{.*?\n    \}}\n", source)
         for name in (
+            "Test-StudioPathPresent",
             "Remove-StudioVenvTreeWithRetry",
             "Merge-StudioVenvRollbackTree",
             "Restore-StudioVenvRollback",
@@ -280,6 +281,7 @@ def test_merging_a_split_move_keeps_every_sibling_at_its_own_path(tmp_path: Path
     blocks = "".join(
         _extract(rf"    function {name} \{{.*?\n    \}}\n", source)
         for name in (
+            "Test-StudioPathPresent",
             "Remove-StudioVenvTreeWithRetry",
             "Merge-StudioVenvRollbackTree",
             "Restore-StudioVenvRollback",
@@ -347,6 +349,7 @@ def test_merging_a_split_move_never_walks_through_a_link(tmp_path: Path, shell: 
     blocks = "".join(
         _extract(rf"    function {name} \{{.*?\n    \}}\n", source)
         for name in (
+            "Test-StudioPathPresent",
             "Remove-StudioVenvTreeWithRetry",
             "Merge-StudioVenvRollbackTree",
             "Restore-StudioVenvRollback",

--- a/tests/test_studio_install_workspace_guard.py
+++ b/tests/test_studio_install_workspace_guard.py
@@ -1151,8 +1151,8 @@ def _run_venv_chain(studio_home, redirect = "default"):
         # Mirrors the `if [ ! -x "$VENV_DIR/bin/python" ]` create gate below the chain.
         + 'if [ -x "$VENV_DIR/bin/python" ]; then echo UV=skipped_migrated\n'
         + 'elif [ -d "$VENV_DIR" ] && [ -n "$(ls -A "$VENV_DIR" 2>/dev/null)" ]; then\n'
-        + '    echo UV=would_fail_dir_not_empty\n'
-        + 'else echo UV=would_create_ok; fi\n'
+        + "    echo UV=would_fail_dir_not_empty\n"
+        + "else echo UV=would_create_ok; fi\n"
     )
     return subprocess.run(
         ["bash", "-c", script],
@@ -1239,13 +1239,17 @@ def test_occupied_venv_dir_still_wins_over_legacy_migration(tmp_path):
 def test_install_sh_reports_a_failed_venv_move(tmp_path):
     """A failed move must say so, matching install.ps1's Exit-InstallFailure on the same step."""
     src = INSTALL_SH.read_text(encoding = "utf-8")
-    assert 'if ! _start_studio_venv_replacement "$VENV_DIR"; then' in src, (
-        "install.sh must check the replacement helper rather than relying on bare set -e"
-    )
+    assert (
+        'if ! _start_studio_venv_replacement "$VENV_DIR"; then' in src
+    ), "install.sh must check the replacement helper rather than relying on bare set -e"
     assert "could not move $VENV_DIR aside to reinstall" in src
 
 
-def _dir_has_entries_says(tmp_path, target, pre = ""):
+def _dir_has_entries_says(
+    tmp_path,
+    target,
+    pre = "",
+):
     """Run the real _dir_has_entries from install.sh against one directory."""
     script = (
         _extract_install_sh_function("_dir_has_entries")
@@ -1253,7 +1257,10 @@ def _dir_has_entries_says(tmp_path, target, pre = ""):
         + f'if _dir_has_entries "{target}"; then echo yes; else echo no; fi\n'
     )
     res = subprocess.run(
-        ["bash", "-c", script], env = {"PATH": "/usr/bin:/bin"}, text = True, capture_output = True,
+        ["bash", "-c", script],
+        env = {"PATH": "/usr/bin:/bin"},
+        text = True,
+        capture_output = True,
     )
     assert res.returncode == 0, f"stderr={res.stderr!r}"
     return res.stdout.strip()
@@ -1270,9 +1277,9 @@ def test_dir_has_entries_survives_noglob_in_the_caller(tmp_path):
 
     empty = tmp_path / "empty"
     empty.mkdir()
-    assert _dir_has_entries_says(tmp_path, empty, pre = "set -f") == "no", (
-        "an empty directory must still be left for uv to create into"
-    )
+    assert (
+        _dir_has_entries_says(tmp_path, empty, pre = "set -f") == "no"
+    ), "an empty directory must still be left for uv to create into"
 
 
 def test_dir_has_entries_restores_the_callers_noglob_setting(tmp_path):
@@ -1283,13 +1290,16 @@ def test_dir_has_entries_restores_the_callers_noglob_setting(tmp_path):
         _extract_install_sh_function("_dir_has_entries")
         + "set -f\n"
         + f'_dir_has_entries "{empty}" || true\n'
-        + 'case $- in *f*) echo NOGLOB_KEPT ;; *) echo NOGLOB_LOST ;; esac\n'
+        + "case $- in *f*) echo NOGLOB_KEPT ;; *) echo NOGLOB_LOST ;; esac\n"
         + "set +f\n"
         + f'_dir_has_entries "{empty}" || true\n'
-        + 'case $- in *f*) echo GLOB_LOST ;; *) echo GLOB_KEPT ;; esac\n'
+        + "case $- in *f*) echo GLOB_LOST ;; *) echo GLOB_KEPT ;; esac\n"
     )
     res = subprocess.run(
-        ["bash", "-c", script], env = {"PATH": "/usr/bin:/bin"}, text = True, capture_output = True,
+        ["bash", "-c", script],
+        env = {"PATH": "/usr/bin:/bin"},
+        text = True,
+        capture_output = True,
     )
     assert "NOGLOB_KEPT" in res.stdout, "the caller's `set -f` must be restored"
     assert "GLOB_KEPT" in res.stdout, "a caller without `set -f` must not gain it"

--- a/tests/test_studio_install_workspace_guard.py
+++ b/tests/test_studio_install_workspace_guard.py
@@ -1335,3 +1335,76 @@ def test_dir_has_entries_still_answers_no_for_a_searchable_empty_dir(tmp_path):
         assert _dir_has_entries_says(tmp_path, empty) == "no"
     finally:
         empty.chmod(0o700)
+
+
+# uv creates a venv only into a path that is absent or an empty directory; every
+# other shape is EEXIST/ERROR_ALREADY_EXISTS. Measured against uv 0.12.1, the
+# version install.sh pins. _dir_has_entries has to agree, or the repair loop the
+# widened branch is meant to end simply continues for the shapes it misses.
+_UV_REFUSES = [
+    ("occupied real dir", "fulldir", True),
+    ("regular file", "plainfile", True),
+    ("dangling symlink", "dangling", True),
+    ("symlink to a file", "link_to_file", True),
+    ("symlink to an occupied dir", "link_to_full", True),
+    ("absent path", "absent", False),
+    ("empty real dir", "emptydir", False),
+    ("symlink to an empty dir", "link_to_empty", False),
+]
+
+
+def _make_uv_shape(root, shape):
+    if shape == "absent":
+        return root / "absent"
+    if shape == "emptydir":
+        (root / "emptydir").mkdir()
+        return root / "emptydir"
+    if shape == "fulldir":
+        (root / "fulldir").mkdir()
+        (root / "fulldir" / "x").write_text("x")
+        return root / "fulldir"
+    if shape == "plainfile":
+        (root / "plainfile").write_text("x")
+        return root / "plainfile"
+    if shape == "dangling":
+        (root / "dangling").symlink_to(root / "gone")
+        return root / "dangling"
+    if shape == "link_to_file":
+        (root / "target_file").write_text("x")
+        (root / "link_to_file").symlink_to(root / "target_file")
+        return root / "link_to_file"
+    if shape == "link_to_full":
+        (root / "target_full").mkdir()
+        (root / "target_full" / "x").write_text("x")
+        (root / "link_to_full").symlink_to(root / "target_full")
+        return root / "link_to_full"
+    if shape == "link_to_empty":
+        (root / "target_empty").mkdir()
+        (root / "link_to_empty").symlink_to(root / "target_empty")
+        return root / "link_to_empty"
+    raise AssertionError(shape)
+
+
+@pytest.mark.parametrize(
+    "label,shape,uv_refuses",
+    _UV_REFUSES,
+    ids = [row[1] for row in _UV_REFUSES],
+)
+def test_dir_has_entries_matches_what_uv_refuses(tmp_path, label, shape, uv_refuses):
+    """The predicate must answer uv's question, not "is this a non-empty directory"."""
+    target = _make_uv_shape(tmp_path, shape)
+    answer = _dir_has_entries_says(tmp_path, target)
+    assert answer == ("yes" if uv_refuses else "no"), (
+        f"{label}: uv {'refuses' if uv_refuses else 'creates into'} this path, "
+        f"so the replacement branch must {'run' if uv_refuses else 'be skipped'}"
+    )
+
+
+def test_install_ps1_helper_answers_on_the_link_itself():
+    """install.ps1 must match: -PathType Container follows a link and misses a dangling one."""
+    src = INSTALL_PS1.read_text(encoding = "utf-8")
+    helper_start = src.index("function Test-DirectoryHasEntries")
+    helper = src[helper_start : src.index("function Clear-MigrationTargetDirectory", helper_start)]
+    assert "Get-Item -LiteralPath $Path -Force" in helper, (
+        "a dangling link is invisible to -PathType Container but still blocks uv"
+    )

--- a/tests/test_studio_install_workspace_guard.py
+++ b/tests/test_studio_install_workspace_guard.py
@@ -1123,10 +1123,10 @@ def test_install_ps1_replacement_branch_covers_an_occupied_venv_dir():
 
 
 def _extract_install_sh_venv_chain() -> str:
-    """Extract the whole venv if/elif chain, past the legacy migration to its closing `fi`.
+    """Extract the venv if/elif chain past the legacy migration to its closing `fi`.
 
-    _extract_install_sh_guard_block stops at the first elif, so it cannot see how the
-    widened first branch and the legacy $STUDIO_HOME/.venv migration interact.
+    _extract_install_sh_guard_block stops at the first elif, so it cannot see the two
+    interacting.
     """
     src = INSTALL_SH.read_text(encoding = "utf-8")
     m = re.search(
@@ -1309,8 +1309,7 @@ def test_dir_has_entries_restores_the_callers_noglob_setting(tmp_path):
 def test_dir_has_entries_treats_an_unenumerable_directory_as_occupied(tmp_path, mode):
     """uv refuses these targets, so reporting them empty would wedge the repair.
 
-    0o444 is readable but not searchable: the globs expand to names, then every
-    -e test fails. 0o111 is the mirror. Both need the same answer as 0o000.
+    0o444 is readable but not searchable, 0o111 the mirror; both must answer as 0o000.
     """
     if os.geteuid() == 0:
         pytest.skip("root ignores directory permissions")
@@ -1319,8 +1318,7 @@ def test_dir_has_entries_treats_an_unenumerable_directory_as_occupied(tmp_path, 
     (blocked / "file.txt").write_text("x")
     blocked.chmod(mode)
     try:
-        # install.ps1's Test-DirectoryHasEntries returns $true from its catch for the
-        # same case; the two installers must not disagree here.
+        # install.ps1's catch returns $true here; the two must not disagree.
         assert _dir_has_entries_says(tmp_path, blocked) == "yes"
     finally:
         blocked.chmod(0o700)
@@ -1337,10 +1335,9 @@ def test_dir_has_entries_still_answers_no_for_a_searchable_empty_dir(tmp_path):
         empty.chmod(0o700)
 
 
-# uv creates a venv only into a path that is absent or an empty directory; every
-# other shape is EEXIST/ERROR_ALREADY_EXISTS. Measured against uv 0.12.1, the
-# version install.sh pins. _dir_has_entries has to agree, or the repair loop the
-# widened branch is meant to end simply continues for the shapes it misses.
+# Measured against uv 0.12.1, the version install.sh pins: uv creates only into a
+# path that is absent or an empty directory, every other shape is EEXIST. The
+# predicate has to agree, or the repair loop continues for the shapes it misses.
 _UV_REFUSES = [
     ("occupied real dir", "fulldir", True),
     ("regular file", "plainfile", True),

--- a/tests/test_studio_install_workspace_guard.py
+++ b/tests/test_studio_install_workspace_guard.py
@@ -1452,9 +1452,8 @@ def _run_rollback_lifecycle(studio_home, shape):
 def test_rollback_restores_every_shape_the_predicate_moves_aside(tmp_path, shape):
     """Whatever _dir_has_entries calls occupied has to be restorable on failure.
 
-    The restore tested existence with -d, so a regular file or a dangling link was
-    silently dropped: the rollback deactivated itself, the original stayed stranded
-    under the rollback name, and the half-built venv was left at $VENV_DIR.
+    Testing with -d dropped a regular file and a dangling link: the rollback
+    deactivated itself and the half-built venv stayed at $VENV_DIR.
     """
     studio_home = tmp_path / "ws"
     studio_home.mkdir()

--- a/tests/test_studio_install_workspace_guard.py
+++ b/tests/test_studio_install_workspace_guard.py
@@ -12,18 +12,27 @@ INSTALL_PS1 = REPO_ROOT / "install.ps1"
 SETUP_PS1 = REPO_ROOT / "studio" / "setup.ps1"
 SETUP_SH = REPO_ROOT / "studio" / "setup.sh"
 
-# Stubs for helpers the extracted guard block calls; mv-based replacement reproduces the venv-gone
-# effect without the full rollback machinery.
+# Stub the rollback helper with a move. The directory predicate is extracted
+# from install.sh because it controls whether the guard runs.
 _INSTALL_GUARD_STUBS = (
     'substep() { :; }\n_start_studio_venv_replacement() {\n    mv -- "$1" "$1.replaced"\n}\n'
 )
+
+
+def _extract_install_sh_function(name: str) -> str:
+    """Extract a top-level install.sh shell function, header line to closing brace."""
+    src = INSTALL_SH.read_text(encoding = "utf-8")
+    m = re.search(rf"^{re.escape(name)}\(\) \{{.*?\n\}}\n", src, re.DOTALL | re.MULTILINE)
+    assert m, f"install.sh function {name} not found"
+    return m.group(0)
 
 
 def _extract_install_sh_guard_block() -> str:
     """Extract install.sh's venv guard block (up to the first elif) as a self-contained snippet."""
     src = INSTALL_SH.read_text(encoding = "utf-8")
     m = re.search(
-        r'(if \[ -x "\$VENV_DIR/bin/python" \]; then\n.*?)elif \[ "\$_STUDIO_HOME_REDIRECT" != "env"',
+        r'(if \[ -x "\$VENV_DIR/bin/python" \] \|\| _dir_has_entries "\$VENV_DIR"; then\n.*?)'
+        r'elif \[ "\$_STUDIO_HOME_REDIRECT" != "env"',
         src,
         re.DOTALL,
     )
@@ -41,6 +50,7 @@ def _build_install_guard_script(
         block = _extract_install_sh_guard_block()
     return (
         _INSTALL_GUARD_STUBS
+        + _extract_install_sh_function("_dir_has_entries")
         + f'STUDIO_HOME="{studio_home}"\n'
         + f'VENV_DIR="$STUDIO_HOME/unsloth_studio"\n'
         + f'_STUDIO_HOME_REDIRECT="{redirect}"\n'
@@ -117,7 +127,7 @@ def test_default_mode_skips_sentinel_check(tmp_path):
 
 def test_install_ps1_has_matching_env_mode_guard():
     src = INSTALL_PS1.read_text(encoding = "utf-8")
-    block_start = src.index("if (Test-Path -LiteralPath $VenvPython)")
+    block_start = src.index("# why: matching guard to the .venv branch below")
     block = src[block_start : block_start + 2000]
     assert (
         "$StudioRedirectMode -eq 'env'" in block
@@ -191,7 +201,7 @@ def test_env_mode_passes_when_bin_unsloth_is_a_symlink(tmp_path):
 def test_install_ps1_sentinel_uses_pathtype_leaf():
     """Remove-Item $VenvDir gate must use -PathType Leaf so a sentinel-path directory cannot satisfy it."""
     src = INSTALL_PS1.read_text(encoding = "utf-8")
-    block_start = src.index("if (Test-Path -LiteralPath $VenvPython)")
+    block_start = src.index("# why: matching guard to the .venv branch below")
     block = src[block_start : block_start + 2000]
     assert (
         'share\\studio.conf") -PathType Leaf' in block
@@ -347,7 +357,7 @@ def test_install_ps1_writes_venv_marker_after_uv_venv():
 def test_install_ps1_guard_accepts_venv_marker():
     """install.ps1 env-mode guard must accept the in-VENV .unsloth-studio-owned marker as a sentinel."""
     src = INSTALL_PS1.read_text(encoding = "utf-8")
-    block_start = src.index("if (Test-Path -LiteralPath $VenvPython)")
+    block_start = src.index("# why: matching guard to the .venv branch below")
     block = src[block_start : block_start + 2000]
     assert (
         '$VenvDir ".unsloth-studio-owned") -PathType Leaf' in block
@@ -1012,3 +1022,98 @@ def test_install_ps1_install_id_file_layout_matches_backend_read_path():
     assert (
         "[System.IO.File]::Move($_idTmp, $_studioIdFile)" in context
     ), "install.ps1 must atomic-rename the temp file into place to avoid half-written ids"
+
+
+def _make_interpreterless_venv(studio_home):
+    """A venv whose uv-managed CPython was deleted: pyvenv.cfg intact, bin/python dangling."""
+    venv = studio_home / "unsloth_studio"
+    (venv / "bin").mkdir(parents = True)
+    (venv / "pyvenv.cfg").write_text("home = /gone/bin\nversion_info = 3.13.14\n")
+    (venv / "bin" / "python").symlink_to("/gone/bin/python3.13")
+    return venv
+
+
+def _run_guard_block(studio_home, redirect):
+    return subprocess.run(
+        ["bash", "-c", _build_install_guard_script(studio_home, redirect)],
+        env = {"PATH": "/usr/bin:/bin"},
+        text = True,
+        capture_output = True,
+    )
+
+
+def test_install_sh_replaces_venv_whose_interpreter_is_gone(tmp_path):
+    """A venv with no usable bin/python must still be moved aside: uv 0.10 will not overwrite it."""
+    studio_home = tmp_path / "ws"
+    venv = _make_interpreterless_venv(studio_home)
+    res = _run_guard_block(studio_home, "default")
+    assert res.returncode == 0, f"stdout={res.stdout!r} stderr={res.stderr!r}"
+    assert "RESULT=ok" in res.stdout
+    assert not venv.exists(), "install.sh must clear $VENV_DIR before `uv venv` runs"
+
+
+def test_install_sh_replaces_venv_dir_holding_only_hidden_entries(tmp_path):
+    """uv refuses any non-empty target, so a leftover holding only dotfiles must be cleared too."""
+    studio_home = tmp_path / "ws"
+    venv = studio_home / "unsloth_studio"
+    venv.mkdir(parents = True)
+    (venv / ".unsloth-studio-owned").write_text("")
+    res = _run_guard_block(studio_home, "default")
+    assert res.returncode == 0, f"stdout={res.stdout!r} stderr={res.stderr!r}"
+    assert not venv.exists()
+
+
+def test_install_sh_leaves_absent_and_empty_venv_dir_to_uv(tmp_path):
+    """uv creates into a missing or empty directory, so neither may trigger a rollback move."""
+    studio_home = tmp_path / "ws"
+    studio_home.mkdir()
+    res = _run_guard_block(studio_home, "default")
+    assert res.returncode == 0, f"stdout={res.stdout!r} stderr={res.stderr!r}"
+    assert not (studio_home / "unsloth_studio.replaced").exists()
+
+    (studio_home / "unsloth_studio").mkdir()
+    res = _run_guard_block(studio_home, "default")
+    assert res.returncode == 0, f"stdout={res.stdout!r} stderr={res.stderr!r}"
+    assert (studio_home / "unsloth_studio").is_dir(), "an empty $VENV_DIR must be left in place"
+    assert not (studio_home / "unsloth_studio.replaced").exists()
+
+
+def test_env_mode_blocks_interpreterless_venv_without_sentinels(tmp_path):
+    """The env-mode ownership guard must cover the interpreter-less case, not just the healthy one."""
+    studio_home = tmp_path / "ws"
+    venv = _make_interpreterless_venv(studio_home)
+    (venv / "important.txt").write_text("keep me")
+    res = _run_guard_block(studio_home, "env")
+    assert res.returncode != 0, (
+        "env-mode without sentinels must refuse to replace $VENV_DIR; "
+        f"stdout={res.stdout!r} stderr={res.stderr!r}"
+    )
+    assert "does not look like an Unsloth Studio install" in res.stderr
+    assert (venv / "important.txt").is_file(), "unrelated workspace data must survive"
+
+
+def test_env_mode_replaces_interpreterless_venv_when_marker_present(tmp_path):
+    """A partial install that left the marker must be replaceable on the next run."""
+    studio_home = tmp_path / "ws"
+    venv = _make_interpreterless_venv(studio_home)
+    (venv / ".unsloth-studio-owned").write_text("")
+    res = _run_guard_block(studio_home, "env")
+    assert res.returncode == 0, f"stdout={res.stdout!r} stderr={res.stderr!r}"
+    assert not venv.exists()
+
+
+def test_install_ps1_replacement_branch_covers_an_occupied_venv_dir():
+    """install.ps1 must move a venv aside on directory content, not only on a present python.exe."""
+    src = INSTALL_PS1.read_text(encoding = "utf-8")
+    assert (
+        "if ((Test-Path -LiteralPath $VenvPython) -or (Test-DirectoryHasEntries -Path $VenvDir))"
+        in src
+    ), "install.ps1 must treat an occupied $VenvDir as an environment to replace"
+    helper_start = src.index("function Test-DirectoryHasEntries")
+    helper = src[helper_start : src.index("function Get-VenvBaseHome", helper_start)]
+    assert (
+        "[System.IO.Directory]::EnumerateFileSystemEntries($Path)" in helper
+    ), "Test-DirectoryHasEntries must count hidden entries and not read the path as a wildcard"
+    assert (
+        "-PathType Container" in helper
+    ), "Test-DirectoryHasEntries must answer false for a missing directory"

--- a/tests/test_studio_install_workspace_guard.py
+++ b/tests/test_studio_install_workspace_guard.py
@@ -1405,3 +1405,76 @@ def test_install_ps1_helper_answers_on_the_link_itself():
     assert (
         "Get-Item -LiteralPath $Path -Force" in helper
     ), "a dangling link is invisible to -PathType Container but still blocks uv"
+
+
+def _run_rollback_lifecycle(studio_home, shape):
+    """Move $VENV_DIR aside, half-create a new venv, then fail and restore."""
+    fns = [
+        "_start_studio_venv_replacement",
+        "_restore_studio_venv_replacement",
+        "_commit_studio_venv_replacement",
+    ]
+    src = INSTALL_SH.read_text(encoding = "utf-8")
+    helpers = ""
+    for fn in fns:
+        m = re.search(rf"^{re.escape(fn)}\(\) \{{.*?\n\}}\n", src, re.DOTALL | re.MULTILINE)
+        assert m, fn
+        helpers += m.group(0)
+    venv = studio_home / "unsloth_studio"
+    if shape == "realdir":
+        venv.mkdir()
+        (venv / "keep.txt").write_text("CANARY")
+    elif shape == "regularfile":
+        venv.write_text("CANARY")
+    elif shape == "danglinglink":
+        venv.symlink_to(studio_home / "gone")
+    else:
+        raise AssertionError(shape)
+    script = (
+        "substep() { :; }\nrollback_substep() { :; }\n"
+        + helpers
+        + f'STUDIO_HOME="{studio_home}"\n'
+        + 'VENV_DIR="$STUDIO_HOME/unsloth_studio"\n'
+        + '_VENV_ROLLBACK_TARGET="$VENV_DIR"\n_VENV_ROLLBACK_DIR=""\n_VENV_ROLLBACK_ACTIVE=false\n'
+        + '_start_studio_venv_replacement "$VENV_DIR"\n'
+        + 'mkdir -p "$VENV_DIR/bin"; echo partial > "$VENV_DIR/bin/python"\n'
+        + "_restore_studio_venv_replacement\n"
+    )
+    return subprocess.run(
+        ["bash", "-c", script], env = {"PATH": "/usr/bin:/bin"}, text = True, capture_output = True,
+    )
+
+
+@pytest.mark.parametrize("shape", ["realdir", "regularfile", "danglinglink"])
+def test_rollback_restores_every_shape_the_predicate_moves_aside(tmp_path, shape):
+    """Whatever _dir_has_entries calls occupied has to be restorable on failure.
+
+    The restore tested existence with -d, so a regular file or a dangling link was
+    silently dropped: the rollback deactivated itself, the original stayed stranded
+    under the rollback name, and the half-built venv was left at $VENV_DIR.
+    """
+    studio_home = tmp_path / "ws"
+    studio_home.mkdir()
+    res = _run_rollback_lifecycle(studio_home, shape)
+    assert res.returncode == 0, f"stdout={res.stdout!r} stderr={res.stderr!r}"
+
+    venv = studio_home / "unsloth_studio"
+    assert venv.exists() or venv.is_symlink(), "the original must be back at $VENV_DIR"
+    assert not (venv / "bin" / "python").is_file(), "the half-built venv must be gone"
+    stranded = list(studio_home.glob("unsloth_studio.rollback.*"))
+    assert not stranded, f"backup left stranded: {[p.name for p in stranded]}"
+
+
+def test_install_ps1_rollback_tests_the_path_not_the_link_target():
+    """Test-Path follows a link, so a dangling backup would read as absent."""
+    src = INSTALL_PS1.read_text(encoding = "utf-8")
+    assert "function Test-StudioPathPresent" in src
+    for fn, nxt in (
+        ("Restore-StudioVenvRollback", "Complete-StudioVenvRollback"),
+        ("Complete-StudioVenvRollback", None),
+    ):
+        start = src.index(f"function {fn} {{")
+        end = src.index(f"function {nxt} {{", start) if nxt else start + 1200
+        assert "Test-StudioPathPresent" in src[start:end], (
+            f"{fn} must test the backup path itself, not the link target"
+        )

--- a/tests/test_studio_install_workspace_guard.py
+++ b/tests/test_studio_install_workspace_guard.py
@@ -1402,6 +1402,6 @@ def test_install_ps1_helper_answers_on_the_link_itself():
     src = INSTALL_PS1.read_text(encoding = "utf-8")
     helper_start = src.index("function Test-DirectoryHasEntries")
     helper = src[helper_start : src.index("function Clear-MigrationTargetDirectory", helper_start)]
-    assert "Get-Item -LiteralPath $Path -Force" in helper, (
-        "a dangling link is invisible to -PathType Container but still blocks uv"
-    )
+    assert (
+        "Get-Item -LiteralPath $Path -Force" in helper
+    ), "a dangling link is invisible to -PathType Container but still blocks uv"

--- a/tests/test_studio_install_workspace_guard.py
+++ b/tests/test_studio_install_workspace_guard.py
@@ -1441,7 +1441,10 @@ def _run_rollback_lifecycle(studio_home, shape):
         + "_restore_studio_venv_replacement\n"
     )
     return subprocess.run(
-        ["bash", "-c", script], env = {"PATH": "/usr/bin:/bin"}, text = True, capture_output = True,
+        ["bash", "-c", script],
+        env = {"PATH": "/usr/bin:/bin"},
+        text = True,
+        capture_output = True,
     )
 
 
@@ -1475,6 +1478,6 @@ def test_install_ps1_rollback_tests_the_path_not_the_link_target():
     ):
         start = src.index(f"function {fn} {{")
         end = src.index(f"function {nxt} {{", start) if nxt else start + 1200
-        assert "Test-StudioPathPresent" in src[start:end], (
-            f"{fn} must test the backup path itself, not the link target"
-        )
+        assert (
+            "Test-StudioPathPresent" in src[start:end]
+        ), f"{fn} must test the backup path itself, not the link target"

--- a/tests/test_studio_install_workspace_guard.py
+++ b/tests/test_studio_install_workspace_guard.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import os
 import re
 import subprocess
 from pathlib import Path
+
+import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 INSTALL_SH = REPO_ROOT / "install.sh"
@@ -1117,3 +1120,208 @@ def test_install_ps1_replacement_branch_covers_an_occupied_venv_dir():
     assert (
         "-PathType Container" in helper
     ), "Test-DirectoryHasEntries must answer false for a missing directory"
+
+
+def _extract_install_sh_venv_chain() -> str:
+    """Extract the whole venv if/elif chain, past the legacy migration to its closing `fi`.
+
+    _extract_install_sh_guard_block stops at the first elif, so it cannot see how the
+    widened first branch and the legacy $STUDIO_HOME/.venv migration interact.
+    """
+    src = INSTALL_SH.read_text(encoding = "utf-8")
+    m = re.search(
+        r'^(if \[ -x "\$VENV_DIR/bin/python" \] \|\| _dir_has_entries "\$VENV_DIR"; then\n.*?^fi$)',
+        src,
+        re.DOTALL | re.MULTILINE,
+    )
+    assert m, "install.sh venv chain not found"
+    return m.group(1) + "\n"
+
+
+def _run_venv_chain(studio_home, redirect = "default"):
+    """Run the full chain, then report what `uv venv` would face at install.sh's create gate."""
+    script = (
+        _INSTALL_GUARD_STUBS
+        + _extract_install_sh_function("_dir_has_entries")
+        + f'STUDIO_HOME="{studio_home}"\n'
+        + 'VENV_DIR="$STUDIO_HOME/unsloth_studio"\n'
+        + f'_STUDIO_HOME_REDIRECT="{redirect}"\n'
+        + 'SKIP_TORCH=true\n_MIGRATED=false\n_PREV_TORCH_VER=""\n'
+        + _extract_install_sh_venv_chain()
+        # Mirrors the `if [ ! -x "$VENV_DIR/bin/python" ]` create gate below the chain.
+        + 'if [ -x "$VENV_DIR/bin/python" ]; then echo UV=skipped_migrated\n'
+        + 'elif [ -d "$VENV_DIR" ] && [ -n "$(ls -A "$VENV_DIR" 2>/dev/null)" ]; then\n'
+        + '    echo UV=would_fail_dir_not_empty\n'
+        + 'else echo UV=would_create_ok; fi\n'
+    )
+    return subprocess.run(
+        ["bash", "-c", script],
+        env = {"PATH": "/usr/bin:/bin"},
+        text = True,
+        capture_output = True,
+    )
+
+
+def _make_legacy_venv(studio_home):
+    """A healthy legacy ~/.unsloth/studio/.venv from before the unsloth_studio layout."""
+    legacy = studio_home / ".venv"
+    (legacy / "bin").mkdir(parents = True)
+    py = legacy / "bin" / "python"
+    py.write_text("#!/bin/sh\nexit 0\n")
+    py.chmod(0o755)
+    (legacy / "marker.txt").write_text("legacy")
+    return legacy
+
+
+def test_legacy_migration_into_empty_venv_dir_does_not_nest(tmp_path):
+    """An empty $VENV_DIR must not make `mv` nest the legacy env inside it (uv then fails)."""
+    studio_home = tmp_path / "ws"
+    studio_home.mkdir()
+    _make_legacy_venv(studio_home)
+    (studio_home / "unsloth_studio").mkdir()
+
+    res = _run_venv_chain(studio_home)
+
+    assert res.returncode == 0, f"stdout={res.stdout!r} stderr={res.stderr!r}"
+    venv = studio_home / "unsloth_studio"
+    assert not (venv / ".venv").exists(), (
+        "legacy environment was nested at $VENV_DIR/.venv; `uv venv` would then refuse the "
+        "occupied target with the same error as #9479"
+    )
+    assert (venv / "marker.txt").is_file(), "legacy environment must land directly in $VENV_DIR"
+    assert "UV=skipped_migrated" in res.stdout
+
+
+def test_legacy_migration_with_absent_venv_dir_still_migrates(tmp_path):
+    """The ordinary migration must keep working once the empty-directory case is handled."""
+    studio_home = tmp_path / "ws"
+    studio_home.mkdir()
+    _make_legacy_venv(studio_home)
+
+    res = _run_venv_chain(studio_home)
+
+    assert res.returncode == 0, f"stdout={res.stdout!r} stderr={res.stderr!r}"
+    assert (studio_home / "unsloth_studio" / "marker.txt").is_file()
+    assert "UV=skipped_migrated" in res.stdout
+
+
+def test_legacy_migration_clears_a_symlinked_empty_venv_dir_without_touching_target(tmp_path):
+    """Unlinking $VENV_DIR must never remove the directory a symlink points at."""
+    studio_home = tmp_path / "ws"
+    studio_home.mkdir()
+    _make_legacy_venv(studio_home)
+    target = tmp_path / "elsewhere"
+    target.mkdir()
+    (studio_home / "unsloth_studio").symlink_to(target)
+
+    res = _run_venv_chain(studio_home)
+
+    assert res.returncode == 0, f"stdout={res.stdout!r} stderr={res.stderr!r}"
+    assert target.is_dir(), "the symlink target must survive"
+    assert (studio_home / "unsloth_studio" / "marker.txt").is_file()
+
+
+def test_occupied_venv_dir_still_wins_over_legacy_migration(tmp_path):
+    """An occupied $VENV_DIR must be replaced rather than migrated into (the #9479 path)."""
+    studio_home = tmp_path / "ws"
+    studio_home.mkdir()
+    legacy = _make_legacy_venv(studio_home)
+    venv = _make_interpreterless_venv(studio_home)
+
+    res = _run_venv_chain(studio_home)
+
+    assert res.returncode == 0, f"stdout={res.stdout!r} stderr={res.stderr!r}"
+    assert "UV=would_create_ok" in res.stdout
+    assert not venv.exists(), "$VENV_DIR must be cleared before `uv venv` runs"
+    assert (legacy / "marker.txt").is_file(), "the legacy environment must be left intact"
+
+
+def test_install_sh_reports_a_failed_venv_move(tmp_path):
+    """A failed move must say so, matching install.ps1's Exit-InstallFailure on the same step."""
+    src = INSTALL_SH.read_text(encoding = "utf-8")
+    assert 'if ! _start_studio_venv_replacement "$VENV_DIR"; then' in src, (
+        "install.sh must check the replacement helper rather than relying on bare set -e"
+    )
+    assert "could not move $VENV_DIR aside to reinstall" in src
+
+
+def _dir_has_entries_says(tmp_path, target, pre = ""):
+    """Run the real _dir_has_entries from install.sh against one directory."""
+    script = (
+        _extract_install_sh_function("_dir_has_entries")
+        + f"{pre}\n"
+        + f'if _dir_has_entries "{target}"; then echo yes; else echo no; fi\n'
+    )
+    res = subprocess.run(
+        ["bash", "-c", script], env = {"PATH": "/usr/bin:/bin"}, text = True, capture_output = True,
+    )
+    assert res.returncode == 0, f"stderr={res.stderr!r}"
+    return res.stdout.strip()
+
+
+def test_dir_has_entries_survives_noglob_in_the_caller(tmp_path):
+    """The check is pure globbing, so `set -f` must not make an occupied directory look empty."""
+    occupied = tmp_path / "occupied"
+    occupied.mkdir()
+    (occupied / "file.txt").write_text("x")
+
+    assert _dir_has_entries_says(tmp_path, occupied, pre = "set -f") == "yes"
+    assert _dir_has_entries_says(tmp_path, occupied) == "yes"
+
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    assert _dir_has_entries_says(tmp_path, empty, pre = "set -f") == "no", (
+        "an empty directory must still be left for uv to create into"
+    )
+
+
+def test_dir_has_entries_restores_the_callers_noglob_setting(tmp_path):
+    """Saving and restoring `-f` matters because _path_has_dir depends on the flag."""
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    script = (
+        _extract_install_sh_function("_dir_has_entries")
+        + "set -f\n"
+        + f'_dir_has_entries "{empty}" || true\n'
+        + 'case $- in *f*) echo NOGLOB_KEPT ;; *) echo NOGLOB_LOST ;; esac\n'
+        + "set +f\n"
+        + f'_dir_has_entries "{empty}" || true\n'
+        + 'case $- in *f*) echo GLOB_LOST ;; *) echo GLOB_KEPT ;; esac\n'
+    )
+    res = subprocess.run(
+        ["bash", "-c", script], env = {"PATH": "/usr/bin:/bin"}, text = True, capture_output = True,
+    )
+    assert "NOGLOB_KEPT" in res.stdout, "the caller's `set -f` must be restored"
+    assert "GLOB_KEPT" in res.stdout, "a caller without `set -f` must not gain it"
+
+
+@pytest.mark.parametrize("mode", [0o000, 0o111, 0o444])
+def test_dir_has_entries_treats_an_unenumerable_directory_as_occupied(tmp_path, mode):
+    """uv refuses these targets, so reporting them empty would wedge the repair.
+
+    0o444 is readable but not searchable: the globs expand to names, then every
+    -e test fails. 0o111 is the mirror. Both need the same answer as 0o000.
+    """
+    if os.geteuid() == 0:
+        pytest.skip("root ignores directory permissions")
+    blocked = tmp_path / f"blocked{mode:o}"
+    blocked.mkdir()
+    (blocked / "file.txt").write_text("x")
+    blocked.chmod(mode)
+    try:
+        # install.ps1's Test-DirectoryHasEntries returns $true from its catch for the
+        # same case; the two installers must not disagree here.
+        assert _dir_has_entries_says(tmp_path, blocked) == "yes"
+    finally:
+        blocked.chmod(0o700)
+
+
+def test_dir_has_entries_still_answers_no_for_a_searchable_empty_dir(tmp_path):
+    """The fail-closed rule must not swallow the empty case uv creates into."""
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    empty.chmod(0o555)
+    try:
+        assert _dir_has_entries_says(tmp_path, empty) == "no"
+    finally:
+        empty.chmod(0o700)


### PR DESCRIPTION
Closes #9479.

## Problem

A Studio install whose managed interpreter disappears can never be repaired. #9479 reports it on macOS arm64: the desktop app's preflight finds `unsloth_studio/bin/unsloth` on disk but unable to spawn, runs the bundled installer, and the installer stops at

```
error: Failed to create virtual environment
  Caused by: A virtual environment already exists at: studio/unsloth_studio

hint: Use the `--clear` flag or set `UV_VENV_CLEAR=1` to replace the existing virtual environment
  error   create venv failed (exit code 2)
  error   create venv (system Python) failed (exit code 2)
```

Every repair retry produces exactly that, so the app loops on the same screen.

Two things combine. uv installs `bin/python` as a symlink into its managed CPython, so removing that CPython (a `uv python` upgrade or prune, a wiped `~/.local/share/uv`) leaves a dangling link beside an intact `pyvenv.cfg`. And uv 0.10 made `uv venv` refuse to write into a directory that already exists with any content, instead of overwriting it. `install.sh` pins uv 0.12.1.

`install.sh` decided whether to move an existing environment aside by testing `[ -x "$VENV_DIR/bin/python" ]`. That is false for exactly this layout, so the replacement was skipped and `uv venv` ran against the leftover directory. The recreate paths further down already call `_discard_venv_for_recreate` first and were never affected; only the create path was.

`install.ps1` had the same shape at `if (Test-Path -LiteralPath $VenvPython)`. There the trigger is an antivirus quarantine taking `Scripts\python.exe` and leaving the rest of the tree. Its "just re-run install.ps1" advice on the missing-interpreter screen was no longer true.

## Fix

Decide on the directory, not on the interpreter. `install.sh` gains `_dir_has_entries`, and the replacement branch becomes `[ -x "$VENV_DIR/bin/python" ] || _dir_has_entries "$VENV_DIR"`; `install.ps1` gains `Test-DirectoryHasEntries` and the matching `-or`. Both count hidden entries and dangling symlinks, and both answer false for a missing or empty directory, which is what uv still creates into unaided.

This widens what gets replaced. At the default managed root, any occupied `unsloth_studio` directory is now replaced, where before only one with a working `bin/python` was. What runs is the existing rollback path rather than a delete: the directory is moved to `unsloth_studio.rollback.<stamp>.<pid>`, the exit and signal traps put it back if the install fails, and `_commit_studio_venv_replacement` discards it only once the install has succeeded.

Custom roots are unchanged. The env-mode ownership guard sits at the top of that same branch, so an `UNSLOTH_STUDIO_HOME` holding an unrelated occupied `unsloth_studio` still gets "does not look like an Unsloth Studio install" and a nonzero exit rather than being replaced.

## Scope

`--clear` and `UV_VENV_CLEAR` are deliberately not used. uv's `--clear` removes a plain directory too (astral-sh/uv#19395), which in env-mode is a user-chosen workspace path.

One consequence outside the reported failure: the legacy `$STUDIO_HOME/.venv` migration is an `elif` on the same chain, so with a leftover `$VENV_DIR` present it used to run `mv "$STUDIO_HOME/.venv" "$VENV_DIR"` into an existing directory and nest the legacy environment inside it. That branch is no longer reached in this state, which matches what already happened when `$VENV_DIR` held a working interpreter.

## Verification

- End-to-end against real uv 0.11.16: an `unsloth_studio` directory with a live `pyvenv.cfg` and a dangling `bin/python`. The old condition leaves it in place and `uv venv` exits 2 with the reported error; the new condition moves it aside and `uv venv` exits 0 with a working interpreter.
- `_dir_has_entries` under `dash` and `bash`, 11 cases: missing, empty, dotfile-only, `..name`-only, dangling-symlink-only, regular file, `[ ]` and `*` in the directory path (occupied and empty), a path that is a file, and a symlink to a non-empty directory.
- Six new cases in `tests/test_studio_install_workspace_guard.py` covering the interpreter-less venv in default mode and in env-mode with and without sentinels, a directory holding only the ownership marker, the missing and empty directories that must stay untouched, and the `install.ps1` branch and helper.
- Installer suites green: `tests/run_all.sh` shell half (all 50 files); the four Python files its runner needs a `python` on PATH for (232 passed); `tests/test_studio_install_workspace_guard.py` (55 passed); the root installer files (411 passed, 125 skipped); `tests/studio/install` plus the AV, CI shell coverage, uv cache, phase timing, and Tauri resource contract suites (2,588 passed, 102 skipped); and the two Windows structural suites (11 passed, 29 skipped off Windows).
- `sh -n install.sh`, `dash -n install.sh`, `git diff --check`, and `ruff check` on the changed test file. `install.ps1` was not syntax-checked: no PowerShell on this machine.
- The wider `tests/python` run has 19 failures and 11 errors in five library test files (`test_fast_language_model_text_only`, `test_patch_trl_rl_trainers_defensive`, `test_rl_config_pickling`, `test_v100_fullft_precision`, `test_vision_lora_targeting`). They reproduce identically on the base commit and come from the installed `unsloth_zoo` on this host.
