### PR TITLE
Studio: give a resize drag its cursor and hit test from an overlay, not the whole document

### DIFF
--- a/studio/frontend/src/components/ui/panel-resize-handle.tsx
+++ b/studio/frontend/src/components/ui/panel-resize-handle.tsx
@@ -21,6 +21,55 @@ const CLICK_COMPAT_WINDOW_MS = 300
 /** Arrow-key resize step for keyboard users. */
 const RESIZE_STEP = 16
 
+// A drag needs one cursor over the whole viewport, because the pointer travels
+// across buttons and text that would otherwise claim their own. That used to be
+// `html[data-panel-resizing] *` plus `cursor`/`user-select` on <body>. Both
+// reach every element in the document: the universal selector matches all of
+// them, and `cursor` and `user-select` are inherited, so writing them on <body>
+// marks inherited style dirty for everything below it. The cost is therefore
+// proportional to the STANDING DOM rather than to the one thing that changed,
+// which is the same shape as the sidebar-width writes scoped in #9400/#9441.
+//
+// A single fixed element on top of the viewport carries the same cursor with an
+// invalidation set of one element. It is transparent and it is removed the
+// instant the drag ends, so nothing about what the user sees changes.
+const DRAG_OVERLAY_SLOT = "panel-resize-drag-overlay"
+/** Nested drags cannot happen through pointer capture, but a stuck overlay would
+ *  swallow the whole UI, so ownership is explicit rather than assumed. */
+let dragOverlayOwners = 0
+
+function acquireDragOverlay(): void {
+  dragOverlayOwners += 1
+  if (dragOverlayOwners > 1) return
+  const el = document.createElement("div")
+  el.setAttribute("data-slot", DRAG_OVERLAY_SLOT)
+  // Decorative and non-interactive as far as assistive tech is concerned: it
+  // exists only to own the cursor while the pointer is already captured.
+  el.setAttribute("aria-hidden", "true")
+  const s = el.style
+  s.position = "fixed"
+  s.inset = "0"
+  // Above every app surface. The overlay outlives no frame the user can act in,
+  // and pointer capture means it never receives the drag's own events.
+  s.zIndex = "2147483647"
+  s.background = "transparent"
+  // col-resize unconditionally, which is what the replaced rule did even when a
+  // collapsed edge was being dragged open.
+  s.cursor = "col-resize"
+  s.userSelect = "none"
+  s.touchAction = "none"
+  document.body.appendChild(el)
+}
+
+function releaseDragOverlay(): void {
+  if (dragOverlayOwners === 0) return
+  dragOverlayOwners -= 1
+  if (dragOverlayOwners > 0) return
+  document
+    .querySelector(`[data-slot="${DRAG_OVERLAY_SLOT}"]`)
+    ?.remove()
+}
+
 type DragState = {
   startX: number
   startWidth: number
@@ -130,6 +179,9 @@ export function PanelResizeHandle({
   // Where `rootVar` is painted, resolved once on pointer down. Always
   // [document.documentElement] with the flag off, which is what shipped.
   const rootTargetsRef = React.useRef<HTMLElement[]>([])
+  // Whether THIS handle is holding the cursor overlay. endDrag also runs as the
+  // effect cleanup, where no drag happened and nothing was acquired.
+  const overlayHeldRef = React.useRef(false)
 
   const paint = React.useCallback(
     (value: string) => {
@@ -177,8 +229,10 @@ export function PanelResizeHandle({
     document.documentElement.removeAttribute("data-panel-resizing")
     targetRef.current = null
     setDragging(false)
-    document.body.style.removeProperty("cursor")
-    document.body.style.removeProperty("user-select")
+    if (overlayHeldRef.current) {
+      overlayHeldRef.current = false
+      releaseDragOverlay()
+    }
   }, [paint, rootVar])
 
   const handlePointerDown = (event: React.PointerEvent<HTMLButtonElement>) => {
@@ -202,8 +256,8 @@ export function PanelResizeHandle({
     targetRef.current?.setAttribute("data-resizing", "true")
     document.documentElement.setAttribute("data-panel-resizing", "true")
     setDragging(true)
-    document.body.style.setProperty("cursor", "col-resize")
-    document.body.style.setProperty("user-select", "none")
+    overlayHeldRef.current = true
+    acquireDragOverlay()
   }
 
   const handlePointerMove = (event: React.PointerEvent<HTMLButtonElement>) => {

--- a/studio/frontend/src/components/ui/panel-resize-handle.tsx
+++ b/studio/frontend/src/components/ui/panel-resize-handle.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/components/ui/tooltip"
 import { getClientPlatform } from "@/components/tauri/window-titlebar"
 import { PANEL_RESIZE_SCOPED_VARS_ENABLED } from "@/components/ui/panel-resize-recalc-flags"
+import { Z_LAYER } from "@/lib/z-layers"
 
 /** Pointer travel (px) below which a drag counts as a plain click. */
 const DRAG_SLOP = 4
@@ -30,9 +31,16 @@ const RESIZE_STEP = 16
 // proportional to the STANDING DOM rather than to the one thing that changed,
 // which is the same shape as the sidebar-width writes scoped in #9400/#9441.
 //
-// A single fixed element on top of the viewport carries the same cursor with an
-// invalidation set of one element. It is transparent and it is removed the
-// instant the drag ends, so nothing about what the user sees changes.
+// The same is true of the rule that blanked pointer events on the sidebar and
+// on [data-slot="sidebar-inset"], the <main> holding the whole app including
+// the thread: `pointer-events` is inherited too, so that write dirtied the
+// thread's subtree on both flips as well.
+//
+// A single fixed element on top of the viewport does both jobs with an
+// invalidation set of one element. It carries the cursor, and by being the hit
+// test target for the whole viewport it keeps hover and click off the content
+// underneath. It is transparent and it is removed the instant the drag ends, so
+// nothing about what the user sees changes.
 const DRAG_OVERLAY_SLOT = "panel-resize-drag-overlay"
 /** Nested drags cannot happen through pointer capture, but a stuck overlay would
  *  swallow the whole UI, so ownership is explicit rather than assumed. */
@@ -49,10 +57,16 @@ function acquireDragOverlay(): void {
   const s = el.style
   s.position = "fixed"
   s.inset = "0"
-  // Above every app surface. The overlay outlives no frame the user can act in,
-  // and pointer capture means it never receives the drag's own events.
-  s.zIndex = "2147483647"
+  // Top of the named scale, not a hand-picked large number: the rules it
+  // replaces were `!important` and blanked whole subtrees, so anything it did
+  // not out-rank it would only partly stand in for.
+  s.zIndex = String(Z_LAYER.DRAG_CURSOR_OVERLAY)
   s.background = "transparent"
+  // Explicit, because it is load-bearing rather than incidental. Being the hit
+  // test target for the whole viewport is what keeps hover and click off the
+  // content underneath, which is the job `pointer-events: none` on
+  // [data-slot="sidebar-inset"] used to do by dirtying the thread's subtree.
+  s.pointerEvents = "auto"
   // col-resize unconditionally, which is what the replaced rule did even when a
   // collapsed edge was being dragged open.
   s.cursor = "col-resize"

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -1612,15 +1612,6 @@ html[data-chat-font] .aui-root {
 	   the standing DOM; the overlay costs one element. See
 	   components/ui/panel-resize-handle.tsx. */
 
-	html[data-panel-resizing]
-		:is(
-			[data-slot="sidebar-inner"],
-			[data-slot="sidebar-inset"],
-			[data-slot="chat-settings-panel"] > div
-		) {
-		pointer-events: none;
-	}
-
 	/* Model selector: pointer cursor on every clickable element. */
 	.unsloth-model-selector-trigger,
 	.unsloth-model-selector-menu button {

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -1605,13 +1605,12 @@ html[data-chat-font] .aui-root {
 		cursor: pointer;
 	}
 
-	/* While a panel edge is dragged, keep the resize cursor even as the pointer
-	   travels over buttons and text that would claim their own. */
-	html[data-panel-resizing],
-	html[data-panel-resizing] * {
-		cursor: col-resize !important;
-		user-select: none !important;
-	}
+	/* The resize cursor during a drag is owned by the fixed overlay that
+	   PanelResizeHandle mounts for the life of the drag, not by a rule here.
+	   A universal descendant selector on <html> restyles every element in the
+	   document on each of the two attribute flips, which costs in proportion to
+	   the standing DOM; the overlay costs one element. See
+	   components/ui/panel-resize-handle.tsx. */
 
 	html[data-panel-resizing]
 		:is(

--- a/studio/frontend/src/lib/z-layers.ts
+++ b/studio/frontend/src/lib/z-layers.ts
@@ -16,6 +16,7 @@
  *   FLOATING_PANEL_TOP   the one of those the user touched last
  *   STARTUP_SCREEN       blocks the app while the backend comes up or quits
  *   TOOLTIP              transient, must be readable above whatever spawned it
+ *   DRAG_CURSOR_OVERLAY  owns the cursor and the hit test during a panel drag
  *
  * In-page surfaces -- dropdowns, popovers, dialogs, sheets, the sidebar, the
  * Tauri titlebar -- all sit in the 1..120 band on Tailwind's own `z-*` scale
@@ -49,6 +50,17 @@ export const Z_LAYER = {
   STARTUP_SCREEN: 9999,
   /** Tooltips, which have to be legible above whatever spawned them. */
   TOOLTIP: 999999,
+  /**
+   * The transparent sheet PanelResizeHandle mounts for the life of a panel
+   * drag. Top of the scale because it owns two things for the whole viewport
+   * while it exists: the resize cursor, and the hit test. It replaces
+   * `html[data-panel-resizing] *`, which was `!important` and so beat every
+   * surface here, and the `pointer-events: none` rule that used to blank the
+   * sidebar and the main content; being above them is what makes it their
+   * equal rather than a partial stand-in. Transparent, and it exists only
+   * between pointerdown and pointerup, so nothing it covers is hidden.
+   */
+  DRAG_CURSOR_OVERLAY: 1000000,
 } as const;
 
 export type ZLayer = (typeof Z_LAYER)[keyof typeof Z_LAYER];

--- a/studio/frontend/tests/z-layers.test.ts
+++ b/studio/frontend/tests/z-layers.test.ts
@@ -18,6 +18,7 @@ const ORDER = [
   "FLOATING_PANEL_TOP",
   "STARTUP_SCREEN",
   "TOOLTIP",
+  "DRAG_CURSOR_OVERLAY",
 ] as const;
 
 test("the named layers are strictly ordered", () => {


### PR DESCRIPTION
A sidebar resize drag gave the whole viewport the `col-resize` cursor with `html[data-panel-resizing] *`, plus inherited `cursor` and `user-select` writes on `<body>`, plus a `pointer-events: none` rule on the sidebar and on `[data-slot="sidebar-inset"]`. All of them reach every element in the document: the universal selector matches all of them, and `cursor`, `user-select` and `pointer-events` are all inherited, so writing them on `<body>` or on `sidebar-inset`, the `<main>` wrapping the whole app including the chat thread, marks inherited style dirty for everything below. The cost is proportional to the standing DOM rather than to the one thing that changed, and it is paid twice per drag, at pointerdown and at pointerup.

This replaces all of them with one transparent fixed element on top of the viewport, mounted for the life of the drag. It carries the cursor, and by being the hit-test target it keeps hover and click off the content underneath. Its invalidation set is one element.

## The boundary stops scaling with the thread

Production bundles of the same commit differing only in this diff, served from `dist/`, real pointer drags, style recalc `elementCount` from a devtools trace. Element counts are DOM counts, so they are not inflated by the harness.

| document elements | before, per drag boundary | after, per drag boundary |
| ---: | ---: | ---: |
| 3,234 | 3,222 | **13** |
| 78,884 | 78,636 | **14** |
| 297,188 | tracks the document | **13 to 14** |

That is the whole point of the change, and it is a change in what the cost depends on rather than a percentage. Mid-drag frames were already 138 elements in both arms and are unchanged.

## What that fixes

Past roughly 45,000 document elements the drag-end style pass delayed the browser's compatibility click beyond `CLICK_COMPAT_WINDOW_MS = 300`, so `onClick` fired `onToggle()` and **the sidebar collapsed after every resize drag**. Five drags per size, production both arms:

| turns | document elements | before | after |
| ---: | ---: | --- | --- |
| 4 | 3,234 | 0/5, 31 ms | 0/5, 10 ms |
| 190 | 49,322 | 5/5, 361 ms | **0/5, 26 ms** |
| 320 | 78,884 | 5/5, 532 ms | **0/5, 40 ms** |
| 640 | 151,652 | 5/5, 999 ms | **0/5, 60 ms** |
| 1,280 | 297,188 | 5/5, 1,970 ms | **0/5, 139 ms** |

The worst single drag anywhere on this branch is 194 ms against a 300 ms window. **The collapse is gone up to 297,188 elements, which is the largest thread that settles reliably here (1,280 turns, a 72 MB payload).** It is bounded that way deliberately rather than called removed, because the claim is only as wide as the sizes actually tested.

Both crossover figures are machine specific. The 300 ms constant and the linear relationship between standing DOM and the delay are not, but the element count where one crosses the other is. `CLICK_COMPAT_WINDOW_MS` is untouched: raising it would be a constant needing rederivation on every machine and every thread size.

## Hit testing: the deleted rule was the weaker guard

The `pointer-events: none` rule existed to keep pointer and hover events off content underneath during a drag. Two probes establish what actually provides that.

On an ordinary drag, neither the rule nor the overlay is what pins hover: **pointer capture** is. Both arms behave identically and both report zero leaked events, so an ordinary drag cannot tell the two designs apart.

They differ on the one path where capture is released mid-drag. With capture deliberately released, the old build **with the rule in place leaked 85 events into the inset** and `:hover` reached inset content; this build leaked **0**, with everything landing on the overlay. So this is not a like-for-like substitution. It is strictly stronger than the rule it removes.

Those zeroes are only meaningful against a control that can produce non-zeroes, so: with no drag in progress, **202 inset events fire** and a calibrated target button visibly changes background. The instrument is awake.

`document.elementFromPoint` returns the overlay at every tested viewport point mid-drag, nothing beneath receives a click, and a plain drag over message text with no resize in progress still selects normally.

## Controls

A bare `handle.click()` still collapses the sidebar in every cell of both arms, so the detector can see a collapse everywhere it is asked to.

**One honest residual, on the real-click no-move control.** A real `mouse.down()` then `mouse.up()` at identical coordinates should toggle once. The old build double-toggles from 49,322 elements upward; this build fixes that at 49,322, 78,884 and 151,652, and still double-toggles at 297,188. That residual is a different path: with no movement, `pointerup` calls `onToggle()` directly, and at 297,188 the collapse re-render is itself what exceeds 300 ms, not the attribute flip this PR addresses. This branch is strictly better than the old one everywhere on this control, and it does not close that path.

Overlay teardown is checked on both routes that end a drag without a pointerup, `pointercancel` and a genuine mid-drag unmount. Zero overlays remain after every drag in every cell.

## Short threads

Re-established on this source rather than carried forward: 0/5 collapse in both arms at 3,234 elements, and this branch is strictly better than the old one on the count axis there, 13 elements per boundary against 3,222. Not merely flat.

## Rendering is unchanged, measured on these builds

Re-captured on the round-2 bundles rather than carried over from the first round, because the z-index changed and the overlay is now explicitly a hit-test target: whether it is invisible is measured here, not reasoned from the earlier result.

Headed Chromium under Xvfb, the real X11 pointer driven through XTest, frames captured with `ffmpeg -f x11grab -draw_mouse 1` so the composited pointer is in the image rather than inferred from computed style. Screen-to-client calibration was stable at (0, 87) in both arms.

The capture carries its own sensitivity control, which is what makes the result falsifiable: at rest, the same four points paint four **different** real glyphs, an arrow over the thread, a hand over a button, an I-beam over the composer and a hand over the sidebar. The pipeline can therefore tell cursor shapes apart, and "col-resize everywhere mid-drag" could have come out otherwise. It did not. The mid-drag row is the col-resize double arrow at all four points, in both arms.

Composite: `outputs/sty51_fix/cursor/r2_composite_both_arms.png`.

Before, mid and after screenshots are byte-identical across arms in 7 of 9 pairs, including **every** `before` and **every** `mid`, so the overlay is invisible while it is mounted. The two differing `after` pairs, at 190 and 320 turns and 41.7% of pixels, were opened side by side rather than explained away: the difference is that the old build's sidebar has collapsed and this one's has not. That is the bug being visible, not an overlay artefact.

The z-index change is part of the correctness argument rather than tidiness: the overlay now stands in for rules that were `!important`, so which surfaces it out-ranks matters. It moves from a hand-picked 2147483647 onto a named layer at 1,000,000, with nothing in the app at or above it. The two exceptions to that scan are a click-through reload still (`pointer-events: none`, and no drag happens during a reload) and a transient 60x60 opacity-0 scrollbar probe. Neither competes. `src/lib/z-layers.ts` exists to stop exactly the hand-picked number this originally used, so the layer is named, documented and added to the ordering contract its test file asks for.

## A rationale that turned out to be false

The removed `user-select: none` was not what prevented text selection during a drag. `mousedown` never fires during a resize drag on either arm, because the handle already calls `preventDefault()` on `pointerdown`. Selection is unaffected either way, verified on both arms at every size, but the removal is justified by the invalidation cost alone and not by preserving a behaviour it was not providing.

## Provenance

Production bundles both arms, one dist per arm, hashed asset filenames with `hasViteClient=false` and `hasSrcMain=false` asserted on every load, mock payload bytes hashed identical across arms at every size, no git drift in either worktree, trace tripwires 22/22 on all 12 traced drags. `drag.moved` was true on every drag, so no collapse is a plain click wearing a drag's name.

One disclosure about the venue, since it is checkable rather than something you should take on trust. The branch worktree's `git status` went from four modified files to empty partway through, when those files were committed as `2fdda8880` while the painted-frame re-run was still in flight. That is a change of state, not of content: the effective diff against the base is unchanged at 91 insertions and 20 deletions, and the built `dist` tree hashed `997ccea59377cdd4` on every round-2 run, before and after the commit. Every number above came from one byte-identical bundle.
