### PR TITLE
Studio: fix the AttributeError that 500s every planned GGUF load

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -24174,7 +24174,9 @@ class LlamaCppBackend:
                     + self._PIPELINE_PER_DEVICE_OVERHEAD_MIB * 1024 * 1024
                     + int(inputs.get("ctx_compute_per_device") or 0)
                 ),
-                host_ram_headroom_bytes = self._HOST_RAM_HEADROOM_MIB * 1024 * 1024,
+                # Module-level, unlike _PIPELINE_PER_DEVICE_OVERHEAD_MIB on the line
+                # above, so it is not reachable through self.
+                host_ram_headroom_bytes = _HOST_RAM_HEADROOM_MIB * 1024 * 1024,
                 # -nkvo is not a reason to decline: it moves the cache and the
                 # recurrent state OUT of VRAM, so the deficit is smaller, not
                 # larger.

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -24174,8 +24174,7 @@ class LlamaCppBackend:
                     + self._PIPELINE_PER_DEVICE_OVERHEAD_MIB * 1024 * 1024
                     + int(inputs.get("ctx_compute_per_device") or 0)
                 ),
-                # Module-level, unlike _PIPELINE_PER_DEVICE_OVERHEAD_MIB on the line
-                # above, so it is not reachable through self.
+                # Module-level, unlike the line above, so not reachable through self.
                 host_ram_headroom_bytes = _HOST_RAM_HEADROOM_MIB * 1024 * 1024,
                 # -nkvo is not a reason to decline: it moves the cache and the
                 # recurrent state OUT of VRAM, so the deficit is smaller, not

--- a/studio/backend/tests/test_offload_planner_seam.py
+++ b/studio/backend/tests/test_offload_planner_seam.py
@@ -61,10 +61,15 @@ def sparse_adapter(tmp_path_factory):
 
 
 class _Stub:
-    """Only what the seam touches."""
+    """Only what the seam touches.
+
+    Deliberately does NOT declare _HOST_RAM_HEADROOM_MIB. That constant is
+    module-level, not a class attribute, so declaring it here let the seam read it off
+    the double while the real backend raised AttributeError on every planned load. The
+    double must not be able to supply an attribute the real class lacks.
+    """
 
     _PIPELINE_PER_DEVICE_OVERHEAD_MIB = 1024
-    _HOST_RAM_HEADROOM_MIB = 2048
     # Discrete by default, so every existing case here is a discrete host. The
     # unified answer is the APU's, and it is exercised deliberately below.
     _unified = False
