### PR TITLE
Studio: show a live preview while an image generates

### DIFF
--- a/studio/backend/core/inference/diffusion.py
+++ b/studio/backend/core/inference/diffusion.py
@@ -5747,6 +5747,7 @@ class DiffusionBackend:
                         and now - gen.preview_at >= diffusion_preview.MIN_INTERVAL_S
                     ):
                         gen.preview_at = now
+                        started = time.monotonic()
                         rendered = diffusion_preview.render(
                             callback_kwargs.get("latents"),
                             preview_vae,
@@ -5757,6 +5758,11 @@ class DiffusionBackend:
                         )
                         if rendered is not None:
                             gen.preview = rendered
+                        # A preview is overhead, not denoising, so its cost is pushed out of
+                        # the window the ETA averages over. Without this the one-off
+                        # projection fit on the first frame lands inside the sample and the
+                        # next callback reads it as a step, inflating the estimate.
+                        gen.first_step_at += time.monotonic() - started
                     return callback_kwargs
 
                 try:

--- a/studio/backend/core/inference/diffusion.py
+++ b/studio/backend/core/inference/diffusion.py
@@ -71,6 +71,8 @@ from .diffusion_ideogram4 import ideogram4_repo_is_fp8, load_ideogram4_pipeline
 from .diffusion_hidream import HIDREAM_FAMILY_NAME, hidream_te4_kwargs
 from .diffusion_krea2 import KREA2_FAMILY_NAME, load_krea2_pipeline
 from .diffusion_memory import (
+    DEFAULT_IMAGE_HEIGHT,
+    DEFAULT_IMAGE_WIDTH,
     MEMORY_MODE_BALANCED,
     MEMORY_MODE_LOW_VRAM,
     OFFLOAD_NONE,
@@ -111,6 +113,7 @@ from .diffusion_attention import (
 from . import diffusion_compile_cache as compile_cache
 from . import diffusion_cond_cache as cond_cache
 from . import diffusion_gguf_compile as gguf_compile
+from . import diffusion_preview
 from .diffusion_batched import (
     chunk_jobs,
     is_oom_error,
@@ -839,6 +842,9 @@ class _GenState:
     first_step_at: float = 0.0
     # Computed once per step (in the callback) so it's stable between polls.
     eta_seconds: Optional[float] = None
+    # Latest latent thumbnail (base64 JPEG data URL), None until the first one renders.
+    preview: Optional[str] = None
+    preview_at: float = 0.0
 
 
 def _estimate_eta(total_steps: int, step: int, first_step_at: float, now: float) -> Optional[float]:
@@ -5735,10 +5741,45 @@ class DiffusionBackend:
                     # Preempt a long denoise on unload/superseding load (diffusers checks _interrupt).
                     if cancel.is_set():
                         pipe._interrupt = True
+                        return callback_kwargs
+                    if (
+                        preview_vae is not None
+                        and now - gen.preview_at >= diffusion_preview.MIN_INTERVAL_S
+                    ):
+                        gen.preview_at = now
+                        rendered = diffusion_preview.render(
+                            callback_kwargs.get("latents"),
+                            preview_vae,
+                            preview_width,
+                            preview_height,
+                            torch,
+                            logger = logger,
+                        )
+                        if rendered is not None:
+                            gen.preview = rendered
                     return callback_kwargs
 
+                try:
+                    preview_width, preview_height = _compile_shape_dims(
+                        workflow, init_pil, width, height
+                    )
+                except Exception:  # noqa: BLE001 -- previews must never block a generation
+                    preview_width, preview_height = (
+                        width or DEFAULT_IMAGE_WIDTH,
+                        height or DEFAULT_IMAGE_HEIGHT,
+                    )
+                preview_vae = (
+                    getattr(state.pipe, "vae", None)
+                    if diffusion_preview.previews_enabled()
+                    else None
+                )
                 if "callback_on_step_end" in call_params:
                     kwargs["callback_on_step_end"] = _on_step
+                    tensor_inputs = "callback_on_step_end_tensor_inputs" in call_params
+                    if preview_vae is not None and tensor_inputs:
+                        kwargs["callback_on_step_end_tensor_inputs"] = ["latents"]
+                    else:
+                        preview_vae = None
 
                 # Re-check an AUTO cache decision against the ACTUAL step count; explicit choices never toggle.
                 if state.cache_auto:
@@ -5903,6 +5944,7 @@ class DiffusionBackend:
                 "total_steps": 0,
                 "fraction": 0.0,
                 "eta_seconds": None,
+                "preview": None,
             }
         return {
             "active": True,
@@ -5910,6 +5952,7 @@ class DiffusionBackend:
             "total_steps": gen.total_steps,
             "fraction": gen.step / gen.total_steps,  # step is 1..total, never over 1.0
             "eta_seconds": gen.eta_seconds,
+            "preview": gen.preview,
         }
 
     def cancel_generate(self) -> bool:

--- a/studio/backend/core/inference/diffusion.py
+++ b/studio/backend/core/inference/diffusion.py
@@ -5768,9 +5768,19 @@ class DiffusionBackend:
                         width or DEFAULT_IMAGE_WIDTH,
                         height or DEFAULT_IMAGE_HEIGHT,
                     )
+                # A preview costs one VAE decode on the first step to fit the projection.
+                # That is the wrong thing to spend on a CPU-only run, which is already slow
+                # and which previews are meant to sit out; and it is unsafe under any offload
+                # policy, where decoding the VAE mid-denoise pulls it onto the accelerator
+                # outside the sequence the memory plan laid out and can leave it resident
+                # while the next step reloads the transformer.
                 preview_vae = (
                     getattr(state.pipe, "vae", None)
-                    if diffusion_preview.previews_enabled()
+                    if (
+                        diffusion_preview.previews_enabled()
+                        and state.offload_policy == OFFLOAD_NONE
+                        and str(getattr(state, "device", "cpu")).split(":")[0] != "cpu"
+                    )
                     else None
                 )
                 if "callback_on_step_end" in call_params:

--- a/studio/backend/core/inference/diffusion_preview.py
+++ b/studio/backend/core/inference/diffusion_preview.py
@@ -53,11 +53,37 @@ def _latent_channels(vae: Any) -> int:
         return 0
 
 
-def _scale_shift(vae: Any) -> tuple[float, float]:
+def _channel_stats(vae: Any, channels: int, torch: Any) -> Optional[tuple[Any, Any]]:
+    config = getattr(vae, "config", None)
+    mean = getattr(config, "latents_mean", None)
+    std = getattr(config, "latents_std", None)
+    if mean is None or std is None:
+        return None
+    mean_t = torch.tensor(mean, dtype = torch.float32).flatten()
+    std_t = torch.tensor(std, dtype = torch.float32).flatten()
+    if mean_t.numel() != channels or std_t.numel() != channels:
+        return None
+    return std_t, mean_t
+
+
+def _to_vae_space(grid: Any, vae: Any, channels: int, torch: Any) -> Optional[Any]:
+    """Undo the denoiser-side normalization, so `grid` is what the decoder was fitted on.
+
+    Three schemes ship in the families Studio loads. Most use the scalar pair; Qwen-Image
+    and Krea-2 normalize per channel and carry no scaling_factor at all, so reading only
+    the scalars left their latents untouched and their colours wrong. FLUX.2 normalizes
+    with its VAE's BatchNorm statistics over patchified latents, whose channel count no
+    longer matches the config, so it gets no preview rather than a miscoloured one."""
+    if getattr(vae, "bn", None) is not None:
+        return None
+    stats = _channel_stats(vae, channels, torch)
+    if stats is not None:
+        std, mean = stats
+        return grid * std + mean
     config = getattr(vae, "config", None)
     scaling = getattr(config, "scaling_factor", None) or 1.0
     shift = getattr(config, "shift_factor", None) or 0.0
-    return float(scaling), float(shift)
+    return grid / float(scaling) + float(shift)
 
 
 def _fit(vae: Any, channels: int, device: Any, dtype: Any, torch: Any) -> Optional[Any]:
@@ -70,7 +96,10 @@ def _fit(vae: Any, channels: int, device: Any, dtype: Any, torch: Any) -> Option
     lhs = noise.float().permute(0, 2, 3, 1).reshape(-1, channels)
     lhs = torch.cat([lhs, torch.ones_like(lhs[:, :1])], dim = 1)
     rhs = target.permute(0, 2, 3, 1).reshape(-1, 3)
-    solution = torch.linalg.lstsq(lhs, rhs).solution
+    # Solved on CPU: MPS ships no linalg_lstsq, and projection() swallows the
+    # NotImplementedError, so on a Mac this would cache "no previews" for the whole
+    # session after paying for the decode. Both matrices are tiny.
+    solution = torch.linalg.lstsq(lhs.cpu(), rhs.cpu()).solution
     if not bool(torch.isfinite(solution).all()):
         return None
     return solution.cpu()
@@ -157,8 +186,9 @@ def render(
         grid = _grid(latents.detach(), channels, width, height)
         if grid is None or int(grid.shape[-1]) != channels:
             return None
-        scaling, shift = _scale_shift(vae)
-        grid = grid.float().cpu() / scaling + shift
+        grid = _to_vae_space(grid.float().cpu(), vae, channels, torch)
+        if grid is None:
+            return None
         rgb = grid @ weights[:channels] + weights[channels]
         pixels = ((rgb + 1.0) * 127.5).clamp(0, 255).to(torch.uint8).numpy()
         return _encode(pixels, width, height)

--- a/studio/backend/core/inference/diffusion_preview.py
+++ b/studio/backend/core/inference/diffusion_preview.py
@@ -61,9 +61,7 @@ def _scale_shift(vae: Any) -> tuple[float, float]:
 
 
 def _fit(vae: Any, channels: int, device: Any, dtype: Any, torch: Any) -> Optional[Any]:
-    noise = torch.randn(
-        _FIT_SAMPLES, channels, _FIT_GRID, _FIT_GRID, device = device, dtype = dtype
-    )
+    noise = torch.randn(_FIT_SAMPLES, channels, _FIT_GRID, _FIT_GRID, device = device, dtype = dtype)
     with torch.no_grad():
         decoded = _decoded(vae, noise)
     if decoded.ndim != 4 or decoded.shape[1] != 3:
@@ -78,7 +76,11 @@ def _fit(vae: Any, channels: int, device: Any, dtype: Any, torch: Any) -> Option
     return solution.cpu()
 
 
-def projection(vae: Any, torch: Any, logger: Any = None) -> Optional[Any]:
+def projection(
+    vae: Any,
+    torch: Any,
+    logger: Any = None,
+) -> Optional[Any]:
     cached = _projections.get(vae, False)
     if cached is not False:
         return cached

--- a/studio/backend/core/inference/diffusion_preview.py
+++ b/studio/backend/core/inference/diffusion_preview.py
@@ -46,11 +46,16 @@ def _decoded(vae: Any, latents: Any) -> Any:
 
 
 def _latent_channels(vae: Any) -> int:
-    value = getattr(getattr(vae, "config", None), "latent_channels", None)
-    try:
-        return int(value)
-    except (TypeError, ValueError):
-        return 0
+    config = getattr(vae, "config", None)
+    # Qwen-Image and Krea-2 carry no latent_channels at all; theirs is z_dim. Reading only
+    # the first name left channels at 0, so projection() cached None and those families
+    # never previewed -- the per-channel denormalization below was never even reached.
+    for name in ("latent_channels", "z_dim"):
+        try:
+            return int(getattr(config, name, None))
+        except (TypeError, ValueError):
+            continue
+    return 0
 
 
 def _channel_stats(vae: Any, channels: int, torch: Any) -> Optional[tuple[Any, Any]]:
@@ -89,7 +94,12 @@ def _to_vae_space(grid: Any, vae: Any, channels: int, torch: Any) -> Optional[An
 def _fit(vae: Any, channels: int, device: Any, dtype: Any, torch: Any) -> Optional[Any]:
     noise = torch.randn(_FIT_SAMPLES, channels, _FIT_GRID, _FIT_GRID, device = device, dtype = dtype)
     with torch.no_grad():
-        decoded = _decoded(vae, noise)
+        try:
+            decoded = _decoded(vae, noise)
+        except Exception:  # noqa: BLE001 -- 5-D decoders want an explicit frame axis
+            decoded = _decoded(vae, noise.unsqueeze(2))
+    if decoded.ndim == 5:
+        decoded = decoded[:, :, 0]
     if decoded.ndim != 4 or decoded.shape[1] != 3:
         return None
     target = torch.nn.functional.adaptive_avg_pool2d(decoded.float(), _FIT_GRID)
@@ -118,7 +128,26 @@ def projection(
         channels = _latent_channels(vae)
         if channels:
             parameter = next(vae.parameters())
-            fitted = _fit(vae, channels, parameter.device, parameter.dtype, torch)
+            # A force_upcast VAE is one the pipeline itself decodes in float32; fitting it at
+            # the loaded float16 overflows on some cards, and the cached None then disabled
+            # previews for the whole load even though the final decode would have worked.
+            # Read as a value, not through the Parameter: vae.to() mutates it in place, so
+            # restoring from parameter.dtype afterwards would restore float32 onto float32.
+            original_dtype = parameter.dtype
+            device = parameter.device
+            upcast = (
+                bool(getattr(getattr(vae, "config", None), "force_upcast", False))
+                and original_dtype != torch.float32
+            )
+            if upcast:
+                vae.to(dtype = torch.float32)
+            try:
+                fitted = _fit(
+                    vae, channels, device, torch.float32 if upcast else original_dtype, torch
+                )
+            finally:
+                if upcast:
+                    vae.to(dtype = original_dtype)
     except Exception as exc:  # noqa: BLE001 -- a preview must never break a generation
         if logger is not None:
             logger.info("diffusion.preview: projection unavailable (%s)", exc)

--- a/studio/backend/core/inference/diffusion_preview.py
+++ b/studio/backend/core/inference/diffusion_preview.py
@@ -1,0 +1,166 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Cheap latent-to-RGB thumbnails for an in-flight denoise.
+
+The projection is least-squares fitted once per VAE against a few decoded random latents,
+so no per-family colour constants are needed. Any failure disables previews for that VAE.
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+import math
+import os
+import weakref
+from typing import Any, Optional
+
+MIN_INTERVAL_S = 0.4
+MAX_EDGE_PX = 256
+
+_FIT_SAMPLES = 4
+_FIT_GRID = 16
+
+# Keyed by the VAE module itself: an id() key would collide after the module is freed.
+_projections: "weakref.WeakKeyDictionary[Any, Any]" = weakref.WeakKeyDictionary()
+
+PREVIEWS_ENV = "UNSLOTH_DIFFUSION_PREVIEWS"
+_DISABLED = ("0", "false", "off", "no")
+
+
+def previews_enabled() -> bool:
+    return os.environ.get(PREVIEWS_ENV, "1").strip().lower() not in _DISABLED
+
+
+def reset() -> None:
+    _projections.clear()
+
+
+def _decoded(vae: Any, latents: Any) -> Any:
+    out = vae.decode(latents)
+    sample = getattr(out, "sample", None)
+    if sample is not None:
+        return sample
+    return out[0] if isinstance(out, (tuple, list)) else out
+
+
+def _latent_channels(vae: Any) -> int:
+    value = getattr(getattr(vae, "config", None), "latent_channels", None)
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _scale_shift(vae: Any) -> tuple[float, float]:
+    config = getattr(vae, "config", None)
+    scaling = getattr(config, "scaling_factor", None) or 1.0
+    shift = getattr(config, "shift_factor", None) or 0.0
+    return float(scaling), float(shift)
+
+
+def _fit(vae: Any, channels: int, device: Any, dtype: Any, torch: Any) -> Optional[Any]:
+    noise = torch.randn(
+        _FIT_SAMPLES, channels, _FIT_GRID, _FIT_GRID, device = device, dtype = dtype
+    )
+    with torch.no_grad():
+        decoded = _decoded(vae, noise)
+    if decoded.ndim != 4 or decoded.shape[1] != 3:
+        return None
+    target = torch.nn.functional.adaptive_avg_pool2d(decoded.float(), _FIT_GRID)
+    lhs = noise.float().permute(0, 2, 3, 1).reshape(-1, channels)
+    lhs = torch.cat([lhs, torch.ones_like(lhs[:, :1])], dim = 1)
+    rhs = target.permute(0, 2, 3, 1).reshape(-1, 3)
+    solution = torch.linalg.lstsq(lhs, rhs).solution
+    if not bool(torch.isfinite(solution).all()):
+        return None
+    return solution.cpu()
+
+
+def projection(vae: Any, torch: Any, logger: Any = None) -> Optional[Any]:
+    cached = _projections.get(vae, False)
+    if cached is not False:
+        return cached
+    fitted = None
+    try:
+        channels = _latent_channels(vae)
+        if channels:
+            parameter = next(vae.parameters())
+            fitted = _fit(vae, channels, parameter.device, parameter.dtype, torch)
+    except Exception as exc:  # noqa: BLE001 -- a preview must never break a generation
+        if logger is not None:
+            logger.info("diffusion.preview: projection unavailable (%s)", exc)
+    _projections[vae] = fitted
+    return fitted
+
+
+def _packed_dims(sequence: int, width: int, height: int) -> Optional[tuple[int, int]]:
+    ratio = max(1, width) / max(1, height)
+    rows = max(1, round(math.sqrt(sequence / ratio)))
+    for delta in range(0, 64):
+        for candidate in (rows - delta, rows + delta):
+            if candidate >= 1 and sequence % candidate == 0:
+                return candidate, sequence // candidate
+    return None
+
+
+def _grid(latents: Any, channels: int, width: int, height: int) -> Optional[Any]:
+    if latents.ndim == 5:
+        latents = latents[:, :, 0]
+    if latents.ndim == 4:
+        return latents[0].permute(1, 2, 0)
+    if latents.ndim == 3:
+        packed = latents[0]
+        depth = int(packed.shape[-1])
+        if not channels or depth % channels:
+            return None
+        dims = _packed_dims(int(packed.shape[0]), width, height)
+        if dims is None:
+            return None
+        rows, columns = dims
+        return packed.reshape(rows, columns, channels, depth // channels).mean(-1)
+    return None
+
+
+def _encode(pixels: Any, width: int, height: int) -> str:
+    from PIL import Image
+
+    image = Image.fromarray(pixels, mode = "RGB")
+    scale = MAX_EDGE_PX / max(1, max(width, height))
+    image = image.resize(
+        (max(1, round(width * scale)), max(1, round(height * scale))), Image.BILINEAR
+    )
+    buffer = io.BytesIO()
+    image.save(buffer, format = "JPEG", quality = 72)
+    return "data:image/jpeg;base64," + base64.b64encode(buffer.getvalue()).decode("ascii")
+
+
+def render(
+    latents: Any,
+    vae: Any,
+    width: int,
+    height: int,
+    torch: Any,
+    logger: Any = None,
+) -> Optional[str]:
+    """A base64 JPEG data URL for these latents, or None when previews are unavailable."""
+    if latents is None:
+        return None
+    try:
+        weights = projection(vae, torch, logger)
+        if weights is None:
+            return None
+        channels = _latent_channels(vae)
+        grid = _grid(latents.detach(), channels, width, height)
+        if grid is None or int(grid.shape[-1]) != channels:
+            return None
+        scaling, shift = _scale_shift(vae)
+        grid = grid.float().cpu() / scaling + shift
+        rgb = grid @ weights[:channels] + weights[channels]
+        pixels = ((rgb + 1.0) * 127.5).clamp(0, 255).to(torch.uint8).numpy()
+        return _encode(pixels, width, height)
+    except Exception as exc:  # noqa: BLE001 -- a preview must never break a generation
+        if logger is not None:
+            logger.info("diffusion.preview: render skipped (%s)", exc)
+        return None

--- a/studio/backend/models/inference.py
+++ b/studio/backend/models/inference.py
@@ -3309,6 +3309,10 @@ class DiffusionGenerateProgressResponse(BaseModel):
     total_steps: int = Field(0, description = "Total denoising steps for this run")
     fraction: float = Field(0.0, description = "step / total_steps, clamped to [0,1]")
     eta_seconds: Optional[float] = Field(None, description = "Estimated seconds remaining")
+    preview: Optional[str] = Field(
+        None,
+        description = "Latest latent thumbnail as a base64 JPEG data URL; null when off",
+    )
 
 
 class DiffusionLoadProgressResponse(BaseModel):

--- a/studio/backend/tests/test_diffusion_preview.py
+++ b/studio/backend/tests/test_diffusion_preview.py
@@ -1,0 +1,136 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Unit tests for the latent preview renderer (``diffusion_preview.py``).
+
+Runs on CPU against a stub VAE whose decoder is an exact linear map, so the fitted
+projection has a known answer and the shape handling (dense, packed, video, junk) is
+exercised without any model weights."""
+
+from __future__ import annotations
+
+import base64
+
+import pytest
+import torch
+
+from core.inference import diffusion_preview as preview
+
+
+class _Config:
+    def __init__(self, channels, scaling = 1.0, shift = 0.0):
+        self.latent_channels = channels
+        self.scaling_factor = scaling
+        self.shift_factor = shift
+
+
+class _LinearVae(torch.nn.Module):
+    """A VAE whose decode is a fixed per-channel linear map to RGB, upscaled 8x."""
+
+    def __init__(self, channels = 4, scaling = 1.0, shift = 0.0):
+        super().__init__()
+        self.config = _Config(channels, scaling, shift)
+        torch.manual_seed(7)
+        self.weight = torch.nn.Parameter(torch.randn(channels, 3) * 0.3)
+
+    def decode(self, latents):
+        rgb = (latents.permute(0, 2, 3, 1) @ self.weight).permute(0, 3, 1, 2)
+        sample = torch.nn.functional.interpolate(rgb, scale_factor = 8, mode = "nearest")
+        return type("DecoderOutput", (), {"sample": sample})()
+
+
+class _BrokenVae(_LinearVae):
+    def decode(self, latents):
+        raise RuntimeError("no decoder here")
+
+
+@pytest.fixture(autouse = True)
+def _clear_cache():
+    preview.reset()
+    yield
+    preview.reset()
+
+
+def _decode_data_url(url):
+    assert url.startswith("data:image/jpeg;base64,")
+    return base64.b64decode(url.split(",", 1)[1])
+
+
+def test_projection_recovers_a_linear_decoder():
+    vae = _LinearVae()
+    fitted = preview.projection(vae, torch)
+    assert fitted is not None
+    assert fitted.shape == (5, 3)
+    assert torch.allclose(fitted[:4], vae.weight, atol = 1e-3)
+    assert torch.allclose(fitted[4], torch.zeros(3), atol = 1e-3)
+
+
+def test_projection_is_cached_per_vae():
+    vae = _LinearVae()
+    assert preview.projection(vae, torch) is preview.projection(vae, torch)
+
+
+def test_dense_latents_render_a_jpeg():
+    vae = _LinearVae()
+    url = preview.render(torch.randn(1, 4, 32, 32), vae, 512, 512, torch)
+    assert _decode_data_url(url).startswith(b"\xff\xd8")
+
+
+def test_packed_latents_render_a_jpeg():
+    vae = _LinearVae()
+    url = preview.render(torch.randn(1, 32 * 32, 16), vae, 512, 512, torch)
+    assert _decode_data_url(url).startswith(b"\xff\xd8")
+
+
+def test_packed_latents_survive_a_non_square_request():
+    vae = _LinearVae()
+    assert preview.render(torch.randn(1, 24 * 32, 16), vae, 512, 384, torch) is not None
+
+
+def test_video_latents_preview_their_first_frame():
+    vae = _LinearVae()
+    assert preview.render(torch.randn(1, 4, 5, 32, 32), vae, 512, 512, torch) is not None
+
+
+def test_the_preview_matches_the_request_aspect_ratio():
+    from PIL import Image
+    import io
+
+    vae = _LinearVae()
+    url = preview.render(torch.randn(1, 4, 24, 32), vae, 512, 384, torch)
+    image = Image.open(io.BytesIO(_decode_data_url(url)))
+    assert image.size == (preview.MAX_EDGE_PX, preview.MAX_EDGE_PX * 384 // 512)
+
+
+def test_a_broken_decoder_disables_previews_without_raising():
+    assert preview.render(torch.randn(1, 4, 32, 32), _BrokenVae(), 512, 512, torch) is None
+
+
+def test_absent_latents_render_nothing():
+    assert preview.render(None, _LinearVae(), 512, 512, torch) is None
+
+
+def test_a_channel_count_the_vae_disowns_renders_nothing():
+    assert preview.render(torch.randn(1, 7, 32, 32), _LinearVae(), 512, 512, torch) is None
+
+
+def test_an_unpackable_sequence_renders_nothing():
+    assert preview.render(torch.randn(1, 32 * 32, 15), _LinearVae(), 512, 512, torch) is None
+
+
+def test_scaling_and_shift_are_undone_before_projecting():
+    plain = _LinearVae()
+    scaled = _LinearVae(scaling = 4.0, shift = 0.5)
+    latents = torch.randn(1, 4, 16, 16)
+    assert preview.render(latents, plain, 512, 512, torch) != preview.render(
+        latents * 4.0, scaled, 512, 512, torch
+    )
+    assert preview.render(latents, plain, 512, 512, torch) == preview.render(
+        (latents - 0.5) * 4.0, scaled, 512, 512, torch
+    )
+
+
+def test_previews_can_be_disabled_by_env(monkeypatch):
+    assert preview.previews_enabled()
+    monkeypatch.setenv(preview.PREVIEWS_ENV, "0")
+    assert not preview.previews_enabled()

--- a/studio/backend/tests/test_diffusion_preview.py
+++ b/studio/backend/tests/test_diffusion_preview.py
@@ -18,7 +18,12 @@ from core.inference import diffusion_preview as preview
 
 
 class _Config:
-    def __init__(self, channels, scaling = 1.0, shift = 0.0):
+    def __init__(
+        self,
+        channels,
+        scaling = 1.0,
+        shift = 0.0,
+    ):
         self.latent_channels = channels
         self.scaling_factor = scaling
         self.shift_factor = shift
@@ -27,7 +32,12 @@ class _Config:
 class _LinearVae(torch.nn.Module):
     """A VAE whose decode is a fixed per-channel linear map to RGB, upscaled 8x."""
 
-    def __init__(self, channels = 4, scaling = 1.0, shift = 0.0):
+    def __init__(
+        self,
+        channels = 4,
+        scaling = 1.0,
+        shift = 0.0,
+    ):
         super().__init__()
         self.config = _Config(channels, scaling, shift)
         torch.manual_seed(7)

--- a/studio/backend/tests/test_diffusion_preview.py
+++ b/studio/backend/tests/test_diffusion_preview.py
@@ -175,7 +175,9 @@ def test_the_projection_solve_survives_a_backend_without_lstsq():
     NotImplementedError, and None is cached -- so every Mac generation silently got no
     preview after paying for the decode. Solving on CPU is what makes this pass."""
     if not torch.backends.mps.is_available():
-        pytest.skip("no MPS backend on this host")
+        # Hides no changed-path failure: the bug IS a missing MPS kernel, so only a host
+        # with MPS reproduces it, and every other test here covers the same solve on CPU.
+        pytest.skip(reason = "no MPS backend on this host, which is what this test needs")
     vae = _LinearVae().to("mps")
     fitted = preview.projection(vae, torch)
     assert fitted is not None, "the projection was not fitted on an MPS VAE"
@@ -212,3 +214,57 @@ def test_a_batchnorm_normalized_vae_renders_nothing():
     # FLUX.2's statistics are over patchified latents, whose channel count no longer
     # matches the config: no preview beats a miscoloured one.
     assert preview.render(torch.randn(1, 4, 16, 16), _BatchNormVae(), 512, 512, torch) is None
+
+
+class _QwenShapedVae(_LinearVae):
+    """Qwen-Image / Krea-2 shape: channels named z_dim, and a 5-D [B,C,T,H,W] decoder."""
+
+    def __init__(self, channels = 4):
+        super().__init__(channels = channels)
+        del self.config.latent_channels
+        del self.config.scaling_factor
+        del self.config.shift_factor
+        self.config.z_dim = channels
+        self.config.latents_mean = [0.10, -0.20, 0.30, -0.40][:channels]
+        self.config.latents_std = [2.0, 0.5, 1.5, 0.8][:channels]
+
+    def decode(self, latents):
+        if latents.ndim != 5:
+            raise ValueError("this decoder takes [B, C, T, H, W]")
+        out = super().decode(latents[:, :, 0])
+        return type("DecoderOutput", (), {"sample": out.sample.unsqueeze(2)})()
+
+
+class _UpcastVae(_LinearVae):
+    """An SDXL-shaped VAE: loaded in float16, but decoded in float32 by the pipeline."""
+
+    def __init__(self):
+        super().__init__()
+        self.config.force_upcast = True
+        self.half()
+
+    def decode(self, latents):
+        if latents.dtype == torch.float16:
+            raise RuntimeError("decoding this VAE in float16 overflows")
+        return super().decode(latents)
+
+
+def test_a_vae_that_names_its_channels_z_dim_still_previews():
+    # latent_channels is absent on these configs, so reading only that name left channels at
+    # 0 and projection() cached None -- Qwen-Image and Krea-2 never previewed at all.
+    vae = _QwenShapedVae()
+    assert preview._latent_channels(vae) == 4
+    assert preview.projection(vae, torch) is not None
+
+
+def test_a_five_dimensional_decoder_renders_a_jpeg():
+    vae = _QwenShapedVae()
+    url = preview.render(torch.randn(1, 4, 32, 32), vae, 512, 512, torch)
+    assert url is not None and _decode_data_url(url).startswith(b"\xff\xd8")
+
+
+def test_a_force_upcast_vae_is_fitted_in_float32_and_left_as_it_was():
+    vae = _UpcastVae()
+    assert preview.projection(vae, torch) is not None
+    # The fit must not leave the VAE upcast behind it.
+    assert next(vae.parameters()).dtype == torch.float16

--- a/studio/backend/tests/test_diffusion_preview.py
+++ b/studio/backend/tests/test_diffusion_preview.py
@@ -144,3 +144,71 @@ def test_previews_can_be_disabled_by_env(monkeypatch):
     assert preview.previews_enabled()
     monkeypatch.setenv(preview.PREVIEWS_ENV, "0")
     assert not preview.previews_enabled()
+
+
+class _PerChannelVae(_LinearVae):
+    """A VAE that normalizes each latent channel, as Qwen-Image and Krea-2 do.
+
+    Those configs carry no ``scaling_factor`` at all, so reading only the scalar pair left
+    their latents un-denormalized and their previews miscoloured."""
+
+    def __init__(self, channels = 4):
+        super().__init__(channels = channels)
+        del self.config.scaling_factor
+        del self.config.shift_factor
+        self.config.latents_mean = [0.10, -0.20, 0.30, -0.40][:channels]
+        self.config.latents_std = [2.0, 0.5, 1.5, 0.8][:channels]
+
+
+class _BatchNormVae(_LinearVae):
+    """FLUX.2 shape: normalization lives in the VAE's BatchNorm, over patchified latents."""
+
+    def __init__(self):
+        super().__init__()
+        self.bn = torch.nn.BatchNorm2d(4)
+
+
+def test_the_projection_solve_survives_a_backend_without_lstsq():
+    """The real reproduction: fit a VAE that lives on MPS.
+
+    ``torch.linalg.lstsq`` has no MPS kernel, ``projection()`` swallows the
+    NotImplementedError, and None is cached -- so every Mac generation silently got no
+    preview after paying for the decode. Solving on CPU is what makes this pass."""
+    if not torch.backends.mps.is_available():
+        pytest.skip("no MPS backend on this host")
+    vae = _LinearVae().to("mps")
+    fitted = preview.projection(vae, torch)
+    assert fitted is not None, "the projection was not fitted on an MPS VAE"
+    assert fitted.device.type == "cpu"
+    url = preview.render(torch.randn(1, 4, 32, 32, device = "mps"), vae, 512, 512, torch)
+    assert url is not None and _decode_data_url(url).startswith(b"\xff\xd8")
+
+
+def test_per_channel_statistics_are_undone_before_projecting():
+    vae = _PerChannelVae()
+    std = torch.tensor(vae.config.latents_std)
+    mean = torch.tensor(vae.config.latents_mean)
+    latents = torch.randn(1, 4, 16, 16)
+    # The denoiser-side value whose decoder-space counterpart is exactly `latents`.
+    normalized = (latents - mean.view(1, 4, 1, 1)) / std.view(1, 4, 1, 1)
+    plain = _LinearVae()
+    assert preview.render(normalized, vae, 512, 512, torch) == preview.render(
+        latents, plain, 512, 512, torch
+    )
+
+
+def test_ignoring_per_channel_statistics_would_change_the_preview():
+    # Guards the fix itself: if the scalar path were still taken for these VAEs the frame
+    # above would equal the un-denormalized one, and the assertion there could not fail.
+    vae = _PerChannelVae()
+    latents = torch.randn(1, 4, 16, 16)
+    plain = _LinearVae()
+    assert preview.render(latents, vae, 512, 512, torch) != preview.render(
+        latents, plain, 512, 512, torch
+    )
+
+
+def test_a_batchnorm_normalized_vae_renders_nothing():
+    # FLUX.2's statistics are over patchified latents, whose channel count no longer
+    # matches the config: no preview beats a miscoloured one.
+    assert preview.render(torch.randn(1, 4, 16, 16), _BatchNormVae(), 512, 512, torch) is None

--- a/studio/frontend/src/features/images/api.ts
+++ b/studio/frontend/src/features/images/api.ts
@@ -63,6 +63,8 @@ export interface DiffusionGenerateProgress {
   total_steps: number;
   fraction: number;
   eta_seconds: number | null;
+  // Latest latent thumbnail as a base64 JPEG data URL; null when previews are unavailable.
+  preview?: string | null;
 }
 
 export interface DiffusionLoadProgress {

--- a/studio/frontend/src/features/images/images-page.tsx
+++ b/studio/frontend/src/features/images/images-page.tsx
@@ -2254,7 +2254,13 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
           return;
         }
         setGenStep((prev) => {
-          if (prev && prev.step === p.step && prev.eta_seconds === p.eta_seconds) return prev;
+          if (
+            prev &&
+            prev.step === p.step &&
+            prev.eta_seconds === p.eta_seconds &&
+            prev.preview === p.preview
+          )
+            return prev;
           return p;
         });
       } catch {
@@ -4307,7 +4313,13 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
 
         <div className="relative flex min-h-[60dvh] min-w-0 flex-1 flex-col overflow-hidden @[50rem]:min-h-0">
           <div className="hover-scrollbar relative flex flex-1 items-center justify-center overflow-auto p-6 px-10 @[50rem]:pt-[60px]">
-            {selected && selectedSrc ? (
+            {busy === "generating" && genStep?.preview ? (
+              <img
+                src={genStep.preview}
+                alt="Generation preview"
+                className="max-h-full max-w-full object-contain shadow-sm"
+              />
+            ) : selected && selectedSrc ? (
               <>
                 <img
                   src={selectedSrc}
@@ -4378,7 +4390,9 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
               <div
                 className={cn(
                   "pointer-events-none absolute flex justify-center px-4",
-                  selectedSrc ? "inset-x-0 bottom-4" : "inset-0 items-center",
+                  selectedSrc || genStep?.preview
+                    ? "inset-x-0 bottom-4"
+                    : "inset-0 items-center",
                 )}
               >
                 <div className="w-72 max-w-full rounded-xl bg-background/85 p-3 shadow-lg ring-1 ring-border backdrop-blur">

--- a/studio/frontend/src/features/images/images-page.tsx
+++ b/studio/frontend/src/features/images/images-page.tsx
@@ -164,6 +164,7 @@ import {
   shouldContinueGenerating,
   shouldReportGenerateError,
 } from "./lib/generation-stop";
+import { nextProgress, previewFrame } from "./lib/generation-preview";
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import { useStagedDownload } from "@/features/hub/download-manager";
 import { DiffusionTrainPanel } from "./train/diffusion-train-panel";
@@ -1630,12 +1631,12 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
     [images, selectedId],
   );
   const selectedSrc = selected ? srcById[selected.id] : undefined;
-  // Keep the last denoise frame up until the finished image can actually render, so the viewer
-  // never drops from a near-complete preview back to a spinner.
-  const previewSrc =
-    heldPreview !== null && (busy === "generating" || (selected !== null && !selectedSrc))
-      ? heldPreview
-      : null;
+  const previewSrc = previewFrame({
+    held: heldPreview,
+    generating: busy === "generating",
+    hasSelection: selected !== null,
+    finishedLoaded: Boolean(selectedSrc),
+  });
 
   // Fetch (once) the object URL for a record's PNG; cached across remounts.
   const ensureSrc = useCallback(async (image: GalleryImage) => {
@@ -2264,17 +2265,15 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
         }
         if (p.preview) setHeldPreview(p.preview);
         setGenStep((prev) => {
-          // The persist window reports active at step 0; letting the bar fall back to "Preparing"
-          // after the last step reads as the run restarting.
-          if (prev && prev.step > 0 && p.step === 0) return prev;
+          const next = nextProgress(prev, p);
           if (
             prev &&
-            prev.step === p.step &&
-            prev.eta_seconds === p.eta_seconds &&
-            prev.preview === p.preview
+            prev.step === next.step &&
+            prev.eta_seconds === next.eta_seconds &&
+            prev.preview === next.preview
           )
             return prev;
-          return p;
+          return next;
         });
       } catch {
         // transient; keep polling

--- a/studio/frontend/src/features/images/images-page.tsx
+++ b/studio/frontend/src/features/images/images-page.tsx
@@ -2291,10 +2291,16 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
             genVisibilityListener.current = null;
           }
           if (!isMounted.current) return;
+          // Re-fetch the first page to merge images the finished run saved, and resync
+          // status. Awaited, and before going idle: a resumed run that was stopped produced
+          // nothing, and releasing its held frame depends on knowing that. Reading the cache
+          // after the load (it refreshes synchronously) is what tells the two apart.
+          const knownBefore = galleryCache.images.length;
+          await loadGallery();
+          if (!isMounted.current) return;
+          setRunProducedImage(galleryCache.images.length > knownBefore);
           setBusy(null);
           setGenStep(null);
-          // Re-fetch the first page to merge images the finished run saved, and resync status.
-          void loadGallery();
           void refreshStatus();
           return;
         }
@@ -3350,6 +3356,12 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
     const knownIds = new Set(galleryCache.images.map((image) => image.id));
     try {
       for (let i = 0; i < runs; i++) {
+        // Per attempt, not per batch. The success latch below is inside this loop, so a
+        // reset left outside it lets attempt 1's outcome speak for attempt 2; and a step
+        // count carried over from the previous attempt makes the next run's genuine step-0
+        // warmup look like the persist window, freezing the card on the old run's ETA.
+        setRunProducedImage(false);
+        setGenStep(null);
         // Stop issuing more GPU generations once the page truly unmounted (a plain tab switch
         // keeps it mounted), or once Stop was pressed: the backend cancel only reaches the denoise
         // in flight, so the remaining runs of a count > 1 request would otherwise start anyway.

--- a/studio/frontend/src/features/images/images-page.tsx
+++ b/studio/frontend/src/features/images/images-page.tsx
@@ -3422,6 +3422,9 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
           await loadGallery();
           // loadGallery refreshes the module cache synchronously, so this run's records are folded in before the next run.
           galleryCache.images.forEach((image) => knownIds.add(image.id));
+          // settleLostGeneration proved this run's record exists, so it has a handoff
+          // coming just like a normal success: the held frame must survive to meet it.
+          setRunProducedImage(true);
           setGenDone(i + 1);
           continue;
         }

--- a/studio/frontend/src/features/images/images-page.tsx
+++ b/studio/frontend/src/features/images/images-page.tsx
@@ -3279,11 +3279,19 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
       pollInFlight = true;
       try {
         const p = await getGenerateProgress();
+        if (p.preview) setHeldPreview(p.preview);
         // Skip the state update (and re-render) when nothing the bar shows moved.
         setGenStep((prev) => {
           if (!p.active) return null;
-          if (prev && prev.step === p.step && prev.eta_seconds === p.eta_seconds) return prev;
-          return p;
+          const next = nextProgress(prev, p);
+          if (
+            prev &&
+            prev.step === next.step &&
+            prev.eta_seconds === next.eta_seconds &&
+            prev.preview === next.preview
+          )
+            return prev;
+          return next;
         });
       } catch {
         // transient; keep polling

--- a/studio/frontend/src/features/images/images-page.tsx
+++ b/studio/frontend/src/features/images/images-page.tsx
@@ -1312,6 +1312,11 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
   // The image the held frame hands off to: tracked while the run owns the selection, so it
   // settles on the record the run produced and any later pick reads as a different image.
   const previewOwner = useRef<string | null>(null);
+  // Set when the user picks a gallery image mid-run, so the preview gives the viewer back.
+  const [browsingDuringRun, setBrowsingDuringRun] = useState(false);
+  // Whether the run has a record coming. False for a cancelled or failed run, which has no
+  // handoff to wait for, so its last frame must be dropped rather than held indefinitely.
+  const [runProducedImage, setRunProducedImage] = useState(true);
   const genPollTimer = useRef<ReturnType<typeof setInterval> | null>(null);
   // visibilitychange handler active while a generation poll runs: background tabs clamp setInterval, so returning fires one immediate poll.
   const genVisibilityListener = useRef<(() => void) | null>(null);
@@ -1639,6 +1644,7 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
     generating: busy === "generating",
     hasSelection: selected !== null,
     finishedLoaded: Boolean(selectedSrc),
+    browsing: browsingDuringRun,
   });
 
   // Drop the frame once its run has handed off, so a later cache miss cannot flash it back.
@@ -1648,16 +1654,24 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
       previewOwner.current = selected?.id ?? null;
       return;
     }
+    // A run resumed against an empty gallery goes idle BEFORE loadGallery brings its record
+    // in, so it ends owning nothing. Adopt the first selection to appear instead of reading
+    // it as the user picking something else, which released the frame during the very
+    // handoff the hold exists for.
+    if (previewOwner.current === null && selected) {
+      previewOwner.current = selected.id;
+    }
     if (
       releaseHeldPreview({
         held: heldPreview,
         generating,
         finishedLoaded: Boolean(selectedSrc),
         selectionMatchesRun: (selected?.id ?? null) === previewOwner.current,
+        producedImage: runProducedImage,
       })
     )
       setHeldPreview(null);
-  }, [busy, heldPreview, selected, selectedSrc]);
+  }, [busy, heldPreview, selected, selectedSrc, runProducedImage]);
 
   // Fetch (once) the object URL for a record's PNG; cached across remounts.
   const ensureSrc = useCallback(async (image: GalleryImage) => {
@@ -3280,6 +3294,10 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
     setGenDone(0);
     setGenStep(null);
     setHeldPreview(null);
+    setBrowsingDuringRun(false);
+    // Nothing produced yet. A run that ends without flipping this back -- cancelled, or
+    // failed -- has no handoff coming, so its last frame is released instead of held.
+    setRunProducedImage(false);
     // Fresh run: a Stop from the PREVIOUS run must not cancel this one.
     cancelRequested.current = false;
     cancelAcked.current = false;
@@ -3416,7 +3434,10 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
         // again duplicates a React key and inflates the next page's offset, skipping a record.
         setImages((prev) => mergeGenerated(prev, res.images));
         res.images.forEach((image) => knownIds.add(image.id));
-        if (res.images[0]) setSelectedId(res.images[0].id);
+        if (res.images[0]) {
+          setSelectedId(res.images[0].id);
+          setRunProducedImage(true);
+        }
         res.images.forEach((image) => void ensureSrc(image));
         setGenDone(i + 1);
       }
@@ -4482,7 +4503,10 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
                 >
                   <button
                     type="button"
-                    onClick={() => setSelectedId(image.id)}
+                    onClick={() => {
+                      setSelectedId(image.id);
+                      if (busy === "generating") setBrowsingDuringRun(true);
+                    }}
                     className="relative size-full overflow-hidden rounded-[10px] bg-muted/40 outline-none ring-1 ring-transparent transition-shadow hover:ring-border focus-visible:ring-2 focus-visible:ring-ring"
                   >
                     {srcById[image.id] ? (

--- a/studio/frontend/src/features/images/images-page.tsx
+++ b/studio/frontend/src/features/images/images-page.tsx
@@ -164,7 +164,7 @@ import {
   shouldContinueGenerating,
   shouldReportGenerateError,
 } from "./lib/generation-stop";
-import { nextProgress, previewFrame } from "./lib/generation-preview";
+import { nextProgress, previewFrame, releaseHeldPreview } from "./lib/generation-preview";
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import { useStagedDownload } from "@/features/hub/download-manager";
 import { DiffusionTrainPanel } from "./train/diffusion-train-panel";
@@ -1309,6 +1309,9 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
   // Held past the denoise: progress reports no preview while the record persists, and the final
   // blob is still loading after that, so clearing on either would blank the viewer mid-handoff.
   const [heldPreview, setHeldPreview] = useState<string | null>(null);
+  // The image the held frame hands off to: tracked while the run owns the selection, so it
+  // settles on the record the run produced and any later pick reads as a different image.
+  const previewOwner = useRef<string | null>(null);
   const genPollTimer = useRef<ReturnType<typeof setInterval> | null>(null);
   // visibilitychange handler active while a generation poll runs: background tabs clamp setInterval, so returning fires one immediate poll.
   const genVisibilityListener = useRef<(() => void) | null>(null);
@@ -1637,6 +1640,24 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
     hasSelection: selected !== null,
     finishedLoaded: Boolean(selectedSrc),
   });
+
+  // Drop the frame once its run has handed off, so a later cache miss cannot flash it back.
+  useEffect(() => {
+    const generating = busy === "generating";
+    if (generating) {
+      previewOwner.current = selected?.id ?? null;
+      return;
+    }
+    if (
+      releaseHeldPreview({
+        held: heldPreview,
+        generating,
+        finishedLoaded: Boolean(selectedSrc),
+        selectionMatchesRun: (selected?.id ?? null) === previewOwner.current,
+      })
+    )
+      setHeldPreview(null);
+  }, [busy, heldPreview, selected, selectedSrc]);
 
   // Fetch (once) the object URL for a record's PNG; cached across remounts.
   const ensureSrc = useCallback(async (image: GalleryImage) => {

--- a/studio/frontend/src/features/images/images-page.tsx
+++ b/studio/frontend/src/features/images/images-page.tsx
@@ -1305,6 +1305,9 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
   const [genDone, setGenDone] = useState<number | null>(null);
   // Live per-step progress (step / total + ETA) polled during generation.
   const [genStep, setGenStep] = useState<DiffusionGenerateProgress | null>(null);
+  // Held past the denoise: progress reports no preview while the record persists, and the final
+  // blob is still loading after that, so clearing on either would blank the viewer mid-handoff.
+  const [heldPreview, setHeldPreview] = useState<string | null>(null);
   const genPollTimer = useRef<ReturnType<typeof setInterval> | null>(null);
   // visibilitychange handler active while a generation poll runs: background tabs clamp setInterval, so returning fires one immediate poll.
   const genVisibilityListener = useRef<(() => void) | null>(null);
@@ -1627,6 +1630,12 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
     [images, selectedId],
   );
   const selectedSrc = selected ? srcById[selected.id] : undefined;
+  // Keep the last denoise frame up until the finished image can actually render, so the viewer
+  // never drops from a near-complete preview back to a spinner.
+  const previewSrc =
+    heldPreview !== null && (busy === "generating" || (selected !== null && !selectedSrc))
+      ? heldPreview
+      : null;
 
   // Fetch (once) the object URL for a record's PNG; cached across remounts.
   const ensureSrc = useCallback(async (image: GalleryImage) => {
@@ -2253,7 +2262,11 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
           void refreshStatus();
           return;
         }
+        if (p.preview) setHeldPreview(p.preview);
         setGenStep((prev) => {
+          // The persist window reports active at step 0; letting the bar fall back to "Preparing"
+          // after the last step reads as the run restarting.
+          if (prev && prev.step > 0 && p.step === 0) return prev;
           if (
             prev &&
             prev.step === p.step &&
@@ -2298,6 +2311,7 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
         if (g.active) {
           setBusy("generating");
           setGenStep(g);
+          if (g.preview) setHeldPreview(g.preview);
           resumeGeneratePoll();
         }
       } catch {
@@ -3245,6 +3259,7 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
     setBusy("generating");
     setGenDone(0);
     setGenStep(null);
+    setHeldPreview(null);
     // Fresh run: a Stop from the PREVIOUS run must not cancel this one.
     cancelRequested.current = false;
     cancelAcked.current = false;
@@ -4313,9 +4328,9 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
 
         <div className="relative flex min-h-[60dvh] min-w-0 flex-1 flex-col overflow-hidden @[50rem]:min-h-0">
           <div className="hover-scrollbar relative flex flex-1 items-center justify-center overflow-auto p-6 px-10 @[50rem]:pt-[60px]">
-            {busy === "generating" && genStep?.preview ? (
+            {previewSrc ? (
               <img
-                src={genStep.preview}
+                src={previewSrc}
                 alt="Generation preview"
                 className="max-h-full max-w-full object-contain shadow-sm"
               />
@@ -4390,9 +4405,7 @@ export function ImagesPage({ active = true }: { active?: boolean }) {
               <div
                 className={cn(
                   "pointer-events-none absolute flex justify-center px-4",
-                  selectedSrc || genStep?.preview
-                    ? "inset-x-0 bottom-4"
-                    : "inset-0 items-center",
+                  selectedSrc || previewSrc ? "inset-x-0 bottom-4" : "inset-0 items-center",
                 )}
               >
                 <div className="w-72 max-w-full rounded-xl bg-background/85 p-3 shadow-lg ring-1 ring-border backdrop-blur">

--- a/studio/frontend/src/features/images/lib/generation-preview.ts
+++ b/studio/frontend/src/features/images/lib/generation-preview.ts
@@ -13,13 +13,18 @@ export function previewFrame(input: {
   generating: boolean;
   hasSelection: boolean;
   finishedLoaded: boolean;
+  browsing: boolean;
 }): string | null {
-  const { held, generating, hasSelection, finishedLoaded } = input;
+  const { held, generating, hasSelection, finishedLoaded, browsing } = input;
   if (held === null) {
     return null;
   }
   if (generating) {
-    return held;
+    // Browsing the gallery mid-run gives the viewer back to the picked image. Without
+    // this the preview owned the viewer for the whole denoise and clicking a thumbnail
+    // changed only the highlight, losing the ability to look at past images during a
+    // long run that the page had before previews existed.
+    return browsing ? null : held;
   }
   return hasSelection && !finishedLoaded ? held : null;
 }
@@ -45,10 +50,18 @@ export function releaseHeldPreview(input: {
   generating: boolean;
   finishedLoaded: boolean;
   selectionMatchesRun: boolean;
+  producedImage: boolean;
 }): boolean {
-  const { held, generating, finishedLoaded, selectionMatchesRun } = input;
+  const { held, generating, finishedLoaded, selectionMatchesRun, producedImage } = input;
   if (held === null || generating) {
     return false;
+  }
+  // A cancelled or failed run has no image coming, so neither release condition below can
+  // ever be met: the selection keeps matching the run and no blob ever loads. Left alone
+  // the last frame sits over an unrelated gallery image for as long as that blob is
+  // missing -- forever, if its fetch fails.
+  if (!producedImage) {
+    return true;
   }
   return finishedLoaded || !selectionMatchesRun;
 }

--- a/studio/frontend/src/features/images/lib/generation-preview.ts
+++ b/studio/frontend/src/features/images/lib/generation-preview.ts
@@ -33,3 +33,22 @@ export function nextProgress<T extends { step: number }>(
     ? previous
     : incoming;
 }
+
+/** Whether the held frame has finished its handoff and must be dropped.
+ *
+ * The frame belongs to the run that produced it. Holding it past that run leaves it able to
+ * cover an unrelated gallery image whose blob has not loaded -- an eviction from the blob
+ * budget, or a page of results still streaming -- which shows the previous run's preview
+ * where a different image belongs. */
+export function releaseHeldPreview(input: {
+  held: string | null;
+  generating: boolean;
+  finishedLoaded: boolean;
+  selectionMatchesRun: boolean;
+}): boolean {
+  const { held, generating, finishedLoaded, selectionMatchesRun } = input;
+  if (held === null || generating) {
+    return false;
+  }
+  return finishedLoaded || !selectionMatchesRun;
+}

--- a/studio/frontend/src/features/images/lib/generation-preview.ts
+++ b/studio/frontend/src/features/images/lib/generation-preview.ts
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+/** What the viewer shows during and just after a generation, kept out of the page so it is testable.
+ *
+ * A run ends in three stages, not one: the denoise stops, the record persists (progress still
+ * reports active, now with no preview and step back at 0), then the finished PNG loads. Reading
+ * either signal straight off the live progress drops the viewer to a spinner between them. */
+
+/** The preview frame to show, or null to fall through to the finished image / spinner. */
+export function previewFrame(input: {
+  held: string | null;
+  generating: boolean;
+  hasSelection: boolean;
+  finishedLoaded: boolean;
+}): string | null {
+  const { held, generating, hasSelection, finishedLoaded } = input;
+  if (held === null) {
+    return null;
+  }
+  if (generating) {
+    return held;
+  }
+  return hasSelection && !finishedLoaded ? held : null;
+}
+
+/** The progress reading to render, ignoring the step-0 report the persist window emits. */
+export function nextProgress<T extends { step: number }>(
+  previous: T | null,
+  incoming: T,
+): T {
+  return previous && previous.step > 0 && incoming.step === 0
+    ? previous
+    : incoming;
+}

--- a/studio/frontend/tests/images-generation-preview.test.ts
+++ b/studio/frontend/tests/images-generation-preview.test.ts
@@ -17,6 +17,7 @@ import { fileURLToPath } from "node:url";
 import {
   nextProgress,
   previewFrame,
+  releaseHeldPreview,
 } from "../src/features/images/lib/generation-preview.ts";
 
 const FRAME_A = "data:image/jpeg;base64,AAAA";
@@ -193,4 +194,118 @@ test("every progress poll that drives the bar also drives the preview", () => {
       "a poll drives the progress bar but hands the viewer no preview",
     );
   }
+});
+
+// The frame is held past the denoise so the handoff to the finished image never blanks. Holding
+// it any longer is its own bug: the gallery blob cache has a byte budget and evicts, and a newly
+// loaded page of results streams its blobs in, so "selected but not loaded yet" is an ordinary
+// state long after a run. Reaching it with a frame still held painted the previous run's preview
+// over whichever image the user had just clicked.
+
+test("the frame is released once the run's own image is up", () => {
+  assert.equal(
+    releaseHeldPreview({
+      held: FRAME_B,
+      generating: false,
+      finishedLoaded: true,
+      selectionMatchesRun: true,
+    }),
+    true,
+  );
+});
+
+test("the frame is released when the user picks a different image", () => {
+  assert.equal(
+    releaseHeldPreview({
+      held: FRAME_B,
+      generating: false,
+      finishedLoaded: false,
+      selectionMatchesRun: false,
+    }),
+    true,
+  );
+});
+
+test("the handoff itself never releases the frame", () => {
+  // Denoise done, record persisting, blob not in yet: exactly what the hold exists for.
+  assert.equal(
+    releaseHeldPreview({
+      held: FRAME_B,
+      generating: false,
+      finishedLoaded: false,
+      selectionMatchesRun: true,
+    }),
+    false,
+  );
+  // And nothing is released mid-denoise.
+  assert.equal(
+    releaseHeldPreview({
+      held: FRAME_B,
+      generating: true,
+      finishedLoaded: false,
+      selectionMatchesRun: true,
+    }),
+    false,
+  );
+});
+
+test("there is nothing to release when no frame is held", () => {
+  assert.equal(
+    releaseHeldPreview({
+      held: null,
+      generating: false,
+      finishedLoaded: false,
+      selectionMatchesRun: false,
+    }),
+    false,
+  );
+});
+
+test("a released frame cannot cover an unrelated image", () => {
+  // Replays the reported sequence: a run finishes and hands off, then the user clicks a gallery
+  // image whose blob was evicted. Without the release the viewer showed FRAME_B for that image.
+  let held: string | null = FRAME_B;
+  const step = (state: {
+    generating: boolean;
+    finishedLoaded: boolean;
+    selectionMatchesRun: boolean;
+  }) => {
+    if (releaseHeldPreview({ held, ...state })) held = null;
+    return previewFrame({
+      held,
+      generating: state.generating,
+      hasSelection: true,
+      finishedLoaded: state.finishedLoaded,
+    });
+  };
+  // The run's image lands and takes over.
+  assert.equal(
+    step({ generating: false, finishedLoaded: true, selectionMatchesRun: true }),
+    null,
+  );
+  // A different image is selected before its blob arrives: no stale frame, just the spinner.
+  assert.equal(
+    step({ generating: false, finishedLoaded: false, selectionMatchesRun: false }),
+    null,
+  );
+  assert.equal(held, null);
+});
+
+test("the page releases the held frame rather than leaving it set", () => {
+  const page = readFileSync(
+    fileURLToPath(
+      new URL("../src/features/images/images-page.tsx", import.meta.url),
+    ),
+    "utf8",
+  );
+  assert.match(
+    page,
+    /releaseHeldPreview\(/,
+    "the page holds a preview but never releases it",
+  );
+  assert.match(
+    page,
+    /previewOwner\.current/,
+    "the release needs the run's image to tell a later pick apart",
+  );
 });

--- a/studio/frontend/tests/images-generation-preview.test.ts
+++ b/studio/frontend/tests/images-generation-preview.test.ts
@@ -30,6 +30,7 @@ test("nothing shows before the first frame arrives", () => {
       generating: true,
       hasSelection: false,
       finishedLoaded: false,
+      browsing: false,
     }),
     null,
   );
@@ -42,6 +43,7 @@ test("the latest frame shows while denoising", () => {
       generating: true,
       hasSelection: false,
       finishedLoaded: false,
+      browsing: false,
     }),
     FRAME_B,
   );
@@ -54,6 +56,7 @@ test("the frame survives the persist window, where progress reports no preview",
       generating: true,
       hasSelection: true,
       finishedLoaded: false,
+      browsing: false,
     }),
     FRAME_B,
   );
@@ -66,6 +69,7 @@ test("the frame survives the blob load, after generating has already gone false"
       generating: false,
       hasSelection: true,
       finishedLoaded: false,
+      browsing: false,
     }),
     FRAME_B,
   );
@@ -78,6 +82,7 @@ test("the finished image takes over once its blob is ready", () => {
       generating: false,
       hasSelection: true,
       finishedLoaded: true,
+      browsing: false,
     }),
     null,
   );
@@ -90,6 +95,7 @@ test("a cancelled run with nothing selected does not strand its last frame", () 
       generating: false,
       hasSelection: false,
       finishedLoaded: false,
+      browsing: false,
     }),
     null,
   );
@@ -103,36 +109,42 @@ test("the viewer never blanks across a whole run", () => {
       generating: true,
       hasSelection: false,
       finishedLoaded: false,
+      browsing: false,
     },
     {
       held: FRAME_A,
       generating: true,
       hasSelection: false,
       finishedLoaded: false,
+      browsing: false,
     },
     {
       held: FRAME_B,
       generating: true,
       hasSelection: false,
       finishedLoaded: false,
+      browsing: false,
     },
     {
       held: FRAME_B,
       generating: true,
       hasSelection: true,
       finishedLoaded: false,
+      browsing: false,
     },
     {
       held: FRAME_B,
       generating: false,
       hasSelection: true,
       finishedLoaded: false,
+      browsing: false,
     },
     {
       held: FRAME_B,
       generating: false,
       hasSelection: true,
       finishedLoaded: true,
+      browsing: false,
     },
   ];
   const shown = run.map(previewFrame);
@@ -209,6 +221,7 @@ test("the frame is released once the run's own image is up", () => {
       generating: false,
       finishedLoaded: true,
       selectionMatchesRun: true,
+      producedImage: true,
     }),
     true,
   );
@@ -221,6 +234,7 @@ test("the frame is released when the user picks a different image", () => {
       generating: false,
       finishedLoaded: false,
       selectionMatchesRun: false,
+      producedImage: true,
     }),
     true,
   );
@@ -234,6 +248,7 @@ test("the handoff itself never releases the frame", () => {
       generating: false,
       finishedLoaded: false,
       selectionMatchesRun: true,
+      producedImage: true,
     }),
     false,
   );
