### PR TITLE
Studio: save a streaming chat turn while it runs, not just at its start and end

### DIFF
--- a/studio/frontend/src/features/chat/runtime-provider.tsx
+++ b/studio/frontend/src/features/chat/runtime-provider.tsx
@@ -2598,10 +2598,9 @@ function ThreadBackendAutosave({
     [reportAutosaveError, saveThread],
   );
 
-  // runEnd rides a subscription bound to whichever thread is main, so a thread that stops
-  // being main mid-run never gets its own runEnd and would otherwise checkpoint for the
-  // life of the page. CancelRegistrar above solves the same problem the same way: ask the
-  // runtime whether the run is still going rather than trusting the event.
+  // runEnd only reaches whichever thread is main, so a thread that stops being main
+  // mid-run never gets its own and would checkpoint for the life of the page. Ask the
+  // runtime instead of trusting the event, as CancelRegistrar above already does.
   const isRunActive = useCallback(
     (threadId: string): boolean => {
       const runtime = aui.threads().__internal_getAssistantRuntime?.();
@@ -2638,11 +2637,10 @@ function ThreadBackendAutosave({
   }, []);
 
   useEffect(() => {
-    // The interval is quiet time between saves, and a hidden renderer may not get one:
-    // Chromium throttles chained timers to a wake a minute, and a WebView can be parked
-    // outright. Checkpoint on the way out instead. beforeunload is deliberately not used
-    // here, matching flushSettingsOnPageHidden: it does not fire on every platform, and a
-    // Tauri quit never fires it at all.
+    // A hidden renderer may never get its next interval: Chromium throttles chained timers
+    // to a wake a minute and a WebView can be parked outright, so checkpoint on the way
+    // out. No beforeunload, matching flushSettingsOnPageHidden: it does not fire on every
+    // platform and a Tauri quit never fires it at all.
     const flush = () => {
       checkpointsRef.current?.flushAll();
     };

--- a/studio/frontend/src/features/chat/runtime-provider.tsx
+++ b/studio/frontend/src/features/chat/runtime-provider.tsx
@@ -2598,22 +2598,64 @@ function ThreadBackendAutosave({
     [reportAutosaveError, saveThread],
   );
 
-  // Keep one scheduler for the component lifetime so its timers remain stoppable. The ref
-  // gives it the latest queueSave when dependencies change.
+  // runEnd rides a subscription bound to whichever thread is main, so a thread that stops
+  // being main mid-run never gets its own runEnd and would otherwise checkpoint for the
+  // life of the page. CancelRegistrar above solves the same problem the same way: ask the
+  // runtime whether the run is still going rather than trusting the event.
+  const isRunActive = useCallback(
+    (threadId: string): boolean => {
+      const runtime = aui.threads().__internal_getAssistantRuntime?.();
+      if (!runtime) {
+        return false;
+      }
+      try {
+        return runtime.threads.getById(threadId).getState().isRunning === true;
+      } catch {
+        // A deleted or detached thread throws out of getById rather than reporting idle.
+        return false;
+      }
+    },
+    [aui],
+  );
+
+  // Keep one scheduler for the component lifetime so its timers remain stoppable. The refs
+  // give it the latest queueSave and liveness check when dependencies change.
   const queueSaveRef = useRef(queueSave);
   useEffect(() => {
     queueSaveRef.current = queueSave;
   }, [queueSave]);
+  const isRunActiveRef = useRef(isRunActive);
+  useEffect(() => {
+    isRunActiveRef.current = isRunActive;
+  }, [isRunActive]);
   const checkpointsRef = useRef<RunCheckpointScheduler | null>(null);
   const checkpoints = useCallback((): RunCheckpointScheduler => {
-    checkpointsRef.current ??= createRunCheckpointScheduler((threadId) =>
-      queueSaveRef.current(threadId),
+    checkpointsRef.current ??= createRunCheckpointScheduler(
+      (threadId) => queueSaveRef.current(threadId),
+      { isActive: (threadId) => isRunActiveRef.current(threadId) },
     );
     return checkpointsRef.current;
   }, []);
 
   useEffect(() => {
+    // The interval is quiet time between saves, and a hidden renderer may not get one:
+    // Chromium throttles chained timers to a wake a minute, and a WebView can be parked
+    // outright. Checkpoint on the way out instead. beforeunload is deliberately not used
+    // here, matching flushSettingsOnPageHidden: it does not fire on every platform, and a
+    // Tauri quit never fires it at all.
+    const flush = () => {
+      checkpointsRef.current?.flushAll();
+    };
+    const onVisibilityChange = () => {
+      if (document.visibilityState === "hidden") {
+        flush();
+      }
+    };
+    window.addEventListener("pagehide", flush);
+    document.addEventListener("visibilitychange", onVisibilityChange);
     return () => {
+      window.removeEventListener("pagehide", flush);
+      document.removeEventListener("visibilitychange", onVisibilityChange);
       checkpointsRef.current?.stopAll();
     };
   }, []);

--- a/studio/frontend/src/features/chat/runtime-provider.tsx
+++ b/studio/frontend/src/features/chat/runtime-provider.tsx
@@ -130,6 +130,10 @@ import {
   refreshContextUsage,
   setActiveBranchReader,
 } from "./utils/refresh-context-usage";
+import {
+  type RunCheckpointScheduler,
+  createRunCheckpointScheduler,
+} from "./utils/run-checkpoint-scheduler";
 import { isAssistantLocalThreadId } from "./utils/thread-ids";
 import { sanitizeThreadScopedSettings } from "./utils/thread-scoped-settings";
 import { VideoAttachmentAdapter } from "./video-attachment-adapter";
@@ -2561,15 +2565,18 @@ function ThreadBackendAutosave({
     [aui, modelType, newThreadSwitchStateRef, pairId],
   );
 
+  // Let checkpoints schedule their next timer after this write settles.
   const queueSave = useCallback(
-    (threadId: string): void => {
-      saveChainRef.current = saveChainRef.current
+    (threadId: string): Promise<void> => {
+      const queued = saveChainRef.current
         .catch(() => {})
         .then(async () => {
           await pendingFirstSavesRef.current.get(threadId);
           await saveThread(threadId);
         })
         .catch(reportAutosaveError);
+      saveChainRef.current = queued;
+      return queued;
     },
     [reportAutosaveError, saveThread],
   );
@@ -2591,11 +2598,33 @@ function ThreadBackendAutosave({
     [reportAutosaveError, saveThread],
   );
 
+  // Keep one scheduler for the component lifetime so its timers remain stoppable. The ref
+  // gives it the latest queueSave when dependencies change.
+  const queueSaveRef = useRef(queueSave);
+  useEffect(() => {
+    queueSaveRef.current = queueSave;
+  }, [queueSave]);
+  const checkpointsRef = useRef<RunCheckpointScheduler | null>(null);
+  const checkpoints = useCallback((): RunCheckpointScheduler => {
+    checkpointsRef.current ??= createRunCheckpointScheduler((threadId) =>
+      queueSaveRef.current(threadId),
+    );
+    return checkpointsRef.current;
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      checkpointsRef.current?.stopAll();
+    };
+  }, []);
+
   useAuiEvent("thread.runEnd", ({ threadId }) => {
+    checkpoints().stop(threadId);
     queueSave(threadId);
   });
 
   useAuiEvent("thread.runStart", ({ threadId }) => {
+    checkpoints().start(threadId);
     const runtime = aui.threads().__internal_getAssistantRuntime?.();
     const { remoteId } =
       runtime?.threads.getItemById(threadId).getState() ?? {};

--- a/studio/frontend/src/features/chat/utils/run-checkpoint-scheduler.ts
+++ b/studio/frontend/src/features/chat/utils/run-checkpoint-scheduler.ts
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+/** Periodically persists partial thread state between runStart and runEnd. */
+
+/** Quiet time after a checkpoint settles before the next one is taken. */
+export const RUN_CHECKPOINT_INTERVAL_MS = 8_000;
+
+/** Injectable so a test can drive the schedule without real time passing. */
+export type RunCheckpointTimers = {
+  setTimeout: (callback: () => void, ms: number) => number;
+  clearTimeout: (handle: number) => void;
+};
+
+export type RunCheckpointScheduler = {
+  /** Begin checkpointing a thread. A second call for a thread already running is a no-op. */
+  start: (threadId: string) => void;
+  /** Stop checkpointing a thread and drop any pending timer. */
+  stop: (threadId: string) => void;
+  /** Stop every thread, for unmount. */
+  stopAll: () => void;
+};
+
+type ThreadState = {
+  handle: number | null;
+  stopped: boolean;
+};
+
+const defaultTimers: RunCheckpointTimers = {
+  setTimeout: (callback, ms) => window.setTimeout(callback, ms),
+  clearTimeout: (handle) => {
+    window.clearTimeout(handle);
+  },
+};
+
+export function createRunCheckpointScheduler(
+  save: (threadId: string) => Promise<unknown>,
+  options: {
+    intervalMs?: number;
+    timers?: RunCheckpointTimers;
+  } = {},
+): RunCheckpointScheduler {
+  const intervalMs = options.intervalMs ?? RUN_CHECKPOINT_INTERVAL_MS;
+  const timers = options.timers ?? defaultTimers;
+  const threads = new Map<string, ThreadState>();
+
+  const schedule = (threadId: string, state: ThreadState): void => {
+    state.handle = timers.setTimeout(() => {
+      state.handle = null;
+      if (state.stopped) {
+        return;
+      }
+      // Retry after transient failures rather than disabling later checkpoints.
+      const reschedule = () => {
+        if (!state.stopped) {
+          schedule(threadId, state);
+        }
+      };
+      save(threadId).then(reschedule, reschedule);
+    }, intervalMs);
+  };
+
+  const stop = (threadId: string): void => {
+    const state = threads.get(threadId);
+    if (!state) {
+      return;
+    }
+    // Also stops an in-flight checkpoint from rescheduling when it settles.
+    state.stopped = true;
+    if (state.handle !== null) {
+      timers.clearTimeout(state.handle);
+      state.handle = null;
+    }
+    threads.delete(threadId);
+  };
+
+  return {
+    start(threadId) {
+      // Repeated runStart events for one thread must not stack timers.
+      if (threads.has(threadId)) {
+        return;
+      }
+      const state: ThreadState = { handle: null, stopped: false };
+      threads.set(threadId, state);
+      schedule(threadId, state);
+    },
+    stop,
+    stopAll() {
+      for (const threadId of [...threads.keys()]) {
+        stop(threadId);
+      }
+    },
+  };
+}

--- a/studio/frontend/src/features/chat/utils/run-checkpoint-scheduler.ts
+++ b/studio/frontend/src/features/chat/utils/run-checkpoint-scheduler.ts
@@ -46,11 +46,9 @@ export function createRunCheckpointScheduler(
     intervalMs?: number;
     timers?: RunCheckpointTimers;
     /**
-     * Whether the run this thread is being checkpointed for is still going. runEnd is the
-     * fast path out, but it is delivered on a subscription bound to whichever thread is
-     * currently main, so a thread that stops being main mid-run never receives its own
-     * runEnd. Without a second opinion that thread would checkpoint for the life of the
-     * page. Omit it and the scheduler behaves exactly as if every thread were active.
+     * Whether the thread's run is still going. runEnd is the fast path out, but it only
+     * reaches whichever thread is main, so one that stops being main mid-run would
+     * checkpoint for the life of the page. Omit it to treat every thread as active.
      */
     isActive?: (threadId: string) => boolean;
   } = {},
@@ -91,8 +89,7 @@ export function createRunCheckpointScheduler(
         }
       };
       if (!isRunning(threadId)) {
-        // The run ended without a runEnd we could hear. That lost the final save too, so
-        // take one here before letting the thread go.
+        // A missed runEnd also lost the final save, so take one on the way out.
         stop(threadId);
         void runSave(threadId).then(noop, noop);
         return;

--- a/studio/frontend/src/features/chat/utils/run-checkpoint-scheduler.ts
+++ b/studio/frontend/src/features/chat/utils/run-checkpoint-scheduler.ts
@@ -19,12 +19,19 @@ export type RunCheckpointScheduler = {
   stop: (threadId: string) => void;
   /** Stop every thread, for unmount. */
   stopAll: () => void;
+  /**
+   * Checkpoint every live thread right now, leaving the schedule untouched. For the page
+   * transitions that precede a renderer going away or being throttled.
+   */
+  flushAll: () => void;
 };
 
 type ThreadState = {
   handle: number | null;
   stopped: boolean;
 };
+
+const noop = (): void => {};
 
 const defaultTimers: RunCheckpointTimers = {
   setTimeout: (callback, ms) => window.setTimeout(callback, ms),
@@ -38,11 +45,38 @@ export function createRunCheckpointScheduler(
   options: {
     intervalMs?: number;
     timers?: RunCheckpointTimers;
+    /**
+     * Whether the run this thread is being checkpointed for is still going. runEnd is the
+     * fast path out, but it is delivered on a subscription bound to whichever thread is
+     * currently main, so a thread that stops being main mid-run never receives its own
+     * runEnd. Without a second opinion that thread would checkpoint for the life of the
+     * page. Omit it and the scheduler behaves exactly as if every thread were active.
+     */
+    isActive?: (threadId: string) => boolean;
   } = {},
 ): RunCheckpointScheduler {
   const intervalMs = options.intervalMs ?? RUN_CHECKPOINT_INTERVAL_MS;
   const timers = options.timers ?? defaultTimers;
+  const isActive = options.isActive;
   const threads = new Map<string, ThreadState>();
+
+  /** Never let a caller's throw escape the timer: that would strand the Map entry. */
+  const runSave = (threadId: string): Promise<unknown> => {
+    try {
+      return Promise.resolve(save(threadId));
+    } catch (error) {
+      return Promise.reject(error);
+    }
+  };
+
+  /** A thread the runtime has dropped throws rather than reporting itself idle. */
+  const isRunning = (threadId: string): boolean => {
+    try {
+      return isActive?.(threadId) ?? true;
+    } catch {
+      return false;
+    }
+  };
 
   const schedule = (threadId: string, state: ThreadState): void => {
     state.handle = timers.setTimeout(() => {
@@ -56,7 +90,14 @@ export function createRunCheckpointScheduler(
           schedule(threadId, state);
         }
       };
-      save(threadId).then(reschedule, reschedule);
+      if (!isRunning(threadId)) {
+        // The run ended without a runEnd we could hear. That lost the final save too, so
+        // take one here before letting the thread go.
+        stop(threadId);
+        void runSave(threadId).then(noop, noop);
+        return;
+      }
+      runSave(threadId).then(reschedule, reschedule);
     }, intervalMs);
   };
 
@@ -88,6 +129,12 @@ export function createRunCheckpointScheduler(
     stopAll() {
       for (const threadId of [...threads.keys()]) {
         stop(threadId);
+      }
+    },
+    flushAll() {
+      // The pending timer stays armed: a flush is an extra checkpoint, not a reschedule.
+      for (const threadId of [...threads.keys()]) {
+        void runSave(threadId).then(noop, noop);
       }
     },
   };

--- a/studio/frontend/tests/chat-run-checkpoint-lifecycle.test.ts
+++ b/studio/frontend/tests/chat-run-checkpoint-lifecycle.test.ts
@@ -1,0 +1,1207 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  RUN_CHECKPOINT_INTERVAL_MS,
+  type RunCheckpointTimers,
+  createRunCheckpointScheduler,
+} from "../src/features/chat/utils/run-checkpoint-scheduler.ts";
+
+const INTERVAL = 1000;
+
+/** The scheduler reschedules from a promise continuation, so let those run. */
+async function flushMicrotasks(): Promise<void> {
+  for (let i = 0; i < 8; i += 1) {
+    await Promise.resolve();
+  }
+}
+
+function createFakeTimers() {
+  let now = 0;
+  let nextHandle = 1;
+  const scheduled = new Map<number, { at: number; callback: () => void }>();
+
+  const timers: RunCheckpointTimers = {
+    setTimeout: (callback, ms) => {
+      const handle = nextHandle;
+      nextHandle += 1;
+      scheduled.set(handle, { at: now + ms, callback });
+      return handle;
+    },
+    clearTimeout: (handle) => {
+      scheduled.delete(handle);
+    },
+  };
+
+  const fireDue = async (): Promise<number> => {
+    const due = [...scheduled.entries()]
+      .filter(([, timer]) => timer.at <= now)
+      .sort(([, a], [, b]) => a.at - b.at);
+    let fired = 0;
+    for (const [handle, timer] of due) {
+      if (!scheduled.delete(handle)) continue;
+      timer.callback();
+      fired += 1;
+      await flushMicrotasks();
+    }
+    return fired;
+  };
+
+  return {
+    timers,
+    pending: () => scheduled.size,
+    /** Due timers are snapshotted once, exactly like the harness the PR ships. */
+    async advance(ms: number): Promise<void> {
+      now += ms;
+      await fireDue();
+    },
+    /**
+     * Advance and then keep firing anything that came due during the pass, so a timer
+     * armed mid-advance still runs. Used where a flush or a settle rearms in the middle.
+     */
+    async advanceUntilQuiet(ms: number): Promise<void> {
+      now += ms;
+      for (let i = 0; i < 50; i += 1) {
+        if ((await fireDue()) === 0) return;
+      }
+      throw new Error("timers never went quiet");
+    },
+  };
+}
+
+/** A save whose settling the test controls. */
+function createGatedSave() {
+  const releases: Array<() => void> = [];
+  const calls: string[] = [];
+  return {
+    calls,
+    save: (threadId: string) => {
+      calls.push(threadId);
+      return new Promise<void>((resolve) => {
+        releases.push(resolve);
+      });
+    },
+    releaseAll(): void {
+      const pending = releases.splice(0, releases.length);
+      for (const release of pending) release();
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// A. backwards compatibility of the new options
+// ---------------------------------------------------------------------------
+
+test("omitting isActive keeps checkpointing indefinitely while started", async () => {
+  const clock = createFakeTimers();
+  const saved: string[] = [];
+  const scheduler = createRunCheckpointScheduler(
+    async (threadId) => {
+      saved.push(threadId);
+    },
+    { intervalMs: INTERVAL, timers: clock.timers },
+  );
+
+  scheduler.start("thread-a");
+  for (let i = 0; i < 12; i += 1) {
+    await clock.advance(INTERVAL);
+  }
+  assert.equal(
+    saved.length,
+    12,
+    "an absent liveness probe must not end the run",
+  );
+  assert.equal(clock.pending(), 1, "the schedule is still armed");
+  scheduler.stop("thread-a");
+});
+
+test("an isActive that always returns true behaves like no isActive at all", async () => {
+  const clock = createFakeTimers();
+  const saved: string[] = [];
+  const scheduler = createRunCheckpointScheduler(
+    async (threadId) => {
+      saved.push(threadId);
+    },
+    { intervalMs: INTERVAL, timers: clock.timers, isActive: () => true },
+  );
+
+  scheduler.start("thread-a");
+  for (let i = 0; i < 12; i += 1) {
+    await clock.advance(INTERVAL);
+  }
+  assert.equal(saved.length, 12);
+  assert.equal(clock.pending(), 1);
+  scheduler.stop("thread-a");
+});
+
+test("an empty options object still uses the production interval", async () => {
+  const clock = createFakeTimers();
+  let saves = 0;
+  const scheduler = createRunCheckpointScheduler(
+    async () => {
+      saves += 1;
+    },
+    { timers: clock.timers },
+  );
+
+  scheduler.start("thread-a");
+  await clock.advance(RUN_CHECKPOINT_INTERVAL_MS - 1);
+  assert.equal(saves, 0, "a default-interval checkpoint fired early");
+  await clock.advance(1);
+  assert.equal(saves, 1);
+  scheduler.stop("thread-a");
+});
+
+test("the original no-options call shape arms a window timer at the production interval", () => {
+  const armed: Array<{ ms: number; callback: () => void }> = [];
+  const cleared: number[] = [];
+  const globals = globalThis as unknown as { window?: unknown };
+  const original = globals.window;
+  globals.window = {
+    setTimeout: (callback: () => void, ms: number) => {
+      armed.push({ ms, callback });
+      return armed.length;
+    },
+    clearTimeout: (handle: number) => {
+      cleared.push(handle);
+    },
+  };
+  try {
+    const scheduler = createRunCheckpointScheduler(async () => {});
+    scheduler.start("thread-a");
+    assert.equal(
+      armed.length,
+      1,
+      "createRunCheckpointScheduler(save) must still work",
+    );
+    assert.equal(armed[0]?.ms, RUN_CHECKPOINT_INTERVAL_MS);
+    scheduler.stop("thread-a");
+    assert.deepEqual(cleared, [1], "stop must clear the window timer");
+  } finally {
+    globals.window = original;
+  }
+});
+
+// ---------------------------------------------------------------------------
+// B. the liveness guard
+// ---------------------------------------------------------------------------
+
+test("a thread that is already inactive at the first tick takes exactly one final save", async () => {
+  const clock = createFakeTimers();
+  const saved: string[] = [];
+  const scheduler = createRunCheckpointScheduler(
+    async (threadId) => {
+      saved.push(threadId);
+    },
+    { intervalMs: INTERVAL, timers: clock.timers, isActive: () => false },
+  );
+
+  scheduler.start("thread-a");
+  await clock.advance(INTERVAL);
+  assert.deepEqual(
+    saved,
+    ["thread-a"],
+    "the lost runEnd must still get its final save",
+  );
+  assert.equal(clock.pending(), 0, "an inactive thread must not stay armed");
+
+  await clock.advance(INTERVAL * 20);
+  assert.deepEqual(saved, ["thread-a"], "the schedule must be over");
+});
+
+test("checkpoints continue while active and end with one final save when the run goes inactive", async () => {
+  const clock = createFakeTimers();
+  let saves = 0;
+  let active = true;
+  const scheduler = createRunCheckpointScheduler(
+    async () => {
+      saves += 1;
+    },
+    { intervalMs: INTERVAL, timers: clock.timers, isActive: () => active },
+  );
+
+  scheduler.start("thread-a");
+  for (let i = 0; i < 4; i += 1) {
+    await clock.advance(INTERVAL);
+  }
+  assert.equal(saves, 4, "four periodic checkpoints while the run is live");
+
+  active = false;
+  await clock.advance(INTERVAL);
+  assert.equal(saves, 5, "four periodic saves plus one final save");
+  assert.equal(clock.pending(), 0);
+
+  await clock.advance(INTERVAL * 10);
+  assert.equal(saves, 5, "nothing may be scheduled after the final save");
+});
+
+test("an isActive that throws is treated as not running", async () => {
+  const clock = createFakeTimers();
+  let saves = 0;
+  const scheduler = createRunCheckpointScheduler(
+    async () => {
+      saves += 1;
+    },
+    {
+      intervalMs: INTERVAL,
+      timers: clock.timers,
+      isActive: () => {
+        throw new Error("thread record is gone");
+      },
+    },
+  );
+
+  scheduler.start("thread-a");
+  await clock.advance(INTERVAL);
+  assert.equal(saves, 1, "a throwing probe must still yield the final save");
+  assert.equal(clock.pending(), 0, "a throwing probe must end the schedule");
+  await clock.advance(INTERVAL * 10);
+  assert.equal(saves, 1);
+});
+
+test("a thread can be started again after it self-terminated", async () => {
+  const clock = createFakeTimers();
+  let saves = 0;
+  let active = false;
+  const scheduler = createRunCheckpointScheduler(
+    async () => {
+      saves += 1;
+    },
+    { intervalMs: INTERVAL, timers: clock.timers, isActive: () => active },
+  );
+
+  scheduler.start("thread-a");
+  await clock.advance(INTERVAL);
+  assert.equal(saves, 1);
+  assert.equal(clock.pending(), 0);
+
+  // The dead-record hazard: a stale Map entry would make this start a silent no-op.
+  active = true;
+  scheduler.start("thread-a");
+  assert.equal(
+    clock.pending(),
+    1,
+    "the self-terminated thread left a stranded map entry",
+  );
+  await clock.advance(INTERVAL);
+  assert.equal(saves, 2, "the revived thread must checkpoint again");
+  scheduler.stop("thread-a");
+});
+
+test("isActive is not consulted before the first interval elapses", async () => {
+  const clock = createFakeTimers();
+  let probes = 0;
+  let saves = 0;
+  const scheduler = createRunCheckpointScheduler(
+    async () => {
+      saves += 1;
+    },
+    {
+      intervalMs: INTERVAL,
+      timers: clock.timers,
+      isActive: () => {
+        probes += 1;
+        return true;
+      },
+    },
+  );
+
+  scheduler.start("thread-a");
+  assert.equal(probes, 0, "start must not probe liveness");
+  assert.equal(saves, 0);
+  await clock.advance(INTERVAL - 1);
+  assert.equal(probes, 0, "no probe before the interval elapses");
+  assert.equal(saves, 0);
+  await clock.advance(1);
+  assert.equal(probes, 1);
+  assert.equal(saves, 1);
+  scheduler.stop("thread-a");
+});
+
+test("liveness is probed once per tick", async () => {
+  const clock = createFakeTimers();
+  let probes = 0;
+  const scheduler = createRunCheckpointScheduler(async () => {}, {
+    intervalMs: INTERVAL,
+    timers: clock.timers,
+    isActive: () => {
+      probes += 1;
+      return true;
+    },
+  });
+
+  scheduler.start("thread-a");
+  await clock.advance(INTERVAL);
+  assert.equal(probes, 1);
+  await clock.advance(INTERVAL);
+  assert.equal(probes, 2, "one probe per checkpoint, not per continuation");
+  scheduler.stop("thread-a");
+});
+
+test("the final save is still attempted when the save itself rejects", async () => {
+  const clock = createFakeTimers();
+  let attempts = 0;
+  const scheduler = createRunCheckpointScheduler(
+    async () => {
+      attempts += 1;
+      throw new Error("write failed");
+    },
+    { intervalMs: INTERVAL, timers: clock.timers, isActive: () => false },
+  );
+
+  scheduler.start("thread-a");
+  await clock.advance(INTERVAL);
+  assert.equal(
+    attempts,
+    1,
+    "the final save must be attempted even if it will fail",
+  );
+  assert.equal(
+    clock.pending(),
+    0,
+    "a failed final save must not resurrect the schedule",
+  );
+  await clock.advance(INTERVAL * 10);
+  assert.equal(attempts, 1);
+});
+
+test("a stop arriving while the final save is in flight does not rearm", async () => {
+  const clock = createFakeTimers();
+  const gated = createGatedSave();
+  const scheduler = createRunCheckpointScheduler(gated.save, {
+    intervalMs: INTERVAL,
+    timers: clock.timers,
+    isActive: () => false,
+  });
+
+  scheduler.start("thread-a");
+  await clock.advance(INTERVAL);
+  assert.deepEqual(gated.calls, ["thread-a"], "the final save is in flight");
+
+  scheduler.stop("thread-a");
+  gated.releaseAll();
+  await flushMicrotasks();
+  assert.equal(clock.pending(), 0, "the settled final save must not rearm");
+  await clock.advance(INTERVAL * 10);
+  assert.deepEqual(gated.calls, ["thread-a"]);
+});
+
+test("the final save is given the thread id that went inactive", async () => {
+  const clock = createFakeTimers();
+  const saved: string[] = [];
+  const scheduler = createRunCheckpointScheduler(
+    async (threadId) => {
+      saved.push(threadId);
+    },
+    {
+      intervalMs: INTERVAL,
+      timers: clock.timers,
+      isActive: (threadId) => threadId !== "thread-b",
+    },
+  );
+
+  scheduler.start("thread-b");
+  await clock.advance(INTERVAL);
+  assert.deepEqual(saved, ["thread-b"]);
+  scheduler.stopAll();
+});
+
+test("one thread going inactive does not stop its sibling", async () => {
+  const clock = createFakeTimers();
+  const saved: string[] = [];
+  const scheduler = createRunCheckpointScheduler(
+    async (threadId) => {
+      saved.push(threadId);
+    },
+    {
+      intervalMs: INTERVAL,
+      timers: clock.timers,
+      isActive: (threadId) => threadId === "thread-a",
+    },
+  );
+
+  scheduler.start("thread-a");
+  scheduler.start("thread-b");
+  await clock.advance(INTERVAL);
+  assert.deepEqual([...saved].sort(), ["thread-a", "thread-b"]);
+  assert.equal(clock.pending(), 1, "only the live thread stays armed");
+
+  await clock.advance(INTERVAL);
+  assert.deepEqual(
+    saved.slice(2),
+    ["thread-a"],
+    "the dead thread must not save again",
+  );
+  scheduler.stopAll();
+});
+
+test("the liveness probe receives the thread id under checkpoint", async () => {
+  const clock = createFakeTimers();
+  const probed: string[] = [];
+  const scheduler = createRunCheckpointScheduler(async () => {}, {
+    intervalMs: INTERVAL,
+    timers: clock.timers,
+    isActive: (threadId) => {
+      probed.push(threadId);
+      return true;
+    },
+  });
+
+  scheduler.start("thread-a");
+  scheduler.start("thread-b");
+  await clock.advance(INTERVAL);
+  assert.deepEqual([...probed].sort(), ["thread-a", "thread-b"]);
+  scheduler.stopAll();
+});
+
+// ---------------------------------------------------------------------------
+// C. sync-throw and non-thenable hardening
+// ---------------------------------------------------------------------------
+
+test("a save that throws synchronously does not stop the schedule", async () => {
+  const clock = createFakeTimers();
+  let attempts = 0;
+  const scheduler = createRunCheckpointScheduler(
+    (() => {
+      attempts += 1;
+      throw new Error("serialiser blew up");
+    }) as unknown as (threadId: string) => Promise<unknown>,
+    { intervalMs: INTERVAL, timers: clock.timers },
+  );
+
+  scheduler.start("thread-a");
+  await clock.advance(INTERVAL);
+  assert.equal(attempts, 1);
+  assert.equal(clock.pending(), 1, "a synchronous throw must still rearm");
+  await clock.advance(INTERVAL);
+  await clock.advance(INTERVAL);
+  assert.equal(
+    attempts,
+    3,
+    "a synchronous throw must not disable later checkpoints",
+  );
+  scheduler.stop("thread-a");
+});
+
+test("a synchronous throw does not escape the timer callback", async () => {
+  const clock = createFakeTimers();
+  const scheduler = createRunCheckpointScheduler(
+    (() => {
+      throw new Error("boom");
+    }) as unknown as (threadId: string) => Promise<unknown>,
+    { intervalMs: INTERVAL, timers: clock.timers },
+  );
+
+  scheduler.start("thread-a");
+  // An escaping throw would reject this advance and fail the test.
+  await clock.advance(INTERVAL);
+  assert.equal(clock.pending(), 1);
+  scheduler.stop("thread-a");
+});
+
+test("a save returning undefined reschedules like a resolved promise", async () => {
+  const clock = createFakeTimers();
+  let attempts = 0;
+  const scheduler = createRunCheckpointScheduler(
+    (() => {
+      attempts += 1;
+      return undefined;
+    }) as unknown as (threadId: string) => Promise<unknown>,
+    { intervalMs: INTERVAL, timers: clock.timers },
+  );
+
+  scheduler.start("thread-a");
+  await clock.advance(INTERVAL);
+  await clock.advance(INTERVAL);
+  await clock.advance(INTERVAL);
+  assert.equal(attempts, 3, "a void return must not strand the schedule");
+  scheduler.stop("thread-a");
+});
+
+test("a save returning a plain non-thenable object reschedules", async () => {
+  const clock = createFakeTimers();
+  let attempts = 0;
+  const scheduler = createRunCheckpointScheduler(
+    (() => {
+      attempts += 1;
+      return { ok: true };
+    }) as unknown as (threadId: string) => Promise<unknown>,
+    { intervalMs: INTERVAL, timers: clock.timers },
+  );
+
+  scheduler.start("thread-a");
+  await clock.advance(INTERVAL);
+  await clock.advance(INTERVAL);
+  assert.equal(attempts, 2);
+  assert.equal(clock.pending(), 1);
+  scheduler.stop("thread-a");
+});
+
+test("a save returning a rejected promise reschedules", async () => {
+  const clock = createFakeTimers();
+  let attempts = 0;
+  const scheduler = createRunCheckpointScheduler(
+    () => {
+      attempts += 1;
+      return Promise.reject(new Error("write failed"));
+    },
+    { intervalMs: INTERVAL, timers: clock.timers },
+  );
+
+  scheduler.start("thread-a");
+  await clock.advance(INTERVAL);
+  await clock.advance(INTERVAL);
+  assert.equal(attempts, 2);
+  assert.equal(clock.pending(), 1);
+  scheduler.stop("thread-a");
+});
+
+test("a synchronous throw leaves no stranded map entry", async () => {
+  const clock = createFakeTimers();
+  let attempts = 0;
+  const scheduler = createRunCheckpointScheduler(
+    (() => {
+      attempts += 1;
+      throw new Error("boom");
+    }) as unknown as (threadId: string) => Promise<unknown>,
+    { intervalMs: INTERVAL, timers: clock.timers },
+  );
+
+  scheduler.start("thread-a");
+  await clock.advance(INTERVAL);
+  assert.equal(attempts, 1);
+
+  scheduler.stop("thread-a");
+  assert.equal(
+    clock.pending(),
+    0,
+    "stop after a synchronous throw must disarm",
+  );
+  scheduler.start("thread-a");
+  assert.equal(clock.pending(), 1, "a thrown save stranded the map entry");
+  await clock.advance(INTERVAL);
+  assert.equal(attempts, 2);
+  scheduler.stop("thread-a");
+});
+
+test("a synchronously throwing save can still be stopped mid-schedule", async () => {
+  const clock = createFakeTimers();
+  let attempts = 0;
+  const scheduler = createRunCheckpointScheduler(
+    (() => {
+      attempts += 1;
+      throw new Error("boom");
+    }) as unknown as (threadId: string) => Promise<unknown>,
+    { intervalMs: INTERVAL, timers: clock.timers },
+  );
+
+  scheduler.start("thread-a");
+  await clock.advance(INTERVAL);
+  scheduler.stop("thread-a");
+  await clock.advance(INTERVAL * 10);
+  assert.equal(attempts, 1, "stop must beat the retry loop");
+  assert.equal(clock.pending(), 0);
+});
+
+test("a throwing probe and a throwing save still terminate cleanly", async () => {
+  const clock = createFakeTimers();
+  let attempts = 0;
+  const scheduler = createRunCheckpointScheduler(
+    (() => {
+      attempts += 1;
+      throw new Error("save boom");
+    }) as unknown as (threadId: string) => Promise<unknown>,
+    {
+      intervalMs: INTERVAL,
+      timers: clock.timers,
+      isActive: () => {
+        throw new Error("probe boom");
+      },
+    },
+  );
+
+  scheduler.start("thread-a");
+  await clock.advance(INTERVAL);
+  assert.equal(attempts, 1, "the final save is attempted even when both throw");
+  assert.equal(clock.pending(), 0);
+  await clock.advance(INTERVAL * 10);
+  assert.equal(attempts, 1);
+});
+
+// ---------------------------------------------------------------------------
+// D. flushAll
+// ---------------------------------------------------------------------------
+
+test("flushAll checkpoints every started thread", async () => {
+  const clock = createFakeTimers();
+  const saved: string[] = [];
+  const scheduler = createRunCheckpointScheduler(
+    async (threadId) => {
+      saved.push(threadId);
+    },
+    { intervalMs: INTERVAL, timers: clock.timers },
+  );
+
+  scheduler.start("thread-a");
+  scheduler.start("thread-b");
+  scheduler.flushAll();
+  await flushMicrotasks();
+  assert.deepEqual([...saved].sort(), ["thread-a", "thread-b"]);
+  scheduler.stopAll();
+});
+
+test("flushAll does not checkpoint a stopped thread", async () => {
+  const clock = createFakeTimers();
+  const saved: string[] = [];
+  const scheduler = createRunCheckpointScheduler(
+    async (threadId) => {
+      saved.push(threadId);
+    },
+    { intervalMs: INTERVAL, timers: clock.timers },
+  );
+
+  scheduler.start("thread-a");
+  scheduler.start("thread-b");
+  scheduler.stop("thread-b");
+  scheduler.flushAll();
+  await flushMicrotasks();
+  assert.deepEqual(saved, ["thread-a"], "a stopped thread must not be flushed");
+  scheduler.stopAll();
+});
+
+test("flushAll leaves the pending timer armed and on its original schedule", async () => {
+  const clock = createFakeTimers();
+  let saves = 0;
+  const scheduler = createRunCheckpointScheduler(
+    async () => {
+      saves += 1;
+    },
+    { intervalMs: INTERVAL, timers: clock.timers },
+  );
+
+  scheduler.start("thread-a");
+  await clock.advance(INTERVAL);
+  assert.equal(saves, 1);
+  const armedBefore = clock.pending();
+  assert.equal(armedBefore, 1);
+
+  scheduler.flushAll();
+  await flushMicrotasks();
+  assert.equal(saves, 2, "the flush is an extra checkpoint");
+  assert.equal(
+    clock.pending(),
+    armedBefore,
+    "a flush must not clear or stack timers",
+  );
+
+  await clock.advance(INTERVAL - 1);
+  assert.equal(
+    saves,
+    2,
+    "the flush must not have pulled the next checkpoint forward",
+  );
+  await clock.advance(1);
+  assert.equal(
+    saves,
+    3,
+    "the next checkpoint must still land on its original deadline",
+  );
+  scheduler.stop("thread-a");
+});
+
+test("flushAll with no started threads is a no-op", async () => {
+  const clock = createFakeTimers();
+  let saves = 0;
+  const scheduler = createRunCheckpointScheduler(
+    async () => {
+      saves += 1;
+    },
+    { intervalMs: INTERVAL, timers: clock.timers },
+  );
+
+  scheduler.flushAll();
+  await flushMicrotasks();
+  assert.equal(saves, 0);
+  assert.equal(clock.pending(), 0);
+});
+
+test("flushAll during an in-flight checkpoint still issues the extra save", async () => {
+  const clock = createFakeTimers();
+  const gated = createGatedSave();
+  const scheduler = createRunCheckpointScheduler(gated.save, {
+    intervalMs: INTERVAL,
+    timers: clock.timers,
+  });
+
+  scheduler.start("thread-a");
+  await clock.advance(INTERVAL);
+  assert.equal(gated.calls.length, 1, "the periodic checkpoint is in flight");
+  assert.equal(clock.pending(), 0, "no timer while a save is in flight");
+
+  scheduler.flushAll();
+  await flushMicrotasks();
+  assert.equal(
+    gated.calls.length,
+    2,
+    "a page-hide flush must not be swallowed",
+  );
+
+  gated.releaseAll();
+  await flushMicrotasks();
+  assert.equal(
+    clock.pending(),
+    1,
+    "the schedule rearms once the periodic save settles",
+  );
+  scheduler.stop("thread-a");
+});
+
+test("flushAll after stopAll saves nothing", async () => {
+  const clock = createFakeTimers();
+  let saves = 0;
+  const scheduler = createRunCheckpointScheduler(
+    async () => {
+      saves += 1;
+    },
+    { intervalMs: INTERVAL, timers: clock.timers },
+  );
+
+  scheduler.start("thread-a");
+  scheduler.start("thread-b");
+  scheduler.stopAll();
+  scheduler.flushAll();
+  await flushMicrotasks();
+  assert.equal(saves, 0, "unmount must not be followed by a flush write");
+});
+
+test("a synchronous throw inside flushAll does not break the scheduler", async () => {
+  const clock = createFakeTimers();
+  const saved: string[] = [];
+  const scheduler = createRunCheckpointScheduler(
+    ((threadId: string) => {
+      saved.push(threadId);
+      if (threadId === "thread-a") throw new Error("boom");
+      return Promise.resolve();
+    }) as unknown as (threadId: string) => Promise<unknown>,
+    { intervalMs: INTERVAL, timers: clock.timers },
+  );
+
+  scheduler.start("thread-a");
+  scheduler.start("thread-b");
+  scheduler.flushAll();
+  await flushMicrotasks();
+  assert.deepEqual(
+    [...saved].sort(),
+    ["thread-a", "thread-b"],
+    "one throwing thread must not abort the rest of the flush",
+  );
+  assert.equal(clock.pending(), 2, "the flush must leave both schedules armed");
+
+  await clock.advance(INTERVAL);
+  assert.equal(
+    saved.length,
+    4,
+    "both threads keep checkpointing after a throwing flush",
+  );
+  scheduler.stopAll();
+});
+
+test("flushAll does not consult isActive", async () => {
+  const clock = createFakeTimers();
+  let saves = 0;
+  let probes = 0;
+  const scheduler = createRunCheckpointScheduler(
+    async () => {
+      saves += 1;
+    },
+    {
+      intervalMs: INTERVAL,
+      timers: clock.timers,
+      isActive: () => {
+        probes += 1;
+        return false;
+      },
+    },
+  );
+
+  scheduler.start("thread-a");
+  scheduler.flushAll();
+  await flushMicrotasks();
+  assert.equal(
+    saves,
+    1,
+    "a page-hide flush must persist regardless of run liveness",
+  );
+  assert.equal(probes, 0, "flushAll must not probe liveness");
+  assert.equal(
+    clock.pending(),
+    1,
+    "the flush must not have ended the schedule",
+  );
+  scheduler.stopAll();
+});
+
+test("repeated flushAll calls each write once per thread", async () => {
+  const clock = createFakeTimers();
+  const saved: string[] = [];
+  const scheduler = createRunCheckpointScheduler(
+    async (threadId) => {
+      saved.push(threadId);
+    },
+    { intervalMs: INTERVAL, timers: clock.timers },
+  );
+
+  scheduler.start("thread-a");
+  scheduler.flushAll();
+  scheduler.flushAll();
+  scheduler.flushAll();
+  await flushMicrotasks();
+  assert.deepEqual(saved, ["thread-a", "thread-a", "thread-a"]);
+  assert.equal(clock.pending(), 1);
+  scheduler.stop("thread-a");
+});
+
+test("flushAll ignores a thread that already self-terminated", async () => {
+  const clock = createFakeTimers();
+  let saves = 0;
+  const scheduler = createRunCheckpointScheduler(
+    async () => {
+      saves += 1;
+    },
+    { intervalMs: INTERVAL, timers: clock.timers, isActive: () => false },
+  );
+
+  scheduler.start("thread-a");
+  await clock.advance(INTERVAL);
+  assert.equal(saves, 1, "the final save");
+
+  scheduler.flushAll();
+  await flushMicrotasks();
+  assert.equal(saves, 1, "a thread already released must not be flushed again");
+});
+
+test("flushAll writes a thread that was restarted after stopAll", async () => {
+  const clock = createFakeTimers();
+  const saved: string[] = [];
+  const scheduler = createRunCheckpointScheduler(
+    async (threadId) => {
+      saved.push(threadId);
+    },
+    { intervalMs: INTERVAL, timers: clock.timers },
+  );
+
+  scheduler.start("thread-a");
+  scheduler.stopAll();
+  scheduler.start("thread-a");
+  scheduler.flushAll();
+  await flushMicrotasks();
+  assert.deepEqual(saved, ["thread-a"]);
+  scheduler.stopAll();
+});
+
+// ---------------------------------------------------------------------------
+// E. pre-existing behaviour that must not regress
+// ---------------------------------------------------------------------------
+
+test("the checkpoint interval constant is still eight seconds", () => {
+  assert.equal(RUN_CHECKPOINT_INTERVAL_MS, 8_000);
+});
+
+test("quiet time is measured after the checkpoint settles, not on a fixed cadence", async () => {
+  const clock = createFakeTimers();
+  const gated = createGatedSave();
+  const scheduler = createRunCheckpointScheduler(gated.save, {
+    intervalMs: INTERVAL,
+    timers: clock.timers,
+  });
+
+  scheduler.start("thread-a");
+  await clock.advance(INTERVAL);
+  assert.equal(gated.calls.length, 1, "checkpoint 1 at t = interval");
+
+  // The save takes five intervals to land.
+  await clock.advance(INTERVAL * 5);
+  assert.equal(gated.calls.length, 1);
+  gated.releaseAll();
+  await flushMicrotasks();
+
+  // Checkpoint 2 must land at save_duration + interval, not at a fixed 2 x interval.
+  await clock.advance(INTERVAL - 1);
+  assert.equal(
+    gated.calls.length,
+    1,
+    "the next checkpoint ignored the settle time",
+  );
+  await clock.advance(1);
+  assert.equal(
+    gated.calls.length,
+    2,
+    "checkpoint 2 lands one quiet interval after settle",
+  );
+  scheduler.stop("thread-a");
+});
+
+test("no timer is armed while a checkpoint is in flight", async () => {
+  const clock = createFakeTimers();
+  const gated = createGatedSave();
+  const scheduler = createRunCheckpointScheduler(gated.save, {
+    intervalMs: INTERVAL,
+    timers: clock.timers,
+  });
+
+  scheduler.start("thread-a");
+  assert.equal(clock.pending(), 1);
+  await clock.advance(INTERVAL);
+  assert.equal(
+    clock.pending(),
+    0,
+    "checkpoints must not stack behind a slow save",
+  );
+  await clock.advance(INTERVAL * 10);
+  assert.equal(gated.calls.length, 1);
+  gated.releaseAll();
+  await flushMicrotasks();
+  assert.equal(clock.pending(), 1);
+  scheduler.stop("thread-a");
+});
+
+test("a duplicate start does not stack timers", async () => {
+  const clock = createFakeTimers();
+  let saves = 0;
+  const scheduler = createRunCheckpointScheduler(
+    async () => {
+      saves += 1;
+    },
+    { intervalMs: INTERVAL, timers: clock.timers },
+  );
+
+  scheduler.start("thread-a");
+  scheduler.start("thread-a");
+  scheduler.start("thread-a");
+  assert.equal(clock.pending(), 1, "one timer per thread, not per start");
+  await clock.advanceUntilQuiet(INTERVAL);
+  assert.equal(
+    saves,
+    1,
+    "a repeated runStart must not double the checkpoint rate",
+  );
+  scheduler.stop("thread-a");
+});
+
+test("stopping an unknown thread is a no-op and does not disturb a live thread", async () => {
+  const clock = createFakeTimers();
+  const saved: string[] = [];
+  const scheduler = createRunCheckpointScheduler(
+    async (threadId) => {
+      saved.push(threadId);
+    },
+    { intervalMs: INTERVAL, timers: clock.timers },
+  );
+
+  scheduler.start("thread-a");
+  scheduler.stop("thread-never-started");
+  assert.equal(clock.pending(), 1, "an unknown stop cleared a live timer");
+  await clock.advance(INTERVAL);
+  assert.deepEqual(saved, ["thread-a"]);
+  scheduler.stop("thread-a");
+});
+
+test("stopping a thread twice is a no-op the second time", async () => {
+  const clock = createFakeTimers();
+  let saves = 0;
+  const scheduler = createRunCheckpointScheduler(
+    async () => {
+      saves += 1;
+    },
+    { intervalMs: INTERVAL, timers: clock.timers },
+  );
+
+  scheduler.start("thread-a");
+  scheduler.stop("thread-a");
+  scheduler.stop("thread-a");
+  assert.equal(clock.pending(), 0);
+  await clock.advance(INTERVAL * 5);
+  assert.equal(saves, 0, "a double stop must not resurrect anything");
+});
+
+test("start after stop restarts the schedule cleanly", async () => {
+  const clock = createFakeTimers();
+  let saves = 0;
+  const scheduler = createRunCheckpointScheduler(
+    async () => {
+      saves += 1;
+    },
+    { intervalMs: INTERVAL, timers: clock.timers },
+  );
+
+  scheduler.start("thread-a");
+  await clock.advance(INTERVAL);
+  assert.equal(saves, 1);
+  scheduler.stop("thread-a");
+  await clock.advance(INTERVAL * 3);
+  assert.equal(saves, 1);
+
+  scheduler.start("thread-a");
+  assert.equal(clock.pending(), 1);
+  await clock.advance(INTERVAL);
+  assert.equal(saves, 2, "a restarted thread must checkpoint again");
+  scheduler.stop("thread-a");
+});
+
+test("stopAll is idempotent and threads can restart after it", async () => {
+  const clock = createFakeTimers();
+  const saved: string[] = [];
+  const scheduler = createRunCheckpointScheduler(
+    async (threadId) => {
+      saved.push(threadId);
+    },
+    { intervalMs: INTERVAL, timers: clock.timers },
+  );
+
+  scheduler.start("thread-a");
+  scheduler.start("thread-b");
+  scheduler.stopAll();
+  scheduler.stopAll();
+  assert.equal(clock.pending(), 0);
+  await clock.advance(INTERVAL * 3);
+  assert.deepEqual(saved, []);
+
+  scheduler.start("thread-a");
+  await clock.advance(INTERVAL);
+  assert.deepEqual(saved, ["thread-a"], "unmount must not poison later runs");
+  scheduler.stopAll();
+});
+
+test("threads are checkpointed independently", async () => {
+  const clock = createFakeTimers();
+  const saved: string[] = [];
+  const scheduler = createRunCheckpointScheduler(
+    async (threadId) => {
+      saved.push(threadId);
+    },
+    { intervalMs: INTERVAL, timers: clock.timers },
+  );
+
+  scheduler.start("thread-a");
+  scheduler.start("thread-b");
+  await clock.advance(INTERVAL);
+  assert.deepEqual([...saved].sort(), ["thread-a", "thread-b"]);
+
+  scheduler.stop("thread-a");
+  await clock.advance(INTERVAL);
+  assert.deepEqual(
+    saved.slice(2),
+    ["thread-b"],
+    "stopping one thread stopped the other",
+  );
+  scheduler.stop("thread-b");
+});
+
+test("a run shorter than one interval produces no checkpoints", async () => {
+  const clock = createFakeTimers();
+  let saves = 0;
+  const scheduler = createRunCheckpointScheduler(
+    async () => {
+      saves += 1;
+    },
+    { intervalMs: INTERVAL, timers: clock.timers },
+  );
+
+  scheduler.start("thread-a");
+  await clock.advance(INTERVAL - 1);
+  scheduler.stop("thread-a");
+  await clock.advance(INTERVAL * 10);
+  assert.equal(saves, 0, "a short run must not write a checkpoint at all");
+  assert.equal(clock.pending(), 0);
+});
+
+test("each thread's save receives its own thread id", async () => {
+  const clock = createFakeTimers();
+  const saved: string[] = [];
+  const scheduler = createRunCheckpointScheduler(
+    async (threadId) => {
+      saved.push(threadId);
+    },
+    { intervalMs: INTERVAL, timers: clock.timers },
+  );
+
+  scheduler.start("alpha");
+  scheduler.start("beta");
+  scheduler.start("gamma");
+  await clock.advance(INTERVAL);
+  assert.deepEqual([...saved].sort(), ["alpha", "beta", "gamma"]);
+  scheduler.stopAll();
+});
+
+test("a custom interval is honoured for every thread", async () => {
+  const clock = createFakeTimers();
+  let saves = 0;
+  const scheduler = createRunCheckpointScheduler(
+    async () => {
+      saves += 1;
+    },
+    { intervalMs: 250, timers: clock.timers },
+  );
+
+  scheduler.start("thread-a");
+  await clock.advance(249);
+  assert.equal(saves, 0);
+  await clock.advance(1);
+  assert.equal(saves, 1);
+  await clock.advance(250);
+  assert.equal(saves, 2);
+  scheduler.stop("thread-a");
+});
+
+test("stop during an in-flight checkpoint ends the schedule", async () => {
+  const clock = createFakeTimers();
+  const gated = createGatedSave();
+  const scheduler = createRunCheckpointScheduler(gated.save, {
+    intervalMs: INTERVAL,
+    timers: clock.timers,
+  });
+
+  scheduler.start("thread-a");
+  await clock.advance(INTERVAL);
+  assert.equal(gated.calls.length, 1);
+
+  scheduler.stop("thread-a");
+  gated.releaseAll();
+  await flushMicrotasks();
+  assert.equal(
+    clock.pending(),
+    0,
+    "the settled save must not rearm after stop",
+  );
+  await clock.advance(INTERVAL * 5);
+  assert.equal(gated.calls.length, 1);
+});
+
+test("a thread restarted while its old save is in flight keeps exactly one schedule", async () => {
+  const clock = createFakeTimers();
+  const gated = createGatedSave();
+  const scheduler = createRunCheckpointScheduler(gated.save, {
+    intervalMs: INTERVAL,
+    timers: clock.timers,
+  });
+
+  scheduler.start("thread-a");
+  await clock.advance(INTERVAL);
+  assert.equal(gated.calls.length, 1);
+
+  scheduler.stop("thread-a");
+  scheduler.start("thread-a");
+  assert.equal(clock.pending(), 1, "the restart arms its own timer");
+
+  // The abandoned save settles; it must not arm a second timer for the new run.
+  gated.releaseAll();
+  await flushMicrotasks();
+  assert.equal(
+    clock.pending(),
+    1,
+    "an abandoned save rearmed on top of the new schedule",
+  );
+  scheduler.stop("thread-a");
+});

--- a/studio/frontend/tests/chat-run-checkpoint-lifecycle.test.ts
+++ b/studio/frontend/tests/chat-run-checkpoint-lifecycle.test.ts
@@ -90,9 +90,7 @@ function createGatedSave() {
   };
 }
 
-// ---------------------------------------------------------------------------
 // A. backwards compatibility of the new options
-// ---------------------------------------------------------------------------
 
 test("omitting isActive keeps checkpointing indefinitely while started", async () => {
   const clock = createFakeTimers();
@@ -184,9 +182,7 @@ test("the original no-options call shape arms a window timer at the production i
   }
 });
 
-// ---------------------------------------------------------------------------
 // B. the liveness guard
-// ---------------------------------------------------------------------------
 
 test("a thread that is already inactive at the first tick takes exactly one final save", async () => {
   const clock = createFakeTimers();
@@ -456,9 +452,7 @@ test("the liveness probe receives the thread id under checkpoint", async () => {
   scheduler.stopAll();
 });
 
-// ---------------------------------------------------------------------------
 // C. sync-throw and non-thenable hardening
-// ---------------------------------------------------------------------------
 
 test("a save that throws synchronously does not stop the schedule", async () => {
   const clock = createFakeTimers();
@@ -630,9 +624,7 @@ test("a throwing probe and a throwing save still terminate cleanly", async () =>
   assert.equal(attempts, 1);
 });
 
-// ---------------------------------------------------------------------------
 // D. flushAll
-// ---------------------------------------------------------------------------
 
 test("flushAll checkpoints every started thread", async () => {
   const clock = createFakeTimers();
@@ -901,9 +893,7 @@ test("flushAll writes a thread that was restarted after stopAll", async () => {
   scheduler.stopAll();
 });
 
-// ---------------------------------------------------------------------------
 // E. pre-existing behaviour that must not regress
-// ---------------------------------------------------------------------------
 
 test("the checkpoint interval constant is still eight seconds", () => {
   assert.equal(RUN_CHECKPOINT_INTERVAL_MS, 8_000);

--- a/studio/frontend/tests/chat-run-checkpoint.test.ts
+++ b/studio/frontend/tests/chat-run-checkpoint.test.ts
@@ -1,0 +1,224 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+import {
+  RUN_CHECKPOINT_INTERVAL_MS,
+  type RunCheckpointTimers,
+  createRunCheckpointScheduler,
+} from "../src/features/chat/utils/run-checkpoint-scheduler.ts";
+
+const INTERVAL = 1000;
+
+test("uses an eight-second production checkpoint interval", () => {
+  assert.equal(RUN_CHECKPOINT_INTERVAL_MS, 8_000);
+});
+
+/** The scheduler reschedules from a promise continuation, so let those run. */
+async function flushMicrotasks(): Promise<void> {
+  for (let i = 0; i < 8; i += 1) {
+    await Promise.resolve();
+  }
+}
+
+function createFakeTimers() {
+  let now = 0;
+  let nextHandle = 1;
+  const scheduled = new Map<number, { at: number; callback: () => void }>();
+
+  const timers: RunCheckpointTimers = {
+    setTimeout: (callback, ms) => {
+      const handle = nextHandle;
+      nextHandle += 1;
+      scheduled.set(handle, { at: now + ms, callback });
+      return handle;
+    },
+    clearTimeout: (handle) => {
+      scheduled.delete(handle);
+    },
+  };
+
+  return {
+    timers,
+    pending: () => scheduled.size,
+    async advance(ms: number): Promise<void> {
+      now += ms;
+      const due = [...scheduled.entries()]
+        .filter(([, timer]) => timer.at <= now)
+        .sort(([, a], [, b]) => a.at - b.at);
+      for (const [handle, timer] of due) {
+        if (!scheduled.delete(handle)) continue;
+        timer.callback();
+        await flushMicrotasks();
+      }
+    },
+  };
+}
+
+test("keeps checkpointing a running thread until it is stopped", async () => {
+  const clock = createFakeTimers();
+  const saved: string[] = [];
+  const scheduler = createRunCheckpointScheduler(
+    async (threadId) => {
+      saved.push(threadId);
+    },
+    { intervalMs: INTERVAL, timers: clock.timers },
+  );
+
+  scheduler.start("thread-a");
+  assert.deepEqual(saved, [], "nothing is saved before the first interval");
+
+  await clock.advance(INTERVAL);
+  assert.deepEqual(saved, ["thread-a"]);
+
+  await clock.advance(INTERVAL);
+  await clock.advance(INTERVAL);
+  assert.deepEqual(saved, ["thread-a", "thread-a", "thread-a"]);
+
+  scheduler.stop("thread-a");
+  await clock.advance(INTERVAL * 5);
+  assert.deepEqual(
+    saved,
+    ["thread-a", "thread-a", "thread-a"],
+    "runEnd stops the schedule",
+  );
+  assert.equal(clock.pending(), 0, "the pending timer is dropped on stop");
+});
+
+test("waits for a slow checkpoint instead of stacking the next one behind it", async () => {
+  const clock = createFakeTimers();
+  let releaseSave = (): void => {};
+  let saves = 0;
+  const scheduler = createRunCheckpointScheduler(
+    () => {
+      saves += 1;
+      return new Promise<void>((resolve) => {
+        releaseSave = resolve;
+      });
+    },
+    { intervalMs: INTERVAL, timers: clock.timers },
+  );
+
+  scheduler.start("thread-a");
+  await clock.advance(INTERVAL);
+  assert.equal(saves, 1);
+
+  // No timer is armed while the save is in flight.
+  await clock.advance(INTERVAL * 10);
+  assert.equal(saves, 1);
+  assert.equal(clock.pending(), 0);
+
+  releaseSave();
+  await flushMicrotasks();
+  assert.equal(
+    clock.pending(),
+    1,
+    "the next checkpoint is armed once the save lands",
+  );
+
+  await clock.advance(INTERVAL);
+  assert.equal(saves, 2);
+});
+
+test("keeps checkpointing after a checkpoint fails to write", async () => {
+  const clock = createFakeTimers();
+  let attempts = 0;
+  const scheduler = createRunCheckpointScheduler(
+    async () => {
+      attempts += 1;
+      throw new Error("write failed");
+    },
+    { intervalMs: INTERVAL, timers: clock.timers },
+  );
+
+  scheduler.start("thread-a");
+  await clock.advance(INTERVAL);
+  await clock.advance(INTERVAL);
+  assert.equal(
+    attempts,
+    2,
+    "one transient write error must not leave the rest of the run unprotected",
+  );
+});
+
+test("a stop during an in-flight checkpoint ends the schedule", async () => {
+  const clock = createFakeTimers();
+  let releaseSave = (): void => {};
+  let saves = 0;
+  const scheduler = createRunCheckpointScheduler(
+    () => {
+      saves += 1;
+      return new Promise<void>((resolve) => {
+        releaseSave = resolve;
+      });
+    },
+    { intervalMs: INTERVAL, timers: clock.timers },
+  );
+
+  scheduler.start("thread-a");
+  await clock.advance(INTERVAL);
+  assert.equal(saves, 1);
+
+  scheduler.stop("thread-a");
+  releaseSave();
+  await flushMicrotasks();
+  assert.equal(
+    clock.pending(),
+    0,
+    "the settled save must not rearm after stop",
+  );
+
+  await clock.advance(INTERVAL * 5);
+  assert.equal(saves, 1);
+});
+
+test("starting a thread twice keeps one schedule, and stopAll ends every thread", async () => {
+  const clock = createFakeTimers();
+  const saved: string[] = [];
+  const scheduler = createRunCheckpointScheduler(
+    async (threadId) => {
+      saved.push(threadId);
+    },
+    { intervalMs: INTERVAL, timers: clock.timers },
+  );
+
+  scheduler.start("thread-a");
+  scheduler.start("thread-a");
+  scheduler.start("thread-b");
+  assert.equal(clock.pending(), 2, "one timer per thread, not per start");
+
+  await clock.advance(INTERVAL);
+  assert.deepEqual(saved.sort(), ["thread-a", "thread-b"]);
+
+  scheduler.stopAll();
+  assert.equal(clock.pending(), 0);
+  await clock.advance(INTERVAL * 5);
+  assert.equal(saved.length, 2);
+});
+
+test("the chat autosave drives the scheduler from runStart to runEnd", async () => {
+  const src = await readFile(
+    new URL("../src/features/chat/runtime-provider.tsx", import.meta.url),
+    "utf8",
+  );
+  assert.match(
+    src,
+    /createRunCheckpointScheduler\(/,
+    "ThreadBackendAutosave no longer builds a checkpoint scheduler",
+  );
+  const runStart = src.indexOf('useAuiEvent("thread.runStart"');
+  const runEnd = src.indexOf('useAuiEvent("thread.runEnd"');
+  assert.ok(runStart > 0 && runEnd > 0, "the autosave run events moved");
+  assert.match(
+    src.slice(runStart, runStart + 200),
+    /checkpoints\(\)\.start\(threadId\)/,
+    "runStart no longer starts checkpointing",
+  );
+  assert.match(
+    src.slice(runEnd, runEnd + 200),
+    /checkpoints\(\)\.stop\(threadId\)/,
+    "runEnd no longer stops checkpointing, so checkpoints outlive the run",
+  );
+});


### PR DESCRIPTION
## Summary

Mitigates the unrecoverable chat loss reported in [#8911](https://github.com/unslothai/unsloth/issues/8911). Studio previously saved a thread at `thread.runStart` and `thread.runEnd`, but not while the response was streaming. If the renderer reloaded during a long generation, the backend retained only the empty assistant placeholder created at the start.

## Change

While a run is active, Studio now checkpoints the thread through the existing `queueSave` path. It waits 8 seconds after each save settles before starting the next one, avoiding stacked writes on large threads. Failed saves are retried on the next interval, and checkpointing stops at `thread.runEnd` or component unmount.

Streamed messages already carry an `incomplete` marker, so a recovered partial response displays "Response stopped." and offers Continue.

The interval is best effort. A reload before the first checkpoint can still lose the turn, and slow saves or delayed timers can widen the recovery window.

## Verification

- Frontend suite: 4,842 passed after rebasing onto current `main`.
- Typecheck passed in both projects, and the new scheduler has no Biome warnings. ESLint reports the same four `react-hooks/refs` errors in `runtime-provider.tsx` on both `main` and this branch.
- `tests/chat-run-checkpoint.test.ts` covers repeated scheduling, slow and failed saves, stopping during an in-flight save, duplicate starts, unmount cleanup, and the run event wiring.
- In a live Studio run with a 15-second interval, the merge base still stored 0 response characters at 15 seconds, while this branch stored 3,719. Reloading mid-stream restored 1,039 characters with the stopped state and Continue action. The production interval is now 8 seconds.

## Scope

This preserves checkpointed output only. It does not prevent renderer reloads, keep inference alive after a frontend disconnect, or reconnect to an active generation. Those remaining parts of #8911 should stay open or be tracked separately.
