### PR TITLE
Xet notice: one toast carrying both messages, three times per install, gone when the download is

### DIFF
--- a/studio/backend/routes/settings.py
+++ b/studio/backend/routes/settings.py
@@ -1085,19 +1085,14 @@ def update_helper_precache(
 
 
 @router.get("/xet-notice", response_model = XetNoticeResponse)
-def get_xet_notice(
-    current_subject: str = Depends(get_current_subject),
-) -> XetNoticeResponse:
+def get_xet_notice(current_subject: str = Depends(get_current_subject)) -> XetNoticeResponse:
     shown = get_xet_notice_count()
-    return XetNoticeResponse(
-        granted = False, shown = shown, limit = XET_NOTICE_LIMIT
-    )
+    return XetNoticeResponse(granted = False, shown = shown, limit = XET_NOTICE_LIMIT)
 
 
 @router.post("/xet-notice/reserve", response_model = XetNoticeResponse)
 def post_xet_notice_reserve(
-    payload: XetNoticeReservePayload,
-    current_subject: str = Depends(get_current_subject),
+    payload: XetNoticeReservePayload, current_subject: str = Depends(get_current_subject)
 ) -> XetNoticeResponse:
     """Take one of the remaining notices. POST because it mutates the count."""
     try:

--- a/studio/backend/routes/settings.py
+++ b/studio/backend/routes/settings.py
@@ -40,6 +40,11 @@ from utils.upload_limits import (
     upload_limit_bytes,
     upload_limit_label,
 )
+from utils.xet_notice_settings import (
+    XET_NOTICE_LIMIT,
+    get_xet_notice_count,
+    reserve_xet_notice,
+)
 from utils.helper_precache_settings import (
     DEFAULT_HELPER_PRECACHE_ENABLED,
     get_helper_precache_enabled,
@@ -568,6 +573,19 @@ class HelperPrecacheResponse(BaseModel):
     disabled_by_env: bool
 
 
+class XetNoticeReservePayload(BaseModel):
+    # A legacy localStorage count from a client that has not reported one before.
+    # Can only raise the stored count (see reserve_xet_notice), so a client cannot
+    # talk its own way back under the limit with it.
+    seen_hint: int = 0
+
+
+class XetNoticeResponse(BaseModel):
+    granted: bool
+    shown: int
+    limit: int
+
+
 class ModelMemoryPayload(BaseModel):
     # None leaves the stored value untouched, so the switches save independently.
     keep_resident: Optional[bool] = None
@@ -1064,6 +1082,35 @@ def update_helper_precache(
             log = logger,
         ) from exc
     return _helper_precache_response(enabled)
+
+
+@router.get("/xet-notice", response_model = XetNoticeResponse)
+def get_xet_notice(
+    current_subject: str = Depends(get_current_subject),
+) -> XetNoticeResponse:
+    shown = get_xet_notice_count()
+    return XetNoticeResponse(
+        granted = False, shown = shown, limit = XET_NOTICE_LIMIT
+    )
+
+
+@router.post("/xet-notice/reserve", response_model = XetNoticeResponse)
+def post_xet_notice_reserve(
+    payload: XetNoticeReservePayload,
+    current_subject: str = Depends(get_current_subject),
+) -> XetNoticeResponse:
+    """Take one of the remaining notices. POST because it mutates the count."""
+    try:
+        result = reserve_xet_notice(payload.seen_hint)
+    except Exception as exc:
+        raise log_and_http_error(
+            exc,
+            500,
+            safe_error_detail(exc, fallback = "Could not reserve the Xet download notice."),
+            event = "settings.reserve_xet_notice_failed",
+            log = logger,
+        ) from exc
+    return XetNoticeResponse(**result)
 
 
 @router.get("/model-memory", response_model = ModelMemoryResponse)

--- a/studio/backend/routes/settings.py
+++ b/studio/backend/routes/settings.py
@@ -40,11 +40,7 @@ from utils.upload_limits import (
     upload_limit_bytes,
     upload_limit_label,
 )
-from utils.xet_notice_settings import (
-    XET_NOTICE_LIMIT,
-    get_xet_notice_count,
-    reserve_xet_notice,
-)
+from utils.xet_notice_settings import reserve_xet_notice
 from utils.helper_precache_settings import (
     DEFAULT_HELPER_PRECACHE_ENABLED,
     get_helper_precache_enabled,
@@ -1082,12 +1078,6 @@ def update_helper_precache(
             log = logger,
         ) from exc
     return _helper_precache_response(enabled)
-
-
-@router.get("/xet-notice", response_model = XetNoticeResponse)
-def get_xet_notice(current_subject: str = Depends(get_current_subject)) -> XetNoticeResponse:
-    shown = get_xet_notice_count()
-    return XetNoticeResponse(granted = False, shown = shown, limit = XET_NOTICE_LIMIT)
 
 
 @router.post("/xet-notice/reserve", response_model = XetNoticeResponse)

--- a/studio/backend/tests/test_xet_notice_settings.py
+++ b/studio/backend/tests/test_xet_notice_settings.py
@@ -1,0 +1,128 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""The Xet notice counter, which is the reason the notice ever stops.
+
+It used to live in the browser, in localStorage, which is scoped to an origin. A
+Studio origin is not stable: run.py defaults to port 8888 and falls back to the next
+free port when it is taken, and 8888 is also Jupyter's default. Colab and the tunnel
+are different origins again. Each of those handed the user a fresh set of three, so
+"show this three times" meant "three times per port, forever".
+
+These tests are about the two properties that gives the install: the count survives,
+and concurrent callers cannot talk their way past the limit.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import threading
+from pathlib import Path
+
+_BACKEND = Path(__file__).resolve().parents[1]
+if str(_BACKEND) not in sys.path:
+    sys.path.insert(0, str(_BACKEND))
+
+import utils.xet_notice_settings as xet  # noqa: E402
+from storage import studio_db  # noqa: E402
+
+
+def test_three_are_granted_and_the_fourth_is_not():
+    assert xet.get_xet_notice_count() == 0
+    granted = [xet.reserve_xet_notice()["granted"] for _ in range(5)]
+    assert granted == [True, True, True, False, False]
+    assert xet.get_xet_notice_count() == xet.XET_NOTICE_LIMIT
+
+
+def test_the_count_outlives_the_process_that_wrote_it():
+    """The whole point. A restart, on any port, must not hand out three more."""
+    for _ in range(2):
+        assert xet.reserve_xet_notice()["granted"] is True
+
+    # A fresh connection is what a restarted backend gets: nothing is cached in
+    # module state, the value comes back off disk.
+    assert xet.get_xet_notice_count() == 2
+    assert xet.reserve_xet_notice() == {"granted": True, "shown": 3, "limit": 3}
+    assert xet.reserve_xet_notice()["granted"] is False
+
+
+def test_concurrent_reservations_never_exceed_the_limit():
+    """Two tabs starting a download at the same moment.
+
+    This is why the reserve is one transaction rather than get_app_setting followed
+    by upsert_app_settings: those open a connection each, so both callers can read
+    the same count and both be granted. The browser implementation needed Web Locks
+    to paper over exactly this, and could not cover a second browser at all.
+    """
+    results: list[bool] = []
+    lock = threading.Lock()
+    start = threading.Barrier(8)
+
+    def worker():
+        start.wait()
+        granted = xet.reserve_xet_notice()["granted"]
+        with lock:
+            results.append(granted)
+
+    threads = [threading.Thread(target = worker) for _ in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert len(results) == 8
+    assert sum(results) == xet.XET_NOTICE_LIMIT
+    assert xet.get_xet_notice_count() == xet.XET_NOTICE_LIMIT
+
+
+def test_a_legacy_hint_raises_the_count_but_never_lowers_it():
+    """Migration from localStorage, in the safe direction only.
+
+    Someone who already spent their three before this moved server-side must not get
+    three more. Equally, the hint arrives from a client, so it must not be able to
+    lower a stored count and win back sightings.
+    """
+    assert xet.reserve_xet_notice(seen_hint = 2)["shown"] == 3
+    assert xet.reserve_xet_notice()["granted"] is False
+
+    # A client claiming it has seen none does not reset anything.
+    assert xet.reserve_xet_notice(seen_hint = 0)["granted"] is False
+    assert xet.get_xet_notice_count() == 3
+
+
+def test_a_hint_at_or_over_the_limit_grants_nothing():
+    assert xet.reserve_xet_notice(seen_hint = 3)["granted"] is False
+    assert xet.reserve_xet_notice(seen_hint = 99)["granted"] is False
+    # The stored count is clamped by what was actually reserved, not by the claim.
+    assert xet.get_xet_notice_count() >= xet.XET_NOTICE_LIMIT
+
+
+def test_an_unreadable_stored_value_reads_as_a_fresh_install():
+    """A hand-edited or half-written row must not wedge the notice off forever."""
+    studio_db.upsert_app_settings({xet.XET_NOTICE_COUNT_KEY: "not a number"})
+    assert xet.get_xet_notice_count() == 0
+    assert xet.reserve_xet_notice()["granted"] is True
+
+    studio_db.upsert_app_settings({xet.XET_NOTICE_COUNT_KEY: -5})
+    assert xet.get_xet_notice_count() == 0
+
+    # A bool is an int in Python; it is not a count.
+    studio_db.upsert_app_settings({xet.XET_NOTICE_COUNT_KEY: True})
+    assert xet.get_xet_notice_count() == 0
+
+
+def test_the_stored_shape_is_a_plain_json_int():
+    """Other readers of app_settings should find a number, not a stringified one."""
+    xet.reserve_xet_notice()
+    stored = studio_db.get_app_setting(xet.XET_NOTICE_COUNT_KEY, None)
+    assert stored == 1
+    conn = studio_db.get_connection()
+    try:
+        row = conn.execute(
+            "SELECT value_json FROM app_settings WHERE key = ?",
+            (xet.XET_NOTICE_COUNT_KEY,),
+        ).fetchone()
+    finally:
+        conn.close()
+    assert json.loads(row["value_json"]) == 1

--- a/studio/backend/tests/test_xet_notice_settings.py
+++ b/studio/backend/tests/test_xet_notice_settings.py
@@ -1,16 +1,10 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-"""The Xet notice counter, which is the reason the notice ever stops.
+"""The Xet notice counter: the count survives, and concurrency cannot beat the limit.
 
-It used to live in the browser, in localStorage, which is scoped to an origin. A
-Studio origin is not stable: run.py defaults to port 8888 and falls back to the next
-free port when it is taken, and 8888 is also Jupyter's default. Colab and the tunnel
-are different origins again. Each of those handed the user a fresh set of three, so
-"show this three times" meant "three times per port, forever".
-
-These tests are about the two properties that gives the install: the count survives,
-and concurrent callers cannot talk their way past the limit.
+It lived in per-origin localStorage, and a Studio origin moves whenever port 8888 is
+taken, so "three times" meant "three times per port, forever".
 """
 
 from __future__ import annotations
@@ -36,7 +30,7 @@ def test_three_are_granted_and_the_fourth_is_not():
 
 
 def test_the_count_outlives_the_process_that_wrote_it():
-    """The whole point. A restart, on any port, must not hand out three more."""
+    """A restart, on any port, must not hand out three more."""
     for _ in range(2):
         assert xet.reserve_xet_notice()["granted"] is True
 
@@ -48,13 +42,8 @@ def test_the_count_outlives_the_process_that_wrote_it():
 
 
 def test_concurrent_reservations_never_exceed_the_limit():
-    """Two tabs starting a download at the same moment.
-
-    This is why the reserve is one transaction rather than get_app_setting followed
-    by upsert_app_settings: those open a connection each, so both callers can read
-    the same count and both be granted. The browser implementation needed Web Locks
-    to paper over exactly this, and could not cover a second browser at all.
-    """
+    """Two tabs at once. Why the reserve is one transaction: a split read and write
+    lets both callers read the same count and both be granted."""
     results: list[bool] = []
     lock = threading.Lock()
     start = threading.Barrier(8)
@@ -77,12 +66,7 @@ def test_concurrent_reservations_never_exceed_the_limit():
 
 
 def test_a_legacy_hint_raises_the_count_but_never_lowers_it():
-    """Migration from localStorage, in the safe direction only.
-
-    Someone who already spent their three before this moved server-side must not get
-    three more. Equally, the hint arrives from a client, so it must not be able to
-    lower a stored count and win back sightings.
-    """
+    """Migration from localStorage, upwards only: it must not win back sightings."""
     assert xet.reserve_xet_notice(seen_hint = 2)["shown"] == 3
     assert xet.reserve_xet_notice()["granted"] is False
 
@@ -99,7 +83,7 @@ def test_a_hint_at_or_over_the_limit_grants_nothing():
 
 
 def test_an_unreadable_stored_value_reads_as_a_fresh_install():
-    """A hand-edited or half-written row must not wedge the notice off forever."""
+    """A junk row must not wedge the notice off forever."""
     studio_db.upsert_app_settings({xet.XET_NOTICE_COUNT_KEY: "not a number"})
     assert xet.get_xet_notice_count() == 0
     assert xet.reserve_xet_notice()["granted"] is True
@@ -113,7 +97,7 @@ def test_an_unreadable_stored_value_reads_as_a_fresh_install():
 
 
 def test_the_stored_shape_is_a_plain_json_int():
-    """Other readers of app_settings should find a number, not a stringified one."""
+    """Other readers of app_settings should find a number, not a string."""
     xet.reserve_xet_notice()
     stored = studio_db.get_app_setting(xet.XET_NOTICE_COUNT_KEY, None)
     assert stored == 1

--- a/studio/backend/utils/xet_notice_settings.py
+++ b/studio/backend/utils/xet_notice_settings.py
@@ -1,0 +1,111 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""How many times the Xet "download is running" notice has been shown, for the life of the install.
+
+The count used to live in the browser, in localStorage under
+``unsloth.studio.xetNoticeCount``. localStorage is scoped to an ORIGIN, and a Studio
+origin is not stable: ``run.py`` defaults to port 8888 and falls back to the next free
+port when that is taken, and 8888 is also Jupyter's default. So starting Studio while a
+notebook server is up moves it to 8889, which is a different origin with an empty store,
+and the notice starts its three all over again. Colab and the Cloudflare tunnel are
+different origins again, as is a second browser or a cleared profile. The user-visible
+effect was a notice that reappeared indefinitely instead of a handful of times ever.
+
+The install has exactly one database, so the count belongs here.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+XET_NOTICE_COUNT_KEY = "xet_notice_shown_count"
+
+# Three sightings is enough to learn what a Xet transfer looks like. The cap lives on
+# this side because the browser is no longer trusted to remember, and a limit enforced
+# where the count is stored cannot disagree with it.
+XET_NOTICE_LIMIT = 3
+
+
+def _coerce_count(value: Any) -> int:
+    """Anything unparseable reads as zero, matching a fresh install."""
+    if isinstance(value, bool):
+        return 0
+    if isinstance(value, int):
+        return max(0, value)
+    if isinstance(value, str):
+        try:
+            return max(0, int(value.strip()))
+        except ValueError:
+            return 0
+    return 0
+
+
+def get_xet_notice_count() -> int:
+    """Read the count. A missing or unreadable row means none have been shown."""
+    try:
+        from storage.studio_db import get_app_setting
+        stored = get_app_setting(XET_NOTICE_COUNT_KEY, 0)
+    except Exception:
+        return 0
+    return _coerce_count(stored)
+
+
+def reserve_xet_notice(seen_hint: int = 0) -> dict[str, Any]:
+    """Take one of the remaining notices, or report that none are left.
+
+    Read-modify-write in ONE transaction. ``get_app_setting`` and
+    ``upsert_app_settings`` each open their own connection, so doing this across the
+    two of them lets two tabs read the same count and both be granted, which is how
+    the browser implementation had to reach for Web Locks. ``BEGIN IMMEDIATE`` takes
+    the write lock up front, so the second caller waits and then reads the first
+    caller's value.
+
+    ``seen_hint`` carries a legacy localStorage count from a client that has not
+    reported one before. It can only raise the stored count, never lower it: a user
+    who already spent their three before this moved server-side must not get three
+    more, and a client cannot use the hint to talk its own way back under the limit.
+    """
+    from storage.studio_db import get_connection
+
+    hint = _coerce_count(seen_hint)
+    conn = get_connection()
+    try:
+        conn.execute("BEGIN IMMEDIATE")
+        row = conn.execute(
+            "SELECT value_json FROM app_settings WHERE key = ?",
+            (XET_NOTICE_COUNT_KEY,),
+        ).fetchone()
+        stored = 0
+        if row is not None:
+            try:
+                stored = _coerce_count(json.loads(row["value_json"]))
+            except (ValueError, TypeError):
+                stored = 0
+        shown = max(stored, hint)
+
+        granted = shown < XET_NOTICE_LIMIT
+        if granted:
+            shown += 1
+        if shown != stored:
+            from datetime import datetime, timezone
+            now = datetime.now(timezone.utc).isoformat()
+            conn.execute(
+                """
+                INSERT INTO app_settings (key, value_json, updated_at)
+                VALUES (?, ?, ?)
+                ON CONFLICT(key) DO UPDATE SET
+                    value_json = excluded.value_json,
+                    updated_at = excluded.updated_at
+                """,
+                (XET_NOTICE_COUNT_KEY, json.dumps(shown), now),
+            )
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+
+    return {"granted": granted, "shown": shown, "limit": XET_NOTICE_LIMIT}

--- a/studio/backend/utils/xet_notice_settings.py
+++ b/studio/backend/utils/xet_notice_settings.py
@@ -1,18 +1,11 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-"""How many times the Xet "download is running" notice has been shown, for the life of the install.
+"""Lifetime count of the Xet "download is running" notice.
 
-The count used to live in the browser, in localStorage under
-``unsloth.studio.xetNoticeCount``. localStorage is scoped to an ORIGIN, and a Studio
-origin is not stable: ``run.py`` defaults to port 8888 and falls back to the next free
-port when that is taken, and 8888 is also Jupyter's default. So starting Studio while a
-notebook server is up moves it to 8889, which is a different origin with an empty store,
-and the notice starts its three all over again. Colab and the Cloudflare tunnel are
-different origins again, as is a second browser or a cleared profile. The user-visible
-effect was a notice that reappeared indefinitely instead of a handful of times ever.
-
-The install has exactly one database, so the count belongs here.
+It lived in localStorage, which is per-origin, and a Studio origin is not stable:
+run.py falls back past port 8888 when Jupyter has it, and Colab and the tunnel differ
+again. Each new origin handed out a fresh three, so the notice never stopped.
 """
 
 from __future__ import annotations
@@ -22,9 +15,7 @@ from typing import Any
 
 XET_NOTICE_COUNT_KEY = "xet_notice_shown_count"
 
-# Three sightings is enough to learn what a Xet transfer looks like. The cap lives on
-# this side because the browser is no longer trusted to remember, and a limit enforced
-# where the count is stored cannot disagree with it.
+# Enforced where the count is stored, so the two cannot disagree.
 XET_NOTICE_LIMIT = 3
 
 
@@ -55,17 +46,12 @@ def get_xet_notice_count() -> int:
 def reserve_xet_notice(seen_hint: int = 0) -> dict[str, Any]:
     """Take one of the remaining notices, or report that none are left.
 
-    Read-modify-write in ONE transaction. ``get_app_setting`` and
-    ``upsert_app_settings`` each open their own connection, so doing this across the
-    two of them lets two tabs read the same count and both be granted, which is how
-    the browser implementation had to reach for Web Locks. ``BEGIN IMMEDIATE`` takes
-    the write lock up front, so the second caller waits and then reads the first
-    caller's value.
+    One transaction: get_app_setting and upsert_app_settings open a connection each,
+    so splitting the read and write lets two tabs both be granted. BEGIN IMMEDIATE
+    takes the write lock up front.
 
-    ``seen_hint`` carries a legacy localStorage count from a client that has not
-    reported one before. It can only raise the stored count, never lower it: a user
-    who already spent their three before this moved server-side must not get three
-    more, and a client cannot use the hint to talk its own way back under the limit.
+    seen_hint is a legacy localStorage count. It can only raise the stored value, so
+    a client cannot talk its way back under the limit.
     """
     from storage.studio_db import get_connection
 

--- a/studio/frontend/src/app/provider.tsx
+++ b/studio/frontend/src/app/provider.tsx
@@ -885,9 +885,8 @@ export function AppProvider({ children }: AppProviderProps) {
   const reduceMotion = useAppearanceCustomStore(
     (s) => s.customization.reduceMotion,
   );
-  // A download-start toast describes the surface it was raised on. It lasts 8s from
-  // a root-level Toaster, so leaving that surface would otherwise park it over the
-  // next route's header controls (see dismissStartToasts for the measurement).
+  // A start toast describes the surface it was raised on, and lasts 8s from a
+  // root-level Toaster; see dismissStartToasts for what it lands on otherwise.
   useEffect(() => {
     dismissStartToasts();
   }, [pathname]);

--- a/studio/frontend/src/app/provider.tsx
+++ b/studio/frontend/src/app/provider.tsx
@@ -19,7 +19,10 @@ import { WebUpdateBanner } from "@/components/web/update-banner";
 import { fetchDeviceType } from "@/config/env";
 import { getTauriAuthFailure, tauriAutoAuth } from "@/features/auth";
 import { DeepLinkHandler } from "@/features/deep-links";
-import { DownloadManagerPanel } from "@/features/hub/download-manager";
+import {
+  DownloadManagerPanel,
+  dismissStartToasts,
+} from "@/features/hub/download-manager";
 import { LoadedModelsIndicator } from "@/features/loaded-models";
 import { NativeIntentDrain } from "@/features/native-intents/native-intent-drain";
 import {
@@ -882,6 +885,12 @@ export function AppProvider({ children }: AppProviderProps) {
   const reduceMotion = useAppearanceCustomStore(
     (s) => s.customization.reduceMotion,
   );
+  // A download-start toast describes the surface it was raised on. It lasts 8s from
+  // a root-level Toaster, so leaving that surface would otherwise park it over the
+  // next route's header controls (see dismissStartToasts for the measurement).
+  useEffect(() => {
+    dismissStartToasts();
+  }, [pathname]);
   return (
     <MotionConfig reducedMotion={REDUCED_MOTION_MAP[reduceMotion]}>
       <TooltipProvider>

--- a/studio/frontend/src/features/chat/chat-page.tsx
+++ b/studio/frontend/src/features/chat/chat-page.tsx
@@ -2856,9 +2856,21 @@ export function ChatPage({
       }
     },
   });
+  // The job the pending auto-load is waiting on, read by the context-change effect
+  // below. Written from an effect, never during render.
+  const pendingAutoLoadKeyRef = useRef<string | null>(null);
   useEffect(() => {
     const pending = pendingHubAutoLoad;
-    if (!pending) return;
+    if (!pending) {
+      pendingAutoLoadKeyRef.current = null;
+      return;
+    }
+    const pendingKey = jobKeyOf(
+      DOWNLOAD_KIND.MODEL,
+      pending.selection.id,
+      pending.selection.ggufVariant ?? null,
+    );
+    pendingAutoLoadKeyRef.current = pendingKey;
     let active = true;
     void (async () => {
       const outcome = await downloadManager.requestStart({
@@ -2905,15 +2917,19 @@ export function ChatPage({
       // This selection is no longer the pending auto-load: the user picked another
       // model, so its completion loads nothing. Drop the toast still saying it will.
       // A no-op once the download itself finished, which dismisses the same id.
-      dismissStartToast(
-        jobKeyOf(
-          DOWNLOAD_KIND.MODEL,
-          pending.selection.id,
-          pending.selection.ggufVariant ?? null,
-        ),
-      );
+      dismissStartToast(pendingKey);
     };
   }, [pendingHubAutoLoad]);
+  // Switching thread, project or starting a new chat keeps the pathname at /chat and
+  // leaves pendingHubAutoLoad untouched, so neither the route sweep nor the cleanup
+  // above runs. onComplete refuses to load into a different contextKey, so the toast
+  // would go on promising an auto-load that cannot happen.
+  useEffect(() => {
+    return () => {
+      const pendingKey = pendingAutoLoadKeyRef.current;
+      if (pendingKey) dismissStartToast(pendingKey);
+    };
+  }, [chatContextKey]);
   const loadNativeModelIntent = useCallback(
     async (intent: NativeIntent, loadingDescription: string) => {
       const label =

--- a/studio/frontend/src/features/chat/chat-page.tsx
+++ b/studio/frontend/src/features/chat/chat-page.tsx
@@ -2864,17 +2864,19 @@ export function ChatPage({
         repoId: pending.selection.id,
         variant: pending.selection.ggufVariant ?? null,
         expectedBytes: pending.selection.expectedBytes ?? 0,
-        // As above: raised by the download manager, folded into the notice.
+        // Folded into the Xet notice only. #9663 removed this surface's own toast
+        // as a duplicate of the download panel, so it must not come back on an
+        // HTTP start or once the three notices are spent.
         callerToast: {
           title: "Downloading model",
           description: "It'll load automatically once the download finishes.",
+          noticeOnly: true,
         },
       });
       if (!active) return;
       if (outcome === "started") {
-        // No toast HERE. #9663 dropped it as a duplicate of the download panel;
-        // its sentence still travels as callerToast above and is folded into the
-        // Xet notice. The auto-load still runs from onComplete.
+        // No toast HERE, and none from the manager either unless the Xet notice
+        // fires and folds the sentence in. The auto-load runs from onComplete.
         return;
       }
       if (outcome === "conflict") {

--- a/studio/frontend/src/features/chat/chat-page.tsx
+++ b/studio/frontend/src/features/chat/chat-page.tsx
@@ -2748,6 +2748,9 @@ export function ChatPage({
             repoId: selection.id,
             variant: selection.ggufVariant ?? null,
             expectedBytes: selection.expectedBytes ?? 0,
+            // This surface toasts about the start below, so the Xet notice
+            // stays quiet rather than stacking a second one on top of it.
+            callerExplainsWait: true,
           });
           if (outcome === "started") {
             toast.info("Downloading in the background", {
@@ -2862,6 +2865,9 @@ export function ChatPage({
         repoId: pending.selection.id,
         variant: pending.selection.ggufVariant ?? null,
         expectedBytes: pending.selection.expectedBytes ?? 0,
+        // Same reason as the background path: the "Downloading model" toast
+        // below already tells the user the wait is expected.
+        callerExplainsWait: true,
       });
       if (!active) return;
       if (outcome === "started") {

--- a/studio/frontend/src/features/chat/chat-page.tsx
+++ b/studio/frontend/src/features/chat/chat-page.tsx
@@ -2748,16 +2748,16 @@ export function ChatPage({
             repoId: selection.id,
             variant: selection.ggufVariant ?? null,
             expectedBytes: selection.expectedBytes ?? 0,
-            // This surface toasts about the start below, so the Xet notice
-            // stays quiet rather than stacking a second one on top of it.
-            callerExplainsWait: true,
-          });
-          if (outcome === "started") {
-            toast.info("Downloading in the background", {
+            // Hand the message over instead of raising it here. The download
+            // manager folds it into the Xet notice when that fires, so one
+            // start produces one toast carrying both explanations.
+            callerToast: {
+              title: "Downloading in the background",
               description:
                 "It'll be ready to load once the current model finishes.",
-            });
-          } else if (outcome === "conflict") {
+            },
+          });
+          if (outcome === "conflict") {
             toast.info("Resume this download from Models", {
               description:
                 "An earlier partial download used a different transport. Open the Model hub tab to resume or restart it.",
@@ -2865,14 +2865,20 @@ export function ChatPage({
         repoId: pending.selection.id,
         variant: pending.selection.ggufVariant ?? null,
         expectedBytes: pending.selection.expectedBytes ?? 0,
-        // Same reason as the background path: the "Downloading model" toast
-        // below already tells the user the wait is expected.
-        callerExplainsWait: true,
+        // As above: the download manager raises this, folded into the Xet
+        // notice when that fires.
+        callerToast: {
+          title: "Downloading model",
+          description: "It'll load automatically once the download finishes.",
+        },
       });
       if (!active) return;
       if (outcome === "started") {
-        // No toast: the download panel already shows this download. The
-        // auto-load still runs from onComplete.
+        // No toast raised HERE. #9663 dropped the one that used to live on this
+        // line because it duplicated the download panel; its sentence is not
+        // dropped though, it travels as callerToast above and the download
+        // manager folds it into the Xet notice rather than stacking a second
+        // card in the same corner. The auto-load still runs from onComplete.
         return;
       }
       if (outcome === "conflict") {

--- a/studio/frontend/src/features/chat/chat-page.tsx
+++ b/studio/frontend/src/features/chat/chat-page.tsx
@@ -2750,8 +2750,7 @@ export function ChatPage({
             repoId: selection.id,
             variant: selection.ggufVariant ?? null,
             expectedBytes: selection.expectedBytes ?? 0,
-            // Handed over, not raised here: the manager folds it into the Xet
-            // notice so one start produces one toast carrying both.
+            // Handed over, not raised here, so one start makes one toast.
             callerToast: {
               title: "Downloading in the background",
               description:
@@ -2856,11 +2855,10 @@ export function ChatPage({
       }
     },
   });
-  // The job the pending auto-load is waiting on, read by the context-change effect
-  // below. Written from an effect, never during render.
+  // The pending auto-load's job, for the context-change effect below. Written from
+  // an effect, never during render.
   const pendingAutoLoadKeyRef = useRef<string | null>(null);
-  // The live context, so a start still in flight can be asked whether the thread it
-  // was requested from is still the one on screen.
+  // The live context, so a start still in flight can check it is still on screen.
   const chatContextKeyRef = useRef(chatContextKey);
   useEffect(() => {
     chatContextKeyRef.current = chatContextKey;
@@ -2884,24 +2882,21 @@ export function ChatPage({
         repoId: pending.selection.id,
         variant: pending.selection.ggufVariant ?? null,
         expectedBytes: pending.selection.expectedBytes ?? 0,
-        // Folded into the Xet notice only. #9663 removed this surface's own toast
-        // as a duplicate of the download panel, so it must not come back on an
-        // HTTP start or once the three notices are spent.
+        // Notice-only: #9663 removed this surface's own toast, so it must not
+        // return on an HTTP start or once the three notices are spent.
         callerToast: {
           title: "Downloading model",
           description: "It'll load automatically once the download finishes.",
           noticeOnly: true,
-          // Asked again when the toast is finally raised, which can be several round
-          // trips later. The cleanup below only dismisses a toast that already exists;
-          // a raise still in flight would otherwise promise an auto-load that
-          // onComplete refuses, since the contextKey it was staged for has changed.
+          // The cleanup below only reaches a toast that already exists; a raise
+          // still in flight would promise an auto-load onComplete then refuses.
           stillValid: () => chatContextKeyRef.current === pending.contextKey,
         },
       });
       if (!active) return;
       if (outcome === "started") {
-        // No toast HERE, and none from the manager either unless the Xet notice
-        // fires and folds the sentence in. The auto-load runs from onComplete.
+        // No toast here, and none from the manager unless the notice folds the
+        // sentence in. The auto-load runs from onComplete.
         return;
       }
       if (outcome === "conflict") {
@@ -2925,16 +2920,13 @@ export function ChatPage({
     })();
     return () => {
       active = false;
-      // This selection is no longer the pending auto-load: the user picked another
-      // model, so its completion loads nothing. Drop the toast still saying it will.
-      // A no-op once the download itself finished, which dismisses the same id.
+      // Another model was picked, so this one's completion loads nothing. A no-op
+      // once the download finished, which dismisses the same id.
       dismissStartToast(pendingKey);
     };
   }, [pendingHubAutoLoad]);
-  // Switching thread, project or starting a new chat keeps the pathname at /chat and
-  // leaves pendingHubAutoLoad untouched, so neither the route sweep nor the cleanup
-  // above runs. onComplete refuses to load into a different contextKey, so the toast
-  // would go on promising an auto-load that cannot happen.
+  // Switching thread or project keeps the pathname and pendingHubAutoLoad, so neither
+  // sweep above runs, yet onComplete refuses to load into a different contextKey.
   useEffect(() => {
     return () => {
       const pendingKey = pendingAutoLoadKeyRef.current;

--- a/studio/frontend/src/features/chat/chat-page.tsx
+++ b/studio/frontend/src/features/chat/chat-page.tsx
@@ -2748,9 +2748,8 @@ export function ChatPage({
             repoId: selection.id,
             variant: selection.ggufVariant ?? null,
             expectedBytes: selection.expectedBytes ?? 0,
-            // Hand the message over instead of raising it here. The download
-            // manager folds it into the Xet notice when that fires, so one
-            // start produces one toast carrying both explanations.
+            // Handed over, not raised here: the manager folds it into the Xet
+            // notice so one start produces one toast carrying both.
             callerToast: {
               title: "Downloading in the background",
               description:
@@ -2865,8 +2864,7 @@ export function ChatPage({
         repoId: pending.selection.id,
         variant: pending.selection.ggufVariant ?? null,
         expectedBytes: pending.selection.expectedBytes ?? 0,
-        // As above: the download manager raises this, folded into the Xet
-        // notice when that fires.
+        // As above: raised by the download manager, folded into the notice.
         callerToast: {
           title: "Downloading model",
           description: "It'll load automatically once the download finishes.",
@@ -2874,11 +2872,9 @@ export function ChatPage({
       });
       if (!active) return;
       if (outcome === "started") {
-        // No toast raised HERE. #9663 dropped the one that used to live on this
-        // line because it duplicated the download panel; its sentence is not
-        // dropped though, it travels as callerToast above and the download
-        // manager folds it into the Xet notice rather than stacking a second
-        // card in the same corner. The auto-load still runs from onComplete.
+        // No toast HERE. #9663 dropped it as a duplicate of the download panel;
+        // its sentence still travels as callerToast above and is folded into the
+        // Xet notice. The auto-load still runs from onComplete.
         return;
       }
       if (outcome === "conflict") {

--- a/studio/frontend/src/features/chat/chat-page.tsx
+++ b/studio/frontend/src/features/chat/chat-page.tsx
@@ -57,7 +57,9 @@ import { Tooltip, TooltipContent } from "@/components/ui/tooltip";
 import { useIsMobile } from "@/hooks/use-mobile";
 import {
   DOWNLOAD_KIND,
+  dismissStartToast,
   downloadManager,
+  jobKeyOf,
   useRepoDownload,
 } from "@/features/hub/download-manager";
 import {
@@ -2900,6 +2902,16 @@ export function ChatPage({
     })();
     return () => {
       active = false;
+      // This selection is no longer the pending auto-load: the user picked another
+      // model, so its completion loads nothing. Drop the toast still saying it will.
+      // A no-op once the download itself finished, which dismisses the same id.
+      dismissStartToast(
+        jobKeyOf(
+          DOWNLOAD_KIND.MODEL,
+          pending.selection.id,
+          pending.selection.ggufVariant ?? null,
+        ),
+      );
     };
   }, [pendingHubAutoLoad]);
   const loadNativeModelIntent = useCallback(

--- a/studio/frontend/src/features/chat/chat-page.tsx
+++ b/studio/frontend/src/features/chat/chat-page.tsx
@@ -2859,6 +2859,12 @@ export function ChatPage({
   // The job the pending auto-load is waiting on, read by the context-change effect
   // below. Written from an effect, never during render.
   const pendingAutoLoadKeyRef = useRef<string | null>(null);
+  // The live context, so a start still in flight can be asked whether the thread it
+  // was requested from is still the one on screen.
+  const chatContextKeyRef = useRef(chatContextKey);
+  useEffect(() => {
+    chatContextKeyRef.current = chatContextKey;
+  }, [chatContextKey]);
   useEffect(() => {
     const pending = pendingHubAutoLoad;
     if (!pending) {
@@ -2885,6 +2891,11 @@ export function ChatPage({
           title: "Downloading model",
           description: "It'll load automatically once the download finishes.",
           noticeOnly: true,
+          // Asked again when the toast is finally raised, which can be several round
+          // trips later. The cleanup below only dismisses a toast that already exists;
+          // a raise still in flight would otherwise promise an auto-load that
+          // onComplete refuses, since the contextKey it was staged for has changed.
+          stillValid: () => chatContextKeyRef.current === pending.contextKey,
         },
       });
       if (!active) return;

--- a/studio/frontend/src/features/hub/download-manager/download-manager-types.ts
+++ b/studio/frontend/src/features/hub/download-manager/download-manager-types.ts
@@ -81,6 +81,11 @@ export interface CallerToast {
    * worth carrying inside the notice, but showing it alone would put the removed
    * toast back on every HTTP start. */
   noticeOnly?: boolean;
+  /** Asked again just before the toast is raised, which can be several round trips
+   * after the start was requested. False drops this line: the state it describes is
+   * gone (chat moved to another thread, so nothing auto-loads), even though the
+   * transfer it was attached to is still running. Absent means always valid. */
+  stillValid?: () => boolean;
 }
 
 /** The variant slot a scoped job occupies. Mirrors the backend's `_scope_variant`: no GGUF quant label starts with "@", so a scope collides with neither a real variant nor the repo's full snapshot. */

--- a/studio/frontend/src/features/hub/download-manager/download-manager-types.ts
+++ b/studio/frontend/src/features/hub/download-manager/download-manager-types.ts
@@ -65,15 +65,10 @@ export interface DownloadRequest {
   checkpoint?: boolean;
   /** What this surface wants said about the start, for the download manager to raise.
    *
-   * Chat used to toast this itself the moment `requestStart` resolved, while `startJob`
-   * independently raised the Xet notice for the same start, so one download produced two
-   * toasts stacked in the same corner. Suppressing one of them loses information: the
-   * notice explains why the bar sits at 0%, chat's line explains that the model loads by
-   * itself afterwards, and the user wants both.
-   *
-   * So the caller states its message and the download manager decides how to say it: folded
-   * into the notice when the notice fires, on its own when it does not (HTTP transport, the
-   * three uses spent, an attached job). One start, one toast, nothing dropped. */
+   * Chat used to toast this itself while startJob raised the Xet notice for the same
+   * start, stacking two toasts. Suppressing one loses information, so the caller states
+   * its message and the manager folds it into the notice, or shows it alone when the
+   * notice does not fire. One start, one toast, nothing dropped. */
   callerToast?: { title: string; description: string };
 }
 

--- a/studio/frontend/src/features/hub/download-manager/download-manager-types.ts
+++ b/studio/frontend/src/features/hub/download-manager/download-manager-types.ts
@@ -63,6 +63,12 @@ export interface DownloadRequest {
   files?: string[];
   /** See `ManagedDownload.checkpoint`. Carried on the request so the job records the role its stager already knew, rather than a surface re-deriving it from filenames. */
   checkpoint?: boolean;
+  /** The caller raises its own toast for this start, so the Xet notice must stay quiet.
+   *
+   * Chat's model picker already says "Downloading model, it'll load automatically once
+   * the download finishes", which is the same reassurance the Xet notice exists to give.
+   * Without this the two stack in the same corner and the user gets told twice. */
+  callerExplainsWait?: boolean;
 }
 
 /** The variant slot a scoped job occupies. Mirrors the backend's `_scope_variant`: no GGUF quant label starts with "@", so a scope collides with neither a real variant nor the repo's full snapshot. */

--- a/studio/frontend/src/features/hub/download-manager/download-manager-types.ts
+++ b/studio/frontend/src/features/hub/download-manager/download-manager-types.ts
@@ -63,12 +63,18 @@ export interface DownloadRequest {
   files?: string[];
   /** See `ManagedDownload.checkpoint`. Carried on the request so the job records the role its stager already knew, rather than a surface re-deriving it from filenames. */
   checkpoint?: boolean;
-  /** The caller raises its own toast for this start, so the Xet notice must stay quiet.
+  /** What this surface wants said about the start, for the download manager to raise.
    *
-   * Chat's model picker already says "Downloading model, it'll load automatically once
-   * the download finishes", which is the same reassurance the Xet notice exists to give.
-   * Without this the two stack in the same corner and the user gets told twice. */
-  callerExplainsWait?: boolean;
+   * Chat used to toast this itself the moment `requestStart` resolved, while `startJob`
+   * independently raised the Xet notice for the same start, so one download produced two
+   * toasts stacked in the same corner. Suppressing one of them loses information: the
+   * notice explains why the bar sits at 0%, chat's line explains that the model loads by
+   * itself afterwards, and the user wants both.
+   *
+   * So the caller states its message and the download manager decides how to say it: folded
+   * into the notice when the notice fires, on its own when it does not (HTTP transport, the
+   * three uses spent, an attached job). One start, one toast, nothing dropped. */
+  callerToast?: { title: string; description: string };
 }
 
 /** The variant slot a scoped job occupies. Mirrors the backend's `_scope_variant`: no GGUF quant label starts with "@", so a scope collides with neither a real variant nor the repo's full snapshot. */

--- a/studio/frontend/src/features/hub/download-manager/download-manager-types.ts
+++ b/studio/frontend/src/features/hub/download-manager/download-manager-types.ts
@@ -69,7 +69,18 @@ export interface DownloadRequest {
    * start, stacking two toasts. Suppressing one loses information, so the caller states
    * its message and the manager folds it into the notice, or shows it alone when the
    * notice does not fire. One start, one toast, nothing dropped. */
-  callerToast?: { title: string; description: string };
+  callerToast?: CallerToast;
+}
+
+export interface CallerToast {
+  title: string;
+  description: string;
+  /** Fold this into a granted Xet notice, but never raise it on its own. For a
+   * surface whose standalone toast was deliberately removed (#9663 dropped chat's
+   * auto-load toast as a duplicate of the download panel): the sentence is still
+   * worth carrying inside the notice, but showing it alone would put the removed
+   * toast back on every HTTP start. */
+  noticeOnly?: boolean;
 }
 
 /** The variant slot a scoped job occupies. Mirrors the backend's `_scope_variant`: no GGUF quant label starts with "@", so a scope collides with neither a real variant nor the repo's full snapshot. */

--- a/studio/frontend/src/features/hub/download-manager/download-manager-types.ts
+++ b/studio/frontend/src/features/hub/download-manager/download-manager-types.ts
@@ -64,27 +64,22 @@ export interface DownloadRequest {
   /** See `ManagedDownload.checkpoint`. Carried on the request so the job records the role its stager already knew, rather than a surface re-deriving it from filenames. */
   checkpoint?: boolean;
   /** What this surface wants said about the start, for the download manager to raise.
-   *
-   * Chat used to toast this itself while startJob raised the Xet notice for the same
-   * start, stacking two toasts. Suppressing one loses information, so the caller states
-   * its message and the manager folds it into the notice, or shows it alone when the
-   * notice does not fire. One start, one toast, nothing dropped. */
+   * Chat used to toast this itself while startJob raised the Xet notice, stacking two.
+   * Suppressing one loses information, so the manager folds this into the notice, or
+   * shows it alone when the notice does not fire. One start, one toast. */
   callerToast?: CallerToast;
 }
 
 export interface CallerToast {
   title: string;
   description: string;
-  /** Fold this into a granted Xet notice, but never raise it on its own. For a
-   * surface whose standalone toast was deliberately removed (#9663 dropped chat's
-   * auto-load toast as a duplicate of the download panel): the sentence is still
-   * worth carrying inside the notice, but showing it alone would put the removed
-   * toast back on every HTTP start. */
+  /** Fold into a granted Xet notice, never raise alone. #9663 removed chat's
+   * auto-load toast as a duplicate of the download panel: the sentence is still worth
+   * carrying inside the notice, but alone it would put that toast back. */
   noticeOnly?: boolean;
-  /** Asked again just before the toast is raised, which can be several round trips
-   * after the start was requested. False drops this line: the state it describes is
-   * gone (chat moved to another thread, so nothing auto-loads), even though the
-   * transfer it was attached to is still running. Absent means always valid. */
+  /** Asked again just before the raise, several round trips after the request. False
+   * drops this line and keeps the notice: chat moved to another thread so nothing
+   * auto-loads, but the transfer is still running. Absent means always valid. */
   stillValid?: () => boolean;
 }
 

--- a/studio/frontend/src/features/hub/download-manager/index.ts
+++ b/studio/frontend/src/features/hub/download-manager/index.ts
@@ -49,7 +49,7 @@ export {
   type StagedDownloadEntry,
 } from "./use-staged-download";
 export { scopedVariant } from "./download-manager-types";
-export { dismissStartToasts } from "./start-toast";
+export { dismissStartToast, dismissStartToasts } from "./start-toast";
 export {
   getTransportMode,
   useDownloadTransportCapabilities,

--- a/studio/frontend/src/features/hub/download-manager/index.ts
+++ b/studio/frontend/src/features/hub/download-manager/index.ts
@@ -49,6 +49,7 @@ export {
   type StagedDownloadEntry,
 } from "./use-staged-download";
 export { scopedVariant } from "./download-manager-types";
+export { dismissStartToasts } from "./start-toast";
 export {
   getTransportMode,
   useDownloadTransportCapabilities,

--- a/studio/frontend/src/features/hub/download-manager/poll-loop.ts
+++ b/studio/frontend/src/features/hub/download-manager/poll-loop.ts
@@ -65,14 +65,16 @@ import type {
   Terminal,
 } from "./download-manager-types";
 import {
-  XET_NOTICE_DESCRIPTION,
-  XET_NOTICE_DESCRIPTION_CLASS,
-  XET_NOTICE_DURATION_MS,
   XET_NOTICE_TITLE,
-  reserveXetNotice,
+  composeNoticeDescription,
   shouldShowXetNotice,
-  xetNoticesShown,
 } from "./xet-progress-notice";
+import { reserveXetNoticeFromServer } from "@/features/settings/api/xet-notice";
+import {
+  dismissStartToast,
+  showCallerToast,
+  showStartToast,
+} from "./start-toast";
 import {
   getState,
   hasActiveRepoPeer,
@@ -201,6 +203,12 @@ export function finalize(
 ): void {
   const job = getState().jobs[key];
   teardownRuntime(key);
+  // The start toast describes a transfer that is now over. Its 8s duration is a
+  // cap, not a description of the download: a small model finished, auto-loaded,
+  // and the toast was still saying the download was running. Dismiss on every
+  // terminal outcome, before the early returns below, so a job that finished
+  // between polls or was already in a terminal display state still clears it.
+  dismissStartToast(key);
   if (!job) return;
   if (TERMINAL_DISPLAY_STATES.has(job.state)) return;
   if (job.kind === DOWNLOAD_KIND.MODEL) {
@@ -734,7 +742,9 @@ export async function startJob(
     }
     const started = transportAfterStart(mode, result.transport);
     if (started !== activeTransport) patchJob(key, { transport: started });
-    // Explain the 0%-then-done shape of a Xet transfer, for the first few only.
+    // One start, one toast. This is the ONLY place a start is announced: chat used
+    // to raise its own the moment requestStart resolved, which stacked a second
+    // toast under this one for the same download.
     if (
       shouldShowXetNotice({
         kind: req.kind,
@@ -743,22 +753,23 @@ export async function startJob(
         // A cancel can land while this start is in flight, and the reissue
         // above is the giveaway. Do not promise a download that is stopping.
         live: result.state === "running" && !rt.cancelRequested,
-        // Chat's picker toasts about this same start; two toasts in one corner
-        // is what the user sees, not two explanations.
-        callerExplained: req.callerExplainsWait === true,
-        shown: xetNoticesShown(),
       })
     ) {
-      // Reserving is async (a cross-tab lock), and nothing below waits on a
-      // toast, so let the download get on with it.
-      void reserveXetNotice().then((reserved) => {
-        if (!reserved) return;
-        toast.info(XET_NOTICE_TITLE, {
-          description: XET_NOTICE_DESCRIPTION,
-          duration: XET_NOTICE_DURATION_MS,
-          classNames: { description: XET_NOTICE_DESCRIPTION_CLASS },
-        });
+      // Reserving is async (it asks the backend for one of the three), and
+      // nothing below waits on a toast, so let the download get on with it.
+      // Losing the reservation still leaves the caller owed its message.
+      void reserveXetNoticeFromServer().then(({ granted }) => {
+        if (granted) {
+          showStartToast(key, {
+            title: XET_NOTICE_TITLE,
+            description: composeNoticeDescription(req.callerToast),
+          });
+          return;
+        }
+        showCallerToast(key, req.callerToast);
       });
+    } else {
+      showCallerToast(key, req.callerToast);
     }
     // An adopted job can already have fallen back from Xet to HTTP, which
     // keeps its original cancel marker and so its stop control.

--- a/studio/frontend/src/features/hub/download-manager/poll-loop.ts
+++ b/studio/frontend/src/features/hub/download-manager/poll-loop.ts
@@ -73,6 +73,7 @@ import { reserveXetNoticeFromServer } from "@/features/settings/api/xet-notice";
 import {
   currentRoute,
   dismissStartToast,
+  liveCallerToast,
   showCallerToast,
   showStartToast,
 } from "./start-toast";
@@ -750,7 +751,14 @@ export async function startJob(
     // A cancel can land while this start is in flight, and the reissue above is
     // the giveaway. Neither message is true of a start that is already stopping.
     const stopping = rt.cancelRequested;
+    // Everything above this point was round trips the user could navigate during.
+    // Checked BEFORE reserving, not only when the toast is raised: a reservation is
+    // one of three for the life of the install, and spending it on a toast that will
+    // be discarded on arrival is how starting a download and going to look at it
+    // burns all three unseen.
+    const onOriginRoute = currentRoute() === startRoute;
     if (
+      onOriginRoute &&
       shouldShowXetNotice({
         kind: req.kind,
         transport: started,
@@ -766,21 +774,25 @@ export async function startJob(
         // cancelled job claiming to be running for another 8s, or hand a restarted
         // job on the same key the old request's message.
         if (!isCurrent(key, epoch) || rt.cancelRequested) return;
+        // The caller's line can go stale on its own while the notice stays true: chat
+        // moved to another thread, so nothing auto-loads, but the transfer is still
+        // running and still needs the 0% explained.
+        const caller = liveCallerToast(req.callerToast);
         if (granted) {
           showStartToast(
             key,
             {
               title: XET_NOTICE_TITLE,
-              description: composeNoticeDescription(req.callerToast),
+              description: composeNoticeDescription(caller),
             },
             startRoute,
           );
           return;
         }
-        showCallerToast(key, req.callerToast, startRoute);
+        showCallerToast(key, caller, startRoute);
       });
-    } else if (!stopping) {
-      showCallerToast(key, req.callerToast, startRoute);
+    } else if (!stopping && onOriginRoute) {
+      showCallerToast(key, liveCallerToast(req.callerToast), startRoute);
     }
     // An adopted job can already have fallen back from Xet to HTTP, which
     // keeps its original cancel marker and so its stop control.

--- a/studio/frontend/src/features/hub/download-manager/poll-loop.ts
+++ b/studio/frontend/src/features/hub/download-manager/poll-loop.ts
@@ -741,19 +741,25 @@ export async function startJob(
     const started = transportAfterStart(mode, result.transport);
     if (started !== activeTransport) patchJob(key, { transport: started });
     // One start, one toast. The only place a start is announced.
+    // A cancel can land while this start is in flight, and the reissue above is
+    // the giveaway. Neither message is true of a start that is already stopping.
+    const stopping = rt.cancelRequested;
     if (
       shouldShowXetNotice({
         kind: req.kind,
         transport: started,
         attached: result.attached === true,
-        // A cancel can land while this start is in flight, and the reissue
-        // above is the giveaway. Do not promise a download that is stopping.
-        live: result.state === "running" && !rt.cancelRequested,
+        live: result.state === "running" && !stopping,
       })
     ) {
       // Async (it asks the backend for one of the three) and nothing below waits on
       // a toast. A lost reservation still leaves the caller owed its message.
       void reserveXetNoticeFromServer().then(({ granted }) => {
+        // This round trip can outlive the transfer: finalize() dismisses by id
+        // BEFORE this resolves, so raising it here would leave a finished or
+        // cancelled job claiming to be running for another 8s, or hand a restarted
+        // job on the same key the old request's message.
+        if (!isCurrent(key, epoch) || rt.cancelRequested) return;
         if (granted) {
           showStartToast(key, {
             title: XET_NOTICE_TITLE,
@@ -763,7 +769,7 @@ export async function startJob(
         }
         showCallerToast(key, req.callerToast);
       });
-    } else {
+    } else if (!stopping) {
       showCallerToast(key, req.callerToast);
     }
     // An adopted job can already have fallen back from Xet to HTTP, which

--- a/studio/frontend/src/features/hub/download-manager/poll-loop.ts
+++ b/studio/frontend/src/features/hub/download-manager/poll-loop.ts
@@ -581,9 +581,8 @@ export async function startJob(
     state?: DownloadJobState;
     transport?: ResolvedTransport;
     cancelTransport?: ResolvedTransport | null;
-    /** The surface this start was asked for, for the start toast to be held against.
-     * Passed in by `requestStart`, whose transport preflight is itself a round trip
-     * the user can navigate during; taken here only for a direct caller. */
+    /** The surface this start was asked for, to hold its toast against. Passed by
+     * `requestStart`, whose preflight is itself navigable; else taken here. */
     originRoute?: string;
   } = {},
 ): Promise<void> {
@@ -747,15 +746,14 @@ export async function startJob(
     }
     const started = transportAfterStart(mode, result.transport);
     if (started !== activeTransport) patchJob(key, { transport: started });
-    // One start, one toast. The only place a start is announced.
-    // A cancel can land while this start is in flight, and the reissue above is
-    // the giveaway. Neither message is true of a start that is already stopping.
+    // One start, one toast: the only place a start is announced. A cancel can land
+    // mid-flight (the reissue above is the giveaway), and neither message is true
+    // of a start that is already stopping.
     const stopping = rt.cancelRequested;
-    // Everything above this point was round trips the user could navigate during.
-    // Checked BEFORE reserving, not only when the toast is raised: a reservation is
-    // one of three for the life of the install, and spending it on a toast that will
-    // be discarded on arrival is how starting a download and going to look at it
-    // burns all three unseen.
+    // Everything above was round trips the user could navigate during. Checked BEFORE
+    // reserving, since a reservation is one of three for the life of the install:
+    // spending one on a toast that will be discarded on arrival is how starting a
+    // download and going to watch it burns all three unseen.
     const onOriginRoute = currentRoute() === startRoute;
     if (
       onOriginRoute &&
@@ -769,14 +767,12 @@ export async function startJob(
       // Async (it asks the backend for one of the three) and nothing below waits on
       // a toast. A lost reservation still leaves the caller owed its message.
       void reserveXetNoticeFromServer().then(({ granted }) => {
-        // This round trip can outlive the transfer: finalize() dismisses by id
-        // BEFORE this resolves, so raising it here would leave a finished or
-        // cancelled job claiming to be running for another 8s, or hand a restarted
-        // job on the same key the old request's message.
+        // This round trip can outlive the transfer: finalize() dismisses by id before
+        // it resolves, so raising here would leave a finished or cancelled job claiming
+        // to run for another 8s, or hand a restart on the same key a stale message.
         if (!isCurrent(key, epoch) || rt.cancelRequested) return;
-        // The caller's line can go stale on its own while the notice stays true: chat
-        // moved to another thread, so nothing auto-loads, but the transfer is still
-        // running and still needs the 0% explained.
+        // The caller's line can go stale while the notice stays true: chat moved
+        // thread, so nothing auto-loads, but the 0% still needs explaining.
         const caller = liveCallerToast(req.callerToast);
         if (granted) {
           showStartToast(

--- a/studio/frontend/src/features/hub/download-manager/poll-loop.ts
+++ b/studio/frontend/src/features/hub/download-manager/poll-loop.ts
@@ -71,6 +71,7 @@ import {
 } from "./xet-progress-notice";
 import { reserveXetNoticeFromServer } from "@/features/settings/api/xet-notice";
 import {
+  currentRoute,
   dismissStartToast,
   showCallerToast,
   showStartToast,
@@ -744,6 +745,10 @@ export async function startJob(
     // A cancel can land while this start is in flight, and the reissue above is
     // the giveaway. Neither message is true of a start that is already stopping.
     const stopping = rt.cancelRequested;
+    // The surface this start belongs to, taken now rather than when the toast is
+    // raised: the reservation below is a round trip, and a raise that lands after
+    // the user has navigated would otherwise claim the page they moved to.
+    const startRoute = currentRoute();
     if (
       shouldShowXetNotice({
         kind: req.kind,
@@ -761,16 +766,20 @@ export async function startJob(
         // job on the same key the old request's message.
         if (!isCurrent(key, epoch) || rt.cancelRequested) return;
         if (granted) {
-          showStartToast(key, {
-            title: XET_NOTICE_TITLE,
-            description: composeNoticeDescription(req.callerToast),
-          });
+          showStartToast(
+            key,
+            {
+              title: XET_NOTICE_TITLE,
+              description: composeNoticeDescription(req.callerToast),
+            },
+            startRoute,
+          );
           return;
         }
-        showCallerToast(key, req.callerToast);
+        showCallerToast(key, req.callerToast, startRoute);
       });
     } else if (!stopping) {
-      showCallerToast(key, req.callerToast);
+      showCallerToast(key, req.callerToast, startRoute);
     }
     // An adopted job can already have fallen back from Xet to HTTP, which
     // keeps its original cancel marker and so its stop control.

--- a/studio/frontend/src/features/hub/download-manager/poll-loop.ts
+++ b/studio/frontend/src/features/hub/download-manager/poll-loop.ts
@@ -203,11 +203,9 @@ export function finalize(
 ): void {
   const job = getState().jobs[key];
   teardownRuntime(key);
-  // The start toast describes a transfer that is now over. Its 8s duration is a
-  // cap, not a description of the download: a small model finished, auto-loaded,
-  // and the toast was still saying the download was running. Dismiss on every
-  // terminal outcome, before the early returns below, so a job that finished
-  // between polls or was already in a terminal display state still clears it.
+  // The 8s duration is a cap, not a description of the transfer: a finished download
+  // left the toast still claiming it was running. Before the early returns below, so
+  // a job already in a terminal display state still clears it.
   dismissStartToast(key);
   if (!job) return;
   if (TERMINAL_DISPLAY_STATES.has(job.state)) return;
@@ -742,9 +740,7 @@ export async function startJob(
     }
     const started = transportAfterStart(mode, result.transport);
     if (started !== activeTransport) patchJob(key, { transport: started });
-    // One start, one toast. This is the ONLY place a start is announced: chat used
-    // to raise its own the moment requestStart resolved, which stacked a second
-    // toast under this one for the same download.
+    // One start, one toast. The only place a start is announced.
     if (
       shouldShowXetNotice({
         kind: req.kind,
@@ -755,9 +751,8 @@ export async function startJob(
         live: result.state === "running" && !rt.cancelRequested,
       })
     ) {
-      // Reserving is async (it asks the backend for one of the three), and
-      // nothing below waits on a toast, so let the download get on with it.
-      // Losing the reservation still leaves the caller owed its message.
+      // Async (it asks the backend for one of the three) and nothing below waits on
+      // a toast. A lost reservation still leaves the caller owed its message.
       void reserveXetNoticeFromServer().then(({ granted }) => {
         if (granted) {
           showStartToast(key, {

--- a/studio/frontend/src/features/hub/download-manager/poll-loop.ts
+++ b/studio/frontend/src/features/hub/download-manager/poll-loop.ts
@@ -743,6 +743,9 @@ export async function startJob(
         // A cancel can land while this start is in flight, and the reissue
         // above is the giveaway. Do not promise a download that is stopping.
         live: result.state === "running" && !rt.cancelRequested,
+        // Chat's picker toasts about this same start; two toasts in one corner
+        // is what the user sees, not two explanations.
+        callerExplained: req.callerExplainsWait === true,
         shown: xetNoticesShown(),
       })
     ) {

--- a/studio/frontend/src/features/hub/download-manager/poll-loop.ts
+++ b/studio/frontend/src/features/hub/download-manager/poll-loop.ts
@@ -580,9 +580,14 @@ export async function startJob(
     state?: DownloadJobState;
     transport?: ResolvedTransport;
     cancelTransport?: ResolvedTransport | null;
+    /** The surface this start was asked for, for the start toast to be held against.
+     * Passed in by `requestStart`, whose transport preflight is itself a round trip
+     * the user can navigate during; taken here only for a direct caller. */
+    originRoute?: string;
   } = {},
 ): Promise<void> {
   const key = jobKeyOf(req.kind, req.repoId, req.variant);
+  const startRoute = opts.originRoute ?? currentRoute();
   // Peer guard stops a FRESH start from double-starting a variant already
   // downloading (or colliding with a no-variant snapshot). Skipped when ADOPTING:
   // the restored own entry would look like a peer and freeze the bar; adoptJob's
@@ -745,10 +750,6 @@ export async function startJob(
     // A cancel can land while this start is in flight, and the reissue above is
     // the giveaway. Neither message is true of a start that is already stopping.
     const stopping = rt.cancelRequested;
-    // The surface this start belongs to, taken now rather than when the toast is
-    // raised: the reservation below is a round trip, and a raise that lands after
-    // the user has navigated would otherwise claim the page they moved to.
-    const startRoute = currentRoute();
     if (
       shouldShowXetNotice({
         kind: req.kind,

--- a/studio/frontend/src/features/hub/download-manager/start-toast.ts
+++ b/studio/frontend/src/features/hub/download-manager/start-toast.ts
@@ -30,15 +30,22 @@ export function startToastId(jobKey: string): string {
 // then belongs to where it landed, and blanket dismissal would take it back out.
 const liveStartToasts = new Map<string, string>();
 
-function currentRoute(): string {
+/** The route to hold a start against. Capture it when the start begins, not when
+ * the toast is raised: the Xet reservation is a round trip, so a raise can land
+ * after the user has already navigated. */
+export function currentRoute(): string {
   return typeof window === "undefined" ? "" : window.location.pathname;
 }
 
 export function showStartToast(
   jobKey: string,
   message: { title: string; description: string },
+  originRoute: string = currentRoute(),
 ): void {
-  liveStartToasts.set(startToastId(jobKey), currentRoute());
+  // Raised late and the surface is gone: the route-change sweep has already been
+  // and gone, so this would sit on the new page for its full 8s.
+  if (originRoute !== currentRoute()) return;
+  liveStartToasts.set(startToastId(jobKey), originRoute);
   toast.info(message.title, {
     id: startToastId(jobKey),
     description: message.description,
@@ -53,9 +60,10 @@ export function showStartToast(
 export function showCallerToast(
   jobKey: string,
   message: CallerToast | undefined,
+  originRoute?: string,
 ): void {
   if (!message || message.noticeOnly) return;
-  showStartToast(jobKey, message);
+  showStartToast(jobKey, message, originRoute);
 }
 
 /** Drop the start toast once the transfer is over. Safe for a job that never raised

--- a/studio/frontend/src/features/hub/download-manager/start-toast.ts
+++ b/studio/frontend/src/features/hub/download-manager/start-toast.ts
@@ -1,21 +1,15 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-// The one toast that announces a download start, and the one place it is dismissed.
+// The one toast announcing a download start, and the one place it is dismissed.
 //
-// Two problems live here, and they are the same problem seen from two ends.
+// Chat used to raise its own while startJob raised the Xet notice, so one download
+// produced two stacked toasts. Callers now hand their message over and the download
+// manager folds it into the notice or shows it alone.
 //
-// Announcing: chat raised its own toast when requestStart resolved while startJob
-// independently raised the Xet notice, so one download produced two toasts stacked
-// in a corner. Callers now hand their message to the download manager instead of
-// speaking for themselves, and it decides whether that message travels folded into
-// the notice or on its own.
-//
-// Dismissing: the toast is sized by a fixed 8s duration that has nothing to do with
-// the transfer, so a small download finished, the model loaded, and the toast was
-// still on screen saying the download was running. The id is derived from the job
-// key rather than stored, because finalize() tears the runtime down before it would
-// get a chance to read anything held there.
+// The 8s duration is unrelated to the transfer, so a finished download left the toast
+// still claiming it was running. The id comes from the job key rather than being
+// stored, since finalize() tears the runtime down first.
 
 import { toast } from "@/lib/toast";
 
@@ -43,12 +37,9 @@ export function showStartToast(jobKey: string, message: CallerToast): void {
   });
 }
 
-/** The caller's own message, when the notice is not the one carrying it.
- *
- * Reached when the transport is HTTP, when the three notices are spent, when the
- * start attached to a job someone else owns, and when the reservation was lost.
- * A Hub start passes nothing and stays silent, which is the behaviour the notice
- * was written for. */
+/** The caller's own message, when the notice is not carrying it: HTTP transport,
+ * the three spent, an attached job, or a lost reservation. A Hub start passes
+ * nothing and stays silent. */
 export function showCallerToast(
   jobKey: string,
   message: CallerToast | undefined,
@@ -57,9 +48,8 @@ export function showCallerToast(
   showStartToast(jobKey, message);
 }
 
-/** Drop the start toast the moment the transfer it describes is over.
- *
- * Safe to call for a job that never raised one: sonner ignores an unknown id. */
+/** Drop the start toast once the transfer is over. Safe for a job that never raised
+ * one: sonner ignores an unknown id. */
 export function dismissStartToast(jobKey: string): void {
   toast.dismiss(startToastId(jobKey));
 }

--- a/studio/frontend/src/features/hub/download-manager/start-toast.ts
+++ b/studio/frontend/src/features/hub/download-manager/start-toast.ts
@@ -13,22 +13,32 @@
 
 import { toast } from "@/lib/toast";
 
+import type { CallerToast } from "./download-manager-types";
 import {
   XET_NOTICE_DESCRIPTION_CLASS,
   XET_NOTICE_DURATION_MS,
 } from "./xet-progress-notice";
-
-export interface CallerToast {
-  title: string;
-  description: string;
-}
 
 /** Stable per-job toast id, so `finalize` can dismiss without carrying state. */
 export function startToastId(jobKey: string): string {
   return `download-start:${jobKey}`;
 }
 
-export function showStartToast(jobKey: string, message: CallerToast): void {
+// Id -> the route it was raised on, so a navigation clears these and nothing else,
+// and only the ones that actually left their surface. Keyed on the route rather than
+// dismissing everything live, because a start can itself change the route: the toast
+// then belongs to where it landed, and blanket dismissal would take it back out.
+const liveStartToasts = new Map<string, string>();
+
+function currentRoute(): string {
+  return typeof window === "undefined" ? "" : window.location.pathname;
+}
+
+export function showStartToast(
+  jobKey: string,
+  message: { title: string; description: string },
+): void {
+  liveStartToasts.set(startToastId(jobKey), currentRoute());
   toast.info(message.title, {
     id: startToastId(jobKey),
     description: message.description,
@@ -39,17 +49,35 @@ export function showStartToast(jobKey: string, message: CallerToast): void {
 
 /** The caller's own message, when the notice is not carrying it: HTTP transport,
  * the three spent, an attached job, or a lost reservation. A Hub start passes
- * nothing and stays silent. */
+ * nothing and stays silent, and so does a `noticeOnly` caller. */
 export function showCallerToast(
   jobKey: string,
   message: CallerToast | undefined,
 ): void {
-  if (!message) return;
+  if (!message || message.noticeOnly) return;
   showStartToast(jobKey, message);
 }
 
 /** Drop the start toast once the transfer is over. Safe for a job that never raised
  * one: sonner ignores an unknown id. */
 export function dismissStartToast(jobKey: string): void {
-  toast.dismiss(startToastId(jobKey));
+  const id = startToastId(jobKey);
+  liveStartToasts.delete(id);
+  toast.dismiss(id);
+}
+
+/** Drop them all when the user leaves the surface that raised them.
+ *
+ * The Toaster is root-level and this lives 8s, so a start in chat followed by a
+ * click on Models carries the toast onto the hub toolbar. The composed chat form
+ * measures 167px tall against a filter row at 158px (1500x1000), which is the
+ * overlap #9293 reverted; the hub's own download panel already shows the transfer.
+ * Only ids raised here, so unrelated toasts survive the navigation. */
+export function dismissStartToasts(): void {
+  const here = currentRoute();
+  for (const [id, raisedOn] of liveStartToasts) {
+    if (raisedOn === here) continue;
+    liveStartToasts.delete(id);
+    toast.dismiss(id);
+  }
 }

--- a/studio/frontend/src/features/hub/download-manager/start-toast.ts
+++ b/studio/frontend/src/features/hub/download-manager/start-toast.ts
@@ -3,13 +3,10 @@
 
 // The one toast announcing a download start, and the one place it is dismissed.
 //
-// Chat used to raise its own while startJob raised the Xet notice, so one download
-// produced two stacked toasts. Callers now hand their message over and the download
-// manager folds it into the notice or shows it alone.
-//
-// The 8s duration is unrelated to the transfer, so a finished download left the toast
-// still claiming it was running. The id comes from the job key rather than being
-// stored, since finalize() tears the runtime down first.
+// Chat used to raise its own alongside the Xet notice, so one download produced two
+// stacked toasts; callers now hand their message over instead. The 8s duration says
+// nothing about the transfer, so the id is derived from the job key and finalize()
+// dismisses it (nothing can be stored: teardownRuntime runs first).
 
 import { toast } from "@/lib/toast";
 
@@ -24,15 +21,12 @@ export function startToastId(jobKey: string): string {
   return `download-start:${jobKey}`;
 }
 
-// Id -> the route it was raised on, so a navigation clears these and nothing else,
-// and only the ones that actually left their surface. Keyed on the route rather than
-// dismissing everything live, because a start can itself change the route: the toast
-// then belongs to where it landed, and blanket dismissal would take it back out.
+// Id -> the route it was raised on. Keyed that way rather than dismissing everything
+// live, because a start can itself navigate: that toast belongs where it landed.
 const liveStartToasts = new Map<string, string>();
 
-/** The route to hold a start against. Capture it when the start begins, not when
- * the toast is raised: the Xet reservation is a round trip, so a raise can land
- * after the user has already navigated. */
+/** The route to hold a start against. Captured when the start begins, since the
+ * preflight and the reservation are round trips a raise can outlive. */
 export function currentRoute(): string {
   return typeof window === "undefined" ? "" : window.location.pathname;
 }
@@ -42,8 +36,8 @@ export function showStartToast(
   message: { title: string; description: string },
   originRoute: string = currentRoute(),
 ): void {
-  // Raised late and the surface is gone: the route-change sweep has already been
-  // and gone, so this would sit on the new page for its full 8s.
+  // Raised late, surface gone: the route sweep has already run, so this would sit
+  // on the new page for its full 8s.
   if (originRoute !== currentRoute()) return;
   liveStartToasts.set(startToastId(jobKey), originRoute);
   toast.info(message.title, {
@@ -82,13 +76,10 @@ export function dismissStartToast(jobKey: string): void {
   toast.dismiss(id);
 }
 
-/** Drop them all when the user leaves the surface that raised them.
- *
- * The Toaster is root-level and this lives 8s, so a start in chat followed by a
- * click on Models carries the toast onto the hub toolbar. The composed chat form
- * measures 167px tall against a filter row at 158px (1500x1000), which is the
- * overlap #9293 reverted; the hub's own download panel already shows the transfer.
- * Only ids raised here, so unrelated toasts survive the navigation. */
+/** Drop the ones whose surface the user just left. The Toaster is root-level and
+ * these live 8s, so chat's composed form (measured 167px tall against a hub filter
+ * row at 158px, 1500x1000) would otherwise land on the toolbar, which is the overlap
+ * #9293 reverted. Only ids raised here, so other toasts survive the navigation. */
 export function dismissStartToasts(): void {
   const here = currentRoute();
   for (const [id, raisedOn] of liveStartToasts) {

--- a/studio/frontend/src/features/hub/download-manager/start-toast.ts
+++ b/studio/frontend/src/features/hub/download-manager/start-toast.ts
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// The one toast that announces a download start, and the one place it is dismissed.
+//
+// Two problems live here, and they are the same problem seen from two ends.
+//
+// Announcing: chat raised its own toast when requestStart resolved while startJob
+// independently raised the Xet notice, so one download produced two toasts stacked
+// in a corner. Callers now hand their message to the download manager instead of
+// speaking for themselves, and it decides whether that message travels folded into
+// the notice or on its own.
+//
+// Dismissing: the toast is sized by a fixed 8s duration that has nothing to do with
+// the transfer, so a small download finished, the model loaded, and the toast was
+// still on screen saying the download was running. The id is derived from the job
+// key rather than stored, because finalize() tears the runtime down before it would
+// get a chance to read anything held there.
+
+import { toast } from "@/lib/toast";
+
+import {
+  XET_NOTICE_DESCRIPTION_CLASS,
+  XET_NOTICE_DURATION_MS,
+} from "./xet-progress-notice";
+
+export interface CallerToast {
+  title: string;
+  description: string;
+}
+
+/** Stable per-job toast id, so `finalize` can dismiss without carrying state. */
+export function startToastId(jobKey: string): string {
+  return `download-start:${jobKey}`;
+}
+
+export function showStartToast(jobKey: string, message: CallerToast): void {
+  toast.info(message.title, {
+    id: startToastId(jobKey),
+    description: message.description,
+    duration: XET_NOTICE_DURATION_MS,
+    classNames: { description: XET_NOTICE_DESCRIPTION_CLASS },
+  });
+}
+
+/** The caller's own message, when the notice is not the one carrying it.
+ *
+ * Reached when the transport is HTTP, when the three notices are spent, when the
+ * start attached to a job someone else owns, and when the reservation was lost.
+ * A Hub start passes nothing and stays silent, which is the behaviour the notice
+ * was written for. */
+export function showCallerToast(
+  jobKey: string,
+  message: CallerToast | undefined,
+): void {
+  if (!message) return;
+  showStartToast(jobKey, message);
+}
+
+/** Drop the start toast the moment the transfer it describes is over.
+ *
+ * Safe to call for a job that never raised one: sonner ignores an unknown id. */
+export function dismissStartToast(jobKey: string): void {
+  toast.dismiss(startToastId(jobKey));
+}

--- a/studio/frontend/src/features/hub/download-manager/start-toast.ts
+++ b/studio/frontend/src/features/hub/download-manager/start-toast.ts
@@ -54,6 +54,14 @@ export function showStartToast(
   });
 }
 
+/** The caller's message if it still describes something true, else nothing. */
+export function liveCallerToast(
+  message: CallerToast | undefined,
+): CallerToast | undefined {
+  if (!message) return undefined;
+  return (message.stillValid?.() ?? true) ? message : undefined;
+}
+
 /** The caller's own message, when the notice is not carrying it: HTTP transport,
  * the three spent, an attached job, or a lost reservation. A Hub start passes
  * nothing and stays silent, and so does a `noticeOnly` caller. */

--- a/studio/frontend/src/features/hub/download-manager/transport-conflict.ts
+++ b/studio/frontend/src/features/hub/download-manager/transport-conflict.ts
@@ -22,7 +22,7 @@ import {
   setConflict,
 } from "./download-manager-state";
 import { startJob } from "./poll-loop";
-import { showCallerToast } from "./start-toast";
+import { currentRoute, showCallerToast } from "./start-toast";
 import { runtimeRegistry } from "./runtime-registry";
 import { getTransportMode } from "./transport-preference";
 import { ACTIVE_STATES, TRANSPORT_STATUS_TIMEOUT_MS } from "./download-manager-config";
@@ -132,7 +132,10 @@ async function runWithPendingStartGuard(
     // Returns "started" WITHOUT running the action, so startJob never announces.
     // Callers used to cover this by toasting themselves; now the manager owns the
     // message, so without this the user gets no feedback at all.
-    showCallerToast(jobKeyOf(req.kind, req.repoId, req.variant), req.callerToast);
+    showCallerToast(
+      jobKeyOf(req.kind, req.repoId, req.variant),
+      req.callerToast,
+    );
     return "started";
   }
   runtimeRegistry.pendingStartRepoKeys.add(startKey);
@@ -149,6 +152,10 @@ async function runWithPendingStartGuard(
 export async function requestStart(
   req: DownloadRequest,
 ): Promise<DownloadStartOutcome> {
+  // Before the preflight below, which is two round trips the user can navigate
+  // during. A route read after them would name the page they moved to, and the
+  // start toast would then be held against the wrong surface.
+  const originRoute = currentRoute();
   return runWithPendingStartGuard(req, async () => {
     let mode: TransportMode = getTransportMode();
     try {
@@ -217,7 +224,7 @@ export async function requestStart(
           description:
             "Starting with HTTP so an existing partial is not discarded. Switch transport to retry with Xet.",
         });
-        await startJob(req, { useXet: false });
+        await startJob(req, { useXet: false, originRoute });
         return isJobActiveFor(req) ? "started" : "error";
       }
       toast.warning("Couldn't verify existing partial download", {
@@ -225,7 +232,7 @@ export async function requestStart(
           "Starting with the selected transport. If a partial from another transport exists, it may be restarted from the beginning.",
       });
     }
-    await startJob(req, { useXet: mode === TRANSPORT.XET });
+    await startJob(req, { useXet: mode === TRANSPORT.XET, originRoute });
     return isJobActiveFor(req) ? "started" : "error";
   });
 }

--- a/studio/frontend/src/features/hub/download-manager/transport-conflict.ts
+++ b/studio/frontend/src/features/hub/download-manager/transport-conflict.ts
@@ -129,9 +129,8 @@ async function runWithPendingStartGuard(
   // exact request is the live transfer; a peer/snapshot/pending start has not.
   if (hasActiveOrPendingStart(req)) {
     if (!isJobActiveFor(req)) return "busy";
-    // Returns "started" WITHOUT running the action, so startJob never announces.
-    // Callers used to cover this by toasting themselves; now the manager owns the
-    // message, so without this the user gets no feedback at all.
+    // Returns "started" WITHOUT running the action, so startJob never announces;
+    // now the manager owns the message, this is the only feedback there is.
     showCallerToast(
       jobKeyOf(req.kind, req.repoId, req.variant),
       req.callerToast,
@@ -153,8 +152,7 @@ export async function requestStart(
   req: DownloadRequest,
 ): Promise<DownloadStartOutcome> {
   // Before the preflight below, which is two round trips the user can navigate
-  // during. A route read after them would name the page they moved to, and the
-  // start toast would then be held against the wrong surface.
+  // during; read after them it would name the page they moved to.
   const originRoute = currentRoute();
   return runWithPendingStartGuard(req, async () => {
     let mode: TransportMode = getTransportMode();
@@ -196,9 +194,8 @@ export async function requestStart(
             next: mode,
             resumable: status.resumable,
           },
-          // Without the caller's line: this start is resolved later from the Hub,
-          // where "it'll load automatically" is a promise chat cannot keep once it
-          // is inactive. The Xet notice still explains the 0% on its own.
+          // Without the caller's line: resolved later from the Hub, where "it'll
+          // load automatically" is a promise chat cannot keep. The notice stands.
           pending: { ...req, callerToast: undefined },
         });
         return "conflict";

--- a/studio/frontend/src/features/hub/download-manager/transport-conflict.ts
+++ b/studio/frontend/src/features/hub/download-manager/transport-conflict.ts
@@ -129,11 +129,9 @@ async function runWithPendingStartGuard(
   // exact request is the live transfer; a peer/snapshot/pending start has not.
   if (hasActiveOrPendingStart(req)) {
     if (!isJobActiveFor(req)) return "busy";
-    // This returns "started" WITHOUT running the action, so startJob never
-    // executes and never announces anything. Callers used to toast for
-    // themselves on "started" and so covered this path by accident; now that
-    // the download manager owns the message, saying nothing here would leave a
-    // user who just picked a model with no feedback at all.
+    // Returns "started" WITHOUT running the action, so startJob never announces.
+    // Callers used to cover this by toasting themselves; now the manager owns the
+    // message, so without this the user gets no feedback at all.
     showCallerToast(jobKeyOf(req.kind, req.repoId, req.variant), req.callerToast);
     return "started";
   }

--- a/studio/frontend/src/features/hub/download-manager/transport-conflict.ts
+++ b/studio/frontend/src/features/hub/download-manager/transport-conflict.ts
@@ -22,6 +22,7 @@ import {
   setConflict,
 } from "./download-manager-state";
 import { startJob } from "./poll-loop";
+import { showCallerToast } from "./start-toast";
 import { runtimeRegistry } from "./runtime-registry";
 import { getTransportMode } from "./transport-preference";
 import { ACTIVE_STATES, TRANSPORT_STATUS_TIMEOUT_MS } from "./download-manager-config";
@@ -127,7 +128,14 @@ async function runWithPendingStartGuard(
   // Already active or pending for the repo: only report "started" when this
   // exact request is the live transfer; a peer/snapshot/pending start has not.
   if (hasActiveOrPendingStart(req)) {
-    return isJobActiveFor(req) ? "started" : "busy";
+    if (!isJobActiveFor(req)) return "busy";
+    // This returns "started" WITHOUT running the action, so startJob never
+    // executes and never announces anything. Callers used to toast for
+    // themselves on "started" and so covered this path by accident; now that
+    // the download manager owns the message, saying nothing here would leave a
+    // user who just picked a model with no feedback at all.
+    showCallerToast(jobKeyOf(req.kind, req.repoId, req.variant), req.callerToast);
+    return "started";
   }
   runtimeRegistry.pendingStartRepoKeys.add(startKey);
   try {

--- a/studio/frontend/src/features/hub/download-manager/transport-conflict.ts
+++ b/studio/frontend/src/features/hub/download-manager/transport-conflict.ts
@@ -189,7 +189,10 @@ export async function requestStart(
             next: mode,
             resumable: status.resumable,
           },
-          pending: req,
+          // Without the caller's line: this start is resolved later from the Hub,
+          // where "it'll load automatically" is a promise chat cannot keep once it
+          // is inactive. The Xet notice still explains the 0% on its own.
+          pending: { ...req, callerToast: undefined },
         });
         return "conflict";
       }

--- a/studio/frontend/src/features/hub/download-manager/xet-progress-notice.ts
+++ b/studio/frontend/src/features/hub/download-manager/xet-progress-notice.ts
@@ -18,23 +18,20 @@ import {
 export const XET_NOTICE_DURATION_MS = 8000;
 
 // SHORT on purpose, as a correctness constraint. At 62 + 330 chars sonner rendered
-// this 235px tall over the Model hub toolbar, leaving 4 to 6 controls unclickable
-// for 8s, which is what #9293 reverted. It must end above the filter row, roughly
-// 158px, so title plus about two lines. Re-measure before adding a sentence.
+// this 235px tall over the Model hub toolbar, leaving 4 to 6 controls unclickable for
+// 8s, which is what #9293 reverted. It must end above the filter row, near 158px, so
+// title plus about two lines. Re-measure before adding a sentence.
 export const XET_NOTICE_TITLE = "Download is running";
 // The "switch to HTTP in Model Hub" advice is gone on purpose: it cost two lines and
-// left the toast bottom at y=126.5 against a filter row centred at y=127, a 0.5px
-// margin that any font or translation would have erased. Without it the toast ends
-// near y=100 and never reaches the row.
+// left the toast bottom at y=126.5 against a row centred at y=127, a margin any font
+// or translation would have erased. Without it the toast ends near y=100.
 export const XET_NOTICE_DESCRIPTION =
   "Xet sends the file in small pieces, so the bar can sit at 0% and then jump to done. Nothing is stuck.";
 export const XET_NOTICE_DESCRIPTION_CLASS = "!text-muted-foreground";
 
-/** The notice, plus whatever the starting surface wanted to add.
- *
- * Chat auto-loads and says so; the Hub does not, passes nothing, and gets the short
- * form, where "it'll load automatically" would be false. The test budget applies to
- * the short form alone, since only that one renders over the hub toolbar. */
+/** The notice, plus whatever the starting surface wanted to add. Chat auto-loads and
+ * says so; the Hub does not, passes nothing, and gets the short form. The test budget
+ * applies to that form alone, since only it renders over the hub toolbar. */
 export function composeNoticeDescription(
   callerToast?: { description: string } | null,
 ): string {

--- a/studio/frontend/src/features/hub/download-manager/xet-progress-notice.ts
+++ b/studio/frontend/src/features/hub/download-manager/xet-progress-notice.ts
@@ -11,8 +11,9 @@ import {
   TRANSPORT,
 } from "./constants";
 
-export const XET_NOTICE_LIMIT = 3;
-export const XET_NOTICE_STORAGE_KEY = "unsloth.studio.xetNoticeCount";
+// The 3-use cap and the count both live on the server now (see
+// studio/backend/utils/xet_notice_settings.py). A copy here could only ever drift
+// out of step with the value actually being enforced.
 
 // Longer than the Toaster's 5s default, like the explanatory toasts in chat.
 export const XET_NOTICE_DURATION_MS = 8000;
@@ -41,58 +42,22 @@ export const XET_NOTICE_DESCRIPTION =
   "Xet sends the file in small pieces, so the bar can sit at 0% and then jump to done. Nothing is stuck.";
 export const XET_NOTICE_DESCRIPTION_CLASS = "!text-muted-foreground";
 
-// Carries the count when the write fails (private mode, quota), which would
-// otherwise repeat the toast on every download.
-let sessionShown = 0;
-
-function readStoredCount(): number {
-  if (typeof window === "undefined") return 0;
-  try {
-    const parsed = Number.parseInt(
-      window.localStorage.getItem(XET_NOTICE_STORAGE_KEY) ?? "",
-      10,
-    );
-    return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : 0;
-  } catch {
-    return 0;
-  }
-}
-
-export function xetNoticesShown(): number {
-  return Math.max(sessionShown, readStoredCount());
-}
-
-export function recordXetNoticeShown(): void {
-  const next = xetNoticesShown() + 1;
-  sessionShown = next;
-  if (typeof window === "undefined") return;
-  try {
-    window.localStorage.setItem(XET_NOTICE_STORAGE_KEY, String(next));
-  } catch {
-    // Counted in memory above, so this session still stops at the limit.
-  }
-}
-
-/** Take one of the three, or report that none are left.
+/** The notice, plus whatever the starting surface wanted to say about this download.
  *
- * localStorage has no compare-and-set, so two tabs starting a download at the
- * same moment can both read the same count and both show the toast. Web Locks
- * are cross-tab, so the read and the write happen as one. Browsers without
- * them fall back to the plain check, which is the race above and still bounded
- * at one extra toast. */
-export async function reserveXetNotice(): Promise<boolean> {
-  const take = () => {
-    if (xetNoticesShown() >= XET_NOTICE_LIMIT) return false;
-    recordXetNoticeShown();
-    return true;
-  };
-  const locks = globalThis.navigator?.locks;
-  if (!locks) return take();
-  try {
-    return await locks.request(XET_NOTICE_STORAGE_KEY, take);
-  } catch {
-    return take();
-  }
+ * Chat's picker auto-loads the model when the transfer finishes and wants to say so;
+ * the Hub does not auto-load anything, passes nothing, and gets the short form. That
+ * split is why the caller supplies the sentence rather than this module hard-coding
+ * it: on the Hub "it'll load automatically" would simply be false.
+ *
+ * The budget in the tests applies to XET_NOTICE_DESCRIPTION alone for the same
+ * reason. The short form is the one that renders over the Model hub toolbar, which is
+ * what #9293 reverted; the composed form only ever appears on chat, where there is no
+ * toolbar underneath it. */
+export function composeNoticeDescription(
+  callerToast?: { description: string } | null,
+): string {
+  const extra = callerToast?.description?.trim();
+  return extra ? `${XET_NOTICE_DESCRIPTION} ${extra}` : XET_NOTICE_DESCRIPTION;
 }
 
 /** Only the transport that behaves this way, and only while it is news.
@@ -103,25 +68,21 @@ export async function reserveXetNotice(): Promise<boolean> {
  * start the user already cancelled has nothing to reassure them about.
  * Neither shows the notice nor spends one of the three.
  *
- * `callerExplained` is a surface that already toasted about this start. Chat's
- * model picker says "Downloading model, it'll load automatically once the
- * download finishes", which is the same reassurance in different words, and
- * sonner stacks the two in one corner. One start, one toast: the notice yields
- * to the more specific message, and does not spend one of its three doing so. */
+ * There is deliberately no "the caller already toasted" clause here any more. An
+ * earlier attempt suppressed the notice whenever chat had something to say, which
+ * removed the 0%-explanation exactly where a big first download makes it most
+ * useful. The caller's line is folded into the notice instead, by
+ * composeNoticeDescription, so nothing has to be dropped to avoid a second toast. */
 export function shouldShowXetNotice(args: {
   kind: DownloadKind;
   transport: ResolvedTransport;
   attached: boolean;
   live: boolean;
-  shown: number;
-  callerExplained?: boolean;
 }): boolean {
   return (
     args.kind === DOWNLOAD_KIND.MODEL &&
     args.transport === TRANSPORT.XET &&
     !args.attached &&
-    args.live &&
-    !args.callerExplained &&
-    args.shown < XET_NOTICE_LIMIT
+    args.live
   );
 }

--- a/studio/frontend/src/features/hub/download-manager/xet-progress-notice.ts
+++ b/studio/frontend/src/features/hub/download-manager/xet-progress-notice.ts
@@ -11,48 +11,30 @@ import {
   TRANSPORT,
 } from "./constants";
 
-// The 3-use cap and the count both live on the server now (see
-// studio/backend/utils/xet_notice_settings.py). A copy here could only ever drift
-// out of step with the value actually being enforced.
+// The cap and the count live on the server (utils/xet_notice_settings.py); a copy
+// here could only drift out of step with what is enforced.
 
 // Longer than the Toaster's 5s default, like the explanatory toasts in chat.
 export const XET_NOTICE_DURATION_MS = 8000;
 
-// Kept SHORT on purpose, and this is a correctness constraint rather than a
-// style preference. The first version of this notice ran 62 characters of
-// title and 330 of description, which sonner rendered 235px tall in the
-// top-right corner. That is where the Model hub keeps its own toolbar, so for
-// the 8s the toast was up it sat on top of the capability filter, the sort
-// dropdown, the Models and Datasets tabs and the repo action icons: measured
-// by hit testing each control's own centre point, 4 to 6 of them resolved into
-// the toast and could not be clicked. That is what got #9159 reverted in
-// #9293. The toast has to end above the filter row to block nothing, which
-// means roughly 158px, so title plus about two lines of description. Adding a
-// sentence here is not free: re-measure before you do.
+// SHORT on purpose, as a correctness constraint. At 62 + 330 chars sonner rendered
+// this 235px tall over the Model hub toolbar, leaving 4 to 6 controls unclickable
+// for 8s, which is what #9293 reverted. It must end above the filter row, roughly
+// 158px, so title plus about two lines. Re-measure before adding a sentence.
 export const XET_NOTICE_TITLE = "Download is running";
-// The "switch to HTTP in Model Hub" advice from the first version is gone on
-// purpose. Measured, it cost two rendered lines and put the toast's bottom edge
-// at y=126.5 with the hub filter row's centre at y=127: a 0.5px margin, which
-// is not a margin. Any font, zoom level or translation longer than the English
-// would have pushed it back over and re-broken the toolbar. Without it the
-// toast ends around y=100 and stops intersecting the row at all. The transport
-// control is two clicks away and discoverable; a toast that eats the toolbar is
-// not worth the shortcut.
+// The "switch to HTTP in Model Hub" advice is gone on purpose: it cost two lines and
+// left the toast bottom at y=126.5 against a filter row centred at y=127, a 0.5px
+// margin that any font or translation would have erased. Without it the toast ends
+// near y=100 and never reaches the row.
 export const XET_NOTICE_DESCRIPTION =
   "Xet sends the file in small pieces, so the bar can sit at 0% and then jump to done. Nothing is stuck.";
 export const XET_NOTICE_DESCRIPTION_CLASS = "!text-muted-foreground";
 
-/** The notice, plus whatever the starting surface wanted to say about this download.
+/** The notice, plus whatever the starting surface wanted to add.
  *
- * Chat's picker auto-loads the model when the transfer finishes and wants to say so;
- * the Hub does not auto-load anything, passes nothing, and gets the short form. That
- * split is why the caller supplies the sentence rather than this module hard-coding
- * it: on the Hub "it'll load automatically" would simply be false.
- *
- * The budget in the tests applies to XET_NOTICE_DESCRIPTION alone for the same
- * reason. The short form is the one that renders over the Model hub toolbar, which is
- * what #9293 reverted; the composed form only ever appears on chat, where there is no
- * toolbar underneath it. */
+ * Chat auto-loads and says so; the Hub does not, passes nothing, and gets the short
+ * form, where "it'll load automatically" would be false. The test budget applies to
+ * the short form alone, since only that one renders over the hub toolbar. */
 export function composeNoticeDescription(
   callerToast?: { description: string } | null,
 ): string {
@@ -68,11 +50,9 @@ export function composeNoticeDescription(
  * start the user already cancelled has nothing to reassure them about.
  * Neither shows the notice nor spends one of the three.
  *
- * There is deliberately no "the caller already toasted" clause here any more. An
- * earlier attempt suppressed the notice whenever chat had something to say, which
- * removed the 0%-explanation exactly where a big first download makes it most
- * useful. The caller's line is folded into the notice instead, by
- * composeNoticeDescription, so nothing has to be dropped to avoid a second toast. */
+ * No "the caller already toasted" clause: suppressing the notice whenever chat had
+ * something to say removed the 0%-explanation where it is most useful. The caller's
+ * line is folded in by composeNoticeDescription instead. */
 export function shouldShowXetNotice(args: {
   kind: DownloadKind;
   transport: ResolvedTransport;

--- a/studio/frontend/src/features/hub/download-manager/xet-progress-notice.ts
+++ b/studio/frontend/src/features/hub/download-manager/xet-progress-notice.ts
@@ -101,19 +101,27 @@ export async function reserveXetNotice(): Promise<boolean> {
  * accepted and reports that job's transport, but this user started nothing.
  * `live` is the backend calling the job running with no cancel pending: a
  * start the user already cancelled has nothing to reassure them about.
- * Neither shows the notice nor spends one of the three. */
+ * Neither shows the notice nor spends one of the three.
+ *
+ * `callerExplained` is a surface that already toasted about this start. Chat's
+ * model picker says "Downloading model, it'll load automatically once the
+ * download finishes", which is the same reassurance in different words, and
+ * sonner stacks the two in one corner. One start, one toast: the notice yields
+ * to the more specific message, and does not spend one of its three doing so. */
 export function shouldShowXetNotice(args: {
   kind: DownloadKind;
   transport: ResolvedTransport;
   attached: boolean;
   live: boolean;
   shown: number;
+  callerExplained?: boolean;
 }): boolean {
   return (
     args.kind === DOWNLOAD_KIND.MODEL &&
     args.transport === TRANSPORT.XET &&
     !args.attached &&
     args.live &&
+    !args.callerExplained &&
     args.shown < XET_NOTICE_LIMIT
   );
 }

--- a/studio/frontend/src/features/settings/api/xet-notice.ts
+++ b/studio/frontend/src/features/settings/api/xet-notice.ts
@@ -17,8 +17,7 @@ export interface XetNoticeReservation {
 }
 
 /** A count recorded before the tally moved server-side. Sent until the server
- * confirms it, and only raises the stored value, so someone who spent their three
- * does not get three more. */
+ * confirms it, and it can only raise the stored value. */
 function readLegacyCount(): number {
   if (typeof window === "undefined") return 0;
   try {
@@ -35,8 +34,8 @@ function readLegacyCount(): number {
 }
 
 /** Only once a response proves the server took the hint. Marking it on the way out
- * would drop the floor whenever the POST failed, and every later request would send
- * 0, handing three fresh notices to someone who had already spent them. */
+ * dropped the floor on any failed POST, handing three fresh notices to someone who
+ * had already spent them. */
 function markLegacyMigrated(): void {
   if (typeof window === "undefined") return;
   try {
@@ -65,15 +64,14 @@ export async function reserveXetNoticeFromServer(): Promise<XetNoticeReservation
         body: JSON.stringify({ seen_hint: readLegacyCount() }),
       },
       // This POST increments a counter, so a retry whose predecessor reached the
-      // backend spends a second notice. The Tauri network retry is on by default;
-      // every other mutation here opts out the same way.
+      // backend spends a second notice. Every other mutation here opts out too.
       { retryNetworkErrors: false },
     );
     if (!res.ok) return denied;
     const body = (await res.json()) as Partial<XetNoticeReservation>;
-    // A proxy or an older backend can answer this unknown route with a 200 and some
-    // other JSON, so `res.ok` is not proof the hint was stored. Only a reply that
-    // reports the cap it enforced came from the reservation endpoint.
+    // A proxy or older backend can answer this unknown route with a 200 and other
+    // JSON, so `res.ok` is no proof the hint was stored. Only a reply reporting the
+    // cap it enforced came from the reservation endpoint.
     if (typeof body.granted !== "boolean" || !isCount(body.limit)) return denied;
     markLegacyMigrated();
     return {

--- a/studio/frontend/src/features/settings/api/xet-notice.ts
+++ b/studio/frontend/src/features/settings/api/xet-notice.ts
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// Asking the backend for one of the three Xet notices.
+//
+// The count used to live in localStorage, which is per-origin, and a Studio origin is
+// not stable: the server falls back past port 8888 when Jupyter already has it, and
+// Colab and the tunnel are different origins again. Every one of those handed the user
+// a fresh set of three, so the notice never actually stopped.
+
+import { authFetch } from "@/features/auth/api";
+
+const LEGACY_COUNT_KEY = "unsloth.studio.xetNoticeCount";
+const LEGACY_MIGRATED_KEY = "unsloth.studio.xetNoticeMigrated";
+
+export interface XetNoticeReservation {
+  granted: boolean;
+  shown: number;
+  limit: number;
+}
+
+/** A count this browser recorded before the tally moved server-side.
+ *
+ * Sent once, and only ever raises the stored count, so someone who already spent
+ * their three does not get three more the first time they run this build. Marked as
+ * migrated straight away: sending it repeatedly is harmless (the server takes the
+ * max) but pointless, and the local value is meaningless afterwards.
+ */
+function takeLegacyCount(): number {
+  if (typeof window === "undefined") return 0;
+  try {
+    if (window.localStorage.getItem(LEGACY_MIGRATED_KEY)) return 0;
+    const raw = window.localStorage.getItem(LEGACY_COUNT_KEY);
+    window.localStorage.setItem(LEGACY_MIGRATED_KEY, "1");
+    const parsed = Number.parseInt(raw ?? "", 10);
+    return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : 0;
+  } catch {
+    // Private mode, or storage disabled. Nothing to migrate.
+    return 0;
+  }
+}
+
+/** Take one of the remaining notices, or report that none are left.
+ *
+ * FAILS CLOSED. If the endpoint is unreachable, older than these routes, or errors,
+ * this reports "not granted" and no toast is shown. The alternative, falling back to
+ * the browser count, would reintroduce exactly the resetting behaviour this replaced,
+ * every time a request happened to fail. Missing the explanation once is a smaller
+ * cost than a notice that comes back forever.
+ */
+export async function reserveXetNoticeFromServer(): Promise<XetNoticeReservation> {
+  const denied: XetNoticeReservation = { granted: false, shown: 0, limit: 0 };
+  try {
+    const res = await authFetch("/api/settings/xet-notice/reserve", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ seen_hint: takeLegacyCount() }),
+    });
+    if (!res.ok) return denied;
+    const body = (await res.json()) as Partial<XetNoticeReservation>;
+    return {
+      granted: body.granted === true,
+      shown: typeof body.shown === "number" ? body.shown : 0,
+      limit: typeof body.limit === "number" ? body.limit : 0,
+    };
+  } catch {
+    return denied;
+  }
+}

--- a/studio/frontend/src/features/settings/api/xet-notice.ts
+++ b/studio/frontend/src/features/settings/api/xet-notice.ts
@@ -16,19 +16,33 @@ export interface XetNoticeReservation {
   limit: number;
 }
 
-/** A count recorded before the tally moved server-side. Sent once, and only raises
- * the stored value, so someone who spent their three does not get three more. */
-function takeLegacyCount(): number {
+/** A count recorded before the tally moved server-side. Sent until the server
+ * confirms it, and only raises the stored value, so someone who spent their three
+ * does not get three more. */
+function readLegacyCount(): number {
   if (typeof window === "undefined") return 0;
   try {
     if (window.localStorage.getItem(LEGACY_MIGRATED_KEY)) return 0;
-    const raw = window.localStorage.getItem(LEGACY_COUNT_KEY);
-    window.localStorage.setItem(LEGACY_MIGRATED_KEY, "1");
-    const parsed = Number.parseInt(raw ?? "", 10);
+    const parsed = Number.parseInt(
+      window.localStorage.getItem(LEGACY_COUNT_KEY) ?? "",
+      10,
+    );
     return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : 0;
   } catch {
     // Private mode, or storage disabled. Nothing to migrate.
     return 0;
+  }
+}
+
+/** Only once a response proves the server took the hint. Marking it on the way out
+ * would drop the floor whenever the POST failed, and every later request would send
+ * 0, handing three fresh notices to someone who had already spent them. */
+function markLegacyMigrated(): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(LEGACY_MIGRATED_KEY, "1");
+  } catch {
+    // Nothing to record it in; the hint is re-sent next time, which is harmless.
   }
 }
 
@@ -39,13 +53,21 @@ function takeLegacyCount(): number {
 export async function reserveXetNoticeFromServer(): Promise<XetNoticeReservation> {
   const denied: XetNoticeReservation = { granted: false, shown: 0, limit: 0 };
   try {
-    const res = await authFetch("/api/settings/xet-notice/reserve", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ seen_hint: takeLegacyCount() }),
-    });
+    const res = await authFetch(
+      "/api/settings/xet-notice/reserve",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ seen_hint: readLegacyCount() }),
+      },
+      // This POST increments a counter, so a retry whose predecessor reached the
+      // backend spends a second notice. The Tauri network retry is on by default;
+      // every other mutation here opts out the same way.
+      { retryNetworkErrors: false },
+    );
     if (!res.ok) return denied;
     const body = (await res.json()) as Partial<XetNoticeReservation>;
+    markLegacyMigrated();
     return {
       granted: body.granted === true,
       shown: typeof body.shown === "number" ? body.shown : 0,

--- a/studio/frontend/src/features/settings/api/xet-notice.ts
+++ b/studio/frontend/src/features/settings/api/xet-notice.ts
@@ -1,12 +1,9 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-// Asking the backend for one of the three Xet notices.
-//
-// The count used to live in localStorage, which is per-origin, and a Studio origin is
-// not stable: the server falls back past port 8888 when Jupyter already has it, and
-// Colab and the tunnel are different origins again. Every one of those handed the user
-// a fresh set of three, so the notice never actually stopped.
+// Asking the backend for one of the three Xet notices. The count was in per-origin
+// localStorage, and a Studio origin moves whenever port 8888 is taken, so every new
+// origin handed out a fresh three and the notice never stopped.
 
 import { authFetch } from "@/features/auth/api";
 
@@ -19,13 +16,8 @@ export interface XetNoticeReservation {
   limit: number;
 }
 
-/** A count this browser recorded before the tally moved server-side.
- *
- * Sent once, and only ever raises the stored count, so someone who already spent
- * their three does not get three more the first time they run this build. Marked as
- * migrated straight away: sending it repeatedly is harmless (the server takes the
- * max) but pointless, and the local value is meaningless afterwards.
- */
+/** A count recorded before the tally moved server-side. Sent once, and only raises
+ * the stored value, so someone who spent their three does not get three more. */
 function takeLegacyCount(): number {
   if (typeof window === "undefined") return 0;
   try {
@@ -42,12 +34,8 @@ function takeLegacyCount(): number {
 
 /** Take one of the remaining notices, or report that none are left.
  *
- * FAILS CLOSED. If the endpoint is unreachable, older than these routes, or errors,
- * this reports "not granted" and no toast is shown. The alternative, falling back to
- * the browser count, would reintroduce exactly the resetting behaviour this replaced,
- * every time a request happened to fail. Missing the explanation once is a smaller
- * cost than a notice that comes back forever.
- */
+ * FAILS CLOSED: an unreachable, older or erroring backend shows nothing. Falling back
+ * to the browser count would restore the resetting bug on any failed request. */
 export async function reserveXetNoticeFromServer(): Promise<XetNoticeReservation> {
   const denied: XetNoticeReservation = { granted: false, shown: 0, limit: 0 };
   try {

--- a/studio/frontend/src/features/settings/api/xet-notice.ts
+++ b/studio/frontend/src/features/settings/api/xet-notice.ts
@@ -46,6 +46,10 @@ function markLegacyMigrated(): void {
   }
 }
 
+function isCount(value: unknown): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
+}
+
 /** Take one of the remaining notices, or report that none are left.
  *
  * FAILS CLOSED: an unreachable, older or erroring backend shows nothing. Falling back
@@ -67,11 +71,15 @@ export async function reserveXetNoticeFromServer(): Promise<XetNoticeReservation
     );
     if (!res.ok) return denied;
     const body = (await res.json()) as Partial<XetNoticeReservation>;
+    // A proxy or an older backend can answer this unknown route with a 200 and some
+    // other JSON, so `res.ok` is not proof the hint was stored. Only a reply that
+    // reports the cap it enforced came from the reservation endpoint.
+    if (typeof body.granted !== "boolean" || !isCount(body.limit)) return denied;
     markLegacyMigrated();
     return {
-      granted: body.granted === true,
-      shown: typeof body.shown === "number" ? body.shown : 0,
-      limit: typeof body.limit === "number" ? body.limit : 0,
+      granted: body.granted,
+      shown: isCount(body.shown) ? body.shown : 0,
+      limit: body.limit,
     };
   } catch {
     return denied;

--- a/studio/frontend/tests/download-start-toast.test.ts
+++ b/studio/frontend/tests/download-start-toast.test.ts
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// The one toast a download start raises, and the three ways it goes away: the
+// transfer ends, the user leaves the surface, or the caller never wanted it alone.
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import { register } from "node:module";
+
+register("./helpers/toast-resolver.mjs", import.meta.url);
+
+let route = "/chat";
+Object.defineProperty(globalThis, "window", {
+  configurable: true,
+  value: { location: { get pathname() { return route; } } },
+});
+
+const { calls } = await import("./helpers/toast-stub.mjs");
+const {
+  dismissStartToast,
+  dismissStartToasts,
+  showCallerToast,
+  showStartToast,
+  startToastId,
+} = await import(
+  "../src/features/hub/download-manager/start-toast.ts"
+);
+
+function reset(at = "/chat") {
+  calls.length = 0;
+  route = at;
+  dismissStartToasts();
+  calls.length = 0;
+}
+
+const MESSAGE = { title: "Download is running", description: "Nothing is stuck." };
+
+test("a start toast is keyed on its job so finalize can drop it", () => {
+  reset();
+  showStartToast("model:repo:q4", MESSAGE);
+  assert.equal(calls[0].kind, "info");
+  assert.equal(calls[0].options.id, startToastId("model:repo:q4"));
+
+  dismissStartToast("model:repo:q4");
+  assert.deepEqual(calls[1], {
+    kind: "dismiss",
+    id: startToastId("model:repo:q4"),
+  });
+});
+
+test("leaving the surface that raised it drops it", () => {
+  // It lasts 8s from a root-level Toaster, so a start in chat followed by a click
+  // on Models parks the composed form over the hub toolbar.
+  reset("/chat");
+  showStartToast("model:repo:q4", MESSAGE);
+  calls.length = 0;
+
+  route = "/hub";
+  dismissStartToasts();
+  assert.deepEqual(calls, [
+    { kind: "dismiss", id: startToastId("model:repo:q4") },
+  ]);
+
+  // Gone for good: a second navigation has nothing left to dismiss.
+  calls.length = 0;
+  route = "/settings";
+  dismissStartToasts();
+  assert.deepEqual(calls, []);
+});
+
+test("a toast raised on the route it landed on stays", () => {
+  // A start can itself navigate, and the toast then belongs where it appeared;
+  // dismissing every live toast on any route change would take it straight back out.
+  reset("/hub");
+  showStartToast("model:repo:q4", MESSAGE);
+  calls.length = 0;
+
+  dismissStartToasts();
+  assert.deepEqual(calls, []);
+});
+
+test("a noticeOnly caller is folded in or not shown at all", () => {
+  // #9663 removed chat's own auto-load toast as a duplicate of the download panel.
+  // Its sentence still rides along for the Xet notice to fold in, but on an HTTP
+  // start, or once the three notices are spent, it must not come back on its own.
+  reset();
+  showCallerToast("model:repo:q4", {
+    title: "Downloading model",
+    description: "It'll load automatically once the download finishes.",
+    noticeOnly: true,
+  });
+  assert.deepEqual(calls, []);
+
+  showCallerToast("model:repo:q4", {
+    title: "Downloading in the background",
+    description: "It'll be ready to load once the current model finishes.",
+  });
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].title, "Downloading in the background");
+});
+
+test("a caller with nothing to say is silent", () => {
+  reset();
+  showCallerToast("model:repo:q4", undefined);
+  assert.deepEqual(calls, []);
+});

--- a/studio/frontend/tests/download-start-toast.test.ts
+++ b/studio/frontend/tests/download-start-toast.test.ts
@@ -13,7 +13,13 @@ register("./helpers/toast-resolver.mjs", import.meta.url);
 let route = "/chat";
 Object.defineProperty(globalThis, "window", {
   configurable: true,
-  value: { location: { get pathname() { return route; } } },
+  value: {
+    location: {
+      get pathname() {
+        return route;
+      },
+    },
+  },
 });
 
 const { calls } = await import("./helpers/toast-stub.mjs");
@@ -23,9 +29,7 @@ const {
   showCallerToast,
   showStartToast,
   startToastId,
-} = await import(
-  "../src/features/hub/download-manager/start-toast.ts"
-);
+} = await import("../src/features/hub/download-manager/start-toast.ts");
 
 function reset(at = "/chat") {
   calls.length = 0;
@@ -34,16 +38,26 @@ function reset(at = "/chat") {
   calls.length = 0;
 }
 
-const MESSAGE = { title: "Download is running", description: "Nothing is stuck." };
+// Compared through a copy, never `calls` itself: node's assert types are `asserts
+// actual is T`, so `deepEqual(calls, [])` narrows the shared array to never[] and every
+// later read of it fails to typecheck.
+function raised() {
+  return calls.slice();
+}
+
+const MESSAGE = {
+  title: "Download is running",
+  description: "Nothing is stuck.",
+};
 
 test("a start toast is keyed on its job so finalize can drop it", () => {
   reset();
   showStartToast("model:repo:q4", MESSAGE);
   assert.equal(calls[0].kind, "info");
-  assert.equal(calls[0].options.id, startToastId("model:repo:q4"));
+  assert.equal(calls[0].options?.id, startToastId("model:repo:q4"));
 
   dismissStartToast("model:repo:q4");
-  assert.deepEqual(calls[1], {
+  assert.deepEqual(raised()[1], {
     kind: "dismiss",
     id: startToastId("model:repo:q4"),
   });
@@ -58,7 +72,7 @@ test("leaving the surface that raised it drops it", () => {
 
   route = "/hub";
   dismissStartToasts();
-  assert.deepEqual(calls, [
+  assert.deepEqual(raised(), [
     { kind: "dismiss", id: startToastId("model:repo:q4") },
   ]);
 
@@ -66,7 +80,23 @@ test("leaving the surface that raised it drops it", () => {
   calls.length = 0;
   route = "/settings";
   dismissStartToasts();
-  assert.deepEqual(calls, []);
+  assert.deepEqual(raised(), []);
+});
+
+test("a raise that lands after the user left is dropped", () => {
+  // The Xet reservation is a round trip, so the raise can happen after navigation.
+  // The route-change sweep has already run by then, and recording the destination
+  // as the origin would leave the composed form on the hub toolbar for its full 8s.
+  reset("/chat");
+  const startedOn = "/chat";
+  route = "/hub";
+  showStartToast("model:repo:q4", MESSAGE, startedOn);
+  assert.deepEqual(raised(), []);
+
+  // And it is not resurrected by going back.
+  route = "/chat";
+  dismissStartToasts();
+  assert.deepEqual(raised(), []);
 });
 
 test("a toast raised on the route it landed on stays", () => {
@@ -77,7 +107,7 @@ test("a toast raised on the route it landed on stays", () => {
   calls.length = 0;
 
   dismissStartToasts();
-  assert.deepEqual(calls, []);
+  assert.deepEqual(raised(), []);
 });
 
 test("a noticeOnly caller is folded in or not shown at all", () => {
@@ -90,7 +120,7 @@ test("a noticeOnly caller is folded in or not shown at all", () => {
     description: "It'll load automatically once the download finishes.",
     noticeOnly: true,
   });
-  assert.deepEqual(calls, []);
+  assert.deepEqual(raised(), []);
 
   showCallerToast("model:repo:q4", {
     title: "Downloading in the background",
@@ -103,5 +133,5 @@ test("a noticeOnly caller is folded in or not shown at all", () => {
 test("a caller with nothing to say is silent", () => {
   reset();
   showCallerToast("model:repo:q4", undefined);
-  assert.deepEqual(calls, []);
+  assert.deepEqual(raised(), []);
 });

--- a/studio/frontend/tests/download-start-toast.test.ts
+++ b/studio/frontend/tests/download-start-toast.test.ts
@@ -26,6 +26,7 @@ const { calls } = await import("./helpers/toast-stub.mjs");
 const {
   dismissStartToast,
   dismissStartToasts,
+  liveCallerToast,
   showCallerToast,
   showStartToast,
   startToastId,
@@ -128,6 +129,27 @@ test("a noticeOnly caller is folded in or not shown at all", () => {
   });
   assert.equal(calls.length, 1);
   assert.equal(calls[0].title, "Downloading in the background");
+});
+
+test("a caller line that has gone stale is dropped", () => {
+  // Chat moved to another thread while the start was still in flight, so nothing
+  // auto-loads any more. The transfer is still running, so the notice it would have
+  // been folded into stays true; only the caller's promise goes.
+  reset();
+  let context = "thread-a";
+  const caller = {
+    title: "Downloading model",
+    description: "It'll load automatically once the download finishes.",
+    stillValid: () => context === "thread-a",
+  };
+  assert.equal(liveCallerToast(caller), caller);
+
+  context = "thread-b";
+  assert.equal(liveCallerToast(caller), undefined);
+
+  // No predicate means always valid, which is every other surface.
+  assert.equal(liveCallerToast(MESSAGE), MESSAGE);
+  assert.equal(liveCallerToast(undefined), undefined);
 });
 
 test("a caller with nothing to say is silent", () => {

--- a/studio/frontend/tests/helpers/toast-resolver.mjs
+++ b/studio/frontend/tests/helpers/toast-resolver.mjs
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// bundler-resolver.mjs's two rules, plus "@/lib/toast" -> a local stub, so a module
+// that only raises toasts can be tested without sonner or react.
+import { existsSync } from "node:fs";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const SRC = fileURLToPath(new URL("../../src/", import.meta.url));
+const TOAST_STUB = new URL("./toast-stub.mjs", import.meta.url).href;
+
+function firstExisting(base) {
+  for (const candidate of [`${base}.ts`, `${base}/index.ts`, base]) {
+    if (existsSync(candidate)) return pathToFileURL(candidate).href;
+  }
+  return null;
+}
+
+export function resolve(specifier, context, next) {
+  if (specifier === "@/lib/toast") return next(TOAST_STUB, context);
+  if (specifier.startsWith("@/")) {
+    const resolved = firstExisting(SRC + specifier.slice(2));
+    return next(resolved ?? specifier, context);
+  }
+  if (specifier.startsWith(".") && context.parentURL?.startsWith("file:")) {
+    const resolved = firstExisting(
+      fileURLToPath(new URL(specifier, context.parentURL)),
+    );
+    if (resolved) return next(resolved, context);
+  }
+  return next(specifier, context);
+}

--- a/studio/frontend/tests/helpers/toast-stub.d.mts
+++ b/studio/frontend/tests/helpers/toast-stub.d.mts
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// Types for toast-stub.mjs so a .ts test can read the recorded calls without `any`.
+
+export interface ToastCall {
+  kind: "default" | "info" | "error" | "warning" | "success" | "dismiss";
+  title?: string;
+  options?: {
+    id?: string;
+    description?: string;
+    duration?: number;
+    classNames?: Record<string, string>;
+  };
+  id?: string;
+}
+
+export declare const calls: ToastCall[];
+
+export declare const toast: ((title: string, options?: unknown) => void) & {
+  info: (title: string, options?: unknown) => void;
+  error: (title: string, options?: unknown) => void;
+  warning: (title: string, options?: unknown) => void;
+  success: (title: string, options?: unknown) => void;
+  dismiss: (id?: string) => void;
+};
+
+export declare function createLoadingToastIcon(): null;

--- a/studio/frontend/tests/helpers/toast-stub.mjs
+++ b/studio/frontend/tests/helpers/toast-stub.mjs
@@ -10,8 +10,10 @@ export const toast = Object.assign(
   {
     info: (title, options) => calls.push({ kind: "info", title, options }),
     error: (title, options) => calls.push({ kind: "error", title, options }),
-    warning: (title, options) => calls.push({ kind: "warning", title, options }),
-    success: (title, options) => calls.push({ kind: "success", title, options }),
+    warning: (title, options) =>
+      calls.push({ kind: "warning", title, options }),
+    success: (title, options) =>
+      calls.push({ kind: "success", title, options }),
     dismiss: (id) => calls.push({ kind: "dismiss", id }),
   },
 );

--- a/studio/frontend/tests/helpers/toast-stub.mjs
+++ b/studio/frontend/tests/helpers/toast-stub.mjs
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// Stands in for "@/lib/toast", which pulls in sonner and a react component. A test
+// that only cares which toasts were raised and dropped reads `calls` instead.
+export const calls = [];
+
+export const toast = Object.assign(
+  (title, options) => calls.push({ kind: "default", title, options }),
+  {
+    info: (title, options) => calls.push({ kind: "info", title, options }),
+    error: (title, options) => calls.push({ kind: "error", title, options }),
+    warning: (title, options) => calls.push({ kind: "warning", title, options }),
+    success: (title, options) => calls.push({ kind: "success", title, options }),
+    dismiss: (id) => calls.push({ kind: "dismiss", id }),
+  },
+);
+
+export function createLoadingToastIcon() {
+  return null;
+}

--- a/studio/frontend/tests/xet-notice-reservation.test.ts
+++ b/studio/frontend/tests/xet-notice-reservation.test.ts
@@ -137,6 +137,27 @@ test("a legacy count survives a failed reservation", async () => {
   assert.equal(store.get(LEGACY_MIGRATED_KEY), "1");
 });
 
+test("a 200 that is not a reservation does not end the migration", async () => {
+  // A proxy or an older backend can answer this unknown route with a 200 and some
+  // other JSON. Treating that as proof the hint was stored drops the floor, and the
+  // three notices come back on the next upgrade.
+  reset();
+  store.set(LEGACY_COUNT_KEY, "3");
+  respond = async () =>
+    new Response(JSON.stringify({ detail: "Not Found" }), { status: 200 });
+  assert.equal((await reserveXetNoticeFromServer()).granted, false);
+  assert.equal(store.get(LEGACY_MIGRATED_KEY), undefined);
+
+  respond = async () =>
+    new Response(JSON.stringify({ granted: true, shown: 4, limit: 3 }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  await reserveXetNoticeFromServer();
+  assert.deepEqual(calls[1].body, { seen_hint: 3 });
+  assert.equal(store.get(LEGACY_MIGRATED_KEY), "1");
+});
+
 test("junk or absent legacy counts migrate as zero", async () => {
   reset();
   await reserveXetNoticeFromServer();

--- a/studio/frontend/tests/xet-notice-reservation.test.ts
+++ b/studio/frontend/tests/xet-notice-reservation.test.ts
@@ -116,6 +116,27 @@ test("a legacy count is sent once, as a floor", async () => {
   assert.deepEqual(calls[1].body, { seen_hint: 0 });
 });
 
+test("a legacy count survives a failed reservation", async () => {
+  // Marking it migrated on the way out dropped the floor whenever the POST failed:
+  // every later request sent 0, so a user who had spent their three got three more.
+  reset();
+  store.set(LEGACY_COUNT_KEY, "3");
+  respond = async () => {
+    throw new Error("network down");
+  };
+  await reserveXetNoticeFromServer();
+  assert.equal(store.get(LEGACY_MIGRATED_KEY), undefined);
+
+  respond = async () =>
+    new Response(JSON.stringify({ granted: true, shown: 4, limit: 3 }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  await reserveXetNoticeFromServer();
+  assert.deepEqual(calls[1].body, { seen_hint: 3 });
+  assert.equal(store.get(LEGACY_MIGRATED_KEY), "1");
+});
+
 test("junk or absent legacy counts migrate as zero", async () => {
   reset();
   await reserveXetNoticeFromServer();

--- a/studio/frontend/tests/xet-notice-reservation.test.ts
+++ b/studio/frontend/tests/xet-notice-reservation.test.ts
@@ -3,17 +3,12 @@
 
 // Reserving one of the three Xet notices.
 //
-// This file used to test a Web Locks dance that serialised two tabs reading the
-// same localStorage count. Both the count and the limit now live on the server
-// (studio/backend/utils/xet_notice_settings.py), which does the read and the write
-// in one transaction, so the race this file existed for is gone rather than
-// narrowed, and the concurrency case moved to test_xet_notice_settings.py.
+// The count and limit moved to the server, which does the read and write in one
+// transaction, so the Web Locks race this file used to cover is gone and the
+// concurrency case lives in test_xet_notice_settings.py.
 //
-// What is left here is the client half: send the legacy count exactly once, and
-// fail CLOSED on anything unexpected. Failing closed is the whole point of the
-// change. The old behaviour reset every time the origin moved, which is why the
-// notice never actually stopped, so a fallback to a local count on error would
-// quietly restore the bug on any flaky request.
+// What is left is the client half: send the legacy count once, and fail CLOSED. A
+// local fallback on error would restore the resetting bug on any flaky request.
 
 import assert from "node:assert/strict";
 import test from "node:test";
@@ -40,11 +35,9 @@ let respond: () => Promise<Response> = async () =>
     headers: { "Content-Type": "application/json" },
   });
 
-// Stub global fetch rather than the authFetch export: ES module namespaces are
-// frozen, so a namespace property cannot be redefined. Going through the real
-// authFetch also covers the header and URL handling instead of mocking it away.
-// The Tauri network retry it wraps only engages under Tauri, so a thrown error
-// surfaces immediately here rather than looping.
+// Stub global fetch, not the authFetch export: ES module namespaces are frozen. This
+// also exercises the real header and URL handling. The Tauri retry it wraps only
+// engages under Tauri, so a thrown error surfaces immediately.
 Object.defineProperty(globalThis, "fetch", {
   configurable: true,
   value: async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -92,8 +85,7 @@ test("a refused reservation is reported as refused", async () => {
 });
 
 test("an error response shows nothing rather than falling back", async () => {
-  // Fail closed. A local fallback here would reinstate the resetting behaviour
-  // on every failed request, which is the bug this replaced.
+  // Fail closed: a local fallback would reinstate the resetting bug on every failure.
   reset();
   respond = async () => new Response("{}", { status: 500 });
   assert.equal((await reserveXetNoticeFromServer()).granted, false);
@@ -112,8 +104,7 @@ test("an error response shows nothing rather than falling back", async () => {
 });
 
 test("a legacy count is sent once, as a floor", async () => {
-  // Someone who already spent their three in localStorage must not get three
-  // more the first time they run a build that counts server-side.
+  // Someone who spent their three in localStorage must not get three more.
   reset();
   store.set(LEGACY_COUNT_KEY, "3");
   await reserveXetNoticeFromServer();

--- a/studio/frontend/tests/xet-notice-reservation.test.ts
+++ b/studio/frontend/tests/xet-notice-reservation.test.ts
@@ -1,9 +1,19 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-// Two tabs starting a Xet download at the same moment used to read the same
-// count and both toast. Its own file: the module's session counter is process
-// wide, so these need a fresh instance of it.
+// Reserving one of the three Xet notices.
+//
+// This file used to test a Web Locks dance that serialised two tabs reading the
+// same localStorage count. Both the count and the limit now live on the server
+// (studio/backend/utils/xet_notice_settings.py), which does the read and the write
+// in one transaction, so the race this file existed for is gone rather than
+// narrowed, and the concurrency case moved to test_xet_notice_settings.py.
+//
+// What is left here is the client half: send the legacy count exactly once, and
+// fail CLOSED on anything unexpected. Failing closed is the whole point of the
+// change. The old behaviour reset every time the origin moved, which is why the
+// notice never actually stopped, so a fallback to a local count on error would
+// quietly restore the bug on any flaky request.
 
 import assert from "node:assert/strict";
 import test from "node:test";
@@ -15,39 +25,118 @@ import {
 
 const { store } = installLocalStorageFake();
 
-// A Web Locks stand-in that really serialises: each request queues behind the
-// last one for that name, which is the property the reservation leans on.
-const lockTails = new Map<string, Promise<unknown>>();
-// globalThis.navigator is getter-only in node, so define over it.
-Object.defineProperty(globalThis, "navigator", {
+const LEGACY_COUNT_KEY = "unsloth.studio.xetNoticeCount";
+const LEGACY_MIGRATED_KEY = "unsloth.studio.xetNoticeMigrated";
+
+interface FetchCall {
+  url: string;
+  body: unknown;
+}
+
+const calls: FetchCall[] = [];
+let respond: () => Promise<Response> = async () =>
+  new Response(JSON.stringify({ granted: true, shown: 1, limit: 3 }), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+
+// Stub global fetch rather than the authFetch export: ES module namespaces are
+// frozen, so a namespace property cannot be redefined. Going through the real
+// authFetch also covers the header and URL handling instead of mocking it away.
+// The Tauri network retry it wraps only engages under Tauri, so a thrown error
+// surfaces immediately here rather than looping.
+Object.defineProperty(globalThis, "fetch", {
   configurable: true,
-  value: {
-    locks: {
-      request: (name: string, fn: () => boolean | Promise<boolean>) => {
-        const tail = lockTails.get(name) ?? Promise.resolve();
-        const run = tail.then(() => fn());
-        lockTails.set(
-          name,
-          run.catch(() => undefined),
-        );
-        return run;
-      },
-    },
+  value: async (input: RequestInfo | URL, init?: RequestInit) => {
+    calls.push({
+      url: String(input),
+      body: typeof init?.body === "string" ? JSON.parse(init.body) : null,
+    });
+    return respond();
   },
 });
 
 registerBundlerResolver();
 
-const { XET_NOTICE_LIMIT, XET_NOTICE_STORAGE_KEY, reserveXetNotice } =
-  await import("../src/features/hub/download-manager/xet-progress-notice.ts");
+const { reserveXetNoticeFromServer } = await import(
+  "../src/features/settings/api/xet-notice.ts"
+);
 
-test("a concurrent burst never hands out more than three", async () => {
-  // Five reservations in flight at once, all reading the count before any
-  // writes. Without the lock the tabs sharing a read would each toast; here
-  // the fourth and fifth lose, which is the two-tabs-on-the-last-slot case.
-  const taken = await Promise.all(
-    Array.from({ length: 5 }, () => reserveXetNotice()),
-  );
-  assert.deepEqual(taken, [true, true, true, false, false]);
-  assert.equal(store.get(XET_NOTICE_STORAGE_KEY), String(XET_NOTICE_LIMIT));
+function reset() {
+  calls.length = 0;
+  store.clear();
+  respond = async () =>
+    new Response(JSON.stringify({ granted: true, shown: 1, limit: 3 }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+}
+
+test("a granted reservation is reported as granted", async () => {
+  reset();
+  const result = await reserveXetNoticeFromServer();
+  assert.equal(result.granted, true);
+  assert.equal(calls.length, 1);
+  assert.match(calls[0].url, /\/api\/settings\/xet-notice\/reserve$/);
+});
+
+test("a refused reservation is reported as refused", async () => {
+  reset();
+  respond = async () =>
+    new Response(JSON.stringify({ granted: false, shown: 3, limit: 3 }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  const result = await reserveXetNoticeFromServer();
+  assert.equal(result.granted, false);
+});
+
+test("an error response shows nothing rather than falling back", async () => {
+  // Fail closed. A local fallback here would reinstate the resetting behaviour
+  // on every failed request, which is the bug this replaced.
+  reset();
+  respond = async () => new Response("{}", { status: 500 });
+  assert.equal((await reserveXetNoticeFromServer()).granted, false);
+
+  reset();
+  respond = async () => {
+    throw new Error("network down");
+  };
+  assert.equal((await reserveXetNoticeFromServer()).granted, false);
+
+  // An older backend has no such route, so the body is not what we expect.
+  reset();
+  respond = async () =>
+    new Response(JSON.stringify({ detail: "Not Found" }), { status: 200 });
+  assert.equal((await reserveXetNoticeFromServer()).granted, false);
+});
+
+test("a legacy count is sent once, as a floor", async () => {
+  // Someone who already spent their three in localStorage must not get three
+  // more the first time they run a build that counts server-side.
+  reset();
+  store.set(LEGACY_COUNT_KEY, "3");
+  await reserveXetNoticeFromServer();
+  assert.deepEqual(calls[0].body, { seen_hint: 3 });
+  assert.equal(store.get(LEGACY_MIGRATED_KEY), "1");
+
+  // Second call does not resend it: the server is authoritative from here.
+  await reserveXetNoticeFromServer();
+  assert.deepEqual(calls[1].body, { seen_hint: 0 });
+});
+
+test("junk or absent legacy counts migrate as zero", async () => {
+  reset();
+  await reserveXetNoticeFromServer();
+  assert.deepEqual(calls[0].body, { seen_hint: 0 });
+
+  reset();
+  store.set(LEGACY_COUNT_KEY, "not a number");
+  await reserveXetNoticeFromServer();
+  assert.deepEqual(calls[0].body, { seen_hint: 0 });
+
+  reset();
+  store.set(LEGACY_COUNT_KEY, "-4");
+  await reserveXetNoticeFromServer();
+  assert.deepEqual(calls[0].body, { seen_hint: 0 });
 });

--- a/studio/frontend/tests/xet-progress-notice.test.ts
+++ b/studio/frontend/tests/xet-progress-notice.test.ts
@@ -43,6 +43,25 @@ test("the notice is for Xet model downloads and nothing else", () => {
   assert.ok(!shouldShowXetNotice({ ...XET_MODEL, kind: "dataset", shown: 0 }));
 });
 
+test("a caller that already toasted about the start gets no second toast", () => {
+  // Reported on main after this landed: picking a model in chat produced the
+  // Xet notice AND chat's own "Downloading model, it'll load automatically
+  // once the download finishes", stacked in the same corner. Both are true and
+  // both say wait, so the user is told twice for one start.
+  //
+  // The earlier UI evidence never caught it because the scene drove the Hub
+  // download card, and only chat's picker raises a start toast of its own. One
+  // start, one toast.
+  assert.ok(
+    !shouldShowXetNotice({ ...XET_MODEL, callerExplained: true, shown: 0 }),
+  );
+  // Absent or false is the Hub path, which explains nothing on its own.
+  assert.ok(
+    shouldShowXetNotice({ ...XET_MODEL, callerExplained: false, shown: 0 }),
+  );
+  assert.ok(shouldShowXetNotice({ ...XET_MODEL, shown: 0 }));
+});
+
 test("attaching to someone else's job shows nothing", () => {
   // The backend accepts the start and reports that job's transport, but this
   // client began no transfer, so it must not spend one of the three either.

--- a/studio/frontend/tests/xet-progress-notice.test.ts
+++ b/studio/frontend/tests/xet-progress-notice.test.ts
@@ -52,12 +52,9 @@ test("a start that is already stopping shows nothing", () => {
 });
 
 test("the predicate does not decide the cap", () => {
-  // The 3-use limit lives on the server (utils/xet_notice_settings.py) because the
-  // browser could not be trusted to remember it: localStorage is per-origin and a
-  // Studio origin moves whenever port 8888 is taken. A second copy of the limit here
-  // could only drift out of step with the one actually being enforced, so the
-  // predicate answers "is this the kind of download worth explaining" and nothing
-  // else. reserveXetNotice is the only thing that can say no on grounds of count.
+  // The limit lives on the server (utils/xet_notice_settings.py); a copy here could
+  // only drift out of step with what is enforced. The predicate answers "is this
+  // worth explaining", and the reservation is the only thing that counts.
   const notice = noticeModule as Record<string, unknown>;
   assert.equal(notice.XET_NOTICE_LIMIT, undefined);
   assert.equal(notice.XET_NOTICE_STORAGE_KEY, undefined);
@@ -66,36 +63,21 @@ test("the predicate does not decide the cap", () => {
 });
 
 test("the copy reassures, in plain words", () => {
-  // The reassurance is the whole point of the toast, so it leads and it is the
-  // only thing here. Explaining chunking, out-of-order writes and batched
-  // commits is what made the first version 330 characters.
+  // The reassurance is the point. Explaining chunking and batched commits is what
+  // made the first version 330 characters.
   assert.match(XET_NOTICE_TITLE, /running/);
   assert.match(XET_NOTICE_DESCRIPTION, /Nothing is stuck/);
 });
 
 test("the copy stays short enough to clear the hub toolbar", () => {
-  // This test IS the #9293 revert, written down.
+  // This test IS the #9293 revert, written down. At 62 + 330 chars the toast rendered
+  // 235px tall over the Model hub toolbar, leaving 4 to 6 controls unclickable for 8s.
   //
-  // The first version of this notice ran 62 characters of title and 330 of
-  // description. Sonner rendered that 235px tall in the top-right corner,
-  // which is where the Model hub keeps its own toolbar, so while the toast
-  // was up the capability filter, the sort dropdown, the Models and Datasets
-  // tabs and the repo action icons were underneath it. Hit testing each
-  // control's own centre point put 4 to 6 of them inside the toast, meaning
-  // unclickable, three times per install at 8s each.
-  //
-  // The budgets below are not guesses. At 149 characters the toast measured
-  // 114.5px tall, bottom edge y=126.5, against a filter row whose centre is
-  // y=127: clickable by half a pixel, which would not have survived a longer
-  // translation or a zoom level. At 101 it ends near y=100 and does not reach
-  // the row at all. So 110 is the real ceiling, not the point where it starts
-  // to break. Nothing else enforces this, and the failure is invisible to unit
-  // tests and to a screenshot taken at the wrong viewport, which is exactly how
-  // it shipped the first time.
-  //
-  // This applies to the BASE description only. That is the one the Hub renders
-  // over its own toolbar; the composed form below is chat-only, and chat has no
-  // toolbar under the toast.
+  // The budgets are measured, not guessed. At 149 chars the bottom edge sat at y=126.5
+  // against a filter row centred at y=127: clickable by half a pixel. At 101 it ends
+  // near y=100 and never reaches the row, so 110 is the ceiling rather than the point
+  // it breaks. Applies to the BASE description only; the composed form is chat-only
+  // and has no toolbar beneath it.
   assert.ok(
     XET_NOTICE_TITLE.length <= 32,
     `title is ${XET_NOTICE_TITLE.length} chars, budget 32`,
@@ -111,10 +93,8 @@ test("the copy stays short enough to clear the hub toolbar", () => {
 });
 
 test("the caller's line is folded in rather than raised as a second toast", () => {
-  // Reported on main: picking a model in chat produced the Xet notice AND chat's
-  // own "Downloading model / It'll load automatically once the download finishes",
-  // stacked in the same corner. Suppressing one loses information the user wants,
-  // so the caller's sentence joins the notice instead.
+  // Reported on main: chat produced the Xet notice AND its own "Downloading model",
+  // stacked. Suppressing one loses information, so the sentence joins the notice.
   const composed = composeNoticeDescription({
     description: "It'll load automatically once the download finishes.",
   });
@@ -128,8 +108,7 @@ test("the caller's line is folded in rather than raised as a second toast", () =
 });
 
 test("a caller with nothing to add leaves the notice alone", () => {
-  // The Hub passes no callerToast: nothing auto-loads there, so the extra
-  // sentence would be false rather than merely long.
+  // The Hub passes none: nothing auto-loads there, so the sentence would be false.
   assert.equal(composeNoticeDescription(), XET_NOTICE_DESCRIPTION);
   assert.equal(composeNoticeDescription(null), XET_NOTICE_DESCRIPTION);
   assert.equal(
@@ -139,9 +118,7 @@ test("a caller with nothing to add leaves the notice alone", () => {
 });
 
 test("it stays up longer than the Toaster default", () => {
-  // Shorter than the first version, but still two sentences a user has to
-  // notice while looking at a progress bar, and it appears at most 3 times
-  // ever. 5s is enough to miss entirely. This is an upper bound only: the
-  // toast is dismissed as soon as the transfer it describes finishes.
+  // Two sentences to notice while watching a progress bar, at most 3 times ever, so
+  // 5s is enough to miss. An upper bound only: it is dismissed when the transfer ends.
   assert.ok(XET_NOTICE_DURATION_MS > 5000);
 });

--- a/studio/frontend/tests/xet-progress-notice.test.ts
+++ b/studio/frontend/tests/xet-progress-notice.test.ts
@@ -12,20 +12,20 @@ import {
   registerBundlerResolver,
 } from "./helpers/kit.ts";
 
-const { store, storage } = installLocalStorageFake();
+installLocalStorageFake();
 registerBundlerResolver();
 
+const noticeModule = await import(
+  "../src/features/hub/download-manager/xet-progress-notice.ts"
+);
 const {
   XET_NOTICE_DESCRIPTION,
   XET_NOTICE_DESCRIPTION_CLASS,
   XET_NOTICE_DURATION_MS,
-  XET_NOTICE_LIMIT,
-  XET_NOTICE_STORAGE_KEY,
   XET_NOTICE_TITLE,
-  recordXetNoticeShown,
+  composeNoticeDescription,
   shouldShowXetNotice,
-  xetNoticesShown,
-} = await import("../src/features/hub/download-manager/xet-progress-notice.ts");
+} = noticeModule;
 
 const XET_MODEL = {
   kind: "model",
@@ -35,94 +35,34 @@ const XET_MODEL = {
 } as const;
 
 test("the notice is for Xet model downloads and nothing else", () => {
-  assert.ok(shouldShowXetNotice({ ...XET_MODEL, shown: 0 }));
+  assert.ok(shouldShowXetNotice({ ...XET_MODEL }));
   // HTTP reports steady progress, so the explanation would be wrong there.
-  assert.ok(
-    !shouldShowXetNotice({ ...XET_MODEL, transport: "http", shown: 0 }),
-  );
-  assert.ok(!shouldShowXetNotice({ ...XET_MODEL, kind: "dataset", shown: 0 }));
-});
-
-test("a caller that already toasted about the start gets no second toast", () => {
-  // Reported on main after this landed: picking a model in chat produced the
-  // Xet notice AND chat's own "Downloading model, it'll load automatically
-  // once the download finishes", stacked in the same corner. Both are true and
-  // both say wait, so the user is told twice for one start.
-  //
-  // The earlier UI evidence never caught it because the scene drove the Hub
-  // download card, and only chat's picker raises a start toast of its own. One
-  // start, one toast.
-  assert.ok(
-    !shouldShowXetNotice({ ...XET_MODEL, callerExplained: true, shown: 0 }),
-  );
-  // Absent or false is the Hub path, which explains nothing on its own.
-  assert.ok(
-    shouldShowXetNotice({ ...XET_MODEL, callerExplained: false, shown: 0 }),
-  );
-  assert.ok(shouldShowXetNotice({ ...XET_MODEL, shown: 0 }));
+  assert.ok(!shouldShowXetNotice({ ...XET_MODEL, transport: "http" }));
+  assert.ok(!shouldShowXetNotice({ ...XET_MODEL, kind: "dataset" }));
 });
 
 test("attaching to someone else's job shows nothing", () => {
-  // The backend accepts the start and reports that job's transport, but this
-  // client began no transfer, so it must not spend one of the three either.
-  assert.ok(!shouldShowXetNotice({ ...XET_MODEL, attached: true, shown: 0 }));
+  // Accepted, and it reports that job's transport, but this user started nothing.
+  assert.ok(!shouldShowXetNotice({ ...XET_MODEL, attached: true }));
 });
 
 test("a start that is already stopping shows nothing", () => {
-  // Cancelling while the start POST is in flight still returns an accepted
-  // start. Promising a running download there would be a lie, and it would
-  // spend one of the three on it.
-  assert.ok(!shouldShowXetNotice({ ...XET_MODEL, live: false, shown: 0 }));
+  // Nothing to reassure the user about if the download is on its way out.
+  assert.ok(!shouldShowXetNotice({ ...XET_MODEL, live: false }));
 });
 
-test("it stops after the first three", () => {
-  assert.equal(XET_NOTICE_LIMIT, 3);
-  assert.ok(shouldShowXetNotice({ ...XET_MODEL, shown: XET_NOTICE_LIMIT - 1 }));
-  assert.ok(!shouldShowXetNotice({ ...XET_MODEL, shown: XET_NOTICE_LIMIT }));
-  // A count already past the limit (an older, larger value) still stops.
-  assert.ok(!shouldShowXetNotice({ ...XET_MODEL, shown: 99 }));
-});
-
-// Before anything is recorded, so the session count cannot mask the read.
-test("a missing or junk stored count reads as none shown", () => {
-  store.clear();
-  assert.equal(xetNoticesShown(), 0);
-  store.set(XET_NOTICE_STORAGE_KEY, "not a number");
-  assert.equal(xetNoticesShown(), 0);
-  store.set(XET_NOTICE_STORAGE_KEY, "-4");
-  assert.equal(xetNoticesShown(), 0);
-});
-
-test("the count persists across sessions", () => {
-  store.clear();
-  recordXetNoticeShown();
-  assert.equal(store.get(XET_NOTICE_STORAGE_KEY), "1");
-  recordXetNoticeShown();
-  assert.equal(store.get(XET_NOTICE_STORAGE_KEY), "2");
-  assert.equal(xetNoticesShown(), 2);
-
-  // What a later session reads back, including one past this session's count.
-  store.set(XET_NOTICE_STORAGE_KEY, "3");
-  assert.equal(xetNoticesShown(), 3);
-  assert.ok(!shouldShowXetNotice({ ...XET_MODEL, shown: xetNoticesShown() }));
-});
-
-test("a storage that refuses writes still advances the count", () => {
-  // Private mode: setItem throws. Without the in-memory carry, every download
-  // would show the toast again.
-  store.clear();
-  const before = xetNoticesShown();
-  const setItem = storage.setItem;
-  storage.setItem = () => {
-    throw new Error("QuotaExceededError");
-  };
-  try {
-    recordXetNoticeShown();
-  } finally {
-    storage.setItem = setItem;
-  }
-  assert.equal(xetNoticesShown(), before + 1);
-  assert.equal(store.get(XET_NOTICE_STORAGE_KEY), undefined);
+test("the predicate does not decide the cap", () => {
+  // The 3-use limit lives on the server (utils/xet_notice_settings.py) because the
+  // browser could not be trusted to remember it: localStorage is per-origin and a
+  // Studio origin moves whenever port 8888 is taken. A second copy of the limit here
+  // could only drift out of step with the one actually being enforced, so the
+  // predicate answers "is this the kind of download worth explaining" and nothing
+  // else. reserveXetNotice is the only thing that can say no on grounds of count.
+  const notice = noticeModule as Record<string, unknown>;
+  assert.equal(notice.XET_NOTICE_LIMIT, undefined);
+  assert.equal(notice.XET_NOTICE_STORAGE_KEY, undefined);
+  assert.equal(notice.xetNoticesShown, undefined);
+  assert.equal(notice.recordXetNoticeShown, undefined);
 });
 
 test("the copy reassures, in plain words", () => {
@@ -152,6 +92,10 @@ test("the copy stays short enough to clear the hub toolbar", () => {
   // to break. Nothing else enforces this, and the failure is invisible to unit
   // tests and to a screenshot taken at the wrong viewport, which is exactly how
   // it shipped the first time.
+  //
+  // This applies to the BASE description only. That is the one the Hub renders
+  // over its own toolbar; the composed form below is chat-only, and chat has no
+  // toolbar under the toast.
   assert.ok(
     XET_NOTICE_TITLE.length <= 32,
     `title is ${XET_NOTICE_TITLE.length} chars, budget 32`,
@@ -166,9 +110,38 @@ test("the copy stays short enough to clear the hub toolbar", () => {
   assert.match(XET_NOTICE_DESCRIPTION_CLASS, /text-muted-foreground/);
 });
 
+test("the caller's line is folded in rather than raised as a second toast", () => {
+  // Reported on main: picking a model in chat produced the Xet notice AND chat's
+  // own "Downloading model / It'll load automatically once the download finishes",
+  // stacked in the same corner. Suppressing one loses information the user wants,
+  // so the caller's sentence joins the notice instead.
+  const composed = composeNoticeDescription({
+    description: "It'll load automatically once the download finishes.",
+  });
+  assert.ok(composed.startsWith(XET_NOTICE_DESCRIPTION));
+  assert.match(composed, /load automatically once the download finishes\.$/);
+  // Exactly one space at the seam, not a double space or a missing one.
+  assert.ok(
+    composed.includes(`${XET_NOTICE_DESCRIPTION} It'll`),
+    `bad seam: ${composed}`,
+  );
+});
+
+test("a caller with nothing to add leaves the notice alone", () => {
+  // The Hub passes no callerToast: nothing auto-loads there, so the extra
+  // sentence would be false rather than merely long.
+  assert.equal(composeNoticeDescription(), XET_NOTICE_DESCRIPTION);
+  assert.equal(composeNoticeDescription(null), XET_NOTICE_DESCRIPTION);
+  assert.equal(
+    composeNoticeDescription({ description: "   " }),
+    XET_NOTICE_DESCRIPTION,
+  );
+});
+
 test("it stays up longer than the Toaster default", () => {
   // Shorter than the first version, but still two sentences a user has to
   // notice while looking at a progress bar, and it appears at most 3 times
-  // ever. 5s is enough to miss entirely.
+  // ever. 5s is enough to miss entirely. This is an upper bound only: the
+  // toast is dismissed as soon as the transfer it describes finishes.
   assert.ok(XET_NOTICE_DURATION_MS > 5000);
 });


### PR DESCRIPTION
Three reports about the same toast, and #9663 in the middle of them.

#9663 fixed the double toast by deleting chat's "Downloading model / It'll load automatically once the download finishes". That removes the duplicate, but it also removes the only place the user is told the model loads by itself. This keeps both by folding them into one toast rather than dropping one, and fixes two other things reported alongside it.

## 1. One toast, carrying both messages

`DownloadRequest` gains `callerToast`. Chat states its message instead of raising it, and the download manager decides how to say it: folded into the Xet notice when that fires, on its own when it does not.

Chat now shows a single toast reading:

> **Download is running**
> Xet sends the file in small pieces, so the bar can sit at 0% and then jump to done. Nothing is stuck. It'll load automatically once the download finishes.

The composed sentence is chat-only. A Hub download does not auto-load, so "It'll load automatically" would be false there, and the Hub form is also the one that renders over the hub toolbar, which is what the character budget in the tests protects.

The auto-load caller is marked `noticeOnly`: its sentence is carried for the notice to fold in, and never raised by itself. #9663 removed that standalone toast deliberately, as a duplicate of the download panel, and an HTTP start or a spent notice must not put it back. The background-download caller, which #9663 did not touch, keeps its own toast.

Nothing is announced for a start that is already being cancelled, or for one whose reservation round trip outlived the transfer. A request deferred by a transport conflict is stored without its caller copy, since it is resumed from the Hub where the chat promise no longer holds.

`runWithPendingStartGuard` also announces now. It returns `"started"` without ever reaching `startJob`, so it used to rely on callers toasting for themselves; once they stopped, that path would have shown nothing at all.

## 2. Three times for the life of the install, not three per origin

The count lived in `localStorage`, which is scoped to an origin, and a Studio origin is not stable. `run.py` defaults to port 8888 and falls back to the next free port when it is taken, and 8888 is also Jupyter's default. Start Studio while a notebook server is up and it lands on 8889, a different origin with an empty store, and the three start again. Colab and the Cloudflare tunnel are different origins again, as is a second browser or a cleared profile. That is why the notice never actually stopped.

It moves to `app_settings` behind `POST /api/settings/xet-notice/reserve`, which does the read and the write in one `BEGIN IMMEDIATE` transaction. That also retires the Web Locks dance in the frontend, which existed only to narrow the same race between two tabs and could not cover a second browser at all.

Fails closed: an unreachable or older backend shows nothing rather than falling back to a count that resets. A one-time migration sends any existing browser count as a floor, so nobody who already spent their three gets three more; the floor is kept until the server confirms it, and the POST opts out of the Tauri network retry so a lost response cannot spend a second notice.

## 3. Gone when the download is, and when its surface is

The 8s duration is a cap, not a description of the transfer, so a small model finished, auto-loaded, and the toast was still saying the download was running. `finalize()` now dismisses it on every terminal outcome, keyed on the job so no state has to survive `teardownRuntime`.

The Toaster is root-level, so the toast also outlived the page that raised it. Measured at 1500x1000, the composed chat form is 115px tall and ends at y=167 against a hub filter row near y=158, so starting a download in chat and then clicking Models parked it over the toolbar, which is the overlap #9293 reverted. A start toast now records the route it was raised on and is dismissed when that route is left. Keyed on the route rather than on "everything currently live", because a start can itself navigate and that toast belongs where it landed.

## Verification

Unit and backend tests: 19 frontend, 7 backend. The load-bearing ones are mutation tested. Removing `BEGIN IMMEDIATE` makes the concurrency test grant more than three; both directions of the migration floor fail when broken; dropping the `noticeOnly` guard or blanket-dismissing on navigation each fail their case. Full frontend suite is unchanged against `main`: 147 failures on both sides.

Against two isolated installs and a real Studio, driving chat's model picker:

| | Port A, notice available | Port B, cap spent, restarted on a different port |
|---|---|---|
| Toasts | 1 | 1 |
| Text | Download is running / Xet sends the file in small pieces ... It'll load automatically once the download finishes. | Downloading model / It'll load automatically once the download finishes. |

Port B is the case that matters: Studio restarted on a different port, so a browser with an empty `localStorage`, and the Xet explanation does not come back.

That run predates the `noticeOnly` change, which is what makes Port B's row obsolete: the auto-load path now shows no toast there at all, matching what #9663 intended, and the download panel is what reports the transfer. Port A is unaffected. The new behaviour is covered by `tests/download-start-toast.test.ts` rather than re-photographed.

The dismiss on completion was checked by cancelling a live download on both sides: 1 toast before, 0 after. Cancel rather than completion on purpose, since a completion races the 8s duration and a toast that vanished after a slow download would prove nothing.

Honest about the setup: the count was driven to the limit directly rather than by clicking three downloads through the picker, which proved unreliable across five runs. The observation is live, the setup is scripted. The three-then-refused sequence itself is covered by `test_xet_notice_settings.py`.
