### PR TITLE
Studio: bound repeated llama-server respawns after SIGKILL

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -462,6 +462,15 @@ class GgufLoadIntent:
             object.__setattr__(self, "gpu_ids", None)
 
 
+@dataclass(frozen = True)
+class _RespawnRetryToken:
+    """One automatic retry, completed only by its own terminal SSE event."""
+
+    process: Any
+    attempt_id: Optional[int]
+    unload_epoch: int
+
+
 class _CpuFallbackRuntime(NamedTuple):
     tempdir: tempfile.TemporaryDirectory
     source_binary: Path
@@ -4895,6 +4904,7 @@ class LlamaCppBackend:
         # receives a fresh budget even when it repeats the same model settings.
         self._respawn_attempts = 0
         self._respawned_process = None
+        self._respawn_attempt_id = 0
         # Bumped by every unload. load_model clears _cancel_event, so a respawn that
         # raced an unload needs a signal that survives the clear (see _respawn_if_dead).
         self._unload_epoch = 0
@@ -23456,7 +23466,7 @@ class LlamaCppBackend:
         except OSError:
             return False
 
-    def _respawn_if_dead(self) -> bool:
+    def _respawn_if_dead(self) -> Optional[_RespawnRetryToken]:
         """Relaunch the llama-server if its process has exited.
 
         A loaded chat model can be SIGKILL'd mid-session (usually GPU/RAM pressure
@@ -23472,20 +23482,28 @@ class LlamaCppBackend:
         with self._respawn_lock:
             proc = self._process
             if proc is None:
-                return False
+                return None
             if self._cancel_event.is_set():
                 # unload_model sets this before it kills, so the child can still be
                 # accepting. Reporting it healthy would aim the retry at a server
                 # that is deliberately going away.
-                return False
+                return None
             if proc is not served_by:
                 # Replaced while we queued: this child never served our request.
-                return self._healthy
+                return (
+                    _RespawnRetryToken(proc, None, self._unload_epoch)
+                    if self._healthy
+                    else None
+                )
             if proc.poll() is None:
                 # Still serving, so the error was transient. Charging it the grace below
                 # would cost a second per caller, serialised under this lock.
                 if self._server_socket_is_open():
-                    return self._healthy
+                    return (
+                        _RespawnRetryToken(proc, None, self._unload_epoch)
+                        if self._healthy
+                        else None
+                    )
                 # A closing server can beat its own exit status: calling it alive returns
                 # the stale _healthy and spends the retry on the corpse.
                 deadline = time.monotonic() + _RESPAWN_REAP_GRACE_S
@@ -23494,28 +23512,37 @@ class LlamaCppBackend:
             if proc.poll() is None:
                 # Alive: either a concurrent caller already respawned it (healthy), or
                 # this connection error wasn't a dead server.
-                return self._healthy
+                return (
+                    _RespawnRetryToken(proc, None, self._unload_epoch)
+                    if self._healthy
+                    else None
+                )
             with self._mtp_runtime_fallback_lock:
                 if self._mtp_runtime_fallback_in_progress:
                     # An MTP-free reload owns this corpse; replaying the old kwargs
                     # restarts the crashing config and aborts that reload.
                     logger.info("Respawn skipped: an MTP-free reload is already recovering.")
-                    return False
+                    return None
             # The RLock lets the load_model below re-enter it.
             with self._serial_load_lock:
                 if self._process is not proc:
                     logger.info("Respawn skipped: a newer load is already active.")
-                    return self._healthy
+                    current = self._process
+                    return (
+                        _RespawnRetryToken(current, None, self._unload_epoch)
+                        if self._healthy and current is not None
+                        else None
+                    )
                 # Snapshot under _lock, the one unload_model holds, so a teardown is
                 # either wholly before us (flag set) or wholly after (epoch bumped).
                 # _serial_load_lock alone would not exclude it: unload never takes it.
                 with self._lock:
                     if self._cancel_event.is_set():
                         logger.info("Respawn skipped: the model was unloaded.")
-                        return False
+                        return None
                     intent = self._last_load_intent
                     if intent is None:
-                        return False
+                        return None
                     if proc is not self._respawned_process:
                         self._respawn_attempts = 0
                     if self._respawn_attempts >= _MAX_CONSECUTIVE_RESPAWN_ATTEMPTS:
@@ -23525,8 +23552,10 @@ class LlamaCppBackend:
                             "without a completed generation. Reload the model after "
                             "reducing GPU/RAM pressure or changing its load settings."
                         )
-                        return False
+                        return None
                     self._respawn_attempts += 1
+                    self._respawn_attempt_id += 1
+                    attempt_id = self._respawn_attempt_id
                     # Record before load_model: if it raises while leaving this corpse
                     # installed, the next request must retain the consumed attempt.
                     self._respawned_process = proc
@@ -23541,7 +23570,7 @@ class LlamaCppBackend:
                 except Exception as exc:
                     self._respawned_process = self._process or proc
                     logger.error(f"Failed to respawn llama-server: {exc}")
-                    return False
+                    return None
                 self._respawned_process = self._process or proc
                 if started and self._unload_epoch != epoch:
                     # An unload landed mid-reload. load_model cleared _cancel_event on
@@ -23549,13 +23578,23 @@ class LlamaCppBackend:
                     # replacement rather than leave a model the user stopped running.
                     logger.info("Respawn undone: the model was unloaded during the reload.")
                     self.unload_model()
-                    return False
-                return started
+                    return None
+                replacement = self._process
+                if not started or replacement is None:
+                    return None
+                return _RespawnRetryToken(replacement, attempt_id, epoch)
 
-    def _mark_respawn_recovered(self, proc) -> None:
-        """Reset the circuit after the respawned child completes a generation."""
+    def _complete_respawn_recovery(self, token: Optional[_RespawnRetryToken]) -> None:
+        """Reset only the automatic retry that emitted this terminal event."""
+        if token is None or token.attempt_id is None:
+            return
         with self._respawn_lock:
-            if self._process is proc and self._respawned_process is proc:
+            if (
+                self._process is token.process
+                and self._respawned_process is token.process
+                and self._respawn_attempt_id == token.attempt_id
+                and self._unload_epoch == token.unload_epoch
+            ):
                 self._respawn_attempts = 0
                 self._respawned_process = None
 
@@ -23582,23 +23621,25 @@ class LlamaCppBackend:
         excluded: the server is slow, not dead, and a replay would spend the
         first-token budget twice.
         """
