### PR TITLE
Make the desktop signing secrets gateable, and decode the cert safely

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -518,6 +518,21 @@ jobs:
     name: Build ${{ matrix.label }}
     needs: prepare-version
     runs-on: ${{ matrix.platform }}
+    # Every signing secret in this workflow -- the Apple certificate and its
+    # notarization credentials, the Azure Trusted Signing set, and the Tauri
+    # updater private key -- is read by this job and no other. Naming an
+    # environment here is what makes those thirteen secrets gateable: without
+    # it there is no place to hang a required reviewer, so anyone who can
+    # dispatch this workflow can sign a release under our identity.
+    #
+    # This is inert until protection rules exist on the environment. GitHub
+    # creates a referenced-but-absent environment on first run with no rules
+    # and no branch policy, and repository secrets keep resolving inside a job
+    # that names an environment, so adding this line alone changes nothing
+    # about how a release runs. Add required reviewers in repo settings to
+    # actually close the gap; one approval releases all three matrix legs,
+    # since pending deployments are approved per (run, environment).
+    environment: release-signing
     # 6.9-20.9 min observed across platforms and cache states.
     timeout-minutes: 60
 
@@ -809,7 +824,12 @@ jobs:
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
           KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
         run: |
-          echo $APPLE_CERTIFICATE | base64 --decode > certificate.p12
+          # Unquoted, this is word-split and glob-expanded before base64 sees
+          # it, and `echo` appends a newline. Base64 tolerates all three today,
+          # which is why it has worked; a re-encoded or line-wrapped secret is
+          # where it stops being tolerable. printf '%s' with quotes passes the
+          # secret through byte for byte.
+          printf '%s' "$APPLE_CERTIFICATE" | base64 --decode > certificate.p12
           security create-keychain -p "$KEYCHAIN_PASSWORD" build.keychain
           security default-keychain -s build.keychain
           security unlock-keychain -p "$KEYCHAIN_PASSWORD" build.keychain


### PR DESCRIPTION
Two changes to `release-desktop.yml`. Neither alters how a release runs today.

### 1. The signing secrets had nowhere to hang a reviewer

All thirteen signing secrets, the Apple certificate and its notarization credentials, the Azure Trusted Signing set and the Tauri updater private key, are read by the `build` job and by no other job in the workflow:

| job | signing secrets |
| --- | --- |
| `prepare-version` | none |
| `build` | all 13 |
| `publish-release` | none |
| `virustotal-scan` | `VIRUS_TOTAL_API_TOKEN` only |

`build` named no environment, so there was no place to attach a required reviewer, and anyone able to dispatch this workflow could sign a release under our identity. It now names a `release-signing` environment, which is the single line that makes all thirteen gateable.

**This is inert on its own.** GitHub creates a referenced-but-absent environment on first run with no protection rules and no branch policy, and repository secrets keep resolving inside a job that names an environment. Environment secrets only win on a colliding name, and this environment holds none. Turning the gate on is a settings change, not a code change: add required reviewers to the `release-signing` environment. One approval then releases all three matrix legs, since pending deployments are approved per `(run, environment)`.

### 2. The Apple certificate was decoded unquoted

`echo $APPLE_CERTIFICATE | base64 --decode` word-splits and glob-expands the secret before `base64` sees it. Tested both shapes against a 900 byte payload:

| secret shape | `echo $VAR` | `printf '%s' "$VAR"` |
| --- | --- | --- |
| single line | rc=0, 900 bytes, matches | rc=0, 900 bytes, matches |
| line wrapped | **rc=1, 57 bytes, corrupt** | rc=0, 900 bytes, matches |

So the new form is byte-identical for the single-line secret in use today, and repairs the wrapped case where the old form silently wrote a truncated `certificate.p12`. Strictly safer in both directions.

### Verification

- YAML parses, `build.environment` reads back as `release-signing`, and no other job gained one.
- `actionlint` reports nothing new. Its one complaint, `queue: max` under `concurrency`, predates this branch and is deliberate per the comment above it.
- Diff is 21 insertions, 1 deletion, confined to the `build` job header and the certificate import step.