### PR TITLE
Studio: stop an unterminated code fence re-repairing itself on every chunk

### DIFF
--- a/studio/frontend/src/components/assistant-ui/streaming-render-schedule.ts
+++ b/studio/frontend/src/components/assistant-ui/streaming-render-schedule.ts
@@ -18,6 +18,28 @@ const ROLLBACK_BLOCKS = 8;
 // full-document path is +73% at 32,768 and +1.6% at 8,192. 8,192 characters is
 // still around 1,300 words of slack, well beyond a marker a later line closes.
 const STALLED_TAIL_CHARACTERS = 8_192;
+// remend repairs the trailing incomplete construct, but it reaches that
+// decision with whole-string passes: one walks the text once per `[` looking
+// for an unterminated link, another escapes comparison operators line by line.
+// Inside an unterminated fence every such character is literal and every pass
+// declines, so those walks cost the length of the fence and change nothing. The
+// fence also lexes into a single block, so `candidateCount` in update() is 0,
+// nothing is ever retained, and the tail grows with the fence: appending one
+// chunk then costs O(fence) and a reply costs the square of it. Repair the head
+// plus a window of the fence body instead, and splice the untouched middle back
+// in. The window carries the last line and the line before it, which is all the
+// trailing repairs read.
+const OPEN_FENCE_REPAIR_WINDOW = 4_096;
+// A plain two-line probe. When remend leaves the head alone with ordinary text
+// after it, no marker is pending for it to close, so it cannot append anything
+// beyond the window either. Measured: with this gate the spliced repair is
+// byte-identical to repairing the whole tail on 17,436 adversarial open-fence
+// frames and on every frame of the streamed benchmark corpora; without it a
+// marker left open before the fence gets its closer at the wrong offset.
+const OPEN_FENCE_PROBE = "\nq\n";
+// An index can only be resolved once the two characters after it are known, so
+// the scan keeps that many back from the live edge and re-reads them.
+const FENCE_SCAN_MARGIN = 2;
 // Balanced marker prefixes preserve the whole-document facts that remend uses
 // to decide how an incomplete tail should close, without changing parity.
 const MULTILINE_KATEX_CONTEXT = "$$\n$$\n\n";
