### PR TITLE
Bump install.sh / install.ps1 pin to unsloth>=2026.8.21

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -5647,7 +5647,7 @@ exit 0
 
     $_desktopMinVer = if ($env:UNSLOTH_DESKTOP_BACKEND_VERSION) { $env:UNSLOTH_DESKTOP_BACKEND_VERSION.Trim() } else { "" }
     $_unslothDesktopInstallSpec = if ($_desktopMinVer) { "unsloth>=$_desktopMinVer" } else { $null }
-    $_unslothReleaseInstallSpec = if ($_unslothDesktopInstallSpec) { $_unslothDesktopInstallSpec } else { "unsloth>=2026.8.20" }
+    $_unslothReleaseInstallSpec = if ($_unslothDesktopInstallSpec) { $_unslothDesktopInstallSpec } else { "unsloth>=2026.8.21" }
 
     if ($_Migrated) {
         # Migrated env: force-reinstall unsloth+unsloth-zoo for a clean state, preserving

--- a/install.sh
+++ b/install.sh
@@ -5189,7 +5189,7 @@ _unsloth_desktop_install_spec=""
 if [ -n "${UNSLOTH_DESKTOP_BACKEND_VERSION:-}" ]; then
     _unsloth_desktop_install_spec="unsloth>=${UNSLOTH_DESKTOP_BACKEND_VERSION}"
 fi
-_unsloth_release_install_spec="${_unsloth_desktop_install_spec:-unsloth>=2026.8.20}"
+_unsloth_release_install_spec="${_unsloth_desktop_install_spec:-unsloth>=2026.8.21}"
 
 if [ "$_MIGRATED" = true ]; then
     # Migrated env: force-reinstall unsloth+unsloth-zoo for a clean state, preserving


### PR DESCRIPTION
## Summary

- PyPI release [unsloth 2026.8.21](https://pypi.org/project/unsloth/2026.8.21/) is now live.
- Bumps the pinned `unsloth` floor in `install.sh` and `install.ps1` from `unsloth>=2026.8.20` to `unsloth>=2026.8.21` so fresh installs resolve to the new wheel.
- The `unsloth-zoo` floor stays at `unsloth-zoo>=2026.8.15`, which is still the current PyPI release, so it is already correct after #9693.
- Tagged on main as `v0.1.803-beta`.

Follows the same pattern as #5716 and #9693.

## Test plan

- [ ] Sanity-run `install.sh` on a clean Linux host
- [ ] Sanity-run `install.ps1` on a clean Windows host
- [ ] Confirm `uv pip install "unsloth>=2026.8.21"` resolves cleanly