@@ -244,6 +259,7 @@ test("the handoff itself never releases the frame", () => {
       generating: true,
       finishedLoaded: false,
       selectionMatchesRun: true,
+      producedImage: true,
     }),
     false,
   );
@@ -256,6 +272,7 @@ test("there is nothing to release when no frame is held", () => {
       generating: false,
       finishedLoaded: false,
       selectionMatchesRun: false,
+      producedImage: true,
     }),
     false,
   );
@@ -270,12 +287,13 @@ test("a released frame cannot cover an unrelated image", () => {
     finishedLoaded: boolean;
     selectionMatchesRun: boolean;
   }) => {
-    if (releaseHeldPreview({ held, ...state })) held = null;
+    if (releaseHeldPreview({ held, ...state, producedImage: true })) held = null;
     return previewFrame({
       held,
       generating: state.generating,
       hasSelection: true,
       finishedLoaded: state.finishedLoaded,
+      browsing: false,
     });
   };
   // The run's image lands and takes over.
@@ -307,5 +325,108 @@ test("the page releases the held frame rather than leaving it set", () => {
     page,
     /previewOwner\.current/,
     "the release needs the run's image to tell a later pick apart",
+  );
+});
+
+// --- browsing the gallery during a run -------------------------------------------------
+// Before previews, the viewer showed whatever thumbnail you clicked, including mid-run.
+// Returning the held frame unconditionally while generating took that away: the highlight
+// moved but the viewer kept showing the denoise.
+
+test("a mid-run gallery pick takes the viewer back from the preview", () => {
+  assert.equal(
+    previewFrame({
+      held: FRAME_B,
+      generating: true,
+      hasSelection: true,
+      finishedLoaded: true,
+      browsing: true,
+    }),
+    null,
+  );
+});
+
+test("the preview keeps the viewer while the run is not being browsed away from", () => {
+  assert.equal(
+    previewFrame({
+      held: FRAME_B,
+      generating: true,
+      hasSelection: true,
+      finishedLoaded: true,
+      browsing: false,
+    }),
+    FRAME_B,
+  );
+});
+
+// --- runs that never produce an image --------------------------------------------------
+// A cancelled or failed run satisfies neither release condition: the selection still
+// matches the run, and no blob of its own is ever coming.
+
+test("a cancelled run's frame is released rather than held forever", () => {
+  assert.equal(
+    releaseHeldPreview({
+      held: FRAME_B,
+      generating: false,
+      finishedLoaded: false,
+      selectionMatchesRun: true,
+      producedImage: false,
+    }),
+    true,
+  );
+});
+
+test("a run that did produce an image still gets its handoff", () => {
+  assert.equal(
+    releaseHeldPreview({
+      held: FRAME_B,
+      generating: false,
+      finishedLoaded: false,
+      selectionMatchesRun: true,
+      producedImage: true,
+    }),
+    false,
+  );
+});
+
+test("a cancelled run cannot leave its frame over a gallery image", () => {
+  let held: string | null = FRAME_B;
+  if (
+    releaseHeldPreview({
+      held,
+      generating: false,
+      finishedLoaded: false,
+      selectionMatchesRun: true,
+      producedImage: false,
+    })
+  )
+    held = null;
+  assert.equal(
+    previewFrame({
+      held,
+      generating: false,
+      hasSelection: true,
+      finishedLoaded: false,
+      browsing: false,
+    }),
+    null,
+    "the cancelled run's last frame must not stand in for the selected image",
+  );
+});
+
+test("the page tracks whether the run produced a record, and mid-run browsing", () => {
+  const page = readFileSync(
+    fileURLToPath(
+      new URL("../src/features/images/images-page.tsx", import.meta.url),
+    ),
+    "utf8",
+  );
+  assert.match(page, /setRunProducedImage\(/, "no record tracking for the release rule");
+  assert.match(page, /setBrowsingDuringRun\(/, "no mid-run browsing signal");
+  // The owner is adopted late, for the resume path that goes idle before its record lands.
+  assert.match(
+    page,
+    /previewOwner\.current === null && selected/,
+    "a run that ends owning nothing must adopt its first selection, not release on it",
   );
 });

--- a/studio/frontend/tests/images-generation-preview.test.ts
+++ b/studio/frontend/tests/images-generation-preview.test.ts
@@ -450,3 +450,47 @@ test("a generation whose POST response was lost still gets its handoff", () => {
     "a recovered generation must count as having produced its image",
   );
 });
+
+// --- sequential runs (Runs > 1) and resumed runs ---------------------------------------
+// Both outcome and progress belong to ONE backend run. Latching either across a batch, or
+// carrying one in from a run the page did not start, misreports the run in flight.
+
+test("each attempt in a batch resets its own outcome and progress", () => {
+  const page = readFileSync(
+    fileURLToPath(
+      new URL("../src/features/images/images-page.tsx", import.meta.url),
+    ),
+    "utf8",
+  );
+  const loop = page.indexOf("for (let i = 0; i < runs; i++)");
+  assert.ok(loop > 0, "the run loop moved");
+  const body = page.slice(loop, loop + 700);
+  assert.match(
+    body,
+    /setRunProducedImage\(false\)/,
+    "attempt 1's success would otherwise speak for a later cancelled attempt",
+  );
+  assert.match(
+    body,
+    /setGenStep\(null\)/,
+    "the previous attempt's step count would otherwise suppress the next run's step 0",
+  );
+});
+
+test("a resumed run records whether it actually produced an image", () => {
+  const page = readFileSync(
+    fileURLToPath(
+      new URL("../src/features/images/images-page.tsx", import.meta.url),
+    ),
+    "utf8",
+  );
+  const resume = page.indexOf("const knownBefore = galleryCache.images.length");
+  assert.ok(resume > 0, "the resumed-run settle moved");
+  const body = page.slice(resume, resume + 400);
+  assert.match(body, /await loadGallery\(\)/, "the outcome must be settled before going idle");
+  assert.match(
+    body,
+    /setRunProducedImage\(galleryCache\.images\.length > knownBefore\)/,
+    "a resumed run that was stopped must not read as having an image coming",
+  );
+});

--- a/studio/frontend/tests/images-generation-preview.test.ts
+++ b/studio/frontend/tests/images-generation-preview.test.ts
@@ -430,3 +430,23 @@ test("the page tracks whether the run produced a record, and mid-run browsing", 
     "a run that ends owning nothing must adopt its first selection, not release on it",
   );
 });
