### PR TITLE
Stop the -bf16 notice claiming a request the caller never made

### DIFF
--- a/tests/test_bf16_quant_disabled_message.py
+++ b/tests/test_bf16_quant_disabled_message.py
@@ -12,6 +12,8 @@ Source-level, because reaching the branch needs a real checkpoint download.
 """
 
 import ast
+import os
+import sys
 from pathlib import Path
 
 import pytest
@@ -64,6 +66,87 @@ def test_the_notice_is_gated_on_no_user_quantization_config(index):
 def test_the_flags_are_still_cleared():
     """The notice is a message; it must not change what the branch does."""
     assert SRC.count("load_in_16bit = True") >= 4
+
+
+@pytest.mark.parametrize("index", [0, 1, 2, 3])
+def test_the_notice_never_calls_the_load_requested(index):
+    """`load_in_4bit` defaults to True in both loaders, so a set flag is not a
+    request: a bare `from_pretrained("org/model-bf16")` reaches this branch with
+    the default still on, and calling that "requested" tells the caller their
+    request was refused when they made none."""
+    guards = _bf16_notice_guards()
+    assert len(guards) == 4, "the notice moved; update this test"
+    text = ast.get_source_segment(SRC, guards[index].body[0]) or ""
+    assert "request" not in text.lower(), (
+        "the '-bf16' notice must describe what happens, not claim the caller "
+        f"asked for it: load_in_4bit defaults to True. Got: {text}"
+    )
+
+
+@pytest.mark.parametrize("index", [0, 1, 2, 3])
+def test_an_explicit_16bit_request_is_not_told_its_quant_was_dropped(index):
+    """`load_in_16bit` defaults to False and nothing sets it True before this
+    branch, so True here is the caller's own word: they asked for the 16bit load
+    they are about to get, and a 'quantization disabled' line is wrong there."""
+    guards = _bf16_notice_guards()
+    assert len(guards) == 4, "the notice moved; update this test"
+    test_src = ast.get_source_segment(SRC, guards[index].test) or ""
+    assert "load_in_16bit" in test_src, (
+        "gate the notice on `not load_in_16bit`: with `load_in_16bit = True` the "
+        "caller explicitly asked for the 16bit load this branch performs"
+    )
+
+
+BEHAVIOUR_PROBE = r"""
+import contextlib, io, os, sys
+os.environ["HF_HUB_OFFLINE"] = "1"  # the notice prints before any download
+from unsloth import FastLanguageModel, FastModel
+
+NAME = "unslothtestorg/Definitely-Not-A-Real-Repo-bf16"
+
+def notice(cls, **kwargs):
+    buf = io.StringIO()
+    try:
+        with contextlib.redirect_stdout(buf):
+            cls.from_pretrained(NAME, **kwargs)
+    except BaseException:
+        pass  # the fake repo cannot resolve; the notice prints long before that
+    lines = [l for l in buf.getvalue().splitlines() if "(-bf16) checkpoint" in l]
+    return lines[0] if lines else ""
+
+for cls in (FastLanguageModel, FastModel):
+    name = cls.__name__
+    bare = notice(cls)
+    assert bare, f"{name}: bare call printed no notice"
+    assert "request" not in bare.lower(), f"{name}: bare call was told it requested 4bit: {bare}"
+    assert not notice(cls, load_in_16bit = True), f"{name}: explicit 16bit call got a notice"
+    assert not notice(cls, load_in_4bit = False), f"{name}: 4bit-off call got a notice"
+print("PROBE_OK")
+"""
+
+
+def test_the_notice_on_a_real_bare_call():
+    """The source checks above pin the shape; this one runs the actual call.
+
+    Out of process: importing unsloth patches the interpreter, and the probe
+    needs an offline environment that must not leak into the rest of the suite.
+    """
+    import subprocess
+
+    env = dict(os.environ, PYTHONPATH = str(ROOT), HF_HUB_OFFLINE = "1")
+    try:
+        proc = subprocess.run(
+            [sys.executable, "-c", BEHAVIOUR_PROBE],
+            capture_output = True,
+            text = True,
+            timeout = 1200,
+            env = env,
+        )
+    except subprocess.TimeoutExpired:
+        pytest.skip("unsloth import timed out")
+    if "PROBE_OK" not in proc.stdout and "AssertionError" not in proc.stderr:
+        pytest.skip(f"unsloth could not be imported here:\n{proc.stderr[-2000:]}")
+    assert "PROBE_OK" in proc.stdout, proc.stderr[-3000:]
 
 
 if __name__ == "__main__":

--- a/tests/test_bf16_quant_disabled_message.py
+++ b/tests/test_bf16_quant_disabled_message.py
@@ -97,26 +97,45 @@ BEHAVIOUR_PROBE = r"""
 import contextlib, io, os, sys
 os.environ["HF_HUB_OFFLINE"] = "1"  # the notice prints before any download
 from unsloth import FastLanguageModel, FastModel
