### PR TITLE
Studio: persist model disclaimer across instances

### DIFF
--- a/studio/backend/routes/settings.py
+++ b/studio/backend/routes/settings.py
@@ -898,9 +898,7 @@ def _download_transport_response(mode: str | None = None) -> DownloadTransportRe
 
 def _chat_preferences_response(enabled: bool | None = None) -> ChatPreferencesResponse:
     return ChatPreferencesResponse(
-        show_model_disclaimer = (
-            get_show_model_disclaimer() if enabled is None else enabled
-        )
+        show_model_disclaimer = (get_show_model_disclaimer() if enabled is None else enabled)
     )
 
 
@@ -1196,8 +1194,7 @@ def get_chat_preferences(
 
 @router.put("/chat-preferences", response_model = ChatPreferencesResponse)
 def update_chat_preferences(
-    payload: ChatPreferencesPayload,
-    current_subject: str = Depends(get_current_subject),
+    payload: ChatPreferencesPayload, current_subject: str = Depends(get_current_subject)
 ) -> ChatPreferencesResponse:
     try:
         enabled = set_show_model_disclaimer(payload.show_model_disclaimer)
@@ -1214,8 +1211,7 @@ def update_chat_preferences(
 
 @router.post("/chat-preferences/migrate", response_model = ChatPreferencesResponse)
 def migrate_chat_preferences(
-    payload: ChatPreferencesMigrationPayload,
-    current_subject: str = Depends(get_current_subject),
+    payload: ChatPreferencesMigrationPayload, current_subject: str = Depends(get_current_subject)
 ) -> ChatPreferencesResponse:
     try:
         enabled = migrate_show_model_disclaimer(payload.show_model_disclaimer)

--- a/studio/backend/routes/settings.py
+++ b/studio/backend/routes/settings.py
@@ -45,6 +45,11 @@ from utils.upload_limits import (
     upload_limit_label,
 )
 from utils.xet_notice_settings import reserve_xet_notice
+from utils.chat_preferences_settings import (
+    get_show_model_disclaimer,
+    migrate_show_model_disclaimer,
+    set_show_model_disclaimer,
+)
 from utils.helper_precache_settings import (
     DEFAULT_HELPER_PRECACHE_ENABLED,
     get_helper_precache_enabled,
@@ -608,6 +613,18 @@ class XetNoticeResponse(BaseModel):
     limit: int
 
 
+class ChatPreferencesPayload(BaseModel):
+    show_model_disclaimer: StrictBool
+
+
+class ChatPreferencesMigrationPayload(BaseModel):
+    show_model_disclaimer: Optional[StrictBool] = None
+
+
+class ChatPreferencesResponse(BaseModel):
+    show_model_disclaimer: bool
+
+
 class ModelMemoryPayload(BaseModel):
     # None leaves the stored value untouched, so the switches save independently.
     keep_resident: Optional[bool] = None
@@ -876,6 +893,14 @@ def _download_transport_response(mode: str | None = None) -> DownloadTransportRe
         xet_unavailable_reason = caps.xet.reason,
         auto_resolves_to = caps.auto_resolves_to,
         auto_reason = caps.auto_reason,
+    )
+
+
+def _chat_preferences_response(enabled: bool | None = None) -> ChatPreferencesResponse:
+    return ChatPreferencesResponse(
+        show_model_disclaimer = (
+            get_show_model_disclaimer() if enabled is None else enabled
+        )
     )
 
 
@@ -1160,6 +1185,49 @@ def post_xet_notice_reserve(
             log = logger,
         ) from exc
     return XetNoticeResponse(**result)
+
+
+@router.get("/chat-preferences", response_model = ChatPreferencesResponse)
+def get_chat_preferences(
+    current_subject: str = Depends(get_current_subject),
+) -> ChatPreferencesResponse:
+    return _chat_preferences_response()
+
+
+@router.put("/chat-preferences", response_model = ChatPreferencesResponse)
+def update_chat_preferences(
+    payload: ChatPreferencesPayload,
+    current_subject: str = Depends(get_current_subject),
+) -> ChatPreferencesResponse:
+    try:
+        enabled = set_show_model_disclaimer(payload.show_model_disclaimer)
+    except Exception as exc:
+        raise log_and_http_error(
+            exc,
+            500,
+            safe_error_detail(exc, fallback = "Could not save chat preferences."),
+            event = "settings.update_chat_preferences_failed",
+            log = logger,
+        ) from exc
+    return _chat_preferences_response(enabled)
+
+
+@router.post("/chat-preferences/migrate", response_model = ChatPreferencesResponse)
+def migrate_chat_preferences(
+    payload: ChatPreferencesMigrationPayload,
+    current_subject: str = Depends(get_current_subject),
+) -> ChatPreferencesResponse:
+    try:
+        enabled = migrate_show_model_disclaimer(payload.show_model_disclaimer)
+    except Exception as exc:
+        raise log_and_http_error(
+            exc,
+            500,
+            safe_error_detail(exc, fallback = "Could not migrate chat preferences."),
+            event = "settings.migrate_chat_preferences_failed",
+            log = logger,
+        ) from exc
+    return _chat_preferences_response(enabled)
 
 
 @router.get("/model-memory", response_model = ModelMemoryResponse)

--- a/studio/backend/tests/test_chat_preferences_settings.py
+++ b/studio/backend/tests/test_chat_preferences_settings.py
@@ -28,10 +28,7 @@ def test_legacy_value_only_seeds_an_empty_server():
 def test_disabled_or_missing_legacy_value_does_not_claim_the_server_default():
     assert preferences.migrate_show_model_disclaimer(False) is False
     assert preferences.migrate_show_model_disclaimer(None) is False
-    assert (
-        studio_db.get_app_setting(preferences.MODEL_DISCLAIMER_SETTING_KEY, None)
-        is None
-    )
+    assert studio_db.get_app_setting(preferences.MODEL_DISCLAIMER_SETTING_KEY, None) is None
     assert preferences.migrate_show_model_disclaimer(True) is True
 
 
@@ -61,9 +58,7 @@ def test_route_round_trip_and_migration(monkeypatch):
     app.dependency_overrides[settings.get_current_subject] = lambda: "admin"
     client = TestClient(app)
 
-    assert client.get("/chat-preferences").json() == {
-        "show_model_disclaimer": False
-    }
+    assert client.get("/chat-preferences").json() == {"show_model_disclaimer": False}
     assert client.post("/chat-preferences/migrate", json = {}).json() == {
         "show_model_disclaimer": False
     }
@@ -73,9 +68,7 @@ def test_route_round_trip_and_migration(monkeypatch):
     assert client.post(
         "/chat-preferences/migrate", json = {"show_model_disclaimer": False}
     ).json() == {"show_model_disclaimer": True}
-    assert client.put(
-        "/chat-preferences", json = {"show_model_disclaimer": False}
-    ).json() == {"show_model_disclaimer": False}
-    assert client.put(
-        "/chat-preferences", json = {"show_model_disclaimer": "yes"}
-    ).status_code == 422
+    assert client.put("/chat-preferences", json = {"show_model_disclaimer": False}).json() == {
+        "show_model_disclaimer": False
+    }
+    assert client.put("/chat-preferences", json = {"show_model_disclaimer": "yes"}).status_code == 422

--- a/studio/backend/tests/test_chat_preferences_settings.py
+++ b/studio/backend/tests/test_chat_preferences_settings.py
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from storage import studio_db
+from utils import chat_preferences_settings as preferences
+
+
+def test_missing_preference_defaults_off():
+    assert preferences.get_show_model_disclaimer() is False
+
+
+def test_saved_preference_survives_a_fresh_connection():
+    assert preferences.set_show_model_disclaimer(True) is True
+    assert preferences.get_show_model_disclaimer() is True
+
+
+def test_legacy_value_only_seeds_an_empty_server():
+    assert preferences.migrate_show_model_disclaimer(True) is True
+    assert preferences.migrate_show_model_disclaimer(False) is True
+    assert preferences.get_show_model_disclaimer() is True
+
+
+def test_disabled_or_missing_legacy_value_does_not_claim_the_server_default():
+    assert preferences.migrate_show_model_disclaimer(False) is False
+    assert preferences.migrate_show_model_disclaimer(None) is False
+    assert (
+        studio_db.get_app_setting(preferences.MODEL_DISCLAIMER_SETTING_KEY, None)
+        is None
+    )
+    assert preferences.migrate_show_model_disclaimer(True) is True
+
+
+def test_route_round_trip_and_migration(monkeypatch):
+    from routes import settings
+
+    stored = {"value": None}
+
+    def get_value():
+        return False if stored["value"] is None else stored["value"]
+
+    def set_value(value):
+        stored["value"] = value
+        return value
+
+    def migrate_value(value):
+        if stored["value"] is None and value is not None:
+            stored["value"] = value
+        return get_value()
+
+    monkeypatch.setattr(settings, "get_show_model_disclaimer", get_value)
+    monkeypatch.setattr(settings, "set_show_model_disclaimer", set_value)
+    monkeypatch.setattr(settings, "migrate_show_model_disclaimer", migrate_value)
+
+    app = FastAPI()
+    app.include_router(settings.router)
+    app.dependency_overrides[settings.get_current_subject] = lambda: "admin"
+    client = TestClient(app)
+
+    assert client.get("/chat-preferences").json() == {
+        "show_model_disclaimer": False
+    }
+    assert client.post("/chat-preferences/migrate", json = {}).json() == {
+        "show_model_disclaimer": False
+    }
+    assert client.post(
+        "/chat-preferences/migrate", json = {"show_model_disclaimer": True}
+    ).json() == {"show_model_disclaimer": True}
+    assert client.post(
+        "/chat-preferences/migrate", json = {"show_model_disclaimer": False}
+    ).json() == {"show_model_disclaimer": True}
+    assert client.put(
+        "/chat-preferences", json = {"show_model_disclaimer": False}
+    ).json() == {"show_model_disclaimer": False}
+    assert client.put(
+        "/chat-preferences", json = {"show_model_disclaimer": "yes"}
+    ).status_code == 422

--- a/studio/backend/utils/chat_preferences_settings.py
+++ b/studio/backend/utils/chat_preferences_settings.py
@@ -20,7 +20,6 @@ def _stored_bool(value: object) -> Optional[bool]:
 
 def get_show_model_disclaimer() -> bool:
     from storage.studio_db import get_app_setting
-
     stored = _stored_bool(get_app_setting(MODEL_DISCLAIMER_SETTING_KEY, None))
     return DEFAULT_SHOW_MODEL_DISCLAIMER if stored is None else stored
 

--- a/studio/backend/utils/chat_preferences_settings.py
+++ b/studio/backend/utils/chat_preferences_settings.py
@@ -1,0 +1,82 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Installation-wide chat preferences."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from typing import Optional
+
+
+MODEL_DISCLAIMER_SETTING_KEY = "chat_show_model_disclaimer"
+DEFAULT_SHOW_MODEL_DISCLAIMER = False
+
+
+def _stored_bool(value: object) -> Optional[bool]:
+    return value if isinstance(value, bool) else None
+
+
+def get_show_model_disclaimer() -> bool:
+    from storage.studio_db import get_app_setting
+
+    stored = _stored_bool(get_app_setting(MODEL_DISCLAIMER_SETTING_KEY, None))
+    return DEFAULT_SHOW_MODEL_DISCLAIMER if stored is None else stored
+
+
+def set_show_model_disclaimer(enabled: bool) -> bool:
+    if not isinstance(enabled, bool):
+        raise ValueError("Model disclaimer setting must be a boolean.")
+    from storage.studio_db import upsert_app_settings
+
+    upsert_app_settings({MODEL_DISCLAIMER_SETTING_KEY: enabled})
+    return enabled
+
+
+def migrate_show_model_disclaimer(legacy: Optional[bool]) -> bool:
+    """Import an enabled browser value only when the server has none."""
+    if legacy is not None and not isinstance(legacy, bool):
+        raise ValueError("Legacy model disclaimer setting must be a boolean.")
+
+    from storage.studio_db import get_connection
+
+    conn = get_connection()
+    try:
+        conn.execute("BEGIN IMMEDIATE")
+        row = conn.execute(
+            "SELECT value_json FROM app_settings WHERE key = ?",
+            (MODEL_DISCLAIMER_SETTING_KEY,),
+        ).fetchone()
+        stored = None
+        if row is not None:
+            try:
+                stored = _stored_bool(json.loads(row["value_json"]))
+            except (TypeError, ValueError):
+                stored = None
+
+        if stored is not None:
+            conn.commit()
+            return stored
+        if legacy is not True:
+            conn.commit()
+            return DEFAULT_SHOW_MODEL_DISCLAIMER
+
+        now = datetime.now(timezone.utc).isoformat()
+        conn.execute(
+            """
+            INSERT INTO app_settings (key, value_json, updated_at)
+            VALUES (?, ?, ?)
+            ON CONFLICT(key) DO UPDATE SET
+                value_json = excluded.value_json,
+                updated_at = excluded.updated_at
+            """,
+            (MODEL_DISCLAIMER_SETTING_KEY, json.dumps(legacy), now),
+        )
+        conn.commit()
+        return legacy
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()

--- a/studio/frontend/src/app/routes/__root.tsx
+++ b/studio/frontend/src/app/routes/__root.tsx
@@ -16,6 +16,7 @@ import {
   ChatPage,
   type ChatSearch,
   clearNewChatDraft,
+  hydrateModelDisclaimerPreference,
   StopRunningChatsDialog,
   useChatRuntimeStore,
 } from "@/features/chat";
@@ -154,6 +155,7 @@ function ChatSettingsHydrationMount() {
   );
   useEffect(() => {
     void hydratePersistedSettings();
+    hydrateModelDisclaimerPreference().catch(() => undefined);
   }, [hydratePersistedSettings]);
   return null;
 }

--- a/studio/frontend/src/features/chat/api/chat-preferences.ts
+++ b/studio/frontend/src/features/chat/api/chat-preferences.ts
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import { authFetch } from "@/features/auth";
+import { readFastApiError } from "@/lib/format-fastapi-error";
+
+interface ApiChatPreferences {
+  // biome-ignore lint/style/useNamingConvention: API schema
+  show_model_disclaimer: boolean;
+}
+
+export interface ChatPreferences {
+  showModelDisclaimer: boolean;
+}
+
+function fromApi(settings: unknown): ChatPreferences {
+  const value = (settings as Partial<ApiChatPreferences> | null)
+    ?.show_model_disclaimer;
+  if (typeof value !== "boolean") {
+    throw new Error("Invalid chat preferences response");
+  }
+  return { showModelDisclaimer: value };
+}
+
+async function requestPreferences(
+  path: string,
+  init?: RequestInit,
+): Promise<ChatPreferences> {
+  const res = await authFetch(path, init);
+  if (!res.ok) {
+    throw new Error(
+      await readFastApiError(res, "Could not load chat preferences"),
+    );
+  }
+  return fromApi(await res.json());
+}
+
+export function loadChatPreferences(): Promise<ChatPreferences> {
+  return requestPreferences("/api/settings/chat-preferences");
+}
+
+export function migrateChatPreferences(
+  showModelDisclaimer: boolean | undefined,
+): Promise<ChatPreferences> {
+  return requestPreferences("/api/settings/chat-preferences/migrate", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(
+      showModelDisclaimer === undefined
+        ? {}
+        : {
+            // biome-ignore lint/style/useNamingConvention: API schema
+            show_model_disclaimer: showModelDisclaimer,
+          },
+    ),
+  });
+}
+
+export function updateChatPreferences(
+  showModelDisclaimer: boolean,
+): Promise<ChatPreferences> {
+  return requestPreferences("/api/settings/chat-preferences", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      // biome-ignore lint/style/useNamingConvention: API schema
+      show_model_disclaimer: showModelDisclaimer,
+    }),
+  });
+}

