### PR TITLE
studiobench: refuse a streamed tail the corpus cannot deliver

### DIFF
--- a/tests/studio/studiobench/fixture/corpus.py
+++ b/tests/studio/studiobench/fixture/corpus.py
@@ -1002,6 +1002,51 @@ def _too_small(rung: str, chars_per_token: float, last_index: int, what: str) ->
     )
 
 
+def _tail_not_deliverable(
+    rung: str,
+    requested: int,
+    source_index: int,
+    deliverable: int,
+    thread_chars: int,
+    target_chars: int,
+) -> ValueError:
+    """An explicit `--stream-tail-chars` the corpus cannot actually deliver.
+
+    Deliberately an ERROR and not a shortfall field, for the same reason `_too_small` is. The
+    quantity this flag exists to vary is the ONLY variable in a reply-length experiment, so a run
+    that silently measures a fraction of it has no honest reading at all -- there is nothing to
+    caveat, the axis simply did not move.
+
+    TWO EFFECTS COMPOUND HERE and the message names both, because fixing only the one you noticed
+    leaves the other. The tail is one corpus unit and `clipped_to` returns the unit unchanged when
+    the ask exceeds it, so delivery is capped at that unit's size. And asking for MORE tail lowers
+    that cap rather than raising it: a bigger tail shrinks `seed_target`, which moves the streamed
+    turn to a lower index, and the corpus escalates in size, so the ceiling falls as the request
+    rises. At the extreme the seeded prefix is evacuated entirely and the rung's own thread goes
+    with it, while the cell keeps its rung label, its rung weight and its place in the table.
+
+    Measured before this guard existed: `--rungs 100K --stream-tail-chars 400000` delivered 15,405
+    characters of the 400,000 asked for (3.9%) on a thread of 18,122 characters against the rung's
+    397,755 (4.6%), and `--assert-liveness` returned `0 scene problems, 0 missed slots`, exit 0,
+    byte-identical to the default run -- because a saturated tail drains FASTER than the film it
+    was supposed to outlast, so the one check that could have noticed goes quieter as the input
+    gets more wrong.
+    """
+    return ValueError(
+        f"the frozen corpus cannot deliver a {requested:,} character streamed tail at the {rung} "
+        f"rung: the streamed turn is unit {source_index}, which is {deliverable:,} characters, so "
+        f"the reply would be {deliverable / requested:.1%} of the one asked for. Asking for more "
+        f"tail makes this worse rather than better, because the seeded prefix shrinks to pay for "
+        f"it and the streamed turn moves to a smaller unit -- here the thread would collapse to "
+        f"{thread_chars:,} characters against the rung's {target_chars:,}, while still being "
+        f"recorded, weighted and reported as {rung}. Ask for less, or move the same request to a "
+        f"higher rung. NOT 'at most {deliverable:,}': that is this unit's size at THIS request, "
+        f"and the ceiling RISES as the request falls, because a smaller tail leaves a longer "
+        f"seeded prefix which draws the streamed turn from a larger unit. Lower the ask until "
+        f"this stops firing rather than reading a maximum off this line."
+    )
+
+
 def unit_text(unit: Unit) -> str:
     """Everything a unit puts on screen, in the order it arrives."""
     return unit.reasoning + unit.content
