### PR TITLE
studio: show gpu temperature and power

### DIFF
--- a/studio/frontend/src/components/floating-monitor-telemetry.ts
+++ b/studio/frontend/src/components/floating-monitor-telemetry.ts
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import type { GpuUtilization } from "@/hooks/use-gpu-utilization";
+import type { GpuDevice } from "@/hooks/use-system";
+
+export type FloatingMonitorGpuTelemetry = GpuDevice & {
+  temperature_c: number | null;
+  power_draw_w: number | null;
+  power_limit_w: number | null;
+};
+
+export function hasFloatingMonitorGpuTelemetry(
+  devices: readonly FloatingMonitorGpuTelemetry[],
+): boolean {
+  return devices.some(
+    (device) =>
+      device.temperature_c != null || device.power_draw_w != null,
+  );
+}
+
+export function resolveFloatingMonitorGpuTelemetry(
+  devices: readonly GpuDevice[],
+  displayedBackend: string | undefined,
+  gpuUtilization: GpuUtilization,
+): FloatingMonitorGpuTelemetry[] {
+  const utilizationDevices =
+    gpuUtilization.devices && gpuUtilization.devices.length > 0
+      ? gpuUtilization.devices
+      : gpuUtilization.available
+        ? [gpuUtilization]
+        : [];
+  const backendsMatch =
+    !displayedBackend ||
+    !gpuUtilization.backend ||
+    displayedBackend === gpuUtilization.backend;
+
+  return devices.map((device) => {
+    const telemetry = backendsMatch
+      ? (utilizationDevices.find(
+          (candidate) =>
+            candidate.index != null && candidate.index === device.index,
+        ) ??
+        utilizationDevices.find(
+          (candidate) =>
+            candidate.visible_ordinal != null &&
+            candidate.visible_ordinal === device.visible_ordinal,
+        ) ??
+        (devices.length === 1 && utilizationDevices.length === 1
+          ? utilizationDevices[0]
+          : undefined))
+      : undefined;
+
+    return {
+      ...device,
+      temperature_c: telemetry?.temperature_c ?? null,
+      power_draw_w: telemetry?.power_draw_w ?? null,
+      power_limit_w: telemetry?.power_limit_w ?? null,
+    };
+  });
+}

--- a/studio/frontend/src/components/floating-monitor.tsx
+++ b/studio/frontend/src/components/floating-monitor.tsx
@@ -4,10 +4,18 @@
 import { Button } from "@/components/ui/button";
 import { Progress } from "@/components/ui/progress";
 import {
+  hasFloatingMonitorGpuTelemetry,
+  resolveFloatingMonitorGpuTelemetry,
+} from "@/components/floating-monitor-telemetry";
+import {
   useMonitorFrameStore,
   useMonitorOverlayStore,
 } from "@/features/settings";
 import { resolveGpuVramUsedGb } from "@/hooks/gpu-vram";
