### PR TITLE
Fix main: read the settings route's contract off its parse tree, not its text

### DIFF
--- a/tests/studio/test_model_picker_contracts.py
+++ b/tests/studio/test_model_picker_contracts.py
@@ -132,13 +132,13 @@ def _model_dump_exclusions(rel: str, function: str) -> set[str]:
                 for element in keyword.value.elts
                 if isinstance(element, ast.Constant) and isinstance(element.value, str)
             }
-            assert len(names) == len(keyword.value.elts), (
-                f"{function}: exclude holds a name this check cannot read statically"
-            )
+            assert len(names) == len(
+                keyword.value.elts
+            ), f"{function}: exclude holds a name this check cannot read statically"
             excluded.append(names)
-    assert len(excluded) == 1, (
-        f"{rel}:{function} has {len(excluded)} model_dump(exclude = ...) calls, want 1"
-    )
+    assert (
+        len(excluded) == 1
+    ), f"{rel}:{function} has {len(excluded)} model_dump(exclude = ...) calls, want 1"
     return excluded[0]
 
 
@@ -149,9 +149,9 @@ def _annotated_field(rel: str, class_name: str, field: str) -> tuple[str, object
             continue
         if not (isinstance(statement.target, ast.Name) and statement.target.id == field):
             continue
-        assert isinstance(statement.value, ast.Constant), (
-            f"{class_name}.{field} no longer defaults to a literal"
-        )
+        assert isinstance(
+            statement.value, ast.Constant
+        ), f"{class_name}.{field} no longer defaults to a literal"
         return ast.unparse(statement.annotation), statement.value.value
     raise AssertionError(f"{rel}:{class_name} declares no field named {field}")
 

--- a/tests/studio/test_model_picker_contracts.py
+++ b/tests/studio/test_model_picker_contracts.py
@@ -13,6 +13,7 @@ backend pytest checks (which prove the backend logic).
 
 from __future__ import annotations
 
+import ast
 import re
 from pathlib import Path
 
@@ -81,6 +82,101 @@ def _read_backend(rel: str) -> str:
     path = WORKDIR / "studio" / "backend" / rel
     assert path.exists(), f"missing backend source file: {path}"
     return path.read_text(encoding = "utf-8")
+
+
+# The frontend greps below have no parser to hand. The backend does, and a rule read out
+# of the parse tree survives the edits that are not about it: a formatter that splits a
+# set literal one name per line, a reordering, a renamed neighbour. Each helper raises
+# rather than returning empty when it cannot find what it was pointed at, so a rule that
+# moves reddens here instead of passing vacuously.
+def _backend_function(rel: str, name: str) -> ast.FunctionDef | ast.AsyncFunctionDef:
+    """The definition of ``name`` in backend file ``rel``."""
+    tree = ast.parse(_read_backend(rel), filename = rel)
+    found = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == name
+    ]
+    assert len(found) == 1, f"{rel} defines {len(found)} functions named {name}, want 1"
+    return found[0]
+
+
+def _backend_class(rel: str, name: str) -> ast.ClassDef:
+    """The definition of class ``name`` in backend file ``rel``."""
+    tree = ast.parse(_read_backend(rel), filename = rel)
+    found = [
+        node for node in ast.walk(tree) if isinstance(node, ast.ClassDef) and node.name == name
+    ]
+    assert len(found) == 1, f"{rel} defines {len(found)} classes named {name}, want 1"
+    return found[0]
+
+
+def _model_dump_exclusions(rel: str, function: str) -> set[str]:
+    """The names the one ``model_dump(exclude = {...})`` inside ``function`` leaves out.
+
+    Exactly one such call, or the answer would be a union across calls and dropping a
+    name from the one that matters could hide behind another.
+    """
+    excluded: list[set[str]] = []
+    for node in ast.walk(_backend_function(rel, function)):
+        if not isinstance(node, ast.Call):
+            continue
+        if not (isinstance(node.func, ast.Attribute) and node.func.attr == "model_dump"):
+            continue
+        for keyword in node.keywords:
+            if keyword.arg != "exclude":
+                continue
+            assert isinstance(keyword.value, ast.Set), f"{function}: exclude is not a set literal"
+            names = {
+                element.value
+                for element in keyword.value.elts
+                if isinstance(element, ast.Constant) and isinstance(element.value, str)
+            }
+            assert len(names) == len(keyword.value.elts), (
+                f"{function}: exclude holds a name this check cannot read statically"
+            )
+            excluded.append(names)
+    assert len(excluded) == 1, (
+        f"{rel}:{function} has {len(excluded)} model_dump(exclude = ...) calls, want 1"
+    )
+    return excluded[0]
+
+
+def _annotated_field(rel: str, class_name: str, field: str) -> tuple[str, object]:
+    """``(annotation, default)`` for ``field: <annotation> = <default>`` on ``class_name``."""
+    for statement in _backend_class(rel, class_name).body:
+        if not isinstance(statement, ast.AnnAssign):
+            continue
+        if not (isinstance(statement.target, ast.Name) and statement.target.id == field):
+            continue
+        assert isinstance(statement.value, ast.Constant), (
+            f"{class_name}.{field} no longer defaults to a literal"
+        )
+        return ast.unparse(statement.annotation), statement.value.value
+    raise AssertionError(f"{rel}:{class_name} declares no field named {field}")
+
+
+def _forwarded_keywords(rel: str, function: str, obj: str) -> set[str]:
+    """Keyword arguments passed as ``name = <obj>.name`` anywhere inside ``function``.
+
+    Same name on both sides, so this says the value reached the callee unmodified and
+    under its own name, which is the part a caller downstream depends on.
+    """
+    forwarded = set()
+    for node in ast.walk(_backend_function(rel, function)):
+        if not isinstance(node, ast.Call):
+            continue
+        for keyword in node.keywords:
+            value = keyword.value
+            if (
+                keyword.arg
+                and isinstance(value, ast.Attribute)
+                and isinstance(value.value, ast.Name)
+                and value.value.id == obj
+                and value.attr == keyword.arg
+            ):
+                forwarded.add(keyword.arg)
+    return forwarded
 
 
 def _brace_matched_body(text: str, declaration: str) -> str:
