### PR TITLE
Read quoted annotations in the import lint, and build the video load doubles off the real backend

### DIFF
--- a/scripts/verify_import_hoist.py
+++ b/scripts/verify_import_hoist.py
@@ -118,6 +118,13 @@ def _import_target(node: ast.AST, alias: ast.alias) -> tuple[str, str]:
     return bound, f"from:{mod}:{alias.name}"
 
 
+def _is_literal_ref(node: ast.AST) -> bool:
+    """Whether `node` names `Literal`, however it was imported (`Literal`, `t.Literal`)."""
+    if isinstance(node, ast.Name):
+        return node.id == "Literal"
+    return isinstance(node, ast.Attribute) and node.attr == "Literal"
+
+
 class _Builder(ast.NodeVisitor):
     """Builds the scope tree + bindings, and records every (scope, Name-load)."""
 
@@ -127,14 +134,52 @@ class _Builder(ast.NodeVisitor):
         # annotations: count as "used" but never as "unresolved" (forward refs)
         self.soft_uses: list[tuple[Scope, str, int]] = []
 
-    def _visit_annotation(self, node, scope: Scope) -> None:
+    # How many nested quoted annotations to unwrap: `Optional["Dict[str, 'T']"]` is two, and
+    # nothing real goes deeper. A bound rather than a guess, so a pathological string cannot
+    # recurse without end.
+    _FORWARD_REF_DEPTH = 3
+
+    def _visit_annotation(
+        self,
+        node,
+        scope: Scope,
+        _depth: int = 0,
+        _lineno: int = 0,
+    ) -> None:
         """Record annotation names as SOFT uses: an import used only in an annotation
-        counts as used, but a forward-ref name is never 'unresolved'."""
+        counts as used, but a forward-ref name is never 'unresolved'.
+
+        A QUOTED annotation is an annotation too. `Optional["TePrequantSource"]` keeps the
+        name inside an `ast.Constant`, where a plain Name walk cannot see it, so a
+        `TYPE_CHECKING` import reached only through a forward reference read as unused and
+        was reported as a BLOCKER against correct code (observed on PR #9599's
+        diffusion_hidream.py). The string is parsed and walked as the type it denotes.
+        """
         if node is None:
             return
-        for n in ast.walk(node):
-            if isinstance(n, ast.Name) and isinstance(n.ctx, ast.Load):
-                self.soft_uses.append((scope, n.id, n.lineno))
+        # `Literal["gguf"]` holds VALUES, not type names. Its arguments are skipped so a
+        # literal that happens to spell a valid identifier cannot mark an unrelated import
+        # used -- the one direction where crediting a soft use loses a real finding.
+        if isinstance(node, ast.Subscript) and _is_literal_ref(node.value):
+            self._visit_annotation(node.value, scope, _depth, _lineno)
+            return
+        if isinstance(node, ast.Constant):
+            if not isinstance(node.value, str) or _depth >= self._FORWARD_REF_DEPTH:
+                return
+            try:
+                inner = ast.parse(node.value.strip(), mode = "eval").body
+            except (SyntaxError, ValueError):
+                # Not every string in an annotation is a type: `Annotated[int, "docs"]` and
+                # friends carry prose. Nothing to credit, and nothing to complain about.
+                return
+            # The parsed tree numbers its lines from 1 inside the string, so findings would
+            # point at the wrong place; report against the line the string itself is on.
+            self._visit_annotation(inner, scope, _depth + 1, _lineno or node.lineno)
+            return
+        if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Load):
+            self.soft_uses.append((scope, node.id, _lineno or node.lineno))
+        for child in ast.iter_child_nodes(node):
+            self._visit_annotation(child, scope, _depth, _lineno)
 
     # -- binding helpers --
     def _bind_targets(self, scope: Scope, target: ast.AST) -> None:
@@ -732,6 +777,48 @@ _SELF_TESTS = {
         'from .a import A\nfrom .b import B\n__all__ = ["A"]\n',
         "BLOCKER",
         "pkg/__init__.py",
+    ),
+    # --- quoted annotations are annotations ---
+    # A TYPE_CHECKING import reached only through a forward reference IS used. Reading the
+    # name out of the ast.Constant is the whole point: without it this reported a BLOCKER
+    # against correct code, which is what fired on PR #9599's diffusion_hidream.py.
+    "forward_ref_string_annotation_counts_as_a_use": (
+        "from typing import TYPE_CHECKING, Optional\ndef f(x) -> Optional[int]:\n    return x\n",
+        "from typing import TYPE_CHECKING, Optional\n"
+        "if TYPE_CHECKING:\n"
+        "    from .m import T\n"
+        'def f(x) -> Optional["T"]:\n'
+        "    return x\n",
+        None,
+    ),
+    # `Optional["Dict[str, 'T']"]`: the name is two strings deep, and each layer is parsed.
+    "nested_forward_ref_counts_as_a_use": (
+        "from typing import TYPE_CHECKING, Optional\ndef f(x) -> Optional[int]:\n    return x\n",
+        "from typing import TYPE_CHECKING, Optional\n"
+        "if TYPE_CHECKING:\n"
+        "    from .m import T\n"
+        "def f(x) -> Optional[\"Optional['T']\"]:\n"
+        "    return x\n",
+        None,
+    ),
+    # The other direction, which is what keeps the fix from being a blanket amnesty:
+    # `Literal["T"]` spells a VALUE, so it must NOT credit an import named T.
+    "a_literal_value_is_not_a_use_of_that_name": (
+        "from typing import TYPE_CHECKING, Literal\ndef f(x) -> Literal['a']:\n    return x\n",
+        "from typing import TYPE_CHECKING, Literal\n"
+        "if TYPE_CHECKING:\n"
+        "    from .m import T\n"
+        "def f(x) -> Literal['T']:\n"
+        "    return x\n",
+        "BLOCKER",
+    ),
+    # Prose in an annotation is not a type and must not raise a parse error into a finding.
+    "unparseable_annotation_string_is_ignored": (
+        "from typing import Annotated\ndef f(x: Annotated[int, 'ok']) -> int:\n    return x\n",
+        "from typing import Annotated\n"
+        "def f(x: Annotated[int, 'not a type at all']) -> int:\n"
+        "    return x\n",
+        None,
     ),
 }
 

--- a/scripts/verify_import_hoist.py
+++ b/scripts/verify_import_hoist.py
@@ -134,9 +134,7 @@ class _Builder(ast.NodeVisitor):
         # annotations: count as "used" but never as "unresolved" (forward refs)
         self.soft_uses: list[tuple[Scope, str, int]] = []
 
-    # How many nested quoted annotations to unwrap: `Optional["Dict[str, 'T']"]` is two, and
-    # nothing real goes deeper. A bound rather than a guess, so a pathological string cannot
-    # recurse without end.
+    # `Optional["Dict[str, 'T']"]` is two deep; nothing real goes further.
     _FORWARD_REF_DEPTH = 3
 
     def _visit_annotation(
@@ -149,17 +147,14 @@ class _Builder(ast.NodeVisitor):
         """Record annotation names as SOFT uses: an import used only in an annotation
         counts as used, but a forward-ref name is never 'unresolved'.
 
