### PR TITLE
Studio: a transient training 409 should not poison the start_request_id

### DIFF
--- a/studio/backend/core/training/training.py
+++ b/studio/backend/core/training/training.py
@@ -1200,9 +1200,7 @@ class TrainingBackend:
             self._prune_start_requests_locked()
             return "reserved", record
 
-    def peek_start_request(
-        self, start_request_id: str
-    ) -> Optional[TrainingStartRequestRecord]:
+    def peek_start_request(self, start_request_id: str) -> Optional[TrainingStartRequestRecord]:
         """The lookup half of reserve_start_request(), with no reservation.
 
         Returns the record a retry of `start_request_id` would replay -- live or

--- a/studio/backend/core/training/training.py
+++ b/studio/backend/core/training/training.py
@@ -1203,10 +1203,9 @@ class TrainingBackend:
     def peek_start_request(self, start_request_id: str) -> Optional[TrainingStartRequestRecord]:
         """The lookup half of reserve_start_request(), with no reservation.
 
-        Returns the record a retry of `start_request_id` would replay -- live or
-        cancellation-tombstoned -- and refreshes the tombstone TTL exactly as the reserve
-        path does, so a retry still keeps a cancellation alive. Returns None when the id
-        is unknown, leaving the caller free to reserve it."""
+        Returns the record a retry would replay (live or cancellation-tombstoned), refreshing
+        the tombstone TTL as the reserve path does so a retry keeps a cancellation alive, or
+        None when the id is unknown and the caller is free to reserve it."""
         with self._lock:
             self._prune_start_cancel_tombstones_locked()
             existing = self._start_requests.get(start_request_id)

--- a/studio/backend/core/training/training.py
+++ b/studio/backend/core/training/training.py
@@ -1200,6 +1200,30 @@ class TrainingBackend:
             self._prune_start_requests_locked()
             return "reserved", record
 
