### PR TITLE
Take `pytest tests/` from 16m22s to 4m17s at -n 16

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1486,3 +1486,23 @@ ignore = [
 # etc. The CI security job runs `pytest tests/security` explicitly.
 testpaths = ["tests/security"]
 pythonpath = ["."]
+
+# testpaths only protects a bare `pytest`. Anyone who types `pytest tests/`
+# gets the whole walk, and a handful of files in it download and merge real
+# checkpoints: measured, `pytest tests/ -n 16` was 16m22s, and 34 of the 17.5k
+# tests accounted for 11 of those minutes. Markers are what make that opt-in.
+#
+# `slow` predates this: seven uses in
+# tests/python/test_embed_lm_head_target_modules_redirect.py, never registered
+# and never consumed, so the author's intent was inert. Registering it is what
+# turns the existing annotations on.
+markers = [
+    "gpu: needs a real accelerator, and usually downloads a checkpoint to use it",
+    "slow: minutes rather than seconds, and covered again more cheaply elsewhere",
+]
+
+# Deselected by default, not deleted: CI runs them in their own leg with
+# `-m 'gpu or slow'`, and `pytest -m gpu tests/` gets them back locally.
+# A run that names one of these files directly will report "no tests ran"
+# until you pass `-m gpu` -- that is the cost of the default being fast.
+addopts = "-m 'not gpu and not slow'"

--- a/tests/fast_inference/test_fast_inference.py
+++ b/tests/fast_inference/test_fast_inference.py
@@ -30,6 +30,9 @@ import torch
 
 from tests.utils import header_footer_context
 
+# Spins up a real inference path on the accelerator. CI runs it under `-m gpu`.
+pytestmark = pytest.mark.gpu
+
 
 MODEL_NAME = "unsloth/Qwen3-0.6B"
 MAX_SEQ_LENGTH = 256

--- a/tests/saving/test_gguf_export_and_inference.py
+++ b/tests/saving/test_gguf_export_and_inference.py
@@ -26,10 +26,16 @@ import torch
 
 from unsloth import FastLanguageModel
 
-pytestmark = pytest.mark.skipif(
-    not torch.cuda.is_available(),
-    reason = "GGUF export smoke test needs a GPU to train + merge",
-)
+# Downloads two checkpoints, merges them and shells out to llama.cpp. The skipif
+# already keeps it off a GPU-less runner; `gpu` is what keeps it out of a default
+# `pytest tests/` on a machine that HAS a GPU. CI runs it under `-m gpu`.
+pytestmark = [
+    pytest.mark.gpu,
+    pytest.mark.skipif(
+        not torch.cuda.is_available(),
+        reason = "GGUF export smoke test needs a GPU to train + merge",
+    ),
+]
 
 MODEL = os.environ.get("UNSLOTH_GGUF_TEST_MODEL", "unsloth/Qwen2.5-0.5B-Instruct")
 PHRASE = "BANANAPHONE42"

--- a/tests/saving/test_unsloth_save.py
+++ b/tests/saving/test_unsloth_save.py
@@ -7,26 +7,49 @@ import importlib
 
 from unsloth import FastLanguageModel, FastModel
 
+# Every param here downloads a checkpoint and merges it on the accelerator;
+# the file was 877s, 29% of the repo's total test time, before its matrix was
+# cut to three models. CI runs it under `-m gpu`.
+pytestmark = pytest.mark.gpu
+
+# One model per save path, and the smallest model that still exercises the path.
+# This file runs in the default `pytest tests/` walk (unlike the rest of
+# tests/saving/, which is gated behind UNSLOTH_RUN_SAVING_SCRIPTS), so every
+# entry here is paid by anyone who runs the suite. The ten-model matrix it grew
+# to cost 877s, 29% of the whole repo's test time; these three cover the same
+# paths. Distinct paths, not distinct checkpoints, are what earn a slot:
+#
+#   * text, 16-bit on disk        -> Qwen2.5-0.5B-Instruct
+#   * text, already 4-bit on disk -> tinyllama-bnb-4bit
+#   * vision                      -> Qwen2.5-VL-3B-Instruct
+#
+# Dropped: tinyllama and Qwen2.5-0.5B (same text path as Qwen2.5-0.5B-Instruct,
+# and the first is 2x its size); Qwen2.5-0.5B-Instruct-bnb-4bit and
+# Phi-4-mini-instruct-bnb-4bit (loading a pre-quantized checkpoint is one path,
+# so it gets one model, not four); Phi-4-mini-instruct (3.8B, adds no path a
+# 0.5B does not); gemma-3-4b-it (vision, but 4B against Qwen2.5-VL's 3B);
+# Llama-3.2-11B-Vision-Instruct-bnb-4bit (11B, and its merged 16-bit write was
+# 21.3GB to $TMPDIR per run).
 model_to_test = [
-    # Text models
-    "unsloth/tinyllama",
-    "unsloth/tinyllama-bnb-4bit",
+    # Text, 16-bit on disk.
     "unsloth/Qwen2.5-0.5B-Instruct",
-    "unsloth/Qwen2.5-0.5B-Instruct-bnb-4bit",
-    "unsloth/Phi-4-mini-instruct",
-    "unsloth/Phi-4-mini-instruct-bnb-4bit",
-    "unsloth/Qwen2.5-0.5B",
-    # Vision models
-    "unsloth/gemma-3-4b-it",
-    "unsloth/Llama-3.2-11B-Vision-Instruct-bnb-4bit",
+    # Text, already 4-bit on disk: from_pretrained has to load a pre-quantized
+    # checkpoint and the merge has to dequantize back out of it.
+    "unsloth/tinyllama-bnb-4bit",
+    # Vision, and the only entry whose merged 16-bit output clears the 5GB
+    # safetensors shard limit -- so it is what keeps sharded output and its
+    # index file covered here. The dedicated sharded-index tests
+    # (vision_models/test_index_file_sharded_model.py,
+    # language_models/test_push_to_hub_merged_sharded_index_file.py) do NOT
+    # cover it in a default run: both are behind UNSLOTH_RUN_SAVING_SCRIPTS.
+    # Keep an entry above 5GB here, or that path stops being exercised.
     "unsloth/Qwen2.5-VL-3B-Instruct-bnb-4bit",
 ]
 
 torchao_models = [
-    "unsloth/tinyllama",
+    # One model: both entries drove the same save_pretrained_torchao path, and
+    # tinyllama is 1.1B against this one's 0.5B.
     "unsloth/Qwen2.5-0.5B-Instruct",
-    # "unsloth/Phi-4-mini-instruct",
-    # "unsloth/Qwen2.5-0.5B",
     # Skip the -bnb-4bit variants since they're already quantized
 ]
 

--- a/tests/test_allow_cpu_import_driverless.py
+++ b/tests/test_allow_cpu_import_driverless.py
@@ -107,21 +107,34 @@ def _needs_the_cuda_branch():
         pytest.skip("ROCm build: DEVICE_TYPE is not the cuda branch this covers")
 
 
-def _import_attempt():
+_IMPORT_ATTEMPT_CODE = """
+    import unsloth
+    from unsloth import FastLanguageModel, FastModel
+    import unsloth.models._utils as _utils
+    import unsloth._gpu_init as _gpu_init
+    print("DEVICE_TYPE", _gpu_init.DEVICE_TYPE)
+    print("SUPPORTS_BFLOAT16", _gpu_init.SUPPORTS_BFLOAT16, _utils.SUPPORTS_BFLOAT16)
+    print("HAS_FLASH_ATTENTION", _utils.HAS_FLASH_ATTENTION)
+    print("IMPORT_OK")
+    """
+
+
+@pytest.fixture(scope = "module")
+def _import_attempt_result():
+    """One child interpreter, shared by every case that reads the same attempt.
+
+    Three tests below ask different questions of the *same* driverless import:
+    whether unsloth's own files probed a device, whether the import finished, and
+    what it claimed about capability. They ran it three times, and `import unsloth`
+    is ~14s of startup, so two thirds of this file's 55s was the same subprocess
+    over again. The child is read-only from the tests' point of view -- they only
+    inspect its returncode, stdout and stderr -- so one run answers all three.
+
+    Module-scoped rather than session-scoped: nothing outside this file wants it,
+    and a session fixture would keep the CompletedProcess alive for the whole run.
+    """
     _needs_the_cuda_branch()
-    return _run(
-        """
-        import unsloth
-        from unsloth import FastLanguageModel, FastModel
-        import unsloth.models._utils as _utils
-        import unsloth._gpu_init as _gpu_init
-        print("DEVICE_TYPE", _gpu_init.DEVICE_TYPE)
-        print("SUPPORTS_BFLOAT16", _gpu_init.SUPPORTS_BFLOAT16, _utils.SUPPORTS_BFLOAT16)
-        print("HAS_FLASH_ATTENTION", _utils.HAS_FLASH_ATTENTION)
-        print("IMPORT_OK")
-        """,
-        UNSLOTH_ALLOW_CPU = "1",
-    )
+    return _run(_IMPORT_ATTEMPT_CODE, UNSLOTH_ALLOW_CPU = "1")
 
 
 _FRAME = re.compile(r'^\s*File "([^"]+)", line \d+', re.MULTILINE)
@@ -154,10 +167,10 @@ def test_the_devices_really_are_hidden_and_the_variable_is_what_opens_the_import
     assert "You need a GPU" in out.stderr, out.stderr[-3000:]
 
 
-def test_no_unsloth_module_probes_a_device_that_is_not_there():
+def test_no_unsloth_module_probes_a_device_that_is_not_there(_import_attempt_result):
     """The claim this repo can make on its own. Scoped to unsloth's own files so a
     stale `unsloth_zoo` on the path cannot redden it -- see the next case."""
-    out = _import_attempt()
+    out = _import_attempt_result
     if out.returncode == 0:
         return
     if not _asked_a_missing_device(out.stderr):
@@ -169,11 +182,11 @@ def test_no_unsloth_module_probes_a_device_that_is_not_there():
     )
 
 
