### PR TITLE
Give the Studio T4 leg a Kaggle client that can read its own credential

### DIFF
--- a/.github/workflows/kaggle-t4-studio-gpu-ci.yml
+++ b/.github/workflows/kaggle-t4-studio-gpu-ci.yml
@@ -286,7 +286,7 @@ jobs:
           python-version: '3.12'
 
       - name: Install the Kaggle client
-        run: python -m pip install --quiet 'kaggle==1.7.4.5'
+        run: python -m pip install --quiet 'kaggle==2.2.4'
 
       # The gate itself is shared with the notebook leg, unchanged. Only the
       # numbers differ.
@@ -349,7 +349,7 @@ jobs:
           python-version: '3.12'
 
       - name: Install the Kaggle client
-        run: python -m pip install --quiet 'kaggle==1.7.4.5'
+        run: python -m pip install --quiet 'kaggle==2.2.4'
 
       # The ref the kernel clones and tests. For a pull request that is the
       # head SHA, so the kernel exercises the proposed code and not the merge

--- a/tests/kaggle/test_studio_gpu_harness.py
+++ b/tests/kaggle/test_studio_gpu_harness.py
@@ -25,6 +25,7 @@ import importlib.util
 import io
 import json
 import os
+import re
 import subprocess
 import sys
 import tarfile
