### PR TITLE
Studio: render MCP images returned as embedded resources

### DIFF
--- a/studio/backend/core/inference/mcp_client.py
+++ b/studio/backend/core/inference/mcp_client.py
@@ -8,6 +8,7 @@ import atexit
 import concurrent.futures
 import hashlib
 import json
+import mimetypes
 import os
 import shlex
 import shutil
@@ -1027,6 +1028,7 @@ def _block_link(block: Any) -> Optional[str]:
 
 # fastmcp File(data=..., format=...) labels payloads as application/<format>
 _IMAGE_SUBTYPES = {
+    "apng": "image/apng",
     "png": "image/png",
     "jpeg": "image/jpeg",
     "jpg": "image/jpeg",
@@ -1036,6 +1038,7 @@ _IMAGE_SUBTYPES = {
     "avif": "image/avif",
     "tif": "image/tiff",
     "tiff": "image/tiff",
+    "ico": "image/vnd.microsoft.icon",
     "svg": "image/svg+xml",
     "svg+xml": "image/svg+xml",
 }
@@ -1049,7 +1052,11 @@ def _image_mime(mime: Any) -> Optional[str]:
     if essence.startswith("image/"):
         return essence
     subtype = essence[len("application/") :] if essence.startswith("application/") else ""
-    return _IMAGE_SUBTYPES.get(subtype)
+    mapped = _IMAGE_SUBTYPES.get(subtype)
+    if mapped:
+        return mapped
+    inferred, _ = mimetypes.guess_type(f"file:///image.{subtype}", strict = False)
+    return inferred if inferred and inferred.startswith("image/") else None
 
 
 def _block_image(block: Any) -> Optional[tuple[str, str]]:
@@ -1062,6 +1069,9 @@ def _block_image(block: Any) -> Optional[tuple[str, str]]:
             return None
         data = getattr(resource, "blob", None)
         mime = getattr(resource, "mimeType", None)
+        if not mime:
+            uri = getattr(resource, "uri", None)
+            mime = mimetypes.guess_type(str(uri), strict = False)[0] if uri else None
     mime = _image_mime(mime)
     if data and mime:
         return str(data), mime

--- a/studio/backend/core/inference/mcp_client.py
+++ b/studio/backend/core/inference/mcp_client.py
@@ -1046,10 +1046,12 @@ _IMAGE_SUBTYPES = {
 def _image_mime(mime: Any) -> Optional[str]:
     if not isinstance(mime, str):
         return None
-    if mime.startswith("image/"):
-        return mime
-    subtype = mime.partition(";")[0].strip().lower()
-    subtype = subtype[len("application/") :] if subtype.startswith("application/") else ""
+    # Type and subtype are case-insensitive (RFC 9110 8.3.1), and the parameters
+    # are not part of what the data: URL needs, so both forms match on essence.
+    essence = mime.partition(";")[0].strip().lower()
+    if essence.startswith("image/"):
+        return essence
+    subtype = essence[len("application/") :] if essence.startswith("application/") else ""
     return _IMAGE_SUBTYPES.get(subtype)
 
 

--- a/studio/backend/core/inference/mcp_client.py
+++ b/studio/backend/core/inference/mcp_client.py
@@ -1017,8 +1017,7 @@ def _block_text(block: Any) -> Optional[str]:
 
 
 def _block_link(block: Any) -> Optional[str]:
-    # Kept apart from _block_text: this line is the host's own filler, so it must
-    # not pass for server text and suppress the structured_content fallback.
+    # keep host-generated link text from suppressing structured_content
     uri = getattr(block, "uri", None)
     if uri and getattr(block, "type", None) == "resource_link":
         name = getattr(block, "name", None)
@@ -1026,10 +1025,7 @@ def _block_link(block: Any) -> Optional[str]:
     return None
 
 
-# FastMCP's File helper labels raw bytes f"application/{format}", so an image
-# handed to it as File(data = ..., format = "png") arrives as "application/png".
-# The frontend renders these through data:<mimeType>;base64, which no browser
-# draws for an application/* type, so the subtype is mapped back to a real one.
+# fastmcp File(data=..., format=...) labels payloads as application/<format>
 _IMAGE_SUBTYPES = {
     "png": "image/png",
     "jpeg": "image/jpeg",
@@ -1038,7 +1034,9 @@ _IMAGE_SUBTYPES = {
     "webp": "image/webp",
     "bmp": "image/bmp",
     "avif": "image/avif",
+    "tif": "image/tiff",
     "tiff": "image/tiff",
+    "svg": "image/svg+xml",
     "svg+xml": "image/svg+xml",
 }
 
@@ -1046,8 +1044,7 @@ _IMAGE_SUBTYPES = {
 def _image_mime(mime: Any) -> Optional[str]:
     if not isinstance(mime, str):
         return None
-    # Type and subtype are case-insensitive (RFC 9110 8.3.1), and the parameters
-    # are not part of what the data: URL needs, so both forms match on essence.
+    # media type names are case-insensitive; data urls need only the essence
     essence = mime.partition(";")[0].strip().lower()
     if essence.startswith("image/"):
         return essence
@@ -1056,8 +1053,7 @@ def _image_mime(mime: Any) -> Optional[str]:
 
 
 def _block_image(block: Any) -> Optional[tuple[str, str]]:
-    # An image arrives either as ImageContent (data/mimeType) or as an
-    # EmbeddedResource wrapping BlobResourceContents (resource.blob/mimeType).
+    # embedded resources keep binary data on resource.blob
     data = getattr(block, "data", None)
     mime = getattr(block, "mimeType", None)
     if not data:

--- a/studio/backend/core/inference/mcp_client.py
+++ b/studio/backend/core/inference/mcp_client.py
@@ -1013,6 +1013,12 @@ def _block_text(block: Any) -> Optional[str]:
     if resource is not None:
         text = getattr(resource, "text", None)
         return str(text) if text else None
+    return None
+
+
+def _block_link(block: Any) -> Optional[str]:
+    # Kept apart from _block_text: this line is the host's own filler, so it must
+    # not pass for server text and suppress the structured_content fallback.
     uri = getattr(block, "uri", None)
     if uri and getattr(block, "type", None) == "resource_link":
         name = getattr(block, "name", None)
@@ -1040,11 +1046,17 @@ def _flatten_result(result: Any) -> str:
     parts = []
     images = []
     omitted = 0
+    has_text = False
     budget = MAX_IMAGE_PAYLOAD_CHARS
     for block in getattr(result, "content", None) or []:
         text = _block_text(block)
         if text:
             parts.append(text)
+            has_text = True
+            continue
+        link = _block_link(block)
+        if link:
+            parts.append(link)
             continue
         image = _block_image(block)
         if image is not None:
@@ -1055,9 +1067,10 @@ def _flatten_result(result: Any) -> str:
             budget -= len(data)
             images.append({"data": data, "mimeType": mime})
     body = "\n".join(parts)
-    if not body:
+    if not has_text:
         structured = getattr(result, "structured_content", None)
-        body = str(structured) if structured is not None else ""
+        if structured is not None:
+            body = f"{structured}\n{body}" if body else str(structured)
     if images or omitted:
         notes = []
         if images:

--- a/studio/backend/core/inference/mcp_client.py
+++ b/studio/backend/core/inference/mcp_client.py
@@ -1076,8 +1076,11 @@ def _image_mime(mime: Any) -> Optional[str]:
     else:
         subtype = essence[len("application/") :] if essence.startswith("application/") else ""
         resolved = _IMAGE_SUBTYPES.get(subtype) or _uri_mime(f"file:///image.{subtype}")
-    # one gate for every branch: an image type the frontend can actually put in a URL
-    return resolved if resolved and _MEDIA_TYPE.match(resolved) else None
+    # one gate for every branch: an image type the frontend can actually put in a URL.
+    # Lowercased again because a registry-derived answer carries the host's spelling:
+    # Windows returns image/JXL for .jxl, where Linux and macOS return image/jxl.
+    resolved = resolved.lower() if resolved else ""
+    return resolved if _MEDIA_TYPE.match(resolved) else None
 
 
 def _resource_mime(obj: Any) -> Any:

--- a/studio/backend/core/inference/mcp_client.py
+++ b/studio/backend/core/inference/mcp_client.py
@@ -10,6 +10,7 @@ import hashlib
 import json
 import mimetypes
 import os
+import re
 import shlex
 import shutil
 import sys
@@ -18,6 +19,7 @@ import time
 import uuid
 from functools import wraps
 from typing import Any, Optional
+from urllib.parse import urlsplit, urlunsplit
 from weakref import WeakKeyDictionary
 
 from loggers import get_logger
@@ -1044,34 +1046,60 @@ _IMAGE_SUBTYPES = {
 }
 
 
+# What may be interpolated into data:<type>;base64,... by tool-fallback.tsx: an
+# RFC 9110 8.3.1 token subtype, minus "*", which names a range and never a payload.
+_MEDIA_TYPE = re.compile(r"^image/[a-z0-9][a-z0-9!#$%&'^_`|~.+-]*$")
+
+
+def _uri_mime(uri: Any) -> Optional[str]:
+    """Guess a media type from a resource URI, using only the part that names it.
+
+    A query or fragment is not part of the name, and mimetypes only stopped reading
+    them in 3.11.9 / 3.12.3 / 3.13 (CPython gh-117217). Studio supports older
+    interpreters, where 'gen.png?download=1' guessed nothing while
+    'download?name=gen.png' guessed image/png -- a dropped image and a bogus one from
+    the same defect. Both are stripped here so every interpreter agrees. The scheme
+    stays so a data: URI still resolves, and a bare host is dropped because a host
+    name is not a file name."""
+    split = urlsplit(str(uri))
+    cleaned = urlunsplit((split.scheme, split.netloc if split.path else "", split.path, "", ""))
+    return mimetypes.guess_type(cleaned, strict = False)[0]
+
+
 def _image_mime(mime: Any) -> Optional[str]:
     if not isinstance(mime, str):
         return None
     # media type names are case-insensitive; data urls need only the essence
     essence = mime.partition(";")[0].strip().lower()
     if essence.startswith("image/"):
-        return essence
-    subtype = essence[len("application/") :] if essence.startswith("application/") else ""
-    mapped = _IMAGE_SUBTYPES.get(subtype)
-    if mapped:
-        return mapped
-    inferred, _ = mimetypes.guess_type(f"file:///image.{subtype}", strict = False)
-    return inferred if inferred and inferred.startswith("image/") else None
+        resolved = essence
+    else:
+        subtype = essence[len("application/") :] if essence.startswith("application/") else ""
+        resolved = _IMAGE_SUBTYPES.get(subtype) or _uri_mime(f"file:///image.{subtype}")
+    # one gate for every branch: an image type the frontend can actually put in a URL
+    return resolved if resolved and _MEDIA_TYPE.match(resolved) else None
+
+
+def _resource_mime(obj: Any) -> Any:
+    # mcp 1.x names the attribute mimeType; mcp 2.x renames it to mime_type and keeps
+    # the camelCase spelling only as a serialization alias.
+    mime = getattr(obj, "mimeType", None)
+    return mime if mime is not None else getattr(obj, "mime_type", None)
 
 
 def _block_image(block: Any) -> Optional[tuple[str, str]]:
     # embedded resources keep binary data on resource.blob
     data = getattr(block, "data", None)
-    mime = getattr(block, "mimeType", None)
+    mime = _resource_mime(block)
     if not data:
         resource = getattr(block, "resource", None)
         if resource is None:
             return None
         data = getattr(resource, "blob", None)
-        mime = getattr(resource, "mimeType", None)
+        mime = _resource_mime(resource)
         if not mime:
             uri = getattr(resource, "uri", None)
-            mime = mimetypes.guess_type(str(uri), strict = False)[0] if uri else None
+            mime = _uri_mime(uri) if uri else None
     mime = _image_mime(mime)
     if data and mime:
         return str(data), mime

--- a/studio/backend/core/inference/mcp_client.py
+++ b/studio/backend/core/inference/mcp_client.py
@@ -1005,20 +1005,50 @@ MCP_IMAGES_SENTINEL = "__MCP_IMAGES__:"
 MAX_IMAGE_PAYLOAD_CHARS = 12_000_000
 
 
+def _block_text(block: Any) -> Optional[str]:
+    text = getattr(block, "text", None)
+    if text:
+        return str(text)
+    resource = getattr(block, "resource", None)
+    if resource is not None:
+        text = getattr(resource, "text", None)
+        return str(text) if text else None
+    uri = getattr(block, "uri", None)
+    if uri and getattr(block, "type", None) == "resource_link":
+        name = getattr(block, "name", None)
+        return f"[resource: {name} <{uri}>]" if name else f"[resource: <{uri}>]"
+    return None
+
+
+def _block_image(block: Any) -> Optional[tuple[str, str]]:
+    # An image arrives either as ImageContent (data/mimeType) or as an
+    # EmbeddedResource wrapping BlobResourceContents (resource.blob/mimeType).
+    data = getattr(block, "data", None)
+    mime = getattr(block, "mimeType", None)
+    if not data:
+        resource = getattr(block, "resource", None)
+        if resource is None:
+            return None
+        data = getattr(resource, "blob", None)
+        mime = getattr(resource, "mimeType", None)
+    if data and isinstance(mime, str) and mime.startswith("image/"):
+        return str(data), mime
+    return None
+
+
 def _flatten_result(result: Any) -> str:
     parts = []
     images = []
     omitted = 0
     budget = MAX_IMAGE_PAYLOAD_CHARS
     for block in getattr(result, "content", None) or []:
-        text = getattr(block, "text", None)
+        text = _block_text(block)
         if text:
-            parts.append(str(text))
+            parts.append(text)
             continue
-        data = getattr(block, "data", None)
-        mime = getattr(block, "mimeType", None)
-        if data and isinstance(mime, str) and mime.startswith("image/"):
-            data = str(data)
+        image = _block_image(block)
+        if image is not None:
+            data, mime = image
             if len(data) > budget:
                 omitted += 1
                 continue

--- a/studio/backend/core/inference/mcp_client.py
+++ b/studio/backend/core/inference/mcp_client.py
@@ -1046,21 +1046,19 @@ _IMAGE_SUBTYPES = {
 }
 
 
-# What may be interpolated into data:<type>;base64,... by tool-fallback.tsx: an
-# RFC 9110 8.3.1 token subtype, minus "*", which names a range and never a payload.
+# What tool-fallback.tsx may interpolate into data:<type>;base64,... : an RFC 9110
+# 8.3.1 token subtype, minus "*", which names a range and never a payload.
 _MEDIA_TYPE = re.compile(r"^image/[a-z0-9][a-z0-9!#$%&'^_`|~.+-]*$")
 
 
 def _uri_mime(uri: Any) -> Optional[str]:
-    """Guess a media type from a resource URI, using only the part that names it.
+    """Guess a media type from the part of a URI that names the resource.
 
-    A query or fragment is not part of the name, and mimetypes only stopped reading
-    them in 3.11.9 / 3.12.3 / 3.13 (CPython gh-117217). Studio supports older
-    interpreters, where 'gen.png?download=1' guessed nothing while
-    'download?name=gen.png' guessed image/png -- a dropped image and a bogus one from
-    the same defect. Both are stripped here so every interpreter agrees. The scheme
-    stays so a data: URI still resolves, and a bare host is dropped because a host
-    name is not a file name."""
+    mimetypes only stopped reading the query and fragment in 3.11.9 / 3.12.3 / 3.13
+    (CPython gh-117217), and on older supported interpreters 'gen.png?download=1'
+    guessed nothing while 'download?name=gen.png' guessed image/png. Dropping both
+    keeps every interpreter in agreement. The scheme stays so a data: URI still
+    resolves; a bare host goes, since a host name is not a file name."""
     split = urlsplit(str(uri))
     cleaned = urlunsplit((split.scheme, split.netloc if split.path else "", split.path, "", ""))
     return mimetypes.guess_type(cleaned, strict = False)[0]
@@ -1076,16 +1074,14 @@ def _image_mime(mime: Any) -> Optional[str]:
     else:
         subtype = essence[len("application/") :] if essence.startswith("application/") else ""
         resolved = _IMAGE_SUBTYPES.get(subtype) or _uri_mime(f"file:///image.{subtype}")
-    # one gate for every branch: an image type the frontend can actually put in a URL.
-    # Lowercased again because a registry-derived answer carries the host's spelling:
-    # Windows returns image/JXL for .jxl, where Linux and macOS return image/jxl.
+    # one gate for every branch. Lowercased again because a registry answer carries the
+    # host's spelling: Windows returns image/JXL for .jxl, Linux and macOS image/jxl.
     resolved = resolved.lower() if resolved else ""
     return resolved if _MEDIA_TYPE.match(resolved) else None
 
 
 def _resource_mime(obj: Any) -> Any:
-    # mcp 1.x names the attribute mimeType; mcp 2.x renames it to mime_type and keeps
-    # the camelCase spelling only as a serialization alias.
+    # mcp 2.x renames mimeType to mime_type, keeping camelCase only as an alias
     mime = getattr(obj, "mimeType", None)
     return mime if mime is not None else getattr(obj, "mime_type", None)
 

--- a/studio/backend/core/inference/mcp_client.py
+++ b/studio/backend/core/inference/mcp_client.py
@@ -1026,6 +1026,33 @@ def _block_link(block: Any) -> Optional[str]:
     return None
 
 
+# FastMCP's File helper labels raw bytes f"application/{format}", so an image
+# handed to it as File(data = ..., format = "png") arrives as "application/png".
+# The frontend renders these through data:<mimeType>;base64, which no browser
+# draws for an application/* type, so the subtype is mapped back to a real one.
+_IMAGE_SUBTYPES = {
+    "png": "image/png",
+    "jpeg": "image/jpeg",
+    "jpg": "image/jpeg",
+    "gif": "image/gif",
+    "webp": "image/webp",
+    "bmp": "image/bmp",
+    "avif": "image/avif",
+    "tiff": "image/tiff",
+    "svg+xml": "image/svg+xml",
+}
+
+
+def _image_mime(mime: Any) -> Optional[str]:
+    if not isinstance(mime, str):
+        return None
+    if mime.startswith("image/"):
+        return mime
+    subtype = mime.partition(";")[0].strip().lower()
+    subtype = subtype[len("application/") :] if subtype.startswith("application/") else ""
+    return _IMAGE_SUBTYPES.get(subtype)
+
+
 def _block_image(block: Any) -> Optional[tuple[str, str]]:
     # An image arrives either as ImageContent (data/mimeType) or as an
     # EmbeddedResource wrapping BlobResourceContents (resource.blob/mimeType).
@@ -1037,7 +1064,8 @@ def _block_image(block: Any) -> Optional[tuple[str, str]]:
             return None
         data = getattr(resource, "blob", None)
         mime = getattr(resource, "mimeType", None)
-    if data and isinstance(mime, str) and mime.startswith("image/"):
+    mime = _image_mime(mime)
+    if data and mime:
         return str(data), mime
     return None
 

--- a/studio/backend/tests/test_mcp_flatten_result.py
+++ b/studio/backend/tests/test_mcp_flatten_result.py
@@ -33,6 +33,24 @@ def _image(data: str = PNG_B64, mime: str = "image/png") -> SimpleNamespace:
     return SimpleNamespace(type = "image", data = data, mimeType = mime)
 
 
+def _blob_resource(data: str = PNG_B64, mime: str = "image/png") -> SimpleNamespace:
+    return SimpleNamespace(
+        type = "resource",
+        resource = SimpleNamespace(uri = "file:///out/gen.png", mimeType = mime, blob = data),
+    )
+
+
+def _text_resource(text: str, mime: str = "text/plain") -> SimpleNamespace:
+    return SimpleNamespace(
+        type = "resource",
+        resource = SimpleNamespace(uri = "file:///out/log.txt", mimeType = mime, text = text),
+    )
+
+
+def _resource_link(uri: str = "file:///out/gen.png", name = None) -> SimpleNamespace:
+    return SimpleNamespace(type = "resource_link", uri = uri, name = name, mimeType = "image/png")
+
+
 def _result(
     *blocks,
     is_error = False,
@@ -218,3 +236,37 @@ def test_stdio_session_call_also_passes_raise_on_error_false(monkeypatch):
     assert out.startswith("Error: boom")
     assert MCP_IMAGES_SENTINEL in out
     assert is_tool_error(out)
+
+
+def test_embedded_resource_image_is_rendered():
+    flat = _flatten_result(_result(_blob_resource()))
+    body, payload = flat.split("\n" + MCP_IMAGES_SENTINEL, 1)
+    assert body == "[1 image attached; displayed to the user]"
+    assert json.loads(payload) == [{"data": PNG_B64, "mimeType": "image/png"}]
+
+
+def test_embedded_resource_image_shares_budget_with_image_content():
+    flat = _flatten_result(_result(_text("rendered"), _image(), _blob_resource(mime = "image/webp")))
+    body, payload = flat.split("\n" + MCP_IMAGES_SENTINEL, 1)
+    assert body == "rendered\n[2 images attached; displayed to the user]"
+    assert [img["mimeType"] for img in json.loads(payload)] == ["image/png", "image/webp"]
+
+
+def test_oversized_embedded_resource_image_omitted():
+    huge = "A" * (MAX_IMAGE_PAYLOAD_CHARS + 1)
+    assert _flatten_result(_result(_blob_resource(data = huge))) == "[1 image omitted (too large)]"
+
+
+def test_embedded_text_resource_contributes_its_text():
+    assert _flatten_result(_result(_text_resource("saved to /out/gen.png"))) == "saved to /out/gen.png"
+
+
+def test_embedded_non_image_blob_still_ignored():
+    assert _flatten_result(_result(_blob_resource(mime = "application/pdf"))) == ""
+
+
+def test_resource_link_keeps_its_uri():
+    assert _flatten_result(_result(_resource_link())) == "[resource: <file:///out/gen.png>]"
+    assert _flatten_result(_result(_resource_link(name = "gen.png"))) == (
+        "[resource: gen.png <file:///out/gen.png>]"
+    )

--- a/studio/backend/tests/test_mcp_flatten_result.py
+++ b/studio/backend/tests/test_mcp_flatten_result.py
@@ -258,7 +258,9 @@ def test_oversized_embedded_resource_image_omitted():
 
 
 def test_embedded_text_resource_contributes_its_text():
-    assert _flatten_result(_result(_text_resource("saved to /out/gen.png"))) == "saved to /out/gen.png"
+    assert (
+        _flatten_result(_result(_text_resource("saved to /out/gen.png"))) == "saved to /out/gen.png"
+    )
 
 
 def test_embedded_non_image_blob_still_ignored():

--- a/studio/backend/tests/test_mcp_flatten_result.py
+++ b/studio/backend/tests/test_mcp_flatten_result.py
@@ -313,3 +313,17 @@ def test_image_content_mime_is_passed_through_unchanged():
     flat = _flatten_result(_result(_image(mime = "image/png")))
     payload = flat.split("\n" + MCP_IMAGES_SENTINEL, 1)[1]
     assert json.loads(payload) == [{"data": PNG_B64, "mimeType": "image/png"}]
+
+
+def test_mixed_case_image_mime_is_matched():
+    # Media type type/subtype are case-insensitive (RFC 9110 8.3.1).
+    for mime in ("IMAGE/PNG", "Image/Png", "image/PNG"):
+        flat = _flatten_result(_result(_blob_resource(mime = mime)))
+        payload = flat.split("\n" + MCP_IMAGES_SENTINEL, 1)[1]
+        assert json.loads(payload) == [{"data": PNG_B64, "mimeType": "image/png"}], mime
+
+
+def test_mime_parameters_are_dropped_from_the_data_url_type():
+    flat = _flatten_result(_result(_image(mime = "image/png; charset=binary")))
+    payload = flat.split("\n" + MCP_IMAGES_SENTINEL, 1)[1]
+    assert json.loads(payload) == [{"data": PNG_B64, "mimeType": "image/png"}]

--- a/studio/backend/tests/test_mcp_flatten_result.py
+++ b/studio/backend/tests/test_mcp_flatten_result.py
@@ -425,3 +425,14 @@ def test_snake_case_mime_attribute_is_read_too():
     flat = _flatten_result(_result(direct))
     payload = flat.split("\n" + MCP_IMAGES_SENTINEL, 1)[1]
     assert json.loads(payload) == [{"data": PNG_B64, "mimeType": "image/jpeg"}]
+
+
+def test_registry_case_does_not_decide_whether_an_image_survives(monkeypatch):
+    # windows answers .jxl with image/JXL where linux and macos answer image/jxl;
+    # the media type is the same one either way (RFC 9110 8.3.1)
+    monkeypatch.setattr(
+        mcp_client.mimetypes, "guess_type", lambda name, strict = True: ("image/JXL", None)
+    )
+    flat = _flatten_result(_result(_blob_resource(mime = "application/jxl")))
+    payload = flat.split("\n" + MCP_IMAGES_SENTINEL, 1)[1]
+    assert json.loads(payload) == [{"data": PNG_B64, "mimeType": "image/jxl"}]

--- a/studio/backend/tests/test_mcp_flatten_result.py
+++ b/studio/backend/tests/test_mcp_flatten_result.py
@@ -33,10 +33,14 @@ def _image(data: str = PNG_B64, mime: str = "image/png") -> SimpleNamespace:
     return SimpleNamespace(type = "image", data = data, mimeType = mime)
 
 
-def _blob_resource(data: str = PNG_B64, mime: str = "image/png") -> SimpleNamespace:
+def _blob_resource(
+    data: str = PNG_B64,
+    mime: str | None = "image/png",
+    uri: str = "file:///out/gen.png",
+) -> SimpleNamespace:
     return SimpleNamespace(
         type = "resource",
-        resource = SimpleNamespace(uri = "file:///out/gen.png", mimeType = mime, blob = data),
+        resource = SimpleNamespace(uri = uri, mimeType = mime, blob = data),
     )
 
 
@@ -294,6 +298,7 @@ def test_fastmcp_file_format_png_is_rendered():
 
 def test_application_image_subtypes_are_normalised():
     for mime, expected in (
+        ("application/apng", "image/apng"),
         ("application/jpeg", "image/jpeg"),
         ("application/jpg", "image/jpeg"),
         ("application/webp", "image/webp"),
@@ -302,12 +307,21 @@ def test_application_image_subtypes_are_normalised():
         ("application/avif", "image/avif"),
         ("application/tif", "image/tiff"),
         ("application/tiff", "image/tiff"),
+        ("application/ico", "image/vnd.microsoft.icon"),
+        ("application/heic", "image/heic"),
         ("application/svg", "image/svg+xml"),
         ("application/svg+xml", "image/svg+xml"),
     ):
         flat = _flatten_result(_result(_blob_resource(mime = mime)))
         payload = flat.split("\n" + MCP_IMAGES_SENTINEL, 1)[1]
         assert json.loads(payload) == [{"data": PNG_B64, "mimeType": expected}], mime
+
+
+def test_blob_resource_without_mime_uses_uri_extension():
+    flat = _flatten_result(_result(_blob_resource(mime = None)))
+    payload = flat.split("\n" + MCP_IMAGES_SENTINEL, 1)[1]
+    assert json.loads(payload) == [{"data": PNG_B64, "mimeType": "image/png"}]
+    assert _flatten_result(_result(_blob_resource(mime = None, uri = "file:///out/report.pdf"))) == ""
 
 
 def test_non_image_application_types_stay_ignored():

--- a/studio/backend/tests/test_mcp_flatten_result.py
+++ b/studio/backend/tests/test_mcp_flatten_result.py
@@ -285,7 +285,7 @@ def test_server_text_still_wins_over_structured_content():
 
 
 def test_fastmcp_file_format_png_is_rendered():
-    # File(data = ..., format = "png") labels the blob "application/png".
+    # fastmcp File(data=..., format="png") labels the blob application/png
     flat = _flatten_result(_result(_blob_resource(mime = "application/png")))
     body, payload = flat.split("\n" + MCP_IMAGES_SENTINEL, 1)
     assert body == "[1 image attached; displayed to the user]"
@@ -298,6 +298,12 @@ def test_application_image_subtypes_are_normalised():
         ("application/jpg", "image/jpeg"),
         ("application/webp", "image/webp"),
         ("application/GIF", "image/gif"),
+        ("application/bmp", "image/bmp"),
+        ("application/avif", "image/avif"),
+        ("application/tif", "image/tiff"),
+        ("application/tiff", "image/tiff"),
+        ("application/svg", "image/svg+xml"),
+        ("application/svg+xml", "image/svg+xml"),
     ):
         flat = _flatten_result(_result(_blob_resource(mime = mime)))
         payload = flat.split("\n" + MCP_IMAGES_SENTINEL, 1)[1]
@@ -316,7 +322,7 @@ def test_image_content_mime_is_passed_through_unchanged():
 
 
 def test_mixed_case_image_mime_is_matched():
-    # Media type type/subtype are case-insensitive (RFC 9110 8.3.1).
+    # media type names are case-insensitive
     for mime in ("IMAGE/PNG", "Image/Png", "image/PNG"):
         flat = _flatten_result(_result(_blob_resource(mime = mime)))
         payload = flat.split("\n" + MCP_IMAGES_SENTINEL, 1)[1]

--- a/studio/backend/tests/test_mcp_flatten_result.py
+++ b/studio/backend/tests/test_mcp_flatten_result.py
@@ -347,3 +347,72 @@ def test_mime_parameters_are_dropped_from_the_data_url_type():
     flat = _flatten_result(_result(_image(mime = "image/png; charset=binary")))
     payload = flat.split("\n" + MCP_IMAGES_SENTINEL, 1)[1]
     assert json.loads(payload) == [{"data": PNG_B64, "mimeType": "image/png"}]
+
+
+def test_uri_query_and_fragment_are_not_part_of_the_name():
+    # mimetypes only stopped reading the query and fragment in 3.11.9/3.12.3/3.13
+    # (CPython gh-117217); on older supported interpreters this dropped the image.
+    for uri in (
+        "file:///out/gen.png?download=1",
+        "file:///out/gen.png#preview",
+        "file:///out/gen.png?download=1#preview",
+        "https://host/out/gen.png?sig=abc123",
+    ):
+        flat = _flatten_result(_result(_blob_resource(mime = None, uri = uri)))
+        payload = flat.split("\n" + MCP_IMAGES_SENTINEL, 1)[1]
+        assert json.loads(payload) == [{"data": PNG_B64, "mimeType": "image/png"}], uri
+
+
+def test_extension_only_in_the_query_is_not_an_image():
+    # the same defect in the other direction: a blob with no image extension in its
+    # path was rendered as one purely because its query named a .png
+    for uri in ("file:///out/download?name=gen.png", "file:///out/download#gen.png"):
+        assert _flatten_result(_result(_blob_resource(mime = None, uri = uri))) == "", uri
+
+
+def test_data_uri_still_resolves_its_own_type():
+    flat = _flatten_result(
+        _result(_blob_resource(mime = None, uri = "data:image/png;base64,iVBORw0KGgo="))
+    )
+    payload = flat.split("\n" + MCP_IMAGES_SENTINEL, 1)[1]
+    assert json.loads(payload) == [{"data": PNG_B64, "mimeType": "image/png"}]
+    assert _flatten_result(
+        _result(_blob_resource(mime = None, uri = "data:application/pdf;base64,JVBERi0="))
+    ) == ""
+
+
+def test_a_bare_host_is_not_a_file_name():
+    # urlsplit puts gen.png in netloc, not path; 3.10 guessed image/png from it
+    assert _flatten_result(_result(_blob_resource(mime = None, uri = "resource://gen.png"))) == ""
+    flat = _flatten_result(_result(_blob_resource(mime = None, uri = "resource://images/gen.png")))
+    assert MCP_IMAGES_SENTINEL in flat
+
+
+def test_malformed_image_types_never_reach_the_data_url():
+    # anything that survives is interpolated into data:<type>;base64, by the frontend
+    for mime in ("image/", "image//png", "image/*", "image/<script>", 'image/png"',
+                 "image/png\nX-Injected: 1"):
+        assert _flatten_result(_result(_blob_resource(mime = mime))) == "", mime
+
+
+def test_unusual_but_valid_image_types_are_kept():
+    for mime in ("image/svg+xml", "image/vnd.microsoft.icon", "image/x-icon", "image/jp2"):
+        flat = _flatten_result(_result(_blob_resource(mime = mime)))
+        payload = flat.split("\n" + MCP_IMAGES_SENTINEL, 1)[1]
+        assert json.loads(payload) == [{"data": PNG_B64, "mimeType": mime}], mime
+
+
+def test_snake_case_mime_attribute_is_read_too():
+    # mcp 2.x renames mimeType to mime_type and keeps camelCase only as an alias
+    block = SimpleNamespace(
+        type = "resource",
+        resource = SimpleNamespace(uri = "file:///out/gen.bin", mime_type = "image/png", blob = PNG_B64),
+    )
+    flat = _flatten_result(_result(block))
+    payload = flat.split("\n" + MCP_IMAGES_SENTINEL, 1)[1]
+    assert json.loads(payload) == [{"data": PNG_B64, "mimeType": "image/png"}]
+
+    direct = SimpleNamespace(type = "image", data = PNG_B64, mime_type = "image/jpeg")
+    flat = _flatten_result(_result(direct))
+    payload = flat.split("\n" + MCP_IMAGES_SENTINEL, 1)[1]
+    assert json.loads(payload) == [{"data": PNG_B64, "mimeType": "image/jpeg"}]

--- a/studio/backend/tests/test_mcp_flatten_result.py
+++ b/studio/backend/tests/test_mcp_flatten_result.py
@@ -282,3 +282,34 @@ def test_resource_link_does_not_displace_structured_content():
 def test_server_text_still_wins_over_structured_content():
     flat = _flatten_result(_result(_resource_link(), _text("done"), structured = {"path": "/x"}))
     assert flat == "[resource: <file:///out/gen.png>]\ndone"
+
+
+def test_fastmcp_file_format_png_is_rendered():
+    # File(data = ..., format = "png") labels the blob "application/png".
+    flat = _flatten_result(_result(_blob_resource(mime = "application/png")))
+    body, payload = flat.split("\n" + MCP_IMAGES_SENTINEL, 1)
+    assert body == "[1 image attached; displayed to the user]"
+    assert json.loads(payload) == [{"data": PNG_B64, "mimeType": "image/png"}]
+
+
+def test_application_image_subtypes_are_normalised():
+    for mime, expected in (
+        ("application/jpeg", "image/jpeg"),
+        ("application/jpg", "image/jpeg"),
+        ("application/webp", "image/webp"),
+        ("application/GIF", "image/gif"),
+    ):
+        flat = _flatten_result(_result(_blob_resource(mime = mime)))
+        payload = flat.split("\n" + MCP_IMAGES_SENTINEL, 1)[1]
+        assert json.loads(payload) == [{"data": PNG_B64, "mimeType": expected}], mime
+
+
+def test_non_image_application_types_stay_ignored():
+    for mime in ("application/pdf", "application/octet-stream", "application/json"):
+        assert _flatten_result(_result(_blob_resource(mime = mime))) == "", mime
+
+
+def test_image_content_mime_is_passed_through_unchanged():
+    flat = _flatten_result(_result(_image(mime = "image/png")))
+    payload = flat.split("\n" + MCP_IMAGES_SENTINEL, 1)[1]
+    assert json.loads(payload) == [{"data": PNG_B64, "mimeType": "image/png"}]

--- a/studio/backend/tests/test_mcp_flatten_result.py
+++ b/studio/backend/tests/test_mcp_flatten_result.py
@@ -272,3 +272,13 @@ def test_resource_link_keeps_its_uri():
     assert _flatten_result(_result(_resource_link(name = "gen.png"))) == (
         "[resource: gen.png <file:///out/gen.png>]"
     )
+
+
+def test_resource_link_does_not_displace_structured_content():
+    flat = _flatten_result(_result(_resource_link(), structured = {"path": "/out/gen.png"}))
+    assert flat == "{'path': '/out/gen.png'}\n[resource: <file:///out/gen.png>]"
+
+
+def test_server_text_still_wins_over_structured_content():
+    flat = _flatten_result(_result(_resource_link(), _text("done"), structured = {"path": "/x"}))
+    assert flat == "[resource: <file:///out/gen.png>]\ndone"

--- a/studio/backend/tests/test_mcp_flatten_result.py
+++ b/studio/backend/tests/test_mcp_flatten_result.py
@@ -364,8 +364,7 @@ def test_uri_query_and_fragment_are_not_part_of_the_name():
 
 
 def test_extension_only_in_the_query_is_not_an_image():
-    # the same defect in the other direction: a blob with no image extension in its
-    # path was rendered as one purely because its query named a .png
+    # the same defect the other way: a query naming a .png made a non-image render
     for uri in ("file:///out/download?name=gen.png", "file:///out/download#gen.png"):
         assert _flatten_result(_result(_blob_resource(mime = None, uri = uri))) == "", uri
 
@@ -428,8 +427,7 @@ def test_snake_case_mime_attribute_is_read_too():
 
 
 def test_registry_case_does_not_decide_whether_an_image_survives(monkeypatch):
-    # windows answers .jxl with image/JXL where linux and macos answer image/jxl;
-    # the media type is the same one either way (RFC 9110 8.3.1)
+    # windows answers .jxl with image/JXL, linux and macos image/jxl; same type per RFC 9110
     monkeypatch.setattr(
         mcp_client.mimetypes, "guess_type", lambda name, strict = True: ("image/JXL", None)
     )

--- a/studio/backend/tests/test_mcp_flatten_result.py
+++ b/studio/backend/tests/test_mcp_flatten_result.py
@@ -376,9 +376,12 @@ def test_data_uri_still_resolves_its_own_type():
     )
     payload = flat.split("\n" + MCP_IMAGES_SENTINEL, 1)[1]
     assert json.loads(payload) == [{"data": PNG_B64, "mimeType": "image/png"}]
-    assert _flatten_result(
-        _result(_blob_resource(mime = None, uri = "data:application/pdf;base64,JVBERi0="))
-    ) == ""
+    assert (
+        _flatten_result(
+            _result(_blob_resource(mime = None, uri = "data:application/pdf;base64,JVBERi0="))
+        )
+        == ""
+    )
 
 
 def test_a_bare_host_is_not_a_file_name():
@@ -390,8 +393,14 @@ def test_a_bare_host_is_not_a_file_name():
 
 def test_malformed_image_types_never_reach_the_data_url():
     # anything that survives is interpolated into data:<type>;base64, by the frontend
-    for mime in ("image/", "image//png", "image/*", "image/<script>", 'image/png"',
-                 "image/png\nX-Injected: 1"):
+    for mime in (
+        "image/",
+        "image//png",
+        "image/*",
+        "image/<script>",
+        'image/png"',
+        "image/png\nX-Injected: 1",
+    ):
         assert _flatten_result(_result(_blob_resource(mime = mime))) == "", mime
 
 


### PR DESCRIPTION
_flatten_result only read a block's own .text and .data. MCP's EmbeddedResource puts the payload in resource.text / resource.blob, so those blocks were dropped and the tool returned an empty string with no image and no text. FastMCP's File helper emits that shape.

Adds two helpers: _block_text also reads resource.text and a resource_link's URI, _block_image also reads resource.blob. The rest of _flatten_result is unchanged, so ImageContent blocks behave exactly as before.