### PR TITLE
CLI: follow model reasoning default in unsloth start

### DIFF
--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -255,8 +255,8 @@ _REASONING_OPTION = typer.Option(
     rich_help_panel = _PANEL_SERVER,
     help = (
         "llama-server reasoning mode for an auto-started coding-agent server. "
-        "Defaults to off so tool calls stay in the structured tool channel; use "
-        "'auto' or 'on' to opt back into model reasoning."
+        "Defaults to auto so the model's chat template decides; use 'on' or 'off' "
+        "to override it."
     ),
 )
 _REASONING_EFFORT_OPTION = typer.Option(
@@ -1158,8 +1158,8 @@ def _start_studio_server(
     child_env = os.environ.copy()
     # Current llama-server versions read this documented env equivalent of --reasoning.
     # Older managed versions ignore an unknown env variable instead of failing startup on
-    # an unknown passthrough CLI flag. An omitted start option still defaults to off.
-    child_env["LLAMA_ARG_REASONING"] = server.reasoning or "off"
+    # an unknown passthrough CLI flag. An omitted start option follows the model template.
+    child_env["LLAMA_ARG_REASONING"] = server.reasoning or "auto"
     # Always written, like the line above: an inherited value would otherwise pin
     # a level the omitted flag promises to leave alone. 'default' is llama.cpp's
     # own sentinel for "keep the chat template's level".

--- a/unsloth_cli/tests/test_start.py
+++ b/unsloth_cli/tests/test_start.py
@@ -2862,12 +2862,12 @@ def test_start_studio_server_forwards_tool_flags_via_command_and_env(monkeypatch
     monkeypatch.delenv("UNSLOTH_DISABLE_TOOL_CALL_HEALING", raising = False)
     monkeypatch.delenv("UNSLOTH_TOOL_CALL_NUDGE", raising = False)
 
-    # Default start: tools off (passthrough), healing + nudging on.
+    # Default start: tools off (passthrough), model-template reasoning, healing + nudging on.
     start._start_studio_server("http://127.0.0.1:8888", "unsloth/M-GGUF", start.LoadOptions())
     cmd, env = captured["command"], captured["kwargs"]["env"]
     assert "--disable-tools" in cmd and "--enable-tools" not in cmd
     assert "--reasoning" not in cmd
-    assert env["LLAMA_ARG_REASONING"] == "off"
+    assert env["LLAMA_ARG_REASONING"] == "auto"
     assert "--gpu-memory-mode" not in cmd
     assert env["UNSLOTH_DISABLE_TOOL_CALL_HEALING"] == "0"
     assert env["UNSLOTH_TOOL_CALL_NUDGE"] == "1"
@@ -3047,7 +3047,9 @@ def test_start_studio_server_forwards_reasoning_effort(monkeypatch):
         start.LoadOptions(),
         start.ServerOptions(reasoning_effort = "medium"),
     )
-    assert captured["kwargs"]["env"]["LLAMA_ARG_REASONING_EFFORT"] == "medium"
+    env = captured["kwargs"]["env"]
+    assert env["LLAMA_ARG_REASONING"] == "auto"
+    assert env["LLAMA_ARG_REASONING_EFFORT"] == "medium"
 
 
 def test_start_studio_server_overrides_inherited_reasoning_effort(monkeypatch):
@@ -3660,7 +3662,7 @@ def test_start_studio_server_builds_command_and_waits(monkeypatch, capsys):
     assert cmd[1] == "run"
     assert "--disable-tools" in cmd and "--no-cloudflare" in cmd
     assert "--reasoning" not in cmd
-    assert captured["kwargs"]["env"]["LLAMA_ARG_REASONING"] == "off"
+    assert captured["kwargs"]["env"]["LLAMA_ARG_REASONING"] == "auto"
     assert cmd[cmd.index("--model") + 1] == "unsloth/Qwen3-1.7B-GGUF:UD-Q4_K_XL"
     assert cmd[cmd.index("--gguf-variant") + 1] == "UD-Q4_K_XL"
     assert cmd[cmd.index("--context-length") + 1] == "8192"


### PR DESCRIPTION
## Summary

- default auto-started agent servers to the model chat template's reasoning mode when `--reasoning` is omitted
- keep explicit `--reasoning on`, `--reasoning off`, and `--reasoning auto` overrides unchanged
- cover the omitted flag and `--reasoning-effort` combination with regression tests

## Why

`unsloth start` currently forces reasoning off even when the model chat template defaults reasoning on. This makes `--reasoning-effort` ineffective unless the user also enables reasoning explicitly.

Using llama.cpp's `auto` mode preserves each model's default while keeping explicit overrides available.

## Testing

```text
521 passed, 3 skipped
```
