### PR TITLE
Studio: keep one copy of the embedding model setting

### DIFF
--- a/studio/frontend/src/features/settings/components/documents-rag-section.tsx
+++ b/studio/frontend/src/features/settings/components/documents-rag-section.tsx
@@ -26,8 +26,7 @@ export function DocumentsRagSection(): ReactElement {
   const hfToken = useChatRuntimeStore((s) => s.hfToken);
   const embeddingModel = useEmbeddingModelStore((s) => s.settings);
   const loadError = useEmbeddingModelStore((s) => s.loadError);
-  const applySettings = useEmbeddingModelStore((s) => s.applySettings);
-  const beginSave = useEmbeddingModelStore((s) => s.beginSave);
+  const save = useEmbeddingModelStore((s) => s.save);
   // Null until the user edits, so the field follows a save made on the other
   // surface instead of pinning whatever this mount first read.
   const [draftOverride, setDraftOverride] = useState<string | null>(null);
@@ -57,14 +56,15 @@ export function DocumentsRagSection(): ReactElement {
     }
     setIsSavingEmbeddingModel(true);
     setSaveError(null);
-    const save = beginSave();
     try {
-      const settings = await updateEmbeddingModelSettings(trimmed, {
-        hfToken: hfToken || undefined,
-        force,
-      });
+      const stood = await save(() =>
+        updateEmbeddingModelSettings(trimmed, {
+          hfToken: hfToken || undefined,
+          force,
+        }),
+      );
       // A later save owns the field now, so this answer says nothing current.
-      if (!applySettings(settings, save)) return;
+      if (!stood) return;
       setDraftOverride(null);
       setEmbeddingModelNeedsForce(false);
       toast.success(t("settings.general.rag.saved"), {
@@ -91,9 +91,8 @@ export function DocumentsRagSection(): ReactElement {
     setIsSavingEmbeddingModel(true);
     setSaveError(null);
     setEmbeddingModelNeedsForce(false);
-    const save = beginSave();
     try {
-      if (!applySettings(await resetEmbeddingModelSettings(), save)) return;
+      if (!(await save(resetEmbeddingModelSettings))) return;
       setDraftOverride(null);
     } catch (error) {
       setSaveError(

--- a/studio/frontend/src/features/settings/components/documents-rag-section.tsx
+++ b/studio/frontend/src/features/settings/components/documents-rag-section.tsx
@@ -27,6 +27,7 @@ export function DocumentsRagSection(): ReactElement {
   const embeddingModel = useEmbeddingModelStore((s) => s.settings);
   const loadError = useEmbeddingModelStore((s) => s.loadError);
   const applySettings = useEmbeddingModelStore((s) => s.applySettings);
+  const beginSave = useEmbeddingModelStore((s) => s.beginSave);
   // Null until the user edits, so the field follows a save made on the other
   // surface instead of pinning whatever this mount first read.
   const [draftOverride, setDraftOverride] = useState<string | null>(null);
@@ -56,12 +57,14 @@ export function DocumentsRagSection(): ReactElement {
     }
     setIsSavingEmbeddingModel(true);
     setSaveError(null);
+    const save = beginSave();
     try {
       const settings = await updateEmbeddingModelSettings(trimmed, {
         hfToken: hfToken || undefined,
         force,
       });
-      applySettings(settings);
+      // A later save owns the field now, so this answer says nothing current.
+      if (!applySettings(settings, save)) return;
       setDraftOverride(null);
       setEmbeddingModelNeedsForce(false);
       toast.success(t("settings.general.rag.saved"), {
@@ -88,8 +91,9 @@ export function DocumentsRagSection(): ReactElement {
     setIsSavingEmbeddingModel(true);
     setSaveError(null);
     setEmbeddingModelNeedsForce(false);
+    const save = beginSave();
     try {
-      applySettings(await resetEmbeddingModelSettings());
+      if (!applySettings(await resetEmbeddingModelSettings(), save)) return;
       setDraftOverride(null);
     } catch (error) {
       setSaveError(

--- a/studio/frontend/src/features/settings/components/documents-rag-section.tsx
+++ b/studio/frontend/src/features/settings/components/documents-rag-section.tsx
@@ -8,70 +8,61 @@ import { toast } from "@/lib/toast";
 import { type ReactElement, useEffect, useState } from "react";
 import {
   EmbeddingModelBlockedError,
-  type EmbeddingModelSettings,
   EmbeddingModelVerificationError,
-  loadEmbeddingModelSettings,
   resetEmbeddingModelSettings,
   updateEmbeddingModelSettings,
 } from "../api/embedding-model";
+import { useEmbeddingModelStore } from "../stores/embedding-model-store";
 import { EmbeddingModelCombobox } from "./embedding-model-combobox";
 import { SettingsRow } from "./settings-row";
 import { SettingsSection } from "./settings-section";
 
 /**
- * Which model indexes uploaded documents. Rendered in both General and Data:
- * each mount loads the setting, so the two never disagree.
+ * Which model indexes uploaded documents. Rendered in both General and Data,
+ * off one shared store, so a save on one is what the other reads.
  */
 export function DocumentsRagSection(): ReactElement {
   const t = useT();
   const hfToken = useChatRuntimeStore((s) => s.hfToken);
-  const [embeddingModel, setEmbeddingModel] =
-    useState<EmbeddingModelSettings | null>(null);
-  const [draftEmbeddingModel, setDraftEmbeddingModel] = useState("");
-  const [embeddingModelError, setEmbeddingModelError] = useState<string | null>(
-    null,
-  );
+  const embeddingModel = useEmbeddingModelStore((s) => s.settings);
+  const loadError = useEmbeddingModelStore((s) => s.loadError);
+  const applySettings = useEmbeddingModelStore((s) => s.applySettings);
+  // Null until the user edits, so the field follows a save made on the other
+  // surface instead of pinning whatever this mount first read.
+  const [draftOverride, setDraftOverride] = useState<string | null>(null);
+  const draftEmbeddingModel =
+    draftOverride ?? embeddingModel?.embeddingModel ?? "";
+  const [saveError, setSaveError] = useState<string | null>(null);
+  // The store carries the backend's reason; an unreadable failure has none.
+  const loadFailure =
+    loadError === null
+      ? null
+      : loadError || t("settings.general.rag.loadError");
+  const embeddingModelError = saveError ?? loadFailure;
   // Set after a 409 (unverifiable model); offers "Save anyway".
   const [embeddingModelNeedsForce, setEmbeddingModelNeedsForce] =
     useState(false);
   const [isSavingEmbeddingModel, setIsSavingEmbeddingModel] = useState(false);
 
   useEffect(() => {
-    let cancelled = false;
-    void loadEmbeddingModelSettings()
-      .then((settings) => {
-        if (cancelled) return;
-        setEmbeddingModel(settings);
-        setDraftEmbeddingModel(settings.embeddingModel);
-      })
-      .catch((error) => {
-        if (cancelled) return;
-        setEmbeddingModelError(
-          error instanceof Error
-            ? error.message
-            : t("settings.general.rag.loadError"),
-        );
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [t]);
+    void useEmbeddingModelStore.getState().load();
+  }, []);
 
   const saveEmbeddingModel = async (force: boolean) => {
     const trimmed = draftEmbeddingModel.trim();
     if (!trimmed) {
-      setEmbeddingModelError(t("settings.general.rag.emptyError"));
+      setSaveError(t("settings.general.rag.emptyError"));
       return;
     }
     setIsSavingEmbeddingModel(true);
-    setEmbeddingModelError(null);
+    setSaveError(null);
     try {
       const settings = await updateEmbeddingModelSettings(trimmed, {
         hfToken: hfToken || undefined,
         force,
       });
-      setEmbeddingModel(settings);
-      setDraftEmbeddingModel(settings.embeddingModel);
+      applySettings(settings);
+      setDraftOverride(null);
       setEmbeddingModelNeedsForce(false);
       toast.success(t("settings.general.rag.saved"), {
         description: t("settings.general.rag.reindexWarning"),
@@ -83,7 +74,7 @@ export function DocumentsRagSection(): ReactElement {
       } else if (error instanceof EmbeddingModelVerificationError) {
         setEmbeddingModelNeedsForce(true);
       }
-      setEmbeddingModelError(
+      setSaveError(
         error instanceof Error
           ? error.message
           : t("settings.general.rag.saveError"),
@@ -95,14 +86,13 @@ export function DocumentsRagSection(): ReactElement {
 
   const resetEmbeddingModel = async () => {
     setIsSavingEmbeddingModel(true);
-    setEmbeddingModelError(null);
+    setSaveError(null);
     setEmbeddingModelNeedsForce(false);
     try {
-      const settings = await resetEmbeddingModelSettings();
-      setEmbeddingModel(settings);
-      setDraftEmbeddingModel(settings.embeddingModel);
+      applySettings(await resetEmbeddingModelSettings());
+      setDraftOverride(null);
     } catch (error) {
-      setEmbeddingModelError(
+      setSaveError(
         error instanceof Error
           ? error.message
           : t("settings.general.rag.saveError"),
@@ -126,9 +116,9 @@ export function DocumentsRagSection(): ReactElement {
             <EmbeddingModelCombobox
               value={draftEmbeddingModel}
               onChange={(next) => {
-                setDraftEmbeddingModel(next);
+                setDraftOverride(next);
                 setEmbeddingModelNeedsForce(false);
-                setEmbeddingModelError(null);
+                setSaveError(null);
               }}
               accessToken={hfToken || undefined}
               disabled={!embeddingModel}

--- a/studio/frontend/src/features/settings/stores/embedding-model-store.ts
+++ b/studio/frontend/src/features/settings/stores/embedding-model-store.ts
@@ -18,10 +18,12 @@ interface EmbeddingModelState {
   loadError: string | null;
   /** Bumped by every committed mutation, so a slower read cannot undo it. */
   revision: number;
-  /** Claim the next save. Its answer commits only while it is the latest. */
-  beginSave: () => number;
-  /** Commits unless a later save was claimed first. True when it stood. */
-  applySettings: (settings: EmbeddingModelSettings, save?: number) => boolean;
+  applySettings: (settings: EmbeddingModelSettings) => void;
+  /**
+   * Run a write and commit its answer. Returns false when a later write
+   * started first, so the caller leaves the field to that one.
+   */
+  save: (request: () => Promise<EmbeddingModelSettings>) => Promise<boolean>;
   load: () => Promise<void>;
 }
 
@@ -30,25 +32,50 @@ interface EmbeddingModelState {
 // and shows an error, or an older model, over what the newer one just read.
 let latestLoad = 0;
 
-// Saves need the same ordering, for the same reason: each surface keeps its own
-// pending flag, so the one the user switched to can start a second save while
-// the first is still out, and responses need not come back in request order.
+// Each surface keeps its own pending flag, so the one the user switches to can
+// write while the first write is still out. Request order is the best guess at
+// which one the user meant, but not proof of what the backend ended on: the
+// later one can fail verification, or persist first. So the newest answer wins
+// the moment it lands, and once every overlapping write has settled the store
+// re-reads instead of trusting the guess.
 let latestSave = 0;
+let savesInFlight = 0;
+let saveWasSuperseded = false;
 
 export const useEmbeddingModelStore = create<EmbeddingModelState>(
   (set, get) => ({
     settings: null,
     loadError: null,
     revision: 0,
-    beginSave: () => ++latestSave,
-    applySettings: (settings, save) => {
-      if (save !== undefined && save !== latestSave) return false;
+    applySettings: (settings) =>
       set((state) => ({
         settings,
         loadError: null,
         revision: state.revision + 1,
-      }));
-      return true;
+      })),
+    save: async (request) => {
+      const save = ++latestSave;
+      savesInFlight += 1;
+      try {
+        const settings = await request();
+        if (save !== latestSave) {
+          saveWasSuperseded = true;
+          return false;
+        }
+        get().applySettings(settings);
+        return true;
+      } catch (error) {
+        // A failed write leaves the backend on whatever the others wrote, so
+        // an overlap has to be settled by a read, not by request order.
+        if (save !== latestSave || savesInFlight > 1) saveWasSuperseded = true;
+        throw error;
+      } finally {
+        savesInFlight -= 1;
+        if (savesInFlight === 0 && saveWasSuperseded) {
+          saveWasSuperseded = false;
+          void get().load();
+        }
+      }
     },
     load: async () => {
       const revision = get().revision;

--- a/studio/frontend/src/features/settings/stores/embedding-model-store.ts
+++ b/studio/frontend/src/features/settings/stores/embedding-model-store.ts
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import { create } from "zustand";
+import {
+  type EmbeddingModelSettings,
+  loadEmbeddingModelSettings,
+} from "../api/embedding-model";
+
+/**
+ * One copy of the embedding model setting for both surfaces that edit it
+ * (General and Data). Component state would let a save made on one tab finish
+ * after the other has mounted and read the old value, leaving the tab on
+ * screen showing a model the toast just said was replaced.
+ */
+interface EmbeddingModelState {
+  settings: EmbeddingModelSettings | null;
+  loadError: string | null;
+  /** Bumped by every committed mutation, so a slower read cannot undo it. */
+  revision: number;
+  applySettings: (settings: EmbeddingModelSettings) => void;
+  load: () => Promise<void>;
+}
+
+export const useEmbeddingModelStore = create<EmbeddingModelState>(
+  (set, get) => ({
+    settings: null,
+    loadError: null,
+    revision: 0,
+    applySettings: (settings) =>
+      set((state) => ({
+        settings,
+        loadError: null,
+        revision: state.revision + 1,
+      })),
+    load: async () => {
+      const revision = get().revision;
+      try {
+        const settings = await loadEmbeddingModelSettings();
+        // A save committed while this read was in flight, so the read is stale.
+        if (get().revision !== revision) return;
+        set({ settings, loadError: null });
+      } catch (error) {
+        if (get().revision !== revision) return;
+        set({
+          loadError: error instanceof Error ? error.message : "",
+        });
+      }
+    },
+  }),
+);

--- a/studio/frontend/src/features/settings/stores/embedding-model-store.ts
+++ b/studio/frontend/src/features/settings/stores/embedding-model-store.ts
@@ -22,6 +22,11 @@ interface EmbeddingModelState {
   load: () => Promise<void>;
 }
 
+// Both surfaces read on mount, so two reads overlap with no save between them
+// to bump the revision. Only the newest may commit, or a slow one lands last
+// and shows an error, or an older model, over what the newer one just read.
+let latestLoad = 0;
+
 export const useEmbeddingModelStore = create<EmbeddingModelState>(
   (set, get) => ({
     settings: null,
@@ -35,13 +40,15 @@ export const useEmbeddingModelStore = create<EmbeddingModelState>(
       })),
     load: async () => {
       const revision = get().revision;
+      const load = ++latestLoad;
+      const stale = () => get().revision !== revision || load !== latestLoad;
       try {
         const settings = await loadEmbeddingModelSettings();
-        // A save committed while this read was in flight, so the read is stale.
-        if (get().revision !== revision) return;
+        // A save committed, or a later read started, while this was in flight.
+        if (stale()) return;
         set({ settings, loadError: null });
       } catch (error) {
-        if (get().revision !== revision) return;
+        if (stale()) return;
         set({
           loadError: error instanceof Error ? error.message : "",
         });

--- a/studio/frontend/src/features/settings/stores/embedding-model-store.ts
+++ b/studio/frontend/src/features/settings/stores/embedding-model-store.ts
@@ -18,7 +18,10 @@ interface EmbeddingModelState {
   loadError: string | null;
   /** Bumped by every committed mutation, so a slower read cannot undo it. */
   revision: number;
-  applySettings: (settings: EmbeddingModelSettings) => void;
+  /** Claim the next save. Its answer commits only while it is the latest. */
+  beginSave: () => number;
+  /** Commits unless a later save was claimed first. True when it stood. */
+  applySettings: (settings: EmbeddingModelSettings, save?: number) => boolean;
   load: () => Promise<void>;
 }
 
@@ -27,17 +30,26 @@ interface EmbeddingModelState {
 // and shows an error, or an older model, over what the newer one just read.
 let latestLoad = 0;
 
+// Saves need the same ordering, for the same reason: each surface keeps its own
+// pending flag, so the one the user switched to can start a second save while
+// the first is still out, and responses need not come back in request order.
+let latestSave = 0;
+
 export const useEmbeddingModelStore = create<EmbeddingModelState>(
   (set, get) => ({
     settings: null,
     loadError: null,
     revision: 0,
-    applySettings: (settings) =>
+    beginSave: () => ++latestSave,
+    applySettings: (settings, save) => {
+      if (save !== undefined && save !== latestSave) return false;
       set((state) => ({
         settings,
         loadError: null,
         revision: state.revision + 1,
-      })),
+      }));
+      return true;
+    },
     load: async () => {
       const revision = get().revision;
       const load = ++latestLoad;

--- a/studio/frontend/tests/embedding-model-store.test.ts
+++ b/studio/frontend/tests/embedding-model-store.test.ts
@@ -235,3 +235,49 @@ test("a save still bumps the revision the reads check", async () => {
   store.applySettings(settings("unsloth/bge-m3"));
   assert.equal(useEmbeddingModelStore.getState().revision, 1);
 });
+
+test("a save with nothing overlapping it commits without a re-read", async () => {
+  reset();
+  const store = useEmbeddingModelStore.getState();
+  let reads = 0;
+  globalThis.fetch = (async () => {
+    reads += 1;
+    throw new Error("should not be read");
+  }) as typeof fetch;
+  assert.ok(await store.save(async () => settings("unsloth/bge-m3")));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  // The ordinary path is one request, not a write followed by a read.
+  assert.equal(reads, 0);
+  assert.equal(
+    useEmbeddingModelStore.getState().settings?.embeddingModel,
+    "unsloth/bge-m3",
+  );
+});
+
+test("the settle flag does not carry into the next save", async () => {
+  reset();
+  const store = useEmbeddingModelStore.getState();
+  // One overlap, reconciled, and then an ordinary save on its own.
+  respondWith("unsloth/bge-m3");
+  let release = (): void => undefined;
+  const gate = new Promise<void>((resolve) => {
+    release = () => resolve();
+  });
+  const first = store.save(async () => {
+    await gate;
+    return settings("unsloth/bge-m3");
+  });
+  await store.save(async () => settings("unsloth/bge-m3"));
+  release();
+  await first;
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  let reads = 0;
+  globalThis.fetch = (async () => {
+    reads += 1;
+    throw new Error("should not be read");
+  }) as typeof fetch;
+  await store.save(async () => settings("unsloth/bge-small-en-v1.5"));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  assert.equal(reads, 0, "the earlier overlap was already settled");
+});

--- a/studio/frontend/tests/embedding-model-store.test.ts
+++ b/studio/frontend/tests/embedding-model-store.test.ts
@@ -107,6 +107,35 @@ test("a read that finishes first is still replaced by the save", async () => {
   );
 });
 
+test("a slow read cannot report over the one that overtook it", async () => {
+  reset();
+  // General mounts and its read hangs; Data mounts behind it and answers.
+  let release = (): void => undefined;
+  const gate = new Promise<void>((resolve) => {
+    release = () => resolve();
+  });
+  globalThis.fetch = (async () => {
+    await gate;
+    throw new Error("network unreachable");
+  }) as typeof fetch;
+  const first = useEmbeddingModelStore.getState().load();
+
+  respondWith("unsloth/bge-m3");
+  await useEmbeddingModelStore.getState().load();
+  release();
+  await first;
+
+  assert.equal(
+    useEmbeddingModelStore.getState().loadError,
+    null,
+    "the newer read succeeded, so no error is raised over it",
+  );
+  assert.equal(
+    useEmbeddingModelStore.getState().settings?.embeddingModel,
+    "unsloth/bge-m3",
+  );
+});
+
 test("a failed read reports the backend's reason", async () => {
   reset();
   globalThis.fetch = (async () =>

--- a/studio/frontend/tests/embedding-model-store.test.ts
+++ b/studio/frontend/tests/embedding-model-store.test.ts
@@ -156,14 +156,23 @@ test("an older save cannot land on top of a newer one", async () => {
   const store = useEmbeddingModelStore.getState();
   // General submits, the user switches to Data, and Data submits its own: the
   // second mount carries its own pending flag, so nothing stopped it.
-  const first = store.beginSave();
-  const second = store.beginSave();
+  let releaseFirst = (): void => undefined;
+  const firstGate = new Promise<void>((resolve) => {
+    releaseFirst = () => resolve();
+  });
+  const first = store.save(async () => {
+    await firstGate;
+    return settings("unsloth/bge-small-en-v1.5");
+  });
+  const second = await store.save(async () => settings("unsloth/bge-m3"));
+  respondWith("unsloth/bge-m3");
+  releaseFirst();
 
-  assert.ok(store.applySettings(settings("unsloth/bge-m3"), second));
+  assert.ok(second);
   assert.equal(
-    store.applySettings(settings("unsloth/bge-small-en-v1.5"), first),
+    await first,
     false,
-    "the superseded save reports that it did not stand",
+    "the superseded save reports it did not stand",
   );
   assert.equal(
     useEmbeddingModelStore.getState().settings?.embeddingModel,
@@ -171,14 +180,58 @@ test("an older save cannot land on top of a newer one", async () => {
   );
 });
 
+test("a superseded save is reconciled against the backend", async () => {
+  reset();
+  const store = useEmbeddingModelStore.getState();
+  // The later save fails verification, so the earlier one is the only write
+  // the backend took. Request order said otherwise, so the store re-reads.
+  respondWith("unsloth/bge-m3");
+  let releaseFirst = (): void => undefined;
+  const firstGate = new Promise<void>((resolve) => {
+    releaseFirst = () => resolve();
+  });
+  const first = store.save(async () => {
+    await firstGate;
+    return settings("unsloth/bge-m3");
+  });
+  const second = store
+    .save(async () => {
+      throw new Error("could not verify that model");
+    })
+    .catch(() => false);
+  assert.equal(await second, false);
+  releaseFirst();
+  await first;
+  // The reconciling read is started from the last save to settle.
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  assert.equal(
+    useEmbeddingModelStore.getState().settings?.embeddingModel,
+    "unsloth/bge-m3",
+    "the store ends on what the backend actually holds",
+  );
+});
+
+test("a lone save that fails does not trigger a re-read", async () => {
+  reset();
+  const store = useEmbeddingModelStore.getState();
+  let reads = 0;
+  globalThis.fetch = (async () => {
+    reads += 1;
+    throw new Error("should not be read");
+  }) as typeof fetch;
+  await store
+    .save(async () => {
+      throw new Error("could not verify that model");
+    })
+    .catch(() => undefined);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  assert.equal(reads, 0, "nothing overlapped it, so nothing needs settling");
+});
+
 test("a save still bumps the revision the reads check", async () => {
   reset();
   const store = useEmbeddingModelStore.getState();
-  store.applySettings(settings("unsloth/bge-m3"), store.beginSave());
-  assert.equal(useEmbeddingModelStore.getState().revision, 1);
-  // A superseded save is not a mutation, so it must not move the revision.
-  const stale = store.beginSave();
-  store.beginSave();
-  store.applySettings(settings("unsloth/bge-small-en-v1.5"), stale);
+  store.applySettings(settings("unsloth/bge-m3"));
   assert.equal(useEmbeddingModelStore.getState().revision, 1);
 });

--- a/studio/frontend/tests/embedding-model-store.test.ts
+++ b/studio/frontend/tests/embedding-model-store.test.ts
@@ -150,3 +150,35 @@ test("a failed read reports the backend's reason", async () => {
     "storage is offline",
   );
 });
+
+test("an older save cannot land on top of a newer one", async () => {
+  reset();
+  const store = useEmbeddingModelStore.getState();
+  // General submits, the user switches to Data, and Data submits its own: the
+  // second mount carries its own pending flag, so nothing stopped it.
+  const first = store.beginSave();
+  const second = store.beginSave();
+
+  assert.ok(store.applySettings(settings("unsloth/bge-m3"), second));
+  assert.equal(
+    store.applySettings(settings("unsloth/bge-small-en-v1.5"), first),
+    false,
+    "the superseded save reports that it did not stand",
+  );
+  assert.equal(
+    useEmbeddingModelStore.getState().settings?.embeddingModel,
+    "unsloth/bge-m3",
+  );
+});
+
+test("a save still bumps the revision the reads check", async () => {
+  reset();
+  const store = useEmbeddingModelStore.getState();
+  store.applySettings(settings("unsloth/bge-m3"), store.beginSave());
+  assert.equal(useEmbeddingModelStore.getState().revision, 1);
+  // A superseded save is not a mutation, so it must not move the revision.
+  const stale = store.beginSave();
+  store.beginSave();
+  store.applySettings(settings("unsloth/bge-small-en-v1.5"), stale);
+  assert.equal(useEmbeddingModelStore.getState().revision, 1);
+});

--- a/studio/frontend/tests/embedding-model-store.test.ts
+++ b/studio/frontend/tests/embedding-model-store.test.ts
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import { register } from "node:module";
+import test from "node:test";
+
+// The api module reaches authFetch through the auth barrel, which re-exports
+// login-page.tsx, and the hub barrel, which reads import.meta.env.
+register("./helpers/vite-env-loader.mjs", import.meta.url);
+register("./helpers/settings-api-resolver.mjs", import.meta.url);
+register("./helpers/hub-stub-resolver.mjs", import.meta.url);
+
+const { useEmbeddingModelStore } = await import(
+  "../src/features/settings/stores/embedding-model-store.ts"
+);
+
+type Settings = {
+  embeddingModel: string;
+  embeddingGgufRepo: string;
+  defaultEmbeddingModel: string;
+  defaultEmbeddingGgufRepo: string;
+  isCustom: boolean;
+};
+
+function settings(model: string): Settings {
+  return {
+    embeddingModel: model,
+    embeddingGgufRepo: "",
+    defaultEmbeddingModel: "unsloth/bge-small-en-v1.5",
+    defaultEmbeddingGgufRepo: "",
+    isCustom: model !== "unsloth/bge-small-en-v1.5",
+  };
+}
+
+/** The GET, answering with `model` after `release` resolves. */
+function respondWith(model: string, release?: Promise<void>): void {
+  globalThis.fetch = (async () => {
+    if (release) await release;
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({
+        // biome-ignore lint/style/useNamingConvention: API schema
+        embedding_model: model,
+        // biome-ignore lint/style/useNamingConvention: API schema
+        embedding_gguf_repo: "",
+        // biome-ignore lint/style/useNamingConvention: API schema
+        default_embedding_model: "unsloth/bge-small-en-v1.5",
+        // biome-ignore lint/style/useNamingConvention: API schema
+        default_embedding_gguf_repo: "",
+        // biome-ignore lint/style/useNamingConvention: API schema
+        is_custom: model !== "unsloth/bge-small-en-v1.5",
+      }),
+    } as unknown as Response;
+  }) as typeof fetch;
+}
+
+function reset(): void {
+  useEmbeddingModelStore.setState({
+    settings: null,
+    loadError: null,
+    revision: 0,
+  });
+}
+
+test("a mount reads the setting", async () => {
+  reset();
+  respondWith("unsloth/bge-m3");
+  await useEmbeddingModelStore.getState().load();
+  assert.equal(
+    useEmbeddingModelStore.getState().settings?.embeddingModel,
+    "unsloth/bge-m3",
+  );
+});
+
+test("a save that lands mid-read is not undone by it", async () => {
+  reset();
+  // The other tab's read is in flight, and answers with the OLD model.
+  let release = (): void => undefined;
+  const gate = new Promise<void>((resolve) => {
+    release = () => resolve();
+  });
+  respondWith("unsloth/bge-small-en-v1.5", gate);
+  const reading = useEmbeddingModelStore.getState().load();
+
+  // The save from the tab the user just left commits first.
+  useEmbeddingModelStore.getState().applySettings(settings("unsloth/bge-m3"));
+  release();
+  await reading;
+
+  assert.equal(
+    useEmbeddingModelStore.getState().settings?.embeddingModel,
+    "unsloth/bge-m3",
+    "the saved model stands, not the value the read started before it",
+  );
+});
+
+test("a read that finishes first is still replaced by the save", async () => {
+  reset();
+  respondWith("unsloth/bge-small-en-v1.5");
+  await useEmbeddingModelStore.getState().load();
+  useEmbeddingModelStore.getState().applySettings(settings("unsloth/bge-m3"));
+  assert.equal(
+    useEmbeddingModelStore.getState().settings?.embeddingModel,
+    "unsloth/bge-m3",
+  );
+});
+
+test("a failed read reports the backend's reason", async () => {
+  reset();
+  globalThis.fetch = (async () =>
+    ({
+      ok: false,
+      status: 500,
+      json: async () => ({ detail: "storage is offline" }),
+    }) as unknown as Response) as typeof fetch;
+  await useEmbeddingModelStore.getState().load();
+  assert.equal(
+    useEmbeddingModelStore.getState().loadError,
+    "storage is offline",
+  );
+});

--- a/studio/frontend/tests/helpers/hub-inventory-stub.mjs
+++ b/studio/frontend/tests/helpers/hub-inventory-stub.mjs
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// The hub barrel re-exports .tsx panels, which bare node cannot parse. Only the
+// cache bump is reachable from the settings API, and it does nothing here.
+export function bumpInventoryVersion() {}

--- a/studio/frontend/tests/helpers/hub-stub-resolver.mjs
+++ b/studio/frontend/tests/helpers/hub-stub-resolver.mjs
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// Register AFTER settings-api-resolver so this sees the bare specifier first.
+// See hub-inventory-stub.mjs.
+const STUB = new URL("./hub-inventory-stub.mjs", import.meta.url).href;
+
+export function resolve(specifier, context, next) {
+  if (specifier === "@/features/hub" || /(^|\/)features\/hub$/.test(specifier)) {
+    return next(STUB, context);
+  }
+  return next(specifier, context);
+}


### PR DESCRIPTION
Follow-up to #9514, which merged before this landed.

Review on that PR pointed out that the Documents & RAG section, now rendered by both General and Data, keeps its state per mount. Reproduced: type a model, hit Save, switch tabs before the request finishes. The originating tab unmounts, its `setEmbeddingModel` becomes a no-op, and the tab now on screen keeps showing the model the success toast just said was replaced. It stays wrong until the dialog is reopened.

## Fix

One store for the setting, in `stores/embedding-model-store.ts`. Both surfaces read it, and save and reset write to it, so the mutation lands wherever the user happens to be. A `revision` counter makes read and write ordering explicit:

```ts
load: async () => {
  const revision = get().revision;
  const settings = await loadEmbeddingModelSettings();
  // A save committed while this read was in flight, so the read is stale.
  if (get().revision !== revision) return;
  set({ settings, loadError: null });
}
```

That covers the other half of the race, where the newly mounted tab's GET is answered with the old model just before the save commits.

The component keeps its own draft, but as an override that is null until the user edits, so an untouched field follows the store instead of pinning whatever that mount first read.

## Testing

- New `tests/embedding-model-store.test.ts` drives both orderings, plus the load-failure message. Removing the revision guard fails the mid-read case, so the test tracks the fix rather than the implementation.
- Exercised in a scratch page that mounts the section the way the dialog does (one tab at a time, keyed) against a stub whose save takes 12s:
  - before: after the save committed, the second tab still read `unsloth/bge-small-en-v1.5`.
  - after: the second tab showed the old value while the save was in flight, then flipped to `unsloth/bge-m3` when it committed.
- `npm test` 4429 passing, `npm run typecheck` and `npm run build` clean, eslint on the touched files unchanged from main.
