### PR TITLE
fix(studio): prevent OXC validator subprocess hangs

### DIFF
--- a/studio/backend/core/data_recipe/local_callable_validators.py
+++ b/studio/backend/core/data_recipe/local_callable_validators.py
@@ -232,8 +232,7 @@ def _run_oxc_batch(
         "mode": validation_mode,
         "code_shape": code_shape,
         "codes": code_values,
-        # The wrapper bounds oxlint with this; a kill from here would leave the
-        # grandchild running.
+        # The wrapper bounds oxlint with this; a kill here would leave the grandchild.
         "timeout_ms": int(_OXC_TIMEOUT_S * 1000),
     }
     # Resolve a usable Node (system or the isolated install, which is not on the

--- a/studio/backend/core/data_recipe/local_callable_validators.py
+++ b/studio/backend/core/data_recipe/local_callable_validators.py
@@ -32,6 +32,7 @@ _OXC_CODE_SHAPES = {"auto", "module", "snippet"}
 
 _OXC_TOOL_DIR = Path(__file__).resolve().parent / "oxc-validator"
 _OXC_RUNNER_PATH = _OXC_TOOL_DIR / "validate.mjs"
+_OXC_TIMEOUT_S = 30
 
 
 from utils.native_path_leases import child_env_without_native_path_secret
@@ -262,8 +263,12 @@ def _run_oxc_batch(
             capture_output = True,
             check = False,
             env = env,
+            timeout = _OXC_TIMEOUT_S,
             **_windows_hidden_subprocess_kwargs(),
         )
+    except subprocess.TimeoutExpired:
+        logger.warning("OXC validation timed out after %ss", _OXC_TIMEOUT_S)
+        return _fallback_results(len(code_values), "OXC validation timed out")
     except (OSError, ValueError) as exc:
         logger.warning("OXC subprocess launch failed: %s", exc)
         return _fallback_results(len(code_values), f"OXC launch failed: {exc}")

--- a/studio/backend/core/data_recipe/local_callable_validators.py
+++ b/studio/backend/core/data_recipe/local_callable_validators.py
@@ -232,8 +232,8 @@ def _run_oxc_batch(
         "mode": validation_mode,
         "code_shape": code_shape,
         "codes": code_values,
-        # The wrapper kills oxlint against this budget. Killing the wrapper from here
-        # would leave oxlint running, since it is a grandchild of this process.
+        # The wrapper bounds oxlint with this; a kill from here would leave the
+        # grandchild running.
         "timeout_ms": int(_OXC_TIMEOUT_S * 1000),
     }
     # Resolve a usable Node (system or the isolated install, which is not on the

--- a/studio/backend/core/data_recipe/local_callable_validators.py
+++ b/studio/backend/core/data_recipe/local_callable_validators.py
@@ -232,6 +232,9 @@ def _run_oxc_batch(
         "mode": validation_mode,
         "code_shape": code_shape,
         "codes": code_values,
+        # The wrapper kills oxlint against this budget. Killing the wrapper from here
+        # would leave oxlint running, since it is a grandchild of this process.
+        "timeout_ms": int(_OXC_TIMEOUT_S * 1000),
     }
     # Resolve a usable Node (system or the isolated install, which is not on the
     # user's PATH); a bare "node" would fail for isolated-Node users.

--- a/studio/backend/core/data_recipe/oxc-validator/validate.mjs
+++ b/studio/backend/core/data_recipe/oxc-validator/validate.mjs
@@ -21,9 +21,8 @@ const CODE_SHAPES = new Set(["auto", "module", "snippet"]);
 const SNIPPET_PREFIX = "(() => {\n";
 const SNIPPET_SUFFIX = "\n})();\nexport {};\n";
 const OXLINT_SUPPRESSED_RULES = ["no-unused-vars", "no-new-array"];
-// The caller kills only this wrapper, so a wedged oxlint has to die here or it is
-// orphaned. It gets the caller's budget minus what this process already spent, measured
-// monotonically from process start so the two cannot drift apart on a clock step.
+// The caller kills only this wrapper, so a wedged oxlint has to die here or it is orphaned.
+// It gets the caller's budget minus what this process spent, on the same monotonic basis.
 const OXLINT_DEFAULT_BUDGET_MS = 30_000;
 // Covers the spawn, which precedes this process, plus its own wind-down.
 const OXLINT_BUDGET_MARGIN_MS = 2_000;

