### PR TITLE
Studio: avoid duplicate llama-server option families

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -61,6 +61,8 @@ from core.inference.context_window import (
 )
 from core.inference.stream_errors import stream_error_from_chunk
 from core.inference.llama_server_args import (
+    _CACHE_TYPE_K_FLAGS,
+    _CACHE_TYPE_V_FLAGS,
     _DEVICE_FLAGS,
     _GPU_LAYER_FLAGS,
     _LAYER_OFFLOAD_FLAGS,
@@ -19219,16 +19221,20 @@ class LlamaCppBackend:
                 # takes a value -- older builds take -fa as a bare boolean and
                 # read a following "on" as a stray positional.
                 if _caps.get("supports_flash_attn", True):
-                    cmd.append("--flash-attn")
-                    if _caps.get("flash_attn_takes_value", True):
-                        cmd.append("on")
+                    if not _extra_args_set_any_flag(extra_args, {"-fa", "--flash-attn"}):
+                        cmd.append("--flash-attn")
+                        if _caps.get("flash_attn_takes_value", True):
+                            cmd.append("on")
                 else:
                     # Only ever reached on an authoritative --help that has no
                     # flash attention to lose, so there is no speed to give up.
                     _flash_attn_known_off = True
                 # Error out at n_ctx instead of silently rotating the KV cache; frontend catches it and points the user at "Context Length".
                 if _caps.get("supports_no_context_shift", True):
-                    cmd.append("--no-context-shift")
+                    if not _extra_args_set_any_flag(
+                        extra_args, {"--context-shift", "--no-context-shift"}
+                    ):
+                        cmd.append("--no-context-shift")
                 # A positive context is always passed (in auto-fit, --fit then
                 # optimizes the gpu-layer offload around it). When auto-fit has
                 # no explicit context, omit -c so --fit sizes it to fit VRAM:
@@ -19393,7 +19399,8 @@ class LlamaCppBackend:
                 # Expose Prometheus /metrics for the engine-stats logger, only
                 # when the binary advertises it (older/custom binaries may not).
                 if server_caps.get("supports_metrics"):
-                    cmd.append("--metrics")
+                    if not _extra_args_set_any_flag(extra_args, {"--metrics", "--no-metrics"}):
+                        cmd.append("--metrics")
                 self._slot_save_dir = None
                 self._slot_save_binary = None
                 self._prompt_cache_disabled = False
@@ -19459,7 +19466,8 @@ class LlamaCppBackend:
 
                 # Enable Jinja chat template rendering
                 if _caps.get("supports_jinja", True):
-                    cmd.extend(["--jinja"])
+                    if not _extra_args_set_any_flag(extra_args, {"--jinja", "--no-jinja"}):
+                        cmd.extend(["--jinja"])
 
                 # KV cache data type
                 _valid_cache_types = _VALID_CACHE_TYPES
@@ -19473,14 +19481,10 @@ class LlamaCppBackend:
                     and cache_type_kv in _valid_cache_types
                     and not _cache_type_from_env
                 ):
-                    cmd.extend(
-                        [
-                            "--cache-type-k",
-                            cache_type_kv,
-                            "--cache-type-v",
-                            cache_type_kv,
-                        ]
-                    )
+                    if not _extra_args_set_any_flag(extra_args, _CACHE_TYPE_K_FLAGS):
+                        cmd.extend(["--cache-type-k", cache_type_kv])
+                    if not _extra_args_set_any_flag(extra_args, _CACHE_TYPE_V_FLAGS):
+                        cmd.extend(["--cache-type-v", cache_type_kv])
                     self._cache_type_kv = cache_type_kv
                     logger.info(f"KV cache type: {cache_type_kv}")
                 else:

--- a/studio/backend/tests/test_health_answers_within_probe_budget.py
+++ b/studio/backend/tests/test_health_answers_within_probe_budget.py
@@ -560,9 +560,9 @@ def test_a_cold_health_call_answers_inside_the_launcher_deadline():
     probe_timeout = _desktop_probe_timeout_s()
     result = _probe(_SLOW_DETECT_S)
 
