### PR TITLE
Derive the fp8 fbgemm test tolerance from the bf16 ULP

### DIFF
--- a/tests/test_fp8_fbgemm_block_shapes.py
+++ b/tests/test_fp8_fbgemm_block_shapes.py
@@ -58,6 +58,32 @@ def _reference(X, Wq, scale, block):
     return (X.float() @ _dequant(Wq, scale, block).T).to(X.dtype)
 
 
+def _bf16_atol(ref, floor = 5e-2):
+    """One bf16 ULP at the largest magnitude in the result.
+
+    Both sides of these comparisons are bf16, and an element's error comes from
+    cancellation among K terms whose magnitudes reach max|ref| -- not from the
+    size of the element itself. The absolute floor is therefore a last-bit
+    difference at THAT magnitude, and any atol below it compares the
+    accumulation order of whichever kernel fbgemm picked rather than whether
+    the fallback is correct.
+
+    Measured on the odd-N fixture (N=250, K=256): the errors land exactly on
+    bf16 ULPs -- max 0.25, p99 0.125, mean 0.021, against max|ref| = 42.75, one
+    ULP of which is 0.334. A flat atol=5e-2 cleared the worst element by 13%,
+    so it held on an idle GPU and failed 2 elements in 1000 under a loaded one,
+    where fbgemm selects a different split-k. Deriving the bound from the dtype
+    keeps the assert on the fallback's correctness: a genuinely wrong kernel
+    misses by orders of magnitude, not by a last bit.
+
+    This costs no detection power. Injecting a uniform mis-scale into the output
+    -- the failure this file exists to catch -- both bounds miss 2% and both
+    catch 5%, 8%, 10%, 50% and 2x, because rtol dominates on the large elements
+    where a mis-scale shows. Only the flake goes.
+    """
+    return max(floor, torch.finfo(torch.bfloat16).eps * ref.abs().max().item())
+
+
 def _check_grad(X, out, Wq, scale, block):
     # grad_output is all-ones, so grad_X is the row-sum of the dequantized weight.
     # The old backward hardcoded 128x128 and returned finite but mis-scaled grads.
@@ -66,7 +92,9 @@ def _check_grad(X, out, Wq, scale, block):
     grad_ref = torch.ones(out.shape, device = out.device, dtype = torch.float32) @ _dequant(
         Wq, scale, block
     )
-    torch.testing.assert_close(X.grad.float(), grad_ref, atol = 5e-2, rtol = 5e-2)
+    torch.testing.assert_close(
+        X.grad.float(), grad_ref, atol = _bf16_atol(grad_ref), rtol = 5e-2
+    )
 
 
 def _rel_err(out, ref):
@@ -118,7 +146,7 @@ def test_odd_k_uses_dequant_fallback():
     assert torch.isfinite(out).all()
 
     ref = _reference(X.detach(), Wq, scale, block)
-    torch.testing.assert_close(out, ref, atol = 5e-2, rtol = 5e-2)
+    torch.testing.assert_close(out, ref, atol = _bf16_atol(ref), rtol = 5e-2)
 
     _check_grad(X, out, Wq, scale, block)
 
@@ -136,7 +164,7 @@ def test_odd_n_uses_dequant_fallback():
 
     out = FP8_fbgemm_block_linear.apply(X, Wq, scale)
     ref = _reference(X.detach(), Wq, scale, block)
-    torch.testing.assert_close(out, ref, atol = 5e-2, rtol = 5e-2)
+    torch.testing.assert_close(out, ref, atol = _bf16_atol(ref), rtol = 5e-2)
 
     _check_grad(X, out, Wq, scale, block)
 


### PR DESCRIPTION
`test_odd_n_uses_dequant_fallback` and `test_non_square_block_uses_dequant_fallback` pass on an idle GPU and fail under a loaded one, two elements in 1000 at a time:

```
Mismatched elements: 2 / 1000 (0.2%)
Greatest absolute difference: 0.05810546875 at index (0, 195) (up to 0.05 allowed)
Greatest relative difference: 1.3359375 at index (3, 68) (up to 0.05 allowed)
```

They pass 8 out of 8 in isolation here. They only fail inside a full `-n 16` run where sixteen workers are sharing the card.

### That is not the kernel

Both sides of the comparison are bf16, and an element's error comes from cancellation among K terms whose magnitudes reach `max|ref|`, not from the size of the element itself. So the absolute floor is a last-bit difference at *that* magnitude.

Measured on the odd-N fixture (N=250, K=256):

| | |
|---|---|
| max abs error | 0.25 |
| p99 abs error | 0.125 |
| mean abs error | 0.021 |
| max\|ref\| | 42.75 |
| one bf16 ULP there | 0.334 |

The errors land exactly on bf16 ULPs. The flat `atol=5e-2` cleared the worst element by **13%**, so it held while fbgemm chose one split-k and failed when a contended GPU made it choose another. The assert was measuring accumulation order, not correctness.

### The change

Derive `atol` from the dtype, floored at the old value so nothing gets looser than it was on small results.

### It costs no detection power

Worth checking rather than assuming, since loosening a tolerance is exactly how a real bug gets hidden. Injecting a uniform mis-scale into the output, which is the failure this file exists to catch:

| injected error | old `atol=0.05` | new `atol=0.334` |
|---|---|---|
| 2% | missed | missed |
| 5% | caught | caught |
| 8% | caught | caught |
| 10% | caught | caught |
| 50% | caught | caught |
| 2x | caught | caught |

Identical, because `rtol` dominates on the large elements where a mis-scale shows. Only the flake goes.

Follows #8953, which added these cases. The fallback itself looks correct: 998 of 1000 elements matched even on the failing runs.
