### PR TITLE
Studio: bound fence tokenization by line length, not by the wall clock

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -25599,8 +25599,7 @@ class LlamaCppBackend:
                 yield _ev
             conversation.extend(_auto["messages"])
         _auto_satisfies_forced_choice = bool(_auto) and (
-            tool_choice == "required"
-            or forced_tool_name(tool_choice) == "search_knowledge_base"
+            tool_choice == "required" or forced_tool_name(tool_choice) == "search_knowledge_base"
         )
 
         _accumulated_completion_tokens = 0
@@ -25816,9 +25815,7 @@ class LlamaCppBackend:
             requested_choice = "auto" if tool_choice is None else tool_choice
             if _forced_choice_resolved and requested_choice not in ("auto", "none"):
                 requested_choice = "auto"
-            requested_choice = (
-                reconciled_tool_choice(requested_choice, tools, safe_tools) or "auto"
-            )
+            requested_choice = reconciled_tool_choice(requested_choice, tools, safe_tools) or "auto"
             forced_name = forced_tool_name(requested_choice)
             if forced_name:
                 matching_tools = [

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -16473,7 +16473,6 @@ async def openai_chat_completions(
 
     def _reject_missing_forced_tool(tool_choice, selected_tools) -> None:
         from core.inference.chat_template_helpers import catalog_tool_names, forced_tool_name
-
         forced_name = forced_tool_name(tool_choice)
         if forced_name and forced_name not in catalog_tool_names(selected_tools):
             raise _reject(
@@ -23692,9 +23691,7 @@ async def anthropic_messages(
         server_tool_choice = openai_tool_choice
         if isinstance(server_tool_choice, dict):
             forced_function = server_tool_choice.get("function")
-            forced_name = (
-                forced_function.get("name") if isinstance(forced_function, dict) else None
-            )
+            forced_name = forced_function.get("name") if isinstance(forced_function, dict) else None
             canonical_name = _STUDIO_ANTHROPIC_TOOL_ALIASES.get(forced_name)
             if canonical_name:
                 server_tool_choice = {

--- a/studio/backend/tests/test_anthropic_messages.py
+++ b/studio/backend/tests/test_anthropic_messages.py
@@ -2733,10 +2733,7 @@ class TestAnthropicMessagesToolRouting:
 
         call_kind, kwargs = backend.calls[0]
         assert call_kind == "tools"
-        assert kwargs["tool_choice"] == {
-            "type": "function",
-            "function": {"name": "web_search"},
-        }
+        assert kwargs["tool_choice"] == {"type": "function", "function": {"name": "web_search"}}
         assert [tool["function"]["name"] for tool in kwargs["tools"]] == ["web_search"]
 
     def test_server_tool_choice_must_be_in_the_selected_catalog(self, monkeypatch):

--- a/studio/backend/tests/test_llama_cpp_tool_loop.py
+++ b/studio/backend/tests/test_llama_cpp_tool_loop.py
@@ -327,7 +327,7 @@ def test_forced_tool_choice_must_exist_in_the_catalog(monkeypatch):
     payloads: list[dict] = []
     backend = _make_backend(monkeypatch, [], payloads)
 
-    with pytest.raises(ValueError, match="Forced tool 'python' is not enabled"):
+    with pytest.raises(ValueError, match = "Forced tool 'python' is not enabled"):
         list(
             backend.generate_chat_completion_with_tools(
                 messages = [{"role": "user", "content": "run python"}],
@@ -375,9 +375,9 @@ def test_forced_tool_choice_retries_after_other_structured_calls(monkeypatch):
     assert [tool["function"]["name"] for tool in payloads[1]["tools"]] == ["web_search"]
     assert payloads[2]["tool_choice"] == "auto"
     assert calls == [("web_search", {"query": "kernel version"})]
-    assert [
-        event.get("tool_name") for event in events if event.get("type") == "tool_start"
-    ] == ["web_search"]
+    assert [event.get("tool_name") for event in events if event.get("type") == "tool_start"] == [
+        "web_search"
+    ]
 
 
 def test_none_tool_choice_never_executes_model_tool_calls(monkeypatch):
@@ -3453,9 +3453,7 @@ def test_rag_autoinject_only_resolves_matching_forced_choices(monkeypatch):
         )
         return payloads[0]
 
-    matching = first_payload(
-        {"type": "function", "function": {"name": "search_knowledge_base"}}
-    )
+    matching = first_payload({"type": "function", "function": {"name": "search_knowledge_base"}})
     required = first_payload("required")
     unrelated = first_payload({"type": "function", "function": {"name": "web_search"}})
 

--- a/studio/frontend/src/components/assistant-ui/code-plugin.ts
+++ b/studio/frontend/src/components/assistant-ui/code-plugin.ts
@@ -73,6 +73,21 @@ const normalizeLanguage = (language: string): BundledLanguage => {
 // text, keeping the 250 ms plain-tail cadence.
 export const MIN_INCREMENTAL_CHARS = 2000;
 const REFRESH_MS = 250;
+// Shiki's own tokenizer guard is a wall clock: a line that takes longer than
+// `tokenizeTimeLimit` (default 500 ms) is abandoned part-way and the rest of it
+// is emitted as one uncoloured token. Dual themes are two passes with two
+// separate budgets, and only the first pays to compile the grammar's regexes,
+// so a loaded machine drops the light theme to plain and keeps the dark one
+// correct -- for the same line, in the same result. Committed lines are never
+// re-tokenized, so that half-plain line is then cached for the life of the
+// fence. Bound the work by line length instead: same protection against a
+// minified blob (~120 ms at this length, growing quadratically past it, which
+// is VS Code's `editor.maxTokenizationLineLength` default for the same reason),
+// but the output depends on the source rather than on the host.
+export const TOKENIZE_LIMITS = {
+  tokenizeTimeLimit: 0,
+  tokenizeMaxLineLength: 20_000,
+} as const;
 // An unvirtualized thread mounts every fence. Bound both their count and source
 // size; token data measured roughly 30 bytes per source character.
 const MAX_FENCES = 512;
@@ -328,6 +343,7 @@ export function createCodePlugin(
         lang,
         themes,
         grammarState: fence.state,
+        ...TOKENIZE_LIMITS,
       });
 
     // Commit every newly completed line.

--- a/studio/frontend/tests/code-plugin-embedded-grammars.test.ts
+++ b/studio/frontend/tests/code-plugin-embedded-grammars.test.ts
@@ -32,6 +32,7 @@ import { createJavaScriptRegexEngine } from "shiki/engine/javascript";
 import {
   createCodePlugin,
   MIN_INCREMENTAL_CHARS,
+  TOKENIZE_LIMITS,
 } from "../src/components/assistant-ui/code-plugin.ts";
 
 const THEMES: [ThemeInput, ThemeInput] = ["github-light", "github-dark"];
@@ -74,6 +75,10 @@ async function reference(code: string, language: HighlightOptions["language"]) {
   return highlighter.codeToTokens(code, {
     lang: language,
     themes: { light: "github-light", dark: "github-dark" },
+    // The reference must run under the plugin's own tokenizer limits, or shiki's
+    // default wall-clock bail can degrade whichever side of the comparison is
+    // unlucky on a slow runner.
+    ...TOKENIZE_LIMITS,
   });
 }
 

--- a/studio/frontend/tests/code-plugin-engine-and-cache.test.ts
+++ b/studio/frontend/tests/code-plugin-engine-and-cache.test.ts
@@ -32,7 +32,10 @@ import type {
 import { createHighlighter } from "shiki";
 import { createJavaScriptRegexEngine } from "shiki/engine/javascript";
 
-import { createCodePlugin } from "../src/components/assistant-ui/code-plugin.ts";
+import {
+  createCodePlugin,
+  TOKENIZE_LIMITS,
+} from "../src/components/assistant-ui/code-plugin.ts";
 
 const THEMES: [ThemeInput, ThemeInput] = ["github-light", "github-dark"];
 
@@ -201,6 +204,8 @@ test("a fence evicted mid-stream still tokenizes correctly when it resumes", asy
     highlighter.codeToTokens(code, {
       lang: "html",
       themes: { light: "github-light", dark: "github-dark" },
+      // Same tokenizer limits as the plugin, so neither side can degrade.
+      ...TOKENIZE_LIMITS,
     }).tokens;
 
   const settle = () => new Promise((r) => setTimeout(r, 260));

--- a/studio/frontend/tests/code-plugin-incremental.test.ts
+++ b/studio/frontend/tests/code-plugin-incremental.test.ts
@@ -11,7 +11,10 @@ import type {
 import { createHighlighter } from "shiki";
 import { createJavaScriptRegexEngine } from "shiki/engine/javascript";
 
-import { createCodePlugin } from "../src/components/assistant-ui/code-plugin.ts";
+import {
+  createCodePlugin,
+  TOKENIZE_LIMITS,
+} from "../src/components/assistant-ui/code-plugin.ts";
 
 const THEMES: [ThemeInput, ThemeInput] = ["github-light", "github-dark"];
 
@@ -98,6 +101,10 @@ async function reference(code: string, language: HighlightOptions["language"]) {
   return highlighter.codeToTokens(code, {
     lang: language,
     themes: { light: "github-light", dark: "github-dark" },
+    // The reference must run under the plugin's own tokenizer limits, or shiki's
+    // default wall-clock bail can degrade whichever side of the comparison is
+    // unlucky on a slow runner.
+    ...TOKENIZE_LIMITS,
   });
 }
 

--- a/studio/frontend/tests/code-plugin-tokenization-work.test.ts
+++ b/studio/frontend/tests/code-plugin-tokenization-work.test.ts
@@ -75,25 +75,17 @@ const highlightOnce = (
 /*
  * THE SAME CALL, BUT WAITING FOR THE TOKENIZED ANSWER RATHER THAN THE FIRST ONE.
  *
- * `highlightOnce` resolves with whatever `plugin.highlight` hands back synchronously, which is the
- * right thing during the streaming loop above: each update there is meant to go down the tokenizing
- * path and the immediate value IS the result. It is the wrong thing for the final correctness check,
- * and that is a real Windows CI failure rather than a hypothetical. When a grown fence past
- * `MIN_INCREMENTAL_CHARS` is called again inside `REFRESH_MS`, `code-plugin.ts` returns
- * `approximateResult` synchronously and delivers the real tokens LATER through the callback --
- * which `highlightOnce` has already thrown away. The deepEqual then compares approximate tokens,
- * every one of them coloured `#005CC5`, against the reference.
+ * `highlightOnce` takes the synchronous return, which is right during the streaming loop and wrong
+ * for the final correctness check -- a real Windows CI failure. A grown fence past
+ * `MIN_INCREMENTAL_CHARS` called again inside `REFRESH_MS` gets `approximateResult` back
+ * synchronously and the real tokens LATER via the callback, so the deepEqual compared approximate
+ * tokens, all coloured `#005CC5`, against the reference.
  *
- * Sleeping longer does not fix it, and that is worth being precise about: `settle()` counts from
- * when this test resumed, while the throttle counts from the plugin's own `lastTokenizedAt`, and a
- * trailing refresh scheduled by an earlier update can land after the sleep began and push that
- * timestamp forward. There is no sleep length that makes the immediate value reliably the
- * tokenized one.
- *
- * So prefer the callback when there is one. If the plugin took the tokenizing path it returns the
- * exact result and never calls back, so the immediate value is adopted once the refresh window has
- * provably passed. Either way the assertion is unchanged and just as strict; only its input stops
- * depending on how loaded the machine is.
+ * No sleep length fixes it: `settle()` counts from when this test resumed, the throttle counts from
+ * the plugin's `lastTokenizedAt`, and a trailing refresh can push that timestamp past the sleep.
+ * So prefer the callback; if the plugin tokenized it never calls back, and the immediate value is
+ * adopted once the refresh window has provably passed. The assertion is unchanged and just as
+ * strict, only its input stops depending on machine load.
  */
 const highlightTokenized = (
   plugin: ReturnType<typeof createCodePlugin>,

--- a/studio/frontend/tests/code-plugin-tokenization-work.test.ts
+++ b/studio/frontend/tests/code-plugin-tokenization-work.test.ts
@@ -42,9 +42,8 @@ import { createHighlighter } from "shiki";
 import { createJavaScriptRegexEngine } from "shiki/engine/javascript";
 
 register("./shiki-tokenization-resolver.mjs", import.meta.url);
-const { createCodePlugin, MIN_INCREMENTAL_CHARS } = await import(
-  "../src/components/assistant-ui/code-plugin.ts"
-);
+const { createCodePlugin, MIN_INCREMENTAL_CHARS, TOKENIZE_LIMITS } =
+  await import("../src/components/assistant-ui/code-plugin.ts");
 const { tokenized } = await import("./shiki-tokenization-counter.mts");
 
 const THEMES: [ThemeInput, ThemeInput] = ["github-light", "github-dark"];
@@ -70,41 +69,6 @@ const highlightOnce = (
       resolve,
     );
     if (immediate) resolve(immediate);
-  });
-
-/*
- * THE SAME CALL, BUT WAITING FOR THE TOKENIZED ANSWER RATHER THAN THE FIRST ONE.
- *
- * `highlightOnce` takes the synchronous return, which is right during the streaming loop and wrong
- * for the final correctness check -- a real Windows CI failure. A grown fence past
- * `MIN_INCREMENTAL_CHARS` called again inside `REFRESH_MS` gets `approximateResult` back
- * synchronously and the real tokens LATER via the callback, so the deepEqual compared approximate
- * tokens, all coloured `#005CC5`, against the reference.
- *
- * No sleep length fixes it: `settle()` counts from when this test resumed, the throttle counts from
- * the plugin's `lastTokenizedAt`, and a trailing refresh can push that timestamp past the sleep.
- * So prefer the callback; if the plugin tokenized it never calls back, and the immediate value is
- * adopted once the refresh window has provably passed. The assertion is unchanged and just as
- * strict, only its input stops depending on machine load.
- */
-const highlightTokenized = (
-  plugin: ReturnType<typeof createCodePlugin>,
-  code: string,
-): Promise<HighlightResult> =>
-  new Promise((resolve) => {
-    let settled = false;
-    const finish = (result: HighlightResult) => {
-      if (settled) return;
-      settled = true;
-      resolve(result);
-    };
-    const immediate = plugin.highlight(
-      { code, language: LANGUAGE, themes: THEMES },
-      finish,
-    );
-    // SETTLE_MS is longer than REFRESH_MS, so a queued refresh has fired by the time this runs; if
-    // none was queued, `immediate` was already the tokenized result.
-    if (immediate) setTimeout(() => finish(immediate), SETTLE_MS);
   });
 
 test("a streaming fence is tokenized once, not once per update", async () => {
@@ -135,7 +99,7 @@ test("a streaming fence is tokenized once, not once per update", async () => {
     updates += 1;
   }
   await settle();
-  last = await highlightTokenized(plugin, SOURCE);
+  last = await highlightOnce(plugin, SOURCE);
 
   assert.ok(
     updates >= 12,
@@ -170,6 +134,61 @@ test("a streaming fence is tokenized once, not once per update", async () => {
     reference.codeToTokens(SOURCE, {
       lang: "typescript",
       themes: { light: "github-light", dark: "github-dark" },
+      ...TOKENIZE_LIMITS,
+    }).tokens,
+  );
+});
+
+/*
+ * WHAT MADE THE ASSERTION ABOVE FAIL ON WINDOWS ONE RUN IN TWENTY.
+ *
+ * Shiki abandons a line once `tokenizeTimeLimit` of wall clock has gone by and emits the rest of it
+ * as one uncoloured token. Dual themes are two passes with two budgets and only the first compiles
+ * the grammar's regexes, so a slow enough host returns the light theme plain and the dark theme
+ * correct -- and the plugin then commits that line and never tokenizes it again. Neither side of the
+ * comparison was safe: CI produced diffs with the plugin degraded, diffs with the reference
+ * degraded, and diffs with both on different lines.
+ *
+ * Racing `Date.now` reproduces an overrun on any machine, without waiting for one: every elapsed
+ * check clears any finite limit, and `tokenizeTimeLimit: 0` skips the check entirely. Which tokens
+ * a real overrun loses depends on where in the line it lands, so this pins the invariant rather
+ * than one signature -- the wall clock must not reach the output at all. The plugin's own throttle
+ * reads `performance.now`, so it is unaffected.
+ */
+test("tokenization does not degrade when the tokenizer overruns the wall clock", async () => {
+  const plugin = createCodePlugin({ themes: THEMES });
+  const prefix = SOURCE.slice(0, MIN_INCREMENTAL_CHARS + 500);
+
+  await highlightOnce(plugin, prefix);
+  // Leave the throttle window so the grown fence takes the tokenizing path.
+  await settle();
+
+  const realNow = Date.now;
+  let result: HighlightResult;
+  try {
+    let elapsed = 0;
+    Date.now = () => realNow() + (elapsed += 60_000);
+    result = plugin.highlight({
+      code: SOURCE,
+      language: LANGUAGE,
+      themes: THEMES,
+    }) as HighlightResult;
+  } finally {
+    Date.now = realNow;
+  }
+
+  assert.ok(result, "the grown fence should tokenize synchronously here");
+  const reference = await createHighlighter({
+    themes: THEMES,
+    langs: ["typescript"],
+    engine: createJavaScriptRegexEngine({ forgiving: true }),
+  });
+  assert.deepEqual(
+    result.tokens,
+    reference.codeToTokens(SOURCE, {
+      lang: "typescript",
+      themes: { light: "github-light", dark: "github-dark" },
+      ...TOKENIZE_LIMITS,
     }).tokens,
   );
 });

--- a/studio/frontend/tests/code-plugin-tokenization-work.test.ts
+++ b/studio/frontend/tests/code-plugin-tokenization-work.test.ts
@@ -72,6 +72,49 @@ const highlightOnce = (
     if (immediate) resolve(immediate);
   });
 
+/*
+ * THE SAME CALL, BUT WAITING FOR THE TOKENIZED ANSWER RATHER THAN THE FIRST ONE.
+ *
+ * `highlightOnce` resolves with whatever `plugin.highlight` hands back synchronously, which is the
+ * right thing during the streaming loop above: each update there is meant to go down the tokenizing
+ * path and the immediate value IS the result. It is the wrong thing for the final correctness check,
+ * and that is a real Windows CI failure rather than a hypothetical. When a grown fence past
+ * `MIN_INCREMENTAL_CHARS` is called again inside `REFRESH_MS`, `code-plugin.ts` returns
+ * `approximateResult` synchronously and delivers the real tokens LATER through the callback --
+ * which `highlightOnce` has already thrown away. The deepEqual then compares approximate tokens,
+ * every one of them coloured `#005CC5`, against the reference.
+ *
+ * Sleeping longer does not fix it, and that is worth being precise about: `settle()` counts from
+ * when this test resumed, while the throttle counts from the plugin's own `lastTokenizedAt`, and a
+ * trailing refresh scheduled by an earlier update can land after the sleep began and push that
+ * timestamp forward. There is no sleep length that makes the immediate value reliably the
+ * tokenized one.
+ *
+ * So prefer the callback when there is one. If the plugin took the tokenizing path it returns the
+ * exact result and never calls back, so the immediate value is adopted once the refresh window has
+ * provably passed. Either way the assertion is unchanged and just as strict; only its input stops
+ * depending on how loaded the machine is.
+ */
+const highlightTokenized = (
+  plugin: ReturnType<typeof createCodePlugin>,
+  code: string,
+): Promise<HighlightResult> =>
+  new Promise((resolve) => {
+    let settled = false;
+    const finish = (result: HighlightResult) => {
+      if (settled) return;
+      settled = true;
+      resolve(result);
+    };
+    const immediate = plugin.highlight(
+      { code, language: LANGUAGE, themes: THEMES },
+      finish,
+    );
+    // SETTLE_MS is longer than REFRESH_MS, so a queued refresh has fired by the time this runs; if
+    // none was queued, `immediate` was already the tokenized result.
+    if (immediate) setTimeout(() => finish(immediate), SETTLE_MS);
+  });
+
 test("a streaming fence is tokenized once, not once per update", async () => {
   assert.ok(
     SOURCE.length > 4 * MIN_INCREMENTAL_CHARS,
@@ -100,7 +143,7 @@ test("a streaming fence is tokenized once, not once per update", async () => {
     updates += 1;
   }
   await settle();
-  last = await highlightOnce(plugin, SOURCE);
+  last = await highlightTokenized(plugin, SOURCE);
 
   assert.ok(
     updates >= 12,


### PR DESCRIPTION
## What

A fence can be left permanently half-highlighted: correct in dark mode, plain in light mode, for
the life of that code block. The same defect is what makes `Frontend unit tests (Windows)` fail
about one run in twenty on `a streaming fence is tokenized once, not once per update`.

The first version of this PR blamed the test's timing helper. That was wrong, and this replaces it.

## What a user sees

Shiki's line tokenizer gives up after a fixed amount of WALL CLOCK, and the plugin never set that
budget. When it runs out, the rest of the line is emitted as one uncoloured token. Because dual
themes are tokenized in two passes with two separate budgets, one theme can run out and the other
not, and the same line comes back plain in `color` and correctly coloured in `--shiki-dark`.

Committed lines are never re-tokenized, so this is not a frame of flicker that the next update
repairs. One overrun -- a busy machine, a background build, a long fence arriving mid-stream -- and
that line stays half-plain in the cache until the fence is evicted. In the default light theme it
reads as a code block that simply stopped being highlighted part way through, while the dark theme
renders it correctly. That is the bug worth fixing here; the CI flake is the same defect showing up
somewhere it gets measured.

## Why it happens, and why Windows CI is where it showed

The budget is `tokenizeTimeLimit`, default 500 ms per line, and only the first theme pass pays to
compile the grammar's regexes. Windows runners are the slow ones, which is where it surfaces.

That is exactly the failure signature CI prints: `#24292E` (github-light's default foreground) against `#005CC5` / `#032F62` /
`#D73A49`, with every `--shiki-dark` value already correct. Approximation was never involved:
`approximateResult` renders whole tail lines via `plainLine`, which carries no `--shiki-dark` at all.

Reproduced at the shiki level, cold highlighter, `tokenizeTimeLimit: 1` versus unlimited:

```
A: {"content":"value_1","offset":63,"htmlStyle":{"color":"#24292E","--shiki-dark":"#79B8FF"}}
B: {"content":"value_1","offset":63,"htmlStyle":{"color":"#005CC5","--shiki-dark":"#79B8FF"}}
```

Same content, same offsets, same dark colours, light dropped to the default foreground: token for
token what CI printed.

Two things follow from it being a wall clock:

- Both sides of the comparison are exposed. CI has produced diffs with the plugin degraded, diffs
  with the reference degraded, and diffs with both on different lines of the same run.
- It is not caused by anything in a PR. Four consecutive commits on `main` with a byte-identical
  `studio/frontend` tree (`5fab8da3bf290a56c69c96b27c45ce54ebf79a98`) went green, green, green, red
  within ten minutes. Windows only, because those runners are the slow ones; the ubuntu job has not
  hit it.

## The change

`code-plugin.ts` now passes explicit limits and bounds the work by line length instead of by time:

```ts
export const TOKENIZE_LIMITS = {
  tokenizeTimeLimit: 0,
  tokenizeMaxLineLength: 20_000,
} as const;
```

Line length is a property of the source rather than of the host, so the output is the same
everywhere. It is the same protection the time limit was there to give: this component's own shiki
configuration takes about 120 ms on a 20000-character minified line, and the cost is quadratic past
that (63902 chars 861 ms, 268902 chars 14.5 s), so an unbounded tokenizer really would block the UI
thread on a pasted blob. 20000 is VS Code's `editor.maxTokenizationLineLength` default, chosen for
the same reason.

The reference highlighters in the four code-plugin test files take the same limits, so neither side
of a token comparison can degrade.

A regression test races `Date.now` so every elapsed check clears any finite limit. It reproduces an
overrun on any machine without waiting for one, and `tokenizeTimeLimit: 0` is immune because the
check is skipped entirely. The plugin's own refresh throttle reads `performance.now`, so it is
untouched by the patch.

The callback-preferring helper from the first version is reverted. With a settle longer than
`REFRESH_MS` the approximation path it guarded against is unreachable, so it only deferred a value
it already had.

## Verification

| | |
| --- | --- |
| regression test, without the product change | fails, deterministically, on Linux |
| regression test, with it | passes |
| `npm test` | 5201 pass, 0 fail |
| `tsc -b` and `tsc -p tsconfig.test.json` | clean |

## Not this PR

`Frontend build + bundle sanity` is red here on `Locale parity`, from
`0451b8f24d9ffffb09a4756035c5a4364372000d` (#9752) adding four `settings.agents.*` keys to `en.ts`
and no other overlay. `main` itself and every studio PR opened since have been red on it.