--- a/studio/backend/core/data_recipe/oxc-validator/validate.mjs
+++ b/studio/backend/core/data_recipe/oxc-validator/validate.mjs
@@ -20,10 +20,16 @@ const CODE_SHAPES = new Set(["auto", "module", "snippet"]);
 const SNIPPET_PREFIX = "(() => {\n";
 const SNIPPET_SUFFIX = "\n})();\nexport {};\n";
 const OXLINT_SUPPRESSED_RULES = ["no-unused-vars", "no-new-array"];
-// Under the caller's own timeout, so a wedged oxlint is killed here instead of
-// being orphaned when the caller kills this wrapper. SIGKILL because SIGTERM is
-// ignorable and spawnSync then waits for the child regardless of the timeout.
-const OXLINT_TIMEOUT_MS = 20_000;
+// The caller kills only this wrapper, so a wedged oxlint has to be killed from here
+// or it survives as an orphan. Its deadline is therefore the caller's own budget
+// minus whatever this process already spent parsing and writing snippets.
+const PROCESS_START_MS = Date.now();
+const OXLINT_DEFAULT_BUDGET_MS = 30_000;
+// Covers node startup, which precedes the clock above, plus this process's wind-down.
+const OXLINT_BUDGET_MARGIN_MS = 2_000;
+// Below this there is no room left to lint, and starting oxlint would only hand the
+// caller's kill an orphan.
+const OXLINT_MIN_TIMEOUT_MS = 1_000;
 const TOOL_DIR = dirname(fileURLToPath(import.meta.url));
 
 function mapLang(value) {
@@ -49,6 +55,11 @@ function mapMode(value) {
     return normalized;
   }
   return "syntax";
+}
+
+function mapBudgetMs(value) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : OXLINT_DEFAULT_BUDGET_MS;
 }
 
 function mapCodeShape(value) {
@@ -378,7 +389,7 @@ function fallbackLintResults(entries, message) {
   );
 }
 
