### PR TITLE
Studio: honour forced tool_choice on local GGUF tool loops

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -25550,7 +25550,12 @@ class LlamaCppBackend:
         # A resumed turn must keep the partial trailing: autoinject appends a tool call
         # plus its result, moving the boundary so the model opens a fresh answer.
         _skip_autoinject = (
-            confirm_tool_calls and not bypass_permissions and permission_mode not in ("auto", "off")
+            tool_choice == "none"
+            or (
+                confirm_tool_calls
+                and not bypass_permissions
+                and permission_mode not in ("auto", "off")
+            )
         ) or bool(continue_final_message and trailing_assistant_text(conversation))
         _auto = None if _skip_autoinject else build_rag_autoinject(conversation, rag_scope)
         if _auto:

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -25765,7 +25765,10 @@ class LlamaCppBackend:
             if not active_tools:
                 _append_budget_exhausted_nudge = False
                 break
-            from core.inference.chat_template_helpers import neutralize_tool_descriptions
+            from core.inference.chat_template_helpers import (
+                neutralize_tool_descriptions,
+                reconciled_tool_choice,
+            )
 
             # An MCP server's description and inputSchema are remote text the template renders
             # into the system turn (#7066). Computed above the gate: a tool dropped for unsafe
@@ -25774,6 +25777,22 @@ class LlamaCppBackend:
             safe_tools = neutralize_tool_descriptions(
                 active_tools, _markup_cache, self.markup_profile
             )
