### PR TITLE
Studio: align sidebar list header actions, and mark downloaded models with a dot

### DIFF
--- a/studio/backend/tests/test_health_answers_within_probe_budget.py
+++ b/studio/backend/tests/test_health_answers_within_probe_budget.py
@@ -560,9 +560,9 @@ def test_a_cold_health_call_answers_inside_the_launcher_deadline():
     probe_timeout = _desktop_probe_timeout_s()
     result = _probe(_SLOW_DETECT_S)
 
-    assert result["cold_hardware_detecting"] is True, (
-        "the cold call got a settled reply, so it never exercised the wait this bound is about"
-    )
+    assert (
+        result["cold_hardware_detecting"] is True
+    ), "the cold call got a settled reply, so it never exercised the wait this bound is about"
     assert result["cold_elapsed"] < probe_timeout, (
         f"the first /api/health call took {result['cold_elapsed']:.2f}s, past the "
         f"{probe_timeout}s the desktop probe allows before it gives up and dead-ends "

--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -1915,10 +1915,13 @@ export function AppSidebar() {
 
   // Header actions end where a hovered row's "…" does: scrollRowPadding + the
   // action's own pr-1.5. 12px normally (the pr-3 class default), 11px here.
-  const headerRightPadding = usesDesktopTitlebar ? "pr-[11px]" : null;
+  const headerRightPadding = usesDesktopTitlebar
+    ? "sidebar-sticky-label-desktop"
+    : null;
   // Recents alone is nudged 2px right there, and carries its padding with it.
-  const recentsHeaderRightPadding = usesDesktopTitlebar ? "pr-[13px]" : null;
-
+  const recentsHeaderRightPadding = usesDesktopTitlebar
+    ? "sidebar-sticky-label-desktop-recents"
+    : null;
 
   // One definition per row, so pinned rows and the flyout can't drift apart.
   const navRows: Record<SidebarNavItemId, NavRowDef> = {

--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -1913,6 +1913,12 @@ export function AppSidebar() {
   // between a pill and the scrollbar, matched to the gap on the other side.
   const scrollRowPadding = usesDesktopTitlebar ? "px-[5px]" : "px-1.5";
 
+  // Header actions end where a hovered row's "…" does: scrollRowPadding + the
+  // action's own pr-1.5. 12px normally (the pr-3 class default), 11px here.
+  const headerRightPadding = usesDesktopTitlebar ? "pr-[11px]" : null;
+  // Recents alone is nudged 2px right there, and carries its padding with it.
+  const recentsHeaderRightPadding = usesDesktopTitlebar ? "pr-[13px]" : null;
+
 
   // One definition per row, so pinned rows and the flyout can't drift apart.
   const navRows: Record<SidebarNavItemId, NavRowDef> = {
@@ -3801,7 +3807,7 @@ export function AppSidebar() {
         {!isStudioRoute && !showTrainingRecents && pinnedChatItems.length > 0 && (
           <Collapsible open={pinnedOpen} onOpenChange={setPinnedOpen} asChild>
             <SidebarGroup className="group-data-[collapsible=icon]:hidden px-0 py-0">
-              <SidebarGroupLabel className={cn("sidebar-sticky-label sidebar-sticky-label-following group/sidebar-header gap-1", scrolled && "is-scrolled")}>
+              <SidebarGroupLabel className={cn("sidebar-sticky-label sidebar-sticky-label-following group/sidebar-header gap-1", headerRightPadding, scrolled && "is-scrolled")}>
                 <CollapsibleTrigger className="cursor-pointer flex min-w-0 flex-1 items-center gap-1 group/sb-collap">
                   Pinned
                   <ChevronDown className="size-3.5 opacity-0 transition-[transform,opacity] duration-200 group-hover/sb-collap:opacity-100 group-focus-visible/sb-collap:opacity-100 data-[state=open]:rotate-0 [[data-state=closed]_&]:rotate-[-90deg] [[data-state=closed]_&]:opacity-100" />
@@ -3850,7 +3856,7 @@ export function AppSidebar() {
             >
               <SidebarGroup className="group-data-[collapsible=icon]:hidden px-0 py-0">
                 {/* Trigger takes the free space; the actions reveal beside it. */}
-                <SidebarGroupLabel className={cn("sidebar-sticky-label sidebar-sticky-label-following group/sidebar-header gap-1", scrolled && "is-scrolled")}>
+                <SidebarGroupLabel className={cn("sidebar-sticky-label sidebar-sticky-label-following group/sidebar-header gap-1", headerRightPadding, scrolled && "is-scrolled")}>
                   <CollapsibleTrigger className="cursor-pointer flex min-w-0 flex-1 items-center gap-1 group/sb-collap">
                     {t("shell.navigation.projects")}
                     <ChevronDown className="size-3.5 opacity-0 transition-[transform,opacity] duration-200 group-hover/sb-collap:opacity-100 group-focus-visible/sb-collap:opacity-100 data-[state=open]:rotate-0 [[data-state=closed]_&]:rotate-[-90deg] [[data-state=closed]_&]:opacity-100" />
@@ -4089,6 +4095,7 @@ export function AppSidebar() {
               <SidebarGroupLabel
                 className={cn(
                   "sidebar-sticky-label sidebar-sticky-label-following group/sidebar-header gap-1",
+                  recentsHeaderRightPadding,
                   scrolled && "is-scrolled",
                   usesDesktopTitlebar && "translate-x-[2px]",
                 )}

--- a/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
@@ -766,12 +766,12 @@ const META_COLUMN = {
   // Fits "UD-Q4_K_XL"; a hard cap, so longer quants clip.
   quant: "min-[560px]:w-[7.2em]",
   // The badge slot holds capability glyphs (18px), the vision badge (24px) and the Hub lists'
-  // "on disk" mark (12px), gap-1 between them. Each width below is the widest set its scope can
+  // "on disk" mark (14px), gap-1 between them. Each width below is the widest set its scope can
   // draw, since anything wider makes min-w-min expand the slot and shift every column after it.
   // Scope draws no glyph: the vision badge alone, or the disk mark alone.
   badge: "min-w-min min-[560px]:w-[24px]",
-  // One glyph plus the disk mark (18 + 4 + 12).
-  badgeMid: "min-w-min min-[560px]:w-[34px]",
+  // One glyph plus the disk mark (18 + 4 + 14).
+  badgeMid: "min-w-min min-[560px]:w-[36px]",
   // Unscoped chat: a generation glyph and audio, plus whichever of vision (On Device rows) or the
   // disk mark (Hub rows) that list carries -- the two never appear on the same row (18+4+18+4+24).
   badgeWide: "min-w-min min-[560px]:w-[68px]",

--- a/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
@@ -80,7 +80,6 @@ import {
   AudioWave01Icon,
   Cancel01Icon,
   DashboardCircleIcon,
-  Download01Icon,
   Flag01Icon,
   FlimSlateIcon,
   Folder02Icon,
@@ -601,20 +600,27 @@ function FormatTag({ tone, label }: { tone: FormatTone; label: string }) {
   );
 }
 
-/** "Already on disk", shown on Hub rows that are also downloaded. */
+/** "Already on disk", shown on Hub rows that are also downloaded. The Hub's own
+ *  on-device dot: a download arrow read as "click to fetch" on the one row that
+ *  needs no fetching. Hit area and tooltip as FormatTag. */
 function DownloadedBadge() {
   return (
-    <span
-      title="Already downloaded"
-      aria-label="Already downloaded"
-      className="flex h-[18px] shrink-0 items-center justify-center text-status-success"
-    >
-      <HugeiconsIcon
-        icon={Download01Icon}
-        className="size-3"
-        strokeWidth={1.8}
-      />
-    </span>
+    <Tooltip delayDuration={0}>
+      <TooltipTrigger asChild={true}>
+        <span
+          aria-label="On device"
+          className="flex h-[18px] w-[14px] shrink-0 items-center justify-center"
+        >
+          <span
+            aria-hidden="true"
+            className="size-[5px] rounded-full bg-status-success"
+          />
+        </span>
+      </TooltipTrigger>
+      <TooltipContent side="top" className="tooltip-compact">
+        On device
+      </TooltipContent>
+    </Tooltip>
   );
 }
 

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -1196,8 +1196,11 @@ html[data-chat-font] .aui-root {
 		color: #fff;
 	}
 
+	/* pr-3, not pr-4: header actions end where a hovered row's "…" does (right-0
+	   + pr-1.5 inside a pill the list inset by px-1.5 = 12px). The desktop
+	   titlebar insets by 5px, so those headers override this in app-sidebar.tsx. */
 	.sidebar-sticky-label {
-		@apply rounded-none bg-sidebar pt-0 pb-[8px] pl-[16px] pr-4 text-ui-14! leading-ui-17 font-medium normal-case focus-visible:ring-0! focus-visible:outline-none transition-shadow duration-150;
+		@apply rounded-none bg-sidebar pt-0 pb-[8px] pl-[16px] pr-3 text-ui-14! leading-ui-17 font-medium normal-case focus-visible:ring-0! focus-visible:outline-none transition-shadow duration-150;
 		/* Muted section-header gray, matching Gemini's "Notebooks"/"Recents".
 		   Lightened from #5f6368 so the label reads as a header, clearly
 		   lighter than the near-black nav items. */

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -1207,6 +1207,15 @@ html[data-chat-font] .aui-root {
 		color: #80868b;
 		letter-spacing: 0;
 	}
+	/* These compound selectors must beat the base label's pr-3 declaration.
+	   Tailwind emits utility classes before this components block, so putting
+	   pr-[11px]/pr-[13px] on the element would lose the cascade. */
+	.sidebar-sticky-label.sidebar-sticky-label-desktop {
+		padding-right: 11px;
+	}
+	.sidebar-sticky-label.sidebar-sticky-label-desktop-recents {
+		padding-right: 13px;
+	}
 	.sidebar-sticky-label-following {
 		@apply pt-[21px];
 	}

--- a/studio/frontend/tests/on-device-dot-and-header-alignment.test.ts
+++ b/studio/frontend/tests/on-device-dot-and-header-alignment.test.ts
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+function read(path: string): string {
+  return readFileSync(fileURLToPath(new URL(path, import.meta.url)), "utf-8");
+}
+
+const PICKERS = read(
+  "../src/features/model-picker/components/model-selector/pickers.tsx",
+);
+const MODELS_TABLE = read("../src/features/hub/catalog/models-table.tsx");
+const SIDEBAR = read("../src/components/app-sidebar.tsx");
+const CSS = read("../src/index.css");
+
+test("a downloaded row is marked the way the Hub marks one", () => {
+  const start = PICKERS.indexOf("function DownloadedBadge()");
+  const badge = PICKERS.slice(start, PICKERS.indexOf("\n}", start));
+  // A download arrow read as "click to fetch this" on the one row that needs
+  // no fetching. The Hub already had the right answer.
+  assert.ok(!badge.includes("Download01Icon"), "no download glyph");
+  assert.match(badge, /size-\[5px\] rounded-full bg-status-success/);
+  assert.match(badge, /aria-label="On device"/);
+  assert.ok(
+    MODELS_TABLE.includes('bg-status-success'),
+    "and the Hub still uses that dot, so the two agree",
+  );
+});
+
+test("the download glyph is gone from the picker entirely", () => {
+  // Left behind, it would still be imported for nothing.
+  assert.ok(!PICKERS.includes("Download01Icon"));
+});
+
+test("every select-model surface shares that one badge", () => {
+  // Images, Video and Audio render the same ModelSelector, so there is no
+  // second copy of the badge to keep in step.
+  const copies = [
+    "../src/features/images/images-page.tsx",
+    "../src/features/video/video-page.tsx",
+    "../src/features/audio/audio-page.tsx",
+  ];
+  for (const path of copies) {
+    const src = read(path);
+    assert.ok(
+      src.includes("@/features/model-picker/components/model-selector"),
+      `${path} uses the shared selector`,
+    );
+    assert.ok(
+      !src.includes("DownloadedBadge"),
+      `${path} has no badge of its own`,
+    );
+  }
+});
+
+test("list header actions end where a hovered row's action does", () => {
+  // A row action is `right-0 pr-1.5` inside a pill the list inset by
+  // scrollRowPadding: 12px in normally, 11px under the desktop titlebar.
+  assert.match(CSS, /\.sidebar-row-action \{\n\t\t@apply absolute top-0 bottom-0 right-0[^;]*pr-1\.5/);
+  const label = CSS.slice(CSS.indexOf(".sidebar-sticky-label {"));
+  assert.match(label.slice(0, 400), /pl-\[16px\] pr-3 /);
+
+  assert.match(SIDEBAR, /const scrollRowPadding = usesDesktopTitlebar \? "px-\[5px\]" : "px-1\.5";/);
+  assert.match(SIDEBAR, /const headerRightPadding = usesDesktopTitlebar \? "pr-\[11px\]" : null;/);
+  // Recents is nudged 2px right there and carries its padding with it.
+  assert.match(SIDEBAR, /const recentsHeaderRightPadding = usesDesktopTitlebar \? "pr-\[13px\]" : null;/);
+});
+
+test("all three list headers take the same alignment", () => {
+  // Pinned and Projects share one class string; Recents has its own because of
+  // the translate. Two of the first, one of the second.
+  const shared = SIDEBAR.split(
+    '"sidebar-sticky-label sidebar-sticky-label-following group/sidebar-header gap-1", headerRightPadding,',
+  ).length - 1;
+  assert.equal(shared, 2, "Pinned and Projects");
+  assert.ok(
+    SIDEBAR.includes("recentsHeaderRightPadding,"),
+    "and Recents applies its own",
+  );
+});

--- a/studio/frontend/tests/on-device-dot-and-header-alignment.test.ts
+++ b/studio/frontend/tests/on-device-dot-and-header-alignment.test.ts
@@ -26,7 +26,7 @@ test("a downloaded row is marked the way the Hub marks one", () => {
   assert.match(badge, /size-\[5px\] rounded-full bg-status-success/);
   assert.match(badge, /aria-label="On device"/);
   assert.ok(
-    MODELS_TABLE.includes('bg-status-success'),
+    MODELS_TABLE.includes("bg-status-success"),
     "and the Hub still uses that dot, so the two agree",
   );
 });
@@ -34,6 +34,13 @@ test("a downloaded row is marked the way the Hub marks one", () => {
 test("the download glyph is gone from the picker entirely", () => {
   // Left behind, it would still be imported for nothing.
   assert.ok(!PICKERS.includes("Download01Icon"));
+});
+
+test("the scoped badge column reserves the wider on-device marker", () => {
+  // Video can show one 18px capability, a 4px gap and the 14px marker. If the
+  // fixed width remains 34px, min-w-min expands only those rows and shifts all
+  // metadata columns after the badge slot.
+  assert.ok(PICKERS.includes('badgeMid: "min-w-min min-[560px]:w-[36px]"'));
 });
 
 test("every select-model surface shares that one badge", () => {
@@ -60,22 +67,48 @@ test("every select-model surface shares that one badge", () => {
 test("list header actions end where a hovered row's action does", () => {
   // A row action is `right-0 pr-1.5` inside a pill the list inset by
   // scrollRowPadding: 12px in normally, 11px under the desktop titlebar.
-  assert.match(CSS, /\.sidebar-row-action \{\n\t\t@apply absolute top-0 bottom-0 right-0[^;]*pr-1\.5/);
+  assert.match(
+    CSS,
+    /\.sidebar-row-action \{\n\t\t@apply absolute top-0 bottom-0 right-0[^;]*pr-1\.5/,
+  );
   const label = CSS.slice(CSS.indexOf(".sidebar-sticky-label {"));
   assert.match(label.slice(0, 400), /pl-\[16px\] pr-3 /);
 
-  assert.match(SIDEBAR, /const scrollRowPadding = usesDesktopTitlebar \? "px-\[5px\]" : "px-1\.5";/);
-  assert.match(SIDEBAR, /const headerRightPadding = usesDesktopTitlebar \? "pr-\[11px\]" : null;/);
+  assert.ok(
+    CSS.includes(
+      ".sidebar-sticky-label.sidebar-sticky-label-desktop {\n\t\tpadding-right: 11px;",
+    ),
+  );
+  assert.ok(
+    CSS.includes(
+      ".sidebar-sticky-label.sidebar-sticky-label-desktop-recents {\n\t\tpadding-right: 13px;",
+    ),
+  );
+
+  assert.match(
+    SIDEBAR,
+    /const scrollRowPadding = usesDesktopTitlebar \? "px-\[5px\]" : "px-1\.5";/,
+  );
+  assert.ok(
+    SIDEBAR.includes(
+      'const headerRightPadding = usesDesktopTitlebar\n    ? "sidebar-sticky-label-desktop"\n    : null;',
+    ),
+  );
   // Recents is nudged 2px right there and carries its padding with it.
-  assert.match(SIDEBAR, /const recentsHeaderRightPadding = usesDesktopTitlebar \? "pr-\[13px\]" : null;/);
+  assert.ok(
+    SIDEBAR.includes(
+      'const recentsHeaderRightPadding = usesDesktopTitlebar\n    ? "sidebar-sticky-label-desktop-recents"\n    : null;',
+    ),
+  );
 });
 
 test("all three list headers take the same alignment", () => {
   // Pinned and Projects share one class string; Recents has its own because of
   // the translate. Two of the first, one of the second.
-  const shared = SIDEBAR.split(
-    '"sidebar-sticky-label sidebar-sticky-label-following group/sidebar-header gap-1", headerRightPadding,',
-  ).length - 1;
+  const shared =
+    SIDEBAR.split(
+      '"sidebar-sticky-label sidebar-sticky-label-following group/sidebar-header gap-1", headerRightPadding,',
+    ).length - 1;
   assert.equal(shared, 2, "Pinned and Projects");
   assert.ok(
     SIDEBAR.includes("recentsHeaderRightPadding,"),


### PR DESCRIPTION
Two small things in the shell that read wrong.

## Sidebar header actions did not line up with the rows below them

The "..." and new-chat actions on the Pinned, Projects and Recents headers sat 16px from the right edge. The "..." that appears when you hover a chat row sits at 12px: `.sidebar-row-action` is `right-0` with `pr-1.5`, inside a pill the list inset by `px-1.5`. So the two columns were 4px out of step, and the header actions floated left of everything under them.

`.sidebar-sticky-label` drops from `pr-4` to `pr-3`. Under the desktop titlebar the list insets rows to `px-[5px]` instead, and Recents alone carries a `translate-x-[2px]`, so those headers take `pr-[11px]` and `pr-[13px]` overrides derived next to `scrollRowPadding`. All three headers move together.

## A downloaded model was marked with a download arrow

In the model picker, a model already on disk got a green download arrow with an "Already downloaded" tooltip. A download glyph reads as "click to fetch this", which is the opposite of what the row means, and it was the only place in the app marking that state this way.

It now uses the same green `bg-status-success` dot the Hub already marks an on-device row with in `models-table.tsx` and `model-card.tsx`, keeping `FormatTag`'s hit area and tooltip so a 5px dot is not a pixel hunt. The label matches the Hub's wording too.

That badge is shared, so Chat, Images, Video and Audio all pick this up from the one `ModelSelector`. There were no per-page copies to keep in step. The download glyph on the **On Device** tab header stays as it is, since there it is a tab affordance rather than a row state.

## Testing

- New `on-device-dot-and-header-alignment.test.ts` pins both changes, including an assertion that Images, Video and Audio use the shared selector and carry no badge of their own.
- 5142 frontend tests pass, `tsc --noEmit` and `npm run build` clean.