### PR TITLE
Check the exclude set's membership, not one spelling of it

### DIFF
--- a/tests/studio/test_model_picker_contracts.py
+++ b/tests/studio/test_model_picker_contracts.py
@@ -2745,7 +2745,13 @@ def test_the_backfill_fills_in_fields_rather_than_skipping_known_keys():
     assert "fill_absent_fields: bool = False" in route, "the rule this mirrors"
     assert "fill_absent_fields = payload.fill_absent_fields," in route
     # A write mode must not leak into saved fields, or model_id-only removal stops working.
-    assert '"remove", "fill_absent_fields"' in route
+    # Read the exclude set itself rather than one spelling of it: membership is the rule,
+    # while the literal's line breaks and entry order are not. Adding mirrors_server_tuning
+    # pushed this set onto several lines and broke the old single-line substring, even
+    # though both names were still excluded.
+    saved_fields_exclude = route.split("saved_fields = payload.model_dump(", 1)[1].split("}", 1)[0]
+    assert '"remove"' in saved_fields_exclude
+    assert '"fill_absent_fields"' in saved_fields_exclude
 
     # The merge is the server's, in the write's transaction: a client-side one reopens the race.
     db = _read_backend("storage/studio_db.py")


### PR DESCRIPTION
## What this fixes

`main`'s **Repo tests (CPU)** job is currently red. Run [32659798911](https://github.com/unslothai/unsloth/actions/runs/32659798911) on `1f475d7f`:

```
1 failed, 9907 passed, 173 skipped, 135 warnings, 40 subtests passed in 668.94s
FAILED tests/studio/test_model_picker_contracts.py::test_the_backfill_fills_in_fields_rather_than_skipping_known_keys
```

## The rule is intact; the assertion is what broke

`settings.py` still excludes both write modes, so a write mode still cannot leak into saved fields and the legacy model_id-only removal still works:

```python
saved_fields = payload.model_dump(
    exclude = {
        "model_id",
        "llama_extra_args",
        "remove",
        "fill_absent_fields",
        "mirrors_server_tuning",
    },
    exclude_none = True,
)
```

The test asserted the **raw** source for `'"remove", "fill_absent_fields"'`. That only held while the set fitted on one line. 1f475d7f (Studio: improve Auto context selection and share remembered model settings) added `mirrors_server_tuning`, which wrapped the literal across five lines:

```diff
-            exclude = {"model_id", "llama_extra_args", "remove", "fill_absent_fields"},
+            exclude = {
+                "model_id",
+                "llama_extra_args",
+                "remove",
+                "fill_absent_fields",
+                "mirrors_server_tuning",
+            },
```

The two names are still adjacent in the set, just not in the text. So this is a false alarm from a correct change, not a regression, and I would rather say that than present it as a product fix.

## The fix

Read the set literal and assert each name is a member:

```python
saved_fields_exclude = route.split("saved_fields = payload.model_dump(", 1)[1].split("}", 1)[0]
assert '"remove"' in saved_fields_exclude
assert '"fill_absent_fields"' in saved_fields_exclude
```

Membership is the rule the comment above it states. The literal's line breaks and entry order are not, and both were being asserted by accident. This survives the wrapping that broke it and the next reordering or insertion, which matters because adding a write mode is exactly the change that will touch this set again.

The two neighbouring assertions on `route` are left alone: `"fill_absent_fields: bool = False"` and `"fill_absent_fields = payload.fill_absent_fields,"` are single-line constructs, so raw matching is fine for them.

## Testing

```
# main (1f475d7f), unmodified
1 failed, 186 passed
FAILED tests/studio/test_model_picker_contracts.py::test_the_backfill_fills_in_fields_rather_than_skipping_known_keys

# with this change
187 passed
```

One failure before and none after, in the same file, which matches CI's single failure exactly.

Test-only change: no product code is touched, so there is nothing to regress in the backend or the picker.
