### PR TITLE
Studio: fix web pages with non-English URLs failing to load

### DIFF
--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -11026,6 +11026,9 @@ _HEX_PAIR_RE = re.compile(r"[0-9A-Fa-f]{2}")
 # Raw download cap > _MAX_PAGE_CHARS since SSR pages embed large <head> sections
 # stripped during conversion; 512 KB still reaches article content.
 _MAX_FETCH_BYTES = 512 * 1024
+# "%" is safe so an already-encoded URL is not re-encoded into %25.
+_IRI_PATH_SAFE = "/%:@!$&'()*+,;="
+_IRI_QUERY_SAFE = "/%:@!$&'()*+,;=?"
 # PDF cross-reference data lives at EOF, so extraction needs the whole body.
 _MAX_PDF_FETCH_BYTES = 10 * 1024 * 1024
 _MAX_WEB_PDF_PAGES = 50
@@ -11562,7 +11565,7 @@ def _fetch_url_raw(
 
     try:
         from urllib.error import HTTPError as _HTTPError
-        from urllib.parse import urljoin, urlunparse
+        from urllib.parse import quote, urljoin, urlunparse
 
         max_bytes = _MAX_FETCH_BYTES
         current_url = url
@@ -11574,6 +11577,12 @@ def _fetch_url_raw(
             if budget_error is not None:
                 return budget_error, "", ""
             cp = urlparse(current_url)
+            # http.client rejects a non-ASCII selector outright.
+            cp = cp._replace(
+                path = quote(cp.path, safe = _IRI_PATH_SAFE),
+                params = quote(cp.params, safe = _IRI_PATH_SAFE),
+                query = quote(cp.query, safe = _IRI_QUERY_SAFE),
+            )
             # Bracket IPv6 so the netloc stays a valid URL.
             validated_netloc = f"[{current_host}]" if ":" in current_host else current_host
             if cp.port:

--- a/studio/backend/tests/test_web_fetch_scheme_normalization.py
+++ b/studio/backend/tests/test_web_fetch_scheme_normalization.py
@@ -168,3 +168,48 @@ def test_schemeless_github_repo_still_routes_to_readme_api():
     assert tools._github_repo_readme_api_url(normalized) == (
         "https://api.github.com/repos/unslothai/unsloth/readme"
     )
+
+
+def _request_url_for(monkeypatch, url):
+    from core.inference import tools
+
+    seen = {}
+
+    class _Opener:
+        def open(self, req, timeout = None):
+            seen["url"] = req.full_url
+            raise RuntimeError("captured")
+
+    monkeypatch.setattr(
+        tools, "_resolve_with_budget", lambda *a: (True, "", "93.184.216.34")
+    )
+    monkeypatch.setattr(tools.urllib.request, "build_opener", lambda *a: _Opener())
+    tools._fetch_url_raw(url, timeout = 5)
+    return seen.get("url", "")
+
+
+def test_non_ascii_path_is_percent_encoded(monkeypatch):
+    got = _request_url_for(
+        monkeypatch, "https://de.wikipedia.org/wiki/Künstliche_Intelligenz"
+    )
+    assert "K%C3%BCnstliche" in got
+    assert got.isascii(), got
+
+
+def test_non_ascii_query_is_percent_encoded(monkeypatch):
+    got = _request_url_for(monkeypatch, "https://example.com/s?q=café")
+    assert "caf%C3%A9" in got
+    assert got.isascii(), got
+
+
+def test_already_encoded_url_is_not_double_encoded(monkeypatch):
+    got = _request_url_for(
+        monkeypatch, "https://de.wikipedia.org/wiki/K%C3%BCnstliche_Intelligenz"
+    )
+    assert "K%C3%BCnstliche" in got
+    assert "%25" not in got
+
+
+def test_ascii_url_is_unchanged(monkeypatch):
+    got = _request_url_for(monkeypatch, "https://example.com/a/b?x=1&y=2")
+    assert got.endswith("/a/b?x=1&y=2"), got

--- a/studio/backend/tests/test_web_fetch_scheme_normalization.py
+++ b/studio/backend/tests/test_web_fetch_scheme_normalization.py
@@ -176,22 +176,22 @@ def _request_url_for(monkeypatch, url):
     seen = {}
 
     class _Opener:
-        def open(self, req, timeout = None):
+        def open(
+            self,
+            req,
+            timeout = None,
+        ):
             seen["url"] = req.full_url
             raise RuntimeError("captured")
 
-    monkeypatch.setattr(
-        tools, "_resolve_with_budget", lambda *a: (True, "", "93.184.216.34")
-    )
+    monkeypatch.setattr(tools, "_resolve_with_budget", lambda *a: (True, "", "93.184.216.34"))
     monkeypatch.setattr(tools.urllib.request, "build_opener", lambda *a: _Opener())
     tools._fetch_url_raw(url, timeout = 5)
     return seen.get("url", "")
 
 
 def test_non_ascii_path_is_percent_encoded(monkeypatch):
-    got = _request_url_for(
-        monkeypatch, "https://de.wikipedia.org/wiki/Künstliche_Intelligenz"
-    )
+    got = _request_url_for(monkeypatch, "https://de.wikipedia.org/wiki/Künstliche_Intelligenz")
     assert "K%C3%BCnstliche" in got
     assert got.isascii(), got
 
@@ -203,9 +203,7 @@ def test_non_ascii_query_is_percent_encoded(monkeypatch):
 
 
 def test_already_encoded_url_is_not_double_encoded(monkeypatch):
-    got = _request_url_for(
-        monkeypatch, "https://de.wikipedia.org/wiki/K%C3%BCnstliche_Intelligenz"
-    )
+    got = _request_url_for(monkeypatch, "https://de.wikipedia.org/wiki/K%C3%BCnstliche_Intelligenz")
     assert "K%C3%BCnstliche" in got
     assert "%25" not in got
 


### PR DESCRIPTION
Reading a page whose address has a non-English character always failed:

https://de.wikipedia.org/wiki/Künstliche_Intelligenz
`Failed to fetch URL: 'ascii' codec can't encode character '\xfc'
`

One German letter was enough. Same for French, Spanish, Turkish, Russian, Japanese, Chinese and Korean. It showed up on any search that was not in English. Search finds good results, the model tries to open the top one, and it fails with an error it cannot act on.

The address was being sent as typed. Now the parts after the domain are converted to the escaped form web servers expect. Addresses that are already escaped are left alone, and plain English ones are unchanged.