### PR TITLE
studio: add kimi k3 api support

### DIFF
--- a/studio/backend/core/inference/external_provider.py
+++ b/studio/backend/core/inference/external_provider.py
@@ -47,6 +47,7 @@ _CONTINUATION_FLAG_PROVIDERS = frozenset({"vllm", "llama_cpp"})
 # "openai" is absent because it never reaches this body: it routes to /v1/responses,
 # which reports usage on its own.
 _USAGE_STREAM_OPTION_PROVIDERS = frozenset({"vllm", "openrouter", "kimi"})
+_MAX_KIMI_WEB_SEARCH_ROUNDS = 8
 
 # structlog so INFO diagnostics reach the backend's JSON log stream (the
 # stdlib root logger defaults to WARNING with no handlers). It accepts the
@@ -1047,8 +1048,7 @@ class ExternalProviderClient:
                 yield line
             return
 
-        # Kimi $web_search needs a 2-call round-trip + thinking off; route to
-        # a helper. Forced-function tool_choice suppresses it.
+        # kimi $web_search uses internal server-tool round trips.
         # https://platform.kimi.ai/docs/guide/use-web-search
         _kimi_tool_choice_forced_function = (
             isinstance(tool_choice, dict)
@@ -1067,6 +1067,7 @@ class ExternalProviderClient:
                 messages,
                 model,
                 max_tokens,
+                reasoning_effort,
             ):
                 yield line
             return
@@ -1117,6 +1118,8 @@ class ExternalProviderClient:
             # Newer OpenAI models (gpt-4o, gpt-5.x) reject max_tokens
             if self.provider_type == "openai":
                 body["max_completion_tokens"] = max_tokens
+            elif self.provider_type == "kimi" and model == "kimi-k3":
+                body["max_completion_tokens"] = max_tokens
             else:
                 body["max_tokens"] = max_tokens
 
@@ -1129,17 +1132,16 @@ class ExternalProviderClient:
         for field in provider_info.get("body_omit", ()):
             body.pop(field, None)
 
-        # Kimi thinking is a top-level body field. kimi-k2-thinking is always
-        # on (ignore the toggle); kimi-k2.6 defaults on, can be disabled.
-        # `keep: all` preserves every chunk for the UI panel.
-        if self.provider_type == "kimi" and enable_thinking is not None:
-            if model == "kimi-k2-thinking":
-                # Always on; ignore client toggle to avoid an API-level reject.
-                pass
-            elif enable_thinking:
-                body["thinking"] = {"type": "enabled", "keep": "all"}
-            else:
-                body["thinking"] = {"type": "disabled"}
+        if self.provider_type == "kimi":
+            if model == "kimi-k3":
+                if reasoning_effort in ("low", "high", "max"):
+                    body["reasoning_effort"] = reasoning_effort
+            elif enable_thinking is not None and model != "kimi-k2-thinking":
+                body["thinking"] = (
+                    {"type": "enabled", "keep": "all"}
+                    if enable_thinking
+                    else {"type": "disabled"}
+                )
         elif self.provider_type == "mistral":
             _apply_mistral_reasoning_controls(body, model, enable_thinking, reasoning_effort)
         elif self.provider_type == "vllm" and enable_thinking is not None:
@@ -1155,7 +1157,7 @@ class ExternalProviderClient:
         # https://openrouter.ai/docs/guides/best-practices/reasoning-tokens
         if self.provider_type == "openrouter":
             normalized_or_model = model.strip().lower()
-            if reasoning_effort in ("low", "medium", "high"):
+            if reasoning_effort in ("low", "medium", "high", "max"):
                 body["reasoning"] = {"effort": reasoning_effort}
             elif enable_thinking is True:
                 body["reasoning"] = {"enabled": True}
@@ -1451,46 +1453,32 @@ class ExternalProviderClient:
             )
 
     async def _stream_kimi_web_search(
-        self, messages: list[dict[str, Any]], model: str, max_tokens: Optional[int]
+        self,
+        messages: list[dict[str, Any]],
+        model: str,
+        max_tokens: Optional[int],
+        reasoning_effort: Optional[str] = None,
+        _search_count: int = 0,
     ) -> AsyncGenerator[str, None]:
-        """
-        Kimi $web_search round-trip.
-
-        Wire flow (per https://platform.kimi.ai/docs/guide/use-web-search):
-          1. POST messages with tools=[{type: "builtin_function",
-             function: {name: "$web_search"}}] and thinking=disabled.
-          2. Stream the first response — accumulate function.arguments across
-             tool_call deltas until finish_reason="tool_calls". Do NOT forward
-             those tool_call chunks to the client (internal protocol step, not
-             user-visible output).
-          3. Build a second request: original messages + the assistant message
-             carrying the tool_calls + a role=tool message echoing the same
-             arguments verbatim (per Kimi docs, the caller "just needs to
-             submit tool_call.function.arguments to Kimi as they are" — the
-             server actually runs the search).
-          4. Stream the second response — the final answer the user sees, with
-             search results already incorporated.
-
-        We synthesize tool_start (with the parsed query) when step (2)
-        completes, and tool_end (with any url_citation annotations the second
-        stream emits) before [DONE], so the chat UI shows the same web-search
-        tool card as other providers.
-        """
+        """Run Kimi's server-side web search round-trip."""
         url = f"{self.base_url}/chat/completions"
+        is_kimi_k3 = model == "kimi-k3"
         body: dict[str, Any] = {
             "model": model,
             "messages": messages,
             "stream": True,
-            # $web_search forbids thinking; sending the toggle would make the
-            # server reject the request with 400.
-            "thinking": {"type": "disabled"},
             "tools": [{"type": "builtin_function", "function": {"name": "$web_search"}}],
         }
+        if is_kimi_k3:
+            if reasoning_effort in ("low", "high", "max"):
+                body["reasoning_effort"] = reasoning_effort
+        else:
+            body["thinking"] = {"type": "disabled"}
         if max_tokens is not None:
-            body["max_tokens"] = max_tokens
+            body[
+                "max_completion_tokens" if is_kimi_k3 else "max_tokens"
+            ] = max_tokens
 
-        # Strip body fields the Kimi registry declares unusable
-        # (temperature/top_p — see body_omit in providers.py).
         from core.inference.providers import get_provider_info
 
         provider_info = get_provider_info(self.provider_type) or {}
@@ -1510,14 +1498,67 @@ class ExternalProviderClient:
             }
             return f"data: {_json.dumps(chunk)}"
 
+        def _capture_chunk(
+            parsed: dict[str, Any],
+            tool_calls: dict[int, dict[str, Any]],
+            content_parts: list[str],
+            reasoning_parts: list[str],
+        ) -> Optional[str]:
+            if "error" in parsed:
+                return sanitize_provider_sse_line(f"data: {_json.dumps(parsed)}")
+            visible_choices: list[dict[str, Any]] = []
+            for choice in parsed.get("choices") or []:
+                if not isinstance(choice, dict):
+                    continue
+                visible_choice = dict(choice)
+                delta = choice.get("delta")
+                visible_delta = dict(delta) if isinstance(delta, dict) else {}
+                if is_kimi_k3 and isinstance(visible_delta.get("content"), str):
+                    content_parts.append(visible_delta["content"])
+                if is_kimi_k3 and isinstance(
+                    visible_delta.get("reasoning_content"), str
+                ):
+                    reasoning_parts.append(visible_delta["reasoning_content"])
+                for tool_call in visible_delta.pop("tool_calls", []) or []:
+                    if not isinstance(tool_call, dict):
+                        continue
+                    index = tool_call.get("index", 0)
+                    slot = tool_calls.setdefault(
+                        index,
+                        {
+                            "id": tool_call.get("id") or f"call_{index}",
+                            "type": "function",
+                            "function": {"name": "", "arguments": ""},
+                        },
+                    )
+                    if tool_call.get("id"):
+                        slot["id"] = tool_call["id"]
+                    function = tool_call.get("function") or {}
+                    if function.get("name"):
+                        slot["function"]["name"] = function["name"]
+                    if function.get("arguments"):
+                        slot["function"]["arguments"] += function["arguments"]
+                visible_choice["delta"] = visible_delta
+                if visible_choice.get("finish_reason") == "tool_calls":
+                    visible_choice["finish_reason"] = None
+                if visible_delta or visible_choice.get("finish_reason") is not None:
+                    visible_choices.append(visible_choice)
+            if not visible_choices and not isinstance(parsed.get("usage"), dict):
+                return None
+            visible_payload = dict(parsed)
+            visible_payload["choices"] = visible_choices
+            return sanitize_provider_sse_line(f"data: {_json.dumps(visible_payload)}")
+
         logger.info(
             "Kimi $web_search round-trip starting (model=%s, url=%s)",
             model,
             url,
         )
 
