### PR TITLE
Studio: Fix Copy preview link and Copy path failing in Safari

### DIFF
--- a/studio/frontend/src/config/env.ts
+++ b/studio/frontend/src/config/env.ts
@@ -251,7 +251,9 @@ export async function fetchDeviceType(options?: {
     if (usePlatformStore.getState().fetched || superseded()) {
       return usePlatformStore.getState().deviceType;
     }
-    forcedWritten = read || forcedWritten;
+    // Deliberately not advancing forcedWritten: this is the browser's guess, seeded so
+    // the chat-only guard has an answer on a cold start. A real reply still in flight
+    // must be allowed to replace it, whenever it lands.
     const deviceType = detectLocalPlatform();
     const chatOnly = deviceType === "mac";
     usePlatformStore.setState({ deviceType, chatOnly, fetched: false });

--- a/studio/frontend/src/config/env.ts
+++ b/studio/frontend/src/config/env.ts
@@ -202,12 +202,26 @@ export async function fetchDeviceType(options?: {
       );
       // Authed-only, so they ride with device_type on the same terms: an expired token
       // gets the unauthenticated body, which carries none of them, and nulling a live
-      // tunnel there leaves every copied preview link pointing at this machine.
-      const cloudflareUrl =
-        data.cloudflare_url ?? (keepPlatform ? previous.cloudflareUrl : null);
-      const serverUrl =
-        data.server_url ?? (keepPlatform ? previous.serverUrl : null);
-      const secure = data.secure ?? (keepPlatform ? previous.secure : false);
+      // tunnel there leaves every copied preview link pointing at this machine. Keyed on
+      // whether the field is THERE, not on whether it is null: health_check ships all
+      // three to an authed caller before it knows a device_type, so a null from one of
+      // those is a tunnel that stopped, and treating it as absent keeps a dead URL.
+      const authedFields = "cloudflare_url" in data;
+      const cloudflareUrl = authedFields
+        ? (data.cloudflare_url ?? null)
+        : keepPlatform
+          ? previous.cloudflareUrl
+          : null;
+      const serverUrl = authedFields
+        ? (data.server_url ?? null)
+        : keepPlatform
+          ? previous.serverUrl
+          : null;
+      const secure = authedFields
+        ? (data.secure ?? false)
+        : keepPlatform
+          ? previous.secure
+          : false;
       // Cache only a server-reported platform. Unauthenticated responses fall
       // back to the browser platform, which can differ from the host (WSL,
       // SSH); keeping fetched=false retries once a token exists.
@@ -228,9 +242,12 @@ export async function fetchDeviceType(options?: {
   } catch {
     // Backend not ready: use client-side detection so chat-only guard works
     // on initial load (important for macOS). Keep fetched=false so a later
-    // call retries against the backend. But a late non-forced failure must not
-    // wipe an authoritative platform that already resolved.
-    if (shouldKeepAuthoritativePlatform(options?.force) || superseded()) {
+    // call retries against the backend. But a failure carries no verdict, so it
+    // must not wipe an authoritative platform that already resolved -- forced or
+    // not. Forced reads recur (the sidebar's recovery poll, the History grid's
+    // link-base poll), and one dropped request would otherwise relabel a Linux
+    // host from the browser it is being viewed from until the next success.
+    if (usePlatformStore.getState().fetched || superseded()) {
       return usePlatformStore.getState().deviceType;
     }
     const deviceType = detectLocalPlatform();

--- a/studio/frontend/src/config/env.ts
+++ b/studio/frontend/src/config/env.ts
@@ -203,7 +203,13 @@ export async function fetchDeviceType(options?: {
         return previous.deviceType;
       }
       authoritativeReply = authoritativeReply || authed;
-      forcedWritten = read || forcedWritten;
+      // Only an authed reply orders the forced reads. An unauthenticated one is accepted
+      // here just to seed a cold start, and letting it take the mark would make it
+      // outrank an authenticated read still in flight -- the same way a failed read used
+      // to, one branch over.
+      if (authed) {
+        forcedWritten = read || forcedWritten;
+      }
       // A provisional reply omits device_type, so a forced refresh during the warm would
       // fall back to the browser platform and relabel a WSL, SSH or remote host as local,
       // changing model filtering, paths and install commands. Keep the server's answer.

--- a/studio/frontend/src/config/env.ts
+++ b/studio/frontend/src/config/env.ts
@@ -108,12 +108,18 @@ const HARDWARE_DETECT_POLL_MS = 200;
 // The bounded wait above is spent at most once per page load: see fetchDeviceType.
 let hardwareWaitSpent = false;
 
+// Forced reads bypass the cache and always write, so they race each other: a slow one
+// landing after a later one restores what that one replaced. Only the newest may write.
+let forcedRead = 0;
+
 // `force` re-reads /api/health even if cached, to pick up a late-arriving tunnel URL.
 export async function fetchDeviceType(options?: {
   force?: boolean;
 }): Promise<DeviceType> {
   const { fetched } = usePlatformStore.getState();
   if (fetched && !options?.force) return usePlatformStore.getState().deviceType;
+  const read = options?.force ? ++forcedRead : 0;
+  const superseded = () => read !== 0 && read !== forcedRead;
 
   try {
     // /api/health only reports the server's device_type to authed callers.
@@ -173,7 +179,7 @@ export async function fetchDeviceType(options?: {
       // later forced refresh already picked up device_type and the tunnel
       // fields; writing either would reset device type or null the tunnel
       // fields. Forced refreshes are explicit re-reads, so they still write.
-      if (shouldKeepAuthoritativePlatform(options?.force)) {
+      if (shouldKeepAuthoritativePlatform(options?.force) || superseded()) {
         return usePlatformStore.getState().deviceType;
       }
       const previous = usePlatformStore.getState();
@@ -194,6 +200,14 @@ export async function fetchDeviceType(options?: {
         data,
         previous,
       );
+      // Authed-only, so they ride with device_type on the same terms: an expired token
+      // gets the unauthenticated body, which carries none of them, and nulling a live
+      // tunnel there leaves every copied preview link pointing at this machine.
+      const cloudflareUrl =
+        data.cloudflare_url ?? (keepPlatform ? previous.cloudflareUrl : null);
+      const serverUrl =
+        data.server_url ?? (keepPlatform ? previous.serverUrl : null);
+      const secure = data.secure ?? (keepPlatform ? previous.secure : false);
       // Cache only a server-reported platform. Unauthenticated responses fall
       // back to the browser platform, which can differ from the host (WSL,
       // SSH); keeping fetched=false retries once a token exists.
@@ -203,9 +217,9 @@ export async function fetchDeviceType(options?: {
         chatOnly,
         chatOnlyReason,
         chatOnlyDetail,
-        cloudflareUrl: data.cloudflare_url ?? null,
-        serverUrl: data.server_url ?? null,
-        secure: data.secure ?? false,
+        cloudflareUrl,
+        serverUrl,
+        secure,
         fetched: data.device_type !== undefined || keepPlatform,
         detectionDeferred: isDetectionDeferred(data),
       });
@@ -216,7 +230,7 @@ export async function fetchDeviceType(options?: {
     // on initial load (important for macOS). Keep fetched=false so a later
     // call retries against the backend. But a late non-forced failure must not
     // wipe an authoritative platform that already resolved.
-    if (shouldKeepAuthoritativePlatform(options?.force)) {
+    if (shouldKeepAuthoritativePlatform(options?.force) || superseded()) {
       return usePlatformStore.getState().deviceType;
     }
     const deviceType = detectLocalPlatform();

--- a/studio/frontend/src/config/env.ts
+++ b/studio/frontend/src/config/env.ts
@@ -109,8 +109,16 @@ const HARDWARE_DETECT_POLL_MS = 200;
 let hardwareWaitSpent = false;
 
 // Forced reads bypass the cache and always write, so they race each other: a slow one
-// landing after a later one restores what that one replaced. Only the newest may write.
+// landing after a later one restores what that one replaced. Ordered on what has been
+// WRITTEN, not on what has been issued -- a later read that fails writes nothing, and
+// discarding an earlier success for it would throw away the only answer either got.
 let forcedRead = 0;
+let forcedWritten = 0;
+// Whether any reply has carried the authed-only fields yet. An unauthenticated body says
+// strictly less than one of those did, so once this is set it must not write over one.
+// Not `fetched`: the backend publishes the tunnel before the hardware verdict, so an
+// authed reply during detection leaves real URLs stored with `fetched` still false.
+let authoritativeReply = false;
 
 // `force` re-reads /api/health even if cached, to pick up a late-arriving tunnel URL.
 export async function fetchDeviceType(options?: {
@@ -119,7 +127,7 @@ export async function fetchDeviceType(options?: {
   const { fetched } = usePlatformStore.getState();
   if (fetched && !options?.force) return usePlatformStore.getState().deviceType;
   const read = options?.force ? ++forcedRead : 0;
-  const superseded = () => read !== 0 && read !== forcedRead;
+  const superseded = () => read !== 0 && read < forcedWritten;
 
   try {
     // /api/health only reports the server's device_type to authed callers.
@@ -186,13 +194,16 @@ export async function fetchDeviceType(options?: {
       // already refuses it for a non-forced read. A forced read is the same reply, so it
       // is refused too -- otherwise every poll made against an expired token walks a
       // measurement back to a browser guess.
+      const authed = "cloudflare_url" in data;
       if (
         shouldKeepAuthoritativePlatform(options?.force) ||
         superseded() ||
-        (!("cloudflare_url" in data) && previous.fetched)
+        (!authed && authoritativeReply)
       ) {
         return previous.deviceType;
       }
+      authoritativeReply = authoritativeReply || authed;
+      forcedWritten = read || forcedWritten;
       // A provisional reply omits device_type, so a forced refresh during the warm would
       // fall back to the browser platform and relabel a WSL, SSH or remote host as local,
       // changing model filtering, paths and install commands. Keep the server's answer.
@@ -240,6 +251,7 @@ export async function fetchDeviceType(options?: {
     if (usePlatformStore.getState().fetched || superseded()) {
       return usePlatformStore.getState().deviceType;
     }
+    forcedWritten = read || forcedWritten;
     const deviceType = detectLocalPlatform();
     const chatOnly = deviceType === "mac";
     usePlatformStore.setState({ deviceType, chatOnly, fetched: false });

--- a/studio/frontend/src/config/env.ts
+++ b/studio/frontend/src/config/env.ts
@@ -179,10 +179,20 @@ export async function fetchDeviceType(options?: {
       // later forced refresh already picked up device_type and the tunnel
       // fields; writing either would reset device type or null the tunnel
       // fields. Forced refreshes are explicit re-reads, so they still write.
-      if (shouldKeepAuthoritativePlatform(options?.force) || superseded()) {
-        return usePlatformStore.getState().deviceType;
-      }
       const previous = usePlatformStore.getState();
+      // The authed-only fields are all-or-nothing, so one of them says which body this is.
+      // An unauthenticated reply carries no device_type, no chat_only_reason and no
+      // tunnel: it can only ever say less than is already stored, and the guard above
+      // already refuses it for a non-forced read. A forced read is the same reply, so it
+      // is refused too -- otherwise every poll made against an expired token walks a
+      // measurement back to a browser guess.
+      if (
+        shouldKeepAuthoritativePlatform(options?.force) ||
+        superseded() ||
+        (!("cloudflare_url" in data) && previous.fetched)
+      ) {
+        return previous.deviceType;
+      }
       // A provisional reply omits device_type, so a forced refresh during the warm would
       // fall back to the browser platform and relabel a WSL, SSH or remote host as local,
       // changing model filtering, paths and install commands. Keep the server's answer.
@@ -200,28 +210,6 @@ export async function fetchDeviceType(options?: {
         data,
         previous,
       );
-      // Authed-only, so they ride with device_type on the same terms: an expired token
-      // gets the unauthenticated body, which carries none of them, and nulling a live
-      // tunnel there leaves every copied preview link pointing at this machine. Keyed on
-      // whether the field is THERE, not on whether it is null: health_check ships all
-      // three to an authed caller before it knows a device_type, so a null from one of
-      // those is a tunnel that stopped, and treating it as absent keeps a dead URL.
-      const authedFields = "cloudflare_url" in data;
-      const cloudflareUrl = authedFields
-        ? (data.cloudflare_url ?? null)
-        : keepPlatform
-          ? previous.cloudflareUrl
-          : null;
-      const serverUrl = authedFields
-        ? (data.server_url ?? null)
-        : keepPlatform
-          ? previous.serverUrl
-          : null;
-      const secure = authedFields
-        ? (data.secure ?? false)
-        : keepPlatform
-          ? previous.secure
-          : false;
       // Cache only a server-reported platform. Unauthenticated responses fall
       // back to the browser platform, which can differ from the host (WSL,
       // SSH); keeping fetched=false retries once a token exists.
@@ -231,9 +219,11 @@ export async function fetchDeviceType(options?: {
         chatOnly,
         chatOnlyReason,
         chatOnlyDetail,
-        cloudflareUrl,
-        serverUrl,
-        secure,
+        // An authed null is a tunnel that stopped, not a field the reply left out: only
+        // an unauthenticated body omits these, and that one no longer reaches here.
+        cloudflareUrl: data.cloudflare_url ?? null,
+        serverUrl: data.server_url ?? null,
+        secure: data.secure ?? false,
         fetched: data.device_type !== undefined || keepPlatform,
         detectionDeferred: isDetectionDeferred(data),
       });

--- a/studio/frontend/src/features/hub/catalog/gguf-download-card.tsx
+++ b/studio/frontend/src/features/hub/catalog/gguf-download-card.tsx
@@ -305,19 +305,36 @@ export function QuantOptionsMenu({
   useEffect(() => {
     pathKeyRef.current = pathKey;
   }, [pathKey]);
+  // Every resolve goes through here so the pointer, the open and a cold copy share one
+  // request: each call costs the backend a full scan of the Hugging Face caches.
+  const inFlightRef = useRef<{ key: string; path: Promise<string> } | null>(null);
+  const resolveCachedPath = useCallback((): Promise<string> => {
+    const live = inFlightRef.current;
+    if (live?.key === pathKey) {
+      return live.path;
+    }
+    const path = getCachedModelPath(repoId, quant)
+      .then(({ path: resolved }) => {
+        // The request for a quant we switched off can land last; it must not evict.
+        if (pathKeyRef.current === pathKey) {
+          cachedPathRef.current = { key: pathKey, path: resolved };
+        }
+        return resolved;
+      })
+      .finally(() => {
+        if (inFlightRef.current?.key === pathKey) {
+          inFlightRef.current = null;
+        }
+      });
+    inFlightRef.current = { key: pathKey, path };
+    return path;
+  }, [repoId, quant, pathKey]);
   const prefetchCachedPath = useCallback(() => {
     if (!downloaded || cachedPathRef.current?.key === pathKey) {
       return;
     }
-    getCachedModelPath(repoId, quant)
-      .then(({ path }) => {
-        // The request for a quant we switched off can land last; it must not evict.
-        if (pathKeyRef.current === pathKey) {
-          cachedPathRef.current = { key: pathKey, path };
-        }
-      })
-      .catch(() => undefined);
-  }, [downloaded, repoId, quant, pathKey]);
+    void resolveCachedPath().catch(() => undefined);
+  }, [downloaded, pathKey, resolveCachedPath]);
   // An inventory bump while the menu is open changes the key under it, and no pointer
   // or open event is coming to notice: prefetchCachedPath's identity moves with the
   // key, so this re-runs and the copy still finds a path waiting for it.
@@ -332,12 +349,7 @@ export function QuantOptionsMenu({
       // Safari drops the click's clipboard permission after any other await.
       const cached = cachedPathRef.current;
       const path =
-        cached?.key === pathKey
-          ? cached.path
-          : (await getCachedModelPath(repoId, quant)).path;
-      if (pathKeyRef.current === pathKey) {
-        cachedPathRef.current = { key: pathKey, path };
-      }
+        cached?.key === pathKey ? cached.path : await resolveCachedPath();
       if (await copyToClipboard(path)) {
         toast.success("Copied path");
       } else {
@@ -348,7 +360,7 @@ export function QuantOptionsMenu({
         err instanceof Error ? err.message : "Failed to resolve model path",
       );
     }
-  }, [repoId, quant, pathKey]);
+  }, [pathKey, resolveCachedPath]);
   const handleCopyId = useCallback(async () => {
     const id = quant ? `${repoId}:${quant}` : repoId;
     if (await copyToClipboard(id)) {

--- a/studio/frontend/src/features/hub/catalog/gguf-download-card.tsx
+++ b/studio/frontend/src/features/hub/catalog/gguf-download-card.tsx
@@ -344,6 +344,11 @@ export function QuantOptionsMenu({
         <button
           type="button"
           onClick={(e) => e.stopPropagation()}
+          // Reaching the menu item means passing over its trigger first, so start the
+          // path here rather than on open: the copy has to have it in hand, or the
+          // click awaits the fetch and Safari drops the clipboard permission again.
+          onPointerEnter={prefetchCachedPath}
+          onFocus={prefetchCachedPath}
           aria-label={`More options for ${label}`}
           className={cn(
             "inline-flex size-6 shrink-0 cursor-pointer items-center justify-center rounded-full",

--- a/studio/frontend/src/features/hub/catalog/gguf-download-card.tsx
+++ b/studio/frontend/src/features/hub/catalog/gguf-download-card.tsx
@@ -295,11 +295,9 @@ export function QuantOptionsMenu({
   const deviceType = usePlatformStore((s) => s.deviceType);
   const revealLabel =
     deviceType === "mac" ? "Reveal in Finder" : "Reveal in Folder";
-  // Keyed to the model it was fetched for: the run bar keeps one menu mounted and
-  // swaps repoId/quant under it, so an unkeyed cache copies the old quant's path.
+  // One menu stays mounted while the run bar swaps repoId/quant under it.
   const cachedPathRef = useRef<{ key: string; path: string } | null>(null);
   const pathKey = JSON.stringify([repoId, quant ?? null]);
-  // What the menu points at now, read by responses that outlive the switch.
   const pathKeyRef = useRef(pathKey);
   useEffect(() => {
     pathKeyRef.current = pathKey;
@@ -310,9 +308,7 @@ export function QuantOptionsMenu({
     }
     getCachedModelPath(repoId, quant)
       .then(({ path }) => {
-        // Switching quants leaves the old request in flight, and it can land last.
-        // Letting it evict the current entry costs the copy its cache hit, which is
-        // the awaited fetch and the lost clipboard activation all over again.
+        // The request for a quant we switched off can land last; it must not evict.
         if (pathKeyRef.current === pathKey) {
           cachedPathRef.current = { key: pathKey, path };
         }
@@ -356,9 +352,7 @@ export function QuantOptionsMenu({
         <button
           type="button"
           onClick={(e) => e.stopPropagation()}
-          // Reaching the menu item means passing over its trigger first, so start the
-          // path here rather than on open: the copy has to have it in hand, or the
-          // click awaits the fetch and Safari drops the clipboard permission again.
+          // The pointer crosses the trigger before the item, so start here, not on open.
           onPointerEnter={prefetchCachedPath}
           onFocus={prefetchCachedPath}
           aria-label={`More options for ${label}`}

--- a/studio/frontend/src/features/hub/catalog/gguf-download-card.tsx
+++ b/studio/frontend/src/features/hub/catalog/gguf-download-card.tsx
@@ -295,23 +295,29 @@ export function QuantOptionsMenu({
   const deviceType = usePlatformStore((s) => s.deviceType);
   const revealLabel =
     deviceType === "mac" ? "Reveal in Finder" : "Reveal in Folder";
-  const cachedPathRef = useRef<string | null>(null);
+  // Keyed to the model it was fetched for: the run bar keeps one menu mounted and
+  // swaps repoId/quant under it, so an unkeyed cache copies the old quant's path.
+  const cachedPathRef = useRef<{ key: string; path: string } | null>(null);
+  const pathKey = JSON.stringify([repoId, quant ?? null]);
   const prefetchCachedPath = useCallback(() => {
-    if (!downloaded || cachedPathRef.current) {
+    if (!downloaded || cachedPathRef.current?.key === pathKey) {
       return;
     }
     getCachedModelPath(repoId, quant)
       .then(({ path }) => {
-        cachedPathRef.current = path;
+        cachedPathRef.current = { key: pathKey, path };
       })
       .catch(() => undefined);
-  }, [downloaded, repoId, quant]);
+  }, [downloaded, repoId, quant, pathKey]);
   const handleCopyPath = useCallback(async () => {
     try {
       // Safari drops the click's clipboard permission after any other await.
+      const cached = cachedPathRef.current;
       const path =
-        cachedPathRef.current ?? (await getCachedModelPath(repoId, quant)).path;
-      cachedPathRef.current = path;
+        cached?.key === pathKey
+          ? cached.path
+          : (await getCachedModelPath(repoId, quant)).path;
+      cachedPathRef.current = { key: pathKey, path };
       if (await copyToClipboard(path)) {
         toast.success("Copied path");
       } else {
@@ -322,7 +328,7 @@ export function QuantOptionsMenu({
         err instanceof Error ? err.message : "Failed to resolve model path",
       );
     }
-  }, [repoId, quant]);
+  }, [repoId, quant, pathKey]);
   const handleCopyId = useCallback(async () => {
     const id = quant ? `${repoId}:${quant}` : repoId;
     if (await copyToClipboard(id)) {

--- a/studio/frontend/src/features/hub/catalog/gguf-download-card.tsx
+++ b/studio/frontend/src/features/hub/catalog/gguf-download-card.tsx
@@ -139,6 +139,12 @@ const FIT_BADGE: Record<GgufFitClass, FitBadgeMeta> = {
 // Long enough that crossing a catalog costs nothing, short enough to be over before the
 // menu has finished opening.
 const HOVER_PREFETCH_MS = 150;
+// How long a resolved path is trusted. The cache exists so the copy has it in hand
+// before Safari's click expires, not to stand in for the cache on disk: a CLI download
+// or a delete moves the snapshot without touching inventoryVersion, and the pre-cache
+// behaviour rescanned on every copy. Long enough to cover opening a menu and choosing
+// from it, short enough that a menu left open does not answer from another era.
+const CACHED_PATH_TTL_MS = 30000;
 const CHIP_BASE =
   "inline-flex h-5 shrink-0 items-center justify-center whitespace-nowrap rounded-full border px-2 text-ui-11p5 font-medium tabular-nums leading-3 shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]";
 const CHIP_DEFAULT =
@@ -302,7 +308,13 @@ export function QuantOptionsMenu({
     deviceType === "mac" ? "Reveal in Finder" : "Reveal in Folder";
   // One menu stays mounted while the run bar swaps repoId/quant under it, and while a
   // re-download moves the snapshot the old path pointed at.
-  const cachedPathRef = useRef<{ key: string; path: string } | null>(null);
+  const cachedPathRef = useRef<{ key: string; path: string; at: number } | null>(null);
+  const freshPath = (key: string): string | null => {
+    const entry = cachedPathRef.current;
+    return entry?.key === key && Date.now() - entry.at < CACHED_PATH_TTL_MS
+      ? entry.path
+      : null;
+  };
   const inventoryVersion = useInventoryVersion();
   const pathKey = JSON.stringify([repoId, quant ?? null, inventoryVersion]);
   const pathKeyRef = useRef(pathKey);
@@ -321,7 +333,7 @@ export function QuantOptionsMenu({
       .then(({ path: resolved }) => {
         // The request for a quant we switched off can land last; it must not evict.
         if (pathKeyRef.current === pathKey) {
-          cachedPathRef.current = { key: pathKey, path: resolved };
+          cachedPathRef.current = { key: pathKey, path: resolved, at: Date.now() };
         }
         return resolved;
       })
@@ -341,7 +353,7 @@ export function QuantOptionsMenu({
     }
   }, []);
   const prefetchCachedPath = useCallback(() => {
-    if (!downloaded || cachedPathRef.current?.key === pathKey) {
+    if (!downloaded || freshPath(pathKey) !== null) {
       return;
     }
     void resolveCachedPath().catch(() => undefined);
@@ -363,9 +375,7 @@ export function QuantOptionsMenu({
   const handleCopyPath = useCallback(async () => {
     try {
       // Safari drops the click's clipboard permission after any other await.
-      const cached = cachedPathRef.current;
-      const path =
-        cached?.key === pathKey ? cached.path : await resolveCachedPath();
+      const path = freshPath(pathKey) ?? (await resolveCachedPath());
       if (await copyToClipboard(path)) {
         toast.success("Copied path");
       } else {

--- a/studio/frontend/src/features/hub/catalog/gguf-download-card.tsx
+++ b/studio/frontend/src/features/hub/catalog/gguf-download-card.tsx
@@ -46,6 +46,7 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from "react";
 import {
@@ -294,9 +295,23 @@ export function QuantOptionsMenu({
   const deviceType = usePlatformStore((s) => s.deviceType);
   const revealLabel =
     deviceType === "mac" ? "Reveal in Finder" : "Reveal in Folder";
+  const cachedPathRef = useRef<string | null>(null);
+  const prefetchCachedPath = useCallback(() => {
+    if (!downloaded || cachedPathRef.current) {
+      return;
+    }
+    getCachedModelPath(repoId, quant)
+      .then(({ path }) => {
+        cachedPathRef.current = path;
+      })
+      .catch(() => undefined);
+  }, [downloaded, repoId, quant]);
   const handleCopyPath = useCallback(async () => {
     try {
-      const { path } = await getCachedModelPath(repoId, quant);
+      // Safari drops the click's clipboard permission after any other await.
+      const path =
+        cachedPathRef.current ?? (await getCachedModelPath(repoId, quant)).path;
+      cachedPathRef.current = path;
       if (await copyToClipboard(path)) {
         toast.success("Copied path");
       } else {
@@ -318,7 +333,7 @@ export function QuantOptionsMenu({
   }, [repoId, quant]);
 
   return (
-    <DropdownMenu>
+    <DropdownMenu onOpenChange={(open) => open && prefetchCachedPath()}>
       <DropdownMenuTrigger asChild={true}>
         <button
           type="button"

--- a/studio/frontend/src/features/hub/catalog/gguf-download-card.tsx
+++ b/studio/frontend/src/features/hub/catalog/gguf-download-card.tsx
@@ -299,13 +299,23 @@ export function QuantOptionsMenu({
   // swaps repoId/quant under it, so an unkeyed cache copies the old quant's path.
   const cachedPathRef = useRef<{ key: string; path: string } | null>(null);
   const pathKey = JSON.stringify([repoId, quant ?? null]);
+  // What the menu points at now, read by responses that outlive the switch.
+  const pathKeyRef = useRef(pathKey);
+  useEffect(() => {
+    pathKeyRef.current = pathKey;
+  }, [pathKey]);
   const prefetchCachedPath = useCallback(() => {
     if (!downloaded || cachedPathRef.current?.key === pathKey) {
       return;
     }
     getCachedModelPath(repoId, quant)
       .then(({ path }) => {
-        cachedPathRef.current = { key: pathKey, path };
+        // Switching quants leaves the old request in flight, and it can land last.
+        // Letting it evict the current entry costs the copy its cache hit, which is
+        // the awaited fetch and the lost clipboard activation all over again.
+        if (pathKeyRef.current === pathKey) {
+          cachedPathRef.current = { key: pathKey, path };
+        }
       })
       .catch(() => undefined);
   }, [downloaded, repoId, quant, pathKey]);
@@ -317,7 +327,9 @@ export function QuantOptionsMenu({
         cached?.key === pathKey
           ? cached.path
           : (await getCachedModelPath(repoId, quant)).path;
-      cachedPathRef.current = { key: pathKey, path };
+      if (pathKeyRef.current === pathKey) {
+        cachedPathRef.current = { key: pathKey, path };
+      }
       if (await copyToClipboard(path)) {
         toast.success("Copied path");
       } else {

--- a/studio/frontend/src/features/hub/catalog/gguf-download-card.tsx
+++ b/studio/frontend/src/features/hub/catalog/gguf-download-card.tsx
@@ -318,6 +318,15 @@ export function QuantOptionsMenu({
       })
       .catch(() => undefined);
   }, [downloaded, repoId, quant, pathKey]);
+  // An inventory bump while the menu is open changes the key under it, and no pointer
+  // or open event is coming to notice: prefetchCachedPath's identity moves with the
+  // key, so this re-runs and the copy still finds a path waiting for it.
+  const [menuOpen, setMenuOpen] = useState(false);
+  useEffect(() => {
+    if (menuOpen) {
+      prefetchCachedPath();
+    }
+  }, [menuOpen, prefetchCachedPath]);
   const handleCopyPath = useCallback(async () => {
     try {
       // Safari drops the click's clipboard permission after any other await.
@@ -350,7 +359,7 @@ export function QuantOptionsMenu({
   }, [repoId, quant]);
 
   return (
-    <DropdownMenu onOpenChange={(open) => open && prefetchCachedPath()}>
+    <DropdownMenu onOpenChange={setMenuOpen}>
       <DropdownMenuTrigger asChild={true}>
         <button
           type="button"

--- a/studio/frontend/src/features/hub/catalog/gguf-download-card.tsx
+++ b/studio/frontend/src/features/hub/catalog/gguf-download-card.tsx
@@ -74,6 +74,7 @@ import {
   normalizeGgufVariantIdentity,
 } from "../lib/model-identity";
 import { useHfTokenStore } from "../stores/hf-token-store";
+import { useInventoryVersion } from "../stores/inventory-events";
 import { DotTag } from "./dot-tag";
 import { DownloadStopIndicator } from "./download-cancel-indicator";
 import {
@@ -295,9 +296,11 @@ export function QuantOptionsMenu({
   const deviceType = usePlatformStore((s) => s.deviceType);
   const revealLabel =
     deviceType === "mac" ? "Reveal in Finder" : "Reveal in Folder";
-  // One menu stays mounted while the run bar swaps repoId/quant under it.
+  // One menu stays mounted while the run bar swaps repoId/quant under it, and while a
+  // re-download moves the snapshot the old path pointed at.
   const cachedPathRef = useRef<{ key: string; path: string } | null>(null);
-  const pathKey = JSON.stringify([repoId, quant ?? null]);
+  const inventoryVersion = useInventoryVersion();
+  const pathKey = JSON.stringify([repoId, quant ?? null, inventoryVersion]);
   const pathKeyRef = useRef(pathKey);
   useEffect(() => {
     pathKeyRef.current = pathKey;

--- a/studio/frontend/src/features/hub/catalog/gguf-download-card.tsx
+++ b/studio/frontend/src/features/hub/catalog/gguf-download-card.tsx
@@ -135,6 +135,10 @@ const FIT_BADGE: Record<GgufFitClass, FitBadgeMeta> = {
 };
 
 /** Chip styling matching the on-device list's StatChip, no icon. */
+// How long the pointer has to settle on the options button before its path is fetched.
+// Long enough that crossing a catalog costs nothing, short enough to be over before the
+// menu has finished opening.
+const HOVER_PREFETCH_MS = 150;
 const CHIP_BASE =
   "inline-flex h-5 shrink-0 items-center justify-center whitespace-nowrap rounded-full border px-2 text-ui-11p5 font-medium tabular-nums leading-3 shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]";
 const CHIP_DEFAULT =
@@ -329,12 +333,24 @@ export function QuantOptionsMenu({
     inFlightRef.current = { key: pathKey, path };
     return path;
   }, [repoId, quant, pathKey]);
+  const hoverTimerRef = useRef<number | null>(null);
+  const cancelPrefetch = useCallback(() => {
+    if (hoverTimerRef.current !== null) {
+      window.clearTimeout(hoverTimerRef.current);
+      hoverTimerRef.current = null;
+    }
+  }, []);
   const prefetchCachedPath = useCallback(() => {
     if (!downloaded || cachedPathRef.current?.key === pathKey) {
       return;
     }
     void resolveCachedPath().catch(() => undefined);
   }, [downloaded, pathKey, resolveCachedPath]);
+  const armPrefetch = useCallback(() => {
+    cancelPrefetch();
+    hoverTimerRef.current = window.setTimeout(prefetchCachedPath, HOVER_PREFETCH_MS);
+  }, [cancelPrefetch, prefetchCachedPath]);
+  useEffect(() => cancelPrefetch, [cancelPrefetch]);
   // An inventory bump while the menu is open changes the key under it, and no pointer
   // or open event is coming to notice: prefetchCachedPath's identity moves with the
   // key, so this re-runs and the copy still finds a path waiting for it.
@@ -376,8 +392,11 @@ export function QuantOptionsMenu({
         <button
           type="button"
           onClick={(e) => e.stopPropagation()}
-          // The pointer crosses the trigger before the item, so start here, not on open.
-          onPointerEnter={prefetchCachedPath}
+          // The pointer crosses the trigger before the item, so start here, not on open --
+          // but only once it settles: each resolve is a full scan of the Hugging Face
+          // caches, and a pointer crossing a full catalog would start one per card.
+          onPointerEnter={armPrefetch}
+          onPointerLeave={cancelPrefetch}
           onFocus={prefetchCachedPath}
           aria-label={`More options for ${label}`}
           className={cn(

--- a/studio/frontend/src/features/studio/history-card-grid.tsx
+++ b/studio/frontend/src/features/studio/history-card-grid.tsx
@@ -56,9 +56,7 @@ type StudioT = ReturnType<typeof useT>;
 
 const PAGE_SIZE = 12;
 const RUNNING_POLL_INTERVAL_MS = 5000;
-// How often the copy-link base is re-read while this grid is on screen. A forced
-// re-read is one GET: fetchDeviceType spends its hardware wait once per page load,
-// not per call.
+// One GET: fetchDeviceType spends its hardware wait once per page load, not per call.
 const LINK_BASE_POLL_MS = 15000;
 
 const statusBadge: Record<string, { className: string }> = {
@@ -257,16 +255,10 @@ export function HistoryCardGrid({
   const [manualFetchInFlight, setManualFetchInFlight] = useState(false);
   const { resumeTrainingRunFromHistory, startBlocked, stopRequested } =
     useTrainingActions();
-  // Copy-link base: Cloudflare tunnel > LAN host:port > origin. Nothing else re-reads
-  // /api/health once the platform verdict settles, so the base is kept fresh here and
-  // never in the click, where Safari drops the clipboard permission across an await.
-  //
-  // Polled rather than read once, because the tunnel URL both arrives and leaves on
-  // the backend's schedule. It is published only after DNS and a public probe --
-  // cloudflare_tunnel.py bounds those at 15s + 45s and retries once over HTTP/2 -- so
-  // a grid that mounted first holds null and would copy a link only this machine can
-  // open; and when cloudflared exits, or another client stops the tunnel, the stored
-  // URL is dead. Neither is corrected by the focus listener while this tab keeps focus.
+  // Copy-link base: Cloudflare tunnel > LAN host:port > origin. Never refreshed in the
+  // click -- Safari drops the clipboard permission across an await -- and nothing else
+  // re-reads /api/health once the verdict settles. Polled because the tunnel URL is
+  // published late (DNS, then a public probe) and can die without warning.
   useEffect(() => {
     const refreshLinkBase = () => {
       void fetchDeviceType({ force: true });

--- a/studio/frontend/src/features/studio/history-card-grid.tsx
+++ b/studio/frontend/src/features/studio/history-card-grid.tsx
@@ -14,7 +14,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Spinner } from "@/components/ui/spinner";
-import { fetchDeviceType, usePlatformStore } from "@/config/env";
+import { usePlatformStore } from "@/config/env";
 import { bumpInventoryVersion } from "@/features/hub";
 import type { TrainingRunSummary } from "@/features/training";
 import {
@@ -604,11 +604,6 @@ export function HistoryCardGrid({
                   className="absolute bottom-3 right-4 z-10 h-6 rounded-full px-2.5 text-ui-11 leading-none shadow-sm"
                   onClick={async (e) => {
                     e.stopPropagation();
-                    try {
-                      await fetchDeviceType({ force: true });
-                    } catch {
-                      // Fall back to the last known server URL or this origin.
-                    }
                     // Encode each segment but keep "/" so the /p route matches.
                     const ref = (run.preview_ref ?? "")
                       .split("/")

--- a/studio/frontend/src/features/studio/history-card-grid.tsx
+++ b/studio/frontend/src/features/studio/history-card-grid.tsx
@@ -56,13 +56,10 @@ type StudioT = ReturnType<typeof useT>;
 
 const PAGE_SIZE = 12;
 const RUNNING_POLL_INTERVAL_MS = 5000;
-// How the copy-link base recovers when the grid mounts inside the tunnel's startup
-// window. start_studio_tunnel waits up to 15s for a URL AFTER the port is bound, so
-// the first /api/health of a session can answer cloudflare_url null; these cover that
-// window and then stop, because a Studio launched without a tunnel never gets one and
-// must not be polled for the rest of the session.
-const LINK_BASE_RETRY_MS = 3000;
-const LINK_BASE_RETRIES = 10;
+// How often the copy-link base is re-read while this grid is on screen. A forced
+// re-read is one GET: fetchDeviceType spends its hardware wait once per page load,
+// not per call.
+const LINK_BASE_POLL_MS = 15000;
 
 const statusBadge: Record<string, { className: string }> = {
   completed: {
@@ -260,40 +257,28 @@ export function HistoryCardGrid({
   const [manualFetchInFlight, setManualFetchInFlight] = useState(false);
   const { resumeTrainingRunFromHistory, startBlocked, stopRequested } =
     useTrainingActions();
-  const cloudflareUrl = usePlatformStore((s) => s.cloudflareUrl);
   // Copy-link base: Cloudflare tunnel > LAN host:port > origin. Nothing else re-reads
-  // /api/health once the platform verdict settles, so the base is refreshed here and
+  // /api/health once the platform verdict settles, so the base is kept fresh here and
   // never in the click, where Safari drops the clipboard permission across an await.
-  // The focus listener is for a tunnel started or stopped somewhere else since.
+  //
+  // Polled rather than read once, because the tunnel URL both arrives and leaves on
+  // the backend's schedule. It is published only after DNS and a public probe --
+  // cloudflare_tunnel.py bounds those at 15s + 45s and retries once over HTTP/2 -- so
+  // a grid that mounted first holds null and would copy a link only this machine can
+  // open; and when cloudflared exits, or another client stops the tunnel, the stored
+  // URL is dead. Neither is corrected by the focus listener while this tab keeps focus.
   useEffect(() => {
     const refreshLinkBase = () => {
       void fetchDeviceType({ force: true });
     };
     refreshLinkBase();
+    const id = window.setInterval(refreshLinkBase, LINK_BASE_POLL_MS);
     window.addEventListener("focus", refreshLinkBase);
-    return () => window.removeEventListener("focus", refreshLinkBase);
+    return () => {
+      window.clearInterval(id);
+      window.removeEventListener("focus", refreshLinkBase);
+    };
   }, []);
-
-  // The one read above is not enough on its own: a grid that mounted while the launch
-  // tunnel was still resolving gets cloudflare_url null, and this tab is already
-  // focused, so no focus event is coming to correct it. Without this the button copies
-  // a link only this machine can open for the rest of the session. Bounded, and torn
-  // down by the re-run a landed URL triggers.
-  useEffect(() => {
-    if (cloudflareUrl !== null) {
-      return;
-    }
-    let left = LINK_BASE_RETRIES;
-    const id = window.setInterval(() => {
-      if (left <= 0) {
-        window.clearInterval(id);
-        return;
-      }
-      left -= 1;
-      void fetchDeviceType({ force: true });
-    }, LINK_BASE_RETRY_MS);
-    return () => window.clearInterval(id);
-  }, [cloudflareUrl]);
 
   const userControllerRef = useRef<AbortController | null>(null);
   const pollControllerRef = useRef<AbortController | null>(null);

--- a/studio/frontend/src/features/studio/history-card-grid.tsx
+++ b/studio/frontend/src/features/studio/history-card-grid.tsx
@@ -260,8 +260,17 @@ export function HistoryCardGrid({
   // re-reads /api/health once the verdict settles. Polled because the tunnel URL is
   // published late (DNS, then a public probe) and can die without warning.
   useEffect(() => {
+    // Skipped while one is outstanding: a forced read always writes the store, so a
+    // slow answer landing after a later one would put the old tunnel URL back.
+    let inFlight = false;
     const refreshLinkBase = () => {
-      void fetchDeviceType({ force: true });
+      if (inFlight) {
+        return;
+      }
+      inFlight = true;
+      void fetchDeviceType({ force: true }).finally(() => {
+        inFlight = false;
+      });
     };
     refreshLinkBase();
     const id = window.setInterval(refreshLinkBase, LINK_BASE_POLL_MS);

--- a/studio/frontend/src/features/studio/history-card-grid.tsx
+++ b/studio/frontend/src/features/studio/history-card-grid.tsx
@@ -56,6 +56,13 @@ type StudioT = ReturnType<typeof useT>;
 
 const PAGE_SIZE = 12;
 const RUNNING_POLL_INTERVAL_MS = 5000;
+// How the copy-link base recovers when the grid mounts inside the tunnel's startup
+// window. start_studio_tunnel waits up to 15s for a URL AFTER the port is bound, so
+// the first /api/health of a session can answer cloudflare_url null; these cover that
+// window and then stop, because a Studio launched without a tunnel never gets one and
+// must not be polled for the rest of the session.
+const LINK_BASE_RETRY_MS = 3000;
+const LINK_BASE_RETRIES = 10;
 
 const statusBadge: Record<string, { className: string }> = {
   completed: {
@@ -253,11 +260,11 @@ export function HistoryCardGrid({
   const [manualFetchInFlight, setManualFetchInFlight] = useState(false);
   const { resumeTrainingRunFromHistory, startBlocked, stopRequested } =
     useTrainingActions();
-  // Copy-link base: Cloudflare tunnel > LAN host:port > origin. The launch tunnel
-  // resolves while the server is already serving, and nothing re-reads /api/health
-  // once the platform verdict settles, so a page loaded during that window keeps a
-  // null tunnel URL and copies a link only this machine can open. Refresh here and
+  const cloudflareUrl = usePlatformStore((s) => s.cloudflareUrl);
+  // Copy-link base: Cloudflare tunnel > LAN host:port > origin. Nothing else re-reads
+  // /api/health once the platform verdict settles, so the base is refreshed here and
   // never in the click, where Safari drops the clipboard permission across an await.
+  // The focus listener is for a tunnel started or stopped somewhere else since.
   useEffect(() => {
     const refreshLinkBase = () => {
       void fetchDeviceType({ force: true });
@@ -266,6 +273,27 @@ export function HistoryCardGrid({
     window.addEventListener("focus", refreshLinkBase);
     return () => window.removeEventListener("focus", refreshLinkBase);
   }, []);
+
+  // The one read above is not enough on its own: a grid that mounted while the launch
+  // tunnel was still resolving gets cloudflare_url null, and this tab is already
+  // focused, so no focus event is coming to correct it. Without this the button copies
+  // a link only this machine can open for the rest of the session. Bounded, and torn
+  // down by the re-run a landed URL triggers.
+  useEffect(() => {
+    if (cloudflareUrl !== null) {
+      return;
+    }
+    let left = LINK_BASE_RETRIES;
+    const id = window.setInterval(() => {
+      if (left <= 0) {
+        window.clearInterval(id);
+        return;
+      }
+      left -= 1;
+      void fetchDeviceType({ force: true });
+    }, LINK_BASE_RETRY_MS);
+    return () => window.clearInterval(id);
+  }, [cloudflareUrl]);
 
   const userControllerRef = useRef<AbortController | null>(null);
   const pollControllerRef = useRef<AbortController | null>(null);

--- a/studio/frontend/src/features/studio/history-card-grid.tsx
+++ b/studio/frontend/src/features/studio/history-card-grid.tsx
@@ -14,7 +14,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Spinner } from "@/components/ui/spinner";
-import { usePlatformStore } from "@/config/env";
+import { fetchDeviceType, usePlatformStore } from "@/config/env";
 import { bumpInventoryVersion } from "@/features/hub";
 import type { TrainingRunSummary } from "@/features/training";
 import {
@@ -253,8 +253,19 @@ export function HistoryCardGrid({
   const [manualFetchInFlight, setManualFetchInFlight] = useState(false);
   const { resumeTrainingRunFromHistory, startBlocked, stopRequested } =
     useTrainingActions();
-  // Copy-link base: Cloudflare tunnel > LAN host:port > origin. The tunnel can now
-  // start and stop at any time, so refresh on click instead of polling at mount.
+  // Copy-link base: Cloudflare tunnel > LAN host:port > origin. The launch tunnel
+  // resolves while the server is already serving, and nothing re-reads /api/health
+  // once the platform verdict settles, so a page loaded during that window keeps a
+  // null tunnel URL and copies a link only this machine can open. Refresh here and
+  // never in the click, where Safari drops the clipboard permission across an await.
+  useEffect(() => {
+    const refreshLinkBase = () => {
+      void fetchDeviceType({ force: true });
+    };
+    refreshLinkBase();
+    window.addEventListener("focus", refreshLinkBase);
+    return () => window.removeEventListener("focus", refreshLinkBase);
+  }, []);
 
   const userControllerRef = useRef<AbortController | null>(null);
   const pollControllerRef = useRef<AbortController | null>(null);

--- a/studio/frontend/src/features/studio/history-card-grid.tsx
+++ b/studio/frontend/src/features/studio/history-card-grid.tsx
@@ -58,6 +58,8 @@ const PAGE_SIZE = 12;
 const RUNNING_POLL_INTERVAL_MS = 5000;
 // One GET: fetchDeviceType spends its hardware wait once per page load, not per call.
 const LINK_BASE_POLL_MS = 15000;
+// When a read is written off as stalled and a fresh one may take the guard.
+const LINK_BASE_STALL_MS = 30000;
 
 const statusBadge: Record<string, { className: string }> = {
   completed: {
@@ -261,15 +263,22 @@ export function HistoryCardGrid({
   // published late (DNS, then a public probe) and can die without warning.
   useEffect(() => {
     // Skipped while one is outstanding: a forced read always writes the store, so a
-    // slow answer landing after a later one would put the old tunnel URL back.
-    let inFlight = false;
+    // slow answer landing after a later one would put the old tunnel URL back. Bounded
+    // the way the sidebar's poll bounds its own, because fetchDeviceType has no timeout
+    // and a read that never settles would otherwise hold the guard for good. Only the
+    // owner clears it, or an abandoned read would free a guard it no longer holds.
+    let pollingSince = 0;
+    let pollOwner = 0;
     const refreshLinkBase = () => {
-      if (inFlight) {
+      if (pollingSince && Date.now() - pollingSince < LINK_BASE_STALL_MS) {
         return;
       }
-      inFlight = true;
+      const owned = ++pollOwner;
+      pollingSince = Date.now();
       void fetchDeviceType({ force: true }).finally(() => {
-        inFlight = false;
+        if (owned === pollOwner) {
+          pollingSince = 0;
+        }
       });
     };
     refreshLinkBase();

--- a/studio/frontend/tests/clipboard-user-gesture.test.ts
+++ b/studio/frontend/tests/clipboard-user-gesture.test.ts
@@ -80,12 +80,21 @@ test("the prefetched model path is keyed to the model it was fetched for", () =>
     "the cache key must cover repoId and quant",
   );
   assert.ok(
-    PREFETCH_PATH.includes("cachedPathRef.current?.key === pathKey"),
+    PREFETCH_PATH.includes("freshPath(pathKey) !== null"),
     "the guard must miss once the menu moved to another model",
   );
   assert.match(
     GGUF,
-    /cachedPathRef\.current = \{ key: pathKey, path: resolved \}/,
+    /entry\?\.key === key && Date\.now\(\) - entry\.at < CACHED_PATH_TTL_MS/,
+    "a CLI download or a delete moves the snapshot without touching inventoryVersion",
+  );
+  assert.ok(
+    COPY_PATH.includes("freshPath(pathKey) ??"),
+    "the copy must not answer from an entry the prefetch would already have replaced",
+  );
+  assert.match(
+    GGUF,
+    /cachedPathRef\.current = \{ key: pathKey, path: resolved, at: Date\.now\(\) \}/,
   );
 });
 
@@ -178,9 +187,8 @@ test("copy path never serves another model's cached path", () => {
     !/cachedPathRef\.current \?\?/.test(COPY_PATH),
     "an unkeyed fallback copies whatever was fetched last",
   );
-  assert.ok(COPY_PATH.includes("cached?.key === pathKey"));
   assert.ok(
-    COPY_PATH.includes("? cached.path"),
+    COPY_PATH.includes("freshPath(pathKey) ?? (await resolveCachedPath())"),
     "a warm cache must skip the fetch, or the await loses the gesture",
   );
 });

--- a/studio/frontend/tests/clipboard-user-gesture.test.ts
+++ b/studio/frontend/tests/clipboard-user-gesture.test.ts
@@ -77,7 +77,7 @@ test("the prefetched model path is keyed to the model it was fetched for", () =>
   assert.match(
     GGUF,
     /const pathKey = [^\n]*repoId[^\n]*quant/,
-    "the cache key must cover both repoId and quant",
+    "the cache key must cover repoId and quant",
   );
   assert.ok(
     PREFETCH_PATH.includes("cachedPathRef.current?.key === pathKey"),
@@ -100,6 +100,25 @@ test("the link base is kept fresh for as long as the grid is on screen", () => {
     !COPY_PREVIEW.includes("setInterval") &&
       !COPY_PREVIEW.includes("fetchDeviceType"),
     "the refresh belongs outside the click",
+  );
+});
+
+test("refreshes do not stack when /api/health is slow", () => {
+  const effect = block(
+    HISTORY,
+    HISTORY.indexOf("const refreshLinkBase = () => {"),
+  );
+  assert.ok(
+    effect.includes("if (inFlight)"),
+    "a forced read always writes, so a slow answer would restore the old URL",
+  );
+});
+
+test("the cached path is dropped when the inventory moves", () => {
+  assert.match(
+    GGUF,
+    /const pathKey = [^\n]*inventoryVersion/,
+    "a re-download moves the snapshot the cached path points at",
   );
 });
 

--- a/studio/frontend/tests/clipboard-user-gesture.test.ts
+++ b/studio/frontend/tests/clipboard-user-gesture.test.ts
@@ -1,22 +1,9 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-// Safari only allows a clipboard write while the click that asked for it is still
-// live, so both copy buttons have to have their text ready before the handler runs.
-// The two ways that breaks:
-//
-//   1. Anything awaited ahead of the write. The write is then rejected and the user
-//      gets "Couldn't copy the link" -- no await may precede copyToClipboard.
-//   2. Prefetching the text without keying it to what is on screen. The run bar keeps
-//      one QuantOptionsMenu mounted and swaps repoId/quant under it, so an unkeyed
-//      cache silently copies the previously selected quant's path.
-//   3. Prefetching once and never again. The tunnel URL arrives on the backend's
-//      schedule (published only after DNS and a public probe) and can leave the same
-//      way, so a single read leaves the store holding null, or a dead hostname, for
-//      the rest of the session -- and the click can no longer correct it.
-//   4. Letting a stale response win. A prefetch for the quant the menu just moved off
-//      can land last; if it evicts the current entry the copy is back to awaiting a
-//      fetch inside the click.
+// Safari only honours a clipboard write while the click that asked for it is still
+// live, so both copy buttons must have their text in hand before the handler runs.
+// Each test below pins one way that breaks.
 //
 // Read from the source: the node suite has no DOM to click in.
 
@@ -31,7 +18,7 @@ function read(path: string): string {
 const HISTORY = read("features/studio/history-card-grid.tsx");
 const GGUF = read("features/hub/catalog/gguf-download-card.tsx");
 
-/** The braced block that starts at `from`, matched to its close. */
+/** The braced block opening after `from`, matched to its close. */
 function block(source: string, from: number): string {
   const open = source.indexOf("{", from);
   assert.notEqual(open, -1, "no block at anchor");
@@ -81,7 +68,7 @@ test("the preview link base is refreshed outside the click", () => {
   );
   assert.ok(
     HISTORY.includes("fetchDeviceType({ force: true })"),
-    "without a forced re-read the tunnel URL never lands and the link stays local",
+    "without a forced re-read the link stays local",
   );
   assert.ok(HISTORY.includes('window.addEventListener("focus"'));
 });
@@ -94,7 +81,7 @@ test("the prefetched model path is keyed to the model it was fetched for", () =>
   );
   assert.ok(
     PREFETCH_PATH.includes("cachedPathRef.current?.key === pathKey"),
-    "the prefetch guard must miss when the menu now points at another model",
+    "the guard must miss once the menu moved to another model",
   );
   assert.ok(PREFETCH_PATH.includes("{ key: pathKey, path }"));
 });
@@ -103,11 +90,11 @@ test("the link base is kept fresh for as long as the grid is on screen", () => {
   assert.match(
     HISTORY,
     /setInterval\(refreshLinkBase, LINK_BASE_POLL_MS\)/,
-    "one read cannot see a tunnel that is published late, or one that dies",
+    "one read misses a tunnel published late, or one that dies",
   );
   assert.ok(
     !/cloudflareUrl !== null/.test(HISTORY),
-    "a cached URL is not a reason to stop: it is exactly what goes stale",
+    "a cached URL is exactly what goes stale",
   );
   assert.ok(
     !COPY_PREVIEW.includes("setInterval") &&
@@ -133,7 +120,7 @@ test("the model path starts resolving before the menu item is reachable", () => 
   );
   assert.ok(
     trigger.includes("onPointerEnter={prefetchCachedPath}"),
-    "waiting for the menu to open leaves the copy click awaiting the fetch",
+    "on open is too late: the click would await the fetch",
   );
   assert.ok(trigger.includes("onFocus={prefetchCachedPath}"));
 });

--- a/studio/frontend/tests/clipboard-user-gesture.test.ts
+++ b/studio/frontend/tests/clipboard-user-gesture.test.ts
@@ -109,8 +109,12 @@ test("refreshes do not stack when /api/health is slow", () => {
     HISTORY.indexOf("const refreshLinkBase = () => {"),
   );
   assert.ok(
-    effect.includes("if (inFlight)"),
+    effect.includes("pollingSince"),
     "a forced read always writes, so a slow answer would restore the old URL",
+  );
+  assert.ok(
+    effect.includes("LINK_BASE_STALL_MS"),
+    "fetchDeviceType has no timeout: a read that never settles must not hold the guard",
   );
 });
 
@@ -119,6 +123,11 @@ test("the cached path is dropped when the inventory moves", () => {
     GGUF,
     /const pathKey = [^\n]*inventoryVersion/,
     "a re-download moves the snapshot the cached path points at",
+  );
+  assert.match(
+    GGUF,
+    /if \(menuOpen\) \{\s*prefetchCachedPath\(\);/,
+    "dropping it under an open menu must start the next one, not wait for an event",
   );
 });
 

--- a/studio/frontend/tests/clipboard-user-gesture.test.ts
+++ b/studio/frontend/tests/clipboard-user-gesture.test.ts
@@ -162,9 +162,14 @@ test("the model path starts resolving before the menu item is reachable", () => 
     GGUF.indexOf("</DropdownMenuTrigger>", open),
   );
   assert.ok(
-    trigger.includes("onPointerEnter={prefetchCachedPath}"),
+    trigger.includes("onPointerEnter={armPrefetch}"),
     "on open is too late: the click would await the fetch",
   );
+  assert.ok(
+    trigger.includes("onPointerLeave={cancelPrefetch}"),
+    "a pointer crossing a full catalog would start a cache scan per card",
+  );
+  assert.match(GGUF, /setTimeout\(prefetchCachedPath, HOVER_PREFETCH_MS\)/);
   assert.ok(trigger.includes("onFocus={prefetchCachedPath}"));
 });
 

--- a/studio/frontend/tests/clipboard-user-gesture.test.ts
+++ b/studio/frontend/tests/clipboard-user-gesture.test.ts
@@ -83,7 +83,10 @@ test("the prefetched model path is keyed to the model it was fetched for", () =>
     PREFETCH_PATH.includes("cachedPathRef.current?.key === pathKey"),
     "the guard must miss once the menu moved to another model",
   );
-  assert.ok(PREFETCH_PATH.includes("{ key: pathKey, path }"));
+  assert.match(
+    GGUF,
+    /cachedPathRef\.current = \{ key: pathKey, path: resolved \}/,
+  );
 });
 
 test("the link base is kept fresh for as long as the grid is on screen", () => {
@@ -131,12 +134,24 @@ test("the cached path is dropped when the inventory moves", () => {
   );
 });
 
-test("a prefetch for the previous model cannot evict the current one", () => {
+test("the pointer, the open and a cold copy share one request", () => {
   assert.ok(
-    PREFETCH_PATH.includes("if (pathKeyRef.current === pathKey)"),
+    PREFETCH_PATH.includes("resolveCachedPath()"),
+    "each resolve is a full scan of the Hugging Face caches",
+  );
+  assert.ok(
+    COPY_PATH.includes("await resolveCachedPath()"),
+    "a cold copy must join the prefetch already running, not start a third",
+  );
+  assert.match(GGUF, /if \(live\?\.key === pathKey\) \{\s*return live\.path;/);
+});
+
+test("a prefetch for the previous model cannot evict the current one", () => {
+  assert.match(
+    GGUF,
+    /if \(pathKeyRef\.current === pathKey\) \{\s*cachedPathRef\.current/,
     "a response that outlived the switch must not commit",
   );
-  assert.ok(COPY_PATH.includes("if (pathKeyRef.current === pathKey)"));
 });
 
 test("the model path starts resolving before the menu item is reachable", () => {

--- a/studio/frontend/tests/clipboard-user-gesture.test.ts
+++ b/studio/frontend/tests/clipboard-user-gesture.test.ts
@@ -10,10 +10,13 @@
 //   2. Prefetching the text without keying it to what is on screen. The run bar keeps
 //      one QuantOptionsMenu mounted and swaps repoId/quant under it, so an unkeyed
 //      cache silently copies the previously selected quant's path.
-//   3. Prefetching once and never again. The launch tunnel resolves while the server is
-//      already serving, so the first /api/health of a session can answer
-//      cloudflare_url null; a single read leaves the store null for the rest of it and
-//      the button copies a link only this machine can open.
+//   3. Prefetching once and never again. The tunnel URL arrives on the backend's
+//      schedule (published only after DNS and a public probe) and can leave the same
+//      way, so a single read leaves the store holding null, or a dead hostname, for
+//      the rest of the session -- and the click can no longer correct it.
+//   4. Letting a stale response win. A prefetch for the quant the menu just moved off
+//      can land last; if it evicts the current entry the copy is back to awaiting a
+//      fetch inside the click.
 //
 // Read from the source: the node suite has no DOM to click in.
 
@@ -96,20 +99,29 @@ test("the prefetched model path is keyed to the model it was fetched for", () =>
   assert.ok(PREFETCH_PATH.includes("{ key: pathKey, path }"));
 });
 
-test("the link base keeps being re-read until the tunnel URL lands", () => {
+test("the link base is kept fresh for as long as the grid is on screen", () => {
   assert.match(
     HISTORY,
-    /if \(cloudflareUrl !== null\) \{\s*return;/,
-    "the retry must stop once a tunnel URL is in the store",
+    /setInterval\(refreshLinkBase, LINK_BASE_POLL_MS\)/,
+    "one read cannot see a tunnel that is published late, or one that dies",
   );
   assert.ok(
-    /LINK_BASE_RETRIES/.test(HISTORY) && /LINK_BASE_RETRY_MS/.test(HISTORY),
-    "the retry must be bounded: a Studio launched without a tunnel never gets one",
+    !/cloudflareUrl !== null/.test(HISTORY),
+    "a cached URL is not a reason to stop: it is exactly what goes stale",
   );
   assert.ok(
-    !COPY_PREVIEW.includes("setInterval"),
-    "the retry belongs outside the click",
+    !COPY_PREVIEW.includes("setInterval") &&
+      !COPY_PREVIEW.includes("fetchDeviceType"),
+    "the refresh belongs outside the click",
   );
+});
+
+test("a prefetch for the previous model cannot evict the current one", () => {
+  assert.ok(
+    PREFETCH_PATH.includes("if (pathKeyRef.current === pathKey)"),
+    "a response that outlived the switch must not commit",
+  );
+  assert.ok(COPY_PATH.includes("if (pathKeyRef.current === pathKey)"));
 });
 
 test("the model path starts resolving before the menu item is reachable", () => {

--- a/studio/frontend/tests/clipboard-user-gesture.test.ts
+++ b/studio/frontend/tests/clipboard-user-gesture.test.ts
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// Safari only allows a clipboard write while the click that asked for it is still
+// live, so both copy buttons have to have their text ready before the handler runs.
+// The two ways that breaks:
+//
+//   1. Anything awaited ahead of the write. The write is then rejected and the user
+//      gets "Couldn't copy the link" -- no await may precede copyToClipboard.
+//   2. Prefetching the text without keying it to what is on screen. The run bar keeps
+//      one QuantOptionsMenu mounted and swaps repoId/quant under it, so an unkeyed
+//      cache silently copies the previously selected quant's path, and the preview
+//      link goes stale the moment the tunnel URL changes.
+//
+// Read from the source: the node suite has no DOM to click in.
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+function read(path: string): string {
+  return readFileSync(new URL(`../src/${path}`, import.meta.url), "utf8");
+}
+
+const HISTORY = read("features/studio/history-card-grid.tsx");
+const GGUF = read("features/hub/catalog/gguf-download-card.tsx");
+
+/** The braced block that starts at `from`, matched to its close. */
+function block(source: string, from: number): string {
+  const open = source.indexOf("{", from);
+  assert.notEqual(open, -1, "no block at anchor");
+  let depth = 0;
+  for (let i = open; i < source.length; i += 1) {
+    if (source[i] === "{") depth += 1;
+    else if (source[i] === "}") {
+      depth -= 1;
+      if (depth === 0) return source.slice(open, i + 1);
+    }
+  }
+  throw new Error("unbalanced block");
+}
+
+/** The body of the handler enclosing `anchor`. */
+function handlerAt(source: string, anchor: string, opener: string): string {
+  const at = source.indexOf(anchor);
+  assert.notEqual(at, -1, `${anchor} not found`);
+  const start = source.lastIndexOf(opener, at);
+  assert.notEqual(start, -1, `${opener} not found before ${anchor}`);
+  return block(source, source.indexOf("=>", start));
+}
+
+const COPY_PREVIEW = handlerAt(HISTORY, 'run.preview_ref ?? ""', "onClick={");
+const COPY_PATH = block(
+  GGUF,
+  GGUF.indexOf("const handleCopyPath = useCallback(async () => {"),
+);
+const PREFETCH_PATH = block(
+  GGUF,
+  GGUF.indexOf("const prefetchCachedPath = useCallback(() => {"),
+);
+
+test("copy preview link writes before it awaits anything", () => {
+  assert.ok(COPY_PREVIEW.includes("copyToClipboard("));
+  assert.equal(
+    COPY_PREVIEW.indexOf("await "),
+    COPY_PREVIEW.indexOf("await copyToClipboard("),
+    "something is awaited before the clipboard write",
+  );
+});
+
+test("the preview link base is refreshed outside the click", () => {
+  assert.ok(
+    !COPY_PREVIEW.includes("fetchDeviceType"),
+    "re-reading /api/health in the click costs the gesture",
+  );
+  assert.ok(
+    HISTORY.includes("fetchDeviceType({ force: true })"),
+    "without a forced re-read the tunnel URL never lands and the link stays local",
+  );
+  assert.ok(HISTORY.includes('window.addEventListener("focus"'));
+});
+
+test("the prefetched model path is keyed to the model it was fetched for", () => {
+  assert.match(
+    GGUF,
+    /const pathKey = [^\n]*repoId[^\n]*quant/,
+    "the cache key must cover both repoId and quant",
+  );
+  assert.ok(
+    PREFETCH_PATH.includes("cachedPathRef.current?.key === pathKey"),
+    "the prefetch guard must miss when the menu now points at another model",
+  );
+  assert.ok(PREFETCH_PATH.includes("{ key: pathKey, path }"));
+});
+
+test("copy path never serves another model's cached path", () => {
+  assert.ok(
+    !/cachedPathRef\.current \?\?/.test(COPY_PATH),
+    "an unkeyed fallback copies whatever was fetched last",
+  );
+  assert.ok(COPY_PATH.includes("cached?.key === pathKey"));
+  assert.ok(
+    COPY_PATH.includes("? cached.path"),
+    "a warm cache must skip the fetch, or the await loses the gesture",
+  );
+});

--- a/studio/frontend/tests/clipboard-user-gesture.test.ts
+++ b/studio/frontend/tests/clipboard-user-gesture.test.ts
@@ -9,8 +9,11 @@
 //      gets "Couldn't copy the link" -- no await may precede copyToClipboard.
 //   2. Prefetching the text without keying it to what is on screen. The run bar keeps
 //      one QuantOptionsMenu mounted and swaps repoId/quant under it, so an unkeyed
-//      cache silently copies the previously selected quant's path, and the preview
-//      link goes stale the moment the tunnel URL changes.
+//      cache silently copies the previously selected quant's path.
+//   3. Prefetching once and never again. The launch tunnel resolves while the server is
+//      already serving, so the first /api/health of a session can answer
+//      cloudflare_url null; a single read leaves the store null for the rest of it and
+//      the button copies a link only this machine can open.
 //
 // Read from the source: the node suite has no DOM to click in.
 
@@ -91,6 +94,36 @@ test("the prefetched model path is keyed to the model it was fetched for", () =>
     "the prefetch guard must miss when the menu now points at another model",
   );
   assert.ok(PREFETCH_PATH.includes("{ key: pathKey, path }"));
+});
+
+test("the link base keeps being re-read until the tunnel URL lands", () => {
+  assert.match(
+    HISTORY,
+    /if \(cloudflareUrl !== null\) \{\s*return;/,
+    "the retry must stop once a tunnel URL is in the store",
+  );
+  assert.ok(
+    /LINK_BASE_RETRIES/.test(HISTORY) && /LINK_BASE_RETRY_MS/.test(HISTORY),
+    "the retry must be bounded: a Studio launched without a tunnel never gets one",
+  );
+  assert.ok(
+    !COPY_PREVIEW.includes("setInterval"),
+    "the retry belongs outside the click",
+  );
+});
+
+test("the model path starts resolving before the menu item is reachable", () => {
+  const open = GGUF.indexOf("<DropdownMenuTrigger");
+  assert.notEqual(open, -1, "no DropdownMenuTrigger");
+  const trigger = GGUF.slice(
+    open,
+    GGUF.indexOf("</DropdownMenuTrigger>", open),
+  );
+  assert.ok(
+    trigger.includes("onPointerEnter={prefetchCachedPath}"),
+    "waiting for the menu to open leaves the copy click awaiting the fetch",
+  );
+  assert.ok(trigger.includes("onFocus={prefetchCachedPath}"));
 });
 
 test("copy path never serves another model's cached path", () => {

--- a/studio/frontend/tests/link-base-authoritative.test.ts
+++ b/studio/frontend/tests/link-base-authoritative.test.ts
@@ -33,14 +33,17 @@ const TUNNEL = "https://live.trycloudflare.com";
 // fields ride with it.
 const AUTHED = {
   device_type: "linux",
-  chat_only: false,
-  chat_only_reason: null,
+  chat_only: true,
+  chat_only_reason: "mlx_unavailable",
+  chat_only_detail: "mlx-lm 0.19 is too old",
   version: "2026.1.1",
   cloudflare_url: TUNNEL,
   server_url: "http://10.0.0.4:8000",
   secure: true,
 };
 // What the same endpoint answers once the token expires: HTTP 200, no authed fields.
+// health_check ships chat_only in the unauthenticated body, but not the reason behind
+// it and not the tunnel: everything that fingerprints the host is authed-only.
 const UNAUTHED = { chat_only: false };
 // Authed, but sent while the hardware snapshot is still provisional: health_check ships
 // the tunnel fields before it knows a device_type. Here the tunnel has been stopped.
@@ -164,4 +167,24 @@ test("a failed read keeps the platform the backend measured", async () => {
     true,
     "a dropped poll threw away the measurement",
   );
+});
+
+test("an expired token does not throw away the reason the UI is explaining", async () => {
+  next = async () => AUTHED;
+  await fetchDeviceType({ force: true });
+  assert.equal(usePlatformStore.getState().chatOnlyReason, "mlx_unavailable");
+
+  // chat_only survives in the unauthenticated body; the reason behind it does not, and
+  // a settled reply is not provisional, so resolveVerdict has nothing to hold on to.
+  next = async () => UNAUTHED;
+  await fetchDeviceType({ force: true });
+
+  const kept = usePlatformStore.getState();
+  assert.equal(
+    kept.chatOnlyReason,
+    "mlx_unavailable",
+    "the greyed-out Train row loses its explanation, and the self-heal poll stops arming",
+  );
+  assert.equal(kept.chatOnlyDetail, "mlx-lm 0.19 is too old");
+  assert.equal(kept.chatOnly, true, "and the verdict itself was flipped");
 });

--- a/studio/frontend/tests/link-base-authoritative.test.ts
+++ b/studio/frontend/tests/link-base-authoritative.test.ts
@@ -261,3 +261,34 @@ test("a later failed refresh does not discard an earlier success", async () => {
     "the only answer either read got was dropped because a failed one started later",
   );
 });
+
+test("a failed refresh does not supersede a success still in flight", async () => {
+  // Nothing measured yet, which is what lets the catch path below write at all.
+  usePlatformStore.setState({ fetched: false, cloudflareUrl: null });
+
+  let releaseSlow = () => {};
+  next = async () => {
+    await new Promise<void>((resolve) => {
+      releaseSlow = resolve;
+    });
+    return AUTHED;
+  };
+  const slow = fetchDeviceType({ force: true });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  // A later read fails and seeds the browser guess, because nothing authoritative is
+  // stored yet. That seed must not outrank the real reply still on its way.
+  next = async () => {
+    throw new Error("network");
+  };
+  await fetchDeviceType({ force: true });
+
+  releaseSlow();
+  await slow;
+  assert.equal(
+    usePlatformStore.getState().deviceType,
+    "linux",
+    "a browser guess from a failed read outranked the measurement that arrived after it",
+  );
+  assert.equal(usePlatformStore.getState().cloudflareUrl, TUNNEL);
+});

--- a/studio/frontend/tests/link-base-authoritative.test.ts
+++ b/studio/frontend/tests/link-base-authoritative.test.ts
@@ -42,6 +42,16 @@ const AUTHED = {
 };
 // What the same endpoint answers once the token expires: HTTP 200, no authed fields.
 const UNAUTHED = { chat_only: false };
+// Authed, but sent while the hardware snapshot is still provisional: health_check ships
+// the tunnel fields before it knows a device_type. Here the tunnel has been stopped.
+const AUTHED_DETECTING = {
+  chat_only: false,
+  hardware_detecting: true,
+  version: "2026.1.1",
+  cloudflare_url: null,
+  server_url: "http://10.0.0.4:8000",
+  secure: false,
+};
 
 let next: () => Promise<Record<string, unknown>> = async () => AUTHED;
 globalThis.fetch = (async () => {
@@ -80,7 +90,7 @@ test("a superseded forced read does not restore what a later one replaced", asyn
   await fetchDeviceType({ force: true });
 
   // The stalled read: it answers with the URL that was live when it was sent.
-  let releaseStalled: (() => void) | null = null;
+  let releaseStalled = () => {};
   next = async () => {
     await new Promise<void>((resolve) => {
       releaseStalled = resolve;
@@ -102,11 +112,56 @@ test("a superseded forced read does not restore what a later one replaced", asyn
     "https://restarted.trycloudflare.com",
   );
 
-  releaseStalled?.();
+  releaseStalled();
   await stalled;
   assert.equal(
     usePlatformStore.getState().cloudflareUrl,
     "https://restarted.trycloudflare.com",
     "the abandoned read wrote its stale tunnel URL over the live one",
+  );
+});
+
+test("a stopped tunnel is cleared even before detection settles", async () => {
+  next = async () => AUTHED;
+  await fetchDeviceType({ force: true });
+  assert.equal(usePlatformStore.getState().cloudflareUrl, TUNNEL);
+
+  next = async () => AUTHED_DETECTING;
+  await fetchDeviceType({ force: true });
+
+  assert.equal(
+    usePlatformStore.getState().cloudflareUrl,
+    null,
+    "an authed null is a tunnel that stopped, not a field the reply left out",
+  );
+  assert.equal(
+    usePlatformStore.getState().deviceType,
+    "linux",
+    "the provisional reply still must not relabel the host",
+  );
+});
+
+test("a failed read keeps the platform the backend measured", async () => {
+  next = async () => AUTHED;
+  await fetchDeviceType({ force: true });
+  const measured = usePlatformStore.getState();
+  assert.equal(measured.deviceType, "linux");
+  assert.equal(measured.fetched, true);
+
+  next = async () => {
+    throw new Error("network");
+  };
+  await fetchDeviceType({ force: true });
+
+  const after = usePlatformStore.getState();
+  assert.equal(
+    after.deviceType,
+    "linux",
+    "a dropped poll relabelled the host from the browser it is viewed in",
+  );
+  assert.equal(
+    after.fetched,
+    true,
+    "a dropped poll threw away the measurement",
   );
 });

--- a/studio/frontend/tests/link-base-authoritative.test.ts
+++ b/studio/frontend/tests/link-base-authoritative.test.ts
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// The History grid re-reads /api/health on a timer to keep the Copy preview link base
+// live, which turned two latent races in the platform store into recurring ones: an
+// unauthenticated reply nulling a tunnel that is still up, and two forced reads landing
+// out of order. Either leaves the button copying a link only this machine can open.
+
+import assert from "node:assert/strict";
+import { register } from "node:module";
+import test from "node:test";
+
+import {
+  installLocalStorageFake,
+  registerBundlerResolver,
+} from "./helpers/kit.ts";
+
+register("./helpers/vite-env-loader.mjs", import.meta.url);
+registerBundlerResolver();
+const { store } = installLocalStorageFake();
+store.set("unsloth_auth_token", "token");
+Object.defineProperty(globalThis, "navigator", {
+  configurable: true,
+  value: {
+    platform: "Linux x86_64",
+    userAgent: "Mozilla/5.0 (X11; Linux x86_64)",
+  },
+});
+
+const TUNNEL = "https://live.trycloudflare.com";
+
+// Authed: device_type only reaches a caller the backend recognises, and the tunnel
+// fields ride with it.
+const AUTHED = {
+  device_type: "linux",
+  chat_only: false,
+  chat_only_reason: null,
+  version: "2026.1.1",
+  cloudflare_url: TUNNEL,
+  server_url: "http://10.0.0.4:8000",
+  secure: true,
+};
+// What the same endpoint answers once the token expires: HTTP 200, no authed fields.
+const UNAUTHED = { chat_only: false };
+
+let next: () => Promise<Record<string, unknown>> = async () => AUTHED;
+globalThis.fetch = (async () => {
+  const body = await next();
+  const res = { ok: true, json: async () => ({ ...body }), clone: () => res };
+  return res;
+}) as unknown as typeof fetch;
+
+const { fetchDeviceType, usePlatformStore } = await import(
+  "../src/config/env.ts"
+);
+
+test("an expired token does not null a tunnel that is still up", async () => {
+  await fetchDeviceType({ force: true });
+  assert.equal(
+    usePlatformStore.getState().cloudflareUrl,
+    TUNNEL,
+    "nothing was stored",
+  );
+
+  next = async () => UNAUTHED;
+  await fetchDeviceType({ force: true });
+
+  const after = usePlatformStore.getState();
+  assert.equal(
+    after.cloudflareUrl,
+    TUNNEL,
+    "the poll nulled the tunnel URL, so Copy preview link falls back to this origin",
+  );
+  assert.equal(after.serverUrl, "http://10.0.0.4:8000");
+  assert.equal(after.secure, true);
+});
+
+test("a superseded forced read does not restore what a later one replaced", async () => {
+  next = async () => AUTHED;
+  await fetchDeviceType({ force: true });
+
+  // The stalled read: it answers with the URL that was live when it was sent.
+  let releaseStalled: (() => void) | null = null;
+  next = async () => {
+    await new Promise<void>((resolve) => {
+      releaseStalled = resolve;
+    });
+    return AUTHED;
+  };
+  const stalled = fetchDeviceType({ force: true });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  // The tunnel is restarted, and the replacement read picks up its new hostname.
+  const restarted = {
+    ...AUTHED,
+    cloudflare_url: "https://restarted.trycloudflare.com",
+  };
+  next = async () => restarted;
+  await fetchDeviceType({ force: true });
+  assert.equal(
+    usePlatformStore.getState().cloudflareUrl,
+    "https://restarted.trycloudflare.com",
+  );
+
+  releaseStalled?.();
+  await stalled;
+  assert.equal(
+    usePlatformStore.getState().cloudflareUrl,
+    "https://restarted.trycloudflare.com",
+    "the abandoned read wrote its stale tunnel URL over the live one",
+  );
+});

--- a/studio/frontend/tests/link-base-authoritative.test.ts
+++ b/studio/frontend/tests/link-base-authoritative.test.ts
@@ -47,6 +47,17 @@ const AUTHED = {
 const UNAUTHED = { chat_only: false };
 // Authed, but sent while the hardware snapshot is still provisional: health_check ships
 // the tunnel fields before it knows a device_type. Here the tunnel has been stopped.
+// Authed and provisional, with the tunnel already up: the backend publishes the tunnel
+// fields before it knows a device_type, so this leaves real URLs stored while `fetched`
+// is still false.
+const AUTHED_DETECTING_TUNNEL = {
+  chat_only: false,
+  hardware_detecting: true,
+  version: "2026.1.1",
+  cloudflare_url: TUNNEL,
+  server_url: "http://10.0.0.4:8000",
+  secure: true,
+};
 const AUTHED_DETECTING = {
   chat_only: false,
   hardware_detecting: true,
@@ -187,4 +198,66 @@ test("an expired token does not throw away the reason the UI is explaining", asy
   );
   assert.equal(kept.chatOnlyDetail, "mlx-lm 0.19 is too old");
   assert.equal(kept.chatOnly, true, "and the verdict itself was flipped");
+});
+
+test("a tunnel learned before the verdict survives an expired token", async () => {
+  // A fresh session: nothing measured yet, so `fetched` is false throughout.
+  usePlatformStore.setState({
+    fetched: false,
+    cloudflareUrl: null,
+    serverUrl: null,
+    secure: false,
+  });
+  next = async () => AUTHED_DETECTING_TUNNEL;
+  await fetchDeviceType({ force: true });
+  const detecting = usePlatformStore.getState();
+  assert.equal(detecting.cloudflareUrl, TUNNEL);
+  assert.equal(
+    detecting.fetched,
+    false,
+    "the verdict is what has not settled here",
+  );
+
+  next = async () => UNAUTHED;
+  await fetchDeviceType({ force: true });
+
+  assert.equal(
+    usePlatformStore.getState().cloudflareUrl,
+    TUNNEL,
+    "gating on `fetched` alone lets the unauthed poll null a tunnel that is up",
+  );
+});
+
+test("a later failed refresh does not discard an earlier success", async () => {
+  next = async () => AUTHED;
+  await fetchDeviceType({ force: true });
+
+  // The slow success, carrying a tunnel that has just been restarted.
+  const restarted = {
+    ...AUTHED,
+    cloudflare_url: "https://second.trycloudflare.com",
+  };
+  let releaseSlow = () => {};
+  next = async () => {
+    await new Promise<void>((resolve) => {
+      releaseSlow = resolve;
+    });
+    return restarted;
+  };
+  const slow = fetchDeviceType({ force: true });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  // A second refresh starts and fails outright, writing nothing.
+  next = async () => {
+    throw new Error("network");
+  };
+  await fetchDeviceType({ force: true });
+
+  releaseSlow();
+  await slow;
+  assert.equal(
+    usePlatformStore.getState().cloudflareUrl,
+    "https://second.trycloudflare.com",
+    "the only answer either read got was dropped because a failed one started later",
+  );
 });

--- a/studio/frontend/tests/link-base-cold-start.test.ts
+++ b/studio/frontend/tests/link-base-cold-start.test.ts
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// The cold start, before any reply has carried the authed-only fields: until then
+// fetchDeviceType accepts an unauthenticated body, because something has to seed the
+// chat-only guard. What it must not do is let that seed order the forced reads -- an
+// authenticated reply still in flight is the only one carrying a verdict or a tunnel.
+//
+// Its own file because that "has an authed reply been seen" state is per module load,
+// and any earlier test that logs in would settle it before this one runs.
+
+import assert from "node:assert/strict";
+import { register } from "node:module";
+import test from "node:test";
+
+import {
+  installLocalStorageFake,
+  registerBundlerResolver,
+} from "./helpers/kit.ts";
+
+register("./helpers/vite-env-loader.mjs", import.meta.url);
+registerBundlerResolver();
+const { store } = installLocalStorageFake();
+store.set("unsloth_auth_token", "token");
+Object.defineProperty(globalThis, "navigator", {
+  configurable: true,
+  value: { platform: "MacIntel", userAgent: "Mozilla/5.0 (Macintosh)" },
+});
+
+const TUNNEL = "https://cold.trycloudflare.com";
+const AUTHED = {
+  device_type: "linux",
+  chat_only: false,
+  chat_only_reason: null,
+  version: "2026.1.1",
+  cloudflare_url: TUNNEL,
+  server_url: "http://10.0.0.4:8000",
+  secure: true,
+};
+// No authed fields: what /api/health answers when the bearer is missing or rejected.
+const UNAUTHED = { chat_only: false };
+
+let next: () => Promise<Record<string, unknown>> = async () => AUTHED;
+globalThis.fetch = (async () => {
+  const body = await next();
+  const res = { ok: true, json: async () => ({ ...body }), clone: () => res };
+  return res;
+}) as unknown as typeof fetch;
+
+const { fetchDeviceType, usePlatformStore } = await import(
+  "../src/config/env.ts"
+);
+
+test("an unauthenticated seed does not outrank an authenticated read in flight", async () => {
+  let releaseAuthed = () => {};
+  next = async () => {
+    await new Promise<void>((resolve) => {
+      releaseAuthed = resolve;
+    });
+    return AUTHED;
+  };
+  const authedRead = fetchDeviceType({ force: true });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  // The session is cleared mid-flight, so this one gets the unprivileged body.
+  next = async () => UNAUTHED;
+  await fetchDeviceType({ force: true });
+  assert.equal(
+    usePlatformStore.getState().deviceType,
+    "mac",
+    "the seed is the browser guess, which is the point of accepting it at all",
+  );
+
+  releaseAuthed();
+  await authedRead;
+  assert.equal(
+    usePlatformStore.getState().cloudflareUrl,
+    TUNNEL,
+    "the unauthenticated seed took the ordering mark and discarded the real reply",
+  );
+  assert.equal(usePlatformStore.getState().deviceType, "linux");
+});


### PR DESCRIPTION
Both buttons awaited a network call before copying. Safari only allows a clipboard write while the click is still live, so the copy was rejected and you got "Couldn't copy the link".

Copy preview link now builds the URL from the store and copies straight away. Copy path prefetches the path when the menu opens so the copy is the first thing the click does.