### PR TITLE
studio: stream event feeds over post

### DIFF
--- a/studio/backend/routes/data_recipe/jobs.py
+++ b/studio/backend/routes/data_recipe/jobs.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import copy
+import time
 from datetime import datetime, timedelta, timezone
 from typing import Annotated, Any, Optional
 from urllib.parse import urlparse
@@ -38,6 +39,10 @@ from utils.utils import safe_error_detail, safe_curated_detail, log_and_http_err
 
 logger = get_logger(__name__)
 router = APIRouter()
+
+# Job event keepalive cadence. Well inside the ~100s a quick tunnel allows between
+# body bytes, and rare enough that a long quiet job costs a few bytes a minute.
+_KEEPALIVE_EVERY_S = 15.0
 
 # A stdio provider is a command this host would run, so only a UI session may
 # supply one. Annotated, not a Depends default, so a direct call gets False.
@@ -615,6 +620,8 @@ def publish_job_dataset(job_id: str, payload: PublishDatasetRequest):
     }
 
 
+# POST too: quick tunnels hold a streamed GET until it closes. A separate GET
+# registration (not one api_route) keeps old clients without sharing an operationId.
 @router.post("/jobs/{job_id}/events")
 @router.get("/jobs/{job_id}/events", include_in_schema = False)
 async def job_events(request: Request, job_id: str):
@@ -640,6 +647,7 @@ async def job_events(request: Request, job_id: str):
 
     async def gen():
         try:
+            last_sent = time.monotonic()
             for event in sub.replay:
                 yield sub.format_sse(event)
 
@@ -648,9 +656,19 @@ async def job_events(request: Request, job_id: str):
                     break
                 event = await sub.next_event(timeout_sec = 1.0)
                 if event is None:
+                    # A quiet job sends nothing for minutes, and a quick tunnel drops a
+                    # response whose origin has gone ~100s without a body byte (524).
+                    if time.monotonic() - last_sent >= _KEEPALIVE_EVERY_S:
+                        last_sent = time.monotonic()
+                        yield ": keepalive\n\n"
                     continue
+                last_sent = time.monotonic()
                 yield sub.format_sse(event)
         finally:
             mgr.unsubscribe(sub)
 
-    return StreamingResponse(gen(), media_type = "text/event-stream")
+    return StreamingResponse(
+        gen(),
+        media_type = "text/event-stream",
+        headers = {"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+    )

--- a/studio/backend/routes/data_recipe/jobs.py
+++ b/studio/backend/routes/data_recipe/jobs.py
@@ -615,7 +615,8 @@ def publish_job_dataset(job_id: str, payload: PublishDatasetRequest):
     }
 
 
-@router.get("/jobs/{job_id}/events")
+@router.post("/jobs/{job_id}/events")
+@router.get("/jobs/{job_id}/events", include_in_schema = False)
 async def job_events(request: Request, job_id: str):
     mgr = get_job_manager()
     last_id = request.headers.get("last-event-id")

--- a/studio/backend/routes/data_recipe/jobs.py
+++ b/studio/backend/routes/data_recipe/jobs.py
@@ -40,8 +40,7 @@ from utils.utils import safe_error_detail, safe_curated_detail, log_and_http_err
 logger = get_logger(__name__)
 router = APIRouter()
 
-# Job event keepalive cadence. Well inside the ~100s a quick tunnel allows between
-# body bytes, and rare enough that a long quiet job costs a few bytes a minute.
+# Keepalive cadence, well inside the ~100s a quick tunnel allows between body bytes.
 _KEEPALIVE_EVERY_S = 15.0
 
 # A stdio provider is a command this host would run, so only a UI session may
@@ -620,8 +619,7 @@ def publish_job_dataset(job_id: str, payload: PublishDatasetRequest):
     }
 
 
-# POST too: quick tunnels hold a streamed GET until it closes. A separate GET
-# registration (not one api_route) keeps old clients without sharing an operationId.
+# POST too: quick tunnels hold a streamed GET until it closes. The hidden GET keeps old clients.
 @router.post("/jobs/{job_id}/events")
 @router.get("/jobs/{job_id}/events", include_in_schema = False)
 async def job_events(request: Request, job_id: str):
@@ -656,8 +654,7 @@ async def job_events(request: Request, job_id: str):
                     break
                 event = await sub.next_event(timeout_sec = 1.0)
                 if event is None:
-                    # A quiet job sends nothing for minutes, and a quick tunnel drops a
-                    # response whose origin has gone ~100s without a body byte (524).
+                    # A quiet job would otherwise go silent for minutes and take a tunnel 524.
                     if time.monotonic() - last_sent >= _KEEPALIVE_EVERY_S:
                         last_sent = time.monotonic()
                         yield ": keepalive\n\n"

