### PR TITLE
Require explicit consent before FP8/FP4 llm-compressor install (library only)

### DIFF
--- a/tests/saving/test_llm_compressor_install_consent.py
+++ b/tests/saving/test_llm_compressor_install_consent.py
@@ -1,0 +1,83 @@
+"""Static guards that FP8/FP4 export requires explicit consent before installing llm-compressor (#8904)."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+SAVE_PY = Path(__file__).resolve().parents[2] / "unsloth" / "save.py"
+
+_MERGED_ENTRYPOINTS = (
+    "unsloth_save_pretrained_merged",
+    "unsloth_push_to_hub_merged",
+    "unsloth_generic_save_pretrained_merged",
+    "unsloth_generic_push_to_hub_merged",
+)
+
+
+def _module() -> ast.Module:
+    return ast.parse(SAVE_PY.read_text(encoding = "utf-8"), filename = str(SAVE_PY))
+
+
+def _get_function(name: str) -> ast.FunctionDef:
+    for node in ast.walk(_module()):
+        if isinstance(node, ast.FunctionDef) and node.name == name:
+            return node
+    raise AssertionError(f"Function {name} not found in save.py")
+
+
+def _first_lineno(fn: ast.AST, predicate) -> int | None:
+    lines = [n.lineno for n in ast.walk(fn) if predicate(n) and hasattr(n, "lineno")]
+    return min(lines) if lines else None
+
+
+def test_manual_install_helper_is_exposed() -> None:
+    names = {n.name for n in ast.walk(_module()) if isinstance(n, ast.FunctionDef)}
+    assert "llm_compressor_manual_install_command" in names
+    assert "_llm_compressor_missing_error" in names
+
+
+def test_install_missing_dependencies_parameter_is_declared() -> None:
+    fn = _get_function("install_llm_compressor")
+    arg_names = [a.arg for a in fn.args.args]
+    assert "install_missing_dependencies" in arg_names
+
+
+def test_consent_gate_precedes_subprocess_install() -> None:
+    fn = _get_function("install_llm_compressor")
+    consent_line = _first_lineno(
+        fn,
+        lambda n: isinstance(n, ast.Name) and n.id == "install_missing_dependencies",
+    )
+    assert consent_line is not None, "install_missing_dependencies must gate installation"
+
+    def _is_check_call(n: ast.AST) -> bool:
+        return (
+            isinstance(n, ast.Call)
+            and isinstance(n.func, ast.Attribute)
+            and n.func.attr == "check_call"
+            and isinstance(n.func.value, ast.Name)
+            and n.func.value.id == "subprocess"
+        )
+
+    install_line = _first_lineno(fn, _is_check_call)
+    assert install_line is not None
+    assert consent_line < install_line, "consent must be checked before subprocess.check_call"
+
+
+def test_compressed_export_entrypoints_declare_consent_kwarg() -> None:
+    for name in _MERGED_ENTRYPOINTS:
+        fn = _get_function(name)
+        arg_names = [a.arg for a in fn.args.args]
+        assert "install_missing_dependencies" in arg_names, f"{name} must expose the consent kwarg"
+
+
+def test_compressed_export_forwards_consent_to_helper() -> None:
+    fn = _get_function("_unsloth_save_compressed_tensors")
+    src = ast.get_source_segment(SAVE_PY.read_text(encoding = "utf-8"), fn) or ""
+    assert "install_llm_compressor(install_missing_dependencies" in src
+
+
+def test_arguments_dict_strips_consent_kwarg() -> None:
+    src = SAVE_PY.read_text(encoding = "utf-8")
+    assert src.count('del arguments["install_missing_dependencies"]') >= 4

--- a/tests/saving/test_llm_compressor_install_pin.py
+++ b/tests/saving/test_llm_compressor_install_pin.py
@@ -92,9 +92,20 @@ def test_install_command_uses_pinned_spec_not_bare_name() -> None:
 
 
 def test_optout_env_gate_precedes_subprocess_install() -> None:
+    helper = _get_function("_llm_compressor_autoinstall_disabled")
+    env_line = _first_lineno(
+        helper, lambda n: isinstance(n, ast.Constant) and n.value == _ENV_FLAG
+    )
+    assert env_line is not None, f"{_ENV_FLAG} opt-out must be checked before auto-install"
+
     fn = _get_function("install_llm_compressor")
-    env_line = _first_lineno(fn, lambda n: isinstance(n, ast.Constant) and n.value == _ENV_FLAG)
-    assert env_line is not None, f"{_ENV_FLAG} opt-out must be checked in install_llm_compressor"
+    helper_call_line = _first_lineno(
+        fn,
+        lambda n: isinstance(n, ast.Call)
+        and isinstance(n.func, ast.Name)
+        and n.func.id == "_llm_compressor_autoinstall_disabled",
+    )
+    assert helper_call_line is not None, "install_llm_compressor must consult the opt-out helper"
 
     def _is_check_call(n: ast.AST) -> bool:
         return (
@@ -108,5 +119,5 @@ def test_optout_env_gate_precedes_subprocess_install() -> None:
     install_line = _first_lineno(fn, _is_check_call)
     assert install_line is not None, "expected a subprocess.check_call install in the function"
     assert (
-        env_line < install_line
+        helper_call_line < install_line
     ), "the auto-install opt-out must be evaluated before any package install runs"

--- a/tests/saving/test_llm_compressor_install_pin.py
+++ b/tests/saving/test_llm_compressor_install_pin.py
@@ -93,9 +93,7 @@ def test_install_command_uses_pinned_spec_not_bare_name() -> None:
 
 def test_optout_env_gate_precedes_subprocess_install() -> None:
     helper = _get_function("_llm_compressor_autoinstall_disabled")
-    env_line = _first_lineno(
-        helper, lambda n: isinstance(n, ast.Constant) and n.value == _ENV_FLAG
-    )
+    env_line = _first_lineno(helper, lambda n: isinstance(n, ast.Constant) and n.value == _ENV_FLAG)
     assert env_line is not None, f"{_ENV_FLAG} opt-out must be checked before auto-install"
 
     fn = _get_function("install_llm_compressor")

--- a/unsloth/save.py
+++ b/unsloth/save.py
@@ -1586,11 +1586,52 @@ def _compressed_quantize_pythonpath():
     return pp or None
 
 
-def install_llm_compressor():
-    """Import llm-compressor, installing it on first use for FP8/FP4 export.
+def _llm_compressor_autoinstall_disabled() -> bool:
+    return os.environ.get("UNSLOTH_DISABLE_LLM_COMPRESSOR_AUTOINSTALL", "0").lower() not in (
+        "0",
+        "",
+        "false",
+        "no",
+    )
 
