### PR TITLE
Give every installing job its own pip cache key

### DIFF
--- a/.github/actions/pip-cache-restore/action.yml
+++ b/.github/actions/pip-cache-restore/action.yml
@@ -30,6 +30,26 @@ description: >-
   runs on the default branch only.
 
 inputs:
+  name:
+    description: >-
+      Short, stable identifier for the INSTALLING JOB (`consolidated`,
+      `notebooks-colab`, ...). Two things depend on it.
+
+      Jobs that install different things must not share a key. Five jobs here
+      passed the same key-files and so resolved to the same key; the save is
+      gated on `cache-hit != 'true'`, so whichever finished first on main wrote
+      the cache and the other four restored it exactly, installed their own
+      extra wheels, and never saved them. Those extras were re-downloaded on
+      every run of main, forever, and nothing about it was visible.
+
+      It also makes each family its own key prefix. Without that, generations of
+      five different jobs sit under `pip-<os>-<arch>-py<ver>-` and cannot be told
+      apart from five generations of one, so cache-janitor.yml cannot prune any
+      of them. 14 GiB of unreachable pip entries had accumulated by 2026-08-26
+      for exactly that reason.
+
+      Lowercase, digits and dashes; it goes into the cache key verbatim.
+    required: true
   key-files:
     description: >-
       Newline-separated glob(s) whose hash keys the cache. Pass the files this
@@ -47,6 +67,9 @@ outputs:
   key:
     description: The full cache key, to hand to pip-cache-save.
     value: ${{ steps.probe.outputs.key }}
+  prefix:
+    description: The cache key without the dependency hash, i.e. the restore-key.
+    value: ${{ steps.probe.outputs.prefix }}
   cache-hit:
     description: 'true when the exact key was restored.'
     value: ${{ steps.restore.outputs.cache-hit }}
@@ -84,7 +107,28 @@ runs:
           echo "::error::pip-cache: key-files matched no file, so the cache key would not distinguish anything. Given: ${{ inputs.key-files }}"
           exit 1
         fi
-        echo "key=pip-${{ runner.os }}-${{ runner.arch }}-py${pyver}-${hash}" >> "$GITHUB_OUTPUT"
+        name="${{ inputs.name }}"
+        # An empty or surprising segment collapses distinct jobs onto one key, or
+        # breaks the janitor's prefix grouping. Both fail silently, so check here.
+        case "$name" in
+          ''|*[!a-z0-9-]*)
+            echo "::error::pip-cache: name must be lowercase letters, digits and dashes. Given: '$name'"
+            exit 1 ;;
+        esac
+
+        # `v2` is a real load-bearing segment, not decoration. Keys minted before
+        # `name` existed look like `pip-Linux-X64-py3.12-<hash>`, and `Linux` is a
+        # valid name, so nothing distinguishes an old key from a new one whose job
+        # happens to be called `linux`. The janitor matches `pip-v2-` only, which
+        # leaves every legacy entry untouched to expire on its own 7-day idle
+        # timer rather than being ranked against keys it has nothing to do with.
+        #
+        # Emitted separately so the restore-key fallback and the janitor's
+        # grouping are built from the same string as the key, not a copy that
+        # can drift.
+        prefix="pip-v2-${name}-${{ runner.os }}-${{ runner.arch }}-py${pyver}-"
+        echo "prefix=$prefix" >> "$GITHUB_OUTPUT"
+        echo "key=${prefix}${hash}" >> "$GITHUB_OUTPUT"
 
     - name: Restore the pip cache
       id: restore
@@ -94,3 +138,15 @@ runs:
       with:
         path: ${{ steps.probe.outputs.dir }}
         key: ${{ steps.probe.outputs.key }}
+        # WITH a prefix fallback, unlike the frontend-dist cache. A dist cache is
+        # a build output: the wrong generation is wrong, so only an exact key will
+        # do. This is pip's HTTP cache, addressed by URL and content hash, where
+        # the previous generation is the current one minus whatever moved. A
+        # dependency bump then costs the changed wheels instead of all of them,
+        # and a stale entry cannot serve wrong content -- the worst it can do is
+        # miss. Same argument that lets the key carry 3.12 rather than 3.12.14.
+        #
+        # `name` is inside the prefix, so the fallback stays inside this job's own
+        # family and never hands one job the wheels another downloaded.
+        restore-keys: |
+          ${{ steps.probe.outputs.prefix }}

