### PR TITLE
Studio: Show the model's thinking on the preview page

### DIFF
--- a/studio/backend/assets/preview_page.html
+++ b/studio/backend/assets/preview_page.html
@@ -445,11 +445,13 @@
                 if (!choice) continue;
                 if (choice.finish_reason === "length") truncated = true;
                 const delta = choice.delta || {};
-                if (delta.reasoning_content) {
+                if (typeof delta.reasoning_content === "string") {
                   reasoning += delta.reasoning_content;
-                  think.hidden = false;
-                  thinkText.textContent = reasoning;
-                  down();
+                  if (reasoning.trim()) {
+                    think.hidden = false;
+                    thinkText.textContent = reasoning;
+                    down();
+                  }
                 }
                 if (delta.content) {
                   acc += delta.content;
@@ -478,7 +480,7 @@
           // prompt repeats a role and is dropped to keep alternation.
           if (hasContent || hasReasoning) {
             const reply = { role: "assistant", content: acc };
-            if (reasoning) reply.reasoning_content = reasoning;
+            if (hasReasoning) reply.reasoning_content = reasoning;
             msgs.push(reply);
           }
           cutoff.hidden = !truncated;

--- a/studio/backend/assets/preview_page.html
+++ b/studio/backend/assets/preview_page.html
@@ -452,10 +452,8 @@
               } catch (_) {}
             }
           }
-          // Keep the assistant turn even when the reply was reasoning-only.
-          // Dropping it leaves two consecutive user messages, and the next
-          // prompt is then discarded to keep roles alternating; reasoning_content
-          // rides along for the templates that replay it.
+          // A reasoning-only reply still needs its turn: without it the next
+          // prompt repeats a role and is dropped to keep alternation.
           if (acc || reasoning) {
             const reply = { role: "assistant", content: acc };
             if (reasoning) reply.reasoning_content = reasoning;

--- a/studio/backend/assets/preview_page.html
+++ b/studio/backend/assets/preview_page.html
@@ -398,6 +398,7 @@
         body.innerHTML = '<span class="dots"><i></i><i></i><i></i></span>';
         const cutoff = document.createElement("div");
         cutoff.className = "cutoff";
+        cutoff.setAttribute("role", "status");
         cutoff.hidden = true;
         out.append(think, body, cutoff);
         let acc = "",

--- a/studio/backend/assets/preview_page.html
+++ b/studio/backend/assets/preview_page.html
@@ -477,8 +477,7 @@
             input.focus();
             return;
           }
-          // A reasoning-only reply still needs its turn: without it the next
-          // prompt repeats a role and is dropped to keep alternation.
+          // keep reasoning-only replies so the next prompt preserves role alternation.
           if (hasContent || hasReasoning) {
             const reply = { role: "assistant", content: acc };
             if (hasReasoning) reply.reasoning_content = reasoning;

--- a/studio/backend/assets/preview_page.html
+++ b/studio/backend/assets/preview_page.html
@@ -402,7 +402,8 @@
         out.append(think, body, cutoff);
         let acc = "",
           reasoning = "",
-          truncated = false;
+          truncated = false,
+          complete = false;
         try {
           const r = await fetch(chatUrl, {
             method: "POST",
@@ -434,7 +435,10 @@
               buf = buf.slice(i + 1);
               if (!line.startsWith("data:")) continue;
               const data = line.slice(5).trim();
-              if (data === "[DONE]") continue;
+              if (data === "[DONE]") {
+                complete = true;
+                continue;
+              }
               try {
                 const j = JSON.parse(data);
                 const choice = j.choices && j.choices[0];
@@ -455,6 +459,7 @@
               } catch (_) {}
             }
           }
+          if (!complete) throw new Error("preview stream ended before completion");
           // A reasoning-only reply still needs its turn: without it the next
           // prompt repeats a role and is dropped to keep alternation.
           if (acc || reasoning) {

--- a/studio/backend/assets/preview_page.html
+++ b/studio/backend/assets/preview_page.html
@@ -396,7 +396,10 @@
         const thinkText = think.appendChild(document.createElement("div"));
         const body = document.createElement("div");
         body.innerHTML = '<span class="dots"><i></i><i></i><i></i></span>';
-        out.append(think, body);
+        const cutoff = document.createElement("div");
+        cutoff.className = "cutoff";
+        cutoff.hidden = true;
+        out.append(think, body, cutoff);
         let acc = "",
           reasoning = "",
           truncated = false;
@@ -459,14 +462,11 @@
             if (reasoning) reply.reasoning_content = reasoning;
             msgs.push(reply);
           }
-          if (!acc) {
-            if (truncated) {
-              body.className = "cutoff";
-              body.textContent = "Reply cut off at the preview length limit.";
-            } else {
-              body.textContent = "";
-            }
-          }
+          cutoff.hidden = !truncated;
+          cutoff.textContent = truncated
+            ? "Reply cut off at the preview length limit."
+            : "";
+          if (!acc) body.textContent = "";
         } catch (err) {
           // Keep any streamed text, flag the break, restore the prompt for retry.
           body.textContent = acc ? acc + "\n\n[connection lost]" : "Network error, please retry.";

--- a/studio/backend/assets/preview_page.html
+++ b/studio/backend/assets/preview_page.html
@@ -460,9 +460,23 @@
             }
           }
           if (!complete) throw new Error("preview stream ended before completion");
