### PR TITLE
Unwedge Backend CI: one deadlocked test, and a timer that names the next one

### DIFF
--- a/.github/workflows/studio-backend-ci.yml
+++ b/.github/workflows/studio-backend-ci.yml
@@ -98,6 +98,13 @@ jobs:
     # this one waits until those dependencies are found and fixed individually. Raising the
     # limit costs nothing until a job actually needs it, and a cancelled leg costs the whole
     # 30 minutes anyway.
+    #
+    # This cap is the last line, not the first one. It reports the word "cancelled" and
+    # names nothing, which is how a single deadlocked test held main red for forty hours
+    # (run 32385375389 onward) while the step timings said the suite itself still finished
+    # its work in six minutes. The per-test --timeout below is what actually names a hang;
+    # this stays as the backstop for a wedge the per-test timer cannot see, such as one in
+    # collection or in a worker that never comes up.
     timeout-minutes: 45
     strategy:
       fail-fast: false
@@ -167,8 +174,11 @@ jobs:
           pip install \
             python-multipart aiofiles sqlalchemy cryptography psutil \
             pyyaml jinja2 mammoth unpdf requests \
-            'numpy<3' pytest pytest-asyncio pytest-xdist httpx \
+            'numpy<3' pytest pytest-asyncio pytest-xdist pytest-timeout httpx \
             soundfile librosa
+          # pytest-timeout: see the --timeout flags below. Without it a test that never
+          # returns is indistinguishable from a slow suite, and the job reports only
+          # "cancelled".
           # soundfile + librosa: test_audio_dataset_decode importorskips both, so without
           # them the no-torchcodec decode path is silently untested here.
           # Torch CPU + transformers are required by a chunk of the backend test
@@ -240,8 +250,17 @@ jobs:
         # serialising all of them would give back most of what this change buys. The
         # isolation guard scans for the tight ones, so a new test below the threshold
         # fails that guard instead of flaking here.
+        #
+        # --timeout: a per-test wall-clock cap, so a test that never returns fails with its
+        # own name in the summary instead of taking the job's 45 minutes down with it and
+        # reporting "cancelled". 330s comes off the measured distribution rather than taste:
+        # the slowest legitimate test in this suite is
+        # test_conversation_archive.py::test_the_newest_revision_survives_a_tied_run_LONGER_than_the_cap
+        # at 82.5s (measured under -n 4 on a contended box; 75.4s serially), and the next
+        # ones down are 76s and 25s, so the cap is 4x the worst real test. Nothing here is
+        # near it, and a deadlock is caught in minutes rather than never.
         run: |
-          python -m pytest tests/ -q --tb=short -n 4 \
+          python -m pytest tests/ -q --tb=short -n 4 --timeout=330 \
             --ignore=tests/test_studio_api.py \
             --ignore=tests/test_streaming_stripper.py \
             --ignore=tests/test_llama_cpp_wait_for_vram_settle.py \
@@ -262,7 +281,7 @@ jobs:
         # Relative timing against a reference measured in the same process. Serial, so the
         # comparison is between two implementations rather than between two schedulings.
         run: |
-          python -m pytest -q --tb=short \
+          python -m pytest -q --tb=short --timeout=330 \
             tests/test_streaming_stripper.py \
             tests/test_llama_cpp_wait_for_vram_settle.py \
             tests/test_tool_xml_strip.py \
@@ -290,7 +309,7 @@ jobs:
         # being old. Roughly 40 tests in under ten seconds, beside the full leg rather
         # than in front of it, so the critical path is the full leg either way.
         run: |
-          python -m pytest -q --tb=short \
+          python -m pytest -q --tb=short --timeout=330 \
             tests/test_third_party_source.py \
             tests/test_recommended_folders_permission.py \
             tests/test_hf_cache_settings.py

--- a/studio/backend/tests/test_credential_routes.py
+++ b/studio/backend/tests/test_credential_routes.py
@@ -1219,9 +1219,17 @@ def test_codex_proof_rollback_leaves_a_concurrent_save_alone(monkeypatch):
 
     update_provider_config suspends between committing the row and recording the proof:
     remember_catalog_account awaits a 30s file lock, and the failure the rollback exists
