### PR TITLE
studiobench: a null-control refusal that read the settled thread is an observation, not a blank

### DIFF
--- a/studio/backend/tests/test_offload_planner_seam.py
+++ b/studio/backend/tests/test_offload_planner_seam.py
@@ -1244,6 +1244,8 @@ def test_the_flat_mtp_reserve_reaches_the_spill_budget():
     reserved = _plan(stub, free_mib = 24 * 1024, usable_mib = 14 * 1024)
     assert generous is not None and reserved is not None
     assert len(reserved.spilled_blocks) > len(generous.spilled_blocks)
+
+
 def test_the_seam_computes_a_per_layer_kv_vector():
     """The data already existed on the backend (_sliding_window_pattern); it just
     never crossed into the planner. Only the RATIOS travel: full attention holds

--- a/tests/studio/studiobench/analysis/parity.py
+++ b/tests/studio/studiobench/analysis/parity.py
@@ -1130,7 +1130,14 @@ def derive_unstable(
             # subtree. It can still lower `undetermined`, which is the direction that only ever
             # narrows the excuse set.
             "unstable": bool(d and (n - settled[action]) >= min_observations),
-            "undetermined": n < min_observations,
+            # THE SAME COUNT `unstable` WAS DECIDED ON, once anything has differed. Leaving this
+            # on the raw total made the mixed state -- one real DIFFER beside one settled match --
+            # read as "decided, and stable": not unstable, not undetermined. `cross_check` then
+            # files a declared action under `declared_stable_in_practice`, whose stated meaning is
+            # that the null never saw it differ, on a run where it differed once. With nothing
+            # differing there is no classification to make and the total is the right count, which
+            # is the case this change exists for.
+            "undetermined": (n - settled[action] if d else n) < min_observations,
         }
     return out
 

--- a/tests/studio/studiobench/analysis/parity.py
+++ b/tests/studio/studiobench/analysis/parity.py
@@ -66,6 +66,32 @@ NOT_EXERCISED = "not_exercised"
 #: "this measurement does not apply here", and so `derive_unstable` counts neither as evidence.
 NOT_APPLICABLE = "not_applicable"
 
+#: A KEY ON A NOT_COMPARABLE RESULT, not a fifth verdict, and the difference matters.
+#:
+#: `compare` has exactly one refusal that ALSO carries a complete positive reading: the scaffold
+#: agreed, every overlay agreed, both arms mounted the same set of messages, and every message
+#: that was not being written at capture time agreed -- and the ONLY thing left over is the
+#: subtree of a reply that was mid-tail on one arm or both. That is a refusal because the digest
+#: of a half-arrived message names a point in a stream rather than a rendering (see the branch
+#: that sets this, and `scene/parity.js` for the measurement behind it), so it must never be a
+#: pass on the A/B result side: a treatment build whose live message renders wrongly would sit in
+#: exactly that shape, and `structural_report` files a refusal under `blind` and takes its exit
+#: code without it.
+#:
+#: THE VERDICT DOES NOT MOVE. This flag is read by `derive_unstable` and by nothing else, because
+#: the NULL CONTROL asks a different question from the result. The result asks "did this build
+#: change the UI"; the null asks "does this action differ against ITSELF", and for that question
+#: a pair where everything readable agreed is an observation of non-difference rather than a
+#: blank. Counting it as a blank is what left `keystroke` and `send_turn` permanently undecided
+#: at 100K on a runner where the in-flight tail happened to land 24 characters apart.
+#:
+#: AND IT CAN ONLY EVER NARROW THE EXCUSE SET. The observation it adds is a NON-difference, so
+#: `differed` cannot grow because of it and no action can become "unstable" on its strength. The
+#: worst it can do is call an action stable that nothing measured as differing, which costs a
+#: loud false alarm on the result and never a silenced regression -- the direction `collect`
+#: already argues for on this side.
+SETTLED_MATCH = "settled_match"
+
 # Actions whose rendered result legitimately differs between two runs of the SAME build, so a
 # digest mismatch there carries no information about the pull request under test.
 #
@@ -859,6 +885,12 @@ def compare(base: Optional[dict], treat: Optional[dict]) -> dict:
                 "moved": [],
                 "in_flight": sorted(streaming),
                 "not_digested": unsettled,
+                # THE ONE REFUSAL THAT ALSO CARRIES A POSITIVE READING. See `SETTLED_MATCH` for
+                # why this flag exists and what it is and is not allowed to move. It is set here
+                # and nowhere else, because this is the only branch reached with `_any_moved`
+                # already false: the scaffold agreed, every overlay agreed, the two arms mounted
+                # the same set of messages, and every message that was NOT being written agreed.
+                SETTLED_MATCH: True,
                 "style_verdict": style_verdict,
                 "style_reason": style_reason,
             }
@@ -1038,19 +1070,45 @@ def derive_unstable(
     `min_observations` guards the obvious trap: one repetition of an action that happened to
     differ once is not evidence that it is unstable, and treating it as evidence would let a
     single flake permanently silence a real signal.
+
+    A SETTLED-MATCH REFUSAL IS AN OBSERVATION, and it is the only refusal that is. `SETTLED_MATCH`
+    states the whole argument; the short version is that this function asks whether an action
+    differs against ITSELF, and a pair whose scaffold, overlays, message set and every settled
+    message row all agreed has answered that question. The only thing it withheld is the subtree
+    of a reply that was still arriving, and that subtree cannot produce a DIFFER on the result
+    side either -- it takes the same branch there and is filed under `blind` -- so nothing is
+    being excused that anything was going to ask about.
+
+    Counting it as blind is not conservative here, it is unreachable. Both arms of a null control
+    are driven through one film at wall-clock offsets, so on the packed 100K rungs the actions
+    that land inside a live turn (`keystroke`, `send_turn`, and the three the declared list
+    already names for the same mechanism) reach this branch whenever the two tails happen to land
+    a chunk apart. Measured on the payload that raised this: `keystroke@r100K` scored 0
+    observations from 2 pairs and `send_turn@r100K` 1 from 2, and `audit_null` returned UNDECIDED
+    on a run in which nothing structural had moved at all.
     """
     seen: dict[str, int] = collections.Counter()
     differ: dict[str, int] = collections.Counter()
     blind: dict[str, int] = collections.Counter()
+    settled: dict[str, int] = collections.Counter()
     for action, result in pairs:
-        if result.get("verdict") not in (MATCH, DIFFER):
+        verdict = result.get("verdict")
+        if verdict not in (MATCH, DIFFER):
+            if verdict == NOT_COMPARABLE and result.get(SETTLED_MATCH):
+                # Everything this pair could read agreed. Counted as an observation of
+                # NON-difference, so `differed` cannot grow on its strength and no action can be
+                # called unstable because of it; the flag is tallied separately so a reader can
+                # see how much of a decided action rests on it.
+                seen[action] += 1
+                settled[action] += 1
+                continue
             # Not comparable and not exercised are both "no reading", and neither may be counted
             # as an observation of stability. An action derived as stable from four pairs that
             # never ran would be permanently trusted on the strength of nothing.
             blind[action] += 1
             continue
         seen[action] += 1
-        if result.get("verdict") == DIFFER:
+        if verdict == DIFFER:
             differ[action] += 1
     out: dict[str, dict] = {}
     for action in sorted(set(seen) | set(blind)):
@@ -1059,6 +1117,11 @@ def derive_unstable(
             "observations": n,
             "differed": d,
             "not_comparable": blind[action],
+            # How many of `observations` came from a settled-match refusal rather than from a
+            # MATCH. Reported rather than hidden inside the count: an action decided entirely
+            # this way was decided on the settled thread only, which is a weaker reading than a
+            # plain MATCH and a reader chasing an excuse needs to be able to tell.
+            SETTLED_MATCH: settled[action],
             # Unstable only with enough observations to mean it. Below that the honest answer is
             # "not enough evidence", which is not the same as "stable" and is not reported as it.
             "unstable": bool(d and n >= min_observations),

--- a/tests/studio/studiobench/analysis/parity.py
+++ b/tests/studio/studiobench/analysis/parity.py
@@ -871,7 +871,15 @@ def compare(base: Optional[dict], treat: Optional[dict]) -> dict:
                 f"msg{i}({bm[i].get('role', '?')}):{bm[i].get('chars')}->{tm[i].get('chars')}c"
                 for i in unsettled[:4]
             )