-        # ---- First call: collect the model's $web_search tool_call ----
         tool_calls_acc: dict[int, dict[str, Any]] = {}
+        assistant_content_parts: list[str] = []
+        assistant_reasoning_parts: list[str] = []
+        first_call_visible_lines: list[str] = []
         try:
             async with _http_client.stream(
                 "POST",
@@ -1553,31 +1594,16 @@ class ExternalProviderClient:
                             parsed = _json.loads(data_str)
                         except Exception:
                             continue
-                        for choice in parsed.get("choices") or []:
-                            if not isinstance(choice, dict):
-                                continue
-                            delta = choice.get("delta") or {}
-                            for tc in delta.get("tool_calls") or []:
-                                if not isinstance(tc, dict):
-                                    continue
-                                idx = tc.get("index", 0)
-                                slot = tool_calls_acc.setdefault(
-                                    idx,
-                                    {
-                                        "id": tc.get("id") or f"call_{idx}",
-                                        "type": "function",
-                                        "function": {"name": "", "arguments": ""},
-                                    },
-                                )
-                                if tc.get("id"):
-                                    slot["id"] = tc["id"]
-                                fn = tc.get("function") or {}
-                                if fn.get("name"):
-                                    slot["function"]["name"] = fn["name"]
-                                if fn.get("arguments"):
-                                    slot["function"]["arguments"] += fn["arguments"]
-                            if choice.get("finish_reason") == "tool_calls":
-                                break
+                        if not isinstance(parsed, dict):
+                            continue
+                        visible_line = _capture_chunk(
+                            parsed,
+                            tool_calls_acc,
+                            assistant_content_parts,
+                            assistant_reasoning_parts,
+                        )
+                        if visible_line is not None:
+                            first_call_visible_lines.append(visible_line)
                 except GeneratorExit:
                     await response.aclose()
                     await lines_gen.aclose()
@@ -1594,20 +1620,20 @@ class ExternalProviderClient:
             )
             return
 
-        # If the model decided not to search, fall back to a plain streaming
-        # call without the builtin tool. Mirrors the UX of every other
-        # provider when web_search is on but the model didn't need it.
         search_calls = [
             tc for tc in tool_calls_acc.values() if tc["function"]["name"] == "$web_search"
         ]
         if not search_calls:
+            if _search_count:
+                for visible_line in first_call_visible_lines:
+                    yield visible_line
+                yield "data: [DONE]"
+                return
             logger.info(
                 "Kimi $web_search: model did not invoke search; falling back to plain stream"
             )
             fallback_body = dict(body)
             fallback_body.pop("tools", None)
-            # This path returns before the common body injection, and Kimi reports no
-            # engine timings, so without this the row has neither tokens nor a speed.
             fallback_body["stream_options"] = {"include_usage": True}
             try:
                 async with _http_client.stream(
@@ -1627,9 +1653,6 @@ class ExternalProviderClient:
                         )
                         yield _error_sse_line(response.status_code, error_text, self.provider_type)
                         return
-                    # Manual __anext__ loop instead of `async for` — see the
-                    # stream_chat_completion comment for the Python 3.13 +
-                    # httpcore 1.0.x GeneratorExit interaction this avoids.
                     lines_gen = response.aiter_lines().__aiter__()
                     try:
                         while True:
@@ -1638,8 +1661,6 @@ class ExternalProviderClient:
                             except StopAsyncIteration:
                                 break
                             if line.strip():
-                                # Same rule as the main relay: never let the
-                                # endpoint speak Studio's control vocabulary.
                                 relayed = sanitize_provider_sse_line(line)
                                 if relayed is not None:
                                     yield relayed
@@ -1659,15 +1680,20 @@ class ExternalProviderClient:
                 )
             return
 
-        # Synthesize tool_start with the parsed search query so the chat UI's
-        # web-search card shows "Searching for: ...".
+        if _search_count >= _MAX_KIMI_WEB_SEARCH_ROUNDS:
+            yield _error_sse_line(
+                502,
+                "Kimi web search exceeded the maximum number of rounds",
+                self.provider_type,
+            )
+            return
+        search_count = _search_count + 1
+
         first_args_raw = search_calls[0]["function"]["arguments"] or "{}"
         try:
             first_args = _json.loads(first_args_raw)
         except Exception:
             first_args = {}
-        # Args are an opaque receipt (`{"search_result":..., "usage":{"total_tokens":N}}`),
-        # not a query — Kimi runs the search server-side and bakes results into context.
         logger.info(
             "Kimi $web_search: %d tool_call(s), args[0]=%s",
             len(search_calls),
@@ -1688,16 +1714,15 @@ class ExternalProviderClient:
                 "arguments": first_args if isinstance(first_args, dict) else {},
             }
         )
-        # The search already ran server-side, so emit tool_end now — otherwise the
-        # UI card sits in "running" through the whole second-call answer.
         yield _build_kimi_tool_end(_synthetic_chunk, tool_call_id, [])
 
-        # ---- Second call: echo the tool_calls back and stream answer ----
         assistant_msg = {
             "role": "assistant",
-            "content": "",
+            "content": "".join(assistant_content_parts) if is_kimi_k3 else "",
             "tool_calls": list(tool_calls_acc.values()),
         }
