### PR TITLE
Import the OpenDocument MIME constants from where they are exported

### DIFF
--- a/studio/frontend/src/features/chat/attachment-content.ts
+++ b/studio/frontend/src/features/chat/attachment-content.ts
@@ -4,10 +4,12 @@
 import { type Unzipped, strFromU8, unzipSync, zipSync } from "fflate";
 
 import {
-  MAX_OPEN_DOCUMENT_ARCHIVE_BYTES,
-  MAX_OPEN_DOCUMENT_XML_BYTES,
   OPEN_DOCUMENT_SPREADSHEET_MIME,
   OPEN_DOCUMENT_TEXT_MIME,
+} from "./open-document-accept";
+import {
+  MAX_OPEN_DOCUMENT_ARCHIVE_BYTES,
+  MAX_OPEN_DOCUMENT_XML_BYTES,
   readOpenDocumentAttachmentContent,
 } from "./open-document";
 


### PR DESCRIPTION
`studio/frontend/src/features/chat/attachment-content.ts` imports `OPEN_DOCUMENT_SPREADSHEET_MIME` and `OPEN_DOCUMENT_TEXT_MIME` from `./open-document`, which exports neither. Both are declared in `./open-document-accept`, and `open-document.ts` only imports the first of them from there, so the name exists locally without being re-exported.

```
src/features/chat/attachment-content.ts(9,3): error TS2459: Module './open-document' declares 'OPEN_DOCUMENT_SPREADSHEET_MIME' locally, but it is not exported.
src/features/chat/attachment-content.ts(10,3): error TS2305: Module './open-document' has no exported member 'OPEN_DOCUMENT_TEXT_MIME'.
```

The frontend build fails on main, and on every open pull request, since each one builds main merged with itself.

## How it got here

#9455 and #8655 landed minutes apart. #8655 added the two consumers in `attachment-content.ts`; #9455 moved the constants into `open-document-accept.ts`. Each branch was internally consistent and neither could see the other, so both were green when they merged and the tree they produced together is not.

## The fix

Take the two MIME constants from the module that exports them, and leave the byte limits and the reader on `./open-document`.

Deliberately not a re-export from `open-document.ts`. That would keep the import site looking correct while leaving one module the apparent owner of constants declared in another, which is the ambiguity that allowed this in the first place.

## Checks

`tsc --noEmit -p tsconfig.app.json` clean, RC 0, against TS2459 and TS2305 before the change. Frontend suite 4391 passed, 0 failed. No behaviour change: the values are identical objects from the same declaration site.