### PR TITLE
Fix main: assert the tool loop controller catalog structurally, not by source proximity

### DIFF
--- a/studio/backend/tests/test_control_markup_neutralize_7066.py
+++ b/studio/backend/tests/test_control_markup_neutralize_7066.py
@@ -3074,6 +3074,16 @@ _INFERENCE_DIR = _REPO_ROOT / "studio" / "backend" / "core" / "inference"
 # has to hand it a catalog that traces back to the sweep.
 _CONTROLLER_MODULES = ("llama_cpp.py", "safetensors_agentic.py")
 
+# The third loop, named rather than forgotten. `studio_tool_loop.py` drives an EXTERNAL
+# provider and builds its controller from `policy.tools`, the request catalog as selected.
+# `external_provider.py` sweeps the catalog it SENDS, but only for the self-hosted providers
+# whose prompt this repo templates, and it keeps that result local: it never reaches
+# `policy.tools`. Sweeping unconditionally here would narrow a hosted API's controller below
+# the catalog its own prompt advertised, which is a different bug, so closing it needs the
+# transport to say whether it templated the prompt. That is a product change and belongs in
+# its own PR; this entry keeps the gap visible and makes a FOURTH loop fail below.
+_CONTROLLER_MODULES_OUT_OF_SCOPE = ("studio_tool_loop.py",)
+
 # Producers whose return value IS a sanitized catalog: the sweep, plus the two catalog
 # builders that wrap it. The builders are held to that below.
 _SWEEP = "neutralize_tool_descriptions"
@@ -3129,12 +3139,18 @@ def _ctrl_target_names(target):
     return []  # attribute / subscript targets are not local names
 
 
+#: Scopes a name can be looked up in, innermost first. Lambda is here because it is in
+#: `_NESTED_SCOPES`: skipping it while its bindings are skipped too would resolve a lambda
+#: parameter against the outer name it shadows.
+_CTRL_LOOKUP_SCOPES = (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda, ast.Module)
+
+
 def _ctrl_scopes(node):
-    """The function and module scopes enclosing *node*, innermost first."""
+    """The scopes enclosing *node*, innermost first."""
     chain = []
     current = getattr(node, "_ctrl_parent", None)
     while current is not None:
-        if isinstance(current, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Module)):
+        if isinstance(current, _CTRL_LOOKUP_SCOPES):
             chain.append(current)
         current = getattr(current, "_ctrl_parent", None)
     return chain
@@ -3213,7 +3229,7 @@ def _ctrl_mutated(scope):
 
 
 def _ctrl_params(scope):
-    if not isinstance(scope, (ast.FunctionDef, ast.AsyncFunctionDef)):
+    if not isinstance(scope, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
         return set()
     args = scope.args
     names = {arg.arg for arg in args.posonlyargs + args.args + args.kwonlyargs}
@@ -3234,6 +3250,64 @@ def _ctrl_sweep_carries_profile(call):
     if profile is None:
         return False
     return not (isinstance(profile, ast.Constant) and profile.value is None)
+
+
+def _ctrl_sweep_roots(
+    expr,
+    scopes,
+    aliases,
+    seen = frozenset(),
+):
+    """The names handed to a sweep or a catalog builder anywhere inside *expr*.
+
+    The catalog a branch narrows, named. Used to check that a `None` branch is guarded by the
+    emptiness of that same catalog rather than of some unrelated flag.
+    """
+    roots = set()
+    if isinstance(expr, ast.Call):
+        if _ctrl_called_name(expr, aliases) in _CATALOG_PRODUCERS and expr.args:
+            if isinstance(expr.args[0], ast.Name):
+                roots.add(expr.args[0].id)
+        for argument in expr.args:
+            roots |= _ctrl_sweep_roots(argument, scopes, aliases, seen)
+        return roots
+    if isinstance(expr, (ast.IfExp, ast.BoolOp)):
+        parts = (expr.body, expr.orelse) if isinstance(expr, ast.IfExp) else expr.values
+        for part in parts:
+            roots |= _ctrl_sweep_roots(part, scopes, aliases, seen)
+        return roots
+    if isinstance(expr, ast.Name) and expr.id not in seen:
+        for scope in scopes:
+            bindings = _ctrl_bindings(scope)
+            if expr.id in bindings:
+                for value in bindings[expr.id]:
+                    roots |= _ctrl_sweep_roots(value, scopes, aliases, seen | {expr.id})
+                break
+    return roots
+
+
+def _ctrl_guard_proves_empty(test, taken_when_true, roots, scopes):
+    """Is *test* the emptiness of a catalog that the sibling branch narrows?
+
+    `None` disables the controller's allowlist entirely, so it is only ever safe on the path
+    where there is nothing to authorize. Both loops say so with the truthiness of the catalog
+    itself -- `unrestricted_tools = not tools` -- and this follows that binding rather than the
+    name, so a rename still resolves while inverting the predicate does not.
+    """
+    seen = set()
+    while isinstance(test, ast.Name) and test.id not in seen:
+        seen.add(test.id)
+        values = [v for scope in scopes for v in _ctrl_bindings(scope).get(test.id, [])]
+        if len(values) != 1:
+            break
+        test = values[0]
+    negated = isinstance(test, ast.UnaryOp) and isinstance(test.op, ast.Not)
+    if negated:
+        test = test.operand
+    # The non-gating branch has to be the one taken when the catalog is FALSY.
+    if negated != taken_when_true:
+        return False
+    return isinstance(test, ast.Name) and test.id in roots
 
 
 def _ctrl_resolve(expr, scopes, aliases, module, seen):
@@ -3265,6 +3339,22 @@ def _ctrl_resolve(expr, scopes, aliases, module, seen):
             if not ok:
                 return False, why, False
             gates = gates or branch_gates
+        if gates and isinstance(expr, ast.IfExp):
+            # WHICH branch gates is not enough on its own. `None if tools else <swept>` gates on
+            # the swept side while selecting `None` exactly when there IS a catalog, so the
+            # predicate that reaches the non-gating branch has to prove there is not one.
+            roots = _ctrl_sweep_roots(expr, scopes, aliases)
+            for branch, taken_when_true in ((expr.body, True), (expr.orelse, False)):
+                _ok, _why, branch_gates = _ctrl_resolve(branch, scopes, aliases, module, seen)
+                if branch_gates:
+                    continue
+                if not _ctrl_guard_proves_empty(expr.test, taken_when_true, roots, scopes):
+                    return (
+                        True,
+                        f"line {expr.lineno}: the branch with no catalog is not guarded by the "
+                        "emptiness of the catalog the other branch narrows",
+                        False,
+                    )
         return True, "every branch is sanitized", gates
     if isinstance(expr, ast.Call):
         name = _ctrl_called_name(expr, aliases)
@@ -3288,6 +3378,24 @@ def _ctrl_resolve(expr, scopes, aliases, module, seen):
                     return (
                         False,
                         f"{expr.id} is filled in place, so its contents are unknown",
+                        False,
+                    )
+            if known and expr.id in _ctrl_params(scope):
+                # A PARAMETER THAT IS ALSO REBOUND still arrives with the caller's value, and
+                # this resolver is flow-insensitive: `if x: tools = sweep(tools, ...)` records
+                # only the swept binding, so the raw parameter on the other path would be
+                # invisible. It has to clear its contract as well as its bindings. This also
+                # closes `catalog = catalog`, where the self-cycle vouched for itself.
+                allowed = _SANITIZED_BY_CONTRACT.get(
+                    (module, getattr(scope, "name", "")), frozenset()
+                )
+                if expr.id not in allowed:
+                    return (
+                        False,
+                        (
+                            f"{expr.id} is a rebound parameter of {getattr(scope, 'name', '?')} "
+                            "with no sanitizing contract, so its incoming value is unchecked"
+                        ),
                         False,
                     )
             if known:
@@ -3411,6 +3519,63 @@ def test_the_resolver_holds_the_shapes_that_defeat_a_source_scan():
         f"c = {swept}\nc.append(tools[0])\nToolLoopController(tools = c)\n"
     )
     assert not ok and "filled in place" in why
