### PR TITLE
Studio: warm fence grammars on real text, not an empty string

### DIFF
--- a/studio/backend/tests/test_offload_planner_seam.py
+++ b/studio/backend/tests/test_offload_planner_seam.py
@@ -1244,6 +1244,8 @@ def test_the_flat_mtp_reserve_reaches_the_spill_budget():
     reserved = _plan(stub, free_mib = 24 * 1024, usable_mib = 14 * 1024)
     assert generous is not None and reserved is not None
     assert len(reserved.spilled_blocks) > len(generous.spilled_blocks)
+
+
 def test_the_seam_computes_a_per_layer_kv_vector():
     """The data already existed on the backend (_sliding_window_pattern); it just
     never crossed into the planner. Only the RATIOS travel: full attention holds

--- a/studio/frontend/src/components/assistant-ui/code-fence-defer.tsx
+++ b/studio/frontend/src/components/assistant-ui/code-fence-defer.tsx
@@ -340,7 +340,7 @@ const upgradeEverythingForPrint = (): void => {
 };
 
 /*
- * GRAMMARS, WARMED AT IDLE, ON REAL TEXT, ONE LANGUAGE PER TASK.
+ * GRAMMARS, WARMED AT IDLE, ON REAL TEXT, ONE TOKENIZATION PER TASK.
  *
  * One fence per language, so `latchNow`'s synchronous path cannot be defeated by a still-loading
  * grammar: on a jump into a language the reader has not met, and on a print, where there is no
@@ -359,32 +359,26 @@ const upgradeEverythingForPrint = (): void => {
  *   warm on real text           183,  190 ms     1                and 2
  *   this: split, eager loads    187,  183 ms     1/64/21/32/1016  and 2/68/36/52/1104
  *
- * The 1,016 ms is ONE tokenize call, typescript's first, which nothing here can subdivide; what
- * the split buys is that the other four do not land on top of it. The unsplit arm pays it too, at
- * t=6.5 s inside a grammar-load callback rather than in a warm, which is why its callback reads
- * 1 ms. On the empty-string arm the same call lands at t=36.5 s, inside the scroll, and that IS
- * the worst frame. Idle is best on the split arm, 25 and 32 ms worst frame against 46/37 unsplit
- * and 38/43 on `""`, because the work is done by t=8 s.
+ * The 1,016 ms is ONE tokenize call, typescript's first, which nothing here can subdivide; the
+ * split only keeps the other four off it. Every arm pays that call: unsplit at t=6.5 s inside a
+ * grammar-load callback, which is why its warm reads 1 ms, and on the `""` arm at t=36.5 s, inside
+ * the scroll, where it IS the worst frame. Moved, not skipped, and the totals say so: tokenize time
+ * RISES, 1607-1746 ms to 1917-2039 ms, because a warmed fence is tokenized once and read from cache
+ * later. Mount is unaffected, worst idle frame is best here (25 and 32 ms against 46/37 unsplit and
+ * 38/43 on `""`), idle is 62.5 fps and 7.1 to 7.4% busy on every arm, the three arms render the
+ * same document (7,259 spans, 27,045 elements, 56 code blocks), and the rig is jam-controlled: a
+ * 200 ms/250 ms hog reads 81% busy.
  *
- * Moved, not skipped: total tokenize time RISES, 1607-1746 ms to 1917-2039 ms, because a warmed
- * fence is tokenized once here and read from cache later. Mount is unaffected, idle is 62.5 fps
- * and 7.1 to 7.4% busy on every arm, the three arms render the same document (7,259 spans, 27,045
- * elements, 56 code blocks), and the rig is jam-controlled: a 200 ms/250 ms hog reads 81% busy.
- *
- * ONE TOKENIZATION PER TASK, BUT EVERY LOAD IN THE FIRST. An idle callback only chooses when it
- * STARTS -- nothing yields once it runs, its 2,000 ms timeout can start it on a busy thread, and
- * WebKitGTK has no `requestIdleCallback` at all, so this venue takes the `setTimeout` fallback and
- * cannot even pick a quiet moment. The table understates that: a COLD grammar makes
- * `code.highlight` queue and return, leaving the tokenizing to each grammar's own load callback.
- * Once loaded it tokenizes INLINE and N languages concatenate -- driving shiki with this
- * component's configuration, the five languages here (c, python, go, typescript, rust) cost 746 ms
- * back to back, worst single language 334 ms.
- *
- * The LOADS stay eager, all of them, in the first pass. Yielding them too would put the last
- * language's grammar 500 ms x N away on the `setTimeout` fallback, and a jump or a print inside
- * that window is exactly what this exists for: `highlight` answers `null` while a grammar loads,
- * so `latchNow`'s synchronous flush would produce streamdown's plain fallback for that frame or
- * that page. A load is cheap and asynchronous; only the tokenization is worth a task of its own.
+ * WHY THE TOKENIZATIONS YIELD AND THE LOADS DO NOT. An idle callback only chooses when it STARTS:
+ * nothing yields once it runs, its 2,000 ms timeout can start it on a busy thread, and WebKitGTK
+ * has no `requestIdleCallback` at all, so this venue takes the `setTimeout` fallback and cannot
+ * even pick a quiet moment. With a grammar already loaded `code.highlight` tokenizes INLINE and N
+ * languages concatenate -- driving shiki with this component's configuration, the five languages
+ * here (c, python, go, typescript, rust) cost 746 ms back to back. But `highlight` answers `null`
+ * WHILE a grammar loads, so yielding the loads too would put the fifth grammar 500 ms x N away and
+ * a jump or a print inside that window would get streamdown's plain fallback out of `latchNow`'s
+ * flush -- the defect this whole pre-warm exists to prevent. So every load starts in the first
+ * pass and only the tokenizing is spread out.
  *
  * NOTHING BOUNDED THE SIZE OF A WARM, and this comment used to claim `MAX_HIGHLIGHT_CHARS` did.
  * It does not reach here: `markdownPluginNeeds` applies it in `markdown-preview.tsx` and
@@ -392,11 +386,10 @@ const upgradeEverythingForPrint = (): void => {
  * source, but `markdown-text.tsx` supplies the code plugin unconditionally and `FenceBlock` warms
  * the whole body -- and `code-plugin.ts`'s `evict` keeps the last fence whatever its size. A LATCH
  * is demanded work and stays uncapped; a warm is SPECULATIVE, on a fence the reader may never
- * reach, so it is capped at the same 20,000 characters. Past the cap, and for a fence that is
- * EMPTY or nothing but newlines, this loads the grammar and stops. Neither marks the grammar
- * warmed, so a later fence in that language still gets its real warm rather than inheriting a
- * tokenization of `""`. The cap costs the measurement nothing: the largest fence at this rung is
- * 2,817 characters.
+ * reach, so it is capped at the same 20,000 characters. Over the cap, and for a fence that is
+ * EMPTY or nothing but newlines, the grammar loads and nothing is tokenized; neither marks the
+ * language warmed, so a later fence that can warm it still does. The cap costs the measurement
+ * nothing: the largest fence at this rung is 2,817 characters.
  */
 const grammarsWarmed = new Set<string>();
 const grammarsLoaded = new Set<string>();

--- a/studio/frontend/src/components/assistant-ui/code-fence-defer.tsx
+++ b/studio/frontend/src/components/assistant-ui/code-fence-defer.tsx
@@ -330,14 +330,34 @@ const upgradeEverythingForPrint = (): void => {
 };
 
 /*
- * GRAMMARS, WARMED AT IDLE. NOT TOKENS.
+ * GRAMMARS, WARMED AT IDLE, ON REAL TEXT.
  *
- * `warm(false)` highlights an EMPTY string in the fence's language: the grammar loads, nothing is
- * tokenized, no span is mounted, the document stays the size deferral made it. It buys that
- * `latchNow`'s synchronous path cannot be defeated by a still-loading grammar -- on a jump into a
- * language the reader has not met, and on a print, where there is no later frame to correct in.
- * Deduplicated by language and scheduled at idle: one load per language, nothing when nothing is
- * deferred.
+ * This warms one fence per language so that `latchNow`'s synchronous path cannot be defeated by a
+ * still-loading grammar -- on a jump into a language the reader has not met, and on a print, where
+ * there is no later frame to correct in. Deduplicated by language and scheduled at idle: one warm
+ * per language, nothing when nothing is deferred.
+ *
+ * IT USED TO WARM ON AN EMPTY STRING, and that made the pre-warm miss most of what it exists to
+ * prevent. Loading a grammar is not the expensive part; running it over text for the first time is.
+ * Highlighting `""` resolves the language and mounts no span, but it never gives the tokenizer any
+ * text, so the first REAL tokenization still pays the whole one-off cost -- and with deferral on,
+ * that lands during a scroll, in one frame, on the fence the reader has just reached.
+ *
+ * Measured at the 100K rung on WebKitGTK 2.50.4, two reps per arm, production build:
+ *
+ *                     worst scroll frame   the same fence's tokenize call
+ *   warm on ""              1081, 1072 ms        1065 ms, at t=32.8 s, DURING the scroll
+ *   warm on real text        182,  190 ms        1034 ms, at t=2.9 s, BEFORE it, and 170 ms during
+ *
+ * The work is not skipped, it is moved, and the totals say so: instrumenting the innermost
+ * tokenizer, total tokenize time RISES from 1609 to 1880 ms, because a warmed fence is tokenized
+ * once here and then read from cache. What changes is where it lands. Mount is unaffected (2689 vs
+ * 2614 ms, and 1089 vs 1058 in the second rep) because this runs on an idle callback after mount,
+ * idle is unaffected (62.5 fps, 7.2% busy on both arms), and the rendered document is identical:
+ * 7,259 highlight spans, 27,046 elements, 56 code blocks on both.
+ *
+ * `MAX_HIGHLIGHT_CHARS` still bounds this: a fence past the cap is never highlighted at all, so no
+ * warm can be large in a way the latch would not already have been.
  */
 const grammarsWarmed = new Set<string>();
 let warmScheduled = false;
@@ -348,7 +368,9 @@ const warmGrammars = (): void => {
     const language = gate.language ?? "text";
     if (grammarsWarmed.has(language)) continue;
     grammarsWarmed.add(language);
-    gate.warm(false);
+    // TRUE, not false: see above. Warming on real text is what actually takes the one-off
+    // tokenizer cost off the scroll.
+    gate.warm(true);
   }
 };
 

--- a/studio/frontend/src/components/assistant-ui/code-fence-defer.tsx
+++ b/studio/frontend/src/components/assistant-ui/code-fence-defer.tsx
@@ -13,6 +13,7 @@ import {
 } from "react";
 import { flushSync } from "react-dom";
 
+import { MAX_HIGHLIGHT_CHARS } from "@/lib/markdown-plugins";
 import { type FenceMode, resolveFenceMode } from "./code-fence-mode";
 
 /*
@@ -178,6 +179,8 @@ type FenceGate = {
   near: HTMLElement | null;
   outer: HTMLElement | null;
   language: string | null;
+  /** Upper bound on what `warm(true)` would tokenize; trimming only removes trailing newlines. */
+  chars: number;
   /** `true` tokenizes this fence's source now; `false` only loads its grammar. */
   warm: (tokens: boolean) => void;
   latch: () => void;
@@ -330,7 +333,7 @@ const upgradeEverythingForPrint = (): void => {
 };
 
 /*
- * GRAMMARS, WARMED AT IDLE, ON REAL TEXT.
+ * GRAMMARS, WARMED AT IDLE, ON REAL TEXT, ONE LANGUAGE PER TASK.
  *
  * This warms one fence per language so that `latchNow`'s synchronous path cannot be defeated by a
  * still-loading grammar -- on a jump into a language the reader has not met, and on a print, where
@@ -343,23 +346,43 @@ const upgradeEverythingForPrint = (): void => {
  * text, so the first REAL tokenization still pays the whole one-off cost -- and with deferral on,
  * that lands during a scroll, in one frame, on the fence the reader has just reached.
  *
- * Measured at the 100K rung on WebKitGTK 2.50.4, two reps per arm, production build:
+ * Three arms out of ONE build at the 100K rung on WebKitGTK 2.50.4, two reps each, so a difference
+ * between arms cannot be a build difference:
  *
- *                     worst scroll frame   the same fence's tokenize call
- *   warm on ""              1081, 1072 ms        1065 ms, at t=32.8 s, DURING the scroll
- *   warm on real text        182,  190 ms        1034 ms, at t=2.9 s, BEFORE it, and 170 ms during
+ *                            worst scroll frame   warm callbacks
+ *   warm on ""                   1592, 1540 ms    1, of 2 and 1 ms
+ *   warm on real text             294,  318 ms    1, of 2 and 1 ms
+ *   one language per task         301,  298 ms    5, worst 108 and 93 ms
  *
- * The work is not skipped, it is moved, and the totals say so: instrumenting the innermost
- * tokenizer, total tokenize time RISES from 1609 to 1880 ms, because a warmed fence is tokenized
- * once here and then read from cache. What changes is where it lands. Mount is unaffected (2689 vs
- * 2614 ms, and 1089 vs 1058 in the second rep) because this runs on an idle callback after mount,
- * idle is unaffected (62.5 fps, 7.2% busy on both arms), and the rendered document is identical:
- * 7,259 highlight spans, 27,046 elements, 56 code blocks on both.
+ * The work is not skipped, it is moved: instrumenting the innermost tokenizer, total tokenize time
+ * RISES (2361-2526 ms to 2851-2869 ms) because a warmed fence is tokenized once here and read from
+ * cache later. Mount and idle are unaffected (62.5 fps, 7.3 to 7.7% busy on every arm) and the two
+ * arms in a rep render the same document, 7,259 spans and 27,046 elements over 56 code blocks in
+ * the second. The rig is jam-controlled: a 200 ms/250 ms hog reads 81% busy against 7.4%.
  *
- * `MAX_HIGHLIGHT_CHARS` still bounds this: a fence past the cap is never highlighted at all, so no
- * warm can be large in a way the latch would not already have been.
+ * WHY ONE LANGUAGE PER TASK. An idle callback only chooses when it STARTS: nothing yields once it
+ * runs, and the 2,000 ms timeout can start it on a busy thread. WebKitGTK has no
+ * `requestIdleCallback` at all, so this venue takes the `setTimeout` fallback and cannot even pick
+ * a quiet moment. The table understates the risk, because a COLD grammar makes `code.highlight`
+ * queue and return, leaving the tokenizing to each grammar's own load callback. Once the grammar
+ * is loaded it tokenizes INLINE, and then N languages in one callback concatenate: driving shiki
+ * with this component's own configuration, the five languages at this rung (c, python, go,
+ * typescript, rust) cost 746 ms back to back, worst single language 334 ms. Split, each task warms
+ * one language and re-schedules, so the chain drains at idle instead of in one block.
+ *
+ * NOTHING BOUNDED THE SIZE OF A WARM, and this comment used to claim `MAX_HIGHLIGHT_CHARS` did.
+ * It does not reach here. `markdownPluginNeeds` applies it in `markdown-preview.tsx` and
+ * `model-readme.tsx`, and `tool-code-cell.tsx` and `attachment-preview.tsx` apply it to their own
+ * source, but `markdown-text.tsx` hands Streamdown the code plugin unconditionally and
+ * `FenceBlock` warms the whole fence body. So a warm on real text was unbounded, on a fence the
+ * reader may never reach, and `code-plugin.ts`'s `evict` keeps the last fence whatever its size. A
+ * LATCH is demanded work and stays uncapped; a warm is SPECULATIVE, so it is capped here at the
+ * same 20,000 characters. Past the cap this loads the grammar and stops, exactly as the
+ * empty-string warm did, and keeps looking for a fence in that language small enough to warm on
+ * real text. It costs the measurement nothing: the largest fence at this rung is 2,817 characters.
  */
 const grammarsWarmed = new Set<string>();
+const grammarsLoaded = new Set<string>();
 let warmScheduled = false;
 
 const warmGrammars = (): void => {
@@ -367,10 +390,23 @@ const warmGrammars = (): void => {
   for (const gate of unreached) {
     const language = gate.language ?? "text";
     if (grammarsWarmed.has(language)) continue;
+    if (gate.chars > MAX_HIGHLIGHT_CHARS) {
+      // Over the cap. Load the grammar and tokenize nothing, then keep looking: another fence in
+      // this language may be small enough to warm properly.
+      if (!grammarsLoaded.has(language)) {
+        grammarsLoaded.add(language);
+        gate.warm(false);
+      }
+      continue;
+    }
     grammarsWarmed.add(language);
     // TRUE, not false: see above. Warming on real text is what actually takes the one-off
     // tokenizer cost off the scroll.
     gate.warm(true);
+    // Yield. `grammarsWarmed` only grows, so each task warms one more language and the chain
+    // drains; a pass that warms nothing falls out of the loop and schedules nothing.
+    scheduleGrammarWarm();
+    return;
   }
 };
 
@@ -498,6 +534,8 @@ const inBand = (node: HTMLElement, scroller: HTMLElement | null): boolean => {
  *                 latches, so that finishing cannot take the highlighting back.
  * @param language  used only to load one grammar per language rather than one per fence; `null`
  *                 warms plain text.
+ * @param chars  this fence's source length, read only by `warmGrammars` to keep a SPECULATIVE
+ *                 warm inside `MAX_HIGHLIGHT_CHARS`. A latch is demanded work and is not capped.
  * @param warm  drive the highlighter over this fence: `true` for tokens, `false` for the grammar
  *                 alone. See `latchNow`. Held in a ref, not an effect dependency, so an
  *                 unmemoized caller cannot rebuild every observer in the thread on every render.
@@ -507,6 +545,7 @@ export function useFenceReached(
   enabled: boolean,
   streaming: boolean,
   language: string | null,
+  chars: number,
   warm: (tokens: boolean) => void,
 ): boolean {
   const [latched, setLatched] = useState(false);
@@ -627,6 +666,7 @@ export function useFenceReached(
       near,
       outer,
       language,
+      chars,
       warm: (tokens) => warmRef.current(tokens),
       latch: () => setLatched(true),
       // Reuses `generation`: this fence has just latched, so every effect keyed on it

--- a/studio/frontend/src/components/assistant-ui/code-fence-defer.tsx
+++ b/studio/frontend/src/components/assistant-ui/code-fence-defer.tsx
@@ -91,11 +91,17 @@ const readBuildFlag = (): string => {
 
 // Streamdown trims trailing newlines off a fence body before rendering it, so
 // the shell has to as well or the two differ by a blank line of height.
-export const trimTrailingNewlines = (text: string): string => {
+//
+// The length is split out because `warmGrammars` needs the size of what a warm WOULD tokenize on
+// every render, and slicing a 20,000 character fence to measure it is a copy per render.
+export const trimmedLength = (text: string): number => {
   let end = text.length;
   while (end > 0 && text[end - 1] === "\n") end -= 1;
-  return text.slice(0, end);
+  return end;
 };
+
+export const trimTrailingNewlines = (text: string): string =>
+  text.slice(0, trimmedLength(text));
 
 /*
  * AN EMPTY FENCE IS ONE LINE TALL, not nothing.
@@ -348,25 +354,37 @@ const upgradeEverythingForPrint = (): void => {
  * fence the reader had just reached. Three arms out of ONE build at the 100K rung on WebKitGTK
  * 2.50.4, two reps each, so a difference between arms cannot be a build difference:
  *
- *                            worst scroll frame   warm callbacks
- *   warm on ""                   1592, 1540 ms    1, of 2 and 1 ms
- *   warm on real text             294,  318 ms    1, of 2 and 1 ms
- *   one language per task         301,  298 ms    5, worst 108 and 93 ms
+ *                          worst scroll frame   warm callbacks, ms
+ *   warm on ""                 1200, 1085 ms     1                and 1
+ *   warm on real text           183,  190 ms     1                and 2
+ *   this: split, eager loads    187,  183 ms     1/64/21/32/1016  and 2/68/36/52/1104
  *
- * Moved, not skipped: total tokenize time RISES, 2361-2526 ms to 2851-2869 ms, because a warmed
- * fence is tokenized once here and read from cache later. Mount and idle are unaffected (62.5 fps,
- * 7.3 to 7.7% busy on every arm), the two arms in a rep render the same document (7,259 spans,
- * 27,046 elements, 56 code blocks in the second), and the rig is jam-controlled: a 200 ms/250 ms
- * hog reads 81% busy against 7.4%.
+ * The 1,016 ms is ONE tokenize call, typescript's first, which nothing here can subdivide; what
+ * the split buys is that the other four do not land on top of it. The unsplit arm pays it too, at
+ * t=6.5 s inside a grammar-load callback rather than in a warm, which is why its callback reads
+ * 1 ms. On the empty-string arm the same call lands at t=36.5 s, inside the scroll, and that IS
+ * the worst frame. Idle is best on the split arm, 25 and 32 ms worst frame against 46/37 unsplit
+ * and 38/43 on `""`, because the work is done by t=8 s.
  *
- * ONE LANGUAGE PER TASK, because an idle callback only chooses when it STARTS -- nothing yields
- * once it runs, its 2,000 ms timeout can start it on a busy thread, and WebKitGTK has no
- * `requestIdleCallback` at all, so this venue takes the `setTimeout` fallback and cannot even pick
- * a quiet moment. The table understates that: a COLD grammar makes `code.highlight` queue and
- * return, leaving the tokenizing to each grammar's own load callback. Once loaded it tokenizes
- * INLINE and N languages concatenate -- driving shiki with this component's configuration, the
- * five languages here (c, python, go, typescript, rust) cost 746 ms back to back, worst single
- * language 334 ms.
+ * Moved, not skipped: total tokenize time RISES, 1607-1746 ms to 1917-2039 ms, because a warmed
+ * fence is tokenized once here and read from cache later. Mount is unaffected, idle is 62.5 fps
+ * and 7.1 to 7.4% busy on every arm, the three arms render the same document (7,259 spans, 27,045
+ * elements, 56 code blocks), and the rig is jam-controlled: a 200 ms/250 ms hog reads 81% busy.
+ *
+ * ONE TOKENIZATION PER TASK, BUT EVERY LOAD IN THE FIRST. An idle callback only chooses when it
+ * STARTS -- nothing yields once it runs, its 2,000 ms timeout can start it on a busy thread, and
+ * WebKitGTK has no `requestIdleCallback` at all, so this venue takes the `setTimeout` fallback and
+ * cannot even pick a quiet moment. The table understates that: a COLD grammar makes
+ * `code.highlight` queue and return, leaving the tokenizing to each grammar's own load callback.
+ * Once loaded it tokenizes INLINE and N languages concatenate -- driving shiki with this
+ * component's configuration, the five languages here (c, python, go, typescript, rust) cost 746 ms
+ * back to back, worst single language 334 ms.
+ *
+ * The LOADS stay eager, all of them, in the first pass. Yielding them too would put the last
+ * language's grammar 500 ms x N away on the `setTimeout` fallback, and a jump or a print inside
+ * that window is exactly what this exists for: `highlight` answers `null` while a grammar loads,
+ * so `latchNow`'s synchronous flush would produce streamdown's plain fallback for that frame or
+ * that page. A load is cheap and asynchronous; only the tokenization is worth a task of its own.
  *
  * NOTHING BOUNDED THE SIZE OF A WARM, and this comment used to claim `MAX_HIGHLIGHT_CHARS` did.
  * It does not reach here: `markdownPluginNeeds` applies it in `markdown-preview.tsx` and
@@ -374,29 +392,37 @@ const upgradeEverythingForPrint = (): void => {
  * source, but `markdown-text.tsx` supplies the code plugin unconditionally and `FenceBlock` warms
  * the whole body -- and `code-plugin.ts`'s `evict` keeps the last fence whatever its size. A LATCH
  * is demanded work and stays uncapped; a warm is SPECULATIVE, on a fence the reader may never
- * reach, so it is capped at the same 20,000 characters. Past the cap this loads the grammar and
- * stops, as the empty-string warm did. It costs the measurement nothing: the largest fence at this
- * rung is 2,817 characters.
+ * reach, so it is capped at the same 20,000 characters. Past the cap, and for a fence that is
+ * EMPTY or nothing but newlines, this loads the grammar and stops. Neither marks the grammar
+ * warmed, so a later fence in that language still gets its real warm rather than inheriting a
+ * tokenization of `""`. The cap costs the measurement nothing: the largest fence at this rung is
+ * 2,817 characters.
  */
 const grammarsWarmed = new Set<string>();
 const grammarsLoaded = new Set<string>();
 let warmScheduled = false;
 
+// Keyed the way `highlight` keys it, or `py` and `Python` are two keys for one grammar.
+const grammarOf = (gate: FenceGate): string =>
+  normalizeLanguage(gate.language ?? "text");
+
 const warmGrammars = (): void => {
   warmScheduled = false;
+  // EVERY GRAMMAR STARTS LOADING IN THE FIRST TASK. A load is cheap and asynchronous, and it is
+  // what `latchNow` needs already present; only the tokenizations below are worth yielding for.
   for (const gate of unreached) {
-    // Keyed the way `highlight` keys it, or `py` and `Python` warm the same grammar twice, on two
-    // different fences, and each is a real tokenization rather than the old empty-string cache hit.
-    const language = normalizeLanguage(gate.language ?? "text");
+    const language = grammarOf(gate);
+    if (grammarsLoaded.has(language)) continue;
+    grammarsLoaded.add(language);
+    gate.warm(false);
+  }
+  for (const gate of unreached) {
+    const language = grammarOf(gate);
     if (grammarsWarmed.has(language)) continue;
-    if (gate.chars > MAX_HIGHLIGHT_CHARS) {
-      // Grammar only, then keep looking: another fence in this language may be small enough.
-      if (!grammarsLoaded.has(language)) {
-        grammarsLoaded.add(language);
-        gate.warm(false);
-      }
-      continue;
-    }
+    // An EMPTY fence would tokenize `""` and teach this loop nothing, and one over the cap is not
+    // ours to tokenize speculatively. Neither marks the grammar warmed, so a later fence in the
+    // same language still gets its real warm.
+    if (gate.chars === 0 || gate.chars > MAX_HIGHLIGHT_CHARS) continue;
     grammarsWarmed.add(language);
     // TRUE, not false: real text is what takes the one-off tokenizer cost off the scroll.
     gate.warm(true);

--- a/studio/frontend/src/components/assistant-ui/code-fence-defer.tsx
+++ b/studio/frontend/src/components/assistant-ui/code-fence-defer.tsx
@@ -335,51 +335,45 @@ const upgradeEverythingForPrint = (): void => {
 /*
  * GRAMMARS, WARMED AT IDLE, ON REAL TEXT, ONE LANGUAGE PER TASK.
  *
- * This warms one fence per language so that `latchNow`'s synchronous path cannot be defeated by a
- * still-loading grammar -- on a jump into a language the reader has not met, and on a print, where
- * there is no later frame to correct in. Deduplicated by language and scheduled at idle: one warm
- * per language, nothing when nothing is deferred.
+ * One fence per language, so `latchNow`'s synchronous path cannot be defeated by a still-loading
+ * grammar: on a jump into a language the reader has not met, and on a print, where there is no
+ * later frame to correct in. Nothing runs when nothing is deferred.
  *
- * IT USED TO WARM ON AN EMPTY STRING, and that made the pre-warm miss most of what it exists to
- * prevent. Loading a grammar is not the expensive part; running it over text for the first time is.
- * Highlighting `""` resolves the language and mounts no span, but it never gives the tokenizer any
- * text, so the first REAL tokenization still pays the whole one-off cost -- and with deferral on,
- * that lands during a scroll, in one frame, on the fence the reader has just reached.
- *
- * Three arms out of ONE build at the 100K rung on WebKitGTK 2.50.4, two reps each, so a difference
- * between arms cannot be a build difference:
+ * IT USED TO WARM ON AN EMPTY STRING. Loading a grammar is the cheap half; running it over text
+ * the first time is not, and `""` never does the second. So the first REAL tokenization still paid
+ * the whole one-off cost, and with deferral on that landed in one frame, during a scroll, on the
+ * fence the reader had just reached. Three arms out of ONE build at the 100K rung on WebKitGTK
+ * 2.50.4, two reps each, so a difference between arms cannot be a build difference:
  *
  *                            worst scroll frame   warm callbacks
  *   warm on ""                   1592, 1540 ms    1, of 2 and 1 ms
  *   warm on real text             294,  318 ms    1, of 2 and 1 ms
  *   one language per task         301,  298 ms    5, worst 108 and 93 ms
  *
- * The work is not skipped, it is moved: instrumenting the innermost tokenizer, total tokenize time
- * RISES (2361-2526 ms to 2851-2869 ms) because a warmed fence is tokenized once here and read from
- * cache later. Mount and idle are unaffected (62.5 fps, 7.3 to 7.7% busy on every arm) and the two
- * arms in a rep render the same document, 7,259 spans and 27,046 elements over 56 code blocks in
- * the second. The rig is jam-controlled: a 200 ms/250 ms hog reads 81% busy against 7.4%.
+ * Moved, not skipped: total tokenize time RISES, 2361-2526 ms to 2851-2869 ms, because a warmed
+ * fence is tokenized once here and read from cache later. Mount and idle are unaffected (62.5 fps,
+ * 7.3 to 7.7% busy on every arm), the two arms in a rep render the same document (7,259 spans,
+ * 27,046 elements, 56 code blocks in the second), and the rig is jam-controlled: a 200 ms/250 ms
+ * hog reads 81% busy against 7.4%.
  *
- * WHY ONE LANGUAGE PER TASK. An idle callback only chooses when it STARTS: nothing yields once it
- * runs, and the 2,000 ms timeout can start it on a busy thread. WebKitGTK has no
+ * ONE LANGUAGE PER TASK, because an idle callback only chooses when it STARTS -- nothing yields
+ * once it runs, its 2,000 ms timeout can start it on a busy thread, and WebKitGTK has no
  * `requestIdleCallback` at all, so this venue takes the `setTimeout` fallback and cannot even pick
- * a quiet moment. The table understates the risk, because a COLD grammar makes `code.highlight`
- * queue and return, leaving the tokenizing to each grammar's own load callback. Once the grammar
- * is loaded it tokenizes INLINE, and then N languages in one callback concatenate: driving shiki
- * with this component's own configuration, the five languages at this rung (c, python, go,
- * typescript, rust) cost 746 ms back to back, worst single language 334 ms. Split, each task warms
- * one language and re-schedules, so the chain drains at idle instead of in one block.
+ * a quiet moment. The table understates that: a COLD grammar makes `code.highlight` queue and
+ * return, leaving the tokenizing to each grammar's own load callback. Once loaded it tokenizes
+ * INLINE and N languages concatenate -- driving shiki with this component's configuration, the
+ * five languages here (c, python, go, typescript, rust) cost 746 ms back to back, worst single
+ * language 334 ms.
  *
  * NOTHING BOUNDED THE SIZE OF A WARM, and this comment used to claim `MAX_HIGHLIGHT_CHARS` did.
- * It does not reach here. `markdownPluginNeeds` applies it in `markdown-preview.tsx` and
- * `model-readme.tsx`, and `tool-code-cell.tsx` and `attachment-preview.tsx` apply it to their own
- * source, but `markdown-text.tsx` hands Streamdown the code plugin unconditionally and
- * `FenceBlock` warms the whole fence body. So a warm on real text was unbounded, on a fence the
- * reader may never reach, and `code-plugin.ts`'s `evict` keeps the last fence whatever its size. A
- * LATCH is demanded work and stays uncapped; a warm is SPECULATIVE, so it is capped here at the
- * same 20,000 characters. Past the cap this loads the grammar and stops, exactly as the
- * empty-string warm did, and keeps looking for a fence in that language small enough to warm on
- * real text. It costs the measurement nothing: the largest fence at this rung is 2,817 characters.
+ * It does not reach here: `markdownPluginNeeds` applies it in `markdown-preview.tsx` and
+ * `model-readme.tsx`, `tool-code-cell.tsx` and `attachment-preview.tsx` apply it to their own
+ * source, but `markdown-text.tsx` supplies the code plugin unconditionally and `FenceBlock` warms
+ * the whole body -- and `code-plugin.ts`'s `evict` keeps the last fence whatever its size. A LATCH
+ * is demanded work and stays uncapped; a warm is SPECULATIVE, on a fence the reader may never
+ * reach, so it is capped at the same 20,000 characters. Past the cap this loads the grammar and
+ * stops, as the empty-string warm did. It costs the measurement nothing: the largest fence at this
+ * rung is 2,817 characters.
  */
 const grammarsWarmed = new Set<string>();
 const grammarsLoaded = new Set<string>();
@@ -391,8 +385,7 @@ const warmGrammars = (): void => {
     const language = gate.language ?? "text";
     if (grammarsWarmed.has(language)) continue;
     if (gate.chars > MAX_HIGHLIGHT_CHARS) {
-      // Over the cap. Load the grammar and tokenize nothing, then keep looking: another fence in
-      // this language may be small enough to warm properly.
+      // Grammar only, then keep looking: another fence in this language may be small enough.
       if (!grammarsLoaded.has(language)) {
         grammarsLoaded.add(language);
         gate.warm(false);
@@ -400,11 +393,10 @@ const warmGrammars = (): void => {
       continue;
     }
     grammarsWarmed.add(language);
-    // TRUE, not false: see above. Warming on real text is what actually takes the one-off
-    // tokenizer cost off the scroll.
+    // TRUE, not false: real text is what takes the one-off tokenizer cost off the scroll.
     gate.warm(true);
-    // Yield. `grammarsWarmed` only grows, so each task warms one more language and the chain
-    // drains; a pass that warms nothing falls out of the loop and schedules nothing.
+    // Yield. `grammarsWarmed` only grows, so the chain drains a language per task; a pass that
+    // warms nothing falls out of the loop and schedules nothing.
     scheduleGrammarWarm();
     return;
   }

--- a/studio/frontend/src/components/assistant-ui/code-fence-defer.tsx
+++ b/studio/frontend/src/components/assistant-ui/code-fence-defer.tsx
@@ -15,6 +15,7 @@ import { flushSync } from "react-dom";
 
 import { MAX_HIGHLIGHT_CHARS } from "@/lib/markdown-plugins";
 import { type FenceMode, resolveFenceMode } from "./code-fence-mode";
+import { normalizeLanguage } from "./code-plugin";
 
 /*
  * MONOTONIC fence highlighting: a fence is rendered as a plain shell until the
@@ -337,7 +338,9 @@ const upgradeEverythingForPrint = (): void => {
  *
  * One fence per language, so `latchNow`'s synchronous path cannot be defeated by a still-loading
  * grammar: on a jump into a language the reader has not met, and on a print, where there is no
- * later frame to correct in. Nothing runs when nothing is deferred.
+ * later frame to correct in. Nothing runs when nothing is deferred. "Per language" means per
+ * GRAMMAR, `normalizeLanguage`, not per fence tag: ```py and ```python are one grammar to the
+ * highlighter, and two keys here would warm it twice, on two different fences.
  *
  * IT USED TO WARM ON AN EMPTY STRING. Loading a grammar is the cheap half; running it over text
  * the first time is not, and `""` never does the second. So the first REAL tokenization still paid
@@ -382,7 +385,9 @@ let warmScheduled = false;
 const warmGrammars = (): void => {
   warmScheduled = false;
   for (const gate of unreached) {
-    const language = gate.language ?? "text";
+    // Keyed the way `highlight` keys it, or `py` and `Python` warm the same grammar twice, on two
+    // different fences, and each is a real tokenization rather than the old empty-string cache hit.
+    const language = normalizeLanguage(gate.language ?? "text");
     if (grammarsWarmed.has(language)) continue;
     if (gate.chars > MAX_HIGHLIGHT_CHARS) {
       // Grammar only, then keep looking: another fence in this language may be small enough.

--- a/studio/frontend/src/components/assistant-ui/code-plugin.ts
+++ b/studio/frontend/src/components/assistant-ui/code-plugin.ts
@@ -61,7 +61,12 @@ const SUPPORTED_LANGUAGE_LIST = Array.from(
 ) as BundledLanguage[];
 const PLAIN_TEXT = "text" as BundledLanguage;
 
-const normalizeLanguage = (language: string): BundledLanguage => {
+/**
+ * The fence tag as Shiki will see it: lower-cased, aliases resolved. Exported so that anything
+ * keying a per-grammar cache uses the same identity `highlight` does -- `py` and `Python` are one
+ * grammar here, and two keys anywhere else means the same grammar is warmed twice.
+ */
+export const normalizeLanguage = (language: string): BundledLanguage => {
   const key = language.trim().toLowerCase();
   const alias = LANGUAGE_ALIAS_OVERRIDES[key] ?? SHIKI_LANGUAGE_ALIASES[key];
   return alias ?? (key as BundledLanguage);

--- a/studio/frontend/src/components/assistant-ui/markdown-text.tsx
+++ b/studio/frontend/src/components/assistant-ui/markdown-text.tsx
@@ -60,6 +60,7 @@ import {
 import {
   DeferredFenceShell,
   fenceMode,
+  trimmedLength,
   trimTrailingNewlines,
   useFenceReached,
 } from "./code-fence-defer";
@@ -553,7 +554,7 @@ function FenceBlock({
     mode !== "off",
     Boolean(isIncomplete),
     languageToken,
-    source.length,
+    trimmedLength(source),
     warm,
   );
 

--- a/studio/frontend/src/components/assistant-ui/markdown-text.tsx
+++ b/studio/frontend/src/components/assistant-ui/markdown-text.tsx
@@ -553,6 +553,7 @@ function FenceBlock({
     mode !== "off",
     Boolean(isIncomplete),
     languageToken,
+    source.length,
     warm,
   );
 

--- a/studio/frontend/tests/code-fence-defer.test.ts
+++ b/studio/frontend/tests/code-fence-defer.test.ts
@@ -469,7 +469,7 @@ test("the idle pre-warm drives the tokenizer over real text, not an empty string
   /*
    * Loading a grammar is cheap; running it over text the first time is not, and `""` never does
    * the second. With deferral on the whole one-off cost therefore landed in one frame on the fence
-   * the reader scrolled to: 1592 and 1540 ms at the 100K rung on WebKitGTK, against 294 and 318 ms
+   * the reader scrolled to: 1200 and 1085 ms at the 100K rung on WebKitGTK, against 183 and 190 ms
    * on real text. Asserted at the source because the invariant is structural, and the alternative
    * is a benchmark noticing it two days later, which is how it was found.
    */
@@ -479,11 +479,17 @@ test("the idle pre-warm drives the tokenizer over real text, not an empty string
     body.includes("gate.warm(true)"),
     "warming on an empty string leaves the first real tokenization to happen during a scroll",
   );
-  // `gate.warm(false)` survives only in the over-cap branch, behind the size check.
+  // The only surviving `gate.warm(false)` is the eager grammar-load pass, which runs BEFORE the
+  // real warm and is deliberately not gated on size. Nothing may reach `warm(false)` afterwards.
   assert.match(
     body,
-    /gate\.chars > MAX_HIGHLIGHT_CHARS\)[\s\S]*gate\.warm\(false\)[\s\S]*gate\.warm\(true\)/,
-    "an unconditional false warm here is the regression this test exists to catch",
+    /grammarsLoaded\.add\(language\);\s*gate\.warm\(false\);[\s\S]*gate\.warm\(true\)/,
+    "an unconditional false warm in place of the real one is the regression this test catches",
+  );
+  assert.equal(
+    (body.match(/gate\.warm\(false\)/g) ?? []).length,
+    1,
+    "one false warm, in the load pass; a second one means a language can be marked warmed on nothing",
   );
   // Anti-vacuity: renamed or restructured, the checks above would pass on an empty slice.
   assert.ok(body.length > 60 && body.includes("grammarsWarmed"), "found the real warmGrammars body");
@@ -507,8 +513,15 @@ test("a speculative warm is capped, and the cap is the shared one", () => {
     "a local redefinition would let this cap drift away from the one every other reader uses",
   );
   assert.ok(
-    /gate\.chars > MAX_HIGHLIGHT_CHARS/.test(SOURCE),
+    /gate\.chars === 0 \|\| gate\.chars > MAX_HIGHLIGHT_CHARS/.test(SOURCE),
     "the warm must consult the fence's size before tokenizing it",
+  );
+  // An EMPTY fence trims to "", so warming it teaches the grammar nothing and would still mark the
+  // language done, leaving every later fence in it to tokenize on the scroll path.
+  assert.match(
+    SOURCE,
+    /if \(gate\.chars === 0 \|\| gate\.chars > MAX_HIGHLIGHT_CHARS\) continue;/,
+    "both cases must `continue`, so the language is left unwarmed for a fence that can warm it",
   );
   // The other half: the latch must NOT have grown a cap.
   const latch = SOURCE.slice(SOURCE.indexOf("const latchNow"));
@@ -518,8 +531,8 @@ test("a speculative warm is capped, and the cap is the shared one", () => {
   );
   assert.match(
     MARKDOWN_TEXT,
-    /useFenceReached\([\s\S]{0,200}?source\.length,/,
-    "the hook can only cap what the caller tells it about",
+    /useFenceReached\([\s\S]{0,200}?trimmedLength\(source\),/,
+    "the hook can only cap what the caller tells it about, and `warm` tokenizes the TRIMMED body",
   );
 });
 
@@ -529,13 +542,27 @@ test("the idle warm yields between languages", () => {
    * this venue takes the setTimeout fallback and cannot even do that. A warm tokenizes
    * synchronously once its grammar is loaded, so every language in one callback is one unyieldable
    * block: 746 ms for the 100K rung's five languages driven through shiki, worst single 334 ms.
+   *
+   * The LOADS are the other half and must NOT be yielded: 500 ms x N on that fallback would leave
+   * a jump or a print inside the window with an unloaded grammar, which is the plain-fallback
+   * frame this whole pre-warm exists to prevent.
    */
   const warm = SOURCE.slice(SOURCE.indexOf("const warmGrammars"));
   const body = warm.slice(0, warm.indexOf("\n};"));
   assert.match(
     body,
     /gate\.warm\(true\);[\s\S]*scheduleGrammarWarm\(\);[\s\S]*return;/,
-    "one language per task: warm, re-schedule, and leave the rest to the next idle slot",
+    "one tokenization per task: warm, re-schedule, and leave the rest to the next idle slot",
+  );
+  // Everything before the second loop, which is the one that tokenizes.
+  const loadPass = body.slice(0, body.indexOf("grammarsWarmed.has"));
+  assert.ok(
+    !loadPass.includes("scheduleGrammarWarm") && !loadPass.includes("return;"),
+    "the grammar loads all start in the first pass; yielding them costs the jump and the print",
+  );
+  assert.ok(
+    !loadPass.includes("MAX_HIGHLIGHT_CHARS") && !loadPass.includes("gate.chars"),
+    "a load ignores size: it tokenizes nothing, and an over-cap language still needs its grammar",
   );
   assert.ok(
     body.includes("grammarsWarmed.add(language)"),
@@ -557,11 +584,9 @@ test("the warm dedupes on the grammar, not on the spelling", async () => {
                                   ["c++", "cpp"], ["bash", "shellscript"], ["text", "text"]]) {
     assert.equal(normalizeLanguage(tag), canonical, tag);
   }
-  const warm = SOURCE.slice(SOURCE.indexOf("const warmGrammars"));
-  const body = warm.slice(0, warm.indexOf("\n};"));
   assert.match(
-    body,
-    /const language = normalizeLanguage\(gate\.language \?\? "text"\)/,
+    SOURCE,
+    /const grammarOf = \(gate: FenceGate\): string =>\s*normalizeLanguage\(gate\.language \?\? "text"\);/,
     "the warm sets must be keyed by the same identity the highlighter uses",
   );
   assert.ok(

--- a/studio/frontend/tests/code-fence-defer.test.ts
+++ b/studio/frontend/tests/code-fence-defer.test.ts
@@ -542,3 +542,30 @@ test("the idle warm yields between languages", () => {
     "the chain terminates only because each task marks one more language done",
   );
 });
+
+test("the warm dedupes on the grammar, not on the spelling", async () => {
+  /*
+   * `grammarsWarmed` keyed the raw fence tag while `code.highlight` lower-cases and resolves
+   * aliases, so a thread mixing ```py and ```python warmed one grammar twice -- and after this PR
+   * each spelling is a real tokenization of a different fence, not the old empty-string cache hit.
+   */
+  const { normalizeLanguage } = await import(
+    "../src/components/assistant-ui/code-plugin.ts"
+  );
+  // Run the identity rather than describe it: aliases, overrides and case all collapse.
+  for (const [tag, canonical] of [["py", "python"], ["Python", "python"], ["JS", "javascript"],
+                                  ["c++", "cpp"], ["bash", "shellscript"], ["text", "text"]]) {
+    assert.equal(normalizeLanguage(tag), canonical, tag);
+  }
+  const warm = SOURCE.slice(SOURCE.indexOf("const warmGrammars"));
+  const body = warm.slice(0, warm.indexOf("\n};"));
+  assert.match(
+    body,
+    /const language = normalizeLanguage\(gate\.language \?\? "text"\)/,
+    "the warm sets must be keyed by the same identity the highlighter uses",
+  );
+  assert.ok(
+    CODE_PLUGIN.includes("export const normalizeLanguage"),
+    "one definition, exported, so the two keyings cannot drift apart",
+  );
+});

--- a/studio/frontend/tests/code-fence-defer.test.ts
+++ b/studio/frontend/tests/code-fence-defer.test.ts
@@ -470,7 +470,7 @@ test("the idle pre-warm drives the tokenizer over real text, not an empty string
    * This warmed on `""` until it was measured. Loading a grammar is cheap; running it over text
    * for the first time is not, and highlighting an empty string never does the second thing. With
    * deferral on, the whole one-off cost therefore landed on the first fence the reader scrolled
-   * to, in a single frame: 1081 and 1072 ms at the 100K rung on WebKitGTK, against 182 and 190 ms
+   * to, in a single frame: 1592 and 1540 ms at the 100K rung on WebKitGTK, against 294 and 318 ms
    * once the warm uses real text.
    *
    * Asserted at the source because the invariant is structural and the alternative is a benchmark
@@ -482,11 +482,70 @@ test("the idle pre-warm drives the tokenizer over real text, not an empty string
     body.includes("gate.warm(true)"),
     "warming on an empty string leaves the first real tokenization to happen during a scroll",
   );
-  assert.ok(
-    !body.includes("gate.warm(false)"),
-    "a false warm here is the regression this test exists to catch",
+  // `gate.warm(false)` survives in exactly one place, the over-cap branch, and it must be reached
+  // only through the size check.
+  assert.match(
+    body,
+    /gate\.chars > MAX_HIGHLIGHT_CHARS\)[\s\S]*gate\.warm\(false\)[\s\S]*gate\.warm\(true\)/,
+    "an unconditional false warm here is the regression this test exists to catch",
   );
-  // Anti-vacuity: if the function is ever renamed or restructured, the two checks above would pass
+  // Anti-vacuity: if the function is ever renamed or restructured, the checks above would pass
   // against an empty slice and prove nothing.
   assert.ok(body.length > 60 && body.includes("grammarsWarmed"), "found the real warmGrammars body");
+});
+
+test("a speculative warm is capped, and the cap is the shared one", () => {
+  /*
+   * The chat renderer never applies MAX_HIGHLIGHT_CHARS: `markdown-text.tsx` supplies the code
+   * plugin unconditionally and `FenceBlock` warms the whole fence body, so warming on real text
+   * would tokenize an arbitrarily large off-screen fence the reader may never reach -- and
+   * `code-plugin.ts`'s `evict` keeps the last fence whatever its size. The latch is demanded work
+   * and stays uncapped; this is the speculative half, so it is bounded.
+   */
+  assert.match(
+    SOURCE,
+    /import \{ MAX_HIGHLIGHT_CHARS \} from "@\/lib\/markdown-plugins";/,
+    "the cap must be the shared constant, not a second copy that can drift",
+  );
+  assert.ok(
+    !/const MAX_HIGHLIGHT_CHARS\s*=/.test(SOURCE),
+    "a local redefinition would let this cap drift away from the one every other reader uses",
+  );
+  assert.ok(
+    /gate\.chars > MAX_HIGHLIGHT_CHARS/.test(SOURCE),
+    "the warm must consult the fence's size before tokenizing it",
+  );
+  // The latch is the other half of the invariant: it must NOT have grown a cap.
+  const latch = SOURCE.slice(SOURCE.indexOf("const latchNow"));
+  assert.ok(
+    !latch.slice(0, latch.indexOf("\n};")).includes("MAX_HIGHLIGHT_CHARS"),
+    "a fence the reader has actually reached is highlighted whatever its size",
+  );
+  assert.match(
+    MARKDOWN_TEXT,
+    /useFenceReached\([\s\S]{0,200}?source\.length,/,
+    "the hook can only cap what the caller tells it about",
+  );
+});
+
+test("the idle warm yields between languages", () => {
+  /*
+   * requestIdleCallback only controls when a callback STARTS. A warm is a synchronous
+   * tokenization once its grammar is loaded, so warming every language in one callback
+   * concatenates N of them into one unyieldable block: 746 ms for the 100K rung's five languages
+   * driven through shiki directly, worst single language 334 ms. WebKitGTK has no
+   * requestIdleCallback at all and takes the setTimeout fallback, which cannot even pick a quiet
+   * moment to start.
+   */
+  const warm = SOURCE.slice(SOURCE.indexOf("const warmGrammars"));
+  const body = warm.slice(0, warm.indexOf("\n};"));
+  assert.match(
+    body,
+    /gate\.warm\(true\);[\s\S]*scheduleGrammarWarm\(\);[\s\S]*return;/,
+    "one language per task: warm, re-schedule, and leave the rest to the next idle slot",
+  );
+  assert.ok(
+    body.includes("grammarsWarmed.add(language)"),
+    "the chain terminates only because each task marks one more language done",
+  );
 });

--- a/studio/frontend/tests/code-fence-defer.test.ts
+++ b/studio/frontend/tests/code-fence-defer.test.ts
@@ -464,3 +464,29 @@ test("token coalescing was measured at zero and is not carried as code", () => {
     "the cited reproducer must exist in this repository",
   );
 });
+
+test("the idle pre-warm drives the tokenizer over real text, not an empty string", () => {
+  /*
+   * This warmed on `""` until it was measured. Loading a grammar is cheap; running it over text
+   * for the first time is not, and highlighting an empty string never does the second thing. With
+   * deferral on, the whole one-off cost therefore landed on the first fence the reader scrolled
+   * to, in a single frame: 1081 and 1072 ms at the 100K rung on WebKitGTK, against 182 and 190 ms
+   * once the warm uses real text.
+   *
+   * Asserted at the source because the invariant is structural and the alternative is a benchmark
+   * noticing it two days later, which is exactly how it was found.
+   */
+  const warm = SOURCE.slice(SOURCE.indexOf("const warmGrammars"));
+  const body = warm.slice(0, warm.indexOf("\n};"));
+  assert.ok(
+    body.includes("gate.warm(true)"),
+    "warming on an empty string leaves the first real tokenization to happen during a scroll",
+  );
+  assert.ok(
+    !body.includes("gate.warm(false)"),
+    "a false warm here is the regression this test exists to catch",
+  );
+  // Anti-vacuity: if the function is ever renamed or restructured, the two checks above would pass
+  // against an empty slice and prove nothing.
+  assert.ok(body.length > 60 && body.includes("grammarsWarmed"), "found the real warmGrammars body");
+});

--- a/studio/frontend/tests/code-fence-defer.test.ts
+++ b/studio/frontend/tests/code-fence-defer.test.ts
@@ -467,14 +467,11 @@ test("token coalescing was measured at zero and is not carried as code", () => {
 
 test("the idle pre-warm drives the tokenizer over real text, not an empty string", () => {
   /*
-   * This warmed on `""` until it was measured. Loading a grammar is cheap; running it over text
-   * for the first time is not, and highlighting an empty string never does the second thing. With
-   * deferral on, the whole one-off cost therefore landed on the first fence the reader scrolled
-   * to, in a single frame: 1592 and 1540 ms at the 100K rung on WebKitGTK, against 294 and 318 ms
-   * once the warm uses real text.
-   *
-   * Asserted at the source because the invariant is structural and the alternative is a benchmark
-   * noticing it two days later, which is exactly how it was found.
+   * Loading a grammar is cheap; running it over text the first time is not, and `""` never does
+   * the second. With deferral on the whole one-off cost therefore landed in one frame on the fence
+   * the reader scrolled to: 1592 and 1540 ms at the 100K rung on WebKitGTK, against 294 and 318 ms
+   * on real text. Asserted at the source because the invariant is structural, and the alternative
+   * is a benchmark noticing it two days later, which is how it was found.
    */
   const warm = SOURCE.slice(SOURCE.indexOf("const warmGrammars"));
   const body = warm.slice(0, warm.indexOf("\n};"));
@@ -482,25 +479,23 @@ test("the idle pre-warm drives the tokenizer over real text, not an empty string
     body.includes("gate.warm(true)"),
     "warming on an empty string leaves the first real tokenization to happen during a scroll",
   );
-  // `gate.warm(false)` survives in exactly one place, the over-cap branch, and it must be reached
-  // only through the size check.
+  // `gate.warm(false)` survives only in the over-cap branch, behind the size check.
   assert.match(
     body,
     /gate\.chars > MAX_HIGHLIGHT_CHARS\)[\s\S]*gate\.warm\(false\)[\s\S]*gate\.warm\(true\)/,
     "an unconditional false warm here is the regression this test exists to catch",
   );
-  // Anti-vacuity: if the function is ever renamed or restructured, the checks above would pass
-  // against an empty slice and prove nothing.
+  // Anti-vacuity: renamed or restructured, the checks above would pass on an empty slice.
   assert.ok(body.length > 60 && body.includes("grammarsWarmed"), "found the real warmGrammars body");
 });
 
 test("a speculative warm is capped, and the cap is the shared one", () => {
   /*
    * The chat renderer never applies MAX_HIGHLIGHT_CHARS: `markdown-text.tsx` supplies the code
-   * plugin unconditionally and `FenceBlock` warms the whole fence body, so warming on real text
-   * would tokenize an arbitrarily large off-screen fence the reader may never reach -- and
-   * `code-plugin.ts`'s `evict` keeps the last fence whatever its size. The latch is demanded work
-   * and stays uncapped; this is the speculative half, so it is bounded.
+   * plugin unconditionally and `FenceBlock` warms the whole body, so a real-text warm would
+   * tokenize an arbitrarily large off-screen fence, and `code-plugin.ts`'s `evict` keeps the last
+   * fence whatever its size. The latch is demanded work and stays uncapped; this half is
+   * speculative, so it is bounded.
    */
   assert.match(
     SOURCE,
@@ -515,7 +510,7 @@ test("a speculative warm is capped, and the cap is the shared one", () => {
     /gate\.chars > MAX_HIGHLIGHT_CHARS/.test(SOURCE),
     "the warm must consult the fence's size before tokenizing it",
   );
-  // The latch is the other half of the invariant: it must NOT have grown a cap.
+  // The other half: the latch must NOT have grown a cap.
   const latch = SOURCE.slice(SOURCE.indexOf("const latchNow"));
   assert.ok(
     !latch.slice(0, latch.indexOf("\n};")).includes("MAX_HIGHLIGHT_CHARS"),
@@ -530,12 +525,10 @@ test("a speculative warm is capped, and the cap is the shared one", () => {
 
 test("the idle warm yields between languages", () => {
   /*
-   * requestIdleCallback only controls when a callback STARTS. A warm is a synchronous
-   * tokenization once its grammar is loaded, so warming every language in one callback
-   * concatenates N of them into one unyieldable block: 746 ms for the 100K rung's five languages
-   * driven through shiki directly, worst single language 334 ms. WebKitGTK has no
-   * requestIdleCallback at all and takes the setTimeout fallback, which cannot even pick a quiet
-   * moment to start.
+   * requestIdleCallback only controls when a callback STARTS, and WebKitGTK has none at all, so
+   * this venue takes the setTimeout fallback and cannot even do that. A warm tokenizes
+   * synchronously once its grammar is loaded, so every language in one callback is one unyieldable
+   * block: 746 ms for the 100K rung's five languages driven through shiki, worst single 334 ms.
    */
   const warm = SOURCE.slice(SOURCE.indexOf("const warmGrammars"));
   const body = warm.slice(0, warm.indexOf("\n};"));

--- a/tests/test_fp8_fbgemm_block_shapes.py
+++ b/tests/test_fp8_fbgemm_block_shapes.py
@@ -92,9 +92,7 @@ def _check_grad(X, out, Wq, scale, block):
     grad_ref = torch.ones(out.shape, device = out.device, dtype = torch.float32) @ _dequant(
         Wq, scale, block
     )
-    torch.testing.assert_close(
-        X.grad.float(), grad_ref, atol = _bf16_atol(grad_ref), rtol = 5e-2
-    )
+    torch.testing.assert_close(X.grad.float(), grad_ref, atol = _bf16_atol(grad_ref), rtol = 5e-2)
 
 
 def _rel_err(out, ref):


### PR DESCRIPTION
## What

Fixes a **1.1 second frame** during a scroll on a long thread, introduced by the off-screen fence
deferral we turned on by default.

## Why it happens

The idle pre-warm exists so a fence reached by a jump or a print is never waiting on a grammar. It
warmed by highlighting an **empty string**, which resolves the language but never runs the grammar
over any text.

Loading a grammar is the cheap half. The first real tokenization is the expensive one, and with
deferral on it landed on whichever fence the reader scrolled to first, in a single frame. The
deferral did not add work, it moved it out of mount and into the gesture.

## Measured

100K rung, WebKitGTK 2.50.4, production build, two reps per arm, jam control passing:

| arm | worst scroll frame |
| --- | --- |
| warm on `""` (today) | 1081, 1072 ms |
| warm on real text | **182, 190 ms** |

The work is moved, not skipped, and the totals say so. Instrumenting the innermost tokenizer rather
than the plugin entry point, total tokenize time **rises** from 1609 to 1880 ms, because a warmed
fence is tokenized once here and then read from cache. The same fence's call moves from t=32.8s,
during the gesture, to t=2.9s, before it.

| | today | with this change |
| --- | --- | --- |
| mount | 2614 / 1058 ms | 2689 / 1089 ms |
| idle | 62.5 fps, 7.2% busy | 62.5 fps, 7.2% busy |
| highlight spans | 7259 | 7259 |
| elements | 27046 | 27046 |
| code blocks | 56 | 56 |

Mount is unaffected because this runs on an idle callback after mount, idle is unaffected, and the
rendered document is identical, so nothing is bought by rendering less.

`MAX_HIGHLIGHT_CHARS` still bounds this: a fence past the cap is never highlighted at all, so no
warm can be large in a way the latch would not already have been.

## How it was found

By ablation, holding content fixed, after two wrong guesses. Disabling the observers removed the
frame but also removed two thirds of the spans, so it could not distinguish "the observers cost" from
"there is less content"; adding four spare observers per target produced no dose response, and adding
one observer back to the ablated arm did not restore the frame. Timing the latches against the frame
on a single clock then put one upgrade 27-30 ms before it, and instrumenting the tokenizer showed
that frame was 99% one Shiki call.

## Tests

The new source assertion is mutation-checked: restoring the empty-string warm makes it fail
(19 pass / 1 fail), and it carries an anti-vacuity check so a rename cannot make it pass against an
empty slice. `code-fence-defer` 20 pass, `code-fence-mode` 8 pass, `code-plugin-incremental` 25 pass,
tsc clean.