+    def peek_start_request(
+        self, start_request_id: str
+    ) -> Optional[TrainingStartRequestRecord]:
+        """The lookup half of reserve_start_request(), with no reservation.
+
+        Returns the record a retry of `start_request_id` would replay -- live or
+        cancellation-tombstoned -- and refreshes the tombstone TTL exactly as the reserve
+        path does, so a retry still keeps a cancellation alive. Returns None when the id
+        is unknown, leaving the caller free to reserve it."""
+        with self._lock:
+            self._prune_start_cancel_tombstones_locked()
+            existing = self._start_requests.get(start_request_id)
+            if existing is not None:
+                return existing
+            cancelled = self._start_cancel_tombstones.get(start_request_id)
+            if cancelled is None:
+                return None
+            record = cancelled[1]
+            self._start_cancel_tombstones[start_request_id] = (
+                time.monotonic() + _START_CANCEL_TOMBSTONE_TTL_S,
+                record,
+            )
+            return record
+
     def resolve_start_request(
         self,
         start_request_id: str,

--- a/studio/backend/routes/training.py
+++ b/studio/backend/routes/training.py
@@ -1170,11 +1170,10 @@ async def start_training(
         backend = get_training_backend()
         job_id = f"job_{datetime.now().strftime('%Y%m%d_%H%M%S')}_{_uuid.uuid4().hex[:8]}"
         if request.start_request_id:
-            # A retry of an id that already resolved replays its stored outcome, even when the
-            # transient guard below would refuse a NEW start: the caller asked what happened to
-            # THIS start, and "an inference request is in progress" is not that answer. Peeking
-            # also refreshes a cancellation tombstone, so a retried-through-the-guard start can
-            # never outlive the tombstone and go on to spawn the run the user cancelled.
+            # A retry of an id that already resolved replays its stored outcome even when the
+            # guard below would refuse a NEW start: the caller asked what happened to THIS
+            # start. Peeking also refreshes a cancellation tombstone, so a retry cannot outlive
+            # it and go on to spawn the run the user cancelled.
             existing_record = backend.peek_start_request(request.start_request_id)
             if existing_record is not None:
                 return _start_request_response(existing_record)
@@ -1182,10 +1181,8 @@ async def start_training(
         # When Unsloth is driven as an inference API (API-key auth), refuse to start training while
         # a request is in flight: training frees VRAM by unloading the chat model, killing the
         # stream. The UI (session auth) still starts and coexists. Mixed UI+API is not special-cased.
-        # Checked BEFORE reserving start_request_id: this refusal is transient (it clears when the
-        # stream ends), so it must not resolve the caller's idempotency key to "rejected" -- that
-        # record is permanent, and a retry with the same key would replay the stale rejection
-        # forever instead of starting the run.
+        # Checked BEFORE reserving start_request_id: this refusal is transient, so resolving the
+        # idempotency key to "rejected" would make every retry replay a stale rejection forever.
         if via_api_key is True:
             from core.inference.llama_keepwarm import other_inference_request_count
             if (

--- a/studio/backend/routes/training.py
+++ b/studio/backend/routes/training.py
@@ -1169,20 +1169,13 @@ async def start_training(
         logger.info(f"Starting training job with model: {request.model_name}")
         backend = get_training_backend()
         job_id = f"job_{datetime.now().strftime('%Y%m%d_%H%M%S')}_{_uuid.uuid4().hex[:8]}"
-        if request.start_request_id:
-            reservation, record = backend.reserve_start_request(
-                request.start_request_id,
-                job_id,
-            )
-            if reservation == "existing":
-                return _start_request_response(record)
-            if reservation == "conflict":
-                return _start_request_response(record)
-            reserved_start_request_id = request.start_request_id
-
         # When Unsloth is driven as an inference API (API-key auth), refuse to start training while
         # a request is in flight: training frees VRAM by unloading the chat model, killing the
         # stream. The UI (session auth) still starts and coexists. Mixed UI+API is not special-cased.
+        # Checked BEFORE reserving start_request_id: this refusal is transient (it clears when the
+        # stream ends), so it must not resolve the caller's idempotency key to "rejected" -- that
+        # record is permanent, and a retry with the same key would replay the stale rejection
+        # forever instead of starting the run.
         if via_api_key is True:
             from core.inference.llama_keepwarm import other_inference_request_count
             if (
@@ -1196,6 +1189,17 @@ async def start_training(
                         "progress. Wait for it to finish, or start training from the Unsloth UI."
                     ),
                 )
+
+        if request.start_request_id:
+            reservation, record = backend.reserve_start_request(
+                request.start_request_id,
+                job_id,
+            )
+            if reservation == "existing":
+                return _start_request_response(record)
+            if reservation == "conflict":
+                return _start_request_response(record)
+            reserved_start_request_id = request.start_request_id
 
         # No in-process ensure_transformers_version(): worker.py activates it before ML imports.
 

--- a/studio/backend/routes/training.py
+++ b/studio/backend/routes/training.py
@@ -1169,6 +1169,16 @@ async def start_training(
         logger.info(f"Starting training job with model: {request.model_name}")
         backend = get_training_backend()
         job_id = f"job_{datetime.now().strftime('%Y%m%d_%H%M%S')}_{_uuid.uuid4().hex[:8]}"
+        if request.start_request_id:
+            # A retry of an id that already resolved replays its stored outcome, even when the
+            # transient guard below would refuse a NEW start: the caller asked what happened to
+            # THIS start, and "an inference request is in progress" is not that answer. Peeking
+            # also refreshes a cancellation tombstone, so a retried-through-the-guard start can
+            # never outlive the tombstone and go on to spawn the run the user cancelled.
+            existing_record = backend.peek_start_request(request.start_request_id)
+            if existing_record is not None:
+                return _start_request_response(existing_record)
+
         # When Unsloth is driven as an inference API (API-key auth), refuse to start training while
         # a request is in flight: training frees VRAM by unloading the chat model, killing the
         # stream. The UI (session auth) still starts and coexists. Mixed UI+API is not special-cased.

--- a/studio/backend/tests/test_mcp_training_start_guard.py
+++ b/studio/backend/tests/test_mcp_training_start_guard.py
@@ -359,9 +359,6 @@ def test_the_mcp_tool_surfaces_the_409_as_a_tool_error_not_a_dict(monkeypatch):
         asyncio.run(run_tool_body())
     assert excinfo.value.status_code == 409
 
-    # What the MCP client actually receives: an isError tool result, not a
-    # JSON-RPC protocol error, and (mask_error_details defaults False) the
-    # detail text survives.
     from fastmcp.exceptions import ToolError
 
     with pytest.raises(ToolError) as tool_error:

--- a/studio/backend/tests/test_mcp_training_start_guard.py
+++ b/studio/backend/tests/test_mcp_training_start_guard.py
@@ -1,0 +1,336 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""End-to-end coverage for the MCP `start_training` inference guard.
+
+PR #9434 made the MCP tool call POST /training/start with via_api_key = True, so
+an MCP agent can no longer unload the chat model out from under a live stream.
+The PR shipped only a forwarding assertion; these tests drive the real route (and
+the real MCP tool) against a simulated in-flight inference request.
+"""
+
+import asyncio
+import importlib.util
+import threading
+from pathlib import Path
+
+import pytest
+from fastapi import HTTPException
+
+import core.inference.llama_keepwarm as keepwarm
+from core.training.training import TrainingBackend
+from models.training import TrainingStartRequest
+
+
+_BACKEND_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _load_training_route(name: str):
+    spec = importlib.util.spec_from_file_location(
+        name,
+        _BACKEND_ROOT / "routes" / "training.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _config(**overrides):
+    payload = {
+        "model_name": "unsloth/test",
+        "training_type": "LoRA/QLoRA",
+        "format_type": "alpaca",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _arm(monkeypatch, route, *, inflight = 0, video = False):
+    """Point the route at a fresh backend and a controllable inference count."""
+    backend = TrainingBackend()
+    monkeypatch.setattr(route, "get_training_backend", lambda: backend)
+    monkeypatch.setattr(
+        keepwarm,
+        "other_inference_request_count",
+        lambda current_request_counted = True, **_: inflight,
+    )
+    monkeypatch.setattr(route, "_background_video_generation_active", lambda: video)
+    return backend
+
+
+async def _call(route, config):
+    return await route.start_training(
+        TrainingStartRequest.model_validate(config),
+        current_subject = "mcp",
+        via_api_key = True,
+    )
+
+
+# --------------------------------------------------------------------------------------
+# The guard itself
+# --------------------------------------------------------------------------------------
+
+
+def test_live_chat_stream_refuses_the_mcp_start(monkeypatch):
+    route = _load_training_route("training_route_guard_stream_test")
+    _arm(monkeypatch, route, inflight = 1)
+
+    with pytest.raises(HTTPException) as excinfo:
+        asyncio.run(_call(route, _config()))
+
+    assert excinfo.value.status_code == 409
+    assert "inference request is in progress" in excinfo.value.detail
+
+
+def test_background_video_generation_also_refuses_the_mcp_start(monkeypatch):
+    """Wider than the PR title: a background clip blocks MCP training too."""
+    route = _load_training_route("training_route_guard_video_test")
+    _arm(monkeypatch, route, inflight = 0, video = True)
+
+    with pytest.raises(HTTPException) as excinfo:
+        asyncio.run(_call(route, _config()))
+
+    assert excinfo.value.status_code == 409
+
+
+def test_idle_backend_lets_the_mcp_start_through_the_guard(monkeypatch):
+    """No inference in flight: the 409 must not fire (the regression question)."""
+    route = _load_training_route("training_route_guard_idle_test")
+    _arm(monkeypatch, route, inflight = 0)
+
+    with pytest.raises(HTTPException) as excinfo:
+        asyncio.run(_call(route, _config()))
+
+    # Validation past the guard still rejects the fake model, but never with the
+    # guard's 409/"inference request is in progress".
+    assert not (
+        excinfo.value.status_code == 409
+        and "inference request is in progress" in str(excinfo.value.detail)
+    )
+
+
+def test_stream_finishing_then_retrying_starts(monkeypatch):
+    route = _load_training_route("training_route_guard_retry_test")
+    counter = {"n": 1}
+    backend = TrainingBackend()
+    monkeypatch.setattr(route, "get_training_backend", lambda: backend)
+    monkeypatch.setattr(
+        keepwarm,
+        "other_inference_request_count",
+        lambda current_request_counted = True, **_: counter["n"],
+    )
+    monkeypatch.setattr(route, "_background_video_generation_active", lambda: False)
+
+    with pytest.raises(HTTPException) as first:
+        asyncio.run(_call(route, _config()))
+    assert first.value.status_code == 409
+
+    counter["n"] = 0
+    with pytest.raises(HTTPException) as second:
+        asyncio.run(_call(route, _config()))
+    assert "inference request is in progress" not in str(second.value.detail)
+
+
+# --------------------------------------------------------------------------------------
+# Counting boundary cases (does the guard over-count and block valid MCP training?)
+# --------------------------------------------------------------------------------------
+
+
+def test_the_mcp_call_does_not_count_itself():
+    """/mcp is not an inference path, so the MCP request is never tracked."""
+    assert keepwarm._is_inference_path("/mcp") is False
+    assert keepwarm._is_inference_path("/mcp/") is False
+
+
+def test_idle_but_warm_model_counts_as_zero(monkeypatch):
+    monkeypatch.setattr(keepwarm, "_inflight", 0)
+    monkeypatch.setattr(keepwarm, "_pending", 0)
+    assert keepwarm.other_inference_request_count(current_request_counted = False) == 0
+
+
+def test_a_completed_request_is_reaped_by_the_middleware_finally():
+    """A stream that ends (or raises) must not leave the count positive forever."""
+
+    async def drive(explode):
+        async def app(scope, receive, send):
+            await send({"type": "http.response.start", "status": 200})
+            if explode:
+                raise RuntimeError("client vanished mid-stream")
+            await send({"type": "http.response.body", "body": b"", "more_body": False})
+
+        middleware = keepwarm.LlamaKeepWarmMiddleware(app)
+        scope = {
+            "type": "http",
+            "method": "POST",
+            "path": "/v1/chat/completions",
+            "headers": [(b"authorization", b"Bearer sk-unsloth-x")],
+        }
+        try:
+            await middleware(scope, None, lambda message: asyncio.sleep(0))
+        except RuntimeError:
+            pass
+
+    before = keepwarm.other_inference_request_count(current_request_counted = False)
+    asyncio.run(drive(False))
+    assert keepwarm.other_inference_request_count(current_request_counted = False) == before
+    asyncio.run(drive(True))
+    assert keepwarm.other_inference_request_count(current_request_counted = False) == before
+
+
+def test_an_untracked_external_provider_request_does_not_block_training():
+    scope = {}
+    before = keepwarm.other_inference_request_count(current_request_counted = False)
+    keepwarm._note_pending()
+    keepwarm._note_start()
+    assert keepwarm.other_inference_request_count(current_request_counted = False) == before + 1
+    keepwarm.untrack_current_request(scope)
+    assert keepwarm.other_inference_request_count(current_request_counted = False) == before
+
+
+def test_a_pending_waiter_counts_as_active(monkeypatch):
+    """include_pending defaults True, so a queued chat also refuses training."""
+    before = keepwarm.other_inference_request_count(current_request_counted = False)
+    keepwarm._note_pending()
+    try:
+        assert keepwarm.other_inference_request_count(current_request_counted = False) == before + 1
+    finally:
+        keepwarm._note_unpending()
+
+
+# --------------------------------------------------------------------------------------
+# FINDING 1: the 409 poisons a caller-supplied start_request_id
+# --------------------------------------------------------------------------------------
+
+
+def test_a_guard_409_permanently_poisons_the_supplied_start_request_id(monkeypatch):
+    """Transient refusal, permanent record: the retry can never start."""
+    route = _load_training_route("training_route_guard_sticky_test")
+    counter = {"n": 1}
+    backend = TrainingBackend()
+    monkeypatch.setattr(route, "get_training_backend", lambda: backend)
+    monkeypatch.setattr(
+        keepwarm,
+        "other_inference_request_count",
+        lambda current_request_counted = True, **_: counter["n"],
+    )
+    monkeypatch.setattr(route, "_background_video_generation_active", lambda: False)
+
+    config = _config(start_request_id = "agent-retry-1")
+
+    with pytest.raises(HTTPException) as first:
+        asyncio.run(_call(route, config))
+    assert first.value.status_code == 409
+
+    record = backend.get_start_request("agent-retry-1")
+    assert record is not None
+    assert record.state == "rejected"
+
+    # Stream is over. The agent retries with the same idempotency key.
+    counter["n"] = 0
+    response = asyncio.run(_call(route, config))
+
+    # It never re-enters the route: it gets the cached rejection back as an error.
+    assert response.status == "error"
+    assert "inference request is in progress" in (response.error or "")
+
+
+def test_a_fresh_start_request_id_recovers(monkeypatch):
+    """The workaround: a new id per attempt is not poisoned."""
+    route = _load_training_route("training_route_guard_fresh_id_test")
+    counter = {"n": 1}
+    backend = TrainingBackend()
+    monkeypatch.setattr(route, "get_training_backend", lambda: backend)
+    monkeypatch.setattr(
+        keepwarm,
+        "other_inference_request_count",
+        lambda current_request_counted = True, **_: counter["n"],
+    )
+    monkeypatch.setattr(route, "_background_video_generation_active", lambda: False)
+
+    with pytest.raises(HTTPException):
+        asyncio.run(_call(route, _config(start_request_id = "attempt-1")))
+
+    counter["n"] = 0
+    with pytest.raises(HTTPException) as second:
+        asyncio.run(_call(route, _config(start_request_id = "attempt-2")))
+    assert "inference request is in progress" not in str(second.value.detail)
+
+
+# --------------------------------------------------------------------------------------
+# FINDING 2: what the MCP client sees on the 409
+# --------------------------------------------------------------------------------------
+
+
+def test_the_mcp_tool_surfaces_the_409_as_a_tool_error_not_a_dict(monkeypatch):
+    """stop_training/get_training_status return dicts; a refused start raises."""
+    import mcp_server
+    import routes.training as training_routes
+
+    monkeypatch.setattr(
+        training_routes,
+        "get_training_backend",
+        lambda: TrainingBackend(),
+    )
+    monkeypatch.setattr(
+        keepwarm,
+        "other_inference_request_count",
+        lambda current_request_counted = True, **_: 1,
+    )
+    monkeypatch.setattr(
+        training_routes, "_background_video_generation_active", lambda: False
+    )
+
+    server = mcp_server.create_studio_mcp()
+
+    # The tool body raises rather than returning the {"status": ...} dict that
+    # stop_training / get_training_status return.
+    async def run_tool_body():
+        tool = await server._get_tool("start_training")
+        return await tool.fn(config = _config())
+
+    with pytest.raises(HTTPException) as excinfo:
+        asyncio.run(run_tool_body())
+    assert excinfo.value.status_code == 409
+
+    # What the MCP client actually receives: an isError tool result, not a
+    # JSON-RPC protocol error, and (mask_error_details defaults False) the
+    # detail text survives.
+    from fastmcp.exceptions import ToolError
+
+    with pytest.raises(ToolError) as tool_error:
+        asyncio.run(server._call_tool_mcp("start_training", {"config": _config()}))
+
+    # mask_error_details defaults False, so the 409 detail survives to the client
+    # (as the text of an isError CallToolResult, not a JSON-RPC protocol error).
+    assert server._mask_error_details is False
+    assert "inference request is in progress" in str(tool_error.value)
+    assert "Error calling tool 'start_training'" in str(tool_error.value)
+
+
+# --------------------------------------------------------------------------------------
+# Concurrency
+# --------------------------------------------------------------------------------------
+
+
+def test_two_concurrent_mcp_starts_during_a_stream_both_refuse(monkeypatch):
+    route = _load_training_route("training_route_guard_concurrent_test")
+    _arm(monkeypatch, route, inflight = 1)
+
+    async def both():
+        return await asyncio.gather(
+            _call(route, _config()),
+            _call(route, _config()),
+            return_exceptions = True,
+        )
+
+    results = asyncio.run(both())
+    assert all(isinstance(r, HTTPException) and r.status_code == 409 for r in results)
+
+
+def test_guard_path_uses_no_platform_specific_apis():
+    """The guard is pure Python: threading + a counter, no fork/signal/posix."""
+    source = (_BACKEND_ROOT / "routes" / "training.py").read_text(encoding = "utf-8")
+    guard = source[source.index("if via_api_key is True:") :][:800]
+    for banned in ("os.fork", "signal.", "SIGKILL", "winreg", "msvcrt"):
+        assert banned not in guard
+    assert threading is not None

--- a/studio/backend/tests/test_mcp_training_start_guard.py
+++ b/studio/backend/tests/test_mcp_training_start_guard.py
@@ -45,7 +45,13 @@ def _config(**overrides):
     return payload
 
 
-def _arm(monkeypatch, route, *, inflight = 0, video = False):
+def _arm(
+    monkeypatch,
+    route,
+    *,
+    inflight = 0,
+    video = False,
+):
     """Point the route at a fresh backend and a controllable inference count."""
     backend = TrainingBackend()
     monkeypatch.setattr(route, "get_training_backend", lambda: backend)
@@ -274,9 +280,7 @@ def test_the_mcp_tool_surfaces_the_409_as_a_tool_error_not_a_dict(monkeypatch):
         "other_inference_request_count",
         lambda current_request_counted = True, **_: 1,
     )
-    monkeypatch.setattr(
-        training_routes, "_background_video_generation_active", lambda: False
-    )
+    monkeypatch.setattr(training_routes, "_background_video_generation_active", lambda: False)
 
     server = mcp_server.create_studio_mcp()
 

--- a/studio/backend/tests/test_mcp_training_start_guard.py
+++ b/studio/backend/tests/test_mcp_training_start_guard.py
@@ -309,9 +309,7 @@ def test_a_cancelled_start_request_id_replays_and_keeps_its_tombstone(monkeypatc
     assert "inference request is in progress" not in str(response.message)
 
     expires_at, _ = backend._start_cancel_tombstones["agent-cancelled"]
-    assert expires_at > time.monotonic() + (
-        training_module._START_CANCEL_TOMBSTONE_TTL_S / 2
-    )
+    assert expires_at > time.monotonic() + (training_module._START_CANCEL_TOMBSTONE_TTL_S / 2)
 
 
 def test_an_unknown_start_request_id_is_still_refused_without_a_record(monkeypatch):

--- a/studio/backend/tests/test_mcp_training_start_guard.py
+++ b/studio/backend/tests/test_mcp_training_start_guard.py
@@ -202,8 +202,8 @@ def test_a_pending_waiter_counts_as_active(monkeypatch):
 # --------------------------------------------------------------------------------------
 
 
-def test_a_guard_409_permanently_poisons_the_supplied_start_request_id(monkeypatch):
-    """Transient refusal, permanent record: the retry can never start."""
+def test_a_guard_409_does_not_poison_the_supplied_start_request_id(monkeypatch):
+    """The refusal is transient, so it must not resolve the idempotency key."""
     route = _load_training_route("training_route_guard_sticky_test")
     counter = {"n": 1}
     backend = TrainingBackend()
@@ -221,17 +221,15 @@ def test_a_guard_409_permanently_poisons_the_supplied_start_request_id(monkeypat
         asyncio.run(_call(route, config))
     assert first.value.status_code == 409
 
-    record = backend.get_start_request("agent-retry-1")
-    assert record is not None
-    assert record.state == "rejected"
+    # The guard runs before the reservation, so no permanent record is written.
+    assert backend.get_start_request("agent-retry-1") is None
 
-    # Stream is over. The agent retries with the same idempotency key.
+    # Stream is over. The agent retries with the same idempotency key and the
+    # start is admitted (it fails later on the fake model, never on the guard).
     counter["n"] = 0
-    response = asyncio.run(_call(route, config))
-
-    # It never re-enters the route: it gets the cached rejection back as an error.
-    assert response.status == "error"
-    assert "inference request is in progress" in (response.error or "")
+    with pytest.raises(HTTPException) as second:
+        asyncio.run(_call(route, config))
+    assert "inference request is in progress" not in str(second.value.detail)
 
 
 def test_a_fresh_start_request_id_recovers(monkeypatch):

--- a/studio/backend/tests/test_mcp_training_start_guard.py
+++ b/studio/backend/tests/test_mcp_training_start_guard.py
@@ -260,6 +260,73 @@ def test_a_fresh_start_request_id_recovers(monkeypatch):
     assert "inference request is in progress" not in str(second.value.detail)
 
 
+def test_a_resolved_start_request_id_still_replays_under_the_guard(monkeypatch):
+    """The transient guard must not swallow the idempotent replay.
+
+    An agent that retries an ACCEPTED start (its first response was lost) while an
+    unrelated inference request is in flight has to hear "your job is queued", not a
+    fresh 409 telling it the start never happened."""
+    route = _load_training_route("training_route_guard_replay_test")
+    backend = _arm(monkeypatch, route, inflight = 1)
+
+    backend.reserve_start_request("agent-accepted", "job-accepted")
+    backend.resolve_start_request(
+        "agent-accepted",
+        state = "accepted",
+        message = "Training started",
+    )
+
+    response = asyncio.run(_call(route, _config(start_request_id = "agent-accepted")))
+
+    assert response.status == "queued"
+    assert response.job_id == "job-accepted"
+    assert "inference request is in progress" not in str(response.message)
+
+
+def test_a_cancelled_start_request_id_replays_and_keeps_its_tombstone(monkeypatch):
+    """A retry blocked by the guard must still refresh the cancellation tombstone.
+
+    Otherwise the tombstone expires mid-inference and the next retry reserves the id
+    afresh and spawns the very run the user cancelled."""
+    import time
+
+    from core.training import training as training_module
+
+    route = _load_training_route("training_route_guard_tombstone_test")
+    backend = _arm(monkeypatch, route, inflight = 1)
+
+    outcome, cancelled = backend.cancel_start_request("agent-cancelled")
+    assert outcome == "cancelled"
+
+    # Wind the tombstone to the brink of its TTL: without a refresh the next retry
+    # would find nothing and start the job.
+    backend._start_cancel_tombstones["agent-cancelled"] = (time.monotonic() + 0.5, cancelled)
+
+    response = asyncio.run(_call(route, _config(start_request_id = "agent-cancelled")))
+
+    assert response.status == "error"
+    assert response.error_code == training_module._START_CANCELLED_ERROR_CODE
+    assert "inference request is in progress" not in str(response.message)
+
+    expires_at, _ = backend._start_cancel_tombstones["agent-cancelled"]
+    assert expires_at > time.monotonic() + (
+        training_module._START_CANCEL_TOMBSTONE_TTL_S / 2
+    )
+
+
+def test_an_unknown_start_request_id_is_still_refused_without_a_record(monkeypatch):
+    """The replay lookup must not resurrect the poisoning bug this PR exists to fix."""
+    route = _load_training_route("training_route_guard_replay_fresh_test")
+    backend = _arm(monkeypatch, route, inflight = 1)
+
+    with pytest.raises(HTTPException) as excinfo:
+        asyncio.run(_call(route, _config(start_request_id = "agent-never-seen")))
+
+    assert excinfo.value.status_code == 409
+    assert backend.get_start_request("agent-never-seen") is None
+    assert backend.peek_start_request("agent-never-seen") is None
+
+
 # --------------------------------------------------------------------------------------
 # FINDING 2: what the MCP client sees on the 409
 # --------------------------------------------------------------------------------------

--- a/studio/backend/tests/test_training_streaming.py
+++ b/studio/backend/tests/test_training_streaming.py
@@ -469,6 +469,7 @@ def test_streaming_start_happy_path_reaches_backend():
         current_job_id = "job_test",
         is_training_active = lambda: False,
         start_training = _start_training,
+        peek_start_request = lambda request_id: None,
         reserve_start_request = lambda request_id, job_id: ("reserved", start_record),
         resolve_start_request = lambda *args, **kwargs: start_record,
     )


### PR DESCRIPTION
Follow-up to #9434, which is already merged.

#9434 made the MCP `start_training` tool call the training route with `via_api_key = True`, so an MCP agent can no longer unload the chat model out from under a live stream. That part is correct, and I confirmed it end to end rather than from the description: there is no drain on the training start path. `_free_vram_for_training` goes straight through `coordinate_models_for_training` to `unload_model` and on to SIGTERM/SIGKILL of the llama-server subprocess, so before the change an MCP start really did truncate a live SSE response. Contrast the `/unload` route, which explicitly waits on `other_inference_request_count` first. The route now returns 409 instead.

The problem is where the guard sits.

## The bug

The 409 is raised after the `start_request_id` reservation block. It is caught at `routes/training.py:1725`, which calls `_reject_start_request` and resolves the record with `state = "rejected"`. Rejected records have no TTL; they are evicted only once 64 entries accumulate.

So a caller that supplies a stable `start_request_id` has that key permanently poisoned by a refusal that was only ever transient. The retry short-circuits on the existing record and replays the stale rejection as `status = "error"` forever, long after the stream has finished. There is no way to start that run again except with a fresh id.

Every other rejection reason on this path (S3 config, resume validation) is genuinely permanent, so resolving the key was right for those. This one is the first that clears on its own.

## The fix

Move the API-key inference guard above the reservation block, so a transient refusal never resolves the caller's idempotency key. The caller gets the same 409 and can retry with the same id once the stream ends.

The diffusion twin at `routes/training.py:2712` has no reservation block, so it needs no change.

## Tests

Adds `studio/backend/tests/test_mcp_training_start_guard.py`, 14 tests, since #9434 shipped only a forwarding assertion:

- live stream refuses, background video refuses, idle backend admits, stream-finishes-then-retry admits
- the `start_request_id` is not poisoned by a transient refusal, and a fresh id recovers. That first one fails without the route change and is the bug reproduction
- the counter boundary cases, since the opposite risk is refusing when nothing is actually streaming: the MCP call does not count itself (MCP is mounted at `/mcp`, and `_is_inference_path` requires a `/v1/` or `/api/inference/` prefix), an idle but warm model counts zero, completed and exploding streams are reaped by the `finally` in `llama_keepwarm`, an untracked external-provider request does not block, and a queued waiter at the unload gate does count
- the MCP client receives `isError` with the 409 detail intact rather than a protocol error
- two concurrent MCP starts both 409

669 tests pass across `test_mcp_training_start_guard.py`, `test_mcp_server.py`, `test_training_start_idempotency.py`, `test_openai_auto_switch.py`, `test_diffusion_training.py` and `test_active_generations.py`.