### PR TITLE
Cut the host-defaults installer windows from structure, not from comments

### DIFF
--- a/tests/sh/test_install_host_defaults.sh
+++ b/tests/sh/test_install_host_defaults.sh
@@ -16,8 +16,8 @@
 #      opt-in, so the capability is not simply undocumented.
 #   3. No launch command the installers print or generate binds a wildcard host.
 #
-# Two things this file used to do, and no longer does, because both went red on
-# an edit that was correct:
+# Three things this file used to do, and no longer does. The first two went red
+# on an edit that was correct; the third went GREEN on one that was not:
 #
 #   * It sliced README.md by heading -- `#### Launch` up to the next heading of
 #     any level -- and asserted BOTH halves inside that one window. Deleting
@@ -35,6 +35,18 @@
 #     the day `-H` is renamed. The flag spellings are now read off the
 #     `typer.Option` in unsloth_cli/commands/studio.py that declares them, so the
 #     needle is derived from the code it protects rather than re-spelled here.
+#
+#   * It sliced the three installer files on hand-written markers, two of which
+#     were COMMENT PROSE ("In interactive terminals, ..."). A comment has no
+#     reason to stay stable, so rewording one turned this guard red for reasons
+#     that had nothing to do with host defaults, and three of the four windows
+#     ran to end of file, so each negative assertion covered a superset of the
+#     region its label named. Worse, the launcher window could go VACUOUS rather
+#     than loud: see the reproduction in the install.sh launcher section below.
+#     Every installer window is now derived from the file's own structure -- a
+#     heredoc delimiter, a top-level `if`/`fi`, a PowerShell brace block -- and
+#     every one of them asserts that it closed on its own closing token instead
+#     of running off the end of the file.
 #
 # `unsloth studio`'s own default (`--host 127.0.0.1`) is asserted separately and
 # structurally in tests/studio/test_cli_studio_defaults.py; this file is about
@@ -344,34 +356,128 @@ assert_detects "a trailing comment naming it"       'unsloth studio  # add -H 0.
 assert_detects "a path, not the subcommand"         'unsloth-studio-launcher -H 0.0.0.0'           ignored
 assert_detects "an empty window"                    ''                                             ignored
 
+# ── the windows ──────────────────────────────────────────────────────────────
+# Every installer window below is cut from the file's own STRUCTURE, never from a
+# comment and never from a sentence someone might reword. Anchoring on a comment
+# is the worst case of all, because a comment exists to be rewritten.
+
+# The heredoc that redirects into the path held by $2, from the line that opens
+# it through its own terminator. `want=delim` returns that terminator instead of
+# the body. Both come from the SAME matched line in the SAME pass, which is the
+# whole point: a window opened by one rule and closed by another can disagree,
+# and when it does the disagreement is silent.
+#
+# While looking for the opener it joins backslash continuations, so the redirect
+# and its `<<` are matched as one shell LOGICAL line however they are wrapped.
+# The joining stops the moment the heredoc opens, because the launcher body has
+# continuations of its own and they are content, not syntax to be folded away.
+_heredoc_window() {
+    awk -v q="\"'" -v target="$2" -v want="${3:-body}" '
+    !delim {
+        line = $0
+        while (line ~ /\\[ \t]*$/ && (getline nxt) > 0) {
+            sub(/\\[ \t]*$/, "", line)
+            sub(/^[ \t]+/, " ", nxt)
+            line = line nxt
+        }
+        if (!index(line, target) || !index(line, "<<")) next
+        rest = substr(line, index(line, "<<") + 2)
+        if (substr(rest, 1, 1) == "-") { dash = 1; rest = substr(rest, 2) }
+        sub(/^[ \t]+/, "", rest)
+        if (index(q, substr(rest, 1, 1))) rest = substr(rest, 2)
+        if (!match(rest, /^[A-Za-z_][A-Za-z0-9_]*/)) next
+        delim = substr(rest, 1, RLENGTH)
+        if (want == "delim") { print delim; exit }
+        print line
+        next
+    }
+    {
+        print
+        line = $0
+        if (dash) sub(/^[ \t]+/, "", line)
+        if (line == delim) exit
+    }
+    ' "$1"
+}
+
+# A top-level shell branch: the `if` line matching $2, through the `fi` in column
+# zero that closes it. Nested branches inside it are indented, so the first
+# column-zero `fi` is the right one. Callers assert the window ended on that `fi`,
+# which is what turns a close that never matched into a report instead of a
+# silent run to end of file.
+_shell_if_block() {
+    awk -v pat="$2" '
+    !found && $0 ~ pat { found = 1; print; next }
+    found { print; if ($0 == "fi") exit }
+    ' "$1"
+}
+
+# A PowerShell block: the line matching $2, through the line where its braces
+# balance again. `[{]` rather than `{` so the brace is a literal and not the
+# start of an ERE interval.
+_ps_brace_block() {
+    awk -v pat="$2" '
+    !found && $0 ~ pat { found = 1 }
+    found { print; depth += gsub(/[{]/, "&") - gsub(/[}]/, "&"); if (depth <= 0) exit }
+    ' "$1"
+}
+
+# The last line of a window, trimmed. A window that ran off the end of the file
+# does not end on its own closing token; that is the difference between a window
+# that closed on purpose and one that was never closed at all.
+_window_close() { printf '%s\n' "$1" | tail -n 1 | sed 's/^[[:space:]]*//; s/[[:space:]]*$//'; }
+
 echo ""
 echo "=== install.sh launcher template ==="
 
