### PR TITLE
Handle invalid Krea2 model indexes clearly

### DIFF
--- a/studio/backend/core/inference/diffusion_krea2.py
+++ b/studio/backend/core/inference/diffusion_krea2.py
@@ -104,6 +104,18 @@ def load_krea2_text_encoder(
     return Qwen3VLModel.from_pretrained(repo_id, config = config, dtype = dtype, **kwargs)
 
 
+def _read_model_index(path: Path, source: str) -> dict[str, Any]:
+    try:
+        model_index = json.loads(path.read_text(encoding = "utf-8-sig"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError(
+            f"Unable to read valid model_index.json from {source} at {path}: {exc}"
+        ) from exc
+    if not isinstance(model_index, dict):
+        raise ValueError(f"model_index.json from {source} at {path} must contain a JSON object")
+    return model_index
+
+
 def _load_model_index(
     repo_id: str,
     hf_token: Optional[str] = None,
@@ -116,7 +128,7 @@ def _load_model_index(
         is_local_dir = root.is_dir()
         local = root / "model_index.json"
         if local.is_file():
-            return json.loads(local.read_text(encoding = "utf-8"))
+            return _read_model_index(local, f"local model directory {root}")
     except OSError:
         pass
     if is_local_dir:
@@ -131,7 +143,7 @@ def _load_model_index(
         local_files_only = local_files_only,
         cache_dir = _live_cache_dir(),
     )
-    return json.loads(Path(path).read_text(encoding = "utf-8"))
+    return _read_model_index(Path(path), f"Hub/cache for {repo_id}")
 
 
 def load_krea2_pipeline(

--- a/studio/backend/core/inference/diffusion_krea2.py
+++ b/studio/backend/core/inference/diffusion_krea2.py
@@ -107,9 +107,8 @@ def load_krea2_text_encoder(
 def _read_model_index(path: Path, source: str) -> dict[str, Any]:
     try:
         model_index = json.loads(path.read_text(encoding = "utf-8-sig"))
-    # RecursionError is a nesting bomb rather than a ValueError, so it needs naming separately or
-    # it stays the one raw traceback left; diffusion_families.pipeline_class_from_index catches the
-    # same set for the same reason.
+    # A nesting bomb raises RecursionError, not a ValueError, so it needs naming separately or it
+    # stays the one raw traceback left. diffusion_families.pipeline_class_from_index does the same.
     except (OSError, UnicodeDecodeError, json.JSONDecodeError, RecursionError) as exc:
         raise ValueError(
             f"Unable to read valid model_index.json from {source} at {path}: {exc}"
@@ -186,9 +185,8 @@ def load_krea2_pipeline(
 
     token = hf_token or None
     cache_dir = _live_cache_dir()
-    # Read the few-KB index BEFORE the components. It used to be read last, so a corrupt index
-    # only reported itself after the tokenizer, the 8.88 GB encoder, the VAE and the 26 GB
-    # transformer had already been built -- a clear message that costs a full load to reach.
+    # A few KB, and it configures the components, so it is read before them: read last, a corrupt
+    # index only surfaced after the encoder, the VAE and the 26 GB transformer were already built.
     model_index = _load_model_index(repo_id, hf_token = token, local_files_only = local_files_only)
     tokenizer = load_krea2_tokenizer(repo_id, hf_token = token, local_files_only = local_files_only)
     if text_encoder is None:

--- a/studio/backend/core/inference/diffusion_krea2.py
+++ b/studio/backend/core/inference/diffusion_krea2.py
@@ -107,7 +107,10 @@ def load_krea2_text_encoder(
 def _read_model_index(path: Path, source: str) -> dict[str, Any]:
     try:
         model_index = json.loads(path.read_text(encoding = "utf-8-sig"))
-    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+    # RecursionError is a nesting bomb rather than a ValueError, so it needs naming separately or
+    # it stays the one raw traceback left; diffusion_families.pipeline_class_from_index catches the
+    # same set for the same reason.
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError, RecursionError) as exc:
         raise ValueError(
             f"Unable to read valid model_index.json from {source} at {path}: {exc}"
         ) from exc
@@ -183,6 +186,10 @@ def load_krea2_pipeline(
 
     token = hf_token or None
     cache_dir = _live_cache_dir()
+    # Read the few-KB index BEFORE the components. It used to be read last, so a corrupt index
+    # only reported itself after the tokenizer, the 8.88 GB encoder, the VAE and the 26 GB
+    # transformer had already been built -- a clear message that costs a full load to reach.
+    model_index = _load_model_index(repo_id, hf_token = token, local_files_only = local_files_only)
     tokenizer = load_krea2_tokenizer(repo_id, hf_token = token, local_files_only = local_files_only)
     if text_encoder is None:
         text_encoder = load_krea2_text_encoder(
@@ -212,7 +219,6 @@ def load_krea2_pipeline(
             local_files_only = local_files_only,
             cache_dir = cache_dir,
         )
-    model_index = _load_model_index(repo_id, hf_token = token, local_files_only = local_files_only)
     return diffusers.Krea2Pipeline(
         scheduler = scheduler,
         vae = vae,

--- a/studio/backend/tests/test_diffusion_krea2.py
+++ b/studio/backend/tests/test_diffusion_krea2.py
@@ -107,8 +107,7 @@ def test_load_model_index_rejects_non_object_json(tmp_path, payload):
 
 def test_load_model_index_wraps_unreadable_local_file(monkeypatch, tmp_path):
     # Present but unreadable (0600, EIO, a Windows AV lock): the OSError used to be swallowed and
-    # re-reported as "not found", sending the user after a file that is right there. Faulted at the
-    # read because chmod cannot stage it -- CI and containers run as root.
+    # re-reported as "not found". Faulted at the read because chmod is a no-op as root.
     (tmp_path / "model_index.json").write_text('{"patch_size": 2}', encoding = "utf-8")
     original = Path.read_text
 
@@ -127,8 +126,7 @@ def test_load_model_index_wraps_unreadable_local_file(monkeypatch, tmp_path):
 
 def test_load_model_index_wraps_a_nesting_bomb(monkeypatch, tmp_path):
     # Valid JSON and valid UTF-8, so neither guard above sees it; the parser blows the stack.
-    # Faulted directly because the triggering depth is not portable: 3.10-3.13 raise on ~50k
-    # nested objects and 3.14's scanner parses the same payload.
+    # Faulted directly because the depth is not portable: 3.14 parses what 3.10-3.13 reject.
     (tmp_path / "model_index.json").write_text('{"a": 1}', encoding = "utf-8")
     monkeypatch.setattr(
         json, "loads", lambda *args, **kwargs: (_ for _ in ()).throw(RecursionError("too deep"))

--- a/studio/backend/tests/test_diffusion_krea2.py
+++ b/studio/backend/tests/test_diffusion_krea2.py
@@ -64,6 +64,62 @@ def test_load_model_index_from_local_path(tmp_path):
     assert _load_model_index(str(tmp_path)) == {"is_distilled": True, "patch_size": 2}
 
 
+def test_load_model_index_wraps_truncated_local_json(tmp_path):
+    (tmp_path / "model_index.json").write_text('{"patch_size":', encoding = "utf-8")
+
+    with pytest.raises(ValueError, match = r"model_index\.json.*local model directory") as exc_info:
+        _load_model_index(str(tmp_path))
+
+    assert isinstance(exc_info.value.__cause__, json.JSONDecodeError)
+
+
+def test_load_model_index_wraps_invalid_utf8(tmp_path):
+    (tmp_path / "model_index.json").write_bytes(b'\xff{"patch_size": 2}')
+
+    with pytest.raises(ValueError, match = r"model_index\.json.*local model directory") as exc_info:
+        _load_model_index(str(tmp_path))
+
+    assert isinstance(exc_info.value.__cause__, UnicodeDecodeError)
+
+
+def test_load_model_index_accepts_utf8_bom(tmp_path):
+    (tmp_path / "model_index.json").write_bytes(b'\xef\xbb\xbf{"patch_size": 2}')
+
+    assert _load_model_index(str(tmp_path)) == {"patch_size": 2}
+
+
+def test_load_model_index_rejects_non_object_json(tmp_path):
+    (tmp_path / "model_index.json").write_text("[]", encoding = "utf-8")
+
+    with pytest.raises(
+        ValueError, match = r"model_index\.json.*must contain a JSON object"
+    ) as exc_info:
+        _load_model_index(str(tmp_path))
+
+    assert exc_info.value.__cause__ is None
+
+
+def test_load_model_index_missing_local_file(tmp_path):
+    with pytest.raises(FileNotFoundError, match = r"model_index\.json not found in local model dir"):
+        _load_model_index(str(tmp_path))
+
+
+def test_load_model_index_wraps_malformed_hub_cache_content(monkeypatch, tmp_path):
+    import huggingface_hub
+
+    downloaded = tmp_path / "downloaded-model_index.json"
+    downloaded.write_text('{"patch_size":', encoding = "utf-8")
+    monkeypatch.setattr(
+        huggingface_hub, "hf_hub_download", lambda *_args, **_kwargs: str(downloaded)
+    )
+
+    with pytest.raises(ValueError, match = r"model_index\.json.*Hub/cache") as exc_info:
+        _load_model_index("krea/Krea-2-Turbo", local_files_only = True)
+
+    assert str(downloaded) in str(exc_info.value)
+    assert isinstance(exc_info.value.__cause__, json.JSONDecodeError)
+
+
 # ── pipeline assembly threads the model_index init config ────────────────────
 
 

--- a/studio/backend/tests/test_diffusion_krea2.py
+++ b/studio/backend/tests/test_diffusion_krea2.py
@@ -94,8 +94,7 @@ def test_load_model_index_accepts_utf8_bom(tmp_path):
     "payload", ["[]", "null", "3", "2.5", '"str"', "true", "false", '[{"a": 1}]']
 )
 def test_load_model_index_rejects_non_object_json(tmp_path, payload):
-    # Every one of these parsed fine before and was handed to the caller, which then died on
-    # ``.get`` one frame away; the type is what makes an index unusable, not just the syntax.
+    # All of these parsed and reached the caller, which then died on ``.get`` one frame away.
     (tmp_path / "model_index.json").write_text(payload, encoding = "utf-8")
 
     with pytest.raises(
@@ -107,10 +106,9 @@ def test_load_model_index_rejects_non_object_json(tmp_path, payload):
 
 
 def test_load_model_index_wraps_unreadable_local_file(monkeypatch, tmp_path):
-    # The file passes is_file() and fails in the read: a 0600 checkpoint copied between users, an
-    # EIO disk, a Windows file held open by an AV scanner. That OSError used to be swallowed and
-    # re-reported as "not found", which sends the user looking for a file that is right there.
-    # chmod cannot stage this (CI and containers run as root), so the read itself is faulted.
+    # Present but unreadable (0600, EIO, a Windows AV lock): the OSError used to be swallowed and
+    # re-reported as "not found", sending the user after a file that is right there. Faulted at the
+    # read because chmod cannot stage it -- CI and containers run as root.
     (tmp_path / "model_index.json").write_text('{"patch_size": 2}', encoding = "utf-8")
     original = Path.read_text
 
@@ -128,10 +126,9 @@ def test_load_model_index_wraps_unreadable_local_file(monkeypatch, tmp_path):
 
 
 def test_load_model_index_wraps_a_nesting_bomb(monkeypatch, tmp_path):
-    # Valid JSON, valid UTF-8, and neither guard above sees it: on a deep enough index the parser
-    # blows the stack first, and RecursionError is not a ValueError. The depth that triggers it is
-    # not portable -- 3.10-3.13 raise on ~50k nested objects, 3.14's scanner parses the same
-    # payload -- so the parser is faulted directly and the guard, not the interpreter, is asserted.
+    # Valid JSON and valid UTF-8, so neither guard above sees it; the parser blows the stack.
+    # Faulted directly because the triggering depth is not portable: 3.10-3.13 raise on ~50k
+    # nested objects and 3.14's scanner parses the same payload.
     (tmp_path / "model_index.json").write_text('{"a": 1}', encoding = "utf-8")
     monkeypatch.setattr(
         json, "loads", lambda *args, **kwargs: (_ for _ in ()).throw(RecursionError("too deep"))
@@ -226,9 +223,8 @@ def test_load_krea2_pipeline_threads_init_config(monkeypatch, tmp_path):
 
 
 def test_a_corrupt_index_is_rejected_before_any_component_is_built(monkeypatch, tmp_path):
-    """The index is a few KB and the components it configures are ~35 GB, so it has to be read
-    first. Read last, a clear message still costs a full load to reach, which is most of what the
-    opaque traceback cost in the first place."""
+    """A few KB against the ~35 GB it configures, so it is read first. Read last, a clear message
+    still costs a full load to reach, which is most of what the opaque traceback cost."""
     (tmp_path / "model_index.json").write_text('{"_class_name": "Krea2Pipe', encoding = "utf-8")
 
     built: list = []

--- a/studio/backend/tests/test_diffusion_krea2.py
+++ b/studio/backend/tests/test_diffusion_krea2.py
@@ -5,8 +5,10 @@
 
 from __future__ import annotations
 
+import errno
 import json
 import sys
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -88,8 +90,13 @@ def test_load_model_index_accepts_utf8_bom(tmp_path):
     assert _load_model_index(str(tmp_path)) == {"patch_size": 2}
 
 
-def test_load_model_index_rejects_non_object_json(tmp_path):
-    (tmp_path / "model_index.json").write_text("[]", encoding = "utf-8")
+@pytest.mark.parametrize(
+    "payload", ["[]", "null", "3", "2.5", '"str"', "true", "false", '[{"a": 1}]']
+)
+def test_load_model_index_rejects_non_object_json(tmp_path, payload):
+    # Every one of these parsed fine before and was handed to the caller, which then died on
+    # ``.get`` one frame away; the type is what makes an index unusable, not just the syntax.
+    (tmp_path / "model_index.json").write_text(payload, encoding = "utf-8")
 
     with pytest.raises(
         ValueError, match = r"model_index\.json.*must contain a JSON object"
@@ -97,6 +104,43 @@ def test_load_model_index_rejects_non_object_json(tmp_path):
         _load_model_index(str(tmp_path))
 
     assert exc_info.value.__cause__ is None
+
+
+def test_load_model_index_wraps_unreadable_local_file(monkeypatch, tmp_path):
+    # The file passes is_file() and fails in the read: a 0600 checkpoint copied between users, an
+    # EIO disk, a Windows file held open by an AV scanner. That OSError used to be swallowed and
+    # re-reported as "not found", which sends the user looking for a file that is right there.
+    # chmod cannot stage this (CI and containers run as root), so the read itself is faulted.
+    (tmp_path / "model_index.json").write_text('{"patch_size": 2}', encoding = "utf-8")
+    original = Path.read_text
+
+    def _deny(self, *args, **kwargs):
+        if self.name == "model_index.json":
+            raise PermissionError(errno.EACCES, "Permission denied")
+        return original(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", _deny)
+
+    with pytest.raises(ValueError, match = r"model_index\.json.*local model directory") as exc_info:
+        _load_model_index(str(tmp_path))
+
+    assert isinstance(exc_info.value.__cause__, PermissionError)
+
+
+def test_load_model_index_wraps_a_nesting_bomb(monkeypatch, tmp_path):
+    # Valid JSON, valid UTF-8, and neither guard above sees it: on a deep enough index the parser
+    # blows the stack first, and RecursionError is not a ValueError. The depth that triggers it is
+    # not portable -- 3.10-3.13 raise on ~50k nested objects, 3.14's scanner parses the same
+    # payload -- so the parser is faulted directly and the guard, not the interpreter, is asserted.
+    (tmp_path / "model_index.json").write_text('{"a": 1}', encoding = "utf-8")
+    monkeypatch.setattr(
+        json, "loads", lambda *args, **kwargs: (_ for _ in ()).throw(RecursionError("too deep"))
+    )
+
+    with pytest.raises(ValueError, match = r"model_index\.json.*local model directory") as exc_info:
+        _load_model_index(str(tmp_path))
+
+    assert isinstance(exc_info.value.__cause__, RecursionError)
 
 
 def test_load_model_index_missing_local_file(tmp_path):
@@ -179,6 +223,47 @@ def test_load_krea2_pipeline_threads_init_config(monkeypatch, tmp_path):
     prebuilt = SimpleNamespace(tag = "prebuilt")
     pipe = load_krea2_pipeline(str(tmp_path), "bf16", transformer = prebuilt)
     assert pipe.transformer is prebuilt
+
+
+def test_a_corrupt_index_is_rejected_before_any_component_is_built(monkeypatch, tmp_path):
+    """The index is a few KB and the components it configures are ~35 GB, so it has to be read
+    first. Read last, a clear message still costs a full load to reach, which is most of what the
+    opaque traceback cost in the first place."""
+    (tmp_path / "model_index.json").write_text('{"_class_name": "Krea2Pipe', encoding = "utf-8")
+
+    built: list = []
+
+    class _Records:
+        def __init__(self, tag):
+            self.tag = tag
+
+        def from_pretrained(self, repo_id, **kwargs):
+            built.append(self.tag)
+            return SimpleNamespace(tag = self.tag)
+
+    monkeypatch.setitem(
+        sys.modules,
+        "diffusers",
+        SimpleNamespace(
+            FlowMatchEulerDiscreteScheduler = _Records("scheduler"),
+            AutoencoderKLQwenImage = _Records("vae"),
+            Krea2Transformer2DModel = _Records("transformer"),
+            Krea2Pipeline = lambda **kwargs: SimpleNamespace(**kwargs),
+        ),
+    )
+    monkeypatch.setattr(
+        "core.inference.diffusion_krea2.load_krea2_tokenizer",
+        lambda repo_id, hf_token = None, local_files_only = False: built.append("tokenizer"),
+    )
+    monkeypatch.setattr(
+        "core.inference.diffusion_krea2.load_krea2_text_encoder",
+        lambda repo_id, dtype, hf_token = None, local_files_only = False: built.append("text_encoder"),
+    )
+
+    with pytest.raises(ValueError, match = r"model_index\.json"):
+        load_krea2_pipeline(str(tmp_path), "bf16")
+
+    assert built == []
 
 
 # ── registry / trust / int8 exclusion wiring ─────────────────────────────────

--- a/studio/backend/tests/test_health_answers_within_probe_budget.py
+++ b/studio/backend/tests/test_health_answers_within_probe_budget.py
@@ -560,9 +560,9 @@ def test_a_cold_health_call_answers_inside_the_launcher_deadline():
     probe_timeout = _desktop_probe_timeout_s()
     result = _probe(_SLOW_DETECT_S)
 
-    assert result["cold_hardware_detecting"] is True, (
-        "the cold call got a settled reply, so it never exercised the wait this bound is about"
-    )
+    assert (
+        result["cold_hardware_detecting"] is True
+    ), "the cold call got a settled reply, so it never exercised the wait this bound is about"
     assert result["cold_elapsed"] < probe_timeout, (
         f"the first /api/health call took {result['cold_elapsed']:.2f}s, past the "
         f"{probe_timeout}s the desktop probe allows before it gives up and dead-ends "


### PR DESCRIPTION
## Summary

- parse local and Hub/cache `model_index.json` files through one validated helper
- accept UTF-8 BOMs while surfacing I/O, decoding, and malformed JSON failures as contextual `ValueError`s with their original causes
- reject non-object JSON immediately while preserving the existing missing-local-file `FileNotFoundError`

## Tests

- `cd studio/backend && python -m pytest -q tests/test_diffusion_krea2.py` (14 passed, 1 skipped)
- `cd studio/backend && python -m pytest -q tests/test_media_family_assembler_offline.py -k krea` (6 passed, 17 deselected)
- `ruff check studio/backend/core/inference/diffusion_krea2.py studio/backend/tests/test_diffusion_krea2.py`
- `python -m py_compile studio/backend/core/inference/diffusion_krea2.py studio/backend/tests/test_diffusion_krea2.py`

Fixes #9749
