### PR TITLE
README: drop the Linux (Arm64) download row, which serves a macOS file

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,6 @@ Download the native Unsloth Desktop app for your operating system:
     <td><b>Linux (AppImage)</b></td>
     <td><a href='https://github.com/unslothai/unsloth/releases/download/v0.1.803-beta/Unsloth-Desktop-0_1_803_beta-Linux.AppImage'>Download</a></td>
   </tr>
-  <tr>
-    <td><b>Linux (Arm64)</b></td>
-    <td><a href='https://github.com/unslothai/unsloth/releases/download/v0.1.803-beta/Unsloth-Desktop-0_1_803_beta-ARM64.app.tar.gz'>Download</a></td>
-  </tr>
 </table>
 
 Download from [Unsloth](https://unsloth.ai/download) or [GitHub Releases](https://github.com/unslothai/unsloth/releases).
@@ -128,10 +124,6 @@ Unsloth can be used in three ways: **[Unsloth Desktop](https://unsloth.ai/downlo
   <tr>
     <td><b>Linux (AppImage)</b></td>
     <td><a href='https://github.com/unslothai/unsloth/releases/download/v0.1.803-beta/Unsloth-Desktop-0_1_803_beta-Linux.AppImage'>Download</a></td>
-  </tr>
-  <tr>
-    <td><b>Linux (Arm64)</b></td>
-    <td><a href='https://github.com/unslothai/unsloth/releases/download/v0.1.803-beta/Unsloth-Desktop-0_1_803_beta-ARM64.app.tar.gz'>Download</a></td>
   </tr>
 </table>
 

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -25569,8 +25569,7 @@ class LlamaCppBackend:
                 yield _ev
             conversation.extend(_auto["messages"])
         _auto_satisfies_forced_choice = bool(_auto) and (
-            tool_choice == "required"
-            or forced_tool_name(tool_choice) == "search_knowledge_base"
+            tool_choice == "required" or forced_tool_name(tool_choice) == "search_knowledge_base"
         )
 
         _accumulated_completion_tokens = 0
@@ -25786,9 +25785,7 @@ class LlamaCppBackend:
             requested_choice = "auto" if tool_choice is None else tool_choice
             if _forced_choice_resolved and requested_choice not in ("auto", "none"):
                 requested_choice = "auto"
-            requested_choice = (
-                reconciled_tool_choice(requested_choice, tools, safe_tools) or "auto"
-            )
+            requested_choice = reconciled_tool_choice(requested_choice, tools, safe_tools) or "auto"
             forced_name = forced_tool_name(requested_choice)
             if forced_name:
                 matching_tools = [

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -16464,7 +16464,6 @@ async def openai_chat_completions(
 
     def _reject_missing_forced_tool(tool_choice, selected_tools) -> None:
         from core.inference.chat_template_helpers import catalog_tool_names, forced_tool_name
-
         forced_name = forced_tool_name(tool_choice)
         if forced_name and forced_name not in catalog_tool_names(selected_tools):
             raise _reject(
@@ -23683,9 +23682,7 @@ async def anthropic_messages(
         server_tool_choice = openai_tool_choice
         if isinstance(server_tool_choice, dict):
             forced_function = server_tool_choice.get("function")
-            forced_name = (
-                forced_function.get("name") if isinstance(forced_function, dict) else None
-            )
+            forced_name = forced_function.get("name") if isinstance(forced_function, dict) else None
             canonical_name = _STUDIO_ANTHROPIC_TOOL_ALIASES.get(forced_name)
             if canonical_name:
                 server_tool_choice = {

--- a/studio/backend/tests/test_anthropic_messages.py
+++ b/studio/backend/tests/test_anthropic_messages.py
@@ -2733,10 +2733,7 @@ class TestAnthropicMessagesToolRouting:
 
         call_kind, kwargs = backend.calls[0]
         assert call_kind == "tools"
-        assert kwargs["tool_choice"] == {
-            "type": "function",
-            "function": {"name": "web_search"},
-        }
+        assert kwargs["tool_choice"] == {"type": "function", "function": {"name": "web_search"}}
         assert [tool["function"]["name"] for tool in kwargs["tools"]] == ["web_search"]
 
     def test_server_tool_choice_must_be_in_the_selected_catalog(self, monkeypatch):

--- a/studio/backend/tests/test_llama_cpp_tool_loop.py
+++ b/studio/backend/tests/test_llama_cpp_tool_loop.py
@@ -327,7 +327,7 @@ def test_forced_tool_choice_must_exist_in_the_catalog(monkeypatch):
     payloads: list[dict] = []
     backend = _make_backend(monkeypatch, [], payloads)
 
-    with pytest.raises(ValueError, match="Forced tool 'python' is not enabled"):
+    with pytest.raises(ValueError, match = "Forced tool 'python' is not enabled"):
         list(
             backend.generate_chat_completion_with_tools(
                 messages = [{"role": "user", "content": "run python"}],
@@ -375,9 +375,9 @@ def test_forced_tool_choice_retries_after_other_structured_calls(monkeypatch):
     assert [tool["function"]["name"] for tool in payloads[1]["tools"]] == ["web_search"]
     assert payloads[2]["tool_choice"] == "auto"
     assert calls == [("web_search", {"query": "kernel version"})]
-    assert [
-        event.get("tool_name") for event in events if event.get("type") == "tool_start"
-    ] == ["web_search"]
+    assert [event.get("tool_name") for event in events if event.get("type") == "tool_start"] == [
+        "web_search"
+    ]
 
 
 def test_none_tool_choice_never_executes_model_tool_calls(monkeypatch):
@@ -3453,9 +3453,7 @@ def test_rag_autoinject_only_resolves_matching_forced_choices(monkeypatch):
         )
         return payloads[0]
 
-    matching = first_payload(
-        {"type": "function", "function": {"name": "search_knowledge_base"}}
-    )
+    matching = first_payload({"type": "function", "function": {"name": "search_knowledge_base"}})
     required = first_payload("required")
     unrelated = first_payload({"type": "function", "function": {"name": "web_search"}})
 


### PR DESCRIPTION
## Problem

Both README download tables carry a **Linux (Arm64)** row pointing at
`Unsloth-Desktop-<version>-ARM64.app.tar.gz`. That file is the macOS Apple
Silicon updater archive, not a Linux arm64 build.

Two things confirm it:

- it is exactly what the `darwin-aarch64` entry of the published `latest.json`
  points at
- it is produced only by the macOS build leg, which stages `.app.tar.gz` as
  `{base}-ARM64.app.tar.gz`

The link is not dead, which is why it has gone unnoticed. It returns 200. Anyone
on Linux arm64 who followed it downloaded a working macOS app bundle.

## Change

The row is removed from both tables. There is no Linux arm64 artifact to point
it at instead: the build matrix covers `aarch64-apple-darwin`, x86_64 Linux and
x86_64 Windows, so shipping one would be a new build leg rather than a link
change.

The `.app.tar.gz` stays published. It is the payload the in app updater fetches
for itself, and it was never meant to be a human download. The macOS row already
covers Apple Silicon users with the `.dmg`, which is the file to double click.

## Scope

Nothing else in the tables changes. The four remaining rows still point at the
version pinned `v0.1.803-beta` assets and all four return 200:

| Row | Status |
|-----|--------|
| Windows | 200 |
| macOS | 200 |
| Linux / Ubuntu (deb) | 200 |
| Linux (AppImage) | 200 |

Migrating these to the stable `/releases/latest/download/Unsloth-Desktop-*.` form
that #9652 makes possible is deliberately left for a follow up. Those URLs 404
until the first release built with the stable asset names is published, so the
links have to move after that release, not before.