@@ -187,6 +192,31 @@ def _plan(
 
 
 # ------------------------------------------------------------------ the gate
+
+
+def test_the_seam_reads_no_attribute_the_real_backend_lacks():
+    """The planner is default-on, so every GGUF load runs this seam against the REAL
+    class, not the double above.
+
+    _planned_tensor_spill read the host-RAM headroom as self._HOST_RAM_HEADROOM_MIB,
+    copying the shape of _PIPELINE_PER_DEVICE_OVERHEAD_MIB on the line above it, but
+    that one is a class attribute and the headroom is module-level. Every load that
+    reached the planning call raised
+
+        'LlamaCppBackend' object has no attribute '_HOST_RAM_HEADROOM_MIB'
+
+    and came back as a 500. Observed loading a 67.6 GB GGUF on a Colab T4 high-RAM VM.
+    The whole seam suite stayed green because the double declared the attribute the
+    real class was missing."""
+    import inspect
+
+    for name in ("_HOST_RAM_HEADROOM_MIB",):
+        assert not hasattr(_Stub, name), (
+            f"the double declares {name}, so it can hide a missing attribute on the "
+            "real backend again"
+        )
+    source = inspect.getsource(LlamaCppBackend._planned_tensor_spill)
+    assert "self._HOST_RAM_HEADROOM_MIB" not in source
 
 
 def test_the_planner_is_on_by_default():

--- a/studio/backend/tests/test_offload_planner_seam.py
+++ b/studio/backend/tests/test_offload_planner_seam.py
@@ -63,10 +63,9 @@ def sparse_adapter(tmp_path_factory):
 class _Stub:
     """Only what the seam touches.
 
-    Deliberately does NOT declare _HOST_RAM_HEADROOM_MIB. That constant is
-    module-level, not a class attribute, so declaring it here let the seam read it off
-    the double while the real backend raised AttributeError on every planned load. The
-    double must not be able to supply an attribute the real class lacks.
+    Must NOT declare _HOST_RAM_HEADROOM_MIB: that constant is module-level, so
+    declaring it here let the double supply what the real backend lacked, hiding an
+    AttributeError on every planned load.
     """
 
     _PIPELINE_PER_DEVICE_OVERHEAD_MIB = 1024
@@ -198,16 +197,10 @@ def test_the_seam_reads_no_attribute_the_real_backend_lacks():
     """The planner is default-on, so every GGUF load runs this seam against the REAL
     class, not the double above.
 
-    _planned_tensor_spill read the host-RAM headroom as self._HOST_RAM_HEADROOM_MIB,
-    copying the shape of _PIPELINE_PER_DEVICE_OVERHEAD_MIB on the line above it, but
-    that one is a class attribute and the headroom is module-level. Every load that
-    reached the planning call raised
-
-        'LlamaCppBackend' object has no attribute '_HOST_RAM_HEADROOM_MIB'
-
-    and came back as a 500. Observed loading a 67.6 GB GGUF on a Colab T4 high-RAM VM.
-    The whole seam suite stayed green because the double declared the attribute the
-    real class was missing."""
+    _planned_tensor_spill read the headroom as self._HOST_RAM_HEADROOM_MIB, but that
+    constant is module-level, so every planned load 500'd with AttributeError (seen on
+    a 67.6 GB GGUF, Colab T4 high-RAM). The suite stayed green only because the double
+    declared it."""
     import inspect
 
     for name in ("_HOST_RAM_HEADROOM_MIB",):


### PR DESCRIPTION
## The bug

`_planned_tensor_spill` reads the host-RAM headroom off `self`:

```python
host_ram_headroom_bytes = self._HOST_RAM_HEADROOM_MIB * 1024 * 1024,
```

It copies the shape of `_PIPELINE_PER_DEVICE_OVERHEAD_MIB` on the line directly above it. That one is a class attribute (`llama_cpp.py:9597`). The headroom is **module-level** (`llama_cpp.py:4721`), so it is not reachable through `self`, and every load that got as far as the planning call raised:

```
'LlamaCppBackend' object has no attribute '_HOST_RAM_HEADROOM_MIB'
```

which reached the client as a 500. Since #9779 the planner is on by default, so this sits on the path of every GGUF load rather than an opt-in one.

Observed loading `unsloth/Qwen3.8-Flash-Next-GGUF` UD-IQ1_S on a Colab T4 high-RAM VM: `llama-server` never spawned, and `POST /api/inference/load` returned 500 after 25s.

## Why no test caught it

The seam suite passed through all of it, because the `_Stub` double declared the attribute itself:

```python
class _Stub:
    _PIPELINE_PER_DEVICE_OVERHEAD_MIB = 1024
    _HOST_RAM_HEADROOM_MIB = 2048   # the real class has no such attribute
```

The lookup found it on the double and never on the class under test, so 126 tests exercised a path that could not work in production.

## The fix

Read the module-level constant, and drop the line from the double so it can never supply an attribute the real class lacks. That second half is most of the value: with the double's declaration gone and the source left unpatched, **66 of the 127 seam tests fail**.

A named test also asserts the double declares no such attribute and that the seam source no longer reaches for this one through `self`.

## Verification

- `tests/test_offload_planner_seam.py`: **127 passed** with the fix.
- Same suite against the unpatched source, with only the double's line removed: **66 failed, 61 passed**, confirming the tests now cover the real lookup.