-    Installs a version-pinned llm-compressor, pinning the current torch + transformers so pip does
-    not upgrade them. Set UNSLOTH_DISABLE_LLM_COMPRESSOR_AUTOINSTALL=1 to forbid the auto-install.
+
+def llm_compressor_manual_install_command() -> str:
+    """Return a suggested manual install command for the active interpreter."""
+    return f"uv pip install --python {sys.executable} '{_LLM_COMPRESSOR_SPEC}'"
+
+
+def _llm_compressor_missing_error(*, autoinstall_disabled: bool) -> str:
+    command = llm_compressor_manual_install_command()
+    pin_note = "(pin torch and transformers to your current versions to avoid upgrading them)."
+    if autoinstall_disabled:
+        return (
+            "Unsloth: llm-compressor is required for FP8/FP4 compressed export but is not "
+            "installed, and automatic installation is disabled via "
+            "UNSLOTH_DISABLE_LLM_COMPRESSOR_AUTOINSTALL. Install it manually with:\n"
+            f"    {command}\n"
+            f"{pin_note}"
+        )
+    return (
+        "Unsloth: llm-compressor is required for FP8/FP4 compressed export but is not "
+        "installed. Install it manually with:\n"
+        f"    {command}\n"
+        f"{pin_note}\n"
+        "Or re-run the export with install_missing_dependencies=True to let Unsloth install "
+        "the pinned package into this interpreter."
+    )
+
+
+def install_llm_compressor(install_missing_dependencies: bool = False):
+    """Import llm-compressor for FP8/FP4 export, optionally installing it first.
+
+    By default this does **not** mutate the active environment: if llm-compressor is missing it
+    raises with :func:`llm_compressor_manual_install_command`. Pass
+    ``install_missing_dependencies=True`` to run a version-pinned pip/uv install (pinning the
+    current torch + transformers so they are not upgraded).
+
+    Set ``UNSLOTH_DISABLE_LLM_COMPRESSOR_AUTOINSTALL=1`` to forbid installation even when
+    ``install_missing_dependencies=True`` (locked-down / air-gapped setups).
+
     Returns (oneshot, QuantizationModifier).
     """
     try:
@@ -1600,20 +1641,9 @@ def install_llm_compressor():
     except Exception:
         pass
 