-# Extract the heredoc that generates ~/.local/share/unsloth/launch-studio.sh.
-# The terminator is read off the `<<` that opens it, so renaming the delimiter
-# cannot silently truncate the window to nothing.
-# Same reason: install.sh contains the literal `$_css_launcher`, it is not ours to expand.
-# shellcheck disable=SC2016
-_launcher_delim=$(grep -m1 'cat > "\$_css_launcher" <<' "$INSTALL_SH" \
-    | sed -E "s/.*<<-?[[:space:]]*[\"']?([A-Za-z_][A-Za-z0-9_]*)[\"']?.*/\1/")
-_launcher=$(awk -v delim="$_launcher_delim" \
-    '/cat > "\$_css_launcher"/{found=1} found{print} $0 == delim{found=0}' "$INSTALL_SH")
+# The heredoc that generates ~/.local/share/unsloth/launch-studio.sh.
+#
+# This window is the one shape in this file that could go vacuous rather than
+# loud, so it is worth stating exactly. It used to find its start with an awk
+# pattern and its terminator with a SEPARATE, stricter grep that also required
+# the `<<` on that same line. Split the redirect across a line continuation --
+#
+#     cat > "$_css_launcher" \
+#         << 'LAUNCHER_EOF'
+#
+# -- and the grep matched nothing, the derived delimiter was the empty string,
+# and `$0 == delim` then matched the first BLANK LINE inside the launcher. The
+# window collapsed from 357 lines to 6. The `#!/usr/bin/env bash` canary sits in
+# those 6 and still passed, so `-H 0.0.0.0` added to the launcher's own `exec`
+# line went through at 39 pass / 0 fail. One helper, one matched line, no second
+# pattern to disagree with the first.
+_launcher_delim=$(_heredoc_window "$INSTALL_SH" '_css_launcher' delim)
+_launcher=$(_heredoc_window "$INSTALL_SH" '_css_launcher' body)
+assert_ge \
+    "launcher template: a heredoc terminator was derived" \
+    "${#_launcher_delim}" 1
 assert_contains \
     "launcher template: extraction found the heredoc content" \
     "$_launcher" "#!/usr/bin/env bash"
+assert_eq \
+    "launcher template: the window closes on the heredoc terminator" \
+    "$_launcher_delim" "$(_window_close "$_launcher")"
 assert_no_wildcard_bind \
     "launcher template: the generated launcher binds no wildcard host" \
     "$_launcher"
 
 echo ""