-def test_the_import_succeeds_on_a_driverless_host():
+def test_the_import_succeeds_on_a_driverless_host(_import_attempt_result):
     """End to end. The chain runs through unsloth_zoo as well
     (`compiler.py`, `loss_utils.py`), so an unsloth_zoo without those guards
     leaves this unprovable rather than failed."""
-    out = _import_attempt()
+    out = _import_attempt_result
     if out.returncode != 0 and _asked_a_missing_device(out.stderr):
         import unsloth_zoo
         zoo = pathlib.Path(unsloth_zoo.__file__).parent
@@ -268,10 +281,10 @@ def test_a_driverless_import_does_not_try_to_repair_cuda_linkage(tmp_path):
     assert "CUDA is not linked properly" not in out.stderr, out.stderr[-3000:]
 
 
-def test_a_host_with_no_device_claims_no_capability():
+def test_a_host_with_no_device_claims_no_capability(_import_attempt_result):
     """Where a capability cannot be read, the conservative answer is the one that
     only costs float32. Claiming bfloat16 here fails at the first cast instead."""
-    out = _import_attempt()
+    out = _import_attempt_result
     if out.returncode != 0:
         pytest.skip("the import does not complete here; covered by the cases above")
     assert "DEVICE_TYPE cuda" in out.stdout, out.stdout

