### PR TITLE
Studio: re-fit the context when a forced drafter adds a reserve it never priced

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -17443,8 +17443,7 @@ class LlamaCppBackend:
                             if (
                                 n_ctx_auto_derived
                                 and _mtp_reserves_gpu
-                                and (_canonicalize_spec_mode(speculative_type) or "auto")
-                                != "auto"
+                                and (_canonicalize_spec_mode(speculative_type) or "auto") != "auto"
                             ):
                                 # Re-fit against the cards the context was fit for,
                                 # not the whole pool: the complaint is the drafter
@@ -17473,27 +17472,29 @@ class LlamaCppBackend:
                                     else []
                                 )
                                 _refit_pool = (
-                                    _pool_budget_mib(_base_gpus, _pin_fraction)
-                                    if _base_gpus
-                                    else 0
+                                    _pool_budget_mib(_base_gpus, _pin_fraction) if _base_gpus else 0
                                 )
-                                _refit = 0 if not _refit_pool else self._fit_context_to_vram(
-                                    effective_ctx,
-                                    _refit_pool,
-                                    model_size_fit,
-                                    cache_type_kv,
-                                    swa_full = swa_full,
-                                    n_parallel = n_parallel,
-                                    kv_unified = planned_kv_unified,
-                                    n_ubatch = _effective_ubatch,
-                                    ctx_checkpoints = _effective_ctx_checkpoints,
-                                    flash_attn = planned_flash_attn,
-                                    mtp_engaged = _mtp_reserves_gpu,
-                                    mtp_overhead_fn = mtp_overhead_fn,
-                                    compute_ctx_bytes_fn = _cc_bytes,
-                                    budget_frac = 1.0,
-                                    pooled = True,
-                                    total_mib = None,
+                                _refit = (
+                                    0
+                                    if not _refit_pool
+                                    else self._fit_context_to_vram(
+                                        effective_ctx,
+                                        _refit_pool,
+                                        model_size_fit,
+                                        cache_type_kv,
+                                        swa_full = swa_full,
+                                        n_parallel = n_parallel,
+                                        kv_unified = planned_kv_unified,
+                                        n_ubatch = _effective_ubatch,
+                                        ctx_checkpoints = _effective_ctx_checkpoints,
+                                        flash_attn = planned_flash_attn,
+                                        mtp_engaged = _mtp_reserves_gpu,
+                                        mtp_overhead_fn = mtp_overhead_fn,
+                                        compute_ctx_bytes_fn = _cc_bytes,
+                                        budget_frac = 1.0,
+                                        pooled = True,
+                                        total_mib = None,
+                                    )
                                 )
                                 # Only ever downwards. The fitter returns the request
                                 # unchanged when the weights alone are over budget,

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -417,6 +417,11 @@ class GgufLoadIntent:
     # for the session.
     disable_vision: bool = False
     n_ctx: int = 4096
+    # True when n_ctx is a value OUR fitter resolved on a previous load and the
+    # client replayed, not one the user asked for. A replayed context is still
+    # honored verbatim; it only becomes re-fittable when a forced speculative
+    # choice adds a reserve that was not priced into it (issue #9550).
+    n_ctx_auto_derived: bool = False
     chat_template_override: Optional[str] = None
     cache_type_kv: Optional[str] = None
     speculative_type: Optional[str] = None
@@ -15015,6 +15020,7 @@ class LlamaCppBackend:
         is_vision = intent.is_vision
         disable_vision = intent.disable_vision
         n_ctx = intent.n_ctx
+        n_ctx_auto_derived = intent.n_ctx_auto_derived
         chat_template_override = intent.chat_template_override
         cache_type_kv = intent.cache_type_kv
         speculative_type = intent.speculative_type
@@ -17414,6 +17420,92 @@ class LlamaCppBackend:
                                 max_available_ctx = min(4096, native_ctx_for_cap)
 
                         if explicit_ctx:
+                            # One exception to honoring it verbatim: a context WE
+                            # resolved, replayed by the client, against a drafter
+                            # the user has now forced on.
+                            #
+                            # Auto drops a drafter that does not fit rather than
+                            # shrink the context for it, and clears mtp_overhead_fn
+                            # when it does, so the context it settles on is fit with
+                            # no reserve in it. The client sends that number back on
+                            # the next load of the same model, which makes it
+                            # explicit; the forced choice then re-arms the reserve,
+                            # and the block below spends the shortfall on more GPUs
+                            # instead of on the context that never priced it. The
+                            # reporter saw a 31 GB model take a second card to hold a
+                            # 2.18 GB drafter at a context picked while that drafter
+                            # was dropped (#9550).
+                            #
+                            # Gated on all three: a user-typed context is still
+                            # honored verbatim, Auto still keeps its context and
+                            # drops the drafter, and a load with no reserve is
+                            # untouched.
+                            if (
+                                n_ctx_auto_derived
+                                and _mtp_reserves_gpu
+                                and (_canonicalize_spec_mode(speculative_type) or "auto")
+                                != "auto"
+                            ):
+                                # Re-fit against the cards the context was fit for,
+                                # not the whole pool: the complaint is the drafter
+                                # pulling in another card, so a pooled budget would
+                                # find room for the reserve and change nothing. Price
+                                # the placement the context already assumed -- model,
+                                # KV and compute buffer, no reserve -- and hold the
+                                # context to it.
+                                _base_indices, _base_fit = self._select_gpus_split_aware(
+                                    model_size_fit
+                                    + _kv_bytes(effective_ctx)
+                                    + _cc_bytes(effective_ctx),
+                                    gpus,
+                                    usable_fraction = _pin_fraction,
+                                    total_by_idx = total_by_idx,
+                                    per_device_overhead_bytes = _pipeline_overhead_bytes
+                                    + _cc_bytes(effective_ctx),
+                                    min_gpus = _layer_min_gpus,
+                                    split_extra_bytes = _cc_split_extra(effective_ctx),
+                                )
+                                # No subset held it even without the reserve, so the
+                                # fitter is not what decides this launch; leave it.
+                                _base_gpus = (
+                                    [g for g in gpus if g[0] in set(_base_indices)]
+                                    if _base_indices and not _base_fit
+                                    else []
+                                )
+                                _refit_pool = (
+                                    _pool_budget_mib(_base_gpus, _pin_fraction)
+                                    if _base_gpus
+                                    else 0
+                                )
+                                _refit = 0 if not _refit_pool else self._fit_context_to_vram(
+                                    effective_ctx,
+                                    _refit_pool,
+                                    model_size_fit,
+                                    cache_type_kv,
+                                    swa_full = swa_full,
+                                    n_parallel = n_parallel,
+                                    kv_unified = planned_kv_unified,
+                                    n_ubatch = _effective_ubatch,
+                                    ctx_checkpoints = _effective_ctx_checkpoints,
+                                    flash_attn = planned_flash_attn,
+                                    mtp_engaged = _mtp_reserves_gpu,
+                                    mtp_overhead_fn = mtp_overhead_fn,
+                                    compute_ctx_bytes_fn = _cc_bytes,
+                                    budget_frac = 1.0,
+                                    pooled = True,
+                                    total_mib = None,
+                                )
+                                # Only ever downwards. The fitter returns the request
+                                # unchanged when the weights alone are over budget,
+                                # and a larger answer would be a context the client
+                                # never showed the user.
+                                if 0 < _refit < effective_ctx:
+                                    logger.info(
+                                        "Context re-fit for the forced drafter: "
+                                        f"{effective_ctx} -> {_refit} "
+                                        f"(reserve {_mtp_bytes(_refit) / 1024**3:.2f} GB)"
+                                    )
+                                    effective_ctx = _refit
                             # Honor the requested context verbatim. If it fits,
                             # pin GPUs and skip --fit; else ship -c <ctx> --fit
                             # on and let llama-server flex -ngl (CPU offload).

--- a/studio/backend/models/inference.py
+++ b/studio/backend/models/inference.py
@@ -57,6 +57,15 @@ class LoadRequest(BaseModel):
         le = 1048576,
         description = "Maximum sequence length (0 = model default for GGUF)",
     )