@@ -1136,7 +1181,28 @@ def plan_rung(
     # during-generation slots are timed against the opening stream, so it has to outlast them;
     # splitting the budget between turns left it draining in four seconds and those slots then ran
     # against a finished reply while still being labelled "during generation".
-    streamed = corpus.unit(len(seeded)).clipped_to(tail_target)
+    source = corpus.unit(len(seeded))
+    # THE REQUESTED TAIL HAS TO BE DELIVERABLE. Keyed on `clipped_to`'s own early return
+    # (`if chars >= self.chars: return self`) rather than on a tolerance, because the two ways a
+    # tail lands under its budget are different in kind and only one of them is a defect: clipping
+    # at a whole BLOCK boundary loses at most one block and is what keeps a prefix from ending
+    # inside a fence, while exceeding the unit loses everything above it and is unbounded. A
+    # percentage bound cannot tell those apart, and a bound nobody can derive is an unacknowledged
+    # bias rather than a tolerance.
+    #
+    # The DEFAULT path is exempt on purpose: `STREAM_TAIL_CHARS` is a ceiling the small rungs are
+    # legitimately under (the 1K rung is 4,000 characters in total, less than one tail), and that
+    # shortfall is the rung being small rather than the corpus failing to answer.
+    if stream_tail_chars is not None and tail_target >= source.chars:
+        raise _tail_not_deliverable(
+            rung,
+            tail_target,
+            len(seeded),
+            source.chars,
+            sum(u.chars for u in seeded) + source.chars + FOLLOW_UP_CHARS * (turns - 1),
+            target_chars,
+        )
+    streamed = source.clipped_to(tail_target)
     follow_ups = [corpus.unit(len(seeded) + i).clipped_to(FOLLOW_UP_CHARS) for i in range(1, turns)]
     if dollars:
         # The streamed turns only. The seeded prefix is rendered once at mount and never

--- a/tests/studio/studiobench/fixture/selftest/test_studiobench_tail_deliverable.py
+++ b/tests/studio/studiobench/fixture/selftest/test_studiobench_tail_deliverable.py
@@ -45,12 +45,23 @@ def corpus() -> Corpus:
 #: reply-axis test's own two assertions across the ladder, not chosen: every `False` here is a
 #: pair that silently under-delivered before the guard, and every `True` is one that did not.
 MATRIX: list[tuple[str, int, bool]] = [
-    ("1K", 24_000, False), ("1K", 96_000, False), ("1K", 400_000, False),
-    ("10K", 24_000, False), ("10K", 48_000, False), ("10K", 96_000, False),
-    ("100K", 24_000, True), ("100K", 48_000, True), ("100K", 96_000, True),
-    ("100K", 200_000, False), ("100K", 400_000, False),
-    ("500K", 96_000, True), ("500K", 200_000, True), ("500K", 400_000, False),
-    ("1M", 96_000, True), ("1M", 200_000, True), ("1M", 400_000, False),
+    ("1K", 24_000, False),
+    ("1K", 96_000, False),
+    ("1K", 400_000, False),
+    ("10K", 24_000, False),
+    ("10K", 48_000, False),
+    ("10K", 96_000, False),
+    ("100K", 24_000, True),
+    ("100K", 48_000, True),
+    ("100K", 96_000, True),
+    ("100K", 200_000, False),
+    ("100K", 400_000, False),
+    ("500K", 96_000, True),
+    ("500K", 200_000, True),
+    ("500K", 400_000, False),
+    ("1M", 96_000, True),
+    ("1M", 200_000, True),
+    ("1M", 400_000, False),
 ]
 
 

--- a/tests/studio/studiobench/fixture/selftest/test_studiobench_tail_deliverable.py
+++ b/tests/studio/studiobench/fixture/selftest/test_studiobench_tail_deliverable.py
@@ -1,0 +1,176 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""An explicit `--stream-tail-chars` must be delivered or refused, never quietly shrunk.
+
+`test_studiobench_reply_axis.py` already asserts the right property -- the reply lands within 10%
+of the ask and the thread does not move -- but only at the 100K rung and only at 24,000 and 96,000.
+Re-run those same two assertions across the ladder before this guard existed and 10 of 15
+(rung, tail) pairs failed them. The shipped test covered exactly the 2 that passed. A test can be
+right about the property and wrong about the coverage, and the value of this file is the matrix.
+
+The failure it pins is silent in both directions at once, which is why nothing caught it:
+`--rungs 100K --stream-tail-chars 400000` streamed 15,405 of the 400,000 requested (3.9%) on a
+thread of 18,122 characters against the rung's 397,755 (4.6%), and the cell still carried the
+`r100K` id that `scoring/from_payload.py` and `report/build.py` use as the rung key. So a 4.6% rung
+was reported, weighted and pooled as 100K. `--assert-liveness` returned `0 scene problems, 0 missed
+slots`, exit 0, byte-identical to the default run: a saturated tail drains FASTER than the film it
+was meant to outlast, so the one gate that could have noticed goes quieter as the input gets worse.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+from studiobench.fixture.corpus import (  # noqa: E402
+    RUNGS,
+    STREAM_TAIL_CHARS,
+    Corpus,
+    plan_rung,
+)
+
+
+@pytest.fixture(scope = "module")
+def corpus() -> Corpus:
+    return Corpus.load()
+
+
+#: Every pair the axis is plausibly asked for, and what the corpus can actually do with it.
+#: `True` means deliverable, `False` means the request has to be refused. Derived by running the
+#: reply-axis test's own two assertions across the ladder, not chosen: every `False` here is a
+#: pair that silently under-delivered before the guard, and every `True` is one that did not.
+MATRIX: list[tuple[str, int, bool]] = [
+    ("1K", 24_000, False), ("1K", 96_000, False), ("1K", 400_000, False),
+    ("10K", 24_000, False), ("10K", 48_000, False), ("10K", 96_000, False),
+    ("100K", 24_000, True), ("100K", 48_000, True), ("100K", 96_000, True),
+    ("100K", 200_000, False), ("100K", 400_000, False),
+    ("500K", 96_000, True), ("500K", 200_000, True), ("500K", 400_000, False),
+    ("1M", 96_000, True), ("1M", 200_000, True), ("1M", 400_000, False),
+]
+
+
+@pytest.mark.parametrize(("rung", "tail", "deliverable"), MATRIX)
+def test_every_requested_tail_is_delivered_or_refused(
+    corpus: Corpus, rung: str, tail: int, deliverable: bool
+):
+    """The whole property, over the whole matrix: no third outcome.
+
+    The two assertions are the reply-axis test's own, applied to every pair rather than to two of
+    them. Where the corpus cannot answer, the requirement is a refusal and not a smaller number.
+    """
+    if not deliverable:
+        with pytest.raises(ValueError, match = "cannot deliver"):
+            plan_rung(corpus, rung, stream_tail_chars = tail)
+        return
+
+    plan = plan_rung(corpus, rung, stream_tail_chars = tail)
+    base = plan_rung(corpus, rung)
+    assert abs(plan.streamed_chars - tail) < tail * 0.1, (rung, tail, plan.streamed_chars)
+    assert abs(plan.total_chars - base.total_chars) < base.total_chars * 0.05, (
+        rung,
+        tail,
+        plan.total_chars,
+        base.total_chars,
+    )
+
+
+def test_the_refusal_names_the_collapse_and_not_only_the_short_reply(corpus: Corpus):
+    """Both effects, because fixing only the one you noticed leaves the other.
+
+    A reader told just "the reply was short" lowers the tail and moves on. The thread collapse is
+    the half that corrupts the rung label, and it is the half a short reply does not imply.
+    """
+    with pytest.raises(ValueError) as excinfo:
+        plan_rung(corpus, "100K", stream_tail_chars = 400_000)
+    message = str(excinfo.value)
+    assert "400,000" in message, message
+    assert "3.9%" in message, message
+    assert "collapse" in message, message
+    assert "100K" in message, message
+
+
+def test_the_refusal_does_not_name_a_maximum_it_has_not_computed(corpus: Corpus):
+    """FAILURE DIRECTION, and it pins a bug this guard shipped with for one revision.
+
+    The obvious wording is "ask for at most N", N being the unit the request landed on. It is
+    wrong, and confidently so: the ceiling RISES as the request falls, because a smaller tail
+    leaves a longer seeded prefix which draws the streamed turn from a larger unit. At 100K the
+    first draft told the reader to ask for at most 15,405 while 96,000 succeeds -- a factor of six
+    in the direction that makes someone abandon a measurement they could have taken.
+
+    A refusal that confidently names the wrong number is worse than a vaguer one, because it sends
+    the reader somewhere specific and wrong.
+    """
+    with pytest.raises(ValueError) as excinfo:
+        plan_rung(corpus, "100K", stream_tail_chars = 400_000)
+    message = str(excinfo.value)
+    assert "at most 15,405" not in message.replace("NOT 'at most 15,405'", ""), message
+    # And the claim the reader needs instead has to actually be there.
+    assert "RISES as the request falls" in message, message
+    # The thing the wrong advice would have forbidden must in fact work.
+    assert plan_rung(corpus, "100K", stream_tail_chars = 96_000).streamed_chars > 90_000
+
+
+def test_the_default_ladder_is_untouched(corpus: Corpus):
+    """The guard is scoped to an EXPLICIT request. The pinned ladder must not acquire a new way
+    to fail, at any rung, and its numbers must not move by a character."""
+    for rung in RUNGS:
+        plan = plan_rung(corpus, rung)
+        assert plan.streamed_chars <= STREAM_TAIL_CHARS, rung
+        assert plan.streamed_chars > 0, rung
+
+
+def test_the_small_rungs_are_under_the_default_tail_without_being_refused(corpus: Corpus):
+    """The exemption that makes the guard correct rather than merely strict.
+
+    The 1K rung is 4,000 characters in total, less than one tail, so it streams 3,883 and is
+    legitimately short. That shortfall is the rung being small, not the corpus failing to answer a
+    question it was asked, and a guard that could not tell those apart would refuse the default
+    ladder at its own smallest rung.
+    """
+    plan = plan_rung(corpus, "1K")
+    assert plan.streamed_chars < STREAM_TAIL_CHARS
+    assert plan.streamed_chars == 3_883, plan.streamed_chars
+
+
+def test_the_default_exemption_is_currently_unreachable_and_says_so(corpus: Corpus):
+    """HONESTY ABOUT COVERAGE. The `stream_tail_chars is not None` clause has no teeth today.
+
+    Mutation-tested and NOT caught: dropping that clause leaves all 168 selftests passing and the
+    default ladder byte-identical, because the guard's other half can never fire on the default
+    path -- `STREAM_TAIL_CHARS` is 6,000 and the smallest unit in the frozen corpus is 11,374, so
+    `tail_target >= source.chars` is unreachable without an explicit request. The clause is
+    defensive, not load bearing, and claiming the matrix above covers it would be exactly the
+    "right about the property, wrong about the coverage" mistake this file exists to correct.
+
+    So pin the PREMISE instead of faking coverage of the branch. Raise `STREAM_TAIL_CHARS` above
+    the smallest unit, or re-freeze a corpus with smaller units, and this fails -- at which point
+    the exemption becomes load bearing and needs a real test rather than this one.
+    """
+    smallest = min(entry["chars"] for entry in corpus.manifest["units"])
+    assert smallest > STREAM_TAIL_CHARS, (
+        f"the smallest corpus unit ({smallest:,}) no longer exceeds STREAM_TAIL_CHARS "
+        f"({STREAM_TAIL_CHARS:,}), so the default path can now reach the deliverability guard. "
+        "The `stream_tail_chars is not None` exemption has become load bearing and needs a test "
+        "that exercises it directly."
+    )
+
+
+def test_block_clipping_is_not_treated_as_under_delivery(corpus: Corpus):
+    """The other half of the same distinction, on the EXPLICIT path.
+
+    A tail clipped at a whole block boundary loses at most one block, and that clipping is load
+    bearing: a character-aligned prefix can end inside a fence, and an unclosed fence is a
+    different Streamdown path with a different cost. Only exceeding the unit is unbounded. The
+    guard keys on `clipped_to`'s own early return rather than on a percentage, which is what lets
+    it separate the two; a bound nobody can derive would be an unacknowledged bias, not a
+    tolerance.
+    """
+    plan = plan_rung(corpus, "100K", stream_tail_chars = 24_000)
+    assert plan.streamed_chars < 24_000, "this pair is expected to clip at a block boundary"
+    assert plan.streamed_chars > 24_000 * 0.9, plan.streamed_chars


### PR DESCRIPTION
## What this fixes

`--stream-tail-chars N` is documented as the only way to vary reply length in this tool. It silently under-delivered, and in a way that corrupted the rung label at the same time.

Two effects compound, and fixing only the one you notice leaves the other:

1. The streamed tail is **one corpus unit**, and `clipped_to` returns the unit unchanged when the ask exceeds it (`fixture/corpus.py`, `if chars >= self.chars: return self`). Delivery is capped at that unit's size.
2. **Asking for more tail lowers that cap rather than raising it.** A bigger tail shrinks `seed_target`, which moves the streamed turn to a lower index, and the corpus escalates in size. At the extreme the seeded prefix is evacuated entirely and the rung's thread goes with it.

Measured at 100K with a 400,000 character request, before this change:

| quantity | asked | delivered |
| --- | ---: | ---: |
| streamed reply | 400,000 | 15,405 (3.9%) |
| thread total | 397,755 | 18,122 (4.6%) |

The cell still carried the `r100K` id that `scoring/from_payload.py` and `report/build.py` use as the rung key, so an 18,122 character thread was recorded, weighted and reported as the 100K rung.

**The check that should have caught it goes quieter as the input gets worse.** `--assert-liveness` returned `0 scene problems, 0 missed slots`, exit 0, byte-identical to the default run, because a saturated tail drains *faster* than the film it was supposed to outlast. That is the shape of catalogued defect 13: a gate that cannot report the other answer is not a gate.

## Delivery across the ladder, before and after

`ok` = accepted, and every accepted pair now lands within 10% of the request with the thread within 5% of the default. Every refused pair is one that previously under-delivered silently.

| tail | 1K | 10K | 100K | 500K | 1M |
| ---: | --- | --- | --- | --- | --- |
| default | 3,883 | 4,832 | 4,642 | 5,420 | 5,994 |
| 24,000 | refused | refused | 23,831 | 23,803 | 23,749 |
| 48,000 | refused | refused | 47,617 | 46,566 | 47,555 |
| 96,000 | refused | refused | 95,762 | 94,892 | 94,941 |
| 200,000 | refused | refused | refused | 198,928 | 199,340 |
| 400,000 | refused | refused | refused | refused | refused |

Before, those `refused` cells returned 15,405 / 11,374 / 133,113 / 306,669 / 290,984 characters with no warning of any kind.

## Why a mechanism predicate and not a tolerance

The guard keys on `clipped_to`'s own early return, not on a percentage. The two ways a tail lands under its budget are different in kind and only one is a defect:

- **Block-boundary clipping** loses at most one block, and it is load bearing: a character-aligned prefix can end inside a fence, and an unclosed fence is a different Streamdown path with a different cost.
- **Exceeding the unit** loses everything above it and is unbounded.

A percentage bound cannot separate those, and a bound nobody can derive is an unacknowledged bias rather than a tolerance.

## The default ladder is untouched

The guard is scoped to an explicit request. `STREAM_TAIL_CHARS = 6_000` is a ceiling the small rungs are legitimately under (the 1K rung is 4,000 characters in total, less than one tail), and that shortfall is the rung being small rather than the corpus failing to answer. Default numbers do not move by a character at any rung.

## Test coverage, and an honest note about it

`test_studiobench_reply_axis.py` already asserts the right property, reply within 10% and thread within 5%, but only at the 100K rung and only at 24,000 and 96,000. Re-running **its own two assertions** across the ladder, 10 of 15 (rung, tail) pairs failed them. The shipped test covered exactly the 2 that passed. A test can be right about the property and wrong about the coverage; the new file is the matrix.

Teeth confirmed by mutation, each restored from a byte snapshot with md5:

| mutant | result |
| --- | --- |
| guard deleted | 12 failed |
| refuse every explicit request | 9 failed |
| restore the wrong "ask for at most N" advice | 1 failed |
| drop the thread-collapse clause from the message | 1 failed |
| raise `STREAM_TAIL_CHARS` above the smallest unit | 1 failed |

**One mutant is NOT caught and the test file says so.** Dropping the `stream_tail_chars is not None` exemption leaves all selftests passing and the default ladder byte-identical, because `STREAM_TAIL_CHARS` (6,000) is below the smallest corpus unit (11,374), so the guard's other half cannot fire on the default path. That clause is defensive, not load bearing. Rather than fake coverage of an unreachable branch, `test_the_default_exemption_is_currently_unreachable_and_says_so` pins the premise, so a re-freeze with smaller units or a raised constant fails loudly and someone re-checks.

## A wording bug this shipped with for one revision

The first draft of the refusal said "ask for at most 15,405 characters". That is confidently wrong: the ceiling **rises as the request falls**, because a smaller tail leaves a longer seeded prefix which draws the streamed turn from a larger unit. At 100K it would have told the reader to ask for at most 15,405 while 96,000 succeeds, a factor of six in the direction that makes someone abandon a measurement they could have taken. A refusal that names the wrong number is worse than a vaguer one. `test_the_refusal_does_not_name_a_maximum_it_has_not_computed` pins it.

## No re-freeze is needed, and please do not do one by analogy

`corpus_hash` covers eight generator parameters plus each unit's `sha256`. `STREAM_TAIL_CHARS` is not among them, `freeze()` never reads it, and `clipped_to` produces a read-time prefix that never touches `units.jsonl`. Verified across tails from 6k to 200k: the hash stays `23cd2464...`. Task #118's re-freeze was driven by `manifest_unit_count`, a different lever. This change is hash-neutral, so everything measured before it remains comparable.

## A suspicion I checked and withdrew

While tracing this I suspected that nothing mechanically refuses to pool payloads taken at different tails, on the grounds that `scoring/ab.py`'s `COMPARABILITY_FIELDS` does not mention `stream_tail_chars`. **That was wrong and I am recording it rather than quietly dropping it.** `scoring/ab.py` is an intra-payload backstop whose only caller builds both identities from one dict. The real cross-payload key is `scoring/payload_rules.py`, which does carry `stream_tail_chars`, and three gates refuse on it: `--compare` exits 1, `floor_table.render` raises, and `--resume` refuses under a changed tail. There is also an existing producer-in-the-loop test that enumerates the field list rather than hard-coding it. No change was needed and none was made.

## Scope

This does not change what the rung ladder varies, and it is not a venue claim.

The ladder pins the streamed tail at 6,000 on every rung deliberately, and that pin should stay. It is a one-way fix: the tail originally grew with the rung, and it was pinned because at field cadence the stream drained in 811 s at 1M against a 135 s film, so every slot labelled "after the reply is complete" ran mid-generation. Scaling it back would also make `analysis/fit.py`'s published exponent unidentifiable, since a tail proportional to the rung reports `b = 1.00` for a purely reply-driven cost that never touches the thread, and `fit.py` reads `b ~ 1` as "linear in thread length".

What this change does is make the orthogonal axis trustworthy, so that a reply-length measurement at a large rung either happens or fails loudly.

## Testing

- `tests/studio/studiobench`: 1442 passed.
- `ruff check tests/studio/studiobench`: clean.
- AST sweep for duplicate names in a single `ImportFrom` across the package: 0.
- `git status --porcelain` diffed before and after the full test run: no stray files.
