### PR TITLE
Studio: announce the installer's pip/uv policy relaxation and let operators keep it

### DIFF
--- a/.github/workflows/cross-platform-parity-ci.yml
+++ b/.github/workflows/cross-platform-parity-ci.yml
@@ -76,6 +76,7 @@ on:
       - 'tests/studio/test_amd_venv_repair_loop.ps1'
       - 'tests/studio/test_amd_name_arch_r9700.ps1'
       - 'tests/studio/test_application_control_cli_fallback.ps1'
+      - 'tests/studio/test_pm_policy_optout_installers.ps1'
       # test_application_control_cli_fallback.ps1 pins install.ps1's trampoline against
       # process.rs's, so a change to either spelling has to run here.
       - 'studio/src-tauri/src/process.rs'
@@ -133,6 +134,7 @@ on:
       - 'tests/studio/test_amd_venv_repair_loop.ps1'
       - 'tests/studio/test_amd_name_arch_r9700.ps1'
       - 'tests/studio/test_application_control_cli_fallback.ps1'
+      - 'tests/studio/test_pm_policy_optout_installers.ps1'
       # test_application_control_cli_fallback.ps1 pins install.ps1's trampoline against
       # process.rs's, so a change to either spelling has to run here.
       - 'studio/src-tauri/src/process.rs'
@@ -229,6 +231,12 @@ jobs:
       - name: XPU arm64 torchaudio tests
         shell: pwsh
         run: pwsh -NoProfile -File tests/studio/test_xpu_arm64_torchaudio.ps1
+      # Same shape: the extracted install helpers run against a recorder standing in for
+      # uv, so what is measured is the environment they hand the manager. No venv needed,
+      # and the pinned-install gate is identical on all three, so it runs on all three.
+      - name: Package-manager policy opt-out tests
+        shell: pwsh
+        run: pwsh -NoProfile -File tests/studio/test_pm_policy_optout_installers.ps1
       # Same again: mocked filesystem reads and one `python -c` child, so no venv, no AMD GPU and
       # no Windows needed. Read the file header before adding cases -- pwsh 7 cannot reproduce the
       # 5.1 half of #8335, so the checks covering it are deliberately source shapes.

--- a/install.ps1
+++ b/install.ps1
@@ -1639,6 +1639,15 @@ public static class UnslothStudioFinalPathV2
         return $Text -replace '(https?://[^\s`#]+)#[^\s`]+', '$1#<redacted>'
     }
 
+    # True when the operator asked for their pip/uv policy to be left in force. Mirrors
+    # _respect_pm_policy() in install_python_stack.py, including its false set, so the same
+    # variable means the same thing on both sides of the hand-off.
+    function Test-RespectPmPolicy {
+        $value = [Environment]::GetEnvironmentVariable('UNSLOTH_RESPECT_PM_POLICY')
+        if ($null -eq $value) { return $false }
+        return @('', '0', 'false', 'no') -notcontains $value.Trim().ToLowerInvariant()
+    }
+
     # Run native commands quietly by default to match install.sh behavior.
     # Full command output is shown only when --verbose / UNSLOTH_VERBOSE=1.
     function Invoke-InstallCommand {
@@ -1649,14 +1658,23 @@ public static class UnslothStudioFinalPathV2
         # Installer-pinned index installs (torch) must beat an inherited uv mirror (#6898):
         # for --default-index, clear the uv index env vars (restore in finally) and set
         # UV_NO_CONFIG=1 so a uv.toml/pyproject index can't outrank the CLI pin (uv 0.10).
+        # This runs before install_python_stack.py, so the Python side's opt-out cannot
+        # cover it: under UNSLOTH_RESPECT_PM_POLICY keep UV_CONFIG_FILE and uv's config
+        # discovery, so the operator's uv.toml binds the pinned torch install too. The
+        # ADDITIVE index variables still go, since the pin is itself a provenance control.
+        $respectPolicy = Test-RespectPmPolicy
         $savedUvIndex = $null
         if ($Command.ToString() -match '--default-index') {
             $savedUvIndex = @{}
-            foreach ($n in 'UV_DEFAULT_INDEX', 'UV_INDEX_URL', 'UV_INDEX', 'UV_EXTRA_INDEX_URL', 'UV_TORCH_BACKEND', 'UV_FIND_LINKS', 'UV_CONFIG_FILE', 'UV_NO_CONFIG') {
+            $scrub = @('UV_DEFAULT_INDEX', 'UV_INDEX_URL', 'UV_INDEX', 'UV_EXTRA_INDEX_URL', 'UV_TORCH_BACKEND', 'UV_FIND_LINKS', 'UV_CONFIG_FILE', 'UV_NO_CONFIG')
+            if ($respectPolicy) {
+                $scrub = @($scrub | Where-Object { @('UV_CONFIG_FILE', 'UV_NO_CONFIG') -notcontains $_ })
+            }
+            foreach ($n in $scrub) {
                 $savedUvIndex[$n] = [Environment]::GetEnvironmentVariable($n)
                 Remove-Item "Env:$n" -ErrorAction SilentlyContinue
             }
-            $env:UV_NO_CONFIG = '1'
+            if (-not $respectPolicy) { $env:UV_NO_CONFIG = '1' }
         }
         $prevEap = $ErrorActionPreference
         $ErrorActionPreference = "Continue"
@@ -1698,7 +1716,10 @@ public static class UnslothStudioFinalPathV2
         } finally {
             $ErrorActionPreference = $prevEap
             if ($savedUvIndex) {
-                Remove-Item "Env:UV_NO_CONFIG" -ErrorAction SilentlyContinue
+                # Only clear what this function SET: under the opt-out UV_NO_CONFIG was
+                # neither saved nor overwritten, so removing it would destroy the
+                # operator's own value for the rest of the run.
+                if (-not $respectPolicy) { Remove-Item "Env:UV_NO_CONFIG" -ErrorAction SilentlyContinue }
                 foreach ($n in $savedUvIndex.Keys) { if ($null -ne $savedUvIndex[$n]) { Set-Item "Env:$n" $savedUvIndex[$n] } }
             }
         }

--- a/install.ps1
+++ b/install.ps1
@@ -1668,7 +1668,12 @@ public static class UnslothStudioFinalPathV2
             $savedUvIndex = @{}
             $scrub = @('UV_DEFAULT_INDEX', 'UV_INDEX_URL', 'UV_INDEX', 'UV_EXTRA_INDEX_URL', 'UV_TORCH_BACKEND', 'UV_FIND_LINKS', 'UV_CONFIG_FILE', 'UV_NO_CONFIG')
             if ($respectPolicy) {
-                $scrub = @($scrub | Where-Object { @('UV_CONFIG_FILE', 'UV_NO_CONFIG') -notcontains $_ })
+                # UV_FIND_LINKS rides along: a uv.toml `[pip] no-index = true` makes it
+                # the only source uv is allowed, `--no-index` has no environment spelling
+                # to detect, and uv prints no resolved configuration to ask.
+                $scrub = @($scrub | Where-Object {
+                    @('UV_CONFIG_FILE', 'UV_NO_CONFIG', 'UV_FIND_LINKS') -notcontains $_
+                })
             }
             foreach ($n in $scrub) {
                 $savedUvIndex[$n] = [Environment]::GetEnvironmentVariable($n)

--- a/install.sh
+++ b/install.sh
@@ -270,7 +270,12 @@ run_install_cmd() {
                 # cannot cover it. Keep UV_CONFIG_FILE and uv's config discovery: the
                 # operator asked for their uv.toml to bind this install too. The ADDITIVE
                 # index variables still go, since the pin is itself a provenance control.
-                set -- env -u UV_DEFAULT_INDEX -u UV_INDEX_URL -u UV_INDEX -u UV_EXTRA_INDEX_URL -u UV_TORCH_BACKEND -u UV_FIND_LINKS "$@"
+                # UV_FIND_LINKS is the exception: a uv.toml `[pip] no-index = true` makes
+                # it the only source uv is allowed, `--no-index` has no environment
+                # spelling to detect, and uv prints no resolved configuration to ask, so
+                # dropping it fails every offline install with "index lookups were
+                # disabled and no additional package locations were provided".
+                set -- env -u UV_DEFAULT_INDEX -u UV_INDEX_URL -u UV_INDEX -u UV_EXTRA_INDEX_URL -u UV_TORCH_BACKEND "$@"
             else
                 set -- env -u UV_DEFAULT_INDEX -u UV_INDEX_URL -u UV_INDEX -u UV_EXTRA_INDEX_URL -u UV_TORCH_BACKEND -u UV_FIND_LINKS -u UV_CONFIG_FILE UV_NO_CONFIG=1 "$@"
             fi

--- a/install.sh
+++ b/install.sh
@@ -250,7 +250,13 @@ _uv_download_markers() {
 # read it as any other non-false value and turned the opt-out ON. The entry points have
 # to agree on a value or the promise holds for only part of a run.
 _respect_pm_policy() {
-    case "$(printf '%s' "${UNSLOTH_RESPECT_PM_POLICY:-}" | tr '[:upper:]' '[:lower:]' | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')" in
+    # Unset or empty is the answer for everyone who has not opted in, so decide it
+    # here rather than paying two subprocesses per pinned install to reach the same
+    # conclusion. The default path then does exactly the work it did before.
+    case "${UNSLOTH_RESPECT_PM_POLICY:-}" in
+        "") return 1 ;;
+    esac
+    case "$(printf '%s' "$UNSLOTH_RESPECT_PM_POLICY" | tr '[:upper:]' '[:lower:]' | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')" in
         ''|0|false|no) return 1 ;;
         *) return 0 ;;
     esac

--- a/install.sh
+++ b/install.sh
@@ -242,6 +242,16 @@ _uv_download_markers() {
     '
 }
 
+# True when the operator asked for their pip/uv policy to be left in force. Mirrors
+# _respect_pm_policy() in studio/install_python_stack.py, including its false set, so the
+# same variable means the same thing at every entry point.
+_respect_pm_policy() {
+    case "$(printf '%s' "${UNSLOTH_RESPECT_PM_POLICY:-}" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')" in
+        ''|0|false|no) return 1 ;;
+        *) return 0 ;;
+    esac
+}
+
 run_install_cmd() {
     _label="$1"
     shift
@@ -250,7 +260,17 @@ run_install_cmd() {
     # redirects torch; UV_NO_CONFIG=1 + dropping UV_CONFIG_FILE stops a uv.toml/pyproject
     # index outranking the CLI pin, uv 0.10).
     case " $* " in
-        *" --default-index "*) set -- env -u UV_DEFAULT_INDEX -u UV_INDEX_URL -u UV_INDEX -u UV_EXTRA_INDEX_URL -u UV_TORCH_BACKEND -u UV_FIND_LINKS -u UV_CONFIG_FILE UV_NO_CONFIG=1 "$@" ;;
+        *" --default-index "*)
+            if _respect_pm_policy; then
+                # This runs before install_python_stack.py, so the Python side's opt-out
+                # cannot cover it. Keep UV_CONFIG_FILE and uv's config discovery: the
+                # operator asked for their uv.toml to bind this install too. The ADDITIVE
+                # index variables still go, since the pin is itself a provenance control.
+                set -- env -u UV_DEFAULT_INDEX -u UV_INDEX_URL -u UV_INDEX -u UV_EXTRA_INDEX_URL -u UV_TORCH_BACKEND -u UV_FIND_LINKS "$@"
+            else
+                set -- env -u UV_DEFAULT_INDEX -u UV_INDEX_URL -u UV_INDEX -u UV_EXTRA_INDEX_URL -u UV_TORCH_BACKEND -u UV_FIND_LINKS -u UV_CONFIG_FILE UV_NO_CONFIG=1 "$@"
+            fi
+            ;;
     esac
     if _is_verbose; then
         # Stream through the redactor: uv echoes index URLs (credentials and

--- a/install.sh
+++ b/install.sh
@@ -245,8 +245,12 @@ _uv_download_markers() {
 # True when the operator asked for their pip/uv policy to be left in force. Mirrors
 # _respect_pm_policy() in studio/install_python_stack.py, including its false set, so the
 # same variable means the same thing at every entry point.
+# TRIM, not "delete every space": `tr -d` collapsed internal whitespace too, so `f alse`
+# read as the false spelling here while Python's .strip() and both PowerShell .Trim()s
+# read it as any other non-false value and turned the opt-out ON. The entry points have
+# to agree on a value or the promise holds for only part of a run.
 _respect_pm_policy() {
-    case "$(printf '%s' "${UNSLOTH_RESPECT_PM_POLICY:-}" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')" in
+    case "$(printf '%s' "${UNSLOTH_RESPECT_PM_POLICY:-}" | tr '[:upper:]' '[:lower:]' | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')" in
         ''|0|false|no) return 1 ;;
         *) return 0 ;;
     esac

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -4693,23 +4693,44 @@ def _config_value_is_on(value: str) -> bool:
 def _hardened_uv_config_paths() -> "list[str]":
     """The uv config files this host has, where a no-build / require-hashes could live.
 
-    The user config and the invocation directory only. uv also reads a pyproject
-    [tool.uv] and a workspace root above the cwd; those are left out deliberately -- this
-    list drives a NOTICE, and missing one costs a line of output, not a behaviour change.
+    System, user and invocation directory, which are the documented locations: uv reads
+    `~/.config/uv/uv.toml` on macOS AND Linux (not Application Support) and
+    `%APPDATA%\\uv\\uv.toml` on Windows, with `/etc/uv/uv.toml` and `%PROGRAMDATA%\\uv`
+    as the system-wide pair. The system one matters most here: a fleet operator hardening
+    every machine puts `no-build` there. uv also reads a pyproject [tool.uv] and a
+    workspace root above the cwd; those are left out deliberately -- this list drives a
+    NOTICE, and missing one costs a line of output, not a behaviour change.
     """
     candidates = []
     explicit = os.environ.get("UV_CONFIG_FILE", "").strip()
     if explicit:
         candidates.append(explicit)
     if IS_WINDOWS:
-        appdata = os.environ.get("APPDATA", "")
-        if appdata:
-            candidates.append(os.path.join(appdata, "uv", "uv.toml"))
+        for variable in ("APPDATA", "PROGRAMDATA"):
+            base = os.environ.get(variable, "")
+            if base:
+                candidates.append(os.path.join(base, "uv", "uv.toml"))
     else:
+        # XDG_CONFIG_HOME first: uv honours it, and a host that sets it does not
+        # necessarily have ~/.config at all.
         base = os.environ.get("XDG_CONFIG_HOME") or os.path.expanduser("~/.config")
         candidates.append(os.path.join(base, "uv", "uv.toml"))
-    candidates.append(os.path.join(os.getcwd(), "uv.toml"))
-    return [path for path in candidates if os.path.isfile(path)]
+        candidates.append("/etc/uv/uv.toml")
+    try:
+        # A deleted working directory raises here rather than returning anything.
+        candidates.append(os.path.join(os.getcwd(), "uv.toml"))
+    except OSError:
+        pass
+    found = []
+    for path in candidates:
+        try:
+            if os.path.isfile(path):
+                found.append(path)
+        except OSError:
+            # A path this process cannot stat (permissions, a dead network mount) is
+            # simply not a config file we can report on.
+            continue
+    return found
 
 
 @functools.lru_cache(maxsize = 1)
@@ -4730,9 +4751,13 @@ def _hardened_pm_policy_names() -> "tuple[str, ...]":
             [sys.executable, "-m", "pip", "config", "list"],
             stdout = subprocess.PIPE,
             stderr = subprocess.DEVNULL,
+            # Bounded because this runs BEFORE the pip upgrade, against a venv that may
+            # have no pip at all (uv creates them without one). A notice must never be
+            # able to hang an install.
+            timeout = 30,
             **_windows_hidden_subprocess_kwargs(),
         )
-    except OSError:
+    except (OSError, subprocess.SubprocessError):
         result = None
     if result is not None and result.returncode == 0:
         for line in (result.stdout or b"").decode("utf-8", "replace").splitlines():
@@ -5374,7 +5399,14 @@ def install_python_stack() -> int:
     # Before the bar starts, so the line cannot land mid-progress: on a hardened host,
     # say which controls are relaxed for the installer's own dependency installs and how
     # to keep them. Silent on every ordinary machine.
-    _announce_pm_policy()
+    #
+    # Guarded because this is a message, not a step. It probes pip and reads files the
+    # install itself never touches, and no failure of that probing is worth aborting an
+    # install over -- the worst case is that the notice is missing.
+    try:
+        _announce_pm_policy()
+    except Exception:
+        pass
 
     # 1. Try uv for faster installs (before pip upgrade -- uv venvs don't
     #    include pip by default).

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -4853,9 +4853,7 @@ def _hardened_pip_config_paths() -> "list[str]":
         # pip 26, `XDG_CONFIG_DIRS=/a:/b pip config debug` enumerates /a/pip/pip.conf and
         # /b/pip/pip.conf. macOS reads its global set from XDG_DATA_DIRS instead, falling
         # back to /Library/Application Support.
-        directories = os.environ.get(
-            "XDG_DATA_DIRS" if IS_MACOS else "XDG_CONFIG_DIRS", ""
-        ).strip()
+        directories = os.environ.get("XDG_DATA_DIRS" if IS_MACOS else "XDG_CONFIG_DIRS", "").strip()
         if directories:
             for directory in directories.split(os.pathsep):
                 if directory.strip():
@@ -4901,8 +4899,9 @@ def _hardened_settings_in_ini(text: str) -> "dict[str, str]":
 
 def _hardened_keys_in_ini(text: str) -> "list[str]":
     """Hardened keys switched ON in a single pip.conf."""
-    return [key for key, value in _hardened_settings_in_ini(text).items()
-            if _config_value_is_on(value)]
+    return [
+        key for key, value in _hardened_settings_in_ini(text).items() if _config_value_is_on(value)
+    ]
 
 
 def _read_text(path: str) -> "str | None":
@@ -4995,10 +4994,12 @@ def _detected_policy() -> "tuple[tuple[str, str, str], ...]":
 
 def _hardened_pm_policy_names() -> "tuple[str, ...]":
     """The detected policy, as the notice prints it."""
-    return tuple(dict.fromkeys(
-        key if source == "env" else f"{source} {key}"
-        for _tool, source, key in _detected_policy()
-    ))
+    return tuple(
+        dict.fromkeys(
+            key if source == "env" else f"{source} {key}"
+            for _tool, source, key in _detected_policy()
+        )
+    )
 
 
 # pip and uv spell the same three controls differently and read none of each other's.
@@ -5015,9 +5016,7 @@ def _translated_policy_env(cmd: "list[str]") -> "dict[str, str]":
     if not _respect_pm_policy():
         return {}
     target = "uv" if cmd[:1] == ["uv"] else "pip"
-    source_keys = {
-        key.lower() for tool, _source, key in _detected_policy() if tool != target
-    }
+    source_keys = {key.lower() for tool, _source, key in _detected_policy() if tool != target}
     if not source_keys:
         return {}
 
@@ -5046,9 +5045,7 @@ def _translated_policy_env(cmd: "list[str]") -> "dict[str, str]":
         if _on("UV_ONLY_BINARY", "UV_ONLY_BINARY_PACKAGE", "only-binary"):
             overrides["PIP_ONLY_BINARY"] = ":all:"
     return {
-        name: value
-        for name, value in overrides.items()
-        if not os.environ.get(name, "").strip()
+        name: value for name, value in overrides.items() if not os.environ.get(name, "").strip()
     }
 
 

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -4952,9 +4952,7 @@ def _uv_project_config() -> "list[str]":
     # Measured on the pinned uv 0.12.1, a `[tool.uv.pip] require-hashes = true` in a
     # project named by either variable is enforced from an unrelated cwd, so walking
     # from getcwd() alone scanned the wrong tree and missed live policy.
-    root = os.environ.get("UV_PROJECT", "").strip() or os.environ.get(
-        "UV_WORKING_DIR", ""
-    ).strip()
+    root = os.environ.get("UV_PROJECT", "").strip() or os.environ.get("UV_WORKING_DIR", "").strip()
     try:
         # A deleted working directory raises here rather than returning anything.
         current = os.path.abspath(root or os.getcwd())

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -4205,9 +4205,7 @@ def _staged_restore_args(name: str, staged: str) -> "tuple[list[str], str]":
         return default, ""
     try:
         digest = hashlib.sha256(Path(wheel).read_bytes()).hexdigest()
-        handle = tempfile.NamedTemporaryFile(
-            "w", suffix = ".txt", delete = False, encoding = "utf-8"
-        )
+        handle = tempfile.NamedTemporaryFile("w", suffix = ".txt", delete = False, encoding = "utf-8")
         with handle:
             handle.write(f"{os.path.abspath(wheel)} --hash=sha256:{digest}\n")
     except OSError:
@@ -4784,7 +4782,6 @@ def _config_value_is_on(value: str, key: "str | None" = None) -> bool:
     return text not in _OFF_VALUES
 
 
-
 # The same control under each manager's name, so an explicitly disabled variable can
 # cancel a config entry that enables the same thing.
 _POLICY_KEY_ALIASES = {
@@ -4812,6 +4809,7 @@ def _env_policy_key(name: str) -> str:
 
 # The pip subcommands this module drives.
 _PIP_COMMANDS = ("install", "download", "wheel")
+
 
 @functools.lru_cache(maxsize = 1)
 def _detected_policy() -> "tuple[tuple[str, str, str], ...]":
@@ -4876,9 +4874,10 @@ def _detected_policy() -> "tuple[tuple[str, str, str], ...]":
             # Printed in load order, so the last definition of a given entry wins.
             settings[(section, option)] = raw.strip().strip("'\"")
         for (_section, option), value in settings.items():
-            if _config_value_is_on(value, option) and _canonical_policy_key(
-                option
-            ) not in cancelled:
+            if (
+                _config_value_is_on(value, option)
+                and _canonical_policy_key(option) not in cancelled
+            ):
                 on.append(("pip", "pip.conf", option))
 
     return tuple(dict.fromkeys(on))

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -4984,6 +4984,11 @@ def _hardened_uv_config_paths() -> "list[str]":
         # discovered set is not merely outranked, it is not read at all. Checked BEFORE
         # --no-config: measured on the pinned uv 0.12.1, an explicit file is read with
         # UV_NO_CONFIG=1 set as well, so returning nothing there dropped live policy.
+        working = os.environ.get("UV_WORKING_DIR", "").strip()
+        if working and not os.path.isabs(explicit):
+            # --directory changes directory BEFORE running, so a relative config path is
+            # resolved there and not against the directory the installer started in.
+            explicit = os.path.join(working, explicit)
         return _existing_files([explicit])
     if _config_value_is_on(os.environ.get("UV_NO_CONFIG", "")):
         # --no-config: uv discovers nothing, so nothing here is policy.
@@ -5117,7 +5122,11 @@ def _hardened_pip_sections(text: str) -> "dict[str, dict[str, str]]":
     except configparser.Error:
         return sections
     for raw_name in parser.sections():
-        name = raw_name.strip().lower()
+        # Verbatim: pip normalises the OPTION name and leaves the SECTION name alone, so
+        # `[INSTALL]` is a section pip never selects. Lowercasing it here reported a
+        # policy pip does not apply, which under the opt-out could refuse the first uv
+        # step over a cross-manager gap that did not exist.
+        name = raw_name
         if name not in sections:
             continue
         for option, value in parser.items(raw_name):
@@ -5308,8 +5317,9 @@ def _policy_scan() -> "tuple[tuple[tuple[str, str, str], ...], dict[str, frozens
             # `:env:` entries restate the environment, already handled above.
             if not separator or name.strip().startswith(":env:"):
                 continue
+            # Section verbatim, option normalised: that is what pip itself does, and
+            # `pip config list` prints an `INSTALL.` prefix for a section pip ignores.
             section, _, option = name.strip().rpartition(".")
-            section = section.strip().lower()
             if option not in _PIP_CONFIG_KEYS:
                 continue
             value = raw.strip().strip("'\"")
@@ -5489,6 +5499,24 @@ def _refuse_unenforceable_policy(cmd: "list[str]", missing: "list[str]") -> None
         )
     )
     sys.exit(1)
+
+
+def _preflight_policy_gap() -> None:
+    """Refuse a cross-manager gap BEFORE the install mutates anything.
+
+    The refusal is right, but its timing was not: `install_python_stack()` removes the
+    completion manifest up front, so a refusal at the first resolving command left a
+    venv that had not been touched marked as a half-built install, and `verify_install()`
+    and the Desktop preflight then rejected a working environment.
+
+    Both managers are probed, because this installer drives both and a control only one
+    of them can see is exactly what the opt-out asks to be stopped for. Nothing is
+    reported unless the opt-out is set, so an ordinary install never reaches the check.
+    """
+    for probe in (["uv", "pip", "install"], [sys.executable, "-m", "pip", "install"]):
+        missing = _unenforceable_policy(probe)
+        if missing:
+            _refuse_unenforceable_policy(probe, missing)
 
 
 def _announce_pm_policy() -> None:
@@ -6123,6 +6151,11 @@ def install_python_stack() -> int:
     # Core packages and shared base requirements occupy one progress slot. A
     # shell-installer handoff skips that slot only while base.txt has no work.
     _TOTAL = base_total - int(skip_base and base_requirements is None)
+
+    # Before the manifest goes away, so a refusal cannot leave an untouched venv marked
+    # half-built. Silent unless the opt-out is set AND a control exists that one of the
+    # two managers cannot see.
+    _preflight_policy_gap()
 
     # Drop it up front: a missing manifest is what tells the CLI, setup.sh and
     # the preflight that an interrupted run left the venv half-built. Stop if it

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -4397,6 +4397,24 @@ def _repair_duplicate_core_metadata(
         ) or install_manifest.pip_backup_metadata_paths(name):
             duplicates.append((name, record_count))
 
+    # Decline here, not inside _stage_replacement(). By the time staging is reached this
+    # has already rewritten METADATA and moved pip's leftover backups aside, and while
+    # the finally below puts them back on a normal return, a SIGKILL or a power loss
+    # cannot run a finally. Under the opt-out the reinstall was never going to be
+    # permitted, so the whole repair is skipped before the first byte is touched and the
+    # tree is left exactly as found for a later run to see.
+    if duplicates and _respect_pm_policy():
+        _safe_print(
+            _red(
+                f"   {_POLICY_OPT_OUT_ENV} is set and repairing duplicate metadata for "
+                + ", ".join(name for name, _ in duplicates)
+                + " would have to reinstall it from a source your policy may refuse; "
+                "leaving it as found. Unset the variable for one run to repair it."
+            ),
+            file = sys.stderr,
+        )
+        return False
+
     repaired: list[str] = []
     staging_dirs: list[str] = []
     # One quarantine per package, discarded as soon as that package is back in place.

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -4660,6 +4660,20 @@ _PM_POLICY_ENV_VARS = (
 )
 
 
+# Of the uv variables above, the ones uv actually reads. Measured against the pinned uv
+# 0.12.1: UV_REQUIRE_HASHES and UV_EXCLUDE_NEWER change the outcome, while UV_NO_BUILD,
+# UV_NO_BUILD_PACKAGE, UV_ONLY_BINARY and UV_NO_BINARY are ignored -- the same source
+# directory installs with any of them set and is refused by the matching --no-build /
+# --no-binary flag or a uv.toml carrying it. `uv help pip install` documents no `[env:]`
+# spelling for those four either.
+#
+# They stay in the strip list above, since removing a variable uv ignores costs nothing.
+# They must not count as DETECTED policy though: reporting one as hardening uv applies
+# both puts a false line in the notice and, worse, lets it stand in for a control uv
+# would really enforce, hiding a genuine cross-manager gap under the opt-out.
+_UV_ENFORCED_ENV_VARS = ("UV_REQUIRE_HASHES", "UV_EXCLUDE_NEWER")
+
+
 def _relaxed_pip_policy_env(cmd: "list[str]") -> "dict[str, str]":
     """Overrides that stop a hardened user pip config failing the installer's own pip.
 
@@ -4702,6 +4716,15 @@ _HARDENED_CONFIG_KEYS = (
     # pip's own spelling of the same control, so a pip-side cutoff is detected too.
     "uploaded-prior-to",
 )
+
+
+# Of that list, the keys pip itself has an option for. Measured with pip 26.2.1:
+# `pip install --help` exposes --require-hashes, --only-binary, --no-binary and
+# --uploaded-prior-to, and nothing for no-build, either -package form or exclude-newer.
+# A pip.conf carrying one of those is an inert entry pip ignores, so reading it as pip
+# policy invents hardening the host does not have -- which under the opt-out made the
+# first uv step refuse over a cross-manager gap that was not one.
+_PIP_CONFIG_KEYS = ("require-hashes", "only-binary", "no-binary", "uploaded-prior-to")
 
 
 # pip's own strtobool false set, verbatim, plus the empty and ":none:" spellings that mean
@@ -4848,18 +4871,42 @@ def _existing_files(candidates: "list[str]") -> "list[str]":
     return found
 
 
+def _uv_project_config() -> "list[str]":
+    """The project configuration uv would discover from the working directory.
+
+    Measured on the pinned uv 0.12.1: uv walks up from the working directory to the
+    nearest ancestor holding a `pyproject.toml` and reads a `uv.toml` beside it if there
+    is one, otherwise that file's `[tool.uv]` tables. A parent `[tool.uv.pip]
+    require-hashes = true` fails an install run from a child directory, which is how
+    Studio is normally launched, so stopping at the working directory alone missed real
+    policy. A `uv.toml` with no `pyproject.toml` beside it is read nowhere, working
+    directory included, so it is not listed: reporting one would be hardening uv does
+    not apply.
+    """
+    try:
+        # A deleted working directory raises here rather than returning anything.
+        current = os.path.abspath(os.getcwd())
+    except OSError:
+        return []
+    while True:
+        if _existing_files([os.path.join(current, "pyproject.toml")]):
+            local = _existing_files([os.path.join(current, "uv.toml")])
+            return local or [os.path.join(current, "pyproject.toml")]
+        parent = os.path.dirname(current)
+        if parent == current:
+            # The root is its own parent, which is how this walk terminates.
+            return []
+        current = parent
+
+
 def _hardened_uv_config_paths() -> "list[str]":
-    """The uv config files this host has, where a no-build / require-hashes could live.
+    """The uv config files this host has, in uv's own precedence order, lowest first.
 
-    `~/.config/uv/uv.toml` on macOS AND Linux (not Application Support), `%APPDATA%\\uv`
-    on Windows, plus the system pair `/etc/uv/uv.toml` and `%PROGRAMDATA%\\uv`. The system
-    one matters most: a fleet operator hardening every machine puts `no-build` there.
-
-    Measured on the pinned uv 0.12.1: the cwd `pyproject.toml` IS read by `uv pip install`
-    (`[tool.uv.pip] require-hashes = true` fails it, `-v` logs "Found workspace
-    configuration"), while a PARENT `pyproject.toml`/`uv.toml` and even a bare `./uv.toml`
-    are NOT. `./uv.toml` is kept anyway: it costs a line of output, and other uv
-    subcommands this module drives may yet read it.
+    System (`/etc/uv/uv.toml`, `%PROGRAMDATA%\\uv`), then user (`~/.config/uv/uv.toml` on
+    macOS AND Linux, not Application Support, and `%APPDATA%\\uv` on Windows), then the
+    project. The system one matters most for a fleet operator hardening every machine;
+    the order matters because the caller resolves last-wins, and a project config
+    switching a control off is uv's answer even when the user config switched it on.
     """
     if _config_value_is_on(os.environ.get("UV_NO_CONFIG", "")):
         # --no-config: uv discovers nothing, so nothing here is policy.
@@ -4871,25 +4918,17 @@ def _hardened_uv_config_paths() -> "list[str]":
         return _existing_files([explicit])
     candidates = []
     if IS_WINDOWS:
-        for variable in ("APPDATA", "PROGRAMDATA"):
+        for variable in ("PROGRAMDATA", "APPDATA"):
             base = os.environ.get(variable, "")
             if base:
                 candidates.append(os.path.join(base, "uv", "uv.toml"))
     else:
-        # XDG_CONFIG_HOME first: uv honours it, and a host that sets it does not
+        candidates.append("/etc/uv/uv.toml")
+        # XDG_CONFIG_HOME next: uv honours it, and a host that sets it does not
         # necessarily have ~/.config at all.
         base = os.environ.get("XDG_CONFIG_HOME") or os.path.expanduser("~/.config")
         candidates.append(os.path.join(base, "uv", "uv.toml"))
-        candidates.append("/etc/uv/uv.toml")
-    try:
-        # A deleted working directory raises here rather than returning anything.
-        cwd = os.getcwd()
-    except OSError:
-        cwd = ""
-    if cwd:
-        candidates.append(os.path.join(cwd, "uv.toml"))
-        candidates.append(os.path.join(cwd, "pyproject.toml"))
-    return _existing_files(candidates)
+    return _existing_files(candidates) + _existing_files(_uv_project_config())
 
 
 def _hardened_pip_config_paths() -> "list[str]":
@@ -4966,43 +5005,71 @@ _PIP_SECTION_RANK = {"global": 0, "install": 1, "download": 1, "wheel": 1}
 _PIP_COMMANDS = ("install", "download", "wheel")
 
 
-def _hardened_settings_in_ini(text: str) -> "dict[str, str]":
-    """Hardened settings from a pip.conf, resolved per subcommand then combined.
+def _hardened_settings_by_command(text: str) -> "dict[str, dict[str, str]]":
+    """Hardened settings from a pip.conf, kept separate for each subcommand.
 
-    A control counts as configured if any of install/download/wheel configures it, and as
-    ON if any of them enables it: this module runs all three, and the caller only needs to
-    know whether the operator has an opinion, not which subcommand carries it.
-
-    Values rather than a filtered list of on-keys, because precedence is resolved across
-    files too: a later pip.conf setting `require-hashes = false` has to be able to cancel
-    an earlier one, and a caller that only ever saw the enabled keys could not do that.
+    Per command rather than combined, because precedence runs file by file and pip
+    resolves each command on its own: a user file's `[install] require-hashes = true`
+    and a site file's `[wheel] require-hashes = false` are two policies, and collapsing
+    each file before the next overwrites it loses the first entirely, reporting an
+    unhardened host while pip still hash-checks every install.
     """
     parser = configparser.RawConfigParser()
     try:
         parser.read_string(text)
     except configparser.Error:
-        return {}
+        return {command: {} for command in _PIP_COMMANDS}
 
     def _section(name: str) -> "dict[str, str]":
         values = {}
-        for key in _HARDENED_CONFIG_KEYS:
+        for key in _PIP_CONFIG_KEYS:
             if parser.has_option(name, key):
                 values[key] = parser.get(name, key, fallback = "")
         return values
 
     sections = {name.strip().lower(): name for name in parser.sections()}
     base = _section(sections["global"]) if "global" in sections else {}
-    combined: dict[str, str] = {}
+    resolved = {}
     for command in _PIP_COMMANDS:
         effective = dict(base)
         if command in sections:
             effective.update(_section(sections[command]))
-        for key, value in effective.items():
+        resolved[command] = effective
+    return resolved
+
+
+def _combine_pip_commands(
+    per_command: "dict[str, dict[str, tuple[str, str]]]",
+) -> "dict[str, tuple[str, str]]":
+    """One answer from the three subcommands' resolved (source, value) settings.
+
+    A control counts as configured if any of install/download/wheel configures it, and as
+    ON if any of them enables it: this module runs all three, and the caller only needs to
+    know whether the operator has an opinion, not which subcommand carries it. The source
+    travels with the value so the notice names the file the winning setting came from.
+    """
+    combined: "dict[str, tuple[str, str]]" = {}
+    for command in _PIP_COMMANDS:
+        for key, entry in per_command.get(command, {}).items():
             # An enabled value anywhere among the three wins; otherwise keep a disabled
             # one so it can still cancel a lower-precedence file.
-            if key not in combined or _config_value_is_on(value):
-                combined[key] = value
+            if key not in combined or _config_value_is_on(entry[1]):
+                combined[key] = entry
     return combined
+
+
+def _hardened_settings_in_ini(text: str) -> "dict[str, str]":
+    """Hardened settings from a single pip.conf, resolved per subcommand then combined.
+
+    Values rather than a filtered list of on-keys, because precedence is resolved across
+    files too: a later pip.conf setting `require-hashes = false` has to be able to cancel
+    an earlier one, and a caller that only ever saw the enabled keys could not do that.
+    """
+    tagged = {
+        command: {key: ("", value) for key, value in values.items()}
+        for command, values in _hardened_settings_by_command(text).items()
+    }
+    return {key: value for key, (_source, value) in _combine_pip_commands(tagged).items()}
 
 
 def _hardened_keys_in_ini(text: str) -> "list[str]":
@@ -5064,6 +5131,13 @@ def _policy_scan() -> "tuple[tuple[tuple[str, str, str], ...], dict[str, frozens
     cancelled: "dict[str, set[str]]" = {"pip": set(), "uv": set()}
 
     def _record(tool: str, source: str, key: str, value: str) -> None:
+        if source == "env" and not value.strip():
+            # pip drops empty environment values before applying precedence, so
+            # PIP_ONLY_BINARY='' neither enables a control nor cancels a pip.conf that
+            # does: measured with pip 26.2.1, the empty variable still rejects an sdist
+            # under `only-binary = :all:` while `:none:` clears it. Treating it as a
+            # cancellation suppressed a policy that was still fully in force.
+            return
         canonical = _canonical_policy_key(key)
         configured[tool].add(canonical)
         if _config_value_is_on(value):
@@ -5075,8 +5149,12 @@ def _policy_scan() -> "tuple[tuple[tuple[str, str, str], ...], dict[str, frozens
 
     for name in _PM_POLICY_ENV_VARS:
         raw = os.environ.get(name)
-        if raw is not None:
-            _record("pip" if name.startswith("PIP_") else "uv", "env", name, raw.strip())
+        if raw is None:
+            continue
+        if name.startswith("UV_") and name not in _UV_ENFORCED_ENV_VARS:
+            # uv ignores it, so it is not policy. See _UV_ENFORCED_ENV_VARS.
+            continue
+        _record("pip" if name.startswith("PIP_") else "uv", "env", name, raw.strip())
 
     try:
         result = subprocess.run(
@@ -5105,32 +5183,49 @@ def _policy_scan() -> "tuple[tuple[tuple[str, str, str], ...], dict[str, frozens
                 continue
             section, _, option = name.strip().rpartition(".")
             section = section.strip().lower()
-            if option not in _HARDENED_CONFIG_KEYS:
+            if option not in _PIP_CONFIG_KEYS:
                 continue
             value = raw.strip().strip("'\"")
             if section == "global":
                 globals_[option] = value
             elif section in per_command:
                 per_command[section][option] = value
-        for command in _PIP_COMMANDS:
-            effective = dict(globals_)
-            effective.update(per_command[command])
-            for option, value in effective.items():
-                if option not in pip_settings or _config_value_is_on(value):
-                    pip_settings[option] = ("pip.conf", value)
+        tagged = {
+            command: {
+                option: ("pip.conf", value)
+                for option, value in dict(globals_, **per_command[command]).items()
+            }
+            for command in _PIP_COMMANDS
+        }
+        pip_settings.update(_combine_pip_commands(tagged))
     else:
         # No usable pip, so read pip's files directly rather than report an ordinary
-        # machine. They come back in pip's own load order, so a later file wins.
+        # machine. They come back in pip's own load order, so a later file wins -- per
+        # subcommand, which is why each one is carried across the files and only combined
+        # at the end. Collapsing a file before reading the next let a `[wheel]` setting in
+        # a low-priority file erase an `[install]` one pip still applies.
+        by_command: "dict[str, dict[str, tuple[str, str]]]" = {
+            name: {} for name in _PIP_COMMANDS
+        }
         for path in _hardened_pip_config_paths():
             text = _read_text(path)
             if text is None:
                 continue
-            for key, value in _hardened_settings_in_ini(text).items():
-                pip_settings[key] = (os.path.basename(path), value)
+            source = os.path.basename(path)
+            for command, values in _hardened_settings_by_command(text).items():
+                by_command[command].update(
+                    {key: (source, value) for key, value in values.items()}
+                )
+        pip_settings.update(_combine_pip_commands(by_command))
     for key, (source, value) in pip_settings.items():
         if _canonical_policy_key(key) not in cancelled["pip"]:
             _record("pip", source, key, value)
 
+    # uv's files come back lowest precedence first, so a higher one simply overwrites:
+    # a project `[tool.uv.pip] require-hashes = false` is uv's effective answer even
+    # where the user config turned it on, and reporting the user value regardless made
+    # a later pip step refuse over a gap uv was not actually enforcing.
+    uv_settings: "dict[str, tuple[str, str, str]]" = {}
     for path in _hardened_uv_config_paths():
         text = _read_text(path)
         if text is None:
@@ -5141,8 +5236,10 @@ def _policy_scan() -> "tuple[tuple[tuple[str, str, str], ...], dict[str, frozens
             else ((), ("pip",))
         )
         for key, value in _hardened_settings_in_toml(text, tables).items():
-            if _canonical_policy_key(key) not in cancelled["uv"]:
-                _record("uv", os.path.basename(path), key, value)
+            uv_settings[_canonical_policy_key(key)] = (os.path.basename(path), key, value)
+    for canonical, (source, key, value) in uv_settings.items():
+        if canonical not in cancelled["uv"]:
+            _record("uv", source, key, value)
 
     return tuple(dict.fromkeys(on)), {tool: frozenset(keys) for tool, keys in configured.items()}
 
@@ -5208,16 +5305,16 @@ def _unenforceable_policy(cmd: "list[str]") -> "list[str]":
     return sorted(missing)
 
 
+# What to tell the operator to set, per manager. The uv side names a uv.toml key wherever
+# uv has no environment spelling for the control: measured on the pinned uv 0.12.1,
+# UV_NO_BUILD and UV_NO_BINARY are ignored, so naming them would send someone round the
+# same loop a second time. Only require-hashes and exclude-newer are settable from the
+# environment there.
 _POLICY_EQUIVALENTS = {
-    "require-hashes": ("PIP_REQUIRE_HASHES", "UV_REQUIRE_HASHES"),
-    "only-binary": ("PIP_ONLY_BINARY", "UV_NO_BUILD / UV_NO_BUILD_PACKAGE"),
-    "no-binary": ("PIP_NO_BINARY", "UV_NO_BINARY / UV_NO_BINARY_PACKAGE"),
-    "no-build": ("PIP_ONLY_BINARY", "UV_NO_BUILD"),
-    "no-build-package": ("PIP_ONLY_BINARY", "UV_NO_BUILD_PACKAGE"),
-    "no-binary-package": ("PIP_NO_BINARY", "UV_NO_BINARY_PACKAGE"),
+    "require-hashes": ("PIP_REQUIRE_HASHES=1", "UV_REQUIRE_HASHES=1"),
+    "no-build": ("PIP_ONLY_BINARY=:all:", "no-build = true in your uv.toml"),
+    "no-binary": ("PIP_NO_BINARY=:all:", "no-binary = true in your uv.toml"),
     "exclude-newer": ("PIP_UPLOADED_PRIOR_TO", "UV_EXCLUDE_NEWER"),
-    "exclude-newer-package": ("", "UV_EXCLUDE_NEWER_PACKAGE"),
-    "uploaded-prior-to": ("PIP_UPLOADED_PRIOR_TO", "UV_EXCLUDE_NEWER"),
 }
 
 
@@ -5267,8 +5364,10 @@ def _announce_pm_policy() -> None:
     _note(
         f"Package manager hardening detected ({listed}). Unsloth relaxes it for its own "
         "dependency installs only -- the shipped requirements are unhashed and a few have "
-        "no wheel at any version -- and never for your other pip commands. Set "
-        f"{_POLICY_OPT_OUT_ENV}=1 to keep your policy in force instead.",
+        "no wheel at any version -- and never for your other pip commands. A uv setting "
+        "still applies to the few steps that do not pin an index, since uv has no "
+        "per-command override for one. Set "
+        f"{_POLICY_OPT_OUT_ENV}=1 to keep your policy in force everywhere instead.",
         _cyan,
     )
 

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -4836,7 +4836,64 @@ def _env_policy_key(name: str) -> str:
 _PIP_COMMANDS = ("install", "download", "wheel")
 
 
-@functools.lru_cache(maxsize = 1)
+def _pip_config_settings() -> "dict[tuple[str, str], str]":
+    """`pip config list`, parsed into {(section, option): value}.
+
+    Memoised, but ONLY once the probe has actually reached pip. A fresh uv venv has no
+    pip when the notice runs, and caching that emptiness meant a later step still saw
+    "nothing configured" after pip had been bootstrapped, which scrubbed PIP_FIND_LINKS
+    out of a pinned command whose only source it was. A probe that cannot import pip
+    fails immediately rather than sitting out the timeout, so retrying is cheap.
+    """
+    cached = getattr(_pip_config_settings, "_cache", None)
+    if cached is not None:
+        return cached
+    try:
+        result = subprocess.run(
+            [sys.executable, "-m", "pip", "config", "list"],
+            stdout = subprocess.PIPE,
+            stderr = subprocess.DEVNULL,
+            # Bounded because this runs BEFORE the pip upgrade, against a venv that may
+            # have no pip at all. A notice must never be able to hang an install.
+            timeout = 30,
+            **_windows_hidden_subprocess_kwargs(),
+        )
+    except (OSError, subprocess.SubprocessError):
+        result = None
+    if result is None or result.returncode != 0:
+        return {}
+    settings: "dict[tuple[str, str], str]" = {}
+    for line in (result.stdout or b"").decode("utf-8", "replace").splitlines():
+        name, separator, raw = line.partition("=")
+        # `:env:` entries restate the environment, which callers read directly.
+        if not separator or name.strip().startswith(":env:"):
+            continue
+        # Section verbatim, option normalised: that is the split pip itself makes,
+        # so `[INSTALL]` is a section it never selects.
+        section, _, option = name.strip().rpartition(".")
+        option = option.strip().lower().replace("_", "-")
+        if section not in ("global",) + _PIP_COMMANDS or option not in _PIP_CONFIG_KEYS:
+            continue
+        # Printed in load order, so the last definition of a given entry wins.
+        settings[(section, option)] = raw.strip().strip("'\"")
+    _pip_config_settings._cache = settings
+    return settings
+
+
+_pip_config_settings._cache = None
+
+
+def _pip_setting_is_on(settings: "dict[tuple[str, str], str]", command: str, option: str) -> bool:
+    """Is `option` on for `command`, with the command's own section beating [global]?
+
+    A command-prefixed key affects only the named command, so these must not be pooled:
+    a `[download] no-index = true` says nothing about `pip install`, and collapsing the
+    two let an install keep a find-links location that is additive for it.
+    """
+    value = settings.get((command, option), settings.get(("global", option)))
+    return value is not None and _config_value_is_on(value, option)
+
+
 def _detected_policy() -> "tuple[tuple[str, str, str], ...]":
     """(tool, source, key) for each hardening this host has configured.
 
@@ -4871,50 +4928,31 @@ def _detected_policy() -> "tuple[tuple[str, str, str], ...]":
             # variable cancels a config entry enabling the same control.
             cancelled.add(_canonical_policy_key(name))
 
-    try:
-        result = subprocess.run(
-            [sys.executable, "-m", "pip", "config", "list"],
-            stdout = subprocess.PIPE,
-            stderr = subprocess.DEVNULL,
-            # Bounded because this runs BEFORE the pip upgrade, against a venv that may
-            # have no pip at all. A notice must never be able to hang an install.
-            timeout = 30,
-            **_windows_hidden_subprocess_kwargs(),
-        )
-    except (OSError, subprocess.SubprocessError):
-        result = None
-    if result is not None and result.returncode == 0:
-        settings: "dict[tuple[str, str], str]" = {}
-        for line in (result.stdout or b"").decode("utf-8", "replace").splitlines():
-            name, separator, raw = line.partition("=")
-            # `:env:` entries restate the environment, already handled above.
-            if not separator or name.strip().startswith(":env:"):
-                continue
-            # Section verbatim, option normalised: that is the split pip itself makes,
-            # so `[INSTALL]` is a section it never selects.
-            section, _, option = name.strip().rpartition(".")
-            option = option.strip().lower().replace("_", "-")
-            if section not in ("global",) + _PIP_COMMANDS or option not in _PIP_CONFIG_KEYS:
-                continue
-            # Printed in load order, so the last definition of a given entry wins.
-            settings[(section, option)] = raw.strip().strip("'\"")
-        # pip applies `[global]` and then the command's own section, so a control the
-        # operator enabled globally and disabled for install, download AND wheel is not
-        # hardening any command this module runs. Reporting it there put the notice in
-        # front of someone whose policy was not being relaxed at all.
-        for option in _PIP_CONFIG_KEYS:
-            if _canonical_policy_key(option) in cancelled:
-                continue
-            for command in _PIP_COMMANDS:
-                value = settings.get((command, option), settings.get(("global", option)))
-                if value is not None and _config_value_is_on(value, option):
-                    on.append(("pip", "pip.conf", option))
-                    break
+    settings = _pip_config_settings()
+    # pip applies `[global]` and then the command's own section, so a control the
+    # operator enabled globally and disabled for install, download AND wheel is not
+    # hardening any command this module runs. Reporting it there put the notice in
+    # front of someone whose policy was not being relaxed at all.
+    for option in _PIP_CONFIG_KEYS:
+        if _canonical_policy_key(option) in cancelled:
+            continue
+        for command in _PIP_COMMANDS:
+            if _pip_setting_is_on(settings, command, option):
+                on.append(("pip", "pip.conf", option))
+                break
 
     return tuple(dict.fromkeys(on))
 
 
-def _pip_no_index_in_force() -> bool:
+def _clear_detected_policy_cache() -> None:
+    """Drop the memoised `pip config list`. Kept under the name the callers already use."""
+    _pip_config_settings._cache = None
+
+
+_detected_policy.cache_clear = _clear_detected_policy_cache
+
+
+def _pip_no_index_in_force(command: str = "install") -> bool:
     """Is pip's no-index effectively ON, counting the config file as well as the env?
 
     `--no-index` means "ignore the indexes and look only at find-links", so whether
@@ -4935,9 +4973,11 @@ def _pip_no_index_in_force() -> bool:
     raw = os.environ.get("PIP_NO_INDEX")
     if raw is not None and raw.strip():
         return _config_value_is_on(raw, "no-index")
-    return any(
-        source == "pip.conf" and key == "no-index" for _tool, source, key in _detected_policy()
-    )
+    # For the COMMAND being run. A command-prefixed key affects only the command it
+    # names, so a `[download] no-index = true` says nothing about `pip install`, and
+    # answering from the pooled reading let an install keep a find-links location that
+    # is purely additive for it.
+    return _pip_setting_is_on(_pip_config_settings(), command, "no-index")
 
 
 def _hardened_pm_policy_names() -> "tuple[str, ...]":

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -5226,9 +5226,7 @@ def _policy_scan() -> "tuple[tuple[tuple[str, str, str], ...], dict[str, frozens
         # a section, which is why every file's sections are pooled and only resolved
         # against each other at the end. Collapsing a file before reading the next let a
         # low-priority setting erase a higher-priority one pip still applies.
-        pooled: "dict[str, dict[str, tuple[str, str]]]" = {
-            name: {} for name in _PIP_SECTIONS
-        }
+        pooled: "dict[str, dict[str, tuple[str, str]]]" = {name: {} for name in _PIP_SECTIONS}
         for path in _hardened_pip_config_paths():
             text = _read_text(path)
             if text is None:

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -12,7 +12,6 @@ activated. Expects `pip` and `python` on PATH to point at the venv.
 from __future__ import annotations
 
 import ast
-import configparser
 import functools
 import glob
 import importlib
@@ -30,10 +29,6 @@ import textwrap
 import urllib.request
 from pathlib import Path
 
-try:  # 3.11+. Only the hardening notice uses it, and it degrades to a regex without it.
-    import tomllib as _tomllib
-except ImportError:  # pragma: no cover - exercised on 3.9/3.10 interpreters
-    _tomllib = None
 
 _STUDIO_DIR = Path(__file__).resolve().parent
 _BACKEND_DIR = _STUDIO_DIR / "backend"
@@ -4704,21 +4699,7 @@ def _relaxed_pip_policy_env(cmd: "list[str]") -> "dict[str, str]":
 # the operator sees which control is being set aside. `exclude-newer` is here for the same
 # reason UV_EXCLUDE_NEWER is in _PM_POLICY_ENV_VARS: an upload cutoff is a reproducibility
 # control, and relaxing one silently is what this notice exists to stop.
-_HARDENED_CONFIG_KEYS = (
-    "require-hashes",
-    "only-binary",
-    "no-binary",
-    "no-binary-package",
-    "no-build",
-    "no-build-package",
-    "exclude-newer",
-    "exclude-newer-package",
-    # pip's own spelling of the same control, so a pip-side cutoff is detected too.
-    "uploaded-prior-to",
-)
-
-
-# Of that list, the keys pip itself has an option for. Measured with pip 26.2.1:
+# The keys pip itself has an option for. Measured with pip 26.2.1:
 # `pip install --help` exposes --require-hashes, --only-binary, --no-binary and
 # --uploaded-prior-to, and nothing for no-build, either -package form or exclude-newer.
 # A pip.conf carrying one of those is an inert entry pip ignores, so reading it as pip
@@ -4763,533 +4744,9 @@ def _config_value_is_on(value: str, key: "str | None" = None) -> bool:
     return text not in _OFF_VALUES
 
 
-def _toml_value_is_on(value: object) -> bool:
-    """The same test for a TOML value, parsed or still in its source spelling.
 
-    `no-build = false` is an ordinary machine, and a list policy switched off is spelled
-    as the empty list, so neither may be reported as active hardening. The empty-collection
-    spellings are handled as text too, because the regex fallback never parses them.
-    """
-    if isinstance(value, bool):
-        return value
-    if isinstance(value, (list, tuple, dict)):
-        return bool(value)
-    text = str(value).strip()
-    if re.fullmatch(r"\[\s*\]|\{\s*\}", text):
-        return False
-    return _config_value_is_on(text)
-
-
-def _toml_value_text(value: object) -> str:
-    """A TOML value as the string the translator works with.
-
-    A list becomes its space-separated members, which is uv's own spelling for the
-    package-scoped controls and the form the pip translation re-splits.
-    """
-    if isinstance(value, bool):
-        # Empty for False, so a TOML boolean stays off whatever the key's type is. A
-        # list-valued control reads any other value as a package name, and "0" would be
-        # one: this is the one place the type is still known, so it is settled here.
-        return "1" if value else ""
-    if isinstance(value, (list, tuple)):
-        return " ".join(str(item).strip() for item in value if str(item).strip())
-    if isinstance(value, dict):
-        # The package-scoped maps, e.g. `exclude-newer-package = { foo = "..." }`. Its
-        # members, so an EMPTY map becomes the empty string and reads as off: str({})
-        # is "{}", which is not one of the off spellings and became phantom hardening.
-        return " ".join(str(item).strip() for item in value if str(item).strip())
-    return str(value).strip()
-
-
-def _inline_table_lines(key: str, body: str) -> "list[str]":
-    """`a = { b = 1, c = { d = 2 } }` as the dotted lines `a.b = 1` and `a.c.d = 2`.
-
-    Only the pre-3.11 fallback needs this; tomllib builds the nesting itself. Without it
-    a `[tool] uv = { pip = { require-hashes = true } }` was skipped entirely, and uv
-    0.12.1 does enforce exactly that.
-    """
-    parts: "list[str]" = []
-    current = ""
-    depth = 0
-    for char in body:
-        if char in "{[":
-            depth += 1
-        elif char in "}]":
-            depth -= 1
-        elif char == "," and depth == 0:
-            parts.append(current)
-            current = ""
-            continue
-        current += char
-    parts.append(current)
-    lines: "list[str]" = []
-    for part in parts:
-        name, separator, raw = part.partition("=")
-        if not separator:
-            continue
-        name = name.strip().strip("\"'")
-        raw = raw.strip()
-        if raw.startswith("{") and raw.endswith("}") and raw[1:-1].strip():
-            lines.extend(_inline_table_lines(f"{key}.{name}", raw[1:-1]))
-        else:
-            lines.append(f"{key}.{name} = {raw}")
-    return lines
-
-
-def _hardened_settings_in_toml(
-    text: str, tables: "tuple[tuple[str, ...], ...]"
-) -> "dict[str, str]":
-    """Hardened keys and their values inside the named tables of a TOML document."""
-    settings: dict[str, str] = {}
-    data = None
-    if _tomllib is not None:
-        try:
-            data = _tomllib.loads(text)
-        except Exception:
-            data = None
-    if data is not None:
-        for table in tables:
-            node: object = data
-            for part in table:
-                node = node.get(part) if isinstance(node, dict) else None
-                if node is None:
-                    break
-            if not isinstance(node, dict):
-                continue
-            for key in _HARDENED_CONFIG_KEYS:
-                if key in node:
-                    settings[key] = _toml_value_text(node[key])
-        return settings
-    current: "tuple[str, ...]" = ()
-    # Join continuation lines first: tomllib is absent here, and a `no-build-package = [`
-    # spread over several lines would otherwise read as the literal value "[".
-    joined: "list[str]" = []
-    pending = ""
-    for raw_line in text.splitlines():
-        piece = raw_line.split("#", 1)[0].rstrip() if "=" in raw_line or pending else raw_line
-        if pending:
-            pending += " " + piece.strip()
-            if pending.count("[") <= pending.count("]"):
-                joined.append(pending)
-                pending = ""
-            continue
-        stripped = piece.strip()
-        if stripped.count("[") > stripped.count("]") and "=" in stripped:
-            pending = stripped
-            continue
-        # `piece`, not the raw line: the comment has already been taken off it, and
-        # keeping it made `no-build = false # disabled` read as the value
-        # "false # disabled", which is not one of the off spellings and so reported a
-        # policy the operator had switched off.
-        joined.append(piece)
-    if pending:
-        joined.append(pending)
-    # Inline tables become dotted keys, which the loop below already understands.
-    expanded: "list[str]" = []
-    for line in joined:
-        name, separator, raw = line.strip().partition("=")
-        raw = raw.strip()
-        if separator and raw.startswith("{") and raw.endswith("}") and raw[1:-1].strip():
-            expanded.extend(_inline_table_lines(name.strip().strip("\"'"), raw[1:-1]))
-        else:
-            expanded.append(line)
-    for line in expanded:
-        stripped = line.strip()
-        if stripped.startswith("#") or not stripped:
-            continue
-        header = re.match(r"^\[\[?([^]]*)\]\]?$", stripped)
-        if header:
-            current = tuple(
-                part.strip().strip("\"'") for part in header.group(1).split(".") if part.strip()
-            )
-            continue
-        key, separator, raw = stripped.partition("=")
-        if not separator:
-            continue
-        key = key.strip().strip("\"'")
-        # A dotted key is the inline spelling of a table: `pip.require-hashes = true` at
-        # the root is `[pip] require-hashes = true`, which uv enforces. The table check
-        # has to come AFTER the path is assembled, since the enclosing header can be a
-        # prefix of it rather than a table this scan reads: under `[tool]`, the expanded
-        # `uv.pip.require-hashes` lives in `tool.uv.pip`, which it does read.
-        head, dot, tail = key.rpartition(".")
-        path = current + tuple(
-            part.strip().strip("\"'") for part in head.split(".") if part.strip()
-        )
-        if path not in tables:
-            continue
-        if dot:
-            key = tail.strip().strip("\"'")
-        if key in _HARDENED_CONFIG_KEYS:
-            raw = raw.strip()
-            if re.fullmatch(r"\[\s*\]|\{\s*\}", raw):
-                raw = ""
-            elif raw.startswith("[") and raw.endswith("]"):
-                raw = " ".join(
-                    item.strip().strip("\"'")
-                    for item in raw[1:-1].split(",")
-                    if item.strip().strip("\"'")
-                )
-            settings[key] = raw.strip().strip("\"'")
-    return settings
-
-
-def _hardened_keys_in_toml(text: str, tables: "tuple[tuple[str, ...], ...]") -> "list[str]":
-    """Hardened keys switched ON inside the named tables of a TOML document.
-
-    `tables` scopes the search, so a stray `no-build` in an unrelated tool's table is not
-    read as uv policy. Both the tomllib path and the pre-3.11 fallback test the VALUE,
-    since reporting `no-build = false` would put a security notice in front of a user who
-    switched the policy off.
-    """
-    return [
-        key
-        for key, value in _hardened_settings_in_toml(text, tables).items()
-        if _config_value_is_on(value, key)
-    ]
-
-
-def _existing_files(candidates: "list[str]") -> "list[str]":
-    found = []
-    for path in candidates:
-        try:
-            if os.path.isfile(path):
-                found.append(path)
-        except OSError:
-            # A path this process cannot stat (permissions, a dead network mount) is
-            # simply not a config file we can report on.
-            continue
-    return found
-
-
-def _explicit_uv_config_path() -> str:
-    """UV_CONFIG_FILE as uv resolves it, or "" when it is not set.
-
-    Shared so the schema decision downstream compares the SAME path this returns: it
-    used to test the raw environment value, so a relative explicit file resolved through
-    UV_WORKING_DIR stopped matching and an explicit `pyproject.toml` was then read with
-    the discovered-project schema instead of the standalone one.
-    """
-    explicit = os.environ.get("UV_CONFIG_FILE", "").strip()
-    if not explicit:
-        return ""
-    working = os.environ.get("UV_WORKING_DIR", "").strip()
-    if working and not os.path.isabs(explicit):
-        # --directory changes directory BEFORE running, so a relative config path is
-        # resolved there and not against the directory the installer started in.
-        return os.path.join(working, explicit)
-    return explicit
-
-
-def _declares_uv_workspace(path: str) -> bool:
-    """True when this pyproject.toml declares a uv workspace.
-
-    Only the declaration matters here, not whether the member the walk stopped at is
-    listed in it: matching uv's member globs is more machinery than a best-effort notice
-    warrants, and an ancestor that declares a workspace over a project beneath it is
-    overwhelmingly that project's root.
-    """
-    text = _read_text(path)
-    if text is None:
-        return False
-    if _tomllib is not None:
-        try:
-            data = _tomllib.loads(text)
-        except Exception:
-            return False
-        node = data.get("tool") if isinstance(data, dict) else None
-        node = node.get("uv") if isinstance(node, dict) else None
-        return isinstance(node, dict) and "workspace" in node
-    return bool(re.search(r"^\s*\[tool\.uv\.workspace[\].]", text, re.MULTILINE))
-
-
-def _uv_project_config() -> "list[str]":
-    """The project configuration uv would discover from the working directory.
-
-    Measured on the pinned uv 0.12.1: uv walks up from the working directory to the
-    nearest ancestor holding a `pyproject.toml` and reads a `uv.toml` beside it if there
-    is one, otherwise that file's `[tool.uv]` tables. A parent `[tool.uv.pip]
-    require-hashes = true` fails an install run from a child directory, which is how
-    Studio is normally launched, so stopping at the working directory alone missed real
-    policy. A `uv.toml` with no `pyproject.toml` beside it is read nowhere, working
-    directory included, so it is not listed: reporting one would be hardening uv does
-    not apply.
-    """
-    # uv's own discovery root, not necessarily this process's: --project / UV_PROJECT
-    # moves it, and --directory / UV_WORKING_DIR moves the working directory itself.
-    # Measured on the pinned uv 0.12.1, a `[tool.uv.pip] require-hashes = true` in a
-    # project named by either variable is enforced from an unrelated cwd, so walking
-    # from getcwd() alone scanned the wrong tree and missed live policy.
-    working = os.environ.get("UV_WORKING_DIR", "").strip()
-    root = os.environ.get("UV_PROJECT", "").strip()
-    if root and working and not os.path.isabs(root):
-        # --directory takes effect first, so a relative --project resolves against it.
-        root = os.path.join(working, root)
-    try:
-        # A deleted working directory raises here rather than returning anything.
-        current = os.path.abspath(root or working or os.getcwd())
-    except OSError:
-        return []
-    found = ""
-    while True:
-        if _existing_files([os.path.join(current, "pyproject.toml")]):
-            if not found:
-                found = current
-            elif _declares_uv_workspace(os.path.join(current, "pyproject.toml")):
-                # A workspace ROOT outranks the member the walk stopped at: measured on
-                # the pinned uv 0.12.1, from root/member/sub it logs "Found workspace
-                # configuration at root/pyproject.toml" and enforces the root's policy.
-                found = current
-                break
-        parent = os.path.dirname(current)
-        if parent == current:
-            # The root is its own parent, which is how this walk terminates.
-            break
-        current = parent
-    if not found:
-        return []
-    local = _existing_files([os.path.join(found, "uv.toml")])
-    return local or [os.path.join(found, "pyproject.toml")]
-
-
-def _hardened_uv_config_paths() -> "list[str]":
-    """The uv config files this host has, in uv's own precedence order, lowest first.
-
-    System (`/etc/uv/uv.toml`, `%PROGRAMDATA%\\uv`), then user (`~/.config/uv/uv.toml` on
-    macOS AND Linux, not Application Support, and `%APPDATA%\\uv` on Windows), then the
-    project. The system one matters most for a fleet operator hardening every machine;
-    the order matters because the caller resolves last-wins, and a project config
-    switching a control off is uv's answer even when the user config switched it on.
-    """
-    explicit = _explicit_uv_config_path()
-    if explicit:
-        # --config-file is used "in place of any discovered configuration files", so the
-        # discovered set is not merely outranked, it is not read at all. Checked BEFORE
-        # --no-config: measured on the pinned uv 0.12.1, an explicit file is read with
-        # UV_NO_CONFIG=1 set as well, so returning nothing there dropped live policy.
-        return _existing_files([explicit])
-    if _config_value_is_on(os.environ.get("UV_NO_CONFIG", "")):
-        # --no-config: uv discovers nothing, so nothing here is policy.
-        return []
-    candidates = []
-    if IS_WINDOWS:
-        for variable in ("PROGRAMDATA", "APPDATA"):
-            base = os.environ.get(variable, "")
-            if base:
-                candidates.append(os.path.join(base, "uv", "uv.toml"))
-    else:
-        candidates.append("/etc/uv/uv.toml")
-        # XDG_CONFIG_HOME next: uv honours it, and a host that sets it does not
-        # necessarily have ~/.config at all.
-        base = os.environ.get("XDG_CONFIG_HOME") or os.path.expanduser("~/.config")
-        candidates.append(os.path.join(base, "uv", "uv.toml"))
-    return _existing_files(candidates) + _existing_files(_uv_project_config())
-
-
-def _hardened_pip_config_paths() -> "list[str]":
-    """pip's documented configuration files, for when `python -m pip` cannot be run.
-
-    install.sh builds the venv with uv, which seeds no pip, so when this notice runs
-    `pip config list` returns nonzero and a require-hashes living only in pip.conf is
-    invisible -- while the pip FALLBACK later in the install reads it fine. Order is pip's
-    own (global, user, site, PIP_CONFIG_FILE); the subprocess answer still wins when it
-    works, since pip merges them itself.
-    """
-    # Within the user kind, pip's get_configuration_files returns
-    # [legacy_config_file, new_config_file] and loads them in that order, so the modern
-    # location is authoritative. Listing it first put the legacy file last and let
-    # ~/.pip/pip.conf override ~/.config/pip/pip.conf, which is the opposite of pip.
-    name = "pip.ini" if IS_WINDOWS else "pip.conf"
-    explicit = os.environ.get("PIP_CONFIG_FILE", "").strip()
-    if explicit and os.path.normcase(explicit) == os.path.normcase(os.devnull):
-        # Documented: PIP_CONFIG_FILE=os.devnull disables the loading of ALL config files.
-        return []
-    # pip's iter_config_files: "per-user config is not loaded when env_config_file
-    # exists". Scanning them anyway invents a policy pip would not apply, which under the
-    # opt-out gets translated into the other manager and fails the install.
-    skip_user = bool(explicit) and os.path.isfile(explicit)
-    candidates = []
-    user: "list[str]" = []
-    if IS_WINDOWS:
-        # pip's legacy user file, still in get_configuration_files(): "pip" on Windows,
-        # ".pip" elsewhere, under the expanded home. First, so %APPDATA% outranks it.
-        user.append(os.path.join(os.path.expanduser("~"), "pip", name))
-        for variable in ("PROGRAMDATA", "APPDATA"):
-            base = os.environ.get(variable, "")
-            if base:
-                target = candidates if variable == "PROGRAMDATA" else user
-                target.append(os.path.join(base, "pip", name))
-    else:
-        # Global is EVERY entry of XDG_CONFIG_DIRS, not just the default: measured with
-        # pip 26, `XDG_CONFIG_DIRS=/a:/b pip config debug` enumerates /a/pip/pip.conf and
-        # /b/pip/pip.conf. macOS reads its global set from XDG_DATA_DIRS instead, falling
-        # back to /Library/Application Support.
-        #
-        # macOS reads BOTH here, deliberately, because pip changed under us: measured,
-        # pip 26.1 resolves the Darwin global set to /Library/Application Support and
-        # ignores XDG_DATA_DIRS entirely, while 26.2.1 lets XDG_DATA_DIRS replace it.
-        # Either pip can be the one on a user's machine, and a location that only one of
-        # them reads costs a stat, so both are scanned rather than guessing the version.
-        directories = os.environ.get("XDG_DATA_DIRS" if IS_MACOS else "XDG_CONFIG_DIRS", "").strip()
-        if IS_MACOS:
-            if "/opt/python" in sys.prefix:
-                # platformdirs puts a Homebrew python's site data under the brew prefix.
-                candidates.append(
-                    os.path.join(sys.prefix.split("/opt/python")[0], "share", "pip", name)
-                )
-            candidates.append(os.path.join("/Library", "Application Support", "pip", name))
-        if directories:
-            for directory in directories.split(os.pathsep):
-                if directory.strip():
-                    candidates.append(os.path.join(directory.strip(), "pip", name))
-        elif not IS_MACOS:
-            candidates.append(os.path.join("/etc", "xdg", "pip", name))
-        candidates.append(os.path.join("/etc", name))
-        home = os.path.expanduser("~")
-        user.append(os.path.join(home, ".pip", name))
-        xdg = os.environ.get("XDG_CONFIG_HOME") or os.path.join(home, ".config")
-        user.append(os.path.join(xdg, "pip", name))
-        if IS_MACOS:
-            # user_config_dir on macOS, so it is the modern file there and goes last.
-            user.append(os.path.join(home, "Library", "Application Support", "pip", name))
-    if not skip_user:
-        candidates.extend(user)
-    # Site, then the explicit file: pip's own load order, which is what makes the
-    # last-wins resolution downstream correct.
-    site = os.environ.get("VIRTUAL_ENV", "") or sys.prefix
-    if site:
-        candidates.append(os.path.join(site, name))
-    if explicit:
-        candidates.append(explicit)
-    return _existing_files(candidates)
-
-
-# pip applies `[global]` first and then the command's own section, whatever order they
-# appear in the file, so `[install]` beats `[global]` for the commands this module runs.
-# Sections for other commands never apply to an install and are ignored entirely.
-_PIP_SECTION_RANK = {"global": 0, "install": 1, "download": 1, "wheel": 1}
-
-
-# The three pip subcommands this module drives. pip applies `[global]` and then the
-# command's own section, so each of these resolves separately: `[install] require-hashes
-# = true` with `[wheel] require-hashes = false` is two different policies, not one.
-_PIP_COMMANDS = ("install", "download", "wheel")
-
-
-_PIP_SECTIONS = ("global",) + _PIP_COMMANDS
-
-
-def _hardened_pip_sections(text: str) -> "dict[str, dict[str, str]]":
-    """Hardened settings from a pip.conf, one bucket per section and NOT merged.
-
-    Unmerged because pip pools every file's `[global]` into one group and every file's
-    command section into another, and applies global first and the command second only
-    at the end: a `[install]` setting in a low-priority file therefore still beats a
-    `[global]` in a high-priority one. Folding global into the command sections file by
-    file gets that backwards, and let a later `[global] require-hashes = false` erase an
-    earlier `[install] require-hashes = true` pip was still applying.
-
-    Option names are normalised the way pip normalises them, lowercased with underscores
-    turned into dashes: `require_hashes = true` is a spelling pip honours, and
-    RawConfigParser keeps the underscore, so matching the dashed name alone missed it.
-    """
-    sections: "dict[str, dict[str, str]]" = {name: {} for name in _PIP_SECTIONS}
-    parser = configparser.RawConfigParser()
-    try:
-        parser.read_string(text)
-    except configparser.Error:
-        return sections
-    for raw_name in parser.sections():
-        # Verbatim: pip normalises the OPTION name and leaves the SECTION name alone, so
-        # `[INSTALL]` is a section pip never selects. Lowercasing it here reported a
-        # policy pip does not apply, which under the opt-out could refuse the first uv
-        # step over a cross-manager gap that did not exist.
-        name = raw_name
-        if name not in sections:
-            continue
-        for option, value in parser.items(raw_name):
-            key = option.strip().lower().replace("_", "-")
-            if key in _PIP_CONFIG_KEYS:
-                sections[name][key] = value
-    return sections
-
-
-def _combine_pip_commands(
-    per_command: "dict[str, dict[str, tuple[str, str]]]",
-) -> "dict[str, tuple[str, str]]":
-    """One answer from the three subcommands' resolved (source, value) settings.
-
-    A control counts as configured if any of install/download/wheel configures it, and as
-    ON if any of them enables it: this module runs all three, and the caller only needs to
-    know whether the operator has an opinion, not which subcommand carries it. The source
-    travels with the value so the notice names the file the winning setting came from.
-    """
-    combined: "dict[str, tuple[str, str]]" = {}
-    for command in _PIP_COMMANDS:
-        for key, entry in per_command.get(command, {}).items():
-            # An enabled value anywhere among the three wins; otherwise keep a disabled
-            # one so it can still cancel a lower-precedence file.
-            if key not in combined or _config_value_is_on(entry[1], key):
-                combined[key] = entry
-    return combined
-
-
-def _pip_slot(command: str) -> str:
-    """The name a pip subcommand's own configured-policy set is kept under."""
-    return f"pip:{command}"
-
-
-def _resolve_pip_sections(
-    pooled: "dict[str, dict[str, tuple[str, str]]]",
-) -> "dict[str, dict[str, tuple[str, str]]]":
-    """pip's own resolution, per subcommand: `[global]` first, then its own section."""
-    return {
-        command: dict(pooled.get("global", {}), **pooled.get(command, {}))
-        for command in _PIP_COMMANDS
-    }
-
-
-def _combine_pip_sections(
-    pooled: "dict[str, dict[str, tuple[str, str]]]",
-) -> "dict[str, tuple[str, str]]":
-    """The three subcommands' resolved settings, combined into one answer."""
-    return _combine_pip_commands(_resolve_pip_sections(pooled))
-
-
-def _hardened_settings_in_ini(text: str) -> "dict[str, str]":
-    """Hardened settings from a single pip.conf, resolved per subcommand then combined.
-
-    Values rather than a filtered list of on-keys, because precedence is resolved across
-    files too: a later pip.conf setting `require-hashes = false` has to be able to cancel
-    an earlier one, and a caller that only ever saw the enabled keys could not do that.
-    """
-    pooled = {
-        name: {key: ("", value) for key, value in values.items()}
-        for name, values in _hardened_pip_sections(text).items()
-    }
-    return {key: value for key, (_source, value) in _combine_pip_sections(pooled).items()}
-
-
-def _hardened_keys_in_ini(text: str) -> "list[str]":
-    """Hardened keys switched ON in a single pip.conf."""
-    return [
-        key
-        for key, value in _hardened_settings_in_ini(text).items()
-        if _config_value_is_on(value, key)
-    ]
-
-
-def _read_text(path: str) -> "str | None":
-    try:
-        with open(path, encoding = "utf-8", errors = "replace") as handle:
-            return handle.read()
-    except OSError:
-        return None
-
-
-# The same control under each manager's name. This decides "has the target manager got an
-# opinion about this already", so pip's `only-binary` (wheels only) and uv's `no-build`
-# are one control, as are a policy and its package-scoped form.
+# The same control under each manager's name, so an explicitly disabled variable can
+# cancel a config entry that enables the same thing.
 _POLICY_KEY_ALIASES = {
     "uploaded-prior-to": "exclude-newer",
     "exclude-newer-package": "exclude-newer",
@@ -5301,8 +4758,7 @@ _POLICY_KEY_ALIASES = {
 
 def _canonical_policy_key(key: str) -> str:
     """One name per control, whatever spelling it arrived in."""
-    name = _env_policy_key(key) if key.isupper() else key.lower()
-    return _POLICY_KEY_ALIASES.get(name, name)
+    return _POLICY_KEY_ALIASES.get(_policy_key_spelling(key), _policy_key_spelling(key))
 
 
 def _env_policy_key(name: str) -> str:
@@ -5314,63 +4770,48 @@ def _env_policy_key(name: str) -> str:
     return name.split("_", 1)[1].lower().replace("_", "-")
 
 
+# The pip subcommands this module drives.
+_PIP_COMMANDS = ("install", "download", "wheel")
+
 @functools.lru_cache(maxsize = 1)
-def _policy_scan() -> "tuple[tuple[tuple[str, str, str], ...], dict[str, frozenset[str]]]":
-    """Everything the hardening probe found: what is ON, and what each manager has an
-    opinion about at all.
+def _detected_policy() -> "tuple[tuple[str, str, str], ...]":
+    """(tool, source, key) for each hardening this host has configured.
 
-    The second half is what stops a deliberate difference between the two managers being
-    reported as a gap: `PIP_REQUIRE_HASHES=1` next to a uv config saying
-    `[pip] require-hashes = false` is the operator configuring them differently, not uv
-    missing a control.
+    ADVISORY, and deliberately narrow. It reports what the two managers can be ASKED
+    about -- the policy environment variables, and pip's own `pip config list` output --
+    and does not go looking through their configuration files.
 
-    Best-effort throughout: a probe that fails just shortens the answer.
+    Reading those files means reimplementing pip's and uv's configuration resolution:
+    discovery order, per-subcommand sections, precedence between them, XDG against
+    Darwin paths, uv workspace roots, UV_PROJECT / UV_WORKING_DIR / UV_CONFIG_FILE
+    interactions, and a TOML parser for the interpreters with no tomllib. That was
+    tried here and it is an unbounded surface: each round of review found another true
+    difference from the real thing, and some of those corrections introduced their own.
+    Nothing in the actual fix depends on it, so it asks instead of emulating.
+
+    The cost is that a pip.conf-only policy is invisible while the venv has no pip yet,
+    which is the state uv leaves a fresh venv in. The consequence of a miss is a line
+    absent from a notice, never a changed install: the opt-out withholds the relaxations
+    mechanically, whether or not anything was detected.
     """
     on: "list[tuple[str, str, str]]" = []
-    # Slots, not tools: pip resolves each subcommand separately, so `[download]
-    # only-binary = :all:` is not an opinion about `pip install`. Crediting pip with it
-    # let a fallback `pip install` proceed as though the operator's control were covered
-    # when that command was in fact unrestricted.
-    configured: "dict[str, set[str]]" = {
-        slot: set() for slot in ("uv",) + tuple(_pip_slot(name) for name in _PIP_COMMANDS)
-    }
-    cancelled: "dict[str, set[str]]" = {"pip": set(), "uv": set()}
+    cancelled: "set[str]" = set()
 
-    def _record(tool: str, source: str, key: str, value: str, slots: "tuple[str, ...]") -> None:
-        if source == "env" and not value.strip():
-            # pip drops empty environment values before applying precedence, so
-            # PIP_ONLY_BINARY='' neither enables a control nor cancels a pip.conf that
-            # does: measured with pip 26.2.1, the empty variable still rejects an sdist
-            # under `only-binary = :all:` while `:none:` clears it. Treating it as a
-            # cancellation suppressed a policy that was still fully in force.
-            return
-        canonical = _canonical_policy_key(key)
-        for slot in slots:
-            configured[slot].add(canonical)
-        if _config_value_is_on(value, key):
-            on.append((tool, source, key))
-        elif source == "env":
-            # pip's environment beats every config file, so an explicitly disabled
-            # variable cancels a file that enables the same control.
-            cancelled[tool].add(canonical)
-
-    all_pip_slots = tuple(_pip_slot(name) for name in _PIP_COMMANDS)
     for name in _PM_POLICY_ENV_VARS:
         raw = os.environ.get(name)
-        if raw is None:
+        if raw is None or not raw.strip():
+            # pip drops empty values before applying precedence, so an empty variable
+            # neither enables a control nor cancels a file that does.
             continue
         if name.startswith("UV_") and name not in _UV_ENFORCED_ENV_VARS:
             # uv ignores it, so it is not policy. See _UV_ENFORCED_ENV_VARS.
             continue
-        is_pip = name.startswith("PIP_")
-        # A variable applies to every pip subcommand, unlike a config section.
-        _record(
-            "pip" if is_pip else "uv",
-            "env",
-            name,
-            raw.strip(),
-            all_pip_slots if is_pip else ("uv",),
-        )
+        if _config_value_is_on(raw, name):
+            on.append(("pip" if name.startswith("PIP_") else "uv", "env", name))
+        elif name.startswith("PIP_"):
+            # pip's environment beats its config files, so an explicitly disabled
+            # variable cancels a config entry enabling the same control.
+            cancelled.add(_canonical_policy_key(name))
 
     try:
         result = subprocess.run(
@@ -5378,105 +4819,34 @@ def _policy_scan() -> "tuple[tuple[tuple[str, str, str], ...], dict[str, frozens
             stdout = subprocess.PIPE,
             stderr = subprocess.DEVNULL,
             # Bounded because this runs BEFORE the pip upgrade, against a venv that may
-            # have no pip at all (uv creates them without one). A notice must never be
-            # able to hang an install.
+            # have no pip at all. A notice must never be able to hang an install.
             timeout = 30,
             **_windows_hidden_subprocess_kwargs(),
         )
     except (OSError, subprocess.SubprocessError):
         result = None
-    pooled: "dict[str, dict[str, tuple[str, str]]]" = {name: {} for name in _PIP_SECTIONS}
     if result is not None and result.returncode == 0:
-        # `pip config list` prints EVERY definition, overridden ones included, in load
-        # order, so a later file wins. Within a file the command section beats [global]
-        # whatever the textual order, and each subcommand resolves separately.
-        per_command: "dict[str, dict[str, str]]" = {name: {} for name in _PIP_COMMANDS}
-        globals_: "dict[str, str]" = {}
+        settings: "dict[tuple[str, str], str]" = {}
         for line in (result.stdout or b"").decode("utf-8", "replace").splitlines():
             name, separator, raw = line.partition("=")
             # `:env:` entries restate the environment, already handled above.
             if not separator or name.strip().startswith(":env:"):
                 continue
-            # Section verbatim, option normalised: that is what pip itself does, and
-            # `pip config list` prints an `INSTALL.` prefix for a section pip ignores.
+            # Section verbatim, option normalised: that is the split pip itself makes,
+            # so `[INSTALL]` is a section it never selects.
             section, _, option = name.strip().rpartition(".")
-            if option not in _PIP_CONFIG_KEYS:
+            option = option.strip().lower().replace("_", "-")
+            if section not in ("global",) + _PIP_COMMANDS or option not in _PIP_CONFIG_KEYS:
                 continue
-            value = raw.strip().strip("'\"")
-            if section == "global":
-                globals_[option] = value
-            elif section in per_command:
-                per_command[section][option] = value
-        pooled = {
-            name: {
-                option: ("pip.conf", value)
-                for option, value in (globals_ if name == "global" else per_command[name]).items()
-            }
-            for name in _PIP_SECTIONS
-        }
-    else:
-        # No usable pip, so read pip's files directly rather than report an ordinary
-        # machine. They come back in pip's own load order, so a later file wins -- within
-        # a section, which is why every file's sections are pooled and only resolved
-        # against each other at the end. Collapsing a file before reading the next let a
-        # low-priority setting erase a higher-priority one pip still applies.
-        for path in _hardened_pip_config_paths():
-            text = _read_text(path)
-            if text is None:
-                continue
-            source = os.path.basename(path)
-            for name, values in _hardened_pip_sections(text).items():
-                pooled[name].update({key: (source, value) for key, value in values.items()})
-    # The `on` list comes from the three combined, so the notice names each control once;
-    # the configured sets stay per subcommand, since that is what decides whether a given
-    # command can enforce it.
-    per_command_settings = _resolve_pip_sections(pooled)
-    for key, (source, value) in _combine_pip_commands(per_command_settings).items():
-        if _canonical_policy_key(key) not in cancelled["pip"]:
-            _record("pip", source, key, value, ())
-    for command in _PIP_COMMANDS:
-        for key in per_command_settings[command]:
-            canonical = _canonical_policy_key(key)
-            if canonical not in cancelled["pip"]:
-                configured[_pip_slot(command)].add(canonical)
+            # Printed in load order, so the last definition of a given entry wins.
+            settings[(section, option)] = raw.strip().strip("'\"")
+        for (_section, option), value in settings.items():
+            if _config_value_is_on(value, option) and _canonical_policy_key(
+                option
+            ) not in cancelled:
+                on.append(("pip", "pip.conf", option))
 
-    # uv's files come back lowest precedence first, so a higher one simply overwrites:
-    # a project `[tool.uv.pip] require-hashes = false` is uv's effective answer even
-    # where the user config turned it on, and reporting the user value regardless made
-    # a later pip step refuse over a gap uv was not actually enforcing.
-    #
-    # Keyed on the literal key, not the canonical one: `no-build` and
-    # `no-build-package` are one CONTROL but two SETTINGS, and collapsing them into one
-    # slot let a `no-build-package = []` erase a `no-build = true` sitting beside it in
-    # the same file. Canonicalising is for comparing controls, not for storing them.
-    uv_settings: "dict[str, tuple[str, str]]" = {}
-    explicit_uv = _explicit_uv_config_path()
-    for path in _hardened_uv_config_paths():
-        text = _read_text(path)
-        if text is None:
-            continue
-        # Schema by provenance, not by name: a file named by UV_CONFIG_FILE is parsed as
-        # a standalone uv.toml whatever it is called, so an explicit file that happens to
-        # be named pyproject.toml still has its policy read from the root tables.
-        is_pyproject = os.path.basename(path) == "pyproject.toml" and path != explicit_uv
-        tables = (("tool", "uv"), ("tool", "uv", "pip")) if is_pyproject else ((), ("pip",))
-        for key, value in _hardened_settings_in_toml(text, tables).items():
-            uv_settings[key] = (os.path.basename(path), value)
-    for key, (source, value) in uv_settings.items():
-        if _canonical_policy_key(key) not in cancelled["uv"]:
-            _record("uv", source, key, value, ("uv",))
-
-    return tuple(dict.fromkeys(on)), {tool: frozenset(keys) for tool, keys in configured.items()}
-
-
-def _detected_policy() -> "tuple[tuple[str, str, str], ...]":
-    """(tool, source, key) for each hardening this host actually applies."""
-    return _policy_scan()[0]
-
-
-def _configured_policy_keys() -> "dict[str, frozenset[str]]":
-    """Per manager, the controls it has any setting for, enabled or not."""
-    return _policy_scan()[1]
+    return tuple(dict.fromkeys(on))
 
 
 def _hardened_pm_policy_names() -> "tuple[str, ...]":
@@ -5487,121 +4857,6 @@ def _hardened_pm_policy_names() -> "tuple[str, ...]":
             for _tool, source, key in _detected_policy()
         )
     )
-
-
-def _is_resolving_cmd(cmd: "list[str]") -> bool:
-    """True when this command actually resolves and installs packages.
-
-    run() routes EVERY command through _install_env_for_cmd, `patch_metadata.py` and
-    `pip check` included. Those resolve nothing, so a policy that cannot be enforced is
-    not their problem -- treating them as pip installs turned an unenforceable cutoff
-    into a hard exit on the final metadata patch, after every real step had succeeded.
-    """
-    return any(arg in _PIP_COMMANDS for arg in cmd)
-
-
-def _pip_subcommand(cmd: "list[str]") -> str:
-    """Which of install / download / wheel this command runs."""
-    for arg in cmd:
-        if arg in _PIP_COMMANDS:
-            return arg
-    return "install"
-
-
-def _unenforceable_policy(cmd: "list[str]") -> "list[str]":
-    """Retained controls the manager running this command cannot see.
-
-    The opt-out promises the operator's policy is applied. pip and uv read none of each
-    other's, so when a step runs uv and the only hardening is pip's, that promise is
-    false unless something is done about it.
-
-    Restating each control in the other manager's spelling was tried and abandoned: pip
-    and uv differ on scopes (`:all:` and commas against a boolean plus a space-separated
-    `-package` variable), on per-subcommand sections, on which config files are even
-    discovered, and on which controls exist at all, and every one of those gaps became a
-    way to fail an install the operator's real policy permitted. Reporting instead is
-    smaller and cannot invent a restriction: the step stops and names the setting to add.
-
-    A control the target manager has its OWN setting for is never reported, on or off --
-    a `[pip] require-hashes = false` in uv's config is a deliberate difference between
-    the two, not a gap.
-    """
-    if not _respect_pm_policy() or not _is_resolving_cmd(cmd):
-        return []
-    target = "uv" if cmd[:1] == ["uv"] else "pip"
-    # For pip, the subcommand being run and not pip in general: `[download] only-binary`
-    # is not an opinion about `pip install`, and treating it as one let a fallback
-    # install proceed as though the control were covered.
-    slot = "uv" if target == "uv" else _pip_slot(_pip_subcommand(cmd))
-    known = _configured_policy_keys().get(slot, frozenset())
-    missing = {
-        key
-        for tool, _source, key in _detected_policy()
-        if tool != target and _canonical_policy_key(key) not in known
-    }
-    return sorted(missing)
-
-
-# What to tell the operator to set, per manager. The uv side names a uv.toml key wherever
-# uv has no environment spelling for the control: measured on the pinned uv 0.12.1,
-# UV_NO_BUILD and UV_NO_BINARY are ignored, so naming them would send someone round the
-# same loop a second time. Only require-hashes and exclude-newer are settable from the
-# environment there.
-_POLICY_EQUIVALENTS = {
-    "require-hashes": ("PIP_REQUIRE_HASHES=1", "UV_REQUIRE_HASHES=1"),
-    "no-build": ("PIP_ONLY_BINARY=:all:", "no-build = true in your uv.toml"),
-    # uv's no-binary is a package LIST, not a flag: `no-binary = true` is a config parse
-    # error there, so naming it would have left the operator with an unusable uv.
-    "no-binary": ("PIP_NO_BINARY=:all:", 'no-binary = [":all:"] in your uv.toml'),
-    "exclude-newer": ("PIP_UPLOADED_PRIOR_TO", "UV_EXCLUDE_NEWER"),
-}
-
-
-def _refuse_unenforceable_policy(cmd: "list[str]", missing: "list[str]") -> None:
-    """Stop the step, naming the control and the setting that would satisfy it."""
-    target = "uv" if cmd[:1] == ["uv"] else "pip"
-    lines = []
-    for key in missing:
-        canonical = _canonical_policy_key(key)
-        pip_name, uv_name = _POLICY_EQUIVALENTS.get(canonical, ("", ""))
-        wanted = uv_name if target == "uv" else pip_name
-        lines.append(
-            f"     {key} -> set {wanted}"
-            if wanted
-            else f"     {key} -> {target} has no equivalent setting"
-        )
-    _safe_print(
-        _red(
-            f"   {_POLICY_OPT_OUT_ENV} is set, but this step runs {target}, which does "
-            f"not read the following policy:\n" + "\n".join(lines) + "\n"
-            f"   Add the {target} setting above, or unset {_POLICY_OPT_OUT_ENV} to let "
-            "Unsloth install its own dependencies as it normally does."
-        )
-    )
-    sys.exit(1)
-
-
-def _preflight_policy_gap(use_uv: bool) -> None:
-    """Refuse a cross-manager gap BEFORE the install mutates anything.
-
-    The refusal is right, but its timing was not: `install_python_stack()` removes the
-    completion manifest up front, so a refusal at the first resolving command left a
-    venv that had not been touched marked as a half-built install, and `verify_install()`
-    and the Desktop preflight then rejected a working environment.
-
-    Only the manager that will actually run the dependency installs is probed. Probing
-    both refused a pip-only policy on a host with no usable uv, where every real command
-    would have kept that policy: `_bootstrap_uv()` had not run yet, so the synthetic uv
-    probe described a manager the install was never going to use. Nothing is reported
-    unless the opt-out is set, so an ordinary install never reaches the check.
-
-    The refusal at the uv-to-pip fallback still covers the other direction, where uv is
-    used, fails, and pip would then be asked to do what uv refused.
-    """
-    probe = ["uv", "pip", "install"] if use_uv else [sys.executable, "-m", "pip", "install"]
-    missing = _unenforceable_policy(probe)
-    if missing:
-        _refuse_unenforceable_policy(probe, missing)
 
 
 def _announce_pm_policy() -> None:
@@ -5617,9 +4872,11 @@ def _announce_pm_policy() -> None:
         _note(
             f"{_POLICY_OPT_OUT_ENV} is set: keeping {listed} in force for Unsloth's own "
             "dependency installs, which will now fail where your policy forbids them "
-            "rather than be relaxed. pip and uv apply it exactly as they would for you, "
-            "including where they choose not to: pip does not apply only-binary to an "
-            "explicitly supplied source archive.",
+            "rather than be relaxed. Each manager applies its own settings, exactly as "
+            "it would for you and including where it chooses not to: pip does not apply "
+            "only-binary to an explicitly supplied source archive, and neither reads the "
+            "other's configuration, so a step that runs uv is bound by your uv settings "
+            "and a step that runs pip by your pip ones.",
             _cyan,
         )
         return
@@ -5943,9 +5200,6 @@ def _install_env_for_cmd(cmd: "list[str]") -> "dict[str, str] | None":
     the price of reading the same files' security settings, and why the default is the
     opposite.
     """
-    missing = _unenforceable_policy(cmd)
-    if missing:
-        _refuse_unenforceable_policy(cmd, missing)
     if not _is_pinned_index_cmd(cmd):
         overrides = _relaxed_pip_policy_env(cmd)
         if not overrides:
@@ -6073,26 +5327,12 @@ def pip_install(
                 if VERBOSE and result.stdout:
                     _safe_print(_redact_install_output(result.stdout))
                 return
-            fallback_cmd = _build_pip_cmd(args) + constraint_args_pip + req_args_pip
-            discarded = _unenforceable_policy(fallback_cmd)
-            if discarded:
-                # Only when falling back would actually DROP a control: pip reads none of
-                # uv's policy, so retrying there would install exactly what uv refused.
-                # Gating on the opt-out flag alone was wrong -- an operator who sets it
-                # pre-emptively on a host with no uv-only policy would have had every
-                # ordinary uv failure, a resolver hiccup included, turned into a fatal
-                # one with no fallback.
-                if result.stdout:
-                    _safe_print(_redact_install_output(result.stdout))
-                _safe_print(
-                    _red(
-                        f"   uv failed and {_POLICY_OPT_OUT_ENV} is set, so the pip "
-                        "fallback is not used: pip does not read "
-                        f"{', '.join(discarded)} and would install what uv refused. "
-                        "Unset it to allow the fallback."
-                    )
-                )
-                sys.exit(result.returncode)
+            # The fallback runs under the opt-out too. pip applies whatever pip is
+            # configured with, and uv's settings were never pip's to read: that is a
+            # property of the two tools, not something this installer introduces, and
+            # bridging it needs a model of both managers' configuration that is not
+            # worth the ways it can be wrong. What the opt-out promises is that the
+            # relaxations below are withheld, and they are, on both paths.
             _safe_print(_red("   uv failed, falling back to pip..."))
             if result.stdout:
                 _safe_print(_redact_install_output(result.stdout))
@@ -6237,19 +5477,6 @@ def install_python_stack() -> int:
     # shell-installer handoff skips that slot only while base.txt has no work.
     _TOTAL = base_total - int(skip_base and base_requirements is None)
 
-    # uv selection first: it only runs dry-run probes, and the preflight below has to
-    # know which manager the dependency installs will use before it can say whether a
-    # control is out of that manager's reach.
-    #
-    # 1. Try uv for faster installs (before pip upgrade -- uv venvs don't
-    #    include pip by default).
-    USE_UV = _bootstrap_uv()
-
-    # Before the manifest goes away, so a refusal cannot leave an untouched venv marked
-    # half-built. Silent unless the opt-out is set AND the manager that will run the
-    # installs cannot see a control the operator configured.
-    _preflight_policy_gap(USE_UV)
-
     # Drop it up front: a missing manifest is what tells the CLI, setup.sh and
     # the preflight that an interrupted run left the venv half-built. Stop if it
     # survives rather than mutate the venv behind a marker that still verifies.
@@ -6274,6 +5501,10 @@ def install_python_stack() -> int:
         _announce_pm_policy()
     except Exception:
         pass
+
+    # 1. Try uv for faster installs (before pip upgrade -- uv venvs don't
+    #    include pip by default).
+    USE_UV = _bootstrap_uv()
 
     # 2. Ensure pip is available (uv venvs from install.sh omit pip).
     _progress("pip bootstrap")

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -4763,9 +4763,15 @@ _EMPTY_POLICY_VALUES = ("", ":none:")
 
 # The upload cutoff is a date, but uv accepts `false` for it as "no cutoff": measured on
 # the pinned uv 0.12.1, UV_EXCLUDE_NEWER=false installs the current release while a date
-# filters it. Reading `false` as a cutoff put a security notice in front of an operator
-# who had switched the control off.
-_FALSE_DISABLES_KEYS = ("exclude-newer", "exclude-newer-package", "uploaded-prior-to")
+# filters it, and UV_EXCLUDE_NEWER=garbage is rejected outright, so `false` is a spelling
+# uv understands rather than a value it tolerates. Reading `false` as a cutoff put a
+# security notice in front of an operator who had switched the control off.
+#
+# uv's spellings ONLY. pip has no off value for its cutoff: measured on pip 26.2.1, both
+# `--uploaded-prior-to false` and PIP_UPLOADED_PRIOR_TO=false exit with "Expected an ISO
+# 8601 datetime string". Treating that as a disable let an unusable value cancel a real
+# pip.conf cutoff, so the notice went quiet about a control the pinned path still drops.
+_FALSE_DISABLES_KEYS = ("exclude-newer", "exclude-newer-package")
 
 
 def _policy_key_spelling(key: str) -> str:

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -5358,7 +5358,19 @@ def _install_env_for_cmd(cmd: "list[str]") -> "dict[str, str] | None":
         # by it carrying `[pip] require-hashes = true` fails a pinned install, and
         # dropping it lets the same install through. Under the opt-out it is the
         # operator's policy file, so it stays.
-        if respect and name in ("UV_CONFIG_FILE", "PIP_NO_INDEX"):
+        # UV_FIND_LINKS is kept unconditionally under the opt-out, where PIP_FIND_LINKS
+        # is kept only while no-index is in force. The asymmetry follows from what each
+        # manager can be ASKED. pip prints its resolved configuration, so the effective
+        # no-index is knowable; uv has no such command, `--no-index` has no environment
+        # spelling at all, and the setting therefore lives only in a uv.toml this module
+        # deliberately does not parse. Measured on the pinned uv 0.12.1, a uv.toml
+        # `[pip] no-index = true` plus UV_FIND_LINKS installs from the wheelhouse, and
+        # the same command without it fails with "index lookups were disabled and no
+        # additional package locations were provided". Guessing wrong in that direction
+        # breaks every offline uv install; the opt-out already accepts that sources
+        # reachable through the retained uv.toml survive, so keeping the operator's own
+        # wheelhouse is the same cost they already agreed to.
+        if respect and name in ("UV_CONFIG_FILE", "PIP_NO_INDEX", "UV_FIND_LINKS"):
             continue
         # PIP_FIND_LINKS genuinely IS additive, so it survives only while no-index is in
         # force and it is the sole remaining source. With no-index off it would add a

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -4784,12 +4784,22 @@ def _config_value_is_on(value: str, key: "str | None" = None) -> bool:
 
     `key` selects the reading: without one the value is treated as a boolean, which is
     right for the plain flags this also parses (UV_NO_CONFIG and friends).
+
+    `:none:` empties a package LIST (`--no-binary :none:`), and means nothing to a
+    boolean. Measured on pip 26.2.1, PIP_NO_INDEX=:none: exits with ":none: is not a
+    valid value for no-index option, please specify a boolean value", so reading it as
+    off let the opt-out drop a variable that would otherwise have stopped the command,
+    turning an install pip refuses into one that can reach the network.
     """
     text = value.strip().lower()
-    if text in _EMPTY_POLICY_VALUES:
+    spelling = _policy_key_spelling(key) if key is not None else None
+    is_boolean = spelling is not None and spelling in _BOOLEAN_POLICY_KEYS
+    if not text:
         return False
-    if key is not None and _policy_key_spelling(key) not in _BOOLEAN_POLICY_KEYS:
-        return not (text == "false" and _policy_key_spelling(key) in _FALSE_DISABLES_KEYS)
+    if text in _EMPTY_POLICY_VALUES and not is_boolean:
+        return False
+    if spelling is not None and not is_boolean:
+        return not (text == "false" and spelling in _FALSE_DISABLES_KEYS)
     return text not in _OFF_VALUES
 
 
@@ -5262,7 +5272,13 @@ def _install_env_for_cmd(cmd: "list[str]") -> "dict[str, str] | None":
     # reach the network on a host that had said not to, which is the opposite of what
     # this branch scrubs the ADDITIVE mirror variables for. If the pinned artifact is
     # not in find-links the step fails, which is what the opt-out promises.
-    keep_offline = _respect_pm_policy() and _config_value_is_on(os.environ.get("PIP_NO_INDEX", ""))
+    # Read as the BOOLEAN it is: without the key this fell through to the generic
+    # reading, where `:none:` counts as empty and the variable was dropped even though
+    # pip rejects that value outright.
+    keep_offline = _respect_pm_policy() and _config_value_is_on(
+        os.environ.get("PIP_NO_INDEX", ""),
+        "no-index",
+    )
     for name in _UV_INDEX_ENV_VARS:
         # UV_CONFIG_FILE is an index variable only incidentally: measured, a file named
         # by it carrying `[pip] require-hashes = true` fails a pinned install, and

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -4914,6 +4914,32 @@ def _detected_policy() -> "tuple[tuple[str, str, str], ...]":
     return tuple(dict.fromkeys(on))
 
 
+def _pip_no_index_in_force() -> bool:
+    """Is pip's no-index effectively ON, counting the config file as well as the env?
+
+    `--no-index` means "ignore the indexes and look only at find-links", so whether
+    PIP_FIND_LINKS is the sole remaining source or merely an extra one depends on this.
+    Reading only the environment got it wrong for an operator whose `no-index = true`
+    sits in pip.conf, which the opt-out keeps readable: find-links was scrubbed as
+    additive and the fallback was left with no sources at all.
+
+    Only reached under the opt-out, so the default path adds no probe and stays exactly
+    as it was. When the environment speaks it decides, in either direction, because pip
+    reads it ahead of its files. Otherwise this falls back to the advisory scan, which
+    for PIP keys is complete: `pip config list` reports every file pip would load.
+
+    An unavailable scan reads as off, and that cannot cost an install: the scan only
+    fails when the venv has no pip, and PIP_FIND_LINKS is inert without pip, since uv
+    reads UV_FIND_LINKS instead.
+    """
+    raw = os.environ.get("PIP_NO_INDEX")
+    if raw is not None and raw.strip():
+        return _config_value_is_on(raw, "no-index")
+    return any(
+        source == "pip.conf" and key == "no-index" for _tool, source, key in _detected_policy()
+    )
+
+
 def _hardened_pm_policy_names() -> "tuple[str, ...]":
     """The detected policy, as the notice prints it."""
     return tuple(
@@ -5284,7 +5310,9 @@ def _install_env_for_cmd(cmd: "list[str]") -> "dict[str, str] | None":
     # Read as the BOOLEAN it is: without the key this fell through to the generic
     # reading, where `:none:` counts as empty and the variable was dropped even though
     # pip rejects that value outright.
-    no_index_on = _config_value_is_on(os.environ.get("PIP_NO_INDEX", ""), "no-index")
+    # Computed only under the opt-out: the default branch scrubs everything regardless,
+    # so it never pays for the scan behind this.
+    no_index_on = respect and _pip_no_index_in_force()
     for name in _UV_INDEX_ENV_VARS:
         # UV_CONFIG_FILE is an index variable only incidentally: measured, a file named
         # by it carrying `[pip] require-hashes = true` fails a pinned install, and

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -4656,6 +4656,7 @@ _PM_POLICY_ENV_VARS = (
     "PIP_ONLY_BINARY",
     "PIP_NO_BINARY",
     "PIP_REQUIRE_HASHES",
+    "PIP_UPLOADED_PRIOR_TO",
 )
 
 
@@ -4698,6 +4699,8 @@ _HARDENED_CONFIG_KEYS = (
     "no-build-package",
     "exclude-newer",
     "exclude-newer-package",
+    # pip's own spelling of the same control, so a pip-side cutoff is detected too.
+    "uploaded-prior-to",
 )
 
 
@@ -4768,7 +4771,26 @@ def _hardened_settings_in_toml(
                     settings[key] = _toml_value_text(node[key])
         return settings
     current: "tuple[str, ...]" = ()
-    for line in text.splitlines():
+    # Join continuation lines first: tomllib is absent here, and a `no-build-package = [`
+    # spread over several lines would otherwise read as the literal value "[".
+    joined: "list[str]" = []
+    pending = ""
+    for raw_line in text.splitlines():
+        piece = raw_line.split("#", 1)[0].rstrip() if "=" in raw_line or pending else raw_line
+        if pending:
+            pending += " " + piece.strip()
+            if pending.count("[") <= pending.count("]"):
+                joined.append(pending)
+                pending = ""
+            continue
+        stripped = piece.strip()
+        if stripped.count("[") > stripped.count("]") and "=" in stripped:
+            pending = stripped
+            continue
+        joined.append(raw_line)
+    if pending:
+        joined.append(pending)
+    for line in joined:
         stripped = line.strip()
         if stripped.startswith("#") or not stripped:
             continue
@@ -4839,10 +4861,15 @@ def _hardened_uv_config_paths() -> "list[str]":
     are NOT. `./uv.toml` is kept anyway: it costs a line of output, and other uv
     subcommands this module drives may yet read it.
     """
-    candidates = []
+    if _config_value_is_on(os.environ.get("UV_NO_CONFIG", "")):
+        # --no-config: uv discovers nothing, so nothing here is policy.
+        return []
     explicit = os.environ.get("UV_CONFIG_FILE", "").strip()
     if explicit:
-        candidates.append(explicit)
+        # --config-file is used "in place of any discovered configuration files", so the
+        # discovered set is not merely outranked, it is not read at all.
+        return _existing_files([explicit])
+    candidates = []
     if IS_WINDOWS:
         for variable in ("APPDATA", "PROGRAMDATA"):
             base = os.environ.get(variable, "")
@@ -4933,30 +4960,49 @@ def _hardened_pip_config_paths() -> "list[str]":
 _PIP_SECTION_RANK = {"global": 0, "install": 1, "download": 1, "wheel": 1}
 
 
+# The three pip subcommands this module drives. pip applies `[global]` and then the
+# command's own section, so each of these resolves separately: `[install] require-hashes
+# = true` with `[wheel] require-hashes = false` is two different policies, not one.
+_PIP_COMMANDS = ("install", "download", "wheel")
+
+
 def _hardened_settings_in_ini(text: str) -> "dict[str, str]":
-    """Hardened keys DEFINED in a pip.conf, with their values, by pip's section rules.
+    """Hardened settings from a pip.conf, resolved per subcommand then combined.
+
+    A control counts as configured if any of install/download/wheel configures it, and as
+    ON if any of them enables it: this module runs all three, and the caller only needs to
+    know whether the operator has an opinion, not which subcommand carries it.
 
     Values rather than a filtered list of on-keys, because precedence is resolved across
-    files: a later pip.conf setting `require-hashes = false` has to be able to cancel an
-    earlier one, and a caller that only ever saw the enabled keys could not do that.
+    files too: a later pip.conf setting `require-hashes = false` has to be able to cancel
+    an earlier one, and a caller that only ever saw the enabled keys could not do that.
     """
     parser = configparser.RawConfigParser()
     try:
         parser.read_string(text)
     except configparser.Error:
         return {}
-    ranked: dict[str, tuple[int, str]] = {}
-    for section in parser.sections():
-        rank = _PIP_SECTION_RANK.get(section.strip().lower())
-        if rank is None:
-            continue
+
+    def _section(name: str) -> "dict[str, str]":
+        values = {}
         for key in _HARDENED_CONFIG_KEYS:
-            if not parser.has_option(section, key):
-                continue
-            value = parser.get(section, key, fallback = "")
-            if rank >= ranked.get(key, (-1, ""))[0]:
-                ranked[key] = (rank, value)
-    return {key: value for key, (_rank, value) in ranked.items()}
+            if parser.has_option(name, key):
+                values[key] = parser.get(name, key, fallback = "")
+        return values
+
+    sections = {name.strip().lower(): name for name in parser.sections()}
+    base = _section(sections["global"]) if "global" in sections else {}
+    combined: dict[str, str] = {}
+    for command in _PIP_COMMANDS:
+        effective = dict(base)
+        if command in sections:
+            effective.update(_section(sections[command]))
+        for key, value in effective.items():
+            # An enabled value anywhere among the three wins; otherwise keep a disabled
+            # one so it can still cancel a lower-precedence file.
+            if key not in combined or _config_value_is_on(value):
+                combined[key] = value
+    return combined
 
 
 def _hardened_keys_in_ini(text: str) -> "list[str]":
@@ -4974,6 +5020,24 @@ def _read_text(path: str) -> "str | None":
         return None
 
 
+# The same control under each manager's name. This decides "has the target manager got an
+# opinion about this already", so pip's `only-binary` (wheels only) and uv's `no-build`
+# are one control, as are a policy and its package-scoped form.
+_POLICY_KEY_ALIASES = {
+    "uploaded-prior-to": "exclude-newer",
+    "exclude-newer-package": "exclude-newer",
+    "only-binary": "no-build",
+    "no-build-package": "no-build",
+    "no-binary-package": "no-binary",
+}
+
+
+def _canonical_policy_key(key: str) -> str:
+    """One name per control, whatever spelling it arrived in."""
+    name = _env_policy_key(key) if key.isupper() else key.lower()
+    return _POLICY_KEY_ALIASES.get(name, name)
+
+
 def _env_policy_key(name: str) -> str:
     """The config-file spelling of a policy environment variable.
 
@@ -4984,38 +5048,35 @@ def _env_policy_key(name: str) -> str:
 
 
 @functools.lru_cache(maxsize = 1)
-def _detected_policy() -> "tuple[tuple[str, str, str, str], ...]":
-    """(tool, source, key, value) for every hardening this host actually applies.
+def _policy_scan() -> "tuple[tuple[tuple[str, str, str], ...], dict[str, frozenset[str]]]":
+    """Everything the hardening probe found: what is ON, and what each manager has an
+    opinion about at all.
 
-    `tool` is "pip" or "uv", which is what makes this more than a display list: under the
-    opt-out the two managers have to be told about each other's policy, since neither
-    reads the other's (measured on the pinned uv 0.12.1, `uv pip install` ignores both
-    PIP_REQUIRE_HASHES and a pip.conf require-hashes). `source` is "env" for a variable,
-    otherwise the config file's basename. `value` is carried so a package-scoped policy
-    stays package-scoped when translated: promoting `PIP_ONLY_BINARY=numpy` to a global
-    `UV_NO_BUILD=1` would fail the extras step on wheel-less dependencies the operator's
-    policy actually permits.
+    The second half is what stops a deliberate difference between the two managers being
+    reported as a gap: `PIP_REQUIRE_HASHES=1` next to a uv config saying
+    `[pip] require-hashes = false` is the operator configuring them differently, not uv
+    missing a control.
 
-    Empty on an ordinary machine. Best-effort throughout: a probe that fails just
-    shortens the list.
+    Best-effort throughout: a probe that fails just shortens the answer.
     """
-    found = []
-    # An environment variable explicitly turned OFF is not hardening, but it is not
-    # nothing either: it beats every config file, so it has to cancel one that enables
-    # the same control rather than being dropped.
+    on: "list[tuple[str, str, str]]" = []
+    configured: "dict[str, set[str]]" = {"pip": set(), "uv": set()}
     cancelled: "dict[str, set[str]]" = {"pip": set(), "uv": set()}
+
+    def _record(tool: str, source: str, key: str, value: str) -> None:
+        canonical = _canonical_policy_key(key)
+        configured[tool].add(canonical)
+        if _config_value_is_on(value):
+            on.append((tool, source, key))
+        elif source == "env":
+            # pip's environment beats every config file, so an explicitly disabled
+            # variable cancels a file that enables the same control.
+            cancelled[tool].add(canonical)
+
     for name in _PM_POLICY_ENV_VARS:
         raw = os.environ.get(name)
-        if raw is None:
-            continue
-        tool = "pip" if name.startswith("PIP_") else "uv"
-        if _config_value_is_on(raw):
-            found.append((tool, "env", name, raw.strip()))
-        else:
-            cancelled[tool].add(_env_policy_key(name))
-
-    def _keep(tool: str, key: str) -> bool:
-        return key not in cancelled[tool]
+        if raw is not None:
+            _record("pip" if name.startswith("PIP_") else "uv", "env", name, raw.strip())
 
     try:
         result = subprocess.run(
@@ -5030,45 +5091,46 @@ def _detected_policy() -> "tuple[tuple[str, str, str, str], ...]":
         )
     except (OSError, subprocess.SubprocessError):
         result = None
+    pip_settings: "dict[str, tuple[str, str]]" = {}
     if result is not None and result.returncode == 0:
-        # `pip config list` prints EVERY definition, including ones a higher-precedence
-        # file overrides: a user pip.conf require-hashes=true and a venv site pip.conf
-        # require-hashes=false emit both lines, and pip enforces the second. Measured on
-        # pip 26.2.1, `config get` returns false there and the install is not
-        # hash-checked. Lines arrive in load order, so a later file wins; within a file
-        # pip applies the command section over `[global]` whatever the textual order, so
-        # the section is ranked rather than discarded.
-        effective: "dict[str, tuple[int, str]]" = {}
+        # `pip config list` prints EVERY definition, overridden ones included, in load
+        # order, so a later file wins. Within a file the command section beats [global]
+        # whatever the textual order, and each subcommand resolves separately.
+        per_command: "dict[str, dict[str, str]]" = {name: {} for name in _PIP_COMMANDS}
+        globals_: "dict[str, str]" = {}
         for line in (result.stdout or b"").decode("utf-8", "replace").splitlines():
             name, separator, raw = line.partition("=")
-            # `:env:` entries restate the environment, already handled above (including
-            # the disabled ones, which is why they can be skipped here).
+            # `:env:` entries restate the environment, already handled above.
             if not separator or name.strip().startswith(":env:"):
                 continue
             section, _, option = name.strip().rpartition(".")
-            rank = _PIP_SECTION_RANK.get(section.strip().lower(), None)
-            if option not in _HARDENED_CONFIG_KEYS or rank is None:
+            section = section.strip().lower()
+            if option not in _HARDENED_CONFIG_KEYS:
                 continue
-            if rank >= effective.get(option, (-1, ""))[0]:
-                effective[option] = (rank, raw.strip().strip("'\""))
-        for option, (_rank, value) in effective.items():
-            if _config_value_is_on(value) and _keep("pip", option):
-                found.append(("pip", "pip.conf", option, value))
+            value = raw.strip().strip("'\"")
+            if section == "global":
+                globals_[option] = value
+            elif section in per_command:
+                per_command[section][option] = value
+        for command in _PIP_COMMANDS:
+            effective = dict(globals_)
+            effective.update(per_command[command])
+            for option, value in effective.items():
+                if option not in pip_settings or _config_value_is_on(value):
+                    pip_settings[option] = ("pip.conf", value)
     else:
         # No usable pip, so read pip's files directly rather than report an ordinary
-        # machine. Only in this branch: when pip answered, it already merged them.
-        # _hardened_pip_config_paths returns them in pip's own load order, so the same
-        # last-wins resolution applies here.
-        winners: "dict[str, tuple[str, str]]" = {}
+        # machine. They come back in pip's own load order, so a later file wins.
         for path in _hardened_pip_config_paths():
             text = _read_text(path)
             if text is None:
                 continue
             for key, value in _hardened_settings_in_ini(text).items():
-                winners[key] = (os.path.basename(path), value)
-        for key, (basename, value) in winners.items():
-            if _config_value_is_on(value) and _keep("pip", key):
-                found.append(("pip", basename, key, value))
+                pip_settings[key] = (os.path.basename(path), value)
+    for key, (source, value) in pip_settings.items():
+        if _canonical_policy_key(key) not in cancelled["pip"]:
+            _record("pip", source, key, value)
+
     for path in _hardened_uv_config_paths():
         text = _read_text(path)
         if text is None:
@@ -5079,9 +5141,22 @@ def _detected_policy() -> "tuple[tuple[str, str, str, str], ...]":
             else ((), ("pip",))
         )
         for key, value in _hardened_settings_in_toml(text, tables).items():
-            if _config_value_is_on(value) and _keep("uv", key):
-                found.append(("uv", os.path.basename(path), key, value))
-    return tuple(dict.fromkeys(found))
+            if _canonical_policy_key(key) not in cancelled["uv"]:
+                _record("uv", os.path.basename(path), key, value)
+
+    return tuple(dict.fromkeys(on)), {
+        tool: frozenset(keys) for tool, keys in configured.items()
+    }
+
+
+def _detected_policy() -> "tuple[tuple[str, str, str], ...]":
+    """(tool, source, key) for each hardening this host actually applies."""
+    return _policy_scan()[0]
+
+
+def _configured_policy_keys() -> "dict[str, frozenset[str]]":
+    """Per manager, the controls it has any setting for, enabled or not."""
+    return _policy_scan()[1]
 
 
 def _hardened_pm_policy_names() -> "tuple[str, ...]":
@@ -5089,107 +5164,83 @@ def _hardened_pm_policy_names() -> "tuple[str, ...]":
     return tuple(
         dict.fromkeys(
             key if source == "env" else f"{source} {key}"
-            for _tool, source, key, _value in _detected_policy()
+            for _tool, source, key in _detected_policy()
         )
     )
 
 
-def _policy_scope(value: str) -> "str | None":
-    """The package list a scoped policy names, or None when it covers everything.
+def _is_resolving_cmd(cmd: "list[str]") -> bool:
+    """True when this command actually resolves and installs packages.
 
-    pip spells "everything" as `:all:` and separates names with commas; uv uses a boolean
-    plus a separate `-package` variable and separates names with spaces. Both spellings
-    land here so the translation can stay scoped instead of promoting a policy about one
-    package into a policy about all of them.
+    run() routes EVERY command through _install_env_for_cmd, `patch_metadata.py` and
+    `pip check` included. Those resolve nothing, so a policy that cannot be enforced is
+    not their problem -- treating them as pip installs turned an unenforceable cutoff
+    into a hard exit on the final metadata patch, after every real step had succeeded.
     """
-    text = value.strip()
-    if text.lower() in (":all:", "1", "true", "yes", "y", "t", "on"):
-        return None
-    names = [part for part in re.split(r"[,\s]+", text) if part and part != ":all:"]
-    return " ".join(names) if names else None
+    return any(arg in ("install", "download", "wheel") for arg in cmd)
 
 
-# pip and uv spell the same controls differently and read none of each other's. Under the
-# opt-out, whichever manager runs is told the other's policy in its own spelling, or the
-# flag only holds for whichever tool the operator happened to configure. Precedent:
-# _uv_staging_plan already translates UV_NO_BINARY / UV_ONLY_BINARY into pip's spellings.
-def _translated_policy_env(cmd: "list[str]") -> "dict[str, str]":
-    """Retained policy, restated for the manager this command actually runs.
+def _unenforceable_policy(cmd: "list[str]") -> "list[str]":
+    """Retained controls the manager running this command cannot see.
 
-    Empty unless the opt-out is set. Never overrides a setting the target manager already
-    has: the operator's own spelling wins over a translation of the other one. Scopes are
-    carried through, so `PIP_ONLY_BINARY=numpy` becomes uv's package-scoped no-build and
-    not a global one that would fail the extras step on its wheel-less dependencies.
+    The opt-out promises the operator's policy is applied. pip and uv read none of each
+    other's, so when a step runs uv and the only hardening is pip's, that promise is
+    false unless something is done about it.
+
+    Restating each control in the other manager's spelling was tried and abandoned: pip
+    and uv differ on scopes (`:all:` and commas against a boolean plus a space-separated
+    `-package` variable), on per-subcommand sections, on which config files are even
+    discovered, and on which controls exist at all, and every one of those gaps became a
+    way to fail an install the operator's real policy permitted. Reporting instead is
+    smaller and cannot invent a restriction: the step stops and names the setting to add.
+
+    A control the target manager has its OWN setting for is never reported, on or off --
+    a `[pip] require-hashes = false` in uv's config is a deliberate difference between
+    the two, not a gap.
     """
-    if not _respect_pm_policy():
-        return {}
+    if not _respect_pm_policy() or not _is_resolving_cmd(cmd):
+        return []
     target = "uv" if cmd[:1] == ["uv"] else "pip"
-    source: "dict[str, str]" = {}
-    for tool, _origin, key, value in _detected_policy():
-        if tool == target:
-            continue
-        source.setdefault(_env_policy_key(key) if key.isupper() else key.lower(), value)
-    if not source:
-        return {}
-
-    overrides: dict[str, str] = {}
-    if target == "uv":
-        if "require-hashes" in source:
-            overrides["UV_REQUIRE_HASHES"] = "1"
-        # pip's only-binary is "wheels only", which uv spells as no-build.
-        for key, whole, scoped in (
-            ("only-binary", "UV_NO_BUILD", "UV_NO_BUILD_PACKAGE"),
-            ("no-binary", "UV_NO_BINARY", "UV_NO_BINARY_PACKAGE"),
-        ):
-            if key not in source:
-                continue
-            names = _policy_scope(source[key])
-            if names is None:
-                overrides[whole] = "1"
-            else:
-                overrides[scoped] = names
-    else:
-        if "require-hashes" in source:
-            overrides["PIP_REQUIRE_HASHES"] = "1"
-        for keys, target_name in (
-            (("no-build", "no-build-package", "only-binary"), "PIP_ONLY_BINARY"),
-            (("no-binary", "no-binary-package"), "PIP_NO_BINARY"),
-        ):
-            names: "list[str]" = []
-            whole = False
-            for key in keys:
-                if key not in source:
-                    continue
-                scope = _policy_scope(source[key])
-                if scope is None:
-                    whole = True
-                else:
-                    names.extend(scope.split())
-            if whole:
-                overrides[target_name] = ":all:"
-            elif names:
-                overrides[target_name] = ",".join(dict.fromkeys(names))
-        cutoff = source.get("exclude-newer", "").strip()
-        if cutoff and not os.environ.get("PIP_UPLOADED_PRIOR_TO", "").strip():
-            # An upload cutoff is a reproducibility control, and pip only grew the
-            # equivalent option in 25.3. Silently dropping it would let this install pick
-            # an artifact the retained policy excludes, so an older pip refuses instead --
-            # the same answer _uv_upload_cutoff_args gives the staging path.
-            if _pip_supports_upload_cutoff():
-                overrides["PIP_UPLOADED_PRIOR_TO"] = cutoff
-            else:
-                _safe_print(
-                    _red(
-                        f"   {_POLICY_OPT_OUT_ENV} is set and an upload cutoff "
-                        f"({cutoff}) is configured, but this pip is too old for "
-                        "--uploaded-prior-to, so the cutoff cannot be enforced here. "
-                        "Upgrade pip to 25.3 or newer, or unset the variable."
-                    )
-                )
-                sys.exit(1)
-    return {
-        name: value for name, value in overrides.items() if not os.environ.get(name, "").strip()
+    known = _configured_policy_keys().get(target, frozenset())
+    missing = {
+        key for tool, _source, key in _detected_policy()
+        if tool != target and _canonical_policy_key(key) not in known
     }
+    return sorted(missing)
+
+
+_POLICY_EQUIVALENTS = {
+    "require-hashes": ("PIP_REQUIRE_HASHES", "UV_REQUIRE_HASHES"),
+    "only-binary": ("PIP_ONLY_BINARY", "UV_NO_BUILD / UV_NO_BUILD_PACKAGE"),
+    "no-binary": ("PIP_NO_BINARY", "UV_NO_BINARY / UV_NO_BINARY_PACKAGE"),
+    "no-build": ("PIP_ONLY_BINARY", "UV_NO_BUILD"),
+    "no-build-package": ("PIP_ONLY_BINARY", "UV_NO_BUILD_PACKAGE"),
+    "no-binary-package": ("PIP_NO_BINARY", "UV_NO_BINARY_PACKAGE"),
+    "exclude-newer": ("PIP_UPLOADED_PRIOR_TO", "UV_EXCLUDE_NEWER"),
+    "exclude-newer-package": ("", "UV_EXCLUDE_NEWER_PACKAGE"),
+    "uploaded-prior-to": ("PIP_UPLOADED_PRIOR_TO", "UV_EXCLUDE_NEWER"),
+}
+
+
+def _refuse_unenforceable_policy(cmd: "list[str]", missing: "list[str]") -> None:
+    """Stop the step, naming the control and the setting that would satisfy it."""
+    target = "uv" if cmd[:1] == ["uv"] else "pip"
+    lines = []
+    for key in missing:
+        canonical = _canonical_policy_key(key)
+        pip_name, uv_name = _POLICY_EQUIVALENTS.get(canonical, ("", ""))
+        wanted = uv_name if target == "uv" else pip_name
+        lines.append(f"     {key} -> set {wanted}" if wanted else
+                     f"     {key} -> {target} has no equivalent setting")
+    _safe_print(
+        _red(
+            f"   {_POLICY_OPT_OUT_ENV} is set, but this step runs {target}, which does "
+            f"not read the following policy:\n" + "\n".join(lines) + "\n"
+            f"   Add the {target} setting above, or unset {_POLICY_OPT_OUT_ENV} to let "
+            "Unsloth install its own dependencies as it normally does."
+        )
+    )
+    sys.exit(1)
 
 
 def _announce_pm_policy() -> None:
@@ -5528,9 +5579,11 @@ def _install_env_for_cmd(cmd: "list[str]") -> "dict[str, str] | None":
     the price of reading the same files' security settings, and why the default is the
     opposite.
     """
+    missing = _unenforceable_policy(cmd)
+    if missing:
+        _refuse_unenforceable_policy(cmd, missing)
     if not _is_pinned_index_cmd(cmd):
-        overrides = dict(_relaxed_pip_policy_env(cmd))
-        overrides.update(_translated_policy_env(cmd))
+        overrides = _relaxed_pip_policy_env(cmd)
         if not overrides:
             return None
         env = os.environ.copy()
@@ -5546,7 +5599,6 @@ def _install_env_for_cmd(cmd: "list[str]") -> "dict[str, str] | None":
             continue
         env.pop(name, None)
     if _respect_pm_policy():
-        env.update(_translated_policy_env(cmd))
         return env
     env["UV_NO_CONFIG"] = "1"
     for name in _PM_POLICY_ENV_VARS:

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -5144,9 +5144,7 @@ def _policy_scan() -> "tuple[tuple[tuple[str, str, str], ...], dict[str, frozens
             if _canonical_policy_key(key) not in cancelled["uv"]:
                 _record("uv", os.path.basename(path), key, value)
 
-    return tuple(dict.fromkeys(on)), {
-        tool: frozenset(keys) for tool, keys in configured.items()
-    }
+    return tuple(dict.fromkeys(on)), {tool: frozenset(keys) for tool, keys in configured.items()}
 
 
 def _detected_policy() -> "tuple[tuple[str, str, str], ...]":
@@ -5203,7 +5201,8 @@ def _unenforceable_policy(cmd: "list[str]") -> "list[str]":
     target = "uv" if cmd[:1] == ["uv"] else "pip"
     known = _configured_policy_keys().get(target, frozenset())
     missing = {
-        key for tool, _source, key in _detected_policy()
+        key
+        for tool, _source, key in _detected_policy()
         if tool != target and _canonical_policy_key(key) not in known
     }
     return sorted(missing)
@@ -5230,8 +5229,11 @@ def _refuse_unenforceable_policy(cmd: "list[str]", missing: "list[str]") -> None
         canonical = _canonical_policy_key(key)
         pip_name, uv_name = _POLICY_EQUIVALENTS.get(canonical, ("", ""))
         wanted = uv_name if target == "uv" else pip_name
-        lines.append(f"     {key} -> set {wanted}" if wanted else
-                     f"     {key} -> {target} has no equivalent setting")
+        lines.append(
+            f"     {key} -> set {wanted}"
+            if wanted
+            else f"     {key} -> {target} has no equivalent setting"
+        )
     _safe_print(
         _red(
             f"   {_POLICY_OPT_OUT_ENV} is set, but this step runs {target}, which does "

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -4766,7 +4766,47 @@ def _toml_value_text(value: object) -> str:
         return "1" if value else "0"
     if isinstance(value, (list, tuple)):
         return " ".join(str(item).strip() for item in value if str(item).strip())
+    if isinstance(value, dict):
+        # The package-scoped maps, e.g. `exclude-newer-package = { foo = "..." }`. Its
+        # members, so an EMPTY map becomes the empty string and reads as off: str({})
+        # is "{}", which is not one of the off spellings and became phantom hardening.
+        return " ".join(str(item).strip() for item in value if str(item).strip())
     return str(value).strip()
+
+
+def _inline_table_lines(key: str, body: str) -> "list[str]":
+    """`a = { b = 1, c = { d = 2 } }` as the dotted lines `a.b = 1` and `a.c.d = 2`.
+
+    Only the pre-3.11 fallback needs this; tomllib builds the nesting itself. Without it
+    a `[tool] uv = { pip = { require-hashes = true } }` was skipped entirely, and uv
+    0.12.1 does enforce exactly that.
+    """
+    parts: "list[str]" = []
+    current = ""
+    depth = 0
+    for char in body:
+        if char in "{[":
+            depth += 1
+        elif char in "}]":
+            depth -= 1
+        elif char == "," and depth == 0:
+            parts.append(current)
+            current = ""
+            continue
+        current += char
+    parts.append(current)
+    lines: "list[str]" = []
+    for part in parts:
+        name, separator, raw = part.partition("=")
+        if not separator:
+            continue
+        name = name.strip().strip("\"'")
+        raw = raw.strip()
+        if raw.startswith("{") and raw.endswith("}") and raw[1:-1].strip():
+            lines.extend(_inline_table_lines(f"{key}.{name}", raw[1:-1]))
+        else:
+            lines.append(f"{key}.{name} = {raw}")
+    return lines
 
 
 def _hardened_settings_in_toml(
@@ -4817,7 +4857,16 @@ def _hardened_settings_in_toml(
         joined.append(piece)
     if pending:
         joined.append(pending)
+    # Inline tables become dotted keys, which the loop below already understands.
+    expanded: "list[str]" = []
     for line in joined:
+        name, separator, raw = line.strip().partition("=")
+        raw = raw.strip()
+        if separator and raw.startswith("{") and raw.endswith("}") and raw[1:-1].strip():
+            expanded.extend(_inline_table_lines(name.strip().strip("\"'"), raw[1:-1]))
+        else:
+            expanded.append(line)
+    for line in expanded:
         stripped = line.strip()
         if stripped.startswith("#") or not stripped:
             continue
@@ -4827,22 +4876,22 @@ def _hardened_settings_in_toml(
                 part.strip().strip("\"'") for part in header.group(1).split(".") if part.strip()
             )
             continue
-        if current not in tables:
-            continue
         key, separator, raw = stripped.partition("=")
         if not separator:
             continue
         key = key.strip().strip("\"'")
-        if "." in key:
-            # A dotted key is the inline spelling of a table: `pip.require-hashes = true`
-            # at the root is `[pip] require-hashes = true`, which uv enforces. Treated as
-            # one literal key it matched nothing and the policy was dropped.
-            head, _, tail = key.rpartition(".")
-            path = current + tuple(
-                part.strip().strip("\"'") for part in head.split(".") if part.strip()
-            )
-            if path not in tables:
-                continue
+        # A dotted key is the inline spelling of a table: `pip.require-hashes = true` at
+        # the root is `[pip] require-hashes = true`, which uv enforces. The table check
+        # has to come AFTER the path is assembled, since the enclosing header can be a
+        # prefix of it rather than a table this scan reads: under `[tool]`, the expanded
+        # `uv.pip.require-hashes` lives in `tool.uv.pip`, which it does read.
+        head, dot, tail = key.rpartition(".")
+        path = current + tuple(
+            part.strip().strip("\"'") for part in head.split(".") if part.strip()
+        )
+        if path not in tables:
+            continue
+        if dot:
             key = tail.strip().strip("\"'")
         if key in _HARDENED_CONFIG_KEYS:
             raw = raw.strip()
@@ -4898,9 +4947,17 @@ def _uv_project_config() -> "list[str]":
     directory included, so it is not listed: reporting one would be hardening uv does
     not apply.
     """
+    # uv's own discovery root, not necessarily this process's: --project / UV_PROJECT
+    # moves it, and --directory / UV_WORKING_DIR moves the working directory itself.
+    # Measured on the pinned uv 0.12.1, a `[tool.uv.pip] require-hashes = true` in a
+    # project named by either variable is enforced from an unrelated cwd, so walking
+    # from getcwd() alone scanned the wrong tree and missed live policy.
+    root = os.environ.get("UV_PROJECT", "").strip() or os.environ.get(
+        "UV_WORKING_DIR", ""
+    ).strip()
     try:
         # A deleted working directory raises here rather than returning anything.
-        current = os.path.abspath(os.getcwd())
+        current = os.path.abspath(root or os.getcwd())
     except OSError:
         return []
     while True:
@@ -4923,14 +4980,16 @@ def _hardened_uv_config_paths() -> "list[str]":
     the order matters because the caller resolves last-wins, and a project config
     switching a control off is uv's answer even when the user config switched it on.
     """
-    if _config_value_is_on(os.environ.get("UV_NO_CONFIG", "")):
-        # --no-config: uv discovers nothing, so nothing here is policy.
-        return []
     explicit = os.environ.get("UV_CONFIG_FILE", "").strip()
     if explicit:
         # --config-file is used "in place of any discovered configuration files", so the
-        # discovered set is not merely outranked, it is not read at all.
+        # discovered set is not merely outranked, it is not read at all. Checked BEFORE
+        # --no-config: measured on the pinned uv 0.12.1, an explicit file is read with
+        # UV_NO_CONFIG=1 set as well, so returning nothing there dropped live policy.
         return _existing_files([explicit])
+    if _config_value_is_on(os.environ.get("UV_NO_CONFIG", "")):
+        # --no-config: uv discovers nothing, so nothing here is policy.
+        return []
     candidates = []
     if IS_WINDOWS:
         for variable in ("PROGRAMDATA", "APPDATA"):
@@ -4984,14 +5043,25 @@ def _hardened_pip_config_paths() -> "list[str]":
         # pip 26, `XDG_CONFIG_DIRS=/a:/b pip config debug` enumerates /a/pip/pip.conf and
         # /b/pip/pip.conf. macOS reads its global set from XDG_DATA_DIRS instead, falling
         # back to /Library/Application Support.
+        #
+        # macOS reads BOTH here, deliberately, because pip changed under us: measured,
+        # pip 26.1 resolves the Darwin global set to /Library/Application Support and
+        # ignores XDG_DATA_DIRS entirely, while 26.2.1 lets XDG_DATA_DIRS replace it.
+        # Either pip can be the one on a user's machine, and a location that only one of
+        # them reads costs a stat, so both are scanned rather than guessing the version.
         directories = os.environ.get("XDG_DATA_DIRS" if IS_MACOS else "XDG_CONFIG_DIRS", "").strip()
+        if IS_MACOS:
+            if "/opt/python" in sys.prefix:
+                # platformdirs puts a Homebrew python's site data under the brew prefix.
+                candidates.append(
+                    os.path.join(sys.prefix.split("/opt/python")[0], "share", "pip", name)
+                )
+            candidates.append(os.path.join("/Library", "Application Support", "pip", name))
         if directories:
             for directory in directories.split(os.pathsep):
                 if directory.strip():
                     candidates.append(os.path.join(directory.strip(), "pip", name))
-        elif IS_MACOS:
-            candidates.append(os.path.join("/Library", "Application Support", "pip", name))
-        else:
+        elif not IS_MACOS:
             candidates.append(os.path.join("/etc", "xdg", "pip", name))
         candidates.append(os.path.join("/etc", name))
         home = os.path.expanduser("~")
@@ -5392,7 +5462,9 @@ def _unenforceable_policy(cmd: "list[str]") -> "list[str]":
 _POLICY_EQUIVALENTS = {
     "require-hashes": ("PIP_REQUIRE_HASHES=1", "UV_REQUIRE_HASHES=1"),
     "no-build": ("PIP_ONLY_BINARY=:all:", "no-build = true in your uv.toml"),
-    "no-binary": ("PIP_NO_BINARY=:all:", "no-binary = true in your uv.toml"),
+    # uv's no-binary is a package LIST, not a flag: `no-binary = true` is a config parse
+    # error there, so naming it would have left the operator with an unusable uv.
+    "no-binary": ("PIP_NO_BINARY=:all:", 'no-binary = [":all:"] in your uv.toml'),
     "exclude-newer": ("PIP_UPLOADED_PRIOR_TO", "UV_EXCLUDE_NEWER"),
 }
 

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -5251,9 +5251,7 @@ def _install_env_for_cmd(cmd: "list[str]") -> "dict[str, str] | None":
     # reach the network on a host that had said not to, which is the opposite of what
     # this branch scrubs the ADDITIVE mirror variables for. If the pinned artifact is
     # not in find-links the step fails, which is what the opt-out promises.
-    keep_offline = _respect_pm_policy() and _config_value_is_on(
-        os.environ.get("PIP_NO_INDEX", "")
-    )
+    keep_offline = _respect_pm_policy() and _config_value_is_on(os.environ.get("PIP_NO_INDEX", ""))
     for name in _UV_INDEX_ENV_VARS:
         # UV_CONFIG_FILE is an index variable only incidentally: measured, a file named
         # by it carrying `[pip] require-hashes = true` fails a pinned install, and

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -5204,18 +5204,14 @@ def _policy_scan() -> "tuple[tuple[tuple[str, str, str], ...], dict[str, frozens
         # subcommand, which is why each one is carried across the files and only combined
         # at the end. Collapsing a file before reading the next let a `[wheel]` setting in
         # a low-priority file erase an `[install]` one pip still applies.
-        by_command: "dict[str, dict[str, tuple[str, str]]]" = {
-            name: {} for name in _PIP_COMMANDS
-        }
+        by_command: "dict[str, dict[str, tuple[str, str]]]" = {name: {} for name in _PIP_COMMANDS}
         for path in _hardened_pip_config_paths():
             text = _read_text(path)
             if text is None:
                 continue
             source = os.path.basename(path)
             for command, values in _hardened_settings_by_command(text).items():
-                by_command[command].update(
-                    {key: (source, value) for key, value in values.items()}
-                )
+                by_command[command].update({key: (source, value) for key, value in values.items()})
         pip_settings.update(_combine_pip_commands(by_command))
     for key, (source, value) in pip_settings.items():
         if _canonical_policy_key(key) not in cancelled["pip"]:

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -4762,6 +4762,12 @@ _BOOLEAN_POLICY_KEYS = ("require-hashes", "no-build")
 # What clears a control of either kind.
 _EMPTY_POLICY_VALUES = ("", ":none:")
 
+# The upload cutoff is a date, but uv accepts `false` for it as "no cutoff": measured on
+# the pinned uv 0.12.1, UV_EXCLUDE_NEWER=false installs the current release while a date
+# filters it. Reading `false` as a cutoff put a security notice in front of an operator
+# who had switched the control off.
+_FALSE_DISABLES_KEYS = ("exclude-newer", "exclude-newer-package", "uploaded-prior-to")
+
 
 def _policy_key_spelling(key: str) -> str:
     """A policy key as its config-file spelling, whichever form it arrived in."""
@@ -4778,7 +4784,7 @@ def _config_value_is_on(value: str, key: "str | None" = None) -> bool:
     if text in _EMPTY_POLICY_VALUES:
         return False
     if key is not None and _policy_key_spelling(key) not in _BOOLEAN_POLICY_KEYS:
-        return True
+        return not (text == "false" and _policy_key_spelling(key) in _FALSE_DISABLES_KEYS)
     return text not in _OFF_VALUES
 
 
@@ -5240,12 +5246,22 @@ def _install_env_for_cmd(cmd: "list[str]") -> "dict[str, str] | None":
         env.update(overrides)
         return env
     env = os.environ.copy()
+    # PIP_NO_INDEX only ever REMOVES sources, so under the opt-out it is kept along with
+    # the PIP_FIND_LINKS it leaves as the sole source. Scrubbing it let a pinned command
+    # reach the network on a host that had said not to, which is the opposite of what
+    # this branch scrubs the ADDITIVE mirror variables for. If the pinned artifact is
+    # not in find-links the step fails, which is what the opt-out promises.
+    keep_offline = _respect_pm_policy() and _config_value_is_on(
+        os.environ.get("PIP_NO_INDEX", "")
+    )
     for name in _UV_INDEX_ENV_VARS:
         # UV_CONFIG_FILE is an index variable only incidentally: measured, a file named
         # by it carrying `[pip] require-hashes = true` fails a pinned install, and
         # dropping it lets the same install through. Under the opt-out it is the
         # operator's policy file, so it stays.
         if name == "UV_CONFIG_FILE" and _respect_pm_policy():
+            continue
+        if keep_offline and name in ("PIP_NO_INDEX", "PIP_FIND_LINKS"):
             continue
         env.pop(name, None)
     if _respect_pm_policy():

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -3737,13 +3737,11 @@ NO_TORCH_SKIP_PACKAGES = {
     "librosa",
 }
 
-# An operator who hardens pip/uv (require-hashes, no-build, only-binary) has their policy
-# relaxed for the installer's OWN dependency installs, because every requirements file we
-# ship is unhashed and a few requirements have no wheel at any version (#8530). The
-# relaxation is scoped to this module's child commands and never written back to
-# os.environ, but it is still their control being set aside, so it is announced once and
-# this variable turns every part of it off. The install then fails on the first step the
-# policy forbids, which is the correct answer for an operator who means it.
+# The installer relaxes a hardened pip/uv policy for its OWN dependency installs: every
+# requirements file we ship is unhashed and a few have no wheel at any version (#8530).
+# That is still the operator's control being set aside, so it is announced once, and this
+# variable turns every part of it off -- the install then fails on the first step the
+# policy forbids, which is the right answer for an operator who means it.
 _POLICY_OPT_OUT_ENV = "UNSLOTH_RESPECT_PM_POLICY"
 
 
@@ -4687,12 +4685,10 @@ def _relaxed_pip_policy_env(cmd: "list[str]") -> "dict[str, str]":
     return {"PIP_REQUIRE_HASHES": "0"}
 
 
-# Settings whose presence means the host has deliberately hardened its package manager,
-# as opposed to merely configuring a mirror. Named in the notice so the operator can see
-# which of their controls the installer is about to set aside. The `-package` and
-# `exclude-newer` spellings are here for the same reason UV_EXCLUDE_NEWER is in
-# _PM_POLICY_ENV_VARS: an upload cutoff is a reproducibility control, and relaxing one
-# silently is the thing this notice exists to stop.
+# Hardening, as opposed to a mirror, which is merely configuration. Named in the notice so
+# the operator sees which control is being set aside. `exclude-newer` is here for the same
+# reason UV_EXCLUDE_NEWER is in _PM_POLICY_ENV_VARS: an upload cutoff is a reproducibility
+# control, and relaxing one silently is what this notice exists to stop.
 _HARDENED_CONFIG_KEYS = (
     "require-hashes",
     "only-binary",
@@ -4726,13 +4722,10 @@ def _toml_value_is_on(value: object) -> bool:
 def _hardened_keys_in_toml(text: str, tables: "tuple[tuple[str, ...], ...]") -> "list[str]":
     """Hardened keys switched ON inside the named tables of a TOML document.
 
-    `tables` is the path to each table to look in, so a uv.toml is read at its root and
-    under `[pip]`, and a pyproject under `[tool.uv]` / `[tool.uv.pip]`, without a stray
-    `no-build` in some unrelated tool's table counting as uv policy.
-
-    tomllib is 3.11+, and this module still runs on older interpreters, so the fallback
-    is a value-capturing regex. Both test the VALUE: reporting `no-build = false` would
-    put a security notice in front of a user who had switched the policy off.
+    `tables` scopes the search, so a stray `no-build` in an unrelated tool's table is not
+    read as uv policy. tomllib is 3.11+ and this module runs on older interpreters, hence
+    the regex fallback; both test the VALUE, since reporting `no-build = false` would put
+    a security notice in front of a user who switched the policy off.
     """
     found: list[str] = []
     data = None
@@ -4779,19 +4772,15 @@ def _existing_files(candidates: "list[str]") -> "list[str]":
 def _hardened_uv_config_paths() -> "list[str]":
     """The uv config files this host has, where a no-build / require-hashes could live.
 
-    System, user, invocation directory and the cwd pyproject, which is what uv actually
-    reads: `~/.config/uv/uv.toml` on macOS AND Linux (not Application Support) and
-    `%APPDATA%\\uv\\uv.toml` on Windows, with `/etc/uv/uv.toml` and `%PROGRAMDATA%\\uv`
-    as the system-wide pair. The system one matters most: a fleet operator hardening every
-    machine puts `no-build` there.
+    `~/.config/uv/uv.toml` on macOS AND Linux (not Application Support), `%APPDATA%\\uv`
+    on Windows, plus the system pair `/etc/uv/uv.toml` and `%PROGRAMDATA%\\uv`. The system
+    one matters most: a fleet operator hardening every machine puts `no-build` there.
 
-    The cwd `pyproject.toml` is included because uv 0.12.1 (the pinned version) really
-    does read it -- measured, `[tool.uv.pip] require-hashes = true` there fails a
-    `uv pip install`, and `-v` logs "Found workspace configuration". A PARENT directory's
-    `pyproject.toml` or `uv.toml` is NOT read by `uv pip install`, and neither is a bare
-    `./uv.toml`: the same probe logs only "Searching for user configuration" and the
-    policy does not apply. `./uv.toml` is kept in the list anyway, since it costs a line
-    of output and other uv subcommands this module drives may yet read it.
+    Measured on the pinned uv 0.12.1: the cwd `pyproject.toml` IS read by `uv pip install`
+    (`[tool.uv.pip] require-hashes = true` fails it, `-v` logs "Found workspace
+    configuration"), while a PARENT `pyproject.toml`/`uv.toml` and even a bare `./uv.toml`
+    are NOT. `./uv.toml` is kept anyway: it costs a line of output, and other uv
+    subcommands this module drives may yet read it.
     """
     candidates = []
     explicit = os.environ.get("UV_CONFIG_FILE", "").strip()
@@ -4822,12 +4811,11 @@ def _hardened_uv_config_paths() -> "list[str]":
 def _hardened_pip_config_paths() -> "list[str]":
     """pip's documented configuration files, for when `python -m pip` cannot be run.
 
-    install.sh creates the venv with uv, which does not seed pip, so at the moment this
-    notice runs `python -m pip config list` returns nonzero and a require-hashes living
-    only in pip.conf is invisible -- while the pip FALLBACK later in the install reads it
-    perfectly well. Locations are pip's own (global, user, site, then PIP_CONFIG_FILE);
-    the subprocess answer is still preferred when it works, because pip merges them in
-    its own documented order and reports the winner.
+    install.sh builds the venv with uv, which seeds no pip, so when this notice runs
+    `pip config list` returns nonzero and a require-hashes living only in pip.conf is
+    invisible -- while the pip FALLBACK later in the install reads it fine. Order is pip's
+    own (global, user, site, PIP_CONFIG_FILE); the subprocess answer still wins when it
+    works, since pip merges them itself.
     """
     name = "pip.ini" if IS_WINDOWS else "pip.conf"
     explicit = os.environ.get("PIP_CONFIG_FILE", "").strip()
@@ -5268,13 +5256,13 @@ def _install_env_for_cmd(cmd: "list[str]") -> "dict[str, str] | None":
     the pin is itself a provenance control and the opt-out is not a request to weaken it
     -- but the policy variables survive, pip.conf is left readable, and uv's config
     discovery is left on, so require-hashes, no-build and only-binary apply to the pinned
-    installs too. Config discovery has to stay: measured on the pinned uv 0.12.1, a user
-    `~/.config/uv/uv.toml` with `[pip] require-hashes = true` fails a pinned install and
-    UV_NO_CONFIG=1 makes the same install succeed, so keeping it would discard exactly the
-    control the opt-out promises to honour. The residual cost is symmetric on both tools:
-    an `extra-index-url` in pip.conf, or an `[[index]]` in that uv.toml, can still add a
-    candidate source under the opt-out. That is the price of reading the same files'
-    security settings, and it is why the default path does the opposite.
+    installs too. Config discovery has to stay on: measured on the pinned uv 0.12.1, a
+    user `~/.config/uv/uv.toml` with `[pip] require-hashes = true` fails a pinned install
+    and UV_NO_CONFIG=1 makes it succeed, so setting it would discard the very control the
+    opt-out promises. The cost is symmetric on both tools: an `extra-index-url` in
+    pip.conf, or an `[[index]]` in that uv.toml, can still add a candidate source. That is
+    the price of reading the same files' security settings, and why the default is the
+    opposite.
     """
     if not _is_pinned_index_cmd(cmd):
         relaxed = _relaxed_pip_policy_env(cmd)
@@ -5398,10 +5386,9 @@ def pip_install(
                     _safe_print(_redact_install_output(result.stdout))
                 return
             if _respect_pm_policy():
-                # The fallback exists to rescue a uv failure, but pip reads none of uv's
-                # policy: under the opt-out it would retry the very install uv refused
-                # and succeed, which is the bypass the flag was set to prevent. Stop
-                # instead, on the same terms as any other fatal step.
+                # pip reads none of uv's policy, so under the opt-out the fallback would
+                # retry the very install uv refused, and succeed. Stop instead, on the
+                # same terms as any other fatal step.
                 if result.stdout:
                     _safe_print(_redact_install_output(result.stdout))
                 _safe_print(
@@ -5573,13 +5560,9 @@ def install_python_stack() -> int:
     # absent torch as a stale venv, and tries to delete the running environment.
     install_manifest.set_no_torch_marker(NO_TORCH)
 
-    # Before the bar starts, so the line cannot land mid-progress: on a hardened host,
-    # say which controls are relaxed for the installer's own dependency installs and how
-    # to keep them. Silent on every ordinary machine.
-    #
-    # Guarded because this is a message, not a step. It probes pip and reads files the
-    # install itself never touches, and no failure of that probing is worth aborting an
-    # install over -- the worst case is that the notice is missing.
+    # Before the bar starts, so the line cannot land mid-progress. Silent on an ordinary
+    # machine. Guarded because this is a message, not a step: it probes pip and reads
+    # files the install never touches, and no failure of that is worth aborting over.
     try:
         _announce_pm_policy()
     except Exception:

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 import ast
 import functools
 import glob
-import hashlib
 import importlib
 import importlib.util
 import json

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -2743,13 +2743,25 @@ def _ensure_xpu_triton() -> None:
         # with it. pip_install, not pip_install_try -- a warning would let the caller write a
         # completion manifest over a venv whose torch.compile is broken, which the next update
         # then fast-paths past (no generic distribution is left to trigger on).
-        pip_install(
-            "triton (Intel XPU)",
-            "--force-reinstall",
-            "--no-deps",
-            wheels[0],
-            constrain = False,
-        )
+        # The wheel is a bare file reference, which require-hashes rejects. This install
+        # runs with the venv already stripped of triton and cannot be retried later --
+        # no generic distribution is left to trigger on -- so under the opt-out it goes
+        # through the wheel's own sha256, exactly as the metadata restore does.
+        requirements = _hashed_requirement_file(wheels[0]) if _respect_pm_policy() else ""
+        try:
+            pip_install(
+                "triton (Intel XPU)",
+                "--force-reinstall",
+                "--no-deps",
+                *(("-r", requirements) if requirements else (wheels[0],)),
+                constrain = False,
+            )
+        finally:
+            if requirements:
+                try:
+                    os.unlink(requirements)
+                except OSError:
+                    pass
     finally:
         shutil.rmtree(tmp, ignore_errors = True)
 
@@ -4175,6 +4187,26 @@ class _QuarantinedMetadata:
         self._copied.clear()
 
 
+def _hashed_requirement_file(wheel: str) -> str:
+    """A requirements file pinning `wheel` by its own sha256, or "" if it cannot be made.
+
+    Under the opt-out, an install of a wheel this installer just fetched or built has to
+    satisfy require-hashes rather than be exempted from it. Each such install also runs
+    AFTER something has been uninstalled, so being refused there leaves the venv missing
+    the package rather than merely unchanged.
+    """
+    try:
+        digest = hashlib.sha256(Path(wheel).read_bytes()).hexdigest()
+        handle = tempfile.NamedTemporaryFile(
+            "w", suffix = ".txt", delete = False, encoding = "utf-8"
+        )
+        with handle:
+            handle.write(f"{os.path.abspath(wheel)} --hash=sha256:{digest}\n")
+    except OSError:
+        return ""
+    return handle.name
+
+
 def _staged_restore_args(name: str, staged: str) -> "tuple[list[str], str]":
     """pip arguments that reinstall `name` from the staged wheel directory.
 
@@ -4203,14 +4235,10 @@ def _staged_restore_args(name: str, staged: str) -> "tuple[list[str], str]":
     if not wheel:
         # Nothing to hash, so nothing better to offer than the default and its error.
         return default, ""
-    try:
-        digest = hashlib.sha256(Path(wheel).read_bytes()).hexdigest()
-        handle = tempfile.NamedTemporaryFile("w", suffix = ".txt", delete = False, encoding = "utf-8")
-        with handle:
-            handle.write(f"{os.path.abspath(wheel)} --hash=sha256:{digest}\n")
-    except OSError:
+    requirements = _hashed_requirement_file(wheel)
+    if not requirements:
         return default, ""
-    return ["--no-deps", "--force-reinstall", "--no-index", "-r", handle.name], handle.name
+    return ["--no-deps", "--force-reinstall", "--no-index", "-r", requirements], requirements
 
 
 def _restore_from_staged(
@@ -4743,7 +4771,12 @@ def _relaxed_pip_policy_env(cmd: "list[str]") -> "dict[str, str]":
 # A pip.conf carrying one of those is an inert entry pip ignores, so reading it as pip
 # policy invents hardening the host does not have -- which under the opt-out made the
 # first uv step refuse over a cross-manager gap that was not one.
-_PIP_CONFIG_KEYS = ("require-hashes", "only-binary", "no-binary", "uploaded-prior-to")
+# `no-index` is here for the same reason it is kept under the opt-out: it REMOVES every
+# remote source, and the pinned branch discards it along with the rest of pip.conf, which
+# is exactly the kind of silent override this notice exists to disclose.
+_PIP_CONFIG_KEYS = (
+    "require-hashes", "only-binary", "no-binary", "uploaded-prior-to", "no-index",
+)
 
 
 # pip's own strtobool false set, verbatim, plus the empty and ":none:" spellings that mean
@@ -4757,7 +4790,7 @@ _OFF_VALUES = ("n", "no", "f", "false", "off", "0")
 # map or a date, where pip documents `:none:` as the way to clear the set and every other
 # value names something real: `PIP_ONLY_BINARY=no` restricts a distribution called "no",
 # and reading it as a disabled flag dropped an artifact rule that was fully in force.
-_BOOLEAN_POLICY_KEYS = ("require-hashes", "no-build")
+_BOOLEAN_POLICY_KEYS = ("require-hashes", "no-build", "no-index")
 
 # What clears a control of either kind.
 _EMPTY_POLICY_VALUES = ("", ":none:")
@@ -4879,12 +4912,20 @@ def _detected_policy() -> "tuple[tuple[str, str, str], ...]":
                 continue
             # Printed in load order, so the last definition of a given entry wins.
             settings[(section, option)] = raw.strip().strip("'\"")
-        for (_section, option), value in settings.items():
-            if (
-                _config_value_is_on(value, option)
-                and _canonical_policy_key(option) not in cancelled
-            ):
-                on.append(("pip", "pip.conf", option))
+        # pip applies `[global]` and then the command's own section, so a control the
+        # operator enabled globally and disabled for install, download AND wheel is not
+        # hardening any command this module runs. Reporting it there put the notice in
+        # front of someone whose policy was not being relaxed at all.
+        for option in _PIP_CONFIG_KEYS:
+            if _canonical_policy_key(option) in cancelled:
+                continue
+            for command in _PIP_COMMANDS:
+                value = settings.get(
+                    (command, option), settings.get(("global", option))
+                )
+                if value is not None and _config_value_is_on(value, option):
+                    on.append(("pip", "pip.conf", option))
+                    break
 
     return tuple(dict.fromkeys(on))
 

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -4807,7 +4807,8 @@ def _hardened_keys_in_toml(text: str, tables: "tuple[tuple[str, ...], ...]") -> 
     switched the policy off.
     """
     return [
-        key for key, value in _hardened_settings_in_toml(text, tables).items()
+        key
+        for key, value in _hardened_settings_in_toml(text, tables).items()
         if _config_value_is_on(value)
     ]
 

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -3731,6 +3731,22 @@ NO_TORCH_SKIP_PACKAGES = {
     "librosa",
 }
 
+# An operator who hardens pip/uv (require-hashes, no-build, only-binary) has their policy
+# relaxed for the installer's OWN dependency installs, because every requirements file we
+# ship is unhashed and a few requirements have no wheel at any version (#8530). The
+# relaxation is scoped to this module's child commands and never written back to
+# os.environ, but it is still their control being set aside, so it is announced once and
+# this variable turns every part of it off. The install then fails on the first step the
+# policy forbids, which is the correct answer for an operator who means it.
+_POLICY_OPT_OUT_ENV = "UNSLOTH_RESPECT_PM_POLICY"
+
+
+def _respect_pm_policy() -> bool:
+    """True when the operator asked for their pip/uv policy to be left in force."""
+    value = os.environ.get(_POLICY_OPT_OUT_ENV, "").strip().lower()
+    return value not in ("", "0", "false", "no")
+
+
 # Requirements with NO wheel on PyPI at any version, so the installer has always built
 # them from source. antlr4-python3-runtime arrives transitively: omegaconf==2.3.1 pins it
 # below the 4.13.2 wheel.
@@ -3756,7 +3772,12 @@ def _sdist_only_build_args(*names: str) -> list[str]:
 
     Naming a package that the resolution never reaches is harmless (verified), so this
     is safe next to the NO_TORCH / Windows requirement filtering.
+
+    Empty under UNSLOTH_RESPECT_PM_POLICY: the exemption exists only to override a
+    user-level no-build/only-binary, so declining to override it is the whole opt-out.
     """
+    if _respect_pm_policy():
+        return []
     args: list[str] = []
     for name in names:
         args += ["--no-binary", name]
@@ -4647,10 +4668,119 @@ def _relaxed_pip_policy_env(cmd: "list[str]") -> "dict[str, str]":
     every requirements file we ship; that is what took the pip FALLBACK down in #8530
     once uv had failed. pip applies env vars AFTER config files, so PIP_REQUIRE_HASHES=0
     overrides it while pip.conf's index-url, trusted-host, cert and proxy stay in force.
+
+    Empty under UNSLOTH_RESPECT_PM_POLICY, so an operator who would rather the install
+    stop than proceed unhashed gets exactly that.
     """
+    if _respect_pm_policy():
+        return {}
     if cmd[:1] == ["uv"] or not any(arg in ("install", "download", "wheel") for arg in cmd):
         return {}
     return {"PIP_REQUIRE_HASHES": "0"}
+
+
+# Settings whose presence means the host has deliberately hardened its package manager,
+# as opposed to merely configuring a mirror. Named in the notice so the operator can see
+# which of their controls the installer is about to set aside.
+_HARDENED_CONFIG_KEYS = ("require-hashes", "only-binary", "no-binary", "no-build")
+
+
+def _config_value_is_on(value: str) -> bool:
+    """A config/env value that turns a policy ON rather than off or empty."""
+    return value.strip().lower() not in ("", "0", "false", "no", "none", ":none:")
+
+
+def _hardened_uv_config_paths() -> "list[str]":
+    """The uv config files this host has, where a no-build / require-hashes could live.
+
+    The user config and the invocation directory only. uv also reads a pyproject
+    [tool.uv] and a workspace root above the cwd; those are left out deliberately -- this
+    list drives a NOTICE, and missing one costs a line of output, not a behaviour change.
+    """
+    candidates = []
+    explicit = os.environ.get("UV_CONFIG_FILE", "").strip()
+    if explicit:
+        candidates.append(explicit)
+    if IS_WINDOWS:
+        appdata = os.environ.get("APPDATA", "")
+        if appdata:
+            candidates.append(os.path.join(appdata, "uv", "uv.toml"))
+    else:
+        base = os.environ.get("XDG_CONFIG_HOME") or os.path.expanduser("~/.config")
+        candidates.append(os.path.join(base, "uv", "uv.toml"))
+    candidates.append(os.path.join(os.getcwd(), "uv.toml"))
+    return [path for path in candidates if os.path.isfile(path)]
+
+
+@functools.lru_cache(maxsize = 1)
+def _hardened_pm_policy_names() -> "tuple[str, ...]":
+    """Human-readable names for the package-manager hardening this host has configured.
+
+    Empty on an ordinary machine, which is the common case and the reason the notice is
+    silent by default. Best-effort throughout: this decides what to PRINT, never what to
+    run, so a probe that fails just shortens the list.
+    """
+    found = [
+        name
+        for name in _PM_POLICY_ENV_VARS
+        if _config_value_is_on(os.environ.get(name, ""))
+    ]
+    try:
+        result = subprocess.run(
+            [sys.executable, "-m", "pip", "config", "list"],
+            stdout = subprocess.PIPE,
+            stderr = subprocess.DEVNULL,
+            **_windows_hidden_subprocess_kwargs(),
+        )
+    except OSError:
+        result = None
+    if result is not None and result.returncode == 0:
+        for line in (result.stdout or b"").decode("utf-8", "replace").splitlines():
+            name, separator, raw = line.partition("=")
+            # `:env:` entries restate the environment, already covered above.
+            if not separator or name.strip().startswith(":env:"):
+                continue
+            option = name.strip().rpartition(".")[2]
+            if option in _HARDENED_CONFIG_KEYS and _config_value_is_on(raw.strip().strip("'\"")):
+                found.append(f"pip.conf {option}")
+    for path in _hardened_uv_config_paths():
+        try:
+            with open(path, encoding = "utf-8", errors = "replace") as handle:
+                text = handle.read()
+        except OSError:
+            continue
+        for key in _HARDENED_CONFIG_KEYS:
+            # Line-anchored so a commented-out setting, or the same word inside a longer
+            # key, is not reported as active policy.
+            if re.search(rf"^\s*{re.escape(key)}\s*=", text, re.MULTILINE):
+                found.append(f"{os.path.basename(path)} {key}")
+    return tuple(dict.fromkeys(found))
+
+
+def _announce_pm_policy() -> None:
+    """Say once, up front, what the installer is doing with a hardened host's policy.
+
+    Silent when nothing is hardened, which is every ordinary machine.
+    """
+    names = _hardened_pm_policy_names()
+    if not names:
+        return
+    listed = ", ".join(names)
+    if _respect_pm_policy():
+        _note(
+            f"{_POLICY_OPT_OUT_ENV} is set: keeping {listed} in force for Unsloth's own "
+            "dependency installs. Steps whose requirements are unhashed, or have no "
+            "wheel at any version, will fail rather than be installed.",
+            _cyan,
+        )
+        return
+    _note(
+        f"Package manager hardening detected ({listed}). Unsloth relaxes it for its own "
+        "dependency installs only -- the shipped requirements are unhashed and a few have "
+        "no wheel at any version -- and never for your other pip commands. Set "
+        f"{_POLICY_OPT_OUT_ENV}=1 to keep your policy in force instead.",
+        _cyan,
+    )
 
 
 def _uv_is_offline() -> bool:
@@ -4948,6 +5078,16 @@ def _install_env_for_cmd(cmd: "list[str]") -> "dict[str, str] | None":
     A non-pinned `pip` command also gets hash-required mode switched off, the one
     relaxation with no command-line equivalent; the wheel-less requirements go through
     the package-scoped --no-binary in _sdist_only_build_args() instead.
+
+    Under UNSLOTH_RESPECT_PM_POLICY the pinned branch still scrubs the INDEX variables --
+    the pin is itself a provenance control and the opt-out is not a request to weaken it
+    -- but the policy variables survive and pip.conf is left readable, so require-hashes,
+    no-build and only-binary apply to the pinned installs too. The residual cost is that
+    an `extra-index-url` in pip.conf can still add a candidate source to the pip fallback;
+    that is the price of honouring the same file's security settings. UV_NO_CONFIG stays
+    on either way because uv has no surgical equivalent, and the only pinned installs are
+    wheel-only torch repairs, which a uv.toml no-build was never going to block; the
+    UV_REQUIRE_HASHES / UV_NO_BUILD spellings that CAN reach them are preserved.
     """
     if not _is_pinned_index_cmd(cmd):
         relaxed = _relaxed_pip_policy_env(cmd)
@@ -4959,9 +5099,11 @@ def _install_env_for_cmd(cmd: "list[str]") -> "dict[str, str] | None":
     env = os.environ.copy()
     for name in _UV_INDEX_ENV_VARS:
         env.pop(name, None)
+    env["UV_NO_CONFIG"] = "1"
+    if _respect_pm_policy():
+        return env
     for name in _PM_POLICY_ENV_VARS:
         env.pop(name, None)
-    env["UV_NO_CONFIG"] = "1"
     env["PIP_CONFIG_FILE"] = os.devnull
     return env
 
@@ -5228,6 +5370,11 @@ def install_python_stack() -> int:
     # pass killed part-way. Otherwise the next update sees neither, reads the
     # absent torch as a stale venv, and tries to delete the running environment.
     install_manifest.set_no_torch_marker(NO_TORCH)
+
+    # Before the bar starts, so the line cannot land mid-progress: on a hardened host,
+    # say which controls are relaxed for the installer's own dependency installs and how
+    # to keep them. Silent on every ordinary machine.
+    _announce_pm_policy()
 
     # 1. Try uv for faster installs (before pip upgrade -- uv venvs don't
     #    include pip by default).

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -4879,21 +4879,30 @@ def _hardened_pip_config_paths() -> "list[str]":
     return _existing_files(candidates)
 
 
-def _hardened_keys_in_ini(text: str) -> "list[str]":
-    """Hardened keys switched ON in a pip.conf, in any of its sections."""
+def _hardened_settings_in_ini(text: str) -> "dict[str, str]":
+    """Hardened keys DEFINED in a pip.conf, with their values, in any of its sections.
+
+    Values rather than a filtered list of on-keys, because precedence is resolved across
+    files: a later pip.conf setting `require-hashes = false` has to be able to cancel an
+    earlier one, and a caller that only ever saw the enabled keys could not do that.
+    """
     parser = configparser.RawConfigParser()
     try:
         parser.read_string(text)
     except configparser.Error:
-        return []
-    found = []
+        return {}
+    settings: dict[str, str] = {}
     for section in parser.sections():
         for key in _HARDENED_CONFIG_KEYS:
             if parser.has_option(section, key):
-                value = parser.get(section, key, fallback = "")
-                if _config_value_is_on(value):
-                    found.append(key)
-    return found
+                settings[key] = parser.get(section, key, fallback = "")
+    return settings
+
+
+def _hardened_keys_in_ini(text: str) -> "list[str]":
+    """Hardened keys switched ON in a single pip.conf."""
+    return [key for key, value in _hardened_settings_in_ini(text).items()
+            if _config_value_is_on(value)]
 
 
 def _read_text(path: str) -> "str | None":
@@ -4936,23 +4945,40 @@ def _detected_policy() -> "tuple[tuple[str, str, str], ...]":
     except (OSError, subprocess.SubprocessError):
         result = None
     if result is not None and result.returncode == 0:
+        # `pip config list` prints EVERY definition, including ones a
+        # higher-precedence file overrides: a user pip.conf require-hashes=true and a
+        # venv site pip.conf require-hashes=false emit both lines, and pip enforces the
+        # second. Measured on pip 26.2.1, `config get` returns false there and the
+        # install is not hash-checked, so taking any enabled occurrence would announce a
+        # policy pip does not apply. The lines come in load order, so last wins.
+        effective: "dict[str, str]" = {}
         for line in (result.stdout or b"").decode("utf-8", "replace").splitlines():
             name, separator, raw = line.partition("=")
             # `:env:` entries restate the environment, already covered above.
             if not separator or name.strip().startswith(":env:"):
                 continue
             option = name.strip().rpartition(".")[2]
-            if option in _HARDENED_CONFIG_KEYS and _config_value_is_on(raw.strip().strip("'\"")):
+            if option in _HARDENED_CONFIG_KEYS:
+                effective[option] = raw.strip().strip("'\"")
+        for option, value in effective.items():
+            if _config_value_is_on(value):
                 found.append(("pip", "pip.conf", option))
     else:
         # No usable pip, so read pip's files directly rather than report an ordinary
         # machine. Only in this branch: when pip answered, it already merged them.
+        # _hardened_pip_config_paths returns them in pip's own load order, so the same
+        # last-wins resolution applies here: a site pip.conf turning a policy off must
+        # cancel the user pip.conf that turned it on.
+        winners: "dict[str, tuple[str, str]]" = {}
         for path in _hardened_pip_config_paths():
             text = _read_text(path)
             if text is None:
                 continue
-            for key in _hardened_keys_in_ini(text):
-                found.append(("pip", os.path.basename(path), key))
+            for key, value in _hardened_settings_in_ini(text).items():
+                winners[key] = (os.path.basename(path), value)
+        for key, (basename, value) in winners.items():
+            if _config_value_is_on(value):
+                found.append(("pip", basename, key))
     for path in _hardened_uv_config_paths():
         text = _read_text(path)
         if text is None:

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -2686,11 +2686,15 @@ def _ensure_xpu_triton() -> None:
         # an optimisation -- torch.compile using the XPU -- so under the opt-out it is
         # skipped BEFORE the download, leaving the venv exactly as it was rather than
         # without triton at all, which no rerun could repair.
+        # Worded without naming a control the operator may not have set: the swap is
+        # skipped for the opt-out itself, not for a hash policy specifically.
         _safe_print(
             _red(
                 f"   {_POLICY_OPT_OUT_ENV} is set and the XPU triton swap would have to "
-                f"install a wheel your hash policy cannot verify; leaving generic triton "
-                f"{generic} in place -- torch.compile will not use the XPU."
+                f"remove generic triton {generic} before installing a wheel your policy "
+                f"may refuse, which no rerun could repair; leaving it in place -- "
+                f"torch.compile will not use the XPU. Unset {_POLICY_OPT_OUT_ENV} for "
+                f"one run to take the swap."
             )
         )
         return
@@ -5267,26 +5271,31 @@ def _install_env_for_cmd(cmd: "list[str]") -> "dict[str, str] | None":
         env.update(overrides)
         return env
     env = os.environ.copy()
-    # PIP_NO_INDEX only ever REMOVES sources, so under the opt-out it is kept along with
-    # the PIP_FIND_LINKS it leaves as the sole source. Scrubbing it let a pinned command
-    # reach the network on a host that had said not to, which is the opposite of what
-    # this branch scrubs the ADDITIVE mirror variables for. If the pinned artifact is
-    # not in find-links the step fails, which is what the opt-out promises.
+    respect = _respect_pm_policy()
+    # PIP_NO_INDEX is a POLICY variable, not an additive one, and it is kept under the
+    # opt-out whichever way it points. Keeping it only when ON was wrong in the other
+    # direction: pip reads the environment ahead of pip.conf, so PIP_NO_INDEX=0 is how an
+    # operator lifts a `no-index = true` in their own config for one run. Measured on pip
+    # 26.2.1, pip.conf `no-index = true` alone fails with "No matching distribution
+    # found", and the same command with PIP_NO_INDEX=0 resolves. Dropping the variable
+    # while leaving pip.conf readable therefore reimposed a restriction the operator had
+    # lifted, and failed an install they had permitted.
+    #
     # Read as the BOOLEAN it is: without the key this fell through to the generic
     # reading, where `:none:` counts as empty and the variable was dropped even though
     # pip rejects that value outright.
-    keep_offline = _respect_pm_policy() and _config_value_is_on(
-        os.environ.get("PIP_NO_INDEX", ""),
-        "no-index",
-    )
+    no_index_on = _config_value_is_on(os.environ.get("PIP_NO_INDEX", ""), "no-index")
     for name in _UV_INDEX_ENV_VARS:
         # UV_CONFIG_FILE is an index variable only incidentally: measured, a file named
         # by it carrying `[pip] require-hashes = true` fails a pinned install, and
         # dropping it lets the same install through. Under the opt-out it is the
         # operator's policy file, so it stays.
-        if name == "UV_CONFIG_FILE" and _respect_pm_policy():
+        if respect and name in ("UV_CONFIG_FILE", "PIP_NO_INDEX"):
             continue
-        if keep_offline and name in ("PIP_NO_INDEX", "PIP_FIND_LINKS"):
+        # PIP_FIND_LINKS genuinely IS additive, so it survives only while no-index is in
+        # force and it is the sole remaining source. With no-index off it would add a
+        # location alongside the pinned index, which is what this loop exists to stop.
+        if respect and name == "PIP_FIND_LINKS" and no_index_on:
             continue
         env.pop(name, None)
     if _respect_pm_policy():

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -4178,18 +4178,15 @@ class _QuarantinedMetadata:
 def _staged_restore_args(name: str, staged: str) -> "tuple[list[str], str]":
     """pip arguments that reinstall `name` from the staged wheel directory.
 
-    By default the wheel is named as a bare requirement and pip resolves it out of
-    `--find-links`. Under the opt-out that is rejected: require-hashes wants every
-    requirement pinned with `==` and carrying a hash, and a bare name is neither. The
-    restore runs AFTER the uninstall loop has already deleted the package records, so
-    failing there leaves the core package gone -- measured, pip answers "In
-    --require-hashes mode, all requirements must have their versions pinned with ==".
+    By default the wheel is a bare requirement resolved out of `--find-links`. Under the
+    opt-out require-hashes rejects that, and the restore runs AFTER the uninstall loop
+    has deleted the package records, so failing there leaves the core package gone.
 
-    The staged wheel is a local file this installer just built, so its hash is knowable.
-    Under the opt-out the restore is written into a requirements file carrying the real
-    sha256 of that exact artifact, which satisfies the policy honestly instead of
-    relaxing it for this one command or abandoning the repair. Measured: pip accepts it
-    and installs under PIP_REQUIRE_HASHES=1.
+    The staged wheel is a local file this installer just built, so its hash is knowable:
+    the restore goes through a requirements file carrying the real sha256, satisfying
+    the policy instead of relaxing it for one command or abandoning the repair.
+    Measured on pip 26.2.1, both directions -- accepted under PIP_REQUIRE_HASHES=1, and
+    "THESE PACKAGES DO NOT MATCH THE HASHES" once the wheel is altered.
 
     Returns (arguments, a temporary requirements file to delete, or "").
     """
@@ -4707,38 +4704,29 @@ _PM_POLICY_ENV_VARS = (
 )
 
 
-# Of the uv variables above, the ones uv actually reads. Measured against the pinned uv
-# 0.12.1: UV_REQUIRE_HASHES and UV_EXCLUDE_NEWER change the outcome, while UV_NO_BUILD,
-# UV_NO_BUILD_PACKAGE, UV_ONLY_BINARY and UV_NO_BINARY are ignored -- the same source
-# directory installs with any of them set and is refused by the matching --no-build /
-# --no-binary flag or a uv.toml carrying it. `uv help pip install` documents no `[env:]`
-# spelling for those four either.
-#
-# They stay in the strip list above, since removing a variable uv ignores costs nothing.
-# They must not count as DETECTED policy though: reporting one as hardening uv applies
-# both puts a false line in the notice and, worse, lets it stand in for a control uv
-# would really enforce, hiding a genuine cross-manager gap under the opt-out.
+# Of the uv variables above, the ones uv actually reads. Measured on the pinned uv
+# 0.12.1: only these two change the outcome; UV_NO_BUILD, UV_NO_BUILD_PACKAGE,
+# UV_ONLY_BINARY and UV_NO_BINARY are ignored, and `uv help pip install` documents no
+# `[env:]` spelling for them. They stay in the strip list, which costs nothing, but must
+# not be REPORTED, or the notice names policy uv does not apply.
 _UV_ENFORCED_ENV_VARS = ("UV_REQUIRE_HASHES", "UV_EXCLUDE_NEWER")
 
 
 def _relaxed_pip_policy_env(cmd: "list[str]") -> "dict[str, str]":
     """Overrides that stop a hardened user pip config failing the installer's own pip.
 
-    Empty for anything that is not a `pip install` / `pip download` / `pip wheel` this
-    module drives, every `uv` command included, so the "non-pinned installs inherit the
-    caller env unchanged" contract holds on a machine with no hostile pip config.
-    `wheel` is in that set because the duplicate-metadata repair stages its replacement
-    with `pip wheel`, where require-hashes applies exactly as it does to install: an
-    unpinned name is rejected before anything is built, so the repair would abort on a
-    hardened machine and leave the conflict it exists to remove.
+    Empty for anything that is not a `pip install` / `download` / `wheel` this module
+    drives, `uv` included, so non-pinned installs inherit the caller env unchanged.
+    `wheel` is in the set because the duplicate-metadata repair stages its replacement
+    with it, and require-hashes rejects an unpinned name there before anything is built.
 
-    `require-hashes = true` makes pip reject any requirement without a --hash, which is
-    every requirements file we ship; that is what took the pip FALLBACK down in #8530
-    once uv had failed. pip applies env vars AFTER config files, so PIP_REQUIRE_HASHES=0
-    overrides it while pip.conf's index-url, trusted-host, cert and proxy stay in force.
+    `require-hashes = true` rejects any requirement without a --hash, which is every
+    requirements file we ship; that took the pip FALLBACK down in #8530 once uv had
+    failed. pip applies env vars AFTER config files, so PIP_REQUIRE_HASHES=0 overrides
+    it while pip.conf's index-url, trusted-host, cert and proxy stay in force.
 
-    Empty under UNSLOTH_RESPECT_PM_POLICY, so an operator who would rather the install
-    stop than proceed unhashed gets exactly that.
+    Empty under UNSLOTH_RESPECT_PM_POLICY: an operator who would rather the install stop
+    than proceed unhashed gets exactly that.
     """
     if _respect_pm_policy():
         return {}
@@ -4829,22 +4817,17 @@ _PIP_COMMANDS = ("install", "download", "wheel")
 def _detected_policy() -> "tuple[tuple[str, str, str], ...]":
     """(tool, source, key) for each hardening this host has configured.
 
-    ADVISORY, and deliberately narrow. It reports what the two managers can be ASKED
-    about -- the policy environment variables, and pip's own `pip config list` output --
-    and does not go looking through their configuration files.
+    ADVISORY, and deliberately narrow: it reports what the managers can be ASKED about,
+    the policy environment variables and pip's own `pip config list`, and does not read
+    their config files. Doing that means reimplementing pip's and uv's configuration
+    resolution -- discovery order, per-subcommand sections, precedence, XDG against
+    Darwin paths, uv workspace roots, UV_PROJECT / UV_WORKING_DIR / UV_CONFIG_FILE, and
+    a TOML parser for the interpreters with no tomllib. It was built here and removed:
+    an unbounded surface that nothing in the fix depends on.
 
-    Reading those files means reimplementing pip's and uv's configuration resolution:
-    discovery order, per-subcommand sections, precedence between them, XDG against
-    Darwin paths, uv workspace roots, UV_PROJECT / UV_WORKING_DIR / UV_CONFIG_FILE
-    interactions, and a TOML parser for the interpreters with no tomllib. That was
-    tried here and it is an unbounded surface: each round of review found another true
-    difference from the real thing, and some of those corrections introduced their own.
-    Nothing in the actual fix depends on it, so it asks instead of emulating.
-
-    The cost is that a pip.conf-only policy is invisible while the venv has no pip yet,
-    which is the state uv leaves a fresh venv in. The consequence of a miss is a line
-    absent from a notice, never a changed install: the opt-out withholds the relaxations
-    mechanically, whether or not anything was detected.
+    So a pip.conf-only policy is invisible while the venv has no pip yet, which is how
+    uv leaves a fresh one. A miss costs a line in a notice, never an install: the
+    opt-out withholds the relaxations whether or not anything was detected.
     """
     on: "list[tuple[str, str, str]]" = []
     cancelled: "set[str]" = set()
@@ -5231,8 +5214,8 @@ def _pip_supports_upload_cutoff() -> bool:
 def _install_env_for_cmd(cmd: "list[str]") -> "dict[str, str] | None":
     """Return an env with the uv index vars stripped for a pinned-index install.
 
-    None (inherit env) when the command does NOT pin an index, so ordinary installs honour
-    the user's mirror. For pinned commands, the uv index/backend vars are removed,
+    None (inherit env) when the command does NOT pin an index, so ordinary installs
+    honour the user's mirror. For pinned commands the uv index/backend vars are removed,
     UV_NO_CONFIG=1 set (a discovered uv.toml outranks the CLI pin), and PIP_CONFIG_FILE
     pointed at os.devnull for the pip fallback. Mirrors install.sh's gate (#6898).
 
@@ -5241,16 +5224,14 @@ def _install_env_for_cmd(cmd: "list[str]") -> "dict[str, str] | None":
     the package-scoped --no-binary in _sdist_only_build_args() instead.
 
     Under UNSLOTH_RESPECT_PM_POLICY the pinned branch still scrubs the INDEX variables --
-    the pin is itself a provenance control and the opt-out is not a request to weaken it
-    -- but the policy variables survive, pip.conf is left readable, and uv's config
-    discovery is left on, so require-hashes, no-build and only-binary apply to the pinned
-    installs too. Config discovery has to stay on: measured on the pinned uv 0.12.1, a
-    user `~/.config/uv/uv.toml` with `[pip] require-hashes = true` fails a pinned install
-    and UV_NO_CONFIG=1 makes it succeed, so setting it would discard the very control the
-    opt-out promises. The cost is symmetric on both tools: an `extra-index-url` in
-    pip.conf, or an `[[index]]` in that uv.toml, can still add a candidate source. That is
-    the price of reading the same files' security settings, and why the default is the
-    opposite.
+    the pin is itself a provenance control -- but the policy variables survive, pip.conf
+    stays readable and uv's config discovery stays on, so the operator's controls apply
+    to pinned installs too. Discovery has to stay on: measured on the pinned uv 0.12.1, a
+    user uv.toml `[pip] require-hashes = true` fails a pinned install and UV_NO_CONFIG=1
+    makes it succeed, so setting it would discard the control the opt-out promises. The
+    cost is symmetric: an `extra-index-url` in pip.conf, or an `[[index]]` in that
+    uv.toml, can still add a candidate source. That is the price of reading the same
+    files' security settings, and why the default is the opposite.
     """
     if not _is_pinned_index_cmd(cmd):
         overrides = _relaxed_pip_policy_env(cmd)

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -4833,6 +4833,17 @@ def _hardened_settings_in_toml(
         if not separator:
             continue
         key = key.strip().strip("\"'")
+        if "." in key:
+            # A dotted key is the inline spelling of a table: `pip.require-hashes = true`
+            # at the root is `[pip] require-hashes = true`, which uv enforces. Treated as
+            # one literal key it matched nothing and the policy was dropped.
+            head, _, tail = key.rpartition(".")
+            path = current + tuple(
+                part.strip().strip("\"'") for part in head.split(".") if part.strip()
+            )
+            if path not in tables:
+                continue
+            key = tail.strip().strip("\"'")
         if key in _HARDENED_CONFIG_KEYS:
             raw = raw.strip()
             if re.fullmatch(r"\[\s*\]|\{\s*\}", raw):
@@ -5068,16 +5079,26 @@ def _combine_pip_commands(
     return combined
 
 
+def _pip_slot(command: str) -> str:
+    """The name a pip subcommand's own configured-policy set is kept under."""
+    return f"pip:{command}"
+
+
+def _resolve_pip_sections(
+    pooled: "dict[str, dict[str, tuple[str, str]]]",
+) -> "dict[str, dict[str, tuple[str, str]]]":
+    """pip's own resolution, per subcommand: `[global]` first, then its own section."""
+    return {
+        command: dict(pooled.get("global", {}), **pooled.get(command, {}))
+        for command in _PIP_COMMANDS
+    }
+
+
 def _combine_pip_sections(
     pooled: "dict[str, dict[str, tuple[str, str]]]",
 ) -> "dict[str, tuple[str, str]]":
-    """pip's own resolution: `[global]` first, then the command's own section."""
-    return _combine_pip_commands(
-        {
-            command: dict(pooled.get("global", {}), **pooled.get(command, {}))
-            for command in _PIP_COMMANDS
-        }
-    )
+    """The three subcommands' resolved settings, combined into one answer."""
+    return _combine_pip_commands(_resolve_pip_sections(pooled))
 
 
 def _hardened_settings_in_ini(text: str) -> "dict[str, str]":
@@ -5149,10 +5170,18 @@ def _policy_scan() -> "tuple[tuple[tuple[str, str, str], ...], dict[str, frozens
     Best-effort throughout: a probe that fails just shortens the answer.
     """
     on: "list[tuple[str, str, str]]" = []
-    configured: "dict[str, set[str]]" = {"pip": set(), "uv": set()}
+    # Slots, not tools: pip resolves each subcommand separately, so `[download]
+    # only-binary = :all:` is not an opinion about `pip install`. Crediting pip with it
+    # let a fallback `pip install` proceed as though the operator's control were covered
+    # when that command was in fact unrestricted.
+    configured: "dict[str, set[str]]" = {
+        slot: set() for slot in ("uv",) + tuple(_pip_slot(name) for name in _PIP_COMMANDS)
+    }
     cancelled: "dict[str, set[str]]" = {"pip": set(), "uv": set()}
 
-    def _record(tool: str, source: str, key: str, value: str) -> None:
+    def _record(
+        tool: str, source: str, key: str, value: str, slots: "tuple[str, ...]"
+    ) -> None:
         if source == "env" and not value.strip():
             # pip drops empty environment values before applying precedence, so
             # PIP_ONLY_BINARY='' neither enables a control nor cancels a pip.conf that
@@ -5161,7 +5190,8 @@ def _policy_scan() -> "tuple[tuple[tuple[str, str, str], ...], dict[str, frozens
             # cancellation suppressed a policy that was still fully in force.
             return
         canonical = _canonical_policy_key(key)
-        configured[tool].add(canonical)
+        for slot in slots:
+            configured[slot].add(canonical)
         if _config_value_is_on(value):
             on.append((tool, source, key))
         elif source == "env":
@@ -5169,6 +5199,7 @@ def _policy_scan() -> "tuple[tuple[tuple[str, str, str], ...], dict[str, frozens
             # variable cancels a file that enables the same control.
             cancelled[tool].add(canonical)
 
+    all_pip_slots = tuple(_pip_slot(name) for name in _PIP_COMMANDS)
     for name in _PM_POLICY_ENV_VARS:
         raw = os.environ.get(name)
         if raw is None:
@@ -5176,7 +5207,15 @@ def _policy_scan() -> "tuple[tuple[tuple[str, str, str], ...], dict[str, frozens
         if name.startswith("UV_") and name not in _UV_ENFORCED_ENV_VARS:
             # uv ignores it, so it is not policy. See _UV_ENFORCED_ENV_VARS.
             continue
-        _record("pip" if name.startswith("PIP_") else "uv", "env", name, raw.strip())
+        is_pip = name.startswith("PIP_")
+        # A variable applies to every pip subcommand, unlike a config section.
+        _record(
+            "pip" if is_pip else "uv",
+            "env",
+            name,
+            raw.strip(),
+            all_pip_slots if is_pip else ("uv",),
+        )
 
     try:
         result = subprocess.run(
@@ -5191,7 +5230,7 @@ def _policy_scan() -> "tuple[tuple[tuple[str, str, str], ...], dict[str, frozens
         )
     except (OSError, subprocess.SubprocessError):
         result = None
-    pip_settings: "dict[str, tuple[str, str]]" = {}
+    pooled: "dict[str, dict[str, tuple[str, str]]]" = {name: {} for name in _PIP_SECTIONS}
     if result is not None and result.returncode == 0:
         # `pip config list` prints EVERY definition, overridden ones included, in load
         # order, so a later file wins. Within a file the command section beats [global]
@@ -5219,14 +5258,12 @@ def _policy_scan() -> "tuple[tuple[tuple[str, str, str], ...], dict[str, frozens
             }
             for name in _PIP_SECTIONS
         }
-        pip_settings.update(_combine_pip_sections(pooled))
     else:
         # No usable pip, so read pip's files directly rather than report an ordinary
         # machine. They come back in pip's own load order, so a later file wins -- within
         # a section, which is why every file's sections are pooled and only resolved
         # against each other at the end. Collapsing a file before reading the next let a
         # low-priority setting erase a higher-priority one pip still applies.
-        pooled: "dict[str, dict[str, tuple[str, str]]]" = {name: {} for name in _PIP_SECTIONS}
         for path in _hardened_pip_config_paths():
             text = _read_text(path)
             if text is None:
@@ -5234,30 +5271,46 @@ def _policy_scan() -> "tuple[tuple[tuple[str, str, str], ...], dict[str, frozens
             source = os.path.basename(path)
             for name, values in _hardened_pip_sections(text).items():
                 pooled[name].update({key: (source, value) for key, value in values.items()})
-        pip_settings.update(_combine_pip_sections(pooled))
-    for key, (source, value) in pip_settings.items():
+    # The `on` list comes from the three combined, so the notice names each control once;
+    # the configured sets stay per subcommand, since that is what decides whether a given
+    # command can enforce it.
+    per_command_settings = _resolve_pip_sections(pooled)
+    for key, (source, value) in _combine_pip_commands(per_command_settings).items():
         if _canonical_policy_key(key) not in cancelled["pip"]:
-            _record("pip", source, key, value)
+            _record("pip", source, key, value, ())
+    for command in _PIP_COMMANDS:
+        for key in per_command_settings[command]:
+            canonical = _canonical_policy_key(key)
+            if canonical not in cancelled["pip"]:
+                configured[_pip_slot(command)].add(canonical)
 
     # uv's files come back lowest precedence first, so a higher one simply overwrites:
     # a project `[tool.uv.pip] require-hashes = false` is uv's effective answer even
     # where the user config turned it on, and reporting the user value regardless made
     # a later pip step refuse over a gap uv was not actually enforcing.
-    uv_settings: "dict[str, tuple[str, str, str]]" = {}
+    #
+    # Keyed on the literal key, not the canonical one: `no-build` and
+    # `no-build-package` are one CONTROL but two SETTINGS, and collapsing them into one
+    # slot let a `no-build-package = []` erase a `no-build = true` sitting beside it in
+    # the same file. Canonicalising is for comparing controls, not for storing them.
+    uv_settings: "dict[str, tuple[str, str]]" = {}
+    explicit_uv = os.environ.get("UV_CONFIG_FILE", "").strip()
     for path in _hardened_uv_config_paths():
         text = _read_text(path)
         if text is None:
             continue
+        # Schema by provenance, not by name: a file named by UV_CONFIG_FILE is parsed as
+        # a standalone uv.toml whatever it is called, so an explicit file that happens to
+        # be named pyproject.toml still has its policy read from the root tables.
+        is_pyproject = os.path.basename(path) == "pyproject.toml" and path != explicit_uv
         tables = (
-            (("tool", "uv"), ("tool", "uv", "pip"))
-            if os.path.basename(path) == "pyproject.toml"
-            else ((), ("pip",))
+            (("tool", "uv"), ("tool", "uv", "pip")) if is_pyproject else ((), ("pip",))
         )
         for key, value in _hardened_settings_in_toml(text, tables).items():
-            uv_settings[_canonical_policy_key(key)] = (os.path.basename(path), key, value)
-    for canonical, (source, key, value) in uv_settings.items():
-        if canonical not in cancelled["uv"]:
-            _record("uv", source, key, value)
+            uv_settings[key] = (os.path.basename(path), value)
+    for key, (source, value) in uv_settings.items():
+        if _canonical_policy_key(key) not in cancelled["uv"]:
+            _record("uv", source, key, value, ("uv",))
 
     return tuple(dict.fromkeys(on)), {tool: frozenset(keys) for tool, keys in configured.items()}
 
@@ -5290,7 +5343,15 @@ def _is_resolving_cmd(cmd: "list[str]") -> bool:
     not their problem -- treating them as pip installs turned an unenforceable cutoff
     into a hard exit on the final metadata patch, after every real step had succeeded.
     """
-    return any(arg in ("install", "download", "wheel") for arg in cmd)
+    return any(arg in _PIP_COMMANDS for arg in cmd)
+
+
+def _pip_subcommand(cmd: "list[str]") -> str:
+    """Which of install / download / wheel this command runs."""
+    for arg in cmd:
+        if arg in _PIP_COMMANDS:
+            return arg
+    return "install"
 
 
 def _unenforceable_policy(cmd: "list[str]") -> "list[str]":
@@ -5314,7 +5375,11 @@ def _unenforceable_policy(cmd: "list[str]") -> "list[str]":
     if not _respect_pm_policy() or not _is_resolving_cmd(cmd):
         return []
     target = "uv" if cmd[:1] == ["uv"] else "pip"
-    known = _configured_policy_keys().get(target, frozenset())
+    # For pip, the subcommand being run and not pip in general: `[download] only-binary`
+    # is not an opinion about `pip install`, and treating it as one let a fallback
+    # install proceed as though the control were covered.
+    slot = "uv" if target == "uv" else _pip_slot(_pip_subcommand(cmd))
+    known = _configured_policy_keys().get(slot, frozenset())
     missing = {
         key
         for tool, _source, key in _detected_policy()
@@ -5383,8 +5448,9 @@ def _announce_pm_policy() -> None:
         f"Package manager hardening detected ({listed}). Unsloth relaxes it for its own "
         "dependency installs only -- the shipped requirements are unhashed and a few have "
         "no wheel at any version -- and never for your other pip commands. On the steps "
-        "that pin an index it is set aside in full; on the few that do not, only pip's "
-        "require-hashes is, so an upload cutoff or a uv setting still applies there. Set "
+        "that pin an index it is set aside in full; on the few that do not, pip's "
+        "require-hashes is relaxed and the handful of packages with no wheel are allowed "
+        "to build from source, while an upload cutoff or a uv setting still applies. Set "
         f"{_POLICY_OPT_OUT_ENV}=1 to keep your policy in force everywhere instead.",
         _cyan,
     )

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -4690,9 +4690,31 @@ _PM_POLICY_ENV_VARS = (
     "PIP_NO_BINARY",
     "PIP_REQUIRE_HASHES",
     "PIP_UPLOADED_PRIOR_TO",
-    # Reported as well as scrubbed: the pinned branch removes it by default, and
-    # `pip config list` shows it as `:env:.no-index`, which this scan skips.
+    # Reported as well as scrubbed: the pinned branch removes it by default through
+    # _UV_INDEX_ENV_VARS, and `pip config list` shows it as `:env:.no-index`, which
+    # this scan skips.
     "PIP_NO_INDEX",
+)
+
+
+# What the DEFAULT pinned branch removes, which is not the same list. The tuple above
+# grew as the notice learned to report more controls, and reporting a control is not a
+# reason to start overriding it: sharing one tuple silently widened the default bypass
+# to UV_ONLY_BINARY, UV_ONLY_BINARY_PACKAGE and PIP_UPLOADED_PRIOR_TO, none of which
+# this installer touched before. The whole change rests on the default path being
+# indistinguishable from before, so this stays exactly as it was and the notice reports
+# the wider set without acting on it. PIP_NO_INDEX is absent because the pinned branch
+# already drops it as an index variable.
+_PM_POLICY_SCRUB_ENV_VARS = (
+    "UV_NO_BUILD",
+    "UV_NO_BUILD_PACKAGE",
+    "UV_NO_BINARY",
+    "UV_NO_BINARY_PACKAGE",
+    "UV_REQUIRE_HASHES",
+    "UV_EXCLUDE_NEWER",
+    "PIP_ONLY_BINARY",
+    "PIP_NO_BINARY",
+    "PIP_REQUIRE_HASHES",
 )
 
 
@@ -5381,7 +5403,7 @@ def _install_env_for_cmd(cmd: "list[str]") -> "dict[str, str] | None":
     if _respect_pm_policy():
         return env
     env["UV_NO_CONFIG"] = "1"
-    for name in _PM_POLICY_ENV_VARS:
+    for name in _PM_POLICY_SCRUB_ENV_VARS:
         env.pop(name, None)
     env["PIP_CONFIG_FILE"] = os.devnull
     return env

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import ast
 import functools
 import glob
+import hashlib
 import importlib
 import importlib.util
 import json
@@ -4174,6 +4175,49 @@ class _QuarantinedMetadata:
         self._copied.clear()
 
 
+def _staged_restore_args(name: str, staged: str) -> "tuple[list[str], str]":
+    """pip arguments that reinstall `name` from the staged wheel directory.
+
+    By default the wheel is named as a bare requirement and pip resolves it out of
+    `--find-links`. Under the opt-out that is rejected: require-hashes wants every
+    requirement pinned with `==` and carrying a hash, and a bare name is neither. The
+    restore runs AFTER the uninstall loop has already deleted the package records, so
+    failing there leaves the core package gone -- measured, pip answers "In
+    --require-hashes mode, all requirements must have their versions pinned with ==".
+
+    The staged wheel is a local file this installer just built, so its hash is knowable.
+    Under the opt-out the restore is written into a requirements file carrying the real
+    sha256 of that exact artifact, which satisfies the policy honestly instead of
+    relaxing it for this one command or abandoning the repair. Measured: pip accepts it
+    and installs under PIP_REQUIRE_HASHES=1.
+
+    Returns (arguments, a temporary requirements file to delete, or "").
+    """
+    default = ["--no-deps", "--force-reinstall", "--no-index", "--find-links", staged, name]
+    if not _respect_pm_policy():
+        return default, ""
+    wanted = re.sub(r"[-_.]+", "-", name).lower()
+    wheel = ""
+    for candidate in sorted(glob.glob(os.path.join(staged, "*.whl"))):
+        project = re.sub(r"[-_.]+", "-", os.path.basename(candidate).split("-")[0]).lower()
+        if project == wanted:
+            wheel = candidate
+            break
+    if not wheel:
+        # Nothing to hash, so nothing better to offer than the default and its error.
+        return default, ""
+    try:
+        digest = hashlib.sha256(Path(wheel).read_bytes()).hexdigest()
+        handle = tempfile.NamedTemporaryFile(
+            "w", suffix = ".txt", delete = False, encoding = "utf-8"
+        )
+        with handle:
+            handle.write(f"{os.path.abspath(wheel)} --hash=sha256:{digest}\n")
+    except OSError:
+        return default, ""
+    return ["--no-deps", "--force-reinstall", "--no-index", "-r", handle.name], handle.name
+
+
 def _restore_from_staged(
     name: str,
     staged: str,
@@ -4188,20 +4232,25 @@ def _restore_from_staged(
     """
     if not (removed_any and staged):
         return
-    if pip_install_try(
-        f"Restoring {name} after an incomplete metadata repair",
-        "--no-cache-dir",
-        "--no-deps",
-        "--force-reinstall",
-        "--no-index",
-        "--find-links",
-        staged,
-        name,
-        # pip, not uv: the wheel is already built and sitting in staged, and uv would
-        # reject the unpinned name under UV_REQUIRE_HASHES with the package records
-        # already gone. Routing through pip also earns the PIP_REQUIRE_HASHES relaxation.
-        force_pip = True,
-    ):
+    restore_args, restore_reqs = _staged_restore_args(name, staged)
+    try:
+        restored_here = pip_install_try(
+            f"Restoring {name} after an incomplete metadata repair",
+            "--no-cache-dir",
+            *restore_args,
+            # pip, not uv: the wheel is already built and sitting in staged, and uv would
+            # reject the unpinned name under UV_REQUIRE_HASHES with the package records
+            # already gone. Routing through pip also earns the PIP_REQUIRE_HASHES
+            # relaxation, which the opt-out withholds -- see _staged_restore_args.
+            force_pip = True,
+        )
+    finally:
+        if restore_reqs:
+            try:
+                os.unlink(restore_reqs)
+            except OSError:
+                pass
+    if restored_here:
         # The wheel just wrote its own valid metadata at the same path the rewritten
         # record occupied, so the unwinding below must not put the original back over
         # it. See _QuarantinedMetadata.forget_copies.
@@ -4491,19 +4540,22 @@ def _repair_duplicate_core_metadata(
                 # The overlay install is preferred because it keeps the editable
                 # or git provenance, but the staged wheel was built from that
                 # same source, so falling back to it never substitutes a release.
-                restored = pip_install_try(
-                    f"Repairing duplicate metadata for {name}",
-                    "--no-cache-dir",
-                    "--no-deps",
-                    "--force-reinstall",
-                    "--no-index",
-                    "--find-links",
-                    staged,
-                    name,
-                    # As _restore_from_staged: pip, so a uv hash policy cannot reject the
-                    # already-built wheel once every record has been removed.
-                    force_pip = True,
-                )
+                repair_args, repair_reqs = _staged_restore_args(name, staged)
+                try:
+                    restored = pip_install_try(
+                        f"Repairing duplicate metadata for {name}",
+                        "--no-cache-dir",
+                        *repair_args,
+                        # As _restore_from_staged: pip, so a uv hash policy cannot reject
+                        # the already-built wheel once every record has been removed.
+                        force_pip = True,
+                    )
+                finally:
+                    if repair_reqs:
+                        try:
+                            os.unlink(repair_reqs)
+                        except OSError:
+                            pass
             if not restored:
                 _safe_print(
                     _red(
@@ -4712,7 +4764,7 @@ _PIP_CONFIG_KEYS = ("require-hashes", "only-binary", "no-binary", "uploaded-prio
 # "no packages selected". `off`, `n` and `f` were missing and read as ENABLED, which both
 # printed a notice about a policy pip does not enforce and, under the opt-out, translated
 # the disabled setting into a uv control that failed the install.
-_OFF_VALUES = ("", "n", "no", "f", "false", "off", "0", "none", ":none:")
+_OFF_VALUES = ("n", "no", "f", "false", "off", "0")
 
 
 # The only two controls whose value is a BOOLEAN. The rest take a package list, a scoped

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -4701,9 +4701,16 @@ _HARDENED_CONFIG_KEYS = (
 )
 
 
+# pip's own strtobool false set, verbatim, plus the empty and ":none:" spellings that mean
+# "no packages selected". `off`, `n` and `f` were missing and read as ENABLED, which both
+# printed a notice about a policy pip does not enforce and, under the opt-out, translated
+# the disabled setting into a uv control that failed the install.
+_OFF_VALUES = ("", "n", "no", "f", "false", "off", "0", "none", ":none:")
+
+
 def _config_value_is_on(value: str) -> bool:
     """A config/env value that turns a policy ON rather than off or empty."""
-    return value.strip().lower() not in ("", "0", "false", "no", "none", ":none:")
+    return value.strip().lower() not in _OFF_VALUES
 
 
 def _toml_value_is_on(value: object) -> bool:
@@ -4723,15 +4730,24 @@ def _toml_value_is_on(value: object) -> bool:
     return _config_value_is_on(text)
 
 
-def _hardened_keys_in_toml(text: str, tables: "tuple[tuple[str, ...], ...]") -> "list[str]":
-    """Hardened keys switched ON inside the named tables of a TOML document.
+def _toml_value_text(value: object) -> str:
+    """A TOML value as the string the translator works with.
 
-    `tables` scopes the search, so a stray `no-build` in an unrelated tool's table is not
-    read as uv policy. tomllib is 3.11+ and this module runs on older interpreters, hence
-    the regex fallback; both test the VALUE, since reporting `no-build = false` would put
-    a security notice in front of a user who switched the policy off.
+    A list becomes its space-separated members, which is uv's own spelling for the
+    package-scoped controls and the form the pip translation re-splits.
     """
-    found: list[str] = []
+    if isinstance(value, bool):
+        return "1" if value else "0"
+    if isinstance(value, (list, tuple)):
+        return " ".join(str(item).strip() for item in value if str(item).strip())
+    return str(value).strip()
+
+
+def _hardened_settings_in_toml(
+    text: str, tables: "tuple[tuple[str, ...], ...]"
+) -> "dict[str, str]":
+    """Hardened keys and their values inside the named tables of a TOML document."""
+    settings: dict[str, str] = {}
     data = None
     if _tomllib is not None:
         try:
@@ -4748,12 +4764,9 @@ def _hardened_keys_in_toml(text: str, tables: "tuple[tuple[str, ...], ...]") -> 
             if not isinstance(node, dict):
                 continue
             for key in _HARDENED_CONFIG_KEYS:
-                if key in node and _toml_value_is_on(node[key]):
-                    found.append(key)
-        return found
-    # The fallback tracks table headers rather than scanning the whole document, so a
-    # `[tool.other] no-build = true` in a pyproject is not read as uv policy the way a
-    # flat search would read it.
+                if key in node:
+                    settings[key] = _toml_value_text(node[key])
+        return settings
     current: "tuple[str, ...]" = ()
     for line in text.splitlines():
         stripped = line.strip()
@@ -4771,9 +4784,32 @@ def _hardened_keys_in_toml(text: str, tables: "tuple[tuple[str, ...], ...]") -> 
         if not separator:
             continue
         key = key.strip().strip("\"'")
-        if key in _HARDENED_CONFIG_KEYS and _toml_value_is_on(raw.strip().strip("\"'")):
-            found.append(key)
-    return found
+        if key in _HARDENED_CONFIG_KEYS:
+            raw = raw.strip()
+            if re.fullmatch(r"\[\s*\]|\{\s*\}", raw):
+                raw = ""
+            elif raw.startswith("[") and raw.endswith("]"):
+                raw = " ".join(
+                    item.strip().strip("\"'")
+                    for item in raw[1:-1].split(",")
+                    if item.strip().strip("\"'")
+                )
+            settings[key] = raw.strip().strip("\"'")
+    return settings
+
+
+def _hardened_keys_in_toml(text: str, tables: "tuple[tuple[str, ...], ...]") -> "list[str]":
+    """Hardened keys switched ON inside the named tables of a TOML document.
+
+    `tables` scopes the search, so a stray `no-build` in an unrelated tool's table is not
+    read as uv policy. Both the tomllib path and the pre-3.11 fallback test the VALUE,
+    since reporting `no-build = false` would put a security notice in front of a user who
+    switched the policy off.
+    """
+    return [
+        key for key, value in _hardened_settings_in_toml(text, tables).items()
+        if _config_value_is_on(value)
+    ]
 
 
 def _existing_files(candidates: "list[str]") -> "list[str]":
@@ -4842,12 +4878,21 @@ def _hardened_pip_config_paths() -> "list[str]":
     if explicit and os.path.normcase(explicit) == os.path.normcase(os.devnull):
         # Documented: PIP_CONFIG_FILE=os.devnull disables the loading of ALL config files.
         return []
+    # pip's iter_config_files: "per-user config is not loaded when env_config_file
+    # exists". Scanning them anyway invents a policy pip would not apply, which under the
+    # opt-out gets translated into the other manager and fails the install.
+    skip_user = bool(explicit) and os.path.isfile(explicit)
     candidates = []
+    user: "list[str]" = []
     if IS_WINDOWS:
         for variable in ("PROGRAMDATA", "APPDATA"):
             base = os.environ.get(variable, "")
             if base:
-                candidates.append(os.path.join(base, "pip", name))
+                target = candidates if variable == "PROGRAMDATA" else user
+                target.append(os.path.join(base, "pip", name))
+        # pip's legacy user file, still in get_configuration_files(): "pip" on Windows,
+        # ".pip" elsewhere, under the expanded home.
+        user.append(os.path.join(os.path.expanduser("~"), "pip", name))
     else:
         # Global is EVERY entry of XDG_CONFIG_DIRS, not just the default: measured with
         # pip 26, `XDG_CONFIG_DIRS=/a:/b pip config debug` enumerates /a/pip/pip.conf and
@@ -4865,10 +4910,14 @@ def _hardened_pip_config_paths() -> "list[str]":
         candidates.append(os.path.join("/etc", name))
         home = os.path.expanduser("~")
         xdg = os.environ.get("XDG_CONFIG_HOME") or os.path.join(home, ".config")
-        candidates.append(os.path.join(xdg, "pip", name))
+        user.append(os.path.join(xdg, "pip", name))
         if IS_MACOS:
-            candidates.append(os.path.join(home, "Library", "Application Support", "pip", name))
-        candidates.append(os.path.join(home, ".pip", name))
+            user.append(os.path.join(home, "Library", "Application Support", "pip", name))
+        user.append(os.path.join(home, ".pip", name))
+    if not skip_user:
+        candidates.extend(user)
+    # Site, then the explicit file: pip's own load order, which is what makes the
+    # last-wins resolution downstream correct.
     site = os.environ.get("VIRTUAL_ENV", "") or sys.prefix
     if site:
         candidates.append(os.path.join(site, name))
@@ -4877,8 +4926,14 @@ def _hardened_pip_config_paths() -> "list[str]":
     return _existing_files(candidates)
 
 
+# pip applies `[global]` first and then the command's own section, whatever order they
+# appear in the file, so `[install]` beats `[global]` for the commands this module runs.
+# Sections for other commands never apply to an install and are ignored entirely.
+_PIP_SECTION_RANK = {"global": 0, "install": 1, "download": 1, "wheel": 1}
+
+
 def _hardened_settings_in_ini(text: str) -> "dict[str, str]":
-    """Hardened keys DEFINED in a pip.conf, with their values, in any of its sections.
+    """Hardened keys DEFINED in a pip.conf, with their values, by pip's section rules.
 
     Values rather than a filtered list of on-keys, because precedence is resolved across
     files: a later pip.conf setting `require-hashes = false` has to be able to cancel an
@@ -4889,12 +4944,18 @@ def _hardened_settings_in_ini(text: str) -> "dict[str, str]":
         parser.read_string(text)
     except configparser.Error:
         return {}
-    settings: dict[str, str] = {}
+    ranked: dict[str, tuple[int, str]] = {}
     for section in parser.sections():
+        rank = _PIP_SECTION_RANK.get(section.strip().lower())
+        if rank is None:
+            continue
         for key in _HARDENED_CONFIG_KEYS:
-            if parser.has_option(section, key):
-                settings[key] = parser.get(section, key, fallback = "")
-    return settings
+            if not parser.has_option(section, key):
+                continue
+            value = parser.get(section, key, fallback = "")
+            if rank >= ranked.get(key, (-1, ""))[0]:
+                ranked[key] = (rank, value)
+    return {key: value for key, (_rank, value) in ranked.items()}
 
 
 def _hardened_keys_in_ini(text: str) -> "list[str]":
@@ -4912,24 +4973,49 @@ def _read_text(path: str) -> "str | None":
         return None
 
 
+def _env_policy_key(name: str) -> str:
+    """The config-file spelling of a policy environment variable.
+
+    PIP_REQUIRE_HASHES and a pip.conf `require-hashes` are the same control, which is what
+    lets an explicitly disabled variable cancel a config file that enables it.
+    """
+    return name.split("_", 1)[1].lower().replace("_", "-")
+
+
 @functools.lru_cache(maxsize = 1)
-def _detected_policy() -> "tuple[tuple[str, str, str], ...]":
-    """(tool, source, key) for every package-manager hardening this host has configured.
+def _detected_policy() -> "tuple[tuple[str, str, str, str], ...]":
+    """(tool, source, key, value) for every hardening this host actually applies.
 
     `tool` is "pip" or "uv", which is what makes this more than a display list: under the
     opt-out the two managers have to be told about each other's policy, since neither
     reads the other's (measured on the pinned uv 0.12.1, `uv pip install` ignores both
     PIP_REQUIRE_HASHES and a pip.conf require-hashes). `source` is "env" for a variable,
-    otherwise the config file's basename.
+    otherwise the config file's basename. `value` is carried so a package-scoped policy
+    stays package-scoped when translated: promoting `PIP_ONLY_BINARY=numpy` to a global
+    `UV_NO_BUILD=1` would fail the extras step on wheel-less dependencies the operator's
+    policy actually permits.
 
     Empty on an ordinary machine. Best-effort throughout: a probe that fails just
     shortens the list.
     """
-    found = [
-        ("pip" if name.startswith("PIP_") else "uv", "env", name)
-        for name in _PM_POLICY_ENV_VARS
-        if _config_value_is_on(os.environ.get(name, ""))
-    ]
+    found = []
+    # An environment variable explicitly turned OFF is not hardening, but it is not
+    # nothing either: it beats every config file, so it has to cancel one that enables
+    # the same control rather than being dropped.
+    cancelled: "dict[str, set[str]]" = {"pip": set(), "uv": set()}
+    for name in _PM_POLICY_ENV_VARS:
+        raw = os.environ.get(name)
+        if raw is None:
+            continue
+        tool = "pip" if name.startswith("PIP_") else "uv"
+        if _config_value_is_on(raw):
+            found.append((tool, "env", name, raw.strip()))
+        else:
+            cancelled[tool].add(_env_policy_key(name))
+
+    def _keep(tool: str, key: str) -> bool:
+        return key not in cancelled[tool]
+
     try:
         result = subprocess.run(
             [sys.executable, "-m", "pip", "config", "list"],
@@ -4944,30 +5030,34 @@ def _detected_policy() -> "tuple[tuple[str, str, str], ...]":
     except (OSError, subprocess.SubprocessError):
         result = None
     if result is not None and result.returncode == 0:
-        # `pip config list` prints EVERY definition, including ones a
-        # higher-precedence file overrides: a user pip.conf require-hashes=true and a
-        # venv site pip.conf require-hashes=false emit both lines, and pip enforces the
-        # second. Measured on pip 26.2.1, `config get` returns false there and the
-        # install is not hash-checked, so taking any enabled occurrence would announce a
-        # policy pip does not apply. The lines come in load order, so last wins.
-        effective: "dict[str, str]" = {}
+        # `pip config list` prints EVERY definition, including ones a higher-precedence
+        # file overrides: a user pip.conf require-hashes=true and a venv site pip.conf
+        # require-hashes=false emit both lines, and pip enforces the second. Measured on
+        # pip 26.2.1, `config get` returns false there and the install is not
+        # hash-checked. Lines arrive in load order, so a later file wins; within a file
+        # pip applies the command section over `[global]` whatever the textual order, so
+        # the section is ranked rather than discarded.
+        effective: "dict[str, tuple[int, str]]" = {}
         for line in (result.stdout or b"").decode("utf-8", "replace").splitlines():
             name, separator, raw = line.partition("=")
-            # `:env:` entries restate the environment, already covered above.
+            # `:env:` entries restate the environment, already handled above (including
+            # the disabled ones, which is why they can be skipped here).
             if not separator or name.strip().startswith(":env:"):
                 continue
-            option = name.strip().rpartition(".")[2]
-            if option in _HARDENED_CONFIG_KEYS:
-                effective[option] = raw.strip().strip("'\"")
-        for option, value in effective.items():
-            if _config_value_is_on(value):
-                found.append(("pip", "pip.conf", option))
+            section, _, option = name.strip().rpartition(".")
+            rank = _PIP_SECTION_RANK.get(section.strip().lower(), None)
+            if option not in _HARDENED_CONFIG_KEYS or rank is None:
+                continue
+            if rank >= effective.get(option, (-1, ""))[0]:
+                effective[option] = (rank, raw.strip().strip("'\""))
+        for option, (_rank, value) in effective.items():
+            if _config_value_is_on(value) and _keep("pip", option):
+                found.append(("pip", "pip.conf", option, value))
     else:
         # No usable pip, so read pip's files directly rather than report an ordinary
         # machine. Only in this branch: when pip answered, it already merged them.
         # _hardened_pip_config_paths returns them in pip's own load order, so the same
-        # last-wins resolution applies here: a site pip.conf turning a policy off must
-        # cancel the user pip.conf that turned it on.
+        # last-wins resolution applies here.
         winners: "dict[str, tuple[str, str]]" = {}
         for path in _hardened_pip_config_paths():
             text = _read_text(path)
@@ -4976,8 +5066,8 @@ def _detected_policy() -> "tuple[tuple[str, str, str], ...]":
             for key, value in _hardened_settings_in_ini(text).items():
                 winners[key] = (os.path.basename(path), value)
         for key, (basename, value) in winners.items():
-            if _config_value_is_on(value):
-                found.append(("pip", basename, key))
+            if _config_value_is_on(value) and _keep("pip", key):
+                found.append(("pip", basename, key, value))
     for path in _hardened_uv_config_paths():
         text = _read_text(path)
         if text is None:
@@ -4987,8 +5077,9 @@ def _detected_policy() -> "tuple[tuple[str, str, str], ...]":
             if os.path.basename(path) == "pyproject.toml"
             else ((), ("pip",))
         )
-        for key in _hardened_keys_in_toml(text, tables):
-            found.append(("uv", os.path.basename(path), key))
+        for key, value in _hardened_settings_in_toml(text, tables).items():
+            if _config_value_is_on(value) and _keep("uv", key):
+                found.append(("uv", os.path.basename(path), key, value))
     return tuple(dict.fromkeys(found))
 
 
@@ -4997,53 +5088,104 @@ def _hardened_pm_policy_names() -> "tuple[str, ...]":
     return tuple(
         dict.fromkeys(
             key if source == "env" else f"{source} {key}"
-            for _tool, source, key in _detected_policy()
+            for _tool, source, key, _value in _detected_policy()
         )
     )
 
 
-# pip and uv spell the same three controls differently and read none of each other's.
-# Under the opt-out, whichever manager runs is told the other's policy in its own
-# spelling, or the flag only holds for whichever tool the operator happened to configure.
-# Precedent: _uv_staging_plan already translates UV_NO_BINARY / UV_ONLY_BINARY into their
-# pip spellings for the same reason.
+def _policy_scope(value: str) -> "str | None":
+    """The package list a scoped policy names, or None when it covers everything.
+
+    pip spells "everything" as `:all:` and separates names with commas; uv uses a boolean
+    plus a separate `-package` variable and separates names with spaces. Both spellings
+    land here so the translation can stay scoped instead of promoting a policy about one
+    package into a policy about all of them.
+    """
+    text = value.strip()
+    if text.lower() in (":all:", "1", "true", "yes", "y", "t", "on"):
+        return None
+    names = [part for part in re.split(r"[,\s]+", text) if part and part != ":all:"]
+    return " ".join(names) if names else None
+
+
+# pip and uv spell the same controls differently and read none of each other's. Under the
+# opt-out, whichever manager runs is told the other's policy in its own spelling, or the
+# flag only holds for whichever tool the operator happened to configure. Precedent:
+# _uv_staging_plan already translates UV_NO_BINARY / UV_ONLY_BINARY into pip's spellings.
 def _translated_policy_env(cmd: "list[str]") -> "dict[str, str]":
     """Retained policy, restated for the manager this command actually runs.
 
     Empty unless the opt-out is set. Never overrides a setting the target manager already
-    has: the operator's own spelling always wins over a translation of the other one.
+    has: the operator's own spelling wins over a translation of the other one. Scopes are
+    carried through, so `PIP_ONLY_BINARY=numpy` becomes uv's package-scoped no-build and
+    not a global one that would fail the extras step on its wheel-less dependencies.
     """
     if not _respect_pm_policy():
         return {}
     target = "uv" if cmd[:1] == ["uv"] else "pip"
-    source_keys = {key.lower() for tool, _source, key in _detected_policy() if tool != target}
-    if not source_keys:
+    source: "dict[str, str]" = {}
+    for tool, _origin, key, value in _detected_policy():
+        if tool == target:
+            continue
+        source.setdefault(_env_policy_key(key) if key.isupper() else key.lower(), value)
+    if not source:
         return {}
-
-    def _on(*names: str) -> bool:
-        return any(
-            name.lower() in source_keys or name.lower().replace("_", "-") in source_keys
-            for name in names
-        )
 
     overrides: dict[str, str] = {}
     if target == "uv":
-        if _on("PIP_REQUIRE_HASHES", "require-hashes"):
+        if "require-hashes" in source:
             overrides["UV_REQUIRE_HASHES"] = "1"
         # pip's only-binary is "wheels only", which uv spells as no-build.
-        if _on("PIP_ONLY_BINARY", "only-binary"):
-            overrides["UV_NO_BUILD"] = "1"
-        if _on("PIP_NO_BINARY", "no-binary"):
-            overrides["UV_NO_BINARY"] = "1"
+        for key, whole, scoped in (
+            ("only-binary", "UV_NO_BUILD", "UV_NO_BUILD_PACKAGE"),
+            ("no-binary", "UV_NO_BINARY", "UV_NO_BINARY_PACKAGE"),
+        ):
+            if key not in source:
+                continue
+            names = _policy_scope(source[key])
+            if names is None:
+                overrides[whole] = "1"
+            else:
+                overrides[scoped] = names
     else:
-        if _on("UV_REQUIRE_HASHES", "require-hashes"):
+        if "require-hashes" in source:
             overrides["PIP_REQUIRE_HASHES"] = "1"
-        if _on("UV_NO_BUILD", "UV_NO_BUILD_PACKAGE", "no-build", "no-build-package"):
-            overrides["PIP_ONLY_BINARY"] = ":all:"
-        if _on("UV_NO_BINARY", "UV_NO_BINARY_PACKAGE", "no-binary", "no-binary-package"):
-            overrides["PIP_NO_BINARY"] = ":all:"
-        if _on("UV_ONLY_BINARY", "UV_ONLY_BINARY_PACKAGE", "only-binary"):
-            overrides["PIP_ONLY_BINARY"] = ":all:"
+        for keys, target_name in (
+            (("no-build", "no-build-package", "only-binary"), "PIP_ONLY_BINARY"),
+            (("no-binary", "no-binary-package"), "PIP_NO_BINARY"),
+        ):
+            names: "list[str]" = []
+            whole = False
+            for key in keys:
+                if key not in source:
+                    continue
+                scope = _policy_scope(source[key])
+                if scope is None:
+                    whole = True
+                else:
+                    names.extend(scope.split())
+            if whole:
+                overrides[target_name] = ":all:"
+            elif names:
+                overrides[target_name] = ",".join(dict.fromkeys(names))
+        cutoff = source.get("exclude-newer", "").strip()
+        if cutoff and not os.environ.get("PIP_UPLOADED_PRIOR_TO", "").strip():
+            # An upload cutoff is a reproducibility control, and pip only grew the
+            # equivalent option in 25.3. Silently dropping it would let this install pick
+            # an artifact the retained policy excludes, so an older pip refuses instead --
+            # the same answer _uv_upload_cutoff_args gives the staging path.
+            if _pip_supports_upload_cutoff():
+                overrides["PIP_UPLOADED_PRIOR_TO"] = cutoff
+            else:
+                _safe_print(
+                    _red(
+                        f"   {_POLICY_OPT_OUT_ENV} is set and an upload cutoff "
+                        f"({cutoff}) is configured, but this pip is too old for "
+                        "--uploaded-prior-to, so the cutoff cannot be enforced here. "
+                        "Upgrade pip to 25.3 or newer, or unset the variable."
+                    )
+                )
+                sys.exit(1)
     return {
         name: value for name, value in overrides.items() if not os.environ.get(name, "").strip()
     }

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -5179,9 +5179,7 @@ def _policy_scan() -> "tuple[tuple[tuple[str, str, str], ...], dict[str, frozens
     }
     cancelled: "dict[str, set[str]]" = {"pip": set(), "uv": set()}
 
-    def _record(
-        tool: str, source: str, key: str, value: str, slots: "tuple[str, ...]"
-    ) -> None:
+    def _record(tool: str, source: str, key: str, value: str, slots: "tuple[str, ...]") -> None:
         if source == "env" and not value.strip():
             # pip drops empty environment values before applying precedence, so
             # PIP_ONLY_BINARY='' neither enables a control nor cancels a pip.conf that
@@ -5303,9 +5301,7 @@ def _policy_scan() -> "tuple[tuple[tuple[str, str, str], ...], dict[str, frozens
         # a standalone uv.toml whatever it is called, so an explicit file that happens to
         # be named pyproject.toml still has its policy read from the root tables.
         is_pyproject = os.path.basename(path) == "pyproject.toml" and path != explicit_uv
-        tables = (
-            (("tool", "uv"), ("tool", "uv", "pip")) if is_pyproject else ((), ("pip",))
-        )
+        tables = (("tool", "uv"), ("tool", "uv", "pip")) if is_pyproject else ((), ("pip",))
         for key, value in _hardened_settings_in_toml(text, tables).items():
             uv_settings[key] = (os.path.basename(path), value)
     for key, (source, value) in uv_settings.items():

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -4197,9 +4197,7 @@ def _hashed_requirement_file(wheel: str) -> str:
     """
     try:
         digest = hashlib.sha256(Path(wheel).read_bytes()).hexdigest()
-        handle = tempfile.NamedTemporaryFile(
-            "w", suffix = ".txt", delete = False, encoding = "utf-8"
-        )
+        handle = tempfile.NamedTemporaryFile("w", suffix = ".txt", delete = False, encoding = "utf-8")
         with handle:
             handle.write(f"{os.path.abspath(wheel)} --hash=sha256:{digest}\n")
     except OSError:
@@ -4775,7 +4773,11 @@ def _relaxed_pip_policy_env(cmd: "list[str]") -> "dict[str, str]":
 # remote source, and the pinned branch discards it along with the rest of pip.conf, which
 # is exactly the kind of silent override this notice exists to disclose.
 _PIP_CONFIG_KEYS = (
-    "require-hashes", "only-binary", "no-binary", "uploaded-prior-to", "no-index",
+    "require-hashes",
+    "only-binary",
+    "no-binary",
+    "uploaded-prior-to",
+    "no-index",
 )
 
 
@@ -4920,9 +4922,7 @@ def _detected_policy() -> "tuple[tuple[str, str, str], ...]":
             if _canonical_policy_key(option) in cancelled:
                 continue
             for command in _PIP_COMMANDS:
-                value = settings.get(
-                    (command, option), settings.get(("global", option))
-                )
+                value = settings.get((command, option), settings.get(("global", option)))
                 if value is not None and _config_value_is_on(value, option):
                     on.append(("pip", "pip.conf", option))
                     break

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -4734,9 +4734,33 @@ _PIP_CONFIG_KEYS = ("require-hashes", "only-binary", "no-binary", "uploaded-prio
 _OFF_VALUES = ("", "n", "no", "f", "false", "off", "0", "none", ":none:")
 
 
-def _config_value_is_on(value: str) -> bool:
-    """A config/env value that turns a policy ON rather than off or empty."""
-    return value.strip().lower() not in _OFF_VALUES
+# The only two controls whose value is a BOOLEAN. The rest take a package list, a scoped
+# map or a date, where pip documents `:none:` as the way to clear the set and every other
+# value names something real: `PIP_ONLY_BINARY=no` restricts a distribution called "no",
+# and reading it as a disabled flag dropped an artifact rule that was fully in force.
+_BOOLEAN_POLICY_KEYS = ("require-hashes", "no-build")
+
+# What clears a control of either kind.
+_EMPTY_POLICY_VALUES = ("", ":none:")
+
+
+def _policy_key_spelling(key: str) -> str:
+    """A policy key as its config-file spelling, whichever form it arrived in."""
+    return _env_policy_key(key) if key.isupper() else key.lower()
+
+
+def _config_value_is_on(value: str, key: "str | None" = None) -> bool:
+    """A config/env value that turns a policy ON rather than off or empty.
+
+    `key` selects the reading: without one the value is treated as a boolean, which is
+    right for the plain flags this also parses (UV_NO_CONFIG and friends).
+    """
+    text = value.strip().lower()
+    if text in _EMPTY_POLICY_VALUES:
+        return False
+    if key is not None and _policy_key_spelling(key) not in _BOOLEAN_POLICY_KEYS:
+        return True
+    return text not in _OFF_VALUES
 
 
 def _toml_value_is_on(value: object) -> bool:
@@ -4763,7 +4787,10 @@ def _toml_value_text(value: object) -> str:
     package-scoped controls and the form the pip translation re-splits.
     """
     if isinstance(value, bool):
-        return "1" if value else "0"
+        # Empty for False, so a TOML boolean stays off whatever the key's type is. A
+        # list-valued control reads any other value as a package name, and "0" would be
+        # one: this is the one place the type is still known, so it is settled here.
+        return "1" if value else ""
     if isinstance(value, (list, tuple)):
         return " ".join(str(item).strip() for item in value if str(item).strip())
     if isinstance(value, dict):
@@ -4918,7 +4945,7 @@ def _hardened_keys_in_toml(text: str, tables: "tuple[tuple[str, ...], ...]") -> 
     return [
         key
         for key, value in _hardened_settings_in_toml(text, tables).items()
-        if _config_value_is_on(value)
+        if _config_value_is_on(value, key)
     ]
 
 
@@ -4933,6 +4960,47 @@ def _existing_files(candidates: "list[str]") -> "list[str]":
             # simply not a config file we can report on.
             continue
     return found
+
+
+def _explicit_uv_config_path() -> str:
+    """UV_CONFIG_FILE as uv resolves it, or "" when it is not set.
+
+    Shared so the schema decision downstream compares the SAME path this returns: it
+    used to test the raw environment value, so a relative explicit file resolved through
+    UV_WORKING_DIR stopped matching and an explicit `pyproject.toml` was then read with
+    the discovered-project schema instead of the standalone one.
+    """
+    explicit = os.environ.get("UV_CONFIG_FILE", "").strip()
+    if not explicit:
+        return ""
+    working = os.environ.get("UV_WORKING_DIR", "").strip()
+    if working and not os.path.isabs(explicit):
+        # --directory changes directory BEFORE running, so a relative config path is
+        # resolved there and not against the directory the installer started in.
+        return os.path.join(working, explicit)
+    return explicit
+
+
+def _declares_uv_workspace(path: str) -> bool:
+    """True when this pyproject.toml declares a uv workspace.
+
+    Only the declaration matters here, not whether the member the walk stopped at is
+    listed in it: matching uv's member globs is more machinery than a best-effort notice
+    warrants, and an ancestor that declares a workspace over a project beneath it is
+    overwhelmingly that project's root.
+    """
+    text = _read_text(path)
+    if text is None:
+        return False
+    if _tomllib is not None:
+        try:
+            data = _tomllib.loads(text)
+        except Exception:
+            return False
+        node = data.get("tool") if isinstance(data, dict) else None
+        node = node.get("uv") if isinstance(node, dict) else None
+        return isinstance(node, dict) and "workspace" in node
+    return bool(re.search(r"^\s*\[tool\.uv\.workspace[\].]", text, re.MULTILINE))
 
 
 def _uv_project_config() -> "list[str]":
@@ -4952,21 +5020,36 @@ def _uv_project_config() -> "list[str]":
     # Measured on the pinned uv 0.12.1, a `[tool.uv.pip] require-hashes = true` in a
     # project named by either variable is enforced from an unrelated cwd, so walking
     # from getcwd() alone scanned the wrong tree and missed live policy.
-    root = os.environ.get("UV_PROJECT", "").strip() or os.environ.get("UV_WORKING_DIR", "").strip()
+    working = os.environ.get("UV_WORKING_DIR", "").strip()
+    root = os.environ.get("UV_PROJECT", "").strip()
+    if root and working and not os.path.isabs(root):
+        # --directory takes effect first, so a relative --project resolves against it.
+        root = os.path.join(working, root)
     try:
         # A deleted working directory raises here rather than returning anything.
-        current = os.path.abspath(root or os.getcwd())
+        current = os.path.abspath(root or working or os.getcwd())
     except OSError:
         return []
+    found = ""
     while True:
         if _existing_files([os.path.join(current, "pyproject.toml")]):
-            local = _existing_files([os.path.join(current, "uv.toml")])
-            return local or [os.path.join(current, "pyproject.toml")]
+            if not found:
+                found = current
+            elif _declares_uv_workspace(os.path.join(current, "pyproject.toml")):
+                # A workspace ROOT outranks the member the walk stopped at: measured on
+                # the pinned uv 0.12.1, from root/member/sub it logs "Found workspace
+                # configuration at root/pyproject.toml" and enforces the root's policy.
+                found = current
+                break
         parent = os.path.dirname(current)
         if parent == current:
             # The root is its own parent, which is how this walk terminates.
-            return []
+            break
         current = parent
+    if not found:
+        return []
+    local = _existing_files([os.path.join(found, "uv.toml")])
+    return local or [os.path.join(found, "pyproject.toml")]
 
 
 def _hardened_uv_config_paths() -> "list[str]":
@@ -4978,17 +5061,12 @@ def _hardened_uv_config_paths() -> "list[str]":
     the order matters because the caller resolves last-wins, and a project config
     switching a control off is uv's answer even when the user config switched it on.
     """
-    explicit = os.environ.get("UV_CONFIG_FILE", "").strip()
+    explicit = _explicit_uv_config_path()
     if explicit:
         # --config-file is used "in place of any discovered configuration files", so the
         # discovered set is not merely outranked, it is not read at all. Checked BEFORE
         # --no-config: measured on the pinned uv 0.12.1, an explicit file is read with
         # UV_NO_CONFIG=1 set as well, so returning nothing there dropped live policy.
-        working = os.environ.get("UV_WORKING_DIR", "").strip()
-        if working and not os.path.isabs(explicit):
-            # --directory changes directory BEFORE running, so a relative config path is
-            # resolved there and not against the directory the installer started in.
-            explicit = os.path.join(working, explicit)
         return _existing_files([explicit])
     if _config_value_is_on(os.environ.get("UV_NO_CONFIG", "")):
         # --no-config: uv discovers nothing, so nothing here is policy.
@@ -5151,7 +5229,7 @@ def _combine_pip_commands(
         for key, entry in per_command.get(command, {}).items():
             # An enabled value anywhere among the three wins; otherwise keep a disabled
             # one so it can still cancel a lower-precedence file.
-            if key not in combined or _config_value_is_on(entry[1]):
+            if key not in combined or _config_value_is_on(entry[1], key):
                 combined[key] = entry
     return combined
 
@@ -5195,7 +5273,9 @@ def _hardened_settings_in_ini(text: str) -> "dict[str, str]":
 def _hardened_keys_in_ini(text: str) -> "list[str]":
     """Hardened keys switched ON in a single pip.conf."""
     return [
-        key for key, value in _hardened_settings_in_ini(text).items() if _config_value_is_on(value)
+        key
+        for key, value in _hardened_settings_in_ini(text).items()
+        if _config_value_is_on(value, key)
     ]
 
 
@@ -5267,7 +5347,7 @@ def _policy_scan() -> "tuple[tuple[tuple[str, str, str], ...], dict[str, frozens
         canonical = _canonical_policy_key(key)
         for slot in slots:
             configured[slot].add(canonical)
-        if _config_value_is_on(value):
+        if _config_value_is_on(value, key):
             on.append((tool, source, key))
         elif source == "env":
             # pip's environment beats every config file, so an explicitly disabled
@@ -5370,7 +5450,7 @@ def _policy_scan() -> "tuple[tuple[tuple[str, str, str], ...], dict[str, frozens
     # slot let a `no-build-package = []` erase a `no-build = true` sitting beside it in
     # the same file. Canonicalising is for comparing controls, not for storing them.
     uv_settings: "dict[str, tuple[str, str]]" = {}
-    explicit_uv = os.environ.get("UV_CONFIG_FILE", "").strip()
+    explicit_uv = _explicit_uv_config_path()
     for path in _hardened_uv_config_paths():
         text = _read_text(path)
         if text is None:
@@ -5501,7 +5581,7 @@ def _refuse_unenforceable_policy(cmd: "list[str]", missing: "list[str]") -> None
     sys.exit(1)
 
 
-def _preflight_policy_gap() -> None:
+def _preflight_policy_gap(use_uv: bool) -> None:
     """Refuse a cross-manager gap BEFORE the install mutates anything.
 
     The refusal is right, but its timing was not: `install_python_stack()` removes the
@@ -5509,14 +5589,19 @@ def _preflight_policy_gap() -> None:
     venv that had not been touched marked as a half-built install, and `verify_install()`
     and the Desktop preflight then rejected a working environment.
 
-    Both managers are probed, because this installer drives both and a control only one
-    of them can see is exactly what the opt-out asks to be stopped for. Nothing is
-    reported unless the opt-out is set, so an ordinary install never reaches the check.
+    Only the manager that will actually run the dependency installs is probed. Probing
+    both refused a pip-only policy on a host with no usable uv, where every real command
+    would have kept that policy: `_bootstrap_uv()` had not run yet, so the synthetic uv
+    probe described a manager the install was never going to use. Nothing is reported
+    unless the opt-out is set, so an ordinary install never reaches the check.
+
+    The refusal at the uv-to-pip fallback still covers the other direction, where uv is
+    used, fails, and pip would then be asked to do what uv refused.
     """
-    for probe in (["uv", "pip", "install"], [sys.executable, "-m", "pip", "install"]):
-        missing = _unenforceable_policy(probe)
-        if missing:
-            _refuse_unenforceable_policy(probe, missing)
+    probe = ["uv", "pip", "install"] if use_uv else [sys.executable, "-m", "pip", "install"]
+    missing = _unenforceable_policy(probe)
+    if missing:
+        _refuse_unenforceable_policy(probe, missing)
 
 
 def _announce_pm_policy() -> None:
@@ -6152,10 +6237,18 @@ def install_python_stack() -> int:
     # shell-installer handoff skips that slot only while base.txt has no work.
     _TOTAL = base_total - int(skip_base and base_requirements is None)
 
+    # uv selection first: it only runs dry-run probes, and the preflight below has to
+    # know which manager the dependency installs will use before it can say whether a
+    # control is out of that manager's reach.
+    #
+    # 1. Try uv for faster installs (before pip upgrade -- uv venvs don't
+    #    include pip by default).
+    USE_UV = _bootstrap_uv()
+
     # Before the manifest goes away, so a refusal cannot leave an untouched venv marked
-    # half-built. Silent unless the opt-out is set AND a control exists that one of the
-    # two managers cannot see.
-    _preflight_policy_gap()
+    # half-built. Silent unless the opt-out is set AND the manager that will run the
+    # installs cannot see a control the operator configured.
+    _preflight_policy_gap(USE_UV)
 
     # Drop it up front: a missing manifest is what tells the CLI, setup.sh and
     # the preflight that an interrupted run left the venv half-built. Stop if it
@@ -6181,10 +6274,6 @@ def install_python_stack() -> int:
         _announce_pm_policy()
     except Exception:
         pass
-
-    # 1. Try uv for faster installs (before pip upgrade -- uv venvs don't
-    #    include pip by default).
-    USE_UV = _bootstrap_uv()
 
     # 2. Ensure pip is available (uv venvs from install.sh omit pip).
     _progress("pip bootstrap")

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -4707,16 +4707,20 @@ def _config_value_is_on(value: str) -> bool:
 
 
 def _toml_value_is_on(value: object) -> bool:
-    """The same test for an already-parsed TOML value.
+    """The same test for a TOML value, parsed or still in its source spelling.
 
     `no-build = false` is an ordinary machine, and a list policy switched off is spelled
-    as the empty list, so neither may be reported as active hardening.
+    as the empty list, so neither may be reported as active hardening. The empty-collection
+    spellings are handled as text too, because the regex fallback never parses them.
     """
     if isinstance(value, bool):
         return value
-    if isinstance(value, (list, tuple)):
+    if isinstance(value, (list, tuple, dict)):
         return bool(value)
-    return _config_value_is_on(str(value))
+    text = str(value).strip()
+    if re.fullmatch(r"\[\s*\]|\{\s*\}", text):
+        return False
+    return _config_value_is_on(text)
 
 
 def _hardened_keys_in_toml(text: str, tables: "tuple[tuple[str, ...], ...]") -> "list[str]":
@@ -4747,11 +4751,27 @@ def _hardened_keys_in_toml(text: str, tables: "tuple[tuple[str, ...], ...]") -> 
                 if key in node and _toml_value_is_on(node[key]):
                     found.append(key)
         return found
-    for key in _HARDENED_CONFIG_KEYS:
-        # Line-anchored so a commented-out setting, or the same word inside a longer key,
-        # is not reported as active policy.
-        match = re.search(rf"^[ \t]*{re.escape(key)}[ \t]*=[ \t]*(.*)$", text, re.MULTILINE)
-        if match and _toml_value_is_on(match.group(1).strip().strip("\"'")):
+    # The fallback tracks table headers rather than scanning the whole document, so a
+    # `[tool.other] no-build = true` in a pyproject is not read as uv policy the way a
+    # flat search would read it.
+    current: "tuple[str, ...]" = ()
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("#") or not stripped:
+            continue
+        header = re.match(r"^\[\[?([^]]*)\]\]?$", stripped)
+        if header:
+            current = tuple(
+                part.strip().strip("\"'") for part in header.group(1).split(".") if part.strip()
+            )
+            continue
+        if current not in tables:
+            continue
+        key, separator, raw = stripped.partition("=")
+        if not separator:
+            continue
+        key = key.strip().strip("\"'")
+        if key in _HARDENED_CONFIG_KEYS and _toml_value_is_on(raw.strip().strip("\"'")):
             found.append(key)
     return found
 
@@ -4829,7 +4849,21 @@ def _hardened_pip_config_paths() -> "list[str]":
             if base:
                 candidates.append(os.path.join(base, "pip", name))
     else:
-        candidates.append(os.path.join("/etc", "xdg", "pip", name))
+        # Global is EVERY entry of XDG_CONFIG_DIRS, not just the default: measured with
+        # pip 26, `XDG_CONFIG_DIRS=/a:/b pip config debug` enumerates /a/pip/pip.conf and
+        # /b/pip/pip.conf. macOS reads its global set from XDG_DATA_DIRS instead, falling
+        # back to /Library/Application Support.
+        directories = os.environ.get(
+            "XDG_DATA_DIRS" if IS_MACOS else "XDG_CONFIG_DIRS", ""
+        ).strip()
+        if directories:
+            for directory in directories.split(os.pathsep):
+                if directory.strip():
+                    candidates.append(os.path.join(directory.strip(), "pip", name))
+        elif IS_MACOS:
+            candidates.append(os.path.join("/Library", "Application Support", "pip", name))
+        else:
+            candidates.append(os.path.join("/etc", "xdg", "pip", name))
         candidates.append(os.path.join("/etc", name))
         home = os.path.expanduser("~")
         xdg = os.environ.get("XDG_CONFIG_HOME") or os.path.join(home, ".config")
@@ -4871,15 +4905,20 @@ def _read_text(path: str) -> "str | None":
 
 
 @functools.lru_cache(maxsize = 1)
-def _hardened_pm_policy_names() -> "tuple[str, ...]":
-    """Human-readable names for the package-manager hardening this host has configured.
+def _detected_policy() -> "tuple[tuple[str, str, str], ...]":
+    """(tool, source, key) for every package-manager hardening this host has configured.
 
-    Empty on an ordinary machine, which is the common case and the reason the notice is
-    silent by default. Best-effort throughout: this decides what to PRINT, never what to
-    run, so a probe that fails just shortens the list.
+    `tool` is "pip" or "uv", which is what makes this more than a display list: under the
+    opt-out the two managers have to be told about each other's policy, since neither
+    reads the other's (measured on the pinned uv 0.12.1, `uv pip install` ignores both
+    PIP_REQUIRE_HASHES and a pip.conf require-hashes). `source` is "env" for a variable,
+    otherwise the config file's basename.
+
+    Empty on an ordinary machine. Best-effort throughout: a probe that fails just
+    shortens the list.
     """
     found = [
-        name
+        ("pip" if name.startswith("PIP_") else "uv", "env", name)
         for name in _PM_POLICY_ENV_VARS
         if _config_value_is_on(os.environ.get(name, ""))
     ]
@@ -4904,7 +4943,7 @@ def _hardened_pm_policy_names() -> "tuple[str, ...]":
                 continue
             option = name.strip().rpartition(".")[2]
             if option in _HARDENED_CONFIG_KEYS and _config_value_is_on(raw.strip().strip("'\"")):
-                found.append(f"pip.conf {option}")
+                found.append(("pip", "pip.conf", option))
     else:
         # No usable pip, so read pip's files directly rather than report an ordinary
         # machine. Only in this branch: when pip answered, it already merged them.
@@ -4913,7 +4952,7 @@ def _hardened_pm_policy_names() -> "tuple[str, ...]":
             if text is None:
                 continue
             for key in _hardened_keys_in_ini(text):
-                found.append(f"{os.path.basename(path)} {key}")
+                found.append(("pip", os.path.basename(path), key))
     for path in _hardened_uv_config_paths():
         text = _read_text(path)
         if text is None:
@@ -4924,8 +4963,67 @@ def _hardened_pm_policy_names() -> "tuple[str, ...]":
             else ((), ("pip",))
         )
         for key in _hardened_keys_in_toml(text, tables):
-            found.append(f"{os.path.basename(path)} {key}")
+            found.append(("uv", os.path.basename(path), key))
     return tuple(dict.fromkeys(found))
+
+
+def _hardened_pm_policy_names() -> "tuple[str, ...]":
+    """The detected policy, as the notice prints it."""
+    return tuple(dict.fromkeys(
+        key if source == "env" else f"{source} {key}"
+        for _tool, source, key in _detected_policy()
+    ))
+
+
+# pip and uv spell the same three controls differently and read none of each other's.
+# Under the opt-out, whichever manager runs is told the other's policy in its own
+# spelling, or the flag only holds for whichever tool the operator happened to configure.
+# Precedent: _uv_staging_plan already translates UV_NO_BINARY / UV_ONLY_BINARY into their
+# pip spellings for the same reason.
+def _translated_policy_env(cmd: "list[str]") -> "dict[str, str]":
+    """Retained policy, restated for the manager this command actually runs.
+
+    Empty unless the opt-out is set. Never overrides a setting the target manager already
+    has: the operator's own spelling always wins over a translation of the other one.
+    """
+    if not _respect_pm_policy():
+        return {}
+    target = "uv" if cmd[:1] == ["uv"] else "pip"
+    source_keys = {
+        key.lower() for tool, _source, key in _detected_policy() if tool != target
+    }
+    if not source_keys:
+        return {}
+
+    def _on(*names: str) -> bool:
+        return any(
+            name.lower() in source_keys or name.lower().replace("_", "-") in source_keys
+            for name in names
+        )
+
+    overrides: dict[str, str] = {}
+    if target == "uv":
+        if _on("PIP_REQUIRE_HASHES", "require-hashes"):
+            overrides["UV_REQUIRE_HASHES"] = "1"
+        # pip's only-binary is "wheels only", which uv spells as no-build.
+        if _on("PIP_ONLY_BINARY", "only-binary"):
+            overrides["UV_NO_BUILD"] = "1"
+        if _on("PIP_NO_BINARY", "no-binary"):
+            overrides["UV_NO_BINARY"] = "1"
+    else:
+        if _on("UV_REQUIRE_HASHES", "require-hashes"):
+            overrides["PIP_REQUIRE_HASHES"] = "1"
+        if _on("UV_NO_BUILD", "UV_NO_BUILD_PACKAGE", "no-build", "no-build-package"):
+            overrides["PIP_ONLY_BINARY"] = ":all:"
+        if _on("UV_NO_BINARY", "UV_NO_BINARY_PACKAGE", "no-binary", "no-binary-package"):
+            overrides["PIP_NO_BINARY"] = ":all:"
+        if _on("UV_ONLY_BINARY", "UV_ONLY_BINARY_PACKAGE", "only-binary"):
+            overrides["PIP_ONLY_BINARY"] = ":all:"
+    return {
+        name: value
+        for name, value in overrides.items()
+        if not os.environ.get(name, "").strip()
+    }
 
 
 def _announce_pm_policy() -> None:
@@ -5265,16 +5363,24 @@ def _install_env_for_cmd(cmd: "list[str]") -> "dict[str, str] | None":
     opposite.
     """
     if not _is_pinned_index_cmd(cmd):
-        relaxed = _relaxed_pip_policy_env(cmd)
-        if not relaxed:
+        overrides = dict(_relaxed_pip_policy_env(cmd))
+        overrides.update(_translated_policy_env(cmd))
+        if not overrides:
             return None
         env = os.environ.copy()
-        env.update(relaxed)
+        env.update(overrides)
         return env
     env = os.environ.copy()
     for name in _UV_INDEX_ENV_VARS:
+        # UV_CONFIG_FILE is an index variable only incidentally: measured, a file named
+        # by it carrying `[pip] require-hashes = true` fails a pinned install, and
+        # dropping it lets the same install through. Under the opt-out it is the
+        # operator's policy file, so it stays.
+        if name == "UV_CONFIG_FILE" and _respect_pm_policy():
+            continue
         env.pop(name, None)
     if _respect_pm_policy():
+        env.update(_translated_policy_env(cmd))
         return env
     env["UV_NO_CONFIG"] = "1"
     for name in _PM_POLICY_ENV_VARS:

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -2680,6 +2680,22 @@ def _ensure_xpu_triton() -> None:
         )
         return
 
+    if _respect_pm_policy():
+        # The swap uninstalls generic triton and installs a wheel fetched from the pinned
+        # index, and there is no expected hash to check that wheel against: deriving one
+        # from the artifact itself would approve whatever the index returned. The swap is
+        # an optimisation -- torch.compile using the XPU -- so under the opt-out it is
+        # skipped BEFORE the download, leaving the venv exactly as it was rather than
+        # without triton at all, which no rerun could repair.
+        _safe_print(
+            _red(
+                f"   {_POLICY_OPT_OUT_ENV} is set and the XPU triton swap would have to "
+                f"install a wheel your hash policy cannot verify; leaving generic triton "
+                f"{generic} in place -- torch.compile will not use the XPU."
+            )
+        )
+        return
+
     # Fetch, THEN uninstall, THEN install from the file. The uninstall cannot go last: the shared
     # paths live in generic triton's OWN record, so removing it afterwards deletes what the XPU
     # build just wrote. Pre-fetching stops a dead mirror stranding the venv between the two
@@ -2743,25 +2759,13 @@ def _ensure_xpu_triton() -> None:
         # with it. pip_install, not pip_install_try -- a warning would let the caller write a
         # completion manifest over a venv whose torch.compile is broken, which the next update
         # then fast-paths past (no generic distribution is left to trigger on).
-        # The wheel is a bare file reference, which require-hashes rejects. This install
-        # runs with the venv already stripped of triton and cannot be retried later --
-        # no generic distribution is left to trigger on -- so under the opt-out it goes
-        # through the wheel's own sha256, exactly as the metadata restore does.
-        requirements = _hashed_requirement_file(wheels[0]) if _respect_pm_policy() else ""
-        try:
-            pip_install(
-                "triton (Intel XPU)",
-                "--force-reinstall",
-                "--no-deps",
-                *(("-r", requirements) if requirements else (wheels[0],)),
-                constrain = False,
-            )
-        finally:
-            if requirements:
-                try:
-                    os.unlink(requirements)
-                except OSError:
-                    pass
+        pip_install(
+            "triton (Intel XPU)",
+            "--force-reinstall",
+            "--no-deps",
+            wheels[0],
+            constrain = False,
+        )
     finally:
         shutil.rmtree(tmp, ignore_errors = True)
 
@@ -4187,58 +4191,6 @@ class _QuarantinedMetadata:
         self._copied.clear()
 
 
-def _hashed_requirement_file(wheel: str) -> str:
-    """A requirements file pinning `wheel` by its own sha256, or "" if it cannot be made.
-
-    Under the opt-out, an install of a wheel this installer just fetched or built has to
-    satisfy require-hashes rather than be exempted from it. Each such install also runs
-    AFTER something has been uninstalled, so being refused there leaves the venv missing
-    the package rather than merely unchanged.
-    """
-    try:
-        digest = hashlib.sha256(Path(wheel).read_bytes()).hexdigest()
-        handle = tempfile.NamedTemporaryFile("w", suffix = ".txt", delete = False, encoding = "utf-8")
-        with handle:
-            handle.write(f"{os.path.abspath(wheel)} --hash=sha256:{digest}\n")
-    except OSError:
-        return ""
-    return handle.name
-
-
-def _staged_restore_args(name: str, staged: str) -> "tuple[list[str], str]":
-    """pip arguments that reinstall `name` from the staged wheel directory.
-
-    By default the wheel is a bare requirement resolved out of `--find-links`. Under the
-    opt-out require-hashes rejects that, and the restore runs AFTER the uninstall loop
-    has deleted the package records, so failing there leaves the core package gone.
-
-    The staged wheel is a local file this installer just built, so its hash is knowable:
-    the restore goes through a requirements file carrying the real sha256, satisfying
-    the policy instead of relaxing it for one command or abandoning the repair.
-    Measured on pip 26.2.1, both directions -- accepted under PIP_REQUIRE_HASHES=1, and
-    "THESE PACKAGES DO NOT MATCH THE HASHES" once the wheel is altered.
-
-    Returns (arguments, a temporary requirements file to delete, or "").
-    """
-    default = ["--no-deps", "--force-reinstall", "--no-index", "--find-links", staged, name]
-    if not _respect_pm_policy():
-        return default, ""
-    wanted = re.sub(r"[-_.]+", "-", name).lower()
-    wheel = ""
-    for candidate in sorted(glob.glob(os.path.join(staged, "*.whl"))):
-        project = re.sub(r"[-_.]+", "-", os.path.basename(candidate).split("-")[0]).lower()
-        if project == wanted:
-            wheel = candidate
-            break
-    if not wheel:
-        # Nothing to hash, so nothing better to offer than the default and its error.
-        return default, ""
-    requirements = _hashed_requirement_file(wheel)
-    if not requirements:
-        return default, ""
-    return ["--no-deps", "--force-reinstall", "--no-index", "-r", requirements], requirements
-
-
 def _restore_from_staged(
     name: str,
     staged: str,
@@ -4253,24 +4205,21 @@ def _restore_from_staged(
     """
     if not (removed_any and staged):
         return
-    restore_args, restore_reqs = _staged_restore_args(name, staged)
-    try:
-        restored_here = pip_install_try(
-            f"Restoring {name} after an incomplete metadata repair",
-            "--no-cache-dir",
-            *restore_args,
-            # pip, not uv: the wheel is already built and sitting in staged, and uv would
-            # reject the unpinned name under UV_REQUIRE_HASHES with the package records
-            # already gone. Routing through pip also earns the PIP_REQUIRE_HASHES
-            # relaxation, which the opt-out withholds -- see _staged_restore_args.
-            force_pip = True,
-        )
-    finally:
-        if restore_reqs:
-            try:
-                os.unlink(restore_reqs)
-            except OSError:
-                pass
+    restored_here = pip_install_try(
+        f"Restoring {name} after an incomplete metadata repair",
+        "--no-cache-dir",
+        "--no-deps",
+        "--force-reinstall",
+        "--no-index",
+        "--find-links",
+        staged,
+        name,
+        # pip, not uv: the wheel is already built and sitting in staged, and uv would
+        # reject the unpinned name under UV_REQUIRE_HASHES with the package records
+        # already gone. The repair never starts under the opt-out, so this cannot be
+        # the step that a hash policy refuses.
+        force_pip = True,
+    )
     if restored_here:
         # The wheel just wrote its own valid metadata at the same path the rewritten
         # record occupied, so the unwinding below must not put the original back over
@@ -4326,6 +4275,22 @@ def _stage_replacement(name: str):
         # leaves the installation intact.
         build_options = ["--no-build-isolation"]
         overrides = {"PIP_NO_INDEX": "1"}
+    if _respect_pm_policy():
+        # The repair deletes every metadata record and then reinstalls from the staged
+        # wheel, and that reinstall cannot be made to satisfy require-hashes honestly:
+        # hashing the artifact we just fetched and handing that digest back to the
+        # protected install approves it with itself, which is not what a hash policy is
+        # for. There is no expected hash to check against, so the repair does not start.
+        # Duplicate metadata is untidy; a venv with the core package uninstalled is not.
+        _safe_print(
+            _red(
+                f"   {_POLICY_OPT_OUT_ENV} is set and repairing {name} would have to "
+                "install a replacement your hash policy cannot verify; leaving the "
+                "install alone."
+            ),
+            file = sys.stderr,
+        )
+        return None
     if USE_UV and _uv_is_offline() and not _is_local_source(name):
         # A checkout on disk needs no network, so offline has nothing to say about it.
         _safe_print(
@@ -4561,22 +4526,19 @@ def _repair_duplicate_core_metadata(
                 # The overlay install is preferred because it keeps the editable
                 # or git provenance, but the staged wheel was built from that
                 # same source, so falling back to it never substitutes a release.
-                repair_args, repair_reqs = _staged_restore_args(name, staged)
-                try:
-                    restored = pip_install_try(
-                        f"Repairing duplicate metadata for {name}",
-                        "--no-cache-dir",
-                        *repair_args,
-                        # As _restore_from_staged: pip, so a uv hash policy cannot reject
-                        # the already-built wheel once every record has been removed.
-                        force_pip = True,
-                    )
-                finally:
-                    if repair_reqs:
-                        try:
-                            os.unlink(repair_reqs)
-                        except OSError:
-                            pass
+                restored = pip_install_try(
+                    f"Repairing duplicate metadata for {name}",
+                    "--no-cache-dir",
+                    "--no-deps",
+                    "--force-reinstall",
+                    "--no-index",
+                    "--find-links",
+                    staged,
+                    name,
+                    # As _restore_from_staged: pip, so a uv hash policy cannot reject the
+                    # already-built wheel once every record has been removed.
+                    force_pip = True,
+                )
             if not restored:
                 _safe_print(
                     _red(
@@ -4725,6 +4687,9 @@ _PM_POLICY_ENV_VARS = (
     "PIP_NO_BINARY",
     "PIP_REQUIRE_HASHES",
     "PIP_UPLOADED_PRIOR_TO",
+    # Reported as well as scrubbed: the pinned branch removes it by default, and
+    # `pip config list` shows it as `:env:.no-index`, which this scan skips.
+    "PIP_NO_INDEX",
 )
 
 

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -12,6 +12,7 @@ activated. Expects `pip` and `python` on PATH to point at the venv.
 from __future__ import annotations
 
 import ast
+import configparser
 import functools
 import glob
 import importlib
@@ -28,6 +29,11 @@ import tempfile
 import textwrap
 import urllib.request
 from pathlib import Path
+
+try:  # 3.11+. Only the hardening notice uses it, and it degrades to a regex without it.
+    import tomllib as _tomllib
+except ImportError:  # pragma: no cover - exercised on 3.9/3.10 interpreters
+    _tomllib = None
 
 _STUDIO_DIR = Path(__file__).resolve().parent
 _BACKEND_DIR = _STUDIO_DIR / "backend"
@@ -4647,6 +4653,8 @@ _PM_POLICY_ENV_VARS = (
     "UV_NO_BINARY_PACKAGE",
     "UV_REQUIRE_HASHES",
     "UV_EXCLUDE_NEWER",
+    "UV_ONLY_BINARY",
+    "UV_ONLY_BINARY_PACKAGE",
     "PIP_ONLY_BINARY",
     "PIP_NO_BINARY",
     "PIP_REQUIRE_HASHES",
@@ -4681,8 +4689,20 @@ def _relaxed_pip_policy_env(cmd: "list[str]") -> "dict[str, str]":
 
 # Settings whose presence means the host has deliberately hardened its package manager,
 # as opposed to merely configuring a mirror. Named in the notice so the operator can see
-# which of their controls the installer is about to set aside.
-_HARDENED_CONFIG_KEYS = ("require-hashes", "only-binary", "no-binary", "no-build")
+# which of their controls the installer is about to set aside. The `-package` and
+# `exclude-newer` spellings are here for the same reason UV_EXCLUDE_NEWER is in
+# _PM_POLICY_ENV_VARS: an upload cutoff is a reproducibility control, and relaxing one
+# silently is the thing this notice exists to stop.
+_HARDENED_CONFIG_KEYS = (
+    "require-hashes",
+    "only-binary",
+    "no-binary",
+    "no-binary-package",
+    "no-build",
+    "no-build-package",
+    "exclude-newer",
+    "exclude-newer-package",
+)
 
 
 def _config_value_is_on(value: str) -> bool:
@@ -4690,16 +4710,88 @@ def _config_value_is_on(value: str) -> bool:
     return value.strip().lower() not in ("", "0", "false", "no", "none", ":none:")
 
 
+def _toml_value_is_on(value: object) -> bool:
+    """The same test for an already-parsed TOML value.
+
+    `no-build = false` is an ordinary machine, and a list policy switched off is spelled
+    as the empty list, so neither may be reported as active hardening.
+    """
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (list, tuple)):
+        return bool(value)
+    return _config_value_is_on(str(value))
+
+
+def _hardened_keys_in_toml(text: str, tables: "tuple[tuple[str, ...], ...]") -> "list[str]":
+    """Hardened keys switched ON inside the named tables of a TOML document.
+
+    `tables` is the path to each table to look in, so a uv.toml is read at its root and
+    under `[pip]`, and a pyproject under `[tool.uv]` / `[tool.uv.pip]`, without a stray
+    `no-build` in some unrelated tool's table counting as uv policy.
+
+    tomllib is 3.11+, and this module still runs on older interpreters, so the fallback
+    is a value-capturing regex. Both test the VALUE: reporting `no-build = false` would
+    put a security notice in front of a user who had switched the policy off.
+    """
+    found: list[str] = []
+    data = None
+    if _tomllib is not None:
+        try:
+            data = _tomllib.loads(text)
+        except Exception:
+            data = None
+    if data is not None:
+        for table in tables:
+            node: object = data
+            for part in table:
+                node = node.get(part) if isinstance(node, dict) else None
+                if node is None:
+                    break
+            if not isinstance(node, dict):
+                continue
+            for key in _HARDENED_CONFIG_KEYS:
+                if key in node and _toml_value_is_on(node[key]):
+                    found.append(key)
+        return found
+    for key in _HARDENED_CONFIG_KEYS:
+        # Line-anchored so a commented-out setting, or the same word inside a longer key,
+        # is not reported as active policy.
+        match = re.search(rf"^[ \t]*{re.escape(key)}[ \t]*=[ \t]*(.*)$", text, re.MULTILINE)
+        if match and _toml_value_is_on(match.group(1).strip().strip("\"'")):
+            found.append(key)
+    return found
+
+
+def _existing_files(candidates: "list[str]") -> "list[str]":
+    found = []
+    for path in candidates:
+        try:
+            if os.path.isfile(path):
+                found.append(path)
+        except OSError:
+            # A path this process cannot stat (permissions, a dead network mount) is
+            # simply not a config file we can report on.
+            continue
+    return found
+
+
 def _hardened_uv_config_paths() -> "list[str]":
     """The uv config files this host has, where a no-build / require-hashes could live.
 
-    System, user and invocation directory, which are the documented locations: uv reads
-    `~/.config/uv/uv.toml` on macOS AND Linux (not Application Support) and
+    System, user, invocation directory and the cwd pyproject, which is what uv actually
+    reads: `~/.config/uv/uv.toml` on macOS AND Linux (not Application Support) and
     `%APPDATA%\\uv\\uv.toml` on Windows, with `/etc/uv/uv.toml` and `%PROGRAMDATA%\\uv`
-    as the system-wide pair. The system one matters most here: a fleet operator hardening
-    every machine puts `no-build` there. uv also reads a pyproject [tool.uv] and a
-    workspace root above the cwd; those are left out deliberately -- this list drives a
-    NOTICE, and missing one costs a line of output, not a behaviour change.
+    as the system-wide pair. The system one matters most: a fleet operator hardening every
+    machine puts `no-build` there.
+
+    The cwd `pyproject.toml` is included because uv 0.12.1 (the pinned version) really
+    does read it -- measured, `[tool.uv.pip] require-hashes = true` there fails a
+    `uv pip install`, and `-v` logs "Found workspace configuration". A PARENT directory's
+    `pyproject.toml` or `uv.toml` is NOT read by `uv pip install`, and neither is a bare
+    `./uv.toml`: the same probe logs only "Searching for user configuration" and the
+    policy does not apply. `./uv.toml` is kept in the list anyway, since it costs a line
+    of output and other uv subcommands this module drives may yet read it.
     """
     candidates = []
     explicit = os.environ.get("UV_CONFIG_FILE", "").strip()
@@ -4718,19 +4810,76 @@ def _hardened_uv_config_paths() -> "list[str]":
         candidates.append("/etc/uv/uv.toml")
     try:
         # A deleted working directory raises here rather than returning anything.
-        candidates.append(os.path.join(os.getcwd(), "uv.toml"))
+        cwd = os.getcwd()
     except OSError:
-        pass
+        cwd = ""
+    if cwd:
+        candidates.append(os.path.join(cwd, "uv.toml"))
+        candidates.append(os.path.join(cwd, "pyproject.toml"))
+    return _existing_files(candidates)
+
+
+def _hardened_pip_config_paths() -> "list[str]":
+    """pip's documented configuration files, for when `python -m pip` cannot be run.
+
+    install.sh creates the venv with uv, which does not seed pip, so at the moment this
+    notice runs `python -m pip config list` returns nonzero and a require-hashes living
+    only in pip.conf is invisible -- while the pip FALLBACK later in the install reads it
+    perfectly well. Locations are pip's own (global, user, site, then PIP_CONFIG_FILE);
+    the subprocess answer is still preferred when it works, because pip merges them in
+    its own documented order and reports the winner.
+    """
+    name = "pip.ini" if IS_WINDOWS else "pip.conf"
+    explicit = os.environ.get("PIP_CONFIG_FILE", "").strip()
+    if explicit and os.path.normcase(explicit) == os.path.normcase(os.devnull):
+        # Documented: PIP_CONFIG_FILE=os.devnull disables the loading of ALL config files.
+        return []
+    candidates = []
+    if IS_WINDOWS:
+        for variable in ("PROGRAMDATA", "APPDATA"):
+            base = os.environ.get(variable, "")
+            if base:
+                candidates.append(os.path.join(base, "pip", name))
+    else:
+        candidates.append(os.path.join("/etc", "xdg", "pip", name))
+        candidates.append(os.path.join("/etc", name))
+        home = os.path.expanduser("~")
+        xdg = os.environ.get("XDG_CONFIG_HOME") or os.path.join(home, ".config")
+        candidates.append(os.path.join(xdg, "pip", name))
+        if IS_MACOS:
+            candidates.append(os.path.join(home, "Library", "Application Support", "pip", name))
+        candidates.append(os.path.join(home, ".pip", name))
+    site = os.environ.get("VIRTUAL_ENV", "") or sys.prefix
+    if site:
+        candidates.append(os.path.join(site, name))
+    if explicit:
+        candidates.append(explicit)
+    return _existing_files(candidates)
+
+
+def _hardened_keys_in_ini(text: str) -> "list[str]":
+    """Hardened keys switched ON in a pip.conf, in any of its sections."""
+    parser = configparser.RawConfigParser()
+    try:
+        parser.read_string(text)
+    except configparser.Error:
+        return []
     found = []
-    for path in candidates:
-        try:
-            if os.path.isfile(path):
-                found.append(path)
-        except OSError:
-            # A path this process cannot stat (permissions, a dead network mount) is
-            # simply not a config file we can report on.
-            continue
+    for section in parser.sections():
+        for key in _HARDENED_CONFIG_KEYS:
+            if parser.has_option(section, key):
+                value = parser.get(section, key, fallback = "")
+                if _config_value_is_on(value):
+                    found.append(key)
     return found
+
+
+def _read_text(path: str) -> "str | None":
+    try:
+        with open(path, encoding = "utf-8", errors = "replace") as handle:
+            return handle.read()
+    except OSError:
+        return None
 
 
 @functools.lru_cache(maxsize = 1)
@@ -4768,17 +4917,26 @@ def _hardened_pm_policy_names() -> "tuple[str, ...]":
             option = name.strip().rpartition(".")[2]
             if option in _HARDENED_CONFIG_KEYS and _config_value_is_on(raw.strip().strip("'\"")):
                 found.append(f"pip.conf {option}")
-    for path in _hardened_uv_config_paths():
-        try:
-            with open(path, encoding = "utf-8", errors = "replace") as handle:
-                text = handle.read()
-        except OSError:
-            continue
-        for key in _HARDENED_CONFIG_KEYS:
-            # Line-anchored so a commented-out setting, or the same word inside a longer
-            # key, is not reported as active policy.
-            if re.search(rf"^\s*{re.escape(key)}\s*=", text, re.MULTILINE):
+    else:
+        # No usable pip, so read pip's files directly rather than report an ordinary
+        # machine. Only in this branch: when pip answered, it already merged them.
+        for path in _hardened_pip_config_paths():
+            text = _read_text(path)
+            if text is None:
+                continue
+            for key in _hardened_keys_in_ini(text):
                 found.append(f"{os.path.basename(path)} {key}")
+    for path in _hardened_uv_config_paths():
+        text = _read_text(path)
+        if text is None:
+            continue
+        tables = (
+            (("tool", "uv"), ("tool", "uv", "pip"))
+            if os.path.basename(path) == "pyproject.toml"
+            else ((), ("pip",))
+        )
+        for key in _hardened_keys_in_toml(text, tables):
+            found.append(f"{os.path.basename(path)} {key}")
     return tuple(dict.fromkeys(found))
 
 
@@ -4794,8 +4952,10 @@ def _announce_pm_policy() -> None:
     if _respect_pm_policy():
         _note(
             f"{_POLICY_OPT_OUT_ENV} is set: keeping {listed} in force for Unsloth's own "
-            "dependency installs. Steps whose requirements are unhashed, or have no "
-            "wheel at any version, will fail rather than be installed.",
+            "dependency installs, which will now fail where your policy forbids them "
+            "rather than be relaxed. pip and uv apply it exactly as they would for you, "
+            "including where they choose not to: pip does not apply only-binary to an "
+            "explicitly supplied source archive.",
             _cyan,
         )
         return
@@ -5106,13 +5266,15 @@ def _install_env_for_cmd(cmd: "list[str]") -> "dict[str, str] | None":
 
     Under UNSLOTH_RESPECT_PM_POLICY the pinned branch still scrubs the INDEX variables --
     the pin is itself a provenance control and the opt-out is not a request to weaken it
-    -- but the policy variables survive and pip.conf is left readable, so require-hashes,
-    no-build and only-binary apply to the pinned installs too. The residual cost is that
-    an `extra-index-url` in pip.conf can still add a candidate source to the pip fallback;
-    that is the price of honouring the same file's security settings. UV_NO_CONFIG stays
-    on either way because uv has no surgical equivalent, and the only pinned installs are
-    wheel-only torch repairs, which a uv.toml no-build was never going to block; the
-    UV_REQUIRE_HASHES / UV_NO_BUILD spellings that CAN reach them are preserved.
+    -- but the policy variables survive, pip.conf is left readable, and uv's config
+    discovery is left on, so require-hashes, no-build and only-binary apply to the pinned
+    installs too. Config discovery has to stay: measured on the pinned uv 0.12.1, a user
+    `~/.config/uv/uv.toml` with `[pip] require-hashes = true` fails a pinned install and
+    UV_NO_CONFIG=1 makes the same install succeed, so keeping it would discard exactly the
+    control the opt-out promises to honour. The residual cost is symmetric on both tools:
+    an `extra-index-url` in pip.conf, or an `[[index]]` in that uv.toml, can still add a
+    candidate source under the opt-out. That is the price of reading the same files'
+    security settings, and it is why the default path does the opposite.
     """
     if not _is_pinned_index_cmd(cmd):
         relaxed = _relaxed_pip_policy_env(cmd)
@@ -5124,9 +5286,9 @@ def _install_env_for_cmd(cmd: "list[str]") -> "dict[str, str] | None":
     env = os.environ.copy()
     for name in _UV_INDEX_ENV_VARS:
         env.pop(name, None)
-    env["UV_NO_CONFIG"] = "1"
     if _respect_pm_policy():
         return env
+    env["UV_NO_CONFIG"] = "1"
     for name in _PM_POLICY_ENV_VARS:
         env.pop(name, None)
     env["PIP_CONFIG_FILE"] = os.devnull
@@ -5235,7 +5397,22 @@ def pip_install(
                 if VERBOSE and result.stdout:
                     _safe_print(_redact_install_output(result.stdout))
                 return
-            _safe_print(_red(f"   uv failed, falling back to pip..."))
+            if _respect_pm_policy():
+                # The fallback exists to rescue a uv failure, but pip reads none of uv's
+                # policy: under the opt-out it would retry the very install uv refused
+                # and succeed, which is the bypass the flag was set to prevent. Stop
+                # instead, on the same terms as any other fatal step.
+                if result.stdout:
+                    _safe_print(_redact_install_output(result.stdout))
+                _safe_print(
+                    _red(
+                        f"   uv failed and {_POLICY_OPT_OUT_ENV} is set, so the pip "
+                        "fallback is not used: pip does not read uv's policy and would "
+                        "install what uv refused. Unset it to allow the fallback."
+                    )
+                )
+                sys.exit(result.returncode)
+            _safe_print(_red("   uv failed, falling back to pip..."))
             if result.stdout:
                 _safe_print(_redact_install_output(result.stdout))
 

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -4810,7 +4810,11 @@ def _hardened_settings_in_toml(
         if stripped.count("[") > stripped.count("]") and "=" in stripped:
             pending = stripped
             continue
-        joined.append(raw_line)
+        # `piece`, not the raw line: the comment has already been taken off it, and
+        # keeping it made `no-build = false # disabled` read as the value
+        # "false # disabled", which is not one of the off spellings and so reported a
+        # policy the operator had switched off.
+        joined.append(piece)
     if pending:
         joined.append(pending)
     for line in joined:
@@ -4940,6 +4944,10 @@ def _hardened_pip_config_paths() -> "list[str]":
     own (global, user, site, PIP_CONFIG_FILE); the subprocess answer still wins when it
     works, since pip merges them itself.
     """
+    # Within the user kind, pip's get_configuration_files returns
+    # [legacy_config_file, new_config_file] and loads them in that order, so the modern
+    # location is authoritative. Listing it first put the legacy file last and let
+    # ~/.pip/pip.conf override ~/.config/pip/pip.conf, which is the opposite of pip.
     name = "pip.ini" if IS_WINDOWS else "pip.conf"
     explicit = os.environ.get("PIP_CONFIG_FILE", "").strip()
     if explicit and os.path.normcase(explicit) == os.path.normcase(os.devnull):
@@ -4952,14 +4960,14 @@ def _hardened_pip_config_paths() -> "list[str]":
     candidates = []
     user: "list[str]" = []
     if IS_WINDOWS:
+        # pip's legacy user file, still in get_configuration_files(): "pip" on Windows,
+        # ".pip" elsewhere, under the expanded home. First, so %APPDATA% outranks it.
+        user.append(os.path.join(os.path.expanduser("~"), "pip", name))
         for variable in ("PROGRAMDATA", "APPDATA"):
             base = os.environ.get(variable, "")
             if base:
                 target = candidates if variable == "PROGRAMDATA" else user
                 target.append(os.path.join(base, "pip", name))
-        # pip's legacy user file, still in get_configuration_files(): "pip" on Windows,
-        # ".pip" elsewhere, under the expanded home.
-        user.append(os.path.join(os.path.expanduser("~"), "pip", name))
     else:
         # Global is EVERY entry of XDG_CONFIG_DIRS, not just the default: measured with
         # pip 26, `XDG_CONFIG_DIRS=/a:/b pip config debug` enumerates /a/pip/pip.conf and
@@ -4976,11 +4984,12 @@ def _hardened_pip_config_paths() -> "list[str]":
             candidates.append(os.path.join("/etc", "xdg", "pip", name))
         candidates.append(os.path.join("/etc", name))
         home = os.path.expanduser("~")
+        user.append(os.path.join(home, ".pip", name))
         xdg = os.environ.get("XDG_CONFIG_HOME") or os.path.join(home, ".config")
         user.append(os.path.join(xdg, "pip", name))
         if IS_MACOS:
+            # user_config_dir on macOS, so it is the modern file there and goes last.
             user.append(os.path.join(home, "Library", "Application Support", "pip", name))
-        user.append(os.path.join(home, ".pip", name))
     if not skip_user:
         candidates.extend(user)
     # Site, then the explicit file: pip's own load order, which is what makes the
@@ -5005,37 +5014,38 @@ _PIP_SECTION_RANK = {"global": 0, "install": 1, "download": 1, "wheel": 1}
 _PIP_COMMANDS = ("install", "download", "wheel")
 
 
-def _hardened_settings_by_command(text: str) -> "dict[str, dict[str, str]]":
-    """Hardened settings from a pip.conf, kept separate for each subcommand.
+_PIP_SECTIONS = ("global",) + _PIP_COMMANDS
 
-    Per command rather than combined, because precedence runs file by file and pip
-    resolves each command on its own: a user file's `[install] require-hashes = true`
-    and a site file's `[wheel] require-hashes = false` are two policies, and collapsing
-    each file before the next overwrites it loses the first entirely, reporting an
-    unhardened host while pip still hash-checks every install.
+
+def _hardened_pip_sections(text: str) -> "dict[str, dict[str, str]]":
+    """Hardened settings from a pip.conf, one bucket per section and NOT merged.
+
+    Unmerged because pip pools every file's `[global]` into one group and every file's
+    command section into another, and applies global first and the command second only
+    at the end: a `[install]` setting in a low-priority file therefore still beats a
+    `[global]` in a high-priority one. Folding global into the command sections file by
+    file gets that backwards, and let a later `[global] require-hashes = false` erase an
+    earlier `[install] require-hashes = true` pip was still applying.
+
+    Option names are normalised the way pip normalises them, lowercased with underscores
+    turned into dashes: `require_hashes = true` is a spelling pip honours, and
+    RawConfigParser keeps the underscore, so matching the dashed name alone missed it.
     """
+    sections: "dict[str, dict[str, str]]" = {name: {} for name in _PIP_SECTIONS}
     parser = configparser.RawConfigParser()
     try:
         parser.read_string(text)
     except configparser.Error:
-        return {command: {} for command in _PIP_COMMANDS}
-
-    def _section(name: str) -> "dict[str, str]":
-        values = {}
-        for key in _PIP_CONFIG_KEYS:
-            if parser.has_option(name, key):
-                values[key] = parser.get(name, key, fallback = "")
-        return values
-
-    sections = {name.strip().lower(): name for name in parser.sections()}
-    base = _section(sections["global"]) if "global" in sections else {}
-    resolved = {}
-    for command in _PIP_COMMANDS:
-        effective = dict(base)
-        if command in sections:
-            effective.update(_section(sections[command]))
-        resolved[command] = effective
-    return resolved
+        return sections
+    for raw_name in parser.sections():
+        name = raw_name.strip().lower()
+        if name not in sections:
+            continue
+        for option, value in parser.items(raw_name):
+            key = option.strip().lower().replace("_", "-")
+            if key in _PIP_CONFIG_KEYS:
+                sections[name][key] = value
+    return sections
 
 
 def _combine_pip_commands(
@@ -5058,6 +5068,18 @@ def _combine_pip_commands(
     return combined
 
 
+def _combine_pip_sections(
+    pooled: "dict[str, dict[str, tuple[str, str]]]",
+) -> "dict[str, tuple[str, str]]":
+    """pip's own resolution: `[global]` first, then the command's own section."""
+    return _combine_pip_commands(
+        {
+            command: dict(pooled.get("global", {}), **pooled.get(command, {}))
+            for command in _PIP_COMMANDS
+        }
+    )
+
+
 def _hardened_settings_in_ini(text: str) -> "dict[str, str]":
     """Hardened settings from a single pip.conf, resolved per subcommand then combined.
 
@@ -5065,11 +5087,11 @@ def _hardened_settings_in_ini(text: str) -> "dict[str, str]":
     files too: a later pip.conf setting `require-hashes = false` has to be able to cancel
     an earlier one, and a caller that only ever saw the enabled keys could not do that.
     """
-    tagged = {
-        command: {key: ("", value) for key, value in values.items()}
-        for command, values in _hardened_settings_by_command(text).items()
+    pooled = {
+        name: {key: ("", value) for key, value in values.items()}
+        for name, values in _hardened_pip_sections(text).items()
     }
-    return {key: value for key, (_source, value) in _combine_pip_commands(tagged).items()}
+    return {key: value for key, (_source, value) in _combine_pip_sections(pooled).items()}
 
 
 def _hardened_keys_in_ini(text: str) -> "list[str]":
@@ -5190,29 +5212,31 @@ def _policy_scan() -> "tuple[tuple[tuple[str, str, str], ...], dict[str, frozens
                 globals_[option] = value
             elif section in per_command:
                 per_command[section][option] = value
-        tagged = {
-            command: {
+        pooled = {
+            name: {
                 option: ("pip.conf", value)
-                for option, value in dict(globals_, **per_command[command]).items()
+                for option, value in (globals_ if name == "global" else per_command[name]).items()
             }
-            for command in _PIP_COMMANDS
+            for name in _PIP_SECTIONS
         }
-        pip_settings.update(_combine_pip_commands(tagged))
+        pip_settings.update(_combine_pip_sections(pooled))
     else:
         # No usable pip, so read pip's files directly rather than report an ordinary
-        # machine. They come back in pip's own load order, so a later file wins -- per
-        # subcommand, which is why each one is carried across the files and only combined
-        # at the end. Collapsing a file before reading the next let a `[wheel]` setting in
-        # a low-priority file erase an `[install]` one pip still applies.
-        by_command: "dict[str, dict[str, tuple[str, str]]]" = {name: {} for name in _PIP_COMMANDS}
+        # machine. They come back in pip's own load order, so a later file wins -- within
+        # a section, which is why every file's sections are pooled and only resolved
+        # against each other at the end. Collapsing a file before reading the next let a
+        # low-priority setting erase a higher-priority one pip still applies.
+        pooled: "dict[str, dict[str, tuple[str, str]]]" = {
+            name: {} for name in _PIP_SECTIONS
+        }
         for path in _hardened_pip_config_paths():
             text = _read_text(path)
             if text is None:
                 continue
             source = os.path.basename(path)
-            for command, values in _hardened_settings_by_command(text).items():
-                by_command[command].update({key: (source, value) for key, value in values.items()})
-        pip_settings.update(_combine_pip_commands(by_command))
+            for name, values in _hardened_pip_sections(text).items():
+                pooled[name].update({key: (source, value) for key, value in values.items()})
+        pip_settings.update(_combine_pip_sections(pooled))
     for key, (source, value) in pip_settings.items():
         if _canonical_policy_key(key) not in cancelled["pip"]:
             _record("pip", source, key, value)
@@ -5360,9 +5384,9 @@ def _announce_pm_policy() -> None:
     _note(
         f"Package manager hardening detected ({listed}). Unsloth relaxes it for its own "
         "dependency installs only -- the shipped requirements are unhashed and a few have "
-        "no wheel at any version -- and never for your other pip commands. A uv setting "
-        "still applies to the few steps that do not pin an index, since uv has no "
-        "per-command override for one. Set "
+        "no wheel at any version -- and never for your other pip commands. On the steps "
+        "that pin an index it is set aside in full; on the few that do not, only pip's "
+        "require-hashes is, so an upload cutoff or a uv setting still applies there. Set "
         f"{_POLICY_OPT_OUT_ENV}=1 to keep your policy in force everywhere instead.",
         _cyan,
     )
@@ -5806,17 +5830,23 @@ def pip_install(
                 if VERBOSE and result.stdout:
                     _safe_print(_redact_install_output(result.stdout))
                 return
-            if _respect_pm_policy():
-                # pip reads none of uv's policy, so under the opt-out the fallback would
-                # retry the very install uv refused, and succeed. Stop instead, on the
-                # same terms as any other fatal step.
+            fallback_cmd = _build_pip_cmd(args) + constraint_args_pip + req_args_pip
+            discarded = _unenforceable_policy(fallback_cmd)
+            if discarded:
+                # Only when falling back would actually DROP a control: pip reads none of
+                # uv's policy, so retrying there would install exactly what uv refused.
+                # Gating on the opt-out flag alone was wrong -- an operator who sets it
+                # pre-emptively on a host with no uv-only policy would have had every
+                # ordinary uv failure, a resolver hiccup included, turned into a fatal
+                # one with no fallback.
                 if result.stdout:
                     _safe_print(_redact_install_output(result.stdout))
                 _safe_print(
                     _red(
                         f"   uv failed and {_POLICY_OPT_OUT_ENV} is set, so the pip "
-                        "fallback is not used: pip does not read uv's policy and would "
-                        "install what uv refused. Unset it to allow the fallback."
+                        "fallback is not used: pip does not read "
+                        f"{', '.join(discarded)} and would install what uv refused. "
+                        "Unset it to allow the fallback."
                     )
                 )
                 sys.exit(result.returncode)

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -4744,7 +4744,12 @@ function Fast-Install {
             # dropping it while leaving pip.conf readable reimposed a restriction they
             # had lifted. PIP_FIND_LINKS genuinely IS additive, so it survives only while
             # no-index is in force and it is the sole remaining source.
-            $keep = @('UV_CONFIG_FILE', 'UV_NO_CONFIG', 'PIP_CONFIG_FILE', 'PIP_NO_INDEX')
+            # UV_FIND_LINKS is kept unconditionally where PIP_FIND_LINKS is conditional:
+            # pip can be asked for its resolved configuration, uv cannot, and uv's
+            # `--no-index` has no environment spelling, so a uv.toml that makes the
+            # wheelhouse the only permitted source is undetectable here.
+            $keep = @('UV_CONFIG_FILE', 'UV_NO_CONFIG', 'PIP_CONFIG_FILE', 'PIP_NO_INDEX',
+                      'UV_FIND_LINKS')
             if (Test-PipNoIndexOn -Command 'install') { $keep += @('PIP_FIND_LINKS') }
             $scrub = @($scrub | Where-Object { $keep -notcontains $_ })
         }

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -4683,8 +4683,15 @@ function Test-PipNoIndexOn {
     if ($null -eq $script:PipNoIndexSections) {
         $found = @{}
         try {
-            $listed = & python -m pip config list 2>$null
-            if ($LASTEXITCODE -eq 0) {
+            # BOUNDED, like the 30s cap _pip_config_settings() puts on the same probe.
+            # A bare `& python -m pip config list` waits forever on a wedged interpreter,
+            # and a policy notice must never be able to hang an install. runpy rather
+            # than a nested `-m` so the timeout kills the process that does the work.
+            $probe = Invoke-BoundedPythonProbe -PythonExe "python" -TimeoutSec 30 -Code (
+                "import runpy,sys; sys.argv=['pip','config','list']; " +
+                "runpy.run_module('pip',run_name='__main__')")
+            $listed = if ($probe.Ok) { $probe.Output -split "`r?`n" } else { @() }
+            if ($probe.Ok) {
                 foreach ($line in @($listed)) {
                     # Section verbatim, option normalised: the split pip itself makes.
                     # `:env:` entries restate the environment, read by the branch above.

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -4659,12 +4659,45 @@ function Test-RespectPmPolicy {
     return @('', '0', 'false', 'no') -notcontains $value.Trim().ToLowerInvariant()
 }
 
-# PIP_NO_INDEX read the way pip reads it, for the one variable the opt-out keeps.
-# Same false set as pip's strtobool, which is what _config_value_is_on() uses.
+# Is pip's no-index effectively ON, counting pip.conf as well as the environment?
+# `--no-index` means "ignore the indexes and look only at find-links", so this decides
+# whether PIP_FIND_LINKS is the sole remaining source or merely an extra one. Reading
+# only the environment got it wrong for an operator whose `no-index = true` sits in
+# pip.conf, which the opt-out keeps readable: find-links was dropped as additive and the
+# fallback was left with no sources at all. Mirrors _pip_no_index_in_force().
+#
+# The environment decides when it speaks, in either direction, because pip reads it
+# ahead of its files. Otherwise ask pip, once per run. A probe that fails reads as off,
+# which cannot cost anything: it only fails when there is no pip, and PIP_FIND_LINKS is
+# inert without pip, since uv reads UV_FIND_LINKS instead.
+$script:PipNoIndexInForce = $null
 function Test-PipNoIndexOn {
     $value = [Environment]::GetEnvironmentVariable('PIP_NO_INDEX')
-    if ($null -eq $value) { return $false }
-    return @('', 'n', 'no', 'f', 'false', 'off', '0') -notcontains $value.Trim().ToLowerInvariant()
+    if ($null -ne $value -and $value.Trim() -ne '') {
+        # Same false set as pip's strtobool, which is what _config_value_is_on() uses.
+        return @('n', 'no', 'f', 'false', 'off', '0') -notcontains $value.Trim().ToLowerInvariant()
+    }
+    if ($null -ne $script:PipNoIndexInForce) { return $script:PipNoIndexInForce }
+    $script:PipNoIndexInForce = $false
+    try {
+        $listed = & python -m pip config list 2>$null
+        if ($LASTEXITCODE -eq 0) {
+            foreach ($line in @($listed)) {
+                # Section verbatim, option normalised: the split pip itself makes. `:env:`
+                # entries restate the environment, which the branch above already read.
+                if (-not "$line".Contains('=')) { continue }
+                $name = ("$line" -split '=', 2)[0].Trim()
+                $raw = ("$line" -split '=', 2)[1].Trim().Trim("'", '"').ToLowerInvariant()
+                if ($name.StartsWith(':env:')) { continue }
+                $option = ($name -split '\.')[-1].ToLowerInvariant().Replace('_', '-')
+                $section = $name.Substring(0, [Math]::Max(0, $name.Length - $option.Length)).TrimEnd('.')
+                if ($option -ne 'no-index') { continue }
+                if (@('global', 'install', 'download', 'wheel') -notcontains $section) { continue }
+                $script:PipNoIndexInForce = @('n', 'no', 'f', 'false', 'off', '0', '') -notcontains $raw
+            }
+        }
+    } catch { $script:PipNoIndexInForce = $false }
+    return $script:PipNoIndexInForce
 }
 
 # Helper: install a package, preferring uv with pip fallback

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -4670,34 +4670,49 @@ function Test-RespectPmPolicy {
 # ahead of its files. Otherwise ask pip, once per run. A probe that fails reads as off,
 # which cannot cost anything: it only fails when there is no pip, and PIP_FIND_LINKS is
 # inert without pip, since uv reads UV_FIND_LINKS instead.
-$script:PipNoIndexInForce = $null
+# Cached only once the probe has actually reached pip: a venv with no pip yet must not
+# memoise "nothing configured" for the rest of the run. Mirrors _pip_config_settings().
+$script:PipNoIndexSections = $null
 function Test-PipNoIndexOn {
+    param([string] $Command = 'install')
     $value = [Environment]::GetEnvironmentVariable('PIP_NO_INDEX')
     if ($null -ne $value -and $value.Trim() -ne '') {
         # Same false set as pip's strtobool, which is what _config_value_is_on() uses.
         return @('n', 'no', 'f', 'false', 'off', '0') -notcontains $value.Trim().ToLowerInvariant()
     }
-    if ($null -ne $script:PipNoIndexInForce) { return $script:PipNoIndexInForce }
-    $script:PipNoIndexInForce = $false
-    try {
-        $listed = & python -m pip config list 2>$null
-        if ($LASTEXITCODE -eq 0) {
-            foreach ($line in @($listed)) {
-                # Section verbatim, option normalised: the split pip itself makes. `:env:`
-                # entries restate the environment, which the branch above already read.
-                if (-not "$line".Contains('=')) { continue }
-                $name = ("$line" -split '=', 2)[0].Trim()
-                $raw = ("$line" -split '=', 2)[1].Trim().Trim("'", '"').ToLowerInvariant()
-                if ($name.StartsWith(':env:')) { continue }
-                $option = ($name -split '\.')[-1].ToLowerInvariant().Replace('_', '-')
-                $section = $name.Substring(0, [Math]::Max(0, $name.Length - $option.Length)).TrimEnd('.')
-                if ($option -ne 'no-index') { continue }
-                if (@('global', 'install', 'download', 'wheel') -notcontains $section) { continue }
-                $script:PipNoIndexInForce = @('n', 'no', 'f', 'false', 'off', '0', '') -notcontains $raw
+    if ($null -eq $script:PipNoIndexSections) {
+        $found = @{}
+        try {
+            $listed = & python -m pip config list 2>$null
+            if ($LASTEXITCODE -eq 0) {
+                foreach ($line in @($listed)) {
+                    # Section verbatim, option normalised: the split pip itself makes.
+                    # `:env:` entries restate the environment, read by the branch above.
+                    if (-not "$line".Contains('=')) { continue }
+                    $name = ("$line" -split '=', 2)[0].Trim()
+                    $raw = ("$line" -split '=', 2)[1].Trim().Trim("'", '"').ToLowerInvariant()
+                    if ($name.StartsWith(':env:')) { continue }
+                    $option = ($name -split '\.')[-1].ToLowerInvariant().Replace('_', '-')
+                    $section = $name.Substring(0, [Math]::Max(0, $name.Length - $option.Length)).TrimEnd('.')
+                    if ($option -ne 'no-index') { continue }
+                    if (@('global', 'install', 'download', 'wheel') -notcontains $section) { continue }
+                    # Printed in load order, so the last definition of an entry wins.
+                    $found[$section] = @('n', 'no', 'f', 'false', 'off', '0', '') -notcontains $raw
+                }
+                $script:PipNoIndexSections = $found
             }
-        }
-    } catch { $script:PipNoIndexInForce = $false }
-    return $script:PipNoIndexInForce
+        } catch { }
+    }
+    if ($null -eq $script:PipNoIndexSections) { return $false }
+    # A command-prefixed key affects only the command it names, so the command's own
+    # section beats [global] and the others do not apply at all.
+    if ($script:PipNoIndexSections.ContainsKey($Command)) {
+        return [bool] $script:PipNoIndexSections[$Command]
+    }
+    if ($script:PipNoIndexSections.ContainsKey('global')) {
+        return [bool] $script:PipNoIndexSections['global']
+    }
+    return $false
 }
 
 # Helper: install a package, preferring uv with pip fallback
@@ -4730,7 +4745,7 @@ function Fast-Install {
             # had lifted. PIP_FIND_LINKS genuinely IS additive, so it survives only while
             # no-index is in force and it is the sole remaining source.
             $keep = @('UV_CONFIG_FILE', 'UV_NO_CONFIG', 'PIP_CONFIG_FILE', 'PIP_NO_INDEX')
-            if (Test-PipNoIndexOn) { $keep += @('PIP_FIND_LINKS') }
+            if (Test-PipNoIndexOn -Command 'install') { $keep += @('PIP_FIND_LINKS') }
             $scrub = @($scrub | Where-Object { $keep -notcontains $_ })
         }
         foreach ($n in $scrub) {
@@ -4790,7 +4805,7 @@ function Fast-Download {
         # Same split as Fast-Install: the policy variable is kept either way, the
         # additive one only while no-index makes it the sole source.
         $keep = @('PIP_CONFIG_FILE', 'PIP_NO_INDEX')
-        if (Test-PipNoIndexOn) { $keep += @('PIP_FIND_LINKS') }
+        if (Test-PipNoIndexOn -Command 'download') { $keep += @('PIP_FIND_LINKS') }
         $scrub = @($scrub | Where-Object { $keep -notcontains $_ })
     }
     foreach ($n in $scrub) {

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -4690,11 +4690,14 @@ function Fast-Install {
                    'PIP_NO_INDEX', 'PIP_INDEX_URL',
                    'UV_CONFIG_FILE', 'UV_NO_CONFIG', 'PIP_CONFIG_FILE')
         if ($respectPolicy) {
-            # PIP_NO_INDEX only ever REMOVES sources, so it and the PIP_FIND_LINKS it
-            # leaves as the sole source are kept: dropping them would send a pinned
-            # command to the network on a host that had said not to.
-            $keep = @('UV_CONFIG_FILE', 'UV_NO_CONFIG', 'PIP_CONFIG_FILE')
-            if (Test-PipNoIndexOn) { $keep += @('PIP_NO_INDEX', 'PIP_FIND_LINKS') }
+            # PIP_NO_INDEX is a POLICY variable and is kept whichever way it points. pip
+            # reads the environment ahead of pip.conf, so PIP_NO_INDEX=0 is how an
+            # operator lifts a `no-index = true` in their own config for one run;
+            # dropping it while leaving pip.conf readable reimposed a restriction they
+            # had lifted. PIP_FIND_LINKS genuinely IS additive, so it survives only while
+            # no-index is in force and it is the sole remaining source.
+            $keep = @('UV_CONFIG_FILE', 'UV_NO_CONFIG', 'PIP_CONFIG_FILE', 'PIP_NO_INDEX')
+            if (Test-PipNoIndexOn) { $keep += @('PIP_FIND_LINKS') }
             $scrub = @($scrub | Where-Object { $keep -notcontains $_ })
         }
         foreach ($n in $scrub) {
@@ -4751,8 +4754,10 @@ function Fast-Download {
     $respectPolicy = Test-RespectPmPolicy
     $scrub = @('PIP_EXTRA_INDEX_URL', 'PIP_FIND_LINKS', 'PIP_NO_INDEX', 'PIP_INDEX_URL', 'PIP_CONFIG_FILE')
     if ($respectPolicy) {
-        $keep = @('PIP_CONFIG_FILE')
-        if (Test-PipNoIndexOn) { $keep += @('PIP_NO_INDEX', 'PIP_FIND_LINKS') }
+        # Same split as Fast-Install: the policy variable is kept either way, the
+        # additive one only while no-index makes it the sole source.
+        $keep = @('PIP_CONFIG_FILE', 'PIP_NO_INDEX')
+        if (Test-PipNoIndexOn) { $keep += @('PIP_FIND_LINKS') }
         $scrub = @($scrub | Where-Object { $keep -notcontains $_ })
     }
     foreach ($n in $scrub) {
@@ -5403,7 +5408,9 @@ if ($stackExit -eq 0 -and $XpuIndexUrl) {
         # PATH, which carries no hash, so a require-hashes policy fails it -- and it runs
         # after triton-windows is already gone. Refusing before the removal keeps the venv
         # whole; the cost is torch.compile on the XPU, which the next run can still fix.
-        substep "[WARN] UNSLOTH_RESPECT_PM_POLICY is set and the XPU triton swap would have to install a wheel your hash policy cannot verify; triton-windows $_tritonWinVer left in place -- it still shadows torch XPU triton, so torch.compile will not use the XPU." "Yellow"
+        # Worded without naming a control the operator may not have set: the swap is
+        # skipped for the opt-out itself, not for a hash policy specifically.
+        substep "[WARN] UNSLOTH_RESPECT_PM_POLICY is set and the XPU triton swap would have to remove triton-windows $_tritonWinVer before installing a wheel your policy may refuse, which no rerun could repair; leaving it in place -- it still shadows torch XPU triton, so torch.compile will not use the XPU. Unset UNSLOTH_RESPECT_PM_POLICY for one run to take the swap." "Yellow"
     }
     elseif ($_tritonWinVer -and $_tritonXpuSpec -match '(?i)xpu') {
         substep "replacing triton-windows $_tritonWinVer with $_tritonXpuSpec (Intel XPU)..." "Cyan"

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -4650,6 +4650,23 @@ if (Get-Command uv -ErrorAction SilentlyContinue) {
 # the catch: this is the last statement before Fast-Install starts resolving `python`.
 Assert-VenvActivated -VenvDir $VenvDir
 
+# True when the operator asked for their pip/uv policy to be left in force. Mirrors
+# _respect_pm_policy() in install_python_stack.py, including its false set, so the same
+# variable means the same thing on both sides of the hand-off.
+function Test-RespectPmPolicy {
+    $value = [Environment]::GetEnvironmentVariable('UNSLOTH_RESPECT_PM_POLICY')
+    if ($null -eq $value) { return $false }
+    return @('', '0', 'false', 'no') -notcontains $value.Trim().ToLowerInvariant()
+}
+
+# PIP_NO_INDEX read the way pip reads it, for the one variable the opt-out keeps.
+# Same false set as pip's strtobool, which is what _config_value_is_on() uses.
+function Test-PipNoIndexOn {
+    $value = [Environment]::GetEnvironmentVariable('PIP_NO_INDEX')
+    if ($null -eq $value) { return $false }
+    return @('', 'n', 'no', 'f', 'false', 'off', '0') -notcontains $value.Trim().ToLowerInvariant()
+}
+
 # Helper: install a package, preferring uv with pip fallback
 function Fast-Install {
     param([Parameter(ValueFromRemainingArguments=$true)]$Args_)
@@ -4660,18 +4677,36 @@ function Fast-Install {
     # pin (uv 0.10); PIP_NO_INDEX / PIP_INDEX_URL would defeat the pinned --index-url in pip.
     $saved = @{}
     $pinned = @($Args_) -contains '--index-url'
+    # These installs run BEFORE install_python_stack.py is invoked, so the Python side's
+    # opt-out cannot cover them: without this gate an operator who set the variable would
+    # have their pip.conf and uv.toml bypassed for the torch install and only see the
+    # notice afterwards. Same split as _install_env_for_cmd(): the ADDITIVE index
+    # variables are still scrubbed, because the pin is itself a provenance control, but
+    # the policy-bearing config files survive.
+    $respectPolicy = Test-RespectPmPolicy
     if ($pinned) {
-        foreach ($n in 'UV_DEFAULT_INDEX', 'UV_INDEX_URL', 'UV_INDEX', 'UV_EXTRA_INDEX_URL',
-                       'UV_TORCH_BACKEND', 'UV_FIND_LINKS', 'PIP_EXTRA_INDEX_URL', 'PIP_FIND_LINKS',
-                       'PIP_NO_INDEX', 'PIP_INDEX_URL',
-                       'UV_CONFIG_FILE', 'UV_NO_CONFIG', 'PIP_CONFIG_FILE') {
+        $scrub = @('UV_DEFAULT_INDEX', 'UV_INDEX_URL', 'UV_INDEX', 'UV_EXTRA_INDEX_URL',
+                   'UV_TORCH_BACKEND', 'UV_FIND_LINKS', 'PIP_EXTRA_INDEX_URL', 'PIP_FIND_LINKS',
+                   'PIP_NO_INDEX', 'PIP_INDEX_URL',
+                   'UV_CONFIG_FILE', 'UV_NO_CONFIG', 'PIP_CONFIG_FILE')
+        if ($respectPolicy) {
+            # PIP_NO_INDEX only ever REMOVES sources, so it and the PIP_FIND_LINKS it
+            # leaves as the sole source are kept: dropping them would send a pinned
+            # command to the network on a host that had said not to.
+            $keep = @('UV_CONFIG_FILE', 'UV_NO_CONFIG', 'PIP_CONFIG_FILE')
+            if (Test-PipNoIndexOn) { $keep += @('PIP_NO_INDEX', 'PIP_FIND_LINKS') }
+            $scrub = @($scrub | Where-Object { $keep -notcontains $_ })
+        }
+        foreach ($n in $scrub) {
             $saved[$n] = [Environment]::GetEnvironmentVariable($n)
             Remove-Item "Env:$n" -ErrorAction SilentlyContinue
         }
-        $env:UV_NO_CONFIG = '1'
-        # A `pip config` global.extra-index-url still adds indexes to the pip FALLBACK;
-        # PIP_CONFIG_FILE = 'nul' (Windows devnull) loads NO config (uv ignores pip config).
-        $env:PIP_CONFIG_FILE = 'nul'
+        if (-not $respectPolicy) {
+            $env:UV_NO_CONFIG = '1'
+            # A `pip config` global.extra-index-url still adds indexes to the pip FALLBACK;
+            # PIP_CONFIG_FILE = 'nul' (Windows devnull) loads NO config (uv ignores pip config).
+            $env:PIP_CONFIG_FILE = 'nul'
+        }
     }
     try {
         if ($UseUv) {
@@ -4682,7 +4717,10 @@ function Fast-Install {
         & python -m pip install @Args_ 2>&1
     }
     finally {
-        if ($pinned) {
+        # Only clear what this function SET. Under the opt-out these two were neither
+        # saved nor overwritten, so removing them here would destroy the operator's own
+        # values for the rest of the run.
+        if ($pinned -and -not $respectPolicy) {
             Remove-Item "Env:UV_NO_CONFIG" -ErrorAction SilentlyContinue
             Remove-Item "Env:PIP_CONFIG_FILE" -ErrorAction SilentlyContinue
         }
@@ -4708,16 +4746,25 @@ function Fast-Uninstall {
 function Fast-Download {
     param([Parameter(ValueFromRemainingArguments=$true)]$Args_)
     $saved = @{}
-    foreach ($n in 'PIP_EXTRA_INDEX_URL', 'PIP_FIND_LINKS', 'PIP_NO_INDEX', 'PIP_INDEX_URL', 'PIP_CONFIG_FILE') {
+    # Gated like Fast-Install: a pip.conf the operator asked to keep in force must also
+    # bind the fetch half of a staged swap, or the wheel arrives unverified.
+    $respectPolicy = Test-RespectPmPolicy
+    $scrub = @('PIP_EXTRA_INDEX_URL', 'PIP_FIND_LINKS', 'PIP_NO_INDEX', 'PIP_INDEX_URL', 'PIP_CONFIG_FILE')
+    if ($respectPolicy) {
+        $keep = @('PIP_CONFIG_FILE')
+        if (Test-PipNoIndexOn) { $keep += @('PIP_NO_INDEX', 'PIP_FIND_LINKS') }
+        $scrub = @($scrub | Where-Object { $keep -notcontains $_ })
+    }
+    foreach ($n in $scrub) {
         $saved[$n] = [Environment]::GetEnvironmentVariable($n)
         Remove-Item "Env:$n" -ErrorAction SilentlyContinue
     }
-    $env:PIP_CONFIG_FILE = 'nul'
+    if (-not $respectPolicy) { $env:PIP_CONFIG_FILE = 'nul' }
     try {
         & python -m pip download @Args_ 2>&1
     }
     finally {
-        Remove-Item "Env:PIP_CONFIG_FILE" -ErrorAction SilentlyContinue
+        if (-not $respectPolicy) { Remove-Item "Env:PIP_CONFIG_FILE" -ErrorAction SilentlyContinue }
         foreach ($n in $saved.Keys) { if ($null -ne $saved[$n]) { Set-Item "Env:$n" $saved[$n] } }
     }
 }
@@ -5351,7 +5398,14 @@ if ($stackExit -eq 0 -and $XpuIndexUrl) {
     $_tritonXpuSpec = if ($_tritonProbe.Ok -and $_tritonProbe.Output -match '(?m)^TRITONXPU=(\S+)\s*$') { $Matches[1] } else { "" }
     # The spec must itself be an XPU triton (pytorch-triton-xpu / triton-xpu); anything else means
     # torch is not the +xpu wheel this branch assumes.
-    if ($_tritonWinVer -and $_tritonXpuSpec -match '(?i)xpu') {
+    if ($_tritonWinVer -and $_tritonXpuSpec -match '(?i)xpu' -and (Test-RespectPmPolicy)) {
+        # Same decline as _ensure_xpu_triton(). The reinstall below installs a local wheel
+        # PATH, which carries no hash, so a require-hashes policy fails it -- and it runs
+        # after triton-windows is already gone. Refusing before the removal keeps the venv
+        # whole; the cost is torch.compile on the XPU, which the next run can still fix.
+        substep "[WARN] UNSLOTH_RESPECT_PM_POLICY is set and the XPU triton swap would have to install a wheel your hash policy cannot verify; triton-windows $_tritonWinVer left in place -- it still shadows torch XPU triton, so torch.compile will not use the XPU." "Yellow"
+    }
+    elseif ($_tritonWinVer -and $_tritonXpuSpec -match '(?i)xpu') {
         substep "replacing triton-windows $_tritonWinVer with $_tritonXpuSpec (Intel XPU)..." "Cyan"
         # install_manifest.manifest_path() is venv_root()/MANIFEST_NAME and venv_root() is
         # sys.prefix, which is $VenvDir here -- the same join Get-PersistedNoTorch does. Assembled

--- a/tests/python/test_cross_platform_parity.py
+++ b/tests/python/test_cross_platform_parity.py
@@ -712,12 +712,20 @@ class TestPinnedIndexClearsUvEnvParity:
         fallback (pip honours PIP_EXTRA_INDEX_URL / PIP_FIND_LINKS in addition to
         --index-url); restoring the vars before the fallback reopens the hole."""
         text = SETUP_PS1.read_text(encoding = "utf-8")
-        fi = text[text.find("function Fast-Install") :][:2500]
+        start = text.find("function Fast-Install")
+        assert start != -1, "setup.ps1 no longer defines Fast-Install"
+        # Bounded by the next top-level function, not by a character count: a fixed
+        # window silently truncates when the body grows, and both anchors then come
+        # back -1, which compares equal and passes the assertion below vacuously.
+        end = text.find("\nfunction ", start + 1)
+        fi = text[start : end if end != -1 else len(text)]
         assert "'PIP_EXTRA_INDEX_URL'" in fi and "'PIP_FIND_LINKS'" in fi
+        fallback = fi.find("python -m pip install")
+        restore = fi.find("finally")
+        assert fallback != -1, "Fast-Install no longer has a pip fallback"
+        assert restore != -1, "Fast-Install no longer restores the scrub in a finally"
         # the pip fallback must sit INSIDE the try whose finally restores the vars
-        assert fi.find("python -m pip install") < fi.find(
-            "finally"
-        ), "pip fallback must run before the scrub is restored"
+        assert fallback < restore, "pip fallback must run before the scrub is restored"
 
     def test_windows_installers_probe_uv_before_replacing_an_incumbent(self):
         """A host can have a working older uv while AppLocker, WDAC or endpoint

--- a/tests/python/test_install_python_stack.py
+++ b/tests/python/test_install_python_stack.py
@@ -692,11 +692,20 @@ class TestTheOptOutKeepsRestrictiveIndexSettings:
         env = self._env({"UNSLOTH_RESPECT_PM_POLICY": "1", "PIP_FIND_LINKS": "/wheels"})
         assert "PIP_FIND_LINKS" not in env
 
-    def test_a_disabled_no_index_does_not_keep_anything(self):
+    def test_a_disabled_no_index_is_carried_through_but_keeps_no_find_links(self):
+        """An explicit off is the operator lifting their own pip.conf, not an absence.
+
+        pip reads the environment ahead of pip.conf, so PIP_NO_INDEX=0 is how a
+        `no-index = true` in config is lifted for one run. Dropping the variable while
+        leaving pip.conf readable put the restriction back and failed an install the
+        operator had permitted. find-links is a different case: with no-index off it
+        ADDS a location beside the pinned index, so it is still scrubbed.
+        """
         env = self._env(
             {"UNSLOTH_RESPECT_PM_POLICY": "1", "PIP_NO_INDEX": "0", "PIP_FIND_LINKS": "/w"}
         )
-        assert "PIP_NO_INDEX" not in env and "PIP_FIND_LINKS" not in env
+        assert env["PIP_NO_INDEX"] == "0"
+        assert "PIP_FIND_LINKS" not in env
 
 
 class TestHardenedPolicyIsAnnounced:
@@ -2854,3 +2863,50 @@ class TestNoneIsAListSentinelNotABoolean:
         env = ips._install_env_for_cmd(cmd)
         assert env is not None
         assert "PIP_NO_INDEX" not in env
+
+
+class TestAnExplicitNoIndexOverrideSurvivesTheOptOut:
+    """pip reads the environment ahead of pip.conf, so PIP_NO_INDEX=0 lifts a config
+    `no-index = true` for one run. Measured on pip 26.2.1 against a clean venv: with
+    pip.conf `no-index = true` the install fails with "No matching distribution found",
+    and the same command with PIP_NO_INDEX=0 resolves. Dropping the variable while
+    leaving pip.conf readable reimposed a restriction the operator had lifted.
+    """
+
+    PINNED = ["uv", "pip", "install", "--index-url", "https://pinned", "torch"]
+
+    def test_an_explicit_off_is_carried_through(self, monkeypatch):
+        monkeypatch.setenv("UNSLOTH_RESPECT_PM_POLICY", "1")
+        monkeypatch.setenv("PIP_NO_INDEX", "0")
+        env = ips._install_env_for_cmd(list(self.PINNED))
+        assert env is not None
+        assert env.get("PIP_NO_INDEX") == "0"
+
+    def test_an_explicit_on_is_carried_through_with_its_find_links(self, monkeypatch):
+        monkeypatch.setenv("UNSLOTH_RESPECT_PM_POLICY", "1")
+        monkeypatch.setenv("PIP_NO_INDEX", "1")
+        monkeypatch.setenv("PIP_FIND_LINKS", "/op/wheels")
+        env = ips._install_env_for_cmd(list(self.PINNED))
+        assert env is not None
+        assert env.get("PIP_NO_INDEX") == "1"
+        assert env.get("PIP_FIND_LINKS") == "/op/wheels"
+
+    def test_find_links_is_still_additive_when_no_index_is_off(self, monkeypatch):
+        # With no-index off, find-links adds a location alongside the pinned index,
+        # which is the whole reason the pinned branch scrubs the mirror variables.
+        monkeypatch.setenv("UNSLOTH_RESPECT_PM_POLICY", "1")
+        monkeypatch.setenv("PIP_NO_INDEX", "0")
+        monkeypatch.setenv("PIP_FIND_LINKS", "/op/wheels")
+        env = ips._install_env_for_cmd(list(self.PINNED))
+        assert env is not None
+        assert "PIP_FIND_LINKS" not in env
+
+    def test_the_default_path_scrubs_both_regardless(self, monkeypatch):
+        monkeypatch.delenv("UNSLOTH_RESPECT_PM_POLICY", raising = False)
+        for value in ("0", "1"):
+            monkeypatch.setenv("PIP_NO_INDEX", value)
+            monkeypatch.setenv("PIP_FIND_LINKS", "/op/wheels")
+            env = ips._install_env_for_cmd(list(self.PINNED))
+            assert env is not None
+            assert "PIP_NO_INDEX" not in env, value
+            assert "PIP_FIND_LINKS" not in env, value

--- a/tests/python/test_install_python_stack.py
+++ b/tests/python/test_install_python_stack.py
@@ -674,6 +674,51 @@ class TestTheMetadataRepairCannotStrandThePackage:
         assert cleanup == "" and args[-1] == "unsloth-zoo"
 
 
+class TestTheOptOutKeepsRestrictiveIndexSettings:
+    """The pinned branch scrubs the index variables so a stale mirror cannot answer a
+    torch repair (#6898), and that survives the opt-out on purpose. PIP_NO_INDEX is the
+    exception: it only ever REMOVES sources, so scrubbing it let a pinned command reach
+    the network on a host that had said not to.
+    """
+
+    CMD = ["uv", "pip", "install", "torch", "--index-url", "https://x/cu128"]
+
+    def _env(self, extra):
+        with mock.patch.dict(os.environ, dict(extra, PATH = "/usr/bin"), clear = True):
+            return ips._install_env_for_cmd(list(self.CMD))
+
+    def test_the_default_path_still_scrubs_everything(self):
+        env = self._env({"PIP_NO_INDEX": "1", "PIP_FIND_LINKS": "/wheels"})
+        assert "PIP_NO_INDEX" not in env and "PIP_FIND_LINKS" not in env
+
+    def test_the_opt_out_keeps_no_index_and_its_find_links(self):
+        """Kept as a pair: PIP_FIND_LINKS is the only source left once PIP_NO_INDEX is
+        honoured, so dropping it would leave the step with nowhere to resolve from."""
+        env = self._env(
+            {
+                "UNSLOTH_RESPECT_PM_POLICY": "1",
+                "PIP_NO_INDEX": "1",
+                "PIP_FIND_LINKS": "/wheels",
+                "PIP_INDEX_URL": "https://mirror/simple",
+            }
+        )
+        assert env["PIP_NO_INDEX"] == "1"
+        assert env["PIP_FIND_LINKS"] == "/wheels"
+        # The ADDITIVE mirror is still scrubbed: that is the provenance control.
+        assert "PIP_INDEX_URL" not in env
+
+    def test_find_links_alone_is_still_scrubbed_under_the_opt_out(self):
+        """Without PIP_NO_INDEX it merely ADDS a source, which is what the scrub is for."""
+        env = self._env({"UNSLOTH_RESPECT_PM_POLICY": "1", "PIP_FIND_LINKS": "/wheels"})
+        assert "PIP_FIND_LINKS" not in env
+
+    def test_a_disabled_no_index_does_not_keep_anything(self):
+        env = self._env(
+            {"UNSLOTH_RESPECT_PM_POLICY": "1", "PIP_NO_INDEX": "0", "PIP_FIND_LINKS": "/w"}
+        )
+        assert "PIP_NO_INDEX" not in env and "PIP_FIND_LINKS" not in env
+
+
 class TestHardenedPolicyIsAnnounced:
     """The relaxation is defensible; doing it silently is not.
 
@@ -716,6 +761,18 @@ class TestHardenedPolicyIsAnnounced:
     def test_env_restatements_from_pip_config_are_not_double_counted(self):
         names = self._names({"PIP_REQUIRE_HASHES": "1"}, ":env:.require-hashes='true'\n")
         assert names == ("PIP_REQUIRE_HASHES",)
+
+    def test_false_disables_the_upload_cutoff(self):
+        """The cutoff is a date, but uv takes `false` for it as "no cutoff": measured on
+        the pinned uv 0.12.1, UV_EXCLUDE_NEWER=false installs the current release while
+        a date filters it. Reading `false` as a cutoff put a security notice in front of
+        an operator who had switched the control off."""
+        assert self._names({"UV_EXCLUDE_NEWER": "false"}) == ()
+        assert self._names({"UV_EXCLUDE_NEWER": "2005-01-01T00:00:00Z"}) == (
+            "UV_EXCLUDE_NEWER",
+        )
+        # Still not a boolean elsewhere: a package list keeps package names.
+        assert self._names({"PIP_ONLY_BINARY": "false"}) == ("PIP_ONLY_BINARY",)
 
     def test_uv_policy_is_reported_from_the_variables_uv_reads(self):
         """uv has no command that prints its resolved configuration, so the notice

--- a/tests/python/test_install_python_stack.py
+++ b/tests/python/test_install_python_stack.py
@@ -596,7 +596,11 @@ class TestHardenedPolicyIsAnnounced:
     it found and the variable that keeps them.
     """
 
-    def _names(self, env: dict, pip_config: str = ""):
+    def _names(
+        self,
+        env: dict,
+        pip_config: str = "",
+    ):
         ips._detected_policy.cache_clear()
         result = mock.Mock(returncode = 0, stdout = pip_config.encode())
         with (
@@ -749,7 +753,13 @@ class TestTheOptOutIsNotDefeatedByOurOwnEscapeHatches:
 class TestConfigDetectionReadsValuesNotJustKeys:
     """The notice is only worth printing if it is accurate in both directions."""
 
-    def _names(self, environment, pip_ok = False, pip_config = "", uv_files = ()):
+    def _names(
+        self,
+        environment,
+        pip_ok = False,
+        pip_config = "",
+        uv_files = (),
+    ):
         ips._detected_policy.cache_clear()
         runner = (
             mock.Mock(return_value = mock.Mock(returncode = 0, stdout = pip_config.encode()))
@@ -824,8 +834,9 @@ class TestConfigDetectionReadsValuesNotJustKeys:
         notice runs `python -m pip config list` fails -- while the pip FALLBACK later in
         the same install reads pip.conf perfectly well."""
         config = tmp_path / "pip.conf"
-        config.write_text("[global]\nrequire-hashes = true\nindex-url = https://m/s\n",
-                          encoding = "utf-8")
+        config.write_text(
+            "[global]\nrequire-hashes = true\nindex-url = https://m/s\n", encoding = "utf-8"
+        )
         ips._detected_policy.cache_clear()
         with (
             mock.patch.dict(os.environ, {}, clear = True),
@@ -846,9 +857,11 @@ class TestConfigDetectionReadsValuesNotJustKeys:
         with (
             mock.patch.dict(os.environ, {}, clear = True),
             mock.patch.object(
-                ips.subprocess, "run",
-                mock.Mock(return_value = mock.Mock(
-                    returncode = 0, stdout = b"global.require-hashes='true'\n")),
+                ips.subprocess,
+                "run",
+                mock.Mock(
+                    return_value = mock.Mock(returncode = 0, stdout = b"global.require-hashes='true'\n")
+                ),
             ),
             mock.patch.object(ips, "_hardened_uv_config_paths", lambda: []),
             mock.patch.object(ips, "_hardened_pip_config_paths", lambda: [str(config)]),
@@ -889,9 +902,7 @@ class TestConfigDetectionReadsValuesNotJustKeys:
             macos = [path.replace(os.sep, "/") for path in ips._hardened_pip_config_paths()]
         assert "/home/u/Library/Application Support/pip/pip.conf" in macos
         with (
-            mock.patch.dict(
-                os.environ, {"APPDATA": "C:\\a", "PROGRAMDATA": "C:\\pd"}, clear = True
-            ),
+            mock.patch.dict(os.environ, {"APPDATA": "C:\\a", "PROGRAMDATA": "C:\\pd"}, clear = True),
             mock.patch.object(ips, "IS_WINDOWS", True),
             mock.patch.object(os.path, "isfile", lambda path: True),
         ):
@@ -912,9 +923,7 @@ class TestConfigDetectionReadsValuesNotJustKeys:
         # And the other order still reports it, so the resolution is precedence, not
         # "an off value anywhere wins".
         listing = "global.require-hashes='false'\nglobal.require-hashes='true'\n"
-        assert self._names({}, pip_ok = True, pip_config = listing) == (
-            "pip.conf require-hashes",
-        )
+        assert self._names({}, pip_ok = True, pip_config = listing) == ("pip.conf require-hashes",)
 
     def test_file_precedence_is_resolved_when_pip_is_missing(self, tmp_path):
         """The same resolution in the branch this feature exists for: no pip at all."""
@@ -928,9 +937,7 @@ class TestConfigDetectionReadsValuesNotJustKeys:
             mock.patch.object(ips.subprocess, "run", mock.Mock(side_effect = OSError)),
             mock.patch.object(ips, "_hardened_uv_config_paths", lambda: []),
             # Returned in pip's load order, so the site file is last and wins.
-            mock.patch.object(
-                ips, "_hardened_pip_config_paths", lambda: [str(user), str(site)]
-            ),
+            mock.patch.object(ips, "_hardened_pip_config_paths", lambda: [str(user), str(site)]),
         ):
             names = ips._hardened_pm_policy_names()
         ips._detected_policy.cache_clear()
@@ -1029,8 +1036,11 @@ class TestNeitherManagerIsLetOffTheOthersPolicy:
         opt-out discarded the operator's policy file."""
         with mock.patch.dict(
             os.environ,
-            {"UNSLOTH_RESPECT_PM_POLICY": "1", "UV_CONFIG_FILE": "/etc/uv/uv.toml",
-             "UV_INDEX_URL": "https://mirror.corp/simple"},
+            {
+                "UNSLOTH_RESPECT_PM_POLICY": "1",
+                "UV_CONFIG_FILE": "/etc/uv/uv.toml",
+                "UV_INDEX_URL": "https://mirror.corp/simple",
+            },
             clear = True,
         ):
             env = ips._install_env_for_cmd(
@@ -1068,8 +1078,9 @@ class TestTheLegacyTomlFallbackTracksTables:
         body = "no-build = true\n[pip]\nrequire-hashes = true\n"
         assert self._keys(body, ((), ("pip",))) == ["no-build", "require-hashes"]
 
-    @pytest.mark.parametrize("value, on", [("[]", False), ("[ ]", False),
-                                           ("{}", False), ('["torch"]', True)])
+    @pytest.mark.parametrize(
+        "value, on", [("[]", False), ("[ ]", False), ("{}", False), ('["torch"]', True)]
+    )
     def test_empty_collections_are_off(self, value, on):
         keys = self._keys(f"no-build-package = {value}\n", ((),))
         assert bool(keys) is on
@@ -1134,9 +1145,7 @@ class TestPipGlobalConfigFollowsXdg:
             paths = [path.replace(os.sep, "/") for path in ips._hardened_pip_config_paths()]
         assert "/Library/Application Support/pip/pip.conf" in paths
         with (
-            mock.patch.dict(
-                os.environ, {"HOME": "/home/u", "XDG_DATA_DIRS": "/d"}, clear = True
-            ),
+            mock.patch.dict(os.environ, {"HOME": "/home/u", "XDG_DATA_DIRS": "/d"}, clear = True),
             _posix_home(),
             mock.patch.object(ips, "IS_WINDOWS", False),
             mock.patch.object(ips, "IS_MACOS", True),
@@ -1199,19 +1208,20 @@ class TestPolicyEnvIsPlatformAndHardwareInvariant:
                     answers.add(
                         None
                         if result is None
-                        else repr(sorted(
-                            (k, v) for k, v in result.items()
-                            if k.startswith(("PIP_", "UV_"))
-                        ))
+                        else repr(
+                            sorted(
+                                (k, v) for k, v in result.items() if k.startswith(("PIP_", "UV_"))
+                            )
+                        )
                     )
                     if result is not None:
                         for name, value in markers.items():
-                            assert result[name] == value, (
-                                f"{accelerator} marker {name} was dropped on {platform}"
-                            )
-            assert len(answers) == 1, (
-                f"{command} produced different environments across platforms: {answers}"
-            )
+                            assert (
+                                result[name] == value
+                            ), f"{accelerator} marker {name} was dropped on {platform}"
+            assert (
+                len(answers) == 1
+            ), f"{command} produced different environments across platforms: {answers}"
 
 
 class TestTheNoticeCannotTakeAnInstallDown:
@@ -1232,7 +1242,8 @@ class TestTheNoticeCannotTakeAnInstallDown:
         with (
             mock.patch.dict(os.environ, {"PIP_REQUIRE_HASHES": "1"}, clear = True),
             mock.patch.object(
-                ips.subprocess, "run",
+                ips.subprocess,
+                "run",
                 mock.Mock(side_effect = ips.subprocess.TimeoutExpired("pip", 30)),
             ),
             mock.patch.object(ips, "_hardened_uv_config_paths", lambda: []),
@@ -1277,9 +1288,7 @@ class TestTheNoticeCannotTakeAnInstallDown:
         assert "/home/u/.config/uv/uv.toml" in posix
         assert "/etc/uv/uv.toml" in posix
         with (
-            mock.patch.dict(
-                os.environ, {"APPDATA": "C:\\a", "PROGRAMDATA": "C:\\pd"}, clear = True
-            ),
+            mock.patch.dict(os.environ, {"APPDATA": "C:\\a", "PROGRAMDATA": "C:\\pd"}, clear = True),
             mock.patch.object(ips, "IS_WINDOWS", True),
             mock.patch.object(os.path, "isfile", lambda path: True),
         ):

--- a/tests/python/test_install_python_stack.py
+++ b/tests/python/test_install_python_stack.py
@@ -23,6 +23,16 @@ sys.path.insert(0, str(STUDIO_DIR))
 import install_python_stack as ips
 
 
+@pytest.fixture(autouse = True)
+def _clear_policy_cache():
+    """_policy_scan is cached for the life of the process, which is right in an installer
+    and wrong across tests: without this a scan taken under one environment answers for
+    the next one."""
+    ips._policy_scan.cache_clear()
+    yield
+    ips._policy_scan.cache_clear()
+
+
 def _posix_home(path: str = "/home/u"):
     """Make os.path.expanduser deterministic regardless of the RUNNER's platform.
 
@@ -537,13 +547,18 @@ class TestOperatorCanKeepTheirPolicy:
     """
 
     HOSTILE = TestHardenedPipConfigRelaxation.HOSTILE
+    # One manager at a time: a mix of pip and uv controls now (correctly) stops the step
+    # to report the gap, which is TestNeitherManagerIsLetOffTheOthersPolicy's subject.
+    PIP_ONLY = {"PIP_REQUIRE_HASHES": "1", "PIP_ONLY_BINARY": ":all:"}
+    UV_ONLY = {"UV_REQUIRE_HASHES": "1", "UV_NO_BUILD": "1"}
 
     @pytest.mark.parametrize("value", ["1", "true", "yes"])
     def test_the_pip_fallback_keeps_hash_mode(self, value):
-        """The relaxation is withdrawn. The env is no longer None, because the uv-side
-        controls in HOSTILE are now restated for pip, but the one thing that must never
-        appear is the hash relaxation itself."""
-        with mock.patch.dict(os.environ, dict(self.HOSTILE, UNSLOTH_RESPECT_PM_POLICY = value)):
+        """The relaxation is withdrawn. Scoped to pip's own controls, because a mix of
+        pip and uv policy is now a reported gap, which is a different test's subject."""
+        with mock.patch.dict(
+            os.environ, dict(self.PIP_ONLY, UNSLOTH_RESPECT_PM_POLICY=value), clear=True
+        ):
             env = ips._install_env_for_cmd(["python", "-m", "pip", "install", "-r", "extras.txt"])
         assert env is None or env.get("PIP_REQUIRE_HASHES") != "0"
 
@@ -565,24 +580,27 @@ class TestOperatorCanKeepTheirPolicy:
         with mock.patch.dict(
             os.environ,
             dict(
-                self.HOSTILE,
+                self.UV_ONLY,
                 UNSLOTH_RESPECT_PM_POLICY = "1",
                 PIP_EXTRA_INDEX_URL = "https://mirror.corp/simple",
                 UV_INDEX_URL = "https://mirror.corp/simple",
             ),
+            clear = True,
         ):
             env = ips._install_env_for_cmd(
                 ["uv", "pip", "install", "torch", "--index-url", "https://x/cu128"]
             )
         assert env is not None
-        for name in ("PIP_REQUIRE_HASHES", "PIP_ONLY_BINARY", "UV_NO_BUILD", "UV_EXCLUDE_NEWER"):
-            assert env[name] == self.HOSTILE[name], f"{name} must survive the opt-out"
+        for name, value in self.UV_ONLY.items():
+            assert env[name] == value, f"{name} must survive the opt-out"
         assert "PIP_CONFIG_FILE" not in env, "pip.conf carries the policy; it must be read"
         for name in ("PIP_EXTRA_INDEX_URL", "UV_INDEX_URL"):
             assert name not in env, f"{name} must still be scrubbed from a pinned install"
 
     def test_the_parent_environment_is_never_mutated(self):
-        with mock.patch.dict(os.environ, dict(self.HOSTILE, UNSLOTH_RESPECT_PM_POLICY = "1")):
+        with mock.patch.dict(
+            os.environ, dict(self.PIP_ONLY, UNSLOTH_RESPECT_PM_POLICY = "1"), clear = True
+        ):
             ips._install_env_for_cmd(["python", "-m", "pip", "install", "x"])
             ips._sdist_only_build_args("openai-whisper")
             assert os.environ["UNSLOTH_RESPECT_PM_POLICY"] == "1"
@@ -602,7 +620,7 @@ class TestHardenedPolicyIsAnnounced:
         env: dict,
         pip_config: str = "",
     ):
-        ips._detected_policy.cache_clear()
+        ips._policy_scan.cache_clear()
         result = mock.Mock(returncode = 0, stdout = pip_config.encode())
         with (
             mock.patch.dict(os.environ, env, clear = True),
@@ -612,7 +630,7 @@ class TestHardenedPolicyIsAnnounced:
             try:
                 return ips._hardened_pm_policy_names()
             finally:
-                ips._detected_policy.cache_clear()
+                ips._policy_scan.cache_clear()
 
     def test_an_ordinary_machine_says_nothing(self):
         assert self._names({}) == ()
@@ -636,14 +654,14 @@ class TestHardenedPolicyIsAnnounced:
     def test_uv_config_hardening_is_reported(self, tmp_path):
         config = tmp_path / "uv.toml"
         config.write_text("# no-build = true\nno-build = true\n", encoding = "utf-8")
-        ips._detected_policy.cache_clear()
+        ips._policy_scan.cache_clear()
         with (
             mock.patch.dict(os.environ, {}, clear = True),
             mock.patch.object(ips.subprocess, "run", side_effect = OSError),
             mock.patch.object(ips, "_hardened_uv_config_paths", lambda: [str(config)]),
         ):
             names = ips._hardened_pm_policy_names()
-        ips._detected_policy.cache_clear()
+        ips._policy_scan.cache_clear()
         assert names == ("uv.toml no-build",)
 
     def test_the_notice_names_the_opt_out(self, capsys):
@@ -692,7 +710,8 @@ class TestTheOptOutIsNotDefeatedByOurOwnEscapeHatches:
         """
         with mock.patch.dict(
             os.environ,
-            dict(TestHardenedPipConfigRelaxation.HOSTILE, UNSLOTH_RESPECT_PM_POLICY = "1"),
+            {"UV_REQUIRE_HASHES": "1", "UNSLOTH_RESPECT_PM_POLICY": "1"},
+            clear = True,
         ):
             env = ips._install_env_for_cmd(
                 ["uv", "pip", "install", "torch", "--index-url", "https://x/cu128"]
@@ -761,7 +780,7 @@ class TestConfigDetectionReadsValuesNotJustKeys:
         pip_config = "",
         uv_files = (),
     ):
-        ips._detected_policy.cache_clear()
+        ips._policy_scan.cache_clear()
         runner = (
             mock.Mock(return_value = mock.Mock(returncode = 0, stdout = pip_config.encode()))
             if pip_ok
@@ -774,7 +793,7 @@ class TestConfigDetectionReadsValuesNotJustKeys:
             mock.patch.object(ips, "_hardened_pip_config_paths", lambda: []),
         ):
             names = ips._hardened_pm_policy_names()
-        ips._detected_policy.cache_clear()
+        ips._policy_scan.cache_clear()
         return names
 
     @pytest.mark.parametrize(
@@ -838,7 +857,7 @@ class TestConfigDetectionReadsValuesNotJustKeys:
         config.write_text(
             "[global]\nrequire-hashes = true\nindex-url = https://m/s\n", encoding = "utf-8"
         )
-        ips._detected_policy.cache_clear()
+        ips._policy_scan.cache_clear()
         with (
             mock.patch.dict(os.environ, {}, clear = True),
             mock.patch.object(ips.subprocess, "run", mock.Mock(side_effect = OSError)),
@@ -846,7 +865,7 @@ class TestConfigDetectionReadsValuesNotJustKeys:
             mock.patch.object(ips, "_hardened_pip_config_paths", lambda: [str(config)]),
         ):
             names = ips._hardened_pm_policy_names()
-        ips._detected_policy.cache_clear()
+        ips._policy_scan.cache_clear()
         assert names == ("pip.conf require-hashes",), "a mirror is not hardening"
 
     def test_pip_files_are_not_double_read_when_pip_answers(self, tmp_path):
@@ -854,7 +873,7 @@ class TestConfigDetectionReadsValuesNotJustKeys:
         the subprocess works its answer is the whole answer."""
         config = tmp_path / "pip.conf"
         config.write_text("[global]\nonly-binary = :all:\n", encoding = "utf-8")
-        ips._detected_policy.cache_clear()
+        ips._policy_scan.cache_clear()
         with (
             mock.patch.dict(os.environ, {}, clear = True),
             mock.patch.object(
@@ -868,7 +887,7 @@ class TestConfigDetectionReadsValuesNotJustKeys:
             mock.patch.object(ips, "_hardened_pip_config_paths", lambda: [str(config)]),
         ):
             names = ips._hardened_pm_policy_names()
-        ips._detected_policy.cache_clear()
+        ips._policy_scan.cache_clear()
         assert names == ("pip.conf require-hashes",)
 
     def test_devnull_pip_config_means_no_files_at_all(self):
@@ -932,7 +951,7 @@ class TestConfigDetectionReadsValuesNotJustKeys:
         user.write_text("[global]\nrequire-hashes = true\n", encoding = "utf-8")
         site = tmp_path / "site.conf"
         site.write_text("[global]\nrequire-hashes = false\n", encoding = "utf-8")
-        ips._detected_policy.cache_clear()
+        ips._policy_scan.cache_clear()
         with (
             mock.patch.dict(os.environ, {}, clear = True),
             mock.patch.object(ips.subprocess, "run", mock.Mock(side_effect = OSError)),
@@ -941,7 +960,7 @@ class TestConfigDetectionReadsValuesNotJustKeys:
             mock.patch.object(ips, "_hardened_pip_config_paths", lambda: [str(user), str(site)]),
         ):
             names = ips._hardened_pm_policy_names()
-        ips._detected_policy.cache_clear()
+        ips._policy_scan.cache_clear()
         assert names == ()
 
     def test_a_malformed_pip_conf_is_survivable(self, tmp_path):
@@ -951,300 +970,105 @@ class TestConfigDetectionReadsValuesNotJustKeys:
 
 
 class TestNeitherManagerIsLetOffTheOthersPolicy:
-    """pip and uv read none of each other's policy, so under the opt-out the manager that
-    actually runs has to be told the other's in its own spelling.
+    """pip and uv read none of each other's policy, so under the opt-out a step that runs
+    the manager the operator did NOT configure would proceed unrestricted.
 
     Measured on the pinned uv 0.12.1: `uv pip install` of an unhashed wheel succeeds with
     PIP_REQUIRE_HASHES=1 set AND with a pip.conf require-hashes, and is rejected only by
-    UV_REQUIRE_HASHES=1. So a pip-only policy plus the uv path was a silent bypass, and
-    the reverse holds when uv is unavailable and pip is selected.
+    UV_REQUIRE_HASHES=1. Since pip_install() prefers uv, a pip-only policy was a silent
+    bypass.
+
+    Restating each control in the other manager's spelling was tried and removed: the two
+    differ on scopes, per-subcommand sections, config discovery and which controls exist
+    at all, and every gap became a way to fail an install the real policy permitted. The
+    step now stops and names the setting to add, which cannot invent a restriction.
     """
 
-    def _detect(self, entries):
-        """Entries are (tool, source, key) or (tool, source, key, value)."""
-        full = tuple(e if len(e) == 4 else (*e, "1") for e in entries)
-        return mock.patch.object(ips, "_detected_policy", lambda: full)
+    def _detect(self, on, configured = None):
+        scan = (tuple(on), {k: frozenset(v) for k, v in (configured or {}).items()})
+        return mock.patch.object(ips, "_policy_scan", lambda: scan)
 
-    def test_pip_policy_reaches_a_uv_command(self):
-        with (
-            mock.patch.dict(os.environ, {"UNSLOTH_RESPECT_PM_POLICY": "1"}, clear = True),
-            self._detect([("pip", "env", "PIP_REQUIRE_HASHES")]),
-        ):
-            env = ips._install_env_for_cmd(["uv", "pip", "install", "-r", "extras.txt"])
-        assert env is not None and env["UV_REQUIRE_HASHES"] == "1"
-
-    def test_pip_conf_policy_reaches_a_uv_command(self):
-        """The file-sourced half matters most: uv cannot read pip.conf at all."""
-        with (
-            mock.patch.dict(os.environ, {"UNSLOTH_RESPECT_PM_POLICY": "1"}, clear = True),
-            self._detect([("pip", "pip.conf", "require-hashes")]),
-        ):
-            env = ips._install_env_for_cmd(["uv", "pip", "install", "-r", "extras.txt"])
-        assert env is not None and env["UV_REQUIRE_HASHES"] == "1"
-
-    def test_only_binary_translates_to_uv_no_build(self):
-        """pip's only-binary is "wheels only", which uv spells as no-build."""
-        with (
-            mock.patch.dict(os.environ, {"UNSLOTH_RESPECT_PM_POLICY": "1"}, clear = True),
-            self._detect([("pip", "pip.conf", "only-binary", ":all:")]),
-        ):
-            env = ips._install_env_for_cmd(["uv", "pip", "install", "x"])
-        assert env is not None and env["UV_NO_BUILD"] == "1"
-
-    def test_uv_policy_reaches_a_pip_command(self):
-        with (
-            mock.patch.dict(os.environ, {"UNSLOTH_RESPECT_PM_POLICY": "1"}, clear = True),
-            self._detect([("uv", "uv.toml", "require-hashes"), ("uv", "env", "UV_NO_BUILD")]),
-        ):
-            env = ips._install_env_for_cmd(["python", "-m", "pip", "install", "x"])
-        assert env is not None
-        assert env["PIP_REQUIRE_HASHES"] == "1"
-        assert env["PIP_ONLY_BINARY"] == ":all:"
-
-    def test_the_operators_own_spelling_always_wins(self):
-        """A translation must never overwrite a value the operator set themselves."""
-        with (
-            mock.patch.dict(
-                os.environ,
-                {"UNSLOTH_RESPECT_PM_POLICY": "1", "UV_REQUIRE_HASHES": "0"},
-                clear = True,
-            ),
-            self._detect([("pip", "env", "PIP_REQUIRE_HASHES")]),
-        ):
-            # Nothing to override, so the caller env is inherited whole and the
-            # operator's explicit UV_REQUIRE_HASHES=0 reaches uv untouched.
-            assert ips._install_env_for_cmd(["uv", "pip", "install", "x"]) is None
-
-    def test_nothing_is_translated_without_the_opt_out(self):
-        """The default path must be untouched: translating there would BREAK #8530's fix
-        by teaching uv a policy it was deliberately not being told about."""
-        with (
-            mock.patch.dict(os.environ, {"PIP_REQUIRE_HASHES": "1"}, clear = True),
-            self._detect([("pip", "env", "PIP_REQUIRE_HASHES")]),
-        ):
-            assert ips._install_env_for_cmd(["uv", "pip", "install", "x"]) is None
-
-    def test_same_tool_policy_is_not_restated(self):
-        """uv already reads its own; restating it would be noise, not enforcement."""
-        with (
-            mock.patch.dict(os.environ, {"UNSLOTH_RESPECT_PM_POLICY": "1"}, clear = True),
-            self._detect([("uv", "env", "UV_REQUIRE_HASHES")]),
-        ):
-            assert ips._install_env_for_cmd(["uv", "pip", "install", "x"]) is None
-
-    def test_an_explicit_uv_config_file_survives_a_pinned_install(self):
-        """UV_CONFIG_FILE is in the index-scrub tuple only incidentally. Measured: a file
-        named by it carrying `[pip] require-hashes = true` fails a pinned install (rc=2)
-        and the identical command without the variable succeeds, so dropping it under the
-        opt-out discarded the operator's policy file."""
-        with mock.patch.dict(
-            os.environ,
-            {
-                "UNSLOTH_RESPECT_PM_POLICY": "1",
-                "UV_CONFIG_FILE": "/etc/uv/uv.toml",
-                "UV_INDEX_URL": "https://mirror.corp/simple",
-            },
-            clear = True,
-        ):
-            env = ips._install_env_for_cmd(
-                ["uv", "pip", "install", "torch", "--index-url", "https://x/cu128"]
-            )
-        assert env is not None
-        assert env["UV_CONFIG_FILE"] == "/etc/uv/uv.toml"
-        assert "UV_INDEX_URL" not in env, "the index scrub still applies"
-
-    def test_the_default_path_still_drops_the_uv_config_file(self):
-        with mock.patch.dict(os.environ, {"UV_CONFIG_FILE": "/etc/uv/uv.toml"}, clear = True):
-            env = ips._install_env_for_cmd(
-                ["uv", "pip", "install", "torch", "--index-url", "https://x/cu128"]
-            )
-        assert env is not None and "UV_CONFIG_FILE" not in env
-
-
-class TestTheLegacyTomlFallbackTracksTables:
-    """3.9/3.10 have no tomllib, and the fallback must not be sloppier than the parser."""
-
-    def _keys(self, body, tables):
-        with mock.patch.object(ips, "_tomllib", None):
-            return ips._hardened_keys_in_toml(body, tables)
-
-    def test_an_unrelated_table_is_not_uv_policy(self):
-        body = '[project]\nname = "x"\n[tool.other]\nno-build = true\n'
-        assert self._keys(body, (("tool", "uv"), ("tool", "uv", "pip"))) == []
-        assert self._keys(body, (("tool", "other"),)) == ["no-build"]
-
-    def test_the_uv_tables_are_still_found(self):
-        body = '[project]\nname = "x"\n[tool.uv.pip]\nrequire-hashes = true\n'
-        assert self._keys(body, (("tool", "uv"), ("tool", "uv", "pip"))) == ["require-hashes"]
-
-    def test_root_and_pip_tables_of_a_uv_toml(self):
-        body = "no-build = true\n[pip]\nrequire-hashes = true\n"
-        assert self._keys(body, ((), ("pip",))) == ["no-build", "require-hashes"]
-
-    @pytest.mark.parametrize(
-        "value, on", [("[]", False), ("[ ]", False), ("{}", False), ('["torch"]', True)]
-    )
-    def test_empty_collections_are_off(self, value, on):
-        keys = self._keys(f"no-build-package = {value}\n", ((),))
-        assert bool(keys) is on
-
-    def test_the_parser_and_the_fallback_agree(self, tmp_path):
-        bodies = [
-            '[project]\nname = "x"\n[tool.other]\nno-build = true\n',
-            '[project]\nname = "x"\n[tool.uv.pip]\nrequire-hashes = true\n',
-            "no-build-package = []\n",
-            'no-build-package = ["torch"]\n',
-            "[pip]\nrequire-hashes = false\n",
-        ]
-        for body in bodies:
-            tables = (("tool", "uv"), ("tool", "uv", "pip")) if "[tool." in body else ((), ("pip",))
-            with mock.patch.object(ips, "_tomllib", None):
-                fallback = ips._hardened_keys_in_toml(body, tables)
-            parsed = ips._hardened_keys_in_toml(body, tables)
-            assert fallback == parsed, f"fallback disagrees with tomllib for {body!r}"
-
-
-class TestPipGlobalConfigFollowsXdg:
-    """pip's global config is every entry of XDG_CONFIG_DIRS, not the default alone.
-    Measured with pip 26: `XDG_CONFIG_DIRS=/a:/b pip config debug` enumerates
-    /a/pip/pip.conf and /b/pip/pip.conf."""
-
-    def test_every_configured_directory_is_searched(self):
-        with (
-            mock.patch.dict(
-                os.environ,
-                {"HOME": "/home/u", "XDG_CONFIG_DIRS": os.pathsep.join(["/a", "/b"])},
-                clear = True,
-            ),
-            _posix_home(),
-            mock.patch.object(ips, "IS_WINDOWS", False),
-            mock.patch.object(ips, "IS_MACOS", False),
-            mock.patch.object(os.path, "isfile", lambda path: True),
-        ):
-            paths = [path.replace(os.sep, "/") for path in ips._hardened_pip_config_paths()]
-        assert "/a/pip/pip.conf" in paths
-        assert "/b/pip/pip.conf" in paths
-        assert "/etc/pip.conf" in paths, "the non-XDG global is separate and still read"
-
-    def test_the_default_is_used_when_unset(self):
-        with (
-            mock.patch.dict(os.environ, {"HOME": "/home/u"}, clear = True),
-            _posix_home(),
-            mock.patch.object(ips, "IS_WINDOWS", False),
-            mock.patch.object(ips, "IS_MACOS", False),
-            mock.patch.object(os.path, "isfile", lambda path: True),
-        ):
-            paths = [path.replace(os.sep, "/") for path in ips._hardened_pip_config_paths()]
-        assert "/etc/xdg/pip/pip.conf" in paths
-
-    def test_macos_reads_its_global_set_from_xdg_data_dirs(self):
-        with (
-            mock.patch.dict(os.environ, {"HOME": "/home/u"}, clear = True),
-            _posix_home(),
-            mock.patch.object(ips, "IS_WINDOWS", False),
-            mock.patch.object(ips, "IS_MACOS", True),
-            mock.patch.object(os.path, "isfile", lambda path: True),
-        ):
-            paths = [path.replace(os.sep, "/") for path in ips._hardened_pip_config_paths()]
-        assert "/Library/Application Support/pip/pip.conf" in paths
-        with (
-            mock.patch.dict(os.environ, {"HOME": "/home/u", "XDG_DATA_DIRS": "/d"}, clear = True),
-            _posix_home(),
-            mock.patch.object(ips, "IS_WINDOWS", False),
-            mock.patch.object(ips, "IS_MACOS", True),
-            mock.patch.object(os.path, "isfile", lambda path: True),
-        ):
-            paths = [path.replace(os.sep, "/") for path in ips._hardened_pip_config_paths()]
-        assert "/d/pip/pip.conf" in paths
-
-
-class TestTranslationKeepsTheOperatorsActualPolicy:
-    """A translation that is stricter than the policy it claims to honour is its own bug.
-
-    Promoting `PIP_ONLY_BINARY=numpy` to a global `UV_NO_BUILD=1` fails the extras step on
-    wheel-less dependencies the operator's policy permits, so the opt-out would break an
-    install nobody asked it to break.
-    """
-
-    def _detect(self, entries):
-        full = tuple(e if len(e) == 4 else (*e, "1") for e in entries)
-        return mock.patch.object(ips, "_detected_policy", lambda: full)
-
-    def _env(
-        self,
-        entries,
-        cmd,
-        extra = None,
-    ):
+    def _run(self, cmd, on, configured = None, env = None):
         environment = {"UNSLOTH_RESPECT_PM_POLICY": "1"}
-        environment.update(extra or {})
-        with mock.patch.dict(os.environ, environment, clear = True), self._detect(entries):
+        environment.update(env or {})
+        with (
+            mock.patch.dict(os.environ, environment, clear = True),
+            self._detect(on, configured),
+        ):
             return ips._install_env_for_cmd(list(cmd))
 
-    def test_a_scoped_pip_policy_stays_scoped_in_uv(self):
-        env = self._env(
-            [("pip", "env", "PIP_ONLY_BINARY", "numpy,scipy")],
-            ["uv", "pip", "install", "x"],
-        )
-        assert env is not None
-        assert env["UV_NO_BUILD_PACKAGE"] == "numpy scipy"
-        assert "UV_NO_BUILD" not in env, "a policy about two packages is not a global one"
-
-    def test_an_all_pip_policy_becomes_a_global_uv_one(self):
-        env = self._env([("pip", "env", "PIP_ONLY_BINARY", ":all:")], ["uv", "pip", "install", "x"])
-        assert env is not None and env["UV_NO_BUILD"] == "1"
-        assert "UV_NO_BUILD_PACKAGE" not in env
-
-    def test_a_scoped_uv_policy_stays_scoped_in_pip(self):
-        env = self._env(
-            [("uv", "env", "UV_NO_BUILD_PACKAGE", "numpy scipy")],
-            ["python", "-m", "pip", "install", "x"],
-        )
-        assert env is not None
-        assert env["PIP_ONLY_BINARY"] == "numpy,scipy", "pip separates names with commas"
-
-    def test_a_global_uv_policy_becomes_all_in_pip(self):
-        env = self._env(
-            [("uv", "uv.toml", "no-build", "1")], ["python", "-m", "pip", "install", "x"]
-        )
-        assert env is not None and env["PIP_ONLY_BINARY"] == ":all:"
-
-    def test_a_global_setting_beats_a_scoped_one_when_both_are_present(self):
-        env = self._env(
-            [("uv", "env", "UV_NO_BUILD", "1"), ("uv", "env", "UV_NO_BUILD_PACKAGE", "numpy")],
-            ["python", "-m", "pip", "install", "x"],
-        )
-        assert env is not None and env["PIP_ONLY_BINARY"] == ":all:"
-
-    def test_the_upload_cutoff_is_translated_for_pip(self):
-        """Verified that pip reads the variable: an invalid PIP_UPLOADED_PRIOR_TO makes
-        pip 26.2.1 fail with an ISO 8601 parse error, so it is not being ignored."""
-        with mock.patch.object(ips, "_pip_supports_upload_cutoff", lambda: True):
-            env = self._env(
-                [("uv", "env", "UV_EXCLUDE_NEWER", "2024-01-01T00:00:00Z")],
-                ["python", "-m", "pip", "install", "x"],
+    def test_a_uv_step_stops_when_only_pip_is_hardened(self):
+        with pytest.raises(SystemExit) as exit_info:
+            self._run(
+                ["uv", "pip", "install", "-r", "extras.txt"],
+                [("pip", "env", "PIP_REQUIRE_HASHES")],
+                {"pip": {"require-hashes"}, "uv": set()},
             )
-        assert env is not None
-        assert env["PIP_UPLOADED_PRIOR_TO"] == "2024-01-01T00:00:00Z"
+        assert exit_info.value.code == 1
 
-    def test_an_unenforceable_cutoff_refuses_rather_than_dropping_it(self):
-        """pip grew --uploaded-prior-to in 25.3. Below that, silently continuing would
-        let the install pick an artifact the retained policy excludes; _uv_upload_cutoff_args
-        already answers the same way for the staging path."""
-        with mock.patch.object(ips, "_pip_supports_upload_cutoff", lambda: False):
-            with pytest.raises(SystemExit):
-                self._env(
-                    [("uv", "env", "UV_EXCLUDE_NEWER", "2024-01-01T00:00:00Z")],
-                    ["python", "-m", "pip", "install", "x"],
-                )
+    def test_a_pip_step_stops_when_only_uv_is_hardened(self):
+        with pytest.raises(SystemExit):
+            self._run(
+                ["python", "-m", "pip", "install", "x"],
+                [("uv", "uv.toml", "no-build")],
+                {"uv": {"no-build"}, "pip": set()},
+            )
 
-    def test_a_cutoff_does_not_touch_a_uv_command(self):
-        """uv reads UV_EXCLUDE_NEWER itself; only the pip path needs the translation."""
-        env = self._env(
-            [("uv", "env", "UV_EXCLUDE_NEWER", "2024-01-01T00:00:00Z")],
+    def test_the_message_names_the_control_and_the_setting_to_add(self, capsys):
+        with pytest.raises(SystemExit):
+            self._run(
+                ["uv", "pip", "install", "x"],
+                [("pip", "pip.conf", "require-hashes")],
+                {"pip": {"require-hashes"}, "uv": set()},
+            )
+        out = " ".join(capsys.readouterr().out.split())
+        assert "require-hashes" in out and "UV_REQUIRE_HASHES" in out
+        assert "UNSLOTH_RESPECT_PM_POLICY" in out
+
+    def test_a_deliberate_difference_is_not_a_gap(self):
+        """A uv config saying `[pip] require-hashes = false` next to PIP_REQUIRE_HASHES=1
+        is the operator configuring the two differently, not uv missing a control."""
+        assert self._run(
             ["uv", "pip", "install", "x"],
-        )
-        assert env is None
+            [("pip", "env", "PIP_REQUIRE_HASHES")],
+            {"pip": {"require-hashes"}, "uv": {"require-hashes"}},
+        ) is None
+
+    def test_the_manager_that_owns_the_policy_is_left_alone(self):
+        assert self._run(
+            ["uv", "pip", "install", "x"],
+            [("uv", "env", "UV_REQUIRE_HASHES")],
+            {"uv": {"require-hashes"}, "pip": set()},
+        ) is None
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            ["python", "patch_metadata.py"],
+            ["python", "-m", "pip", "check"],
+            ["python", "-m", "pip", "--version"],
+            ["python", "-m", "ensurepip", "--upgrade"],
+        ],
+    )
+    def test_a_command_that_resolves_nothing_is_never_refused(self, cmd):
+        """run() routes EVERY command through this helper. Treating them all as pip
+        installs turned an unenforceable policy into a hard exit on the final metadata
+        patch, after every real step had succeeded."""
+        assert self._run(
+            cmd,
+            [("uv", "env", "UV_EXCLUDE_NEWER")],
+            {"uv": {"exclude-newer"}, "pip": set()},
+        ) is None
+
+    def test_nothing_is_refused_without_the_opt_out(self):
+        with (
+            mock.patch.dict(os.environ, {}, clear = True),
+            self._detect(
+                [("pip", "env", "PIP_REQUIRE_HASHES")],
+                {"pip": {"require-hashes"}, "uv": set()},
+            ),
+        ):
+            assert ips._install_env_for_cmd(["uv", "pip", "install", "x"]) is None
 
 
 class TestDetectionMatchesPipsOwnRules:
@@ -1258,7 +1082,7 @@ class TestDetectionMatchesPipsOwnRules:
         uv_files = (),
         pip_files = (),
     ):
-        ips._detected_policy.cache_clear()
+        ips._policy_scan.cache_clear()
         runner = (
             mock.Mock(return_value = mock.Mock(returncode = 0, stdout = pip_config.encode()))
             if pip_ok
@@ -1271,7 +1095,7 @@ class TestDetectionMatchesPipsOwnRules:
             mock.patch.object(ips, "_hardened_pip_config_paths", lambda: list(pip_files)),
         ):
             names = ips._hardened_pm_policy_names()
-        ips._detected_policy.cache_clear()
+        ips._policy_scan.cache_clear()
         return names
 
     @pytest.mark.parametrize("value", ["off", "n", "f", "no", "false", "0", ""])
@@ -1378,7 +1202,20 @@ class TestPolicyEnvIsPlatformAndHardwareInvariant:
     @pytest.mark.parametrize("opt_out", ["", "1"])
     @pytest.mark.parametrize("hardened", [False, True])
     def test_identical_on_every_platform_and_accelerator(self, opt_out, hardened):
-        policy = TestHardenedPipConfigRelaxation.HOSTILE if hardened else {}
+        # One manager's controls: a cross-manager gap refuses under the opt-out, and a
+        # refusal is not an environment to compare across platforms.
+        # Both managers configured, so no cross-manager gap: a refusal is not an
+        # environment, and this sweep is about environment construction.
+        policy = (
+            {
+                "PIP_REQUIRE_HASHES": "1",
+                "UV_REQUIRE_HASHES": "1",
+                "PIP_ONLY_BINARY": ":all:",
+                "UV_NO_BUILD": "1",
+            }
+            if hardened
+            else {}
+        )
         for command in self.COMMANDS:
             answers = set()
             for platform, settings in self.PLATFORMS.items():
@@ -1422,12 +1259,12 @@ class TestTheNoticeCannotTakeAnInstallDown:
         """An unbounded probe on a half-written pip is a hang with no output at all."""
         source = Path(ips.__file__).read_text(encoding = "utf-8")
         body = source[
-            source.index("def _detected_policy") : source.index("def _hardened_pm_policy_names")
+            source.index("def _policy_scan") : source.index("def _detected_policy")
         ]
         assert "timeout = 30" in body, "the pip config probe must pass an explicit timeout"
 
     def test_a_hanging_pip_still_yields_the_environment_half(self):
-        ips._detected_policy.cache_clear()
+        ips._policy_scan.cache_clear()
         with (
             mock.patch.dict(os.environ, {"PIP_REQUIRE_HASHES": "1"}, clear = True),
             mock.patch.object(
@@ -1438,7 +1275,7 @@ class TestTheNoticeCannotTakeAnInstallDown:
             mock.patch.object(ips, "_hardened_uv_config_paths", lambda: []),
         ):
             names = ips._hardened_pm_policy_names()
-        ips._detected_policy.cache_clear()
+        ips._policy_scan.cache_clear()
         assert names == ("PIP_REQUIRE_HASHES",)
 
     def test_the_call_site_swallows_anything(self):
@@ -1506,14 +1343,14 @@ class TestTheNoticeCannotTakeAnInstallDown:
     def test_an_unreadable_or_undecodable_config_is_skipped(self, tmp_path):
         undecodable = tmp_path / "uv.toml"
         undecodable.write_bytes(b'name = "\xff\xfe"\nno-build = true\n')
-        ips._detected_policy.cache_clear()
+        ips._policy_scan.cache_clear()
         with (
             mock.patch.dict(os.environ, {}, clear = True),
             mock.patch.object(ips.subprocess, "run", mock.Mock(side_effect = OSError)),
             mock.patch.object(ips, "_hardened_uv_config_paths", lambda: [str(undecodable)]),
         ):
             names = ips._hardened_pm_policy_names()
-        ips._detected_policy.cache_clear()
+        ips._policy_scan.cache_clear()
         assert names == ("uv.toml no-build",), "lenient decoding, not a crash"
 
 

--- a/tests/python/test_install_python_stack.py
+++ b/tests/python/test_install_python_stack.py
@@ -1412,6 +1412,58 @@ class TestDetectionMatchesWhatTheManagersActuallyEnforce:
             ]
         assert paths.index("C:/u/pip/pip.ini") < paths.index("C:/a/pip/pip.ini"), paths
 
+    def test_a_package_scoped_key_does_not_erase_its_global_twin(self, tmp_path):
+        """`no-build` and `no-build-package` are one CONTROL but two SETTINGS. Storing
+        them under the canonical name let an empty `no-build-package = []` beside an
+        active `no-build = true` erase it, and uv still refuses source builds there."""
+        config = tmp_path / "uv.toml"
+        config.write_text("no-build = true\nno-build-package = []\n", encoding = "utf-8")
+        assert self._names({}, uv_files = [str(config)]) == ("uv.toml no-build",)
+
+    def test_an_explicit_config_file_is_read_as_a_standalone_uv_toml(self, tmp_path):
+        """uv parses the file named by UV_CONFIG_FILE with the uv.toml schema whatever it
+        is called, so choosing the schema from the basename lost the policy of an
+        explicit file that happened to be named pyproject.toml."""
+        explicit = tmp_path / "pyproject.toml"
+        explicit.write_text("no-build = true\n", encoding = "utf-8")
+        assert self._names(
+            {"UV_CONFIG_FILE": str(explicit)}, uv_files = [str(explicit)]
+        ) == ("pyproject.toml no-build",)
+        # A DISCOVERED pyproject.toml keeps the [tool.uv] schema, where a root key is
+        # some other tool's setting and not uv policy.
+        assert self._names({}, uv_files = [str(explicit)]) == ()
+
+    def test_a_dotted_key_is_a_table_in_the_legacy_parser(self):
+        """`pip.require-hashes = true` at the root of a uv.toml is the inline spelling of
+        `[pip] require-hashes = true`, which uv enforces. Read as one literal key it
+        matched nothing and the policy was dropped on 3.9 and 3.10."""
+        with mock.patch.object(ips, "_tomllib", None):
+            assert ips._hardened_keys_in_toml(
+                "pip.require-hashes = true\n", ((), ("pip",))
+            ) == ["require-hashes"]
+            # A dotted key naming a table we do not read stays ignored.
+            assert ips._hardened_keys_in_toml(
+                "other.require-hashes = true\n", ((), ("pip",))
+            ) == []
+
+    def test_a_download_only_section_is_not_an_opinion_about_install(self, tmp_path):
+        """pip resolves each subcommand separately, so `[download] only-binary = :all:`
+        does not restrict `pip install`. Pooling the three let a fallback install run as
+        though the operator's control were covered when that command was unrestricted."""
+        config = tmp_path / "pip.conf"
+        config.write_text("[download]\nonly-binary = :all:\n", encoding = "utf-8")
+        ips._policy_scan.cache_clear()
+        with (
+            mock.patch.dict(os.environ, {"UNSLOTH_RESPECT_PM_POLICY": "1"}, clear = True),
+            mock.patch.object(ips.subprocess, "run", mock.Mock(side_effect = OSError())),
+            mock.patch.object(ips, "_hardened_pip_config_paths", lambda: [str(config)]),
+            mock.patch.object(ips, "_hardened_uv_config_paths", lambda: []),
+        ):
+            keys = ips._configured_policy_keys()
+            assert "no-build" in keys["pip:download"]
+            assert "no-build" not in keys["pip:install"], keys
+        ips._policy_scan.cache_clear()
+
     def test_an_inline_comment_is_not_part_of_the_value(self):
         """The pre-3.11 fallback had already stripped the comment and then appended the
         raw line anyway, so `no-build = false # disabled` read as the value

--- a/tests/python/test_install_python_stack.py
+++ b/tests/python/test_install_python_stack.py
@@ -768,9 +768,7 @@ class TestHardenedPolicyIsAnnounced:
         a date filters it. Reading `false` as a cutoff put a security notice in front of
         an operator who had switched the control off."""
         assert self._names({"UV_EXCLUDE_NEWER": "false"}) == ()
-        assert self._names({"UV_EXCLUDE_NEWER": "2005-01-01T00:00:00Z"}) == (
-            "UV_EXCLUDE_NEWER",
-        )
+        assert self._names({"UV_EXCLUDE_NEWER": "2005-01-01T00:00:00Z"}) == ("UV_EXCLUDE_NEWER",)
         # Still not a boolean elsewhere: a package list keeps package names.
         assert self._names({"PIP_ONLY_BINARY": "false"}) == ("PIP_ONLY_BINARY",)
 

--- a/tests/python/test_install_python_stack.py
+++ b/tests/python/test_install_python_stack.py
@@ -3113,3 +3113,70 @@ class TestUvFindLinksSurvivesTheOptOut:
         env = ips._install_env_for_cmd(list(self.PINNED))
         assert env is not None
         assert "UV_FIND_LINKS" not in env
+
+
+class TestReportingAControlIsNotPermissionToOverrideIt:
+    """The notice's list and the default path's scrub list are separate on purpose.
+
+    `_PM_POLICY_ENV_VARS` grew as the notice learned to report more controls. It is
+    also what the default pinned branch used to remove, so widening it silently
+    widened the default bypass to UV_ONLY_BINARY, UV_ONLY_BINARY_PACKAGE and
+    PIP_UPLOADED_PRIOR_TO, none of which this installer touched before. The whole
+    change rests on the default path being indistinguishable from before.
+    """
+
+    # Exactly what the installer removed before this change. Do not add to this
+    # without deciding, separately and deliberately, to override one more control.
+    BASELINE = {
+        "UV_NO_BUILD",
+        "UV_NO_BUILD_PACKAGE",
+        "UV_NO_BINARY",
+        "UV_NO_BINARY_PACKAGE",
+        "UV_REQUIRE_HASHES",
+        "UV_EXCLUDE_NEWER",
+        "PIP_ONLY_BINARY",
+        "PIP_NO_BINARY",
+        "PIP_REQUIRE_HASHES",
+    }
+
+    def test_the_default_scrub_set_has_not_grown(self):
+        assert set(ips._PM_POLICY_SCRUB_ENV_VARS) == self.BASELINE
+
+    def test_the_notice_reports_more_than_the_default_path_overrides(self):
+        reported = set(ips._PM_POLICY_ENV_VARS)
+        assert self.BASELINE < reported, "the notice should report at least the scrubbed set"
+        assert {"UV_ONLY_BINARY", "PIP_UPLOADED_PRIOR_TO"} <= reported
+
+    @pytest.mark.parametrize(
+        "name", ["UV_ONLY_BINARY", "UV_ONLY_BINARY_PACKAGE", "PIP_UPLOADED_PRIOR_TO"]
+    )
+    def test_a_reported_only_control_survives_the_default_path(self, name, monkeypatch):
+        monkeypatch.delenv("UNSLOTH_RESPECT_PM_POLICY", raising = False)
+        monkeypatch.setenv(name, ":all:" if "BINARY" in name else "2026-01-01")
+        cmd = ["uv", "pip", "install", "--index-url", "https://pinned", "torch"]
+        env = ips._install_env_for_cmd(cmd)
+        assert env is not None
+        assert name in env, (
+            f"{name} is reported by the notice but was never overridden before this "
+            f"change; the default path must still leave it alone"
+        )
+
+    def test_the_scrubbed_controls_are_still_scrubbed_by_default(self, monkeypatch):
+        monkeypatch.delenv("UNSLOTH_RESPECT_PM_POLICY", raising = False)
+        for name in self.BASELINE:
+            monkeypatch.setenv(name, "1")
+        cmd = ["uv", "pip", "install", "--index-url", "https://pinned", "torch"]
+        env = ips._install_env_for_cmd(cmd)
+        assert env is not None
+        for name in self.BASELINE:
+            assert name not in env, name
+
+    def test_the_opt_out_still_keeps_everything(self, monkeypatch):
+        monkeypatch.setenv("UNSLOTH_RESPECT_PM_POLICY", "1")
+        for name in set(ips._PM_POLICY_ENV_VARS) | self.BASELINE:
+            monkeypatch.setenv(name, "1")
+        cmd = ["uv", "pip", "install", "--index-url", "https://pinned", "torch"]
+        env = ips._install_env_for_cmd(cmd)
+        assert env is not None
+        for name in self.BASELINE:
+            assert env.get(name) == "1", name

--- a/tests/python/test_install_python_stack.py
+++ b/tests/python/test_install_python_stack.py
@@ -1462,6 +1462,85 @@ class TestDetectionMatchesWhatTheManagersActuallyEnforce:
             assert "no-build" not in keys["pip:install"], keys
         ips._policy_scan.cache_clear()
 
+    @pytest.mark.parametrize("variable", ["UV_PROJECT", "UV_WORKING_DIR"])
+    def test_uvs_own_project_root_is_used_not_this_processs_cwd(self, variable, tmp_path):
+        """Measured on the pinned uv 0.12.1: a `[tool.uv.pip] require-hashes = true` in
+        a project named by either variable is enforced from an unrelated cwd. Walking
+        from getcwd() alone scanned the wrong tree."""
+        project = tmp_path / "elsewhere"
+        project.mkdir()
+        (project / "pyproject.toml").write_text('[project]\nname = "p"\n', encoding = "utf-8")
+        elsewhere = tmp_path / "cwd"
+        elsewhere.mkdir()
+        with (
+            mock.patch.dict(os.environ, {variable: str(project)}, clear = True),
+            mock.patch.object(os, "getcwd", lambda: str(elsewhere)),
+        ):
+            assert ips._uv_project_config() == [str(project / "pyproject.toml")]
+
+    def test_an_explicit_config_file_survives_no_config(self, tmp_path):
+        """Measured: uv reads the file named by UV_CONFIG_FILE with UV_NO_CONFIG=1 set
+        as well, so returning nothing there dropped policy that was still in force."""
+        explicit = tmp_path / "uv.toml"
+        explicit.write_text("[pip]\nrequire-hashes = true\n", encoding = "utf-8")
+        with mock.patch.dict(
+            os.environ,
+            {"UV_CONFIG_FILE": str(explicit), "UV_NO_CONFIG": "1"},
+            clear = True,
+        ):
+            assert ips._hardened_uv_config_paths() == [str(explicit)]
+        # Without an explicit file, --no-config still means nothing is discovered.
+        with mock.patch.dict(os.environ, {"UV_NO_CONFIG": "1"}, clear = True):
+            assert ips._hardened_uv_config_paths() == []
+
+    def test_the_macos_global_set_covers_both_pip_generations(self):
+        """pip changed under us: measured, pip 26.1 resolves the Darwin global set to
+        /Library/Application Support and ignores XDG_DATA_DIRS, while 26.2.1 lets
+        XDG_DATA_DIRS replace it. Either can be the pip on a user's machine."""
+        with (
+            mock.patch.dict(os.environ, {"XDG_DATA_DIRS": "/a", "HOME": "/home/u"}, clear = True),
+            _posix_home(),
+            mock.patch.object(ips, "IS_WINDOWS", False),
+            mock.patch.object(ips, "IS_MACOS", True),
+            mock.patch.object(os.path, "isfile", lambda path: True),
+        ):
+            paths = [path.replace(os.sep, "/") for path in ips._hardened_pip_config_paths()]
+        assert "/Library/Application Support/pip/pip.conf" in paths, paths
+        assert "/a/pip/pip.conf" in paths, paths
+
+    def test_the_refusal_names_a_uv_no_binary_value_uv_accepts(self):
+        """uv's no-binary is a package LIST: `no-binary = true` is a config parse error
+        there, so the remediation would have left the operator with an unusable uv."""
+        _pip, uv_name = ips._POLICY_EQUIVALENTS["no-binary"]
+        assert ":all:" in uv_name and "= true" not in uv_name, uv_name
+
+    @pytest.mark.parametrize(
+        "body,tables,expected",
+        [
+            ("[tool]\nuv = { pip = { require-hashes = true } }\n",
+             (("tool", "uv"), ("tool", "uv", "pip")), ["require-hashes"]),
+            ("pip = { require-hashes = true }\n", ((), ("pip",)), ["require-hashes"]),
+            ("[other]\nuv = { pip = { require-hashes = true } }\n",
+             (("tool", "uv"), ("tool", "uv", "pip")), []),
+        ],
+    )
+    def test_the_legacy_parser_reads_inline_tables(self, body, tables, expected):
+        """uv 0.12.1 enforces `[tool] uv = { pip = { require-hashes = true } }`, which
+        the pre-3.11 fallback skipped because `tool` is not itself a table it reads."""
+        with mock.patch.object(ips, "_tomllib", None):
+            assert ips._hardened_keys_in_toml(body, tables) == expected
+
+    def test_an_empty_toml_map_is_not_hardening(self):
+        """`exclude-newer-package = {}` reached the value conversion as an empty dict and
+        came out as the string "{}", which is not an off spelling. uv applies no cutoff
+        for it, and under the opt-out the phantom control could stop a pip step."""
+        assert ips._hardened_keys_in_toml("[pip]\nexclude-newer-package = {}\n",
+                                          ((), ("pip",))) == []
+        assert ips._hardened_keys_in_toml(
+            '[pip]\nexclude-newer-package = { foo = "2020-01-01T00:00:00Z" }\n',
+            ((), ("pip",)),
+        ) == ["exclude-newer-package"]
+
     def test_an_inline_comment_is_not_part_of_the_value(self):
         """The pre-3.11 fallback had already stripped the comment and then appended the
         raw line anyway, so `no-build = false # disabled` read as the value

--- a/tests/python/test_install_python_stack.py
+++ b/tests/python/test_install_python_stack.py
@@ -7,6 +7,8 @@ import contextlib
 import importlib
 import inspect
 import io
+import hashlib
+import pathlib
 import os
 import re
 import shutil
@@ -605,6 +607,73 @@ class TestOperatorCanKeepTheirPolicy:
             ips._sdist_only_build_args("openai-whisper")
             assert os.environ["UNSLOTH_RESPECT_PM_POLICY"] == "1"
             assert os.environ["PIP_REQUIRE_HASHES"] == "1"
+
+
+class TestTheMetadataRepairCannotStrandThePackage:
+    """The repair uninstalls every record and then reinstalls from a staged wheel. If
+    that reinstall is refused, the core package is simply gone -- and under the opt-out
+    it WAS refused, because the restore names an unpinned, unhashed requirement while
+    require-hashes is in force. Measured against pip 26.2.1: "In --require-hashes mode,
+    all requirements must have their versions pinned with ==".
+    """
+
+    def _staged(self, tmp_path):
+        staged = tmp_path / "staged"
+        staged.mkdir()
+        wheel = staged / "unsloth_zoo-1.0-py3-none-any.whl"
+        wheel.write_bytes(b"PK\x03\x04 not a real wheel, but a real file to hash\n")
+        return staged, wheel
+
+    def test_the_default_path_still_names_the_requirement(self, tmp_path):
+        """Unchanged where nothing is hardened: same command as before this fix."""
+        staged, _ = self._staged(tmp_path)
+        with mock.patch.dict(os.environ, {}, clear = True):
+            args, cleanup = ips._staged_restore_args("unsloth-zoo", str(staged))
+        assert cleanup == ""
+        assert args == [
+            "--no-deps", "--force-reinstall", "--no-index",
+            "--find-links", str(staged), "unsloth-zoo",
+        ]
+
+    def test_the_opt_out_restores_through_a_real_hash(self, tmp_path):
+        """Not a relaxation and not a skipped repair: the staged wheel is a local file
+        this installer just built, so its hash is knowable and the policy is satisfied
+        honestly. Measured: pip accepts this under PIP_REQUIRE_HASHES=1, and rejects it
+        with THESE PACKAGES DO NOT MATCH THE HASHES if the wheel is altered."""
+        staged, wheel = self._staged(tmp_path)
+        with mock.patch.dict(
+            os.environ, {"UNSLOTH_RESPECT_PM_POLICY": "1"}, clear = True
+        ):
+            args, cleanup = ips._staged_restore_args("unsloth-zoo", str(staged))
+        try:
+            assert args[:4] == ["--no-deps", "--force-reinstall", "--no-index", "-r"]
+            body = pathlib.Path(cleanup).read_text(encoding = "utf-8")
+            digest = hashlib.sha256(wheel.read_bytes()).hexdigest()
+            assert str(wheel) in body and f"--hash=sha256:{digest}" in body, body
+        finally:
+            os.unlink(cleanup)
+
+    def test_a_normalised_name_still_finds_its_wheel(self, tmp_path):
+        """The wheel spells the project with an underscore and the requirement with a
+        dash, so the match has to normalise both."""
+        staged, _ = self._staged(tmp_path)
+        with mock.patch.dict(
+            os.environ, {"UNSLOTH_RESPECT_PM_POLICY": "1"}, clear = True
+        ):
+            args, cleanup = ips._staged_restore_args("Unsloth_Zoo", str(staged))
+        assert cleanup, "the underscore spelling must match unsloth_zoo-1.0-...whl"
+        os.unlink(cleanup)
+
+    def test_a_missing_wheel_falls_back_rather_than_raising(self, tmp_path):
+        """Nothing to hash is not a crash: the caller gets the ordinary arguments and
+        whatever pip says about them."""
+        staged = tmp_path / "empty"
+        staged.mkdir()
+        with mock.patch.dict(
+            os.environ, {"UNSLOTH_RESPECT_PM_POLICY": "1"}, clear = True
+        ):
+            args, cleanup = ips._staged_restore_args("unsloth-zoo", str(staged))
+        assert cleanup == "" and args[-1] == "unsloth-zoo"
 
 
 class TestHardenedPolicyIsAnnounced:

--- a/tests/python/test_install_python_stack.py
+++ b/tests/python/test_install_python_stack.py
@@ -1022,8 +1022,13 @@ class TestTheNoticeCannotTakeAnInstallDown:
 
     def test_the_pip_probe_is_bounded(self):
         """No timeout here means an install that hangs forever on a wedged pip."""
-        source = inspect.getsource(ips._detected_policy)
+        # The probe lives in _pip_config_settings, which _detected_policy calls.
+        source = inspect.getsource(ips._pip_config_settings)
         assert "timeout = 30" in source, "the pip config probe must be bounded"
+        assert "subprocess.run" in source, (
+            "this test is checking the function that actually runs pip; if the probe "
+            "moved again, follow it rather than leaving the assertion looking at nothing"
+        )
 
     def test_a_hanging_pip_still_yields_the_environment_half(self):
         ips._detected_policy.cache_clear()
@@ -2996,3 +3001,77 @@ class TestNoIndexCountsTheConfigFileNotJustTheEnvironment:
         assert env is not None
         assert "PIP_FIND_LINKS" not in env and "PIP_NO_INDEX" not in env
         assert called == []
+
+
+class TestNoIndexIsReadForTheCommandBeingRun:
+    """A command-prefixed pip.conf key affects only the command it names.
+
+    Pooling `[global]`, `[install]`, `[download]` and `[wheel]` into one answer let a
+    `[download] no-index = true` hold PIP_FIND_LINKS through a pinned INSTALL, where it
+    is purely additive and could satisfy torch from an unpinned location.
+    """
+
+    def test_the_commands_own_section_beats_global(self):
+        settings = {("global", "no-index"): "true", ("install", "no-index"): "false"}
+        assert ips._pip_setting_is_on(settings, "install", "no-index") is False
+        assert ips._pip_setting_is_on(settings, "download", "no-index") is True
+
+    def test_another_commands_section_does_not_apply(self):
+        settings = {("download", "no-index"): "true"}
+        assert ips._pip_setting_is_on(settings, "install", "no-index") is False
+        assert ips._pip_setting_is_on(settings, "download", "no-index") is True
+
+    def test_global_applies_where_no_command_section_exists(self):
+        settings = {("global", "no-index"): "true"}
+        for command in ips._PIP_COMMANDS:
+            assert ips._pip_setting_is_on(settings, command, "no-index") is True
+
+
+class TestAFailedPipProbeIsNotMemoisedForTheRun:
+    """A fresh uv venv has no pip when the notice runs.
+
+    Caching that emptiness meant a later step still saw "nothing configured" after pip
+    had been bootstrapped, which scrubbed PIP_FIND_LINKS out of a pinned command whose
+    only source it was. Only a reading that reached pip is kept.
+    """
+
+    def test_an_unreachable_pip_leaves_the_cache_empty(self, monkeypatch, tmp_path):
+        ips._detected_policy.cache_clear()
+        monkeypatch.setattr(ips.sys, "executable", str(tmp_path / "no-such-python"))
+        assert ips._pip_config_settings() == {}
+        assert ips._pip_config_settings._cache is None, (
+            "a probe that never reached pip must not be memoised: pip can be "
+            "bootstrapped later in the same run"
+        )
+        ips._detected_policy.cache_clear()
+
+    def test_a_successful_probe_is_memoised(self, monkeypatch, tmp_path):
+        ips._detected_policy.cache_clear()
+        conf = tmp_path / "pip.conf"
+        conf.write_text("[global]\nno-index = true\n", encoding = "utf-8")
+        monkeypatch.setenv("PIP_CONFIG_FILE", str(conf))
+        try:
+            first = ips._pip_config_settings()
+            assert first.get(("global", "no-index")) == "true"
+            assert ips._pip_config_settings._cache is not None
+            # Second call must not re-probe: point the interpreter at nothing and the
+            # memoised answer should still come back.
+            monkeypatch.setattr(ips.sys, "executable", str(tmp_path / "gone"))
+            assert ips._pip_config_settings() == first
+        finally:
+            ips._detected_policy.cache_clear()
+
+    def test_the_answer_changes_once_pip_appears(self, monkeypatch, tmp_path):
+        ips._detected_policy.cache_clear()
+        conf = tmp_path / "pip.conf"
+        conf.write_text("[global]\nno-index = true\n", encoding = "utf-8")
+        monkeypatch.setenv("PIP_CONFIG_FILE", str(conf))
+        monkeypatch.delenv("PIP_NO_INDEX", raising = False)
+        real = ips.sys.executable
+        try:
+            monkeypatch.setattr(ips.sys, "executable", str(tmp_path / "no-such-python"))
+            assert ips._pip_no_index_in_force() is False
+            monkeypatch.setattr(ips.sys, "executable", real)
+            assert ips._pip_no_index_in_force() is True
+        finally:
+            ips._detected_policy.cache_clear()

--- a/tests/python/test_install_python_stack.py
+++ b/tests/python/test_install_python_stack.py
@@ -1426,9 +1426,9 @@ class TestDetectionMatchesWhatTheManagersActuallyEnforce:
         explicit file that happened to be named pyproject.toml."""
         explicit = tmp_path / "pyproject.toml"
         explicit.write_text("no-build = true\n", encoding = "utf-8")
-        assert self._names(
-            {"UV_CONFIG_FILE": str(explicit)}, uv_files = [str(explicit)]
-        ) == ("pyproject.toml no-build",)
+        assert self._names({"UV_CONFIG_FILE": str(explicit)}, uv_files = [str(explicit)]) == (
+            "pyproject.toml no-build",
+        )
         # A DISCOVERED pyproject.toml keeps the [tool.uv] schema, where a root key is
         # some other tool's setting and not uv policy.
         assert self._names({}, uv_files = [str(explicit)]) == ()
@@ -1438,13 +1438,11 @@ class TestDetectionMatchesWhatTheManagersActuallyEnforce:
         `[pip] require-hashes = true`, which uv enforces. Read as one literal key it
         matched nothing and the policy was dropped on 3.9 and 3.10."""
         with mock.patch.object(ips, "_tomllib", None):
-            assert ips._hardened_keys_in_toml(
-                "pip.require-hashes = true\n", ((), ("pip",))
-            ) == ["require-hashes"]
+            assert ips._hardened_keys_in_toml("pip.require-hashes = true\n", ((), ("pip",))) == [
+                "require-hashes"
+            ]
             # A dotted key naming a table we do not read stays ignored.
-            assert ips._hardened_keys_in_toml(
-                "other.require-hashes = true\n", ((), ("pip",))
-            ) == []
+            assert ips._hardened_keys_in_toml("other.require-hashes = true\n", ((), ("pip",))) == []
 
     def test_a_download_only_section_is_not_an_opinion_about_install(self, tmp_path):
         """pip resolves each subcommand separately, so `[download] only-binary = :all:`

--- a/tests/python/test_install_python_stack.py
+++ b/tests/python/test_install_python_stack.py
@@ -3180,3 +3180,55 @@ class TestReportingAControlIsNotPermissionToOverrideIt:
         assert env is not None
         for name in self.BASELINE:
             assert env.get(name) == "1", name
+
+
+class TestTheMetadataRepairDeclinesBeforeTouchingAnything:
+    """The guard sits at the top of the repair, not inside _stage_replacement().
+
+    By the time staging is reached the repair has already rewritten METADATA and moved
+    pip's leftover backups aside. A normal return puts them back through the finally,
+    but a SIGKILL or a power loss cannot run a finally, so under the opt-out the repair
+    is declined before the first byte is touched.
+    """
+
+    def test_no_filesystem_call_is_reached_under_the_opt_out(self, monkeypatch):
+        monkeypatch.setenv("UNSLOTH_RESPECT_PM_POLICY", "1")
+        touched: "list[str]" = []
+
+        # Anything that could mutate the tree records itself instead of running.
+        for name in ("_rewrite_minimal_metadata",):
+            if hasattr(ips, name):
+                monkeypatch.setattr(
+                    ips,
+                    name,
+                    lambda *a, _n = name, **k: touched.append(_n) or True,
+                )
+        monkeypatch.setattr(
+            ips._QuarantinedMetadata,
+            "back_up",
+            lambda self, *a, **k: touched.append("back_up") or True,
+        )
+        monkeypatch.setattr(
+            ips._QuarantinedMetadata,
+            "take",
+            lambda self, *a, **k: touched.append("take") or True,
+        )
+        monkeypatch.setattr(
+            ips.install_manifest,
+            "installed_versions",
+            lambda name: ["1.0", "2.0"],
+        )
+        monkeypatch.setattr(
+            ips.install_manifest,
+            "invalid_metadata_paths",
+            lambda name: ["/x/a.dist-info"],
+        )
+        monkeypatch.setattr(
+            ips.install_manifest,
+            "pip_backup_metadata_paths",
+            lambda name: ["/x/~pkg"],
+        )
+
+        result = ips._repair_duplicate_core_metadata(("unsloth",))
+        assert result is False
+        assert touched == [], f"the repair mutated the tree before declining: {touched}"

--- a/tests/python/test_install_python_stack.py
+++ b/tests/python/test_install_python_stack.py
@@ -899,6 +899,43 @@ class TestConfigDetectionReadsValuesNotJustKeys:
         assert windows and all(path.endswith("pip.ini") for path in windows)
         assert any(path.startswith("C:\\pd") for path in windows)
 
+    def test_pip_config_precedence_is_resolved(self):
+        """`pip config list` prints EVERY definition, overridden ones included.
+
+        Measured on pip 26.2.1 with a user pip.conf `require-hashes = true` and a venv
+        site pip.conf `require-hashes = false`: both lines are emitted, `pip config get
+        global.require-hashes` returns false, and the install is NOT hash-checked. Taking
+        any enabled occurrence announced a policy pip does not apply.
+        """
+        listing = "global.require-hashes='true'\nglobal.require-hashes='false'\n"
+        assert self._names({}, pip_ok = True, pip_config = listing) == ()
+        # And the other order still reports it, so the resolution is precedence, not
+        # "an off value anywhere wins".
+        listing = "global.require-hashes='false'\nglobal.require-hashes='true'\n"
+        assert self._names({}, pip_ok = True, pip_config = listing) == (
+            "pip.conf require-hashes",
+        )
+
+    def test_file_precedence_is_resolved_when_pip_is_missing(self, tmp_path):
+        """The same resolution in the branch this feature exists for: no pip at all."""
+        user = tmp_path / "user.conf"
+        user.write_text("[global]\nrequire-hashes = true\n", encoding = "utf-8")
+        site = tmp_path / "site.conf"
+        site.write_text("[global]\nrequire-hashes = false\n", encoding = "utf-8")
+        ips._detected_policy.cache_clear()
+        with (
+            mock.patch.dict(os.environ, {}, clear = True),
+            mock.patch.object(ips.subprocess, "run", mock.Mock(side_effect = OSError)),
+            mock.patch.object(ips, "_hardened_uv_config_paths", lambda: []),
+            # Returned in pip's load order, so the site file is last and wins.
+            mock.patch.object(
+                ips, "_hardened_pip_config_paths", lambda: [str(user), str(site)]
+            ),
+        ):
+            names = ips._hardened_pm_policy_names()
+        ips._detected_policy.cache_clear()
+        assert names == ()
+
     def test_a_malformed_pip_conf_is_survivable(self, tmp_path):
         config = tmp_path / "pip.conf"
         config.write_text("this is not ini at all\n[[[\n", encoding = "utf-8")

--- a/tests/python/test_install_python_stack.py
+++ b/tests/python/test_install_python_stack.py
@@ -544,9 +544,7 @@ class TestOperatorCanKeepTheirPolicy:
         controls in HOSTILE are now restated for pip, but the one thing that must never
         appear is the hash relaxation itself."""
         with mock.patch.dict(os.environ, dict(self.HOSTILE, UNSLOTH_RESPECT_PM_POLICY = value)):
-            env = ips._install_env_for_cmd(
-                ["python", "-m", "pip", "install", "-r", "extras.txt"]
-            )
+            env = ips._install_env_for_cmd(["python", "-m", "pip", "install", "-r", "extras.txt"])
         assert env is None or env.get("PIP_REQUIRE_HASHES") != "0"
 
     @pytest.mark.parametrize("value", ["", "0", "false", "no"])
@@ -1172,7 +1170,12 @@ class TestTranslationKeepsTheOperatorsActualPolicy:
         full = tuple(e if len(e) == 4 else (*e, "1") for e in entries)
         return mock.patch.object(ips, "_detected_policy", lambda: full)
 
-    def _env(self, entries, cmd, extra = None):
+    def _env(
+        self,
+        entries,
+        cmd,
+        extra = None,
+    ):
         environment = {"UNSLOTH_RESPECT_PM_POLICY": "1"}
         environment.update(extra or {})
         with mock.patch.dict(os.environ, environment, clear = True), self._detect(entries):
@@ -1188,9 +1191,7 @@ class TestTranslationKeepsTheOperatorsActualPolicy:
         assert "UV_NO_BUILD" not in env, "a policy about two packages is not a global one"
 
     def test_an_all_pip_policy_becomes_a_global_uv_one(self):
-        env = self._env(
-            [("pip", "env", "PIP_ONLY_BINARY", ":all:")], ["uv", "pip", "install", "x"]
-        )
+        env = self._env([("pip", "env", "PIP_ONLY_BINARY", ":all:")], ["uv", "pip", "install", "x"])
         assert env is not None and env["UV_NO_BUILD"] == "1"
         assert "UV_NO_BUILD_PACKAGE" not in env
 
@@ -1210,8 +1211,7 @@ class TestTranslationKeepsTheOperatorsActualPolicy:
 
     def test_a_global_setting_beats_a_scoped_one_when_both_are_present(self):
         env = self._env(
-            [("uv", "env", "UV_NO_BUILD", "1"),
-             ("uv", "env", "UV_NO_BUILD_PACKAGE", "numpy")],
+            [("uv", "env", "UV_NO_BUILD", "1"), ("uv", "env", "UV_NO_BUILD_PACKAGE", "numpy")],
             ["python", "-m", "pip", "install", "x"],
         )
         assert env is not None and env["PIP_ONLY_BINARY"] == ":all:"
@@ -1250,8 +1250,14 @@ class TestTranslationKeepsTheOperatorsActualPolicy:
 class TestDetectionMatchesPipsOwnRules:
     """Each of these was checked against pip's source or measured, not assumed."""
 
-    def _names(self, environment, pip_ok = False, pip_config = "", uv_files = (),
-               pip_files = ()):
+    def _names(
+        self,
+        environment,
+        pip_ok = False,
+        pip_config = "",
+        uv_files = (),
+        pip_files = (),
+    ):
         ips._detected_policy.cache_clear()
         runner = (
             mock.Mock(return_value = mock.Mock(returncode = 0, stdout = pip_config.encode()))
@@ -1285,9 +1291,7 @@ class TestDetectionMatchesPipsOwnRules:
         and, under the opt-out, translated the cancelled setting into uv and failed."""
         config = tmp_path / "pip.conf"
         config.write_text("[global]\nrequire-hashes = true\n", encoding = "utf-8")
-        assert self._names(
-            {"PIP_REQUIRE_HASHES": "0"}, pip_files = [str(config)]
-        ) == ()
+        assert self._names({"PIP_REQUIRE_HASHES": "0"}, pip_files = [str(config)]) == ()
         # Without the cancelling variable it is reported normally.
         assert self._names({}, pip_files = [str(config)]) == ("pip.conf require-hashes",)
 
@@ -1304,9 +1308,7 @@ class TestDetectionMatchesPipsOwnRules:
 
     def test_config_list_ranks_sections_too(self):
         listing = "install.require-hashes='true'\nglobal.require-hashes='false'\n"
-        assert self._names({}, pip_ok = True, pip_config = listing) == (
-            "pip.conf require-hashes",
-        )
+        assert self._names({}, pip_ok = True, pip_config = listing) == ("pip.conf require-hashes",)
 
     def test_user_configs_are_skipped_when_an_explicit_file_exists(self, tmp_path):
         """pip's iter_config_files: "per-user config is not loaded when env_config_file
@@ -1322,9 +1324,7 @@ class TestDetectionMatchesPipsOwnRules:
             _posix_home(),
             mock.patch.object(ips, "IS_WINDOWS", False),
             mock.patch.object(ips, "IS_MACOS", False),
-            mock.patch.object(
-                os.path, "isfile", lambda path: True
-            ),
+            mock.patch.object(os.path, "isfile", lambda path: True),
         ):
             paths = [path.replace(os.sep, "/") for path in ips._hardened_pip_config_paths()]
         assert not any("/home/u/.config/pip" in path for path in paths)

--- a/tests/python/test_install_python_stack.py
+++ b/tests/python/test_install_python_stack.py
@@ -1187,6 +1187,156 @@ class TestDetectionMatchesPipsOwnRules:
         assert any(path.startswith("C:\\u") and path.endswith("pip.ini") for path in paths)
 
 
+class TestDetectionMatchesWhatTheManagersActuallyEnforce:
+    """Detection has to report the policy in force, not the policy that looks configured.
+
+    Every claim below was measured against the versions Unsloth ships against: the uv
+    0.12.1 that setup.sh pins by sha256, and pip 26.2.1. Over-reporting is not the safe
+    direction here, because under the opt-out a control credited to one manager and not
+    the other stops the step.
+    """
+
+    _names = TestDetectionMatchesPipsOwnRules._names
+
+    @pytest.mark.parametrize(
+        "name,value",
+        [
+            ("UV_NO_BUILD", "true"),
+            ("UV_NO_BUILD_PACKAGE", "simsrc"),
+            ("UV_ONLY_BINARY", ":all:"),
+            ("UV_NO_BINARY", ":all:"),
+        ],
+    )
+    def test_the_uv_artifact_variables_uv_ignores_are_not_policy(self, name, value):
+        """Measured on the pinned uv 0.12.1: a source directory installs with any of
+        these set, and is refused by the matching --no-build / --no-binary flag or by a
+        uv.toml carrying it. `uv help pip install` lists no [env:] spelling for them.
+
+        They are still stripped from a pinned command, which costs nothing. Counting one
+        as uv policy is the harm: it hid a genuine pip-side gap under the opt-out by
+        making uv look as though it had the control covered."""
+        assert self._names({name: value}) == ()
+        assert ips._configured_policy_keys()["uv"] == frozenset()
+
+    @pytest.mark.parametrize("name", ["UV_REQUIRE_HASHES", "UV_EXCLUDE_NEWER"])
+    def test_the_uv_variables_uv_does_read_are_still_policy(self, name):
+        """The same measurement the other way: UV_REQUIRE_HASHES fails an unhashed
+        install and UV_EXCLUDE_NEWER filters by upload date, both from the environment
+        alone."""
+        value = "1" if name.endswith("HASHES") else "2020-01-01T00:00:00Z"
+        assert self._names({name: value}) == (name,)
+
+    @pytest.mark.parametrize("key", ["no-build", "no-build-package", "exclude-newer"])
+    def test_a_uv_only_key_in_pip_conf_is_not_pip_policy(self, key, tmp_path):
+        """pip 26.2.1 has no option for these, so `pip install --help` exposes nothing
+        for them and an entry in pip.conf is inert. Reading one as pip policy made the
+        first uv step refuse under the opt-out over a gap that did not exist."""
+        config = tmp_path / "pip.conf"
+        config.write_text(f"[global]\n{key} = true\n", encoding = "utf-8")
+        assert self._names({}, pip_files = [str(config)]) == ()
+
+    @pytest.mark.parametrize("key", ["require-hashes", "only-binary", "uploaded-prior-to"])
+    def test_the_keys_pip_does_have_are_still_read(self, key, tmp_path):
+        config = tmp_path / "pip.conf"
+        value = "true" if key == "require-hashes" else ":all:"
+        config.write_text(f"[global]\n{key} = {value}\n", encoding = "utf-8")
+        assert self._names({}, pip_files = [str(config)]) == (f"pip.conf {key}",)
+
+    def test_an_empty_variable_does_not_cancel_a_config_file(self, tmp_path):
+        """pip drops empty environment values before applying precedence. Measured with
+        pip 26.2.1: PIP_ONLY_BINARY='' still rejects an sdist under a pip.conf
+        `only-binary = :all:`, while `:none:` clears it. Treating the empty spelling as a
+        cancellation suppressed a policy that was fully in force."""
+        config = tmp_path / "pip.conf"
+        config.write_text("[global]\nonly-binary = :all:\n", encoding = "utf-8")
+        assert self._names({"PIP_ONLY_BINARY": ""}, pip_files = [str(config)]) == (
+            "pip.conf only-binary",
+        )
+        assert self._names({"PIP_ONLY_BINARY": ":none:"}, pip_files = [str(config)]) == ()
+
+    def test_a_subcommand_setting_survives_a_later_file(self, tmp_path):
+        """pip resolves each command separately across ALL its files, so a low-priority
+        file's [wheel] entry cannot erase a higher one's [install] entry. Collapsing each
+        file before reading the next reported an unhardened host while pip was still
+        hash-checking every install."""
+        first = tmp_path / "user.conf"
+        first.write_text("[install]\nrequire-hashes = true\n", encoding = "utf-8")
+        second = tmp_path / "site.conf"
+        second.write_text("[wheel]\nrequire-hashes = false\n", encoding = "utf-8")
+        assert self._names({}, pip_files = [str(first), str(second)]) == (
+            "user.conf require-hashes",
+        )
+        # And the ordinary same-section override still works.
+        third = tmp_path / "later.conf"
+        third.write_text("[install]\nrequire-hashes = false\n", encoding = "utf-8")
+        assert self._names({}, pip_files = [str(first), str(third)]) == ()
+
+    def test_a_project_config_can_switch_a_user_config_off(self, tmp_path):
+        """Measured on the pinned uv 0.12.1: a user `~/.config/uv/uv.toml` with
+        `[pip] require-hashes = true` plus a project `[tool.uv.pip] require-hashes =
+        false` installs unhashed. Reporting the user value regardless made a later pip
+        step refuse under the opt-out over policy uv was not enforcing."""
+        user = tmp_path / "uv.toml"
+        user.write_text("[pip]\nrequire-hashes = true\n", encoding = "utf-8")
+        project = tmp_path / "pyproject.toml"
+        project.write_text(
+            '[project]\nname = "p"\nversion = "0"\n[tool.uv.pip]\nrequire-hashes = false\n',
+            encoding = "utf-8",
+        )
+        assert self._names({}, uv_files = [str(user)]) == ("uv.toml require-hashes",)
+        assert self._names({}, uv_files = [str(user), str(project)]) == ()
+
+    def test_the_uv_files_come_back_lowest_precedence_first(self, tmp_path):
+        """The resolution above is only correct if the order is: system, user, project."""
+        home = tmp_path / "home"
+        (home / "uv").mkdir(parents = True)
+        (home / "uv" / "uv.toml").write_text("[pip]\nno-build = true\n", encoding = "utf-8")
+        project = tmp_path / "proj"
+        project.mkdir()
+        (project / "pyproject.toml").write_text('[project]\nname = "p"\n', encoding = "utf-8")
+        with (
+            mock.patch.dict(os.environ, {"XDG_CONFIG_HOME": str(home)}, clear = True),
+            mock.patch.object(ips, "IS_WINDOWS", False),
+            mock.patch.object(os, "getcwd", lambda: str(project)),
+            mock.patch.object(ips.os.path, "isfile", os.path.isfile),
+        ):
+            paths = ips._hardened_uv_config_paths()
+        assert paths[-1] == str(project / "pyproject.toml"), paths
+        assert str(home / "uv" / "uv.toml") in paths
+
+    def test_a_parent_pyproject_is_discovered_from_a_child_directory(self, tmp_path):
+        """Measured on the pinned uv 0.12.1: a parent `[tool.uv.pip] require-hashes =
+        true` fails an install run from a child directory. Studio is normally launched
+        from one, so stopping at the working directory missed real policy."""
+        parent = tmp_path / "parent"
+        (parent / "child" / "deep").mkdir(parents = True)
+        (parent / "pyproject.toml").write_text('[project]\nname = "p"\n', encoding = "utf-8")
+        with mock.patch.object(os, "getcwd", lambda: str(parent / "child" / "deep")):
+            assert ips._uv_project_config() == [str(parent / "pyproject.toml")]
+
+    def test_a_uv_toml_beside_the_pyproject_wins(self, tmp_path):
+        (tmp_path / "pyproject.toml").write_text('[project]\nname = "p"\n', encoding = "utf-8")
+        (tmp_path / "uv.toml").write_text("[pip]\nrequire-hashes = true\n", encoding = "utf-8")
+        with mock.patch.object(os, "getcwd", lambda: str(tmp_path)):
+            assert ips._uv_project_config() == [str(tmp_path / "uv.toml")]
+
+    def test_a_uv_toml_with_no_pyproject_beside_it_is_not_read(self, tmp_path):
+        """Measured: uv reads it in neither the working directory nor any ancestor, so
+        reporting it would be hardening uv does not apply."""
+        (tmp_path / "uv.toml").write_text("[pip]\nrequire-hashes = true\n", encoding = "utf-8")
+        with mock.patch.object(os, "getcwd", lambda: str(tmp_path)):
+            assert ips._uv_project_config() == []
+
+    def test_the_walk_terminates_on_a_host_with_no_pyproject_anywhere(self):
+        with mock.patch.object(os, "getcwd", lambda: "/a/b/c"):
+            with mock.patch.object(ips.os.path, "isfile", lambda path: False):
+                assert ips._uv_project_config() == []
+
+    def test_a_deleted_working_directory_is_not_an_error(self):
+        with mock.patch.object(os, "getcwd", mock.Mock(side_effect = OSError("gone"))):
+            assert ips._uv_project_config() == []
+
+
 class TestPolicyEnvIsPlatformAndHardwareInvariant:
     """The env this helper builds must not depend on the platform or the accelerator.
 
@@ -1225,16 +1375,11 @@ class TestPolicyEnvIsPlatformAndHardwareInvariant:
         # refusal is not an environment to compare across platforms.
         # Both managers configured, so no cross-manager gap: a refusal is not an
         # environment, and this sweep is about environment construction.
-        policy = (
-            {
-                "PIP_REQUIRE_HASHES": "1",
-                "UV_REQUIRE_HASHES": "1",
-                "PIP_ONLY_BINARY": ":all:",
-                "UV_NO_BUILD": "1",
-            }
-            if hardened
-            else {}
-        )
+        # require-hashes on both sides, and only that: it is the one artifact-policy
+        # control with an environment spelling uv actually reads, so it is the only way
+        # to configure both managers without writing config files. UV_NO_BUILD would not
+        # do, since uv ignores it and detection no longer pretends otherwise.
+        policy = {"PIP_REQUIRE_HASHES": "1", "UV_REQUIRE_HASHES": "1"} if hardened else {}
         for command in self.COMMANDS:
             answers = set()
             for platform, settings in self.PLATFORMS.items():

--- a/tests/python/test_install_python_stack.py
+++ b/tests/python/test_install_python_stack.py
@@ -2810,3 +2810,47 @@ class TestAFalseCutoffOnlyDisablesTheManagerThatAcceptsIt:
         for key in ("exclude-newer", "uploaded-prior-to"):
             assert ips._config_value_is_on("", key) is False, key
             assert ips._config_value_is_on("   ", key) is False, key
+
+
+class TestNoneIsAListSentinelNotABoolean:
+    """`:none:` empties a package list; to a boolean it is a value pip rejects.
+
+    Measured on pip 26.2.1: `PIP_NO_INDEX=:none:` exits with ":none: is not a valid
+    value for no-index option, please specify a boolean value like yes/no, true/false
+    or 1/0 instead". Reading it as off let the opt-out drop a variable that would
+    otherwise have stopped the command, which turns an install pip refuses into one
+    that can reach the network.
+    """
+
+    def test_none_does_not_switch_off_a_boolean_control(self):
+        for key in ips._BOOLEAN_POLICY_KEYS:
+            assert ips._config_value_is_on(":none:", key) is True, key
+
+    def test_none_still_empties_a_package_list(self):
+        for key in ("no-binary", "only-binary"):
+            assert ips._config_value_is_on(":none:", key) is False, key
+
+    def test_an_empty_value_is_off_for_every_kind_of_key(self):
+        for key in (None, "no-index", "no-binary", "exclude-newer"):
+            assert ips._config_value_is_on("", key) is False, key
+            assert ips._config_value_is_on("   ", key) is False, key
+
+    def test_the_opt_out_keeps_a_no_index_pip_would_reject(self, monkeypatch):
+        # The value is unusable, so the pinned step fails -- which is exactly what the
+        # opt-out promises. Dropping it would have let the same step succeed instead.
+        monkeypatch.setenv("UNSLOTH_RESPECT_PM_POLICY", "1")
+        monkeypatch.setenv("PIP_NO_INDEX", ":none:")
+        monkeypatch.setenv("PIP_FIND_LINKS", "/op/wheels")
+        cmd = ["uv", "pip", "install", "--index-url", "https://pinned", "torch"]
+        env = ips._install_env_for_cmd(cmd)
+        assert env is not None
+        assert env.get("PIP_NO_INDEX") == ":none:"
+        assert env.get("PIP_FIND_LINKS") == "/op/wheels"
+
+    def test_the_default_path_still_scrubs_it(self, monkeypatch):
+        monkeypatch.delenv("UNSLOTH_RESPECT_PM_POLICY", raising = False)
+        monkeypatch.setenv("PIP_NO_INDEX", ":none:")
+        cmd = ["uv", "pip", "install", "--index-url", "https://pinned", "torch"]
+        env = ips._install_env_for_cmd(cmd)
+        assert env is not None
+        assert "PIP_NO_INDEX" not in env

--- a/tests/python/test_install_python_stack.py
+++ b/tests/python/test_install_python_stack.py
@@ -645,7 +645,9 @@ class TestHardenedPolicyIsAnnounced:
             mock.patch.dict(os.environ, {"UNSLOTH_RESPECT_PM_POLICY": "1"}, clear = True),
         ):
             ips._announce_pm_policy()
-        assert "will fail" in capsys.readouterr().out
+        # Normalised: _note() wraps to the terminal, so the phrase spans lines.
+        text = " ".join(capsys.readouterr().out.split())
+        assert "will now fail where your policy forbids them" in text
 
     def test_nothing_is_printed_on_an_ordinary_machine(self, capsys):
         with (
@@ -654,6 +656,237 @@ class TestHardenedPolicyIsAnnounced:
         ):
             ips._announce_pm_policy()
         assert capsys.readouterr().out == ""
+
+
+class TestTheOptOutIsNotDefeatedByOurOwnEscapeHatches:
+    """Three ways the opt-out let policy through anyway, each measured, each closed.
+
+    The flag promises the operator's policy is left in force. Anything the installer does
+    that quietly restores the relaxed behaviour makes that promise false, which is worse
+    than not offering the flag.
+    """
+
+    def test_pinned_installs_keep_uv_config_discovery(self):
+        """UV_NO_CONFIG=1 discards a USER uv.toml, which is where a require-hashes lives.
+
+        Measured on the pinned uv 0.12.1: `~/.config/uv/uv.toml` with
+        `[pip] require-hashes = true` fails a `uv pip install --no-index --find-links`,
+        and the identical command with UV_NO_CONFIG=1 succeeds. Setting it under the
+        opt-out therefore discarded exactly the control being promised.
+        """
+        with mock.patch.dict(
+            os.environ,
+            dict(TestHardenedPipConfigRelaxation.HOSTILE, UNSLOTH_RESPECT_PM_POLICY = "1"),
+        ):
+            env = ips._install_env_for_cmd(
+                ["uv", "pip", "install", "torch", "--index-url", "https://x/cu128"]
+            )
+        assert env is not None
+        assert "UV_NO_CONFIG" not in env, "the opt-out must leave uv config discovery on"
+
+    def test_the_default_path_still_disables_uv_config_discovery(self):
+        """Unchanged where it matters: a discovered uv.toml outranks the CLI pin."""
+        with mock.patch.dict(os.environ, {}, clear = True):
+            env = ips._install_env_for_cmd(
+                ["uv", "pip", "install", "torch", "--index-url", "https://x/cu128"]
+            )
+        assert env is not None and env["UV_NO_CONFIG"] == "1"
+        assert env["PIP_CONFIG_FILE"] == os.devnull
+
+    def test_the_pip_fallback_is_refused_under_the_opt_out(self):
+        """pip reads none of uv's policy, so falling back to it after uv refused an
+        install runs the very command the policy rejected. Stop instead."""
+        calls: list = []
+
+        with (
+            mock.patch.object(ips, "USE_UV", True),
+            mock.patch.object(ips, "subprocess") as sp,
+            mock.patch.object(ips, "run", lambda *a, **k: calls.append(a)),
+            mock.patch.object(ips, "_invalidate_torch_runtime_probe", lambda: None),
+            mock.patch.dict(os.environ, {"UNSLOTH_RESPECT_PM_POLICY": "1"}),
+        ):
+            sp.run.return_value = mock.Mock(returncode = 2, stdout = "")
+            sp.PIPE, sp.STDOUT = -1, -2
+            with pytest.raises(SystemExit) as exit_info:
+                ips.pip_install("deps", "somepackage")
+        assert exit_info.value.code == 2
+        assert calls == [], "the pip fallback must not run under the opt-out"
+
+    def test_the_pip_fallback_still_runs_by_default(self):
+        """The whole point of #8530's fix: uv failing must not end the install."""
+        calls: list = []
+
+        with (
+            mock.patch.object(ips, "USE_UV", True),
+            mock.patch.object(ips, "subprocess") as sp,
+            mock.patch.object(ips, "run", lambda *a, **k: calls.append(a)),
+            mock.patch.object(ips, "_invalidate_torch_runtime_probe", lambda: None),
+            mock.patch.dict(os.environ, {}, clear = True),
+        ):
+            sp.run.return_value = mock.Mock(returncode = 2, stdout = "")
+            sp.PIPE, sp.STDOUT = -1, -2
+            ips.pip_install("deps", "somepackage")
+        assert len(calls) == 1, "uv failing must still fall back to pip by default"
+
+    def test_uv_only_binary_counts_as_policy(self):
+        """_uv_staging_plan already treats UV_ONLY_BINARY as uv's artifact policy, so the
+        policy set that drives detection and the pinned scrub must agree with it."""
+        assert "UV_ONLY_BINARY" in ips._PM_POLICY_ENV_VARS
+        assert "UV_ONLY_BINARY_PACKAGE" in ips._PM_POLICY_ENV_VARS
+
+
+class TestConfigDetectionReadsValuesNotJustKeys:
+    """The notice is only worth printing if it is accurate in both directions."""
+
+    def _names(self, environment, pip_ok = False, pip_config = "", uv_files = ()):
+        ips._hardened_pm_policy_names.cache_clear()
+        runner = (
+            mock.Mock(return_value = mock.Mock(returncode = 0, stdout = pip_config.encode()))
+            if pip_ok
+            else mock.Mock(side_effect = OSError("no pip"))
+        )
+        with (
+            mock.patch.dict(os.environ, environment, clear = True),
+            mock.patch.object(ips.subprocess, "run", runner),
+            mock.patch.object(ips, "_hardened_uv_config_paths", lambda: list(uv_files)),
+            mock.patch.object(ips, "_hardened_pip_config_paths", lambda: []),
+        ):
+            names = ips._hardened_pm_policy_names()
+        ips._hardened_pm_policy_names.cache_clear()
+        return names
+
+    @pytest.mark.parametrize(
+        "body, expected",
+        [
+            ("no-build = true\n", ("uv.toml no-build",)),
+            # A disabled policy is an ordinary machine; reporting it puts a security
+            # notice in front of someone who switched the control off.
+            ("no-build = false\n", ()),
+            ("no-binary = false\n", ()),
+            ("no-build-package = []\n", ()),
+            ('no-build-package = ["torch"]\n', ("uv.toml no-build-package",)),
+            ('exclude-newer = "2024-01-01T00:00:00Z"\n', ("uv.toml exclude-newer",)),
+            ("# no-build = true\n", ()),
+            ("no-build-isolation = true\n", ()),
+            ("[pip]\nrequire-hashes = true\n", ("uv.toml require-hashes",)),
+            # uv reads none of this table, so neither do we.
+            ("[tool.other]\nno-build = true\n", ()),
+        ],
+    )
+    def test_uv_toml_values_are_parsed(self, tmp_path, body, expected):
+        config = tmp_path / "uv.toml"
+        config.write_text(body, encoding = "utf-8")
+        assert self._names({}, uv_files = [str(config)]) == expected
+
+    def test_pyproject_is_read_only_under_tool_uv(self, tmp_path):
+        """Measured on uv 0.12.1: a cwd pyproject's [tool.uv.pip] require-hashes DOES
+        fail a uv pip install ("Found workspace configuration" in -v), so it is real
+        policy. A parent directory's pyproject is NOT read, and neither is a bare
+        parent uv.toml, so neither is claimed here."""
+        config = tmp_path / "pyproject.toml"
+        config.write_text(
+            '[project]\nname = "x"\nversion = "1"\n[tool.uv.pip]\nrequire-hashes = true\n',
+            encoding = "utf-8",
+        )
+        assert self._names({}, uv_files = [str(config)]) == ("pyproject.toml require-hashes",)
+        config.write_text(
+            '[project]\nname = "x"\nversion = "1"\n[tool.poetry]\nno-build = true\n',
+            encoding = "utf-8",
+        )
+        assert self._names({}, uv_files = [str(config)]) == ()
+
+    def test_the_regex_fallback_agrees_with_the_parser(self, tmp_path):
+        """3.9/3.10 have no tomllib. The fallback must still test the value."""
+        config = tmp_path / "uv.toml"
+        for body, expected in (
+            ("no-build = true\n", ("uv.toml no-build",)),
+            ("no-build = false\n", ()),
+            ("  no-build   =   true  \n", ("uv.toml no-build",)),
+            ("# no-build = true\n", ()),
+        ):
+            config.write_text(body, encoding = "utf-8")
+            with mock.patch.object(ips, "_tomllib", None):
+                assert self._names({}, uv_files = [str(config)]) == expected
+
+    def test_pip_config_is_read_directly_when_pip_is_missing(self, tmp_path):
+        """install.sh builds the venv with uv, which seeds no pip, so at the moment the
+        notice runs `python -m pip config list` fails -- while the pip FALLBACK later in
+        the same install reads pip.conf perfectly well."""
+        config = tmp_path / "pip.conf"
+        config.write_text("[global]\nrequire-hashes = true\nindex-url = https://m/s\n",
+                          encoding = "utf-8")
+        ips._hardened_pm_policy_names.cache_clear()
+        with (
+            mock.patch.dict(os.environ, {}, clear = True),
+            mock.patch.object(ips.subprocess, "run", mock.Mock(side_effect = OSError)),
+            mock.patch.object(ips, "_hardened_uv_config_paths", lambda: []),
+            mock.patch.object(ips, "_hardened_pip_config_paths", lambda: [str(config)]),
+        ):
+            names = ips._hardened_pm_policy_names()
+        ips._hardened_pm_policy_names.cache_clear()
+        assert names == ("pip.conf require-hashes",), "a mirror is not hardening"
+
+    def test_pip_files_are_not_double_read_when_pip_answers(self, tmp_path):
+        """pip merges global/user/site in its own order and reports the winner, so when
+        the subprocess works its answer is the whole answer."""
+        config = tmp_path / "pip.conf"
+        config.write_text("[global]\nonly-binary = :all:\n", encoding = "utf-8")
+        ips._hardened_pm_policy_names.cache_clear()
+        with (
+            mock.patch.dict(os.environ, {}, clear = True),
+            mock.patch.object(
+                ips.subprocess, "run",
+                mock.Mock(return_value = mock.Mock(
+                    returncode = 0, stdout = b"global.require-hashes='true'\n")),
+            ),
+            mock.patch.object(ips, "_hardened_uv_config_paths", lambda: []),
+            mock.patch.object(ips, "_hardened_pip_config_paths", lambda: [str(config)]),
+        ):
+            names = ips._hardened_pm_policy_names()
+        ips._hardened_pm_policy_names.cache_clear()
+        assert names == ("pip.conf require-hashes",)
+
+    def test_devnull_pip_config_means_no_files_at_all(self):
+        """Documented pip behaviour: PIP_CONFIG_FILE=os.devnull disables the loading of
+        ALL configuration files, so there is nothing to report."""
+        with mock.patch.dict(os.environ, {"PIP_CONFIG_FILE": os.devnull}, clear = True):
+            assert ips._hardened_pip_config_paths() == []
+
+    def test_documented_pip_locations_are_searched(self):
+        with (
+            mock.patch.dict(os.environ, {"HOME": "/home/u"}, clear = True),
+            mock.patch.object(ips, "IS_WINDOWS", False),
+            mock.patch.object(ips, "IS_MACOS", False),
+            mock.patch.object(os.path, "isfile", lambda path: True),
+        ):
+            posix = ips._hardened_pip_config_paths()
+        assert "/etc/pip.conf" in posix
+        assert "/etc/xdg/pip/pip.conf" in posix
+        assert "/home/u/.config/pip/pip.conf" in posix
+        assert "/home/u/.pip/pip.conf" in posix
+        with (
+            mock.patch.dict(os.environ, {"HOME": "/home/u"}, clear = True),
+            mock.patch.object(ips, "IS_WINDOWS", False),
+            mock.patch.object(ips, "IS_MACOS", True),
+            mock.patch.object(os.path, "isfile", lambda path: True),
+        ):
+            macos = ips._hardened_pip_config_paths()
+        assert "/home/u/Library/Application Support/pip/pip.conf" in macos
+        with (
+            mock.patch.dict(
+                os.environ, {"APPDATA": "C:\\a", "PROGRAMDATA": "C:\\pd"}, clear = True
+            ),
+            mock.patch.object(ips, "IS_WINDOWS", True),
+            mock.patch.object(os.path, "isfile", lambda path: True),
+        ):
+            windows = ips._hardened_pip_config_paths()
+        assert all(path.endswith("pip.ini") for path in windows if "pip" in path)
+        assert any("C:\\pd" in path for path in windows)
+
+    def test_a_malformed_pip_conf_is_survivable(self, tmp_path):
+        config = tmp_path / "pip.conf"
+        config.write_text("this is not ini at all\n[[[\n", encoding = "utf-8")
+        assert ips._hardened_keys_in_ini(config.read_text(encoding = "utf-8")) == []
 
 
 class TestPolicyEnvIsPlatformAndHardwareInvariant:

--- a/tests/python/test_install_python_stack.py
+++ b/tests/python/test_install_python_stack.py
@@ -26,6 +26,18 @@ import install_python_stack as ips
 
 
 @pytest.fixture(autouse = True)
+def _neutral_policy_environment(monkeypatch):
+    """Run as an ordinary machine unless a test says otherwise.
+
+    UNSLOTH_RESPECT_PM_POLICY changes what several of these code paths do, so inheriting
+    it from the developer's shell rewrites the suite's subject: with it set, the metadata
+    repair and the XPU swap both decline to start and dozens of unrelated assertions
+    fail. Tests that want the opt-out set it themselves.
+    """
+    monkeypatch.delenv("UNSLOTH_RESPECT_PM_POLICY", raising = False)
+
+
+@pytest.fixture(autouse = True)
 def _clear_policy_cache():
     """_policy_scan is cached for the life of the process, which is right in an installer
     and wrong across tests: without this a scan taken under one environment answers for
@@ -609,69 +621,41 @@ class TestOperatorCanKeepTheirPolicy:
             assert os.environ["PIP_REQUIRE_HASHES"] == "1"
 
 
-class TestTheMetadataRepairCannotStrandThePackage:
-    """The repair uninstalls every record and then reinstalls from a staged wheel. If
-    that reinstall is refused, the core package is simply gone -- and under the opt-out
-    it WAS refused, because the restore names an unpinned, unhashed requirement while
-    require-hashes is in force. Measured against pip 26.2.1: "In --require-hashes mode,
-    all requirements must have their versions pinned with ==".
+class TestDestructiveRepairsDoNotStartUnderTheOptOut:
+    """Two paths uninstall something and can only finish by installing a replacement:
+    the duplicate-metadata repair and the Intel XPU triton swap. Under a hash policy
+    that replacement cannot be verified -- there is no expected digest to check it
+    against, and deriving one from the artifact just fetched would approve it with
+    itself. So neither starts, and the venv is left exactly as it was.
     """
 
-    def _staged(self, tmp_path):
-        staged = tmp_path / "staged"
-        staged.mkdir()
-        wheel = staged / "unsloth_zoo-1.0-py3-none-any.whl"
-        wheel.write_bytes(b"PK\x03\x04 not a real wheel, but a real file to hash\n")
-        return staged, wheel
+    def test_the_metadata_repair_declines_before_staging(self, capsys):
+        with mock.patch.dict(
+            os.environ, {"UNSLOTH_RESPECT_PM_POLICY": "1"}, clear = True
+        ):
+            assert ips._stage_replacement("unsloth-zoo") is None
+        out = capsys.readouterr().err
+        assert "UNSLOTH_RESPECT_PM_POLICY" in out and "leaving the install alone" in out
 
-    def test_the_default_path_still_names_the_requirement(self, tmp_path):
-        """Unchanged where nothing is hardened: same command as before this fix."""
-        staged, _ = self._staged(tmp_path)
-        with mock.patch.dict(os.environ, {}, clear = True):
-            args, cleanup = ips._staged_restore_args("unsloth-zoo", str(staged))
-        assert cleanup == ""
-        assert args == [
-            "--no-deps",
-            "--force-reinstall",
-            "--no-index",
-            "--find-links",
-            str(staged),
-            "unsloth-zoo",
-        ]
+    def test_the_default_path_still_stages(self):
+        """Nothing is skipped on an ordinary machine: the bail is opt-out only."""
+        with (
+            mock.patch.dict(os.environ, {}, clear = True),
+            mock.patch.object(ips, "USE_UV", False),
+            mock.patch.object(ips, "tempfile") as fake_tempfile,
+            mock.patch.object(ips, "pip_install_try", lambda *a, **k: False),
+        ):
+            fake_tempfile.mkdtemp.return_value = "/tmp/staging"
+            # It gets far enough to try, which is all this asserts; the staging itself
+            # is covered by TestDuplicateCoreMetadataRepair.
+            ips._stage_replacement("unsloth-zoo")
+            assert fake_tempfile.mkdtemp.called
 
-    def test_the_opt_out_restores_through_a_real_hash(self, tmp_path):
-        """Not a relaxation and not a skipped repair: the staged wheel is a local file
-        this installer just built, so its hash is knowable and the policy is satisfied
-        honestly. Measured: pip accepts this under PIP_REQUIRE_HASHES=1, and rejects it
-        with THESE PACKAGES DO NOT MATCH THE HASHES if the wheel is altered."""
-        staged, wheel = self._staged(tmp_path)
-        with mock.patch.dict(os.environ, {"UNSLOTH_RESPECT_PM_POLICY": "1"}, clear = True):
-            args, cleanup = ips._staged_restore_args("unsloth-zoo", str(staged))
-        try:
-            assert args[:4] == ["--no-deps", "--force-reinstall", "--no-index", "-r"]
-            body = pathlib.Path(cleanup).read_text(encoding = "utf-8")
-            digest = hashlib.sha256(wheel.read_bytes()).hexdigest()
-            assert str(wheel) in body and f"--hash=sha256:{digest}" in body, body
-        finally:
-            os.unlink(cleanup)
-
-    def test_a_normalised_name_still_finds_its_wheel(self, tmp_path):
-        """The wheel spells the project with an underscore and the requirement with a
-        dash, so the match has to normalise both."""
-        staged, _ = self._staged(tmp_path)
-        with mock.patch.dict(os.environ, {"UNSLOTH_RESPECT_PM_POLICY": "1"}, clear = True):
-            args, cleanup = ips._staged_restore_args("Unsloth_Zoo", str(staged))
-        assert cleanup, "the underscore spelling must match unsloth_zoo-1.0-...whl"
-        os.unlink(cleanup)
-
-    def test_a_missing_wheel_falls_back_rather_than_raising(self, tmp_path):
-        """Nothing to hash is not a crash: the caller gets the ordinary arguments and
-        whatever pip says about them."""
-        staged = tmp_path / "empty"
-        staged.mkdir()
-        with mock.patch.dict(os.environ, {"UNSLOTH_RESPECT_PM_POLICY": "1"}, clear = True):
-            args, cleanup = ips._staged_restore_args("unsloth-zoo", str(staged))
-        assert cleanup == "" and args[-1] == "unsloth-zoo"
+    def test_no_self_approving_hash_helper_survives(self):
+        """The approach this replaced hashed the wheel it had just downloaded and handed
+        that digest to the protected install, which is not what a hash policy is for."""
+        assert not hasattr(ips, "_hashed_requirement_file")
+        assert not hasattr(ips, "_staged_restore_args")
 
 
 class TestTheOptOutKeepsRestrictiveIndexSettings:
@@ -717,27 +701,6 @@ class TestTheOptOutKeepsRestrictiveIndexSettings:
             {"UNSLOTH_RESPECT_PM_POLICY": "1", "PIP_NO_INDEX": "0", "PIP_FIND_LINKS": "/w"}
         )
         assert "PIP_NO_INDEX" not in env and "PIP_FIND_LINKS" not in env
-
-
-class TestTheXpuTritonSwapCannotStrandTheVenv:
-    """The swap uninstalls generic triton and installs the downloaded wheel by path. A
-    bare file reference is rejected under require-hashes, and by then the venv has NO
-    triton and no generic distribution left to trigger a retry on.
-    """
-
-    def test_the_wheel_is_pinned_by_its_own_hash(self, tmp_path):
-        wheel = tmp_path / "triton_xpu-3.5.0-py3-none-any.whl"
-        wheel.write_bytes(b"not a real wheel, but a real file to hash\n")
-        requirements = ips._hashed_requirement_file(str(wheel))
-        try:
-            body = pathlib.Path(requirements).read_text(encoding = "utf-8")
-            digest = hashlib.sha256(wheel.read_bytes()).hexdigest()
-            assert str(wheel) in body and f"--hash=sha256:{digest}" in body, body
-        finally:
-            os.unlink(requirements)
-
-    def test_an_unreadable_wheel_is_not_an_error(self, tmp_path):
-        assert ips._hashed_requirement_file(str(tmp_path / "gone.whl")) == ""
 
 
 class TestHardenedPolicyIsAnnounced:

--- a/tests/python/test_install_python_stack.py
+++ b/tests/python/test_install_python_stack.py
@@ -728,24 +728,53 @@ class TestTheOptOutIsNotDefeatedByOurOwnEscapeHatches:
         assert env is not None and env["UV_NO_CONFIG"] == "1"
         assert env["PIP_CONFIG_FILE"] == os.devnull
 
-    def test_the_pip_fallback_is_refused_under_the_opt_out(self):
-        """pip reads none of uv's policy, so falling back to it after uv refused an
-        install runs the very command the policy rejected. Stop instead."""
+    def _fallback_calls(self, environment: dict) -> "tuple[list, object]":
         calls: list = []
-
+        raised = None
         with (
             mock.patch.object(ips, "USE_UV", True),
             mock.patch.object(ips, "subprocess") as sp,
             mock.patch.object(ips, "run", lambda *a, **k: calls.append(a)),
             mock.patch.object(ips, "_invalidate_torch_runtime_probe", lambda: None),
-            mock.patch.dict(os.environ, {"UNSLOTH_RESPECT_PM_POLICY": "1"}),
+            mock.patch.dict(os.environ, environment, clear = True),
         ):
             sp.run.return_value = mock.Mock(returncode = 2, stdout = "")
             sp.PIPE, sp.STDOUT = -1, -2
-            with pytest.raises(SystemExit) as exit_info:
+            try:
                 ips.pip_install("deps", "somepackage")
-        assert exit_info.value.code == 2
-        assert calls == [], "the pip fallback must not run under the opt-out"
+            except SystemExit as exit_info:
+                raised = exit_info
+        return calls, raised
+
+    def test_the_pip_fallback_is_refused_when_it_would_drop_a_uv_policy(self):
+        """pip reads none of uv's policy, so falling back to it after uv refused an
+        install runs the very command the policy rejected. Stop instead."""
+        calls, raised = self._fallback_calls(
+            {"UNSLOTH_RESPECT_PM_POLICY": "1", "UV_REQUIRE_HASHES": "1"}
+        )
+        assert raised is not None and raised.code == 2
+        assert calls == [], "the pip fallback must not run when it would drop the policy"
+
+    def test_the_fallback_still_runs_when_the_opt_out_drops_nothing(self):
+        """The flag alone is not a reason to refuse. An operator who sets it
+        pre-emptively on a host with no uv-only policy would otherwise have every
+        ordinary uv failure, a resolver hiccup included, turned into a fatal one."""
+        calls, raised = self._fallback_calls({"UNSLOTH_RESPECT_PM_POLICY": "1"})
+        assert raised is None, "nothing is being discarded, so nothing to refuse"
+        assert calls, "the pip fallback must still run"
+
+    def test_the_fallback_runs_when_pip_can_enforce_the_same_control(self):
+        """Both managers configured is not a gap: pip applies its own require-hashes to
+        the fallback, so the operator's policy survives it."""
+        calls, raised = self._fallback_calls(
+            {
+                "UNSLOTH_RESPECT_PM_POLICY": "1",
+                "UV_REQUIRE_HASHES": "1",
+                "PIP_REQUIRE_HASHES": "1",
+            }
+        )
+        assert raised is None
+        assert calls, "the pip fallback must still run"
 
     def test_the_pip_fallback_still_runs_by_default(self):
         """The whole point of #8530's fix: uv failing must not end the install."""
@@ -1333,6 +1362,66 @@ class TestDetectionMatchesWhatTheManagersActuallyEnforce:
     def test_a_deleted_working_directory_is_not_an_error(self):
         with mock.patch.object(os, "getcwd", mock.Mock(side_effect = OSError("gone"))):
             assert ips._uv_project_config() == []
+
+    def test_a_command_section_beats_a_global_in_a_higher_priority_file(self, tmp_path):
+        """pip pools every file's [global] into one group and every file's command
+        section into another, then applies global first and the command second, so an
+        [install] entry in a low-priority file still wins. Folding global into the
+        command sections file by file let a later [global] erase it."""
+        first = tmp_path / "user.conf"
+        first.write_text("[install]\nrequire-hashes = true\n", encoding = "utf-8")
+        second = tmp_path / "site.conf"
+        second.write_text("[global]\nrequire-hashes = false\n", encoding = "utf-8")
+        assert self._names({}, pip_files = [str(first), str(second)]) == (
+            "user.conf require-hashes",
+        )
+
+    def test_the_underscore_spelling_is_normalised(self, tmp_path):
+        """pip's _normalize_name lowercases and turns underscores into dashes, so
+        `require_hashes` is a spelling it honours. RawConfigParser keeps the underscore,
+        so matching only the dashed name read a hardened host as ordinary."""
+        config = tmp_path / "pip.conf"
+        config.write_text("[global]\nREQUIRE_HASHES = true\n", encoding = "utf-8")
+        assert self._names({}, pip_files = [str(config)]) == ("pip.conf require-hashes",)
+
+    def test_the_modern_user_file_outranks_the_legacy_one(self):
+        """pip's get_configuration_files returns the user kind as
+        [legacy_config_file, new_config_file] and loads them in that order."""
+        with (
+            mock.patch.dict(os.environ, {"HOME": "/home/u"}, clear = True),
+            _posix_home(),
+            mock.patch.object(ips, "IS_WINDOWS", False),
+            mock.patch.object(ips, "IS_MACOS", False),
+            mock.patch.object(os.path, "isfile", lambda path: True),
+        ):
+            paths = [path.replace(os.sep, "/") for path in ips._hardened_pip_config_paths()]
+        assert paths.index("/home/u/.pip/pip.conf") < paths.index(
+            "/home/u/.config/pip/pip.conf"
+        ), paths
+
+    def test_the_windows_appdata_file_outranks_the_legacy_one(self):
+        with (
+            mock.patch.dict(os.environ, {"APPDATA": "C:\\a"}, clear = True),
+            mock.patch.object(ips, "IS_WINDOWS", True),
+            mock.patch.object(os.path, "expanduser", lambda p: p.replace("~", "C:\\u", 1)),
+            mock.patch.object(os.path, "isfile", lambda path: True),
+        ):
+            # os.path.join follows the RUNNER, so normalise both separators: this test is
+            # about the ORDER of the locations, not how a platform spells a path.
+            paths = [
+                path.replace("\\", "/").replace(os.sep, "/")
+                for path in ips._hardened_pip_config_paths()
+            ]
+        assert paths.index("C:/u/pip/pip.ini") < paths.index("C:/a/pip/pip.ini"), paths
+
+    def test_an_inline_comment_is_not_part_of_the_value(self):
+        """The pre-3.11 fallback had already stripped the comment and then appended the
+        raw line anyway, so `no-build = false # disabled` read as the value
+        "false # disabled", which is not an off spelling."""
+        body = "no-build = false # disabled by the platform team\n"
+        with mock.patch.object(ips, "_tomllib", None):
+            assert ips._hardened_keys_in_toml(body, ((),)) == []
+            assert ips._hardened_keys_in_toml("no-build = true # on\n", ((),)) == ["no-build"]
 
 
 class TestPolicyEnvIsPlatformAndHardwareInvariant:

--- a/tests/python/test_install_python_stack.py
+++ b/tests/python/test_install_python_stack.py
@@ -1588,6 +1588,18 @@ class TestDetectionMatchesWhatTheManagersActuallyEnforce:
         """The refusal was right and its timing was not: the manifest is removed up
         front, so refusing at the first resolving command left an untouched venv marked
         half-built and the Desktop preflight then rejected a working environment."""
+        # uv will run the installs, and the only policy is pip's, which uv cannot see.
+        with (
+            mock.patch.dict(
+                os.environ,
+                {"UNSLOTH_RESPECT_PM_POLICY": "1", "PIP_REQUIRE_HASHES": "1"},
+                clear = True,
+            ),
+            pytest.raises(SystemExit),
+        ):
+            ips._preflight_policy_gap(use_uv = True)
+        # And the other way round, on a host with no usable uv.
+        ips._policy_scan.cache_clear()
         with (
             mock.patch.dict(
                 os.environ,
@@ -1596,14 +1608,33 @@ class TestDetectionMatchesWhatTheManagersActuallyEnforce:
             ),
             pytest.raises(SystemExit),
         ):
-            ips._preflight_policy_gap()
+            ips._preflight_policy_gap(use_uv = False)
+
+    def test_the_preflight_probes_only_the_manager_that_will_run(self):
+        """A pip-only rule on a host with no usable uv is not a gap: every real command
+        keeps it. Probing both refused an install that would have honoured the policy
+        in full, because _bootstrap_uv() had not run and the uv probe described a
+        manager the install was never going to use."""
+        with mock.patch.dict(
+            os.environ,
+            {"UNSLOTH_RESPECT_PM_POLICY": "1", "PIP_ONLY_BINARY": ":all:"},
+            clear = True,
+        ):
+            ips._preflight_policy_gap(use_uv = False)
+        ips._policy_scan.cache_clear()
+        with mock.patch.dict(
+            os.environ,
+            {"UNSLOTH_RESPECT_PM_POLICY": "1", "UV_REQUIRE_HASHES": "1"},
+            clear = True,
+        ):
+            ips._preflight_policy_gap(use_uv = True)
 
     def test_the_preflight_is_silent_without_the_opt_out(self):
         """An ordinary install must never reach the check, whatever the host has set."""
         with mock.patch.dict(
             os.environ, {"UV_REQUIRE_HASHES": "1", "PIP_ONLY_BINARY": ":all:"}, clear = True
         ):
-            ips._preflight_policy_gap()
+            ips._preflight_policy_gap(use_uv = True)
 
     def test_the_preflight_is_silent_when_both_managers_are_configured(self):
         with mock.patch.dict(
@@ -1615,7 +1646,81 @@ class TestDetectionMatchesWhatTheManagersActuallyEnforce:
             },
             clear = True,
         ):
-            ips._preflight_policy_gap()
+            ips._preflight_policy_gap(use_uv = True)
+
+    def test_a_relative_uv_project_resolves_against_uvs_directory(self, tmp_path):
+        """--directory takes effect first, so a relative --project is resolved there.
+        Measured: UV_WORKING_DIR=work UV_PROJECT=proj enforces work/proj's policy."""
+        work = tmp_path / "work"
+        (work / "proj").mkdir(parents = True)
+        (work / "proj" / "pyproject.toml").write_text('[project]\nname = "p"\n',
+                                                      encoding = "utf-8")
+        with (
+            mock.patch.dict(
+                os.environ,
+                {"UV_WORKING_DIR": str(work), "UV_PROJECT": "proj"},
+                clear = True,
+            ),
+            mock.patch.object(os, "getcwd", lambda: str(tmp_path)),
+        ):
+            assert ips._uv_project_config() == [str(work / "proj" / "pyproject.toml")]
+
+    def test_the_workspace_root_outranks_the_member_the_walk_stops_at(self, tmp_path):
+        """Measured on the pinned uv 0.12.1: from root/member/sub it logs "Found
+        workspace configuration at root/pyproject.toml" and enforces the ROOT's
+        require-hashes, not the member's absence of one."""
+        root = tmp_path / "ws"
+        (root / "member" / "sub").mkdir(parents = True)
+        (root / "pyproject.toml").write_text(
+            '[project]\nname = "root"\n[tool.uv.workspace]\nmembers = ["member"]\n',
+            encoding = "utf-8",
+        )
+        (root / "member" / "pyproject.toml").write_text('[project]\nname = "m"\n',
+                                                        encoding = "utf-8")
+        with mock.patch.object(os, "getcwd", lambda: str(root / "member" / "sub")):
+            assert ips._uv_project_config() == [str(root / "pyproject.toml")]
+        # A plain parent project with no workspace declaration still wins nothing: the
+        # nearest pyproject is uv's answer there.
+        (root / "pyproject.toml").write_text('[project]\nname = "root"\n',
+                                             encoding = "utf-8")
+        with mock.patch.object(os, "getcwd", lambda: str(root / "member" / "sub")):
+            assert ips._uv_project_config() == [str(root / "member" / "pyproject.toml")]
+
+    def test_a_resolved_explicit_config_keeps_the_standalone_schema(self, tmp_path):
+        """The schema decision compared the RAW environment value, so a relative
+        explicit file resolved through UV_WORKING_DIR stopped matching and an explicit
+        pyproject.toml was read with the discovered-project schema instead."""
+        work = tmp_path / "work"
+        work.mkdir()
+        (work / "pyproject.toml").write_text("no-build = true\n", encoding = "utf-8")
+        assert ips._explicit_uv_config_path.__doc__  # documented, not incidental
+        with mock.patch.dict(
+            os.environ,
+            {"UV_CONFIG_FILE": "pyproject.toml", "UV_WORKING_DIR": str(work)},
+            clear = True,
+        ):
+            assert ips._explicit_uv_config_path() == str(work / "pyproject.toml")
+            assert ips._hardened_uv_config_paths() == [str(work / "pyproject.toml")]
+        assert self._names(
+            {"UV_CONFIG_FILE": "pyproject.toml", "UV_WORKING_DIR": str(work)},
+            uv_files = [str(work / "pyproject.toml")],
+        ) == ("pyproject.toml no-build",)
+
+    @pytest.mark.parametrize("value", ["none", "no", "false", "off", "0"])
+    def test_an_artifact_list_value_is_a_package_name_not_a_boolean(self, value):
+        """pip documents `:none:` as the way to clear --only-binary, and everything else
+        as package names, so PIP_ONLY_BINARY=no restricts a distribution called "no".
+        Reading it as a disabled flag dropped an artifact rule that was in force."""
+        assert self._names({"PIP_ONLY_BINARY": value}) == ("PIP_ONLY_BINARY",)
+        # The two spellings that really do clear it.
+        assert self._names({"PIP_ONLY_BINARY": ":none:"}) == ()
+        assert self._names({"PIP_ONLY_BINARY": ""}) == ()
+
+    @pytest.mark.parametrize("value", ["no", "false", "off", "0"])
+    def test_a_boolean_control_still_reads_pips_false_spellings(self, value):
+        """require-hashes and no-build are the two that ARE booleans."""
+        assert self._names({"PIP_REQUIRE_HASHES": value}) == ()
+        assert self._names({"PIP_REQUIRE_HASHES": "1"}) == ("PIP_REQUIRE_HASHES",)
 
     def test_an_inline_comment_is_not_part_of_the_value(self):
         """The pre-3.11 fallback had already stripped the comment and then appended the

--- a/tests/python/test_install_python_stack.py
+++ b/tests/python/test_install_python_stack.py
@@ -719,6 +719,27 @@ class TestTheOptOutKeepsRestrictiveIndexSettings:
         assert "PIP_NO_INDEX" not in env and "PIP_FIND_LINKS" not in env
 
 
+class TestTheXpuTritonSwapCannotStrandTheVenv:
+    """The swap uninstalls generic triton and installs the downloaded wheel by path. A
+    bare file reference is rejected under require-hashes, and by then the venv has NO
+    triton and no generic distribution left to trigger a retry on.
+    """
+
+    def test_the_wheel_is_pinned_by_its_own_hash(self, tmp_path):
+        wheel = tmp_path / "triton_xpu-3.5.0-py3-none-any.whl"
+        wheel.write_bytes(b"not a real wheel, but a real file to hash\n")
+        requirements = ips._hashed_requirement_file(str(wheel))
+        try:
+            body = pathlib.Path(requirements).read_text(encoding = "utf-8")
+            digest = hashlib.sha256(wheel.read_bytes()).hexdigest()
+            assert str(wheel) in body and f"--hash=sha256:{digest}" in body, body
+        finally:
+            os.unlink(requirements)
+
+    def test_an_unreadable_wheel_is_not_an_error(self, tmp_path):
+        assert ips._hashed_requirement_file(str(tmp_path / "gone.whl")) == ""
+
+
 class TestHardenedPolicyIsAnnounced:
     """The relaxation is defensible; doing it silently is not.
 
@@ -771,6 +792,26 @@ class TestHardenedPolicyIsAnnounced:
         assert self._names({"UV_EXCLUDE_NEWER": "2005-01-01T00:00:00Z"}) == ("UV_EXCLUDE_NEWER",)
         # Still not a boolean elsewhere: a package list keeps package names.
         assert self._names({"PIP_ONLY_BINARY": "false"}) == ("PIP_ONLY_BINARY",)
+
+    def test_a_control_disabled_for_every_command_is_not_reported(self):
+        """pip applies [global] then the command's own section, so a control enabled
+        globally and disabled for install, download AND wheel hardens nothing this
+        module runs. Reporting it put the notice in front of someone whose policy was
+        not being relaxed at all."""
+        listing = (
+            "global.require-hashes='true'\ninstall.require-hashes='false'\n"
+            "download.require-hashes='false'\nwheel.require-hashes='false'\n"
+        )
+        assert self._names({}, listing) == ()
+        # Disabled for only ONE of them still leaves the other two hardened.
+        partial = "global.require-hashes='true'\ninstall.require-hashes='false'\n"
+        assert self._names({}, partial) == ("pip.conf require-hashes",)
+
+    def test_an_explicit_no_index_is_reported(self):
+        """no-index REMOVES every remote source, and the pinned branch discards it with
+        the rest of pip.conf, which is exactly what this notice exists to disclose."""
+        assert self._names({}, "global.no-index='true'\n") == ("pip.conf no-index",)
+        assert self._names({}, "global.no-index='false'\n") == ()
 
     def test_uv_policy_is_reported_from_the_variables_uv_reads(self):
         """uv has no command that prints its resolved configuration, so the notice

--- a/tests/python/test_install_python_stack.py
+++ b/tests/python/test_install_python_stack.py
@@ -540,11 +540,14 @@ class TestOperatorCanKeepTheirPolicy:
 
     @pytest.mark.parametrize("value", ["1", "true", "yes"])
     def test_the_pip_fallback_keeps_hash_mode(self, value):
+        """The relaxation is withdrawn. The env is no longer None, because the uv-side
+        controls in HOSTILE are now restated for pip, but the one thing that must never
+        appear is the hash relaxation itself."""
         with mock.patch.dict(os.environ, dict(self.HOSTILE, UNSLOTH_RESPECT_PM_POLICY = value)):
-            assert (
-                ips._install_env_for_cmd(["python", "-m", "pip", "install", "-r", "extras.txt"])
-                is None
-            ), "the opt-out must leave the child env untouched"
+            env = ips._install_env_for_cmd(
+                ["python", "-m", "pip", "install", "-r", "extras.txt"]
+            )
+        assert env is None or env.get("PIP_REQUIRE_HASHES") != "0"
 
     @pytest.mark.parametrize("value", ["", "0", "false", "no"])
     def test_off_and_unset_spellings_keep_the_default(self, value):
@@ -960,7 +963,9 @@ class TestNeitherManagerIsLetOffTheOthersPolicy:
     """
 
     def _detect(self, entries):
-        return mock.patch.object(ips, "_detected_policy", lambda: tuple(entries))
+        """Entries are (tool, source, key) or (tool, source, key, value)."""
+        full = tuple(e if len(e) == 4 else (*e, "1") for e in entries)
+        return mock.patch.object(ips, "_detected_policy", lambda: full)
 
     def test_pip_policy_reaches_a_uv_command(self):
         with (
@@ -983,7 +988,7 @@ class TestNeitherManagerIsLetOffTheOthersPolicy:
         """pip's only-binary is "wheels only", which uv spells as no-build."""
         with (
             mock.patch.dict(os.environ, {"UNSLOTH_RESPECT_PM_POLICY": "1"}, clear = True),
-            self._detect([("pip", "pip.conf", "only-binary")]),
+            self._detect([("pip", "pip.conf", "only-binary", ":all:")]),
         ):
             env = ips._install_env_for_cmd(["uv", "pip", "install", "x"])
         assert env is not None and env["UV_NO_BUILD"] == "1"
@@ -1153,6 +1158,190 @@ class TestPipGlobalConfigFollowsXdg:
         ):
             paths = [path.replace(os.sep, "/") for path in ips._hardened_pip_config_paths()]
         assert "/d/pip/pip.conf" in paths
+
+
+class TestTranslationKeepsTheOperatorsActualPolicy:
+    """A translation that is stricter than the policy it claims to honour is its own bug.
+
+    Promoting `PIP_ONLY_BINARY=numpy` to a global `UV_NO_BUILD=1` fails the extras step on
+    wheel-less dependencies the operator's policy permits, so the opt-out would break an
+    install nobody asked it to break.
+    """
+
+    def _detect(self, entries):
+        full = tuple(e if len(e) == 4 else (*e, "1") for e in entries)
+        return mock.patch.object(ips, "_detected_policy", lambda: full)
+
+    def _env(self, entries, cmd, extra = None):
+        environment = {"UNSLOTH_RESPECT_PM_POLICY": "1"}
+        environment.update(extra or {})
+        with mock.patch.dict(os.environ, environment, clear = True), self._detect(entries):
+            return ips._install_env_for_cmd(list(cmd))
+
+    def test_a_scoped_pip_policy_stays_scoped_in_uv(self):
+        env = self._env(
+            [("pip", "env", "PIP_ONLY_BINARY", "numpy,scipy")],
+            ["uv", "pip", "install", "x"],
+        )
+        assert env is not None
+        assert env["UV_NO_BUILD_PACKAGE"] == "numpy scipy"
+        assert "UV_NO_BUILD" not in env, "a policy about two packages is not a global one"
+
+    def test_an_all_pip_policy_becomes_a_global_uv_one(self):
+        env = self._env(
+            [("pip", "env", "PIP_ONLY_BINARY", ":all:")], ["uv", "pip", "install", "x"]
+        )
+        assert env is not None and env["UV_NO_BUILD"] == "1"
+        assert "UV_NO_BUILD_PACKAGE" not in env
+
+    def test_a_scoped_uv_policy_stays_scoped_in_pip(self):
+        env = self._env(
+            [("uv", "env", "UV_NO_BUILD_PACKAGE", "numpy scipy")],
+            ["python", "-m", "pip", "install", "x"],
+        )
+        assert env is not None
+        assert env["PIP_ONLY_BINARY"] == "numpy,scipy", "pip separates names with commas"
+
+    def test_a_global_uv_policy_becomes_all_in_pip(self):
+        env = self._env(
+            [("uv", "uv.toml", "no-build", "1")], ["python", "-m", "pip", "install", "x"]
+        )
+        assert env is not None and env["PIP_ONLY_BINARY"] == ":all:"
+
+    def test_a_global_setting_beats_a_scoped_one_when_both_are_present(self):
+        env = self._env(
+            [("uv", "env", "UV_NO_BUILD", "1"),
+             ("uv", "env", "UV_NO_BUILD_PACKAGE", "numpy")],
+            ["python", "-m", "pip", "install", "x"],
+        )
+        assert env is not None and env["PIP_ONLY_BINARY"] == ":all:"
+
+    def test_the_upload_cutoff_is_translated_for_pip(self):
+        """Verified that pip reads the variable: an invalid PIP_UPLOADED_PRIOR_TO makes
+        pip 26.2.1 fail with an ISO 8601 parse error, so it is not being ignored."""
+        with mock.patch.object(ips, "_pip_supports_upload_cutoff", lambda: True):
+            env = self._env(
+                [("uv", "env", "UV_EXCLUDE_NEWER", "2024-01-01T00:00:00Z")],
+                ["python", "-m", "pip", "install", "x"],
+            )
+        assert env is not None
+        assert env["PIP_UPLOADED_PRIOR_TO"] == "2024-01-01T00:00:00Z"
+
+    def test_an_unenforceable_cutoff_refuses_rather_than_dropping_it(self):
+        """pip grew --uploaded-prior-to in 25.3. Below that, silently continuing would
+        let the install pick an artifact the retained policy excludes; _uv_upload_cutoff_args
+        already answers the same way for the staging path."""
+        with mock.patch.object(ips, "_pip_supports_upload_cutoff", lambda: False):
+            with pytest.raises(SystemExit):
+                self._env(
+                    [("uv", "env", "UV_EXCLUDE_NEWER", "2024-01-01T00:00:00Z")],
+                    ["python", "-m", "pip", "install", "x"],
+                )
+
+    def test_a_cutoff_does_not_touch_a_uv_command(self):
+        """uv reads UV_EXCLUDE_NEWER itself; only the pip path needs the translation."""
+        env = self._env(
+            [("uv", "env", "UV_EXCLUDE_NEWER", "2024-01-01T00:00:00Z")],
+            ["uv", "pip", "install", "x"],
+        )
+        assert env is None
+
+
+class TestDetectionMatchesPipsOwnRules:
+    """Each of these was checked against pip's source or measured, not assumed."""
+
+    def _names(self, environment, pip_ok = False, pip_config = "", uv_files = (),
+               pip_files = ()):
+        ips._detected_policy.cache_clear()
+        runner = (
+            mock.Mock(return_value = mock.Mock(returncode = 0, stdout = pip_config.encode()))
+            if pip_ok
+            else mock.Mock(side_effect = OSError("no pip"))
+        )
+        with (
+            mock.patch.dict(os.environ, environment, clear = True),
+            mock.patch.object(ips.subprocess, "run", runner),
+            mock.patch.object(ips, "_hardened_uv_config_paths", lambda: list(uv_files)),
+            mock.patch.object(ips, "_hardened_pip_config_paths", lambda: list(pip_files)),
+        ):
+            names = ips._hardened_pm_policy_names()
+        ips._detected_policy.cache_clear()
+        return names
+
+    @pytest.mark.parametrize("value", ["off", "n", "f", "no", "false", "0", ""])
+    def test_pips_false_spellings_are_all_disabled(self, value):
+        """pip's strtobool: false is n, no, f, false, off, 0. `off`, `n` and `f` were
+        being read as ENABLED, which under the opt-out translated a disabled setting
+        into a uv control and failed the install."""
+        assert self._names({"PIP_REQUIRE_HASHES": value}) == ()
+
+    @pytest.mark.parametrize("value", ["on", "y", "t", "yes", "true", "1"])
+    def test_pips_true_spellings_are_all_enabled(self, value):
+        assert self._names({"PIP_REQUIRE_HASHES": value}) == ("PIP_REQUIRE_HASHES",)
+
+    def test_a_disabled_environment_variable_cancels_a_config_file(self, tmp_path):
+        """pip's environment beats every config file, so a config that enables a control
+        the environment explicitly disables is not policy. Reporting it printed a notice
+        and, under the opt-out, translated the cancelled setting into uv and failed."""
+        config = tmp_path / "pip.conf"
+        config.write_text("[global]\nrequire-hashes = true\n", encoding = "utf-8")
+        assert self._names(
+            {"PIP_REQUIRE_HASHES": "0"}, pip_files = [str(config)]
+        ) == ()
+        # Without the cancelling variable it is reported normally.
+        assert self._names({}, pip_files = [str(config)]) == ("pip.conf require-hashes",)
+
+    def test_the_command_section_beats_global_whatever_the_order(self):
+        """pip applies [global] then the command's own section, independent of textual
+        order, so [install] wins for the commands this module runs."""
+        body = "[install]\nrequire-hashes = true\n[global]\nrequire-hashes = false\n"
+        assert ips._hardened_settings_in_ini(body) == {"require-hashes": "true"}
+        body = "[global]\nrequire-hashes = false\n[install]\nrequire-hashes = true\n"
+        assert ips._hardened_settings_in_ini(body) == {"require-hashes": "true"}
+
+    def test_a_section_for_another_command_is_ignored(self):
+        assert ips._hardened_settings_in_ini("[freeze]\nrequire-hashes = true\n") == {}
+
+    def test_config_list_ranks_sections_too(self):
+        listing = "install.require-hashes='true'\nglobal.require-hashes='false'\n"
+        assert self._names({}, pip_ok = True, pip_config = listing) == (
+            "pip.conf require-hashes",
+        )
+
+    def test_user_configs_are_skipped_when_an_explicit_file_exists(self, tmp_path):
+        """pip's iter_config_files: "per-user config is not loaded when env_config_file
+        exists". Scanning them anyway invents a policy pip would not apply."""
+        explicit = tmp_path / "explicit.conf"
+        explicit.write_text("[global]\ntimeout = 60\n", encoding = "utf-8")
+        with (
+            mock.patch.dict(
+                os.environ,
+                {"HOME": "/home/u", "PIP_CONFIG_FILE": str(explicit)},
+                clear = True,
+            ),
+            _posix_home(),
+            mock.patch.object(ips, "IS_WINDOWS", False),
+            mock.patch.object(ips, "IS_MACOS", False),
+            mock.patch.object(
+                os.path, "isfile", lambda path: True
+            ),
+        ):
+            paths = [path.replace(os.sep, "/") for path in ips._hardened_pip_config_paths()]
+        assert not any("/home/u/.config/pip" in path for path in paths)
+        assert not any("/home/u/.pip" in path for path in paths)
+        assert "/etc/pip.conf" in paths, "global and site are still loaded"
+        assert str(explicit).replace(os.sep, "/") in paths
+
+    def test_the_windows_legacy_user_config_is_searched(self):
+        """pip's get_configuration_files still returns ~/pip/pip.ini on Windows."""
+        with (
+            mock.patch.dict(os.environ, {"APPDATA": "C:\\a"}, clear = True),
+            mock.patch.object(ips, "IS_WINDOWS", True),
+            mock.patch.object(os.path, "expanduser", lambda p: p.replace("~", "C:\\u", 1)),
+            mock.patch.object(os.path, "isfile", lambda path: True),
+        ):
+            paths = ips._hardened_pip_config_paths()
+        assert any(path.startswith("C:\\u") and path.endswith("pip.ini") for path in paths)
 
 
 class TestPolicyEnvIsPlatformAndHardwareInvariant:

--- a/tests/python/test_install_python_stack.py
+++ b/tests/python/test_install_python_stack.py
@@ -1548,6 +1548,75 @@ class TestDetectionMatchesWhatTheManagersActuallyEnforce:
             ((), ("pip",)),
         ) == ["exclude-newer-package"]
 
+    def test_a_relative_explicit_config_resolves_against_uvs_directory(self, tmp_path):
+        """--directory changes directory before running, so a relative --config-file is
+        resolved there. Measured: UV_WORKING_DIR=work UV_CONFIG_FILE=cfg.toml enforces
+        require-hashes, while the same relative path without it cannot even be opened."""
+        work = tmp_path / "work"
+        work.mkdir()
+        (work / "cfg.toml").write_text("[pip]\nrequire-hashes = true\n", encoding = "utf-8")
+        with mock.patch.dict(
+            os.environ,
+            {"UV_CONFIG_FILE": "cfg.toml", "UV_WORKING_DIR": str(work)},
+            clear = True,
+        ):
+            assert ips._hardened_uv_config_paths() == [str(work / "cfg.toml")]
+        # An absolute path is left alone.
+        absolute = str(work / "cfg.toml")
+        with mock.patch.dict(
+            os.environ,
+            {"UV_CONFIG_FILE": absolute, "UV_WORKING_DIR": str(tmp_path)},
+            clear = True,
+        ):
+            assert ips._hardened_uv_config_paths() == [absolute]
+
+    def test_pip_section_names_are_case_sensitive(self, tmp_path):
+        """pip normalises the OPTION name and leaves the SECTION name alone, so
+        `[INSTALL]` is a section it never selects. Measured with pip 26.2.1: an
+        `[INSTALL] require-hashes = true` installs happily, `[install]` does not."""
+        config = tmp_path / "pip.conf"
+        config.write_text("[INSTALL]\nrequire-hashes = true\n", encoding = "utf-8")
+        assert self._names({}, pip_files = [str(config)]) == ()
+        config.write_text("[install]\nrequire-hashes = true\n", encoding = "utf-8")
+        assert self._names({}, pip_files = [str(config)]) == ("pip.conf require-hashes",)
+
+    def test_config_list_keeps_section_case_too(self):
+        listing = "INSTALL.require-hashes='true'\n"
+        assert self._names({}, pip_ok = True, pip_config = listing) == ()
+
+    def test_a_gap_is_refused_before_the_manifest_is_touched(self):
+        """The refusal was right and its timing was not: the manifest is removed up
+        front, so refusing at the first resolving command left an untouched venv marked
+        half-built and the Desktop preflight then rejected a working environment."""
+        with (
+            mock.patch.dict(
+                os.environ,
+                {"UNSLOTH_RESPECT_PM_POLICY": "1", "UV_REQUIRE_HASHES": "1"},
+                clear = True,
+            ),
+            pytest.raises(SystemExit),
+        ):
+            ips._preflight_policy_gap()
+
+    def test_the_preflight_is_silent_without_the_opt_out(self):
+        """An ordinary install must never reach the check, whatever the host has set."""
+        with mock.patch.dict(
+            os.environ, {"UV_REQUIRE_HASHES": "1", "PIP_ONLY_BINARY": ":all:"}, clear = True
+        ):
+            ips._preflight_policy_gap()
+
+    def test_the_preflight_is_silent_when_both_managers_are_configured(self):
+        with mock.patch.dict(
+            os.environ,
+            {
+                "UNSLOTH_RESPECT_PM_POLICY": "1",
+                "UV_REQUIRE_HASHES": "1",
+                "PIP_REQUIRE_HASHES": "1",
+            },
+            clear = True,
+        ):
+            ips._preflight_policy_gap()
+
     def test_an_inline_comment_is_not_part_of_the_value(self):
         """The pre-3.11 fallback had already stripped the comment and then appended the
         raw line anyway, so `no-build = false # disabled` read as the value

--- a/tests/python/test_install_python_stack.py
+++ b/tests/python/test_install_python_stack.py
@@ -28,9 +28,9 @@ def _clear_policy_cache():
     """_policy_scan is cached for the life of the process, which is right in an installer
     and wrong across tests: without this a scan taken under one environment answers for
     the next one."""
-    ips._policy_scan.cache_clear()
+    ips._detected_policy.cache_clear()
     yield
-    ips._policy_scan.cache_clear()
+    ips._detected_policy.cache_clear()
 
 
 def _posix_home(path: str = "/home/u"):
@@ -620,17 +620,16 @@ class TestHardenedPolicyIsAnnounced:
         env: dict,
         pip_config: str = "",
     ):
-        ips._policy_scan.cache_clear()
+        ips._detected_policy.cache_clear()
         result = mock.Mock(returncode = 0, stdout = pip_config.encode())
         with (
             mock.patch.dict(os.environ, env, clear = True),
             mock.patch.object(ips.subprocess, "run", return_value = result),
-            mock.patch.object(ips, "_hardened_uv_config_paths", lambda: []),
         ):
             try:
                 return ips._hardened_pm_policy_names()
             finally:
-                ips._policy_scan.cache_clear()
+                ips._detected_policy.cache_clear()
 
     def test_an_ordinary_machine_says_nothing(self):
         assert self._names({}) == ()
@@ -651,18 +650,24 @@ class TestHardenedPolicyIsAnnounced:
         names = self._names({"PIP_REQUIRE_HASHES": "1"}, ":env:.require-hashes='true'\n")
         assert names == ("PIP_REQUIRE_HASHES",)
 
-    def test_uv_config_hardening_is_reported(self, tmp_path):
-        config = tmp_path / "uv.toml"
-        config.write_text("# no-build = true\nno-build = true\n", encoding = "utf-8")
-        ips._policy_scan.cache_clear()
-        with (
-            mock.patch.dict(os.environ, {}, clear = True),
-            mock.patch.object(ips.subprocess, "run", side_effect = OSError),
-            mock.patch.object(ips, "_hardened_uv_config_paths", lambda: [str(config)]),
+    def test_uv_policy_is_reported_from_the_variables_uv_reads(self):
+        """uv has no command that prints its resolved configuration, so the notice
+        reports the two variables uv genuinely honours and does not go looking through
+        uv.toml. Measured on the pinned uv 0.12.1: UV_REQUIRE_HASHES and
+        UV_EXCLUDE_NEWER change the outcome, UV_NO_BUILD and the other artifact
+        spellings are ignored, so reporting one would name policy uv does not apply."""
+        assert self._names({"UV_REQUIRE_HASHES": "1"}) == ("UV_REQUIRE_HASHES",)
+        assert self._names({"UV_NO_BUILD": "1"}) == ()
+
+    def test_an_undetected_setting_costs_a_line_not_an_install(self):
+        """The point of keeping detection advisory: with nothing detected the notice is
+        silent, and the opt-out still withholds every relaxation."""
+        assert self._names({}) == ()
+        with mock.patch.dict(
+            os.environ, {"UNSLOTH_RESPECT_PM_POLICY": "1"}, clear = True
         ):
-            names = ips._hardened_pm_policy_names()
-        ips._policy_scan.cache_clear()
-        assert names == ("uv.toml no-build",)
+            assert ips._relaxed_pip_policy_env(["python", "-m", "pip", "install", "x"]) == {}
+            assert ips._sdist_only_build_args("diffusers") == []
 
     def test_the_notice_names_the_opt_out(self, capsys):
         with (
@@ -746,14 +751,20 @@ class TestTheOptOutIsNotDefeatedByOurOwnEscapeHatches:
                 raised = exit_info
         return calls, raised
 
-    def test_the_pip_fallback_is_refused_when_it_would_drop_a_uv_policy(self):
-        """pip reads none of uv's policy, so falling back to it after uv refused an
-        install runs the very command the policy rejected. Stop instead."""
+    def test_the_fallback_runs_under_the_opt_out_without_relaxing_anything(self):
+        """uv failing must not end the install, opt-out or not. pip then applies whatever
+        pip is configured with: uv's settings were never pip's to read, which is a
+        property of the two tools rather than something this installer introduces.
+        What the opt-out promises is that OUR relaxations are withheld, and they are."""
         calls, raised = self._fallback_calls(
             {"UNSLOTH_RESPECT_PM_POLICY": "1", "UV_REQUIRE_HASHES": "1"}
         )
-        assert raised is not None and raised.code == 2
-        assert calls == [], "the pip fallback must not run when it would drop the policy"
+        assert raised is None
+        assert calls, "the pip fallback must still run"
+        with mock.patch.dict(
+            os.environ, {"UNSLOTH_RESPECT_PM_POLICY": "1"}, clear = True
+        ):
+            assert ips._relaxed_pip_policy_env(["python", "-m", "pip", "install", "x"]) == {}
 
     def test_the_fallback_still_runs_when_the_opt_out_drops_nothing(self):
         """The flag alone is not a reason to refuse. An operator who sets it
@@ -797,939 +808,6 @@ class TestTheOptOutIsNotDefeatedByOurOwnEscapeHatches:
         policy set that drives detection and the pinned scrub must agree with it."""
         assert "UV_ONLY_BINARY" in ips._PM_POLICY_ENV_VARS
         assert "UV_ONLY_BINARY_PACKAGE" in ips._PM_POLICY_ENV_VARS
-
-
-class TestConfigDetectionReadsValuesNotJustKeys:
-    """The notice is only worth printing if it is accurate in both directions."""
-
-    def _names(
-        self,
-        environment,
-        pip_ok = False,
-        pip_config = "",
-        uv_files = (),
-    ):
-        ips._policy_scan.cache_clear()
-        runner = (
-            mock.Mock(return_value = mock.Mock(returncode = 0, stdout = pip_config.encode()))
-            if pip_ok
-            else mock.Mock(side_effect = OSError("no pip"))
-        )
-        with (
-            mock.patch.dict(os.environ, environment, clear = True),
-            mock.patch.object(ips.subprocess, "run", runner),
-            mock.patch.object(ips, "_hardened_uv_config_paths", lambda: list(uv_files)),
-            mock.patch.object(ips, "_hardened_pip_config_paths", lambda: []),
-        ):
-            names = ips._hardened_pm_policy_names()
-        ips._policy_scan.cache_clear()
-        return names
-
-    @pytest.mark.parametrize(
-        "body, expected",
-        [
-            ("no-build = true\n", ("uv.toml no-build",)),
-            # A disabled policy is an ordinary machine; reporting it puts a security
-            # notice in front of someone who switched the control off.
-            ("no-build = false\n", ()),
-            ("no-binary = false\n", ()),
-            ("no-build-package = []\n", ()),
-            ('no-build-package = ["torch"]\n', ("uv.toml no-build-package",)),
-            ('exclude-newer = "2024-01-01T00:00:00Z"\n', ("uv.toml exclude-newer",)),
-            ("# no-build = true\n", ()),
-            ("no-build-isolation = true\n", ()),
-            ("[pip]\nrequire-hashes = true\n", ("uv.toml require-hashes",)),
-            # uv reads none of this table, so neither do we.
-            ("[tool.other]\nno-build = true\n", ()),
-        ],
-    )
-    def test_uv_toml_values_are_parsed(self, tmp_path, body, expected):
-        config = tmp_path / "uv.toml"
-        config.write_text(body, encoding = "utf-8")
-        assert self._names({}, uv_files = [str(config)]) == expected
-
-    def test_pyproject_is_read_only_under_tool_uv(self, tmp_path):
-        """Measured on uv 0.12.1: a cwd pyproject's [tool.uv.pip] require-hashes DOES
-        fail a uv pip install ("Found workspace configuration" in -v), so it is real
-        policy. A parent directory's pyproject is NOT read, and neither is a bare
-        parent uv.toml, so neither is claimed here."""
-        config = tmp_path / "pyproject.toml"
-        config.write_text(
-            '[project]\nname = "x"\nversion = "1"\n[tool.uv.pip]\nrequire-hashes = true\n',
-            encoding = "utf-8",
-        )
-        assert self._names({}, uv_files = [str(config)]) == ("pyproject.toml require-hashes",)
-        config.write_text(
-            '[project]\nname = "x"\nversion = "1"\n[tool.poetry]\nno-build = true\n',
-            encoding = "utf-8",
-        )
-        assert self._names({}, uv_files = [str(config)]) == ()
-
-    def test_the_regex_fallback_agrees_with_the_parser(self, tmp_path):
-        """3.9/3.10 have no tomllib. The fallback must still test the value."""
-        config = tmp_path / "uv.toml"
-        for body, expected in (
-            ("no-build = true\n", ("uv.toml no-build",)),
-            ("no-build = false\n", ()),
-            ("  no-build   =   true  \n", ("uv.toml no-build",)),
-            ("# no-build = true\n", ()),
-        ):
-            config.write_text(body, encoding = "utf-8")
-            with mock.patch.object(ips, "_tomllib", None):
-                assert self._names({}, uv_files = [str(config)]) == expected
-
-    def test_pip_config_is_read_directly_when_pip_is_missing(self, tmp_path):
-        """install.sh builds the venv with uv, which seeds no pip, so at the moment the
-        notice runs `python -m pip config list` fails -- while the pip FALLBACK later in
-        the same install reads pip.conf perfectly well."""
-        config = tmp_path / "pip.conf"
-        config.write_text(
-            "[global]\nrequire-hashes = true\nindex-url = https://m/s\n", encoding = "utf-8"
-        )
-        ips._policy_scan.cache_clear()
-        with (
-            mock.patch.dict(os.environ, {}, clear = True),
-            mock.patch.object(ips.subprocess, "run", mock.Mock(side_effect = OSError)),
-            mock.patch.object(ips, "_hardened_uv_config_paths", lambda: []),
-            mock.patch.object(ips, "_hardened_pip_config_paths", lambda: [str(config)]),
-        ):
-            names = ips._hardened_pm_policy_names()
-        ips._policy_scan.cache_clear()
-        assert names == ("pip.conf require-hashes",), "a mirror is not hardening"
-
-    def test_pip_files_are_not_double_read_when_pip_answers(self, tmp_path):
-        """pip merges global/user/site in its own order and reports the winner, so when
-        the subprocess works its answer is the whole answer."""
-        config = tmp_path / "pip.conf"
-        config.write_text("[global]\nonly-binary = :all:\n", encoding = "utf-8")
-        ips._policy_scan.cache_clear()
-        with (
-            mock.patch.dict(os.environ, {}, clear = True),
-            mock.patch.object(
-                ips.subprocess,
-                "run",
-                mock.Mock(
-                    return_value = mock.Mock(returncode = 0, stdout = b"global.require-hashes='true'\n")
-                ),
-            ),
-            mock.patch.object(ips, "_hardened_uv_config_paths", lambda: []),
-            mock.patch.object(ips, "_hardened_pip_config_paths", lambda: [str(config)]),
-        ):
-            names = ips._hardened_pm_policy_names()
-        ips._policy_scan.cache_clear()
-        assert names == ("pip.conf require-hashes",)
-
-    def test_devnull_pip_config_means_no_files_at_all(self):
-        """Documented pip behaviour: PIP_CONFIG_FILE=os.devnull disables the loading of
-        ALL configuration files, so there is nothing to report."""
-        with mock.patch.dict(os.environ, {"PIP_CONFIG_FILE": os.devnull}, clear = True):
-            assert ips._hardened_pip_config_paths() == []
-
-    def test_documented_pip_locations_are_searched(self):
-        # Separator-normalised: these force IS_WINDOWS=False to exercise the POSIX branch,
-        # but os.path.join still uses the RUNNER's separator, so a literal "/etc/pip.conf"
-        # would fail the whole suite on windows-latest.
-        with (
-            mock.patch.dict(os.environ, {"HOME": "/home/u"}, clear = True),
-            _posix_home(),
-            mock.patch.object(ips, "IS_WINDOWS", False),
-            mock.patch.object(ips, "IS_MACOS", False),
-            mock.patch.object(os.path, "isfile", lambda path: True),
-        ):
-            posix = [path.replace(os.sep, "/") for path in ips._hardened_pip_config_paths()]
-        assert "/etc/pip.conf" in posix
-        assert "/etc/xdg/pip/pip.conf" in posix
-        assert "/home/u/.config/pip/pip.conf" in posix
-        assert "/home/u/.pip/pip.conf" in posix
-        with (
-            mock.patch.dict(os.environ, {"HOME": "/home/u"}, clear = True),
-            _posix_home(),
-            mock.patch.object(ips, "IS_WINDOWS", False),
-            mock.patch.object(ips, "IS_MACOS", True),
-            mock.patch.object(os.path, "isfile", lambda path: True),
-        ):
-            macos = [path.replace(os.sep, "/") for path in ips._hardened_pip_config_paths()]
-        assert "/home/u/Library/Application Support/pip/pip.conf" in macos
-        with (
-            mock.patch.dict(os.environ, {"APPDATA": "C:\\a", "PROGRAMDATA": "C:\\pd"}, clear = True),
-            mock.patch.object(ips, "IS_WINDOWS", True),
-            mock.patch.object(os.path, "isfile", lambda path: True),
-        ):
-            windows = ips._hardened_pip_config_paths()
-        assert windows and all(path.endswith("pip.ini") for path in windows)
-        assert any(path.startswith("C:\\pd") for path in windows)
-
-    def test_pip_config_precedence_is_resolved(self):
-        """`pip config list` prints EVERY definition, overridden ones included.
-
-        Measured on pip 26.2.1 with a user pip.conf `require-hashes = true` and a venv
-        site pip.conf `require-hashes = false`: both lines are emitted, `pip config get
-        global.require-hashes` returns false, and the install is NOT hash-checked. Taking
-        any enabled occurrence announced a policy pip does not apply.
-        """
-        listing = "global.require-hashes='true'\nglobal.require-hashes='false'\n"
-        assert self._names({}, pip_ok = True, pip_config = listing) == ()
-        # And the other order still reports it, so the resolution is precedence, not
-        # "an off value anywhere wins".
-        listing = "global.require-hashes='false'\nglobal.require-hashes='true'\n"
-        assert self._names({}, pip_ok = True, pip_config = listing) == ("pip.conf require-hashes",)
-
-    def test_file_precedence_is_resolved_when_pip_is_missing(self, tmp_path):
-        """The same resolution in the branch this feature exists for: no pip at all."""
-        user = tmp_path / "user.conf"
-        user.write_text("[global]\nrequire-hashes = true\n", encoding = "utf-8")
-        site = tmp_path / "site.conf"
-        site.write_text("[global]\nrequire-hashes = false\n", encoding = "utf-8")
-        ips._policy_scan.cache_clear()
-        with (
-            mock.patch.dict(os.environ, {}, clear = True),
-            mock.patch.object(ips.subprocess, "run", mock.Mock(side_effect = OSError)),
-            mock.patch.object(ips, "_hardened_uv_config_paths", lambda: []),
-            # Returned in pip's load order, so the site file is last and wins.
-            mock.patch.object(ips, "_hardened_pip_config_paths", lambda: [str(user), str(site)]),
-        ):
-            names = ips._hardened_pm_policy_names()
-        ips._policy_scan.cache_clear()
-        assert names == ()
-
-    def test_a_malformed_pip_conf_is_survivable(self, tmp_path):
-        config = tmp_path / "pip.conf"
-        config.write_text("this is not ini at all\n[[[\n", encoding = "utf-8")
-        assert ips._hardened_keys_in_ini(config.read_text(encoding = "utf-8")) == []
-
-
-class TestNeitherManagerIsLetOffTheOthersPolicy:
-    """pip and uv read none of each other's policy, so under the opt-out a step that runs
-    the manager the operator did NOT configure would proceed unrestricted.
-
-    Measured on the pinned uv 0.12.1: `uv pip install` of an unhashed wheel succeeds with
-    PIP_REQUIRE_HASHES=1 set AND with a pip.conf require-hashes, and is rejected only by
-    UV_REQUIRE_HASHES=1. Since pip_install() prefers uv, a pip-only policy was a silent
-    bypass.
-
-    Restating each control in the other manager's spelling was tried and removed: the two
-    differ on scopes, per-subcommand sections, config discovery and which controls exist
-    at all, and every gap became a way to fail an install the real policy permitted. The
-    step now stops and names the setting to add, which cannot invent a restriction.
-    """
-
-    def _detect(
-        self,
-        on,
-        configured = None,
-    ):
-        scan = (tuple(on), {k: frozenset(v) for k, v in (configured or {}).items()})
-        return mock.patch.object(ips, "_policy_scan", lambda: scan)
-
-    def _run(
-        self,
-        cmd,
-        on,
-        configured = None,
-        env = None,
-    ):
-        environment = {"UNSLOTH_RESPECT_PM_POLICY": "1"}
-        environment.update(env or {})
-        with (
-            mock.patch.dict(os.environ, environment, clear = True),
-            self._detect(on, configured),
-        ):
-            return ips._install_env_for_cmd(list(cmd))
-
-    def test_a_uv_step_stops_when_only_pip_is_hardened(self):
-        with pytest.raises(SystemExit) as exit_info:
-            self._run(
-                ["uv", "pip", "install", "-r", "extras.txt"],
-                [("pip", "env", "PIP_REQUIRE_HASHES")],
-                {"pip": {"require-hashes"}, "uv": set()},
-            )
-        assert exit_info.value.code == 1
-
-    def test_a_pip_step_stops_when_only_uv_is_hardened(self):
-        with pytest.raises(SystemExit):
-            self._run(
-                ["python", "-m", "pip", "install", "x"],
-                [("uv", "uv.toml", "no-build")],
-                {"uv": {"no-build"}, "pip": set()},
-            )
-
-    def test_the_message_names_the_control_and_the_setting_to_add(self, capsys):
-        with pytest.raises(SystemExit):
-            self._run(
-                ["uv", "pip", "install", "x"],
-                [("pip", "pip.conf", "require-hashes")],
-                {"pip": {"require-hashes"}, "uv": set()},
-            )
-        out = " ".join(capsys.readouterr().out.split())
-        assert "require-hashes" in out and "UV_REQUIRE_HASHES" in out
-        assert "UNSLOTH_RESPECT_PM_POLICY" in out
-
-    def test_a_deliberate_difference_is_not_a_gap(self):
-        """A uv config saying `[pip] require-hashes = false` next to PIP_REQUIRE_HASHES=1
-        is the operator configuring the two differently, not uv missing a control."""
-        assert (
-            self._run(
-                ["uv", "pip", "install", "x"],
-                [("pip", "env", "PIP_REQUIRE_HASHES")],
-                {"pip": {"require-hashes"}, "uv": {"require-hashes"}},
-            )
-            is None
-        )
-
-    def test_the_manager_that_owns_the_policy_is_left_alone(self):
-        assert (
-            self._run(
-                ["uv", "pip", "install", "x"],
-                [("uv", "env", "UV_REQUIRE_HASHES")],
-                {"uv": {"require-hashes"}, "pip": set()},
-            )
-            is None
-        )
-
-    @pytest.mark.parametrize(
-        "cmd",
-        [
-            ["python", "patch_metadata.py"],
-            ["python", "-m", "pip", "check"],
-            ["python", "-m", "pip", "--version"],
-            ["python", "-m", "ensurepip", "--upgrade"],
-        ],
-    )
-    def test_a_command_that_resolves_nothing_is_never_refused(self, cmd):
-        """run() routes EVERY command through this helper. Treating them all as pip
-        installs turned an unenforceable policy into a hard exit on the final metadata
-        patch, after every real step had succeeded."""
-        assert (
-            self._run(
-                cmd,
-                [("uv", "env", "UV_EXCLUDE_NEWER")],
-                {"uv": {"exclude-newer"}, "pip": set()},
-            )
-            is None
-        )
-
-    def test_nothing_is_refused_without_the_opt_out(self):
-        with (
-            mock.patch.dict(os.environ, {}, clear = True),
-            self._detect(
-                [("pip", "env", "PIP_REQUIRE_HASHES")],
-                {"pip": {"require-hashes"}, "uv": set()},
-            ),
-        ):
-            assert ips._install_env_for_cmd(["uv", "pip", "install", "x"]) is None
-
-
-class TestDetectionMatchesPipsOwnRules:
-    """Each of these was checked against pip's source or measured, not assumed."""
-
-    def _names(
-        self,
-        environment,
-        pip_ok = False,
-        pip_config = "",
-        uv_files = (),
-        pip_files = (),
-    ):
-        ips._policy_scan.cache_clear()
-        runner = (
-            mock.Mock(return_value = mock.Mock(returncode = 0, stdout = pip_config.encode()))
-            if pip_ok
-            else mock.Mock(side_effect = OSError("no pip"))
-        )
-        with (
-            mock.patch.dict(os.environ, environment, clear = True),
-            mock.patch.object(ips.subprocess, "run", runner),
-            mock.patch.object(ips, "_hardened_uv_config_paths", lambda: list(uv_files)),
-            mock.patch.object(ips, "_hardened_pip_config_paths", lambda: list(pip_files)),
-        ):
-            names = ips._hardened_pm_policy_names()
-        ips._policy_scan.cache_clear()
-        return names
-
-    @pytest.mark.parametrize("value", ["off", "n", "f", "no", "false", "0", ""])
-    def test_pips_false_spellings_are_all_disabled(self, value):
-        """pip's strtobool: false is n, no, f, false, off, 0. `off`, `n` and `f` were
-        being read as ENABLED, which under the opt-out translated a disabled setting
-        into a uv control and failed the install."""
-        assert self._names({"PIP_REQUIRE_HASHES": value}) == ()
-
-    @pytest.mark.parametrize("value", ["on", "y", "t", "yes", "true", "1"])
-    def test_pips_true_spellings_are_all_enabled(self, value):
-        assert self._names({"PIP_REQUIRE_HASHES": value}) == ("PIP_REQUIRE_HASHES",)
-
-    def test_a_disabled_environment_variable_cancels_a_config_file(self, tmp_path):
-        """pip's environment beats every config file, so a config that enables a control
-        the environment explicitly disables is not policy. Reporting it printed a notice
-        and, under the opt-out, translated the cancelled setting into uv and failed."""
-        config = tmp_path / "pip.conf"
-        config.write_text("[global]\nrequire-hashes = true\n", encoding = "utf-8")
-        assert self._names({"PIP_REQUIRE_HASHES": "0"}, pip_files = [str(config)]) == ()
-        # Without the cancelling variable it is reported normally.
-        assert self._names({}, pip_files = [str(config)]) == ("pip.conf require-hashes",)
-
-    def test_the_command_section_beats_global_whatever_the_order(self):
-        """pip applies [global] then the command's own section, independent of textual
-        order, so [install] wins for the commands this module runs."""
-        body = "[install]\nrequire-hashes = true\n[global]\nrequire-hashes = false\n"
-        assert ips._hardened_settings_in_ini(body) == {"require-hashes": "true"}
-        body = "[global]\nrequire-hashes = false\n[install]\nrequire-hashes = true\n"
-        assert ips._hardened_settings_in_ini(body) == {"require-hashes": "true"}
-
-    def test_a_section_for_another_command_is_ignored(self):
-        assert ips._hardened_settings_in_ini("[freeze]\nrequire-hashes = true\n") == {}
-
-    def test_config_list_ranks_sections_too(self):
-        listing = "install.require-hashes='true'\nglobal.require-hashes='false'\n"
-        assert self._names({}, pip_ok = True, pip_config = listing) == ("pip.conf require-hashes",)
-
-    def test_user_configs_are_skipped_when_an_explicit_file_exists(self, tmp_path):
-        """pip's iter_config_files: "per-user config is not loaded when env_config_file
-        exists". Scanning them anyway invents a policy pip would not apply."""
-        explicit = tmp_path / "explicit.conf"
-        explicit.write_text("[global]\ntimeout = 60\n", encoding = "utf-8")
-        with (
-            mock.patch.dict(
-                os.environ,
-                {"HOME": "/home/u", "PIP_CONFIG_FILE": str(explicit)},
-                clear = True,
-            ),
-            _posix_home(),
-            mock.patch.object(ips, "IS_WINDOWS", False),
-            mock.patch.object(ips, "IS_MACOS", False),
-            mock.patch.object(os.path, "isfile", lambda path: True),
-        ):
-            paths = [path.replace(os.sep, "/") for path in ips._hardened_pip_config_paths()]
-        assert not any("/home/u/.config/pip" in path for path in paths)
-        assert not any("/home/u/.pip" in path for path in paths)
-        assert "/etc/pip.conf" in paths, "global and site are still loaded"
-        assert str(explicit).replace(os.sep, "/") in paths
-
-    def test_the_windows_legacy_user_config_is_searched(self):
-        """pip's get_configuration_files still returns ~/pip/pip.ini on Windows."""
-        with (
-            mock.patch.dict(os.environ, {"APPDATA": "C:\\a"}, clear = True),
-            mock.patch.object(ips, "IS_WINDOWS", True),
-            mock.patch.object(os.path, "expanduser", lambda p: p.replace("~", "C:\\u", 1)),
-            mock.patch.object(os.path, "isfile", lambda path: True),
-        ):
-            paths = ips._hardened_pip_config_paths()
-        assert any(path.startswith("C:\\u") and path.endswith("pip.ini") for path in paths)
-
-
-class TestDetectionMatchesWhatTheManagersActuallyEnforce:
-    """Detection has to report the policy in force, not the policy that looks configured.
-
-    Every claim below was measured against the versions Unsloth ships against: the uv
-    0.12.1 that setup.sh pins by sha256, and pip 26.2.1. Over-reporting is not the safe
-    direction here, because under the opt-out a control credited to one manager and not
-    the other stops the step.
-    """
-
-    _names = TestDetectionMatchesPipsOwnRules._names
-
-    @pytest.mark.parametrize(
-        "name,value",
-        [
-            ("UV_NO_BUILD", "true"),
-            ("UV_NO_BUILD_PACKAGE", "simsrc"),
-            ("UV_ONLY_BINARY", ":all:"),
-            ("UV_NO_BINARY", ":all:"),
-        ],
-    )
-    def test_the_uv_artifact_variables_uv_ignores_are_not_policy(self, name, value):
-        """Measured on the pinned uv 0.12.1: a source directory installs with any of
-        these set, and is refused by the matching --no-build / --no-binary flag or by a
-        uv.toml carrying it. `uv help pip install` lists no [env:] spelling for them.
-
-        They are still stripped from a pinned command, which costs nothing. Counting one
-        as uv policy is the harm: it hid a genuine pip-side gap under the opt-out by
-        making uv look as though it had the control covered."""
-        assert self._names({name: value}) == ()
-        assert ips._configured_policy_keys()["uv"] == frozenset()
-
-    @pytest.mark.parametrize("name", ["UV_REQUIRE_HASHES", "UV_EXCLUDE_NEWER"])
-    def test_the_uv_variables_uv_does_read_are_still_policy(self, name):
-        """The same measurement the other way: UV_REQUIRE_HASHES fails an unhashed
-        install and UV_EXCLUDE_NEWER filters by upload date, both from the environment
-        alone."""
-        value = "1" if name.endswith("HASHES") else "2020-01-01T00:00:00Z"
-        assert self._names({name: value}) == (name,)
-
-    @pytest.mark.parametrize("key", ["no-build", "no-build-package", "exclude-newer"])
-    def test_a_uv_only_key_in_pip_conf_is_not_pip_policy(self, key, tmp_path):
-        """pip 26.2.1 has no option for these, so `pip install --help` exposes nothing
-        for them and an entry in pip.conf is inert. Reading one as pip policy made the
-        first uv step refuse under the opt-out over a gap that did not exist."""
-        config = tmp_path / "pip.conf"
-        config.write_text(f"[global]\n{key} = true\n", encoding = "utf-8")
-        assert self._names({}, pip_files = [str(config)]) == ()
-
-    @pytest.mark.parametrize("key", ["require-hashes", "only-binary", "uploaded-prior-to"])
-    def test_the_keys_pip_does_have_are_still_read(self, key, tmp_path):
-        config = tmp_path / "pip.conf"
-        value = "true" if key == "require-hashes" else ":all:"
-        config.write_text(f"[global]\n{key} = {value}\n", encoding = "utf-8")
-        assert self._names({}, pip_files = [str(config)]) == (f"pip.conf {key}",)
-
-    def test_an_empty_variable_does_not_cancel_a_config_file(self, tmp_path):
-        """pip drops empty environment values before applying precedence. Measured with
-        pip 26.2.1: PIP_ONLY_BINARY='' still rejects an sdist under a pip.conf
-        `only-binary = :all:`, while `:none:` clears it. Treating the empty spelling as a
-        cancellation suppressed a policy that was fully in force."""
-        config = tmp_path / "pip.conf"
-        config.write_text("[global]\nonly-binary = :all:\n", encoding = "utf-8")
-        assert self._names({"PIP_ONLY_BINARY": ""}, pip_files = [str(config)]) == (
-            "pip.conf only-binary",
-        )
-        assert self._names({"PIP_ONLY_BINARY": ":none:"}, pip_files = [str(config)]) == ()
-
-    def test_a_subcommand_setting_survives_a_later_file(self, tmp_path):
-        """pip resolves each command separately across ALL its files, so a low-priority
-        file's [wheel] entry cannot erase a higher one's [install] entry. Collapsing each
-        file before reading the next reported an unhardened host while pip was still
-        hash-checking every install."""
-        first = tmp_path / "user.conf"
-        first.write_text("[install]\nrequire-hashes = true\n", encoding = "utf-8")
-        second = tmp_path / "site.conf"
-        second.write_text("[wheel]\nrequire-hashes = false\n", encoding = "utf-8")
-        assert self._names({}, pip_files = [str(first), str(second)]) == ("user.conf require-hashes",)
-        # And the ordinary same-section override still works.
-        third = tmp_path / "later.conf"
-        third.write_text("[install]\nrequire-hashes = false\n", encoding = "utf-8")
-        assert self._names({}, pip_files = [str(first), str(third)]) == ()
-
-    def test_a_project_config_can_switch_a_user_config_off(self, tmp_path):
-        """Measured on the pinned uv 0.12.1: a user `~/.config/uv/uv.toml` with
-        `[pip] require-hashes = true` plus a project `[tool.uv.pip] require-hashes =
-        false` installs unhashed. Reporting the user value regardless made a later pip
-        step refuse under the opt-out over policy uv was not enforcing."""
-        user = tmp_path / "uv.toml"
-        user.write_text("[pip]\nrequire-hashes = true\n", encoding = "utf-8")
-        project = tmp_path / "pyproject.toml"
-        project.write_text(
-            '[project]\nname = "p"\nversion = "0"\n[tool.uv.pip]\nrequire-hashes = false\n',
-            encoding = "utf-8",
-        )
-        assert self._names({}, uv_files = [str(user)]) == ("uv.toml require-hashes",)
-        assert self._names({}, uv_files = [str(user), str(project)]) == ()
-
-    def test_the_uv_files_come_back_lowest_precedence_first(self, tmp_path):
-        """The resolution above is only correct if the order is: system, user, project."""
-        home = tmp_path / "home"
-        (home / "uv").mkdir(parents = True)
-        (home / "uv" / "uv.toml").write_text("[pip]\nno-build = true\n", encoding = "utf-8")
-        project = tmp_path / "proj"
-        project.mkdir()
-        (project / "pyproject.toml").write_text('[project]\nname = "p"\n', encoding = "utf-8")
-        with (
-            mock.patch.dict(os.environ, {"XDG_CONFIG_HOME": str(home)}, clear = True),
-            mock.patch.object(ips, "IS_WINDOWS", False),
-            mock.patch.object(os, "getcwd", lambda: str(project)),
-            mock.patch.object(ips.os.path, "isfile", os.path.isfile),
-        ):
-            paths = ips._hardened_uv_config_paths()
-        assert paths[-1] == str(project / "pyproject.toml"), paths
-        assert str(home / "uv" / "uv.toml") in paths
-
-    def test_a_parent_pyproject_is_discovered_from_a_child_directory(self, tmp_path):
-        """Measured on the pinned uv 0.12.1: a parent `[tool.uv.pip] require-hashes =
-        true` fails an install run from a child directory. Studio is normally launched
-        from one, so stopping at the working directory missed real policy."""
-        parent = tmp_path / "parent"
-        (parent / "child" / "deep").mkdir(parents = True)
-        (parent / "pyproject.toml").write_text('[project]\nname = "p"\n', encoding = "utf-8")
-        with mock.patch.object(os, "getcwd", lambda: str(parent / "child" / "deep")):
-            assert ips._uv_project_config() == [str(parent / "pyproject.toml")]
-
-    def test_a_uv_toml_beside_the_pyproject_wins(self, tmp_path):
-        (tmp_path / "pyproject.toml").write_text('[project]\nname = "p"\n', encoding = "utf-8")
-        (tmp_path / "uv.toml").write_text("[pip]\nrequire-hashes = true\n", encoding = "utf-8")
-        with mock.patch.object(os, "getcwd", lambda: str(tmp_path)):
-            assert ips._uv_project_config() == [str(tmp_path / "uv.toml")]
-
-    def test_a_uv_toml_with_no_pyproject_beside_it_is_not_read(self, tmp_path):
-        """Measured: uv reads it in neither the working directory nor any ancestor, so
-        reporting it would be hardening uv does not apply."""
-        (tmp_path / "uv.toml").write_text("[pip]\nrequire-hashes = true\n", encoding = "utf-8")
-        with mock.patch.object(os, "getcwd", lambda: str(tmp_path)):
-            assert ips._uv_project_config() == []
-
-    def test_the_walk_terminates_on_a_host_with_no_pyproject_anywhere(self):
-        with mock.patch.object(os, "getcwd", lambda: "/a/b/c"):
-            with mock.patch.object(ips.os.path, "isfile", lambda path: False):
-                assert ips._uv_project_config() == []
-
-    def test_a_deleted_working_directory_is_not_an_error(self):
-        with mock.patch.object(os, "getcwd", mock.Mock(side_effect = OSError("gone"))):
-            assert ips._uv_project_config() == []
-
-    def test_a_command_section_beats_a_global_in_a_higher_priority_file(self, tmp_path):
-        """pip pools every file's [global] into one group and every file's command
-        section into another, then applies global first and the command second, so an
-        [install] entry in a low-priority file still wins. Folding global into the
-        command sections file by file let a later [global] erase it."""
-        first = tmp_path / "user.conf"
-        first.write_text("[install]\nrequire-hashes = true\n", encoding = "utf-8")
-        second = tmp_path / "site.conf"
-        second.write_text("[global]\nrequire-hashes = false\n", encoding = "utf-8")
-        assert self._names({}, pip_files = [str(first), str(second)]) == ("user.conf require-hashes",)
-
-    def test_the_underscore_spelling_is_normalised(self, tmp_path):
-        """pip's _normalize_name lowercases and turns underscores into dashes, so
-        `require_hashes` is a spelling it honours. RawConfigParser keeps the underscore,
-        so matching only the dashed name read a hardened host as ordinary."""
-        config = tmp_path / "pip.conf"
-        config.write_text("[global]\nREQUIRE_HASHES = true\n", encoding = "utf-8")
-        assert self._names({}, pip_files = [str(config)]) == ("pip.conf require-hashes",)
-
-    def test_the_modern_user_file_outranks_the_legacy_one(self):
-        """pip's get_configuration_files returns the user kind as
-        [legacy_config_file, new_config_file] and loads them in that order."""
-        with (
-            mock.patch.dict(os.environ, {"HOME": "/home/u"}, clear = True),
-            _posix_home(),
-            mock.patch.object(ips, "IS_WINDOWS", False),
-            mock.patch.object(ips, "IS_MACOS", False),
-            mock.patch.object(os.path, "isfile", lambda path: True),
-        ):
-            paths = [path.replace(os.sep, "/") for path in ips._hardened_pip_config_paths()]
-        assert paths.index("/home/u/.pip/pip.conf") < paths.index(
-            "/home/u/.config/pip/pip.conf"
-        ), paths
-
-    def test_the_windows_appdata_file_outranks_the_legacy_one(self):
-        with (
-            mock.patch.dict(os.environ, {"APPDATA": "C:\\a"}, clear = True),
-            mock.patch.object(ips, "IS_WINDOWS", True),
-            mock.patch.object(os.path, "expanduser", lambda p: p.replace("~", "C:\\u", 1)),
-            mock.patch.object(os.path, "isfile", lambda path: True),
-        ):
-            # os.path.join follows the RUNNER, so normalise both separators: this test is
-            # about the ORDER of the locations, not how a platform spells a path.
-            paths = [
-                path.replace("\\", "/").replace(os.sep, "/")
-                for path in ips._hardened_pip_config_paths()
-            ]
-        assert paths.index("C:/u/pip/pip.ini") < paths.index("C:/a/pip/pip.ini"), paths
-
-    def test_a_package_scoped_key_does_not_erase_its_global_twin(self, tmp_path):
-        """`no-build` and `no-build-package` are one CONTROL but two SETTINGS. Storing
-        them under the canonical name let an empty `no-build-package = []` beside an
-        active `no-build = true` erase it, and uv still refuses source builds there."""
-        config = tmp_path / "uv.toml"
-        config.write_text("no-build = true\nno-build-package = []\n", encoding = "utf-8")
-        assert self._names({}, uv_files = [str(config)]) == ("uv.toml no-build",)
-
-    def test_an_explicit_config_file_is_read_as_a_standalone_uv_toml(self, tmp_path):
-        """uv parses the file named by UV_CONFIG_FILE with the uv.toml schema whatever it
-        is called, so choosing the schema from the basename lost the policy of an
-        explicit file that happened to be named pyproject.toml."""
-        explicit = tmp_path / "pyproject.toml"
-        explicit.write_text("no-build = true\n", encoding = "utf-8")
-        assert self._names({"UV_CONFIG_FILE": str(explicit)}, uv_files = [str(explicit)]) == (
-            "pyproject.toml no-build",
-        )
-        # A DISCOVERED pyproject.toml keeps the [tool.uv] schema, where a root key is
-        # some other tool's setting and not uv policy.
-        assert self._names({}, uv_files = [str(explicit)]) == ()
-
-    def test_a_dotted_key_is_a_table_in_the_legacy_parser(self):
-        """`pip.require-hashes = true` at the root of a uv.toml is the inline spelling of
-        `[pip] require-hashes = true`, which uv enforces. Read as one literal key it
-        matched nothing and the policy was dropped on 3.9 and 3.10."""
-        with mock.patch.object(ips, "_tomllib", None):
-            assert ips._hardened_keys_in_toml("pip.require-hashes = true\n", ((), ("pip",))) == [
-                "require-hashes"
-            ]
-            # A dotted key naming a table we do not read stays ignored.
-            assert ips._hardened_keys_in_toml("other.require-hashes = true\n", ((), ("pip",))) == []
-
-    def test_a_download_only_section_is_not_an_opinion_about_install(self, tmp_path):
-        """pip resolves each subcommand separately, so `[download] only-binary = :all:`
-        does not restrict `pip install`. Pooling the three let a fallback install run as
-        though the operator's control were covered when that command was unrestricted."""
-        config = tmp_path / "pip.conf"
-        config.write_text("[download]\nonly-binary = :all:\n", encoding = "utf-8")
-        ips._policy_scan.cache_clear()
-        with (
-            mock.patch.dict(os.environ, {"UNSLOTH_RESPECT_PM_POLICY": "1"}, clear = True),
-            mock.patch.object(ips.subprocess, "run", mock.Mock(side_effect = OSError())),
-            mock.patch.object(ips, "_hardened_pip_config_paths", lambda: [str(config)]),
-            mock.patch.object(ips, "_hardened_uv_config_paths", lambda: []),
-        ):
-            keys = ips._configured_policy_keys()
-            assert "no-build" in keys["pip:download"]
-            assert "no-build" not in keys["pip:install"], keys
-        ips._policy_scan.cache_clear()
-
-    @pytest.mark.parametrize("variable", ["UV_PROJECT", "UV_WORKING_DIR"])
-    def test_uvs_own_project_root_is_used_not_this_processs_cwd(self, variable, tmp_path):
-        """Measured on the pinned uv 0.12.1: a `[tool.uv.pip] require-hashes = true` in
-        a project named by either variable is enforced from an unrelated cwd. Walking
-        from getcwd() alone scanned the wrong tree."""
-        project = tmp_path / "elsewhere"
-        project.mkdir()
-        (project / "pyproject.toml").write_text('[project]\nname = "p"\n', encoding = "utf-8")
-        elsewhere = tmp_path / "cwd"
-        elsewhere.mkdir()
-        with (
-            mock.patch.dict(os.environ, {variable: str(project)}, clear = True),
-            mock.patch.object(os, "getcwd", lambda: str(elsewhere)),
-        ):
-            assert ips._uv_project_config() == [str(project / "pyproject.toml")]
-
-    def test_an_explicit_config_file_survives_no_config(self, tmp_path):
-        """Measured: uv reads the file named by UV_CONFIG_FILE with UV_NO_CONFIG=1 set
-        as well, so returning nothing there dropped policy that was still in force."""
-        explicit = tmp_path / "uv.toml"
-        explicit.write_text("[pip]\nrequire-hashes = true\n", encoding = "utf-8")
-        with mock.patch.dict(
-            os.environ,
-            {"UV_CONFIG_FILE": str(explicit), "UV_NO_CONFIG": "1"},
-            clear = True,
-        ):
-            assert ips._hardened_uv_config_paths() == [str(explicit)]
-        # Without an explicit file, --no-config still means nothing is discovered.
-        with mock.patch.dict(os.environ, {"UV_NO_CONFIG": "1"}, clear = True):
-            assert ips._hardened_uv_config_paths() == []
-
-    def test_the_macos_global_set_covers_both_pip_generations(self):
-        """pip changed under us: measured, pip 26.1 resolves the Darwin global set to
-        /Library/Application Support and ignores XDG_DATA_DIRS, while 26.2.1 lets
-        XDG_DATA_DIRS replace it. Either can be the pip on a user's machine."""
-        with (
-            mock.patch.dict(os.environ, {"XDG_DATA_DIRS": "/a", "HOME": "/home/u"}, clear = True),
-            _posix_home(),
-            mock.patch.object(ips, "IS_WINDOWS", False),
-            mock.patch.object(ips, "IS_MACOS", True),
-            mock.patch.object(os.path, "isfile", lambda path: True),
-        ):
-            paths = [path.replace(os.sep, "/") for path in ips._hardened_pip_config_paths()]
-        assert "/Library/Application Support/pip/pip.conf" in paths, paths
-        assert "/a/pip/pip.conf" in paths, paths
-
-    def test_the_refusal_names_a_uv_no_binary_value_uv_accepts(self):
-        """uv's no-binary is a package LIST: `no-binary = true` is a config parse error
-        there, so the remediation would have left the operator with an unusable uv."""
-        _pip, uv_name = ips._POLICY_EQUIVALENTS["no-binary"]
-        assert ":all:" in uv_name and "= true" not in uv_name, uv_name
-
-    @pytest.mark.parametrize(
-        "body,tables,expected",
-        [
-            (
-                "[tool]\nuv = { pip = { require-hashes = true } }\n",
-                (("tool", "uv"), ("tool", "uv", "pip")),
-                ["require-hashes"],
-            ),
-            ("pip = { require-hashes = true }\n", ((), ("pip",)), ["require-hashes"]),
-            (
-                "[other]\nuv = { pip = { require-hashes = true } }\n",
-                (("tool", "uv"), ("tool", "uv", "pip")),
-                [],
-            ),
-        ],
-    )
-    def test_the_legacy_parser_reads_inline_tables(self, body, tables, expected):
-        """uv 0.12.1 enforces `[tool] uv = { pip = { require-hashes = true } }`, which
-        the pre-3.11 fallback skipped because `tool` is not itself a table it reads."""
-        with mock.patch.object(ips, "_tomllib", None):
-            assert ips._hardened_keys_in_toml(body, tables) == expected
-
-    def test_an_empty_toml_map_is_not_hardening(self):
-        """`exclude-newer-package = {}` reached the value conversion as an empty dict and
-        came out as the string "{}", which is not an off spelling. uv applies no cutoff
-        for it, and under the opt-out the phantom control could stop a pip step."""
-        assert (
-            ips._hardened_keys_in_toml("[pip]\nexclude-newer-package = {}\n", ((), ("pip",))) == []
-        )
-        assert ips._hardened_keys_in_toml(
-            '[pip]\nexclude-newer-package = { foo = "2020-01-01T00:00:00Z" }\n',
-            ((), ("pip",)),
-        ) == ["exclude-newer-package"]
-
-    def test_a_relative_explicit_config_resolves_against_uvs_directory(self, tmp_path):
-        """--directory changes directory before running, so a relative --config-file is
-        resolved there. Measured: UV_WORKING_DIR=work UV_CONFIG_FILE=cfg.toml enforces
-        require-hashes, while the same relative path without it cannot even be opened."""
-        work = tmp_path / "work"
-        work.mkdir()
-        (work / "cfg.toml").write_text("[pip]\nrequire-hashes = true\n", encoding = "utf-8")
-        with mock.patch.dict(
-            os.environ,
-            {"UV_CONFIG_FILE": "cfg.toml", "UV_WORKING_DIR": str(work)},
-            clear = True,
-        ):
-            assert ips._hardened_uv_config_paths() == [str(work / "cfg.toml")]
-        # An absolute path is left alone.
-        absolute = str(work / "cfg.toml")
-        with mock.patch.dict(
-            os.environ,
-            {"UV_CONFIG_FILE": absolute, "UV_WORKING_DIR": str(tmp_path)},
-            clear = True,
-        ):
-            assert ips._hardened_uv_config_paths() == [absolute]
-
-    def test_pip_section_names_are_case_sensitive(self, tmp_path):
-        """pip normalises the OPTION name and leaves the SECTION name alone, so
-        `[INSTALL]` is a section it never selects. Measured with pip 26.2.1: an
-        `[INSTALL] require-hashes = true` installs happily, `[install]` does not."""
-        config = tmp_path / "pip.conf"
-        config.write_text("[INSTALL]\nrequire-hashes = true\n", encoding = "utf-8")
-        assert self._names({}, pip_files = [str(config)]) == ()
-        config.write_text("[install]\nrequire-hashes = true\n", encoding = "utf-8")
-        assert self._names({}, pip_files = [str(config)]) == ("pip.conf require-hashes",)
-
-    def test_config_list_keeps_section_case_too(self):
-        listing = "INSTALL.require-hashes='true'\n"
-        assert self._names({}, pip_ok = True, pip_config = listing) == ()
-
-    def test_a_gap_is_refused_before_the_manifest_is_touched(self):
-        """The refusal was right and its timing was not: the manifest is removed up
-        front, so refusing at the first resolving command left an untouched venv marked
-        half-built and the Desktop preflight then rejected a working environment."""
-        # uv will run the installs, and the only policy is pip's, which uv cannot see.
-        with (
-            mock.patch.dict(
-                os.environ,
-                {"UNSLOTH_RESPECT_PM_POLICY": "1", "PIP_REQUIRE_HASHES": "1"},
-                clear = True,
-            ),
-            pytest.raises(SystemExit),
-        ):
-            ips._preflight_policy_gap(use_uv = True)
-        # And the other way round, on a host with no usable uv.
-        ips._policy_scan.cache_clear()
-        with (
-            mock.patch.dict(
-                os.environ,
-                {"UNSLOTH_RESPECT_PM_POLICY": "1", "UV_REQUIRE_HASHES": "1"},
-                clear = True,
-            ),
-            pytest.raises(SystemExit),
-        ):
-            ips._preflight_policy_gap(use_uv = False)
-
-    def test_the_preflight_probes_only_the_manager_that_will_run(self):
-        """A pip-only rule on a host with no usable uv is not a gap: every real command
-        keeps it. Probing both refused an install that would have honoured the policy
-        in full, because _bootstrap_uv() had not run and the uv probe described a
-        manager the install was never going to use."""
-        with mock.patch.dict(
-            os.environ,
-            {"UNSLOTH_RESPECT_PM_POLICY": "1", "PIP_ONLY_BINARY": ":all:"},
-            clear = True,
-        ):
-            ips._preflight_policy_gap(use_uv = False)
-        ips._policy_scan.cache_clear()
-        with mock.patch.dict(
-            os.environ,
-            {"UNSLOTH_RESPECT_PM_POLICY": "1", "UV_REQUIRE_HASHES": "1"},
-            clear = True,
-        ):
-            ips._preflight_policy_gap(use_uv = True)
-
-    def test_the_preflight_is_silent_without_the_opt_out(self):
-        """An ordinary install must never reach the check, whatever the host has set."""
-        with mock.patch.dict(
-            os.environ, {"UV_REQUIRE_HASHES": "1", "PIP_ONLY_BINARY": ":all:"}, clear = True
-        ):
-            ips._preflight_policy_gap(use_uv = True)
-
-    def test_the_preflight_is_silent_when_both_managers_are_configured(self):
-        with mock.patch.dict(
-            os.environ,
-            {
-                "UNSLOTH_RESPECT_PM_POLICY": "1",
-                "UV_REQUIRE_HASHES": "1",
-                "PIP_REQUIRE_HASHES": "1",
-            },
-            clear = True,
-        ):
-            ips._preflight_policy_gap(use_uv = True)
-
-    def test_a_relative_uv_project_resolves_against_uvs_directory(self, tmp_path):
-        """--directory takes effect first, so a relative --project is resolved there.
-        Measured: UV_WORKING_DIR=work UV_PROJECT=proj enforces work/proj's policy."""
-        work = tmp_path / "work"
-        (work / "proj").mkdir(parents = True)
-        (work / "proj" / "pyproject.toml").write_text('[project]\nname = "p"\n',
-                                                      encoding = "utf-8")
-        with (
-            mock.patch.dict(
-                os.environ,
-                {"UV_WORKING_DIR": str(work), "UV_PROJECT": "proj"},
-                clear = True,
-            ),
-            mock.patch.object(os, "getcwd", lambda: str(tmp_path)),
-        ):
-            assert ips._uv_project_config() == [str(work / "proj" / "pyproject.toml")]
-
-    def test_the_workspace_root_outranks_the_member_the_walk_stops_at(self, tmp_path):
-        """Measured on the pinned uv 0.12.1: from root/member/sub it logs "Found
-        workspace configuration at root/pyproject.toml" and enforces the ROOT's
-        require-hashes, not the member's absence of one."""
-        root = tmp_path / "ws"
-        (root / "member" / "sub").mkdir(parents = True)
-        (root / "pyproject.toml").write_text(
-            '[project]\nname = "root"\n[tool.uv.workspace]\nmembers = ["member"]\n',
-            encoding = "utf-8",
-        )
-        (root / "member" / "pyproject.toml").write_text('[project]\nname = "m"\n',
-                                                        encoding = "utf-8")
-        with mock.patch.object(os, "getcwd", lambda: str(root / "member" / "sub")):
-            assert ips._uv_project_config() == [str(root / "pyproject.toml")]
-        # A plain parent project with no workspace declaration still wins nothing: the
-        # nearest pyproject is uv's answer there.
-        (root / "pyproject.toml").write_text('[project]\nname = "root"\n',
-                                             encoding = "utf-8")
-        with mock.patch.object(os, "getcwd", lambda: str(root / "member" / "sub")):
-            assert ips._uv_project_config() == [str(root / "member" / "pyproject.toml")]
-
-    def test_a_resolved_explicit_config_keeps_the_standalone_schema(self, tmp_path):
-        """The schema decision compared the RAW environment value, so a relative
-        explicit file resolved through UV_WORKING_DIR stopped matching and an explicit
-        pyproject.toml was read with the discovered-project schema instead."""
-        work = tmp_path / "work"
-        work.mkdir()
-        (work / "pyproject.toml").write_text("no-build = true\n", encoding = "utf-8")
-        assert ips._explicit_uv_config_path.__doc__  # documented, not incidental
-        with mock.patch.dict(
-            os.environ,
-            {"UV_CONFIG_FILE": "pyproject.toml", "UV_WORKING_DIR": str(work)},
-            clear = True,
-        ):
-            assert ips._explicit_uv_config_path() == str(work / "pyproject.toml")
-            assert ips._hardened_uv_config_paths() == [str(work / "pyproject.toml")]
-        assert self._names(
-            {"UV_CONFIG_FILE": "pyproject.toml", "UV_WORKING_DIR": str(work)},
-            uv_files = [str(work / "pyproject.toml")],
-        ) == ("pyproject.toml no-build",)
-
-    @pytest.mark.parametrize("value", ["none", "no", "false", "off", "0"])
-    def test_an_artifact_list_value_is_a_package_name_not_a_boolean(self, value):
-        """pip documents `:none:` as the way to clear --only-binary, and everything else
-        as package names, so PIP_ONLY_BINARY=no restricts a distribution called "no".
-        Reading it as a disabled flag dropped an artifact rule that was in force."""
-        assert self._names({"PIP_ONLY_BINARY": value}) == ("PIP_ONLY_BINARY",)
-        # The two spellings that really do clear it.
-        assert self._names({"PIP_ONLY_BINARY": ":none:"}) == ()
-        assert self._names({"PIP_ONLY_BINARY": ""}) == ()
-
-    @pytest.mark.parametrize("value", ["no", "false", "off", "0"])
-    def test_a_boolean_control_still_reads_pips_false_spellings(self, value):
-        """require-hashes and no-build are the two that ARE booleans."""
-        assert self._names({"PIP_REQUIRE_HASHES": value}) == ()
-        assert self._names({"PIP_REQUIRE_HASHES": "1"}) == ("PIP_REQUIRE_HASHES",)
-
-    def test_an_inline_comment_is_not_part_of_the_value(self):
-        """The pre-3.11 fallback had already stripped the comment and then appended the
-        raw line anyway, so `no-build = false # disabled` read as the value
-        "false # disabled", which is not an off spelling."""
-        body = "no-build = false # disabled by the platform team\n"
-        with mock.patch.object(ips, "_tomllib", None):
-            assert ips._hardened_keys_in_toml(body, ((),)) == []
-            assert ips._hardened_keys_in_toml("no-build = true # on\n", ((),)) == ["no-build"]
 
 
 class TestPolicyEnvIsPlatformAndHardwareInvariant:
@@ -1810,105 +888,48 @@ class TestPolicyEnvIsPlatformAndHardwareInvariant:
 
 
 class TestTheNoticeCannotTakeAnInstallDown:
-    """It runs BEFORE the pip upgrade, against a venv uv may have created without pip,
-    and it reads files off disk. Every way that can go wrong must cost the notice, not
-    the install."""
+    """It is a message, not a step. Every way the probe can go wrong ends in a missing
+    line, never a failed install: it runs before the pip upgrade, against a venv uv
+    created without pip at all.
+    """
 
     def test_the_pip_probe_is_bounded(self):
-        """An unbounded probe on a half-written pip is a hang with no output at all."""
-        source = Path(ips.__file__).read_text(encoding = "utf-8")
-        body = source[source.index("def _policy_scan") : source.index("def _detected_policy")]
-        assert "timeout = 30" in body, "the pip config probe must pass an explicit timeout"
+        """No timeout here means an install that hangs forever on a wedged pip."""
+        source = inspect.getsource(ips._detected_policy)
+        assert "timeout = 30" in source, "the pip config probe must be bounded"
 
     def test_a_hanging_pip_still_yields_the_environment_half(self):
-        ips._policy_scan.cache_clear()
+        ips._detected_policy.cache_clear()
         with (
             mock.patch.dict(os.environ, {"PIP_REQUIRE_HASHES": "1"}, clear = True),
             mock.patch.object(
                 ips.subprocess,
                 "run",
-                mock.Mock(side_effect = ips.subprocess.TimeoutExpired("pip", 30)),
+                side_effect = ips.subprocess.TimeoutExpired(cmd = "pip", timeout = 30),
             ),
-            mock.patch.object(ips, "_hardened_uv_config_paths", lambda: []),
         ):
-            names = ips._hardened_pm_policy_names()
-        ips._policy_scan.cache_clear()
-        assert names == ("PIP_REQUIRE_HASHES",)
+            assert ips._hardened_pm_policy_names() == ("PIP_REQUIRE_HASHES",)
+        ips._detected_policy.cache_clear()
 
-    def test_the_call_site_swallows_anything(self):
-        """The notice is a message, not a step. Nothing it probes is worth aborting on."""
-        source = Path(ips.__file__).read_text(encoding = "utf-8")
-        assert (
-            "try:\n        _announce_pm_policy()\n    except Exception:\n        pass" in source
-        ), "install_python_stack() must guard the notice"
+    def test_a_broken_pip_is_not_an_error(self):
+        for failure in (OSError("no pip"), ips.subprocess.SubprocessError("boom")):
+            ips._detected_policy.cache_clear()
+            with (
+                mock.patch.dict(os.environ, {}, clear = True),
+                mock.patch.object(ips.subprocess, "run", side_effect = failure),
+            ):
+                assert ips._hardened_pm_policy_names() == ()
+            ips._detected_policy.cache_clear()
 
-    @pytest.mark.parametrize(
-        "environment",
-        [{}, {"HOME": "/home/u"}, {"XDG_CONFIG_HOME": "/xdg"}, {"APPDATA": "C:\\a"}],
-    )
-    @pytest.mark.parametrize("windows", [False, True])
-    def test_path_discovery_never_raises(self, environment, windows):
-        """A service account with no HOME, or Windows with no APPDATA, still installs."""
-        with (
-            mock.patch.dict(os.environ, environment, clear = True),
-            mock.patch.object(ips, "IS_WINDOWS", windows),
-        ):
-            assert isinstance(ips._hardened_uv_config_paths(), list)
-
-    def test_documented_config_locations_are_searched(self):
-        """uv reads ~/.config/uv/uv.toml on macOS AND Linux (not Application Support),
-        %APPDATA%\\uv on Windows, with /etc/uv and %PROGRAMDATA%\\uv system-wide. The
-        system one is where a fleet operator puts the policy this notice is about."""
-        # Separator-normalised for the same reason as the pip locations above: os.path.join
-        # follows the RUNNER, not the patched IS_WINDOWS.
-        with (
-            mock.patch.dict(os.environ, {"HOME": "/home/u"}, clear = True),
-            _posix_home(),
-            mock.patch.object(ips, "IS_WINDOWS", False),
-            mock.patch.object(os.path, "isfile", lambda path: True),
-        ):
-            posix = [path.replace(os.sep, "/") for path in ips._hardened_uv_config_paths()]
-        assert "/home/u/.config/uv/uv.toml" in posix
-        assert "/etc/uv/uv.toml" in posix
-        with (
-            mock.patch.dict(os.environ, {"APPDATA": "C:\\a", "PROGRAMDATA": "C:\\pd"}, clear = True),
-            mock.patch.object(ips, "IS_WINDOWS", True),
-            mock.patch.object(os.path, "isfile", lambda path: True),
-        ):
-            windows = ips._hardened_uv_config_paths()
-        assert any(path.startswith("C:\\a") for path in windows)
-        assert any(path.startswith("C:\\pd") for path in windows)
-        assert not any(path.replace(os.sep, "/").startswith("/etc/uv") for path in windows)
-
-    def test_a_deleted_working_directory_is_survivable(self):
-        with (
-            mock.patch.dict(os.environ, {"HOME": "/home/u"}, clear = True),
-            _posix_home(),
-            mock.patch.object(os, "getcwd", mock.Mock(side_effect = FileNotFoundError)),
-            mock.patch.object(os.path, "isfile", lambda path: True),
-        ):
-            assert isinstance(ips._hardened_uv_config_paths(), list)
-
-    def test_an_unstattable_path_is_skipped(self):
-        with (
-            mock.patch.dict(os.environ, {"HOME": "/home/u"}, clear = True),
-            _posix_home(),
-            mock.patch.object(os.path, "isfile", mock.Mock(side_effect = PermissionError)),
-        ):
-            assert ips._hardened_uv_config_paths() == []
-
-    def test_an_unreadable_or_undecodable_config_is_skipped(self, tmp_path):
-        undecodable = tmp_path / "uv.toml"
-        undecodable.write_bytes(b'name = "\xff\xfe"\nno-build = true\n')
-        ips._policy_scan.cache_clear()
+    def test_undecodable_probe_output_is_not_an_error(self):
+        ips._detected_policy.cache_clear()
+        result = mock.Mock(returncode = 0, stdout = b"\xff\xfe not utf-8 \x00\n")
         with (
             mock.patch.dict(os.environ, {}, clear = True),
-            mock.patch.object(ips.subprocess, "run", mock.Mock(side_effect = OSError)),
-            mock.patch.object(ips, "_hardened_uv_config_paths", lambda: [str(undecodable)]),
+            mock.patch.object(ips.subprocess, "run", return_value = result),
         ):
-            names = ips._hardened_pm_policy_names()
-        ips._policy_scan.cache_clear()
-        assert names == ("uv.toml no-build",), "lenient decoding, not a crash"
+            assert ips._hardened_pm_policy_names() == ()
+        ips._detected_policy.cache_clear()
 
 
 class TestProgressLineNotes:

--- a/tests/python/test_install_python_stack.py
+++ b/tests/python/test_install_python_stack.py
@@ -2910,3 +2910,89 @@ class TestAnExplicitNoIndexOverrideSurvivesTheOptOut:
             assert env is not None
             assert "PIP_NO_INDEX" not in env, value
             assert "PIP_FIND_LINKS" not in env, value
+
+
+class TestNoIndexCountsTheConfigFileNotJustTheEnvironment:
+    """`--no-index` means "ignore indexes, look only at find-links", so whether
+    PIP_FIND_LINKS is the sole source or an extra one depends on the EFFECTIVE state.
+    The opt-out keeps pip.conf readable, so a `no-index = true` living there counts;
+    reading only the environment scrubbed find-links as additive and left the pip
+    fallback with no sources at all.
+    """
+
+    PINNED = ["uv", "pip", "install", "--index-url", "https://pinned", "torch"]
+
+    @pytest.fixture
+    def no_index_conf(self, tmp_path):
+        path = tmp_path / "pip.conf"
+        path.write_text("[global]\nno-index = true\n", encoding = "utf-8")
+        return str(path)
+
+    def _env(self, monkeypatch, **environ):
+        for key in ("PIP_NO_INDEX", "PIP_FIND_LINKS", "PIP_CONFIG_FILE"):
+            monkeypatch.delenv(key, raising = False)
+        for key, value in environ.items():
+            monkeypatch.setenv(key, value)
+        ips._detected_policy.cache_clear()
+        try:
+            return ips._install_env_for_cmd(list(self.PINNED))
+        finally:
+            ips._detected_policy.cache_clear()
+
+    def test_find_links_survives_a_config_only_no_index(self, monkeypatch, no_index_conf):
+        env = self._env(
+            monkeypatch,
+            UNSLOTH_RESPECT_PM_POLICY = "1",
+            PIP_CONFIG_FILE = no_index_conf,
+            PIP_FIND_LINKS = "/op/wheels",
+        )
+        assert env is not None
+        assert env.get("PIP_FIND_LINKS") == "/op/wheels"
+
+    def test_find_links_is_still_scrubbed_with_no_no_index_anywhere(self, monkeypatch):
+        env = self._env(
+            monkeypatch,
+            UNSLOTH_RESPECT_PM_POLICY = "1",
+            PIP_CONFIG_FILE = os.devnull,
+            PIP_FIND_LINKS = "/op/wheels",
+        )
+        assert env is not None
+        assert "PIP_FIND_LINKS" not in env
+
+    def test_the_environment_overrides_the_config_in_both_directions(
+        self, monkeypatch, no_index_conf
+    ):
+        # pip reads the environment ahead of its files, so an explicit off wins and
+        # find-links goes back to being merely additive.
+        env = self._env(
+            monkeypatch,
+            UNSLOTH_RESPECT_PM_POLICY = "1",
+            PIP_CONFIG_FILE = no_index_conf,
+            PIP_NO_INDEX = "0",
+            PIP_FIND_LINKS = "/op/wheels",
+        )
+        assert env is not None
+        assert env.get("PIP_NO_INDEX") == "0"
+        assert "PIP_FIND_LINKS" not in env
+
+    def test_the_default_path_scrubs_both_and_asks_pip_nothing(self, monkeypatch, no_index_conf):
+        # The scan must not be reached without the opt-out: the default path is the one
+        # that has to stay exactly as it was.
+        monkeypatch.delenv("UNSLOTH_RESPECT_PM_POLICY", raising = False)
+        called = []
+        original = ips._detected_policy
+
+        def _spy():
+            called.append(True)
+            return original()
+
+        _spy.cache_clear = original.cache_clear
+        monkeypatch.setattr(ips, "_detected_policy", _spy)
+        env = self._env(
+            monkeypatch,
+            PIP_CONFIG_FILE = no_index_conf,
+            PIP_FIND_LINKS = "/op/wheels",
+        )
+        assert env is not None
+        assert "PIP_FIND_LINKS" not in env and "PIP_NO_INDEX" not in env
+        assert called == []

--- a/tests/python/test_install_python_stack.py
+++ b/tests/python/test_install_python_stack.py
@@ -1372,9 +1372,7 @@ class TestDetectionMatchesWhatTheManagersActuallyEnforce:
         first.write_text("[install]\nrequire-hashes = true\n", encoding = "utf-8")
         second = tmp_path / "site.conf"
         second.write_text("[global]\nrequire-hashes = false\n", encoding = "utf-8")
-        assert self._names({}, pip_files = [str(first), str(second)]) == (
-            "user.conf require-hashes",
-        )
+        assert self._names({}, pip_files = [str(first), str(second)]) == ("user.conf require-hashes",)
 
     def test_the_underscore_spelling_is_normalised(self, tmp_path):
         """pip's _normalize_name lowercases and turns underscores into dashes, so

--- a/tests/python/test_install_python_stack.py
+++ b/tests/python/test_install_python_stack.py
@@ -7,8 +7,6 @@ import contextlib
 import importlib
 import inspect
 import io
-import hashlib
-import pathlib
 import os
 import re
 import shutil

--- a/tests/python/test_install_python_stack.py
+++ b/tests/python/test_install_python_stack.py
@@ -1263,9 +1263,7 @@ class TestDetectionMatchesWhatTheManagersActuallyEnforce:
         first.write_text("[install]\nrequire-hashes = true\n", encoding = "utf-8")
         second = tmp_path / "site.conf"
         second.write_text("[wheel]\nrequire-hashes = false\n", encoding = "utf-8")
-        assert self._names({}, pip_files = [str(first), str(second)]) == (
-            "user.conf require-hashes",
-        )
+        assert self._names({}, pip_files = [str(first), str(second)]) == ("user.conf require-hashes",)
         # And the ordinary same-section override still works.
         third = tmp_path / "later.conf"
         third.write_text("[install]\nrequire-hashes = false\n", encoding = "utf-8")

--- a/tests/python/test_install_python_stack.py
+++ b/tests/python/test_install_python_stack.py
@@ -853,13 +853,16 @@ class TestConfigDetectionReadsValuesNotJustKeys:
             assert ips._hardened_pip_config_paths() == []
 
     def test_documented_pip_locations_are_searched(self):
+        # Separator-normalised: these force IS_WINDOWS=False to exercise the POSIX branch,
+        # but os.path.join still uses the RUNNER's separator, so a literal "/etc/pip.conf"
+        # would fail the whole suite on windows-latest.
         with (
             mock.patch.dict(os.environ, {"HOME": "/home/u"}, clear = True),
             mock.patch.object(ips, "IS_WINDOWS", False),
             mock.patch.object(ips, "IS_MACOS", False),
             mock.patch.object(os.path, "isfile", lambda path: True),
         ):
-            posix = ips._hardened_pip_config_paths()
+            posix = [path.replace(os.sep, "/") for path in ips._hardened_pip_config_paths()]
         assert "/etc/pip.conf" in posix
         assert "/etc/xdg/pip/pip.conf" in posix
         assert "/home/u/.config/pip/pip.conf" in posix
@@ -870,7 +873,7 @@ class TestConfigDetectionReadsValuesNotJustKeys:
             mock.patch.object(ips, "IS_MACOS", True),
             mock.patch.object(os.path, "isfile", lambda path: True),
         ):
-            macos = ips._hardened_pip_config_paths()
+            macos = [path.replace(os.sep, "/") for path in ips._hardened_pip_config_paths()]
         assert "/home/u/Library/Application Support/pip/pip.conf" in macos
         with (
             mock.patch.dict(
@@ -880,8 +883,8 @@ class TestConfigDetectionReadsValuesNotJustKeys:
             mock.patch.object(os.path, "isfile", lambda path: True),
         ):
             windows = ips._hardened_pip_config_paths()
-        assert all(path.endswith("pip.ini") for path in windows if "pip" in path)
-        assert any("C:\\pd" in path for path in windows)
+        assert windows and all(path.endswith("pip.ini") for path in windows)
+        assert any(path.startswith("C:\\pd") for path in windows)
 
     def test_a_malformed_pip_conf_is_survivable(self, tmp_path):
         config = tmp_path / "pip.conf"
@@ -1008,12 +1011,14 @@ class TestTheNoticeCannotTakeAnInstallDown:
         """uv reads ~/.config/uv/uv.toml on macOS AND Linux (not Application Support),
         %APPDATA%\\uv on Windows, with /etc/uv and %PROGRAMDATA%\\uv system-wide. The
         system one is where a fleet operator puts the policy this notice is about."""
+        # Separator-normalised for the same reason as the pip locations above: os.path.join
+        # follows the RUNNER, not the patched IS_WINDOWS.
         with (
             mock.patch.dict(os.environ, {"HOME": "/home/u"}, clear = True),
             mock.patch.object(ips, "IS_WINDOWS", False),
             mock.patch.object(os.path, "isfile", lambda path: True),
         ):
-            posix = ips._hardened_uv_config_paths()
+            posix = [path.replace(os.sep, "/") for path in ips._hardened_uv_config_paths()]
         assert "/home/u/.config/uv/uv.toml" in posix
         assert "/etc/uv/uv.toml" in posix
         with (
@@ -1024,9 +1029,9 @@ class TestTheNoticeCannotTakeAnInstallDown:
             mock.patch.object(os.path, "isfile", lambda path: True),
         ):
             windows = ips._hardened_uv_config_paths()
-        assert any("C:\\a" in path for path in windows)
-        assert any("C:\\pd" in path for path in windows)
-        assert not any(path.startswith("/etc/uv") for path in windows)
+        assert any(path.startswith("C:\\a") for path in windows)
+        assert any(path.startswith("C:\\pd") for path in windows)
+        assert not any(path.replace(os.sep, "/").startswith("/etc/uv") for path in windows)
 
     def test_a_deleted_working_directory_is_survivable(self):
         with (

--- a/tests/python/test_install_python_stack.py
+++ b/tests/python/test_install_python_stack.py
@@ -2777,3 +2777,36 @@ class TestDesktopBackendVersionConstraint:
                 else package_name
             )
             assert unsloth_spec == "unsloth"
+
+
+class TestAFalseCutoffOnlyDisablesTheManagerThatAcceptsIt:
+    """`false` is an off spelling for uv's exclude-newer and an ERROR for pip's cutoff.
+
+    Measured, not assumed. On the pinned uv 0.12.1, UV_EXCLUDE_NEWER=false resolves
+    normally while UV_EXCLUDE_NEWER=garbage is rejected, so uv understands `false` as
+    "no cutoff" rather than merely tolerating it. On pip 26.2.1 both
+    `--uploaded-prior-to false` and PIP_UPLOADED_PRIOR_TO=false exit with "Expected an
+    ISO 8601 datetime string". Treating pip's spelling as a disable let an unusable
+    environment value cancel a real pip.conf cutoff, which took the notice quiet about
+    a control the pinned path still drops.
+    """
+
+    def test_uv_cutoff_spellings_are_disabled_by_false(self):
+        for key in ("exclude-newer", "exclude-newer-package"):
+            assert ips._config_value_is_on("false", key) is False, key
+            assert ips._config_value_is_on("2026-01-01", key) is True, key
+
+    def test_pips_cutoff_is_not_disabled_by_a_value_pip_rejects(self):
+        # pip errors on this value, so it can neither be a cutoff nor an off switch.
+        # Reporting it keeps the notice honest about a setting that is still there.
+        assert ips._config_value_is_on("false", "uploaded-prior-to") is True
+        assert ips._config_value_is_on("false", "PIP_UPLOADED_PRIOR_TO") is True
+
+    def test_the_false_disables_set_holds_only_uv_spellings(self):
+        assert "uploaded-prior-to" not in ips._FALSE_DISABLES_KEYS
+        assert set(ips._FALSE_DISABLES_KEYS) == {"exclude-newer", "exclude-newer-package"}
+
+    def test_an_empty_cutoff_is_still_off_for_both(self):
+        for key in ("exclude-newer", "uploaded-prior-to"):
+            assert ips._config_value_is_on("", key) is False, key
+            assert ips._config_value_is_on("   ", key) is False, key

--- a/tests/python/test_install_python_stack.py
+++ b/tests/python/test_install_python_stack.py
@@ -3075,3 +3075,41 @@ class TestAFailedPipProbeIsNotMemoisedForTheRun:
             assert ips._pip_no_index_in_force() is True
         finally:
             ips._detected_policy.cache_clear()
+
+
+class TestUvFindLinksSurvivesTheOptOut:
+    """uv's no-index is undetectable, so its wheelhouse cannot be treated as additive.
+
+    Measured on the pinned uv 0.12.1: a uv.toml `[pip] no-index = true` plus
+    UV_FIND_LINKS installs from the wheelhouse, and the same pinned command without it
+    fails with "index lookups were disabled and no additional package locations were
+    provided". `--no-index` has no environment spelling and uv prints no resolved
+    configuration, so unlike pip there is nothing to ask; guessing wrong in that
+    direction breaks every offline uv install.
+    """
+
+    PINNED = ["uv", "pip", "install", "--index-url", "https://pinned", "torch"]
+
+    def test_the_wheelhouse_reaches_uv_under_the_opt_out(self, monkeypatch):
+        monkeypatch.setenv("UNSLOTH_RESPECT_PM_POLICY", "1")
+        monkeypatch.setenv("UV_FIND_LINKS", "/op/wheels")
+        env = ips._install_env_for_cmd(list(self.PINNED))
+        assert env is not None
+        assert env.get("UV_FIND_LINKS") == "/op/wheels"
+
+    def test_the_additive_mirrors_are_still_scrubbed_alongside_it(self, monkeypatch):
+        monkeypatch.setenv("UNSLOTH_RESPECT_PM_POLICY", "1")
+        monkeypatch.setenv("UV_FIND_LINKS", "/op/wheels")
+        for name in ("UV_INDEX_URL", "UV_EXTRA_INDEX_URL", "UV_DEFAULT_INDEX"):
+            monkeypatch.setenv(name, "https://mirror.corp")
+        env = ips._install_env_for_cmd(list(self.PINNED))
+        assert env is not None
+        for name in ("UV_INDEX_URL", "UV_EXTRA_INDEX_URL", "UV_DEFAULT_INDEX"):
+            assert name not in env, name
+
+    def test_the_default_path_still_scrubs_it(self, monkeypatch):
+        monkeypatch.delenv("UNSLOTH_RESPECT_PM_POLICY", raising = False)
+        monkeypatch.setenv("UV_FIND_LINKS", "/op/wheels")
+        env = ips._install_env_for_cmd(list(self.PINNED))
+        assert env is not None
+        assert "UV_FIND_LINKS" not in env

--- a/tests/python/test_install_python_stack.py
+++ b/tests/python/test_install_python_stack.py
@@ -23,6 +23,17 @@ sys.path.insert(0, str(STUDIO_DIR))
 import install_python_stack as ips
 
 
+def _posix_home(path: str = "/home/u"):
+    """Make os.path.expanduser deterministic regardless of the RUNNER's platform.
+
+    ntpath.expanduser reads USERPROFILE, not HOME, so on windows-latest a test that only
+    sets HOME gets a literal "~" back and the POSIX branch it is exercising cannot be
+    asserted at all. Patching the function is the honest fix: these tests are about which
+    locations the installer searches, not about how a platform spells a home directory.
+    """
+    return mock.patch.object(os.path, "expanduser", lambda p: p.replace("~", path, 1))
+
+
 class TestBuildUvCmdTorchBackend:
     """Verify _build_uv_cmd only adds --torch-backend when UV_TORCH_BACKEND is set."""
 
@@ -858,6 +869,7 @@ class TestConfigDetectionReadsValuesNotJustKeys:
         # would fail the whole suite on windows-latest.
         with (
             mock.patch.dict(os.environ, {"HOME": "/home/u"}, clear = True),
+            _posix_home(),
             mock.patch.object(ips, "IS_WINDOWS", False),
             mock.patch.object(ips, "IS_MACOS", False),
             mock.patch.object(os.path, "isfile", lambda path: True),
@@ -869,6 +881,7 @@ class TestConfigDetectionReadsValuesNotJustKeys:
         assert "/home/u/.pip/pip.conf" in posix
         with (
             mock.patch.dict(os.environ, {"HOME": "/home/u"}, clear = True),
+            _posix_home(),
             mock.patch.object(ips, "IS_WINDOWS", False),
             mock.patch.object(ips, "IS_MACOS", True),
             mock.patch.object(os.path, "isfile", lambda path: True),
@@ -1052,6 +1065,7 @@ class TestPipGlobalConfigFollowsXdg:
                 {"HOME": "/home/u", "XDG_CONFIG_DIRS": os.pathsep.join(["/a", "/b"])},
                 clear = True,
             ),
+            _posix_home(),
             mock.patch.object(ips, "IS_WINDOWS", False),
             mock.patch.object(ips, "IS_MACOS", False),
             mock.patch.object(os.path, "isfile", lambda path: True),
@@ -1064,6 +1078,7 @@ class TestPipGlobalConfigFollowsXdg:
     def test_the_default_is_used_when_unset(self):
         with (
             mock.patch.dict(os.environ, {"HOME": "/home/u"}, clear = True),
+            _posix_home(),
             mock.patch.object(ips, "IS_WINDOWS", False),
             mock.patch.object(ips, "IS_MACOS", False),
             mock.patch.object(os.path, "isfile", lambda path: True),
@@ -1074,6 +1089,7 @@ class TestPipGlobalConfigFollowsXdg:
     def test_macos_reads_its_global_set_from_xdg_data_dirs(self):
         with (
             mock.patch.dict(os.environ, {"HOME": "/home/u"}, clear = True),
+            _posix_home(),
             mock.patch.object(ips, "IS_WINDOWS", False),
             mock.patch.object(ips, "IS_MACOS", True),
             mock.patch.object(os.path, "isfile", lambda path: True),
@@ -1084,6 +1100,7 @@ class TestPipGlobalConfigFollowsXdg:
             mock.patch.dict(
                 os.environ, {"HOME": "/home/u", "XDG_DATA_DIRS": "/d"}, clear = True
             ),
+            _posix_home(),
             mock.patch.object(ips, "IS_WINDOWS", False),
             mock.patch.object(ips, "IS_MACOS", True),
             mock.patch.object(os.path, "isfile", lambda path: True),
@@ -1215,6 +1232,7 @@ class TestTheNoticeCannotTakeAnInstallDown:
         # follows the RUNNER, not the patched IS_WINDOWS.
         with (
             mock.patch.dict(os.environ, {"HOME": "/home/u"}, clear = True),
+            _posix_home(),
             mock.patch.object(ips, "IS_WINDOWS", False),
             mock.patch.object(os.path, "isfile", lambda path: True),
         ):
@@ -1236,6 +1254,7 @@ class TestTheNoticeCannotTakeAnInstallDown:
     def test_a_deleted_working_directory_is_survivable(self):
         with (
             mock.patch.dict(os.environ, {"HOME": "/home/u"}, clear = True),
+            _posix_home(),
             mock.patch.object(os, "getcwd", mock.Mock(side_effect = FileNotFoundError)),
             mock.patch.object(os.path, "isfile", lambda path: True),
         ):
@@ -1244,6 +1263,7 @@ class TestTheNoticeCannotTakeAnInstallDown:
     def test_an_unstattable_path_is_skipped(self):
         with (
             mock.patch.dict(os.environ, {"HOME": "/home/u"}, clear = True),
+            _posix_home(),
             mock.patch.object(os.path, "isfile", mock.Mock(side_effect = PermissionError)),
         ):
             assert ips._hardened_uv_config_paths() == []

--- a/tests/python/test_install_python_stack.py
+++ b/tests/python/test_install_python_stack.py
@@ -586,7 +586,7 @@ class TestHardenedPolicyIsAnnounced:
     """
 
     def _names(self, env: dict, pip_config: str = ""):
-        ips._hardened_pm_policy_names.cache_clear()
+        ips._detected_policy.cache_clear()
         result = mock.Mock(returncode = 0, stdout = pip_config.encode())
         with (
             mock.patch.dict(os.environ, env, clear = True),
@@ -596,7 +596,7 @@ class TestHardenedPolicyIsAnnounced:
             try:
                 return ips._hardened_pm_policy_names()
             finally:
-                ips._hardened_pm_policy_names.cache_clear()
+                ips._detected_policy.cache_clear()
 
     def test_an_ordinary_machine_says_nothing(self):
         assert self._names({}) == ()
@@ -620,14 +620,14 @@ class TestHardenedPolicyIsAnnounced:
     def test_uv_config_hardening_is_reported(self, tmp_path):
         config = tmp_path / "uv.toml"
         config.write_text("# no-build = true\nno-build = true\n", encoding = "utf-8")
-        ips._hardened_pm_policy_names.cache_clear()
+        ips._detected_policy.cache_clear()
         with (
             mock.patch.dict(os.environ, {}, clear = True),
             mock.patch.object(ips.subprocess, "run", side_effect = OSError),
             mock.patch.object(ips, "_hardened_uv_config_paths", lambda: [str(config)]),
         ):
             names = ips._hardened_pm_policy_names()
-        ips._hardened_pm_policy_names.cache_clear()
+        ips._detected_policy.cache_clear()
         assert names == ("uv.toml no-build",)
 
     def test_the_notice_names_the_opt_out(self, capsys):
@@ -739,7 +739,7 @@ class TestConfigDetectionReadsValuesNotJustKeys:
     """The notice is only worth printing if it is accurate in both directions."""
 
     def _names(self, environment, pip_ok = False, pip_config = "", uv_files = ()):
-        ips._hardened_pm_policy_names.cache_clear()
+        ips._detected_policy.cache_clear()
         runner = (
             mock.Mock(return_value = mock.Mock(returncode = 0, stdout = pip_config.encode()))
             if pip_ok
@@ -752,7 +752,7 @@ class TestConfigDetectionReadsValuesNotJustKeys:
             mock.patch.object(ips, "_hardened_pip_config_paths", lambda: []),
         ):
             names = ips._hardened_pm_policy_names()
-        ips._hardened_pm_policy_names.cache_clear()
+        ips._detected_policy.cache_clear()
         return names
 
     @pytest.mark.parametrize(
@@ -815,7 +815,7 @@ class TestConfigDetectionReadsValuesNotJustKeys:
         config = tmp_path / "pip.conf"
         config.write_text("[global]\nrequire-hashes = true\nindex-url = https://m/s\n",
                           encoding = "utf-8")
-        ips._hardened_pm_policy_names.cache_clear()
+        ips._detected_policy.cache_clear()
         with (
             mock.patch.dict(os.environ, {}, clear = True),
             mock.patch.object(ips.subprocess, "run", mock.Mock(side_effect = OSError)),
@@ -823,7 +823,7 @@ class TestConfigDetectionReadsValuesNotJustKeys:
             mock.patch.object(ips, "_hardened_pip_config_paths", lambda: [str(config)]),
         ):
             names = ips._hardened_pm_policy_names()
-        ips._hardened_pm_policy_names.cache_clear()
+        ips._detected_policy.cache_clear()
         assert names == ("pip.conf require-hashes",), "a mirror is not hardening"
 
     def test_pip_files_are_not_double_read_when_pip_answers(self, tmp_path):
@@ -831,7 +831,7 @@ class TestConfigDetectionReadsValuesNotJustKeys:
         the subprocess works its answer is the whole answer."""
         config = tmp_path / "pip.conf"
         config.write_text("[global]\nonly-binary = :all:\n", encoding = "utf-8")
-        ips._hardened_pm_policy_names.cache_clear()
+        ips._detected_policy.cache_clear()
         with (
             mock.patch.dict(os.environ, {}, clear = True),
             mock.patch.object(
@@ -843,7 +843,7 @@ class TestConfigDetectionReadsValuesNotJustKeys:
             mock.patch.object(ips, "_hardened_pip_config_paths", lambda: [str(config)]),
         ):
             names = ips._hardened_pm_policy_names()
-        ips._hardened_pm_policy_names.cache_clear()
+        ips._detected_policy.cache_clear()
         assert names == ("pip.conf require-hashes",)
 
     def test_devnull_pip_config_means_no_files_at_all(self):
@@ -890,6 +890,206 @@ class TestConfigDetectionReadsValuesNotJustKeys:
         config = tmp_path / "pip.conf"
         config.write_text("this is not ini at all\n[[[\n", encoding = "utf-8")
         assert ips._hardened_keys_in_ini(config.read_text(encoding = "utf-8")) == []
+
+
+class TestNeitherManagerIsLetOffTheOthersPolicy:
+    """pip and uv read none of each other's policy, so under the opt-out the manager that
+    actually runs has to be told the other's in its own spelling.
+
+    Measured on the pinned uv 0.12.1: `uv pip install` of an unhashed wheel succeeds with
+    PIP_REQUIRE_HASHES=1 set AND with a pip.conf require-hashes, and is rejected only by
+    UV_REQUIRE_HASHES=1. So a pip-only policy plus the uv path was a silent bypass, and
+    the reverse holds when uv is unavailable and pip is selected.
+    """
+
+    def _detect(self, entries):
+        return mock.patch.object(ips, "_detected_policy", lambda: tuple(entries))
+
+    def test_pip_policy_reaches_a_uv_command(self):
+        with (
+            mock.patch.dict(os.environ, {"UNSLOTH_RESPECT_PM_POLICY": "1"}, clear = True),
+            self._detect([("pip", "env", "PIP_REQUIRE_HASHES")]),
+        ):
+            env = ips._install_env_for_cmd(["uv", "pip", "install", "-r", "extras.txt"])
+        assert env is not None and env["UV_REQUIRE_HASHES"] == "1"
+
+    def test_pip_conf_policy_reaches_a_uv_command(self):
+        """The file-sourced half matters most: uv cannot read pip.conf at all."""
+        with (
+            mock.patch.dict(os.environ, {"UNSLOTH_RESPECT_PM_POLICY": "1"}, clear = True),
+            self._detect([("pip", "pip.conf", "require-hashes")]),
+        ):
+            env = ips._install_env_for_cmd(["uv", "pip", "install", "-r", "extras.txt"])
+        assert env is not None and env["UV_REQUIRE_HASHES"] == "1"
+
+    def test_only_binary_translates_to_uv_no_build(self):
+        """pip's only-binary is "wheels only", which uv spells as no-build."""
+        with (
+            mock.patch.dict(os.environ, {"UNSLOTH_RESPECT_PM_POLICY": "1"}, clear = True),
+            self._detect([("pip", "pip.conf", "only-binary")]),
+        ):
+            env = ips._install_env_for_cmd(["uv", "pip", "install", "x"])
+        assert env is not None and env["UV_NO_BUILD"] == "1"
+
+    def test_uv_policy_reaches_a_pip_command(self):
+        with (
+            mock.patch.dict(os.environ, {"UNSLOTH_RESPECT_PM_POLICY": "1"}, clear = True),
+            self._detect([("uv", "uv.toml", "require-hashes"), ("uv", "env", "UV_NO_BUILD")]),
+        ):
+            env = ips._install_env_for_cmd(["python", "-m", "pip", "install", "x"])
+        assert env is not None
+        assert env["PIP_REQUIRE_HASHES"] == "1"
+        assert env["PIP_ONLY_BINARY"] == ":all:"
+
+    def test_the_operators_own_spelling_always_wins(self):
+        """A translation must never overwrite a value the operator set themselves."""
+        with (
+            mock.patch.dict(
+                os.environ,
+                {"UNSLOTH_RESPECT_PM_POLICY": "1", "UV_REQUIRE_HASHES": "0"},
+                clear = True,
+            ),
+            self._detect([("pip", "env", "PIP_REQUIRE_HASHES")]),
+        ):
+            # Nothing to override, so the caller env is inherited whole and the
+            # operator's explicit UV_REQUIRE_HASHES=0 reaches uv untouched.
+            assert ips._install_env_for_cmd(["uv", "pip", "install", "x"]) is None
+
+    def test_nothing_is_translated_without_the_opt_out(self):
+        """The default path must be untouched: translating there would BREAK #8530's fix
+        by teaching uv a policy it was deliberately not being told about."""
+        with (
+            mock.patch.dict(os.environ, {"PIP_REQUIRE_HASHES": "1"}, clear = True),
+            self._detect([("pip", "env", "PIP_REQUIRE_HASHES")]),
+        ):
+            assert ips._install_env_for_cmd(["uv", "pip", "install", "x"]) is None
+
+    def test_same_tool_policy_is_not_restated(self):
+        """uv already reads its own; restating it would be noise, not enforcement."""
+        with (
+            mock.patch.dict(os.environ, {"UNSLOTH_RESPECT_PM_POLICY": "1"}, clear = True),
+            self._detect([("uv", "env", "UV_REQUIRE_HASHES")]),
+        ):
+            assert ips._install_env_for_cmd(["uv", "pip", "install", "x"]) is None
+
+    def test_an_explicit_uv_config_file_survives_a_pinned_install(self):
+        """UV_CONFIG_FILE is in the index-scrub tuple only incidentally. Measured: a file
+        named by it carrying `[pip] require-hashes = true` fails a pinned install (rc=2)
+        and the identical command without the variable succeeds, so dropping it under the
+        opt-out discarded the operator's policy file."""
+        with mock.patch.dict(
+            os.environ,
+            {"UNSLOTH_RESPECT_PM_POLICY": "1", "UV_CONFIG_FILE": "/etc/uv/uv.toml",
+             "UV_INDEX_URL": "https://mirror.corp/simple"},
+            clear = True,
+        ):
+            env = ips._install_env_for_cmd(
+                ["uv", "pip", "install", "torch", "--index-url", "https://x/cu128"]
+            )
+        assert env is not None
+        assert env["UV_CONFIG_FILE"] == "/etc/uv/uv.toml"
+        assert "UV_INDEX_URL" not in env, "the index scrub still applies"
+
+    def test_the_default_path_still_drops_the_uv_config_file(self):
+        with mock.patch.dict(os.environ, {"UV_CONFIG_FILE": "/etc/uv/uv.toml"}, clear = True):
+            env = ips._install_env_for_cmd(
+                ["uv", "pip", "install", "torch", "--index-url", "https://x/cu128"]
+            )
+        assert env is not None and "UV_CONFIG_FILE" not in env
+
+
+class TestTheLegacyTomlFallbackTracksTables:
+    """3.9/3.10 have no tomllib, and the fallback must not be sloppier than the parser."""
+
+    def _keys(self, body, tables):
+        with mock.patch.object(ips, "_tomllib", None):
+            return ips._hardened_keys_in_toml(body, tables)
+
+    def test_an_unrelated_table_is_not_uv_policy(self):
+        body = '[project]\nname = "x"\n[tool.other]\nno-build = true\n'
+        assert self._keys(body, (("tool", "uv"), ("tool", "uv", "pip"))) == []
+        assert self._keys(body, (("tool", "other"),)) == ["no-build"]
+
+    def test_the_uv_tables_are_still_found(self):
+        body = '[project]\nname = "x"\n[tool.uv.pip]\nrequire-hashes = true\n'
+        assert self._keys(body, (("tool", "uv"), ("tool", "uv", "pip"))) == ["require-hashes"]
+
+    def test_root_and_pip_tables_of_a_uv_toml(self):
+        body = "no-build = true\n[pip]\nrequire-hashes = true\n"
+        assert self._keys(body, ((), ("pip",))) == ["no-build", "require-hashes"]
+
+    @pytest.mark.parametrize("value, on", [("[]", False), ("[ ]", False),
+                                           ("{}", False), ('["torch"]', True)])
+    def test_empty_collections_are_off(self, value, on):
+        keys = self._keys(f"no-build-package = {value}\n", ((),))
+        assert bool(keys) is on
+
+    def test_the_parser_and_the_fallback_agree(self, tmp_path):
+        bodies = [
+            '[project]\nname = "x"\n[tool.other]\nno-build = true\n',
+            '[project]\nname = "x"\n[tool.uv.pip]\nrequire-hashes = true\n',
+            "no-build-package = []\n",
+            'no-build-package = ["torch"]\n',
+            "[pip]\nrequire-hashes = false\n",
+        ]
+        for body in bodies:
+            tables = (("tool", "uv"), ("tool", "uv", "pip")) if "[tool." in body else ((), ("pip",))
+            with mock.patch.object(ips, "_tomllib", None):
+                fallback = ips._hardened_keys_in_toml(body, tables)
+            parsed = ips._hardened_keys_in_toml(body, tables)
+            assert fallback == parsed, f"fallback disagrees with tomllib for {body!r}"
+
+
+class TestPipGlobalConfigFollowsXdg:
+    """pip's global config is every entry of XDG_CONFIG_DIRS, not the default alone.
+    Measured with pip 26: `XDG_CONFIG_DIRS=/a:/b pip config debug` enumerates
+    /a/pip/pip.conf and /b/pip/pip.conf."""
+
+    def test_every_configured_directory_is_searched(self):
+        with (
+            mock.patch.dict(
+                os.environ,
+                {"HOME": "/home/u", "XDG_CONFIG_DIRS": os.pathsep.join(["/a", "/b"])},
+                clear = True,
+            ),
+            mock.patch.object(ips, "IS_WINDOWS", False),
+            mock.patch.object(ips, "IS_MACOS", False),
+            mock.patch.object(os.path, "isfile", lambda path: True),
+        ):
+            paths = [path.replace(os.sep, "/") for path in ips._hardened_pip_config_paths()]
+        assert "/a/pip/pip.conf" in paths
+        assert "/b/pip/pip.conf" in paths
+        assert "/etc/pip.conf" in paths, "the non-XDG global is separate and still read"
+
+    def test_the_default_is_used_when_unset(self):
+        with (
+            mock.patch.dict(os.environ, {"HOME": "/home/u"}, clear = True),
+            mock.patch.object(ips, "IS_WINDOWS", False),
+            mock.patch.object(ips, "IS_MACOS", False),
+            mock.patch.object(os.path, "isfile", lambda path: True),
+        ):
+            paths = [path.replace(os.sep, "/") for path in ips._hardened_pip_config_paths()]
+        assert "/etc/xdg/pip/pip.conf" in paths
+
+    def test_macos_reads_its_global_set_from_xdg_data_dirs(self):
+        with (
+            mock.patch.dict(os.environ, {"HOME": "/home/u"}, clear = True),
+            mock.patch.object(ips, "IS_WINDOWS", False),
+            mock.patch.object(ips, "IS_MACOS", True),
+            mock.patch.object(os.path, "isfile", lambda path: True),
+        ):
+            paths = [path.replace(os.sep, "/") for path in ips._hardened_pip_config_paths()]
+        assert "/Library/Application Support/pip/pip.conf" in paths
+        with (
+            mock.patch.dict(
+                os.environ, {"HOME": "/home/u", "XDG_DATA_DIRS": "/d"}, clear = True
+            ),
+            mock.patch.object(ips, "IS_WINDOWS", False),
+            mock.patch.object(ips, "IS_MACOS", True),
+            mock.patch.object(os.path, "isfile", lambda path: True),
+        ):
+            paths = [path.replace(os.sep, "/") for path in ips._hardened_pip_config_paths()]
+        assert "/d/pip/pip.conf" in paths
 
 
 class TestPolicyEnvIsPlatformAndHardwareInvariant:
@@ -969,12 +1169,12 @@ class TestTheNoticeCannotTakeAnInstallDown:
         """An unbounded probe on a half-written pip is a hang with no output at all."""
         source = Path(ips.__file__).read_text(encoding = "utf-8")
         body = source[
-            source.index("def _hardened_pm_policy_names") : source.index("def _announce_pm_policy")
+            source.index("def _detected_policy") : source.index("def _hardened_pm_policy_names")
         ]
         assert "timeout = 30" in body, "the pip config probe must pass an explicit timeout"
 
     def test_a_hanging_pip_still_yields_the_environment_half(self):
-        ips._hardened_pm_policy_names.cache_clear()
+        ips._detected_policy.cache_clear()
         with (
             mock.patch.dict(os.environ, {"PIP_REQUIRE_HASHES": "1"}, clear = True),
             mock.patch.object(
@@ -984,7 +1184,7 @@ class TestTheNoticeCannotTakeAnInstallDown:
             mock.patch.object(ips, "_hardened_uv_config_paths", lambda: []),
         ):
             names = ips._hardened_pm_policy_names()
-        ips._hardened_pm_policy_names.cache_clear()
+        ips._detected_policy.cache_clear()
         assert names == ("PIP_REQUIRE_HASHES",)
 
     def test_the_call_site_swallows_anything(self):
@@ -1051,14 +1251,14 @@ class TestTheNoticeCannotTakeAnInstallDown:
     def test_an_unreadable_or_undecodable_config_is_skipped(self, tmp_path):
         undecodable = tmp_path / "uv.toml"
         undecodable.write_bytes(b'name = "\xff\xfe"\nno-build = true\n')
-        ips._hardened_pm_policy_names.cache_clear()
+        ips._detected_policy.cache_clear()
         with (
             mock.patch.dict(os.environ, {}, clear = True),
             mock.patch.object(ips.subprocess, "run", mock.Mock(side_effect = OSError)),
             mock.patch.object(ips, "_hardened_uv_config_paths", lambda: [str(undecodable)]),
         ):
             names = ips._hardened_pm_policy_names()
-        ips._hardened_pm_policy_names.cache_clear()
+        ips._detected_policy.cache_clear()
         assert names == ("uv.toml no-build",), "lenient decoding, not a crash"
 
 

--- a/tests/python/test_install_python_stack.py
+++ b/tests/python/test_install_python_stack.py
@@ -656,6 +656,174 @@ class TestHardenedPolicyIsAnnounced:
         assert capsys.readouterr().out == ""
 
 
+class TestPolicyEnvIsPlatformAndHardwareInvariant:
+    """The env this helper builds must not depend on the platform or the accelerator.
+
+    It reads no hardware state and it should stay that way: an installer change that
+    quietly behaves differently on one of [Windows, Linux, WSL, macOS] x [NVIDIA, AMD,
+    CPU] is the failure mode that costs a release. Asserted by construction rather than
+    trusted, and the accelerator variables are checked to PASS THROUGH untouched, since
+    the torch repair steps downstream read them.
+    """
+
+    PLATFORMS = {
+        "Linux": {"IS_WINDOWS": False, "IS_MACOS": False, "IS_MAC_ARM": False},
+        # WSL is Linux to this module; the markers are carried to prove they are inert.
+        "WSL": {"IS_WINDOWS": False, "IS_MACOS": False, "IS_MAC_ARM": False},
+        "Windows": {"IS_WINDOWS": True, "IS_MACOS": False, "IS_MAC_ARM": False},
+        "macOS": {"IS_WINDOWS": False, "IS_MACOS": True, "IS_MAC_ARM": True},
+    }
+    ACCELERATORS = {
+        "nvidia": {"CUDA_VISIBLE_DEVICES": "0", "UNSLOTH_TORCH_BACKEND": "cuda"},
+        "amd": {"HIP_VISIBLE_DEVICES": "0", "HSA_OVERRIDE_GFX_VERSION": "11.0.0"},
+        "cpu": {"UNSLOTH_TORCH_BACKEND": "cpu"},
+    }
+    COMMANDS = [
+        ["python", "-m", "pip", "install", "-r", "extras.txt"],
+        ["python", "-m", "pip", "download", "pytorch-triton-xpu==3.5.0"],
+        ["python", "-m", "pip", "check"],
+        ["uv", "pip", "install", "-r", "base.txt"],
+        ["uv", "pip", "install", "torch", "--index-url", "https://x/cu128"],
+        ["python", "-m", "pip", "install", "torch", "--default-index", "https://x/rocm6.4"],
+    ]
+
+    @pytest.mark.parametrize("opt_out", ["", "1"])
+    @pytest.mark.parametrize("hardened", [False, True])
+    def test_identical_on_every_platform_and_accelerator(self, opt_out, hardened):
+        policy = TestHardenedPipConfigRelaxation.HOSTILE if hardened else {}
+        for command in self.COMMANDS:
+            answers = set()
+            for platform, settings in self.PLATFORMS.items():
+                for accelerator, markers in self.ACCELERATORS.items():
+                    env = dict(policy, **markers)
+                    if opt_out:
+                        env["UNSLOTH_RESPECT_PM_POLICY"] = opt_out
+                    if platform == "WSL":
+                        env["WSL_DISTRO_NAME"] = "Ubuntu"
+                    with (
+                        mock.patch.dict(os.environ, env, clear = True),
+                        mock.patch.multiple(ips, **settings),
+                    ):
+                        result = ips._install_env_for_cmd(list(command))
+                    # Only the keys this helper owns; the markers themselves differ.
+                    answers.add(
+                        None
+                        if result is None
+                        else repr(sorted(
+                            (k, v) for k, v in result.items()
+                            if k.startswith(("PIP_", "UV_"))
+                        ))
+                    )
+                    if result is not None:
+                        for name, value in markers.items():
+                            assert result[name] == value, (
+                                f"{accelerator} marker {name} was dropped on {platform}"
+                            )
+            assert len(answers) == 1, (
+                f"{command} produced different environments across platforms: {answers}"
+            )
+
+
+class TestTheNoticeCannotTakeAnInstallDown:
+    """It runs BEFORE the pip upgrade, against a venv uv may have created without pip,
+    and it reads files off disk. Every way that can go wrong must cost the notice, not
+    the install."""
+
+    def test_the_pip_probe_is_bounded(self):
+        """An unbounded probe on a half-written pip is a hang with no output at all."""
+        source = Path(ips.__file__).read_text(encoding = "utf-8")
+        body = source[
+            source.index("def _hardened_pm_policy_names") : source.index("def _announce_pm_policy")
+        ]
+        assert "timeout = 30" in body, "the pip config probe must pass an explicit timeout"
+
+    def test_a_hanging_pip_still_yields_the_environment_half(self):
+        ips._hardened_pm_policy_names.cache_clear()
+        with (
+            mock.patch.dict(os.environ, {"PIP_REQUIRE_HASHES": "1"}, clear = True),
+            mock.patch.object(
+                ips.subprocess, "run",
+                mock.Mock(side_effect = ips.subprocess.TimeoutExpired("pip", 30)),
+            ),
+            mock.patch.object(ips, "_hardened_uv_config_paths", lambda: []),
+        ):
+            names = ips._hardened_pm_policy_names()
+        ips._hardened_pm_policy_names.cache_clear()
+        assert names == ("PIP_REQUIRE_HASHES",)
+
+    def test_the_call_site_swallows_anything(self):
+        """The notice is a message, not a step. Nothing it probes is worth aborting on."""
+        source = Path(ips.__file__).read_text(encoding = "utf-8")
+        assert (
+            "try:\n        _announce_pm_policy()\n    except Exception:\n        pass" in source
+        ), "install_python_stack() must guard the notice"
+
+    @pytest.mark.parametrize(
+        "environment",
+        [{}, {"HOME": "/home/u"}, {"XDG_CONFIG_HOME": "/xdg"}, {"APPDATA": "C:\\a"}],
+    )
+    @pytest.mark.parametrize("windows", [False, True])
+    def test_path_discovery_never_raises(self, environment, windows):
+        """A service account with no HOME, or Windows with no APPDATA, still installs."""
+        with (
+            mock.patch.dict(os.environ, environment, clear = True),
+            mock.patch.object(ips, "IS_WINDOWS", windows),
+        ):
+            assert isinstance(ips._hardened_uv_config_paths(), list)
+
+    def test_documented_config_locations_are_searched(self):
+        """uv reads ~/.config/uv/uv.toml on macOS AND Linux (not Application Support),
+        %APPDATA%\\uv on Windows, with /etc/uv and %PROGRAMDATA%\\uv system-wide. The
+        system one is where a fleet operator puts the policy this notice is about."""
+        with (
+            mock.patch.dict(os.environ, {"HOME": "/home/u"}, clear = True),
+            mock.patch.object(ips, "IS_WINDOWS", False),
+            mock.patch.object(os.path, "isfile", lambda path: True),
+        ):
+            posix = ips._hardened_uv_config_paths()
+        assert "/home/u/.config/uv/uv.toml" in posix
+        assert "/etc/uv/uv.toml" in posix
+        with (
+            mock.patch.dict(
+                os.environ, {"APPDATA": "C:\\a", "PROGRAMDATA": "C:\\pd"}, clear = True
+            ),
+            mock.patch.object(ips, "IS_WINDOWS", True),
+            mock.patch.object(os.path, "isfile", lambda path: True),
+        ):
+            windows = ips._hardened_uv_config_paths()
+        assert any("C:\\a" in path for path in windows)
+        assert any("C:\\pd" in path for path in windows)
+        assert not any(path.startswith("/etc/uv") for path in windows)
+
+    def test_a_deleted_working_directory_is_survivable(self):
+        with (
+            mock.patch.dict(os.environ, {"HOME": "/home/u"}, clear = True),
+            mock.patch.object(os, "getcwd", mock.Mock(side_effect = FileNotFoundError)),
+            mock.patch.object(os.path, "isfile", lambda path: True),
+        ):
+            assert isinstance(ips._hardened_uv_config_paths(), list)
+
+    def test_an_unstattable_path_is_skipped(self):
+        with (
+            mock.patch.dict(os.environ, {"HOME": "/home/u"}, clear = True),
+            mock.patch.object(os.path, "isfile", mock.Mock(side_effect = PermissionError)),
+        ):
+            assert ips._hardened_uv_config_paths() == []
+
+    def test_an_unreadable_or_undecodable_config_is_skipped(self, tmp_path):
+        undecodable = tmp_path / "uv.toml"
+        undecodable.write_bytes(b'name = "\xff\xfe"\nno-build = true\n')
+        ips._hardened_pm_policy_names.cache_clear()
+        with (
+            mock.patch.dict(os.environ, {}, clear = True),
+            mock.patch.object(ips.subprocess, "run", mock.Mock(side_effect = OSError)),
+            mock.patch.object(ips, "_hardened_uv_config_paths", lambda: [str(undecodable)]),
+        ):
+            names = ips._hardened_pm_policy_names()
+        ips._hardened_pm_policy_names.cache_clear()
+        assert names == ("uv.toml no-build",), "lenient decoding, not a crash"
+
+
 class TestProgressLineNotes:
     """_progress() leaves the cursor mid-line, so anything printed between two
     progress steps must close that line first. Before centralising this, a real

--- a/tests/python/test_install_python_stack.py
+++ b/tests/python/test_install_python_stack.py
@@ -630,9 +630,7 @@ class TestDestructiveRepairsDoNotStartUnderTheOptOut:
     """
 
     def test_the_metadata_repair_declines_before_staging(self, capsys):
-        with mock.patch.dict(
-            os.environ, {"UNSLOTH_RESPECT_PM_POLICY": "1"}, clear = True
-        ):
+        with mock.patch.dict(os.environ, {"UNSLOTH_RESPECT_PM_POLICY": "1"}, clear = True):
             assert ips._stage_replacement("unsloth-zoo") is None
         out = capsys.readouterr().err
         assert "UNSLOTH_RESPECT_PM_POLICY" in out and "leaving the install alone" in out

--- a/tests/python/test_install_python_stack.py
+++ b/tests/python/test_install_python_stack.py
@@ -1517,11 +1517,17 @@ class TestDetectionMatchesWhatTheManagersActuallyEnforce:
     @pytest.mark.parametrize(
         "body,tables,expected",
         [
-            ("[tool]\nuv = { pip = { require-hashes = true } }\n",
-             (("tool", "uv"), ("tool", "uv", "pip")), ["require-hashes"]),
+            (
+                "[tool]\nuv = { pip = { require-hashes = true } }\n",
+                (("tool", "uv"), ("tool", "uv", "pip")),
+                ["require-hashes"],
+            ),
             ("pip = { require-hashes = true }\n", ((), ("pip",)), ["require-hashes"]),
-            ("[other]\nuv = { pip = { require-hashes = true } }\n",
-             (("tool", "uv"), ("tool", "uv", "pip")), []),
+            (
+                "[other]\nuv = { pip = { require-hashes = true } }\n",
+                (("tool", "uv"), ("tool", "uv", "pip")),
+                [],
+            ),
         ],
     )
     def test_the_legacy_parser_reads_inline_tables(self, body, tables, expected):
@@ -1534,8 +1540,9 @@ class TestDetectionMatchesWhatTheManagersActuallyEnforce:
         """`exclude-newer-package = {}` reached the value conversion as an empty dict and
         came out as the string "{}", which is not an off spelling. uv applies no cutoff
         for it, and under the opt-out the phantom control could stop a pip step."""
-        assert ips._hardened_keys_in_toml("[pip]\nexclude-newer-package = {}\n",
-                                          ((), ("pip",))) == []
+        assert (
+            ips._hardened_keys_in_toml("[pip]\nexclude-newer-package = {}\n", ((), ("pip",))) == []
+        )
         assert ips._hardened_keys_in_toml(
             '[pip]\nexclude-newer-package = { foo = "2020-01-01T00:00:00Z" }\n',
             ((), ("pip",)),

--- a/tests/python/test_install_python_stack.py
+++ b/tests/python/test_install_python_stack.py
@@ -631,8 +631,12 @@ class TestTheMetadataRepairCannotStrandThePackage:
             args, cleanup = ips._staged_restore_args("unsloth-zoo", str(staged))
         assert cleanup == ""
         assert args == [
-            "--no-deps", "--force-reinstall", "--no-index",
-            "--find-links", str(staged), "unsloth-zoo",
+            "--no-deps",
+            "--force-reinstall",
+            "--no-index",
+            "--find-links",
+            str(staged),
+            "unsloth-zoo",
         ]
 
     def test_the_opt_out_restores_through_a_real_hash(self, tmp_path):
@@ -641,9 +645,7 @@ class TestTheMetadataRepairCannotStrandThePackage:
         honestly. Measured: pip accepts this under PIP_REQUIRE_HASHES=1, and rejects it
         with THESE PACKAGES DO NOT MATCH THE HASHES if the wheel is altered."""
         staged, wheel = self._staged(tmp_path)
-        with mock.patch.dict(
-            os.environ, {"UNSLOTH_RESPECT_PM_POLICY": "1"}, clear = True
-        ):
+        with mock.patch.dict(os.environ, {"UNSLOTH_RESPECT_PM_POLICY": "1"}, clear = True):
             args, cleanup = ips._staged_restore_args("unsloth-zoo", str(staged))
         try:
             assert args[:4] == ["--no-deps", "--force-reinstall", "--no-index", "-r"]
@@ -657,9 +659,7 @@ class TestTheMetadataRepairCannotStrandThePackage:
         """The wheel spells the project with an underscore and the requirement with a
         dash, so the match has to normalise both."""
         staged, _ = self._staged(tmp_path)
-        with mock.patch.dict(
-            os.environ, {"UNSLOTH_RESPECT_PM_POLICY": "1"}, clear = True
-        ):
+        with mock.patch.dict(os.environ, {"UNSLOTH_RESPECT_PM_POLICY": "1"}, clear = True):
             args, cleanup = ips._staged_restore_args("Unsloth_Zoo", str(staged))
         assert cleanup, "the underscore spelling must match unsloth_zoo-1.0-...whl"
         os.unlink(cleanup)
@@ -669,9 +669,7 @@ class TestTheMetadataRepairCannotStrandThePackage:
         whatever pip says about them."""
         staged = tmp_path / "empty"
         staged.mkdir()
-        with mock.patch.dict(
-            os.environ, {"UNSLOTH_RESPECT_PM_POLICY": "1"}, clear = True
-        ):
+        with mock.patch.dict(os.environ, {"UNSLOTH_RESPECT_PM_POLICY": "1"}, clear = True):
             args, cleanup = ips._staged_restore_args("unsloth-zoo", str(staged))
         assert cleanup == "" and args[-1] == "unsloth-zoo"
 
@@ -732,9 +730,7 @@ class TestHardenedPolicyIsAnnounced:
         """The point of keeping detection advisory: with nothing detected the notice is
         silent, and the opt-out still withholds every relaxation."""
         assert self._names({}) == ()
-        with mock.patch.dict(
-            os.environ, {"UNSLOTH_RESPECT_PM_POLICY": "1"}, clear = True
-        ):
+        with mock.patch.dict(os.environ, {"UNSLOTH_RESPECT_PM_POLICY": "1"}, clear = True):
             assert ips._relaxed_pip_policy_env(["python", "-m", "pip", "install", "x"]) == {}
             assert ips._sdist_only_build_args("diffusers") == []
 
@@ -830,9 +826,7 @@ class TestTheOptOutIsNotDefeatedByOurOwnEscapeHatches:
         )
         assert raised is None
         assert calls, "the pip fallback must still run"
-        with mock.patch.dict(
-            os.environ, {"UNSLOTH_RESPECT_PM_POLICY": "1"}, clear = True
-        ):
+        with mock.patch.dict(os.environ, {"UNSLOTH_RESPECT_PM_POLICY": "1"}, clear = True):
             assert ips._relaxed_pip_policy_env(["python", "-m", "pip", "install", "x"]) == {}
 
     def test_the_fallback_still_runs_when_the_opt_out_drops_nothing(self):

--- a/tests/python/test_install_python_stack.py
+++ b/tests/python/test_install_python_stack.py
@@ -516,6 +516,146 @@ class TestHardenedPipConfigRelaxation:
             assert name in seen["cmd"], "the fallback lost the source-build exemptions"
 
 
+class TestOperatorCanKeepTheirPolicy:
+    """UNSLOTH_RESPECT_PM_POLICY=1 turns every relaxation above off.
+
+    The relaxations exist because the shipped requirements cannot satisfy a
+    require-hashes / only-binary policy at all, so enforcing one means the install
+    FAILS. That is a legitimate answer for an operator who set the policy deliberately,
+    but only they can make the call, so it is an explicit opt-in rather than the default.
+    """
+
+    HOSTILE = TestHardenedPipConfigRelaxation.HOSTILE
+
+    @pytest.mark.parametrize("value", ["1", "true", "yes"])
+    def test_the_pip_fallback_keeps_hash_mode(self, value):
+        with mock.patch.dict(os.environ, dict(self.HOSTILE, UNSLOTH_RESPECT_PM_POLICY = value)):
+            assert (
+                ips._install_env_for_cmd(["python", "-m", "pip", "install", "-r", "extras.txt"])
+                is None
+            ), "the opt-out must leave the child env untouched"
+
+    @pytest.mark.parametrize("value", ["", "0", "false", "no"])
+    def test_off_and_unset_spellings_keep_the_default(self, value):
+        with mock.patch.dict(os.environ, dict(self.HOSTILE, UNSLOTH_RESPECT_PM_POLICY = value)):
+            env = ips._install_env_for_cmd(["python", "-m", "pip", "install", "-r", "extras.txt"])
+        assert env is not None and env["PIP_REQUIRE_HASHES"] == "0"
+
+    def test_source_build_exemptions_are_withdrawn(self):
+        """The --no-binary exemptions exist ONLY to override a user no-build, so under
+        the opt-out there is nothing left for them to do."""
+        with mock.patch.dict(os.environ, {"UNSLOTH_RESPECT_PM_POLICY": "1"}):
+            assert ips._sdist_only_build_args(*ips.SDIST_ONLY_PACKAGES) == []
+
+    def test_pinned_installs_keep_policy_but_still_scrub_the_index(self):
+        """The pin is itself a provenance control: honouring a hash policy must not be
+        read as permission to let an inherited mirror answer a pinned torch repair."""
+        with mock.patch.dict(
+            os.environ,
+            dict(
+                self.HOSTILE,
+                UNSLOTH_RESPECT_PM_POLICY = "1",
+                PIP_EXTRA_INDEX_URL = "https://mirror.corp/simple",
+                UV_INDEX_URL = "https://mirror.corp/simple",
+            ),
+        ):
+            env = ips._install_env_for_cmd(
+                ["uv", "pip", "install", "torch", "--index-url", "https://x/cu128"]
+            )
+        assert env is not None
+        for name in ("PIP_REQUIRE_HASHES", "PIP_ONLY_BINARY", "UV_NO_BUILD", "UV_EXCLUDE_NEWER"):
+            assert env[name] == self.HOSTILE[name], f"{name} must survive the opt-out"
+        assert "PIP_CONFIG_FILE" not in env, "pip.conf carries the policy; it must be read"
+        for name in ("PIP_EXTRA_INDEX_URL", "UV_INDEX_URL"):
+            assert name not in env, f"{name} must still be scrubbed from a pinned install"
+
+    def test_the_parent_environment_is_never_mutated(self):
+        with mock.patch.dict(os.environ, dict(self.HOSTILE, UNSLOTH_RESPECT_PM_POLICY = "1")):
+            ips._install_env_for_cmd(["python", "-m", "pip", "install", "x"])
+            ips._sdist_only_build_args("openai-whisper")
+            assert os.environ["UNSLOTH_RESPECT_PM_POLICY"] == "1"
+            assert os.environ["PIP_REQUIRE_HASHES"] == "1"
+
+
+class TestHardenedPolicyIsAnnounced:
+    """The relaxation is defensible; doing it silently is not.
+
+    An operator who configured require-hashes and watched the install succeed anyway had
+    no way to learn that their control had been set aside. The notice names the settings
+    it found and the variable that keeps them.
+    """
+
+    def _names(self, env: dict, pip_config: str = ""):
+        ips._hardened_pm_policy_names.cache_clear()
+        result = mock.Mock(returncode = 0, stdout = pip_config.encode())
+        with (
+            mock.patch.dict(os.environ, env, clear = True),
+            mock.patch.object(ips.subprocess, "run", return_value = result),
+            mock.patch.object(ips, "_hardened_uv_config_paths", lambda: []),
+        ):
+            try:
+                return ips._hardened_pm_policy_names()
+            finally:
+                ips._hardened_pm_policy_names.cache_clear()
+
+    def test_an_ordinary_machine_says_nothing(self):
+        assert self._names({}) == ()
+
+    def test_a_policy_env_var_is_reported(self):
+        assert "PIP_REQUIRE_HASHES" in self._names({"PIP_REQUIRE_HASHES": "1"})
+
+    def test_a_disabled_policy_is_not_reported(self):
+        """PIP_REQUIRE_HASHES=0 is the absence of the policy, not the presence of it."""
+        assert self._names({"PIP_REQUIRE_HASHES": "0", "PIP_NO_BINARY": ""}) == ()
+
+    def test_pip_config_hardening_is_reported(self):
+        names = self._names({}, "global.require-hashes='true'\nglobal.index-url='https://m/s'\n")
+        assert "pip.conf require-hashes" in names
+        assert not any("index-url" in name for name in names), "a mirror is not hardening"
+
+    def test_env_restatements_from_pip_config_are_not_double_counted(self):
+        names = self._names({"PIP_REQUIRE_HASHES": "1"}, ":env:.require-hashes='true'\n")
+        assert names == ("PIP_REQUIRE_HASHES",)
+
+    def test_uv_config_hardening_is_reported(self, tmp_path):
+        config = tmp_path / "uv.toml"
+        config.write_text("# no-build = true\nno-build = true\n", encoding = "utf-8")
+        ips._hardened_pm_policy_names.cache_clear()
+        with (
+            mock.patch.dict(os.environ, {}, clear = True),
+            mock.patch.object(ips.subprocess, "run", side_effect = OSError),
+            mock.patch.object(ips, "_hardened_uv_config_paths", lambda: [str(config)]),
+        ):
+            names = ips._hardened_pm_policy_names()
+        ips._hardened_pm_policy_names.cache_clear()
+        assert names == ("uv.toml no-build",)
+
+    def test_the_notice_names_the_opt_out(self, capsys):
+        with (
+            mock.patch.object(ips, "_hardened_pm_policy_names", lambda: ("PIP_REQUIRE_HASHES",)),
+            mock.patch.dict(os.environ, {}, clear = True),
+        ):
+            ips._announce_pm_policy()
+        out = capsys.readouterr().out
+        assert "PIP_REQUIRE_HASHES" in out and "UNSLOTH_RESPECT_PM_POLICY" in out
+
+    def test_the_opt_out_notice_warns_that_steps_will_fail(self, capsys):
+        with (
+            mock.patch.object(ips, "_hardened_pm_policy_names", lambda: ("PIP_REQUIRE_HASHES",)),
+            mock.patch.dict(os.environ, {"UNSLOTH_RESPECT_PM_POLICY": "1"}, clear = True),
+        ):
+            ips._announce_pm_policy()
+        assert "will fail" in capsys.readouterr().out
+
+    def test_nothing_is_printed_on_an_ordinary_machine(self, capsys):
+        with (
+            mock.patch.object(ips, "_hardened_pm_policy_names", lambda: ()),
+            mock.patch.dict(os.environ, {}, clear = True),
+        ):
+            ips._announce_pm_policy()
+        assert capsys.readouterr().out == ""
+
+
 class TestProgressLineNotes:
     """_progress() leaves the cursor mid-line, so anything printed between two
     progress steps must close that line first. Before centralising this, a real

--- a/tests/python/test_install_python_stack.py
+++ b/tests/python/test_install_python_stack.py
@@ -557,7 +557,7 @@ class TestOperatorCanKeepTheirPolicy:
         """The relaxation is withdrawn. Scoped to pip's own controls, because a mix of
         pip and uv policy is now a reported gap, which is a different test's subject."""
         with mock.patch.dict(
-            os.environ, dict(self.PIP_ONLY, UNSLOTH_RESPECT_PM_POLICY=value), clear=True
+            os.environ, dict(self.PIP_ONLY, UNSLOTH_RESPECT_PM_POLICY = value), clear = True
         ):
             env = ips._install_env_for_cmd(["python", "-m", "pip", "install", "-r", "extras.txt"])
         assert env is None or env.get("PIP_REQUIRE_HASHES") != "0"
@@ -984,11 +984,21 @@ class TestNeitherManagerIsLetOffTheOthersPolicy:
     step now stops and names the setting to add, which cannot invent a restriction.
     """
 
-    def _detect(self, on, configured = None):
+    def _detect(
+        self,
+        on,
+        configured = None,
+    ):
         scan = (tuple(on), {k: frozenset(v) for k, v in (configured or {}).items()})
         return mock.patch.object(ips, "_policy_scan", lambda: scan)
 
-    def _run(self, cmd, on, configured = None, env = None):
+    def _run(
+        self,
+        cmd,
+        on,
+        configured = None,
+        env = None,
+    ):
         environment = {"UNSLOTH_RESPECT_PM_POLICY": "1"}
         environment.update(env or {})
         with (
@@ -1028,18 +1038,24 @@ class TestNeitherManagerIsLetOffTheOthersPolicy:
     def test_a_deliberate_difference_is_not_a_gap(self):
         """A uv config saying `[pip] require-hashes = false` next to PIP_REQUIRE_HASHES=1
         is the operator configuring the two differently, not uv missing a control."""
-        assert self._run(
-            ["uv", "pip", "install", "x"],
-            [("pip", "env", "PIP_REQUIRE_HASHES")],
-            {"pip": {"require-hashes"}, "uv": {"require-hashes"}},
-        ) is None
+        assert (
+            self._run(
+                ["uv", "pip", "install", "x"],
+                [("pip", "env", "PIP_REQUIRE_HASHES")],
+                {"pip": {"require-hashes"}, "uv": {"require-hashes"}},
+            )
+            is None
+        )
 
     def test_the_manager_that_owns_the_policy_is_left_alone(self):
-        assert self._run(
-            ["uv", "pip", "install", "x"],
-            [("uv", "env", "UV_REQUIRE_HASHES")],
-            {"uv": {"require-hashes"}, "pip": set()},
-        ) is None
+        assert (
+            self._run(
+                ["uv", "pip", "install", "x"],
+                [("uv", "env", "UV_REQUIRE_HASHES")],
+                {"uv": {"require-hashes"}, "pip": set()},
+            )
+            is None
+        )
 
     @pytest.mark.parametrize(
         "cmd",
@@ -1054,11 +1070,14 @@ class TestNeitherManagerIsLetOffTheOthersPolicy:
         """run() routes EVERY command through this helper. Treating them all as pip
         installs turned an unenforceable policy into a hard exit on the final metadata
         patch, after every real step had succeeded."""
-        assert self._run(
-            cmd,
-            [("uv", "env", "UV_EXCLUDE_NEWER")],
-            {"uv": {"exclude-newer"}, "pip": set()},
-        ) is None
+        assert (
+            self._run(
+                cmd,
+                [("uv", "env", "UV_EXCLUDE_NEWER")],
+                {"uv": {"exclude-newer"}, "pip": set()},
+            )
+            is None
+        )
 
     def test_nothing_is_refused_without_the_opt_out(self):
         with (
@@ -1258,9 +1277,7 @@ class TestTheNoticeCannotTakeAnInstallDown:
     def test_the_pip_probe_is_bounded(self):
         """An unbounded probe on a half-written pip is a hang with no output at all."""
         source = Path(ips.__file__).read_text(encoding = "utf-8")
-        body = source[
-            source.index("def _policy_scan") : source.index("def _detected_policy")
-        ]
+        body = source[source.index("def _policy_scan") : source.index("def _detected_policy")]
         assert "timeout = 30" in body, "the pip config probe must pass an explicit timeout"
 
     def test_a_hanging_pip_still_yields_the_environment_half(self):

--- a/tests/python/test_pm_policy_optout_shell.py
+++ b/tests/python/test_pm_policy_optout_shell.py
@@ -161,3 +161,96 @@ def test_the_opt_out_arm_keeps_the_uv_wheelhouse():
         "-u UV_FIND_LINKS" not in opt_out
     ), "the opt-out arm must leave the operator's wheelhouse in place"
     assert "-u UV_FIND_LINKS" in default, "the default path must not move: it is what fixes #6898"
+
+
+def _run_case_arm(value: "str | None") -> str:
+    """Execute install.sh's real --default-index arm and return the argv it builds.
+
+    String-matching the branch is not enough: a gate rewritten to something that can
+    never be true still contains the words the structural test looks for, so it stays
+    green while the opt-out silently stops working. This runs the thing.
+    """
+    text = INSTALL_SH.read_text(encoding = "utf-8")
+    predicate = _shell_predicate()
+    start = text.index("run_install_cmd() {")
+    body = text[start : text.index("\n}", start)]
+    case_start = body.index('case " $* " in')
+    case_end = body.index("esac", case_start) + 4
+    script = (
+        predicate
+        + "\nbuild() {\n"
+        + body[case_start:case_end]
+        + '\nprintf "%s\\n" "$*"\n}\nbuild "$@"\n'
+    )
+    env = {"PATH": "/usr/bin:/bin"}
+    if value is not None:
+        env["UNSLOTH_RESPECT_PM_POLICY"] = value
+    result = subprocess.run(
+        [
+            "sh",
+            "-c",
+            script,
+            "sh",
+            "uv",
+            "pip",
+            "install",
+            "--default-index",
+            "https://download.pytorch.org/whl/cu124",
+            "torch",
+        ],
+        capture_output = True,
+        text = True,
+        timeout = 60,
+        env = env,
+    )
+    assert result.returncode == 0, result.stderr
+    return result.stdout.strip()
+
+
+@pytest.mark.skipif(shutil.which("sh") is None, reason = "no POSIX sh")
+def test_the_gate_actually_selects_the_arm_when_the_opt_out_is_set():
+    """Executed, not pattern-matched. Fails if the gate becomes unreachable."""
+    opted = _run_case_arm("1")
+    assert "-u UV_CONFIG_FILE" not in opted, opted
+    assert "UV_NO_CONFIG=1" not in opted, opted
+    assert "-u UV_FIND_LINKS" not in opted, opted
+    # The additive mirror still goes, in both arms.
+    assert "-u UV_INDEX_URL" in opted, opted
+
+
+@pytest.mark.skipif(shutil.which("sh") is None, reason = "no POSIX sh")
+@pytest.mark.parametrize("value", [None, "", "0", "false", "no"])
+def test_the_default_arm_is_selected_for_every_off_spelling(value):
+    """The default path must be reached whenever the operator has not opted in."""
+    built = _run_case_arm(value)
+    assert "-u UV_CONFIG_FILE" in built, (value, built)
+    assert "UV_NO_CONFIG=1" in built, (value, built)
+    assert "-u UV_FIND_LINKS" in built, (value, built)
+
+
+@pytest.mark.skipif(shutil.which("sh") is None, reason = "no POSIX sh")
+def test_an_unset_opt_out_spawns_no_helper_processes():
+    """The default path must not pay subprocesses to decide it is the default path.
+
+    `tr` and `sed` were run for every pinned install, including the overwhelming
+    majority where the variable is not set at all.
+    """
+    predicate = _shell_predicate()
+    # Poison both helpers: if the unset path reaches them, the shell reports failure.
+    script = (
+        "tr() { echo 'HELPER-RAN' >&2; return 1; }\n"
+        "sed() { echo 'HELPER-RAN' >&2; return 1; }\n"
+        + predicate
+        + "\nif _respect_pm_policy; then echo ON; else echo OFF; fi\n"
+    )
+    result = subprocess.run(
+        ["sh", "-c", script],
+        capture_output = True,
+        text = True,
+        timeout = 60,
+        env = {"PATH": "/usr/bin:/bin"},
+    )
+    assert result.stdout.strip() == "OFF", result.stdout
+    assert (
+        "HELPER-RAN" not in result.stderr
+    ), "the unset path still spawns tr/sed; it should decide before doing any work"

--- a/tests/python/test_pm_policy_optout_shell.py
+++ b/tests/python/test_pm_policy_optout_shell.py
@@ -38,22 +38,49 @@ def _shell_predicate() -> str:
 
 # A value the shell and Python disagree on is the failure this file exists to catch, so
 # the set spans the false list, its casing, surrounding space, and ordinary true values.
-@pytest.mark.parametrize("value", [
-    "", "0", "false", "FALSE", "False", "no", "NO", " no ", " 0 ", "\t0\t",
-    "1", "yes", "on", "true", "2", "anything",
-    # Internal whitespace: the shell trimmed with `tr -d`, which deletes every space
-    # rather than the ends, so `f alse` collapsed to the false spelling here while
-    # Python read it as an ordinary non-false value and turned the opt-out ON.
-    "f alse", "n o", "fal se", "0 0", " no thing ", "a b",
-    # A lone separator strips to empty on both sides, which is the false spelling.
-    " ", "\t", "\n", " \t ",
-])
+@pytest.mark.parametrize(
+    "value",
+    [
+        "",
+        "0",
+        "false",
+        "FALSE",
+        "False",
+        "no",
+        "NO",
+        " no ",
+        " 0 ",
+        "\t0\t",
+        "1",
+        "yes",
+        "on",
+        "true",
+        "2",
+        "anything",
+        # Internal whitespace: the shell trimmed with `tr -d`, which deletes every space
+        # rather than the ends, so `f alse` collapsed to the false spelling here while
+        # Python read it as an ordinary non-false value and turned the opt-out ON.
+        "f alse",
+        "n o",
+        "fal se",
+        "0 0",
+        " no thing ",
+        "a b",
+        # A lone separator strips to empty on both sides, which is the false spelling.
+        " ",
+        "\t",
+        "\n",
+        " \t ",
+    ],
+)
 @pytest.mark.skipif(shutil.which("sh") is None, reason = "no POSIX sh")
 def test_the_shell_and_python_agree_on_the_opt_out(value, monkeypatch):
-    script = f'{_shell_predicate()}\nif _respect_pm_policy; then echo ON; else echo OFF; fi\n'
+    script = f"{_shell_predicate()}\nif _respect_pm_policy; then echo ON; else echo OFF; fi\n"
     result = subprocess.run(
         ["sh", "-c", script],
-        capture_output = True, text = True, timeout = 60,
+        capture_output = True,
+        text = True,
+        timeout = 60,
         env = {"UNSLOTH_RESPECT_PM_POLICY": value, "PATH": "/usr/bin:/bin"},
     )
     assert result.returncode == 0, result.stderr
@@ -69,10 +96,12 @@ def test_the_shell_and_python_agree_on_the_opt_out(value, monkeypatch):
 
 @pytest.mark.skipif(shutil.which("sh") is None, reason = "no POSIX sh")
 def test_an_unset_variable_is_off_on_both_sides(monkeypatch):
-    script = f'{_shell_predicate()}\nif _respect_pm_policy; then echo ON; else echo OFF; fi\n'
+    script = f"{_shell_predicate()}\nif _respect_pm_policy; then echo ON; else echo OFF; fi\n"
     result = subprocess.run(
         ["sh", "-c", script],
-        capture_output = True, text = True, timeout = 60,
+        capture_output = True,
+        text = True,
+        timeout = 60,
         env = {"PATH": "/usr/bin:/bin"},
     )
     assert result.returncode == 0, result.stderr
@@ -85,7 +114,9 @@ def test_the_pinned_branch_is_gated_on_the_opt_out():
     """Both arms exist, and only the default one discards the operator's uv config."""
     text = INSTALL_SH.read_text(encoding = "utf-8")
     match = re.search(
-        r'\*" --default-index "\*\)(.*?)^\s*esac', text, re.MULTILINE | re.DOTALL,
+        r'\*" --default-index "\*\)(.*?)^\s*esac',
+        text,
+        re.MULTILINE | re.DOTALL,
     )
     assert match, "install.sh no longer scrubs the env for --default-index"
     branch = match.group(1)
@@ -98,12 +129,12 @@ def test_the_pinned_branch_is_gated_on_the_opt_out():
     # control, and #6898 is an inherited mirror pulling CPU torch over the CUDA build.
     for arm, name in ((opt_out, "opt-out"), (default, "default")):
         assert "-u UV_INDEX_URL" in arm, f"the {name} arm stopped scrubbing the mirror"
-    assert "-u UV_CONFIG_FILE" not in opt_out, (
-        "the opt-out arm must leave the operator's uv.toml in place"
-    )
-    assert "UV_NO_CONFIG=1" not in opt_out, (
-        "forcing UV_NO_CONFIG=1 would discard the very policy the opt-out promises to keep"
-    )
-    assert "-u UV_CONFIG_FILE" in default and "UV_NO_CONFIG=1" in default, (
-        "the default path must not move: it is what fixes #6898 and #8530"
-    )
+    assert (
+        "-u UV_CONFIG_FILE" not in opt_out
+    ), "the opt-out arm must leave the operator's uv.toml in place"
+    assert (
+        "UV_NO_CONFIG=1" not in opt_out
+    ), "forcing UV_NO_CONFIG=1 would discard the very policy the opt-out promises to keep"
+    assert (
+        "-u UV_CONFIG_FILE" in default and "UV_NO_CONFIG=1" in default
+    ), "the default path must not move: it is what fixes #6898 and #8530"

--- a/tests/python/test_pm_policy_optout_shell.py
+++ b/tests/python/test_pm_policy_optout_shell.py
@@ -138,3 +138,26 @@ def test_the_pinned_branch_is_gated_on_the_opt_out():
     assert (
         "-u UV_CONFIG_FILE" in default and "UV_NO_CONFIG=1" in default
     ), "the default path must not move: it is what fixes #6898 and #8530"
+
+
+def test_the_opt_out_arm_keeps_the_uv_wheelhouse():
+    """uv's no-index lives only in uv.toml, so UV_FIND_LINKS cannot be dropped.
+
+    Measured on the pinned uv 0.12.1, a uv.toml `[pip] no-index = true` plus
+    UV_FIND_LINKS installs from the wheelhouse and the same command without it fails
+    with "index lookups were disabled and no additional package locations were
+    provided". install.sh runs its pinned torch install before the Python installer,
+    so the opt-out has to keep it here too.
+    """
+    text = INSTALL_SH.read_text(encoding = "utf-8")
+    match = re.search(
+        r'\*" --default-index "\*\)(.*?)^\s*esac',
+        text,
+        re.MULTILINE | re.DOTALL,
+    )
+    assert match, "install.sh no longer scrubs the env for --default-index"
+    opt_out, _, default = match.group(1).partition("else")
+    assert (
+        "-u UV_FIND_LINKS" not in opt_out
+    ), "the opt-out arm must leave the operator's wheelhouse in place"
+    assert "-u UV_FIND_LINKS" in default, "the default path must not move: it is what fixes #6898"

--- a/tests/python/test_pm_policy_optout_shell.py
+++ b/tests/python/test_pm_policy_optout_shell.py
@@ -41,6 +41,12 @@ def _shell_predicate() -> str:
 @pytest.mark.parametrize("value", [
     "", "0", "false", "FALSE", "False", "no", "NO", " no ", " 0 ", "\t0\t",
     "1", "yes", "on", "true", "2", "anything",
+    # Internal whitespace: the shell trimmed with `tr -d`, which deletes every space
+    # rather than the ends, so `f alse` collapsed to the false spelling here while
+    # Python read it as an ordinary non-false value and turned the opt-out ON.
+    "f alse", "n o", "fal se", "0 0", " no thing ", "a b",
+    # A lone separator strips to empty on both sides, which is the false spelling.
+    " ", "\t", "\n", " \t ",
 ])
 @pytest.mark.skipif(shutil.which("sh") is None, reason = "no POSIX sh")
 def test_the_shell_and_python_agree_on_the_opt_out(value, monkeypatch):

--- a/tests/python/test_pm_policy_optout_shell.py
+++ b/tests/python/test_pm_policy_optout_shell.py
@@ -1,0 +1,103 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+
+"""install.sh honours UNSLOTH_RESPECT_PM_POLICY, and reads it the way Python does.
+
+The pinned torch install in install.sh runs before install_python_stack.py exists in the
+process tree, so the Python opt-out cannot reach it: without the gate an operator who set
+the variable would still have their uv.toml bypassed for that install. The predicate is
+lifted out of install.sh and executed by a real /bin/sh, then compared value for value
+against _respect_pm_policy(). A variable that means one thing to the shell and another to
+Python would be worse than no gate at all, and nothing else in the tree would catch it.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+INSTALL_SH = REPO / "install.sh"
+
+sys.path.insert(0, str(REPO / "studio"))
+import install_python_stack as ips  # noqa: E402
+
+
+def _shell_predicate() -> str:
+    """The real _respect_pm_policy() out of install.sh, or fail loudly."""
+    text = INSTALL_SH.read_text(encoding = "utf-8")
+    match = re.search(r"^_respect_pm_policy\(\) \{.*?^\}", text, re.MULTILINE | re.DOTALL)
+    assert match, "install.sh no longer defines _respect_pm_policy()"
+    return match.group(0)
+
+
+# A value the shell and Python disagree on is the failure this file exists to catch, so
+# the set spans the false list, its casing, surrounding space, and ordinary true values.
+@pytest.mark.parametrize("value", [
+    "", "0", "false", "FALSE", "False", "no", "NO", " no ", " 0 ", "\t0\t",
+    "1", "yes", "on", "true", "2", "anything",
+])
+@pytest.mark.skipif(shutil.which("sh") is None, reason = "no POSIX sh")
+def test_the_shell_and_python_agree_on_the_opt_out(value, monkeypatch):
+    script = f'{_shell_predicate()}\nif _respect_pm_policy; then echo ON; else echo OFF; fi\n'
+    result = subprocess.run(
+        ["sh", "-c", script],
+        capture_output = True, text = True, timeout = 60,
+        env = {"UNSLOTH_RESPECT_PM_POLICY": value, "PATH": "/usr/bin:/bin"},
+    )
+    assert result.returncode == 0, result.stderr
+    shell_says_on = result.stdout.strip() == "ON"
+
+    monkeypatch.setenv("UNSLOTH_RESPECT_PM_POLICY", value)
+    assert shell_says_on == ips._respect_pm_policy(), (
+        f"install.sh and install_python_stack.py disagree on "
+        f"UNSLOTH_RESPECT_PM_POLICY={value!r}: shell={'ON' if shell_says_on else 'OFF'}, "
+        f"python={'ON' if ips._respect_pm_policy() else 'OFF'}"
+    )
+
+
+@pytest.mark.skipif(shutil.which("sh") is None, reason = "no POSIX sh")
+def test_an_unset_variable_is_off_on_both_sides(monkeypatch):
+    script = f'{_shell_predicate()}\nif _respect_pm_policy; then echo ON; else echo OFF; fi\n'
+    result = subprocess.run(
+        ["sh", "-c", script],
+        capture_output = True, text = True, timeout = 60,
+        env = {"PATH": "/usr/bin:/bin"},
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "OFF"
+    monkeypatch.delenv("UNSLOTH_RESPECT_PM_POLICY", raising = False)
+    assert ips._respect_pm_policy() is False
+
+
+def test_the_pinned_branch_is_gated_on_the_opt_out():
+    """Both arms exist, and only the default one discards the operator's uv config."""
+    text = INSTALL_SH.read_text(encoding = "utf-8")
+    match = re.search(
+        r'\*" --default-index "\*\)(.*?)^\s*esac', text, re.MULTILINE | re.DOTALL,
+    )
+    assert match, "install.sh no longer scrubs the env for --default-index"
+    branch = match.group(1)
+    assert "_respect_pm_policy" in branch, (
+        "the pinned install in install.sh runs before install_python_stack.py, so without "
+        "this gate the opt-out cannot reach it"
+    )
+    opt_out, _, default = branch.partition("else")
+    # The additive mirror variables go in BOTH arms: the pin is itself a provenance
+    # control, and #6898 is an inherited mirror pulling CPU torch over the CUDA build.
+    for arm, name in ((opt_out, "opt-out"), (default, "default")):
+        assert "-u UV_INDEX_URL" in arm, f"the {name} arm stopped scrubbing the mirror"
+    assert "-u UV_CONFIG_FILE" not in opt_out, (
+        "the opt-out arm must leave the operator's uv.toml in place"
+    )
+    assert "UV_NO_CONFIG=1" not in opt_out, (
+        "forcing UV_NO_CONFIG=1 would discard the very policy the opt-out promises to keep"
+    )
+    assert "-u UV_CONFIG_FILE" in default and "UV_NO_CONFIG=1" in default, (
+        "the default path must not move: it is what fixes #6898 and #8530"
+    )

--- a/tests/studio/test_pm_policy_optout_installers.ps1
+++ b/tests/studio/test_pm_policy_optout_installers.ps1
@@ -137,7 +137,7 @@ Check "but find-links is scrubbed, being additive again" ($null -eq $Recorded['P
 # sources at all. `python` is stubbed so the probe is a fixture, not a real pip.
 Write-Host "a config-only no-index still keeps find-links"
 Reset-Env
-$script:PipNoIndexInForce = $null
+$script:PipNoIndexSections = $null
 function python { if ($args -contains 'list') { "global.no-index = true" }; $global:LASTEXITCODE = 0 }
 $env:UNSLOTH_RESPECT_PM_POLICY = "1"
 $env:PIP_FIND_LINKS = "C:\op\wheels"
@@ -146,13 +146,13 @@ Check "find-links survives a pip.conf no-index" ($Recorded['PIP_FIND_LINKS'] -eq
 
 Write-Host "and with no no-index anywhere it is still additive"
 Reset-Env
-$script:PipNoIndexInForce = $null
+$script:PipNoIndexSections = $null
 function python { $global:LASTEXITCODE = 0 }
 $env:UNSLOTH_RESPECT_PM_POLICY = "1"
 $env:PIP_FIND_LINKS = "C:\op\wheels"
 Fast-Install --index-url https://x torch | Out-Null
 Check "find-links is scrubbed when nothing sets no-index" ($null -eq $Recorded['PIP_FIND_LINKS'])
-$script:PipNoIndexInForce = $null
+$script:PipNoIndexSections = $null
 Remove-Item function:python -ErrorAction SilentlyContinue
 
 Write-Host "a command with no pinned index is untouched either way"
@@ -173,9 +173,37 @@ foreach ($pair in @(@('', $false), @('0', $false), @('false', $false), @('FALSE'
 }
 
 Reset-Env
+
+# A command-prefixed key affects only the command it names, so a `[download] no-index`
+# says nothing about `pip install`. Pooling them let an install keep a find-links
+# location that is purely additive for it.
+Write-Host "no-index is read for the command being run"
+Reset-Env
+$script:PipNoIndexSections = $null
+function python { if ($args -contains 'list') { "download.no-index = true" }; $global:LASTEXITCODE = 0 }
+$env:UNSLOTH_RESPECT_PM_POLICY = "1"
+$env:PIP_FIND_LINKS = "C:\op\wheels"
+Fast-Install --index-url https://x torch | Out-Null
+Check "a download-scoped no-index does not hold find-links for install" ($null -eq $Recorded['PIP_FIND_LINKS'])
+
+Reset-Env
+$script:PipNoIndexSections = $null
+function python { if ($args -contains 'list') { "global.no-index = true"; "install.no-index = false" }; $global:LASTEXITCODE = 0 }
+$env:UNSLOTH_RESPECT_PM_POLICY = "1"
+$env:PIP_FIND_LINKS = "C:\op\wheels"
+Fast-Install --index-url https://x torch | Out-Null
+Check "an install-scoped false beats a global true" ($null -eq $Recorded['PIP_FIND_LINKS'])
+
+Reset-Env
+$script:PipNoIndexSections = $null
+function python { if ($args -contains 'list') { "install.no-index = true" }; $global:LASTEXITCODE = 0 }
+$env:UNSLOTH_RESPECT_PM_POLICY = "1"
+$env:PIP_FIND_LINKS = "C:\op\wheels"
+Fast-Install --index-url https://x torch | Out-Null
+Check "an install-scoped true holds find-links" ($Recorded['PIP_FIND_LINKS'] -eq "C:\op\wheels")
+$script:PipNoIndexSections = $null
+Remove-Item function:python -ErrorAction SilentlyContinue
+
 Write-Host ""
-if ($failures -gt 0) {
-    Write-Host "$failures check(s) FAILED" -ForegroundColor Red
-    exit 1
-}
+if ($failures -gt 0) { Write-Host "$failures check(s) FAILED" -ForegroundColor Red; exit 1 }
 Write-Host "all checks passed"

--- a/tests/studio/test_pm_policy_optout_installers.ps1
+++ b/tests/studio/test_pm_policy_optout_installers.ps1
@@ -132,6 +132,29 @@ Fast-Install --index-url https://x torch | Out-Null
 Check "an explicit OFF is carried through, not dropped" ($Recorded['PIP_NO_INDEX'] -eq '0')
 Check "but find-links is scrubbed, being additive again" ($null -eq $Recorded['PIP_FIND_LINKS'])
 
+# The effective state can come from pip.conf, which the opt-out keeps readable. Reading
+# only the environment scrubbed find-links as additive and left the fallback with no
+# sources at all. `python` is stubbed so the probe is a fixture, not a real pip.
+Write-Host "a config-only no-index still keeps find-links"
+Reset-Env
+$script:PipNoIndexInForce = $null
+function python { if ($args -contains 'list') { "global.no-index = true" }; $global:LASTEXITCODE = 0 }
+$env:UNSLOTH_RESPECT_PM_POLICY = "1"
+$env:PIP_FIND_LINKS = "C:\op\wheels"
+Fast-Install --index-url https://x torch | Out-Null
+Check "find-links survives a pip.conf no-index" ($Recorded['PIP_FIND_LINKS'] -eq "C:\op\wheels")
+
+Write-Host "and with no no-index anywhere it is still additive"
+Reset-Env
+$script:PipNoIndexInForce = $null
+function python { $global:LASTEXITCODE = 0 }
+$env:UNSLOTH_RESPECT_PM_POLICY = "1"
+$env:PIP_FIND_LINKS = "C:\op\wheels"
+Fast-Install --index-url https://x torch | Out-Null
+Check "find-links is scrubbed when nothing sets no-index" ($null -eq $Recorded['PIP_FIND_LINKS'])
+$script:PipNoIndexInForce = $null
+Remove-Item function:python -ErrorAction SilentlyContinue
+
 Write-Host "a command with no pinned index is untouched either way"
 Reset-Env
 $env:UV_CONFIG_FILE = "C:\op\uv.toml"

--- a/tests/studio/test_pm_policy_optout_installers.ps1
+++ b/tests/studio/test_pm_policy_optout_installers.ps1
@@ -1,0 +1,153 @@
+#!/usr/bin/env pwsh
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+# Unit tests for the UNSLOTH_RESPECT_PM_POLICY gate in the PowerShell install helpers.
+# These run BEFORE install_python_stack.py is invoked, so the Python side's opt-out cannot
+# cover them: without the gate an operator who set the variable would still have their
+# pip.conf and uv.toml bypassed for the pinned torch install, and would only see the notice
+# afterwards. The functions are AST-extracted and run in-process with the package manager
+# replaced by a recorder, so what is measured is the environment each helper actually hands
+# to uv/pip. Its oracle is _install_env_for_cmd() in studio/install_python_stack.py, which
+# makes the same split: additive INDEX variables are scrubbed even under the opt-out
+# (the pin is itself a provenance control), policy-bearing config survives.
+# Run: pwsh -NoProfile -File tests/studio/test_pm_policy_optout_installers.ps1
+
+$ErrorActionPreference = "Stop"
+$repo = (Resolve-Path ([System.IO.Path]::Combine($PSScriptRoot, "..", ".."))).Path
+
+function Get-FunctionText {
+    param([string] $Path, [string] $Name)
+    $tokens = $null; $errors = $null
+    $ast = [System.Management.Automation.Language.Parser]::ParseFile($Path, [ref]$tokens, [ref]$errors)
+    if ($errors) { $errors | ForEach-Object { $_.ToString() }; throw "$Path has parse errors" }
+    $fn = $ast.FindAll({ param($n)
+        $n -is [System.Management.Automation.Language.FunctionDefinitionAst] -and $n.Name -eq $Name
+    }, $true)
+    if ($fn.Count -ne 1) { throw "expected exactly one $Name in $Path, found $($fn.Count)" }
+    return $fn[0].Extent.Text
+}
+
+$setup = Join-Path $repo "studio/setup.ps1"
+$bootstrap = Join-Path $repo "install.ps1"
+foreach ($n in 'Test-RespectPmPolicy', 'Test-PipNoIndexOn', 'Fast-Install', 'Fast-Download') {
+    Invoke-Expression (Get-FunctionText $setup $n)
+}
+
+$failures = 0
+function Check($name, $cond) {
+    if ($cond) { Write-Host "  PASS  $name" }
+    else { Write-Host "  FAIL  $name" -ForegroundColor Red; $script:failures++ }
+}
+
+# Both installers carry their own copy of the predicate, so a fix to one that misses the
+# other would leave the promise half-kept. Compared with indentation normalised.
+function Normalize($text) { (($text -replace "`r", "") -split "`n" | ForEach-Object { $_.Trim() }) -join "`n" }
+Write-Host "the opt-out predicate is identical in both installers"
+Check "install.ps1 and studio/setup.ps1 agree on Test-RespectPmPolicy" (
+    (Normalize (Get-FunctionText $bootstrap 'Test-RespectPmPolicy')) -eq
+    (Normalize (Get-FunctionText $setup 'Test-RespectPmPolicy')))
+# An empty or wrong extraction would make every case below pass vacuously.
+Check "extraction kept the variable name" ((Get-FunctionText $setup 'Test-RespectPmPolicy') -match 'UNSLOTH_RESPECT_PM_POLICY')
+Check "extraction kept the pinned-index gate" ((Get-FunctionText $setup 'Fast-Install') -match "'--index-url'")
+
+# Stand-ins for the real managers: record the environment, report success.
+$script:UseUv = $true
+$UseUv = $true
+$global:Recorded = $null
+function Get-Command { param($Name) [pscustomobject]@{ Source = "python" } }
+function uv {
+    $global:Recorded = @{}
+    foreach ($k in 'UV_CONFIG_FILE', 'UV_NO_CONFIG', 'PIP_CONFIG_FILE', 'PIP_NO_INDEX',
+                   'PIP_FIND_LINKS', 'UV_INDEX_URL', 'PIP_EXTRA_INDEX_URL') {
+        $global:Recorded[$k] = [Environment]::GetEnvironmentVariable($k)
+    }
+    $global:LASTEXITCODE = 0
+}
+
+function Reset-Env {
+    foreach ($k in 'UV_CONFIG_FILE', 'UV_NO_CONFIG', 'PIP_CONFIG_FILE', 'PIP_NO_INDEX',
+                   'PIP_FIND_LINKS', 'UV_INDEX_URL', 'PIP_EXTRA_INDEX_URL',
+                   'UNSLOTH_RESPECT_PM_POLICY') {
+        Remove-Item "Env:$k" -ErrorAction SilentlyContinue
+    }
+}
+
+# The default path must not move: #6898 (an inherited mirror pulling CPU torch over the
+# CUDA build) and #8530 (a user policy failing the whole install) are both fixed by it.
+Write-Host "the default path is unchanged"
+Reset-Env
+$env:UV_CONFIG_FILE = "C:\op\uv.toml"
+$env:UV_INDEX_URL = "https://mirror.corp"
+$env:PIP_CONFIG_FILE = "C:\op\pip.conf"
+Fast-Install --index-url https://download.pytorch.org/whl/cu124 torch | Out-Null
+Check "UV_NO_CONFIG=1 is set"                 ($Recorded['UV_NO_CONFIG'] -eq '1')
+Check "the operator uv.toml is dropped"       ($null -eq $Recorded['UV_CONFIG_FILE'])
+Check "PIP_CONFIG_FILE points at nul"         ($Recorded['PIP_CONFIG_FILE'] -eq 'nul')
+Check "the additive mirror is dropped"        ($null -eq $Recorded['UV_INDEX_URL'])
+Check "UV_CONFIG_FILE is restored afterwards" ($env:UV_CONFIG_FILE -eq "C:\op\uv.toml")
+
+Write-Host "under the opt-out the operator's policy files reach the manager"
+Reset-Env
+$env:UNSLOTH_RESPECT_PM_POLICY = "1"
+$env:UV_CONFIG_FILE = "C:\op\uv.toml"
+$env:UV_INDEX_URL = "https://mirror.corp"
+$env:PIP_CONFIG_FILE = "C:\op\pip.conf"
+$env:PIP_EXTRA_INDEX_URL = "https://mirror.corp"
+Fast-Install --index-url https://download.pytorch.org/whl/cu124 torch | Out-Null
+Check "the uv.toml reaches uv"                    ($Recorded['UV_CONFIG_FILE'] -eq "C:\op\uv.toml")
+Check "UV_NO_CONFIG is not forced on"             ($null -eq $Recorded['UV_NO_CONFIG'])
+Check "pip.conf is not redirected to nul"         ($Recorded['PIP_CONFIG_FILE'] -eq "C:\op\pip.conf")
+Check "the additive uv mirror is still scrubbed"  ($null -eq $Recorded['UV_INDEX_URL'])
+Check "the additive pip mirror is still scrubbed" ($null -eq $Recorded['PIP_EXTRA_INDEX_URL'])
+# The finally block clears what the function SET. Under the opt-out it set neither, and
+# neither was saved, so clearing them here would destroy the operator's own values.
+Check "UV_CONFIG_FILE survives the call"          ($env:UV_CONFIG_FILE -eq "C:\op\uv.toml")
+Check "PIP_CONFIG_FILE survives the call"         ($env:PIP_CONFIG_FILE -eq "C:\op\pip.conf")
+
+Write-Host "an operator's own UV_NO_CONFIG is left alone"
+Reset-Env
+$env:UNSLOTH_RESPECT_PM_POLICY = "1"
+$env:UV_NO_CONFIG = "1"
+Fast-Install --index-url https://x torch | Out-Null
+Check "it reaches uv"              ($Recorded['UV_NO_CONFIG'] -eq '1')
+Check "and is still set afterwards" ($env:UV_NO_CONFIG -eq '1')
+
+# PIP_NO_INDEX only ever REMOVES sources, so honouring it is more restrictive, not less.
+Write-Host "PIP_NO_INDEX is kept under the opt-out, read the way pip reads it"
+Reset-Env
+$env:UNSLOTH_RESPECT_PM_POLICY = "1"
+$env:PIP_NO_INDEX = "1"
+$env:PIP_FIND_LINKS = "C:\op\wheels"
+Fast-Install --index-url https://x torch | Out-Null
+Check "PIP_NO_INDEX is kept"      ($Recorded['PIP_NO_INDEX'] -eq '1')
+Check "PIP_FIND_LINKS is kept too" ($Recorded['PIP_FIND_LINKS'] -eq "C:\op\wheels")
+Reset-Env
+$env:UNSLOTH_RESPECT_PM_POLICY = "1"
+$env:PIP_NO_INDEX = "0"
+Fast-Install --index-url https://x torch | Out-Null
+Check "a false PIP_NO_INDEX is scrubbed" ($null -eq $Recorded['PIP_NO_INDEX'])
+
+Write-Host "a command with no pinned index is untouched either way"
+Reset-Env
+$env:UV_CONFIG_FILE = "C:\op\uv.toml"
+Fast-Install --upgrade pip | Out-Null
+Check "no scrub without --index-url" ($Recorded['UV_CONFIG_FILE'] -eq "C:\op\uv.toml")
+
+# The false set must match _respect_pm_policy() in install_python_stack.py exactly: a
+# variable that means one thing to the shell and another to Python is worse than no gate.
+Write-Host "the false set matches the Python predicate"
+foreach ($pair in @(@('', $false), @('0', $false), @('false', $false), @('FALSE', $false),
+                    @('no', $false), @(' No ', $false), @('1', $true), @('yes', $true),
+                    @('on', $true))) {
+    Reset-Env
+    $env:UNSLOTH_RESPECT_PM_POLICY = $pair[0]
+    Check "UNSLOTH_RESPECT_PM_POLICY='$($pair[0])' is $($pair[1])" ((Test-RespectPmPolicy) -eq $pair[1])
+}
+
+Reset-Env
+Write-Host ""
+if ($failures -gt 0) {
+    Write-Host "$failures check(s) FAILED" -ForegroundColor Red
+    exit 1
+}
+Write-Host "all checks passed"

--- a/tests/studio/test_pm_policy_optout_installers.ps1
+++ b/tests/studio/test_pm_policy_optout_installers.ps1
@@ -143,7 +143,7 @@ Check "but find-links is scrubbed, being additive again" ($null -eq $Recorded['P
 Write-Host "a config-only no-index still keeps find-links"
 Reset-Env
 $script:PipNoIndexSections = $null
-function python { if ($args -contains 'list') { "global.no-index = true" }; $global:LASTEXITCODE = 0 }
+function Invoke-BoundedPythonProbe { [pscustomobject]@{ Ok = $true; Output = "global.no-index = true"; Error = "" } }
 $env:UNSLOTH_RESPECT_PM_POLICY = "1"
 $env:PIP_FIND_LINKS = "C:\op\wheels"
 Fast-Install --index-url https://x torch | Out-Null
@@ -152,13 +152,13 @@ Check "find-links survives a pip.conf no-index" ($Recorded['PIP_FIND_LINKS'] -eq
 Write-Host "and with no no-index anywhere it is still additive"
 Reset-Env
 $script:PipNoIndexSections = $null
-function python { $global:LASTEXITCODE = 0 }
+function Invoke-BoundedPythonProbe { [pscustomobject]@{ Ok = $true; Output = ""; Error = "" } }
 $env:UNSLOTH_RESPECT_PM_POLICY = "1"
 $env:PIP_FIND_LINKS = "C:\op\wheels"
 Fast-Install --index-url https://x torch | Out-Null
 Check "find-links is scrubbed when nothing sets no-index" ($null -eq $Recorded['PIP_FIND_LINKS'])
 $script:PipNoIndexSections = $null
-Remove-Item function:python -ErrorAction SilentlyContinue
+Remove-Item function:Invoke-BoundedPythonProbe -ErrorAction SilentlyContinue
 
 Write-Host "a command with no pinned index is untouched either way"
 Reset-Env
@@ -185,7 +185,7 @@ Reset-Env
 Write-Host "no-index is read for the command being run"
 Reset-Env
 $script:PipNoIndexSections = $null
-function python { if ($args -contains 'list') { "download.no-index = true" }; $global:LASTEXITCODE = 0 }
+function Invoke-BoundedPythonProbe { [pscustomobject]@{ Ok = $true; Output = "download.no-index = true"; Error = "" } }
 $env:UNSLOTH_RESPECT_PM_POLICY = "1"
 $env:PIP_FIND_LINKS = "C:\op\wheels"
 Fast-Install --index-url https://x torch | Out-Null
@@ -193,7 +193,7 @@ Check "a download-scoped no-index does not hold find-links for install" ($null -
 
 Reset-Env
 $script:PipNoIndexSections = $null
-function python { if ($args -contains 'list') { "global.no-index = true"; "install.no-index = false" }; $global:LASTEXITCODE = 0 }
+function Invoke-BoundedPythonProbe { [pscustomobject]@{ Ok = $true; Output = "global.no-index = true`ninstall.no-index = false"; Error = "" } }
 $env:UNSLOTH_RESPECT_PM_POLICY = "1"
 $env:PIP_FIND_LINKS = "C:\op\wheels"
 Fast-Install --index-url https://x torch | Out-Null
@@ -201,13 +201,26 @@ Check "an install-scoped false beats a global true" ($null -eq $Recorded['PIP_FI
 
 Reset-Env
 $script:PipNoIndexSections = $null
-function python { if ($args -contains 'list') { "install.no-index = true" }; $global:LASTEXITCODE = 0 }
+function Invoke-BoundedPythonProbe { [pscustomobject]@{ Ok = $true; Output = "install.no-index = true"; Error = "" } }
 $env:UNSLOTH_RESPECT_PM_POLICY = "1"
 $env:PIP_FIND_LINKS = "C:\op\wheels"
 Fast-Install --index-url https://x torch | Out-Null
 Check "an install-scoped true holds find-links" ($Recorded['PIP_FIND_LINKS'] -eq "C:\op\wheels")
 $script:PipNoIndexSections = $null
-Remove-Item function:python -ErrorAction SilentlyContinue
+Remove-Item function:Invoke-BoundedPythonProbe -ErrorAction SilentlyContinue
+
+Write-Host ""
+
+# A policy notice must never be able to hang an install. The Python side caps the same
+# probe at 30s; a bare `& python -m pip config list` waits forever on a wedged
+# interpreter, which is only reachable under the opt-out but is a hang all the same.
+Write-Host "the pip probe is bounded"
+$probeText = Get-FunctionText $setup 'Test-PipNoIndexOn'
+Check "it goes through the bounded runner" ($probeText -match 'Invoke-BoundedPythonProbe')
+Check "with an explicit timeout"           ($probeText -match '-TimeoutSec\s+30')
+# Code only: the comment above the call names the shape it replaced.
+$probeCode = ($probeText -split "`n" | Where-Object { $_.TrimStart() -notmatch '^#' }) -join "`n"
+Check "and never calls pip unbounded"      ($probeCode -notmatch '&\s*python\s+-m\s+pip')
 
 Write-Host ""
 if ($failures -gt 0) { Write-Host "$failures check(s) FAILED" -ForegroundColor Red; exit 1 }

--- a/tests/studio/test_pm_policy_optout_installers.ps1
+++ b/tests/studio/test_pm_policy_optout_installers.ps1
@@ -58,7 +58,7 @@ function Get-Command { param($Name) [pscustomobject]@{ Source = "python" } }
 function uv {
     $global:Recorded = @{}
     foreach ($k in 'UV_CONFIG_FILE', 'UV_NO_CONFIG', 'PIP_CONFIG_FILE', 'PIP_NO_INDEX',
-                   'PIP_FIND_LINKS', 'UV_INDEX_URL', 'PIP_EXTRA_INDEX_URL') {
+                   'PIP_FIND_LINKS', 'UV_INDEX_URL', 'PIP_EXTRA_INDEX_URL', 'UV_FIND_LINKS') {
         $global:Recorded[$k] = [Environment]::GetEnvironmentVariable($k)
     }
     $global:LASTEXITCODE = 0
@@ -91,6 +91,7 @@ Reset-Env
 $env:UNSLOTH_RESPECT_PM_POLICY = "1"
 $env:UV_CONFIG_FILE = "C:\op\uv.toml"
 $env:UV_INDEX_URL = "https://mirror.corp"
+$env:UV_FIND_LINKS = "C:\op\wheels"
 $env:PIP_CONFIG_FILE = "C:\op\pip.conf"
 $env:PIP_EXTRA_INDEX_URL = "https://mirror.corp"
 Fast-Install --index-url https://download.pytorch.org/whl/cu124 torch | Out-Null
@@ -98,6 +99,10 @@ Check "the uv.toml reaches uv"                    ($Recorded['UV_CONFIG_FILE'] -
 Check "UV_NO_CONFIG is not forced on"             ($null -eq $Recorded['UV_NO_CONFIG'])
 Check "pip.conf is not redirected to nul"         ($Recorded['PIP_CONFIG_FILE'] -eq "C:\op\pip.conf")
 Check "the additive uv mirror is still scrubbed"  ($null -eq $Recorded['UV_INDEX_URL'])
+# uv's `--no-index` has no environment spelling and uv prints no resolved configuration,
+# so a uv.toml that makes the wheelhouse the only permitted source is undetectable here.
+# Dropping it failed every offline uv install, so it is kept unconditionally.
+Check "the uv wheelhouse is kept"                 ($Recorded['UV_FIND_LINKS'] -eq "C:\op\wheels")
 Check "the additive pip mirror is still scrubbed" ($null -eq $Recorded['PIP_EXTRA_INDEX_URL'])
 # The finally block clears what the function SET. Under the opt-out it set neither, and
 # neither was saved, so clearing them here would destroy the operator's own values.

--- a/tests/studio/test_pm_policy_optout_installers.ps1
+++ b/tests/studio/test_pm_policy_optout_installers.ps1
@@ -112,20 +112,25 @@ Fast-Install --index-url https://x torch | Out-Null
 Check "it reaches uv"              ($Recorded['UV_NO_CONFIG'] -eq '1')
 Check "and is still set afterwards" ($env:UV_NO_CONFIG -eq '1')
 
-# PIP_NO_INDEX only ever REMOVES sources, so honouring it is more restrictive, not less.
-Write-Host "PIP_NO_INDEX is kept under the opt-out, read the way pip reads it"
+# PIP_NO_INDEX is a POLICY variable and is kept whichever way it points: pip reads the
+# environment ahead of pip.conf, so PIP_NO_INDEX=0 is how an operator lifts a config
+# `no-index = true` for one run. PIP_FIND_LINKS genuinely IS additive, so it survives
+# only while no-index is in force and it is the sole remaining source.
+Write-Host "PIP_NO_INDEX is kept under the opt-out, in both directions"
 Reset-Env
 $env:UNSLOTH_RESPECT_PM_POLICY = "1"
 $env:PIP_NO_INDEX = "1"
 $env:PIP_FIND_LINKS = "C:\op\wheels"
 Fast-Install --index-url https://x torch | Out-Null
-Check "PIP_NO_INDEX is kept"      ($Recorded['PIP_NO_INDEX'] -eq '1')
-Check "PIP_FIND_LINKS is kept too" ($Recorded['PIP_FIND_LINKS'] -eq "C:\op\wheels")
+Check "an enabled PIP_NO_INDEX is kept" ($Recorded['PIP_NO_INDEX'] -eq '1')
+Check "PIP_FIND_LINKS rides along with it" ($Recorded['PIP_FIND_LINKS'] -eq "C:\op\wheels")
 Reset-Env
 $env:UNSLOTH_RESPECT_PM_POLICY = "1"
 $env:PIP_NO_INDEX = "0"
+$env:PIP_FIND_LINKS = "C:\op\wheels"
 Fast-Install --index-url https://x torch | Out-Null
-Check "a false PIP_NO_INDEX is scrubbed" ($null -eq $Recorded['PIP_NO_INDEX'])
+Check "an explicit OFF is carried through, not dropped" ($Recorded['PIP_NO_INDEX'] -eq '0')
+Check "but find-links is scrubbed, being additive again" ($null -eq $Recorded['PIP_FIND_LINKS'])
 
 Write-Host "a command with no pinned index is untouched either way"
 Reset-Env

--- a/tests/studio/test_xpu_triton_swap.py
+++ b/tests/studio/test_xpu_triton_swap.py
@@ -50,6 +50,9 @@ def _load_real_index_env_scrub():
         # at CALL time, so omitting either only shows up as a NameError once a test
         # actually invokes the scrub.
         ("_PM_POLICY_ENV_VARS = (", "\n)\n", 2),
+        # The opt-out gate both of the functions below consult.
+        ('_POLICY_OPT_OUT_ENV = "', "\n\n", 0),
+        ("def _respect_pm_policy(", "\n\n\n", 0),
         ("def _relaxed_pip_policy_env(", "\n\ndef ", 0),
         ("def _is_pinned_index_cmd(", "\n\ndef ", 0),
         ("def _install_env_for_cmd(", "\n\ndef ", 0),

--- a/tests/studio/test_xpu_triton_swap.py
+++ b/tests/studio/test_xpu_triton_swap.py
@@ -34,16 +34,30 @@ REPO = Path(__file__).resolve().parents[2]
 STACK = REPO / "studio/install_python_stack.py"
 
 
+
+
+@pytest.fixture(autouse = True)
+def _neutral_policy_environment(monkeypatch):
+    """Run as an ordinary machine unless a test says otherwise.
+
+    UNSLOTH_RESPECT_PM_POLICY changes what several of these code paths do, so inheriting
+    it from the developer's shell rewrites the suite's subject: with it set, the metadata
+    repair and the XPU swap both decline to start and dozens of unrelated assertions
+    fail. Tests that want the opt-out set it themselves.
+    """
+    monkeypatch.delenv("UNSLOTH_RESPECT_PM_POLICY", raising = False)
+
 def _load_real_index_env_scrub():
     """The module's OWN _install_env_for_cmd, so the scrub is executed, not re-implemented.
 
     It is defined below the slice the swap comes from, so it is pulled in separately rather
     than stubbed -- a hand-written copy here would agree with a broken original forever.
     """
+    import functools as _functools
     import os as _os
 
     src = STACK.read_text(encoding = "utf-8")
-    ns: dict = {"os": _os}
+    ns: dict = {"os": _os, "functools": _functools}
     for anchor, end, keep in (
         ("_UV_INDEX_ENV_VARS = (", "\n)\n", 2),
         # _install_env_for_cmd calls both of these, and they resolve from this namespace
@@ -54,11 +68,20 @@ def _load_real_index_env_scrub():
         ('_POLICY_OPT_OUT_ENV = "', "\n\n", 0),
         ("def _respect_pm_policy(", "\n\n\n", 0),
         ("def _relaxed_pip_policy_env(", "\n\ndef ", 0),
+        # _install_env_for_cmd calls _config_value_is_on to decide whether an explicit
+        # no-index survives the opt-out, and that helper needs its own tables. Without
+        # them the slice raises NameError the moment this module is run with
+        # UNSLOTH_RESPECT_PM_POLICY set, so the opt-out path could not be exercised here
+        # at all -- and a hardened developer environment would fail rather than test it.
+        ("_OFF_VALUES = (", "\n", 0),
+        ("_BOOLEAN_POLICY_KEYS = (", "\n", 0),
+        ("_EMPTY_POLICY_VALUES = (", "\n", 0),
+        ("_FALSE_DISABLES_KEYS = (", "\n", 0),
+        ("def _env_policy_key(", "\n\ndef ", 0),
+        ("def _policy_key_spelling(", "\n\ndef ", 0),
+        ("def _config_value_is_on(", "\n\ndef ", 0),
         ("def _is_pinned_index_cmd(", "\n\ndef ", 0),
         ("def _install_env_for_cmd(", "\n\ndef ", 0),
-        # The XPU swap needs these two as well: it hashes the wheel it just downloaded
-        # when the operator has kept their policy in force.
-        ("def _hashed_requirement_file(", "\n\ndef ", 0),
     ):
         start = src.index(anchor)
         exec(compile(src[start : src.index(end, start) + keep], str(STACK), "exec"), ns)
@@ -70,7 +93,6 @@ def _load_real_index_env_scrub():
 _real_module_slices = _load_real_index_env_scrub()
 _real_install_env_for_cmd = _real_module_slices["_install_env_for_cmd"]
 _real_respect_pm_policy = _real_module_slices["_respect_pm_policy"]
-_real_hashed_requirement_file = _real_module_slices["_hashed_requirement_file"]
 
 
 def _load(
@@ -213,7 +235,6 @@ def _load(
         # for the same reason as the scrub: a hand-written copy would agree with a broken
         # original forever.
         "_respect_pm_policy": _real_respect_pm_policy,
-        "_hashed_requirement_file": _real_hashed_requirement_file,
     }
     exec(compile(body, str(STACK), "exec"), ns)
     mod.__dict__.update(ns)

--- a/tests/studio/test_xpu_triton_swap.py
+++ b/tests/studio/test_xpu_triton_swap.py
@@ -34,8 +34,6 @@ REPO = Path(__file__).resolve().parents[2]
 STACK = REPO / "studio/install_python_stack.py"
 
 
-
-
 @pytest.fixture(autouse = True)
 def _neutral_policy_environment(monkeypatch):
     """Run as an ordinary machine unless a test says otherwise.
@@ -46,6 +44,7 @@ def _neutral_policy_environment(monkeypatch):
     fail. Tests that want the opt-out set it themselves.
     """
     monkeypatch.delenv("UNSLOTH_RESPECT_PM_POLICY", raising = False)
+
 
 def _load_real_index_env_scrub():
     """The module's OWN _install_env_for_cmd, so the scrub is executed, not re-implemented.

--- a/tests/studio/test_xpu_triton_swap.py
+++ b/tests/studio/test_xpu_triton_swap.py
@@ -56,15 +56,21 @@ def _load_real_index_env_scrub():
         ("def _relaxed_pip_policy_env(", "\n\ndef ", 0),
         ("def _is_pinned_index_cmd(", "\n\ndef ", 0),
         ("def _install_env_for_cmd(", "\n\ndef ", 0),
+        # The XPU swap needs these two as well: it hashes the wheel it just downloaded
+        # when the operator has kept their policy in force.
+        ("def _hashed_requirement_file(", "\n\ndef ", 0),
     ):
         start = src.index(anchor)
         exec(compile(src[start : src.index(end, start) + keep], str(STACK), "exec"), ns)
     assert "PIP_NO_INDEX" in ns["_UV_INDEX_ENV_VARS"], "extraction lost the pip vars"
     assert "PIP_REQUIRE_HASHES" in ns["_PM_POLICY_ENV_VARS"], "extraction lost the policy vars"
-    return ns["_install_env_for_cmd"]
+    return ns
 
 
-_real_install_env_for_cmd = _load_real_index_env_scrub()
+_real_module_slices = _load_real_index_env_scrub()
+_real_install_env_for_cmd = _real_module_slices["_install_env_for_cmd"]
+_real_respect_pm_policy = _real_module_slices["_respect_pm_policy"]
+_real_hashed_requirement_file = _real_module_slices["_hashed_requirement_file"]
 
 
 def _load(
@@ -202,6 +208,12 @@ def _load(
         "_safe_print": (
             lambda *a, **k: log.append("WARN") if a and "left in place" in str(a[0]) else None
         ),
+        # The swap now asks whether the operator kept their policy, and hashes the
+        # downloaded wheel when they did. Extracted from the module rather than stubbed,
+        # for the same reason as the scrub: a hand-written copy would agree with a broken
+        # original forever.
+        "_respect_pm_policy": _real_respect_pm_policy,
+        "_hashed_requirement_file": _real_hashed_requirement_file,
     }
     exec(compile(body, str(STACK), "exec"), ns)
     mod.__dict__.update(ns)

--- a/tests/studio/test_xpu_triton_swap.py
+++ b/tests/studio/test_xpu_triton_swap.py
@@ -54,6 +54,12 @@ def _load_real_index_env_scrub():
         ('_POLICY_OPT_OUT_ENV = "', "\n\n", 0),
         ("def _respect_pm_policy(", "\n\n\n", 0),
         ("def _relaxed_pip_policy_env(", "\n\ndef ", 0),
+        # The cross-manager gate. Extracted rather than stubbed for the same reason as the
+        # rest: these tests never set the opt-out, so it short-circuits before it can
+        # reach the policy scan, but a hand-written copy would agree with a broken
+        # original forever.
+        ("def _is_resolving_cmd(", "\n\ndef ", 0),
+        ("def _unenforceable_policy(", "\n\ndef ", 0),
         ("def _is_pinned_index_cmd(", "\n\ndef ", 0),
         ("def _install_env_for_cmd(", "\n\ndef ", 0),
     ):
@@ -61,6 +67,9 @@ def _load_real_index_env_scrub():
         exec(compile(src[start : src.index(end, start) + keep], str(STACK), "exec"), ns)
     assert "PIP_NO_INDEX" in ns["_UV_INDEX_ENV_VARS"], "extraction lost the pip vars"
     assert "PIP_REQUIRE_HASHES" in ns["_PM_POLICY_ENV_VARS"], "extraction lost the policy vars"
+    assert not ns["_unenforceable_policy"](["uv", "pip", "install", "x"]), (
+        "without the opt-out the gate must short-circuit before any policy scan"
+    )
     return ns["_install_env_for_cmd"]
 
 

--- a/tests/studio/test_xpu_triton_swap.py
+++ b/tests/studio/test_xpu_triton_swap.py
@@ -54,12 +54,6 @@ def _load_real_index_env_scrub():
         ('_POLICY_OPT_OUT_ENV = "', "\n\n", 0),
         ("def _respect_pm_policy(", "\n\n\n", 0),
         ("def _relaxed_pip_policy_env(", "\n\ndef ", 0),
-        # The cross-manager gate. Extracted rather than stubbed for the same reason as the
-        # rest: these tests never set the opt-out, so it short-circuits before it can
-        # reach the policy scan, but a hand-written copy would agree with a broken
-        # original forever.
-        ("def _is_resolving_cmd(", "\n\ndef ", 0),
-        ("def _unenforceable_policy(", "\n\ndef ", 0),
         ("def _is_pinned_index_cmd(", "\n\ndef ", 0),
         ("def _install_env_for_cmd(", "\n\ndef ", 0),
     ):
@@ -67,9 +61,6 @@ def _load_real_index_env_scrub():
         exec(compile(src[start : src.index(end, start) + keep], str(STACK), "exec"), ns)
     assert "PIP_NO_INDEX" in ns["_UV_INDEX_ENV_VARS"], "extraction lost the pip vars"
     assert "PIP_REQUIRE_HASHES" in ns["_PM_POLICY_ENV_VARS"], "extraction lost the policy vars"
-    assert not ns["_unenforceable_policy"](
-        ["uv", "pip", "install", "x"]
-    ), "without the opt-out the gate must short-circuit before any policy scan"
     return ns["_install_env_for_cmd"]
 
 

--- a/tests/studio/test_xpu_triton_swap.py
+++ b/tests/studio/test_xpu_triton_swap.py
@@ -67,9 +67,9 @@ def _load_real_index_env_scrub():
         exec(compile(src[start : src.index(end, start) + keep], str(STACK), "exec"), ns)
     assert "PIP_NO_INDEX" in ns["_UV_INDEX_ENV_VARS"], "extraction lost the pip vars"
     assert "PIP_REQUIRE_HASHES" in ns["_PM_POLICY_ENV_VARS"], "extraction lost the policy vars"
-    assert not ns["_unenforceable_policy"](["uv", "pip", "install", "x"]), (
-        "without the opt-out the gate must short-circuit before any policy scan"
-    )
+    assert not ns["_unenforceable_policy"](
+        ["uv", "pip", "install", "x"]
+    ), "without the opt-out the gate must short-circuit before any policy scan"
     return ns["_install_env_for_cmd"]
 
 


### PR DESCRIPTION
## What this is

A security review flagged the installer for disabling `require-hashes` and stripping no-build / only-binary policy from its own pip and uv child commands, and proposed reverting it.

I did not take the revert. Those relaxations are the fix for #8530 and they have to stay: every requirements file we ship is unhashed, and a few requirements have no wheel on PyPI at any version, so a `require-hashes = true` or `only-binary = :all:` policy is unsatisfiable by construction. Enforcing it does not install something safer, it fails the install. On a hardened host the revert breaks Studio and Desktop setup outright.

What was actually wrong is narrower. The bypass was silent and could not be declined. Someone who had configured `require-hashes` and watched the install succeed had no way to learn their control had been set aside, and no way to insist on it. That is what this fixes.

## Changes

`UNSLOTH_RESPECT_PM_POLICY=1` withholds every relaxation, at all four entry points. The install then fails on the first step the operator's policy forbids, which is the correct answer for someone who means it.

**1. The opt-out reaches the shell installers, not just Python.** On Windows the pinned torch installs happen in `setup.ps1`'s `Fast-Install` long before `install_python_stack.py` is invoked, and that helper drops `UV_CONFIG_FILE`, sets `UV_NO_CONFIG=1` and points `PIP_CONFIG_FILE` at `nul`. `install.ps1` and `install.sh` scrub the same way for their own pinned install. All three now read the variable, so an operator who sets it does not have their `pip.conf` and `uv.toml` bypassed and then get told about it afterwards.

**2. The index scrub survives the opt-out, with three deliberate exceptions.** Honouring a policy is not permission to let an inherited mirror answer a pinned torch repair, so the additive index variables are still stripped (#6898). The exceptions are the variables that only ever remove sources or that carry the policy itself:

- `PIP_NO_INDEX` is kept whichever way it points. pip reads the environment ahead of `pip.conf`, so `PIP_NO_INDEX=0` is how an operator lifts a config `no-index = true` for one run; dropping it reimposed a restriction they had lifted.
- `PIP_FIND_LINKS` is kept while no-index is in force, since it is then the only permitted source rather than an addition. The effective state counts `pip.conf` as well as the environment, evaluated for the command being run: a command-prefixed key affects only the command it names, so a `[download] no-index` says nothing about `pip install`.
- `UV_FIND_LINKS` is kept unconditionally. The asymmetry is deliberate and follows from what each manager can be asked. pip prints its resolved configuration, so its effective no-index is knowable. uv has no such command and `--no-index` has no environment spelling at all, so the setting lives only in a `uv.toml` this change does not parse. Measured on the pinned uv 0.12.1, dropping it fails every offline install with "index lookups were disabled and no additional package locations were provided".

**3. Destructive steps decline rather than strand the venv.** The duplicate-metadata repair and the XPU triton swap both uninstall before installing a replacement. Under the opt-out that replacement is a local wheel path, which carries no hash, so a `require-hashes` policy fails it with the venv already stripped and no rerun able to repair it. Both now decline before anything is removed, and say so.

**4. A one-time notice, on hardened hosts only.** `_hardened_pm_policy_names()` reports what the managers can be ASKED about: the policy environment variables, and `pip config list` (skipping `:env:` restatements and mirror-only keys, which are configuration rather than hardening). It names which controls are relaxed and how to keep them, and prints before the progress bar so it cannot land mid-line.

Detection is deliberately advisory and does not read either manager's configuration files. Doing that means reimplementing pip's and uv's configuration resolution: discovery order, per-subcommand sections, precedence, XDG against Darwin paths, uv workspace roots, `UV_PROJECT` / `UV_WORKING_DIR` / `UV_CONFIG_FILE`, and a TOML parser for the interpreters with no `tomllib`. I built that and removed it. It is an unbounded surface, review kept finding true differences from the real thing, and several of the corrections introduced their own. Nothing in the fix depends on it.

The cost is that a `pip.conf`-only policy is invisible while the venv has no pip yet, which is the state uv leaves a fresh venv in. A miss costs a line in a notice, never an install: the opt-out withholds the relaxations mechanically, whether or not anything was detected. The probe is memoised only once it has actually reached pip, so a venv with no pip yet does not pin that answer for the rest of the run.

## No default UX change

With the variable unset, every installer behaves byte-identically to today. That is checked rather than asserted: 135 command and environment combinations byte-compared against `main`, and 2403 invariance checks across [Windows, Linux, WSL, macOS] x [NVIDIA, AMD, CPU]. On an ordinary machine nothing is detected and nothing prints. Studio, Desktop and the notebook install paths are untouched.

## Left alone deliberately

- The `diffusers` GitHub archive pin. It is already commit-SHA addressed, and a `--hash` pin there breaks on GitHub's non-reproducible archive zips.
- Stripping `UV_REQUIRE_HASHES` / `UV_EXCLUDE_NEWER` in the shell installers' default arm. `install.sh` has never done this, and adding it would make the shell layer relax a control it enforces today. That is a separate decision about how much policy the installer should override, and it belongs in its own change rather than the one that adds the way to decline.
- Narrowing the XPU bailout to a detected hash requirement. `pip_install` resolves to uv when uv is in use, and a `[pip] require-hashes = true` in a user `uv.toml` is not visible here, so the gate cannot be computed reliably. Being conservative costs one optimisation, clearly reported, with a documented one-run workaround. Being wrong costs a venv with no triton.

## Tests

- `tests/python/test_install_python_stack.py`: the opt-out on and off, the source-build exemptions being withdrawn, pinned installs keeping policy while still scrubbing the index, the parent environment never being mutated, the notice staying silent on an ordinary machine and never being able to take an install down, the destructive steps declining under the opt-out, `:none:` read as a list sentinel rather than a boolean, `false` disabling only uv's cutoff spellings and not pip's, no-index read per command, and a failed pip probe not being memoised for the run.
- `tests/python/test_pm_policy_optout_shell.py`: executes `install.sh`'s predicate under a real `sh` and compares it value by value against `_respect_pm_policy()`, since a variable that means one thing to the shell and another to Python would be worse than no gate.
- `tests/studio/test_pm_policy_optout_installers.ps1`: AST-extracts the PowerShell helpers and runs them against a recorder standing in for uv, so what is asserted is the environment each helper actually hands the manager.

```
tests/python/test_install_python_stack.py
tests/python/test_pm_policy_optout_shell.py
tests/python/test_cross_platform_parity.py
tests/studio/test_xpu_triton_swap.py
385 passed          (and 278 passed with UNSLOTH_RESPECT_PM_POLICY=1 inherited)
```

`ruff check` clean, `sh -n` clean, all three installers parse. The wider `tests/python` and `tests/studio` sweep is unchanged: the only failures are pre-existing on a clean tree (`test_rl_config_pickling`, `test_negative_control_no_tokenizers`, the `test_e2e_no_torch_sandbox` live-server test) or environment-dependent fixtures unrelated to these files.
