### PR TITLE
Studio: keep the memory row readable on a narrow panel

### DIFF
--- a/studio/frontend/src/features/model-picker/components/model-config-page.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-config-page.tsx
@@ -80,6 +80,7 @@ import { resolveEstimateContext } from "../model-config/estimate-context";
 import {
   type MemoryFitVerdict,
   formatMemoryGb,
+  glueNoteItems,
   resolveDraftCacheNote,
   resolveKvNote,
   resolveMemoryFit,
@@ -955,7 +956,7 @@ function MemoryBreakdownLine({
       <span className="min-w-0 text-ui-11 leading-relaxed text-muted-foreground">
         {label}
         {note ? (
-          <span className="ml-1 text-muted-foreground/70">{note}</span>
+          <span className="ml-1 text-muted-foreground/70">{glueNoteItems(note)}</span>
         ) : null}
       </span>
       <span
@@ -1035,7 +1036,13 @@ function MemoryEstimateRow({
   );
   return (
     <div className="space-y-2">
-      <div className={ROW_CLASS}>
+      {/* Wraps, unlike the other rows, because this one is the only header carrying a
+          title AND two figures. The panel is w-[min(468px,...)], so under a ~460px
+          window it shrinks with the viewport, and the figures do not shrink: the
+          title absorbed the whole shortfall and truncated to "E..." at 320px. Letting
+          the figures drop to their own line costs a line only where they would not
+          have fitted anyway, and is identical above that width. */}
+      <div className={`${ROW_CLASS} flex-wrap gap-y-1`}>
         <button
           type="button"
           onClick={() => onExpandedChange(!expanded)}
@@ -1053,8 +1060,10 @@ function MemoryEstimateRow({
             strokeWidth={1.75}
           />
         </button>
+        {/* ml-auto so that on the wrapped line, where justify-between has nothing to
+            push against, the figures still sit under the right edge they had. */}
         <div
-          className={`flex shrink-0 items-center gap-3 transition-opacity ${stale || loading ? "opacity-50" : ""}`}
+          className={`ml-auto flex shrink-0 items-center gap-3 transition-opacity ${stale || loading ? "opacity-50" : ""}`}
         >
           {/* One pool: offloading a layer moves it within the same memory rather
               than out of it, so the honest single figure is the total. Reporting

--- a/studio/frontend/src/features/model-picker/model-config/memory-fit.ts
+++ b/studio/frontend/src/features/model-picker/model-config/memory-fit.ts
@@ -320,7 +320,7 @@ export function resolveMemoryAdvisory(
 export const NOTE_SEPARATOR = " · ";
 
 /**
- * The same caption, breakable only between its items.
+ * A separated caption, breakable only between its items.
  *
  * A caption like "f16 · 262,144 tokens · 4 slots" does not fit the panel once the
  * window is narrow enough to shrink it, and left to itself the browser breaks at the
@@ -328,10 +328,19 @@ export const NOTE_SEPARATOR = " · ";
  * Gluing each item together with U+00A0 leaves exactly one break opportunity per
  * bullet, and gluing the bullet to the item that FOLLOWS it means the break lands
  * before the bullet rather than orphaning it at the end of the previous line.
+ *
+ * A note with NO separator is returned untouched. It has no items to keep apart, so
+ * gluing it would buy nothing and cost every break opportunity it had: the Weights and
+ * Draft cache notes are ordinary prose ("256 of 257 layers on GPU"), and glued they
+ * became a single unbreakable run that overflows the caption column rather than
+ * wrapping inside it, which is worse than the orphan this function exists to prevent.
  */
 export function glueNoteItems(note: string): string {
-  return note
-    .split(NOTE_SEPARATOR)
+  const items = note.split(NOTE_SEPARATOR);
+  if (items.length < 2) {
+    return note;
+  }
+  return items
     .map((item, index) => {
       const glued = item.replace(/ /g, "\u00a0");
       return index === 0 ? glued : `\u00b7\u00a0${glued}`;

--- a/studio/frontend/src/features/model-picker/model-config/memory-fit.ts
+++ b/studio/frontend/src/features/model-picker/model-config/memory-fit.ts
@@ -316,6 +316,29 @@ export function resolveMemoryAdvisory(
   return null;
 }
 
+/** What `resolveKvNote` joins its items with, and what `glueNoteItems` splits on. */
+export const NOTE_SEPARATOR = " · ";
+
+/**
+ * The same caption, breakable only between its items.
+ *
+ * A caption like "f16 · 262,144 tokens · 4 slots" does not fit the panel once the
+ * window is narrow enough to shrink it, and left to itself the browser breaks at the
+ * last space that fits -- which put "slots" alone on a line under "... tokens · 4".
+ * Gluing each item together with U+00A0 leaves exactly one break opportunity per
+ * bullet, and gluing the bullet to the item that FOLLOWS it means the break lands
+ * before the bullet rather than orphaning it at the end of the previous line.
+ */
+export function glueNoteItems(note: string): string {
+  return note
+    .split(NOTE_SEPARATOR)
+    .map((item, index) => {
+      const glued = item.replace(/ /g, "\u00a0");
+      return index === 0 ? glued : `\u00b7\u00a0${glued}`;
+    })
+    .join(" ");
+}
+
 /** The KV line's caption: dtype, what was priced, and where it lives. */
 export function resolveKvNote(estimate: {
   cacheTypeKv: string | null;

--- a/studio/frontend/tests/memory-estimate-narrow-panel.test.ts
+++ b/studio/frontend/tests/memory-estimate-narrow-panel.test.ts
@@ -15,7 +15,11 @@ import path from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
 
-import { glueNoteItems, resolveKvNote } from "../src/features/model-picker/model-config/memory-fit.ts";
+import {
+  glueNoteItems,
+  resolveDraftCacheNote,
+  resolveKvNote,
+} from "../src/features/model-picker/model-config/memory-fit.ts";
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const CONFIG_PAGE = readFileSync(
@@ -66,9 +70,30 @@ test("the bullet leads its item, so a break cannot orphan it", () => {
   }
 });
 
-test("a one-item note is unchanged apart from its own glue", () => {
-  assert.equal(glueNoteItems("host RAM"), `host${NBSP}RAM`);
-  assert.equal(glueNoteItems("f16"), "f16");
+test("a note with no separator keeps every break opportunity it had", () => {
+  // Only the KV caption is a list. Weights and Draft cache are ordinary prose, and
+  // gluing those bought nothing while costing them the ability to wrap at all, so a
+  // long one ran past the caption column into the value instead of wrapping inside it.
+  for (const note of [
+    "256 of 257 layers on GPU",
+    "2.14 GB on GPU",
+    "host RAM",
+    "f16",
+  ]) {
+    assert.equal(glueNoteItems(note), note);
+    assert.doesNotMatch(glueNoteItems(note), new RegExp(NBSP));
+  }
+});
+
+test("the notes the row actually builds are left breakable", () => {
+  // The two non-list note sources, at their real call sites in model-config-page.
+  assert.match(CONFIG_PAGE, /layers on GPU`/);
+  const hostNote = resolveDraftCacheNote(0, 1e9);
+  assert.equal(hostNote, "host RAM");
+  for (const note of ["256 of 257 layers on GPU", hostNote ?? ""]) {
+    const spaces = (glueNoteItems(note).match(/ /g) || []).length;
+    assert.ok(spaces > 0, `${note} has no break opportunity left`);
+  }
 });
 
 test("gluing round-trips the note the row actually builds", () => {

--- a/studio/frontend/tests/memory-estimate-narrow-panel.test.ts
+++ b/studio/frontend/tests/memory-estimate-narrow-panel.test.ts
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// The Estimated Memory Usage header is the only row in the panel carrying a title AND
+// two figures, and the panel is w-[min(468px,calc(100vw-1rem))] -- so under a ~460px
+// window it shrinks while the figures do not. Measured on the merged build at 320px
+// the title had been squeezed from 150px to 11px and rendered as "E...", which is what
+// was reported. The layout half is asserted against the source, the idiom
+// tensor-parallel-row-gating already uses for markup that cannot be imported; the note
+// half is a pure function and is exercised directly.
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { glueNoteItems, resolveKvNote } from "../src/features/model-picker/model-config/memory-fit.ts";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const CONFIG_PAGE = readFileSync(
+  path.join(
+    HERE,
+    "..",
+    "src/features/model-picker/components/model-config-page.tsx",
+  ),
+  "utf8",
+);
+
+const NBSP = " ";
+
+test("the memory header may wrap, so the figures drop rather than eat the title", () => {
+  assert.match(CONFIG_PAGE, /\$\{ROW_CLASS\} flex-wrap gap-y-1/);
+});
+
+test("the wrapped figures still sit at the right edge", () => {
+  // justify-between has nothing to push against on a line holding one item, so
+  // without this the figures jump to the left margin when they wrap.
+  assert.match(CONFIG_PAGE, /className=\{`ml-auto flex shrink-0 items-center gap-3/);
+});
+
+test("the header title is still allowed to truncate as a backstop", () => {
+  // Wrapping is what keeps it whole at the widths that matter; truncation stays for a
+  // locale whose title does not fit a line of its own. Dropping min-w-0 here would
+  // overflow the panel instead.
+  assert.match(
+    CONFIG_PAGE,
+    /className="flex min-w-0 items-center gap-1\.5 rounded-sm text-left/,
+  );
+});
+
+test("breakdown notes are rendered glued", () => {
+  assert.match(CONFIG_PAGE, /\{glueNoteItems\(note\)\}/);
+});
+
+test("an item's own spaces do not break", () => {
+  const glued = glueNoteItems("f16 · 262,144 tokens · 4 slots");
+  assert.equal(glued, `f16 ·${NBSP}262,144${NBSP}tokens ·${NBSP}4${NBSP}slots`);
+  // The only ordinary spaces left are the ones a line may break at: one per bullet.
+  assert.equal(glued.split(" ").length - 1, 2);
+});
+
+test("the bullet leads its item, so a break cannot orphan it", () => {
+  for (const item of glueNoteItems("f16 · 4 slots").split(" ").slice(1)) {
+    assert.ok(item.startsWith(`·${NBSP}`), `bullet detached from ${item}`);
+  }
+});
+
+test("a one-item note is unchanged apart from its own glue", () => {
+  assert.equal(glueNoteItems("host RAM"), `host${NBSP}RAM`);
+  assert.equal(glueNoteItems("f16"), "f16");
+});
+
+test("gluing round-trips the note the row actually builds", () => {
+  const note = resolveKvNote({
+    cacheTypeKv: "q8_0",
+    nCtx: 262144,
+    nParallel: 4,
+    kvOnGpu: false,
+  });
+  // Same text to a reader, and to anyone grepping the panel: only the spaces differ.
+  assert.equal(glueNoteItems(note).replace(new RegExp(NBSP, "g"), " "), note);
+});


### PR DESCRIPTION
Follow-up to #9525. The Estimated Memory Usage row is unreadable once the panel gets narrow.

## What happens

The model config panel is `w-[min(468px,calc(100vw-1rem))]`, so below roughly a 460px viewport it stops being 468px and shrinks with the window. That header is the only row in the panel carrying a title and two figures at once, and the figures are `shrink-0`, so the title absorbed the entire shortfall. Measured on the current build, with the same model at each width:

| viewport | title width | clipped |
| --- | --- | --- |
| 1500px | 150px | no |
| 500px | 150px | no |
| 460px | 150px | no |
| 400px | 91px | yes |
| 360px | 51px | yes |
| 320px | 11px | yes |

At 320px "Estimated Memory Usage" renders as "E...", which leaves a row reading `E. BETA ^ GPU 2.14 GB Total 2.14 GB`. With a larger model it is worse, because the figures are wider: at four significant digits the title is gone entirely and the Beta badge collides with the GPU caption.

## The fix

Let that header wrap. The figures drop to a line of their own only at the widths where they would not have fitted beside the title anyway, and `ml-auto` keeps them under the right edge they already had, since `justify-between` has nothing to push against on a line holding one item. At 460px and above the layout is byte for byte what it was: same row height, same title width, same single line.

The `min-w-0 truncate` on the title stays as the backstop for a locale whose title does not fit a line of its own. Dropping it would overflow the panel rather than clip.

## Breakdown captions

Smaller version of the same problem. `f16 . 262,144 tokens . 4 slots` broke at whatever space happened to fit, which put the word "slots" alone on a line under `... tokens . 4`. `glueNoteItems` joins each item with U+00A0, leaving exactly one break opportunity per bullet, and attaches the bullet to the item that follows it so the break lands before the bullet rather than orphaning it at the end of the previous line. Measured in the real 183px caption column, the last line goes from a 22px fragment to the whole 38px item.

## Before and after

Left is the current build, right is this branch, same model and same server, photographed at 400px and 320px.

![narrow panel before and after](https://raw.githubusercontent.com/danielhanchen/unsloth-staging-2/ui-evidence/memory-row-narrow-panel.png)

## Checks

- `npm test` 5647 passed, 0 failed
- `npm run typecheck` clean, `npm run build` clean, `npm run i18n:check:strict` no errors
- `npx eslint` on both touched files reports the same 8 pre-existing errors as on `main`, none of them new
- `tests/memory-estimate-narrow-panel.test.ts` added; its three layout assertions and both note assertions fail on the parent commit, the fourth is a deliberate pin that the truncation backstop is still there



Rebased onto `main` after #9825 landed. Both touched the same two files, so this was re-verified rather than assumed to be safe: all 8 assertions in the new test still pass against the reworded comments, the full frontend suite is 5647 passed and 0 failed, and `npm run typecheck` is clean.
