### PR TITLE
Remove duplicate TRL vLLM generation patch

### DIFF
--- a/unsloth/models/rl.py
+++ b/unsloth/models/rl.py
@@ -4329,16 +4329,6 @@ def patch_trl_vllm_generation():
     return
 
 
-def patch_trl_vllm_generation():
-    # trl moved vllm stuff to trl/generation/vllm_generation.py
-    # We need to min_p patch it to not instantiate another vLLM instance if we already have one with fast_inference
-    # Find the instance of self.llm = LLM(..) (multiline) and wrap it around an if clause
-    for function in RL_ADDITIONAL_FUNCTIONS["vllm_generation"]:
-        logger.info(f"Unsloth: Patching trl VLLMGeneration with function: {function.__name__}")
-        function()
-    return
-
-
 def PatchFastRL(algorithm = None, FastLanguageModel = None):
     if FastLanguageModel is not None:
         PatchRL(FastLanguageModel)


### PR DESCRIPTION
## Summary

- remove the duplicate `patch_trl_vllm_generation` definition. The two copies were
  byte-identical, so behaviour is unchanged either way
- Python binds the later `def`, so `rl.py:4332` was the live one and 4322 was already dead.
  This deletes 4332 and keeps 4322
- the `PatchFastRL` call site is unchanged

## Tests

- `python scripts/lint_duplicate_definitions.py unsloth/models/rl.py`
- `python -m pytest -q --tb=short tests/test_lint_duplicate_definitions.py`
- `python -m compileall -q unsloth/models/rl.py`
- `ruff check unsloth/models/rl.py`

Fixes #9747
