### PR TITLE
fix: [Bug] import unsloth failed and shows UnicodeDecodeError

### DIFF
--- a/tests/test_subprocess_encoding.py
+++ b/tests/test_subprocess_encoding.py
@@ -1,0 +1,80 @@
+import importlib.util
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+
+
+def _load_subprocess_encoding_module():
+    module_path = (
+        Path(__file__).resolve().parents[1]
+        / "unsloth"
+        / "_subprocess_encoding.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "unsloth_subprocess_encoding_test",
+        module_path,
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _invalid_utf8_command():
+    return [
+        sys.executable,
+        "-c",
+        "import sys; sys.stdout.buffer.write(bytes([0xf8]))",
+    ]
+
+
+def test_replaces_invalid_bytes_for_text_subprocesses():
+    helper = _load_subprocess_encoding_module()
+
+    with pytest.raises(UnicodeDecodeError):
+        subprocess.run(
+            _invalid_utf8_command(),
+            stdout = subprocess.PIPE,
+            check = True,
+            encoding = "utf-8",
+        )
+
+    with helper.replace_subprocess_decode_errors():
+        result = subprocess.run(
+            _invalid_utf8_command(),
+            stdout = subprocess.PIPE,
+            check = True,
+            encoding = "utf-8",
+        )
+
+    assert result.stdout == "\ufffd"
+
+
+def test_preserves_binary_subprocess_output():
+    helper = _load_subprocess_encoding_module()
+
+    with helper.replace_subprocess_decode_errors():
+        result = subprocess.run(
+            _invalid_utf8_command(),
+            stdout = subprocess.PIPE,
+            check = True,
+        )
+
+    assert result.stdout == bytes([0xf8])
+
+
+def test_restores_popen_after_success_and_error():
+    helper = _load_subprocess_encoding_module()
+    original_popen = subprocess.Popen
+
+    with helper.replace_subprocess_decode_errors():
+        assert subprocess.Popen is not original_popen
+    assert subprocess.Popen is original_popen
+
+    with pytest.raises(RuntimeError):
+        with helper.replace_subprocess_decode_errors():
+            assert subprocess.Popen is not original_popen
+            raise RuntimeError("stop initialization")
+
+    assert subprocess.Popen is original_popen

--- a/tests/test_subprocess_encoding.py
+++ b/tests/test_subprocess_encoding.py
@@ -7,11 +7,7 @@ import pytest
 
 
 def _load_subprocess_encoding_module():
-    module_path = (
-        Path(__file__).resolve().parents[1]
-        / "unsloth"
-        / "_subprocess_encoding.py"
-    )
+    module_path = Path(__file__).resolve().parents[1] / "unsloth" / "_subprocess_encoding.py"
     spec = importlib.util.spec_from_file_location(
         "unsloth_subprocess_encoding_test",
         module_path,
@@ -61,7 +57,7 @@ def test_preserves_binary_subprocess_output():
             check = True,
         )
 
-    assert result.stdout == bytes([0xf8])
+    assert result.stdout == bytes([0xF8])
 
 
 def test_restores_popen_after_success_and_error():

--- a/unsloth/__init__.py
+++ b/unsloth/__init__.py
@@ -1528,8 +1528,11 @@ if _IS_MLX:
 
 else:
     # GPU path: load everything from _gpu_init
-    from ._gpu_init import *
-    from ._gpu_init import __version__
+    from ._subprocess_encoding import replace_subprocess_decode_errors as _safe_subprocess_text
+    with _safe_subprocess_text():
+        from ._gpu_init import *
+        from ._gpu_init import __version__
+    del _safe_subprocess_text
 
     def get_gpu_memory_stats():
         """Return CUDA/ROCm/XPU device stats, peak memory, and total memory in GiB."""

--- a/unsloth/__init__.py
+++ b/unsloth/__init__.py
@@ -1529,6 +1529,7 @@ if _IS_MLX:
 else:
     # GPU path: load everything from _gpu_init
     from ._subprocess_encoding import replace_subprocess_decode_errors as _safe_subprocess_text
+
     with _safe_subprocess_text():
         from ._gpu_init import *
         from ._gpu_init import __version__

--- a/unsloth/_subprocess_encoding.py
+++ b/unsloth/_subprocess_encoding.py
@@ -1,0 +1,54 @@
+# Copyright 2023-present Daniel Han-Chen & the Unsloth team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Compatibility helpers for text emitted by platform probing commands."""
+
+import contextlib
+import subprocess
+
+
+@contextlib.contextmanager
+def replace_subprocess_decode_errors():
+    """Replace malformed bytes from text subprocesses created in this scope.
+
+    GPU libraries probe commands such as ``nvidia-smi`` and ``ldconfig`` while
+    they are imported. Some WSL installations return bytes that are invalid in
+    the process locale even though the probing library requests UTF-8 text.
+    Such diagnostic output must not make ``import unsloth`` fail.
+
+    Binary subprocesses and callers that choose an explicit ``errors`` policy
+    retain their existing behavior. The Popen replacement is also removed when
+    the scoped import raises.
+    """
+    original_popen = subprocess.Popen
+
+    class EncodingSafePopen(original_popen):
+        def __init__(self, *args, **kwargs):
+            text_mode = (
+                kwargs.get("text", False)
+                or kwargs.get("universal_newlines", False)
+                or kwargs.get("encoding") is not None
+            )
+            if text_mode:
+                kwargs.setdefault("errors", "replace")
+            super().__init__(*args, **kwargs)
+
+    subprocess.Popen = EncodingSafePopen
+    try:
+        yield
+    finally:
+        # Avoid overwriting a replacement installed independently while the
+        # context was active.
+        if subprocess.Popen is EncodingSafePopen:
+            subprocess.Popen = original_popen


### PR DESCRIPTION
Closes #2489

I used an AI coding assistant to help draft this patch, then reviewed the diff and ran the test suite locally before opening this PR. Happy to make adjustments if the approach doesn't fit the project's conventions.

Tests: `python -m pytest -q tests/test_subprocess_encoding.py`