@@ -2261,3 +2262,32 @@ def test_a_box_without_nvidia_smi_reports_no_gpu_rather_than_crashing(tmp_path, 
     assert module.gpu_inventory() == []
     assert module.nvidia_used_mib() is None
     assert module.nvidia_compute_apps() is None
+
+
+def test_the_kaggle_client_is_new_enough_to_read_the_only_credential_we_have():
+    """A client that cannot read KAGGLE_API_TOKEN makes this workflow report green forever.
+
+    The gate is handed exactly one credential, KAGGLE_API_TOKEN, and nothing in
+    the workflow or under .github/scripts/kaggle_t4_ci writes a kaggle.json. On
+    2.x, authenticate() tries _authenticate_with_access_token() first, which
+    reaches kagglesdk.get_access_token_from_env() and reads that variable. On
+    1.7.4.5 it does not: KAGGLE_API_TOKEN appears only in
+    kagglesdk/kaggle_http_client.py, whose own header says that client "is not
+    currently usable by the CLI", so authenticate() falls through to
+    read_config_file() and raises IOError, which IS OSError on Python 3.
+
+    That error is not loud. gate.py turns any error into a skip unless
+    --no-soft-fail is passed, and a skip exits 0, so the run is green with the
+    GPU job skipped: identical on the surface to the ~95% of invocations the
+    5% sampler declines. Observed on run 32605377065, dispatched with
+    force=true to bypass the sampler, which still reported
+    "could not authenticate to Kaggle: OSError" and a green workflow.
+
+    The notebook leg has carried this guard since it was written; this leg had
+    no equivalent and sat on 1.7.4.5, so it had never authenticated once.
+    """
+    packaging_version = pytest.importorskip("packaging.version")
+    pins = re.findall(r"pip install [^\n]*'kaggle==([0-9][^']*)'", WORKFLOW.read_text(encoding = "utf-8"))
+    assert pins, "no pinned kaggle client in the workflow"
+    assert len(set(pins)) == 1, f"jobs disagree on the kaggle client: {pins}"
+    assert packaging_version.Version(pins[0]) >= packaging_version.Version("2.2.0"), pins[0]

--- a/tests/kaggle/test_studio_gpu_harness.py
+++ b/tests/kaggle/test_studio_gpu_harness.py
@@ -2287,7 +2287,9 @@ def test_the_kaggle_client_is_new_enough_to_read_the_only_credential_we_have():
     no equivalent and sat on 1.7.4.5, so it had never authenticated once.
     """
     packaging_version = pytest.importorskip("packaging.version")
-    pins = re.findall(r"pip install [^\n]*'kaggle==([0-9][^']*)'", WORKFLOW.read_text(encoding = "utf-8"))
+    pins = re.findall(
+        r"pip install [^\n]*'kaggle==([0-9][^']*)'", WORKFLOW.read_text(encoding = "utf-8")
+    )
     assert pins, "no pinned kaggle client in the workflow"
     assert len(set(pins)) == 1, f"jobs disagree on the kaggle client: {pins}"
     assert packaging_version.Version(pins[0]) >= packaging_version.Version("2.2.0"), pins[0]


### PR DESCRIPTION
The Kaggle Studio GPU leg has never run on a T4. Not sampling, not quota: it cannot authenticate, and the failure reports green.

## What happens

The gate is handed exactly one credential, `KAGGLE_API_TOKEN`, and nothing in the workflow or under `.github/scripts/kaggle_t4_ci` writes a `kaggle.json`.

On `kaggle==1.7.4.5`, `authenticate()` cannot read that variable. `KAGGLE_API_TOKEN` appears only in `kagglesdk/kaggle_http_client.py`, whose own header says:

> This was created from kaggle_api_client.py, prior to recent changes to auth handling. The new client requires KAGGLE_API_TOKEN, so it is not currently usable by the CLI.

So `authenticate()` falls through to `read_config_file()` and raises `IOError('Could not find ...')`, which is `OSError` on Python 3.

That error is then swallowed. `gate.py` turns any error into a skip unless `--no-soft-fail` is passed, and a skip exits 0:

```python
errors_are_skips = args.soft_fail is not False
...
msg = f"could not authenticate to Kaggle: {type(exc).__name__}"
if not errors_are_skips:
    return 1
return _decide(False, msg)
```

Neither Kaggle workflow passes `--no-soft-fail`, so the run is green with the GPU job skipped, which looks exactly like the roughly 95 percent of invocations the 5 percent sampler declines.

## Evidence

Dispatched with `force=true` to bypass the sampler, run `32605377065`:

```
[gate] reason=could not authenticate to Kaggle: OSError
[gate] SKIP: could not authenticate to Kaggle: OSError
run=completed/success | gate=success | Studio GPU smoke=skipped
```

Scanning back 500 runs of this workflow, no `Studio GPU smoke` job has ever completed. The few that left `skipped` were cancelled at 0m. The notebook leg, which pins `2.2.4`, ran a real T4 to completion on 2026-08-16 in 11 minutes.

## The fix

Pin `2.2.4`, the version the notebook leg already uses. Its `authenticate()` tries `_authenticate_with_access_token()` first, which reaches `kagglesdk.get_access_token_from_env()`:

```python
access_token = os.environ.get("KAGGLE_API_TOKEN")
if access_token:
    ...
    return (access_token, "KAGGLE_API_TOKEN")
```

Verified by downloading both wheels rather than from memory.

`tests/kaggle/test_t4_smoke_harness.py` has guarded this pin for the notebook leg since it was written, and its docstring already names this exact failure: "authenticate() on 1.7.4.5 refuses KAGGLE_API_TOKEN, the only credential this workflow has, and demands a kaggle.json nothing writes." That guard reads `kaggle-t4-notebook-ci.yml` only. This leg had no equivalent, which is how it sat on 1.7.4.5. This adds the matching guard to `tests/kaggle/test_studio_gpu_harness.py`.

## Verification

`tests/kaggle/test_studio_gpu_harness.py`: 140 passed.

Mutation, reverting the pin to `1.7.4.5`:

| pin | new guard |
|---|---|
| `kaggle==1.7.4.5` | 1 failed |
| `kaggle==2.2.4` | 1 passed |

## Not addressed here

An error-class gate skip still reports green. That is deliberate for pull requests, since an error in the gate says nothing about the code under test, but it does mean a dead credential is invisible until someone dispatches a forced run and reads the gate log. Worth a follow up, and it is a behaviour change to `gate.py` shared by both legs rather than a pin bump, so it does not belong in this one.
