### PR TITLE
Studio: scope two :has() rules to direct children so they stop walking the whole thread

### DIFF
--- a/studio/frontend/src/components/ui/sidebar.tsx
+++ b/studio/frontend/src/components/ui/sidebar.tsx
@@ -207,9 +207,23 @@ function SidebarProvider({
           //
           // This wrapper is an ancestor of the chat thread, as the note on
           // --sidebar-width above already says. A `:has()` whose argument is a
-          // DESCENDANT selector has to be re-evaluated whenever anything is
+          // DESCENDANT selector has to be re-checked whenever anything is
           // inserted or removed anywhere in the subject's subtree, and
-          // re-evaluating it on an ancestor of the thread restyles the thread.
+          // answering it means WALKING that subtree. On an ancestor of the
+          // thread that walk is the whole thread, on every mutation.
+          //
+          // It is a traversal, NOT a restyle, and the difference matters
+          // because it is why containment does not help. Blink's own
+          // `UpdateLayoutTree.elementCount` for one inserted span is 1 with
+          // these rules in their child form, 2 with one of them in descendant
+          // form and 3 with both: only the subjects are restyled, never the
+          // thread. So there is no scope for `contain:` to reduce, which is
+          // what the note in index.css near `content-visibility: visible` was
+          // seeing when it recorded containment on the message roots as no
+          // help. `content-visibility: auto` on the message roots does not
+          // help either, measured at -7%: the argument re-check walks skipped
+          // content too.
+          //
           // Measured at the 500K rung, corpus 23cd2464, on a 357,843-element
           // thread: appending one EMPTY span inside a message cost 17.5 and
           // 18.6 ms in two concurrent arms with this rule in place, 8.7 ms with
@@ -217,6 +231,15 @@ function SidebarProvider({
           // chat-page.tsx deleted. Deleting the other eleven `:has()` rules
           // that survived the bisect changed nothing (17.2 / 19.2 ms), and the
           // same span appended to <body> costs 0.10 ms either way.
+          //
+          // CHROMIUM ONLY. On a synthetic thread carrying this same ancestor
+          // chain and the built Studio stylesheet, at 300,464 elements, one
+          // inserted span costs 1.20 ms plain / 1.29 ms child / 5.63 ms one
+          // descendant rule / 10.30 ms both in Chromium, and 4.33 / 4.58 /
+          // 4.58 / 4.33 ms in WebKitGTK and 4.65 / 4.72 / 4.45 / 5.10 ms in
+          // Firefox: flat in both, within noise of each other. So this change
+          // is free where it does not help and it does not regress the engine
+          // Studio uses on Linux.
           //
           // The child combinator is not a weakening. `data-variant` is rendered
           // on the root element of `Sidebar` below, and `Sidebar` is a direct

--- a/studio/frontend/src/components/ui/sidebar.tsx
+++ b/studio/frontend/src/components/ui/sidebar.tsx
@@ -203,7 +203,28 @@ function SidebarProvider({
           } as React.CSSProperties
         }
         className={cn(
-          "group/sidebar-wrapper has-data-[variant=inset]:bg-sidebar flex min-h-svh w-full",
+          // `has-[>...]`, not `has-[...]`, and the combinator is the whole point.
+          //
+          // This wrapper is an ancestor of the chat thread, as the note on
+          // --sidebar-width above already says. A `:has()` whose argument is a
+          // DESCENDANT selector has to be re-evaluated whenever anything is
+          // inserted or removed anywhere in the subject's subtree, and
+          // re-evaluating it on an ancestor of the thread restyles the thread.
+          // Measured at the 500K rung, corpus 23cd2464, on a 357,843-element
+          // thread: appending one EMPTY span inside a message cost 17.5 and
+          // 18.6 ms in two concurrent arms with this rule in place, 8.7 ms with
+          // this rule alone deleted, and 0.10 ms with this rule and the one on
+          // chat-page.tsx deleted. Deleting the other eleven `:has()` rules
+          // that survived the bisect changed nothing (17.2 / 19.2 ms), and the
+          // same span appended to <body> costs 0.10 ms either way.
+          //
+          // The child combinator is not a weakening. `data-variant` is rendered
+          // on the root element of `Sidebar` below, and `Sidebar` is a direct
+          // child of this wrapper (AppSidebar returns it inside a Fragment,
+          // which is not a DOM node), so the two selectors match the same
+          // elements. What changes is that a mutation deep in the thread can no
+          // longer make Blink ask this question again.
+          "group/sidebar-wrapper has-[>[data-variant=inset]]:bg-sidebar flex min-h-svh w-full",
           className
         )}
         {...props}

--- a/studio/frontend/src/features/chat/chat-page.tsx
+++ b/studio/frontend/src/features/chat/chat-page.tsx
@@ -3670,10 +3670,18 @@ export function ChatPage({
 
           `has-[>...]`, not `has-[...]`. This element is an ancestor of every
           message in the thread, and a `:has()` with a DESCENDANT argument must
-          be re-evaluated whenever anything is inserted or removed anywhere in
-          its subtree. Re-evaluating it here restyles the whole thread, and this
-          one also declares an inheriting custom property, which is the same
-          shape PR #9328 fixed for --aui-scroll-stabilizer.
+          be re-checked whenever anything is inserted or removed anywhere in its
+          subtree. Answering it means walking that subtree, so here it walks the
+          whole thread on every mutation.
+
+          It is a traversal and not a restyle: Blink's own
+          `UpdateLayoutTree.elementCount` for one inserted span is 1 once both
+          this rule and the sidebar wrapper's are in their child form, 2 with
+          one of them still in descendant form and 3 with both, i.e. only the
+          subjects are ever restyled. That is why containment cannot help and
+          why the inheriting custom property this rule declares is not the
+          carrier either: the same rule declaring a non-inherited `background`
+          costs the same. Related to #9328 by family, not by mechanism.
 
           Measured at the 500K rung, corpus 23cd2464, on a 357,843-element
           thread, as the cost of appending one EMPTY span inside a message: 17.5
@@ -3681,7 +3689,9 @@ export function ChatPage({
           9.3 ms with this rule alone deleted, and 0.10 ms with this rule and
           the one on the sidebar wrapper both deleted. The same span appended to
           <body> costs 0.10 ms either way, so the cost is the thread being under
-          the subject and nothing else.
+          the subject and nothing else. Chromium only: WebKitGTK and Firefox are
+          flat across all four selector forms, so this neither helps nor hurts
+          the engine Studio uses on Linux.
 
           ChatModelNotice renders a direct child of this element (see below), so
           the child combinator matches exactly what the descendant form matched.

--- a/studio/frontend/src/features/chat/chat-page.tsx
+++ b/studio/frontend/src/features/chat/chat-page.tsx
@@ -3666,8 +3666,29 @@ export function ChatPage({
       {/* `--studio-chat-notice-height` is 0 until ChatModelNotice is on screen; the
           thread viewport adds it to the top padding it reserves for the header, so
           without it the first message reads under an opaque bar. Declared on the
-          nearest ancestor of BOTH so the two cannot disagree about its height. */}
-      <div className="relative flex min-h-0 min-w-0 flex-1 basis-0 flex-col overflow-hidden has-[[data-chat-model-notice]]:[--studio-chat-notice-height:2.25rem]">
+          nearest ancestor of BOTH so the two cannot disagree about its height.
+
+          `has-[>...]`, not `has-[...]`. This element is an ancestor of every
+          message in the thread, and a `:has()` with a DESCENDANT argument must
+          be re-evaluated whenever anything is inserted or removed anywhere in
+          its subtree. Re-evaluating it here restyles the whole thread, and this
+          one also declares an inheriting custom property, which is the same
+          shape PR #9328 fixed for --aui-scroll-stabilizer.
+
+          Measured at the 500K rung, corpus 23cd2464, on a 357,843-element
+          thread, as the cost of appending one EMPTY span inside a message: 17.5
+          and 18.6 ms in two concurrent arms with this rule as it was, 9.8 and
+          9.3 ms with this rule alone deleted, and 0.10 ms with this rule and
+          the one on the sidebar wrapper both deleted. The same span appended to
+          <body> costs 0.10 ms either way, so the cost is the thread being under
+          the subject and nothing else.
+
+          ChatModelNotice renders a direct child of this element (see below), so
+          the child combinator matches exactly what the descendant form matched.
+          If it is ever moved deeper, the notice's height stops being reserved
+          and the first message reads under the bar again, which is why
+          `tests/thread-ancestor-has-scope.test.ts` asserts the depth. */}
+      <div className="relative flex min-h-0 min-w-0 flex-1 basis-0 flex-col overflow-hidden has-[>[data-chat-model-notice]]:[--studio-chat-notice-height:2.25rem]">
         <NativeModelDropOverlay state={nativeModelDropState} />
         {/* Fade under the top bar so messages dissolve as they scroll
             beneath it, instead of a hard cut. */}

--- a/studio/frontend/tests/chat-remembers-its-model.test.ts
+++ b/studio/frontend/tests/chat-remembers-its-model.test.ts
@@ -145,9 +145,17 @@ test("the conversation reserves the space the notice overlay takes", () => {
 
   // One declaration of the height, on the nearest ancestor of both, so the bar and
   // the padding cannot drift apart.
+  //
+  // `has-[>...]`, not `has-[...]`: the descendant form made every DOM change anywhere in the
+  // thread re-evaluate this `:has()` on an ancestor of every message, which restyles the whole
+  // thread. Measured at the 500K rung on a 357,843-element thread, appending one empty span
+  // inside a message cost 17.5 / 18.6 ms with the descendant form and 0.10 ms once this rule and
+  // the sidebar wrapper's were both put in their child form. The notice is a direct child of the
+  // declaring element, so the two selectors match the same elements; that is asserted separately
+  // in `tests/thread-ancestor-has-scope.test.ts`, which is what keeps the child form honest.
   assert.match(
     page,
-    /has-\[\[data-chat-model-notice\]\]:\[--studio-chat-notice-height:2\.25rem\]/,
+    /has-\[>\[data-chat-model-notice\]\]:\[--studio-chat-notice-height:2\.25rem\]/,
   );
   // The notice claims the same variable rather than a padding of its own.
   assert.match(notice, /data-chat-model-notice=""/);

--- a/studio/frontend/tests/chat-remembers-its-model.test.ts
+++ b/studio/frontend/tests/chat-remembers-its-model.test.ts
@@ -147,8 +147,8 @@ test("the conversation reserves the space the notice overlay takes", () => {
   // the padding cannot drift apart.
   //
   // `has-[>...]`, not `has-[...]`: the descendant form made every DOM change anywhere in the
-  // thread re-evaluate this `:has()` on an ancestor of every message, which restyles the whole
-  // thread. Measured at the 500K rung on a 357,843-element thread, appending one empty span
+  // thread re-check this `:has()` on an ancestor of every message, and answering it walks the
+  // whole thread. Measured at the 500K rung on a 357,843-element thread, appending one empty span
   // inside a message cost 17.5 / 18.6 ms with the descendant form and 0.10 ms once this rule and
   // the sidebar wrapper's were both put in their child form. The notice is a direct child of the
   // declaring element, so the two selectors match the same elements; that is asserted separately

--- a/studio/frontend/tests/thread-ancestor-has-scope.test.ts
+++ b/studio/frontend/tests/thread-ancestor-has-scope.test.ts
@@ -4,10 +4,24 @@
 /*
  * NO DESCENDANT-ARGUMENT `:has()` ON AN ANCESTOR OF THE THREAD.
  *
- * A `:has()` whose argument is a descendant selector has to be re-evaluated whenever anything is
- * inserted or removed anywhere inside the subject. On an ancestor of the chat thread that means
- * every message that mounts, every token that streams and every deferred code fence that upgrades
- * restyles the whole thread.
+ * A `:has()` whose argument is a descendant selector has to be re-checked whenever anything is
+ * inserted or removed anywhere inside the subject, and answering it means WALKING the subject's
+ * subtree. On an ancestor of the chat thread that walk is the whole thread, and it happens for
+ * every message that mounts, every token that streams and every deferred code fence that
+ * upgrades.
+ *
+ * It is a traversal, not a restyle. Blink's `UpdateLayoutTree.elementCount` for one inserted span
+ * is 1 with both rules in their child form, 2 with one still in descendant form and 3 with both:
+ * only the subjects are restyled. That is why no amount of `contain:` helps, and why
+ * `content-visibility: auto` on the message roots does not either (measured at -7%): the argument
+ * re-check walks skipped content too. The only lever is the combinator.
+ *
+ * CHROMIUM ONLY. On a synthetic thread with the same ancestor chain and the built Studio
+ * stylesheet, at 300,464 elements, one inserted span costs 1.20 / 1.29 / 5.63 / 10.30 ms for
+ * plain / child / one descendant rule / both in Chromium, against 4.33 / 4.58 / 4.58 / 4.33 ms in
+ * WebKitGTK and 4.65 / 4.72 / 4.45 / 5.10 ms in Firefox. The other two engines are flat, so this
+ * is free where it does not help. This test still guards the shape in every engine, because the
+ * regression it prevents is a Chromium one and Studio runs in a browser too.
  *
  * Measured at the 500K rung, corpus 23cd2464, on a 357,843-element thread, as the cost of
  * appending ONE EMPTY span inside a message, in two concurrent arms:

--- a/studio/frontend/tests/thread-ancestor-has-scope.test.ts
+++ b/studio/frontend/tests/thread-ancestor-has-scope.test.ts
@@ -1,0 +1,224 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+/*
+ * NO DESCENDANT-ARGUMENT `:has()` ON AN ANCESTOR OF THE THREAD.
+ *
+ * A `:has()` whose argument is a descendant selector has to be re-evaluated whenever anything is
+ * inserted or removed anywhere inside the subject. On an ancestor of the chat thread that means
+ * every message that mounts, every token that streams and every deferred code fence that upgrades
+ * restyles the whole thread.
+ *
+ * Measured at the 500K rung, corpus 23cd2464, on a 357,843-element thread, as the cost of
+ * appending ONE EMPTY span inside a message, in two concurrent arms:
+ *
+ *   every rule in place                                        17.5 / 18.6 ms
+ *   sidebar wrapper's rule alone deleted                        8.7 /  9.0 ms
+ *   chat wrapper's rule alone deleted                           9.8 /  9.3 ms
+ *   both deleted                                               0.10 / 0.10 ms
+ *   the other eleven `:has()` rules the bisect kept, deleted   17.2 / 19.2 ms
+ *   all 142 `:has()` rules in the bundle deleted               0.10 / 0.10 ms
+ *   the same span appended to <body> instead                   0.10 / 0.10 ms
+ *
+ * So those two rules were the whole cost and no other rule contributed. This test is what stops
+ * a third one being added, because the symptom is a frame rate on a long thread and nothing
+ * about writing `has-[[data-x]]` looks expensive.
+ *
+ * IT IS A SOURCE TEST AND THAT IS A REAL LIMIT. It reads the two elements it knows about. A
+ * `:has()` utility introduced on some other ancestor of the thread would not be caught here, and
+ * the honest guard for that is the perf ladder, not this file.
+ */
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import ts from "typescript";
+
+import { openingTag } from "./helpers/tsx-ast.ts";
+
+const read = (rel: string): string =>
+  readFileSync(fileURLToPath(new URL(rel, import.meta.url)), "utf8");
+
+const parse = (rel: string): ts.SourceFile =>
+  ts.createSourceFile(rel, read(rel), ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+
+/** Every string literal in the file, so a className built by `cn(...)` is covered too. */
+const stringLiterals = (source: ts.SourceFile): string[] => {
+  const out: string[] = [];
+  const walk = (node: ts.Node): void => {
+    if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) {
+      out.push(node.text);
+    }
+    ts.forEachChild(node, walk);
+  };
+  walk(source);
+  return out;
+};
+
+/*
+ * Tailwind's `has-*` variants, and which of them carry a DESCENDANT argument.
+ *
+ *   has-[>[data-x]]        child      cheap: only a change to the subject's own child list can
+ *                                     change the answer, so a mutation deep in the thread is
+ *                                     skipped outright
+ *   has-[[data-x]]         descendant expensive: any insertion or removal in the subtree
+ *   has-data-[variant=v]   descendant expensive: shorthand for has-[[data-variant=v]]
+ *   has-aria-invalid       descendant expensive
+ *   group-has-[...]        descendant expensive, on whichever element carries the `group`
+ *
+ * Matching is done on the class token so that `has-[>...]` is not read as a descendant form by a
+ * looser substring test, which is the one way this check could pass while the defect is present.
+ */
+const descendantHasUtilities = (className: string): string[] =>
+  className
+    .split(/\s+/)
+    .filter((token) => {
+      const variant = token.startsWith("group-has-") ? token.slice("group-".length) : token;
+      if (!variant.startsWith("has-")) return false;
+      if (variant.startsWith("has-[>")) return false;
+      return true;
+    });
+
+test("the sidebar wrapper, an ancestor of the whole app, has no descendant-argument :has()", () => {
+  const source = parse("../src/components/ui/sidebar.tsx");
+  const wrappers = stringLiterals(source).filter((s) => s.includes("group/sidebar-wrapper"));
+  assert.equal(
+    wrappers.length,
+    1,
+    "expected exactly one className carrying group/sidebar-wrapper; if this element was "
+      + "restructured the assertion below is no longer looking at the ancestor of the thread",
+  );
+  assert.deepEqual(
+    descendantHasUtilities(wrappers[0]),
+    [],
+    `sidebar-wrapper className carries a descendant-argument :has(): ${wrappers[0]}`,
+  );
+  // The rule is still THERE, in its child form. Dropping it entirely would also pass the
+  // assertion above and would silently change what an inset sidebar looks like.
+  assert.ok(
+    wrappers[0].includes("has-[>[data-variant=inset]]:bg-sidebar"),
+    `sidebar-wrapper lost the inset background rule: ${wrappers[0]}`,
+  );
+});
+
+test("the chat wrapper that contains the thread has no descendant-argument :has()", () => {
+  const source = parse("../src/features/chat/chat-page.tsx");
+  const wrappers = stringLiterals(source).filter((s) =>
+    s.includes("--studio-chat-notice-height:"),
+  );
+  assert.equal(
+    wrappers.length,
+    1,
+    "expected exactly one className declaring --studio-chat-notice-height",
+  );
+  assert.deepEqual(
+    descendantHasUtilities(wrappers[0]),
+    [],
+    `the chat wrapper carries a descendant-argument :has(): ${wrappers[0]}`,
+  );
+  assert.ok(
+    wrappers[0].includes("has-[>[data-chat-model-notice]]:[--studio-chat-notice-height:2.25rem]"),
+    `the chat wrapper lost the notice-height rule: ${wrappers[0]}`,
+  );
+});
+
+/*
+ * THE CHILD COMBINATOR IS ONLY EQUIVALENT IF THE NOTICE IS A CHILD.
+ *
+ * Without this the previous test is satisfied by a selector that matches nothing, the height is
+ * never reserved, and the first message reads under the opaque header bar. That is a visible
+ * regression with no failing test, which is exactly the shape this file exists to prevent.
+ */
+test("ChatModelNotice renders a DIRECT child of the element declaring the notice height", () => {
+  const source = parse("../src/features/chat/chat-page.tsx");
+
+  const declaringDiv = ((): ts.JsxElement | null => {
+    let found: ts.JsxElement | null = null;
+    const walk = (node: ts.Node): void => {
+      if (found) return;
+      if (ts.isJsxElement(node)) {
+        const tag = node.openingElement;
+        for (const attr of tag.attributes.properties) {
+          if (!ts.isJsxAttribute(attr)) continue;
+          if (attr.name.getText() !== "className") continue;
+          const init = attr.initializer;
+          if (!init || !ts.isStringLiteral(init)) continue;
+          if (init.text.includes("--studio-chat-notice-height:")) {
+            found = node;
+            return;
+          }
+        }
+      }
+      ts.forEachChild(node, walk);
+    };
+    walk(source);
+    return found;
+  })();
+
+  assert.ok(declaringDiv, "could not find the element declaring --studio-chat-notice-height");
+
+  // A JSX expression container is not a DOM node, so `{cond && <ChatModelNotice/>}` still renders
+  // a direct child. Unwrapping one level of `{...}` and of `&&` is therefore correct, and going
+  // deeper than that would start accepting real wrappers.
+  const directChildTagNames = declaringDiv.children.flatMap((child): string[] => {
+    const fromNode = (node: ts.Node): string[] => {
+      const tag = openingTag(node);
+      if (tag) return [tag.tagName.getText()];
+      if (ts.isParenthesizedExpression(node)) return fromNode(node.expression);
+      if (
+        ts.isBinaryExpression(node)
+        && node.operatorToken.kind === ts.SyntaxKind.AmpersandAmpersandToken
+      ) {
+        return fromNode(node.right);
+      }
+      if (ts.isConditionalExpression(node)) {
+        return [...fromNode(node.whenTrue), ...fromNode(node.whenFalse)];
+      }
+      return [];
+    };
+    if (ts.isJsxExpression(child)) {
+      return child.expression ? fromNode(child.expression) : [];
+    }
+    return fromNode(child);
+  });
+
+  assert.ok(
+    directChildTagNames.includes("ChatModelNotice"),
+    "ChatModelNotice is no longer a direct child of the element whose "
+      + "has-[>[data-chat-model-notice]] rule reserves its height, so the height is never "
+      + `reserved. Direct children seen: ${directChildTagNames.join(", ")}`,
+  );
+});
+
+/*
+ * And the notice really is the element the selector names. If `data-chat-model-notice` moved off
+ * the component's root onto something inside it, the child combinator would stop matching while
+ * every assertion above still passed.
+ */
+test("data-chat-model-notice is on the root element ChatModelNotice returns", () => {
+  const source = parse("../src/features/chat/components/chat-model-notice.tsx");
+  let rootHasAttribute = false;
+  const walk = (node: ts.Node): void => {
+    if (rootHasAttribute) return;
+    if (ts.isReturnStatement(node) && node.expression) {
+      let expression: ts.Node = node.expression;
+      while (ts.isParenthesizedExpression(expression)) expression = expression.expression;
+      const tag = openingTag(expression);
+      if (tag) {
+        for (const attr of tag.attributes.properties) {
+          if (!ts.isJsxAttribute(attr)) continue;
+          if (attr.name.getText() === "data-chat-model-notice") rootHasAttribute = true;
+        }
+      }
+    }
+    ts.forEachChild(node, walk);
+  };
+  walk(source);
+  assert.ok(
+    rootHasAttribute,
+    "no return in chat-model-notice.tsx yields a root element carrying "
+      + "data-chat-model-notice, so has-[>[data-chat-model-notice]] cannot match",
+  );
+});

--- a/tests/studio/playwright_chat_ui.py
+++ b/tests/studio/playwright_chat_ui.py
@@ -204,6 +204,57 @@ def exercise_permission_mode_controls(page, shoot):
             pass  # best-effort -- proceed even if network never idles
         expect(pill).to_be_visible(timeout = 30_000)
 
+    # choose() only drives THIS tab. The mirror to /api/chat/settings is a 400ms
+    # trailing-edge debounce (SETTINGS_DEBOUNCE_MS, chat-runtime-store.ts) whose
+    # only early flush is the beforeunload keepalive, so the pill turning over
+    # proves the click landed locally, not that the installation stored it.
+    #
+    # Measured on webkit, timed from the choose() below: choose returns at
+    # t+238ms, set_legacy_confirm at t+248ms, and the reload starts there. The
+    # debounce would not have fired until ~t+630ms, so the only PUT that goes out
+    # at all is the beforeunload keepalive at t+252ms, and the reloaded page's
+    # hydrating GET arrives at t+697ms. The assertion after the reload was
+    # therefore never testing the level this step chose. It was betting that an
+    # unload-time keepalive beats a hydrating GET by 445ms of loopback, on every
+    # engine, every run.
+    #
+    # When that bet loses, hydration returns the level the migration loop above
+    # left on the install ("off"), the pill reads "Run automatically", and the
+    # step fails as though migration were broken. That is what took webkit red at
+    # 20a98fd54 while chromium and firefox passed the same assertion in the same
+    # job.
+    #
+    # So: wait for the level to actually be ON the installation before reloading
+    # and asserting on it. Assert what was achieved, not what was commanded. This
+    # deliberately stops depending on the unload-time flush; that flush is worth a
+    # test of its own, but it was never what this step meant to assert.
+    def expect_server_mode(expected, timeout_ms = 15_000):
+        deadline = time.monotonic() + timeout_ms / 1000.0
+        seen = "<never read>"
+        while True:
+            seen = page.evaluate(
+                """async () => {
+                    const token = localStorage.getItem("unsloth_auth_token");
+                    const res = await fetch("/api/chat/settings", {
+                        headers: token ? { Authorization: "Bearer " + token } : {},
+                        cache: "no-store",
+                    });
+                    if (!res.ok) return "<http " + res.status + ">";
+                    const body = await res.json();
+                    return (body && body.settings && body.settings.permissionMode) ?? null;
+                }"""
+            )
+            if seen == expected:
+                return
+            if time.monotonic() >= deadline:
+                break
+            page.wait_for_timeout(100)
+        fail(
+            f"permission level never reached the installation: /api/chat/settings "
+            f"reports permissionMode={seen!r} after {timeout_ms}ms, expected "
+            f"{expected!r} -- the debounced mirror never landed"
+        )
+
     page.route("**/api/chat/settings", refuse_settings_hydration)
     set_legacy_confirm(None)
     reload_and_wait_for_pill()
@@ -260,6 +311,7 @@ def exercise_permission_mode_controls(page, shoot):
     # rather than its own derivation.
     choose("Ask for approval")
     expect_mode("Ask for approval")
+    expect_server_mode("ask")
     set_legacy_confirm("false")
     reload_and_wait_for_pill()
     expect_mode("Ask for approval")


### PR DESCRIPTION
# Studio: scope two `:has()` rules to direct children so they stop walking the whole thread

Scrolling a long chat in Chromium drops frames, and two CSS selectors are a large part of it.

## The mechanism

A `:has()` whose argument is a **descendant** selector has to be re-checked whenever anything is inserted or removed anywhere inside its subject, and answering it means **walking the subject's subtree**. Two of them sit on ancestors of every message:

| file | selector | what it is on |
|---|---|---|
| `studio/frontend/src/components/ui/sidebar.tsx` | `has-data-[variant=inset]:bg-sidebar` | `[data-slot="sidebar-wrapper"]`, which wraps the whole application |
| `studio/frontend/src/features/chat/chat-page.tsx` | `has-[[data-chat-model-notice]]:[--studio-chat-notice-height:2.25rem]` | the wrapper containing the thread |

So every message that mounts, every token that streams and every deferred code fence that upgrades walks the entire thread, twice.

**It is a traversal, not a restyle.** Blink's own `UpdateLayoutTree.elementCount` for one inserted span is **1** with both rules in their child form, **2** with one still in descendant form and **3** with both. Only the subjects are restyled. The cost is O(subtree) in time and O(1) in restyled elements.

That distinction is load-bearing rather than pedantic, because it explains two results that otherwise look like contradictions:

- **Containment cannot help**, because there is no scope left to reduce. That is exactly what the note in `index.css` near `content-visibility: visible` was recording when it said containment on the message roots was no help.
- **`content-visibility: auto` on the message roots does not help either**, measured at **-7%** on the same insertion: the argument re-check walks skipped content too.

It also retires an angle I first thought was the carrier. The chat wrapper's rule declares an unregistered inheriting custom property, which is the shape of #9328. Measured, the same rule declaring a non-inherited `background` costs the same, so the combinator carries the cost and the property does not. Related by family, not by mechanism.

## Attribution

Local headless Chromium 151, corpus `23cd2464`, r500K, 357,843 elements, two concurrent arms every time. The measured quantity is the cost of appending **one empty `<span>`** inside a message, timed as the forced style and layout flush that follows.

Controls first, because an ablation whose positive control is cheap is not loaded:

| control | requirement | measured |
|---|---|---|
| negative: force the flush with nothing dirtied | must be ~0 | **0.00 ms** |
| positive: write an unregistered inherited custom property on the scroller | must be large | **1,938 ms** |
| positive: insert a `<style>` element, whole-document by construction | must be large | **35 ms** |
| drift: the control again after every probe | must match the first | 17.4 / 19.0 vs 17.5 / 18.6 ms |

A reversible stylesheet bisect, with a delete-and-reinsert arm as its negative control:

| arm | rep A | rep B |
|---|---:|---:|
| every rule in place | 17.5 ms | 18.6 ms |
| all 142 `:has()` rules removed | **0.10** | **0.10** |
| 816 universal-selector rules removed | 18.4 | 17.3 |
| 80 structural-pseudo rules removed | 18.1 | 17.4 |
| delete-and-reinsert a rule matching nothing | 18.0 | 18.4 |

Then per rule, over the eight the bisect kept:

| removed | rep A | rep B |
|---|---:|---:|
| the sidebar wrapper's rule alone | 8.7 | 9.0 |
| the chat wrapper's rule alone | 9.8 | 9.3 |
| **both** | **0.10** | **0.10** |
| the other eleven, together | 17.2 | 19.2 |

For comparison, the same span appended to `<body>` costs **0.10 ms** in every arm, and the cost is linear in thread size above ~25k elements: 7.3 ms at 111,995 elements, 36.7 ms at 357,843, about 30 ns per element per insertion for the pair.

## The fix

Both selectors become their child form, `has-[>...]`. Not a weakening: `data-variant` is on the root element `Sidebar` renders and `data-chat-model-notice` is on the root element `ChatModelNotice` renders, and both are direct children of the elements carrying the rule, so the same elements match. What changes is that a mutation deep in the thread can no longer make the engine ask the question again.

Re-measured on the **built bundles**, not by deleting rules at runtime, same page, same DOM:

| | before | after |
|---|---:|---:|
| empty span inside a message | 21.5 ms | **0.20 ms** |
| shiki-shaped span inside a message | 17.8 ms | **0.30 ms** |
| the same span on `<body>` | 0.10 ms | 0.20 ms |
| positive control, inherited custom property | 1,938 ms | 1,900 ms |
| positive control, `<style>` insert | 35.1 ms | 36.7 ms |
| a class toggled on the scroller itself | 15.8 ms | 17.3 ms |

Both positive controls are unchanged, so the page did not become globally cheaper: one specific traversal was removed. The scroller class toggle is unchanged too, which is correct, since that is a real style change for that element and its descendants.

## Scroll, r500K, Chromium

Four arms per bundle, run concurrently, **ports rotated between waves** so a per-port or launch-order effect cannot masquerade as the arm. Identical DOM in all eight (357,923 elements, 335 code blocks, 247,675 highlight spans) and an identical gesture (632,088 px commanded and **632,088 px travelled**, 704 steps, top reached, no deadline hit).

| bundle | scroll fps | busy | traversal | step p95 | worst frame |
|---|---|---|---|---|---|
| before | 28.2 / 28.2 / 30.9 / 28.2 | 82.2 - 83.9% | 46.7 - 51.3 s | 83 - 100 ms | 217 - 267 ms |
| after | **35.4 / 34.4 / 39.3 / 39.3** | 77.6 - 82.0% | **36.7 - 42.0 s** | **50 - 67 ms** | 183 - 233 ms |

The arms do not overlap: the worst `after` (34.4) beats the best `before` (30.9).

The frame-rate channel is effective rate over wall time, not `1000/p50`. A jammed positive control ran in the same wave: a deliberately blocked main thread read **59.6 to 20.0 fps** on the reported channel while `1000/p50` read 59.9 both jammed and unjammed.

## The limit: this is Chromium only

Stated up front rather than buried, because Studio and Desktop on Linux render through WebKitGTK, not Chromium.

On a synthetic thread carrying Studio's real ancestor chain and its built stylesheet, at 300,464 elements, one inserted span costs, for plain / child / one descendant rule / both:

| engine | plain | child | one descendant | both |
|---|---|---|---|---|
| Chromium | 1.20 | 1.29 | 5.63 | **10.30** ms |
| WebKitGTK | 4.33 | 4.58 | 4.58 | **4.33** ms |
| Firefox | 4.65 | 4.72 | 4.45 | **5.10** ms |

WebKitGTK and Firefox are flat across all four forms. `:has()` support was verified live in each engine first, so "no penalty" cannot be "the rule was dropped".

Confirmed end to end on the real app in real WebKitGTK 2.50.4 at r500K, three arms per bundle, identical gesture at 613,800 px travelled:

| bundle | scroll fps | wall |
|---|---|---|
| before | 14.68 / 14.18 / 14.25 | 95.6 / 98.7 / 98.4 s |
| after | 14.36 / 14.21 / 14.51 | 97.3 / 98.7 / 96.7 s |

The arms overlap completely. So this does nothing for Studio on Linux and Desktop, and it does not regress them either. The Chromium win stands for Studio in a browser. **The WebKitGTK collapse is a different mechanism and is still open.**

## Short context

A hard gate, and it holds. Identical DOM at both rungs.

| rung | before | after |
|---|---|---|
| 0K | 59.4 fps at 1.4% busy | 59.3 fps at 1.5% busy |
| 100K | 57.5 fps at 42.6% busy | 58.0 fps at 37.9% busy |

Separately, three reps per bundle through a dedicated short-context harness, after a jammed positive control resolving at 13.0 fps / 91.3% busy against 58 fps / 39% unjammed: 0K idle, scroll and stream and 100K idle, scroll and stream are all flat or better, every delta inside the base spread except 100K scroll `busy_pct`, which is 39.1 / 39.8 / 38.8 before against 35.3 / 36.1 / 36.3 after.

## UI idempotency

Nothing renders differently. This hides nothing, defers nothing and clips nothing.

An idempotency gate was built for this change, with its positive control built first, and the control changed the design: `DOM.performSearch` walks the DOM tree and cannot see rendering, so under a `content-visibility: hidden` breaker it found **6 of 6** needles that `window.find` could not find at all. The gate uses `window.find`.

Every check is red under at least one deliberate breaker, so none of them is decoration:

| check | none | cv_hidden | cv_auto | cv_auto_cis | cv_auto_fences | latch_never | print_never | contain_paint_clip |
|---|---|---|---|---|---|---|---|---|
| find | PASS | **FAIL** | PASS | PASS | PASS | PASS | PASS | PASS |
| select_all | PASS | **FAIL** | PASS | PASS | PASS | PASS | PASS | PASS |
| copy | PASS | **FAIL** | PASS | PASS | PASS | PASS | PASS | PASS |
| latch | PASS | **FAIL** | PASS | PASS | PASS | **FAIL** | PASS | PASS |
| geometry | PASS | PASS | **FAIL** | **FAIL** | PASS | PASS | PASS | **FAIL** |
| print | PASS | PASS | PASS | PASS | PASS | PASS | **FAIL** | PASS |

Base against this branch at r100K, every quantity **bit-identical**, checksums included: elements 22,247; fences 56; deferred at mount 53; spans at mount 2,458; fence-body checksum 4708751141648480; viewport scrollHeight 56,455 before and 56,547 after a full traversal; find 6/6; selected non-space 166,818 with checksum 1195575140194632; clipboard 189,318 chars / 166,818 non-space / same checksum; commanded and travelled 111,202; deferred after traversal 0; print 53 to 0 with spans 2,458 to 41,410 on both doors.

Selector equivalence measured by putting the attribute on the DOM and reading what the engine computes on every ancestor of the thread viewport: before, nine ancestors respond with `2.25rem` as direct child **and** as grandchild; after, exactly one does, and only as a direct child. The shape `ChatPage` actually renders gives `2.25rem` in both and puts the first message at **84 px** in both, against 48 px with no notice, so exactly 36 px is reserved either way. Sidebar wrapper background is `rgba(0, 0, 0, 0)` in both; forced onto the direct child it is `rgb(255, 255, 255)` in both; forced onto a grandchild it is white before and transparent after, which is the intended narrowing and is unreachable today because `variant="inset"` is not used anywhere in Studio.

## The guard

`studio/frontend/tests/thread-ancestor-has-scope.test.ts`. It asserts both selectors keep their child form, that each rule is still present rather than merely deleted, and, because a child combinator is only equivalent while the target really is a child, that `ChatModelNotice` renders a **direct** child of the declaring element and that `data-chat-model-notice` is on the component's root. Each of the four checks was confirmed to fail on its own deliberate breaker, and the files were restored from md5-verified byte snapshots afterwards.

`tests/chat-remembers-its-model.test.ts` pinned the old selector and is updated to pin the new one, keeping its original intent: one declaration of the height, on the nearest ancestor of both the bar and the padding.

All 4,816 frontend tests pass, and `typecheck` is clean.
