### PR TITLE
desktop: turn webkit compositing off on the one wayland nvidia setup that freezes

### DIFF
--- a/studio/backend/tests/test_health_answers_within_probe_budget.py
+++ b/studio/backend/tests/test_health_answers_within_probe_budget.py
@@ -560,9 +560,9 @@ def test_a_cold_health_call_answers_inside_the_launcher_deadline():
     probe_timeout = _desktop_probe_timeout_s()
     result = _probe(_SLOW_DETECT_S)
 
-    assert result["cold_hardware_detecting"] is True, (
-        "the cold call got a settled reply, so it never exercised the wait this bound is about"
-    )
+    assert (
+        result["cold_hardware_detecting"] is True
+    ), "the cold call got a settled reply, so it never exercised the wait this bound is about"
     assert result["cold_elapsed"] < probe_timeout, (
         f"the first /api/health call took {result['cold_elapsed']:.2f}s, past the "
         f"{probe_timeout}s the desktop probe allows before it gives up and dead-ends "

--- a/studio/scripts/unsloth_freeze_report.py
+++ b/studio/scripts/unsloth_freeze_report.py
@@ -183,14 +183,19 @@ CANDIDATE_VARS = tuple(sorted({k for _, extra, _ in CANDIDATES for k in extra}))
 #                                     test above.
 #   GDK_BACKEND                       selects the display backend, which is what decides
 #                                     between the shared-memory switch and no workaround.
+#   UNSLOTH_WEBKIT_DISABLE_COMPOSITING  the app's own on/off switch for the compositing
+#                                     workaround, and the one a freezing host is told to
+#                                     export, so it is the value most likely to still be
+#                                     set in the shell that runs this script.
 #
-# None of the first four appear in CANDIDATES, so a cleared set derived from CANDIDATES
-# left every one of them active. Any of them still exported in the reporter's shell then
-# pins all four launches, INCLUDING the control, and a control that cannot produce the
-# other answer is not a control: the report comes back saying the comparison was clean
-# when nothing was ever compared.
+# None of these appear in CANDIDATES, so a cleared set derived from CANDIDATES left every
+# one of them active. Any of them still exported in the reporter's shell then pins all four
+# launches, INCLUDING the control, and a control that cannot produce the other answer is not
+# a control: the report comes back saying the comparison was clean when nothing was ever
+# compared.
 RENDERER_OVERRIDE_VARS = (
     "GDK_BACKEND",
+    "UNSLOTH_WEBKIT_DISABLE_COMPOSITING",
     "UNSLOTH_WEBKIT_RENDERER_WORKAROUND",
     "WEBKIT_DISABLE_DMABUF_RENDERER",
     "WEBKIT_DMABUF_RENDERER_FORCE_SHM",

--- a/studio/scripts/unsloth_freeze_report.py
+++ b/studio/scripts/unsloth_freeze_report.py
@@ -185,8 +185,8 @@ CANDIDATE_VARS = tuple(sorted({k for _, extra, _ in CANDIDATES for k in extra}))
 #                                     between the shared-memory switch and no workaround.
 #   UNSLOTH_WEBKIT_DISABLE_COMPOSITING  the app's own on/off switch for the compositing
 #                                     workaround, and the one a freezing host is told to
-#                                     export, so it is the value most likely to still be
-#                                     set in the shell that runs this script.
+#                                     export, so of all of these it is the likeliest to
+#                                     still be set in the shell that runs this script.
 #
 # None of these appear in CANDIDATES, so a cleared set derived from CANDIDATES left every
 # one of them active. Any of them still exported in the reporter's shell then pins all four

--- a/studio/src-tauri/src/linux_webkit.rs
+++ b/studio/src-tauri/src/linux_webkit.rs
@@ -18,12 +18,23 @@ const DISABLE_DMABUF: &str = "WEBKIT_DISABLE_DMABUF_RENDERER";
 // disable-nvidia-dmabuf.patch's own opt-out, read inside isNVIDIA(). WebKit returns on
 // DISABLE_DMABUF first, so it never gets there unless we honour it ourselves.
 const FORCE_DMABUF: &str = "WEBKIT_FORCE_DMABUF_RENDERER";
+// Turns accelerated compositing off outright, a level above the transport switches above.
+// Unlike DISABLE_DMABUF, do not assume WebKit special-cases "0" here, so presence alone is
+// treated as an operator override and our own setting below is the documented way off.
+const DISABLE_COMPOSITING: &str = "WEBKIT_DISABLE_COMPOSITING_MODE";
+// Ours, not WebKit's. 1 forces the compositing workaround on, 0 forces it off. It exists so
+// a report from a host outside the narrow rule below can be settled without shipping a new
+// predicate for every configuration.
+const DISABLE_COMPOSITING_SETTING: &str = "UNSLOTH_WEBKIT_DISABLE_COMPOSITING";
 // Comma-joined list of the variables we set, so a relaunch tells our own inherited output
 // from an operator's value. Tauri's process::restart does not env_clear. WebKit never reads it.
 const APPLIED_WORKAROUND: &str = "UNSLOTH_WEBKIT_RENDERER_WORKAROUND";
 const FORCE_SHARED_MEMORY_MIN_VERSION: (u32, u32) = (2, 44);
 // both the proprietary and open nvidia modules publish this; nouveau does not and is unaffected
 const NVIDIA_DRIVER_VERSION_PATH: &str = "/proc/driver/nvidia/version";
+// The open modules announce themselves in the same file the presence probe already reads.
+const OPEN_KERNEL_MODULE_MARKER: &str = "Open Kernel Module";
+const DRM_CLASS_DIR: &str = "/sys/class/drm";
 
 const NVIDIA_REASON: &str = "NVIDIA driver loaded (no Wayland session)";
 const NVIDIA_WAYLAND_REASON: &str = "NVIDIA driver loaded (Wayland session)";
@@ -31,6 +42,9 @@ const NVIDIA_APPIMAGE_GLES_REASON: &str =
     "NVIDIA driver loaded; AppImage without a usable GLES library";
 const WAYLAND_REASON: &str = "Wayland session";
 const APPIMAGE_GLES_REASON: &str = "AppImage without a usable GLES library";
+const COMPOSITING_REASON: &str =
+    "Wayland session on NVIDIA with mixed GPU vendors and the open kernel module";
+const COMPOSITING_FORCED_REASON: &str = "compositing workaround requested by the environment";
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum RenderingWorkaround {
@@ -41,6 +55,9 @@ enum RenderingWorkaround {
     /// Unpatched libraries ignore the variable.
     ForceSharedMemoryOnNvidia,
     DisableDmabuf,
+    /// Not a transport at all. The others choose how buffers reach the compositor; this
+    /// stops WebKit compositing on the GPU in the first place.
+    DisableCompositing,
 }
 
 impl RenderingWorkaround {
@@ -49,6 +66,7 @@ impl RenderingWorkaround {
             Self::ForceSharedMemory => &[FORCE_SHARED_MEMORY],
             Self::ForceSharedMemoryOnNvidia => &[FORCE_SHARED_MEMORY, FORCE_DMABUF],
             Self::DisableDmabuf => &[DISABLE_DMABUF],
+            Self::DisableCompositing => &[DISABLE_COMPOSITING],
         }
     }
 }
@@ -105,6 +123,8 @@ fn rendering_plan(
     nvidia_driver_loaded: bool,
     wayland_socket: bool,
     x11_open: bool,
+    mixed_gpu_vendors: bool,
+    open_kernel_module: bool,
 ) -> RenderingPlan {
     // Either renderer variable is an operator override when present, `=0` and an empty
     // value included, unless the marker says we wrote it. Without that test a launch
@@ -128,6 +148,9 @@ fn rendering_plan(
     if env(FORCE_SHARED_MEMORY).is_some() && !ours(FORCE_SHARED_MEMORY) {
         return RenderingPlan::PreserveEnvironment;
     }
+    if env(DISABLE_COMPOSITING).is_some() && !ours(DISABLE_COMPOSITING) {
+        return RenderingPlan::PreserveEnvironment;
+    }
 
     // Stands the NVIDIA branch down and nothing else: it answers that patch's question,
     // not the missing-GLES one below, and that launch cannot render without its fallback.
@@ -146,6 +169,39 @@ fn rendering_plan(
         wayland_socket,
         x11_open,
     );
+
+    // A freeze, not a transport failure, and none of the switches below reach it. The
+    // WebKit web process stops executing about 45 seconds in and never resumes: every
+    // frontend timer stops together while the native watchdog, in a different process,
+    // keeps answering. Measured on one Wayland NVIDIA host under FORCE_SHM, under
+    // DISABLE_DMABUF and under neither, all three freezing, and fixed both by turning
+    // accelerated compositing off and by leaving Wayland altogether.
+    //
+    // It is deliberately NOT gated on Wayland plus NVIDIA. A second NVIDIA Wayland host
+    // was measured on the same driver and the same WebKitGTK and does not freeze at all,
+    // so that predicate would take accelerated compositing away from a machine that is
+    // demonstrably fine.
+    //
+    // The two axes that separate the affected host from the healthy one are mixed GPU
+    // vendors (an Intel iGPU beside the NVIDIA dGPU) and the open kernel module. Requiring
+    // BOTH is overfitted on purpose. With one host on each side neither axis is
+    // established as the cause, and the conservative reading is the one that leaves every
+    // machine measured so far exactly as it is today. Anyone outside the rule who reports
+    // the same freeze gets UNSLOTH_WEBKIT_DISABLE_COMPOSITING=1, which is why that setting
+    // exists: a support answer that survives a restart, instead of a widened guess.
+    let compositing_setting = env(DISABLE_COMPOSITING_SETTING);
+    let requested = |wanted: &str| compositing_setting.as_deref() == Some(OsStr::new(wanted));
+    if !requested("0")
+        && (requested("1")
+            || (wayland_session && nvidia_driver_loaded && mixed_gpu_vendors && open_kernel_module))
+    {
+        let reason = if requested("1") {
+            COMPOSITING_FORCED_REASON
+        } else {
+            COMPOSITING_REASON
+        };
+        return RenderingPlan::Apply(RenderingWorkaround::DisableCompositing, reason);
+    }
 
     // The DMA-BUF transport breaks on the proprietary driver on either display server, so
     // this cannot be gated on a Wayland session. Upstream declined the fix (bug 262607
@@ -292,6 +348,43 @@ fn nvidia_driver_loaded() -> bool {
     std::path::Path::new(NVIDIA_DRIVER_VERSION_PATH).exists()
 }
 
+/// Is more than one GPU vendor present, e.g. an Intel iGPU beside an NVIDIA dGPU?
+///
+/// Reads PCI vendor ids straight out of sysfs. No GL context and no device is opened, so
+/// this is safe before GTK init, which is the same constraint that stops the NVIDIA probe
+/// asking which GPU will actually render.
+fn mixed_gpu_vendors_in(dir: &str) -> bool {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return false;
+    };
+    let mut seen: Vec<String> = Vec::new();
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        // cardN only. `cardN-CONNECTOR` entries are outputs of a card already counted, and
+        // renderDN is the same device under a second node.
+        if !name.starts_with("card") || name.contains('-') {
+            continue;
+        }
+        // A card with no readable vendor is a virtual framebuffer (simpledrm and friends).
+        // Counting "missing" as a vendor of its own makes every such host look hybrid, and
+        // hosts with one are not rare: this workspace's own box has exactly that card0.
+        let Ok(vendor) = std::fs::read_to_string(entry.path().join("device/vendor")) else {
+            continue;
+        };
+        let vendor = vendor.trim().to_owned();
+        if !vendor.is_empty() && !seen.iter().any(|known| *known == vendor) {
+            seen.push(vendor);
+        }
+    }
+    seen.len() > 1
+}
+
+/// The open kernel modules say so in the file the presence probe already reads.
+fn open_kernel_module_at(path: &str) -> bool {
+    std::fs::read_to_string(path).is_ok_and(|text| text.contains(OPEN_KERNEL_MODULE_MARKER))
+}
+
 fn gles_is_usable() -> bool {
     // Match libepoxy's runtime load, including unresolved dependencies.
     unsafe {
@@ -341,6 +434,8 @@ pub fn configure_renderer() -> Option<(&'static [&'static str], &'static str)> {
         nvidia_driver_loaded(),
         wayland_socket_present(),
         x11_display_open(std::env::var_os(X11_DISPLAY), X11_SOCKET_DIR),
+        mixed_gpu_vendors_in(DRM_CLASS_DIR),
+        open_kernel_module_at(NVIDIA_DRIVER_VERSION_PATH),
     ) {
         RenderingPlan::Apply(workaround, reason) => {
             let variables = workaround.variables();
@@ -423,6 +518,36 @@ mod tests {
             nvidia_driver_loaded,
             wayland_socket,
             x11_open,
+            // Every pre-existing case models a single-vendor host on the proprietary
+            // module, which is what they asserted before the compositing rule existed.
+            // Keeping that default here is what makes those assertions still mean the
+            // same thing: the new rule cannot fire in any of them.
+            false,
+            false,
+        )
+    }
+
+    /// The compositing rule's own inputs, which no other case varies.
+    fn plan_on_graphics(
+        vars: &[(&str, &str)],
+        nvidia_driver_loaded: bool,
+        mixed_gpu_vendors: bool,
+        open_kernel_module: bool,
+    ) -> RenderingPlan {
+        let live = named(vars, WAYLAND_DISPLAY);
+        rendering_plan(
+            |name| {
+                vars.iter()
+                    .find(|(key, _)| *key == name)
+                    .map(|(_, value)| OsString::from(value))
+            },
+            MODERN_WEBKIT,
+            true,
+            nvidia_driver_loaded,
+            live,
+            named(vars, X11_DISPLAY),
+            mixed_gpu_vendors,
+            open_kernel_module,
         )
     }
 
@@ -1078,4 +1203,133 @@ mod tests {
             RenderingPlan::PreserveEnvironment
         );
     }
+    // The compositing rule. Two real hosts sit on either side of it, and the tests are
+    // named after what each one measured rather than after the branch they exercise.
+
+    const WAYLAND: &[(&str, &str)] = &[(WAYLAND_DISPLAY, "wayland-0")];
+
+    #[test]
+    fn the_freezing_host_gets_compositing_turned_off() {
+        // Ubuntu 26.04, GNOME Wayland, Intel Arc iGPU beside an RTX 4050 Mobile, open
+        // kernel module. Froze at about 45s under FORCE_SHM, under DISABLE_DMABUF and
+        // under neither, and kept polling for a full run with compositing off.
+        assert_eq!(
+            plan_on_graphics(WAYLAND, true, true, true),
+            RenderingPlan::Apply(RenderingWorkaround::DisableCompositing, COMPOSITING_REASON)
+        );
+    }
+
+    #[test]
+    fn the_healthy_nvidia_wayland_host_is_left_alone() {
+        // Linux Mint 22, Cinnamon on Wayland, two discrete NVIDIA cards on the proprietary
+        // module, same driver and same WebKitGTK as the host above. It does not freeze, so
+        // gating on Wayland plus NVIDIA alone would take compositing off a machine that is
+        // measurably fine. It keeps the transport workaround it has today.
+        let plan = plan_on_graphics(WAYLAND, true, false, false);
+        assert_ne!(
+            plan,
+            RenderingPlan::Apply(RenderingWorkaround::DisableCompositing, COMPOSITING_REASON)
+        );
+        assert_eq!(
+            plan,
+            RenderingPlan::Apply(RenderingWorkaround::DisableDmabuf, NVIDIA_WAYLAND_REASON)
+        );
+    }
+
+    #[test]
+    fn either_axis_alone_is_not_enough() {
+        // Requiring both is the whole point: with one host on each side neither axis is
+        // established, so a machine matching only one keeps today's behaviour.
+        for (mixed, open) in [(true, false), (false, true)] {
+            assert_eq!(
+                plan_on_graphics(WAYLAND, true, mixed, open),
+                RenderingPlan::Apply(RenderingWorkaround::DisableDmabuf, NVIDIA_WAYLAND_REASON),
+                "mixed_gpu_vendors={mixed} open_kernel_module={open}"
+            );
+        }
+    }
+
+    #[test]
+    fn x11_never_takes_the_compositing_workaround() {
+        // The same hardware on X11 was measured healthy, and the freeze needs the Wayland
+        // path. An X11 session keeps the shared-memory switch it has today.
+        let x11: &[(&str, &str)] = &[(X11_DISPLAY, ":0")];
+        assert_eq!(
+            plan_on_graphics(x11, true, true, true),
+            RenderingPlan::Apply(
+                RenderingWorkaround::ForceSharedMemoryOnNvidia,
+                NVIDIA_REASON
+            )
+        );
+    }
+
+    #[test]
+    fn the_setting_settles_a_report_without_a_new_predicate() {
+        // A host outside the rule that reports the same freeze, and the opposite case: a
+        // host inside it that the rule is wrong about. Both without shipping code.
+        let forced: &[(&str, &str)] = &[(DISABLE_COMPOSITING_SETTING, "1")];
+        assert_eq!(
+            plan_on_graphics(forced, false, false, false),
+            RenderingPlan::Apply(
+                RenderingWorkaround::DisableCompositing,
+                COMPOSITING_FORCED_REASON
+            )
+        );
+        let off: &[(&str, &str)] = &[(WAYLAND_DISPLAY, "wayland-0"), (DISABLE_COMPOSITING_SETTING, "0")];
+        assert_eq!(
+            plan_on_graphics(off, true, true, true),
+            RenderingPlan::Apply(RenderingWorkaround::DisableDmabuf, NVIDIA_WAYLAND_REASON)
+        );
+    }
+
+    #[test]
+    fn an_operator_who_set_the_variable_keeps_their_environment() {
+        let theirs: &[(&str, &str)] = &[(WAYLAND_DISPLAY, "wayland-0"), (DISABLE_COMPOSITING, "1")];
+        assert_eq!(
+            plan_on_graphics(theirs, true, true, true),
+            RenderingPlan::PreserveEnvironment
+        );
+    }
+
+    #[test]
+    fn a_virtual_framebuffer_does_not_make_a_host_look_hybrid() {
+        // card0 with no readable vendor is a virtual framebuffer, and this workspace's own
+        // box has one beside eight NVIDIA cards. Counting a missing vendor as its own
+        // would make every such host match the rule.
+        let dir = std::env::temp_dir().join(format!("unsloth-drm-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let card = |name: &str| dir.join(name).join("device");
+        std::fs::create_dir_all(card("card0")).unwrap();
+        std::fs::create_dir_all(card("card1")).unwrap();
+        std::fs::write(card("card1").join("vendor"), "0x10de\n").unwrap();
+        let path = dir.to_string_lossy().into_owned();
+        assert!(!mixed_gpu_vendors_in(&path), "one real vendor is not mixed");
+
+        // A connector entry is an output of a card already counted, not a second device.
+        std::fs::create_dir_all(card("card1-DP-1")).unwrap();
+        std::fs::write(card("card1-DP-1").join("vendor"), "0x8086\n").unwrap();
+        assert!(!mixed_gpu_vendors_in(&path), "connectors are not devices");
+
+        std::fs::create_dir_all(card("card2")).unwrap();
+        std::fs::write(card("card2").join("vendor"), "0x8086\n").unwrap();
+        assert!(mixed_gpu_vendors_in(&path), "Intel beside NVIDIA is mixed");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn the_open_module_is_read_from_the_file_the_probe_already_opens() {
+        let dir = std::env::temp_dir().join(format!("unsloth-nvrm-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let open = dir.join("open");
+        let proprietary = dir.join("proprietary");
+        std::fs::write(&open, "NVRM version: NVIDIA UNIX Open Kernel Module for x86_64  580.173.02\n")
+            .unwrap();
+        std::fs::write(&proprietary, "NVRM version: NVIDIA UNIX x86_64 Kernel Module  580.173.02\n")
+            .unwrap();
+        assert!(open_kernel_module_at(&open.to_string_lossy()));
+        assert!(!open_kernel_module_at(&proprietary.to_string_lossy()));
+        assert!(!open_kernel_module_at("/nonexistent/nvidia/version"));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
 }

--- a/studio/src-tauri/src/linux_webkit.rs
+++ b/studio/src-tauri/src/linux_webkit.rs
@@ -1268,7 +1268,10 @@ mod tests {
                 COMPOSITING_FORCED_REASON
             )
         );
-        let off: &[(&str, &str)] = &[(WAYLAND_DISPLAY, "wayland-0"), (DISABLE_COMPOSITING_SETTING, "0")];
+        let off: &[(&str, &str)] = &[
+            (WAYLAND_DISPLAY, "wayland-0"),
+            (DISABLE_COMPOSITING_SETTING, "0"),
+        ];
         assert_eq!(
             plan_on_graphics(off, true, true, true),
             RenderingPlan::Apply(RenderingWorkaround::DisableDmabuf, NVIDIA_WAYLAND_REASON)
@@ -1314,14 +1317,19 @@ mod tests {
         std::fs::create_dir_all(&dir).unwrap();
         let open = dir.join("open");
         let proprietary = dir.join("proprietary");
-        std::fs::write(&open, "NVRM version: NVIDIA UNIX Open Kernel Module for x86_64  580.173.02\n")
-            .unwrap();
-        std::fs::write(&proprietary, "NVRM version: NVIDIA UNIX x86_64 Kernel Module  580.173.02\n")
-            .unwrap();
+        std::fs::write(
+            &open,
+            "NVRM version: NVIDIA UNIX Open Kernel Module for x86_64  580.173.02\n",
+        )
+        .unwrap();
+        std::fs::write(
+            &proprietary,
+            "NVRM version: NVIDIA UNIX x86_64 Kernel Module  580.173.02\n",
+        )
+        .unwrap();
         assert!(open_kernel_module_at(&open.to_string_lossy()));
         assert!(!open_kernel_module_at(&proprietary.to_string_lossy()));
         assert!(!open_kernel_module_at("/nonexistent/nvidia/version"));
         let _ = std::fs::remove_dir_all(&dir);
     }
-
 }

--- a/studio/src-tauri/src/linux_webkit.rs
+++ b/studio/src-tauri/src/linux_webkit.rs
@@ -19,12 +19,11 @@ const DISABLE_DMABUF: &str = "WEBKIT_DISABLE_DMABUF_RENDERER";
 // DISABLE_DMABUF first, so it never gets there unless we honour it ourselves.
 const FORCE_DMABUF: &str = "WEBKIT_FORCE_DMABUF_RENDERER";
 // Turns accelerated compositing off outright, a level above the transport switches above.
-// Unlike DISABLE_DMABUF, do not assume WebKit special-cases "0" here, so presence alone is
-// treated as an operator override and our own setting below is the documented way off.
+// WebKit is not assumed to special-case "0" here, so presence alone is an operator override
+// and the setting below is the documented way off.
 const DISABLE_COMPOSITING: &str = "WEBKIT_DISABLE_COMPOSITING_MODE";
-// Ours, not WebKit's. 1 forces the compositing workaround on, 0 forces it off. It exists so
-// a report from a host outside the narrow rule below can be settled without shipping a new
-// predicate for every configuration.
+// Ours, not WebKit's. 1 forces the compositing workaround on, 0 forces it off, so a report
+// from outside the narrow rule below is settled without shipping a new predicate.
 const DISABLE_COMPOSITING_SETTING: &str = "UNSLOTH_WEBKIT_DISABLE_COMPOSITING";
 // Comma-joined list of the variables we set, so a relaunch tells our own inherited output
 // from an operator's value. Tauri's process::restart does not env_clear. WebKit never reads it.
@@ -56,7 +55,7 @@ enum RenderingWorkaround {
     ForceSharedMemoryOnNvidia,
     DisableDmabuf,
     /// Not a transport at all. The others choose how buffers reach the compositor; this
-    /// stops WebKit compositing on the GPU in the first place.
+    /// stops WebKit compositing on the GPU at all.
     DisableCompositing,
 }
 
@@ -172,23 +171,17 @@ fn rendering_plan(
 
     // A freeze, not a transport failure, and none of the switches below reach it. The
     // WebKit web process stops executing about 45 seconds in and never resumes: every
-    // frontend timer stops together while the native watchdog, in a different process,
-    // keeps answering. Measured on one Wayland NVIDIA host under FORCE_SHM, under
-    // DISABLE_DMABUF and under neither, all three freezing, and fixed both by turning
-    // accelerated compositing off and by leaving Wayland altogether.
+    // frontend timer stops together while the native watchdog, in another process, keeps
+    // answering. One Wayland NVIDIA host froze under FORCE_SHM, under DISABLE_DMABUF and
+    // under neither, and ran clean with compositing off or off Wayland.
     //
-    // It is deliberately NOT gated on Wayland plus NVIDIA. A second NVIDIA Wayland host
-    // was measured on the same driver and the same WebKitGTK and does not freeze at all,
-    // so that predicate would take accelerated compositing away from a machine that is
-    // demonstrably fine.
-    //
-    // The two axes that separate the affected host from the healthy one are mixed GPU
-    // vendors (an Intel iGPU beside the NVIDIA dGPU) and the open kernel module. Requiring
-    // BOTH is overfitted on purpose. With one host on each side neither axis is
-    // established as the cause, and the conservative reading is the one that leaves every
-    // machine measured so far exactly as it is today. Anyone outside the rule who reports
-    // the same freeze gets UNSLOTH_WEBKIT_DISABLE_COMPOSITING=1, which is why that setting
-    // exists: a support answer that survives a restart, instead of a widened guess.
+    // Not gated on Wayland plus NVIDIA alone: a second host on the same driver and the
+    // same WebKitGTK does not freeze, and that predicate would take accelerated
+    // compositing off a machine that is demonstrably fine. The two axes separating them
+    // are mixed GPU vendors (an Intel iGPU beside the NVIDIA dGPU) and the open kernel
+    // module. Requiring BOTH is overfitted on purpose: with one host on each side neither
+    // axis is established, so the conservative rule leaves every measured machine as it is
+    // today. Anyone outside it reporting the same freeze gets the setting above.
     let compositing_setting = env(DISABLE_COMPOSITING_SETTING);
     let requested = |wanted: &str| compositing_setting.as_deref() == Some(OsStr::new(wanted));
     if !requested("0")
@@ -350,9 +343,9 @@ fn nvidia_driver_loaded() -> bool {
 
 /// Is more than one GPU vendor present, e.g. an Intel iGPU beside an NVIDIA dGPU?
 ///
-/// Reads PCI vendor ids straight out of sysfs. No GL context and no device is opened, so
-/// this is safe before GTK init, which is the same constraint that stops the NVIDIA probe
-/// asking which GPU will actually render.
+/// Reads PCI vendor ids out of sysfs, opening no device and no GL context, so it is safe
+/// before GTK init. That is the same constraint that stops the NVIDIA probe asking which
+/// GPU will actually render.
 fn mixed_gpu_vendors_in(dir: &str) -> bool {
     let Ok(entries) = std::fs::read_dir(dir) else {
         return false;
@@ -366,9 +359,9 @@ fn mixed_gpu_vendors_in(dir: &str) -> bool {
         if !name.starts_with("card") || name.contains('-') {
             continue;
         }
-        // A card with no readable vendor is a virtual framebuffer (simpledrm and friends).
-        // Counting "missing" as a vendor of its own makes every such host look hybrid, and
-        // hosts with one are not rare: this workspace's own box has exactly that card0.
+        // A card with no readable vendor is a virtual framebuffer (simpledrm and friends),
+        // and such hosts are not rare. Counting "missing" as a vendor of its own would make
+        // every one of them look hybrid.
         let Ok(vendor) = std::fs::read_to_string(entry.path().join("device/vendor")) else {
             continue;
         };
@@ -1203,8 +1196,8 @@ mod tests {
             RenderingPlan::PreserveEnvironment
         );
     }
-    // The compositing rule. Two real hosts sit on either side of it, and the tests are
-    // named after what each one measured rather than after the branch they exercise.
+    // The compositing rule. Two real hosts sit on either side of it, and these tests are
+    // named after what each one measured rather than after the branch it exercises.
 
     const WAYLAND: &[(&str, &str)] = &[(WAYLAND_DISPLAY, "wayland-0")];
 
@@ -1222,9 +1215,9 @@ mod tests {
     #[test]
     fn the_healthy_nvidia_wayland_host_is_left_alone() {
         // Linux Mint 22, Cinnamon on Wayland, two discrete NVIDIA cards on the proprietary
-        // module, same driver and same WebKitGTK as the host above. It does not freeze, so
-        // gating on Wayland plus NVIDIA alone would take compositing off a machine that is
-        // measurably fine. It keeps the transport workaround it has today.
+        // module, same driver and same WebKitGTK as the host above, and it does not freeze.
+        // Gating on Wayland plus NVIDIA alone would take compositing off a machine that is
+        // measurably fine, so it keeps the transport workaround it has today.
         let plan = plan_on_graphics(WAYLAND, true, false, false);
         assert_ne!(
             plan,
@@ -1238,8 +1231,8 @@ mod tests {
 
     #[test]
     fn either_axis_alone_is_not_enough() {
-        // Requiring both is the whole point: with one host on each side neither axis is
-        // established, so a machine matching only one keeps today's behaviour.
+        // With one host on each side neither axis is established on its own, so a machine
+        // matching only one keeps today's behaviour.
         for (mixed, open) in [(true, false), (false, true)] {
             assert_eq!(
                 plan_on_graphics(WAYLAND, true, mixed, open),
@@ -1265,8 +1258,8 @@ mod tests {
 
     #[test]
     fn the_setting_settles_a_report_without_a_new_predicate() {
-        // A host outside the rule that reports the same freeze, and the opposite case: a
-        // host inside it that the rule is wrong about. Both without shipping code.
+        // Both directions without shipping code: a host outside the rule that reports the
+        // same freeze, and a host inside it that the rule is wrong about.
         let forced: &[(&str, &str)] = &[(DISABLE_COMPOSITING_SETTING, "1")];
         assert_eq!(
             plan_on_graphics(forced, false, false, false),
@@ -1293,9 +1286,8 @@ mod tests {
 
     #[test]
     fn a_virtual_framebuffer_does_not_make_a_host_look_hybrid() {
-        // card0 with no readable vendor is a virtual framebuffer, and this workspace's own
-        // box has one beside eight NVIDIA cards. Counting a missing vendor as its own
-        // would make every such host match the rule.
+        // A card with no readable vendor is a virtual framebuffer, and hosts pair one with
+        // real GPUs. Counting a missing vendor as its own would make them all match.
         let dir = std::env::temp_dir().join(format!("unsloth-drm-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&dir);
         let card = |name: &str| dir.join(name).join("device");

--- a/tests/studio/test_freeze_report_verdicts.py
+++ b/tests/studio/test_freeze_report_verdicts.py
@@ -234,14 +234,16 @@ def test_control_is_not_pinned_by_an_override_the_candidates_never_name():
     """linux_webkit.rs returns PreserveEnvironment on an inherited
     WEBKIT_DISABLE_DMABUF_RENDERER or WEBKIT_DMABUF_RENDERER_FORCE_SHM, honours
     WEBKIT_FORCE_DMABUF_RENDERER as the NVIDIA patch's opt-out, and reads
-    UNSLOTH_WEBKIT_RENDERER_WORKAROUND as its own claim on values it set itself. None of
-    those four are in CANDIDATES, so a set derived from CANDIDATES leaves them active and
-    they pin every launch including the control."""
+    UNSLOTH_WEBKIT_RENDERER_WORKAROUND as its own claim on values it set itself, and takes
+    UNSLOTH_WEBKIT_DISABLE_COMPOSITING as an instruction either way. None of them are in
+    CANDIDATES, so a set derived from CANDIDATES leaves them active and they pin every
+    launch including the control."""
     base = {
         "WEBKIT_DISABLE_DMABUF_RENDERER": "1",
         "WEBKIT_DMABUF_RENDERER_FORCE_SHM": "1",
         "WEBKIT_FORCE_DMABUF_RENDERER": "1",
         "UNSLOTH_WEBKIT_RENDERER_WORKAROUND": "WEBKIT_DISABLE_DMABUF_RENDERER",
+        "UNSLOTH_WEBKIT_DISABLE_COMPOSITING": "1",
         "GDK_BACKEND": "x11",
         "PATH": "/usr/bin",
     }
@@ -263,6 +265,25 @@ def test_the_app_marker_is_recorded_so_a_stale_claim_is_visible():
     explain a launch that preserved the environment."""
     import inspect
     assert "UNSLOTH_WEBKIT_RENDERER_WORKAROUND" in inspect.getsource(freeze.exec_env)
+
+
+def test_every_setting_the_app_reads_is_one_the_reporter_clears():
+    """The list above is hand-maintained, so it goes stale the moment linux_webkit.rs learns
+    a new UNSLOTH_WEBKIT_* setting: an inherited value then pins all four launches including
+    the control, and the report reads clean without having compared anything. Read the names
+    back out of the Rust rather than restating them here, so adding one there fails here."""
+    import re
+
+    source = (REPO_ROOT / "studio" / "src-tauri" / "src" / "linux_webkit.rs").read_text(
+        encoding = "utf-8"
+    )
+    settings = set(re.findall(r'"(UNSLOTH_WEBKIT_[A-Z_]+)"', source))
+    assert settings, "no settings found; the pattern above stopped matching the Rust"
+    missing = sorted(settings - set(freeze.RENDERER_OVERRIDE_VARS))
+    assert missing == [], (
+        f"{missing} steer the app but survive candidate_env(), so an inherited value pins "
+        f"every launch including the control. Add them to RENDERER_OVERRIDE_VARS."
+    )
 
 
 def test_ports_cover_the_range_the_desktop_actually_uses():

--- a/tests/studio/test_freeze_report_verdicts.py
+++ b/tests/studio/test_freeze_report_verdicts.py
@@ -269,9 +269,9 @@ def test_the_app_marker_is_recorded_so_a_stale_claim_is_visible():
 
 def test_every_setting_the_app_reads_is_one_the_reporter_clears():
     """The list above is hand-maintained, so it goes stale the moment linux_webkit.rs learns
-    a new UNSLOTH_WEBKIT_* setting: an inherited value then pins all four launches including
-    the control, and the report reads clean without having compared anything. Read the names
-    back out of the Rust rather than restating them here, so adding one there fails here."""
+    a new UNSLOTH_WEBKIT_* setting: an inherited value pins every launch including the
+    control, and the report reads clean without having compared anything. Reading the names
+    back out of the Rust, rather than restating them, is what makes adding one fail here."""
     import re
 
     source = (REPO_ROOT / "studio" / "src-tauri" / "src" / "linux_webkit.rs").read_text(


### PR DESCRIPTION
## The bug

A user on Ubuntu 26.04 reported Unsloth Desktop freezing on Wayland while the backend stayed reachable from a phone on the same network. That detail turned out to matter: the backend is a separate process and was healthy throughout.

Measured on their machine with `studio/scripts/unsloth_freeze_report.py`, the WebKit web process stops executing about 45 seconds in and never resumes. It is not a paint stall. Every frontend timer stops at the same moment, and the only thing still reaching the backend afterwards is `/api/liveness` from the native watchdog, which runs in a different process.

```
candidate                            interface polls          watchdog   verdict
control                              flat at 21 from t=45      1 -> 16    FROZE
WEBKIT_DISABLE_COMPOSITING_MODE=1    7 -> 107, linear             16      OK
__NV_DISABLE_EXPLICIT_SYNC=1         flat at 16 from t=45      1 -> 16    FROZE
GDK_BACKEND=x11                      7 -> 106, linear             16      OK
```

They had already tried `WEBKIT_DMABUF_RENDERER_FORCE_SHM=1` and `WEBKIT_DISABLE_DMABUF_RENDERER=1` by hand, and both froze. So every buffer transport switch has now failed on that host, and the two things that work both remove accelerated compositing from the Wayland path. This is not a transport failure, which is why nothing already in `linux_webkit.rs` reaches it.

## Why it is not gated on Wayland plus NVIDIA

A second reporter ran the same script on Wayland, on the same driver `580.173.02` and the same WebKitGTK `2.52.3`, with two discrete NVIDIA cards. Control was clean at 126 polls. They do not freeze.

| | affected host | healthy host |
|---|---|---|
| session | wayland | wayland |
| driver | 580.173.02 | 580.173.02 |
| webkit2gtk | 2.52.3 | 2.52.3 |
| control | FROZE at 45s | OK, 126 polls |
| GPU vendors | Intel iGPU + NVIDIA dGPU | NVIDIA only |
| kernel module | open | proprietary |

Gating on Wayland plus NVIDIA would take accelerated compositing away from that second machine, which is measurably fine. So the rule requires two more things: mixed GPU vendors, and the open kernel module.

**This is overfitted on purpose.** With one host on each side, neither axis is established as the cause, and it may well be neither. The conservative reading is the one that leaves every machine measured so far exactly as it is today, and that is what requiring both does: the healthy host fails the rule on two independent counts.

## The setting

`UNSLOTH_WEBKIT_DISABLE_COMPOSITING=1` forces the workaround on, `0` forces it off.

It exists because the rule above will be wrong for someone. A user outside it who reports the same freeze can be given a one line answer that survives a restart, and a user inside it who does not need it can stand it down, neither of which requires shipping a new predicate for each configuration that turns up.

## What changed

- new `RenderingWorkaround::DisableCompositing`, applying `WEBKIT_DISABLE_COMPOSITING_MODE`. Not a transport: the existing variants choose how buffers reach the compositor, this stops WebKit compositing on the GPU at all
- `mixed_gpu_vendors_in()` reads PCI vendor ids from `/sys/class/drm/card*/device/vendor`
- `open_kernel_module_at()` reads the file the NVIDIA presence probe already opens
- `WEBKIT_DISABLE_COMPOSITING_MODE` set by the user is treated as an operator override, like the other two renderer variables

Both probes read sysfs and procfs only. No GL context, no device opened, so they are safe before GTK init, which is the same constraint that stops the existing NVIDIA probe from asking which GPU will actually render.

Cards with no readable `vendor` are skipped. A virtual framebuffer beside a real GPU would otherwise make every such host look hybrid, and that is not hypothetical: the box I tested on has exactly that `card0` beside eight NVIDIA cards. There is a test for it.

## Testing

`cargo test --bins --no-fail-fast` in `studio/src-tauri`: **473 passed, 0 failed**, including all 51 `linux_webkit` cases.

Eight new tests, named for what the two real hosts measured rather than for the branch they exercise:

- the freezing host gets compositing turned off
- the healthy NVIDIA Wayland host is left alone, and keeps the transport workaround it has today
- either axis alone is not enough
- X11 never takes the compositing workaround
- the setting settles a report without a new predicate, both directions
- an operator who set the variable keeps their environment
- a virtual framebuffer does not make a host look hybrid, and connector entries are not devices
- the open module marker is read correctly, including a missing file

Every pre-existing case is unchanged. The two new inputs default to `false` in the shared test helper, which models a single vendor host on the proprietary module, so the new rule cannot fire in any of them and those assertions still mean what they meant before.

## What this does not do

It does not explain the bug. The freeze is a WebKitGTK and NVIDIA interaction on the Wayland path, on current versions of both, and nothing in Unsloth is implicated beyond shipping a WebKitGTK app. This picks a rendering path that avoids it on the one configuration where it is measured.

`GDK_BACKEND=x11` also avoids the freeze but is deliberately not used or suggested: on the second reporter's machine it never opened a window, and on one attempt it took the whole Cinnamon session down.

Two follow-ups worth doing separately. A backtrace of the frozen web process would turn the compositor deadlock reading from inference into fact. And detecting the freeze at runtime, which the app is already equipped to do since it owns both poll loops, would let the workaround apply itself only where it is needed and make a predicate like this one unnecessary.