-        A QUOTED annotation is an annotation too. `Optional["TePrequantSource"]` keeps the
-        name inside an `ast.Constant`, where a plain Name walk cannot see it, so a
-        `TYPE_CHECKING` import reached only through a forward reference read as unused and
-        was reported as a BLOCKER against correct code (observed on PR #9599's
-        diffusion_hidream.py). The string is parsed and walked as the type it denotes.
+        A QUOTED annotation is one too: `Optional["T"]` keeps the name in an ast.Constant,
+        invisible to a Name walk, so a TYPE_CHECKING import reached only that way read as
+        unused and blocked correct code. Parse the string and walk what it denotes.
         """
         if node is None:
             return
-        # `Literal["gguf"]` holds VALUES, not type names. Its arguments are skipped so a
-        # literal that happens to spell a valid identifier cannot mark an unrelated import
-        # used -- the one direction where crediting a soft use loses a real finding.
+        # Literal[...] holds values, not type names. Skipping its args is what keeps this
+        # from crediting an unrelated import, the one direction that loses a real finding.
         if isinstance(node, ast.Subscript) and _is_literal_ref(node.value):
             self._visit_annotation(node.value, scope, _depth, _lineno)
             return
@@ -169,11 +164,8 @@ class _Builder(ast.NodeVisitor):
             try:
                 inner = ast.parse(node.value.strip(), mode = "eval").body
             except (SyntaxError, ValueError):
-                # Not every string in an annotation is a type: `Annotated[int, "docs"]` and
-                # friends carry prose. Nothing to credit, and nothing to complain about.
-                return
-            # The parsed tree numbers its lines from 1 inside the string, so findings would
-            # point at the wrong place; report against the line the string itself is on.
+                return  # Prose, as in Annotated[int, "docs"]. Nothing to credit.
+            # Report against the string's own line; the parsed tree numbers from 1.
             self._visit_annotation(inner, scope, _depth + 1, _lineno or node.lineno)
             return
         if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Load):
@@ -779,9 +771,7 @@ _SELF_TESTS = {
         "pkg/__init__.py",
     ),
     # --- quoted annotations are annotations ---
-    # A TYPE_CHECKING import reached only through a forward reference IS used. Reading the
-    # name out of the ast.Constant is the whole point: without it this reported a BLOCKER
-    # against correct code, which is what fired on PR #9599's diffusion_hidream.py.
+    # A TYPE_CHECKING import reached only through a forward reference IS used.
     "forward_ref_string_annotation_counts_as_a_use": (
         "from typing import TYPE_CHECKING, Optional\ndef f(x) -> Optional[int]:\n    return x\n",
         "from typing import TYPE_CHECKING, Optional\n"
@@ -791,7 +781,7 @@ _SELF_TESTS = {
         "    return x\n",
         None,
     ),
-    # `Optional["Dict[str, 'T']"]`: the name is two strings deep, and each layer is parsed.
+    # Two strings deep; each layer is parsed.
     "nested_forward_ref_counts_as_a_use": (
         "from typing import TYPE_CHECKING, Optional\ndef f(x) -> Optional[int]:\n    return x\n",
         "from typing import TYPE_CHECKING, Optional\n"
@@ -801,8 +791,7 @@ _SELF_TESTS = {
         "    return x\n",
         None,
     ),
-    # The other direction, which is what keeps the fix from being a blanket amnesty:
-    # `Literal["T"]` spells a VALUE, so it must NOT credit an import named T.
+    # The other direction: Literal['T'] is a VALUE, so it must NOT credit an import T.
     "a_literal_value_is_not_a_use_of_that_name": (
         "from typing import TYPE_CHECKING, Literal\ndef f(x) -> Literal['a']:\n    return x\n",
         "from typing import TYPE_CHECKING, Literal\n"
@@ -812,7 +801,7 @@ _SELF_TESTS = {
         "    return x\n",
         "BLOCKER",
     ),
-    # Prose in an annotation is not a type and must not raise a parse error into a finding.
+    # Prose is not a type, and a parse error there is not a finding.
     "unparseable_annotation_string_is_ignored": (
         "from typing import Annotated\ndef f(x: Annotated[int, 'ok']) -> int:\n    return x\n",
         "from typing import Annotated\n"

--- a/studio/backend/tests/test_media_auto_switch.py
+++ b/studio/backend/tests/test_media_auto_switch.py
@@ -35,6 +35,52 @@ from core.inference.openai_auto_download import preferred_quant
 from utils.api_errors import install_api_error_handlers
 
 
+def _a_real_video_family(name = "wan2.2-ti2v-5b"):
+    """A genuine ``VideoFamily`` off the registry, for tests that only need the load route to
+    have something family-shaped to carry.
+
+    A bare ``object()`` or a two-field SimpleNamespace stands in for a frozen dataclass with
+    forty fields, so the first route step to read a field nobody hand-copied fails on an
+    AttributeError that says nothing about what the test was checking. The registry entry
+    always has every field the route can ask for, because it is the thing the route gets.
+    """
+    from core.inference.video_families import detect_video_family
+
+    # Resolved by NAME rather than by repo id: which tokens a repo id matches is its own rule,
+    # tested elsewhere, and not something these tests should be able to break.
+    fam = detect_video_family("", override = name)
+    assert fam is not None, f"the video family registry no longer has {name!r}"
+    return fam
+
+
+def _video_load_backend(**overrides):
+    """A video backend double for the LOAD route, built from the real class.
+
+    A real ``VideoBackend`` with the one or two methods each caller's assertion is about
+    replaced, rather than a class re-declaring that surface by hand: every OTHER call the
+    route makes then runs the real implementation, which for the load route's preflight and
+    reservation helpers is pure resolution over the family registry -- no hub, no GPU, no
+    weights. ``__init__`` allocates locks and empty state and touches nothing else.
+
+    A hand-rolled stub has to be extended by hand every time the route grows a call, and
+    until someone does, unrelated tests fail on a missing attribute rather than on what they
+    assert. That is exactly how PR #9599's reservation preflight turned these two red.
+
+    ``overrides`` are checked against the real class, so a stub for a method that does not
+    exist (a typo, or one that has since been renamed) fails loudly here instead of quietly
+    never being called.
+    """
+    from core.inference.video import VideoBackend
+
+    unknown = sorted(name for name in overrides if not hasattr(VideoBackend, name))
+    assert not unknown, f"not part of the video backend's surface: {unknown}"
+
+    backend = VideoBackend()
+    for name, impl in overrides.items():
+        setattr(backend, name, impl)
+    return backend
+
+
 def _info(
     model_id,
     path,
@@ -1134,20 +1180,49 @@ def test_a_local_video_pipeline_is_still_planned(h3_modular, enabled, backend, l
     assert loads == []
 
 
+def test_every_backend_call_the_video_route_makes_exists_on_the_backend():
+    """``backend.<name>`` in routes/video.py must name something ``VideoBackend`` has.
+
+    The route reaches the backend through ``get_video_backend()``, which is untyped at the
+    call site, so a method renamed on the class or misspelled in the route is not a syntax
+    error, not a lint finding, and not visible to any test whose double happens to stub the
+    old name. It is an AttributeError on a real load, and the route's own tests mock the
+    backend out, so nothing here would have caught it.
+
+    Read out of the parse tree rather than the text: the rule is which names the route asks
+    the backend for, not how they are spelled across lines.
+    """
+    import ast
+    import inspect
+
+    import routes.video as video_route
+    from core.inference.video import VideoBackend
+
+    tree = ast.parse(inspect.getsource(video_route))
+    asked = {
+        node.attr
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Attribute)
+        and isinstance(node.value, ast.Name)
+        and node.value.id == "backend"
+        and isinstance(node.ctx, ast.Load)
+    }
+    assert asked, "no backend calls found -- the route was restructured, so this guard is blind"
+    missing = sorted(name for name in asked if not hasattr(VideoBackend, name))
+    assert not missing, f"routes/video.py calls backend methods that do not exist: {missing}"
+
+
 def test_the_video_load_route_records_provenance_without_raising(monkeypatch):
     # The provenance call is made positionally from both load routes, so a signature that drifts
     # from them 500s every load after the background work has already been accepted.
     import core.inference.video as video_module
     from routes.video import router as video_router
 
-    class _Backend:
-        def validate_load_request(self, *a, **k):
-            return object()
-
-        def begin_load(self, *a, **k):
-            return {"loaded": False, "repo_id": None}
-
-    monkeypatch.setattr(video_module, "get_video_backend", lambda: _Backend())
+    backend = _video_load_backend(
+        validate_load_request = lambda *a, **k: _a_real_video_family(),
+        begin_load = lambda *a, **k: {"loaded": False, "repo_id": None},
+    )
+    monkeypatch.setattr(video_module, "get_video_backend", lambda: backend)
     monkeypatch.setattr(video_module, "resolve_video_model_kind", lambda *a, **k: "gguf")
     monkeypatch.setattr(video_module, "assert_video_precision_available", lambda *a, **k: None)
     monkeypatch.setattr("routes.video._guard_video_load_against_training", lambda: None)
@@ -2436,22 +2511,29 @@ def _capture_begin_load(monkeypatch, route):
     """Record the local_files_only begin_load is called with, for either media route."""
     seen: list = []
 
-    class _Backend:
-        def validate_load_request(self, *a, **k):
-            return types.SimpleNamespace(name = "z-image", base_repo = None)
-
-        def begin_load(self, *a, **k):
-            seen.append(k.get("local_files_only"))
-            return {"loaded": False, "repo_id": None}
+    def _begin_load(*a, **k):
+        seen.append(k.get("local_files_only"))
+        return {"loaded": False, "repo_id": None}
 
     if route == "images":
         import core.inference.diffusion_engine_router as router_module
+
+        class _Backend:
+            def validate_load_request(self, *a, **k):
+                return types.SimpleNamespace(name = "z-image", base_repo = None)
+
+            begin_load = staticmethod(_begin_load)
+
         monkeypatch.setattr(router_module, "select_and_activate_engine", lambda *a, **k: _Backend())
         monkeypatch.setattr(router_module, "get_active_diffusion_engine", lambda: _Backend())
     else:
         import core.inference.video as video_module
 
-        monkeypatch.setattr(video_module, "get_video_backend", lambda: _Backend())
+        backend = _video_load_backend(
+            validate_load_request = lambda *a, **k: _a_real_video_family(),
+            begin_load = _begin_load,
+        )
+        monkeypatch.setattr(video_module, "get_video_backend", lambda: backend)
         monkeypatch.setattr(video_module, "resolve_video_model_kind", lambda *a, **k: "gguf")
         monkeypatch.setattr(video_module, "assert_video_precision_available", lambda *a, **k: None)
         monkeypatch.setattr("routes.video._guard_video_load_against_training", lambda: None)

--- a/studio/backend/tests/test_media_auto_switch.py
+++ b/studio/backend/tests/test_media_auto_switch.py
@@ -36,39 +36,30 @@ from utils.api_errors import install_api_error_handlers
 
 
 def _a_real_video_family(name = "wan2.2-ti2v-5b"):
-    """A genuine ``VideoFamily`` off the registry, for tests that only need the load route to
-    have something family-shaped to carry.
+    """A real ``VideoFamily``, for tests that just need the route to carry one.
 
-    A bare ``object()`` or a two-field SimpleNamespace stands in for a frozen dataclass with
-    forty fields, so the first route step to read a field nobody hand-copied fails on an
-    AttributeError that says nothing about what the test was checking. The registry entry
-    always has every field the route can ask for, because it is the thing the route gets.
+    A bare ``object()`` stands in for a forty-field frozen dataclass, so the first field
+    nobody hand-copied fails the test on an AttributeError about nothing it asserts.
     """
     from core.inference.video_families import detect_video_family
 