+# Without bitsandbytes both loaders clear `load_in_4bit` before the branch, so
+# there is no quant left to disable and the notice correctly stays silent.
+from unsloth.models.loader import ALLOW_BITSANDBYTES
 
 NAME = "unslothtestorg/Definitely-Not-A-Real-Repo-bf16"
 
 def notice(cls, **kwargs):
     buf = io.StringIO()
+    err = ""
     try:
         with contextlib.redirect_stdout(buf):
             cls.from_pretrained(NAME, **kwargs)
-    except BaseException:
-        pass  # the fake repo cannot resolve; the notice prints long before that
+    except BaseException as e:
+        err = f"{type(e).__name__}: {e}"  # the fake repo cannot resolve, and the
+        # notice prints long before that -- but the mode check does not.
+    # FastModel rejects mutually exclusive modes before the '-bf16' branch, so an
+    # empty result from that raise means the call never reached the code under
+    # test and an assertion on it would pass without exercising anything.
+    assert "Can only load in" not in err, f"{cls.__name__} {kwargs}: never reached the branch: {err}"
     lines = [l for l in buf.getvalue().splitlines() if "(-bf16) checkpoint" in l]
     return lines[0] if lines else ""
 
 for cls in (FastLanguageModel, FastModel):
     name = cls.__name__
     bare = notice(cls)
-    assert bare, f"{name}: bare call printed no notice"
-    assert "request" not in bare.lower(), f"{name}: bare call was told it requested 4bit: {bare}"
-    assert not notice(cls, load_in_16bit = True), f"{name}: explicit 16bit call got a notice"
+    if ALLOW_BITSANDBYTES:
+        assert bare, f"{name}: bare call printed no notice"
+        assert "request" not in bare.lower(), f"{name}: bare call was told it requested 4bit: {bare}"
+    else:
+        assert not bare, f"{name}: 4bit was already off, but the notice still ran: {bare}"
     assert not notice(cls, load_in_4bit = False), f"{name}: 4bit-off call got a notice"
+
+# `load_in_16bit = True` on its own leaves the default `load_in_4bit = True` set:
+# the one combination where the notice is suppressed by the caller's 16bit word
+# rather than by there being no quant to drop. FastLanguageModel takes that pair,
+# so it is the half that pins the gate; FastModel raises on it, and there the
+# explicit 16bit call can only be spelled with 4bit off.
+assert not notice(FastLanguageModel, load_in_16bit = True), "FastLanguageModel: explicit 16bit call got a notice"
+assert not notice(FastModel, load_in_4bit = False, load_in_16bit = True), "FastModel: explicit 16bit call got a notice"
 print("PROBE_OK")
 """
 

--- a/tests/test_bf16_quant_disabled_message.py
+++ b/tests/test_bf16_quant_disabled_message.py
@@ -3,10 +3,9 @@
 
 """The '-bf16' notice must not claim 16bit when a quantization_config survives.
 