+        retry_token = None
         for attempt in range(2):
             response_opened = False
-            opened_process = self._process
             try:
                 url = f"{self.base_url}/v1/chat/completions"
-                with self._open_stream(url, payload, cancel_event) as opened:
+                with self._open_stream(url, payload, cancel_event) as (
+                    response,
+                    first_token_deadline,
+                ):
                     response_opened = True
-                    opened_process = self._process
-                    yield opened
-                    self._mark_respawn_recovered(opened_process)
+                    yield response, first_token_deadline, retry_token
                     return
             except (httpx.NetworkError, httpx.RemoteProtocolError) as exc:
                 if response_opened:
                     raise
                 if self._maybe_recover_from_mtp_crash(exc):
                     raise RuntimeError("Lost connection to llama-server") from exc
-                if attempt == 0 and self._respawn_if_dead():
+                retry_token = self._respawn_if_dead() if attempt == 0 else None
+                if retry_token is not None:
                     logger.warning(
                         "llama-server was unreachable; respawned it and retrying the generation"
                     )
@@ -23634,6 +23675,7 @@ class LlamaCppBackend:
         thread_id: Optional[str] = None,
         tools_withheld: bool = False,
         _allow_respawn_retry: bool = True,
+        _respawn_retry_token: Optional[_RespawnRetryToken] = None,
     ) -> Generator[Union[str, dict], None, None]:
         """
         Send a chat completion to llama-server and stream tokens back.
@@ -23818,6 +23860,7 @@ class LlamaCppBackend:
                         if not line:
                             continue
                         if line == "data: [DONE]":
+                            self._complete_respawn_recovery(_respawn_retry_token)
                             if in_thinking:
                                 if has_content_tokens:
                                     # Real thinking + content: close the tag
@@ -23934,7 +23977,12 @@ class LlamaCppBackend:
             # generation once (bounded by the private flag, no duplicate output).
             if self._maybe_recover_from_mtp_crash(e):
                 raise RuntimeError("Lost connection to llama-server")
-            if _allow_respawn_retry and not cumulative and self._respawn_if_dead():
+            respawn_retry = (
+                self._respawn_if_dead()
+                if _allow_respawn_retry and not cumulative
+                else None
+            )
+            if respawn_retry is not None:
                 logger.warning(
                     "llama-server was unreachable; respawned it and retrying the generation"
                 )
@@ -23979,6 +24027,7 @@ class LlamaCppBackend:
                     # tools as the first attempt was.
                     tools_withheld = tools_withheld,
                     _allow_respawn_retry = False,
+                    _respawn_retry_token = respawn_retry,
                 )
                 return
             raise RuntimeError("Lost connection to llama-server")
@@ -24658,6 +24707,7 @@ class LlamaCppBackend:
                 ) as (
                     response,
                     first_token_deadline,
+                    _iteration_respawn_retry_token,
                 ):
                     for truncation in _respawn_truncations:
                         yield {"type": "context_truncated", **truncation}
@@ -24675,6 +24725,9 @@ class LlamaCppBackend:
                             if not line:
                                 continue
                             if line == "data: [DONE]":
+                                self._complete_respawn_recovery(
+                                    _iteration_respawn_retry_token
+                                )
                                 # Flush thinking state for STREAMING
                                 if detect_state == _S_STREAMING and in_thinking:
                                     if has_content_tokens:
@@ -26198,6 +26251,7 @@ class LlamaCppBackend:
             ) as (
                 response,
                 first_token_deadline,
+                _final_respawn_retry_token,
             ):
                 for truncation in _final_respawn_truncations:
                     yield {"type": "context_truncated", **truncation}
@@ -26215,6 +26269,7 @@ class LlamaCppBackend:
                         if not line:
                             continue
                         if line == "data: [DONE]":
+                            self._complete_respawn_recovery(_final_respawn_retry_token)
                             if in_thinking:
                                 if (
                                     _final_reasoning_started_at is not None

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -1233,6 +1233,10 @@ def _inject_recall(conversation: list[dict], recall: dict, style: str) -> Option
 # A transport error can arrive before the child is reapable; a request path cannot
 # afford the 5s the background MTP reload spends on the same race.
 _RESPAWN_REAP_GRACE_S = 1.0
+# Stop replaying a pressure-sensitive load forever across independent requests.
+# A completed generation resets the chain; an explicit load naturally presents a
+# different process and starts a fresh one.
+_MAX_CONSECUTIVE_RESPAWN_ATTEMPTS = 3
 
 
 def _finalize_reasoning_only_cumulative(
@@ -4886,6 +4890,11 @@ class LlamaCppBackend:
         # Serialises mid-session respawns so many generations hitting a killed
         # server trigger at most one reload (see _respawn_if_dead).
         self._respawn_lock = threading.Lock()
+        # Process identity ties the counter to one automatic-recovery chain. A
+        # caller-driven load replaces the process without recording it here, so it
+        # receives a fresh budget even when it repeats the same model settings.
+        self._respawn_attempts = 0
+        self._respawned_process = None
         # Bumped by every unload. load_model clears _cancel_event, so a respawn that
         # raced an unload needs a signal that survives the clear (see _respawn_if_dead).
         self._unload_epoch = 0
@@ -23507,6 +23516,20 @@ class LlamaCppBackend:
                     intent = self._last_load_intent
                     if intent is None:
                         return False
+                    if proc is not self._respawned_process:
+                        self._respawn_attempts = 0
+                    if self._respawn_attempts >= _MAX_CONSECUTIVE_RESPAWN_ATTEMPTS:
+                        logger.error(
+                            "Automatic llama-server recovery stopped after "
+                            f"{_MAX_CONSECUTIVE_RESPAWN_ATTEMPTS} consecutive respawns "
+                            "without a completed generation. Reload the model after "
+                            "reducing GPU/RAM pressure or changing its load settings."
+                        )
+                        return False
+                    self._respawn_attempts += 1
+                    # Record before load_model: if it raises while leaving this corpse
+                    # installed, the next request must retain the consumed attempt.
+                    self._respawned_process = proc
                     epoch = self._unload_epoch
                     self._healthy = False
                 logger.warning(
@@ -23516,8 +23539,10 @@ class LlamaCppBackend:
                 try:
                     started = bool(self.load_model(intent))
                 except Exception as exc:
+                    self._respawned_process = self._process or proc
                     logger.error(f"Failed to respawn llama-server: {exc}")
                     return False
+                self._respawned_process = self._process or proc
                 if started and self._unload_epoch != epoch:
                     # An unload landed mid-reload. load_model cleared _cancel_event on
                     # the way in, so the epoch is the only surviving evidence; undo the
@@ -23526,6 +23551,13 @@ class LlamaCppBackend:
                     self.unload_model()
                     return False
                 return started
+
+    def _mark_respawn_recovered(self, proc) -> None:
+        """Reset the circuit after the respawned child completes a generation."""
+        with self._respawn_lock:
+            if self._process is proc and self._respawned_process is proc:
+                self._respawn_attempts = 0
+                self._respawned_process = None
 
     @contextlib.contextmanager
     def _open_chat_stream_with_respawn_retry(
@@ -23552,11 +23584,14 @@ class LlamaCppBackend:
         """
         for attempt in range(2):
             response_opened = False