-    # Resolved by NAME rather than by repo id: which tokens a repo id matches is its own rule,
-    # tested elsewhere, and not something these tests should be able to break.
+    # By name, not repo id: which tokens a repo id matches is its own rule, tested elsewhere.
     fam = detect_video_family("", override = name)
     assert fam is not None, f"the video family registry no longer has {name!r}"
     return fam
 
 
 def _video_load_backend(**overrides):
-    """A video backend double for the LOAD route, built from the real class.
+    """A real ``VideoBackend`` with only the asserted methods replaced.
 
-    A real ``VideoBackend`` with the one or two methods each caller's assertion is about
-    replaced, rather than a class re-declaring that surface by hand: every OTHER call the
-    route makes then runs the real implementation, which for the load route's preflight and
-    reservation helpers is pure resolution over the family registry -- no hub, no GPU, no
-    weights. ``__init__`` allocates locks and empty state and touches nothing else.
+    Every other call the route makes runs the real implementation, which for the load
+    route's preflight and reservation helpers is pure registry resolution: no hub, no GPU,
+    no weights, and ``__init__`` only allocates locks. A hand-rolled stub instead needs
+    extending every time the route grows a call, and until it is, unrelated tests fail on a
+    missing attribute rather than on what they assert.
 
-    A hand-rolled stub has to be extended by hand every time the route grows a call, and
-    until someone does, unrelated tests fail on a missing attribute rather than on what they
-    assert. That is exactly how PR #9599's reservation preflight turned these two red.
-
-    ``overrides`` are checked against the real class, so a stub for a method that does not
-    exist (a typo, or one that has since been renamed) fails loudly here instead of quietly
-    never being called.
+    ``overrides`` are checked against the class, so a stub for a method that does not exist
+    fails loudly instead of quietly never being called.
     """
     from core.inference.video import VideoBackend
 
@@ -1183,14 +1174,10 @@ def test_a_local_video_pipeline_is_still_planned(h3_modular, enabled, backend, l
 def test_every_backend_call_the_video_route_makes_exists_on_the_backend():
     """``backend.<name>`` in routes/video.py must name something ``VideoBackend`` has.
 
