### PR TITLE
Map Qwen3.8-27B to the unsloth repos

### DIFF
--- a/unsloth/models/mapper.py
+++ b/unsloth/models/mapper.py
@@ -1389,6 +1389,7 @@ __INT_TO_FLOAT_MAPPER = \
     "unsloth/Qwen3.8-27B-unsloth-bnb-4bit" : (
         "unsloth/Qwen3.8-27B",
         "Qwen/Qwen3.8-27B",
+        "unsloth/Qwen3.8-27B-unsloth-bnb-4bit",
     ),
 }
 

--- a/unsloth/models/mapper.py
+++ b/unsloth/models/mapper.py
@@ -1386,6 +1386,10 @@ __INT_TO_FLOAT_MAPPER = \
         "meta-models/Muse-Glimmer-30B",
         "unsloth/Muse-Glimmer-30B-unsloth-bnb-4bit",
     ),
+    "unsloth/Qwen3.8-27B-unsloth-bnb-4bit" : (
+        "unsloth/Qwen3.8-27B",
+        "Qwen/Qwen3.8-27B",
+    ),
 }
 
 INT_TO_FLOAT_MAPPER  = {}


### PR DESCRIPTION
### Summary

Adds the Qwen3.8-27B entry to `__INT_TO_FLOAT_MAPPER`, so `Qwen/Qwen3.8-27B` relocates to the unsloth repos:

- 16-bit: `unsloth/Qwen3.8-27B`
- 4-bit: `unsloth/Qwen3.8-27B-unsloth-bnb-4bit`

### Resolved behaviour

Checked through `get_model_name` rather than only by reading the dict:

| input | `load_in_4bit=True` | `load_in_4bit=False` |
| --- | --- | --- |
| `Qwen/Qwen3.8-27B` | `unsloth/qwen3.8-27b-unsloth-bnb-4bit` | `unsloth/Qwen3.8-27B` |
| `qwen/qwen3.8-27b` | `unsloth/qwen3.8-27b-unsloth-bnb-4bit` | `unsloth/Qwen3.8-27B` |
| `unsloth/Qwen3.8-27B` | `unsloth/qwen3.8-27b-unsloth-bnb-4bit` | `unsloth/Qwen3.8-27B` |

The lowercased 4-bit result is the existing behaviour for every entry, not something this one introduces: `meta-models/Muse-Glimmer-30B` gives `unsloth/muse-glimmer-30b-unsloth-bnb-4bit` and `Qwen/Qwen3-8B` gives `unsloth/qwen3-8b-unsloth-bnb-4bit`. Confirmed the lowercase name resolves on the Hub to `unsloth/Qwen3.8-27B-unsloth-bnb-4bit`.

### Entry shape

Follows `unsloth/Muse-Glimmer-30B-unsloth-bnb-4bit`, where the third element repeats the dynamic 4-bit name rather than naming a pre-dynamic `-bnb-4bit` repo. That matters beyond consistency: the three-element branch also registers the 4-bit name in `MAP_TO_UNSLOTH_16bit`, so a model loaded from the 4-bit repo can still find its 16-bit base.

| lookup | result |
| --- | --- |
| `MAP_TO_UNSLOTH_16bit["Qwen/Qwen3.8-27B"]` | `unsloth/Qwen3.8-27B` |
| `MAP_TO_UNSLOTH_16bit["unsloth/Qwen3.8-27B-unsloth-bnb-4bit"]` | `unsloth/Qwen3.8-27B` |
| `INT_TO_FLOAT_MAPPER["unsloth/Qwen3.8-27B-unsloth-bnb-4bit"]` | `unsloth/Qwen3.8-27B` |

There is no `unsloth/Qwen3.8-27B-bnb-4bit` repo, which is why the third slot repeats the dynamic name. Every repo referenced by this entry was confirmed to exist before committing.

FP8 is deliberately not mapped here. `Qwen/Qwen3.8-27B-FP8` and `unsloth/Qwen3.8-27B-FP8` both exist, so the `{"8": ..., "16": ...}` form would work, but that form wants an explicit `(official, block, row)` triple and I have not verified which scaling `unsloth/Qwen3.8-27B-FP8` actually uses. Guessing would populate `FLOAT_TO_FP8_BLOCK_MAPPER` and `FLOAT_TO_FP8_ROW_MAPPER` with a wrong answer, which is worse than leaving them empty. Happy to add it as a follow-up once that is confirmed.

### Tests

`tests/test_mapper_no_duplicate_keys.py`, `tests/test_new_mapper_no_global_leak.py`, `tests/test_get_model_name.py`, `tests/test_new_mapper_fetched_fp8.py`, `tests/test_bad_mappings_redirect.py`: 10 passed, 40 subtests passed.

Also asserted directly that the new entry produces no `FLOAT_TO_FP8_BLOCK_MAPPER` or `FLOAT_TO_FP8_ROW_MAPPER` side effects.