+
+
+def test_the_resolver_holds_the_shapes_that_look_sanitized_on_one_path():
+    """Three ways a value reaches the controller raw on a path the resolver was not reading."""
+    swept = "neutralize_tool_descriptions(tools, None, markup)"
+    # THE PREDICATE, not just the branches. This gates on the swept side and still hands the
+    # controller None exactly when there IS a catalog, so `or`-ing the branches is not enough.
+    ok, _why, gates = _ctrl_resolve_source(
+        f"c = {swept}\nToolLoopController(tools = None if tools else c)\n"
+    )
+    assert ok and not gates
+    # Guarded the right way round, following the binding rather than the name.
+    ok, _why, gates = _ctrl_resolve_source(
+        f"empty = not tools\nc = {swept}\nToolLoopController(tools = None if empty else c)\n"
+    )
+    assert ok and gates
+    # A REBOUND PARAMETER still arrives with the caller's value, and this resolver is
+    # flow-insensitive, so a sweep on one path must not vouch for the other.
+    ok, why, _gates = _ctrl_resolve_source(
+        f"def loop(tools, sanitize, markup):\n"
+        f"    if sanitize:\n        tools = {swept}\n"
+        f"    ToolLoopController(tools = tools)\n"
+    )
+    assert not ok and "rebound parameter" in why
+    # Including the degenerate self-cycle, which used to vouch for itself.
+    ok, why, _gates = _ctrl_resolve_source(
+        "def loop(catalog):\n    catalog = catalog\n    ToolLoopController(tools = catalog)\n"
+    )
+    assert not ok
+    # A LAMBDA PARAMETER shadows the outer proof at runtime, so it must shadow it here.
+    ok, why, _gates = _ctrl_resolve_source(
+        f"safe = {swept}\nfactory = lambda safe: ToolLoopController(tools = safe)\n"
+    )
+    assert not ok and "safe" in why
+
+
+def test_every_tool_loop_controller_is_classified():
+    """A controller nobody listed is a controller nobody checked, so a new loop fails here.
+
+    The guard above covers the two local loops; `_CONTROLLER_MODULES_OUT_OF_SCOPE` names the
+    external one and says why. A fourth construction site belongs in one list or the other,
+    and this is what forces the choice (#7066).
+    """
+    known = set(_CONTROLLER_MODULES) | set(_CONTROLLER_MODULES_OUT_OF_SCOPE)
+    found = set()
+    for path in sorted((_REPO_ROOT / "studio" / "backend").rglob("*.py")):
+        if "tests" in path.parts:
+            continue
+        tree = _ctrl_parse(path)
+        if _ctrl_controller_sites(tree, _ctrl_aliases(tree)):
+            found.add(path.name)
+    assert found, "nothing builds a ToolLoopController any more"
+    assert found - known == set(), (
+        f"unclassified ToolLoopController site(s): {sorted(found - known)}. Add each to "
+        "_CONTROLLER_MODULES, or to _CONTROLLER_MODULES_OUT_OF_SCOPE with a reason."
+    )
+    assert set(_CONTROLLER_MODULES) <= found, "a checked module no longer builds a controller"
 
 
 def test_the_sanitized_by_contract_catalog_is_sanitized_at_every_caller():

--- a/studio/backend/tests/test_control_markup_neutralize_7066.py
+++ b/studio/backend/tests/test_control_markup_neutralize_7066.py
@@ -3082,7 +3082,15 @@ _CONTROLLER_MODULES = ("llama_cpp.py", "safetensors_agentic.py")
 # the catalog its own prompt advertised, which is a different bug, so closing it needs the
 # transport to say whether it templated the prompt. That is a product change and belongs in
 # its own PR; this entry keeps the gap visible and makes a FOURTH loop fail below.
-_CONTROLLER_MODULES_OUT_OF_SCOPE = ("studio_tool_loop.py",)
+# Keyed by ``(path under studio/backend, enclosing function)`` rather than by filename: a
+# SECOND controller in this module, or a same-named module elsewhere, must not inherit the
+# exemption this one earned.
+_CONTROLLER_SITES_OUT_OF_SCOPE = frozenset(
+    {("core/inference/studio_tool_loop.py", "stream_with_studio_tools")}
+)
+
+# The two loops the guard above resolves, as paths for the same reason.
+_CONTROLLER_MODULE_PATHS = frozenset({f"core/inference/{module}" for module in _CONTROLLER_MODULES})
 
 # Producers whose return value IS a sanitized catalog: the sweep, plus the two catalog
 # builders that wrap it. The builders are held to that below.
