### PR TITLE
fix(studio): point denied --parallel extra args at the n_parallel load field

### DIFF
--- a/studio/backend/core/inference/llama_server_args.py
+++ b/studio/backend/core/inference/llama_server_args.py
@@ -280,10 +280,17 @@ def validate_extra_args(args: Optional[Iterable[str]]) -> list[str]:
             raise ValueError("extra llama-server args cannot contain control characters")
         flag = _flag_name(token)
         if flag is not None and flag in _DENYLIST:
-            raise ValueError(
+            message = (
                 f"llama-server flag '{flag}' is managed by Unsloth Studio "
                 f"and cannot be passed as an extra arg"
             )
+            # Why (#9510): users reaching for `--parallel 1` to cap concurrent predictions on a
+            # local model hit this refusal with no pointer to the supported knob; name it.
+            if flag in {"-np", "--parallel", "--n-parallel"}:
+                message += (
+                    "; set n_parallel on the load request (parallel decode slots) instead"
+                )
+            raise ValueError(message)
         if flag is None:
             # A token belonging to no flag. Today's llama-server answers "invalid
             # argument" and refuses to start, which is a failed load rather than a

--- a/studio/backend/core/inference/llama_server_args.py
+++ b/studio/backend/core/inference/llama_server_args.py
@@ -287,9 +287,7 @@ def validate_extra_args(args: Optional[Iterable[str]]) -> list[str]:
             # Why (#9510): users reaching for `--parallel 1` to cap concurrent predictions on a
             # local model hit this refusal with no pointer to the supported knob; name it.
             if flag in {"-np", "--parallel", "--n-parallel"}:
-                message += (
-                    "; set n_parallel on the load request (parallel decode slots) instead"
-                )
+                message += "; set n_parallel on the load request (parallel decode slots) instead"
             raise ValueError(message)
         if flag is None:
             # A token belonging to no flag. Today's llama-server answers "invalid

--- a/studio/backend/tests/test_llama_extra_args_compatibility.py
+++ b/studio/backend/tests/test_llama_extra_args_compatibility.py
@@ -530,3 +530,16 @@ def test_a_padded_flag_is_carried_over_by_dropping_it_with_its_value():
     assert dropped == ["--top-k"]
     kept, _dropped = _lsa.drop_managed_flags(["--verbose ", "--numa", "distribute"])
     assert kept == ["--numa", "distribute"]
+
+
+@pytest.mark.parametrize("flag", ["--parallel", "-np", "--n-parallel"])
+def test_parallel_denials_point_at_the_supported_knob(flag):
+    # Why (#9510): the parallel slot count IS user-settable, just not through extra args --
+    # refusing `--parallel 1` without naming n_parallel sent users to undocumented env hacks.
+    with pytest.raises(ValueError, match = "managed by Unsloth Studio.*n_parallel"):
+        _lsa.validate_extra_args([flag, "1"])
+
+
+def test_other_denials_stay_terse():
+    with pytest.raises(ValueError, match = "cannot be passed as an extra arg$"):
+        _lsa.validate_extra_args(["--model", "/etc/passwd"])

--- a/studio/frontend/src/features/model-picker/model-config/llama-extra-args.ts
+++ b/studio/frontend/src/features/model-picker/model-config/llama-extra-args.ts
@@ -624,10 +624,9 @@ export type ExtraArgsDiagnostic = {
 };
 
 /**
- * Controls in this panel that emit the same flag. Not a denial: the backend appends
- * extras last and reconciles the ones that move its own sizing (`parse_ctx_override`
- * and friends exist for exactly that), and the CLI has always allowed it. The user
- * just deserves to be told which one wins.
+ * Controls in this panel that own the same llama-server setting. For pass-through
+ * flags, the mapping explains which value wins. For managed flags such as parallel
+ * slots, it points the refusal at the supported control instead of leaving a dead end.
  */
 const CONTROL_OWNED_FLAGS: Record<string, string> = {
   "--ctx-size": "Context Length",
@@ -636,6 +635,9 @@ const CONTROL_OWNED_FLAGS: Record<string, string> = {
   "-b": "Batch Size",
   "--ubatch-size": "Micro-batch Size",
   "-ub": "Micro-batch Size",
+  "--parallel": "Parallel Slots",
+  "--n-parallel": "Parallel Slots",
+  "-np": "Parallel Slots",
   "--cache-type-k": "KV Cache Dtype",
   "-ctk": "KV Cache Dtype",
   "--cache-type-v": "KV Cache Dtype",

--- a/studio/frontend/src/features/model-picker/model-config/llama-extra-args.ts
+++ b/studio/frontend/src/features/model-picker/model-config/llama-extra-args.ts
@@ -624,9 +624,20 @@ export type ExtraArgsDiagnostic = {
 };
 
 /**
- * Controls in this panel that own the same llama-server setting. For pass-through
- * flags, the mapping explains which value wins. For managed flags such as parallel
- * slots, it points the refusal at the supported control instead of leaving a dead end.
+ * Managed flags whose supported replacement is a control in this panel. This stays
+ * available while the async flag catalogue is loading or unavailable: the backend
+ * denies these unconditionally, so they must never fall through to the "wins" note.
+ */
+const MANAGED_CONTROL_FLAGS: Record<string, string> = {
+  "--parallel": "Parallel Slots",
+  "--n-parallel": "Parallel Slots",
+  "-np": "Parallel Slots",
+};
+
+/**
+ * Pass-through flags that a control in this panel also emits. The backend appends
+ * these last and reconciles the ones that affect its sizing, so the mapping explains
+ * which value wins.
  */
 const CONTROL_OWNED_FLAGS: Record<string, string> = {
   "--ctx-size": "Context Length",
@@ -635,9 +646,6 @@ const CONTROL_OWNED_FLAGS: Record<string, string> = {
   "-b": "Batch Size",
   "--ubatch-size": "Micro-batch Size",
   "-ub": "Micro-batch Size",
-  "--parallel": "Parallel Slots",
-  "--n-parallel": "Parallel Slots",
-  "-np": "Parallel Slots",
   "--cache-type-k": "KV Cache Dtype",
   "-ctk": "KV Cache Dtype",
   "--cache-type-v": "KV Cache Dtype",
@@ -1046,6 +1054,9 @@ export function diagnoseExtraArgs(
       continue;
     }
     seen.add(flag);
+    const managedControl = MANAGED_CONTROL_FLAGS[flag];
+    const isManaged =
+      managedControl !== undefined || Boolean(catalog?.managed.has(flag));
 
     if (token !== token.trim()) {
       // The padding is part of the token llama.cpp looks up, so a quoted "--top-k "
@@ -1056,7 +1067,7 @@ export function diagnoseExtraArgs(
         level: "error",
         message: `Remove the spaces around "${token}". llama-server reads them as part of the flag.`,
       });
-    } else if (token.includes("=") && !catalog?.managed.has(flag)) {
+    } else if (token.includes("=") && !isManaged) {
       // Measured on b10342 and b10360: "--top-k=20", "--ctx-size=4096" and
       // "--flash-attn=on" each exit with "error: invalid argument". A managed flag
       // is left to the message below, which names the control that owns it.
@@ -1066,8 +1077,8 @@ export function diagnoseExtraArgs(
       });
     }
 
-    if (catalog?.managed.has(flag)) {
-      const control = CONTROL_OWNED_FLAGS[flag];
+    if (isManaged) {
+      const control = managedControl ?? CONTROL_OWNED_FLAGS[flag];
       out.push({
         level: "error",
         message: control

--- a/studio/frontend/tests/llama-extra-args-diagnostics.test.ts
+++ b/studio/frontend/tests/llama-extra-args-diagnostics.test.ts
@@ -61,14 +61,22 @@ test("a well-formed argument the binary knows says nothing", () => {
   assert.deepEqual(diagnoseExtraArgs("", CATALOG), []);
 });
 
-test("a managed flag is an error that names the control that owns it", () => {
-  const text = messages("--parallel 8");
-  assert.match(text, /--parallel/);
-  assert.equal(levels("--parallel 8")[0], "error");
-  assert.equal(
-    extraArgsAreLoadable(diagnoseExtraArgs("--parallel 8", CATALOG)),
-    false,
-  );
+test("parallel aliases point at the supported control", () => {
+  for (const input of [
+    "--parallel 8",
+    "--n-parallel 8",
+    "--n_parallel 8",
+    "-np 8",
+    "-np8",
+  ]) {
+    const diagnostics = diagnoseExtraArgs(input, CATALOG);
+    assert.match(
+      messages(input),
+      /is set by Parallel Slots above and cannot be passed here\.$/,
+    );
+    assert.equal(diagnostics[0]?.level, "error");
+    assert.equal(extraArgsAreLoadable(diagnostics), false);
+  }
 });
 
 test("a managed flag with no control says who owns it instead", () => {

--- a/studio/frontend/tests/llama-extra-args-diagnostics.test.ts
+++ b/studio/frontend/tests/llama-extra-args-diagnostics.test.ts
@@ -62,20 +62,24 @@ test("a well-formed argument the binary knows says nothing", () => {
 });
 
 test("parallel aliases point at the supported control", () => {
-  for (const input of [
-    "--parallel 8",
-    "--n-parallel 8",
-    "--n_parallel 8",
-    "-np 8",
-    "-np8",
-  ]) {
-    const diagnostics = diagnoseExtraArgs(input, CATALOG);
-    assert.match(
-      messages(input),
-      /is set by Parallel Slots above and cannot be passed here\.$/,
-    );
-    assert.equal(diagnostics[0]?.level, "error");
-    assert.equal(extraArgsAreLoadable(diagnostics), false);
+  for (const catalog of [CATALOG, null]) {
+    for (const input of [
+      "--parallel 8",
+      "--parallel=8",
+      "--n-parallel 8",
+      "--n_parallel 8",
+      "-np 8",
+      "-np8",
+    ]) {
+      const diagnostics = diagnoseExtraArgs(input, catalog);
+      assert.equal(diagnostics.length, 1);
+      assert.match(
+        diagnostics[0]?.message ?? "",
+        /is set by Parallel Slots above and cannot be passed here\.$/,
+      );
+      assert.equal(diagnostics[0]?.level, "error");
+      assert.equal(extraArgsAreLoadable(diagnostics), false);
+    }
   }
 });
 
@@ -96,13 +100,15 @@ test("an attached or equals form is caught the same way", () => {
 test("a flag a control also sets is a note, not a refusal", () => {
   // Deliberate: the backend appends extras last and reconciles the ones that move
   // its own sizing, and the CLI has always allowed this. Say who wins, do not block.
-  const diagnostics = diagnoseExtraArgs("--batch-size 512", CATALOG);
-  assert.deepEqual(
-    diagnostics.map((d) => d.level),
-    ["note"],
-  );
-  assert.match(diagnostics[0].message, /Batch Size/);
-  assert.equal(extraArgsAreLoadable(diagnostics), true);
+  for (const catalog of [CATALOG, null]) {
+    const diagnostics = diagnoseExtraArgs("--batch-size 512", catalog);
+    assert.deepEqual(
+      diagnostics.map((d) => d.level),
+      ["note"],
+    );
+    assert.match(diagnostics[0].message, /Batch Size/);
+    assert.equal(extraArgsAreLoadable(diagnostics), true);
+  }
 });
 
 test("a flag missing from this build warns but still loads", () => {


### PR DESCRIPTION
## What

When `validate_extra_args` rejects the parallel slot family (`--parallel` / `-np` / `--n-parallel`), the error now names the supported knob: `set n_parallel on the load request (parallel decode slots) instead`. Every other denylisted flag keeps the original terse message.

## Why (refs #9510)

From the issue's API feedback: a local-model user hitting slow TPS from too many concurrent predictions tried `--parallel 1` in the model's extra args and got `"--parallel is managed by Unsloth and cannot be passed here."` — a dead end. The slot count *is* user-settable (`LoadRequest.n_parallel`, range-pinned by `PARALLEL_SLOTS_MIN`/`PARALLEL_SLOTS_MAX`), but the refusal gave no pointer, so the workaround was undocumented env hacks.

(The issue's other asks — auto-start on first request, LAN auto-start, remote-password visibility, GPU re-detection — are larger features I'm deliberately not bundling here.)

## Testing

- New cases in `test_llama_extra_args_compatibility.py`: all three spellings of the parallel flag raise with `n_parallel` named in the message, and an unrelated denial (`--model`) still ends at "cannot be passed as an extra arg" without the guidance.
- Diff-verified: with only the `llama_server_args.py` change stashed, the three guidance tests fail; with it applied the file passes 47/47.

Refs #9510
