### PR TITLE
Studio: defer off-screen code fence highlighting by default

### DIFF
--- a/studio/frontend/smoke-heavy-thread-main.tsx
+++ b/studio/frontend/smoke-heavy-thread-main.tsx
@@ -585,11 +585,30 @@ const EXPECTED_PER_CYCLE: Record<string, number> = {
   artifactCards: 2,
   // python, typescript, json, svg, the html document, and the two tool result panes.
   codeBlocks: 7,
-  // Shiki is async and per block, so a <pre> exists long before it is highlighted. A floor under
-  // the token count is what tells a finished thread apart from one still building itself; a
-  // settled-looking count of 577 against the 3216 a whole cycle produces is a real measured
-  // failure of the naive "it stopped moving" gate.
-  highlightedTokens: 2500,
+  /*
+   * THE CODE ITSELF, in characters, which is the deferral-invariant way to ask this.
+   *
+   * This row used to be a floor of 2,500 highlighted tokens, and that number was doing two jobs
+   * at once. Off-screen fences now render as a plain shell by default, so a token count is partly a
+   * measurement of where the viewport happens to be: measured on Chromium the same fixture
+   * renders 1,322 tokens for one cycle where it used to render 3,216, with no fixture change at
+   * all. Lowering the floor to fit would have left the check unable to tell a deferred thread
+   * from one that had quietly stopped rendering code, which is the only thing it is for.
+   *
+   * Characters inside `pre code` do not move: the deferred shell carries the same text node the
+   * highlighted block carries. Measured at 12,660 for one cycle and 51,081 for four, with 2 of 5
+   * and 15 of 20 fences deferred respectively, so the number is flat across a fourfold change in
+   * how much of the thread the reader had reached. It is also flat across engines: Chromium,
+   * Firefox and WebKit each report 12,660 for one cycle, to the character.
+   *
+   * The floor is 12,000 against that 12,660. One cycle is seven code blocks averaging about 1,800
+   * characters, so the 660 of slack is well under half of the smallest thing that could go
+   * missing: losing any one block still fails.
+   *
+   * The OTHER job that number was doing, telling a finished thread from one still building
+   * itself, is now `unhighlightedMountedFences` in the census, asked per block.
+   */
+  codeChars: 12000,
 };
 
 /**
@@ -781,6 +800,40 @@ function HeavyThreadApi({
           domNodes: document.getElementsByTagName("*").length,
           codeBlocks: document.querySelectorAll("pre").length,
           highlightedTokens: document.querySelectorAll("pre code span").length,
+          /*
+           * HOW MUCH CODE IS ON THE PAGE, which is what "is this the heavy thread" needs to ask.
+           *
+           * `highlightedTokens` used to answer it, and cannot any more: off-screen fences render
+           * as a plain shell by default, so the token count now measures where the reader is
+           * looking as much as what the fixture built. Characters do not move: the shell holds
+           * the same text node the highlighted block holds, which is what makes selection,
+           * clipboard and find-in-page identical across the two states. So this reads the same
+           * number whether a fence is deferred or not, and still goes down the moment the
+           * fixture stops rendering code.
+           */
+          codeChars: Array.from(document.querySelectorAll("pre code")).reduce(
+            (total, node) => total + (node.textContent?.length ?? 0),
+            0,
+          ),
+          fenceBlocks: document.querySelectorAll('[data-streamdown="code-block"]').length,
+          deferredFences: document.querySelectorAll("[data-unsloth-fence-deferred]").length,
+          /*
+           * A fence that is NEITHER deferred NOR highlighted, at rest.
+           *
+           * This is the half of the old token floor that was about settlement rather than about
+           * the fixture, and it asks it per block instead of in total. Streamdown mounts a code
+           * block showing its own unhighlighted fallback and colours it from a passive effect, so
+           * this state exists for a frame on any build; a thread that has settled must hold none
+           * of them. Stronger than a floor on the total, which a thread with one block stuck on
+           * the fallback passes as long as the others make up the count.
+           */
+          unhighlightedMountedFences: Array.from(
+            document.querySelectorAll('[data-streamdown="code-block"]'),
+          ).filter(
+            (block) =>
+              !block.hasAttribute("data-unsloth-fence-deferred") &&
+              block.querySelector("pre code span") === null,
+          ).length,
           toolParts: document.querySelectorAll(".aui-tool-fallback-root").length,
           // The collapsible CONTENT ELEMENT, which Radix keeps in the tree for its collapse
           // animation. It is present whether the card is open or shut, so it counts cards, not

--- a/studio/frontend/smoke-heavy-thread-main.tsx
+++ b/studio/frontend/smoke-heavy-thread-main.tsx
@@ -586,27 +586,17 @@ const EXPECTED_PER_CYCLE: Record<string, number> = {
   // python, typescript, json, svg, the html document, and the two tool result panes.
   codeBlocks: 7,
   /*
-   * THE CODE ITSELF, in characters, which is the deferral-invariant way to ask this.
+   * THE CODE ITSELF, in characters: the one size measure deferral cannot move.
    *
-   * This row used to be a floor of 2,500 highlighted tokens, and that number was doing two jobs
-   * at once. Off-screen fences now render as a plain shell by default, so a token count is partly a
-   * measurement of where the viewport happens to be: measured on Chromium the same fixture
-   * renders 1,322 tokens for one cycle where it used to render 3,216, with no fixture change at
-   * all. Lowering the floor to fit would have left the check unable to tell a deferred thread
-   * from one that had quietly stopped rendering code, which is the only thing it is for.
+   * This was a floor of 2,500 highlighted tokens, doing two jobs at once. Off-screen fences now
+   * render as a plain shell, so tokens partly measure where the viewport is: the same fixture
+   * renders 1,322 per cycle where it rendered 3,216. Characters do not move, because the shell
+   * carries the same text node: 12,660 for one cycle and 51,081 for four (2 of 5 and 15 of 20
+   * fences deferred), and Chromium, Firefox and WebKit each report 12,660 to the character.
    *
-   * Characters inside `pre code` do not move: the deferred shell carries the same text node the
-   * highlighted block carries. Measured at 12,660 for one cycle and 51,081 for four, with 2 of 5
-   * and 15 of 20 fences deferred respectively, so the number is flat across a fourfold change in
-   * how much of the thread the reader had reached. It is also flat across engines: Chromium,
-   * Firefox and WebKit each report 12,660 for one cycle, to the character.
-   *
-   * The floor is 12,000 against that 12,660. One cycle is seven code blocks averaging about 1,800
-   * characters, so the 660 of slack is well under half of the smallest thing that could go
-   * missing: losing any one block still fails.
-   *
-   * The OTHER job that number was doing, telling a finished thread from one still building
-   * itself, is now `unhighlightedMountedFences` in the census, asked per block.
+   * Floor 12,000 against 12,660; a cycle is seven blocks averaging ~1,800 chars, so losing any one
+   * block still fails. The other job, telling a settled thread from one still building itself, is
+   * now `unhighlightedMountedFences`, asked per block.
    */
   codeChars: 12000,
 };
