### PR TITLE
studio: dump the backend's own thread stacks while a stall is in progress

### DIFF
--- a/.github/workflows/studio-mac-ui-smoke.yml
+++ b/.github/workflows/studio-mac-ui-smoke.yml
@@ -136,6 +136,10 @@ jobs:
       GGUF_VARIANT: UD-Q4_K_XL
       GGUF_FILE: gemma-3-270m-it-UD-Q4_K_XL.gguf
       STUDIO_PORT: '18896'
+      # The backend stall watchdog (#9712) is diagnostic and off by default; arm
+      # it for every phase here so the next stall leaves a thread dump in that
+      # phase's server log.
+      UNSLOTH_STUDIO_STALL_WATCHDOG: '1'
       HF_HOME: ${{ github.workspace }}/hf-cache
       # GitHub's macOS runners expose a PARAVIRTUAL Metal device, and Unsloth refuses to
       # offload to it because paravirtual Apple GPUs return corrupt output. The absorbed

--- a/studio/backend/main.py
+++ b/studio/backend/main.py
@@ -717,11 +717,12 @@ async def lifespan(app: FastAPI):
     # The backend's own stall watchdog (#9712). Liveness answers prove the loop is
     # serving only when something probes from outside, and the observed stalls were
     # over before anyone could attach py-spy. This dumps thread stacks from inside
-    # the process while a stall is still in progress. Suppressed while the warm is
-    # importing torch, the one stall with a known frame.
-    from utils.stall_watchdog import start_stall_watchdog
+    # the process while a stall is still in progress. Stood down from its first beat
+    # until the warm is over: its dead man's switch cannot be disarmed once the
+    # warm's `import torch` has the GIL, so it must never be armed before then.
+    from utils.stall_watchdog import stand_down_for_the_warm, start_stall_watchdog
 
