### PR TITLE
Name the encoding when the declared-polls probe writes its artifact

### DIFF
--- a/tests/studio/playwright_declared_polls.py
+++ b/tests/studio/playwright_declared_polls.py
@@ -218,7 +218,8 @@ def main() -> int:
                 "undeclared": undeclared,
             },
             indent = 2,
-        )
+        ),
+        encoding = "utf-8",
     )
 
     info(


### PR DESCRIPTION
`tests/test_source_read_encoding.py` scans the test trees for reads and writes that take the platform default encoding. On Windows that is not UTF-8, so such a call breaks as soon as the file gains a non-ASCII byte.

`tests/studio/playwright_declared_polls.py:210` was the single offender, so `Repo tests (CPU)` has been red on main since that probe landed, and every PR that merges main inherits the failure:

```
AssertionError: 1 file reads in the test trees touch a checked-in file with the platform
default encoding, so they break on Windows as soon as that file gains a non-ASCII byte.
Pass encoding = "utf-8": ['tests/studio/playwright_declared_polls.py:210: write_text()']
```

One keyword. `tests/test_source_read_encoding.py` passes with it and fails without it.