-# Anchored on content, not a line count: both installers outgrew their tail windows.
 echo "=== install.sh end-of-install block ==="
 
-_end=$(awk '/In interactive terminals/{found=1} found{print}' "$INSTALL_SH")
+# The post-install prompt-or-print branch, anchored on the `if` that declares it.
+# The anchor used to be the comment ABOVE that `if` ("In interactive terminals,
+# ask the user before starting Unsloth ..."), and the window ran from there to
+# end of file. `_SKIP_AUTOSTART` is a shell variable this branch reads: renaming
+# it is a code change, and the prompt canary below reports it at once instead of
+# leaving an empty window behind.
+_end=$(_shell_if_block "$INSTALL_SH" '^if .*_SKIP_AUTOSTART.*; then$')
 # "read" alone also matches "readable" and "_can_read_tty", so pin the full prompt.
 assert_contains \
     "install.sh: interactive block prompts user (read)" \
     "$_end" "read -r _reply"
+assert_eq \
+    "install.sh: the end-of-install window closes on its own fi" \
+    "fi" "$(_window_close "$_end")"
 assert_no_wildcard_bind \
     "install.sh: end-of-install commands bind no wildcard host" \
     "$_end"
@@ -379,10 +485,15 @@ assert_no_wildcard_bind \
 echo ""
 echo "=== install.ps1 end-of-install block ==="
 
-_ps1_end=$(awk '/In interactive terminals/{found=1} found{print}' "$INSTALL_PS1")
+# Same branch, same reasoning, PowerShell braces instead of `fi`. Also anchored
+# on the comment above it until now, and also ran to end of file.
+_ps1_end=$(_ps_brace_block "$INSTALL_PS1" '^[ \t]*if [(][$]IsInteractive[)] [{][ \t]*$')
 assert_contains \
     "install.ps1: interactive block prompts user (Read-Host)" \
     "$_ps1_end" "Read-Host"
+assert_eq \
+    "install.ps1: the end-of-install window closes on its own brace" \
+    "}" "$(_window_close "$_ps1_end")"
 assert_no_wildcard_bind \
     "install.ps1: end-of-install commands bind no wildcard host" \
     "$_ps1_end"
@@ -390,14 +501,42 @@ assert_no_wildcard_bind \
 echo ""
 echo "=== studio/setup.sh launch hint ==="
 
-_setup_tail=$(awk '/"launch"/{found=1} found{print}' "$SETUP_SH")
-# Canary: an empty window would let the negative assertion below pass vacuously.
+# Deliberately NOT windowed, and the label says so. The footer that prints the
+# hint lives in a top-level `if [ "$_LLAMA_ONLY" = "1" ]; then` block, and that
+# same header opens three different top-level blocks in setup.sh, so there is no
+# structural boundary that picks out the footer -- only the ordinal "the third
+# one", which is a hand-written marker wearing a different hat. The old anchor
+# was the bare string `"launch"` and ran to end of file from there, so reading
+# the whole file loses no coverage, gains the rest of it, and cannot be narrowed
+# by an edit anywhere. Over-reporting here is cheap; the file's own wildcard
+# opt-in is prose ("add -H 0.0.0.0 for LAN / cloud access") with no `studio` word
+# in it, so it is not a launch command and does not trip this.
+_setup_all=$(cat "$SETUP_SH")
+# Canary: setup.sh still prints a launch hint at all. A file that stopped
+# mentioning studio would otherwise satisfy the assertion below by saying nothing.
 assert_contains \
-    "studio/setup.sh: extraction found the launch hint" \
-    "$_setup_tail" "unsloth studio -p 8888"
+    "studio/setup.sh: the footer still prints a launch hint" \
+    "$_setup_all" "unsloth studio -p 8888"
 assert_no_wildcard_bind \