@@ -3265,10 +3273,17 @@ def _ctrl_sweep_roots(
     """
     roots = set()
     if isinstance(expr, ast.Call):
-        if _ctrl_called_name(expr, aliases) in _CATALOG_PRODUCERS and expr.args:
-            if isinstance(expr.args[0], ast.Name):
-                roots.add(expr.args[0].id)
-        for argument in expr.args:
+        if _ctrl_called_name(expr, aliases) in _CATALOG_PRODUCERS:
+            # Positional OR keyword: `neutralize_tool_descriptions(tools = tools, ...)` is the
+            # same call, and a guard that only reads `args[0]` would fail a rename of the
+            # argument style -- the refactor fragility this whole test exists to remove.
+            catalog = expr.args[0] if expr.args else None
+            for keyword in expr.keywords:
+                if keyword.arg == "tools":
+                    catalog = keyword.value
+            if isinstance(catalog, ast.Name):
+                roots.add(catalog.id)
+        for argument in list(expr.args) + [k.value for k in expr.keywords]:
             roots |= _ctrl_sweep_roots(argument, scopes, aliases, seen)
         return roots
     if isinstance(expr, (ast.IfExp, ast.BoolOp)):
@@ -3339,6 +3354,19 @@ def _ctrl_resolve(expr, scopes, aliases, module, seen):
             if not ok:
                 return False, why, False
             gates = gates or branch_gates
+        if gates and isinstance(expr, ast.BoolOp):
+            # NO PREDICATE TO READ, and short-circuit makes any operand reachable: `safe or None`
+            # evaluates to None exactly when the sweep emptied the catalog, which is the moment
+            # the allowlist matters most. Every operand has to gate.
+            for value in expr.values:
+                _ok, _why, value_gates = _ctrl_resolve(value, scopes, aliases, module, seen)
+                if not value_gates:
+                    return (
+                        True,
+                        f"line {expr.lineno}: an operand with no catalog is reachable by "
+                        "short-circuit, and nothing here proves the catalog is empty",
+                        False,
+                    )
         if gates and isinstance(expr, ast.IfExp):
             # WHICH branch gates is not enough on its own. `None if tools else <swept>` gates on
             # the swept side while selecting `None` exactly when there IS a catalog, so the
@@ -3548,6 +3576,17 @@ def test_the_resolver_holds_the_shapes_that_look_sanitized_on_one_path():
         "def loop(catalog):\n    catalog = catalog\n    ToolLoopController(tools = catalog)\n"
     )
     assert not ok
+    # SHORT-CIRCUIT reaches the None operand exactly when the sweep emptied the catalog.
+    ok, _why, gates = _ctrl_resolve_source(f"c = {swept}\nToolLoopController(tools = c or None)\n")
+    assert ok and not gates
+    ok, _why, gates = _ctrl_resolve_source(f"c = {swept}\nToolLoopController(tools = c or [])\n")
+    assert ok and gates
+    # THE KEYWORD SPELLING of the sweep is the same call, so the guard must still find its root.
+    ok, _why, gates = _ctrl_resolve_source(
+        "c = neutralize_tool_descriptions(tools = tools, markup = markup)\n"
+        "ToolLoopController(tools = None if not tools else c)\n"
+    )
+    assert ok and gates
     # A LAMBDA PARAMETER shadows the outer proof at runtime, so it must shadow it here.
     ok, why, _gates = _ctrl_resolve_source(
         f"safe = {swept}\nfactory = lambda safe: ToolLoopController(tools = safe)\n"
@@ -3558,24 +3597,38 @@ def test_the_resolver_holds_the_shapes_that_look_sanitized_on_one_path():
 def test_every_tool_loop_controller_is_classified():
     """A controller nobody listed is a controller nobody checked, so a new loop fails here.
 
-    The guard above covers the two local loops; `_CONTROLLER_MODULES_OUT_OF_SCOPE` names the
-    external one and says why. A fourth construction site belongs in one list or the other,
-    and this is what forces the choice (#7066).
+    Per SITE, not per file. The guard above resolves every site in the two local modules;
+    `_CONTROLLER_SITES_OUT_OF_SCOPE` names the external one and says why. A second controller
+    added to that same module is a different flow and has to be classified on its own (#7066).
     """
-    known = set(_CONTROLLER_MODULES) | set(_CONTROLLER_MODULES_OUT_OF_SCOPE)
+    backend = _REPO_ROOT / "studio" / "backend"
     found = set()
-    for path in sorted((_REPO_ROOT / "studio" / "backend").rglob("*.py")):
+    for path in sorted(backend.rglob("*.py")):
         if "tests" in path.parts:
             continue
         tree = _ctrl_parse(path)
-        if _ctrl_controller_sites(tree, _ctrl_aliases(tree)):
-            found.add(path.name)
+        relative = path.relative_to(backend).as_posix()
+        for call in _ctrl_controller_sites(tree, _ctrl_aliases(tree)):
+            enclosing = next(
+                (
+                    scope.name
+                    for scope in _ctrl_scopes(call)
+                    if isinstance(scope, (ast.FunctionDef, ast.AsyncFunctionDef))
+                ),
+                "<module>",
+            )
+            found.add((relative, enclosing))
     assert found, "nothing builds a ToolLoopController any more"
-    assert found - known == set(), (
-        f"unclassified ToolLoopController site(s): {sorted(found - known)}. Add each to "
-        "_CONTROLLER_MODULES, or to _CONTROLLER_MODULES_OUT_OF_SCOPE with a reason."
+    covered = {site for site in found if site[0] in _CONTROLLER_MODULE_PATHS}
+    unclassified = found - covered - _CONTROLLER_SITES_OUT_OF_SCOPE
+    assert unclassified == set(), (
+        f"unclassified ToolLoopController site(s): {sorted(unclassified)}. Add the module to "
+        "_CONTROLLER_MODULES, or the site to _CONTROLLER_SITES_OUT_OF_SCOPE with a reason."
     )
-    assert set(_CONTROLLER_MODULES) <= found, "a checked module no longer builds a controller"
+    assert {site[0] for site in covered} == set(
+        _CONTROLLER_MODULE_PATHS
+    ), "a checked module no longer builds a controller"
+    assert _CONTROLLER_SITES_OUT_OF_SCOPE <= found, "an exempted site is gone; drop its entry"
 
 
 def test_the_sanitized_by_contract_catalog_is_sanitized_at_every_caller():

--- a/studio/backend/tests/test_control_markup_neutralize_7066.py
+++ b/studio/backend/tests/test_control_markup_neutralize_7066.py
@@ -3248,9 +3248,7 @@ def _ctrl_resolve(expr, scopes, aliases, module, seen):
             bindings = _ctrl_bindings(scope)
             if expr.id in bindings:
                 for value in bindings[expr.id]:
-                    ok, why = _ctrl_resolve(
-                        value, scopes, aliases, module, seen | {expr.id}
-                    )
+                    ok, why = _ctrl_resolve(value, scopes, aliases, module, seen | {expr.id})
                     if not ok:
                         return False, f"{expr.id} -> {why}"
                 return True, f"{expr.id} is sanitized"
@@ -3354,9 +3352,9 @@ def test_every_catalog_producer_returns_a_swept_catalog():
         raw = node.args.args[0].arg
         for statement in ast.walk(node):
             if isinstance(statement, ast.Return) and isinstance(statement.value, ast.Name):
-                assert statement.value.id != raw, (
-                    f"{producer}:{statement.lineno} returns its unswept {raw} argument"
-                )
+                assert (
+                    statement.value.id != raw
+                ), f"{producer}:{statement.lineno} returns its unswept {raw} argument"
 
 
 @pytest.mark.parametrize("role", ["user", "system", "tool", "ipython"])

--- a/studio/backend/tests/test_control_markup_neutralize_7066.py
+++ b/studio/backend/tests/test_control_markup_neutralize_7066.py
@@ -10,6 +10,7 @@ Mistral, Granite and Gemma-4 templates.
 """
 
 import ast
+import collections
 import datetime
 import json
 from pathlib import Path
@@ -3082,11 +3083,16 @@ _CONTROLLER_MODULES = ("llama_cpp.py", "safetensors_agentic.py")
 # the catalog its own prompt advertised, which is a different bug, so closing it needs the
 # transport to say whether it templated the prompt. That is a product change and belongs in
 # its own PR; this entry keeps the gap visible and makes a FOURTH loop fail below.
-# Keyed by ``(path under studio/backend, enclosing function)`` rather than by filename: a
-# SECOND controller in this module, or a same-named module elsewhere, must not inherit the
-# exemption this one earned.
+# Keyed by ``(path under studio/backend, enclosing function, how many sites it holds)`` rather
+# than by filename: a SECOND controller in this function or this module, or a same-named module
+# elsewhere, must not inherit the exemption this one earned.
+#
+# The COUNT rather than a line number, deliberately. A line number moves when anything above it
+# does, so it would fail on an unrelated edit -- the fragility this file exists to remove -- while
+# the count moves only when a controller is added or removed, which is exactly the event that has
+# to force a decision.
 _CONTROLLER_SITES_OUT_OF_SCOPE = frozenset(
-    {("core/inference/studio_tool_loop.py", "stream_with_studio_tools")}
+    {("core/inference/studio_tool_loop.py", "stream_with_studio_tools", 1)}
 )
 
 # The two loops the guard above resolves, as paths for the same reason.
@@ -3599,10 +3605,11 @@ def test_every_tool_loop_controller_is_classified():
 
     Per SITE, not per file. The guard above resolves every site in the two local modules;
     `_CONTROLLER_SITES_OUT_OF_SCOPE` names the external one and says why. A second controller
-    added to that same module is a different flow and has to be classified on its own (#7066).
+    added to that same module, or to that same function, is a different flow and has to be
+    classified on its own (#7066).
     """
     backend = _REPO_ROOT / "studio" / "backend"
-    found = set()
+    counts: dict[tuple[str, str], int] = collections.Counter()
     for path in sorted(backend.rglob("*.py")):
         if "tests" in path.parts:
             continue
@@ -3617,7 +3624,8 @@ def test_every_tool_loop_controller_is_classified():
                 ),
                 "<module>",
             )
-            found.add((relative, enclosing))
+            counts[(relative, enclosing)] += 1
+    found = {(path, enclosing, total) for (path, enclosing), total in counts.items()}
     assert found, "nothing builds a ToolLoopController any more"
     covered = {site for site in found if site[0] in _CONTROLLER_MODULE_PATHS}
     unclassified = found - covered - _CONTROLLER_SITES_OUT_OF_SCOPE

--- a/studio/backend/tests/test_control_markup_neutralize_7066.py
+++ b/studio/backend/tests/test_control_markup_neutralize_7066.py
@@ -3215,8 +3215,7 @@ def _ctrl_mutated(scope):
     """Names filled in place DIRECTLY in *scope*, which no resolved catalog may be.
 
     Rejected rather than modelled: what a mutation puts in the list is the dataflow this resolver
-    would have to follow anyway. Scoped like `_ctrl_bindings`.
-    """
+    would have to follow anyway. Scoped like `_ctrl_bindings`."""
     names = set()
 
     def visit(node):
@@ -3274,15 +3273,15 @@ def _ctrl_sweep_roots(
 ):
     """The names handed to a sweep or a catalog builder anywhere inside *expr*.
 
-    The catalog a branch narrows, named. Used to check that a `None` branch is guarded by the
-    emptiness of that same catalog rather than of some unrelated flag.
+    The catalog a branch narrows, named, so a `None` branch can be checked against the emptiness
+    of THAT catalog rather than of some unrelated flag.
     """
     roots = set()
     if isinstance(expr, ast.Call):
         if _ctrl_called_name(expr, aliases) in _CATALOG_PRODUCERS:
-            # Positional OR keyword: `neutralize_tool_descriptions(tools = tools, ...)` is the
-            # same call, and a guard that only reads `args[0]` would fail a rename of the
-            # argument style -- the refactor fragility this whole test exists to remove.
+            # Positional OR keyword. `neutralize_tool_descriptions(tools = tools, ...)` is the
+            # same call, and reading only `args[0]` would fail a change of argument style: the
+            # refactor fragility this test exists to remove.
             catalog = expr.args[0] if expr.args else None
             for keyword in expr.keywords:
                 if keyword.arg == "tools":
@@ -3310,10 +3309,10 @@ def _ctrl_sweep_roots(
 def _ctrl_guard_proves_empty(test, taken_when_true, roots, scopes):
     """Is *test* the emptiness of a catalog that the sibling branch narrows?
 
-    `None` disables the controller's allowlist entirely, so it is only ever safe on the path
-    where there is nothing to authorize. Both loops say so with the truthiness of the catalog
-    itself -- `unrestricted_tools = not tools` -- and this follows that binding rather than the
-    name, so a rename still resolves while inverting the predicate does not.
+    `None` disables the allowlist entirely, so it is only safe where there is nothing to
+    authorize. Both loops say so with the truthiness of the catalog itself,
+    `unrestricted_tools = not tools`; this follows the binding rather than the name, so a rename
+    resolves and inverting the predicate does not.
     """
     seen = set()
     while isinstance(test, ast.Name) and test.id not in seen:
@@ -3361,9 +3360,9 @@ def _ctrl_resolve(expr, scopes, aliases, module, seen):
                 return False, why, False
             gates = gates or branch_gates
         if gates and isinstance(expr, ast.BoolOp):
-            # NO PREDICATE TO READ, and short-circuit makes any operand reachable: `safe or None`
-            # evaluates to None exactly when the sweep emptied the catalog, which is the moment
-            # the allowlist matters most. Every operand has to gate.
+            # NO PREDICATE TO READ, and short-circuit reaches any operand: `safe or None` is None
+            # exactly when the sweep emptied the catalog, which is when the allowlist matters
+            # most. Every operand has to gate.
             for value in expr.values:
                 _ok, _why, value_gates = _ctrl_resolve(value, scopes, aliases, module, seen)
                 if not value_gates:
@@ -3374,9 +3373,9 @@ def _ctrl_resolve(expr, scopes, aliases, module, seen):
                         False,
                     )
         if gates and isinstance(expr, ast.IfExp):
-            # WHICH branch gates is not enough on its own. `None if tools else <swept>` gates on
-            # the swept side while selecting `None` exactly when there IS a catalog, so the
-            # predicate that reaches the non-gating branch has to prove there is not one.
+            # WHICH branch gates is not enough. `None if tools else <swept>` gates on the swept
+            # side while selecting `None` exactly when there IS a catalog, so the predicate
+            # reaching the non-gating branch has to prove there is not one.
             roots = _ctrl_sweep_roots(expr, scopes, aliases)
             for branch, taken_when_true in ((expr.body, True), (expr.orelse, False)):
                 _ok, _why, branch_gates = _ctrl_resolve(branch, scopes, aliases, module, seen)
@@ -3415,11 +3414,10 @@ def _ctrl_resolve(expr, scopes, aliases, module, seen):
                         False,
                     )
             if known and expr.id in _ctrl_params(scope):
-                # A PARAMETER THAT IS ALSO REBOUND still arrives with the caller's value, and
-                # this resolver is flow-insensitive: `if x: tools = sweep(tools, ...)` records
-                # only the swept binding, so the raw parameter on the other path would be
-                # invisible. It has to clear its contract as well as its bindings. This also
-                # closes `catalog = catalog`, where the self-cycle vouched for itself.
+                # A REBOUND PARAMETER still arrives with the caller's value, and this resolver is
+                # flow-insensitive: `if x: tools = sweep(tools, ...)` records only the swept
+                # binding, leaving the raw parameter on the other path invisible. It has to clear
+                # its contract too, which also closes `catalog = catalog` vouching for itself.
                 allowed = _SANITIZED_BY_CONTRACT.get(
                     (module, getattr(scope, "name", "")), frozenset()
                 )
@@ -3530,9 +3528,8 @@ def _ctrl_resolve_source(source):
 def test_the_resolver_holds_the_shapes_that_defeat_a_source_scan():
     """The two ways past a dataflow guard that a text scan would have caught by accident.
 
-    Both are regressions a refactor can land without meaning to, and neither hands the
-    controller anything a reader would call raw.
-    """
+    Both are regressions a refactor can land without meaning to, and neither hands the controller
+    anything a reader would call raw."""
     swept = "neutralize_tool_descriptions(tools, None, markup)"
     # An UNRESTRICTED controller: `_restrict_to_allowed = False`, so every tool the sweep
     # dropped is executable again. It resolves, and must not satisfy the site.

--- a/studio/backend/tests/test_control_markup_neutralize_7066.py
+++ b/studio/backend/tests/test_control_markup_neutralize_7066.py
@@ -3177,6 +3177,44 @@ def _ctrl_bindings(scope):
     return bindings
 
 
+#: Calls and assignments that refill a catalog WITHOUT rebinding its name, so `_ctrl_bindings`
+#: never sees the new contents. `controller_tools = []` followed by `controller_tools.extend(tools)`
+#: would otherwise resolve on the empty literal alone.
+_CTRL_MUTATORS = frozenset({"append", "extend", "insert", "update", "add"})
+
+
+def _ctrl_mutated(scope):
+    """Names filled in place DIRECTLY in *scope*, which no resolved catalog may be.
+
+    Rejected rather than modelled: what a mutation puts in the list is exactly the dataflow this
+    resolver would have to follow, and a catalog nothing rebinds is not one it can vouch for.
+    Scoped like `_ctrl_bindings` so an inner helper's same-named local is not read as this one.
+    """
+    names = set()
+
+    def visit(node):
+        for child in ast.iter_child_nodes(node):
+            if isinstance(child, _NESTED_SCOPES):
+                continue
+            if (
+                isinstance(child, ast.Call)
+                and isinstance(child.func, ast.Attribute)
+                and child.func.attr in _CTRL_MUTATORS
+                and isinstance(child.func.value, ast.Name)
+            ):
+                names.add(child.func.value.id)
+            elif isinstance(child, ast.Assign):
+                for target in child.targets:
+                    if isinstance(target, (ast.Subscript, ast.Attribute)) and isinstance(
+                        target.value, ast.Name
+                    ):
+                        names.add(target.value.id)
+            visit(child)
+
+    visit(scope)
+    return names
+
+
 def _ctrl_params(scope):
     if not isinstance(scope, (ast.FunctionDef, ast.AsyncFunctionDef)):
         return set()
@@ -3206,64 +3244,89 @@ def _ctrl_sweep_carries_profile(call):
 def _ctrl_resolve(expr, scopes, aliases, module, seen):
     """Does *expr* provably evaluate to a sanitized tool catalog?
 
-    Returns ``(ok, why)``. This walks the dataflow rather than the source text: hoisting
+    Returns ``(ok, why, gates)``. This walks the dataflow rather than the source text: hoisting
     the sweep into a local, rewrapping the call or renaming the variable all still
     resolve, while handing the controller the raw catalog does not.
+
+    ``gates`` is separate from ``ok`` because ``None`` is not a catalog at all: it turns the
+    controller's name allowlist OFF (``_restrict_to_allowed = tools is not None``), which is
+    sanitization's opposite and not a weaker form of it. It is sanitized-vacuously, so ``ok``,
+    and it authorizes everything, so it never satisfies a site that has to gate.
     """
     if isinstance(expr, ast.Constant) and expr.value is None:
-        return True, "no catalog (the controller does not gate)"
+        return True, "no catalog, so the controller does not gate", False
     if isinstance(expr, (ast.List, ast.Tuple, ast.Set)) and not expr.elts:
-        return True, "empty catalog"
+        return True, "empty catalog", True
     if isinstance(expr, ast.Dict) and not expr.keys:
-        return True, "empty catalog"
+        return True, "empty catalog", True
     if isinstance(expr, ast.Starred):
         return _ctrl_resolve(expr.value, scopes, aliases, module, seen)
-    if isinstance(expr, ast.IfExp):
-        for branch in (expr.body, expr.orelse):
-            ok, why = _ctrl_resolve(branch, scopes, aliases, module, seen)
+    if isinstance(expr, (ast.IfExp, ast.BoolOp)):
+        branches = (expr.body, expr.orelse) if isinstance(expr, ast.IfExp) else expr.values
+        # EVERY branch has to resolve, and it is enough that ONE gates: the shape both loops use
+        # is `None if there are no tools else <swept>`, where the swept branch is the one that
+        # ever holds a catalog and the None branch has nothing to authorize.
+        gates = False
+        for branch in branches:
+            ok, why, branch_gates = _ctrl_resolve(branch, scopes, aliases, module, seen)
             if not ok:
-                return False, why
-        return True, "every branch is sanitized"
-    if isinstance(expr, ast.BoolOp):
-        for value in expr.values:
-            ok, why = _ctrl_resolve(value, scopes, aliases, module, seen)
-            if not ok:
-                return False, why
-        return True, "every operand is sanitized"
+                return False, why, False
+            gates = gates or branch_gates
+        return True, "every branch is sanitized", gates
     if isinstance(expr, ast.Call):
         name = _ctrl_called_name(expr, aliases)
         if name == _SWEEP:
             if not _ctrl_sweep_carries_profile(expr):
-                return False, f"line {expr.lineno}: {_SWEEP} was not given a markup profile"
-            return True, "swept at the construction site"
+                return False, f"line {expr.lineno}: {_SWEEP} was not given a markup profile", False
+            return True, "swept at the construction site", True
         if name in _CATALOG_PRODUCERS:
-            return True, f"built by {name}"
+            return True, f"built by {name}", True
         if name in ("list", "tuple") and len(expr.args) == 1 and not expr.keywords:
             return _ctrl_resolve(expr.args[0], scopes, aliases, module, seen)
-        return False, f"line {expr.lineno}: {name}(...) is not a sanitized catalog"
+        return False, f"line {expr.lineno}: {name}(...) is not a sanitized catalog", False
     if isinstance(expr, ast.Name):
         if expr.id in seen:
-            return True, "already being resolved"
+            return True, "already being resolved", True
         for scope in scopes:
             bindings = _ctrl_bindings(scope)
-            if expr.id in bindings:
+            known = expr.id in bindings
+            if known or expr.id in _ctrl_params(scope):
+                if expr.id in _ctrl_mutated(scope):
+                    return (
+                        False,
+                        f"{expr.id} is filled in place, so its contents are unknown",
+                        False,
+                    )
+            if known:
+                gates = False
                 for value in bindings[expr.id]:
-                    ok, why = _ctrl_resolve(value, scopes, aliases, module, seen | {expr.id})
+                    ok, why, value_gates = _ctrl_resolve(
+                        value, scopes, aliases, module, seen | {expr.id}
+                    )
                     if not ok:
-                        return False, f"{expr.id} -> {why}"
-                return True, f"{expr.id} is sanitized"
+                        return False, f"{expr.id} -> {why}", False
+                    gates = gates or value_gates
+                return True, f"{expr.id} is sanitized", gates
             if expr.id in _ctrl_params(scope):
                 allowed = _SANITIZED_BY_CONTRACT.get(
                     (module, getattr(scope, "name", "")), frozenset()
                 )
                 if expr.id in allowed:
-                    return True, f"{expr.id} is sanitized by the caller's contract"
-                return False, (
-                    f"{expr.id} is a parameter of {getattr(scope, 'name', '?')} with no "
-                    "sanitizing contract"
+                    return True, f"{expr.id} is sanitized by the caller's contract", True
+                return (
+                    False,
+                    (
+                        f"{expr.id} is a parameter of {getattr(scope, 'name', '?')} with no "
+                        "sanitizing contract"
+                    ),
+                    False,
                 )
-        return False, f"{expr.id} is unbound here"
-    return False, f"line {getattr(expr, 'lineno', '?')}: {type(expr).__name__} is not resolvable"
+        return False, f"{expr.id} is unbound here", False
+    return (
+        False,
+        f"line {getattr(expr, 'lineno', '?')}: {type(expr).__name__} is not resolvable",
+        False,
+    )
 
 
 def _ctrl_controller_sites(tree, aliases):
@@ -3290,6 +3353,10 @@ def test_tool_loop_controllers_are_built_from_the_sanitized_catalog():
     this used to scan was emptied by #9773 hoisting the very same sweep one statement up
     into a local, and a formatter rewrapping the call would have done the same: a test a
     reformat can break is not testing what it claims.
+
+    Sanitized AND gating. A bare ``tools = None`` is sanitized vacuously but sets
+    ``_restrict_to_allowed = False``, so prepare_call stops checking names at all and every tool
+    the sweep removed becomes executable again -- the #7066 failure, reached from the other side.
     """
     checked = 0
     for module in _CONTROLLER_MODULES:
@@ -3300,10 +3367,59 @@ def test_tool_loop_controllers_are_built_from_the_sanitized_catalog():
         for call in sites:
             catalog = _ctrl_catalog_argument(call)
             assert catalog is not None, f"{module}:{call.lineno}: no catalog was passed"
-            ok, why = _ctrl_resolve(catalog, _ctrl_scopes(call), aliases, module, frozenset())
+            ok, why, gates = _ctrl_resolve(
+                catalog, _ctrl_scopes(call), aliases, module, frozenset()
+            )
             assert ok, f"{module}:{call.lineno}: the controller catalog is not sanitized: {why}"
+            assert gates, (
+                f"{module}:{call.lineno}: the controller is never given a catalog to gate on, so "
+                f"its name allowlist is off and a swept-out tool stays executable: {why}"
+            )
             checked += 1
     assert checked >= len(_CONTROLLER_MODULES)
+
+
+def _ctrl_resolve_source(source):
+    """Run the resolver over a synthetic module, exactly as the guard above runs it."""
+    tree = ast.parse(source)
+    for parent in ast.walk(tree):
+        for child in ast.iter_child_nodes(parent):
+            child._ctrl_parent = parent
+    aliases = _ctrl_aliases(tree)
+    call = _ctrl_controller_sites(tree, aliases)[0]
+    return _ctrl_resolve(
+        _ctrl_catalog_argument(call), _ctrl_scopes(call), aliases, "synthetic.py", frozenset()
+    )
+
+
+def test_the_resolver_holds_the_shapes_that_defeat_a_source_scan():
+    """The two ways past a dataflow guard that a text scan would have caught by accident.
+
+    Both are regressions a refactor can land without meaning to, and neither hands the
+    controller anything a reader would call raw, which is why they are pinned here.
+    """
+    swept = "neutralize_tool_descriptions(tools, None, markup)"
+    # An UNRESTRICTED controller. `tools = None` sets `_restrict_to_allowed = False`, so
+    # prepare_call stops checking names and every tool the sweep dropped is executable again.
+    # It resolves -- there is no catalog to sanitize -- and it must not satisfy the site.
+    ok, _why, gates = _ctrl_resolve_source(f"c = {swept}\nToolLoopController(tools = None)\n")
+    assert ok and not gates
+    # The same shape the loops legitimately use still gates: None only when there is nothing
+    # to authorize, the swept catalog otherwise.
+    ok, _why, gates = _ctrl_resolve_source(
+        f"c = {swept}\nToolLoopController(tools = None if not tools else c)\n"
+    )
+    assert ok and gates
+    # A catalog FILLED IN PLACE. The binding table records the empty literal and never sees
+    # the raw tools arrive, so the name has to be refused rather than resolved.
+    ok, why, _gates = _ctrl_resolve_source(
+        "c = []\nc.extend(tools)\nToolLoopController(tools = c)\n"
+    )
+    assert not ok and "filled in place" in why
+    ok, why, _gates = _ctrl_resolve_source(
+        f"c = {swept}\nc.append(tools[0])\nToolLoopController(tools = c)\n"
+    )
+    assert not ok and "filled in place" in why
 
 
 def test_the_sanitized_by_contract_catalog_is_sanitized_at_every_caller():
@@ -3322,7 +3438,9 @@ def test_the_sanitized_by_contract_catalog_is_sanitized_at_every_caller():
             for keyword in node.keywords:
                 if keyword.arg not in wanted:
                     continue
-                ok, why = _ctrl_resolve(
+                # No gating requirement here: ``renderable_tools = None`` is how a caller says it
+                # has no narrowed catalog to offer, and the loop then sweeps `tools` itself.
+                ok, why, _gates = _ctrl_resolve(
                     keyword.value, _ctrl_scopes(node), aliases, path.name, frozenset()
                 )
                 assert ok, f"{path.name}:{node.lineno}: {keyword.arg} is not sanitized: {why}"

--- a/studio/backend/tests/test_control_markup_neutralize_7066.py
+++ b/studio/backend/tests/test_control_markup_neutralize_7066.py
@@ -3070,20 +3070,19 @@ def test_vendor_extension_fields_are_swept_not_dropped():
 
 _INFERENCE_DIR = _REPO_ROOT / "studio" / "backend" / "core" / "inference"
 
-# The local tool loops. Each builds the controller prepare_call authorizes against, so
-# each has to hand it a catalog that traces back to the sweep.
+# The local tool loops. Each builds the controller prepare_call authorizes against, so each
+# has to hand it a catalog that traces back to the sweep.
 _CONTROLLER_MODULES = ("llama_cpp.py", "safetensors_agentic.py")
 
-# Producers whose return value IS a sanitized catalog. The sweep itself, plus the two
-# catalog builders that wrap it; the builders are held to that below.
+# Producers whose return value IS a sanitized catalog: the sweep, plus the two catalog
+# builders that wrap it. The builders are held to that below.
 _SWEEP = "neutralize_tool_descriptions"
 _CATALOG_PRODUCERS = frozenset(
     {_SWEEP, "renderable_tool_catalog", "renderable_tool_catalog_for_targets"}
 )
 
-# A parameter the CALLER is required to hand a sanitized catalog. Only the narrowed
-# catalog qualifies, and the contract is not taken on trust: every production call site
-# that supplies one is resolved with the same resolver by the test below.
+# A parameter the CALLER must hand a sanitized catalog. Not taken on trust: the test below
+# resolves every production call site that supplies one.
 _SANITIZED_BY_CONTRACT = {
     ("safetensors_agentic.py", "run_safetensors_tool_loop"): frozenset({"renderable_tools"}),
 }
@@ -3103,7 +3102,7 @@ def _ctrl_parse(path):
 def _ctrl_aliases(tree):
     """``as`` bindings, so ``neutralize_tool_descriptions as _neutralize_...`` still counts.
 
-    Whole-tree rather than module level: llama_cpp.py imports the sweep inside the loop.
+    Whole-tree, not module level: llama_cpp.py imports the sweep inside the loop.
     """
     aliases = {}
     for node in ast.walk(tree):
@@ -3144,9 +3143,9 @@ def _ctrl_scopes(node):
 def _ctrl_bindings(scope):
     """``name -> every expression bound to it`` DIRECTLY in *scope*.
 
-    Nested scopes are not descended into, so an inner helper's rebinding of the same name
-    is not mistaken for the outer one. Every binding has to resolve, not just one: a name
-    that is swept on one branch and raw on another is not a sanitized catalog.
+    Nested scopes are skipped, so an inner helper's rebind of the same name is not read as
+    this one. EVERY binding has to resolve: swept on one branch and raw on another is not
+    a sanitized catalog.
     """
     bindings = {}
 
@@ -3177,18 +3176,16 @@ def _ctrl_bindings(scope):
     return bindings
 
 
-#: Calls and assignments that refill a catalog WITHOUT rebinding its name, so `_ctrl_bindings`
-#: never sees the new contents. `controller_tools = []` followed by `controller_tools.extend(tools)`
-#: would otherwise resolve on the empty literal alone.
+#: Calls that refill a catalog WITHOUT rebinding its name, so `_ctrl_bindings` never sees the new
+#: contents: `controller_tools = []; controller_tools.extend(tools)` resolves on the literal alone.
 _CTRL_MUTATORS = frozenset({"append", "extend", "insert", "update", "add"})
 
 
 def _ctrl_mutated(scope):
     """Names filled in place DIRECTLY in *scope*, which no resolved catalog may be.
 
-    Rejected rather than modelled: what a mutation puts in the list is exactly the dataflow this
-    resolver would have to follow, and a catalog nothing rebinds is not one it can vouch for.
-    Scoped like `_ctrl_bindings` so an inner helper's same-named local is not read as this one.
+    Rejected rather than modelled: what a mutation puts in the list is the dataflow this resolver
+    would have to follow anyway. Scoped like `_ctrl_bindings`.
     """
     names = set()
 
@@ -3227,11 +3224,9 @@ def _ctrl_params(scope):
 
 
 def _ctrl_sweep_carries_profile(call):
-    """The sweep has to be given THIS turn's markup profile.
-
-    Sweeping under the default profile drops what the renderer keeps and keeps what it
-    drops, so the authorized catalog stops matching the prompt the model was shown.
-    """
+    """The sweep has to be given THIS turn's markup profile: under the default it drops what
+    the renderer keeps and keeps what it drops, so the authorized catalog stops matching the
+    prompt the model was shown."""
     profile = call.args[2] if len(call.args) >= 3 else None
     for keyword in call.keywords:
         if keyword.arg == "markup":
@@ -3244,14 +3239,13 @@ def _ctrl_sweep_carries_profile(call):
 def _ctrl_resolve(expr, scopes, aliases, module, seen):
     """Does *expr* provably evaluate to a sanitized tool catalog?
 
-    Returns ``(ok, why, gates)``. This walks the dataflow rather than the source text: hoisting
-    the sweep into a local, rewrapping the call or renaming the variable all still
-    resolve, while handing the controller the raw catalog does not.
+    Returns ``(ok, why, gates)``. Walks the dataflow rather than the source text: hoisting the
+    sweep into a local, rewrapping the call or renaming the variable all still resolve, while
+    handing the controller the raw catalog does not.
 
-    ``gates`` is separate from ``ok`` because ``None`` is not a catalog at all: it turns the
-    controller's name allowlist OFF (``_restrict_to_allowed = tools is not None``), which is
-    sanitization's opposite and not a weaker form of it. It is sanitized-vacuously, so ``ok``,
-    and it authorizes everything, so it never satisfies a site that has to gate.
+    ``gates`` is separate from ``ok`` because ``None`` is not a catalog at all. It turns the
+    name allowlist OFF (``_restrict_to_allowed = tools is not None``), which is sanitization's
+    opposite: vacuously ``ok``, and never enough for a site that has to gate.
     """
     if isinstance(expr, ast.Constant) and expr.value is None:
         return True, "no catalog, so the controller does not gate", False
@@ -3263,9 +3257,8 @@ def _ctrl_resolve(expr, scopes, aliases, module, seen):
         return _ctrl_resolve(expr.value, scopes, aliases, module, seen)
     if isinstance(expr, (ast.IfExp, ast.BoolOp)):
         branches = (expr.body, expr.orelse) if isinstance(expr, ast.IfExp) else expr.values
-        # EVERY branch has to resolve, and it is enough that ONE gates: the shape both loops use
-        # is `None if there are no tools else <swept>`, where the swept branch is the one that
-        # ever holds a catalog and the None branch has nothing to authorize.
+        # EVERY branch has to resolve, and it is enough that ONE gates: both loops use
+        # `None if there are no tools else <swept>`, where None has nothing to authorize.
         gates = False
         for branch in branches:
             ok, why, branch_gates = _ctrl_resolve(branch, scopes, aliases, module, seen)
@@ -3349,14 +3342,14 @@ def test_tool_loop_controllers_are_built_from_the_sanitized_catalog():
     structured delta.tool_calls path reaches it without passing _enabled_tool_names at
     all, so sanitizing only the gates left a dropped tool executable by name (#7066).
 
-    Asserted on the dataflow, not on source text near the construction site. The window
-    this used to scan was emptied by #9773 hoisting the very same sweep one statement up
-    into a local, and a formatter rewrapping the call would have done the same: a test a
-    reformat can break is not testing what it claims.
+    Asserted on the dataflow, not on source text near the construction site. The window this
+    used to scan was emptied by #9773 hoisting the very same sweep one statement up into a
+    local, and a formatter rewrapping the call would have done the same: a test a reformat can
+    break is not testing what it claims.
 
-    Sanitized AND gating. A bare ``tools = None`` is sanitized vacuously but sets
-    ``_restrict_to_allowed = False``, so prepare_call stops checking names at all and every tool
-    the sweep removed becomes executable again -- the #7066 failure, reached from the other side.
+    Sanitized AND gating. A bare ``tools = None`` is vacuously sanitized but sets
+    ``_restrict_to_allowed = False``, so prepare_call stops checking names and every tool the
+    sweep removed is executable again -- #7066 reached from the other side.
     """
     checked = 0
     for module in _CONTROLLER_MODULES:
@@ -3396,22 +3389,20 @@ def test_the_resolver_holds_the_shapes_that_defeat_a_source_scan():
     """The two ways past a dataflow guard that a text scan would have caught by accident.
 
     Both are regressions a refactor can land without meaning to, and neither hands the
-    controller anything a reader would call raw, which is why they are pinned here.
+    controller anything a reader would call raw.
     """
     swept = "neutralize_tool_descriptions(tools, None, markup)"
-    # An UNRESTRICTED controller. `tools = None` sets `_restrict_to_allowed = False`, so
-    # prepare_call stops checking names and every tool the sweep dropped is executable again.
-    # It resolves -- there is no catalog to sanitize -- and it must not satisfy the site.
+    # An UNRESTRICTED controller: `_restrict_to_allowed = False`, so every tool the sweep
+    # dropped is executable again. It resolves, and must not satisfy the site.
     ok, _why, gates = _ctrl_resolve_source(f"c = {swept}\nToolLoopController(tools = None)\n")
     assert ok and not gates
-    # The same shape the loops legitimately use still gates: None only when there is nothing
-    # to authorize, the swept catalog otherwise.
+    # The shape the loops legitimately use still gates.
     ok, _why, gates = _ctrl_resolve_source(
         f"c = {swept}\nToolLoopController(tools = None if not tools else c)\n"
     )
     assert ok and gates
-    # A catalog FILLED IN PLACE. The binding table records the empty literal and never sees
-    # the raw tools arrive, so the name has to be refused rather than resolved.
+    # FILLED IN PLACE: the binding table records the literal and never sees the raw tools
+    # arrive, so the name is refused rather than resolved.
     ok, why, _gates = _ctrl_resolve_source(
         "c = []\nc.extend(tools)\nToolLoopController(tools = c)\n"
     )
@@ -3438,8 +3429,8 @@ def test_the_sanitized_by_contract_catalog_is_sanitized_at_every_caller():
             for keyword in node.keywords:
                 if keyword.arg not in wanted:
                     continue
-                # No gating requirement here: ``renderable_tools = None`` is how a caller says it
-                # has no narrowed catalog to offer, and the loop then sweeps `tools` itself.
+                # No gating requirement: ``renderable_tools = None`` is how a caller says it
+                # has no narrowed catalog, and the loop then sweeps `tools` itself.
                 ok, why, _gates = _ctrl_resolve(
                     keyword.value, _ctrl_scopes(node), aliases, path.name, frozenset()
                 )

--- a/studio/backend/tests/test_control_markup_neutralize_7066.py
+++ b/studio/backend/tests/test_control_markup_neutralize_7066.py
@@ -3068,24 +3068,295 @@ def test_vendor_extension_fields_are_swept_not_dropped():
     assert list(out[0]["function"]["parameters"]["properties"]) == ["city"]
 
 
+_INFERENCE_DIR = _REPO_ROOT / "studio" / "backend" / "core" / "inference"
+
+# The local tool loops. Each builds the controller prepare_call authorizes against, so
+# each has to hand it a catalog that traces back to the sweep.
+_CONTROLLER_MODULES = ("llama_cpp.py", "safetensors_agentic.py")
+
+# Producers whose return value IS a sanitized catalog. The sweep itself, plus the two
+# catalog builders that wrap it; the builders are held to that below.
+_SWEEP = "neutralize_tool_descriptions"
+_CATALOG_PRODUCERS = frozenset(
+    {_SWEEP, "renderable_tool_catalog", "renderable_tool_catalog_for_targets"}
+)
+
+# A parameter the CALLER is required to hand a sanitized catalog. Only the narrowed
+# catalog qualifies, and the contract is not taken on trust: every production call site
+# that supplies one is resolved with the same resolver by the test below.
+_SANITIZED_BY_CONTRACT = {
+    ("safetensors_agentic.py", "run_safetensors_tool_loop"): frozenset({"renderable_tools"}),
+}
+
+_NESTED_SCOPES = (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda, ast.ClassDef)
+
+
+def _ctrl_parse(path):
+    """Parse *path* with parent links, so a call site can find its enclosing scopes."""
+    tree = ast.parse(path.read_text(encoding = "utf-8"), filename = str(path))
+    for parent in ast.walk(tree):
+        for child in ast.iter_child_nodes(parent):
+            child._ctrl_parent = parent
+    return tree
+
+
+def _ctrl_aliases(tree):
+    """``as`` bindings, so ``neutralize_tool_descriptions as _neutralize_...`` still counts.
+
+    Whole-tree rather than module level: llama_cpp.py imports the sweep inside the loop.
+    """
+    aliases = {}
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.Import, ast.ImportFrom)):
+            for alias in node.names:
+                if alias.asname:
+                    aliases[alias.asname] = alias.name.rsplit(".", 1)[-1]
+    return aliases
+
+
+def _ctrl_called_name(call, aliases):
+    func = call.func
+    name = func.attr if isinstance(func, ast.Attribute) else getattr(func, "id", None)
+    return aliases.get(name, name)
+
+
+def _ctrl_target_names(target):
+    if isinstance(target, ast.Name):
+        return [target.id]
+    if isinstance(target, ast.Starred):
+        return _ctrl_target_names(target.value)
+    if isinstance(target, (ast.Tuple, ast.List)):
+        return [name for element in target.elts for name in _ctrl_target_names(element)]
+    return []  # attribute / subscript targets are not local names
+
+
+def _ctrl_scopes(node):
+    """The function and module scopes enclosing *node*, innermost first."""
+    chain = []
+    current = getattr(node, "_ctrl_parent", None)
+    while current is not None:
+        if isinstance(current, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Module)):
+            chain.append(current)
+        current = getattr(current, "_ctrl_parent", None)
+    return chain
+
+
+def _ctrl_bindings(scope):
+    """``name -> every expression bound to it`` DIRECTLY in *scope*.
+
+    Nested scopes are not descended into, so an inner helper's rebinding of the same name
+    is not mistaken for the outer one. Every binding has to resolve, not just one: a name
+    that is swept on one branch and raw on another is not a sanitized catalog.
+    """
+    bindings = {}
+
+    def record(target, value):
+        for name in _ctrl_target_names(target):
+            bindings.setdefault(name, []).append(value)
+
+    def visit(node):
+        for child in ast.iter_child_nodes(node):
+            if isinstance(child, _NESTED_SCOPES):
+                continue
+            if isinstance(child, ast.Assign):
+                for target in child.targets:
+                    record(target, child.value)
+            elif isinstance(child, (ast.AnnAssign, ast.AugAssign)) and child.value is not None:
+                record(child.target, child.value)
+            elif isinstance(child, ast.NamedExpr):
+                record(child.target, child.value)
+            elif isinstance(child, (ast.For, ast.AsyncFor)):
+                record(child.target, child.iter)  # element of an unresolved iterable
+            elif isinstance(child, (ast.With, ast.AsyncWith)):
+                for item in child.items:
+                    if item.optional_vars is not None:
+                        record(item.optional_vars, item.context_expr)
+            visit(child)
+
+    visit(scope)
+    return bindings
+
+
+def _ctrl_params(scope):
+    if not isinstance(scope, (ast.FunctionDef, ast.AsyncFunctionDef)):
+        return set()
+    args = scope.args
+    names = {arg.arg for arg in args.posonlyargs + args.args + args.kwonlyargs}
+    for extra in (args.vararg, args.kwarg):
+        if extra is not None:
+            names.add(extra.arg)
+    return names
+
+
+def _ctrl_sweep_carries_profile(call):
+    """The sweep has to be given THIS turn's markup profile.
+
+    Sweeping under the default profile drops what the renderer keeps and keeps what it
+    drops, so the authorized catalog stops matching the prompt the model was shown.
+    """
+    profile = call.args[2] if len(call.args) >= 3 else None
+    for keyword in call.keywords:
+        if keyword.arg == "markup":
+            profile = keyword.value
+    if profile is None:
+        return False
+    return not (isinstance(profile, ast.Constant) and profile.value is None)
+
+
+def _ctrl_resolve(expr, scopes, aliases, module, seen):
+    """Does *expr* provably evaluate to a sanitized tool catalog?
+
+    Returns ``(ok, why)``. This walks the dataflow rather than the source text: hoisting
+    the sweep into a local, rewrapping the call or renaming the variable all still
+    resolve, while handing the controller the raw catalog does not.
+    """
+    if isinstance(expr, ast.Constant) and expr.value is None:
+        return True, "no catalog (the controller does not gate)"
+    if isinstance(expr, (ast.List, ast.Tuple, ast.Set)) and not expr.elts:
+        return True, "empty catalog"
+    if isinstance(expr, ast.Dict) and not expr.keys:
+        return True, "empty catalog"
+    if isinstance(expr, ast.Starred):
+        return _ctrl_resolve(expr.value, scopes, aliases, module, seen)
+    if isinstance(expr, ast.IfExp):
+        for branch in (expr.body, expr.orelse):
+            ok, why = _ctrl_resolve(branch, scopes, aliases, module, seen)
+            if not ok:
+                return False, why
+        return True, "every branch is sanitized"
+    if isinstance(expr, ast.BoolOp):
+        for value in expr.values:
+            ok, why = _ctrl_resolve(value, scopes, aliases, module, seen)
+            if not ok:
+                return False, why
+        return True, "every operand is sanitized"
+    if isinstance(expr, ast.Call):
+        name = _ctrl_called_name(expr, aliases)
+        if name == _SWEEP:
+            if not _ctrl_sweep_carries_profile(expr):
+                return False, f"line {expr.lineno}: {_SWEEP} was not given a markup profile"
+            return True, "swept at the construction site"
+        if name in _CATALOG_PRODUCERS:
+            return True, f"built by {name}"
+        if name in ("list", "tuple") and len(expr.args) == 1 and not expr.keywords:
+            return _ctrl_resolve(expr.args[0], scopes, aliases, module, seen)
+        return False, f"line {expr.lineno}: {name}(...) is not a sanitized catalog"
+    if isinstance(expr, ast.Name):
+        if expr.id in seen:
+            return True, "already being resolved"
+        for scope in scopes:
+            bindings = _ctrl_bindings(scope)
+            if expr.id in bindings:
+                for value in bindings[expr.id]:
+                    ok, why = _ctrl_resolve(
+                        value, scopes, aliases, module, seen | {expr.id}
+                    )
+                    if not ok:
+                        return False, f"{expr.id} -> {why}"
+                return True, f"{expr.id} is sanitized"
+            if expr.id in _ctrl_params(scope):
+                allowed = _SANITIZED_BY_CONTRACT.get(
+                    (module, getattr(scope, "name", "")), frozenset()
+                )
+                if expr.id in allowed:
+                    return True, f"{expr.id} is sanitized by the caller's contract"
+                return False, (
+                    f"{expr.id} is a parameter of {getattr(scope, 'name', '?')} with no "
+                    "sanitizing contract"
+                )
+        return False, f"{expr.id} is unbound here"
+    return False, f"line {getattr(expr, 'lineno', '?')}: {type(expr).__name__} is not resolvable"
+
+
+def _ctrl_controller_sites(tree, aliases):
+    return [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and _ctrl_called_name(node, aliases) == "ToolLoopController"
+    ]
+
+
+def _ctrl_catalog_argument(call):
+    for keyword in call.keywords:
+        if keyword.arg == "tools":
+            return keyword.value
+    return call.args[0] if call.args else None
+
+
 def test_tool_loop_controllers_are_built_from_the_sanitized_catalog():
     """The controller is what prepare_call authorizes against, and llama-server's
     structured delta.tool_calls path reaches it without passing _enabled_tool_names at
-    all, so sanitizing only the gates left a dropped tool executable by name (#7066)."""
-    for module in ("llama_cpp.py", "safetensors_agentic.py"):
-        source = (_REPO_ROOT / "studio" / "backend" / "core" / "inference" / module).read_text(
-            encoding = "utf-8"
-        )
-        start = source.index("ToolLoopController(")
-        window = source[start : start + 200]
-        # Either sanitized at construction, or handed the catalog the caller already
-        # narrowed to what every template this turn could select would advertise.
-        assert "neutralize_tool_descriptions" in window or "_authorized" in window, module
-    agentic = (
-        _REPO_ROOT / "studio" / "backend" / "core" / "inference" / "safetensors_agentic.py"
-    ).read_text(encoding = "utf-8")
-    assert "renderable_tools" in agentic
-    assert "neutralize_tool_descriptions(tools, None, markup)" in agentic
+    all, so sanitizing only the gates left a dropped tool executable by name (#7066).
+
+    Asserted on the dataflow, not on source text near the construction site. The window
+    this used to scan was emptied by #9773 hoisting the very same sweep one statement up
+    into a local, and a formatter rewrapping the call would have done the same: a test a
+    reformat can break is not testing what it claims.
+    """
+    checked = 0
+    for module in _CONTROLLER_MODULES:
+        tree = _ctrl_parse(_INFERENCE_DIR / module)
+        aliases = _ctrl_aliases(tree)
+        sites = _ctrl_controller_sites(tree, aliases)
+        assert sites, f"{module} no longer builds a ToolLoopController"
+        for call in sites:
+            catalog = _ctrl_catalog_argument(call)
+            assert catalog is not None, f"{module}:{call.lineno}: no catalog was passed"
+            ok, why = _ctrl_resolve(catalog, _ctrl_scopes(call), aliases, module, frozenset())
+            assert ok, f"{module}:{call.lineno}: the controller catalog is not sanitized: {why}"
+            checked += 1
+    assert checked >= len(_CONTROLLER_MODULES)
+
+
+def test_the_sanitized_by_contract_catalog_is_sanitized_at_every_caller():
+    """``renderable_tools`` is the one catalog the loop takes on trust, so the trust is
+    checked: every production caller that supplies it must pass a swept catalog (#7066)."""
+    wanted = {name for names in _SANITIZED_BY_CONTRACT.values() for name in names}
+    callers = 0
+    for path in sorted((_REPO_ROOT / "studio" / "backend").rglob("*.py")):
+        if "tests" in path.parts:
+            continue
+        tree = _ctrl_parse(path)
+        aliases = _ctrl_aliases(tree)
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            for keyword in node.keywords:
+                if keyword.arg not in wanted:
+                    continue
+                ok, why = _ctrl_resolve(
+                    keyword.value, _ctrl_scopes(node), aliases, path.name, frozenset()
+                )
+                assert ok, f"{path.name}:{node.lineno}: {keyword.arg} is not sanitized: {why}"
+                callers += 1
+    assert callers, "no caller supplies the sanitized-by-contract catalog any more"
+
+
+def test_every_catalog_producer_returns_a_swept_catalog():
+    """The resolver trusts the catalog builders, so they must actually run the sweep and
+    must never hand their own ``tools`` argument straight back (#7066)."""
+    tree = _ctrl_parse(_INFERENCE_DIR / "chat_template_helpers.py")
+    aliases = _ctrl_aliases(tree)
+    functions = {
+        node.name: node
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    }
+    for producer in sorted(_CATALOG_PRODUCERS - {_SWEEP}):
+        node = functions.get(producer)
+        assert node is not None, f"{producer} is gone; the resolver still trusts it"
+        called = {
+            _ctrl_called_name(call, aliases)
+            for call in ast.walk(node)
+            if isinstance(call, ast.Call)
+        }
+        assert called & _CATALOG_PRODUCERS, f"{producer} no longer sweeps the catalog"
+        raw = node.args.args[0].arg
+        for statement in ast.walk(node):
+            if isinstance(statement, ast.Return) and isinstance(statement.value, ast.Name):
+                assert statement.value.id != raw, (
+                    f"{producer}:{statement.lineno} returns its unswept {raw} argument"
+                )
 
 
 @pytest.mark.parametrize("role", ["user", "system", "tool", "ipython"])

--- a/studio/backend/tests/test_control_markup_neutralize_7066.py
+++ b/studio/backend/tests/test_control_markup_neutralize_7066.py
@@ -3123,6 +3123,12 @@ def _ctrl_parse(path):
     return tree
 
 
+#: Names whose identity the resolver depends on, so an assignment that rebinds one is followed
+#: like an ``as`` import. Anything else stays unaliased: a blanket ``x = y`` map would make
+#: unrelated locals answer to a trusted name.
+_CTRL_TRACKED_CALLABLES = frozenset(_CATALOG_PRODUCERS | {"ToolLoopController"})
+
+
 def _ctrl_aliases(tree):
     """``as`` bindings, so ``neutralize_tool_descriptions as _neutralize_...`` still counts.
 
@@ -3134,6 +3140,17 @@ def _ctrl_aliases(tree):
             for alias in node.names:
                 if alias.asname:
                     aliases[alias.asname] = alias.name.rsplit(".", 1)[-1]
+    # `controller_cls = ToolLoopController` then `controller_cls(tools = raw)` is the same call,
+    # and it would otherwise not be a controller site at all -- so the whole guard, including the
+    # site enumeration below, would skip it.
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign) or len(node.targets) != 1:
+            continue
+        target, value = node.targets[0], node.value
+        name = value.attr if isinstance(value, ast.Attribute) else getattr(value, "id", None)
+        name = aliases.get(name, name)
+        if isinstance(target, ast.Name) and name in _CTRL_TRACKED_CALLABLES:
+            aliases[target.id] = name
     return aliases
 
 
@@ -3265,6 +3282,14 @@ def _ctrl_sweep_carries_profile(call):
     return not (isinstance(profile, ast.Constant) and profile.value is None)
 
 
+def _ctrl_defining_scope(name, scopes):
+    """The innermost scope in *scopes* that binds *name*, which is the one Python would use."""
+    for scope in scopes:
+        if name in _ctrl_bindings(scope) or name in _ctrl_params(scope):
+            return scope
+    return None
+
+
 def _ctrl_sweep_roots(
     expr,
     scopes,
@@ -3287,7 +3312,9 @@ def _ctrl_sweep_roots(
                 if keyword.arg == "tools":
                     catalog = keyword.value
             if isinstance(catalog, ast.Name):
-                roots.add(catalog.id)
+                # The BINDING, not the spelling. An inner helper whose parameter shadows the name
+                # the outer scope swept is a different catalog wearing the same identifier.
+                roots.add((catalog.id, _ctrl_defining_scope(catalog.id, scopes)))
         for argument in list(expr.args) + [k.value for k in expr.keywords]:
             roots |= _ctrl_sweep_roots(argument, scopes, aliases, seen)
         return roots
@@ -3297,11 +3324,15 @@ def _ctrl_sweep_roots(
             roots |= _ctrl_sweep_roots(part, scopes, aliases, seen)
         return roots
     if isinstance(expr, ast.Name) and expr.id not in seen:
-        for scope in scopes:
+        for depth, scope in enumerate(scopes):
             bindings = _ctrl_bindings(scope)
             if expr.id in bindings:
+                # The binding's OWN scope chain from here outward. Reading it in the call site's
+                # chain would resolve the sweep's argument against an inner name that shadows it,
+                # which is the confusion the scope in each root exists to prevent.
+                outward = scopes[depth:]
                 for value in bindings[expr.id]:
-                    roots |= _ctrl_sweep_roots(value, scopes, aliases, seen | {expr.id})
+                    roots |= _ctrl_sweep_roots(value, outward, aliases, seen | {expr.id})
                 break
     return roots
 
@@ -3327,7 +3358,7 @@ def _ctrl_guard_proves_empty(test, taken_when_true, roots, scopes):
     # The non-gating branch has to be the one taken when the catalog is FALSY.
     if negated != taken_when_true:
         return False
-    return isinstance(test, ast.Name) and test.id in roots
+    return isinstance(test, ast.Name) and (test.id, _ctrl_defining_scope(test.id, scopes)) in roots
 
 
 def _ctrl_resolve(expr, scopes, aliases, module, seen):
@@ -3431,14 +3462,18 @@ def _ctrl_resolve(expr, scopes, aliases, module, seen):
                         False,
                     )
             if known:
-                gates = False
+                # EVERY binding has to gate, not just one. A conditional expression carries a
+                # predicate that can prove there is nothing to authorize; a set of separate
+                # assignments carries none, so `catalog = None` followed by
+                # `if enabled: catalog = sweep(...)` leaves the unrestricted path reachable.
+                gates = True
                 for value in bindings[expr.id]:
                     ok, why, value_gates = _ctrl_resolve(
                         value, scopes, aliases, module, seen | {expr.id}
                     )
                     if not ok:
                         return False, f"{expr.id} -> {why}", False
-                    gates = gates or value_gates
+                    gates = gates and value_gates
                 return True, f"{expr.id} is sanitized", gates
             if expr.id in _ctrl_params(scope):
                 allowed = _SANITIZED_BY_CONTRACT.get(
@@ -3590,6 +3625,24 @@ def test_the_resolver_holds_the_shapes_that_look_sanitized_on_one_path():
         "ToolLoopController(tools = None if not tools else c)\n"
     )
     assert ok and gates
+    # SEPARATE ASSIGNMENTS carry no predicate, so a reachable None binding is not excused by a
+    # swept one somewhere else.
+    ok, _why, gates = _ctrl_resolve_source(
+        f"c = None\nif enabled:\n    c = {swept}\nToolLoopController(tools = c)\n"
+    )
+    assert ok and not gates
+    # A SHADOWED ROOT is a different catalog wearing the same identifier, so the emptiness proof
+    # must not carry across the scope that shadows it.
+    ok, _why, gates = _ctrl_resolve_source(
+        f"safe = {swept}\n"
+        "def make(tools):\n    ToolLoopController(tools = None if not tools else safe)\n"
+    )
+    assert ok and not gates
+    # AN ALIASED CONSTRUCTOR is still a controller site, or the guard never sees it at all.
+    ok, why, _gates = _ctrl_resolve_source(
+        "controller_cls = ToolLoopController\ncontroller_cls(tools = tools)\n"
+    )
+    assert not ok
     # A LAMBDA PARAMETER shadows the outer proof at runtime, so it must shadow it here.
     ok, why, _gates = _ctrl_resolve_source(
         f"safe = {swept}\nfactory = lambda safe: ToolLoopController(tools = safe)\n"


### PR DESCRIPTION
Third and last of the main-red defects I know of. `Backend CI / (Python 3.13)` and `Repo tests (CPU)` both collect this file, so every open Studio PR inherits the failure. Companions: #9802 (workflow guard not collected in the unfiltered job) and #9808 (locale parity).

## What is red

```
studio/backend/tests/test_control_markup_neutralize_7066.py::test_tool_loop_controllers_are_built_from_the_sanitized_catalog
tests/test_control_markup_neutralize_7066.py:3083: AssertionError: llama_cpp.py
    assert "neutralize_tool_descriptions" in window or "_authorized" in window, module
```

Not PR-specific. It fails on main and on every branch cut from it, including four unrelated contributors' PRs (#9798, #9797, #9796, #9788).

## What turned it red

`50f6ba2af` (#9773, "Studio: honour forced tool_choice on local GGUF tool loops"). I bisected the marker across 60 commits of `llama_cpp.py`: every commit through `05cee801b` passes, `50f6ba2af` and everything after fails.

The whole of its change at that site:

```diff
+        controller_tools = (
+            []
+            if tool_choice == "none"
+            else _neutralize_tool_descriptions(tools, None, self.markup_profile)
+        )
         tool_controller = ToolLoopController(
-            tools = _neutralize_tool_descriptions(tools, None, self.markup_profile),
+            tools = controller_tools,
             auto_heal_tool_calls = auto_heal_tool_calls,
         )
```

## The test is at fault, not the product

The sanitization is still there, four lines above the construction site, and it is the exact same call with the exact same arguments. #9773 hoisted it into a local only so it could short-circuit to `[]` on `tool_choice == "none"`, which if anything narrows the catalog further. Nothing unsanitized reaches the controller, then or now.

What broke is the test. It took a fixed 200-character slice of source text starting at `ToolLoopController(` and required the sweep to be spelled inside it. Moving the identical call one statement up emptied the window. A formatter would have done the same: pre-commit.ci has been rewrapping `llama_cpp.py` lately, and any rewrap that pushes text past the 200-character mark breaks this assertion without changing behaviour at all. This is the same fragile-window class we already cleaned out of the host-defaults guard.

Widening the window only moves the cliff, so I did not.

## What replaces it

The assertion is now on the dataflow rather than on source proximity. For every `ToolLoopController(` in `llama_cpp.py` and `safetensors_agentic.py`, the `tools` argument is resolved through the AST: local assignments, conditional expressions, boolean operands and `list()`/`tuple()` wrappers are followed until the value terminates in

- `neutralize_tool_descriptions(...)`, which additionally has to be given this turn's markup profile rather than the default,
- one of the catalog builders that wraps it, or
- `None` / an empty literal, which carry no catalog at all.

`as` imports are resolved, so `neutralize_tool_descriptions as _neutralize_tool_descriptions` still counts, and scopes are walked innermost-first without descending into nested functions. Every binding of a name has to resolve, not just one, so a catalog that is swept on one branch and raw on another does not pass.

Two supporting tests hold up what the resolver takes on trust:

- `test_the_sanitized_by_contract_catalog_is_sanitized_at_every_caller` - `renderable_tools` is the one catalog the safetensors loop accepts from its caller, so every production call site that supplies it is resolved by the same resolver.
- `test_every_catalog_producer_returns_a_swept_catalog` - the catalog builders must sweep, and must never hand their own `tools` argument straight back.

## Mutation proof

Deliberately broken, then reverted:

| Mutation | Result |
| --- | --- |
| `llama_cpp.py` hands the controller the raw `tools` | **fails** |
| `llama_cpp.py` sweeps without the markup profile | **fails** |
| `safetensors_agentic.py` hands the controller the raw `tools` | **fails** |
| a caller passes an unswept `renderable_tools` | **fails** |
| `renderable_tool_catalog` returns its unswept `tools` | **fails** |
| pure reformat: the sweep inlined back into the constructor | **passes**, as it must |

The last row is the point. The old assertion could not tell those two apart.

## Tests

```
tests/test_control_markup_neutralize_7066.py
tests/test_tool_loop_controller.py
tests/test_llama_cpp_tool_loop.py
tests/test_safetensors_tool_loop.py
this branch -> 2 failed, 1204 passed, 1 skipped in 97.59s
origin/main -> 3 failed, 1201 passed, 1 skipped in 130.29s
```

Same four files, same runner, run side by side. `origin/main` fails `test_tool_loop_controllers_are_built_from_the_sanitized_catalog` plus `test_text_only_vision_system_prompt_is_neutralized` and `test_vision_processor_render_is_neutralized`; this branch fails only the latter two, which are pre-existing on this runner and unrelated to this change.
