### PR TITLE
CI: install frontend dependencies for overlay rail smoke

### DIFF
--- a/.github/workflows/studio-ui-smoke.yml
+++ b/.github/workflows/studio-ui-smoke.yml
@@ -605,6 +605,11 @@ jobs:
       # does not. Serves its own vite rather than the Studio above it, so it needs no
       # BASE_URL and does not care what state that Studio is in; it is here only because
       # WebKit's install is already paid for on this shard.
+      - name: Install frontend dependencies for the overlay rail smoke
+        if: matrix.shard == 'banner'
+        working-directory: studio/frontend
+        run: npm ci --ignore-scripts --no-fund --no-audit
+
       - name: Overlay rail shadow gutter, other engines (Playwright)
         if: matrix.shard == 'banner'
         env:


### PR DESCRIPTION
## Summary

- Install the locked frontend dependencies before the self-hosted overlay rail smoke.
- Limit the install to the `banner` shard and disable dependency lifecycle scripts.

## Motivation

The smoke added by #9246 starts `npm run dev`, but the normal Studio installation removes `studio/frontend/node_modules` after building. A clean runner therefore reaches the smoke without Vite and exits with `sh: 1: vite: not found` before Firefox or WebKit is exercised.

## Tests

- `npm ci --ignore-scripts --no-fund --no-audit`
- `npm run dev -- --version` (`vite/8.0.16`)
- `playwright_overlay_rail.py` with Firefox
- `playwright_overlay_rail.py` with WebKit
- 136 targeted workflow, shard, and trigger tests