+    max_seq_length_auto_derived: bool = Field(
+        False,
+        description = (
+            "Whether max_seq_length is a value a previous load's fitter resolved and "
+            "the client replayed, rather than one the user asked for. Only then may "
+            "the planner re-fit it; the default keeps every existing client's context "
+            "honored verbatim."
+        ),
+    )
     load_in_4bit: bool = Field(True, description = "Load model in 4-bit quantization")
     is_lora: bool = Field(False, description = "Whether this is a LoRA adapter")
     gguf_variant: Optional[str] = Field(

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -5368,6 +5368,9 @@ def _gguf_request_intent(
     }
     settings.update(
         n_ctx = request.max_seq_length,
+        n_ctx_auto_derived = bool(
+            getattr(request, "max_seq_length_auto_derived", False)
+        ),
         chat_template_override = chat_template_override,
         extra_args = extra_args,
         gpu_ids = gpu_ids,

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -5368,9 +5368,7 @@ def _gguf_request_intent(
     }
     settings.update(
         n_ctx = request.max_seq_length,
-        n_ctx_auto_derived = bool(
-            getattr(request, "max_seq_length_auto_derived", False)
-        ),
+        n_ctx_auto_derived = bool(getattr(request, "max_seq_length_auto_derived", False)),
         chat_template_override = chat_template_override,
         extra_args = extra_args,
         gpu_ids = gpu_ids,

--- a/studio/backend/tests/test_mtp_context_refit_9550.py
+++ b/studio/backend/tests/test_mtp_context_refit_9550.py
@@ -134,9 +134,9 @@ def test_the_mtp_reserve_does_cost_context(tmp_path):
     with_mtp = _fit(backend, NATIVE_CTX, mtp = True)
 
     assert without_mtp < NATIVE_CTX, "the fit should have reduced the requested context"
-    assert with_mtp < without_mtp, (
-        "the MTP reserve must cost context, or there is nothing to re-fit"
-    )
+    assert (
+        with_mtp < without_mtp
+    ), "the MTP reserve must cost context, or there is nothing to re-fit"
 
 
 def _auto_then_forced(tmp_path: Path, *, auto_derived: bool):
@@ -180,14 +180,14 @@ def test_forcing_mtp_refits_the_context_against_its_reserve(tmp_path):
 
     assert cmd[cmd.index("--spec-type") + 1] == "draft-mtp"
     launched_ctx = int(cmd[cmd.index("-c") + 1])
-    assert launched_ctx < resolved_ctx, (
-        f"expected a re-fit below {resolved_ctx}, launched at {launched_ctx}"
-    )
+    assert (
+        launched_ctx < resolved_ctx
+    ), f"expected a re-fit below {resolved_ctx}, launched at {launched_ctx}"
 
     backend2._read_gguf_metadata(None)
-    assert launched_ctx <= _fit(backend2, resolved_ctx, mtp = True), (
-        "the launched context must fit the budget that now carries the reserve"
-    )
+    assert launched_ctx <= _fit(
+        backend2, resolved_ctx, mtp = True
+    ), "the launched context must fit the budget that now carries the reserve"
 
 
 def test_a_user_typed_context_is_still_honored_verbatim(tmp_path):

--- a/studio/backend/tests/test_mtp_context_refit_9550.py
+++ b/studio/backend/tests/test_mtp_context_refit_9550.py
@@ -1,0 +1,200 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Regression tests for issue #9550 -- forcing MTP reuses the context Auto picked
+while MTP was DROPPED, instead of re-fitting against the MTP reserve.
+
+The reporter's two loads of the same 31.0 GB Qwen3.6-40B MTP GGUF, from the issue:
+
+    # Auto: drafter does not fit, so it is dropped and the context is fit WITHOUT it
+    Speculative decoding disabled for this load: ... needs 46.7 GB of a 44.3 GB budget
+    Context auto-reduced: 262144 -> 112896 (model: 31.0 GB, est. KV cache: 11.2 GB)
+    GGUF size: 31.0 GB, ..., context: 112896, GPUs free: [(0, 45914), (1, 8032)], selected: [0]
+
+    # Then the user forces MTP in the dropdown and reloads
+    GGUF size: 31.0 GB, ..., MTP reserve: 2.18 GB (draft KV @ 112896 + verify n_max=2),
+    context: 112896, GPUs free: [(0, 45914), (1, 8032)], selected: [0, 1]
+
+The second load runs at the SAME 112896 and pays the 2.18 GB reserve on top, pulling
+in the 8 GiB card to cover the overflow, rather than re-deriving the largest context
+that fits with the reserve.
+
+Two things combined to produce that:
+
+1. ``llama_cpp.py`` clears ``mtp_overhead_fn`` when the Auto probe drops the drafter
+   (deliberately -- the fit must not shrink the context for a drafter that will not
+   launch), so the reduced context is fit against a budget with no reserve in it.
+2. The frontend then sends that resolved context back as ``max_seq_length`` on the
+   next load of the same model (``preset-policy.ts`` returns ``ggufContextLength``
+   for a same-model reload), which makes ``explicit_ctx`` true and takes the
+   "honor the requested context verbatim" branch -- so the reducer never re-ran,
+   even though the reserve was now live.
+
+The fix marks the replayed value's provenance (``max_seq_length_auto_derived`` ->
+``GgufLoadIntent.n_ctx_auto_derived``) and re-fits inside the explicit branch when,
+and only when, all of: the context was ours, a forced choice re-armed the reserve,
+and that reserve costs GPU memory. A context the user typed is still honored
+verbatim, which the last test here pins.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_TESTS_DIR = str(Path(__file__).resolve().parent)
+if _TESTS_DIR not in sys.path:
+    sys.path.insert(0, _TESTS_DIR)
+
+from test_llama_cpp_placement import _backend, _launch  # noqa: E402
+
+GB = 1024**3
+
+# The reporter's box and model, from the #9550 log lines.
+GPUS = [(0, 45914, 46080), (1, 8032, 8176)]
+MODEL_BYTES = int(31.0 * GB)
+NATIVE_CTX = 262144
+REPORTED_CTX = 112896
+KV_BYTES_AT_REPORTED_CTX = int(11.2 * GB)
+MTP_BYTES_AT_REPORTED_CTX = int(2.18 * GB)
+
+
+def _reporter_backend(tmp_path: Path):
+    """A backend sized like the reporter's load, with the real context fitter.
+
+    The KV, compute and MTP terms are stubbed LINEAR in the context so the fit is
+    the only thing under test and the arithmetic is checkable by hand; their real
+    shapes are covered elsewhere.
+    """
+    backend, gguf = _backend(tmp_path, vulkan = False, memory = GPUS)
+
+    def read_metadata(_path):
+        backend._nextn_predict_layers = 1
+        backend._n_layers = 48
+        backend._n_kv_heads = 8
+        backend._n_heads = 40
+        backend._embedding_length = 5120
+        backend._kv_key_length = 128
+        backend._kv_value_length = 128
+        # The model's native context. With no explicit max_seq_length this is
+        # what the auto path starts from -- 262144 in the reporter's log.
+        backend._context_length = NATIVE_CTX
+
+    def _ctx_of(args, kwargs):
+        if "n_ctx" in kwargs:
+            return int(kwargs["n_ctx"] or 0)
+        return int(args[0]) if args else 0
+
+    backend._read_gguf_metadata = read_metadata
+    backend._get_gguf_size_bytes = lambda _path: MODEL_BYTES
+    backend._can_estimate_kv = lambda: True
+    backend._estimate_kv_cache_bytes = lambda *a, **k: int(
+        KV_BYTES_AT_REPORTED_CTX * (_ctx_of(a, k) / REPORTED_CTX)
+    )
+    backend._compute_buffer_ctx_bytes = lambda *a, **k: 0
+    backend._estimate_compute_buffer_bytes = lambda **k: 1
+    backend._mtp_draft_kv_bytes = lambda *a, **k: 0
+    backend._estimate_mtp_overhead_bytes = lambda *a, **k: int(
+        MTP_BYTES_AT_REPORTED_CTX * (_ctx_of(a, k) / REPORTED_CTX)
+    )
+    backend.probe_server_capabilities = lambda _binary = None: {
+        "mtp_token": "draft-mtp",
+        "supports_ngram_mod": True,
+        "spec_draft_n_max_flag": "--spec-draft-n-max",
+    }
+    backend._select_gpus = lambda *args, **kwargs: ([0], False)
+    backend._select_gpus_split_aware = lambda *args, **kwargs: ([0], False)
+    return backend, gguf
+
+
+def _fit(backend, requested_ctx: int, *, mtp: bool) -> int:
+    """The largest context the fitter says card 0 can hold, with and without the
+    MTP reserve. This is the comparison the second load never makes."""
+    overhead = backend._estimate_mtp_overhead_bytes if mtp else None
+    return backend._fit_context_to_vram(
+        requested_ctx,
+        GPUS[0][1],
+        MODEL_BYTES,
+        mtp_engaged = mtp,
+        mtp_overhead_fn = (lambda n: overhead(n)) if overhead else None,
+        total_mib = GPUS[0][2],
+    )
+
+
+def test_the_mtp_reserve_does_cost_context(tmp_path):
+    """Precondition for the issue: charging the reserve genuinely lowers the
+    largest context that fits, so re-fitting would have produced a smaller
+    number rather than being a no-op."""
+    backend, _gguf = _reporter_backend(tmp_path)
+    backend._read_gguf_metadata(None)
+
+    without_mtp = _fit(backend, NATIVE_CTX, mtp = False)
+    with_mtp = _fit(backend, NATIVE_CTX, mtp = True)
+
+    assert without_mtp < NATIVE_CTX, "the fit should have reduced the requested context"
+    assert with_mtp < without_mtp, (
+        "the MTP reserve must cost context, or there is nothing to re-fit"
+    )
+
+
+def _auto_then_forced(tmp_path: Path, *, auto_derived: bool):
+    """The two loads the reporter made, in order.
+
+    Load 1 is Auto with no explicit context, so the reducer runs and the drafter
+    is dropped. Load 2 forces MTP and carries load 1's resolved context back, the
+    way the frontend replays ``ggufContextLength`` for a same-model reload.
+    """
+    backend, gguf = _reporter_backend(tmp_path)
+    first = _launch(backend, gguf, speculative_type = "auto", n_ctx = 0, n_parallel = 4)
+    resolved_ctx = int(first["cmd"][first["cmd"].index("-c") + 1])
+
+    backend2, gguf2 = _reporter_backend(tmp_path)
+    second = _launch(
+        backend2,
+        gguf2,
+        speculative_type = "mtp",
+        n_ctx = resolved_ctx,
+        n_ctx_auto_derived = auto_derived,
+        n_parallel = 4,
+    )
+    return backend2, resolved_ctx, second["cmd"]
+
+
+def test_auto_still_keeps_its_context_and_drops_the_drafter(tmp_path):
+    """Unchanged: Auto will not shrink the context to buy a speed option."""
+    backend, gguf = _reporter_backend(tmp_path)
+    result = _launch(backend, gguf, speculative_type = "auto", n_ctx = 0, n_parallel = 4)
+
+    cmd = result["cmd"]
+    assert int(cmd[cmd.index("-c") + 1]) < NATIVE_CTX, "the native context was reduced"
+    assert "draft-mtp" not in cmd
+    assert backend.spec_fallback_reason == "drafter_no_vram"
+
+
+def test_forcing_mtp_refits_the_context_against_its_reserve(tmp_path):
+    """The fix. Forcing MTP re-derives a context that fits WITH the reserve
+    instead of inheriting one that was only valid while the drafter was gone."""
+    backend2, resolved_ctx, cmd = _auto_then_forced(tmp_path, auto_derived = True)
+
+    assert cmd[cmd.index("--spec-type") + 1] == "draft-mtp"
+    launched_ctx = int(cmd[cmd.index("-c") + 1])
+    assert launched_ctx < resolved_ctx, (
+        f"expected a re-fit below {resolved_ctx}, launched at {launched_ctx}"
+    )
+
+    backend2._read_gguf_metadata(None)
+    assert launched_ctx <= _fit(backend2, resolved_ctx, mtp = True), (
+        "the launched context must fit the budget that now carries the reserve"
+    )
+
+
+def test_a_user_typed_context_is_still_honored_verbatim(tmp_path):
+    """The gate. Same forced drafter, same numbers, but the context came from the
+    user, so the shortfall is spent on placement as before and not on their
+    context. Everything that pins verbatim honoring elsewhere depends on this."""
+    _backend2, resolved_ctx, cmd = _auto_then_forced(tmp_path, auto_derived = False)
+
+    assert cmd[cmd.index("--spec-type") + 1] == "draft-mtp"
+    assert int(cmd[cmd.index("-c") + 1]) == resolved_ctx

--- a/studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts
+++ b/studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts
@@ -77,6 +77,7 @@ import {
   mergeBackendRecommendedInference,
   resolveFitMaxSeqLength,
   resolveLoadMaxSeqLength,
+  resolveLoadMaxSeqLengthDetailed,
   resolveManualAutoCtxPin,
 } from "../presets/preset-policy";
 import { recordLastLocalModelLoad } from "../utils/last-local-model-load";
@@ -1534,7 +1535,7 @@ export function useChatModelRuntime() {
             ) {
               loadCustomContextLength = loadGgufContextLength;
             }
-            const effectiveMaxSeqLength = resolveLoadMaxSeqLength({
+            const resolvedMaxSeqLength = resolveLoadMaxSeqLengthDetailed({
               modelId,
               ggufVariant,
               isGguf,
@@ -1545,6 +1546,7 @@ export function useChatModelRuntime() {
               maxSeqLength,
               presetSource: loadActivePresetSource,
             });
+            const effectiveMaxSeqLength = resolvedMaxSeqLength.value;
             const loadMaxSeqLength = resolveFitMaxSeqLength(
               isGguf,
               loadGpuMemoryMode,
@@ -1563,6 +1565,16 @@ export function useChatModelRuntime() {
               nativePathLease: loadNativePathLease,
               hf_token: hfToken,
               max_seq_length: loadMaxSeqLength,
+              // Provenance, not a different value: this is the context OUR fitter
+              // resolved on the previous load of this model, replayed so the sheet
+              // keeps showing it. Saying so lets the backend re-fit it when a
+              // forced drafter adds a reserve the number never priced (#9550);
+              // anything the user chose stays honored verbatim.
+              // biome-ignore lint/style/useNamingConvention: API schema
+              max_seq_length_auto_derived:
+                resolvedMaxSeqLength.source === "resident-reload" &&
+                loadMaxSeqLength === resolvedMaxSeqLength.value &&
+                loadMaxSeqLength > 0,
               load_in_4bit: true,
               is_lora: isLora,
               gguf_variant: ggufVariant ?? null,

--- a/studio/frontend/src/features/chat/presets/preset-policy.ts
+++ b/studio/frontend/src/features/chat/presets/preset-policy.ts
@@ -301,17 +301,7 @@ export function mergeBackendRecommendedInference({
   };
 }
 
-export function resolveLoadMaxSeqLength({
-  modelId,
-  ggufVariant,
-  isGguf,
-  customContextLength,
-  ggufContextLength,
-  currentCheckpoint,
-  activeGgufVariant,
-  maxSeqLength,
-  presetSource,
-}: {
+type LoadMaxSeqLengthArgs = {
   modelId: string;
   ggufVariant?: string | null;
   isGguf?: boolean | null;
@@ -321,7 +311,38 @@ export function resolveLoadMaxSeqLength({
   activeGgufVariant?: string | null;
   maxSeqLength: number;
   presetSource: ChatPresetSource;
-}): number {
+};
+
+/**
+ * Where the context we are about to send came from.
+ *
+ * `resident-reload` is the one the backend may re-fit: it is a value OUR fitter
+ * resolved on the previous load of this same model, replayed so the sheet keeps
+ * showing what the user sees. Everything else is either a number the user chose
+ * or a 0 that asks the fitter to decide, and both are honored as-is. See #9550.
+ */
+export type LoadMaxSeqLengthSource =
+  | "user-pinned"
+  | "builtin-default"
+  | "resident-reload"
+  | "gguf-auto"
+  | "transformers";
+
+export function resolveLoadMaxSeqLengthDetailed(args: LoadMaxSeqLengthArgs): {
+  value: number;
+  source: LoadMaxSeqLengthSource;
+} {
+  const {
+    modelId,
+    ggufVariant,
+    isGguf,
+    customContextLength,
+    ggufContextLength,
+    currentCheckpoint,
+    activeGgufVariant,
+    maxSeqLength,
+    presetSource,
+  } = args;
   const isDirectGgufFile = modelId.toLowerCase().endsWith(".gguf");
   const isGgufLoad = isGguf === true || ggufVariant != null || isDirectGgufFile;
   const isReloadingCurrentGguf =
@@ -330,18 +351,22 @@ export function resolveLoadMaxSeqLength({
     (ggufVariant ?? null) === (activeGgufVariant ?? null);
 
   if (customContextLength != null) {
-    return customContextLength;
+    return { value: customContextLength, source: "user-pinned" };
   }
   if (isGgufLoad && presetSource === "builtin-default") {
-    return 0;
+    return { value: 0, source: "builtin-default" };
   }
   if (isReloadingCurrentGguf) {
-    return ggufContextLength ?? 0;
+    return { value: ggufContextLength ?? 0, source: "resident-reload" };
   }
   if (isGgufLoad) {
-    return 0;
+    return { value: 0, source: "gguf-auto" };
   }
-  return maxSeqLength;
+  return { value: maxSeqLength, source: "transformers" };
+}
+
+export function resolveLoadMaxSeqLength(args: LoadMaxSeqLengthArgs): number {
+  return resolveLoadMaxSeqLengthDetailed(args).value;
 }
 
 /**

--- a/studio/frontend/src/features/chat/types/api.ts
+++ b/studio/frontend/src/features/chat/types/api.ts
@@ -58,6 +58,13 @@ export interface LoadModelRequest {
   nativePathLease?: string | null;
   hf_token: string | null;
   max_seq_length: number;
+  /**
+   * Whether max_seq_length is a value a previous load's fitter resolved and we
+   * replayed, rather than one the user asked for. Only then may the backend
+   * re-fit it, which is how a forced drafter stops inheriting a context that
+   * never priced its reserve (#9550). Omitted means user-supplied.
+   */
+  max_seq_length_auto_derived?: boolean;
   load_in_4bit: boolean;
   is_lora: boolean;
   gguf_variant?: string | null;

--- a/studio/frontend/tests/load-max-seq-length-source.test.ts
+++ b/studio/frontend/tests/load-max-seq-length-source.test.ts
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// Reloading the same GGUF replays the context OUR fitter resolved last time, so
+// the sheet keeps showing what the user sees. That replay is also what makes the
+// value look user-supplied to the backend, which is how a forced drafter ended up
+// inheriting a context fit while the drafter was dropped (#9550). The value sent
+// is unchanged; only its provenance is now reported, so the wrapper must keep
+// returning exactly what it did before.
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { registerBundlerResolver } from "./helpers/kit.ts";
+
+registerBundlerResolver();
+
+const { resolveLoadMaxSeqLength, resolveLoadMaxSeqLengthDetailed } =
+  await import("../src/features/chat/presets/preset-policy.ts");
+
+const GGUF = {
+  modelId: "unsloth/Qwen3-8B-GGUF",
+  ggufVariant: "Q4_K_M",
+  isGguf: true,
+  customContextLength: null as number | null,
+  ggufContextLength: null as number | null,
+  currentCheckpoint: "",
+  activeGgufVariant: null as string | null,
+  maxSeqLength: 4096,
+  presetSource: "user" as const,
+};
+
+test("a same-model GGUF reload is marked as our own resolved context", () => {
+  const resolved = resolveLoadMaxSeqLengthDetailed({
+    ...GGUF,
+    ggufContextLength: 112896,
+    currentCheckpoint: GGUF.modelId,
+    activeGgufVariant: "Q4_K_M",
+  });
+  assert.equal(resolved.value, 112896);
+  assert.equal(resolved.source, "resident-reload");
+});
+
+test("a context the user pinned is not ours to re-fit", () => {
+  const resolved = resolveLoadMaxSeqLengthDetailed({
+    ...GGUF,
+    customContextLength: 65536,
+    ggufContextLength: 112896,
+    currentCheckpoint: GGUF.modelId,
+    activeGgufVariant: "Q4_K_M",
+  });
+  assert.equal(resolved.value, 65536);
+  assert.equal(resolved.source, "user-pinned");
+});
+
+test("a first load asks the fitter and is not a replay", () => {
+  const resolved = resolveLoadMaxSeqLengthDetailed(GGUF);
+  assert.equal(resolved.value, 0);
+  assert.equal(resolved.source, "gguf-auto");
+});
+
+test("a builtin-default preset asks the fitter too", () => {
+  const resolved = resolveLoadMaxSeqLengthDetailed({
+    ...GGUF,
+    presetSource: "builtin-default",
+    ggufContextLength: 112896,
+    currentCheckpoint: GGUF.modelId,
+    activeGgufVariant: "Q4_K_M",
+  });
+  assert.equal(resolved.value, 0);
+  assert.equal(resolved.source, "builtin-default");
+});
+
+test("a transformers load carries its own maxSeqLength", () => {
+  const resolved = resolveLoadMaxSeqLengthDetailed({
+    ...GGUF,
+    isGguf: false,
+    ggufVariant: null,
+    modelId: "unsloth/Qwen3-8B",
+  });
+  assert.equal(resolved.value, 4096);
+  assert.equal(resolved.source, "transformers");
+});
+
+test("the wrapper returns exactly the detailed value in every branch", () => {
+  const cases = [
+    GGUF,
+    { ...GGUF, customContextLength: 65536 },
+    {
+      ...GGUF,
+      ggufContextLength: 112896,
+      currentCheckpoint: GGUF.modelId,
+      activeGgufVariant: "Q4_K_M",
+    },
+    { ...GGUF, presetSource: "builtin-default" as const },
+    { ...GGUF, isGguf: false, ggufVariant: null, modelId: "unsloth/Qwen3-8B" },
+  ];
+  for (const args of cases) {
+    assert.equal(
+      resolveLoadMaxSeqLength(args),
+      resolveLoadMaxSeqLengthDetailed(args).value,
+    );
+  }
+});


### PR DESCRIPTION
## Problem

From #9550, the same 31.0 GB model loaded twice:

```
# Auto: the drafter does not fit, so it is dropped and the context is fit WITHOUT it
Speculative decoding disabled for this load: ... needs 46.7 GB of a 44.3 GB budget
Context auto-reduced: 262144 -> 112896 (model: 31.0 GB, est. KV cache: 11.2 GB)
GGUF size: 31.0 GB, ..., context: 112896, GPUs free: [(0, 45914), (1, 8032)], selected: [0]

# The user then picks MTP in the dropdown and reloads
GGUF size: 31.0 GB, ..., MTP reserve: 2.18 GB (draft KV @ 112896 + verify n_max=2),
context: 112896, GPUs free: [(0, 45914), (1, 8032)], selected: [0, 1]
```

The second load runs at the same 112896 and pays the reserve on top, pulling in the 8 GiB card to cover it, instead of re-deriving a context that fits with the reserve.

Two things combine:

1. The Auto drafter-drop probe clears `mtp_overhead_fn` (`llama_cpp.py:17067-17073`), deliberately, so the fit does not shrink the context for a drafter that will not launch. The context it settles on is therefore fit against a budget with no reserve in it.
2. Reloading the same model replays that resolved context as `max_seq_length` (`preset-policy.ts:338-339` returns `ggufContextLength`), which makes `explicit_ctx` true and takes the honor-verbatim branch (`:17342-17367`). The forced choice re-arms the reserve, and that branch spends the shortfall on `_select_gpus_split_aware` rather than on the context.

The replay is there for a good reason (`use-chat-model-runtime.ts:1520-1527`: sending 0 on a manual pinned reload means the native context and likely OOM), so it cannot simply be removed.

## Fix

Send the same value, and say where it came from.

- `resolveLoadMaxSeqLength` gains a detailed variant returning the branch that supplied the value; the existing function becomes a thin wrapper, so the five call sites, `resident-config-match.ts` and `preset-load-config.ts` are untouched and the dedupe comparison and settings sheet cannot drift.
- `LoadRequest.max_seq_length_auto_derived` carries that provenance through `GgufLoadIntent.n_ctx_auto_derived`. Default False, so every existing client keeps verbatim honoring.
- Inside `if explicit_ctx:`, the context is re-fit when all three hold: the value was ours, the speculative choice is forced rather than Auto, and the reserve costs GPU memory.

It prices the cards the context was already fit for rather than the whole pool. A pooled budget finds room for the reserve and changes nothing, which leaves the extra card in place, and the extra card is the complaint.

Reproduced with the reporter's numbers, then fixed:

```
Context auto-reduced: 262144 -> 122624 (model: 31.0 GB, est. KV cache: 12.2 GB)
Context re-fit for the forced drafter: 122624 -> 100864 (reserve 1.95 GB)
... context: 100864, GPUs free: [(0, 45914), (1, 8032)], selected: [0]
```

## Why the gate is narrow

About twenty tests assert an explicit context is honored verbatim (`test_llama_cpp_context_fit.py`, `test_llama_cpp_placement.py`, `test_mmproj_placement_policy.py`, `test_tensor_parallel.py`). Every one is either `speculative_type="auto"` or has no spec reserve, so the forced-mode gate excludes them all; the drop probe at `:16853-16855` is auto-only, so the two gates line up. The mirror implementation at `test_llama_cpp_context_fit.py:160-270` has no MTP or spec concept, so it needs no lockstep change.

Manual with a fixed layer count keeps its contract: that path supplies `customContextLength`, so it never takes the replay branch and the flag is False.

## Tests

`test_mtp_context_refit_9550.py`, four cases: the reserve genuinely costs context (precondition), Auto still keeps its context and drops the drafter, forcing MTP re-fits, and a user-typed context under the same forced drafter is still honored verbatim. Plus `load-max-seq-length-source.test.ts` for the provenance, including that the wrapper returns exactly what it did before in every branch.

On the AMD DevLab runner: 672 passed across the placement, context-fit, mmproj, tensor-parallel, arch-gate, gpu-memory-mode and native-context suites, with the one pre-existing host-specific failure that reproduces identically from unmodified main on the same runner.

Fixes #9550
