### PR TITLE
Studio: use live trending GGUFs in agent setup

### DIFF
--- a/studio/backend/tests/test_health_answers_within_probe_budget.py
+++ b/studio/backend/tests/test_health_answers_within_probe_budget.py
@@ -560,9 +560,9 @@ def test_a_cold_health_call_answers_inside_the_launcher_deadline():
     probe_timeout = _desktop_probe_timeout_s()
     result = _probe(_SLOW_DETECT_S)
 
-    assert result["cold_hardware_detecting"] is True, (
-        "the cold call got a settled reply, so it never exercised the wait this bound is about"
-    )
+    assert (
+        result["cold_hardware_detecting"] is True
+    ), "the cold call got a settled reply, so it never exercised the wait this bound is about"
     assert result["cold_elapsed"] < probe_timeout, (
         f"the first /api/health call took {result['cold_elapsed']:.2f}s, past the "
         f"{probe_timeout}s the desktop probe allows before it gives up and dead-ends "

--- a/studio/backend/tests/test_health_answers_within_probe_budget.py
+++ b/studio/backend/tests/test_health_answers_within_probe_budget.py
@@ -560,9 +560,9 @@ def test_a_cold_health_call_answers_inside_the_launcher_deadline():
     probe_timeout = _desktop_probe_timeout_s()
     result = _probe(_SLOW_DETECT_S)
 
-    assert (
-        result["cold_hardware_detecting"] is True
-    ), "the cold call got a settled reply, so it never exercised the wait this bound is about"
+    assert result["cold_hardware_detecting"] is True, (
+        "the cold call got a settled reply, so it never exercised the wait this bound is about"
+    )
     assert result["cold_elapsed"] < probe_timeout, (
         f"the first /api/health call took {result['cold_elapsed']:.2f}s, past the "
         f"{probe_timeout}s the desktop probe allows before it gives up and dead-ends "

--- a/studio/frontend/src/features/settings/lib/agent-hub-model.ts
+++ b/studio/frontend/src/features/settings/lib/agent-hub-model.ts
@@ -2,6 +2,7 @@
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
 type HubModelTaskMetadata = {
+  id?: string | null;
   pipelineTag?: string | null;
   tags?: readonly string[] | null;
 };
@@ -14,11 +15,56 @@ const SPEECH_ONLY_TAGS: ReadonlySet<string> = new Set([
   "automatic-speech-recognition",
 ]);
 
+const CLASSIFIER_TASKS: ReadonlySet<string> = new Set([
+  "text-classification",
+  "token-classification",
+  "zero-shot-classification",
+]);
+
+const RERANKER_TAGS: ReadonlySet<string> = new Set([
+  "reranker",
+  "reranking",
+  "text-ranking",
+  "cross-encoder",
+]);
+
+const RERANKER_ID_PATTERN =
+  /(?:^|[-_./])(?:rerank(?:er|ing)?|classif(?:ier|ication))(?:$|[-_./])/i;
+
+function normalize(value: string | null | undefined): string | null {
+  const normalized = value?.toLowerCase().trim();
+  return normalized || null;
+}
+
 export function isSpeechOnlyHubModel(model: HubModelTaskMetadata): boolean {
-  return [model.pipelineTag, ...(model.tags ?? [])].some((tag) => {
-    if (tag == null) {
-      return false;
-    }
-    return SPEECH_ONLY_TAGS.has(tag.toLowerCase().trim());
+  const pipeline = normalize(model.pipelineTag);
+  if (pipeline) {
+    return SPEECH_ONLY_TAGS.has(pipeline);
+  }
+  return (model.tags ?? []).some((tag) => {
+    const normalized = normalize(tag);
+    return normalized != null && SPEECH_ONLY_TAGS.has(normalized);
+  });
+}
+
+export function isClassifierOrRerankerHubModel(
+  model: HubModelTaskMetadata,
+): boolean {
+  const pipeline = normalize(model.pipelineTag);
+  if (pipeline && CLASSIFIER_TASKS.has(pipeline)) {
+    return true;
+  }
+  if (RERANKER_ID_PATTERN.test(model.id ?? "")) {
+    return true;
+  }
+  if (pipeline) {
+    return false;
+  }
+  return (model.tags ?? []).some((tag) => {
+    const normalized = normalize(tag);
+    return (
+      normalized != null &&
+      (CLASSIFIER_TASKS.has(normalized) || RERANKER_TAGS.has(normalized))
+    );
   });
 }

--- a/studio/frontend/src/features/settings/lib/agent-hub-model.ts
+++ b/studio/frontend/src/features/settings/lib/agent-hub-model.ts
@@ -7,6 +7,17 @@ type HubModelTaskMetadata = {
   tags?: readonly string[] | null;
 };
 
+// Coding agents require a chat-completions model. When the Hub declares a
+// primary pipeline, admit only pipelines that can consume conversational text;
+// a missing pipeline remains eligible because many valid GGUF repos omit it.
+const CHAT_GENERATION_TASKS: ReadonlySet<string> = new Set([
+  "text-generation",
+  "conversational",
+  "image-text-to-text",
+  "audio-text-to-text",
+  "any-to-any",
+]);
+
 // These generation tasks belong to the Audio page and cannot serve coding-agent
 // chat completions. Keep this narrower than generic audio tags so audio-capable
 // chat and vision-language models remain available.
@@ -34,6 +45,11 @@ const RERANKER_ID_PATTERN =
 function normalize(value: string | null | undefined): string | null {
   const normalized = value?.toLowerCase().trim();
   return normalized || null;
+}
+
+export function isChatGenerativeHubModel(model: HubModelTaskMetadata): boolean {
+  const pipeline = normalize(model.pipelineTag);
+  return pipeline == null || CHAT_GENERATION_TASKS.has(pipeline);
 }
 
 export function isSpeechOnlyHubModel(model: HubModelTaskMetadata): boolean {

--- a/studio/frontend/src/features/settings/lib/agent-hub-model.ts
+++ b/studio/frontend/src/features/settings/lib/agent-hub-model.ts
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+type HubModelTaskMetadata = {
+  pipelineTag?: string | null;
+  tags?: readonly string[] | null;
+};
+
+// These generation tasks belong to the Audio page and cannot serve coding-agent
+// chat completions. Keep this narrower than generic audio tags so audio-capable
+// chat and vision-language models remain available.
+const SPEECH_ONLY_TAGS: ReadonlySet<string> = new Set([
+  "text-to-speech",
+  "automatic-speech-recognition",
+]);
+
+export function isSpeechOnlyHubModel(model: HubModelTaskMetadata): boolean {
+  return [model.pipelineTag, ...(model.tags ?? [])].some((tag) => {
+    if (tag == null) {
+      return false;
+    }
+    return SPEECH_ONLY_TAGS.has(tag.toLowerCase().trim());
+  });
+}

--- a/studio/frontend/src/features/settings/lib/agent-hub-model.ts
+++ b/studio/frontend/src/features/settings/lib/agent-hub-model.ts
@@ -51,7 +51,10 @@ export function isClassifierOrRerankerHubModel(
   model: HubModelTaskMetadata,
 ): boolean {
   const pipeline = normalize(model.pipelineTag);
-  if (pipeline && CLASSIFIER_TASKS.has(pipeline)) {
+  if (
+    pipeline &&
+    (CLASSIFIER_TASKS.has(pipeline) || RERANKER_TAGS.has(pipeline))
+  ) {
     return true;
   }
   if (RERANKER_ID_PATTERN.test(model.id ?? "")) {

--- a/studio/frontend/src/features/settings/tabs/agents-tab.tsx
+++ b/studio/frontend/src/features/settings/tabs/agents-tab.tsx
@@ -62,6 +62,7 @@ import {
 import { SettingsSection } from "../components/settings-section";
 import { psSingle, shSingle } from "../components/usage-examples";
 import {
+  isChatGenerativeHubModel,
   isClassifierOrRerankerHubModel,
   isSpeechOnlyHubModel,
 } from "../lib/agent-hub-model.ts";
@@ -776,6 +777,7 @@ export function AgentsTab() {
         .filter(
           (model) =>
             model.isGguf &&
+            isChatGenerativeHubModel(model) &&
             !isEmbeddingHubModel(model) &&
             !isSpeechOnlyHubModel(model) &&
             !isClassifierOrRerankerHubModel(model),

--- a/studio/frontend/src/features/settings/tabs/agents-tab.tsx
+++ b/studio/frontend/src/features/settings/tabs/agents-tab.tsx
@@ -70,7 +70,6 @@ const EXAMPLE_MODEL_OPTIONS = [
   "--top-p 0.95",
   "--top-k 20",
   "--min-p 0.0",
-  "--presence-penalty 0.0",
   "--reasoning-effort medium",
 ].join(" ");
 const MODEL_RESULT_LIMIT = 7;
@@ -662,7 +661,7 @@ export function AgentsTab() {
     sortBy: "trendingScore",
     sortDirection: "desc",
     accessToken: hfAccessToken,
-    keepUnsupportedTags: true,
+    keepUnsupportedTags: false,
     enabled: online,
   });
   // The remote snippet runs on the client, so use the client platform, not deviceType.
@@ -1133,6 +1132,7 @@ export function AgentsTab() {
     // absence there is not evidence.
     if (
       looksLikePath(restored) ||
+      isHuggingFaceRepo(restored) ||
       discoveredKeys.has(modelKey(restored)) ||
       (active && modelKey(active.model) === modelKey(restored))
     ) {

--- a/studio/frontend/src/features/settings/tabs/agents-tab.tsx
+++ b/studio/frontend/src/features/settings/tabs/agents-tab.tsx
@@ -61,6 +61,7 @@ import {
 } from "../components/agent-command";
 import { SettingsSection } from "../components/settings-section";
 import { psSingle, shSingle } from "../components/usage-examples";
+import { isSpeechOnlyHubModel } from "../lib/agent-hub-model.ts";
 import { useSettingsPanelPrefsStore } from "../stores/settings-panel-prefs-store";
 
 const DOCS_URL = "https://unsloth.ai/docs/integrations/unsloth-start";
@@ -775,7 +776,12 @@ export function AgentsTab() {
   const trendingModels = useMemo(
     () =>
       trendingGgufs
-        .filter((model) => model.isGguf && !isEmbeddingHubModel(model))
+        .filter(
+          (model) =>
+            model.isGguf &&
+            !isEmbeddingHubModel(model) &&
+            !isSpeechOnlyHubModel(model),
+        )
         .map((model) => model.id),
     [trendingGgufs],
   );

--- a/studio/frontend/src/features/settings/tabs/agents-tab.tsx
+++ b/studio/frontend/src/features/settings/tabs/agents-tab.tsx
@@ -71,6 +71,7 @@ const DOCS_URL = "https://unsloth.ai/docs/integrations/unsloth-start";
 const FLAGS_DOCS_URL = `${DOCS_URL}#flags--options`;
 const EXAMPLE_MODEL_REPO = "unsloth/Qwen3.8-27B-GGUF";
 const EXAMPLE_MODEL_VARIANT = "UD-Q4_K_XL";
+const EXAMPLE_MODEL_FLAGS = "--reasoning-effort medium";
 const MODEL_RESULT_LIMIT = 7;
 const STATUS_POLL_MS = 5000;
 const HUGGING_FACE_REPO_PATTERN = /^[^/\\:\s]+\/[^/\\:\s]+$/;
@@ -847,7 +848,13 @@ export function AgentsTab() {
     selectedVariant && !suffixVariant
       ? `--model ${commandModelArg} --gguf-variant ${quoteShellArg(selectedVariant, isWindowsShell)}`
       : `--model ${commandModelArg}`;
-  const modelArgs = attachOnly ? "" : selectedModelArgs;
+  const selectedModelFlags =
+    modelKey(selectedModel) === modelKey(EXAMPLE_MODEL_REPO)
+      ? EXAMPLE_MODEL_FLAGS
+      : "";
+  const modelArgs = attachOnly
+    ? ""
+    : [selectedModelArgs, selectedModelFlags].filter(Boolean).join(" ");
   // No key is passed: the CLI caches an explicit one per base, overwriting a working
   // saved key. Omitting it replays the saved key; the remote section covers first setup.
   const commandOs = isWindowsShell ? "windows" : "unix";

--- a/studio/frontend/src/features/settings/tabs/agents-tab.tsx
+++ b/studio/frontend/src/features/settings/tabs/agents-tab.tsx
@@ -33,7 +33,13 @@ import {
   listLocalModels,
   listModels,
 } from "@/features/chat";
-import { useHfTokenStore } from "@/features/hub";
+import {
+  ggufVariantDisplayLabel,
+  hfApiToken,
+  useHfTokenStore,
+  useHubModelSearch,
+  useOnlineStatus,
+} from "@/features/hub";
 import type { TranslationKey } from "@/i18n";
 import { useT } from "@/i18n";
 import { getApiBase, isTauri } from "@/lib/api-base";
@@ -54,11 +60,19 @@ import {
 import { SettingsSection } from "../components/settings-section";
 import { psSingle, shSingle } from "../components/usage-examples";
 import { useSettingsPanelPrefsStore } from "../stores/settings-panel-prefs-store";
-import { ggufVariantDisplayLabel } from "@/features/hub";
 
 const DOCS_URL = "https://unsloth.ai/docs/integrations/unsloth-start";
-const EXAMPLE_MODEL_REPO = "unsloth/gemma-4-E4B-it-GGUF";
+const EXAMPLE_MODEL_REPO = "unsloth/Qwen3.8-27B-GGUF";
 const EXAMPLE_MODEL_VARIANT = "UD-Q4_K_XL";
+const EXAMPLE_MODEL_OPTIONS = [
+  "--context-length 32768",
+  "--temperature 1.0",
+  "--top-p 0.95",
+  "--top-k 20",
+  "--min-p 0.0",
+  "--presence-penalty 0.0",
+  "--reasoning-effort medium",
+].join(" ");
 const MODEL_RESULT_LIMIT = 7;
 const STATUS_POLL_MS = 5000;
 const HUGGING_FACE_REPO_PATTERN = /^[^/\\:\s]+\/[^/\\:\s]+$/;
@@ -219,6 +233,20 @@ function looksLikePath(value: string): boolean {
 // hugging face ids fold case; a path does not, since Linux paths are sensitive.
 function modelKey(model: string): string {
   return looksLikePath(model) ? model : model.toLowerCase();
+}
+
+function mergeModelOrder(primary: string[], fallback: string[]): string[] {
+  const ordered: string[] = [];
+  const seen = new Set<string>();
+  for (const model of [...primary, ...fallback]) {
+    const key = modelKey(model);
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    ordered.push(model);
+  }
+  return ordered;
 }
 
 function isHuggingFaceRepo(model: string): boolean {
@@ -626,7 +654,17 @@ export function AgentsTab() {
   const t = useT();
   const serverUrl = usePlatformStore((s) => s.serverUrl);
   const hfToken = useHfTokenStore((s) => s.token);
+  const hfAccessToken = hfApiToken(hfToken);
+  const online = useOnlineStatus();
   const deviceType = usePlatformStore((s) => s.deviceType);
+  const { results: trendingGgufs } = useHubModelSearch("", {
+    channel: { owner: "unsloth", tags: ["gguf"] },
+    sortBy: "trendingScore",
+    sortDirection: "desc",
+    accessToken: hfAccessToken,
+    keepUnsupportedTags: true,
+    enabled: online,
+  });
   // The remote snippet runs on the client, so use the client platform, not deviceType.
   // Anchor the match: a bare includes("win") would also match "darwin".
   const [isWindowsClient] = useState(() => {
@@ -725,6 +763,17 @@ export function AgentsTab() {
   const [variantsFailed, setVariantsFailed] = useState(false);
 
   const labelFor = (model: string) => modelLabels[model] ?? model;
+  const trendingModels = useMemo(
+    () =>
+      trendingGgufs
+        .filter((model) => model.isGguf)
+        .map((model) => model.id),
+    [trendingGgufs],
+  );
+  const orderedModels = useMemo(
+    () => mergeModelOrder(trendingModels, models),
+    [models, trendingModels],
+  );
   const matchingModels = useMemo(() => {
     const tokens = modelSearch
       .trim()
@@ -733,8 +782,8 @@ export function AgentsTab() {
       .filter(Boolean);
     const matches =
       tokens.length === 0
-        ? models
-        : models.filter((model) => {
+        ? orderedModels
+        : orderedModels.filter((model) => {
             // Search both, so a scanned model is findable by name and by path.
             const haystack =
               `${model} ${modelLabels[model] ?? ""}`.toLowerCase();
@@ -748,7 +797,7 @@ export function AgentsTab() {
       ];
     }
     return matches;
-  }, [modelLabels, modelSearch, models, selectedModel]);
+  }, [modelLabels, modelSearch, orderedModels, selectedModel]);
 
   const visibleModels = matchingModels.slice(0, MODEL_RESULT_LIMIT);
   const preferredVariant = knownVariants[selectedModel] ?? null;
@@ -774,11 +823,17 @@ export function AgentsTab() {
   // A bare `unsloth start` attaches to whatever is loaded, which is the only way
   // to reach a native-grant GGUF: naming it would switch the server to another model.
   const attachOnly = selectedModel === attachOnlyModel;
-  const modelArgs = attachOnly
-    ? ""
-    : selectedVariant && !suffixVariant
+  const selectedModelArgs =
+    selectedVariant && !suffixVariant
       ? `--model ${commandModelArg} --gguf-variant ${quoteShellArg(selectedVariant, isWindowsShell)}`
       : `--model ${commandModelArg}`;
+  const selectedModelOptions =
+    modelKey(selectedModel) === modelKey(EXAMPLE_MODEL_REPO)
+      ? EXAMPLE_MODEL_OPTIONS
+      : "";
+  const modelArgs = attachOnly
+    ? ""
+    : [selectedModelArgs, selectedModelOptions].filter(Boolean).join(" ");
   // No key is passed: the CLI caches an explicit one per base, overwriting a working
   // saved key. Omitting it replays the saved key; the remote section covers first setup.
   const commandOs = isWindowsShell ? "windows" : "unix";

--- a/studio/frontend/src/features/settings/tabs/agents-tab.tsx
+++ b/studio/frontend/src/features/settings/tabs/agents-tab.tsx
@@ -34,6 +34,8 @@ import {
   listModels,
 } from "@/features/chat";
 import {
+  EMBEDDING_TAGS,
+  type HfModelResult,
   ggufVariantDisplayLabel,
   hfApiToken,
   useHfTokenStore,
@@ -250,6 +252,14 @@ function mergeModelOrder(primary: string[], fallback: string[]): string[] {
 
 function isHuggingFaceRepo(model: string): boolean {
   return HUGGING_FACE_REPO_PATTERN.test(model);
+}
+
+function isEmbeddingHubModel(
+  model: Pick<HfModelResult, "pipelineTag" | "tags">,
+): boolean {
+  return [model.pipelineTag, ...(model.tags ?? [])].some(
+    (tag) => tag != null && EMBEDDING_TAGS.has(tag.toLowerCase()),
+  );
 }
 
 function formatBytes(bytes: number): string {
@@ -765,7 +775,7 @@ export function AgentsTab() {
   const trendingModels = useMemo(
     () =>
       trendingGgufs
-        .filter((model) => model.isGguf)
+        .filter((model) => model.isGguf && !isEmbeddingHubModel(model))
         .map((model) => model.id),
     [trendingGgufs],
   );
@@ -789,11 +799,17 @@ export function AgentsTab() {
             return tokens.every((token) => haystack.includes(token));
           });
 
-    if (tokens.length === 0 && matches.includes(selectedModel)) {
-      return [
-        selectedModel,
-        ...matches.filter((model) => model !== selectedModel),
-      ];
+    if (tokens.length === 0) {
+      const selectedKey = modelKey(selectedModel);
+      const selectedIndex = matches.findIndex(
+        (model) => modelKey(model) === selectedKey,
+      );
+      if (selectedIndex > 0) {
+        return [
+          matches[selectedIndex],
+          ...matches.filter((_, index) => index !== selectedIndex),
+        ];
+      }
     }
     return matches;
   }, [modelLabels, modelSearch, orderedModels, selectedModel]);
@@ -1459,7 +1475,9 @@ export function AgentsTab() {
                         <CommandItem
                           key={model}
                           value={model}
-                          data-checked={model === selectedModel}
+                          data-checked={
+                            modelKey(model) === modelKey(selectedModel)
+                          }
                           onSelect={() => {
                             modelSelectionChanged.current = true;
                             restoredModel.current = null;

--- a/studio/frontend/src/features/settings/tabs/agents-tab.tsx
+++ b/studio/frontend/src/features/settings/tabs/agents-tab.tsx
@@ -61,7 +61,10 @@ import {
 } from "../components/agent-command";
 import { SettingsSection } from "../components/settings-section";
 import { psSingle, shSingle } from "../components/usage-examples";
-import { isSpeechOnlyHubModel } from "../lib/agent-hub-model.ts";
+import {
+  isClassifierOrRerankerHubModel,
+  isSpeechOnlyHubModel,
+} from "../lib/agent-hub-model.ts";
 import { useSettingsPanelPrefsStore } from "../stores/settings-panel-prefs-store";
 
 const DOCS_URL = "https://unsloth.ai/docs/integrations/unsloth-start";
@@ -780,7 +783,8 @@ export function AgentsTab() {
           (model) =>
             model.isGguf &&
             !isEmbeddingHubModel(model) &&
-            !isSpeechOnlyHubModel(model),
+            !isSpeechOnlyHubModel(model) &&
+            !isClassifierOrRerankerHubModel(model),
         )
         .map((model) => model.id),
     [trendingGgufs],
@@ -828,12 +832,14 @@ export function AgentsTab() {
   // /v1/models advertises for it. The resident model is exempt: it already
   // loaded by id, and cached-gguf keeps the largest copy across caches, whose
   // snapshot could switch cache or quant under it.
-  const cachedLoadId =
-    selectedModel === activeStatusModel
-      ? null
-      : (cachedLoadIds[selectedModel] ??
-        cachedLoadIds[selectedModel.toLowerCase()] ??
-        null);
+  const selectedModelIsActive =
+    activeStatusModel != null &&
+    modelKey(selectedModel) === modelKey(activeStatusModel);
+  const cachedLoadId = selectedModelIsActive
+    ? null
+    : (cachedLoadIds[selectedModel] ??
+      cachedLoadIds[selectedModel.toLowerCase()] ??
+      null);
   const modelId = cachedLoadId ?? selectedModel;
   const suffixVariant = isHuggingFaceRepo(modelId);
   const commandModel =
@@ -849,7 +855,8 @@ export function AgentsTab() {
       ? `--model ${commandModelArg} --gguf-variant ${quoteShellArg(selectedVariant, isWindowsShell)}`
       : `--model ${commandModelArg}`;
   const selectedModelOptions =
-    modelKey(selectedModel) === modelKey(EXAMPLE_MODEL_REPO)
+    modelKey(selectedModel) === modelKey(EXAMPLE_MODEL_REPO) &&
+    !selectedModelIsActive
       ? EXAMPLE_MODEL_OPTIONS
       : "";
   const modelArgs = attachOnly

--- a/studio/frontend/src/features/settings/tabs/agents-tab.tsx
+++ b/studio/frontend/src/features/settings/tabs/agents-tab.tsx
@@ -68,16 +68,9 @@ import {
 import { useSettingsPanelPrefsStore } from "../stores/settings-panel-prefs-store";
 
 const DOCS_URL = "https://unsloth.ai/docs/integrations/unsloth-start";
+const FLAGS_DOCS_URL = `${DOCS_URL}#flags--options`;
 const EXAMPLE_MODEL_REPO = "unsloth/Qwen3.8-27B-GGUF";
 const EXAMPLE_MODEL_VARIANT = "UD-Q4_K_XL";
-const EXAMPLE_MODEL_OPTIONS = [
-  "--context-length 32768",
-  "--temperature 1.0",
-  "--top-p 0.95",
-  "--top-k 20",
-  "--min-p 0.0",
-  "--reasoning-effort medium",
-].join(" ");
 const MODEL_RESULT_LIMIT = 7;
 const STATUS_POLL_MS = 5000;
 const HUGGING_FACE_REPO_PATTERN = /^[^/\\:\s]+\/[^/\\:\s]+$/;
@@ -854,14 +847,7 @@ export function AgentsTab() {
     selectedVariant && !suffixVariant
       ? `--model ${commandModelArg} --gguf-variant ${quoteShellArg(selectedVariant, isWindowsShell)}`
       : `--model ${commandModelArg}`;
-  const selectedModelOptions =
-    modelKey(selectedModel) === modelKey(EXAMPLE_MODEL_REPO) &&
-    !selectedModelIsActive
-      ? EXAMPLE_MODEL_OPTIONS
-      : "";
-  const modelArgs = attachOnly
-    ? ""
-    : [selectedModelArgs, selectedModelOptions].filter(Boolean).join(" ");
+  const modelArgs = attachOnly ? "" : selectedModelArgs;
   // No key is passed: the CLI caches an explicit one per base, overwriting a working
   // saved key. Omitting it replays the saved key; the remote section covers first setup.
   const commandOs = isWindowsShell ? "windows" : "unix";
@@ -1619,12 +1605,27 @@ export function AgentsTab() {
           <span className="text-xs font-medium text-foreground">
             {t("settings.agents.generatedCommand")}
           </span>
+          <p className="text-ui-11 leading-relaxed text-muted-foreground">
+            {t("settings.agents.automaticSettingsNote")}
+          </p>
           <CopyableCode
             value={command}
             copyLabel={t("settings.agents.copyGeneratedCommand")}
             copied={copied}
             onCopy={handleCopy}
           />
+          <p className="text-ui-11 leading-relaxed text-muted-foreground">
+            {t("settings.agents.configurationNote")}{" "}
+            <a
+              href={FLAGS_DOCS_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="rounded text-foreground underline decoration-border decoration-dotted underline-offset-2 transition-colors hover:decoration-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+            >
+              {t("settings.agents.configurationDocs")}
+            </a>{" "}
+            {t("settings.agents.configurationFlagsSuffix")}
+          </p>
         </div>
 
         <SubagentSection

--- a/studio/frontend/src/i18n/locales/en.ts
+++ b/studio/frontend/src/i18n/locales/en.ts
@@ -1211,6 +1211,12 @@ export const en = {
       docs: "Docs",
       agentDocs: "Open {agent} setup docs",
       copyGeneratedCommand: "Copy generated command",
+      automaticSettingsNote:
+        "Unsloth automatically applies the model’s recommended settings if you have not set any flags.",
+      configurationNote:
+        "You can also adjust any configuration. See further below or",
+      configurationDocs: "docs",
+      configurationFlagsSuffix: "for flags.",
       modelNote:
         "Codex requires a GGUF model served by llama-server. Other agents can also use transformer-backed models; remove --model to use the model already loaded in Unsloth.",
       subagent: {

--- a/studio/frontend/tests/agents-model-picker.test.ts
+++ b/studio/frontend/tests/agents-model-picker.test.ts
@@ -26,7 +26,6 @@ test("the default model uses its recommended thinking settings", () => {
     "--top-p 0.95",
     "--top-k 20",
     "--min-p 0.0",
-    "--presence-penalty 0.0",
     "--reasoning-effort medium",
   ]) {
     assert.ok(options.includes(option), `${option} is in the default command`);
@@ -36,6 +35,7 @@ test("the default model uses its recommended thinking settings", () => {
       "modelKey(selectedModel) === modelKey(EXAMPLE_MODEL_REPO)",
     ),
   );
+  assert.ok(!options.includes("--presence-penalty"));
 });
 
 test("the model dropdown loads live trending GGUFs", () => {
@@ -45,6 +45,11 @@ test("the model dropdown loads live trending GGUFs", () => {
   assert.ok(request.includes('tags: ["gguf"]'));
   assert.ok(request.includes('sortBy: "trendingScore"'));
   assert.ok(request.includes('sortDirection: "desc"'));
+  assert.ok(request.includes("keepUnsupportedTags: false"));
   assert.ok(TAB.includes("mergeModelOrder(trendingModels, models)"));
   assert.ok(TAB.includes("[...primary, ...fallback]"));
+});
+
+test("restored Hub selections remain valid while uncached", () => {
+  assert.ok(TAB.includes("isHuggingFaceRepo(restored)"));
 });

--- a/studio/frontend/tests/agents-model-picker.test.ts
+++ b/studio/frontend/tests/agents-model-picker.test.ts
@@ -6,6 +6,7 @@ import { readFileSync } from "node:fs";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
 import {
+  isChatGenerativeHubModel,
   isClassifierOrRerankerHubModel,
   isSpeechOnlyHubModel,
 } from "../src/features/settings/lib/agent-hub-model.ts";
@@ -36,9 +37,7 @@ test("the default model demonstrates reasoning effort without sampling flags", (
     assert.ok(!flags.includes(samplingFlag));
   }
   assert.ok(
-    TAB.includes(
-      "modelKey(selectedModel) === modelKey(EXAMPLE_MODEL_REPO)",
-    ),
+    TAB.includes("modelKey(selectedModel) === modelKey(EXAMPLE_MODEL_REPO)"),
   );
   assert.equal(
     en.settings.agents.automaticSettingsNote,
@@ -62,12 +61,42 @@ test("the model dropdown loads live trending GGUFs", () => {
   assert.ok(request.includes('sortBy: "trendingScore"'));
   assert.ok(request.includes('sortDirection: "desc"'));
   assert.ok(request.includes("keepUnsupportedTags: false"));
+  assert.ok(TAB.includes("isChatGenerativeHubModel(model)"));
   assert.ok(TAB.includes("!isEmbeddingHubModel(model)"));
   assert.ok(TAB.includes("EMBEDDING_TAGS.has(tag.toLowerCase())"));
   assert.ok(TAB.includes("!isSpeechOnlyHubModel(model)"));
   assert.ok(TAB.includes("!isClassifierOrRerankerHubModel(model)"));
   assert.ok(TAB.includes("mergeModelOrder(trendingModels, models)"));
   assert.ok(TAB.includes("[...primary, ...fallback]"));
+});
+
+test("the agent feed admits only declared chat-generation pipelines", () => {
+  for (const pipelineTag of [
+    "text-generation",
+    "conversational",
+    "image-text-to-text",
+    "audio-text-to-text",
+    "any-to-any",
+  ]) {
+    assert.equal(isChatGenerativeHubModel({ pipelineTag }), true);
+  }
+  for (const pipelineTag of [
+    "fill-mask",
+    "audio-classification",
+    "voice-activity-detection",
+    "feature-extraction",
+    "question-answering",
+    "image-classification",
+    "text-to-speech",
+    "text-classification",
+  ]) {
+    assert.equal(isChatGenerativeHubModel({ pipelineTag }), false);
+  }
+  assert.equal(
+    isChatGenerativeHubModel({ pipelineTag: "  TEXT-GENERATION " }),
+    true,
+  );
+  assert.equal(isChatGenerativeHubModel({}), true);
 });
 
 test("the agent feed excludes speech-only model tasks", () => {

--- a/studio/frontend/tests/agents-model-picker.test.ts
+++ b/studio/frontend/tests/agents-model-picker.test.ts
@@ -5,6 +5,7 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
+import { isSpeechOnlyHubModel } from "../src/features/settings/lib/agent-hub-model.ts";
 
 const TAB = readFileSync(
   fileURLToPath(
@@ -46,8 +47,35 @@ test("the model dropdown loads live trending GGUFs", () => {
   assert.ok(request.includes("keepUnsupportedTags: false"));
   assert.ok(TAB.includes("!isEmbeddingHubModel(model)"));
   assert.ok(TAB.includes("EMBEDDING_TAGS.has(tag.toLowerCase())"));
+  assert.ok(TAB.includes("!isSpeechOnlyHubModel(model)"));
   assert.ok(TAB.includes("mergeModelOrder(trendingModels, models)"));
   assert.ok(TAB.includes("[...primary, ...fallback]"));
+});
+
+test("the agent feed excludes speech-only model tasks", () => {
+  for (const pipelineTag of [
+    "text-to-speech",
+    "automatic-speech-recognition",
+  ]) {
+    assert.equal(isSpeechOnlyHubModel({ pipelineTag }), true);
+  }
+  assert.equal(
+    isSpeechOnlyHubModel({
+      pipelineTag: "text-generation",
+      tags: ["GGUF", " TEXT-TO-SPEECH "],
+    }),
+    true,
+  );
+  for (const pipelineTag of [
+    "text-generation",
+    "image-text-to-text",
+    "audio-text-to-text",
+  ]) {
+    assert.equal(
+      isSpeechOnlyHubModel({ pipelineTag, tags: ["gguf", "audio"] }),
+      false,
+    );
+  }
 });
 
 test("restored Hub selections remain valid while uncached", () => {

--- a/studio/frontend/tests/agents-model-picker.test.ts
+++ b/studio/frontend/tests/agents-model-picker.test.ts
@@ -94,6 +94,7 @@ test("the agent feed excludes classifier and reranker models", () => {
     "text-classification",
     "token-classification",
     "zero-shot-classification",
+    "text-ranking",
   ]) {
     assert.equal(isClassifierOrRerankerHubModel({ pipelineTag }), true);
   }

--- a/studio/frontend/tests/agents-model-picker.test.ts
+++ b/studio/frontend/tests/agents-model-picker.test.ts
@@ -31,9 +31,7 @@ test("the default model uses its recommended thinking settings", () => {
     assert.ok(options.includes(option), `${option} is in the default command`);
   }
   assert.ok(
-    TAB.includes(
-      "modelKey(selectedModel) === modelKey(EXAMPLE_MODEL_REPO)",
-    ),
+    TAB.includes("modelKey(selectedModel) === modelKey(EXAMPLE_MODEL_REPO)"),
   );
   assert.ok(!options.includes("--presence-penalty"));
 });
@@ -46,10 +44,17 @@ test("the model dropdown loads live trending GGUFs", () => {
   assert.ok(request.includes('sortBy: "trendingScore"'));
   assert.ok(request.includes('sortDirection: "desc"'));
   assert.ok(request.includes("keepUnsupportedTags: false"));
+  assert.ok(TAB.includes("!isEmbeddingHubModel(model)"));
+  assert.ok(TAB.includes("EMBEDDING_TAGS.has(tag.toLowerCase())"));
   assert.ok(TAB.includes("mergeModelOrder(trendingModels, models)"));
   assert.ok(TAB.includes("[...primary, ...fallback]"));
 });
 
 test("restored Hub selections remain valid while uncached", () => {
   assert.ok(TAB.includes("isHuggingFaceRepo(restored)"));
+});
+
+test("model selection matching ignores Hub repository casing", () => {
+  assert.ok(TAB.includes("modelKey(model) === selectedKey"));
+  assert.ok(TAB.includes("modelKey(model) === modelKey(selectedModel)"));
 });

--- a/studio/frontend/tests/agents-model-picker.test.ts
+++ b/studio/frontend/tests/agents-model-picker.test.ts
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const TAB = readFileSync(
+  fileURLToPath(
+    new URL("../src/features/settings/tabs/agents-tab.tsx", import.meta.url),
+  ),
+  "utf-8",
+);
+
+test("the default model uses its recommended thinking settings", () => {
+  assert.ok(
+    TAB.includes('const EXAMPLE_MODEL_REPO = "unsloth/Qwen3.8-27B-GGUF";'),
+  );
+  assert.ok(TAB.includes('const EXAMPLE_MODEL_VARIANT = "UD-Q4_K_XL";'));
+  const start = TAB.indexOf("const EXAMPLE_MODEL_OPTIONS");
+  const options = TAB.slice(start, TAB.indexOf("].join", start));
+  for (const option of [
+    "--context-length 32768",
+    "--temperature 1.0",
+    "--top-p 0.95",
+    "--top-k 20",
+    "--min-p 0.0",
+    "--presence-penalty 0.0",
+    "--reasoning-effort medium",
+  ]) {
+    assert.ok(options.includes(option), `${option} is in the default command`);
+  }
+  assert.ok(
+    TAB.includes(
+      "modelKey(selectedModel) === modelKey(EXAMPLE_MODEL_REPO)",
+    ),
+  );
+});
+
+test("the model dropdown loads live trending GGUFs", () => {
+  const start = TAB.indexOf('useHubModelSearch("", {');
+  const request = TAB.slice(start, TAB.indexOf("});", start));
+  assert.ok(request.includes('owner: "unsloth"'));
+  assert.ok(request.includes('tags: ["gguf"]'));
+  assert.ok(request.includes('sortBy: "trendingScore"'));
+  assert.ok(request.includes('sortDirection: "desc"'));
+  assert.ok(TAB.includes("mergeModelOrder(trendingModels, models)"));
+  assert.ok(TAB.includes("[...primary, ...fallback]"));
+});

--- a/studio/frontend/tests/agents-model-picker.test.ts
+++ b/studio/frontend/tests/agents-model-picker.test.ts
@@ -18,14 +18,27 @@ const TAB = readFileSync(
   "utf-8",
 );
 
-test("the default model relies on automatic recommended settings", () => {
+test("the default model demonstrates reasoning effort without sampling flags", () => {
   assert.ok(
     TAB.includes('const EXAMPLE_MODEL_REPO = "unsloth/Qwen3.8-27B-GGUF";'),
   );
   assert.ok(TAB.includes('const EXAMPLE_MODEL_VARIANT = "UD-Q4_K_XL";'));
-  assert.ok(!TAB.includes("EXAMPLE_MODEL_OPTIONS"));
+  const start = TAB.indexOf("const EXAMPLE_MODEL_FLAGS");
+  const flags = TAB.slice(start, TAB.indexOf(";", start));
+  assert.ok(flags.includes("--reasoning-effort medium"));
+  for (const samplingFlag of [
+    "--temperature",
+    "--top-p",
+    "--top-k",
+    "--min-p",
+    "--presence-penalty",
+  ]) {
+    assert.ok(!flags.includes(samplingFlag));
+  }
   assert.ok(
-    TAB.includes('const modelArgs = attachOnly ? "" : selectedModelArgs;'),
+    TAB.includes(
+      "modelKey(selectedModel) === modelKey(EXAMPLE_MODEL_REPO)",
+    ),
   );
   assert.equal(
     en.settings.agents.automaticSettingsNote,

--- a/studio/frontend/tests/agents-model-picker.test.ts
+++ b/studio/frontend/tests/agents-model-picker.test.ts
@@ -5,7 +5,10 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
-import { isSpeechOnlyHubModel } from "../src/features/settings/lib/agent-hub-model.ts";
+import {
+  isClassifierOrRerankerHubModel,
+  isSpeechOnlyHubModel,
+} from "../src/features/settings/lib/agent-hub-model.ts";
 
 const TAB = readFileSync(
   fileURLToPath(
@@ -48,6 +51,7 @@ test("the model dropdown loads live trending GGUFs", () => {
   assert.ok(TAB.includes("!isEmbeddingHubModel(model)"));
   assert.ok(TAB.includes("EMBEDDING_TAGS.has(tag.toLowerCase())"));
   assert.ok(TAB.includes("!isSpeechOnlyHubModel(model)"));
+  assert.ok(TAB.includes("!isClassifierOrRerankerHubModel(model)"));
   assert.ok(TAB.includes("mergeModelOrder(trendingModels, models)"));
   assert.ok(TAB.includes("[...primary, ...fallback]"));
 });
@@ -61,21 +65,60 @@ test("the agent feed excludes speech-only model tasks", () => {
   }
   assert.equal(
     isSpeechOnlyHubModel({
-      pipelineTag: "text-generation",
       tags: ["GGUF", " TEXT-TO-SPEECH "],
     }),
     true,
   );
+  assert.equal(
+    isSpeechOnlyHubModel({
+      pipelineTag: "text-generation",
+      tags: ["gguf", "text-to-speech"],
+    }),
+    false,
+  );
+  assert.equal(
+    isSpeechOnlyHubModel({
+      pipelineTag: "audio-text-to-text",
+      tags: ["gguf", "automatic-speech-recognition"],
+    }),
+    false,
+  );
+  assert.equal(
+    isSpeechOnlyHubModel({ pipelineTag: "image-text-to-text" }),
+    false,
+  );
+});
+
+test("the agent feed excludes classifier and reranker models", () => {
   for (const pipelineTag of [
-    "text-generation",
-    "image-text-to-text",
-    "audio-text-to-text",
+    "text-classification",
+    "token-classification",
+    "zero-shot-classification",
   ]) {
-    assert.equal(
-      isSpeechOnlyHubModel({ pipelineTag, tags: ["gguf", "audio"] }),
-      false,
-    );
+    assert.equal(isClassifierOrRerankerHubModel({ pipelineTag }), true);
   }
+  assert.equal(
+    isClassifierOrRerankerHubModel({ id: "unsloth/Qwen3-Reranker-GGUF" }),
+    true,
+  );
+  assert.equal(
+    isClassifierOrRerankerHubModel({ tags: ["gguf", "cross-encoder"] }),
+    true,
+  );
+  assert.equal(
+    isClassifierOrRerankerHubModel({
+      pipelineTag: "text-generation",
+      tags: ["text-classification"],
+    }),
+    false,
+  );
+  assert.equal(
+    isClassifierOrRerankerHubModel({
+      id: "unsloth/Qwen3.8-27B-GGUF",
+      pipelineTag: "text-generation",
+    }),
+    false,
+  );
 });
 
 test("restored Hub selections remain valid while uncached", () => {
@@ -85,4 +128,9 @@ test("restored Hub selections remain valid while uncached", () => {
 test("model selection matching ignores Hub repository casing", () => {
   assert.ok(TAB.includes("modelKey(model) === selectedKey"));
   assert.ok(TAB.includes("modelKey(model) === modelKey(selectedModel)"));
+});
+
+test("an adopted resident model does not receive example load overrides", () => {
+  assert.ok(TAB.includes("const selectedModelIsActive"));
+  assert.ok(TAB.includes("!selectedModelIsActive"));
 });

--- a/studio/frontend/tests/agents-model-picker.test.ts
+++ b/studio/frontend/tests/agents-model-picker.test.ts
@@ -9,6 +9,7 @@ import {
   isClassifierOrRerankerHubModel,
   isSpeechOnlyHubModel,
 } from "../src/features/settings/lib/agent-hub-model.ts";
+import { en } from "../src/i18n/locales/en.ts";
 
 const TAB = readFileSync(
   fileURLToPath(
@@ -17,27 +18,27 @@ const TAB = readFileSync(
   "utf-8",
 );
 
-test("the default model uses its recommended thinking settings", () => {
+test("the default model relies on automatic recommended settings", () => {
   assert.ok(
     TAB.includes('const EXAMPLE_MODEL_REPO = "unsloth/Qwen3.8-27B-GGUF";'),
   );
   assert.ok(TAB.includes('const EXAMPLE_MODEL_VARIANT = "UD-Q4_K_XL";'));
-  const start = TAB.indexOf("const EXAMPLE_MODEL_OPTIONS");
-  const options = TAB.slice(start, TAB.indexOf("].join", start));
-  for (const option of [
-    "--context-length 32768",
-    "--temperature 1.0",
-    "--top-p 0.95",
-    "--top-k 20",
-    "--min-p 0.0",
-    "--reasoning-effort medium",
-  ]) {
-    assert.ok(options.includes(option), `${option} is in the default command`);
-  }
+  assert.ok(!TAB.includes("EXAMPLE_MODEL_OPTIONS"));
   assert.ok(
-    TAB.includes("modelKey(selectedModel) === modelKey(EXAMPLE_MODEL_REPO)"),
+    TAB.includes('const modelArgs = attachOnly ? "" : selectedModelArgs;'),
   );
-  assert.ok(!options.includes("--presence-penalty"));
+  assert.equal(
+    en.settings.agents.automaticSettingsNote,
+    "Unsloth automatically applies the model’s recommended settings if you have not set any flags.",
+  );
+  assert.equal(
+    en.settings.agents.configurationNote,
+    "You can also adjust any configuration. See further below or",
+  );
+  assert.equal(en.settings.agents.configurationDocs, "docs");
+  assert.equal(en.settings.agents.configurationFlagsSuffix, "for flags.");
+  assert.ok(TAB.includes("href={FLAGS_DOCS_URL}"));
+  assert.ok(TAB.includes("#flags--options"));
 });
 
 test("the model dropdown loads live trending GGUFs", () => {
@@ -131,7 +132,9 @@ test("model selection matching ignores Hub repository casing", () => {
   assert.ok(TAB.includes("modelKey(model) === modelKey(selectedModel)"));
 });
 
-test("an adopted resident model does not receive example load overrides", () => {
+test("an adopted resident model does not use a cached load ID", () => {
   assert.ok(TAB.includes("const selectedModelIsActive"));
-  assert.ok(TAB.includes("!selectedModelIsActive"));
+  assert.ok(
+    TAB.includes("const cachedLoadId = selectedModelIsActive\n    ? null"),
+  );
 });


### PR DESCRIPTION
## Summary

- use Qwen3.8-27B with UD-Q4_K_XL as the default agent model
- include its 32K context, thinking sampling parameters, and medium reasoning effort in generated commands
- order the model dropdown from the live Unsloth GGUF trending feed while preserving local and cached fallbacks
- add regression coverage for the default command and live ordering

## Testing

- `npm run typecheck`
- `node --experimental-strip-types --test tests/agents-model-picker.test.ts tests/agents-reasoning-tip.test.ts`
- `npx eslint tests/agents-model-picker.test.ts`
- `git diff --check`