### PR TITLE
studio: show lm studio model names in chat

### DIFF
--- a/studio/backend/tests/test_health_answers_within_probe_budget.py
+++ b/studio/backend/tests/test_health_answers_within_probe_budget.py
@@ -560,9 +560,9 @@ def test_a_cold_health_call_answers_inside_the_launcher_deadline():
     probe_timeout = _desktop_probe_timeout_s()
     result = _probe(_SLOW_DETECT_S)
 
-    assert result["cold_hardware_detecting"] is True, (
-        "the cold call got a settled reply, so it never exercised the wait this bound is about"
-    )
+    assert (
+        result["cold_hardware_detecting"] is True
+    ), "the cold call got a settled reply, so it never exercised the wait this bound is about"
     assert result["cold_elapsed"] < probe_timeout, (
         f"the first /api/health call took {result['cold_elapsed']:.2f}s, past the "
         f"{probe_timeout}s the desktop probe allows before it gives up and dead-ends "

--- a/studio/frontend/src/features/chat/local-model-options.ts
+++ b/studio/frontend/src/features/chat/local-model-options.ts
@@ -51,10 +51,7 @@ export function chatLocalModelOptions(
     seen.add(model.id);
     options.push({
       id: model.id,
-      name:
-        model.source === "lmstudio" && model.model_id
-          ? model.model_id
-          : model.display_name,
+      name: model.display_name,
       baseModel: baseModelLabel(model.source),
       updatedAt: model.updated_at ?? undefined,
       source: "local" as const,

--- a/studio/frontend/src/features/model-picker/components/model-selector.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector.tsx
@@ -50,6 +50,7 @@ import type { CommunityModelPolicy } from "./model-selector/audio-picker-policy"
 import type { CatalogGroup } from "./model-selector/model-catalog";
 import { HubModelPicker, hasDownloadedModels } from "./model-selector/pickers";
 import { PillTabs } from "./model-selector/pill-tabs";
+import { loraOptionLabel } from "./model-selector/row-meta";
 import { isFineTunedSource } from "./model-selector/source-tabs";
 import type {
   DeletedModelRef,
@@ -693,10 +694,7 @@ export function ModelSelector({
       all.set(model.id, model);
     }
     for (const lora of loraModels) {
-      // Strip "/ suffix" from display name (e.g. "foo_123/foo" → "foo_123")
-      const displayName = lora.name.includes("/")
-        ? lora.name.split("/")[0].trim()
-        : lora.name;
+      const displayName = loraOptionLabel(lora);
       // Show type tag instead of base model name
       const isLocal = lora.source === "local";
       const isTraining = lora.source === "training";

--- a/studio/frontend/src/features/model-picker/components/model-selector/row-meta.ts
+++ b/studio/frontend/src/features/model-picker/components/model-selector/row-meta.ts
@@ -1,8 +1,11 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-// Pure helpers for model-row presentation: owner/name split, format pills,
-// param chip, tabular size. No React/DOM deps so they stay easy to test.
+// Pure helpers for model-row presentation: owner/name split, lora trigger
+// label, format pills, param chip, tabular size. No React/DOM deps so they
+// stay easy to test.
+
+import type { LoraModelOption } from "./types";
 
 export type FormatTone = "gguf" | "mlx" | "checkpoint" | "adapter";
 
@@ -38,6 +41,18 @@ export function splitRepoLabel(label: string): {
 export function isUnslothOwner(owner: string | null | undefined): boolean {
   const normalized = owner?.toLowerCase();
   return normalized === "unsloth" || normalized === "unslothai";
+}
+
+/** Selector trigger label. Training and exported runs are named "<run>/<model>"
+ *  ("foo_123/foo"), so the run is the label; local inventory rows keep theirs,
+ *  since an Ollama repo name carries real slashes ("hf.co/unsloth/...:Q4_K_M"). */
+export function loraOptionLabel(
+  option: Pick<LoraModelOption, "name" | "source">,
+): string {
+  if (option.source === "local" || !option.name.includes("/")) {
+    return option.name;
+  }
+  return option.name.split("/")[0].trim();
 }
 
 export type MetaToken =

--- a/studio/frontend/tests/chat-local-model-options.test.ts
+++ b/studio/frontend/tests/chat-local-model-options.test.ts
@@ -78,16 +78,18 @@ test("hf_cache rows stay out of the local list", () => {
   assert.deepEqual(chatLocalModelOptions([row({ source: "hf_cache" })]), []);
 });
 
-test("LM Studio rows prefer the model id and keep their label", () => {
+test("LM Studio rows use the model name without the publisher folder", () => {
+  const modelPath = "N:\\AI Models\\Qwen\\Qwen3.6-40B-Deck-Opus";
   const options = chatLocalModelOptions([
     row({
-      id: "/lm/x",
+      id: modelPath,
       source: "lmstudio",
-      model_id: "publisher/model",
-      display_name: "x",
+      model_id: "Qwen/Qwen3.6-40B-Deck-Opus",
+      display_name: "Qwen3.6-40B-Deck-Opus",
     }),
   ]);
-  assert.equal(options[0]?.name, "publisher/model");
+  assert.equal(options[0]?.id, modelPath);
+  assert.equal(options[0]?.name, "Qwen3.6-40B-Deck-Opus");
   assert.equal(options[0]?.baseModel, "LM Studio");
 });
 

--- a/studio/frontend/tests/model-selector-trigger-label.test.ts
+++ b/studio/frontend/tests/model-selector-trigger-label.test.ts
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// The selector trigger names a lora by the segment before its first slash, so the
+// training run shows rather than "<run>/<model>". Local inventory names carry real
+// slashes, so the same strip left an Ollama row reading "hf.co". Pinned end to end:
+// what Chat feeds the selector, and what the trigger then renders.
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { registerBundlerResolver } from "./helpers/kit.ts";
+
+registerBundlerResolver();
+
+const { chatLocalModelOptions } = await import(
+  "../src/features/chat/local-model-options.ts"
+);
+
+const { loraOptionLabel } = await import(
+  "../src/features/model-picker/components/model-selector/row-meta.ts"
+);
+
+function localRow(over: Record<string, unknown> = {}) {
+  return {
+    id: "/models/demo",
+    // biome-ignore lint/style/useNamingConvention: API schema
+    display_name: "demo",
+    path: "/models/demo",
+    source: "models_dir",
+    ...over,
+  } as never;
+}
+
+test("a training or exported run is still named by its run prefix", () => {
+  assert.equal(
+    loraOptionLabel({ name: "foo_123/foo", source: "training" }),
+    "foo_123",
+  );
+  assert.equal(
+    loraOptionLabel({ name: "foo_123/foo", source: "exported" }),
+    "foo_123",
+  );
+  assert.equal(
+    loraOptionLabel({ name: "foo_123", source: "training" }),
+    "foo_123",
+  );
+});
+
+test("an LM Studio pick shows the model folder, not the publisher", () => {
+  const options = chatLocalModelOptions([
+    localRow({
+      id: "N:\\AI Models\\Qwen\\Qwen3.6-40B-Deck-Opus",
+      source: "lmstudio",
+      // biome-ignore lint/style/useNamingConvention: API schema
+      model_id: "Qwen/Qwen3.6-40B-Deck-Opus",
+      // biome-ignore lint/style/useNamingConvention: API schema
+      display_name: "Qwen3.6-40B-Deck-Opus",
+    }),
+  ]);
+  const option = options[0];
+  assert.ok(option);
+  assert.equal(loraOptionLabel(option), "Qwen3.6-40B-Deck-Opus");
+});
+
+test("an Ollama pick keeps the slashes in its repo name", () => {
+  // ollama pull hf.co/unsloth/Qwen3-8B-GGUF:Q4_K_M; repo_name keeps its host and
+  // namespace for anything outside registry.ollama.ai/library.
+  const options = chatLocalModelOptions([
+    localRow({
+      id: "ollama-manifest:%2Fhome%2Fu%2F.ollama%2Fmanifests%2Fhf.co%2Funsloth",
+      source: "ollama",
+      // biome-ignore lint/style/useNamingConvention: API schema
+      model_format: "gguf",
+      // biome-ignore lint/style/useNamingConvention: API schema
+      display_name: "hf.co/unsloth/Qwen3-8B-GGUF:Q4_K_M (qwen3 Q4_K_M)",
+    }),
+  ]);
+  const option = options[0];
+  assert.ok(option);
+  assert.equal(
+    loraOptionLabel(option),
+    "hf.co/unsloth/Qwen3-8B-GGUF:Q4_K_M (qwen3 Q4_K_M)",
+  );
+
+  const namespaced = chatLocalModelOptions([
+    localRow({
+      id: "ollama-manifest:%2Fhome%2Fu%2F.ollama%2Fmanifests%2Fsomeuser",
+      source: "ollama",
+      // biome-ignore lint/style/useNamingConvention: API schema
+      model_format: "gguf",
+      // biome-ignore lint/style/useNamingConvention: API schema
+      display_name: "someuser/mymodel:latest",
+    }),
+  ])[0];
+  assert.ok(namespaced);
+  assert.equal(loraOptionLabel(namespaced), "someuser/mymodel:latest");
+});


### PR DESCRIPTION
Related to #9548. Left open rather than auto-closed: the reporter asked for the GGUF's internal metadata name, and this ships the leaf directory name instead, which is the label LM Studio itself shows.

Two changes, one of them an intentional presentation change rather than a pure bugfix.

**Trigger label no longer truncates local model names.** `ModelSelector` named every lora option by the segment before its first slash, which is right for a training run (`foo_123/foo` -> `foo_123`) and wrong for local inventory rows whose names carry real slashes. That strip now lives in `loraOptionLabel` (`model-selector/row-meta.ts`) and is scoped to `lora.source !== "local"`. `chat-page.tsx` builds `loraModels` as `[...fromLoras, ...localModels]`, so only training and exported rows were ever meant to be truncated.

This fixes Ollama as well as LM Studio. `display_name` is `f"{repo_name}:{tag}"` and `repo_name` keeps its host and namespace for anything outside `registry.ollama.ai/library` (`_ollama_model_info_from_manifest` in `studio/backend/hub/services/models/ollama.py`), so a model pulled with `ollama pull hf.co/unsloth/Qwen3-8B-GGUF:Q4_K_M` rendered as `hf.co`, and `someuser/mymodel:latest` as `someuser`.

**Chat now labels LM Studio rows by `display_name`, dropping the publisher folder.** This is deliberate, and it reverses part of #4653. `chatLocalModelOptions` used `model_id` (`publisher/model`) for LM Studio rows; it now uses `display_name`, the leaf directory name. The publisher leaves Chat except for the hover tooltip, and two publishers sharing a folder name read the same in the list. Hub already labels LM Studio rows by `display_name` and carries the source in a separate `owner` field (`view-models.ts:54-72,272`), so Chat matches it.

![LM Studio model name before and after](https://raw.githubusercontent.com/mahiatlinux/unsloth/pr-assets-studio-lmstudio-model-name/pr9548_before_after.png)

## Checks
- `node --experimental-strip-types --test tests/model-selector-trigger-label.test.ts tests/chat-local-model-options.test.ts tests/model-row-owner.test.ts tests/sole-quant-row-state.test.ts tests/model-picker-variant-presentation.test.ts` (28 passed)
- `npm test` (5137/5140; the 3 failures are `remend-complete-markdown.test.ts` pinning remend 1.3.1 against a borrowed 1.3.0 `node_modules`, unrelated to this change)
- `npm run typecheck` clean
- mutation-checked the new test: dropping the `source === "local"` scope fails the Ollama case, restoring the `model_id` label fails the LM Studio case, and removing the strip entirely fails the training-run case
- isolated Studio base/head UI: `Qwen` -> `Qwen3.6-40B-Deck-Opus`
