### PR TITLE
studio: write the observed polls artifact as utf-8

### DIFF
--- a/tests/studio/playwright_declared_polls.py
+++ b/tests/studio/playwright_declared_polls.py
@@ -218,7 +218,8 @@ def main() -> int:
                 "undeclared": undeclared,
             },
             indent = 2,
-        )
+        ),
+        encoding = "utf-8",
     )
 
     info(


### PR DESCRIPTION
## What is failing

`tests/test_source_read_encoding.py` is red on `main`, and has been for its last two Backend CI runs:

```
AssertionError: 1 file reads in the test trees touch a checked-in file with the
platform default encoding, so they break on Windows as soon as that file gains a
non-ASCII byte. Pass encoding = "utf-8":
['tests/studio/playwright_declared_polls.py:210: write_text()']
```

Because it is on `main`, every branch cut from it fails the same check, which is how I ran into it.

## Cause

`#9665` (Studio: guard log volume in CI so it cannot regress unnoticed) added the `observed_polls.json` write without an encoding. It is the only offender in that file; `git log -S` puts it in that commit and nowhere else.

## The fix

Pass `encoding = "utf-8"`, which is what the guard asks for.

The guard is correct and worth keeping as is. That artifact holds route paths collected from the page, so it is exactly the kind of file that picks up a non-ASCII byte later and then breaks only on Windows, which is the failure mode the check exists to prevent. Nothing about `#9665` is wrong beyond the missing keyword.

## Testing

```
python3 -m pytest tests/test_source_read_encoding.py -q
1 passed
```

Failing beforehand is already demonstrated by the CI run linked above, on unmodified `main`.