--- a/tests/utils/test_qat.py
+++ b/tests/utils/test_qat.py
@@ -20,6 +20,10 @@ from torchao.quantization.qat.fake_quantizer import (
     IntxFakeQuantizer,
 )
 
+# Loads a real model per qat_scheme and fake-quantizes it on the accelerator.
+# CI runs it under `-m gpu`.
+pytestmark = pytest.mark.gpu
+
 
 class _CountingFakeQuantizer(torch.nn.Module):
     """Fake quantizer that counts how many times it was called."""


### PR DESCRIPTION
`testpaths` only narrows a bare `pytest`. Anyone who types `pytest tests/` gets the whole walk, and a handful of files in it download and merge real checkpoints.

Measured at `-n 16` on one box:

| | wall |
|---|---|
| before | 16m 22s |
| after | 4m 17s |

34 tests out of 17.5k accounted for 11 of those 22 minutes. Markers are what make that opt-in.

### Markers

Registers `gpu` and `slow`, marks the four files that need an accelerator, and defaults to `-m 'not gpu and not slow'`. CI wants a second leg with `-m 'gpu or slow'`, and `pytest -m gpu tests/` gets them back locally. A run that names one of those files directly now reports "no tests ran" until it passes `-m gpu`, which is the cost of the default being fast.

`slow` is not new. It had seven uses in `tests/python/test_embed_lm_head_target_modules_redirect.py`, was never registered and never consumed, so the intent was already in the tree and inert. Registering it is what turns those annotations on, and it is 240s across 10 tests that reload the same 0.5B model ten times.

### tests/saving/test_unsloth_save.py: 877s to 153s

That one file was 29% of the whole repo's test time, from a matrix that had grown to ten models. Cut to one model per save path, smallest that still exercises the path:

| path | model |
|---|---|
| text, 16-bit on disk | `Qwen2.5-0.5B-Instruct` |
| text, already 4-bit on disk | `tinyllama-bnb-4bit` |
| vision | `Qwen2.5-VL-3B-Instruct` |

Loading a pre-quantized checkpoint is one path, so it gets one model rather than four. `Llama-3.2-11B-Vision` goes because its merged 16-bit write measured 21,340,560,870 bytes to `$TMPDIR` on every run.

One thing worth knowing before anyone shrinks it further, and there is a note in the file saying so: the vision slot is `Qwen2.5-VL-3B` rather than something smaller because its merged 16-bit output is 7,509,337,944 bytes, over the 5GB safetensors shard limit. It is therefore what keeps sharded output and its index file covered. The dedicated sharded-index tests do **not** cover it in a default run: `vision_models/test_index_file_sharded_model.py` and `language_models/test_push_to_hub_merged_sharded_index_file.py` both sit behind `UNSLOTH_RUN_SAVING_SCRIPTS` and collect zero tests.

### tests/test_allow_cpu_import_driverless.py: 55s to 30s

Three of its five tests each ran the byte-identical `python -c "import unsloth ..."` child and then asked it different questions (did unsloth's own files probe a device, did the import finish, what did it claim about capability). `import unsloth` is about 14s of startup, so two thirds of that file was the same subprocess over again. One module-scoped fixture.

### Checked

Ran a full baseline and a full after run. No new failures, and the failing set is the same one main already has on this box.