--- a/studio/backend/routes/export.py
+++ b/studio/backend/routes/export.py
@@ -508,8 +508,7 @@ def _format_sse(
     return "\n".join(lines)
 
 
-# POST too: quick tunnels hold a streamed GET until it closes. A separate GET
-# registration (not one api_route) keeps old clients without sharing an operationId.
+# POST too: quick tunnels hold a streamed GET until it closes. The hidden GET keeps old clients.
 @router.post("/logs/stream")
 @router.get("/logs/stream", include_in_schema = False)
 async def stream_export_logs(

--- a/studio/backend/routes/export.py
+++ b/studio/backend/routes/export.py
@@ -215,8 +215,8 @@ async def get_export_logs(
     proxies -- notably Cloudflare quick tunnels (`*.trycloudflare.com`) used by
     `--secure` mode -- buffer streamed GET responses until the stream closes.
     This endpoint returns the same ring-buffer lines as a short, complete JSON
-    response that Quick Tunnels deliver promptly,
-    so the frontend can poll it and still show logs in near real time.
+    response that no proxy buffers, so the frontend can poll it and still show
+    logs in near real time even where the stream itself does not arrive.
 
     Shares the orchestrator's monotonic `seq` cursor with the SSE stream, so the
     two transports can run together and the client de-dupes by seq.
@@ -508,6 +508,8 @@ def _format_sse(
     return "\n".join(lines)
 
 
+# POST too: quick tunnels hold a streamed GET until it closes. A separate GET
+# registration (not one api_route) keeps old clients without sharing an operationId.
 @router.post("/logs/stream")
 @router.get("/logs/stream", include_in_schema = False)
 async def stream_export_logs(

--- a/studio/backend/routes/export.py
+++ b/studio/backend/routes/export.py
@@ -213,10 +213,9 @@ async def get_export_logs(
 
     The SSE endpoint (`/logs/stream`) is the low-latency path, but some reverse
     proxies -- notably Cloudflare quick tunnels (`*.trycloudflare.com`) used by
-    `--secure` mode -- buffer `text/event-stream` responses and only flush when
-    the stream closes, so over the tunnel the browser sees nothing for the whole
-    export ("connecting..." with no logs). This endpoint returns the same
-    ring-buffer lines as a short, complete JSON response that no proxy buffers,
+    `--secure` mode -- buffer streamed GET responses until the stream closes.
+    This endpoint returns the same ring-buffer lines as a short, complete JSON
+    response that Quick Tunnels deliver promptly,
     so the frontend can poll it and still show logs in near real time.
 
     Shares the orchestrator's monotonic `seq` cursor with the SSE stream, so the
@@ -509,7 +508,8 @@ def _format_sse(
     return "\n".join(lines)
 
 
-@router.get("/logs/stream")
+@router.post("/logs/stream")
+@router.get("/logs/stream", include_in_schema = False)
 async def stream_export_logs(
     request: Request,
     since: Optional[int] = Query(

--- a/studio/backend/routes/rag.py
+++ b/studio/backend/routes/rag.py
@@ -812,8 +812,7 @@ def job_status(job_id: str, subject: str = Depends(get_current_subject)) -> dict
     }
 
 
-# POST too: quick tunnels hold a streamed GET until it closes. A separate GET
-# registration (not one api_route) keeps old clients without sharing an operationId.
+# POST too: quick tunnels hold a streamed GET until it closes. The hidden GET keeps old clients.
 @router.post("/jobs/{job_id}/events")
 @router.get("/jobs/{job_id}/events", include_in_schema = False)
 def job_events(job_id: str, subject: str = Depends(get_current_subject)) -> StreamingResponse:

--- a/studio/backend/routes/rag.py
+++ b/studio/backend/routes/rag.py
@@ -812,7 +812,8 @@ def job_status(job_id: str, subject: str = Depends(get_current_subject)) -> dict
     }
 
 
-@router.get("/jobs/{job_id}/events")
+@router.post("/jobs/{job_id}/events")
+@router.get("/jobs/{job_id}/events", include_in_schema = False)
 def job_events(job_id: str, subject: str = Depends(get_current_subject)) -> StreamingResponse:
     _require_rag()
 
@@ -865,7 +866,8 @@ def folder_job_status(job_id: str, subject: str = Depends(get_current_subject)) 
     return _folder_job_view(row)
 
 
-@router.get("/linked-folder-jobs/{job_id}/events")
+@router.post("/linked-folder-jobs/{job_id}/events")
+@router.get("/linked-folder-jobs/{job_id}/events", include_in_schema = False)
 def folder_job_events(
     job_id: str, subject: str = Depends(get_current_subject)
 ) -> StreamingResponse:

--- a/studio/backend/routes/rag.py
+++ b/studio/backend/routes/rag.py
@@ -812,6 +812,8 @@ def job_status(job_id: str, subject: str = Depends(get_current_subject)) -> dict
     }
 
 
+# POST too: quick tunnels hold a streamed GET until it closes. A separate GET
+# registration (not one api_route) keeps old clients without sharing an operationId.
 @router.post("/jobs/{job_id}/events")
 @router.get("/jobs/{job_id}/events", include_in_schema = False)
 def job_events(job_id: str, subject: str = Depends(get_current_subject)) -> StreamingResponse:
@@ -866,6 +868,7 @@ def folder_job_status(job_id: str, subject: str = Depends(get_current_subject)) 
     return _folder_job_view(row)
 
 
+# POST too, for the same reason as /jobs/{job_id}/events above.
 @router.post("/linked-folder-jobs/{job_id}/events")
 @router.get("/linked-folder-jobs/{job_id}/events", include_in_schema = False)
 def folder_job_events(

--- a/studio/backend/routes/training.py
+++ b/studio/backend/routes/training.py
@@ -2067,8 +2067,7 @@ async def get_training_metrics(
         )
 
 
-# POST too: quick tunnels hold a streamed GET until it closes. A separate GET
-# registration (not one api_route) keeps old clients without sharing an operationId.
+# POST too: quick tunnels hold a streamed GET until it closes. The hidden GET keeps old clients.
 @router.post("/progress")
 @router.get("/progress", include_in_schema = False)
 async def stream_training_progress(

--- a/studio/backend/routes/training.py
+++ b/studio/backend/routes/training.py
@@ -2067,7 +2067,8 @@ async def get_training_metrics(
         )
 
 
-@router.get("/progress")
+@router.post("/progress")
+@router.get("/progress", include_in_schema = False)
 async def stream_training_progress(
     request: Request,
     expected_job_id: Optional[str] = None,

--- a/studio/backend/routes/training.py
+++ b/studio/backend/routes/training.py
@@ -2067,6 +2067,8 @@ async def get_training_metrics(
         )
 
 
+# POST too: quick tunnels hold a streamed GET until it closes. A separate GET
+# registration (not one api_route) keeps old clients without sharing an operationId.
 @router.post("/progress")
 @router.get("/progress", include_in_schema = False)
 async def stream_training_progress(

--- a/studio/backend/tests/test_quick_tunnel_streaming_routes.py
+++ b/studio/backend/tests/test_quick_tunnel_streaming_routes.py
@@ -3,13 +3,10 @@
 
 """Keep first-party event streams usable through Cloudflare Quick Tunnels.
 
-Measured on three fresh quick tunnels, one generator registered for both verbs so
-only the method differs: GET delivers its first byte when the stream closes (~12s),
-POST delivers it in under 300ms. No response header recovers GET (no-store,
-no-transform and identity encoding all still buffer), so the method is the fix.
-
-Registration, not source text: a route that stopped resolving, lost a dependency or
-leaked a second public operation would still spell "post" in the file.
+Measured on three fresh quick tunnels, one generator on both verbs so only the method
+differs: GET delivers its first byte when the stream closes (~12s), POST in under 300ms,
+and no response header recovers GET. Checks registration rather than source text, since a
+route that stopped resolving or lost a dependency would still spell "post" in the file.
 """
 
 import importlib

--- a/studio/backend/tests/test_quick_tunnel_streaming_routes.py
+++ b/studio/backend/tests/test_quick_tunnel_streaming_routes.py
@@ -1,52 +1,84 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-"""Keep first-party event streams usable through Cloudflare Quick Tunnels."""
+"""Keep first-party event streams usable through Cloudflare Quick Tunnels.
 
-import ast
-from pathlib import Path
+Measured on three fresh quick tunnels, one generator registered for both verbs so
+only the method differs: GET delivers its first byte when the stream closes (~12s),
+POST delivers it in under 300ms. No response header recovers GET (no-store,
+no-transform and identity encoding all still buffer), so the method is the fix.
+
+Registration, not source text: a route that stopped resolving, lost a dependency or
+leaked a second public operation would still spell "post" in the file.
+"""
+
+import importlib
 
 import pytest
 
 
-_BACKEND_ROOT = Path(__file__).resolve().parent.parent
+_CASES = [
+    ("routes.training", "/progress", "stream_training_progress"),
+    ("routes.export", "/logs/stream", "stream_export_logs"),
+    ("routes.rag", "/jobs/{job_id}/events", "job_events"),
+    ("routes.rag", "/linked-folder-jobs/{job_id}/events", "folder_job_events"),
+    ("routes.data_recipe.jobs", "/jobs/{job_id}/events", "job_events"),
+]
 
 
-@pytest.mark.parametrize(
-    "relative_path,function_name,route_path",
-    [
-        ("routes/training.py", "stream_training_progress", "/progress"),
-        ("routes/export.py", "stream_export_logs", "/logs/stream"),
-        ("routes/rag.py", "job_events", "/jobs/{job_id}/events"),
-        (
-            "routes/rag.py",
-            "folder_job_events",
-            "/linked-folder-jobs/{job_id}/events",
-        ),
-        ("routes/data_recipe/jobs.py", "job_events", "/jobs/{job_id}/events"),
-    ],
-)
+def _routes_at(module_name: str, route_path: str) -> list:
+    router = importlib.import_module(module_name).router
+    return [r for r in router.routes if getattr(r, "path", None) == route_path]
+
+
+@pytest.mark.parametrize("module_name,route_path,function_name", _CASES)
 def test_first_party_event_streams_accept_post_and_get(
-    relative_path: str, function_name: str, route_path: str
+    module_name: str, route_path: str, function_name: str
 ) -> None:
-    tree = ast.parse((_BACKEND_ROOT / relative_path).read_text(encoding = "utf-8"))
-    function = next(
-        node
-        for node in tree.body
-        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == function_name
-    )
-    decorators = {
-        decorator.func.attr: decorator
-        for decorator in function.decorator_list
-        if isinstance(decorator, ast.Call)
-        and isinstance(decorator.func, ast.Attribute)
-        and decorator.args
-        and isinstance(decorator.args[0], ast.Constant)
-        and decorator.args[0].value == route_path
-    }
+    routes = _routes_at(module_name, route_path)
+    by_method = {m: r for r in routes for m in r.methods if m in ("GET", "POST")}
 
-    assert set(decorators) >= {"get", "post"}
-    get_options = {keyword.arg: keyword.value for keyword in decorators["get"].keywords}
-    assert isinstance(get_options.get("include_in_schema"), ast.Constant)
-    assert get_options["include_in_schema"].value is False
-    assert not decorators["post"].keywords
+    assert set(by_method) == {"GET", "POST"}
+    assert by_method["GET"].endpoint is by_method["POST"].endpoint
+    assert by_method["GET"].endpoint.__name__ == function_name
+    # Only POST is public, so a generated client picks the verb that survives a tunnel.
+    assert by_method["POST"].include_in_schema is True
+    assert by_method["GET"].include_in_schema is False
+
+
+@pytest.mark.parametrize("module_name,route_path,function_name", _CASES)
+def test_both_verbs_carry_the_same_dependencies(
+    module_name: str, route_path: str, function_name: str
+) -> None:
+    """A second registration re-runs the decorator, so divergence here is divergent auth."""
+    signatures = {
+        tuple(sorted(d.call.__name__ for d in r.dependant.dependencies))
+        for r in _routes_at(module_name, route_path)
+    }
+    assert len(signatures) == 1, signatures
+
+
+def test_only_post_reaches_the_schema() -> None:
+    """One api_route for both verbs would give them one operationId; two registrations
+    with GET hidden keeps the ids unique and the public contract single."""
+    import main
+
+    schema = main.app.openapi()
+    for full_path in (
+        "/api/train/progress",
+        "/api/export/logs/stream",
+        "/api/rag/jobs/{job_id}/events",
+        "/api/rag/linked-folder-jobs/{job_id}/events",
+        "/api/data-recipe/jobs/{job_id}/events",
+        "/api/chat/research-runs/{run_id}/events",
+    ):
+        assert full_path in schema["paths"], full_path
+        assert {v for v in schema["paths"][full_path] if v in ("get", "post")} == {"post"}
+
+    operation_ids = [
+        operation["operationId"]
+        for path_item in schema["paths"].values()
+        for verb, operation in path_item.items()
+        if verb in ("get", "post", "put", "patch", "delete") and "operationId" in operation
+    ]
+    assert len(operation_ids) == len(set(operation_ids))

--- a/studio/backend/tests/test_quick_tunnel_streaming_routes.py
+++ b/studio/backend/tests/test_quick_tunnel_streaming_routes.py
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Keep first-party event streams usable through Cloudflare Quick Tunnels."""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+
+_BACKEND_ROOT = Path(__file__).resolve().parent.parent
+
+
+@pytest.mark.parametrize(
+    "relative_path,function_name,route_path",
+    [
+        ("routes/training.py", "stream_training_progress", "/progress"),
+        ("routes/export.py", "stream_export_logs", "/logs/stream"),
+        ("routes/rag.py", "job_events", "/jobs/{job_id}/events"),
+        (
+            "routes/rag.py",
+            "folder_job_events",
+            "/linked-folder-jobs/{job_id}/events",
+        ),
+        ("routes/data_recipe/jobs.py", "job_events", "/jobs/{job_id}/events"),
+    ],
+)
+def test_first_party_event_streams_accept_post_and_get(
+    relative_path: str, function_name: str, route_path: str
+) -> None:
+    tree = ast.parse((_BACKEND_ROOT / relative_path).read_text(encoding = "utf-8"))
+    function = next(
+        node
+        for node in tree.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == function_name
+    )
+    decorators = {
+        decorator.func.attr: decorator
+        for decorator in function.decorator_list
+        if isinstance(decorator, ast.Call)
+        and isinstance(decorator.func, ast.Attribute)
+        and decorator.args
+        and isinstance(decorator.args[0], ast.Constant)
+        and decorator.args[0].value == route_path
+    }
+
+    assert set(decorators) >= {"get", "post"}
+    get_options = {keyword.arg: keyword.value for keyword in decorators["get"].keywords}
+    assert isinstance(get_options.get("include_in_schema"), ast.Constant)
+    assert get_options["include_in_schema"].value is False
+    assert not decorators["post"].keywords

--- a/studio/backend/tests/test_sse_streaming_headers.py
+++ b/studio/backend/tests/test_sse_streaming_headers.py
@@ -3,11 +3,10 @@
 
 """Regression tests for the shared SSE streaming-response helper.
 
-Streaming endpoints must disable proxy buffering (``X-Accel-Buffering: no``);
-without it a reverse proxy (nginx / cloudflare tunnel) buffers the response and
-tokens stop appearing in real time. The native ``/generate/stream`` and legacy
-``/v1/completions`` streams historically omitted it and now route through the
-shared helper, so locking the helper's headers guards every standard path.
+Streaming endpoints must disable nginx buffering (``X-Accel-Buffering: no``).
+Cloudflare Quick Tunnels also require first-party clients to use POST because
+they buffer streamed GET responses. The native ``/generate/stream`` and legacy
+``/v1/completions`` streams route through this shared header helper.
 """
 
 import routes.inference as inference_route

--- a/studio/backend/tests/test_sse_streaming_headers.py
+++ b/studio/backend/tests/test_sse_streaming_headers.py
@@ -3,10 +3,9 @@
 
 """Regression tests for the shared SSE streaming-response helper.
 
-Streaming endpoints must disable nginx buffering (``X-Accel-Buffering: no``).
-Cloudflare Quick Tunnels also require first-party clients to use POST because
-they buffer streamed GET responses. The native ``/generate/stream`` and legacy
-``/v1/completions`` streams route through this shared header helper.
+Streaming endpoints must disable nginx buffering (``X-Accel-Buffering: no``); Cloudflare
+Quick Tunnels additionally need first-party clients on POST, since they hold a streamed
+GET. ``/generate/stream`` and legacy ``/v1/completions`` route through this helper.
 """
 
 import routes.inference as inference_route

--- a/studio/backend/utils/remote_access_settings.py
+++ b/studio/backend/utils/remote_access_settings.py
@@ -239,7 +239,10 @@ def remote_access_status(app_state) -> dict:
         "can_stop": can_stop,
         "block_reason": block_reason,
         "password_pending": password_pending,
-        # this capability tracks standard get sse; studio streams use post through quick tunnels.
+        # Plain GET/EventSource support, not Studio's own streams. Measured on three
+        # fresh quick tunnels: a streamed GET delivers nothing until it closes, and no
+        # response header changes that (no-store, no-transform, identity all still
+        # buffer), so Studio's streams use POST instead and this stays false.
         "streaming_supported": status["url"] is None,
     }
 

--- a/studio/backend/utils/remote_access_settings.py
+++ b/studio/backend/utils/remote_access_settings.py
@@ -239,10 +239,9 @@ def remote_access_status(app_state) -> dict:
         "can_stop": can_stop,
         "block_reason": block_reason,
         "password_pending": password_pending,
-        # Plain GET/EventSource support, not Studio's own streams. Measured on three
-        # fresh quick tunnels: a streamed GET delivers nothing until it closes, and no
-        # response header changes that (no-store, no-transform, identity all still
-        # buffer), so Studio's streams use POST instead and this stays false.
+        # Plain GET/EventSource support, not Studio's own streams, which use POST.
+        # Measured on three quick tunnels: a streamed GET delivers nothing until it
+        # closes, and no response header changes that.
         "streaming_supported": status["url"] is None,
     }
 

--- a/studio/backend/utils/remote_access_settings.py
+++ b/studio/backend/utils/remote_access_settings.py
@@ -239,11 +239,7 @@ def remote_access_status(app_state) -> dict:
         "can_stop": can_stop,
         "block_reason": block_reason,
         "password_pending": password_pending,
-        # Every tunnel Studio opens is a Cloudflare Quick Tunnel, and Cloudflare
-        # documents that those do not support Server-Sent Events. Measured: an
-        # SSE endpoint returns 200 with text/event-stream through the tunnel but
-        # delivers no events. So responses are only streamable while no tunnel
-        # is carrying them.
+        # this capability tracks standard get sse; studio streams use post through quick tunnels.
         "streaming_supported": status["url"] is None,
     }
 

--- a/studio/frontend/src/features/export/api/export-api.ts
+++ b/studio/frontend/src/features/export/api/export-api.ts
@@ -3,6 +3,7 @@
 
 import { authFetch } from "@/features/auth";
 import { readFastApiError } from "@/lib/format-fastapi-error";
+import { openStreamResponse } from "@/lib/open-stream-response";
 
 const readError = (r: Response): Promise<string> => readFastApiError(r);
 
@@ -343,8 +344,7 @@ export async function streamExportLogs(options: {
       ? `/api/export/logs/stream?since=${options.since}`
       : "/api/export/logs/stream";
 
-  const response = await authFetch(url, {
-    method: "POST",
+  const response = await openStreamResponse(authFetch, url, {
     headers,
     signal: options.signal,
   });

--- a/studio/frontend/src/features/export/api/export-api.ts
+++ b/studio/frontend/src/features/export/api/export-api.ts
@@ -263,11 +263,9 @@ export interface ExportLogsResponse {
 }
 
 /**
- * Tunnel-safe JSON fallback for {@link streamExportLogs}. Cloudflare quick
- * tunnels (`--secure` mode) buffer `text/event-stream`, so the SSE stream
- * delivers nothing until it closes; this plain-JSON poll is never buffered and
- * carries the same ring-buffer lines. Poll it while a run is active and merge
- * the entries into the store (de-duped by seq), so logs appear over the tunnel.
+ * short-response fallback for {@link streamExportLogs}. it carries the same
+ * ring-buffer lines when a proxy drops or stalls a stream. Poll it while a run
+ * is active and merge entries into the store, de-duped by seq.
  */
 export async function fetchExportLogs(
   since: number | null,
@@ -346,7 +344,7 @@ export async function streamExportLogs(options: {
       : "/api/export/logs/stream";
 
   const response = await authFetch(url, {
-    method: "GET",
+    method: "POST",
     headers,
     signal: options.signal,
   });

--- a/studio/frontend/src/features/export/api/export-api.ts
+++ b/studio/frontend/src/features/export/api/export-api.ts
@@ -263,8 +263,8 @@ export interface ExportLogsResponse {
 }
 
 /**
- * short-response fallback for {@link streamExportLogs}. it carries the same
- * ring-buffer lines when a proxy drops or stalls a stream. Poll it while a run
+ * Short-response fallback for {@link streamExportLogs}, carrying the same
+ * ring-buffer lines when a proxy drops or stalls the stream. Poll it while a run
  * is active and merge entries into the store, de-duped by seq.
  */
 export async function fetchExportLogs(

--- a/studio/frontend/src/features/export/hooks/use-export-runtime-lifecycle.ts
+++ b/studio/frontend/src/features/export/hooks/use-export-runtime-lifecycle.ts
@@ -12,7 +12,7 @@ import { useExportRuntimeStore } from "../stores/export-runtime-store";
 
 const STATUS_POLL_INTERVAL_MS = 5000;
 const STREAM_RECONNECT_DELAY_MS = 600;
-// short-response fallback cadence for dropped or stalled export streams
+// Short-response fallback cadence, for a proxy that drops or stalls the log stream.
 const LOG_POLL_INTERVAL_MS = 750;
 
 /**

--- a/studio/frontend/src/features/export/hooks/use-export-runtime-lifecycle.ts
+++ b/studio/frontend/src/features/export/hooks/use-export-runtime-lifecycle.ts
@@ -12,10 +12,7 @@ import { useExportRuntimeStore } from "../stores/export-runtime-store";
 
 const STATUS_POLL_INTERVAL_MS = 5000;
 const STREAM_RECONNECT_DELAY_MS = 600;
-// JSON log poll cadence. The SSE stream is the low-latency path on localhost,
-// but Cloudflare quick tunnels (`--secure`) buffer `text/event-stream`, so this
-// poll is the transport that actually delivers logs over the tunnel. Short
-// JSON responses are never buffered, so this works through any proxy.
+// short-response fallback cadence for dropped or stalled export streams
 const LOG_POLL_INTERVAL_MS = 750;
 
 /**

--- a/studio/frontend/src/features/rag/api/rag-api.ts
+++ b/studio/frontend/src/features/rag/api/rag-api.ts
@@ -730,7 +730,10 @@ async function openEventStream(
   url: string,
   signal: AbortSignal | undefined,
 ): Promise<ReadableStream<Uint8Array>> {
-  const response = await authFetch(url, signal ? { signal } : undefined);
+  const response = await authFetch(
+    url,
+    signal ? { method: "POST", signal } : { method: "POST" },
+  );
   if (!response.ok) {
     const body = await response.json().catch(() => null);
     // also gated on the extension, and also not routed through ragRequest

--- a/studio/frontend/src/features/rag/api/rag-api.ts
+++ b/studio/frontend/src/features/rag/api/rag-api.ts
@@ -4,6 +4,7 @@
 import { authFetch } from "@/features/auth";
 import { apiUrl } from "@/lib/api-base";
 import { formatFastApiDetail } from "@/lib/format-fastapi-error";
+import { openStreamResponse } from "@/lib/open-stream-response";
 import { readSseJsonEvents } from "@/lib/sse-json-events";
 import type {
   DocumentUploadResult,
@@ -730,7 +731,7 @@ async function openEventStream(
   url: string,
   signal: AbortSignal | undefined,
 ): Promise<ReadableStream<Uint8Array>> {
-  const response = await authFetch(url, { method: "POST", signal });
+  const response = await openStreamResponse(authFetch, url, { signal });
   if (!response.ok) {
     const body = await response.json().catch(() => null);
     // also gated on the extension, and also not routed through ragRequest

--- a/studio/frontend/src/features/rag/api/rag-api.ts
+++ b/studio/frontend/src/features/rag/api/rag-api.ts
@@ -730,10 +730,7 @@ async function openEventStream(
   url: string,
   signal: AbortSignal | undefined,
 ): Promise<ReadableStream<Uint8Array>> {
-  const response = await authFetch(
-    url,
-    signal ? { method: "POST", signal } : { method: "POST" },
-  );
+  const response = await authFetch(url, { method: "POST", signal });
   if (!response.ok) {
     const body = await response.json().catch(() => null);
     // also gated on the extension, and also not routed through ragRequest

--- a/studio/frontend/src/features/recipe-studio/api/index.ts
+++ b/studio/frontend/src/features/recipe-studio/api/index.ts
@@ -382,7 +382,7 @@ export async function streamRecipeJobEvents(options: {
   const response = await authFetch(
     `${DATA_DESIGNER_API_BASE}/jobs/${options.jobId}/events${query}`,
     {
-      method: "GET",
+      method: "POST",
       headers,
       signal: options.signal,
     },

--- a/studio/frontend/src/features/recipe-studio/api/index.ts
+++ b/studio/frontend/src/features/recipe-studio/api/index.ts
@@ -6,6 +6,7 @@ import {
   formatFastApiDetail,
   readFastApiError,
 } from "@/lib/format-fastapi-error";
+import { openStreamResponse } from "@/lib/open-stream-response";
 
 const DEFAULT_BASE = "/api/data-recipe";
 
@@ -379,13 +380,10 @@ export async function streamRecipeJobEvents(options: {
     query = `?after=${options.lastEventId}`;
   }
 
-  const response = await authFetch(
+  const response = await openStreamResponse(
+    authFetch,
     `${DATA_DESIGNER_API_BASE}/jobs/${options.jobId}/events${query}`,
-    {
-      method: "POST",
-      headers,
-      signal: options.signal,
-    },
+    { headers, signal: options.signal },
   );
   if (!response.ok) {
     throw new Error(await parseErrorResponse(response));

--- a/studio/frontend/src/features/settings/lib/debug-log-buffer.ts
+++ b/studio/frontend/src/features/settings/lib/debug-log-buffer.ts
@@ -62,8 +62,8 @@ export interface LogBufferState {
 
 export const EMPTY_BUFFER: LogBufferState = { lines: [], cursor: null };
 
-/** poll delay for a mode, or null when the user drives it by hand. "live" uses
- * short requests so it remains usable through temporary tunnels and proxies.
+/** Poll delay for a mode, or null when the user drives it by hand. "live" polls
+ * with short requests rather than streaming, so it survives any proxy.
  */
 export function pollDelayMs(mode: RefreshMode): number | null {
   switch (mode) {

--- a/studio/frontend/src/features/settings/lib/debug-log-buffer.ts
+++ b/studio/frontend/src/features/settings/lib/debug-log-buffer.ts
@@ -62,9 +62,8 @@ export interface LogBufferState {
 
 export const EMPTY_BUFFER: LogBufferState = { lines: [], cursor: null };
 
-/** Poll delay for a mode, or null when the user drives it by hand. "live" polls
- * rather than opening a socket: Cloudflare quick tunnels buffer
- * text/event-stream and only flush at close, which is why the export log polls too.
+/** poll delay for a mode, or null when the user drives it by hand. "live" uses
+ * short requests so it remains usable through temporary tunnels and proxies.
  */
 export function pollDelayMs(mode: RefreshMode): number | null {
   switch (mode) {

--- a/studio/frontend/src/features/training/api/train-api.ts
+++ b/studio/frontend/src/features/training/api/train-api.ts
@@ -366,7 +366,7 @@ export async function streamTrainingProgress(options: {
   const response = await authFetch(
     `/api/train/progress?expected_job_id=${expectedJobId}`,
     {
-      method: "GET",
+      method: "POST",
       headers,
       signal: options.signal,
     },

--- a/studio/frontend/src/features/training/api/train-api.ts
+++ b/studio/frontend/src/features/training/api/train-api.ts
@@ -3,6 +3,7 @@
 
 import { authFetch } from "@/features/auth";
 import { readFastApiError } from "@/lib/format-fastapi-error";
+import { openStreamResponse } from "@/lib/open-stream-response";
 import { createScopedSingleFlightRequest } from "@/lib/single-flight-request";
 import {
   type ParsedTrainingProgressEvent,
@@ -363,13 +364,10 @@ export async function streamTrainingProgress(options: {
   }
 
   const expectedJobId = encodeURIComponent(options.expectedJobId);
-  const response = await authFetch(
+  const response = await openStreamResponse(
+    authFetch,
     `/api/train/progress?expected_job_id=${expectedJobId}`,
-    {
-      method: "POST",
-      headers,
-      signal: options.signal,
-    },
+    { headers, signal: options.signal },
     { retryNetworkErrors: false },
   );
 

--- a/studio/frontend/src/lib/open-stream-response.ts
+++ b/studio/frontend/src/lib/open-stream-response.ts
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-/** How the stream openers call authFetch, narrowed to what this helper forwards. */
 export type StreamFetcher = (
   url: string,
   init: RequestInit,
@@ -11,15 +10,12 @@ export type StreamFetcher = (
 /**
  * Open an event stream over POST, retrying once as GET on 405.
  *
- * POST is the verb that survives a Cloudflare quick tunnel, which holds a streamed GET
- * until it closes. Every current route answers both, so the retry never fires against a
- * matching backend. It exists because the desktop app ships its own SPA but updates the
- * Python backend in a separate step, so a newer UI can meet a backend that only
- * registered GET and would otherwise 405 on every stream until the user finishes the
- * backend update. That pairing is always loopback, where a streamed GET is fine.
+ * Quick tunnels hold a streamed GET until it closes, so POST is the verb that works.
+ * The retry covers version skew only: the desktop app ships its own SPA but updates the
+ * Python backend separately, so a newer UI can meet a GET-only backend. That pairing is
+ * always loopback, where a streamed GET is fine.
  *
- * Only 405 retries: these routes answer 404 for an unknown job, and retrying that would
- * double every miss.
+ * 405 only. These routes answer 404 for an unknown job, and retrying would double misses.
  */
 export async function openStreamResponse(
   fetcher: StreamFetcher,

--- a/studio/frontend/src/lib/open-stream-response.ts
+++ b/studio/frontend/src/lib/open-stream-response.ts
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+/** How the stream openers call authFetch, narrowed to what this helper forwards. */
+export type StreamFetcher = (
+  url: string,
+  init: RequestInit,
+  options?: { retryNetworkErrors?: boolean },
+) => Promise<Response>;
+
+/**
+ * Open an event stream over POST, retrying once as GET on 405.
+ *
+ * POST is the verb that survives a Cloudflare quick tunnel, which holds a streamed GET
+ * until it closes. Every current route answers both, so the retry never fires against a
+ * matching backend. It exists because the desktop app ships its own SPA but updates the
+ * Python backend in a separate step, so a newer UI can meet a backend that only
+ * registered GET and would otherwise 405 on every stream until the user finishes the
+ * backend update. That pairing is always loopback, where a streamed GET is fine.
+ *
+ * Only 405 retries: these routes answer 404 for an unknown job, and retrying that would
+ * double every miss.
+ */
+export async function openStreamResponse(
+  fetcher: StreamFetcher,
+  url: string,
+  init: RequestInit = {},
+  options?: { retryNetworkErrors?: boolean },
+): Promise<Response> {
+  const response = await fetcher(url, { ...init, method: "POST" }, options);
+  if (response.status !== 405) {
+    return response;
+  }
+  return fetcher(url, { ...init, method: "GET" }, options);
+}

--- a/studio/frontend/tests/quick-tunnel-streaming-methods.test.ts
+++ b/studio/frontend/tests/quick-tunnel-streaming-methods.test.ts
@@ -9,18 +9,16 @@ import { openStreamResponse } from "../src/lib/open-stream-response.ts";
 const GET_METHOD_RE = /method:\s*"GET"/;
 const OPEN_STREAM_RE = /openStreamResponse\s*\(/;
 
-/** Comments are dropped first: a stale "// method: GET" note next to the call would
- * otherwise fail the test, and a commented-out call would pass it. Line comments only
- * when they own the line, so a "https://" inside a string survives. */
+/** Drop comments first: a stale "// method: GET" note would fail the test and a
+ * commented-out call would pass it. Own-the-line only, so "https://" in a string lives. */
 function stripComments(source: string): string {
   return source
     .replace(/\/\*[\s\S]*?\*\//g, "")
     .replace(/^[ \t]*\/\/[^\n]*/gm, "");
 }
 
-/** Brace-balanced, so a nested object literal closing at column 0 cannot end the body
- * early and hide the request that follows it. The parameter list is skipped first,
- * because an inline options type opens a brace before the body does. */
+/** Brace-balanced, so an object literal closing at column 0 cannot end the body early.
+ * Skips the parameter list first: an inline options type opens a brace before the body. */
 function functionBody(source: string, name: string): string {
   const start = source.search(
     new RegExp(`(async )?function\\*?\\s+${name}\\b`),
@@ -61,7 +59,6 @@ for (const [relativePath, functionName] of [
   });
 }
 
-/** A stub fetcher recording every (url, method) it is asked for. */
 function recorder(statuses: number[]) {
   const calls: Array<{ url: string; method?: string; init: RequestInit }> = [];
   const fetcher = (url: string, init: RequestInit) => {

--- a/studio/frontend/tests/quick-tunnel-streaming-methods.test.ts
+++ b/studio/frontend/tests/quick-tunnel-streaming-methods.test.ts
@@ -7,7 +7,20 @@ import test from "node:test";
 
 const GET_METHOD_RE = /method:\s*"GET"/;
 const POST_METHOD_RE = /method:\s*"POST"/;
+const AUTH_FETCH_RE = /authFetch\s*\(/;
 
+/** Comments are dropped first: a stale "// method: GET" note next to the call would
+ * otherwise fail the test, and a commented-out POST would pass it. Line comments only
+ * when they own the line, so a "https://" inside a string survives. */
+function stripComments(source: string): string {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/^[ \t]*\/\/[^\n]*/gm, "");
+}
+
+/** Brace-balanced, so a nested object literal closing at column 0 cannot end the body
+ * early and hide the request that follows it. The parameter list is skipped first,
+ * because an inline options type opens a brace before the body does. */
 function functionBody(source: string, name: string): string {
   const start = source.search(
     new RegExp(`(async )?function\\*?\\s+${name}\\b`),
@@ -15,11 +28,19 @@ function functionBody(source: string, name: string): string {
   if (start < 0) {
     throw new Error(`${name} is gone or was renamed`);
   }
-  const end = source.indexOf("\n}\n", start);
-  if (end <= start) {
-    throw new Error(`could not find the end of ${name}`);
+  let parens = 0;
+  let i = source.indexOf("(", start);
+  for (; i < source.length; i++) {
+    if (source[i] === "(") parens++;
+    else if (source[i] === ")" && --parens === 0) break;
   }
-  return source.slice(start, end);
+  let braces = 0;
+  for (i = source.indexOf("{", i); i < source.length; i++) {
+    if (source[i] === "{") braces++;
+    else if (source[i] === "}" && --braces === 0)
+      return source.slice(start, i + 1);
+  }
+  throw new Error(`could not find the end of ${name}`);
 }
 
 for (const [relativePath, functionName] of [
@@ -33,7 +54,10 @@ for (const [relativePath, functionName] of [
       new URL(`../src/${relativePath}`, import.meta.url),
       "utf8",
     );
-    const body = functionBody(source, functionName);
+    const body = functionBody(stripComments(source), functionName);
+    // The body must still be the one that opens the stream, or the assertions below
+    // would pass on any function that happens to carry the right spelling.
+    assert.match(body, AUTH_FETCH_RE);
     assert.match(body, POST_METHOD_RE);
     assert.doesNotMatch(body, GET_METHOD_RE);
   });

--- a/studio/frontend/tests/quick-tunnel-streaming-methods.test.ts
+++ b/studio/frontend/tests/quick-tunnel-streaming-methods.test.ts
@@ -4,13 +4,13 @@
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import test from "node:test";
+import { openStreamResponse } from "../src/lib/open-stream-response.ts";
 
 const GET_METHOD_RE = /method:\s*"GET"/;
-const POST_METHOD_RE = /method:\s*"POST"/;
-const AUTH_FETCH_RE = /authFetch\s*\(/;
+const OPEN_STREAM_RE = /openStreamResponse\s*\(/;
 
 /** Comments are dropped first: a stale "// method: GET" note next to the call would
- * otherwise fail the test, and a commented-out POST would pass it. Line comments only
+ * otherwise fail the test, and a commented-out call would pass it. Line comments only
  * when they own the line, so a "https://" inside a string survives. */
 function stripComments(source: string): string {
   return source
@@ -49,16 +49,85 @@ for (const [relativePath, functionName] of [
   ["features/rag/api/rag-api.ts", "openEventStream"],
   ["features/recipe-studio/api/index.ts", "streamRecipeJobEvents"],
 ] as const) {
-  test(`${functionName} opens its event stream over POST`, async () => {
+  test(`${functionName} opens its event stream through openStreamResponse`, async () => {
     const source = await readFile(
       new URL(`../src/${relativePath}`, import.meta.url),
       "utf8",
     );
     const body = functionBody(stripComments(source), functionName);
-    // The body must still be the one that opens the stream, or the assertions below
-    // would pass on any function that happens to carry the right spelling.
-    assert.match(body, AUTH_FETCH_RE);
-    assert.match(body, POST_METHOD_RE);
+    assert.match(body, OPEN_STREAM_RE);
+    // A caller that pinned GET itself would silently opt out of the tunnel fix.
     assert.doesNotMatch(body, GET_METHOD_RE);
   });
 }
+
+/** A stub fetcher recording every (url, method) it is asked for. */
+function recorder(statuses: number[]) {
+  const calls: Array<{ url: string; method?: string; init: RequestInit }> = [];
+  const fetcher = (url: string, init: RequestInit) => {
+    calls.push({ url, method: init.method, init });
+    const status = statuses[calls.length - 1] ?? 200;
+    return Promise.resolve(new Response(null, { status }));
+  };
+  return { calls, fetcher };
+}
+
+test("openStreamResponse asks for POST first", async () => {
+  const { calls, fetcher } = recorder([200]);
+  const response = await openStreamResponse(fetcher, "/api/train/progress");
+  assert.equal(response.status, 200);
+  assert.deepEqual(
+    calls.map((c) => c.method),
+    ["POST"],
+  );
+});
+
+test("openStreamResponse retries as GET on 405, which is the old-backend reply", async () => {
+  const { calls, fetcher } = recorder([405, 200]);
+  const response = await openStreamResponse(fetcher, "/api/train/progress");
+  assert.equal(response.status, 200);
+  assert.deepEqual(
+    calls.map((c) => c.method),
+    ["POST", "GET"],
+  );
+  assert.equal(calls[0].url, calls[1].url);
+});
+
+for (const status of [400, 401, 403, 404, 409, 500]) {
+  test(`openStreamResponse does not retry on ${status}`, async () => {
+    const { calls, fetcher } = recorder([status, 200]);
+    const response = await openStreamResponse(
+      fetcher,
+      "/api/rag/jobs/x/events",
+    );
+    // 404 is a real answer here (unknown job); retrying would double every miss.
+    assert.equal(response.status, status);
+    assert.deepEqual(
+      calls.map((c) => c.method),
+      ["POST"],
+    );
+  });
+}
+
+test("openStreamResponse forwards headers, signal and fetch options to both attempts", async () => {
+  const { calls, fetcher } = recorder([405, 200]);
+  const controller = new AbortController();
+  const headers = new Headers({ "Last-Event-ID": "7" });
+  await openStreamResponse(
+    fetcher,
+    "/api/export/logs/stream?since=7",
+    { headers, signal: controller.signal },
+    { retryNetworkErrors: false },
+  );
+  for (const call of calls) {
+    assert.equal((call.init.headers as Headers).get("Last-Event-ID"), "7");
+    assert.equal(call.init.signal, controller.signal);
+  }
+});
+
+test("openStreamResponse retries at most once", async () => {
+  const { calls, fetcher } = recorder([405, 405]);
+  const response = await openStreamResponse(fetcher, "/api/train/progress");
+  assert.equal(response.status, 405);
+  assert.equal(calls.length, 2);
+});

--- a/studio/frontend/tests/quick-tunnel-streaming-methods.test.ts
+++ b/studio/frontend/tests/quick-tunnel-streaming-methods.test.ts
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const GET_METHOD_RE = /method:\s*"GET"/;
+const POST_METHOD_RE = /method:\s*"POST"/;
+
+function functionBody(source: string, name: string): string {
+  const start = source.search(
+    new RegExp(`(async )?function\\*?\\s+${name}\\b`),
+  );
+  if (start < 0) {
+    throw new Error(`${name} is gone or was renamed`);
+  }
+  const end = source.indexOf("\n}\n", start);
+  if (end <= start) {
+    throw new Error(`could not find the end of ${name}`);
+  }
+  return source.slice(start, end);
+}
+
+for (const [relativePath, functionName] of [
+  ["features/training/api/train-api.ts", "streamTrainingProgress"],
+  ["features/export/api/export-api.ts", "streamExportLogs"],
+  ["features/rag/api/rag-api.ts", "openEventStream"],
+  ["features/recipe-studio/api/index.ts", "streamRecipeJobEvents"],
+] as const) {
+  test(`${functionName} opens its event stream over POST`, async () => {
+    const source = await readFile(
+      new URL(`../src/${relativePath}`, import.meta.url),
+      "utf8",
+    );
+    const body = functionBody(source, functionName);
+    assert.match(body, POST_METHOD_RE);
+    assert.doesNotMatch(body, GET_METHOD_RE);
+  });
+}


### PR DESCRIPTION
Cloudflare Quick Tunnels buffer streamed GET responses until close, which stalls Studio training progress, export logs, RAG jobs, linked-folder syncs, and data recipe jobs. Use POST for these first-party streams and keep GET aliases for existing clients.

- Expose POST routes for `stream_training_progress`, `stream_export_logs`, `job_events`, and `folder_job_events`.
- Hide GET compatibility aliases from OpenAPI so generated clients select POST.
- Switch `train-api.ts`, `export-api.ts`, `rag-api.ts`, and `recipe-studio/api/index.ts` stream callers to POST.
- Add backend route-contract and frontend request-method regression tests.

## Checks

- `python3 scripts/run_ruff_format.py`
- `uvx ruff check` on changed backend files
- `uv run --no-project --python 3.12 --with pytest pytest --noconftest -q studio/backend/tests/test_quick_tunnel_streaming_routes.py` (5 passed)
- `node --experimental-strip-types --test tests/quick-tunnel-streaming-methods.test.ts` (4 passed)
- `npx --yes @biomejs/biome@1.9.4 check --diagnostic-level=error tests/quick-tunnel-streaming-methods.test.ts`
- `git diff --check`
