### PR TITLE
Validate studio_install_id before baking it into the launcher

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -2137,13 +2137,11 @@ public static class UnslothStudioFinalPathV2
             if ((Test-Path -LiteralPath $_studioIdFile) -and `
                 ((Get-Item -LiteralPath $_studioIdFile).Length -gt 0)) {
                 $_studioRootId = ([System.IO.File]::ReadAllText($_studioIdFile)).Trim()
-                # Same contract as the backend (_STUDIO_INSTALL_ID_RE) and the
-                # desktop app: exactly 64 lowercase hex. -cnotmatch, because
-                # -notmatch is case-insensitive and would accept uppercase the
-                # backend rejects. Anything else is not an id -- no backend can
-                # report it, and it lands inside a single-quoted assignment in
-                # the generated launcher, so a pre-planted value with a quote
-                # would be launcher code. Regenerate instead of trusting it.
+                # Same contract as the backend and the desktop app: 64
+                # lowercase hex. -cnotmatch because -notmatch is case
+                # insensitive and would take uppercase the backend rejects.
+                # Anything else lands in a single-quoted assignment in the
+                # generated launcher, so a planted quote would be code.
                 if ($_studioRootId -cnotmatch '^[0-9a-f]{64}$') {
                     $_studioRootId = ""
                 }
@@ -2168,9 +2166,9 @@ public static class UnslothStudioFinalPathV2
                     if ($_adoptedRootId -cmatch '^[0-9a-f]{64}$') {
                         $_studioRootId = $_adoptedRootId
                     } else {
-                        # Zero-length or malformed incumbent is an interrupted
-                        # write or a pre-planted value, not an id. Replace it
-                        # with one atomic rename, no unlink.
+                        # Zero-length or malformed is an interrupted write
+                        # or a planted value, not an id: replace it with one
+                        # atomic rename, no unlink.
                         Move-Item -LiteralPath $_idTmp -Destination $_studioIdFile -Force
                     }
                 } finally {

--- a/install.ps1
+++ b/install.ps1
@@ -2137,6 +2137,16 @@ public static class UnslothStudioFinalPathV2
             if ((Test-Path -LiteralPath $_studioIdFile) -and `
                 ((Get-Item -LiteralPath $_studioIdFile).Length -gt 0)) {
                 $_studioRootId = ([System.IO.File]::ReadAllText($_studioIdFile)).Trim()
+                # Same contract as the backend (_STUDIO_INSTALL_ID_RE) and the
+                # desktop app: exactly 64 lowercase hex. -cnotmatch, because
+                # -notmatch is case-insensitive and would accept uppercase the
+                # backend rejects. Anything else is not an id -- no backend can
+                # report it, and it lands inside a single-quoted assignment in
+                # the generated launcher, so a pre-planted value with a quote
+                # would be launcher code. Regenerate instead of trusting it.
+                if ($_studioRootId -cnotmatch '^[0-9a-f]{64}$') {
+                    $_studioRootId = ""
+                }
             }
             if (-not $_studioRootId) {
                 $_idBytes = New-Object byte[] 32
@@ -2155,11 +2165,12 @@ public static class UnslothStudioFinalPathV2
                     try {
                         $_adoptedRootId = ([System.IO.File]::ReadAllText($_studioIdFile)).Trim()
                     } catch { }
-                    if ($_adoptedRootId) {
+                    if ($_adoptedRootId -cmatch '^[0-9a-f]{64}$') {
                         $_studioRootId = $_adoptedRootId
                     } else {
-                        # Zero-length incumbent is an interrupted write, not an
-                        # id. Replace it with one atomic rename, no unlink.
+                        # Zero-length or malformed incumbent is an interrupted
+                        # write or a pre-planted value, not an id. Replace it
+                        # with one atomic rename, no unlink.
                         Move-Item -LiteralPath $_idTmp -Destination $_studioIdFile -Force
                     }
                 } finally {

--- a/install.sh
+++ b/install.sh
@@ -1043,28 +1043,27 @@ _css_install_id_is_valid() {
     [ "${#1}" -eq 64 ]
 }
 
-# Echoes the id stored at $1 if it satisfies the contract, nothing otherwise.
-# Returns 1 when the path could not be READ at all, which is not the same
-# answer: a read that fails may still be sitting on a valid id.
+# Echoes the id at $1 when it satisfies the contract, nothing otherwise.
+# Returns 1 when the path could not be READ, a different answer: a failed read
+# may still be sitting on a valid id.
 _css_read_valid_install_id() {
     # Regular files only: a FIFO here (or a symlink to one, or to a device)
     # would park the installer on the open, waiting for a writer forever.
     [ -f "$1" ] || return 0
-    # A NUL cannot live in a shell variable, so command substitution drops it:
-    # <32 hex>\0<32 hex> would read back as a perfectly valid token while the
-    # backend, which keeps the byte, still reports "". Catch it before it
-    # disappears, by mapping NULs to a character a variable can hold.
+    # A NUL cannot live in a shell variable, so command substitution drops it
+    # and <32 hex>\0<32 hex> would read back valid while the backend, which
+    # keeps the byte, reports "". Catch it by mapping NULs to a real character.
     if [ -n "$({ tr -dc '\000' < "$1" | tr '\000' 'N'; } 2>/dev/null)" ]; then
         return 0
     fi
     # Group the redirect, or the shell's own "cannot open" escapes 2>/dev/null.
-    # A failed read is reported, never flattened into "no id": permissions, or
-    # a transient error on an NFS/FUSE-backed root, must not license a rewrite.
+    # A failed read is reported, never flattened into "no id": permissions or a
+    # transient NFS/FUSE fault must not license a rewrite.
     _cvi_id=$({ cat "$1"; } 2>/dev/null) || return 1
-    # Trim what the backend's .strip() trims, the SURROUNDING whitespace only.
+    # Trim what the backend's .strip() trims, SURROUNDING whitespace only.
     # Deleting interior whitespace would mint a 64-hex token out of bytes the
-    # backend reads as something else, leaving the launcher holding an id its
-    # own backend never reports.
+    # backend reads otherwise, leaving the launcher holding an id it never
+    # reports.
     _cvi_id=${_cvi_id#"${_cvi_id%%[![:space:]]*}"}
     _cvi_id=${_cvi_id%"${_cvi_id##*[![:space:]]}"}
     if _css_install_id_is_valid "$_cvi_id"; then

--- a/install.sh
+++ b/install.sh
@@ -1048,6 +1048,13 @@ _css_read_valid_install_id() {
     # Regular files only: a FIFO here (or a symlink to one, or to a device)
     # would park the installer on the open, waiting for a writer forever.
     [ -f "$1" ] || return 0
+    # A NUL cannot live in a shell variable, so command substitution drops it:
+    # <32 hex>\0<32 hex> would read back as a perfectly valid token while the
+    # backend, which keeps the byte, still reports "". Catch it before it
+    # disappears, by mapping NULs to a character a variable can hold.
+    if [ -n "$({ tr -dc '\000' < "$1" | tr '\000' 'N'; } 2>/dev/null)" ]; then
+        return 0
+    fi
     # Group the redirect, or the shell's own "cannot open" escapes 2>/dev/null.
     _cvi_id=$({ cat "$1"; } 2>/dev/null || true)
     # Trim what the backend's .strip() trims, the SURROUNDING whitespace only.

--- a/install.sh
+++ b/install.sh
@@ -1044,6 +1044,8 @@ _css_install_id_is_valid() {
 }
 
 # Echoes the id stored at $1 if it satisfies the contract, nothing otherwise.
+# Returns 1 when the path could not be READ at all, which is not the same
+# answer: a read that fails may still be sitting on a valid id.
 _css_read_valid_install_id() {
     # Regular files only: a FIFO here (or a symlink to one, or to a device)
     # would park the installer on the open, waiting for a writer forever.
@@ -1056,7 +1058,9 @@ _css_read_valid_install_id() {
         return 0
     fi
     # Group the redirect, or the shell's own "cannot open" escapes 2>/dev/null.
-    _cvi_id=$({ cat "$1"; } 2>/dev/null || true)
+    # A failed read is reported, never flattened into "no id": permissions, or
+    # a transient error on an NFS/FUSE-backed root, must not license a rewrite.
+    _cvi_id=$({ cat "$1"; } 2>/dev/null) || return 1
     # Trim what the backend's .strip() trims, the SURROUNDING whitespace only.
     # Deleting interior whitespace would mint a 64-hex token out of bytes the
     # backend reads as something else, leaving the launcher holding an id its
@@ -1112,12 +1116,10 @@ create_studio_shortcuts() {
     # Reuse an existing id only when it matches the contract above: a re-run
     # over a normal install is then a no-op, and a pre-populated custom root
     # cannot reach the launcher.
-    _css_studio_root_id=$(_css_read_valid_install_id "$_css_id_file")
     # Unreadable is not malformed: in a shared root the id can be a good one
     # owned by someone else and already reported by a running backend, so
     # regenerating would break that install. Refuse, as this did pre-validation.
-    if [ -z "$_css_studio_root_id" ] && [ -f "$_css_id_file" ] \
-        && [ ! -r "$_css_id_file" ]; then
+    if ! _css_studio_root_id=$(_css_read_valid_install_id "$_css_id_file"); then
         echo "[WARN] Cannot create launcher: cannot read $_css_id_file" >&2
         return 1
     fi
@@ -1146,8 +1148,8 @@ create_studio_shortcuts() {
                 # vanishes). Also covers filesystems without hard links
                 # (exFAT/FAT32). -d because renaming onto a directory moves
                 # the temp inside it instead of replacing it.
-                if [ -z "$(_css_read_valid_install_id "$_css_id_file")" ] \
-                    && [ ! -d "$_css_id_file" ]; then
+                if _css_incumbent=$(_css_read_valid_install_id "$_css_id_file") \
+                    && [ -z "$_css_incumbent" ] && [ ! -d "$_css_id_file" ]; then
                     mv "$_css_id_tmp" "$_css_id_file" 2>/dev/null || true
                 fi
             fi
@@ -1159,8 +1161,8 @@ create_studio_shortcuts() {
         # Bake what is on disk, not what we meant to write: that is what the
         # backend reports from /api/health, whoever won the race. An unwritable
         # or non-regular path leaves this empty and no launcher is generated.
-        _css_studio_root_id=$(_css_read_valid_install_id "$_css_id_file")
-        unset _css_new_id _css_id_tmp
+        _css_studio_root_id=$(_css_read_valid_install_id "$_css_id_file") || true
+        unset _css_new_id _css_id_tmp _css_incumbent
     fi
     if [ -z "$_css_studio_root_id" ]; then
         echo "[WARN] Cannot create launcher: failed to read $_css_id_file" >&2

--- a/install.sh
+++ b/install.sh
@@ -1036,9 +1036,8 @@ _smart_apt_install() {
 # app (is_valid_studio_root_id). Nothing else is an id: no backend reports it,
 # and the launcher holds it in a single-quoted assignment, so a planted value
 # with a quote in it would be launcher code.
-# Subshell bodies so LC_ALL=C is scoped to the check: the character classes
-# below must mean the same bytes whatever locale the installer inherits, and
-# the contract is pure ASCII.
+# Subshell bodies scope LC_ALL=C to the check: the classes below must mean the
+# same bytes in any inherited locale, and the contract is pure ASCII.
 _css_install_id_is_valid() (
     LC_ALL=C
     export LC_ALL
@@ -1057,10 +1056,9 @@ _css_read_valid_install_id() (
     # Regular files only: a FIFO here (or a symlink to one, or to a device)
     # would park the installer on the open, waiting for a writer forever.
     [ -f "$1" ] || return 0
-    # A zero-length file cannot be holding an id, and -s answers that from
-    # stat, without a read. So an empty file we also cannot read stays "no id"
-    # and is replaced, as it was before this validation existed, instead of
-    # failing the install. A real id is 64 bytes and never reaches this.
+    # -s answers "no id" from stat, without a read, so an empty file we also
+    # cannot read is replaced as it was pre-validation instead of failing the
+    # install. A real id is 64 bytes and never reaches this.
     [ -s "$1" ] || return 0
     # A NUL cannot live in a shell variable, so command substitution drops it
     # and <32 hex>\0<32 hex> would read back valid while the backend, which

--- a/install.sh
+++ b/install.sh
@@ -1036,17 +1036,24 @@ _smart_apt_install() {
 # app (is_valid_studio_root_id). Nothing else is an id: no backend reports it,
 # and the launcher holds it in a single-quoted assignment, so a planted value
 # with a quote in it would be launcher code.
-_css_install_id_is_valid() {
+# Subshell bodies so LC_ALL=C is scoped to the check: the character classes
+# below must mean the same bytes whatever locale the installer inherits, and
+# the contract is pure ASCII.
+_css_install_id_is_valid() (
+    LC_ALL=C
+    export LC_ALL
     case "${1:-}" in
         "" | *[!0123456789abcdef]*) return 1 ;;
     esac
     [ "${#1}" -eq 64 ]
-}
+)
 
 # Echoes the id at $1 when it satisfies the contract, nothing otherwise.
 # Returns 1 when the path could not be READ, a different answer: a failed read
 # may still be sitting on a valid id.
-_css_read_valid_install_id() {
+_css_read_valid_install_id() (
+    LC_ALL=C
+    export LC_ALL
     # Regular files only: a FIFO here (or a symlink to one, or to a device)
     # would park the installer on the open, waiting for a writer forever.
     [ -f "$1" ] || return 0
@@ -1074,8 +1081,7 @@ _css_read_valid_install_id() {
     if _css_install_id_is_valid "$_cvi_id"; then
         printf '%s' "$_cvi_id"
     fi
-    unset _cvi_id
-}
+)
 
 # ── Helper: create desktop shortcuts and launcher script ──
 # Usage: create_studio_shortcuts <unsloth_exe> <os>

--- a/install.sh
+++ b/install.sh
@@ -1031,6 +1031,31 @@ _smart_apt_install() {
     fi
 }
 
+# ── Helper: the studio_install_id contract ──
+# Exactly 64 lowercase hex characters, the same rule the backend applies in
+# studio/backend/main.py (_STUDIO_INSTALL_ID_RE) and the desktop app applies
+# in desktop_backend_owner.rs (is_valid_studio_root_id). Anything else is not
+# an id: no backend can ever report it, and since the launcher holds it in a
+# single-quoted shell assignment, a pre-planted value containing a quote would
+# become launcher code. Validate before reuse, regenerate anything else.
+_css_install_id_is_valid() {
+    case "${1:-}" in
+        "" | *[!0123456789abcdef]*) return 1 ;;
+    esac
+    [ "${#1}" -eq 64 ]
+}
+
+# Echoes the id stored at $1 if it satisfies the contract, nothing otherwise.
+_css_read_valid_install_id() {
+    # Group the redirect so an unreadable/absent file is silent: 2>/dev/null on
+    # `tr` alone would not cover the shell's own "cannot open" message.
+    _cvi_id=$({ tr -d ' \t\r\n' < "$1"; } 2>/dev/null || true)
+    if _css_install_id_is_valid "$_cvi_id"; then
+        printf '%s' "$_cvi_id"
+    fi
+    unset _cvi_id
+}
+
 # ── Helper: create desktop shortcuts and launcher script ──
 # Usage: create_studio_shortcuts <unsloth_exe> <os>
 # Creates ~/.local/share/unsloth/launch-studio.sh (shared launcher),
@@ -1071,14 +1096,18 @@ create_studio_shortcuts() {
     _css_id_dir="$STUDIO_HOME/share"
     mkdir -p "$_css_id_dir"
     _css_id_file="$_css_id_dir/studio_install_id"
-    if [ ! -s "$_css_id_file" ]; then
+    # An existing id is reused only when it matches the contract above, so a
+    # re-run over a normal install is a no-op and a pre-populated custom root
+    # cannot inject anything into the generated launcher.
+    _css_studio_root_id=$(_css_read_valid_install_id "$_css_id_file")
+    if [ -z "$_css_studio_root_id" ]; then
         if [ -r /dev/urandom ]; then
             _css_new_id=$(od -An -N32 -tx1 /dev/urandom 2>/dev/null | tr -d ' \n')
         fi
-        if [ -z "${_css_new_id:-}" ] && command -v python3 >/dev/null 2>&1; then
+        if ! _css_install_id_is_valid "${_css_new_id:-}" && command -v python3 >/dev/null 2>&1; then
             _css_new_id=$(python3 -c 'import secrets; print(secrets.token_hex(32))' 2>/dev/null)
         fi
-        if [ -z "${_css_new_id:-}" ]; then
+        if ! _css_install_id_is_valid "${_css_new_id:-}"; then
             echo "[WARN] Cannot create launcher: no entropy source for studio_install_id" >&2
             return 1
         fi
@@ -1089,19 +1118,24 @@ create_studio_shortcuts() {
         # $$ is the parent's pid inside a subshell in some shells.
         _css_id_tmp="$_css_id_file.$$.$(printf '%.8s' "$_css_new_id").tmp"
         if printf '%s' "$_css_new_id" > "$_css_id_tmp"; then
-            if ! ln "$_css_id_tmp" "$_css_id_file" 2>/dev/null; then
-                # A usable incumbent always wins. A zero-length file is an
-                # interrupted write, not an id, so replace it with one rename
-                # (no unlink, so the path never vanishes). This branch also
-                # covers filesystems without hard links (exFAT/FAT32).
-                [ -s "$_css_id_file" ] || mv "$_css_id_tmp" "$_css_id_file"
+            if ln "$_css_id_tmp" "$_css_id_file" 2>/dev/null; then
+                _css_studio_root_id="$_css_new_id"
+            else
+                # A usable incumbent always wins -- but only a valid one. A
+                # zero-length or malformed file is an interrupted write or a
+                # pre-planted value, so replace it with one rename (no unlink,
+                # so the path never vanishes). This branch also covers
+                # filesystems without hard links (exFAT/FAT32).
+                _css_studio_root_id=$(_css_read_valid_install_id "$_css_id_file")
+                if [ -z "$_css_studio_root_id" ] && mv "$_css_id_tmp" "$_css_id_file"; then
+                    _css_studio_root_id="$_css_new_id"
+                fi
             fi
         fi
         rm -f "$_css_id_tmp"
         chmod 600 "$_css_id_file" 2>/dev/null || true
         unset _css_new_id _css_id_tmp
     fi
-    _css_studio_root_id=$(cat "$_css_id_file" 2>/dev/null)
     if [ -z "$_css_studio_root_id" ]; then
         echo "[WARN] Cannot create launcher: failed to read $_css_id_file" >&2
         return 1

--- a/install.sh
+++ b/install.sh
@@ -1047,9 +1047,18 @@ _css_install_id_is_valid() {
 
 # Echoes the id stored at $1 if it satisfies the contract, nothing otherwise.
 _css_read_valid_install_id() {
-    # Group the redirect so an unreadable/absent file is silent: 2>/dev/null on
-    # `tr` alone would not cover the shell's own "cannot open" message.
-    _cvi_id=$({ tr -d ' \t\r\n' < "$1"; } 2>/dev/null || true)
+    # Regular files only. A FIFO (or a symlink to one, or to a device) at this
+    # path would park the installer on the open, waiting for a writer forever.
+    [ -f "$1" ] || return 0
+    # Group the redirect so an unreadable file is silent: 2>/dev/null on `cat`
+    # alone would not cover the shell's own "cannot open" message.
+    _cvi_id=$({ cat "$1"; } 2>/dev/null || true)
+    # Trim exactly what the backend's .strip() trims, the SURROUNDING
+    # whitespace. Deleting interior whitespace instead would mint a 64-hex
+    # token out of bytes the backend reads as something else, and the launcher
+    # would then hold an id its own backend never reports.
+    _cvi_id=${_cvi_id#"${_cvi_id%%[![:space:]]*}"}
+    _cvi_id=${_cvi_id%"${_cvi_id##*[![:space:]]}"}
     if _css_install_id_is_valid "$_cvi_id"; then
         printf '%s' "$_cvi_id"
     fi
@@ -1100,6 +1109,15 @@ create_studio_shortcuts() {
     # re-run over a normal install is a no-op and a pre-populated custom root
     # cannot inject anything into the generated launcher.
     _css_studio_root_id=$(_css_read_valid_install_id "$_css_id_file")
+    # An id we merely cannot READ is not a malformed id. It can be a perfectly
+    # good one owned by another user in a shared root, and a running backend
+    # may already be reporting it, so regenerating would break that install.
+    # Refuse instead, which is what this did before the id was validated.
+    if [ -z "$_css_studio_root_id" ] && [ -f "$_css_id_file" ] \
+        && [ ! -r "$_css_id_file" ]; then
+        echo "[WARN] Cannot create launcher: cannot read $_css_id_file" >&2
+        return 1
+    fi
     if [ -z "$_css_studio_root_id" ]; then
         if [ -r /dev/urandom ]; then
             _css_new_id=$(od -An -N32 -tx1 /dev/urandom 2>/dev/null | tr -d ' \n')

--- a/install.sh
+++ b/install.sh
@@ -1118,22 +1118,29 @@ create_studio_shortcuts() {
         # $$ is the parent's pid inside a subshell in some shells.
         _css_id_tmp="$_css_id_file.$$.$(printf '%.8s' "$_css_new_id").tmp"
         if printf '%s' "$_css_new_id" > "$_css_id_tmp"; then
-            if ln "$_css_id_tmp" "$_css_id_file" 2>/dev/null; then
-                _css_studio_root_id="$_css_new_id"
-            else
+            if ! ln "$_css_id_tmp" "$_css_id_file" 2>/dev/null; then
                 # A usable incumbent always wins -- but only a valid one. A
                 # zero-length or malformed file is an interrupted write or a
                 # pre-planted value, so replace it with one rename (no unlink,
                 # so the path never vanishes). This branch also covers
-                # filesystems without hard links (exFAT/FAT32).
-                _css_studio_root_id=$(_css_read_valid_install_id "$_css_id_file")
-                if [ -z "$_css_studio_root_id" ] && mv "$_css_id_tmp" "$_css_id_file"; then
-                    _css_studio_root_id="$_css_new_id"
+                # filesystems without hard links (exFAT/FAT32). The -d test is
+                # there because renaming onto a directory moves the temp file
+                # inside it instead of replacing it.
+                if [ -z "$(_css_read_valid_install_id "$_css_id_file")" ] \
+                    && [ ! -d "$_css_id_file" ]; then
+                    mv "$_css_id_tmp" "$_css_id_file" 2>/dev/null || true
                 fi
             fi
         fi
         rm -f "$_css_id_tmp"
-        chmod 600 "$_css_id_file" 2>/dev/null || true
+        if [ -f "$_css_id_file" ]; then
+            chmod 600 "$_css_id_file" 2>/dev/null || true
+        fi
+        # Bake what is on disk, not what we hoped to write: that is the byte
+        # string the backend will report from /api/health, whoever won the
+        # race. An unwritable or non-regular path leaves this empty and the
+        # launcher is not generated at all.
+        _css_studio_root_id=$(_css_read_valid_install_id "$_css_id_file")
         unset _css_new_id _css_id_tmp
     fi
     if [ -z "$_css_studio_root_id" ]; then

--- a/install.sh
+++ b/install.sh
@@ -1032,12 +1032,10 @@ _smart_apt_install() {
 }
 
 # ── Helper: the studio_install_id contract ──
-# Exactly 64 lowercase hex characters, the same rule the backend applies in
-# studio/backend/main.py (_STUDIO_INSTALL_ID_RE) and the desktop app applies
-# in desktop_backend_owner.rs (is_valid_studio_root_id). Anything else is not
-# an id: no backend can ever report it, and since the launcher holds it in a
-# single-quoted shell assignment, a pre-planted value containing a quote would
-# become launcher code. Validate before reuse, regenerate anything else.
+# 64 lowercase hex, as in the backend (_STUDIO_INSTALL_ID_RE) and the desktop
+# app (is_valid_studio_root_id). Nothing else is an id: no backend reports it,
+# and the launcher holds it in a single-quoted assignment, so a planted value
+# with a quote in it would be launcher code.
 _css_install_id_is_valid() {
     case "${1:-}" in
         "" | *[!0123456789abcdef]*) return 1 ;;
@@ -1047,16 +1045,15 @@ _css_install_id_is_valid() {
 
 # Echoes the id stored at $1 if it satisfies the contract, nothing otherwise.
 _css_read_valid_install_id() {
-    # Regular files only. A FIFO (or a symlink to one, or to a device) at this
-    # path would park the installer on the open, waiting for a writer forever.
+    # Regular files only: a FIFO here (or a symlink to one, or to a device)
+    # would park the installer on the open, waiting for a writer forever.
     [ -f "$1" ] || return 0
-    # Group the redirect so an unreadable file is silent: 2>/dev/null on `cat`
-    # alone would not cover the shell's own "cannot open" message.
+    # Group the redirect, or the shell's own "cannot open" escapes 2>/dev/null.
     _cvi_id=$({ cat "$1"; } 2>/dev/null || true)
-    # Trim exactly what the backend's .strip() trims, the SURROUNDING
-    # whitespace. Deleting interior whitespace instead would mint a 64-hex
-    # token out of bytes the backend reads as something else, and the launcher
-    # would then hold an id its own backend never reports.
+    # Trim what the backend's .strip() trims, the SURROUNDING whitespace only.
+    # Deleting interior whitespace would mint a 64-hex token out of bytes the
+    # backend reads as something else, leaving the launcher holding an id its
+    # own backend never reports.
     _cvi_id=${_cvi_id#"${_cvi_id%%[![:space:]]*}"}
     _cvi_id=${_cvi_id%"${_cvi_id##*[![:space:]]}"}
     if _css_install_id_is_valid "$_cvi_id"; then
@@ -1105,14 +1102,13 @@ create_studio_shortcuts() {
     _css_id_dir="$STUDIO_HOME/share"
     mkdir -p "$_css_id_dir"
     _css_id_file="$_css_id_dir/studio_install_id"
-    # An existing id is reused only when it matches the contract above, so a
-    # re-run over a normal install is a no-op and a pre-populated custom root
-    # cannot inject anything into the generated launcher.
+    # Reuse an existing id only when it matches the contract above: a re-run
+    # over a normal install is then a no-op, and a pre-populated custom root
+    # cannot reach the launcher.
     _css_studio_root_id=$(_css_read_valid_install_id "$_css_id_file")
-    # An id we merely cannot READ is not a malformed id. It can be a perfectly
-    # good one owned by another user in a shared root, and a running backend
-    # may already be reporting it, so regenerating would break that install.
-    # Refuse instead, which is what this did before the id was validated.
+    # Unreadable is not malformed: in a shared root the id can be a good one
+    # owned by someone else and already reported by a running backend, so
+    # regenerating would break that install. Refuse, as this did pre-validation.
     if [ -z "$_css_studio_root_id" ] && [ -f "$_css_id_file" ] \
         && [ ! -r "$_css_id_file" ]; then
         echo "[WARN] Cannot create launcher: cannot read $_css_id_file" >&2
@@ -1137,13 +1133,12 @@ create_studio_shortcuts() {
         _css_id_tmp="$_css_id_file.$$.$(printf '%.8s' "$_css_new_id").tmp"
         if printf '%s' "$_css_new_id" > "$_css_id_tmp"; then
             if ! ln "$_css_id_tmp" "$_css_id_file" 2>/dev/null; then
-                # A usable incumbent always wins -- but only a valid one. A
-                # zero-length or malformed file is an interrupted write or a
-                # pre-planted value, so replace it with one rename (no unlink,
-                # so the path never vanishes). This branch also covers
-                # filesystems without hard links (exFAT/FAT32). The -d test is
-                # there because renaming onto a directory moves the temp file
-                # inside it instead of replacing it.
+                # A usable incumbent wins, but only a valid one: zero-length
+                # or malformed is an interrupted write or a planted value, so
+                # replace it with one rename (no unlink, the path never
+                # vanishes). Also covers filesystems without hard links
+                # (exFAT/FAT32). -d because renaming onto a directory moves
+                # the temp inside it instead of replacing it.
                 if [ -z "$(_css_read_valid_install_id "$_css_id_file")" ] \
                     && [ ! -d "$_css_id_file" ]; then
                     mv "$_css_id_tmp" "$_css_id_file" 2>/dev/null || true
@@ -1154,10 +1149,9 @@ create_studio_shortcuts() {
         if [ -f "$_css_id_file" ]; then
             chmod 600 "$_css_id_file" 2>/dev/null || true
         fi
-        # Bake what is on disk, not what we hoped to write: that is the byte
-        # string the backend will report from /api/health, whoever won the
-        # race. An unwritable or non-regular path leaves this empty and the
-        # launcher is not generated at all.
+        # Bake what is on disk, not what we meant to write: that is what the
+        # backend reports from /api/health, whoever won the race. An unwritable
+        # or non-regular path leaves this empty and no launcher is generated.
         _css_studio_root_id=$(_css_read_valid_install_id "$_css_id_file")
         unset _css_new_id _css_id_tmp
     fi

--- a/install.sh
+++ b/install.sh
@@ -1050,6 +1050,11 @@ _css_read_valid_install_id() {
     # Regular files only: a FIFO here (or a symlink to one, or to a device)
     # would park the installer on the open, waiting for a writer forever.
     [ -f "$1" ] || return 0
+    # A zero-length file cannot be holding an id, and -s answers that from
+    # stat, without a read. So an empty file we also cannot read stays "no id"
+    # and is replaced, as it was before this validation existed, instead of
+    # failing the install. A real id is 64 bytes and never reaches this.
+    [ -s "$1" ] || return 0
     # A NUL cannot live in a shell variable, so command substitution drops it
     # and <32 hex>\0<32 hex> would read back valid while the backend, which
     # keeps the byte, reports "". Catch it by mapping NULs to a real character.

--- a/studio/backend/tests/test_health_answers_within_probe_budget.py
+++ b/studio/backend/tests/test_health_answers_within_probe_budget.py
@@ -560,9 +560,9 @@ def test_a_cold_health_call_answers_inside_the_launcher_deadline():
     probe_timeout = _desktop_probe_timeout_s()
     result = _probe(_SLOW_DETECT_S)
 
-    assert result["cold_hardware_detecting"] is True, (
-        "the cold call got a settled reply, so it never exercised the wait this bound is about"
-    )
+    assert (
+        result["cold_hardware_detecting"] is True
+    ), "the cold call got a settled reply, so it never exercised the wait this bound is about"
     assert result["cold_elapsed"] < probe_timeout, (
         f"the first /api/health call took {result['cold_elapsed']:.2f}s, past the "
         f"{probe_timeout}s the desktop probe allows before it gives up and dead-ends "

--- a/tests/test_studio_install_workspace_guard.py
+++ b/tests/test_studio_install_workspace_guard.py
@@ -942,8 +942,7 @@ def test_install_sh_replaces_an_empty_id_even_when_it_cannot_read_it(tmp_path):
     id_file.write_bytes(b"")
     id_file.chmod(0o000)
     probe = (
-        _install_id_helpers()
-        + f'if out=$(_css_read_valid_install_id "{id_file}"); then\n'
+        _install_id_helpers() + f'if out=$(_css_read_valid_install_id "{id_file}"); then\n'
         '    printf "READ_OK=[%s]\\n" "$out"\n'
         "else\n"
         '    printf "READ_FAILED\\n"\n'
@@ -954,9 +953,9 @@ def test_install_sh_replaces_an_empty_id_even_when_it_cannot_read_it(tmp_path):
     finally:
         id_file.chmod(0o600)
     assert res.returncode == 0, res.stderr
-    assert "READ_OK=[]" in res.stdout, (
-        f"an empty id must be regenerated, not refused; got {res.stdout!r}"
-    )
+    assert (
+        "READ_OK=[]" in res.stdout
+    ), f"an empty id must be regenerated, not refused; got {res.stdout!r}"
 
 
 @pytest.mark.skipif(

--- a/tests/test_studio_install_workspace_guard.py
+++ b/tests/test_studio_install_workspace_guard.py
@@ -837,9 +837,8 @@ def test_install_sh_trims_only_surrounding_whitespace_in_an_existing_id(tmp_path
 def test_install_sh_rejects_an_id_holding_a_nul_byte(tmp_path):
     """A NUL must be caught before the shell silently drops it.
 
-    Command substitution cannot carry a NUL, so `<32 hex>\\0<32 hex>` reads back
-    as a valid token, while the backend keeps the byte and reports "". The
-    launcher would then hold an id its own backend never reports.
+    Command substitution cannot carry one, so `<32 hex>\\0<32 hex>` reads back
+    valid while the backend keeps the byte and reports "".
     """
     src = INSTALL_SH.read_text(encoding = "utf-8")
     assert (
@@ -869,9 +868,9 @@ def test_install_sh_rejects_an_id_holding_a_nul_byte(tmp_path):
 def test_install_sh_reports_a_failed_read_instead_of_regenerating(tmp_path):
     """A read that FAILS is not the same answer as a malformed id.
 
-    `-r` can pass while the read itself errors (a transient fault on an
-    NFS/FUSE-backed root). Flattening that into "no id" let the publish path
-    replace a valid incumbent that a running backend still reports.
+    `-r` can pass while the read errors, on an NFS or FUSE backed root.
+    Flattening that into "no id" let the publish path replace a valid
+    incumbent a running backend still reports.
     """
     src = INSTALL_SH.read_text(encoding = "utf-8")
     assert (

--- a/tests/test_studio_install_workspace_guard.py
+++ b/tests/test_studio_install_workspace_guard.py
@@ -907,6 +907,41 @@ def test_install_sh_reports_a_failed_read_instead_of_regenerating(tmp_path):
     os.name != "posix" or os.geteuid() == 0,
     reason = "needs POSIX mode bits, and root reads regardless of them",
 )
+def test_install_sh_replaces_an_empty_id_even_when_it_cannot_read_it(tmp_path):
+    """Zero length is an answer stat can give: that file holds no id.
+
+    Refusing here would fail an install that succeeded before the id was
+    validated at all, since a zero-length file was simply replaced. The
+    protection is for ids we cannot read, and an id is 64 bytes, never zero.
+    """
+    src = INSTALL_SH.read_text(encoding = "utf-8")
+    assert '[ -s "$1" ] || return 0' in src, "an empty id file must read as no id"
+
+    id_file = tmp_path / "studio_install_id"
+    id_file.write_bytes(b"")
+    id_file.chmod(0o000)
+    probe = (
+        _install_id_helpers()
+        + f'if out=$(_css_read_valid_install_id "{id_file}"); then\n'
+        '    printf "READ_OK=[%s]\\n" "$out"\n'
+        "else\n"
+        '    printf "READ_FAILED\\n"\n'
+        "fi\n"
+    )
+    try:
+        res = subprocess.run(["sh", "-c", probe], text = True, capture_output = True)
+    finally:
+        id_file.chmod(0o600)
+    assert res.returncode == 0, res.stderr
+    assert "READ_OK=[]" in res.stdout, (
+        f"an empty id must be regenerated, not refused; got {res.stdout!r}"
+    )
+
+
+@pytest.mark.skipif(
+    os.name != "posix" or os.geteuid() == 0,
+    reason = "needs POSIX mode bits, and root reads regardless of them",
+)
 def test_install_sh_refuses_an_unreadable_existing_id(tmp_path):
     """An id we cannot READ must not be treated as malformed and replaced.
 

--- a/tests/test_studio_install_workspace_guard.py
+++ b/tests/test_studio_install_workspace_guard.py
@@ -832,6 +832,34 @@ def test_install_sh_trims_only_surrounding_whitespace_in_an_existing_id(tmp_path
             assert got == "a" * 64, f"surrounding whitespace must be trimmed, got {got!r}"
 
 
+def test_install_sh_rejects_an_id_holding_a_nul_byte(tmp_path):
+    """A NUL must be caught before the shell silently drops it.
+
+    Command substitution cannot carry a NUL, so `<32 hex>\\0<32 hex>` reads back
+    as a valid token, while the backend keeps the byte and reports "". The
+    launcher would then hold an id its own backend never reports.
+    """
+    src = INSTALL_SH.read_text(encoding = "utf-8")
+    assert (
+        """tr -dc '\\000' < "$1" | tr '\\000' 'N'""" in src
+    ), "install.sh must detect NUL bytes before reading the id into a variable"
+
+    id_file = tmp_path / "studio_install_id"
+    probe = _install_id_helpers() + f'printf "OUT=[%s]\\n" "$(_css_read_valid_install_id "{id_file}")"\n'
+    for content in [
+        b"a" * 32 + b"\x00" + b"a" * 32,
+        b"b" * 64 + b"\x00",
+        b"\x00" + b"c" * 64,
+    ]:
+        id_file.write_bytes(content)
+        res = subprocess.run(["sh", "-c", probe], text = True, capture_output = True)
+        assert res.returncode == 0, res.stderr
+        assert "OUT=[]" in res.stdout, f"{content!r} must not read as an id, got {res.stdout!r}"
+    id_file.write_bytes(b"d" * 64)
+    res = subprocess.run(["sh", "-c", probe], text = True, capture_output = True)
+    assert "OUT=[" + "d" * 64 + "]" in res.stdout, "a clean id must still be reused"
+
+
 @pytest.mark.skipif(os.geteuid() == 0, reason = "root reads regardless of mode bits")
 def test_install_sh_refuses_an_unreadable_existing_id(tmp_path):
     """An id we cannot READ must not be treated as malformed and replaced.

--- a/tests/test_studio_install_workspace_guard.py
+++ b/tests/test_studio_install_workspace_guard.py
@@ -20,9 +20,30 @@ def _install_id_helpers() -> str:
     """The shipped _css_install_id_is_valid / _css_read_valid_install_id bodies,
     sliced out of install.sh so the shell tests below run the real validator."""
     src = INSTALL_SH.read_text(encoding = "utf-8")
-    start = src.index("_css_install_id_is_valid() {")
+    start = src.index("_css_install_id_is_valid() ")
     end = src.index("# ── Helper: create desktop shortcuts", start)
     return src[start:end]
+
+
+def _extract_create_studio_shortcuts() -> str:
+    """The shipped helpers plus the whole create_studio_shortcuts body.
+
+    The function contains heredocs with their own `}` at column 0, so the real
+    end is found by asking `sh -n` which candidate close brace parses.
+    """
+    src = INSTALL_SH.read_text(encoding = "utf-8")
+    lines = src.splitlines()
+    start = next(i for i, l in enumerate(lines) if l.startswith("_css_install_id_is_valid() "))
+    fn = next(i for i, l in enumerate(lines) if l.startswith("create_studio_shortcuts() {"))
+    eof = next(i for i, l in enumerate(lines) if i > fn and l == "LAUNCHER_EOF")
+    for i, line in enumerate(lines):
+        if i <= eof or line != "}":
+            continue
+        candidate = "\n".join(lines[start : i + 1]) + "\n"
+        if subprocess.run(["sh", "-n"], input = candidate, text = True,
+                          capture_output = True).returncode == 0:
+            return candidate
+    raise AssertionError("could not slice create_studio_shortcuts from install.sh")
 
 
 # Stub the rollback helper with a move. The directory predicate is extracted
@@ -1000,6 +1021,58 @@ def test_install_sh_never_reads_a_non_regular_id_path(tmp_path):
     assert res.returncode == 0, res.stderr
     assert "OUT=[]" in res.stdout, f"a FIFO must read as no id, got {res.stdout!r}"
 
+
+
+@pytest.mark.skipif(os.name != "posix", reason = "runs the POSIX installer function")
+def test_create_studio_shortcuts_end_to_end_never_embeds_a_planted_id(tmp_path):
+    """The REAL create_studio_shortcuts, not a reconstruction of it.
+
+    The helper-level tests above cannot catch a caller that validates and then
+    embeds something else, so this runs the shipped function over a planted id
+    and inspects the launcher it actually writes.
+    """
+    home = tmp_path / "home"
+    studio_home = tmp_path / "studio"
+    data_dir = tmp_path / "data"
+    for d in (home, studio_home / "share", data_dir, tmp_path / "bin"):
+        d.mkdir(parents = True)
+    marker = tmp_path / "PWNED"
+    (studio_home / "share" / "studio_install_id").write_text(
+        f"x'; touch {marker}; exit 0 #", encoding = "utf-8")
+    exe = tmp_path / "bin" / "unsloth"
+    exe.write_text("#!/bin/sh\nexit 0\n", encoding = "utf-8")
+    exe.chmod(0o755)
+
+    script = (
+        "set -e\n"
+        "download() { : ; }\n"
+        "substep() { : ; }\n"
+        '_LOCK_KEY="testkey"\n'
+        f'STUDIO_HOME="{studio_home}"\nDATA_DIR="{data_dir}"\n'
+        "_STUDIO_HOME_REDIRECT=default\n"
+        + _extract_create_studio_shortcuts()
+        + f'\ncreate_studio_shortcuts "{exe}" "linux"\n'
+    )
+    res = subprocess.run(
+        ["sh", "-c", script], text = True, capture_output = True, timeout = 300,
+        env = dict(os.environ, HOME = str(home)), cwd = str(tmp_path),
+    )
+    assert res.returncode == 0, f"installer step failed: {res.stderr[-400:]}"
+
+    launcher = data_dir / "launch-studio.sh"
+    assert launcher.is_file(), "no launcher was written"
+    m = re.search(r"^_EXPECTED_STUDIO_ROOT_ID='(.*)'$", launcher.read_text(), re.M)
+    assert m, "launcher has no id assignment"
+    baked = m.group(1)
+    assert re.fullmatch(r"[0-9a-f]{64}", baked), f"planted id reached the launcher: {baked!r}"
+
+    # The launcher must agree with what the backend would report from the file.
+    on_disk = (studio_home / "share" / "studio_install_id").read_text().strip()
+    assert baked == on_disk, "the launcher and the id file disagree"
+    assert subprocess.run(["bash", "-n", str(launcher)]).returncode == 0
+
+    subprocess.run(["sh", "-c", f". {launcher}"], capture_output = True, timeout = 60)
+    assert not marker.exists(), "the planted id executed as launcher code"
 
 def test_install_sh_never_bakes_a_planted_id_into_the_launcher(tmp_path):
     """A pre-planted studio_install_id must be regenerated, not embedded.

--- a/tests/test_studio_install_workspace_guard.py
+++ b/tests/test_studio_install_workspace_guard.py
@@ -630,7 +630,7 @@ def test_install_sh_create_shortcuts_seeds_id_from_csprng_with_python_fallback(t
     """_create_shortcuts seeds ids from /dev/urandom (python3 secrets fallback) and is re-run idempotent."""
     src = INSTALL_SH.read_text(encoding = "utf-8")
     fn_start = src.index('_css_data_dir="$DATA_DIR"')
-    block = src[fn_start : fn_start + 3000]
+    block = src[fn_start : fn_start + 4200]
     urandom_idx = block.index("od -An -N32 -tx1 /dev/urandom")
     py_fallback_idx = block.index("python3 -c 'import secrets;", urandom_idx)
     assert (
@@ -681,7 +681,7 @@ def test_install_sh_publishes_the_id_without_clobbering():
     """install.sh must publish the id no-clobber, so it cannot replace one the desktop app minted."""
     src = INSTALL_SH.read_text(encoding = "utf-8")
     fn_start = src.index('_css_id_dir="$STUDIO_HOME/share"')
-    block = src[fn_start : fn_start + 3000]
+    block = src[fn_start : fn_start + 4200]
     assert (
         'ln "$_css_id_tmp" "$_css_id_file"' in block
     ), "install.sh must publish the id with ln (EEXIST on a race), not a clobbering mv"
@@ -710,7 +710,7 @@ def test_install_sh_bakes_the_id_that_is_actually_on_disk(tmp_path):
     """
     src = INSTALL_SH.read_text(encoding = "utf-8")
     fn_start = src.index('_css_id_dir="$STUDIO_HOME/share"')
-    block = src[fn_start : fn_start + 3000]
+    block = src[fn_start : fn_start + 4200]
     read_back = '_css_studio_root_id=$(_css_read_valid_install_id "$_css_id_file")'
     assert block.count(read_back) >= 2, "the id must be re-read after publication"
     assert block.rindex(read_back) > block.index(
@@ -796,6 +796,101 @@ def test_install_sh_id_publish_replaces_a_blank_incumbent(tmp_path):
     res = subprocess.run(["sh", "-c", publish], text = True, capture_output = True)
     assert res.returncode == 0, res.stderr
     assert res.stdout.strip() == fresh, "a blank id must be replaced, not adopted"
+
+
+def test_install_sh_trims_only_surrounding_whitespace_in_an_existing_id(tmp_path):
+    """Interior whitespace must fail the check, not be deleted into a valid id.
+
+    The backend applies `.strip()` and then an exact regex, so `<32 hex>\\n<32
+    hex>` is NOT an id to it. Deleting the newline instead would mint a 64-hex
+    token the installer bakes into the launcher while the backend keeps
+    reporting "", and the launcher would reject its own backend forever.
+    """
+    src = INSTALL_SH.read_text(encoding = "utf-8")
+    assert (
+        "tr -d ' \\t\\r\\n'" not in src
+    ), "install.sh must not delete interior whitespace from the id"
+    assert (
+        '_cvi_id=${_cvi_id#"${_cvi_id%%[![:space:]]*}"}' in src
+        and '_cvi_id=${_cvi_id%"${_cvi_id##*[![:space:]]}"}' in src
+    ), "install.sh must trim only the surrounding whitespace, as the backend does"
+
+    id_file = tmp_path / "studio_install_id"
+    probe = _install_id_helpers() + f'printf "OUT=[%s]\\n" "$(_css_read_valid_install_id "{id_file}")"\n'
+    for content, expect_reuse in [
+        ("a" * 32 + "\n" + "a" * 32, False),
+        ("a" * 32 + " " + "a" * 32, False),
+        ("  " + "a" * 64 + "  \n", True),
+        ("\n\n" + "a" * 64 + "\n\n", True),
+        ("\t" + "a" * 64 + "\r\n", True),
+    ]:
+        id_file.write_text(content, encoding = "utf-8")
+        res = subprocess.run(["sh", "-c", probe], text = True, capture_output = True)
+        assert res.returncode == 0, res.stderr
+        got = res.stdout.strip()[len("OUT=[") : -1]
+        assert bool(got) is expect_reuse, f"{content!r} -> {got!r}"
+        if expect_reuse:
+            assert got == "a" * 64, f"surrounding whitespace must be trimmed, got {got!r}"
+
+
+@pytest.mark.skipif(os.geteuid() == 0, reason = "root reads regardless of mode bits")
+def test_install_sh_refuses_an_unreadable_existing_id(tmp_path):
+    """An id we cannot READ must not be treated as malformed and replaced.
+
+    In a shared root the file can be a perfectly good id owned by another user
+    (this installer chmod 600s it), and a running backend may already report
+    it. Regenerating would break that install, so the shortcut step refuses,
+    which is what it did before the id was validated at all.
+    """
+    src = INSTALL_SH.read_text(encoding = "utf-8")
+    fn_start = src.index('_css_id_dir="$STUDIO_HOME/share"')
+    block = src[fn_start : fn_start + 4200]
+    assert (
+        '[ -f "$_css_id_file" ] \\\n        && [ ! -r "$_css_id_file" ]' in block
+    ), "install.sh must separate an unreadable id from a malformed one"
+    assert (
+        "[WARN] Cannot create launcher: cannot read" in block
+    ), "the unreadable-id branch must warn"
+
+    studio_home = tmp_path / "studio"
+    (studio_home / "share").mkdir(parents = True)
+    id_file = studio_home / "share" / "studio_install_id"
+    id_file.write_text("b" * 64, encoding = "utf-8")
+    id_file.chmod(0o000)
+    try:
+        probe = (
+            _install_id_helpers()
+            + f'_css_id_file="{id_file}"\n'
+            '_css_studio_root_id=$(_css_read_valid_install_id "$_css_id_file")\n'
+            'if [ -z "$_css_studio_root_id" ] && [ -f "$_css_id_file" ] \\\n'
+            '    && [ ! -r "$_css_id_file" ]; then echo REFUSED; exit 0; fi\n'
+            'echo "REUSED=$_css_studio_root_id"\n'
+        )
+        res = subprocess.run(["sh", "-c", probe], text = True, capture_output = True)
+        assert res.returncode == 0, res.stderr
+        assert "REFUSED" in res.stdout, f"expected a refusal, got {res.stdout!r}"
+    finally:
+        id_file.chmod(0o600)
+    assert id_file.read_text() == "b" * 64, "the unreadable id must survive untouched"
+
+
+def test_install_sh_never_reads_a_non_regular_id_path(tmp_path):
+    """A FIFO at the id path must not park the installer on the open.
+
+    `cat` on a FIFO blocks until a writer appears, so an unconditional read of
+    a shared/custom root would hang the install forever.
+    """
+    src = INSTALL_SH.read_text(encoding = "utf-8")
+    assert (
+        '[ -f "$1" ] || return 0' in src
+    ), "install.sh must read the id only from a regular file"
+
+    id_file = tmp_path / "studio_install_id"
+    os.mkfifo(id_file)
+    probe = _install_id_helpers() + f'printf "OUT=[%s]\\n" "$(_css_read_valid_install_id "{id_file}")"\n'
+    res = subprocess.run(["sh", "-c", probe], text = True, capture_output = True, timeout = 20)
+    assert res.returncode == 0, res.stderr
+    assert "OUT=[]" in res.stdout, f"a FIFO must read as no id, got {res.stdout!r}"
 
 
 def test_install_sh_never_bakes_a_planted_id_into_the_launcher(tmp_path):
@@ -893,7 +988,7 @@ def test_install_sh_create_shortcuts_fails_fast_when_no_entropy():
     """With no entropy source, _create_shortcuts must `return 1` not bake an empty studio_root_id."""
     src = INSTALL_SH.read_text(encoding = "utf-8")
     fn_start = src.index('_css_data_dir="$DATA_DIR"')
-    block = src[fn_start : fn_start + 4200]
+    block = src[fn_start : fn_start + 5200]
     assert (
         "[WARN] Cannot create launcher: no entropy source for studio_install_id" in block
     ), "install.sh must warn when neither urandom nor python3 is available"

--- a/tests/test_studio_install_workspace_guard.py
+++ b/tests/test_studio_install_workspace_guard.py
@@ -860,7 +860,10 @@ def test_install_sh_rejects_an_id_holding_a_nul_byte(tmp_path):
     assert "OUT=[" + "d" * 64 + "]" in res.stdout, "a clean id must still be reused"
 
 
-@pytest.mark.skipif(os.geteuid() == 0, reason = "root reads regardless of mode bits")
+@pytest.mark.skipif(
+    os.name != "posix" or os.geteuid() == 0,
+    reason = "needs POSIX mode bits, and root reads regardless of them",
+)
 def test_install_sh_refuses_an_unreadable_existing_id(tmp_path):
     """An id we cannot READ must not be treated as malformed and replaced.
 
@@ -900,6 +903,7 @@ def test_install_sh_refuses_an_unreadable_existing_id(tmp_path):
     assert id_file.read_text() == "b" * 64, "the unreadable id must survive untouched"
 
 
+@pytest.mark.skipif(not hasattr(os, "mkfifo"), reason = "no FIFOs on this platform")
 def test_install_sh_never_reads_a_non_regular_id_path(tmp_path):
     """A FIFO at the id path must not park the installer on the open.
 

--- a/tests/test_studio_install_workspace_guard.py
+++ b/tests/test_studio_install_workspace_guard.py
@@ -40,8 +40,10 @@ def _extract_create_studio_shortcuts() -> str:
         if i <= eof or line != "}":
             continue
         candidate = "\n".join(lines[start : i + 1]) + "\n"
-        if subprocess.run(["sh", "-n"], input = candidate, text = True,
-                          capture_output = True).returncode == 0:
+        if (
+            subprocess.run(["sh", "-n"], input = candidate, text = True, capture_output = True).returncode
+            == 0
+        ):
             return candidate
     raise AssertionError("could not slice create_studio_shortcuts from install.sh")
 
@@ -1021,7 +1023,6 @@ def test_install_sh_never_reads_a_non_regular_id_path(tmp_path):
     assert "OUT=[]" in res.stdout, f"a FIFO must read as no id, got {res.stdout!r}"
 
 
-
 @pytest.mark.skipif(os.name != "posix", reason = "runs the POSIX installer function")
 def test_create_studio_shortcuts_end_to_end_never_embeds_a_planted_id(tmp_path):
     """The REAL create_studio_shortcuts, not a reconstruction of it.
@@ -1037,7 +1038,8 @@ def test_create_studio_shortcuts_end_to_end_never_embeds_a_planted_id(tmp_path):
         d.mkdir(parents = True)
     marker = tmp_path / "PWNED"
     (studio_home / "share" / "studio_install_id").write_text(
-        f"x'; touch {marker}; exit 0 #", encoding = "utf-8")
+        f"x'; touch {marker}; exit 0 #", encoding = "utf-8"
+    )
     exe = tmp_path / "bin" / "unsloth"
     exe.write_text("#!/bin/sh\nexit 0\n", encoding = "utf-8")
     exe.chmod(0o755)
@@ -1053,8 +1055,12 @@ def test_create_studio_shortcuts_end_to_end_never_embeds_a_planted_id(tmp_path):
         + f'\ncreate_studio_shortcuts "{exe}" "linux"\n'
     )
     res = subprocess.run(
-        ["sh", "-c", script], text = True, capture_output = True, timeout = 300,
-        env = dict(os.environ, HOME = str(home)), cwd = str(tmp_path),
+        ["sh", "-c", script],
+        text = True,
+        capture_output = True,
+        timeout = 300,
+        env = dict(os.environ, HOME = str(home)),
+        cwd = str(tmp_path),
     )
     assert res.returncode == 0, f"installer step failed: {res.stderr[-400:]}"
 
@@ -1072,6 +1078,7 @@ def test_create_studio_shortcuts_end_to_end_never_embeds_a_planted_id(tmp_path):
 
     subprocess.run(["sh", "-c", f". {launcher}"], capture_output = True, timeout = 60)
     assert not marker.exists(), "the planted id executed as launcher code"
+
 
 def test_install_sh_never_bakes_a_planted_id_into_the_launcher(tmp_path):
     """A pre-planted studio_install_id must be regenerated, not embedded.

--- a/tests/test_studio_install_workspace_guard.py
+++ b/tests/test_studio_install_workspace_guard.py
@@ -15,6 +15,16 @@ INSTALL_PS1 = REPO_ROOT / "install.ps1"
 SETUP_PS1 = REPO_ROOT / "studio" / "setup.ps1"
 SETUP_SH = REPO_ROOT / "studio" / "setup.sh"
 
+
+def _install_id_helpers() -> str:
+    """The shipped _css_install_id_is_valid / _css_read_valid_install_id bodies,
+    sliced out of install.sh so the shell tests below run the real validator."""
+    src = INSTALL_SH.read_text(encoding = "utf-8")
+    start = src.index("_css_install_id_is_valid() {")
+    end = src.index("# ── Helper: create desktop shortcuts", start)
+    return src[start:end]
+
+
 # Stub the rollback helper with a move. The directory predicate is extracted
 # from install.sh because it controls whether the guard runs.
 _INSTALL_GUARD_STUBS = (
@@ -626,29 +636,33 @@ def test_install_sh_create_shortcuts_seeds_id_from_csprng_with_python_fallback(t
     assert (
         urandom_idx < py_fallback_idx
     ), "/dev/urandom must be tried before the python3 secrets fallback"
-    # Non-empty id file check before generation is what makes re-runs idempotent.
+    # Reusing an existing id only when it is valid is what makes re-runs
+    # idempotent -- and keeps a pre-planted value out of the launcher.
     assert (
-        'if [ ! -s "$_css_id_file" ]; then' in block
-    ), "install.sh must skip id generation when the file already has content"
+        '_css_studio_root_id=$(_css_read_valid_install_id "$_css_id_file")' in block
+    ), "install.sh must reuse an existing id only after validating it"
 
     # Behavioral check: run the generation block twice to confirm idempotence.
     studio_home = tmp_path / "studio"
     (studio_home / "share").mkdir(parents = True)
     gen_script = (
-        f'STUDIO_HOME="{studio_home}"\n'
+        _install_id_helpers()
+        + f'STUDIO_HOME="{studio_home}"\n'
         '_css_id_dir="$STUDIO_HOME/share"\n'
         '_css_id_file="$_css_id_dir/studio_install_id"\n'
         # Replicate the generation block narrowly so it fails loud on contract drift.
         "gen() {\n"
-        '    if [ ! -s "$_css_id_file" ]; then\n'
+        '    _css_studio_root_id=$(_css_read_valid_install_id "$_css_id_file")\n'
+        '    if [ -z "$_css_studio_root_id" ]; then\n'
         '        _css_new_id=$(od -An -N32 -tx1 /dev/urandom 2>/dev/null | tr -d " \\n")\n'
         '        _t="$_css_id_file.$$.tmp"\n'
         '        printf "%s" "$_css_new_id" > "$_t"\n'
         '        ln "$_t" "$_css_id_file" 2>/dev/null \\\n'
         '            || { [ -s "$_css_id_file" ] || mv "$_t" "$_css_id_file"; }\n'
         '        rm -f "$_t"\n'
+        '        _css_studio_root_id="$_css_new_id"\n'
         "    fi\n"
-        '    cat "$_css_id_file"\n'
+        '    printf "%s\\n" "$_css_studio_root_id"\n'
         "}\n"
         "a=$(gen); b=$(gen)\n"
         '[ "$a" = "$b" ] || { echo MISMATCH; exit 1; }\n'
@@ -668,16 +682,19 @@ def test_install_sh_publishes_the_id_without_clobbering():
     """install.sh must publish the id no-clobber, so it cannot replace one the desktop app minted."""
     src = INSTALL_SH.read_text(encoding = "utf-8")
     fn_start = src.index('_css_id_dir="$STUDIO_HOME/share"')
-    block = src[fn_start : fn_start + 2400]
+    block = src[fn_start : fn_start + 3000]
     assert (
         'ln "$_css_id_tmp" "$_css_id_file"' in block
     ), "install.sh must publish the id with ln (EEXIST on a race), not a clobbering mv"
+    _guarded_mv = (
+        'if [ -z "$_css_studio_root_id" ] && mv "$_css_id_tmp" "$_css_id_file"; then'
+    )
     assert 'mv "$_css_id_tmp" "$_css_id_file"' not in block.replace(
-        '[ -s "$_css_id_file" ] || mv "$_css_id_tmp" "$_css_id_file"', ""
+        _guarded_mv, ""
     ), "the only remaining mv must be the no-hard-link fallback, guarded on the destination"
     assert (
-        '[ -s "$_css_id_file" ] || mv' in block
-    ), "the mv branch must refuse to replace a usable incumbent id"
+        _guarded_mv in block
+    ), "the mv branch must refuse to replace a usable (valid) incumbent id"
     assert (
         'rm -f "$_css_id_file"' not in block
     ), "never unlink the id: an unlink opens a window where a valid id is deleted"
@@ -695,12 +712,16 @@ def test_install_sh_id_publish_adopts_the_winner_of_a_race(tmp_path):
     # Replicate the publish step with the guard removed, so only the publication
     # primitive decides the outcome: a clobbering mv would overwrite the incumbent.
     publish = (
-        f'_css_id_file="{id_file}"\n'
+        _install_id_helpers()
+        + f'_css_id_file="{id_file}"\n'
         '_css_id_tmp="$_css_id_file.$$.tmp"\n'
         '_css_new_id="' + "b" * 64 + '"\n'
         'printf "%s" "$_css_new_id" > "$_css_id_tmp"\n'
         'if ! ln "$_css_id_tmp" "$_css_id_file" 2>/dev/null; then\n'
-        '    [ -s "$_css_id_file" ] || mv "$_css_id_tmp" "$_css_id_file"\n'
+        '    _css_studio_root_id=$(_css_read_valid_install_id "$_css_id_file")\n'
+        '    if [ -z "$_css_studio_root_id" ] && mv "$_css_id_tmp" "$_css_id_file"; then\n'
+        '        _css_studio_root_id="$_css_new_id"\n'
+        "    fi\n"
         "fi\n"
         'rm -f "$_css_id_tmp"\n'
         'cat "$_css_id_file"\n'
@@ -725,12 +746,16 @@ def test_install_sh_id_publish_replaces_a_blank_incumbent(tmp_path):
     fresh = "c" * 64
 
     publish = (
-        f'_css_id_file="{id_file}"\n'
+        _install_id_helpers()
+        + f'_css_id_file="{id_file}"\n'
         f'_css_new_id="{fresh}"\n'
         '_css_id_tmp="$_css_id_file.$$.$(printf "%.8s" "$_css_new_id").tmp"\n'
         'printf "%s" "$_css_new_id" > "$_css_id_tmp"\n'
         'if ! ln "$_css_id_tmp" "$_css_id_file" 2>/dev/null; then\n'
-        '    [ -s "$_css_id_file" ] || mv "$_css_id_tmp" "$_css_id_file"\n'
+        '    _css_studio_root_id=$(_css_read_valid_install_id "$_css_id_file")\n'
+        '    if [ -z "$_css_studio_root_id" ] && mv "$_css_id_tmp" "$_css_id_file"; then\n'
+        '        _css_studio_root_id="$_css_new_id"\n'
+        "    fi\n"
         "fi\n"
         'rm -f "$_css_id_tmp"\n'
         'cat "$_css_id_file"\n'
@@ -738,6 +763,65 @@ def test_install_sh_id_publish_replaces_a_blank_incumbent(tmp_path):
     res = subprocess.run(["sh", "-c", publish], text = True, capture_output = True)
     assert res.returncode == 0, res.stderr
     assert res.stdout.strip() == fresh, "a blank id must be replaced, not adopted"
+
+
+def test_install_sh_never_bakes_a_planted_id_into_the_launcher(tmp_path):
+    """A pre-planted studio_install_id must be regenerated, not embedded.
+
+    The launcher holds the id in a single-quoted shell assignment, so a value
+    containing a quote would break out and run as launcher code on every
+    Studio start. Custom roots (UNSLOTH_STUDIO_HOME) can live in shared or
+    workspace directories, so the file is not trusted just for being there.
+    """
+    studio_home = tmp_path / "studio"
+    (studio_home / "share").mkdir(parents = True)
+    id_file = studio_home / "share" / "studio_install_id"
+    marker = tmp_path / "pwned"
+    id_file.write_text(f"x'; touch {marker}; exit 0 #", encoding = "utf-8")
+
+    launcher = tmp_path / "launch-studio.sh"
+    script = (
+        _install_id_helpers()
+        + f'_css_id_file="{id_file}"\n'
+        '_css_studio_root_id=$(_css_read_valid_install_id "$_css_id_file")\n'
+        'if [ -z "$_css_studio_root_id" ]; then\n'
+        '    _css_studio_root_id=$(od -An -N32 -tx1 /dev/urandom | tr -d " \\n")\n'
+        "fi\n"
+        # The real embedding step from install.sh.
+        f"printf \"%s\\n\" \"_EXPECTED_STUDIO_ROOT_ID='@@STUDIO_ROOT_ID@@'\" > {launcher}\n"
+        f'sed -e "s|@@STUDIO_ROOT_ID@@|$_css_studio_root_id|g" {launcher} > {launcher}.tmp\n'
+        f"mv {launcher}.tmp {launcher}\n"
+    )
+    res = subprocess.run(["sh", "-c", script], text = True, capture_output = True)
+    assert res.returncode == 0, res.stderr
+
+    baked = launcher.read_text(encoding = "utf-8").strip()
+    prefix, quoted = "_EXPECTED_STUDIO_ROOT_ID='", baked[len("_EXPECTED_STUDIO_ROOT_ID='") : -1]
+    assert baked.startswith(prefix) and baked.endswith("'"), f"unexpected launcher line: {baked!r}"
+    assert len(quoted) == 64 and all(
+        c in "0123456789abcdef" for c in quoted
+    ), f"a planted id must be regenerated, got {quoted!r}"
+
+    # Belt and braces: sourcing the generated line must not run anything.
+    subprocess.run(["sh", "-c", f". {launcher}"], text = True, capture_output = True)
+    assert not marker.exists(), "the planted id executed as launcher code"
+
+
+def test_install_ps1_validates_an_existing_id_before_embedding_it():
+    """install.ps1 must reject a non-hex existing id instead of interpolating it.
+
+    -cnotmatch, not -notmatch: PowerShell's -match is case-insensitive and
+    would accept an uppercase id the backend's regex rejects.
+    """
+    src = INSTALL_PS1.read_text(encoding = "utf-8")
+    idx = src.index('$_studioIdFile = Join-Path $_studioIdDir "studio_install_id"')
+    block = src[idx : idx + 1200]
+    assert (
+        "$_studioRootId -cnotmatch '^[0-9a-f]{64}$'" in block
+    ), "install.ps1 must validate an existing id as 64 lowercase hex before reuse"
+    assert block.index("ReadAllText($_studioIdFile)") < block.index(
+        "$_studioRootId -cnotmatch"
+    ), "the validation must follow the read and precede any use of the value"
 
 
 def test_install_ps1_publishes_the_id_without_clobbering():
@@ -766,8 +850,8 @@ def test_install_ps1_publishes_the_id_without_clobbering():
         "$_studioRootId = $_adoptedRootId" in block
     ), "the adopted id must become the value baked into the launcher"
     assert (
-        "if ($_adoptedRootId)" in block
-    ), "install.ps1 must only adopt a non-empty id, so a blank one cannot become the expected id"
+        "if ($_adoptedRootId -cmatch '^[0-9a-f]{64}$')" in block
+    ), "install.ps1 must only adopt a valid id, so a blank or planted one cannot become the expected id"
     assert (
         "Remove-Item -LiteralPath $_studioIdFile" not in block
     ), "never unlink the id: an unlink opens a window where a valid id is deleted"

--- a/tests/test_studio_install_workspace_guard.py
+++ b/tests/test_studio_install_workspace_guard.py
@@ -646,8 +646,7 @@ def test_install_sh_create_shortcuts_seeds_id_from_csprng_with_python_fallback(t
     studio_home = tmp_path / "studio"
     (studio_home / "share").mkdir(parents = True)
     gen_script = (
-        _install_id_helpers()
-        + f'STUDIO_HOME="{studio_home}"\n'
+        _install_id_helpers() + f'STUDIO_HOME="{studio_home}"\n'
         '_css_id_dir="$STUDIO_HOME/share"\n'
         '_css_id_file="$_css_id_dir/studio_install_id"\n'
         # Replicate the generation block narrowly so it fails loud on contract drift.
@@ -686,9 +685,7 @@ def test_install_sh_publishes_the_id_without_clobbering():
     assert (
         'ln "$_css_id_tmp" "$_css_id_file"' in block
     ), "install.sh must publish the id with ln (EEXIST on a race), not a clobbering mv"
-    _guarded_mv = (
-        'if [ -z "$_css_studio_root_id" ] && mv "$_css_id_tmp" "$_css_id_file"; then'
-    )
+    _guarded_mv = 'if [ -z "$_css_studio_root_id" ] && mv "$_css_id_tmp" "$_css_id_file"; then'
     assert 'mv "$_css_id_tmp" "$_css_id_file"' not in block.replace(
         _guarded_mv, ""
     ), "the only remaining mv must be the no-hard-link fallback, guarded on the destination"
@@ -712,8 +709,7 @@ def test_install_sh_id_publish_adopts_the_winner_of_a_race(tmp_path):
     # Replicate the publish step with the guard removed, so only the publication
     # primitive decides the outcome: a clobbering mv would overwrite the incumbent.
     publish = (
-        _install_id_helpers()
-        + f'_css_id_file="{id_file}"\n'
+        _install_id_helpers() + f'_css_id_file="{id_file}"\n'
         '_css_id_tmp="$_css_id_file.$$.tmp"\n'
         '_css_new_id="' + "b" * 64 + '"\n'
         'printf "%s" "$_css_new_id" > "$_css_id_tmp"\n'
@@ -746,8 +742,7 @@ def test_install_sh_id_publish_replaces_a_blank_incumbent(tmp_path):
     fresh = "c" * 64
 
     publish = (
-        _install_id_helpers()
-        + f'_css_id_file="{id_file}"\n'
+        _install_id_helpers() + f'_css_id_file="{id_file}"\n'
         f'_css_new_id="{fresh}"\n'
         '_css_id_tmp="$_css_id_file.$$.$(printf "%.8s" "$_css_new_id").tmp"\n'
         'printf "%s" "$_css_new_id" > "$_css_id_tmp"\n'
@@ -781,14 +776,13 @@ def test_install_sh_never_bakes_a_planted_id_into_the_launcher(tmp_path):
 
     launcher = tmp_path / "launch-studio.sh"
     script = (
-        _install_id_helpers()
-        + f'_css_id_file="{id_file}"\n'
+        _install_id_helpers() + f'_css_id_file="{id_file}"\n'
         '_css_studio_root_id=$(_css_read_valid_install_id "$_css_id_file")\n'
         'if [ -z "$_css_studio_root_id" ]; then\n'
         '    _css_studio_root_id=$(od -An -N32 -tx1 /dev/urandom | tr -d " \\n")\n'
         "fi\n"
         # The real embedding step from install.sh.
-        f"printf \"%s\\n\" \"_EXPECTED_STUDIO_ROOT_ID='@@STUDIO_ROOT_ID@@'\" > {launcher}\n"
+        f'printf "%s\\n" "_EXPECTED_STUDIO_ROOT_ID=\'@@STUDIO_ROOT_ID@@\'" > {launcher}\n'
         f'sed -e "s|@@STUDIO_ROOT_ID@@|$_css_studio_root_id|g" {launcher} > {launcher}.tmp\n'
         f"mv {launcher}.tmp {launcher}\n"
     )

--- a/tests/test_studio_install_workspace_guard.py
+++ b/tests/test_studio_install_workspace_guard.py
@@ -690,9 +690,9 @@ def test_install_sh_publishes_the_id_without_clobbering():
         _guarded_mv, ""
     ), "the only remaining mv must be the no-hard-link fallback, guarded on the destination"
     assert (
-        'if [ -z "$(_css_read_valid_install_id "$_css_id_file")" ] \\\n'
-        '                    && [ ! -d "$_css_id_file" ]; then' in block
-    ), "the mv branch must refuse to replace a usable (valid) incumbent, or a directory"
+        'if _css_incumbent=$(_css_read_valid_install_id "$_css_id_file") \\\n'
+        '                    && [ -z "$_css_incumbent" ] && [ ! -d "$_css_id_file" ]; then' in block
+    ), "the mv branch must refuse a valid incumbent, an unreadable one, or a directory"
     assert _guarded_mv in block, "the fallback mv must not abort the installer under set -e"
     assert (
         'rm -f "$_css_id_file"' not in block
@@ -860,6 +860,46 @@ def test_install_sh_rejects_an_id_holding_a_nul_byte(tmp_path):
     assert "OUT=[" + "d" * 64 + "]" in res.stdout, "a clean id must still be reused"
 
 
+@pytest.mark.skipif(os.name != "posix", reason = "PATH-shadowed cat is a POSIX shape")
+def test_install_sh_reports_a_failed_read_instead_of_regenerating(tmp_path):
+    """A read that FAILS is not the same answer as a malformed id.
+
+    `-r` can pass while the read itself errors (a transient fault on an
+    NFS/FUSE-backed root). Flattening that into "no id" let the publish path
+    replace a valid incumbent that a running backend still reports.
+    """
+    src = INSTALL_SH.read_text(encoding = "utf-8")
+    assert (
+        '_cvi_id=$({ cat "$1"; } 2>/dev/null) || return 1' in src
+    ), "the read helper must report a failed read, not swallow it"
+    assert (
+        'if ! _css_studio_root_id=$(_css_read_valid_install_id "$_css_id_file"); then' in src
+    ), "the caller must refuse on a failed read"
+
+    id_file = tmp_path / "studio_install_id"
+    good = "b" * 64
+    id_file.write_text(good, encoding = "utf-8")
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_cat = fake_bin / "cat"
+    fake_cat.write_text("#!/bin/sh\nexit 1\n", encoding = "utf-8")
+    fake_cat.chmod(0o755)
+
+    probe = (
+        _install_id_helpers()
+        + f'if out=$(_css_read_valid_install_id "{id_file}"); then\n'
+        '    printf "READ_OK=[%s]\\n" "$out"\n'
+        "else\n"
+        '    printf "READ_FAILED\\n"\n'
+        "fi\n"
+    )
+    env = dict(os.environ, PATH = f"{fake_bin}:{os.environ['PATH']}")
+    res = subprocess.run(["sh", "-c", probe], text = True, capture_output = True, env = env)
+    assert res.returncode == 0, res.stderr
+    assert "READ_FAILED" in res.stdout, f"a failed read must be reported, got {res.stdout!r}"
+    assert id_file.read_text() == good, "the id must be left alone"
+
+
 @pytest.mark.skipif(
     os.name != "posix" or os.geteuid() == 0,
     reason = "needs POSIX mode bits, and root reads regardless of them",
@@ -875,7 +915,8 @@ def test_install_sh_refuses_an_unreadable_existing_id(tmp_path):
     fn_start = src.index('_css_id_dir="$STUDIO_HOME/share"')
     block = src[fn_start : fn_start + 4200]
     assert (
-        '[ -f "$_css_id_file" ] \\\n        && [ ! -r "$_css_id_file" ]' in block
+        'if ! _css_studio_root_id=$(_css_read_valid_install_id "$_css_id_file"); then'
+        in block
     ), "install.sh must separate an unreadable id from a malformed one"
     assert (
         "[WARN] Cannot create launcher: cannot read" in block
@@ -890,9 +931,9 @@ def test_install_sh_refuses_an_unreadable_existing_id(tmp_path):
         probe = (
             _install_id_helpers()
             + f'_css_id_file="{id_file}"\n'
-            '_css_studio_root_id=$(_css_read_valid_install_id "$_css_id_file")\n'
-            'if [ -z "$_css_studio_root_id" ] && [ -f "$_css_id_file" ] \\\n'
-            '    && [ ! -r "$_css_id_file" ]; then echo REFUSED; exit 0; fi\n'
+            'if ! _css_studio_root_id=$(_css_read_valid_install_id "$_css_id_file"); then\n'
+            '    echo REFUSED; exit 0\n'
+            'fi\n'
             'echo "REUSED=$_css_studio_root_id"\n'
         )
         res = subprocess.run(["sh", "-c", probe], text = True, capture_output = True)

--- a/tests/test_studio_install_workspace_guard.py
+++ b/tests/test_studio_install_workspace_guard.py
@@ -685,17 +685,55 @@ def test_install_sh_publishes_the_id_without_clobbering():
     assert (
         'ln "$_css_id_tmp" "$_css_id_file"' in block
     ), "install.sh must publish the id with ln (EEXIST on a race), not a clobbering mv"
-    _guarded_mv = 'if [ -z "$_css_studio_root_id" ] && mv "$_css_id_tmp" "$_css_id_file"; then'
+    _guarded_mv = 'mv "$_css_id_tmp" "$_css_id_file" 2>/dev/null || true'
     assert 'mv "$_css_id_tmp" "$_css_id_file"' not in block.replace(
         _guarded_mv, ""
     ), "the only remaining mv must be the no-hard-link fallback, guarded on the destination"
     assert (
-        _guarded_mv in block
-    ), "the mv branch must refuse to replace a usable (valid) incumbent id"
+        'if [ -z "$(_css_read_valid_install_id "$_css_id_file")" ] \\\n'
+        '                    && [ ! -d "$_css_id_file" ]; then' in block
+    ), "the mv branch must refuse to replace a usable (valid) incumbent, or a directory"
+    assert _guarded_mv in block, "the fallback mv must not abort the installer under set -e"
     assert (
         'rm -f "$_css_id_file"' not in block
     ), "never unlink the id: an unlink opens a window where a valid id is deleted"
     assert 'rm -f "$_css_id_tmp"' in block, "the temp sibling must not be left behind"
+
+
+def test_install_sh_bakes_the_id_that_is_actually_on_disk(tmp_path):
+    """The launcher must hold what the id file holds, not what we tried to write.
+
+    The backend reports the file's content from /api/health, so any path where
+    publication silently did something else (destination is a directory, so
+    `ln` links the temp INSIDE it; another writer won; the share dir is not
+    writable) must resolve to the on-disk value or to no launcher at all.
+    """
+    src = INSTALL_SH.read_text(encoding = "utf-8")
+    fn_start = src.index('_css_id_dir="$STUDIO_HOME/share"')
+    block = src[fn_start : fn_start + 3000]
+    read_back = '_css_studio_root_id=$(_css_read_valid_install_id "$_css_id_file")'
+    assert block.count(read_back) >= 2, "the id must be re-read after publication"
+    assert block.rindex(read_back) > block.index(
+        'rm -f "$_css_id_tmp"'
+    ), "the value baked into the launcher must be read back after the publish step"
+
+    # Behavioural: a directory at the id path must not yield a launcher.
+    studio_home = tmp_path / "studio"
+    (studio_home / "share" / "studio_install_id").mkdir(parents = True)
+    probe = (
+        _install_id_helpers()
+        + f'_css_id_file="{studio_home}/share/studio_install_id"\n'
+        'printf "%s" "' + "d" * 64 + '" > "$_css_id_file.tmp"\n'
+        'ln "$_css_id_file.tmp" "$_css_id_file" 2>/dev/null || true\n'
+        'rm -f "$_css_id_file.tmp"\n'
+        'printf "ID=[%s]\\n" "$(_css_read_valid_install_id "$_css_id_file")"\n'
+    )
+    res = subprocess.run(["sh", "-c", probe], text = True, capture_output = True)
+    assert res.returncode == 0, res.stderr
+    assert "ID=[]" in res.stdout, (
+        "a directory at the id path must read back as no id, so the launcher is "
+        f"not generated; got {res.stdout!r}"
+    )
 
 
 def test_install_sh_id_publish_adopts_the_winner_of_a_race(tmp_path):

--- a/tests/test_studio_install_workspace_guard.py
+++ b/tests/test_studio_install_workspace_guard.py
@@ -721,8 +721,7 @@ def test_install_sh_bakes_the_id_that_is_actually_on_disk(tmp_path):
     studio_home = tmp_path / "studio"
     (studio_home / "share" / "studio_install_id").mkdir(parents = True)
     probe = (
-        _install_id_helpers()
-        + f'_css_id_file="{studio_home}/share/studio_install_id"\n'
+        _install_id_helpers() + f'_css_id_file="{studio_home}/share/studio_install_id"\n'
         'printf "%s" "' + "d" * 64 + '" > "$_css_id_file.tmp"\n'
         'ln "$_css_id_file.tmp" "$_css_id_file" 2>/dev/null || true\n'
         'rm -f "$_css_id_file.tmp"\n'
@@ -815,7 +814,10 @@ def test_install_sh_trims_only_surrounding_whitespace_in_an_existing_id(tmp_path
     ), "install.sh must trim only the surrounding whitespace, as the backend does"
 
     id_file = tmp_path / "studio_install_id"
-    probe = _install_id_helpers() + f'printf "OUT=[%s]\\n" "$(_css_read_valid_install_id "{id_file}")"\n'
+    probe = (
+        _install_id_helpers()
+        + f'printf "OUT=[%s]\\n" "$(_css_read_valid_install_id "{id_file}")"\n'
+    )
     for content, expect_reuse in [
         ("a" * 32 + "\n" + "a" * 32, False),
         ("a" * 32 + " " + "a" * 32, False),
@@ -845,7 +847,10 @@ def test_install_sh_rejects_an_id_holding_a_nul_byte(tmp_path):
     ), "install.sh must detect NUL bytes before reading the id into a variable"
 
     id_file = tmp_path / "studio_install_id"
-    probe = _install_id_helpers() + f'printf "OUT=[%s]\\n" "$(_css_read_valid_install_id "{id_file}")"\n'
+    probe = (
+        _install_id_helpers()
+        + f'printf "OUT=[%s]\\n" "$(_css_read_valid_install_id "{id_file}")"\n'
+    )
     for content in [
         b"a" * 32 + b"\x00" + b"a" * 32,
         b"b" * 64 + b"\x00",
@@ -886,8 +891,7 @@ def test_install_sh_reports_a_failed_read_instead_of_regenerating(tmp_path):
     fake_cat.chmod(0o755)
 
     probe = (
-        _install_id_helpers()
-        + f'if out=$(_css_read_valid_install_id "{id_file}"); then\n'
+        _install_id_helpers() + f'if out=$(_css_read_valid_install_id "{id_file}"); then\n'
         '    printf "READ_OK=[%s]\\n" "$out"\n'
         "else\n"
         '    printf "READ_FAILED\\n"\n'
@@ -915,8 +919,7 @@ def test_install_sh_refuses_an_unreadable_existing_id(tmp_path):
     fn_start = src.index('_css_id_dir="$STUDIO_HOME/share"')
     block = src[fn_start : fn_start + 4200]
     assert (
-        'if ! _css_studio_root_id=$(_css_read_valid_install_id "$_css_id_file"); then'
-        in block
+        'if ! _css_studio_root_id=$(_css_read_valid_install_id "$_css_id_file"); then' in block
     ), "install.sh must separate an unreadable id from a malformed one"
     assert (
         "[WARN] Cannot create launcher: cannot read" in block
@@ -929,11 +932,10 @@ def test_install_sh_refuses_an_unreadable_existing_id(tmp_path):
     id_file.chmod(0o000)
     try:
         probe = (
-            _install_id_helpers()
-            + f'_css_id_file="{id_file}"\n'
+            _install_id_helpers() + f'_css_id_file="{id_file}"\n'
             'if ! _css_studio_root_id=$(_css_read_valid_install_id "$_css_id_file"); then\n'
-            '    echo REFUSED; exit 0\n'
-            'fi\n'
+            "    echo REFUSED; exit 0\n"
+            "fi\n"
             'echo "REUSED=$_css_studio_root_id"\n'
         )
         res = subprocess.run(["sh", "-c", probe], text = True, capture_output = True)
@@ -952,13 +954,14 @@ def test_install_sh_never_reads_a_non_regular_id_path(tmp_path):
     or custom root hangs the install forever.
     """
     src = INSTALL_SH.read_text(encoding = "utf-8")
-    assert (
-        '[ -f "$1" ] || return 0' in src
-    ), "install.sh must read the id only from a regular file"
+    assert '[ -f "$1" ] || return 0' in src, "install.sh must read the id only from a regular file"
 
     id_file = tmp_path / "studio_install_id"
     os.mkfifo(id_file)
-    probe = _install_id_helpers() + f'printf "OUT=[%s]\\n" "$(_css_read_valid_install_id "{id_file}")"\n'
+    probe = (
+        _install_id_helpers()
+        + f'printf "OUT=[%s]\\n" "$(_css_read_valid_install_id "{id_file}")"\n'
+    )
     res = subprocess.run(["sh", "-c", probe], text = True, capture_output = True, timeout = 20)
     assert res.returncode == 0, res.stderr
     assert "OUT=[]" in res.stdout, f"a FIFO must read as no id, got {res.stdout!r}"

--- a/tests/test_studio_install_workspace_guard.py
+++ b/tests/test_studio_install_workspace_guard.py
@@ -28,8 +28,7 @@ def _install_id_helpers() -> str:
 def _extract_create_studio_shortcuts() -> str:
     """The shipped helpers plus the whole create_studio_shortcuts body.
 
-    The function contains heredocs with their own `}` at column 0, so the real
-    end is found by asking `sh -n` which candidate close brace parses.
+    Heredocs carry their own `}` at column 0, so `sh -n` picks the real one.
     """
     src = INSTALL_SH.read_text(encoding = "utf-8")
     lines = src.splitlines()
@@ -933,8 +932,7 @@ def test_install_sh_reports_a_failed_read_instead_of_regenerating(tmp_path):
 def test_install_sh_replaces_an_empty_id_even_when_it_cannot_read_it(tmp_path):
     """Zero length is an answer stat can give: that file holds no id.
 
-    Refusing here would fail an install that succeeded before the id was
-    validated at all, since a zero-length file was simply replaced. The
+    Refusing would fail an install that pre-validation simply completed. The
     protection is for ids we cannot read, and an id is 64 bytes, never zero.
     """
     src = INSTALL_SH.read_text(encoding = "utf-8")
@@ -1027,9 +1025,8 @@ def test_install_sh_never_reads_a_non_regular_id_path(tmp_path):
 def test_create_studio_shortcuts_end_to_end_never_embeds_a_planted_id(tmp_path):
     """The REAL create_studio_shortcuts, not a reconstruction of it.
 
-    The helper-level tests above cannot catch a caller that validates and then
-    embeds something else, so this runs the shipped function over a planted id
-    and inspects the launcher it actually writes.
+    Helper-level tests cannot catch a caller that validates then embeds
+    something else, so this inspects the launcher the shipped function writes.
     """
     home = tmp_path / "home"
     studio_home = tmp_path / "studio"

--- a/tests/test_studio_install_workspace_guard.py
+++ b/tests/test_studio_install_workspace_guard.py
@@ -703,10 +703,10 @@ def test_install_sh_publishes_the_id_without_clobbering():
 def test_install_sh_bakes_the_id_that_is_actually_on_disk(tmp_path):
     """The launcher must hold what the id file holds, not what we tried to write.
 
-    The backend reports the file's content from /api/health, so any path where
-    publication silently did something else (destination is a directory, so
-    `ln` links the temp INSIDE it; another writer won; the share dir is not
-    writable) must resolve to the on-disk value or to no launcher at all.
+    The backend reports the file's content, so every path where publication did
+    something else (a directory destination, so `ln` links the temp inside it;
+    a lost race; an unwritable share dir) must resolve to the on-disk value or
+    to no launcher at all.
     """
     src = INSTALL_SH.read_text(encoding = "utf-8")
     fn_start = src.index('_css_id_dir="$STUDIO_HOME/share"')
@@ -801,10 +801,9 @@ def test_install_sh_id_publish_replaces_a_blank_incumbent(tmp_path):
 def test_install_sh_trims_only_surrounding_whitespace_in_an_existing_id(tmp_path):
     """Interior whitespace must fail the check, not be deleted into a valid id.
 
-    The backend applies `.strip()` and then an exact regex, so `<32 hex>\\n<32
-    hex>` is NOT an id to it. Deleting the newline instead would mint a 64-hex
-    token the installer bakes into the launcher while the backend keeps
-    reporting "", and the launcher would reject its own backend forever.
+    The backend strips then regex-matches, so `<32 hex>\\n<32 hex>` is not an id
+    to it. Deleting the newline would bake a token the backend never reports,
+    leaving the launcher rejecting its own backend forever.
     """
     src = INSTALL_SH.read_text(encoding = "utf-8")
     assert (
@@ -837,10 +836,9 @@ def test_install_sh_trims_only_surrounding_whitespace_in_an_existing_id(tmp_path
 def test_install_sh_refuses_an_unreadable_existing_id(tmp_path):
     """An id we cannot READ must not be treated as malformed and replaced.
 
-    In a shared root the file can be a perfectly good id owned by another user
-    (this installer chmod 600s it), and a running backend may already report
-    it. Regenerating would break that install, so the shortcut step refuses,
-    which is what it did before the id was validated at all.
+    In a shared root it can be a good id owned by someone else that a running
+    backend already reports, so the step refuses, as it did before the id was
+    validated at all.
     """
     src = INSTALL_SH.read_text(encoding = "utf-8")
     fn_start = src.index('_css_id_dir="$STUDIO_HOME/share"')
@@ -877,8 +875,8 @@ def test_install_sh_refuses_an_unreadable_existing_id(tmp_path):
 def test_install_sh_never_reads_a_non_regular_id_path(tmp_path):
     """A FIFO at the id path must not park the installer on the open.
 
-    `cat` on a FIFO blocks until a writer appears, so an unconditional read of
-    a shared/custom root would hang the install forever.
+    `cat` blocks until a writer appears, so an unconditional read of a shared
+    or custom root hangs the install forever.
     """
     src = INSTALL_SH.read_text(encoding = "utf-8")
     assert (
@@ -896,10 +894,9 @@ def test_install_sh_never_reads_a_non_regular_id_path(tmp_path):
 def test_install_sh_never_bakes_a_planted_id_into_the_launcher(tmp_path):
     """A pre-planted studio_install_id must be regenerated, not embedded.
 
-    The launcher holds the id in a single-quoted shell assignment, so a value
-    containing a quote would break out and run as launcher code on every
-    Studio start. Custom roots (UNSLOTH_STUDIO_HOME) can live in shared or
-    workspace directories, so the file is not trusted just for being there.
+    The launcher holds the id in a single-quoted assignment, so a quote in it
+    runs as launcher code on every Studio start. Custom roots can live in
+    shared directories, so the file is not trusted for merely being there.
     """
     studio_home = tmp_path / "studio"
     (studio_home / "share").mkdir(parents = True)
@@ -937,8 +934,8 @@ def test_install_sh_never_bakes_a_planted_id_into_the_launcher(tmp_path):
 def test_install_ps1_validates_an_existing_id_before_embedding_it():
     """install.ps1 must reject a non-hex existing id instead of interpolating it.
 
-    -cnotmatch, not -notmatch: PowerShell's -match is case-insensitive and
-    would accept an uppercase id the backend's regex rejects.
+    -cnotmatch, not -notmatch: -match is case insensitive and would accept an
+    uppercase id the backend's regex rejects.
     """
     src = INSTALL_PS1.read_text(encoding = "utf-8")
     idx = src.index('$_studioIdFile = Join-Path $_studioIdDir "studio_install_id"')


### PR DESCRIPTION
`install.sh` and `install.ps1` mint a fresh `studio_install_id` only when `$STUDIO_HOME/share/studio_install_id` is absent or empty. If the file already has content, that content is read verbatim and substituted into the generated launcher, where it sits inside a single-quoted assignment:

```sh
_EXPECTED_STUDIO_ROOT_ID='@@STUDIO_ROOT_ID@@'
```

A planted value containing a quote breaks out of the assignment and runs as launcher code every time Studio starts. For example an id file containing `x'; <cmd> #` generates:

```sh
_EXPECTED_STUDIO_ROOT_ID='x'; <cmd> #'
```

`install.ps1` has the same shape at `$_ExpectedStudioRootId = '...'`. This matters for custom roots, since `UNSLOTH_STUDIO_HOME` / `STUDIO_HOME` can point at a shared, CI, or workspace directory that is writable before the install runs.

Both the backend (`studio/backend/main.py`, `_STUDIO_INSTALL_ID_RE`) and the desktop app (`studio/src-tauri/src/desktop_backend_owner.rs`, `is_valid_studio_root_id`) already require exactly 64 lowercase hex characters. Only the installers skipped that check, on the one path that turns the value into code.

## Changes

`install.sh`

- Two new helpers, `_css_install_id_is_valid` and `_css_read_valid_install_id`, encoding the same 64 lowercase hex contract. POSIX `case` glob plus a length test, no bashisms, since the script is `#!/bin/sh`. The read helper is silent on a missing or unreadable file.
- Reuse is gated on validity instead of `[ ! -s "$_css_id_file" ]`, and the value baked into the launcher now comes from the branch that established it rather than a `cat` after the fact.
- The freshly generated id is validated too, so a broken `od` or `python3` falls into the existing "no entropy source" path instead of baking junk.
- On the race-adopt path an incumbent is adopted only when it is a real id. A zero-length or malformed file is still replaced by the single rename, with no unlink.

`install.ps1`

- Validate an existing id with `-cnotmatch '^[0-9a-f]{64}$'` before use, and the raced-in winner with `-cmatch`. Case sensitive on purpose: `-match` is case insensitive in PowerShell and would accept an uppercase id the backend rejects.

## Behaviour

Re-runs over a normal install stay a no-op. A valid id is reused byte for byte and nothing is rewritten, so previously generated launchers keep matching.

A malformed id was already a dead end before this change: `/api/health` reports `""` for it and the desktop app refuses to start with "delete that file and reopen Unsloth". Regenerating it removes a broken state rather than changing a working one. No new prompts, no aborts, and no change to the install, Studio, or Desktop flows.

## Tests

`tests/test_studio_install_workspace_guard.py`

- The shell behaviour tests now slice the real helper bodies out of `install.sh` instead of re-implementing them, so they fail loud on contract drift.
- New `test_install_sh_never_bakes_a_planted_id_into_the_launcher`: plants `x'; touch <marker>; exit 0 #`, runs the real read plus the real `sed` embed, then asserts the baked value is 64 hex characters and that sourcing the generated line creates no marker file.
- New `test_install_ps1_validates_an_existing_id_before_embedding_it`, pinned to `-cnotmatch` and to the validation following the read.
- Updated the four assertions that were pinned to the old `[ ! -s ... ]` and `if ($_adoptedRootId)` shapes.

Verified locally: `sh -n install.sh` clean, `install.ps1` parses clean under `pwsh`, and the full guard suite passes at 81 tests.
