### PR TITLE
CI: give the overlay rail harness the vite it needs, and tighten the wildcard-host detector

### DIFF
--- a/.github/workflows/studio-ui-smoke.yml
+++ b/.github/workflows/studio-ui-smoke.yml
@@ -601,6 +601,32 @@ jobs:
               python tests/studio/playwright_update_banner_layout.py
           done
 
+      # The overlay rail harness below serves its own vite, and this job has no
+      # node_modules to serve it with. Installing Studio is not enough: setup.sh installs
+      # the frontend dev dependencies only when it has to build the frontend, and the
+      # frontend-dist cache above exists precisely to stop that build (the restore action
+      # asserts the installer reported the frontend up to date). So on a cache hit there is
+      # no vite and `npm run dev` exits 127, while a cache miss builds and passes, which is
+      # why this step looked green when it landed and red on every run since.
+      #
+      # Conditional on the binary rather than unconditional: on the cold-cache path
+      # setup.sh has already installed these, and `npm ci` would delete and refetch them.
+      - name: Frontend dev dependencies for the overlay rail harness
+        if: matrix.shard == 'banner'
+        working-directory: studio/frontend
+        run: |
+          if [ -x node_modules/.bin/vite ]; then
+            echo "vite already present from the frontend build; not reinstalling"
+          else
+            npm ci --no-fund --no-audit
+          fi
+          # A silent install is worse than a loud one: without this the next step fails as
+          # a Playwright timeout rather than as a missing toolchain.
+          if [ ! -x node_modules/.bin/vite ]; then
+            echo "::error::npm ci finished but studio/frontend/node_modules/.bin/vite is still missing"
+            exit 1
+          fi
+
       # The rail's block gutter, in the two engines this runner has that the frontend CI
       # does not. Serves its own vite rather than the Studio above it, so it needs no
       # BASE_URL and does not care what state that Studio is in; it is here only because

--- a/tests/sh/test_install_host_defaults.sh
+++ b/tests/sh/test_install_host_defaults.sh
@@ -36,9 +36,13 @@ assert_not_contains() {
     fi
 }
 
