### PR TITLE
Keep the context length a load was given instead of resetting it to Auto

### DIFF
--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -149,7 +149,7 @@ import {
 } from "../stores/chat-runtime-store";
 import {
   resolveFitMaxSeqLength,
-  resolveLoadedCtxPin,
+  resolveExplicitCtxPin,
 } from "../presets/preset-policy";
 import { ensureGpuDeviceCache } from "@/hooks/use-gpu-info";
 import { useExternalProvidersStore } from "../stores/external-providers-store";
@@ -3329,9 +3329,10 @@ async function autoLoadSmallestModel(options?: AutoLoadOptions): Promise<{
         is_gguf: loadResp.is_gguf ?? candidate.kind === "gguf",
       });
       if (candidate.kind === "gguf") {
-        // fitMaxSeqLength is what went on the wire as max_seq_length, so the pin
-        // cannot disagree with the launched -c.
-        const keepCustomCtx = resolveLoadedCtxPin(fitMaxSeqLength);
+        // The Context Length saved for this model, not fitMaxSeqLength: the wire
+        // value is Auto-resolved for a same-model reload, so pinning it would
+        // convert Auto into a number the user never set (see resolveExplicitCtxPin).
+        const keepCustomCtx = resolveExplicitCtxPin(config.customContextLength);
         // Slots this auto-load committed. Diffusion ignores --parallel, so a count
         // there would mint a phantom override a saved preset carries onto a GGUF.
         const committedSlots =

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -149,7 +149,7 @@ import {
 } from "../stores/chat-runtime-store";
 import {
   resolveFitMaxSeqLength,
-  resolveManualAutoCtxPin,
+  resolveLoadedCtxPin,
 } from "../presets/preset-policy";
 import { ensureGpuDeviceCache } from "@/hooks/use-gpu-info";
 import { useExternalProvidersStore } from "../stores/external-providers-store";
@@ -3329,15 +3329,11 @@ async function autoLoadSmallestModel(options?: AutoLoadOptions): Promise<{
         is_gguf: loadResp.is_gguf ?? candidate.kind === "gguf",
       });
       if (candidate.kind === "gguf") {
-        // Keep an explicit Manual+Auto context pin the load just applied (so a
-        // later Apply doesn't silently revert it to auto-fit sizing), mirroring
-        // the interactive path's keepCustomCtx; other cases baseline on
-        // ggufContextLength.
-        const keepCustomCtx = resolveManualAutoCtxPin(
-          effectiveGpuMemoryMode,
-          effectiveGpuLayers,
-          config.customContextLength ?? null,
-        );
+        // The context this auto-load was invoked with, kept so a later Apply
+        // doesn't silently revert it to auto-fit sizing. fitMaxSeqLength is what
+        // went on the wire as max_seq_length, mirroring the interactive path's
+        // keepCustomCtx; 0 (Auto) clears the pin.
+        const keepCustomCtx = resolveLoadedCtxPin(fitMaxSeqLength);
         // Slots this auto-load committed. Diffusion ignores --parallel, so a count
         // there would mint a phantom override a saved preset carries onto a GGUF.
         const committedSlots =
@@ -3394,9 +3390,10 @@ async function autoLoadSmallestModel(options?: AutoLoadOptions): Promise<{
           defaultChatTemplate: loadResp.chat_template ?? null,
           chatTemplateOverride: effectiveChatTemplateOverride,
           loadedChatTemplateOverride: effectiveChatTemplateOverride,
-          // Retain the saved requested context so re-saving the config keeps the
-          // override; null stays null (auto/VRAM-fit).
-          customContextLength: config.customContextLength,
+          // The same pin as the baseline above, so the control opens undirtied:
+          // the saved config and the launched -c are the same number whenever
+          // one was requested, and null stays null (auto/VRAM-fit).
+          customContextLength: keepCustomCtx,
           loadedIsMultimodal: isMultimodalResponse(loadResp),
           mmprojFallbackReason: loadResp.mmproj_fallback_reason ?? null,
           loadedIsDiffusion: loadResp.is_diffusion ?? false,

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -3329,10 +3329,8 @@ async function autoLoadSmallestModel(options?: AutoLoadOptions): Promise<{
         is_gguf: loadResp.is_gguf ?? candidate.kind === "gguf",
       });
       if (candidate.kind === "gguf") {
-        // The context this auto-load was invoked with, kept so a later Apply
-        // doesn't silently revert it to auto-fit sizing. fitMaxSeqLength is what
-        // went on the wire as max_seq_length, mirroring the interactive path's
-        // keepCustomCtx; 0 (Auto) clears the pin.
+        // fitMaxSeqLength is what went on the wire as max_seq_length, so the pin
+        // cannot disagree with the launched -c.
         const keepCustomCtx = resolveLoadedCtxPin(fitMaxSeqLength);
         // Slots this auto-load committed. Diffusion ignores --parallel, so a count
         // there would mint a phantom override a saved preset carries onto a GGUF.
@@ -3390,9 +3388,7 @@ async function autoLoadSmallestModel(options?: AutoLoadOptions): Promise<{
           defaultChatTemplate: loadResp.chat_template ?? null,
           chatTemplateOverride: effectiveChatTemplateOverride,
           loadedChatTemplateOverride: effectiveChatTemplateOverride,
-          // The same pin as the baseline above, so the control opens undirtied:
-          // the saved config and the launched -c are the same number whenever
-          // one was requested, and null stays null (auto/VRAM-fit).
+          // Same value as the baseline above, so the control opens undirtied.
           customContextLength: keepCustomCtx,
           loadedIsMultimodal: isMultimodalResponse(loadResp),
           mmprojFallbackReason: loadResp.mmproj_fallback_reason ?? null,

--- a/studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts
+++ b/studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts
@@ -89,7 +89,7 @@ import {
   mergeBackendRecommendedInference,
   resolveFitMaxSeqLength,
   resolveLoadMaxSeqLength,
-  resolveManualAutoCtxPin,
+  resolveLoadedCtxPin,
 } from "../presets/preset-policy";
 import { recordLastLocalModelLoad } from "../utils/last-local-model-load";
 import { loadFallbackNotice } from "../utils/mmproj-fallback";
@@ -1764,14 +1764,13 @@ export function useChatModelRuntime() {
             const reportedNativeCtx = loadResponse.is_gguf
               ? (loadResponse.native_context_length ?? null)
               : null;
-            // Keep an explicit Manual+Auto context pin (so a later Apply doesn't
-            // revert it to Auto) and retain the user's requested context so
-            // re-open/re-save keeps the intended override, not the backend's
-            // auto-fit context; null stays null.
-            const keepCustomCtx = resolveManualAutoCtxPin(
-              loadGpuMemoryMode,
-              loadGpuLayers,
-              loadCustomContextLength,
+            // The context this load was invoked with, kept so a later Apply
+            // doesn't revert it to Auto and so re-open/re-save keeps the
+            // intended override rather than the backend's auto-fit context.
+            // loadMaxSeqLength is what went on the wire as max_seq_length, so
+            // the pin cannot disagree with the launched -c; 0 (Auto) clears it.
+            const keepCustomCtx = resolveLoadedCtxPin(
+              loadResponse.is_gguf ? loadMaxSeqLength : null,
             );
             const reasoningAlwaysOn = loadResponse.reasoning_always_on ?? false;
             const reasoningStyle = loadResponse.reasoning_style ?? "enable_thinking";

--- a/studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts
+++ b/studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts
@@ -89,7 +89,7 @@ import {
   mergeBackendRecommendedInference,
   resolveFitMaxSeqLength,
   resolveLoadMaxSeqLength,
-  resolveLoadedCtxPin,
+  resolveExplicitCtxPin,
 } from "../presets/preset-policy";
 import { recordLastLocalModelLoad } from "../utils/last-local-model-load";
 import { loadFallbackNotice } from "../utils/mmproj-fallback";
@@ -1574,6 +1574,12 @@ export function useChatModelRuntime() {
               loadSplitRatio = null;
             }
 
+            // The Context Length the USER set for this load, captured before the
+            // clamp below can stand in for it. This, not the n_ctx that goes on
+            // the wire, is what the completed load pins: several send rules put a
+            // positive n_ctx on the wire with the control on Auto, and a pin read
+            // back out of one of those is a number the user never chose.
+            const explicitCtxPin = loadCustomContextLength;
             // Pinning layers on the SAME model keeps the currently resolved
             // context: with no explicit pin, a manual+pinned reload would send 0,
             // which the backend's --fit off branch treats as the NATIVE context --
@@ -1764,10 +1770,10 @@ export function useChatModelRuntime() {
             const reportedNativeCtx = loadResponse.is_gguf
               ? (loadResponse.native_context_length ?? null)
               : null;
-            // loadMaxSeqLength is what went on the wire as max_seq_length, so
-            // the pin cannot disagree with the launched -c.
-            const keepCustomCtx = resolveLoadedCtxPin(
-              loadResponse.is_gguf ? loadMaxSeqLength : null,
+            // The user's own Context Length (see explicitCtxPin), so an Auto load
+            // stays Auto whatever n_ctx the send rules resolved for it.
+            const keepCustomCtx = resolveExplicitCtxPin(
+              loadResponse.is_gguf ? explicitCtxPin : null,
             );
             const reasoningAlwaysOn = loadResponse.reasoning_always_on ?? false;
             const reasoningStyle = loadResponse.reasoning_style ?? "enable_thinking";

--- a/studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts
+++ b/studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts
@@ -1764,11 +1764,8 @@ export function useChatModelRuntime() {
             const reportedNativeCtx = loadResponse.is_gguf
               ? (loadResponse.native_context_length ?? null)
               : null;
-            // The context this load was invoked with, kept so a later Apply
-            // doesn't revert it to Auto and so re-open/re-save keeps the
-            // intended override rather than the backend's auto-fit context.
             // loadMaxSeqLength is what went on the wire as max_seq_length, so
-            // the pin cannot disagree with the launched -c; 0 (Auto) clears it.
+            // the pin cannot disagree with the launched -c.
             const keepCustomCtx = resolveLoadedCtxPin(
               loadResponse.is_gguf ? loadMaxSeqLength : null,
             );

--- a/studio/frontend/src/features/chat/lib/apply-inference-status-to-store.ts
+++ b/studio/frontend/src/features/chat/lib/apply-inference-status-to-store.ts
@@ -10,7 +10,7 @@ import { getInferenceStatus } from "../api/chat-api";
 import { isSpeechOnlyStatus } from "./speech-only-status";
 import {
   mergeBackendRecommendedInference,
-  resolveManualAutoCtxPin,
+  resolveLoadedCtxPin,
 } from "../presets/preset-policy";
 import { clampReasoningEffortToLevels } from "../provider-capabilities";
 import {
@@ -304,18 +304,41 @@ export function applyActiveModelStatusToStore(
     seedLoadParams,
     modelChanged: slotsModelChanged,
   });
-  // A Manual + Auto-layers load sent its positive context pin as max_seq_length,
-  // and status only exposes the RESOLVED context; re-seed the pin from the
-  // requested value (parity with the load paths' keepCustomCtx). Baselines
-  // unconditionally: anything but an applicable pin is null, so a previous
-  // model's pin can't survive a model change underneath and reload at the old length.
-  const gpuPin = status.is_gguf
-    ? resolveManualAutoCtxPin(
-        status.gpu_memory_mode ?? "auto",
-        status.gpu_layers ?? -1,
-        status.requested_context_length ?? null,
-      )
+  // A load sends its context pin as max_seq_length and status only exposes the
+  // RESOLVED context, so re-seed the pin from the requested value (parity with
+  // the load paths' keepCustomCtx).
+  //
+  // A previous model's pin still cannot survive a model change underneath and
+  // reload at the old length, and it never was the narrowness of the old
+  // Manual-only filter that guaranteed that: it is the SOURCE. This reads only
+  // `status`, never `prevState`, and `requested_context_length` is by definition
+  // the n_ctx the ACTIVE load was invoked with (backend: llama_backend
+  // .requested_n_ctx). So whichever model the server is running is the model
+  // this pin describes, and the outgoing one's value is overwritten rather than
+  // carried. The caller also applies this under the checkpoint the same status
+  // named, so the two cannot disagree about which model is being described.
+  const loadedCtxPin = status.is_gguf
+    ? resolveLoadedCtxPin(status.requested_context_length ?? null)
     : null;
+  // The one window where status can still answer for the OUTGOING model is a
+  // poll landing while this tab's own load is in flight -- status refreshes do
+  // run with modelLoading still true (see use-chat-model-runtime's
+  // loadedLlamaExtraArgs note). That was invisible while the pin was almost
+  // always null; now that a pin survives in every GPU Memory mode a stale poll
+  // would plant the outgoing model's context on the model coming in. So the pin
+  // takes the same rule as every other load param here: while a load is in
+  // flight performLoad owns it. It clears the field itself on a cross-model
+  // switch, writes the authoritative value on completion, and restores the
+  // outgoing model's own baseline if the load fails.
+  const ctxPinFields = seedLoadParams
+    ? {
+        customContextLength: loadedCtxPin,
+        loadedCustomContextLength: loadedCtxPin,
+      }
+    : {
+        customContextLength: prevState.customContextLength,
+        loadedCustomContextLength: prevState.loadedCustomContextLength,
+      };
   const incomingGpuMode = status.is_gguf
     ? (status.gpu_memory_mode ?? "auto")
     : null;
@@ -340,7 +363,9 @@ export function applyActiveModelStatusToStore(
       },
       { ids: incomingGpuIds, indexKind: incomingGpuIndexKind },
     ) ||
-    prevState.loadedCustomContextLength !== gpuPin;
+    // Only when this status is allowed to advance the baseline; mid-load it is
+    // not, and a difference it will not apply is not a change.
+    (seedLoadParams && prevState.loadedCustomContextLength !== loadedCtxPin);
   const gpuMemoryEditsPending =
     (prevState.loadedGpuMemoryMode !== null &&
       prevState.gpuMemoryMode !== prevState.loadedGpuMemoryMode) ||
@@ -364,8 +389,7 @@ export function applyActiveModelStatusToStore(
   const preserveSameModelEdits = gpuStatusChanged && !hydratingExistingModel;
   const gpuStatusFields = {
     ...incomingGpuFields,
-    customContextLength: gpuPin,
-    loadedCustomContextLength: gpuPin,
+    ...ctxPinFields,
     ...(preserveSameModelEdits &&
       gpuMemoryEditsPending && {
         gpuMemoryMode: prevState.gpuMemoryMode,

--- a/studio/frontend/src/features/chat/lib/apply-inference-status-to-store.ts
+++ b/studio/frontend/src/features/chat/lib/apply-inference-status-to-store.ts
@@ -8,10 +8,7 @@ import { resolveResidentInitialConfig } from "@/features/model-picker";
 import { modelDisplayName } from "@/features/hub/lib/model-identity";
 import { getInferenceStatus } from "../api/chat-api";
 import { isSpeechOnlyStatus } from "./speech-only-status";
-import {
-  mergeBackendRecommendedInference,
-  resolveLoadedCtxPin,
-} from "../presets/preset-policy";
+import { mergeBackendRecommendedInference } from "../presets/preset-policy";
 import { clampReasoningEffortToLevels } from "../provider-capabilities";
 import {
   CHAT_REASONING_ENABLED_KEY,
@@ -33,6 +30,7 @@ import { resolveQwenThinkingParams } from "../utils/qwen-params";
 import { sameGpuSelection } from "@/hooks/gpu-selection";
 import { resolveBatchSizeSeed } from "./resolve-batch-size-seed";
 import { resolveChatTemplateSeed } from "./resolve-chat-template-seed";
+import { resolveCtxPinSeed } from "./resolve-ctx-pin-seed";
 import { shouldSeedVisionSwitch } from "./resolve-vision-switch-seed";
 
 type LocalReasoningEffort = Extract<ReasoningEffort, "low" | "medium" | "high">;
@@ -305,32 +303,22 @@ export function applyActiveModelStatusToStore(
     modelChanged: slotsModelChanged,
   });
   // A load sends its context pin as max_seq_length and status only exposes the
-  // RESOLVED context, so re-seed the pin from the requested value (parity with
-  // the load paths' keepCustomCtx). Sourced from `status` alone, never
-  // `prevState`: `requested_context_length` is by definition the n_ctx the ACTIVE
-  // load was invoked with (backend: llama_backend.requested_n_ctx), so a model
-  // change underneath overwrites the outgoing model's pin rather than carrying it.
-  const loadedCtxPin = status.is_gguf
-    ? resolveLoadedCtxPin(status.requested_context_length ?? null)
-    : null;
-  // Status can still answer for the OUTGOING model in one window: a poll landing
-  // while this tab's own load is in flight, since refreshes do run with
-  // modelLoading still true (see use-chat-model-runtime's loadedLlamaExtraArgs
-  // note). Harmless while the pin was almost always null, but now that one
-  // survives in every GPU Memory mode a stale poll would plant the outgoing
-  // model's context on the model coming in. So the pin takes the same rule as
-  // every other load param: while a load is in flight performLoad owns it,
-  // clearing it on a cross-model switch, writing the authoritative value on
-  // completion, and restoring the outgoing model's baseline if the load fails.
-  const ctxPinFields = seedLoadParams
-    ? {
-        customContextLength: loadedCtxPin,
-        loadedCustomContextLength: loadedCtxPin,
-      }
-    : {
-        customContextLength: prevState.customContextLength,
-        loadedCustomContextLength: prevState.loadedCustomContextLength,
-      };
+  // resolved context plus the requested n_ctx, and a positive requested n_ctx
+  // does NOT mean a human asked for it: an Auto same-model reload under a custom
+  // preset reports one too. So the pin is re-seeded here from what this tab (or
+  // the model's saved config) actually recorded, never inferred from the echo
+  // alone, and the echo is trusted only where it is unambiguous. See
+  // resolveCtxPinSeed for the full rule, including the mid-load window where
+  // status still answers for the OUTGOING model.
+  const ctxPinFields = resolveCtxPinSeed({
+    incoming: status.requested_context_length,
+    isGguf: status.is_gguf ?? true,
+    seedLoadParams,
+    modelChanged: slotsModelChanged,
+    remembered: remembered?.remembered
+      ? (remembered.config.customContextLength ?? null)
+      : null,
+  });
   const incomingGpuMode = status.is_gguf
     ? (status.gpu_memory_mode ?? "auto")
     : null;
@@ -355,8 +343,11 @@ export function applyActiveModelStatusToStore(
       },
       { ids: incomingGpuIds, indexKind: incomingGpuIndexKind },
     ) ||
-    // A difference this status will not apply (mid-load) is not a change.
-    (seedLoadParams && prevState.loadedCustomContextLength !== loadedCtxPin);
+    // Only a pin this status will actually move counts: a difference it declines
+    // to apply (mid-load, or an echo it cannot read intent out of) is not one.
+    (ctxPinFields.loadedCustomContextLength !== undefined &&
+      prevState.loadedCustomContextLength !==
+        ctxPinFields.loadedCustomContextLength);
   const gpuMemoryEditsPending =
     (prevState.loadedGpuMemoryMode !== null &&
       prevState.gpuMemoryMode !== prevState.loadedGpuMemoryMode) ||

--- a/studio/frontend/src/features/chat/lib/apply-inference-status-to-store.ts
+++ b/studio/frontend/src/features/chat/lib/apply-inference-status-to-store.ts
@@ -318,6 +318,12 @@ export function applyActiveModelStatusToStore(
     remembered: remembered?.remembered
       ? (remembered.config.customContextLength ?? null)
       : null,
+    // Raw, not the normalised incomingGpuMode/incomingGpuLayers below: the rule
+    // needs "Manual with AUTO layers", and those normalise layers to null off
+    // manual, which would read as "no layers reported" rather than as Auto.
+    gpuMemoryMode: status.gpu_memory_mode ?? null,
+    gpuLayers: status.gpu_layers ?? null,
+    loadedPin: prevState.loadedCustomContextLength ?? null,
   });
   const incomingGpuMode = status.is_gguf
     ? (status.gpu_memory_mode ?? "auto")

--- a/studio/frontend/src/features/chat/lib/apply-inference-status-to-store.ts
+++ b/studio/frontend/src/features/chat/lib/apply-inference-status-to-store.ts
@@ -306,30 +306,22 @@ export function applyActiveModelStatusToStore(
   });
   // A load sends its context pin as max_seq_length and status only exposes the
   // RESOLVED context, so re-seed the pin from the requested value (parity with
-  // the load paths' keepCustomCtx).
-  //
-  // A previous model's pin still cannot survive a model change underneath and
-  // reload at the old length, and it never was the narrowness of the old
-  // Manual-only filter that guaranteed that: it is the SOURCE. This reads only
-  // `status`, never `prevState`, and `requested_context_length` is by definition
-  // the n_ctx the ACTIVE load was invoked with (backend: llama_backend
-  // .requested_n_ctx). So whichever model the server is running is the model
-  // this pin describes, and the outgoing one's value is overwritten rather than
-  // carried. The caller also applies this under the checkpoint the same status
-  // named, so the two cannot disagree about which model is being described.
+  // the load paths' keepCustomCtx). Sourced from `status` alone, never
+  // `prevState`: `requested_context_length` is by definition the n_ctx the ACTIVE
+  // load was invoked with (backend: llama_backend.requested_n_ctx), so a model
+  // change underneath overwrites the outgoing model's pin rather than carrying it.
   const loadedCtxPin = status.is_gguf
     ? resolveLoadedCtxPin(status.requested_context_length ?? null)
     : null;
-  // The one window where status can still answer for the OUTGOING model is a
-  // poll landing while this tab's own load is in flight -- status refreshes do
-  // run with modelLoading still true (see use-chat-model-runtime's
-  // loadedLlamaExtraArgs note). That was invisible while the pin was almost
-  // always null; now that a pin survives in every GPU Memory mode a stale poll
-  // would plant the outgoing model's context on the model coming in. So the pin
-  // takes the same rule as every other load param here: while a load is in
-  // flight performLoad owns it. It clears the field itself on a cross-model
-  // switch, writes the authoritative value on completion, and restores the
-  // outgoing model's own baseline if the load fails.
+  // Status can still answer for the OUTGOING model in one window: a poll landing
+  // while this tab's own load is in flight, since refreshes do run with
+  // modelLoading still true (see use-chat-model-runtime's loadedLlamaExtraArgs
+  // note). Harmless while the pin was almost always null, but now that one
+  // survives in every GPU Memory mode a stale poll would plant the outgoing
+  // model's context on the model coming in. So the pin takes the same rule as
+  // every other load param: while a load is in flight performLoad owns it,
+  // clearing it on a cross-model switch, writing the authoritative value on
+  // completion, and restoring the outgoing model's baseline if the load fails.
   const ctxPinFields = seedLoadParams
     ? {
         customContextLength: loadedCtxPin,
@@ -363,8 +355,7 @@ export function applyActiveModelStatusToStore(
       },
       { ids: incomingGpuIds, indexKind: incomingGpuIndexKind },
     ) ||
-    // Only when this status is allowed to advance the baseline; mid-load it is
-    // not, and a difference it will not apply is not a change.
+    // A difference this status will not apply (mid-load) is not a change.
     (seedLoadParams && prevState.loadedCustomContextLength !== loadedCtxPin);
   const gpuMemoryEditsPending =
     (prevState.loadedGpuMemoryMode !== null &&

--- a/studio/frontend/src/features/chat/lib/resolve-ctx-pin-seed.ts
+++ b/studio/frontend/src/features/chat/lib/resolve-ctx-pin-seed.ts
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// what a fresh /api/inference/status does to the Context Length control and its baseline
+
+/**
+ * The subset of the pair this rule owns -- the editable Context Length (null =
+ * Auto) and the value the resident server was invoked with, as this tab last saw
+ * it -- to write back. Empty means leave the store alone.
+ */
+export interface CtxPinSeed {
+  customContextLength?: number | null;
+  loadedCustomContextLength?: number | null;
+}
+
+const CLEAR: CtxPinSeed = {
+  customContextLength: null,
+  loadedCustomContextLength: null,
+};
+
+/**
+ * Status reports `requested_n_ctx` (the n_ctx the running server was launched
+ * with) and nothing about whether a human chose it, and the two are not the same
+ * question: `resolveLoadMaxSeqLength` sends the resolved context on a same-model
+ * reload so the reload does not resize, so an Auto reload under a custom or
+ * modified preset reports a positive `requested_n_ctx` exactly like an explicit
+ * pin does. A positive value is therefore evidence of nothing on its own, and no
+ * backend field could fix that: the frontend sends the same number in both
+ * cases, so the backend has no more information than this does.
+ *
+ * So this never invents a pin out of a positive echo. It clears one only on the
+ * unambiguous signal (0, the wire value for Auto, which only an Auto load
+ * sends), it leaves the control alone entirely while the model has not changed
+ * -- whatever this tab's own load recorded there is better evidence than the
+ * echo -- and on a model change, where nothing in the store belongs to the model
+ * that arrived, it adopts that model's SAVED Context Length only when the
+ * running server corroborates it by matching. That last step is the rule the
+ * batch sizes next door already use for their own remembered values.
+ */
+export function resolveCtxPinSeed(options: {
+  /** ``status.requested_context_length``; undefined on a backend that omits the field. */
+  incoming: number | null | undefined;
+  /** ``status.is_gguf``: only a GGUF load carries an n_ctx. */
+  isGguf: boolean;
+  /** No load of this tab's own is in flight (``!modelLoading``). */
+  seedLoadParams: boolean;
+  /** The model/variant changed underneath this tab, so nothing recorded here survives it. */
+  modelChanged: boolean;
+  /** This model's SAVED Context Length, or null when it saved none / has no record. */
+  remembered: number | null;
+}): CtxPinSeed {
+  const { incoming, isGguf, seedLoadParams, modelChanged, remembered } = options;
+  // while a load is in flight performLoad owns the load params. This is also the
+  // mid-load window where status still answers for the OUTGOING model (refreshes
+  // do run with modelLoading true), so nothing here can plant a stale pin.
+  if (!seedLoadParams) return {};
+  // a non-GGUF has no n_ctx: its max_seq_length must not be left standing as one
+  if (!isGguf) return CLEAR;
+  if (incoming === undefined) {
+    // An older backend saying nothing. Nothing recorded against the model that
+    // just left may survive it, but a steady poll must not touch the control.
+    return modelChanged ? CLEAR : {};
+  }
+  // 0 is the wire value for Auto and only an Auto load sends it, so this is the
+  // one echo that proves its own meaning.
+  if (incoming === null || !(incoming > 0)) return CLEAR;
+  if (!modelChanged) {
+    // Same model, ambiguous echo. What is in the store came from watching this
+    // tab's own load, which knew what the user actually asked for; an echo that
+    // an Auto reload produces just as readily is not grounds to overwrite it,
+    // in either direction.
+    return {};
+  }
+  // A model changed underneath this tab, so nothing in the store belongs to the
+  // one that arrived. Its saved config is the only record of intent left;
+  // require the running server to match it, or a stale pin would be re-pinned
+  // onto a server that is not running it.
+  return remembered != null && remembered > 0 && remembered === incoming
+    ? {
+        customContextLength: remembered,
+        loadedCustomContextLength: remembered,
+      }
+    : CLEAR;
+}

--- a/studio/frontend/src/features/chat/lib/resolve-ctx-pin-seed.ts
+++ b/studio/frontend/src/features/chat/lib/resolve-ctx-pin-seed.ts
@@ -28,7 +28,14 @@ const CLEAR: CtxPinSeed = {
  * backend field could fix that: the frontend sends the same number in both
  * cases, so the backend has no more information than this does.
  *
- * So this never invents a pin out of a positive echo. It clears one only on the
+ * Two exceptions, both where the echo says more than "positive". Under Manual
+ * memory with Auto layers the load sends its pin through
+ * `resolveFitMaxSeqLength`, which puts 0 on the wire for Auto without exception,
+ * so a positive echo there IS an explicit pin and is adopted. And an echo that
+ * contradicts the pin this tab recorded means another client reloaded the same
+ * model at a different context, so the baseline is dropped rather than resent.
+ *
+ * Otherwise this never invents a pin out of a positive echo. It clears one only on the
  * unambiguous signal (0, the wire value for Auto, which only an Auto load
  * sends), it leaves the control alone entirely while the model has not changed
  * -- whatever this tab's own load recorded there is better evidence than the
@@ -48,8 +55,23 @@ export function resolveCtxPinSeed(options: {
   modelChanged: boolean;
   /** This model's SAVED Context Length, or null when it saved none / has no record. */
   remembered: number | null;
+  /** ``status.gpu_memory_mode`` for the resident server. */
+  gpuMemoryMode?: "auto" | "manual" | null;
+  /** ``status.gpu_layers`` as reported, NOT normalised: negative means Auto layers. */
+  gpuLayers?: number | null;
+  /** ``loadedCustomContextLength``: the n_ctx this tab last recorded for this server. */
+  loadedPin?: number | null;
 }): CtxPinSeed {
-  const { incoming, isGguf, seedLoadParams, modelChanged, remembered } = options;
+  const {
+    incoming,
+    isGguf,
+    seedLoadParams,
+    modelChanged,
+    remembered,
+    gpuMemoryMode,
+    gpuLayers,
+    loadedPin,
+  } = options;
   // while a load is in flight performLoad owns the load params. This is also the
   // mid-load window where status still answers for the OUTGOING model (refreshes
   // do run with modelLoading true), so nothing here can plant a stale pin.
@@ -64,12 +86,33 @@ export function resolveCtxPinSeed(options: {
   // 0 is the wire value for Auto and only an Auto load sends it, so this is the
   // one echo that proves its own meaning.
   if (incoming === null || !(incoming > 0)) return CLEAR;
+  // One placement mode has no ambiguity to reason around: under Manual memory
+  // with Auto layers the load sends its pin as max_seq_length through
+  // resolveFitMaxSeqLength, which answers `customContextLength > 0 ? it : 0`.
+  // Auto there is 0 on the wire, always, so a POSITIVE echo in this mode is
+  // proof of an explicit pin rather than evidence of nothing. Read before the
+  // branches below because it outranks both of them: it is better evidence than
+  // a saved config, and on a model change it describes the model that arrived.
+  if (gpuMemoryMode === "manual" && gpuLayers != null && gpuLayers < 0) {
+    return { customContextLength: incoming, loadedCustomContextLength: incoming };
+  }
   if (!modelChanged) {
     // Same model, ambiguous echo. What is in the store came from watching this
     // tab's own load, which knew what the user actually asked for; an echo that
     // an Auto reload produces just as readily is not grounds to overwrite it,
     // in either direction.
-    return {};
+    //
+    // Unless it CONTRADICTS the record. Another tab or an API client can reload
+    // the same model at a different context, and then the pin here describes an
+    // invocation that is no longer running: keeping it means the next unrelated
+    // Apply resends it and silently takes back the other client's choice. The
+    // echo still cannot say whether a human chose the new value, so it is not
+    // adopted; the stale baseline is dropped instead, which leaves the control
+    // on Auto and the next Apply agreeing with the server rather than fighting
+    // it. Clearing is safe against an Auto reload of our own pinned model too:
+    // that reports the resolved context, which IS the pin, so it matches here
+    // and nothing moves.
+    return loadedPin != null && loadedPin !== incoming ? CLEAR : {};
   }
   // A model changed underneath this tab, so nothing in the store belongs to the
   // one that arrived. Its saved config is the only record of intent left;

--- a/studio/frontend/src/features/chat/presets/preset-policy.ts
+++ b/studio/frontend/src/features/chat/presets/preset-policy.ts
@@ -365,16 +365,28 @@ export function resolveFitMaxSeqLength(
   return customContextLength && customContextLength > 0 ? customContextLength : 0;
 }
 
-// A Manual + Auto-layers load sends its positive context pin as max_seq_length;
-// keep it across a status reseed/Apply so the model isn't reverted to auto-fit
-// sizing. Anything else (Auto mode, pinned layers, no pin) baselines to null.
-// The caller keeps its own isGguf/targetIsGguf guard inline.
-export function resolveManualAutoCtxPin(
-  gpuMemoryMode: "auto" | "manual",
-  gpuLayers: number,
-  customContextLength: number | null,
+/**
+ * The context pin a completed load leaves behind: the n_ctx it was actually
+ * invoked with, or null when it asked for Auto. 0 is the wire value for Auto
+ * (the backend then sizes the context itself), so it is the one input that
+ * clears the pin.
+ *
+ * Every GPU Memory mode, deliberately. The predicate this replaces kept a pin
+ * only under Manual + Auto layers, but the Context Length control is offered in
+ * every mode and `resolveLoadMaxSeqLength` honors a pin in every mode. A
+ * survival rule narrower than the send rule meant a load on Default sent the
+ * user's 262,144, then dropped it on completion: the settings panel re-seeded to
+ * Auto (`customContextLength` is the first field of its React key) and the next
+ * load sent 0, which the backend resolves to its host-offload fallback of 8,192
+ * for a model that fits no GPU subset.
+ *
+ * Callers keep their own isGguf/targetIsGguf guard inline: a non-GGUF load has
+ * no n_ctx, and its max_seq_length must not be pinned as one.
+ */
+export function resolveLoadedCtxPin(
+  requestedContextLength: number | null | undefined,
 ): number | null {
-  return gpuMemoryMode === "manual" && gpuLayers < 0 && (customContextLength ?? 0) > 0
-    ? customContextLength
+  return requestedContextLength && requestedContextLength > 0
+    ? requestedContextLength
     : null;
 }

--- a/studio/frontend/src/features/chat/presets/preset-policy.ts
+++ b/studio/frontend/src/features/chat/presets/preset-policy.ts
@@ -366,9 +366,16 @@ export function resolveFitMaxSeqLength(
 }
 
 /**
- * The context pin a completed load leaves behind: the n_ctx it was actually
- * invoked with, or null when it asked for Auto. 0 is the wire value for Auto, so
- * it is the one input that clears the pin.
+ * The context pin a completed load leaves behind: the Context Length the user
+ * EXPLICITLY set for it, or null for Auto.
+ *
+ * Takes the user's setting, never the n_ctx that went on the wire. The wire
+ * value cannot answer this: `resolveLoadMaxSeqLength`'s isReloadingCurrentGguf
+ * branch sends the resolved context on a same-model reload so the reload does
+ * not resize, so under a custom or modified preset an Auto load puts a positive
+ * n_ctx on the wire too. Reading a pin back out of that turned Auto into a
+ * numeric pin at the current context on any same-model reload, after which a GPU
+ * memory change could no longer auto-resize.
  *
  * Takes no GPU Memory mode, deliberately. `resolveLoadMaxSeqLength` honors a pin
  * in every mode, but the predicate this replaces kept one only under Manual +
@@ -378,10 +385,10 @@ export function resolveFitMaxSeqLength(
  * Callers keep their own isGguf/targetIsGguf guard inline: a non-GGUF load has
  * no n_ctx, and its max_seq_length must not be pinned as one.
  */
-export function resolveLoadedCtxPin(
-  requestedContextLength: number | null | undefined,
+export function resolveExplicitCtxPin(
+  customContextLength: number | null | undefined,
 ): number | null {
-  return requestedContextLength && requestedContextLength > 0
-    ? requestedContextLength
+  return customContextLength && customContextLength > 0
+    ? customContextLength
     : null;
 }

--- a/studio/frontend/src/features/chat/presets/preset-policy.ts
+++ b/studio/frontend/src/features/chat/presets/preset-policy.ts
@@ -367,18 +367,13 @@ export function resolveFitMaxSeqLength(
 
 /**
  * The context pin a completed load leaves behind: the n_ctx it was actually
- * invoked with, or null when it asked for Auto. 0 is the wire value for Auto
- * (the backend then sizes the context itself), so it is the one input that
- * clears the pin.
+ * invoked with, or null when it asked for Auto. 0 is the wire value for Auto, so
+ * it is the one input that clears the pin.
  *
- * Every GPU Memory mode, deliberately. The predicate this replaces kept a pin
- * only under Manual + Auto layers, but the Context Length control is offered in
- * every mode and `resolveLoadMaxSeqLength` honors a pin in every mode. A
- * survival rule narrower than the send rule meant a load on Default sent the
- * user's 262,144, then dropped it on completion: the settings panel re-seeded to
- * Auto (`customContextLength` is the first field of its React key) and the next
- * load sent 0, which the backend resolves to its host-offload fallback of 8,192
- * for a model that fits no GPU subset.
+ * Takes no GPU Memory mode, deliberately. `resolveLoadMaxSeqLength` honors a pin
+ * in every mode, but the predicate this replaces kept one only under Manual +
+ * Auto layers: a survival rule narrower than the send rule, so a load on Default
+ * sent the user's pin and then dropped it on completion. That was the bug.
  *
  * Callers keep their own isGguf/targetIsGguf guard inline: a non-GGUF load has
  * no n_ctx, and its max_seq_length must not be pinned as one.

--- a/studio/frontend/src/features/chat/shared-composer.tsx
+++ b/studio/frontend/src/features/chat/shared-composer.tsx
@@ -1618,11 +1618,9 @@ export function SharedComposer({
         store.setModelRequiresTrustRemoteCode(
           resp.requires_trust_remote_code ?? false,
         );
-        // The context this pane's load was invoked with, kept so a later
-        // Apply/Reset doesn't silently revert the model to auto-fit sizing.
-        // compareMaxSeqLength is what went on the wire as max_seq_length,
-        // mirroring the interactive path's keepCustomCtx. Non-GGUF compare loads
-        // send a sequence length rather than an n_ctx, so their baseline clears.
+        // compareMaxSeqLength is what went on the wire as max_seq_length, so the
+        // pin cannot disagree with the launched -c. Non-GGUF compare loads send a
+        // sequence length rather than an n_ctx, so their baseline clears.
         const keepCustomCtx = targetIsGguf
           ? resolveLoadedCtxPin(compareMaxSeqLength)
           : null;
@@ -1694,11 +1692,9 @@ export function SharedComposer({
           loadedVisionDisabledByUser: resp.vision_disabled_by_user ?? false,
           mmprojFallbackReason: resp.mmproj_fallback_reason ?? null,
           activeModelIsLocal: resp.is_local_model ?? false,
-          // Record the context this pane loaded with (like the single-model path)
-          // so when it becomes the active model, the UI and later reload/save use
-          // its context, not the previous/default one. The same value as the
-          // baseline above: both name the n_ctx this pane actually sent, so the
-          // control opens undirtied.
+          // Same value as the baseline above, so that when this pane becomes the
+          // active model the UI and later reload/save use the context it actually
+          // loaded with, not the previous/default one.
           customContextLength: keepCustomCtx,
           ggufContextLength: resp.is_gguf ? (resp.context_length ?? null) : null,
           ggufNativeContextLength: resp.is_gguf

--- a/studio/frontend/src/features/chat/shared-composer.tsx
+++ b/studio/frontend/src/features/chat/shared-composer.tsx
@@ -122,7 +122,7 @@ import {
   loadModel,
   validateModel,
 } from "./api/chat-api";
-import { resolveFitMaxSeqLength, resolveManualAutoCtxPin } from "./presets/preset-policy";
+import { resolveFitMaxSeqLength, resolveLoadedCtxPin } from "./presets/preset-policy";
 import { ensureGpuDeviceCache } from "@/hooks/use-gpu-info";
 import {
   parseExternalModelId,
@@ -1618,16 +1618,13 @@ export function SharedComposer({
         store.setModelRequiresTrustRemoteCode(
           resp.requires_trust_remote_code ?? false,
         );
-        // Keep an explicit Manual+Auto context pin the load just applied (so a
-        // later Apply/Reset doesn't silently revert the model to auto-fit
-        // sizing), mirroring the interactive path's keepCustomCtx. Non-GGUF
-        // compare loads don't send the pin, so their baseline clears.
+        // The context this pane's load was invoked with, kept so a later
+        // Apply/Reset doesn't silently revert the model to auto-fit sizing.
+        // compareMaxSeqLength is what went on the wire as max_seq_length,
+        // mirroring the interactive path's keepCustomCtx. Non-GGUF compare loads
+        // send a sequence length rather than an n_ctx, so their baseline clears.
         const keepCustomCtx = targetIsGguf
-          ? resolveManualAutoCtxPin(
-              effectiveGpuMemoryMode,
-              effectiveGpuLayers,
-              effectiveCustomContextLength,
-            )
+          ? resolveLoadedCtxPin(compareMaxSeqLength)
           : null;
         // Slots this compare load committed. Diffusion ignores --parallel, so a
         // count there would mint a phantom override a preset carries onto a GGUF.
@@ -1699,10 +1696,10 @@ export function SharedComposer({
           activeModelIsLocal: resp.is_local_model ?? false,
           // Record the context this pane loaded with (like the single-model path)
           // so when it becomes the active model, the UI and later reload/save use
-          // its context, not the previous/default one.
-          customContextLength: targetIsGguf
-            ? (ownConfig.customContextLength ?? keepCustomCtx)
-            : null,
+          // its context, not the previous/default one. The same value as the
+          // baseline above: both name the n_ctx this pane actually sent, so the
+          // control opens undirtied.
+          customContextLength: keepCustomCtx,
           ggufContextLength: resp.is_gguf ? (resp.context_length ?? null) : null,
           ggufNativeContextLength: resp.is_gguf
             ? (resp.native_context_length ?? null)

--- a/studio/frontend/src/features/chat/shared-composer.tsx
+++ b/studio/frontend/src/features/chat/shared-composer.tsx
@@ -122,7 +122,7 @@ import {
   loadModel,
   validateModel,
 } from "./api/chat-api";
-import { resolveFitMaxSeqLength, resolveLoadedCtxPin } from "./presets/preset-policy";
+import { resolveFitMaxSeqLength, resolveExplicitCtxPin } from "./presets/preset-policy";
 import { ensureGpuDeviceCache } from "@/hooks/use-gpu-info";
 import {
   parseExternalModelId,
@@ -1618,11 +1618,13 @@ export function SharedComposer({
         store.setModelRequiresTrustRemoteCode(
           resp.requires_trust_remote_code ?? false,
         );
-        // compareMaxSeqLength is what went on the wire as max_seq_length, so the
-        // pin cannot disagree with the launched -c. Non-GGUF compare loads send a
-        // sequence length rather than an n_ctx, so their baseline clears.
+        // This pane's own saved Context Length, not compareMaxSeqLength: the wire
+        // value is Auto-resolved for a same-model reload, so pinning it would
+        // convert Auto into a number the user never set (see resolveExplicitCtxPin).
+        // Non-GGUF compare loads send a sequence length rather than an n_ctx, so
+        // their baseline clears.
         const keepCustomCtx = targetIsGguf
-          ? resolveLoadedCtxPin(compareMaxSeqLength)
+          ? resolveExplicitCtxPin(effectiveCustomContextLength)
           : null;
         // Slots this compare load committed. Diffusion ignores --parallel, so a
         // count there would mint a phantom override a preset carries onto a GGUF.

--- a/studio/frontend/tests/context-pin-survives-load.test.ts
+++ b/studio/frontend/tests/context-pin-survives-load.test.ts
@@ -10,9 +10,19 @@
 // for a model that fits no GPU subset: "it's ignoring my Context Length and always stop
 // at Auto (8,192)".
 //
-// The rule is now "the pin is the n_ctx the load was invoked with, 0 (Auto) clears it".
-// The four writers are checked at the source, like the llama-extra-args status test next
-// door: each sits inside one large object literal with no seam to call.
+// The rule is now "the pin is the Context Length the user EXPLICITLY set, Auto pins
+// nothing". Not "the n_ctx the load was invoked with": those are different questions.
+// resolveLoadMaxSeqLength sends the resolved context on a same-model reload so the reload
+// does not resize, so with the control on Auto a custom or modified preset puts a positive
+// n_ctx on the wire, and reading a pin back out of it converted Auto into a numeric pin at
+// the current context -- after which a GPU memory change can no longer auto-resize.
+//
+// So both of these have to hold at once, and they pull against each other:
+//   1. an explicitly set context survives a completed load, in EVERY GPU Memory mode;
+//   2. Auto stays Auto across a same-model reload, under EVERY preset source.
+// The three in-app writers are checked at the source, like the llama-extra-args status test
+// next door: each sits inside one large object literal with no seam to call. The status
+// path has a seam (resolveCtxPinSeed) and is checked through it.
 
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
@@ -39,18 +49,43 @@ const CONFIG_PAGE = read(
 );
 
 const policy = await import("../src/features/chat/presets/preset-policy.ts");
+const { resolveCtxPinSeed } = await import(
+  "../src/features/chat/lib/resolve-ctx-pin-seed.ts"
+);
 const { loadedConfigSignature } = await import(
   "../src/features/model-picker/model-config/config-signature.ts"
 );
 
 const RETIRED_PREDICATE = /resolveManualAutoCtxPin/;
+/** A writer feeding a WIRE value back in as the pin: the regression this guards. */
+const WIRE_AS_PIN =
+  /resolveExplicitCtxPin\([^)]*\b(?:loadMaxSeqLength|fitMaxSeqLength|compareMaxSeqLength|effectiveMaxSeqLength|requested_context_length)\b/;
+
+/** An empty Context Length pair: the control on Auto with a matching baseline. */
+const CLEARED = { customContextLength: null, loadedCustomContextLength: null };
 
 const MODEL = "unsloth/Some-Huge-MoE-GGUF";
 const OTHER_MODEL = "unsloth/Something-Else-GGUF";
 const VARIANT = "UD-Q4_K_XL";
 const REQUESTED = 262144;
+const PRESET_SOURCES = ["builtin-default", "custom", "modified"] as const;
+
+/** The sources every writer-level assertion runs over. */
+const WRITERS = [
+  ["applier", APPLIER],
+  ["runtime", RUNTIME],
+  ["adapter", ADAPTER],
+  ["composer", COMPOSER],
+] as const;
 
 type Mode = "auto" | "manual";
+
+/**
+ * What a completed load leaves in customContextLength, given the Context Length
+ * the user had set for it. The three in-app writers all reduce to this.
+ */
+const pinAfterLoad = (customContextLength: number | null) =>
+  policy.resolveExplicitCtxPin(customContextLength);
 
 /** The n_ctx a load would put on the wire as max_seq_length. */
 function sentNCtx(
@@ -61,12 +96,15 @@ function sentNCtx(
     residentCtx = 0,
     modelId = MODEL,
     currentCheckpoint = MODEL,
+    // The configuration the bug was reported in.
+    presetSource = "builtin-default",
   }: {
     mode?: Mode;
     gpuLayers?: number;
     residentCtx?: number;
     modelId?: string;
     currentCheckpoint?: string;
+    presetSource?: (typeof PRESET_SOURCES)[number];
   } = {},
 ): number {
   return policy.resolveFitMaxSeqLength(
@@ -83,8 +121,7 @@ function sentNCtx(
       currentCheckpoint,
       activeGgufVariant: VARIANT,
       maxSeqLength: 4096,
-      // The configuration the bug was reported in.
-      presetSource: policy.getPresetSource("Default"),
+      presetSource,
     }),
   );
 }
@@ -110,7 +147,7 @@ test("a completed load keeps the context it was invoked with, in every mode", ()
     const sent = sentNCtx(REQUESTED, { mode, gpuLayers });
     assert.equal(sent, REQUESTED, `${mode}/${gpuLayers} sent the wrong n_ctx`);
     assert.equal(
-      policy.resolveLoadedCtxPin(sent),
+      pinAfterLoad(REQUESTED),
       REQUESTED,
       `${mode}/${gpuLayers} dropped the pin`,
     );
@@ -120,25 +157,22 @@ test("a completed load keeps the context it was invoked with, in every mode", ()
 test("the next load still sends the user's number", () => {
   // The reported failure: the SECOND load came back at 8,192, because the pin
   // was gone by then and 0 went out instead.
-  const pinAfterLoad = policy.resolveLoadedCtxPin(sentNCtx(REQUESTED));
+  const pin = pinAfterLoad(REQUESTED);
   assert.equal(
-    sentNCtx(pinAfterLoad, { residentCtx: REQUESTED }),
+    sentNCtx(pin, { residentCtx: REQUESTED }),
     REQUESTED,
     "the reload reverted to Auto",
   );
   // And it stays put over any number of reloads.
-  const pinAfterReload = policy.resolveLoadedCtxPin(
-    sentNCtx(pinAfterLoad, { residentCtx: REQUESTED }),
-  );
-  assert.equal(pinAfterReload, REQUESTED);
+  assert.equal(pinAfterLoad(pin), REQUESTED);
 });
 
 test("the settings panel does not remount back to Auto", () => {
   // customContextLength is the first field of modelConfigInstanceKey, so a pin
   // that vanishes on completion re-keys the editor and snaps it back to Auto.
-  const pinAfterLoad = policy.resolveLoadedCtxPin(sentNCtx(REQUESTED));
+  const pin = pinAfterLoad(REQUESTED);
   assert.equal(
-    loadedConfigSignature(configWithPin(pinAfterLoad)),
+    loadedConfigSignature(configWithPin(pin)),
     loadedConfigSignature(configWithPin(REQUESTED)),
     "the editor would remount and lose the pin",
   );
@@ -147,7 +181,7 @@ test("the settings panel does not remount back to Auto", () => {
     loadedConfigSignature(configWithPin(null)),
     loadedConfigSignature(configWithPin(REQUESTED)),
   );
-  assert.notEqual(pinAfterLoad, null);
+  assert.notEqual(pin, null);
   // The link this rests on: null is what the panel calls Auto.
   assert.match(
     CONFIG_PAGE,
@@ -160,64 +194,165 @@ test("an Auto load still clears the pin and stays Auto", () => {
   // is nothing to pin and the control must keep reading Auto.
   const sentAuto = sentNCtx(null);
   assert.equal(sentAuto, 0);
-  const pinAfterAutoLoad = policy.resolveLoadedCtxPin(sentAuto);
+  const pinAfterAutoLoad = pinAfterLoad(null);
   assert.equal(pinAfterAutoLoad, null);
   assert.equal(sentNCtx(pinAfterAutoLoad, { residentCtx: 8192 }), 0);
   // A pin cleared by hand (the user dragging back to Auto) reads the same way.
-  assert.equal(policy.resolveLoadedCtxPin(0), null);
-  assert.equal(policy.resolveLoadedCtxPin(null), null);
-  assert.equal(policy.resolveLoadedCtxPin(undefined), null);
+  assert.equal(policy.resolveExplicitCtxPin(0), null);
+  assert.equal(policy.resolveExplicitCtxPin(null), null);
+  assert.equal(policy.resolveExplicitCtxPin(undefined), null);
 });
 
 test("a model change does not carry the old pin across", () => {
-  // requested_context_length is the n_ctx of the ACTIVE load, never a previous
-  // value held in the store, so the outgoing model's pin is overwritten rather
-  // than inherited.
-  const outgoingPin = policy.resolveLoadedCtxPin(REQUESTED);
-  assert.equal(outgoingPin, REQUESTED);
-  const incomingOnAuto = { requested_context_length: 0, is_gguf: true };
-  assert.equal(
-    policy.resolveLoadedCtxPin(incomingOnAuto.requested_context_length),
-    null,
-  );
+  // Nothing the outgoing model left in the store may reach the incoming one, and
+  // the status echo cannot stand in for it: a length that happens to match the
+  // old pin is exactly what an Auto load on the new model reports too.
+  const seed = (over: Partial<Parameters<typeof resolveCtxPinSeed>[0]> = {}) =>
+    resolveCtxPinSeed({
+      incoming: REQUESTED,
+      isGguf: true,
+      seedLoadParams: true,
+      modelChanged: true,
+      remembered: null,
+      ...over,
+    });
+  // The new model came up on Auto. 0 proves its own meaning, so the pin clears.
+  assert.deepEqual(seed({ incoming: 0 }), CLEARED);
+  // The new model came up at the outgoing pin's length with nothing saved for it:
+  // still cleared, because nothing recorded that a human asked for it.
+  assert.deepEqual(seed(), CLEARED);
+  // The new model's OWN saved Context Length, corroborated by the server running
+  // it, is the only thing that can seed a pin here.
+  assert.deepEqual(seed({ remembered: REQUESTED }), {
+    customContextLength: REQUESTED,
+    loadedCustomContextLength: REQUESTED,
+  });
+  // A saved pin the running server is NOT honouring seeds nothing.
+  assert.deepEqual(seed({ remembered: 8192 }), CLEARED);
+  // A non-GGUF has no n_ctx, so a GGUF pin cannot be left standing over it.
+  assert.deepEqual(seed({ isGguf: false }), CLEARED);
   // The next load for the new model is Auto, not the old model's length.
   assert.equal(
     sentNCtx(null, { modelId: OTHER_MODEL, currentCheckpoint: MODEL }),
     0,
   );
-  // Sourced from status alone, so nothing in the store can leak across.
-  assert.match(
-    APPLIER,
-    /const loadedCtxPin = status\.is_gguf\s*\n\s*\? resolveLoadedCtxPin\(status\.requested_context_length \?\? null\)\s*\n\s*: null;/,
-  );
   // performLoad clears it outright on a cross-model switch, before the load.
   assert.match(RUNTIME, /customContextLength: null,\s*\n\s*\}\);/);
+  // The applier reads the saved value through the same resolver the batch sizes
+  // use, so "remembered" is this model's record and not the store's leftovers.
+  assert.match(
+    APPLIER,
+    /remembered: remembered\?\.remembered\s*\n\s*\? \(remembered\.config\.customContextLength \?\? null\)\s*\n\s*: null,/,
+  );
 });
 
 test("a poll landing mid-load cannot plant the outgoing model's context", () => {
   // The one window where status still answers for the model on its way out.
   // Harmless while the pin was almost always null; now it is a real number.
-  assert.match(
-    APPLIER,
-    /const ctxPinFields = seedLoadParams\s*\n\s*\? \{\s*\n\s*customContextLength: loadedCtxPin,\s*\n\s*loadedCustomContextLength: loadedCtxPin,/,
+  assert.deepEqual(
+    resolveCtxPinSeed({
+      incoming: REQUESTED,
+      isGguf: true,
+      seedLoadParams: false,
+      modelChanged: true,
+      remembered: REQUESTED,
+    }),
+    {},
+    "a mid-load poll planted a pin",
   );
-  assert.match(
-    APPLIER,
-    /: \{\s*\n\s*customContextLength: prevState\.customContextLength,\s*\n\s*loadedCustomContextLength: prevState\.loadedCustomContextLength,/,
+  // And it cannot clear one either: performLoad owns the pair for the whole load.
+  assert.deepEqual(
+    resolveCtxPinSeed({
+      incoming: 0,
+      isGguf: true,
+      seedLoadParams: false,
+      modelChanged: false,
+      remembered: null,
+    }),
+    {},
+    "a mid-load poll cleared the pin",
   );
+  // An empty seed writes no keys at all, so the store keeps what it had.
+  assert.match(APPLIER, /const ctxPinFields = resolveCtxPinSeed\(\{/);
+  assert.match(APPLIER, /\.\.\.ctxPinFields,/);
   // A baseline this status will not apply is not a change worth preserving edits over.
   assert.match(
     APPLIER,
-    /\(seedLoadParams && prevState\.loadedCustomContextLength !== loadedCtxPin\);/,
+    /\(ctxPinFields\.loadedCustomContextLength !== undefined &&\s*\n\s*prevState\.loadedCustomContextLength !==\s*\n?\s*ctxPinFields\.loadedCustomContextLength\);/,
   );
 });
 
-test("all four writers pin the n_ctx their load actually sent", () => {
-  // They disagreed before: two kept the value, two threw it away, and the one
-  // the picker uses was the one that threw it away.
+test("Auto stays Auto across a same-model reload, under every preset source", () => {
+  // resolveLoadMaxSeqLength's isReloadingCurrentGguf branch: outside
+  // builtin-default, a same-model reload on Auto puts the RESOLVED context on the
+  // wire so the reload does not resize. Reading a pin back out of that turned
+  // Auto into a numeric pin at the current context on any same-model reload --
+  // applying an unrelated model setting was enough -- after which a GPU memory
+  // change could no longer auto-resize the context.
+  assert.equal(policy.getPresetSource("Default"), "builtin-default");
+  assert.equal(policy.getPresetSource("My Preset"), "custom");
+  const onTheWire = Object.fromEntries(
+    PRESET_SOURCES.map((presetSource) => [
+      presetSource,
+      sentNCtx(null, { presetSource, residentCtx: REQUESTED }),
+    ]),
+  );
+  // Not hypothetical: two of the three really do send a number for Auto.
+  assert.deepEqual(onTheWire, {
+    "builtin-default": 0,
+    custom: REQUESTED,
+    modified: REQUESTED,
+  });
+  for (const presetSource of PRESET_SOURCES) {
+    // The control was on Auto, so the load leaves it on Auto whatever it sent...
+    const pin = pinAfterLoad(null);
+    assert.equal(pin, null, `${presetSource} turned Auto into a pin`);
+    // ...and the reload after it is still Auto, so the context can still resize.
+    assert.equal(
+      sentNCtx(pin, { presetSource, residentCtx: REQUESTED }),
+      onTheWire[presetSource],
+    );
+  }
+  // The status echo of those reloads says REQUESTED, and is refused as evidence.
+  assert.deepEqual(
+    resolveCtxPinSeed({
+      incoming: REQUESTED,
+      isGguf: true,
+      seedLoadParams: true,
+      modelChanged: false,
+      remembered: REQUESTED,
+    }),
+    {},
+    "the status path re-pinned an Auto reload",
+  );
+  // No writer may go back to feeding a wire value in as the pin.
+  for (const [label, source] of WRITERS) {
+    assert.doesNotMatch(source, WIRE_AS_PIN, `${label} pins a wire value`);
+  }
+});
+
+test("the clamp that stops a manual reload resizing is not a user pin", () => {
+  // performLoad substitutes the resolved context for Auto when layers are pinned
+  // on the same model, or the reload would send 0 and llama.cpp's --fit-off
+  // branch would take that as the NATIVE context. That is the app protecting the
+  // load, not the user choosing a length, so the pin is captured BEFORE it.
+  const capture = RUNTIME.indexOf("const explicitCtxPin = loadCustomContextLength;");
+  const clamp = RUNTIME.indexOf("loadCustomContextLength = loadGgufContextLength;");
+  assert.notEqual(capture, -1, "the load no longer captures the user's setting");
+  assert.notEqual(clamp, -1);
+  assert.ok(
+    capture < clamp,
+    "the clamp now runs before the pin is captured, so the app's substituted length " +
+      "would be recorded as the user's choice",
+  );
+});
+
+test("the three in-app writers pin what the user asked for, not what they sent", () => {
+  // The regression: all three took the resolved n_ctx, which is the user's number
+  // only when there is one, and the current context otherwise.
   assert.match(
     RUNTIME,
-    /const keepCustomCtx = resolveLoadedCtxPin\(\s*\n\s*loadResponse\.is_gguf \? loadMaxSeqLength : null,\s*\n\s*\);/,
+    /const keepCustomCtx = resolveExplicitCtxPin\(\s*\n\s*loadResponse\.is_gguf \? explicitCtxPin : null,\s*\n\s*\);/,
   );
   assert.match(
     RUNTIME,
@@ -225,16 +360,23 @@ test("all four writers pin the n_ctx their load actually sent", () => {
   );
   assert.match(
     ADAPTER,
-    /const keepCustomCtx = resolveLoadedCtxPin\(fitMaxSeqLength\);/,
+    /const keepCustomCtx = resolveExplicitCtxPin\(config\.customContextLength\);/,
   );
   assert.match(ADAPTER, /customContextLength: keepCustomCtx,/);
   assert.match(ADAPTER, /loadedCustomContextLength: keepCustomCtx,/);
   assert.match(
     COMPOSER,
-    /const keepCustomCtx = targetIsGguf\s*\n\s*\? resolveLoadedCtxPin\(compareMaxSeqLength\)\s*\n\s*: null;/,
+    /const keepCustomCtx = targetIsGguf\s*\n\s*\? resolveExplicitCtxPin\(effectiveCustomContextLength\)\s*\n\s*: null;/,
   );
   assert.match(COMPOSER, /customContextLength: keepCustomCtx,/);
   assert.match(COMPOSER, /loadedCustomContextLength: keepCustomCtx,/);
+  // Each argument is that path's own per-model setting, which is also what fed
+  // its send rule, so a pinned load's -c and its pin cannot disagree.
+  assert.match(COMPOSER, /const effectiveCustomContextLength = ownConfig\.customContextLength;/);
+  assert.match(
+    ADAPTER,
+    /customContextLength: config\.customContextLength,\s*\n\s*ggufContextLength: null,/,
+  );
 });
 
 test("the Manual-only predicate is retired, not left to be picked up again", () => {
@@ -244,12 +386,12 @@ test("the Manual-only predicate is retired, not left to be picked up again", () 
     (policy as Record<string, unknown>).resolveManualAutoCtxPin,
     undefined,
   );
-  for (const [label, source] of [
-    ["applier", APPLIER],
-    ["runtime", RUNTIME],
-    ["adapter", ADAPTER],
-    ["composer", COMPOSER],
-  ] as const) {
+  // Neither is the wire-valued predicate that replaced it and read Auto as a pin.
+  assert.equal(
+    (policy as Record<string, unknown>).resolveLoadedCtxPin,
+    undefined,
+  );
+  for (const [label, source] of WRITERS) {
     assert.doesNotMatch(
       source,
       RETIRED_PREDICATE,

--- a/studio/frontend/tests/context-pin-survives-load.test.ts
+++ b/studio/frontend/tests/context-pin-survives-load.test.ts
@@ -3,14 +3,12 @@
 
 // What happens to an explicit Context Length once the load that used it finishes.
 //
-// The send rule honors a pin in every GPU Memory mode (resolveLoadMaxSeqLength returns
-// it before it looks at anything else). The survival rule used to be narrower: only a
-// Manual + Auto-layers load kept its pin, so a load on Default sent the user's 262,144
-// and then dropped it. customContextLength is the first field of ModelConfigPage's React
-// key, so the panel remounted and re-seeded to Auto, and the next load sent 0 -- which
-// the backend resolves to its host-offload fallback of 8,192 (_AUTO_OFFLOAD_CTX) for a
-// model that fits no GPU subset. The user's report: "it's ignoring my Context Length and
-// always stop at Auto (8,192)".
+// The send rule honors a pin in every GPU Memory mode, but the survival rule used to be
+// narrower: only a Manual + Auto-layers load kept its pin, so a load on Default sent the
+// user's 262,144 and then dropped it. The panel re-seeded to Auto and the next load sent
+// 0, which the backend resolves to its host-offload fallback of 8,192 (_AUTO_OFFLOAD_CTX)
+// for a model that fits no GPU subset: "it's ignoring my Context Length and always stop
+// at Auto (8,192)".
 //
 // The rule is now "the pin is the n_ctx the load was invoked with, 0 (Auto) clears it".
 // The four writers are checked at the source, like the llama-extra-args status test next
@@ -85,8 +83,7 @@ function sentNCtx(
       currentCheckpoint,
       activeGgufVariant: VARIANT,
       maxSeqLength: 4096,
-      // The store's own default (getPresetSource("Default")), which is the
-      // configuration the bug was reported in.
+      // The configuration the bug was reported in.
       presetSource: policy.getPresetSource("Default"),
     }),
   );
@@ -103,8 +100,7 @@ function configWithPin(pin: number | null) {
 }
 
 test("a completed load keeps the context it was invoked with, in every mode", () => {
-  // No GPU Memory mode in the signature at all: that is the fix. The control is
-  // offered in every mode, so its pin has to survive in every mode.
+  // No GPU Memory mode in the signature at all: that is the fix.
   for (const [mode, gpuLayers] of [
     ["auto", -1],
     ["auto", 20],
@@ -122,8 +118,8 @@ test("a completed load keeps the context it was invoked with, in every mode", ()
 });
 
 test("the next load still sends the user's number", () => {
-  // The reported failure: the second load is the one that came back at 8,192,
-  // because the pin was gone and 0 went out instead.
+  // The reported failure: the SECOND load came back at 8,192, because the pin
+  // was gone by then and 0 went out instead.
   const pinAfterLoad = policy.resolveLoadedCtxPin(sentNCtx(REQUESTED));
   assert.equal(
     sentNCtx(pinAfterLoad, { residentCtx: REQUESTED }),
@@ -139,8 +135,7 @@ test("the next load still sends the user's number", () => {
 
 test("the settings panel does not remount back to Auto", () => {
   // customContextLength is the first field of modelConfigInstanceKey, so a pin
-  // that vanishes on completion re-keys the editor, which re-seeds configState
-  // from the cleared config and snaps the slider to position 0 (Auto).
+  // that vanishes on completion re-keys the editor and snaps it back to Auto.
   const pinAfterLoad = policy.resolveLoadedCtxPin(sentNCtx(REQUESTED));
   assert.equal(
     loadedConfigSignature(configWithPin(pinAfterLoad)),
@@ -161,8 +156,8 @@ test("the settings panel does not remount back to Auto", () => {
 });
 
 test("an Auto load still clears the pin and stays Auto", () => {
-  // 0 is the wire value for Auto; the backend omits -c or sizes the context
-  // itself, so there is nothing to pin and the control must keep reading Auto.
+  // 0 is the wire value for Auto: the backend sizes the context itself, so there
+  // is nothing to pin and the control must keep reading Auto.
   const sentAuto = sentNCtx(null);
   assert.equal(sentAuto, 0);
   const pinAfterAutoLoad = policy.resolveLoadedCtxPin(sentAuto);
@@ -175,10 +170,9 @@ test("an Auto load still clears the pin and stays Auto", () => {
 });
 
 test("a model change does not carry the old pin across", () => {
-  // The status applier reads requested_context_length, which is the n_ctx of the
-  // ACTIVE load, never a previous value held in the store. A different model
-  // loaded underneath therefore reports its own, and one that came up on Auto
-  // reports 0 -- so the outgoing model's pin is overwritten, not inherited.
+  // requested_context_length is the n_ctx of the ACTIVE load, never a previous
+  // value held in the store, so the outgoing model's pin is overwritten rather
+  // than inherited.
   const outgoingPin = policy.resolveLoadedCtxPin(REQUESTED);
   assert.equal(outgoingPin, REQUESTED);
   const incomingOnAuto = { requested_context_length: 0, is_gguf: true };
@@ -202,8 +196,7 @@ test("a model change does not carry the old pin across", () => {
 
 test("a poll landing mid-load cannot plant the outgoing model's context", () => {
   // The one window where status still answers for the model on its way out.
-  // Harmless while the pin was almost always null; now it is a real number, so
-  // the applier takes the same in-flight rule as every other load param.
+  // Harmless while the pin was almost always null; now it is a real number.
   assert.match(
     APPLIER,
     /const ctxPinFields = seedLoadParams\s*\n\s*\? \{\s*\n\s*customContextLength: loadedCtxPin,\s*\n\s*loadedCustomContextLength: loadedCtxPin,/,
@@ -245,8 +238,8 @@ test("all four writers pin the n_ctx their load actually sent", () => {
 });
 
 test("the Manual-only predicate is retired, not left to be picked up again", () => {
-  // It answered a different question ("does Manual + Auto layers need its pin
-  // re-derived") and had no caller left once the four writers moved off it.
+  // It answered a different question and had no caller left once the four
+  // writers moved off it.
   assert.equal(
     (policy as Record<string, unknown>).resolveManualAutoCtxPin,
     undefined,

--- a/studio/frontend/tests/context-pin-survives-load.test.ts
+++ b/studio/frontend/tests/context-pin-survives-load.test.ts
@@ -406,3 +406,84 @@ test("the Manual-only predicate is retired, not left to be picked up again", () 
     REQUESTED,
   );
 });
+
+test("another client reloading the same model at a new context invalidates the baseline", () => {
+  // The pin here describes an invocation that is no longer running. Keeping it
+  // means the next unrelated Apply resends it and silently takes back the other
+  // client's context, so a contradicted baseline is dropped. The echo still
+  // cannot say whether a human chose the new value, so it is not adopted either.
+  const seed = (over: Partial<Parameters<typeof resolveCtxPinSeed>[0]> = {}) =>
+    resolveCtxPinSeed({
+      incoming: REQUESTED,
+      isGguf: true,
+      seedLoadParams: true,
+      modelChanged: false,
+      remembered: null,
+      ...over,
+    });
+
+  // Contradicted: we recorded 8192, the server reports it is running 262144.
+  assert.deepEqual(seed({ loadedPin: 8192 }), CLEARED);
+  // Agreeing echoes leave the control alone, which is what keeps an explicit pin
+  // alive across every ordinary poll.
+  assert.deepEqual(seed({ loadedPin: REQUESTED }), {});
+  // Auto here holds: with no pin recorded there is no baseline to contradict, and
+  // an Auto reload under a custom preset reports a positive n_ctx exactly like
+  // this. Adopting it would be the bug this file exists to prevent.
+  assert.deepEqual(seed({ loadedPin: null }), {});
+  // Our own pinned model reloaded on Auto reports the resolved context, which IS
+  // the pin, so it matches and nothing moves.
+  assert.deepEqual(seed({ loadedPin: REQUESTED, incoming: REQUESTED }), {});
+  // Still nothing mid-load: performLoad owns the pair there.
+  assert.deepEqual(seed({ loadedPin: 8192, seedLoadParams: false }), {});
+});
+
+test("a positive echo under manual memory with auto layers is an explicit pin", () => {
+  // resolveFitMaxSeqLength is what that placement sends, and it answers
+  // `customContextLength > 0 ? it : 0`, so Auto is 0 on the wire without
+  // exception and a positive echo cannot have come from Auto.
+  assert.equal(policy.resolveFitMaxSeqLength(true, "manual", -1, null, 4096), 0);
+  assert.equal(
+    policy.resolveFitMaxSeqLength(true, "manual", -1, REQUESTED, 4096),
+    REQUESTED,
+  );
+
+  const seed = (over: Partial<Parameters<typeof resolveCtxPinSeed>[0]> = {}) =>
+    resolveCtxPinSeed({
+      incoming: REQUESTED,
+      isGguf: true,
+      seedLoadParams: true,
+      modelChanged: false,
+      remembered: null,
+      gpuMemoryMode: "manual",
+      gpuLayers: -1,
+      ...over,
+    });
+  const PINNED = {
+    customContextLength: REQUESTED,
+    loadedCustomContextLength: REQUESTED,
+  };
+
+  // A fresh tab hydrating a resident pinned server, with nothing saved for it.
+  assert.deepEqual(seed(), PINNED);
+  // Same on a model change: the echo describes the model that ARRIVED, so it
+  // beats both the store's leftovers and a saved config.
+  assert.deepEqual(seed({ modelChanged: true }), PINNED);
+  // Auto in this mode still reports 0, and 0 still clears.
+  assert.deepEqual(seed({ incoming: 0 }), CLEARED);
+  // Pinned layers is a different placement: it does not send through
+  // resolveFitMaxSeqLength, so the echo is ambiguous again and is not adopted.
+  assert.deepEqual(seed({ gpuLayers: 20 }), {});
+  // Neither is Default memory, which is where the original bug lived.
+  assert.deepEqual(seed({ gpuMemoryMode: "auto", gpuLayers: -1 }), {});
+  // The mid-load window outranks it, as it does everything else here.
+  assert.deepEqual(seed({ seedLoadParams: false }), {});
+  // The applier passes the RAW status fields: the normalised ones null out
+  // layers off manual, which would read as "not reported" rather than as Auto.
+  assert.match(APPLIER, /gpuMemoryMode: status\.gpu_memory_mode \?\? null,/);
+  assert.match(APPLIER, /gpuLayers: status\.gpu_layers \?\? null,/);
+  assert.match(
+    APPLIER,
+    /loadedPin: prevState\.loadedCustomContextLength \?\? null,/,
+  );
+});

--- a/studio/frontend/tests/context-pin-survives-load.test.ts
+++ b/studio/frontend/tests/context-pin-survives-load.test.ts
@@ -1,0 +1,273 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// What happens to an explicit Context Length once the load that used it finishes.
+//
+// The send rule honors a pin in every GPU Memory mode (resolveLoadMaxSeqLength returns
+// it before it looks at anything else). The survival rule used to be narrower: only a
+// Manual + Auto-layers load kept its pin, so a load on Default sent the user's 262,144
+// and then dropped it. customContextLength is the first field of ModelConfigPage's React
+// key, so the panel remounted and re-seeded to Auto, and the next load sent 0 -- which
+// the backend resolves to its host-offload fallback of 8,192 (_AUTO_OFFLOAD_CTX) for a
+// model that fits no GPU subset. The user's report: "it's ignoring my Context Length and
+// always stop at Auto (8,192)".
+//
+// The rule is now "the pin is the n_ctx the load was invoked with, 0 (Auto) clears it".
+// The four writers are checked at the source, like the llama-extra-args status test next
+// door: each sits inside one large object literal with no seam to call.
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { registerBundlerResolver } from "./helpers/kit.ts";
+
+registerBundlerResolver();
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const read = (relative: string) =>
+  readFileSync(path.join(HERE, "..", relative), "utf8");
+
+const APPLIER = read(
+  "src/features/chat/lib/apply-inference-status-to-store.ts",
+);
+const RUNTIME = read("src/features/chat/hooks/use-chat-model-runtime.ts");
+const ADAPTER = read("src/features/chat/api/chat-adapter.ts");
+const COMPOSER = read("src/features/chat/shared-composer.tsx");
+const CONFIG_PAGE = read(
+  "src/features/model-picker/components/model-config-page.tsx",
+);
+
+const policy = await import("../src/features/chat/presets/preset-policy.ts");
+const { loadedConfigSignature } = await import(
+  "../src/features/model-picker/model-config/config-signature.ts"
+);
+
+const RETIRED_PREDICATE = /resolveManualAutoCtxPin/;
+
+const MODEL = "unsloth/Some-Huge-MoE-GGUF";
+const OTHER_MODEL = "unsloth/Something-Else-GGUF";
+const VARIANT = "UD-Q4_K_XL";
+const REQUESTED = 262144;
+
+type Mode = "auto" | "manual";
+
+/** The n_ctx a load would put on the wire as max_seq_length. */
+function sentNCtx(
+  customContextLength: number | null,
+  {
+    mode = "auto",
+    gpuLayers = -1,
+    residentCtx = 0,
+    modelId = MODEL,
+    currentCheckpoint = MODEL,
+  }: {
+    mode?: Mode;
+    gpuLayers?: number;
+    residentCtx?: number;
+    modelId?: string;
+    currentCheckpoint?: string;
+  } = {},
+): number {
+  return policy.resolveFitMaxSeqLength(
+    true,
+    mode,
+    gpuLayers,
+    customContextLength,
+    policy.resolveLoadMaxSeqLength({
+      modelId,
+      ggufVariant: VARIANT,
+      isGguf: true,
+      customContextLength,
+      ggufContextLength: residentCtx,
+      currentCheckpoint,
+      activeGgufVariant: VARIANT,
+      maxSeqLength: 4096,
+      // The store's own default (getPresetSource("Default")), which is the
+      // configuration the bug was reported in.
+      presetSource: policy.getPresetSource("Default"),
+    }),
+  );
+}
+
+/** A per-model config as ModelConfigPage seeds it from the live store. */
+function configWithPin(pin: number | null) {
+  return {
+    customContextLength: pin,
+    gpuMemoryMode: "auto",
+    gpuLayers: -1,
+    nCpuMoe: 0,
+  } as never;
+}
+
+test("a completed load keeps the context it was invoked with, in every mode", () => {
+  // No GPU Memory mode in the signature at all: that is the fix. The control is
+  // offered in every mode, so its pin has to survive in every mode.
+  for (const [mode, gpuLayers] of [
+    ["auto", -1],
+    ["auto", 20],
+    ["manual", -1],
+    ["manual", 20],
+  ] as const) {
+    const sent = sentNCtx(REQUESTED, { mode, gpuLayers });
+    assert.equal(sent, REQUESTED, `${mode}/${gpuLayers} sent the wrong n_ctx`);
+    assert.equal(
+      policy.resolveLoadedCtxPin(sent),
+      REQUESTED,
+      `${mode}/${gpuLayers} dropped the pin`,
+    );
+  }
+});
+
+test("the next load still sends the user's number", () => {
+  // The reported failure: the second load is the one that came back at 8,192,
+  // because the pin was gone and 0 went out instead.
+  const pinAfterLoad = policy.resolveLoadedCtxPin(sentNCtx(REQUESTED));
+  assert.equal(
+    sentNCtx(pinAfterLoad, { residentCtx: REQUESTED }),
+    REQUESTED,
+    "the reload reverted to Auto",
+  );
+  // And it stays put over any number of reloads.
+  const pinAfterReload = policy.resolveLoadedCtxPin(
+    sentNCtx(pinAfterLoad, { residentCtx: REQUESTED }),
+  );
+  assert.equal(pinAfterReload, REQUESTED);
+});
+
+test("the settings panel does not remount back to Auto", () => {
+  // customContextLength is the first field of modelConfigInstanceKey, so a pin
+  // that vanishes on completion re-keys the editor, which re-seeds configState
+  // from the cleared config and snaps the slider to position 0 (Auto).
+  const pinAfterLoad = policy.resolveLoadedCtxPin(sentNCtx(REQUESTED));
+  assert.equal(
+    loadedConfigSignature(configWithPin(pinAfterLoad)),
+    loadedConfigSignature(configWithPin(REQUESTED)),
+    "the editor would remount and lose the pin",
+  );
+  // ...and the panel would have read the cleared config as Auto.
+  assert.notEqual(
+    loadedConfigSignature(configWithPin(null)),
+    loadedConfigSignature(configWithPin(REQUESTED)),
+  );
+  assert.notEqual(pinAfterLoad, null);
+  // The link this rests on: null is what the panel calls Auto.
+  assert.match(
+    CONFIG_PAGE,
+    /const contextIsAuto = config\.customContextLength == null;/,
+  );
+});
+
+test("an Auto load still clears the pin and stays Auto", () => {
+  // 0 is the wire value for Auto; the backend omits -c or sizes the context
+  // itself, so there is nothing to pin and the control must keep reading Auto.
+  const sentAuto = sentNCtx(null);
+  assert.equal(sentAuto, 0);
+  const pinAfterAutoLoad = policy.resolveLoadedCtxPin(sentAuto);
+  assert.equal(pinAfterAutoLoad, null);
+  assert.equal(sentNCtx(pinAfterAutoLoad, { residentCtx: 8192 }), 0);
+  // A pin cleared by hand (the user dragging back to Auto) reads the same way.
+  assert.equal(policy.resolveLoadedCtxPin(0), null);
+  assert.equal(policy.resolveLoadedCtxPin(null), null);
+  assert.equal(policy.resolveLoadedCtxPin(undefined), null);
+});
+
+test("a model change does not carry the old pin across", () => {
+  // The status applier reads requested_context_length, which is the n_ctx of the
+  // ACTIVE load, never a previous value held in the store. A different model
+  // loaded underneath therefore reports its own, and one that came up on Auto
+  // reports 0 -- so the outgoing model's pin is overwritten, not inherited.
+  const outgoingPin = policy.resolveLoadedCtxPin(REQUESTED);
+  assert.equal(outgoingPin, REQUESTED);
+  const incomingOnAuto = { requested_context_length: 0, is_gguf: true };
+  assert.equal(
+    policy.resolveLoadedCtxPin(incomingOnAuto.requested_context_length),
+    null,
+  );
+  // The next load for the new model is Auto, not the old model's length.
+  assert.equal(
+    sentNCtx(null, { modelId: OTHER_MODEL, currentCheckpoint: MODEL }),
+    0,
+  );
+  // Sourced from status alone, so nothing in the store can leak across.
+  assert.match(
+    APPLIER,
+    /const loadedCtxPin = status\.is_gguf\s*\n\s*\? resolveLoadedCtxPin\(status\.requested_context_length \?\? null\)\s*\n\s*: null;/,
+  );
+  // performLoad clears it outright on a cross-model switch, before the load.
+  assert.match(RUNTIME, /customContextLength: null,\s*\n\s*\}\);/);
+});
+
+test("a poll landing mid-load cannot plant the outgoing model's context", () => {
+  // The one window where status still answers for the model on its way out.
+  // Harmless while the pin was almost always null; now it is a real number, so
+  // the applier takes the same in-flight rule as every other load param.
+  assert.match(
+    APPLIER,
+    /const ctxPinFields = seedLoadParams\s*\n\s*\? \{\s*\n\s*customContextLength: loadedCtxPin,\s*\n\s*loadedCustomContextLength: loadedCtxPin,/,
+  );
+  assert.match(
+    APPLIER,
+    /: \{\s*\n\s*customContextLength: prevState\.customContextLength,\s*\n\s*loadedCustomContextLength: prevState\.loadedCustomContextLength,/,
+  );
+  // A baseline this status will not apply is not a change worth preserving edits over.
+  assert.match(
+    APPLIER,
+    /\(seedLoadParams && prevState\.loadedCustomContextLength !== loadedCtxPin\);/,
+  );
+});
+
+test("all four writers pin the n_ctx their load actually sent", () => {
+  // They disagreed before: two kept the value, two threw it away, and the one
+  // the picker uses was the one that threw it away.
+  assert.match(
+    RUNTIME,
+    /const keepCustomCtx = resolveLoadedCtxPin\(\s*\n\s*loadResponse\.is_gguf \? loadMaxSeqLength : null,\s*\n\s*\);/,
+  );
+  assert.match(
+    RUNTIME,
+    /customContextLength: keepCustomCtx,\s*\n\s*loadedCustomContextLength: keepCustomCtx,/,
+  );
+  assert.match(
+    ADAPTER,
+    /const keepCustomCtx = resolveLoadedCtxPin\(fitMaxSeqLength\);/,
+  );
+  assert.match(ADAPTER, /customContextLength: keepCustomCtx,/);
+  assert.match(ADAPTER, /loadedCustomContextLength: keepCustomCtx,/);
+  assert.match(
+    COMPOSER,
+    /const keepCustomCtx = targetIsGguf\s*\n\s*\? resolveLoadedCtxPin\(compareMaxSeqLength\)\s*\n\s*: null;/,
+  );
+  assert.match(COMPOSER, /customContextLength: keepCustomCtx,/);
+  assert.match(COMPOSER, /loadedCustomContextLength: keepCustomCtx,/);
+});
+
+test("the Manual-only predicate is retired, not left to be picked up again", () => {
+  // It answered a different question ("does Manual + Auto layers need its pin
+  // re-derived") and had no caller left once the four writers moved off it.
+  assert.equal(
+    (policy as Record<string, unknown>).resolveManualAutoCtxPin,
+    undefined,
+  );
+  for (const [label, source] of [
+    ["applier", APPLIER],
+    ["runtime", RUNTIME],
+    ["adapter", ADAPTER],
+    ["composer", COMPOSER],
+  ] as const) {
+    assert.doesNotMatch(
+      source,
+      RETIRED_PREDICATE,
+      `${label} still calls the retired predicate`,
+    );
+  }
+  // The SEND rule it was named after stays: Manual + Auto layers still sends 0
+  // when there is no pin, because llama.cpp's --fit owns the sizing there.
+  assert.equal(sentNCtx(null, { mode: "manual", gpuLayers: -1 }), 0);
+  assert.equal(
+    sentNCtx(REQUESTED, { mode: "manual", gpuLayers: -1 }),
+    REQUESTED,
+  );
+});

--- a/tests/studio/test_chat_autoload_failure_gate.py
+++ b/tests/studio/test_chat_autoload_failure_gate.py
@@ -353,8 +353,10 @@ function resolveLoadMaxSeqLength(args: any) { return args.maxSeqLength ?? 0; }
 function resolveFitMaxSeqLength(..._a: any[]) { return 0; }
 // Mirrors the real predicate rather than returning a constant: the sliced region
 // stores its result as the load's context pin, so a stub that always answered null
-// would make every autoload scenario here agree with a bug in it.
-function resolveLoadedCtxPin(n: any) { return n && n > 0 ? n : null; }
+// would make every autoload scenario here agree with a bug in it. It takes the
+// user's own Context Length (config.customContextLength above), never the n_ctx
+// that went on the wire, which is Auto-resolved on a same-model reload.
+function resolveExplicitCtxPin(n: any) { return n && n > 0 ? n : null; }
 async function ensureGpuDeviceCache() {}
 function reconcilePersistedGpuIds(ids: any) { return ids; }
 function saveSpeculativeType(_x: any) {}

--- a/tests/studio/test_chat_autoload_failure_gate.py
+++ b/tests/studio/test_chat_autoload_failure_gate.py
@@ -351,7 +351,10 @@ function resolveInitialConfig(_id: string, _variant: any) {
 }
 function resolveLoadMaxSeqLength(args: any) { return args.maxSeqLength ?? 0; }
 function resolveFitMaxSeqLength(..._a: any[]) { return 0; }
-function resolveManualAutoCtxPin(..._a: any[]) { return null; }
+// Mirrors the real predicate rather than returning a constant: the sliced region
+// stores its result as the load's context pin, so a stub that always answered null
+// would make every autoload scenario here agree with a bug in it.
+function resolveLoadedCtxPin(n: any) { return n && n > 0 ? n : null; }
 async function ensureGpuDeviceCache() {}
 function reconcilePersistedGpuIds(ids: any) { return ids; }
 function saveSpeculativeType(_x: any) {}


### PR DESCRIPTION
## The report

Setting Context Length explicitly and loading works once, then silently reverts to Auto on every load after it. Reported as "it seems like its ignoring my Context Length and always stop at Auto (8,192)", with the slider pushed to 262,144.

On a model that fits no GPU subset, Auto resolves to the host-offload fallback of 8,192. So a user who asked for 262,144 gets 8,192, and nothing on screen says why.

## The backend was not at fault

It launches `-c 262144` for every shape tested: a 400 GB MoE on one card, on two cards, on no GPU at all, with manual or auto layers, and with `-ncmoe` passed as an extra argument. The route passes `max_seq_length` through verbatim and the Pydantic bound is 1048576. 8,192 comes out only when the request arrives asking for Auto.

## What actually happened

The frontend threw the pin away the moment the load succeeded. All four post-load writers derived what to keep from `resolveManualAutoCtxPin`, which answers a narrower question:

```ts
gpuMemoryMode === "manual" && gpuLayers < 0 && (customContextLength ?? 0) > 0
```

The Context Length control is offered in every GPU Memory mode, and `resolveLoadMaxSeqLength` honors a pin in every mode, so the survival rule was narrower than the send rule. On Default, the pin became null the instant the load completed. `customContextLength` is the first field of the settings panel's React key, so that flip remounted the editor, which re-seeded from the cleared config and rendered the literal "Auto". The next load sent 0.

The user's first load really did run at 262,144. It is the second one that drops to 8,192, which is why it reads as "always stops at Auto".

The four writers also disagreed with each other, which is the clearest sign this was a bug and not a policy:

| site | what it wrote |
| --- | --- |
| auto-load path | kept the pin |
| compare path | kept the pin |
| interactive path | dropped it |
| status refresh | dropped it unconditionally, on every refresh |

So even the two paths that kept the pin lost it on the next status refresh.

## The fix

`resolveLoadedCtxPin` replaces the predicate with the question actually being asked: what context did this load request? Positive keeps it, 0 means Auto and clears it. GPU memory mode is not a parameter.

The backend already publishes exactly this value as `requested_context_length`, and the status path was reading it and then feeding it into the mode filter that discarded it. All four writers now source the n_ctx their load put on the wire, so they agree. `resolveManualAutoCtxPin` had no callers left and is retired; the send-side `resolveFitMaxSeqLength` it was named after stays.

Widening the pin exposed a window that was harmless while it was almost always null: a status refresh can land with `modelLoading` still true, and a stale poll would then plant the outgoing model's context on the model coming in. The pin now takes the same `seedLoadParams` rule the file already applies to every other load parameter, leaving `performLoad` to own the field mid-load. A model change still carries nothing across, because the value is sourced from the status describing the active load and never from previous state.

No backend change. `git status` touches `studio/frontend` only.

## Tests

New `studio/frontend/tests/context-pin-survives-load.test.ts`, covering the pin surviving a completed load in all four mode and layer combinations, the panel not remounting to Auto, the next load still sending 262,144, an Auto load still clearing the pin and staying Auto, a model change carrying nothing across, the mid-load window, all four writers, and the retirement.

- With the change: 8 of 8 pass.
- With `studio/frontend/src` reverted: 0 of 8 pass.
- Full frontend suite: 5656 passed, 0 failed.
- `npm run typecheck` clean. Lint diffed against the base on the five changed files: no new findings.

## Follow-up, not in this PR

Tensor parallel silently reduces an explicit context by a much larger margin, as low as a fifth of what was asked for, announced only as a log line. It can be reached without touching the Tensor Parallel toggle, including through an inherited `LLAMA_ARG_SPLIT_MODE=tensor`. This fix makes that reduction visible for the first time, since the pin now holds the requested value, but the existing capacity copy names the post-reduction number and reads as a warning about the future rather than a statement about what already happened. That deserves its own change.