### PR TITLE
Give start_vite's unit tests a toolchain, rather than weakening the refusal

### DIFF
--- a/tests/studio/test_playwright_server_lifecycle.py
+++ b/tests/studio/test_playwright_server_lifecycle.py
@@ -61,8 +61,34 @@ def posix_branch(monkeypatch, no_signals):
     monkeypatch.setattr(robust.signal, "SIGKILL", SIGKILL, raising = False)
 
 
+@pytest.fixture
+def installed_frontend(monkeypatch, tmp_path):
+    """A frontend tree that satisfies start_vite's toolchain precondition, without an install.
+
+    `start_vite` refuses up front when `studio/frontend/node_modules` carries no vite, which
+    is the whole point of #9654: a missing toolchain must not reach npm and come back as
+    "vite exited with code 127", because that reads as a vite crash rather than as a setup
+    step nobody ran. It is a precondition of the same kind as the occupied-port refusal
+    above it, and the tests below are about process-group selection and port refusal, not
+    about the toolchain, so they get a tree that has one.
+
+    Pointed at a tmp_path tree rather than stubbed out on purpose. Stubbing
+    `_require_frontend_toolchain` to a no-op would keep these tests green if the check were
+    deleted outright; a synthetic tree makes the check actually run, and
+    test_start_vite_refuses_a_tree_with_no_frontend_toolchain below pins the other
+    direction. It also keeps this file's promise that nothing here touches a real install.
+    """
+    binaries = tmp_path / "node_modules" / ".bin"
+    binaries.mkdir(parents = True)
+    (binaries / "vite").write_text("#!/bin/sh\n", encoding = "utf-8")
+    monkeypatch.setattr(robust, "FRONTEND", tmp_path)
+    return tmp_path
+
+
 @pytest.mark.parametrize("osname", ["posix", "nt"])
-def test_start_vite_picks_the_platform_process_group(monkeypatch, no_signals, osname) -> None:
+def test_start_vite_picks_the_platform_process_group(
+    monkeypatch, no_signals, installed_frontend, osname
+) -> None:
     captured: dict = {}
     monkeypatch.setattr(robust.os, "name", osname)
     monkeypatch.setattr(robust, "_port_is_taken", lambda port, host: False)
