### PR TITLE
studiobench: give the action bar selftest's two clocks one origin

### DIFF
--- a/tests/studio/studiobench/scene/selftest/test_studiobench_action_bar_wait.py
+++ b/tests/studio/studiobench/scene/selftest/test_studiobench_action_bar_wait.py
@@ -53,6 +53,14 @@ DOM_JS = Path(__file__).resolve().parents[1] / "dom.js"
 #: comfortably outside anything a single sample could catch.
 LATE_MOUNT_MS = 400
 
+#: The mount deadline is armed by the action's own first look (see `HARNESS_JS`), so it can only
+#: start level with or after `waitForActionButton`'s clock and `waitedMs` cannot undershoot
+#: `LATE_MOUNT_MS` by any elapsed time at all. What is left is dom.js rounding `waitedMs` to a
+#: tenth. This is an allowance for clock granularity, not a tolerance for load: the wait ends at
+#: the first sample taken at or after the bar mounts, and a slow machine can only push that sample
+#: LATER. Nothing here scales with `LATE_MOUNT_MS`.
+MOUNT_CLOCK_SLACK_MS = 1
+
 HARNESS_JS = r"""
 const fs = require("fs");
 const domSrc = fs.readFileSync(process.argv[2], "utf8");
@@ -86,8 +94,26 @@ const node = (sel, attrs, kids) => {
   return self;
 };
 
-const started = Date.now();
-const mounted = () => Date.now() - started >= mountAfterMs;
+// ── one clock, one origin ──────────────────────────────────────────────────────────────────────
+//
+// The bar mounts `mountAfterMs` after THE ACTION FIRST LOOKS FOR IT, and the deadline is armed by
+// that first look rather than by this script loading. The two instants are not the same: between
+// them sit two readFileSync calls, the dom.js eval, two Function compiles and V8's lazy compile of
+// the action body on its first call, all of it charged to whatever else the machine is doing.
+// Armed at load, the deadline would already be part-spent by the time `waitForActionButton` set
+// its own `started`, and the `waitedMs` measured from THAT origin would come back short by the
+// setup cost -- a number about the runner's load rather than about the wait.
+//
+// Arming here instead puts both clocks on one origin, and puts them there in the only order that
+// is safe. `waitForActionButton` stamps `started`, hovers, and only then reads a control; that
+// read is the first call below, so the mount deadline can start level with the action's clock or
+// a hair after it, never before. `waitedMs` therefore cannot come in under `mountAfterMs`, and a
+// loaded machine can only push the sample that ends the wait LATER.
+let started = null;
+const mounted = () => {
+  if (started === null) started = performance.now();
+  return performance.now() - started >= mountAfterMs;
+};
 
 const state = { menuOpen: false, hovers: 0 };
 
@@ -206,7 +232,11 @@ def test_a_control_that_arrives_late_is_waited_for_rather_than_reported_missing(
     """
     out = run_menu(LATE_MOUNT_MS)
     assert out["ran"] is True, out
-    assert out["waitedMs"] >= LATE_MOUNT_MS * 0.8, out
+    # Still a liveness assertion, not a timing one: the bar was NOT there when the wait began, and
+    # the action stayed until it arrived. The bound is tight because the harness arms the mount
+    # deadline off the same clock and the same instant the action starts looking, so anything short
+    # of `LATE_MOUNT_MS` means the wait ended early -- a control that was there all along.
+    assert out["waitedMs"] >= LATE_MOUNT_MS - MOUNT_CLOCK_SLACK_MS, out
     assert out["waitedMs"] < ACTION_BAR_WAIT_MS, out
     # The menu really opened and closed on the control that was waited for, so the wait produced a
     # measurement rather than merely a truthy `ran`.


### PR DESCRIPTION
`Selftests, lint and the single-file build` is red on main at 83539fa97 (run 32637092740):

```
tests/studio/studiobench/scene/selftest/test_studiobench_action_bar_wait.py::test_a_control_that_arrives_late_is_waited_for_rather_than_reported_missing
AssertionError: {'ran': True, 'waitedMs': 307.9, 'openMs': 0.1, 'closeMs': 0, ...}
assert 307.9 >= (400 * 0.8)
```

