### PR TITLE
fix: [Bug] import unsloth failed and shows UnicodeDecodeError

### DIFF
--- a/tests/test_subprocess_encoding.py
+++ b/tests/test_subprocess_encoding.py
@@ -1,0 +1,62 @@
+import importlib.util
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+
+
+def _load_subprocess_encoding_module():
+    # Loading through `import unsloth...` would execute the package initializer
+    # whose GPU import behavior this helper is intended to protect.
+    path = Path(__file__).resolve().parents[1] / "unsloth" / "_subprocess_encoding.py"
+    spec = importlib.util.spec_from_file_location("_unsloth_subprocess_encoding_test", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _invalid_utf8_command():
+    return [
+        sys.executable,
+        "-c",
+        "import os; os.write(1, b'\\xf8GPU')",
+    ]
+
+
+def test_replaces_invalid_text_output_and_restores_popen():
+    module = _load_subprocess_encoding_module()
+    original_popen = subprocess.Popen
+
+    with pytest.raises(UnicodeDecodeError):
+        subprocess.check_output(_invalid_utf8_command(), encoding = "utf-8")
+
+    with module.replace_invalid_subprocess_text():
+        output = subprocess.check_output(_invalid_utf8_command(), encoding = "utf-8")
+        assert output == "\ufffdGPU"
+
+    assert subprocess.Popen is original_popen
+
+
+def test_preserves_explicit_strict_decoding_policy():
+    module = _load_subprocess_encoding_module()
+
+    with module.replace_invalid_subprocess_text():
+        with pytest.raises(UnicodeDecodeError):
+            subprocess.check_output(
+                _invalid_utf8_command(),
+                encoding = "utf-8",
+                errors = "strict",
+            )
+
+
+def test_restores_popen_when_context_body_raises():
+    module = _load_subprocess_encoding_module()
+    original_popen = subprocess.Popen
+
+    with pytest.raises(RuntimeError, match = "backend import failed"):
+        with module.replace_invalid_subprocess_text():
+            assert subprocess.Popen is not original_popen
+            raise RuntimeError("backend import failed")
+
+    assert subprocess.Popen is original_popen

--- a/unsloth/__init__.py
+++ b/unsloth/__init__.py
@@ -1532,6 +1532,7 @@ else:
     # the package itself unimportable. Keep the relaxed decoding scoped to the
     # backend import and preserve explicit subprocess error policies.
     from ._subprocess_encoding import replace_invalid_subprocess_text as _safe_probe_text
+
     with _safe_probe_text():
         # GPU path: load everything from _gpu_init
         from ._gpu_init import *

--- a/unsloth/__init__.py
+++ b/unsloth/__init__.py
@@ -1527,9 +1527,16 @@ if _IS_MLX:
     _install_mlx_unsloth_trainer_shim()
 
 else:
-    # GPU path: load everything from _gpu_init
-    from ._gpu_init import *
-    from ._gpu_init import __version__
+    # GPU startup probes can invoke driver/system utilities whose output is not
+    # valid UTF-8 (notably under WSL). A malformed diagnostic byte must not make
+    # the package itself unimportable. Keep the relaxed decoding scoped to the
+    # backend import and preserve explicit subprocess error policies.
+    from ._subprocess_encoding import replace_invalid_subprocess_text as _safe_probe_text
+    with _safe_probe_text():
+        # GPU path: load everything from _gpu_init
+        from ._gpu_init import *
+        from ._gpu_init import __version__
+    del _safe_probe_text
 
     def get_gpu_memory_stats():
         """Return CUDA/ROCm/XPU device stats, peak memory, and total memory in GiB."""

--- a/unsloth/_subprocess_encoding.py
+++ b/unsloth/_subprocess_encoding.py
@@ -1,0 +1,51 @@
+# Copyright 2023-present Daniel Han-Chen & the Unsloth team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import contextlib
+import subprocess
+
+
+@contextlib.contextmanager
+def replace_invalid_subprocess_text():
+    """Replace malformed bytes in text subprocesses created within the context.
+
+    GPU discovery code and imported dependencies may execute system utilities
+    such as driver probes. Their diagnostic output is not guaranteed to match
+    the process locale, particularly when Windows tools are exposed through
+    WSL. Python otherwise decodes text-mode output strictly and can turn one
+    malformed diagnostic byte into an import-time UnicodeDecodeError.
+
+    Callers that explicitly select an error policy remain authoritative, and
+    binary subprocesses are unchanged.
+    """
+    original_popen = subprocess.Popen
+
+    def safe_popen(*args, **kwargs):
+        text_mode = (
+            kwargs.get("text", False)
+            or kwargs.get("universal_newlines", False)
+            or kwargs.get("encoding") is not None
+        )
+        if text_mode and kwargs.get("errors") is None:
+            kwargs["errors"] = "replace"
+        return original_popen(*args, **kwargs)
+
+    subprocess.Popen = safe_popen
+    try:
+        yield
+    finally:
+        # Avoid overwriting an unrelated patch installed while the context was
+        # active. Nested uses restore correctly because each owns its wrapper.
+        if subprocess.Popen is safe_popen:
+            subprocess.Popen = original_popen


### PR DESCRIPTION
Closes #2489

I used an AI coding assistant to help draft this patch, then reviewed the diff and ran the test suite locally before opening this PR. Happy to make adjustments if the approach doesn't fit the project's conventions.

Tests: `python -m pytest -q tests/test_subprocess_encoding.py`