### PR TITLE
docs: remove duplicate Search bullet and fix error messages

### DIFF
--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -1054,7 +1054,7 @@ class FastBaseModel:
         if is_vlm_config and fast_inference:
             if not any(arch in VLLM_SUPPORTED_VLM for arch in model_types):
                 raise RuntimeError(
-                    f"Unsloth: Fast inference is only supported for Language models and Qwen2.5-VL, Gemma3 among vision models. "
+                    f"Unsloth: Fast inference is only supported for Language models and Qwen2.5-VL, Qwen3-VL, Gemma3, Mistral3 among vision models. "
                     f"Found architectures: {', '.join(model_types)}!"
                 )
 


### PR DESCRIPTION
## Description

This PR fixes three minor issues:

1. **README.md**: Remove duplicate 'Search & RAG' bullet point (line 80 was a duplicate of line 78)
2. **chat_templates.py**: Remove two redundant pass statements
3. **vision.py**: Update error message to include Qwen3-VL and Mistral3 in the list of supported VLM models

## Changes

- README.md: Removed duplicate line * **Search:** Use private and unlimited web search, deep research, and RAG.
- unsloth/chat_templates.py: Removed two unnecessary pass statements at lines 2071 and 2078
- unsloth/models/vision.py: Updated error message to list all supported VLM architectures

## Testing

These are documentation and code style fixes that don't change functionality. The error message update ensures users see the correct list of supported models.