### PR TITLE
 fix: declare checkpoint on ChatInferenceSettings so Studio presets persist

### DIFF
--- a/studio/backend/routes/chat_history.py
+++ b/studio/backend/routes/chat_history.py
@@ -358,6 +358,13 @@ class ChatInferenceSettings(BaseModel):
     systemVariables: Optional[str] = None
     trustRemoteCode: Optional[bool] = None
     fastMode: Optional[bool] = None
+    # The UI's InferenceParams carries `checkpoint` (the model id) inside params,
+    # and preset save bodies include it. Without declaring it here, extra="forbid"
+    # rejects the WHOLE PUT /api/chat/settings body, so every preset
+    # create/copy/edit 400s and nothing persists (issue #9500). Same bug family as
+    # fastMode before it (fixed by declaring the field). It names the model rather
+    # than being a tuning knob, so it is stored but never treated as a setting.
+    checkpoint: Optional[str] = None
 
 
 class ChatPresetLoadConfig(BaseModel):


### PR DESCRIPTION
Fixes #9500

The UI's InferenceParams includes checkpoint (the model id) and preset save bodies carry params.checkpoint. ChatInferenceSettings uses extra="forbid" but did not declare the field, so PUT /api/chat/settings rejected the entire body with 400 — every preset create/copy/edit failed to persist. Declaring the field mirrors the fastMode fix (#5870) for the same bug family.