### PR TITLE
studio: keep a resumed turn's provider metadata through the continuation merge

### DIFF
--- a/studio/backend/core/inference/chat_template_helpers.py
+++ b/studio/backend/core/inference/chat_template_helpers.py
@@ -2417,13 +2417,10 @@ def append_assistant_turn(
     consecutive assistant messages and break role alternation. Self-limiting, since
     after a tool result the conversation no longer ends with a plain assistant turn.
 
-    The merge is over the resumed turn, not a replacement of it. Assigning the new
-    message into the slot would drop every key the partial carried that the
-    continuation does not repeat, and ``extra_content`` is exactly such a key: it
-    is the namespaced envelope a translator reads back (``google`` for Gemini's
-    thought signatures and native parts, plus ``anthropic`` and
-    ``openai_codex_reasoning``). Gemini pins the text part's signature back on
-    from that field alone, so a resumed turn replayed without it is rejected.
+    Merge over the resumed turn rather than replacing it, or every key the partial
+    carried but the continuation does not repeat is lost. ``extra_content`` is such a
+    key, and Gemini reads the text part's thought signature back from it alone, so a
+    resumed turn replayed without it is rejected.
     """
     # Same acceptance rule as the prompt boundary, so a partial sent as text parts merges too.
     prev_text = trailing_assistant_text(conversation) if continue_final_message else None

--- a/studio/backend/core/inference/chat_template_helpers.py
+++ b/studio/backend/core/inference/chat_template_helpers.py
@@ -2416,12 +2416,22 @@ def append_assistant_turn(
     model just added are one turn, so they are merged: appending would instead give two
     consecutive assistant messages and break role alternation. Self-limiting, since
     after a tool result the conversation no longer ends with a plain assistant turn.
+
+    The merge is over the resumed turn, not a replacement of it. Assigning the new
+    message into the slot would drop every key the partial carried that the
+    continuation does not repeat, and ``extra_content`` is exactly such a key: it
+    is the namespaced envelope a translator reads back (``google`` for Gemini's
+    thought signatures and native parts, plus ``anthropic`` and
+    ``openai_codex_reasoning``). Gemini pins the text part's signature back on
+    from that field alone, so a resumed turn replayed without it is rejected.
     """
     # Same acceptance rule as the prompt boundary, so a partial sent as text parts merges too.
     prev_text = trailing_assistant_text(conversation) if continue_final_message else None
     if prev_text is not None and isinstance(assistant_msg.get("content"), str):
-        assistant_msg["content"] = f"{prev_text}{assistant_msg['content']}"
-        conversation[-1] = assistant_msg
+        # Copy rather than mutate: the caller owns assistant_msg and may still read it.
+        merged_msg = {**conversation[-1], **assistant_msg}
+        merged_msg["content"] = f"{prev_text}{assistant_msg['content']}"
+        conversation[-1] = merged_msg
         return
     conversation.append(assistant_msg)
 

--- a/studio/backend/tests/test_chat_template_continuation.py
+++ b/studio/backend/tests/test_chat_template_continuation.py
@@ -587,6 +587,67 @@ def test_a_text_part_partial_merges_rather_than_doubling_the_turn():
     assert conversation[-1]["tool_calls"] == [{"id": "c1"}]
 
 
+def test_a_resumed_partial_keeps_the_metadata_the_continuation_does_not_repeat():
+    """Gemini pins the text part's signature back on from extra_content alone.
+
+    The merge used to assign the continuation into the slot, so every key the
+    partial carried and the continuation did not was dropped and the replayed
+    turn was rejected.
+    """
+    conversation = [
+        {"role": "user", "content": "q"},
+        {
+            "role": "assistant",
+            "content": "Looking that ",
+            "extra_content": {"google": {"thought_signature": "SIG-PARTIAL"}},
+        },
+    ]
+    append_assistant_turn(
+        conversation,
+        {"role": "assistant", "content": "up now."},
+        continue_final_message = True,
+    )
+
+    assert conversation[-1]["content"] == "Looking that up now."
+    assert conversation[-1]["extra_content"] == {"google": {"thought_signature": "SIG-PARTIAL"}}
+
+
+def test_a_merge_leaves_the_callers_message_alone():
+    """The caller owns the dict it passed and may still read it afterwards."""
+    conversation = [
+        {"role": "user", "content": "q"},
+        {"role": "assistant", "content": "Looking that "},
+    ]
+    generated = {"role": "assistant", "content": "up now."}
+    append_assistant_turn(conversation, generated, continue_final_message = True)
+
+    assert conversation[-1]["content"] == "Looking that up now."
+    assert generated["content"] == "up now."
+
+
+def test_a_continuation_still_wins_on_a_key_it_does_repeat():
+    """Merging must not resurrect a stale value the new turn deliberately set."""
+    conversation = [
+        {"role": "user", "content": "q"},
+        {
+            "role": "assistant",
+            "content": "Looking that ",
+            "extra_content": {"google": {"thought_signature": "STALE"}},
+        },
+    ]
+    append_assistant_turn(
+        conversation,
+        {
+            "role": "assistant",
+            "content": "up now.",
+            "extra_content": {"google": {"thought_signature": "FRESH"}},
+        },
+        continue_final_message = True,
+    )
+
+    assert conversation[-1]["extra_content"] == {"google": {"thought_signature": "FRESH"}}
+
+
 def test_a_merge_stops_once_the_turn_is_no_longer_the_resumed_one():
     """Self-limiting: after a tool result or a nudge the partial is not trailing."""
     after_tool = [


### PR DESCRIPTION
## The bug

`append_assistant_turn` (`studio/backend/core/inference/chat_template_helpers.py`) merges a continuation into the trailing partial rather than appending, so that role alternation survives. It did that by assigning the new message into the slot:

```python
assistant_msg["content"] = f"{prev_text}{assistant_msg['content']}"
conversation[-1] = assistant_msg
```

That replaces the resumed turn, so every key the partial carried and the continuation does not repeat is dropped.

`extra_content` is exactly such a key. It is the namespaced envelope a translator reads back on the way out, and there are three namespaces in the tree today: `google` (15 sites, Gemini thought signatures and native parts), `anthropic` (11 sites) and `openai_codex_reasoning`. The field's own schema in `models/inference.py` describes it as "provider-specific extra fields the translator may read".

For Gemini the consequence is hard rather than cosmetic. `studio_tool_loop.py` says it plainly:

> Gemini 3 stows the text part's thoughtSignature here and its translator pins it back on from this field alone, so a turn replayed without it is rejected.

Observed on `main`:

```
merged turn     : {'role': 'assistant', 'content': 'Looking that up now.'}
caller dict now : {'role': 'assistant', 'content': 'Looking that up now.'}
```

The signature is gone, and the second line is a separate defect: the same statement mutates the dict the caller passed in, so a caller that reads it back afterwards sees text it never wrote.

## The fix

Merge over the existing message instead of replacing it.

```python
merged_msg = {**conversation[-1], **assistant_msg}
merged_msg["content"] = f"{prev_text}{assistant_msg['content']}"
conversation[-1] = merged_msg
```

After:

```
merged turn     : {'role': 'assistant', 'content': 'Looking that up now.',
                   'extra_content': {'google': {'thought_signature': 'SIG-PARTIAL'}}}
caller dict now : {'role': 'assistant', 'content': 'up now.'}
```

Namespace agnostic on purpose. Special casing `extra_content["google"]` would have left `anthropic` and `openai_codex_reasoning` broken and set the same trap for the next provider that adds one.

## Scope

This is not specific to any one loop. Six of the eight `append_assistant_turn` call sites are tool-result replay across the GGUF, safetensors and external loops, and the merge path itself is reached by the continue-a-partial-response feature from #8064, which is independent of tool calling entirely.

## Tests

Three added to `tests/test_chat_template_continuation.py`:

- `test_a_resumed_partial_keeps_the_metadata_the_continuation_does_not_repeat` - fails on main
- `test_a_merge_leaves_the_callers_message_alone` - fails on main
- `test_a_continuation_still_wins_on_a_key_it_does_repeat` - passes on both, guarding the fix against over-correcting into resurrecting a stale value

Verified both directions:

```
against main:      2 failed, 1 passed
against this PR:   42 passed  (whole file)
blast radius:     731 passed  (continuation, GGUF, safetensors, external, hosted replay,
                               passthrough healing, plan classifier)
ruff check and scripts/run_ruff_format.py --check: clean
```

Found while looking at #9125, but it is independent of that PR and of tool-call nudging, so it is split out to land on its own.