### PR TITLE
Studio: stop the temporary toggle tagging a saved app-created chat

### DIFF
--- a/studio/frontend/src/features/chat/runtime-provider.tsx
+++ b/studio/frontend/src/features/chat/runtime-provider.tsx
@@ -724,18 +724,11 @@ export async function ensureThreadRecord({
   const incognitoAtInit = incognito ?? runtimeStateAtInit.incognito;
   const modelIdAtInit = modelId ?? runtimeStateAtInit.params.checkpoint ?? "";
   const createdAtInit = createdAt ?? Date.now();
-  // A temporary chat can skip the history list entirely so a storage outage cannot block
-  // the first send. Only initialize() can take that shortcut, because only initialize()
-  // knows the thread has never been sent to.
-  //
-  // This used to test `isAssistantLocalThreadId(threadId)` for the same thing, on the
-  // assumption that a `__LOCALID_` id meant a fresh thread. It does not: the id assistant-ui
-  // mints is returned as the row's remoteId and stays its primary key for good. So with the
-  // toggle on, any caller passing the OPEN chat's id tagged that saved chat incognito for the
-  // rest of the session -- openai-code-exec-section calls this three times with
-  // activeThreadId and no incognito argument, so it reads the live toggle. A tagged chat
-  // stops persisting, and once per-chat settings and fork counts consult isThreadIncognito
-  // it silently loses those too.
+  // A temporary chat skips the history list so a storage outage cannot block its first send.
+  // Gated on the caller knowing the thread is new, not on its id: a `__LOCALID_` id is the
+  // permanent primary key of every chat the app creates, so testing the prefix here tagged
+  // SAVED chats incognito whenever the toggle was on and a caller passed the open chat's id
+  // (openai-code-exec-section does, three times). A tagged chat stops persisting.
   if (incognitoAtInit && neverSent) {
     markThreadIncognito(threadId);
     return;
@@ -745,9 +738,8 @@ export async function ensureThreadRecord({
   if (existing) {
     return;
   }
-  // Keep the existing check first so an already-persisted thread is never tagged --
-  // that's what keeps a real thread saving normally even if the toggle flips on while
-  // its run is still streaming.
+  // After the row check, so an already-persisted thread is never tagged: that is what keeps
+  // a real chat saving normally when the toggle flips on mid-stream.
   if (incognitoAtInit) {
     markThreadIncognito(threadId);
     return;
@@ -853,9 +845,8 @@ function createStudioDbAdapter(
           pairId,
           projectId: projectIdAtInit,
           incognito: incognitoAtInit,
-          // assistant-ui runs initialize() once, for the thread it has just minted, so this
-          // is the one caller that can promise the chat has never been sent to. Every other
-          // caller hands in whatever chat is open, which may well be saved.
+          // The one caller that can promise this: assistant-ui runs initialize() once, for
+          // the id it just minted. Others hand in whatever chat is open.
           neverSent: true,
           modelId: modelIdAtInit,
           createdAt: createdAtInit,

--- a/studio/frontend/src/features/chat/runtime-provider.tsx
+++ b/studio/frontend/src/features/chat/runtime-provider.tsx
@@ -726,9 +726,8 @@ export async function ensureThreadRecord({
   const createdAtInit = createdAt ?? Date.now();
   // A temporary chat skips the history list so a storage outage cannot block its first send.
   // Gated on the caller knowing the thread is new, not on its id: a `__LOCALID_` id is the
-  // permanent primary key of every chat the app creates, so testing the prefix here tagged
-  // SAVED chats incognito whenever the toggle was on and a caller passed the open chat's id
-  // (openai-code-exec-section does, three times). A tagged chat stops persisting.
+  // permanent key of every chat the app creates, so keying on the prefix tagged SAVED chats
+  // incognito whenever a caller passed the open chat's id with the toggle on.
   if (incognitoAtInit && neverSent) {
     markThreadIncognito(threadId);
     return;

--- a/studio/frontend/src/features/chat/runtime-provider.tsx
+++ b/studio/frontend/src/features/chat/runtime-provider.tsx
@@ -697,6 +697,7 @@ export async function ensureThreadRecord({
   pairId,
   projectId,
   incognito,
+  neverSent,
   modelId,
   createdAt,
 }: {
@@ -706,6 +707,8 @@ export async function ensureThreadRecord({
   projectId?: string | null;
   /** Snapshot from the send this row belongs to, so a retry cannot read a since-flipped toggle. */
   incognito?: boolean;
+  /** True only from initialize(), which runs once for a thread that has never been sent to. */
+  neverSent?: boolean;
   /** Snapshot from the send this row belongs to, so retries cannot adopt a later checkpoint. */
   modelId?: string;
   /** Snapshot from the send this row belongs to, so retries retain its original creation time. */
@@ -721,9 +724,19 @@ export async function ensureThreadRecord({
   const incognitoAtInit = incognito ?? runtimeStateAtInit.incognito;
   const modelIdAtInit = modelId ?? runtimeStateAtInit.params.checkpoint ?? "";
   const createdAtInit = createdAt ?? Date.now();
-  // Fresh assistant-ui threads are local ids. Temporary chats can skip the
-  // history list entirely so a storage outage cannot block the first send.
-  if (incognitoAtInit && isAssistantLocalThreadId(threadId)) {
+  // A temporary chat can skip the history list entirely so a storage outage cannot block
+  // the first send. Only initialize() can take that shortcut, because only initialize()
+  // knows the thread has never been sent to.
+  //
+  // This used to test `isAssistantLocalThreadId(threadId)` for the same thing, on the
+  // assumption that a `__LOCALID_` id meant a fresh thread. It does not: the id assistant-ui
+  // mints is returned as the row's remoteId and stays its primary key for good. So with the
+  // toggle on, any caller passing the OPEN chat's id tagged that saved chat incognito for the
+  // rest of the session -- openai-code-exec-section calls this three times with
+  // activeThreadId and no incognito argument, so it reads the live toggle. A tagged chat
+  // stops persisting, and once per-chat settings and fork counts consult isThreadIncognito
+  // it silently loses those too.
+  if (incognitoAtInit && neverSent) {
     markThreadIncognito(threadId);
     return;
   }
@@ -732,9 +745,9 @@ export async function ensureThreadRecord({
   if (existing) {
     return;
   }
-  // For non-local ids, keep the existing check first so an already-persisted
-  // thread is never tagged -- that's what keeps a real thread saving normally
-  // even if the toggle flips on while its run is still streaming.
+  // Keep the existing check first so an already-persisted thread is never tagged --
+  // that's what keeps a real thread saving normally even if the toggle flips on while
+  // its run is still streaming.
   if (incognitoAtInit) {
     markThreadIncognito(threadId);
     return;
@@ -840,6 +853,10 @@ function createStudioDbAdapter(
           pairId,
           projectId: projectIdAtInit,
           incognito: incognitoAtInit,
+          // assistant-ui runs initialize() once, for the thread it has just minted, so this
+          // is the one caller that can promise the chat has never been sent to. Every other
+          // caller hands in whatever chat is open, which may well be saved.
+          neverSent: true,
           modelId: modelIdAtInit,
           createdAt: createdAtInit,
         }),

--- a/studio/frontend/tests/incognito-tagging-invariants.test.ts
+++ b/studio/frontend/tests/incognito-tagging-invariants.test.ts
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// ensureThreadRecord's incognito shortcut skips the history list so a storage outage
+// cannot block a temporary chat's first send. It used to take that shortcut for any
+// `__LOCALID_` id, on the assumption that the prefix meant "fresh thread".
+//
+// It does not. The prefix is the permanent primary key of every chat the app creates, so
+// with the temporary toggle on, a caller passing the OPEN chat's id tagged that SAVED
+// chat incognito for the rest of the session. openai-code-exec-section does exactly that,
+// three times, with activeThreadId. A tagged chat stops persisting, and since per-chat
+// settings and fork counts both consult isThreadIncognito, it silently loses those too.
+//
+// Structural, like thread-scoped-pairing-invariants.test.ts: runtime-provider.tsx cannot
+// be loaded under stubs, so what is pinned here is the shape of the decision.
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const provider = readFileSync(
+  new URL("../src/features/chat/runtime-provider.tsx", import.meta.url),
+  "utf8",
+);
+
+/** ensureThreadRecord's body, code only. */
+function ensureThreadRecordBody(): string {
+  const start = provider.indexOf("export async function ensureThreadRecord({");
+  assert.ok(start > 0, "ensureThreadRecord not found");
+  const end = provider.indexOf("const record: ThreadRecord = {", start);
+  assert.ok(end > start, "end of ensureThreadRecord's guards not found");
+  return provider
+    .slice(start, end)
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/^[ \t]*\/\/.*$/gm, "");
+}
+
+test("the incognito shortcut is gated on the thread being new, not on its id", () => {
+  const body = ensureThreadRecordBody();
+
+  assert.match(
+    body,
+    /if \(incognitoAtInit && neverSent\) \{/,
+    "the shortcut must ask whether the thread has ever been sent to",
+  );
+  assert.doesNotMatch(
+    body,
+    /isAssistantLocalThreadId/,
+    "a `__LOCALID_` prefix says nothing about whether a row exists: every chat the app " +
+      "creates keeps that id after it is saved",
+  );
+});
+
+test("only initialize() claims a thread has never been sent to", () => {
+  // assistant-ui calls initialize() once, for the id it has just minted. Every other
+  // caller hands in whatever chat is open, which may well be saved, so none of them may
+  // pass this flag.
+  const claims = provider.match(/neverSent: true/g) ?? [];
+  assert.equal(
+    claims.length,
+    1,
+    `neverSent: true is claimed ${claims.length} times; only initialize() may claim it`,
+  );
+
+  const initialize = provider.slice(
+    provider.indexOf("initialize(threadId: string) {"),
+    provider.indexOf("adoptDefaultThreadRun"),
+  );
+  assert.match(initialize, /neverSent: true/);
+});
+
+test("a saved chat still reaches the existing-row check before it can be tagged", () => {
+  // The ordering that keeps a real chat saving normally even if the toggle flips on
+  // mid-stream. Without it, the tag is unconditional for anything the shortcut misses.
+  const body = ensureThreadRecordBody();
+  const shortcut = body.indexOf("incognitoAtInit && neverSent");
+  const lookup = body.indexOf("await getStoredChatThread(threadId)");
+  const lateTag = body.lastIndexOf("if (incognitoAtInit)");
+
+  assert.ok(shortcut > 0 && lookup > shortcut, "the row lookup must follow the shortcut");
+  assert.ok(
+    lateTag > lookup,
+    "every path that did not take the shortcut must consult the stored row first",
+  );
+});

--- a/studio/frontend/tests/incognito-tagging-invariants.test.ts
+++ b/studio/frontend/tests/incognito-tagging-invariants.test.ts
@@ -1,18 +1,14 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-// ensureThreadRecord's incognito shortcut skips the history list so a storage outage
-// cannot block a temporary chat's first send. It used to take that shortcut for any
-// `__LOCALID_` id, on the assumption that the prefix meant "fresh thread".
+// ensureThreadRecord's incognito shortcut used to key on a `__LOCALID_` id, which is the
+// permanent primary key of every chat the app creates, not a "fresh thread" marker. With the
+// toggle on, a caller passing the OPEN chat's id therefore tagged that SAVED chat incognito
+// for the session, and a tagged chat stops persisting, loses its settings snapshot and loses
+// its fork badge.
 //
-// It does not. The prefix is the permanent primary key of every chat the app creates, so
-// with the temporary toggle on, a caller passing the OPEN chat's id tagged that SAVED
-// chat incognito for the rest of the session. openai-code-exec-section does exactly that,
-// three times, with activeThreadId. A tagged chat stops persisting, and since per-chat
-// settings and fork counts both consult isThreadIncognito, it silently loses those too.
-//
-// Structural, like thread-scoped-pairing-invariants.test.ts: runtime-provider.tsx cannot
-// be loaded under stubs, so what is pinned here is the shape of the decision.
+// Structural, like thread-scoped-pairing-invariants.test.ts: runtime-provider.tsx cannot be
+// loaded under stubs, so what is pinned here is the shape of the decision.
 
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
@@ -52,9 +48,7 @@ test("the incognito shortcut is gated on the thread being new, not on its id", (
 });
 
 test("only initialize() claims a thread has never been sent to", () => {
-  // assistant-ui calls initialize() once, for the id it has just minted. Every other
-  // caller hands in whatever chat is open, which may well be saved, so none of them may
-  // pass this flag.
+  // Every other caller hands in whatever chat is open, which may well be saved.
   const claims = provider.match(/neverSent: true/g) ?? [];
   assert.equal(
     claims.length,
@@ -70,8 +64,7 @@ test("only initialize() claims a thread has never been sent to", () => {
 });
 
 test("a saved chat still reaches the existing-row check before it can be tagged", () => {
-  // The ordering that keeps a real chat saving normally even if the toggle flips on
-  // mid-stream. Without it, the tag is unconditional for anything the shortcut misses.
+  // Without this ordering the tag is unconditional for anything the shortcut misses.
   const body = ensureThreadRecordBody();
   const shortcut = body.indexOf("incognitoAtInit && neverSent");
   const lookup = body.indexOf("await getStoredChatThread(threadId)");


### PR DESCRIPTION
`ensureThreadRecord` takes a shortcut for a temporary chat, skipping the history list so a storage outage cannot block its first send. It picks that path with `isAssistantLocalThreadId`, reading a `__LOCALID_` id as "fresh thread".

That id is not a fresh-thread marker. `initialize()` returns it unchanged as the row's `remoteId`, so it stays the primary key of every chat the app creates, saved ones included. With the temporary toggle on, any caller that passes the **open** chat's id therefore tags that saved chat incognito for the rest of the session, and a tagged chat stops persisting. `openai-code-exec-section.tsx` calls this three times with `activeThreadId` and no `incognito` argument, so it reads the live toggle.

The fix gates the shortcut on the caller knowing the thread has never been sent to. Only `initialize()` can know that: assistant-ui runs it once, for the id it has just minted. Every other caller falls through to the existing-row check first, which is the ordering that already kept a real chat saving normally when the toggle flipped mid-stream. The outage resilience the shortcut exists for is unchanged, because the first send is exactly the `initialize()` case.

### Why now

Worth landing before #9639 rather than after. That PR makes per-chat settings and fork counts consult `isThreadIncognito`, so from then on this mis-tag also costs the chat its settings snapshot and its fork badge, with no error and nothing on screen to explain it.

I found this while reviewing #9639 and first pushed it there. Backed it out again: main has since rewritten that file's import block, and on top of that branch the fix removes a now-unused import from it, which turns a cleanly mergeable PR into a conflicted one over one line. On main the import is still used elsewhere, so here it touches no import block and merges clean.

### Checks

Typecheck passes. Frontend suite 5142/5145; the three failures are markdown/Streamdown tests that fail identically on unmodified main on this machine. New test pins the shape of the decision: the shortcut asks whether the thread is new rather than what its id looks like, only `initialize()` may claim that, and every other path still consults the stored row first.
