### PR TITLE
Extract the rollback helpers' dependency closure instead of a hand-written list

### DIFF
--- a/tests/studio/test_install_rollback_lifecycle.ps1
+++ b/tests/studio/test_install_rollback_lifecycle.ps1
@@ -12,7 +12,12 @@ $tokens = $null; $errors = $null
 $ast = [System.Management.Automation.Language.Parser]::ParseFile($installPath, [ref]$tokens, [ref]$errors)
 if ($errors) { $errors | ForEach-Object { $_.ToString() }; throw "install.ps1 has parse errors" }
 
-$helperNames = @(
+# The six functions under test. Extracting only these is what broke when #9501 added a
+# sibling helper they call: the list is maintained by hand, so it goes stale the moment
+# a helper grows a dependency, and the failure surfaces as "not recognized" inside an
+# unrelated case rather than as a missing extraction. Extract the transitive closure
+# instead, so a new callee is picked up without anyone remembering to add it here.
+$subjectNames = @(
     "Start-StudioVenvRollback",
     "Remove-StudioVenvTreeWithRetry",
     "Test-StudioVenvRollbackMustBePreserved",
@@ -20,19 +25,79 @@ $helperNames = @(
     "Restore-StudioVenvRollback",
     "Complete-StudioVenvRollback"
 )
-foreach ($name in $helperNames) {
-    $fn = $ast.FindAll({ param($node)
-        $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and $node.Name -eq $name
-    }, $true)
-    if ($fn.Count -ne 1) { throw "expected exactly one $name in install.ps1, found $($fn.Count)" }
-    Invoke-Expression $fn[0].Extent.Text
+
+$definitions = @{}
+foreach ($node in $ast.FindAll({ param($n)
+    $n -is [System.Management.Automation.Language.FunctionDefinitionAst]
+}, $true)) {
+    if ($definitions.ContainsKey($node.Name)) {
+        throw "install.ps1 defines $($node.Name) more than once; the extraction cannot tell which one is under test"
+    }
+    $definitions[$node.Name] = $node
 }
+
+foreach ($name in $subjectNames) {
+    if (-not $definitions.ContainsKey($name)) {
+        throw "expected $name in install.ps1, found no definition (renamed or removed?)"
+    }
+}
+
+# Sinks this file stubs below. The walk stops at them, so their own dependencies (ANSI
+# colouring and the like) are not dragged in for functions that are replaced anyway.
+$stubbedNames = @("substep", "Write-StudioLine")
+
+# Breadth-first over the call graph, following only names install.ps1 itself defines.
+# Anything else is a real cmdlet or one of the stubs below and must not be extracted.
+$extracted = [System.Collections.Generic.List[string]]::new()
+$seen = @{}
+$queue = [System.Collections.Generic.Queue[string]]::new()
+foreach ($name in $subjectNames) { $queue.Enqueue($name) }
+while ($queue.Count -gt 0) {
+    $name = $queue.Dequeue()
+    if ($seen.ContainsKey($name)) { continue }
+    $seen[$name] = $true
+    $extracted.Add($name)
+    foreach ($call in $definitions[$name].Body.FindAll({ param($n)
+        $n -is [System.Management.Automation.Language.CommandAst]
+    }, $true)) {
+        $callee = $call.GetCommandName()
+        if ($callee -and $definitions.ContainsKey($callee) -and
+            $stubbedNames -notcontains $callee -and -not $seen.ContainsKey($callee)) {
+            $queue.Enqueue($callee)
+        }
+    }
+}
+
+foreach ($name in $extracted) { Invoke-Expression $definitions[$name].Extent.Text }
+
+$pulledIn = @($extracted | Where-Object { $subjectNames -notcontains $_ })
+if ($pulledIn.Count -gt 0) { Write-Host "Extracted dependencies: $($pulledIn -join ', ')" }
 
 function substep { param([string]$Message, [string]$Color) }
 # The rollback helpers report through install.ps1's UTF-8 stdout sink on their warn
 # and error branches. None of the cases below take one today, but this file runs
 # under "Stop", so an undefined sink would abort the suite rather than fail a check.
 function Write-StudioLine { param([string]$Message, [string]$ForegroundColor) Write-Host $Message }
+
+# Fail here, with the caller named, rather than 60 lines further down as "the term X is
+# not recognized" inside whichever case happened to reach it first. The closure above
+# makes an install.ps1-defined callee unreachable by construction; this catches the rest,
+# including a helper that calls a sink this file forgot to stub.
+$unresolved = [System.Collections.Generic.List[string]]::new()
+foreach ($name in $extracted) {
+    foreach ($call in $definitions[$name].Body.FindAll({ param($n)
+        $n -is [System.Management.Automation.Language.CommandAst]
+    }, $true)) {
+        $callee = $call.GetCommandName()
+        if (-not $callee) { continue }
+        if (-not (Get-Command -Name $callee -ErrorAction SilentlyContinue)) {
+            $unresolved.Add("$callee (called by $name)")
+        }
+    }
+}
+if ($unresolved.Count -gt 0) {
+    throw "extracted helpers call commands that do not resolve: $(($unresolved | Sort-Object -Unique) -join '; ')"
+}
 
 $failures = 0
 function Check($name, $condition) {


### PR DESCRIPTION
## The failure

`parity (windows-latest)` has been red on main since `f1f95f71` (2026-08-23 05:12 UTC), in the `PowerShell rollback lifecycle tests` step:

```
Test-StudioPathPresent:
Line |
   9 |         if (Test-StudioPathPresent -Path $backup) {
     |             ~~~~~~~~~~~~~~~~~~~~~~
     | The term 'Test-StudioPathPresent' is not recognized as a name of a cmdlet,
     | function, script file, or executable program.
```

`tests/studio/test_install_rollback_lifecycle.ps1` AST-extracts the venv rollback helpers out of `install.ps1` so the top-level installer is never executed. It extracted six functions named in a list maintained by hand, and nothing checked that those six were self-contained.

## Which change caused it, and which side is wrong

#9501 (`f1f95f71f`, "Installer: replace an existing venv whose interpreter is gone") added `Test-StudioPathPresent` at `install.ps1:4018` and called it from `Restore-StudioVenvRollback` and `Complete-StudioVenvRollback`.

**The production change is correct.** All of these are siblings inside `Install-UnslothStudio`, defined before their callers in the same scope, so they resolve normally when the installer runs. I checked this specifically rather than assuming it, because a nested helper called across function boundaries would have been a real defect worth reverting for. It is not one.

**The test is what is wrong**, and it is wrong structurally rather than by one omission. It failed as an unrecognized command deep inside an unrelated case, naming neither the actual problem nor the list that needed editing.

## The list was already broken

`Merge-StudioVenvRollbackTree` has been missing from that list since #7823 added it. The only reason it never failed is that no assertion reaches the partial-merge path that calls it. Adding `Test-StudioPathPresent` to the list would have fixed today's red and left that in place, waiting for whoever first wrote a test for partial restore.

That is the argument against re-baselining here: the list is a manual mirror of a dependency graph, and it had already drifted once without anyone noticing.

## The fix

Walk the call graph. Starting from the six functions under test, follow every callee `install.ps1` itself defines, stop at the two sinks this file stubs, and extract the closure. A helper that grows a dependency is picked up without anyone remembering to edit the test.

The six stay named explicitly, because a rename or removal should still fail loudly rather than silently shrink what is under test.

A resolution guard runs once the stubs are defined: if any extracted helper calls something that does not resolve, the suite throws up front and names both the command and its caller. The closure makes an `install.ps1`-defined callee unreachable by construction, so the guard covers the rest, such as a helper calling an output sink this file forgot to stub.

## Verification

On pwsh 7.6, the suite fails exactly as CI reports before the change and passes after, printing the two dependencies it pulled in:

```
Extracted dependencies: Test-StudioPathPresent, Merge-StudioVenvRollbackTree
...
All checks passed
```

Three mutations confirm it can still fail, each exiting 1:

| mutation | result |
|---|---|
| block extraction of `Test-StudioPathPresent` (simulates the stale hand-list) | guard throws, naming both `Restore-StudioVenvRollback` and `Complete-StudioVenvRollback` |
| rename `Complete-StudioVenvRollback` in `install.ps1` | `expected Complete-StudioVenvRollback in install.ps1, found no definition (renamed or removed?)` |
| give a helper a call to a command that does not exist | caught before any case runs, naming the caller |

`install.ps1` is unmodified; the only changed file is the test.

## Note

This is the third test in two days to break on how it slices source rather than on behaviour, after #9579 (a shell test slicing `setup.sh` at a keyword that had been demoted from `if` to `elif`) and #9578 (a selftest comparing two clock origins). All three passed for reasons unrelated to what they claimed to check.
