### PR TITLE
Studio: read the memory row's captions past their line-breaking glue

### DIFF
--- a/tests/studio/playwright_memory_estimate.py
+++ b/tests/studio/playwright_memory_estimate.py
@@ -676,12 +676,23 @@ with sync_playwright() as p:
             page.wait_for_timeout(200)
         return estimate_visible() == present
 
+    def _readable(raw: str | None) -> str:
+        """`inner_text` with the row's layout glue normalised back to plain spaces.
+
+        The breakdown captions join their items with U+00A0 so a narrow panel breaks
+        between "262,144 tokens" and "4 slots" rather than inside either. That is a
+        line-breaking detail and not something a reader distinguishes, but it does
+        defeat a plain `"6,144 tokens" in text` check, so every assertion below reads
+        the caption the way it looks rather than the way it is encoded.
+        """
+        return (raw or "").replace(" ", " ").strip()
+
     def header_text() -> str:
         button = estimate_button()
         if button is None:
             return ""
         try:
-            return (button.locator("xpath=..").inner_text() or "").strip()
+            return _readable(button.locator("xpath=..").inner_text())
         except Exception:
             return ""
 
@@ -701,7 +712,7 @@ with sync_playwright() as p:
         if _count(panel) == 0:
             return ""
         try:
-            return (panel.inner_text() or "").strip()
+            return _readable(panel.inner_text())
         except Exception:
             return ""
 


### PR DESCRIPTION
Fixes the `Chat UI Tests (picker)` failure that #9824 left on `main`.

## What broke

#9824 made the memory row's breakdown captions join their items with U+00A0, so a narrow panel breaks between `262,144 tokens` and `4 slots` rather than inside either. `tests/studio/playwright_memory_estimate.py` asserts on those captions with a plain substring check, and that stopped matching: the space between the figure and the word is no longer a space.

The figure itself was always correct. From the staging run:

```
KV cache f16 ·\xa06,144\xa0tokens
FAIL: the KV note does not quote the priced context '6,144 tokens'
```

`6,144` is exactly what the response priced and exactly what is on screen. Only the encoding of the separator changed, so the scene was reporting a mismatch that a reader cannot see.

I should have caught this in #9824. The two commits went in together on the branch and the scene is not part of `npm test`, so nothing local exercised it.

## The fix

Normalise U+00A0 back to an ordinary space in the two `inner_text` readers the assertions go through, so every check reads the caption the way it looks rather than the way it is encoded. Nothing else in the scene changes, and the placement note (`12 of 28 layers on GPU`) keeps matching as before.

Verified against the exact strings the failing run produced, both assertions:

| assertion | before | after |
| --- | --- | --- |
| `'6,144 tokens'` in the KV note | no match | matches |
| `'4,096 tokens'` in the restored note | no match | matches |
| `'12 of 28 layers on GPU'` | matches | matches |
