### PR TITLE
Studio: turn on the grid-based reasoning collapse

### DIFF
--- a/studio/frontend/src/components/assistant-ui/thread-feature-flags.ts
+++ b/studio/frontend/src/components/assistant-ui/thread-feature-flags.ts
@@ -23,7 +23,26 @@
 // transition does not fire, and changing three collapsibles at once would make an A/B on the
 // reasoning toggle unattributable.
 //
-// OFF until the A/B has run. CONTRIBUTING-perf.md is explicit that a direction is not a result, and
-// this one also changes the rendered DOM (one wrapper element inside the content), so it needs
-// screenshots as well as the parity digest.
-export const GRID_COLLAPSE_REASONING_ENABLED = false;
+// ON. The A/B this comment was waiting for has run, on the standard tier at the 100K rung, four
+// repetitions across two independent waves, each wave carrying its own null control measured in
+// band under the same load. `reasoning_toggle.open_ms` cleared all three gates in BOTH waves:
+// -33.6% against a 15.2% floor, and -20.6% against an 11.8% floor. It is the only metric that did,
+// and the jank index cleared in the first wave and fell under its floor in the second, so the claim
+// here is narrow: opening a reasoning pane on a long thread gets meaningfully cheaper, and nothing
+// else was shown to move.
+//
+// The screenshots this comment asked for were taken, on two production builds of the same commit
+// differing only in this boolean. Collapsed, the two panes are byte-identical PNGs. Expanded, they
+// differ in 25 pixels along one text baseline at a maximum channel delta of 2/255, which is
+// antialiasing. `textContent` is byte-identical in both states, 23,965 characters expanded.
+// Geometry matches to the sub-pixel: root 744x5937.38 and content 718x5896.25 on both arms, the
+// grid row resolving `1fr` to exactly the height Radix measures.
+//
+// The parity digest does report a difference, and it is real rather than noise: the per-message
+// structural signature is 209 characters shorter, entirely within `[data-slot="reasoning-root"]`.
+// It is accounted for to the byte: -242 from the class list (Radix's eight animation and duration
+// tokens replaced by four grid tokens), -8 from the dropped `style` attribute presence token, and
+// +41 for the wrapper element this comment already predicted. No `aria-*` semantics change; the
+// only ARIA delta is Radix's `radix-` id prefix disappearing, and the control relationship resolves
+// on both arms.
+export const GRID_COLLAPSE_REASONING_ENABLED = true;

--- a/studio/frontend/tests/reasoning-grid-collapse.test.ts
+++ b/studio/frontend/tests/reasoning-grid-collapse.test.ts
@@ -132,8 +132,13 @@ test("nothing writes a ref during render", () => {
   assert.ok(code.includes("const next = !open;"));
 });
 