+        if is_kimi_k3 and assistant_reasoning_parts:
+            assistant_msg["reasoning_content"] = "".join(assistant_reasoning_parts)
         tool_msgs = [
             {
                 "role": "tool",
@@ -1709,11 +1734,11 @@ class ExternalProviderClient:
         ]
         followup_body = dict(body)
         followup_body["messages"] = list(messages) + [assistant_msg] + tool_msgs
-        # Request a final `usage` block (OAI-compat streams omit it otherwise) so
-        # we can see prompt_tokens jump when search context is injected.
         followup_body["stream_options"] = {"include_usage": True}
-        # Keep the tool on the second call so the model can search again mid-turn.
 
+        next_tool_calls: dict[int, dict[str, Any]] = {}
+        next_content_parts: list[str] = []
+        next_reasoning_parts: list[str] = []
         try:
             async with _http_client.stream(
                 "POST",
@@ -1734,8 +1759,6 @@ class ExternalProviderClient:
                     return
 
                 lines_gen = response.aiter_lines().__aiter__()
-                # Latch final usage; a big prompt_tokens is evidence the server
-                # injected search results into context.
                 last_usage: Optional[dict[str, Any]] = None
                 annotation_shapes: set[str] = set()
                 try:
@@ -1748,35 +1771,39 @@ class ExternalProviderClient:
                             continue
                         if line.startswith("data:"):
                             data_str = line[len("data:") :].strip()
-                            if data_str and data_str != "[DONE]":
-                                try:
-                                    parsed = _json.loads(data_str)
-                                except Exception:
-                                    parsed = None
-                                if isinstance(parsed, dict):
-                                    usage = parsed.get("usage")
-                                    if isinstance(usage, dict):
-                                        last_usage = usage
-                                    # Scan annotations for diagnostics only; Kimi
-                                    # doesn't emit url_citation today, but a future
-                                    # version's type name would show in the log.
-                                    for choice in parsed.get("choices") or []:
-                                        if not isinstance(choice, dict):
-                                            continue
-                                        for envelope in (
-                                            choice.get("delta"),
-                                            choice.get("message"),
-                                        ):
-                                            if not isinstance(envelope, dict):
-                                                continue
-                                            for ann in envelope.get("annotations") or []:
-                                                if isinstance(ann, dict):
-                                                    annotation_shapes.add(
-                                                        str(ann.get("type") or "?")
-                                                    )
-                        # Same rule as the main relay: never let the endpoint
-                        # speak Studio's control vocabulary.
-                        relayed = sanitize_provider_sse_line(line)
+                            if not data_str or data_str == "[DONE]":
+                                continue
+                            try:
+                                parsed = _json.loads(data_str)
+                            except Exception:
+                                continue
+                            if not isinstance(parsed, dict):
+                                continue
+                            usage = parsed.get("usage")
+                            if isinstance(usage, dict):
+                                last_usage = usage
+                            for choice in parsed.get("choices") or []:
+                                if not isinstance(choice, dict):
+                                    continue
+                                for envelope in (
+                                    choice.get("delta"),
+                                    choice.get("message"),
+                                ):
+                                    if not isinstance(envelope, dict):
+                                        continue
+                                    for annotation in envelope.get("annotations") or []:
+                                        if isinstance(annotation, dict):
+                                            annotation_shapes.add(
+                                                str(annotation.get("type") or "?")
+                                            )
+                            relayed = _capture_chunk(
+                                parsed,
+                                next_tool_calls,
+                                next_content_parts,
+                                next_reasoning_parts,
+                            )
+                        else:
+                            relayed = sanitize_provider_sse_line(line)
                         if relayed is None:
                             continue
                         yield relayed
@@ -1804,6 +1831,82 @@ class ExternalProviderClient:
                 f"Error communicating with kimi: {exc}",
                 self.provider_type,
             )
+            return
+
+        if not next_tool_calls:
+            yield "data: [DONE]"
+            return
+        next_search_calls = [
+            call
+            for call in next_tool_calls.values()
+            if call["function"]["name"] == "$web_search"
+        ]
+        if len(next_search_calls) != len(next_tool_calls):
+            yield _error_sse_line(
+                502,
+                "Kimi returned an unsupported tool call during web search",
+                self.provider_type,
+            )
+            return
+        if search_count >= _MAX_KIMI_WEB_SEARCH_ROUNDS:
+            yield _error_sse_line(
+                502,
+                "Kimi web search exceeded the maximum number of rounds",
+                self.provider_type,
+            )
+            return
+
+        for search_call in next_search_calls:
+            arguments_raw = search_call["function"]["arguments"] or "{}"
+            try:
+                arguments = _json.loads(arguments_raw)
+            except Exception:
+                arguments = {}
+            repeated_tool_call_id = search_call["id"]
+            yield _synthetic_chunk(
+                {
+                    "type": "tool_start",
+                    "tool_name": "web_search",
+                    "tool_call_id": repeated_tool_call_id,
+                    "arguments": arguments if isinstance(arguments, dict) else {},
+                }
+            )
+            yield _build_kimi_tool_end(
+                _synthetic_chunk,
+                repeated_tool_call_id,
+                [],
+            )
+
+        next_assistant_message: dict[str, Any] = {
+            "role": "assistant",
+            "content": "".join(next_content_parts) if is_kimi_k3 else "",
+            "tool_calls": list(next_tool_calls.values()),
+        }
+        if is_kimi_k3 and next_reasoning_parts:
+            next_assistant_message["reasoning_content"] = "".join(
+                next_reasoning_parts
+            )
+        next_tool_messages = [
+            {
+                "role": "tool",
+                "tool_call_id": call["id"],
+                "name": call["function"]["name"],
+                "content": call["function"]["arguments"],
+            }
+            for call in next_tool_calls.values()
+        ]
+        next_messages = followup_body["messages"] + [
+            next_assistant_message,
+            *next_tool_messages,
+        ]
+        async for line in self._stream_kimi_web_search(
+            next_messages,
+            model,
+            max_tokens,
+            reasoning_effort,
+            search_count + 1,
+        ):
+            yield line
 
     async def _stream_anthropic(
         self,

--- a/studio/backend/core/inference/external_provider.py
+++ b/studio/backend/core/inference/external_provider.py
@@ -1138,9 +1138,7 @@ class ExternalProviderClient:
                     body["reasoning_effort"] = reasoning_effort
             elif enable_thinking is not None and model != "kimi-k2-thinking":
                 body["thinking"] = (
-                    {"type": "enabled", "keep": "all"}
-                    if enable_thinking
-                    else {"type": "disabled"}
+                    {"type": "enabled", "keep": "all"} if enable_thinking else {"type": "disabled"}
                 )
         elif self.provider_type == "mistral":
             _apply_mistral_reasoning_controls(body, model, enable_thinking, reasoning_effort)
@@ -1475,9 +1473,7 @@ class ExternalProviderClient:
         else:
             body["thinking"] = {"type": "disabled"}
         if max_tokens is not None:
-            body[
-                "max_completion_tokens" if is_kimi_k3 else "max_tokens"
-            ] = max_tokens
+            body["max_completion_tokens" if is_kimi_k3 else "max_tokens"] = max_tokens
 
         from core.inference.providers import get_provider_info
 
@@ -1515,9 +1511,7 @@ class ExternalProviderClient:
                 visible_delta = dict(delta) if isinstance(delta, dict) else {}
                 if is_kimi_k3 and isinstance(visible_delta.get("content"), str):
                     content_parts.append(visible_delta["content"])
-                if is_kimi_k3 and isinstance(
-                    visible_delta.get("reasoning_content"), str
-                ):
+                if is_kimi_k3 and isinstance(visible_delta.get("reasoning_content"), str):
                     reasoning_parts.append(visible_delta["reasoning_content"])
                 for tool_call in visible_delta.pop("tool_calls", []) or []:
                     if not isinstance(tool_call, dict):
@@ -1837,9 +1831,7 @@ class ExternalProviderClient:
             yield "data: [DONE]"
             return
         next_search_calls = [
-            call
-            for call in next_tool_calls.values()
-            if call["function"]["name"] == "$web_search"
+            call for call in next_tool_calls.values() if call["function"]["name"] == "$web_search"
         ]
         if len(next_search_calls) != len(next_tool_calls):
             yield _error_sse_line(
@@ -1883,9 +1875,7 @@ class ExternalProviderClient:
             "tool_calls": list(next_tool_calls.values()),
         }
         if is_kimi_k3 and next_reasoning_parts:
-            next_assistant_message["reasoning_content"] = "".join(
-                next_reasoning_parts
-            )
+            next_assistant_message["reasoning_content"] = "".join(next_reasoning_parts)
         next_tool_messages = [
             {
                 "role": "tool",

--- a/studio/backend/core/inference/providers.py
+++ b/studio/backend/core/inference/providers.py
@@ -219,12 +219,9 @@ PROVIDER_REGISTRY: dict[str, dict[str, Any]] = {
     "kimi": {
         "display_name": "Kimi",
         "base_url": "https://api.moonshot.ai/v1",
-        # Surface only the two SoTA multimodal models (kimi-k2.6/k2.5);
-        # moonshot-v1-* and dated k2 previews are filtered by the allowlist.
-        # Docs: https://platform.kimi.ai/docs/models
-        # Listing/overview: https://platform.kimi.ai/docs/api/list-models
-        #                   https://platform.kimi.ai/docs/api/overview
+        # model catalog: https://platform.kimi.ai/docs/models
         "default_models": [
+            "kimi-k3",
             "kimi-k2.6",
             "kimi-k2.5",
         ],
@@ -237,10 +234,9 @@ PROVIDER_REGISTRY: dict[str, dict[str, Any]] = {
         "auth_header": "Authorization",
         "auth_prefix": "Bearer ",
         "notes": "Moonshot API key. China: use base URL https://api.moonshot.cn/v1",
-        "model_id_allowlist": re.compile(r"^kimi-k2\.[56]$"),
-        # Reasoning-class: the API rejects custom temperature/top_p ("only 1
-        # is allowed"). Strip both so the server uses its required defaults.
-        "body_omit": ("temperature", "top_p"),
+        "model_id_allowlist": re.compile(r"^kimi-(?:k3|k2\.[56])$"),
+        # reasoning-class models require fixed sampling values.
+        "body_omit": ("temperature", "top_p", "presence_penalty"),
     },
     "qwen": {
         "display_name": "Qwen",
@@ -386,6 +382,7 @@ PROVIDER_REGISTRY: dict[str, dict[str, Any]] = {
             "openrouter/owl-alpha",
             "poolside/laguna-xs.2:free",
             "~google/gemini-pro-latest",
+            "moonshotai/kimi-k3",
             "~moonshotai/kimi-latest",
         ],
         "supports_streaming": True,

--- a/studio/backend/core/inference/studio_tool_loop.py
+++ b/studio/backend/core/inference/studio_tool_loop.py
@@ -330,6 +330,7 @@ class ToolLoopRun:
     messages: list[dict[str, Any]]
     session_id: str | None = None
     thread_id: str | None = None
+    provider_type: str | None = None
     model: str | None = None
     tool_choice: Any = None
     continue_final_message: bool = False
@@ -361,6 +362,7 @@ class _Turn:
     round: int = 0
     healed: list[dict[str, Any]] = field(default_factory = list)
     text: list[str] = field(default_factory = list)
+    reasoning_content: list[str] = field(default_factory = list)
     reasoning_extra: dict[str, Any] | None = None
     finish_reason: str | None = None
     # Results from tools the PROVIDER ran this turn, keyed by call id so a
@@ -797,6 +799,9 @@ async def stream_with_studio_tools(
     round_id = 0
     executed_any = False
     model_name = run.model or "external"
+    preserve_reasoning_content = (
+        run.provider_type == "kimi" and (run.model or "").strip().lower() == "kimi-k3"
+    )
     usage_totals: dict[str, Any] = {}
     # Dedup, one-shot tracking and the force-final-answer transition are the same
     # ledger the local loops keep, so an external model cannot spend the budget
@@ -906,6 +911,9 @@ async def stream_with_studio_tools(
                 delta = choice.get("delta")
                 delta = delta if isinstance(delta, dict) else {}
                 content = delta.get("content")
+                reasoning_content = delta.get("reasoning_content")
+                if preserve_reasoning_content and isinstance(reasoning_content, str):
+                    turn.reasoning_content.append(reasoning_content)
                 raw_calls = delta.get("tool_calls")
                 extra = delta.get("extra_content")
                 if isinstance(extra, dict):
@@ -1369,6 +1377,8 @@ async def stream_with_studio_tools(
             )
         if turn.reasoning_extra:
             assistant_message["extra_content"] = turn.reasoning_extra
+        if preserve_reasoning_content and turn.reasoning_content:
+            assistant_message["reasoning_content"] = "".join(turn.reasoning_content)
         if assistant_tool_calls:
             assistant_message["tool_calls"] = assistant_tool_calls
         if assistant_message["content"] or assistant_tool_calls:

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -13241,6 +13241,7 @@ def _build_external_messages(
     supports_vision: bool,
     provider_type: Optional[str] = None,
     base_url: Optional[str] = None,
+    model: Optional[str] = None,
 ) -> list[dict]:
     """
     Convert ChatMessage list to OpenAI-compatible dicts for external providers.
@@ -13266,6 +13267,9 @@ def _build_external_messages(
     document_provider = provider_type in _INPUT_DOCUMENT_PROVIDERS
     anthropic = provider_type == "anthropic"
     openai = provider_type == "openai"
+    replay_reasoning_content = (
+        provider_type == "kimi" and (model or "").strip().lower() == "kimi-k3"
+    )
     # `extra_content` carries the assistant's text-part `thoughtSignature`
     # round-trip on Gemini's native streamGenerateContent endpoint. Custom
     # Gemini OpenAI-compat gateways (LiteLLM etc.) route through
@@ -13397,7 +13401,12 @@ def _build_external_messages(
             # (some providers reject empty assistant turns). Preserve assistant
             # turns whose only payload is tool_calls so multi-turn
             # function-call loops round-trip.
-            if msg.role == "assistant" and not msg.content.strip() and not msg.tool_calls:
+            if (
+                msg.role == "assistant"
+                and not msg.content.strip()
+                and not msg.tool_calls
+                and not (replay_reasoning_content and msg.reasoning_content)
+            ):
                 continue
             out: dict[str, Any] = {"role": msg.role, "content": msg.content}
             if msg.role == "assistant" and msg.tool_calls:
@@ -13410,6 +13419,8 @@ def _build_external_messages(
                     # `{"role":"assistant","content":""}` that some providers
                     # reject. Skip it entirely.
                     continue
+            if replay_reasoning_content and msg.role == "assistant" and msg.reasoning_content:
+                out["reasoning_content"] = msg.reasoning_content
             if msg.role == "tool":
                 if msg.tool_call_id:
                     out["tool_call_id"] = msg.tool_call_id
@@ -13422,17 +13433,24 @@ def _build_external_messages(
         # Assistant messages with content=None but populated tool_calls are
         # valid (post-tool-call turn). Forward them so the provider helper can
         # rebuild the functionCall part.
-        if msg.content is None and msg.role == "assistant" and msg.tool_calls:
+        if (
+            msg.content is None
+            and msg.role == "assistant"
+            and (msg.tool_calls or (replay_reasoning_content and msg.reasoning_content))
+        ):
             _filtered_tcs = _filter_tool_calls(msg.tool_calls)
-            if not _filtered_tcs:
+            if msg.tool_calls and not _filtered_tcs:
                 # Every tool_call was provider-side synthetic and dropped;
                 # skip the whole message to avoid an empty assistant turn.
                 continue
             _assistant_only: dict[str, Any] = {
                 "role": "assistant",
                 "content": "",
-                "tool_calls": _filtered_tcs,
             }
+            if _filtered_tcs:
+                _assistant_only["tool_calls"] = _filtered_tcs
+            if replay_reasoning_content and msg.reasoning_content:
+                _assistant_only["reasoning_content"] = msg.reasoning_content
             if emit_extra_content and msg.extra_content:
                 _assistant_only["extra_content"] = msg.extra_content
             result.append(_assistant_only)
@@ -14130,6 +14148,7 @@ async def _proxy_to_external_provider(
         _supports_vision,
         provider_type = provider_type,
         base_url = base_url,
+        model = model,
     )
     monitor_id = None
     if not getattr(request.state, "skip_api_monitor", False):
@@ -14235,6 +14254,7 @@ async def _proxy_to_external_provider(
                     messages = chat_messages,
                     session_id = payload.session_id,
                     thread_id = payload.thread_id,
+                    provider_type = provider_type,
                     # The loop withholds the provider's own usage-only chunks and
                     # sends one summed chunk instead, so this is the only model id
                     # the client sees for the whole answer. Omitted, it falls back

--- a/studio/backend/tests/test_external_provider_usage_chunk.py
+++ b/studio/backend/tests/test_external_provider_usage_chunk.py
@@ -114,6 +114,7 @@ def test_build_usage_chunk_returns_none_when_all_zero():
 
 # ── streaming integration tests ─────────────────────────────────────
 
+
 def _drive(coro):
     return asyncio.new_event_loop().run_until_complete(coro)
 
@@ -793,14 +794,9 @@ def test_kimi_k3_web_search_loops_until_the_model_stops(monkeypatch):
         "reason 1",
         "reason 2",
     ]
-    assert [message["content"] for message in third_turn_assistants] == [
-        "draft 1",
-        "draft 2",
-    ]
+    assert [message["content"] for message in third_turn_assistants] == ["draft 1", "draft 2"]
     assert [
-        message["tool_call_id"]
-        for message in bodies[2]["messages"]
-        if message["role"] == "tool"
+        message["tool_call_id"] for message in bodies[2]["messages"] if message["role"] == "tool"
     ] == ["call_search_1", "call_search_2"]
 
 

--- a/studio/backend/tests/test_external_provider_usage_chunk.py
+++ b/studio/backend/tests/test_external_provider_usage_chunk.py
@@ -20,6 +20,8 @@ from core.inference.external_provider import (
     ExternalProviderClient,
     _build_usage_chunk,
 )
+from models.inference import ChatMessage
+from routes.inference import _build_external_messages
 
 
 # ── _build_usage_chunk unit tests ───────────────────────────────────
@@ -111,7 +113,6 @@ def test_build_usage_chunk_returns_none_when_all_zero():
 
 
 # ── streaming integration tests ─────────────────────────────────────
-
 
 def _drive(coro):
     return asyncio.new_event_loop().run_until_complete(coro)
@@ -611,14 +612,11 @@ def test_streamed_usage_is_requested_only_where_documented(monkeypatch, provider
 
 
 def test_kimi_no_search_fallback_requests_usage(monkeypatch):
-    # The web-search path returns before the common body injection, and Kimi reports no
-    # engine timings, so this fallback would leave tokens and speed blank.
     bodies: list = []
 
     def handler(request: httpx.Request) -> httpx.Response:
         body = json.loads(request.content.decode("utf-8"))
         bodies.append(body)
-        # First call: the model declines to invoke $web_search.
         return httpx.Response(
             200,
             content = b'data: {"choices":[{"delta":{"content":"hi"}}]}\n\ndata: [DONE]\n\n',
@@ -644,11 +642,203 @@ def test_kimi_no_search_fallback_requests_usage(monkeypatch):
         await client.close()
 
     _drive(run())
-    assert len(bodies) >= 2, "the search call then the plain fallback"
-    search_body, fallback_body = bodies[0], bodies[-1]
-    assert "tools" in search_body
-    assert "tools" not in fallback_body
-    assert fallback_body["stream_options"] == {"include_usage": True}
+    assert len(bodies) == 2
+    assert "tools" in bodies[0]
+    assert "tools" not in bodies[1]
+    assert bodies[1]["stream_options"] == {"include_usage": True}
+
+
+def test_kimi_k3_serializes_reasoning_effort_and_fixed_sampling(monkeypatch):
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["body"] = json.loads(request.content.decode("utf-8"))
+        return httpx.Response(
+            200,
+            content = b"data: [DONE]\n\n",
+            headers = {"content-type": "text/event-stream"},
+        )
+
+    _mock_http_client(monkeypatch, handler)
+
+    async def run():
+        client = ExternalProviderClient(
+            provider_type = "kimi",
+            base_url = "http://kimi.example/v1",
+            api_key = "sk-test",
+        )
+        await _collect(
+            client.stream_chat_completion(
+                messages = [{"role": "user", "content": "ping"}],
+                model = "kimi-k3",
+                temperature = 0.2,
+                top_p = 0.4,
+                presence_penalty = 0.7,
+                max_tokens = 1048576,
+                reasoning_effort = "high",
+            )
+        )
+        await client.close()
+
+    _drive(run())
+    body = captured["body"]
+    assert body["reasoning_effort"] == "high"
+    assert body["max_completion_tokens"] == 1048576
+    assert "max_tokens" not in body
+    assert "thinking" not in body
+    assert "temperature" not in body
+    assert "top_p" not in body
+    assert "presence_penalty" not in body
+
+
+def test_kimi_k3_replays_reasoning_content_between_turns():
+    messages = [
+        ChatMessage(role = "assistant", content = "answer", reasoning_content = "trace"),
+        ChatMessage(role = "assistant", content = "", reasoning_content = "trace only"),
+    ]
+    kimi_k3 = _build_external_messages(
+        messages,
+        supports_vision = True,
+        provider_type = "kimi",
+        model = "kimi-k3",
+    )
+    assert [message["reasoning_content"] for message in kimi_k3] == ["trace", "trace only"]
+
+    kimi_k2 = _build_external_messages(
+        messages,
+        supports_vision = True,
+        provider_type = "kimi",
+        model = "kimi-k2.6",
+    )
+    assert all("reasoning_content" not in message for message in kimi_k2)
+
+
+def test_kimi_k3_web_search_loops_until_the_model_stops(monkeypatch):
+    bodies: list[dict] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        bodies.append(json.loads(request.content.decode("utf-8")))
+        round_number = len(bodies)
+        if round_number <= 2:
+            call_id = f"call_search_{round_number}"
+            payload = {
+                "choices": [
+                    {
+                        "delta": {
+                            "reasoning_content": f"reason {round_number}",
+                            "content": f"draft {round_number}",
+                            "tool_calls": [
+                                {
+                                    "index": 0,
+                                    "id": call_id,
+                                    "type": "function",
+                                    "function": {
+                                        "name": "$web_search",
+                                        "arguments": json.dumps(
+                                            {"search_result": f"result {round_number}"}
+                                        ),
+                                    },
+                                }
+                            ],
+                        },
+                        "finish_reason": "tool_calls",
+                    }
+                ]
+            }
+            content = f"data: {json.dumps(payload)}\n\ndata: [DONE]\n\n".encode()
+        else:
+            content = (
+                b'data: {"choices":[{"delta":{"reasoning_content":"final reason"}}]}\n\n'
+                b'data: {"choices":[{"delta":{"content":"final answer"},'
+                b'"finish_reason":"stop"}],"usage":{"prompt_tokens":20,'
+                b'"completion_tokens":4}}\n\ndata: [DONE]\n\n'
+            )
+        return httpx.Response(
+            200,
+            content = content,
+            headers = {"content-type": "text/event-stream"},
+        )
+
+    _mock_http_client(monkeypatch, handler)
+
+    async def run():
+        client = ExternalProviderClient(
+            provider_type = "kimi",
+            base_url = "http://kimi.example/v1",
+            api_key = "sk-test",
+        )
+        lines = await _collect(
+            client.stream_chat_completion(
+                messages = [{"role": "user", "content": "search twice"}],
+                model = "kimi-k3",
+                max_tokens = 32768,
+                reasoning_effort = "max",
+                enabled_tools = ["web_search"],
+            )
+        )
+        await client.close()
+        return lines
+
+    lines = _drive(run())
+    assert len(bodies) == 3
+    assert all('"tool_calls"' not in line for line in lines)
+    assert sum('"type": "tool_start"' in line for line in lines) == 2
+    assert any('"content": "final answer"' in line for line in lines)
+    assert lines.count("data: [DONE]") == 1
+
+    third_turn_assistants = [
+        message for message in bodies[2]["messages"] if message["role"] == "assistant"
+    ]
+    assert [message["reasoning_content"] for message in third_turn_assistants] == [
+        "reason 1",
+        "reason 2",
+    ]
+    assert [message["content"] for message in third_turn_assistants] == [
+        "draft 1",
+        "draft 2",
+    ]
+    assert [
+        message["tool_call_id"]
+        for message in bodies[2]["messages"]
+        if message["role"] == "tool"
+    ] == ["call_search_1", "call_search_2"]
+
+
+def test_openrouter_kimi_k3_serializes_max_reasoning_effort(monkeypatch):
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["body"] = json.loads(request.content.decode("utf-8"))
+        return httpx.Response(
+            200,
+            content = b"data: [DONE]\n\n",
+            headers = {"content-type": "text/event-stream"},
+        )
+
+    _mock_http_client(monkeypatch, handler)
+
+    async def run():
+        client = ExternalProviderClient(
+            provider_type = "openrouter",
+            base_url = "https://openrouter.ai/api/v1",
+            api_key = "sk-test",
+        )
+        await _collect(
+            client.stream_chat_completion(
+                messages = [{"role": "user", "content": "ping"}],
+                model = "moonshotai/kimi-k3",
+                max_tokens = 32768,
+                reasoning_effort = "max",
+            )
+        )
+        await client.close()
+
+    _drive(run())
+    body = captured["body"]
+    assert body["reasoning"] == {"effort": "max"}
+    assert "reasoning_effort" not in body
+    assert "thinking" not in body
+    assert "max_completion_tokens" not in body
 
 
 def test_a_type_carried_only_by_the_sse_event_field_is_honoured(monkeypatch):

--- a/studio/backend/tests/test_hosted_result_replay.py
+++ b/studio/backend/tests/test_hosted_result_replay.py
@@ -138,7 +138,12 @@ def executed(monkeypatch):
     return calls
 
 
-def _run(transport, *, provider_type = None, model = None):
+def _run(
+    transport,
+    *,
+    provider_type = None,
+    model = None,
+):
     async def _collect():
         out: list[str] = []
         agen = stream_with_studio_tools(

--- a/studio/backend/tests/test_hosted_result_replay.py
+++ b/studio/backend/tests/test_hosted_result_replay.py
@@ -86,6 +86,12 @@ def _text(content: str) -> str:
     return "data: " + json.dumps({"choices": [{"index": 0, "delta": {"content": content}}]})
 
 
+def _reasoning(content: str) -> str:
+    return "data: " + json.dumps(
+        {"choices": [{"index": 0, "delta": {"reasoning_content": content}}]}
+    )
+
+
 def _finish(reason: str = "tool_calls") -> str:
     return "data: " + json.dumps({"choices": [{"index": 0, "delta": {}, "finish_reason": reason}]})
 
@@ -132,7 +138,7 @@ def executed(monkeypatch):
     return calls
 
 
-def _run(transport):
+def _run(transport, *, provider_type = None, model = None):
     async def _collect():
         out: list[str] = []
         agen = stream_with_studio_tools(
@@ -141,6 +147,8 @@ def _run(transport):
                 messages = [{"role": "user", "content": "hi"}],
                 session_id = "s1",
                 thread_id = "t1",
+                provider_type = provider_type,
+                model = model,
             ),
             policy = ToolLoopPolicy(
                 tools = [WEB],
@@ -252,6 +260,39 @@ def test_the_models_own_prose_is_kept_alongside(executed):
     replayed = _replayed(transport)
     assert "Searching now." in replayed
     assert "hosted output" in replayed
+
+
+def test_kimi_k3_reasoning_reaches_the_local_tool_follow_up(executed):
+    transport = FakeTransport(
+        [
+            [_reasoning("plan "), _reasoning("then act"), _call_line(), _finish()],
+            [_text("done"), _finish("stop")],
+            [_DONE],
+        ]
+    )
+    _run(transport, provider_type = "kimi", model = "kimi-k3")
+    assistant = next(
+        message
+        for message in transport.requests[1]["messages"]
+        if message.get("role") == "assistant" and message.get("tool_calls")
+    )
+    assert assistant["reasoning_content"] == "plan then act"
+
+
+@pytest.mark.parametrize(
+    ("provider_type", "model"),
+    [("kimi", "kimi-k2.6"), ("openrouter", "moonshotai/kimi-k3")],
+)
+def test_other_tool_loops_do_not_replay_kimi_reasoning(executed, provider_type, model):
+    transport = FakeTransport(
+        [
+            [_reasoning("private"), _call_line(), _finish()],
+            [_text("done"), _finish("stop")],
+            [_DONE],
+        ]
+    )
+    _run(transport, provider_type = provider_type, model = model)
+    assert "reasoning_content" not in _replayed(transport)
 
 
 # ── what must not be replayed ────────────────────────────────────────

--- a/studio/backend/tests/test_provider_model_allowlist.py
+++ b/studio/backend/tests/test_provider_model_allowlist.py
@@ -29,6 +29,7 @@ def test_current_generation_model_ids_reach_the_picker():
             "gemini-3-pro-image",
             "gemini-2.5-flash",
         ],
+        "kimi": ["kimi-k3", "kimi-k2.6", "kimi-k2.5"],
     }
     for provider, model_ids in live.items():
         registry = PROVIDER_REGISTRY[provider]
@@ -47,3 +48,8 @@ def test_dated_snapshots_and_retired_ids_stay_out_of_the_picker():
         assert openai["model_id_denylist"].search(model_id), model_id
     gemini = PROVIDER_REGISTRY["gemini"]
     assert "gemini-3-pro-preview" in gemini["model_id_deny_exact"]
+
+
+def test_kimi_k3_seeds_direct_and_openrouter_connections():
+    assert PROVIDER_REGISTRY["kimi"]["default_models"][0] == "kimi-k3"
+    assert "moonshotai/kimi-k3" in PROVIDER_REGISTRY["openrouter"]["default_models"]

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -4856,7 +4856,6 @@ const ReasoningToggle: FC<{ side?: "top" | "bottom" }> = ({
     externalSelection != null
       ? externalProviders.find((p) => p.id === externalSelection.providerId)
       : undefined;
-  const isKimiExternal = selectedExternalProvider?.providerType === "kimi";
   const toolsEnabled = useChatRuntimeStore((s) => s.toolsEnabled);
   const setToolsEnabled = useChatRuntimeStore((s) => s.setToolsEnabled);
   const supportsPreserveThinking = useChatRuntimeStore(
@@ -4870,6 +4869,9 @@ const ReasoningToggle: FC<{ side?: "top" | "bottom" }> = ({
     lastOpenRouterChosenModel
       ? lastOpenRouterChosenModel
       : externalSelection?.modelId;
+  const isKimiExternal =
+    selectedExternalProvider?.providerType === "kimi" &&
+    externalSelection?.modelId.trim().toLowerCase() !== "kimi-k3";
   const externalReasoningCaps =
     externalSelection != null
       ? getExternalReasoningCapabilities(
@@ -4998,8 +5000,7 @@ const ReasoningToggle: FC<{ side?: "top" | "bottom" }> = ({
                       setReasoningEffort(level);
                       setReasoningEnabled(true);
                       applyQwenThinkingParams(true);
-                      // Kimi's $web_search builtin forbids thinking, so
-                      // enabling thinking flips the Search pill off.
+                      // older kimi models require search and thinking to stay exclusive.
                       if (isKimiExternal && toolsEnabled) {
                         setToolsEnabled(false, { persist: false });
                       }
@@ -5092,7 +5093,7 @@ const ReasoningToggle: FC<{ side?: "top" | "bottom" }> = ({
         const next = !reasoningEnabled;
         setReasoningEnabled(next);
         applyQwenThinkingParams(next);
-        // Mutually exclusive with Search on Kimi (see dropdown branch).
+        // older kimi models require search and thinking to stay exclusive.
         if (isKimiExternal && next && toolsEnabled) {
           setToolsEnabled(false, { persist: false });
         }
@@ -5150,7 +5151,9 @@ const WebSearchToggle: FC = () => {
     externalSelection != null
       ? externalProviders.find((p) => p.id === externalSelection.providerId)
       : undefined;
-  const isKimiExternal = selectedExternalProvider?.providerType === "kimi";
+  const isKimiExternal =
+    selectedExternalProvider?.providerType === "kimi" &&
+    externalSelection?.modelId.trim().toLowerCase() !== "kimi-k3";
   // Disable only when a loaded model lacks the capability; with no model the
   // tool can still be pre-selected, matching the + menu.
   const disabled = modelLoaded && !(supportsTools || supportsBuiltinWebSearch);
@@ -5162,9 +5165,7 @@ const WebSearchToggle: FC = () => {
       onClick={() => {
         const next = !toolsEnabled;
         setToolsEnabled(next);
-        // Kimi's $web_search builtin requires thinking=disabled (see
-        // https://platform.kimi.ai/docs/guide/use-web-search). Keep the two
-        // pills mutually exclusive so visible state matches what's sent.
+        // older kimi models require search and thinking to stay exclusive.
         if (isKimiExternal) {
           setReasoningEnabled(!next, { persist: false });
           applyQwenThinkingParams(!next);
@@ -5461,7 +5462,9 @@ const ComposerToolsMenu: FC<{
     externalSelection != null
       ? externalProviders.find((p) => p.id === externalSelection.providerId)
       : undefined;
-  const isKimiExternal = selectedExternalProvider?.providerType === "kimi";
+  const isKimiExternal =
+    selectedExternalProvider?.providerType === "kimi" &&
+    externalSelection?.modelId.trim().toLowerCase() !== "kimi-k3";
   // Disable only when a loaded model lacks the capability; with no model the
   // tool can still be pre-selected, matching the pill logic above.
   const searchDisabled =
@@ -5791,7 +5794,7 @@ const ComposerToolsMenu: FC<{
           onSelect={() => {
             const next = !toolsEnabled;
             setToolsEnabled(next);
-            // Mirror the Search pill: Kimi forbids search + thinking together.
+            // older kimi models require search and thinking to stay exclusive.
             if (isKimiExternal) {
               setReasoningEnabled(!next, { persist: false });
               applyQwenThinkingParams(!next);

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -4429,9 +4429,13 @@ export function createOpenAIStreamAdapter(
       // toOpenAIMessages emits assistant tool_calls + role="tool"
       // follow-ups; the backend Gemini translator rebuilds the
       // functionCall / functionResponse parts (with thoughtSignature).
+      const replayAssistantReasoning =
+        !isExternalRequest ||
+        (externalProvider?.providerType === "kimi" &&
+          externalSelection?.modelId.trim().toLowerCase() === "kimi-k3");
       const outboundMessages = survivingMessages
         .flatMap((message) =>
-          toOpenAIMessages(message, !isExternalRequest),
+          toOpenAIMessages(message, replayAssistantReasoning),
         )
         .filter((message): message is NonNullable<typeof message> =>
           Boolean(message),

--- a/studio/frontend/src/features/chat/chat-page.tsx
+++ b/studio/frontend/src/features/chat/chat-page.tsx
@@ -171,6 +171,8 @@ import {
   clampReasoningEffortToLevels,
   getExternalReasoningCapabilities,
   getProviderCapabilities,
+  isKimiK3Selection,
+  kimiSearchRequiresThinkingOff,
   providerHostsCodeExecution,
   providerSupportsBuiltinCodeExecution,
   providerSupportsBuiltinImageGeneration,
@@ -2286,6 +2288,10 @@ export function ChatPage({
     // Responses-API tools). Everyone else "medium". Overridable via Think.
     const isAnthropic = provider?.providerType === "anthropic";
     const isOpenAI = provider?.providerType === "openai";
+    const isKimiK3 = isKimiK3Selection(
+      provider?.providerType,
+      selection.modelId,
+    );
     const anthropicTopEffort = effortLevels.includes("xhigh")
       ? "xhigh"
       : effortLevels.includes("high")
@@ -2301,9 +2307,11 @@ export function ChatPage({
         ? anthropicTopEffort
         : isOpenAI
           ? openaiDefaultEffort
-          : effortLevels.includes("medium")
-            ? "medium"
-            : clampedEffort
+          : isKimiK3 && effortLevels.includes("max")
+            ? "max"
+            : effortLevels.includes("medium")
+              ? "medium"
+              : clampedEffort
       : state.reasoningEffort;
     const supportsBuiltinWebSearch = providerSupportsBuiltinWebSearch(
       provider?.providerType,
@@ -2370,7 +2378,10 @@ export function ChatPage({
       supportsStudioTools: supportsStudioToolsHere,
     });
     const nextToolsEnabled = canSearch
-      ? isKimi
+      ? kimiSearchRequiresThinkingOff(
+          provider?.providerType,
+          selection.modelId,
+        )
         ? false
         : (storedToolsEnabled ?? searchOnByDefault)
       : false;
@@ -2838,6 +2849,10 @@ export function ChatPage({
         // Anthropic highest level, OpenAI "high", everyone else "medium".
         const isAnthropic = selectedProvider?.providerType === "anthropic";
         const isOpenAI = selectedProvider?.providerType === "openai";
+        const isKimiK3 = isKimiK3Selection(
+          selectedProvider?.providerType,
+          selectedExternal?.modelId,
+        );
         const anthropicTopEffort = effortLevels.includes("xhigh")
           ? "xhigh"
           : effortLevels.includes("high")
@@ -2853,9 +2868,11 @@ export function ChatPage({
             ? anthropicTopEffort
             : isOpenAI
               ? openaiDefaultEffort
-              : effortLevels.includes("medium")
-                ? "medium"
-                : clampedEffort
+              : isKimiK3 && effortLevels.includes("max")
+                ? "max"
+                : effortLevels.includes("medium")
+                  ? "medium"
+                  : clampedEffort
           : store.reasoningEffort;
         // Clear any cached router-picked openrouter/free model unless staying
         // on openrouter/free, else the chip keeps a stale ":<chosen>" suffix.
@@ -2924,7 +2941,10 @@ export function ChatPage({
           supportsStudioTools: supportsStudioToolsHere,
         });
         const nextToolsEnabled = canSearch
-          ? isKimi
+          ? kimiSearchRequiresThinkingOff(
+              selectedProvider?.providerType,
+              selectedExternal?.modelId,
+            )
             ? false
             : (storedToolsEnabled ?? searchOnByDefault)
           : false;

--- a/studio/frontend/src/features/chat/external-providers.ts
+++ b/studio/frontend/src/features/chat/external-providers.ts
@@ -111,6 +111,7 @@ const VISION_CAPABLE_PROVIDER_TYPES = new Set<string>([
   "openai",
   "anthropic",
   "gemini",
+  "kimi",
   "openrouter",
 ]);
 

--- a/studio/frontend/src/features/chat/provider-capabilities.ts
+++ b/studio/frontend/src/features/chat/provider-capabilities.ts
@@ -82,6 +82,7 @@ export const EXTERNAL_MAX_OUTPUT_TOKENS = 32768;
  *   OpenAI:    developers.openai.com/api/docs/models/gpt-5.5
  *   Anthropic: platform.claude.com/docs/en/about-claude/models
  *   Gemini:    ai.google.dev/gemini-api/docs/models/gemini-3.1-pro-preview
+ *   kimi:      platform.kimi.ai/docs/models
  *   DeepSeek:  api-docs.deepseek.com/quick_start/pricing (V4 family)
  * Local-model path is unaffected.
  */
@@ -128,6 +129,7 @@ const EXTERNAL_MAX_OUTPUT_TOKENS_BY_MODEL: Array<{
     prefixes: ["gemini-3", "gemini-pro", "gemini-flash"],
     cap: 65536,
   },
+  { providerType: "kimi", prefixes: ["kimi-k3"], cap: 1048576 },
   // DeepSeek (V4: deepseek-chat / deepseek-reasoner alias V4-flash).
   { providerType: "deepseek", prefixes: ["deepseek"], cap: 384000 },
 ];
@@ -234,8 +236,8 @@ function _inferProviderFromOpenrouterId(
  *                 router's universal web-search shape; works for every
  *                 underlying model including the `openrouter/free` router).
  *   - Kimi:       `tools: [{type: "builtin_function", function: {name:
- *                          "$web_search"}}]` with `thinking: {type:
- *                          "disabled"}`. Requires a client round-trip:
+ *                          "$web_search"}}]` with model-specific reasoning
+ *                 controls. Requires a client round-trip:
  *                 the first call returns the search args; the backend
  *                 echoes them back as a role=tool message; the second
  *                 call streams the answer. Handled in
@@ -629,17 +631,14 @@ const PROVIDER_CAPABILITIES: Record<string, ProviderCapabilities> = {
     repetitionPenalty: false,
     presencePenalty: true,
   },
-  // Kimi k2.5/k2.6 are reasoning-class — the API locks temperature and top_p to
-  // fixed defaults and 400s on any other value ("invalid temperature: only 1 is
-  // allowed for this model"). Hide both sliders. Backend also strips these via
-  // PROVIDER_REGISTRY['kimi']['body_omit'].
+  // kimi k2.5/k2.6/k3 lock temperature and top_p to fixed defaults.
   kimi: {
     temperature: false,
     topP: false,
     topK: false,
     minP: false,
     repetitionPenalty: false,
-    presencePenalty: true,
+    presencePenalty: false,
   },
   // DeepSeek deprecated presence/frequency penalty in their current docs.
   deepseek: {
@@ -690,6 +689,28 @@ function isOpenRouterMandatoryReasoningModel(modelId: string): boolean {
   const normalized = modelId.trim().toLowerCase();
   const canonical = normalized.startsWith("~") ? normalized.slice(1) : normalized;
   return OPENROUTER_MANDATORY_REASONING_MODELS.has(canonical);
+}
+
+export function isKimiK3Selection(
+  providerType: string | null | undefined,
+  modelId: string | null | undefined,
+): boolean {
+  const provider = providerType?.trim().toLowerCase();
+  const model = modelId?.trim().toLowerCase();
+  return (
+    (provider === "kimi" && model === "kimi-k3") ||
+    (provider === "openrouter" && model === "moonshotai/kimi-k3")
+  );
+}
+
+export function kimiSearchRequiresThinkingOff(
+  providerType: string | null | undefined,
+  modelId: string | null | undefined,
+): boolean {
+  return (
+    providerType?.trim().toLowerCase() === "kimi" &&
+    modelId?.trim().toLowerCase() !== "kimi-k3"
+  );
 }
 type ReasoningCaps = {
   supportsReasoning: boolean;
@@ -835,7 +856,17 @@ function withReasoningEffortStyle(caps: ReasoningCaps): ExternalReasoningCapabil
 }
 
 function resolveKimiReasoningCapabilities(modelId: string): ExternalReasoningCapabilities {
-  // Kimi exposes a boolean thinking toggle, not an effort scale.
+  if (modelId === "kimi-k3") {
+    return {
+      ...DEFAULT_EXTERNAL_REASONING_CAPABILITIES,
+      supportsReasoning: true,
+      reasoningStyle: "reasoning_effort",
+      reasoningAlwaysOn: true,
+      supportsReasoningOff: false,
+      reasoningEffortLevels: ["low", "high", "max"],
+    };
+  }
+  // kimi k2 exposes a boolean thinking toggle, not an effort scale.
   //   - kimi-k2.6:        on by default, toggleable via
   //                       extra_body: {thinking: {type: enabled|disabled}}
   //   - kimi-k2-thinking: always on, no off switch
@@ -1047,6 +1078,15 @@ export function getExternalReasoningCapabilities(
   const isMistralProvider = normalizedProvider === "mistral";
   const isOpenRouterProvider = normalizedProvider === "openrouter";
   if (isOpenRouterProvider) {
+    if (isKimiK3Selection(normalizedProvider, normalizedModel)) {
+      return {
+        supportsReasoning: true,
+        reasoningStyle: "reasoning_effort",
+        reasoningAlwaysOn: false,
+        supportsReasoningOff: true,
+        reasoningEffortLevels: ["low", "high", "max"],
+      };
+    }
     // OpenRouter's unified `reasoning` param is accepted on every request; the
     // gateway no-ops for non-reasoning models. Mandatory-reasoning ids are
     // handled by the early guard; everything else gets a toggleable control.

--- a/studio/frontend/src/features/chat/shared-composer.tsx
+++ b/studio/frontend/src/features/chat/shared-composer.tsx
@@ -736,11 +736,9 @@ export function SharedComposer({
   const reasoningLockedOn =
     effectiveSupportsReasoning &&
     (effectiveReasoningAlwaysOn || !effectiveSupportsReasoningOff);
-  // Kimi's $web_search builtin mandates thinking=disabled
-  // (https://platform.kimi.ai/docs/guide/use-web-search). Both pills stay
-  // clickable, but turning one on flips the other off; the click handlers
-  // below enforce this so the visible state matches what the backend sends.
-  const isKimiExternal = selectedExternalProvider?.providerType === "kimi";
+  const isKimiExternal =
+    selectedExternalProvider?.providerType === "kimi" &&
+    externalSelection?.modelId.trim().toLowerCase() !== "kimi-k3";
   const effectiveReasoningEnabled = reasoningLockedOn ? true : reasoningEnabled;
   const effectiveReasoningVisualEnabled =
     effectiveReasoningEnabled && reasoningEffort !== "none";
@@ -2258,7 +2256,7 @@ export function SharedComposer({
                 onSelect={() => {
                   const next = !toolsEnabled;
                   setToolsEnabled(next);
-                  // Mirror the Search pill: Kimi forbids search + thinking together.
+                  // older kimi models require search and thinking to stay exclusive.
                   if (isKimiExternal) {
                     setReasoningEnabled(!next, { persist: false });
                     applyQwenThinkingParams(!next);
@@ -2364,9 +2362,7 @@ export function SharedComposer({
             onClick={() => {
               const next = !toolsEnabled;
               setToolsEnabled(next);
-              // Kimi's $web_search builtin requires thinking=disabled
-              // (https://platform.kimi.ai/docs/guide/use-web-search): toggle
-              // the Think pill off when Search is on, mirroring the backend.
+              // older kimi models require thinking off for $web_search.
               if (isKimiExternal) {
                 setReasoningEnabled(!next, { persist: false });
                 applyQwenThinkingParams(!next);
@@ -2550,8 +2546,7 @@ export function SharedComposer({
                               setReasoningEffort(level);
                               setReasoningEnabled(true);
                               applyQwenThinkingParams(true);
-                              // Mutual exclusion: turning thinking on for a
-                              // Kimi model forces the web_search builtin off.
+                              // older kimi models require search and thinking to stay exclusive.
                               if (isKimiExternal && toolsEnabled) {
                                 setToolsEnabled(false, { persist: false });
                               }
@@ -2644,8 +2639,7 @@ export function SharedComposer({
                   const next = !reasoningEnabled;
                   setReasoningEnabled(next);
                   applyQwenThinkingParams(next);
-                  // Mutual exclusion: Kimi's $web_search builtin requires
-                  // thinking off, so turning thinking on flips Search off.
+                  // older kimi models require search and thinking to stay exclusive.
                   if (isKimiExternal && next && toolsEnabled) {
                     setToolsEnabled(false, { persist: false });
                   }

--- a/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
+++ b/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
@@ -852,7 +852,7 @@ const explicitlyEditedThreadFields = new Set<string>();
  */
 const constraintSuppressedThreadFields = new Set<string>();
 
-/** Both pills of Kimi's search/thinking exclusion; the only non-persisting setters. */
+/** both pills of the legacy kimi search/thinking exclusion. */
 const CONSTRAINT_SUPPRESSIBLE_KEYS = ["reasoningEnabled", "toolsEnabled"] as const;
 
 function noteConstraintSuppressedThreadField(
@@ -3376,15 +3376,11 @@ function externalCheckpointRefusesDeepResearch(
   return provider != null && provider.providerType !== "openai_codex";
 }
 
-/**
- * Kimi's $web_search builtin requires thinking disabled, so the composer keeps the two
- * pills mutually exclusive. A restore has to do the same, or a chat stored under another
- * provider sends a combination Kimi rejects.
- */
 function isKimiCheckpoint(checkpoint: string | null | undefined): boolean {
   const parsed = parseExternalModelId(checkpoint);
   if (!parsed) return false;
   return (
+    parsed.modelId.trim().toLowerCase() !== "kimi-k3" &&
     useExternalProvidersStore
       .getState()
       .providers.find((candidate) => candidate.id === parsed.providerId)

--- a/studio/frontend/tests/provider-capabilities-current-models.test.ts
+++ b/studio/frontend/tests/provider-capabilities-current-models.test.ts
@@ -11,6 +11,9 @@ registerBundlerResolver();
 const {
   getExternalMaxOutputTokens,
   getExternalReasoningCapabilities,
+  getProviderCapabilities,
+  isKimiK3Selection,
+  kimiSearchRequiresThinkingOff,
   providerSupportsBuiltinCodeExecution,
 
   providerSupportsBuiltinWebSearch,
@@ -121,6 +124,39 @@ test("Gemini 3.x minors keep the thinkingLevel ladder", () => {
   }
   const pro = getExternalReasoningCapabilities("gemini", "gemini-3.1-pro-preview");
   assert.deepEqual([...pro.reasoningEffortLevels], ["low", "medium", "high"]);
+});
+
+test("Kimi K3 exposes its fixed reasoning, vision, tools, and output limits", () => {
+  const caps = getExternalReasoningCapabilities("kimi", "kimi-k3");
+  assert.equal(caps.supportsReasoning, true);
+  assert.equal(caps.reasoningStyle, "reasoning_effort");
+  assert.equal(caps.reasoningAlwaysOn, true);
+  assert.equal(caps.supportsReasoningOff, false);
+  assert.deepEqual([...caps.reasoningEffortLevels], ["low", "high", "max"]);
+  assert.equal(getExternalMaxOutputTokens("kimi", "kimi-k3"), 1048576);
+  assert.equal(providerSupportsBuiltinWebSearch("kimi", "kimi-k3"), true);
+  assert.equal(providerModelSupportsVision("kimi", "kimi-k3"), true);
+  assert.equal(getProviderCapabilities("kimi")?.presencePenalty, false);
+});
+
+test("Kimi K3 keeps search enabled and uses route-specific reasoning controls", () => {
+  assert.equal(isKimiK3Selection("kimi", "kimi-k3"), true);
+  assert.equal(kimiSearchRequiresThinkingOff("kimi", "kimi-k3"), false);
+  assert.equal(kimiSearchRequiresThinkingOff("kimi", "kimi-k2.6"), true);
+
+  const openRouterCaps = getExternalReasoningCapabilities(
+    "openrouter",
+    "moonshotai/kimi-k3",
+  );
+  assert.equal(isKimiK3Selection("openrouter", "moonshotai/kimi-k3"), true);
+  assert.equal(openRouterCaps.supportsReasoning, true);
+  assert.equal(openRouterCaps.reasoningStyle, "reasoning_effort");
+  assert.equal(openRouterCaps.reasoningAlwaysOn, false);
+  assert.equal(openRouterCaps.supportsReasoningOff, true);
+  assert.deepEqual(
+    [...openRouterCaps.reasoningEffortLevels],
+    ["low", "high", "max"],
+  );
 });
 
 test("new Anthropic and OpenAI ids keep their max-output cap and code pill", () => {


### PR DESCRIPTION
## Summary

- add Kimi K3 to direct Kimi and OpenRouter model catalogs
- expose K3 vision, search, 1M output, and low/high/max reasoning controls
- replay K3 reasoning across local tool calls and repeated web-search turns
- keep Search and Thinking active together for direct K3

## Testing

- 66 focused backend tests passed
- 12 focused frontend capability tests passed
- 4,264 frontend tests passed
- TypeScript typecheck and Ruff passed
- headless Playwright verified direct K3 selection, reselection, reload, Search, Thinking Max, and the OpenRouter effort menu

## Screenshots

| Before | After |
| --- | --- |
| ![Kimi K3 before](https://raw.githubusercontent.com/mahiatlinux/unsloth/pr-assets-studio-kimi-k3-api/before.png) | ![Kimi K3 after](https://raw.githubusercontent.com/mahiatlinux/unsloth/pr-assets-studio-kimi-k3-api/after.png) |

Fixes #8735