+          const hasContent = Boolean(acc.trim());
+          const hasReasoning = Boolean(reasoning.trim());
+          if (!hasContent && !hasReasoning) {
+            body.classList.add("error");
+            body.textContent = truncated
+              ? "Reply cut off before the model returned an answer. Please try again."
+              : "The model returned an empty reply. Please try again.";
+            msgs.pop();
+            input.value = content;
+            autosize();
+            btn.disabled = false;
+            input.focus();
+            return;
+          }
           // A reasoning-only reply still needs its turn: without it the next
           // prompt repeats a role and is dropped to keep alternation.
-          if (acc || reasoning) {
+          if (hasContent || hasReasoning) {
             const reply = { role: "assistant", content: acc };
             if (reasoning) reply.reasoning_content = reasoning;
             msgs.push(reply);

--- a/studio/backend/assets/preview_page.html
+++ b/studio/backend/assets/preview_page.html
@@ -158,6 +158,23 @@
           background: #2d1716;
         }
       }
+      .think {
+        margin-bottom: 10px;
+        font-size: 14px;
+        color: var(--muted);
+      }
+      .think summary {
+        cursor: pointer;
+      }
+      .think div {
+        margin-top: 6px;
+        padding-left: 12px;
+        border-left: 2px solid var(--border);
+      }
+      .cutoff {
+        color: var(--muted);
+        font-style: italic;
+      }
       .dots {
         display: inline-flex;
         gap: 5px;
@@ -372,8 +389,17 @@
         msgs.push({ role: "user", content });
         add("user").textContent = content;
         const out = add("assistant");
-        out.innerHTML = '<span class="dots"><i></i><i></i><i></i></span>';
-        let acc = "";
+        const think = document.createElement("details");
+        think.className = "think";
+        think.hidden = true;
+        think.appendChild(document.createElement("summary")).textContent = "Thinking";
+        const thinkText = think.appendChild(document.createElement("div"));
+        const body = document.createElement("div");
+        body.innerHTML = '<span class="dots"><i></i><i></i><i></i></span>';
+        out.append(think, body);
+        let acc = "",
+          reasoning = "",
+          truncated = false;
         try {
           const r = await fetch(chatUrl, {
             method: "POST",
@@ -385,7 +411,7 @@
             }),
           });
           if (!r.ok) {
-            showError(out, r.status, await r.text());
+            showError(body, r.status, await r.text());
             msgs.pop();
             input.value = content; // restore the prompt so the user can retry
             autosize();
@@ -408,24 +434,35 @@
               if (data === "[DONE]") continue;
               try {
                 const j = JSON.parse(data);
-                const d =
-                  j.choices &&
-                  j.choices[0] &&
-                  j.choices[0].delta &&
-                  j.choices[0].delta.content;
-                if (d) {
-                  acc += d;
-                  out.textContent = acc;
+                const choice = j.choices && j.choices[0];
+                if (!choice) continue;
+                if (choice.finish_reason === "length") truncated = true;
+                const delta = choice.delta || {};
+                if (delta.reasoning_content) {
+                  reasoning += delta.reasoning_content;
+                  think.hidden = false;
+                  thinkText.textContent = reasoning;
+                  down();
+                }
+                if (delta.content) {
+                  acc += delta.content;
+                  body.textContent = acc;
                   down();
                 }
               } catch (_) {}
             }
           }
-          if (!acc) out.textContent = "";
-          msgs.push({ role: "assistant", content: acc });
+          if (acc) {
+            msgs.push({ role: "assistant", content: acc });
+          } else if (truncated) {
+            body.className = "cutoff";
+            body.textContent = "Reply cut off at the preview length limit.";
+          } else {
+            body.textContent = "";
+          }
         } catch (err) {
           // Keep any streamed text, flag the break, restore the prompt for retry.
-          out.textContent = acc ? acc + "\n\n[connection lost]" : "Network error, please retry.";
+          body.textContent = acc ? acc + "\n\n[connection lost]" : "Network error, please retry.";
           msgs.pop();
           input.value = content;
           autosize();

--- a/studio/backend/assets/preview_page.html
+++ b/studio/backend/assets/preview_page.html
@@ -452,13 +452,22 @@
               } catch (_) {}
             }
           }