@@ -148,12 +174,59 @@ def test_teardown_tolerates_a_process_that_already_vanished(monkeypatch, posix_b
     robust.stop_process(_FakeProc())
 
 
-def test_an_occupied_port_is_refused_rather_than_measured(monkeypatch, no_signals) -> None:
+def test_an_occupied_port_is_refused_rather_than_measured(
+    monkeypatch, no_signals, installed_frontend
+) -> None:
     """--strictPort makes our vite exit, and the readiness poll would then be reading whatever
-    else holds the port. Refuse up front instead."""
+    else holds the port. Refuse up front instead.
+
+    Given a satisfied toolchain even though the port check currently runs first, so this
+    keeps asserting the port refusal specifically and not the order the two preconditions
+    happen to be written in.
+    """
     monkeypatch.setattr(robust, "_port_is_taken", lambda port, host: True)
     with pytest.raises(RuntimeError, match = "already serving"):
         robust.start_vite(5199)
+
+
+def test_start_vite_refuses_a_tree_with_no_frontend_toolchain(
+    monkeypatch, no_signals, tmp_path
+) -> None:
+    """The failure #9654 exists to name, and the reason the refusal has to be up front.
+
+    A job that installs Studio from a warm frontend-dist cache never builds the frontend, so
+    setup.sh skips its npm install and node_modules is never created. Reaching npm in that
+    state costs a spawn and returns `vite exited with code 127`, which is indistinguishable
+    from vite crashing. So the assertion is not only that it raises: it is that nothing was
+    spawned, because a refusal that lands after Popen has already lost the cause.
+    """
+    (tmp_path / "node_modules").mkdir()
+    monkeypatch.setattr(robust, "FRONTEND", tmp_path)
+    monkeypatch.setattr(robust, "_port_is_taken", lambda port, host: False)
+    spawned: list = []
+    monkeypatch.setattr(robust.subprocess, "Popen", lambda cmd, **kw: spawned.append(cmd))
+    with pytest.raises(RuntimeError, match = "dev dependencies are not installed"):
+        robust.start_vite(5199)
+    assert spawned == [], "the refusal must land before npm is spawned, or the cause is lost"
+
+
+@pytest.mark.parametrize("binary", ["vite", "vite.cmd", "vite.exe", "vite.bunx"])
+def test_the_toolchain_check_accepts_every_platform_binary(monkeypatch, tmp_path, binary) -> None:
+    """bun writes .bunx shims and npm writes .cmd/.exe on Windows, so a POSIX-only name test
+    would reject a perfectly good Windows or bun tree and send someone chasing a phantom."""
+    binaries = tmp_path / "node_modules" / ".bin"
+    binaries.mkdir(parents = True)
+    (binaries / binary).write_text("", encoding = "utf-8")
+    monkeypatch.setattr(robust, "FRONTEND", tmp_path)
+    robust._require_frontend_toolchain()
+
+
+def test_the_toolchain_check_names_a_missing_frontend_separately(monkeypatch, tmp_path) -> None:
+    """Run from outside the repo is a different mistake from run without an install, and the
+    two must not share one message."""
+    monkeypatch.setattr(robust, "FRONTEND", tmp_path / "not-a-checkout")
+    with pytest.raises(RuntimeError, match = "no frontend at"):
+        robust._require_frontend_toolchain()
 
 
 def test_readiness_gives_up_as_soon_as_our_server_dies(monkeypatch, no_signals) -> None:


### PR DESCRIPTION
`Repo tests (CPU)` is red on main at `f2fa54f8c`:

```
FAILED tests/studio/test_playwright_server_lifecycle.py::test_start_vite_picks_the_platform_process_group[posix]
FAILED tests/studio/test_playwright_server_lifecycle.py::test_start_vite_picks_the_platform_process_group[nt]
  RuntimeError: the frontend dev dependencies are not installed at .../studio/frontend/node_modules
```

Attribution is #9654, `f2fa54f8c`, which is the commit that introduced `_require_frontend_toolchain` and the string in that message. Reproduced locally on a clean checkout of `f2fa54f8c`: 2 failed, 17 passed.

## Which side is wrong

Both readings were live, so stating the one I took and why.

**The refusal is right and stays exactly as it is.** `start_vite`'s entire job is to start vite. There is no caller that reaches it without meaning to launch a dev server; the only thing in the repo that calls it with `subprocess.Popen` stubbed is a unit test. Moving the check to the point of use means moving it after the spawn, and after the spawn is precisely the state #9654 removed: `npm run dev` exits 127, the readiness poll reports `vite exited with code 127`, and a missing setup step reads as a vite crash. That cost a day of it looking like flake. Weakening or relocating it would undo the PR.

**The two tests are stale.** Three things say so:

- They exercise which process-group flag the platform gets, nothing else. `_require_frontend_toolchain` is not what they are about.
- They **already stub the sibling precondition**. `monkeypatch.setattr(robust, "_port_is_taken", lambda port, host: False)` is in both of them, because the occupied-port refusal is not what they are about either. The toolchain check is a precondition of exactly the same shape, added later, and the tests were not updated for it.
- The file's own docstring is explicit: *"Everything here is monkeypatched: no npm, no browser, no sockets bound."* A check that stats the real `studio/frontend` is a real-world dependency this file never intended to have.

So the change is entirely in the test file. `tests/studio/_playwright_robust.py` is untouched.

## A tree, not a stub

The obvious fix is `monkeypatch.setattr(robust, "_require_frontend_toolchain", lambda: None)`, and it is the wrong one: it would keep both tests green if the refusal were deleted from `start_vite` outright, which is the vacuity shape we keep finding. They get a synthetic tree instead:

```python
@pytest.fixture
def installed_frontend(monkeypatch, tmp_path):
    binaries = tmp_path / "node_modules" / ".bin"
    binaries.mkdir(parents = True)
    (binaries / "vite").write_text("#!/bin/sh\n", encoding = "utf-8")
    monkeypatch.setattr(robust, "FRONTEND", tmp_path)
```

The check runs and passes on its merits, and nothing depends on a real install. The demonstration that this is not a stub is case V6 below.

`test_an_occupied_port_is_refused_rather_than_measured` gets the same fixture. It passes on main today only because the port check happens to be written above the toolchain check; with a satisfied toolchain it asserts the port refusal itself rather than the order the two preconditions are written in.

## The refusal had no test at all

That is the other half of this. #9654's up-front refusal is the thing the PR exists for, and nothing pinned it, so it could be deleted or narrowed silently. Three tests added:

- it must reject a tree with no toolchain **before anything is spawned**. The assertion is not just that it raises, it is `assert spawned == []`, because a refusal landing after `Popen` has already lost the cause.
- it must accept `vite.cmd`, `vite.exe` and `vite.bunx`, not only the POSIX name. bun writes `.bunx` shims and npm writes `.cmd` on Windows, and a POSIX-only check would reject a good tree.
- a missing checkout must be reported as its own failure, not folded into "not installed". Run from outside the repo is a different mistake from run without an install.

## Anti-vacuity

25 passed on a clean tree, on a checkout with **no `studio/frontend/node_modules` at all**, which is the condition that made main red. Every case mutated the real file, was confirmed on disk by md5, and was restored from a byte snapshot.

| mutation | expect | result |
|---|---|---|
| V1 the `_require_frontend_toolchain()` call deleted from `start_vite` | fail | `FAILED ...refuses_a_tree_with_no_frontend_toolchain` |
| V2 the call moved to after the `Popen` | fail | `AssertionError: the refusal must land before npm is spawned, or the cause is lost` |
| V3 the check returns early and accepts anything | fail | 2 failed, both toolchain tests |
| V4 `vite.cmd` / `vite.exe` / `vite.bunx` dropped from the accepted names | fail | 3 failed, one per shim |
| V5 the missing-frontend branch removed | fail | `FAILED ...names_a_missing_frontend_separately` |
| V6 **control**: the check made to reject everything | fail | `FAILED ...picks_the_platform_process_group[posix]` and `[nt]` |

V6 is the one that matters for the fixture. Both process-group tests go red when the check is broken, which is only possible because they run it. Had they stubbed it out they would have stayed green, and the fix would have been a way of not noticing.

## Checked

- `tests/studio/test_playwright_server_lifecycle.py`: 25 passed, was 17 passed / 2 failed on main
- `tests/studio/test_playwright_suites_run_in_ci.py` and `test_indicator_browsers_run_in_parallel.py`: 21 passed
- ruff clean, `git diff --check` clean
- `tests/studio/_playwright_robust.py` not modified: `git diff origin/main` touches one file
