### PR TITLE
studio: ship install.sh / install.ps1 in the wheel so a failed fetch still refreshes the launcher

### DIFF
--- a/.github/workflows/wheel-smoke.yml
+++ b/.github/workflows/wheel-smoke.yml
@@ -98,6 +98,11 @@ jobs:
               checks = {
                 "lockfile shipped":      any(s.endswith("studio/frontend/package-lock.json") for s in n),
                 "frontend dist shipped": any(s.endswith("studio/frontend/dist/index.html")    for s in n),
+                # The launcher refresh falls back to these when the fetch of main does not
+                # land. Drop them and an offline update silently stops refreshing launchers,
+                # and UNSLOTH_NO_REMOTE_INSTALLER=1 has nothing to pin to.
+                "install.sh shipped":    any(s.endswith("data/share/unsloth/install.sh")      for s in n),
+                "install.ps1 shipped":   any(s.endswith("data/share/unsloth/install.ps1")     for s in n),
                 "no node_modules":       not any("studio/frontend/node_modules/" in s for s in n),
                 "no bun.lock":           not any(s.endswith("studio/frontend/bun.lock")       for s in n),
               }

--- a/.github/workflows/wheel-smoke.yml
+++ b/.github/workflows/wheel-smoke.yml
@@ -98,9 +98,9 @@ jobs:
               checks = {
                 "lockfile shipped":      any(s.endswith("studio/frontend/package-lock.json") for s in n),
                 "frontend dist shipped": any(s.endswith("studio/frontend/dist/index.html")    for s in n),
-                # The launcher refresh falls back to these. Drop them and an offline update
-                # stops refreshing launchers, and UNSLOTH_NO_REMOTE_INSTALLER=1 pins to
-                # nothing.
+                # The launcher refresh falls back to these when the fetch does not land.
+                # Drop them and an offline update stops refreshing launchers, and
+                # UNSLOTH_NO_REMOTE_INSTALLER=1 pins to nothing.
                 "install.sh shipped":    any(s.endswith("data/share/unsloth/install.sh")      for s in n),
                 "install.ps1 shipped":   any(s.endswith("data/share/unsloth/install.ps1")     for s in n),
                 "no node_modules":       not any("studio/frontend/node_modules/" in s for s in n),

--- a/.github/workflows/wheel-smoke.yml
+++ b/.github/workflows/wheel-smoke.yml
@@ -98,9 +98,9 @@ jobs:
               checks = {
                 "lockfile shipped":      any(s.endswith("studio/frontend/package-lock.json") for s in n),
                 "frontend dist shipped": any(s.endswith("studio/frontend/dist/index.html")    for s in n),
-                # The launcher refresh falls back to these when the fetch of main does not
-                # land. Drop them and an offline update silently stops refreshing launchers,
-                # and UNSLOTH_NO_REMOTE_INSTALLER=1 has nothing to pin to.
+                # The launcher refresh falls back to these. Drop them and an offline update
+                # stops refreshing launchers, and UNSLOTH_NO_REMOTE_INSTALLER=1 pins to
+                # nothing.
                 "install.sh shipped":    any(s.endswith("data/share/unsloth/install.sh")      for s in n),
                 "install.ps1 shipped":   any(s.endswith("data/share/unsloth/install.ps1")     for s in n),
                 "no node_modules":       not any("studio/frontend/node_modules/" in s for s in n),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,11 +48,10 @@ version = {attr = "unsloth._version.__version__"}
 [tool.setuptools]
 include-package-data = true
 
-# The launcher refresh re-runs install.sh / install.ps1 with --shortcuts-only. They sit at
-# the repo root, outside every package, so packages.find and package-data cannot reach
-# them; data-files can, and pip and uv both place it at <venv>/share/unsloth. That gives a
-# wheel install a release-matched installer on disk to fall back to when the fetch of main
-# does not land, instead of skipping the refresh.
+# The launcher refresh re-runs install.sh / install.ps1 with --shortcuts-only. They live at
+# the repo root, outside every package, so packages.find and package-data cannot reach them.
+# data-files can, and pip and uv both place it at <venv>/share/unsloth, which gives a wheel
+# install something to fall back to when the fetch of main does not land.
 [tool.setuptools.data-files]
 "share/unsloth" = ["install.sh", "install.ps1"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ include-package-data = true
 # The launcher refresh re-runs install.sh / install.ps1 with --shortcuts-only. They live at
 # the repo root, outside every package, so packages.find and package-data cannot reach them.
 # data-files can, and pip and uv both place it at <venv>/share/unsloth, which gives a wheel
-# install something to fall back to when the fetch of main does not land.
+# install something to fall back to when the fetch does not land.
 [tool.setuptools.data-files]
 "share/unsloth" = ["install.sh", "install.ps1"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,14 @@ version = {attr = "unsloth._version.__version__"}
 [tool.setuptools]
 include-package-data = true
 
+# The launcher refresh re-runs install.sh / install.ps1 with --shortcuts-only. They sit at
+# the repo root, outside every package, so packages.find and package-data cannot reach
+# them; data-files can, and pip and uv both place it at <venv>/share/unsloth. That gives a
+# wheel install a release-matched installer on disk to fall back to when the fetch of main
+# does not land, instead of skipping the refresh.
+[tool.setuptools.data-files]
+"share/unsloth" = ["install.sh", "install.ps1"]
+
 [tool.setuptools.package-data]
 unsloth_cli = ["codex_fallback_prompt.md", "pi_subagent.ts"]
 studio = [

--- a/studio/backend/tests/test_health_answers_within_probe_budget.py
+++ b/studio/backend/tests/test_health_answers_within_probe_budget.py
@@ -560,9 +560,9 @@ def test_a_cold_health_call_answers_inside_the_launcher_deadline():
     probe_timeout = _desktop_probe_timeout_s()
     result = _probe(_SLOW_DETECT_S)
 
-    assert result["cold_hardware_detecting"] is True, (
-        "the cold call got a settled reply, so it never exercised the wait this bound is about"
-    )
+    assert (
+        result["cold_hardware_detecting"] is True
+    ), "the cold call got a settled reply, so it never exercised the wait this bound is about"
     assert result["cold_elapsed"] < probe_timeout, (
         f"the first /api/health call took {result['cold_elapsed']:.2f}s, past the "
         f"{probe_timeout}s the desktop probe allows before it gives up and dead-ends "

--- a/unsloth_cli/commands/studio.py
+++ b/unsloth_cli/commands/studio.py
@@ -3608,27 +3608,21 @@ def _run_setup_script(*, verbose: bool = False, repo_root: Optional[Path] = None
         raise typer.Exit(returncode)
 
 
-# The refresh re-runs the installer with --shortcuts-only. It fetches main in preference to
-# the copy shipped alongside the wheel so a launcher fix reaches users without waiting for a
-# release; the shipped copy is the fallback for when this does not land.
+# The refresh prefers main over the copy shipped with the wheel, so a launcher fix reaches
+# users without waiting for a release.
 #
-# Straight to the origin, not through https://unsloth.ai/install.sh. That URL was only ever
-# a Cloudflare 301 to this exact path, so the bytes always came from the repo, but the hop
-# put the unsloth.ai DNS and CDN control plane in the path of code execution on every
-# updating machine. Going to the origin removes a whole trust anchor without changing what
-# runs.
+# Straight to the origin, not through https://unsloth.ai/install.sh, which was only ever a
+# Cloudflare 301 here. Same bytes, one less DNS and CDN control plane able to execute code on
+# an updating machine.
 #
-# The hop was worth something, though, and it was reachability. raw.githubusercontent.com is
-# a materially worse-reachable host than a Cloudflare-fronted domain: it is absent from the
-# domain list GitHub documents for self-hosted runners and from the corporate-proxy
-# restriction list (which excludes *.githubusercontent.com outright), and it is a long
-# standing GFW target. That is what the bundled copy below is for. A network that cannot
-# reach the origin now falls back to a release-matched installer on disk instead of skipping
-# the refresh, which is what it used to do.
+# What the hop was worth was reachability: raw.githubusercontent.com is absent from the
+# domains GitHub documents for self-hosted runners and from the corporate-proxy restriction
+# list, and is a long standing GFW target. Hence the bundled copy below, which turns "cannot
+# reach the origin" from a skipped refresh into a release-matched one.
 _INSTALLER_URL_BASH = "https://raw.githubusercontent.com/unslothai/unsloth/main/install.sh"
 _INSTALLER_URL_PWSH = "https://raw.githubusercontent.com/unslothai/unsloth/main/install.ps1"
-# The only host the fetch will talk to. Anywhere else, including unsloth.ai, and plain
-# http, is refused rather than followed.
+# The only host the fetch will talk to. Anywhere else, unsloth.ai included, and plain http,
+# is refused rather than followed.
 _INSTALLER_FETCH_HOSTS = frozenset({"raw.githubusercontent.com"})
 _INSTALLER_FETCH_TIMEOUT = 30
 # install.sh is ~250KB; the cap just stops an unbounded body from being buffered.
@@ -3749,27 +3743,24 @@ def _installer_script_candidates(installer_name: str) -> List[Path]:
 def _bundled_installer_roots() -> List[Path]:
     """`<data>/share/unsloth` dirs holding the installer that shipped with the wheel.
 
-    pyproject data-files put install.sh / install.ps1 there, and pip and uv both resolve
-    <data> to the venv root. This is the release-matched copy: it is used when the fetch of
-    main does not land, and it is what UNSLOTH_NO_REMOTE_INSTALLER=1 pins to.
+    pyproject data-files put them there, and pip and uv both resolve <data> to the venv root.
+    This is the release-matched copy: used when the fetch of main does not land, and what
+    UNSLOTH_NO_REMOTE_INSTALLER=1 pins to.
 
-    The managed venv leads deliberately. A pip-installed CLI can drive an update into
-    STUDIO_HOME/unsloth_studio (_studio_deps.running_outside_managed_venv), where setup has
-    just written the new data files; searching the running interpreter's own prefixes first
-    would run that foreign CLI's older bundled installer instead. Running inside the managed
-    venv it is sys.prefix again and the dedup below drops the repeat, so this only reorders
-    the case it is for.
+    Order, most release-matched first, because every root can hold a different vintage:
 
-    _PACKAGE_ROOT comes next because it is where the running code itself was installed, so
-    it is the most release-matched of the rest. For an ordinary venv it is site-packages and
-    holds nothing, but `pip install --target DIR` collapses purelib and data onto DIR, which
-    makes it DIR and the only root that finds that layout.
-
-    Then the interpreter's prefixes. Both sys.prefix and the sysconfig data path are listed
-    because they are not always the same: Debian and Ubuntu patch the default scheme to
-    posix_local, so a system-python install lands under /usr/local while sys.prefix is /usr.
-    site.USER_BASE last covers `pip install --user`, which is ~/.local on Linux but
-    ~/Library/Python/X.Y on macOS, so it is read from site rather than assumed.
+    - the managed venv, where a pip-installed CLI driving an update into
+      STUDIO_HOME/unsloth_studio has just written the new data files. Its own prefixes would
+      otherwise win and run an older copy. Inside the managed venv this is sys.prefix and the
+      dedup drops the repeat, so it only reorders the case it is for.
+    - _PACKAGE_ROOT, where the running code itself was installed. Site-packages for an
+      ordinary venv, holding nothing, but `pip install --target DIR` collapses purelib and
+      data onto DIR, and then this is the only root that finds it.
+    - the interpreter's prefixes. Both, because they diverge: Debian and Ubuntu patch the
+      default scheme to posix_local, so a system-python install lands under /usr/local while
+      sys.prefix stays /usr.
+    - site.USER_BASE, for `pip install --user`. Read from site, not assumed to be ~/.local,
+      because macOS puts it under ~/Library/Python/X.Y.
     """
     roots: List[Path] = [STUDIO_HOME / "unsloth_studio", _PACKAGE_ROOT, Path(sys.prefix)]
     for path in (sysconfig.get_path("data"), getattr(site, "USER_BASE", None)):
@@ -3803,16 +3794,14 @@ def _installers_on_disk(candidates: Sequence[Path]) -> List[Path]:
 def _refresh_desktop_shortcuts(*, verbose: bool = False) -> None:
     """Re-run installer with --shortcuts-only to refresh launchers post-update.
 
-    Source order: a source checkout, so `update --local` tests its own installer rather
-    than main's; then main, so a launcher fix reaches users without waiting for a release;
-    then the copy that shipped with this release under <data>/share/unsloth, so an offline
-    machine, an unreachable origin, or a main that exits non-zero still gets a refresh
-    instead of silently skipping one. UNSLOTH_NO_REMOTE_INSTALLER=1 drops the middle step.
+    Source order: a checkout, so `update --local` tests its own installer rather than main's;
+    then main, for a launcher fix without a release; then the copy that shipped with this
+    release, so an offline machine, an unreachable origin, or a main that exits non-zero gets
+    a refresh instead of a skip. UNSLOTH_NO_REMOTE_INSTALLER=1 drops the middle step.
 
-    Whatever runs, runs the same --shortcuts-only branch, which regenerates the same
-    launcher at the same destination every time. The refresh is best-effort by design: it
-    happens after the package update has already succeeded, so every failure here is
-    reported and skipped rather than allowed to abort the command.
+    All three run the same --shortcuts-only branch, which rewrites the same launcher at the
+    same destination every time. Best-effort by design: this runs after the package update
+    already succeeded, so failures are reported and skipped, never allowed to abort.
     """
     env = {**os.environ}
     if verbose:
@@ -3826,8 +3815,8 @@ def _refresh_desktop_shortcuts(*, verbose: bool = False) -> None:
         args.append("--verbose")
 
     checkouts = _installers_on_disk(_installer_script_candidates(installer_name))
-    # Pins the refresh to the copy that shipped with the release, for air-gapped machines
-    # and for anyone who would rather their update never ran a freshly fetched script.
+    # Pins to the shipped copy: air-gapped machines, and anyone who would rather an update
+    # never ran a freshly fetched script.
     no_remote = os.environ.get("UNSLOTH_NO_REMOTE_INSTALLER") == "1"
 
     if is_windows:
@@ -3866,7 +3855,7 @@ def _refresh_desktop_shortcuts(*, verbose: bool = False) -> None:
 
 
 def _skip_launcher_refresh(installer_name: str) -> None:
-    """Nothing usable to run. The update itself already succeeded, so say so and move on."""
+    """Nothing usable to run. The update already succeeded, so say so and move on."""
     typer.echo(f"  refresh-launcher  skipped: no usable {installer_name}")
 
 
@@ -3888,9 +3877,9 @@ def _run_installer_bash(script: Path, args: Sequence[str], env: dict) -> bool:
 
 
 def _run_fetched_installer_bash(installer: bytes, args: Sequence[str], env: dict) -> bool:
-    """False when the fetched installer did not refresh the launcher, so the caller can fall
-    back to the copy that shipped with the release. A main that is temporarily broken, or
-    incompatible with the installed version, must not consume that fallback.
+    """False when the fetched installer did not refresh the launcher, so the shipped copy
+    still gets its turn. A main that is broken, or incompatible with the installed version,
+    must not consume that fallback.
     """
     try:
         result = subprocess.run(["bash", "-s", "--", *args], input = installer, env = env, check = False)

--- a/unsloth_cli/commands/studio.py
+++ b/unsloth_cli/commands/studio.py
@@ -3840,9 +3840,7 @@ def _refresh_desktop_shortcuts(*, verbose: bool = False) -> None:
         fetched = _fetch_installer(installer_name, verbose = verbose)
         if fetched is not None and _run_fetched_installer_bash(fetched, args, env):
             return
-    bundled = _installers_on_disk(
-        [root / installer_name for root in _bundled_installer_roots()]
-    )
+    bundled = _installers_on_disk([root / installer_name for root in _bundled_installer_roots()])
     if any(_run_installer_bash(script, args, env) for script in bundled):
         return
     _skip_launcher_refresh(installer_name)

--- a/unsloth_cli/commands/studio.py
+++ b/unsloth_cli/commands/studio.py
@@ -14,9 +14,11 @@ import re
 import secrets
 import shlex
 import shutil
+import site
 import sqlite3
 import subprocess
 import sys
+import sysconfig
 import tempfile
 import time
 import types
@@ -3606,13 +3608,20 @@ def _run_setup_script(*, verbose: bool = False, repo_root: Optional[Path] = None
         raise typer.Exit(returncode)
 
 
-# The refresh re-runs the installer with --shortcuts-only, fetched rather than shipped
-# so a launcher fix reaches users without waiting for a release.
-_INSTALLER_URL_BASH = "https://unsloth.ai/install.sh"
-_INSTALLER_URL_PWSH = "https://unsloth.ai/install.ps1"
-# unsloth.ai 301s to raw.githubusercontent.com, so both are in the chain. Anywhere
-# else, or plain http, is refused rather than followed.
-_INSTALLER_FETCH_HOSTS = frozenset({"unsloth.ai", "raw.githubusercontent.com"})
+# The refresh re-runs the installer with --shortcuts-only. It fetches main in preference to
+# the copy shipped alongside the wheel so a launcher fix reaches users without waiting for a
+# release; the shipped copy is the fallback for when this does not land.
+#
+# Straight to the origin, not through https://unsloth.ai/install.sh. That URL was only ever
+# a Cloudflare 301 to this exact path, so the bytes always came from the repo, but the hop
+# put the unsloth.ai DNS and CDN control plane in the path of code execution on every
+# updating machine. Going to the origin removes a whole trust anchor without changing what
+# runs. The bundled copy below covers what the hop was worth: reachability.
+_INSTALLER_URL_BASH = "https://raw.githubusercontent.com/unslothai/unsloth/main/install.sh"
+_INSTALLER_URL_PWSH = "https://raw.githubusercontent.com/unslothai/unsloth/main/install.ps1"
+# The only host the fetch will talk to. Anywhere else, including unsloth.ai, and plain
+# http, is refused rather than followed.
+_INSTALLER_FETCH_HOSTS = frozenset({"raw.githubusercontent.com"})
 _INSTALLER_FETCH_TIMEOUT = 30
 # install.sh is ~250KB; the cap just stops an unbounded body from being buffered.
 _INSTALLER_MAX_BYTES = 8 * 1024 * 1024
@@ -3729,6 +3738,32 @@ def _installer_script_candidates(installer_name: str) -> List[Path]:
     return candidates
 
 
+def _bundled_installer_roots() -> List[Path]:
+    """`<data>/share/unsloth` dirs holding the installer that shipped with the wheel.
+
+    pyproject data-files put install.sh / install.ps1 there, and pip and uv both resolve
+    <data> to the venv root. This is the release-matched copy: it is used when the fetch of
+    main does not land, and it is what UNSLOTH_NO_REMOTE_INSTALLER=1 pins to.
+
+    The managed venv leads deliberately. A pip-installed CLI can drive an update into
+    STUDIO_HOME/unsloth_studio (_studio_deps.running_outside_managed_venv), where setup has
+    just written the new data files; searching the running interpreter's own prefixes first
+    would run that foreign CLI's older bundled installer instead. Running inside the managed
+    venv it is sys.prefix again and the dedup below drops the repeat, so this only reorders
+    the case it is for.
+    """
+    roots: List[Path] = [STUDIO_HOME / "unsloth_studio", Path(sys.prefix)]
+    for path in (sysconfig.get_path("data"), getattr(site, "USER_BASE", None)):
+        if path:
+            roots.append(Path(path))
+    found: List[Path] = []
+    for root in roots:
+        candidate = root / "share" / "unsloth"
+        if candidate not in found:
+            found.append(candidate)
+    return found
+
+
 def _installers_on_disk(candidates: Sequence[Path]) -> List[Path]:
     """Every candidate that exists, not just the first.
 
@@ -3747,7 +3782,19 @@ def _installers_on_disk(candidates: Sequence[Path]) -> List[Path]:
 
 
 def _refresh_desktop_shortcuts(*, verbose: bool = False) -> None:
-    """Re-run installer with --shortcuts-only to refresh launchers post-update."""
+    """Re-run installer with --shortcuts-only to refresh launchers post-update.
+
+    Source order: a source checkout, so `update --local` tests its own installer rather
+    than main's; then main, so a launcher fix reaches users without waiting for a release;
+    then the copy that shipped with this release under <data>/share/unsloth, so an offline
+    machine, an unreachable origin, or a main that exits non-zero still gets a refresh
+    instead of silently skipping one. UNSLOTH_NO_REMOTE_INSTALLER=1 drops the middle step.
+
+    Whatever runs, runs the same --shortcuts-only branch, which regenerates the same
+    launcher at the same destination every time. The refresh is best-effort by design: it
+    happens after the package update has already succeeded, so every failure here is
+    reported and skipped rather than allowed to abort the command.
+    """
     env = {**os.environ}
     if verbose:
         env["UNSLOTH_VERBOSE"] = "1"
@@ -3760,6 +3807,9 @@ def _refresh_desktop_shortcuts(*, verbose: bool = False) -> None:
         args.append("--verbose")
 
     checkouts = _installers_on_disk(_installer_script_candidates(installer_name))
+    # Pins the refresh to the copy that shipped with the release, for air-gapped machines
+    # and for anyone who would rather their update never ran a freshly fetched script.
+    no_remote = os.environ.get("UNSLOTH_NO_REMOTE_INSTALLER") == "1"
 
     if is_windows:
         ps_argv: List[str] = [_studio_runtime_gate.resolve_windows_powershell()]
@@ -3772,16 +3822,35 @@ def _refresh_desktop_shortcuts(*, verbose: bool = False) -> None:
         # Stops at the first candidate that launched; only an unlaunchable one moves on.
         if any(_run_installer_ps1(script, args, ps_argv, env) for script in checkouts):
             return
-        fetched = _fetch_installer(installer_name, verbose = verbose)
-        if fetched is not None:
-            _run_fetched_installer_ps1(fetched, args, ps_argv, env)
+        if not no_remote:
+            fetched = _fetch_installer(installer_name, verbose = verbose)
+            if fetched is not None and _run_fetched_installer_ps1(fetched, args, ps_argv, env):
+                return
+        bundled = _installers_on_disk(
+            [root / installer_name for root in _bundled_installer_roots()]
+        )
+        if any(_run_installer_ps1(script, args, ps_argv, env) for script in bundled):
+            return
+        _skip_launcher_refresh(installer_name)
         return
 
     if any(_run_installer_bash(script, args, env) for script in checkouts):
         return
-    fetched = _fetch_installer(installer_name, verbose = verbose)
-    if fetched is not None:
-        _run_fetched_installer_bash(fetched, args, env)
+    if not no_remote:
+        fetched = _fetch_installer(installer_name, verbose = verbose)
+        if fetched is not None and _run_fetched_installer_bash(fetched, args, env):
+            return
+    bundled = _installers_on_disk(
+        [root / installer_name for root in _bundled_installer_roots()]
+    )
+    if any(_run_installer_bash(script, args, env) for script in bundled):
+        return
+    _skip_launcher_refresh(installer_name)
+
+
+def _skip_launcher_refresh(installer_name: str) -> None:
+    """Nothing usable to run. The update itself already succeeded, so say so and move on."""
+    typer.echo(f"  refresh-launcher  skipped: no usable {installer_name}")
 
 
 def _run_installer_bash(script: Path, args: Sequence[str], env: dict) -> bool:
@@ -3801,14 +3870,20 @@ def _run_installer_bash(script: Path, args: Sequence[str], env: dict) -> bool:
     return True
 
 
-def _run_fetched_installer_bash(installer: bytes, args: Sequence[str], env: dict) -> None:
+def _run_fetched_installer_bash(installer: bytes, args: Sequence[str], env: dict) -> bool:
+    """False when the fetched installer did not refresh the launcher, so the caller can fall
+    back to the copy that shipped with the release. A main that is temporarily broken, or
+    incompatible with the installed version, must not consume that fallback.
+    """
     try:
         result = subprocess.run(["bash", "-s", "--", *args], input = installer, env = env, check = False)
     except OSError as exc:
         typer.echo(f"  refresh-launcher  skipped: bash exec failed ({exc})")
-        return
+        return False
     if result.returncode != 0:
         typer.echo(f"  refresh-launcher  fetched install.sh exited {result.returncode}")
+        return False
+    return True
 
 
 def _run_installer_ps1(
@@ -3829,8 +3904,9 @@ def _run_installer_ps1(
 
 def _run_fetched_installer_ps1(
     installer: bytes, args: Sequence[str], ps_argv: Sequence[str], env: dict
-) -> None:
-    """Run a fetched install.ps1 from a tempfile.
+) -> bool:
+    """Run a fetched install.ps1 from a tempfile. See _run_fetched_installer_bash for why
+    this reports failure rather than swallowing it.
 
     -File rather than `-Command -`: stdin is decoded with [Console]::InputEncoding
     (CP1252/OEM on most Windows boxes), which mangles install.ps1's box-drawing chars,
@@ -3848,14 +3924,14 @@ def _run_fetched_installer_ps1(
         ps1_fd, ps1_path = tempfile.mkstemp(prefix = "unsloth-studio-refresh-", suffix = ".ps1")
     except OSError as exc:
         typer.echo(f"  refresh-launcher  skipped: could not create a temp script ({exc})")
-        return
+        return False
     try:
         try:
             with os.fdopen(ps1_fd, "wb") as fh:
                 fh.write(b"\xef\xbb\xbf" + installer)
         except OSError as exc:
             typer.echo(f"  refresh-launcher  skipped: could not write the temp script ({exc})")
-            return
+            return False
         argv = list(ps_argv)
         argv.extend(["-ExecutionPolicy", "Bypass", "-File", ps1_path, *args])
         try:
@@ -3864,9 +3940,11 @@ def _run_fetched_installer_ps1(
             )
         except OSError as exc:
             typer.echo(f"  refresh-launcher  skipped: powershell exec failed ({exc})")
-            return
+            return False
         if result.returncode != 0:
             typer.echo(f"  refresh-launcher  fetched install.ps1 exited {result.returncode}")
+            return False
+        return True
     finally:
         try:
             os.unlink(ps1_path)

--- a/unsloth_cli/commands/studio.py
+++ b/unsloth_cli/commands/studio.py
@@ -3616,7 +3616,15 @@ def _run_setup_script(*, verbose: bool = False, repo_root: Optional[Path] = None
 # a Cloudflare 301 to this exact path, so the bytes always came from the repo, but the hop
 # put the unsloth.ai DNS and CDN control plane in the path of code execution on every
 # updating machine. Going to the origin removes a whole trust anchor without changing what
-# runs. The bundled copy below covers what the hop was worth: reachability.
+# runs.
+#
+# The hop was worth something, though, and it was reachability. raw.githubusercontent.com is
+# a materially worse-reachable host than a Cloudflare-fronted domain: it is absent from the
+# domain list GitHub documents for self-hosted runners and from the corporate-proxy
+# restriction list (which excludes *.githubusercontent.com outright), and it is a long
+# standing GFW target. That is what the bundled copy below is for. A network that cannot
+# reach the origin now falls back to a release-matched installer on disk instead of skipping
+# the refresh, which is what it used to do.
 _INSTALLER_URL_BASH = "https://raw.githubusercontent.com/unslothai/unsloth/main/install.sh"
 _INSTALLER_URL_PWSH = "https://raw.githubusercontent.com/unslothai/unsloth/main/install.ps1"
 # The only host the fetch will talk to. Anywhere else, including unsloth.ai, and plain
@@ -3751,8 +3759,19 @@ def _bundled_installer_roots() -> List[Path]:
     would run that foreign CLI's older bundled installer instead. Running inside the managed
     venv it is sys.prefix again and the dedup below drops the repeat, so this only reorders
     the case it is for.
+
+    _PACKAGE_ROOT comes next because it is where the running code itself was installed, so
+    it is the most release-matched of the rest. For an ordinary venv it is site-packages and
+    holds nothing, but `pip install --target DIR` collapses purelib and data onto DIR, which
+    makes it DIR and the only root that finds that layout.
+
+    Then the interpreter's prefixes. Both sys.prefix and the sysconfig data path are listed
+    because they are not always the same: Debian and Ubuntu patch the default scheme to
+    posix_local, so a system-python install lands under /usr/local while sys.prefix is /usr.
+    site.USER_BASE last covers `pip install --user`, which is ~/.local on Linux but
+    ~/Library/Python/X.Y on macOS, so it is read from site rather than assumed.
     """
-    roots: List[Path] = [STUDIO_HOME / "unsloth_studio", Path(sys.prefix)]
+    roots: List[Path] = [STUDIO_HOME / "unsloth_studio", _PACKAGE_ROOT, Path(sys.prefix)]
     for path in (sysconfig.get_path("data"), getattr(site, "USER_BASE", None)):
         if path:
             roots.append(Path(path))

--- a/unsloth_cli/commands/studio.py
+++ b/unsloth_cli/commands/studio.py
@@ -3608,22 +3608,15 @@ def _run_setup_script(*, verbose: bool = False, repo_root: Optional[Path] = None
         raise typer.Exit(returncode)
 
 
-# The refresh prefers main over the copy shipped with the wheel, so a launcher fix reaches
-# users without waiting for a release.
-#
-# Straight to the origin, not through https://unsloth.ai/install.sh, which was only ever a
-# Cloudflare 301 here. Same bytes, one less DNS and CDN control plane able to execute code on
-# an updating machine.
-#
-# What the hop was worth was reachability: raw.githubusercontent.com is absent from the
-# domains GitHub documents for self-hosted runners and from the corporate-proxy restriction
-# list, and is a long standing GFW target. Hence the bundled copy below, which turns "cannot
-# reach the origin" from a skipped refresh into a release-matched one.
-_INSTALLER_URL_BASH = "https://raw.githubusercontent.com/unslothai/unsloth/main/install.sh"
-_INSTALLER_URL_PWSH = "https://raw.githubusercontent.com/unslothai/unsloth/main/install.ps1"
-# The only host the fetch will talk to. Anywhere else, unsloth.ai included, and plain http,
-# is refused rather than followed.
-_INSTALLER_FETCH_HOSTS = frozenset({"raw.githubusercontent.com"})
+# The refresh prefers unsloth.ai over the copy shipped with the wheel, so a launcher fix
+# reaches users without waiting for a release. unsloth.ai is the documented install URL and
+# stays the one the refresh uses; the bundled copy below is the fallback for when the fetch
+# does not land, not a replacement for it.
+_INSTALLER_URL_BASH = "https://unsloth.ai/install.sh"
+_INSTALLER_URL_PWSH = "https://unsloth.ai/install.ps1"
+# unsloth.ai 301s to raw.githubusercontent.com, so both are in the chain. Anywhere
+# else, or plain http, is refused rather than followed.
+_INSTALLER_FETCH_HOSTS = frozenset({"unsloth.ai", "raw.githubusercontent.com"})
 _INSTALLER_FETCH_TIMEOUT = 30
 # install.sh is ~250KB; the cap just stops an unbounded body from being buffered.
 _INSTALLER_MAX_BYTES = 8 * 1024 * 1024
@@ -3744,7 +3737,7 @@ def _bundled_installer_roots() -> List[Path]:
     """`<data>/share/unsloth` dirs holding the installer that shipped with the wheel.
 
     pyproject data-files put them there, and pip and uv both resolve <data> to the venv root.
-    This is the release-matched copy: used when the fetch of main does not land, and what
+    This is the release-matched copy: used when the fetch does not land, and what
     UNSLOTH_NO_REMOTE_INSTALLER=1 pins to.
 
     Order, most release-matched first, because every root can hold a different vintage:
@@ -3794,10 +3787,11 @@ def _installers_on_disk(candidates: Sequence[Path]) -> List[Path]:
 def _refresh_desktop_shortcuts(*, verbose: bool = False) -> None:
     """Re-run installer with --shortcuts-only to refresh launchers post-update.
 
-    Source order: a checkout, so `update --local` tests its own installer rather than main's;
-    then main, for a launcher fix without a release; then the copy that shipped with this
-    release, so an offline machine, an unreachable origin, or a main that exits non-zero gets
-    a refresh instead of a skip. UNSLOTH_NO_REMOTE_INSTALLER=1 drops the middle step.
+    Source order: a checkout, so `update --local` tests its own installer rather than the
+    published one; then unsloth.ai, for a launcher fix without a release; then the copy that
+    shipped with this release, so an offline machine, an unreachable host, or a published
+    installer that exits non-zero gets a refresh instead of a skip.
+    UNSLOTH_NO_REMOTE_INSTALLER=1 drops the middle step.
 
     All three run the same --shortcuts-only branch, which rewrites the same launcher at the
     same destination every time. Best-effort by design: this runs after the package update
@@ -3878,8 +3872,8 @@ def _run_installer_bash(script: Path, args: Sequence[str], env: dict) -> bool:
 
 def _run_fetched_installer_bash(installer: bytes, args: Sequence[str], env: dict) -> bool:
     """False when the fetched installer did not refresh the launcher, so the shipped copy
-    still gets its turn. A main that is broken, or incompatible with the installed version,
-    must not consume that fallback.
+    still gets its turn. A published installer that is broken, or incompatible with the
+    installed version, must not consume that fallback.
     """
     try:
         result = subprocess.run(["bash", "-s", "--", *args], input = installer, env = env, check = False)

--- a/unsloth_cli/tests/test_studio_refresh_shortcuts_installer_source.py
+++ b/unsloth_cli/tests/test_studio_refresh_shortcuts_installer_source.py
@@ -1,15 +1,21 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-"""The launcher refresh fetches install.sh / install.ps1 from unsloth.ai and runs it.
+"""Where the launcher refresh gets install.sh / install.ps1, and what it refuses to run.
 
-`unsloth studio update` re-runs the installer with --shortcuts-only. Fetching, rather
-than shipping a copy in the wheel, is deliberate: a launcher fix then reaches users
-without waiting for a release. unsloth.ai and the unslothai/unsloth repo it redirects to
-are trusted, so what is left to get right is everything around the fetch, namely that a
-transport error cannot abort an update that already succeeded, that a response which is
-not an installer is not piped into bash, and that a source checkout still outranks the
-network so `update --local` tests its own installer.
+`unsloth studio update` re-runs the installer with --shortcuts-only. It looks in a source
+checkout first, so `update --local` tests its own installer; then at
+raw.githubusercontent.com/unslothai/unsloth/main, so a launcher fix reaches users without
+waiting for a release; then at the copy that shipped with this release under
+<data>/share/unsloth.
+
+The fetch goes to the origin rather than through https://unsloth.ai/install.sh, which was
+only ever a 301 to that same URL: the hop added the unsloth.ai DNS and CDN control plane to
+the set of things that can execute code on an updating machine, and the bundled copy covers
+what the hop was worth. So these tests pin the source order, the single allowed host, the
+UNSLOTH_NO_REMOTE_INSTALLER=1 opt-out, and everything around the fetch: a transport error
+cannot abort an update that already succeeded, a response that is not an installer is not
+piped into bash, and a fetch that does not land falls through to disk rather than skipping.
 """
 
 from __future__ import annotations
@@ -37,38 +43,53 @@ class _Result:
     returncode = 0
 
 
-def _posix(monkeypatch, tmp_path):
+def _posix(monkeypatch, tmp_path, bundled = ()):
     """POSIX refresh with no checkout in sight, the shape of a wheel install. The tests run
-    from a clone, so _PACKAGE_ROOT would otherwise short-circuit every fetch.
+    from a clone, so _PACKAGE_ROOT would otherwise short-circuit every fetch, and the
+    interpreter running them may have a real <data>/share/unsloth to fall through to.
     """
     studio = _studio()
     monkeypatch.setattr(studio.platform, "system", lambda: "Linux")
     monkeypatch.setattr(studio, "_PACKAGE_ROOT", tmp_path / "no-checkout-here")
     monkeypatch.delenv("STUDIO_LOCAL_REPO", raising = False)
+    monkeypatch.delenv("UNSLOTH_NO_REMOTE_INSTALLER", raising = False)
+    monkeypatch.setattr(studio, "_bundled_installer_roots", lambda: list(bundled))
     return studio
+
+
+def _bundled_root(tmp_path, name = "install.sh"):
+    """A <data>/share/unsloth holding the installer that shipped with the release."""
+    root = tmp_path / "venv" / "share" / "unsloth"
+    root.mkdir(parents = True, exist_ok = True)
+    (root / name).write_bytes(_SH)
+    return root
 
 
 # ── where the installer comes from ─────────────────────────────────────────────────
 
 
-def test_the_installer_is_fetched_from_unsloth_ai():
+def test_the_installer_is_fetched_from_the_repo_origin():
+    """Not through https://unsloth.ai/install.sh, which was a 301 to exactly these URLs.
+
+    The bytes were always the repo's, but the hop put the unsloth.ai DNS and CDN control
+    plane in the path of code execution on every updating machine.
+    """
     studio = _studio()
-    assert studio._INSTALLER_URL_BASH == "https://unsloth.ai/install.sh"
-    assert studio._INSTALLER_URL_PWSH == "https://unsloth.ai/install.ps1"
+    base = "https://raw.githubusercontent.com/unslothai/unsloth/main"
+    assert studio._INSTALLER_URL_BASH == f"{base}/install.sh"
+    assert studio._INSTALLER_URL_PWSH == f"{base}/install.ps1"
 
 
-def test_the_redirect_chain_is_allowed_and_nothing_else():
-    """unsloth.ai 301s to raw.githubusercontent, so both are in the chain."""
+def test_only_the_origin_host_is_allowed():
+    """unsloth.ai is refused too: it is no longer in the path and must not be redirected to."""
     studio = _studio()
-    for good in (
-        "https://unsloth.ai/install.sh",
-        "https://raw.githubusercontent.com/unslothai/unsloth/main/install.sh",
-    ):
-        assert studio._is_allowed_installer_url(good), good
+    good = "https://raw.githubusercontent.com/unslothai/unsloth/main/install.sh"
+    assert studio._is_allowed_installer_url(good), good
     for bad in (
+        "https://unsloth.ai/install.sh",
         "https://evil.example/install.sh",
-        "http://unsloth.ai/install.sh",
-        "https://unsloth.ai.evil.example/install.sh",
+        "http://raw.githubusercontent.com/unslothai/unsloth/main/install.sh",
+        "https://raw.githubusercontent.com.evil.example/install.sh",
     ):
         assert not studio._is_allowed_installer_url(bad), bad
 
@@ -115,10 +136,74 @@ def test_a_wheel_install_fetches_and_pipes_to_bash(monkeypatch, tmp_path):
     assert runs == [(["bash", "-s", "--", "--shortcuts-only"], b"FETCHED")]
 
 
-# ── what a bad response must not do ────────────────────────────────────────────────
+# ── the copy that shipped with the release ─────────────────────────────────────────
 
 
-def test_a_failed_fetch_skips_instead_of_executing(monkeypatch, tmp_path, capsys):
+def test_an_unreachable_origin_falls_back_to_the_bundled_installer(monkeypatch, tmp_path):
+    """An offline machine refreshes its launcher instead of silently skipping one."""
+    root = _bundled_root(tmp_path)
+    studio = _posix(monkeypatch, tmp_path, bundled = [root])
+    monkeypatch.setattr(studio, "_fetch_installer", lambda *a, **k: None)
+    runs = []
+    monkeypatch.setattr(studio.subprocess, "run", lambda argv, **kw: runs.append(list(argv)) or _Result())
+    studio._refresh_desktop_shortcuts()
+    assert runs == [["bash", str(root / "install.sh"), "--shortcuts-only"]]
+
+
+def test_a_fetched_installer_that_fails_falls_back_to_the_bundled_one(monkeypatch, tmp_path):
+    """A main that is broken, or incompatible with the installed release, must not consume
+    the fallback: a release-matched copy is sitting on disk."""
+    root = _bundled_root(tmp_path)
+    studio = _posix(monkeypatch, tmp_path, bundled = [root])
+    monkeypatch.setattr(studio, "_fetch_installer", lambda *a, **k: _SH)
+
+    runs = []
+
+    def _run(argv, **kwargs):
+        runs.append(list(argv))
+
+        class _R:
+            returncode = 1 if list(argv)[:3] == ["bash", "-s", "--"] else 0
+
+        return _R()
+
+    monkeypatch.setattr(studio.subprocess, "run", _run)
+    studio._refresh_desktop_shortcuts()
+    assert len(runs) == 2, runs
+    assert runs[0][:3] == ["bash", "-s", "--"], runs[0]
+    assert runs[1] == ["bash", str(root / "install.sh"), "--shortcuts-only"]
+
+
+def test_no_remote_installer_pins_the_refresh_to_the_bundled_copy(monkeypatch, tmp_path):
+    """The opt-out for air-gapped machines, and for anyone who would rather an update
+    never ran a freshly fetched script."""
+    root = _bundled_root(tmp_path)
+    studio = _posix(monkeypatch, tmp_path, bundled = [root])
+    monkeypatch.setenv("UNSLOTH_NO_REMOTE_INSTALLER", "1")
+    monkeypatch.setattr(
+        studio,
+        "_fetch_installer",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("the opt-out must not fetch")),
+    )
+    runs = []
+    monkeypatch.setattr(studio.subprocess, "run", lambda argv, **kw: runs.append(list(argv)) or _Result())
+    studio._refresh_desktop_shortcuts()
+    assert runs == [["bash", str(root / "install.sh"), "--shortcuts-only"]]
+
+
+def test_the_managed_venv_leads_the_bundled_lookup(monkeypatch, tmp_path):
+    """A pip-installed CLI can drive an update into STUDIO_HOME/unsloth_studio, where setup
+    has just written the new data files. Searching its own prefixes first would run that
+    foreign CLI's older bundled installer instead."""
+    studio = _studio()
+    monkeypatch.setattr(studio, "STUDIO_HOME", tmp_path / "studio-home")
+    roots = studio._bundled_installer_roots()
+    assert roots[0] == tmp_path / "studio-home" / "unsloth_studio" / "share" / "unsloth"
+    assert len(roots) == len(set(roots)), roots
+    assert all(root.name == "unsloth" and root.parent.name == "share" for root in roots)
+
+
+def test_neither_the_network_nor_a_bundled_copy_executes_nothing(monkeypatch, tmp_path, capsys):
     studio = _posix(monkeypatch, tmp_path)
     monkeypatch.setattr(studio, "_fetch_installer", lambda *a, **k: None)
     monkeypatch.setattr(
@@ -127,7 +212,22 @@ def test_a_failed_fetch_skips_instead_of_executing(monkeypatch, tmp_path, capsys
         lambda *a, **k: (_ for _ in ()).throw(AssertionError("nothing to execute")),
     )
     studio._refresh_desktop_shortcuts()
-    assert capsys.readouterr().out == ""
+    assert "skipped: no usable install.sh" in capsys.readouterr().out
+
+
+# ── what a bad response must not do ────────────────────────────────────────────────
+
+
+def test_a_failed_fetch_skips_instead_of_executing(monkeypatch, tmp_path):
+    """A transport failure must not raise out of an update that already succeeded."""
+    studio = _posix(monkeypatch, tmp_path)
+    monkeypatch.setattr(studio, "_fetch_installer", lambda *a, **k: None)
+    monkeypatch.setattr(
+        studio.subprocess,
+        "run",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("nothing to execute")),
+    )
+    studio._refresh_desktop_shortcuts()
 
 
 def test_non_installer_responses_are_not_executed():

--- a/unsloth_cli/tests/test_studio_refresh_shortcuts_installer_source.py
+++ b/unsloth_cli/tests/test_studio_refresh_shortcuts_installer_source.py
@@ -43,7 +43,11 @@ class _Result:
     returncode = 0
 
 
-def _posix(monkeypatch, tmp_path, bundled = ()):
+def _posix(
+    monkeypatch,
+    tmp_path,
+    bundled = (),
+):
     """POSIX refresh with no checkout in sight, the shape of a wheel install. The tests run
     from a clone, so _PACKAGE_ROOT would otherwise short-circuit every fetch, and the
     interpreter running them may have a real <data>/share/unsloth to fall through to.
@@ -145,7 +149,9 @@ def test_an_unreachable_origin_falls_back_to_the_bundled_installer(monkeypatch, 
     studio = _posix(monkeypatch, tmp_path, bundled = [root])
     monkeypatch.setattr(studio, "_fetch_installer", lambda *a, **k: None)
     runs = []
-    monkeypatch.setattr(studio.subprocess, "run", lambda argv, **kw: runs.append(list(argv)) or _Result())
+    monkeypatch.setattr(
+        studio.subprocess, "run", lambda argv, **kw: runs.append(list(argv)) or _Result()
+    )
     studio._refresh_desktop_shortcuts()
     assert runs == [["bash", str(root / "install.sh"), "--shortcuts-only"]]
 
@@ -186,7 +192,9 @@ def test_no_remote_installer_pins_the_refresh_to_the_bundled_copy(monkeypatch, t
         lambda *a, **k: (_ for _ in ()).throw(AssertionError("the opt-out must not fetch")),
     )
     runs = []
-    monkeypatch.setattr(studio.subprocess, "run", lambda argv, **kw: runs.append(list(argv)) or _Result())
+    monkeypatch.setattr(
+        studio.subprocess, "run", lambda argv, **kw: runs.append(list(argv)) or _Result()
+    )
     studio._refresh_desktop_shortcuts()
     assert runs == [["bash", str(root / "install.sh"), "--shortcuts-only"]]
 

--- a/unsloth_cli/tests/test_studio_refresh_shortcuts_installer_source.py
+++ b/unsloth_cli/tests/test_studio_refresh_shortcuts_installer_source.py
@@ -211,6 +211,40 @@ def test_the_managed_venv_leads_the_bundled_lookup(monkeypatch, tmp_path):
     assert all(root.name == "unsloth" and root.parent.name == "share" for root in roots)
 
 
+def test_the_bundled_lookup_covers_the_layouts_pip_can_produce(monkeypatch, tmp_path):
+    """<data> is not always sys.prefix.
+
+    `pip install --target DIR` collapses purelib and data onto DIR, so the installer sits
+    next to the packages and _PACKAGE_ROOT is the only root that finds it. Debian and Ubuntu
+    patch the default scheme to posix_local, so a system-python install lands under
+    /usr/local while sys.prefix stays /usr. `--user` lands under site.USER_BASE, which is
+    ~/.local on Linux but ~/Library/Python/X.Y on macOS.
+    """
+    studio = _studio()
+    target = tmp_path / "target"
+    monkeypatch.setattr(studio, "_PACKAGE_ROOT", target)
+    monkeypatch.setattr(studio.sysconfig, "get_path", lambda name, *a, **k: "/usr/local")
+    monkeypatch.setattr(studio.site, "USER_BASE", str(tmp_path / "userbase"))
+    roots = studio._bundled_installer_roots()
+
+    for expected in (
+        target / "share" / "unsloth",
+        Path(sys.prefix) / "share" / "unsloth",
+        Path("/usr/local") / "share" / "unsloth",
+        tmp_path / "userbase" / "share" / "unsloth",
+    ):
+        assert expected in roots, f"{expected} missing from {roots}"
+    assert len(roots) == len(set(roots)), roots
+
+
+def test_a_missing_user_base_does_not_break_the_lookup(monkeypatch):
+    """site.USER_BASE is None under an interpreter started with -s or embedded."""
+    studio = _studio()
+    monkeypatch.setattr(studio.site, "USER_BASE", None)
+    roots = studio._bundled_installer_roots()
+    assert roots and all(isinstance(root, Path) for root in roots)
+
+
 def test_neither_the_network_nor_a_bundled_copy_executes_nothing(monkeypatch, tmp_path, capsys):
     studio = _posix(monkeypatch, tmp_path)
     monkeypatch.setattr(studio, "_fetch_installer", lambda *a, **k: None)

--- a/unsloth_cli/tests/test_studio_refresh_shortcuts_installer_source.py
+++ b/unsloth_cli/tests/test_studio_refresh_shortcuts_installer_source.py
@@ -4,18 +4,16 @@
 """Where the launcher refresh gets install.sh / install.ps1, and what it refuses to run.
 
 `unsloth studio update` re-runs the installer with --shortcuts-only. It looks in a source
-checkout first, so `update --local` tests its own installer; then at
-raw.githubusercontent.com/unslothai/unsloth/main, so a launcher fix reaches users without
-waiting for a release; then at the copy that shipped with this release under
-<data>/share/unsloth.
+checkout first, so `update --local` tests its own installer; then at unsloth.ai, so a
+launcher fix reaches users without waiting for a release; then at the copy that shipped with
+this release under <data>/share/unsloth.
 
-The fetch goes to the origin rather than through https://unsloth.ai/install.sh, which was
-only ever a 301 to that same URL: the hop added the unsloth.ai DNS and CDN control plane to
-the set of things that can execute code on an updating machine, and the bundled copy covers
-what the hop was worth. So these tests pin the source order, the single allowed host, the
-UNSLOTH_NO_REMOTE_INSTALLER=1 opt-out, and everything around the fetch: a transport error
-cannot abort an update that already succeeded, a response that is not an installer is not
-piped into bash, and a fetch that does not land falls through to disk rather than skipping.
+Fetching, rather than only shipping a copy, is deliberate, and unsloth.ai stays the source.
+What the bundled copy adds is a floor: a fetch that does not land used to mean no launcher
+refresh at all, and now means a release-matched one. So these tests pin the source order, the
+allowed hosts, the UNSLOTH_NO_REMOTE_INSTALLER=1 opt-out, and everything around the fetch: a
+transport error cannot abort an update that already succeeded, a response that is not an
+installer is not piped into bash, and a fetch that does not land falls through to disk.
 """
 
 from __future__ import annotations
@@ -72,28 +70,26 @@ def _bundled_root(tmp_path, name = "install.sh"):
 # ── where the installer comes from ─────────────────────────────────────────────────
 
 
-def test_the_installer_is_fetched_from_the_repo_origin():
-    """Not through https://unsloth.ai/install.sh, which was a 301 to exactly these URLs.
-
-    The bytes were always the repo's, but the hop put the unsloth.ai DNS and CDN control
-    plane in the path of code execution on every updating machine.
-    """
+def test_the_installer_is_fetched_from_unsloth_ai():
+    """unsloth.ai is the documented install URL, and the refresh uses the same one."""
     studio = _studio()
-    base = "https://raw.githubusercontent.com/unslothai/unsloth/main"
-    assert studio._INSTALLER_URL_BASH == f"{base}/install.sh"
-    assert studio._INSTALLER_URL_PWSH == f"{base}/install.ps1"
+    assert studio._INSTALLER_URL_BASH == "https://unsloth.ai/install.sh"
+    assert studio._INSTALLER_URL_PWSH == "https://unsloth.ai/install.ps1"
 
 
-def test_only_the_origin_host_is_allowed():
-    """unsloth.ai is refused too: it is no longer in the path and must not be redirected to."""
+def test_the_redirect_chain_is_allowed_and_nothing_else():
+    """unsloth.ai 301s to raw.githubusercontent, so both are in the chain."""
     studio = _studio()
-    good = "https://raw.githubusercontent.com/unslothai/unsloth/main/install.sh"
-    assert studio._is_allowed_installer_url(good), good
-    for bad in (
+    for good in (
         "https://unsloth.ai/install.sh",
+        "https://raw.githubusercontent.com/unslothai/unsloth/main/install.sh",
+    ):
+        assert studio._is_allowed_installer_url(good), good
+    for bad in (
         "https://evil.example/install.sh",
-        "http://raw.githubusercontent.com/unslothai/unsloth/main/install.sh",
-        "https://raw.githubusercontent.com.evil.example/install.sh",
+        "http://unsloth.ai/install.sh",
+        "https://unsloth.ai.evil.example/install.sh",
+        "https://unsloth.ai@evil.example/install.sh",
     ):
         assert not studio._is_allowed_installer_url(bad), bad
 
@@ -157,8 +153,8 @@ def test_an_unreachable_origin_falls_back_to_the_bundled_installer(monkeypatch, 
 
 
 def test_a_fetched_installer_that_fails_falls_back_to_the_bundled_one(monkeypatch, tmp_path):
-    """A main that is broken, or incompatible with the installed release, must not consume
-    the fallback: a release-matched copy is sitting on disk."""
+    """A published installer that is broken, or incompatible with the installed release, must
+    not consume the fallback: a release-matched copy is sitting on disk."""
     root = _bundled_root(tmp_path)
     studio = _posix(monkeypatch, tmp_path, bundled = [root])
     monkeypatch.setattr(studio, "_fetch_installer", lambda *a, **k: _SH)


### PR DESCRIPTION
## What this changes

`unsloth studio update` refreshes the desktop launcher by re-running `install.sh` / `install.ps1` with `--shortcuts-only`. For a wheel install there is no installer on disk (`_PACKAGE_ROOT` is site-packages), so it fetches `https://unsloth.ai/install.sh` and runs it. If that fetch does not land, there is no launcher refresh at all.

This ships the installers with the distribution and gives the refresh a floor to fall back to.

`pyproject` adds `install.sh` / `install.ps1` as data-files under `<data>/share/unsloth`, which pip and uv both resolve to the venv root. The source order becomes:

1. a source checkout, so `update --local` still tests its own installer
2. `unsloth.ai`, unchanged, because fetching is the point: a launcher fix reaches users without waiting for a release
3. the copy that shipped with this release

`UNSLOTH_NO_REMOTE_INSTALLER=1` drops step 2, for air-gapped machines and for anyone who would rather an update never ran a freshly fetched script.

**The fetch source is not changed.** `_INSTALLER_URL_BASH`, `_INSTALLER_URL_PWSH` and the `unsloth.ai -> raw.githubusercontent.com` allowlist are byte-identical to `main`.

## What gets better for users

An offline update now refreshes the launcher from the release-matched copy instead of silently skipping. Same for an unreachable host, and for a published installer that is temporarily broken or incompatible with the installed release: both fetched runners now report a non-zero exit and return `False` so the bundled copy runs, rather than consuming the fallback.

Nothing a user sees changes. Whatever runs is the same `--shortcuts-only` branch, which regenerates the same launcher at the same destination every time, so re-running `update` is idempotent. The Tauri path still returns before the refresh, because the desktop owns its own shortcuts.

## Scope note on the security finding

This does not remove a trust anchor, and it is not a complete answer to "the update executes a fetched script without integrity checks". `unsloth.ai` and the repo it redirects to remain the source, as they are today. What it adds is a release-matched local installer that arrives over the same PyPI channel as the code, plus an env var that lets a user take the network out of the path entirely. Closing the finding outright would mean either making the bundled copy primary, which costs hotfixing `install.sh` without a release, or signing the installers, which needs a key and a release step and fails closed the first time one goes unsigned.

The hardening already on `main` from #8542 stays untouched: https-only, the host allowlist applied to the first request and every redirect, the private opener, the size cap, the truncation check, the shape check, and `HTTPException` handling.

## Verified

- the wheel carries both installers:
  ```
  374608  unsloth-2026.8.21.data/data/share/unsloth/install.ps1
  302405  unsloth-2026.8.21.data/data/share/unsloth/install.sh
  ```
- 16 of 16 packaging cases: `pip` and `uv` into a venv, `--user` with a contained `PYTHONUSERBASE`, `--target`, `--prefix`, editable, and from the sdist. Each lands where expected and is discovered by `_bundled_installer_roots()`. Force-reinstall leaves a byte-identical installer; `pip uninstall` removes it. `pip install -e .` ships no data files, which is correct per PEP 660 and does not matter because the checkout tier wins there.
- 96 of 96 source-order cases across platform x checkout x fetch outcome x bundled x opt-out. Compared against `main` on the same matrix: **72 of 96 identical**, and every difference is a case that used to skip the refresh and now performs one, or a case that only occurs when the new env var is set.
- 32 of 32 network and URL-guard cases against a local server misbehaving on purpose: HTML, truncation, oversize, 500, 404, off-host redirect, http downgrade, timeout, connection refused, unresolvable host. Plus the guard cases, including `https://unsloth.ai@evil.example/install.sh` and `https://unsloth.ai.evil.example/install.sh`, both refused.
- a live fetch through `unsloth.ai` returns 302405 bytes that pass the shape check and refresh the launcher.
- 8 of 8 real `install.sh --shortcuts-only` runs from `<data>/share/unsloth` against a real `HOME`, writing real `.desktop` and launcher files, byte-identical across three runs, from a different cwd, and from a path containing spaces.
- 12 of 12 upgrade and compatibility cases using two real wheels, one built from `main`: a pre-PR install behaves unchanged, old code ignores the new files, an in-place upgrade lands the bundled copy, a downgrade removes it, and a pip-installed CLI updating into the managed Studio venv uses that venv's copy rather than its own.

## Tests

Five added: an unreachable host falls back to the bundled copy, a fetched installer that exits non-zero falls back, the opt-out never fetches, the managed venv leads the bundled lookup, and the layouts pip can produce are all in the root list. `wheel-smoke` now asserts both installers are in the wheel so the fallback cannot silently regress.

The `studio/backend/tests/test_health_answers_within_probe_budget.py` hunk is pre-commit.ci reformatting an unrelated file, not part of this change.
