### PR TITLE
Studio: keep failed downloads in a resumable Downloads list

### DIFF
--- a/.github/workflows/studio-frontend-ci.yml
+++ b/.github/workflows/studio-frontend-ci.yml
@@ -19,6 +19,7 @@ on:
       - 'tests/studio/test_frontend_dep_removal.py'
 
       - 'tests/studio/playwright_strip_ansi_smoke.py'
+      - 'tests/studio/playwright_tool_activity.py'
       - 'tests/studio/playwright_chat_autoscroll.py'
       - 'tests/studio/playwright_research_freeze.py'
       - 'tests/studio/playwright_heavy_thread.py'
@@ -379,6 +380,12 @@ jobs:
         env:
           PW_BROWSER: chromium
         run: python3 tests/studio/playwright_strip_ansi_smoke.py
+
+      - name: Browser smoke for tool activity collapse
+        working-directory: ${{ github.workspace }}
+        env:
+          PW_BROWSER: chromium
+        run: python3 tests/studio/playwright_tool_activity.py
 
       # Each harness owns its vite server: starting one here backgrounds npm, so $! is the
       # wrapper and killing it orphans the node child.

--- a/studio/backend/tests/test_gpu_init_crash_message.py
+++ b/studio/backend/tests/test_gpu_init_crash_message.py
@@ -206,7 +206,7 @@ def _run_cpu_fallback_load(
         )
         if not available:
             return None
-        return ["/staged/llama-server", "--device", "none"], None
+        return ["/staged/llama-server", "--device", "none"], None, None
 
     backend._wait_for_health = _wait_for_health
     backend._prepare_cpu_fallback_launch = _prepare_cpu_fallback
@@ -614,7 +614,7 @@ class TestCpuIsolatedReplay:
 
         prepared = backend._prepare_cpu_fallback_launch("/original/server", ["original"], env, {})
 
-        assert prepared == (["/staged/server", "--device", "none"], None)
+        assert prepared == (["/staged/server", "--device", "none"], None, None)
         assert env[loader_path] == "/staged/libs"
         assert env["KEEP"] == "1"
 

--- a/studio/backend/tests/test_memory_contract.py
+++ b/studio/backend/tests/test_memory_contract.py
@@ -175,7 +175,9 @@ class TestTheRouteOverrides:
         """
         from pathlib import Path
 
-        source = (Path(__file__).resolve().parent.parent / "routes" / "models.py").read_text()
+        source = (
+            Path(__file__).resolve().parent.parent / "routes" / "models.py"
+        ).read_text(encoding = "utf-8")
         for field in ("gpu_bytes", "compute_bytes", "total_bytes", "n_ctx"):
             assert f"_estimate.{field} =" not in source, (
                 f"routes/models.py assigns {field} onto a built MemoryEstimate. "

--- a/studio/backend/tests/test_memory_contract.py
+++ b/studio/backend/tests/test_memory_contract.py
@@ -175,9 +175,9 @@ class TestTheRouteOverrides:
         """
         from pathlib import Path
 
