### PR TITLE
Studio: let workers spawn the killable Hugging Face prefetch child

### DIFF
--- a/studio/backend/tests/test_process_lifetime.py
+++ b/studio/backend/tests/test_process_lifetime.py
@@ -521,10 +521,8 @@ def test_allow_child_processes_survives_a_missing_config(monkeypatch):
 def test_an_older_process_lifetime_still_gets_the_parent_death_binding(monkeypatch):
     """A tree without `allow_child_processes` must keep the binding that predates it.
 
-    `allow_child_processes` is newer than `bind_current_process_to_parent_lifetime`.
-    Importing both in one statement would make an older process_lifetime.py raise
-    ImportError for the whole block, so a worker would lose the parent-death
-    binding as well -- turning a missing download fix into leaked workers.
+    Importing both names in one statement would raise ImportError for the whole
+    block, costing the worker its parent-death binding as well.
     """
     from utils import native_path_leases
 

--- a/studio/backend/tests/test_process_lifetime.py
+++ b/studio/backend/tests/test_process_lifetime.py
@@ -483,6 +483,12 @@ def _run_nested_child_arm(tmp_path, arm: str) -> tuple[str, bool]:
     return proc.stdout, marker.exists()
 
 
+@pytest.mark.skipif(
+    not __debug__,
+    reason = "CPython's daemonic-children guard is an assert, so -O strips it and a "
+             "daemonic worker spawns freely -- this arm would assert the opposite of "
+             "what it means",
+)
 def test_daemonic_worker_cannot_spawn_children_without_the_shim(tmp_path):
     stdout, grandchild_ran = _run_nested_child_arm(tmp_path, "plain")
     assert "refused AssertionError: daemonic processes are not allowed to have children" in stdout
@@ -510,3 +516,24 @@ def test_allow_child_processes_clears_only_the_daemon_bit(monkeypatch):
 def test_allow_child_processes_survives_a_missing_config(monkeypatch):
     monkeypatch.setattr(multiprocessing.process, "current_process", lambda: type("P", (), {})())
     pl.allow_child_processes()
+
+
+def test_an_older_process_lifetime_still_gets_the_parent_death_binding(monkeypatch):
+    """A tree without `allow_child_processes` must keep the binding that predates it.
+
+    `allow_child_processes` is newer than `bind_current_process_to_parent_lifetime`.
+    Importing both in one statement would make an older process_lifetime.py raise
+    ImportError for the whole block, so a worker would lose the parent-death
+    binding as well -- turning a missing download fix into leaked workers.
+    """
+    from utils import native_path_leases
+
+    calls = []
+    monkeypatch.setattr(
+        pl, "bind_current_process_to_parent_lifetime", lambda: calls.append("bind")
+    )
+    monkeypatch.delattr(pl, "allow_child_processes")
+
+    native_path_leases.run_without_native_path_secret(lambda: None)
+
+    assert calls == ["bind"]

--- a/studio/backend/tests/test_process_lifetime.py
+++ b/studio/backend/tests/test_process_lifetime.py
@@ -486,8 +486,8 @@ def _run_nested_child_arm(tmp_path, arm: str) -> tuple[str, bool]:
 @pytest.mark.skipif(
     not __debug__,
     reason = "CPython's daemonic-children guard is an assert, so -O strips it and a "
-             "daemonic worker spawns freely -- this arm would assert the opposite of "
-             "what it means",
+    "daemonic worker spawns freely -- this arm would assert the opposite of "
+    "what it means",
 )
 def test_daemonic_worker_cannot_spawn_children_without_the_shim(tmp_path):
     stdout, grandchild_ran = _run_nested_child_arm(tmp_path, "plain")
