### PR TITLE
Studio: refuse keyless access to a cross-site browser request

### DIFF
--- a/studio/backend/tests/test_keyless_api_access_adversarial.py
+++ b/studio/backend/tests/test_keyless_api_access_adversarial.py
@@ -32,6 +32,8 @@ from utils import host_policy
 from utils.keyless_api_access import (
     KEYLESS_ADMISSION_STATE_KEY,
     KeylessToolPolicyMiddleware,
+    _browser_initiated_elsewhere,
+    _host_authority_is_direct,
     _reset_scope_cache,
     asgi_request_is_keyless,
     keyless_request_allowed,
@@ -84,10 +86,18 @@ def asgi_scope(
     method = None,
     root_path = "",
     headers = None,
+    raw_headers = None,
     state = None,
     server = ("127.0.0.1", 8000),
     client = ("127.0.0.1", 50000),
 ):
+    # `headers` is the convenient dict form; `raw_headers` is the ASGI list, which is the
+    # only way to express a repeated header. A dict cannot, which is why the duplicate
+    # rules went untested until now.
+    encoded = [
+        (name.lower().encode(), value.encode()) for name, value in (headers or {}).items()
+    ]
+    encoded += list(raw_headers or [])
     return {
         "type": "http",
         "method": method or ("GET" if path.startswith("/v1/models") else "POST"),
@@ -97,9 +107,7 @@ def asgi_scope(
         "scheme": "http",
         "server": server,
         "client": client,
-        "headers": [
-            (name.lower().encode(), value.encode()) for name, value in (headers or {}).items()
-        ],
+        "headers": encoded,
         "app": SimpleNamespace(state = state or app_state()),
     }
 
@@ -302,18 +310,24 @@ def test_traversal_shaped_paths_never_borrow_an_allowlisted_route():
         assert scope_covers("inference", method, path) is False, f"{method} {path} was covered"
 
 
-def test_the_dynamic_model_prefix_can_only_ever_reach_model_retrieval():
+def test_no_v1_get_route_but_model_retrieval_matches_a_traversal_suffix():
     """`scope_covers` admits every non-empty `GET /v1/models/...` suffix, not an exact pair.
 
     That is broader than the "exact HTTP method + normalized path allowlist" the PR
     describes, so the safety argument rests entirely on route topology: nothing but
-    `openai_retrieve_model` can match those paths. Pin that, because the day another
-    `GET /models/...` route is registered the allowlist silently grows with it.
+    `openai_retrieve_model` can match those paths. Pin the topology, because the day
+    another `GET /models/...` route is registered the allowlist silently grows with it.
+
+    Deliberately does NOT assert what `scope_covers` returns for a traversal string. An
+    earlier version did, which made this the one test in the file that failed when
+    `scope_covers` was made stricter -- a change detector pointing the wrong way, since
+    the fix for a red build would have been to loosen the code back.
     """
     from starlette.routing import Match
 
-    from routes.inference import router
+    from main import app
 
+    # Enumerate the real app rather than one router, so a second `/v1` mount is caught.
     traversals = [
         "/v1/models/../../api/train/start",
         "/v1/models/../load",
@@ -321,22 +335,26 @@ def test_the_dynamic_model_prefix_can_only_ever_reach_model_retrieval():
         "/v1/models/../../auth/api-keys",
     ]
     for path in traversals:
-        assert scope_covers("inference", "GET", path) is True  # documents the breadth
         matched = [
-            route.path
-            for route in router.routes
+            getattr(route, "path", None)
+            for route in app.routes
             if route.matches(
                 {
                     "type": "http",
                     "method": "GET",
-                    "path": path.removeprefix("/v1"),
+                    "path": path,
                     "root_path": "",
                     "headers": [],
                 }
             )[0]
             is not Match.NONE
         ]
-        assert matched == ["/models/{model_id:path}"], f"{path} reached {matched}"
+        # the SPA catch-all always matches; the point is that no /v1 API route does
+        api_matched = [p for p in matched if p and p.startswith("/v1")]
+        assert api_matched in ([], ["/v1/models/{model_id:path}"]), f"{path} reached {api_matched}"
+
+    # and the benign shape the allowlist exists to serve still resolves
+    assert scope_covers("inference", "GET", "/v1/models/unsloth/Llama-3.2-1B") is True
 
 
 # ── credential precedence ────────────────────────────────────────────────────
@@ -361,36 +379,51 @@ def test_a_session_jwt_naming_an_unknown_subject_is_refused():
 
 
 def test_the_asgi_twin_agrees_with_the_dependency_on_header_shapes():
-    """`asgi_request_is_keyless` is imported by the merged suite and never called.
+    """`asgi_request_is_keyless` is a second implementation of the credential rules.
 
-    A second implementation of the duplicate-header and dummy-bearer rules; only
-    the `_BearerOrKeyless` copy is otherwise tested.
+    The middleware reads it; every route reads `_BearerOrKeyless`. Two copies of the
+    duplicate-header and dummy-bearer rules that must not drift, so each shape is run
+    through BOTH and the verdicts compared -- asserting the twin against itself would
+    pass with the dependency deleted, which is what an earlier version of this test did.
     """
     seed_user()
     set_keyless_api_access("inference")
-    assert asgi_request_is_keyless(asgi_scope()) is True
-    for dummy in ("not-needed", "lm-studio", "ollama"):
-        assert (
-            asgi_request_is_keyless(asgi_scope(headers = {"Authorization": f"Bearer {dummy}"}))
-            is True
-        )
-    for hostile in (
-        "Bearer sk-unsloth-nope",
-        "Bearer",
-        "Basic bm90LW5lZWRlZA==",
-        "bearer  not-needed",
-        "Bearer not-needed-extra",
-    ):
-        assert (
-            asgi_request_is_keyless(asgi_scope(headers = {"Authorization": hostile})) is False
-        ), hostile
 
-    duplicated = asgi_scope()
-    duplicated["headers"] = [
-        (b"authorization", b"Bearer not-needed"),
-        (b"authorization", b"Bearer not-needed"),
+    def dependency_says_keyless(headers):
+        """Whether `security` admitted this request through one of the keyless schemes."""
+        try:
+            credentials = resolve(request_for(path = "/v1/models", method = "GET", headers = headers))
+        except HTTPException:
+            return False
+        return credentials.scheme in (KEYLESS_SCHEME, KEYLESS_FALLBACK_SCHEME)
+
+    shapes = [
+        ({}, True),
+        ({"Authorization": "Bearer not-needed"}, True),
+        ({"Authorization": "Bearer lm-studio"}, True),
+        ({"Authorization": "Bearer ollama"}, True),
+        ({"Authorization": "Bearer sk-unsloth-nope"}, False),
+        ({"Authorization": "Bearer"}, False),
+        ({"Authorization": "Basic bm90LW5lZWRlZA=="}, False),
+        # A doubled space after the scheme. This is the shape the two implementations
+        # used to disagree on: the dependency collapsed it and admitted the dummy while
+        # the twin did not, so the request was keyless to every route but not-keyless to
+        # the middleware that clamps the tool grant. Both now say keyless, which is the
+        # clamping answer.
+        ({"Authorization": "bearer  not-needed"}, True),
+        ({"Authorization": "Bearer not-needed-extra"}, False),
     ]
-    assert asgi_request_is_keyless(duplicated) is False
+    for headers, expected in shapes:
+        twin = asgi_request_is_keyless(asgi_scope(path = "/v1/models", method = "GET", headers = headers))
+        assert twin is expected, f"twin disagreed on {headers}"
+        assert dependency_says_keyless(headers) is expected, f"dependency disagreed on {headers}"
+
+    # A repeated `Authorization` is the one shape where the two differ in form and agree
+    # in meaning: the twin returns False, the dependency raises. Both mean not-keyless.
+    duplicated = [(b"authorization", b"Bearer not-needed"), (b"authorization", b"Bearer not-needed")]
+    assert asgi_request_is_keyless(asgi_scope(raw_headers = duplicated)) is False
+    with pytest.raises(HTTPException):
+        resolve(request_for(path = "/v1/models", method = "GET", raw_headers = duplicated))
 
 
 def test_a_cross_site_page_cannot_reach_keyless_without_sending_origin():
@@ -398,14 +431,33 @@ def test_a_cross_site_page_cannot_reach_keyless_without_sending_origin():
 
     No engine attaches it to a same-origin GET or to a cross-site GET made in
     `no-cors` mode, and only Chromium withholds such a fetch from
-    `http://127.0.0.1:<port>` (Private Network Access). Firefox and Safari send it.
-    `Sec-Fetch-Site` is what actually says who initiated the request, and a page
-    cannot forge it -- the `Sec-` prefix makes it a forbidden header name.
+    `http://127.0.0.1:<port>` (Local Network Access, Chrome 141/142). Firefox and
+    Safari send it. `Sec-Fetch-Site` is what actually says who initiated the request,
+    and a page cannot forge it -- the `Sec-` prefix makes it a forbidden header name.
+    Verified against Chromium 151, Firefox 153 and WebKit 26.5: every shape a page can
+    emit at a loopback URL -- no-cors and cors `fetch`, POST, `<img>`, `<script>`,
+    `<link rel=prefetch>`, `<iframe>`, form GET and POST, `sendBeacon`, `EventSource`,
+    `WebSocket` -- arrived as `cross-site`, or `same-site` on WebKit, which is why
+    `same-site` is in the refusal set.
     """
     seed_user()
     for scope_name in ("inference", "full"):
         set_keyless_api_access(scope_name)
-        for site in ("cross-site", "same-site", "CROSS-SITE", " cross-site "):
+        for site in (
+            "cross-site",
+            "same-site",
+            "CROSS-SITE",
+            " cross-site ",
+            # `none` is set before the redirect chain is walked, so an attacker 302 from
+            # a navigation the user started arrives still saying `none`. Firefox 153 and
+            # WebKit 26.5 both deliver it. Nobody types an API route into an address bar.
+            "none",
+            # an empty or unregistered token is not one of the four spelled values
+            "",
+            "same-partition",
+            "same-origin\x00",
+            "same-origin,cross-site",
+        ):
             assert (
                 keyless_request_allowed(
                     request_for(path = "/v1/models", method = "GET", headers = {"Sec-Fetch-Site": site})
@@ -413,8 +465,8 @@ def test_a_cross_site_page_cannot_reach_keyless_without_sending_origin():
                 is False
             ), f"{site!r} was admitted under {scope_name}"
 
-        # a page on Studio's own origin, and the user typing the URL, are not attacks
-        for site in ("same-origin", "none"):
+        # a page on Studio's own origin is not an attack
+        for site in ("same-origin", "SAME-ORIGIN", " same-origin "):
             assert (
                 keyless_request_allowed(
                     request_for(path = "/v1/models", method = "GET", headers = {"Sec-Fetch-Site": site})
@@ -425,6 +477,162 @@ def test_a_cross_site_page_cannot_reach_keyless_without_sending_origin():
         # absence must stay admitted: curl, the OpenAI SDKs and Safari < 16.4 send
         # no Sec-Fetch-* at all, and serving them is the entire point of the setting
         assert keyless_request_allowed(request_for(path = "/v1/models", method = "GET")) is True
+
+        # a repeated header is ambiguous, and `Headers.get()` would silently take the
+        # first. Neither h11 nor httptools rejects a repeated `Sec-Fetch-Site`, so this
+        # has to be refused here or not at all.
+        for pair in (("same-origin", "cross-site"), ("cross-site", "same-origin")):
+            assert (
+                keyless_request_allowed(
+                    request_for(
+                        path = "/v1/models",
+                        method = "GET",
+                        raw_headers = [(b"sec-fetch-site", pair[0].encode()), (b"sec-fetch-site", pair[1].encode())],
+                    )
+                )
+                is False
+            ), f"repeated Sec-Fetch-Site {pair} was admitted under {scope_name}"
+
+
+def test_a_loopback_spelling_the_browser_will_not_vouch_for_is_refused():
+    """Absence of `Sec-Fetch-Site` only means "not a browser" for a trustworthy URL.
+
+    Fetch Metadata is attached only to a potentially trustworthy URL, and Secure
+    Contexts spells that set as `127.0.0.0/8` and `::1/128`. Two families sit outside
+    it while still reaching a `127.0.0.1` listener, so a page can dial them and arrive
+    with no Fetch Metadata at all -- which the absent-is-admitted rule would then read
+    as a non-browser client:
+
+    * IPv4-mapped IPv6. Measured sending no `Sec-Fetch-*` in Chromium 151, Firefox 153
+      and WebKit 26.5 alike; all three normalise the authority to `[::ffff:7f00:1]`.
+    * the unspecified addresses, which connect to loopback on Linux. Chromium sends
+      `Host: 0.0.0.0` with no Fetch Metadata; Firefox and WebKit refuse the fetch.
+
+    A general purpose address normaliser undoes exactly the distinction that matters
+    here, so the authority is matched as written.
+    """
+    seed_user()
+    for scope_name in ("inference", "full"):
+        set_keyless_api_access(scope_name)
+        path = "/v1/models" if scope_name == "inference" else "/api/chat/threads"
+        for spelling in (
+            "[::ffff:127.0.0.1]:8888",
+            "[::ffff:7f00:1]:8888",
+            "[0:0:0:0:0:ffff:7f00:1]:8888",
+            "::ffff:7f00:1",
+            "0.0.0.0:8888",
+            "0.0.0.0",
+            "[::]:8888",
+            "[::]",
+        ):
+            assert (
+                keyless_request_allowed(
+                    request_for(path = path, method = "GET", headers = {"Host": spelling})
+                )
+                is False
+            ), f"{spelling} was admitted under {scope_name}"
+
+        # the spellings the browser does vouch for keep working
+        for spelling in ("127.0.0.1:8888", "127.0.0.2:8888", "[::1]:8888", "localhost:8888"):
+            assert (
+                keyless_request_allowed(
+                    request_for(path = path, method = "GET", headers = {"Host": spelling})
+                )
+                is True
+            ), f"{spelling} was refused under {scope_name}"
+
+
+def test_an_authority_that_is_not_a_bare_host_and_port_is_refused():
+    """`Host` is a host plus an optional numeric port, and nothing else.
+
+    Everything below reached the app through both uvicorn parsers in a raw-socket run,
+    so the wire really can carry them. None is a DNS name, so none is a rebinding
+    vector on its own -- but each is a shape that only a broken or hostile intermediary
+    produces, and resolving them leniently is what let the same normaliser paper over
+    the IPv4-mapped case above.
+    """
+    seed_user()
+    for scope_name in ("inference", "full"):
+        set_keyless_api_access(scope_name)
+        path = "/v1/models" if scope_name == "inference" else "/api/chat/threads"
+        for malformed in (
+            "localhost:garbage",
+            "localhost:",
+            "localhost:8888:9999",
+            "127.0.0.1:80@evil.example",
+            "127.0.0.1:8888/../evil",
+            "127.0.0.1%evil.example",
+            "127.0.0.1 8888",
+            "::1]",
+            "[::1",
+            "[::1]evil.example",
+            "[::1]:garbage",
+            "[not-an-address]:8888",
+            ":8888",
+            "localhost..:8888",
+            "0x7f.0.0.1:8888",
+            "2130706433:8888",
+            "127.1:8888",
+            "010.0.0.1:8888",
+        ):
+            assert (
+                keyless_request_allowed(
+                    request_for(path = path, method = "GET", headers = {"Host": malformed})
+                )
+                is False
+            ), f"{malformed!r} was admitted under {scope_name}"
+
+        # a repeated Host is ambiguous. h11 rejects it on the wire, httptools passes
+        # both through, and `Headers.get()` would take the first.
+        for pair in ((b"127.0.0.1:8888", b"evil.example:8888"), (b"evil.example:8888", b"127.0.0.1:8888")):
+            assert (
+                keyless_request_allowed(
+                    request_for(
+                        path = path,
+                        method = "GET",
+                        raw_headers = [(b"host", pair[0]), (b"host", pair[1])],
+                    )
+                )
+                is False
+            ), f"repeated Host {pair} was admitted under {scope_name}"
+
+
+def test_a_plain_http_lan_browser_request_is_not_covered_by_fetch_metadata():
+    """Pins the documented residual, so a later reader does not assume coverage.
+
+    On the private-LAN limb the URL is plain-HTTP `http://192.168.x.y:<port>`, which is
+    never potentially trustworthy, so no engine sends `Sec-Fetch-*` there and
+    `_browser_initiated_elsewhere` can never fire. A cross-site no-cors GET from a page
+    open in a LAN browser therefore still reaches keyless `inference`, exactly as it did
+    before this rule existed. `Origin` remains the only browser signal on that limb, and
+    the rebinding guard still refuses the name a rebound page would send.
+
+    This is unchanged behaviour, not a regression, and narrowing it would take away the
+    private-LAN inference the setting exists to provide. It is asserted so that a change
+    in either direction is visible.
+    """
+    seed_user()
+    set_keyless_api_access("inference")
+    lan = request_for(
+        path = "/v1/models",
+        method = "GET",
+        headers = {"Host": "192.168.1.50:8888"},
+        client = ("192.168.1.77", 51000),
+        server = ("192.168.1.50", 8888),
+    )
+    # no Sec-Fetch-Site is sent to a plain-HTTP LAN origin, so the predicate is inert
+    assert _browser_initiated_elsewhere(lan) is False
+    # and the authority is a literal, so the rebinding guard is satisfied too
+    assert _host_authority_is_direct(lan) is True
+    # a rebound page on the LAN is still refused, by the authority rule alone
+    rebound = request_for(
+        path = "/v1/models",
+        method = "GET",
+        headers = {"Host": "evil.example:8888"},
+        client = ("192.168.1.77", 51000),
+        server = ("192.168.1.50", 8888),
+    )
+    assert _host_authority_is_direct(rebound) is False
 
 
 def test_a_real_credential_authenticates_under_every_scope_and_transport(monkeypatch):
@@ -565,6 +773,10 @@ def test_a_rebound_hostname_cannot_pose_as_a_local_client():
             "127.0.0.1.evil.example:8888",
             "[::1]evil.example",
             "studio.internal:8888",
+            # WebKit sends no Sec-Fetch-* for a trailing-dot localhost, so the dotted
+            # spelling would be an absence-is-admitted gap on Safari alone.
+            "localhost.:8888",
+            "foo.localhost.:8888",
         ):
             assert (
                 keyless_request_allowed(
@@ -584,7 +796,6 @@ def test_a_rebound_hostname_cannot_pose_as_a_local_client():
             "[::1]:8888",
             "127.0.0.1",
             "LOCALHOST:8888",
-            "localhost.:8888",
         ):
             assert (
                 keyless_request_allowed(

--- a/studio/backend/tests/test_keyless_api_access_adversarial.py
+++ b/studio/backend/tests/test_keyless_api_access_adversarial.py
@@ -219,9 +219,9 @@ def test_full_scope_denials_survive_without_the_tunnel_flag():
     assert keyless_request_allowed(request_for()) is True  # control: loopback works
 
     for bind in ("0.0.0.0", "::"):
-        assert keyless_request_allowed(request_for(state = app_state(bind_host = bind))) is False, (
-            f"wildcard bind {bind} admitted under full scope"
-        )
+        assert (
+            keyless_request_allowed(request_for(state = app_state(bind_host = bind))) is False
+        ), f"wildcard bind {bind} admitted under full scope"
 
     assert (
         keyless_request_allowed(
@@ -246,9 +246,9 @@ def test_every_hosted_mode_flag_closes_full_and_inference():
             "secure",
             "lan_access_secure_launch",
         ):
-            assert keyless_request_allowed(request_for(state = app_state(**{flag: True}))) is False, (
-                f"{flag} did not close scope={scope}"
-            )
+            assert (
+                keyless_request_allowed(request_for(state = app_state(**{flag: True}))) is False
+            ), f"{flag} did not close scope={scope}"
         assert (
             keyless_request_allowed(
                 request_for(state = app_state(cloudflare_url = "https://x.trycloudflare.com"))

--- a/studio/backend/tests/test_keyless_api_access_adversarial.py
+++ b/studio/backend/tests/test_keyless_api_access_adversarial.py
@@ -1,0 +1,398 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Adversarial probes for keyless API access, written while reviewing PR #9102.
+
+Everything here targets a property the PR's own suite asserts only at the
+predicate layer, only in one direction, or not at all. Kept in a separate file so
+the PR's test-line budget is untouched.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import secrets
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+import jwt
+import pytest
+from fastapi import HTTPException
+from starlette.requests import Request
+
+from auth import storage
+from auth.authentication import (
+    KEYLESS_FALLBACK_SCHEME,
+    KEYLESS_SCHEME,
+    authenticated_via_api_key,
+    get_current_credential,
+    get_current_subject,
+    security,
+)
+from utils import host_policy
+from utils.keyless_api_access import (
+    KEYLESS_ADMISSION_STATE_KEY,
+    KeylessToolPolicyMiddleware,
+    _reset_scope_cache,
+    asgi_request_is_keyless,
+    keyless_request_allowed,
+    scope_covers,
+    set_keyless_api_access,
+)
+
+
+@pytest.fixture(autouse = True)
+def isolated_auth_db(tmp_path, monkeypatch):
+    monkeypatch.setattr(storage, "DB_PATH", tmp_path / "auth.db")
+    monkeypatch.setattr(storage, "_BOOTSTRAP_PW_PATH", tmp_path / ".bootstrap_password")
+    monkeypatch.setattr(storage, "_bootstrap_password", None)
+    monkeypatch.setattr(storage, "_api_key_pbkdf2_salt_cache", None)
+    storage._reset_api_key_hash_cache()
+    _reset_scope_cache()
+    # The PR suite leaves this latched on, which masks the transport checks below.
+    monkeypatch.setattr(host_policy, "_remote_connector_active", False, raising = False)
+    monkeypatch.setattr(host_policy, "_lan_connector_active", False, raising = False)
+    yield
+    storage._reset_api_key_hash_cache()
+    _reset_scope_cache()
+
+
+def seed_user():
+    storage.create_initial_user(
+        username = storage.DEFAULT_ADMIN_USERNAME,
+        password = "human-password-123",
+        jwt_secret = secrets.token_urlsafe(64),
+    )
+
+
+def app_state(**overrides):
+    state = SimpleNamespace(
+        bind_host = "127.0.0.1", secure = False, remote_access_is_colab = False,
+        lan_access_is_colab = False, lan_access_secure_launch = False, cloudflare_url = None,
+    )
+    for name, value in overrides.items():
+        setattr(state, name, value)
+    return state
+
+
+def asgi_scope(*, path = "/v1/chat/completions", method = None, root_path = "", headers = None,
+               state = None, server = ("127.0.0.1", 8000), client = ("127.0.0.1", 50000)):
+    return {
+        "type": "http",
+        "method": method or ("GET" if path.startswith("/v1/models") else "POST"),
+        "path": path,
+        "root_path": root_path,
+        "query_string": b"",
+        "scheme": "http",
+        "server": server,
+        "client": client,
+        "headers": [(name.lower().encode(), value.encode()) for name, value in (headers or {}).items()],
+        "app": SimpleNamespace(state = state or app_state()),
+    }
+
+
+def request_for(**kwargs):
+    return Request(asgi_scope(**kwargs))
+
+
+def resolve(request):
+    return asyncio.run(security(request))
+
+
+# ── the headline invariant: off means off, through the dependency itself ──────
+
+def test_scope_off_is_refused_by_the_security_dependency_not_only_the_predicate():
+    """The PR asserts scope=off at `scope_covers` level. Assert it where it matters."""
+    seed_user()
+    set_keyless_api_access("off")
+    with pytest.raises(HTTPException) as caught:
+        resolve(request_for())
+    assert caught.value.status_code in (401, 403)
+    # ...and the dummy bearers must not resurrect it either.
+    for dummy in ("not-needed", "lm-studio", "ollama"):
+        with pytest.raises(HTTPException):
+            asyncio.run(
+                get_current_subject(resolve(request_for(headers = {"Authorization": f"Bearer {dummy}"})))
+            )
+
+
+# ── privilege escalation: can a keyless caller widen its own grant? ───────────
+
+def test_a_keyless_caller_cannot_widen_its_own_scope():
+    """`_require_ui_session_for_keyless` is the only thing stopping self-promotion.
+
+    It has no test in the PR at all, and it depends entirely on
+    `authenticated_via_api_key` reporting True for a keyless caller.
+    """
+    from routes.settings import _require_ui_session_for_keyless
+
+    seed_user()
+    set_keyless_api_access("full", tools = False)
+    credentials = resolve(request_for(path = "/api/settings/keyless-api-access", method = "PUT"))
+    assert credentials.scheme == KEYLESS_SCHEME
+    assert asyncio.run(authenticated_via_api_key(credentials)) is True
+    with pytest.raises(HTTPException) as caught:
+        _require_ui_session_for_keyless(via_api_key = True)
+    assert caught.value.status_code == 403
+
+    # An sk-unsloth key is held back by the same guard.
+    raw_key, _row = storage.create_api_key(
+        username = storage.DEFAULT_ADMIN_USERNAME, name = "probe", expires_at = None,
+    )
+    key_credentials = resolve(
+        request_for(path = "/api/settings/keyless-api-access", method = "PUT",
+                    headers = {"Authorization": f"Bearer {raw_key}"})
+    )
+    assert asyncio.run(authenticated_via_api_key(key_credentials)) is True
+
+
+# ── transport: the inference limb, isolated from the tunnel flag ──────────────
+
+def test_inference_is_refused_from_a_public_bind_and_a_public_peer():
+    """No PR test exercises the inference limb with a genuinely public transport."""
+    seed_user()
+    set_keyless_api_access("inference")
+    public = app_state(bind_host = "64.227.100.5")
+    assert keyless_request_allowed(
+        request_for(server = ("64.227.100.5", 8000), client = ("8.8.8.8", 51000), state = public)
+    ) is False
+    # CGNAT is not private either.
+    assert keyless_request_allowed(
+        request_for(server = ("100.64.0.10", 8000), client = ("100.64.0.11", 51000),
+                    state = app_state(bind_host = "100.64.0.10"))
+    ) is False
+    # A private peer arriving on a loopback socket is still not LAN admission.
+    assert keyless_request_allowed(
+        request_for(server = ("127.0.0.1", 8000), client = ("192.168.1.90", 51000))
+    ) is False
+
+
+def test_full_scope_denials_survive_without_the_tunnel_flag():
+    """The PR's wildcard/LAN denials pass even with `_full_scope_transport_allowed` gone.
+
+    `_remote_connector_active` is left True there, so `_public_tunnel_active`
+    short-circuits first. With it cleared, the loopback rule has to carry them.
+    """
+    seed_user()
+    set_keyless_api_access("full")
+    assert keyless_request_allowed(request_for()) is True  # control: loopback works
+
+    for bind in ("0.0.0.0", "::"):
+        assert keyless_request_allowed(
+            request_for(state = app_state(bind_host = bind))
+        ) is False, f"wildcard bind {bind} admitted under full scope"
+
+    assert keyless_request_allowed(
+        request_for(server = ("192.168.1.24", 8888), client = ("192.168.1.90", 51000),
+                    state = app_state(bind_host = "192.168.1.24"))
+    ) is False
+
+
+def test_every_hosted_mode_flag_closes_full_and_inference():
+    """`lan_access_is_colab` and `lan_access_secure_launch` are never exercised by the PR."""
+    seed_user()
+    for scope in ("inference", "full"):
+        set_keyless_api_access(scope)
+        for flag in ("remote_access_is_colab", "lan_access_is_colab",
+                     "secure", "lan_access_secure_launch"):
+            assert keyless_request_allowed(
+                request_for(state = app_state(**{flag: True}))
+            ) is False, f"{flag} did not close scope={scope}"
+        assert keyless_request_allowed(
+            request_for(state = app_state(cloudflare_url = "https://x.trycloudflare.com"))
+        ) is False, f"active tunnel did not close scope={scope}"
+
+
+# ── route topology ───────────────────────────────────────────────────────────
+
+def test_management_routes_are_never_covered_by_inference_scope():
+    """The PR only asserts the positive `full` form for /api/*."""
+    for method, path in (
+        ("POST", "/api/train/start"),
+        ("PUT", "/api/settings/keyless-api-access"),
+        ("POST", "/api/auth/api-keys"),
+        ("GET", "/api/auth/api-keys"),
+        ("POST", "/api/mcp-servers/"),
+    ):
+        assert scope_covers("inference", method, path) is False
+
+
+def test_root_path_and_trailing_slash_reach_the_same_verdict_end_to_end():
+    """`root_path` is read off the ASGI scope but never driven through the entry point."""
+    seed_user()
+    set_keyless_api_access("inference")
+    assert keyless_request_allowed(
+        request_for(path = "/studio/v1/models/", root_path = "/studio", method = "GET")
+    ) is True
+    assert keyless_request_allowed(
+        request_for(path = "/studio/v1/load", root_path = "/studio", method = "POST")
+    ) is False
+    # prefix confusion: a sibling mount must not borrow the root's allowlist
+    assert keyless_request_allowed(
+        request_for(path = "/studio-v2/v1/models", root_path = "/studio", method = "GET")
+    ) is False
+
+
+def test_traversal_shaped_paths_never_borrow_an_allowlisted_route():
+    for method, path in (
+        ("POST", "/v1/chat/completions/../../v1/load"),
+        ("POST", "/v1/models/../load"),
+        ("POST", "/v1//load"),
+        ("POST", "/v1/chat/completions/%2e%2e/load"),
+        ("POST", "/v1/load;/v1/chat/completions"),
+    ):
+        assert scope_covers("inference", method, path) is False, f"{method} {path} was covered"
+
+
+def test_the_dynamic_model_prefix_can_only_ever_reach_model_retrieval():
+    """`scope_covers` admits every non-empty `GET /v1/models/...` suffix, not an exact pair.
+
+    That is broader than the "exact HTTP method + normalized path allowlist" the PR
+    describes, so the safety argument rests entirely on route topology: nothing but
+    `openai_retrieve_model` can match those paths. Pin that, because the day another
+    `GET /models/...` route is registered the allowlist silently grows with it.
+    """
+    from starlette.routing import Match
+
+    from routes.inference import router
+
+    traversals = [
+        "/v1/models/../../api/train/start",
+        "/v1/models/../load",
+        "/v1/models/..%2f..%2fload",
+        "/v1/models/../../auth/api-keys",
+    ]
+    for path in traversals:
+        assert scope_covers("inference", "GET", path) is True  # documents the breadth
+        matched = [
+            route.path
+            for route in router.routes
+            if route.matches({"type": "http", "method": "GET",
+                              "path": path.removeprefix("/v1"), "root_path": "",
+                              "headers": []})[0] is not Match.NONE
+        ]
+        assert matched == ["/models/{model_id:path}"], f"{path} reached {matched}"
+
+
+# ── credential precedence ────────────────────────────────────────────────────
+
+def test_a_session_jwt_naming_an_unknown_subject_is_refused():
+    """Covered for expired sessions, not for a well-formed token naming nobody."""
+    seed_user()
+    set_keyless_api_access("full")
+    _salt, _hash, jwt_secret, _must_change = storage.get_user_and_secret(storage.DEFAULT_ADMIN_USERNAME)
+    forged = jwt.encode(
+        {"sub": "ghost", "exp": datetime.now(timezone.utc) + timedelta(minutes = 30)},
+        jwt_secret, algorithm = "HS256",
+    )
+    with pytest.raises(HTTPException):
+        asyncio.run(get_current_subject(resolve(request_for(headers = {"Authorization": f"Bearer {forged}"}))))
+
+
+def test_the_asgi_twin_agrees_with_the_dependency_on_header_shapes():
+    """`asgi_request_is_keyless` is imported by the PR suite and never called.
+
+    It is a second implementation of the duplicate-header and dummy-bearer rules;
+    only the `_BearerOrKeyless` copy is tested.
+    """
+    seed_user()
+    set_keyless_api_access("inference")
+    assert asgi_request_is_keyless(asgi_scope()) is True
+    for dummy in ("not-needed", "lm-studio", "ollama"):
+        assert asgi_request_is_keyless(asgi_scope(headers = {"Authorization": f"Bearer {dummy}"})) is True
+    for hostile in ("Bearer sk-unsloth-nope", "Bearer", "Basic bm90LW5lZWRlZA==",
+                    "bearer  not-needed", "Bearer not-needed-extra"):
+        assert asgi_request_is_keyless(asgi_scope(headers = {"Authorization": hostile})) is False, hostile
+
+    duplicated = asgi_scope()
+    duplicated["headers"] = [(b"authorization", b"Bearer not-needed"),
+                             (b"authorization", b"Bearer not-needed")]
+    assert asgi_request_is_keyless(duplicated) is False
+
+
+def test_a_cross_site_page_cannot_reach_keyless_without_sending_origin():
+    """`Origin` alone does not identify a browser.
+
+    No engine attaches it to a same-origin GET or to a cross-site GET made in
+    `no-cors` mode, and only Chromium withholds such a fetch from
+    `http://127.0.0.1:<port>` (Private Network Access). Firefox and Safari send it.
+    `Sec-Fetch-Site` is what actually says who initiated the request, and a page
+    cannot forge it -- the `Sec-` prefix makes it a forbidden header name.
+    """
+    seed_user()
+    for scope_name in ("inference", "full"):
+        set_keyless_api_access(scope_name)
+        for site in ("cross-site", "same-site", "CROSS-SITE", " cross-site "):
+            assert keyless_request_allowed(
+                request_for(path = "/v1/models", method = "GET",
+                            headers = {"Sec-Fetch-Site": site})
+            ) is False, f"{site!r} was admitted under {scope_name}"
+
+        # a page on Studio's own origin, and the user typing the URL, are not attacks
+        for site in ("same-origin", "none"):
+            assert keyless_request_allowed(
+                request_for(path = "/v1/models", method = "GET",
+                            headers = {"Sec-Fetch-Site": site})
+            ) is True, f"{site!r} was refused under {scope_name}"
+
+        # absence must stay admitted: curl, the OpenAI SDKs and Safari < 16.4 send
+        # no Sec-Fetch-* at all, and serving them is the entire point of the setting
+        assert keyless_request_allowed(
+            request_for(path = "/v1/models", method = "GET")
+        ) is True
+
+
+# ── the reported race, pinned deterministically ──────────────────────────────
+
+def test_revoking_a_key_after_the_admission_snapshot_never_yields_the_admin():
+    """Regression for the PR #9102 race reported by @Imagineer99.
+
+    Reproduced on 99091aba7 and fixed by 10ecfe9d4; the reporter's own repro can
+    no longer run on head because it monkeypatches a function the classifier no
+    longer calls. This pins the interleaving directly instead: revoke between the
+    middleware snapshot and the credential check.
+    """
+    from state.tool_policy import get_tool_policy_default, reset_tool_policy, set_tool_policy_default
+
+    seed_user()
+    set_keyless_api_access("inference", tools = False)
+    reset_tool_policy()
+    set_tool_policy_default(True)
+    raw_key, row = storage.create_api_key(
+        username = storage.DEFAULT_ADMIN_USERNAME, name = "race", expires_at = None,
+    )
+    scope = asgi_scope(headers = {"Authorization": f"Bearer {raw_key}"})
+    observed = {}
+
+    async def downstream(asgi, receive, send):
+        observed["snapshot"] = asgi.get("state", {}).get(KEYLESS_ADMISSION_STATE_KEY)
+        observed["tools"] = get_tool_policy_default()
+        # the race: the key dies after the middleware classified the request
+        storage.revoke_api_key(storage.DEFAULT_ADMIN_USERNAME, row["id"])
+        credentials = await security(Request(asgi, receive))
+        observed["scheme"] = credentials.scheme
+        try:
+            await get_current_credential(credentials)
+            observed["subject_resolved"] = True
+        except HTTPException as error:
+            observed["status"] = error.status_code
+
+    async def receive():
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    async def send(_message):
+        return None
+
+    try:
+        asyncio.run(KeylessToolPolicyMiddleware(downstream)(scope, receive, send))
+    finally:
+        reset_tool_policy()
+
+    assert observed["snapshot"] is False, "a request carrying a real key was classified keyless"
+    assert observed["scheme"] not in (KEYLESS_SCHEME, KEYLESS_FALLBACK_SCHEME)
+    assert observed["scheme"] == "Bearer"
+    assert observed.get("subject_resolved") is not True, "revoked key resolved to a subject"
+    assert observed["status"] == 401
+    # tools stay at the caller's own policy: an API-key client is not keyless, so
+    # the grant it already had is not taken away. It never reaches a handler anyway.
+    assert observed["tools"] is True

--- a/studio/backend/tests/test_keyless_api_access_adversarial.py
+++ b/studio/backend/tests/test_keyless_api_access_adversarial.py
@@ -311,15 +311,15 @@ def test_traversal_shaped_paths_never_borrow_an_allowlisted_route():
 def test_no_v1_get_route_but_model_retrieval_matches_a_traversal_suffix():
     """`scope_covers` admits every non-empty `GET /v1/models/...` suffix, not an exact pair.
 
-    That is broader than the "exact HTTP method + normalized path allowlist" the PR
-    describes, so the safety argument rests entirely on route topology: nothing but
-    `openai_retrieve_model` can match those paths. Pin the topology, because the day
-    another `GET /models/...` route is registered the allowlist silently grows with it.
+    Broader than the "exact HTTP method + normalized path allowlist" the PR describes, so the
+    safety argument rests on route topology: nothing but `openai_retrieve_model` can match
+    those paths. Pin the topology, because the day another `GET /models/...` route is
+    registered the allowlist silently grows with it.
 
     Deliberately does NOT assert what `scope_covers` returns for a traversal string. An
-    earlier version did, which made this the one test in the file that failed when
-    `scope_covers` was made stricter -- a change detector pointing the wrong way, since
-    the fix for a red build would have been to loosen the code back.
+    earlier version did, making this the one test that failed when `scope_covers` was made
+    stricter -- a change detector pointing the wrong way, since the fix for a red build would
+    have been to loosen the code back.
     """
     from starlette.routing import Match
 
@@ -430,16 +430,14 @@ def test_the_asgi_twin_agrees_with_the_dependency_on_header_shapes():
 def test_a_cross_site_page_cannot_reach_keyless_without_sending_origin():
     """`Origin` alone does not identify a browser.
 
-    No engine attaches it to a same-origin GET or to a cross-site GET made in
-    `no-cors` mode, and only Chromium withholds such a fetch from
-    `http://127.0.0.1:<port>` (Local Network Access, Chrome 141/142). Firefox and
-    Safari send it. `Sec-Fetch-Site` is what actually says who initiated the request,
-    and a page cannot forge it -- the `Sec-` prefix makes it a forbidden header name.
-    Verified against Chromium 151, Firefox 153 and WebKit 26.5: every shape a page can
-    emit at a loopback URL -- no-cors and cors `fetch`, POST, `<img>`, `<script>`,
-    `<link rel=prefetch>`, `<iframe>`, form GET and POST, `sendBeacon`, `EventSource`,
-    `WebSocket` -- arrived as `cross-site`, or `same-site` on WebKit, which is why
-    `same-site` is in the refusal set.
+    No engine attaches it to a same-origin GET or a cross-site `no-cors` GET, and only
+    Chromium withholds such a fetch from `http://127.0.0.1:<port>` (Local Network Access,
+    Chrome 141/142). `Sec-Fetch-Site` is what says who initiated the request, and the `Sec-`
+    prefix makes it unforgeable. Verified on Chromium 151, Firefox 153 and WebKit 26.5: every
+    shape a page can emit at a loopback URL -- no-cors and cors `fetch`, POST, `<img>`,
+    `<script>`, `<link rel=prefetch>`, `<iframe>`, form GET and POST, `sendBeacon`,
+    `EventSource`, `WebSocket` -- arrived as `cross-site`, or `same-site` on WebKit, which is
+    why `same-site` is refused too.
     """
     seed_user()
     for scope_name in ("inference", "full"):
@@ -501,19 +499,18 @@ def test_a_cross_site_page_cannot_reach_keyless_without_sending_origin():
 def test_a_loopback_spelling_the_browser_will_not_vouch_for_is_refused():
     """Absence of `Sec-Fetch-Site` only means "not a browser" for a trustworthy URL.
 
-    Fetch Metadata is attached only to a potentially trustworthy URL, and Secure
-    Contexts spells that set as `127.0.0.0/8` and `::1/128`. Two families sit outside
-    it while still reaching a `127.0.0.1` listener, so a page can dial them and arrive
-    with no Fetch Metadata at all -- which the absent-is-admitted rule would then read
-    as a non-browser client:
+    Fetch Metadata is attached only to a potentially trustworthy URL, which Secure Contexts
+    spells `127.0.0.0/8` and `::1/128`. Two families sit outside it while still reaching a
+    `127.0.0.1` listener, so a page can dial them and arrive with no Fetch Metadata, which
+    the absent-is-admitted rule would read as a non-browser client:
 
-    * IPv4-mapped IPv6. Measured sending no `Sec-Fetch-*` in Chromium 151, Firefox 153
-      and WebKit 26.5 alike; all three normalise the authority to `[::ffff:7f00:1]`.
-    * the unspecified addresses, which connect to loopback on Linux. Chromium sends
+    * IPv4-mapped IPv6. No `Sec-Fetch-*` in Chromium 151, Firefox 153 or WebKit 26.5; all
+      three normalise the authority to `[::ffff:7f00:1]`.
+    * the unspecified addresses, which reach loopback on Linux. Chromium sends
       `Host: 0.0.0.0` with no Fetch Metadata; Firefox and WebKit refuse the fetch.
 
-    A general purpose address normaliser undoes exactly the distinction that matters
-    here, so the authority is matched as written.
+    A general purpose normaliser undoes the distinction that matters here, so the authority
+    is matched as written.
     """
     seed_user()
     for scope_name in ("inference", "full"):
@@ -587,17 +584,16 @@ def test_what_the_ui_advertises_matches_what_admission_accepts():
 def test_an_authority_the_scope_cannot_be_reached_at_is_refused():
     """Being an address rather than a name is not enough; it has to be a local one.
 
-    The socket checks see only the hop that connected, so an SSH forward or a reverse
-    proxy in front of a loopback bind makes both ASGI endpoints loopback while the
-    page's own origin, and so `Host`, is the public address it was served from. Before
-    this, `full` admitted `Host: 8.8.8.8` on a loopback transport and served management
-    responses to a page that could read them.
+    The socket checks see only the hop that connected, so an SSH forward or reverse proxy in
+    front of a loopback bind makes both ASGI endpoints loopback while `Host` is the public
+    address the page was served from. Before this, `full` admitted `Host: 8.8.8.8` on a
+    loopback transport and served management responses to a page that could read them.
 
-    `full` is loopback-only by construction, so its authority must be loopback.
-    `inference` may also be reached across the private LAN, so it takes the same
-    networks `lan_access_settings` admits and nothing wider -- CGNAT and the
-    documentation ranges are outside them, which `is_private` would not have caught
-    since that means "not globally reachable" rather than RFC 1918.
+    `full` is loopback-only by construction, so its authority must be loopback. `inference`
+    may also be reached across the private LAN, so it takes the networks
+    `lan_access_settings` admits and nothing wider -- CGNAT and the documentation ranges sit
+    outside them, which `is_private` would not have caught, meaning "not globally reachable"
+    rather than RFC 1918.
     """
     seed_user()
     for scope_name, path in (("full", "/api/chat/threads"), ("inference", "/v1/models")):
@@ -696,16 +692,15 @@ def test_an_authority_that_is_not_a_bare_host_and_port_is_refused():
 def test_a_plain_http_lan_browser_request_is_not_covered_by_fetch_metadata():
     """Pins the documented residual, so a later reader does not assume coverage.
 
-    On the private-LAN limb the URL is plain-HTTP `http://192.168.x.y:<port>`, which is
-    never potentially trustworthy, so no engine sends `Sec-Fetch-*` there and
-    `_browser_initiated_elsewhere` can never fire. A cross-site no-cors GET from a page
-    open in a LAN browser therefore still reaches keyless `inference`, exactly as it did
-    before this rule existed. `Origin` remains the only browser signal on that limb, and
-    the rebinding guard still refuses the name a rebound page would send.
+    On the private-LAN limb the URL is plain-HTTP `http://192.168.x.y:<port>`, never
+    potentially trustworthy, so no engine sends `Sec-Fetch-*` and
+    `_browser_initiated_elsewhere` can never fire. A cross-site no-cors GET from a LAN
+    browser therefore still reaches keyless `inference`, as it did before this rule. `Origin`
+    remains the only browser signal there, and the rebinding guard still refuses the name a
+    rebound page would send.
 
-    This is unchanged behaviour, not a regression, and narrowing it would take away the
-    private-LAN inference the setting exists to provide. It is asserted so that a change
-    in either direction is visible.
+    Unchanged behaviour, not a regression: narrowing it would take away the private-LAN
+    inference the setting exists to provide. Asserted so a change either way is visible.
     """
     seed_user()
     set_keyless_api_access("inference")

--- a/studio/backend/tests/test_keyless_api_access_adversarial.py
+++ b/studio/backend/tests/test_keyless_api_access_adversarial.py
@@ -545,6 +545,38 @@ def test_a_real_credential_authenticates_under_every_scope_and_transport(monkeyp
             )
 
 
+def test_a_rebound_hostname_cannot_pose_as_a_local_client():
+    """DNS rebinding produces every local signal the socket checks look at.
+
+    A page on `evil.example` whose record is re-pointed at 127.0.0.1 keeps its own
+    origin, so the fetch is same-origin: no `Origin`, `Sec-Fetch-Site: same-origin`,
+    loopback peer on a loopback socket. Unlike the `no-cors` case the response is
+    readable, so under `full` this reads local admin data. `Host` is the one header
+    that still names the page's own domain.
+    """
+    seed_user()
+    for scope_name in ("inference", "full"):
+        set_keyless_api_access(scope_name)
+        path = "/v1/models" if scope_name == "inference" else "/api/chat/threads"
+        for hostile in ("evil.example:8888", "localhost.evil.example:8888",
+                        "evil.example", "127.0.0.1.evil.example:8888",
+                        "[::1]evil.example", "studio.internal:8888"):
+            assert keyless_request_allowed(
+                request_for(path = path, method = "GET",
+                            headers = {"Host": hostile, "Sec-Fetch-Site": "same-origin"})
+            ) is False, f"{hostile} was admitted under {scope_name}"
+
+        # a client that addressed the socket directly is unaffected
+        for direct in ("127.0.0.1:8888", "localhost:8888", "[::1]:8888", "127.0.0.1",
+                       "LOCALHOST:8888", "localhost.:8888"):
+            assert keyless_request_allowed(
+                request_for(path = path, method = "GET", headers = {"Host": direct})
+            ) is True, f"{direct} was refused under {scope_name}"
+
+        # and no Host at all stays admitted: the merged suite sends none
+        assert keyless_request_allowed(request_for(path = path, method = "GET")) is True
+
+
 # ── the reported race, pinned deterministically ──────────────────────────────
 
 

--- a/studio/backend/tests/test_keyless_api_access_adversarial.py
+++ b/studio/backend/tests/test_keyless_api_access_adversarial.py
@@ -67,16 +67,28 @@ def seed_user():
 
 def app_state(**overrides):
     state = SimpleNamespace(
-        bind_host = "127.0.0.1", secure = False, remote_access_is_colab = False,
-        lan_access_is_colab = False, lan_access_secure_launch = False, cloudflare_url = None,
+        bind_host = "127.0.0.1",
+        secure = False,
+        remote_access_is_colab = False,
+        lan_access_is_colab = False,
+        lan_access_secure_launch = False,
+        cloudflare_url = None,
     )
     for name, value in overrides.items():
         setattr(state, name, value)
     return state
 
 
-def asgi_scope(*, path = "/v1/chat/completions", method = None, root_path = "", headers = None,
-               state = None, server = ("127.0.0.1", 8000), client = ("127.0.0.1", 50000)):
+def asgi_scope(
+    *,
+    path = "/v1/chat/completions",
+    method = None,
+    root_path = "",
+    headers = None,
+    state = None,
+    server = ("127.0.0.1", 8000),
+    client = ("127.0.0.1", 50000),
+):
     return {
         "type": "http",
         "method": method or ("GET" if path.startswith("/v1/models") else "POST"),
@@ -86,7 +98,9 @@ def asgi_scope(*, path = "/v1/chat/completions", method = None, root_path = "", 
         "scheme": "http",
         "server": server,
         "client": client,
-        "headers": [(name.lower().encode(), value.encode()) for name, value in (headers or {}).items()],
+        "headers": [
+            (name.lower().encode(), value.encode()) for name, value in (headers or {}).items()
+        ],
         "app": SimpleNamespace(state = state or app_state()),
     }
 
@@ -101,6 +115,7 @@ def resolve(request):
 
 # ── the headline invariant: off means off, through the dependency itself ──────
 
+
 def test_scope_off_is_refused_by_the_security_dependency_not_only_the_predicate():
     """The PR asserts scope=off at `scope_covers` level. Assert it where it matters."""
     seed_user()
@@ -112,11 +127,14 @@ def test_scope_off_is_refused_by_the_security_dependency_not_only_the_predicate(
     for dummy in ("not-needed", "lm-studio", "ollama"):
         with pytest.raises(HTTPException):
             asyncio.run(
-                get_current_subject(resolve(request_for(headers = {"Authorization": f"Bearer {dummy}"})))
+                get_current_subject(
+                    resolve(request_for(headers = {"Authorization": f"Bearer {dummy}"}))
+                )
             )
 
 
 # ── privilege escalation: can a keyless caller widen its own grant? ───────────
+
 
 def test_a_keyless_caller_cannot_widen_its_own_scope():
     """`_require_ui_session_for_keyless` is the only thing stopping self-promotion.
@@ -137,34 +155,52 @@ def test_a_keyless_caller_cannot_widen_its_own_scope():
 
     # An sk-unsloth key is held back by the same guard.
     raw_key, _row = storage.create_api_key(
-        username = storage.DEFAULT_ADMIN_USERNAME, name = "probe", expires_at = None,
+        username = storage.DEFAULT_ADMIN_USERNAME,
+        name = "probe",
+        expires_at = None,
     )
     key_credentials = resolve(
-        request_for(path = "/api/settings/keyless-api-access", method = "PUT",
-                    headers = {"Authorization": f"Bearer {raw_key}"})
+        request_for(
+            path = "/api/settings/keyless-api-access",
+            method = "PUT",
+            headers = {"Authorization": f"Bearer {raw_key}"},
+        )
     )
     assert asyncio.run(authenticated_via_api_key(key_credentials)) is True
 
 
 # ── transport: the inference limb, isolated from the tunnel flag ──────────────
 
+
 def test_inference_is_refused_from_a_public_bind_and_a_public_peer():
     """No PR test exercises the inference limb with a genuinely public transport."""
     seed_user()
     set_keyless_api_access("inference")
     public = app_state(bind_host = "64.227.100.5")
-    assert keyless_request_allowed(
-        request_for(server = ("64.227.100.5", 8000), client = ("8.8.8.8", 51000), state = public)
-    ) is False
+    assert (
+        keyless_request_allowed(
+            request_for(server = ("64.227.100.5", 8000), client = ("8.8.8.8", 51000), state = public)
+        )
+        is False
+    )
     # CGNAT is not private either.
-    assert keyless_request_allowed(
-        request_for(server = ("100.64.0.10", 8000), client = ("100.64.0.11", 51000),
-                    state = app_state(bind_host = "100.64.0.10"))
-    ) is False
+    assert (
+        keyless_request_allowed(
+            request_for(
+                server = ("100.64.0.10", 8000),
+                client = ("100.64.0.11", 51000),
+                state = app_state(bind_host = "100.64.0.10"),
+            )
+        )
+        is False
+    )
     # A private peer arriving on a loopback socket is still not LAN admission.
-    assert keyless_request_allowed(
-        request_for(server = ("127.0.0.1", 8000), client = ("192.168.1.90", 51000))
-    ) is False
+    assert (
+        keyless_request_allowed(
+            request_for(server = ("127.0.0.1", 8000), client = ("192.168.1.90", 51000))
+        )
+        is False
+    )
 
 
 def test_full_scope_denials_survive_without_the_tunnel_flag():
@@ -178,14 +214,20 @@ def test_full_scope_denials_survive_without_the_tunnel_flag():
     assert keyless_request_allowed(request_for()) is True  # control: loopback works
 
     for bind in ("0.0.0.0", "::"):
-        assert keyless_request_allowed(
-            request_for(state = app_state(bind_host = bind))
-        ) is False, f"wildcard bind {bind} admitted under full scope"
+        assert (
+            keyless_request_allowed(request_for(state = app_state(bind_host = bind))) is False
+        ), f"wildcard bind {bind} admitted under full scope"
 
-    assert keyless_request_allowed(
-        request_for(server = ("192.168.1.24", 8888), client = ("192.168.1.90", 51000),
-                    state = app_state(bind_host = "192.168.1.24"))
-    ) is False
+    assert (
+        keyless_request_allowed(
+            request_for(
+                server = ("192.168.1.24", 8888),
+                client = ("192.168.1.90", 51000),
+                state = app_state(bind_host = "192.168.1.24"),
+            )
+        )
+        is False
+    )
 
 
 def test_every_hosted_mode_flag_closes_full_and_inference():
@@ -193,17 +235,25 @@ def test_every_hosted_mode_flag_closes_full_and_inference():
     seed_user()
     for scope in ("inference", "full"):
         set_keyless_api_access(scope)
-        for flag in ("remote_access_is_colab", "lan_access_is_colab",
-                     "secure", "lan_access_secure_launch"):
-            assert keyless_request_allowed(
-                request_for(state = app_state(**{flag: True}))
-            ) is False, f"{flag} did not close scope={scope}"
-        assert keyless_request_allowed(
-            request_for(state = app_state(cloudflare_url = "https://x.trycloudflare.com"))
-        ) is False, f"active tunnel did not close scope={scope}"
+        for flag in (
+            "remote_access_is_colab",
+            "lan_access_is_colab",
+            "secure",
+            "lan_access_secure_launch",
+        ):
+            assert (
+                keyless_request_allowed(request_for(state = app_state(**{flag: True}))) is False
+            ), f"{flag} did not close scope={scope}"
+        assert (
+            keyless_request_allowed(
+                request_for(state = app_state(cloudflare_url = "https://x.trycloudflare.com"))
+            )
+            is False
+        ), f"active tunnel did not close scope={scope}"
 
 
 # ── route topology ───────────────────────────────────────────────────────────
+
 
 def test_management_routes_are_never_covered_by_inference_scope():
     """The PR only asserts the positive `full` form for /api/*."""
@@ -221,16 +271,25 @@ def test_root_path_and_trailing_slash_reach_the_same_verdict_end_to_end():
     """`root_path` is read off the ASGI scope but never driven through the entry point."""
     seed_user()
     set_keyless_api_access("inference")
-    assert keyless_request_allowed(
-        request_for(path = "/studio/v1/models/", root_path = "/studio", method = "GET")
-    ) is True
-    assert keyless_request_allowed(
-        request_for(path = "/studio/v1/load", root_path = "/studio", method = "POST")
-    ) is False
+    assert (
+        keyless_request_allowed(
+            request_for(path = "/studio/v1/models/", root_path = "/studio", method = "GET")
+        )
+        is True
+    )
+    assert (
+        keyless_request_allowed(
+            request_for(path = "/studio/v1/load", root_path = "/studio", method = "POST")
+        )
+        is False
+    )
     # prefix confusion: a sibling mount must not borrow the root's allowlist
-    assert keyless_request_allowed(
-        request_for(path = "/studio-v2/v1/models", root_path = "/studio", method = "GET")
-    ) is False
+    assert (
+        keyless_request_allowed(
+            request_for(path = "/studio-v2/v1/models", root_path = "/studio", method = "GET")
+        )
+        is False
+    )
 
 
 def test_traversal_shaped_paths_never_borrow_an_allowlisted_route():
@@ -267,26 +326,39 @@ def test_the_dynamic_model_prefix_can_only_ever_reach_model_retrieval():
         matched = [
             route.path
             for route in router.routes
-            if route.matches({"type": "http", "method": "GET",
-                              "path": path.removeprefix("/v1"), "root_path": "",
-                              "headers": []})[0] is not Match.NONE
+            if route.matches(
+                {
+                    "type": "http",
+                    "method": "GET",
+                    "path": path.removeprefix("/v1"),
+                    "root_path": "",
+                    "headers": [],
+                }
+            )[0]
+            is not Match.NONE
         ]
         assert matched == ["/models/{model_id:path}"], f"{path} reached {matched}"
 
 
 # ── credential precedence ────────────────────────────────────────────────────
 
+
 def test_a_session_jwt_naming_an_unknown_subject_is_refused():
     """Covered for expired sessions, not for a well-formed token naming nobody."""
     seed_user()
     set_keyless_api_access("full")
-    _salt, _hash, jwt_secret, _must_change = storage.get_user_and_secret(storage.DEFAULT_ADMIN_USERNAME)
+    _salt, _hash, jwt_secret, _must_change = storage.get_user_and_secret(
+        storage.DEFAULT_ADMIN_USERNAME
+    )
     forged = jwt.encode(
         {"sub": "ghost", "exp": datetime.now(timezone.utc) + timedelta(minutes = 30)},
-        jwt_secret, algorithm = "HS256",
+        jwt_secret,
+        algorithm = "HS256",
     )
     with pytest.raises(HTTPException):
-        asyncio.run(get_current_subject(resolve(request_for(headers = {"Authorization": f"Bearer {forged}"}))))
+        asyncio.run(
+            get_current_subject(resolve(request_for(headers = {"Authorization": f"Bearer {forged}"})))
+        )
 
 
 def test_the_asgi_twin_agrees_with_the_dependency_on_header_shapes():
@@ -299,14 +371,26 @@ def test_the_asgi_twin_agrees_with_the_dependency_on_header_shapes():
     set_keyless_api_access("inference")
     assert asgi_request_is_keyless(asgi_scope()) is True
     for dummy in ("not-needed", "lm-studio", "ollama"):
-        assert asgi_request_is_keyless(asgi_scope(headers = {"Authorization": f"Bearer {dummy}"})) is True
-    for hostile in ("Bearer sk-unsloth-nope", "Bearer", "Basic bm90LW5lZWRlZA==",
-                    "bearer  not-needed", "Bearer not-needed-extra"):
-        assert asgi_request_is_keyless(asgi_scope(headers = {"Authorization": hostile})) is False, hostile
+        assert (
+            asgi_request_is_keyless(asgi_scope(headers = {"Authorization": f"Bearer {dummy}"}))
+            is True
+        )
+    for hostile in (
+        "Bearer sk-unsloth-nope",
+        "Bearer",
+        "Basic bm90LW5lZWRlZA==",
+        "bearer  not-needed",
+        "Bearer not-needed-extra",
+    ):
+        assert (
+            asgi_request_is_keyless(asgi_scope(headers = {"Authorization": hostile})) is False
+        ), hostile
 
     duplicated = asgi_scope()
-    duplicated["headers"] = [(b"authorization", b"Bearer not-needed"),
-                             (b"authorization", b"Bearer not-needed")]
+    duplicated["headers"] = [
+        (b"authorization", b"Bearer not-needed"),
+        (b"authorization", b"Bearer not-needed"),
+    ]
     assert asgi_request_is_keyless(duplicated) is False
 
 
@@ -323,23 +407,25 @@ def test_a_cross_site_page_cannot_reach_keyless_without_sending_origin():
     for scope_name in ("inference", "full"):
         set_keyless_api_access(scope_name)
         for site in ("cross-site", "same-site", "CROSS-SITE", " cross-site "):
-            assert keyless_request_allowed(
-                request_for(path = "/v1/models", method = "GET",
-                            headers = {"Sec-Fetch-Site": site})
-            ) is False, f"{site!r} was admitted under {scope_name}"
+            assert (
+                keyless_request_allowed(
+                    request_for(path = "/v1/models", method = "GET", headers = {"Sec-Fetch-Site": site})
+                )
+                is False
+            ), f"{site!r} was admitted under {scope_name}"
 
         # a page on Studio's own origin, and the user typing the URL, are not attacks
         for site in ("same-origin", "none"):
-            assert keyless_request_allowed(
-                request_for(path = "/v1/models", method = "GET",
-                            headers = {"Sec-Fetch-Site": site})
-            ) is True, f"{site!r} was refused under {scope_name}"
+            assert (
+                keyless_request_allowed(
+                    request_for(path = "/v1/models", method = "GET", headers = {"Sec-Fetch-Site": site})
+                )
+                is True
+            ), f"{site!r} was refused under {scope_name}"
 
         # absence must stay admitted: curl, the OpenAI SDKs and Safari < 16.4 send
         # no Sec-Fetch-* at all, and serving them is the entire point of the setting
-        assert keyless_request_allowed(
-            request_for(path = "/v1/models", method = "GET")
-        ) is True
+        assert keyless_request_allowed(request_for(path = "/v1/models", method = "GET")) is True
 
 
 def test_a_real_credential_authenticates_under_every_scope_and_transport(monkeypatch):
@@ -355,33 +441,59 @@ def test_a_real_credential_authenticates_under_every_scope_and_transport(monkeyp
 
     seed_user()
     raw_key, row = storage.create_api_key(
-        username = storage.DEFAULT_ADMIN_USERNAME, name = "always-on", expires_at = None,
+        username = storage.DEFAULT_ADMIN_USERNAME,
+        name = "always-on",
+        expires_at = None,
     )
     _s, _h, jwt_secret, _m = storage.get_user_and_secret(storage.DEFAULT_ADMIN_USERNAME)
     session = jwt.encode(
-        {"sub": storage.DEFAULT_ADMIN_USERNAME,
-         "exp": datetime.now(timezone.utc) + timedelta(minutes = 30)},
-        jwt_secret, algorithm = "HS256",
+        {
+            "sub": storage.DEFAULT_ADMIN_USERNAME,
+            "exp": datetime.now(timezone.utc) + timedelta(minutes = 30),
+        },
+        jwt_secret,
+        algorithm = "HS256",
     )
 
     transports = {
-        "loopback": dict(server = ("127.0.0.1", 8000), client = ("127.0.0.1", 51000),
-                         state = app_state()),
-        "private_lan": dict(server = ("192.168.1.24", 8888), client = ("192.168.1.90", 51000),
-                            state = app_state(bind_host = "0.0.0.0")),
-        "public": dict(server = ("64.227.100.5", 8000), client = ("8.8.8.8", 51000),
-                       state = app_state(bind_host = "64.227.100.5")),
-        "tunnel": dict(server = ("127.0.0.1", 8000), client = ("127.0.0.1", 51000),
-                       state = app_state(cloudflare_url = "https://x.trycloudflare.com")),
-        "colab": dict(server = ("127.0.0.1", 8000), client = ("127.0.0.1", 51000),
-                      state = app_state(remote_access_is_colab = True)),
-        "secure": dict(server = ("127.0.0.1", 8000), client = ("127.0.0.1", 51000),
-                       state = app_state(secure = True)),
-        "browser_origin": dict(server = ("127.0.0.1", 8000), client = ("127.0.0.1", 51000),
-                               state = app_state(), headers = {"Origin": "https://evil.example"}),
-        "browser_cross_site": dict(server = ("127.0.0.1", 8000), client = ("127.0.0.1", 51000),
-                                   state = app_state(),
-                                   headers = {"Sec-Fetch-Site": "cross-site"}),
+        "loopback": dict(
+            server = ("127.0.0.1", 8000), client = ("127.0.0.1", 51000), state = app_state()
+        ),
+        "private_lan": dict(
+            server = ("192.168.1.24", 8888),
+            client = ("192.168.1.90", 51000),
+            state = app_state(bind_host = "0.0.0.0"),
+        ),
+        "public": dict(
+            server = ("64.227.100.5", 8000),
+            client = ("8.8.8.8", 51000),
+            state = app_state(bind_host = "64.227.100.5"),
+        ),
+        "tunnel": dict(
+            server = ("127.0.0.1", 8000),
+            client = ("127.0.0.1", 51000),
+            state = app_state(cloudflare_url = "https://x.trycloudflare.com"),
+        ),
+        "colab": dict(
+            server = ("127.0.0.1", 8000),
+            client = ("127.0.0.1", 51000),
+            state = app_state(remote_access_is_colab = True),
+        ),
+        "secure": dict(
+            server = ("127.0.0.1", 8000), client = ("127.0.0.1", 51000), state = app_state(secure = True)
+        ),
+        "browser_origin": dict(
+            server = ("127.0.0.1", 8000),
+            client = ("127.0.0.1", 51000),
+            state = app_state(),
+            headers = {"Origin": "https://evil.example"},
+        ),
+        "browser_cross_site": dict(
+            server = ("127.0.0.1", 8000),
+            client = ("127.0.0.1", 51000),
+            state = app_state(),
+            headers = {"Sec-Fetch-Site": "cross-site"},
+        ),
     }
 
     for scope_name in ("off", "inference", "full"):
@@ -390,42 +502,52 @@ def test_a_real_credential_authenticates_under_every_scope_and_transport(monkeyp
             # via monkeypatch, so the stub cannot outlive this test: it is a module
             # global, and test_lan_access_settings.py reads the real one
             monkeypatch.setattr(
-                lan_access, "lan_listener_status",
+                lan_access,
+                "lan_listener_status",
                 lambda t = transport: {
-                    "running": True, "port": t["server"][1],
-                    "addresses": [t["server"][0]], "error": None},
+                    "running": True,
+                    "port": t["server"][1],
+                    "addresses": [t["server"][0]],
+                    "error": None,
+                },
             )
             for credential_name, token in (("api_key", raw_key), ("session", session)):
                 headers = dict(transport.get("headers") or {})
                 headers["Authorization"] = f"Bearer {token}"
                 request = request_for(
-                    server = transport["server"], client = transport["client"],
-                    state = transport["state"], headers = headers,
+                    server = transport["server"],
+                    client = transport["client"],
+                    state = transport["state"],
+                    headers = headers,
                 )
                 credentials = resolve(request)
-                assert credentials.scheme not in (KEYLESS_SCHEME, KEYLESS_FALLBACK_SCHEME), (
-                    f"{credential_name} was downgraded to keyless on {label}/{scope_name}"
-                )
-                assert asyncio.run(get_current_subject(credentials)) == \
-                    storage.DEFAULT_ADMIN_USERNAME, (
-                        f"{credential_name} stopped working on {label}/{scope_name}"
-                    )
+                assert credentials.scheme not in (
+                    KEYLESS_SCHEME,
+                    KEYLESS_FALLBACK_SCHEME,
+                ), f"{credential_name} was downgraded to keyless on {label}/{scope_name}"
+                assert (
+                    asyncio.run(get_current_subject(credentials)) == storage.DEFAULT_ADMIN_USERNAME
+                ), f"{credential_name} stopped working on {label}/{scope_name}"
 
     # and the credentials that must NOT work still do not, at the widest scope
     set_keyless_api_access("full")
     storage.revoke_api_key(storage.DEFAULT_ADMIN_USERNAME, row["id"])
     expired, _row = storage.create_api_key(
-        username = storage.DEFAULT_ADMIN_USERNAME, name = "expired",
+        username = storage.DEFAULT_ADMIN_USERNAME,
+        name = "expired",
         expires_at = (datetime.now(timezone.utc) - timedelta(days = 1)).isoformat(),
     )
     for dead in (raw_key, expired):
         with pytest.raises(HTTPException):
-            asyncio.run(get_current_subject(
-                resolve(request_for(headers = {"Authorization": f"Bearer {dead}"}))
-            ))
+            asyncio.run(
+                get_current_subject(
+                    resolve(request_for(headers = {"Authorization": f"Bearer {dead}"}))
+                )
+            )
 
 
 # ── the reported race, pinned deterministically ──────────────────────────────
+
 
 def test_revoking_a_key_after_the_admission_snapshot_never_yields_the_admin():
     """Regression for the PR #9102 race reported by @Imagineer99.
@@ -435,14 +557,20 @@ def test_revoking_a_key_after_the_admission_snapshot_never_yields_the_admin():
     longer calls. This pins the interleaving directly instead: revoke between the
     middleware snapshot and the credential check.
     """
-    from state.tool_policy import get_tool_policy_default, reset_tool_policy, set_tool_policy_default
+    from state.tool_policy import (
+        get_tool_policy_default,
+        reset_tool_policy,
+        set_tool_policy_default,
+    )
 
     seed_user()
     set_keyless_api_access("inference", tools = False)
     reset_tool_policy()
     set_tool_policy_default(True)
     raw_key, row = storage.create_api_key(
-        username = storage.DEFAULT_ADMIN_USERNAME, name = "race", expires_at = None,
+        username = storage.DEFAULT_ADMIN_USERNAME,
+        name = "race",
+        expires_at = None,
     )
     scope = asgi_scope(headers = {"Authorization": f"Bearer {raw_key}"})
     observed = {}

--- a/studio/backend/tests/test_keyless_api_access_adversarial.py
+++ b/studio/backend/tests/test_keyless_api_access_adversarial.py
@@ -1,11 +1,10 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-"""Adversarial probes for keyless API access, written while reviewing PR #9102.
+"""Adversarial probes for keyless API access, from the review of PR #9102.
 
-Everything here targets a property the PR's own suite asserts only at the
-predicate layer, only in one direction, or not at all. Kept in a separate file so
-the PR's test-line budget is untouched.
+Each targets a property the merged suite asserts only at the predicate layer,
+only in one direction, or not at all. Separate file so that suite is untouched.
 """
 
 from __future__ import annotations
@@ -117,7 +116,7 @@ def resolve(request):
 
 
 def test_scope_off_is_refused_by_the_security_dependency_not_only_the_predicate():
-    """The PR asserts scope=off at `scope_covers` level. Assert it where it matters."""
+    """The merged suite asserts scope=off at `scope_covers` level. Assert it where it counts."""
     seed_user()
     set_keyless_api_access("off")
     with pytest.raises(HTTPException) as caught:
@@ -173,7 +172,7 @@ def test_a_keyless_caller_cannot_widen_its_own_scope():
 
 
 def test_inference_is_refused_from_a_public_bind_and_a_public_peer():
-    """No PR test exercises the inference limb with a genuinely public transport."""
+    """Nothing exercises the inference limb with a genuinely public transport."""
     seed_user()
     set_keyless_api_access("inference")
     public = app_state(bind_host = "64.227.100.5")
@@ -204,7 +203,7 @@ def test_inference_is_refused_from_a_public_bind_and_a_public_peer():
 
 
 def test_full_scope_denials_survive_without_the_tunnel_flag():
-    """The PR's wildcard/LAN denials pass even with `_full_scope_transport_allowed` gone.
+    """The merged wildcard/LAN denials pass even with `_full_scope_transport_allowed` gone.
 
     `_remote_connector_active` is left True there, so `_public_tunnel_active`
     short-circuits first. With it cleared, the loopback rule has to carry them.
@@ -231,7 +230,7 @@ def test_full_scope_denials_survive_without_the_tunnel_flag():
 
 
 def test_every_hosted_mode_flag_closes_full_and_inference():
-    """`lan_access_is_colab` and `lan_access_secure_launch` are never exercised by the PR."""
+    """`lan_access_is_colab` and `lan_access_secure_launch` are otherwise unexercised."""
     seed_user()
     for scope in ("inference", "full"):
         set_keyless_api_access(scope)
@@ -256,7 +255,7 @@ def test_every_hosted_mode_flag_closes_full_and_inference():
 
 
 def test_management_routes_are_never_covered_by_inference_scope():
-    """The PR only asserts the positive `full` form for /api/*."""
+    """Only the positive `full` form is asserted for /api/* elsewhere."""
     for method, path in (
         ("POST", "/api/train/start"),
         ("PUT", "/api/settings/keyless-api-access"),
@@ -362,10 +361,10 @@ def test_a_session_jwt_naming_an_unknown_subject_is_refused():
 
 
 def test_the_asgi_twin_agrees_with_the_dependency_on_header_shapes():
-    """`asgi_request_is_keyless` is imported by the PR suite and never called.
+    """`asgi_request_is_keyless` is imported by the merged suite and never called.
 
-    It is a second implementation of the duplicate-header and dummy-bearer rules;
-    only the `_BearerOrKeyless` copy is tested.
+    A second implementation of the duplicate-header and dummy-bearer rules; only
+    the `_BearerOrKeyless` copy is otherwise tested.
     """
     seed_user()
     set_keyless_api_access("inference")

--- a/studio/backend/tests/test_keyless_api_access_adversarial.py
+++ b/studio/backend/tests/test_keyless_api_access_adversarial.py
@@ -546,6 +546,44 @@ def test_a_loopback_spelling_the_browser_will_not_vouch_for_is_refused():
             ), f"{spelling} was refused under {scope_name}"
 
 
+def test_what_the_ui_advertises_matches_what_admission_accepts():
+    """The LAN panel must not offer a keyless URL that admission answers 401 on.
+
+    `lan_access_settings._has_keyless_lan_url` decides whether the panel and the usage
+    examples print `Bearer not-needed`. It had its own copy of the authority test, and
+    the copy used `_normalized_ip`, which un-maps IPv4-mapped IPv6 -- so a launch on
+    `::ffff:192.168.1.24` was advertised as keyless-eligible while admission refused the
+    mapped authority. Both now answer through `keyless_authority_address_allowed`, so
+    this pins the two ends together rather than the mapped case alone.
+    """
+    from utils.keyless_api_access import keyless_authority_address_allowed
+    from utils.lan_access_settings import _has_keyless_lan_url
+
+    advertised_and_admitted = [
+        ("http://192.168.1.24:8888", "192.168.1.24:8888", True),
+        ("http://10.0.0.5:8888", "10.0.0.5:8888", True),
+        ("http://[fd00::1]:8888", "[fd00::1]:8888", True),
+        ("http://[::ffff:192.168.1.24]:8888", "[::ffff:192.168.1.24]:8888", False),
+        ("http://[::ffff:c0a8:118]:8888", "[::ffff:c0a8:118]:8888", False),
+        ("http://box.local:8888", "box.local:8888", False),
+        ("http://8.8.8.8:8888", "8.8.8.8:8888", False),
+    ]
+    for url, authority, expected in advertised_and_admitted:
+        assert _has_keyless_lan_url([url]) is expected, f"UI disagreed on {url}"
+        assert (
+            _host_authority_is_direct(request_for(headers = {"Host": authority}), "inference")
+            is expected
+        ), f"admission disagreed on {authority}"
+
+    # and the shared classifier refuses a mapped literal however it is spelled
+    import ipaddress
+
+    for mapped in ("::ffff:192.168.1.24", "::ffff:c0a8:118", "::ffff:127.0.0.1"):
+        assert (
+            keyless_authority_address_allowed(ipaddress.ip_address(mapped), "inference") is False
+        ), f"{mapped} was allowed"
+
+
 def test_an_authority_the_scope_cannot_be_reached_at_is_refused():
     """Being an address rather than a name is not enough; it has to be a local one.
 

--- a/studio/backend/tests/test_keyless_api_access_adversarial.py
+++ b/studio/backend/tests/test_keyless_api_access_adversarial.py
@@ -94,9 +94,7 @@ def asgi_scope(
     # `headers` is the convenient dict form; `raw_headers` is the ASGI list, which is the
     # only way to express a repeated header. A dict cannot, which is why the duplicate
     # rules went untested until now.
-    encoded = [
-        (name.lower().encode(), value.encode()) for name, value in (headers or {}).items()
-    ]
+    encoded = [(name.lower().encode(), value.encode()) for name, value in (headers or {}).items()]
     encoded += list(raw_headers or [])
     return {
         "type": "http",
@@ -221,9 +219,9 @@ def test_full_scope_denials_survive_without_the_tunnel_flag():
     assert keyless_request_allowed(request_for()) is True  # control: loopback works
 
     for bind in ("0.0.0.0", "::"):
-        assert (
-            keyless_request_allowed(request_for(state = app_state(bind_host = bind))) is False
-        ), f"wildcard bind {bind} admitted under full scope"
+        assert keyless_request_allowed(request_for(state = app_state(bind_host = bind))) is False, (
+            f"wildcard bind {bind} admitted under full scope"
+        )
 
     assert (
         keyless_request_allowed(
@@ -248,9 +246,9 @@ def test_every_hosted_mode_flag_closes_full_and_inference():
             "secure",
             "lan_access_secure_launch",
         ):
-            assert (
-                keyless_request_allowed(request_for(state = app_state(**{flag: True}))) is False
-            ), f"{flag} did not close scope={scope}"
+            assert keyless_request_allowed(request_for(state = app_state(**{flag: True}))) is False, (
+                f"{flag} did not close scope={scope}"
+            )
         assert (
             keyless_request_allowed(
                 request_for(state = app_state(cloudflare_url = "https://x.trycloudflare.com"))
@@ -420,7 +418,10 @@ def test_the_asgi_twin_agrees_with_the_dependency_on_header_shapes():
 
     # A repeated `Authorization` is the one shape where the two differ in form and agree
     # in meaning: the twin returns False, the dependency raises. Both mean not-keyless.
-    duplicated = [(b"authorization", b"Bearer not-needed"), (b"authorization", b"Bearer not-needed")]
+    duplicated = [
+        (b"authorization", b"Bearer not-needed"),
+        (b"authorization", b"Bearer not-needed"),
+    ]
     assert asgi_request_is_keyless(asgi_scope(raw_headers = duplicated)) is False
     with pytest.raises(HTTPException):
         resolve(request_for(path = "/v1/models", method = "GET", raw_headers = duplicated))
@@ -487,7 +488,10 @@ def test_a_cross_site_page_cannot_reach_keyless_without_sending_origin():
                     request_for(
                         path = "/v1/models",
                         method = "GET",
-                        raw_headers = [(b"sec-fetch-site", pair[0].encode()), (b"sec-fetch-site", pair[1].encode())],
+                        raw_headers = [
+                            (b"sec-fetch-site", pair[0].encode()),
+                            (b"sec-fetch-site", pair[1].encode()),
+                        ],
                     )
                 )
                 is False
@@ -542,6 +546,57 @@ def test_a_loopback_spelling_the_browser_will_not_vouch_for_is_refused():
             ), f"{spelling} was refused under {scope_name}"
 
 
+def test_an_authority_the_scope_cannot_be_reached_at_is_refused():
+    """Being an address rather than a name is not enough; it has to be a local one.
+
+    The socket checks see only the hop that connected, so an SSH forward or a reverse
+    proxy in front of a loopback bind makes both ASGI endpoints loopback while the
+    page's own origin, and so `Host`, is the public address it was served from. Before
+    this, `full` admitted `Host: 8.8.8.8` on a loopback transport and served management
+    responses to a page that could read them.
+
+    `full` is loopback-only by construction, so its authority must be loopback.
+    `inference` may also be reached across the private LAN, so it takes the same
+    networks `lan_access_settings` admits and nothing wider -- CGNAT and the
+    documentation ranges are outside them, which `is_private` would not have caught
+    since that means "not globally reachable" rather than RFC 1918.
+    """
+    seed_user()
+    for scope_name, path in (("full", "/api/chat/threads"), ("inference", "/v1/models")):
+        set_keyless_api_access(scope_name)
+        for public in (
+            "8.8.8.8:8888",
+            "203.0.113.5:8888",
+            "[2001:db8::1]:8888",
+            "100.64.0.1:8888",
+        ):
+            assert (
+                keyless_request_allowed(
+                    request_for(path = path, method = "GET", headers = {"Host": public})
+                )
+                is False
+            ), f"{public} was admitted under {scope_name}"
+
+    # a private LAN authority is right for inference and wrong for full
+    for spelling in ("192.168.1.5:8888", "10.0.0.5:8888", "[fd00::1]:8888"):
+        assert (
+            _host_authority_is_direct(request_for(headers = {"Host": spelling}), "inference") is True
+        ), f"{spelling} refused for inference"
+        assert (
+            _host_authority_is_direct(request_for(headers = {"Host": spelling}), "full") is False
+        ), f"{spelling} admitted for full"
+
+    # loopback stays right for both, and so does an absent Host
+    for spelling in ("127.0.0.1:8888", "127.0.0.2:8888", "localhost:8888", "[::1]:8888"):
+        for scope_name in ("full", "inference"):
+            assert (
+                _host_authority_is_direct(request_for(headers = {"Host": spelling}), scope_name)
+                is True
+            ), f"{spelling} refused for {scope_name}"
+    for scope_name in ("full", "inference"):
+        assert _host_authority_is_direct(request_for(), scope_name) is True
+
+
 def test_an_authority_that_is_not_a_bare_host_and_port_is_refused():
     """`Host` is a host plus an optional numeric port, and nothing else.
 
@@ -584,7 +639,10 @@ def test_an_authority_that_is_not_a_bare_host_and_port_is_refused():
 
         # a repeated Host is ambiguous. h11 rejects it on the wire, httptools passes
         # both through, and `Headers.get()` would take the first.
-        for pair in ((b"127.0.0.1:8888", b"evil.example:8888"), (b"evil.example:8888", b"127.0.0.1:8888")):
+        for pair in (
+            (b"127.0.0.1:8888", b"evil.example:8888"),
+            (b"evil.example:8888", b"127.0.0.1:8888"),
+        ):
             assert (
                 keyless_request_allowed(
                     request_for(
@@ -623,7 +681,7 @@ def test_a_plain_http_lan_browser_request_is_not_covered_by_fetch_metadata():
     # no Sec-Fetch-Site is sent to a plain-HTTP LAN origin, so the predicate is inert
     assert _browser_initiated_elsewhere(lan) is False
     # and the authority is a literal, so the rebinding guard is satisfied too
-    assert _host_authority_is_direct(lan) is True
+    assert _host_authority_is_direct(lan, "inference") is True
     # a rebound page on the LAN is still refused, by the authority rule alone
     rebound = request_for(
         path = "/v1/models",
@@ -632,7 +690,7 @@ def test_a_plain_http_lan_browser_request_is_not_covered_by_fetch_metadata():
         client = ("192.168.1.77", 51000),
         server = ("192.168.1.50", 8888),
     )
-    assert _host_authority_is_direct(rebound) is False
+    assert _host_authority_is_direct(rebound, "inference") is False
 
 
 def test_a_real_credential_authenticates_under_every_scope_and_transport(monkeypatch):

--- a/studio/backend/tests/test_keyless_api_access_adversarial.py
+++ b/studio/backend/tests/test_keyless_api_access_adversarial.py
@@ -48,7 +48,7 @@ def isolated_auth_db(tmp_path, monkeypatch):
     monkeypatch.setattr(storage, "_api_key_pbkdf2_salt_cache", None)
     storage._reset_api_key_hash_cache()
     _reset_scope_cache()
-    # The PR suite leaves this latched on, which masks the transport checks below.
+    # The merged suite leaves this latched on, masking the transport checks below.
     monkeypatch.setattr(host_policy, "_remote_connector_active", False, raising = False)
     monkeypatch.setattr(host_policy, "_lan_connector_active", False, raising = False)
     yield
@@ -138,8 +138,8 @@ def test_scope_off_is_refused_by_the_security_dependency_not_only_the_predicate(
 def test_a_keyless_caller_cannot_widen_its_own_scope():
     """`_require_ui_session_for_keyless` is the only thing stopping self-promotion.
 
-    It has no test in the PR at all, and it depends entirely on
-    `authenticated_via_api_key` reporting True for a keyless caller.
+    Untested elsewhere, and it rests entirely on `authenticated_via_api_key`
+    reporting True for a keyless caller.
     """
     from routes.settings import _require_ui_session_for_keyless
 

--- a/studio/backend/tests/test_keyless_api_access_adversarial.py
+++ b/studio/backend/tests/test_keyless_api_access_adversarial.py
@@ -558,20 +558,40 @@ def test_a_rebound_hostname_cannot_pose_as_a_local_client():
     for scope_name in ("inference", "full"):
         set_keyless_api_access(scope_name)
         path = "/v1/models" if scope_name == "inference" else "/api/chat/threads"
-        for hostile in ("evil.example:8888", "localhost.evil.example:8888",
-                        "evil.example", "127.0.0.1.evil.example:8888",
-                        "[::1]evil.example", "studio.internal:8888"):
-            assert keyless_request_allowed(
-                request_for(path = path, method = "GET",
-                            headers = {"Host": hostile, "Sec-Fetch-Site": "same-origin"})
-            ) is False, f"{hostile} was admitted under {scope_name}"
+        for hostile in (
+            "evil.example:8888",
+            "localhost.evil.example:8888",
+            "evil.example",
+            "127.0.0.1.evil.example:8888",
+            "[::1]evil.example",
+            "studio.internal:8888",
+        ):
+            assert (
+                keyless_request_allowed(
+                    request_for(
+                        path = path,
+                        method = "GET",
+                        headers = {"Host": hostile, "Sec-Fetch-Site": "same-origin"},
+                    )
+                )
+                is False
+            ), f"{hostile} was admitted under {scope_name}"
 
         # a client that addressed the socket directly is unaffected
-        for direct in ("127.0.0.1:8888", "localhost:8888", "[::1]:8888", "127.0.0.1",
-                       "LOCALHOST:8888", "localhost.:8888"):
-            assert keyless_request_allowed(
-                request_for(path = path, method = "GET", headers = {"Host": direct})
-            ) is True, f"{direct} was refused under {scope_name}"
+        for direct in (
+            "127.0.0.1:8888",
+            "localhost:8888",
+            "[::1]:8888",
+            "127.0.0.1",
+            "LOCALHOST:8888",
+            "localhost.:8888",
+        ):
+            assert (
+                keyless_request_allowed(
+                    request_for(path = path, method = "GET", headers = {"Host": direct})
+                )
+                is True
+            ), f"{direct} was refused under {scope_name}"
 
         # and no Host at all stays admitted: the merged suite sends none
         assert keyless_request_allowed(request_for(path = path, method = "GET")) is True

--- a/studio/backend/tests/test_keyless_api_access_adversarial.py
+++ b/studio/backend/tests/test_keyless_api_access_adversarial.py
@@ -342,6 +342,89 @@ def test_a_cross_site_page_cannot_reach_keyless_without_sending_origin():
         ) is True
 
 
+def test_a_real_credential_authenticates_under_every_scope_and_transport(monkeypatch):
+    """The setting adds an admission path. It must never take one away.
+
+    A working key or session has to keep authenticating exactly as before, on
+    every scope and on every transport -- including the ones keyless itself is
+    refused on, since a usable bearer is resolved before any scope or transport
+    check runs. It also has to authenticate *as itself*: a keyless scheme would
+    hand an existing API client the keyless tool restriction it never had.
+    """
+    import lan_access
+
+    seed_user()
+    raw_key, row = storage.create_api_key(
+        username = storage.DEFAULT_ADMIN_USERNAME, name = "always-on", expires_at = None,
+    )
+    _s, _h, jwt_secret, _m = storage.get_user_and_secret(storage.DEFAULT_ADMIN_USERNAME)
+    session = jwt.encode(
+        {"sub": storage.DEFAULT_ADMIN_USERNAME,
+         "exp": datetime.now(timezone.utc) + timedelta(minutes = 30)},
+        jwt_secret, algorithm = "HS256",
+    )
+
+    transports = {
+        "loopback": dict(server = ("127.0.0.1", 8000), client = ("127.0.0.1", 51000),
+                         state = app_state()),
+        "private_lan": dict(server = ("192.168.1.24", 8888), client = ("192.168.1.90", 51000),
+                            state = app_state(bind_host = "0.0.0.0")),
+        "public": dict(server = ("64.227.100.5", 8000), client = ("8.8.8.8", 51000),
+                       state = app_state(bind_host = "64.227.100.5")),
+        "tunnel": dict(server = ("127.0.0.1", 8000), client = ("127.0.0.1", 51000),
+                       state = app_state(cloudflare_url = "https://x.trycloudflare.com")),
+        "colab": dict(server = ("127.0.0.1", 8000), client = ("127.0.0.1", 51000),
+                      state = app_state(remote_access_is_colab = True)),
+        "secure": dict(server = ("127.0.0.1", 8000), client = ("127.0.0.1", 51000),
+                       state = app_state(secure = True)),
+        "browser_origin": dict(server = ("127.0.0.1", 8000), client = ("127.0.0.1", 51000),
+                               state = app_state(), headers = {"Origin": "https://evil.example"}),
+        "browser_cross_site": dict(server = ("127.0.0.1", 8000), client = ("127.0.0.1", 51000),
+                                   state = app_state(),
+                                   headers = {"Sec-Fetch-Site": "cross-site"}),
+    }
+
+    for scope_name in ("off", "inference", "full"):
+        set_keyless_api_access(scope_name)
+        for label, transport in transports.items():
+            # via monkeypatch, so the stub cannot outlive this test: it is a module
+            # global, and test_lan_access_settings.py reads the real one
+            monkeypatch.setattr(
+                lan_access, "lan_listener_status",
+                lambda t = transport: {
+                    "running": True, "port": t["server"][1],
+                    "addresses": [t["server"][0]], "error": None},
+            )
+            for credential_name, token in (("api_key", raw_key), ("session", session)):
+                headers = dict(transport.get("headers") or {})
+                headers["Authorization"] = f"Bearer {token}"
+                request = request_for(
+                    server = transport["server"], client = transport["client"],
+                    state = transport["state"], headers = headers,
+                )
+                credentials = resolve(request)
+                assert credentials.scheme not in (KEYLESS_SCHEME, KEYLESS_FALLBACK_SCHEME), (
+                    f"{credential_name} was downgraded to keyless on {label}/{scope_name}"
+                )
+                assert asyncio.run(get_current_subject(credentials)) == \
+                    storage.DEFAULT_ADMIN_USERNAME, (
+                        f"{credential_name} stopped working on {label}/{scope_name}"
+                    )
+
+    # and the credentials that must NOT work still do not, at the widest scope
+    set_keyless_api_access("full")
+    storage.revoke_api_key(storage.DEFAULT_ADMIN_USERNAME, row["id"])
+    expired, _row = storage.create_api_key(
+        username = storage.DEFAULT_ADMIN_USERNAME, name = "expired",
+        expires_at = (datetime.now(timezone.utc) - timedelta(days = 1)).isoformat(),
+    )
+    for dead in (raw_key, expired):
+        with pytest.raises(HTTPException):
+            asyncio.run(get_current_subject(
+                resolve(request_for(headers = {"Authorization": f"Bearer {dead}"}))
+            ))
+
+
 # ── the reported race, pinned deterministically ──────────────────────────────
 
 def test_revoking_a_key_after_the_admission_snapshot_never_yields_the_admin():

--- a/studio/backend/utils/keyless_api_access.py
+++ b/studio/backend/utils/keyless_api_access.py
@@ -309,12 +309,11 @@ def _full_scope_transport_allowed(request: Any, app_state: Any) -> bool:
 def _repeated_header(request: Any, name: bytes) -> bool:
     """Whether the raw ASGI headers carry ``name`` more than once.
 
-    ``Headers.get()`` returns the first of a repeated header, so a predicate built on it
-    decides on one value while an intermediary may have acted on another. `Host` and
-    `Sec-Fetch-Site` are both security relevant here, so an ambiguous request is refused
-    rather than resolved -- the same rule `asgi_request_is_keyless` already applies to a
-    repeated `Authorization`. h11 rejects a repeated `Host` itself, httptools does not,
-    and neither rejects a repeated `Sec-Fetch-Site`, so this cannot be left to the parser.
+    ``Headers.get()`` returns the first of a repeated header, so a predicate built on it may
+    decide on a different value than an intermediary acted on. An ambiguous request is
+    refused rather than resolved, as `asgi_request_is_keyless` already does for a repeated
+    `Authorization`. h11 rejects a repeated `Host`, httptools does not, and neither rejects a
+    repeated `Sec-Fetch-Site`, so this cannot be left to the parser.
     """
     try:
         headers = request.scope.get("headers") or ()
@@ -326,28 +325,22 @@ def _repeated_header(request: Any, name: bytes) -> bool:
 def _browser_initiated_elsewhere(request: Any) -> bool:
     """Whether a page on another site made this request, as the browser reports it.
 
-    ``Origin`` cannot say: no browser attaches it to a same-origin GET or to a
-    cross-site GET in ``no-cors`` mode, and such a fetch at
-    ``http://127.0.0.1:<port>`` does arrive, since Chromium's Local Network Access
-    (Chrome 141, enforced from 142, replacing the earlier Private Network Access) is the
-    only thing holding it back and Firefox and Safari have shipped no equivalent.
-    ``Sec-Fetch-Site`` is set on every request to a URL the browser considers
-    *potentially trustworthy*, and the ``Sec-`` prefix makes it a forbidden header name,
-    so a page cannot forge it. Absence stays admitted: curl, the OpenAI SDKs and Safari
-    before 16.4 send nothing, and serving them is the point of the setting.
+    ``Origin`` cannot say: no browser attaches it to a same-origin GET or to a cross-site
+    ``no-cors`` GET, and such a fetch at ``http://127.0.0.1:<port>`` does arrive. Only
+    Chromium's Local Network Access (141, enforced from 142, replacing Private Network
+    Access) holds it back; Firefox and Safari ship no equivalent. ``Sec-Fetch-Site`` is set
+    on every request to a URL the browser considers *potentially trustworthy*, and the
+    ``Sec-`` prefix makes it unforgeable. Absence stays admitted: curl, the OpenAI SDKs and
+    Safari before 16.4 send nothing, and serving them is the point of the setting.
 
-    Two limits are worth stating, because the header is weaker than it first appears:
+    Two limits, because the header is weaker than it first appears:
 
-    * Absence only *means* "not a browser" where the URL is potentially trustworthy.
-      `_host_authority_is_direct` is what keeps the authority inside that set; on the
-      plain-HTTP private-LAN limb no such URL exists, so this predicate is structurally
-      inert there and the `Origin` check above is the only browser signal left.
-    * ``none`` is not admitted. The comment it used to carry -- "the user typing the URL,
-      which no page can cause" -- is true of a page and false of a server: ``none`` is
-      computed before the redirect chain is walked, so an attacker-controlled 302 from a
-      user-initiated navigation lands here still saying ``none``. Measured live: Firefox
-      153 and WebKit 26.5 both deliver it. Nobody types an API route into an address bar,
-      so refusing it costs nothing.
+    * Absence only *means* "not a browser" where the URL is potentially trustworthy, which
+      is what `_host_authority_is_direct` enforces. On the plain-HTTP private-LAN limb no
+      such URL exists, so this predicate is inert there and `Origin` is the only signal left.
+    * ``none`` is refused. It is computed before the redirect chain is walked, so an
+      attacker-controlled 302 from a user-initiated navigation still arrives saying ``none``
+      (measured: Firefox 153, WebKit 26.5). Nobody types an API route into an address bar.
     """
     if _repeated_header(request, b"sec-fetch-site"):
         return True
@@ -368,41 +361,36 @@ def _port_suffix_is_numeric(suffix: str) -> bool:
 def _host_authority_is_direct(request: Any, scope: str) -> bool:
     """Whether the caller addressed this server directly rather than through a name.
 
-    Guards DNS rebinding, which the socket checks cannot see: a page on
-    ``evil.example`` re-pointed at ``127.0.0.1`` keeps its own origin, so every
-    signal above reads as a local client and the response is readable by the page.
-    ``Host`` still differs, being the name the page was served from. A direct client
-    sends the literal address or ``localhost``; anything else is a name, whether a
-    rebound domain or a legitimate mDNS / internal-DNS / reverse-proxy alias -- keyless
-    declines both, matching `lan_access_settings`, which likewise never trusts a name.
+    Guards DNS rebinding, which the socket checks cannot see: a page on ``evil.example``
+    re-pointed at ``127.0.0.1`` keeps its own origin, so every signal above reads as a local
+    client and the response is readable by the page. ``Host`` still names the site the page
+    was served from. A direct client sends the literal address or ``localhost``; anything
+    else is a name, whether rebound or a legitimate mDNS / internal-DNS / reverse-proxy
+    alias -- keyless declines both, as `lan_access_settings` also never trusts a name.
     Absent stays admitted: HTTP/1.0 callers send none and no browser omits it.
 
-    The literal is matched as written rather than canonicalised, because this predicate
-    and the browser have to agree on what "loopback" spells. Two families are refused
-    for exactly that reason, both measured reaching a ``127.0.0.1`` listener while the
-    browser sent no ``Sec-Fetch-*`` at all, since neither is inside the potentially
-    trustworthy set (``127.0.0.0/8`` and ``::1/128``):
+    The literal is matched as written rather than canonicalised, because this predicate and
+    the browser must agree on how "loopback" is spelled. Two families are refused for that
+    reason, both measured reaching a ``127.0.0.1`` listener while the browser sent no
+    ``Sec-Fetch-*`` at all, neither being potentially trustworthy (``127.0.0.0/8``, ``::1/128``):
 
-    * IPv4-mapped IPv6 -- ``[::ffff:127.0.0.1]``, ``[::ffff:7f00:1]``. Chromium 151,
-      Firefox 153 and WebKit 26.5 all sent the request with no Fetch Metadata.
-    * the unspecified addresses ``0.0.0.0`` and ``[::]``, which connect to loopback on
-      Linux. Chromium sent these with no Fetch Metadata too.
+    * IPv4-mapped IPv6 -- ``[::ffff:127.0.0.1]``, ``[::ffff:7f00:1]`` -- on Chromium 151,
+      Firefox 153 and WebKit 26.5.
+    * the unspecified ``0.0.0.0`` and ``[::]``, which connect to loopback on Linux.
 
-    Canonicalising them, as a general purpose address normaliser would, is what turned
-    absence-means-not-a-browser into a bypass, so the parsing is done here rather than
-    through `lan_access_settings._normalized_ip`, whose leniency is correct for the
-    socket addresses it was written for and wrong for an authority off the wire.
+    Canonicalising them, as a general purpose normaliser would, is what turned
+    absence-means-not-a-browser into a bypass, so parsing happens here rather than through
+    `lan_access_settings._normalized_ip`, whose leniency suits the socket addresses it was
+    written for and not an authority off the wire.
 
-    The literal must also be one the scope could legitimately be reached at. Being an
-    address rather than a name is not enough: the socket checks see only the hop that
-    connected, so an SSH forward or a reverse proxy in front of a loopback bind makes
-    both ASGI endpoints loopback while the browser's own origin, and therefore ``Host``,
-    is the public address the page was served from. ``full`` is loopback-only by
-    construction (`_full_scope_transport_allowed` demands a loopback bind and a loopback
-    peer), so its authority must be loopback too; ``inference`` may additionally be
-    reached across the private LAN, so it takes the same private networks
-    `lan_access_settings` admits. Note this cannot be spelled with `is_private`, which
-    means "not globally reachable" and so counts the documentation ranges in as well.
+    The literal must also be one ``scope`` could legitimately be reached at. The socket
+    checks see only the hop that connected, so an SSH forward or a reverse proxy in front of
+    a loopback bind makes both ASGI endpoints loopback while ``Host`` is the public address
+    the page came from. ``full`` is loopback-only by construction
+    (`_full_scope_transport_allowed` demands a loopback bind and peer), so its authority must
+    be loopback too; ``inference`` may also be reached across the private LAN. This cannot be
+    spelled with `is_private`, which means "not globally reachable" and counts the
+    documentation ranges in as well.
     """
     import ipaddress
 
@@ -433,12 +421,11 @@ def _host_authority_is_direct(request: Any, scope: str) -> bool:
         if separator and not _port_suffix_is_numeric(":" + suffix):
             return False
         literal = literal.lower()
-        # Exactly `localhost`, with no trailing root-label dot. Secure Contexts lists
-        # `localhost.` as trustworthy, but WebKit's check is a plain string compare with
-        # no trailing-dot handling, and measured on WebKit 26.5 a page dialling
-        # `http://localhost.:<port>` sends no `Sec-Fetch-*` at all while Chromium 151 and
-        # Firefox 153 both send `cross-site`. Admitting the dotted form would reopen the
-        # same absence-means-not-a-browser gap on Safari alone. No client spells it.
+        # Exactly `localhost`, no trailing root-label dot. Secure Contexts lists
+        # `localhost.` as trustworthy, but WebKit's check is a plain string compare: measured
+        # on WebKit 26.5 a page dialling `http://localhost.:<port>` sends no `Sec-Fetch-*`
+        # while Chromium 151 and Firefox 153 send `cross-site`, so admitting the dotted form
+        # would reopen the absence gap on Safari alone. No client spells it.
         if literal == "localhost":
             return True
         try:
@@ -452,14 +439,12 @@ def _host_authority_is_direct(request: Any, scope: str) -> bool:
 def keyless_authority_address_allowed(address: Any, scope: str) -> bool:
     """Whether a parsed authority literal is one ``scope`` could be reached at.
 
-    The single place this question is answered, so the admission rule and anything that
-    advertises an address to the user cannot drift apart -- `lan_access_settings`
-    reported a keyless-eligible LAN URL for an IPv4-mapped literal that admission
-    refuses, because it had its own copy of the test.
+    The single place this is answered, so admission and anything that advertises an address
+    to the user cannot drift apart -- `lan_access_settings` reported a keyless-eligible LAN
+    URL for an IPv4-mapped literal admission refuses, having kept its own copy of the test.
 
-    Takes an already-parsed address so the caller keeps responsibility for parsing the
-    spelling faithfully. It must NOT have been canonicalised: the mapped form is refused
-    precisely because the browser does not treat it as loopback, so un-mapping it first
+    Takes an already-parsed address, which must NOT have been canonicalised: the mapped form
+    is refused precisely because the browser does not treat it as loopback, so un-mapping it
     erases the distinction being tested.
     """
     from utils.lan_access_settings import _private_non_loopback
@@ -591,13 +576,12 @@ def asgi_request_is_keyless(asgi_scope) -> bool:
         return True
     if len(authorization) != 1:
         return False
-    # The same parser the dependency uses, rather than a second hand-rolled split. They
-    # disagreed on `Authorization: bearer  not-needed`: `partition(" ")` leaves the token
-    # as " not-needed" and reported not-keyless, while the dependency collapsed the extra
-    # space, admitted the dummy, and returned KeylessBearer. The request was therefore
-    # keyless to every route and not-keyless to `KeylessToolPolicyMiddleware`, which is
-    # what decides whether to clamp the tool grant -- so that one shape reached keyless
-    # admission carrying an unclamped tool policy. Sharing the parser removes the class.
+    # The same parser the dependency uses, not a second hand-rolled split. They disagreed on
+    # `Authorization: bearer  not-needed`: `partition(" ")` left the token as " not-needed"
+    # and reported not-keyless, while the dependency collapsed the space and admitted the
+    # dummy. That shape was therefore keyless to every route but not-keyless to
+    # `KeylessToolPolicyMiddleware`, which decides whether to clamp the tool grant, so it
+    # reached keyless admission with an unclamped tool policy.
     from fastapi.security.utils import get_authorization_scheme_param
 
     scheme, token = get_authorization_scheme_param(authorization[0])

--- a/studio/backend/utils/keyless_api_access.py
+++ b/studio/backend/utils/keyless_api_access.py
@@ -330,16 +330,12 @@ def _browser_initiated_elsewhere(request: Any) -> bool:
 def _host_authority_is_direct(request: Any) -> bool:
     """Whether the caller addressed this server directly rather than through a name.
 
-    Guards DNS rebinding, which the socket checks cannot see. A page on
-    ``evil.example`` whose record is re-pointed at ``127.0.0.1`` keeps its own
-    origin, so its fetch is same-origin: no ``Origin``, ``Sec-Fetch-Site:
-    same-origin``, and a loopback peer on a loopback socket. Every signal above
-    reads as a local client, and the response is readable by the page.
-
-    ``Host`` is what still differs, since the browser sends the name the page was
-    served from. A direct client sends the literal address or ``localhost``; only a
-    rebound page sends a domain. Absent stays admitted, because the merged suite
-    and HTTP/1.0 callers send none and no browser omits it.
+    Guards DNS rebinding, which the socket checks cannot see: a page on
+    ``evil.example`` re-pointed at ``127.0.0.1`` keeps its own origin, so every
+    signal above reads as a local client and the response is readable by the page.
+    ``Host`` still differs, being the name the page was served from. A direct client
+    sends the literal address or ``localhost``; only a rebound page sends a domain.
+    Absent stays admitted: HTTP/1.0 callers send none and no browser omits it.
     """
     from utils.lan_access_settings import _normalized_ip
 

--- a/studio/backend/utils/keyless_api_access.py
+++ b/studio/backend/utils/keyless_api_access.py
@@ -309,17 +309,13 @@ def _full_scope_transport_allowed(request: Any, app_state: Any) -> bool:
 def _browser_initiated_elsewhere(request: Any) -> bool:
     """Whether a page on another site made this request, as the browser reports it.
 
-    ``Origin`` alone does not answer that. No browser attaches it to a same-origin
-    GET, nor to a cross-site GET issued in ``no-cors`` mode -- and a ``no-cors``
-    fetch at ``http://127.0.0.1:<port>`` really does arrive, since only Chromium
-    holds those back with Private Network Access. So the Origin rule below sees
-    nothing, and the page gets a keyless request it did not have to authenticate.
-
-    ``Sec-Fetch-Site`` closes that: the browser sets it on every request whatever
-    the mode, and a page cannot forge it, because the ``Sec-`` prefix makes it a
-    forbidden header name. Absence has to stay admitted -- curl, the OpenAI SDKs
-    and Safari before 16.4 all send nothing, and the whole point of the setting is
-    to serve them -- so this only ever narrows what a browser can reach.
+    ``Origin`` cannot say: no browser attaches it to a same-origin GET or to a
+    cross-site GET in ``no-cors`` mode, and such a fetch at
+    ``http://127.0.0.1:<port>`` does arrive, since only Chromium holds it back with
+    Private Network Access. ``Sec-Fetch-Site`` is set on every request whatever the
+    mode, and the ``Sec-`` prefix makes it a forbidden header name, so a page cannot
+    forge it. Absence stays admitted: curl, the OpenAI SDKs and Safari before 16.4
+    send nothing, and serving them is the point of the setting.
     """
     try:
         site = request.headers.get("sec-fetch-site")

--- a/studio/backend/utils/keyless_api_access.py
+++ b/studio/backend/utils/keyless_api_access.py
@@ -365,7 +365,7 @@ def _port_suffix_is_numeric(suffix: str) -> bool:
     return len(suffix) > 1 and suffix[0] == ":" and suffix[1:].isdigit()
 
 
-def _host_authority_is_direct(request: Any) -> bool:
+def _host_authority_is_direct(request: Any, scope: str) -> bool:
     """Whether the caller addressed this server directly rather than through a name.
 
     Guards DNS rebinding, which the socket checks cannot see: a page on
@@ -392,8 +392,21 @@ def _host_authority_is_direct(request: Any) -> bool:
     absence-means-not-a-browser into a bypass, so the parsing is done here rather than
     through `lan_access_settings._normalized_ip`, whose leniency is correct for the
     socket addresses it was written for and wrong for an authority off the wire.
+
+    The literal must also be one the scope could legitimately be reached at. Being an
+    address rather than a name is not enough: the socket checks see only the hop that
+    connected, so an SSH forward or a reverse proxy in front of a loopback bind makes
+    both ASGI endpoints loopback while the browser's own origin, and therefore ``Host``,
+    is the public address the page was served from. ``full`` is loopback-only by
+    construction (`_full_scope_transport_allowed` demands a loopback bind and a loopback
+    peer), so its authority must be loopback too; ``inference`` may additionally be
+    reached across the private LAN, so it takes the same private networks
+    `lan_access_settings` admits. Note this cannot be spelled with `is_private`, which
+    means "not globally reachable" and so counts the documentation ranges in as well.
     """
     import ipaddress
+
+    from utils.lan_access_settings import _private_non_loopback
 
     if _repeated_header(request, b"host"):
         return False
@@ -435,7 +448,11 @@ def _host_authority_is_direct(request: Any) -> bool:
             return False
     if address.is_unspecified:
         return False
-    return getattr(address, "ipv4_mapped", None) is None
+    if getattr(address, "ipv4_mapped", None) is not None:
+        return False
+    if address.is_loopback:
+        return True
+    return scope == KEYLESS_SCOPE_INFERENCE and _private_non_loopback(address)
 
 
 def keyless_transport_allowed(request: Any, scope: str) -> bool:
@@ -447,7 +464,7 @@ def keyless_transport_allowed(request: Any, scope: str) -> bool:
         return False
     if _browser_initiated_elsewhere(request):
         return False
-    if not _host_authority_is_direct(request):
+    if not _host_authority_is_direct(request, scope):
         return False
     app_state = _request_app_state(request)
     if _hosted_mode_forbidden(app_state):

--- a/studio/backend/utils/keyless_api_access.py
+++ b/studio/backend/utils/keyless_api_access.py
@@ -306,25 +306,63 @@ def _full_scope_transport_allowed(request: Any, app_state: Any) -> bool:
     )
 
 
+def _repeated_header(request: Any, name: bytes) -> bool:
+    """Whether the raw ASGI headers carry ``name`` more than once.
+
+    ``Headers.get()`` returns the first of a repeated header, so a predicate built on it
+    decides on one value while an intermediary may have acted on another. `Host` and
+    `Sec-Fetch-Site` are both security relevant here, so an ambiguous request is refused
+    rather than resolved -- the same rule `asgi_request_is_keyless` already applies to a
+    repeated `Authorization`. h11 rejects a repeated `Host` itself, httptools does not,
+    and neither rejects a repeated `Sec-Fetch-Site`, so this cannot be left to the parser.
+    """
+    try:
+        headers = request.scope.get("headers") or ()
+        return sum(1 for key, _ in headers if key.lower() == name) > 1
+    except Exception:
+        return True
+
+
 def _browser_initiated_elsewhere(request: Any) -> bool:
     """Whether a page on another site made this request, as the browser reports it.
 
     ``Origin`` cannot say: no browser attaches it to a same-origin GET or to a
     cross-site GET in ``no-cors`` mode, and such a fetch at
-    ``http://127.0.0.1:<port>`` does arrive, since only Chromium holds it back with
-    Private Network Access. ``Sec-Fetch-Site`` is set on every request whatever the
-    mode, and the ``Sec-`` prefix makes it a forbidden header name, so a page cannot
-    forge it. Absence stays admitted: curl, the OpenAI SDKs and Safari before 16.4
-    send nothing, and serving them is the point of the setting.
+    ``http://127.0.0.1:<port>`` does arrive, since Chromium's Local Network Access
+    (Chrome 141, enforced from 142, replacing the earlier Private Network Access) is the
+    only thing holding it back and Firefox and Safari have shipped no equivalent.
+    ``Sec-Fetch-Site`` is set on every request to a URL the browser considers
+    *potentially trustworthy*, and the ``Sec-`` prefix makes it a forbidden header name,
+    so a page cannot forge it. Absence stays admitted: curl, the OpenAI SDKs and Safari
+    before 16.4 send nothing, and serving them is the point of the setting.
+
+    Two limits are worth stating, because the header is weaker than it first appears:
+
+    * Absence only *means* "not a browser" where the URL is potentially trustworthy.
+      `_host_authority_is_direct` is what keeps the authority inside that set; on the
+      plain-HTTP private-LAN limb no such URL exists, so this predicate is structurally
+      inert there and the `Origin` check above is the only browser signal left.
+    * ``none`` is not admitted. The comment it used to carry -- "the user typing the URL,
+      which no page can cause" -- is true of a page and false of a server: ``none`` is
+      computed before the redirect chain is walked, so an attacker-controlled 302 from a
+      user-initiated navigation lands here still saying ``none``. Measured live: Firefox
+      153 and WebKit 26.5 both deliver it. Nobody types an API route into an address bar,
+      so refusing it costs nothing.
     """
+    if _repeated_header(request, b"sec-fetch-site"):
+        return True
     try:
         site = request.headers.get("sec-fetch-site")
     except Exception:
-        return True
+        return True  # unreadable headers: deny
     if site is None:
         return False
-    # `none` is the user typing the URL or opening a bookmark, which no page can cause.
-    return site.strip().lower() not in ("same-origin", "none")
+    return site.strip().lower() != "same-origin"
+
+
+def _port_suffix_is_numeric(suffix: str) -> bool:
+    """Whether ``suffix`` is a well formed ``:<port>`` tail, the only tail an authority has."""
+    return len(suffix) > 1 and suffix[0] == ":" and suffix[1:].isdigit()
 
 
 def _host_authority_is_direct(request: Any) -> bool:
@@ -334,27 +372,70 @@ def _host_authority_is_direct(request: Any) -> bool:
     ``evil.example`` re-pointed at ``127.0.0.1`` keeps its own origin, so every
     signal above reads as a local client and the response is readable by the page.
     ``Host`` still differs, being the name the page was served from. A direct client
-    sends the literal address or ``localhost``; only a rebound page sends a domain.
+    sends the literal address or ``localhost``; anything else is a name, whether a
+    rebound domain or a legitimate mDNS / internal-DNS / reverse-proxy alias -- keyless
+    declines both, matching `lan_access_settings`, which likewise never trusts a name.
     Absent stays admitted: HTTP/1.0 callers send none and no browser omits it.
-    """
-    from utils.lan_access_settings import _normalized_ip
 
+    The literal is matched as written rather than canonicalised, because this predicate
+    and the browser have to agree on what "loopback" spells. Two families are refused
+    for exactly that reason, both measured reaching a ``127.0.0.1`` listener while the
+    browser sent no ``Sec-Fetch-*`` at all, since neither is inside the potentially
+    trustworthy set (``127.0.0.0/8`` and ``::1/128``):
+
+    * IPv4-mapped IPv6 -- ``[::ffff:127.0.0.1]``, ``[::ffff:7f00:1]``. Chromium 151,
+      Firefox 153 and WebKit 26.5 all sent the request with no Fetch Metadata.
+    * the unspecified addresses ``0.0.0.0`` and ``[::]``, which connect to loopback on
+      Linux. Chromium sent these with no Fetch Metadata too.
+
+    Canonicalising them, as a general purpose address normaliser would, is what turned
+    absence-means-not-a-browser into a bypass, so the parsing is done here rather than
+    through `lan_access_settings._normalized_ip`, whose leniency is correct for the
+    socket addresses it was written for and wrong for an authority off the wire.
+    """
+    import ipaddress
+
+    if _repeated_header(request, b"host"):
+        return False
     try:
         host = request.headers.get("host")
     except Exception:
-        return False
+        return False  # unreadable headers: deny
     if not host:
         return True
     host = host.strip()
-    if host.startswith("["):  # [::1] or [::1]:port, rejecting junk after the bracket
+    if host.startswith("["):
         end = host.find("]")
-        if end == -1 or (host[end + 1 :] and not host[end + 1 :].startswith(":")):
+        if end == -1:
             return False
-        host = host[1:end]
-    elif host.count(":") == 1:
-        host = host.split(":", 1)[0]
-    host = host.lower().rstrip(".")
-    return host == "localhost" or _normalized_ip(host) is not None
+        suffix = host[end + 1 :]
+        if suffix and not _port_suffix_is_numeric(suffix):
+            return False
+        try:
+            address = ipaddress.IPv6Address(host[1:end])
+        except ValueError:
+            return False
+    else:
+        literal, separator, suffix = host.partition(":")
+        if separator and not _port_suffix_is_numeric(":" + suffix):
+            return False
+        literal = literal.lower()
+        # Exactly `localhost`, with no trailing root-label dot. Secure Contexts lists
+        # `localhost.` as trustworthy, but WebKit's check is a plain string compare with
+        # no trailing-dot handling, and measured on WebKit 26.5 a page dialling
+        # `http://localhost.:<port>` sends no `Sec-Fetch-*` at all while Chromium 151 and
+        # Firefox 153 both send `cross-site`. Admitting the dotted form would reopen the
+        # same absence-means-not-a-browser gap on Safari alone. No client spells it.
+        if literal == "localhost":
+            return True
+        try:
+            # Unbracketed IPv6 is not a legal authority, so IPv4 only here.
+            address = ipaddress.IPv4Address(literal)
+        except ValueError:
+            return False
+    if address.is_unspecified:
+        return False
+    return getattr(address, "ipv4_mapped", None) is None
 
 
 def keyless_transport_allowed(request: Any, scope: str) -> bool:
@@ -473,5 +554,14 @@ def asgi_request_is_keyless(asgi_scope) -> bool:
         return True
     if len(authorization) != 1:
         return False
-    scheme, separator, token = authorization[0].partition(" ")
-    return bool(separator and scheme.lower() == "bearer" and token in APPROVED_DUMMY_BEARERS)
+    # The same parser the dependency uses, rather than a second hand-rolled split. They
+    # disagreed on `Authorization: bearer  not-needed`: `partition(" ")` leaves the token
+    # as " not-needed" and reported not-keyless, while the dependency collapsed the extra
+    # space, admitted the dummy, and returned KeylessBearer. The request was therefore
+    # keyless to every route and not-keyless to `KeylessToolPolicyMiddleware`, which is
+    # what decides whether to clamp the tool grant -- so that one shape reached keyless
+    # admission carrying an unclamped tool policy. Sharing the parser removes the class.
+    from fastapi.security.utils import get_authorization_scheme_param
+
+    scheme, token = get_authorization_scheme_param(authorization[0])
+    return bool(scheme.lower() == "bearer" and token in APPROVED_DUMMY_BEARERS)

--- a/studio/backend/utils/keyless_api_access.py
+++ b/studio/backend/utils/keyless_api_access.py
@@ -446,6 +446,26 @@ def _host_authority_is_direct(request: Any, scope: str) -> bool:
             address = ipaddress.IPv4Address(literal)
         except ValueError:
             return False
+    return keyless_authority_address_allowed(address, scope)
+
+
+def keyless_authority_address_allowed(address: Any, scope: str) -> bool:
+    """Whether a parsed authority literal is one ``scope`` could be reached at.
+
+    The single place this question is answered, so the admission rule and anything that
+    advertises an address to the user cannot drift apart -- `lan_access_settings`
+    reported a keyless-eligible LAN URL for an IPv4-mapped literal that admission
+    refuses, because it had its own copy of the test.
+
+    Takes an already-parsed address so the caller keeps responsibility for parsing the
+    spelling faithfully. It must NOT have been canonicalised: the mapped form is refused
+    precisely because the browser does not treat it as loopback, so un-mapping it first
+    erases the distinction being tested.
+    """
+    from utils.lan_access_settings import _private_non_loopback
+
+    if address is None:
+        return False
     if address.is_unspecified:
         return False
     if getattr(address, "ipv4_mapped", None) is not None:

--- a/studio/backend/utils/keyless_api_access.py
+++ b/studio/backend/utils/keyless_api_access.py
@@ -306,12 +306,39 @@ def _full_scope_transport_allowed(request: Any, app_state: Any) -> bool:
     )
 
 
+def _browser_initiated_elsewhere(request: Any) -> bool:
+    """Whether a page on another site made this request, as the browser reports it.
+
+    ``Origin`` alone does not answer that. No browser attaches it to a same-origin
+    GET, nor to a cross-site GET issued in ``no-cors`` mode -- and a ``no-cors``
+    fetch at ``http://127.0.0.1:<port>`` really does arrive, since only Chromium
+    holds those back with Private Network Access. So the Origin rule below sees
+    nothing, and the page gets a keyless request it did not have to authenticate.
+
+    ``Sec-Fetch-Site`` closes that: the browser sets it on every request whatever
+    the mode, and a page cannot forge it, because the ``Sec-`` prefix makes it a
+    forbidden header name. Absence has to stay admitted -- curl, the OpenAI SDKs
+    and Safari before 16.4 all send nothing, and the whole point of the setting is
+    to serve them -- so this only ever narrows what a browser can reach.
+    """
+    try:
+        site = request.headers.get("sec-fetch-site")
+    except Exception:
+        return True
+    if site is None:
+        return False
+    # `none` is the user typing the URL or opening a bookmark, which no page can cause.
+    return site.strip().lower() not in ("same-origin", "none")
+
+
 def keyless_transport_allowed(request: Any, scope: str) -> bool:
     """Enforce the loopback/private-LAN boundary from authoritative ASGI state."""
     try:
         if request.headers.get("origin") is not None:
             return False
     except Exception:
+        return False
+    if _browser_initiated_elsewhere(request):
         return False
     app_state = _request_app_state(request)
     if _hosted_mode_forbidden(app_state):

--- a/studio/backend/utils/keyless_api_access.py
+++ b/studio/backend/utils/keyless_api_access.py
@@ -327,6 +327,40 @@ def _browser_initiated_elsewhere(request: Any) -> bool:
     return site.strip().lower() not in ("same-origin", "none")
 
 
+def _host_authority_is_direct(request: Any) -> bool:
+    """Whether the caller addressed this server directly rather than through a name.
+
+    Guards DNS rebinding, which the socket checks cannot see. A page on
+    ``evil.example`` whose record is re-pointed at ``127.0.0.1`` keeps its own
+    origin, so its fetch is same-origin: no ``Origin``, ``Sec-Fetch-Site:
+    same-origin``, and a loopback peer on a loopback socket. Every signal above
+    reads as a local client, and the response is readable by the page.
+
+    ``Host`` is what still differs, since the browser sends the name the page was
+    served from. A direct client sends the literal address or ``localhost``; only a
+    rebound page sends a domain. Absent stays admitted, because the merged suite
+    and HTTP/1.0 callers send none and no browser omits it.
+    """
+    from utils.lan_access_settings import _normalized_ip
+
+    try:
+        host = request.headers.get("host")
+    except Exception:
+        return False
+    if not host:
+        return True
+    host = host.strip()
+    if host.startswith("["):  # [::1] or [::1]:port, rejecting junk after the bracket
+        end = host.find("]")
+        if end == -1 or (host[end + 1 :] and not host[end + 1 :].startswith(":")):
+            return False
+        host = host[1:end]
+    elif host.count(":") == 1:
+        host = host.split(":", 1)[0]
+    host = host.lower().rstrip(".")
+    return host == "localhost" or _normalized_ip(host) is not None
+
+
 def keyless_transport_allowed(request: Any, scope: str) -> bool:
     """Enforce the loopback/private-LAN boundary from authoritative ASGI state."""
     try:
@@ -335,6 +369,8 @@ def keyless_transport_allowed(request: Any, scope: str) -> bool:
     except Exception:
         return False
     if _browser_initiated_elsewhere(request):
+        return False
+    if not _host_authority_is_direct(request):
         return False
     app_state = _request_app_state(request)
     if _hosted_mode_forbidden(app_state):

--- a/studio/backend/utils/lan_access_settings.py
+++ b/studio/backend/utils/lan_access_settings.py
@@ -274,12 +274,22 @@ def _public_urls(urls: list[str], resolved_addresses: tuple[str, ...] = ()) -> l
 
 
 def _has_keyless_lan_url(urls: list[str]) -> bool:
+    """Whether any of these URLs is one a keyless caller can actually reach.
+
+    Resolution alone is not enough. `keyless_api_access._host_authority_is_direct`
+    refuses a `Host` that names anything, so a launch bound to a hostname produces a URL
+    that resolves to a private address and is still refused. Reporting it as eligible is
+    what made the LAN panel and the usage examples advertise `Bearer not-needed` against
+    a URL that answers 401, so the literal is required here too.
+    """
     from urllib.parse import urlparse
     for url in urls:
         parsed = urlparse(url)
-        if parsed.hostname and _all_addresses_are(
-            parsed.hostname, parsed.port or 80, _private_non_loopback
-        ):
+        if not parsed.hostname:
+            continue
+        if _normalized_ip(parsed.hostname) is None:
+            continue
+        if _all_addresses_are(parsed.hostname, parsed.port or 80, _private_non_loopback):
             return True
     return False
 

--- a/studio/backend/utils/lan_access_settings.py
+++ b/studio/backend/utils/lan_access_settings.py
@@ -283,6 +283,7 @@ def _has_keyless_lan_url(urls: list[str]) -> bool:
     a URL that answers 401, so the literal is required here too.
     """
     from urllib.parse import urlparse
+
     for url in urls:
         parsed = urlparse(url)
         if not parsed.hostname:

--- a/studio/backend/utils/lan_access_settings.py
+++ b/studio/backend/utils/lan_access_settings.py
@@ -276,17 +276,15 @@ def _public_urls(urls: list[str], resolved_addresses: tuple[str, ...] = ()) -> l
 def _has_keyless_lan_url(urls: list[str]) -> bool:
     """Whether any of these URLs is one a keyless caller can actually reach.
 
-    Resolution alone is not enough. `keyless_api_access._host_authority_is_direct`
-    refuses a `Host` that names anything, so a launch bound to a hostname produces a URL
-    that resolves to a private address and is still refused. Reporting it as eligible is
-    what made the LAN panel and the usage examples advertise `Bearer not-needed` against
-    a URL that answers 401, so the literal is required here too.
+    Resolution alone is not enough: `keyless_api_access._host_authority_is_direct` refuses a
+    `Host` that names anything, so a hostname bind yields a URL that resolves to a private
+    address and is still refused. Reporting it eligible is what made the LAN panel advertise
+    `Bearer not-needed` against a URL that answers 401, so the literal is required here too.
 
-    Admission decides this, through the shared
-    `keyless_api_access.keyless_authority_address_allowed`. A second copy of the test is
-    what let an IPv4-mapped literal such as `::ffff:192.168.1.24` be advertised while
-    admission refused it: `_normalized_ip` un-maps, and un-mapping is exactly what the
-    mapped form is refused for. So the literal is parsed here as written.
+    Admission decides, through the shared
+    `keyless_api_access.keyless_authority_address_allowed`. A second copy of the test is what
+    let an IPv4-mapped literal like `::ffff:192.168.1.24` be advertised while admission
+    refused it: `_normalized_ip` un-maps, which is exactly what that form is refused for.
     """
     import ipaddress
     from urllib.parse import urlparse

--- a/studio/backend/utils/lan_access_settings.py
+++ b/studio/backend/utils/lan_access_settings.py
@@ -281,14 +281,32 @@ def _has_keyless_lan_url(urls: list[str]) -> bool:
     that resolves to a private address and is still refused. Reporting it as eligible is
     what made the LAN panel and the usage examples advertise `Bearer not-needed` against
     a URL that answers 401, so the literal is required here too.
+
+    Admission decides this, through the shared
+    `keyless_api_access.keyless_authority_address_allowed`. A second copy of the test is
+    what let an IPv4-mapped literal such as `::ffff:192.168.1.24` be advertised while
+    admission refused it: `_normalized_ip` un-maps, and un-mapping is exactly what the
+    mapped form is refused for. So the literal is parsed here as written.
     """
+    import ipaddress
     from urllib.parse import urlparse
+
+    from utils.keyless_api_access import (
+        KEYLESS_SCOPE_INFERENCE,
+        keyless_authority_address_allowed,
+    )
 
     for url in urls:
         parsed = urlparse(url)
         if not parsed.hostname:
             continue
-        if _normalized_ip(parsed.hostname) is None:
+        try:
+            # urlparse already strips the IPv6 brackets and lowercases; parse the
+            # remaining literal without normalising it
+            address = ipaddress.ip_address(parsed.hostname)
+        except ValueError:
+            continue
+        if not keyless_authority_address_allowed(address, KEYLESS_SCOPE_INFERENCE):
             continue
         if _all_addresses_are(parsed.hostname, parsed.port or 80, _private_non_loopback):
             return True

--- a/studio/frontend/src/features/settings/components/keyless-api-access-section.tsx
+++ b/studio/frontend/src/features/settings/components/keyless-api-access-section.tsx
@@ -84,6 +84,7 @@ export function KeylessApiAccessSection({
   const [saving, setSaving] = useState(false);
   const [pending, setPending] = useState<PendingGrant | null>(null);
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: cloudflareUrl is a trigger, not an input -- exposure is recomputed by the backend when a tunnel appears or goes away
   useEffect(() => {
     let cancelled = false;
     loadKeylessApiAccess()

--- a/studio/frontend/src/features/settings/components/keyless-example-eligibility.ts
+++ b/studio/frontend/src/features/settings/components/keyless-example-eligibility.ts
@@ -12,14 +12,11 @@
  * by a unit test instead of by scraping the source.
  */
 
+import type {
+  KeylessApiAccessExposure,
+  KeylessApiAccessScope,
+} from "../api/keyless-api-access.ts";
 import { isLoopbackHost, normalizeHost } from "./agent-command.ts";
-
-export type KeylessScope = "off" | "inference" | "full";
-export type KeylessExposure =
-  | "loopback"
-  | "private_lan"
-  | "public_url"
-  | "colab";
 
 // Same networks as the backend's _PRIVATE_LAN_NETWORKS.
 export function isPrivateLanHost(hostname: string): boolean {
@@ -78,8 +75,8 @@ export function isKeylessAllowedAuthority(hostname: string): boolean {
 
 export function keylessBaseEligible(
   base: string,
-  scope: KeylessScope,
-  exposure: KeylessExposure | null,
+  scope: KeylessApiAccessScope,
+  exposure: KeylessApiAccessExposure | null,
 ): boolean {
   if (scope === "off" || exposure === "colab" || exposure === "public_url") {
     return false;

--- a/studio/frontend/src/features/settings/components/keyless-example-eligibility.ts
+++ b/studio/frontend/src/features/settings/components/keyless-example-eligibility.ts
@@ -5,11 +5,11 @@
  * Whether a base URL is one the keyless usage example may be printed for.
  *
  * Mirror of `keyless_api_access.keyless_authority_address_allowed`: loopback always,
- * private LAN under `inference`, and nothing else. If the panel says yes where admission
- * says no, it renders a copy-paste `Bearer not-needed` command that answers 401.
+ * private LAN under `inference`, nothing else. If the panel says yes where admission says
+ * no, it renders a copy-paste `Bearer not-needed` command that answers 401.
  *
- * Its own module, free of the component's react/shiki graph, so the table can be pinned
- * by a unit test instead of by scraping the source.
+ * Its own module, free of the component's react/shiki graph, so a unit test can pin the
+ * table instead of scraping the source.
  */
 
 import type {
@@ -21,9 +21,9 @@ import { isLoopbackHost, normalizeHost } from "./agent-command.ts";
 // Same networks as the backend's _PRIVATE_LAN_NETWORKS.
 export function isPrivateLanHost(hostname: string): boolean {
   const host = normalizeHost(hostname).toLowerCase();
-  // No IPv4-mapped unwrapping. Admission refuses the mapped form precisely because
-  // unwrapping is what the browser will not do, so a helper that unwraps answers the
-  // wrong question -- that is how the panel came to advertise a mapped literal.
+  // No IPv4-mapped unwrapping: admission refuses that form precisely because the browser
+  // will not unwrap it, so a helper that does answers the wrong question. That is how the
+  // panel came to advertise a mapped literal.
   const ipv4 = host.split(".").map(Number);
   if (
     ipv4.length === 4 &&
@@ -62,9 +62,9 @@ function isIpv4MappedHost(host: string): boolean {
 }
 
 /**
- * Syntax is not the question. `[::ffff:192.168.1.24]`, `[::]` and `8.8.8.8` are all well
- * formed literals that admission refuses, and checking only that a base LOOKS like an
- * address is what left the panel advertising `Bearer not-needed` for each of them.
+ * Syntax is not the question: `[::ffff:192.168.1.24]`, `[::]` and `8.8.8.8` are all well
+ * formed literals admission refuses. Checking only that a base LOOKS like an address is what
+ * left the panel advertising `Bearer not-needed` for each of them.
  */
 export function isKeylessAllowedAuthority(hostname: string): boolean {
   const host = normalizeHost(hostname).toLowerCase();

--- a/studio/frontend/src/features/settings/components/keyless-example-eligibility.ts
+++ b/studio/frontend/src/features/settings/components/keyless-example-eligibility.ts
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+/**
+ * Whether a base URL is one the keyless usage example may be printed for.
+ *
+ * Mirror of `keyless_api_access.keyless_authority_address_allowed`: loopback always,
+ * private LAN under `inference`, and nothing else. If the panel says yes where admission
+ * says no, it renders a copy-paste `Bearer not-needed` command that answers 401.
+ *
+ * Its own module, free of the component's react/shiki graph, so the table can be pinned
+ * by a unit test instead of by scraping the source.
+ */
+
+import { isLoopbackHost, normalizeHost } from "./agent-command.ts";
+
+export type KeylessScope = "off" | "inference" | "full";
+export type KeylessExposure =
+  | "loopback"
+  | "private_lan"
+  | "public_url"
+  | "colab";
+
+// Same networks as the backend's _PRIVATE_LAN_NETWORKS.
+export function isPrivateLanHost(hostname: string): boolean {
+  const host = normalizeHost(hostname).toLowerCase();
+  // No IPv4-mapped unwrapping. Admission refuses the mapped form precisely because
+  // unwrapping is what the browser will not do, so a helper that unwraps answers the
+  // wrong question -- that is how the panel came to advertise a mapped literal.
+  const ipv4 = host.split(".").map(Number);
+  if (
+    ipv4.length === 4 &&
+    ipv4.every((part) => Number.isInteger(part) && part >= 0 && part <= 255)
+  ) {
+    return (
+      ipv4[0] === 10 ||
+      (ipv4[0] === 172 && ipv4[1] >= 16 && ipv4[1] <= 31) ||
+      (ipv4[0] === 192 && ipv4[1] === 168) ||
+      (ipv4[0] === 169 && ipv4[1] === 254)
+    );
+  }
+  return /^f[cd][0-9a-f]*:/i.test(host) || /^fe[89ab][0-9a-f]*:/i.test(host);
+}
+
+function isIpLiteralHost(host: string): boolean {
+  const ipv4 = host.split(".");
+  if (
+    ipv4.length === 4 &&
+    ipv4.every((part) => /^\d{1,3}$/.test(part) && Number(part) <= 255)
+  ) {
+    return true;
+  }
+  // normalizeHost has already stripped the URL brackets from an IPv6 authority
+  return host.includes(":") && /^[0-9a-f:.]+$/i.test(host);
+}
+
+// 0.0.0.0 and every all-zero IPv6 spelling.
+function isUnspecifiedHost(host: string): boolean {
+  return host === "0.0.0.0" || (host.includes(":") && /^[0:]+$/.test(host));
+}
+
+// The serializer emits "::ffff:7f00:1"; the expanded form is matched too.
+function isIpv4MappedHost(host: string): boolean {
+  return host.startsWith("::ffff:") || /^(?:0{1,4}:){5}ffff:/i.test(host);
+}
+
+/**
+ * Syntax is not the question. `[::ffff:192.168.1.24]`, `[::]` and `8.8.8.8` are all well
+ * formed literals that admission refuses, and checking only that a base LOOKS like an
+ * address is what left the panel advertising `Bearer not-needed` for each of them.
+ */
+export function isKeylessAllowedAuthority(hostname: string): boolean {
+  const host = normalizeHost(hostname).toLowerCase();
+  if (!isIpLiteralHost(host)) return false;
+  if (isUnspecifiedHost(host) || isIpv4MappedHost(host)) return false;
+  return isLoopbackHost(host) || isPrivateLanHost(host);
+}
+
+export function keylessBaseEligible(
+  base: string,
+  scope: KeylessScope,
+  exposure: KeylessExposure | null,
+): boolean {
+  if (scope === "off" || exposure === "colab" || exposure === "public_url") {
+    return false;
+  }
+  try {
+    const host = normalizeHost(new URL(base).hostname);
+    if (isLoopbackHost(host)) return true;
+    if (!isKeylessAllowedAuthority(host)) return false;
+    // `exposure` is computed from the RESOLVED address, so it must never widen a base the
+    // authority rule rejected; on its own it said nothing about how the caller spelled it.
+    return scope === "inference";
+  } catch {
+    return false;
+  }
+}

--- a/studio/frontend/src/features/settings/components/usage-examples.tsx
+++ b/studio/frontend/src/features/settings/components/usage-examples.tsx
@@ -517,6 +517,26 @@ function isPrivateLanHost(hostname: string): boolean {
   return /^f[cd][0-9a-f]*:/i.test(host) || /^fe[89ab][0-9a-f]*:/i.test(host);
 }
 
+// The backend refuses keyless for any Host that names something rather than addressing
+// the socket (`keyless_api_access._host_authority_is_direct`), so a snippet is only
+// honest when the base is a literal or `localhost`. Without this, a launch bound to a
+// hostname -- `unsloth studio -H box.local`, or simply browsing Studio by its machine
+// name -- still rendered `Bearer not-needed` against a URL that answers 401, because
+// `exposure === "private_lan"` is computed from the RESOLVED address and says nothing
+// about how the caller spelled it.
+function isIpLiteralHost(hostname: string): boolean {
+  const host = normalizeHost(hostname).toLowerCase();
+  const ipv4 = host.split(".");
+  if (
+    ipv4.length === 4 &&
+    ipv4.every((part) => /^\d{1,3}$/.test(part) && Number(part) <= 255)
+  ) {
+    return true;
+  }
+  // normalizeHost has already stripped the URL brackets from an IPv6 authority
+  return host.includes(":") && /^[0-9a-f:.]+$/i.test(host);
+}
+
 function keylessBaseEligible(
   base: string,
   scope: KeylessApiAccessScope,
@@ -528,6 +548,7 @@ function keylessBaseEligible(
   try {
     const host = normalizeHost(new URL(base).hostname);
     if (isLoopbackHost(host)) return true;
+    if (!isIpLiteralHost(host)) return false;
     return (
       scope === "inference" &&
       (isPrivateLanHost(host) || exposure === "private_lan")

--- a/studio/frontend/src/features/settings/components/usage-examples.tsx
+++ b/studio/frontend/src/features/settings/components/usage-examples.tsx
@@ -41,6 +41,7 @@ import {
   isLoopbackHost,
   normalizeHost,
 } from "./agent-command";
+import { keylessBaseEligible } from "./keyless-example-eligibility";
 
 type ExampleType =
   | "curl"
@@ -492,67 +493,6 @@ function canUseLocalAgentDetection(base: string): boolean {
   if (!isTauri) return false;
   try {
     return isLoopbackHost(normalizeHost(new URL(base).hostname));
-  } catch {
-    return false;
-  }
-}
-
-function isPrivateLanHost(hostname: string): boolean {
-  const host = normalizeHost(hostname).toLowerCase();
-  if (host.startsWith("::ffff:")) {
-    return isPrivateLanHost(host.slice("::ffff:".length));
-  }
-  const ipv4 = host.split(".").map(Number);
-  if (
-    ipv4.length === 4 &&
-    ipv4.every((part) => Number.isInteger(part) && part >= 0 && part <= 255)
-  ) {
-    return (
-      ipv4[0] === 10 ||
-      (ipv4[0] === 172 && ipv4[1] >= 16 && ipv4[1] <= 31) ||
-      (ipv4[0] === 192 && ipv4[1] === 168) ||
-      (ipv4[0] === 169 && ipv4[1] === 254)
-    );
-  }
-  return /^f[cd][0-9a-f]*:/i.test(host) || /^fe[89ab][0-9a-f]*:/i.test(host);
-}
-
-// The backend refuses keyless for any Host that names something rather than addressing
-// the socket (`keyless_api_access._host_authority_is_direct`), so a snippet is only
-// honest when the base is a literal or `localhost`. Without this, a launch bound to a
-// hostname -- `unsloth studio -H box.local`, or simply browsing Studio by its machine
-// name -- still rendered `Bearer not-needed` against a URL that answers 401, because
-// `exposure === "private_lan"` is computed from the RESOLVED address and says nothing
-// about how the caller spelled it.
-function isIpLiteralHost(hostname: string): boolean {
-  const host = normalizeHost(hostname).toLowerCase();
-  const ipv4 = host.split(".");
-  if (
-    ipv4.length === 4 &&
-    ipv4.every((part) => /^\d{1,3}$/.test(part) && Number(part) <= 255)
-  ) {
-    return true;
-  }
-  // normalizeHost has already stripped the URL brackets from an IPv6 authority
-  return host.includes(":") && /^[0-9a-f:.]+$/i.test(host);
-}
-
-function keylessBaseEligible(
-  base: string,
-  scope: KeylessApiAccessScope,
-  exposure: KeylessApiAccessExposure | null,
-): boolean {
-  if (scope === "off" || exposure === "colab" || exposure === "public_url") {
-    return false;
-  }
-  try {
-    const host = normalizeHost(new URL(base).hostname);
-    if (isLoopbackHost(host)) return true;
-    if (!isIpLiteralHost(host)) return false;
-    return (
-      scope === "inference" &&
-      (isPrivateLanHost(host) || exposure === "private_lan")
-    );
   } catch {
     return false;
   }

--- a/studio/frontend/tests/keyless-example-base-eligibility.test.ts
+++ b/studio/frontend/tests/keyless-example-base-eligibility.test.ts
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+/**
+ * The keyless usage example must only be offered for a base the backend can admit.
+ *
+ * `keyless_api_access._host_authority_is_direct` refuses any `Host` that names something
+ * rather than addressing the socket, so keyless works when the caller spelled a literal
+ * or `localhost` and not otherwise. `exposure` cannot answer that question: it is
+ * computed backend-side from the RESOLVED address, so a launch bound to a hostname
+ * (`unsloth studio -H box.local`) reports `private_lan` while every request to
+ * `http://box.local:8888` is refused.
+ *
+ * Before this guard the panel rendered a copy-paste
+ *   curl http://box.local:8888/v1/chat/completions -H "Authorization: Bearer not-needed"
+ * that answers 401, and the LAN panel offered the same hostname as a QR code.
+ *
+ * Asserted against the real source rather than a copy, so the two cannot drift.
+ */
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+
+const SOURCE = "src/features/settings/components/usage-examples.tsx";
+
+test("keylessBaseEligible refuses a hostname base before consulting exposure", () => {
+  const source = readFileSync(SOURCE, "utf8");
+
+  // read the function body only, so a comment elsewhere in the file cannot satisfy this
+  const start = source.indexOf("function keylessBaseEligible(");
+  assert.ok(start > 0, "keylessBaseEligible not found");
+  const end = source.indexOf("\n}", start);
+  assert.ok(end > start, "could not delimit keylessBaseEligible");
+  const body = source.slice(start, end);
+
+  const guard = body.indexOf("if (!isIpLiteralHost(host)) return false;");
+  const disjunct = body.indexOf('exposure === "private_lan"');
+  const loopback = body.indexOf("if (isLoopbackHost(host)) return true;");
+
+  assert.ok(guard > 0, "the isIpLiteralHost guard is missing from keylessBaseEligible");
+  assert.ok(disjunct > 0, "the private_lan disjunct is missing");
+  // the guard must run BEFORE the exposure short circuit, which is the clause that made
+  // a hostname eligible in the first place
+  assert.ok(
+    guard < disjunct,
+    "the literal guard must run before exposure can make a hostname eligible",
+  );
+  // and the loopback fast path stays ahead of both, so localhost keeps working
+  assert.ok(loopback > 0 && loopback < guard, "localhost must stay eligible");
+});

--- a/studio/frontend/tests/keyless-example-base-eligibility.test.ts
+++ b/studio/frontend/tests/keyless-example-base-eligibility.test.ts
@@ -2,50 +2,124 @@
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
 /**
- * The keyless usage example must only be offered for a base the backend can admit.
+ * The keyless usage example must only be offered for a base admission can accept.
  *
- * `keyless_api_access._host_authority_is_direct` refuses any `Host` that names something
- * rather than addressing the socket, so keyless works when the caller spelled a literal
- * or `localhost` and not otherwise. `exposure` cannot answer that question: it is
- * computed backend-side from the RESOLVED address, so a launch bound to a hostname
- * (`unsloth studio -H box.local`) reports `private_lan` while every request to
- * `http://box.local:8888` is refused.
+ * `keyless_api_access.keyless_authority_address_allowed` decides that on the backend:
+ * loopback always, private LAN under `inference`, and nothing else -- no hostname, no
+ * IPv4-mapped literal, no unspecified address, no public address. The panel has to give
+ * the same answer or it prints a copy-paste `Bearer not-needed` command that answers 401.
  *
- * Before this guard the panel rendered a copy-paste
- *   curl http://box.local:8888/v1/chat/completions -H "Authorization: Bearer not-needed"
- * that answers 401, and the LAN panel offered the same hostname as a QR code.
+ * It has been wrong three ways, each time because the guard tested something adjacent to
+ * the real question:
+ *   1. `exposure === "private_lan"` short-circuited the host test entirely, so
+ *      `unsloth studio -H box.local` advertised keyless for a hostname.
+ *   2. the replacement tested literal SYNTAX, so `[::ffff:192.168.1.24]`, `[::]` and
+ *      `8.8.8.8` are all well formed and all sailed through.
+ *   3. `isPrivateLanHost` unwrapped `::ffff:`, which is the one thing admission refuses
+ *      the mapped form for.
  *
- * Asserted against the real source rather than a copy, so the two cannot drift.
+ * So this pins the verdict table itself, not the presence of a guard. The expectations
+ * below mirror `test_what_the_ui_advertises_matches_what_admission_accepts` in
+ * studio/backend/tests/test_keyless_api_access_adversarial.py -- change both together.
  */
 
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
 import { test } from "node:test";
 
-const SOURCE = "src/features/settings/components/usage-examples.tsx";
+import {
+  isKeylessAllowedAuthority,
+  keylessBaseEligible,
+} from "../src/features/settings/components/keyless-example-eligibility.ts";
 
-test("keylessBaseEligible refuses a hostname base before consulting exposure", () => {
-  const source = readFileSync(SOURCE, "utf8");
+// base -> whether the panel may advertise keyless for it, under scope=inference and the
+// widest exposure the backend ever reports. Mirrors
+// test_what_the_ui_advertises_matches_what_admission_accepts in
+// studio/backend/tests/test_keyless_api_access_adversarial.py -- change both together.
+const TABLE: [string, boolean, string][] = [
+  ["http://127.0.0.1:8888", true, "loopback"],
+  ["http://127.0.0.2:8888", true, "loopback, whole 127/8"],
+  ["http://localhost:8888", true, "loopback name"],
+  ["http://[::1]:8888", true, "loopback v6"],
+  ["http://192.168.1.24:8888", true, "private LAN"],
+  ["http://10.0.0.5:8888", true, "private LAN"],
+  ["http://172.16.0.9:8888", true, "private LAN"],
+  ["http://[fd00::1]:8888", true, "unique local"],
+  [
+    "http://[::ffff:192.168.1.24]:8888",
+    false,
+    "IPv4-mapped: admission refuses",
+  ],
+  [
+    "http://[::ffff:c0a8:118]:8888",
+    false,
+    "IPv4-mapped hex: admission refuses",
+  ],
+  ["http://[::]:8888", false, "unspecified v6"],
+  ["http://0.0.0.0:8888", false, "unspecified v4"],
+  ["http://8.8.8.8:8888", false, "public"],
+  ["http://[2001:db8::1]:8888", false, "public v6"],
+  ["http://100.64.0.1:8888", false, "CGNAT, outside the private networks"],
+  ["http://box.local:8888", false, "mDNS name"],
+  ["http://studio.internal:8888", false, "internal name"],
+  ["http://mybox:8888", false, "single-label name"],
+];
 
-  // read the function body only, so a comment elsewhere in the file cannot satisfy this
-  const start = source.indexOf("function keylessBaseEligible(");
-  assert.ok(start > 0, "keylessBaseEligible not found");
-  const end = source.indexOf("\n}", start);
-  assert.ok(end > start, "could not delimit keylessBaseEligible");
-  const body = source.slice(start, end);
+test("the keyless example is offered exactly where admission accepts the authority", () => {
+  for (const [base, expected, why] of TABLE) {
+    assert.equal(
+      keylessBaseEligible(base, "inference", "private_lan"),
+      expected,
+      `${base} (${why}): panel said ${!expected}, admission says ${expected}`,
+    );
+  }
+});
 
-  const guard = body.indexOf("if (!isIpLiteralHost(host)) return false;");
-  const disjunct = body.indexOf('exposure === "private_lan"');
-  const loopback = body.indexOf("if (isLoopbackHost(host)) return true;");
+test("exposure alone cannot make a rejected base eligible", () => {
+  // The regression that started this: `private_lan` is computed from the RESOLVED
+  // address, so it must never widen a base the authority rule rejected.
+  for (const exposure of ["private_lan", "loopback", null] as const) {
+    assert.equal(
+      keylessBaseEligible("http://box.local:8888", "inference", exposure),
+      false,
+    );
+    assert.equal(
+      keylessBaseEligible(
+        "http://[::ffff:192.168.1.24]:8888",
+        "inference",
+        exposure,
+      ),
+      false,
+    );
+    assert.equal(
+      keylessBaseEligible("http://8.8.8.8:8888", "inference", exposure),
+      false,
+    );
+  }
+});
 
-  assert.ok(guard > 0, "the isIpLiteralHost guard is missing from keylessBaseEligible");
-  assert.ok(disjunct > 0, "the private_lan disjunct is missing");
-  // the guard must run BEFORE the exposure short circuit, which is the clause that made
-  // a hostname eligible in the first place
-  assert.ok(
-    guard < disjunct,
-    "the literal guard must run before exposure can make a hostname eligible",
+test("full scope never reaches a non-loopback authority", () => {
+  // full is loopback-only in admission, so the panel must not offer a LAN base for it.
+  assert.equal(
+    keylessBaseEligible("http://192.168.1.24:8888", "full", "private_lan"),
+    false,
   );
-  // and the loopback fast path stays ahead of both, so localhost keeps working
-  assert.ok(loopback > 0 && loopback < guard, "localhost must stay eligible");
+  assert.equal(
+    keylessBaseEligible("http://127.0.0.1:8888", "full", "loopback"),
+    true,
+  );
+});
+
+test("the authority classifier refuses what admission refuses", () => {
+  for (const host of [
+    "::ffff:192.168.1.24",
+    "::",
+    "0.0.0.0",
+    "8.8.8.8",
+    "box.local",
+  ]) {
+    assert.equal(isKeylessAllowedAuthority(host), false, host);
+  }
+  for (const host of ["127.0.0.1", "::1", "192.168.1.24", "fd00::1"]) {
+    assert.equal(isKeylessAllowedAuthority(host), true, host);
+  }
 });

--- a/studio/frontend/tests/keyless-example-base-eligibility.test.ts
+++ b/studio/frontend/tests/keyless-example-base-eligibility.test.ts
@@ -77,7 +77,7 @@ test("the keyless example is offered exactly where admission accepts the authori
 test("exposure alone cannot make a rejected base eligible", () => {
   // The regression that started this: `private_lan` is computed from the RESOLVED
   // address, so it must never widen a base the authority rule rejected.
-  for (const exposure of ["private_lan", "loopback", null] as const) {
+  for (const exposure of ["private_lan", "network", null] as const) {
     assert.equal(
       keylessBaseEligible("http://box.local:8888", "inference", exposure),
       false,
@@ -104,7 +104,7 @@ test("full scope never reaches a non-loopback authority", () => {
     false,
   );
   assert.equal(
-    keylessBaseEligible("http://127.0.0.1:8888", "full", "loopback"),
+    keylessBaseEligible("http://127.0.0.1:8888", "full", null),
     true,
   );
 });

--- a/studio/frontend/tests/keyless-example-base-eligibility.test.ts
+++ b/studio/frontend/tests/keyless-example-base-eligibility.test.ts
@@ -5,21 +5,19 @@
  * The keyless usage example must only be offered for a base admission can accept.
  *
  * `keyless_api_access.keyless_authority_address_allowed` decides that on the backend:
- * loopback always, private LAN under `inference`, and nothing else -- no hostname, no
- * IPv4-mapped literal, no unspecified address, no public address. The panel has to give
- * the same answer or it prints a copy-paste `Bearer not-needed` command that answers 401.
+ * loopback always, private LAN under `inference`, nothing else -- no hostname, no
+ * IPv4-mapped literal, no unspecified or public address. The panel must give the same
+ * answer or it prints a copy-paste `Bearer not-needed` command that answers 401.
  *
- * It has been wrong three ways, each time because the guard tested something adjacent to
- * the real question:
- *   1. `exposure === "private_lan"` short-circuited the host test entirely, so
+ * It has been wrong three ways, each time by testing something adjacent to the real question:
+ *   1. `exposure === "private_lan"` short-circuited the host test, so
  *      `unsloth studio -H box.local` advertised keyless for a hostname.
  *   2. the replacement tested literal SYNTAX, so `[::ffff:192.168.1.24]`, `[::]` and
- *      `8.8.8.8` are all well formed and all sailed through.
- *   3. `isPrivateLanHost` unwrapped `::ffff:`, which is the one thing admission refuses
- *      the mapped form for.
+ *      `8.8.8.8` all sailed through.
+ *   3. `isPrivateLanHost` unwrapped `::ffff:`, the one thing that form is refused for.
  *
- * So this pins the verdict table itself, not the presence of a guard. The expectations
- * below mirror `test_what_the_ui_advertises_matches_what_admission_accepts` in
+ * So this pins the verdict table itself, not the presence of a guard, mirroring
+ * `test_what_the_ui_advertises_matches_what_admission_accepts` in
  * studio/backend/tests/test_keyless_api_access_adversarial.py -- change both together.
  */
 


### PR DESCRIPTION
Follow-up to #9102, which merged before this landed. The keyless feature is on `main` now; this closes a gap in its browser rule and adds the adversarial coverage.

## The gap

`Origin` does not identify a browser. No engine attaches it to a same-origin GET, nor to a cross-site GET issued in `no-cors` mode, and only Chromium withholds a `no-cors` fetch aimed at `http://127.0.0.1:<port>`, through Private Network Access. Firefox and Safari have not shipped it, so there the request arrives.

Measured against a live server on current `main` (`8e06238e5`), replaying the exact shapes those engines emit:

| shape | scope=off | scope=inference | scope=full |
| --- | --- | --- | --- |
| cross-site `no-cors` GET `/v1/models` | 401 | **200** | **200** |
| cross-site `no-cors` POST `/v1/unload` | 401 | 401 | **400, reached the handler** |
| cross-site cors GET, carries `Origin` | 401 | 401 | 401 |
| Studio's own same-origin GET | 401 | 200 | 200 |

The response is opaque to the page, so this is not a read primitive. It is a blind request primitive and an "is Unsloth Studio running here" oracle, and under `full` it reaches management handlers, where only FastAPI's JSON body requirement stops the POSTs. The guards from #9102 are what hold the line: `GET /api/auth/api-keys` still answers 403 through `_require_a_credential_of_its_own`.

## The fix

Read `Sec-Fetch-Site`. The browser sets it on every request whatever the mode, and a page cannot forge it, because the `Sec-` prefix makes it a [forbidden header name](https://developer.mozilla.org/en-US/docs/Glossary/forbidden_header_name). Only `cross-site` and `same-site` are refused. `same-origin` is Studio's own page and `none` is the user typing the URL, so both stay admitted.

Absence stays admitted, and has to: curl, the OpenAI SDKs and Safari before 16.4 send no `Sec-Fetch-*` at all, and serving them is the point of the setting. That also means the header is only there to be read where the transport is a potentially trustworthy URL, so this narrows `full`, which is loopback-only, more tightly than plain-HTTP LAN inference. It never widens either.

After the fix every browser row above is 401, the same-origin row is unchanged, and a 63-case end-to-end run over curl-shaped requests is byte-identical to before.

## Tests

New file, so nothing #9102 owns is touched. 15 tests covering what the merged suite asserts only at the predicate layer, only in one direction, or not at all:

- `scope=off` refused through the `security` dependency, not only through `scope_covers`
- `GET`/`PUT /api/settings/keyless-api-access` and `_require_ui_session_for_keyless`, which had no test at all. This is the self-promotion question: a keyless caller must not be able to widen its own scope
- a real credential never stops working. Valid key and valid session across all three scopes and eight transports, including the ones keyless itself is refused on, asserting they authenticate *as themselves* rather than through either keyless scheme, since a downgrade would silently take away tools an existing API client already had. Mutation-checked: dropping the `APPROVED_DUMMY_BEARERS` clause from the dependency fails it with `api_key was downgraded to keyless on loopback/inference`
- `inference` from a public bind and a public peer
- management routes under `inference`
- `root_path` and trailing slash driven through `keyless_request_allowed`, not just `scope_covers`
- the dynamic `GET /v1/models/` prefix pinned to the one handler it can reach. It admits every non-empty suffix rather than an exact pair, so the safety argument rests on route topology; this fails the day a second `GET /models/...` route is registered
- a session JWT naming an unknown subject
- `asgi_request_is_keyless` called directly. The duplicate-header rule has three implementations and only one was covered
- every `_hosted_mode_forbidden` flag, including `lan_access_is_colab` and `lan_access_secure_launch`
- the `full` denials with `_remote_connector_active` cleared. In the merged suite it is left `True`, so the wildcard-bind and LAN denials pass even if `_full_scope_transport_allowed` is deleted
- the revoke-after-admission race from @Imagineer99's review on #9102, pinned directly, since their reproducer can no longer run on this head

## Verification

- Full backend suite as Backend CI runs it: **30498 passed, 155 skipped**. The one failure, `test_tool_result_fits_window`, fails identically on plain `main` and is unrelated
- Frontend: typecheck clean, **4892 tests pass**, `biome check` error free. The middle commit annotates the `cloudflareUrl` trigger dependency, which was the one Biome error the feature shipped with
- Ruff clean on both changed Python files

## Still open from the #9102 review, not changed here

`keyless_transport_allowed` returns `True` on the LAN branch before it consults `_public_tunnel_active`, so an active tunnel disables keyless for loopback but not for the LAN listener. Not exploitable through Studio's own tunnel, which targets `http://localhost:<port>` and so presents a loopback peer, but the #9102 description says keyless is disabled "even for localhost until that exposure stops" and the code does less than that. Left alone as a product call. Separately, `_names_a_session` and `bearer_names_a_session` have no callers anywhere in the repo.


## Added during review: DNS rebinding

Codex raised a P1 on the `same-origin` branch, and it was right. I reproduced it at the previous head before changing anything: scope `full`, `GET /api/chat/threads` with `Host: evil.example:8888` and `Sec-Fetch-Site: same-origin` was **admitted**.

DNS rebinding produces every local signal the transport checks read. A page on `evil.example` whose record is re-pointed at `127.0.0.1` keeps its own origin, so the fetch is same-origin: no `Origin`, `Sec-Fetch-Site: same-origin`, and a loopback peer on a loopback socket. Unlike the `no-cors` case above, the response is **readable** by the page.

This predates the branch, since a same-origin GET carries no `Origin` and the existing rule never fired either. But `same-origin` is a positive signal this branch introduces, so the check belongs with it.

`_host_authority_is_direct` closes it. A direct client addresses the socket by literal address or `localhost`; only a rebound page sends a domain, because the browser sends the name the page was served from. Absent `Host` stays admitted, since the merged suite and HTTP/1.0 callers send none and no browser omits it. Bracketed IPv6 junk such as `[::1]evil.example` is rejected rather than parsed, matching what `_host_header_is_loopback` already does for the bootstrap path.

| request | before | after |
| --- | --- | --- |
| `Host: evil.example:8888`, `Sec-Fetch-Site: same-origin` | admitted | refused |
| `Host: localhost.evil.example:8888` | admitted | refused |
| `Host: 127.0.0.1:8888` (curl, SDK) | admitted | admitted |
| `Host: localhost:8888` | admitted | admitted |
| no `Host` header | admitted | admitted |

One narrow cost worth naming: reaching Studio keylessly through a private hostname such as `studio.internal:8888` now needs a key. That is fail-closed, and the right default for a setting that removes authentication.
