### PR TITLE
Studio: list the other embedding models, and show Documents & RAG in Data

### DIFF
--- a/studio/frontend/src/features/settings/components/documents-rag-section.tsx
+++ b/studio/frontend/src/features/settings/components/documents-rag-section.tsx
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import { Button } from "@/components/ui/button";
+import { useChatRuntimeStore } from "@/features/chat";
+import { useT } from "@/i18n";
+import { toast } from "@/lib/toast";
+import { type ReactElement, useEffect, useState } from "react";
+import {
+  EmbeddingModelBlockedError,
+  type EmbeddingModelSettings,
+  EmbeddingModelVerificationError,
+  loadEmbeddingModelSettings,
+  resetEmbeddingModelSettings,
+  updateEmbeddingModelSettings,
+} from "../api/embedding-model";
+import { EmbeddingModelCombobox } from "./embedding-model-combobox";
+import { SettingsRow } from "./settings-row";
+import { SettingsSection } from "./settings-section";
+
+/**
+ * Which model indexes uploaded documents. Rendered in both General and Data:
+ * each mount loads the setting, so the two never disagree.
+ */
+export function DocumentsRagSection(): ReactElement {
+  const t = useT();
+  const hfToken = useChatRuntimeStore((s) => s.hfToken);
+  const [embeddingModel, setEmbeddingModel] =
+    useState<EmbeddingModelSettings | null>(null);
+  const [draftEmbeddingModel, setDraftEmbeddingModel] = useState("");
+  const [embeddingModelError, setEmbeddingModelError] = useState<string | null>(
+    null,
+  );
+  // Set after a 409 (unverifiable model); offers "Save anyway".
+  const [embeddingModelNeedsForce, setEmbeddingModelNeedsForce] =
+    useState(false);
+  const [isSavingEmbeddingModel, setIsSavingEmbeddingModel] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    void loadEmbeddingModelSettings()
+      .then((settings) => {
+        if (cancelled) return;
+        setEmbeddingModel(settings);
+        setDraftEmbeddingModel(settings.embeddingModel);
+      })
+      .catch((error) => {
+        if (cancelled) return;
+        setEmbeddingModelError(
+          error instanceof Error
+            ? error.message
+            : t("settings.general.rag.loadError"),
+        );
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [t]);
+
+  const saveEmbeddingModel = async (force: boolean) => {
+    const trimmed = draftEmbeddingModel.trim();
+    if (!trimmed) {
+      setEmbeddingModelError(t("settings.general.rag.emptyError"));
+      return;
+    }
+    setIsSavingEmbeddingModel(true);
+    setEmbeddingModelError(null);
+    try {
+      const settings = await updateEmbeddingModelSettings(trimmed, {
+        hfToken: hfToken || undefined,
+        force,
+      });
+      setEmbeddingModel(settings);
+      setDraftEmbeddingModel(settings.embeddingModel);
+      setEmbeddingModelNeedsForce(false);
+      toast.success(t("settings.general.rag.saved"), {
+        description: t("settings.general.rag.reindexWarning"),
+      });
+    } catch (error) {
+      // A hard security block cannot be forced; keep the "save anyway" action hidden.
+      if (error instanceof EmbeddingModelBlockedError) {
+        setEmbeddingModelNeedsForce(false);
+      } else if (error instanceof EmbeddingModelVerificationError) {
+        setEmbeddingModelNeedsForce(true);
+      }
+      setEmbeddingModelError(
+        error instanceof Error
+          ? error.message
+          : t("settings.general.rag.saveError"),
+      );
+    } finally {
+      setIsSavingEmbeddingModel(false);
+    }
+  };
+
+  const resetEmbeddingModel = async () => {
+    setIsSavingEmbeddingModel(true);
+    setEmbeddingModelError(null);
+    setEmbeddingModelNeedsForce(false);
+    try {
+      const settings = await resetEmbeddingModelSettings();
+      setEmbeddingModel(settings);
+      setDraftEmbeddingModel(settings.embeddingModel);
+    } catch (error) {
+      setEmbeddingModelError(
+        error instanceof Error
+          ? error.message
+          : t("settings.general.rag.saveError"),
+      );
+    } finally {
+      setIsSavingEmbeddingModel(false);
+    }
+  };
+
+  return (
+    <SettingsSection title={t("settings.general.rag.sectionTitle")}>
+      <SettingsRow
+        label={t("settings.general.rag.embeddingModel")}
+        description={t("settings.general.rag.embeddingModelDescription", {
+          defaultModel: embeddingModel?.defaultEmbeddingModel ?? "",
+        })}
+        className="max-[360px]:flex-col max-[360px]:items-stretch max-[360px]:gap-3"
+      >
+        <div className="flex flex-col items-end gap-1 max-[360px]:w-full">
+          <div className="flex items-center gap-2 max-[360px]:w-full">
+            <EmbeddingModelCombobox
+              value={draftEmbeddingModel}
+              onChange={(next) => {
+                setDraftEmbeddingModel(next);
+                setEmbeddingModelNeedsForce(false);
+                setEmbeddingModelError(null);
+              }}
+              accessToken={hfToken || undefined}
+              disabled={!embeddingModel}
+              placeholder={t("settings.general.rag.searchPlaceholder")}
+              ariaLabel={t("settings.general.rag.embeddingModel")}
+              className="w-[220px] max-[360px]:min-w-0 max-[360px]:flex-1"
+            />
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={
+                !embeddingModel ||
+                isSavingEmbeddingModel ||
+                draftEmbeddingModel.trim() === embeddingModel.embeddingModel
+              }
+              onClick={() => void saveEmbeddingModel(false)}
+            >
+              {isSavingEmbeddingModel ? t("common.saving") : t("common.save")}
+            </Button>
+          </div>
+          {embeddingModelError ? (
+            <span className="max-w-[300px] text-right text-xs text-destructive">
+              {embeddingModelError}
+            </span>
+          ) : null}
+          <div className="flex items-center gap-2">
+            {embeddingModelNeedsForce ? (
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={isSavingEmbeddingModel}
+                onClick={() => void saveEmbeddingModel(true)}
+              >
+                {t("settings.general.rag.saveAnyway")}
+              </Button>
+            ) : null}
+            {embeddingModel?.isCustom ? (
+              <Button
+                variant="ghost"
+                size="sm"
+                disabled={isSavingEmbeddingModel}
+                onClick={() => void resetEmbeddingModel()}
+              >
+                {t("settings.general.rag.resetAction")}
+              </Button>
+            ) : null}
+          </div>
+          <span className="max-w-[300px] text-right text-xs text-muted-foreground">
+            {t("settings.general.rag.reindexWarning")}
+          </span>
+        </div>
+      </SettingsRow>
+    </SettingsSection>
+  );
+}

--- a/studio/frontend/src/features/settings/components/embedding-model-combobox.tsx
+++ b/studio/frontend/src/features/settings/components/embedding-model-combobox.tsx
@@ -13,7 +13,7 @@ import { Spinner } from "@/components/ui/spinner";
 import type { PipelineType } from "@huggingface/hub";
 import { useHubModelSearch } from "@/features/hub/hooks/use-hub-model-search";
 import { useDebouncedValue } from "@/hooks";
-import { type ReactElement, useMemo, useRef } from "react";
+import { type ReactElement, useMemo, useRef, useState } from "react";
 
 // HF pipeline filter for embedding models; matches the backend's
 // is_embedding_model signals (sentence-similarity / feature-extraction).
@@ -44,9 +44,12 @@ export function EmbeddingModelCombobox({
 }: EmbeddingModelComboboxProps): ReactElement {
   const selectingRef = useRef(false);
   const anchorRef = useRef<HTMLDivElement>(null);
-  // Fully controlled: the parent updates value on every keystroke, so the
-  // prop itself is the search query.
-  const debouncedQuery = useDebouncedValue(value);
+  // Only text the user typed is a query. A saved or selected value searches for
+  // itself, which leaves the list holding that one model instead of the others.
+  const [typed, setTyped] = useState<string | null>(null);
+  // Anything the parent set (selection, reset, reload) clears the query.
+  const query = typed !== null && typed === value ? typed : "";
+  const debouncedQuery = useDebouncedValue(query);
 
   const { results, isLoading } = useHubModelSearch(debouncedQuery, {
     task: EMBEDDING_TASKS,
@@ -92,8 +95,10 @@ export function EmbeddingModelCombobox({
         onInputValueChange={(next) => {
           if (selectingRef.current) {
             selectingRef.current = false;
+            setTyped(null);
             return;
           }
+          setTyped(next);
           onChange(next);
         }}
         itemToStringValue={(item) => item}

--- a/studio/frontend/src/features/settings/components/embedding-model-combobox.tsx
+++ b/studio/frontend/src/features/settings/components/embedding-model-combobox.tsx
@@ -42,7 +42,6 @@ export function EmbeddingModelCombobox({
   ariaLabel,
   className,
 }: EmbeddingModelComboboxProps): ReactElement {
-  const selectingRef = useRef(false);
   const anchorRef = useRef<HTMLDivElement>(null);
   // Only text the user typed is a query. A saved or selected value searches for
   // itself, which leaves the list holding that one model instead of the others.
@@ -92,9 +91,10 @@ export function EmbeddingModelCombobox({
         filter={null}
         value={value.trim() ? value : null}
         onValueChange={(next) => onChange(next ?? "")}
-        onInputValueChange={(next) => {
-          if (selectingRef.current) {
-            selectingRef.current = false;
+        onInputValueChange={(next, details) => {
+          // The settings load and a pick both write the input too, and arrive
+          // with another reason; only typing is a search.
+          if (details.reason !== "input-change") {
             setTyped(null);
             return;
           }
@@ -121,13 +121,7 @@ export function EmbeddingModelCombobox({
           )}
           <ComboboxList>
             {(id: string) => (
-              <ComboboxItem
-                key={id}
-                value={id}
-                onPointerDown={() => {
-                  selectingRef.current = true;
-                }}
-              >
+              <ComboboxItem key={id} value={id}>
                 <span className="truncate font-mono text-ui-11">{id}</span>
               </ComboboxItem>
             )}

--- a/studio/frontend/src/features/settings/components/embedding-model-combobox.tsx
+++ b/studio/frontend/src/features/settings/components/embedding-model-combobox.tsx
@@ -46,7 +46,8 @@ export function EmbeddingModelCombobox({
   // Only text the user typed is a query. A saved or selected value searches for
   // itself, which leaves the list holding that one model instead of the others.
   const [typed, setTyped] = useState<string | null>(null);
-  // Anything the parent set (selection, reset, reload) clears the query.
+  // Anything the parent set (selection, reset, reload) clears the query. Saving
+  // writes the same string back, which this cannot see, so closing clears it too.
   const query = typed !== null && typed === value ? typed : "";
   const debouncedQuery = useDebouncedValue(query);
 
@@ -89,6 +90,11 @@ export function EmbeddingModelCombobox({
         items={items}
         filteredItems={items}
         filter={null}
+        onOpenChange={(open) => {
+          // The search lasts as long as the list is open, as the model picker
+          // in Settings -> Agents does.
+          if (!open) setTyped(null);
+        }}
         value={value.trim() ? value : null}
         onValueChange={(next) => onChange(next ?? "")}
         onInputValueChange={(next, details) => {

--- a/studio/frontend/src/features/settings/tabs/data-tab.tsx
+++ b/studio/frontend/src/features/settings/tabs/data-tab.tsx
@@ -71,6 +71,7 @@ import { useEffect, useRef, useState } from "react";
 import { ArchivedChatsView } from "../components/archived-chats-dialog";
 import { ArchivedMediaView } from "../components/archived-media-dialog";
 import { ManageChatsView } from "../components/manage-chats-view";
+import { DocumentsRagSection } from "../components/documents-rag-section";
 import { SettingsRow } from "../components/settings-row";
 import { SettingsSection } from "../components/settings-section";
 import { UploadedFilesView } from "../components/uploaded-files-dialog";
@@ -943,6 +944,8 @@ export function DataTab() {
           </div>
         ) : null}
       </SettingsSection>
+
+      <DocumentsRagSection />
 
       <Dialog open={archiveConfirmOpen} onOpenChange={setArchiveConfirmOpen}>
         <DialogContent className="max-w-md">

--- a/studio/frontend/src/features/settings/tabs/general-tab.tsx
+++ b/studio/frontend/src/features/settings/tabs/general-tab.tsx
@@ -40,14 +40,6 @@ import { cn } from "@/lib/utils";
 import { Check, Eye, EyeOff } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import {
-  EmbeddingModelBlockedError,
-  type EmbeddingModelSettings,
-  EmbeddingModelVerificationError,
-  loadEmbeddingModelSettings,
-  resetEmbeddingModelSettings,
-  updateEmbeddingModelSettings,
-} from "../api/embedding-model";
-import {
   type HelperPrecacheSettings,
   loadHelperPrecacheSettings,
   updateHelperPrecacheSettings,
@@ -71,7 +63,7 @@ import {
   DesktopUpdateControl,
   DesktopUpdateNote,
 } from "../components/desktop-update-control";
-import { EmbeddingModelCombobox } from "../components/embedding-model-combobox";
+import { DocumentsRagSection } from "../components/documents-rag-section";
 import { LanguageSelect } from "../components/language-select";
 import { SettingsRow } from "../components/settings-row";
 import { SettingsSection } from "../components/settings-section";
@@ -219,16 +211,6 @@ export function GeneralTab() {
     loadError: t("settings.general.startup.loadError"),
     saveError: t("settings.general.startup.closeToTraySaveError"),
   });
-  const [embeddingModel, setEmbeddingModel] =
-    useState<EmbeddingModelSettings | null>(null);
-  const [draftEmbeddingModel, setDraftEmbeddingModel] = useState("");
-  const [embeddingModelError, setEmbeddingModelError] = useState<string | null>(
-    null,
-  );
-  // Set after a 409 (unverifiable model); offers "Save anyway".
-  const [embeddingModelNeedsForce, setEmbeddingModelNeedsForce] =
-    useState(false);
-  const [isSavingEmbeddingModel, setIsSavingEmbeddingModel] = useState(false);
 
   const draftRef = useRef(draftToken);
   useEffect(() => {
@@ -329,26 +311,6 @@ export function GeneralTab() {
     };
   }, [t]);
 
-  useEffect(() => {
-    let cancelled = false;
-    void loadEmbeddingModelSettings()
-      .then((settings) => {
-        if (cancelled) return;
-        setEmbeddingModel(settings);
-        setDraftEmbeddingModel(settings.embeddingModel);
-      })
-      .catch((error) => {
-        if (cancelled) return;
-        setEmbeddingModelError(
-          error instanceof Error
-            ? error.message
-            : t("settings.general.rag.loadError"),
-        );
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [t]);
 
   const saveHelperPrecache = async (enabled: boolean) => {
     setIsSavingHelperPrecache(true);
@@ -403,60 +365,6 @@ export function GeneralTab() {
     }
   };
 
-  const saveEmbeddingModel = async (force: boolean) => {
-    const trimmed = draftEmbeddingModel.trim();
-    if (!trimmed) {
-      setEmbeddingModelError(t("settings.general.rag.emptyError"));
-      return;
-    }
-    setIsSavingEmbeddingModel(true);
-    setEmbeddingModelError(null);
-    try {
-      const settings = await updateEmbeddingModelSettings(trimmed, {
-        hfToken: hfToken || undefined,
-        force,
-      });
-      setEmbeddingModel(settings);
-      setDraftEmbeddingModel(settings.embeddingModel);
-      setEmbeddingModelNeedsForce(false);
-      toast.success(t("settings.general.rag.saved"), {
-        description: t("settings.general.rag.reindexWarning"),
-      });
-    } catch (error) {
-      // A hard security block cannot be forced; keep the "save anyway" action hidden.
-      if (error instanceof EmbeddingModelBlockedError) {
-        setEmbeddingModelNeedsForce(false);
-      } else if (error instanceof EmbeddingModelVerificationError) {
-        setEmbeddingModelNeedsForce(true);
-      }
-      setEmbeddingModelError(
-        error instanceof Error
-          ? error.message
-          : t("settings.general.rag.saveError"),
-      );
-    } finally {
-      setIsSavingEmbeddingModel(false);
-    }
-  };
-
-  const resetEmbeddingModel = async () => {
-    setIsSavingEmbeddingModel(true);
-    setEmbeddingModelError(null);
-    setEmbeddingModelNeedsForce(false);
-    try {
-      const settings = await resetEmbeddingModelSettings();
-      setEmbeddingModel(settings);
-      setDraftEmbeddingModel(settings.embeddingModel);
-    } catch (error) {
-      setEmbeddingModelError(
-        error instanceof Error
-          ? error.message
-          : t("settings.general.rag.saveError"),
-      );
-    } finally {
-      setIsSavingEmbeddingModel(false);
-    }
-  };
 
   const saveUploadLimit = async () => {
     const parsed = Number(draftUploadLimit);
@@ -721,75 +629,7 @@ export function GeneralTab() {
         </SettingsRow>
       </SettingsSection>
 
-      <SettingsSection title={t("settings.general.rag.sectionTitle")}>
-        <SettingsRow
-          label={t("settings.general.rag.embeddingModel")}
-          description={t("settings.general.rag.embeddingModelDescription", {
-            defaultModel: embeddingModel?.defaultEmbeddingModel ?? "",
-          })}
-          className="max-[360px]:flex-col max-[360px]:items-stretch max-[360px]:gap-3"
-        >
-          <div className="flex flex-col items-end gap-1 max-[360px]:w-full">
-            <div className="flex items-center gap-2 max-[360px]:w-full">
-              <EmbeddingModelCombobox
-                value={draftEmbeddingModel}
-                onChange={(next) => {
-                  setDraftEmbeddingModel(next);
-                  setEmbeddingModelNeedsForce(false);
-                  setEmbeddingModelError(null);
-                }}
-                accessToken={hfToken || undefined}
-                disabled={!embeddingModel}
-                placeholder={t("settings.general.rag.searchPlaceholder")}
-                ariaLabel={t("settings.general.rag.embeddingModel")}
-                className="w-[220px] max-[360px]:min-w-0 max-[360px]:flex-1"
-              />
-              <Button
-                variant="outline"
-                size="sm"
-                disabled={
-                  !embeddingModel ||
-                  isSavingEmbeddingModel ||
-                  draftEmbeddingModel.trim() === embeddingModel.embeddingModel
-                }
-                onClick={() => void saveEmbeddingModel(false)}
-              >
-                {isSavingEmbeddingModel ? t("common.saving") : t("common.save")}
-              </Button>
-            </div>
-            {embeddingModelError ? (
-              <span className="max-w-[300px] text-right text-xs text-destructive">
-                {embeddingModelError}
-              </span>
-            ) : null}
-            <div className="flex items-center gap-2">
-              {embeddingModelNeedsForce ? (
-                <Button
-                  variant="outline"
-                  size="sm"
-                  disabled={isSavingEmbeddingModel}
-                  onClick={() => void saveEmbeddingModel(true)}
-                >
-                  {t("settings.general.rag.saveAnyway")}
-                </Button>
-              ) : null}
-              {embeddingModel?.isCustom ? (
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  disabled={isSavingEmbeddingModel}
-                  onClick={() => void resetEmbeddingModel()}
-                >
-                  {t("settings.general.rag.resetAction")}
-                </Button>
-              ) : null}
-            </div>
-            <span className="max-w-[300px] text-right text-xs text-muted-foreground">
-              {t("settings.general.rag.reindexWarning")}
-            </span>
-          </div>
-        </SettingsRow>
-      </SettingsSection>
+      <DocumentsRagSection />
 
       <SettingsSection title={t("settings.general.uploads.sectionTitle")}>
         <SettingsRow

--- a/studio/frontend/src/features/settings/tabs/general-tab.tsx
+++ b/studio/frontend/src/features/settings/tabs/general-tab.tsx
@@ -740,7 +740,7 @@ export function GeneralTab() {
                 }}
                 accessToken={hfToken || undefined}
                 disabled={!embeddingModel}
-                placeholder={embeddingModel?.defaultEmbeddingModel ?? ""}
+                placeholder={t("settings.general.rag.searchPlaceholder")}
                 ariaLabel={t("settings.general.rag.embeddingModel")}
                 className="w-[220px] max-[360px]:min-w-0 max-[360px]:flex-1"
               />

--- a/studio/frontend/src/i18n/locales/ar.ts
+++ b/studio/frontend/src/i18n/locales/ar.ts
@@ -573,6 +573,7 @@ export const ar = {
         embeddingModel: "نموذج التضمين (Embedding)",
         embeddingModelDescription:
           "نموذج Hugging Face أو مسار محلي يُستخدم لفهرسة مستنداتك والبحث فيها. القيمة الافتراضية هي {defaultModel}.",
+        searchPlaceholder: "ابحث عن نماذج التضمين",
         reindexWarning:
           "يؤثر فقط في المستندات التي تُفهرس حديثًا. أعِد رفع المستندات الحالية بعد تغيير النموذج.",
         emptyError: "أدخل معرّف نموذج Hugging Face أو مسارًا محليًا.",

--- a/studio/frontend/src/i18n/locales/de.ts
+++ b/studio/frontend/src/i18n/locales/de.ts
@@ -594,6 +594,7 @@ export const de = {
         embeddingModel: "Embedding-Modell",
         embeddingModelDescription:
           "Hugging-Face-Modell oder lokaler Pfad zum Indexieren und Durchsuchen Ihrer Dokumente. Standard ist {defaultModel}.",
+        searchPlaceholder: "Embedding-Modelle suchen",
         reindexWarning:
           "Betrifft nur neu indexierte Dokumente. Laden Sie bestehende nach einer Modelländerung erneut hoch.",
         emptyError:

--- a/studio/frontend/src/i18n/locales/en.ts
+++ b/studio/frontend/src/i18n/locales/en.ts
@@ -575,6 +575,7 @@ export const en = {
         embeddingModel: "Embedding model",
         embeddingModelDescription:
           "Hugging Face model or local path used to index and search your documents. Default is {defaultModel}.",
+        searchPlaceholder: "Search embedding models",
         reindexWarning:
           "Only affects newly indexed documents. Re-upload existing ones after changing the model.",
         emptyError: "Enter a Hugging Face model id or local path.",

--- a/studio/frontend/src/i18n/locales/es.ts
+++ b/studio/frontend/src/i18n/locales/es.ts
@@ -589,6 +589,7 @@ export const es = {
         embeddingModel: "Modelo de embeddings",
         embeddingModelDescription:
           "Modelo de Hugging Face o ruta local usada para indexar y buscar tus documentos. El valor predeterminado es {defaultModel}.",
+        searchPlaceholder: "Buscar modelos de embedding",
         reindexWarning:
           "Solo afecta a los documentos recién indexados. Vuelve a subir los existentes tras cambiar el modelo.",
         emptyError:

--- a/studio/frontend/src/i18n/locales/fr.ts
+++ b/studio/frontend/src/i18n/locales/fr.ts
@@ -593,6 +593,7 @@ export const fr = {
         embeddingModel: "Modèle d'embedding",
         embeddingModelDescription:
           "Modèle Hugging Face ou chemin local utilisé pour indexer et rechercher vos documents. La valeur par défaut est {defaultModel}.",
+        searchPlaceholder: "Rechercher des modèles d'embedding",
         reindexWarning:
           "N'affecte que les documents nouvellement indexés. Téléversez à nouveau les documents existants après avoir changé de modèle.",
         emptyError:

--- a/studio/frontend/src/i18n/locales/hi.ts
+++ b/studio/frontend/src/i18n/locales/hi.ts
@@ -577,6 +577,7 @@ export const hi = {
         embeddingModel: "एम्बेडिंग मॉडल",
         embeddingModelDescription:
           "आपके दस्तावेज़ों को इंडेक्स और खोजने के लिए उपयोग किया जाने वाला Hugging Face मॉडल या स्थानीय पथ। डिफ़ॉल्ट {defaultModel} है।",
+        searchPlaceholder: "एम्बेडिंग मॉडल खोजें",
         reindexWarning:
           "केवल नए इंडेक्स किए गए दस्तावेज़ों को प्रभावित करता है। मॉडल बदलने के बाद मौजूदा दस्तावेज़ फिर से अपलोड करें।",
         emptyError: "एक Hugging Face मॉडल id या स्थानीय पथ दर्ज करें।",

--- a/studio/frontend/src/i18n/locales/it.ts
+++ b/studio/frontend/src/i18n/locales/it.ts
@@ -565,6 +565,7 @@ export const it = {
         embeddingModel: "Modello di embedding",
         embeddingModelDescription:
           "Modello Hugging Face o percorso locale usato per indicizzare e cercare nei tuoi documenti. Il valore predefinito è {defaultModel}.",
+        searchPlaceholder: "Cerca modelli di embedding",
         reindexWarning:
           "Vale solo per i documenti indicizzati da ora in poi. Ricarica quelli esistenti dopo aver cambiato modello.",
         emptyError:

--- a/studio/frontend/src/i18n/locales/ja.ts
+++ b/studio/frontend/src/i18n/locales/ja.ts
@@ -563,6 +563,7 @@ export const ja = {
         sectionTitle: "ドキュメントと RAG",
         embeddingModel: "埋め込みモデル",
         embeddingModelDescription: "ドキュメントのインデックス作成と検索に使用する Hugging Face モデルまたはローカルパス。デフォルトは {defaultModel} です。",
+        searchPlaceholder: "埋め込みモデルを検索",
         reindexWarning: "新しくインデックスされるドキュメントにのみ影響します。モデルを変更した後は、既存のドキュメントを再アップロードしてください。",
         emptyError: "Hugging Face モデル ID またはローカルパスを入力してください。",
         loadError: "埋め込みモデル設定の読み込みに失敗しました。",

--- a/studio/frontend/src/i18n/locales/ko.ts
+++ b/studio/frontend/src/i18n/locales/ko.ts
@@ -571,6 +571,7 @@ export const ko = {
         embeddingModel: "임베딩 모델",
         embeddingModelDescription:
           "문서를 색인하고 검색하는 데 사용되는 Hugging Face 모델 또는 로컬 경로입니다. 기본값은 {defaultModel}입니다.",
+        searchPlaceholder: "임베딩 모델 검색",
         reindexWarning:
           "새로 색인되는 문서에만 적용됩니다. 모델을 변경한 후 기존 문서를 다시 업로드하세요.",
         emptyError: "Hugging Face 모델 ID 또는 로컬 경로를 입력하세요.",

--- a/studio/frontend/src/i18n/locales/pt-br.ts
+++ b/studio/frontend/src/i18n/locales/pt-br.ts
@@ -583,6 +583,7 @@ export const ptBR = {
         embeddingModel: "Modelo de embedding",
         embeddingModelDescription:
           "Modelo do Hugging Face ou caminho local usado para indexar e buscar seus documentos. O padrão é {defaultModel}.",
+        searchPlaceholder: "Buscar modelos de embedding",
         reindexWarning:
           "Afeta apenas documentos recém-indexados. Reenvie os documentos existentes após alterar o modelo.",
         emptyError: "Insira um id de modelo do Hugging Face ou um caminho local.",

--- a/studio/frontend/src/i18n/locales/ru.ts
+++ b/studio/frontend/src/i18n/locales/ru.ts
@@ -577,6 +577,7 @@ export const ru = {
         embeddingModel: "Модель эмбеддингов",
         embeddingModelDescription:
           "Модель Hugging Face или локальный путь для индексации и поиска по вашим документам. По умолчанию {defaultModel}.",
+        searchPlaceholder: "Поиск embedding-моделей",
         reindexWarning:
           "Влияет только на вновь индексируемые документы. После смены модели загрузите существующие документы заново.",
         emptyError: "Введите ID модели Hugging Face или локальный путь.",

--- a/studio/frontend/src/i18n/locales/zh-CN.ts
+++ b/studio/frontend/src/i18n/locales/zh-CN.ts
@@ -558,6 +558,7 @@ export const zhCN = {
         embeddingModel: "Embedding 模型",
         embeddingModelDescription:
           "用于为文档建立索引和搜索的 Hugging Face 模型或本地路径。默认值为 {defaultModel}。",
+        searchPlaceholder: "搜索嵌入模型",
         reindexWarning:
           "仅影响新建立索引的文档。更改模型后请重新上传已有文档。",
         emptyError: "请输入 Hugging Face 模型 ID 或本地路径。",

--- a/studio/frontend/tests/embedding-model-combobox-query.test.ts
+++ b/studio/frontend/tests/embedding-model-combobox-query.test.ts
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { en } from "../src/i18n/locales/en.ts";
+
+// The component reaches the hub barrel and cannot be imported here, so this
+// asserts on source, like ~50 sibling tests.
+const COMBOBOX = readFileSync(
+  fileURLToPath(
+    new URL(
+      "../src/features/settings/components/embedding-model-combobox.tsx",
+      import.meta.url,
+    ),
+  ),
+  "utf-8",
+);
+const GENERAL_TAB = readFileSync(
+  fileURLToPath(
+    new URL("../src/features/settings/tabs/general-tab.tsx", import.meta.url),
+  ),
+  "utf-8",
+);
+
+test("only typed text searches the Hub", () => {
+  // Searching for the saved model returns that model, so the list held one row
+  // and the other embedding models were unreachable without clearing the field.
+  assert.match(COMBOBOX, /const query = typed !== null && typed === value \? typed : ""/);
+  assert.match(COMBOBOX, /useDebouncedValue\(query\)/);
+  assert.ok(
+    !COMBOBOX.includes("useDebouncedValue(value)"),
+    "the controlled value is no longer the query",
+  );
+});
+
+test("a selection stops filtering by what was typed to find it", () => {
+  const start = COMBOBOX.indexOf("onInputValueChange");
+  const handler = COMBOBOX.slice(start, COMBOBOX.indexOf("}}", start));
+  // The selecting branch runs on pick; leaving the query would reopen the list
+  // still filtered by the old search.
+  assert.ok(handler.includes("selectingRef.current"));
+  assert.ok(handler.includes("setTyped(null)"));
+  assert.ok(handler.includes("setTyped(next)"));
+});
+
+test("the field says what it does", () => {
+  assert.match(
+    GENERAL_TAB,
+    /placeholder=\{t\("settings.general.rag.searchPlaceholder"\)\}/,
+  );
+  assert.equal(
+    en.settings.general.rag.searchPlaceholder,
+    "Search embedding models",
+  );
+});

--- a/studio/frontend/tests/embedding-model-combobox-query.test.ts
+++ b/studio/frontend/tests/embedding-model-combobox-query.test.ts
@@ -48,6 +48,15 @@ test("only a keystroke counts as typing", () => {
   assert.ok(handler.includes("setTyped(next)"));
 });
 
+test("closing the list ends the search", () => {
+  const start = COMBOBOX.indexOf("onOpenChange");
+  const handler = COMBOBOX.slice(start, COMBOBOX.indexOf("}}", start));
+  // Saving writes the same string back, so the value never changes and the
+  // equality guard cannot see it. Without this, reopening the list after a
+  // save is still filtered by what was typed to enter the model.
+  assert.ok(handler.includes("if (!open) setTyped(null)"));
+});
+
 test("the field says what it does", () => {
   assert.match(
     SECTION,

--- a/studio/frontend/tests/embedding-model-combobox-query.test.ts
+++ b/studio/frontend/tests/embedding-model-combobox-query.test.ts
@@ -8,28 +8,28 @@ import { fileURLToPath } from "node:url";
 
 import { en } from "../src/i18n/locales/en.ts";
 
-// The component reaches the hub barrel and cannot be imported here, so this
+function read(path: string): string {
+  return readFileSync(fileURLToPath(new URL(path, import.meta.url)), "utf-8");
+}
+
+// These reach the hub and chat barrels and cannot be imported here, so this
 // asserts on source, like ~50 sibling tests.
-const COMBOBOX = readFileSync(
-  fileURLToPath(
-    new URL(
-      "../src/features/settings/components/embedding-model-combobox.tsx",
-      import.meta.url,
-    ),
-  ),
-  "utf-8",
+const COMBOBOX = read(
+  "../src/features/settings/components/embedding-model-combobox.tsx",
 );
-const GENERAL_TAB = readFileSync(
-  fileURLToPath(
-    new URL("../src/features/settings/tabs/general-tab.tsx", import.meta.url),
-  ),
-  "utf-8",
+const SECTION = read(
+  "../src/features/settings/components/documents-rag-section.tsx",
 );
+const GENERAL_TAB = read("../src/features/settings/tabs/general-tab.tsx");
+const DATA_TAB = read("../src/features/settings/tabs/data-tab.tsx");
 
 test("only typed text searches the Hub", () => {
   // Searching for the saved model returns that model, so the list held one row
   // and the other embedding models were unreachable without clearing the field.
-  assert.match(COMBOBOX, /const query = typed !== null && typed === value \? typed : ""/);
+  assert.match(
+    COMBOBOX,
+    /const query = typed !== null && typed === value \? typed : ""/,
+  );
   assert.match(COMBOBOX, /useDebouncedValue\(query\)/);
   assert.ok(
     !COMBOBOX.includes("useDebouncedValue(value)"),
@@ -37,23 +37,39 @@ test("only typed text searches the Hub", () => {
   );
 });
 
-test("a selection stops filtering by what was typed to find it", () => {
+test("only a keystroke counts as typing", () => {
   const start = COMBOBOX.indexOf("onInputValueChange");
   const handler = COMBOBOX.slice(start, COMBOBOX.indexOf("}}", start));
-  // The selecting branch runs on pick; leaving the query would reopen the list
-  // still filtered by the old search.
-  assert.ok(handler.includes("selectingRef.current"));
+  // base-ui writes the input for the settings load ("none") and for a pick
+  // ("item-press") too. Treating those as a search collapses the list to the
+  // model already set, which is what the field did before.
+  assert.ok(handler.includes('details.reason !== "input-change"'));
   assert.ok(handler.includes("setTyped(null)"));
   assert.ok(handler.includes("setTyped(next)"));
 });
 
 test("the field says what it does", () => {
   assert.match(
-    GENERAL_TAB,
+    SECTION,
     /placeholder=\{t\("settings.general.rag.searchPlaceholder"\)\}/,
   );
   assert.equal(
     en.settings.general.rag.searchPlaceholder,
     "Search embedding models",
   );
+});
+
+test("General and Data show the same section, not two copies of it", () => {
+  assert.ok(SECTION.includes("export function DocumentsRagSection"));
+  for (const [name, tab] of [
+    ["general", GENERAL_TAB],
+    ["data", DATA_TAB],
+  ] as const) {
+    assert.ok(tab.includes("<DocumentsRagSection />"), `${name} renders it`);
+    // A second copy of the load and save logic would let the two tabs disagree.
+    assert.ok(
+      !tab.includes("loadEmbeddingModelSettings"),
+      `${name} has no embedding logic of its own`,
+    );
+  }
 });

--- a/tests/studio/test_settings_compact_overflow_contract.py
+++ b/tests/studio/test_settings_compact_overflow_contract.py
@@ -10,6 +10,7 @@ API_MONITOR_PAGE = REPO / "studio/frontend/src/features/api-monitor/api-monitor-
 MONITOR_LINK = REPO / "studio/frontend/src/features/settings/components/monitor-link.tsx"
 REMOTE_ACCESS = REPO / "studio/frontend/src/features/settings/components/remote-access-section.tsx"
 GENERAL_TAB = REPO / "studio/frontend/src/features/settings/tabs/general-tab.tsx"
+SETTINGS = REPO / "studio/frontend/src/features/settings"
 
 
 def test_dialog_content_can_shrink_inside_the_dialog_grid():
@@ -47,8 +48,24 @@ def test_remote_access_card_can_shrink():
 
 
 def test_embedding_model_controls_stack_on_the_narrowest_viewports():
-    source = GENERAL_TAB.read_text(encoding = "utf-8")
-    assert (
-        'className="max-[360px]:flex-col max-[360px]:items-stretch max-[360px]:gap-3"'
-    ) in source
-    assert 'className="w-[220px] max-[360px]:min-w-0 max-[360px]:flex-1"' in source
+    # The picker has already moved once, from the General tab to Documents & RAG, and
+    # pinning the filename turned that move into a red build even though both responsive
+    # classes came along untouched. Follow whichever settings surface renders the picker.
+    # Dropping the classes still fails; relocating them no longer does.
+    owners = [
+        path
+        for path in sorted(SETTINGS.rglob("*.tsx"))
+        if "<EmbeddingModelCombobox" in path.read_text(encoding = "utf-8")
+    ]
+    assert owners, "no settings surface renders EmbeddingModelCombobox"
+
+    missing = [
+        str(path.relative_to(REPO))
+        for path in owners
+        if not (
+            'className="max-[360px]:flex-col max-[360px]:items-stretch max-[360px]:gap-3"'
+            in (source := path.read_text(encoding = "utf-8"))
+            and 'className="w-[220px] max-[360px]:min-w-0 max-[360px]:flex-1"' in source
+        )
+    ]
+    assert missing == []


### PR DESCRIPTION
Settings -> General -> Documents & RAG, the embedding model field only ever offered one option once a model was saved. Opening the dropdown on `unsloth/bge-small-en-v1.5` listed `unsloth/bge-small-en-v1.5` and nothing else, so there was no way to see what else was available without clearing the field first.

## Cause

The combobox is fully controlled and passed its own text straight to the Hub search, so the saved value searched for itself. That query matches one repo, the list collapses to that row, and the curated `unsloth` listing (which the empty query returns) was only reachable by deleting the text.

## Fix

Only text the user typed is a query. base-ui reports why the input changed, so a keystroke is told apart from the writes it does on its own:

```ts
if (details.reason !== "input-change") {
  setTyped(null);
  return;
}
```

The reasons that matter here are `none` for the fill that follows the settings request, and `item-press` for a pick. Both used to look identical to typing, and the first is the one that put the saved model back into the query a moment after the field appeared. The reason check also replaces the pointer-down guard that was standing in for "this was a selection".

The query is additionally held to the controlled value:

```ts
const query = typed !== null && typed === value ? typed : "";
```

so any parent write (Reset to default, a reload) drops the search without needing an effect.

Behaviour now:

- Opening the field on a saved model lists the curated embedding models with the current one ticked.
- Typing still searches the whole Hub, unchanged.
- Picking a result clears the search, so reopening the list is not still filtered by whatever was typed to find it.

## Documents & RAG in Data settings

The embedding model decides how uploaded documents are indexed, which is what the Data tab is about, but the setting only existed under General. The section is now a component (`components/documents-rag-section.tsx`) rendered by both tabs, rather than a second copy of the load, save, force-save and reset logic that could drift from the first. Data shows it under Files, next to uploaded files and linked folders.

Search still routes "embedding model" to General, which stays the one canonical hit.

## Placeholder

The placeholder repeated the default model id, which the row description already states ("Default is unsloth/bge-small-en-v1.5"). It now reads "Search embedding models", which says what the field does. Added as `settings.general.rag.searchPlaceholder` in all 12 locales.

## Testing

- `npm test`: 4283 passing, 0 failing, including the new `tests/embedding-model-combobox-query.test.ts`.
- `npm run i18n:check:strict`: no missing keys across the 12 locales.
- `npm run typecheck`, `npm run build`: clean.
- eslint on the touched files: unchanged from main (3 pre-existing errors either side); the new component is clean.
- Exercised against the live Hub in a scratch page, with the value arriving after mount the way the settings request delivers it: opening on `unsloth/bge-small-en-v1.5` listed embeddinggemma-300m, bge-small-en-v1.5 (ticked), bge-m3, Qwen3-Embedding-4B, Qwen3-Embedding-0.6B and the rest; typing `gte-modernbert` returned the matching repos; selecting one committed it and reopening showed the curated list again. The extracted section was rendered on its own and loaded, listed and saved the same way.
