### PR TITLE
Studio: auto-scroll the startup and update logs

### DIFF
--- a/studio/frontend/src/components/tauri/diagnostics-copy-actions.tsx
+++ b/studio/frontend/src/components/tauri/diagnostics-copy-actions.tsx
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import { Button } from "@/components/ui/button";
+import type { CopySupportDiagnosticsResult } from "@/lib/tauri-diagnostics";
+
+import { useState } from "react";
+
+/**
+ * The action row every failure state ends in: copy the support report, plus whatever
+ * recovery buttons that state offers, passed as children so the caller keeps ownership
+ * of them. When the clipboard refuses — a headless session, a denied permission — the
+ * report is rendered into a selectable textarea so the user can still hand it over.
+ */
+export function DiagnosticsCopyActions({
+  onCopyDiagnostics,
+  children,
+}: {
+  onCopyDiagnostics: () => Promise<CopySupportDiagnosticsResult>;
+  children: React.ReactNode;
+}) {
+  const [copying, setCopying] = useState(false);
+  const [manualReport, setManualReport] = useState<string | null>(null);
+  const [manualMessage, setManualMessage] = useState<string | null>(null);
+
+  async function handleCopyDiagnostics() {
+    setCopying(true);
+    try {
+      const result = await onCopyDiagnostics();
+      if (result.ok) {
+        setManualReport(null);
+        setManualMessage(null);
+      } else {
+        setManualReport(result.report);
+        setManualMessage(result.error ?? "Clipboard copy failed. Select and copy the diagnostics below.");
+      }
+    } catch (error) {
+      setManualReport(null);
+      setManualMessage(`Diagnostics copy failed: ${String(error)}`);
+    } finally {
+      setCopying(false);
+    }
+  }
+
+  return (
+    <div className="mt-4 flex w-full flex-col items-center gap-3">
+      <div className="flex flex-wrap items-center justify-center gap-3">
+        <Button
+          variant="muted"
+          size="hero"
+          onClick={() => void handleCopyDiagnostics()}
+        >
+          {copying ? "Copying..." : "Copy Diagnostics"}
+        </Button>
+        {children}
+      </div>
+      {manualMessage && (
+        <p className="max-w-md text-center text-xs text-destructive">{manualMessage}</p>
+      )}
+      {manualReport && (
+        // text-left, not the inherited centering: a diagnostics report is read line by
+        // line, and both screens center everything else in their column.
+        <textarea
+          readOnly
+          value={manualReport}
+          onFocus={(event) => event.currentTarget.select()}
+          className="h-32 w-full max-w-md resize-none rounded-lg border border-border/50 bg-muted/30 p-2 text-left font-mono text-ui-10 text-muted-foreground"
+        />
+      )}
+    </div>
+  );
+}