+            opened_process = self._process
             try:
                 url = f"{self.base_url}/v1/chat/completions"
                 with self._open_stream(url, payload, cancel_event) as opened:
                     response_opened = True
+                    opened_process = self._process
                     yield opened
+                    self._mark_respawn_recovered(opened_process)
                     return
             except (httpx.NetworkError, httpx.RemoteProtocolError) as exc:
                 if response_opened:

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -23490,11 +23490,7 @@ class LlamaCppBackend:
                 return None
             if proc is not served_by:
                 # Replaced while we queued: this child never served our request.
-                return (
-                    _RespawnRetryToken(proc, None, self._unload_epoch)
-                    if self._healthy
-                    else None
-                )
+                return _RespawnRetryToken(proc, None, self._unload_epoch) if self._healthy else None
             if proc.poll() is None:
                 # Still serving, so the error was transient. Charging it the grace below
                 # would cost a second per caller, serialised under this lock.
@@ -23512,11 +23508,7 @@ class LlamaCppBackend:
             if proc.poll() is None:
                 # Alive: either a concurrent caller already respawned it (healthy), or
                 # this connection error wasn't a dead server.
-                return (
-                    _RespawnRetryToken(proc, None, self._unload_epoch)
-                    if self._healthy
-                    else None
-                )
+                return _RespawnRetryToken(proc, None, self._unload_epoch) if self._healthy else None
             with self._mtp_runtime_fallback_lock:
                 if self._mtp_runtime_fallback_in_progress:
                     # An MTP-free reload owns this corpse; replaying the old kwargs