@@ -529,9 +529,7 @@ def test_an_older_process_lifetime_still_gets_the_parent_death_binding(monkeypat
     from utils import native_path_leases
 
     calls = []
-    monkeypatch.setattr(
-        pl, "bind_current_process_to_parent_lifetime", lambda: calls.append("bind")
-    )
+    monkeypatch.setattr(pl, "bind_current_process_to_parent_lifetime", lambda: calls.append("bind"))
     monkeypatch.delattr(pl, "allow_child_processes")
 
     native_path_leases.run_without_native_path_secret(lambda: None)

--- a/studio/backend/tests/test_process_lifetime.py
+++ b/studio/backend/tests/test_process_lifetime.py
@@ -427,7 +427,7 @@ def test_windows_job_install_degrades_on_assign_failure(monkeypatch):
 # Daemonic workers spawning children (#9094)
 
 
-_NESTED_CHILD_SCRIPT = '''
+_NESTED_CHILD_SCRIPT = """
 import multiprocessing as mp
 import sys
 
@@ -466,7 +466,7 @@ if __name__ == "__main__":
     print("parent-sees-daemon", worker.daemon, flush = True)
     print("worker", queue.get(timeout = 60), flush = True)
     worker.join(30)
-'''
+"""
 
 
 def _run_nested_child_arm(tmp_path, arm: str) -> tuple[str, bool]:
@@ -508,7 +508,5 @@ def test_allow_child_processes_clears_only_the_daemon_bit(monkeypatch):
 
 
 def test_allow_child_processes_survives_a_missing_config(monkeypatch):
-    monkeypatch.setattr(
-        multiprocessing.process, "current_process", lambda: type("P", (), {})()
-    )
+    monkeypatch.setattr(multiprocessing.process, "current_process", lambda: type("P", (), {})())
     pl.allow_child_processes()

--- a/studio/backend/tests/test_process_lifetime.py
+++ b/studio/backend/tests/test_process_lifetime.py
@@ -9,6 +9,7 @@ Windows Job Object path is exercised with a mocked kernel32 so it runs on CI.
 
 from __future__ import annotations
 
+import multiprocessing.process
 import os
 import signal
 import subprocess
@@ -421,3 +422,93 @@ def test_windows_job_install_degrades_on_assign_failure(monkeypatch):
     pl._install_windows_job()
     assert pl._win_job_handle is None  # not retained when assignment fails
     assert "close" in log  # the orphaned job handle is closed
+
+
+# Daemonic workers spawning children (#9094)
+
+
+_NESTED_CHILD_SCRIPT = '''
+import multiprocessing as mp
+import sys
+
+sys.path.insert(0, {backend!r})
+
+CTX = mp.get_context("spawn")
+
+
+def _grandchild(marker):
+    with open(marker, "w") as handle:
+        handle.write("ran")
+
+
+def _worker(queue, marker):
+    try:
+        proc = CTX.Process(target = _grandchild, args = (marker,), daemon = True)
+        proc.start()
+        proc.join(30)
+        queue.put("started exit={{}}".format(proc.exitcode))
+    except Exception as exc:
+        queue.put("refused {{}}: {{}}".format(type(exc).__name__, exc))
+
+
+def _no_shim(target, *args, **kwargs):
+    return target(*args, **kwargs)
+
+
+if __name__ == "__main__":
+    from utils.native_path_leases import run_without_native_path_secret
+
+    arm, marker = sys.argv[1], sys.argv[2]
+    entry = run_without_native_path_secret if arm == "shim" else _no_shim
+    queue = CTX.Queue()
+    worker = CTX.Process(target = entry, args = (_worker, queue, marker), daemon = True)
+    worker.start()
+    print("parent-sees-daemon", worker.daemon, flush = True)
+    print("worker", queue.get(timeout = 60), flush = True)
+    worker.join(30)
+'''
+
+
+def _run_nested_child_arm(tmp_path, arm: str) -> tuple[str, bool]:
+    script = tmp_path / f"nested_{arm}.py"
+    script.write_text(_NESTED_CHILD_SCRIPT.format(backend = str(_BACKEND)))
+    marker = tmp_path / f"grandchild_{arm}.txt"
+    proc = subprocess.run(
+        [sys.executable, str(script), arm, str(marker)],
+        capture_output = True,
+        text = True,
+        timeout = 180,
+    )
+    assert proc.returncode == 0, proc.stderr
+    return proc.stdout, marker.exists()
+
+
+def test_daemonic_worker_cannot_spawn_children_without_the_shim(tmp_path):
+    stdout, grandchild_ran = _run_nested_child_arm(tmp_path, "plain")
+    assert "refused AssertionError: daemonic processes are not allowed to have children" in stdout
+    assert not grandchild_ran
+
+
+def test_daemonic_worker_spawns_children_through_the_shim(tmp_path):
+    stdout, grandchild_ran = _run_nested_child_arm(tmp_path, "shim")
+    assert "worker started exit=0" in stdout
+    assert grandchild_ran
+    # The parent still sees the worker as daemonic.
+    assert "parent-sees-daemon True" in stdout
+
+
+def test_allow_child_processes_clears_only_the_daemon_bit(monkeypatch):
+    # Do not mutate the pytest process's real multiprocessing config.
+    config = {"daemon": True, "authkey": b"secret", "semprefix": "/mp"}
+    monkeypatch.setattr(
+        multiprocessing.process, "current_process", lambda: type("P", (), {"_config": config})()
+    )
+    pl.allow_child_processes()
+    assert config == {"daemon": False, "authkey": b"secret", "semprefix": "/mp"}
+
+
+def test_allow_child_processes_survives_a_missing_config(monkeypatch):
+    monkeypatch.setattr(
+        multiprocessing.process, "current_process", lambda: type("P", (), {})()
+    )
+    pl.allow_child_processes()

--- a/studio/backend/utils/native_path_leases.py
+++ b/studio/backend/utils/native_path_leases.py
@@ -122,13 +122,19 @@ def run_without_native_path_secret(
     # Runs in the spawned child: bind it to the parent's death (Linux), since
     # multiprocessing children cannot be given a preexec_fn by the parent. Shared
     # entrypoint for the inference/export/training/data-recipe workers.
+    # Imported and called separately, not as one try block: allow_child_processes
+    # is newer than bind_current_process_to_parent_lifetime, so a tree carrying an
+    # older process_lifetime.py would raise ImportError on the combined import and
+    # silently lose the parent-death binding too -- trading an orphaned download
+    # for orphaned workers.
     try:
-        from utils.process_lifetime import (
-            allow_child_processes,
-            bind_current_process_to_parent_lifetime,
-        )
+        from utils.process_lifetime import bind_current_process_to_parent_lifetime
         bind_current_process_to_parent_lifetime()
+    except Exception:
+        pass
+    try:
         # Clear the worker's daemon policy so HF prefetch can spawn (#9094).
+        from utils.process_lifetime import allow_child_processes
         allow_child_processes()
     except Exception:
         pass

--- a/studio/backend/utils/native_path_leases.py
+++ b/studio/backend/utils/native_path_leases.py
@@ -123,8 +123,13 @@ def run_without_native_path_secret(
     # multiprocessing children cannot be given a preexec_fn by the parent. Shared
     # entrypoint for the inference/export/training/data-recipe workers.
     try:
-        from utils.process_lifetime import bind_current_process_to_parent_lifetime
+        from utils.process_lifetime import (
+            allow_child_processes,
+            bind_current_process_to_parent_lifetime,
+        )
         bind_current_process_to_parent_lifetime()
+        # Clear the worker's daemon policy so HF prefetch can spawn (#9094).
+        allow_child_processes()
     except Exception:
         pass
 

--- a/studio/backend/utils/native_path_leases.py
+++ b/studio/backend/utils/native_path_leases.py
@@ -122,11 +122,8 @@ def run_without_native_path_secret(
     # Runs in the spawned child: bind it to the parent's death (Linux), since
     # multiprocessing children cannot be given a preexec_fn by the parent. Shared
     # entrypoint for the inference/export/training/data-recipe workers.
-    # Imported and called separately, not as one try block: allow_child_processes
-    # is newer than bind_current_process_to_parent_lifetime, so a tree carrying an
-    # older process_lifetime.py would raise ImportError on the combined import and
-    # silently lose the parent-death binding too -- trading an orphaned download
-    # for orphaned workers.
+    # Two try blocks, not one: allow_child_processes is the newer name, so on an
+    # older process_lifetime.py a combined import would lose the binding as well.
     try:
         from utils.process_lifetime import bind_current_process_to_parent_lifetime
         bind_current_process_to_parent_lifetime()

--- a/studio/backend/utils/process_lifetime.py
+++ b/studio/backend/utils/process_lifetime.py
@@ -335,21 +335,13 @@ def bind_current_process_to_parent_lifetime() -> None:
 
 
 def allow_child_processes() -> None:
-    """Allow the current multiprocessing worker to spawn children.
+    """Allow the current multiprocessing worker to spawn children (#9094).
 
-    CPython refuses to let a daemonic process start one (process.py: `assert not
-    _current_process._config.get('daemon')`), which left the killable Hugging
-    Face prefetch child unstartable inside a worker (#9094).
-
-    Anything this worker spawns afterwards INHERITS the cleared flag, because
-    `Process.__init__` copies `_config`. A grandchild that does not pass
-    `daemon =` itself is therefore non-daemonic, and multiprocessing's
-    `_exit_function` `join()`s non-daemonic children unconditionally and without
-    a timeout -- it only `terminate()`s daemonic ones. Such a grandchild holds
-    the worker's exit open forever. Everything reachable from a worker today
-    passes `daemon = True` explicitly (the HF prefetch child does, and it is
-    `adopt_pid`-ed so the macOS sweep and the Windows job still cover it); keep
-    it that way.
+    Children inherit the cleared flag, since `Process.__init__` copies `_config`.
+    A grandchild that does not pass `daemon =` itself is therefore non-daemonic,
+    and `_exit_function` joins those unconditionally and without a timeout, so it
+    would hold the worker's exit open forever. Everything a worker reaches today
+    passes `daemon = True`; keep it that way.
     """
     try:
         from multiprocessing import process as multiprocessing_process

--- a/studio/backend/utils/process_lifetime.py
+++ b/studio/backend/utils/process_lifetime.py
@@ -335,7 +335,22 @@ def bind_current_process_to_parent_lifetime() -> None:
 
 
 def allow_child_processes() -> None:
-    """Allow the current multiprocessing worker to spawn children."""
+    """Allow the current multiprocessing worker to spawn children.
+
+    CPython refuses to let a daemonic process start one (process.py: `assert not
+    _current_process._config.get('daemon')`), which left the killable Hugging
+    Face prefetch child unstartable inside a worker (#9094).
+
+    Anything this worker spawns afterwards INHERITS the cleared flag, because
+    `Process.__init__` copies `_config`. A grandchild that does not pass
+    `daemon =` itself is therefore non-daemonic, and multiprocessing's
+    `_exit_function` `join()`s non-daemonic children unconditionally and without
+    a timeout -- it only `terminate()`s daemonic ones. Such a grandchild holds
+    the worker's exit open forever. Everything reachable from a worker today
+    passes `daemon = True` explicitly (the HF prefetch child does, and it is
+    `adopt_pid`-ed so the macOS sweep and the Windows job still cover it); keep
+    it that way.
+    """
     try:
         from multiprocessing import process as multiprocessing_process
 

--- a/studio/backend/utils/process_lifetime.py
+++ b/studio/backend/utils/process_lifetime.py
@@ -334,6 +334,19 @@ def bind_current_process_to_parent_lifetime() -> None:
         pass
 
 
+def allow_child_processes() -> None:
+    """Allow the current multiprocessing worker to spawn children."""
+    try:
+        from multiprocessing import process as multiprocessing_process
+
+        # This config is child-local; the parent's Process handle stays daemonic.
+        config = getattr(multiprocessing_process.current_process(), "_config", None)
+        if isinstance(config, dict):
+            config["daemon"] = False
+    except Exception:
+        pass
+
+
 def compose_preexec(
     existing: Optional[Callable[[], None]], owner_pid: Optional[int] = None
 ) -> Optional[Callable[[], None]]:


### PR DESCRIPTION
Addresses #9094.

## Problem

Studio starts its inference, training, export, and data-recipe workers with `daemon = True`. CPython therefore prevented those workers from starting the killable child used by `maybe_prefetch_hf_snapshot`:

```
AssertionError: daemonic processes are not allowed to have children
```

Every affected model load skipped the protected Hugging Face prefetch path, including its stall detection, Xet-to-HTTP fallback, and partial-download cleanup, then continued with an in-process download.

## Fix

The shared worker entrypoint, `run_without_native_path_secret`, now clears the daemon policy from the worker's own multiprocessing config after binding the worker to its parent lifetime.

The parent's `Process` handle remains daemonic, so its existing worker cleanup behavior is unchanged. The Linux parent-death signal, Windows Job Object, and macOS startup sweep are also unchanged. The Hugging Face download child remains daemonic and bound to the worker's lifetime.

## Verification

Live A/B through `POST /api/inference/load` on Linux with the same model and a fresh Hugging Face cache entry:

| | Before | After |
|---|---:|---:|
| Daemon assertion in the log | 1 | 0 |
| Prefetch children observed | 0 | 4 |
| Load result | 200 in 31.8s | 200 in 35.7s |

Killing the backend after loading the model left no worker behind.

`test_process_lifetime.py` adds a regression test covering both the rejected daemon-worker topology and the fixed shared-entrypoint path. The focused lifetime, Hugging Face fallback/cache, orchestrator teardown, worker crash, scoped download, training spawn, and refactor-guard suites pass.

## Scope

This fixes the daemon assertion only. It does not add retries for the reported `httpx.RemoteProtocolError` or change the UI's cached-versus-downloading status, so #9094 should remain open for those symptoms.