-    start_stall_watchdog(asyncio.get_running_loop(), suppress = _torch_warm_in_progress)
+    start_stall_watchdog(asyncio.get_running_loop(), suppress = stand_down_for_the_warm)
 
     _lifespan_log.info(
         "lifespan pre-auth setup completed in %.1fms",

--- a/studio/backend/main.py
+++ b/studio/backend/main.py
@@ -713,6 +713,16 @@ async def lifespan(app: FastAPI):
     from core.inference.key_exchange import init_key_pair
 
     init_key_pair()
+
+    # The backend's own stall watchdog (#9712). Liveness answers prove the loop is
+    # serving only when something probes from outside, and the observed stalls were
+    # over before anyone could attach py-spy. This dumps thread stacks from inside
+    # the process while a stall is still in progress. Suppressed while the warm is
+    # importing torch, the one stall with a known frame.
+    from utils.stall_watchdog import start_stall_watchdog
+
+    start_stall_watchdog(asyncio.get_running_loop(), suppress = _torch_warm_in_progress)
+
     _lifespan_log.info(
         "lifespan pre-auth setup completed in %.1fms",
         (_time.perf_counter() - _lifespan_started) * 1000,
@@ -750,6 +760,12 @@ async def lifespan(app: FastAPI):
 
     # Before any shutdown await: a warm finishing during one would still read the lifespan as current.
     _stop_post_warm_thread()
+
+    # Retire the stall watchdog before teardown starts blocking the loop on purpose,
+    # or shutdown itself reads as a stall and dumps into the exit log.
+    from utils.stall_watchdog import stop_stall_watchdog
+
+    stop_stall_watchdog()
 
     # Retire the coordinated warm at shutdown entry too. run_lifespan_shutdown() repeats
     # this after cleanup, but its awaits would otherwise let startup imports continue for

--- a/studio/backend/main.py
+++ b/studio/backend/main.py
@@ -717,9 +717,11 @@ async def lifespan(app: FastAPI):
     # The backend's own stall watchdog (#9712). Liveness answers prove the loop is
     # serving only when something probes from outside, and the observed stalls were
     # over before anyone could attach py-spy. This dumps thread stacks from inside
-    # the process while a stall is still in progress. Stood down from its first beat
-    # until the warm is over: its dead man's switch cannot be disarmed once the
-    # warm's `import torch` has the GIL, so it must never be armed before then.
+    # the process while a stall is still in progress. Diagnostic, so it only runs
+    # where UNSLOTH_STUDIO_STALL_WATCHDOG=1 asks for it, which the mac smoke
+    # workflow does; a desktop run gets no extra thread. Stood down from its first
+    # beat until the warm is over: its dead man's switch cannot be disarmed once
+    # the warm's `import torch` has the GIL, so it must never be armed before then.
     from utils.stall_watchdog import stand_down_for_the_warm, start_stall_watchdog
 
     start_stall_watchdog(asyncio.get_running_loop(), suppress = stand_down_for_the_warm)

--- a/studio/backend/tests/test_stall_watchdog.py
+++ b/studio/backend/tests/test_stall_watchdog.py
@@ -197,6 +197,53 @@ def test_repeated_gil_stalls_dump_once_per_cooldown(loop_in_thread, tmp_path):
     )
 
 
+def test_a_python_dump_disarms_the_switch_for_the_cooldown(loop_in_thread, tmp_path):
+    """The two paths share the cooldown. A slow-probe dump leaves the switch armed
+    from earlier in the same beat unless it is taken down with it, and a GIL freeze
+    right after would land a second dump inside the window."""
+    dump_path = tmp_path / "dump.txt"
+
+    def blocks_the_loop():
+        time.sleep(0.5)
+
+    def holds_the_gil():
+        old = sys.getswitchinterval()
+        sys.setswitchinterval(10.0)
+        try:
+            deadline = time.monotonic() + 0.8
+            while time.monotonic() < deadline:
+                pass
+        finally:
+            sys.setswitchinterval(old)
+
+    with dump_path.open("w") as dump_file:
+        watchdog = StallWatchdog(
+            loop_in_thread,
+            dump_file = dump_file,
+            beat_interval_s = 0.05,
+            probe_slow_s = 0.05,
+            slow_probes_before_dump = 2,
+            dead_man_timeout_s = 0.3,
+            dump_cooldown_s = 60.0,
+        )
+        watchdog.start()
+        try:
+            loop_in_thread.call_soon_threadsafe(blocks_the_loop)
+            assert _wait_for(
+                lambda: "stall watchdog:" in dump_path.read_text(errors = "replace")
+            )
+            loop_in_thread.call_soon_threadsafe(holds_the_gil)
+            time.sleep(1.4)
+        finally:
+            watchdog.stop()
+
+    text = dump_path.read_text(errors = "replace")
+    assert "Timeout" not in text, (
+        "the dead man's switch fired inside the cooldown a slow-probe dump started; "
+        "one stall episode left two dumps"
+    )
+
+
 def test_stands_down_until_the_warm_is_over(monkeypatch):
     """The dead man's switch cannot be disarmed once the warm holds the GIL, so the
     gate has to be closed before the warm starts, and stay closed until it is over.

--- a/studio/backend/tests/test_stall_watchdog.py
+++ b/studio/backend/tests/test_stall_watchdog.py
@@ -1,0 +1,215 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Invariant: a stalled event loop gets its thread stacks dumped while still stalled.
+
+#9712: the backend stops serving every route for 10-33s and recovers before anyone
+can attach py-spy. The watchdog exists so the next occurrence writes its own
+diagnosis. Two stall shapes, two capture paths, both exercised here for real:
+
+- Loop stuck, GIL free: the watchdog thread still runs, counts consecutive slow
+  no-op probes, and dumps from Python.
+- GIL held: no Python thread runs, the watchdog included. The dead man's switch it
+  re-arms every beat has to fire from faulthandler's C thread mid-stall. The test
+  holds the GIL genuinely (a busy loop under a long sys.setswitchinterval) rather
+  than mocking the freeze, because the C thread firing without the GIL is the one
+  property the whole design rests on.
+
+CPU-only, no network, no GPU, no weights. Slowest test holds the GIL ~1.2s.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from utils.stall_watchdog import (
+    StallWatchdog,
+    start_stall_watchdog,
+    stop_stall_watchdog,
+)
+
+_BACKEND_DIR = Path(__file__).resolve().parent.parent
+
+
+@pytest.fixture()
+def loop_in_thread():
+    loop = asyncio.new_event_loop()
+    thread = threading.Thread(target = loop.run_forever, daemon = True, name = "test-loop")
+    thread.start()
+    yield loop
+    loop.call_soon_threadsafe(loop.stop)
+    thread.join(timeout = 5)
+    # Drain whatever probes the watchdog left queued, or closing the loop leaves
+    # never-awaited no-op coroutines behind as warnings.
+    loop.run_until_complete(asyncio.sleep(0.1))
+    loop.close()
+
+
+def _wait_for(predicate, timeout_s: float = 10.0) -> bool:
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.02)
+    return predicate()
+
+
+def test_a_blocked_loop_dumps_after_consecutive_slow_probes(loop_in_thread, tmp_path):
+    """The GIL-free shape: something blocking sits on the loop, Python threads still
+    run, so the slow-probe counter reaches its threshold and dumps. The dump must
+    name the blocking frame, otherwise it answers nothing."""
+    dump_path = tmp_path / "dump.txt"
+
+    def blocked_in_a_syscall():
+        time.sleep(1.2)
+
+    with dump_path.open("w") as dump_file:
+        watchdog = StallWatchdog(
+            loop_in_thread,
+            dump_file = dump_file,
+            beat_interval_s = 0.05,
+            probe_slow_s = 0.05,
+            slow_probes_before_dump = 3,
+            # Out of the way: this test is about the Python-side path.
+            dead_man_timeout_s = 30.0,
+            dump_cooldown_s = 0.0,
+        )
+        watchdog.start()
+        try:
+            loop_in_thread.call_soon_threadsafe(blocked_in_a_syscall)
+            assert _wait_for(
+                lambda: "stall watchdog:" in dump_path.read_text(errors = "replace")
+            ), "no dump was written while the loop was blocked"
+        finally:
+            watchdog.stop()
+
+    text = dump_path.read_text(errors = "replace")
+    assert "consecutive slow probes" in text
+    assert "blocked_in_a_syscall" in text, (
+        "the dump does not show the frame the loop is stuck in; it cannot answer "
+        "what #9712 asks"
+    )
+
+
+def test_a_gil_holding_stall_is_dumped_mid_stall(loop_in_thread, tmp_path):
+    """The #9712 shape: the GIL is held, so the watchdog thread itself is frozen and
+    slow-probe counting observes nothing until the stall is over. Only the dead
+    man's switch can capture this, firing from C while no Python thread runs."""
+    dump_path = tmp_path / "dump.txt"
+    released = threading.Event()
+
+    def holds_the_gil():
+        old = sys.getswitchinterval()
+        # A pure-Python busy loop only releases the GIL at switch-interval
+        # boundaries; pushing the interval past the hold keeps it for the duration.
+        sys.setswitchinterval(10.0)
+        try:
+            deadline = time.monotonic() + 1.2
+            while time.monotonic() < deadline:
+                pass
+        finally:
+            sys.setswitchinterval(old)
+            released.set()
+
+    with dump_path.open("w") as dump_file:
+        watchdog = StallWatchdog(
+            loop_in_thread,
+            dump_file = dump_file,
+            beat_interval_s = 0.05,
+            probe_slow_s = 0.05,
+            slow_probes_before_dump = 1000,  # the Python path must not be the one firing
+            dead_man_timeout_s = 0.4,
+            dump_cooldown_s = 0.0,
+        )
+        watchdog.start()
+        try:
+            # Let it arm at least once before the freeze.
+            assert _wait_for(lambda: watchdog._dead_man_armed, timeout_s = 5.0)
+            loop_in_thread.call_soon_threadsafe(holds_the_gil)
+            assert released.wait(timeout = 30.0)
+            assert _wait_for(lambda: "Timeout" in dump_path.read_text(errors = "replace"))
+        finally:
+            watchdog.stop()
+
+    text = dump_path.read_text(errors = "replace")
+    assert "holds_the_gil" in text, (
+        "the mid-stall dump does not show the GIL holder's frame; identifying it is "
+        "the point of the dead man's switch"
+    )
+
+
+def test_no_dump_while_suppressed(loop_in_thread, tmp_path):
+    """The warm's `import torch` is a legitimate long GIL hold with a known frame.
+    While the suppress callable says so, neither capture path may fire."""
+    dump_path = tmp_path / "dump.txt"
+
+    with dump_path.open("w") as dump_file:
+        watchdog = StallWatchdog(
+            loop_in_thread,
+            suppress = lambda: True,
+            dump_file = dump_file,
+            beat_interval_s = 0.05,
+            probe_slow_s = 0.05,
+            slow_probes_before_dump = 1,
+            dead_man_timeout_s = 0.2,
+            dump_cooldown_s = 0.0,
+        )
+        watchdog.start()
+        try:
+            loop_in_thread.call_soon_threadsafe(time.sleep, 0.8)
+            time.sleep(1.2)
+        finally:
+            watchdog.stop()
+
+    assert dump_path.read_text(errors = "replace") == "", (
+        "the watchdog dumped during a suppressed window; every warm import would "
+        "land a spurious dump in the log"
+    )
+
+
+def test_the_disable_env_var_means_no_thread(loop_in_thread, monkeypatch):
+    monkeypatch.setenv("UNSLOTH_STUDIO_DISABLE_STALL_WATCHDOG", "1")
+    assert start_stall_watchdog(loop_in_thread) is None
+    assert not any(t.name == "stall-watchdog" for t in threading.enumerate())
+
+
+def test_start_and_stop_manage_one_process_wide_instance(loop_in_thread, monkeypatch):
+    monkeypatch.delenv("UNSLOTH_STUDIO_DISABLE_STALL_WATCHDOG", raising = False)
+    first = start_stall_watchdog(loop_in_thread)
+    try:
+        assert first is not None
+        second = start_stall_watchdog(loop_in_thread)
+        assert second is not None
+        assert _wait_for(
+            lambda: not (first._thread and first._thread.is_alive()), timeout_s = 5.0
+        ), "starting a second watchdog left the first one's thread running"
+    finally:
+        stop_stall_watchdog()
+    assert _wait_for(
+        lambda: not any(t.name == "stall-watchdog" for t in threading.enumerate()),
+        timeout_s = 5.0,
+    )
+
+
+def test_the_lifespan_wires_it_in():
+    """Cross-file guard: the module only does anything because main.py starts it at
+    startup and retires it at shutdown entry, and either side can be edited alone."""
+    source = (_BACKEND_DIR / "main.py").read_text(encoding = "utf-8")
+    assert "start_stall_watchdog(asyncio.get_running_loop()" in source, (
+        "main.py no longer starts the stall watchdog; the next #9712 stall leaves "
+        "no dump behind"
+    )
+    assert "suppress = _torch_warm_in_progress" in source, (
+        "the watchdog no longer stands down during the warm; every cold start would "
+        "dump over the torch import"
+    )
+    assert "stop_stall_watchdog()" in source, (
+        "main.py never retires the watchdog, so shutdown's deliberate blocking "
+        "reads as a stall and dumps into the exit log"
+    )

--- a/studio/backend/tests/test_stall_watchdog.py
+++ b/studio/backend/tests/test_stall_watchdog.py
@@ -308,14 +308,16 @@ def test_no_dump_while_suppressed(loop_in_thread, tmp_path):
     )
 
 