+import {
+  type GpuUtilization,
+  useGpuUtilization,
+} from "@/hooks/use-gpu-utilization";
 import { aggregateGpuMemoryTotalGb, useSystemInfo } from "@/hooks/use-system";
 import { useT } from "@/i18n";
 import {
@@ -419,11 +427,13 @@ function formatGiB(value: number): string {
 interface FloatingMonitorPanelProps {
   onClose: () => void;
   systemInfo: ReturnType<typeof useSystemInfo>;
+  gpuUtilization: GpuUtilization;
 }
 
 function FloatingMonitorPanel({
   onClose,
   systemInfo,
+  gpuUtilization,
 }: FloatingMonitorPanelProps) {
   const t = useT();
   const [constraintsElement, setConstraintsElement] =
@@ -477,6 +487,12 @@ function FloatingMonitorPanel({
   const unknownLabel = t("settings.resources.environment.unknown");
 
   const hasGpu = (displayedGpu?.available ?? false) && devices.length > 0;
+  const telemetryDevices = resolveFloatingMonitorGpuTelemetry(
+    devices,
+    displayedGpu?.backend,
+    gpuUtilization,
+  );
+  const hasGpuTelemetry = hasFloatingMonitorGpuTelemetry(telemetryDevices);
 
   // The container sits on the floating panel layer, above the bottom-right
   // overlay stack. That stack normally dodges this monitor, but the dodge has a
@@ -608,6 +624,55 @@ function FloatingMonitorPanel({
                 />
               </div>
             )}
+            {hasGpuTelemetry && (
+              <div
+                data-testid="floating-monitor-gpu-telemetry"
+                className="space-y-2 border-t border-border/60 pt-2"
+              >
+                {telemetryDevices.map((device, index) => (
+                  <div
+                    key={`${device.index_kind ?? "gpu"}-${device.index ?? index}`}
+                    className="space-y-1"
+                  >
+                    {devices.length > 1 && (
+                      <div className="truncate text-ui-11 font-medium text-foreground">
+                        {t("settings.resources.gpu.deviceWithIndex", {
+                          index:
+                            device.visible_ordinal ?? device.index ?? index,
+                        })}
+                        , {device.name ?? unknownLabel}
+                      </div>
+                    )}
+                    <div className="grid grid-cols-[minmax(0,1fr)_auto] gap-x-2 gap-y-1 text-ui-11 font-mono">
+                      <span className="text-muted-foreground">
+                        {t("studio.progress.temperature")}
+                      </span>
+                      <span
+                        data-testid={`floating-monitor-gpu-temperature-${index}`}
+                        className="tabular-nums text-foreground"
+                      >
+                        {device.temperature_c != null
+                          ? `${device.temperature_c}°C`
+                          : "--"}
+                      </span>
+                      <span className="text-muted-foreground">
+                        {t("studio.progress.power")}
+                      </span>
+                      <span
+                        data-testid={`floating-monitor-gpu-power-${index}`}
+                        className="tabular-nums text-foreground"
+                      >
+                        {device.power_draw_w != null
+                          ? device.power_limit_w != null
+                            ? `${device.power_draw_w} / ${device.power_limit_w} W`
+                            : `${device.power_draw_w} W`
+                          : "--"}
+                      </span>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
             {separateInferenceGpu && (
               <div className="flex justify-between gap-2 text-ui-11 font-mono">
                 <span className="text-muted-foreground">
@@ -633,6 +698,7 @@ function FloatingMonitorPanel({
 export function FloatingMonitor() {
   const { isOpen, setIsOpen } = useMonitorOverlayStore();
   const systemInfo = useSystemInfo({ enabled: isOpen, pollMs: 5000 });
+  const gpuUtilization = useGpuUtilization(isOpen, 5000);
   const [panelKey, setPanelKey] = useState(0);
   const wasOpenRef = useRef(isOpen);
 
@@ -651,6 +717,7 @@ export function FloatingMonitor() {
         <FloatingMonitorPanel
           key={panelKey}
           systemInfo={systemInfo}
+          gpuUtilization={gpuUtilization}
           onClose={() => setIsOpen(false)}
         />
       )}

--- a/studio/frontend/src/hooks/gpu-utilization-polling.ts
+++ b/studio/frontend/src/hooks/gpu-utilization-polling.ts
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+export interface PollingTimer {
+  setTimeout(callback: () => void, delayMs: number): ReturnType<typeof setTimeout>;
+  clearTimeout(timer: ReturnType<typeof setTimeout>): void;
+}
+
+const DEFAULT_TIMER: PollingTimer = {
+  setTimeout: (callback, delayMs) => setTimeout(callback, delayMs),
+  clearTimeout: (timer) => clearTimeout(timer),
+};
+
+export function createSingleFlight<T>(poll: () => Promise<T>): () => Promise<T> {
+  let inFlight: Promise<T> | null = null;
+
+  return () => {
+    if (inFlight !== null) return inFlight;
+
+    const request = poll();
+    inFlight = request;
+    const clear = () => {
+      if (inFlight === request) inFlight = null;
+    };
+    void request.then(clear, clear);
+    return request;
+  };
+}
+
+export function startSerialPolling(
+  poll: () => Promise<void>,
+  intervalMs: number,
+  timer: PollingTimer = DEFAULT_TIMER,
+): () => void {
+  let cancelled = false;
+  let timeout: ReturnType<typeof setTimeout> | null = null;
+
+  const run = async () => {
+    if (cancelled) return;
+
+    try {
+      await poll();
+    } finally {
+      if (!cancelled) {
+        timeout = timer.setTimeout(() => {
+          timeout = null;
+          void run();
+        }, intervalMs);
+      }
+    }
+  };
+
+  void run();
+
+  return () => {
+    cancelled = true;
+    if (timeout !== null) timer.clearTimeout(timeout);
+  };
+}

--- a/studio/frontend/src/hooks/use-gpu-utilization.ts
+++ b/studio/frontend/src/hooks/use-gpu-utilization.ts
@@ -2,7 +2,11 @@
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
 import { authFetch } from "@/features/auth";
-import { useEffect, useRef, useState } from "react";
+import {
+    createSingleFlight,
+    startSerialPolling,
+} from "@/hooks/gpu-utilization-polling";
+import { useEffect, useState } from "react";
 
 export interface GpuUtilization {
     available: boolean;
@@ -33,43 +37,43 @@ const DEFAULT: GpuUtilization = {
     power_utilization_pct: null,
 };
 
-/**
- * Poll `GET /api/train/hardware` for live GPU utilization stats while
- * `enabled` (training running). Interval defaults to 10 000 ms.
- */
+const fetchGpuUtilization = createSingleFlight(async () => {
+    const response = await authFetch("/api/train/hardware");
+    if (!response.ok) return null;
+    return (await response.json()) as GpuUtilization;
+});
+
 export function useGpuUtilization(
     enabled: boolean,
     intervalMs = 10_000,
 ): GpuUtilization {
     const [data, setData] = useState<GpuUtilization>(DEFAULT);
-    const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
     useEffect(() => {
         if (!enabled) {
-            // Reset when training stops so the cards show "--" again
-            setData(DEFAULT);
-            return;
+            let cancelled = false;
+            queueMicrotask(() => {
+                if (!cancelled) setData(DEFAULT);
+            });
+            return () => {
+                cancelled = true;
+            };
         }
 
         let cancelled = false;
 
-        async function poll() {
+        const stopPolling = startSerialPolling(async () => {
             try {
-                const res = await authFetch("/api/train/hardware");
-                if (!res.ok || cancelled) return;
-                const json = (await res.json()) as GpuUtilization;
-                if (!cancelled) setData(json);
+                const nextData = await fetchGpuUtilization();
+                if (!cancelled && nextData) setData(nextData);
             } catch {
-                // Retry on the next poll.
+                return;
             }
-        }
-
-        void poll();
-        timerRef.current = setInterval(() => void poll(), intervalMs);
+        }, intervalMs);
 
         return () => {
             cancelled = true;
-            if (timerRef.current) clearInterval(timerRef.current);
+            stopPolling();
         };
     }, [enabled, intervalMs]);
 

--- a/studio/frontend/tests/floating-monitor-telemetry.test.ts
+++ b/studio/frontend/tests/floating-monitor-telemetry.test.ts
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  hasFloatingMonitorGpuTelemetry,
+  resolveFloatingMonitorGpuTelemetry,
+} from "../src/components/floating-monitor-telemetry.ts";
+import type { GpuUtilization } from "../src/hooks/use-gpu-utilization.ts";
+
+function utilization(
+  overrides: Partial<GpuUtilization> = {},
+): GpuUtilization {
+  return {
+    available: true,
+    backend: "cuda",
+    gpu_utilization_pct: null,
+    temperature_c: null,
+    vram_used_gb: null,
+    vram_total_gb: null,
+    vram_utilization_pct: null,
+    power_draw_w: null,
+    power_limit_w: null,
+    power_utilization_pct: null,
+    ...overrides,
+  };
+}
+
+test("single-GPU telemetry uses the legacy top-level payload", () => {
+  const resolved = resolveFloatingMonitorGpuTelemetry(
+    [{ index: 0, name: "Apple M4" }],
+    "mlx",
+    utilization({
+      backend: "mlx",
+      temperature_c: 58.9,
+      power_draw_w: 0.2,
+    }),
+  );
+
+  assert.deepEqual(resolved, [
+    {
+      index: 0,
+      name: "Apple M4",
+      temperature_c: 58.9,
+      power_draw_w: 0.2,
+      power_limit_w: null,
+    },
+  ]);
+});
+
+test("multi-GPU telemetry follows physical indices instead of response order", () => {
+  const resolved = resolveFloatingMonitorGpuTelemetry(
+    [
+      { index: 5, visible_ordinal: 0, name: "GPU Five" },
+      { index: 3, visible_ordinal: 1, name: "GPU Three" },
+    ],
+    "cuda",
+    utilization({
+      devices: [
+        utilization({
+          index: 3,
+          visible_ordinal: 1,
+          temperature_c: 62,
+          power_draw_w: 180,
+          power_limit_w: 300,
+        }),
+        utilization({
+          index: 5,
+          visible_ordinal: 0,
+          temperature_c: 54,
+          power_draw_w: 120,
+          power_limit_w: 300,
+        }),
+      ],
+    }),
+  );
+
+  assert.deepEqual(
+    resolved.map(({ temperature_c, power_draw_w }) => ({
+      temperature_c,
+      power_draw_w,
+    })),
+    [
+      { temperature_c: 54, power_draw_w: 120 },
+      { temperature_c: 62, power_draw_w: 180 },
+    ],
+  );
+});
+
+test("visible ordinals support relative-index telemetry", () => {
+  const [resolved] = resolveFloatingMonitorGpuTelemetry(
+    [{ visible_ordinal: 1, name: "Relative GPU" }],
+    "xpu",
+    utilization({
+      backend: "xpu",
+      devices: [
+        utilization({
+          backend: "xpu",
+          visible_ordinal: 1,
+          temperature_c: 48,
+        }),
+      ],
+    }),
+  );
+
+  assert.equal(resolved.temperature_c, 48);
+  assert.equal(resolved.power_draw_w, null);
+});
+
+test("backend mismatches never merge unrelated index spaces", () => {
+  const [resolved] = resolveFloatingMonitorGpuTelemetry(
+    [{ index: 0, name: "Vulkan GPU" }],
+    "vulkan",
+    utilization({
+      backend: "cuda",
+      index: 0,
+      temperature_c: 90,
+      power_draw_w: 400,
+    }),
+  );
+
+  assert.equal(resolved.temperature_c, null);
+  assert.equal(resolved.power_draw_w, null);
+});
+
+test("unavailable telemetry remains unknown", () => {
+  const [resolved] = resolveFloatingMonitorGpuTelemetry(
+    [{ index: 0, name: "GPU" }],
+    "cuda",
+    utilization({ available: false }),
+  );
+
+  assert.equal(resolved.temperature_c, null);
+  assert.equal(resolved.power_draw_w, null);
+  assert.equal(resolved.power_limit_w, null);
+});
+
+test("a power limit without live readings stays hidden", () => {
+  const resolved = resolveFloatingMonitorGpuTelemetry(
+    [{ index: 0, name: "GPU" }],
+    "cuda",
+    utilization({ power_limit_w: 300 }),
+  );
+
+  assert.equal(hasFloatingMonitorGpuTelemetry(resolved), false);
+});
+
+test("temperature or power draw reveals telemetry", () => {
+  const temperature = resolveFloatingMonitorGpuTelemetry(
+    [{ index: 0, name: "GPU" }],
+    "cuda",
+    utilization({ temperature_c: 0 }),
+  );
+  const power = resolveFloatingMonitorGpuTelemetry(
+    [{ index: 0, name: "GPU" }],
+    "cuda",
+    utilization({ power_draw_w: 0 }),
+  );
+
+  assert.equal(hasFloatingMonitorGpuTelemetry(temperature), true);
+  assert.equal(hasFloatingMonitorGpuTelemetry(power), true);
+});

--- a/studio/frontend/tests/gpu-utilization-polling.test.ts
+++ b/studio/frontend/tests/gpu-utilization-polling.test.ts
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  createSingleFlight,
+  type PollingTimer,
+  startSerialPolling,
+} from "../src/hooks/gpu-utilization-polling.ts";
+
+function deferred(): {
+  promise: Promise<void>;
+  resolve: () => void;
+} {
+  let resolve = () => {};
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+function fakeTimer(): PollingTimer & {
+  callbacks: Array<() => void>;
+  cleared: Array<ReturnType<typeof setTimeout>>;
+} {
+  const callbacks: Array<() => void> = [];
+  const cleared: Array<ReturnType<typeof setTimeout>> = [];
+  return {
+    callbacks,
+    cleared,
+    setTimeout(callback) {
+      callbacks.push(callback);
+      return callbacks.length as unknown as ReturnType<typeof setTimeout>;
+    },
+    clearTimeout(timer) {
+      cleared.push(timer);
+    },
+  };
+}
+
+test("serial polling schedules the next request only after completion", async () => {
+  const timer = fakeTimer();
+  const first = deferred();
+  const second = deferred();
+  let calls = 0;
+  const stop = startSerialPolling(
+    () => {
+      calls += 1;
+      return calls === 1 ? first.promise : second.promise;
+    },
+    5000,
+    timer,
+  );
+
+  assert.equal(calls, 1);
+  assert.equal(timer.callbacks.length, 0);
+
+  first.resolve();
+  await first.promise;
+  await Promise.resolve();
+  assert.equal(timer.callbacks.length, 1);
+
+  timer.callbacks.shift()?.();
+  assert.equal(calls, 2);
+  assert.equal(timer.callbacks.length, 0);
+
+  stop();
+  second.resolve();
+  await second.promise;
+  await Promise.resolve();
+  assert.equal(timer.callbacks.length, 0);
+});
+
+test("single-flight polling shares work across concurrent consumers", async () => {
+  const first = deferred();
+  let calls = 0;
+  const poll = createSingleFlight(() => {
+    calls += 1;
+    return first.promise;
+  });
+
+  const firstRequest = poll();
+  const secondRequest = poll();
+  assert.equal(firstRequest, secondRequest);
+  assert.equal(calls, 1);
+
+  first.resolve();
+  await firstRequest;
+  await Promise.resolve();
+  void poll();
+  assert.equal(calls, 2);
+});
+
+test("stopping serial polling clears a scheduled request", async () => {
+  const timer = fakeTimer();
+  const first = deferred();
+  let calls = 0;
+  const stop = startSerialPolling(() => {
+    calls += 1;
+    return first.promise;
+  }, 5000, timer);
+
+  first.resolve();
+  await first.promise;
+  await Promise.resolve();
+  const scheduled = timer.callbacks[0];
+  stop();
+
+  assert.deepEqual(timer.cleared, [1]);
+  scheduled();
+  assert.equal(calls, 1);
+});


### PR DESCRIPTION
Show GPU temperature and power in the FloatingMonitor. The monitor joins `/api/train/hardware` telemetry to `/api/system` inventory by physical index or visible ordinal, labels identical GPUs clearly, and hides the section when no live temperature or power reading exists.

GPU polling now runs serially and shares in-flight requests across consumers, so a slow hardware probe cannot create overlapping work or overwrite newer telemetry.

Fixes #9015

![before](https://raw.githubusercontent.com/mahiatlinux/unsloth/pr-assets-studio-live-monitor-gpu-metrics/before.png)

![after](https://raw.githubusercontent.com/mahiatlinux/unsloth/pr-assets-studio-live-monitor-gpu-metrics/after.png)

## Checks

- 27 focused frontend tests
- Frontend typecheck
- ESLint
- Frontend production build
- Headless Playwright for slow polling, single GPU, reversed identical GPUs, partial telemetry, and limit-only telemetry
- Live Apple MLX hardware response with temperature and power