--- a/studio/frontend/src/components/tauri/log-details.tsx
+++ b/studio/frontend/src/components/tauri/log-details.tsx
@@ -1,13 +1,20 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
+import { isFollowingTail } from "@/components/tauri/log-follow";
+
 import { ChevronDown as ChevronDownIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
+import { useLayoutEffect, useRef } from "react";
 
 /**
  * The collapsed log tail every long-running full-window screen shows under its status
  * line. Shared so install, repair and update stay one control rather than three copies
  * that drift apart; only the noun in the toggle and the lines themselves differ.
+ *
+ * The log follows its own tail, but yields: scrolling up to read something pins the view
+ * there however many lines arrive next, and scrolling back to the bottom resumes the
+ * follow. Reopening the panel always starts at the latest line.
  */
 export function LogDetails({
   label,
@@ -17,12 +24,60 @@ export function LogDetails({
   label: string;
   lines: string[];
 }) {
+  const detailsRef = useRef<HTMLDetailsElement>(null);
+  const logRef = useRef<HTMLPreElement>(null);
+  // A ref, not state: nothing renders from it, and a re-render per scroll event while a
+  // log is streaming is exactly what this component cannot afford.
+  const following = useRef(true);
+
+  const text = lines.join("\n");
+
+  // Layout effect, not a passive one: the browser must not paint the new lines at the old
+  // offset first, or a fast-appending log visibly judders on every update.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: text is the trigger, not a read - new lines changed the DOM, which is what there is to react to
+  useLayoutEffect(() => {
+    if (!following.current) {
+      return;
+    }
+    const log = logRef.current;
+    if (!log) {
+      return;
+    }
+    log.scrollTop = log.scrollHeight;
+  }, [text]);
+
+  function handleScroll() {
+    const log = logRef.current;
+    if (!log) {
+      return;
+    }
+    following.current = isFollowingTail(log);
+  }
+
+  function handleToggle() {
+    // Closed <details> content has no layout, so scrollTop cannot be set while it is
+    // hidden and the effect above no-ops for every line that arrives meanwhile. Catch up
+    // on open, which is also the moment a stale pinned offset is least worth keeping.
+    if (!detailsRef.current?.open) {
+      return;
+    }
+    following.current = true;
+    const log = logRef.current;
+    if (log) {
+      log.scrollTop = log.scrollHeight;
+    }
+  }
+
   if (lines.length === 0) {
     return null;
   }
 
   return (
-    <details className="group mt-2 w-full max-w-sm text-left">
+    <details
+      ref={detailsRef}
+      onToggle={handleToggle}
+      className="group mt-2 w-full max-w-sm text-left"
+    >
       <summary className="mx-auto flex w-fit cursor-pointer list-none items-center gap-1 rounded-md px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring [&::-webkit-details-marker]:hidden">
         <span className="group-open:hidden">Show {label}</span>
         <span className="hidden group-open:inline">Hide {label}</span>
@@ -33,8 +88,12 @@ export function LogDetails({
           className="size-[13px] shrink-0 transition-transform group-open:rotate-180"
         />
       </summary>
-      <pre className="mt-2 max-h-28 overflow-auto whitespace-pre-wrap break-words rounded-lg border border-border/50 bg-muted/30 p-3 font-mono text-ui-10 leading-relaxed text-muted-foreground">
-        {lines.join("\n")}
+      <pre
+        ref={logRef}
+        onScroll={handleScroll}
+        className="mt-2 max-h-28 overflow-auto whitespace-pre-wrap break-words rounded-lg border border-border/50 bg-muted/30 p-3 font-mono text-ui-10 leading-relaxed text-muted-foreground"
+      >
+        {text}
       </pre>
     </details>
   );

--- a/studio/frontend/src/components/tauri/log-details.tsx
+++ b/studio/frontend/src/components/tauri/log-details.tsx
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import { ChevronDown as ChevronDownIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+
+/**
+ * The collapsed log tail every long-running full-window screen shows under its status
+ * line. Shared so install, repair and update stay one control rather than three copies
+ * that drift apart; only the noun in the toggle and the lines themselves differ.
+ */
+export function LogDetails({
+  label,
+  lines,
+}: {
+  /** Noun phrase completing "Show ..." / "Hide ...", e.g. "installation details". */
+  label: string;
+  lines: string[];
+}) {
+  if (lines.length === 0) {
+    return null;
+  }
+
+  return (
+    <details className="group mt-2 w-full max-w-sm text-left">
+      <summary className="mx-auto flex w-fit cursor-pointer list-none items-center gap-1 rounded-md px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring [&::-webkit-details-marker]:hidden">
+        <span className="group-open:hidden">Show {label}</span>
+        <span className="hidden group-open:inline">Hide {label}</span>
+        <HugeiconsIcon
+          icon={ChevronDownIcon}
+          aria-hidden="true"
+          strokeWidth={1.5}
+          className="size-[13px] shrink-0 transition-transform group-open:rotate-180"
+        />
+      </summary>
+      <pre className="mt-2 max-h-28 overflow-auto whitespace-pre-wrap break-words rounded-lg border border-border/50 bg-muted/30 p-3 font-mono text-ui-10 leading-relaxed text-muted-foreground">
+        {lines.join("\n")}
+      </pre>
+    </details>
+  );
+}

--- a/studio/frontend/src/components/tauri/log-follow.ts
+++ b/studio/frontend/src/components/tauri/log-follow.ts
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+/**
+ * How close to the bottom still counts as "at the bottom". Fractional line heights and
+ * browser zoom leave the scroll offset a hair short of the end, so an exact comparison
+ * would read as a manual scroll-up on the user's behalf and stop the follow.
+ */
+export const STICK_THRESHOLD_PX = 8;
+
+/** The three scroll metrics the decision needs, so callers can pass a plain object. */
+export interface ScrollMetrics {
+  scrollHeight: number;
+  scrollTop: number;
+  clientHeight: number;
+}
+
+/**
+ * Whether a scrolling log should keep following its tail. Separate from the component so
+ * the thresholds can be exercised without a DOM.
+ */
+export function isFollowingTail({
+  scrollHeight,
+  scrollTop,
+  clientHeight,
+}: ScrollMetrics): boolean {
+  // A log shorter than its box never scrolls, so it is always at its own end. Reported
+  // dimensions are also 0 while the <details> is closed, which lands here and keeps the
+  // follow armed for whenever it opens.
+  if (scrollHeight <= clientHeight) {
+    return true;
+  }
+  return scrollHeight - scrollTop - clientHeight <= STICK_THRESHOLD_PX;
+}

--- a/studio/frontend/src/components/tauri/startup-screen.tsx
+++ b/studio/frontend/src/components/tauri/startup-screen.tsx
@@ -1,18 +1,19 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
+import { DiagnosticsCopyActions } from "@/components/tauri/diagnostics-copy-actions";
+import { LogDetails } from "@/components/tauri/log-details";
 import {
   installProgressMessage,
   startupWaitingMessage,
   STATUS_MESSAGE_ROTATION_MS,
   type StartupMessage,
 } from "@/components/tauri/startup-messages";
+import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
 import type { BackendStatus } from "@/hooks/use-tauri-backend";
 import type { CopySupportDiagnosticsResult } from "@/lib/tauri-diagnostics";
 
-import { ChevronDown as ChevronDownIcon } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
 import { AnimatePresence, motion } from "motion/react";
 import { type ReactNode, useEffect, useState } from "react";
 
@@ -31,67 +32,6 @@ interface StartupScreenProps {
   onStartServer: () => void;
   onCopyDiagnostics: () => Promise<CopySupportDiagnosticsResult>;
 }
-
-function DiagnosticsCopyActions({
-  onCopyDiagnostics,
-  children,
-}: {
-  onCopyDiagnostics: () => Promise<CopySupportDiagnosticsResult>;
-  children: React.ReactNode;
-}) {
-  const [copying, setCopying] = useState(false);
-  const [manualReport, setManualReport] = useState<string | null>(null);
-  const [manualMessage, setManualMessage] = useState<string | null>(null);
-
-  async function handleCopyDiagnostics() {
-    setCopying(true);
-    try {
-      const result = await onCopyDiagnostics();
-      if (result.ok) {
-        setManualReport(null);
-        setManualMessage(null);
-      } else {
-        setManualReport(result.report);
-        setManualMessage(result.error ?? "Clipboard copy failed. Select and copy the diagnostics below.");
-      }
-    } catch (error) {
-      setManualReport(null);
-      setManualMessage(`Diagnostics copy failed: ${String(error)}`);
-    } finally {
-      setCopying(false);
-    }
-  }
-
-  return (
-    <div className="mt-4 flex w-full flex-col items-center gap-3">
-      <div className="flex gap-3">
-        <ActionButton
-          variant="secondary"
-          onClick={() => void handleCopyDiagnostics()}
-        >
-          {copying ? "Copying..." : "Copy Diagnostics"}
-        </ActionButton>
-        {children}
-      </div>
-      {manualMessage && (
-        <p className="max-w-md text-center text-xs text-destructive">{manualMessage}</p>
-      )}
-      {manualReport && (
-        <textarea
-          readOnly
-          value={manualReport}
-          onFocus={(event) => event.currentTarget.select()}
-          className="h-32 w-full max-w-md resize-none rounded-lg border border-border/50 bg-muted/30 p-2 font-mono text-ui-10 text-muted-foreground"
-        />
-      )}
-    </div>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Constants
-// ---------------------------------------------------------------------------
-
 
 const EASE_OUT_QUART: [number, number, number, number] = [0.165, 0.84, 0.44, 1];
 
@@ -115,27 +55,6 @@ function Logo() {
         unsloth
       </span>
     </div>
-  );
-}
-
-function ActionButton({
-  onClick,
-  variant = "primary",
-  children,
-}: {
-  onClick: () => void;
-  variant?: "primary" | "secondary";
-  children: React.ReactNode;
-}) {
-  const base = "rounded-lg px-5 py-2.5 text-sm font-medium cursor-pointer transition-colors";
-  const styles =
-    variant === "primary"
-      ? `${base} bg-primary text-primary-foreground hover:bg-primary/80`
-      : `${base} bg-muted text-foreground hover:bg-muted/80`;
-  return (
-    <button type="button" className={styles} onClick={onClick}>
-      {children}
-    </button>
   );
 }
 
@@ -170,9 +89,9 @@ function NotInstalledContent({ onInstall }: { onInstall: () => void }) {
         >
           To install Unsloth, click Get Started.
         </p>
-        <ActionButton onClick={onInstall}>
+        <Button size="hero" onClick={onInstall}>
           Get Started
-        </ActionButton>
+        </Button>
       </div>
     </div>
   );
@@ -218,23 +137,7 @@ function InstallingContent({
           {message.title}
         </p>
         <p className="text-sm text-muted-foreground">{message.subtitle}</p>
-        {detailLines.length > 0 && (
-          <details className="group mt-2 w-full max-w-sm text-left">
-            <summary className="mx-auto flex w-fit cursor-pointer list-none items-center gap-1 rounded-md px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring [&::-webkit-details-marker]:hidden">
-              <span className="group-open:hidden">Show installation details</span>
-              <span className="hidden group-open:inline">Hide installation details</span>
-              <HugeiconsIcon
-                icon={ChevronDownIcon}
-                aria-hidden="true"
-                strokeWidth={1.5}
-                className="size-[13px] shrink-0 transition-transform group-open:rotate-180"
-              />
-            </summary>
-            <pre className="mt-2 max-h-28 overflow-auto whitespace-pre-wrap break-words rounded-lg border border-border/50 bg-muted/30 p-3 font-mono text-ui-10 leading-relaxed text-muted-foreground">
-              {detailLines.join("\n")}
-            </pre>
-          </details>
-        )}
+        <LogDetails label="installation details" lines={detailLines} />
       </div>
     </div>
   );
@@ -260,23 +163,7 @@ function RepairingContent({
         <Spinner className="size-6 text-primary" />
         <p className="text-sm font-bold text-foreground">Getting things ready...</p>
         <p className="text-sm text-muted-foreground">This won’t take long.</p>
-        {detailLines.length > 0 && (
-          <details className="group mt-2 w-full max-w-sm text-left">
-            <summary className="mx-auto flex w-fit cursor-pointer list-none items-center gap-1 rounded-md px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring [&::-webkit-details-marker]:hidden">
-              <span className="group-open:hidden">Show setup details</span>
-              <span className="hidden group-open:inline">Hide setup details</span>
-              <HugeiconsIcon
-                icon={ChevronDownIcon}
-                aria-hidden="true"
-                strokeWidth={1.5}
-                className="size-[13px] shrink-0 transition-transform group-open:rotate-180"
-              />
-            </summary>
-            <pre className="mt-2 max-h-28 overflow-auto whitespace-pre-wrap break-words rounded-lg border border-border/50 bg-muted/30 p-3 font-mono text-ui-10 leading-relaxed text-muted-foreground">
-              {detailLines.join("\n")}
-            </pre>
-          </details>
-        )}
+        <LogDetails label="setup details" lines={detailLines} />
       </div>
     </div>
   );
@@ -317,7 +204,7 @@ function InstallErrorContent({
           <p className="max-w-xs text-center text-xs text-muted-foreground">{error}</p>
         )}
         <DiagnosticsCopyActions onCopyDiagnostics={onCopyDiagnostics}>
-          <ActionButton onClick={onRetryInstall}>Try Again</ActionButton>
+          <Button size="hero" onClick={onRetryInstall}>Try Again</Button>
         </DiagnosticsCopyActions>
       </div>
     </>
@@ -342,7 +229,7 @@ function RepairErrorContent({
           <p className="max-w-md text-center text-xs text-muted-foreground">{error}</p>
         )}
         <DiagnosticsCopyActions onCopyDiagnostics={onCopyDiagnostics}>
-          <ActionButton onClick={onRetry}>Retry</ActionButton>
+          <Button size="hero" onClick={onRetry}>Retry</Button>
         </DiagnosticsCopyActions>
       </div>
     </>
@@ -372,8 +259,8 @@ function NeedsElevationContent({
           ))}
         </div>
         <div className="mt-4 flex gap-3">
-          <ActionButton variant="secondary" onClick={onRetryInstall}>Cancel</ActionButton>
-          <ActionButton onClick={onApproveElevation}>Allow</ActionButton>
+          <Button variant="muted" size="hero" onClick={onRetryInstall}>Cancel</Button>
+          <Button size="hero" onClick={onApproveElevation}>Allow</Button>
         </div>
       </div>
     </>
@@ -404,7 +291,7 @@ function StoppedContent({ onStartServer }: { onStartServer: () => void }) {
       <div className="mt-8 flex flex-col items-center gap-2">
         <p className="text-sm font-medium text-foreground">Server stopped</p>
         <div className="mt-4">
-          <ActionButton onClick={onStartServer}>Start Server</ActionButton>
+          <Button size="hero" onClick={onStartServer}>Start Server</Button>
         </div>
       </div>
     </>
@@ -429,7 +316,7 @@ function ErrorContent({
           <p className="max-w-md text-center text-xs text-muted-foreground">{error}</p>
         )}
         <DiagnosticsCopyActions onCopyDiagnostics={onCopyDiagnostics}>
-          <ActionButton onClick={onRetry}>Retry</ActionButton>
+          <Button size="hero" onClick={onRetry}>Retry</Button>
         </DiagnosticsCopyActions>
       </div>
     </>

--- a/studio/frontend/src/components/tauri/update-screen.tsx
+++ b/studio/frontend/src/components/tauri/update-screen.tsx
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
+import { DiagnosticsCopyActions } from "@/components/tauri/diagnostics-copy-actions";
+import { LogDetails } from "@/components/tauri/log-details";
+import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
 import type { UpdateStatus } from "@/hooks/use-tauri-update";
 import type { CopySupportDiagnosticsResult } from "@/lib/tauri-diagnostics";
 
-import { ChevronDown as ChevronDownIcon } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
 import { AnimatePresence, motion } from "motion/react";
-import { useState } from "react";
 
 interface UpdateScreenProps {
   status: UpdateStatus;
@@ -71,30 +71,6 @@ function statusSubtext(status: UpdateStatus, progress: number): string {
   }
 }
 
-function UpdateDetails({ logs }: { logs: string[] }) {
-  if (logs.length === 0) {
-    return null;
-  }
-
-  return (
-    <details className="group mt-2 w-full max-w-sm text-left">
-      <summary className="mx-auto flex w-fit cursor-pointer list-none items-center gap-1 rounded-md px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring [&::-webkit-details-marker]:hidden">
-        <span className="group-open:hidden">Show update details</span>
-        <span className="hidden group-open:inline">Hide update details</span>
-        <HugeiconsIcon
-          icon={ChevronDownIcon}
-          aria-hidden="true"
-          strokeWidth={1.5}
-          className="size-[13px] shrink-0 transition-transform group-open:rotate-180"
-        />
-      </summary>
-      <pre className="mt-2 max-h-28 overflow-auto whitespace-pre-wrap break-words rounded-lg border border-border/50 bg-muted/30 p-3 font-mono text-ui-10 leading-relaxed text-muted-foreground">
-        {logs.join("\n")}
-      </pre>
-    </details>
-  );
-}
-
 export function UpdateScreen({
   status,
   logs,
@@ -105,31 +81,6 @@ export function UpdateScreen({
   onCopyDiagnostics,
 }: UpdateScreenProps) {
   const isError = status === "error";
-  const [copying, setCopying] = useState(false);
-  const [manualReport, setManualReport] = useState<string | null>(null);
-  const [manualMessage, setManualMessage] = useState<string | null>(null);
-
-  async function handleCopyDiagnostics() {
-    setCopying(true);
-    try {
-      const result = await onCopyDiagnostics();
-      if (result.ok) {
-        setManualReport(null);
-        setManualMessage(null);
-      } else {
-        setManualReport(result.report);
-        setManualMessage(
-          result.error ??
-            "Clipboard copy failed. Select and copy the diagnostics below.",
-        );
-      }
-    } catch (copyError) {
-      setManualReport(null);
-      setManualMessage(`Diagnostics copy failed: ${String(copyError)}`);
-    } finally {
-      setCopying(false);
-    }
-  }
 
   return (
     <div className="box-border flex h-full w-full flex-col items-center overflow-y-auto bg-background pb-6 pt-[var(--studio-startup-top-inset,0px)]">
@@ -184,46 +135,17 @@ export function UpdateScreen({
             </AnimatePresence>
 
             {isError && (
-              <div className="mt-2 flex flex-wrap items-center justify-center gap-2">
-                <button
-                  type="button"
-                  className="rounded-lg bg-muted px-5 py-2.5 text-sm font-medium text-foreground transition-colors hover:bg-muted/80"
-                  onClick={() => void handleCopyDiagnostics()}
-                >
-                  {copying ? "Copying..." : "Copy Diagnostics"}
-                </button>
-                <button
-                  type="button"
-                  className="rounded-lg bg-primary px-5 py-2.5 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/80"
-                  onClick={onRetry}
-                >
+              <DiagnosticsCopyActions onCopyDiagnostics={onCopyDiagnostics}>
+                <Button size="hero" onClick={onRetry}>
                   Retry
-                </button>
-                <button
-                  type="button"
-                  className="rounded-lg bg-muted px-5 py-2.5 text-sm font-medium text-foreground transition-colors hover:bg-muted/80"
-                  onClick={onSkipRestart}
-                >
+                </Button>
+                <Button variant="muted" size="hero" onClick={onSkipRestart}>
                   Skip & Restart
-                </button>
-              </div>
+                </Button>
+              </DiagnosticsCopyActions>
             )}
 
-            {manualMessage && (
-              <p className="mt-1 max-w-md text-xs text-destructive">
-                {manualMessage}
-              </p>
-            )}
-            {manualReport && (
-              <textarea
-                readOnly
-                value={manualReport}
-                onFocus={(event) => event.currentTarget.select()}
-                className="mt-1 h-32 w-full max-w-md resize-none rounded-lg border border-border/50 bg-muted/30 p-2 text-left font-mono text-ui-10 text-muted-foreground"
-              />
-            )}
-
-            <UpdateDetails logs={logs} />
+            <LogDetails label="update details" lines={logs} />
           </div>
         </motion.div>
       </div>

--- a/studio/frontend/src/components/ui/button.tsx
+++ b/studio/frontend/src/components/ui/button.tsx
@@ -22,6 +22,9 @@ export const buttonVariants = cva(
           "bg-secondary text-secondary-foreground hover:bg-secondary/80 aria-expanded:bg-secondary aria-expanded:text-secondary-foreground",
         ghost:
           "hover:bg-muted hover:text-foreground dark:hover:bg-muted/50 aria-expanded:bg-muted aria-expanded:text-foreground",
+        // Neutral grey at rest, unlike `secondary`, whose token carries a hue in some
+        // themes. The quiet half of a pair of full-window screen actions.
+        muted: "bg-muted text-foreground hover:bg-muted/80",
         destructive:
           "bg-destructive/10 hover:bg-destructive/20 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/20 text-destructive focus-visible:border-destructive/40 dark:hover:bg-destructive/30",
         link: "text-primary underline-offset-4 hover:underline",
@@ -36,6 +39,10 @@ export const buttonVariants = cva(
         "icon-xs": "size-6 [&_svg:not([class*='size-'])]:size-3",
         "icon-sm": "size-8",
         "icon-lg": "size-10",
+        // Full-window screen actions (startup, update): taller than `lg`, and squared
+        // off rather than pill-shaped, so they read as page-level rather than in-line.
+        // Height is left to the padding, so the label sets it.
+        hero: "h-auto rounded-lg px-5 py-2.5",
       },
     },
     defaultVariants: {

--- a/studio/frontend/tests/tauri-details-toggle.test.ts
+++ b/studio/frontend/tests/tauri-details-toggle.test.ts
@@ -22,23 +22,38 @@ function summaryForLabel(sourceText: string, label: string): string {
   return sourceText.slice(start, end);
 }
 
-test("Tauri detail toggles put a custom down chevron after their labels", async () => {
+test("the shared detail toggle puts a custom down chevron after its label", async () => {
+  const summary = summaryForLabel(await source("log-details.tsx"), "Show {label}");
+
+  assert.match(summary, /\blist-none\b/);
+  assert.match(summary, /\[&::\-webkit-details-marker\]:hidden/);
+  assert.match(summary, /\bflex\b/);
+  assert.ok(
+    summary.indexOf("<HugeiconsIcon") > summary.indexOf("Show {label}") &&
+      summary.includes("icon={ChevronDownIcon}"),
+    "the chevron must be on the right",
+  );
+});
+
+test("every Tauri screen names its logs through the shared toggle", async () => {
   const startup = await source("startup-screen.tsx");
   const update = await source("update-screen.tsx");
 
   for (const [sourceText, label] of [
-    [startup, "Show installation details"],
-    [startup, "Show setup details"],
-    [update, "Show update details"],
+    [startup, "installation details"],
+    [startup, "setup details"],
+    [update, "update details"],
   ] as const) {
-    const summary = summaryForLabel(sourceText, label);
-    assert.match(summary, /\blist-none\b/);
-    assert.match(summary, /\[&::\-webkit-details-marker\]:hidden/);
-    assert.match(summary, /\bflex\b/);
-    assert.ok(
-      summary.indexOf("<HugeiconsIcon") > summary.indexOf(label) &&
-        summary.includes("icon={ChevronDownIcon}"),
-      `${label} chevron must be on the right`,
+    assert.match(
+      sourceText,
+      new RegExp(`<LogDetails label="${label}" lines=`),
+      `${label} must render through LogDetails`,
     );
+  }
+
+  // The copies these replaced drifted apart on spacing and wording; a hand-rolled
+  // <details> back in a screen is the shape that let that happen.
+  for (const sourceText of [startup, update]) {
+    assert.doesNotMatch(sourceText, /<details/);
   }
 });

--- a/studio/frontend/tests/tauri-log-follow.test.ts
+++ b/studio/frontend/tests/tauri-log-follow.test.ts
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// The install and update logs stream while the user is stuck watching them, which is
+// exactly when someone scrolls up to read a line that went past. Following the tail is
+// only acceptable if that scroll-up wins until they come back down on their own.
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+import {
+  STICK_THRESHOLD_PX,
+  isFollowingTail,
+} from "../src/components/tauri/log-follow.ts";
+
+/** A log box 100px tall holding 500px of lines: 400px of travel, bottom at 400. */
+const TALL = { scrollHeight: 500, clientHeight: 100 };
+
+test("a log parked at the bottom keeps following", () => {
+  assert.equal(isFollowingTail({ ...TALL, scrollTop: 400 }), true);
+});
+
+test("a log scrolled up stops following", () => {
+  assert.equal(isFollowingTail({ ...TALL, scrollTop: 399 - STICK_THRESHOLD_PX }), false);
+  assert.equal(isFollowingTail({ ...TALL, scrollTop: 0 }), false);
+});
+
+test("scrolling back down to the bottom resumes the follow", () => {
+  assert.equal(isFollowingTail({ ...TALL, scrollTop: 0 }), false);
+  assert.equal(isFollowingTail({ ...TALL, scrollTop: 400 }), true);
+});
+
+test("a sub-pixel gap at the end still counts as the bottom", () => {
+  // Fractional line heights and browser zoom land the offset just short of the end;
+  // treating that as a manual scroll-up would stop the follow nobody asked to stop.
+  assert.equal(isFollowingTail({ ...TALL, scrollTop: 399.4 }), true);
+  assert.equal(isFollowingTail({ ...TALL, scrollTop: 400 - STICK_THRESHOLD_PX }), true);
+});
+
+test("a log shorter than its box is always at its own end", () => {
+  assert.equal(
+    isFollowingTail({ scrollHeight: 40, scrollTop: 0, clientHeight: 100 }),
+    true,
+  );
+});
+
+test("a closed panel reports zeroes and stays armed to follow", () => {
+  // Hidden <details> content has no layout, so every metric reads 0. That must not latch
+  // the follow off for the lines that arrive before the user opens it.
+  assert.equal(
+    isFollowingTail({ scrollHeight: 0, scrollTop: 0, clientHeight: 0 }),
+    true,
+  );
+});
+
+test("LogDetails drives its scrolling through the shared predicate", async () => {
+  const source = await readFile(
+    new URL("../src/components/tauri/log-details.tsx", import.meta.url),
+    "utf8",
+  );
+
+  assert.match(source, /isFollowingTail\(log\)/);
+  assert.match(source, /onScroll=\{handleScroll\}/);
+  assert.match(source, /onToggle=\{handleToggle\}/);
+  // A passive effect paints the new lines at the old offset first, which reads as a
+  // judder on every append.
+  assert.match(source, /useLayoutEffect/);
+  // Following state must not go through useState: a render per scroll event is the one
+  // cost a streaming log cannot carry.
+  assert.doesNotMatch(source, /useState/);
+});


### PR DESCRIPTION
This is a small thing, but it has been bugging me every time I install or update. The detail log on the startup and update screens does not auto-scroll. You open "Show installation details" during a job that takes a few minutes, and you keep looking at the first three lines. The part you want to see, what it is doing right now or what just failed, stays out of view.

## What this does

The log now scrolls down on its own as new lines come in, but it gets out of the way if you take over:

- If you scroll up to read something, it stays where you put it, no matter how many new lines arrive.
- If you scroll back to the bottom, it starts following again.
- If you close and reopen the panel, it jumps to the newest line.

The last one is not a style choice. When a `<details>` is closed, its content has no layout, so the code cannot set `scrollTop` while it is hidden, and any lines that arrive in the meantime are missed. Jumping to the bottom on open is the only way the panel is not stale.

The check for "are we at the bottom" allows a few pixels of slack. Fractional line heights and browser zoom can leave the scroll position slightly short of the end. Without the slack that would look like the user scrolled up, and the log would stop following for no reason.

## Why the diff is bigger than the fix

The same panel was written out three times: installing, repairing, and updating. The three copies were identical except for one word in the toggle label and where the lines came from. Fixing the scrolling once would have meant fixing it three times, so the three are now one `LogDetails` component.

The copy-diagnostics block had the same problem. It was a component in the startup screen and copy-pasted inline in the update screen. It is one component now.

`ActionButton` was a second button system sitting next to `ui/button.tsx`. It is now a `hero` size and a `muted` variant on the shared `Button`. I added `muted` instead of reusing the existing `secondary` variant because the two tokens are not the same: in one theme `--secondary` has a colour tint while `--muted` is plain grey. These buttons are grey, so `secondary` would have changed how they look.

The two screens drop 214 lines and add 23.

## Additional changes to look at

- The buttons on these screens now get focus rings. The old hand-written ones had none. This matters on a startup screen, where there may be nothing else showing where the keyboard focus is.
- They are 2px taller. The shared `Button` has `border border-transparent` and the old ones had no border.
- The diagnostics text box is now left-aligned. On the startup screen it was picking up `text-center` from a parent, so a long report was centred.

## Testing

`npm test`. The old detail-toggle test now checks the shared component. `tauri-log-follow.test.ts` covers the scroll decision: at the bottom, scrolled up, back at the bottom, sub-pixel gap, short log, and closed panel. `tsc` and `biome` are clean on the files I changed.