### PR TITLE
Tests: extract setup.sh's fast path without depending on if vs elif

### DIFF
--- a/tests/sh/test_setup_desktop_backend_version_fastpath.sh
+++ b/tests/sh/test_setup_desktop_backend_version_fastpath.sh
@@ -11,13 +11,75 @@ SETUP_SH="$SCRIPT_DIR/../../studio/setup.sh"
 WORK=$(mktemp -d)
 trap 'rm -rf "$WORK"' EXIT
 
-# Extract the fast-path check block from setup.sh
-awk '/if \[ -n "\$INSTALLED_VER" \] && \[ -n "\$LATEST_VER" \] && \[ "\$INSTALLED_VER" = "\$LATEST_VER" \]/ {on=1}
-     on && /^        _setup_pin=/ {exit}
-     on {print}' "$SETUP_SH" > "$WORK/fastpath_blk.sh"
-echo "fi" >> "$WORK/fastpath_blk.sh"
+BLK="$WORK/fastpath_blk.sh"
 
-[ -s "$WORK/fastpath_blk.sh" ] || { echo "FATAL: fastpath block not found in $SETUP_SH" >&2; exit 1; }
+# This test runs the fast path by slicing it out of setup.sh, so every slice
+# assumption below is checked and reported as drift. An unchecked slice fails
+# as a bare "syntax error near unexpected token" from a temp file the reader
+# has never heard of, which is how the elif of #8515 sat red on main: the
+# condition text was unchanged, only the keyword in front of it moved, and
+# three of the six cases still "passed" because a block that never sourced
+# leaves _SKIP_PYTHON_DEPS at its false default.
+drift() {
+    echo "FATAL: the fast-path extraction no longer matches $SETUP_SH -- $1" >&2
+    echo "       Fix the extraction in $0 (or the block in setup.sh), do not silence it:" >&2
+    echo "       start anchor is the INSTALLED_VER = LATEST_VER condition (any if/elif keyword)," >&2
+    echo "       end anchor is the first _setup_pin= assignment after it." >&2
+    exit 1
+}
+
+# Matched as a literal, and deliberately without the leading keyword: the block
+# is reached by an elif today and was reached by an if before #8515, and which
+# one it is has no bearing on what this test exercises. The keyword is checked
+# separately below and normalised to a plain `if` on the way out, so the slice
+# is always a standalone, parseable construct.
+FASTPATH_COND='[ -n "$INSTALLED_VER" ] && [ -n "$LATEST_VER" ] && [ "$INSTALLED_VER" = "$LATEST_VER" ]; then'
+
+_extract_status=0
+awk -v COND="$FASTPATH_COND" '
+    index($0, COND) > 0 { starts++ }
+    !on && index($0, COND) > 0 {
+        prefix = substr($0, 1, index($0, COND) - 1)
+        if (prefix !~ /^[ \t]*(el)?if $/) { bad_prefix = prefix; next }
+        on = 1
+        print "if " COND
+        next
+    }
+    on && !ended && $0 ~ /^[ \t]*_setup_pin=/ { ended = 1; next }
+    on && !ended { body++; print }
+    END {
+        if (starts != 1) { print starts + 0 > "/dev/stderr"; exit 3 }
+        if (!on) { print bad_prefix > "/dev/stderr"; exit 4 }
+        if (!ended) { exit 5 }
+        if (body == 0) { exit 6 }
+        print "fi"
+    }
+' "$SETUP_SH" > "$BLK" 2> "$WORK/extract_err" || _extract_status=$?
+
+case "$_extract_status" in
+    0) ;;
+    3) drift "expected exactly 1 line holding the fast-path condition, found $(cat "$WORK/extract_err")" ;;
+    4) drift "the fast-path condition is no longer introduced by if/elif (leading text: '$(cat "$WORK/extract_err")')" ;;
+    5) drift "the end anchor (_setup_pin=) no longer follows the fast-path condition" ;;
+    6) drift "the fast-path block is empty" ;;
+    *) drift "the extraction failed with status $_extract_status" ;;
+esac
+
+# The slice has to still contain what this test claims to test. Without these
+# the extraction could shrink to nothing meaningful and every case would pass.
+grep -q '_SKIP_PYTHON_DEPS=true' "$BLK" \
+    || drift "the extracted block never sets _SKIP_PYTHON_DEPS=true"
+grep -q 'UNSLOTH_DESKTOP_BACKEND_VERSION' "$BLK" \
+    || drift "the extracted block no longer consults UNSLOTH_DESKTOP_BACKEND_VERSION"
+
+# The part that matters: a slice that does not parse is drift, not a test failure.
+if ! _syntax_err=$(bash -n "$BLK" 2>&1); then
+    echo "--- extracted block ---" >&2
+    cat -n "$BLK" >&2
+    echo "--- bash -n ---" >&2
+    echo "$_syntax_err" >&2
+    drift "the extracted block is not valid bash (see above)"
+fi
 
 PASS=0
 FAIL=0
@@ -58,12 +120,17 @@ eval_fastpath() {
         _PKG_NAME="unsloth"
         SCRIPT_DIR="$WORK"
         _SKIP_PYTHON_DEPS=false
-        step() { :; }
+        # false is also what a block that never ran leaves behind, so three of
+        # the six cases below would pass on a block that did nothing at all.
+        # Both ways that can happen report themselves instead.
+        _STEP_CALLS=0
+        step() { _STEP_CALLS=$((_STEP_CALLS + 1)); }
         substep() { :; }
-        
+
         # Execute extracted block
         # shellcheck disable=SC1090
-        . "$WORK/fastpath_blk.sh"
+        . "$BLK" || { echo "BLOCK_FAILED_TO_RUN"; exit 0; }
+        [ "$_STEP_CALLS" -gt 0 ] || { echo "BLOCK_NOT_ENTERED"; exit 0; }
         echo "$_SKIP_PYTHON_DEPS"
     )
 }


