### PR TITLE
Studio: drop the duplicate download toast on a hub auto-load

### DIFF
--- a/studio/frontend/src/features/chat/chat-page.tsx
+++ b/studio/frontend/src/features/chat/chat-page.tsx
@@ -2865,9 +2865,8 @@ export function ChatPage({
       });
       if (!active) return;
       if (outcome === "started") {
-        toast.info("Downloading model", {
-          description: "It'll load automatically once the download finishes.",
-        });
+        // No toast: the download panel already shows this download. The
+        // auto-load still runs from onComplete.
         return;
       }
       if (outcome === "conflict") {


### PR DESCRIPTION
Picking a model from the hub that is not downloaded yet starts the download and then reports it twice: a "Downloading model" toast, and the download panel in the bottom right rail, which is already showing that repo, that variant and a progress bar.

The toast says nothing the panel does not, and it renders over the rail, so one download ends up with two cards in the same corner. With an update banner up as well, the toast covers that too.

## The change

`chat-page.tsx`, the `started` branch of the hub auto-load effect: return without the toast. Nothing else in the effect moves.

The auto-load is unaffected. It runs from `useRepoDownload`'s `onComplete`, not from the toast.

`conflict` and `busy` keep theirs. Neither of those starts a download, so neither has a panel row to point at, and the toast is the only answer the click gets.

The Xet notice from #9658 is untouched. It answers a different question, why a running download can sit at 0%, which the progress bar cannot answer on its own.

## Checks

The frontend builds, and biome reports the same two pre-existing diagnostics on this file as it does on `main`, so nothing here is new. No test referenced the removed strings.