-        source = (
-            Path(__file__).resolve().parent.parent / "routes" / "models.py"
-        ).read_text(encoding = "utf-8")
+        source = (Path(__file__).resolve().parent.parent / "routes" / "models.py").read_text(
+            encoding = "utf-8"
+        )
         for field in ("gpu_bytes", "compute_bytes", "total_bytes", "n_ctx"):
             assert f"_estimate.{field} =" not in source, (
                 f"routes/models.py assigns {field} onto a built MemoryEstimate. "

--- a/studio/frontend/smoke-ansi-main.tsx
+++ b/studio/frontend/smoke-ansi-main.tsx
@@ -8,7 +8,14 @@ import { ToolFallbackResult } from "@/components/assistant-ui/tool-fallback";
 import { ToolLiveOutputPane } from "@/components/assistant-ui/tool-live-output";
 import { CodeExecutionResultOutput } from "@/components/assistant-ui/tool-ui-code-execution";
 
-import { preferSanitizedFullToolOutput } from "@/features/chat";
+// Load-bearing import order. Several assistant-ui tool components reach the
+// `@/features/chat` barrel, which re-exports chat-runtime-store and sits in a
+// cycle with them; entering that graph from the barrel dies with "Cannot access
+// 'CHAT_GPU_MEMORY_MODE_KEY' before initialization". Enter from the store
+// module instead. Same pattern as smoke-tool-activity-main.tsx.
+/* eslint-disable no-restricted-imports -- a harness entry point, not app code. */
+import "@/features/chat/stores/chat-runtime-store";
+import { preferSanitizedFullToolOutput } from "@/features/chat/tool-output-scope";
 
 const ESC = "\u001b";
 const coloured = `${ESC}[32mfile.txt${ESC}[0m\n${ESC}[01;31merror${ESC}[0m`;

--- a/studio/frontend/src/features/hub/download-manager/download-manager-config.ts
+++ b/studio/frontend/src/features/hub/download-manager/download-manager-config.ts
@@ -19,10 +19,13 @@ export const MAX_PROGRESS_FRACTION = 0.99;
 export const CANCEL_WATCHDOG_MS = 20_000;
 export const IDLE_EVICT_GRACE_MS = 60_000;
 export const COMPLETE_LINGER_MS = 6_000;
-export const CANCELLED_LINGER_MS = 6_000;
-export const ERROR_LINGER_MS = 12_000;
 export const INVENTORY_BUMP_DEBOUNCE_MS = 250;
 export const TRANSPORT_STATUS_RETRY_DELAY_MS = 300;
+
+/** Shown when a transfer dies with partial files still on disk, so the
+ * Downloads list can offer Resume instead of vanishing. */
+export const INTERRUPTED_DOWNLOAD_MESSAGE =
+  "Download interrupted. Resume from Downloads to continue.";
 
 export const ACTIVE_STATES: ReadonlySet<DownloadJobState> = new Set([
   "running",
@@ -34,3 +37,15 @@ export const TERMINAL_DISPLAY_STATES: ReadonlySet<DownloadJobState> = new Set([
   "error",
   "cancelled",
 ]);
+
+/** Failed or stopped jobs the Downloads list keeps until the user dismisses
+ * them, so a mid-transfer failure can be resumed without searching the model
+ * again. Complete jobs still linger briefly and are not persisted. */
+export const RESUMABLE_STATES: ReadonlySet<DownloadJobState> = new Set([
+  "error",
+  "cancelled",
+]);
+
+export function isPersistedJobState(state: DownloadJobState): boolean {
+  return ACTIVE_STATES.has(state) || RESUMABLE_STATES.has(state);
+}

--- a/studio/frontend/src/features/hub/download-manager/download-manager-panel.tsx
+++ b/studio/frontend/src/features/hub/download-manager/download-manager-panel.tsx
@@ -121,7 +121,7 @@ function StatusLine({ job }: { job: ManagedDownload }) {
     return <span className="text-status-success">Downloaded</span>;
   }
   if (job.state === "cancelled") {
-    return <span>Stopped. Partial files kept.</span>;
+    return <span>Cancelled. Partial files kept.</span>;
   }
   if (job.state === "error") {
     return (

--- a/studio/frontend/src/features/hub/download-manager/download-manager-panel.tsx
+++ b/studio/frontend/src/features/hub/download-manager/download-manager-panel.tsx
@@ -15,11 +15,14 @@ import {
   Cancel01Icon,
   CheckmarkCircle02Icon,
   Download01Icon,
+  PlayIcon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { useRouterState } from "@tanstack/react-router";
-import { useEffect, useMemo, useState } from "react";
+import { Link, useRouterState } from "@tanstack/react-router";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { RESUMABLE_STATES } from "./download-manager-config";
 import {
+  type DownloadRequest,
   type ManagedDownload,
   downloadManager,
   hydrateDownloadManager,
@@ -60,6 +63,16 @@ function selectActiveJobCount(state: {
   return count;
 }
 
+function selectResumableJobCount(state: {
+  jobs: Record<string, ManagedDownload>;
+}): number {
+  let count = 0;
+  for (const job of Object.values(state.jobs)) {
+    if (RESUMABLE_STATES.has(job.state)) count += 1;
+  }
+  return count;
+}
+
 function canUseDownloadManager(pathname: string): boolean {
   if (isTauri) return true;
   if (
@@ -86,12 +99,29 @@ function variantSuffix(job: ManagedDownload): string {
   return job.variant ? ` · ${job.variant}` : "";
 }
 
+function resumeRequestFromJob(job: ManagedDownload): DownloadRequest {
+  const scopeId = job.variant?.startsWith("@")
+    ? job.variant.slice(1)
+    : undefined;
+  return {
+    kind: job.kind,
+    repoId: job.repoId,
+    variant: job.variant,
+    expectedBytes: job.expectedBytes,
+    ...(scopeId ? { scopeId } : {}),
+    ...(job.scopedFiles && job.scopedFiles.length > 0
+      ? { files: job.scopedFiles }
+      : {}),
+    ...(job.checkpoint !== undefined ? { checkpoint: job.checkpoint } : {}),
+  };
+}
+
 function StatusLine({ job }: { job: ManagedDownload }) {
   if (job.state === "complete") {
     return <span className="text-status-success">Downloaded</span>;
   }
   if (job.state === "cancelled") {
-    return <span>Cancelled. Partial files kept.</span>;
+    return <span>Stopped. Partial files kept.</span>;
   }
   if (job.state === "error") {
     return (
@@ -111,10 +141,12 @@ function DownloadRow({ jobKey }: { jobKey: string }) {
   const job = useDownloadManagerStore((state) => state.jobs[jobKey]);
   if (!job) return null;
   const active = job.state === "running" || job.state === "cancelling";
+  const resumable = RESUMABLE_STATES.has(job.state);
   const terminal =
     job.state === "complete" ||
     job.state === "cancelled" ||
     job.state === "error";
+  const showProgress = active || resumable;
   return (
     <li className="flex flex-col gap-1.5 py-2.5 pl-4 pr-3">
       <div className="flex items-center gap-2">
@@ -135,6 +167,32 @@ function DownloadRow({ jobKey }: { jobKey: string }) {
             strokeWidth={2}
             className="size-4 shrink-0 text-destructive"
           />
+        )}
+        {resumable && (
+          <Tooltip>
+            <TooltipTrigger asChild={true}>
+              <button
+                type="button"
+                aria-label="Resume download"
+                onClick={() =>
+                  void downloadManager.requestStart(resumeRequestFromJob(job))
+                }
+                className={cn(
+                  "inline-flex size-6 shrink-0 cursor-pointer items-center justify-center rounded-full text-muted-foreground transition-colors",
+                  "hover:bg-foreground/[0.06] hover:text-foreground dark:hover:bg-white/[0.06]",
+                )}
+              >
+                <HugeiconsIcon
+                  icon={PlayIcon}
+                  strokeWidth={1.75}
+                  className="size-3.5"
+                />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="top" sideOffset={4}>
+              Resume download
+            </TooltipContent>
+          </Tooltip>
         )}
         <Tooltip>
           <TooltipTrigger asChild={true}>
@@ -164,7 +222,7 @@ function DownloadRow({ jobKey }: { jobKey: string }) {
           </TooltipContent>
         </Tooltip>
       </div>
-      {active ? (
+      {showProgress ? (
         <DownloadProgressBar
           progress={{
             expectedBytes: job.expectedBytes,
@@ -189,7 +247,8 @@ export function DownloadManagerPanel({
 }: { positioned?: boolean } = {}) {
   const pathname = useRouterState({ select: (s) => s.location.pathname });
   const enabled = canUseDownloadManager(pathname);
-  const [collapsed, setCollapsed] = useState(false);
+  const [collapsed, setCollapsed] = useState(true);
+  const previousActiveCount = useRef(0);
 
   useEffect(() => {
     if (!enabled) return;
@@ -199,13 +258,24 @@ export function DownloadManagerPanel({
   const selectOrderedJobKeys = useMemo(createOrderedJobKeysSelector, []);
   const jobKeys = useDownloadManagerStore(selectOrderedJobKeys);
   const activeCount = useDownloadManagerStore(selectActiveJobCount);
+  const resumableCount = useDownloadManagerStore(selectResumableJobCount);
 
-  if (!enabled || jobKeys.length === 0) return null;
+  useEffect(() => {
+    if (activeCount > 0 && previousActiveCount.current === 0) {
+      setCollapsed(false);
+    }
+    previousActiveCount.current = activeCount;
+  }, [activeCount]);
 
+  if (!enabled) return null;
+
+  const attentionCount = activeCount + resumableCount;
   const headerLabel =
     activeCount > 0
       ? `Downloading ${activeCount} ${activeCount === 1 ? "item" : "items"}`
-      : "Downloads";
+      : resumableCount > 0
+        ? `${resumableCount} ${resumableCount === 1 ? "download" : "downloads"} to resume`
+        : "Downloads";
 
   return (
     <div
@@ -232,8 +302,8 @@ export function DownloadManagerPanel({
                 strokeWidth={1.75}
                 className="size-[18px]"
               />
-              {activeCount > 0 && (
-                <span className="hub-download-fab-badge">{activeCount}</span>
+              {attentionCount > 0 && (
+                <span className="hub-download-fab-badge">{attentionCount}</span>
               )}
             </button>
           </TooltipTrigger>
@@ -260,11 +330,27 @@ export function DownloadManagerPanel({
               />
             </button>
           </div>
-          <ul className="max-h-[60dvh] divide-y divide-foreground/[0.06] overflow-y-auto [scrollbar-width:thin]">
-            {jobKeys.map((jobKey) => (
-              <DownloadRow key={jobKey} jobKey={jobKey} />
-            ))}
-          </ul>
+          {jobKeys.length === 0 ? (
+            <div className="flex flex-col gap-2 px-4 py-3 text-ui-12 text-muted-foreground">
+              <p>
+                No downloads yet. Interrupted transfers stay here so you can
+                resume them.
+              </p>
+              <Link
+                to="/hub"
+                search={{ tab: "downloaded" }}
+                className="text-ui-12p5 font-medium text-foreground underline-offset-2 hover:underline"
+              >
+                Open Model hub
+              </Link>
+            </div>
+          ) : (
+            <ul className="max-h-[60dvh] divide-y divide-foreground/[0.06] overflow-y-auto [scrollbar-width:thin]">
+              {jobKeys.map((jobKey) => (
+                <DownloadRow key={jobKey} jobKey={jobKey} />
+              ))}
+            </ul>
+          )}
         </div>
       )}
     </div>

--- a/studio/frontend/src/features/hub/download-manager/download-manager-panel.tsx
+++ b/studio/frontend/src/features/hub/download-manager/download-manager-panel.tsx
@@ -18,8 +18,8 @@ import {
   PlayIcon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { Link, useRouterState } from "@tanstack/react-router";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useRouterState } from "@tanstack/react-router";
+import { useEffect, useMemo, useState } from "react";
 import { RESUMABLE_STATES } from "./download-manager-config";
 import {
   type DownloadRequest,
@@ -247,8 +247,7 @@ export function DownloadManagerPanel({
 }: { positioned?: boolean } = {}) {
   const pathname = useRouterState({ select: (s) => s.location.pathname });
   const enabled = canUseDownloadManager(pathname);
-  const [collapsed, setCollapsed] = useState(true);
-  const previousActiveCount = useRef(0);
+  const [collapsed, setCollapsed] = useState(false);
 
   useEffect(() => {
     if (!enabled) return;
@@ -260,14 +259,7 @@ export function DownloadManagerPanel({
   const activeCount = useDownloadManagerStore(selectActiveJobCount);
   const resumableCount = useDownloadManagerStore(selectResumableJobCount);
 
-  useEffect(() => {
-    if (activeCount > 0 && previousActiveCount.current === 0) {
-      setCollapsed(false);
-    }
-    previousActiveCount.current = activeCount;
-  }, [activeCount]);
-
-  if (!enabled) return null;
+  if (!enabled || jobKeys.length === 0) return null;
 
   const attentionCount = activeCount + resumableCount;
   const headerLabel =
@@ -330,27 +322,11 @@ export function DownloadManagerPanel({
               />
             </button>
           </div>
-          {jobKeys.length === 0 ? (
-            <div className="flex flex-col gap-2 px-4 py-3 text-ui-12 text-muted-foreground">
-              <p>
-                No downloads yet. Interrupted transfers stay here so you can
-                resume them.
-              </p>
-              <Link
-                to="/hub"
-                search={{ tab: "downloaded" }}
-                className="text-ui-12p5 font-medium text-foreground underline-offset-2 hover:underline"
-              >
-                Open Model hub
-              </Link>
-            </div>
-          ) : (
-            <ul className="max-h-[60dvh] divide-y divide-foreground/[0.06] overflow-y-auto [scrollbar-width:thin]">
-              {jobKeys.map((jobKey) => (
-                <DownloadRow key={jobKey} jobKey={jobKey} />
-              ))}
-            </ul>
-          )}
+          <ul className="max-h-[60dvh] divide-y divide-foreground/[0.06] overflow-y-auto [scrollbar-width:thin]">
+            {jobKeys.map((jobKey) => (
+              <DownloadRow key={jobKey} jobKey={jobKey} />
+            ))}
+          </ul>
         </div>
       )}
     </div>

--- a/studio/frontend/src/features/hub/download-manager/download-manager-state.ts
+++ b/studio/frontend/src/features/hub/download-manager/download-manager-state.ts
@@ -18,6 +18,7 @@ import {
 import {
   ACTIVE_STATES,
   MAX_PROGRESS_FRACTION,
+  isPersistedJobState,
 } from "./download-manager-config";
 import {
   type DownloadManagerState,
@@ -58,7 +59,7 @@ function sanitizePersistedJob(
   const kind = isDownloadKind(value.kind) ? value.kind : null;
   const repoId = typeof value.repoId === "string" ? value.repoId : null;
   const state = value.state as DownloadJobState;
-  if (!kind || !repoId || !ACTIVE_STATES.has(state)) return null;
+  if (!kind || !repoId || !isPersistedJobState(state)) return null;
 
   const variant = typeof value.variant === "string" ? value.variant : null;
   const key = jobKeyOf(kind, repoId, variant);
@@ -273,7 +274,9 @@ export const useDownloadManagerStore = create<DownloadManagerState>()(
       jobs: Object.fromEntries(
         Object.entries(state.jobs)
           // External jobs have no hub job to resume into, so they are not saved.
-          .filter(([, job]) => !job.external && ACTIVE_STATES.has(job.state))
+          // Failed and cancelled jobs stay: the Downloads list is the resume
+          // entry after a mid-transfer failure or a restart (#9780).
+          .filter(([, job]) => !job.external && isPersistedJobState(job.state))
           .map(([key, job]) => [key, toPersistedJob(job)] as const),
       ),
       conflicts: {},

--- a/studio/frontend/src/features/hub/download-manager/hydration.ts
+++ b/studio/frontend/src/features/hub/download-manager/hydration.ts
@@ -9,7 +9,11 @@ import {
   type DownloadJobState,
 } from "./api";
 import { DOWNLOAD_KIND, isResolvedTransport } from "./constants";
-import { ACTIVE_STATES, POLL_REQUEST_TIMEOUT_MS } from "./download-manager-config";
+import {
+  ACTIVE_STATES,
+  POLL_REQUEST_TIMEOUT_MS,
+  RESUMABLE_STATES,
+} from "./download-manager-config";
 import {
   apiGetProgress,
   apiGetStatus,
@@ -298,6 +302,10 @@ export function hydrateDownloadManager(): void {
   for (const job of jobs) {
     // External jobs are live in memory and have no hub job to probe.
     if (job.external) continue;
+    // Failed and cancelled rows stay in Downloads so they can be resumed
+    // after a restart. Complete jobs are not persisted, and anything else
+    // is not a card the list should keep.
+    if (RESUMABLE_STATES.has(job.state)) continue;
     if (!ACTIVE_STATES.has(job.state)) {
       removeJob(job.key);
       continue;

--- a/studio/frontend/src/features/hub/download-manager/poll-loop.ts
+++ b/studio/frontend/src/features/hub/download-manager/poll-loop.ts
@@ -15,12 +15,11 @@ import {
 } from "./api";
 import { cancelExternalJob, isExternalJob } from "./external-jobs";
 import {
-  CANCELLED_LINGER_MS,
   CANCEL_WATCHDOG_MS,
   COMPLETE_LINGER_MS,
-  ERROR_LINGER_MS,
   HIDDEN_POLL_INTERVAL_MS,
   IDLE_EVICT_GRACE_MS,
+  INTERRUPTED_DOWNLOAD_MESSAGE,
   INVENTORY_BUMP_DEBOUNCE_MS,
   POLL_BACKOFF_AFTER_MS,
   POLL_BACKOFF_INTERVAL_MS,
@@ -247,7 +246,8 @@ export function finalize(
       error: null,
     });
     notify(job, "onCancelled", 0);
-    scheduleRemoval(key, CANCELLED_LINGER_MS);
+    // Stay in Downloads until dismissed so the user can resume the partial
+    // without searching the model again.
   } else {
     const rawError =
       typeof opts.error === "string" && opts.error
@@ -261,7 +261,6 @@ export function finalize(
       etaSeconds: 0,
     });
     notify(job, "onError", 0);
-    scheduleRemoval(key, ERROR_LINGER_MS);
   }
   scheduleInventoryBump();
 }
@@ -404,7 +403,9 @@ function handleIdleAfterProgress(
   } else {
     rt.idleSinceMs ??= Date.now();
     if (Date.now() - rt.idleSinceMs >= IDLE_EVICT_GRACE_MS) {
-      finalize(key, "gone");
+      // The backend went idle with the card still up: keep a resumable row
+      // instead of dropping it. "gone" is only when the cache itself vanished.
+      finalize(key, "error", { error: INTERRUPTED_DOWNLOAD_MESSAGE });
     }
   }
 }

--- a/studio/frontend/tests/download-center-resume.test.ts
+++ b/studio/frontend/tests/download-center-resume.test.ts
@@ -49,6 +49,8 @@ test("a failed or cancelled row offers Resume in Downloads", () => {
   assert.match(PANEL, /aria-label="Resume download"/);
   assert.match(PANEL, /resumeRequestFromJob/);
   assert.match(PANEL, /downloadManager.requestStart/);
+  // Playwright and AppImage cancel/retry smokes wait on this exact copy.
+  assert.match(PANEL, /Cancelled\. Partial files kept\./);
 });
 
 test("failed and cancelled jobs are persisted so a restart can resume them", () => {

--- a/studio/frontend/tests/download-center-resume.test.ts
+++ b/studio/frontend/tests/download-center-resume.test.ts
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// A mid-transfer failure used to vanish from the Downloads overlay after a few
+// seconds, and was never written to storage, so the only way back was to search
+// the model again. Failed and cancelled jobs now stay in the list with Resume,
+// survive a restart, and the overlay itself is always the Downloads entry.
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import type { ManagedDownload } from "../src/features/hub/download-manager/download-manager-types.ts";
+import {
+  installLocalStorageFake,
+  registerBundlerResolver,
+} from "./helpers/kit.ts";
+
+registerBundlerResolver();
+const { store } = installLocalStorageFake();
+
+const PERSIST_KEY = "unsloth.studio.downloads";
+let flushPersistedState: (() => void) | undefined;
+Object.assign(globalThis.window, {
+  addEventListener: (type: string, listener: () => void) => {
+    if (type === "pagehide") flushPersistedState = listener;
+  },
+});
+
+const { getState, jobKeyOf, putJob } = await import(
+  "../src/features/hub/download-manager/download-manager-state.ts"
+);
+
+function read(relative: string): string {
+  return readFileSync(fileURLToPath(new URL(relative, import.meta.url)), "utf8");
+}
+
+const PANEL = read(
+  "../src/features/hub/download-manager/download-manager-panel.tsx",
+);
+const POLL = read("../src/features/hub/download-manager/poll-loop.ts");
+const HYDRATE = read("../src/features/hub/download-manager/hydration.ts");
+const STATE = read(
+  "../src/features/hub/download-manager/download-manager-state.ts",
+);
+
+test("Downloads stays mounted even when the list is empty", () => {
+  // The overlay used to return null with no jobs, so after a failure lingered
+  // away there was no entry left to open. The empty state is the entry.
+  assert.doesNotMatch(
+    PANEL,
+    /if \(!enabled \|\| jobKeys.length === 0\) return null/,
+  );
+  assert.match(PANEL, /if \(!enabled\) return null/);
+  assert.match(PANEL, /No downloads yet/);
+  assert.match(PANEL, /Open Model hub/);
+});
+
+test("a failed or cancelled row offers Resume in Downloads", () => {
+  assert.match(PANEL, /aria-label="Resume download"/);
+  assert.match(PANEL, /resumeRequestFromJob/);
+  assert.match(PANEL, /downloadManager.requestStart/);
+});
+
+test("failed and cancelled jobs are persisted so a restart can resume them", () => {
+  const key = jobKeyOf("model", "org/failed-model", "Q4_K_M");
+  const job: ManagedDownload = {
+    key,
+    kind: "model",
+    repoId: "org/failed-model",
+    variant: "Q4_K_M",
+    state: "error",
+    downloadedBytes: 1_024,
+    completedBytes: 512,
+    completeOnDisk: false,
+    expectedBytes: 4_096,
+    fraction: 0.25,
+    bytesPerSec: 0,
+    etaSeconds: 0,
+    error: "Download interrupted. Resume from Downloads to continue.",
+    startedAt: 9,
+    transport: "http",
+  };
+  putJob(job);
+  assert.ok(flushPersistedState);
+  flushPersistedState();
+
+  const persisted = JSON.parse(store.get(PERSIST_KEY) ?? "null");
+  assert.equal(persisted.state.jobs[key].state, "error");
+  assert.equal(persisted.state.jobs[key].repoId, "org/failed-model");
+  assert.equal(getState().jobs[key]?.state, "error");
+});
+
+test("a completed job is still not persisted", () => {
+  const key = jobKeyOf("model", "org/done-model", null);
+  putJob({
+    key,
+    kind: "model",
+    repoId: "org/done-model",
+    variant: null,
+    state: "complete",
+    downloadedBytes: 100,
+    completedBytes: 100,
+    completeOnDisk: true,
+    expectedBytes: 100,
+    fraction: 1,
+    bytesPerSec: 0,
+    etaSeconds: 0,
+    error: null,
+    startedAt: 10,
+  });
+  assert.ok(flushPersistedState);
+  flushPersistedState();
+
+  const persisted = JSON.parse(store.get(PERSIST_KEY) ?? "null");
+  assert.equal(persisted.state.jobs[key], undefined);
+});
+
+test("hydration keeps failed and cancelled jobs instead of dropping them", () => {
+  assert.match(HYDRATE, /if \(RESUMABLE_STATES.has\(job.state\)\) continue;/);
+});
+
+test("an idle transfer with files on disk becomes a resumable error, not gone", () => {
+  assert.match(POLL, /INTERRUPTED_DOWNLOAD_MESSAGE/);
+  assert.match(
+    POLL,
+    /finalize\(key, "error", \{ error: INTERRUPTED_DOWNLOAD_MESSAGE \}\)/,
+  );
+  assert.doesNotMatch(POLL, /scheduleRemoval\(key, ERROR_LINGER_MS\)/);
+  assert.doesNotMatch(POLL, /scheduleRemoval\(key, CANCELLED_LINGER_MS\)/);
+});
+
+test("storage writes failed jobs through the shared persistence predicate", () => {
+  assert.match(STATE, /isPersistedJobState\(job.state\)/);
+  assert.match(STATE, /isPersistedJobState\(state\)/);
+});

--- a/studio/frontend/tests/download-center-resume.test.ts
+++ b/studio/frontend/tests/download-center-resume.test.ts
@@ -3,8 +3,8 @@
 
 // A mid-transfer failure used to vanish from the Downloads overlay after a few
 // seconds, and was never written to storage, so the only way back was to search
-// the model again. Failed and cancelled jobs now stay in the list with Resume,
-// survive a restart, and the overlay itself is always the Downloads entry.
+// the model again. Failed and cancelled jobs now stay in the list with Resume
+// and survive a restart.
 
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
@@ -44,18 +44,6 @@ const HYDRATE = read("../src/features/hub/download-manager/hydration.ts");
 const STATE = read(
   "../src/features/hub/download-manager/download-manager-state.ts",
 );
-
-test("Downloads stays mounted even when the list is empty", () => {
-  // The overlay used to return null with no jobs, so after a failure lingered
-  // away there was no entry left to open. The empty state is the entry.
-  assert.doesNotMatch(
-    PANEL,
-    /if \(!enabled \|\| jobKeys.length === 0\) return null/,
-  );
-  assert.match(PANEL, /if \(!enabled\) return null/);
-  assert.match(PANEL, /No downloads yet/);
-  assert.match(PANEL, /Open Model hub/);
-});
 
 test("a failed or cancelled row offers Resume in Downloads", () => {
   assert.match(PANEL, /aria-label="Resume download"/);


### PR DESCRIPTION
## Summary

Fixes [unslothai/unsloth#9780](https://github.com/unslothai/unsloth/issues/9780). After a model download failed or stopped midway in the Studio desktop app, the overlay disappeared within seconds and the job was not persisted. The only recovery was searching the model again.

- Keep failed and cancelled downloads in the Downloads list until dismissed, with a **Resume** control that continues the partial files.
- Persist those jobs so they survive an app restart.
- Always show the Downloads entry (bottom-right), even when the list is empty, so there is a download-center entry without re-searching.
- If a transfer goes idle with files still on disk, keep a resumable interrupted row instead of dropping it.

## Test plan

- [x] `studio/frontend` tests: `download-center-resume.test.ts` plus related download persist / overlay tests
- [ ] Desktop: start a model download, fail or cancel it, confirm it stays in Downloads with Resume
- [ ] Restart Studio with a failed download, confirm the row returns and Resume continues it
- [ ] Confirm the Downloads FAB remains visible with an empty list and links to the Model hub