The test is mine, from #9297.

## What was wrong

The two numbers in that assertion were measured from different origins.

`HARNESS_JS` armed the mount deadline at top level, `const started = Date.now()`, so the shimmed bar appeared 400 ms after the harness SCRIPT LOADED. `waitedMs` comes from `waitForActionButton` in `scene/dom.js`, whose clock starts when the action is INVOKED. Between those two instants sit two `readFileSync` calls, the `dom.js` eval, two `new Function` compiles, and V8 lazily compiling the action body on its first call.

So `waitedMs` was `LATE_MOUNT_MS` minus that setup cost, and the setup cost is whatever else the machine happens to be doing. On an idle machine it is a few milliseconds and the assertion passes. On the runner it cost about 92 ms and it did not. The `* 0.8` was absorbing an offset that is not constant, not allowing for timer jitter, so it did not have a value that was correct for both machines.

Note what the failure payload says: `ran: True`, `items: 2`, `openMs` and `closeMs` both present. The action waited for the late bar and drove it correctly. Only the number describing the wait was measured against the wrong zero.

## The fix

Arm the mount deadline from the action's own first look at the DOM, read off the same `performance.now()` `dom.js` reads, rather than at script load.

The ordering is what makes this safe rather than merely closer. `waitForActionButton` stamps `started`, calls `hoverLastAssistantMessage` (which only queries `document`), and then reads a control. That read is the first call into the shim's `mounted()`, so the deadline starts level with the action's clock or a hair after it, never before. `waitedMs` therefore cannot undershoot `LATE_MOUNT_MS` by any elapsed time, and a slow machine can only push the sample that ends the wait LATER, never earlier.

That lets the bound get tighter rather than looser: `>= LATE_MOUNT_MS - 1` instead of `>= 0.8 * LATE_MOUNT_MS`. The 1 ms is `dom.js` rounding `waitedMs` to a tenth, and it does not scale with `LATE_MOUNT_MS`. The upper bound `waitedMs < ACTION_BAR_WAIT_MS` is unchanged, and the assertion still says what it existed to say, that the bar was absent when the wait began rather than there all along. It remains a liveness test.

No change to `scene/actions.py` or `scene/dom.js`. The shipped code was never at fault; the harness was measuring it wrong.

## Measurements

40 runs per condition. Loaded means pinned with `taskset` to a single core against 48 spinners, so setup time is inflated the way the runner inflated it.

| condition | min | p50 | max | test result |
| --- | --- | --- | --- | --- |
| before, idle | 403.2 | 404.4 | 405.7 | 40/40 pass |
| before, loaded | 210.1 | 267.6 | 419.0 | **16/40 pass, 24 fail** |
| after, idle | 403.2 | 404.4 | 404.8 | 40/40 pass |
| after, loaded | 400.3 | 409.2 | 417.4 | 40/40 pass |

The loaded failures reproduce the CI signature exactly, including `ran: True` and `items: 2` on every one of them. Pushed further, to 96 spinners on one core, the fixed test still reports min 400.5 and 0 failures.

`test_the_wait_is_bounded_and_a_control_that_never_appears_still_reports_not_run` is sound and is left alone. Both of its numbers are on the action's own clock: the loop runs while elapsed is under 300 ms, so `waitedMs >= 300` structurally. Measured at min 300.3 across 40 runs under the same load, against its bound of 250.

Full job test set on this branch: `python -m pytest tests/studio/studiobench -q` gives 654 passed.

One thing I did not change, recorded here because I saw it. `test_a_settled_reply_costs_the_action_nothing` asserts `waitedMs < 50` and does genuinely measure elapsed wall time, so at 96 spinners on one core it goes over on 1 or 2 runs in 40 as `dom.js`'s methods are JIT compiled inside the measured window. That is identical before and after this change, it needs a load far past the level that reproduces the actual CI failure, and it is a different defect, so it is out of scope here.

`Repo tests (CPU)` is also red on main right now for an unrelated `stripSearchImageTokens is not defined`, which another change is handling.