-            return {
+            # A ROW WHOSE ROLE CHANGED IS NOT SOMETHING THIS PAIR READ AND AGREED ON, and
+            # `_any_moved` cannot see it: the role is captured beside the digest, and the digest of
+            # an in-flight row is withheld. `settled_messages_moved` reports a role change even for
+            # a row in flight, on the ground that how far a reply has arrived says nothing about
+            # whose message it is, and the two readings must not disagree. The verdict is already
+            # the refusal either way; what this decides is whether the refusal ALSO carries a
+            # positive reading, and a pair whose roles disagree carries none.
+            roles_agree = all(bm[i].get("role") == tm[i].get("role") for i in set(bm) & set(tm))
+            out = {
                 "verdict": NOT_COMPARABLE,
                 "reason": (
                     f"the settled thread is identical on both arms and the only difference is in "
@@ -885,15 +893,17 @@ def compare(base: Optional[dict], treat: Optional[dict]) -> dict:
                 "moved": [],
                 "in_flight": sorted(streaming),
                 "not_digested": unsettled,
+                "style_verdict": style_verdict,
+                "style_reason": style_reason,
+            }
+            if roles_agree:
                 # THE ONE REFUSAL THAT ALSO CARRIES A POSITIVE READING. See `SETTLED_MATCH` for
                 # why this flag exists and what it is and is not allowed to move. It is set here
                 # and nowhere else, because this is the only branch reached with `_any_moved`
                 # already false: the scaffold agreed, every overlay agreed, the two arms mounted
                 # the same set of messages, and every message that was NOT being written agreed.
-                SETTLED_MATCH: True,
-                "style_verdict": style_verdict,
-                "style_reason": style_reason,
-            }
+                out[SETTLED_MATCH] = True
+            return out
         return {
             "verdict": MATCH,
             "reason": "",

--- a/tests/studio/studiobench/analysis/parity.py
+++ b/tests/studio/studiobench/analysis/parity.py
@@ -66,30 +66,25 @@ NOT_EXERCISED = "not_exercised"
 #: "this measurement does not apply here", and so `derive_unstable` counts neither as evidence.
 NOT_APPLICABLE = "not_applicable"
 
-#: A KEY ON A NOT_COMPARABLE RESULT, not a fifth verdict, and the difference matters.
+#: A KEY ON A NOT_COMPARABLE RESULT, not a fifth verdict.
 #:
-#: `compare` has exactly one refusal that ALSO carries a complete positive reading: the scaffold
-#: agreed, every overlay agreed, both arms mounted the same set of messages, and every message
-#: that was not being written at capture time agreed -- and the ONLY thing left over is the
-#: subtree of a reply that was mid-tail on one arm or both. That is a refusal because the digest
-#: of a half-arrived message names a point in a stream rather than a rendering (see the branch
-#: that sets this, and `scene/parity.js` for the measurement behind it), so it must never be a
-#: pass on the A/B result side: a treatment build whose live message renders wrongly would sit in
-#: exactly that shape, and `structural_report` files a refusal under `blind` and takes its exit
-#: code without it.
+#: `compare` has one refusal that ALSO carries a complete positive reading: the scaffold, every
+#: overlay, the mounted message set and every message not being written at capture time all
+#: agreed, and the only leftover is the subtree of a reply that was mid-tail. It stays a refusal
+#: because a half-arrived digest names a point in a stream rather than a rendering, and it must
+#: never be a pass on the A/B result side: a treatment build whose live message renders wrongly
+#: sits in exactly that shape, and `structural_report` files it under `blind`.
 #:
-#: THE VERDICT DOES NOT MOVE. This flag is read by `derive_unstable` and by nothing else, because
-#: the NULL CONTROL asks a different question from the result. The result asks "did this build
-#: change the UI"; the null asks "does this action differ against ITSELF", and for that question
-#: a pair where everything readable agreed is an observation of non-difference rather than a
-#: blank. Counting it as a blank is what left `keystroke` and `send_turn` permanently undecided
-#: at 100K on a runner where the in-flight tail happened to land 24 characters apart.
+#: THE VERDICT DOES NOT MOVE; only `derive_unstable` reads this. The result asks "did this build
+#: change the UI", the null asks "does this action differ against ITSELF", and for the second
+#: question a pair where everything readable agreed is an observation of non-difference rather
+#: than a blank. Calling it blank is what left `keystroke` and `send_turn` permanently undecided
+#: at 100K on a runner where the in-flight tail landed 24 characters apart.
 #:
-#: AND IT CAN ONLY EVER NARROW THE EXCUSE SET. The observation it adds is a NON-difference, so
-#: `differed` cannot grow because of it and no action can become "unstable" on its strength. The
-#: worst it can do is call an action stable that nothing measured as differing, which costs a
-#: loud false alarm on the result and never a silenced regression -- the direction `collect`
-#: already argues for on this side.
+#: AND IT CAN ONLY NARROW THE EXCUSE SET: the observation is a NON-difference, so `differed`
+#: cannot grow and nothing can be marked unstable on its strength. The worst case is calling an
+#: action stable that nothing measured as differing, which costs a loud false alarm on the
+#: result and never a silenced regression.
 SETTLED_MATCH = "settled_match"
 
 # Actions whose rendered result legitimately differs between two runs of the SAME build, so a
@@ -871,13 +866,12 @@ def compare(base: Optional[dict], treat: Optional[dict]) -> dict:
                 f"msg{i}({bm[i].get('role', '?')}):{bm[i].get('chars')}->{tm[i].get('chars')}c"
                 for i in unsettled[:4]
             )
-            # A ROW WHOSE ROLE CHANGED IS NOT SOMETHING THIS PAIR READ AND AGREED ON, and
-            # `_any_moved` cannot see it: the role is captured beside the digest, and the digest of
-            # an in-flight row is withheld. `settled_messages_moved` reports a role change even for
-            # a row in flight, on the ground that how far a reply has arrived says nothing about
-            # whose message it is, and the two readings must not disagree. The verdict is already
-            # the refusal either way; what this decides is whether the refusal ALSO carries a
-            # positive reading, and a pair whose roles disagree carries none.
+            # A ROW WHOSE ROLE CHANGED IS NOT SOMETHING THIS PAIR AGREED ON, and `_any_moved`
+            # cannot see it: the role sits beside the digest, and an in-flight digest is withheld.
+            # `settled_messages_moved` reports a role change even in flight -- how far a reply has
+            # arrived says nothing about whose message it is -- and the two readings must not
+            # disagree. The verdict is the refusal either way; this only decides whether the
+            # refusal ALSO carries a positive reading, and a role disagreement carries none.
             roles_agree = all(bm[i].get("role") == tm[i].get("role") for i in set(bm) & set(tm))
             out = {
                 "verdict": NOT_COMPARABLE,
@@ -1081,21 +1075,17 @@ def derive_unstable(
     differ once is not evidence that it is unstable, and treating it as evidence would let a
     single flake permanently silence a real signal.
 
-    A SETTLED-MATCH REFUSAL IS AN OBSERVATION, and it is the only refusal that is. `SETTLED_MATCH`
-    states the whole argument; the short version is that this function asks whether an action
-    differs against ITSELF, and a pair whose scaffold, overlays, message set and every settled
-    message row all agreed has answered that question. The only thing it withheld is the subtree
-    of a reply that was still arriving, and that subtree cannot produce a DIFFER on the result
-    side either -- it takes the same branch there and is filed under `blind` -- so nothing is
-    being excused that anything was going to ask about.
+    A SETTLED-MATCH REFUSAL IS AN OBSERVATION, and the only refusal that is. `SETTLED_MATCH` has
+    the argument; the short version is that this function asks whether an action differs against
+    ITSELF, and a pair whose scaffold, overlays, message set and every settled row agreed has
+    answered that. What it withheld cannot produce a DIFFER on the result side either, so nothing
+    is excused that anything was going to ask about.
 
-    Counting it as blind is not conservative here, it is unreachable. Both arms of a null control
-    are driven through one film at wall-clock offsets, so on the packed 100K rungs the actions
-    that land inside a live turn (`keystroke`, `send_turn`, and the three the declared list
-    already names for the same mechanism) reach this branch whenever the two tails happen to land
-    a chunk apart. Measured on the payload that raised this: `keystroke@r100K` scored 0
-    observations from 2 pairs and `send_turn@r100K` 1 from 2, and `audit_null` returned UNDECIDED
-    on a run in which nothing structural had moved at all.
+    Counting it as blind is not conservative here, it is unreachable: both arms are driven through
+    one film at wall-clock offsets, so on the packed 100K rungs every action landing inside a live
+    turn reaches this branch whenever the two tails land a chunk apart. Measured on the payload
+    that raised this, `keystroke@r100K` scored 0 observations from 2 pairs and `send_turn@r100K`
+    1 from 2, and `audit_null` returned UNDECIDED on a run in which nothing had moved.
     """
     seen: dict[str, int] = collections.Counter()
     differ: dict[str, int] = collections.Counter()
@@ -1105,10 +1095,9 @@ def derive_unstable(
         verdict = result.get("verdict")
         if verdict not in (MATCH, DIFFER):
             if verdict == NOT_COMPARABLE and result.get(SETTLED_MATCH):
-                # Everything this pair could read agreed. Counted as an observation of
-                # NON-difference, so `differed` cannot grow on its strength and no action can be
-                # called unstable because of it; the flag is tallied separately so a reader can
-                # see how much of a decided action rests on it.
+                # Everything this pair could read agreed: an observation of NON-difference, so
+                # `differed` cannot grow and nothing can be called unstable on its strength.
+                # Tallied separately so a reader can see how much of a decision rests on it.
                 seen[action] += 1
                 settled[action] += 1
                 continue
@@ -1127,10 +1116,9 @@ def derive_unstable(
             "observations": n,
             "differed": d,
             "not_comparable": blind[action],
-            # How many of `observations` came from a settled-match refusal rather than from a
-            # MATCH. Reported rather than hidden inside the count: an action decided entirely
-            # this way was decided on the settled thread only, which is a weaker reading than a
-            # plain MATCH and a reader chasing an excuse needs to be able to tell.
+            # How many of `observations` came from a settled-match refusal rather than a MATCH.
+            # Reported rather than folded in: an action decided entirely this way was decided on
+            # the settled thread only, which is the weaker reading.
             SETTLED_MATCH: settled[action],
             # Unstable only with enough observations to mean it. Below that the honest answer is
             # "not enough evidence", which is not the same as "stable" and is not reported as it.

--- a/tests/studio/studiobench/analysis/parity.py
+++ b/tests/studio/studiobench/analysis/parity.py
@@ -1123,20 +1123,16 @@ def derive_unstable(
             # Unstable only with enough observations to mean it. Below that the honest answer is
             # "not enough evidence", which is not the same as "stable" and is not reported as it.
             #
-            # COUNTED FROM THE COMPLETE COMPARISONS ONLY, so a settled-match refusal can decide an
-            # action but can never help CLASSIFY one as unstable. One DIFFER beside one settled
-            # match is one differing comparison, and letting the refusal supply the second
-            # observation would mint an exemption out of a reading that never saw the live
-            # subtree. It can still lower `undetermined`, which is the direction that only ever
-            # narrows the excuse set.
+            # FROM THE COMPLETE COMPARISONS ONLY: a settled-match refusal can decide an action
+            # and never help CLASSIFY one as unstable. One DIFFER beside one settled match is one
+            # differing comparison, and letting the refusal supply the second would mint an
+            # exemption from a reading that never saw the live subtree.
             "unstable": bool(d and (n - settled[action]) >= min_observations),
-            # THE SAME COUNT `unstable` WAS DECIDED ON, once anything has differed. Leaving this
-            # on the raw total made the mixed state -- one real DIFFER beside one settled match --
-            # read as "decided, and stable": not unstable, not undetermined. `cross_check` then
-            # files a declared action under `declared_stable_in_practice`, whose stated meaning is
-            # that the null never saw it differ, on a run where it differed once. With nothing
-            # differing there is no classification to make and the total is the right count, which
-            # is the case this change exists for.
+            # THE SAME COUNT `unstable` WAS DECIDED ON, once anything has differed. On the raw
+            # total the mixed state -- one DIFFER beside one settled match -- read as "decided and
+            # stable", so `cross_check` filed a declared action under `declared_stable_in_practice`
+            # ("the null never saw it differ") on a run where it differed once. With nothing
+            # differing there is no classification to make and the total is the right count.
             "undetermined": (n - settled[action] if d else n) < min_observations,
         }
     return out

--- a/tests/studio/studiobench/analysis/parity.py
+++ b/tests/studio/studiobench/analysis/parity.py
@@ -1122,7 +1122,14 @@ def derive_unstable(
             SETTLED_MATCH: settled[action],
             # Unstable only with enough observations to mean it. Below that the honest answer is
             # "not enough evidence", which is not the same as "stable" and is not reported as it.
-            "unstable": bool(d and n >= min_observations),
+            #
+            # COUNTED FROM THE COMPLETE COMPARISONS ONLY, so a settled-match refusal can decide an
+            # action but can never help CLASSIFY one as unstable. One DIFFER beside one settled
+            # match is one differing comparison, and letting the refusal supply the second
+            # observation would mint an exemption out of a reading that never saw the live
+            # subtree. It can still lower `undetermined`, which is the direction that only ever
+            # narrows the excuse set.
+            "unstable": bool(d and (n - settled[action]) >= min_observations),
             "undetermined": n < min_observations,
         }
     return out

--- a/tests/studio/studiobench/sweep/selftest/test_studiobench_null_audit.py
+++ b/tests/studio/studiobench/sweep/selftest/test_studiobench_null_audit.py
@@ -1396,3 +1396,231 @@ def test_a_missing_composer_is_not_exempt_just_because_send_turn_can_be_queued(t
         tmp_path, "gone", "send_turn", ("rep0", "rep1"), reason = "no composer on the page"
     )
     assert U.report([gone], "t", U.UNSTABLE_ACTIONS, min_reps = 2, min_compared = 16) == 1
+
+
+# ── the reply that was still arriving is not a blind capture ──────────
+#
+# WHAT TURNED RED. On a wave of `studiobench UI parity` the audit came back UNDECIDED with 13
+# decided, 0 differed and 2 undecided: `keystroke@r100K` and `send_turn@r100K`, both "never
+# reached min_observations" despite `--min-reps 2` and both actions having run on both arms in
+# both repetitions. They are exactly the two actions whose slot lands INSIDE a live turn on the
+# packed 100K film, and the payload says so -- `streaming: true`, `in_flight: [19]` and `[22]`,
+# with the in-flight message 18,277 characters on one arm and 18,253 on the other.
+#
+# WHERE IT CAME FROM. Before #9575 that pair scored DIFFER, which is wrong but is an OBSERVATION,
+# so the null decided the action and the audit passed. #9575 correctly demoted it to
+# NOT_COMPARABLE -- a mid-stream digest names a point in a stream, not a rendering -- and
+# `derive_unstable` files every NOT_COMPARABLE under `blind`, which is zero observations. Replayed
+# against the real payload from that job: pre-#9575 keystroke scores 2 observations and post-#9575
+# it scores 0.
+#
+# So the refusal is right and the accounting behind it was not. `SETTLED_MATCH` is the narrow
+# repair: that one branch is reached only when the scaffold, the overlays, the message SET and
+# every settled message row have already agreed, so it is a complete reading of everything the
+# pair could read, and for "does this action differ against itself" that is an observation.
+#
+# Held here in both directions, because a fix that makes the audit easier to pass is worth nothing
+# without the control that shows it still fails.
+
+
+def streaming_pair_rows(
+    cid_base: str,
+    cid_treat: str,
+    action: str,
+    *,
+    base_tail: str,
+    treat_tail: str,
+    scaffold: str = "SCAF",
+    settled: str = "SETTLED",
+    treat_settled: str | None = None,
+    treat_scaffold: str | None = None,
+) -> list[dict]:
+    """A base/treatment pair captured with message 1 STILL BEING WRITTEN on both arms.
+
+    Modelled on the real `keystroke@r100K` rows from the failing run: both arms streaming, both
+    naming the same message in flight, both rendering the same composer control, and the settled
+    half of the thread byte-identical. `base_tail`/`treat_tail` are the digest of the message that
+    was still arriving, which is the only thing wall clock gets to move.
+
+    `treat_settled` and `treat_scaffold` exist so the negative controls can move something the
+    stream provably cannot reach, and watch the branch decline to fire.
+    """
+    def side(cid: str, tail: str, settled_digest: str, scaffold_digest: str) -> dict:
+        return {
+            "row_type": "action",
+            "cell_id": cid,
+            "action": action,
+            "ran": True,
+            "timings": {"open_ms": 5.0},
+            "parity": {
+                "parity_attempted": True,
+                "root_kind": "thread",
+                "digest": f"{scaffold_digest}:{settled_digest}:{tail}",
+                "chars": 100,
+                "digest_scaffold": scaffold_digest,
+                "chars_scaffold": 40,
+                "streaming": True,
+                "in_flight": [1],
+                "in_flight_unplaced": False,
+                "status_hook_present": True,
+                "queued_idle": False,
+                "composer_control": "Stop",
+                "messages": [
+                    {"i": 0, "role": "user", "digest": settled_digest, "chars": 10},
+                    {"i": 1, "role": "assistant", "digest": tail, "chars": len(tail)},
+                ],
+                "overlays": [],
+                "style": {"style_attempted": True, "capped": False, "nodes": []},
+            },
+        }
+
+    return [
+        side(cid_base, base_tail, settled, scaffold),
+        side(
+            cid_treat,
+            treat_tail,
+            settled if treat_settled is None else treat_settled,
+            scaffold if treat_scaffold is None else treat_scaffold,
+        ),
+    ]
+
+
+def streaming_null(tmp_path: Path, name: str, cells: list[list[dict]]) -> Path:
+    rows: list[dict] = [{"row_type": "run_meta", "tier": "fast"}]
+    for cell in cells:
+        rows.extend(cell)
+    out = tmp_path / name
+    out.mkdir(parents = True, exist_ok = True)
+    path = out / "payload.jsonl"
+    path.write_text("".join(json.dumps(r) + "\n" for r in rows), encoding = "utf-8")
+    return path
+
+
+def test_a_mid_stream_tail_is_still_a_refusal_and_never_a_pass():
+    # FIRST, the thing that must not change. The verdict stays NOT_COMPARABLE. A treatment build
+    # whose live message renders wrongly sits in exactly this shape, `structural_report` files a
+    # refusal under `blind` and takes its exit code without it, so promoting this to MATCH would
+    # hide a real regression. The repair is in what the NULL counts, not in what the result says.
+    rows = streaming_pair_rows("r100K.base.rep0", "r100K.treatment.rep0", "keystroke",
+                               base_tail = "T18277", treat_tail = "T18253")
+    got = P.compare(rows[0]["parity"], rows[1]["parity"])
+    assert got["verdict"] == P.NOT_COMPARABLE
+    assert "STILL BEING WRITTEN" in got["reason"]
+    assert got["moved"] == []
+    # And it carries the flag that says the rest of the thread WAS read and did agree.
+    assert got[P.SETTLED_MATCH] is True
+
+
+def test_a_refusal_that_read_the_settled_thread_is_an_observation():
+    # The unit the audit is built on. Two settled-match refusals are two observations of
+    # non-difference, so the action is decided and is NOT called unstable.
+    rows = streaming_pair_rows("r100K.base.rep0", "r100K.treatment.rep0", "keystroke",
+                               base_tail = "T18277", treat_tail = "T18253")
+    pair = ("keystroke", P.compare(rows[0]["parity"], rows[1]["parity"]))
+    row = P.derive_unstable([pair, pair])["keystroke"]
+    assert row["observations"] == 2
+    assert row["differed"] == 0
+    assert row["not_comparable"] == 0
+    assert row[P.SETTLED_MATCH] == 2
+    assert row["undetermined"] is False
+    assert row["unstable"] is False
+
+
+def test_an_ordinary_refusal_is_still_blind():
+    # THE CONTROL. Without this the change reads as "count NOT_COMPARABLE as an observation",
+    # which would let an action that never rendered at all be derived as stable and trusted
+    # forever. A capture that failed carries no settled reading and must stay at zero.
+    blind = {"verdict": P.NOT_COMPARABLE, "reason": "threadRoot is not a function"}
+    row = P.derive_unstable([("keystroke", blind), ("keystroke", blind)])["keystroke"]
+    assert row["observations"] == 0
+    assert row["not_comparable"] == 2
+    assert row[P.SETTLED_MATCH] == 0
+    assert row["undetermined"] is True
+
+
+def test_a_settled_message_that_moved_is_a_difference_not_an_observation():
+    # The other control, one layer down: the flag is only set when everything OUTSIDE the live
+    # message agreed. Move a settled row and the pair is a DIFFER, so the null records real
+    # instability exactly as before.
+    rows = streaming_pair_rows("r100K.base.rep0", "r100K.treatment.rep0", "keystroke",
+                               base_tail = "T18277", treat_tail = "T18253",
+                               treat_settled = "MOVED")
+    got = P.compare(rows[0]["parity"], rows[1]["parity"])
+    assert got["verdict"] == P.DIFFER
+    assert P.SETTLED_MATCH not in got
+
+
+def test_a_scaffold_that_moved_is_a_difference_not_an_observation():
+    # And the scaffold half of the same claim. Both arms agree they are streaming and agree about
+    # the composer control, so this is not the generation-disagreement refusal: it is a thread
+    # scaffolding change on a pair that was otherwise identical, and it stays a finding.
+    rows = streaming_pair_rows("r100K.base.rep0", "r100K.treatment.rep0", "keystroke",
+                               base_tail = "T18277", treat_tail = "T18253",
+                               treat_scaffold = "MOVED")
+    got = P.compare(rows[0]["parity"], rows[1]["parity"])
+    assert got["verdict"] == P.DIFFER
+    assert P.SETTLED_MATCH not in got
+
+
+def test_the_audit_decides_an_action_whose_only_leftover_was_the_live_reply(tmp_path):
+    # END TO END, and this is the case that turned the job red. Two repetitions of `keystroke`,
+    # both inside a live turn, the settled thread identical on every arm and only the in-flight
+    # tail landing a chunk apart. Nothing structural moved on this build against itself, and the
+    # audit must be able to say so.
+    null = streaming_null(
+        tmp_path,
+        "inflight",
+        [
+            streaming_pair_rows("r100K.base.rep0", "r100K.treatment.rep0", "keystroke",
+                                base_tail = "T18277", treat_tail = "T18253"),
+            streaming_pair_rows("r100K.base.rep1", "r100K.treatment.rep1", "keystroke",
+                                base_tail = "T21004", treat_tail = "T20980"),
+        ],
+    )
+    rc, report = U.audit_null([null], scope = {("r100K", "keystroke")})
+    assert rc == 0, report
+    assert report["decided"] == [("r100K", "keystroke")]
+    assert report["undecided"] == []
+    assert report["differed"] == []
+    # Reported as the narrower reading it is, rather than folded in with a plain MATCH.
+    assert report["decided_on_settled_thread"] == [("r100K", "keystroke")]
+
+
+def test_the_audit_still_fails_when_the_capture_itself_was_blind(tmp_path):
+    # THE PAIRED FAILURE. Same scope, same two repetitions, but the arms could not place the
+    # stream at all -- `in_flight_unplaced`, which is the `data-status` hook having gone quiet.
+    # There is no settled reading behind that refusal and the audit must stay red on it.
+    cells = []
+    for rep, tails in (("rep0", ("T1", "T2")), ("rep1", ("T3", "T4"))):
+        cell = streaming_pair_rows(
+            f"r100K.base.{rep}", f"r100K.treatment.{rep}", "keystroke",
+            base_tail = tails[0], treat_tail = tails[1],
+        )
+        for row in cell:
+            row["parity"]["in_flight_unplaced"] = True
+        cells.append(cell)
+    null = streaming_null(tmp_path, "unplaced", cells)
+    rc, report = U.audit_null([null], scope = {("r100K", "keystroke")})
+    assert rc == 1
+    assert report["decided"] == []
+    assert report["undecided"] == [("r100K", "keystroke")]
+
+
+def test_a_settled_match_can_never_grow_the_excuse_set(tmp_path):
+    # THE SAFETY DIRECTION, asserted rather than argued. The observation this adds is a
+    # NON-difference, so no action can be called unstable on its strength and the derived excuse
+    # set can only ever narrow. A null control made entirely of settled-match refusals derives an
+    # EMPTY measured set, which means a corroborated difference in the result gets no excuse from
+    # it -- the loud direction, never the silent one.
+    null = streaming_null(
+        tmp_path,
+        "narrow",
+        [
+            streaming_pair_rows("r100K.base.rep0", "r100K.treatment.rep0", "keystroke",
+                                base_tail = "A", treat_tail = "B"),
+            streaming_pair_rows("r100K.base.rep1", "r100K.treatment.rep1", "keystroke",
+                                base_tail = "C", treat_tail = "D"),
+        ],
+    )
+    unstable, _derived, _checks = U.unstable_set([null])
+    assert not [e for e in unstable if isinstance(e, tuple)]

--- a/tests/studio/studiobench/sweep/selftest/test_studiobench_null_audit.py
+++ b/tests/studio/studiobench/sweep/selftest/test_studiobench_null_audit.py
@@ -1434,6 +1434,7 @@ def streaming_pair_rows(
     settled: str = "SETTLED",
     treat_settled: str | None = None,
     treat_scaffold: str | None = None,
+    treat_role: str | None = None,
 ) -> list[dict]:
     """A base/treatment pair captured with message 1 STILL BEING WRITTEN on both arms.
 
@@ -1442,11 +1443,17 @@ def streaming_pair_rows(
     half of the thread byte-identical. `base_tail`/`treat_tail` are the digest of the message that
     was still arriving, which is the only thing wall clock gets to move.
 
-    `treat_settled` and `treat_scaffold` exist so the negative controls can move something the
-    stream provably cannot reach, and watch the branch decline to fire.
+    `treat_settled`, `treat_scaffold` and `treat_role` exist so the negative controls can move
+    something the stream provably cannot reach, and watch the branch decline to fire.
     """
 
-    def side(cid: str, tail: str, settled_digest: str, scaffold_digest: str) -> dict:
+    def side(
+        cid: str,
+        tail: str,
+        settled_digest: str,
+        scaffold_digest: str,
+        role: str = "assistant",
+    ) -> dict:
         return {
             "row_type": "action",
             "cell_id": cid,
@@ -1468,7 +1475,7 @@ def streaming_pair_rows(
                 "composer_control": "Stop",
                 "messages": [
                     {"i": 0, "role": "user", "digest": settled_digest, "chars": 10},
-                    {"i": 1, "role": "assistant", "digest": tail, "chars": len(tail)},
+                    {"i": 1, "role": role, "digest": tail, "chars": len(tail)},
                 ],
                 "overlays": [],
                 "style": {"style_attempted": True, "capped": False, "nodes": []},
@@ -1482,6 +1489,7 @@ def streaming_pair_rows(
             treat_tail,
             settled if treat_settled is None else treat_settled,
             scaffold if treat_scaffold is None else treat_scaffold,
+            "assistant" if treat_role is None else treat_role,
         ),
     ]
 
@@ -1581,6 +1589,33 @@ def test_a_scaffold_that_moved_is_a_difference_not_an_observation():
     got = P.compare(rows[0]["parity"], rows[1]["parity"])
     assert got["verdict"] == P.DIFFER
     assert P.SETTLED_MATCH not in got
+
+
+def test_a_live_row_whose_role_changed_carries_no_positive_reading():
+    # The control that is NOT reachable through `_any_moved`, which is what makes it worth
+    # asserting. The role is captured beside the digest, and the digest of an in-flight row is
+    # withheld, so a row that is `assistant` on one arm and `user` on the other passes the
+    # digest comparison untouched and the pair still reads as "everything settled agreed".
+    # `settled_messages_moved` calls that a structural change even in flight -- how far a reply
+    # has arrived says nothing about whose message it is -- so the flag must not fire here.
+    rows = streaming_pair_rows(
+        "r100K.base.rep0",
+        "r100K.treatment.rep0",
+        "keystroke",
+        base_tail = "T18277",
+        treat_tail = "T18253",
+        treat_role = "user",
+    )
+    base, treat = rows[0]["parity"], rows[1]["parity"]
+    assert P.settled_messages_moved(base, treat) == ["msg1:role assistant->user"]
+    got = P.compare(base, treat)
+    assert got["verdict"] == P.NOT_COMPARABLE
+    assert P.SETTLED_MATCH not in got
+    # And so it stays blind: two of them decide nothing and the audit still has to say undecided.
+    row = P.derive_unstable([("keystroke", got), ("keystroke", got)])["keystroke"]
+    assert row["observations"] == 0
+    assert row["not_comparable"] == 2
+    assert row["undetermined"] is True
 
 
 def test_the_audit_decides_an_action_whose_only_leftover_was_the_live_reply(tmp_path):

--- a/tests/studio/studiobench/sweep/selftest/test_studiobench_null_audit.py
+++ b/tests/studio/studiobench/sweep/selftest/test_studiobench_null_audit.py
@@ -1612,6 +1612,34 @@ def test_a_live_row_whose_role_changed_carries_no_positive_reading():
     assert row["undetermined"] is True
 
 
+def test_a_settled_match_cannot_supply_the_observation_that_mints_an_exemption():
+    # DECIDING an action and CLASSIFYING it unstable are different claims, and only the first is
+    # this flag's to make. One real DIFFER beside one settled-match refusal is one differing
+    # comparison, so letting the refusal supply the second observation would derive
+    # `(rung, action)` into the MEASURED exemption set on a reading that never saw the live
+    # subtree -- the excuse set growing, which `SETTLED_MATCH` promises it cannot do.
+    rows = streaming_pair_rows(
+        "r100K.base.rep0",
+        "r100K.treatment.rep0",
+        "keystroke",
+        base_tail = "T18277",
+        treat_tail = "T18253",
+    )
+    settled = P.compare(rows[0]["parity"], rows[1]["parity"])
+    assert settled[P.SETTLED_MATCH] is True
+    differ = {"verdict": P.DIFFER, "reason": "", "moved": ["msg0"]}
+    row = P.derive_unstable([("keystroke", differ), ("keystroke", settled)])["keystroke"]
+    assert row["observations"] == 2
+    assert row["differed"] == 1
+    assert row[P.SETTLED_MATCH] == 1
+    # Decided, because two readings answered; NOT unstable, because only one of them compared.
+    assert row["undetermined"] is False
+    assert row["unstable"] is False
+    # Two complete comparisons still classify exactly as before.
+    both = P.derive_unstable([("keystroke", differ), ("keystroke", differ)])["keystroke"]
+    assert both["unstable"] is True
+
+
 def test_the_audit_decides_an_action_whose_only_leftover_was_the_live_reply(tmp_path):
     # END TO END, the case that turned the job red: two repetitions of `keystroke` inside a live
     # turn, the settled thread identical on every arm and only the in-flight tail a chunk apart.

--- a/tests/studio/studiobench/sweep/selftest/test_studiobench_null_audit.py
+++ b/tests/studio/studiobench/sweep/selftest/test_studiobench_null_audit.py
@@ -1632,9 +1632,13 @@ def test_a_settled_match_cannot_supply_the_observation_that_mints_an_exemption()
     assert row["observations"] == 2
     assert row["differed"] == 1
     assert row[P.SETTLED_MATCH] == 1
-    # Decided, because two readings answered; NOT unstable, because only one of them compared.
-    assert row["undetermined"] is False
+    # NOT unstable, because only one of the two readings compared anything. And not "decided,
+    # and stable" either: one differing comparison is the single flake `min_observations` exists
+    # for, so once anything has differed the same count decides both. Left on the raw total this
+    # would reach `cross_check` as `declared_stable_in_practice`, whose stated meaning is that the
+    # null never saw this action differ, on a run where it differed once.
     assert row["unstable"] is False
+    assert row["undetermined"] is True
     # Two complete comparisons still classify exactly as before.
     both = P.derive_unstable([("keystroke", differ), ("keystroke", differ)])["keystroke"]
     assert both["unstable"] is True

--- a/tests/studio/studiobench/sweep/selftest/test_studiobench_null_audit.py
+++ b/tests/studio/studiobench/sweep/selftest/test_studiobench_null_audit.py
@@ -1614,10 +1614,10 @@ def test_a_live_row_whose_role_changed_carries_no_positive_reading():
 
 def test_a_settled_match_cannot_supply_the_observation_that_mints_an_exemption():
     # DECIDING an action and CLASSIFYING it unstable are different claims, and only the first is
-    # this flag's to make. One real DIFFER beside one settled-match refusal is one differing
-    # comparison, so letting the refusal supply the second observation would derive
-    # `(rung, action)` into the MEASURED exemption set on a reading that never saw the live
-    # subtree -- the excuse set growing, which `SETTLED_MATCH` promises it cannot do.
+    # this flag's to make. One DIFFER beside one settled-match refusal is one differing comparison,
+    # so letting the refusal supply the second observation would derive `(rung, action)` into the
+    # MEASURED exemption set from a reading that never saw the live subtree -- the excuse set
+    # growing, which `SETTLED_MATCH` promises it cannot do.
     rows = streaming_pair_rows(
         "r100K.base.rep0",
         "r100K.treatment.rep0",
@@ -1632,11 +1632,10 @@ def test_a_settled_match_cannot_supply_the_observation_that_mints_an_exemption()
     assert row["observations"] == 2
     assert row["differed"] == 1
     assert row[P.SETTLED_MATCH] == 1
-    # NOT unstable, because only one of the two readings compared anything. And not "decided,
-    # and stable" either: one differing comparison is the single flake `min_observations` exists
-    # for, so once anything has differed the same count decides both. Left on the raw total this
-    # would reach `cross_check` as `declared_stable_in_practice`, whose stated meaning is that the
-    # null never saw this action differ, on a run where it differed once.
+    # NOT unstable, because only one of the two readings compared anything, and not "decided and
+    # stable" either: one differing comparison is the single flake `min_observations` exists for.
+    # On the raw total this reached `cross_check` as `declared_stable_in_practice`, whose stated
+    # meaning is that the null never saw this action differ.
     assert row["unstable"] is False
     assert row["undetermined"] is True
     # Two complete comparisons still classify exactly as before.

--- a/tests/studio/studiobench/sweep/selftest/test_studiobench_null_audit.py
+++ b/tests/studio/studiobench/sweep/selftest/test_studiobench_null_audit.py
@@ -1445,6 +1445,7 @@ def streaming_pair_rows(
     `treat_settled` and `treat_scaffold` exist so the negative controls can move something the
     stream provably cannot reach, and watch the branch decline to fire.
     """
+
     def side(cid: str, tail: str, settled_digest: str, scaffold_digest: str) -> dict:
         return {
             "row_type": "action",
@@ -1501,8 +1502,13 @@ def test_a_mid_stream_tail_is_still_a_refusal_and_never_a_pass():
     # whose live message renders wrongly sits in exactly this shape, `structural_report` files a
     # refusal under `blind` and takes its exit code without it, so promoting this to MATCH would
     # hide a real regression. The repair is in what the NULL counts, not in what the result says.
-    rows = streaming_pair_rows("r100K.base.rep0", "r100K.treatment.rep0", "keystroke",
-                               base_tail = "T18277", treat_tail = "T18253")
+    rows = streaming_pair_rows(
+        "r100K.base.rep0",
+        "r100K.treatment.rep0",
+        "keystroke",
+        base_tail = "T18277",
+        treat_tail = "T18253",
+    )
     got = P.compare(rows[0]["parity"], rows[1]["parity"])
     assert got["verdict"] == P.NOT_COMPARABLE
     assert "STILL BEING WRITTEN" in got["reason"]
@@ -1514,8 +1520,13 @@ def test_a_mid_stream_tail_is_still_a_refusal_and_never_a_pass():
 def test_a_refusal_that_read_the_settled_thread_is_an_observation():
     # The unit the audit is built on. Two settled-match refusals are two observations of
     # non-difference, so the action is decided and is NOT called unstable.
-    rows = streaming_pair_rows("r100K.base.rep0", "r100K.treatment.rep0", "keystroke",
-                               base_tail = "T18277", treat_tail = "T18253")
+    rows = streaming_pair_rows(
+        "r100K.base.rep0",
+        "r100K.treatment.rep0",
+        "keystroke",
+        base_tail = "T18277",
+        treat_tail = "T18253",
+    )
     pair = ("keystroke", P.compare(rows[0]["parity"], rows[1]["parity"]))
     row = P.derive_unstable([pair, pair])["keystroke"]
     assert row["observations"] == 2
@@ -1542,9 +1553,14 @@ def test_a_settled_message_that_moved_is_a_difference_not_an_observation():
     # The other control, one layer down: the flag is only set when everything OUTSIDE the live
     # message agreed. Move a settled row and the pair is a DIFFER, so the null records real
     # instability exactly as before.
-    rows = streaming_pair_rows("r100K.base.rep0", "r100K.treatment.rep0", "keystroke",
-                               base_tail = "T18277", treat_tail = "T18253",
-                               treat_settled = "MOVED")
+    rows = streaming_pair_rows(
+        "r100K.base.rep0",
+        "r100K.treatment.rep0",
+        "keystroke",
+        base_tail = "T18277",
+        treat_tail = "T18253",
+        treat_settled = "MOVED",
+    )
     got = P.compare(rows[0]["parity"], rows[1]["parity"])
     assert got["verdict"] == P.DIFFER
     assert P.SETTLED_MATCH not in got
@@ -1554,9 +1570,14 @@ def test_a_scaffold_that_moved_is_a_difference_not_an_observation():
     # And the scaffold half of the same claim. Both arms agree they are streaming and agree about
     # the composer control, so this is not the generation-disagreement refusal: it is a thread
     # scaffolding change on a pair that was otherwise identical, and it stays a finding.
-    rows = streaming_pair_rows("r100K.base.rep0", "r100K.treatment.rep0", "keystroke",
-                               base_tail = "T18277", treat_tail = "T18253",
-                               treat_scaffold = "MOVED")
+    rows = streaming_pair_rows(
+        "r100K.base.rep0",
+        "r100K.treatment.rep0",
+        "keystroke",
+        base_tail = "T18277",
+        treat_tail = "T18253",
+        treat_scaffold = "MOVED",
+    )
     got = P.compare(rows[0]["parity"], rows[1]["parity"])
     assert got["verdict"] == P.DIFFER
     assert P.SETTLED_MATCH not in got
@@ -1571,10 +1592,20 @@ def test_the_audit_decides_an_action_whose_only_leftover_was_the_live_reply(tmp_
         tmp_path,
         "inflight",
         [
-            streaming_pair_rows("r100K.base.rep0", "r100K.treatment.rep0", "keystroke",
-                                base_tail = "T18277", treat_tail = "T18253"),
-            streaming_pair_rows("r100K.base.rep1", "r100K.treatment.rep1", "keystroke",
-                                base_tail = "T21004", treat_tail = "T20980"),
+            streaming_pair_rows(
+                "r100K.base.rep0",
+                "r100K.treatment.rep0",
+                "keystroke",
+                base_tail = "T18277",
+                treat_tail = "T18253",
+            ),
+            streaming_pair_rows(
+                "r100K.base.rep1",
+                "r100K.treatment.rep1",
+                "keystroke",
+                base_tail = "T21004",
+                treat_tail = "T20980",
+            ),
         ],
     )
     rc, report = U.audit_null([null], scope = {("r100K", "keystroke")})
@@ -1593,8 +1624,11 @@ def test_the_audit_still_fails_when_the_capture_itself_was_blind(tmp_path):
     cells = []
     for rep, tails in (("rep0", ("T1", "T2")), ("rep1", ("T3", "T4"))):
         cell = streaming_pair_rows(
-            f"r100K.base.{rep}", f"r100K.treatment.{rep}", "keystroke",
-            base_tail = tails[0], treat_tail = tails[1],
+            f"r100K.base.{rep}",
+            f"r100K.treatment.{rep}",
+            "keystroke",
+            base_tail = tails[0],
+            treat_tail = tails[1],
         )
         for row in cell:
             row["parity"]["in_flight_unplaced"] = True
@@ -1616,10 +1650,20 @@ def test_a_settled_match_can_never_grow_the_excuse_set(tmp_path):
         tmp_path,
         "narrow",
         [
-            streaming_pair_rows("r100K.base.rep0", "r100K.treatment.rep0", "keystroke",
-                                base_tail = "A", treat_tail = "B"),
-            streaming_pair_rows("r100K.base.rep1", "r100K.treatment.rep1", "keystroke",
-                                base_tail = "C", treat_tail = "D"),
+            streaming_pair_rows(
+                "r100K.base.rep0",
+                "r100K.treatment.rep0",
+                "keystroke",
+                base_tail = "A",
+                treat_tail = "B",
+            ),
+            streaming_pair_rows(
+                "r100K.base.rep1",
+                "r100K.treatment.rep1",
+                "keystroke",
+                base_tail = "C",
+                treat_tail = "D",
+            ),
         ],
     )
     unstable, _derived, _checks = U.unstable_set([null])

--- a/tests/studio/studiobench/sweep/selftest/test_studiobench_null_audit.py
+++ b/tests/studio/studiobench/sweep/selftest/test_studiobench_null_audit.py
@@ -1400,26 +1400,23 @@ def test_a_missing_composer_is_not_exempt_just_because_send_turn_can_be_queued(t
 
 # ── the reply that was still arriving is not a blind capture ──────────
 #
-# WHAT TURNED RED. On a wave of `studiobench UI parity` the audit came back UNDECIDED with 13
-# decided, 0 differed and 2 undecided: `keystroke@r100K` and `send_turn@r100K`, both "never
-# reached min_observations" despite `--min-reps 2` and both actions having run on both arms in
-# both repetitions. They are exactly the two actions whose slot lands INSIDE a live turn on the
-# packed 100K film, and the payload says so -- `streaming: true`, `in_flight: [19]` and `[22]`,
-# with the in-flight message 18,277 characters on one arm and 18,253 on the other.
+# WHAT TURNED RED. A wave of `studiobench UI parity` audited UNDECIDED with 13 decided, 0 differed
+# and 2 undecided: `keystroke@r100K` and `send_turn@r100K`, both "never reached min_observations"
+# despite `--min-reps 2` and both having run on both arms in both repetitions. They are the two
+# actions whose slot lands INSIDE a live turn on the packed 100K film, and the payload says so:
+# `streaming: true`, `in_flight: [19]` and `[22]`, the in-flight message 18,277 characters on one
+# arm and 18,253 on the other.
 #
-# WHERE IT CAME FROM. Before #9575 that pair scored DIFFER, which is wrong but is an OBSERVATION,
-# so the null decided the action and the audit passed. #9575 correctly demoted it to
-# NOT_COMPARABLE -- a mid-stream digest names a point in a stream, not a rendering -- and
-# `derive_unstable` files every NOT_COMPARABLE under `blind`, which is zero observations. Replayed
-# against the real payload from that job: pre-#9575 keystroke scores 2 observations and post-#9575
-# it scores 0.
+# WHERE IT CAME FROM. Pre-#9575 that pair scored DIFFER, which is wrong but is an OBSERVATION, so
+# the null decided the action and the audit passed. #9575 correctly demoted it to NOT_COMPARABLE,
+# and `derive_unstable` files every NOT_COMPARABLE under `blind`, which is zero observations.
+# Replayed against the real payload: keystroke scores 2 observations pre-#9575 and 0 after.
 #
 # So the refusal is right and the accounting behind it was not. `SETTLED_MATCH` is the narrow
-# repair: that one branch is reached only when the scaffold, the overlays, the message SET and
-# every settled message row have already agreed, so it is a complete reading of everything the
-# pair could read, and for "does this action differ against itself" that is an observation.
+# repair: that branch is reached only once the scaffold, overlays, message set and every settled
+# row have agreed, so it is a complete reading of everything the pair could read.
 #
-# Held here in both directions, because a fix that makes the audit easier to pass is worth nothing
+# Held in both directions, because a fix that makes the audit easier to pass is worth nothing
 # without the control that shows it still fails.
 
 
@@ -1439,12 +1436,12 @@ def streaming_pair_rows(
     """A base/treatment pair captured with message 1 STILL BEING WRITTEN on both arms.
 
     Modelled on the real `keystroke@r100K` rows from the failing run: both arms streaming, both
-    naming the same message in flight, both rendering the same composer control, and the settled
-    half of the thread byte-identical. `base_tail`/`treat_tail` are the digest of the message that
-    was still arriving, which is the only thing wall clock gets to move.
+    naming the same message in flight, the same composer control, and the settled half of the
+    thread byte-identical. `base_tail`/`treat_tail` are the digest of the still-arriving message,
+    the only thing wall clock gets to move.
 
-    `treat_settled`, `treat_scaffold` and `treat_role` exist so the negative controls can move
-    something the stream provably cannot reach, and watch the branch decline to fire.
+    `treat_settled`, `treat_scaffold` and `treat_role` let the negative controls move something
+    the stream provably cannot reach, and watch the branch decline to fire.
     """
 
     def side(
@@ -1506,10 +1503,9 @@ def streaming_null(tmp_path: Path, name: str, cells: list[list[dict]]) -> Path:
 
 
 def test_a_mid_stream_tail_is_still_a_refusal_and_never_a_pass():
-    # FIRST, the thing that must not change. The verdict stays NOT_COMPARABLE. A treatment build
-    # whose live message renders wrongly sits in exactly this shape, `structural_report` files a
-    # refusal under `blind` and takes its exit code without it, so promoting this to MATCH would
-    # hide a real regression. The repair is in what the NULL counts, not in what the result says.
+    # FIRST, the thing that must not change: the verdict stays NOT_COMPARABLE. A treatment build
+    # whose live message renders wrongly sits in exactly this shape, so promoting it to MATCH
+    # would hide a regression. The repair is in what the NULL counts, not in what the result says.
     rows = streaming_pair_rows(
         "r100K.base.rep0",
         "r100K.treatment.rep0",
@@ -1546,9 +1542,9 @@ def test_a_refusal_that_read_the_settled_thread_is_an_observation():
 
 
 def test_an_ordinary_refusal_is_still_blind():
-    # THE CONTROL. Without this the change reads as "count NOT_COMPARABLE as an observation",
-    # which would let an action that never rendered at all be derived as stable and trusted
-    # forever. A capture that failed carries no settled reading and must stay at zero.
+    # THE CONTROL. Without it the change reads as "count NOT_COMPARABLE as an observation", which
+    # would derive an action that never rendered at all as stable. A failed capture carries no
+    # settled reading and stays at zero.
     blind = {"verdict": P.NOT_COMPARABLE, "reason": "threadRoot is not a function"}
     row = P.derive_unstable([("keystroke", blind), ("keystroke", blind)])["keystroke"]
     assert row["observations"] == 0
@@ -1558,9 +1554,8 @@ def test_an_ordinary_refusal_is_still_blind():
 
 
 def test_a_settled_message_that_moved_is_a_difference_not_an_observation():
-    # The other control, one layer down: the flag is only set when everything OUTSIDE the live
-    # message agreed. Move a settled row and the pair is a DIFFER, so the null records real
-    # instability exactly as before.
+    # One layer down: the flag is only set when everything OUTSIDE the live message agreed. Move
+    # a settled row and the pair is a DIFFER, so real instability is recorded as before.
     rows = streaming_pair_rows(
         "r100K.base.rep0",
         "r100K.treatment.rep0",
@@ -1575,9 +1570,9 @@ def test_a_settled_message_that_moved_is_a_difference_not_an_observation():
 
 
 def test_a_scaffold_that_moved_is_a_difference_not_an_observation():
-    # And the scaffold half of the same claim. Both arms agree they are streaming and agree about
-    # the composer control, so this is not the generation-disagreement refusal: it is a thread
-    # scaffolding change on a pair that was otherwise identical, and it stays a finding.
+    # The scaffold half of the same claim. Both arms agree on streaming and on the composer
+    # control, so this is not the generation-disagreement refusal but a scaffolding change on an
+    # otherwise identical pair, and it stays a finding.
     rows = streaming_pair_rows(
         "r100K.base.rep0",
         "r100K.treatment.rep0",
@@ -1592,12 +1587,11 @@ def test_a_scaffold_that_moved_is_a_difference_not_an_observation():
 
 
 def test_a_live_row_whose_role_changed_carries_no_positive_reading():
-    # The control that is NOT reachable through `_any_moved`, which is what makes it worth
-    # asserting. The role is captured beside the digest, and the digest of an in-flight row is
-    # withheld, so a row that is `assistant` on one arm and `user` on the other passes the
-    # digest comparison untouched and the pair still reads as "everything settled agreed".
-    # `settled_messages_moved` calls that a structural change even in flight -- how far a reply
-    # has arrived says nothing about whose message it is -- so the flag must not fire here.
+    # The control `_any_moved` cannot reach, which is what makes it worth asserting. The role
+    # sits beside the digest and an in-flight digest is withheld, so `assistant` on one arm and
+    # `user` on the other passes the digest comparison untouched and the pair still reads as
+    # "everything settled agreed". `settled_messages_moved` calls that a structural change even
+    # in flight, so the flag must not fire here.
     rows = streaming_pair_rows(
         "r100K.base.rep0",
         "r100K.treatment.rep0",
@@ -1619,10 +1613,9 @@ def test_a_live_row_whose_role_changed_carries_no_positive_reading():
 
 
 def test_the_audit_decides_an_action_whose_only_leftover_was_the_live_reply(tmp_path):
-    # END TO END, and this is the case that turned the job red. Two repetitions of `keystroke`,
-    # both inside a live turn, the settled thread identical on every arm and only the in-flight
-    # tail landing a chunk apart. Nothing structural moved on this build against itself, and the
-    # audit must be able to say so.
+    # END TO END, the case that turned the job red: two repetitions of `keystroke` inside a live
+    # turn, the settled thread identical on every arm and only the in-flight tail a chunk apart.
+    # Nothing structural moved on this build against itself, and the audit must be able to say so.
     null = streaming_null(
         tmp_path,
         "inflight",
@@ -1653,9 +1646,9 @@ def test_the_audit_decides_an_action_whose_only_leftover_was_the_live_reply(tmp_
 
 
 def test_the_audit_still_fails_when_the_capture_itself_was_blind(tmp_path):
-    # THE PAIRED FAILURE. Same scope, same two repetitions, but the arms could not place the
-    # stream at all -- `in_flight_unplaced`, which is the `data-status` hook having gone quiet.
-    # There is no settled reading behind that refusal and the audit must stay red on it.
+    # THE PAIRED FAILURE. Same scope and repetitions, but the arms could not place the stream at
+    # all (`in_flight_unplaced`: the `data-status` hook went quiet). No settled reading sits
+    # behind that refusal, so the audit stays red.
     cells = []
     for rep, tails in (("rep0", ("T1", "T2")), ("rep1", ("T3", "T4"))):
         cell = streaming_pair_rows(
@@ -1676,11 +1669,9 @@ def test_the_audit_still_fails_when_the_capture_itself_was_blind(tmp_path):
 
 
 def test_a_settled_match_can_never_grow_the_excuse_set(tmp_path):
-    # THE SAFETY DIRECTION, asserted rather than argued. The observation this adds is a
-    # NON-difference, so no action can be called unstable on its strength and the derived excuse
-    # set can only ever narrow. A null control made entirely of settled-match refusals derives an
-    # EMPTY measured set, which means a corroborated difference in the result gets no excuse from
-    # it -- the loud direction, never the silent one.
+    # THE SAFETY DIRECTION, asserted rather than argued. The observation is a NON-difference, so
+    # the derived excuse set can only narrow: a null made entirely of settled-match refusals
+    # derives an EMPTY measured set, so a corroborated difference gets no excuse from it.
     null = streaming_null(
         tmp_path,
         "narrow",

--- a/tests/studio/studiobench/sweep/ui_parity.py
+++ b/tests/studio/studiobench/sweep/ui_parity.py
@@ -1357,6 +1357,13 @@ def audit_null(
     permanently undecided for an honest reason. Those names are excused by `allow_undecided`, and
     every one of them is a hole, so they are printed.
 
+    ONE REFUSAL IS NOT BLIND, and it is the one that made this audit unsatisfiable on the packed
+    rungs. A pair whose scaffold, overlays, message set and every SETTLED message row agreed, and
+    whose only leftover is the subtree of a reply that was still arriving, is counted by
+    `derive_unstable` as an observation of non-difference -- see `parity.SETTLED_MATCH`. How many
+    of the decided entries rest on that reading is reported here rather than folded away, because
+    it is a weaker claim than a plain MATCH: the settled thread was read, the live tail was not.
+
     SCOPED TO WHAT THE EXCUSE CHANGES, when a scope is given, and this is the difference between
     a gate that means something and one no runner can satisfy. The null control exists to excuse
     the result's noise, so the only actions it owes an opinion on are the ones an excuse would
@@ -1377,6 +1384,10 @@ def audit_null(
         by_rung[rung_of_cell(cell)].append((action, r))
 
     decided, undecided, differed, excused, out_of_scope = [], [], [], [], []
+    # Decided entries every one of whose observations came from a settled-match refusal. Named
+    # apart from `decided` because it is the weaker reading: the settled thread was compared and
+    # agreed, and the live tail was never read at all.
+    on_settled = []
     for rung, pairs in sorted(by_rung.items()):
         for action, row in sorted(P.derive_unstable(pairs).items()):
             entry = (rung, action)
@@ -1391,6 +1402,8 @@ def audit_null(
                 (excused if action in allow_undecided else undecided).append(entry)
                 continue
             decided.append(entry)
+            if row.get(P.SETTLED_MATCH) and row[P.SETTLED_MATCH] >= row["observations"]:
+                on_settled.append(entry)
             if row["unstable"]:
                 differed.append(entry)
 
@@ -1427,6 +1440,7 @@ def audit_null(
         "out_of_scope": out_of_scope,
         "differed": differed,
         "missing": missing,
+        "decided_on_settled_thread": on_settled,
     }
     # NOTHING TO DECIDE IS A PASS, and only when a scope said so. A result whose every action
     # matched asks the null for no excuses at all, and there is no way to fail a question that
@@ -1462,6 +1476,14 @@ def print_null_audit(rc: int, report_: dict, allow_undecided: frozenset) -> None
         return
     print(f"  decided (rung, action):     {len(report_['decided'])}")
     print(f"  of which differed:          {len(report_['differed'])}  (the MEASURED unstable set)")
+    if report_.get("decided_on_settled_thread"):
+        # Said out loud, because it is a narrower claim than the line above it and a reader
+        # weighing an excuse needs to know which reading it came from.
+        print(
+            f"  of which on the settled thread only: "
+            f"{len(report_['decided_on_settled_thread'])}  (a reply was still arriving on every "
+            "observation, so its subtree was withheld and the rest of the thread agreed)"
+        )
     print(f"  undecided:                  {len(report_['undecided'])}")
     if allow_undecided and report_["excused"]:
         print(

--- a/tests/studio/studiobench/sweep/ui_parity.py
+++ b/tests/studio/studiobench/sweep/ui_parity.py
@@ -1358,11 +1358,10 @@ def audit_null(
     every one of them is a hole, so they are printed.
 
     ONE REFUSAL IS NOT BLIND, and it is the one that made this audit unsatisfiable on the packed
-    rungs. A pair whose scaffold, overlays, message set and every SETTLED message row agreed, and
-    whose only leftover is the subtree of a reply that was still arriving, is counted by
-    `derive_unstable` as an observation of non-difference -- see `parity.SETTLED_MATCH`. How many
-    of the decided entries rest on that reading is reported here rather than folded away, because
-    it is a weaker claim than a plain MATCH: the settled thread was read, the live tail was not.
+    rungs. A pair whose scaffold, overlays, message set and every SETTLED row agreed, with only
+    the subtree of a still-arriving reply left over, counts as an observation of non-difference
+    (`parity.SETTLED_MATCH`). How many decided entries rest on it is reported rather than folded
+    away, because it is the weaker claim: the settled thread was read, the live tail was not.
 
     SCOPED TO WHAT THE EXCUSE CHANGES, when a scope is given, and this is the difference between
     a gate that means something and one no runner can satisfy. The null control exists to excuse
@@ -1384,9 +1383,8 @@ def audit_null(
         by_rung[rung_of_cell(cell)].append((action, r))
 
     decided, undecided, differed, excused, out_of_scope = [], [], [], [], []
-    # Decided entries every one of whose observations came from a settled-match refusal. Named
-    # apart from `decided` because it is the weaker reading: the settled thread was compared and
-    # agreed, and the live tail was never read at all.
+    # Decided entries whose every observation came from a settled-match refusal. Kept apart from
+    # `decided` because the live tail was never read at all.
     on_settled = []
     for rung, pairs in sorted(by_rung.items()):
         for action, row in sorted(P.derive_unstable(pairs).items()):
@@ -1477,8 +1475,7 @@ def print_null_audit(rc: int, report_: dict, allow_undecided: frozenset) -> None
     print(f"  decided (rung, action):     {len(report_['decided'])}")
     print(f"  of which differed:          {len(report_['differed'])}  (the MEASURED unstable set)")
     if report_.get("decided_on_settled_thread"):
-        # Said out loud, because it is a narrower claim than the line above it and a reader
-        # weighing an excuse needs to know which reading it came from.
+        # A narrower claim than the line above, so it is said out loud.
         print(
             f"  of which on the settled thread only: "
             f"{len(report_['decided_on_settled_thread'])}  (a reply was still arriving on every "

--- a/tests/test_fp8_fbgemm_block_shapes.py
+++ b/tests/test_fp8_fbgemm_block_shapes.py
@@ -92,9 +92,7 @@ def _check_grad(X, out, Wq, scale, block):
     grad_ref = torch.ones(out.shape, device = out.device, dtype = torch.float32) @ _dequant(
         Wq, scale, block
     )
-    torch.testing.assert_close(
-        X.grad.float(), grad_ref, atol = _bf16_atol(grad_ref), rtol = 5e-2
-    )
+    torch.testing.assert_close(X.grad.float(), grad_ref, atol = _bf16_atol(grad_ref), rtol = 5e-2)
 
 
 def _rel_err(out, ref):


### PR DESCRIPTION
## What turned red

`studiobench UI parity` -> "Parity verdict, scored against the null" failed with:

```
NULL CONTROL AUDIT: UNDECIDED
  decided (rung, action):     13
  of which differed:          0  (the MEASURED unstable set)
  undecided:                  2

  These (rung, action) pairs never reached min_observations:
    keystroke@r100K
    send_turn@r100K
```

`--min-reps 2` was passed and both actions ran on both arms in both repetitions. The null control found nothing differing anywhere, and the job still exited 1.

## Why

`keystroke` and `send_turn` are the two actions whose slot lands inside a live turn on the packed 100K film. The payload says so directly: `streaming: true`, `in_flight: [19]` and `[22]`, with the message that was still being written 18,277 characters on one arm and 18,253 on the other, and the settled half of the thread byte-identical across both.

`analysis/parity.compare` handles that correctly. It withholds the in-flight message subtree and returns NOT_COMPARABLE with the reason "the settled thread is identical on both arms and the only difference is in 1 message(s) that were STILL BEING WRITTEN when the digest was taken". That is the right verdict and it should stay: a mid-stream digest names a point in a stream rather than a rendering, and calling it MATCH would hide a treatment build whose live message renders wrongly.

`analysis/parity.derive_unstable` then files every NOT_COMPARABLE under `blind`, which is zero observations, so `observations = 0 < 2`, the pair is `undetermined`, and `audit_null` returns 1.

So the accounting behind the refusal was wrong, not the refusal, and not the product. #9575 is where it came from: before it, this pair scored DIFFER, which is the wrong verdict but is an observation, so the null decided the action and the audit passed. #9575 demoted it to a fourth outcome and did not thread that outcome through `derive_unstable`.

## Evidence

The failing job's own `payload.jsonl`, replayed through both revisions of the comparison code:

```
before #9575 (68a40ef18)         after #9575, main today
keystroke rep0  differ           keystroke rep0  not_comparable
keystroke rep1  differ           keystroke rep1  not_comparable
send_turn rep0  differ           send_turn rep0  not_comparable
send_turn rep1  match            send_turn rep1  match

r100K keystroke {observations: 2, differed: 2}    {observations: 0, not_comparable: 2, undetermined: True}
r100K send_turn {observations: 2, differed: 1}    {observations: 1, not_comparable: 1, undetermined: True}
```

Same payload, scoped the way the workflow scopes it, on main and on this branch:

```
main                                   this branch
NULL CONTROL AUDIT: UNDECIDED          NULL CONTROL AUDIT: DECIDED
  decided:    0                          decided:    2
  undecided:  2                          of which on the settled thread only: 1
EXIT 1                                   undecided:  0
                                       EXIT 0
```

## The change

`parity.SETTLED_MATCH` is a key set on that one refusal and read by `derive_unstable` and by nothing else. The branch is reachable only after `_any_moved` has already returned false, which means the scaffold agreed, every overlay agreed, both arms mounted the same set of messages, and every message that was not being written agreed. That is a complete reading of everything the pair could read, and for the question the null control asks -- does this action differ against itself -- it is an observation of non-difference.

The verdict does not move. `structural_report` still buckets the pair under `blind` and still takes its exit code without it, so the result side is unchanged.

It can only ever narrow the excuse set. The observation added is a non-difference, so `differed` cannot grow on its strength and no action can become "unstable" because of it. The worst it can do is call an action stable that nothing measured as differing, which costs a loud false alarm on the result and never a silenced regression.

The audit now also reports how many decided entries rest entirely on that reading, because "the settled thread agreed and the live tail was never read" is a weaker claim than a plain MATCH and a reader weighing an excuse should be able to tell.

## What the new tests lock down

Nine tests in `sweep/selftest/test_studiobench_null_audit.py`, paired in both directions the way that file requires. Six of them fail on main and all nine pass here.

- the mid-stream pair is still NOT_COMPARABLE with an empty `moved`, so the refusal has not been softened into a pass
- two settled-match refusals are two observations, `differed` 0, not unstable
- an ordinary failed capture is still blind at zero observations, which is the control that stops this becoming "count NOT_COMPARABLE as an observation"
- a settled message row that moved is still DIFFER and carries no flag
- a scaffold that moved, on arms that agree about generation, is still DIFFER and carries no flag
- end to end: a null whose only leftover is the live reply audits DECIDED, and is reported as decided on the settled thread only
- end to end control: a null whose arms could not place the stream at all (`in_flight_unplaced`, the `data-status` hook gone quiet) still audits UNDECIDED
- a null made entirely of settled-match refusals derives an empty measured set, so it hands out no excuses

## What this does not cover

The in-flight message subtree itself is still not compared, on either side. A rendering regression confined to a reply while it is being written is invisible to this gate, exactly as it was before this change; #9575 states that trade and this does not narrow it. What changed is only that the null control is no longer prevented from deciding an action because of it.

`--reps 2` remains the real slack constraint: an action whose slot one arm genuinely misses is still blind, still undetermined, and still fails the audit.

## Tests

```
python -m pytest tests/studio/studiobench/ -q
1553 passed
```