-          if (acc) {
-            msgs.push({ role: "assistant", content: acc });
-          } else if (truncated) {
-            body.className = "cutoff";
-            body.textContent = "Reply cut off at the preview length limit.";
-          } else {
-            body.textContent = "";
+          // Keep the assistant turn even when the reply was reasoning-only.
+          // Dropping it leaves two consecutive user messages, and the next
+          // prompt is then discarded to keep roles alternating; reasoning_content
+          // rides along for the templates that replay it.
+          if (acc || reasoning) {
+            const reply = { role: "assistant", content: acc };
+            if (reasoning) reply.reasoning_content = reasoning;
+            msgs.push(reply);
+          }
+          if (!acc) {
+            if (truncated) {
+              body.className = "cutoff";
+              body.textContent = "Reply cut off at the preview length limit.";
+            } else {
+              body.textContent = "";
+            }
           }
         } catch (err) {
           // Keep any streamed text, flag the break, restore the prompt for retry.

--- a/studio/backend/tests/test_preview_routes.py
+++ b/studio/backend/tests/test_preview_routes.py
@@ -127,6 +127,17 @@ def test_page_renders_friendly_busy_message(client):
     assert "Unsloth is currently using another model" in response.text
 
 
+def test_page_renders_reasoning_stream(client):
+    # The page used to read only delta.content, so every reasoning_content chunk
+    # was dropped and a thinking model rendered an empty bubble.
+    text = client.get(f"/p/demorun?k={_sig('demorun')}").text
+    assert "delta.reasoning_content" in text
+    assert 'choice.finish_reason === "length"' in text
+    # Reasoning counts against the preview cap, so a reply that spent it all on
+    # thinking must say so instead of showing nothing.
+    assert "Reply cut off at the preview length limit." in text
+
+
 def test_page_escapes_title(tmp_path, monkeypatch, captured):
     outputs = tmp_path / "outputs"
     # Run dir name carries an HTML-special char; the page must escape it.

--- a/studio/backend/tests/test_preview_routes.py
+++ b/studio/backend/tests/test_preview_routes.py
@@ -138,6 +138,16 @@ def test_page_renders_reasoning_stream(client):
     assert "Reply cut off at the preview length limit." in text
 
 
+def test_page_keeps_assistant_turn_for_reasoning_only_reply(client):
+    # A reasoning-only reply must still push an assistant turn. Without one the
+    # next prompt is a second consecutive user message, which format_chat_prompt
+    # drops to keep roles alternating -- the visitor's follow-up is answered as
+    # if it had never been sent.
+    text = client.get(f"/p/demorun?k={_sig('demorun')}").text
+    assert "if (acc || reasoning)" in text
+    assert "reply.reasoning_content = reasoning" in text
+
+
 def test_page_escapes_title(tmp_path, monkeypatch, captured):
     outputs = tmp_path / "outputs"
     # Run dir name carries an HTML-special char; the page must escape it.

--- a/studio/backend/tests/test_preview_routes.py
+++ b/studio/backend/tests/test_preview_routes.py
@@ -128,21 +128,17 @@ def test_page_renders_friendly_busy_message(client):
 
 
 def test_page_renders_reasoning_stream(client):
-    # The page used to read only delta.content, so every reasoning_content chunk
-    # was dropped and a thinking model rendered an empty bubble.
+    # The page read only delta.content, so a thinking model's reasoning
+    # vanished and a cap spent on it left an empty bubble.
     text = client.get(f"/p/demorun?k={_sig('demorun')}").text
     assert "delta.reasoning_content" in text
     assert 'choice.finish_reason === "length"' in text
-    # Reasoning counts against the preview cap, so a reply that spent it all on
-    # thinking must say so instead of showing nothing.
     assert "Reply cut off at the preview length limit." in text
 
 
 def test_page_keeps_assistant_turn_for_reasoning_only_reply(client):
-    # A reasoning-only reply must still push an assistant turn. Without one the
-    # next prompt is a second consecutive user message, which format_chat_prompt
-    # drops to keep roles alternating -- the visitor's follow-up is answered as
-    # if it had never been sent.
+    # Without the assistant turn the next prompt repeats a role and
+    # format_chat_prompt drops it, so the follow-up is never answered.
     text = client.get(f"/p/demorun?k={_sig('demorun')}").text
     assert "if (acc || reasoning)" in text
     assert "reply.reasoning_content = reasoning" in text

--- a/studio/backend/tests/test_preview_routes.py
+++ b/studio/backend/tests/test_preview_routes.py
@@ -135,6 +135,7 @@ def test_page_renders_reasoning_stream(client):
     assert 'choice.finish_reason === "length"' in text
     assert "Reply cut off at the preview length limit." in text
     assert "cutoff.hidden = !truncated" in text
+    assert 'cutoff.setAttribute("role", "status")' in text
     assert "preview stream ended before completion" in text
 
 

--- a/studio/backend/tests/test_preview_routes.py
+++ b/studio/backend/tests/test_preview_routes.py
@@ -128,8 +128,6 @@ def test_page_renders_friendly_busy_message(client):
 
 
 def test_page_renders_reasoning_stream(client):
-    # The page read only delta.content, so a thinking model's reasoning
-    # vanished and a cap spent on it left an empty bubble.
     text = client.get(f"/p/demorun?k={_sig('demorun')}").text
     assert "delta.reasoning_content" in text
     assert 'choice.finish_reason === "length"' in text
@@ -140,8 +138,6 @@ def test_page_renders_reasoning_stream(client):
 
 
 def test_page_keeps_assistant_turn_for_reasoning_only_reply(client):
-    # Without the assistant turn the next prompt repeats a role and
-    # format_chat_prompt drops it, so the follow-up is never answered.
     text = client.get(f"/p/demorun?k={_sig('demorun')}").text
     assert "if (hasContent || hasReasoning)" in text
     assert "if (hasReasoning) reply.reasoning_content = reasoning" in text

--- a/studio/backend/tests/test_preview_routes.py
+++ b/studio/backend/tests/test_preview_routes.py
@@ -134,6 +134,7 @@ def test_page_renders_reasoning_stream(client):
     assert "delta.reasoning_content" in text
     assert 'choice.finish_reason === "length"' in text
     assert "Reply cut off at the preview length limit." in text
+    assert "cutoff.hidden = !truncated" in text
 
 
 def test_page_keeps_assistant_turn_for_reasoning_only_reply(client):

--- a/studio/backend/tests/test_preview_routes.py
+++ b/studio/backend/tests/test_preview_routes.py
@@ -142,8 +142,15 @@ def test_page_keeps_assistant_turn_for_reasoning_only_reply(client):
     # Without the assistant turn the next prompt repeats a role and
     # format_chat_prompt drops it, so the follow-up is never answered.
     text = client.get(f"/p/demorun?k={_sig('demorun')}").text
-    assert "if (acc || reasoning)" in text
+    assert "if (hasContent || hasReasoning)" in text
     assert "reply.reasoning_content = reasoning" in text
+
+
+def test_page_recovers_from_empty_reply(client):
+    text = client.get(f"/p/demorun?k={_sig('demorun')}").text
+    assert "if (!hasContent && !hasReasoning)" in text
+    assert "The model returned an empty reply. Please try again." in text
+    assert "Reply cut off before the model returned an answer." in text
 
 
 def test_page_escapes_title(tmp_path, monkeypatch, captured):

--- a/studio/backend/tests/test_preview_routes.py
+++ b/studio/backend/tests/test_preview_routes.py
@@ -143,7 +143,8 @@ def test_page_keeps_assistant_turn_for_reasoning_only_reply(client):
     # format_chat_prompt drops it, so the follow-up is never answered.
     text = client.get(f"/p/demorun?k={_sig('demorun')}").text
     assert "if (hasContent || hasReasoning)" in text
-    assert "reply.reasoning_content = reasoning" in text
+    assert "if (hasReasoning) reply.reasoning_content = reasoning" in text
+    assert "if (reasoning.trim())" in text
 
 
 def test_page_recovers_from_empty_reply(client):

--- a/studio/backend/tests/test_preview_routes.py
+++ b/studio/backend/tests/test_preview_routes.py
@@ -135,6 +135,7 @@ def test_page_renders_reasoning_stream(client):
     assert 'choice.finish_reason === "length"' in text
     assert "Reply cut off at the preview length limit." in text
     assert "cutoff.hidden = !truncated" in text
+    assert "preview stream ended before completion" in text
 
 
 def test_page_keeps_assistant_turn_for_reasoning_only_reply(client):


### PR DESCRIPTION
The public /p preview page only read delta.content from the stream, so it threw away every reasoning_content chunk. Thinking models look fine in Studio chat and show nothing on the preview page.

It also wastes the budget. Preview caps generation at 1024 tokens, half the normal default, and reasoning counts against that cap. On an always-thinking model like Qwen3-4B-Thinking-2507 there's no way to turn it off, so if the thinking fills the cap the visitor gets an empty bubble with no error.

This reads reasoning_content into a muted block above the answer, and says "Reply cut off at the preview length limit" when finish_reason is length and nothing else came back.

Also stops pushing an empty assistant message into the history when a reply produced no content.