-    "studio/setup.sh: the launch hint binds no wildcard host" \
-    "$_setup_tail"
+    "studio/setup.sh: no launch command in setup.sh binds a wildcard host" \
+    "$_setup_all"
+
+echo ""
+echo "=== the installers, whole file ==="
+
+# The windows above name the region each guard is ABOUT, which is what makes a
+# failure readable. These two name the file, which is what makes the family hard
+# to defeat: a window can be narrowed by an edit and still look healthy, a whole
+# file cannot, so a wildcard bind that lands outside every window is still
+# reported, just with a less specific label. Both installers are clean today
+# because their opt-in text is prose rather than a runnable command; if that ever
+# stops being true, prefer rephrasing the prose over deleting these two.
+assert_no_wildcard_bind \
+    "install.sh: no launch command anywhere in the file binds a wildcard host" \
+    "$(cat "$INSTALL_SH")"
+assert_no_wildcard_bind \
+    "install.ps1: no launch command anywhere in the file binds a wildcard host" \
+    "$(cat "$INSTALL_PS1")"
 
 echo ""
 echo "=== README.md launch commands ==="


### PR DESCRIPTION
Follow-up to #9655, which replaced the README heading slice in `tests/sh/test_install_host_defaults.sh` with a structural probe. Four sibling windows were inventoried at the time and deliberately left alone. This does those four.

The security property is unchanged and is not weakened anywhere: the installers and README must not put a wildcard bind (`0.0.0.0`, `[::]`, `::`) in a default launch command, and the LAN opt-in must still be documented as an opt-in. This is about how the file finds the region it asserts on.

### What was wrong

Three of the four windows ran to end of file, so each negative assertion covered a superset of the region its label named. Two of them were anchored on **comment prose**:

| window | old anchor | kind |
|---|---|---|
| install.sh launcher | `/cat > "\$_css_launcher"/` + a second `grep` for the terminator | code, but two patterns |
| install.sh end block | `/In interactive terminals/` | comment |
| install.ps1 end block | `/In interactive terminals/` | comment |
| studio/setup.sh hint | `/"launch"/` | printed label |

A comment is the worst possible anchor, because a comment exists to be rewritten. Rewording either of those two turns this guard red on an edit that has nothing to do with host defaults, which is how it took `main` red twice already.

### The one that could go quiet

The launcher window is not just fragile. It can go **vacuous**, and I have a reproduction on `b3d86b2d0`.

It found its start with an awk pattern that matched `cat > "$_css_launcher"`, and found its terminator with a separate, stricter `grep` that also required the `<<` on that same line. Wrap the redirect across a line continuation, which is a formatting change and nothing more:

```sh
cat > "$_css_launcher" \
    << 'LAUNCHER_EOF'
```

The `grep` now matches nothing, so the derived delimiter is the empty string, so `$0 == delim` matches the first **blank line** inside the heredoc. The window collapses from 357 lines to 6. The `#!/usr/bin/env bash` canary sits inside those 6 and still passes.

With that reformat in place I changed the launcher's own launch line to

```sh
exec "$UNSLOTH_EXE" studio -H 0.0.0.0 -p "$_launch_port"
```

so every TTY launch of the installed Studio binds the LAN, and the suite reported `PASS: 39 / FAIL: 0 / ALL PASSED`. On this branch the same tree reports 2 failures.

To be clear about the scope: this is the only one of the four that can be quiet. The other three fail loudly on a marker reword. Their cost is a red on `main` from an unrelated edit, plus the end-of-file over-reach, not a blind guard.

### What replaces them

Each window is now cut from the file's own structure.

**`install.sh` launcher** is the heredoc, bounded by its own delimiter, where the start and the terminator come from the same matched line in the same helper. There is no second pattern left to disagree with the first. The helper also joins backslash continuations while it is looking for the opener, so the redirect and its `<<` are matched as one shell logical line however they are wrapped, and it stops joining the moment the heredoc opens, because the launcher body has continuations of its own and those are content.

**`install.sh` end block** is the top-level `if` that declares the post-install branch, through the `fi` in column zero that closes it, anchored on `_SKIP_AUTOSTART` rather than on the comment above it.

