### PR TITLE
Refuse to train a model split across devices, instead of dying in index_select

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -25569,8 +25569,7 @@ class LlamaCppBackend:
                 yield _ev
             conversation.extend(_auto["messages"])
         _auto_satisfies_forced_choice = bool(_auto) and (
-            tool_choice == "required"
-            or forced_tool_name(tool_choice) == "search_knowledge_base"
+            tool_choice == "required" or forced_tool_name(tool_choice) == "search_knowledge_base"
         )
 
         _accumulated_completion_tokens = 0
@@ -25786,9 +25785,7 @@ class LlamaCppBackend:
             requested_choice = "auto" if tool_choice is None else tool_choice
             if _forced_choice_resolved and requested_choice not in ("auto", "none"):
                 requested_choice = "auto"
-            requested_choice = (
-                reconciled_tool_choice(requested_choice, tools, safe_tools) or "auto"
-            )
+            requested_choice = reconciled_tool_choice(requested_choice, tools, safe_tools) or "auto"
             forced_name = forced_tool_name(requested_choice)
             if forced_name:
                 matching_tools = [

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -16464,7 +16464,6 @@ async def openai_chat_completions(
 
     def _reject_missing_forced_tool(tool_choice, selected_tools) -> None:
         from core.inference.chat_template_helpers import catalog_tool_names, forced_tool_name
-
         forced_name = forced_tool_name(tool_choice)
         if forced_name and forced_name not in catalog_tool_names(selected_tools):
             raise _reject(
@@ -23683,9 +23682,7 @@ async def anthropic_messages(
         server_tool_choice = openai_tool_choice
         if isinstance(server_tool_choice, dict):
             forced_function = server_tool_choice.get("function")
-            forced_name = (
-                forced_function.get("name") if isinstance(forced_function, dict) else None
-            )
+            forced_name = forced_function.get("name") if isinstance(forced_function, dict) else None
             canonical_name = _STUDIO_ANTHROPIC_TOOL_ALIASES.get(forced_name)
             if canonical_name:
                 server_tool_choice = {

--- a/studio/backend/tests/test_anthropic_messages.py
+++ b/studio/backend/tests/test_anthropic_messages.py
@@ -2733,10 +2733,7 @@ class TestAnthropicMessagesToolRouting:
 
         call_kind, kwargs = backend.calls[0]
         assert call_kind == "tools"
-        assert kwargs["tool_choice"] == {
-            "type": "function",
-            "function": {"name": "web_search"},
-        }
+        assert kwargs["tool_choice"] == {"type": "function", "function": {"name": "web_search"}}
         assert [tool["function"]["name"] for tool in kwargs["tools"]] == ["web_search"]
 
     def test_server_tool_choice_must_be_in_the_selected_catalog(self, monkeypatch):

--- a/studio/backend/tests/test_llama_cpp_tool_loop.py
+++ b/studio/backend/tests/test_llama_cpp_tool_loop.py
@@ -327,7 +327,7 @@ def test_forced_tool_choice_must_exist_in_the_catalog(monkeypatch):
     payloads: list[dict] = []
     backend = _make_backend(monkeypatch, [], payloads)
 
-    with pytest.raises(ValueError, match="Forced tool 'python' is not enabled"):
+    with pytest.raises(ValueError, match = "Forced tool 'python' is not enabled"):
         list(
             backend.generate_chat_completion_with_tools(
                 messages = [{"role": "user", "content": "run python"}],
@@ -375,9 +375,9 @@ def test_forced_tool_choice_retries_after_other_structured_calls(monkeypatch):
     assert [tool["function"]["name"] for tool in payloads[1]["tools"]] == ["web_search"]
     assert payloads[2]["tool_choice"] == "auto"
     assert calls == [("web_search", {"query": "kernel version"})]
-    assert [
-        event.get("tool_name") for event in events if event.get("type") == "tool_start"
-    ] == ["web_search"]
+    assert [event.get("tool_name") for event in events if event.get("type") == "tool_start"] == [
+        "web_search"
+    ]
 
 
 def test_none_tool_choice_never_executes_model_tool_calls(monkeypatch):
@@ -3453,9 +3453,7 @@ def test_rag_autoinject_only_resolves_matching_forced_choices(monkeypatch):
         )
         return payloads[0]
 
-    matching = first_payload(
-        {"type": "function", "function": {"name": "search_knowledge_base"}}
-    )
+    matching = first_payload({"type": "function", "function": {"name": "search_knowledge_base"}})
     required = first_payload("required")
     unrelated = first_payload({"type": "function", "function": {"name": "web_search"}})
 

--- a/tests/test_multi_gpu_shard_guard.py
+++ b/tests/test_multi_gpu_shard_guard.py
@@ -1,0 +1,154 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+
+"""Training a model split across devices fails, and it should say so.
+
+`accelerate` shards across every visible card by default, so a user with two
+GPUs and no ``device_map`` gets the split without asking for it. The training
+loop then announces ``Num GPUs used = 2`` and dies at the first embedding
+lookup:
+
+    RuntimeError: Expected all tensors to be on the same device, but got index
+    is on cuda:0, different from other tensors on cuda:1
+    (when checking argument in method wrapper_CUDA__index_select)
+
+which reads as a tensor bug rather than a placement one. Reproduced on 2x Tesla
+T4 with ``unsloth/Qwen3-0.6B`` in 4bit: 232849408 parameters on cuda:0 and
+155582464 on cuda:1, dying at step 0.
+
+Aligning that one call site would only move the error -- ``llama.py`` allocates
+working buffers on device 0 in several other places -- so the loop refuses,
+the same answer it already gives for TPUs a few lines below.
+
+The guard is generated source spliced into ``_inner_training_loop``, so these
+rules extract the literal and RUN it. Asserting that the text is present would
+pass on a guard that never fires.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+
+import pytest
+
+LLAMA = Path(__file__).resolve().parents[1] / "unsloth" / "models" / "llama.py"
+SRC = LLAMA.read_text(encoding = "utf-8")
+
+
+class _Param:
+    def __init__(self, device):
+        self.device = _Device(device)
+
+
+class _Device:
+    def __init__(self, spec):
+        self.type = spec.split(":")[0]
+        self._spec = spec
+
+    def __str__(self):
+        return self._spec
+
+
+class _Model:
+    def __init__(self, devices):
+        self._devices = devices
+
+    def parameters(self):
+        return [_Param(d) for d in self._devices]
+
+
+def _guard_source() -> str:
+    """The literal the training loop splices in, re-indented as it re-indents it.
+
+    EXEC'd out of the file rather than read as text, because the literal is
+    escaped twice: `\\n` in the file is `\\n` in the string and a newline only
+    once the generated source is compiled. Reading it with a regex gives the
+    outer layer and runs none of it.
+    """
+    start = SRC.index("        multi_gpu_guard = \"\"\"")
+    end = SRC.index("multi_gpu_guard = multi_gpu_guard.split", start)
+    scope: dict = {}
+    exec("if True:\n" + SRC[start:end], scope)
+    body = scope["multi_gpu_guard"]
+    # The same re-indent the loop applies, with no leading whitespace since
+    # this runs at module level rather than inside a method.
+    lines = body.split("\n")
+    body = "\n".join([lines[0]] + [x[8:] for x in lines[1:]])
+    # The loop appends `debug_info =` so the banner assignment continues from
+    # it; that trailing fragment is not runnable on its own.
+    return body.rsplit("debug_info =", 1)[0]
+
+
+def _run(devices, env = None):
+    scope = {"model": _Model(devices), "os": os}
+    if env is not None:
+        os.environ["UNSLOTH_ALLOW_MULTI_GPU"] = env
+    else:
+        os.environ.pop("UNSLOTH_ALLOW_MULTI_GPU", None)
+    try:
+        exec(_guard_source(), scope)
+    finally:
+        os.environ.pop("UNSLOTH_ALLOW_MULTI_GPU", None)
+
+
+def test_a_split_model_is_refused_with_the_devices_named():
+    with pytest.raises(RuntimeError) as excinfo:
+        _run(["cuda:0", "cuda:0", "cuda:1"])
+    message = str(excinfo.value)
+    # The devices, so the reader can see WHICH cards without instrumenting.
+    assert "cuda:0" in message and "cuda:1" in message
+    # And the two ways out, spelled out. An error that says only "unsupported"
+    # leaves the user to find this out by searching issues.
+    assert "CUDA_VISIBLE_DEVICES=0" in message
+    assert 'device_map = {"": 0}' in message
+
+
+def test_one_device_is_untouched():
+    """The overwhelmingly common case, and it must cost nothing."""
+    _run(["cuda:0", "cuda:0", "cuda:0"])
+    _run(["cuda:1", "cuda:1"])
+
+
+def test_DDP_is_not_caught_by_this():
+    """Each DDP rank holds the WHOLE model on its own single device, so the set
+    has one element per process. That is why the check reads the parameter
+    devices rather than `torch.cuda.device_count()` or `args.world_size`, both
+    of which are greater than one under DDP and would break it."""
+    _run(["cuda:3", "cuda:3", "cuda:3"])
+
+
+def test_cpu_parameters_do_not_count_as_a_second_device():
+    """`offload_embedding` deliberately puts the input embedding on the CPU and
+    installs hooks to move it, which is a supported configuration. Counting the
+    CPU as a device would refuse it."""
+    _run(["cpu", "cuda:0", "cuda:0"])
+
+
+def test_the_escape_hatch_works_and_is_opt_in():
+    with pytest.raises(RuntimeError):
+        _run(["cuda:0", "cuda:1"], env = "0")
+    _run(["cuda:0", "cuda:1"], env = "1")
+
+
+def test_the_guard_runs_BEFORE_the_banner_announces_a_device_count():
+    """Order matters for what the user sees. Announcing `Num GPUs used = 2` and
+    then refusing reads as a contradiction; refusing first reads as an answer.
+    """
+    guard_at = SRC.index("multi_gpu_guard = ")
+    splice = SRC.index('inner_training_loop.replace(\n            "debug_info =", multi_gpu_guard, 1,\n        )')
+    banner_splice = SRC.index("inner_training_loop.replace(original_debug, debug_info)")
+    assert guard_at < banner_splice
+    # The guard is spliced in AFTER the banner is put in place, which is what
+    # puts it textually ahead of the banner: it replaces the first
+    # `debug_info =`, and that is the banner's own assignment.
+    assert banner_splice < splice
+
+
+def test_it_is_a_refusal_and_not_a_warning():
+    """A warning here is worse than nothing: the run continues and dies anyway,
+    with the warning scrolled off above a traceback about index_select."""
+    body = _guard_source()
+    assert "raise RuntimeError(" in body
+    assert "warn" not in body.lower()

--- a/tests/test_multi_gpu_shard_guard.py
+++ b/tests/test_multi_gpu_shard_guard.py
@@ -67,7 +67,7 @@ def _guard_source() -> str:
     once the generated source is compiled. Reading it with a regex gives the
     outer layer and runs none of it.
     """
-    start = SRC.index("        multi_gpu_guard = \"\"\"")
+    start = SRC.index('        multi_gpu_guard = """')
     end = SRC.index("multi_gpu_guard = multi_gpu_guard.split", start)
     scope: dict = {}
     exec("if True:\n" + SRC[start:end], scope)
@@ -137,7 +137,9 @@ def test_the_guard_runs_BEFORE_the_banner_announces_a_device_count():
     then refusing reads as a contradiction; refusing first reads as an answer.
     """
     guard_at = SRC.index("multi_gpu_guard = ")
-    splice = SRC.index('inner_training_loop.replace(\n            "debug_info =", multi_gpu_guard, 1,\n        )')
+    splice = SRC.index(
+        'inner_training_loop.replace(\n            "debug_info =", multi_gpu_guard, 1,\n        )'
+    )
     banner_splice = SRC.index("inner_training_loop.replace(original_debug, debug_info)")
     assert guard_at < banner_splice
     # The guard is spliced in AFTER the banner is put in place, which is what

--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -2984,6 +2984,56 @@ class FastLlamaModel:
 
         # Cannot use \\ since it will cause a SyntaxWarning in Python 3.12
         # Instead use chr(92) == \\
+        # A model whose parameters span more than one CUDA device is not a
+        # configuration this training loop supports, and it fails in a way that
+        # names the wrong thing. `accelerate` shards across every visible card
+        # by default, so a user with two GPUs and no `device_map` gets the split
+        # without asking for it, is told "Num GPUs used = 2", and then dies at
+        # the first embedding lookup with
+        #
+        #   RuntimeError: Expected all tensors to be on the same device, but got
+        #   index is on cuda:0, different from other tensors on cuda:1
+        #   (when checking argument in method wrapper_CUDA__index_select)
+        #
+        # which reads as a tensor bug rather than as a placement one. That is
+        # not the only such site: this file allocates working buffers on
+        # `{DEVICE_TYPE_TORCH}:0` in several places, so aligning the embedding
+        # alone would move the error rather than remove it.
+        #
+        # Checked HERE because this is where the device set is already computed
+        # for the banner, and raising is the same answer this loop already gives
+        # for TPUs a few lines below. Reproduced on 2x Tesla T4 with
+        # `unsloth/Qwen3-0.6B` in 4bit: 232849408 parameters on cuda:0 and
+        # 155582464 on cuda:1, dying at step 0.
+        #
+        # DDP is unaffected, and that is the reason the check is on the
+        # PARAMETER devices rather than on `torch.cuda.device_count()` or on
+        # `args.world_size`: each DDP rank holds the whole model on its own
+        # single device, so the set has one element per process. This fires only
+        # on single-process model sharding, which is the case that cannot work.
+        multi_gpu_guard = """_unsloth_param_devices = sorted(
+            {str(p.device) for p in model.parameters() if p.device.type != "cpu"}
+        )
+        if len(_unsloth_param_devices) > 1 and \\
+            os.environ.get("UNSLOTH_ALLOW_MULTI_GPU", "0") != "1":
+            raise RuntimeError(
+                "Unsloth: this model is split across " +
+                str(len(_unsloth_param_devices)) + " devices (" +
+                ", ".join(_unsloth_param_devices) + "), and training a split "
+                "model is not supported - it fails at the first embedding "
+                "lookup with a message about tensor devices rather than about "
+                "placement.\\n"
+                "Load it onto ONE device instead, with either:\\n"
+                "  CUDA_VISIBLE_DEVICES=0   before starting python, or\\n"
+                '  FastLanguageModel.from_pretrained(..., device_map = {"": 0})'
+                "\\nSet UNSLOTH_ALLOW_MULTI_GPU=1 to attempt it anyway."
+            )
+        debug_info ="""
+        multi_gpu_guard = multi_gpu_guard.split("\n")
+        multi_gpu_guard = "\n".join(
+            [multi_gpu_guard[0]] + [spaces + x[8:] for x in multi_gpu_guard[1:]]
+        )
+
         debug_info = """debug_info = \\
         f"==((====))==  Unsloth - 2x faster free finetuning | Num GPUs used = {len(set(p.device for p in model.parameters()))}\\n"\\
         f"   {chr(92)}{chr(92)}   /|    Num examples = {num_examples:,} | Num Epochs = {num_train_epochs:,} | Total steps = {max_steps:,}\\n"\\
@@ -2999,6 +3049,11 @@ class FastLlamaModel:
         debug_info = debug_info.split("\n")
         debug_info = "\n".join([debug_info[0]] + [spaces + x[8:] for x in debug_info[1:]])
         inner_training_loop = inner_training_loop.replace(original_debug, debug_info)
+        # Ahead of the banner, so the run stops before announcing a device count
+        # it cannot honour.
+        inner_training_loop = inner_training_loop.replace(
+            "debug_info =", multi_gpu_guard, 1,
+        )
 
         debug_info = """n_total_devices = total_train_batch_size // \\
             args.gradient_accumulation_steps // self._train_batch_size

--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -3052,7 +3052,9 @@ class FastLlamaModel:
         # Ahead of the banner, so the run stops before announcing a device count
         # it cannot honour.
         inner_training_loop = inner_training_loop.replace(
-            "debug_info =", multi_gpu_guard, 1,
+            "debug_info =",
+            multi_gpu_guard,
+            1,
         )
 
         debug_info = """n_total_devices = total_train_batch_size // \\


### PR DESCRIPTION
### The problem

`accelerate` shards a model across every visible card by default, so anyone with two GPUs and no `device_map` gets the split without asking for it. The training loop then announces `Num GPUs used = 2` and dies at the first embedding lookup:

```
File "unsloth/models/llama.py", line 972, in LlamaModel_fast_forward
  inputs_embeds = self.embed_tokens(input_ids)
RuntimeError: Expected all tensors to be on the same device, but got index is on
cuda:0, different from other tensors on cuda:1
(when checking argument in method wrapper_CUDA__index_select)
```

That reads as a tensor bug rather than a placement one, and the banner immediately above it says we are using both GPUs. Reproduced on 2x Tesla T4 with `unsloth/Qwen3-0.6B` in 4bit: 232849408 parameters on `cuda:0` and 155582464 on `cuda:1`, dying at step 0.

This is the same family as #2467 and #2882.

### Why this refuses rather than repairs

Aligning that one call site would move the error, not remove it. `llama.py` allocates on device 0 in several other places, so a split model runs into the next one:

| line | allocation |
|---|---|
| 958 | `position_ids` on `{DEVICE_TYPE_TORCH}:0` |
| 1289, 1291 | fast softmax scratch on `:0` |
| 1294, 1297 | fast MLP scratch on `:0` |

So single GPU is what the loop supports, and it now says so at the point where it already computes the device set for the banner. That is the same answer it gives for TPUs a few lines below.

### What it does not break

The check reads the **parameter devices**, not `torch.cuda.device_count()` and not `args.world_size`. Both of those are greater than one under DDP, and using either would break it. Each DDP rank holds the whole model on its own single device, so the set has one element per process, and the guard fires only on single-process model sharding.

CPU parameters are excluded, so `offload_embedding` (which deliberately puts the input embedding on the CPU and hooks it back) is untouched.

`UNSLOTH_ALLOW_MULTI_GPU=1` skips the check for anyone who wants to try anyway.

### On hardware

2x Tesla T4, sm_75, `unsloth/Qwen3-0.6B` in 4bit, both cards visible:

```
Unsloth: this model is split across 2 devices (cuda:0, cuda:1), and training a
split model is not supported - it fails at the first embedding lookup with a
message about tensor devices rather than about placement.
Load it onto ONE device instead, with either:
  CUDA_VISIBLE_DEVICES=0   before starting python, or
  FastLanguageModel.from_pretrained(..., device_map = {"": 0})
Set UNSLOTH_ALLOW_MULTI_GPU=1 to attempt it anyway.
```

Zero occurrences of `index_select` in that run: the message replaces the confusing traceback rather than arriving alongside it.

### Tests

`tests/test_multi_gpu_shard_guard.py`, 7 rules. They **exec** the guard rather than grepping for it: the literal is escaped twice on its way into the generated training loop, so a text assertion would pass on a guard that never runs.

Five mutations caught: never firing, counting the CPU as a device, warning instead of raising, dropping the remedy from the message, and ignoring the escape hatch. The generated source was also checked to still compile with the guard spliced ahead of the banner and the `n_total_devices` block intact.