--- a/studio/frontend/src/features/chat/index.ts
+++ b/studio/frontend/src/features/chat/index.ts
@@ -54,6 +54,11 @@ export {
   type Preset,
 } from "./chat-settings-sheet";
 export { useChatRuntimeStore } from "./stores/chat-runtime-store";
+export {
+  hydrateModelDisclaimerPreference,
+  refreshModelDisclaimerPreference,
+  saveModelDisclaimerPreference,
+} from "./sync-model-disclaimer-preference";
 export { useChatActive, useInComparePane } from "./runtime-provider";
 export {
   CHAT_RAG_CAPTION_KEY,

--- a/studio/frontend/src/features/chat/sync-model-disclaimer-preference.ts
+++ b/studio/frontend/src/features/chat/sync-model-disclaimer-preference.ts
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import {
+  loadChatPreferences,
+  migrateChatPreferences,
+  updateChatPreferences,
+} from "./api/chat-preferences";
+import { useChatPreferencesStore } from "./stores/chat-preferences-store";
+
+const STORAGE_KEY = "unsloth_chat_preferences";
+
+let mutationRevision = 0;
+// Preserve request order across hydration, refreshes, and writes.
+let operationQueue: Promise<void> = Promise.resolve();
+
+function enqueue(operation: () => Promise<void>): Promise<void> {
+  const next = operationQueue.then(operation, operation);
+  operationQueue = next.catch(() => undefined);
+  return next;
+}
+
+export function readLegacyModelDisclaimer(): boolean | undefined {
+  if (typeof window === "undefined") {
+    return undefined;
+  }
+  try {
+    const raw = JSON.parse(
+      window.localStorage.getItem(STORAGE_KEY) ?? "null",
+    ) as {
+      state?: { showModelDisclaimer?: unknown };
+    } | null;
+    const value = raw?.state?.showModelDisclaimer;
+    return value === true ? true : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+async function hydrate(migrateLegacy: boolean): Promise<void> {
+  const mutation = mutationRevision;
+  const settings = migrateLegacy
+    ? await migrateChatPreferences(readLegacyModelDisclaimer())
+    : await loadChatPreferences();
+  if (mutation !== mutationRevision) {
+    return;
+  }
+  useChatPreferencesStore
+    .getState()
+    .setShowModelDisclaimer(settings.showModelDisclaimer);
+}
+
+export async function hydrateModelDisclaimerPreference(): Promise<void> {
+  await enqueue(() => hydrate(true));
+}
+
+export async function refreshModelDisclaimerPreference(): Promise<void> {
+  await enqueue(() => hydrate(false));
+}
+
+export async function saveModelDisclaimerPreference(
+  showModelDisclaimer: boolean,
+): Promise<void> {
+  const previous = useChatPreferencesStore.getState().showModelDisclaimer;
+  const mutation = ++mutationRevision;
+  useChatPreferencesStore
+    .getState()
+    .setShowModelDisclaimer(showModelDisclaimer);
+
+  await enqueue(async () => {
+    try {
+      const saved = await updateChatPreferences(showModelDisclaimer);
+      if (mutation !== mutationRevision) {
+        return;
+      }
+      useChatPreferencesStore
+        .getState()
+        .setShowModelDisclaimer(saved.showModelDisclaimer);
+    } catch (error) {
+      if (mutation === mutationRevision) {
+        try {
+          await hydrate(false);
+        } catch {
+          useChatPreferencesStore.getState().setShowModelDisclaimer(previous);
+        }
+      }
+      throw error;
+    }
+  });
+}

--- a/studio/frontend/src/features/chat/sync-model-disclaimer-preference.ts
+++ b/studio/frontend/src/features/chat/sync-model-disclaimer-preference.ts
@@ -37,12 +37,14 @@ export function readLegacyModelDisclaimer(): boolean | undefined {
   }
 }
 
-async function hydrate(migrateLegacy: boolean): Promise<void> {
-  const mutation = mutationRevision;
+async function hydrate(
+  migrateLegacy: boolean,
+  expectedMutation: number,
+): Promise<void> {
   const settings = migrateLegacy
     ? await migrateChatPreferences(readLegacyModelDisclaimer())
     : await loadChatPreferences();
-  if (mutation !== mutationRevision) {
+  if (expectedMutation !== mutationRevision) {
     return;
   }
   useChatPreferencesStore
@@ -50,12 +52,17 @@ async function hydrate(migrateLegacy: boolean): Promise<void> {
     .setShowModelDisclaimer(settings.showModelDisclaimer);
 }
 
+function enqueueHydration(migrateLegacy: boolean): Promise<void> {
+  const expectedMutation = mutationRevision;
+  return enqueue(() => hydrate(migrateLegacy, expectedMutation));
+}
+
 export async function hydrateModelDisclaimerPreference(): Promise<void> {
-  await enqueue(() => hydrate(true));
+  await enqueueHydration(true);
 }
 
 export async function refreshModelDisclaimerPreference(): Promise<void> {
-  await enqueue(() => hydrate(false));
+  await enqueueHydration(false);
 }
 
 export async function saveModelDisclaimerPreference(
@@ -79,7 +86,7 @@ export async function saveModelDisclaimerPreference(
     } catch (error) {
       if (mutation === mutationRevision) {
         try {
-          await hydrate(false);
+          await hydrate(false, mutation);
         } catch {
           useChatPreferencesStore.getState().setShowModelDisclaimer(previous);
         }

--- a/studio/frontend/src/features/settings/tabs/chat-tab.tsx
+++ b/studio/frontend/src/features/settings/tabs/chat-tab.tsx
@@ -11,6 +11,8 @@ import {
 import { Switch } from "@/components/ui/switch";
 import {
   type PlusMenuItemId,
+  refreshModelDisclaimerPreference,
+  saveModelDisclaimerPreference,
   useChatPreferencesStore,
   useChatRuntimeStore,
   usePlusMenuPrefsStore,
@@ -20,6 +22,7 @@ import { PASTED_TEXT_THRESHOLD_CHOICES } from "@/features/chat/utils/pasted-text
 import { formatBindingLabel, isMacPlatform } from "../lib/keyboard-shortcuts";
 import { useUserProfileStore } from "@/features/profile";
 import { type TranslationKey, useT } from "@/i18n";
+import { toast } from "@/lib/toast";
 import {
   Bookmark02Icon,
   Download01Icon,
@@ -196,9 +199,6 @@ export function ChatTab() {
   const showModelDisclaimer = useChatPreferencesStore(
     (state) => state.showModelDisclaimer,
   );
-  const setShowModelDisclaimer = useChatPreferencesStore(
-    (state) => state.setShowModelDisclaimer,
-  );
   const showResponseModel = useChatPreferencesStore(
     (state) => state.showResponseModel,
   );
@@ -228,6 +228,7 @@ export function ChatTab() {
 
   useEffect(() => {
     void hydratePersistedSettings();
+    refreshModelDisclaimerPreference().catch(() => undefined);
   }, [hydratePersistedSettings]);
 
   return (
@@ -322,7 +323,11 @@ export function ChatTab() {
         >
           <Switch
             checked={showModelDisclaimer}
-            onCheckedChange={setShowModelDisclaimer}
+            onCheckedChange={(checked) => {
+              return saveModelDisclaimerPreference(checked).catch(() => {
+                toast.error("Could not save the model disclaimer setting.");
+              });
+            }}
           />
         </SettingsRow>
         <SettingsRow

--- a/studio/frontend/tests/model-disclaimer-preference.test.ts
+++ b/studio/frontend/tests/model-disclaimer-preference.test.ts
@@ -15,7 +15,30 @@ let serverValue: boolean | undefined;
 const requests: Array<{ method: string; path: string; body: unknown }> = [];
 const API_KEY = "show_model_disclaimer";
 
-globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+type ResponseGate = {
+  method: string;
+  reached: Promise<void>;
+  wait: Promise<void>;
+  markReached: () => void;
+  release: () => void;
+};
+
+let responseGate: ResponseGate | null = null;
+
+function holdNextResponse(method: string): ResponseGate {
+  let markReached: () => void = () => undefined;
+  let release: () => void = () => undefined;
+  const reached = new Promise<void>((resolve) => {
+    markReached = resolve;
+  });
+  const wait = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  responseGate = { method, reached, wait, markReached, release };
+  return responseGate;
+}
+
+globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
   const path = String(input);
   const method = init?.method ?? "GET";
   const body = init?.body ? JSON.parse(String(init.body)) : undefined;
@@ -30,12 +53,18 @@ globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
     serverValue = (body as Record<string, boolean>)[API_KEY];
   }
 
-  return Promise.resolve(
-    new Response(JSON.stringify({ [API_KEY]: serverValue ?? false }), {
-      status: 200,
-      headers: { "Content-Type": "application/json" },
-    }),
-  );
+  const responseValue = serverValue ?? false;
+  const gate = responseGate?.method === method ? responseGate : null;
+  if (gate) {
+    responseGate = null;
+    gate.markReached();
+    await gate.wait;
+  }
+
+  return new Response(JSON.stringify({ [API_KEY]: responseValue }), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
 }) as typeof fetch;
 
 const { useChatPreferencesStore } = await import(
@@ -101,6 +130,33 @@ test("a legacy disabled default does not claim the installation setting", () => 
     JSON.stringify({ state: { showModelDisclaimer: false }, version: 0 }),
   );
   assert.equal(readLegacyModelDisclaimer(), undefined);
+});
+
+test("a queued refresh cannot revert a newer toggle", async () => {
+  serverValue = false;
+  requests.length = 0;
+  localStorage.delete("unsloth_chat_preferences");
+  useChatPreferencesStore.getState().setShowModelDisclaimer(false);
+  localStorage.delete("unsloth_chat_preferences");
+
+  const migrationGate = holdNextResponse("POST");
+  const migration = hydrateModelDisclaimerPreference();
+  await migrationGate.reached;
+
+  const refresh = refreshModelDisclaimerPreference();
+  const saveGate = holdNextResponse("PUT");
+  const save = saveModelDisclaimerPreference(true);
+  migrationGate.release();
+  await saveGate.reached;
+
+  assert.equal(useChatPreferencesStore.getState().showModelDisclaimer, true);
+  assert.deepEqual(
+    requests.map(({ method }) => method),
+    ["POST", "GET", "PUT"],
+  );
+  saveGate.release();
+  await Promise.all([migration, refresh, save]);
+  assert.equal(serverValue, true);
 });
 
 test("saving the switch updates both the browser and installation", async () => {

--- a/studio/frontend/tests/model-disclaimer-preference.test.ts
+++ b/studio/frontend/tests/model-disclaimer-preference.test.ts
@@ -3,14 +3,50 @@
 
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
+import { register } from "node:module";
 import test from "node:test";
 
-import { registerBundlerResolver } from "./helpers/kit.ts";
+import { installLocalStorageFake } from "./helpers/kit.ts";
 
-registerBundlerResolver();
+register("./helpers/settings-api-resolver.mjs", import.meta.url);
+const { store: localStorage } = installLocalStorageFake();
+
+let serverValue: boolean | undefined;
+const requests: Array<{ method: string; path: string; body: unknown }> = [];
+const API_KEY = "show_model_disclaimer";
+
+globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+  const path = String(input);
+  const method = init?.method ?? "GET";
+  const body = init?.body ? JSON.parse(String(init.body)) : undefined;
+  requests.push({ method, path, body });
+
+  if (method === "POST" && path.endsWith("/migrate")) {
+    const legacy = (body as Record<string, unknown> | undefined)?.[API_KEY];
+    if (serverValue === undefined && typeof legacy === "boolean") {
+      serverValue = legacy;
+    }
+  } else if (method === "PUT") {
+    serverValue = (body as Record<string, boolean>)[API_KEY];
+  }
+
+  return Promise.resolve(
+    new Response(JSON.stringify({ [API_KEY]: serverValue ?? false }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    }),
+  );
+}) as typeof fetch;
+
 const { useChatPreferencesStore } = await import(
   "../src/features/chat/stores/chat-preferences-store.ts"
 );
+const {
+  hydrateModelDisclaimerPreference,
+  readLegacyModelDisclaimer,
+  refreshModelDisclaimerPreference,
+  saveModelDisclaimerPreference,
+} = await import("../src/features/chat/sync-model-disclaimer-preference.ts");
 const MISSING_DISCLAIMER_DEFAULT_PATTERN =
   /showModelDisclaimer: saved\?\.showModelDisclaimer \?\? false/;
 
@@ -28,4 +64,56 @@ test("a saved payload without the model disclaimer key defaults to hidden", asyn
     "utf8",
   );
   assert.match(source, MISSING_DISCLAIMER_DEFAULT_PATTERN);
+});
+
+test("the legacy browser value seeds the installation setting once", async () => {
+  serverValue = undefined;
+  requests.length = 0;
+  localStorage.set(
+    "unsloth_chat_preferences",
+    JSON.stringify({ state: { showModelDisclaimer: true }, version: 0 }),
+  );
+
+  assert.equal(readLegacyModelDisclaimer(), true);
+  await Promise.all([
+    hydrateModelDisclaimerPreference(),
+    refreshModelDisclaimerPreference(),
+  ]);
+  assert.equal(serverValue, true);
+  assert.equal(useChatPreferencesStore.getState().showModelDisclaimer, true);
+  assert.deepEqual(requests[0], {
+    method: "POST",
+    path: "/api/settings/chat-preferences/migrate",
+    body: { [API_KEY]: true },
+  });
+  assert.equal(requests[1]?.method, "GET");
+
+  localStorage.delete("unsloth_chat_preferences");
+  useChatPreferencesStore.getState().setShowModelDisclaimer(false);
+  localStorage.delete("unsloth_chat_preferences");
+  await hydrateModelDisclaimerPreference();
+  assert.equal(useChatPreferencesStore.getState().showModelDisclaimer, true);
+});
+
+test("a legacy disabled default does not claim the installation setting", () => {
+  localStorage.set(
+    "unsloth_chat_preferences",
+    JSON.stringify({ state: { showModelDisclaimer: false }, version: 0 }),
+  );
+  assert.equal(readLegacyModelDisclaimer(), undefined);
+});
+
+test("saving the switch updates both the browser and installation", async () => {
+  serverValue = false;
+  requests.length = 0;
+
+  await saveModelDisclaimerPreference(true);
+
+  assert.equal(serverValue, true);
+  assert.equal(useChatPreferencesStore.getState().showModelDisclaimer, true);
+  assert.deepEqual(requests[0], {
+    method: "PUT",
+    path: "/api/settings/chat-preferences",
+    body: { [API_KEY]: true },
+  });
 });


### PR DESCRIPTION
## Summary

- Store the model disclaimer preference in the Studio database so it survives host, port, and tunnel changes.
- Import an existing enabled browser preference without letting an untouched disabled default claim the server value.
- Serialize hydration, refreshes, and writes so quick toggles and startup requests cannot publish stale state.
- Refresh the preference when Chat settings opens and retain browser storage as a local mirror and fallback.
- Add backend and frontend regression coverage for migration and cross-origin persistence.

## Tests

- `npm test` (5,651 passed)
- `npm run typecheck`
- `node --experimental-strip-types --test tests/model-disclaimer-preference.test.ts` (5 passed)
- `uv run --no-project --with pytest --with fastapi==0.141.1 --with httpx --with structlog python -m pytest -q studio/backend/tests/test_chat_preferences_settings.py` (5 passed)
- `uvx ruff check studio/backend/utils/chat_preferences_settings.py studio/backend/routes/settings.py studio/backend/tests/test_chat_preferences_settings.py`
- `npx biome check src/features/chat/api/chat-preferences.ts src/features/chat/sync-model-disclaimer-preference.ts tests/model-disclaimer-preference.test.ts`