### PR TITLE
studio: show the train run preview as a column on a laptop window

### DIFF
--- a/studio/frontend/src/features/studio/studio-page.tsx
+++ b/studio/frontend/src/features/studio/studio-page.tsx
@@ -242,14 +242,15 @@ export function StudioPage(): ReactElement {
               <>
                 <TabsContent value="configure" className="mt-0">
                   <div className="@container/train-configure">
-                    <div className="grid grid-cols-1 gap-8 @5xl/train-configure:grid-cols-[minmax(0,1fr)_320px] @5xl/train-configure:gap-10">
+                    {/* 64rem only fit windows 1376px and wider; 56rem still clears @md/train-section */}
+                    <div className="grid grid-cols-1 gap-8 @4xl/train-configure:grid-cols-[minmax(0,1fr)_320px] @5xl/train-configure:gap-10">
                       <div className="min-w-0">
                         <TrainingWizard
                           paramMode={paramMode}
                           onParamModeChange={setParamMode}
                         />
                       </div>
-                      <div className="@5xl/train-configure:sticky @5xl/train-configure:top-6 @5xl/train-configure:self-start">
+                      <div className="@4xl/train-configure:sticky @4xl/train-configure:top-6 @4xl/train-configure:self-start">
                         <RunPreviewCard
                           paramMode={paramMode}
                           startCta={<StartTrainingCta />}

--- a/studio/frontend/tests/train-configure-preview-column.test.ts
+++ b/studio/frontend/tests/train-configure-preview-column.test.ts
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import { readFile, readdir } from "node:fs/promises";
+import { createRequire } from "node:module";
+import test from "node:test";
+
+import { SIDEBAR_WIDTH_DEFAULT } from "../src/hooks/use-sidebar-width.ts";
+
+// widest window that must still show both columns with the sidebar expanded; the 64rem tier shipped in #7633 needed 1376px
+const WINDOW_BUDGET_PX = 1280;
+
+// container queries resolve rem against the root font size, which studio leaves at the browser default
+const ROOT_FONT_PX = 16;
+
+const STUDIO_PAGE = new URL(
+  "../src/features/studio/studio-page.tsx",
+  import.meta.url,
+);
+const TRAINING_WIZARD = new URL(
+  "../src/features/studio/wizard/training-wizard.tsx",
+  import.meta.url,
+);
+const STUDIO_CSS = new URL("../src/index.css", import.meta.url);
+const WIZARD_DIR = new URL("../src/features/studio/wizard/", import.meta.url);
+const SECTIONS_DIR = new URL(
+  "../src/features/studio/sections/",
+  import.meta.url,
+);
+
+const CONTAINER_SCALE = /--container-([\w-]+):\s*([\d.]+)rem/g;
+const SPACING_SCALE = /--spacing:\s*([\d.]+)rem/;
+const CLASS_NAME = /className="([^"]+)"/g;
+const TWO_COLUMN_RULE =
+  /@([\w-]+)\/train-configure:grid-cols-\[minmax\(0,1fr\)_(\d+)px\]/;
+// arbitrary variants such as @min-[40rem] are captured too, so an unresolvable tier throws rather than dropping out of the budget
+const CONFIGURE_GAP = /@([^/\s"]+)\/train-configure:gap-([\d.]+)/g;
+const TRAIN_SECTION_TIER = /@([^/\s"]+)\/train-section:/g;
+const PAGE_MAX_WIDTH = /max-w-\[(\d+)px\]/;
+const PAGE_PADDING = /(?:^|\s)sm:px-(\d+)(?:\s|$)/;
+const CARD_BORDER = /\.elevated-card\s*\{[^}]*?border:\s*(\d+)px/;
+
+/** tailwind's own --container-* and --spacing scales, in px */
+async function tailwindScales(): Promise<{
+  containers: Map<string, number>;
+  spacing: number;
+}> {
+  const themePath = createRequire(import.meta.url).resolve(
+    "tailwindcss/theme.css",
+  );
+  const theme = await readFile(themePath, "utf8");
+  const containers = new Map<string, number>();
+  for (const [, name, rem] of theme.matchAll(CONTAINER_SCALE)) {
+    containers.set(name, Number(rem) * ROOT_FONT_PX);
+  }
+  const spacing = SPACING_SCALE.exec(theme);
+  if (!spacing) {
+    throw new Error("tailwind theme has no --spacing");
+  }
+  return { containers, spacing: Number(spacing[1]) * ROOT_FONT_PX };
+}
+
+/** the single className in source that contains marker */
+function classNameContaining(source: string, marker: string): string {
+  const found = [...source.matchAll(CLASS_NAME)]
+    .map((match) => match[1])
+    .filter((value) => value.includes(marker));
+  if (found.length !== 1) {
+    throw new Error(
+      `expected one className with ${marker}, got ${found.length}`,
+    );
+  }
+  return found[0];
+}
+
+/** a bare utility such as gap-8 or p-5, in spacing steps */
+function baseStep(className: string, utility: string): number {
+  const match = new RegExp(`(?:^|\\s)${utility}-(\\d+)(?:\\s|$)`).exec(
+    className,
+  );
+  if (!match) {
+    throw new Error(`no base ${utility}-* in "${className}"`);
+  }
+  return Number(match[1]);
+}
+
+/** narrowest @*\/train-section tier the wizard actually uses, in px */
+async function smallestTrainSectionTier(
+  containers: Map<string, number>,
+): Promise<number> {
+  const widths: number[] = [];
+  for (const dir of [WIZARD_DIR, SECTIONS_DIR]) {
+    for (const entry of await readdir(dir)) {
+      if (!entry.endsWith(".tsx")) {
+        continue;
+      }
+      const source = await readFile(new URL(entry, dir), "utf8");
+      for (const [, tier] of source.matchAll(TRAIN_SECTION_TIER)) {
+        const px = containers.get(tier);
+        if (px === undefined) {
+          throw new Error(
+            `unresolvable tier @${tier}/train-section in ${entry}`,
+          );
+        }
+        widths.push(px);
+      }
+    }
+  }
+  if (widths.length === 0) {
+    throw new Error("no train-section container queries found");
+  }
+  return Math.min(...widths);
+}
+
+test("the run preview column reaches a laptop window without dropping the wizard below @md/train-section", async () => {
+  const { containers, spacing } = await tailwindScales();
+  const page = await readFile(STUDIO_PAGE, "utf8");
+  const wizard = await readFile(TRAINING_WIZARD, "utf8");
+
+  // every tier below is inert unless the named containers are still declared
+  classNameContaining(page, "@container/train-configure");
+  classNameContaining(wizard, "@container/train-section");
+
+  const grid = classNameContaining(page, "grid-cols-[minmax(0,1fr)_");
+  const columns = TWO_COLUMN_RULE.exec(grid);
+  assert.ok(columns, "no train-configure two-column rule on the grid");
+  const [, tierName, previewTrack] = columns;
+
+  const thresholdPx = containers.get(tierName);
+  assert.ok(thresholdPx, `unknown container tier @${tierName}`);
+  const previewPx = Number(previewTrack);
+
+  // the preview only earns its sticky offset once it is a column, so both switch on the same tier
+  const sticky = classNameContaining(page, "/train-configure:sticky");
+  assert.match(
+    sticky,
+    new RegExp(`@${tierName}/train-configure:sticky`),
+    `preview sticks at a different tier than the ${tierName} column split`,
+  );
+
+  // gap at the narrowest two-column width: the base gap unless a variant at or below the split tier replaces it
+  let gapPx = baseStep(grid, "gap") * spacing;
+  let gapTierPx = 0;
+  for (const [, variantTier, step] of grid.matchAll(CONFIGURE_GAP)) {
+    const variantPx = containers.get(variantTier);
+    if (variantPx === undefined) {
+      throw new Error(
+        `unresolvable tier @${variantTier}/train-configure on the gap`,
+      );
+    }
+    if (variantPx <= thresholdPx && variantPx >= gapTierPx) {
+      gapPx = Number(step) * spacing;
+      gapTierPx = variantPx;
+    }
+  }
+
+  const wrapper = classNameContaining(page, "mx-auto");
+  const maxWidth = PAGE_MAX_WIDTH.exec(wrapper);
+  assert.ok(maxWidth, "page wrapper has no explicit max width");
+  const padding = PAGE_PADDING.exec(wrapper);
+  assert.ok(padding, "page wrapper has no sm:px-* padding");
+  const paddingPx = Number(padding[1]) * spacing;
+
+  // a threshold above the page's own width cap can never match, however wide the window gets
+  const widestContainerPx = Number(maxWidth[1]) - 2 * paddingPx;
+  assert.ok(
+    thresholdPx <= widestContainerPx,
+    `@${tierName} (${thresholdPx}px) never matches inside a ${widestContainerPx}px container`,
+  );
+
+  // the container is min(cap, window - sidebar) - padding, so the tier is really a window-width requirement
+  const windowPx = thresholdPx + 2 * paddingPx + SIDEBAR_WIDTH_DEFAULT;
+  assert.ok(
+    windowPx <= WINDOW_BUDGET_PX,
+    `two columns need a ${windowPx}px window, budget is ${WINDOW_BUDGET_PX}px`,
+  );
+
+  // and the wizard column still clears the narrowest tier its own sections use
+  const card = classNameContaining(wizard, "@container/train-card");
+  assert.ok(
+    card.includes("elevated-card"),
+    "the training card no longer uses elevated-card, so its border is unknown",
+  );
+  const css = await readFile(STUDIO_CSS, "utf8");
+  const border = CARD_BORDER.exec(css);
+  assert.ok(border, "elevated-card has no border width to subtract");
+  const cardInsetPx = (baseStep(card, "p") * spacing + Number(border[1])) * 2;
+  const wizardSectionPx = thresholdPx - gapPx - previewPx - cardInsetPx;
+  const smallestSectionTier = await smallestTrainSectionTier(containers);
+  assert.ok(
+    wizardSectionPx >= smallestSectionTier,
+    `wizard section gets ${wizardSectionPx}px, below the ${smallestSectionTier}px train-section tier`,
+  );
+});

--- a/studio/frontend/tests/train-configure-preview-column.test.ts
+++ b/studio/frontend/tests/train-configure-preview-column.test.ts
@@ -8,7 +8,7 @@ import test from "node:test";
 
 import { SIDEBAR_WIDTH_DEFAULT } from "../src/hooks/use-sidebar-width.ts";
 
-// widest window that must still show both columns with the sidebar expanded; the 64rem tier shipped in #7633 needed 1376px
+// widest window that must still show both columns with the sidebar expanded; the previous 64rem tier needed 1376px
 const WINDOW_BUDGET_PX = 1280;
 
 // container queries resolve rem against the root font size, which studio leaves at the browser default
@@ -85,7 +85,7 @@ function baseStep(className: string, utility: string): number {
   return Number(match[1]);
 }
 
-/** narrowest @*\/train-section tier the wizard actually uses, in px */
+/** narrowest @*\/train-section tier in top-level wizard and section files, in px */
 async function smallestTrainSectionTier(
   containers: Map<string, number>,
 ): Promise<number> {


### PR DESCRIPTION
The Run preview card on Train > Configure, and the Start training button inside it, only become a second column when the `train-configure` container query matches. That container is the page wrapper in `studio/frontend/src/features/studio/studio-page.tsx`:

```
mx-auto flex w-full max-w-[1180px] ... px-5 ... sm:px-9
```

so its width is `min(1180, window - sidebar) - 72`, and `SIDEBAR_WIDTH_DEFAULT` in `studio/frontend/src/hooks/use-sidebar-width.ts` is 280. The `@5xl` tier added in #7633 is 64rem, which turns into a 1376px window requirement. Below that the card dropped out of the grid and rendered as a full-width row under the wizard, which is what happens on every laptop-sized window: `MINIMUM_APP_WINDOW_SIZE` is 900px wide and a first run opens at 75% of the work area, so a 1440px display gets a 1080px window and never showed the column at all.

## What changed

`studio-page.tsx` moves the two-column grid and the preview card's sticky positioning down to `@4xl/train-configure` (56rem) from `@5xl` (64rem). `@5xl/train-configure:gap-10` stays where it is, so the gap is 32px in the new band and widens to 40px once there is room for it.

56rem is the narrowest tier that still leaves the wizard column above its own `@md/train-section` threshold. At 896px of container the wizard track is 544px, and after the training card's `p-5` and 1px border its `@container/train-section` is 502px against the 448px that tier needs, so the model/method/token row stays two across rather than collapsing to buy the preview its 320px.

Measured in Chromium against CSS compiled from the edited class strings by the repo's own Tailwind 4.2.4:

| sidebar | before | after |
| --- | --- | --- |
| 280px, expanded | two columns from a 1376px window | from 1248px |
| 3rem rail, collapsed | from 1144px | from 1016px |

## Screenshots

Two isolated Studio installs, one at `55213845e` and one at this branch, driven through Train > Configure at 1280x900. Both sides report the same 280px sidebar and the same 928px container, so the only variable is the tier.

Top of the tab. The wizard gives up its full width for the preview column:

![before and after, top of Configure](https://raw.githubusercontent.com/mahiatlinux/unsloth/pr-assets-studio-train-preview-column/train-preview-column-top.png)

Scrolled to the Run preview card. Before, it sits below Configuration as a full-width row; after, it is pinned beside the wizard:

![before and after, the Run preview card](https://raw.githubusercontent.com/mahiatlinux/unsloth/pr-assets-studio-train-preview-column/train-preview-column-card.png)

Geometry read from the same servers that were photographed, `data-tour="studio-dataset"` against `data-tour="studio-start"`:

| | before | after |
| --- | --- | --- |
| wizard card | 928px wide, x 316-1244 | 576px wide, x 316-892 |
| Start training | 878px wide, x 341-1219 | 270px wide, x 949-1219 |
| Start top minus wizard bottom | +919px | -215px |
| layout | stacked | two-column |

## Regression test

`studio/frontend/tests/train-configure-preview-column.test.ts` reads the tier, the 320px preview track, the gaps, the page padding and `SIDEBAR_WIDTH_DEFAULT` out of the source, and the `--container-*` and `--spacing` scales out of the resolved `tailwindcss/theme.css`, then holds both ends of the corridor:

- the tier must be reachable inside the page's own max width
- two columns must need no more than a 1280px window with the sidebar expanded
- the wizard column must still clear `@md/train-section`, the narrowest tier the wizard's own sections use

It also pins the sticky offset to the same tier as the column split, so the preview cannot scroll away inside its own track, and checks that `@container/train-configure` and `@container/train-section` are still declared, since every tier it reads is inert without them.

Mutation-checked, restoring the source afterwards:

| mutation | failure |
| --- | --- |
| tier back to `@5xl` | `two columns need a 1376px window, budget is 1280px` |
| tier down to `@2xl` | `wizard section gets 278px, below the 448px train-section tier` |
| sticky tier desynced | `preview sticks at a different tier than the 4xl column split` |
| named container deleted or renamed | `expected one className with @container/train-configure, got 0` |
| preview track to 480px | `wizard section gets 342px, below the 448px train-section tier` |
| a section tier rewritten as `@min-[40rem]` | `unresolvable tier @min-[40rem]/train-section in params-section.tsx` |

## Checks

- `npm test` in `studio/frontend`: 5138 pass, 0 fail
- `npx tsc -b` and `npx tsc -p tsconfig.test.json`: clean
- `npx biome check`: `studio-page.tsx` reports the same two diagnostics as its parent commit; the new test file reports only the `noNodejsModules` warnings every test in that directory produces
- two Studio installs built from the two trees, driven at 1280x900, screenshots and geometry above
- no Python touched, so ruff and pytest do not apply; no training was run, so no GPU checks apply