--- a/.github/workflows/cache-janitor.yml
+++ b/.github/workflows/cache-janitor.yml
@@ -3,27 +3,62 @@
 
 name: Cache janitor
 
-# Keeps Actions cache usage clear of the 50 GB ceiling. At the ceiling GitHub
-# evicts by LRU regardless of reachability, and a partially evicted cache still
-# restores, then misses on the evicted objects: the hit rate collapses with
-# nothing failing.
+# Keeps Actions cache usage clear of the 50 GiB ceiling. At the ceiling GitHub
+# deletes whole entries by last-access date, regardless of reachability, so the
+# live entry of a family can go between the run that wrote it and the run that
+# needs it. The documented result is cache thrashing: entries created and deleted
+# at a high frequency, the hit rate collapsing with nothing failing.
 #
-# Deletes only families that resolve via restore-keys, where GitHub returns the
-# most recent prefix match so older generations serve no routine build:
-#   codeql-overlay-base-database-*  keys embed commit SHA + run id
-#   v0-rust-*                       Swatinem/rust-cache
+# The ceiling is per-repository and admin-set. 50 GiB is this repo's; the zoo's
+# is 20 GiB, where the same constant copied across was wrong for a week and the
+# warning could never fire. If someone raises it, this number and the threshold
+# at the bottom are the two places to change.
+#
+# Four families are pruned.
+#
+#   1. Caches on refs/pull/N/* whose PR is closed or merged. Lookup is scoped
+#      by ref and nothing but that PR's own runs can restore its merge ref, so
+#      once the PR is not open the entry is unreachable for good, and GitHub
+#      does not collect it on merge. Almost everything here already saves on
+#      main only, so this is a backstop rather than the main event. The PR state
+#      decides, not age: an open PR's caches are live no matter how old, and a
+#      lookup that errors keeps the cache.
+#
+#   2. Superseded generations of families whose keys embed a build identity:
+#        codeql-overlay-base-database-*  keys embed commit SHA + run id
+#        v0-rust-*                       Swatinem/rust-cache
+#
+#   3. Superseded generations of pip-v2-*, the pip HTTP caches written by
+#      .github/actions/pip-cache-save. `name` is inside the prefix as of the
+#      commit that added it, so each installing job is its own family and its
+#      generations rank against each other and nothing else. Before that every
+#      job sat under `pip-<os>-<arch>-py<ver>-`, five of them sharing one key,
+#      and no prefix could tell five live caches from five generations of one --
+#      so this family could not be pruned at all, and 57 entries were still
+#      resident on 2026-08-26 having last been read a day or more earlier.
+#
+#      Legacy `pip-<os>-...` keys are deliberately NOT matched. `Linux` is a
+#      valid name, so an old key is indistinguishable from a new one whose job
+#      is called `linux`; they are left to expire on their own 7-day timer
+#      rather than be ranked against keys they have nothing to do with.
+#
+#   4. Superseded generations of uv-* (the uv download cache) and fe-dist-* (the
+#      built frontend). One key formula each across all their call sites, so the
+#      prefix is unambiguous without a name. fe-dist takes no restore-keys by
+#      design, so an older generation answers only an exact revert of the
+#      frontend sources; 59 entries in 3 families had accumulated there.
 #
 # "Older" is not the same as unreachable. rust-cache passes its full key to
 # restoreCache, which tries an exact match first, so a build returning to an
 # earlier dependency state (a re-run of an old commit, a lockfile revert) can
-# still hit an older generation exactly. Pruning trades those rare exact hits
-# for headroom, which is the point; keep is the dial.
+# still hit an older generation exactly. The pip and uv caches are the same
+# shape. keep is the dial, and it is set for hit rate, not for headroom: the budget exists to be
+# spent, so a generation that can still answer something stays. What goes is what
+# can answer nothing -- unreachable refs, and generations past keep.
 #
 # Everything else is left alone. The hf-* / *-gguf-* model caches use exact keys,
 # so an entry that looks superseded is the only one its key will ever match and
-# deleting it costs a multi-GB re-download. setup-python does resolve by
-# restore-keys, but its hash is over the dependency file: one generation is live
-# at a time, and a superseded one expires by itself after 7 days unused.
+# deleting it costs a multi-GB re-download.
 
 on:
   schedule:
@@ -36,7 +71,7 @@ on:
         options: [report, delete]
         default: report
       keep:
-        description: 'Generations kept per prefix. 2 so an in-flight run cannot lose the cache it just resolved.'
+        description: 'Generations kept per prefix. 2 so an in-flight run cannot lose the cache it just resolved, and so a reverted dependency bump still hits.'
         type: string
         default: '2'
 
@@ -55,6 +90,7 @@ jobs:
     timeout-minutes: 20
     permissions:
       actions: write
+      pull-requests: read
     steps:
       - name: Prune
         continue-on-error: true  # housekeeping must never page anyone
@@ -68,6 +104,7 @@ jobs:
           set -euo pipefail
           repo="$GITHUB_REPOSITORY"
           all="$RUNNER_TEMP/caches.tsv"
+          live="$RUNNER_TEMP/live.tsv"
           grouped="$RUNNER_TEMP/grouped.tsv"
 
           # Whitelist 1..99. Anything `[ n -le KEEP ]` cannot compare exits 2,
@@ -76,6 +113,8 @@ jobs:
           # exit 0. All-digit is not enough, since a value past bash's integer
           # range fails the same way.
           case "$KEEP" in [1-9]|[1-9][0-9]) ;; *) echo "::warning::invalid keep=$KEEP, using 2"; KEEP=2 ;; esac
+
+          gib() { awk -v b="${1:-0}" 'BEGIN { printf "%.1f", b / 1073741824 }'; }
 
           # Report a failed inventory. Deleting nothing is the safe direction,
           # but silence means a broken janitor looks identical to a clean repo
@@ -89,8 +128,51 @@ jobs:
 
           total=$(awk -F'\t' '{s+=$3} END {printf "%d", s+0}' "$all")
           count=$(grep -c . "$all" || true)
-          echo "$count caches, $(( total / 1073741824 )) GiB, delete=$DELETE keep=$KEEP"
+          echo "$count caches, $(gib "$total") GiB, delete=$DELETE keep=$KEEP"
 
+          freed=0; deleted=0; stale_pr=0
+
+          # Pass 1: caches belonging to a PR that is no longer open. Unreachable
+          # regardless of generation, so this runs before ranking and removes
+          # them from it -- otherwise a merged PR's entries occupy the keep slots
+          # of their own (ref, version, prefix) group and shield each other.
+          declare -A prstate=()
+          : > "$live"
+          while IFS=$'\t' read -r id created size ref ver key; do
+            [ -z "${id:-}" ] && continue
+            num=""
+            case "$ref" in
+              refs/pull/*/merge|refs/pull/*/head)
+                num="${ref#refs/pull/}"; num="${num%/*}" ;;
+            esac
+            if [ -n "$num" ]; then
+              case "$num" in
+                ''|*[!0-9]*) num="" ;;  # not a PR number; fall through to ranking
+              esac
+            fi
+            if [ -n "$num" ]; then
+              if [ -z "${prstate[$num]:-}" ]; then
+                # An error must not read as "closed". Default to open so a rate
+                # limit or a transient 5xx keeps the cache instead of freeing it.
+                prstate[$num]=$(gh api "repos/$repo/pulls/$num" -q '.state' < /dev/null 2>/dev/null || echo open)
+                [ -n "${prstate[$num]}" ] || prstate[$num]=open
+              fi
+              if [ "${prstate[$num]}" != "open" ]; then
+                echo "stale PR #$num ($(gib "$size") GiB): $key"
+                stale_pr=$(( stale_pr + 1 ))
+                if [ "$DELETE" != "yes" ]; then
+                  freed=$(( freed + size )); deleted=$(( deleted + 1 )); continue
+                fi
+                if gh api -X DELETE "repos/$repo/actions/caches/$id" --silent < /dev/null 2>/dev/null; then
+                  freed=$(( freed + size )); deleted=$(( deleted + 1 ))
+                fi
+                continue
+              fi
+            fi
+            printf '%s\t%s\t%s\t%s\t%s\t%s\n' "$id" "$created" "$size" "$ref" "$ver" "$key" >> "$live"
+          done < "$all"
+
+          # Pass 2: rank the survivors by generation within each family.
           : > "$grouped"
           while IFS=$'\t' read -r id created size ref ver key; do
             [ -z "${id:-}" ] && continue
@@ -99,6 +181,13 @@ jobs:
                 pre=$(printf '%s' "$key" | sed -E 's/-[0-9a-f]{40}-[0-9]+-[0-9]+$//') ;;
               v0-rust-*)
                 pre=$(printf '%s' "$key" | sed -E 's/-[0-9a-f]{8,}$//') ;;