-    The route reaches the backend through ``get_video_backend()``, which is untyped at the
-    call site, so a method renamed on the class or misspelled in the route is not a syntax
-    error, not a lint finding, and not visible to any test whose double happens to stub the
-    old name. It is an AttributeError on a real load, and the route's own tests mock the
-    backend out, so nothing here would have caught it.
-
-    Read out of the parse tree rather than the text: the rule is which names the route asks
-    the backend for, not how they are spelled across lines.
+    ``get_video_backend()`` is untyped at the call site, so a method renamed on the class or
+    misspelled in the route is no syntax error, no lint finding, and invisible to any double
+    stubbing the old name. It is an AttributeError on a real load, and the route's own tests
+    mock the backend out. Read off the parse tree, not the text.
     """
     import ast
     import inspect


### PR DESCRIPTION
Two CI safety nets that fail on correct code. Both turned up while working out why the backend leg was red across the currently open PRs.

## `verify_import_hoist.py` cannot see a quoted forward reference

The annotation walk looked for `ast.Name` only. A quoted forward reference keeps the name inside an `ast.Constant`, so in

```python
if TYPE_CHECKING:
    from .diffusion_te_prequant import TePrequantSource

def hidream_te4_prequant_source(...) -> Optional["TePrequantSource"]:
```

the `TYPE_CHECKING` import read as unused and was reported as:

```
[BLOCKER] HOISTED-IMPORT-UNUSED 'TePrequantSource' (['from:.diffusion_te_prequant:TePrequantSource'])
          added but unused -> un-normalized alias or wrong rename target?
```

That is a lint failure nobody can clear without deleting an import the file needs. It fired twice on #9599 alone (`TePrequantSource`, and `InferenceLoadReservation` in `routes/inference.py`), and it will fire on any PR that adds a `TYPE_CHECKING` import used through a quoted annotation.

Annotation strings are now parsed and walked as the type they denote, to a depth of three so `Optional["Dict[str, 'T']"]` resolves and a pathological string cannot recurse without end.

`Literal[...]` arguments are deliberately skipped. Those are values, not type names. Crediting a soft use is the one direction that can lose a real finding, so a literal that happens to spell an identifier must not mark an import used. Four self-tests cover both directions, plus an annotation string that is prose rather than a type.

Verified: re-running the fixed lint over #9599's 79 changed Python files drops both false positives and still blocks on the one real finding there (an `UNRESOLVED-NEW 'fp8_engages'`). No new findings across the last six merges to main.

## The video load route's test doubles are narrower than the route

Two tests in `test_media_auto_switch.py` stand up a hand-rolled backend. One returned a bare `object()` where the route gets a forty-field frozen `VideoFamily`, and neither declared more than two methods. So the first route step to reach for anything else fails on an `AttributeError` that says nothing about what the test was checking:

```
routes/video.py:284: in load_video_model_gated
    load_reservation.add(resolve_video_base_repo(fam, request.base_repo))
E   AttributeError: 'object' object has no attribute 'base_repo'
E   AttributeError: '_Backend' object has no attribute 'preflight_load_repositories'
```

Those two tests are about provenance and about the `local_files_only` the loader is handed. They should stay about that, and they should not have to be edited every time the route grows a call.

They now take a real `VideoBackend` with only the asserted methods replaced. `__init__` allocates locks and empty state, and the load route's preflight and reservation helpers are pure resolution over the family registry, so nothing here reaches the hub, a GPU or any weights. Overrides are checked against the real class, so a stub for a method that does not exist fails loudly instead of quietly never being called, and the family comes from the registry rather than being hand-copied.

## And the direction a double cannot cover

Added `test_every_backend_call_the_video_route_makes_exists_on_the_backend`: every `backend.<name>` in `routes/video.py` must name something `VideoBackend` actually has.

That call site is untyped, so a method renamed on the class or misspelled in the route is not a syntax error, not a lint finding, and not visible to any test whose double happens to stub the old name. It is an `AttributeError` on a real load, and the route's own tests mock the backend out, so nothing would have caught it. Read off the parse tree rather than the text, so a set literal reflowed by the formatter is not a change to it.

Mutation-checked by renaming `backend.begin_load` to `backend.begin_lodd` in the route; the guard fails as intended.

## Testing

- `scripts/verify_import_hoist.py --self-test`: all pass, including the four new cases and every pre-existing one.
- Full backend suite on this tree: 29469 passed, 121 skipped, 0 failed.
- The two reworked tests pass both on main and against #9599's head, which is the point. They absorb the route's new backend calls without pre-committing to them.
