### PR TITLE
Name the encoding when the poll probe writes its artifact

### DIFF
--- a/tests/studio/playwright_declared_polls.py
+++ b/tests/studio/playwright_declared_polls.py
@@ -218,7 +218,8 @@ def main() -> int:
                 "undeclared": undeclared,
             },
             indent = 2,
-        )
+        ),
+        encoding = "utf-8",
     )
 
     info(


### PR DESCRIPTION
`test_checked_in_file_reads_name_an_encoding` is red on `main`, so every pull request opened against it currently fails `Repo tests (CPU)` on this one line.

`tests/studio/playwright_declared_polls.py:210` writes `observed_polls.json` with the platform default encoding. That breaks on Windows as soon as the artifact carries a non-ASCII byte, and it can: the keys are observed API paths.

Reproduced on a clean checkout of `main` at 96a0900f4 with no other changes:

```
FAILED tests/test_source_read_encoding.py::test_checked_in_file_reads_name_an_encoding
AssertionError: 1 file reads in the test trees touch a checked-in file with the
platform default encoding ... ['tests/studio/playwright_declared_polls.py:210: write_text()']
```

With `encoding = "utf-8"` the guard passes. Found while driving #9701, whose CI this was blocking.