-    for is exactly the one where that lock was contended. A save the user makes during
-    those seconds commits in between. Restoring the whole pre-request snapshot would put
-    the row back to before *both* requests and erase the second one's successful edit.
+    for is exactly the one where that lock was contended. Another write to the row lands
+    in between. Restoring the whole pre-request snapshot would put the row back to before
+    *both* writes and erase the second one's successful edit.
+
+    The interleaved write goes at providers_db directly rather than through a second
+    update_provider_config call. serialize_provider_config holds a per-provider
+    asyncio.Lock across the whole handler, so a second call on the same provider cannot
+    run while this one is parked -- awaiting one from inside this test deadlocks the
+    event loop, since the await that would release the gate sits behind it. What the
+    rollback actually defends against is the row moving under the handler, which any
+    writer can do, so the row write is both the reachable shape and the one under test.
     """
     import json
 
@@ -1262,10 +1270,13 @@ def test_codex_proof_rollback_leaves_a_concurrent_save_alone(monkeypatch):
     codex_client._catalog_accounts[provider_id] = "acct-1"
 
     gate = asyncio.Event()
+    parked = asyncio.Event()
 
     async def _blocked_then_busy(_provider_id, _account_id):
         # Stands in for provider_oauth_write_guard's flock acquire: a real suspension
-        # point, then the timeout it raises.
+        # point, then the timeout it raises. `parked` is the handshake, so the test
+        # resumes on the suspension itself rather than on a count of loop turns.
+        parked.set()
         await gate.wait()
         raise codex_auth.CodexAuthError("ChatGPT credential update is busy. Please retry.")
 
@@ -1282,20 +1293,14 @@ def test_codex_proof_rollback_leaves_a_concurrent_save_alone(monkeypatch):
                 via_api_key = False,
             )
         )
-        for _ in range(100):
-            await asyncio.sleep(0)
-            if gate._waiters:
-                break
+        await asyncio.wait_for(parked.wait(), timeout = 10)
         # Its row is committed and it is now parked in remember_catalog_account.
         assert providers_db.get_provider(provider_id)["models"] == ["gpt-5.4", listed]
 
-        # The user saves again while that one hangs. This one has no selection of its
-        # own, so it records no proof and completes.
-        await providers_route.update_provider_config(
-            provider_id,
-            ProviderUpdate(display_name = "Renamed while the first save hung"),
-            credential = ("alice", None),
-            via_api_key = False,
+        # Another write renames the row while that one hangs. It touches a column the
+        # parked request never wrote, so there is nothing of its own to undo there.
+        providers_db.update_provider(
+            id = provider_id, display_name = "Renamed while the first save hung"
         )
 
         gate.set()

--- a/studio/backend/tests/test_export_absolute_paths.py
+++ b/studio/backend/tests/test_export_absolute_paths.py
@@ -173,6 +173,7 @@ def _install_lightweight_backend_stubs(monkeypatch):
     utils_model_config = types.ModuleType("utils.models.model_config")
     utils_model_config._extract_quant_label = lambda value: value
     utils_model_config._is_big_endian_gguf_path = lambda *args, **kwargs: False
+    utils_model_config._is_imatrix_path = lambda *args, **kwargs: False
     utils_model_config._is_mtp_drafter = lambda *args, **kwargs: False
     utils_model_config.is_audio_input_type = lambda *args, **kwargs: None
     monkeypatch.setitem(

--- a/studio/backend/tests/test_recommended_folders_has_model.py
+++ b/studio/backend/tests/test_recommended_folders_has_model.py
@@ -24,6 +24,7 @@ import json
 import os
 from pathlib import Path
 
+from utils.models.model_config import _is_imatrix_path
 from utils.paths.path_utils import is_appledouble_metadata
 
 _backend_root = Path(__file__).resolve().parent.parent
@@ -52,6 +53,10 @@ def _load_has_downloaded_model():
         "os": os,
         "json": json,
         "is_appledouble_metadata": is_appledouble_metadata,
+        # The real one, like is_appledouble_metadata above: importing it costs no more
+        # than the module it lives in, and a stub here would let the imatrix exclusion
+        # this function depends on regress without the test noticing.
+        "_is_imatrix_path": _is_imatrix_path,
     }
     exec(compile(module, f"<extracted {_models_src}>", "exec"), ns)
     return ns["_dir_has_downloaded_model"]


### PR DESCRIPTION
Backend CI has been red on `main` for about forty hours and it blocks every open PR. One test deadlocks. The suite itself is fine.

## The boundary

| | run | sha | `(Python 3.13)` job | `Backend tests` step |
|---|---|---|---|---|
| last green | 32385347777 | `b4240405d` | success, 10m17s | **393s** |
| first red | 32385375389 | `caa0b7925` | cancelled, 29m27s | hung, cut at the then-30m cap |
| current main | 32538719955 | `746ad086d` | cancelled, 45m15s | hung, cut at the 45m cap |

Seventeen seconds separate the last green run from the first red one, and exactly one commit sits in the gap: `caa0b7925`, "Studio: offer only the Codex models the ChatGPT plan can actually reach" (#9302).

## What the measurement showed

A hanging test, not a suite that outgrew the wall, and not the dependency install.

The red job's own log settles it. `Install backend test dependencies (CPU only)` took 75s. pytest started at 00:01:32, finished collection at 00:02:43, and reached 95% of the suite at 00:08:05. Then it printed nothing at all for the remaining 37 minutes, until the job cap fired and the runner reported the word "cancelled".

Reproduced locally on the runner's shape (`-n 4`, same ignores and deselections), with a per-test timer added so a hang names itself:

| tree | tests | wall | timeouts |
|---|---|---|---|
| `b4240405d` last green | 25986 passed | 6m29s | none |
| `caa0b7925` first red | 26040 passed | 11m53s | 1 |
| this branch | see below | see below | none |

The 11m53s is 6m23s of real work plus one test sitting on a 330s timer. #9302 added 54 tests and no measurable time. The suite does its work in six and a half minutes against a 45 minute cap, so there is nothing here to split, parallelise further, or raise the limit for.

## Where the fault is

The test, not the product code.

`test_codex_proof_rollback_leaves_a_concurrent_save_alone` starts one `update_provider_config` on a provider, parks it inside a stubbed `remember_catalog_account` on an `asyncio.Event`, and then awaits a second `update_provider_config` on the same provider before setting that event.

`serialize_provider_config` wraps that handler in a per-provider `asyncio.Lock` held for the whole call, and has since #9234, well before #9302:

```python
async def _serialized(provider_id: str, *args, **kwargs):
    async with provider_config_guard(provider_id):
        return await handler(provider_id, *args, **kwargs)
```

So the second call cannot start while the first holds the lock, and the `gate.set()` that would release the first sits behind the second. The loop has no runnable task and no timer, parks in `selectors.poll(None)`, and stays there. Confirmed directly: two coroutines through `provider_config_guard("provider-x")`, the first parked, and the second never runs.

I checked the retry path in `openai_codex_client.py` too, since it was the standing suspicion. It is sound and is not involved: `_MAX_TRANSIENT_RETRIES` is 2, the backoff is `2**attempt`, `_retry_delay_seconds` clamps an upstream `retry-after` to 60s, and `_retry_pause` re-checks the cancel event every 100ms. Worst case is bounded and cancellable, and no test in the file drives a retryable status anyway.

## The fix

The interleaved write now goes at `providers_db.update_provider` directly. That is what `_restore_metadata` actually defends against, since the route lock already forbids a second concurrent save on the same provider, and it is reachable by any other writer. Every assertion is unchanged, and the test still catches the bug it exists for: reverting `_restore_metadata` to restore the whole pre-request snapshot fails it in 1.24s.

The parked handshake is now an `Event` the stub sets, awaited with `asyncio.wait_for(..., timeout = 10)`, instead of a hundred turns of `asyncio.sleep(0)` polling the private `gate._waiters`.

## The guard

`pytest-timeout` was not a dependency anywhere in the repo. Backend CI now installs it and passes `--timeout=330` to its pytest steps.

A `timeout-minutes` job cap names nothing. That is the reason this cost forty hours rather than one CI round: three separate PRs each carried a red `(Python 3.13)` at 45m14s, 45m15s and 45m16s, all reading "cancelled", which looks like a concurrency cancel and says nothing about which test is at fault. A per-test cap fails the test by name in the summary. The job cap stays as the backstop for a wedge the per-test timer cannot see, such as one during collection.

330s is taken off the measured distribution rather than picked for looking tidy. The slowest legitimate test in this suite is `test_conversation_archive.py::test_the_newest_revision_survives_a_tied_run_LONGER_than_the_cap` at 82.5s under `-n 4` (75.4s serially), with 76s and 25s next below it, so the cap is 4x the worst real test and nothing in the suite is within reach of it.

`repo-cpu-tests` is deliberately left alone: I have no local measurement of its per-test distribution, and putting an unmeasured cap on a job that is currently green is how you trade one red for another.