@@ -23978,9 +23970,7 @@ class LlamaCppBackend:
             if self._maybe_recover_from_mtp_crash(e):
                 raise RuntimeError("Lost connection to llama-server")
             respawn_retry = (
-                self._respawn_if_dead()
-                if _allow_respawn_retry and not cumulative
-                else None
+                self._respawn_if_dead() if _allow_respawn_retry and not cumulative else None
             )
             if respawn_retry is not None:
                 logger.warning(
@@ -24725,9 +24715,7 @@ class LlamaCppBackend:
                             if not line:
                                 continue
                             if line == "data: [DONE]":
-                                self._complete_respawn_recovery(
-                                    _iteration_respawn_retry_token
-                                )
+                                self._complete_respawn_recovery(_iteration_respawn_retry_token)
                                 # Flush thinking state for STREAMING
                                 if detect_state == _S_STREAMING and in_thinking:
                                     if has_content_tokens:

--- a/tests/studio/test_llama_cpp_respawn_budget.py
+++ b/tests/studio/test_llama_cpp_respawn_budget.py
@@ -1,0 +1,98 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+"""Regression tests for bounded llama-server crash recovery."""
+
+from __future__ import annotations
+
+import sys
+from contextlib import contextmanager
+from pathlib import Path
+
+import httpx
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+STUDIO_BACKEND = REPO_ROOT / "studio" / "backend"
+if str(STUDIO_BACKEND) not in sys.path:
+    sys.path.insert(0, str(STUDIO_BACKEND))
+
+from core.inference.llama_cpp import GgufLoadIntent, LlamaCppBackend  # noqa: E402
+
+
+class _Process:
+    def __init__(self, returncode: int | None = -9) -> None:
+        self.returncode = returncode
+
+    def poll(self) -> int | None:
+        return self.returncode
+
+
+def _backend_with_dead_process() -> LlamaCppBackend:
+    backend = LlamaCppBackend()
+    backend._process = _Process()
+    backend._healthy = True
+    backend._model_identifier = "pressure-sensitive"
+    backend._last_load_intent = GgufLoadIntent(
+        model_identifier = "pressure-sensitive",
+        n_ctx = 16384,
+    )
+    return backend
+
+
+def test_repeated_failed_recoveries_stop_replaying_the_same_intent() -> None:
+    backend = _backend_with_dead_process()
+    loads: list[GgufLoadIntent] = []
+
+    def load_model(intent: GgufLoadIntent) -> bool:
+        loads.append(intent)
+        backend._process = _Process()
+        backend._healthy = True
+        return True
+
+    backend.load_model = load_model
+
+    results = [backend._respawn_if_dead() for _ in range(5)]
+
+    assert results == [True, True, True, False, False]
+    assert loads == [backend._last_load_intent] * 3
+
+
+def test_completed_generation_restores_the_respawn_budget() -> None:
+    backend = _backend_with_dead_process()
+    loads: list[GgufLoadIntent] = []
+
+    def dead_load(intent: GgufLoadIntent) -> bool:
+        loads.append(intent)
+        backend._process = _Process()
+        backend._healthy = True
+        return True
+
+    backend.load_model = dead_load
+    assert backend._respawn_if_dead() is True
+    assert backend._respawn_if_dead() is True
+
+    stream_attempts = 0
+
+    @contextmanager
+    def open_stream(url, payload, cancel_event):
+        nonlocal stream_attempts
+        stream_attempts += 1
+        if stream_attempts == 1:
+            raise httpx.ConnectError("forced dead child")
+        yield object()
+
+    def healthy_load(intent: GgufLoadIntent) -> bool:
+        loads.append(intent)
+        backend._process = _Process(returncode = None)
+        backend._healthy = True
+        return True
+
+    backend._open_stream = open_stream
+    backend.load_model = healthy_load
+    with backend._open_chat_stream_with_respawn_retry({}, None):
+        pass
+
+    backend._process.returncode = -9
+    backend.load_model = dead_load
+    assert [backend._respawn_if_dead() for _ in range(4)] == [True, True, True, False]
+

--- a/tests/studio/test_llama_cpp_respawn_budget.py
+++ b/tests/studio/test_llama_cpp_respawn_budget.py
@@ -51,13 +51,13 @@ def test_repeated_failed_recoveries_stop_replaying_the_same_intent() -> None:
 
     backend.load_model = load_model
 
-    results = [backend._respawn_if_dead() for _ in range(5)]
+    results = [bool(backend._respawn_if_dead()) for _ in range(5)]
 
     assert results == [True, True, True, False, False]
     assert loads == [backend._last_load_intent] * 3
 
 
-def test_completed_generation_restores_the_respawn_budget() -> None:
+def test_opened_stream_does_not_restore_the_budget_before_done() -> None:
     backend = _backend_with_dead_process()
     loads: list[GgufLoadIntent] = []
 
@@ -68,8 +68,8 @@ def test_completed_generation_restores_the_respawn_budget() -> None:
         return True
 
     backend.load_model = dead_load
-    assert backend._respawn_if_dead() is True
-    assert backend._respawn_if_dead() is True
+    assert backend._respawn_if_dead() is not None
+    assert backend._respawn_if_dead() is not None
 
     stream_attempts = 0
 
@@ -79,7 +79,7 @@ def test_completed_generation_restores_the_respawn_budget() -> None:
         stream_attempts += 1
         if stream_attempts == 1:
             raise httpx.ConnectError("forced dead child")
-        yield object()
+        yield object(), None
 
     def healthy_load(intent: GgufLoadIntent) -> bool:
         loads.append(intent)
@@ -94,24 +94,14 @@ def test_completed_generation_restores_the_respawn_budget() -> None:
 
     backend._process.returncode = -9
     backend.load_model = dead_load
-    assert [backend._respawn_if_dead() for _ in range(4)] == [True, True, True, False]
+    assert backend._respawn_if_dead() is None
 
 
-def test_later_completed_generation_also_restores_the_budget() -> None:
+def test_caller_driven_new_process_starts_a_fresh_budget() -> None:
     backend = _backend_with_dead_process()
-    backend._process = _Process(returncode = None)
-    backend._respawned_process = backend._process
     backend._respawn_attempts = 3
-
-    @contextmanager
-    def open_stream(url, payload, cancel_event):
-        yield object()
-
-    backend._open_stream = open_stream
-    with backend._open_chat_stream_with_respawn_retry({}, None):
-        pass
-
-    backend._process.returncode = -9
+    backend._respawned_process = backend._process
+    backend._process = _Process()
 
     def dead_load(intent: GgufLoadIntent) -> bool:
         backend._process = _Process()
@@ -119,4 +109,54 @@ def test_later_completed_generation_also_restores_the_budget() -> None:
         return True
 
     backend.load_model = dead_load
-    assert [backend._respawn_if_dead() for _ in range(4)] == [True, True, True, False]
+    assert [bool(backend._respawn_if_dead()) for _ in range(4)] == [True, True, True, False]
+
+
+def test_direct_completion_recovery_restores_the_budget_each_time() -> None:
+    backend = _backend_with_dead_process()
+    backend._port = 1
+    stream_attempts = 0
+
+    @contextmanager
+    def open_stream(url, payload, cancel_event):
+        nonlocal stream_attempts
+        stream_attempts += 1
+        if stream_attempts % 2:
+            raise httpx.ConnectError("forced dead child")
+        yield object(), None
+
+    def healthy_load(intent: GgufLoadIntent) -> bool:
+        backend._process = _Process(returncode = None)
+        backend._healthy = True
+        return True
+
+    backend._open_stream = open_stream
+    backend._iter_text_cancellable = lambda *args, **kwargs: iter(["data: [DONE]\n"])
+    backend._maybe_recover_from_mtp_crash = lambda exc: False
+    backend.load_model = healthy_load
+
+    for _ in range(4):
+        list(backend.generate_chat_completion([{"role": "user", "content": "ping"}]))
+        backend._process.returncode = -9
+
+    assert stream_attempts == 8
+
+
+def test_stale_completion_token_cannot_reset_a_newer_recovery() -> None:
+    backend = _backend_with_dead_process()
+
+    def dead_load(intent: GgufLoadIntent) -> bool:
+        backend._process = _Process()
+        backend._healthy = True
+        return True
+
+    backend.load_model = dead_load
+    first = backend._respawn_if_dead()
+    second = backend._respawn_if_dead()
+    assert first is not None and second is not None
+
+    backend._complete_respawn_recovery(first)
+    assert backend._respawn_attempts == 2
+
+    backend._complete_respawn_recovery(second)
+    assert backend._respawn_attempts == 0

--- a/tests/studio/test_llama_cpp_respawn_budget.py
+++ b/tests/studio/test_llama_cpp_respawn_budget.py
@@ -96,3 +96,27 @@ def test_completed_generation_restores_the_respawn_budget() -> None:
     backend.load_model = dead_load
     assert [backend._respawn_if_dead() for _ in range(4)] == [True, True, True, False]
 
+
+def test_later_completed_generation_also_restores_the_budget() -> None:
+    backend = _backend_with_dead_process()
+    backend._process = _Process(returncode = None)
+    backend._respawned_process = backend._process
+    backend._respawn_attempts = 3
+
+    @contextmanager
+    def open_stream(url, payload, cancel_event):
+        yield object()
+
+    backend._open_stream = open_stream
+    with backend._open_chat_stream_with_respawn_retry({}, None):
+        pass
+
+    backend._process.returncode = -9
+
+    def dead_load(intent: GgufLoadIntent) -> bool:
+        backend._process = _Process()
+        backend._healthy = True
+        return True
+
+    backend.load_model = dead_load
+    assert [backend._respawn_if_dead() for _ in range(4)] == [True, True, True, False]


### PR DESCRIPTION
## Summary

- stop automatically replaying the same llama.cpp load intent after three consecutive
  respawns that never complete a generation;
- bind recovery completion to a one-shot token for the exact respawn attempt, replacement
  process, and unload epoch;
- restore the respawn budget only after the recovered stream reaches `data: [DONE]`;
- cover repeated deaths, incomplete streams, successful recovery, caller-driven replacement,
  and stale completion tokens.

Closes #9688.

## Why

Studio already limits a retry inside one generation request, but every independent request
gets a fresh retry. If `llama-server` and each replacement die before completing a generation,
the next request replays `_last_load_intent` again indefinitely.

A deterministic pre-fix reproduction issued five independent requests after five child
deaths and observed five `load_model` replays. The same real-process SIGKILL harness now
observes three replays followed by two refusals:

```text
before: [true, true, true, true, true]  load_model calls = 5
after:  [true, true, true, false, false] load_model calls = 3
```

The reset deliberately occurs at the exact SSE terminal event rather than when a context
manager closes: closing may also mean cancellation or an exception. Attempt/process/epoch
matching prevents an old or unrelated completion from resetting a newer failure chain.

This change does not claim that a production OOM occurred. No live OOM was observed or
induced; the report and patch reproduce the supervisor behavior with lightweight child
processes terminated by SIGKILL.

## Validation

- `pytest -q tests/studio/test_llama_cpp_respawn_budget.py` — 5 passed
- adjacent Studio suite — 76 passed, 0 failed, 0 skipped
- temporary real-process SIGKILL harness — 1 passed
- `ruff check studio/backend/core/inference/llama_cpp.py tests/studio/test_llama_cpp_respawn_budget.py` — passed
- `git diff --check origin/main...HEAD` — passed
