### PR TITLE
fix(hub): exempt the active channel's owner from the feed's iconless gate

### DIFF
--- a/studio/frontend/src/features/hub/hub-page.tsx
+++ b/studio/frontend/src/features/hub/hub-page.tsx
@@ -846,12 +846,19 @@ export function ModelsPage() {
 
   const filteredDiscoverRows = useMemo(() => {
     if (isDatasetMode) return discoverRows;
+    // Why (#9456): the iconless likes gate exists to keep the general feed
+    // clean, but an owner-scoped channel ("Latest Unsloth Models") is curated
+    // content — its owner's newest models routinely sit under the threshold and
+    // match no provider stem, so the gate emptied the whole channel.
+    const channelOwner = activeChannel?.owner?.toLowerCase() ?? null
     return discoverRows.filter(
       (row) =>
         !isHiddenModelId(row.id) &&
         !isConfiguredHiddenModelId(hiddenEmbeddingModelIds, row.id) &&
-        // Feed shows logo'd models, plus iconless ones above the likes threshold.
+        // Feed shows logo'd models, plus iconless ones above the likes threshold;
+        // a channel's own owner is always shown.
         (!isFeedMode ||
+          (channelOwner !== null && row.owner.toLowerCase() === channelOwner) ||
           resolveOwnerProviderLogo(row.owner, row.repo) !== null ||
           (row.result.likes ?? 0) >= MIN_ICONLESS_MODEL_LIKES) &&
         matchesFormat(

--- a/studio/frontend/tests/hub-feed-channel-owner-gate.test.ts
+++ b/studio/frontend/tests/hub-feed-channel-owner-gate.test.ts
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// The feed's iconless gate (logo'd providers, or likes >= 30) is a general-feed
+// cleanliness rule. An owner-scoped channel is curated content, so its owner's
+// rows must bypass the gate — otherwise a channel like "Latest Unsloth Models"
+// renders empty while its newest models sit under the threshold and match no
+// provider stem (#9456).
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFile } from "node:fs/promises";
+
+function read(path: string): Promise<string> {
+  return readFile(new URL(path, import.meta.url), "utf8");
+}
+
+test("the feed's iconless gate exempts the active channel's owner", async () => {
+  const page = await read("../src/features/hub/hub-page.tsx");
+  const source = page.slice(
+    page.indexOf("const filteredDiscoverRows = useMemo"),
+  );
+  const filterBody = source.slice(0, source.indexOf(");", source.indexOf("discoverRows.filter")));
+
+  assert.match(
+    filterBody,
+    /channelOwner !== null && row\.owner\.toLowerCase\(\) === channelOwner/,
+    "the channel-owner exemption must be part of the feed gate",
+  );
+  // The exemption must fire before the likes threshold, so a sub-threshold
+  // channel row never depends on the threshold to be visible.
+  const exemptAt = filterBody.indexOf("channelOwner !== null");
+  const likesAt = filterBody.indexOf("MIN_ICONLESS_MODEL_LIKES");
+  assert.ok(
+    exemptAt !== -1 && likesAt !== -1 && exemptAt < likesAt,
+    "the channel-owner check must precede the likes threshold",
+  );
+  // The gate itself must stay scoped to feed mode.
+  assert.match(filterBody, /!isFeedMode ||/);
+});


### PR DESCRIPTION
## Summary

**What**

The feed's iconless-visibility gate (`logo'd provider OR likes ≥ 30`) now exempts rows owned by the **active channel's owner**. The general feed's behavior is unchanged.

**Why**

#9456 — the "Latest Unsloth Models" channel (owner-scoped, sorted by `createdAt`) can render its empty-state while the API returns hundreds of models. Two independent facts make that possible, and this PR removes the one that's unambiguously wrong:

1. **Verified in current source**: the model id is mapped from the repo id (`id: m.name` in `use-hub-model-search.ts:242`), so `owner`/`repo` parse fine on main — the `id: t._id` shape the reporter decompiled is `@huggingface/hub`'s `listModels` yield (`{...additional, id: item._id, name: item.id}`, confirmed in the vendored 2.15.0 dist), which the app mapper translates; their build may predate or diverge from this, and the mirror variable is worth their follow-up data.
2. **The gate itself**: for a row from an owner-scoped channel, visibility currently depends on the repo name matching a provider stem (unsloth is a *relabeled* owner — its avatar is swapped for the upstream provider's logo, so `resolveOwnerProviderLogo` returns null unless the name matches) or on `likes ≥ 30`. The newest models — the entire point of a `createdAt`-sorted channel — routinely sit under 30 likes and plenty match no stem, so the gate drops them. A curated channel showing none of its owner's new models is the reported symptom, whatever the id plumbing did in that build.

The fix treats channel-owner rows as curated content: always visible in that channel, popularity gate untouched elsewhere.

**Testing**

- New `hub-feed-channel-owner-gate.test.ts` (source-contract style, matching `hub-recovery-paths.test.ts`): the channel-owner exemption exists inside the feed gate, precedes the likes threshold, and the gate stays scoped to feed mode. **Verified to fail on the pre-change filter.** 1/1 via `node --experimental-strip-types --test`.
- `tsc -b` clean.

Fixes the channel-empty half of #9456