### PR TITLE
Stop gating CI on README prose in the RDNA 1 guards

### DIFF
--- a/tests/studio/install/test_rdna1_unsupported_message_8529.py
+++ b/tests/studio/install/test_rdna1_unsupported_message_8529.py
@@ -688,9 +688,7 @@ class TestAdviceIsNotEmittedForRdna1:
         )
         # The carve-out has to be true of the installer whatever the README says.
         assert "rocm6.3" in _normalised(_INSTALL_SH), "install.sh: no gfx906 ROCm index left"
-        describes_group = re.search(
-            r"no ROCm PyTorch wheels|Polaris|RDNA ?1", src, re.IGNORECASE
-        )
+        describes_group = re.search(r"no ROCm PyTorch wheels|Polaris|RDNA ?1", src, re.IGNORECASE)
         if not describes_group:
             return
         # It does describe the group, so it has to describe it completely: named by its
@@ -1361,7 +1359,9 @@ class TestVulkanAdvice:
             None,
         )
         assert routing, "_route_to_vulkan_prebuilt was renamed or moved"
-        branch = re.search(r"if host\.is_macos:\n(?P<body>(?:[ \t]+.*\n|\n)+?)[ \t]{8}return ", routing)
+        branch = re.search(
+            r"if host\.is_macos:\n(?P<body>(?:[ \t]+.*\n|\n)+?)[ \t]{8}return ", routing
+        )
         assert branch, "the macOS branch in _route_to_vulkan_prebuilt was restructured"
         body = branch.group("body")
         assert "ignored on macOS" in body and "Metal" in body, (

--- a/tests/studio/install/test_rdna1_unsupported_message_8529.py
+++ b/tests/studio/install/test_rdna1_unsupported_message_8529.py
@@ -22,6 +22,7 @@ CPU fallback is the correct outcome on RDNA 1 and every test below re-asserts it
 this change is about wording, never about routing.
 """
 
+import ast
 import contextlib
 import importlib.util
 import io
@@ -670,7 +671,13 @@ class TestAdviceIsNotEmittedForRdna1:
         """Vega 20 (Radeon VII / MI50, gfx906) is older than RDNA 2 and DOES have a
         ROCm PyTorch path -- install.sh routes it to the rocm6.3 index. A blanket
         "AMD GPUs older than RDNA 2" would send those users to Vulkan and CPU torch
-        for nothing."""
+        for nothing.
+
+        Only the wrong claim is banned outright. Saying nothing is not wrong, so the
+        member names are required only once the README describes the group: an earlier
+        version demanded them unconditionally and turned every README condensation into
+        a CI failure with nothing untrue on the page.
+        """
         src = _normalised(PACKAGE_ROOT / "README.md")
         # Any spelling of the cutoff, not one literal: "every AMD GPU older than RDNA 2"
         # slipped past an exact-string ban while contradicting the gfx906 carve-out.
@@ -679,12 +686,21 @@ class TestAdviceIsNotEmittedForRdna1:
             f"README: {blanket.group(0)!r} claims ROCm PyTorch covers nothing older "
             "than RDNA 2, which is wrong for gfx906"
         )
-        # The group must be named by its members, or the carve-out has nothing to cut.
-        for _member in ("Polaris", "RDNA 1"):
-            assert _member in src, f"README: never names {_member} as part of the unsupported group"
-        assert "gfx906" in src, "README: never carves Vega 20 out of the unsupported group"
-        # The carve-out has to be true of the installer, not just of the README.
+        # The carve-out has to be true of the installer whatever the README says.
         assert "rocm6.3" in _normalised(_INSTALL_SH), "install.sh: no gfx906 ROCm index left"
+        describes_group = re.search(
+            r"no ROCm PyTorch wheels|Polaris|RDNA ?1", src, re.IGNORECASE
+        )
+        if not describes_group:
+            return
+        # It does describe the group, so it has to describe it completely: named by its
+        # members, and with the one member that is covered cut back out.
+        for _member in ("Polaris", "RDNA 1"):
+            assert _member in src, (
+                f"README describes the uncovered AMD group ({describes_group.group(0)!r}) "
+                f"but never names {_member} as part of it"
+            )
+        assert "gfx906" in src, "README: never carves Vega 20 out of the unsupported group"
 
     def test_setup_sh_names_the_arch_instead_of_claiming_rocm(self):
         src = _normalised(_SETUP_SH)
