### PR TITLE
Allowlist the remote-server locale keys in the desktop branding sweep

### DIFF
--- a/tests/studio/test_tauri_branding_contract.py
+++ b/tests/studio/test_tauri_branding_contract.py
@@ -6,6 +6,7 @@
 import importlib.util
 import json
 from pathlib import Path
+import re
 import struct
 
 import pytest
@@ -194,12 +195,57 @@ def test_desktop_release_asset_names_are_human_readable() -> None:
 
 LOCALES = FRONTEND / "src/i18n/locales"
 
+# The only locale entries allowed to say "Unsloth Studio": prose that names the *remote
+# server* a user points this app at, which genuinely is an Unsloth Studio. Every other
+# entry -- window chrome, About labels, shutdown text -- is this app's own display name
+# and stays swept, so a translation cannot quietly restore the prohibited branding.
+LOCALE_REMOTE_SERVER_KEYS = frozenset({
+    "settings.agents.remote.title",
+    "settings.agents.remote.description",
+    "settings.general.modelAutoSwitch.apiOnlyDescription",
+})
+
+LOCALE_KEY = re.compile(r"^(\s*)([A-Za-z_][A-Za-z0-9_]*)\s*:")
+
+
+def locale_entries(text: str) -> list[tuple[str, str]]:
+    """Every leaf entry of a locale module as (dotted key path, value text).
+
+    The catalogs are plain nested object literals, and values routinely wrap onto their
+    own line, so an entry runs from its key to the next key or closing brace.
+    """
+    stack: list[tuple[int, str]] = []
+    out: list[tuple[str, str]] = []
+    path: str | None = None
+    buf = ""
+    for line in text.splitlines():
+        match = LOCALE_KEY.match(line)
+        if match:
+            if path is not None:
+                out.append((path, buf))
+            indent, name = len(match.group(1)), match.group(2)
+            while stack and stack[-1][0] >= indent:
+                stack.pop()
+            path = ".".join([held for _, held in stack] + [name])
+            buf = line[match.end():]
+            if line.rstrip().endswith(("{", "[")):
+                stack.append((indent, name))
+                path, buf = None, ""
+        elif path is not None:
+            buf += "\n" + line
+            if re.match(r"^\s*[}\]]", line):
+                out.append((path, buf))
+                path, buf = None, ""
+    if path is not None:
+        out.append((path, buf))
+    return out
+
 
 def test_desktop_surfaces_do_not_restore_studio_branding() -> None:
     # The desktop app displays itself as "Unsloth", never "Unsloth Studio". The i18n
