### PR TITLE
Studio: make the Thinking pill toggle again

### DIFF
--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -4907,30 +4907,77 @@ const ReasoningToggle: FC<{ side?: "top" | "bottom" }> = ({
     : reasoningLockedOn || (effectiveReasoningEnabled && !disabled);
 
   if (useDropdown) {
+    // Effort models keep the whole pill as the trigger: picking a level is the
+    // primary action there, and Off is one of the rows.
+    const splitPill =
+      supportsPreserveThinking && !isEffort && !reasoningLockedOn && !disabled;
+    const toggleThinking = () => {
+      const next = !effectiveReasoningEnabled;
+      setReasoningEnabled(next);
+      applyQwenThinkingParams(next);
+      if (!next) setPreserveThinking(false);
+      if (isKimiExternal && next && toolsEnabled) {
+        setToolsEnabled(false, { persist: false });
+      }
+    };
     return (
       <DropdownMenu>
-        <DropdownMenuTrigger asChild={true}>
-          <button
-            type="button"
-            disabled={disabled}
-            className="unsloth-thinking-pill"
-            data-pill-label="Thinking settings"
-            data-active={activeLook ? "true" : "false"}
-            aria-label={thinkEffortAriaLabel({
-              modelLoaded,
-              reasoningDisabled: disabled,
-              reasoningEffort,
-            })}
-          >
-            <ThinkIcon />
-            {activeLook ? (
-              <span className="unsloth-thinking-label">
-                {isEffort ? `Thinking · ${effortLabel}` : "Thinking"}
-              </span>
-            ) : null}
-            <ArrowDownStandardIcon className="unsloth-thinking-caret size-[15px]" />
-          </button>
-        </DropdownMenuTrigger>
+        <div className="unsloth-thinking-split">
+          {splitPill ? (
+            <button
+              type="button"
+              className="unsloth-thinking-pill unsloth-thinking-split-toggle"
+              data-pill-label="Thinking"
+              data-active={activeLook ? "true" : "false"}
+              aria-label={thinkToggleAriaLabel({
+                reasoningLockedOn,
+                modelLoaded,
+                reasoningDisabled: disabled,
+                effectiveReasoningEnabled,
+              })}
+              onClick={toggleThinking}
+            >
+              <PillGlyph>
+                <ThinkIcon />
+              </PillGlyph>
+              {activeLook ? (
+                <span className="unsloth-thinking-label">Thinking</span>
+              ) : null}
+            </button>
+          ) : null}
+          <DropdownMenuTrigger asChild={true}>
+            <button
+              type="button"
+              disabled={disabled}
+              className="unsloth-thinking-pill"
+              data-pill-label="Thinking settings"
+              data-active={activeLook ? "true" : "false"}
+              aria-label={
+                splitPill
+                  ? "Thinking settings"
+                  : thinkEffortAriaLabel({
+                      modelLoaded,
+                      reasoningDisabled: disabled,
+                      reasoningEffort,
+                    })
+              }
+            >
+              {splitPill ? (
+                <BulbIcon className="unsloth-thinking-split-icon size-[15.5px]" />
+              ) : (
+                <>
+                  <ThinkIcon />
+                  {activeLook ? (
+                    <span className="unsloth-thinking-label">
+                      {isEffort ? `Thinking · ${effortLabel}` : "Thinking"}
+                    </span>
+                  ) : null}
+                </>
+              )}
+              <ArrowDownStandardIcon className="unsloth-thinking-caret size-[15px]" />
+            </button>
+          </DropdownMenuTrigger>
+        </div>
         <DropdownMenuContent
           side={side}
           align="end"

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -4920,10 +4920,47 @@ const ReasoningToggle: FC<{ side?: "top" | "bottom" }> = ({
         setToolsEnabled(false, { persist: false });
       }
     };
+    // Only the split pill needs the wrapper. Wrapping the lone trigger too
+    // would move its background to an element the button's disabled:opacity-40
+    // cannot dim, so an unloaded model's pill would light up on hover.
+    const settingsTrigger = (
+      <DropdownMenuTrigger asChild={true}>
+        <button
+          type="button"
+          disabled={disabled}
+          className="unsloth-thinking-pill"
+          data-pill-label="Thinking settings"
+          data-active={activeLook ? "true" : "false"}
+          aria-label={
+            splitPill
+              ? "Thinking settings"
+              : thinkEffortAriaLabel({
+                  modelLoaded,
+                  reasoningDisabled: disabled,
+                  reasoningEffort,
+                })
+          }
+        >
+          {splitPill ? (
+            <BulbIcon className="unsloth-thinking-split-icon size-[15.5px]" />
+          ) : (
+            <>
+              <ThinkIcon />
+              {activeLook ? (
+                <span className="unsloth-thinking-label">
+                  {isEffort ? `Thinking · ${effortLabel}` : "Thinking"}
+                </span>
+              ) : null}
+            </>
+          )}
+          <ArrowDownStandardIcon className="unsloth-thinking-caret size-[15px]" />
+        </button>
+      </DropdownMenuTrigger>
+    );
     return (
       <DropdownMenu>
-        <div className="unsloth-thinking-split">
-          {splitPill ? (
+        {splitPill ? (
+          <div className="unsloth-thinking-split">
             <button
               type="button"
               className="unsloth-thinking-pill unsloth-thinking-split-toggle"
@@ -4944,40 +4981,11 @@ const ReasoningToggle: FC<{ side?: "top" | "bottom" }> = ({
                 <span className="unsloth-thinking-label">Thinking</span>
               ) : null}
             </button>
-          ) : null}
-          <DropdownMenuTrigger asChild={true}>
-            <button
-              type="button"
-              disabled={disabled}
-              className="unsloth-thinking-pill"
-              data-pill-label="Thinking settings"
-              data-active={activeLook ? "true" : "false"}
-              aria-label={
-                splitPill
-                  ? "Thinking settings"
-                  : thinkEffortAriaLabel({
-                      modelLoaded,
-                      reasoningDisabled: disabled,
-                      reasoningEffort,
-                    })
-              }
-            >
-              {splitPill ? (
-                <BulbIcon className="unsloth-thinking-split-icon size-[15.5px]" />
-              ) : (
-                <>
-                  <ThinkIcon />
-                  {activeLook ? (
-                    <span className="unsloth-thinking-label">
-                      {isEffort ? `Thinking · ${effortLabel}` : "Thinking"}
-                    </span>
-                  ) : null}
-                </>
-              )}
-              <ArrowDownStandardIcon className="unsloth-thinking-caret size-[15px]" />
-            </button>
-          </DropdownMenuTrigger>
-        </div>
+            {settingsTrigger}
+          </div>
+        ) : (
+          settingsTrigger
+        )}
         <DropdownMenuContent
           side={side}
           align="end"

--- a/studio/frontend/src/features/chat/shared-composer.tsx
+++ b/studio/frontend/src/features/chat/shared-composer.tsx
@@ -742,6 +742,22 @@ export function SharedComposer({
   const thinkingActiveLook = isEffort
     ? reasoningLockedOn || (effectiveReasoningVisualEnabled && !reasoningDisabled)
     : reasoningLockedOn || (effectiveReasoningEnabled && !reasoningDisabled);
+  // Effort models keep the whole pill as the trigger: picking a level is the
+  // primary action there, and Off is one of the rows.
+  const splitThinkingPill =
+    supportsPreserveThinking &&
+    !isEffort &&
+    !reasoningLockedOn &&
+    !reasoningDisabled;
+  const toggleThinking = () => {
+    const next = !effectiveReasoningEnabled;
+    setReasoningEnabled(next);
+    applyQwenThinkingParams(next);
+    if (!next) setPreserveThinking(false);
+    if (isKimiExternal && next && toolsEnabled) {
+      setToolsEnabled(false, { persist: false });
+    }
+  };
   // Two-pill gating: Search lights up on a local tool runtime (supportsTools:
   // Code/python + local web_search) OR a provider-run server-side web_search
   // (supportsBuiltinWebSearch: OpenAI/Anthropic/OpenRouter/Kimi). Code lights
@@ -2434,33 +2450,67 @@ export function SharedComposer({
           {showReasoningControl ? (
             isEffort || supportsPreserveThinking ? (
               <DropdownMenu>
-                <DropdownMenuTrigger asChild={true}>
-                  <button
-                    type="button"
-                    disabled={reasoningDisabled}
-                    className="unsloth-thinking-pill"
-                    data-pill-label="Thinking settings"
-                    data-active={thinkingActiveLook ? "true" : "false"}
-                    aria-label={thinkEffortAriaLabel({
-                      modelLoaded,
-                      reasoningDisabled,
-                      reasoningEffort,
-                    })}
-                  >
-                    <BulbIcon className="size-[15.5px]" />
-                    {thinkingActiveLook ? (
-                      <span className="unsloth-thinking-label">
-                        {isEffort
-                          ? `Thinking · ${formatReasoningEffortLabel(
+                <div className="unsloth-thinking-split">
+                  {splitThinkingPill ? (
+                    <button
+                      type="button"
+                      className="unsloth-thinking-pill unsloth-thinking-split-toggle"
+                      data-pill-label="Thinking"
+                      data-active={thinkingActiveLook ? "true" : "false"}
+                      aria-label={thinkToggleAriaLabel({
+                        reasoningLockedOn,
+                        modelLoaded,
+                        reasoningDisabled,
+                        effectiveReasoningEnabled,
+                      })}
+                      onClick={toggleThinking}
+                    >
+                      <PillGlyph>
+                        <BulbIcon className="size-[15.5px]" />
+                      </PillGlyph>
+                      {thinkingActiveLook ? (
+                        <span className="unsloth-thinking-label">Thinking</span>
+                      ) : null}
+                    </button>
+                  ) : null}
+                  <DropdownMenuTrigger asChild={true}>
+                    <button
+                      type="button"
+                      disabled={reasoningDisabled}
+                      className="unsloth-thinking-pill"
+                      data-pill-label="Thinking settings"
+                      data-active={thinkingActiveLook ? "true" : "false"}
+                      aria-label={
+                        splitThinkingPill
+                          ? "Thinking settings"
+                          : thinkEffortAriaLabel({
+                              modelLoaded,
+                              reasoningDisabled,
                               reasoningEffort,
-                              externalSelection?.modelId,
-                            )}`
-                          : "Thinking"}
-                      </span>
-                    ) : null}
-                    <ArrowDownStandardIcon className="unsloth-thinking-caret size-[15px]" />
-                  </button>
-                </DropdownMenuTrigger>
+                            })
+                      }
+                    >
+                      {splitThinkingPill ? (
+                        <BulbIcon className="unsloth-thinking-split-icon size-[15.5px]" />
+                      ) : (
+                        <>
+                          <BulbIcon className="size-[15.5px]" />
+                          {thinkingActiveLook ? (
+                            <span className="unsloth-thinking-label">
+                              {isEffort
+                                ? `Thinking · ${formatReasoningEffortLabel(
+                                    reasoningEffort,
+                                    externalSelection?.modelId,
+                                  )}`
+                                : "Thinking"}
+                            </span>
+                          ) : null}
+                        </>
+                      )}
+                      <ArrowDownStandardIcon className="unsloth-thinking-caret size-[15px]" />
+                    </button>
+                  </DropdownMenuTrigger>
+                </div>
                 <DropdownMenuContent
                   side="top"
                   align="end"

--- a/studio/frontend/src/features/chat/shared-composer.tsx
+++ b/studio/frontend/src/features/chat/shared-composer.tsx
@@ -758,6 +758,48 @@ export function SharedComposer({
       setToolsEnabled(false, { persist: false });
     }
   };
+  // Only the split pill needs the wrapper. Wrapping the lone trigger too would
+  // move its background to an element the button's disabled:opacity-40 cannot
+  // dim, so an unloaded model's pill would light up on hover.
+  const thinkingSettingsTrigger = (
+    <DropdownMenuTrigger asChild={true}>
+      <button
+        type="button"
+        disabled={reasoningDisabled}
+        className="unsloth-thinking-pill"
+        data-pill-label="Thinking settings"
+        data-active={thinkingActiveLook ? "true" : "false"}
+        aria-label={
+          splitThinkingPill
+            ? "Thinking settings"
+            : thinkEffortAriaLabel({
+                modelLoaded,
+                reasoningDisabled,
+                reasoningEffort,
+              })
+        }
+      >
+        {splitThinkingPill ? (
+          <BulbIcon className="unsloth-thinking-split-icon size-[15.5px]" />
+        ) : (
+          <>
+            <BulbIcon className="size-[15.5px]" />
+            {thinkingActiveLook ? (
+              <span className="unsloth-thinking-label">
+                {isEffort
+                  ? `Thinking · ${formatReasoningEffortLabel(
+                      reasoningEffort,
+                      externalSelection?.modelId,
+                    )}`
+                  : "Thinking"}
+              </span>
+            ) : null}
+          </>
+        )}
+        <ArrowDownStandardIcon className="unsloth-thinking-caret size-[15px]" />
+      </button>
+    </DropdownMenuTrigger>
+  );
   // Two-pill gating: Search lights up on a local tool runtime (supportsTools:
   // Code/python + local web_search) OR a provider-run server-side web_search
   // (supportsBuiltinWebSearch: OpenAI/Anthropic/OpenRouter/Kimi). Code lights
@@ -2450,8 +2492,8 @@ export function SharedComposer({
           {showReasoningControl ? (
             isEffort || supportsPreserveThinking ? (
               <DropdownMenu>
-                <div className="unsloth-thinking-split">
-                  {splitThinkingPill ? (
+                {splitThinkingPill ? (
+                  <div className="unsloth-thinking-split">
                     <button
                       type="button"
                       className="unsloth-thinking-pill unsloth-thinking-split-toggle"
@@ -2472,45 +2514,11 @@ export function SharedComposer({
                         <span className="unsloth-thinking-label">Thinking</span>
                       ) : null}
                     </button>
-                  ) : null}
-                  <DropdownMenuTrigger asChild={true}>
-                    <button
-                      type="button"
-                      disabled={reasoningDisabled}
-                      className="unsloth-thinking-pill"
-                      data-pill-label="Thinking settings"
-                      data-active={thinkingActiveLook ? "true" : "false"}
-                      aria-label={
-                        splitThinkingPill
-                          ? "Thinking settings"
-                          : thinkEffortAriaLabel({
-                              modelLoaded,
-                              reasoningDisabled,
-                              reasoningEffort,
-                            })
-                      }
-                    >
-                      {splitThinkingPill ? (
-                        <BulbIcon className="unsloth-thinking-split-icon size-[15.5px]" />
-                      ) : (
-                        <>
-                          <BulbIcon className="size-[15.5px]" />
-                          {thinkingActiveLook ? (
-                            <span className="unsloth-thinking-label">
-                              {isEffort
-                                ? `Thinking · ${formatReasoningEffortLabel(
-                                    reasoningEffort,
-                                    externalSelection?.modelId,
-                                  )}`
-                                : "Thinking"}
-                            </span>
-                          ) : null}
-                        </>
-                      )}
-                      <ArrowDownStandardIcon className="unsloth-thinking-caret size-[15px]" />
-                    </button>
-                  </DropdownMenuTrigger>
-                </div>
+                    {thinkingSettingsTrigger}
+                  </div>
+                ) : (
+                  thinkingSettingsTrigger
+                )}
                 <DropdownMenuContent
                   side="top"
                   align="end"

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -2087,6 +2087,23 @@ html[data-chat-font] .aui-root {
 		cursor: pointer;
 	}
 
+	/* Split Thinking pill: the left half toggles, the right half opens the menu. */
+	.unsloth-thinking-split {
+		@apply inline-flex shrink-0 items-center;
+	}
+
+	.unsloth-thinking-split-toggle {
+		@apply rounded-r-none pr-1;
+	}
+
+	.unsloth-thinking-split-toggle + .unsloth-thinking-pill {
+		@apply rounded-l-none pl-0.5;
+	}
+
+	.unsloth-thinking-split-icon {
+		display: none;
+	}
+
 	/* Keep Thinking on the control row in narrow split layouts. */
 	@container (max-width: 36rem) {
 		.unsloth-thinking-pill {
@@ -2097,6 +2114,19 @@ html[data-chat-font] .aui-root {
 		.unsloth-thinking-label,
 		.unsloth-thinking-caret {
 			display: none;
+		}
+
+		/* No caret to aim at, so the trigger takes the whole pill back. */
+		.unsloth-thinking-split-toggle {
+			display: none;
+		}
+
+		.unsloth-thinking-split-toggle + .unsloth-thinking-pill {
+			@apply rounded-full px-0;
+		}
+
+		.unsloth-thinking-split-icon {
+			display: block;
 		}
 
 		.unsloth-thinking-pill[data-pill-label] {

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -2102,6 +2102,13 @@ html[data-chat-font] .aui-root {
 		@apply bg-muted-foreground/10;
 	}
 
+	/* The open menu disables pointer events outside itself, and the trigger
+	   opts back in above. The toggle half needs the same, or half of what
+	   looks and lights like one pill stops answering clicks. */
+	.unsloth-thinking-split:has([data-state="open"]) .unsloth-thinking-split-toggle {
+		pointer-events: auto;
+	}
+
 	.unsloth-thinking-split .unsloth-thinking-pill:hover,
 	.unsloth-thinking-split .unsloth-thinking-pill[data-state="open"] {
 		background: transparent;

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -2087,17 +2087,32 @@ html[data-chat-font] .aui-root {
 		cursor: pointer;
 	}
 
-	/* Split Thinking pill: the left half toggles, the right half opens the menu. */
+	/* Split Thinking pill: the left half toggles, the right half opens the menu.
+	   The container paints the one pill background, so hovering either half
+	   lights the whole pill instead of a half-pill wedge. */
 	.unsloth-thinking-split {
-		@apply inline-flex shrink-0 items-center;
+		@apply inline-flex shrink-0 items-center rounded-full transition-colors;
+	}
+
+	.unsloth-thinking-split:hover {
+		@apply bg-primary/10 dark:bg-white/[0.1];
+	}
+
+	.unsloth-thinking-split:has([data-state="open"]) {
+		@apply bg-muted-foreground/10;
+	}
+
+	.unsloth-thinking-split .unsloth-thinking-pill:hover,
+	.unsloth-thinking-split .unsloth-thinking-pill[data-state="open"] {
+		background: transparent;
 	}
 
 	.unsloth-thinking-split-toggle {
-		@apply rounded-r-none pr-1;
+		@apply pr-1;
 	}
 
 	.unsloth-thinking-split-toggle + .unsloth-thinking-pill {
-		@apply rounded-l-none pl-0.5;
+		@apply pl-0.5;
 	}
 
 	.unsloth-thinking-split-icon {
@@ -2122,7 +2137,7 @@ html[data-chat-font] .aui-root {
 		}
 
 		.unsloth-thinking-split-toggle + .unsloth-thinking-pill {
-			@apply rounded-full px-0;
+			@apply px-0;
 		}
 
 		.unsloth-thinking-split-icon {

--- a/studio/frontend/tests/thinking-pill-split.test.ts
+++ b/studio/frontend/tests/thinking-pill-split.test.ts
@@ -37,15 +37,50 @@ test("the narrow layout swaps the split pill back to a single trigger", () => {
   );
 });
 
+const COMPOSERS = [
+  { path: "../src/components/assistant-ui/thread.tsx", flag: "splitPill" },
+  { path: "../src/features/chat/shared-composer.tsx", flag: "splitThinkingPill" },
+];
+
+function read(path: string): string {
+  return readFileSync(new URL(path, import.meta.url), "utf8");
+}
+
 test("both composers render the icon that narrow layout reveals", () => {
-  for (const path of [
-    "../src/components/assistant-ui/thread.tsx",
-    "../src/features/chat/shared-composer.tsx",
-  ]) {
-    const source = readFileSync(new URL(path, import.meta.url), "utf8");
+  for (const { path } of COMPOSERS) {
     assert.ok(
-      source.includes("unsloth-thinking-split-icon"),
+      read(path).includes("unsloth-thinking-split-icon"),
       `${path} drops the narrow-layout icon`,
+    );
+  }
+});
+
+test("only a split pill gets the wrapper that paints the background", () => {
+  for (const { path, flag } of COMPOSERS) {
+    const source = read(path);
+    const at = source.indexOf('className="unsloth-thinking-split"');
+    assert.notEqual(at, -1, `${path} drops the split wrapper`);
+    // The wrapper holds the hover background, and it is not the button, so
+    // disabled:opacity-40 cannot dim it. Wrapping a lone trigger would light
+    // an unloaded model's pill at full strength.
+    assert.match(
+      source.slice(Math.max(0, at - 160), at),
+      new RegExp(`${flag} \\?`),
+      `${path} wraps the trigger when the pill is not split`,
+    );
+  }
+});
+
+test("the toggle half is wired to the thinking toggle", () => {
+  for (const { path } of COMPOSERS) {
+    const source = read(path);
+    const at = source.indexOf("unsloth-thinking-split-toggle");
+    assert.notEqual(at, -1, `${path} drops the toggle half`);
+    const button = source.slice(at, source.indexOf("</button>", at));
+    assert.match(
+      button,
+      /onClick=\{toggleThinking\}/,
+      `${path} left half no longer toggles thinking`,
     );
   }
 });

--- a/studio/frontend/tests/thinking-pill-split.test.ts
+++ b/studio/frontend/tests/thinking-pill-split.test.ts
@@ -55,6 +55,19 @@ test("both composers render the icon that narrow layout reveals", () => {
   }
 });
 
+test("the toggle half still answers clicks while the menu is open", () => {
+  // Radix's modal menu drops pointer events outside its content. The open
+  // trigger opts back in, so the toggle half has to as well, or half of one
+  // pill goes dead exactly while it is lit as one pill.
+  assert.match(
+    block(
+      css,
+      '.unsloth-thinking-split:has([data-state="open"]) .unsloth-thinking-split-toggle {',
+    ),
+    /pointer-events:\s*auto/,
+  );
+});
+
 test("only a split pill gets the wrapper that paints the background", () => {
   for (const { path, flag } of COMPOSERS) {
     const source = read(path);

--- a/studio/frontend/tests/thinking-pill-split.test.ts
+++ b/studio/frontend/tests/thinking-pill-split.test.ts
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+/**
+ * The split Thinking pill puts the options behind the caret, and the narrow
+ * layout hides that caret. Without the swap below, the menu (Preserve thinking,
+ * and the effort rows) becomes unreachable there.
+ */
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const css = readFileSync(new URL("../src/index.css", import.meta.url), "utf8");
+
+function block(source: string, opener: string): string {
+  const start = source.indexOf(opener);
+  assert.notEqual(start, -1, `missing ${opener}`);
+  let depth = 0;
+  for (let i = start; i < source.length; i++) {
+    if (source[i] === "{") depth++;
+    else if (source[i] === "}" && --depth === 0) return source.slice(start, i);
+  }
+  throw new Error(`unterminated ${opener}`);
+}
+
+test("the narrow layout swaps the split pill back to a single trigger", () => {
+  const narrow = block(css, "@container (max-width: 36rem)");
+  assert.match(narrow, /\.unsloth-thinking-caret\s*{[^}]*display:\s*none/);
+  assert.match(
+    block(narrow, ".unsloth-thinking-split-toggle {"),
+    /display:\s*none/,
+  );
+  assert.match(
+    block(narrow, ".unsloth-thinking-split-icon {"),
+    /display:\s*block/,
+  );
+});
+
+test("both composers render the icon that narrow layout reveals", () => {
+  for (const path of [
+    "../src/components/assistant-ui/thread.tsx",
+    "../src/features/chat/shared-composer.tsx",
+  ]) {
+    const source = readFileSync(new URL(path, import.meta.url), "utf8");
+    assert.ok(
+      source.includes("unsloth-thinking-split-icon"),
+      `${path} drops the narrow-layout icon`,
+    );
+  }
+});


### PR DESCRIPTION
On models that support Preserve thinking, the Thinking pill opened a menu instead of toggling. Every other model toggles in one click.

Now the left side of the pill turns thinking on and off, and the arrow opens the options. The pill still looks and highlights as one pill. Effort models are unchanged. In narrow layouts the arrow is hidden, so the whole pill opens the menu like before.

Tested with gemma-4-E2B-it-GGUF loaded: clicking the pill sends thinking enabled or disabled, and Preserve thinking sends both flags.