### PR TITLE
Extract the rollback helpers' own dependencies in the PowerShell lifecycle test

### DIFF
--- a/tests/studio/test_install_rollback_lifecycle.ps1
+++ b/tests/studio/test_install_rollback_lifecycle.ps1
@@ -12,6 +12,8 @@ $tokens = $null; $errors = $null
 $ast = [System.Management.Automation.Language.Parser]::ParseFile($installPath, [ref]$tokens, [ref]$errors)
 if ($errors) { $errors | ForEach-Object { $_.ToString() }; throw "install.ps1 has parse errors" }
 
+# The helpers under test. Anything they call is pulled in below, so a helper that
+# gains a dependency does not have to be added here by hand.
 $helperNames = @(
     "Start-StudioVenvRollback",
     "Remove-StudioVenvTreeWithRetry",
@@ -20,13 +22,44 @@ $helperNames = @(
     "Restore-StudioVenvRollback",
     "Complete-StudioVenvRollback"
 )
-foreach ($name in $helperNames) {
-    $fn = $ast.FindAll({ param($node)
-        $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and $node.Name -eq $name
-    }, $true)
-    if ($fn.Count -ne 1) { throw "expected exactly one $name in install.ps1, found $($fn.Count)" }
-    Invoke-Expression $fn[0].Extent.Text
+
+# install.ps1 nests these inside Install-UnslothStudio, so at runtime PowerShell's
+# dynamic scoping hands each one its siblings. An extracted function has no such
+# frame, so extract its callees too or the first call dies with "term not
+# recognized" (#9501 added Test-StudioPathPresent and hit exactly that).
+$defs = @{}
+foreach ($fn in $ast.FindAll({ param($node)
+    $node -is [System.Management.Automation.Language.FunctionDefinitionAst]
+}, $true)) {
+    if (-not $defs.ContainsKey($fn.Name)) { $defs[$fn.Name] = @() }
+    $defs[$fn.Name] += $fn
 }
+
+# Output sinks this file stubs below. Extracting install.ps1's real ones would leave
+# which definition wins depending on the order of this file.
+$stubbedHere = @("substep", "Write-StudioLine")
+
+$needed = [System.Collections.Generic.List[string]]::new()
+$queue = [System.Collections.Generic.Queue[string]]::new()
+foreach ($name in $helperNames) { $queue.Enqueue($name) }
+while ($queue.Count -gt 0) {
+    $name = $queue.Dequeue()
+    if ($needed.Contains($name)) { continue }
+    if (-not $defs.ContainsKey($name)) { throw "install.ps1 does not define $name" }
+    if ($defs[$name].Count -ne 1) {
+        throw "expected exactly one $name in install.ps1, found $($defs[$name].Count)"
+    }
+    $needed.Add($name)
+    foreach ($call in $defs[$name][0].FindAll({ param($node)
+        $node -is [System.Management.Automation.Language.CommandAst]
+    }, $true)) {
+        $called = $call.GetCommandName()
+        if ($called -and $defs.ContainsKey($called) -and $stubbedHere -notcontains $called) {
+            $queue.Enqueue($called)
+        }
+    }
+}
+foreach ($name in $needed) { Invoke-Expression $defs[$name][0].Extent.Text }
 
 function substep { param([string]$Message, [string]$Color) }
 # The rollback helpers report through install.ps1's UTF-8 stdout sink on their warn


### PR DESCRIPTION
`parity (windows-latest)` has been failing on main since #9501, on every PR and on main itself:

```
Test-StudioPathPresent:
Line |
   9 |  if (Test-StudioPathPresent -Path $backup) {
     |      ~~~~~~~~~~~~~~~~~~~~~~
The term 'Test-StudioPathPresent' is not recognized as a name of a cmdlet, function,
script file, or executable program.
```

## Why

`install.ps1` nests the venv rollback helpers inside `Install-UnslothStudio`, so at runtime PowerShell's dynamic scoping hands each one its siblings. `tests/studio/test_install_rollback_lifecycle.ps1` AST-extracts them and runs them standalone, deliberately never executing the installer, so that frame does not exist. It extracted them from a hand-maintained list of six names.

#9501 added `Test-StudioPathPresent` and called it from `Restore-StudioVenvRollback` and `Complete-StudioVenvRollback`, but the name was not added to that list, so the callee was never defined in the test session.

## Which side is wrong

Resolving the scopes with the PowerShell AST, all seven helpers are nested inside `Install-UnslothStudio`, and the new one sits at line 4018 immediately before the other six at 4024 onward:

| helper | line | enclosing |
| --- | --- | --- |
| `Test-StudioPathPresent` | 4018 | `Install-UnslothStudio` |
| `Start-StudioVenvRollback` | 4024 | `Install-UnslothStudio` |
| `Remove-StudioVenvTreeWithRetry` | 4073 | `Install-UnslothStudio` |
| `Test-StudioVenvRollbackMustBePreserved` | 4093 | `Install-UnslothStudio` |
| `Remove-StaleStudioVenvRollbacks` | 4105 | `Install-UnslothStudio` |
| `Restore-StudioVenvRollback` | 4179 | `Install-UnslothStudio` |
| `Complete-StudioVenvRollback` | 4230 | `Install-UnslothStudio` |

So #9501 is right: the helper follows the established placement exactly, and the installer works. The test is what does not hold, because a hand-maintained extraction list silently breaks whenever a helper gains a dependency. Adding the one name would have unblocked CI today and left the same trap for the next helper, so this fixes the mechanism instead.

## The change

The test now walks each helper's AST for the functions it calls and extracts those transitively, so a new dependency no longer has to be registered by hand. On today's tree that pulls in `Test-StudioPathPresent` and `Merge-StudioVenvRollbackTree` beyond the six seeds. `substep` and `Write-StudioLine`, which the file deliberately stubs, are excluded, so which definition wins no longer depends on the order of the file.

## Verification

On the merge base, with `pwsh`:

- old test: fails with `The term 'Test-StudioPathPresent' is not recognized`
- new test: `All checks passed`

And to show the hardening is real rather than a one-off patch, I injected a sibling helper called from `Restore-StudioVenvRollback`, mimicking the next occurrence of this class:

- old test: still fails
- new test: `All checks passed`

`tests/sh/test_install_rollback_lifecycle.sh`, the POSIX sibling that runs on the ubuntu leg, is unaffected and still reports 19 passed, 0 failed. No other file asserts on this test's contents.

Note for later: about fifteen other `tests/studio/*.ps1` files extract functions from `install.ps1` or `setup.ps1` the same way, several with hardcoded name lists, so they carry the same latent trap. None is failing today, so I have left them alone rather than widen an unblocking fix.