### PR TITLE
Studio: detect connected llama.cpp reasoning on demand

### DIFF
--- a/studio/backend/core/inference/external_provider.py
+++ b/studio/backend/core/inference/external_provider.py
@@ -14,7 +14,7 @@ import mimetypes
 import re
 import time
 from typing import Any, AsyncGenerator, Literal, NamedTuple, Optional, Union
-from urllib.parse import urlparse, urlsplit, urlunsplit
+from urllib.parse import quote, urlparse, urlsplit, urlunsplit
 
 import httpx
 import structlog
@@ -902,9 +902,10 @@ class ExternalProviderClient:
         # Generous per-byte read timeout: reasoning models pause tens of seconds
         # between bytes, but a dead upstream must eventually error, not hang forever.
         self._stream_timeout = httpx.Timeout(timeout, connect = 10.0, read = 300.0)
-        # llama.cpp serves a single model, so its chat template is fetched once
-        # per client and reused across every model id in the catalog.
-        self._probed_llama_cpp_template: Optional[str] = None
+        # llama.cpp chat templates are cached per model id on this client: a
+        # single-model server reuses one entry, a router-mode server
+        # (--models-dir / --models-preset) has one per served model.
+        self._probed_llama_cpp_templates: dict[str, Optional[str]] = {}
 
     def _auth_headers(self) -> dict[str, str]:
         """Build authentication headers using the provider's registry config."""
@@ -6460,8 +6461,10 @@ class ExternalProviderClient:
 
         Only llama.cpp exposes its chat template to clients: ``GET /props``
         returns the loaded model's ``chat_template`` (the same Jinja template the
-        local GGUF path classifies). One model is served, so the result is
-        fetched once and cached on this client for every catalog id.
+        local GGUF path classifies). In router mode (``--models-dir`` /
+        ``--models-preset``) the server serves several models and ``/props``
+        selects one via ``?model=<id>``, so the result is fetched and cached per
+        model id; a single-model server falls back to the bare ``/props``.
 
         Every other provider type has no standard Jinja chat-template endpoint
         and returns ``None`` -- notably Ollama, whose ``/api/show`` ``template``
@@ -6471,26 +6474,34 @@ class ExternalProviderClient:
         model listing it decorates.
         """
         if self.provider_type == "llama_cpp":
-            if self._probed_llama_cpp_template is None:
-                self._probed_llama_cpp_template = await self._probe_llama_cpp_chat_template()
-            return self._probed_llama_cpp_template
+            key = model_id or ""
+            if key not in self._probed_llama_cpp_templates:
+                self._probed_llama_cpp_templates[key] = await self._probe_llama_cpp_chat_template(key)
+            return self._probed_llama_cpp_templates[key]
         return None
 
-    async def _probe_llama_cpp_chat_template(self) -> Optional[str]:
+    async def _probe_llama_cpp_chat_template(self, model_id: str) -> Optional[str]:
         root = self.base_url.removesuffix("/v1").rstrip("/")
-        try:
-            response = await _http_client.get(
-                f"{root}/props",
-                headers = self._auth_headers(),
-                timeout = httpx.Timeout(5.0, connect = 5.0),
-            )
-            response.raise_for_status()
-            data = response.json()
-            template = data.get("chat_template") if isinstance(data, dict) else None
-            return template if isinstance(template, str) and template else None
-        except (httpx.HTTPError, ValueError) as exc:
-            logger.debug("llama_cpp /props chat-template probe failed: %s", exc)
-            return None
+        # Router mode names each served model, so ask for the specific one first;
+        # a single-model server ignores the query param (or has no matching
+        # entry), so fall back to the bare endpoint, which is what it answers.
+        candidates = [f"{root}/props?model={quote(model_id, safe='')}"] if model_id else []
+        candidates.append(f"{root}/props")
+        for url in candidates:
+            try:
+                response = await _http_client.get(
+                    url,
+                    headers = self._auth_headers(),
+                    timeout = httpx.Timeout(5.0, connect = 5.0),
+                )
+                response.raise_for_status()
+                data = response.json()
+                template = data.get("chat_template") if isinstance(data, dict) else None
+                if isinstance(template, str) and template:
+                    return template
+            except (httpx.HTTPError, ValueError) as exc:
+                logger.debug("llama_cpp %s chat-template probe failed: %s", url, exc)
+        return None
 
     async def verify_models_endpoint_lightweight(self) -> None:
         """

--- a/studio/backend/core/inference/external_provider.py
+++ b/studio/backend/core/inference/external_provider.py
@@ -6476,7 +6476,9 @@ class ExternalProviderClient:
         if self.provider_type == "llama_cpp":
             key = model_id or ""
             if key not in self._probed_llama_cpp_templates:
-                self._probed_llama_cpp_templates[key] = await self._probe_llama_cpp_chat_template(key)
+                self._probed_llama_cpp_templates[key] = await self._probe_llama_cpp_chat_template(
+                    key
+                )
             return self._probed_llama_cpp_templates[key]
         return None
 
@@ -6485,7 +6487,7 @@ class ExternalProviderClient:
         # Router mode names each served model, so ask for the specific one first;
         # a single-model server ignores the query param (or has no matching
         # entry), so fall back to the bare endpoint, which is what it answers.
-        candidates = [f"{root}/props?model={quote(model_id, safe='')}"] if model_id else []
+        candidates = [f"{root}/props?model={quote(model_id, safe = '')}"] if model_id else []
         candidates.append(f"{root}/props")
         for url in candidates:
             try:

--- a/studio/backend/core/inference/external_provider.py
+++ b/studio/backend/core/inference/external_provider.py
@@ -902,6 +902,9 @@ class ExternalProviderClient:
         # Generous per-byte read timeout: reasoning models pause tens of seconds
         # between bytes, but a dead upstream must eventually error, not hang forever.
         self._stream_timeout = httpx.Timeout(timeout, connect = 10.0, read = 300.0)
+        # llama.cpp serves a single model, so its chat template is fetched once
+        # per client and reused across every model id in the catalog.
+        self._probed_llama_cpp_template: Optional[str] = None
 
     def _auth_headers(self) -> dict[str, str]:
         """Build authentication headers using the provider's registry config."""
@@ -1149,12 +1152,21 @@ class ExternalProviderClient:
                 body["thinking"] = {"type": "disabled"}
         elif self.provider_type == "mistral":
             _apply_mistral_reasoning_controls(body, model, enable_thinking, reasoning_effort)
-        elif self.provider_type == "vllm" and enable_thinking is not None:
-            # vLLM gates thinking via chat_template_kwargs.enable_thinking.
+        elif self.provider_type in ("vllm", "llama_cpp") and (
+            enable_thinking is not None or reasoning_effort is not None
+        ):
+            # vLLM and llama-server both apply the model's own chat template on
+            # the way in and accept `chat_template_kwargs` on
+            # /v1/chat/completions, so the resolved reasoning controls render
+            # exactly as they do for an in-process load. llama-server merges
+            # these per key over its load-time defaults.
             tpl_kw = body.get("chat_template_kwargs")
             if not isinstance(tpl_kw, dict):
                 tpl_kw = {}
-            tpl_kw["enable_thinking"] = bool(enable_thinking)
+            if enable_thinking is not None:
+                tpl_kw["enable_thinking"] = bool(enable_thinking)
+            if reasoning_effort is not None:
+                tpl_kw["reasoning_effort"] = reasoning_effort
             body["chat_template_kwargs"] = tpl_kw
 
         # OpenRouter's unified `reasoning` field gates per-model thinking.
@@ -6442,6 +6454,43 @@ class ExternalProviderClient:
             for entry in raw_models
             if isinstance(entry, dict) and entry.get("name", "").strip()
         ]
+
+    async def probe_chat_template(self, model_id: str) -> Optional[str]:
+        """Best-effort Jinja chat template for a connected self-hosted model.
+
+        Only llama.cpp exposes its chat template to clients: ``GET /props``
+        returns the loaded model's ``chat_template`` (the same Jinja template the
+        local GGUF path classifies). One model is served, so the result is
+        fetched once and cached on this client for every catalog id.
+
+        Every other provider type has no standard Jinja chat-template endpoint
+        and returns ``None`` -- notably Ollama, whose ``/api/show`` ``template``
+        is a Go template with a different variable surface and no
+        ``reasoning_effort`` concept, so it cannot feed the Jinja classifier.
+        Failures also return ``None``: a capability probe must never break the
+        model listing it decorates.
+        """
+        if self.provider_type == "llama_cpp":
+            if self._probed_llama_cpp_template is None:
+                self._probed_llama_cpp_template = await self._probe_llama_cpp_chat_template()
+            return self._probed_llama_cpp_template
+        return None
+
+    async def _probe_llama_cpp_chat_template(self) -> Optional[str]:
+        root = self.base_url.removesuffix("/v1").rstrip("/")
+        try:
+            response = await _http_client.get(
+                f"{root}/props",
+                headers = self._auth_headers(),
+                timeout = httpx.Timeout(5.0, connect = 5.0),
+            )
+            response.raise_for_status()
+            data = response.json()
+            template = data.get("chat_template") if isinstance(data, dict) else None
+            return template if isinstance(template, str) and template else None
+        except (httpx.HTTPError, ValueError) as exc:
+            logger.debug("llama_cpp /props chat-template probe failed: %s", exc)
+            return None
 
     async def verify_models_endpoint_lightweight(self) -> None:
         """

--- a/studio/backend/models/providers.py
+++ b/studio/backend/models/providers.py
@@ -193,10 +193,24 @@ class ProviderModelInfo(BaseModel):
     display_name: str = Field("", description = "Human-readable model name")
     context_length: Optional[int] = Field(None, description = "Maximum context length in tokens")
     owned_by: Optional[str] = Field(None, description = "Model owner/organization")
-    reasoning: Optional[ProviderModelReasoning] = Field(
-        None,
-        description = "Reasoning capabilities probed from the server's chat template; absent when the provider exposes no template endpoint or the probe failed",
+
+
+class ProviderModelReasoningRequest(BaseModel):
+    """Probe one connected model's reasoning capabilities on demand."""
+
+    provider_id: Optional[str] = Field(
+        None, description = "Saved provider config whose stored key may be used"
     )