@@ -558,15 +580,122 @@ const emphasisContext = (context: RetainedContext): string => {
 
 // Taking the context as a value lets a candidate commit be priced before it is
 // applied, which the repeated-Markdown check in update() needs.
-function repairTail(tail: string, context: RetainedContext): string {
-  const prefix =
+function repairContextPrefix(context: RetainedContext): string {
+  return (
     emphasisContext(context) +
     singleAsteriskContext(context) +
-    (context.multilineKatex ? MULTILINE_KATEX_CONTEXT : "");
+    (context.multilineKatex ? MULTILINE_KATEX_CONTEXT : "")
+  );
+}
+
+function repairTail(tail: string, context: RetainedContext): string {
+  const prefix = repairContextPrefix(context);
   if (!prefix) {
     return remend(tail);
   }
   return remend(prefix + tail).slice(prefix.length);
+}
+
+// Where remend believes a fence is open. It toggles on any ``` run, wherever on
+// the line that run sits, and a backslash escapes the backtick after it, so this
+// deliberately mirrors remend rather than CommonMark: a mid-line ``` closes the
+// fence for remend and must close it here too.
+type OpenFenceState = {
+  index: number;
+  fenceOpen: boolean;
+  bodyStart: number;
+  // `$$` and `~~` are the two markers remend counts across a fence instead of
+  // skipping over it, so a body holding either can still change what it
+  // appends. Those replies take the whole-tail path.
+  bodyHasGlobalMarker: boolean;
+};
+
+const initialOpenFenceState = (): OpenFenceState => ({
+  index: 0,
+  fenceOpen: false,
+  bodyStart: -1,
+  bodyHasGlobalMarker: false,
+});
+
+function advanceOpenFence(
+  state: OpenFenceState,
+  text: string,
+  limit: number,
+): OpenFenceState {
+  let { index, fenceOpen, bodyStart, bodyHasGlobalMarker } = state;
+  while (index < limit) {
+    const character = text[index];
+    if (character === "\\" && text[index + 1] === "`") {
+      index += 2;
+      continue;
+    }
+    if (
+      character === "`" &&
+      text[index + 1] === "`" &&
+      text[index + 2] === "`"
+    ) {
+      fenceOpen = !fenceOpen;
+      bodyStart = fenceOpen ? index + 3 : -1;
+      bodyHasGlobalMarker = false;
+      index += 3;
+      continue;
+    }
+    if (
+      fenceOpen &&
+      (character === "$" || character === "~") &&
+      text[index + 1] === character
+    ) {
+      bodyHasGlobalMarker = true;
+    }
+    index += 1;
+  }
+  return { index, fenceOpen, bodyStart, bodyHasGlobalMarker };
+}
+
+// Carries the scan across updates so a growing tail costs the characters that
+// arrived, not the characters it holds. Any text that is not an extension of the
+// last one rescans from the start, which is what a commit or a rewrite hands it.
+class OpenFenceTracker {
+  private text = "";
+  private resolved = initialOpenFenceState();
+
+  // Start of the open fence's body, or -1 when the whole-tail repair applies.
+  bodyStart(text: string): number {
+    if (!hasPrefix(text, this.text)) {
+      this.resolved = initialOpenFenceState();
+    }
+    const limit = Math.max(0, text.length - FENCE_SCAN_MARGIN);
+    if (limit > this.resolved.index) {
+      this.resolved = advanceOpenFence(this.resolved, text, limit);
+    }
+    this.text = text;
+    const live = advanceOpenFence(this.resolved, text, text.length);
+    return live.fenceOpen && !live.bodyHasGlobalMarker ? live.bodyStart : -1;
+  }
+}
+
+// A head the probe found inert contributes nothing but "a fence is open", which
+// one opener reproduces. Standing in for it keeps the repair off the head as
+// well as off the elided body.
+const OPEN_FENCE_SYNTHETIC_HEAD = "```\n";
+
+// The spliced repair, or null when it cannot be shown to match repairTail.
+// Both refusals fall back to repairing the whole tail: a body still shorter
+// than the window has nothing to elide, and a body whose final line is longer
+// than the window leaves no line boundary to cut on, which is the only place
+// the splice can start without changing what the trailing repairs read.
+function repairOpenFenceTail(tail: string, bodyStart: number): string | null {
+  const cut = tail.indexOf("\n", tail.length - OPEN_FENCE_REPAIR_WINDOW);
+  if (cut < 0 || cut + 1 <= bodyStart) {
+    return null;
+  }
+  const repaired = remend(OPEN_FENCE_SYNTHETIC_HEAD + tail.slice(cut + 1));
+  if (!hasPrefix(repaired, OPEN_FENCE_SYNTHETIC_HEAD)) {
+    return null;
+  }
+  return (
+    tail.slice(0, cut + 1) + repaired.slice(OPEN_FENCE_SYNTHETIC_HEAD.length)
+  );
 }
 
 const advanceContext = (
@@ -727,6 +856,9 @@ export class IncrementalMarkdownCache {
   private committedLength = 0;
   private commitPoints: CommitPoint[] = [];
   private context = createRetainedContext();
+  private fenceTracker = new OpenFenceTracker();
+  private openFenceHead: string | null = null;
+  private openFenceHeadInert = false;
   private fullDocumentMode = false;
   private lastMarkdown: string | null = null;
   private droppedRetainedBlocks = false;
@@ -755,6 +887,28 @@ export class IncrementalMarkdownCache {
     this.droppedRetainedBlocks = false;
     this.lastMarkdown = markdown;
     return { markdown, parseMarkdownIntoBlocks: this.parseMarkdownIntoBlocks };
+  }
+
+  // The repair of a tail sitting inside an open fence, or null to repair the
+  // whole tail as before. The head is everything the repair would have to keep:
+  // once the probe shows remend leaves it alone, it holds nothing that could
+  // change the repair of the body, and it stays fixed until the fence closes,
+  // so the probe is paid once per fence rather than once per chunk.
+  private repairOpenFence(): string | null {
+    const bodyStart = this.fenceTracker.bodyStart(this.tail);
+    if (bodyStart < 0) {
+      return null;
+    }
+    const head =
+      repairContextPrefix(this.context) + this.tail.slice(0, bodyStart);
+    if (head !== this.openFenceHead) {
+      this.openFenceHead = head;
+      const probed = head + OPEN_FENCE_PROBE;
+      this.openFenceHeadInert = remend(probed) === probed;
+    }
+    return this.openFenceHeadInert
+      ? repairOpenFenceTail(this.tail, bodyStart)
+      : null;
   }
 
   private resetIncrementalState(markdown: string): void {
@@ -885,7 +1039,8 @@ export class IncrementalMarkdownCache {
 
     this.updateTail(markdown);
 
-    const repaired = repairTail(this.tail, this.context);
+    const repaired =
+      this.repairOpenFence() ?? repairTail(this.tail, this.context);
 
     // Streamdown deliberately turns a repaired document containing footnotes
     // into one block so definitions can resolve references anywhere in the

--- a/studio/frontend/src/components/assistant-ui/streaming-render-schedule.ts
+++ b/studio/frontend/src/components/assistant-ui/streaming-render-schedule.ts
@@ -32,10 +32,13 @@ const STALLED_TAIL_CHARACTERS = 8_192;
 const OPEN_FENCE_REPAIR_WINDOW = 4_096;
 // A plain two-line probe. When remend leaves the head alone with ordinary text
 // after it, no marker is pending for it to close, so it cannot append anything
-// beyond the window either. Measured: with this gate the spliced repair is
-// byte-identical to repairing the whole tail on 17,436 adversarial open-fence
-// frames and on every frame of the streamed benchmark corpora; without it a
-// marker left open before the fence gets its closer at the wrong offset.
+// beyond the window either. Without it a marker left open before the fence gets
+// its closer at the wrong offset.
+//
+// Its verdict is a property of the HEAD, while remend decides from the whole
+// string, so on its own it is not enough: text later in the body can flip a
+// global parity the probe assumed and revive a marker it cleared. The body
+// marker refusal below is what closes that gap, and the two only work together.
 const OPEN_FENCE_PROBE = "\nq\n";
 // An index can only be resolved once the two characters after it are known, so
 // the scan keeps that many back from the live edge and re-reads them.
@@ -604,7 +607,9 @@ type OpenFenceState = {
   index: number;
   fenceOpen: boolean;
   bodyStart: number;
-  // The FIRST ` $ or ~ in the current fence body, or -1.
+  // The FIRST ` $ or ~ in the current fence body, or -1. Its mere presence
+  // disqualifies the splice, so only whether one exists ever matters; the index
+  // is kept because it reads better in a test than a bare boolean.
   //
   // remend does not have one notion of "inside a fence"; it has at least three,
   // and they disagree. `isWithinCodeBlock` walks the text and honours a
@@ -717,8 +722,18 @@ const OPEN_FENCE_SYNTHETIC_HEAD = "```\n";
 //     ending in `-`, `--`, `=` or `==` into one carrying a zero-width space
 //     that repairing the whole tail does not add, and that the copy button
 //     would then put on the clipboard;
-//   a ` $ or ~ anywhere in what the cut would elide is a character one of
+//   a ` $ or ~ ANYWHERE in the body, elided or retained, is a character one of
 //     remend's fence notions counts, and the opener cannot stand in for it.
+//
+// The last one deliberately covers the retained window and not just the elided
+// middle, because the probe that licenses the opener reads the head ALONE while
+// remend decides from the whole string. An escaped \``` in the window flips the
+// global triple-run parity, so the whole-tail repair closes an unmatched inline
+// backtick that sits before the opener and the spliced output does not; a `$$`
+// there moves the math parity the other way. Neither is reachable from a
+// refusal on the cut, since the probe runs before the cut is chosen. Keeping
+// the body free of all three characters is what makes the probe's verdict a
+// property of the whole tail rather than of the head it was handed.
 function repairOpenFenceTail(
   tail: string,
   bodyStart: number,
@@ -729,7 +744,7 @@ function repairOpenFenceTail(
     cut < 0 ||
     cut + 1 <= bodyStart ||
     tail.indexOf("\n", cut + 1) < 0 ||
-    (firstBodyMarker >= 0 && firstBodyMarker <= cut)
+    firstBodyMarker >= 0
   ) {
     return null;
   }

--- a/studio/frontend/src/components/assistant-ui/streaming-render-schedule.ts
+++ b/studio/frontend/src/components/assistant-ui/streaming-render-schedule.ts
@@ -604,17 +604,27 @@ type OpenFenceState = {
   index: number;
   fenceOpen: boolean;
   bodyStart: number;
-  // `$$` and `~~` are the two markers remend counts across a fence instead of
-  // skipping over it, so a body holding either can still change what it
-  // appends. Those replies take the whole-tail path.
-  bodyHasGlobalMarker: boolean;
+  // The FIRST ` $ or ~ in the current fence body, or -1.
+  //
+  // remend does not have one notion of "inside a fence"; it has at least three,
+  // and they disagree. `isWithinCodeBlock` walks the text and honours a
+  // backslash before a backtick, the emphasis counters toggle on ``` without
+  // honouring it, and the inline-code repair just counts /```/g. An escaped
+  // \``` or a ```` run flips the last of those and not the first. The opener
+  // that stands in for the elided text can only reproduce all three when the
+  // elided part holds none of the characters any of them counts.
+  //
+  // The first such character, not the last: a marker sitting in the window
+  // would otherwise mask an earlier one sitting in the elided middle, which is
+  // the half that matters. First is also monotone, so it costs nothing to keep.
+  firstBodyMarker: number;
 };
 
 const initialOpenFenceState = (): OpenFenceState => ({
   index: 0,
   fenceOpen: false,
   bodyStart: -1,
-  bodyHasGlobalMarker: false,
+  firstBodyMarker: -1,
 });
 
 function advanceOpenFence(
@@ -622,10 +632,15 @@ function advanceOpenFence(
   text: string,
   limit: number,
 ): OpenFenceState {
-  let { index, fenceOpen, bodyStart, bodyHasGlobalMarker } = state;
+  let { index, fenceOpen, bodyStart, firstBodyMarker } = state;
   while (index < limit) {
     const character = text[index];
     if (character === "\\" && text[index + 1] === "`") {
+      // Escaped for `isWithinCodeBlock`, not for the passes that only count
+      // ``` runs, so the backtick still counts as a marker.
+      if (fenceOpen && firstBodyMarker < 0) {
+        firstBodyMarker = index + 1;
+      }
       index += 2;
       continue;
     }
@@ -636,20 +651,20 @@ function advanceOpenFence(
     ) {
       fenceOpen = !fenceOpen;
       bodyStart = fenceOpen ? index + 3 : -1;
-      bodyHasGlobalMarker = false;
+      firstBodyMarker = -1;
       index += 3;
       continue;
     }
     if (
       fenceOpen &&
-      (character === "$" || character === "~") &&
-      text[index + 1] === character
+      firstBodyMarker < 0 &&
+      (character === "`" || character === "$" || character === "~")
     ) {
-      bodyHasGlobalMarker = true;
+      firstBodyMarker = index;
     }
     index += 1;
   }
-  return { index, fenceOpen, bodyStart, bodyHasGlobalMarker };
+  return { index, fenceOpen, bodyStart, firstBodyMarker };
 }
 
 // Carries the scan across updates so a growing tail costs the characters that
@@ -659,8 +674,11 @@ class OpenFenceTracker {
   private text = "";
   private resolved = initialOpenFenceState();
 
-  // Start of the open fence's body, or -1 when the whole-tail repair applies.
-  bodyStart(text: string): number {
+  // Where the open fence's body starts and where its first marker sits, or null
+  // when the whole-tail repair applies.
+  spliceBounds(
+    text: string,
+  ): { bodyStart: number; firstBodyMarker: number } | null {
     if (!hasPrefix(text, this.text)) {
       this.resolved = initialOpenFenceState();
     }
@@ -670,7 +688,13 @@ class OpenFenceTracker {
     }
     this.text = text;
     const live = advanceOpenFence(this.resolved, text, text.length);
-    return live.fenceOpen && !live.bodyHasGlobalMarker ? live.bodyStart : -1;
+    if (!live.fenceOpen) {
+      return null;
+    }
+    return {
+      bodyStart: live.bodyStart,
+      firstBodyMarker: live.firstBodyMarker,
+    };
   }
 }
 
@@ -679,14 +703,34 @@ class OpenFenceTracker {
 // well as off the elided body.
 const OPEN_FENCE_SYNTHETIC_HEAD = "```\n";
 
-// The spliced repair, or null when it cannot be shown to match repairTail.
-// Both refusals fall back to repairing the whole tail: a body still shorter
-// than the window has nothing to elide, and a body whose final line is longer
-// than the window leaves no line boundary to cut on, which is the only place
-// the splice can start without changing what the trailing repairs read.
-function repairOpenFenceTail(tail: string, bodyStart: number): string | null {
+// The spliced repair, or null when it cannot be shown to match repairTail. All
+// four refusals fall back to repairing the whole tail:
+//
+//   a body still shorter than the window has nothing to elide;
+//   a final line longer than the window leaves no line boundary to cut on,
+//     which is the only place the splice can start without changing what the
+//     trailing repairs read;
+//   a PRECEDING line longer than the window puts the cut on the newline that
+//     ends it, so the window holds the final line alone. remend's setext repair
+//     reads exactly one line back, and the synthetic opener standing in for it
+//     is never blank, so a whitespace-only line elided that way turns a tail
+//     ending in `-`, `--`, `=` or `==` into one carrying a zero-width space
+//     that repairing the whole tail does not add, and that the copy button
+//     would then put on the clipboard;
+//   a ` $ or ~ anywhere in what the cut would elide is a character one of
+//     remend's fence notions counts, and the opener cannot stand in for it.
+function repairOpenFenceTail(
+  tail: string,
+  bodyStart: number,
+  firstBodyMarker: number,
+): string | null {
   const cut = tail.indexOf("\n", tail.length - OPEN_FENCE_REPAIR_WINDOW);
-  if (cut < 0 || cut + 1 <= bodyStart) {
+  if (
+    cut < 0 ||
+    cut + 1 <= bodyStart ||
+    tail.indexOf("\n", cut + 1) < 0 ||
+    (firstBodyMarker >= 0 && firstBodyMarker <= cut)
+  ) {
     return null;
   }
   const repaired = remend(OPEN_FENCE_SYNTHETIC_HEAD + tail.slice(cut + 1));
@@ -895,19 +939,19 @@ export class IncrementalMarkdownCache {
   // change the repair of the body, and it stays fixed until the fence closes,
   // so the probe is paid once per fence rather than once per chunk.
   private repairOpenFence(): string | null {
-    const bodyStart = this.fenceTracker.bodyStart(this.tail);
-    if (bodyStart < 0) {
+    const bounds = this.fenceTracker.spliceBounds(this.tail);
+    if (bounds === null) {
       return null;
     }
     const head =
-      repairContextPrefix(this.context) + this.tail.slice(0, bodyStart);
+      repairContextPrefix(this.context) + this.tail.slice(0, bounds.bodyStart);
     if (head !== this.openFenceHead) {
       this.openFenceHead = head;
       const probed = head + OPEN_FENCE_PROBE;
       this.openFenceHeadInert = remend(probed) === probed;
     }
     return this.openFenceHeadInert
-      ? repairOpenFenceTail(this.tail, bodyStart)
+      ? repairOpenFenceTail(this.tail, bounds.bodyStart, bounds.firstBodyMarker)
       : null;
   }
 

--- a/studio/frontend/tests/streaming-open-fence-repair.test.ts
+++ b/studio/frontend/tests/streaming-open-fence-repair.test.ts
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import remend from "remend";
+
+import { IncrementalMarkdownCache } from "../src/components/assistant-ui/streaming-render-schedule.ts";
+
+/**
+ * A fence that has opened and not yet closed pins the cache: the whole fence
+ * lexes into one block, so no prefix is ever retained and the live tail grows
+ * with the fence. Repairing that tail is worse than linear -- remend walks the
+ * whole string once per `[`, and code is dense in brackets -- so appending one
+ * chunk used to cost the length of the fence.
+ *
+ * Two things have to hold for the shortcut that fixes it: the repaired text is
+ * the text the whole-tail repair would have produced, and the work per chunk no
+ * longer grows with the fence.
+ */
+
+const codeLine = (index: number) =>
+  `def step_${index}(x, y=${index}):\n    z = [item for item in range(${index})]  # note\n    return {'z': z, 'x': x * y}\n`;
+
+function fenceBody(lines: number): string {
+  let body = "";
+  for (let index = 0; index < lines; index += 1) {
+    body += codeLine(index);
+  }
+  return body;
+}
+
+const tailOf = (cache: IncrementalMarkdownCache): string =>
+  (cache as unknown as { tail: string }).tail;
+
+const contextOf = (cache: IncrementalMarkdownCache): Record<string, unknown> =>
+  (cache as unknown as { context: Record<string, unknown> }).context;
+
+/**
+ * Stream `text` in fixed chunks and assert every frame renders the Markdown the
+ * whole-tail repair would have rendered.
+ *
+ * After update() the cache's own tail is the text its return value repaired,
+ * whether or not that update retained a block, so `remend(tail)` is the
+ * reference render. It is only the reference while the retained context carries
+ * no marker prefix, which the assertion below holds these replies to.
+ */
+function assertRepairMatches(text: string, chunk = 192): void {
+  const cache = new IncrementalMarkdownCache();
+  for (let end = chunk; end <= text.length; end += chunk) {
+    const render = cache.update(text.slice(0, end));
+    const context = contextOf(cache);
+    assert.equal(
+      context.bold || context.singleAsterisk || context.singleUnderscore,
+      false,
+      "reply must not need a marker context for remend(tail) to be the reference",
+    );
+    assert.equal(
+      render.markdown,
+      remend(tailOf(cache)),
+      `frame at ${end} characters diverged from the whole-tail repair`,
+    );
+  }
+}
+
+test("an unterminated fence repairs to the whole-tail result", () => {
+  assertRepairMatches(`Here is the code.\n\n\`\`\`python\n${fenceBody(180)}`);
+});
+
+test("a fence that closes and reopens repairs to the whole-tail result", () => {
+  const text = `Intro paragraph one.\n\nIntro paragraph two.\n\n\`\`\`python\n${fenceBody(70)}\`\`\`\n\nProse between the fences.\n\n\`\`\`js\n${fenceBody(70)}\`\`\`\n\nClosing prose.\n`;
+  assertRepairMatches(text);
+});
+
+test("CRLF inside an unterminated fence repairs to the whole-tail result", () => {
+  const text = `Intro.\r\n\r\n\`\`\`python\r\n${fenceBody(110).replace(/\n/g, "\r\n")}`;
+  assertRepairMatches(text);
+});
+
+test("a tilde fence keeps the whole-tail repair", () => {
+  assertRepairMatches(`Intro.\n\n~~~python\n${fenceBody(110)}`);
+});
+
+test("a nested longer fence repairs to the whole-tail result", () => {
+  assertRepairMatches(
+    `Intro.\n\n\`\`\`\`markdown\n\`\`\`python\n${fenceBody(110)}`,
+  );
+});
+
+test("display math inside an open fence keeps the whole-tail repair", () => {
+  assertRepairMatches(`Intro.\n\n\`\`\`text\n$$\n${fenceBody(90)}`);
+});
+
+test("a marker left open before the fence keeps the whole-tail repair", () => {
+  assertRepairMatches(`Intro **bold\n\n\`\`\`python\n${fenceBody(110)}`);
+});
+
+test("a fence that never closes stays live and is never committed away", () => {
+  const text = `Intro.\n\n\`\`\`python\n${fenceBody(300)}`;
+  const cache = new IncrementalMarkdownCache();
+  let render = cache.update(text.slice(0, 64));
+  for (let end = 128; end < text.length; end += 128) {
+    render = cache.update(text.slice(0, end));
+  }
+  render = cache.update(text);
+  const blocks = render.parseMarkdownIntoBlocks(render.markdown);
+  assert.equal(blocks.join(""), remend(text));
+});
+
+/**
+ * A complexity test, not a timing test. remend decides where a construct ends
+ * with `substring` probes whose receiver is the whole string, so charging every
+ * probe its receiver's length prices a repair at the length of what it was
+ * given. Doubling the fence must roughly double that bill, which is what a
+ * per-chunk cost independent of the fence looks like. Before this shortcut the
+ * same doubling multiplied it by about 16.
+ */
+function repairCharacters(text: string, chunk = 256): number {
+  const realSubstring = String.prototype.substring;
+  let counted = 0;
+  String.prototype.substring = function counting(
+    this: string,
+    start: number,
+    end?: number,
+  ): string {
+    counted += this.length;
+    return realSubstring.call(this, start, end);
+  } as unknown as typeof realSubstring;
+  try {
+    const cache = new IncrementalMarkdownCache();
+    for (let end = chunk; end <= text.length; end += chunk) {
+      cache.update(text.slice(0, end));
+    }
+  } finally {
+    String.prototype.substring = realSubstring;
+  }
+  return counted;
+}
+
+test("appending to an open fence does not cost the length of the fence", () => {
+  const short = repairCharacters(`Intro.\n\n\`\`\`python\n${fenceBody(180)}`);
+  const long = repairCharacters(`Intro.\n\n\`\`\`python\n${fenceBody(360)}`);
+  assert.ok(
+    long < short * 3,
+    `doubling the fence multiplied the repair by ${(long / short).toFixed(1)}`,
+  );
+});

--- a/studio/frontend/tests/streaming-open-fence-repair.test.ts
+++ b/studio/frontend/tests/streaming-open-fence-repair.test.ts
@@ -159,6 +159,43 @@ test("an escaped fence before two overlong lines keeps the whole-tail repair", (
   );
 });
 
+// Built by concatenation, not escapes: a backslash followed by a triple-backtick
+// run is exactly the sequence this bug needs, and writing it inside a template
+// literal produced three ESCAPED backticks instead, which is a different string
+// and quietly stopped covering the case.
+const BACKTICK = String.fromCharCode(96);
+const ESCAPED_FENCE = `\\${BACKTICK}${BACKTICK}${BACKTICK}`;
+const DANGLING_INLINE_BACKTICK = `${BACKTICK}\n\n`;
+const FENCE_OPENER = `${BACKTICK}${BACKTICK}${BACKTICK}\n`;
+
+/**
+ * An unmatched inline backtick BEFORE the opener, and a marker in the part of
+ * the window the splice RETAINS rather than elides.
+ *
+ * The probe that licenses the opener standing in for the head reads the head
+ * alone, and it runs before the cut is chosen. remend decides from the whole
+ * string: an escaped \``` later in the body flips the global triple-run parity,
+ * so repairing the whole tail closes the head's dangling backtick while the
+ * spliced output, whose synthetic head never had one, does not. A `$$` there
+ * moves the math parity the other way and the splice appends where the whole
+ * tail does not. Neither is reachable from a refusal on the cut, which is why
+ * the body-marker refusal covers the retained window and not just the middle.
+ *
+ * Reported on unslothai/unsloth#9517 as review item 3836846709.
+ */
+for (const [name, windowText] of [
+  ["an escaped fence", `${ESCAPED_FENCE} more`],
+  ["display math", "$$odd"],
+  // A `~~` here does NOT reproduce and is deliberately absent: a case that
+  // passes on the broken code documents nothing and reads as coverage.
+] as const) {
+  test(`${name} in the retained window keeps the whole-tail repair`, () => {
+    assertRepairMatches(
+      `${DANGLING_INLINE_BACKTICK}${FENCE_OPENER}${"x".repeat(OVERLONG_BLANK_LINE)}\n${windowText}\n`,
+    );
+  });
+}
+
 test("a fence that never closes stays live and is never committed away", () => {
   const text = `Intro.\n\n\`\`\`python\n${fenceBody(300)}`;
   const cache = new IncrementalMarkdownCache();

--- a/studio/frontend/tests/streaming-open-fence-repair.test.ts
+++ b/studio/frontend/tests/streaming-open-fence-repair.test.ts
@@ -30,6 +30,9 @@ function fenceBody(lines: number): string {
   return body;
 }
 
+// Comfortably past OPEN_FENCE_REPAIR_WINDOW, so the cut cannot land inside it.
+const OVERLONG_BLANK_LINE = 6_000;
+
 const tailOf = (cache: IncrementalMarkdownCache): string =>
   (cache as unknown as { tail: string }).tail;
 
@@ -47,7 +50,15 @@ const contextOf = (cache: IncrementalMarkdownCache): Record<string, unknown> =>
  */
 function assertRepairMatches(text: string, chunk = 192): void {
   const cache = new IncrementalMarkdownCache();
-  for (let end = chunk; end <= text.length; end += chunk) {
+  const ends: number[] = [];
+  for (let end = chunk; end < text.length; end += chunk) {
+    ends.push(end);
+  }
+  // The last frame is fed exactly, not at whatever multiple of the chunk size
+  // happens to land near it. Several of the divergences this file exists to
+  // catch only show on a tail that ends on a specific character.
+  ends.push(text.length);
+  for (const end of ends) {
     const render = cache.update(text.slice(0, end));
     const context = contextOf(cache);
     assert.equal(
@@ -93,6 +104,59 @@ test("display math inside an open fence keeps the whole-tail repair", () => {
 
 test("a marker left open before the fence keeps the whole-tail repair", () => {
   assertRepairMatches(`Intro **bold\n\n\`\`\`python\n${fenceBody(110)}`);
+});
+
+/**
+ * A whitespace-only line longer than the repair window, then a tail that looks
+ * like a setext underline.
+ *
+ * The window is cut at the first line boundary at or after its start, so a
+ * preceding line this long puts the cut on the newline that ENDS it and leaves
+ * the window holding the final line alone. remend's setext repair reads exactly
+ * one line back, and the opener that stands in for the head is never blank, so
+ * the elided blank line used to become a non-blank one and the repair appended a
+ * zero-width space the whole-tail repair does not add -- a hidden character in
+ * rendered code, and on the clipboard behind the copy button.
+ *
+ * Reported on unslothai/unsloth#9517 as review item 3836360429.
+ */
+for (const filler of [" ", "\t"]) {
+  for (const underline of ["-", "--", "=", "=="]) {
+    const label = JSON.stringify(filler);
+    test(`a ${label} line longer than the window before ${underline} keeps the whole-tail repair`, () => {
+      const blank = filler.repeat(OVERLONG_BLANK_LINE);
+      assertRepairMatches(
+        `Here is the code.\n\n\`\`\`python\nx = 1\n${blank}\n${underline}`,
+      );
+    });
+  }
+}
+
+/**
+ * A ` $ or ~ inside the part of the fence body that the window elides.
+ *
+ * remend has at least three notions of "inside a fence" and they disagree: the
+ * escape-aware walk behind `isWithinCodeBlock`, the emphasis counters that
+ * toggle on ``` without honouring a backslash, and the inline-code repair that
+ * just counts /```/g. An escaped \``` or a ```` run flips some and not others,
+ * so the opener that stands in for the elided text cannot reproduce them all
+ * once the elided part carries one of those characters, and the repair appends
+ * a stray closer the whole-tail repair does not add.
+ *
+ * These two are the shrunk reproducers, kept verbatim: the shape needs a stray
+ * backtick before the fence, a longer opener, and an escaped fence inside it,
+ * so a tidier-looking case silently stops covering the bug.
+ */
+test("an escaped fence in the elided body keeps the whole-tail repair", () => {
+  assertRepairMatches(
+    `a\`\n\n\`\`\`\`md\n\\\`\`\`\n${"ab".repeat(3000)}\n===\n`,
+  );
+});
+
+test("an escaped fence before two overlong lines keeps the whole-tail repair", () => {
+  assertRepairMatches(
+    `- a\n- b\n\n\`\`\`\`md\n\\\`\`\`\n* * *\n${" ".repeat(5000)}\n${"x".repeat(5000)}\n\`tick\n`,
+  );
 });
 
 test("a fence that never closes stays live and is never committed away", () => {


### PR DESCRIPTION
## UI idempotency, first and as a gate

This changes how a streamed reply is repaired before it is split into blocks, which is the highest-risk place in the app for a silent rendering difference, so the rendered document was checked before any timing was read.

**Frame-by-frame, base against head.** Both builds of the module were driven through the same stream and compared on *every* frame on the three things the renderer consumes: the Markdown string handed to Streamdown, the block list that string is split into, and the render generation that keys the component.

| corpus | frames | markdown differs | blocks differ | render generation differs | final document identical |
|---|---|---|---|---|---|
| ls_never_closes | 1,407 | 0 | 0 | 0 | yes |
| ls_few_large | 1,407 | 0 | 0 | 0 | yes |
| ls_many_small | 1,407 | 0 | 0 | 0 | yes |
| mix_few_large | 1,407 | 0 | 0 | 0 | yes |
| mix_many_small | 1,407 | 0 | 0 | 0 | yes |
| plain_prose | 1,407 | 0 | 0 | 0 | yes |

8,442 frames, zero differences, so nothing rendered changes. **Nothing differs mid-stream either**, not only at the end: the shortcut is not an approximation that converges, it returns the same bytes on every frame. The block splitter is not touched at all -- `parseMarkdownIntoBlocks` is called on the same string it was called on before.

**studiobench A/B parity digest, with its null.** `--tier standard --reps 4 --ab pr9517 --engine chromium`, base and treatment interleaved in one session against a byte-identical seeded thread, DOM digest at the close of each scripted action. The null control (base against base) ran in the same sweep and its measured variation replaces the declared unstable set.

```
null control (base vs base), same sweep
  unstable in practice: delete_message, model_change, reasoning_toggle,
                        select_all_copy, settings, thread_reopen
  style probe differing: 7

PR 9517 vs base, scored against that measured floor
  64 action pairs across 1 shard
  matched:                    39
  stable actions differing:   0     <-- the verdict
  unstable actions differing: 20    (expected to vary; not a verdict)
  NOT COMPARABLE:             0     (never measured; not a pass)
  NOT EXERCISED:              5     (delete_message, image_upload: no button to click)
  style probe differing:      6     (advisory; the null's own was 7)
```

---

## The finding

A streamed reply collapses while a code fence is open, and the cost scales with the characters accumulated inside that fence, not with how many elements are mounted.

The cleanest evidence for the axis is a window where the mounted element count is **exactly constant at 760** while 11,479 characters stream in and rAF fps falls from 58.8 to 3.9. The node count is the same integer throughout, `code_blocks` is still 0 and `highlight_spans` is still 0, so nothing about the DOM and nothing about syntax highlighting can explain it. The work is upstream of both.

Off-browser, feeding the streaming path chunk by chunk over a 90,000 character reply whose fence never closes, `IncrementalMarkdownCache.update` costs **29,000 ms** in total and per-update cost tracks the live tail exactly:

```
end=20480  tail=16768  update=10.8ms   remend=10.8ms  committed_blocks=81
end=35840  tail=32128  update=37.0ms   remend=34.9ms  committed_blocks=81
end=51200  tail=47488  update=79.8ms   remend=80.3ms  committed_blocks=81
end=66560  tail=62848  update=134.6ms  remend=137.0ms committed_blocks=81
end=81920  tail=78208  update=207.4ms  remend=204.9ms committed_blocks=81
```

`committed_blocks` never moves and essentially all of the time is `remend`.

## The mechanism

Two things compound.

**Nothing can be retained.** `update()` computes

```ts
const candidateCount = Math.max(0, blocks.length - ROLLBACK_BLOCKS);
if (candidateCount === 0) {
  return this.render(repaired);
}
```

An open fence lexes into a *single* block, so the repaired tail never has more than `ROLLBACK_BLOCKS` blocks, `candidateCount` is 0 on every chunk, and the early return leaves before the `STALLED_TAIL_CHARACTERS` budget that exists for exactly this shape. The live tail therefore grows with the fence, without bound.

**Repairing that tail is quadratic.** `repairTail` calls `remend(this.tail)`. remend's link pass walks the whole string once per `[` to decide whether a link is unterminated, and its `isWithinCodeBlock` probe scans from index 0 each time. Bracketed content is what makes it quadratic, and code is dense in brackets:

```
remend() on an open fence, by body content
brackets []     8000:12.49ms  16000:43.77  32000:175.36  64000:689.14
parens ()       8000:0.10ms   16000:0.23   32000:0.38    64000:0.65
underscore _    8000:0.40ms   16000:0.25   32000:0.45    64000:0.94
plain words     8000:0.08ms   16000:0.17   32000:0.33    64000:0.71
```

Inside an unterminated fence every one of those brackets is literal and every pass declines. The walk finds nothing and still costs the length of the fence, on every streamed chunk.

This is upstream of #8935, which made *tokenization* incremental. Nothing here is tokenized: the fence has not been recognised yet.

## The fix

Repair a bounded window of the fence body behind a synthetic opener, and splice the untouched middle back in. An incremental scanner mirrors **remend's own** notion of an open fence (any ` ``` ` run toggles it, wherever on the line it sits, a backslash escapes the backtick after it), carried across updates so a growing tail costs the characters that arrived rather than the characters it holds.

The shortcut is only taken when it can be shown to return what repairing the whole tail returns. **Four refusals** fall back to the whole-tail path, and the last two are the interesting half of this pull request, because they are the reason the byte-identical claim is true rather than nearly true:

1. **A body still shorter than the window** has nothing to elide, so there is no saving to take.
2. **A final line longer than the window** leaves no line boundary to cut on. The cut has to land on one, because that is the only place the splice can start without changing what the trailing repairs read.
3. **A preceding line longer than the window** puts the cut on the newline that *ends* it, so the window holds the final line alone. remend's setext repair reads exactly one line back, and the synthetic opener standing in for it is never blank, so a whitespace-only line elided that way turned a tail ending in `-`, `--`, `=` or `==` into one carrying a **zero-width space** that repairing the whole tail does not add, and that the copy button would then put on the clipboard.
4. **A ` `` ` `, `$` or `~` anywhere in the body**, retained window included, not only in what the cut elides. remend does not have one notion of "inside a fence"; it has at least three and they disagree. `isWithinCodeBlock` walks the text and honours a backslash before a backtick, the emphasis counters toggle on ` ``` ` without honouring it, and the inline-code repair just counts `/```/g`. An escaped `` \``` `` or a ```` ```` ```` run flips some and not others, so the opener cannot stand in for the elided text and a stray closer was appended.

A probe also checks that remend leaves the head alone before the head is elided. **That probe is the reason refusal 4 has to cover the retained window too.** It reads the head *alone*, and it runs before the cut is chosen, while remend decides from the whole string. An escaped `` \``` `` later in the body flips the global triple-run parity, so the whole-tail repair closes an unmatched inline backtick sitting before the opener while the spliced output, whose synthetic head never had one, does not; a `$$` there moves the maths parity the other way and the splice appends where the whole tail does not. No refusal on the cut can reach either, because the probe is upstream of the cut. Widening the probe instead does not work: probing the head against the real window still leaves 76 divergences, since the repair then goes on to use the synthetic head, whose missing backtick is what moves the inline-code toggle in the first place. Keeping the body free of all three characters is what makes the probe's verdict a property of the whole tail rather than of the head it was handed.

Appending a chunk to an open fence then costs the window, not the fence.

### What this narrows

Refusal 4 has a cost worth knowing before you hit it. A fence whose body carries a backtick, dollar or tilde **anywhere at all** loses the fast path for the rest of that fence and falls back to repairing the whole tail, at the original quadratic cost. In practice that means **JavaScript or TypeScript with template literals, and shell with `$VAR`**. Python, Go, Rust, JSON, C and plain prose are unaffected.

All five benchmark corpora are unaffected too: their fast-path frame count is **2,077 with the guard and 2,077 without it**, so none of the numbers below pay for it. That is a fact about these corpora rather than a general reassurance, and a reply that is mostly shell or mostly TypeScript will not see the improvement.

This is a deliberate trade. The alternative was reproducing three mutually inconsistent fence conventions from a third-party library inside our own code, and three separate reviews each found a case where that reproduction was wrong. A refusal that is too broad costs speed on inputs we can name; a reproduction that is subtly wrong costs correctness on inputs nobody can enumerate.

## Equivalence

The spliced repair is byte-identical to repairing the whole tail on every frame that takes it, across three independent fixtures.

Both sweeps matter, and the second is why the first is no longer quoted alone. The **randomized** generator shuffles pieces; it had every ingredient for the third bug (unmatched inline backticks in its head set, escaped fences and four-backtick runs in its piece set) and still reported **0 divergences on code the structured sweep puts at 304**, because it never assembled them into the required layout. The **structured** sweep emits that layout directly -- head, opener, elided filler, retained window -- across 4,500 combinations, and is what a claim of byte-identity should rest on:

| sweep | fast-path frames | divergences |
|---|---|---|
| structured, 4,500 layouts, before refusal 4 widened | 2,080 | **304** |
| structured, 4,500 layouts, after | 480 | **0** |
| randomized, 4 seeds | about 1,020 each | 0 |
| five corpora, every frame | 2,077 | 0 |

Each round of review widened the fixture, and each widening found the bug the previous fixture could not see: short lines only, then no over-long lines, then no assembled layout.

`tests/streaming-open-fence-repair.test.ts` asserts per-frame equality for an unterminated fence, a fence that closes and reopens, CRLF, a tilde fence, a nested longer fence, `$$` inside the body, a marker left open before the fence, eight setext cases across two whitespace fillers, two shrunk reproducers for a marker in the elided middle, and two for a marker in the retained window. Every one of those fails on the commit before its own fix. A `~~` case in the retained window is deliberately **absent**: it does not reproduce, and a case that passes on the broken code documents nothing while reading as coverage.

## Before and after, with the null

Real WebKitGTK 2.50.4 (`libwebkit2gtk-4.1` via PyGObject, not Playwright WebKit), `run_meta.platform.engine = webkitgtk` derived from the page probe (X11 UA plus the `window.webkit.messageHandlers` bridge), not from the command line. 90,000 characters, field cadence, four concurrent uncapped arms, all on the guarded build (`a87fafc0`) against base (`f01f6a0c`). `base` and `null` are the same build, so their gap is the floor.

**A fence that never closes** (`ls_never_closes`):

| arm | stream fps_p5 | stream p95 | recover fps_p5 | frames |
|---|---|---|---|---|
| base | 8.20 | 122 ms | 1.95 | 8,340 |
| null (base) | 7.41 | 135 ms | 1.90 | 7,874 |
| head | **32.26** | **31 ms** | **23.81** | 16,967 |

**The shipped large-fence corpus** (`mix_few_large`):

| arm | stream fps_p5 | stream p95 | recover fps_p5 | frames |
|---|---|---|---|---|
| base | 8.20 | 122 ms | 3.66 | 9,018 |
| null (base) | 7.46 | 134 ms | 3.58 | 9,063 |
| head | **10.42** | **96 ms** | **10.64** | 9,920 |

Smaller, and the reason is worth stating: `make_corpus_pair.py` truncates each prose run to an exact character budget (`prose(per_p, rng)[:per_p]`), which removes the trailing blank line and glues the next ` ``` ` onto the end of a prose line. A ` ``` ` that is not at the start of a line is an inline code span, not a fenced block, which is why that corpus reports `code_blocks: 0`. Its fence is open for only part of the stream; the rest is a tail that stays uncommittable for a different reason. The gain there is the open-fence part.

**Control, many small fences** (`mix_many_small`), healthy today and required to stay healthy:

| arm | stream fps_p5 | stream p95 | recover fps_p5 | frames |
|---|---|---|---|---|
| base | 58.82 | 17 ms | 58.82 | 20,806 |
| null (base) | 58.82 | 17 ms | 58.82 | 20,822 |
| head | 58.82 | 17 ms | 58.82 | 20,797 |

Unchanged on every field.

## Complexity, measured without a clock

`tests/streaming-open-fence-repair.test.ts` charges every `substring` probe its receiver's length, which prices a repair at the length of what it was given, and so reads the same on a loaded CI box as on an idle one. Doubling the fence:

```
fence lines   90       180      360      720      1440
before        1.00x -> 17.18 -> 16.52 -> 16.06 -> 16.60
after         1.00x ->  2.56 ->  2.21 ->  2.09 ->  2.05
```

2.05 per doubling is a per-chunk cost independent of the fence length. The test fails on `main` with a 17.2x multiplier.