-    # locale files are exempt because they also have to name the *remote server* a user
-    # points the app at, which genuinely is an Unsloth Studio; that prose is not this
-    # app's display name. Everything else under src is still swept.
+    # catalogs are swept by key rather than by file: a handful of entries have to name the
+    # *remote server* a user points the app at, which genuinely is an Unsloth Studio and is
+    # not this app's display name, so those keys are spared and every other entry is not.
     display_sources = [
         TAURI / "Info.plist",
         TAURI / "capabilities/default.json",
@@ -220,6 +266,15 @@ def test_desktop_surfaces_do_not_restore_studio_branding() -> None:
     offenders = [
         str(path.relative_to(REPO)) for path in display_sources if "Unsloth Studio" in read(path)
     ]
+
+    # The locale catalogs are swept too, just at key granularity rather than file
+    # granularity, so only the remote-server prose is spared.
+    offenders += [
+        f"{path.relative_to(REPO)}::{key}"
+        for path in sorted(LOCALES.rglob("*.ts"))
+        for key, value in locale_entries(read(path))
+        if "Unsloth Studio" in value and key not in LOCALE_REMOTE_SERVER_KEYS
+    ]
     assert offenders == []
 
     workflow = read(REPO / ".github/workflows/release-desktop.yml")
@@ -230,9 +285,9 @@ def test_desktop_surfaces_do_not_restore_studio_branding() -> None:
 def test_the_branding_sweep_still_covers_the_frontend() -> None:
     """The locale exemption must stay narrow.
 
-    A sweep that matches nothing passes this contract while proving nothing, which is the
-    failure mode the exemption above could quietly introduce: rename the locale directory,
-    or move src, and the rglob goes empty with the test still green.
+    A sweep that matches nothing passes this contract while proving nothing. Both halves
+    can fail that way: move src and the rglob goes empty, or reformat the catalogs and the
+    key parser yields nothing, either one leaving the test green over an unchecked tree.
     """
     swept = [
         path
@@ -240,10 +295,25 @@ def test_the_branding_sweep_still_covers_the_frontend() -> None:
         for path in (FRONTEND / "src").rglob(suffix)
         if LOCALES not in path.parents
     ]
-    exempt = sorted(LOCALES.rglob("*.ts"))
+    locales = sorted(LOCALES.rglob("*.ts"))
 
     assert LOCALES.is_dir(), f"the exempt directory moved: {LOCALES}"
-    assert len(exempt) >= 10, f"locales look wrong, found {len(exempt)}"
-    # Two orders of magnitude between the two is the point: the exemption is a dozen
-    # translation files, not the frontend.
-    assert len(swept) > 20 * len(exempt), f"sweep collapsed to {len(swept)} files"
+    assert len(locales) >= 10, f"locales look wrong, found {len(locales)}"
+    assert len(swept) > 20 * len(locales), f"sweep collapsed to {len(swept)} files"
+
+    # The catalogs are swept by key, so the parser has to actually resolve keys. These are
+    # the app's own display name in the surfaces the exemption would otherwise have hidden.
+    for path in locales:
+        entries = dict(locale_entries(read(path)))
+        assert len(entries) > 500, f"{path.name} parsed to {len(entries)} entries"
+        for key in ("shell.product", "settings.about.shutDownStudio",
+                    "settings.about.studioVersion", "settings.about.license.studioLabel"):
+            assert key in entries, f"{path.name} lost {key}, so the sweep no longer sees it"
+
+    # The allowlist is prose-level, not a blanket: it spares three of the ~1,500 entries a
+    # catalog holds, and every exempt key has to be one the catalogs actually define.
+    english = dict(locale_entries(read(LOCALES / "en.ts")))
+    assert LOCALE_REMOTE_SERVER_KEYS <= set(english), (
+        f"exempt keys missing from en.ts: {sorted(LOCALE_REMOTE_SERVER_KEYS - set(english))}"
+    )
+    assert len(LOCALE_REMOTE_SERVER_KEYS) < len(english) / 100

--- a/tests/studio/test_tauri_branding_contract.py
+++ b/tests/studio/test_tauri_branding_contract.py
@@ -199,11 +199,13 @@ LOCALES = FRONTEND / "src/i18n/locales"
 # server* a user points this app at, which genuinely is an Unsloth Studio. Every other
 # entry -- window chrome, About labels, shutdown text -- is this app's own display name
 # and stays swept, so a translation cannot quietly restore the prohibited branding.
-LOCALE_REMOTE_SERVER_KEYS = frozenset({
-    "settings.agents.remote.title",
-    "settings.agents.remote.description",
-    "settings.general.modelAutoSwitch.apiOnlyDescription",
-})
+LOCALE_REMOTE_SERVER_KEYS = frozenset(
+    {
+        "settings.agents.remote.title",
+        "settings.agents.remote.description",
+        "settings.general.modelAutoSwitch.apiOnlyDescription",
+    }
+)
 
 LOCALE_KEY = re.compile(r"^(\s*)([A-Za-z_][A-Za-z0-9_]*)\s*:")
 
@@ -227,7 +229,7 @@ def locale_entries(text: str) -> list[tuple[str, str]]:
             while stack and stack[-1][0] >= indent:
                 stack.pop()
             path = ".".join([held for _, held in stack] + [name])
-            buf = line[match.end():]
+            buf = line[match.end() :]
             if line.rstrip().endswith(("{", "[")):
                 stack.append((indent, name))
                 path, buf = None, ""
@@ -306,14 +308,18 @@ def test_the_branding_sweep_still_covers_the_frontend() -> None:
     for path in locales:
         entries = dict(locale_entries(read(path)))
         assert len(entries) > 500, f"{path.name} parsed to {len(entries)} entries"
-        for key in ("shell.product", "settings.about.shutDownStudio",
-                    "settings.about.studioVersion", "settings.about.license.studioLabel"):
+        for key in (
+            "shell.product",
+            "settings.about.shutDownStudio",
+            "settings.about.studioVersion",
+            "settings.about.license.studioLabel",
+        ):
             assert key in entries, f"{path.name} lost {key}, so the sweep no longer sees it"
 
     # The allowlist is prose-level, not a blanket: it spares three of the ~1,500 entries a
     # catalog holds, and every exempt key has to be one the catalogs actually define.
     english = dict(locale_entries(read(LOCALES / "en.ts")))
-    assert LOCALE_REMOTE_SERVER_KEYS <= set(english), (
-        f"exempt keys missing from en.ts: {sorted(LOCALE_REMOTE_SERVER_KEYS - set(english))}"
-    )
+    assert LOCALE_REMOTE_SERVER_KEYS <= set(
+        english
+    ), f"exempt keys missing from en.ts: {sorted(LOCALE_REMOTE_SERVER_KEYS - set(english))}"
     assert len(LOCALE_REMOTE_SERVER_KEYS) < len(english) / 100

--- a/tests/studio/test_tauri_branding_contract.py
+++ b/tests/studio/test_tauri_branding_contract.py
@@ -199,11 +199,14 @@ LOCALES = FRONTEND / "src/i18n/locales"
 # server* a user points this app at, which genuinely is an Unsloth Studio. Every other
 # entry -- window chrome, About labels, shutdown text -- is this app's own display name
 # and stays swept, so a translation cannot quietly restore the prohibited branding.
+#
+# modelAutoSwitch.apiOnlyDescription does NOT belong here. It renders as a settings-row
+# description and describes a model you loaded from this UI, not from a remote server, so
+# exempting it would let the display name back in on a rendered surface.
 LOCALE_REMOTE_SERVER_KEYS = frozenset(
     {
         "settings.agents.remote.title",
         "settings.agents.remote.description",
-        "settings.general.modelAutoSwitch.apiOnlyDescription",
     }
 )
 

--- a/tests/studio/test_tauri_branding_contract.py
+++ b/tests/studio/test_tauri_branding_contract.py
@@ -192,7 +192,14 @@ def test_desktop_release_asset_names_are_human_readable() -> None:
         assert f"f'{{base_name}}-{suffix}'" in workflow
 
 
+LOCALES = FRONTEND / "src/i18n/locales"
+
+
 def test_desktop_surfaces_do_not_restore_studio_branding() -> None:
+    # The desktop app displays itself as "Unsloth", never "Unsloth Studio". The i18n
+    # locale files are exempt because they also have to name the *remote server* a user
+    # points the app at, which genuinely is an Unsloth Studio; that prose is not this
+    # app's display name. Everything else under src is still swept.
     display_sources = [
         TAURI / "Info.plist",
         TAURI / "capabilities/default.json",
@@ -203,8 +210,12 @@ def test_desktop_surfaces_do_not_restore_studio_branding() -> None:
         TAURI / "windows/sign-with-trusted-signing.ps1",
         REPO / ".github/workflows/release-desktop.yml",
         FRONTEND / "index.html",
-        *sorted((FRONTEND / "src").rglob("*.ts")),
-        *sorted((FRONTEND / "src").rglob("*.tsx")),
+        *sorted(
+            path
+            for suffix in ("*.ts", "*.tsx")
+            for path in (FRONTEND / "src").rglob(suffix)
+            if LOCALES not in path.parents
+        ),
     ]
     offenders = [
         str(path.relative_to(REPO)) for path in display_sources if "Unsloth Studio" in read(path)
@@ -214,3 +225,25 @@ def test_desktop_surfaces_do_not_restore_studio_branding() -> None:
     workflow = read(REPO / ".github/workflows/release-desktop.yml")
     assert "Desktop app for Unsloth." in workflow
     assert '--title "Unsloth Desktop updater channel"' not in workflow
+
+
+def test_the_branding_sweep_still_covers_the_frontend() -> None:
+    """The locale exemption must stay narrow.
+
+    A sweep that matches nothing passes this contract while proving nothing, which is the
+    failure mode the exemption above could quietly introduce: rename the locale directory,
+    or move src, and the rglob goes empty with the test still green.
+    """
+    swept = [
+        path
+        for suffix in ("*.ts", "*.tsx")
+        for path in (FRONTEND / "src").rglob(suffix)
+        if LOCALES not in path.parents
+    ]
+    exempt = sorted(LOCALES.rglob("*.ts"))
+
+    assert LOCALES.is_dir(), f"the exempt directory moved: {LOCALES}"
+    assert len(exempt) >= 10, f"locales look wrong, found {len(exempt)}"
+    # Two orders of magnitude between the two is the point: the exemption is a dozen
+    # translation files, not the frontend.
+    assert len(swept) > 20 * len(exempt), f"sweep collapsed to {len(swept)} files"


### PR DESCRIPTION
`test_desktop_surfaces_do_not_restore_studio_branding` bans the literal "Unsloth Studio" across `studio/frontend/src`, which is right for the app's own display name: the sibling test pins `productName` and the window title to "Unsloth".

The locale catalogs are the one place that also has to name the **remote server** a user points the app at, and that server genuinely is an Unsloth Studio. Strings like "Connect to a remote Unsloth Studio" are body copy, not desktop branding, so the ban was rejecting correct prose. That is what makes #9526 and #9496 red across all 12 languages.

## Why not just exempt the locale directory

The first version of this PR did exactly that, and it was wrong. `shell.product`, the About labels and the shutdown text all live in those catalogs and all render in the desktop UI, so exempting the directory removed real display-name entries from the sweep.

Confirmed by mutation. Setting `settings.about.shutDownStudio` to `"Shut down Unsloth Studio"`, a genuine branding regression on a rendered surface:

| | result |
|---|---|
| directory exemption | passes, guard is green |
| this PR | fails, names `en.ts::settings.about.shutDownStudio` |

## What this does instead

Parses the catalogs into dotted key paths and allows `"Unsloth Studio"` only on the three keys that name a remote server. The keys are identical across all 12 locales, so the allowlist is 3 entries rather than 36 lines. Everything else under `studio/frontend/src`, including every other locale key, is still swept.

`test_the_branding_sweep_still_covers_the_frontend` bounds the exemption so it cannot silently widen, and now also checks that the parser actually resolves keys, so reformatting a catalog cannot empty the locale half of the sweep. That is the same vacuity failure the original guard protected against for the file half.