+
+    provider_type: str = Field(..., description = "Provider type from the registry")
+    encrypted_api_key: Optional[str] = Field(
+        None,
+        description = "RSA-encrypted, base64-encoded API key (optional for local providers)",
+    )
+    base_url: Optional[str] = Field(
+        None, description = "Custom base URL (overrides registry default)"
+    )
+    model_id: str = Field(..., description = "Model ID to probe, as returned by /models")
 
 
 class ProviderModelsRequest(BaseModel):

--- a/studio/backend/models/providers.py
+++ b/studio/backend/models/providers.py
@@ -170,9 +170,11 @@ class ProviderModelReasoning(BaseModel):
         False,
         description = "Whether the model supports thinking/reasoning mode (enable_thinking or reasoning_effort)",
     )
-    reasoning_style: Literal["enable_thinking", "reasoning_effort", "enable_thinking_effort"] = Field(
-        "enable_thinking",
-        description = "Reasoning control style: 'enable_thinking' (boolean), 'reasoning_effort' (effort ladder), or 'enable_thinking_effort' (on/off gate plus an effort level)",
+    reasoning_style: Literal["enable_thinking", "reasoning_effort", "enable_thinking_effort"] = (
+        Field(
+            "enable_thinking",
+            description = "Reasoning control style: 'enable_thinking' (boolean), 'reasoning_effort' (effort ladder), or 'enable_thinking_effort' (on/off gate plus an effort level)",
+        )
     )
     reasoning_effort_levels: list[str] = Field(
         default_factory = list,

--- a/studio/backend/models/providers.py
+++ b/studio/backend/models/providers.py
@@ -156,6 +156,34 @@ class ProviderResponse(BaseModel):
 # ── Model listing ─────────────────────────────────────────────────
 
 
+class ProviderModelReasoning(BaseModel):
+    """Reasoning controls a connected model advertises through its chat template.
+
+    Only populated for self-hosted servers that expose a Jinja chat template to
+    clients (llama.cpp ``/props``). Mirrors the flags the local GGUF/safetensors
+    paths derive from the same classifier
+    (``core.inference.llama_cpp.detect_reasoning_flags``) so the frontend sees
+    one consistent shape.
+    """
+
+    supports_reasoning: bool = Field(
+        False,
+        description = "Whether the model supports thinking/reasoning mode (enable_thinking or reasoning_effort)",
+    )
+    reasoning_style: Literal["enable_thinking", "reasoning_effort", "enable_thinking_effort"] = Field(
+        "enable_thinking",
+        description = "Reasoning control style: 'enable_thinking' (boolean), 'reasoning_effort' (effort ladder), or 'enable_thinking_effort' (on/off gate plus an effort level)",
+    )
+    reasoning_effort_levels: list[str] = Field(
+        default_factory = list,
+        description = "Discrete reasoning_effort levels the template offers (e.g. ['low', 'medium', 'high', 'xhigh']); empty when the style is not effort-based",
+    )
+    reasoning_always_on: bool = Field(
+        False,
+        description = "Whether reasoning is always on (hardcoded <think> tags, not toggleable)",
+    )
+
+
 class ProviderModelInfo(BaseModel):
     """A model available from an external provider."""
 
@@ -163,6 +191,10 @@ class ProviderModelInfo(BaseModel):
     display_name: str = Field("", description = "Human-readable model name")
     context_length: Optional[int] = Field(None, description = "Maximum context length in tokens")
     owned_by: Optional[str] = Field(None, description = "Model owner/organization")
+    reasoning: Optional[ProviderModelReasoning] = Field(
+        None,
+        description = "Reasoning capabilities probed from the server's chat template; absent when the provider exposes no template endpoint or the probe failed",
+    )
 
 
 class ProviderModelsRequest(BaseModel):

--- a/studio/backend/routes/providers.py
+++ b/studio/backend/routes/providers.py
@@ -49,6 +49,7 @@ from models.providers import (
     ProviderCredentialMigration,
     ProviderModelInfo,
     ProviderModelReasoning,
+    ProviderModelReasoningRequest,
     ProviderModelsRequest,
     ProviderResponse,
     ProviderRegistryEntry,
@@ -873,26 +874,87 @@ async def list_provider_models(
         limit = info.get("model_id_limit")
         if isinstance(limit, int) and limit > 0:
             models = models[:limit]
-        reasoning_by_model = await _probe_model_reasoning(client, payload.provider_type, models)
-        result: list[ProviderModelInfo] = []
-        for m in models:
-            model_id = m.get("id", "")
-            result.append(
-                ProviderModelInfo(
-                    id = model_id,
-                    display_name = model_id,
-                    context_length = m.get("context_length") or m.get("context_window"),
-                    owned_by = m.get("owned_by"),
-                    reasoning = reasoning_by_model.get(str(model_id).strip()),
-                )
+        return [
+            ProviderModelInfo(
+                id = m.get("id", ""),
+                display_name = m.get("id", ""),
+                context_length = m.get("context_length") or m.get("context_window"),
+                owned_by = m.get("owned_by"),
             )
-        return result
+            for m in models
+        ]
     except Exception as exc:
         raise log_and_http_error(
             exc,
             502,
             f"Failed to list models from {payload.provider_type}.",
             event = "providers.list_models_failed",
+            log = logger,
+        )
+    finally:
+        await client.close()
+
+
+@router.post("/model-reasoning", response_model = Optional[ProviderModelReasoning])
+async def get_provider_model_reasoning(
+    payload: ProviderModelReasoningRequest,
+    _current_subject: str = Depends(get_current_subject),
+    via_api_key: bool = Depends(authenticated_via_api_key),
+):
+    """Probe one connected model's reasoning controls from its chat template.
+
+    On-demand, single-model companion to ``/models``: llama.cpp reports a model's
+    ``chat_template`` only once it is (lazily) loaded, so a catalog-wide probe
+    would force-load every model. The UI probes exactly the model a user selects
+    and caches the result.
+
+    Returns ``null`` when the provider exposes no template endpoint or the probe
+    cannot obtain one.
+    """
+
+    model_id = (payload.model_id or "").strip()
+    if not model_id:
+        raise HTTPException(status_code = 400, detail = "model_id is required.")
+
+    payload = _bind_saved_provider_target(payload)
+    info = get_provider_info(payload.provider_type)
+    if info is None:
+        raise HTTPException(
+            status_code = 400,
+            detail = f"Unknown provider type: {payload.provider_type}",
+        )
+
+    api_key = resolve_provider_api_key_or_400(
+        payload.provider_id,
+        payload.encrypted_api_key,
+        allow_saved_key = not via_api_key,
+    )
+
+    base_url = payload.base_url or info["base_url"]
+    try:
+        base_url = validate_provider_base_url(base_url)
+    except ValueError as exc:
+        raise HTTPException(status_code = 400, detail = str(exc)) from None
+
+    client = ExternalProviderClient(
+        provider_type = payload.provider_type,
+        base_url = base_url,
+        api_key = api_key,
+        timeout = 15.0,
+    )
+    try:
+        by_model = await _probe_model_reasoning(
+            client,
+            payload.provider_type,
+            [{"id": model_id}],
+        )
+        return by_model.get(model_id)
+    except Exception as exc:
+        raise log_and_http_error(
+            exc,
+            502,
+            f"Failed to probe model reasoning for {payload.provider_type}.",
+            event = "providers.model_reasoning_failed",
             log = logger,
         )
     finally:

--- a/studio/backend/routes/providers.py
+++ b/studio/backend/routes/providers.py
@@ -726,9 +726,7 @@ async def test_provider(
 
 
 async def _probe_model_reasoning(
-    client: ExternalProviderClient,
-    provider_type: str,
-    models: list[dict],
+    client: ExternalProviderClient, provider_type: str, models: list[dict]
 ) -> dict[str, ProviderModelReasoning]:
     """Derive reasoning capabilities from a connected server's chat template.
 

--- a/studio/backend/routes/providers.py
+++ b/studio/backend/routes/providers.py
@@ -47,8 +47,9 @@ from core.inference import openai_codex_auth, openai_codex_client
 from models.providers import (
     ProviderCreate,
     ProviderCredentialMigration,
-    ProviderModelsRequest,
     ProviderModelInfo,
+    ProviderModelReasoning,
+    ProviderModelsRequest,
     ProviderResponse,
     ProviderRegistryEntry,
     ProviderTestRequest,
@@ -724,6 +725,69 @@ async def test_provider(
 # ── List models from provider ─────────────────────────────────────
 
 
+async def _probe_model_reasoning(
+    client: ExternalProviderClient,
+    provider_type: str,
+    models: list[dict],
+) -> dict[str, ProviderModelReasoning]:
+    """Derive reasoning capabilities from a connected server's chat template.
+
+    Only llama.cpp exposes a Jinja chat template to clients; every other
+    provider returns an empty mapping, leaving the ``reasoning`` field absent.
+    Classification reuses ``detect_reasoning_flags`` -- the same classifier the
+    local GGUF/safetensors load paths run -- so the frontend sees one consistent
+    shape. Best-effort: a probe or classification failure leaves the model
+    unclassified rather than failing the listing.
+    """
+    if provider_type != "llama_cpp":
+        return {}
+    probe = getattr(client, "probe_chat_template", None)
+    if probe is None:
+        return {}
+    from core.inference.llama_cpp import detect_reasoning_flags
+
+    out: dict[str, ProviderModelReasoning] = {}
+    for model in models:
+        if not isinstance(model, dict):
+            continue
+        model_id = str(model.get("id") or "").strip()
+        if not model_id:
+            continue
+        try:
+            template = await probe(model_id)
+        except Exception:
+            logger.debug(
+                "chat-template probe raised for %s/%s",
+                provider_type,
+                model_id,
+                exc_info = True,
+            )
+            continue
+        if not template:
+            continue
+        try:
+            flags = detect_reasoning_flags(
+                template,
+                model_identifier = model_id,
+                log_source = f"external:{provider_type}",
+            )
+        except Exception:
+            logger.debug(
+                "reasoning classification failed for %s/%s",
+                provider_type,
+                model_id,
+                exc_info = True,
+            )
+            continue
+        out[model_id] = ProviderModelReasoning(
+            supports_reasoning = bool(flags.get("supports_reasoning")),
+            reasoning_style = flags.get("reasoning_style", "enable_thinking"),
+            reasoning_effort_levels = list(flags.get("reasoning_effort_levels") or []),
+            reasoning_always_on = bool(flags.get("reasoning_always_on")),
+        )
+    return out
+
+
 @router.post("/models", response_model = list[ProviderModelInfo])
 async def list_provider_models(
     payload: ProviderModelsRequest,
@@ -811,15 +875,20 @@ async def list_provider_models(
         limit = info.get("model_id_limit")
         if isinstance(limit, int) and limit > 0:
             models = models[:limit]
-        return [
-            ProviderModelInfo(
-                id = m.get("id", ""),
-                display_name = m.get("id", ""),
-                context_length = m.get("context_length") or m.get("context_window"),
-                owned_by = m.get("owned_by"),
+        reasoning_by_model = await _probe_model_reasoning(client, payload.provider_type, models)
+        result: list[ProviderModelInfo] = []
+        for m in models:
+            model_id = m.get("id", "")
+            result.append(
+                ProviderModelInfo(
+                    id = model_id,
+                    display_name = model_id,
+                    context_length = m.get("context_length") or m.get("context_window"),
+                    owned_by = m.get("owned_by"),
+                    reasoning = reasoning_by_model.get(str(model_id).strip()),
+                )
             )
-            for m in models
-        ]
+        return result
     except Exception as exc:
         raise log_and_http_error(
             exc,

--- a/studio/backend/tests/test_provider_model_reasoning_probe.py
+++ b/studio/backend/tests/test_provider_model_reasoning_probe.py
@@ -45,7 +45,11 @@ QWEN38_TEMPLATE = (
 
 
 class _FakeResponse:
-    def __init__(self, status_code = 200, body = None):
+    def __init__(
+        self,
+        status_code = 200,
+        body = None,
+    ):
         self.status_code = status_code
         self._body = body or {}
 
@@ -64,13 +68,24 @@ class _FakeAsyncClient:
         self.get_response: object = _FakeResponse(200, {})
         self.post_response: object = _FakeResponse(200, {})
 
-    async def get(self, url, headers = None, timeout = None):
+    async def get(
+        self,
+        url,
+        headers = None,
+        timeout = None,
+    ):
         self.get_calls.append((url, headers, timeout))
         if isinstance(self.get_response, Exception):
             raise self.get_response
         return self.get_response
 
-    async def post(self, url, headers = None, json = None, timeout = None):
+    async def post(
+        self,
+        url,
+        headers = None,
+        json = None,
+        timeout = None,
+    ):
         self.post_calls.append((url, headers, json, timeout))
         if isinstance(self.post_response, Exception):
             raise self.post_response
@@ -98,7 +113,9 @@ def test_llama_cpp_probe_reads_chat_template(monkeypatch):
     fake.get_response = _FakeResponse(200, {"chat_template": QWEN38_TEMPLATE})
     monkeypatch.setattr(ep_mod, "_http_client", fake)
 
-    template = _run(_make_client("llama_cpp", "http://127.0.0.1:8080/v1").probe_chat_template("any"))
+    template = _run(
+        _make_client("llama_cpp", "http://127.0.0.1:8080/v1").probe_chat_template("any")
+    )
 
     assert template == QWEN38_TEMPLATE
     # /props lives at the server root, not under the OpenAI-compat /v1 prefix.
@@ -122,7 +139,9 @@ def test_unsupported_provider_returns_none_without_http(monkeypatch):
     monkeypatch.setattr(ep_mod, "_http_client", fake)
 
     assert _run(_make_client("custom", "http://127.0.0.1:8080/v1").probe_chat_template("x")) is None
-    assert _run(_make_client("ollama", "http://127.0.0.1:11434/v1").probe_chat_template("x")) is None
+    assert (
+        _run(_make_client("ollama", "http://127.0.0.1:11434/v1").probe_chat_template("x")) is None
+    )
     assert fake.get_calls == []
     assert fake.post_calls == []
 
@@ -132,7 +151,9 @@ def test_probe_failure_returns_none(monkeypatch):
     fake.get_response = httpx.ConnectError("down")
     monkeypatch.setattr(ep_mod, "_http_client", fake)
 
-    assert _run(_make_client("llama_cpp", "http://127.0.0.1:8080/v1").probe_chat_template("x")) is None
+    assert (
+        _run(_make_client("llama_cpp", "http://127.0.0.1:8080/v1").probe_chat_template("x")) is None
+    )
 
 
 def test_probe_missing_template_key_returns_none(monkeypatch):
@@ -140,7 +161,9 @@ def test_probe_missing_template_key_returns_none(monkeypatch):
     fake.get_response = _FakeResponse(200, {"default_generation_settings": {}})
     monkeypatch.setattr(ep_mod, "_http_client", fake)
 
-    assert _run(_make_client("llama_cpp", "http://127.0.0.1:8080/v1").probe_chat_template("x")) is None
+    assert (
+        _run(_make_client("llama_cpp", "http://127.0.0.1:8080/v1").probe_chat_template("x")) is None
+    )
 
 
 # ── _probe_model_reasoning classification ────────────────────────────

--- a/studio/backend/tests/test_provider_model_reasoning_probe.py
+++ b/studio/backend/tests/test_provider_model_reasoning_probe.py
@@ -108,7 +108,7 @@ def _run(coro):
 # ── ExternalProviderClient.probe_chat_template ───────────────────────
 
 
-def test_llama_cpp_probe_reads_chat_template(monkeypatch):
+def test_llama_cpp_probe_reads_chat_template_via_model_query(monkeypatch):
     fake = _FakeAsyncClient()
     fake.get_response = _FakeResponse(200, {"chat_template": QWEN38_TEMPLATE})
     monkeypatch.setattr(ep_mod, "_http_client", fake)
@@ -118,20 +118,50 @@ def test_llama_cpp_probe_reads_chat_template(monkeypatch):
     )
 
     assert template == QWEN38_TEMPLATE
-    # /props lives at the server root, not under the OpenAI-compat /v1 prefix.
-    assert fake.get_calls[0][0] == "http://127.0.0.1:8080/props"
+    # Router mode names each served model: /props is addressed per model, and it
+    # lives at the server root, not under the OpenAI-compat /v1 prefix.
+    assert fake.get_calls[0][0] == "http://127.0.0.1:8080/props?model=any"
 
 
-def test_llama_cpp_probe_is_cached_across_models(monkeypatch):
+def test_llama_cpp_probe_falls_back_to_bare_props(monkeypatch):
+    # A single-model server has no per-model /props entry, so the ?model= probe
+    # returns no template and the bare endpoint answers.
+    fake = _FakeAsyncClient()
+
+    def dispatch(url, headers = None, timeout = None):
+        fake.get_calls.append((url, headers, timeout))
+        if "model=" in url:
+            return _FakeResponse(200, {"chat_template": ""})
+        return _FakeResponse(200, {"chat_template": QWEN38_TEMPLATE})
+
+    monkeypatch.setattr(ep_mod, "_http_client", fake)
+    monkeypatch.setattr(fake, "get", dispatch)
+
+    template = _run(
+        _make_client("llama_cpp", "http://127.0.0.1:8080/v1").probe_chat_template("only-model")
+    )
+
+    assert template == QWEN38_TEMPLATE
+    assert [url for url, _, _ in fake.get_calls] == [
+        "http://127.0.0.1:8080/props?model=only-model",
+        "http://127.0.0.1:8080/props",
+    ]
+
+
+def test_llama_cpp_probe_caches_per_model_id(monkeypatch):
     fake = _FakeAsyncClient()
     fake.get_response = _FakeResponse(200, {"chat_template": QWEN38_TEMPLATE})
     monkeypatch.setattr(ep_mod, "_http_client", fake)
 
     client = _make_client("llama_cpp", "http://127.0.0.1:8080/v1")
     assert _run(client.probe_chat_template("model-a")) == QWEN38_TEMPLATE
+    assert _run(client.probe_chat_template("model-a")) == QWEN38_TEMPLATE
     assert _run(client.probe_chat_template("model-b")) == QWEN38_TEMPLATE
-    # One loaded model, one /props read.
-    assert len(fake.get_calls) == 1
+    # One /props read per distinct model id, cached per id.
+    assert [url for url, _, _ in fake.get_calls] == [
+        "http://127.0.0.1:8080/props?model=model-a",
+        "http://127.0.0.1:8080/props?model=model-b",
+    ]
 
 
 def test_unsupported_provider_returns_none_without_http(monkeypatch):
@@ -221,10 +251,10 @@ def test_probe_model_reasoning_requires_probe_method():
     assert out == {}
 
 
-# ── list_provider_models end-to-end ──────────────────────────────────
+# ── routes: listing stays cheap, on-demand probe is explicit ─────────
 
 
-def test_list_provider_models_attaches_reasoning(monkeypatch):
+def test_list_provider_models_does_not_probe_reasoning(monkeypatch):
     from routes import providers as providers_route
     from routes.providers import ProviderModelsRequest, list_provider_models
 
@@ -235,12 +265,10 @@ def test_list_provider_models_attaches_reasoning(monkeypatch):
         async def list_models(self):
             return [{"id": "qwen3.8-14b"}]
 
-        async def probe_chat_template(self, model_id):
-            return QWEN38_TEMPLATE
-
         async def close(self):
             return None
 
+    # No `probe_chat_template` method: a catalog-time probe would AttributeError.
     monkeypatch.setattr(providers_route, "ExternalProviderClient", _FakeClient)
 
     result = _run(
@@ -255,36 +283,97 @@ def test_list_provider_models_attaches_reasoning(monkeypatch):
     )
 
     assert [m.id for m in result] == ["qwen3.8-14b"]
-    assert result[0].reasoning is not None
-    assert result[0].reasoning.reasoning_style == "enable_thinking_effort"
-    assert result[0].reasoning.reasoning_effort_levels == ["low", "medium", "xhigh"]
 
 
-def test_list_provider_models_leaves_reasoning_absent_for_other_providers(monkeypatch):
+def test_get_provider_model_reasoning_probes_single_model(monkeypatch):
     from routes import providers as providers_route
-    from routes.providers import ProviderModelsRequest, list_provider_models
+    from routes.providers import (
+        ProviderModelReasoningRequest,
+        get_provider_model_reasoning,
+    )
 
     class _FakeClient:
         def __init__(self, **kwargs):
             pass
 
-        async def list_models(self):
-            return [{"id": "mistral-small-latest"}]
+        async def probe_chat_template(self, model_id):
+            assert model_id == "qwen3.8-14b"
+            return QWEN38_TEMPLATE
 
         async def close(self):
             return None
 
     monkeypatch.setattr(providers_route, "ExternalProviderClient", _FakeClient)
 
-    result = _run(
-        list_provider_models(
-            ProviderModelsRequest(provider_type = "mistral", base_url = "https://api.mistral.ai/v1"),
+    reasoning = _run(
+        get_provider_model_reasoning(
+            ProviderModelReasoningRequest(
+                provider_type = "llama_cpp",
+                base_url = "http://127.0.0.1:8080/v1",
+                model_id = "qwen3.8-14b",
+            ),
             _current_subject = "alice",
             via_api_key = False,
         )
     )
 
-    assert result[0].reasoning is None
+    assert reasoning is not None
+    assert reasoning.supports_reasoning is True
+    assert reasoning.reasoning_style == "enable_thinking_effort"
+    assert reasoning.reasoning_effort_levels == ["low", "medium", "xhigh"]
+
+
+def test_get_provider_model_reasoning_returns_none_for_other_providers(monkeypatch):
+    from routes import providers as providers_route
+    from routes.providers import (
+        ProviderModelReasoningRequest,
+        get_provider_model_reasoning,
+    )
+
+    class _FakeClient:
+        def __init__(self, **kwargs):
+            pass
+
+        async def close(self):
+            return None
+
+    monkeypatch.setattr(providers_route, "ExternalProviderClient", _FakeClient)
+
+    reasoning = _run(
+        get_provider_model_reasoning(
+            ProviderModelReasoningRequest(
+                provider_type = "mistral",
+                base_url = "https://api.mistral.ai/v1",
+                model_id = "mistral-small-latest",
+            ),
+            _current_subject = "alice",
+            via_api_key = False,
+        )
+    )
+
+    assert reasoning is None
+
+
+def test_get_provider_model_reasoning_requires_model_id(monkeypatch):
+    from routes import providers as providers_route
+    from routes.providers import (
+        ProviderModelReasoningRequest,
+        get_provider_model_reasoning,
+    )
+
+    with pytest.raises(Exception) as exc:
+        _run(
+            get_provider_model_reasoning(
+                ProviderModelReasoningRequest(
+                    provider_type = "llama_cpp",
+                    base_url = "http://127.0.0.1:8080/v1",
+                    model_id = "   ",
+                ),
+                _current_subject = "alice",
+                via_api_key = False,
+            )
+        )
+    assert "model_id" in str(exc.value)
 
 
 # ── stream_chat_completion forwards reasoning as chat_template_kwargs ─

--- a/studio/backend/tests/test_provider_model_reasoning_probe.py
+++ b/studio/backend/tests/test_provider_model_reasoning_probe.py
@@ -1,0 +1,348 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Chat-template reasoning probing + forwarding for connected llama.cpp servers.
+
+The local GGUF/safetensors load paths classify reasoning controls from the
+model's Jinja chat template; a connected llama.cpp server exposes that same
+template (``GET /props``), so ``list_provider_models`` probes it and classifies
+it with the same ``detect_reasoning_flags`` helper, and the chat-completions
+proxy forwards the resolved ``enable_thinking`` / ``reasoning_effort`` back as
+``chat_template_kwargs`` so the server's template renders them.
+
+Stubbed httpx; no subprocess, GPU, or network. Cross-platform.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_BACKEND_DIR = str(Path(__file__).resolve().parent.parent)
+if _BACKEND_DIR not in sys.path:
+    sys.path.insert(0, _BACKEND_DIR)
+
+import httpx  # noqa: E402
+
+import core.inference.external_provider as ep_mod  # noqa: E402
+from core.inference.external_provider import ExternalProviderClient  # noqa: E402
+from routes.providers import _probe_model_reasoning  # noqa: E402
+
+
+# enable_thinking on/off gate PLUS a reasoning_effort ladder -- the Qwen3.8 shape.
+QWEN38_TEMPLATE = (
+    "{%- if enable_thinking is defined and enable_thinking %}"
+    "{%- if reasoning_effort == 'low' %}{{- 'LOW' -}}"
+    "{%- elif reasoning_effort == 'medium' %}{{- 'MEDIUM' -}}"
+    "{%- elif reasoning_effort == 'xhigh' %}{{- 'XHIGH' -}}"
+    "{%- endif %}{%- endif %}"
+    "{%- for message in messages %}{{- message.content }}{%- endfor %}"
+)
+
+
+class _FakeResponse:
+    def __init__(self, status_code = 200, body = None):
+        self.status_code = status_code
+        self._body = body or {}
+
+    def json(self):
+        return self._body
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise httpx.HTTPError(f"status {self.status_code}")
+
+
+class _FakeAsyncClient:
+    def __init__(self):
+        self.get_calls = []
+        self.post_calls = []
+        self.get_response: object = _FakeResponse(200, {})
+        self.post_response: object = _FakeResponse(200, {})
+
+    async def get(self, url, headers = None, timeout = None):
+        self.get_calls.append((url, headers, timeout))
+        if isinstance(self.get_response, Exception):
+            raise self.get_response
+        return self.get_response
+
+    async def post(self, url, headers = None, json = None, timeout = None):
+        self.post_calls.append((url, headers, json, timeout))
+        if isinstance(self.post_response, Exception):
+            raise self.post_response
+        return self.post_response
+
+
+def _make_client(provider_type: str, base_url: str) -> ExternalProviderClient:
+    return ExternalProviderClient(
+        provider_type = provider_type,
+        base_url = base_url,
+        api_key = "",
+        timeout = 15.0,
+    )
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+# ── ExternalProviderClient.probe_chat_template ───────────────────────
+
+
+def test_llama_cpp_probe_reads_chat_template(monkeypatch):
+    fake = _FakeAsyncClient()
+    fake.get_response = _FakeResponse(200, {"chat_template": QWEN38_TEMPLATE})
+    monkeypatch.setattr(ep_mod, "_http_client", fake)
+
+    template = _run(_make_client("llama_cpp", "http://127.0.0.1:8080/v1").probe_chat_template("any"))
+
+    assert template == QWEN38_TEMPLATE
+    # /props lives at the server root, not under the OpenAI-compat /v1 prefix.
+    assert fake.get_calls[0][0] == "http://127.0.0.1:8080/props"
+
+
+def test_llama_cpp_probe_is_cached_across_models(monkeypatch):
+    fake = _FakeAsyncClient()
+    fake.get_response = _FakeResponse(200, {"chat_template": QWEN38_TEMPLATE})
+    monkeypatch.setattr(ep_mod, "_http_client", fake)
+
+    client = _make_client("llama_cpp", "http://127.0.0.1:8080/v1")
+    assert _run(client.probe_chat_template("model-a")) == QWEN38_TEMPLATE
+    assert _run(client.probe_chat_template("model-b")) == QWEN38_TEMPLATE
+    # One loaded model, one /props read.
+    assert len(fake.get_calls) == 1
+
+
+def test_unsupported_provider_returns_none_without_http(monkeypatch):
+    fake = _FakeAsyncClient()
+    monkeypatch.setattr(ep_mod, "_http_client", fake)
+
+    assert _run(_make_client("custom", "http://127.0.0.1:8080/v1").probe_chat_template("x")) is None
+    assert _run(_make_client("ollama", "http://127.0.0.1:11434/v1").probe_chat_template("x")) is None
+    assert fake.get_calls == []
+    assert fake.post_calls == []
+
+
+def test_probe_failure_returns_none(monkeypatch):
+    fake = _FakeAsyncClient()
+    fake.get_response = httpx.ConnectError("down")
+    monkeypatch.setattr(ep_mod, "_http_client", fake)
+
+    assert _run(_make_client("llama_cpp", "http://127.0.0.1:8080/v1").probe_chat_template("x")) is None
+
+
+def test_probe_missing_template_key_returns_none(monkeypatch):
+    fake = _FakeAsyncClient()
+    fake.get_response = _FakeResponse(200, {"default_generation_settings": {}})
+    monkeypatch.setattr(ep_mod, "_http_client", fake)
+
+    assert _run(_make_client("llama_cpp", "http://127.0.0.1:8080/v1").probe_chat_template("x")) is None
+
+
+# ── _probe_model_reasoning classification ────────────────────────────
+
+
+class _ProbeClient:
+    def __init__(self, template):
+        self._template = template
+
+    async def probe_chat_template(self, model_id):
+        return self._template
+
+
+def test_probe_model_reasoning_classifies_effort_levels():
+    out = _run(
+        _probe_model_reasoning(
+            _ProbeClient(QWEN38_TEMPLATE),
+            "llama_cpp",
+            [{"id": "qwen3.8-14b"}],
+        )
+    )
+
+    assert "qwen3.8-14b" in out
+    reasoning = out["qwen3.8-14b"]
+    assert reasoning.supports_reasoning is True
+    assert reasoning.reasoning_style == "enable_thinking_effort"
+    assert reasoning.reasoning_effort_levels == ["low", "medium", "xhigh"]
+    assert reasoning.reasoning_always_on is False
+
+
+def test_probe_model_reasoning_skips_unsupported_provider():
+    out = _run(_probe_model_reasoning(_ProbeClient(QWEN38_TEMPLATE), "ollama", [{"id": "x"}]))
+    assert out == {}
+
+
+def test_probe_model_reasoning_skips_when_probe_returns_none():
+    out = _run(_probe_model_reasoning(_ProbeClient(None), "llama_cpp", [{"id": "x"}]))
+    assert out == {}
+
+
+def test_probe_model_reasoning_skips_when_probe_raises():
+    class _BoomClient:
+        async def probe_chat_template(self, model_id):
+            raise RuntimeError("server gone")
+
+    out = _run(_probe_model_reasoning(_BoomClient(), "llama_cpp", [{"id": "x"}]))
+    assert out == {}
+
+
+def test_probe_model_reasoning_requires_probe_method():
+    class _NoProbeClient:
+        pass
+
+    out = _run(_probe_model_reasoning(_NoProbeClient(), "llama_cpp", [{"id": "x"}]))
+    assert out == {}
+
+
+# ── list_provider_models end-to-end ──────────────────────────────────
+
+
+def test_list_provider_models_attaches_reasoning(monkeypatch):
+    from routes import providers as providers_route
+    from routes.providers import ProviderModelsRequest, list_provider_models
+
+    class _FakeClient:
+        def __init__(self, **kwargs):
+            pass
+
+        async def list_models(self):
+            return [{"id": "qwen3.8-14b"}]
+
+        async def probe_chat_template(self, model_id):
+            return QWEN38_TEMPLATE
+
+        async def close(self):
+            return None
+
+    monkeypatch.setattr(providers_route, "ExternalProviderClient", _FakeClient)
+
+    result = _run(
+        list_provider_models(
+            ProviderModelsRequest(
+                provider_type = "llama_cpp",
+                base_url = "http://127.0.0.1:8080/v1",
+            ),
+            _current_subject = "alice",
+            via_api_key = False,
+        )
+    )
+
+    assert [m.id for m in result] == ["qwen3.8-14b"]
+    assert result[0].reasoning is not None
+    assert result[0].reasoning.reasoning_style == "enable_thinking_effort"
+    assert result[0].reasoning.reasoning_effort_levels == ["low", "medium", "xhigh"]
+
+
+def test_list_provider_models_leaves_reasoning_absent_for_other_providers(monkeypatch):
+    from routes import providers as providers_route
+    from routes.providers import ProviderModelsRequest, list_provider_models
+
+    class _FakeClient:
+        def __init__(self, **kwargs):
+            pass
+
+        async def list_models(self):
+            return [{"id": "mistral-small-latest"}]
+
+        async def close(self):
+            return None
+
+    monkeypatch.setattr(providers_route, "ExternalProviderClient", _FakeClient)
+
+    result = _run(
+        list_provider_models(
+            ProviderModelsRequest(provider_type = "mistral", base_url = "https://api.mistral.ai/v1"),
+            _current_subject = "alice",
+            via_api_key = False,
+        )
+    )
+
+    assert result[0].reasoning is None
+
+
+# ── stream_chat_completion forwards reasoning as chat_template_kwargs ─
+
+
+def _drive(coro):
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+async def _collect(agen):
+    out = []
+    async for line in agen:
+        out.append(line)
+    return out
+
+
+def _mock_http_client(monkeypatch, handler):
+    transport = httpx.MockTransport(handler)
+    monkeypatch.setattr(ep_mod, "_http_client", httpx.AsyncClient(transport = transport))
+
+
+def _make_llama_cpp_client() -> ExternalProviderClient:
+    return _make_client("llama_cpp", "http://127.0.0.1:8080/v1")
+
+
+_SSE = b'data: {"choices":[{"delta":{"content":"ok"}}]}\n\ndata: [DONE]\n\n'
+
+
+def _stream_body(monkeypatch, provider_type, **kwargs):
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["body"] = json.loads(request.content.decode("utf-8"))
+        return httpx.Response(200, content = _SSE, headers = {"content-type": "text/event-stream"})
+
+    _mock_http_client(monkeypatch, handler)
+
+    async def run():
+        client = _make_client(provider_type, "http://127.0.0.1:8080/v1")
+        lines = await _collect(
+            client.stream_chat_completion(
+                messages = [{"role": "user", "content": "hi"}],
+                model = "m",
+                **kwargs,
+            )
+        )
+        await client.close()
+        return lines
+
+    _drive(run())
+    return captured.get("body") or {}
+
+
+def test_llama_cpp_forwards_reasoning_effort(monkeypatch):
+    body = _stream_body(monkeypatch, "llama_cpp", reasoning_effort = "xhigh")
+    assert body["chat_template_kwargs"] == {"reasoning_effort": "xhigh"}
+
+
+def test_llama_cpp_forwards_enable_thinking_and_effort(monkeypatch):
+    body = _stream_body(monkeypatch, "llama_cpp", enable_thinking = True, reasoning_effort = "medium")
+    assert body["chat_template_kwargs"] == {"enable_thinking": True, "reasoning_effort": "medium"}
+
+
+def test_llama_cpp_forwards_enable_thinking_alone(monkeypatch):
+    body = _stream_body(monkeypatch, "llama_cpp", enable_thinking = False)
+    assert body["chat_template_kwargs"] == {"enable_thinking": False}
+
+
+def test_llama_cpp_omits_chat_template_kwargs_without_reasoning_fields(monkeypatch):
+    body = _stream_body(monkeypatch, "llama_cpp")
+    assert "chat_template_kwargs" not in body
+
+
+def test_vllm_still_forwards_enable_thinking(monkeypatch):
+    body = _stream_body(monkeypatch, "vllm", enable_thinking = True)
+    assert body["chat_template_kwargs"] == {"enable_thinking": True}
+
+
+def test_ollama_does_not_forward_reasoning_kwargs(monkeypatch):
+    # Ollama's OpenAI-compat endpoint drops chat_template_kwargs (it has no
+    # reasoning_effort concept in its Go templates), so we leave the body alone;
+    # a native `think` path would be separate work.
+    body = _stream_body(monkeypatch, "ollama", enable_thinking = True, reasoning_effort = "high")
+    assert "chat_template_kwargs" not in body

--- a/studio/backend/tests/test_provider_model_reasoning_probe.py
+++ b/studio/backend/tests/test_provider_model_reasoning_probe.py
@@ -128,7 +128,11 @@ def test_llama_cpp_probe_falls_back_to_bare_props(monkeypatch):
     # returns no template and the bare endpoint answers.
     fake = _FakeAsyncClient()
 
-    def dispatch(url, headers = None, timeout = None):
+    def dispatch(
+        url,
+        headers = None,
+        timeout = None,
+    ):
         fake.get_calls.append((url, headers, timeout))
         if "model=" in url:
             return _FakeResponse(200, {"chat_template": ""})

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -109,6 +109,7 @@ import {
 import { useChatPreferencesStore } from "@/features/chat/stores/chat-preferences-store";
 import { useChatProjects } from "@/features/chat/hooks/use-chat-projects";
 import { NewProjectDialog } from "@/features/chat/components/new-project-dialog";
+import { DetectReasoningButton } from "@/features/chat/components/detect-reasoning-button";
 import { ResearchMessage } from "@/features/chat/components/research-message";
 import {
   DeepResearchComposerButton,
@@ -5122,9 +5123,18 @@ const ReasoningToggle: FC<{ side?: "top" | "bottom" }> = ({
   };
   const effortLabel = formatEffortLabel(reasoningEffort);
 
-  // Only rendered for models that can reason.
+  // Only rendered for models that can reason; an un-probed connected llama.cpp
+  // model gets a one-shot "Detect reasoning" affordance instead.
   if (!effectiveSupportsReasoning) {
-    return null;
+    return (
+      <DetectReasoningButton
+        providerType={selectedExternalProvider?.providerType ?? ""}
+        providerId={selectedExternalProvider?.id}
+        modelId={effectiveExternalModelId ?? ""}
+        baseUrl={selectedExternalProvider?.baseUrl ?? null}
+        isReasoningProvider={selectedExternalProvider?.isReasoningModel === true}
+      />
+    );
   }
 
   // enable_thinking_effort (GLM-5.2: high|max + disable) reuses the effort

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -5706,15 +5706,25 @@ export function createOpenAIStreamAdapter(
                 ? { fast_mode: true }
                 : {}),
               ...(externalReasoningCaps.supportsReasoning
-                ? externalReasoningCaps.reasoningStyle === "reasoning_effort"
-                  ? externalReasoningEnabled
-                    ? { reasoning_effort: selectedExternalEffort }
-                    : externalReasoningCaps.supportsReasoningOff
-                      ? { reasoning_effort: "none" }
-                      : {
-                          reasoning_effort: fallbackExternalEffort,
-                        }
-                  : { thinking: { type: reasoningEnabled ? "enabled" : "disabled" } }
+                ? externalReasoningCaps.reasoningStyle === "enable_thinking_effort"
+                  ? // GLM-5.2 / Qwen3.8-style: an on/off gate plus an effort
+                    // level. Sends both so a self-hosted server's template can
+                    // render the requested effort; off is a real disable.
+                    externalReasoningEnabled
+                    ? {
+                        enable_thinking: true,
+                        reasoning_effort: selectedExternalEffort,
+                      }
+                    : { enable_thinking: false }
+                  : externalReasoningCaps.reasoningStyle === "reasoning_effort"
+                    ? externalReasoningEnabled
+                      ? { reasoning_effort: selectedExternalEffort }
+                      : externalReasoningCaps.supportsReasoningOff
+                        ? { reasoning_effort: "none" }
+                        : {
+                            reasoning_effort: fallbackExternalEffort,
+                          }
+                    : { thinking: { type: reasoningEnabled ? "enabled" : "disabled" } }
                 : {}),
             };
           }

--- a/studio/frontend/src/features/chat/api/providers-api.ts
+++ b/studio/frontend/src/features/chat/api/providers-api.ts
@@ -52,6 +52,16 @@ export interface ProviderConfig {
   updated_at: string;
 }
 
+export interface ProviderModelReasoning {
+  supports_reasoning: boolean;
+  reasoning_style:
+    | "enable_thinking"
+    | "reasoning_effort"
+    | "enable_thinking_effort";
+  reasoning_effort_levels: string[];
+  reasoning_always_on: boolean;
+}
+
 export interface ProviderModelInfo {
   id: string;
   display_name: string;
@@ -59,6 +69,11 @@ export interface ProviderModelInfo {
   owned_by?: string | null;
   /** Only the ChatGPT plan catalog reports this; the registry describes the rest. */
   vision?: boolean | null;
+  /**
+   * Reasoning controls probed from the server's chat template. Present only for
+   * self-hosted providers that expose a Jinja template (llama.cpp).
+   */
+  reasoning?: ProviderModelReasoning | null;
 }
 
 export interface ProviderTestResult {

--- a/studio/frontend/src/features/chat/api/providers-api.ts
+++ b/studio/frontend/src/features/chat/api/providers-api.ts
@@ -69,11 +69,6 @@ export interface ProviderModelInfo {
   owned_by?: string | null;
   /** Only the ChatGPT plan catalog reports this; the registry describes the rest. */
   vision?: boolean | null;
-  /**
-   * Reasoning controls probed from the server's chat template. Present only for
-   * self-hosted providers that expose a Jinja template (llama.cpp).
-   */
-  reasoning?: ProviderModelReasoning | null;
 }
 
 export interface ProviderTestResult {
@@ -327,6 +322,31 @@ export async function listProviderModels(payload: {
       }),
     });
     return parseJsonOrThrow<ProviderModelInfo[]>(response);
+  });
+}
+
+export async function fetchProviderModelReasoning(payload: {
+  providerType: string;
+
+  providerId?: string | null;
+  apiKey: string;
+  baseUrl?: string | null;
+  modelId: string;
+}): Promise<ProviderModelReasoning | null> {
+  return withApiKeyEncryptionRetry(payload.apiKey, async (encryptedApiKey) => {
+    const response = await authFetch("/api/providers/model-reasoning", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        provider_type: payload.providerType,
+
+        provider_id: payload.providerId ?? null,
+        encrypted_api_key: encryptedApiKey,
+        base_url: payload.baseUrl ?? null,
+        model_id: payload.modelId,
+      }),
+    });
+    return parseJsonOrThrow<ProviderModelReasoning | null>(response);
   });
 }
 

--- a/studio/frontend/src/features/chat/chat-providers-dialog.tsx
+++ b/studio/frontend/src/features/chat/chat-providers-dialog.tsx
@@ -70,6 +70,7 @@ import {
   getProviderModelCapabilities,
   providerModelSupportsStudioTools,
   setProviderModelCapabilities,
+  setProviderModelReasoningCapabilities,
   removeExternalProviderApiKey,
   supportsProviderMaxOutputTokens,
   supportsProviderReasoningToggle,
@@ -673,6 +674,10 @@ export function ChatProvidersSettings({
         apiKey: apiKey.trim(),
         baseUrl,
       });
+      // Cache backend-probed reasoning capabilities (llama.cpp /props) so the
+      // composer's Think menu can offer effort levels for self-hosted reasoning
+      // models without a page reload.
+      setProviderModelReasoningCapabilities(backendProviderType, models);
       const registryDefaults = supportsRemoteModelCatalog(providerType)
         ? []
         : (registryByType.get(providerType)?.default_models ?? []);

--- a/studio/frontend/src/features/chat/chat-providers-dialog.tsx
+++ b/studio/frontend/src/features/chat/chat-providers-dialog.tsx
@@ -70,7 +70,6 @@ import {
   getProviderModelCapabilities,
   providerModelSupportsStudioTools,
   setProviderModelCapabilities,
-  setProviderModelReasoningCapabilities,
   removeExternalProviderApiKey,
   supportsProviderMaxOutputTokens,
   supportsProviderReasoningToggle,
@@ -674,10 +673,6 @@ export function ChatProvidersSettings({
         apiKey: apiKey.trim(),
         baseUrl,
       });
-      // Cache backend-probed reasoning capabilities (llama.cpp /props) so the
-      // composer's Think menu can offer effort levels for self-hosted reasoning
-      // models without a page reload.
-      setProviderModelReasoningCapabilities(backendProviderType, models);
       const registryDefaults = supportsRemoteModelCatalog(providerType)
         ? []
         : (registryByType.get(providerType)?.default_models ?? []);

--- a/studio/frontend/src/features/chat/components/detect-reasoning-button.tsx
+++ b/studio/frontend/src/features/chat/components/detect-reasoning-button.tsx
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import { useState } from "react";
+
+import { Spinner } from "@/components/ui/spinner";
+import { BulbIcon } from "@/lib/bulb-icon";
+import { toast } from "@/lib/toast";
+
+import { fetchProviderModelReasoning } from "../api/providers-api";
+import {
+  getProviderModelReasoningCapabilities,
+  setProviderModelReasoningCapabilities,
+} from "../external-providers";
+import {
+  clampReasoningEffortToLevels,
+  getExternalReasoningCapabilities,
+} from "../provider-capabilities";
+import {
+  type ReasoningEffort,
+  useChatRuntimeStore,
+} from "../stores/chat-runtime-store";
+
+/** Publish a cached probe result to the runtime store and return whether the
+ * model actually supports reasoning. */
+function applyReasoningCapsToStore(
+  providerType: string,
+  modelId: string,
+  isReasoningProvider?: boolean,
+  baseUrl?: string | null,
+): boolean {
+  const caps = getExternalReasoningCapabilities(providerType, modelId, {
+    isReasoningProvider,
+    baseUrl: baseUrl ?? null,
+  });
+  const state = useChatRuntimeStore.getState();
+  const levels = caps.reasoningEffortLevels;
+  const clamped = clampReasoningEffortToLevels(state.reasoningEffort, levels);
+  const nextEffort: ReasoningEffort = caps.supportsReasoning
+    ? levels.includes("medium")
+      ? "medium"
+      : clamped
+    : state.reasoningEffort;
+  useChatRuntimeStore.setState({
+    supportsReasoning: caps.supportsReasoning,
+    reasoningAlwaysOn: caps.reasoningAlwaysOn,
+    reasoningStyle: caps.reasoningStyle,
+    supportsReasoningOff: caps.supportsReasoningOff,
+    reasoningEffortLevels: levels,
+    reasoningEffort: nextEffort,
+    reasoningEnabled: caps.supportsReasoning ? true : state.reasoningEnabled,
+  });
+  return caps.supportsReasoning;
+}
+
+/**
+ * One-shot "Detect reasoning" affordance for a connected llama.cpp model whose
+ * reasoning controls haven't been probed yet.
+ *
+ * llama.cpp reports a model's Jinja chat template only once it is (lazily)
+ * loaded, so probing the whole catalog at list time would force-load every
+ * model. This probes exactly the selected model on an explicit click, caches
+ * the result, and publishes the reasoning caps to the runtime store so the
+ * composer's Think control appears in place of this button.
+ */
+export function DetectReasoningButton({
+  providerType,
+  providerId,
+  modelId,
+  baseUrl,
+  isReasoningProvider,
+}: {
+  providerType: string;
+  providerId?: string;
+  modelId: string;
+  baseUrl?: string | null;
+  isReasoningProvider?: boolean;
+}) {
+  const [detecting, setDetecting] = useState(false);
+
+  // Only llama.cpp exposes a probeable Jinja template, and only an uncached
+  // model needs detection (a probed negative is cached as
+  // `supports_reasoning: false`, so it never shows the button again).
+  if (providerType !== "llama_cpp") {
+    return null;
+  }
+  if (
+    getProviderModelReasoningCapabilities(providerType, modelId) !== undefined
+  ) {
+    return null;
+  }
+
+  async function detect() {
+    setDetecting(true);
+    try {
+      const reasoning = await fetchProviderModelReasoning({
+        providerType,
+        providerId: providerId ?? null,
+        apiKey: "",
+        baseUrl: baseUrl ?? null,
+        modelId,
+      });
+      setProviderModelReasoningCapabilities(providerType, modelId, reasoning);
+      if (reasoning) {
+        const supports = applyReasoningCapsToStore(
+          providerType,
+          modelId,
+          isReasoningProvider,
+          baseUrl,
+        );
+        if (!supports) {
+          toast.info("This model doesn't expose reasoning controls.");
+        }
+      } else {
+        toast.error("Couldn't read this model's chat template.");
+      }
+    } catch {
+      toast.error("Couldn't detect reasoning controls.");
+    } finally {
+      setDetecting(false);
+    }
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={detect}
+      disabled={detecting}
+      className="unsloth-thinking-pill"
+      data-pill-label="Detect reasoning"
+      aria-label="Detect reasoning capabilities"
+    >
+      {detecting ? (
+        <Spinner className="size-[15.5px]" />
+      ) : (
+        <BulbIcon className="size-[15.5px]" />
+      )}
+      <span className="unsloth-thinking-label">Detect reasoning</span>
+    </button>
+  );
+}

--- a/studio/frontend/src/features/chat/external-providers.ts
+++ b/studio/frontend/src/features/chat/external-providers.ts
@@ -4,6 +4,8 @@
 import type {
   ProviderAuthKind,
   ProviderAuthStatus,
+  ProviderModelInfo,
+  ProviderModelReasoning,
 } from "./api/providers-api";
 
 export interface ExternalProviderConfig {
@@ -209,6 +211,89 @@ export function pruneProviderModelCapabilities(knownProviderTypes: Iterable<stri
     }
   }
   if (removed) persistProviderModelCapabilities();
+}
+
+// Per-connection-model reasoning capabilities, probed from the server's chat
+// template by the backend (llama.cpp /props). Mirrors REGISTRY_MODEL_CAPABILITIES
+// above: localStorage-backed so a probed control survives a reload without
+// re-fetching the model catalog, keyed by provider type + model id so
+// `getExternalReasoningCapabilities` can consult it without reaching for the
+// providers store.
+const PROBED_MODEL_REASONING_KEY = "unsloth_chat_provider_model_reasoning";
+const PROBED_MODEL_REASONING = new Map<
+  string,
+  Record<string, ProviderModelReasoning>
+>();
+let probedModelReasoningHydrated = false;
+
+function hydrateProbedModelReasoning(): void {
+  if (probedModelReasoningHydrated) return;
+  probedModelReasoningHydrated = true;
+  if (!canUseStorage()) return;
+  try {
+    const parsed = JSON.parse(
+      localStorage.getItem(PROBED_MODEL_REASONING_KEY) ?? "{}",
+    ) as Record<string, Record<string, ProviderModelReasoning>>;
+    for (const [providerType, capabilities] of Object.entries(parsed)) {
+      if (capabilities && typeof capabilities === "object") {
+        PROBED_MODEL_REASONING.set(providerType, capabilities);
+      }
+    }
+  } catch {
+    // Ignore invalid browser state; the next catalog fetch repopulates it.
+  }
+}
+
+function persistProbedModelReasoning(): void {
+  if (!canUseStorage()) return;
+  try {
+    localStorage.setItem(
+      PROBED_MODEL_REASONING_KEY,
+      JSON.stringify(Object.fromEntries(PROBED_MODEL_REASONING)),
+    );
+  } catch {
+    // Ignore storage failures; capabilities remain valid for this session.
+  }
+}
+
+/** Record the reasoning capabilities the backend probed for a model catalog.
+
+ * Entries without a `reasoning` payload are dropped, so re-fetching the catalog
+ * converges the map on the server's current truth rather than accumulating
+ * stale model ids. */
+export function setProviderModelReasoningCapabilities(
+  providerType: string,
+  models: readonly ProviderModelInfo[],
+): void {
+  hydrateProbedModelReasoning();
+  const normalized = providerType.trim().toLowerCase();
+  const next: Record<string, ProviderModelReasoning> = {};
+  for (const model of models) {
+    // Model ids are matched case-insensitively throughout the capability
+    // tables, so store the probe key in the same normalized form the getter
+    // (and `getExternalReasoningCapabilities`) looks up.
+    const id = model.id?.trim().toLowerCase();
+    if (id && model.reasoning) {
+      next[id] = model.reasoning;
+    }
+  }
+  if (Object.keys(next).length > 0) {
+    PROBED_MODEL_REASONING.set(normalized, next);
+  } else {
+    PROBED_MODEL_REASONING.delete(normalized);
+  }
+  persistProbedModelReasoning();
+}
+
+export function getProviderModelReasoningCapabilities(
+  providerType: string | null | undefined,
+  modelId: string | null | undefined,
+): ProviderModelReasoning | undefined {
+  if (!providerType || !modelId) return undefined;
+  hydrateProbedModelReasoning();
+  return PROBED_MODEL_REASONING.get(providerType.trim().toLowerCase())?.[
+    modelId.trim().toLowerCase()
+  ];
 }
 
 

--- a/studio/frontend/src/features/chat/external-providers.ts
+++ b/studio/frontend/src/features/chat/external-providers.ts
@@ -4,7 +4,6 @@
 import type {
   ProviderAuthKind,
   ProviderAuthStatus,
-  ProviderModelInfo,
   ProviderModelReasoning,
 } from "./api/providers-api";
 
@@ -256,26 +255,30 @@ function persistProbedModelReasoning(): void {
   }
 }
 
-/** Record the reasoning capabilities the backend probed for a model catalog.
+/** Record the reasoning capabilities the backend probed for one connected model.
 
- * Entries without a `reasoning` payload are dropped, so re-fetching the catalog
- * converges the map on the server's current truth rather than accumulating
- * stale model ids. */
+ * Called after an explicit "Detect reasoning" action. ``reasoning`` is the
+ * classifier output (which may carry ``supports_reasoning: false`` for a
+ * non-reasoning template, so that a probed negative is also cached and not
+ * re-probed); ``null`` removes any cached entry so a failed probe can be retried. */
 export function setProviderModelReasoningCapabilities(
   providerType: string,
-  models: readonly ProviderModelInfo[],
+  modelId: string,
+  reasoning: ProviderModelReasoning | null,
 ): void {
   hydrateProbedModelReasoning();
   const normalized = providerType.trim().toLowerCase();
-  const next: Record<string, ProviderModelReasoning> = {};
-  for (const model of models) {
-    // Model ids are matched case-insensitively throughout the capability
-    // tables, so store the probe key in the same normalized form the getter
-    // (and `getExternalReasoningCapabilities`) looks up.
-    const id = model.id?.trim().toLowerCase();
-    if (id && model.reasoning) {
-      next[id] = model.reasoning;
-    }
+  // Model ids are matched case-insensitively throughout the capability tables,
+  // so store the probe key in the same normalized form the getter (and
+  // `getExternalReasoningCapabilities`) looks up.
+  const id = modelId.trim().toLowerCase();
+  const next: Record<string, ProviderModelReasoning> = {
+    ...(PROBED_MODEL_REASONING.get(normalized) ?? {}),
+  };
+  if (reasoning) {
+    next[id] = reasoning;
+  } else {
+    delete next[id];
   }
   if (Object.keys(next).length > 0) {
     PROBED_MODEL_REASONING.set(normalized, next);

--- a/studio/frontend/src/features/chat/provider-capabilities.ts
+++ b/studio/frontend/src/features/chat/provider-capabilities.ts
@@ -2,9 +2,11 @@
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
 import {
+  getProviderModelReasoningCapabilities,
   normalizeProviderMaxOutputTokens,
   providerModelSupportsStudioTools,
 } from "./external-providers";
+import type { ProviderModelReasoning } from "./api/providers-api";
 
 /**
  * Per-provider sampling parameter capability matrix.
@@ -1002,6 +1004,30 @@ function resolveConnectionLevelReasoning(
   return null;
 }
 
+/** Map a backend-probed reasoning payload onto the external capability shape.
+
+ * Derives `supportsReasoningOff` the same way the local load path does
+ * (`reasoningCapsFromLoad`): only the pure `reasoning_effort` style (gpt-oss /
+ * Harmony) is always-on, while `enable_thinking` and `enable_thinking_effort`
+ * both carry an off switch. */
+function reasoningCapsFromProbe(
+  probe: ProviderModelReasoning,
+): ExternalReasoningCapabilities {
+  const style = probe.reasoning_style;
+  const levels = (
+    probe.reasoning_effort_levels && probe.reasoning_effort_levels.length > 0
+      ? probe.reasoning_effort_levels
+      : DEFAULT_EFFORT_LEVELS
+  ) as ExternalReasoningCapabilities["reasoningEffortLevels"];
+  return {
+    supportsReasoning: probe.supports_reasoning,
+    reasoningStyle: style,
+    reasoningAlwaysOn: probe.reasoning_always_on,
+    supportsReasoningOff: style !== "reasoning_effort",
+    reasoningEffortLevels: levels,
+  };
+}
+
 /**
  * Resolve external-model thinking capabilities. Provider-specific matching lives
  * in the per-provider resolvers; others default to no reasoning controls.
@@ -1022,6 +1048,19 @@ export function getExternalReasoningCapabilities(
   }
   if (!normalizedModel) {
     return withEnableThinkingStyle();
+  }
+
+  // Backend-probed capabilities win over the hardcoded tables: the server's
+  // chat template is the ground truth for self-hosted connections (llama.cpp),
+  // and the tables below only ever describe hosted providers whose templates
+  // are not exposed. Only llama.cpp ever carries a probed entry, so this cannot
+  // shadow the OpenAI/Anthropic/Gemini ladders.
+  const probed = getProviderModelReasoningCapabilities(
+    normalizedProvider,
+    normalizedModel,
+  );
+  if (probed) {
+    return reasoningCapsFromProbe(probed);
   }
 
   // Some OpenRouter-routed ids are mandatory-reasoning and must stay on even

--- a/studio/frontend/src/features/chat/shared-composer.tsx
+++ b/studio/frontend/src/features/chat/shared-composer.tsx
@@ -124,6 +124,7 @@ import {
   providerModelSupportsStudioTools,
 } from "./external-providers";
 import { compareModelDisplayName } from "./lib/external-model-label";
+import { DetectReasoningButton } from "./components/detect-reasoning-button";
 import { useExternalProvidersStore } from "./stores/external-providers-store";
 import { useComposerPillFit } from "@/hooks/use-composer-pill-fit";
 import { useIsMobile } from "@/hooks/use-mobile";
@@ -2673,7 +2674,17 @@ export function SharedComposer({
                 ) : null}
               </button>
             )
-          ) : null}
+          ) : (
+            <DetectReasoningButton
+              providerType={selectedExternalProvider?.providerType ?? ""}
+              providerId={selectedExternalProvider?.id}
+              modelId={effectiveExternalModelId ?? ""}
+              baseUrl={selectedExternalProvider?.baseUrl ?? null}
+              isReasoningProvider={
+                selectedExternalProvider?.isReasoningModel === true
+              }
+            />
+          )}
           {
             <>
               {!isDictating ? (

--- a/studio/frontend/tests/provider-model-reasoning-probe.test.ts
+++ b/studio/frontend/tests/provider-model-reasoning-probe.test.ts
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { registerBundlerResolver } from "./helpers/kit.ts";
+
+registerBundlerResolver();
+
+const { getExternalReasoningCapabilities } = await import(
+  "../src/features/chat/provider-capabilities.ts"
+);
+
+const { setProviderModelReasoningCapabilities } = await import(
+  "../src/features/chat/external-providers.ts"
+);
+
+// Reasoning capabilities for self-hosted connections are probed from the server's
+// Jinja chat template by the backend and must win over the hardcoded provider
+// tables, so a Qwen3.8 served by llama.cpp surfaces the same effort ladder the
+// local GGUF path derives.
+
+test("backend-probed enable_thinking_effort ladder wins for llama.cpp", () => {
+  setProviderModelReasoningCapabilities("llama_cpp", [
+    {
+      // Server-reported case; the getter matches case-insensitively.
+      id: "Qwen3.8-14B",
+      display_name: "Qwen3.8-14B",
+      reasoning: {
+        supports_reasoning: true,
+        reasoning_style: "enable_thinking_effort",
+        reasoning_effort_levels: ["low", "medium", "xhigh"],
+        reasoning_always_on: false,
+      },
+    },
+  ]);
+
+  const caps = getExternalReasoningCapabilities("llama_cpp", "qwen3.8-14b");
+  assert.equal(caps.supportsReasoning, true);
+  assert.equal(caps.reasoningStyle, "enable_thinking_effort");
+  assert.equal(caps.supportsReasoningOff, true);
+  assert.deepEqual([...caps.reasoningEffortLevels], ["low", "medium", "xhigh"]);
+});
+
+test("probed reasoning_effort style has no off switch", () => {
+  setProviderModelReasoningCapabilities("llama_cpp", [
+    {
+      id: "gpt-oss-20b",
+      display_name: "gpt-oss-20b",
+      reasoning: {
+        supports_reasoning: true,
+        reasoning_style: "reasoning_effort",
+        reasoning_effort_levels: ["low", "medium", "high"],
+        reasoning_always_on: false,
+      },
+    },
+  ]);
+
+  const caps = getExternalReasoningCapabilities("llama_cpp", "gpt-oss-20b");
+  assert.equal(caps.supportsReasoning, true);
+  assert.equal(caps.supportsReasoningOff, false);
+  assert.deepEqual([...caps.reasoningEffortLevels], ["low", "medium", "high"]);
+});
+
+test("an unprobed self-hosted model keeps today's no-reasoning fallback", () => {
+  setProviderModelReasoningCapabilities("ollama", []);
+
+  const caps = getExternalReasoningCapabilities("ollama", "plain:latest");
+  assert.equal(caps.supportsReasoning, false);
+});
+
+test("hosted provider ladders are not shadowed by the probe map", () => {
+  const caps = getExternalReasoningCapabilities("anthropic", "claude-opus-5");
+  assert.equal(caps.supportsReasoning, true);
+  assert.deepEqual(
+    [...caps.reasoningEffortLevels],
+    ["none", "low", "medium", "high", "xhigh", "max"],
+  );
+});

--- a/studio/frontend/tests/provider-model-reasoning-probe.test.ts
+++ b/studio/frontend/tests/provider-model-reasoning-probe.test.ts
@@ -12,30 +12,25 @@ const { getExternalReasoningCapabilities } = await import(
   "../src/features/chat/provider-capabilities.ts"
 );
 
-const { setProviderModelReasoningCapabilities } = await import(
-  "../src/features/chat/external-providers.ts"
-);
+const {
+  getProviderModelReasoningCapabilities,
+  setProviderModelReasoningCapabilities,
+} = await import("../src/features/chat/external-providers.ts");
 
-// Reasoning capabilities for self-hosted connections are probed from the server's
-// Jinja chat template by the backend and must win over the hardcoded provider
-// tables, so a Qwen3.8 served by llama.cpp surfaces the same effort ladder the
-// local GGUF path derives.
+// Reasoning capabilities for connected llama.cpp models are probed per model on
+// an explicit "Detect reasoning" action and cached. The cached result must win
+// over the hardcoded provider tables, so a Qwen3.8 served by llama.cpp surfaces
+// the same effort ladder the local GGUF path derives.
 
 test("backend-probed enable_thinking_effort ladder wins for llama.cpp", () => {
-  setProviderModelReasoningCapabilities("llama_cpp", [
-    {
-      // Server-reported case; the getter matches case-insensitively.
-      id: "Qwen3.8-14B",
-      display_name: "Qwen3.8-14B",
-      reasoning: {
-        supports_reasoning: true,
-        reasoning_style: "enable_thinking_effort",
-        reasoning_effort_levels: ["low", "medium", "xhigh"],
-        reasoning_always_on: false,
-      },
-    },
-  ]);
+  setProviderModelReasoningCapabilities("llama_cpp", "Qwen3.8-14B", {
+    supports_reasoning: true,
+    reasoning_style: "enable_thinking_effort",
+    reasoning_effort_levels: ["low", "medium", "xhigh"],
+    reasoning_always_on: false,
+  });
 
+  // The getter matches case-insensitively.
   const caps = getExternalReasoningCapabilities("llama_cpp", "qwen3.8-14b");
   assert.equal(caps.supportsReasoning, true);
   assert.equal(caps.reasoningStyle, "enable_thinking_effort");
@@ -44,18 +39,12 @@ test("backend-probed enable_thinking_effort ladder wins for llama.cpp", () => {
 });
 
 test("probed reasoning_effort style has no off switch", () => {
-  setProviderModelReasoningCapabilities("llama_cpp", [
-    {
-      id: "gpt-oss-20b",
-      display_name: "gpt-oss-20b",
-      reasoning: {
-        supports_reasoning: true,
-        reasoning_style: "reasoning_effort",
-        reasoning_effort_levels: ["low", "medium", "high"],
-        reasoning_always_on: false,
-      },
-    },
-  ]);
+  setProviderModelReasoningCapabilities("llama_cpp", "gpt-oss-20b", {
+    supports_reasoning: true,
+    reasoning_style: "reasoning_effort",
+    reasoning_effort_levels: ["low", "medium", "high"],
+    reasoning_always_on: false,
+  });
 
   const caps = getExternalReasoningCapabilities("llama_cpp", "gpt-oss-20b");
   assert.equal(caps.supportsReasoning, true);
@@ -63,10 +52,29 @@ test("probed reasoning_effort style has no off switch", () => {
   assert.deepEqual([...caps.reasoningEffortLevels], ["low", "medium", "high"]);
 });
 
-test("an unprobed self-hosted model keeps today's no-reasoning fallback", () => {
-  setProviderModelReasoningCapabilities("ollama", []);
+test("a probed non-reasoning model is cached as unsupported", () => {
+  setProviderModelReasoningCapabilities("llama_cpp", "plain-model", {
+    supports_reasoning: false,
+    reasoning_style: "enable_thinking",
+    reasoning_effort_levels: [],
+    reasoning_always_on: false,
+  });
 
-  const caps = getExternalReasoningCapabilities("ollama", "plain:latest");
+  assert.ok(
+    getProviderModelReasoningCapabilities("llama_cpp", "plain-model"),
+  );
+  const caps = getExternalReasoningCapabilities("llama_cpp", "plain-model");
+  assert.equal(caps.supportsReasoning, false);
+});
+
+test("clearing a cached entry falls back to no reasoning", () => {
+  setProviderModelReasoningCapabilities("llama_cpp", "qwen3.8-14b", null);
+
+  assert.equal(
+    getProviderModelReasoningCapabilities("llama_cpp", "qwen3.8-14b"),
+    undefined,
+  );
+  const caps = getExternalReasoningCapabilities("llama_cpp", "qwen3.8-14b");
   assert.equal(caps.supportsReasoning, false);
 });
 


### PR DESCRIPTION
Depends on https://github.com/unslothai/unsloth/pull/9661 (Studio: probe + forward reasoning_effort for connected llama.cpp servers).

Follow-up that replaces the catalog-time reasoning probe with an explicit,
on-demand probe. In llama.cpp router mode (--models-dir / --models-preset),
`/props?model=<id>` lazy-loads the model, so probing every model during
"Reload models" force-loaded the whole catalog. This probes exactly the model
the user selects, on an explicit action.

- Backend: drop the per-model `reasoning` field from `/models`; add
  `POST /api/providers/model-reasoning` (single-model probe → `ProviderModelReasoning | null`).
- Frontend: a "Detect reasoning" chip in the composer Think area
  (shared-composer + thread) that probes and caches on click, then reveals the
  effort ladder.

Tests: backend on-demand endpoint + listing-does-not-probe; frontend
single-model cache and probed-negative handling.