### PR TITLE
Studio: align composer and research activity icons

### DIFF
--- a/studio/backend/tests/test_health_answers_within_probe_budget.py
+++ b/studio/backend/tests/test_health_answers_within_probe_budget.py
@@ -560,9 +560,9 @@ def test_a_cold_health_call_answers_inside_the_launcher_deadline():
     probe_timeout = _desktop_probe_timeout_s()
     result = _probe(_SLOW_DETECT_S)
 
-    assert result["cold_hardware_detecting"] is True, (
-        "the cold call got a settled reply, so it never exercised the wait this bound is about"
-    )
+    assert (
+        result["cold_hardware_detecting"] is True
+    ), "the cold call got a settled reply, so it never exercised the wait this bound is about"
     assert result["cold_elapsed"] < probe_timeout, (
         f"the first /api/health call took {result['cold_elapsed']:.2f}s, past the "
         f"{probe_timeout}s the desktop probe allows before it gives up and dead-ends "

--- a/studio/frontend/src/components/assistant-ui/chat-dictation-bar.tsx
+++ b/studio/frontend/src/components/assistant-ui/chat-dictation-bar.tsx
@@ -261,7 +261,7 @@ export const ChatDictationBar: FC<{
           {transcribing === "stop" ? (
             <Spinner className="size-3.5" />
           ) : (
-            <SquareIcon className="size-3 fill-current" />
+            <SquareIcon className="aui-composer-cancel-icon size-3 fill-current" />
           )}
         </TooltipIconButton>
         <TooltipIconButton

--- a/studio/frontend/src/features/chat/components/research-activity-panel.tsx
+++ b/studio/frontend/src/features/chat/components/research-activity-panel.tsx
@@ -23,26 +23,26 @@ import {
 } from "@/components/ui/sheet";
 import { Spinner } from "@/components/ui/spinner";
 import { Textarea } from "@/components/ui/textarea";
+import { BulbIcon } from "@/lib/bulb-icon";
 import { openLink } from "@/lib/open-link";
 import { toast } from "@/lib/toast";
 import { cn } from "@/lib/utils";
-import { Telescope02Icon } from "@hugeicons/core-free-icons";
+import {
+  DashedLineCircleIcon as CircleDashedIcon,
+  Telescope02Icon,
+} from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import {
   ArrowDown,
   ArrowUp,
-  BookOpen,
-  Brain,
   Check,
   ChevronDown,
   ExternalLink,
   FileText,
-  Globe2,
+  GlobeIcon,
   Pencil,
   Plus,
   RotateCcw,
-  Search,
-  Square,
   Trash2,
   X,
 } from "lucide-react";
@@ -318,12 +318,18 @@ function ActivityIcon({
   if (activity.state === "failed")
     return <X className={cn(className, "text-destructive")} />;
   if (activity.state === "cancelled")
-    return <Square className={cn(className, "text-muted-foreground")} />;
-  if (activity.kind === "reasoning") return <Brain className={className} />;
+    return (
+      <HugeiconsIcon
+        icon={CircleDashedIcon}
+        className={cn(className, "text-muted-foreground")}
+      />
+    );
+  if (activity.kind === "reasoning")
+    return <BulbIcon className={className} />;
   if (activity.kind === "plan") return <FileText className={className} />;
   if (activity.kind === "report") return <FileText className={className} />;
-  if (activity.action === "fetch") return <BookOpen className={className} />;
-  if (activity.action === "search") return <Search className={className} />;
+  if (activity.action === "fetch" || activity.action === "search")
+    return <GlobeIcon className={className} />;
   return <Check className={className} />;
 }
 
@@ -433,7 +439,7 @@ const ActivityRow = memo(function ActivityRow({
           onClick={() => openLink(source.url)}
           className="group/source flex w-full items-start gap-2 rounded-xl px-2 py-2 text-left transition-colors hover:bg-muted/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
         >
-          <Globe2 className="mt-0.5 size-3.5 shrink-0" />
+          <GlobeIcon className="mt-0.5 size-3.5 shrink-0" />
           <span className="min-w-0 flex-1">
             <span className="block line-clamp-2 break-words font-medium text-foreground/85">
               {source.title || source.url}
@@ -487,11 +493,11 @@ const ActivityRow = memo(function ActivityRow({
       >
         <CollapsibleTrigger
           disabled={!hasDetails}
-          className="group/activity flex min-h-10 w-full items-start gap-2 py-2 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-default"
+          className="group/activity relative flex min-h-10 w-full items-center gap-2 py-2 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-default"
         >
           <span
             className={cn(
-              "absolute left-0 top-3 flex size-[15px] items-center justify-center rounded-full bg-background text-muted-foreground",
+              "absolute -left-7 top-1/2 flex size-[15px] -translate-y-1/2 items-center justify-center rounded-full bg-background text-muted-foreground",
               activity.kind === "step" &&
                 activity.state !== "failed" &&
                 "bg-primary/10 text-primary",
@@ -503,14 +509,14 @@ const ActivityRow = memo(function ActivityRow({
           <span className="min-w-0 flex-1 break-words text-ui-13p5 font-medium leading-5 text-foreground/90">
             {activity.title}
           </span>
-          <time className="mt-0.5 shrink-0 text-ui-10p5 tabular-nums text-muted-foreground">
+          <time className="shrink-0 text-ui-10p5 tabular-nums text-muted-foreground">
             {new Date(activity.createdAt).toLocaleTimeString([], {
               hour: "numeric",
               minute: "2-digit",
             })}
           </time>
           {hasDetails ? (
-            <ChevronDown className="mt-0.5 size-3.5 shrink-0 text-muted-foreground transition-transform group-data-[state=open]/activity:rotate-180" />
+            <ChevronDown className="size-3.5 shrink-0 text-muted-foreground transition-transform group-data-[state=open]/activity:rotate-180" />
           ) : null}
         </CollapsibleTrigger>
         {hasDetails ? <CollapsibleContent>{content}</CollapsibleContent> : null}
@@ -927,7 +933,7 @@ export function ResearchActivityPanel({
                 className="mt-1 flex items-center gap-1 text-ui-10p5 font-medium text-primary/75"
                 title={websiteLimitTitle}
               >
-                <Globe2 className="size-3" />
+                <GlobeIcon className="size-3" />
                 <span className="truncate">{websiteLimitLabel}</span>
               </p>
             ) : null}

--- a/studio/frontend/src/features/chat/shared-composer.tsx
+++ b/studio/frontend/src/features/chat/shared-composer.tsx
@@ -2767,7 +2767,7 @@ export function SharedComposer({
                       : "Stop dictation"
                   }
                 >
-                  <SquareIcon className="size-3 animate-pulse fill-current" />
+                  <SquareIcon className="aui-composer-cancel-icon size-3 animate-pulse fill-current" />
                 </TooltipIconButton>
               )}
             </>
@@ -2795,7 +2795,7 @@ export function SharedComposer({
               className="ml-1.5 size-9 rounded-full"
               onClick={stop}
             >
-              <SquareIcon className="size-3 fill-current" />
+              <SquareIcon className="aui-composer-cancel-icon size-3 fill-current" />
             </Button>
           ) : (
             <TooltipIconButton

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -3154,6 +3154,13 @@ html[data-chat-font] .aui-root {
 	& svg.unsloth-send-icon {
 		width: calc(var(--ui-icon-size) * 1.15);
 		height: calc(var(--ui-icon-size) * 1.15);
+		/* The stroked arrow rasterizes half a Retina pixel to the right. */
+		transform: translateX(-0.25px);
+	}
+	/* The filled stop glyph lands one Retina pixel right of the circular
+	   action's center even though its SVG box is flex-centered. */
+	& svg.aui-composer-cancel-icon {
+		transform: translateX(-0.5px);
 	}
 	/* Composer plus keeps its pre-#7400 22px base (1.375x the token is the same
 	   curve a 22px glyph would follow), so only its scaling changed. */

--- a/studio/frontend/tests/composer-icon-alignment.test.ts
+++ b/studio/frontend/tests/composer-icon-alignment.test.ts
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const componentSources = [
+  "../src/components/assistant-ui/thread.tsx",
+  "../src/components/assistant-ui/chat-dictation-bar.tsx",
+  "../src/features/chat/shared-composer.tsx",
+].map((path) => readFileSync(new URL(path, import.meta.url), "utf8"));
+
+const css = readFileSync(new URL("../src/index.css", import.meta.url), "utf8");
+
+function tags(source: string, component: string): string[] {
+  return source.match(new RegExp(`<${component}\\b[^>]*\\/>`, "g")) ?? [];
+}
+
+test("every composer send arrow uses the optical centering class", () => {
+  const arrows = componentSources.flatMap((source) => tags(source, "ArrowUpIcon"));
+
+  assert.equal(arrows.length, 5);
+  for (const arrow of arrows) assert.match(arrow, /unsloth-send-icon/);
+  assert.match(
+    css,
+    /svg\.unsloth-send-icon[\s\S]*?transform: translateX\(-0\.25px\)/,
+  );
+});
+
+test("every isolated composer stop square uses the optical centering class", () => {
+  const stops = componentSources
+    .flatMap((source) => tags(source, "SquareIcon"))
+    .filter((tag) => /\bsize-3\b/.test(tag));
+
+  assert.equal(stops.length, 6);
+  for (const stop of stops) assert.match(stop, /aui-composer-cancel-icon/);
+  assert.match(
+    css,
+    /svg\.aui-composer-cancel-icon[\s\S]*?transform: translateX\(-0\.5px\)/,
+  );
+});

--- a/studio/frontend/tests/research-activity-visuals.test.ts
+++ b/studio/frontend/tests/research-activity-visuals.test.ts
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const source = readFileSync(
+  new URL(
+    "../src/features/chat/components/research-activity-panel.tsx",
+    import.meta.url,
+  ),
+  "utf8",
+);
+
+function between(start: string, end: string): string {
+  const startIndex = source.indexOf(start);
+  const endIndex = source.indexOf(end, startIndex);
+  assert.ok(startIndex >= 0 && endIndex > startIndex, `missing ${start}`);
+  return source.slice(startIndex, endIndex);
+}
+
+test("research activity reuses Unsloth's standard thought and web icons", () => {
+  const icon = between("function ActivityIcon", "const ActivityRow");
+
+  assert.match(icon, /<BulbIcon className=\{className\}/);
+  assert.match(icon, /<GlobeIcon className=\{className\}/);
+  assert.doesNotMatch(icon, /<(?:Brain|BookOpen|Search)\b/);
+});
+
+test("cancelled research uses the requested Hugeicons dashed circle", () => {
+  const icon = between("function ActivityIcon", "const ActivityRow");
+
+  assert.match(source, /DashedLineCircleIcon as CircleDashedIcon/);
+  assert.match(icon, /icon=\{CircleDashedIcon\}/);
+  assert.doesNotMatch(icon, /<Square\b/);
+});
+
+test("timeline labels, icons, times, and disclosure controls share one center", () => {
+  const row = between("const ActivityRow", "function PlanReview");
+  const trigger = row.slice(
+    row.indexOf("<CollapsibleTrigger"),
+    row.indexOf("</CollapsibleTrigger>"),
+  );
+
+  assert.match(trigger, /relative flex min-h-10 w-full items-center/);
+  assert.match(
+    trigger,
+    /absolute -left-7 top-1\/2 flex size-\[15px\] -translate-y-1\/2/,
+  );
+  assert.doesNotMatch(trigger, /items-start|className="mt-0\.5 shrink-0/);
+});


### PR DESCRIPTION
## Summary

- optically center all composer send arrows and isolated circular stop glyphs
- cover main chat, dictation, base vs LoRA comparison, and model comparison composers
- vertically center deep research activity icons, labels, timestamps, and disclosure controls
- reuse the shared thinking bulb and standard globe icons in deep research
- replace cancelled activity squares with the Hugeicons dashed circle
- add regression coverage for the composer and research activity alignment contracts

## Audit findings

- all 5 composer send arrows use the shared optical-centering class
- all 6 isolated 12px circular stop squares use the shared optical-centering class
- labeled inline controls, including the prompt-queue pill and voice preview button, intentionally retain their existing spacing
- unrelated Hugeicons stop, cancel, pause, move-up, and move-down controls do not use the composer correction
- production changes are frontend presentation only and do not alter hardware, backend, model, inference, storage, API, event-handler, or hit-target paths
- pre-commit CI also reformatted one existing backend test assertion with no semantic change

## Testing

- `node --experimental-strip-types --test tests/composer-icon-alignment.test.ts tests/research-activity-visuals.test.ts tests/research-activity-follow-loop.test.ts`
- `npm run typecheck`
- `npm run build`
- `git diff --check`