-A `-bf16` name drops the plain load_in_4bit / 8bit / fp8 flags, so the notice is
-accurate for those. A user-supplied `quantization_config` is only read into the
-local flags: it stays in `**kwargs`, both loaders forward it, and Transformers
-quantizes anyway, so there the notice would say the opposite of what happens.
+A `-bf16` name drops the plain load_in_4bit / 8bit / fp8 flags, but a user
+`quantization_config` stays in `**kwargs` and still quantizes, so there the
+notice would say the opposite of what happens.
 
 Source-level, because reaching the branch needs a real checkpoint download.
 """
@@ -70,10 +69,8 @@ def test_the_flags_are_still_cleared():
 
 @pytest.mark.parametrize("index", [0, 1, 2, 3])
 def test_the_notice_never_calls_the_load_requested(index):
-    """`load_in_4bit` defaults to True in both loaders, so a set flag is not a
-    request: a bare `from_pretrained("org/model-bf16")` reaches this branch with
-    the default still on, and calling that "requested" tells the caller their
-    request was refused when they made none."""
+    """`load_in_4bit` defaults to True, so a bare `from_pretrained("org/model-bf16")`
+    reaches this branch with the flag set without the caller requesting anything."""
     guards = _bf16_notice_guards()
     assert len(guards) == 4, "the notice moved; update this test"
     text = ast.get_source_segment(SRC, guards[index].body[0]) or ""
@@ -86,8 +83,7 @@ def test_the_notice_never_calls_the_load_requested(index):
 @pytest.mark.parametrize("index", [0, 1, 2, 3])
 def test_an_explicit_16bit_request_is_not_told_its_quant_was_dropped(index):
     """`load_in_16bit` defaults to False and nothing sets it True before this
-    branch, so True here is the caller's own word: they asked for the 16bit load
-    they are about to get, and a 'quantization disabled' line is wrong there."""
+    branch, so True here is the caller's own word: they asked for this load."""
     guards = _bf16_notice_guards()
     assert len(guards) == 4, "the notice moved; update this test"
     test_src = ast.get_source_segment(SRC, guards[index].test) or ""
@@ -126,11 +122,8 @@ print("PROBE_OK")
 
 
 def test_the_notice_on_a_real_bare_call():
-    """The source checks above pin the shape; this one runs the actual call.
-
-    Out of process: importing unsloth patches the interpreter, and the probe
-    needs an offline environment that must not leak into the rest of the suite.
-    """
+    """Out of process: importing unsloth patches the interpreter, and the probe
+    needs an offline environment that must not leak into the rest of the suite."""
     import subprocess
 
     env = dict(os.environ, PYTHONPATH = str(ROOT), HF_HUB_OFFLINE = "1")

--- a/unsloth/models/loader.py
+++ b/unsloth/models/loader.py
@@ -654,11 +654,9 @@ class FastLanguageModel(FastLlamaModel):
         if model_name.lower().endswith("-bf16") and (
             load_in_16bit or not os.path.isdir(os.path.expanduser(model_name))
         ):