-def test_the_disable_env_var_means_no_thread(loop_in_thread, monkeypatch):
-    monkeypatch.setenv("UNSLOTH_STUDIO_DISABLE_STALL_WATCHDOG", "1")
+def test_off_unless_the_env_opts_in(loop_in_thread, monkeypatch):
+    """Diagnostic tooling: a desktop run must carry neither the thread nor the
+    faulthandler timer, so nothing starts without the env the CI workflow sets."""
+    monkeypatch.delenv("UNSLOTH_STUDIO_STALL_WATCHDOG", raising = False)
     assert start_stall_watchdog(loop_in_thread) is None
     assert not any(t.name == "stall-watchdog" for t in threading.enumerate())
 
 
 def test_start_and_stop_manage_one_process_wide_instance(loop_in_thread, monkeypatch):
-    monkeypatch.delenv("UNSLOTH_STUDIO_DISABLE_STALL_WATCHDOG", raising = False)
+    monkeypatch.setenv("UNSLOTH_STUDIO_STALL_WATCHDOG", "1")
     first = start_stall_watchdog(loop_in_thread)
     try:
         assert first is not None
@@ -346,4 +348,14 @@ def test_the_lifespan_wires_it_in():
     assert "stop_stall_watchdog()" in source, (
         "main.py never retires the watchdog, so shutdown's deliberate blocking "
         "reads as a stall and dumps into the exit log"
+    )
+
+    workflow = (
+        _BACKEND_DIR.parent.parent
+        / ".github" / "workflows" / "studio-mac-ui-smoke.yml"
+    )
+    assert workflow.is_file(), f"{workflow} moved; update this guard"
+    assert "UNSLOTH_STUDIO_STALL_WATCHDOG" in workflow.read_text(encoding = "utf-8"), (
+        "the watchdog is opt-in and the mac smoke workflow no longer opts in; the "
+        "one place #9712 stalls have been seen runs without it"
     )