-    # Opt-out for locked-down / air-gapped setups: forbid the auto-install, require a manual one.
-    if os.environ.get("UNSLOTH_DISABLE_LLM_COMPRESSOR_AUTOINSTALL", "0").lower() not in (
-        "0",
-        "",
-        "false",
-        "no",
-    ):
-        raise RuntimeError(
-            "Unsloth: llm-compressor is required for FP8/FP4 compressed export but is not "
-            "installed, and automatic installation is disabled via "
-            "UNSLOTH_DISABLE_LLM_COMPRESSOR_AUTOINSTALL. Install it manually with:\n"
-            f"    uv pip install --python {sys.executable} '{_LLM_COMPRESSOR_SPEC}'\n"
-            "(pin torch and transformers to your current versions to avoid upgrading them)."
-        )
+    autoinstall_disabled = _llm_compressor_autoinstall_disabled()
+    if autoinstall_disabled or not install_missing_dependencies:
+        raise RuntimeError(_llm_compressor_missing_error(autoinstall_disabled = autoinstall_disabled))
 
     print(
         "Unsloth: Installing llm-compressor for FP8/FP4 export "
@@ -2374,6 +2404,7 @@ def unsloth_save_pretrained_merged(
     calibration_dataset = None,
     num_calibration_samples: int = 512,
     max_seq_length: int = 2048,
+    install_missing_dependencies: bool = False,
 ):
     """
     Same as .save_pretrained(...) except 4bit weights are auto
@@ -2385,7 +2416,8 @@ def unsloth_save_pretrained_merged(
     3.  `lora`: Save LoRA adapters with no merging. Useful for HF inference.
     4.  FP8 / FP4 compressed export for vLLM (`fp8`, `mxfp4`, `nvfp4`, `mxfp8`): keeps the
         16bit merge at `save_directory` and writes the quantized checkpoint to
-        `save_directory + "-<fmt>"`.
+        `save_directory + "-<fmt>"`. Requires llm-compressor; pass
+        ``install_missing_dependencies=True`` to install the pinned package on demand.
     """
     if tokenizer is None:
         logger.warning_once(
@@ -2430,6 +2462,7 @@ def unsloth_save_pretrained_merged(
             calibration_dataset = calibration_dataset,
             num_calibration_samples = num_calibration_samples,
             max_seq_length = max_seq_length,
+            install_missing_dependencies = install_missing_dependencies,
             # Forward standard save kwargs to the 16bit merge.
             state_dict = state_dict,
             save_function = save_function,
@@ -2485,6 +2518,7 @@ def unsloth_save_pretrained_merged(
     del arguments["calibration_dataset"]
     del arguments["num_calibration_samples"]
     del arguments["max_seq_length"]
+    del arguments["install_missing_dependencies"]
     unsloth_save_model(**arguments)
     for _ in range(3):
         gc.collect()
@@ -2511,6 +2545,7 @@ def unsloth_push_to_hub_merged(
     calibration_dataset = None,
     num_calibration_samples: int = 512,
     max_seq_length: int = 2048,
+    install_missing_dependencies: bool = False,
 ):
     """
     Same as .push_to_hub(...) except 4bit weights are auto
@@ -2521,6 +2556,7 @@ def unsloth_push_to_hub_merged(
     2.  `4bit`: Merge LoRA into int4 weights. Useful for DPO / HF inference.
     3.  `lora`: Save LoRA adapters with no merging. Useful for HF inference.
     4.  FP8 / FP4 compressed export for vLLM: `fp8`, `mxfp4`, `nvfp4`, `mxfp8`.
+        Pass ``install_missing_dependencies=True`` to install llm-compressor on demand.
     """
     if tokenizer is None:
         logger.warning_once(
@@ -2549,6 +2585,7 @@ def unsloth_push_to_hub_merged(
             calibration_dataset = calibration_dataset,
             num_calibration_samples = num_calibration_samples,
             max_seq_length = max_seq_length,
+            install_missing_dependencies = install_missing_dependencies,
             # Forward standard save kwargs to the 16bit merge.
             use_temp_dir = use_temp_dir,
             max_shard_size = max_shard_size,
@@ -2604,6 +2641,7 @@ def unsloth_push_to_hub_merged(
     del arguments["calibration_dataset"]
     del arguments["num_calibration_samples"]
     del arguments["max_seq_length"]
+    del arguments["install_missing_dependencies"]
     unsloth_save_model(**arguments)
     for _ in range(3):
         gc.collect()
@@ -6443,6 +6481,7 @@ def unsloth_generic_save_pretrained_merged(
     calibration_dataset = None,
     num_calibration_samples: int = 512,
     max_seq_length: int = 2048,
+    install_missing_dependencies: bool = False,
 ):
     """
     Same as .push_to_hub(...) except 4bit weights are auto
@@ -6456,6 +6495,7 @@ def unsloth_generic_save_pretrained_merged(
         `fp8` (dynamic W8A8), `mxfp4`, `nvfp4` (W4A4), `mxfp8`. The LoRA is merged to 16bit at
         `save_directory`, then a quantized checkpoint is written to `save_directory + "-<fmt>"`.
         `nvfp4` needs calibration data (defaults to ultrachat; override with `calibration_dataset`).
+        Pass ``install_missing_dependencies=True`` to install llm-compressor on demand.
     """
     if tokenizer is None:
         logger.warning_once(
@@ -6498,6 +6538,7 @@ def unsloth_generic_save_pretrained_merged(
             calibration_dataset = calibration_dataset,
             num_calibration_samples = num_calibration_samples,
             max_seq_length = max_seq_length,
+            install_missing_dependencies = install_missing_dependencies,
             # Forward standard save kwargs to the 16bit merge.
             state_dict = state_dict,
             save_function = save_function,
@@ -6551,6 +6592,7 @@ def unsloth_generic_save_pretrained_merged(
     del arguments["calibration_dataset"]
     del arguments["num_calibration_samples"]
     del arguments["max_seq_length"]
+    del arguments["install_missing_dependencies"]
     unsloth_generic_save(**arguments)
     for _ in range(3):
         gc.collect()
@@ -6577,6 +6619,7 @@ def unsloth_generic_push_to_hub_merged(
     calibration_dataset = None,
     num_calibration_samples: int = 512,
     max_seq_length: int = 2048,
+    install_missing_dependencies: bool = False,
 ):
     """
     Same as .push_to_hub(...) except 4bit weights are auto
@@ -6587,6 +6630,7 @@ def unsloth_generic_push_to_hub_merged(
     2.  `4bit`: Merge LoRA into int4 weights. Useful for DPO / HF inference.
     3.  `lora`: Save LoRA adapters with no merging. Useful for HF inference.
     4.  FP8 / FP4 compressed export for vLLM: `fp8`, `mxfp4`, `nvfp4`, `mxfp8`.
+        Pass ``install_missing_dependencies=True`` to install llm-compressor on demand.
     """
     if tokenizer is None:
         logger.warning_once(
@@ -6615,6 +6659,7 @@ def unsloth_generic_push_to_hub_merged(
             calibration_dataset = calibration_dataset,
             num_calibration_samples = num_calibration_samples,
             max_seq_length = max_seq_length,
+            install_missing_dependencies = install_missing_dependencies,
             # Forward standard save kwargs to the 16bit merge.
             use_temp_dir = use_temp_dir,
             max_shard_size = max_shard_size,
@@ -6670,6 +6715,7 @@ def unsloth_generic_push_to_hub_merged(
     del arguments["calibration_dataset"]
     del arguments["num_calibration_samples"]
     del arguments["max_seq_length"]
+    del arguments["install_missing_dependencies"]
     unsloth_generic_save(**arguments)
     for _ in range(3):
         gc.collect()
@@ -7192,6 +7238,7 @@ def _unsloth_save_compressed_tensors(
     calibration_dataset = None,
     num_calibration_samples: int = 512,
     max_seq_length: int = 2048,
+    install_missing_dependencies: bool = False,
     **merge_kwargs,
 ):
     """Export an FP8/FP4 compressed-tensors checkpoint via llm-compressor.
@@ -7221,7 +7268,7 @@ def _unsloth_save_compressed_tensors(
     #    it, install the workspace llm-compressor and fail fast past its transformers ceiling.
     _shadow_pythonpath = _compressed_quantize_pythonpath()
     if _shadow_pythonpath is None:
-        install_llm_compressor()
+        install_llm_compressor(install_missing_dependencies = install_missing_dependencies)
         # llm-compressor cannot run under a newer transformers than its ceiling: the quantization
         # subprocess would die with a cryptic ImportError (TORCH_INIT_FUNCTIONS) only AFTER the costly
         # 16bit merge. Detect and fail fast with an actionable message instead.


### PR DESCRIPTION
## Summary

Library-only split of #9405 per maintainer feedback — closes #8904 (Phase 1).

FP8/FP4 compressed export no longer auto-runs pip/uv when `llm-compressor` is missing. Instead it raises an actionable error with the pinned install command. Callers that want the previous behavior pass `install_missing_dependencies=True`.

- `install_llm_compressor(install_missing_dependencies=False)` — default is fail-with-instructions
- `llm_compressor_manual_install_command()` — helper for Studio/UI to show the exact command
- Threaded through `_unsloth_save_compressed_tensors` and all four `*_save_*_merged` entry points
- `UNSLOTH_DISABLE_LLM_COMPRESSOR_AUTOINSTALL=1` still hard-blocks even when `install_missing_dependencies=True`

**Not included (Phase 2 follow-up):** Studio probe endpoint, consent dialog, store, and hook — those stay in a separate PR.

## Test plan

- [x] `pytest tests/saving/test_llm_compressor_install_pin.py tests/saving/test_llm_compressor_install_consent.py` (11 passed)

## Follow-up (Phase 2)

Studio consent dialog before compressed export + similar treatment for the llm-compressor-main shadow provision path (#9405 Studio changes).