+              pip-v2-*|uv-*|fe-dist-*)
+                # Strip only the trailing dependency hash. Everything before it --
+                # the job name for pip-v2, the OS for uv and fe-dist -- stays in the
+                # prefix on purpose: those are separate keys that never substitute
+                # for one another, and folding them into one group would rank live
+                # caches as generations of each other and delete all but two.
+                pre=$(printf '%s' "$key" | sed -E 's/-[0-9a-f]{64}$//') ;;
               *) continue ;;
             esac
             # Unshortened means the suffix did not match, which would make
@@ -110,15 +199,16 @@ jobs:
             # independently. Ranking them together lets two entries from one
             # scope evict every usable entry of another.
             printf '%s\t%s\t%s\t%s\n' "$ref|$ver|$pre" "$created" "$id" "$size" >> "$grouped"
-          done < "$all"
+          done < "$live"
 
           sort -t"$(printf '\t')" -k1,1 -k2,2r -o "$grouped" "$grouped"
 
-          prev=""; n=0; freed=0; deleted=0
+          prev=""; n=0; superseded=0
           while IFS=$'\t' read -r pre created id size; do
             [ -z "${pre:-}" ] && continue
             if [ "$pre" != "$prev" ]; then prev="$pre"; n=1; else n=$(( n + 1 )); fi
             [ "$n" -le "$KEEP" ] && continue
+            superseded=$(( superseded + 1 ))
             if [ "$DELETE" != "yes" ]; then
               freed=$(( freed + size )); deleted=$(( deleted + 1 )); continue
             fi
@@ -130,7 +220,7 @@ jobs:
 
           after=$(( total - freed ))
           verb="pruned"; [ "$DELETE" = "yes" ] || verb="would prune"
-          echo "$verb $deleted caches, $(( freed / 1073741824 )) GiB"
+          echo "$verb $deleted caches, $(gib "$freed") GiB"
           {
             echo "### Cache janitor"
             echo ""
@@ -139,12 +229,16 @@ jobs:
             echo "| mode | $([ "$DELETE" = yes ] && echo delete || echo 'report only') |"
             echo "| kept per prefix | $KEEP |"
             echo "| caches total | $count |"
+            echo "| closed-PR candidates | $stale_pr |"
+            echo "| superseded candidates | $superseded |"
             echo "| candidates $verb | $deleted |"
-            echo "| freed | $(( freed / 1073741824 )) GiB |"
-            echo "| usage before | $(( total / 1073741824 )) GiB of 50 GB |"
-            echo "| usage after | $(( after / 1073741824 )) GiB of 50 GB |"
+            echo "| freed | $(gib "$freed") GiB |"
+            echo "| usage before | $(gib "$total") GiB of 50 GiB |"
+            echo "| usage after | $(gib "$after") GiB of 50 GiB |"
           } >> "$GITHUB_STEP_SUMMARY"
 
+          # 80% of the 50 GiB ceiling. Above this a single dependency bump can
+          # push the repo over between two scheduled sweeps.
           if [ "$after" -gt 42949672960 ]; then
-            echo "::warning::Cache usage is $(( after / 1073741824 )) GiB of 50 GB after pruning. Lower keep to 1, or find the family that grew."
+            echo "::warning::Cache usage is $(gib "$after") GiB of 50 GiB after pruning. Lower keep to 1, or find the family that grew."
           fi

--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -145,6 +145,7 @@ jobs:
         id: pip-cache
         uses: ./.github/actions/pip-cache-restore
         with:
+          name: consolidated
           key-files: |
             pyproject.toml
             studio/backend/requirements/*.txt
@@ -2366,6 +2367,7 @@ jobs:
         id: pip-cache
         uses: ./.github/actions/pip-cache-restore
         with:
+          name: llama-cpp-smoke
           key-files: |
             pyproject.toml
             studio/backend/requirements/*.txt

--- a/.github/workflows/mlx-ci.yml
+++ b/.github/workflows/mlx-ci.yml
@@ -192,6 +192,7 @@ jobs:
         id: pip-cache
         uses: ./.github/actions/pip-cache-restore
         with:
+          name: mlx
           key-files: |
             pyproject.toml
             studio/backend/requirements/*.txt

--- a/.github/workflows/notebooks-ci.yml
+++ b/.github/workflows/notebooks-ci.yml
@@ -293,6 +293,7 @@ jobs:
         # exist and the step fails with "Can't find 'action.yml'".
         uses: ./unsloth/.github/actions/pip-cache-restore
         with:
+          name: notebooks-api
           key-files: |
             unsloth/.github/workflows/notebooks-ci.yml
 
@@ -428,6 +429,7 @@ jobs:
         # exist and the step fails with "Can't find 'action.yml'".
         uses: ./unsloth/.github/actions/pip-cache-restore
         with:
+          name: notebooks-colab
           # The freeze is the pin set, so it is what the downloads depend on. The
           # workflow comes too because the seed step rewrites those pins in place
           # -- CPU index mapping, skips, spoofs -- so an edit there changes what

--- a/.github/workflows/studio-backend-ci.yml
+++ b/.github/workflows/studio-backend-ci.yml
@@ -158,6 +158,7 @@ jobs:
         id: pip-cache
         uses: ./.github/actions/pip-cache-restore
         with:
+          name: studio-backend
           key-files: |
             pyproject.toml
             studio/backend/requirements/*.txt
@@ -360,6 +361,7 @@ jobs:
         id: pip-cache
         uses: ./.github/actions/pip-cache-restore
         with:
+          name: repo-cpu-tests
           key-files: |
             pyproject.toml
             studio/backend/requirements/*.txt

--- a/.github/workflows/studio-export-capability-ci.yml
+++ b/.github/workflows/studio-export-capability-ci.yml
@@ -84,6 +84,7 @@ jobs:
         id: pip-cache
         uses: ./.github/actions/pip-cache-restore
         with:
+          name: studio-export
           key-files: |
             .github/workflows/studio-export-capability-ci.yml
 

--- a/.github/workflows/version-compat-ci.yml
+++ b/.github/workflows/version-compat-ci.yml
@@ -168,6 +168,7 @@ jobs:
         # exist and the step fails with "Can't find 'action.yml'".
         uses: ./unsloth/.github/actions/pip-cache-restore
         with:
+          name: version-compat-spoof
           key-files: |
             unsloth/.github/workflows/version-compat-ci.yml
 
@@ -276,6 +277,7 @@ jobs:
         # exist and the step fails with "Can't find 'action.yml'".
         uses: ./unsloth/.github/actions/pip-cache-restore
         with:
+          name: version-compat-grpo
           key-files: |
             unsloth/.github/workflows/version-compat-ci.yml
 

--- a/tests/studio/test_pip_cache_naming.py
+++ b/tests/studio/test_pip_cache_naming.py
@@ -3,19 +3,17 @@
 
 """Every installing job must own its pip cache key, and no two may share one.
 
-Two failures hide behind a shared key, and neither shows up as red.
+Five jobs did share one, and neither consequence showed up as red.
 
-pip-cache-save is gated on `cache-hit != 'true'`. When five jobs resolved to the
-same key -- which they did, all passing `pyproject.toml` + `studio/backend/
-requirements/*.txt` -- whichever finished first on main wrote the cache and the
-other four restored it EXACTLY, installed their own extra wheels, and never
-saved them. Those extras were re-downloaded on every run of main, forever.
+pip-cache-save is gated on `cache-hit != 'true'`, so whichever job finished
+first on main wrote the cache and the other four restored it EXACTLY, installed
+their own extra wheels, and never saved them -- re-downloading those on every
+run of main, forever.
 
-And a shared prefix cannot be ranked. `cache-janitor.yml` prunes by generation
-within a key prefix; with five live jobs under `pip-<os>-<arch>-py<ver>-` there
-is no way to tell five live caches from five generations of one, so the family
-could not be pruned at all. 57 entries were still resident on 2026-08-26, last
-read a day or more earlier, against a repo at 41.4 of 50 GiB.
+And a shared prefix cannot be ranked. cache-janitor.yml prunes by generation
+within a prefix, and five live jobs under `pip-<os>-<arch>-py<ver>-` are
+indistinguishable from five generations of one, so the family could not be
+pruned at all: 57 stale entries on 2026-08-26, against 41.4 of 50 GiB.
 
 `name` fixes both, and only stays fixed if nothing silently reuses one.
 """
@@ -40,8 +38,7 @@ def _jobs(path):
 
 
 def _restores(steps):
-    # The path differs between workflows: jobs that check the repo out into a
-    # subdirectory say ./unsloth/.github/actions/..., so match on the suffix.
+    # Suffix match: jobs checking out into a subdirectory say ./unsloth/.github/...
     return [s for s in steps if str(s.get("uses", "")).endswith(RESTORE_SUFFIX)]
 
 
@@ -92,9 +89,8 @@ def test_no_two_jobs_share_a_cache_name():
 
 
 def test_jobs_sharing_key_files_still_have_distinct_names():
-    # The regression that produced the original defect: two jobs given the same
-    # key-files are the ones most likely to be given the same name, and that is
-    # exactly the case that must not collapse.
+    # Jobs given the same key-files are the likeliest to be given the same name,
+    # which is the exact case that produced the original defect.
     by_files = {}
     for path in WORKFLOWS:
         for job, steps in _jobs(path):

--- a/tests/studio/test_pip_cache_naming.py
+++ b/tests/studio/test_pip_cache_naming.py
@@ -1,0 +1,135 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Every installing job must own its pip cache key, and no two may share one.
+
+Two failures hide behind a shared key, and neither shows up as red.
+
+pip-cache-save is gated on `cache-hit != 'true'`. When five jobs resolved to the
+same key -- which they did, all passing `pyproject.toml` + `studio/backend/
+requirements/*.txt` -- whichever finished first on main wrote the cache and the
+other four restored it EXACTLY, installed their own extra wheels, and never
+saved them. Those extras were re-downloaded on every run of main, forever.
+
+And a shared prefix cannot be ranked. `cache-janitor.yml` prunes by generation
+within a key prefix; with five live jobs under `pip-<os>-<arch>-py<ver>-` there
+is no way to tell five live caches from five generations of one, so the family
+could not be pruned at all. 57 entries were still resident on 2026-08-26, last
+read a day or more earlier, against a repo at 41.4 of 50 GiB.
+
+`name` fixes both, and only stays fixed if nothing silently reuses one.
+"""
+
+import re
+import pathlib
+
+import pytest
+import yaml
+
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+WORKFLOWS = sorted((REPO / ".github" / "workflows").glob("*.yml"))
+RESTORE_SUFFIX = "actions/pip-cache-restore"
+SAVE_SUFFIX = "actions/pip-cache-save"
+
+
+def _jobs(path):
+    doc = yaml.safe_load(path.read_text()) or {}
+    for name, job in (doc.get("jobs") or {}).items():
+        yield name, (job.get("steps") or [])
+
+
+def _restores(steps):
+    # The path differs between workflows: jobs that check the repo out into a
+    # subdirectory say ./unsloth/.github/actions/..., so match on the suffix.
+    return [s for s in steps if str(s.get("uses", "")).endswith(RESTORE_SUFFIX)]
+
+
+def test_call_sites_exist():
+    # A suffix that matches nothing would make every assertion below vacuous.
+    found = sum(len(_restores(steps)) for p in WORKFLOWS for _, steps in _jobs(p))
+    assert found >= 10, f"only {found} pip-cache-restore call sites found; this test is stale"
+
+
+@pytest.mark.parametrize("path", WORKFLOWS, ids=lambda p: p.name)
+def test_no_builtin_setup_python_pip_cache(path):
+    for job, steps in _jobs(path):
+        for step in steps:
+            if not str(step.get("uses", "")).startswith("actions/setup-python@"):
+                continue
+            assert "cache" not in (step.get("with") or {}), (
+                f"{path.name}:{job} uses setup-python's built-in cache, which saves on "
+                f"whatever ref the job ran on. Use the pip-cache-restore / -save pair."
+            )
+
+
+@pytest.mark.parametrize("path", WORKFLOWS, ids=lambda p: p.name)
+def test_every_restore_names_itself(path):
+    for job, steps in _jobs(path):
+        for step in _restores(steps):
+            name = (step.get("with") or {}).get("name", "")
+            assert re.fullmatch(r"[a-z0-9-]+", name or ""), (
+                f"{path.name}:{job} restore name={name!r} must be lowercase letters, "
+                f"digits and dashes; it goes into the cache key verbatim."
+            )
+            files = [f for f in ((step.get("with") or {}).get("key-files") or "").split() if f]
+            assert files, f"{path.name}:{job} passes no key-files"
+
+
+def test_no_two_jobs_share_a_cache_name():
+    seen = {}
+    for path in WORKFLOWS:
+        for job, steps in _jobs(path):
+            for step in _restores(steps):
+                name = (step.get("with") or {}).get("name") or ""
+                where = f"{path.name}:{job}"
+                assert name not in seen, (
+                    f"cache name {name!r} is used by both {seen[name]} and {where}. "
+                    f"A shared name is a shared key: only the first job to finish on "
+                    f"main saves, the rest silently re-download their extras every run."
+                )
+                seen[name] = where
+
+
+def test_jobs_sharing_key_files_still_have_distinct_names():
+    # The regression that produced the original defect: two jobs given the same
+    # key-files are the ones most likely to be given the same name, and that is
+    # exactly the case that must not collapse.
+    by_files = {}
+    for path in WORKFLOWS:
+        for job, steps in _jobs(path):
+            for step in _restores(steps):
+                with_ = step.get("with") or {}
+                files = " ".join((with_.get("key-files") or "").split())
+                by_files.setdefault(files, []).append((f"{path.name}:{job}", with_.get("name")))
+    for files, entries in by_files.items():
+        names = [n for _, n in entries]
+        assert len(names) == len(set(names)), (
+            f"{len(entries)} jobs share key-files {files!r} and reuse a name among "
+            f"{names}; each needs its own so each can save its own wheels"
+        )
+
+
+def test_key_is_versioned_and_carries_the_name():
+    action = (REPO / ".github/actions/pip-cache-restore/action.yml").read_text()
+    assert 'prefix="pip-v2-${name}-' in action, (
+        "the key must stay pip-v2-<name>-... . The v2 segment is what lets "
+        "cache-janitor.yml match only post-rename keys: 'Linux' is a valid name, so "
+        "a legacy pip-<os>-... key is otherwise indistinguishable from a new one."
+    )
+
+
+def test_janitor_matches_v2_keys_only():
+    janitor = (REPO / ".github/workflows/cache-janitor.yml").read_text()
+    assert "pip-v2-*|uv-*|fe-dist-*)" in janitor, "janitor no longer ranks the pip/uv/fe-dist families"
+    assert "\n              pip-*)" not in janitor, (
+        "the janitor must not match bare pip-* : legacy keys from before `name` "
+        "existed would then be ranked against unrelated jobs' keys and deleted."
+    )
+
+
+def test_save_runs_on_the_default_branch_only():
+    action = yaml.safe_load((REPO / ".github/actions/pip-cache-save/action.yml").read_text())
+    condition = " ".join(str(action["runs"]["steps"][0].get("if", "")).split())
+    assert "github.ref == 'refs/heads/main'" in condition
+    assert "always()" in condition

--- a/tests/studio/test_pip_cache_naming.py
+++ b/tests/studio/test_pip_cache_naming.py
@@ -51,7 +51,7 @@ def test_call_sites_exist():
     assert found >= 10, f"only {found} pip-cache-restore call sites found; this test is stale"
 
 
-@pytest.mark.parametrize("path", WORKFLOWS, ids=lambda p: p.name)
+@pytest.mark.parametrize("path", WORKFLOWS, ids = lambda p: p.name)
 def test_no_builtin_setup_python_pip_cache(path):
     for job, steps in _jobs(path):
         for step in steps:
@@ -63,7 +63,7 @@ def test_no_builtin_setup_python_pip_cache(path):
             )
 
 
-@pytest.mark.parametrize("path", WORKFLOWS, ids=lambda p: p.name)
+@pytest.mark.parametrize("path", WORKFLOWS, ids = lambda p: p.name)
 def test_every_restore_names_itself(path):
     for job, steps in _jobs(path):
         for step in _restores(steps):
@@ -121,7 +121,9 @@ def test_key_is_versioned_and_carries_the_name():
 
 def test_janitor_matches_v2_keys_only():
     janitor = (REPO / ".github/workflows/cache-janitor.yml").read_text()
-    assert "pip-v2-*|uv-*|fe-dist-*)" in janitor, "janitor no longer ranks the pip/uv/fe-dist families"
+    assert (
+        "pip-v2-*|uv-*|fe-dist-*)" in janitor
+    ), "janitor no longer ranks the pip/uv/fe-dist families"
     assert "\n              pip-*)" not in janitor, (
         "the janitor must not match bare pip-* : legacy keys from before `name` "
         "existed would then be ranked against unrelated jobs' keys and deleted."


### PR DESCRIPTION
## The problem

Five jobs passed the same `key-files` to `pip-cache-restore` and so resolved to the same cache key: `consolidated`, `llama-cpp-smoke`, mlx `dispatch`, studio-backend `pytest`, `repo-cpu-tests`. `version-compat-ci`'s two jobs had the same arrangement. Two things follow, and neither shows up as red.

**Four of the five never save anything.** `pip-cache-save` is gated on `cache-hit != 'true'`. Whichever job finished first on main wrote the cache; the other four restored it *exactly*, installed their own extra wheels, and never saved them. Those extras were re-downloaded on every run of main, permanently.

**A shared prefix cannot be ranked.** `cache-janitor.yml` prunes by generation within a key prefix. With five live jobs under `pip-<os>-<arch>-py<ver>-`, nothing distinguishes five live caches from five generations of one — so the largest family in the repo was the one family the janitor could not touch. On 2026-08-26 the repo held 141 caches at **41.4 of 50 GiB**, 57 of them last read a day or more earlier. Those 57 (5.4 GiB) are now cleared by hand; this stops them coming back.

## `name`, and why it identifies the job

`name` is now required on `pip-cache-restore` and identifies the **job**, not the dependency profile. Sharing one entry between jobs that install different things looks thriftier and is not: it buys a partial hit and then discards every wheel the sharing job added. One entry per job costs more bytes and returns a full hit. That is the right trade while there is budget, and the point of the budget is to be spent.

The key becomes `pip-v2-<name>-<os>-<arch>-py<ver>-<hash>`.

The `v2` segment is load-bearing, not decoration. Keys minted before this look like `pip-Linux-X64-py3.12-<hash>`; `Linux` is a valid name, so nothing tells an old key from a new one whose job happens to be called `linux`. The janitor matches `pip-v2-` only, leaving every legacy entry to expire on its own 7-day timer rather than be ranked against keys it has nothing to do with.

## Prefix fallback on the restore

The restore now passes a `restore-keys` prefix. `frontend-dist-restore` deliberately does not, and for a build output that is correct — the wrong generation is wrong. This is pip's HTTP cache, addressed by URL and content hash, where the previous generation is the current one minus whatever moved. A dependency bump costs the changed wheels instead of all of them, and a stale entry cannot serve wrong content. It is the same argument that already lets the key carry `3.12` rather than `3.12.14`. `name` sits inside the prefix, so a fallback never hands one job another's wheels.

## Call sites

| workflow | job | `name` |
| --- | --- | --- |
| consolidated-tests-ci | consolidated | `consolidated` |
| consolidated-tests-ci | llama-cpp-smoke | `llama-cpp-smoke` |
| mlx-ci | dispatch | `mlx` |
| notebooks-ci | api-introspect | `notebooks-api` |
| notebooks-ci | smoke-install | `notebooks-colab` |
| studio-backend-ci | pytest | `studio-backend` |
| studio-backend-ci | repo-cpu-tests | `repo-cpu-tests` |
| studio-export-capability-ci | capability | `studio-export` |
| version-compat-ci | zoo-imports-under-spoof | `version-compat-spoof` |
| version-compat-ci | grpo-fake-run | `version-compat-grpo` |

## Janitor

Gains the closed-PR sweep, fractional-GiB reporting and the corrected eviction wording from unslothai/unsloth-zoo#1107 (the 50 GiB constant was already right here), plus three families it could not previously rank: `pip-v2-*`, `uv-*`, `fe-dist-*`.

Replayed against a fixture built from the live inventory, with `gh` stubbed, `keep=2`:

```
145 caches, 44.6 GiB, delete=yes keep=2
pruned 58 caches, 3.5 GiB
deleted by family: {'fe-dist': 53, 'uv': 3, 'pip-v2': 2}
```

The two `pip-v2` deletions are the two oldest of a synthetic four-generation group; a single-generation `pip-v2-mlx` is untouched, and **zero** legacy `pip-<os>-` entries enter the ranking. `uv-Linux` (4 entries) drops 2 and `uv-macOS` (3) drops 1, as `keep=2` should.

## Test

`tests/studio/test_pip_cache_naming.py` (92 cases): no workflow uses setup-python's built-in cache; every restore names itself with a well-formed name; no two jobs share a name; jobs that share `key-files` still have distinct names (the regression that produced this defect); the key stays `pip-v2-<name>-`; the janitor matches `pip-v2-` and never bare `pip-*`; the save stays gated to main with `always()`.

## Deliberately not in this PR

Several jobs place the save many steps after the install — `consolidated` restores at step 2 and saves at step 28. A composite step with no `if:` is skipped once an earlier step has failed, so a red test between them discards a completed install. Worth fixing; it moves steps in ten jobs and belongs in its own change.
