### PR TITLE
Studio: send the most recent chat image to vision models

### DIFF
--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -13436,16 +13436,12 @@ def _extract_content_parts(messages: list) -> tuple[str, list[dict], "Optional[s
                 elif part.type == "image_url":
                     url = part.image_url.url
                     if url.startswith("data:"):
-                        # A data URL carrying no payload is not an image, so it
-                        # must not displace a real one from an earlier turn.
+                        # A payloadless data URL is not an image, so it must not
+                        # displace a real one from an earlier turn.
                         part_b64 = url.partition(",")[2]
                         if part_b64:
-                            # Within one message the FIRST image wins, matching
-                            # findLatestUserImageBase64 (chat-adapter.ts), which
-                            # returns on the first image part of the newest user
-                            # message. This value overrides that one downstream,
-                            # so a message carrying several images must not hand
-                            # the model a different one than the UI sent.
+                            # First within a message, matching the frontend's
+                            # findLatestUserImageBase64 (chat-adapter.ts).
                             if message_image_b64 is None:
                                 message_image_b64 = part_b64
                         else:
@@ -13454,8 +13450,7 @@ def _extract_content_parts(messages: list) -> tuple[str, list[dict], "Optional[s
                             )
                     else:
                         logger.warning(f"Remote image URLs not yet supported: {url[:80]}...")
-            # Later turns win: single-image backends must see the image just
-            # attached, not the one that opened the thread.
+            # Latest message wins: send the image just attached, not the thread's first.
             if message_image_b64 is not None:
                 latest_image_b64 = message_image_b64
                 if msg.role == "user":
@@ -13473,10 +13468,8 @@ def _extract_content_parts(messages: list) -> tuple[str, list[dict], "Optional[s
             chat_message["reasoning_content"] = msg.reasoning_content
         chat_messages.append(chat_message)
 
-    # The user's own newest attachment outranks an assistant's generated image: the
-    # frontend picks the legacy image_base64 field the same way (findLatestUserImageBase64
-    # in chat-adapter.ts) and this value overrides it downstream. An assistant-only
-    # history still falls back, so such a chat keeps reaching a vision model.
+    # A user's own attachment outranks an assistant-generated one, as the frontend's
+    # legacy image_base64 field does. An assistant-only history still falls back.
     return (
         "\n\n".join(p for p in system_parts if p),
         chat_messages,

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -13429,27 +13429,37 @@ def _extract_content_parts(messages: list) -> tuple[str, list[dict], "Optional[s
         elif isinstance(msg.content, list):
             # Multimodal content parts
             text_parts: list[str] = []
+            message_image_b64: Optional[str] = None
             for part in msg.content:
                 if part.type == "text":
                     text_parts.append(part.text)
                 elif part.type == "image_url":
                     url = part.image_url.url
                     if url.startswith("data:"):
-                        # Later turns win: single-image backends must see the
-                        # image just attached, not the one that opened the thread.
                         # A data URL carrying no payload is not an image, so it
                         # must not displace a real one from an earlier turn.
                         part_b64 = url.partition(",")[2]
                         if part_b64:
-                            latest_image_b64 = part_b64
-                            if msg.role == "user":
-                                latest_user_image_b64 = part_b64
+                            # Within one message the FIRST image wins, matching
+                            # findLatestUserImageBase64 (chat-adapter.ts), which
+                            # returns on the first image part of the newest user
+                            # message. This value overrides that one downstream,
+                            # so a message carrying several images must not hand
+                            # the model a different one than the UI sent.
+                            if message_image_b64 is None:
+                                message_image_b64 = part_b64
                         else:
                             logger.warning(
                                 f"Ignoring image URL with no base64 payload: {url[:80]}..."
                             )
                     else:
                         logger.warning(f"Remote image URLs not yet supported: {url[:80]}...")
+            # Later turns win: single-image backends must see the image just
+            # attached, not the one that opened the thread.
+            if message_image_b64 is not None:
+                latest_image_b64 = message_image_b64
+                if msg.role == "user":
+                    latest_user_image_b64 = message_image_b64
             combined_text = "\n".join(text_parts) if text_parts else ""
         elif msg.role == "assistant" and msg.reasoning_content:
             # A reasoning-only turn has no visible content, but still needs a

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -13442,7 +13442,9 @@ def _extract_content_parts(messages: list) -> tuple[str, list[dict], "Optional[s
                         if part_b64:
                             latest_image_b64 = part_b64
                         else:
-                            logger.warning(f"Ignoring image URL with no base64 payload: {url[:80]}...")
+                            logger.warning(
+                                f"Ignoring image URL with no base64 payload: {url[:80]}..."
+                            )
                     else:
                         logger.warning(f"Remote image URLs not yet supported: {url[:80]}...")
             combined_text = "\n".join(text_parts) if text_parts else ""

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -13404,11 +13404,11 @@ def _extract_content_parts(messages: list) -> tuple[str, list[dict], "Optional[s
         system_prompt:  System message text (empty string if none).
         chat_messages:  Non-system messages with content flattened to strings and
                         assistant reasoning_content preserved.
-        image_base64:   Base64 of the *first* image found, or ``None``.
+        image_base64:   Base64 of the most recent image found, or ``None``.
     """
     system_parts: list[str] = []
     chat_messages: list[dict] = []
-    first_image_b64: Optional[str] = None
+    latest_image_b64: Optional[str] = None
 
     for msg in messages:
         # ── System / developer messages → extract as system_prompt ────────
@@ -13431,11 +13431,12 @@ def _extract_content_parts(messages: list) -> tuple[str, list[dict], "Optional[s
             for part in msg.content:
                 if part.type == "text":
                     text_parts.append(part.text)
-                elif part.type == "image_url" and first_image_b64 is None:
+                elif part.type == "image_url":
                     url = part.image_url.url
                     if url.startswith("data:"):
-                        # data:image/png;base64,<DATA> -> extract <DATA>
-                        first_image_b64 = url.split(",", 1)[1] if "," in url else None
+                        # Later turns win: single-image backends must see the
+                        # image just attached, not the one that opened the thread.
+                        latest_image_b64 = url.split(",", 1)[1] if "," in url else None
                     else:
                         logger.warning(f"Remote image URLs not yet supported: {url[:80]}...")
             combined_text = "\n".join(text_parts) if text_parts else ""
@@ -13451,7 +13452,7 @@ def _extract_content_parts(messages: list) -> tuple[str, list[dict], "Optional[s
             chat_message["reasoning_content"] = msg.reasoning_content
         chat_messages.append(chat_message)
 
-    return "\n\n".join(p for p in system_parts if p), chat_messages, first_image_b64
+    return "\n\n".join(p for p in system_parts if p), chat_messages, latest_image_b64
 
 
 # ── External provider proxy ──────────────────────────────────────

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -13409,6 +13409,7 @@ def _extract_content_parts(messages: list) -> tuple[str, list[dict], "Optional[s
     system_parts: list[str] = []
     chat_messages: list[dict] = []
     latest_image_b64: Optional[str] = None
+    latest_user_image_b64: Optional[str] = None
 
     for msg in messages:
         # ── System / developer messages → extract as system_prompt ────────
@@ -13441,6 +13442,8 @@ def _extract_content_parts(messages: list) -> tuple[str, list[dict], "Optional[s
                         part_b64 = url.partition(",")[2]
                         if part_b64:
                             latest_image_b64 = part_b64
+                            if msg.role == "user":
+                                latest_user_image_b64 = part_b64
                         else:
                             logger.warning(
                                 f"Ignoring image URL with no base64 payload: {url[:80]}..."
@@ -13460,7 +13463,15 @@ def _extract_content_parts(messages: list) -> tuple[str, list[dict], "Optional[s
             chat_message["reasoning_content"] = msg.reasoning_content
         chat_messages.append(chat_message)
 
-    return "\n\n".join(p for p in system_parts if p), chat_messages, latest_image_b64
+    # The user's own newest attachment outranks an assistant's generated image: the
+    # frontend picks the legacy image_base64 field the same way (findLatestUserImageBase64
+    # in chat-adapter.ts) and this value overrides it downstream. An assistant-only
+    # history still falls back, so such a chat keeps reaching a vision model.
+    return (
+        "\n\n".join(p for p in system_parts if p),
+        chat_messages,
+        latest_user_image_b64 or latest_image_b64,
+    )
 
 
 # ── External provider proxy ──────────────────────────────────────

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -13436,7 +13436,13 @@ def _extract_content_parts(messages: list) -> tuple[str, list[dict], "Optional[s
                     if url.startswith("data:"):
                         # Later turns win: single-image backends must see the
                         # image just attached, not the one that opened the thread.
-                        latest_image_b64 = url.split(",", 1)[1] if "," in url else None
+                        # A data URL carrying no payload is not an image, so it
+                        # must not displace a real one from an earlier turn.
+                        part_b64 = url.partition(",")[2]
+                        if part_b64:
+                            latest_image_b64 = part_b64
+                        else:
+                            logger.warning(f"Ignoring image URL with no base64 payload: {url[:80]}...")
                     else:
                         logger.warning(f"Remote image URLs not yet supported: {url[:80]}...")
             combined_text = "\n".join(text_parts) if text_parts else ""

--- a/studio/backend/tests/test_openai_tool_passthrough.py
+++ b/studio/backend/tests/test_openai_tool_passthrough.py
@@ -1980,10 +1980,8 @@ class TestOpenAICompatibilityHelpers:
         assert image_b64 == "GENERATED"
 
     def test_first_image_wins_within_one_message(self):
-        # The composer allows multi-select, so one turn can carry several
-        # images. findLatestUserImageBase64 (chat-adapter.ts) returns on the
-        # first image part of the newest user message, and this value overrides
-        # that one downstream, so both sides must name the same image.
+        # The composer allows multi-select, and findLatestUserImageBase64
+        # (chat-adapter.ts) names the first of them, so this must agree.
         payload = ChatCompletionRequest(
             messages = [
                 {
@@ -2044,8 +2042,7 @@ class TestOpenAICompatibilityHelpers:
         assert image_b64 == "LATER"
 
     def test_payloadless_part_does_not_claim_the_message_slot(self):
-        # An empty data URL is not an image, so the first REAL image in the
-        # message wins rather than the message contributing nothing.
+        # An empty data URL is not an image, so the first real one still wins.
         payload = ChatCompletionRequest(
             messages = [
                 {
@@ -2070,8 +2067,8 @@ class TestOpenAICompatibilityHelpers:
         assert image_b64 == "RIGHT"
 
     def test_earlier_real_image_survives_a_payloadless_opening_turn(self):
-        # The pre-PR helper latched "" from the opening turn and suppressed
-        # every later image, so the request reached the model with none.
+        # The old helper latched "" here and suppressed every later image, so
+        # the request reached the model with none.
         def turn(url):
             return {
                 "role": "user",

--- a/studio/backend/tests/test_openai_tool_passthrough.py
+++ b/studio/backend/tests/test_openai_tool_passthrough.py
@@ -1926,6 +1926,59 @@ class TestOpenAICompatibilityHelpers:
 
             assert image_b64 == "AAAA", empty_url
 
+    def test_user_attachment_outranks_assistant_generated_image(self):
+        payload = ChatCompletionRequest(
+            messages = [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "what is this?"},
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": "data:image/png;base64,USERPHOTO"},
+                        },
+                    ],
+                },
+                {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "text", "text": "here is a cartoon of it"},
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": "data:image/png;base64,GENERATED"},
+                        },
+                    ],
+                },
+                {"role": "user", "content": "what colour was the shirt?"},
+            ]
+        )
+
+        _, _, image_b64 = _extract_content_parts(payload.messages)
+
+        assert image_b64 == "USERPHOTO"
+
+    def test_assistant_only_image_is_still_returned(self):
+        payload = ChatCompletionRequest(
+            messages = [
+                {"role": "user", "content": "show me something"},
+                {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "text", "text": "here you go"},
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": "data:image/png;base64,GENERATED"},
+                        },
+                    ],
+                },
+                {"role": "user", "content": "describe it"},
+            ]
+        )
+
+        _, _, image_b64 = _extract_content_parts(payload.messages)
+
+        assert image_b64 == "GENERATED"
+
 
 # =====================================================================
 # _friendly_error — httpx transport failures

--- a/studio/backend/tests/test_openai_tool_passthrough.py
+++ b/studio/backend/tests/test_openai_tool_passthrough.py
@@ -1858,6 +1858,51 @@ class TestOpenAICompatibilityHelpers:
         assert chat_messages == [{"role": "user", "content": "hi"}]
         assert image_b64 is None
 
+    def test_latest_image_wins_over_earlier_turns(self):
+        def turn(letter):
+            return {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": f"what is {letter}?"},
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": f"data:image/png;base64,{letter}"},
+                    },
+                ],
+            }
+
+        payload = ChatCompletionRequest(
+            messages = [
+                turn("AAAA"),
+                {"role": "assistant", "content": "the first one"},
+                turn("BBBB"),
+            ]
+        )
+
+        _, _, image_b64 = _extract_content_parts(payload.messages)
+
+        assert image_b64 == "BBBB"
+
+    def test_single_image_still_returned(self):
+        payload = ChatCompletionRequest(
+            messages = [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "what is this?"},
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": "data:image/png;base64,AAAA"},
+                        },
+                    ],
+                }
+            ]
+        )
+
+        _, _, image_b64 = _extract_content_parts(payload.messages)
+
+        assert image_b64 == "AAAA"
+
 
 # =====================================================================
 # _friendly_error — httpx transport failures

--- a/studio/backend/tests/test_openai_tool_passthrough.py
+++ b/studio/backend/tests/test_openai_tool_passthrough.py
@@ -1903,6 +1903,29 @@ class TestOpenAICompatibilityHelpers:
 
         assert image_b64 == "AAAA"
 
+    def test_payloadless_later_image_keeps_earlier_one(self):
+        def turn(url):
+            return {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "what is this?"},
+                    {"type": "image_url", "image_url": {"url": url}},
+                ],
+            }
+
+        for empty_url in ("data:image/png;base64,", "data:image/png;base64"):
+            payload = ChatCompletionRequest(
+                messages = [
+                    turn("data:image/png;base64,AAAA"),
+                    {"role": "assistant", "content": "a cat"},
+                    turn(empty_url),
+                ]
+            )
+
+            _, _, image_b64 = _extract_content_parts(payload.messages)
+
+            assert image_b64 == "AAAA", empty_url
+
 
 # =====================================================================
 # _friendly_error — httpx transport failures

--- a/studio/backend/tests/test_openai_tool_passthrough.py
+++ b/studio/backend/tests/test_openai_tool_passthrough.py
@@ -1979,6 +1979,120 @@ class TestOpenAICompatibilityHelpers:
 
         assert image_b64 == "GENERATED"
 
+    def test_first_image_wins_within_one_message(self):
+        # The composer allows multi-select, so one turn can carry several
+        # images. findLatestUserImageBase64 (chat-adapter.ts) returns on the
+        # first image part of the newest user message, and this value overrides
+        # that one downstream, so both sides must name the same image.
+        payload = ChatCompletionRequest(
+            messages = [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "compare these"},
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": "data:image/png;base64,LEFT"},
+                        },
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": "data:image/png;base64,RIGHT"},
+                        },
+                    ],
+                }
+            ]
+        )
+
+        _, _, image_b64 = _extract_content_parts(payload.messages)
+
+        assert image_b64 == "LEFT"
+
+    def test_later_turn_still_wins_over_a_multi_image_turn(self):
+        # Per-message first, per-thread latest: the two rules compose.
+        payload = ChatCompletionRequest(
+            messages = [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "compare these"},
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": "data:image/png;base64,LEFT"},
+                        },
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": "data:image/png;base64,RIGHT"},
+                        },
+                    ],
+                },
+                {"role": "assistant", "content": "two cats"},
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "and this?"},
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": "data:image/png;base64,LATER"},
+                        },
+                    ],
+                },
+            ]
+        )
+
+        _, _, image_b64 = _extract_content_parts(payload.messages)
+
+        assert image_b64 == "LATER"
+
+    def test_payloadless_part_does_not_claim_the_message_slot(self):
+        # An empty data URL is not an image, so the first REAL image in the
+        # message wins rather than the message contributing nothing.
+        payload = ChatCompletionRequest(
+            messages = [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "compare these"},
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": "data:image/png;base64,"},
+                        },
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": "data:image/png;base64,RIGHT"},
+                        },
+                    ],
+                }
+            ]
+        )
+
+        _, _, image_b64 = _extract_content_parts(payload.messages)
+
+        assert image_b64 == "RIGHT"
+
+    def test_earlier_real_image_survives_a_payloadless_opening_turn(self):
+        # The pre-PR helper latched "" from the opening turn and suppressed
+        # every later image, so the request reached the model with none.
+        def turn(url):
+            return {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "what is this?"},
+                    {"type": "image_url", "image_url": {"url": url}},
+                ],
+            }
+
+        payload = ChatCompletionRequest(
+            messages = [
+                turn("data:image/png;base64,"),
+                {"role": "assistant", "content": "I cannot see an image"},
+                turn("data:image/png;base64,REAL"),
+            ]
+        )
+
+        _, _, image_b64 = _extract_content_parts(payload.messages)
+
+        assert image_b64 == "REAL"
+
 
 # =====================================================================
 # _friendly_error — httpx transport failures


### PR DESCRIPTION
Attach a second image to a chat and ask about it, and safetensors vision models describe the first image instead. Every turn after the first image is wrong until you start a new chat.

_extract_content_parts kept the first image_url it saw and skipped the rest, so the newest image never reached the model.

 These backends take one image, so send the newest instead of the oldest. GGUF is unchanged.