-    assert result["cold_hardware_detecting"] is True, (
-        "the cold call got a settled reply, so it never exercised the wait this bound is about"
-    )
+    assert (
+        result["cold_hardware_detecting"] is True
+    ), "the cold call got a settled reply, so it never exercised the wait this bound is about"
     assert result["cold_elapsed"] < probe_timeout, (
         f"the first /api/health call took {result['cold_elapsed']:.2f}s, past the "
         f"{probe_timeout}s the desktop probe allows before it gives up and dead-ends "

--- a/studio/backend/tests/test_llama_extra_args_end_to_end.py
+++ b/studio/backend/tests/test_llama_extra_args_end_to_end.py
@@ -100,6 +100,87 @@ def test_a_multi_token_value_stays_one_argv_entry(tmp_path):
 
 
 @pytest.mark.parametrize(
+    "extra_args,family",
+    [
+        pytest.param(["--cache-type-k", "q4_0"], {"-ctk", "--cache-type-k"}, id = "cache-k"),
+        pytest.param(["-ctk", "q4_0"], {"-ctk", "--cache-type-k"}, id = "cache-k-short"),
+        pytest.param(["--cache-type-v", "q4_0"], {"-ctv", "--cache-type-v"}, id = "cache-v"),
+        pytest.param(["-ctv", "q4_0"], {"-ctv", "--cache-type-v"}, id = "cache-v-short"),
+        pytest.param(["--flash-attn", "off"], {"-fa", "--flash-attn"}, id = "flash-off"),
+        pytest.param(["-fa", "off"], {"-fa", "--flash-attn"}, id = "flash-short"),
+        pytest.param(
+            ["--context-shift"],
+            {"--context-shift", "--no-context-shift"},
+            id = "context-shift",
+        ),
+        pytest.param(
+            ["--no-context-shift"],
+            {"--context-shift", "--no-context-shift"},
+            id = "no-context-shift",
+        ),
+        pytest.param(["--jinja"], {"--jinja", "--no-jinja"}, id = "jinja"),
+        pytest.param(["--no-jinja"], {"--jinja", "--no-jinja"}, id = "no-jinja"),
+    ],
+)
+def test_an_explicit_semantic_override_suppresses_the_automatic_atom(tmp_path, extra_args, family):
+    cmd = _cmd(tmp_path, cache_type_kv = "q8_0", extra_args = extra_args)
+
+    assert cmd[-len(extra_args) :] == extra_args
+    assert family.isdisjoint(cmd[: -len(extra_args)])
+
+
+@pytest.mark.parametrize("extra_arg", ["--metrics", "--no-metrics"])
+def test_a_supported_metrics_override_suppresses_the_automatic_flag(tmp_path, extra_arg):
+    backend, gguf = _backend(tmp_path, vulkan = False, memory = [(0, 20_000, 24_000)])
+    caps = backend.probe_server_capabilities()
+    caps["supports_metrics"] = True
+    backend.probe_server_capabilities = lambda _binary = None: caps
+
+    cmd = _launch(backend, gguf, extra_args = [extra_arg])["cmd"]
+
+    assert cmd[-1] == extra_arg
+    assert not {"--metrics", "--no-metrics"}.intersection(cmd[:-1])
+
+
+@pytest.mark.parametrize(
+    "extra_args,other_axis",
+    [
+        pytest.param(["-ctk", "q4_0"], "--cache-type-v", id = "k-keeps-v"),
+        pytest.param(["-ctv", "q4_0"], "--cache-type-k", id = "v-keeps-k"),
+    ],
+)
+def test_cache_axis_overrides_are_independent(tmp_path, extra_args, other_axis):
+    cmd = _cmd(tmp_path, cache_type_kv = "q8_0", extra_args = extra_args)
+
+    assert other_axis in cmd[: -len(extra_args)]
+    assert cmd[-len(extra_args) :] == extra_args
+
+
+def test_a_supported_flash_override_is_not_treated_as_a_missing_flag(tmp_path):
+    extra_args = ["-fa", "on"]
+    cmd = _cmd(tmp_path, cache_type_kv = "q8_0", extra_args = extra_args)
+
+    cache_v = cmd.index("--cache-type-v")
+    assert cmd[cache_v + 1] == "q8_0"
+    assert cmd[-len(extra_args) :] == extra_args
+
+
+def test_unknown_and_repeated_extra_args_remain_verbatim_and_last(tmp_path):
+    extra_args = [
+        "--future-flag",
+        "alpha",
+        "--metrics",
+        "--future-flag",
+        "omega",
+        "--no-metrics",
+    ]
+    cmd = _cmd(tmp_path, extra_args = extra_args)
+
+    assert cmd[-len(extra_args) :] == extra_args
+    assert not {"--metrics", "--no-metrics"}.intersection(cmd[: -len(extra_args)])
+
+
+@pytest.mark.parametrize(
     "denied",
     [
         ["--agent"],


### PR DESCRIPTION
## Summary

- skip Studio-generated llama-server options when `extra_args` already owns the same semantic option family
- handle K/V cache overrides independently and preserve user-supplied arguments verbatim
- cover positive/negative aliases, divergent values, repeated unknown arguments, and Flash Attention capability accounting

## Motivation

Studio currently appends explicit `extra_args` after its generated arguments. When both contain the same option family, llama.cpp accepts the last value but emits duplicate-option deprecation warnings. Omitting only the equivalent generated option preserves explicit-user precedence without relying on that deprecated behavior.

## Testing

- rebased on current `main` (`55213845e`) after reproducing the duplicate families there
- 781 targeted and adjacent test executions passed (754 distinct tests)
- the metrics regression guard explicitly enables server metrics capability and covers both `--metrics` and `--no-metrics`
- Ruff 0.15.12, Python compilation, and `git diff --check` passed
- differential regression check fails on the exact parent and passes with this change
- isolated Qwen3.8 runtime validation passed through the raw API, DeepSeek Harness, and Hermes, including real tool calls; controlled option families appeared only once in the llama-server command