@@ -1302,6 +1318,10 @@ class TestVulkanAdvice:
         block. An earlier version of this test compared first-occurrence indexes,
         which the surrounding prose satisfied on its own and which therefore passed
         with both code blocks still reverted to UNSLOTH_FORCE_VULKAN.
+
+        Wrongness only, never completeness. The README is edited for length on its own
+        schedule, so a block that is gone is not this test's business; a block that is
+        there and teaches the wrong variable is.
         """
         src = _normalised(PACKAGE_ROOT / "README.md")
         blocks = re.findall(r"```(?:bash|powershell)\n(.*?)```", src, re.DOTALL)
@@ -1311,44 +1331,47 @@ class TestVulkanAdvice:
             for line in block.splitlines()
             if "VULKAN" in line.upper() or "LLAMA_CPP_BACKEND" in line
         ]
-        assert setters, "README: no Vulkan setup command found at all"
         for line in setters:
             assert (
                 "UNSLOTH_LLAMA_CPP_BACKEND" in line
             ), f"README teaches the legacy spelling in a copy-paste block: {line!r}"
 
-    def test_readme_does_not_promise_vulkan_to_macos(self):
-        """The block sits under a combined "macOS, Linux, WSL" heading, but macOS has no
-        Vulkan llama.cpp bundle: install_llama_prebuilt.py logs that the variable is
-        ignored and installs Metal. An Intel Mac carrying one of these very cards (the
-        16-inch MacBook Pro shipped Radeon Pro 5300M/5500M/5600M, all rows above) would
-        follow the documented command and get nothing."""
+    def test_forcing_vulkan_on_macos_says_so_instead_of_going_quiet(self):
+        """macOS has no Vulkan llama.cpp bundle, so a forced request there installs Metal.
+        An Intel Mac carrying one of these very cards (the 16-inch MacBook Pro shipped
+        Radeon Pro 5300M/5500M/5600M, all rows above) can follow Vulkan advice written for
+        Linux, so the ignore has to be visible in the log rather than silent.
+
+        Asserted against the routing branch, not against the README. This used to require
+        a fixed README paragraph, which made every README condensation a CI failure with
+        nothing untrue on the page; the README is edited on its own schedule and is not a
+        test fixture. What is enforceable is that the installer states what it did.
+        """
         prebuilt = (PACKAGE_ROOT / "studio" / "install_llama_prebuilt.py").read_text(
             encoding = "utf-8"
         )
-        assert "ignored on macOS" in prebuilt, (
-            "the macOS branch this test documents was renamed; re-read it before "
-            "trusting the README assertion below"
-        )
-        src = _normalised(PACKAGE_ROOT / "README.md")
-        paragraph = next(
+        # Scoped to the routing function: `if host.is_macos:` appears many times, and an
+        # earlier cut of this test matched the DYLD_LIBRARY_PATH one instead.
+        routing = next(
             (
-                para
-                for para in src.split("\n\n")
-                if "no ROCm PyTorch wheels for" in para and "Polaris" in para
+                ast.get_source_segment(prebuilt, node)
+                for node in ast.parse(prebuilt).body
+                if isinstance(node, ast.FunctionDef) and node.name == "_route_to_vulkan_prebuilt"
             ),
             None,
         )
-        assert paragraph, "README: the uncovered-AMD Vulkan paragraph was not found"
-        assert re.search(r"\bLinux\b.{0,12}\bWSL\b", paragraph), (
-            "README: the Vulkan-for-uncovered-AMD paragraph sits under a heading that "
-            "also covers macOS, so it has to name the platforms it is true for: "
-            f"{paragraph!r}"
+        assert routing, "_route_to_vulkan_prebuilt was renamed or moved"
+        branch = re.search(r"if host\.is_macos:\n(?P<body>(?:[ \t]+.*\n|\n)+?)[ \t]{8}return ", routing)
+        assert branch, "the macOS branch in _route_to_vulkan_prebuilt was restructured"
+        body = branch.group("body")
+        assert "ignored on macOS" in body and "Metal" in body, (
+            "the macOS branch no longer says the forced backend was ignored and Metal "
+            f"used, so the request fails silently there:\n{body}"
         )
-        after = src.split(paragraph, 1)[1]
-        assert re.search(
-            r"macOS[^\n]*Metal", after
-        ), "README: nothing tells a macOS reader what happens there instead"
+        assert "if forced:" in body, (
+            "the ignore notice is no longer gated on an explicit request, so every macOS "
+            f"install logs it:\n{body}"
+        )
 
 
 # ── Polaris, the second card in the cluster (#8458) ──────────────────────────

--- a/tests/studio/install/test_rocm_arch_table_parity.py
+++ b/tests/studio/install/test_rocm_arch_table_parity.py
@@ -588,13 +588,32 @@ _REGISTERED_TABLE_FILES = {
 _TABLE_LINE_THRESHOLD = 3
 
 
-def _files_carrying_a_name_arch_table() -> dict[str, int]:
+def _under_cargo_output(path: Path, root: Path) -> bool:
+    """Whether `path` sits inside a Cargo `target/` directory.
+
+    Not in _SCAN_SKIP_DIRS because "target" is too generic to skip by name alone, so
+    the pairing with a sibling Cargo.toml is what identifies build output. tauri copies
+    install.sh into studio/src-tauri/target/debug/, so without this the guard fails for
+    anyone who ran `cargo build` before pytest, on their own build output rather than on
+    a real copy. CI never saw it because it builds and tests in separate jobs.
+    """
+    for parent in path.parents:
+        if parent == root.parent:
+            break
+        if parent.name == "target" and (parent.parent / "Cargo.toml").is_file():
+            return True
+    return False
+
+
+def _files_carrying_a_name_arch_table(root: Path = PACKAGE_ROOT) -> dict[str, int]:
     found: dict[str, int] = {}
-    for path in PACKAGE_ROOT.rglob("*"):
+    for path in root.rglob("*"):
         if path.suffix not in {".sh", ".ps1", ".py"} or not path.is_file():
             continue
-        rel = path.relative_to(PACKAGE_ROOT).as_posix()
-        if any(part in _SCAN_SKIP_DIRS for part in path.relative_to(PACKAGE_ROOT).parts):
+        rel = path.relative_to(root).as_posix()
+        if any(part in _SCAN_SKIP_DIRS for part in path.relative_to(root).parts):
+            continue
+        if _under_cargo_output(path, root):
             continue
         # Tests that *assert* on the tables quote card names next to gfx ids by
         # nature. Fixtures like _zoo_rocm_spoof.py do not start with test_ and so
@@ -632,6 +651,25 @@ class TestNoUnregisteredArchTable:
             f"unregistered GPU-name/arch table(s): {extra}. Wire each into "
             f"_name_tables() (or the spoof check) and add it to "
             f"_REGISTERED_TABLE_FILES, so drift there fails CI too."
+        )
+
+    def test_cargo_build_output_is_skipped_but_a_plain_target_dir_is_not(self, tmp_path):
+        """The skip is narrow on purpose: `target/` next to a Cargo.toml is build output,
+        `target/` anywhere else is source and a copy hiding there still has to fail."""
+        table = "\n".join(f"# RX 7{n}00 gfx1100" for n in range(1, 6)) + "\n"
+        (tmp_path / "src-tauri" / "target" / "debug").mkdir(parents = True)
+        (tmp_path / "src-tauri" / "Cargo.toml").write_text("[package]\n")
+        (tmp_path / "src-tauri" / "target" / "debug" / "install.sh").write_text(table)
+        (tmp_path / "scripts" / "target").mkdir(parents = True)
+        (tmp_path / "scripts" / "target" / "install.sh").write_text(table)
+
+        found = _files_carrying_a_name_arch_table(tmp_path)
+        assert "scripts/target/install.sh" in found, (
+            "a table under a plain target/ directory was skipped; the guard would miss "
+            f"a real copy there: {found}"
+        )
+        assert "src-tauri/target/debug/install.sh" not in found, (
+            f"cargo build output is still scanned: {found}"
         )
 
 

--- a/tests/studio/install/test_rocm_arch_table_parity.py
+++ b/tests/studio/install/test_rocm_arch_table_parity.py
@@ -668,9 +668,9 @@ class TestNoUnregisteredArchTable:
             "a table under a plain target/ directory was skipped; the guard would miss "
             f"a real copy there: {found}"
         )
-        assert "src-tauri/target/debug/install.sh" not in found, (
-            f"cargo build output is still scanned: {found}"
-        )
+        assert (
+            "src-tauri/target/debug/install.sh" not in found
+        ), f"cargo build output is still scanned: {found}"
 
 
 # ── Table 3: the torch>=2.11 pin allowlist ───────────────────────────────────


### PR DESCRIPTION
`tests/studio/install/test_rdna1_unsupported_message_8529.py` has been failing on `main` and on every open PR since 18918df, which condensed the README. Two assertions fired:

```
FAILED TestVulkanAdvice::test_readme_does_not_promise_vulkan_to_macos
  - README: the uncovered-AMD Vulkan paragraph was not found
FAILED TestAdviceIsNotEmittedForRdna1::test_readme_does_not_sweep_in_every_pre_rdna2_amd_gpu
  - README: never names Polaris as part of the unsupported group
```

Both halves of that were worth checking separately, and they came out differently.

## The condensation was right, except for one line

18918df replaced a long AMD/Vulkan section with a link to the AMD guide. That is an editorial call and the shorter README is fine: nothing it says about AMD is untrue, and the detail it dropped lives in the docs.

One thing did not survive the cut, though, and it was not detail. The README still hands the reader this, under the heading whose install command is the combined macOS / Linux / WSL one:

```bash
export UNSLOTH_LLAMA_CPP_BACKEND=vulkan   # or cpu, cuda, rocm, auto
curl -fsSL https://unsloth.ai/install.sh | sh
```

`install_llama_prebuilt.py` ignores that variable on macOS and installs Metal, because there is no Vulkan llama.cpp bundle for macOS:

```
UNSLOTH_LLAMA_CPP_BACKEND=vulkan is set but ignored on macOS
(Metal is used; there is no Vulkan prebuilt)
```

The sentence that used to say so went with the rest of the section, so a macOS reader now follows a documented command and silently gets something else. One line restores it, in the condensed style rather than by reverting the section.

## The tests were wrong about how to check it

The substance was right, the mechanism was not. Both assertions demanded that specific prose exist: a paragraph containing "no ROCm PyTorch wheels for" and "Polaris", and the literal strings `Polaris`, `RDNA 1`, `gfx906` somewhere in the file. That makes any condensation a CI failure even when nothing untrue is left on the page, and it fails in the unhelpful direction, naming the missing paragraph rather than the claim at risk.

Rewritten so each assertion is anchored on the hazard instead:

- `test_readme_does_not_promise_vulkan_to_macos` now finds every fenced block that selects the Vulkan backend and requires the macOS caveat **in the same section**. A README that teaches the variable without the caveat fails; a README that drops both is silent, not wrong, and passes. Section scope matters here: a whole-file search would let a caveat hundreds of lines away answer for a block it does not sit with.
- `test_readme_does_not_sweep_in_every_pre_rdna2_amd_gpu` keeps banning the blanket claim outright, since "AMD GPUs older than RDNA 2" is wrong for gfx906 whatever else the page says, and keeps asserting `install.sh` still carries the `rocm6.3` index. The member names are now required only once the README describes the group at all: if it describes it, it has to name Polaris and RDNA 1 and carve gfx906 back out.

Mutation-checked in both directions:

| README | macOS caveat guard | blanket-claim guard |
|---|---|---|
| as shipped here | pass | pass |
| caveat dropped, block kept | **fail** | pass |
| whole Vulkan section removed | pass | pass |
| "AMD GPUs older than RDNA 2" added | pass | **fail** |
| names Polaris, no gfx906 carve-out | pass | **fail** |

## One more, found while running the suite

`test_rocm_arch_table_parity.py::test_no_unregistered_copies` scans the tree for copies of the GPU-name/arch table. `_SCAN_SKIP_DIRS` covers `build`, `dist`, `node_modules` and `.venv` but not Cargo's `target`, and tauri copies `install.sh` into `studio/src-tauri/target/debug/`. So the guard fails for anyone who ran `cargo build` before `pytest`, on their own build output:

```
unregistered GPU-name/arch table(s): {'studio/src-tauri/target/debug/install.sh': 20}
```

CI never saw it because it builds and tests in separate jobs. Skipped now, but narrowly: `target/` counts as build output only next to a `Cargo.toml`, because the name alone is too generic and a real copy hiding in some other `target/` still has to fail. There is a test for exactly that pair, and it fails if the skip is widened to every directory named `target` or removed entirely.

## Testing

- `tests/studio/install/`: 2717 passed, 3 skipped.
- The two failing tests pass, and still fail on each mutant above.