-function runLintBatch(entries) {
+function runLintBatch(entries, deadlineMs) {
   if (entries.length === 0) {
     return new Map();
   }
@@ -399,10 +410,15 @@ function runLintBatch(entries) {
       "json",
       tempDir,
     ];
+    const timeoutMs = deadlineMs - Date.now();
+    if (timeoutMs < OXLINT_MIN_TIMEOUT_MS) {
+      return fallbackLintResults(entries, "oxlint skipped: validation budget exhausted");
+    }
     const exec = spawnSync(oxlintBin, oxlintArgs, {
       encoding: "utf8",
       cwd: TOOL_DIR,
-      timeout: OXLINT_TIMEOUT_MS,
+      timeout: timeoutMs,
+      // SIGTERM is ignorable, and spawnSync then waits out the child regardless.
       killSignal: "SIGKILL",
     });
     if (exec.error) {
@@ -502,7 +518,7 @@ function readStdin() {
   });
 }
 
-function runValidation({ codes, lang, mode, codeShape }) {
+function runValidation({ codes, lang, mode, codeShape, oxlintDeadlineMs }) {
   if (mode === "syntax") {
     return codes.map((code, index) =>
       validateSyntaxOne({ code, lang, index, codeShape }).result,
@@ -513,7 +529,7 @@ function runValidation({ codes, lang, mode, codeShape }) {
     const entries = codes.map((code, index) =>
       resolveLintEntry({ code, lang, index, codeShape }),
     );
-    const lintMap = runLintBatch(entries);
+    const lintMap = runLintBatch(entries, oxlintDeadlineMs);
     return entries.map(
       (entry) =>
         lintMap.get(entry.index) ??
@@ -531,7 +547,7 @@ function runValidation({ codes, lang, mode, codeShape }) {
   const lintTargets = syntaxRuns
     .filter((run) => run.result.is_valid === true)
     .map((run) => run.lintEntry);
-  const lintMap = runLintBatch(lintTargets);
+  const lintMap = runLintBatch(lintTargets, oxlintDeadlineMs);
 
   return syntaxRuns.map((run) => {
     if (run.result.is_valid !== true) {
@@ -572,7 +588,9 @@ async function main() {
   const mode = mapMode(payload?.mode);
   const codeShape = mapCodeShape(payload?.code_shape);
   const codes = Array.isArray(payload?.codes) ? payload.codes : [];
-  const out = runValidation({ codes, lang, mode, codeShape });
+  const oxlintDeadlineMs =
+    PROCESS_START_MS + mapBudgetMs(payload?.timeout_ms) - OXLINT_BUDGET_MARGIN_MS;
+  const out = runValidation({ codes, lang, mode, codeShape, oxlintDeadlineMs });
   process.stdout.write(JSON.stringify(out));
 }
 

--- a/studio/backend/core/data_recipe/oxc-validator/validate.mjs
+++ b/studio/backend/core/data_recipe/oxc-validator/validate.mjs
@@ -5,6 +5,7 @@ import { spawnSync } from "node:child_process";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { basename, dirname, join } from "node:path";
+import { performance } from "node:perf_hooks";
 import { fileURLToPath } from "node:url";
 import { parseSync } from "oxc-parser";
 
@@ -22,9 +23,11 @@ const SNIPPET_SUFFIX = "\n})();\nexport {};\n";
 const OXLINT_SUPPRESSED_RULES = ["no-unused-vars", "no-new-array"];
 // The caller kills only this wrapper, so a wedged oxlint has to die here or it is
 // orphaned. Its deadline is the caller's budget minus what this process already spent.
-const PROCESS_START_MS = Date.now();
+// timeOrigin, not Date.now(), so the startup and imports above are counted too. It is
+// fractional, and spawnSync rejects a non-integer timeout, so floor it here.
+const PROCESS_START_MS = Math.floor(performance.timeOrigin);
 const OXLINT_DEFAULT_BUDGET_MS = 30_000;
-// Covers node startup, which precedes the clock above.
+// Covers the spawn the clock above cannot see, plus this process's wind-down.
 const OXLINT_BUDGET_MARGIN_MS = 2_000;
 // Below this, starting oxlint would only hand the caller's kill an orphan.
 const OXLINT_MIN_TIMEOUT_MS = 1_000;
@@ -57,7 +60,7 @@ function mapMode(value) {
 
 function mapBudgetMs(value) {
   const parsed = Number(value);
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : OXLINT_DEFAULT_BUDGET_MS;
+  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : OXLINT_DEFAULT_BUDGET_MS;
 }
 
 function mapCodeShape(value) {

--- a/studio/backend/core/data_recipe/oxc-validator/validate.mjs
+++ b/studio/backend/core/data_recipe/oxc-validator/validate.mjs
@@ -20,6 +20,10 @@ const CODE_SHAPES = new Set(["auto", "module", "snippet"]);
 const SNIPPET_PREFIX = "(() => {\n";
 const SNIPPET_SUFFIX = "\n})();\nexport {};\n";
 const OXLINT_SUPPRESSED_RULES = ["no-unused-vars", "no-new-array"];
+// Under the caller's own timeout, so a wedged oxlint is killed here instead of
+// being orphaned when the caller kills this wrapper. SIGKILL because SIGTERM is
+// ignorable and spawnSync then waits for the child regardless of the timeout.
+const OXLINT_TIMEOUT_MS = 20_000;
 const TOOL_DIR = dirname(fileURLToPath(import.meta.url));
 
 function mapLang(value) {
@@ -398,6 +402,8 @@ function runLintBatch(entries) {
     const exec = spawnSync(oxlintBin, oxlintArgs, {
       encoding: "utf8",
       cwd: TOOL_DIR,
+      timeout: OXLINT_TIMEOUT_MS,
+      killSignal: "SIGKILL",
     });
     if (exec.error) {
       return fallbackLintResults(

--- a/studio/backend/core/data_recipe/oxc-validator/validate.mjs
+++ b/studio/backend/core/data_recipe/oxc-validator/validate.mjs
@@ -20,15 +20,13 @@ const CODE_SHAPES = new Set(["auto", "module", "snippet"]);
 const SNIPPET_PREFIX = "(() => {\n";
 const SNIPPET_SUFFIX = "\n})();\nexport {};\n";
 const OXLINT_SUPPRESSED_RULES = ["no-unused-vars", "no-new-array"];
-// The caller kills only this wrapper, so a wedged oxlint has to be killed from here
-// or it survives as an orphan. Its deadline is therefore the caller's own budget
-// minus whatever this process already spent parsing and writing snippets.
+// The caller kills only this wrapper, so a wedged oxlint has to die here or it is
+// orphaned. Its deadline is the caller's budget minus what this process already spent.
 const PROCESS_START_MS = Date.now();
 const OXLINT_DEFAULT_BUDGET_MS = 30_000;
-// Covers node startup, which precedes the clock above, plus this process's wind-down.
+// Covers node startup, which precedes the clock above.
 const OXLINT_BUDGET_MARGIN_MS = 2_000;
-// Below this there is no room left to lint, and starting oxlint would only hand the
-// caller's kill an orphan.
+// Below this, starting oxlint would only hand the caller's kill an orphan.
 const OXLINT_MIN_TIMEOUT_MS = 1_000;
 const TOOL_DIR = dirname(fileURLToPath(import.meta.url));
 

--- a/studio/backend/core/data_recipe/oxc-validator/validate.mjs
+++ b/studio/backend/core/data_recipe/oxc-validator/validate.mjs
@@ -22,12 +22,10 @@ const SNIPPET_PREFIX = "(() => {\n";
 const SNIPPET_SUFFIX = "\n})();\nexport {};\n";
 const OXLINT_SUPPRESSED_RULES = ["no-unused-vars", "no-new-array"];
 // The caller kills only this wrapper, so a wedged oxlint has to die here or it is
-// orphaned. Its deadline is the caller's budget minus what this process already spent.
-// timeOrigin, not Date.now(), so the startup and imports above are counted too. It is
-// fractional, and spawnSync rejects a non-integer timeout, so floor it here.
-const PROCESS_START_MS = Math.floor(performance.timeOrigin);
+// orphaned. It gets the caller's budget minus what this process already spent, measured
+// monotonically from process start so the two cannot drift apart on a clock step.
 const OXLINT_DEFAULT_BUDGET_MS = 30_000;
-// Covers the spawn the clock above cannot see, plus this process's wind-down.
+// Covers the spawn, which precedes this process, plus its own wind-down.
 const OXLINT_BUDGET_MARGIN_MS = 2_000;
 // Below this, starting oxlint would only hand the caller's kill an orphan.
 const OXLINT_MIN_TIMEOUT_MS = 1_000;
@@ -390,7 +388,7 @@ function fallbackLintResults(entries, message) {
   );
 }
 
-function runLintBatch(entries, deadlineMs) {
+function runLintBatch(entries, budgetMs) {
   if (entries.length === 0) {
     return new Map();
   }
@@ -411,7 +409,7 @@ function runLintBatch(entries, deadlineMs) {
       "json",
       tempDir,
     ];
-    const timeoutMs = deadlineMs - Date.now();
+    const timeoutMs = Math.floor(budgetMs - OXLINT_BUDGET_MARGIN_MS - performance.now());
     if (timeoutMs < OXLINT_MIN_TIMEOUT_MS) {
       return fallbackLintResults(entries, "oxlint skipped: validation budget exhausted");
     }
@@ -519,7 +517,7 @@ function readStdin() {
   });
 }
 
-function runValidation({ codes, lang, mode, codeShape, oxlintDeadlineMs }) {
+function runValidation({ codes, lang, mode, codeShape, oxlintBudgetMs }) {
   if (mode === "syntax") {
     return codes.map((code, index) =>
       validateSyntaxOne({ code, lang, index, codeShape }).result,
@@ -530,7 +528,7 @@ function runValidation({ codes, lang, mode, codeShape, oxlintDeadlineMs }) {
     const entries = codes.map((code, index) =>
       resolveLintEntry({ code, lang, index, codeShape }),
     );
-    const lintMap = runLintBatch(entries, oxlintDeadlineMs);
+    const lintMap = runLintBatch(entries, oxlintBudgetMs);
     return entries.map(
       (entry) =>
         lintMap.get(entry.index) ??
@@ -548,7 +546,7 @@ function runValidation({ codes, lang, mode, codeShape, oxlintDeadlineMs }) {
   const lintTargets = syntaxRuns
     .filter((run) => run.result.is_valid === true)
     .map((run) => run.lintEntry);
-  const lintMap = runLintBatch(lintTargets, oxlintDeadlineMs);
+  const lintMap = runLintBatch(lintTargets, oxlintBudgetMs);
 
   return syntaxRuns.map((run) => {
     if (run.result.is_valid !== true) {
@@ -589,9 +587,8 @@ async function main() {
   const mode = mapMode(payload?.mode);
   const codeShape = mapCodeShape(payload?.code_shape);
   const codes = Array.isArray(payload?.codes) ? payload.codes : [];
-  const oxlintDeadlineMs =
-    PROCESS_START_MS + mapBudgetMs(payload?.timeout_ms) - OXLINT_BUDGET_MARGIN_MS;
-  const out = runValidation({ codes, lang, mode, codeShape, oxlintDeadlineMs });
+  const oxlintBudgetMs = mapBudgetMs(payload?.timeout_ms);
+  const out = runValidation({ codes, lang, mode, codeShape, oxlintBudgetMs });
   process.stdout.write(JSON.stringify(out));
 }
 

--- a/studio/backend/tests/test_health_answers_within_probe_budget.py
+++ b/studio/backend/tests/test_health_answers_within_probe_budget.py
@@ -560,9 +560,9 @@ def test_a_cold_health_call_answers_inside_the_launcher_deadline():
     probe_timeout = _desktop_probe_timeout_s()
     result = _probe(_SLOW_DETECT_S)
 
-    assert result["cold_hardware_detecting"] is True, (
-        "the cold call got a settled reply, so it never exercised the wait this bound is about"
-    )
+    assert (
+        result["cold_hardware_detecting"] is True
+    ), "the cold call got a settled reply, so it never exercised the wait this bound is about"
     assert result["cold_elapsed"] < probe_timeout, (
         f"the first /api/health call took {result['cold_elapsed']:.2f}s, past the "
         f"{probe_timeout}s the desktop probe allows before it gives up and dead-ends "

--- a/studio/backend/tests/test_health_answers_within_probe_budget.py
+++ b/studio/backend/tests/test_health_answers_within_probe_budget.py
@@ -560,9 +560,9 @@ def test_a_cold_health_call_answers_inside_the_launcher_deadline():
     probe_timeout = _desktop_probe_timeout_s()
     result = _probe(_SLOW_DETECT_S)
 
-    assert (
-        result["cold_hardware_detecting"] is True
-    ), "the cold call got a settled reply, so it never exercised the wait this bound is about"
+    assert result["cold_hardware_detecting"] is True, (
+        "the cold call got a settled reply, so it never exercised the wait this bound is about"
+    )
     assert result["cold_elapsed"] < probe_timeout, (
         f"the first /api/health call took {result['cold_elapsed']:.2f}s, past the "
         f"{probe_timeout}s the desktop probe allows before it gives up and dead-ends "

--- a/studio/backend/tests/test_local_callable_validators.py
+++ b/studio/backend/tests/test_local_callable_validators.py
@@ -35,8 +35,7 @@ def test_oxc_batch_falls_back_when_node_times_out(monkeypatch, tmp_path):
 
     assert len(calls) == 1
     assert calls[0][1]["timeout"] == validators._OXC_TIMEOUT_S
-    # The wrapper needs the same budget to bound oxlint, which this process cannot
-    # reach: killing the wrapper leaves its own child running.
+    # The wrapper needs the same budget: oxlint is a grandchild this kill cannot reach.
     assert json.loads(calls[0][1]["input"])["timeout_ms"] == validators._OXC_TIMEOUT_S * 1000
     assert len(results) == 2
     assert all(result["is_valid"] is False for result in results)
@@ -48,11 +47,9 @@ def test_oxc_batch_falls_back_when_node_times_out(monkeypatch, tmp_path):
 
 
 def test_the_wrapper_kills_oxlint_against_the_remaining_caller_budget():
-    # Python's timeout SIGKILLs only the Node wrapper, so oxlint, a grandchild, has to
-    # be killed inside validate.mjs or it survives as an orphan. A fixed inner bound is
-    # not enough: parsing and writing the batch runs first, so what oxlint gets has to
-    # be what is left of the caller's budget. The backend ships no JS test runner, so
-    # the invariant is guarded on the source.
+    # Python's timeout SIGKILLs only the wrapper, so oxlint has to die inside validate.mjs.
+    # A fixed inner bound is not enough: parsing runs first, so oxlint gets what is left of
+    # the caller's budget. Guarded on the source because the backend ships no JS test runner.
     source = validators._OXC_RUNNER_PATH.read_text(encoding = "utf-8")
 
     assert re.search(

--- a/studio/backend/tests/test_local_callable_validators.py
+++ b/studio/backend/tests/test_local_callable_validators.py
@@ -53,14 +53,16 @@ def test_the_wrapper_kills_oxlint_against_the_remaining_caller_budget():
     source = validators._OXC_RUNNER_PATH.read_text(encoding = "utf-8")
 
     assert re.search(
-        r"PROCESS_START_MS\s*\+\s*mapBudgetMs\(payload\?\.timeout_ms\)", source
-    ), "the oxlint deadline must be derived from the timeout_ms the caller sends"
+        r"mapBudgetMs\(payload\?\.timeout_ms\)", source
+    ), "the oxlint budget must come from the timeout_ms the caller sends"
 
-    # timeOrigin is the process start; Date.now() here would start the clock after node
-    # boot and the native oxc-parser import, which this process is not charged for.
-    assert (
-        "const PROCESS_START_MS = Math.floor(performance.timeOrigin);" in source
-    ), "the deadline must be anchored on the process start, not on module evaluation"
+    # performance.now() is monotonic ms since the process started, the same basis as the
+    # caller's timeout, and it already counts node boot and the oxc-parser import.
+    # Date.now() would drift from the caller on any wall-clock step.
+    remaining = re.search(r"const timeoutMs = ([^;]+);", source)
+    assert remaining, "runLintBatch must compute what is left of the caller's budget"
+    assert "performance.now()" in remaining.group(1)
+    assert "Date.now()" not in remaining.group(1)
 
     fallback_budget = re.search(r"const OXLINT_DEFAULT_BUDGET_MS = ([\d_]+);", source)
     assert fallback_budget, "validate.mjs must declare OXLINT_DEFAULT_BUDGET_MS"

--- a/studio/backend/tests/test_local_callable_validators.py
+++ b/studio/backend/tests/test_local_callable_validators.py
@@ -47,18 +47,16 @@ def test_oxc_batch_falls_back_when_node_times_out(monkeypatch, tmp_path):
 
 
 def test_the_wrapper_kills_oxlint_against_the_remaining_caller_budget():
-    # Python's timeout SIGKILLs only the wrapper, so oxlint has to die inside validate.mjs.
-    # A fixed inner bound is not enough: parsing runs first, so oxlint gets what is left of
-    # the caller's budget. Guarded on the source because the backend ships no JS test runner.
+    # Python's timeout SIGKILLs only the wrapper, so oxlint has to die inside validate.mjs,
+    # against what is left of the caller's budget. On the source: no JS test runner ships.
     source = validators._OXC_RUNNER_PATH.read_text(encoding = "utf-8")
 
     assert re.search(
         r"mapBudgetMs\(payload\?\.timeout_ms\)", source
     ), "the oxlint budget must come from the timeout_ms the caller sends"
 
-    # performance.now() is monotonic ms since the process started, the same basis as the
-    # caller's timeout, and it already counts node boot and the oxc-parser import.
-    # Date.now() would drift from the caller on any wall-clock step.
+    # performance.now() is monotonic ms since process start, the same basis as the caller's
+    # timeout; Date.now() would drift from it on a wall-clock step.
     remaining = re.search(r"const timeoutMs = ([^;]+);", source)
     assert remaining, "runLintBatch must compute what is left of the caller's budget"
     assert "performance.now()" in remaining.group(1)

--- a/studio/backend/tests/test_local_callable_validators.py
+++ b/studio/backend/tests/test_local_callable_validators.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
+import re
 import subprocess
 from pathlib import Path
 
@@ -40,3 +41,22 @@ def test_oxc_batch_falls_back_when_node_times_out(monkeypatch, tmp_path):
         "OXC validation timed out",
         "OXC validation timed out",
     ]
+
+
+def test_oxlint_spawn_is_bounded_below_the_python_timeout():
+    # validate.mjs owns oxlint's lifetime: the Python timeout SIGKILLs only the Node
+    # wrapper, so an oxlint bounded from Python alone survives as an orphan. The
+    # backend ships no JS test runner, so the invariant is guarded on the source.
+    source = validators._OXC_RUNNER_PATH.read_text(encoding = "utf-8")
+
+    declared = re.search(r"const OXLINT_TIMEOUT_MS = ([\d_]+);", source)
+    assert declared, "validate.mjs must declare OXLINT_TIMEOUT_MS"
+    assert (
+        int(declared.group(1).replace("_", "")) / 1000 < validators._OXC_TIMEOUT_S
+    ), "oxlint must give up before the Python wait does, or Python kills the wrapper first"
+
+    options = re.search(r"spawnSync\(oxlintBin, oxlintArgs, \{(.*?)\}\)", source, re.S)
+    assert options, "oxlint must still be launched through spawnSync(oxlintBin, oxlintArgs, ...)"
+    assert "timeout: OXLINT_TIMEOUT_MS" in options.group(1)
+    # SIGTERM is ignorable, and spawnSync then waits out the child anyway.
+    assert 'killSignal: "SIGKILL"' in options.group(1)

--- a/studio/backend/tests/test_local_callable_validators.py
+++ b/studio/backend/tests/test_local_callable_validators.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
+import json
 import re
 import subprocess
 from pathlib import Path
@@ -34,6 +35,9 @@ def test_oxc_batch_falls_back_when_node_times_out(monkeypatch, tmp_path):
 
     assert len(calls) == 1
     assert calls[0][1]["timeout"] == validators._OXC_TIMEOUT_S
+    # The wrapper needs the same budget to bound oxlint, which this process cannot
+    # reach: killing the wrapper leaves its own child running.
+    assert json.loads(calls[0][1]["input"])["timeout_ms"] == validators._OXC_TIMEOUT_S * 1000
     assert len(results) == 2
     assert all(result["is_valid"] is False for result in results)
     assert all(result["error_count"] == 1 for result in results)
@@ -43,20 +47,28 @@ def test_oxc_batch_falls_back_when_node_times_out(monkeypatch, tmp_path):
     ]
 
 
-def test_oxlint_spawn_is_bounded_below_the_python_timeout():
-    # validate.mjs owns oxlint's lifetime: the Python timeout SIGKILLs only the Node
-    # wrapper, so an oxlint bounded from Python alone survives as an orphan. The
-    # backend ships no JS test runner, so the invariant is guarded on the source.
+def test_the_wrapper_kills_oxlint_against_the_remaining_caller_budget():
+    # Python's timeout SIGKILLs only the Node wrapper, so oxlint, a grandchild, has to
+    # be killed inside validate.mjs or it survives as an orphan. A fixed inner bound is
+    # not enough: parsing and writing the batch runs first, so what oxlint gets has to
+    # be what is left of the caller's budget. The backend ships no JS test runner, so
+    # the invariant is guarded on the source.
     source = validators._OXC_RUNNER_PATH.read_text(encoding = "utf-8")
 
-    declared = re.search(r"const OXLINT_TIMEOUT_MS = ([\d_]+);", source)
-    assert declared, "validate.mjs must declare OXLINT_TIMEOUT_MS"
+    assert re.search(
+        r"PROCESS_START_MS\s*\+\s*mapBudgetMs\(payload\?\.timeout_ms\)", source
+    ), "the oxlint deadline must be derived from the timeout_ms the caller sends"
+
+    fallback_budget = re.search(r"const OXLINT_DEFAULT_BUDGET_MS = ([\d_]+);", source)
+    assert fallback_budget, "validate.mjs must declare OXLINT_DEFAULT_BUDGET_MS"
     assert (
-        int(declared.group(1).replace("_", "")) / 1000 < validators._OXC_TIMEOUT_S
-    ), "oxlint must give up before the Python wait does, or Python kills the wrapper first"
+        int(fallback_budget.group(1).replace("_", "")) == validators._OXC_TIMEOUT_S * 1000
+    ), "the fallback budget must match the wait this process actually gives the wrapper"
 
     options = re.search(r"spawnSync\(oxlintBin, oxlintArgs, \{(.*?)\}\)", source, re.S)
     assert options, "oxlint must still be launched through spawnSync(oxlintBin, oxlintArgs, ...)"
-    assert "timeout: OXLINT_TIMEOUT_MS" in options.group(1)
+    assert "timeout: timeoutMs" in options.group(
+        1
+    ), "oxlint's bound must be the computed remainder, not a constant"
     # SIGTERM is ignorable, and spawnSync then waits out the child anyway.
     assert 'killSignal: "SIGKILL"' in options.group(1)

--- a/studio/backend/tests/test_local_callable_validators.py
+++ b/studio/backend/tests/test_local_callable_validators.py
@@ -56,6 +56,12 @@ def test_the_wrapper_kills_oxlint_against_the_remaining_caller_budget():
         r"PROCESS_START_MS\s*\+\s*mapBudgetMs\(payload\?\.timeout_ms\)", source
     ), "the oxlint deadline must be derived from the timeout_ms the caller sends"
 
+    # timeOrigin is the process start; Date.now() here would start the clock after node
+    # boot and the native oxc-parser import, which this process is not charged for.
+    assert (
+        "const PROCESS_START_MS = Math.floor(performance.timeOrigin);" in source
+    ), "the deadline must be anchored on the process start, not on module evaluation"
+
     fallback_budget = re.search(r"const OXLINT_DEFAULT_BUDGET_MS = ([\d_]+);", source)
     assert fallback_budget, "validate.mjs must declare OXLINT_DEFAULT_BUDGET_MS"
     assert (

--- a/studio/backend/tests/test_local_callable_validators.py
+++ b/studio/backend/tests/test_local_callable_validators.py
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import subprocess
+from pathlib import Path
+
+from core.data_recipe import local_callable_validators as validators
+
+
+def test_oxc_batch_falls_back_when_node_times_out(monkeypatch, tmp_path):
+    runner = tmp_path / "validate.mjs"
+    runner.touch()
+    calls = []
+
+    def fake_run(*args, **kwargs):
+        calls.append((args, kwargs))
+        raise subprocess.TimeoutExpired(cmd = args[0], timeout = kwargs["timeout"])
+
+    monkeypatch.setattr(validators, "_OXC_RUNNER_PATH", runner)
+    monkeypatch.setattr(validators, "resolve_node_executable", lambda: "node")
+    monkeypatch.setattr(validators, "ensure_dir", lambda path: tmp_path)
+    monkeypatch.setattr(validators, "oxc_validator_tmp_root", lambda: tmp_path)
+    monkeypatch.setattr(validators, "child_env_without_native_path_secret", lambda: {})
+    monkeypatch.setattr(validators, "_windows_hidden_subprocess_kwargs", lambda: {})
+    monkeypatch.setattr(validators.subprocess, "run", fake_run)
+
+    results = validators._run_oxc_batch(
+        node_lang = "js",
+        validation_mode = "syntax",
+        code_shape = "auto",
+        code_values = ["const value = 1;", "const value = 2;"],
+    )
+
+    assert len(calls) == 1
+    assert calls[0][1]["timeout"] == validators._OXC_TIMEOUT_S
+    assert len(results) == 2
+    assert all(result["is_valid"] is False for result in results)
+    assert all(result["error_count"] == 1 for result in results)
+    assert [result["error_message"] for result in results] == [
+        "OXC validation timed out",
+        "OXC validation timed out",
+    ]


### PR DESCRIPTION
## Summary

Bound the OXC local-callable validator's Node subprocess wait to 30 seconds.

## Root cause

`_run_oxc_batch()` used `subprocess.run(...)` without a timeout on the `POST /data-recipe/validate` request path. A Node process that starts but never exits could therefore pin the request worker indefinitely.

## Fix

Pass the shared 30-second timeout to `subprocess.run` and translate `subprocess.TimeoutExpired` into the existing fail-closed fallback result, with a warning log. Added regression coverage for the timeout and per-row fallback behavior.

## Testing

- `PYTHONPATH=studio/backend uv run --no-project --with pytest --with structlog python -m pytest --noconftest studio/backend/tests/test_local_callable_validators.py -q` — 1 passed
- `PYTHONPATH=studio/backend uv run --no-project --with pytest --with structlog python -m pytest --noconftest studio/backend/tests/test_data_recipe_pump_resilience.py studio/backend/tests/test_data_recipe_sampling_progress.py -q` — 5 passed
- `uv run --no-project --with ruff ruff check studio/backend/core/data_recipe/local_callable_validators.py studio/backend/tests/test_local_callable_validators.py` — passed
- `python -m compileall -q studio/backend/core/data_recipe/local_callable_validators.py studio/backend/tests/test_local_callable_validators.py` — passed

## Issue

Fixes #9750