+# Anywhere on the line, not just at the start: a documented command is regularly prefixed,
+# by a shell prompt, by `sudo`, or by an inline env assignment, and
+# `UNSLOTH_STUDIO_PASSWORD=... unsloth studio -H 0.0.0.0` is the same wildcard bind as the
+# bare one. Anchoring on the line start let that shape through.
 studio_commands() {
     printf '%s\n' "$1" \
-        | awk '/^[[:space:]]*(\$[[:space:]]*)?unsloth[[:space:]]+studio([[:space:]]|$)/'
+        | awk '/(^|[[:space:]])unsloth[[:space:]]+studio([[:space:]]|$)/'
 }
 
 assert_studio_wildcard_host_state() {
@@ -58,6 +62,56 @@ assert_studio_wildcard_host_state() {
         FAIL=$((FAIL + 1))
     fi
 }
+
+assert_wildcard_detection() {
+    _label="$1"; _fixture="$2"; _expected="$3"
+    _commands=$(studio_commands "$_fixture")
+    if printf '%s\n' "$_commands" \
+        | grep -Eq '(^|[[:space:]])(-H|--host)(=|[[:space:]]+)0\.0\.0\.0([[:space:]]|$)'; then
+        _actual="present"
+    else
+        _actual="absent"
+    fi
+    if [ "$_actual" = "$_expected" ]; then
+        echo "  PASS: $_label"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: $_label (expected $_expected, detector said $_actual)"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+echo ""
+# The assertions below are only as good as the detector they share. Every negative
+# assertion in this file passes when the detector sees nothing, so a detector that quietly
+# stops matching turns the whole file green while guarding nothing. These fixtures pin what
+# it must catch and what it must not, against the shapes README commands actually take.
+echo "=== wildcard-host detector ==="
+
+assert_wildcard_detection "detector: bare wildcard bind" \
+    'unsloth studio -H 0.0.0.0' "present"
+assert_wildcard_detection "detector: long flag" \
+    'unsloth studio --host 0.0.0.0' "present"
+assert_wildcard_detection "detector: long flag with =" \
+    'unsloth studio --host=0.0.0.0' "present"
+assert_wildcard_detection "detector: trailing flags after the bind" \
+    'unsloth studio -H 0.0.0.0 -p 8888' "present"
+assert_wildcard_detection "detector: shell-prompt prefix" \
+    '$ unsloth studio -H 0.0.0.0' "present"
+assert_wildcard_detection "detector: inline env assignment prefix" \
+    "UNSLOTH_STUDIO_PASSWORD='x' unsloth studio --host=0.0.0.0" "present"
+assert_wildcard_detection "detector: indented inside a fenced block" \
+    '    unsloth studio -H 0.0.0.0' "present"
+assert_wildcard_detection "detector: loopback default is not a wildcard" \
+    'unsloth studio' "absent"
+assert_wildcard_detection "detector: an explicit loopback bind is not a wildcard" \
+    'unsloth studio -H 127.0.0.1' "absent"
+assert_wildcard_detection "detector: a longer address starting 0.0.0.0 is not the wildcard" \
+    'unsloth studio -H 0.0.0.01' "absent"
+assert_wildcard_detection "detector: another program's wildcard bind is not ours" \
+    'jupyter lab --ip 0.0.0.0' "absent"
+assert_wildcard_detection "detector: an empty window finds nothing" \
+    '' "absent"
 
 echo ""
 echo "=== install.sh launcher template ==="

--- a/tests/studio/_playwright_robust.py
+++ b/tests/studio/_playwright_robust.py
@@ -159,6 +159,35 @@ def _arm_teardown_signals() -> None:
             return
 
 
+def _require_frontend_toolchain() -> None:
+    """Fail with the cause when the frontend dev dependencies are not installed.
+
+    `npm run dev` on a tree with no `node_modules` exits 127 with `sh: 1: vite: not found`,
+    and the readiness poll then reports "vite exited with code 127", which reads as a vite
+    crash. It is not: the toolchain was never installed, and no amount of retrying or
+    port-shuffling will help. A missing toolchain and a broken one are different failures
+    and must not look the same.
+
+    This is not hypothetical. A job that installs Studio from a warm frontend-dist cache
+    never builds the frontend, so `studio/setup.sh` skips its `npm install` and there is no
+    `node_modules` for this harness to use, while the same job on a cold cache builds and
+    passes. That makes the failure look like flake instead of a missing setup step.
+    """
+    if not FRONTEND.is_dir():
+        raise RuntimeError(f"no frontend at {FRONTEND}; this harness must run from the repo")
+    binaries = FRONTEND / "node_modules" / ".bin"
+    if any((binaries / name).exists() for name in ("vite", "vite.cmd", "vite.exe", "vite.bunx")):
+        return
+    raise RuntimeError(
+        f"the frontend dev dependencies are not installed at {FRONTEND / 'node_modules'}, so "
+        f"`npm run dev` would exit 127 with 'vite: not found'.\n"
+        f"Run `npm ci` in {FRONTEND} first. In CI, a job that restores a prebuilt "
+        f"studio/frontend/dist from cache never builds the frontend, so setup.sh skips its "
+        f"npm install and this directory stays empty: such a job has to install the "
+        f"dependencies itself before running a harness that serves its own vite."
+    )
+
+
 def start_vite(port: int, *, host: str = "127.0.0.1") -> subprocess.Popen[str]:
     """Start `vite dev` on `port` in its own process group, with stdout drained.
 
@@ -169,6 +198,7 @@ def start_vite(port: int, *, host: str = "127.0.0.1") -> subprocess.Popen[str]:
         raise RuntimeError(
             f"{host}:{port} is already serving. Stop it, or move this harness with SMOKE_PORT."
         )
+    _require_frontend_toolchain()
     process_group = (
         {"creationflags": subprocess.CREATE_NEW_PROCESS_GROUP}
         if os.name == "nt"


### PR DESCRIPTION
Two CI guards, one broken since yesterday and one weaker than it looks. Both diagnosed against the runs rather than guessed at.

## The overlay rail step has never worked on a warm cache

`Overlay rail shadow gutter, other engines (Playwright)` has failed on every `studio-ui-smoke` run since #9246 added it, and passed on #9246's own run. Identical commit content, opposite result, so it reads as flake. It is not.

The harness serves its own vite through `npm run dev` in `studio/frontend`. That job never installs the frontend dev dependencies. It installs Studio, and `studio/setup.sh` installs them only when it has to build the frontend. The frontend-dist cache exists precisely to stop that build, and `frontend-dist-restore` asserts the installer reported the frontend up to date. So:

- cache miss: setup.sh builds, `node_modules` exists, the step passes
- cache hit: no `node_modules`, `npm run dev` exits 127 with `sh: 1: vite: not found`, the step fails

#9246's run logged `Cache not found for input keys: fe-dist-Linux-4b4d8135...`. The runs since log `Cache hit` for the same key.

The harness is not at fault, and neither is its use in `studio-frontend-ci.yml`, where `npm ci` has already run. Only the new step's assumption was wrong. Its comment says the step sits on that shard because "WebKit's install is already paid for", which is true of the browsers and not of the toolchain.

So the shard installs the dependencies itself, conditional on the binary rather than unconditional: on the cold-cache path setup.sh has already put them there, and `npm ci` would delete and refetch them for nothing. The step then checks the binary arrived, because a silent install would surface later as a Playwright timeout instead of a missing toolchain.

I kept the step where it is rather than moving it to `studio-frontend-ci.yml`. Moving it would trade an `npm ci` for a `playwright install firefox webkit`, and the reason the step is on this shard in the first place is that those two browsers are already there.

## start_vite now names the cause

"vite exited with code 127" reads as a vite crash. The toolchain was never installed, and no retry or port change helps. A missing toolchain and a broken one are different failures and must not look the same, so `start_vite` refuses up front with the cause and the remedy, including why a dist-cache job in particular ends up without one. This is what made the failure look like flake for a day.

## The wildcard-host detector let a real shape through

Separately, the detector added in #9623 anchored on a command at the **start** of a line:

```
/^[[:space:]]*(\$[[:space:]]*)?unsloth[[:space:]]+studio([[:space:]]|$)/
```

Documented commands are regularly prefixed, and `UNSLOTH_STUDIO_PASSWORD='x' unsloth studio --host=0.0.0.0` in the Launch section passed the guard. Confirmed by injecting it into `README.md`: exit 0 before, exit 1 now. It matches the command anywhere on the line instead.

Twelve fixtures pin the detector itself. Every negative assertion in that file passes when the detector sees nothing, so a detector that quietly stops matching turns the whole file green while guarding nothing:

```
PASS: detector: bare wildcard bind
PASS: detector: long flag
PASS: detector: long flag with =
PASS: detector: trailing flags after the bind
PASS: detector: shell-prompt prefix
PASS: detector: inline env assignment prefix
PASS: detector: indented inside a fenced block
PASS: detector: loopback default is not a wildcard
PASS: detector: an explicit loopback bind is not a wildcard
PASS: detector: a longer address starting 0.0.0.0 is not the wildcard
PASS: detector: another program's wildcard bind is not ours
PASS: detector: an empty window finds nothing
```

To be clear about #9623 itself: its rescoping was right. The README moved the `-H 0.0.0.0` opt-in out of `#### Launch` and into `#### Remote HTTPS & LAN Access` in e264bbae9, which is a better home for it, so the guard's assumption about where the text lived was the thing that was wrong, not the README. This only tightens the detector it introduced.

## Checked

`tests/sh/test_install_host_defaults.sh`: 23 passed, 0 failed on a clean tree. Mutation-tested, all four caught, and clean again afterwards:

| injected into README | before | after |
|---|---|---|
| `unsloth studio -H 0.0.0.0` in Launch | caught | caught |
| `UNSLOTH_STUDIO_PASSWORD='x' unsloth studio --host=0.0.0.0` in Launch | **missed** | caught |
| `$ unsloth studio -H 0.0.0.0` in Launch | caught | caught |
| opt-in deleted from the Studio quickstart | caught | caught |

`_require_frontend_toolchain` verified both directions: it raises on a tree with no `node_modules`, `start_vite` refuses before spawning npm, and it accepts a tree carrying `vite` or the Windows `vite.cmd`. shellcheck clean at `-S warning`, ruff clean, `bash -n` clean, and the workflow parses with the install step ordered ahead of the overlay rail step.