@@ -2741,11 +2837,18 @@ def test_the_backfill_fills_in_fields_rather_than_skipping_known_keys():
     # Ordinary saves must stay unconditional, or a settings edit would never land.
     assert "syncModelOverride" in api and "fill_absent_fields: true" in api
 
-    route = _read_backend("routes/settings.py")
-    assert "fill_absent_fields: bool = False" in route, "the rule this mirrors"
-    assert "fill_absent_fields = payload.fill_absent_fields," in route
+    # Read out of the route's parse tree, not its text. The rule is which names the route
+    # declares, forwards and excludes; a set literal reflowed one name per line by the
+    # formatter, or a name added beside them, is not a change to it.
+    route = "routes/settings.py"
+    handler = "update_openai_auto_switch_override"
+    assert _annotated_field(route, "ModelOverridePayload", "fill_absent_fields") == (
+        "bool",
+        False,
+    ), "the rule this mirrors"
+    assert "fill_absent_fields" in _forwarded_keywords(route, handler, "payload")
     # A write mode must not leak into saved fields, or model_id-only removal stops working.
-    assert '"remove", "fill_absent_fields"' in route
+    assert {"remove", "fill_absent_fields"} <= _model_dump_exclusions(route, handler)
 
     # The merge is the server's, in the write's transaction: a client-side one reopens the race.
     db = _read_backend("storage/studio_db.py")


### PR DESCRIPTION
`Repo tests (CPU)` has been red on main since #9492 (1f475d7f1), on
`tests/studio/test_model_picker_contracts.py::test_the_backfill_fills_in_fields_rather_than_skipping_known_keys`.
Every open PR inherits it. Run 32659798911.

### What actually broke

The rule the test guards did not change. #9492 added a third name,
`mirrors_server_tuning`, to the `model_dump(exclude = {...})` set in
`update_openai_auto_switch_override`. The formatter then split that set one name
per line, and this assertion stopped matching:

```python
route = _read_backend("routes/settings.py")
assert '"remove", "fill_absent_fields"' in route
```

`route` is the raw source text of `studio/backend/routes/settings.py`, so the
two names now have a newline and sixteen spaces between them. Both are still
excluded, and write modes still stay out of `saved_fields`. #9492 is correct
here and the test was stale.

### Why not just re-pin the literal

This is the third failure of this exact shape on main in as many days: #9579
sliced `setup.sh` at a keyword that had been demoted from `if` to `elif`, and
#9578 compared two clock origins. Pinning a new literal only moves the next one
into the future. A test that has to be re-edited whenever a set literal is
reflowed is not testing the thing it names.

### The fix

The frontend greps in this file have no parser to hand. The backend does. Three
helpers read the rule out of `settings.py`'s AST:

- `_model_dump_exclusions` returns the names the one `model_dump(exclude = ...)`
  in a given function leaves out. Exactly one such call is required, or the
  answer would be a union across calls and a name dropped from the call that
  matters could hide behind another.
- `_annotated_field` returns the annotation and literal default of a pydantic
  field, so "declared as a bool defaulting to False" is asserted as that rather
  than as a substring.
- `_forwarded_keywords` returns the keyword arguments passed as
  `name = payload.name`, which is the part the storage layer depends on.

Each raises rather than returning empty when it cannot find what it was pointed
at, so a renamed handler or field reddens here instead of passing vacuously.

### Anti-vacuity evidence

One mutation at a time against `settings.py`, running the repaired test:

| Mutation | Result |
|---|---|
| unmodified main | pass |
| `"fill_absent_fields"` dropped from the exclude set | **fail** |
| the exclude set reflowed onto one line, reordered | pass |
| the payload field defaulted to `True` | **fail** |
| `fill_absent_fields` no longer forwarded to the db call | **fail** |
| the route handler renamed | **fail** |
| the payload field renamed | **fail** |

The reflow is the case that caused this outage and is now the only one that
stays green. Every mutation that actually breaks the contract still reddens.

### Local run

`tests/studio/test_model_picker_contracts.py`: 187 passed, was 186 passed and 1
failed. No production code is touched by this PR.

The second failure on the same run, `(Python 3.13)` / `Backend tests`, is a
different root cause and is fixed separately.