**`install.ps1` end block** is the `if ($IsInteractive) {` block, through the line where its braces balance again.

**`studio/setup.sh`** is deliberately **not** windowed, and the label says so. Its footer sits in a top-level `if [ "$_LLAMA_ONLY" = "1" ]; then` block, and that same header opens three different top-level blocks in that file, so no structural boundary picks out the footer, only the ordinal "the third one", which is a hand-written marker wearing a different hat. The old anchor ran to end of file from `"launch"` anyway, so reading the whole file loses no coverage and gains the rest of it. Over-reporting there is cheap: the file's own wildcard opt-in is prose (`add -H 0.0.0.0 for LAN / cloud access`) with no `studio` word in it, so it is not a launch command and does not trip this.

Every window now asserts that it **closed on its own closing token** (`LAUNCHER_EOF`, `fi`, `}`). That is what turns a close that never matched into a report instead of a silent run to end of file, and it is the assertion that would have caught the vacuity above.

Two whole-file backstops were added for `install.sh` and `install.ps1`. The windows name the region each guard is about, which is what makes a failure readable; the backstops name the file, which is what makes the family hard to defeat. Both installers are clean today because their opt-in text is prose rather than a runnable command.

### Both directions, per window

Every mutation was applied to a byte snapshot and restored with md5 confirmation, never with `git checkout --`. Each row was run against the `origin/main` guard and this branch's guard on the same mutated tree.

| case | mutation | old guard | this branch |
|---|---|---|---|
| W1-a | wildcard on the generated launcher's `exec` line | RED 38/1 | RED 43/2 |
| W1-b | heredoc opener wrapped onto a line continuation | GREEN (blind) | GREEN 45/0 |
| **W1-c** | **that wrap plus the wildcard on `exec`** | **GREEN 39/0** | **RED 43/2** |
| W1-d | delimiter renamed `LAUNCHER_EOF` -> `STUDIO_LAUNCH_EOF` | GREEN | GREEN 45/0 |
| W1-e | space dropped: `cat >"$_css_launcher" <<` | RED 38/1 | GREEN 45/0 |
| W2-a | wildcard in the non-interactive `substep` hint | RED 38/1 | RED 43/2 |
| W2-b | reword `In interactive terminals` | RED 38/1 | GREEN 45/0 |
| W2-c | delete that comment block entirely | RED 38/1 | GREEN 45/0 |
| W2-d | `--host=0.0.0.0` on the interactive autostart `exec` | RED 38/1 | RED 43/2 |
| W3-a | wildcard in the ps1 non-interactive hint | RED 38/1 | RED 43/2 |
| W3-b | reword the ps1 `In interactive terminals` comment | RED 38/1 | GREEN 45/0 |
| W3-c | wildcard in the ps1 `Start-Process` arg list | RED 38/1 | RED 43/2 |
| W4-a | wildcard in the setup.sh footer hint | RED 38/1 | RED 44/1 |
| W4-b | printed label `"launch"` renamed to `"start"` | RED 38/1 | GREEN 45/0 |
| W4-c | wildcard added above the old window's start | GREEN 39/0 | RED 44/1 |
| blind | `studio_commands()` forced to return `[]` | RED 24/15 | RED 30/15 |

W1-c is the vacuity. W1-b, W1-e, W2-b, W2-c, W3-b and W4-b are the reds this removes. W1-e and W4-c are coverage the old windows did not have. The blinding row is the anti-vacuity check on the detector itself: forcing the shared matcher to see nothing produces 15 failures, not a quiet green.

### Counts

39 pass / 0 fail before, 45 pass / 0 fail after. The six new assertions are three window-closed checks, one "a heredoc terminator was derived" canary, and the two whole-file backstops.

No installer, README or CLI file is touched; the diff is this one test file. `shellcheck -e SC1090,SC2034` and `bash -n`, the two checks lint-ci runs over committed shell, are both clean.