--- a/studio/backend/tests/test_stall_watchdog.py
+++ b/studio/backend/tests/test_stall_watchdog.py
@@ -93,8 +93,7 @@ def test_a_blocked_loop_dumps_after_consecutive_slow_probes(loop_in_thread, tmp_
     text = dump_path.read_text(errors = "replace")
     assert "consecutive slow probes" in text
     assert "blocked_in_a_syscall" in text, (
-        "the dump does not show the frame the loop is stuck in; it cannot answer "
-        "what #9712 asks"
+        "the dump does not show the frame the loop is stuck in; it cannot answer what #9712 asks"
     )
 
 
@@ -229,9 +228,7 @@ def test_a_python_dump_disarms_the_switch_for_the_cooldown(loop_in_thread, tmp_p
         watchdog.start()
         try:
             loop_in_thread.call_soon_threadsafe(blocks_the_loop)
-            assert _wait_for(
-                lambda: "stall watchdog:" in dump_path.read_text(errors = "replace")
-            )
+            assert _wait_for(lambda: "stall watchdog:" in dump_path.read_text(errors = "replace"))
             loop_in_thread.call_soon_threadsafe(holds_the_gil)
             time.sleep(1.4)
         finally:
@@ -254,7 +251,8 @@ def test_stands_down_until_the_warm_is_over(monkeypatch):
 
     def status(started: bool, finished: bool, alive: bool):
         monkeypatch.setattr(
-            tw, "warm_status",
+            tw,
+            "warm_status",
             lambda: {"started": started, "finished": finished, "alive": alive, "stages": {}},
         )
 
@@ -339,8 +337,7 @@ def test_the_lifespan_wires_it_in():
     startup and retires it at shutdown entry, and either side can be edited alone."""
     source = (_BACKEND_DIR / "main.py").read_text(encoding = "utf-8")
     assert "start_stall_watchdog(asyncio.get_running_loop()" in source, (
-        "main.py no longer starts the stall watchdog; the next #9712 stall leaves "
-        "no dump behind"
+        "main.py no longer starts the stall watchdog; the next #9712 stall leaves no dump behind"
     )
     assert "suppress = stand_down_for_the_warm" in source, (
         "the watchdog no longer stands down for the warm; every cold start would "

--- a/studio/backend/tests/test_stall_watchdog.py
+++ b/studio/backend/tests/test_stall_watchdog.py
@@ -92,9 +92,9 @@ def test_a_blocked_loop_dumps_after_consecutive_slow_probes(loop_in_thread, tmp_
 
     text = dump_path.read_text(errors = "replace")
     assert "consecutive slow probes" in text
-    assert "blocked_in_a_syscall" in text, (
-        "the dump does not show the frame the loop is stuck in; it cannot answer what #9712 asks"
-    )
+    assert (
+        "blocked_in_a_syscall" in text
+    ), "the dump does not show the frame the loop is stuck in; it cannot answer what #9712 asks"
 
 
 def test_a_gil_holding_stall_is_dumped_mid_stall(loop_in_thread, tmp_path):
@@ -338,9 +338,9 @@ def test_the_lifespan_wires_it_in():
     """Cross-file guard: the module only does anything because main.py starts it at
     startup and retires it at shutdown entry, and either side can be edited alone."""
     source = (_BACKEND_DIR / "main.py").read_text(encoding = "utf-8")
-    assert "start_stall_watchdog(asyncio.get_running_loop()" in source, (
-        "main.py no longer starts the stall watchdog; the next #9712 stall leaves no dump behind"
-    )
+    assert (
+        "start_stall_watchdog(asyncio.get_running_loop()" in source
+    ), "main.py no longer starts the stall watchdog; the next #9712 stall leaves no dump behind"
     assert "suppress = stand_down_for_the_warm" in source, (
         "the watchdog no longer stands down for the warm; every cold start would "
         "dump over the torch import"
@@ -350,10 +350,7 @@ def test_the_lifespan_wires_it_in():
         "reads as a stall and dumps into the exit log"
     )
 
-    workflow = (
-        _BACKEND_DIR.parent.parent
-        / ".github" / "workflows" / "studio-mac-ui-smoke.yml"
-    )
+    workflow = _BACKEND_DIR.parent.parent / ".github" / "workflows" / "studio-mac-ui-smoke.yml"
     assert workflow.is_file(), f"{workflow} moved; update this guard"
     assert "UNSLOTH_STUDIO_STALL_WATCHDOG" in workflow.read_text(encoding = "utf-8"), (
         "the watchdog is opt-in and the mac smoke workflow no longer opts in; the "

--- a/studio/backend/tests/test_stall_watchdog.py
+++ b/studio/backend/tests/test_stall_watchdog.py
@@ -30,6 +30,7 @@ import pytest
 
 from utils.stall_watchdog import (
     StallWatchdog,
+    stand_down_for_the_warm,
     start_stall_watchdog,
     stop_stall_watchdog,
 )
@@ -144,6 +145,95 @@ def test_a_gil_holding_stall_is_dumped_mid_stall(loop_in_thread, tmp_path):
     )
 
 
+def test_repeated_gil_stalls_dump_once_per_cooldown(loop_in_thread, tmp_path):
+    """The switch fires on its own once armed, so the cooldown has to gate the
+    arming: a host that stalls chronically must leave one dump, and silence, until
+    the window passes."""
+    dump_path = tmp_path / "dump.txt"
+
+    def hold_gil_for(seconds: float):
+        released = threading.Event()
+
+        def holder():
+            old = sys.getswitchinterval()
+            sys.setswitchinterval(10.0)
+            try:
+                deadline = time.monotonic() + seconds
+                while time.monotonic() < deadline:
+                    pass
+            finally:
+                sys.setswitchinterval(old)
+                released.set()
+
+        loop_in_thread.call_soon_threadsafe(holder)
+        assert released.wait(timeout = 30.0)
+
+    with dump_path.open("w") as dump_file:
+        watchdog = StallWatchdog(
+            loop_in_thread,
+            dump_file = dump_file,
+            beat_interval_s = 0.05,
+            probe_slow_s = 0.05,
+            slow_probes_before_dump = 1000,
+            dead_man_timeout_s = 0.3,
+            dump_cooldown_s = 60.0,
+        )
+        watchdog.start()
+        try:
+            assert _wait_for(lambda: watchdog._dead_man_armed, timeout_s = 5.0)
+            hold_gil_for(0.8)
+            assert _wait_for(lambda: "Timeout" in dump_path.read_text(errors = "replace"))
+            # Let the recovery beat land and start the cooldown before stalling again.
+            assert _wait_for(lambda: watchdog._last_dump is not None, timeout_s = 5.0)
+            hold_gil_for(0.8)
+            time.sleep(0.3)
+        finally:
+            watchdog.stop()
+
+    text = dump_path.read_text(errors = "replace")
+    assert text.count("Timeout") == 1, (
+        "a second stall inside the cooldown window dumped again; a chronically "
+        "stalling host would fill its log with stacks"
+    )
+
+
+def test_stands_down_until_the_warm_is_over(monkeypatch):
+    """The dead man's switch cannot be disarmed once the warm holds the GIL, so the
+    gate has to be closed before the warm starts, and stay closed until it is over.
+    Gating on 'warm running' left the window between the watchdog's first beat and
+    start_background_warm(), and every cold start dumped over the torch import."""
+    import utils.stall_watchdog as sw
+    import utils.torch_warmup as tw
+
+    def status(started: bool, finished: bool, alive: bool):
+        monkeypatch.setattr(
+            tw, "warm_status",
+            lambda: {"started": started, "finished": finished, "alive": alive, "stages": {}},
+        )
+
+    monkeypatch.delenv(tw.DISABLE_ENV_VAR, raising = False)
+    status(started = False, finished = False, alive = False)
+    assert sw.stand_down_for_the_warm() is True, (
+        "not standing down before the warm starts is the arming race: the switch "
+        "armed in that window dumps over `import torch` on every cold start"
+    )
+    status(started = True, finished = False, alive = True)
+    assert sw.stand_down_for_the_warm() is True
+    status(started = True, finished = True, alive = False)
+    assert sw.stand_down_for_the_warm() is False
+    # A warm that died mid-stage is not coming back; staying down would blind the
+    # watchdog for the rest of the session.
+    status(started = True, finished = False, alive = False)
+    assert sw.stand_down_for_the_warm() is False
+
+    monkeypatch.setenv(tw.DISABLE_ENV_VAR, "1")
+    status(started = False, finished = False, alive = False)
+    assert sw.stand_down_for_the_warm() is False, (
+        "with the warm switched off no warm is coming; standing down anyway keeps "
+        "the watchdog disarmed for the whole session"
+    )
+
+
 def test_no_dump_while_suppressed(loop_in_thread, tmp_path):
     """The warm's `import torch` is a legitimate long GIL hold with a known frame.
     While the suppress callable says so, neither capture path may fire."""
@@ -205,8 +295,8 @@ def test_the_lifespan_wires_it_in():
         "main.py no longer starts the stall watchdog; the next #9712 stall leaves "
         "no dump behind"
     )
-    assert "suppress = _torch_warm_in_progress" in source, (
-        "the watchdog no longer stands down during the warm; every cold start would "
+    assert "suppress = stand_down_for_the_warm" in source, (
+        "the watchdog no longer stands down for the warm; every cold start would "
         "dump over the torch import"
     )
     assert "stop_stall_watchdog()" in source, (

--- a/studio/backend/utils/stall_watchdog.py
+++ b/studio/backend/utils/stall_watchdog.py
@@ -21,6 +21,11 @@ A stall has two shapes, and they need different capture mechanisms:
   acquiring the GIL, so when the beats stop, it fires mid-stall and writes the frame
   every thread is actually in -- including the one sitting on the GIL.
 
+Diagnostic tooling, so it is off unless UNSLOTH_STUDIO_STALL_WATCHDOG=1: a normal
+desktop run carries neither the extra thread nor the faulthandler timer. The mac
+smoke workflow sets the env for every phase, which is where #9712's stalls were
+observed.
+
 Dumps go to the stderr file descriptor: the CI workflow redirects it to the
 ``logs/*.log`` it uploads, and the desktop launcher captures the child's pipe. A
 direct terminal launch shows dumps on the console but its on-disk session log
@@ -58,7 +63,7 @@ import structlog
 
 logger = structlog.get_logger(__name__)
 
-DISABLE_ENV_VAR = "UNSLOTH_STUDIO_DISABLE_STALL_WATCHDOG"
+ENABLE_ENV_VAR = "UNSLOTH_STUDIO_STALL_WATCHDOG"
 
 BEAT_INTERVAL_S = 2.5
 # Passing runs of the mac smoke report worst-case route latency around 50ms, with
@@ -287,8 +292,8 @@ _watchdog_lock = threading.Lock()
 def start_stall_watchdog(
     loop: asyncio.AbstractEventLoop, *, suppress: Optional[Callable[[], bool]] = None
 ) -> Optional[StallWatchdog]:
-    """Start the process-wide watchdog. Returns None when disabled by env."""
-    if os.environ.get(DISABLE_ENV_VAR) == "1":
+    """Start the process-wide watchdog. Returns None unless the env opts in."""
+    if os.environ.get(ENABLE_ENV_VAR) != "1":
         return None
     global _watchdog
     with _watchdog_lock:

--- a/studio/backend/utils/stall_watchdog.py
+++ b/studio/backend/utils/stall_watchdog.py
@@ -169,7 +169,9 @@ class StallWatchdog:
             last_beat = beat_started
 
             if self._suppress_now():
-                self._stop_event.wait(self._beat_interval_s)
+                # Shorter waits while standing down: a full beat's sleep after the
+                # warm finishes is a window where a stall goes entirely uncaptured.
+                self._stop_event.wait(min(self._beat_interval_s, 0.5))
                 continue
 
             self._arm_dead_man()
@@ -262,6 +264,10 @@ class StallWatchdog:
             return
         now = time.monotonic()
         self._last_dump = now
+        # The switch armed earlier this beat is still live and would fire a second
+        # dump if a GIL freeze followed inside the cooldown; the cooldown owns both
+        # paths, so take it down now rather than at the next beat.
+        self._cancel_dead_man()
         stalled_for = now - (self._stall_started or now)
         try:
             self._dump_file.write(

--- a/studio/backend/utils/stall_watchdog.py
+++ b/studio/backend/utils/stall_watchdog.py
@@ -1,0 +1,256 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Dump every thread's stack while the event loop is stalled, from inside the process.
+
+#9712: the backend stops answering every route for 10-33s on macOS CI, then recovers.
+The stalls are too rare to sit next to with py-spy (once in 1711 runs) and over before
+anyone could attach, so the dump has to come from the stalled process itself, taken
+while the stall is still in progress.
+
+A stall has two shapes, and they need different capture mechanisms:
+
+- The event loop is stuck but the GIL is free (a blocking call that slipped onto the
+  loop, a syscall that will not return). Python threads still run, so a watchdog
+  thread can time a no-op scheduled onto the loop and dump from Python after enough
+  consecutive slow probes.
+- Something is holding the GIL. No Python thread runs at all, the watchdog included,
+  so counting slow probes observes nothing until the stall is already over. For this
+  shape the watchdog re-arms ``faulthandler.dump_traceback_later`` on every beat: a
+  dead man's switch. faulthandler's timeout thread is C code that dumps without
+  acquiring the GIL, so when the beats stop, it fires mid-stall and writes the frame
+  every thread is actually in -- including the one sitting on the GIL.
+
+Dumps go to stderr, which every launch path already captures: the CI workflow
+redirects the backend to ``logs/*.log`` and the desktop launcher collects child
+stdio. A dump is a few KB of text and fires at most once per cooldown window.
+
+Suppressed while the coordinated warm is running: its ``import torch`` holds the
+GIL for tens of seconds on a healthy process, which is a known stall with a known
+frame. The launcher's health watchdog holds its startup grace open over the same
+window for the same reason.
+
+Not a replacement for the launcher-side health watchdog in commands.rs: that one
+decides whether to kill the process from outside. This one only ever writes
+diagnostics, from inside.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import faulthandler
+import os
+import threading
+import time
+from concurrent.futures import TimeoutError as FutureTimeoutError
+from typing import Callable, Optional, TextIO
+
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+DISABLE_ENV_VAR = "UNSLOTH_STUDIO_DISABLE_STALL_WATCHDOG"
+
+BEAT_INTERVAL_S = 5.0
+# Passing runs of the mac smoke report worst-case route latency around 50ms, with
+# outliers to ~3.4s on a saturated instance. 1s flags a probe as slow without
+# counting those single-probe outliers as a stall on their own.
+PROBE_SLOW_S = 1.0
+# Three slow beats in a row is ~11s of continuously unresponsive loop, the low end
+# of the observed stalls and past anything a healthy run has shown.
+SLOW_PROBES_BEFORE_DUMP = 3
+# The dead man's switch fires this long after the last re-arm. Also the width of a
+# GIL hold the watchdog tolerates before it considers its own silence a stall.
+DEAD_MAN_TIMEOUT_S = 10.0
+# One dump per stall is the useful number; a host that stalls chronically should
+# not fill its log with them.
+DUMP_COOLDOWN_S = 600.0
+
+
+async def _noop() -> None:
+    return None
+
+
+class StallWatchdog:
+    """One daemon thread beating against the event loop. start() / stop()."""
+
+    def __init__(
+        self,
+        loop: asyncio.AbstractEventLoop,
+        *,
+        suppress: Optional[Callable[[], bool]] = None,
+        dump_file: Optional[TextIO] = None,
+        beat_interval_s: float = BEAT_INTERVAL_S,
+        probe_slow_s: float = PROBE_SLOW_S,
+        slow_probes_before_dump: int = SLOW_PROBES_BEFORE_DUMP,
+        dead_man_timeout_s: float = DEAD_MAN_TIMEOUT_S,
+        dump_cooldown_s: float = DUMP_COOLDOWN_S,
+    ) -> None:
+        import sys
+
+        self._loop = loop
+        self._suppress = suppress or (lambda: False)
+        self._dump_file = dump_file if dump_file is not None else sys.stderr
+        self._beat_interval_s = beat_interval_s
+        self._probe_slow_s = probe_slow_s
+        self._slow_probes_before_dump = slow_probes_before_dump
+        self._dead_man_timeout_s = dead_man_timeout_s
+        self._dump_cooldown_s = dump_cooldown_s
+
+        self._stop_event = threading.Event()
+        self._thread: Optional[threading.Thread] = None
+        self._slow_streak = 0
+        self._stall_started: Optional[float] = None
+        self._last_dump: Optional[float] = None
+        self._dead_man_armed = False
+
+    def start(self) -> None:
+        self._thread = threading.Thread(
+            target = self._run,
+            daemon = True,
+            name = "stall-watchdog",
+        )
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop_event.set()
+        self._cancel_dead_man()
+        thread = self._thread
+        if thread is not None:
+            thread.join(timeout = 2.0)
+
+    # -- the beat ---------------------------------------------------------------
+
+    def _run(self) -> None:
+        last_beat = time.monotonic()
+        while not self._stop_event.is_set():
+            beat_started = time.monotonic()
+            # The watchdog going quiet is itself the signal in the GIL-held shape:
+            # the switch fired while this thread could not run. Say so on recovery,
+            # with the one number the raw dump cannot carry.
+            gap = beat_started - last_beat
+            if self._dead_man_armed and gap > self._dead_man_timeout_s:
+                logger.warning(
+                    "stall watchdog was itself blocked for %.1fs; if the GIL was held, "
+                    "faulthandler wrote a thread dump to stderr (system sleep also lands here)",
+                    gap,
+                )
+            last_beat = beat_started
+
+            if self._suppress_now():
+                self._stop_event.wait(self._beat_interval_s)
+                continue
+
+            self._arm_dead_man()
+            self._probe(beat_started)
+
+            elapsed = time.monotonic() - beat_started
+            self._stop_event.wait(max(0.0, self._beat_interval_s - elapsed))
+        self._cancel_dead_man()
+
+    def _suppress_now(self) -> bool:
+        try:
+            suppressed = bool(self._suppress())
+        except Exception:
+            suppressed = False
+        if suppressed:
+            self._cancel_dead_man()
+            self._slow_streak = 0
+            self._stall_started = None
+        return suppressed
+
+    def _probe(self, beat_started: float) -> None:
+        try:
+            future = asyncio.run_coroutine_threadsafe(_noop(), self._loop)
+        except RuntimeError:
+            # Loop closed; shutdown is racing us. The stop() call will land shortly.
+            self._stop_event.wait(self._beat_interval_s)
+            return
+        try:
+            future.result(timeout = self._probe_slow_s)
+        except FutureTimeoutError:
+            # Left to finish on its own once the loop recovers: cancelling a task
+            # that never started leaves a never-awaited coroutine warning behind.
+            self._slow_streak += 1
+            if self._stall_started is None:
+                self._stall_started = beat_started
+            if self._slow_streak >= self._slow_probes_before_dump:
+                self._dump_from_python()
+            return
+        except Exception:
+            # A failed no-op means the loop answered; that is all the probe asks.
+            pass
+        if self._slow_streak:
+            stalled_for = time.monotonic() - (self._stall_started or beat_started)
+            logger.warning(
+                "event loop answering again after %.1fs (%d consecutive slow probes)",
+                stalled_for,
+                self._slow_streak,
+            )
+        self._slow_streak = 0
+        self._stall_started = None
+
+    # -- dumps ------------------------------------------------------------------
+
+    def _arm_dead_man(self) -> None:
+        try:
+            faulthandler.dump_traceback_later(
+                self._dead_man_timeout_s,
+                repeat = False,
+                file = self._dump_file,
+                exit = False,
+            )
+            self._dead_man_armed = True
+        except Exception:
+            # No usable fileno (a replaced stderr). The Python-side path still works.
+            self._dead_man_armed = False
+
+    def _cancel_dead_man(self) -> None:
+        if self._dead_man_armed:
+            faulthandler.cancel_dump_traceback_later()
+            self._dead_man_armed = False
+
+    def _dump_from_python(self) -> None:
+        now = time.monotonic()
+        if self._last_dump is not None and now - self._last_dump < self._dump_cooldown_s:
+            return
+        self._last_dump = now
+        stalled_for = now - (self._stall_started or now)
+        try:
+            self._dump_file.write(
+                f"\nstall watchdog: event loop unresponsive for {stalled_for:.1f}s "
+                f"({self._slow_streak} consecutive slow probes), dumping all threads\n"
+            )
+            self._dump_file.flush()
+            faulthandler.dump_traceback(file = self._dump_file, all_threads = True)
+        except Exception as exc:
+            logger.warning("stall watchdog could not write a thread dump: %s", exc)
+
+
+_watchdog: Optional[StallWatchdog] = None
+_watchdog_lock = threading.Lock()
+
+
+def start_stall_watchdog(
+    loop: asyncio.AbstractEventLoop,
+    *,
+    suppress: Optional[Callable[[], bool]] = None,
+) -> Optional[StallWatchdog]:
+    """Start the process-wide watchdog. Returns None when disabled by env."""
+    if os.environ.get(DISABLE_ENV_VAR) == "1":
+        return None
+    global _watchdog
+    with _watchdog_lock:
+        if _watchdog is not None:
+            _watchdog.stop()
+        _watchdog = StallWatchdog(loop, suppress = suppress)
+        _watchdog.start()
+        return _watchdog
+
+
+def stop_stall_watchdog() -> None:
+    global _watchdog
+    with _watchdog_lock:
+        if _watchdog is not None:
+            _watchdog.stop()
+            _watchdog = None

--- a/studio/backend/utils/stall_watchdog.py
+++ b/studio/backend/utils/stall_watchdog.py
@@ -285,9 +285,7 @@ _watchdog_lock = threading.Lock()
 
 
 def start_stall_watchdog(
-    loop: asyncio.AbstractEventLoop,
-    *,
-    suppress: Optional[Callable[[], bool]] = None,
+    loop: asyncio.AbstractEventLoop, *, suppress: Optional[Callable[[], bool]] = None
 ) -> Optional[StallWatchdog]:
     """Start the process-wide watchdog. Returns None when disabled by env."""
     if os.environ.get(DISABLE_ENV_VAR) == "1":

--- a/studio/backend/utils/stall_watchdog.py
+++ b/studio/backend/utils/stall_watchdog.py
@@ -21,14 +21,23 @@ A stall has two shapes, and they need different capture mechanisms:
   acquiring the GIL, so when the beats stop, it fires mid-stall and writes the frame
   every thread is actually in -- including the one sitting on the GIL.
 
-Dumps go to stderr, which every launch path already captures: the CI workflow
-redirects the backend to ``logs/*.log`` and the desktop launcher collects child
-stdio. A dump is a few KB of text and fires at most once per cooldown window.
+Dumps go to the stderr file descriptor: the CI workflow redirects it to the
+``logs/*.log`` it uploads, and the desktop launcher captures the child's pipe. A
+direct terminal launch shows dumps on the console but its on-disk session log
+misses them -- faulthandler writes at C level, underneath run.py's tee -- which is
+the price of staying visible to the two consumers that diagnose #9712. The
+structlog markers the watchdog emits around a stall do go through the tee.
 
-Suppressed while the coordinated warm is running: its ``import torch`` holds the
-GIL for tens of seconds on a healthy process, which is a known stall with a known
-frame. The launcher's health watchdog holds its startup grace open over the same
-window for the same reason.
+The dead man's switch cannot be disarmed once something has the GIL, so it must
+never be armed while the coordinated warm could still start: the warm's
+``import torch`` holds the GIL for tens of seconds on a healthy process, and a beat
+that armed just before it grabbed the GIL would dump over the one stall with a
+known frame. The watchdog therefore stands down from its first beat until the warm
+is over (see ``stand_down_for_the_warm``), the same window the launcher's health
+watchdog holds its startup grace open for.
+
+faulthandler's delayed-dump timer is process-global and this module assumes it is
+its only user; nothing else in the backend arms it.
 
 Not a replacement for the launcher-side health watchdog in commands.rs: that one
 decides whether to kill the process from outside. This one only ever writes
@@ -51,20 +60,38 @@ logger = structlog.get_logger(__name__)
 
 DISABLE_ENV_VAR = "UNSLOTH_STUDIO_DISABLE_STALL_WATCHDOG"
 
-BEAT_INTERVAL_S = 5.0
+BEAT_INTERVAL_S = 2.5
 # Passing runs of the mac smoke report worst-case route latency around 50ms, with
 # outliers to ~3.4s on a saturated instance. 1s flags a probe as slow without
 # counting those single-probe outliers as a stall on their own.
 PROBE_SLOW_S = 1.0
-# Three slow beats in a row is ~11s of continuously unresponsive loop, the low end
-# of the observed stalls and past anything a healthy run has shown.
+# Three slow beats in a row is 6-8.5s of continuously unresponsive loop depending
+# on where in a beat the stall lands: past any healthy run, and early enough to
+# dump before the shortest stall on record (10.03s) recovers.
 SLOW_PROBES_BEFORE_DUMP = 3
-# The dead man's switch fires this long after the last re-arm. Also the width of a
-# GIL hold the watchdog tolerates before it considers its own silence a stall.
-DEAD_MAN_TIMEOUT_S = 10.0
+# The dead man's switch fires this long after the last re-arm, so 5.5-8s into a
+# GIL-held stall. Sized for the same 10s floor as the slow-probe path.
+DEAD_MAN_TIMEOUT_S = 8.0
 # One dump per stall is the useful number; a host that stalls chronically should
-# not fill its log with them.
+# not fill its log with them. Applies to both capture paths.
 DUMP_COOLDOWN_S = 600.0
+
+
+def stand_down_for_the_warm() -> bool:
+    """True from process start until the coordinated warm is over.
+
+    Suppressing only while the warm is *running* leaves a window between the
+    watchdog's first beat and start_background_warm(), and a switch armed in that
+    window cannot be disarmed once the warm has the GIL. When the warm is switched
+    off entirely, no warm is coming and the watchdog engages immediately.
+    """
+    from utils.torch_warmup import DISABLE_ENV_VAR as _WARM_DISABLED
+    from utils.torch_warmup import warm_status
+
+    status = warm_status()
+    if status["started"]:
+        return bool(status["alive"] and not status["finished"])
+    return os.environ.get(_WARM_DISABLED) != "1"
 
 
 async def _noop() -> None:
@@ -103,6 +130,7 @@ class StallWatchdog:
         self._stall_started: Optional[float] = None
         self._last_dump: Optional[float] = None
         self._dead_man_armed = False
+        self._arm_failure_logged = False
 
     def start(self) -> None:
         self._thread = threading.Thread(
@@ -127,9 +155,12 @@ class StallWatchdog:
             beat_started = time.monotonic()
             # The watchdog going quiet is itself the signal in the GIL-held shape:
             # the switch fired while this thread could not run. Say so on recovery,
-            # with the one number the raw dump cannot carry.
+            # with the one number the raw dump cannot carry, and start the cooldown
+            # so back-to-back stalls do not each leave a dump.
             gap = beat_started - last_beat
             if self._dead_man_armed and gap > self._dead_man_timeout_s:
+                self._last_dump = beat_started
+                self._dead_man_armed = False
                 logger.warning(
                     "stall watchdog was itself blocked for %.1fs; if the GIL was held, "
                     "faulthandler wrote a thread dump to stderr (system sleep also lands here)",
@@ -192,7 +223,16 @@ class StallWatchdog:
 
     # -- dumps ------------------------------------------------------------------
 
+    def _in_cooldown(self) -> bool:
+        return (
+            self._last_dump is not None
+            and time.monotonic() - self._last_dump < self._dump_cooldown_s
+        )
+
     def _arm_dead_man(self) -> None:
+        if self._in_cooldown():
+            self._cancel_dead_man()
+            return
         try:
             faulthandler.dump_traceback_later(
                 self._dead_man_timeout_s,
@@ -201,9 +241,16 @@ class StallWatchdog:
                 exit = False,
             )
             self._dead_man_armed = True
-        except Exception:
-            # No usable fileno (a replaced stderr). The Python-side path still works.
+        except Exception as exc:
             self._dead_man_armed = False
+            # Once: a dump target with no usable file descriptor never grows one.
+            if not self._arm_failure_logged:
+                self._arm_failure_logged = True
+                logger.warning(
+                    "stall watchdog cannot arm faulthandler (%s); GIL-held stalls "
+                    "will not be dumped, only slow-probe ones",
+                    exc,
+                )
 
     def _cancel_dead_man(self) -> None:
         if self._dead_man_armed:
@@ -211,9 +258,9 @@ class StallWatchdog:
             self._dead_man_armed = False
 
     def _dump_from_python(self) -> None:
-        now = time.monotonic()
-        if self._last_dump is not None and now - self._last_dump < self._dump_cooldown_s:
+        if self._in_cooldown():
             return
+        now = time.monotonic()
         self._last_dump = now
         stalled_for = now - (self._stall_started or now)
         try:


### PR DESCRIPTION
The stalls in #9712 are over before anyone can attach py-spy, so the dump has to come from inside the process while the stall is still running.

A watchdog thread beats against the event loop. Each beat re-arms faulthandler.dump_traceback_later as a dead man's switch: faulthandler's timeout thread runs C code that never takes the GIL, so when a GIL holder freezes every Python thread, the watchdog included, the switch still fires mid-stall and writes the frame every thread is sitting in. The beat also times a no-op scheduled onto the loop and dumps from Python after three consecutive slow probes, which covers a loop that is stuck while the GIL is free. Thresholds are sized so both paths dump inside the shortest stall on record.

Dumps go to stderr, which the CI workflow and the desktop launcher already capture. The watchdog stands down from its first beat until the torch warm is over, because the switch cannot be disarmed once the warm's import holds the GIL. Both paths share one dump per cooldown window, and UNSLOTH_STUDIO_DISABLE_STALL_WATCHDOG=1 turns it off. Happy to gate it behind an env the CI workflow sets if a dump thread shouldn't ship in the product.

From the repo root:

```
python3 -m venv .venv
.venv/bin/pip install pytest structlog huggingface_hub
cd studio/backend
../../.venv/bin/python -m pytest tests/test_stall_watchdog.py -v
```

9 passed in 8.0s on macOS, Python 3.12. The capture-path tests stall a real event loop: time.sleep scheduled onto it for the GIL-free path, and for the GIL-held path a busy loop under a stretched switch interval. Both assert the dump names the frame that held things up.