@@ -801,15 +791,11 @@ function HeavyThreadApi({
           codeBlocks: document.querySelectorAll("pre").length,
           highlightedTokens: document.querySelectorAll("pre code span").length,
           /*
-           * HOW MUCH CODE IS ON THE PAGE, which is what "is this the heavy thread" needs to ask.
-           *
-           * `highlightedTokens` used to answer it, and cannot any more: off-screen fences render
-           * as a plain shell by default, so the token count now measures where the reader is
-           * looking as much as what the fixture built. Characters do not move: the shell holds
-           * the same text node the highlighted block holds, which is what makes selection,
-           * clipboard and find-in-page identical across the two states. So this reads the same
-           * number whether a fence is deferred or not, and still goes down the moment the
-           * fixture stops rendering code.
+           * HOW MUCH CODE IS ON THE PAGE. `highlightedTokens` cannot answer that any more: a
+           * deferred fence renders as a plain shell, so tokens measure where the reader is
+           * looking. The shell holds the same text node the highlighted block holds (which is
+           * also why selection, clipboard and find-in-page are identical across the two states),
+           * so characters read the same either way and still drop if the fixture loses code.
            */
           codeChars: Array.from(document.querySelectorAll("pre code")).reduce(
             (total, node) => total + (node.textContent?.length ?? 0),
@@ -818,14 +804,11 @@ function HeavyThreadApi({
           fenceBlocks: document.querySelectorAll('[data-streamdown="code-block"]').length,
           deferredFences: document.querySelectorAll("[data-unsloth-fence-deferred]").length,
           /*
-           * A fence that is NEITHER deferred NOR highlighted, at rest.
-           *
-           * This is the half of the old token floor that was about settlement rather than about
-           * the fixture, and it asks it per block instead of in total. Streamdown mounts a code
-           * block showing its own unhighlighted fallback and colours it from a passive effect, so
-           * this state exists for a frame on any build; a thread that has settled must hold none
-           * of them. Stronger than a floor on the total, which a thread with one block stuck on
-           * the fallback passes as long as the others make up the count.
+           * A fence that is NEITHER deferred NOR highlighted, at rest: the settlement half of the
+           * old token floor, asked per block. Streamdown mounts a code block on its own
+           * unhighlighted fallback and colours it from a passive effect, so this state exists for
+           * a frame on any build and a settled thread must hold none. Stronger than a floor on
+           * the total, which one stuck block passes as long as the others make up the count.
            */
           unhighlightedMountedFences: Array.from(
             document.querySelectorAll('[data-streamdown="code-block"]'),

--- a/studio/frontend/src/components/assistant-ui/code-fence-defer.tsx
+++ b/studio/frontend/src/components/assistant-ui/code-fence-defer.tsx
@@ -8,8 +8,12 @@ import {
   type RefObject,
   useEffect,
   useLayoutEffect,
+  useRef,
   useState,
 } from "react";
+import { flushSync } from "react-dom";
+
+import { type FenceMode, resolveFenceMode } from "./code-fence-mode";
 
 /*
  * MONOTONIC fence highlighting: a fence is rendered as a plain shell until the
@@ -49,39 +53,17 @@ import {
 const REACH_MARGIN = "100% 0px";
 
 /*
- * Three states, not two.
- *
- *   "off"        ship default. Every fence is highlighted at mount, as today.
- *   "defer"      the change: an unreached fence is a plain shell and is never tokenized.
- *   "tokenize"   MEASUREMENT ONLY. An unreached fence is the same plain shell, but the
- *                highlighter is still driven over its source and the result thrown away.
- *
- * `tokenize` exists to answer one question and is not a shipping mode. `defer` removes two
- * things at once: the spans from the document, and the tokenizer work that produces them. An
- * improvement seen under `defer` alone cannot say which of the two paid for it. `tokenize`
- * holds the DOM at `defer`'s size and puts only the tokenizer work back, so the gap between
- * `tokenize` and `defer` is the tokenizer's contribution and the gap between `off` and
- * `tokenize` is the document's.
+ * WHICH MODE IS IN FORCE lives in `code-fence-mode.ts`, a plain `.ts` module with no JSX in it, so
+ * the decision table is exercised by a test that RUNS it rather than by regexes over this file.
+ * Re-exported here because this is the module every consumer already imports.
  */
-export type FenceMode = "off" | "defer" | "tokenize";
+export { type FenceMode, resolveFenceMode, SHIP_DEFAULT } from "./code-fence-mode";
 
-export const fenceMode = (): FenceMode => {
-  const runtime = (globalThis as Record<string, unknown>)
-    .__UNSLOTH_DEFER_FENCE_HIGHLIGHT__;
-  const raw =
-    typeof runtime === "string"
-      ? runtime
-      : runtime === true
-        ? "defer"
-        : runtime === false
-          ? "off"
-          : readBuildFlag();
-  return raw === "1" || raw === "defer"
-    ? "defer"
-    : raw === "tokenize"
-      ? "tokenize"
-      : "off";
-};
+export const fenceMode = (): FenceMode =>
+  resolveFenceMode(
+    (globalThis as Record<string, unknown>).__UNSLOTH_DEFER_FENCE_HIGHLIGHT__,
+    readBuildFlag(),
+  );
 
 const readBuildFlag = (): string => {
   try {
@@ -169,31 +151,232 @@ const CAN_OBSERVE =
   typeof globalThis !== "undefined";
 
 /*
- * PRINT: NOT HANDLED, and measured rather than assumed.
+ * THE REGISTER OF FENCES THAT HAVE NOT BEEN REACHED YET.
  *
- * A print renders the whole document, so every deferred fence is on the page whether or not the
- * reader reached it. Colour is the only thing deferral costs there: the text is a live text node,
- * so it prints complete, in order, correctly laid out and in the right font.
+ * Two things need to reach across all of them at once, and neither can wait for a React render:
+ * a discontinuous scroll, which lands the viewport somewhere no observer has warned about, and a
+ * print, which puts the WHOLE document on the page at once. Both are handled below, and both go
+ * through `latchNow`.
  *
- * There WAS a `beforeprint` path here that latched every mounted fence, warmed each language's
- * grammar at idle and flushed twice. It has been removed because it did not work, and the
- * measurement is the reason. Synchronous dispatch and read in one task, 100K rung, cold open:
- *
- *   delay after open   flag off: blocks on the raw fallback   flag on
- *   1.5 s              56 of 56                               56 of 56
- *   3 s and beyond     0                                      53 of 56
- *
- * The shipped build has a real window of about three seconds and is fully highlighted after it.
- * With the flag on, 53 of 56 blocks stayed on streamdown's raw fallback at every delay out to
- * twenty seconds. Neither a warm grammar nor a second `flushSync` makes a lazily imported,
- * effect-driven highlighter produce tokens inside the synchronous print task, because
- * `beforeprint` returns and the browser snapshots before any of that can land.
- *
- * So the honest position is that this is a stated limitation, not a solved problem: with the flag
- * on, printing a long thread prints unreached fences without syntax colour. Keeping the machinery
- * would have meant maintaining a module-global claim, two bookkeeping sets and an idle scheduler
- * for a benefit that was measured at zero.
+ * A gate carries the two elements its observers were built against, resolved at the same moment
+ * and rebuilt with them, so nothing here walks the ancestor chain or reads a computed style
+ * again. `warm` is supplied by the caller because the highlighter instance lives with the
+ * component that renders the block, not here.
  */
+type FenceGate = {
+  node: HTMLElement;
+  near: HTMLElement | null;
+  outer: HTMLElement | null;
+  language: string | null;
+  /** `true` tokenizes this fence's source now; `false` only loads its grammar. */
+  warm: (tokens: boolean) => void;
+  latch: () => void;
+  /** A state write that changes nothing, whose only job is to give React sync work to do. */
+  poke: () => void;
+};
+
+const unreached = new Set<FenceGate>();
+
+/** Is this gate's fence where the observers would call it reached? */
+const gateOpen = (gate: FenceGate): boolean =>
+  inBand(gate.node, gate.near)
+  && (gate.near === gate.outer || inBand(gate.near as HTMLElement, gate.outer));
+
+/*
+ * UPGRADE THESE FENCES INSIDE THIS TASK, so the browser paints them highlighted rather than
+ * painting the plain shell first and correcting it a few frames later.
+ *
+ * THREE STEPS, and all three are needed. Each one was put here because dropping it was measured
+ * to put a painted plain frame back.
+ *
+ *   1. `warm(true)`. Streamdown's highlighted body asks the code plugin for tokens and renders
+ *      its own plain fallback whenever the plugin answers `null`. The plugin answers `null` only
+ *      while a grammar is still loading; once the grammar is in hand it tokenizes and returns in
+ *      the same call. Warming first is what turns the render below into a cache hit.
+ *   2. The inner `flushSync(latch)`. A state update scheduled normally lands after the next paint,
+ *      which is the whole defect. This commits the swap from shell to block inside this task.
+ *   3. The inner `flushSync(poke)`, INSIDE an outer `flushSync`. Step 2 does not produce the
+ *      COLOURED commit: `HighlightedCodeBlockBody` starts from `useState(raw)` and asks for its
+ *      tokens from a PASSIVE effect, so every newly mounted code block renders unhighlighted once.
+ *      On the shipped default that render happens at thread mount, off screen; deferred, it
+ *      happens wherever the latch happens, and it is a real plain frame on the reader's screen.
+ *
+ * WHY THE POKE, AND WHY THE NESTING. Both follow from how react-dom flushes, and an empty
+ * `flushSync(() => {})` -- the obvious thing to write -- does neither:
+ *
+ *   - React runs pending passive effects from `performSyncWorkOnRoot`, which it only reaches when
+ *     there is sync work waiting. A flush with nothing to do never enters the work loop, so it
+ *     never runs the effect that colours the block. `poke` is that work: a state write on a fence
+ *     that has already latched, whose own effects all early-return, so it re-renders the one or
+ *     two blocks just swapped in and changes nothing else.
+ *   - `flushSync` restores React's update priority BEFORE it performs the flush. So the update the
+ *     passive effect schedules is resolved against the ambient priority, and a scroll is
+ *     continuous rather than discrete, which means it is NOT flushed synchronously and lands on
+ *     the next frame after all. Nesting fixes exactly that: the outer call holds the priority at
+ *     discrete for the whole of its body, and the inner flushes perform their work inside that
+ *     body, so the effect's update is discrete too and goes out with them.
+ *
+ * One way only. Nothing here can clear a latch.
+ */
+const latchNow = (arrived: readonly FenceGate[]): void => {
+  if (arrived.length === 0) return;
+  for (const gate of arrived) {
+    unreached.delete(gate);
+    gate.warm(true);
+  }
+  flushSync(() => {
+    flushSync(() => {
+      for (const gate of arrived) gate.latch();
+    });
+    flushSync(() => {
+      for (const gate of arrived) gate.poke();
+    });
+  });
+};
+
+/*
+ * A DISCONTINUOUS SCROLL: a scrollbar drag, Ctrl+End, an anchor jump, a restored position.
+ *
+ * The observers below carry one root height of lookahead (`REACH_MARGIN`), and the pre-paint gate
+ * runs only when this component renders. Neither covers a jump: the viewport can move further
+ * than the lookahead in one step, with no React render in between, and an IntersectionObserver
+ * record is delivered one or more frames AFTER the browser has painted. Measured in Chromium at
+ * the 100K rung, 16 seeded jumps: 8 of them painted 3 to 4 frames of plain code, 50 to 190 ms.
+ *
+ * WHY A SCROLL LISTENER IS ENOUGH, AND WHEN IT PAINTS. Scroll events are dispatched in the "run
+ * the scroll steps" of the same update-the-rendering pass that will paint the new position, and
+ * that step runs BEFORE animation-frame callbacks and before style, layout and paint. A
+ * `flushSync` from here is therefore part of the frame the reader is about to see, not the one
+ * after it. A programmatic `scrollTo`, a wheel, a drag and a keyboard jump all arrive down this
+ * one path.
+ *
+ * THE THRESHOLD IS DERIVED, NOT TUNED. `REACH_MARGIN` grows the root's band by one root height in
+ * each direction, so after a scroll of `d` the newly visible strip sits at `[d, d + h]` measured
+ * from the old top, and that is inside the old band exactly when `d <= h`. A scroll of at most one
+ * root height can therefore only reveal fences the observers had already reached; anything further
+ * can reveal one they had not. So the pass below runs when, and only when, the lookahead provably
+ * did not cover the movement, and a continuous scroll pays one subtraction per event.
+ *
+ * ONE LISTENER, NOT ONE PER FENCE. Scroll events do not bubble, but they do capture, so a single
+ * capturing listener on the document sees scrolling on every element including nested reasoning
+ * panes. It is attached when the first fence registers and removed when the last one latches, so
+ * a thread with nothing left to defer carries no scroll cost at all.
+ */
+const lastScrollTop = new WeakMap<EventTarget, number>();
+let scrollWatched = false;
+
+const onScroll = (event: Event): void => {
+  if (unreached.size === 0) return;
+  const target = event.target;
+  if (target === null) return;
+  const element = target === document ? null : (target as HTMLElement);
+  const top = element ? element.scrollTop : window.scrollY;
+  const height = element ? element.clientHeight : window.innerHeight;
+  const before = lastScrollTop.get(target);
+  lastScrollTop.set(target, top);
+  // An unseen scroller has no previous position to difference, so its first event is treated as a
+  // jump. That costs one pass, once per scroller, and never assumes a movement was small.
+  if (before !== undefined && Math.abs(top - before) <= height) return;
+  const arrived: FenceGate[] = [];
+  for (const gate of unreached) {
+    if (gateOpen(gate)) arrived.push(gate);
+  }
+  latchNow(arrived);
+};
+
+const watchScrolling = (): void => {
+  if (scrollWatched || typeof document === "undefined") return;
+  scrollWatched = true;
+  document.addEventListener("scroll", onScroll, { capture: true, passive: true });
+};
+
+const unwatchScrolling = (): void => {
+  if (!scrollWatched || unreached.size > 0 || typeof document === "undefined") return;
+  scrollWatched = false;
+  document.removeEventListener("scroll", onScroll, { capture: true });
+};
+
+/*
+ * PRINT, which is the one gesture that puts every deferred fence on the page at once.
+ *
+ * Colour is the only thing deferral costs a printed page: the shell holds a live text node, so it
+ * prints complete, in order, correctly laid out and in the right font. But a printed page that
+ * loses the colouring on the fences the reader never scrolled past is a defect the reader can see
+ * and keep, and the printed window does not even coincide with the reader's -- a print lays the
+ * document out at PAPER width while the scroll offset carries across as a raw pixel count, so the
+ * page lands several fences away from where the reader was. Measured at Letter against a 1280 px
+ * window: 1 to 2 deferred fences on every sampled page, and a 6.6% pixel difference against the
+ * same page printed with the flag off. Matching the paper to the window removes it, which is what
+ * identifies the cause -- and is exactly why chasing the window is the wrong fix. The whole
+ * document is on the page, so the whole document is what has to be highlighted.
+ *
+ * WHY AN EARLIER ATTEMPT AT THIS FAILED, since it was measured and reported as impossible. It
+ * latched every fence from `beforeprint` with `flushSync` and the blocks did swap, but 53 of 56
+ * of them printed on streamdown's raw fallback: the swap alone renders the block UNHIGHLIGHTED,
+ * because the highlighted body asks the plugin for tokens from a passive effect and the plugin
+ * answers `null` until the grammar is loaded. `latchNow` closes both halves -- it warms the tokens
+ * first, and it flushes the colouring render as well as the swap -- and `warmGrammars` below
+ * removes the remaining asynchrony by making sure a grammar is never what is missing at the moment
+ * the snapshot is taken.
+ *
+ * BOTH DOORS. `beforeprint` covers Ctrl+P and the print menu. A headless `page.pdf()` and
+ * DevTools' print emulation change the media query without ever firing it, and a PDF export is
+ * exactly the path a reader uses to keep a copy.
+ *
+ * Still one way only: `printed` never goes back to false, so a print permanently upgrades the
+ * thread rather than putting it back afterwards. Reverting on `afterprint` would be the
+ * bidirectional edge this whole design exists to avoid.
+ */
+let printed = false;
+
+const upgradeEverythingForPrint = (): void => {
+  if (printed) return;
+  printed = true;
+  latchNow([...unreached]);
+};
+
+/*
+ * GRAMMARS, WARMED AT IDLE. NOT TOKENS.
+ *
+ * `warm(false)` asks the plugin to highlight an EMPTY string in this fence's language, which
+ * loads the grammar and tokenizes nothing. That is the whole of it: no fence is tokenized, no
+ * span is mounted, and the document stays exactly the size deferral made it. What it buys is that
+ * the synchronous path in `latchNow` can never be defeated by a grammar that happens to still be
+ * loading -- on a jump into a language the reader has not met yet, and on a print, where there is
+ * no later frame to correct in.
+ *
+ * Deduplicated by language and scheduled at idle, so a thread whose fences are all one language
+ * pays one grammar load and a thread with nothing deferred pays nothing.
+ */
+const grammarsWarmed = new Set<string>();
+let warmScheduled = false;
+
+const warmGrammars = (): void => {
+  warmScheduled = false;
+  for (const gate of unreached) {
+    const language = gate.language ?? "text";
+    if (grammarsWarmed.has(language)) continue;
+    grammarsWarmed.add(language);
+    gate.warm(false);
+  }
+};
+
+const scheduleGrammarWarm = (): void => {
+  if (warmScheduled || typeof globalThis === "undefined") return;
+  warmScheduled = true;
+  const idle = (globalThis as Record<string, unknown>).requestIdleCallback as
+    | ((cb: () => void, options?: { timeout: number }) => number)
+    | undefined;
+  if (typeof idle === "function") idle(warmGrammars, { timeout: 2000 });
+  else setTimeout(warmGrammars, 500);
+};
+
+if (typeof window !== "undefined" && typeof window.addEventListener === "function") {
+  window.addEventListener("beforeprint", upgradeEverythingForPrint);
+  window.matchMedia?.("print")?.addEventListener?.("change", (event) => {
+    if (event.matches) upgradeEverythingForPrint();
+  });
+}
 
 /*
  * THE NEAREST SCROLLING ANCESTOR, found rather than named.
@@ -300,17 +483,30 @@ const inBand = (node: HTMLElement, scroller: HTMLElement | null): boolean => {
  *                 state is ever written, no observer is built and no layout is read.
  * @param streaming  the fence is still being written. It is highlighted while it streams AND it
  *                 latches, so that finishing cannot take the highlighting back.
+ * @param language  the fence's language token, used only to load one grammar per language rather
+ *                 than one per fence. `null` is the unknown-language case and warms plain text.
+ * @param warm  drive the highlighter over this fence: `true` for its tokens, `false` for its
+ *                 grammar alone. Called from a jump and from a print, where the swap has to be
+ *                 coloured inside the same task; see `latchNow`. Held in a ref rather than taken
+ *                 as an effect dependency so that a caller who does not memoize it cannot rebuild
+ *                 every observer in the thread on every render.
  */
 export function useFenceReached(
   host: RefObject<HTMLElement | null>,
   enabled: boolean,
   streaming: boolean,
+  language: string | null,
+  warm: (tokens: boolean) => void,
 ): boolean {
   const [latched, setLatched] = useState(false);
   // Bumped when the resolved scrolling ancestor stops being one, which rebuilds the gates below
   // against the element that clips this fence now. Never read for anything else.
   const [generation, setGeneration] = useState(0);
-  const reached = !enabled || !CAN_OBSERVE || streaming || latched;
+  const reached = !enabled || !CAN_OBSERVE || streaming || latched || printed;
+  const warmRef = useRef(warm);
+  useEffect(() => {
+    warmRef.current = warm;
+  }, [warm]);
 
   /*
    * A COMPLETING STREAM MUST NOT DOWNGRADE.
@@ -413,6 +609,26 @@ export function useFenceReached(
     ));
     gates.forEach(([target], i) => observers[i].observe(target));
 
+    // The same two elements, handed to the register so a jump and a print can ask the same two
+    // questions of this fence without a render and without walking the ancestor chain again. The
+    // register is rebuilt with the observers, so a rebind can never leave a stale root behind in
+    // one gate and not the other.
+    const registered: FenceGate = {
+      node,
+      near,
+      outer,
+      language,
+      warm: (tokens) => warmRef.current(tokens),
+      latch: () => setLatched(true),
+      // `generation` is bumped rather than a state of its own being added: this fence has just
+      // latched, so every effect keyed on it early-returns and the bump costs one render of one
+      // already-upgraded block. See `latchNow` for why React needs the work.
+      poke: () => setGeneration((n) => n + 1),
+    };
+    unreached.add(registered);
+    watchScrolling();
+    scheduleGrammarWarm();
+
     // `reasoning.tsx` drops `max-h-64` when a stream ends and keeps `overflow-y-auto`, so the pane
     // stops being a scroller and its box becomes the whole trace. Watch for that and rebuild.
     let resize: ResizeObserver | undefined;
@@ -426,6 +642,8 @@ export function useFenceReached(
     return () => {
       for (const observer of observers) observer.disconnect();
       resize?.disconnect();
+      unreached.delete(registered);
+      unwatchScrolling();
     };
   }, [reached, host, generation]);
 

--- a/studio/frontend/src/components/assistant-ui/code-fence-defer.tsx
+++ b/studio/frontend/src/components/assistant-ui/code-fence-defer.tsx
@@ -47,9 +47,27 @@ import { type FenceMode, resolveFenceMode } from "./code-fence-mode";
  * renders rather than what a settled thread costs.
  */
 
-// How far outside the viewport a fence counts as "reached". One viewport of
-// slack in each direction, so the upgrade has a frame or two to land before the
-// block is actually on screen and the reader never sees the swap.
+/*
+ * How far outside the viewport a fence counts as "reached". One viewport of slack in each
+ * direction, so the upgrade has a frame or two to land before the block is actually on screen and
+ * the reader never sees the swap.
+ *
+ * THE PERCENTAGE RESOLVES AGAINST THE ROOT'S HEIGHT, and the spec says otherwise. Intersection
+ * Observer 2.2 says percentages "are resolved relative to the width of the undilated rectangle",
+ * for all four sides; no engine does that for top and bottom, and w3c/IntersectionObserver#391 is
+ * open on exactly that discrepancy. Measured on a synthetic scroller of known size, with `0px 0px`
+ * and `300px 0px` run alongside as controls that must come back 0 and 300:
+ *
+ *   root 300x800 -> 800 px    root 1600x600 -> 600 px    root 600x1400 -> 1400 px
+ *
+ * on Chromium, Firefox and WebKit alike, nine rows, every control reproduced. So it is the HEIGHT,
+ * which is what `inBand` and the jump test below both assume.
+ *
+ * That is a measurement of today's engines against a spec that says something else, so it is
+ * guarded rather than trusted: `pf9462_parity.py` re-measures it on two geometries on every run
+ * and fails the run if the observer's lookahead and the pre-paint band stop agreeing, which is
+ * what an engine moving to the spec's reading would look like.
+ */
 const REACH_MARGIN = "100% 0px";
 
 /*

--- a/studio/frontend/src/components/assistant-ui/code-fence-defer.tsx
+++ b/studio/frontend/src/components/assistant-ui/code-fence-defer.tsx
@@ -323,15 +323,26 @@ const unwatchScrolling = (): void => {
  * DevTools' print emulation change the media query without ever firing it, and a PDF export is
  * exactly the path a reader uses to keep a copy.
  *
- * Still one way only: `printed` never goes back to false, so a print permanently upgrades the
- * thread rather than putting it back afterwards. Reverting on `afterprint` would be the
- * bidirectional edge this whole design exists to avoid.
+ * WHAT A PRINT UPGRADES IS THE DOCUMENT THAT WAS PRINTED, and nothing else.
+ *
+ * This was a module-global `printed` flag folded into every future fence's `reached`, and that is
+ * a session-wide latch rather than a monotonic one: measured at the 100K rung, a thread holding 53
+ * of 56 fences deferred, 2,458 spans and 22,794 elements printed once and then, after navigating
+ * away inside the app and back, remounted with 0 deferred, 41,410 spans and 61,747 elements. One
+ * Ctrl+P turned the whole default off for the rest of the tab's life, including threads that were
+ * never on the printed page.
+ *
+ * So the print latches the fences that are on the page WHEN IT HAPPENS, which is exactly the set
+ * that is about to be printed, and a fence mounted afterwards defers again as usual. Still one way
+ * only, and for the same reason as everywhere else here: `latchNow` can only latch. Reverting on
+ * `afterprint` would be the bidirectional edge this whole design exists to avoid, and nothing
+ * below does it.
+ *
+ * Every print upgrades whatever is unreached at that moment, rather than the first print winning
+ * and later ones doing nothing: print, scroll somewhere new, print again, and the second page is
+ * as complete as the first.
  */
-let printed = false;
-
 const upgradeEverythingForPrint = (): void => {
-  if (printed) return;
-  printed = true;
   latchNow([...unreached]);
 };
 
@@ -502,7 +513,7 @@ export function useFenceReached(
   // Bumped when the resolved scrolling ancestor stops being one, which rebuilds the gates below
   // against the element that clips this fence now. Never read for anything else.
   const [generation, setGeneration] = useState(0);
-  const reached = !enabled || !CAN_OBSERVE || streaming || latched || printed;
+  const reached = !enabled || !CAN_OBSERVE || streaming || latched;
   const warmRef = useRef(warm);
   useEffect(() => {
     warmRef.current = warm;

--- a/studio/frontend/src/components/assistant-ui/code-fence-defer.tsx
+++ b/studio/frontend/src/components/assistant-ui/code-fence-defer.tsx
@@ -48,32 +48,28 @@ import { type FenceMode, resolveFenceMode } from "./code-fence-mode";
  */
 
 /*
- * How far outside the viewport a fence counts as "reached". One viewport of slack in each
- * direction, so the upgrade has a frame or two to land before the block is actually on screen and
- * the reader never sees the swap.
+ * How far outside the viewport a fence counts as "reached": one viewport of slack each way, so the
+ * upgrade lands a frame or two before the block is on screen and the reader never sees the swap.
  *
  * THE PERCENTAGE RESOLVES AGAINST THE ROOT'S HEIGHT, and the spec says otherwise. Intersection
- * Observer 2.2 says percentages "are resolved relative to the width of the undilated rectangle",
+ * Observer 2.2 says percentages "are resolved relative to the width of the undilated rectangle"
  * for all four sides; no engine does that for top and bottom, and w3c/IntersectionObserver#391 is
- * open on exactly that discrepancy. Measured on a synthetic scroller of known size, with `0px 0px`
- * and `300px 0px` run alongside as controls that must come back 0 and 300:
+ * open on exactly that. Measured on a synthetic scroller, with `0px 0px` and `300px 0px` alongside
+ * as controls that must come back 0 and 300:
  *
  *   root 300x800 -> 800 px    root 1600x600 -> 600 px    root 600x1400 -> 1400 px
  *
  * on Chromium, Firefox and WebKit alike, nine rows, every control reproduced. So it is the HEIGHT,
- * which is what `inBand` and the jump test below both assume.
- *
- * That is a measurement of today's engines against a spec that says something else, so it is
- * guarded rather than trusted: `pf9462_parity.py` re-measures it on two geometries on every run
- * and fails the run if the observer's lookahead and the pre-paint band stop agreeing, which is
- * what an engine moving to the spec's reading would look like.
+ * which `inBand` and the jump test below both assume. That is today's engines against a spec that
+ * reads otherwise, so it is guarded rather than trusted: `pf9462_parity.py` re-measures two
+ * geometries every run and fails if the observer's lookahead and the pre-paint band stop agreeing,
+ * which is what an engine moving to the spec's reading would look like.
  */
 const REACH_MARGIN = "100% 0px";
 
 /*
- * WHICH MODE IS IN FORCE lives in `code-fence-mode.ts`, a plain `.ts` module with no JSX in it, so
- * the decision table is exercised by a test that RUNS it rather than by regexes over this file.
- * Re-exported here because this is the module every consumer already imports.
+ * The mode decision lives in `code-fence-mode.ts`, a JSX-free `.ts` so a test can RUN the table
+ * rather than regex this file. Re-exported here because consumers already import this module.
  */
 export { type FenceMode, resolveFenceMode, SHIP_DEFAULT } from "./code-fence-mode";
 
@@ -169,17 +165,13 @@ const CAN_OBSERVE =
   typeof globalThis !== "undefined";
 
 /*
- * THE REGISTER OF FENCES THAT HAVE NOT BEEN REACHED YET.
- *
- * Two things need to reach across all of them at once, and neither can wait for a React render:
- * a discontinuous scroll, which lands the viewport somewhere no observer has warned about, and a
- * print, which puts the WHOLE document on the page at once. Both are handled below, and both go
- * through `latchNow`.
+ * THE REGISTER OF FENCES THAT HAVE NOT BEEN REACHED YET, for the two things that must reach across
+ * all of them at once without waiting for a React render: a discontinuous scroll, and a print,
+ * which puts the WHOLE document on the page. Both go through `latchNow` below.
  *
  * A gate carries the two elements its observers were built against, resolved at the same moment
- * and rebuilt with them, so nothing here walks the ancestor chain or reads a computed style
- * again. `warm` is supplied by the caller because the highlighter instance lives with the
- * component that renders the block, not here.
+ * and rebuilt with them, so nothing here re-walks the ancestor chain or re-reads a computed style.
+ * `warm` comes from the caller because the highlighter instance lives with the block's component.
  */
 type FenceGate = {
   node: HTMLElement;
@@ -201,38 +193,30 @@ const gateOpen = (gate: FenceGate): boolean =>
   && (gate.near === gate.outer || inBand(gate.near as HTMLElement, gate.outer));
 
 /*
- * UPGRADE THESE FENCES INSIDE THIS TASK, so the browser paints them highlighted rather than
- * painting the plain shell first and correcting it a few frames later.
+ * UPGRADE THESE FENCES INSIDE THIS TASK, so the browser paints them highlighted instead of
+ * painting the plain shell and correcting it a few frames later. Dropping any of the three steps
+ * was measured to put a painted plain frame back:
  *
- * THREE STEPS, and all three are needed. Each one was put here because dropping it was measured
- * to put a painted plain frame back.
- *
- *   1. `warm(true)`. Streamdown's highlighted body asks the code plugin for tokens and renders
- *      its own plain fallback whenever the plugin answers `null`. The plugin answers `null` only
- *      while a grammar is still loading; once the grammar is in hand it tokenizes and returns in
- *      the same call. Warming first is what turns the render below into a cache hit.
- *   2. The inner `flushSync(latch)`. A state update scheduled normally lands after the next paint,
- *      which is the whole defect. This commits the swap from shell to block inside this task.
+ *   1. `warm(true)`. Streamdown's highlighted body renders its own plain fallback whenever the
+ *      plugin answers `null`, which it does only while a grammar is loading; with the grammar in
+ *      hand it tokenizes in the same call. Warming makes the render below a cache hit.
+ *   2. The inner `flushSync(latch)`. A normally scheduled update lands after the next paint, which
+ *      is the whole defect. This commits the shell-to-block swap in this task.
  *   3. The inner `flushSync(poke)`, INSIDE an outer `flushSync`. Step 2 does not produce the
- *      COLOURED commit: `HighlightedCodeBlockBody` starts from `useState(raw)` and asks for its
- *      tokens from a PASSIVE effect, so every newly mounted code block renders unhighlighted once.
- *      On the shipped default that render happens at thread mount, off screen; deferred, it
- *      happens wherever the latch happens, and it is a real plain frame on the reader's screen.
+ *      COLOURED commit: `HighlightedCodeBlockBody` starts at `useState(raw)` and asks for tokens
+ *      from a PASSIVE effect, so every newly mounted block renders unhighlighted once. Off screen
+ *      at thread mount that is invisible; deferred, it is a plain frame on the reader's screen.
  *
- * WHY THE POKE, AND WHY THE NESTING. Both follow from how react-dom flushes, and an empty
- * `flushSync(() => {})` -- the obvious thing to write -- does neither:
+ * WHY THE POKE AND THE NESTING, since an empty `flushSync(() => {})` does neither:
  *
- *   - React runs pending passive effects from `performSyncWorkOnRoot`, which it only reaches when
- *     there is sync work waiting. A flush with nothing to do never enters the work loop, so it
- *     never runs the effect that colours the block. `poke` is that work: a state write on a fence
- *     that has already latched, whose own effects all early-return, so it re-renders the one or
- *     two blocks just swapped in and changes nothing else.
- *   - `flushSync` restores React's update priority BEFORE it performs the flush. So the update the
- *     passive effect schedules is resolved against the ambient priority, and a scroll is
- *     continuous rather than discrete, which means it is NOT flushed synchronously and lands on
- *     the next frame after all. Nesting fixes exactly that: the outer call holds the priority at
- *     discrete for the whole of its body, and the inner flushes perform their work inside that
- *     body, so the effect's update is discrete too and goes out with them.
+ *   - React runs pending passive effects from `performSyncWorkOnRoot`, reached only when sync work
+ *     is waiting, so a flush with nothing to do never runs the effect that colours the block.
+ *     `poke` is that work: a state write on an already-latched fence whose own effects all
+ *     early-return.
+ *   - `flushSync` restores React's update priority BEFORE performing the flush, so the passive
+ *     effect's update resolves against the ambient priority, and a scroll is continuous rather
+ *     than discrete, so it is not flushed and lands next frame after all. The outer call holds the
+ *     priority discrete across its whole body, so the inner flushes carry the effect's update too.
  *
  * One way only. Nothing here can clear a latch.
  */
@@ -255,30 +239,25 @@ const latchNow = (arrived: readonly FenceGate[]): void => {
 /*
  * A DISCONTINUOUS SCROLL: a scrollbar drag, Ctrl+End, an anchor jump, a restored position.
  *
- * The observers below carry one root height of lookahead (`REACH_MARGIN`), and the pre-paint gate
- * runs only when this component renders. Neither covers a jump: the viewport can move further
- * than the lookahead in one step, with no React render in between, and an IntersectionObserver
- * record is delivered one or more frames AFTER the browser has painted. Measured in Chromium at
- * the 100K rung, 16 seeded jumps: 8 of them painted 3 to 4 frames of plain code, 50 to 190 ms.
+ * Neither the observers' one root height of lookahead (`REACH_MARGIN`) nor the render-time
+ * pre-paint gate covers a jump: the viewport can move further than the lookahead in one step with
+ * no React render in between, and an IntersectionObserver record is delivered one or more frames
+ * AFTER the paint. Chromium at the 100K rung, 16 seeded jumps: 8 painted 3 to 4 frames of plain
+ * code, 50 to 190 ms.
  *
- * WHY A SCROLL LISTENER IS ENOUGH, AND WHEN IT PAINTS. Scroll events are dispatched in the "run
- * the scroll steps" of the same update-the-rendering pass that will paint the new position, and
- * that step runs BEFORE animation-frame callbacks and before style, layout and paint. A
- * `flushSync` from here is therefore part of the frame the reader is about to see, not the one
- * after it. A programmatic `scrollTo`, a wheel, a drag and a keyboard jump all arrive down this
- * one path.
+ * A SCROLL LISTENER IS ENOUGH AND IS IN TIME: scroll events are dispatched in the "run the scroll
+ * steps" of the same update-the-rendering pass that will paint the new position, before
+ * animation-frame callbacks and before style, layout and paint, so a `flushSync` from here is part
+ * of the frame the reader is about to see. `scrollTo`, wheel, drag and keyboard all arrive here.
  *
- * THE THRESHOLD IS DERIVED, NOT TUNED. `REACH_MARGIN` grows the root's band by one root height in
- * each direction, so after a scroll of `d` the newly visible strip sits at `[d, d + h]` measured
- * from the old top, and that is inside the old band exactly when `d <= h`. A scroll of at most one
- * root height can therefore only reveal fences the observers had already reached; anything further
- * can reveal one they had not. So the pass below runs when, and only when, the lookahead provably
- * did not cover the movement, and a continuous scroll pays one subtraction per event.
+ * THE THRESHOLD IS DERIVED, NOT TUNED. The band is one root height `h` bigger each way, so after a
+ * scroll of `d` the newly visible strip `[d, d + h]` is inside the old band exactly when `d <= h`.
+ * The pass therefore runs only when the lookahead provably did not cover the movement, and a
+ * continuous scroll pays one subtraction per event.
  *
- * ONE LISTENER, NOT ONE PER FENCE. Scroll events do not bubble, but they do capture, so a single
- * capturing listener on the document sees scrolling on every element including nested reasoning
- * panes. It is attached when the first fence registers and removed when the last one latches, so
- * a thread with nothing left to defer carries no scroll cost at all.
+ * ONE LISTENER, NOT ONE PER FENCE. Scroll does not bubble but does capture, so one capturing
+ * document listener sees every element including nested reasoning panes. Attached when the first
+ * fence registers and removed when the last latches, so nothing left to defer costs nothing.
  */
 const lastScrollTop = new WeakMap<EventTarget, number>();
 let scrollWatched = false;
@@ -292,8 +271,8 @@ const onScroll = (event: Event): void => {
   const height = element ? element.clientHeight : window.innerHeight;
   const before = lastScrollTop.get(target);
   lastScrollTop.set(target, top);
-  // An unseen scroller has no previous position to difference, so its first event is treated as a
-  // jump. That costs one pass, once per scroller, and never assumes a movement was small.
+  // An unseen scroller has no previous position, so its first event counts as a jump: one pass per
+  // scroller, and never an assumption that the movement was small.
   if (before !== undefined && Math.abs(top - before) <= height) return;
   const arrived: FenceGate[] = [];
   for (const gate of unreached) {
@@ -315,50 +294,36 @@ const unwatchScrolling = (): void => {
 };
 
 /*
- * PRINT, which is the one gesture that puts every deferred fence on the page at once.
+ * PRINT, the one gesture that puts every deferred fence on the page at once.
  *
- * Colour is the only thing deferral costs a printed page: the shell holds a live text node, so it
- * prints complete, in order, correctly laid out and in the right font. But a printed page that
- * loses the colouring on the fences the reader never scrolled past is a defect the reader can see
- * and keep, and the printed window does not even coincide with the reader's -- a print lays the
- * document out at PAPER width while the scroll offset carries across as a raw pixel count, so the
- * page lands several fences away from where the reader was. Measured at Letter against a 1280 px
- * window: 1 to 2 deferred fences on every sampled page, and a 6.6% pixel difference against the
- * same page printed with the flag off. Matching the paper to the window removes it, which is what
- * identifies the cause -- and is exactly why chasing the window is the wrong fix. The whole
- * document is on the page, so the whole document is what has to be highlighted.
+ * Colour is all deferral costs a printed page -- the shell holds a live text node, so it prints
+ * complete, in order and in the right font -- but a page that lost the colour on fences the reader
+ * never scrolled past is a defect they can see and keep. Nor does the printed window match the
+ * reader's: a print lays out at PAPER width while the scroll offset carries across as raw pixels,
+ * so the page lands several fences away. Letter against a 1280 px window: 1 to 2 deferred fences
+ * on every sampled page, 6.6% pixel difference against the same page with the flag off; matching
+ * paper to window removes it, which identifies the cause and is why chasing the window is the
+ * wrong fix. The whole document is on the page, so the whole document has to be highlighted.
  *
- * WHY AN EARLIER ATTEMPT AT THIS FAILED, since it was measured and reported as impossible. It
- * latched every fence from `beforeprint` with `flushSync` and the blocks did swap, but 53 of 56
- * of them printed on streamdown's raw fallback: the swap alone renders the block UNHIGHLIGHTED,
- * because the highlighted body asks the plugin for tokens from a passive effect and the plugin
- * answers `null` until the grammar is loaded. `latchNow` closes both halves -- it warms the tokens
- * first, and it flushes the colouring render as well as the swap -- and `warmGrammars` below
- * removes the remaining asynchrony by making sure a grammar is never what is missing at the moment
- * the snapshot is taken.
+ * WHY AN EARLIER ATTEMPT FAILED and was reported as impossible: it latched every fence from
+ * `beforeprint` with `flushSync`, the blocks swapped, and 53 of 56 still printed on streamdown's
+ * raw fallback, because the swap alone renders UNHIGHLIGHTED while the passive effect waits on a
+ * grammar. `latchNow` closes both halves (warm, then flush the colouring render as well as the
+ * swap) and `warmGrammars` below keeps a loading grammar from being what is missing at snapshot.
  *
- * BOTH DOORS. `beforeprint` covers Ctrl+P and the print menu. A headless `page.pdf()` and
- * DevTools' print emulation change the media query without ever firing it, and a PDF export is
- * exactly the path a reader uses to keep a copy.
+ * BOTH DOORS: `beforeprint` covers Ctrl+P and the print menu; headless `page.pdf()` and DevTools
+ * print emulation change the media query without firing it, and a PDF export is how a reader keeps
+ * a copy.
  *
- * WHAT A PRINT UPGRADES IS THE DOCUMENT THAT WAS PRINTED, and nothing else.
- *
- * This was a module-global `printed` flag folded into every future fence's `reached`, and that is
- * a session-wide latch rather than a monotonic one: measured at the 100K rung, a thread holding 53
- * of 56 fences deferred, 2,458 spans and 22,794 elements printed once and then, after navigating
- * away inside the app and back, remounted with 0 deferred, 41,410 spans and 61,747 elements. One
- * Ctrl+P turned the whole default off for the rest of the tab's life, including threads that were
- * never on the printed page.
- *
- * So the print latches the fences that are on the page WHEN IT HAPPENS, which is exactly the set
- * that is about to be printed, and a fence mounted afterwards defers again as usual. Still one way
- * only, and for the same reason as everywhere else here: `latchNow` can only latch. Reverting on
- * `afterprint` would be the bidirectional edge this whole design exists to avoid, and nothing
- * below does it.
- *
- * Every print upgrades whatever is unreached at that moment, rather than the first print winning
- * and later ones doing nothing: print, scroll somewhere new, print again, and the second page is
- * as complete as the first.
+ * A PRINT UPGRADES THE DOCUMENT THAT WAS PRINTED, AND NOTHING ELSE. This was a module-global
+ * `printed` folded into every future fence's `reached`, a session-wide latch rather than a
+ * monotonic one: at the 100K rung a thread with 53 of 56 fences deferred, 2,458 spans and 22,794
+ * elements printed once, then after navigating away inside the app and back remounted with 0
+ * deferred, 41,410 spans and 61,747 elements. One Ctrl+P turned the default off for the tab's
+ * life, including threads never on the printed page. So a print latches what is on the page WHEN
+ * IT HAPPENS and a fence mounted afterwards defers again; every print does it again, so print,
+ * scroll, print gives a second page as complete as the first. Still one way only: `latchNow` can
+ * only latch, and reverting on `afterprint` would be the bidirectional edge this design avoids.
  */
 const upgradeEverythingForPrint = (): void => {
   latchNow([...unreached]);
@@ -367,15 +332,12 @@ const upgradeEverythingForPrint = (): void => {
 /*
  * GRAMMARS, WARMED AT IDLE. NOT TOKENS.
  *
- * `warm(false)` asks the plugin to highlight an EMPTY string in this fence's language, which
- * loads the grammar and tokenizes nothing. That is the whole of it: no fence is tokenized, no
- * span is mounted, and the document stays exactly the size deferral made it. What it buys is that
- * the synchronous path in `latchNow` can never be defeated by a grammar that happens to still be
- * loading -- on a jump into a language the reader has not met yet, and on a print, where there is
- * no later frame to correct in.
- *
- * Deduplicated by language and scheduled at idle, so a thread whose fences are all one language
- * pays one grammar load and a thread with nothing deferred pays nothing.
+ * `warm(false)` highlights an EMPTY string in the fence's language: the grammar loads, nothing is
+ * tokenized, no span is mounted, the document stays the size deferral made it. It buys that
+ * `latchNow`'s synchronous path cannot be defeated by a still-loading grammar -- on a jump into a
+ * language the reader has not met, and on a print, where there is no later frame to correct in.
+ * Deduplicated by language and scheduled at idle: one load per language, nothing when nothing is
+ * deferred.
  */
 const grammarsWarmed = new Set<string>();
 let warmScheduled = false;
@@ -512,13 +474,11 @@ const inBand = (node: HTMLElement, scroller: HTMLElement | null): boolean => {
  *                 state is ever written, no observer is built and no layout is read.
  * @param streaming  the fence is still being written. It is highlighted while it streams AND it
  *                 latches, so that finishing cannot take the highlighting back.
- * @param language  the fence's language token, used only to load one grammar per language rather
- *                 than one per fence. `null` is the unknown-language case and warms plain text.
- * @param warm  drive the highlighter over this fence: `true` for its tokens, `false` for its
- *                 grammar alone. Called from a jump and from a print, where the swap has to be
- *                 coloured inside the same task; see `latchNow`. Held in a ref rather than taken
- *                 as an effect dependency so that a caller who does not memoize it cannot rebuild
- *                 every observer in the thread on every render.
+ * @param language  used only to load one grammar per language rather than one per fence; `null`
+ *                 warms plain text.
+ * @param warm  drive the highlighter over this fence: `true` for tokens, `false` for the grammar
+ *                 alone. See `latchNow`. Held in a ref, not an effect dependency, so an
+ *                 unmemoized caller cannot rebuild every observer in the thread on every render.
  */
 export function useFenceReached(
   host: RefObject<HTMLElement | null>,
@@ -638,10 +598,8 @@ export function useFenceReached(
     ));
     gates.forEach(([target], i) => observers[i].observe(target));
 
-    // The same two elements, handed to the register so a jump and a print can ask the same two
-    // questions of this fence without a render and without walking the ancestor chain again. The
-    // register is rebuilt with the observers, so a rebind can never leave a stale root behind in
-    // one gate and not the other.
+    // The same two elements, so a jump and a print can ask the same questions without a render or
+    // another ancestor walk. Rebuilt with the observers, so a rebind cannot leave a stale root.
     const registered: FenceGate = {
       node,
       near,
@@ -649,9 +607,8 @@ export function useFenceReached(
       language,
       warm: (tokens) => warmRef.current(tokens),
       latch: () => setLatched(true),
-      // `generation` is bumped rather than a state of its own being added: this fence has just
-      // latched, so every effect keyed on it early-returns and the bump costs one render of one
-      // already-upgraded block. See `latchNow` for why React needs the work.
+      // Reuses `generation`: this fence has just latched, so every effect keyed on it
+      // early-returns and the bump costs one render. See `latchNow` for why React needs the work.
       poke: () => setGeneration((n) => n + 1),
     };
     unreached.add(registered);

--- a/studio/frontend/src/components/assistant-ui/code-fence-mode.ts
+++ b/studio/frontend/src/components/assistant-ui/code-fence-mode.ts
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+/*
+ * WHICH FENCE MODE IS IN FORCE, decided in one pure function.
+ *
+ * This lives apart from `code-fence-defer.tsx` for one reason: that file is a `.tsx` and the
+ * frontend's tests run under `node --experimental-strip-types`, which cannot load JSX. A decision
+ * table that can only be checked by regexes over its own source is a decision table nobody has
+ * actually run. Here every row below is exercised by `tests/code-fence-mode.test.ts`.
+ */
+
+/*
+ * Three states, not two.
+ *
+ *   "off"        every fence is highlighted at mount. What shipped before `defer` became default.
+ *   "defer"      SHIP DEFAULT. An unreached fence is a plain shell and is never tokenized.
+ *   "tokenize"   MEASUREMENT ONLY. An unreached fence is the same plain shell, but the
+ *                highlighter is still driven over its source and the result thrown away.
+ *
+ * `tokenize` exists to answer one question and is not a shipping mode. `defer` removes two things
+ * at once: the spans from the document, and the tokenizer work that produces them. An improvement
+ * seen under `defer` alone cannot say which of the two paid for it. `tokenize` holds the DOM at
+ * `defer`'s size and puts only the tokenizer work back, so the gap between `tokenize` and `defer`
+ * is the tokenizer's contribution and the gap between `off` and `tokenize` is the document's.
+ *
+ * It is reachable ONLY by the exact string "tokenize". No boolean, no empty value and no default
+ * can land on it, which is what keeps a measurement arm out of a shipped install.
+ */
+export type FenceMode = "off" | "defer" | "tokenize";
+
+/**
+ * The ship default. Moving this line is the whole of "turn deferral on by default"; every override
+ * below keeps working in both directions afterwards.
+ */
+export const SHIP_DEFAULT: FenceMode = "defer";
+
+/*
+ * AN UNSET FLAG AND AN UNRECOGNISED ONE DO NOT RESOLVE TO THE SAME MODE.
+ *
+ * Unset is the overwhelmingly common case -- every install that has never heard of this flag --
+ * and it takes `SHIP_DEFAULT`.
+ *
+ * An unrecognised non-empty value is somebody who tried to configure this and mistyped. Resolving
+ * that to the default would silently ignore the attempt. Resolving it to `off` gives them the mode
+ * where every fence is highlighted at mount, which is never wrong-looking, and is the same answer
+ * this flag gave before the default moved. A typo therefore degrades to the old behaviour rather
+ * than to the new one, through the env var and through the runtime global alike.
+ */
+
+/**
+ * @param runtime  `__UNSLOTH_DEFER_FENCE_HIGHLIGHT__`, whatever it is: a string, a boolean, or
+ *                 absent. A boolean is the ergonomic form typed into a devtools console, and it
+ *                 has to work in BOTH directions or the escape hatch is only an accelerator.
+ * @param build    the build flag `VITE_UNSLOTH_DEFER_FENCE_HIGHLIGHT`, `""` when never set.
+ */
+export const resolveFenceMode = (
+  runtime: unknown,
+  build: string,
+): FenceMode => {
+  const raw =
+    typeof runtime === "string"
+      ? runtime
+      : runtime === true
+        ? "defer"
+        : runtime === false
+          ? "off"
+          : build;
+  return raw === "1" || raw === "defer"
+    ? "defer"
+    : raw === "tokenize"
+      ? "tokenize"
+      : raw === ""
+        ? SHIP_DEFAULT
+        : "off";
+};

--- a/studio/frontend/src/components/assistant-ui/code-fence-mode.ts
+++ b/studio/frontend/src/components/assistant-ui/code-fence-mode.ts
@@ -4,55 +4,37 @@
 /*
  * WHICH FENCE MODE IS IN FORCE, decided in one pure function.
  *
- * This lives apart from `code-fence-defer.tsx` for one reason: that file is a `.tsx` and the
- * frontend's tests run under `node --experimental-strip-types`, which cannot load JSX. A decision
- * table that can only be checked by regexes over its own source is a decision table nobody has
- * actually run. Here every row below is exercised by `tests/code-fence-mode.test.ts`.
- */
-
-/*
- * Three states, not two.
+ * Kept out of `code-fence-defer.tsx` because that is a `.tsx` and the frontend's tests run under
+ * `node --experimental-strip-types`, which cannot load JSX. Every row below is RUN by
+ * `tests/code-fence-mode.test.ts` rather than checked by regexes over the source.
  *
  *   "off"        every fence is highlighted at mount. What shipped before `defer` became default.
  *   "defer"      SHIP DEFAULT. An unreached fence is a plain shell and is never tokenized.
- *   "tokenize"   MEASUREMENT ONLY. An unreached fence is the same plain shell, but the
- *                highlighter is still driven over its source and the result thrown away.
+ *   "tokenize"   MEASUREMENT ONLY. Same plain shell, but the highlighter is still driven over the
+ *                source and the result thrown away.
  *
- * `tokenize` exists to answer one question and is not a shipping mode. `defer` removes two things
- * at once: the spans from the document, and the tokenizer work that produces them. An improvement
- * seen under `defer` alone cannot say which of the two paid for it. `tokenize` holds the DOM at
- * `defer`'s size and puts only the tokenizer work back, so the gap between `tokenize` and `defer`
- * is the tokenizer's contribution and the gap between `off` and `tokenize` is the document's.
- *
- * It is reachable ONLY by the exact string "tokenize". No boolean, no empty value and no default
- * can land on it, which is what keeps a measurement arm out of a shipped install.
+ * `tokenize` is not a shipping mode. `defer` removes the spans AND the tokenizer work that makes
+ * them, so an improvement under `defer` alone cannot say which paid for it; `tokenize` holds the
+ * DOM at `defer`'s size with only the tokenizer work back, so tokenize-minus-defer is the
+ * tokenizer's share and off-minus-tokenize the document's. Reachable ONLY by the exact string
+ * "tokenize" -- no boolean, empty value or default lands there, which keeps a measurement arm out
+ * of a shipped install.
  */
 export type FenceMode = "off" | "defer" | "tokenize";
 
-/**
- * The ship default. Moving this line is the whole of "turn deferral on by default"; every override
- * below keeps working in both directions afterwards.
- */
+/** Moving this line is the whole of "turn deferral on by default"; every override still works. */
 export const SHIP_DEFAULT: FenceMode = "defer";
 
-/*
- * AN UNSET FLAG AND AN UNRECOGNISED ONE DO NOT RESOLVE TO THE SAME MODE.
- *
- * Unset is the overwhelmingly common case -- every install that has never heard of this flag --
- * and it takes `SHIP_DEFAULT`.
- *
- * An unrecognised non-empty value is somebody who tried to configure this and mistyped. Resolving
- * that to the default would silently ignore the attempt. Resolving it to `off` gives them the mode
- * where every fence is highlighted at mount, which is never wrong-looking, and is the same answer
- * this flag gave before the default moved. A typo therefore degrades to the old behaviour rather
- * than to the new one, through the env var and through the runtime global alike.
- */
-
 /**
- * @param runtime  `__UNSLOTH_DEFER_FENCE_HIGHLIGHT__`, whatever it is: a string, a boolean, or
- *                 absent. A boolean is the ergonomic form typed into a devtools console, and it
- *                 has to work in BOTH directions or the escape hatch is only an accelerator.
- * @param build    the build flag `VITE_UNSLOTH_DEFER_FENCE_HIGHLIGHT`, `""` when never set.
+ * AN UNSET FLAG AND AN UNRECOGNISED ONE DO NOT RESOLVE TO THE SAME MODE. Unset means an install
+ * that never heard of this flag, and takes `SHIP_DEFAULT`. An unrecognised non-empty value means
+ * somebody tried to configure it and mistyped: resolving that to the default would silently ignore
+ * the attempt, so it degrades to `off`, which is never wrong-looking and is what this flag gave
+ * before the default moved. Same rule for the env var and the runtime global.
+ *
+ * @param runtime  `__UNSLOTH_DEFER_FENCE_HIGHLIGHT__`: string, boolean or absent. The boolean is
+ *                 the devtools-console form and has to work in BOTH directions.
+ * @param build    `VITE_UNSLOTH_DEFER_FENCE_HIGHLIGHT`, `""` when never set.
  */
 export const resolveFenceMode = (
   runtime: unknown,

--- a/studio/frontend/src/components/assistant-ui/markdown-text.tsx
+++ b/studio/frontend/src/components/assistant-ui/markdown-text.tsx
@@ -498,9 +498,6 @@ function FenceBlock({
 }) {
   const host = useRef<HTMLDivElement | null>(null);
   const mode = fenceMode();
-  // A streaming fence is the one the reader is watching, so it never defers, and the hook latches
-  // it so that finishing the stream cannot hand it back the plain shell.
-  const reached = useFenceReached(host, mode !== "off", Boolean(isIncomplete));
 
   /*
    * WHICH FENCES THIS COVERS, and which it does not.
@@ -528,6 +525,38 @@ function FenceBlock({
   // tokenize an unknown language as plain text -- which is exactly the grammar work the arm
   // exists to put back.
   const languageToken = language?.trim().split(/\s+/)[0] || null;
+
+  /*
+   * DRIVE THE HIGHLIGHTER OVER THIS FENCE ON DEMAND. The latch owns WHEN; this owns WHAT, because
+   * the plugin instance lives here with the component that renders the block.
+   *
+   * `tokens: true` produces this fence's tokens. `code.highlight` returns them synchronously once
+   * the grammar is loaded and caches on the source string, so the result is the same object the
+   * block's own render is about to ask for -- which is what lets a jump or a print swap straight
+   * to a COLOURED block rather than to streamdown's plain fallback.
+   *
+   * `tokens: false` highlights the empty string, which loads the grammar and tokenizes nothing.
+   */
+  const warm = useCallback(
+    (tokens: boolean) => {
+      code.highlight({
+        code: tokens ? trimTrailingNewlines(source) : "",
+        language: (languageToken ?? "text") as never,
+        themes: STREAMDOWN_SHIKI_THEME,
+      }, () => {});
+    },
+    [source, languageToken],
+  );
+
+  // A streaming fence is the one the reader is watching, so it never defers, and the hook latches
+  // it so that finishing the stream cannot hand it back the plain shell.
+  const reached = useFenceReached(
+    host,
+    mode !== "off",
+    Boolean(isIncomplete),
+    languageToken,
+    warm,
+  );
 
   // MEASUREMENT ARM ONLY. See `FenceMode`: this puts the tokenizer work back while leaving the
   // document at the deferred size, so the two costs can be told apart. `code.highlight` caches

--- a/studio/frontend/src/components/assistant-ui/markdown-text.tsx
+++ b/studio/frontend/src/components/assistant-ui/markdown-text.tsx
@@ -530,12 +530,10 @@ function FenceBlock({
    * DRIVE THE HIGHLIGHTER OVER THIS FENCE ON DEMAND. The latch owns WHEN; this owns WHAT, because
    * the plugin instance lives here with the component that renders the block.
    *
-   * `tokens: true` produces this fence's tokens. `code.highlight` returns them synchronously once
-   * the grammar is loaded and caches on the source string, so the result is the same object the
-   * block's own render is about to ask for -- which is what lets a jump or a print swap straight
-   * to a COLOURED block rather than to streamdown's plain fallback.
-   *
-   * `tokens: false` highlights the empty string, which loads the grammar and tokenizes nothing.
+   * `tokens: true`: `code.highlight` returns synchronously once the grammar is loaded and caches
+   * on the source string, so this is the same object the block's own render is about to ask for,
+   * which is what lets a jump or a print swap straight to a COLOURED block rather than to
+   * streamdown's plain fallback. `tokens: false` highlights "", loading the grammar only.
    */
   const warm = useCallback(
     (tokens: boolean) => {

--- a/studio/frontend/tests/code-fence-defer.test.ts
+++ b/studio/frontend/tests/code-fence-defer.test.ts
@@ -215,18 +215,22 @@ test("a nested scroller is gated by the outermost one as well", () => {
   assert.equal(band(ahead, onScreen), true, "so a fence one window below it still pre-warms");
 });
 
-test("the flag defaults off, and off means today's behaviour", () => {
+test("the mode is decided in one place, and `off` still means the pre-default behaviour", () => {
+  // The decision table itself is in `code-fence-mode.ts` and is RUN, row by row, by
+  // `tests/code-fence-mode.test.ts`. What this file has to pin is that this module does not grow
+  // a second opinion about the mode, and that `off` still switches the whole hook out.
   assert.ok(
-    SOURCE.includes('return raw === "1" || raw === "defer"'),
-    "the mode is decided from the flag value",
+    SOURCE.includes('export { type FenceMode, resolveFenceMode, SHIP_DEFAULT } from "./code-fence-mode";'),
+    "the mode module is the single source of the decision",
   );
   assert.ok(
-    /:\s*"off";/.test(SOURCE),
-    "any value that is not an understood mode must fall through to off",
+    !/raw === "defer"|SHIP_DEFAULT: FenceMode|const raw =/.test(SOURCE),
+    "no copy of the decision table may live here as well",
   );
   assert.ok(
-    MARKDOWN_TEXT.includes('useFenceReached(host, mode !== "off", Boolean(isIncomplete))'),
-    "with the flag off every fence must render immediately, exactly as it does today",
+    /useFenceReached\(\s*host,\s*mode !== "off",\s*Boolean\(isIncomplete\),/.test(MARKDOWN_TEXT),
+    "with the mode off every fence must render immediately, exactly as it did before the default " +
+      "moved",
   );
 });
 
@@ -302,9 +306,12 @@ test("the gate does not mount a wrapper element of its own", () => {
 });
 
 test("the tokenize arm is measurement only and is not reachable from a boolean flag", () => {
+  // The selection rule itself, and every shape that must NOT reach it, is exercised in
+  // `tests/code-fence-mode.test.ts`. What matters here is that the measurement arm cannot be
+  // entered from this module by any route other than that one resolved mode.
   assert.ok(
-    SOURCE.includes('raw === "tokenize"'),
-    "the tokenize arm is selected by an explicit string, never by a truthy flag",
+    !/"tokenize"/.test(SOURCE),
+    "this module must not name the measurement arm at all; it only consumes a resolved mode",
   );
   assert.ok(
     MARKDOWN_TEXT.includes('const pretokenize = mode === "tokenize" && !reached'),
@@ -312,32 +319,81 @@ test("the tokenize arm is measurement only and is not reachable from a boolean f
   );
 });
 
-test("there is no print machinery left to leak", () => {
-  // A `beforeprint` path that latched every mounted fence, warmed grammars at idle and flushed
-  // twice was removed after it was measured: synchronous dispatch and read in one task, 53 of 56
-  // blocks still printed on streamdown's raw fallback at every delay out to twenty seconds. The
-  // shipped build is fully highlighted after about three seconds. Neither a warm grammar nor a
-  // second flushSync makes an effect-driven, lazily imported highlighter produce tokens inside
-  // the synchronous print task.
-  //
-  // Three review rounds went on leaks inside that machinery. This test exists so it does not come
-  // back without a measurement showing it works.
-  for (const gone of ["flushSync", "printListeners", "claimChunkWarm", "beforeprint"]) {
+test("a print upgrades the whole document, and never puts it back", () => {
+  // An earlier `beforeprint` path latched every fence and was removed after it was measured: 53
+  // of 56 blocks still printed on streamdown's raw fallback out to twenty seconds. The reason was
+  // not the latch, it was what the latch renders -- streamdown's highlighted body asks the plugin
+  // for tokens from a PASSIVE effect and shows a plain fallback until the plugin answers, and the
+  // plugin answers `null` while a grammar is loading. `latchNow` closes both halves: it warms the
+  // tokens first, then flushes twice so the passive effect and the update it schedules land in
+  // the same task. Do not re-remove one half and keep the other.
+  for (const door of ["beforeprint", 'matchMedia?.("print")']) {
     assert.ok(
-      !new RegExp(`(addEventListener|const|let)[^\\n]*${gone}`).test(SOURCE),
-      `${gone} was removed because it did not work; re-adding it needs a measurement first`,
+      SOURCE.includes(door),
+      `${door} is one of the two ways a document reaches a printer, and both must be covered`,
     );
   }
   assert.ok(
-    !/warmedGrammars|pendingGrammars/.test(MARKDOWN_TEXT),
-    "the grammar warm-up was removed with the rest of the print path",
+    !/addEventListener\(\s*"afterprint"/.test(SOURCE),
+    "reverting on afterprint would be exactly the bidirectional edge this design removes",
+  );
+  const assignments = SOURCE.match(/printed = (?:true|false)/g) ?? [];
+  assert.deepEqual(
+    assignments,
+    ["printed = false", "printed = true"],
+    "`printed` is declared false and set true exactly once; nothing may clear it again",
   );
 });
 
-test("the print limitation is written down where it is decided", () => {
+test("an upgrade taken inside one task warms, flushes, and flushes again", () => {
+  // Each of the three is load-bearing on its own; dropping any one puts a plain frame back on
+  // screen (on a jump) or a colourless fence on the page (in a print).
+  const latchNow = SOURCE.slice(SOURCE.indexOf("const latchNow"));
+  const body = latchNow.slice(0, latchNow.indexOf("\n};"));
+  assert.ok(body.includes("gate.warm(true)"), "the tokens have to exist before the swap renders");
   assert.ok(
-    SOURCE.includes("PRINT: NOT HANDLED") && SOURCE.includes("53 of 56"),
-    "the measured limitation belongs next to the code that causes it, with its number",
+    body.indexOf("gate.warm(true)") < body.indexOf("flushSync"),
+    "warming after the flush is warming after the paint",
+  );
+  assert.equal(
+    body.split("flushSync").length - 1,
+    3,
+    "an outer flush holds the update priority discrete; one inner flush commits the swap and the "
+      + "second runs the passive effect that colours it",
+  );
+  assert.ok(
+    body.includes("gate.poke()"),
+    "react only runs pending passive effects when it has sync work, so the second flush needs some",
+  );
+});
+
+test("a jump is recognised from the lookahead, not from a tuned number", () => {
+  // `REACH_MARGIN` grows the observer band by one root height, so a scroll of at most one height
+  // can only reveal fences the observers had already reached. The pass therefore runs when, and
+  // only when, the movement exceeded the lookahead. A literal pixel threshold here would be a
+  // number nobody could derive and nobody would maintain.
+  assert.ok(
+    /Math\.abs\(top - before\) <= height/.test(SOURCE),
+    "the jump test compares the movement against the root height the margin is one of",
+  );
+  assert.ok(
+    !/[^a-zA-Z_]\d{2,}\s*(?:px)?\s*[;)]/.test(SOURCE.slice(SOURCE.indexOf("const onScroll"), SOURCE.indexOf("const watchScrolling"))),
+    "no pixel constant may appear in the jump test",
+  );
+});
+
+test("nothing is watched once there is nothing left to defer", () => {
+  // The claim this change rests on is that a fence the reader has already reached carries no
+  // residual per-scroll cost. One capturing listener is shared by every fence, so it has to be
+  // removed when the last one latches or the claim stops being true.
+  assert.ok(
+    /document\.addEventListener\("scroll", onScroll, \{ capture: true, passive: true \}\)/.test(SOURCE),
+    "one capturing, passive listener sees scrolling on nested panes as well as on the thread",
+  );
+  assert.ok(
+    /unreached\.size > 0/.test(SOURCE) &&
+      /document\.removeEventListener\("scroll", onScroll/.test(SOURCE),
+    "the listener is removed when the register empties",
   );
 });
 

--- a/studio/frontend/tests/code-fence-defer.test.ts
+++ b/studio/frontend/tests/code-fence-defer.test.ts
@@ -337,11 +337,20 @@ test("a print upgrades the whole document, and never puts it back", () => {
     !/addEventListener\(\s*"afterprint"/.test(SOURCE),
     "reverting on afterprint would be exactly the bidirectional edge this design removes",
   );
-  const assignments = SOURCE.match(/printed = (?:true|false)/g) ?? [];
-  assert.deepEqual(
-    assignments,
-    ["printed = false", "printed = true"],
-    "`printed` is declared false and set true exactly once; nothing may clear it again",
+  // A PRINT IS NOT A SESSION-WIDE SWITCH. This was a module-global `printed` folded into every
+  // future fence's `reached`, which measured, at the 100K rung, as: print once, navigate away
+  // inside the app and back, and the thread remounts with 0 of 56 fences deferred, 41,410 spans
+  // and 61,747 elements instead of 53, 2,458 and 22,794. One Ctrl+P turned the default off for
+  // the rest of the tab.
+  assert.ok(
+    /const reached = !enabled \|\| !CAN_OBSERVE \|\| streaming \|\| latched;/.test(SOURCE),
+    "no print state may be folded into a fence's reached: a fence mounted after a print was not " +
+      "on the printed page and has nothing to latch for",
+  );
+  assert.ok(
+    /const upgradeEverythingForPrint = \(\): void => \{\s*latchNow\(\[\.\.\.unreached\]\);\s*\};/
+      .test(SOURCE),
+    "a print latches exactly what is unreached when it happens, and every print does it again",
   );
 });
 

--- a/studio/frontend/tests/code-fence-defer.test.ts
+++ b/studio/frontend/tests/code-fence-defer.test.ts
@@ -216,9 +216,8 @@ test("a nested scroller is gated by the outermost one as well", () => {
 });
 
 test("the mode is decided in one place, and `off` still means the pre-default behaviour", () => {
-  // The decision table itself is in `code-fence-mode.ts` and is RUN, row by row, by
-  // `tests/code-fence-mode.test.ts`. What this file has to pin is that this module does not grow
-  // a second opinion about the mode, and that `off` still switches the whole hook out.
+  // The table itself is RUN row by row in `tests/code-fence-mode.test.ts`. What this file pins is
+  // that this module grows no second opinion, and that `off` still switches the whole hook out.
   assert.ok(
     SOURCE.includes('export { type FenceMode, resolveFenceMode, SHIP_DEFAULT } from "./code-fence-mode";'),
     "the mode module is the single source of the decision",
@@ -306,9 +305,8 @@ test("the gate does not mount a wrapper element of its own", () => {
 });
 
 test("the tokenize arm is measurement only and is not reachable from a boolean flag", () => {
-  // The selection rule itself, and every shape that must NOT reach it, is exercised in
-  // `tests/code-fence-mode.test.ts`. What matters here is that the measurement arm cannot be
-  // entered from this module by any route other than that one resolved mode.
+  // The selection rule, and every shape that must NOT reach it, is exercised in
+  // `tests/code-fence-mode.test.ts`. Here: no route into the arm except that resolved mode.
   assert.ok(
     !/"tokenize"/.test(SOURCE),
     "this module must not name the measurement arm at all; it only consumes a resolved mode",
@@ -320,13 +318,10 @@ test("the tokenize arm is measurement only and is not reachable from a boolean f
 });
 
 test("a print upgrades the whole document, and never puts it back", () => {
-  // An earlier `beforeprint` path latched every fence and was removed after it was measured: 53
-  // of 56 blocks still printed on streamdown's raw fallback out to twenty seconds. The reason was
-  // not the latch, it was what the latch renders -- streamdown's highlighted body asks the plugin
-  // for tokens from a PASSIVE effect and shows a plain fallback until the plugin answers, and the
-  // plugin answers `null` while a grammar is loading. `latchNow` closes both halves: it warms the
-  // tokens first, then flushes twice so the passive effect and the update it schedules land in
-  // the same task. Do not re-remove one half and keep the other.
+  // An earlier `beforeprint` path was removed after 53 of 56 blocks still printed on streamdown's
+  // raw fallback out to twenty seconds. The latch was not the problem: what it renders is, since
+  // the highlighted body asks for tokens from a PASSIVE effect and the plugin answers `null` while
+  // a grammar loads. `latchNow` closes both halves, warming then flushing twice. Keep both.
   for (const door of ["beforeprint", 'matchMedia?.("print")']) {
     assert.ok(
       SOURCE.includes(door),
@@ -337,11 +332,10 @@ test("a print upgrades the whole document, and never puts it back", () => {
     !/addEventListener\(\s*"afterprint"/.test(SOURCE),
     "reverting on afterprint would be exactly the bidirectional edge this design removes",
   );
-  // A PRINT IS NOT A SESSION-WIDE SWITCH. This was a module-global `printed` folded into every
-  // future fence's `reached`, which measured, at the 100K rung, as: print once, navigate away
-  // inside the app and back, and the thread remounts with 0 of 56 fences deferred, 41,410 spans
-  // and 61,747 elements instead of 53, 2,458 and 22,794. One Ctrl+P turned the default off for
-  // the rest of the tab.
+  // A PRINT IS NOT A SESSION-WIDE SWITCH. As a module-global `printed` folded into every future
+  // fence's `reached` it measured, at the 100K rung: print once, navigate away in-app and back,
+  // and the thread remounts with 0 of 56 fences deferred, 41,410 spans and 61,747 elements instead
+  // of 53, 2,458 and 22,794. One Ctrl+P turned the default off for the rest of the tab.
   assert.ok(
     /const reached = !enabled \|\| !CAN_OBSERVE \|\| streaming \|\| latched;/.test(SOURCE),
     "no print state may be folded into a fence's reached: a fence mounted after a print was not " +
@@ -355,8 +349,8 @@ test("a print upgrades the whole document, and never puts it back", () => {
 });
 
 test("an upgrade taken inside one task warms, flushes, and flushes again", () => {
-  // Each of the three is load-bearing on its own; dropping any one puts a plain frame back on
-  // screen (on a jump) or a colourless fence on the page (in a print).
+  // Dropping any one of the three puts a plain frame back on a jump, or a colourless fence on a
+  // printed page.
   const latchNow = SOURCE.slice(SOURCE.indexOf("const latchNow"));
   const body = latchNow.slice(0, latchNow.indexOf("\n};"));
   assert.ok(body.includes("gate.warm(true)"), "the tokens have to exist before the swap renders");
@@ -377,10 +371,9 @@ test("an upgrade taken inside one task warms, flushes, and flushes again", () =>
 });
 
 test("a jump is recognised from the lookahead, not from a tuned number", () => {
-  // `REACH_MARGIN` grows the observer band by one root height, so a scroll of at most one height
-  // can only reveal fences the observers had already reached. The pass therefore runs when, and
-  // only when, the movement exceeded the lookahead. A literal pixel threshold here would be a
-  // number nobody could derive and nobody would maintain.
+  // `REACH_MARGIN` grows the band by one root height, so a scroll of at most one height can only
+  // reveal fences already reached: the pass runs exactly when the movement beat the lookahead. A
+  // literal pixel threshold would be a number nobody could derive or maintain.
   assert.ok(
     /Math\.abs\(top - before\) <= height/.test(SOURCE),
     "the jump test compares the movement against the root height the margin is one of",
@@ -392,9 +385,8 @@ test("a jump is recognised from the lookahead, not from a tuned number", () => {
 });
 
 test("nothing is watched once there is nothing left to defer", () => {
-  // The claim this change rests on is that a fence the reader has already reached carries no
-  // residual per-scroll cost. One capturing listener is shared by every fence, so it has to be
-  // removed when the last one latches or the claim stops being true.
+  // This change claims a reached fence carries no residual per-scroll cost. The one shared
+  // capturing listener must therefore be removed when the last fence latches.
   assert.ok(
     /document\.addEventListener\("scroll", onScroll, \{ capture: true, passive: true \}\)/.test(SOURCE),
     "one capturing, passive listener sees scrolling on nested panes as well as on the thread",

--- a/studio/frontend/tests/code-fence-mode.test.ts
+++ b/studio/frontend/tests/code-fence-mode.test.ts
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+import {
+  SHIP_DEFAULT,
+  resolveFenceMode,
+} from "../src/components/assistant-ui/code-fence-mode.ts";
+
+/**
+ * The fence mode decision table, RUN rather than described.
+ *
+ * Every other test around this change is a regex over a source file, because the thing being
+ * protected is a React hook over IntersectionObserver and a behavioural test would need a DOM.
+ * This one is not: the mode is a pure function of two values, and the whole point of the default
+ * moving from "off" to "defer" is that every existing way of overriding it keeps working in BOTH
+ * directions. A truth table nobody executes is not evidence that it does.
+ */
+
+test("an install that has never set the flag gets the ship default", () => {
+  assert.equal(SHIP_DEFAULT, "defer", "the ship default is deferral");
+  assert.equal(resolveFenceMode(undefined, ""), "defer");
+});
+
+test("the build flag overrides the default in both directions", () => {
+  // DOWN: an install that wants exactly the old rendering says so and gets it.
+  assert.equal(resolveFenceMode(undefined, "off"), "off");
+  assert.equal(resolveFenceMode(undefined, "0"), "off");
+  // UP: still selects deferral explicitly, which is what every measurement arm passes.
+  assert.equal(resolveFenceMode(undefined, "defer"), "defer");
+  assert.equal(resolveFenceMode(undefined, "1"), "defer");
+});
+
+test("the runtime global overrides the default in both directions", () => {
+  // The string forms.
+  assert.equal(resolveFenceMode("off", ""), "off");
+  assert.equal(resolveFenceMode("defer", ""), "defer");
+  // And the boolean forms a devtools console types. `false` must turn it OFF against a default
+  // that is now ON, which is the direction that did not previously have to work.
+  assert.equal(resolveFenceMode(false, ""), "off");
+  assert.equal(resolveFenceMode(true, ""), "defer");
+});
+
+test("the runtime global beats the build flag, both ways round", () => {
+  assert.equal(
+    resolveFenceMode(false, "defer"),
+    "off",
+    "global off beats a build that said on",
+  );
+  assert.equal(resolveFenceMode("off", "defer"), "off");
+  assert.equal(
+    resolveFenceMode(true, "off"),
+    "defer",
+    "global on beats a build that said off",
+  );
+  assert.equal(resolveFenceMode("defer", "off"), "defer");
+});
+
+test("a typo degrades to the old behaviour, never to the new default", () => {
+  // Someone tried to configure this and misspelled it. Falling through to the DEFAULT would
+  // silently ignore the attempt; falling through to `off` gives them the mode where every fence is
+  // highlighted at mount, which is never wrong-looking, and is what this flag did before the
+  // default moved.
+  for (const typo of [
+    "defr",
+    "DEFER",
+    "true",
+    "yes",
+    "on",
+    "2",
+    " defer",
+    "tokenise",
+  ]) {
+    assert.equal(
+      resolveFenceMode(undefined, typo),
+      "off",
+      `build flag ${typo}`,
+    );
+    assert.equal(resolveFenceMode(typo, ""), "off", `runtime global ${typo}`);
+  }
+});
+
+test("tokenize is measurement only and no default or boolean can reach it", () => {
+  assert.equal(
+    resolveFenceMode(undefined, "tokenize"),
+    "tokenize",
+    "explicit string only",
+  );
+  assert.equal(resolveFenceMode("tokenize", ""), "tokenize");
+  // Nothing else may land there. In particular the two shapes that carry no opinion about which
+  // mode is wanted -- an absent global and an unset build flag -- must not.
+  assert.notEqual(resolveFenceMode(undefined, ""), "tokenize");
+  assert.notEqual(resolveFenceMode(true, ""), "tokenize");
+  assert.notEqual(resolveFenceMode(false, ""), "tokenize");
+  assert.notEqual(resolveFenceMode(1 as unknown, ""), "tokenize");
+  assert.notEqual(resolveFenceMode({} as unknown, ""), "tokenize");
+});
+
+test("a non-string non-boolean global is ignored rather than coerced", () => {
+  // `globalThis.__UNSLOTH_DEFER_FENCE_HIGHLIGHT__ = 1` is a plausible console typo. Coercing it
+  // would make a truthy number mean "defer" and a falsy one mean "off", which are two more
+  // undocumented spellings. It falls through to the build flag instead.
+  assert.equal(resolveFenceMode(1 as unknown, "off"), "off");
+  assert.equal(resolveFenceMode(0 as unknown, "defer"), "defer");
+  assert.equal(resolveFenceMode(null, ""), SHIP_DEFAULT);
+  assert.equal(resolveFenceMode({} as unknown, ""), SHIP_DEFAULT);
+});
+
+/**
+ * The mode module must stay free of JSX, or this file stops being loadable and every assertion
+ * above silently turns back into a comment.
+ */
+test("the mode module is plain TypeScript", () => {
+  const source = readFileSync(
+    new URL(
+      "../src/components/assistant-ui/code-fence-mode.ts",
+      import.meta.url,
+    ),
+    "utf8",
+  );
+  assert.ok(
+    !/<[A-Za-z]/.test(source.replace(/^\s*[/*].*$/gm, "")),
+    "no JSX in the mode module",
+  );
+  assert.ok(
+    !/\bfrom\s+["']react["']/.test(source),
+    "and no react import: this module has to load under --experimental-strip-types",
+  );
+});

--- a/studio/frontend/tests/code-fence-mode.test.ts
+++ b/studio/frontend/tests/code-fence-mode.test.ts
@@ -13,11 +13,10 @@ import {
 /**
  * The fence mode decision table, RUN rather than described.
  *
- * Every other test around this change is a regex over a source file, because the thing being
- * protected is a React hook over IntersectionObserver and a behavioural test would need a DOM.
- * This one is not: the mode is a pure function of two values, and the whole point of the default
- * moving from "off" to "defer" is that every existing way of overriding it keeps working in BOTH
- * directions. A truth table nobody executes is not evidence that it does.
+ * The other tests around this change are regexes over source, because what they protect is a React
+ * hook over IntersectionObserver and would need a DOM. This is a pure function of two values, and
+ * the point of the default moving from "off" to "defer" is that every existing override keeps
+ * working in BOTH directions. A truth table nobody executes is not evidence of that.
  */
 
 test("an install that has never set the flag gets the ship default", () => {
@@ -35,11 +34,10 @@ test("the build flag overrides the default in both directions", () => {
 });
 
 test("the runtime global overrides the default in both directions", () => {
-  // The string forms.
   assert.equal(resolveFenceMode("off", ""), "off");
   assert.equal(resolveFenceMode("defer", ""), "defer");
-  // And the boolean forms a devtools console types. `false` must turn it OFF against a default
-  // that is now ON, which is the direction that did not previously have to work.
+  // The boolean forms a devtools console types. `false` must turn it OFF against a now-ON default,
+  // the direction that did not previously have to work.
   assert.equal(resolveFenceMode(false, ""), "off");
   assert.equal(resolveFenceMode(true, ""), "defer");
 });
@@ -60,10 +58,8 @@ test("the runtime global beats the build flag, both ways round", () => {
 });
 
 test("a typo degrades to the old behaviour, never to the new default", () => {
-  // Someone tried to configure this and misspelled it. Falling through to the DEFAULT would
-  // silently ignore the attempt; falling through to `off` gives them the mode where every fence is
-  // highlighted at mount, which is never wrong-looking, and is what this flag did before the
-  // default moved.
+  // Falling through to the DEFAULT would silently ignore the attempt. `off` highlights every fence
+  // at mount, which is never wrong-looking, and is what this flag did before the default moved.
   for (const typo of [
     "defr",
     "DEFER",
@@ -90,8 +86,8 @@ test("tokenize is measurement only and no default or boolean can reach it", () =
     "explicit string only",
   );
   assert.equal(resolveFenceMode("tokenize", ""), "tokenize");
-  // Nothing else may land there. In particular the two shapes that carry no opinion about which
-  // mode is wanted -- an absent global and an unset build flag -- must not.
+  // Nothing else may land there, least of all the shapes carrying no opinion: absent global, unset
+  // build flag.
   assert.notEqual(resolveFenceMode(undefined, ""), "tokenize");
   assert.notEqual(resolveFenceMode(true, ""), "tokenize");
   assert.notEqual(resolveFenceMode(false, ""), "tokenize");
@@ -100,19 +96,15 @@ test("tokenize is measurement only and no default or boolean can reach it", () =
 });
 
 test("a non-string non-boolean global is ignored rather than coerced", () => {
-  // `globalThis.__UNSLOTH_DEFER_FENCE_HIGHLIGHT__ = 1` is a plausible console typo. Coercing it
-  // would make a truthy number mean "defer" and a falsy one mean "off", which are two more
-  // undocumented spellings. It falls through to the build flag instead.
+  // `__UNSLOTH_DEFER_FENCE_HIGHLIGHT__ = 1` is a plausible console typo. Coercing it would add two
+  // more undocumented spellings, so it falls through to the build flag instead.
   assert.equal(resolveFenceMode(1 as unknown, "off"), "off");
   assert.equal(resolveFenceMode(0 as unknown, "defer"), "defer");
   assert.equal(resolveFenceMode(null, ""), SHIP_DEFAULT);
   assert.equal(resolveFenceMode({} as unknown, ""), SHIP_DEFAULT);
 });
 
-/**
- * The mode module must stay free of JSX, or this file stops being loadable and every assertion
- * above silently turns back into a comment.
- */
+/** JSX in the mode module makes this file unloadable and every assertion above a comment. */
 test("the mode module is plain TypeScript", () => {
   const source = readFileSync(
     new URL(

--- a/tests/studio/playwright_heavy_thread.py
+++ b/tests/studio/playwright_heavy_thread.py
@@ -1199,7 +1199,15 @@ TABLE_ROWS = (
     ("messages rendered", lambda r: r["counts"]["messages"]),
     ("dom nodes", lambda r: r["counts"]["domNodes"]),
     ("code blocks", lambda r: r["counts"]["codeBlocks"]),
+    # Printed side by side deliberately. `code chars` is what the fixture built and does not move
+    # when a fence defers; `highlighted tokens` and `deferred fences` are how much of it the
+    # reader's viewport had reached. A reader comparing two runs needs to see all three, because
+    # only the first is a statement about the fixture.
+    ("code chars", lambda r: r["counts"].get("codeChars", 0)),
     ("highlighted tokens", lambda r: r["counts"]["highlightedTokens"]),
+    ("fence blocks", lambda r: r["counts"].get("fenceBlocks", 0)),
+    ("deferred fences", lambda r: r["counts"].get("deferredFences", 0)),
+    ("mounted but unhighlighted fences", lambda r: r["counts"].get("unhighlightedMountedFences", 0)),
     ("tool parts", lambda r: r["counts"]["toolParts"]),
     ("collapsible tool outputs", lambda r: r["counts"]["collapsibleOutputs"]),
     ("code execution panes", lambda r: r["counts"]["codeExecutionPanes"]),
@@ -1757,6 +1765,25 @@ def harness_failures(results: dict, report: dict) -> list[str]:
                     )
             if counts.get("highlightedTokens", 0) <= 0:
                 failures.append(f"{where} highlighted nothing; Shiki never ran")
+            # DEFERRAL IS EXPECTED. AN UNHIGHLIGHTED MOUNTED FENCE IS NOT.
+            #
+            # Off-screen code fences render as a plain shell by default, so a floor under the
+            # total token count no longer separates "this thread has settled" from "the reader is
+            # not looking at most of the code". This asks the question per block instead: every
+            # fence is either a deferred shell, which is a state with a name and an attribute, or
+            # it is highlighted. The third state -- mounted, not deferred, and still showing
+            # streamdown's own unhighlighted fallback -- exists for a frame while the highlighter's
+            # passive effect runs, and a settled thread must hold none of them.
+            #
+            # This is STRICTER than the total it replaces: one block stuck on the fallback used to
+            # pass as long as the other blocks made the count up.
+            stuck = counts.get("unhighlightedMountedFences", 0)
+            if stuck:
+                failures.append(
+                    f"{where} left {stuck} of {counts.get('fenceBlocks', 0)} code fences mounted "
+                    f"but unhighlighted after settling, neither deferred nor coloured; the "
+                    "thread had not finished building itself when it was measured"
+                )
             viewport = row["viewport"]
             if viewport["scrollHeight"] <= viewport["clientHeight"]:
                 failures.append(

--- a/tests/studio/playwright_heavy_thread.py
+++ b/tests/studio/playwright_heavy_thread.py
@@ -1199,10 +1199,9 @@ TABLE_ROWS = (
     ("messages rendered", lambda r: r["counts"]["messages"]),
     ("dom nodes", lambda r: r["counts"]["domNodes"]),
     ("code blocks", lambda r: r["counts"]["codeBlocks"]),
-    # Printed side by side deliberately. `code chars` is what the fixture built and does not move
-    # when a fence defers; `highlighted tokens` and `deferred fences` are how much of it the
-    # reader's viewport had reached. A reader comparing two runs needs to see all three, because
-    # only the first is a statement about the fixture.
+    # Side by side deliberately: `code chars` is what the fixture built and does not move when a
+    # fence defers, while `highlighted tokens` and `deferred fences` are how much of it the
+    # viewport reached. Only the first is a statement about the fixture.
     ("code chars", lambda r: r["counts"].get("codeChars", 0)),
     ("highlighted tokens", lambda r: r["counts"]["highlightedTokens"]),
     ("fence blocks", lambda r: r["counts"].get("fenceBlocks", 0)),
@@ -1770,16 +1769,12 @@ def harness_failures(results: dict, report: dict) -> list[str]:
                 failures.append(f"{where} highlighted nothing; Shiki never ran")
             # DEFERRAL IS EXPECTED. AN UNHIGHLIGHTED MOUNTED FENCE IS NOT.
             #
-            # Off-screen code fences render as a plain shell by default, so a floor under the
-            # total token count no longer separates "this thread has settled" from "the reader is
-            # not looking at most of the code". This asks the question per block instead: every
-            # fence is either a deferred shell, which is a state with a name and an attribute, or
-            # it is highlighted. The third state -- mounted, not deferred, and still showing
-            # streamdown's own unhighlighted fallback -- exists for a frame while the highlighter's
-            # passive effect runs, and a settled thread must hold none of them.
-            #
-            # This is STRICTER than the total it replaces: one block stuck on the fallback used to
-            # pass as long as the other blocks made the count up.
+            # A floor on total tokens no longer separates "settled" from "the reader is not looking
+            # at most of the code", so ask per block: a fence is either a deferred shell, which is
+            # a named state with an attribute, or highlighted. The third state -- mounted, not
+            # deferred, still on streamdown's fallback -- lasts a frame while the highlighter's
+            # passive effect runs, and a settled thread must hold none. Stricter than the total it
+            # replaces, which one stuck block passed as long as the others made the count up.
             stuck = counts.get("unhighlightedMountedFences", 0)
             if stuck:
                 failures.append(

--- a/tests/studio/playwright_heavy_thread.py
+++ b/tests/studio/playwright_heavy_thread.py
@@ -1207,7 +1207,10 @@ TABLE_ROWS = (
     ("highlighted tokens", lambda r: r["counts"]["highlightedTokens"]),
     ("fence blocks", lambda r: r["counts"].get("fenceBlocks", 0)),
     ("deferred fences", lambda r: r["counts"].get("deferredFences", 0)),
-    ("mounted but unhighlighted fences", lambda r: r["counts"].get("unhighlightedMountedFences", 0)),
+    (
+        "mounted but unhighlighted fences",
+        lambda r: r["counts"].get("unhighlightedMountedFences", 0),
+    ),
     ("tool parts", lambda r: r["counts"]["toolParts"]),
     ("collapsible tool outputs", lambda r: r["counts"]["collapsibleOutputs"]),
     ("code execution panes", lambda r: r["counts"]["codeExecutionPanes"]),

--- a/tests/studio/test_heavy_thread_harness_contract.py
+++ b/tests/studio/test_heavy_thread_harness_contract.py
@@ -126,6 +126,28 @@ def test_the_verdict_asserts_the_fixture_and_not_just_its_size() -> None:
     assert 'counts.get("highlightedTokens", 0)' in decision
 
 
+def test_the_fixture_assertion_survives_deferred_fence_highlighting() -> None:
+    # Off-screen fences render as a plain shell by default, so a floor under the TOKEN count is
+    # partly a measurement of where the viewport is: the same unchanged fixture dropped from 3,216
+    # tokens per cycle to 1,322. Lowering that floor to fit would leave the check unable to tell a
+    # deferred thread from one that had quietly stopped rendering code, which is the only thing it
+    # is for. The size assertion is therefore made on characters, which the shell carries too.
+    page = (FRONTEND / "smoke-heavy-thread-main.tsx").read_text(encoding = "utf-8")
+    head = page.index("const EXPECTED_PER_CYCLE")
+    expected = page[head : page.index("};", head)]
+    assert "codeChars: 12000" in expected, "the floor has to be on something deferral cannot move"
+    assert "highlightedTokens:" not in expected, "the token floor was the thing deferral broke"
+
+
+def test_a_fence_may_be_deferred_or_highlighted_but_not_neither() -> None:
+    # The half of the old token floor that was about SETTLEMENT rather than about the fixture,
+    # asked per block instead of in total. One block stuck on streamdown's unhighlighted fallback
+    # used to pass as long as the other blocks made the count up.
+    page = (FRONTEND / "smoke-heavy-thread-main.tsx").read_text(encoding = "utf-8")
+    assert "unhighlightedMountedFences" in page
+    assert 'counts.get("unhighlightedMountedFences", 0)' in verdict()
+
+
 def test_the_verdict_asserts_the_keystroke_reached_the_runtime() -> None:
     # The DOM value is what the harness itself wrote. A keystroke that reached nothing still
     # reports the ~33ms paint floor, which reads as a plausible timing.

--- a/tests/studio/test_heavy_thread_harness_contract.py
+++ b/tests/studio/test_heavy_thread_harness_contract.py
@@ -127,11 +127,10 @@ def test_the_verdict_asserts_the_fixture_and_not_just_its_size() -> None:
 
 
 def test_the_fixture_assertion_survives_deferred_fence_highlighting() -> None:
-    # Off-screen fences render as a plain shell by default, so a floor under the TOKEN count is
-    # partly a measurement of where the viewport is: the same unchanged fixture dropped from 3,216
-    # tokens per cycle to 1,322. Lowering that floor to fit would leave the check unable to tell a
-    # deferred thread from one that had quietly stopped rendering code, which is the only thing it
-    # is for. The size assertion is therefore made on characters, which the shell carries too.
+    # A floor on the TOKEN count partly measures where the viewport is: the same unchanged fixture
+    # dropped from 3,216 tokens per cycle to 1,322. Lowering it to fit would leave the check unable
+    # to tell a deferred thread from one that stopped rendering code, which is all it is for. So
+    # the size assertion is on characters, which the deferred shell carries too.
     page = (FRONTEND / "smoke-heavy-thread-main.tsx").read_text(encoding = "utf-8")
     head = page.index("const EXPECTED_PER_CYCLE")
     expected = page[head : page.index("};", head)]
@@ -140,9 +139,8 @@ def test_the_fixture_assertion_survives_deferred_fence_highlighting() -> None:
 
 
 def test_a_fence_may_be_deferred_or_highlighted_but_not_neither() -> None:
-    # The half of the old token floor that was about SETTLEMENT rather than about the fixture,
-    # asked per block instead of in total. One block stuck on streamdown's unhighlighted fallback
-    # used to pass as long as the other blocks made the count up.
+    # The SETTLEMENT half of the old token floor, asked per block. One block stuck on streamdown's
+    # unhighlighted fallback used to pass as long as the others made the count up.
     page = (FRONTEND / "smoke-heavy-thread-main.tsx").read_text(encoding = "utf-8")
     assert "unhighlightedMountedFences" in page
     assert 'counts.get("unhighlightedMountedFences", 0)' in verdict()

--- a/tests/studio/test_heavy_thread_measurement_integrity.py
+++ b/tests/studio/test_heavy_thread_measurement_integrity.py
@@ -624,10 +624,9 @@ def test_a_clean_cell_produces_no_harness_failure() -> None:
 
 
 def test_deferred_fences_are_not_a_harness_failure() -> None:
-    # THE POINT OF MEASURING CHARACTERS. Off-screen fences render as a plain shell by default, so
-    # a real, complete, correctly built thread now holds far fewer highlighted tokens than the
-    # same thread did before the default moved -- 1,322 against 3,216 for one cycle, measured. The
-    # fixture is untouched, and the harness must not call that broken.
+    # THE POINT OF MEASURING CHARACTERS. A real, complete thread now holds far fewer highlighted
+    # tokens than before the default moved: 1,322 against 3,216 for one cycle, measured, with the
+    # fixture untouched. The harness must not call that broken.
     cell = copy.deepcopy(clean_cell())
     cell["counts"]["deferredFences"] = 4
     cell["counts"]["highlightedTokens"] = 300
@@ -635,10 +634,9 @@ def test_deferred_fences_are_not_a_harness_failure() -> None:
 
 
 def test_a_fixture_that_lost_its_code_is_still_a_harness_failure() -> None:
-    # The check this replaces was there to catch a fixture that is not the heavy thread it claims
-    # to be, and it still does. Highlighted tokens are left HIGH here, so the only thing that can
-    # fail is the character floor: a thread whose code blocks quietly emptied still renders, still
-    # scrolls and still produces a rising curve, of something else.
+    # The replaced check caught a fixture that is not the heavy thread it claims to be, and this
+    # still does. Tokens are left HIGH so only the character floor can fail: a thread whose code
+    # blocks quietly emptied still renders, still scrolls and still curves, of something else.
     cell = copy.deepcopy(clean_cell())
     cell["counts"]["codeChars"] = 6000
     cell["counts"]["highlightedTokens"] = 99999
@@ -647,8 +645,8 @@ def test_a_fixture_that_lost_its_code_is_still_a_harness_failure() -> None:
 
 
 def test_a_fence_that_is_neither_deferred_nor_highlighted_is_a_harness_failure() -> None:
-    # The other half of what the token floor used to do, asked per block. A single block stuck on
-    # streamdown's unhighlighted fallback passed the old total as long as the rest made it up.
+    # The other half of the old token floor, per block: one block stuck on streamdown's
+    # unhighlighted fallback passed the total as long as the rest made it up.
     cell = copy.deepcopy(clean_cell())
     cell["counts"]["unhighlightedMountedFences"] = 1
     failures = HARNESS.harness_failures(results_with(cell), discriminating_report())

--- a/tests/studio/test_heavy_thread_measurement_integrity.py
+++ b/tests/studio/test_heavy_thread_measurement_integrity.py
@@ -538,12 +538,16 @@ def test_the_median_of_three_good_repetitions_is_unchanged() -> None:
 
 def clean_cell() -> dict:
     """One (engine, size) cell that harness_failures() has nothing to say about."""
-    per_cycle = {"images": 3, "codeBlocks": 7}
+    per_cycle = {"images": 3, "codeBlocks": 7, "codeChars": 12000}
     counts = {
         "messages": 20,
         "domNodes": 4000,
         "codeBlocks": 7,
+        "codeChars": 12660,
         "highlightedTokens": 3000,
+        "fenceBlocks": 5,
+        "deferredFences": 2,
+        "unhighlightedMountedFences": 0,
         "images": 3,
         "actionBars": 10,
         "tooltipTriggers": 30,
@@ -617,6 +621,38 @@ def discriminating_report() -> dict:
 def test_a_clean_cell_produces_no_harness_failure() -> None:
     # The guards below are only worth anything if they are silent on a good run.
     assert HARNESS.harness_failures(results_with(clean_cell()), discriminating_report()) == []
+
+
+def test_deferred_fences_are_not_a_harness_failure() -> None:
+    # THE POINT OF MEASURING CHARACTERS. Off-screen fences render as a plain shell by default, so
+    # a real, complete, correctly built thread now holds far fewer highlighted tokens than the
+    # same thread did before the default moved -- 1,322 against 3,216 for one cycle, measured. The
+    # fixture is untouched, and the harness must not call that broken.
+    cell = copy.deepcopy(clean_cell())
+    cell["counts"]["deferredFences"] = 4
+    cell["counts"]["highlightedTokens"] = 300
+    assert HARNESS.harness_failures(results_with(cell), discriminating_report()) == []
+
+
+def test_a_fixture_that_lost_its_code_is_still_a_harness_failure() -> None:
+    # The check this replaces was there to catch a fixture that is not the heavy thread it claims
+    # to be, and it still does. Highlighted tokens are left HIGH here, so the only thing that can
+    # fail is the character floor: a thread whose code blocks quietly emptied still renders, still
+    # scrolls and still produces a rising curve, of something else.
+    cell = copy.deepcopy(clean_cell())
+    cell["counts"]["codeChars"] = 6000
+    cell["counts"]["highlightedTokens"] = 99999
+    failures = HARNESS.harness_failures(results_with(cell), discriminating_report())
+    assert any("6000 codeChars, short of the 12000" in f for f in failures), failures
+
+
+def test_a_fence_that_is_neither_deferred_nor_highlighted_is_a_harness_failure() -> None:
+    # The other half of what the token floor used to do, asked per block. A single block stuck on
+    # streamdown's unhighlighted fallback passed the old total as long as the rest made it up.
+    cell = copy.deepcopy(clean_cell())
+    cell["counts"]["unhighlightedMountedFences"] = 1
+    failures = HARNESS.harness_failures(results_with(cell), discriminating_report())
+    assert any("mounted but unhighlighted" in f for f in failures), failures
 
 
 def test_a_scroll_that_never_settled_is_a_harness_failure() -> None:


### PR DESCRIPTION
Turns on the deferred off-screen code fence highlighting merged in #9462. That mechanism has been inert behind a flag defaulting to `off`, because turning it on caused two things a reader could see. Both are fixed here rather than accepted, so the default moves with neither of them.

## The two regressions, reproduced before they were fixed

Both were reproduced at the candidate commit first, with the same instruments that found them.

| | reproduced at the candidate | after this PR |
|---|---|---|
| painted frames showing plain code on a jump, Chromium 100K | 29 of 274, 8 of 16 jumps, median 92 ms | **0** |
| deferred fences on a printed page, Letter | 1 to 2 on every sampled page | **none** |
| printed page against main, differing pixels, Letter | 6.5628% | **0.0034%** |

### A discontinuous scroll painted plain code

A scrollbar drag, `Ctrl+End` or an anchor jump can move the viewport further than the observers' one-viewport lookahead, with no React render in between, and an `IntersectionObserver` record is delivered after the browser has painted.

A capturing scroll listener now latches the fences the jump landed on inside the same task, so the swap is part of the frame the reader is about to see. Scroll events are dispatched in the "run the scroll steps" of the same rendering pass that will paint the new position, before animation-frame callbacks and before style, layout and paint.

The test for "is this a jump" is derived from the observer margin rather than picked. `rootMargin` grows the band by one root height, so after a scroll of `d` the newly visible strip is inside the old band exactly when `d <= h`. A scroll of at most one root height can therefore only reveal fences the observers had already reached. A continuous scroll pays one subtraction per event, and the single capturing listener is removed when the last fence latches, so a thread with nothing left to defer carries no scroll cost at all.

### Print lost colour on one or two fences per page

A print lays the document out at paper width while the scroll offset carries across as a raw pixel count, so the printed page lands several fences away from the reader's window. Matching the paper to the window removes the difference, which is what identifies the cause and is also why chasing the window is the wrong fix: the whole document is on the page, so the whole document is what has to be highlighted. Both doors are covered, `beforeprint` for `Ctrl+P` and the print menu, and the print media query for `page.pdf` and PDF export.

An earlier attempt at this was removed from #9462 after it was measured to leave 53 of 56 blocks on streamdown's raw fallback. The reason was not the latch. Streamdown's highlighted body asks the plugin for tokens from a **passive effect** and shows a plain fallback until it answers, and the plugin answers `null` while a grammar is still loading, so latching alone renders the block unhighlighted. Three things close it, and each one was measured to matter:

- the tokens are warmed first, so the render that follows is a cache hit;
- grammars are loaded at idle as empty-string tokenizations, which mount no span and tokenize no fence, so a loading grammar can never be what is missing when the snapshot is taken;
- the flush is nested, because react-dom only runs pending passive effects when it has sync work (`performSyncWorkOnRoot` begins with `flushPendingEffects`), and `flushSync` restores the update priority *before* it flushes, so an update scheduled by a passive effect during a scroll resolves as continuous and is not flushed. An outer `flushSync` holds the priority discrete while the two inner ones do the work.

## What it costs and what it saves

Measured on this commit, Chromium, 100K rung, against `main` built and served concurrently on the same machine, every delta printed beside the delta its own concurrent same-commit null control reported for the same metric in the same wall clock. `floor = max(|null delta|, null spread)`; a metric counts only if it clears its own floor, its paired ratios agree on sign, and the effect exceeds its own scatter.

| metric | base | this PR | delta | null delta | floor | verdict |
|---|---:|---:|---:|---:|---:|---|
| `reasoning_toggle.close_ms` | 718.9 | 150.8 | **-76.9%** | +0.8% | 10.6% | faster |
| `jank_index` | 26.4 | 10.7 | **-59.5%** | -3.4% | 8.4% | faster |
| `time_in_jank_pct` | 5.5 | 2.3 | **-58.3%** | +0.9% | 8.2% | faster |
| `select_all_copy.total_ms` | 944.6 | 511.3 | -45.8% | -3.1% | 7.5% | faster |
| `census.scroll_after.highlight_spans` | 42,077 | 6,988 | -83.4% | 0.0% | 0.0% | faster |
| `census.scroll_after.elements` | 63,126 | 28,037 | -55.6% | 0.0% | 0.0% | faster |

Every other metric in the battery is reported VOID against its own floor rather than claimed. The three user-visible ones above are the same three that cleared their floor before the two fixes were written, so the fixes did not erode the win; `reasoning_toggle.close_ms`, `jank_index` and `time_in_jank_pct` all came back larger with tighter floors.

At rest the 100K thread mounts 22,808 elements instead of 61,760 and 2,458 highlight spans instead of 41,410, with 53 of 56 fences deferred. That is unchanged by the two fixes, so neither the jump latch nor the idle grammar warm gives back any of the standing saving.

The worst case, a traversal that visits every fence so nothing can be saved, shows no metric slower than its floor.

## What is unchanged

- 160 of 160 viewports byte-identical to `main` at matched scroll positions once settled, with the in-band null also 160 of 160.
- 0 reverse edges within a mount, against a deliberately bidirectional mutant scoring 152 in the same run.
- 0 settled positions showing a plain fence, against a no-lookahead mutant scoring 37.
- `select_all_copy.count.selected_chars` held exactly at 194,992: the text a reader can select and copy is the same text.
- `off` still means what it meant. The build flag and the runtime global still override the default in both directions, a typo still degrades to `off` rather than to the new default, and `tokenize` is still reachable only by its exact string.

## Controls

Every number above comes from a run that also served two deliberately defective builds and refuses to report anything if it cannot see them. The pixel probe classifies composited frames from a CDP screencast, never from a DOM read, on a classifier calibrated at a 209x separation between the two known states. In the same runs the no-lookahead mutant scored 172 to 176 painted plain frames and the pre-fix candidate scored 26 to 29, while this branch scored 0.
