### PR TITLE
Name the encoding when the poll probe writes its artifact

### DIFF
--- a/tests/studio/playwright_declared_polls.py
+++ b/tests/studio/playwright_declared_polls.py
@@ -218,7 +218,8 @@ def main() -> int:
                 "undeclared": undeclared,
             },
             indent = 2,
-        )
+        ),
+        encoding = "utf-8",
     )
 
     info(


### PR DESCRIPTION
`tests/test_source_read_encoding.py` has been failing on main since #9665 landed, which blocks every open PR as soon as it merges main in.

```
AssertionError: 1 file reads in the test trees touch a checked-in file with the
platform default encoding, so they break on Windows as soon as that file gains a
non-ASCII byte. Pass encoding = "utf-8":
['tests/studio/playwright_declared_polls.py:210: write_text()']
```

`observed_polls.json` is written with the platform default encoding. One line, matching every other checked-in file write in the test trees.

Verified the guard is not vacuous: with the fix the run is green, and with the `encoding` argument removed again the same run fails naming this exact call site. The file was restored from an md5-verified byte snapshot rather than a checkout.