### PR TITLE
Prevent stale hydration from overwriting remembered model settings

### DIFF
--- a/studio/frontend/src/features/model-picker/components/model-config-page.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-config-page.tsx
@@ -2096,15 +2096,6 @@ export function ModelConfigPage({
     // rewrite live input: typing --agent during the window cleared the box instead
     // of showing the error, and a long paste could be trimmed behind the cursor.
     const configAtStart = configRef.current;
-    // What STORAGE holds for this model, which is not always what the panel shows:
-    // an active model seeds the panel from loadedConfig, the config the resident
-    // model is running with. The hydrated record is written against this instead,
-    // or opening the panel replaces settings the user never touched here -- a legacy
-    // config just migrated in, one saved from another origin -- with the runtime.
-    const storedAtStart = resolveInitialConfig(
-      configId,
-      target.ggufVariant,
-    ).config;
     const rememberAtStart = rememberRef.current;
     const localAtStart = configAtStart.llamaExtraArgs;
     // The denylist, not the catalogue: sanitizing a stored list needs only the flags
@@ -2245,9 +2236,10 @@ export function ModelConfigPage({
           if (hasNonDefaultAdvanced(serverConfig)) {
             setAutoOpenAdvanced(true);
           }
-          // Onto the stored record, not the shown one: see storedAtStart. The row
-          // outranks both, so the shared settings still land in local storage for
-          // the load paths that never open this panel.
+          // Onto the current stored record, not the shown one: an active model seeds
+          // the panel from loadedConfig, and another tab can save while hydration is
+          // in flight. The row outranks both, so the shared settings still land in
+          // local storage for the load paths that never open this panel.
           //
           // Unconditionally, because savePerModelConfig says "no settings" by
           // DELETING the entry: a merge that comes out default is a clear that has
@@ -2256,7 +2248,11 @@ export function ModelConfigPage({
           // case, and skipping it stranded the old flag here for model-selector's
           // quick select to reload without ever opening this panel. Writing when
           // no record exists is already a no-op.
-          const rememberedConfig = fromApiOverride(resolvedRow, storedAtStart);
+          const storedConfig = resolveInitialConfig(
+            configId,
+            target.ggufVariant,
+          ).config;
+          const rememberedConfig = fromApiOverride(resolvedRow, storedConfig);
           // Same budget as any other write, so the same clean-up: eviction is silent
           // and still reports success, and a dropped model would keep applying its
           // server row to API loads while the picker showed defaults, with nothing

--- a/studio/frontend/src/features/model-picker/components/model-config-page.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-config-page.tsx
@@ -118,6 +118,7 @@ import {
   isServedByMlx,
   normalizeMaxSeqLength,
   normalizePerModelConfig,
+  perModelConfigStorageChanged,
   readAdvancedSettingsOpen,
   resolveInitialConfig,
   saveAdvancedSettingsOpen,
@@ -2096,6 +2097,7 @@ export function ModelConfigPage({
     // rewrite live input: typing --agent during the window cleared the box instead
     // of showing the error, and a long paste could be trimmed behind the cursor.
     const configAtStart = configRef.current;
+    const storedAtStart = resolveInitialConfig(configId, target.ggufVariant);
     const rememberAtStart = rememberRef.current;
     const localAtStart = configAtStart.llamaExtraArgs;
     // The denylist, not the catalogue: sanitizing a stored list needs only the flags
@@ -2229,6 +2231,13 @@ export function ModelConfigPage({
           configRef.current === configAtStart &&
           rememberRef.current === rememberAtStart
         ) {
+          const storedConfig = resolveInitialConfig(
+            configId,
+            target.ggufVariant,
+          );
+          if (perModelConfigStorageChanged(storedAtStart, storedConfig)) {
+            return;
+          }
           setExtraArgsLoadable(hydratedIsLoadable);
           setConfig(serverConfig);
           setRemember(true);
@@ -2236,11 +2245,6 @@ export function ModelConfigPage({
           if (hasNonDefaultAdvanced(serverConfig)) {
             setAutoOpenAdvanced(true);
           }
-          // Onto the current stored record, not the shown one: an active model seeds
-          // the panel from loadedConfig, and another tab can save while hydration is
-          // in flight. The row outranks both, so the shared settings still land in
-          // local storage for the load paths that never open this panel.
-          //
           // Unconditionally, because savePerModelConfig says "no settings" by
           // DELETING the entry: a merge that comes out default is a clear that has
           // to travel, not a write to skip. Clearing a model's only remembered
@@ -2248,11 +2252,10 @@ export function ModelConfigPage({
           // case, and skipping it stranded the old flag here for model-selector's
           // quick select to reload without ever opening this panel. Writing when
           // no record exists is already a no-op.
-          const storedConfig = resolveInitialConfig(
-            configId,
-            target.ggufVariant,
-          ).config;
-          const rememberedConfig = fromApiOverride(resolvedRow, storedConfig);
+          const rememberedConfig = fromApiOverride(
+            resolvedRow,
+            storedConfig.config,
+          );
           // Same budget as any other write, so the same clean-up: eviction is silent
           // and still reports success, and a dropped model would keep applying its
           // server row to API loads while the picker showed defaults, with nothing

--- a/studio/frontend/src/features/model-picker/model-config/per-model-config.ts
+++ b/studio/frontend/src/features/model-picker/model-config/per-model-config.ts
@@ -1179,10 +1179,26 @@ export function adoptLegacyConfigKey(
   return writeMap(map);
 }
 
+export interface ResolvedPerModelConfig {
+  config: PerModelConfig;
+  remembered: boolean;
+}
+
+export function perModelConfigStorageChanged(
+  atStart: ResolvedPerModelConfig,
+  current: ResolvedPerModelConfig,
+): boolean {
+  return (
+    atStart.remembered !== current.remembered ||
+    JSON.stringify(toStoredConfig(atStart.config)) !==
+      JSON.stringify(toStoredConfig(current.config))
+  );
+}
+
 export function resolveInitialConfig(
   modelId: string,
   ggufVariant?: string | null,
-): { config: PerModelConfig; remembered: boolean } {
+): ResolvedPerModelConfig {
   const saved = loadPerModelConfig(modelId, ggufVariant);
   if (saved) {
     return { config: saved, remembered: true };
@@ -1202,7 +1218,7 @@ export function resolveInitialConfig(
 export function resolveResidentInitialConfig(
   modelId: string,
   ggufVariant?: string | null,
-): { config: PerModelConfig; remembered: boolean } {
+): ResolvedPerModelConfig {
   const direct = resolveInitialConfig(modelId, ggufVariant);
   if (direct.remembered) {
     return direct;

--- a/studio/frontend/tests/llama-extra-args-panel-hydration.test.ts
+++ b/studio/frontend/tests/llama-extra-args-panel-hydration.test.ts
@@ -177,18 +177,6 @@ test("the panel adopts a shared server config without overwriting a live edit", 
     PANEL,
     /sanitizedLocal = cleaned\.length > 0 \? cleaned : null;/,
   );
-  // What it WRITES is merged onto the stored record instead. An active model seeds
-  // the panel from loadedConfig, so persisting the shown config replaced remembered
-  // settings this browser never touched (a just-migrated legacy config among them)
-  // with whatever the resident model is running.
-  assert.match(
-    PANEL,
-    /const storedAtStart = resolveInitialConfig\(\s*\n?\s*configId,\s*\n?\s*target\.ggufVariant,\s*\n?\s*\)\.config;/,
-  );
-  assert.match(
-    PANEL,
-    /const rememberedConfig = fromApiOverride\(resolvedRow, storedAtStart\);/,
-  );
   // Whitespace-tolerant: the call carries an eviction list now, so it spans lines.
   assert.match(
     PANEL,
@@ -199,6 +187,39 @@ test("the panel adopts a shared server config without overwriting a live edit", 
   assert.match(PANEL, /setConfig\(serverConfig\);/);
   assert.match(PANEL, /setRemember\(true\);/);
   assert.match(PANEL, /setSavedRemember\(true\);/);
+});
+
+test("the hydration write-back merges against current storage", () => {
+  const requestStart = PANEL.indexOf("Promise.all([");
+  const responseStart = PANEL.indexOf(
+    ".then(([resolvedOverride, managed]) => {",
+    requestStart,
+  );
+  const adoptionStart = PANEL.indexOf(
+    "if (\n          resolvedRow &&",
+    responseStart,
+  );
+  const writeBackEnd = PANEL.indexOf(
+    "setSavedRemember(hydrationSaved);",
+    adoptionStart,
+  );
+  assert.ok(
+    requestStart >= 0 &&
+      responseStart > requestStart &&
+      adoptionStart > responseStart &&
+      writeBackEnd > adoptionStart,
+    "the storage read must be inside the successful hydration write-back",
+  );
+
+  const beforeResponse = PANEL.slice(requestStart, responseStart);
+  assert.doesNotMatch(beforeResponse, /resolveInitialConfig\(/);
+  assert.doesNotMatch(PANEL, /storedAtStart/);
+
+  const writeBack = PANEL.slice(adoptionStart, writeBackEnd);
+  assert.match(
+    writeBack,
+    /const storedConfig = resolveInitialConfig\(\s*configId,\s*target\.ggufVariant,\s*\)\.config;\s*const rememberedConfig = fromApiOverride\(resolvedRow, storedConfig\);[\s\S]*savePerModelConfig\(\s*configId,\s*target\.ggufVariant,\s*rememberedConfig,/,
+  );
 });
 
 test("a build that serves one slot does not raise the floor", () => {

--- a/studio/frontend/tests/llama-extra-args-panel-hydration.test.ts
+++ b/studio/frontend/tests/llama-extra-args-panel-hydration.test.ts
@@ -12,6 +12,24 @@ import path from "node:path";
 import { test } from "node:test";
 import { fileURLToPath } from "node:url";
 
+import {
+  installLocalStorageFake,
+  registerBundlerResolver,
+} from "./helpers/kit.ts";
+
+registerBundlerResolver();
+installLocalStorageFake();
+
+const {
+  DEFAULT_PER_MODEL_CONFIG,
+  deletePerModelConfig,
+  perModelConfigStorageChanged,
+  resolveInitialConfig,
+  savePerModelConfig,
+} = await import(
+  "../src/features/model-picker/model-config/per-model-config.ts"
+);
+
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const PANEL = readFileSync(
   path.join(
@@ -189,8 +207,53 @@ test("the panel adopts a shared server config without overwriting a live edit", 
   assert.match(PANEL, /setSavedRemember\(true\);/);
 });
 
-test("the hydration write-back merges against current storage", () => {
+test("hydration detects a newer save or forget", () => {
+  const modelId = "unsloth/Hydration-Race-GGUF";
+  const variant = "Q4_K_M";
+  assert.ok(
+    savePerModelConfig(modelId, variant, {
+      ...DEFAULT_PER_MODEL_CONFIG,
+      customContextLength: 2048,
+    }),
+  );
+  const atStart = resolveInitialConfig(modelId, variant);
+
+  assert.ok(
+    savePerModelConfig(modelId, variant, {
+      ...DEFAULT_PER_MODEL_CONFIG,
+      customContextLength: 4096,
+    }),
+  );
+  assert.equal(
+    perModelConfigStorageChanged(
+      atStart,
+      resolveInitialConfig(modelId, variant),
+    ),
+    true,
+  );
+
+  assert.ok(deletePerModelConfig(modelId, variant));
+  assert.equal(
+    perModelConfigStorageChanged(
+      atStart,
+      resolveInitialConfig(modelId, variant),
+    ),
+    true,
+  );
+  assert.equal(
+    perModelConfigStorageChanged(atStart, {
+      config: { ...atStart.config },
+      remembered: atStart.remembered,
+    }),
+    false,
+  );
+});
+
+test("the hydration write-back rejects a stale server response", () => {
   const requestStart = PANEL.indexOf("Promise.all([");
+  const storageSnapshot = PANEL.indexOf(
+    "const storedAtStart = resolveInitialConfig(configId, target.ggufVariant);",
+  );
   const responseStart = PANEL.indexOf(
     ".then(([resolvedOverride, managed]) => {",
     requestStart,
@@ -205,20 +268,18 @@ test("the hydration write-back merges against current storage", () => {
   );
   assert.ok(
     requestStart >= 0 &&
+      storageSnapshot >= 0 &&
+      storageSnapshot < requestStart &&
       responseStart > requestStart &&
       adoptionStart > responseStart &&
       writeBackEnd > adoptionStart,
-    "the storage read must be inside the successful hydration write-back",
+    "the storage snapshot must precede the request and guard its write-back",
   );
-
-  const beforeResponse = PANEL.slice(requestStart, responseStart);
-  assert.doesNotMatch(beforeResponse, /resolveInitialConfig\(/);
-  assert.doesNotMatch(PANEL, /storedAtStart/);
 
   const writeBack = PANEL.slice(adoptionStart, writeBackEnd);
   assert.match(
     writeBack,
-    /const storedConfig = resolveInitialConfig\(\s*configId,\s*target\.ggufVariant,\s*\)\.config;\s*const rememberedConfig = fromApiOverride\(resolvedRow, storedConfig\);[\s\S]*savePerModelConfig\(\s*configId,\s*target\.ggufVariant,\s*rememberedConfig,/,
+    /const storedConfig = resolveInitialConfig\(\s*configId,\s*target\.ggufVariant,\s*\);\s*if \(perModelConfigStorageChanged\(storedAtStart, storedConfig\)\) \{\s*return;\s*\}[\s\S]*const rememberedConfig = fromApiOverride\(\s*resolvedRow,\s*storedConfig\.config,\s*\);[\s\S]*savePerModelConfig\(\s*configId,\s*target\.ggufVariant,\s*rememberedConfig,/,
   );
 });
 


### PR DESCRIPTION
## Summary

- re-read the current per-model config after asynchronous hydration resolves
- merge the resolved server row onto that current config before the unconditional write-back
- add a focused hydration source contract covering read order and removal of the effect-start snapshot

## Tests

- `node --experimental-strip-types --test tests/llama-extra-args-panel-hydration.test.ts` (18 passed)
- related model-config and persistence tests (99 passed)
- `npm run typecheck`
- full frontend suite: 5140 passed; 3 known local failures because installed `remend` is 1.3.0 while the project pins 1.3.1

Fixes #9604