### PR TITLE
Collect the pip-cache naming guard in the one job a workflow-only PR starts

### DIFF
--- a/.github/workflows/workflow-trigger-lint.yml
+++ b/.github/workflows/workflow-trigger-lint.yml
@@ -138,6 +138,7 @@ jobs:
             tests/studio/test_ui_shard_engines.py \
             tests/studio/test_zoo_suite_parallel_isolation.py \
             tests/studio/test_ci_shell_suite_coverage.py \
+            tests/studio/test_pip_cache_naming.py \
             tests/studio/test_compile_caches_are_per_worker.py \
             tests/studio/test_composer_rtl_bidi_attribute.py \
             tests/studio/test_frontend_dep_removal.py \

--- a/studio/backend/tests/test_offload_planner_seam.py
+++ b/studio/backend/tests/test_offload_planner_seam.py
@@ -1244,6 +1244,8 @@ def test_the_flat_mtp_reserve_reaches_the_spill_budget():
     reserved = _plan(stub, free_mib = 24 * 1024, usable_mib = 14 * 1024)
     assert generous is not None and reserved is not None
     assert len(reserved.spilled_blocks) > len(generous.spilled_blocks)
+
+
 def test_the_seam_computes_a_per_layer_kv_vector():
     """The data already existed on the backend (_sliding_window_pattern); it just
     never crossed into the planner. Only the RATIOS travel: full attention holds

--- a/tests/test_fp8_fbgemm_block_shapes.py
+++ b/tests/test_fp8_fbgemm_block_shapes.py
@@ -92,9 +92,7 @@ def _check_grad(X, out, Wq, scale, block):
     grad_ref = torch.ones(out.shape, device = out.device, dtype = torch.float32) @ _dequant(
         Wq, scale, block
     )
-    torch.testing.assert_close(
-        X.grad.float(), grad_ref, atol = _bf16_atol(grad_ref), rtol = 5e-2
-    )
+    torch.testing.assert_close(X.grad.float(), grad_ref, atol = _bf16_atol(grad_ref), rtol = 5e-2)
 
 
 def _rel_err(out, ref):


### PR DESCRIPTION
`tests/studio/test_pip_cache_naming.py` reads `.github/workflows/*.yml` and is not in `workflow-trigger-lint.yml`'s pytest list, so `test_workflow_guards_run_unfiltered` is **red on main**:

```
these guards read a workflow file but are not run by workflow-trigger-lint,
the only job with no paths filter: ['test_pip_cache_naming.py']
```

Reproduced on a clean checkout of `60d2a636b`.

That guard exists because every other job filters on source paths, so a PR editing only workflow files, which is exactly the change this module exists to reject, never collects it. It would still catch the mistake later, on the unfiltered push to main, after the change had merged.

One line, beside the other cache guard in the list. The module imports only `re`, `pathlib`, `pytest` and `yaml`, so it runs in that job's deliberately minimal environment (pyyaml, pytest and vermin) without adding an install.

Verified: `tests/studio/test_workflow_guards_run_unfiltered.py` and `tests/studio/test_pip_cache_naming.py` together, 98 passed.