-test("the flag is off by default", () => {
-  assert.match(FLAGS, /export const GRID_COLLAPSE_REASONING_ENABLED = false;/);
+test("the flag is on", () => {
+  // Was "off by default" while the A/B was outstanding. It has run: two independent waves at the
+  // 100K rung, each with its own in-band null control, and `reasoning_toggle.open_ms` cleared all
+  // three gates in both. The assertion is kept rather than deleted so that the flag's value stays
+  // a deliberate, reviewed choice instead of something that can drift silently in either
+  // direction.
+  assert.match(FLAGS, /export const GRID_COLLAPSE_REASONING_ENABLED = true;/);
 });
 
 test("the reasoning pane picks its primitive from the flag on all three slots", () => {


### PR DESCRIPTION
PR #9423 replaced Radix's measured-height collapsible with a local grid primitive that never measures, and merged behind `GRID_COLLAPSE_REASONING_ENABLED` defaulting off. The flag has been off ever since, so nobody has been getting the improvement. This turns it on.

The flag file itself said "OFF until the A/B has run", and asked for screenshots as well as a parity digest because the change adds one wrapper element to the DOM. Both have now been done, on current main.

## The mechanism

Radix's `CollapsibleContentImpl` runs a `useLayoutEffect` that writes `transitionDuration: 0s` and `animationName: none`, reads `getBoundingClientRect()`, then writes the styles back, on every `open` change, unconditionally, whether or not any stylesheet consumes the `--radix-collapsible-content-height` it produces. That read is a synchronous full-document layout, and Blink's layout is O(total layout objects) rather than O(dirty objects), so on a long thread it is charged the whole document. The grid primitive transitions `grid-template-rows` from `0fr` to `1fr` and never measures.

## What was measured

studiobench standard tier, 100K rung, `--reps 4` split into **two independent waves** of two repetitions, in headless Chromium (`--engine chromium`, read back from `run_meta.platform.engine` in each payload rather than trusted from the command line).

Both arms are production `npm run build` bundles served by the Studio backend with `--frontend`, each with its own `UNSLOTH_STUDIO_HOME` and port, never a shared `--home`. The two dists differ only in this one boolean: base `746ad086d` bundle sha256 `7e6c4a2ff23be5a9`, flag-on `8ef4bcfc7` bundle `0aeee6754062b578`. Every payload passed `--assert-liveness`.

Each wave carried its **own null control**, base against base, identical bytes, running as one of the concurrent jobs so the floor sees the same contention the result does. Wave 0's floor is not wave 1's floor, and neither is quoted against the other.

### The result, both waves

| metric | wave | n | base | treat | delta | spread | floor | verdict |
|---|---|---|---|---|---|---|---|---|
| `reasoning_toggle.open_ms` | 0 | 2 | 2165.1 | 1438.5 | **-33.6%** | 30.2% | 15.2% | faster |
| `reasoning_toggle.open_ms` | 1 | 2 | 2226.5 | 1767.2 | **-20.6%** | 4.7% | 11.8% | faster |
| `jank_index` | 0 | 2 | 61.6 | 49.1 | -20.1% | 11.8% | 12.9% | faster |
| `jank_index` | 1 | 2 | 64.3 | 54.9 | -14.6% | 18.1% | 16.7% | VOID (under floor) |
| `time_in_jank_pct` | 0 | 2 | 3.9 | 3.6 | -7.2% | 5.5% | 4.9% | faster |
| `time_in_jank_pct` | 1 | 2 | 4.0 | 3.8 | -4.3% | 9.4% | 11.4% | VOID (under floor) |
| `reasoning_toggle.close_ms` | 0 | 2 | 833.2 | 874.3 | +4.5% | 66.4% | 20.6% | VOID (under floor) |
| `reasoning_toggle.close_ms` | 1 | 2 | 846.0 | 634.8 | -24.9% | 2.4% | 33.5% | VOID (under floor) |

**The claim is deliberately narrow.** `reasoning_toggle.open_ms` is the only metric that cleared all three gates in both waves. The jank index cleared in wave 0 and fell under its floor in wave 1, so it is reported and not claimed. Opening a reasoning pane on a long thread gets meaningfully cheaper; nothing else was shown to move.

The magnitude differs between waves, -33.6% and -20.6%, and wave 0's spread (30.2%) is close to its own delta. Wave 1 is the tighter measurement (spread 4.7%). Treat the effect as "roughly a fifth to a third off", not as a precise figure.

Nothing regressed past its floor in either wave. Two `SLOWER` rows appear in wave 0 on `scroll_after.gesture_ms` and `scroll_after.per_step_ms`, both `+0.0%` against a `0.0%` floor; that is the scroll gesture's fixed step cadence, not a regression.

### Provenance of the original numbers

PR #9423 reported -24.8% and -21.1% at n=8. Those are **the original author's figures on an older tree** and are quoted here as history. They have not been re-measured. The table above is fresh measurement on current main.

## Parity

`sweep/ui_parity.py`, `--mode digest`, scored against the null control from the same run:

| arm | stable actions differing | null on the same run |
|---|---|---|
| flag on, wave 0 | 12 | 0 |
| flag on, wave 1 | 2 | 0 |

The null reporting 0 in both waves is what makes the non-zero readings trustworthy rather than noise. **The difference is real**, it persists under `--mode visible`, so it cannot take the off-screen exemption, and it needs explaining rather than waving through.

It is a per-message structural signature that is **exactly 209 characters shorter**, identically on every assistant message carrying a reasoning pane, in every stable action and both repetitions. Note that `parity.js` records `chars: sig.length`, the length of the normalised structural signature, **not** visible text.

Measured directly, by serving both dists side by side and computing the signature with the harness's own `window.__sb.parity.signature` on a seeded 23,868-character reasoning trace: 100% of the delta is inside `[data-slot="reasoning-root"]`, on the single `[data-slot="reasoning-content"]` div, and it accounts to the byte:

| term | bytes |
|---|---|
| `class` value: Radix's 8 animation/duration tokens replaced by 4 grid tokens | -242 |
| ` style=*` presence token, Radix emits `style`, the grid primitive emits none | -8 |
| the `min-h-0 overflow-hidden` wrapper element and its close tag | +41 |
| **total** | **-209** |

The expanded pane gives -211, because the grid class swaps `hidden` (6) for `grid` (4). The digest's 209 is the collapsed pane, which is what a seeded thread shows by default.

## What the user sees

- `textContent` is **byte-identical** on both arms: 21 characters collapsed ("Thought for 0 seconds"), **23,965 characters expanded**, and identical again after re-collapsing.
- Collapsed screenshots are **byte-identical PNGs** (md5 `376de7f5e49873048eab4f13a9b9ea31`).
- Expanded screenshots differ in **25 pixels**, bbox (483,567)-(1227,574), **maximum channel delta 2/255**. That is text antialiasing on one baseline, not a layout difference.
- Geometry matches to the sub-pixel: root 744x23.13 collapsed and 744x5937.38 expanded on both arms; content 0x0 collapsed and 718x5896.25 expanded on both. The grid row resolves `1fr` to exactly the height Radix measures.
- `data-state`, `data-variant`, `aria-expanded`, the `hidden` attribute and the trigger label are identical in every state.

### Accessibility

Same ARIA attribute count and set. One value differs: `aria-controls` is `radix-_r_8j_` on the Radix arm and `_r_8j_` on the grid arm, because Radix prefixes its generated id and the local primitive uses a bare `useId()`. On both arms it resolves to the same element, so the control relationship is intact, and both `id` and `aria-controls` are in the digest's `VOLATILE_ATTRS`, which is why this contributes 0 of the 209. No role or landmark changes. The extra wrapper carries no role, no ARIA and no id, so an AT tree flattens it.

### One behavioural difference the digest cannot express

On the grid arm the content div and its wrapper stay in the DOM while closed, 11 elements against 10, whereas Radix unmounts the content entirely. **Children are unmounted on both arms**, so no message text is retained by a closed pane.

## Tests

`npm test` in `studio/frontend`: 4279 passing, 0 failing. `tsc --noEmit` clean.

`tests/reasoning-grid-collapse.test.ts` asserted the flag was `false`. It now asserts `true`, kept as an assertion rather than deleted so the value stays a reviewed choice and cannot drift silently in either direction.