+
+test("a generation whose POST response was lost still gets its handoff", () => {
+  // The secure-mode tunnel caps the response near 100s, so a long run can succeed with its
+  // POST lost. settleLostGeneration then proves the record exists off the gallery. That path
+  // has an image coming just like a normal success, so it must mark the run as produced --
+  // otherwise the release rule treats it as cancelled and drops the frame mid-handoff.
+  const page = readFileSync(
+    fileURLToPath(
+      new URL("../src/features/images/images-page.tsx", import.meta.url),
+    ),
+    "utf8",
+  );
+  const recovery = page.indexOf("await settleLostGeneration(");
+  assert.ok(recovery > 0, "the lost-response recovery branch moved");
+  assert.match(
+    page.slice(recovery, recovery + 900),
+    /setRunProducedImage\(true\)/,
+    "a recovered generation must count as having produced its image",
+  );
+});

--- a/studio/frontend/tests/images-generation-preview.test.ts
+++ b/studio/frontend/tests/images-generation-preview.test.ts
@@ -10,7 +10,9 @@
 // These replay that whole sequence and assert the viewer never goes backwards.
 
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import test from "node:test";
+import { fileURLToPath } from "node:url";
 
 import {
   nextProgress,
@@ -162,4 +164,33 @@ test("step 0 still shows before the run has ticked", () => {
 test("real progress still advances the bar", () => {
   const advanced = { step: 5, total_steps: 9 };
   assert.equal(nextProgress({ step: 4, total_steps: 9 }, advanced), advanced);
+});
+
+// The page polls progress from two independent places: the resume path, and the loop
+// handleGenerate starts when you press Generate. Wiring the preview into only one of them
+// left the button path with no frames at all, which is invisible to the unit tests above
+// because the helper was fine and simply never received anything.
+test("every progress poll that drives the bar also drives the preview", () => {
+  const page = readFileSync(
+    fileURLToPath(
+      new URL("../src/features/images/images-page.tsx", import.meta.url),
+    ),
+    "utf8",
+  );
+  // Scoped to polls that render progress: settleLostGeneration also polls, but it waits out a
+  // lost POST from module scope and has no viewer state to set.
+  const driving = [...page.matchAll(/await getGenerateProgress\(\)/g)].filter(
+    (poll) => page.slice(poll.index, poll.index + 1400).includes("setGenStep("),
+  );
+  assert.ok(
+    driving.length >= 2,
+    "expected both the resume and the Generate poll",
+  );
+  for (const poll of driving) {
+    assert.match(
+      page.slice(poll.index, poll.index + 1400),
+      /setHeldPreview\(/,
+      "a poll drives the progress bar but hands the viewer no preview",
+    );
+  }
 });

--- a/studio/frontend/tests/images-generation-preview.test.ts
+++ b/studio/frontend/tests/images-generation-preview.test.ts
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// A generation ends in three stages the page sees as separate states: the denoise stops, the
+// gallery record persists (progress still reports active, now with no preview and step back at
+// 0), then the finished PNG loads. Reading the preview straight off live progress blanked the
+// viewer for the last two -- the user watched a near-complete image vanish into a spinner -- and
+// the step-0 report reset the bar to "Preparing" after the final step, reading as a restart.
+//
+// These replay that whole sequence and assert the viewer never goes backwards.
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  nextProgress,
+  previewFrame,
+} from "../src/features/images/lib/generation-preview.ts";
+
+const FRAME_A = "data:image/jpeg;base64,AAAA";
+const FRAME_B = "data:image/jpeg;base64,BBBB";
+
+test("nothing shows before the first frame arrives", () => {
+  assert.equal(
+    previewFrame({
+      held: null,
+      generating: true,
+      hasSelection: false,
+      finishedLoaded: false,
+    }),
+    null,
+  );
+});
+
+test("the latest frame shows while denoising", () => {
+  assert.equal(
+    previewFrame({
+      held: FRAME_B,
+      generating: true,
+      hasSelection: false,
+      finishedLoaded: false,
+    }),
+    FRAME_B,
+  );
+});
+
+test("the frame survives the persist window, where progress reports no preview", () => {
+  assert.equal(
+    previewFrame({
+      held: FRAME_B,
+      generating: true,
+      hasSelection: true,
+      finishedLoaded: false,
+    }),
+    FRAME_B,
+  );
+});
+
+test("the frame survives the blob load, after generating has already gone false", () => {
+  assert.equal(
+    previewFrame({
+      held: FRAME_B,
+      generating: false,
+      hasSelection: true,
+      finishedLoaded: false,
+    }),
+    FRAME_B,
+  );
+});
+
+test("the finished image takes over once its blob is ready", () => {
+  assert.equal(
+    previewFrame({
+      held: FRAME_B,
+      generating: false,
+      hasSelection: true,
+      finishedLoaded: true,
+    }),
+    null,
+  );
+});
+
+test("a cancelled run with nothing selected does not strand its last frame", () => {
+  assert.equal(
+    previewFrame({
+      held: FRAME_B,
+      generating: false,
+      hasSelection: false,
+      finishedLoaded: false,
+    }),
+    null,
+  );
+});
+
+test("the viewer never blanks across a whole run", () => {
+  // The recorded sequence: warmup, two denoise frames, persist, blob load, done.
+  const run = [
+    {
+      held: null,
+      generating: true,
+      hasSelection: false,
+      finishedLoaded: false,
+    },
+    {
+      held: FRAME_A,
+      generating: true,
+      hasSelection: false,
+      finishedLoaded: false,
+    },
+    {
+      held: FRAME_B,
+      generating: true,
+      hasSelection: false,
+      finishedLoaded: false,
+    },
+    {
+      held: FRAME_B,
+      generating: true,
+      hasSelection: true,
+      finishedLoaded: false,
+    },
+    {
+      held: FRAME_B,
+      generating: false,
+      hasSelection: true,
+      finishedLoaded: false,
+    },
+    {
+      held: FRAME_B,
+      generating: false,
+      hasSelection: true,
+      finishedLoaded: true,
+    },
+  ];
+  const shown = run.map(previewFrame);
+  assert.deepEqual(shown, [null, FRAME_A, FRAME_B, FRAME_B, FRAME_B, null]);
+  // Once a frame is up it stays up until the finished image replaces it: no null in between.
+  const first = shown.findIndex((frame) => frame !== null);
+  const last = shown.length - 1;
+  assert.ok(shown.slice(first, last).every((frame) => frame !== null));
+  assert.equal(
+    shown[last],
+    null,
+    "the finished image, not a frame, ends the run",
+  );
+});
+
+test("the persist window's step-0 report does not rewind the bar", () => {
+  const atLastStep = { step: 9, total_steps: 9 };
+  assert.equal(
+    nextProgress(atLastStep, { step: 0, total_steps: 0 }),
+    atLastStep,
+  );
+});
+
+test("step 0 still shows before the run has ticked", () => {
+  const warmup = { step: 0, total_steps: 9 };
+  assert.equal(nextProgress(null, warmup), warmup);
+  assert.equal(nextProgress({ step: 0, total_steps: 9 }, warmup), warmup);
+});
+
+test("real progress still advances the bar", () => {
+  const advanced = { step: 5, total_steps: 9 };
+  assert.equal(nextProgress({ step: 4, total_steps: 9 }, advanced), advanced);
+});


### PR DESCRIPTION
Right now you only see a percentage bar while an image generates. This shows the image as it forms, blurry at first and sharper each step.

The colours are worked out per model the first time it runs, by decoding a few random latents and fitting a small matrix. Nothing is hardcoded per family. It sends the preview on the progress endpoint the page already polls.

Works on GPU and Mac. Skipped on CPU only machines, on MiniMax-H3, and on pipelines that don't expose latents in the callback. If anything fails the preview switches off and the generation carries on. UNSLOTH_DIFFUSION_PREVIEWS=0
disables it.

Checked the colour fit against madebyollin/taesd: 0.90 correlation with the real decode, stable across seeds. 13 backend tests, 10 frontend tests.