### PR DESCRIPTION
## The red

`tests/sh/test_setup_desktop_backend_version_fastpath.sh` fails 3 of 6 on `main`:

```
fastpath_blk.sh: line 1: syntax error near unexpected token `elif'
fastpath_blk.sh: line 1: `    elif [ -n "$INSTALLED_VER" ] && [ -n "$LATEST_VER" ] && [ "$INSTALLED_VER" = "$LATEST_VER" ]; then'
```

The test slices the version fast path out of `studio/setup.sh` with awk and sources the slice. The start anchor matched the condition text but was blind to the keyword in front of it, so the slice began at `elif` and could not parse.

The other three cases passed vacuously, not correctly. They expect `false`, and a block that never sources leaves `_SKIP_PYTHON_DEPS` at the `false` the test itself set a line earlier.

## Where it came from

`90644db9e` (#8515, "Studio: repair duplicate package metadata during updates") put a duplicate-metadata branch ahead of the fast path, so the fast path became the `elif` of that chain. Confirmed by running the test either side rather than by reading the diff:

| tree | result |
| --- | --- |
| `f1f95f71f` (#8515's parent) | 6 passed, 0 failed |
| `90644db9e` (#8515) | 3 passed, 3 failed |

The test itself predates that commit (added in `dc26127a4`, #8670).

## The production side is correct

`studio/setup.sh` is not touched here.

- `bash -n studio/setup.sh` is clean, so the shipped script was never broken.
- The new branch only *precedes* the fast path. When the probe exit is not 2 the `elif` is the identical condition the old `if` had, and when it is 2 the fast path is skipped so the dependency pass repairs the duplicate metadata, which is the intent.
- Everything the test exercises, the `UNSLOTH_DESKTOP_BACKEND_VERSION` escape inside the branch, is unchanged.
- The parity question: `studio/setup.ps1` grew the matching `elseif ($_InstalledVersionProbeExit -eq 2)` in the same commit, and the XPU pin escape the surrounding comment says it mirrors is present on both sides. No follow-up issue needed.

So the defect is entirely in how the test slices, and the fix belongs in the test.

## The fix

The extraction matches the condition as a literal *without* the keyword, checks separately that the keyword is an `if` or an `elif`, and re-emits the block as a standalone `if`. Re-anchoring on the enclosing `if` was rejected: it reproduces the same defect one line up, and the enclosing branch is different logic.

Every assumption the slice makes now reports itself as drift by name:

- exactly one line carries the fast-path condition (0 or 2+ is drift)
- that line is introduced by `if` or `elif`
- the `_setup_pin=` end anchor still follows it
- the body is non-empty, still sets `_SKIP_PYTHON_DEPS=true`, and still consults `UNSLOTH_DESKTOP_BACKEND_VERSION`
- **`bash -n` on the extracted fragment**, with the numbered fragment and the parser error printed

Next time `setup.sh` moves, the test says `the fast-path extraction no longer matches studio/setup.sh -- ...` instead of a cryptic syntax error against a temp file the reader has never heard of.

The cases also stop trusting the default: the runner prints `BLOCK_FAILED_TO_RUN` if sourcing fails and `BLOCK_NOT_ENTERED` if the fast path was never taken, so no case can pass on a block that did nothing.

### Why not have setup.sh expose the decision as a sourceable function

Considered and rejected, and this is a real tradeoff. `setup.sh` has no sourced-helper precedent: it is the only `.sh` under `studio/`, it sources nothing from the tree, and it runs top to bottom, so a test cannot source it without either a new shipped file (which then has to survive packaging and every install path) or a sourcing guard in an installer that runs on user machines. It is also deliberately mirrored against `setup.ps1`, which cannot take the same split. And the block is not a pure decision: it runs `$VENV_DIR/bin/python` probes, emits `step`/`substep` output, and mutates several globals. A self-verifying extraction is the accepted outcome, and it is the pattern the sibling `tests/sh/test_setup_xpu_fastpath_escape.sh` already uses (content assertions plus `bash -n` on its own slice).

## Verification

All 6 cases pass, and the whole `tests/sh` suite is green.

Mutation testing, each mutation applied to a throwaway copy of `setup.sh`, shows the test still has teeth and that the failure modes are distinguishable:

| mutation | result |
| --- | --- |
| none (control) | 6 passed |
| plain `if` instead of `elif` (pre-#8515 shape) | 6 passed, so the fix is keyword-agnostic in both directions |
| keyword is neither `if` nor `elif` | drift: "the fast-path condition is no longer introduced by if/elif (leading text: `    while `)" |
| condition text changed | drift: "expected exactly 1 line holding the fast-path condition, found 0" |
| condition text appears twice | drift: "... found 2" |
| `_setup_pin=` end anchor renamed | drift: "the end anchor (_setup_pin=) no longer follows the fast-path condition" |
| unbalanced `fi` inside the block | drift: "the extracted block is not valid bash", with the fragment and the `bash -n` error |
| the whole desktop-version escape deleted | drift: "the extracted block no longer consults UNSLOTH_DESKTOP_BACKEND_VERSION" |
| escape no longer clears `_SKIP_PYTHON_DEPS` | 3 real FAILs, the behavioural break the test exists to catch |
| fast path entered but `step` never runs | 6 FAILs reporting `BLOCK_NOT_ENTERED`, where the old test would have passed 3 |

The last two rows are the point: a behavioural regression fails as a test failure, and a structural change to `setup.sh` fails as drift with a name.