+            requested_choice = "auto" if tool_choice is None else tool_choice
+            if _forced_choice_resolved and requested_choice not in ("auto", "none"):
+                requested_choice = "auto"
+            requested_choice = (
+                reconciled_tool_choice(requested_choice, tools, safe_tools) or "auto"
+            )
+            forced_name = forced_tool_name(requested_choice)
+            if forced_name:
+                matching_tools = [
+                    tool
+                    for tool in safe_tools
+                    if (tool.get("function") or {}).get("name") == forced_name
+                ]
+                if matching_tools:
+                    safe_tools = matching_tools
+                    requested_choice = "required"
             # Gate the markerless bare-JSON form on enabled names so an ordinary JSON answer isn't misread as a call.
             _enabled_tool_names = {
                 (tool.get("function") or {}).get("name")
@@ -25789,7 +25808,6 @@ class LlamaCppBackend:
                 append_assistant_turn,
                 neutralize_control_markup,
                 neutralize_control_markup_in_messages,
-                reconciled_tool_choice,
             )
 
             _reasoning_kw = self._request_reasoning_kwargs(
@@ -25933,25 +25951,6 @@ class LlamaCppBackend:
             # As in the passthrough builder: if every name carried markup the catalog is
             # now empty, and "tools": [] would still advertise tool use.
             if safe_tools:
-                # Local GGUF owns Studio's web_search; honour a forced function
-                # so enabled_tools: ["web_search"] plus tool_choice pinning that
-                # name actually calls it (#9730). Default stays auto.
-                requested_choice = "auto" if tool_choice is None else tool_choice
-                if _forced_choice_resolved and requested_choice not in ("auto", "none"):
-                    requested_choice = "auto"
-                requested_choice = (
-                    reconciled_tool_choice(requested_choice, tools, safe_tools) or "auto"
-                )
-                forced_name = forced_tool_name(requested_choice)
-                if forced_name:
-                    matching_tools = [
-                        tool
-                        for tool in safe_tools
-                        if (tool.get("function") or {}).get("name") == forced_name
-                    ]
-                    if matching_tools:
-                        safe_tools = matching_tools
-                        requested_choice = "required"
                 payload["tools"] = safe_tools
                 payload["tool_choice"] = requested_choice
             if _reasoning_kw is not None:
@@ -26982,6 +26981,7 @@ class LlamaCppBackend:
                         tc,
                         forced = _forced_tool_call_pending,
                         provisional = provisional_match,
+                        allowed_tool_names = {forced_name} if forced_name else None,
                     )
 
                     if not decision.should_execute:

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -25774,6 +25774,7 @@ class LlamaCppBackend:
             # in the first 1-2 chunks without a non-streaming penalty.
             from core.inference.chat_template_helpers import (
                 append_assistant_turn,
+                forced_tool_name,
                 neutralize_control_markup,
                 neutralize_control_markup_in_messages,
                 reconciled_tool_choice,
@@ -25920,16 +25921,27 @@ class LlamaCppBackend:
             # As in the passthrough builder: if every name carried markup the catalog is
             # now empty, and "tools": [] would still advertise tool use.
             if safe_tools:
-                payload["tools"] = safe_tools
                 # Local GGUF owns Studio's web_search; honour a forced function
                 # so enabled_tools: ["web_search"] plus tool_choice pinning that
                 # name actually calls it (#9730). Default stays auto.
                 requested_choice = "auto" if tool_choice is None else tool_choice
                 if _executed_any and requested_choice not in ("auto", "none"):
                     requested_choice = "auto"
-                payload["tool_choice"] = (
+                requested_choice = (
                     reconciled_tool_choice(requested_choice, tools, safe_tools) or "auto"
                 )
+                forced_name = forced_tool_name(requested_choice)
+                if forced_name:
+                    matching_tools = [
+                        tool
+                        for tool in safe_tools
+                        if (tool.get("function") or {}).get("name") == forced_name
+                    ]
+                    if matching_tools:
+                        safe_tools = matching_tools
+                        requested_choice = "required"
+                payload["tools"] = safe_tools
+                payload["tool_choice"] = requested_choice
             if _reasoning_kw is not None:
                 payload["chat_template_kwargs"] = _reasoning_kw
             # Re-checked per iteration: once a tool result is appended the partial is

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -25744,9 +25744,8 @@ class LlamaCppBackend:
         from core.inference.chat_template_helpers import sweep_cache as _sweep_cache
 
         _markup_cache = _sweep_cache()
-        # A forced function applies until something actually runs; the follow-up
-        # must be free to answer in prose (same rule as stream_with_studio_tools).
-        _executed_any = False
+        # A forced function applies until the model produces it; execution or denial resolves it.
+        _forced_choice_resolved = False
         for iteration in range(max_tool_iterations + _extra):
             if cancel_event is not None and cancel_event.is_set():
                 return
@@ -25930,7 +25929,7 @@ class LlamaCppBackend:
                 # so enabled_tools: ["web_search"] plus tool_choice pinning that
                 # name actually calls it (#9730). Default stays auto.
                 requested_choice = "auto" if tool_choice is None else tool_choice
-                if _executed_any and requested_choice not in ("auto", "none"):
+                if _forced_choice_resolved and requested_choice not in ("auto", "none"):
                     requested_choice = "auto"
                 requested_choice = (
                     reconciled_tool_choice(requested_choice, tools, safe_tools) or "auto"
@@ -27064,6 +27063,7 @@ class LlamaCppBackend:
                             yield {"type": "status", "text": decision.status_text}
                         if _decision == "deny":
                             decision_slot = None
+                            _forced_choice_resolved = True
                             resolved_provisional_tool_call_ids.add(decision.tool_call_id)
                             yield {
                                 "type": "tool_end",
@@ -27308,7 +27308,7 @@ class LlamaCppBackend:
                     _last_reprompt_text = ""
                     # A tool ran this turn, so it counts against the caller's budget.
                     _turn_executed_real_tool = True
-                    _executed_any = True
+                    _forced_choice_resolved = True
                     yield completion.tool_end_event()
                     conversation.append(completion.tool_message())
 

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -25545,7 +25545,7 @@ class LlamaCppBackend:
         # retrieval call would actually prompt (ask mode); auto never gates the
         # safe search_knowledge_base tool, so retrieval must still run there.
         # off never prompts either, so it also keeps first-pass retrieval.
-        from core.inference.chat_template_helpers import trailing_assistant_text
+        from core.inference.chat_template_helpers import forced_tool_name, trailing_assistant_text
 
         # A resumed turn must keep the partial trailing: autoinject appends a tool call
         # plus its result, moving the boundary so the model opens a fresh answer.
@@ -25557,6 +25557,10 @@ class LlamaCppBackend:
             for _ev in _auto["events"]:
                 yield _ev
             conversation.extend(_auto["messages"])
+        _auto_satisfies_forced_choice = bool(_auto) and (
+            tool_choice == "required"
+            or forced_tool_name(tool_choice) == "search_knowledge_base"
+        )
 
         _accumulated_completion_tokens = 0
         _accumulated_predicted_ms = 0.0
@@ -25745,7 +25749,7 @@ class LlamaCppBackend:
 
         _markup_cache = _sweep_cache()
         # A forced function applies until the model produces it; execution or denial resolves it.
-        _forced_choice_resolved = False
+        _forced_choice_resolved = _auto_satisfies_forced_choice
         for iteration in range(max_tool_iterations + _extra):
             if cancel_event is not None and cancel_event.is_set():
                 return
@@ -25778,7 +25782,6 @@ class LlamaCppBackend:
             # in the first 1-2 chunks without a non-streaming penalty.
             from core.inference.chat_template_helpers import (
                 append_assistant_turn,
-                forced_tool_name,
                 neutralize_control_markup,
                 neutralize_control_markup_in_messages,
                 reconciled_tool_choice,

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -26301,7 +26301,7 @@ class LlamaCppBackend:
                                             and any(
                                                 (tool.get("function") or {}).get("name")
                                                 == current_name
-                                                for tool in active_tools
+                                                for tool in safe_tools
                                             )
                                         ):
                                             provisional_started_tool_calls[current_id] = (

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -25697,8 +25697,13 @@ class LlamaCppBackend:
             neutralize_tool_descriptions as _neutralize_tool_descriptions,
         )
 
+        controller_tools = (
+            []
+            if tool_choice == "none"
+            else _neutralize_tool_descriptions(tools, None, self.markup_profile)
+        )
         tool_controller = ToolLoopController(
-            tools = _neutralize_tool_descriptions(tools, None, self.markup_profile),
+            tools = controller_tools,
             auto_heal_tool_calls = auto_heal_tool_calls,
         )
 

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -25547,6 +25547,12 @@ class LlamaCppBackend:
         # off never prompts either, so it also keeps first-pass retrieval.
         from core.inference.chat_template_helpers import forced_tool_name, trailing_assistant_text
 
+        initial_forced_name = forced_tool_name(tool_choice)
+        if initial_forced_name and initial_forced_name not in _gguf_active_tool_names(tools):
+            raise ValueError(
+                f"Forced tool '{initial_forced_name}' is not enabled for this request."
+            )
+
         # A resumed turn must keep the partial trailing: autoinject appends a tool call
         # plus its result, moving the boundary so the model opens a fresh answer.
         _skip_autoinject = (

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -25440,6 +25440,7 @@ class LlamaCppBackend:
         perf_callback: Optional[Callable[[dict], None]] = None,
         reasoning_provenance: Optional[dict] = None,
         context_overflow: Optional[str] = None,
+        tool_choice: Any = None,
     ) -> Generator[dict, None, None]:
         """
         Agentic loop: let the model call tools, execute them, and continue.
@@ -25738,6 +25739,9 @@ class LlamaCppBackend:
         from core.inference.chat_template_helpers import sweep_cache as _sweep_cache
 
         _markup_cache = _sweep_cache()
+        # A forced function applies until something actually runs; the follow-up
+        # must be free to answer in prose (same rule as stream_with_studio_tools).
+        _executed_any = False
         for iteration in range(max_tool_iterations + _extra):
             if cancel_event is not None and cancel_event.is_set():
                 return
@@ -25772,6 +25776,7 @@ class LlamaCppBackend:
                 append_assistant_turn,
                 neutralize_control_markup,
                 neutralize_control_markup_in_messages,
+                reconciled_tool_choice,
             )
 
             _reasoning_kw = self._request_reasoning_kwargs(
@@ -25916,7 +25921,15 @@ class LlamaCppBackend:
             # now empty, and "tools": [] would still advertise tool use.
             if safe_tools:
                 payload["tools"] = safe_tools
-                payload["tool_choice"] = "auto"
+                # Local GGUF owns Studio's web_search; honour a forced function
+                # so enabled_tools: ["web_search"] plus tool_choice pinning that
+                # name actually calls it (#9730). Default stays auto.
+                requested_choice = "auto" if tool_choice is None else tool_choice
+                if _executed_any and requested_choice not in ("auto", "none"):
+                    requested_choice = "auto"
+                payload["tool_choice"] = (
+                    reconciled_tool_choice(requested_choice, tools, safe_tools) or "auto"
+                )
             if _reasoning_kw is not None:
                 payload["chat_template_kwargs"] = _reasoning_kw
             # Re-checked per iteration: once a tool result is appended the partial is
@@ -27278,6 +27291,7 @@ class LlamaCppBackend:
                     _last_reprompt_text = ""
                     # A tool ran this turn, so it counts against the caller's budget.
                     _turn_executed_real_tool = True
+                    _executed_any = True
                     yield completion.tool_end_event()
                     conversation.append(completion.tool_message())
 

--- a/studio/backend/core/inference/tool_loop_controller.py
+++ b/studio/backend/core/inference/tool_loop_controller.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import copy
 import json
 from dataclasses import dataclass, field
-from typing import Any, Literal, Mapping, Sequence
+from typing import Any, Collection, Literal, Mapping, Sequence
 from urllib.parse import urlparse
 
 from core.inference.tool_call_parser import TOOL_ERROR_NUDGE, TOOL_ERROR_PREFIXES
@@ -486,6 +486,7 @@ class ToolLoopController:
         *,
         forced: bool = False,
         provisional: bool = False,
+        allowed_tool_names: Collection[str] | None = None,
     ) -> ToolCallDecision:
         """Classify a parsed tool call before any visible event is yielded."""
         function = tool_call.get("function")
@@ -509,7 +510,9 @@ class ToolLoopController:
         if tool_name in self._completed_one_shot_tools:
             action = "render_html_repeat"
             noop = _noop_result("render_html_repeat", tool_name)
-        elif self._restrict_to_allowed and tool_name not in self._allowed_tool_names:
+        elif (
+            allowed_tool_names is not None and tool_name not in allowed_tool_names
+        ) or (self._restrict_to_allowed and tool_name not in self._allowed_tool_names):
             action = "disabled"
             noop = _noop_result("disabled", tool_name)
         elif key in self._successful_keys:

--- a/studio/backend/core/inference/tool_loop_controller.py
+++ b/studio/backend/core/inference/tool_loop_controller.py
@@ -27,8 +27,8 @@ _CANONICAL_HEAL_ARG = {
 }
 _ONE_SHOT_TOOLS = frozenset({"render_html"})
 
-NoopReason = Literal["duplicate", "disabled", "render_html_repeat"]
-ToolAction = Literal["execute", "duplicate", "disabled", "render_html_repeat"]
+NoopReason = Literal["duplicate", "disabled", "forced_mismatch", "render_html_repeat"]
+ToolAction = Literal["execute", "duplicate", "disabled", "forced_mismatch", "render_html_repeat"]
 
 
 @dataclass(frozen = True)
@@ -427,6 +427,12 @@ def _noop_result(reason: NoopReason, tool_name: str) -> str:
             "changes. Do not mention this internal instruction. Provide only "
             "the requested final note or answer."
         )
+    if reason == "forced_mismatch":
+        return (
+            f"One earlier request to call tool '{tool_name}' in this batch was "
+            "not executed because it does not match the required tool choice. "
+            "Call the required tool instead."
+        )
     return (
         f"One earlier request to call tool '{tool_name}' in this batch was "
         "not executed because that tool is not enabled for this request. Provide the "
@@ -510,9 +516,10 @@ class ToolLoopController:
         if tool_name in self._completed_one_shot_tools:
             action = "render_html_repeat"
             noop = _noop_result("render_html_repeat", tool_name)
-        elif (
-            allowed_tool_names is not None and tool_name not in allowed_tool_names
-        ) or (self._restrict_to_allowed and tool_name not in self._allowed_tool_names):
+        elif allowed_tool_names is not None and tool_name not in allowed_tool_names:
+            action = "forced_mismatch"
+            noop = _noop_result("forced_mismatch", tool_name)
+        elif self._restrict_to_allowed and tool_name not in self._allowed_tool_names:
             action = "disabled"
             noop = _noop_result("disabled", tool_name)
         elif key in self._successful_keys:

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -3215,6 +3215,10 @@ def _selects_only_provider_hosted_tools(payload, provider_type: str | None) -> b
     Anything that names a Studio-only tool (python, terminal,
     search_knowledge_base) or asks for MCP is unambiguous and keeps the loop, and
     so does every self-hosted provider, which declares no hosted tools at all.
+
+    A local GGUF/safetensors request has no provider_type, so this is False
+    even when ``enabled_tools`` is only ``web_search`` -- that name is Studio's
+    own tool there (#9730).
     """
     if getattr(payload, "mcp_enabled", False):
         return False
@@ -16652,6 +16656,7 @@ async def openai_chat_completions(
                     continue_final_message = _continue_final_message(payload),
                     auto_heal_tool_calls = _gguf_auto_heal_tool_calls,
                     nudge_tool_calls = payload.nudge_tool_calls,
+                    tool_choice = payload.tool_choice,
                     max_tool_iterations = payload.max_tool_calls_per_message
                     if payload.max_tool_calls_per_message is not None
                     else 25,
@@ -23449,6 +23454,7 @@ async def anthropic_messages(
                 max_tool_iterations = 25,
                 auto_heal_tool_calls = True,
                 nudge_tool_calls = payload.nudge_tool_calls,
+                tool_choice = openai_tool_choice,
                 tool_call_timeout = 300,
                 session_id = payload.session_id,
                 thread_id = payload.thread_id,

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -16214,6 +16214,21 @@ async def openai_chat_completions(
             api_monitor.fail(monitor_id, fail_detail)
         return HTTPException(status_code = status_code, detail = detail)
 
+    def _reject_missing_forced_tool(tool_choice, selected_tools) -> None:
+        from core.inference.chat_template_helpers import catalog_tool_names, forced_tool_name
+
+        forced_name = forced_tool_name(tool_choice)
+        if forced_name and forced_name not in catalog_tool_names(selected_tools):
+            raise _reject(
+                400,
+                openai_error_body(
+                    f"Invalid 'tool_choice': function '{forced_name}' is not enabled.",
+                    status = 400,
+                    code = "invalid_value",
+                    param = "tool_choice",
+                ),
+            )
+
     def _reject_unsupported_n(path_label: str) -> "HTTPException":
         return _reject(
             400,
@@ -16529,6 +16544,7 @@ async def openai_chat_completions(
                 # reset is POSSIBLE somewhere, not that this request can perform one.
                 checkpoint_fitted = _rolling_context_policy(payload) is not None,
             )
+            _reject_missing_forced_tool(payload.tool_choice, tools_to_use)
             # Skip the tool loop when no tool survived, so the safetensors
             # loop's "empty = allow all" semantic can't reach built-in tools
             # the caller didn't opt into. Callers who omit enabled_tools still
@@ -18193,6 +18209,7 @@ async def openai_chat_completions(
         _sf_tools_to_use = await _select_request_tools(
             payload, tools_on = _sf_tools_on, mcp_allowed = _sf_mcp_allowed
         )
+        _reject_missing_forced_tool(payload.tool_choice, _sf_tools_to_use)
         # Mirror the GGUF path: refuse to enter the tool loop when nothing
         # survived, so a model-emitted built-in call can't piggy-back on the
         # empty allow-list.
@@ -23422,6 +23439,20 @@ async def anthropic_messages(
                     "type": "function",
                     "function": {"name": canonical_name},
                 }
+        from core.inference.chat_template_helpers import catalog_tool_names, forced_tool_name
+
+        forced_name = forced_tool_name(server_tool_choice)
+        if forced_name and forced_name not in catalog_tool_names(openai_tools):
+            message = f"Invalid 'tool_choice': function '{forced_name}' is not enabled."
+            api_monitor.fail(monitor_id, message)
+            raise HTTPException(
+                status_code = 400,
+                detail = anthropic_error_body(
+                    message,
+                    status = 400,
+                    err_type = "invalid_request_error",
+                ),
+            )
 
         # Build tool-use system prompt nudge (same logic as /chat/completions)
         _nudge = _build_tool_action_nudge(

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -23410,6 +23410,19 @@ async def anthropic_messages(
         if _full_access:
             openai_tools = apply_full_access_tool_descriptions(openai_tools)
 
+        server_tool_choice = openai_tool_choice
+        if isinstance(server_tool_choice, dict):
+            forced_function = server_tool_choice.get("function")
+            forced_name = (
+                forced_function.get("name") if isinstance(forced_function, dict) else None
+            )
+            canonical_name = _STUDIO_ANTHROPIC_TOOL_ALIASES.get(forced_name)
+            if canonical_name:
+                server_tool_choice = {
+                    "type": "function",
+                    "function": {"name": canonical_name},
+                }
+
         # Build tool-use system prompt nudge (same logic as /chat/completions)
         _nudge = _build_tool_action_nudge(
             tools = openai_tools,
@@ -23454,7 +23467,7 @@ async def anthropic_messages(
                 max_tool_iterations = 25,
                 auto_heal_tool_calls = True,
                 nudge_tool_calls = payload.nudge_tool_calls,
-                tool_choice = openai_tool_choice,
+                tool_choice = server_tool_choice,
                 tool_call_timeout = 300,
                 session_id = payload.session_id,
                 thread_id = payload.thread_id,

--- a/studio/backend/tests/test_anthropic_messages.py
+++ b/studio/backend/tests/test_anthropic_messages.py
@@ -2722,6 +2722,23 @@ class TestAnthropicMessagesToolRouting:
         _drive(anthropic_messages(payload, request = None, current_subject = "t"))
         assert backend.calls[0][0] == "tools"
 
+    def test_server_tool_choice_alias_uses_the_selected_studio_name(self, monkeypatch):
+        backend = _mock_backend(monkeypatch)
+        payload = _basic_payload(
+            tools = [{"type": "web_fetch_20250910", "name": "web_fetch"}],
+            tool_choice = {"type": "tool", "name": "web_fetch"},
+        )
+
+        _drive(anthropic_messages(payload, request = None, current_subject = "t"))
+
+        call_kind, kwargs = backend.calls[0]
+        assert call_kind == "tools"
+        assert kwargs["tool_choice"] == {
+            "type": "function",
+            "function": {"name": "web_search"},
+        }
+        assert [tool["function"]["name"] for tool in kwargs["tools"]] == ["web_search"]
+
     def test_confirm_tool_calls_rejected_for_server_tools(self, monkeypatch):
         backend = _mock_backend(monkeypatch)
         payload = _basic_payload(

--- a/studio/backend/tests/test_anthropic_messages.py
+++ b/studio/backend/tests/test_anthropic_messages.py
@@ -2739,6 +2739,20 @@ class TestAnthropicMessagesToolRouting:
         }
         assert [tool["function"]["name"] for tool in kwargs["tools"]] == ["web_search"]
 
+    def test_server_tool_choice_must_be_in_the_selected_catalog(self, monkeypatch):
+        backend = _mock_backend(monkeypatch)
+        payload = _basic_payload(
+            tools = [{"type": "web_search_20250305", "name": "web_search"}],
+            tool_choice = {"type": "tool", "name": "python"},
+        )
+
+        with pytest.raises(HTTPException) as exc:
+            _drive(anthropic_messages(payload, request = None, current_subject = "t"))
+
+        assert exc.value.status_code == 400
+        assert "python" in exc.value.detail["error"]["message"]
+        assert backend.calls == []
+
     def test_confirm_tool_calls_rejected_for_server_tools(self, monkeypatch):
         backend = _mock_backend(monkeypatch)
         payload = _basic_payload(

--- a/studio/backend/tests/test_llama_cpp_tool_loop.py
+++ b/studio/backend/tests/test_llama_cpp_tool_loop.py
@@ -3357,6 +3357,50 @@ def test_rag_autoinject_counts_as_a_prior_tool_execution(monkeypatch):
     assert events
 
 
+def test_rag_autoinject_only_resolves_matching_forced_choices(monkeypatch):
+    monkeypatch.setattr(
+        "core.inference.tools.build_rag_autoinject",
+        lambda *_a, **_k: {
+            "events": [],
+            "messages": [{"role": "user", "content": "Retrieved passage: Tokyo."}],
+        },
+    )
+    tools = [
+        {"type": "function", "function": {"name": "search_knowledge_base"}},
+        {"type": "function", "function": {"name": "web_search"}},
+    ]
+
+    def first_payload(tool_choice):
+        payloads: list[dict] = []
+        backend = _make_backend(
+            monkeypatch,
+            [[_sse({"content": "The passage describes Tokyo."}), _done()]],
+            payloads,
+        )
+        list(
+            backend.generate_chat_completion_with_tools(
+                messages = [{"role": "user", "content": "summarize the docs"}],
+                tools = tools,
+                tool_choice = tool_choice,
+                max_tool_iterations = 1,
+                nudge_tool_calls = False,
+                rag_scope = {"thread_id": "t1"},
+            )
+        )
+        return payloads[0]
+
+    matching = first_payload(
+        {"type": "function", "function": {"name": "search_knowledge_base"}}
+    )
+    required = first_payload("required")
+    unrelated = first_payload({"type": "function", "function": {"name": "web_search"}})
+
+    assert matching["tool_choice"] == "auto"
+    assert required["tool_choice"] == "auto"
+    assert unrelated["tool_choice"] == "required"
+    assert [tool["function"]["name"] for tool in unrelated["tools"]] == ["web_search"]
+
+
 def test_confirm_tool_calls_deny_skips_gguf_tool_and_retry_can_execute(monkeypatch):
     same_call = _structured_tool_call("python", {"code": "print(1)"}, "call_py")
     streams = [

--- a/studio/backend/tests/test_llama_cpp_tool_loop.py
+++ b/studio/backend/tests/test_llama_cpp_tool_loop.py
@@ -297,7 +297,14 @@ def test_forced_web_search_tool_choice_is_sent_until_a_tool_runs(monkeypatch):
                         "name": "web_search",
                         "parameters": {"type": "object", "properties": {}},
                     },
-                }
+                },
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "python",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                },
             ],
             tool_choice = {"type": "function", "function": {"name": "web_search"}},
             max_tool_iterations = 5,
@@ -305,7 +312,8 @@ def test_forced_web_search_tool_choice_is_sent_until_a_tool_runs(monkeypatch):
         )
     )
 
-    assert payloads[0]["tool_choice"] == {"type": "function", "function": {"name": "web_search"}}
+    assert payloads[0]["tool_choice"] == "required"
+    assert [tool["function"]["name"] for tool in payloads[0]["tools"]] == ["web_search"]
     assert payloads[1]["tool_choice"] == "auto"
     assert any(
         event.get("type") == "tool_start" and event.get("tool_name") == "web_search"

--- a/studio/backend/tests/test_llama_cpp_tool_loop.py
+++ b/studio/backend/tests/test_llama_cpp_tool_loop.py
@@ -340,18 +340,22 @@ def test_forced_tool_choice_must_exist_in_the_catalog(monkeypatch):
     assert payloads == []
 
 
-def test_forced_tool_choice_rejects_other_structured_calls(monkeypatch):
+def test_forced_tool_choice_retries_after_other_structured_calls(monkeypatch):
+    wrong_code = "print('wrong tool')\n" * 20
     streams = [
-        _structured_tool_call("python", {"code": "print(1)"}, "call_python"),
-        [_sse({"content": "No tool ran."}), _done()],
+        _structured_tool_call("python", {"code": wrong_code}, "call_python"),
+        _structured_tool_call("web_search", {"query": "kernel version"}, "call_search"),
+        [_sse({"content": "The search completed."}), _done()],
     ]
     payloads: list[dict] = []
     backend = _make_backend(monkeypatch, streams, payloads)
+    calls: list[tuple[str, dict]] = []
 
-    def fail_execute_tool(name, arguments, **_kwargs):
-        raise AssertionError(f"unexpected tool execution: {name} {arguments}")
+    def fake_execute_tool(name, arguments, **_kwargs):
+        calls.append((name, arguments))
+        return "Linux kernel result"
 
-    monkeypatch.setattr("core.inference.tools.execute_tool", fail_execute_tool)
+    monkeypatch.setattr("core.inference.tools.execute_tool", fake_execute_tool)
 
     events = list(
         backend.generate_chat_completion_with_tools(
@@ -361,13 +365,19 @@ def test_forced_tool_choice_rejects_other_structured_calls(monkeypatch):
                 {"type": "function", "function": {"name": "python"}},
             ],
             tool_choice = {"type": "function", "function": {"name": "web_search"}},
-            max_tool_iterations = 1,
+            max_tool_iterations = 2,
         )
     )
 
     assert payloads[0]["tool_choice"] == "required"
     assert [tool["function"]["name"] for tool in payloads[0]["tools"]] == ["web_search"]
-    assert not [event for event in events if event.get("type") in {"tool_start", "tool_end"}]
+    assert payloads[1]["tool_choice"] == "required"
+    assert [tool["function"]["name"] for tool in payloads[1]["tools"]] == ["web_search"]
+    assert payloads[2]["tool_choice"] == "auto"
+    assert calls == [("web_search", {"query": "kernel version"})]
+    assert [
+        event.get("tool_name") for event in events if event.get("type") == "tool_start"
+    ] == ["web_search"]
 
 
 def test_none_tool_choice_never_executes_model_tool_calls(monkeypatch):

--- a/studio/backend/tests/test_llama_cpp_tool_loop.py
+++ b/studio/backend/tests/test_llama_cpp_tool_loop.py
@@ -321,6 +321,36 @@ def test_forced_web_search_tool_choice_is_sent_until_a_tool_runs(monkeypatch):
     )
 
 
+def test_forced_tool_choice_rejects_other_structured_calls(monkeypatch):
+    streams = [
+        _structured_tool_call("python", {"code": "print(1)"}, "call_python"),
+        [_sse({"content": "No tool ran."}), _done()],
+    ]
+    payloads: list[dict] = []
+    backend = _make_backend(monkeypatch, streams, payloads)
+
+    def fail_execute_tool(name, arguments, **_kwargs):
+        raise AssertionError(f"unexpected tool execution: {name} {arguments}")
+
+    monkeypatch.setattr("core.inference.tools.execute_tool", fail_execute_tool)
+
+    events = list(
+        backend.generate_chat_completion_with_tools(
+            messages = [{"role": "user", "content": "search the web"}],
+            tools = [
+                {"type": "function", "function": {"name": "web_search"}},
+                {"type": "function", "function": {"name": "python"}},
+            ],
+            tool_choice = {"type": "function", "function": {"name": "web_search"}},
+            max_tool_iterations = 1,
+        )
+    )
+
+    assert payloads[0]["tool_choice"] == "required"
+    assert [tool["function"]["name"] for tool in payloads[0]["tools"]] == ["web_search"]
+    assert not [event for event in events if event.get("type") in {"tool_start", "tool_end"}]
+
+
 def test_none_tool_choice_never_executes_model_tool_calls(monkeypatch):
     stream = [
         *_structured_tool_call("python", {"code": "print(1)"}, "call_python")[:-1],

--- a/studio/backend/tests/test_llama_cpp_tool_loop.py
+++ b/studio/backend/tests/test_llama_cpp_tool_loop.py
@@ -321,6 +321,44 @@ def test_forced_web_search_tool_choice_is_sent_until_a_tool_runs(monkeypatch):
     )
 
 
+def test_none_tool_choice_never_executes_model_tool_calls(monkeypatch):
+    stream = [
+        *_structured_tool_call("python", {"code": "print(1)"}, "call_python")[:-1],
+        _sse({"content": "I will answer without tools."}),
+        _done(),
+    ]
+    payloads: list[dict] = []
+    backend = _make_backend(monkeypatch, [stream], payloads)
+
+    def fail_execute_tool(name, arguments, **_kwargs):
+        raise AssertionError(f"unexpected tool execution: {name} {arguments}")
+
+    monkeypatch.setattr("core.inference.tools.execute_tool", fail_execute_tool)
+
+    events = list(
+        backend.generate_chat_completion_with_tools(
+            messages = [{"role": "user", "content": "answer directly"}],
+            tools = [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "python",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                }
+            ],
+            tool_choice = "none",
+            max_tool_iterations = 1,
+        )
+    )
+
+    assert len(payloads) == 1
+    assert "tools" not in payloads[0]
+    assert "tool_choice" not in payloads[0]
+    assert not [event for event in events if event.get("type") in {"tool_start", "tool_end"}]
+    assert any(event.get("text") == "I will answer without tools." for event in events)
+
+
 def test_structured_tool_call_after_visible_preface_is_executed(monkeypatch):
     """llama-server may emit content first and then native delta.tool_calls.
 

--- a/studio/backend/tests/test_llama_cpp_tool_loop.py
+++ b/studio/backend/tests/test_llama_cpp_tool_loop.py
@@ -333,7 +333,11 @@ def test_none_tool_choice_never_executes_model_tool_calls(monkeypatch):
     def fail_execute_tool(name, arguments, **_kwargs):
         raise AssertionError(f"unexpected tool execution: {name} {arguments}")
 
+    def fail_autoinject(*_args, **_kwargs):
+        raise AssertionError("tool_choice=none must not autoinject retrieval")
+
     monkeypatch.setattr("core.inference.tools.execute_tool", fail_execute_tool)
+    monkeypatch.setattr("core.inference.tools.build_rag_autoinject", fail_autoinject)
 
     events = list(
         backend.generate_chat_completion_with_tools(
@@ -349,6 +353,7 @@ def test_none_tool_choice_never_executes_model_tool_calls(monkeypatch):
             ],
             tool_choice = "none",
             max_tool_iterations = 1,
+            rag_scope = {"thread_id": "t1", "autoinject": True},
         )
     )
 

--- a/studio/backend/tests/test_llama_cpp_tool_loop.py
+++ b/studio/backend/tests/test_llama_cpp_tool_loop.py
@@ -305,10 +305,7 @@ def test_forced_web_search_tool_choice_is_sent_until_a_tool_runs(monkeypatch):
         )
     )
 
-    assert payloads[0]["tool_choice"] == {
-        "type": "function",
-        "function": {"name": "web_search"},
-    }
+    assert payloads[0]["tool_choice"] == {"type": "function", "function": {"name": "web_search"}}
     assert payloads[1]["tool_choice"] == "auto"
     assert any(
         event.get("type") == "tool_start" and event.get("tool_name") == "web_search"

--- a/studio/backend/tests/test_llama_cpp_tool_loop.py
+++ b/studio/backend/tests/test_llama_cpp_tool_loop.py
@@ -3391,6 +3391,7 @@ def test_confirm_tool_calls_deny_skips_gguf_tool_and_retry_can_execute(monkeypat
         backend.generate_chat_completion_with_tools(
             messages = [{"role": "user", "content": "run python"}],
             tools = [{"type": "function", "function": {"name": "python"}}],
+            tool_choice = {"type": "function", "function": {"name": "python"}},
             max_tool_iterations = 2,
             confirm_tool_calls = True,
             # Unset defaults to "auto", which would not prompt this safe print(1).
@@ -3404,6 +3405,7 @@ def test_confirm_tool_calls_deny_skips_gguf_tool_and_retry_can_execute(monkeypat
     assert len(starts) == 2
     assert [event["result"] for event in ends] == [TOOL_REJECTED_MESSAGE, "OK"]
     assert calls == [("python", {"code": "print(1)"})]
+    assert [payload.get("tool_choice") for payload in payloads] == ["required", "auto", "auto"]
 
 
 def _streamed_structured_tool_call(

--- a/studio/backend/tests/test_llama_cpp_tool_loop.py
+++ b/studio/backend/tests/test_llama_cpp_tool_loop.py
@@ -17,6 +17,8 @@ import sys
 import threading
 from pathlib import Path
 
+import pytest
+
 _BACKEND_DIR = str(Path(__file__).resolve().parent.parent)
 if _BACKEND_DIR not in sys.path:
     sys.path.insert(0, _BACKEND_DIR)
@@ -319,6 +321,23 @@ def test_forced_web_search_tool_choice_is_sent_until_a_tool_runs(monkeypatch):
         event.get("type") == "tool_start" and event.get("tool_name") == "web_search"
         for event in events
     )
+
+
+def test_forced_tool_choice_must_exist_in_the_catalog(monkeypatch):
+    payloads: list[dict] = []
+    backend = _make_backend(monkeypatch, [], payloads)
+
+    with pytest.raises(ValueError, match="Forced tool 'python' is not enabled"):
+        list(
+            backend.generate_chat_completion_with_tools(
+                messages = [{"role": "user", "content": "run python"}],
+                tools = [{"type": "function", "function": {"name": "web_search"}}],
+                tool_choice = {"type": "function", "function": {"name": "python"}},
+                max_tool_iterations = 1,
+            )
+        )
+
+    assert payloads == []
 
 
 def test_forced_tool_choice_rejects_other_structured_calls(monkeypatch):

--- a/studio/backend/tests/test_llama_cpp_tool_loop.py
+++ b/studio/backend/tests/test_llama_cpp_tool_loop.py
@@ -263,6 +263,59 @@ def _structured_tool_call(tool_name: str, arguments: dict, call_id: str) -> list
     ]
 
 
+def test_forced_web_search_tool_choice_is_sent_until_a_tool_runs(monkeypatch):
+    """#9730: a forced web_search must reach llama-server on the first turn.
+
+    After the call executes, the follow-up is auto so the model can answer.
+    """
+    first_stream = _structured_tool_call(
+        "web_search", {"query": "current Linux kernel version"}, "call_search"
+    )
+    second_stream = [_sse({"content": "The current version of the Linux kernel is 6.10."}), _done()]
+    payloads: list[dict] = []
+    backend = _make_backend(monkeypatch, [first_stream, second_stream], payloads)
+    monkeypatch.setattr(
+        "core.inference.tools.execute_tool",
+        lambda name, arguments, **_kwargs: "Linux kernel 6.10",
+    )
+
+    events = list(
+        backend.generate_chat_completion_with_tools(
+            messages = [
+                {
+                    "role": "user",
+                    "content": (
+                        "Search the web for the current version of the Linux kernel, "
+                        "then answer in one sentence."
+                    ),
+                }
+            ],
+            tools = [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "web_search",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                }
+            ],
+            tool_choice = {"type": "function", "function": {"name": "web_search"}},
+            max_tool_iterations = 5,
+            permission_mode = "off",
+        )
+    )
+
+    assert payloads[0]["tool_choice"] == {
+        "type": "function",
+        "function": {"name": "web_search"},
+    }
+    assert payloads[1]["tool_choice"] == "auto"
+    assert any(
+        event.get("type") == "tool_start" and event.get("tool_name") == "web_search"
+        for event in events
+    )
+
+
 def test_structured_tool_call_after_visible_preface_is_executed(monkeypatch):
     """llama-server may emit content first and then native delta.tool_calls.
 

--- a/studio/backend/tests/test_openai_tool_passthrough.py
+++ b/studio/backend/tests/test_openai_tool_passthrough.py
@@ -2470,6 +2470,67 @@ class TestGgufVisionToolRouting:
 
         assert captured["kwargs"]["disable_parallel_tool_use"] is True
 
+    def test_enabled_tools_web_search_only_enters_gguf_tool_loop(self, monkeypatch):
+        """#9730: enable_tools + enabled_tools: ["web_search"] on a local GGUF
+        must enter Studio's loop with that catalog, not answer from memory."""
+        import routes.inference as inf_mod
+
+        reset_tool_policy()
+        captured = {}
+
+        def _plain(**kwargs):
+            raise AssertionError("plain GGUF path should not be used")
+
+        def _tools(**kwargs):
+            captured["kwargs"] = kwargs
+            yield {"type": "content", "text": "The current version of the Linux kernel is 6.10."}
+
+        backend = SimpleNamespace(
+            is_loaded = True,
+            is_vision = False,
+            supports_tools = True,
+            model_identifier = "Qwen3.5-2B-MTP-GGUF",
+            context_length = 4096,
+            generate_chat_completion = _plain,
+            generate_chat_completion_with_tools = _tools,
+        )
+        monitor = ApiMonitor(max_entries = 3)
+        monkeypatch.setattr(inf_mod, "api_monitor", monitor)
+        monkeypatch.setattr(inf_mod, "get_llama_cpp_backend", lambda: backend)
+
+        payload = ChatCompletionRequest(
+            model = "default",
+            messages = [
+                {
+                    "role": "user",
+                    "content": (
+                        "Search the web for the current version of the Linux kernel, "
+                        "then answer in one sentence."
+                    ),
+                }
+            ],
+            enable_tools = True,
+            enabled_tools = ["web_search"],
+            permission_mode = "off",
+            tool_choice = {"type": "function", "function": {"name": "web_search"}},
+            max_tokens = 512,
+            temperature = 0.0,
+            stream = True,
+        )
+
+        response = self._drive(
+            openai_chat_completions(payload, request = self._Request(), current_subject = "test")
+        )
+        self._consume_response(response)
+
+        assert "kwargs" in captured
+        assert [t["function"]["name"] for t in captured["kwargs"]["tools"]] == ["web_search"]
+        assert captured["kwargs"]["tool_choice"] == {
+            "type": "function",
+            "function": {"name": "web_search"},
+        }
+        assert captured["kwargs"]["permission_mode"] == "off"
+
     def test_confirm_tool_calls_requires_streaming_for_gguf_tools(self, monkeypatch):
         import routes.inference as inf_mod
 

--- a/studio/backend/tests/test_openai_tool_passthrough.py
+++ b/studio/backend/tests/test_openai_tool_passthrough.py
@@ -2531,6 +2531,46 @@ class TestGgufVisionToolRouting:
         }
         assert captured["kwargs"]["permission_mode"] == "off"
 
+    def test_forced_tool_choice_must_be_in_the_selected_gguf_catalog(self, monkeypatch):
+        import routes.inference as inf_mod
+
+        reset_tool_policy()
+
+        def _tools(**_kwargs):
+            raise AssertionError("invalid forced choice must not start generation")
+
+        backend = SimpleNamespace(
+            is_loaded = True,
+            is_vision = False,
+            supports_tools = True,
+            model_identifier = "test-gguf",
+            context_length = 4096,
+            generate_chat_completion_with_tools = _tools,
+        )
+        monkeypatch.setattr(inf_mod, "api_monitor", ApiMonitor(max_entries = 3))
+        monkeypatch.setattr(inf_mod, "get_llama_cpp_backend", lambda: backend)
+        payload = ChatCompletionRequest(
+            model = "default",
+            messages = [{"role": "user", "content": "run python"}],
+            enable_tools = True,
+            enabled_tools = ["web_search"],
+            permission_mode = "off",
+            tool_choice = {"type": "function", "function": {"name": "python"}},
+            stream = True,
+        )
+
+        with pytest.raises(HTTPException) as exc:
+            self._drive(
+                openai_chat_completions(
+                    payload,
+                    request = self._Request(),
+                    current_subject = "test",
+                )
+            )
+
+        assert exc.value.status_code == 400
+        assert exc.value.detail["error"]["param"] == "tool_choice"
+
     def test_confirm_tool_calls_requires_streaming_for_gguf_tools(self, monkeypatch):
         import routes.inference as inf_mod
 

--- a/studio/backend/tests/test_run_tools_locally_discriminator.py
+++ b/studio/backend/tests/test_run_tools_locally_discriminator.py
@@ -190,3 +190,25 @@ def test_the_field_defaults_to_absent_not_false():
     payload = _payload(enabled_tools = ["web_search"])
     dumped = payload.model_dump(exclude_unset = True)
     assert "run_tools_locally" not in dumped
+
+
+def test_local_gguf_search_only_is_not_a_hosted_request():
+    """#9730: a loaded GGUF has no provider_type; web_search is Studio's tool."""
+    from models.inference import ChatCompletionRequest
+    from routes.inference import _select_request_tools, _selects_only_provider_hosted_tools
+
+    payload = ChatCompletionRequest(
+        messages = [{"role": "user", "content": "Search the web for the Linux kernel version."}],
+        enable_tools = True,
+        enabled_tools = ["web_search"],
+        permission_mode = "off",
+        tool_choice = {"type": "function", "function": {"name": "web_search"}},
+    )
+    assert payload.provider_type is None
+    assert payload.provider_id is None
+    assert _selects_only_provider_hosted_tools(payload, None) is False
+    names = [
+        t["function"]["name"]
+        for t in _drive(_select_request_tools(payload, tools_on = True, mcp_allowed = False))
+    ]
+    assert names == ["web_search"]

--- a/studio/backend/tests/test_tool_loop_controller.py
+++ b/studio/backend/tests/test_tool_loop_controller.py
@@ -234,6 +234,23 @@ def test_disabled_tool_is_internal_noop_not_visible_tool_error():
     assert controller.active_tools() == []
 
 
+def test_forced_mismatch_keeps_the_required_tool_active():
+    controller = ToolLoopController(tools = [_tool("web_search"), _tool("python")])
+    decision = controller.prepare_call(
+        _call("python", {"code": "print(1)"}),
+        allowed_tool_names = {"web_search"},
+    )
+    completion = controller.record_noop(decision)
+
+    assert decision.action == "forced_mismatch"
+    assert "required tool choice" in completion.model_message()["content"]
+    assert not controller.force_final_answer
+    assert [tool["function"]["name"] for tool in controller.active_tools()] == [
+        "web_search",
+        "python",
+    ]
+
+
 def test_render_html_success_filters_active_tools_and_repeat_is_internal():
     controller = ToolLoopController(tools = [_tool("render_html"), _tool("web_search")])
     assert [t["function"]["name"] for t in controller.active_tools()] == [


### PR DESCRIPTION
## Summary

Fixes [unslothai/unsloth#9730](https://github.com/unslothai/unsloth/issues/9730). On a local GGUF model, `enable_tools: true` plus `enabled_tools: ["web_search"]` with a forced `tool_choice` ran **no tools**, so small models answered from memory. The same request with `enabled_tools` omitted still called `web_search`. `enabled_tools: ["python"]` was unaffected.

The hosted-tool discriminator (`_selects_only_provider_hosted_tools`) is not the local-GGUF path: a loaded GGUF has no `provider_type`, `provider_hosted_tools` is empty, and the local loop already kept `web_search` in the catalog. The GGUF agentic loop then **hardcoded** `tool_choice` to `"auto"`, so the request's forced `web_search` never reached llama-server.

- Forward `payload.tool_choice` into `generate_chat_completion_with_tools` (OpenAI chat and Anthropic GGUF loops).
- Honour a forced function on the first turn; after a tool actually runs, drop it to `"auto"` so the model can answer in prose (same rule as `stream_with_studio_tools`).
- Document that a local GGUF request is not a hosted-only selection even when `enabled_tools` is only `web_search`.
- Hosted providers are unchanged: `enabled_tools: ["web_search"]` without `run_tools_locally` still stays hosted.

## Test plan

- [x] `pytest tests/test_llama_cpp_tool_loop.py::test_forced_web_search_tool_choice_is_sent_until_a_tool_runs` — first llama-server payload is forced `web_search`, follow-up is `"auto"`, `tool_start` fires
- [x] `pytest tests/test_openai_tool_passthrough.py::TestGgufVisionToolRouting::test_enabled_tools_web_search_only_enters_gguf_tool_loop` — issue-shaped request enters the GGUF loop with catalog `["web_search"]` and the forced `tool_choice`
- [x] `pytest tests/test_run_tools_locally_discriminator.py` — local GGUF is not hosted-only; `test_search_only_without_the_flag_stays_hosted` still holds for OpenAI/Gemini/Kimi/OpenRouter
- [x] `pytest tests/test_external_hosted_tool_passthrough.py::test_a_self_hosted_provider_still_runs_studios_own_web_search`