### PR TITLE
Name the encoding when the poll watcher writes its artifact

### DIFF
--- a/tests/studio/playwright_declared_polls.py
+++ b/tests/studio/playwright_declared_polls.py
@@ -218,7 +218,8 @@ def main() -> int:
                 "undeclared": undeclared,
             },
             indent = 2,
-        )
+        ),
+        encoding = "utf-8",
     )
 
     info(


### PR DESCRIPTION
`tests/test_source_read_encoding.py::test_checked_in_file_reads_name_an_encoding` fails on `main`:

```
AssertionError: 1 file reads in the test trees touch a checked-in file with the
platform default encoding, so they break on Windows as soon as that file gains a
non-ASCII byte. Pass encoding = "utf-8":
['tests/studio/playwright_declared_polls.py:210: write_text()']
```

That makes **Repo tests (CPU)**, and so the whole Backend CI job, red on every open PR, which hides real failures behind a defect none of those branches introduced. I hit it on two unrelated PRs and traced it back to `main`.

One call, and the only one left in the file: line 99 is `urlopen`, which is unrelated.

Verified on a staging replica of current `main`: Backend CI fails there without this and the guard test passes with it. `ruff check` clean.