-            # Only the plain flags are dropped; a user quantization_config stays
-            # in **kwargs and still quantizes, so stay quiet in that case.
-            # `load_in_4bit` defaults to True, so a set flag is not proof the caller
-            # asked for 4bit: report what happens, never what was "requested". An
-            # explicit `load_in_16bit` IS a request for exactly this, so stay quiet.
+            # A user quantization_config stays in **kwargs and still quantizes.
+            # `load_in_4bit` defaults to True, so a set flag is not proof of a
+            # request; an explicit `load_in_16bit` IS one, for exactly this load.
             if (
                 not load_in_16bit
                 and (load_in_4bit or load_in_8bit or load_in_fp8 != False)
@@ -854,11 +852,9 @@ class FastLanguageModel(FastLlamaModel):
             if model_name.lower().endswith("-bf16") and (
                 load_in_16bit or not os.path.isdir(os.path.expanduser(model_name))
             ):
-                # Only the plain flags are dropped; a user quantization_config stays
-                # in **kwargs and still quantizes, so stay quiet in that case.
-                # `load_in_4bit` defaults to True, so a set flag is not proof the caller
-                # asked for 4bit: report what happens, never what was "requested". An
-                # explicit `load_in_16bit` IS a request for exactly this, so stay quiet.
+                # A user quantization_config stays in **kwargs and still quantizes.
+                # `load_in_4bit` defaults to True, so a set flag is not proof of a
+                # request; an explicit `load_in_16bit` IS one, for exactly this load.
                 if (
                     not load_in_16bit
                     and (load_in_4bit or load_in_8bit or load_in_fp8 != False)
@@ -1465,11 +1461,9 @@ class FastModel(FastBaseModel):
         if model_name.lower().endswith("-bf16") and (
             load_in_16bit or not os.path.isdir(os.path.expanduser(model_name))
         ):
-            # Only the plain flags are dropped; a user quantization_config stays
-            # in **kwargs and still quantizes, so stay quiet in that case.
-            # `load_in_4bit` defaults to True, so a set flag is not proof the caller
-            # asked for 4bit: report what happens, never what was "requested". An
-            # explicit `load_in_16bit` IS a request for exactly this, so stay quiet.
+            # A user quantization_config stays in **kwargs and still quantizes.
+            # `load_in_4bit` defaults to True, so a set flag is not proof of a
+            # request; an explicit `load_in_16bit` IS one, for exactly this load.
             if (
                 not load_in_16bit
                 and (load_in_4bit or load_in_8bit or load_in_fp8 != False)
@@ -1870,11 +1864,9 @@ class FastModel(FastBaseModel):
             if model_name.lower().endswith("-bf16") and (
                 load_in_16bit or not os.path.isdir(os.path.expanduser(model_name))
             ):
-                # Only the plain flags are dropped; a user quantization_config stays
-                # in **kwargs and still quantizes, so stay quiet in that case.
-                # `load_in_4bit` defaults to True, so a set flag is not proof the caller
-                # asked for 4bit: report what happens, never what was "requested". An
-                # explicit `load_in_16bit` IS a request for exactly this, so stay quiet.
+                # A user quantization_config stays in **kwargs and still quantizes.
+                # `load_in_4bit` defaults to True, so a set flag is not proof of a
+                # request; an explicit `load_in_16bit` IS one, for exactly this load.
                 if (
                     not load_in_16bit
                     and (load_in_4bit or load_in_8bit or load_in_fp8 != False)

--- a/unsloth/models/loader.py
+++ b/unsloth/models/loader.py
@@ -656,14 +656,20 @@ class FastLanguageModel(FastLlamaModel):
         ):
             # Only the plain flags are dropped; a user quantization_config stays
             # in **kwargs and still quantizes, so stay quiet in that case.
-            if (load_in_4bit or load_in_8bit or load_in_fp8 != False) and kwargs.get(
-                "quantization_config", None
-            ) is None:
+            # `load_in_4bit` defaults to True, so a set flag is not proof the caller
+            # asked for 4bit: report what happens, never what was "requested". An
+            # explicit `load_in_16bit` IS a request for exactly this, so stay quiet.
+            if (
+                not load_in_16bit
+                and (load_in_4bit or load_in_8bit or load_in_fp8 != False)
+                and kwargs.get("quantization_config", None) is None
+            ):
                 print(
-                    f"Unsloth: `{model_name}` is a 16bit (-bf16) checkpoint, so the "
-                    f"requested 4bit/8bit/fp8 loading is disabled and the model will "
-                    f"load in 16bit. Point at the 4bit repo instead if that is not "
-                    f"what you wanted -- a 16bit load needs far more VRAM."
+                    f"Unsloth: `{model_name}` is a 16bit (-bf16) checkpoint, so "
+                    f"4bit/8bit/fp8 loading is disabled and the model will "
+                    f"load in 16bit, which needs far more VRAM. Unsloth loads "
+                    f"4bit by default; point at the 4bit repo instead if you "
+                    f"wanted that."
                 )
             load_in_4bit = False
             load_in_8bit = False
@@ -848,16 +854,22 @@ class FastLanguageModel(FastLlamaModel):
             if model_name.lower().endswith("-bf16") and (
                 load_in_16bit or not os.path.isdir(os.path.expanduser(model_name))
             ):
-                # Only the plain flags are dropped; a user quantization_config
-                # stays in **kwargs and still quantizes, so stay quiet then.
-                if (load_in_4bit or load_in_8bit or load_in_fp8 != False) and kwargs.get(
-                    "quantization_config", None
-                ) is None:
+                # Only the plain flags are dropped; a user quantization_config stays
+                # in **kwargs and still quantizes, so stay quiet in that case.
+                # `load_in_4bit` defaults to True, so a set flag is not proof the caller
+                # asked for 4bit: report what happens, never what was "requested". An
+                # explicit `load_in_16bit` IS a request for exactly this, so stay quiet.
+                if (
+                    not load_in_16bit
+                    and (load_in_4bit or load_in_8bit or load_in_fp8 != False)
+                    and kwargs.get("quantization_config", None) is None
+                ):
                     print(
-                        f"Unsloth: `{model_name}` is a 16bit (-bf16) checkpoint, so the "
-                        f"requested 4bit/8bit/fp8 loading is disabled and the model will "
-                        f"load in 16bit. Point at the 4bit repo instead if that is not "
-                        f"what you wanted -- a 16bit load needs far more VRAM."
+                        f"Unsloth: `{model_name}` is a 16bit (-bf16) checkpoint, so "
+                        f"4bit/8bit/fp8 loading is disabled and the model will "
+                        f"load in 16bit, which needs far more VRAM. Unsloth loads "
+                        f"4bit by default; point at the 4bit repo instead if you "
+                        f"wanted that."
                     )
                 load_in_4bit = False
                 load_in_8bit = False
@@ -1455,14 +1467,20 @@ class FastModel(FastBaseModel):
         ):
             # Only the plain flags are dropped; a user quantization_config stays
             # in **kwargs and still quantizes, so stay quiet in that case.
-            if (load_in_4bit or load_in_8bit or load_in_fp8 != False) and kwargs.get(
-                "quantization_config", None
-            ) is None:
+            # `load_in_4bit` defaults to True, so a set flag is not proof the caller
+            # asked for 4bit: report what happens, never what was "requested". An
+            # explicit `load_in_16bit` IS a request for exactly this, so stay quiet.
+            if (
+                not load_in_16bit
+                and (load_in_4bit or load_in_8bit or load_in_fp8 != False)
+                and kwargs.get("quantization_config", None) is None
+            ):
                 print(
-                    f"Unsloth: `{model_name}` is a 16bit (-bf16) checkpoint, so the "
-                    f"requested 4bit/8bit/fp8 loading is disabled and the model will "
-                    f"load in 16bit. Point at the 4bit repo instead if that is not "
-                    f"what you wanted -- a 16bit load needs far more VRAM."
+                    f"Unsloth: `{model_name}` is a 16bit (-bf16) checkpoint, so "
+                    f"4bit/8bit/fp8 loading is disabled and the model will "
+                    f"load in 16bit, which needs far more VRAM. Unsloth loads "
+                    f"4bit by default; point at the 4bit repo instead if you "
+                    f"wanted that."
                 )
             load_in_4bit = False
             load_in_8bit = False
@@ -1852,16 +1870,22 @@ class FastModel(FastBaseModel):
             if model_name.lower().endswith("-bf16") and (
                 load_in_16bit or not os.path.isdir(os.path.expanduser(model_name))
             ):
-                # Only the plain flags are dropped; a user quantization_config
-                # stays in **kwargs and still quantizes, so stay quiet then.
-                if (load_in_4bit or load_in_8bit or load_in_fp8 != False) and kwargs.get(
-                    "quantization_config", None
-                ) is None:
+                # Only the plain flags are dropped; a user quantization_config stays
+                # in **kwargs and still quantizes, so stay quiet in that case.
+                # `load_in_4bit` defaults to True, so a set flag is not proof the caller
+                # asked for 4bit: report what happens, never what was "requested". An
+                # explicit `load_in_16bit` IS a request for exactly this, so stay quiet.
+                if (
+                    not load_in_16bit
+                    and (load_in_4bit or load_in_8bit or load_in_fp8 != False)
+                    and kwargs.get("quantization_config", None) is None
+                ):
                     print(
-                        f"Unsloth: `{model_name}` is a 16bit (-bf16) checkpoint, so the "
-                        f"requested 4bit/8bit/fp8 loading is disabled and the model will "
-                        f"load in 16bit. Point at the 4bit repo instead if that is not "
-                        f"what you wanted -- a 16bit load needs far more VRAM."
+                        f"Unsloth: `{model_name}` is a 16bit (-bf16) checkpoint, so "
+                        f"4bit/8bit/fp8 loading is disabled and the model will "
+                        f"load in 16bit, which needs far more VRAM. Unsloth loads "
+                        f"4bit by default; point at the 4bit repo instead if you "
+                        f"wanted that."
                     )
                 load_in_4bit = False
                 load_in_8bit = False


### PR DESCRIPTION
Follow-up to #9678, which merged while its last review round was still open.

## The problem

`load_in_4bit` defaults to `True` in both loaders:

- `unsloth/models/loader.py:431` - `FastLanguageModel.from_pretrained`
- `unsloth/models/loader.py:1236` - `FastModel.from_pretrained`

Nothing between the signature and the `-bf16` branch clears it on an ordinary call. The block at `:462` that reads `kwargs["quantization_config"]` only ever turns flags on, and the bitsandbytes-unavailable branch at `:577` only fires when bitsandbytes is missing.

So a bare `FastLanguageModel.from_pretrained("org/model-bf16")` reached the notice added in #9678 with the default flag still set, and was told:

```
Unsloth: `org/model-bf16` is a 16bit (-bf16) checkpoint, so the requested
4bit/8bit/fp8 loading is disabled and the model will load in 16bit. ...
```

when it had requested nothing. That is the most common call in the library.

## The change

The notice now reports what happens rather than what was asked for, and names the 4bit default as the reason so the advice to point at the 4bit repo still lands:

```
Unsloth: `org/model-bf16` is a 16bit (-bf16) checkpoint, so 4bit/8bit/fp8
loading is disabled and the model will load in 16bit, which needs far more
VRAM. Unsloth loads 4bit by default; point at the 4bit repo instead if you
wanted that.
```

It is also suppressed when `load_in_16bit` is set. That flag defaults to `False` and nothing sets it `True` before the branch, so `True` there really is the caller's word, and telling someone who explicitly asked for 16bit that their quantization was dropped is noise.

Applied to all four copies of the branch, two in each loader. The `quantization_config` gate from #9678 is unchanged.

## What is deliberately not changed

The signature default stays `load_in_4bit = True` rather than moving to a `None` sentinel. It is a documented public default and `int(load_in_4bit)` arithmetic exists downstream at `unsloth/models/vision.py:1234`, so a sentinel would be an API change for a message fix.

## Tests

Two new source-level guards plus a behavioural one that runs a child interpreter with `HF_HUB_OFFLINE=1` (the notice prints before any download) and asserts the bare call prints a notice making no claim about a request, while an explicit `load_in_16bit = True` or `load_in_4bit = False` prints nothing.

Against the unfixed loader that file reports 9 failed, 6 passed; with the fix, 15 passed. Full run:

```
tests/test_bf16_quant_disabled_message.py
tests/test_offloaded_parameter_hint.py
tests/test_kaggle_gguf_error_message.py
58 passed
```

One trap for anyone rewording the message later: the guard detector matches the substring `load in 16bit` through `ast.get_source_segment`, so wrapping the f-string such that the phrase spans two source lines makes all four guards invisible to the tests.